### PR TITLE
fix(tga): three bugs — is_ticketed prose matches, validator env race, agentic_pct coverage

### DIFF
--- a/.test-pointer-allowlist.tsv
+++ b/.test-pointer-allowlist.tsv
@@ -253,10 +253,6 @@ crates/trusty-git-analytics/src/collect/git/reachability.rs	scan_default_branch_
 crates/trusty-git-analytics/src/collect/pm_adapter/tests.rs	logs_contain
 crates/trusty-git-analytics/src/commands/incidents/mod.rs	parse_datadog_value_handles_monitor_shape
 crates/trusty-git-analytics/src/commands/override_cmd.rs	list_returns_all_when_repo_none
-crates/trusty-git-analytics/src/report/aggregator/mod.rs	persist_weekly_engineer_upserts_rows
-crates/trusty-git-analytics/src/report/aggregator/mod.rs	persist_weekly_quality_upserts_rows
-crates/trusty-git-analytics/src/report/persist.rs	persist_weekly_engineer_upserts_rows
-crates/trusty-git-analytics/src/report/persist.rs	persist_weekly_quality_upserts_rows
 crates/trusty-installer/src/commands/plist_bootstrap.rs	resolve_uid_returns_nonzero
 crates/trusty-installer/src/commands/prereqs/mod.rs	check_no_warn_for_unrelated
 crates/trusty-installer/src/commands/prereqs/phase.rs	phase_all_present

--- a/crates/trusty-git-analytics/changelog.d/5252-agentic-pct-coverage.md
+++ b/crates/trusty-git-analytics/changelog.d/5252-agentic-pct-coverage.md
@@ -1,0 +1,12 @@
+Fixed
+
+- `persist.rs` and `aggregator/mod.rs` cited a
+  `report::tests::persist_weekly_engineer_upserts_rows` that did not exist, so
+  the `agentic_pct` formula DOC-67 §8 reports had no test naming it. That test
+  now exists and runs eight real commit shapes — a multi-trailer house footer, a
+  bare Claude Code footer, a Copilot trailer, a forge squash-merge whose body was
+  replaced, a machine merge summary, a hand-written commit, a revert and a
+  bot-authored commit identified only by its email — through `ai_markers::detect`
+  and the aggregator, then reads the persisted row back. The stale
+  `persist_weekly_quality_upserts_rows` pointer is corrected too, and all four
+  rows leave the test-pointer ratchet allowlist.

--- a/crates/trusty-git-analytics/changelog.d/5725-validator-env-race.md
+++ b/crates/trusty-git-analytics/changelog.d/5725-validator-env-race.md
@@ -1,0 +1,11 @@
+Fixed
+
+- The Bitbucket auth check and the LLM API-key check now take their environment
+  values as arguments instead of reading `BITBUCKET_TOKEN`,
+  `BITBUCKET_APP_PASSWORD`, `OPENROUTER_API_KEY` and `OPENAI_API_KEY` inline.
+  Their tests previously removed those variables process-wide, which is `unsafe`
+  under the 2024 edition and raced the rest of the suite: the restore put
+  `OPENROUTER_API_KEY` back while a concurrent test was resolving a credential,
+  failing it 40 runs out of 40. No test in `validator_tests.rs` mutates the
+  process environment any more, and the present-key branches are covered for the
+  first time.

--- a/crates/trusty-git-analytics/changelog.d/5735-is-ticketed-subject-anchored.md
+++ b/crates/trusty-git-analytics/changelog.d/5735-is-ticketed-subject-anchored.md
@@ -1,0 +1,12 @@
+Fixed
+
+- `is_ticketed` no longer counts a JIRA-shaped string found anywhere in a commit
+  message. `UTF-8`, `SHA-256`, `GCC-11`, `ADR-0034` and `DOC-39` are the same
+  shape as `PROJ-123`, and 237 of this repository's 2633 commits were reported
+  ticketed on one of them alone. A JIRA/Linear key now counts only where the
+  subject declares it, which is the rule #5199 already applied to
+  `extract_ticket_id` — the two functions no longer disagree. GitHub
+  action-keyword refs (`closes #N`) and Azure DevOps refs (`AB#N`) are unchanged
+  and still count from anywhere in the message. Expect `commits.ticketed` to
+  fall on repositories that cite documents or technical identifiers in commit
+  bodies.

--- a/crates/trusty-git-analytics/src/collect/ticket.rs
+++ b/crates/trusty-git-analytics/src/collect/ticket.rs
@@ -4,18 +4,21 @@
 //! to an external work-tracking system. We currently recognize:
 //!
 //! - **JIRA / Linear style**: `PROJ-123`, `ENG-456`, `ABC-9` —
-//!   uppercase project key, hyphen, digits. The Linear identifier format
-//!   (`ENG-123`, `FE-456`) is a subset of this pattern.
+//!   uppercase project key, hyphen, digits, declared at the start of the
+//!   commit SUBJECT. The Linear identifier format (`ENG-123`, `FE-456`) is a
+//!   subset of this pattern.
 //! - **GitHub action-keyword refs**: `fixes #123`, `closes #45`,
 //!   `resolves #7` (case-insensitive, also matches `fix`/`close`/`resolve`).
 //! - **Azure DevOps work-item refs**: `AB#123`.
 //!
-//! **Note on JIRA-shaped tokens (issue #5199):** [`extract_ticket_id`] reads a
-//! JIRA/Linear key from the **subject line only**, and rejects documentation
-//! prefixes (`ADR`, `DOC`, `RFC`, `SPEC`). [`is_ticketed`] still scans the whole
-//! message with the unrestricted pattern — the two now disagree deliberately,
-//! because `ticketed` is an operator-facing quality metric last tuned by #445
-//! and narrowing it is a separate decision.
+//! **Note on JIRA-shaped tokens (issues #5199, #5735):** [`extract_ticket_id`]
+//! and [`is_ticketed`] read a JIRA/Linear key the same way — from the
+//! **subject line only**, rejecting documentation prefixes (`ADR`, `DOC`,
+//! `RFC`, `SPEC`) via [`subject_ticket_key`]. #5199 narrowed
+//! [`extract_ticket_id`] and left [`is_ticketed`] scanning the whole message
+//! with the unrestricted pattern; #5735 measured what that cost — 237 of this
+//! repository's 2633 commits counted ticketed on nothing but a `UTF-8`- or
+//! `ADR-0034`-shaped string in a body. The two now agree.
 //!
 //! **Note on bare `#N` refs (issue #445):** A bare `#N` preceded by
 //! whitespace (the `gh_bare` pattern) is explicitly *excluded* from
@@ -37,8 +40,11 @@ use regex::Regex;
 /// A bare `#N` reference no longer qualifies a commit as "ticketed" — only
 /// JIRA/Linear, GitHub action-keyword refs, and Azure DevOps refs do.
 /// The bare pattern still lives in [`ExtractPatterns`] for `ticket_id` population.
