### PR TITLE
fix(trusty-review): stranded claim reports Approve, CLI run posts ungated, in_flight leaks (#5126, #5113, #5020)

### DIFF
--- a/.test-pointer-allowlist.tsv
+++ b/.test-pointer-allowlist.tsv
@@ -724,7 +724,6 @@ crates/trusty-review/src/report/synthesize_guard.rs	verify_prose_rejects_fabrica
 crates/trusty-review/src/service/handlers.rs	health_inference_ok_when_llm_ok
 crates/trusty-review/src/service/handlers.rs	health_returns_ok_json
 crates/trusty-review/src/service/handlers.rs	new_for_test
-crates/trusty-review/src/service/handlers.rs	review_endpoint_with_fake_deps_returns_result
 crates/trusty-review/src/service/handlers.rs	status_returns_json_with_in_flight
 crates/trusty-review/src/service/inference_probe.rs	probe_default_starts_unknown
 crates/trusty-review/src/service/mod.rs	health_returns_ok_json

--- a/crates/trusty-review/changelog.d/5020-in-flight-counter-guard.md
+++ b/crates/trusty-review/changelog.d/5020-in-flight-counter-guard.md
@@ -1,3 +1,3 @@
 Fixed
 
-- `GET /status` no longer reports an in-flight count that never comes down. `POST /review` now holds the counter through the new `InFlightCountGuard`, whose `Drop` runs the decrement, so a client disconnect that drops the handler future mid-review releases the slot — as does a panic. The decrement saturates at zero rather than wrapping. See #5020.
+- `GET /status` no longer reports an in-flight count that never comes down. `POST /review` now holds the counter through the new `InFlightCountGuard`, whose `Drop` runs the decrement, so a client disconnect that drops the handler future mid-review releases the slot — as does a panic. The decrement saturates at zero rather than wrapping, and warns when it does so, since the guard is the counter's only writer and an already-zero read means one raise was released twice. See #5020.

--- a/crates/trusty-review/changelog.d/5020-in-flight-counter-guard.md
+++ b/crates/trusty-review/changelog.d/5020-in-flight-counter-guard.md
@@ -1,0 +1,3 @@
+Fixed
+
+- `GET /status` no longer reports an in-flight count that never comes down. `POST /review` now holds the counter through the new `InFlightCountGuard`, whose `Drop` runs the decrement, so a client disconnect that drops the handler future mid-review releases the slot — as does a panic. The decrement saturates at zero rather than wrapping. See #5020.

--- a/crates/trusty-review/changelog.d/5113-cli-run-claim-gate.md
+++ b/crates/trusty-review/changelog.d/5113-cli-run-claim-gate.md
@@ -1,0 +1,3 @@
+Fixed
+
+- `trusty-review run` against a GitHub PR now opens the durable dedup claim store, so a re-run against the same `(owner, repo, pr, head_sha)` no longer posts a second comment. `build_deps_async` takes a `DedupNeed` and `dedup_need_for` derives it from the diff source and `allow_posting`; local diff sources still open nothing. `run_review` additionally aborts before any network call when posting is reachable and no store is present, so the combination fails closed wherever it is expressed. See #5113.

--- a/crates/trusty-review/changelog.d/5126-stranded-claim-not-approve.md
+++ b/crates/trusty-review/changelog.d/5126-stranded-claim-not-approve.md
@@ -1,0 +1,3 @@
+Fixed
+
+- A dedup claim another process still holds no longer reports `APPROVE`. `DedupStore::claim` now returns `ClaimOutcome::InProgressElsewhere` for a fresh in-progress record and keeps `Skipped` for a completed one, so the runner tells a review that never ran apart from one that ran and finished; the blocked run reports UNKNOWN with the reason instead of a verdict. Previously a process that died between `claim` and `complete` made every re-run of that PR report approval for up to two hours. See #5126.

--- a/crates/trusty-review/src/commands/calibrate.rs
+++ b/crates/trusty-review/src/commands/calibrate.rs
@@ -443,7 +443,16 @@ pub async fn cmd_calibrate(_config: ReviewConfig, args: CalibrateArgs) -> Result
             entry.repo,
             entry.pr
         );