+///
+/// #5735: there is no `jira` field either. A JIRA/Linear key now reaches
+/// [`is_ticketed`] only through [`subject_ticket_key`], so the whole-message
+/// pattern that used to live here has no remaining caller.
 struct TicketPatterns {
-    jira: Regex,
     gh_action: Regex,
     azdo: Regex,
 }
@@ -51,10 +57,6 @@ fn patterns() -> &'static TicketPatterns {
         // [`patterns_compile`] below — any regression is caught at test
         // time, not at runtime.
         TicketPatterns {
-            // JIRA / Linear: uppercase letters (>=1), optional digits, '-', digits.
-            // Word boundaries prevent matching inside `FOO-BAR-1`-style identifiers'
-            // middle, while still catching the trailing `BAR-1` segment.
-            jira: Regex::new(r"\b[A-Z][A-Z0-9]*-\d+\b").expect("jira pattern compiles"),
             // GitHub action keyword: fix(es|ed)?|close(s|d)?|resolve(s|d)?  #123
             gh_action: Regex::new(r"(?i)\b(?:fix(?:es|ed)?|close[sd]?|resolve[sd]?)\s+#\d+\b")
                 .expect("gh_action pattern compiles"),
@@ -174,19 +176,31 @@ fn subject_ticket_key(subject: &str) -> Option<String> {
 /// Return `true` if `message` contains any recognized ticket reference.
 ///
 /// Why: downstream metrics (ticketed-commit rate, quality score) must only
-/// count commits that are genuinely linked to a tracked work item. A bare
-/// `#N` reference (e.g. `#42` from a release note) is too noisy — it fires
-/// on nearly every multi-line commit body and inflates the ticketed rate to
-/// ~100% (issue #445). The `gh_bare` pattern is intentionally **excluded**
-/// from this OR-chain; it is still used by [`extract_ticket_id`] to populate
+/// count commits that are genuinely linked to a tracked work item. Two
+/// separate noise classes had to be excluded to make that true.
+///
+/// A bare `#N` reference (e.g. `#42` from a release note) fires on nearly
+/// every multi-line commit body and inflated the ticketed rate to ~100%
+/// (issue #445). The `gh_bare` pattern is intentionally **excluded** from
+/// this OR-chain; it is still used by [`extract_ticket_id`] to populate
 /// `commits.ticket_id` as a last-resort identifier.
-/// What: returns `true` for JIRA/Linear identifiers (`PROJ-N`), GitHub
-/// action-keyword refs (`closes #N`, `fixes #N`), and Azure DevOps refs
-/// (`AB#N`). A bare `#N` with no action keyword does NOT make a commit
-/// ticketed.
+///
+/// A JIRA-shaped token anywhere in the message is prose, not a declaration
+/// (issue #5735). `UTF-8`, `SHA-256`, `GCC-11`, `ADR-0034` and `DOC-39` are
+/// the same shape as `PROJ-123`, so no pattern can separate them and no
+/// deny-list can enumerate them — 237 of this repository's 2633 commits were
+/// counted ticketed on such a string alone. Position separates them:
+/// [`subject_ticket_key`] accepts a key only where the author declares one.
+///
+/// What: returns `true` for a JIRA/Linear key the SUBJECT declares
+/// (`PROJ-123: …`), a GitHub action-keyword ref anywhere in the message
+/// (`closes #N`, `fixes #N`), or an Azure DevOps ref anywhere (`AB#N`).
+/// A bare `#N`, and a JIRA-shaped token that is not the subject's leading
+/// token, both return `false`.
 /// Test: `tests::ticketed_*` below; the critical regression cases are
-/// `bare_hash_alone_is_NOT_ticketed`, `closes_hash_IS_ticketed`,
-/// `jira_IS_ticketed`, and `azdo_IS_ticketed`.
+/// `bare_hash_alone_is_not_ticketed`, `closes_hash_is_ticketed`,
+/// `jira_is_ticketed`, `azdo_is_ticketed`, and
+/// `jira_shaped_prose_is_not_ticketed`.
 ///
 /// # Examples
 ///
@@ -197,10 +211,18 @@ fn subject_ticket_key(subject: &str) -> Option<String> {
 /// assert!(is_ticketed("Fix login (closes #42)"));
 /// assert!(!is_ticketed("misc cleanup"));
 /// assert!(!is_ticketed("some note about #42"));
+///
+/// // #5735: a JIRA-shaped token in prose is not a ticket reference.
+/// assert!(!is_ticketed("fix: stem handling\n\nA multi-byte UTF-8 name breaks it.\n"));
+/// assert!(!is_ticketed("docs: amend ADR-0034"));
 /// ```
 pub fn is_ticketed(message: &str) -> bool {
     let p = patterns();
-    p.jira.is_match(message) || p.gh_action.is_match(message) || p.azdo.is_match(message)
+    p.gh_action.is_match(message)
+        || p.azdo.is_match(message)
+        // #5735: the same subject-anchored, doc-prefix-rejecting rule
+        // `extract_ticket_id` uses, so the two cannot disagree.
+        || subject_ticket_key(message.lines().next().unwrap_or("")).is_some()
 }
 
 /// Extract the ticket identifier a commit message declares.
@@ -569,7 +591,11 @@ mod tests {
     fn jira_style_is_ticketed() {
         assert!(is_ticketed("ENG-123: add feature"));
         assert!(is_ticketed("PROJ-1 initial commit"));
-        assert!(is_ticketed("Backport from upstream (ABC-4567)"));
+        // #5735: `Backport from upstream (ABC-4567)` used to pass here. It is
+        // now covered as a NEGATIVE in
+        // `jira_shaped_prose_is_not_ticketed` — a mid-subject parenthetical is
+        // the same position `UTF-8` and `ADR-0034` occupy.
+        assert!(is_ticketed("[ABC-4567] backport from upstream"));
     }
 
     #[test]
@@ -642,8 +668,11 @@ mod tests {
 
     #[test]
     fn multiline_body_with_ticket_is_ticketed() {
-        // JIRA ref anywhere in body → ticketed.
-        let msg = "Refactor module structure\n\nMoves things around.\nRelates to PROJ-789.\n";
+        // #5735: a JIRA ref in the BODY is no longer ticketed — that position
+        // is where `UTF-8` and `ADR-0034` live. The subject still declares.
+        let body_only = "Refactor module structure\n\nMoves things around.\nRelates to PROJ-789.\n";
+        assert!(!is_ticketed(body_only));
+        let msg = "PROJ-789: refactor module structure\n\nMoves things around.\n";
         assert!(is_ticketed(msg));
 
         // Bare #N in body is NOT ticketed (issue #445 fix); action keyword is.
@@ -668,9 +697,72 @@ mod tests {
         let p = patterns();
         assert!(!p.azdo.is_match("#1234 some work"));
         assert!(!p.azdo.is_match("fixes #99"));
-        // And the existing JIRA pattern must not accidentally fire on AB#N
-        // (different separator: `#` vs `-`).
-        assert!(!p.jira.is_match("AB#1234"));
+        // And the JIRA route must not fire on AB#N either (different
+        // separator: `#` vs `-`), so `AB#1234` is ticketed only as ADO.
+        assert_eq!(subject_ticket_key("AB#1234"), None);
+    }
+
+    /// Why: #5735 — `is_ticketed` ran an unrestricted `\b[A-Z][A-Z0-9]*-\d+\b`
+    /// over the whole message, so a `UTF-8` or `ADR-0034` in a body marked the
+    /// commit ticketed. 237 of this repository's 2633 commits were counted on
+    /// nothing else. `commits.ticketed` is the operator-facing quality metric
+    /// #445 tuned deliberately, so the inflation lands in a reported number.
+    /// What: every one of these is a JIRA-SHAPED string sitting where prose
+    /// sits — a body line, a mid-subject parenthetical, a tail segment — and
+    /// none of them makes a commit ticketed. The last two are the documentation
+    /// prefixes [`DOC_REF_PREFIXES`] rejects even in declaring position.
+    /// Test: this test itself.
+    #[test]
+    fn jira_shaped_prose_is_not_ticketed() {
+        for msg in [
+            // The two cases #5735 names.
+            "fix: stem handling\n\nA filename containing a multi-byte UTF-8 character breaks.\n",
+            "docs: amend ADR-0034 point 7",
+            // The rest of the measured long tail, in body position.
+            "chore: pin the digest\n\nVerifies the artifact against the published SHA-256.\n",
+            "chore: bump anydoc\n\nAvoids reintroducing RUSTSEC-2026-0187.\n",
+            "build: probe the toolchain\n\nMirrors the AL2023/GCC-11 desync.\n",
+            "docs: rate table\n\nGPT-5 and Gemini rates differ.\n",
+            "fix: parse timestamps\n\nISO-8601 offsets were dropped.\n",
+            "docs: manifest\n\nPer DOC-39 the manifest is an allowlist.\n",
+            "chore: triage\n\nResolves the HIGH-1 finding from the audit.\n",
+            // A mid-subject parenthetical is the same position as prose.
+            "Backport from upstream (ABC-4567)",
+            // A tail segment of a longer identifier stays unreachable.
+            "SPEC-INSTALLER-01 detect target",
+            // Declaring position, documentation prefix: still not a ticket.
+            "DOC-67 §2 rewrite",
+            "RFC-2119 keyword sweep",
+        ] {
+            assert!(!is_ticketed(msg), "message: {msg:?}");
+        }
+    }
+
+    /// Why: #5735 narrowed where a JIRA/Linear key counts, so the subject
+    /// shapes that DO declare one must be proven still to count — a fix that
+    /// zeroed the metric would be as wrong as the inflation it replaced.
+    /// What: `is_ticketed` agrees with `extract_ticket_id` on every subject
+    /// form, and the GitHub and Azure DevOps routes are untouched by position.
+    /// Test: this test itself.
+    #[test]
+    fn subject_declared_key_is_still_ticketed() {
+        for msg in [
+            "BB-2746: refactor auth service",
+            "DRE-405 fix demand calculation",
+            "fix(auth): PROJ-12 tighten token check",
+            "[ENG-77] add endpoint",
+            "feat!: API-9 breaking rename",
+            "SRE-3104",
+            "ENG-7 refactor\n\nBody mentions UTF-8 and ADR-0034.\n",
+        ] {
+            assert!(is_ticketed(msg), "message: {msg:?}");
+            assert!(extract_ticket_id(msg).is_some(), "message: {msg:?}");
+        }
+        // Position never mattered for these two routes and still does not.
+        assert!(is_ticketed("Rework the guard\n\nCloses #5735\n"));
+        assert!(is_ticketed(
+            "Refactor module\n\nbody mentions AB#7 explicitly"
+        ));
     }
 
     #[test]

--- a/crates/trusty-git-analytics/src/core/config/validator.rs
+++ b/crates/trusty-git-analytics/src/core/config/validator.rs
@@ -38,7 +38,7 @@
 
 use std::path::Path;
 
-use super::{expand_path, Config, GithubConfig};
+use super::{expand_path, BitbucketConfig, ClassificationConfig, Config, GithubConfig};
 
 /// A single configuration validation failure.
 ///
@@ -134,6 +134,93 @@ fn github_token_missing(gh: &GithubConfig, env_token: Option<&str>) -> bool {
     }
     let non_empty = |s: &str| !s.trim().is_empty();
     !gh.token.as_deref().is_some_and(non_empty) && !env_token.is_some_and(non_empty)
+}
+
+/// Is `s` present and not whitespace-only?
+fn present(s: Option<&str>) -> bool {
+    s.is_some_and(|v| !v.trim().is_empty())
+}
+
+/// Decide whether Bitbucket PR fetching is enabled with no usable auth mode.
+///
+/// Why (#5725): the enclosing check read `BITBUCKET_TOKEN` and
+/// `BITBUCKET_APP_PASSWORD` inline, so the only way to test the missing-auth
+/// branch was to remove both process-wide — `unsafe` under the 2024 edition and
+/// a race against every other test thread. Taking both env values as arguments
+/// makes every branch provable without touching global state, the same shape
+/// #5313 used for [`github_token_missing`].
+/// What: returns `true` only when `fetch_prs` is on and neither auth mode
+/// resolves — bearer token (config or env), nor `username` paired with an app
+/// password (config or env).
+/// Test: `bitbucket_auth_missing_across_config_and_env`.
+fn bitbucket_auth_missing(
+    bb: &BitbucketConfig,
+    token_env: Option<&str>,
+    pwd_env: Option<&str>,
+) -> bool {
+    if !bb.fetch_prs {
+        return false;
+    }
+    let has_token = present(bb.token.as_deref()) || present(token_env);
+    let has_basic = present(bb.username.as_deref())
+        && (present(bb.app_password.as_deref()) || present(pwd_env));
+    !has_token && !has_basic
+}
+
+/// The env var names whose presence can satisfy `provider`'s API-key
+/// requirement, or `None` when the provider needs no key check.
+///
+/// Why: `bedrock` uses the AWS default credential chain, so no single API-key
+/// check applies; every other provider has a fixed key list. Naming that list
+/// separately lets [`llm_key_missing`] stay pure.
+/// What: `openrouter` and `openai` map to their one key each; anything else
+/// (including `auto`) accepts either. `bedrock` maps to `None`.
+/// Test: `llm_key_missing_across_providers_and_env`.
+fn llm_env_keys(provider: &str) -> Option<&'static [&'static str]> {
+    match provider {
+        "openrouter" => Some(&["OPENROUTER_API_KEY"]),
+        "openai" => Some(&["OPENAI_API_KEY"]),
+        "bedrock" => None,
+        _ => Some(&["OPENROUTER_API_KEY", "OPENAI_API_KEY"]),
+    }
+}
+
+/// Decide whether LLM classification is enabled with no API key available.
+///
+/// Why (#5725): the enclosing check read `OPENROUTER_API_KEY` and
+/// `OPENAI_API_KEY` inline, so the only way to test the missing-key branch was
+/// to remove both process-wide. That removal raced
+/// `profile::batch_reviewer::tests::from_slug_with_store_errors_when_no_credential_resolves`,
+/// whose `#[serial]` tag serializes it only against other `#[serial]` tests —
+/// the unguarded restore put `OPENROUTER_API_KEY` back mid-resolution and that
+/// test failed. `env_lookup` is now an argument, so no test needs the process
+/// environment at all.
+/// What: returns the provider name when `use_llm` is on and neither the config
+/// key nor any key `env_lookup` answers for carries a non-whitespace value.
+/// `bedrock` always returns `None` — see [`llm_env_keys`].
+/// Test: `llm_key_missing_across_providers_and_env`.
+fn llm_key_missing(
+    cls: &ClassificationConfig,
+    env_lookup: impl Fn(&str) -> Option<String>,
+) -> Option<String> {
+    if !cls.use_llm {
+        return None;
+    }
+    let provider = cls.llm_provider.as_str();
+    let env_keys = llm_env_keys(provider)?;
+    // Only `openrouter` and `auto` read a key from the config file; `openai`
+    // has no config field, so its key must come from the environment.
+    let config_key = match provider {
+        "openai" => None,
+        _ => cls.openrouter_api_key.as_deref(),
+    };
+    if present(config_key) {
+        return None;
+    }
+    if env_keys.iter().any(|k| present(env_lookup(k).as_deref())) {
+        return None;
+    }
+    Some(provider.to_string())
 }
 
 /// Runs a battery of validation checks against a [`Config`].
@@ -276,21 +363,10 @@ impl<'a> ConfigValidator<'a> {
             });
         }
 
-        let nonempty = |o: Option<&str>| o.map(|s| !s.trim().is_empty()).unwrap_or(false);
-        let token_in_cfg = nonempty(bb.token.as_deref());
-        let token_in_env = std::env::var("BITBUCKET_TOKEN")
-            .map(|v| !v.trim().is_empty())
-            .unwrap_or(false);
-        let user = nonempty(bb.username.as_deref());
-        let pwd_in_cfg = nonempty(bb.app_password.as_deref());
-        let pwd_in_env = std::env::var("BITBUCKET_APP_PASSWORD")
-            .map(|v| !v.trim().is_empty())
-            .unwrap_or(false);
-
-        let has_token = token_in_cfg || token_in_env;
-        let has_basic = user && (pwd_in_cfg || pwd_in_env);
-
-        if !has_token && !has_basic {
+        // #5725: read the env here so the decision itself stays pure.
+        let token_env = std::env::var("BITBUCKET_TOKEN").ok();
+        let pwd_env = std::env::var("BITBUCKET_APP_PASSWORD").ok();
+        if bitbucket_auth_missing(bb, token_env.as_deref(), pwd_env.as_deref()) {
             errors.push(ConfigError::MissingBitbucketAuth);
         }
     }
@@ -334,34 +410,9 @@ impl<'a> ConfigValidator<'a> {
         let Some(cls) = self.config.classification.as_ref() else {
             return;
         };
-        if !cls.use_llm {
-            return;
-        }
-        let provider = cls.llm_provider.as_str();
-        let (config_key, env_keys): (Option<&str>, &[&str]) = match provider {
-            "openrouter" => (cls.openrouter_api_key.as_deref(), &["OPENROUTER_API_KEY"]),
-            "openai" => (None, &["OPENAI_API_KEY"]),
-            // Bedrock uses the AWS default credential chain (env vars, shared
-            // config, IAM role, etc.) — no single API-key check applies. Skip
-            // the missing-key validation; the SDK will surface auth errors at
-            // call time.
-            "bedrock" => return,
-            // "auto" — accept either provider's key.
-            _ => (
-                cls.openrouter_api_key.as_deref(),
-                &["OPENROUTER_API_KEY", "OPENAI_API_KEY"],
-            ),
-        };
-        let cfg_present = config_key.map(|k| !k.trim().is_empty()).unwrap_or(false);
-        let env_present = env_keys.iter().any(|k| {
-            std::env::var(k)
-                .map(|v| !v.trim().is_empty())
-                .unwrap_or(false)
-        });
-        if !cfg_present && !env_present {
-            errors.push(ConfigError::MissingLlmKey {
-                provider: provider.to_string(),
-            });
+        // #5725: read the env here so the decision itself stays pure.
+        if let Some(provider) = llm_key_missing(cls, |k| std::env::var(k).ok()) {
+            errors.push(ConfigError::MissingLlmKey { provider });
         }
     }
 

--- a/crates/trusty-git-analytics/src/core/config/validator_tests.rs
+++ b/crates/trusty-git-analytics/src/core/config/validator_tests.rs
@@ -170,38 +170,104 @@ fn empty_jira_block_is_fine() {
     );
 }
 
-#[test]
-fn missing_llm_key_reported() {
-    let prev_or = std::env::var("OPENROUTER_API_KEY").ok();
-    let prev_oa = std::env::var("OPENAI_API_KEY").ok();
-    // SAFETY: env var manipulation is unsafe in 2024 edition.
-    unsafe {
-        std::env::remove_var("OPENROUTER_API_KEY");
-        std::env::remove_var("OPENAI_API_KEY");
-    }
-
-    let mut cfg = empty_config();
-    cfg.classification = Some(ClassificationConfig {
+/// Build a `ClassificationConfig` with LLM classification on.
+fn llm_enabled(provider: &str, config_key: Option<&str>) -> ClassificationConfig {
+    ClassificationConfig {
         use_llm: true,
-        llm_provider: "openrouter".into(),
-        openrouter_api_key: None,
+        llm_provider: provider.into(),
+        openrouter_api_key: config_key.map(str::to_string),
         ..Default::default()
-    });
-    let errors = ConfigValidator::new(&cfg).validate();
-    let found = errors
-        .iter()
-        .any(|e| matches!(e, ConfigError::MissingLlmKey { .. }));
-
-    // SAFETY: env var manipulation is unsafe in 2024 edition.
-    unsafe {
-        if let Some(v) = prev_or {
-            std::env::set_var("OPENROUTER_API_KEY", v);
-        }
-        if let Some(v) = prev_oa {
-            std::env::set_var("OPENAI_API_KEY", v);
-        }
     }
-    assert!(found, "got {errors:?}");
+}
+
+/// An `env_lookup` that answers only for the named key.
+fn only(key: &'static str, value: &'static str) -> impl Fn(&str) -> Option<String> {
+    move |k| (k == key).then(|| value.to_string())
+}
+
+/// Why: a config with `use_llm = true` and no API key anywhere cannot classify,
+/// so validation must say so before the run starts.
+/// What: drive `llm_key_missing` across every provider and every source a key
+/// can come from, with `env_lookup` supplied per case.
+/// Test: this test. #5725: it used to remove `OPENROUTER_API_KEY` and
+/// `OPENAI_API_KEY` process-wide to reach the missing-key branch. That is
+/// `unsafe` under the 2024 edition, and its restore raced
+/// `profile::batch_reviewer::tests::from_slug_with_store_errors_when_no_credential_resolves` —
+/// putting the key back mid-resolution and failing that test 40 runs out of 40.
+/// The env lookup is now an argument, so the present-key branches are covered
+/// too; they were unreachable before.
+#[test]
+fn llm_key_missing_across_providers_and_env() {
+    let none = |_: &str| None;
+
+    assert_eq!(
+        llm_key_missing(&llm_enabled("openrouter", None), none),
+        Some("openrouter".to_string()),
+        "no config key and no env key means classification cannot run"
+    );
+    assert_eq!(
+        llm_key_missing(&llm_enabled("openrouter", Some("   ")), |_| Some(
+            "\t".to_string()
+        )),
+        Some("openrouter".to_string()),
+        "whitespace-only keys count as absent"
+    );
+    assert_eq!(
+        llm_key_missing(&llm_enabled("openrouter", Some("sk-or-xxx")), none),
+        None,
+        "a config key satisfies the check"
+    );
+    assert_eq!(
+        llm_key_missing(
+            &llm_enabled("openrouter", None),
+            only("OPENROUTER_API_KEY", "sk-or-xxx")
+        ),
+        None,
+        "OPENROUTER_API_KEY satisfies the check"
+    );
+    assert_eq!(
+        llm_key_missing(
+            &llm_enabled("openrouter", None),
+            only("OPENAI_API_KEY", "sk-oa-xxx")
+        ),
+        Some("openrouter".to_string()),
+        "the wrong provider's key does not satisfy openrouter"
+    );
+
+    // `openai` reads no config field — its key must come from the environment.
+    assert_eq!(
+        llm_key_missing(&llm_enabled("openai", Some("sk-or-xxx")), none),
+        Some("openai".to_string()),
+        "the openrouter config key is not an openai key"
+    );
+    assert_eq!(
+        llm_key_missing(
+            &llm_enabled("openai", None),
+            only("OPENAI_API_KEY", "sk-oa-xxx")
+        ),
+        None
+    );
+
+    // `auto` accepts either provider's key.
+    assert_eq!(
+        llm_key_missing(
+            &llm_enabled("auto", None),
+            only("OPENAI_API_KEY", "sk-oa-xxx")
+        ),
+        None
+    );
+    assert_eq!(
+        llm_key_missing(&llm_enabled("auto", None), none),
+        Some("auto".to_string())
+    );
+
+    // Bedrock uses the AWS credential chain — no API-key check applies.
+    assert_eq!(llm_key_missing(&llm_enabled("bedrock", None), none), None);
+
+    // LLM off means no key is required.
+    let mut off = llm_enabled("openrouter", None);
+    off.use_llm = false;
+    assert_eq!(llm_key_missing(&off, none), None);
 }
 
 #[test]
@@ -241,88 +307,143 @@ fn nonexistent_output_dir_is_created_and_passes() {
     assert!(exists, "validator should have created the dir");
 }
 
-/// Drop guard that snapshots an env var, removes it for the test, and
-/// restores it (or removes it again if it was originally absent) on drop.
-///
-/// Why: previous closure-based helpers ran restore code *after* the test
-/// body, which meant a panicking assertion would skip the restore and
-/// leak mutated global env state into the rest of the test run. A Drop
-/// guard runs during unwinding too, so panicking tests still restore.
-///
-/// SAFETY: env-var mutation is `unsafe` in the 2024 edition. We accept
-/// it here only inside `#[cfg(test)]` and rely on the guard being the
-/// sole writer in the test it covers.
-struct EnvVarGuard {
-    name: &'static str,
-    original: Option<String>,
-}
-
-impl EnvVarGuard {
-    /// Snapshot `name`, remove it, and arrange for restore on drop.
-    fn remove(name: &'static str) -> Self {
-        let original = std::env::var(name).ok();
-        // SAFETY: 2024-edition env mutation; isolated to this test thread
-        // via Drop ordering; cleanup is guaranteed via the impl below.
-        unsafe { std::env::remove_var(name) };
-        Self { name, original }
+/// Build a `BitbucketConfig` with PR fetching on and the given auth fields.
+fn bitbucket_fetching_prs(
+    token: Option<&str>,
+    username: Option<&str>,
+    app_password: Option<&str>,
+) -> BitbucketConfig {
+    BitbucketConfig {
+        token: token.map(str::to_string),
+        username: username.map(str::to_string),
+        app_password: app_password.map(str::to_string),
+        workspace: Some("acme".into()),
+        repo_slug: Some("widgets".into()),
+        fetch_prs: true,
+        ..Default::default()
     }
 }
 
-impl Drop for EnvVarGuard {
-    fn drop(&mut self) {
-        // SAFETY: see [`EnvVarGuard::remove`].
-        unsafe {
-            match self.original.as_deref() {
-                Some(v) => std::env::set_var(self.name, v),
-                None => std::env::remove_var(self.name),
-            }
-        }
-    }
+/// Why: Bitbucket PR fetching needs one of two auth modes, and either half of
+/// either mode can arrive from the config file or the environment. Validation
+/// must reject only the combinations that leave no usable mode.
+/// What: drive `bitbucket_auth_missing` across bearer-token and basic-auth
+/// sources, including whitespace-only values and the partial-basic case.
+/// Test: this test. #5725: the four Bitbucket tests below used to clear
+/// `BITBUCKET_TOKEN` and `BITBUCKET_APP_PASSWORD` process-wide through an
+/// `EnvVarGuard`, which is `unsafe` under the 2024 edition and races every other
+/// test thread. Both env values are now arguments, so the env-supplied branches
+/// are covered too; they were unreachable before.
+#[test]
+fn bitbucket_auth_missing_across_config_and_env() {
+    assert!(
+        bitbucket_auth_missing(&bitbucket_fetching_prs(None, None, None), None, None),
+        "no auth in config and none in the environment"
+    );
+    assert!(
+        !bitbucket_auth_missing(
+            &bitbucket_fetching_prs(Some("workspace-access-token"), None, None),
+            None,
+            None
+        ),
+        "a config bearer token satisfies the check"
+    );
+    assert!(
+        !bitbucket_auth_missing(
+            &bitbucket_fetching_prs(None, None, None),
+            Some("env-token"),
+            None
+        ),
+        "BITBUCKET_TOKEN satisfies the check"
+    );
+    assert!(
+        !bitbucket_auth_missing(
+            &bitbucket_fetching_prs(None, Some("alice"), Some("abcd")),
+            None,
+            None
+        ),
+        "a config username/app-password pair satisfies the check"
+    );
+    assert!(
+        !bitbucket_auth_missing(
+            &bitbucket_fetching_prs(None, Some("alice"), None),
+            None,
+            Some("env-pwd")
+        ),
+        "BITBUCKET_APP_PASSWORD pairs with a config username"
+    );
+    assert!(
+        bitbucket_auth_missing(
+            &bitbucket_fetching_prs(None, Some("alice"), None),
+            None,
+            None
+        ),
+        "a username with no password anywhere is partial auth, not auth"
+    );
+    assert!(
+        bitbucket_auth_missing(
+            &bitbucket_fetching_prs(None, None, Some("abcd")),
+            None,
+            None
+        ),
+        "an app password with no username is partial auth, not auth"
+    );
+    assert!(
+        bitbucket_auth_missing(
+            &bitbucket_fetching_prs(Some("  "), Some("alice"), Some("\t")),
+            Some(" "),
+            Some("")
+        ),
+        "whitespace-only values count as absent in every position"
+    );
+
+    let mut off = bitbucket_fetching_prs(None, None, None);
+    off.fetch_prs = false;
+    assert!(
+        !bitbucket_auth_missing(&off, None, None),
+        "no auth is required when fetch_prs is off"
+    );
 }
 
-/// Save and clear the Bitbucket env vars for the duration of a closure,
-/// then restore them — panic-safe via [`EnvVarGuard`].
-fn with_clean_bitbucket_env<F: FnOnce()>(f: F) {
-    let _t = EnvVarGuard::remove("BITBUCKET_TOKEN");
-    let _p = EnvVarGuard::remove("BITBUCKET_APP_PASSWORD");
-    f();
-    // Guards drop here (or earlier on panic), restoring env.
-}
-
+/// Why: the workspace and repo_slug checks are separate from auth and consult
+/// no environment, so they are provable through the whole validator.
+/// What: a Bitbucket block with PR fetching on and neither field set reports
+/// both as incomplete.
+/// Test: this test itself.
 #[test]
 fn bitbucket_requires_workspace_and_repo_slug_when_fetch_prs() {
-    with_clean_bitbucket_env(|| {
-        let mut cfg = empty_config();
-        cfg.bitbucket = Some(BitbucketConfig {
-            token: Some("bearer".into()),
-            fetch_prs: true,
-            ..Default::default()
-        });
-        let errors = ConfigValidator::new(&cfg).validate();
-        let missing: Vec<&str> = errors
-            .iter()
-            .filter_map(|e| match e {
-                ConfigError::IncompleteBitbucketConfig { field } => Some(field.as_str()),
-                _ => None,
-            })
-            .collect();
-        assert!(missing.contains(&"workspace"), "got {errors:?}");
-        assert!(missing.contains(&"repo_slug"), "got {errors:?}");
+    let mut cfg = empty_config();
+    cfg.bitbucket = Some(BitbucketConfig {
+        token: Some("bearer".into()),
+        fetch_prs: true,
+        ..Default::default()
     });
+    let errors = ConfigValidator::new(&cfg).validate();
+    let missing: Vec<&str> = errors
+        .iter()
+        .filter_map(|e| match e {
+            ConfigError::IncompleteBitbucketConfig { field } => Some(field.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert!(missing.contains(&"workspace"), "got {errors:?}");
+    assert!(missing.contains(&"repo_slug"), "got {errors:?}");
 }
 
+/// Why: the two complete auth modes must pass the whole validator, not just the
+/// decision function.
+/// What: a bearer token and a username/app-password pair each yield no
+/// Bitbucket error. An ambient `BITBUCKET_*` value could only ADD auth, so
+/// these assertions need no environment control (#5725).
+/// Test: this test itself.
 #[test]
-fn bitbucket_accepts_app_password_pair() {
-    with_clean_bitbucket_env(|| {
+fn bitbucket_complete_auth_passes_validation() {
+    for bb in [
+        bitbucket_fetching_prs(None, Some("alice"), Some("abcd")),
+        bitbucket_fetching_prs(Some("workspace-access-token"), None, None),
+    ] {
         let mut cfg = empty_config();
-        cfg.bitbucket = Some(BitbucketConfig {
-            username: Some("alice".into()),
-            app_password: Some("abcd".into()),
-            workspace: Some("acme".into()),
-            repo_slug: Some("widgets".into()),
-            fetch_prs: true,
-            ..Default::default()
-        });
+        cfg.bitbucket = Some(bb);
         let errors = ConfigValidator::new(&cfg).validate();
         assert!(
             !errors.iter().any(|e| matches!(
@@ -331,51 +452,7 @@ fn bitbucket_accepts_app_password_pair() {
             )),
             "got {errors:?}"
         );
-    });
-}
-
-#[test]
-fn bitbucket_accepts_bearer_token() {
-    with_clean_bitbucket_env(|| {
-        let mut cfg = empty_config();
-        cfg.bitbucket = Some(BitbucketConfig {
-            token: Some("workspace-access-token".into()),
-            workspace: Some("acme".into()),
-            repo_slug: Some("widgets".into()),
-            fetch_prs: true,
-            ..Default::default()
-        });
-        let errors = ConfigValidator::new(&cfg).validate();
-        assert!(
-            !errors.iter().any(|e| matches!(
-                e,
-                ConfigError::MissingBitbucketAuth | ConfigError::IncompleteBitbucketConfig { .. }
-            )),
-            "got {errors:?}"
-        );
-    });
-}
-
-#[test]
-fn bitbucket_rejects_partial_auth() {
-    with_clean_bitbucket_env(|| {
-        let mut cfg = empty_config();
-        // username without app_password
-        cfg.bitbucket = Some(BitbucketConfig {
-            username: Some("alice".into()),
-            workspace: Some("acme".into()),
-            repo_slug: Some("widgets".into()),
-            fetch_prs: true,
-            ..Default::default()
-        });
-        let errors = ConfigValidator::new(&cfg).validate();
-        assert!(
-            errors
-                .iter()
-                .any(|e| matches!(e, ConfigError::MissingBitbucketAuth)),
-            "got {errors:?}"
-        );
-    });
+    }
 }
 
 #[test]
@@ -409,16 +486,16 @@ fn config_validator_rejects_ado_with_no_projects() {
 
 #[test]
 fn bitbucket_block_off_is_fine() {
-    with_clean_bitbucket_env(|| {
-        let mut cfg = empty_config();
-        cfg.bitbucket = Some(BitbucketConfig::default());
-        let errors = ConfigValidator::new(&cfg).validate();
-        assert!(
-            !errors.iter().any(|e| matches!(
-                e,
-                ConfigError::MissingBitbucketAuth | ConfigError::IncompleteBitbucketConfig { .. }
-            )),
-            "got {errors:?}"
-        );
-    });
+    // `fetch_prs` defaults off, so the check returns before it reads anything —
+    // no environment control needed (#5725).
+    let mut cfg = empty_config();
+    cfg.bitbucket = Some(BitbucketConfig::default());
+    let errors = ConfigValidator::new(&cfg).validate();
+    assert!(
+        !errors.iter().any(|e| matches!(
+            e,
+            ConfigError::MissingBitbucketAuth | ConfigError::IncompleteBitbucketConfig { .. }
+        )),
+        "got {errors:?}"
+    );
 }

--- a/crates/trusty-git-analytics/src/report/aggregator/mod.rs
+++ b/crates/trusty-git-analytics/src/report/aggregator/mod.rs
@@ -597,7 +597,7 @@ impl Aggregator {
     /// the implementation lives in [`crate::report::persist`] to keep this file
     /// within the 500-line cap.
     /// What: delegates to [`crate::report::persist::persist_weekly_quality`].
-    /// Test: `report::tests::persist_weekly_quality_upserts_rows`.
+    /// Test: `report::tests::persist_weekly_quality_upserts_rows_and_is_idempotent`.
     pub fn persist_weekly_quality(db: &Database, data: &ReportData) -> Result<usize> {
         crate::report::persist::persist_weekly_quality(db, data)
     }

--- a/crates/trusty-git-analytics/src/report/persist.rs
+++ b/crates/trusty-git-analytics/src/report/persist.rs
@@ -7,7 +7,7 @@
 //! What: two public functions — [`persist_weekly_quality`] and
 //! [`persist_weekly_engineer`] — each UPSERT one row per
 //! [`crate::report::models::WeeklyActivity`] into the corresponding fact table.
-//! Test: `report::tests::persist_weekly_quality_upserts_rows` and
+//! Test: `report::tests::persist_weekly_quality_upserts_rows_and_is_idempotent` and
 //! `report::tests::persist_weekly_engineer_upserts_rows`.
 
 use std::collections::HashMap;
@@ -70,7 +70,7 @@ fn computed_at_secs() -> i64 {
 /// name into the email-keyed column: doing so would produce rows that can never
 /// join with other tables and would silently corrupt aggregate queries.
 /// To fix unmapped identities run `tga aliases list` and add the missing mapping.
-/// Test: `report::tests::persist_weekly_quality_upserts_rows`.
+/// Test: `report::tests::persist_weekly_quality_upserts_rows_and_is_idempotent`.
 ///
 /// # Errors
 ///

--- a/crates/trusty-git-analytics/src/report/tests.rs
+++ b/crates/trusty-git-analytics/src/report/tests.rs
@@ -9,6 +9,8 @@
 
 use std::path::PathBuf;
 
+use crate::collect::ai_attribution::AgenticMode;
+use crate::collect::ai_markers::{detect, CommitSignals};
 use crate::core::config::{Config, OutputConfig, RepositoryConfig};
 use crate::core::db::Database;
 
@@ -985,4 +987,218 @@ fn agentic_pct_keeps_unknown_in_the_denominator() {
         "agentic_pct must be 1/4; 50.0 would bucket unknown as agentic and \
          33.3 would drop it from the denominator. got {pct}"
     );
+}
+
+// =========================================================================
+// fact_weekly_engineer end-to-end against real commit shapes (issue #5252)
+// =========================================================================
+
+/// One fixture commit, in the shape the git walk hands to detection.
+struct CommitShape {
+    sha: &'static str,
+    author_name: &'static str,
+    author_email: &'static str,
+    committer_email: &'static str,
+    message: &'static str,
+    is_merge: bool,
+    /// The mode detection must return. Asserted, not assumed — a marker-set
+    /// change that shifts a commit between buckets has to fail HERE, naming the
+    /// commit, rather than silently moving `agentic_pct`.
+    expect: AgenticMode,
+}
+
+/// Seven commit messages taken from the shapes this repository actually
+/// produces: a multi-trailer house footer, a bare Claude Code footer, a Copilot
+/// trailer, a forge squash-merge whose body was replaced, a machine merge
+/// summary, a hand-written commit, a revert, and a bot-authored commit
+/// identified only by its email.
+fn real_commit_shapes() -> Vec<CommitShape> {
+    vec![
+        CommitShape {
+            sha: "c1",
+            author_name: "Dana",
+            author_email: "dana@example.com",
+            committer_email: "dana@example.com",
+            message: "feat(tga): harvest branch and PR refs\n\n\
+                 Adds two extractors and routes both through the deny-list.\n\n\
+                 Refs #5734\n\
+                 Co-Authored-By: Claude <noreply@anthropic.com>\n\
+                 🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools\n",
+            is_merge: false,
+            expect: AgenticMode::FullAgentic,
+        },
+        CommitShape {
+            sha: "c2",
+            author_name: "Dana",
+            author_email: "dana@example.com",
+            committer_email: "dana@example.com",
+            // #5249: the house-footer shape that carries no `Co-Authored-By:`.
+            message: "fix(report): keep unknown in the denominator\n\n\
+                 🤖 Generated with [Claude Code](https://claude.com/claude-code)\n",
+            is_merge: false,
+            expect: AgenticMode::FullAgentic,
+        },
+        CommitShape {
+            sha: "c3",
+            author_name: "Dana",
+            author_email: "dana@example.com",
+            committer_email: "dana@example.com",
+            message: "chore: tidy the import block\n\n\
+                 Co-authored-by: Copilot <copilot@users.noreply.github.com>\n",
+            is_merge: false,
+            expect: AgenticMode::IdeAssisted,
+        },
+        CommitShape {
+            sha: "c4",
+            author_name: "Dana",
+            author_email: "dana@example.com",
+            committer_email: "noreply@github.com",
+            // A forge squash-merge with the PR title as the subject and every
+            // remaining line a synthesized trailer — the body where a footer
+            // would have lived is gone (#5250).
+            message: "feat(audit): checkpoint the sweep per repository (#5494)\n\n\
+                 Co-authored-by: Dana Dev <dana@example.com>\n",
+            is_merge: false,
+            expect: AgenticMode::Unknown,
+        },
+        CommitShape {
+            sha: "c5",
+            author_name: "Dana",
+            author_email: "dana@example.com",
+            committer_email: "dana@example.com",
+            message: "Merge branch 'main' into feature/harvest-refs\n",
+            is_merge: true,
+            expect: AgenticMode::Unknown,
+        },
+        CommitShape {
+            sha: "c6",
+            author_name: "Dana",
+            author_email: "dana@example.com",
+            committer_email: "dana@example.com",
+            message: "docs: correct the fact-table column description\n",
+            is_merge: false,
+            expect: AgenticMode::None,
+        },
+        CommitShape {
+            sha: "c7",
+            author_name: "Dana",
+            author_email: "dana@example.com",
+            committer_email: "dana@example.com",
+            message: "Revert \"feat(tga): harvest branch and PR refs\"\n\n\
+                 This reverts commit c1.\n",
+            is_merge: false,
+            expect: AgenticMode::None,
+        },
+        CommitShape {
+            sha: "c8",
+            author_name: "devin-ai-integration[bot]",
+            author_email: "devin-ai-integration[bot]@users.noreply.github.com",
+            committer_email: "devin-ai-integration[bot]@users.noreply.github.com",
+            // No marker in the text at all — the bot identity is the signal.
+            message: "chore(deps): bump the lockfile\n",
+            is_merge: false,
+            expect: AgenticMode::FullAgentic,
+        },
+    ]
+}
+
+/// Why: #5252 — `persist.rs` and `aggregator/mod.rs` both cited a
+/// `persist_weekly_engineer_upserts_rows` that did not exist, so the
+/// `agentic_pct` formula had no test naming it, and every detection test was a
+/// synthetic one-liner. A percentage an acquirer reads (DOC-67 §8) was resting
+/// on arithmetic nothing proved end to end.
+/// What: runs the eight fixture messages through `ai_markers::detect` exactly as
+/// `collect::git::extractor` does, stores the verdict, aggregates, and reads the
+/// persisted row back. Dana's week is 7 commits, one of them a revert, so
+/// `net_commits` is 6 with 2 full-agentic — `agentic_pct` must be 33.33…, which
+/// no other bucketing produces: 42.9 would forget the revert, 28.6 would count
+/// the revert in the denominator, and 50.0 would fold `ide_assisted` into the
+/// numerator. The bot commit lands on its own grain key at 100.0, and a second
+/// persist proves the UPSERT.
+/// Test: this test itself.
+#[test]
+fn persist_weekly_engineer_upserts_rows() {
+    let db = Database::open_in_memory().expect("open db");
+    let shapes = real_commit_shapes();
+    for (i, c) in shapes.iter().enumerate() {
+        let detection = detect(&CommitSignals {
+            message: c.message,
+            author_email: c.author_email,
+            committer_email: c.committer_email,
+        });
+        assert_eq!(
+            detection.mode, c.expect,
+            "detection drifted for {}: {:?}",
+            c.sha, c.message
+        );
+        db.connection()
+            .execute(
+                "INSERT INTO commits (sha, author_name, author_email, timestamp, message, \
+                     repository, files_changed, insertions, deletions, is_merge, ticketed, \
+                     agentic_mode) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, 'repo-a', 2, 20, 4, ?6, 0, ?7)",
+                rusqlite::params![
+                    c.sha,
+                    c.author_name,
+                    c.author_email,
+                    // All eight land in ISO week 2024-W03.
+                    format!("2024-01-1{}T09:00:00+00:00", 5 + i % 5),
+                    c.message,
+                    c.is_merge as i64,
+                    detection.mode.as_str(),
+                ],
+            )
+            .expect("insert fixture commit");
+    }
+
+    let data = Aggregator::build(&db, &baseline_config()).expect("aggregate");
+
+    let dana = data
+        .weekly_activity
+        .iter()
+        .find(|w| w.author.contains("Dana"))
+        .expect("Dana has a weekly bucket");
+    assert_eq!(dana.commit_count_net, 6, "7 commits less 1 revert");
+    assert_eq!(dana.agentic_count, 2, "c1 and c2 only");
+    assert_eq!(dana.ide_assisted_count, 1, "c3 only");
+
+    let row = |email: &str| -> (i64, i64, i64, f64) {
+        db.connection()
+            .query_row(
+                "SELECT net_commits, agentic_count, ide_assisted_count, agentic_pct \
+                 FROM fact_weekly_engineer WHERE author_email = ?1",
+                [email],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
+            )
+            .expect("read persisted engineer row")
+    };
+
+    let (net, agentic, ide, pct) = row("dana@example.com");
+    assert_eq!((net, agentic, ide), (6, 2, 1));
+    assert!(
+        (pct - 200.0 / 6.0).abs() < 1e-9,
+        "agentic_pct must be 2/6; 42.9 would forget the revert, 28.6 would keep \
+         it in the denominator, 50.0 would count ide_assisted. got {pct}"
+    );
+
+    let (bot_net, bot_agentic, bot_ide, bot_pct) = row(shapes[7].author_email);
+    assert_eq!(
+        (bot_net, bot_agentic, bot_ide),
+        (1, 1, 0),
+        "the bot commit is its own grain key, not folded into Dana's"
+    );
+    assert!((bot_pct - 100.0).abs() < 1e-9, "got {bot_pct}");
+
+    // UPSERT, not INSERT: persisting the same data again must not duplicate a
+    // grain key or change a value.
+    let written = Aggregator::persist_weekly_engineer(&db, &data).expect("second persist");
+    assert_eq!(written, 2, "one row per author-week");
+    let total: i64 = db
+        .connection()
+        .query_row("SELECT COUNT(*) FROM fact_weekly_engineer", [], |r| {
+            r.get(0)
+        })
+        .expect("count rows");
+    assert_eq!(total, 2, "re-persisting must not duplicate the grain key");
+    assert_eq!(row("dana@example.com"), (6, 2, 1, pct));
 }


### PR DESCRIPTION
Three tga bugs, one commit each. See #5735, #5725, #5252 for the defects.

## Test ladder

Rung 3 — localized behavior inside one crate. One regression test per bug,
each shown failing before its fix.

```
cargo fmt --check                                  clean
cargo check -p tga                                 clean
cargo clippy -p tga --all-targets -- -D warnings   clean
cargo test -p tga                                  1334 passed; 0 failed; 7 ignored
bash scripts/check_test_pointers.sh                26130 citations, 0 dangling
bash scripts/check_line_cap.sh                     4114 files, 0 violations
bash scripts/check_changelog_fragment.sh           1 crate recorded
```

## Failing-before evidence

**#5735** — `jira_shaped_prose_is_not_ticketed` against the pre-fix
`is_ticketed`:

```
test collect::ticket::tests::jira_shaped_prose_is_not_ticketed ... FAILED
panicked at crates/trusty-git-analytics/src/collect/ticket.rs:735:13:
message: "fix: stem handling\n\nA filename containing a multi-byte UTF-8 character breaks.\n"
test result: FAILED. 31 passed; 2 failed
```

**#5725** — flake class, so the proof is repetition. Pre-fix, with an ambient
`OPENROUTER_API_KEY`, the two racing tests in one binary: **40 failures / 40
runs**, always `from_slug_with_store_errors_when_no_credential_resolves`
resolving a credential the other test had just restored. Post-fix, same
command: **0 / 10**.

**#5252** — pointer repair, proven by removing the four ratchet rows on the
pre-fix pointers:

```
FAIL: .../report/persist.rs:193: Test: pointer cites `persist_weekly_engineer_upserts_rows`
      — no `fn persist_weekly_engineer_upserts_rows(` found in crate
test-pointers: 6 dangling pointer(s), 0 stale allowlist entries — FAILED.
```

Post-fix: 0 dangling, and the four rows are gone from
`.test-pointer-allowlist.tsv` — the ratchet shrinks.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