-        let deps = match build_deps_async(&cfg, &reviewer_model, &default_provider).await {
+        // #5113: calibration is always `allow_posting: false`, so the post path
+        // is unreachable and the claim store has nothing to guard.
+        let deps = match build_deps_async(
+            &cfg,
+            &reviewer_model,
+            &default_provider,
+            trusty_review::store::DedupNeed::NotNeeded,
+        )
+        .await
+        {
             Ok(d) => d,
             Err(e) => {
                 warn!("calibrate: failed to build deps for PR {}: {e}", entry.pr);

--- a/crates/trusty-review/src/commands/compare.rs
+++ b/crates/trusty-review/src/commands/compare.rs
@@ -22,6 +22,8 @@ use trusty_review::{
 };
 
 use crate::commands::diff_source::{LocalDiffFlags, resolve_local_diff_source};
+use trusty_review::store::DedupNeed;
+
 use crate::commands::run::{apply_source_root_fallback, build_deps_async, resolve_source_root_arg};
 
 // ─── compare args ────────────────────────────────────────────────────────────
@@ -161,7 +163,10 @@ pub async fn cmd_compare(mut config: ReviewConfig, args: CompareArgs) -> Result<
     let (diff_source, _stdin_tmp) = materialize_stdin_if_needed(diff_source)?;
 
     for model in &models {
-        let mut deps = build_deps_async(&config, model, default_provider).await?;
+        // #5113: `compare` runs `allow_posting: false` below, so the post path
+        // is unreachable and the claim store has nothing to guard.
+        let mut deps =
+            build_deps_async(&config, model, default_provider, DedupNeed::NotNeeded).await?;
         apply_source_root_fallback(&mut deps, source_root_notice.as_deref());
         let input = ReviewInput {
             diff_source: diff_source.clone(),

--- a/crates/trusty-review/src/commands/run.rs
+++ b/crates/trusty-review/src/commands/run.rs
@@ -26,6 +26,7 @@ use trusty_review::{
         CallerContext, DiffSource, ReviewDeps, ReviewInput, TriggerDecision, log_json_path,
         run_review,
     },
+    store::{DedupNeed, open_dedup_for},
 };
 
 use crate::cli_verify;
@@ -167,8 +168,17 @@ pub async fn cmd_run(config: ReviewConfig, args: RunArgs) -> Result<()> {
         .resolve_index(&search_for_resolve)
         .await;
 
-    let mut deps =
-        build_deps_async(&config_with_overrides, &reviewer_model, &default_provider).await?;
+    // #5113: `allow_posting` is hardcoded `true` below, so a GitHub-PR run can
+    // post — and must carry the claim gate that keeps a re-run from posting a
+    // second comment.
+    const ALLOW_POSTING: bool = true;
+    let mut deps = build_deps_async(
+        &config_with_overrides,
+        &reviewer_model,
+        &default_provider,
+        dedup_need_for(&diff_source, ALLOW_POSTING),
+    )
+    .await?;
     apply_source_root_fallback(&mut deps, source_root_notice.as_deref());
 
     let surface = surface_for_diff_source(&diff_source);
@@ -180,7 +190,7 @@ pub async fn cmd_run(config: ReviewConfig, args: RunArgs) -> Result<()> {
         print_result: true,
         trigger: TriggerDecision::None,
         run_mode: RunMode::Cli,
-        allow_posting: true,
+        allow_posting: ALLOW_POSTING,
         caller_context: CallerContext::default(),
         surface,
     };
@@ -285,18 +295,47 @@ pub async fn resolve_diff_source_run(config: &ReviewConfig, args: &RunArgs) -> R
     })
 }
 
+/// Decide whether a `run`-style invocation needs the durable dedup store
+/// (#5113).
+///
+/// Why: `cmd_run` sets `allow_posting: true`, so a GitHub-PR invocation can
+/// post a live comment — and a run that can post must carry the claim gate that
+/// makes the post idempotent, or a re-run against the same
+/// `(owner, repo, pr, head_sha)` posts a second comment. The local sources
+/// never reach the post path, so opening (and locking) `dedup.redb` for them
+/// would be pure cost. Extracted as a pure function for the same reason
+/// `surface_for_diff_source` is: the rule is testable without building a
+/// `ReviewConfig` or an LLM provider.
+/// What: `Required` when posting is allowed AND the diff came from a GitHub PR;
+/// `NotNeeded` otherwise.
+/// Test: `dedup_need_for_github_posting_is_required`,
+/// `dedup_need_for_github_without_posting_is_not_needed`,
+/// `dedup_need_for_local_sources_is_not_needed`.
+pub fn dedup_need_for(diff_source: &DiffSource, allow_posting: bool) -> DedupNeed {
+    if allow_posting && matches!(diff_source, DiffSource::Github { .. }) {
+        DedupNeed::Required
+    } else {
+        DedupNeed::NotNeeded
+    }
+}
+
 /// Build the injected service dependencies from `ReviewConfig` and a model id.
 ///
 /// Why: both `run` and `compare` need the same set of deps; building them from
 /// config in one place avoids repetition.  Async because `BedrockProvider::new`
 /// loads AWS credentials asynchronously.
 /// What: uses `build_provider` (which resolves the `bedrock/`/`openrouter/`
-/// prefix), builds the optional verifier, constructs search/analyze clients.
-/// Test: covered transitively by runner tests that inject a FakeLlm.
+/// prefix), builds the optional verifier, constructs search/analyze clients, and
+/// opens the dedup store when `dedup_need` says this invocation can post
+/// (#5113). A `Required` store that cannot be opened is an error, never a
+/// downgrade to `dedup: None` — the same contract the `serve` path declares.
+/// Test: covered transitively by runner tests that inject a FakeLlm;
+/// `dedup_need_for_*` cover the need decision itself.
 pub async fn build_deps_async(
     config: &ReviewConfig,
     model: &str,
     default_provider: &trusty_review::config::Provider,
+    dedup_need: DedupNeed,
 ) -> Result<ReviewDeps> {
     let llm = build_provider(model, default_provider, config)
         .await
@@ -313,12 +352,15 @@ pub async fn build_deps_async(
     let analyze = SubprocessAnalyzeClient::from_config(config)
         .map_err(|e| anyhow::anyhow!("failed to build analyze HTTP client: {e}"))?;
 
+    let dedup = open_dedup_for(&config.log_dir, dedup_need)
+        .map_err(|e| anyhow::anyhow!("failed to open the dedup claim store: {e}"))?;
+
     Ok(ReviewDeps {
         llm,
         verifier,
         search: Arc::new(search),
         analyze: Some(Arc::new(analyze)),
-        dedup: None,
+        dedup,
     })
 }
 
@@ -489,6 +531,65 @@ mod tests {
             surface_for_diff_source(&DiffSource::Stdin),
             InvocationSurface::Interactive
         );
+    }
+
+    // ── dedup_need_for (#5113) ──────────────────────────────────────────────
+
+    /// REGRESSION (#5113): a posting-capable `run` against a GitHub PR must
+    /// declare the claim store required.
+    ///
+    /// Why: `cmd_run` sets `allow_posting: true` and `build_deps_async` hardcoded
+    /// `dedup: None`, so a re-run against the same `(owner, repo, pr, head_sha)`
+    /// posted a second comment with nothing to stop it.
+    /// What: asserts the need decision for the posting GitHub case.
+    /// Test: this test.
+    #[test]
+    fn dedup_need_for_github_posting_is_required() {
+        let source = DiffSource::Github {
+            owner: "acme".to_string(),
+            repo: "backend".to_string(),
+            pr: 42,
+            token: "tok".to_string(),
+        };
+        assert_eq!(dedup_need_for(&source, true), DedupNeed::Required);
+    }
+
+    /// A GitHub source that cannot post (`compare`, the MCP tools) has nothing
+    /// for the claim gate to guard, so it must not open — or lock — the file.
+    #[test]
+    fn dedup_need_for_github_without_posting_is_not_needed() {
+        let source = DiffSource::Github {
+            owner: "acme".to_string(),
+            repo: "backend".to_string(),
+            pr: 42,
+            token: "tok".to_string(),
+        };
+        assert_eq!(dedup_need_for(&source, false), DedupNeed::NotNeeded);
+    }
+
+    /// Every local source is forced log-only downstream, so posting stays
+    /// unreachable even with `allow_posting: true` — which is exactly how the
+    /// CLI runs `--local-diff` and `--base`.
+    #[test]
+    fn dedup_need_for_local_sources_is_not_needed() {
+        let sources = [
+            DiffSource::LocalFile {
+                path: std::path::PathBuf::from("/tmp/x.diff"),
+            },
+            DiffSource::GitRange {
+                repo_root: std::path::PathBuf::from("/repo"),
+                base: "main".to_string(),
+                head: None,
+            },
+            DiffSource::Stdin,
+        ];
+        for source in &sources {
+            assert_eq!(
+                dedup_need_for(source, true),
+                DedupNeed::NotNeeded,
+                "a local source can never post: {source:?}"
+            );
+        }
     }
 
     // ── --source-root (#2994) ───────────────────────────────────────────────

--- a/crates/trusty-review/src/pipeline/runner.rs
+++ b/crates/trusty-review/src/pipeline/runner.rs
@@ -264,6 +264,27 @@ pub async fn run_review(
                 result.findings_count = result.findings.len();
                 return result;
             }
+            // #5126: the slot is held by someone else, so this review never
+            // ran. Report that, never a verdict.
+            ClaimGate::InProgressElsewhere => {
+                warn!(
+                    owner = %owner,
+                    repo = %repo,
+                    pr = pr_number,
+                    head_sha = %head_sha,
+                    "dedup: another holder owns the in-progress claim — not reviewed"
+                );
+                let stale_secs = crate::config::constants::DEDUP_STALE_SECS;
+                result.verdict = Verdict::Unknown;
+                result.error = Some(format!(
+                    "not reviewed: another review holds the in-progress dedup claim for \
+                     head SHA {head_sha}; it clears when that review finishes or after \
+                     {stale_secs}s"
+                ));
+                // NotHeld — this review never acquired the claim, so it must
+                // not delete the holder's record.
+                return abort_dry(result, config, &input, &deps, DedupClaim::NotHeld).await;
+            }
             ClaimGate::Proceed => {
                 debug!(head_sha = %head_sha, "dedup: claimed review slot");
             }
@@ -821,18 +842,22 @@ fn is_truncated(finish_reason: Option<&str>, output_tokens: u32, max_tokens: u32
 
 /// What the runner does with a `claim()` outcome.
 ///
-/// Why: naming the three outcomes makes the fail-closed rule reviewable in one
-/// place. It used to be an inline `match` whose error arm proceeded with the
-/// review, so a store failure produced an ungated live comment — and on the
-/// next redelivery, another one.
-/// What: `Proceed` owns the slot; `DuplicateSkip` short-circuits a completed
-/// review; `Abort` carries the reason a claim could not be established.
+/// Why: naming the outcomes makes the fail-closed rule reviewable in one place.
+/// It used to be an inline `match` whose error arm proceeded with the review,
+/// so a store failure produced an ungated live comment — and on the next
+/// redelivery, another one.
+/// What: `Proceed` owns the slot; `DuplicateSkip` short-circuits a review that
+/// already ran to completion; `InProgressElsewhere` blocks a review that has
+/// NOT run because another holder owns the slot (#5126); `Abort` carries the
+/// reason a claim could not be established.
 /// Test: `classify_claim_*` in `runner_tests.rs`.
 pub(super) enum ClaimGate {
     /// This caller owns the review slot.
     Proceed,
     /// A completed review already exists for this head SHA.
     DuplicateSkip,
+    /// Another holder owns a fresh in-progress claim; nothing was reviewed.
+    InProgressElsewhere,
     /// The claim gate did not engage; abort without posting.
     Abort(String),
 }
@@ -848,14 +873,17 @@ pub(super) enum ClaimGate {
 /// of the trade: a dropped review is visible and re-requestable, a duplicate
 /// comment cannot be retracted. Every error aborts, `Contended` included, which
 /// is the variant a stuck sibling process produces during a rolling upgrade.
-/// What: maps `Ok(Claimed)` → `Proceed`, `Ok(Skipped)` → `DuplicateSkip`, and
-/// every `Err` → `Abort` carrying the error's `Display`.
+/// What: maps `Ok(Claimed)` → `Proceed`, `Ok(Skipped)` → `DuplicateSkip`,
+/// `Ok(InProgressElsewhere)` → `InProgressElsewhere` (#5126), and every `Err` →
+/// `Abort` carrying the error's `Display`.
 /// Test: `classify_claim_contended_aborts`, `classify_claim_open_error_aborts`,
-/// `classify_claim_claimed_proceeds`, `classify_claim_skipped_is_duplicate`.
+/// `classify_claim_claimed_proceeds`, `classify_claim_skipped_is_duplicate`,
+/// `stranded_in_progress_claim_is_not_a_duplicate_skip`.
 pub(super) fn classify_claim(outcome: Result<ClaimOutcome, DedupError>) -> ClaimGate {
     match outcome {
         Ok(ClaimOutcome::Claimed) => ClaimGate::Proceed,
         Ok(ClaimOutcome::Skipped) => ClaimGate::DuplicateSkip,
+        Ok(ClaimOutcome::InProgressElsewhere) => ClaimGate::InProgressElsewhere,
         Err(e) => ClaimGate::Abort(e.to_string()),
     }
 }

--- a/crates/trusty-review/src/pipeline/runner.rs
+++ b/crates/trusty-review/src/pipeline/runner.rs
@@ -36,6 +36,7 @@ use crate::{
         },
         diff_analyzer::DiffAnalyzer, // noise filter (Stages A+B); #624
         parser::parse_review_response,
+        post::{FinalizeAction, decide_action},
         prompt::{ReviewPrMeta, build_review_prompt_with_coverage},
         runner_context::{gather_context, gather_external_context_md},
         runner_mapreduce::{MapReduceRun, run_mapreduce_branch},
@@ -168,7 +169,8 @@ pub struct ReviewDeps {
 /// errors (fail-safe: verdict = APPROVE with an `error` field set).
 /// Test: `run_review_with_fake_provider_approves`, `run_review_fail_safe_on_llm_error`,
 /// `run_review_search_down_skips_when_required`,
-/// `run_review_search_down_degraded_when_optout`.
+/// `run_review_search_down_degraded_when_optout`,
+/// `run_review_posting_without_dedup_store_fails_closed`.
 pub async fn run_review(
     config: &ReviewConfig,
     input: ReviewInput,
@@ -205,6 +207,40 @@ pub async fn run_review(
     } else {
         String::new()
     };
+
+    // ── Step 1b: posting requires the claim gate (#5113) ──────────────────
+    // The dedup contract makes a live post idempotent, so a run that can reach
+    // the post path without a store has no defence against a duplicate comment
+    // on a re-run. `decide_action` is the single place that decides whether the
+    // post path is reachable, so ask it rather than re-deriving the rule. This
+    // runs before the PR-metadata fetch so an unguarded run costs nothing.
+    if !is_local
+        && deps.dedup.is_none()
+        && decide_action(config.dry_run, input.trigger, input.allow_posting, true)
+            == FinalizeAction::Post
+    {
+        error!(
+            owner = %owner,
+            repo = %repo,
+            pr = pr_number,
+            "posting is enabled with no dedup claim store — aborting without posting (#5113)"
+        );
+        let mut result = ReviewResult::new(
+            owner.clone(),
+            repo.clone(),
+            pr_number,
+            format!("PR #{pr_number}"),
+            pr_url.clone(),
+        );
+        result.verdict = Verdict::Unknown;
+        result.error = Some(
+            "not reviewed: posting is enabled but no dedup claim store is configured, so a \
+             re-run could post a duplicate comment (#5113)"
+                .to_string(),
+        );
+        // NotHeld — no claim was ever attempted, let alone acquired.
+        return abort_dry(result, config, &input, &deps, DedupClaim::NotHeld).await;
+    }
 
     // ── Step 2: fetch PR metadata (skip for local-diff mode) ──────────────
     let (pr_meta, head_sha): (ReviewPrMeta, String) = if is_local {

--- a/crates/trusty-review/src/pipeline/runner_tests.rs
+++ b/crates/trusty-review/src/pipeline/runner_tests.rs
@@ -1349,7 +1349,14 @@ async fn run_review_serve_mode_empty_token_fails_closed_with_actionable_error() 
         caller_context: CallerContext::default(),
         surface: InvocationSurface::default(),
     };
-    let deps = ready_deps(Arc::new(FakeLlm::approves()), None);
+    // #5113: the serve path declares `DedupNeed::Required`, so a faithful
+    // fixture carries a real store — without one the run now aborts at the
+    // claim-gate guard before it ever reaches token resolution.
+    let dir = tempfile::tempdir().unwrap();
+    let mut deps = ready_deps(Arc::new(FakeLlm::approves()), None);
+    deps.dedup = Some(Arc::new(
+        crate::store::DedupStore::open(&dir.path().join("dedup.redb")).expect("open"),
+    ));
 
     let result = run_review(&config, input, deps).await;
 
@@ -2317,5 +2324,103 @@ async fn run_review_self_admitted_unverifiable_claim_is_not_confirmed() {
     assert!(
         result.findings[0].description.contains("incidents::run"),
         "the original claim must still reach the author verbatim"
+    );
+}
+
+// ─── #5113: posting requires the claim gate ─────────────────────────────────
+
+/// REGRESSION (#5113): a run that can post but carries no dedup store must
+/// abort before doing anything, not review and post unguarded.
+///
+/// Why: the CLI `run` path set `allow_posting: true` with `dedup: None`, so a
+/// re-run against an already-reviewed `(owner, repo, pr, head_sha)` posted a
+/// second comment with no error and no warning. Wiring a store into that one
+/// call site fixes the instance; failing closed here makes the combination
+/// unusable wherever it is expressed.
+/// What: a GitHub diff source, `allow_posting: true`, `dry_run: false` (so
+/// `decide_action` selects `Post`), and no dedup store. The run must return
+/// UNKNOWN with an error naming the missing claim store, and must not post.
+/// Test: this test. Fails pre-fix: the run proceeded past this point, so the
+/// error named GitHub token resolution instead of the missing claim store.
+#[tokio::test]
+async fn run_review_posting_without_dedup_store_fails_closed() {
+    let mut config = default_config();
+    config.dry_run = false; // service-live: the post path is reachable
+
+    let input = ReviewInput {
+        diff_source: DiffSource::Github {
+            owner: "acme".to_string(),
+            repo: "backend".to_string(),
+            pr: 42,
+            token: "tok".to_string(),
+        },
+        reviewer_model: "openai/gpt-5.4-nano-20260317".to_string(),
+        write_log: false,
+        print_result: false,
+        trigger: TriggerDecision::None,
+        run_mode: RunMode::Cli,
+        allow_posting: true,
+        caller_context: CallerContext::default(),
+        surface: InvocationSurface::default(),
+    };
+    // `dedup: None` — the exact `build_deps_async` shape #5113 reported.
+    let deps = ready_deps(Arc::new(FakeLlm::approves()), None);
+    assert!(deps.dedup.is_none(), "the fixture must carry no claim gate");
+
+    let result = run_review(&config, input, deps).await;
+
+    assert!(!result.posted, "an unguarded run must never post");
+    assert_eq!(
+        result.verdict,
+        Verdict::Unknown,
+        "a run that never happened must not report a verdict"
+    );
+    let error = result.error.expect("the abort must explain itself");
+    assert!(
+        error.contains("dedup claim store"),
+        "the error must name the missing claim gate so an operator can wire it: {error}"
+    );
+}
+
+/// Why: the #5113 guard must not fire where nothing can be posted. The CLI runs
+/// `--local-diff` and `--base` with the same `allow_posting: true` it uses for a
+/// PR, so a guard keyed on that flag alone would break both — and `compare` and
+/// `calibrate` build their deps through the same helper.
+/// What: a local diff source with `allow_posting: true` and `dry_run: false`,
+/// carrying no dedup store, must review normally rather than abort.
+/// Test: this test.
+#[tokio::test]
+async fn run_review_local_source_without_dedup_store_is_not_blocked() {
+    let (source, _tmp) = local_diff_source("+fn x() {}\n");
+    let mut config = default_config();
+    config.dry_run = false; // would select Post if the source were a GitHub PR
+
+    let input = ReviewInput {
+        diff_source: source,
+        reviewer_model: "openai/gpt-5.4-nano-20260317".to_string(),
+        write_log: false,
+        print_result: false,
+        trigger: TriggerDecision::None,
+        run_mode: RunMode::Cli,
+        allow_posting: true,
+        caller_context: CallerContext::default(),
+        surface: InvocationSurface::default(),
+    };
+    let deps = ready_deps(Arc::new(FakeLlm::approves()), None);
+
+    let result = run_review(&config, input, deps).await;
+
+    assert!(
+        !result
+            .error
+            .as_deref()
+            .is_some_and(|e| e.contains("dedup claim store")),
+        "a local diff has nowhere to post, so the claim gate must not block it: {:?}",
+        result.error
+    );
+    assert_eq!(
+        result.verdict,
+        Verdict::Approve,
+        "the review itself must still run to completion"
     );
 }

--- a/crates/trusty-review/src/pipeline/runner_tests.rs
+++ b/crates/trusty-review/src/pipeline/runner_tests.rs
@@ -1925,6 +1925,7 @@ fn classify_claim_contended_aborts() {
             panic!("a contended claim must NOT proceed — that posts an ungated comment (#5064)")
         }
         ClaimGate::DuplicateSkip => panic!("a contended claim is not a duplicate"),
+        ClaimGate::InProgressElsewhere => panic!("a contended claim is not a live claim"),
     }
 }
 
@@ -1966,6 +1967,78 @@ fn classify_claim_skipped_is_duplicate() {
         classify_claim(Ok(ClaimOutcome::Skipped)),
         ClaimGate::DuplicateSkip
     ));
+}
+
+/// REGRESSION (#5126): a claim another holder owns must not classify as a
+/// completed duplicate.
+///
+/// Why: `DuplicateSkip` is the arm that sets `Verdict::Approve` and returns. A
+/// stranded `InProgress` record — what a process that died between `claim` and
+/// `complete` leaves behind — reached that arm too, so for the whole
+/// `DEDUP_STALE_SECS` window every re-run of that PR reported approval for a
+/// review that never ran. This drives the outcome through a real store rather
+/// than a hand-built enum value, so it exercises the store and the classifier
+/// together and compiles against the pre-fix source as well.
+/// What: one store writes an in-progress claim; a second store on the same file
+/// claims the same key; the resulting gate must not be `DuplicateSkip`.
+/// Test: this test. Fails pre-fix at the first assertion — the second claim
+/// returned `Skipped`, which classified as `DuplicateSkip`.
+#[tokio::test]
+async fn stranded_in_progress_claim_is_not_a_duplicate_skip() {
+    use crate::store::DedupStore;
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("dedup.redb");
+
+    // A holder claims the slot and then dies without completing or releasing.
+    let stranded = DedupStore::open(&path).expect("open");
+    stranded
+        .claim_blocking("acme", "backend", 42, "sha-stranded")
+        .expect("claim");
+    drop(stranded);
+
+    let store = Arc::new(DedupStore::open(&path).expect("open"));
+    let gate = classify_claim(store.claim("acme", "backend", 42, "sha-stranded").await);
+
+    assert!(
+        !matches!(gate, ClaimGate::DuplicateSkip),
+        "a stranded in-progress claim is not a completed review — classifying it as one \
+         is what made the runner report Verdict::Approve for an unrun review (#5126)"
+    );
+    assert!(
+        matches!(gate, ClaimGate::InProgressElsewhere),
+        "the runner must be told the slot is held, so it can report 'not reviewed'"
+    );
+}
+
+/// Why: fixing the stranded-claim arm must not disarm the case dedup exists
+/// for — a genuinely completed review must still short-circuit.
+/// What: a store completes a claim; a second store's claim for the same key
+/// still classifies as `DuplicateSkip`.
+/// Test: this test.
+#[tokio::test]
+async fn completed_claim_still_classifies_as_duplicate_skip() {
+    use crate::store::DedupStore;
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("dedup.redb");
+
+    let owner = DedupStore::open(&path).expect("open");
+    owner
+        .claim_blocking("acme", "backend", 42, "sha-done")
+        .expect("claim");
+    owner
+        .complete_blocking("acme", "backend", 42, "sha-done")
+        .expect("complete");
+    drop(owner);
+
+    let store = Arc::new(DedupStore::open(&path).expect("open"));
+    let gate = classify_claim(store.claim("acme", "backend", 42, "sha-done").await);
+
+    assert!(
+        matches!(gate, ClaimGate::DuplicateSkip),
+        "a completed review must still suppress the re-run"
+    );
 }
 
 /// Why: the round-1 fix routed the failed-claim path into `abort_dry`, which

--- a/crates/trusty-review/src/service/handlers.rs
+++ b/crates/trusty-review/src/service/handlers.rs
@@ -29,7 +29,7 @@ use crate::{
     llm::LlmProvider,
     pipeline::{DiffSource, ReviewDeps, ReviewInput, TriggerDecision, run_review},
     service::inference_probe::{InferenceProbe, InferenceStatus},
-    store::{DedupStore, InFlightRegistry},
+    store::{DedupStore, InFlightCountGuard, InFlightRegistry},
 };
 
 // ─── AppState ─────────────────────────────────────────────────────────────────
@@ -593,8 +593,10 @@ pub async fn handle_status(State(state): State<AppState>) -> impl IntoResponse {
 /// until the verdict is ready (design intent: sub-10s for a normal PR).
 /// What: parses the request body, resolves the DiffSource, calls `run_review`,
 /// and returns the `ReviewResult` as JSON.  Always dry-run (push firewall
-/// remains in force).  Does NOT post to GitHub.
-/// Test: `review_endpoint_with_fake_deps_returns_result`.
+/// remains in force).  Does NOT post to GitHub.  The `in_flight` counter is
+/// held by an RAII guard so a dropped future still releases it (#5020).
+/// Test: `review_handler_bad_request_missing_fields`,
+/// `review_handler_decrements_in_flight_when_client_disconnects`.
 pub async fn handle_review(
     State(state): State<AppState>,
     Json(req): Json<ReviewRequest>,
@@ -648,9 +650,11 @@ pub async fn handle_review(
         surface: InvocationSurface::default(),
     };
 
-    state.in_flight.fetch_add(1, Ordering::Relaxed);
+    // #5020: the decrement has to survive a dropped future (client disconnect,
+    // consumer timeout) and a panic, so it lives in the guard's `Drop`, not in
+    // a statement after the `await` that a cancellation never reaches.
+    let _in_flight = InFlightCountGuard::enter(&state.in_flight);
     let result = run_review(&state.config, input, deps).await;
-    state.in_flight.fetch_sub(1, Ordering::Relaxed);
 
     info!(
         verdict = %result.verdict,

--- a/crates/trusty-review/src/service/handlers_tests.rs
+++ b/crates/trusty-review/src/service/handlers_tests.rs
@@ -466,6 +466,109 @@ async fn review_handler_bad_request_missing_fields() {
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
 }
 
+// ── in_flight counter leak (#5020) ────────────────────────────────────────────
+
+/// A search stub that signals once `health()` is entered and then never
+/// answers, parking `handle_review` inside `run_review`'s required-context
+/// gate.
+///
+/// Why: reproducing the leak needs the handler future to be dropped while it is
+/// suspended mid-review — exactly what a client disconnect does. Signalling on
+/// entry makes that deterministic: the test waits for the signal instead of
+/// sleeping and hoping.
+/// What: sends on a one-shot channel the first time `health()` runs, then awaits
+/// `std::future::pending`.
+/// Test: `review_handler_decrements_in_flight_when_client_disconnects`.
+struct ParkingSearch {
+    entered: std::sync::Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
+}
+
+#[async_trait]
+impl SearchClient for ParkingSearch {
+    async fn health(&self) -> Result<SearchHealth, SearchClientError> {
+        if let Some(tx) = self
+            .entered
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .take()
+        {
+            let _ = tx.send(());
+        }
+        std::future::pending::<()>().await;
+        unreachable!("ParkingSearch::health never resolves")
+    }
+
+    async fn list_indexes(&self) -> Result<Vec<IndexInfo>, SearchClientError> {
+        Ok(vec![])
+    }
+
+    async fn search(
+        &self,
+        _index_id: &str,
+        _query: &str,
+        _top_k: Option<u32>,
+    ) -> Result<Vec<SearchResult>, SearchClientError> {
+        Ok(vec![])
+    }
+}
+
+/// REGRESSION (#5020): dropping the `handle_review` future mid-review must
+/// still release the `in_flight` slot.
+///
+/// Why: the counter was raised before the `await` and lowered after it, so a
+/// dropped future — which a client disconnect or a consumer timeout produces
+/// against a long review — skipped the decrement entirely. The counter then only
+/// grew, and `GET /status` (whose sole load signal it is) reported a figure that
+/// never came back down until the process restarted. A fix that only handles the
+/// normal return path leaves this test red.
+/// What: parks the review inside the context gate, confirms the counter reads 1
+/// while it is suspended, drops the future without ever polling it to
+/// completion, and asserts the counter returns to 0.
+/// Test: this test. Fails pre-fix at the final assertion, which reads 1.
+#[tokio::test]
+async fn review_handler_decrements_in_flight_when_client_disconnects() {
+    use std::sync::atomic::Ordering;
+
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    let state = AppState::new(
+        crate::config::ReviewConfig::load(None),
+        Arc::new(FakeLlm),
+        Arc::new(ParkingSearch {
+            entered: std::sync::Mutex::new(Some(tx)),
+        }),
+        None,
+    );
+
+    let req = ReviewRequest {
+        local_diff_text: Some("+fn hello() {}\n".to_string()),
+        ..Default::default()
+    };
+    let mut fut = Box::pin(handle_review(State(state.clone()), Json(req)));
+
+    // Drive the handler only until the review is provably suspended inside the
+    // pipeline — no sleep, no timeout guess.
+    tokio::select! {
+        _ = &mut fut => panic!("the parked review must not complete"),
+        signal = rx => signal.expect("the review must reach the context gate"),
+    }
+
+    assert_eq!(
+        state.in_flight.load(Ordering::Relaxed),
+        1,
+        "the counter must be raised while a review is running"
+    );
+
+    // The client hangs up: axum drops the handler future mid-`await`.
+    drop(fut);
+
+    assert_eq!(
+        state.in_flight.load(Ordering::Relaxed),
+        0,
+        "a dropped handler future must still release the in_flight slot — leaking it \
+         is what pinned /status at a load figure that never came down (#5020)"
+    );
+}
+
 // ── Inference-probe handler tests (#719) ──────────────────────────────────────
 
 /// /health includes `inference: "ok"` and `status: "ok"` when the LLM succeeds.

--- a/crates/trusty-review/src/store/dedup.rs
+++ b/crates/trusty-review/src/store/dedup.rs
@@ -136,17 +136,34 @@ struct ClaimRecord {
 
 /// Outcome of a `claim` attempt.
 ///
-/// Why: the runner branches on whether it owns the review or should skip a
-/// duplicate.
-/// What: `Claimed` means this caller should proceed; `Skipped` means a completed
-/// review already exists for this SHA.
-/// Test: `claim_then_skip_after_complete`, `different_sha_not_skipped`.
+/// Why: the runner branches on whether it owns the review, should skip a
+/// duplicate, or was blocked by a claim someone else holds. #5126: `Skipped`
+/// used to cover the last two at once, so a review that never ran reported the
+/// same outcome as one that ran and finished — and the runner turned both into
+/// `Verdict::Approve`. Only a `Completed` record proves a review happened.
+/// What: `Claimed` means this caller should proceed; `Skipped` means a
+/// *completed* review already exists for this SHA; `InProgressElsewhere` means
+/// another holder wrote a fresh `InProgress` claim and nothing has been
+/// reviewed yet.
+/// Test: `claim_then_skip_after_complete`, `different_sha_not_skipped`,
+/// `fresh_in_progress_claim_is_not_a_completed_review`.
+///
+/// `#[non_exhaustive]`: adding `InProgressElsewhere` is the second variant
+/// addition this module has paid a breaking bump for (see [`DedupError`]). The
+/// attribute makes every future one additive for external exhaustive matches.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ClaimOutcome {
     /// The claim was acquired; the caller owns this review.
     Claimed,
     /// A completed review already exists for this SHA; skip.
     Skipped,
+    /// Another holder owns a fresh (non-stale) in-progress claim for this SHA.
+    ///
+    /// Nothing has been reviewed. The caller must not proceed AND must not
+    /// report a verdict — a crashed holder leaves this state standing for the
+    /// whole `DEDUP_STALE_SECS` window (#5126).
+    InProgressElsewhere,
 }
 
 // ─── Store ──────────────────────────────────────────────────────────────────────
@@ -186,11 +203,13 @@ impl DedupStore {
     /// Open (or create) the dedup store at `path`.
     ///
     /// **Blocking** — probes the file, so it can wait out a concurrent holder
-    /// for up to the lock-wait budget. Today the only `Required` caller is the
-    /// HTTP daemon's synchronous startup, before it accepts traffic; the stdio
-    /// path declares `DedupNeed::NotNeeded` and never reaches here. A future
-    /// caller on a hot async path must wrap this the way the claim/complete/
-    /// release wrappers do (#5064).
+    /// for up to the lock-wait budget. Two `Required` callers reach here, both
+    /// during one-shot startup: the HTTP daemon before it accepts traffic, and
+    /// `commands::run::build_deps_async` before the CLI's single review begins
+    /// (#5113). Neither has other work on the runtime to stall. A future caller
+    /// on a hot async path must wrap this the way the claim/complete/release
+    /// wrappers do (#5064). The stdio path declares `DedupNeed::NotNeeded` and
+    /// never reaches here.
     ///
     /// Why: the store lives under the review log dir so it persists across
     /// daemon restarts (spec: `{LOG_DIR}/dedup.redb`). Issue #702: redb 4.x
@@ -262,10 +281,12 @@ impl DedupStore {
     /// Why: this is the idempotency gate — it must atomically decide whether the
     /// caller runs the review or skips because a completed one already exists.
     /// What: within one write transaction, reads any existing record: a
-    /// `Completed` record → `Skipped`; a fresh `InProgress` record → `Skipped`
-    /// (another worker owns it); a stale `InProgress` record or no record →
-    /// writes a fresh `InProgress` claim and returns `Claimed`.
-    /// Test: `claim_then_skip_after_complete`, `concurrent_in_progress_skips`,
+    /// `Completed` record → `Skipped`; a fresh `InProgress` record →
+    /// `InProgressElsewhere` (another holder owns it and nothing has been
+    /// reviewed — #5126); a stale `InProgress` record or no record → writes a
+    /// fresh `InProgress` claim and returns `Claimed`.
+    /// Test: `claim_then_skip_after_complete`,
+    /// `fresh_in_progress_claim_is_not_a_completed_review`,
     /// `stale_in_progress_is_reclaimable`.
     pub fn claim_blocking(
         &self,
@@ -291,22 +312,28 @@ impl DedupStore {
                     .map_err(|e| DedupError::Transaction(e.to_string()))?
                     .map(|v| v.value().to_string());
 
-                let should_claim = match existing {
-                    None => true,
+                // #5126: three outcomes, not two. A completed record proves a
+                // review ran; a fresh in-progress record proves only that
+                // someone else holds the slot.
+                let decided = match existing {
+                    None => ClaimOutcome::Claimed,
                     Some(raw) => {
                         let rec: ClaimRecord = serde_json::from_str(&raw)
                             .map_err(|e| DedupError::Serde(e.to_string()))?;
                         match rec.state {
-                            ClaimState::Completed => false,
+                            ClaimState::Completed => ClaimOutcome::Skipped,
                             // In-progress: reclaim only if stale (assume abandoned).
-                            ClaimState::InProgress => {
-                                now.saturating_sub(rec.updated_at) > DEDUP_STALE_SECS
+                            ClaimState::InProgress
+                                if now.saturating_sub(rec.updated_at) > DEDUP_STALE_SECS =>
+                            {
+                                ClaimOutcome::Claimed
                             }
+                            ClaimState::InProgress => ClaimOutcome::InProgressElsewhere,
                         }
                     }
                 };
 
-                if should_claim {
+                if decided == ClaimOutcome::Claimed {
                     let rec = ClaimRecord {
                         state: ClaimState::InProgress,
                         updated_at: now,
@@ -316,10 +343,8 @@ impl DedupStore {
                     table
                         .insert(key.as_str(), json.as_str())
                         .map_err(|e| DedupError::Transaction(e.to_string()))?;
-                    ClaimOutcome::Claimed
-                } else {
-                    ClaimOutcome::Skipped
                 }
+                decided
             };
             write
                 .commit()

--- a/crates/trusty-review/src/store/dedup_tests.rs
+++ b/crates/trusty-review/src/store/dedup_tests.rs
@@ -68,10 +68,19 @@ fn first_claim_succeeds() {
     assert_eq!(outcome, ClaimOutcome::Claimed);
 }
 
+/// REGRESSION (#5126): a fresh in-progress claim must not report as a
+/// completed review.
+///
+/// Why: `Skipped` is what the runner turns into `Verdict::Approve`. When a
+/// held (or stranded) in-progress claim also returned `Skipped`, a review that
+/// never ran reported approval — for the whole `DEDUP_STALE_SECS` window after
+/// a holder crashed between `claim` and `complete`.
+/// What: claims a SHA, then re-claims it while the first claim is still
+/// in-progress and not stale.
+/// Test: this test. Fails pre-fix at the `assert_ne!`, which observes the
+/// `Skipped` the old two-way outcome produced.
 #[test]
-fn concurrent_in_progress_skips() {
-    // A second claim for the same SHA while the first is still in-progress
-    // (and not stale) is skipped — another worker owns it.
+fn fresh_in_progress_claim_is_not_a_completed_review() {
     let (store, _d) = temp_store();
     assert_eq!(
         store
@@ -79,11 +88,21 @@ fn concurrent_in_progress_skips() {
             .unwrap(),
         ClaimOutcome::Claimed
     );
+
+    let second = store
+        .claim_blocking("acme", "backend", 42, "sha-abc")
+        .unwrap();
+
+    assert_ne!(
+        second,
+        ClaimOutcome::Skipped,
+        "a held in-progress claim means nothing was reviewed — reporting it as a \
+         completed review is what made the runner approve an unrun review (#5126)"
+    );
     assert_eq!(
-        store
-            .claim_blocking("acme", "backend", 42, "sha-abc")
-            .unwrap(),
-        ClaimOutcome::Skipped
+        second,
+        ClaimOutcome::InProgressElsewhere,
+        "the second caller must be told another holder owns the slot"
     );
 }
 
@@ -267,16 +286,19 @@ fn concurrent_threads_claim_exactly_once() {
         .collect();
 
     let mut claimed = 0usize;
-    let mut skipped = 0usize;
+    let mut blocked = 0usize;
     for h in handles {
         match h.join().expect("thread must not panic") {
             Ok(ClaimOutcome::Claimed) => claimed += 1,
-            Ok(ClaimOutcome::Skipped) => skipped += 1,
+            // #5126: the losers see the winner's in-progress claim, which is
+            // not a completed review.
+            Ok(ClaimOutcome::InProgressElsewhere) => blocked += 1,
+            Ok(other) => panic!("no thread may see a completed review here: {other:?}"),
             Err(e) => panic!("concurrent claim must not error under contention: {e}"),
         }
     }
     assert_eq!(claimed, 1, "exactly one caller may own the claim");
-    assert_eq!(skipped, THREADS - 1, "every other caller must be skipped");
+    assert_eq!(blocked, THREADS - 1, "every other caller must be blocked");
 }
 
 /// Why: contention is waited out, but not forever — and when the budget expires

--- a/crates/trusty-review/src/store/in_flight.rs
+++ b/crates/trusty-review/src/store/in_flight.rs
@@ -128,9 +128,11 @@ impl Drop for InFlightGuard {
 /// What: raises the counter on construction and lowers it in `Drop`, so every
 /// exit path — return, cancellation, panic unwind — settles it. The decrement
 /// saturates at zero so a stray extra drop cannot wrap the counter to `u64::MAX`
-/// and turn an undercount into an absurd overcount.
+/// and turn an undercount into an absurd overcount — and warns when it does,
+/// because saturating alone would swap one loud wrong number for a quiet one.
 /// Test: `count_guard_decrements_on_drop`, `count_guard_decrements_on_unwind`,
 /// `count_guard_drop_saturates_at_zero`,
+/// `count_guard_release_reports_an_already_zero_counter`,
 /// `review_handler_decrements_in_flight_when_client_disconnects`.
 #[derive(Debug)]
 pub struct InFlightCountGuard {
@@ -150,17 +152,38 @@ impl InFlightCountGuard {
             counter: Arc::clone(counter),
         }
     }
+
+    /// Lower `counter` by one, reporting whether it was already at zero.
+    ///
+    /// Why: the guard is the only writer of the counter it holds, so observing
+    /// zero here means one raise was released twice. Saturating keeps the
+    /// reported figure plausible; returning the observation is what stops it
+    /// from being silent. Split out of `Drop` so the underflow branch is
+    /// testable without capturing a tracing subscriber.
+    /// What: `saturating_sub(1)` under `fetch_update`; `true` when the value
+    /// read was already zero. The closure never returns `None`, so the update
+    /// cannot fail.
+    /// Test: `count_guard_release_reports_an_already_zero_counter`.
+    fn release_one(counter: &AtomicU64) -> bool {
+        counter
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |n| {
+                Some(n.saturating_sub(1))
+            })
+            .is_ok_and(|previous| previous == 0)
+    }
 }
 
 impl Drop for InFlightCountGuard {
     fn drop(&mut self) {
-        // Saturating: a counter that already read zero must stay zero rather
-        // than wrap to u64::MAX.
-        let _ = self
-            .counter
-            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |n| {
-                Some(n.saturating_sub(1))
-            });
+        if Self::release_one(&self.counter) {
+            // Unreachable while the guard is the counter's only writer, so
+            // reaching it means a second release against one raise — the
+            // undercount that saturating would otherwise hide (#5020).
+            tracing::warn!(
+                "in-flight counter was already zero when a guard dropped — one raise was \
+                 released twice, so /status now under-reports the real load"
+            );
+        }
     }
 }
 
@@ -265,6 +288,35 @@ mod tests {
         drop(guard);
 
         assert_eq!(counter.load(Ordering::Relaxed), 0);
+    }
+
+    /// The saturating decrement must report the underflow it absorbs.
+    ///
+    /// Why: saturating alone trades a loud wrong number (`u64::MAX`) for a
+    /// quiet one — `/status` would read plausibly low with nothing said. The
+    /// guard owns the counter outright, so an already-zero read is a broken
+    /// invariant and the operator needs to hear about it.
+    /// What: asserts `release_one` reports `true` at zero and `false` at one,
+    /// and that both leave a sane value behind.
+    /// Test: this test.
+    #[test]
+    fn count_guard_release_reports_an_already_zero_counter() {
+        let counter = AtomicU64::new(1);
+        assert!(
+            !InFlightCountGuard::release_one(&counter),
+            "a normal release is not an underflow"
+        );
+        assert_eq!(counter.load(Ordering::Relaxed), 0);
+
+        assert!(
+            InFlightCountGuard::release_one(&counter),
+            "releasing an already-zero counter must be reported, not silently absorbed"
+        );
+        assert_eq!(
+            counter.load(Ordering::Relaxed),
+            0,
+            "and it must still saturate rather than wrap"
+        );
     }
 
     #[test]

--- a/crates/trusty-review/src/store/in_flight.rs
+++ b/crates/trusty-review/src/store/in_flight.rs
@@ -12,10 +12,17 @@
 //! return an RAII `InFlightGuard` that removes the key on drop, so the slot is
 //! always released even if the review task panics.
 //!
+//! `InFlightCountGuard` applies the same RAII rule to the plain `AtomicU64`
+//! counter `GET /status` reports (#5020): the decrement runs on drop, so it
+//! survives a client disconnect (which drops the handler future mid-`await`)
+//! and a panic unwind alike.
+//!
 //! Test: `pr_guard_blocks_second`, `pr_guard_released_on_drop`,
-//! `sha_guard_independent_of_pr`, `different_pr_not_blocked`.
+//! `sha_guard_independent_of_pr`, `different_pr_not_blocked`,
+//! `count_guard_decrements_on_drop`, `count_guard_decrements_on_unwind`.
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use dashmap::DashSet;
 
@@ -110,6 +117,53 @@ impl Drop for InFlightGuard {
     }
 }
 
+/// RAII guard around a plain in-flight *counter* (#5020).
+///
+/// Why: `POST /review` raised `AppState::in_flight` and lowered it after the
+/// `await`, with nothing between. A dropped handler future — which a client
+/// disconnect or a consumer timeout produces against a long review — skipped
+/// the decrement, so the counter only ever grew and `GET /status` reported a
+/// load figure that never came back down. A live daemon read `in_flight: 9`
+/// across a minute while reviews were both starting and finishing.
+/// What: raises the counter on construction and lowers it in `Drop`, so every
+/// exit path — return, cancellation, panic unwind — settles it. The decrement
+/// saturates at zero so a stray extra drop cannot wrap the counter to `u64::MAX`
+/// and turn an undercount into an absurd overcount.
+/// Test: `count_guard_decrements_on_drop`, `count_guard_decrements_on_unwind`,
+/// `count_guard_drop_saturates_at_zero`,
+/// `review_handler_decrements_in_flight_when_client_disconnects`.
+#[derive(Debug)]
+pub struct InFlightCountGuard {
+    counter: Arc<AtomicU64>,
+}
+
+impl InFlightCountGuard {
+    /// Raise `counter` and hand back the guard that lowers it again.
+    ///
+    /// Why: making entry and exit one object is what removes the "did every
+    /// path decrement?" question from the call site.
+    /// What: `fetch_add(1)` now; the matching `fetch_sub` happens in `Drop`.
+    /// Test: `count_guard_decrements_on_drop`.
+    pub fn enter(counter: &Arc<AtomicU64>) -> Self {
+        counter.fetch_add(1, Ordering::Relaxed);
+        Self {
+            counter: Arc::clone(counter),
+        }
+    }
+}
+
+impl Drop for InFlightCountGuard {
+    fn drop(&mut self) {
+        // Saturating: a counter that already read zero must stay zero rather
+        // than wrap to u64::MAX.
+        let _ = self
+            .counter
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |n| {
+                Some(n.saturating_sub(1))
+            });
+    }
+}
+
 // ─── Unit tests ───────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -147,6 +201,70 @@ mod tests {
         assert!(reg.try_acquire_pr("acme", "backend", 43).is_some());
         // A different repo is independent.
         assert!(reg.try_acquire_pr("acme", "frontend", 42).is_some());
+    }
+
+    /// The counter returns to its prior value when the guard is dropped.
+    ///
+    /// Why: this is the whole contract `POST /review` leaned on and did not
+    /// have (#5020).
+    /// What: enters twice, drops each guard, and reads the counter at each step.
+    /// Test: this test.
+    #[test]
+    fn count_guard_decrements_on_drop() {
+        let counter = Arc::new(AtomicU64::new(0));
+
+        let first = InFlightCountGuard::enter(&counter);
+        let second = InFlightCountGuard::enter(&counter);
+        assert_eq!(counter.load(Ordering::Relaxed), 2);
+
+        drop(second);
+        assert_eq!(counter.load(Ordering::Relaxed), 1);
+        drop(first);
+        assert_eq!(counter.load(Ordering::Relaxed), 0);
+    }
+
+    /// REGRESSION (#5020): the decrement must run on a panic unwind, not only
+    /// on a normal return.
+    ///
+    /// Why: the reported leak has two triggers — a dropped future and a panic
+    /// inside `run_review`. A fix that only handled the normal path would leave
+    /// the second one leaking, and this test is what catches that.
+    /// What: panics while holding a guard, catches the unwind, and asserts the
+    /// counter came back to zero.
+    /// Test: this test.
+    #[test]
+    fn count_guard_decrements_on_unwind() {
+        let counter = Arc::new(AtomicU64::new(0));
+        let for_panic = Arc::clone(&counter);
+
+        let caught = std::panic::catch_unwind(move || {
+            let _guard = InFlightCountGuard::enter(&for_panic);
+            panic!("the review task panicked mid-flight");
+        });
+
+        assert!(caught.is_err(), "the panic must have been caught");
+        assert_eq!(
+            counter.load(Ordering::Relaxed),
+            0,
+            "a panicking review must not leave the counter raised (#5020)"
+        );
+    }
+
+    /// A drop against a zero counter must not wrap it to `u64::MAX`.
+    ///
+    /// Why: an undercount is a small lie; `in_flight: 18446744073709551615` is
+    /// an operator-hostile one.
+    /// What: forces the counter to zero underneath a live guard, then drops it.
+    /// Test: this test.
+    #[test]
+    fn count_guard_drop_saturates_at_zero() {
+        let counter = Arc::new(AtomicU64::new(0));
+        let guard = InFlightCountGuard::enter(&counter);
+        counter.store(0, Ordering::Relaxed);
+
+        drop(guard);
+
+        assert_eq!(counter.load(Ordering::Relaxed), 0);
     }
 
     #[test]

--- a/crates/trusty-review/src/store/mod.rs
+++ b/crates/trusty-review/src/store/mod.rs
@@ -18,7 +18,7 @@ pub mod in_flight;
 
 pub use dedup::{ClaimOutcome, DedupError, DedupStore};
 pub use dedup_open::{DedupNeed, open_for as open_dedup_for};
-pub use in_flight::{InFlightGuard, InFlightRegistry};
+pub use in_flight::{InFlightCountGuard, InFlightGuard, InFlightRegistry};
 
 /// Classify a `redb::DatabaseError` as an incompatible / unreadable file format
 /// (issue #702).


### PR DESCRIPTION
Three fail-open defects in trusty-review's claim gate and load counter. One commit per issue.

- **#5126** — `DedupStore::claim` returned `Skipped` both for a completed review and for a fresh `InProgress` record a crashed holder left behind, and the runner turned both into `Verdict::Approve`. `claim` now returns `InProgressElsewhere` for the second case; the runner reports UNKNOWN with the reason and passes `DedupClaim::NotHeld` so it never deletes the holder's record.
- **#5113** — the CLI `run` path set `allow_posting: true` with `dedup: None`, so a re-run could post a second comment. `build_deps_async` now takes a `DedupNeed` derived by `dedup_need_for`, and `run_review` aborts before the PR-metadata fetch when `decide_action` selects `Post` with no store present.
- **#5020** — `POST /review` lowered `in_flight` after the `await`, so a dropped future skipped it. The new `InFlightCountGuard` decrements in `Drop`.

Each fix carries a regression test that fails on the pre-fix code; each was verified by reverting the fix and running the test. Both failure-branch bugs (#5126, #5020) have a test on the error arm specifically — a fix that only handled the normal return path leaves them red.

## Gates — rung 3

```
cargo fmt --check                                     EXIT=0
cargo check -p trusty-review --all-targets            EXIT=0
cargo clippy -p trusty-review --all-targets -D warnings  EXIT=0
cargo test -p trusty-review                           EXIT=0  → 1701 passed; 0 failed; 5 ignored (lib)
                                                                 + 8 integration targets, all ok
bash scripts/check_test_pointers.sh                   EXIT=0  → 26142 citations, 0 dangling
bash scripts/check_line_cap.sh                        EXIT=0  → 0 violations
bash scripts/check_changelog_fragment.sh              EXIT=0  → 1 crate recorded
bash scripts/check_sld.sh                             EXIT=0
```

Rung 3, not 4: every change is inside `trusty-review`. `ClaimOutcome` gained a variant and `#[non_exhaustive]`, and `build_deps_async` gained a parameter — both crate-internal here, and the release-time semver gate is where the published-API delta gets read.

Refs #5126, #5113, #5020.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
