### PR TITLE
fix(trusty-review): confluence citation form, stale data-gaps entry, empty head_sha fail-closed (#5022, #6039, #6062)

### DIFF
--- a/crates/trusty-review/assets/prompts/system_prompt_coverage_gating.md
+++ b/crates/trusty-review/assets/prompts/system_prompt_coverage_gating.md
@@ -105,7 +105,7 @@ author has openly hedged is a false positive.
 ## Inline citation grammar (prose traceability)
 When your prose (`review_body`, or a finding's `body`/`consequence`) references a
 specific piece of grounding context, cite it inline using EXACTLY one of these
-four bracket forms — no other bracket-citation form is valid:
+five bracket forms — no other bracket-citation form is valid:
 - [code: `path/to/File.ext:42` — "brief excerpt"] — a specific file/line in the
   diff or repository.
 - [jira: TICKET-123 — "brief excerpt from the ticket"] — a JIRA ticket present
@@ -115,6 +115,8 @@ four bracket forms — no other bracket-citation form is valid:
   the same citation form used there — do not invent a different one).
 - [gh: #123 — "brief excerpt from the issue/PR"] — a linked GitHub issue or PR
   present in the provided context.
+- [confluence: "Page Title" — "brief excerpt"] — a Confluence page present in
+  the provided context.
 
 **Distinct from `source_citation`.** These bracket forms are INLINE prose
 citations — they make the rendered review text traceable to its source. They are

--- a/crates/trusty-review/assets/prompts/system_prompt_stock.md
+++ b/crates/trusty-review/assets/prompts/system_prompt_stock.md
@@ -105,7 +105,7 @@ author has openly hedged is a false positive.
 ## Inline citation grammar (prose traceability)
 When your prose (`review_body`, or a finding's `body`/`consequence`) references a
 specific piece of grounding context, cite it inline using EXACTLY one of these
-four bracket forms — no other bracket-citation form is valid:
+five bracket forms — no other bracket-citation form is valid:
 - [code: `path/to/File.ext:42` — "brief excerpt"] — a specific file/line in the
   diff or repository.
 - [jira: TICKET-123 — "brief excerpt from the ticket"] — a JIRA ticket present
@@ -115,6 +115,8 @@ four bracket forms — no other bracket-citation form is valid:
   the same citation form used there — do not invent a different one).
 - [gh: #123 — "brief excerpt from the issue/PR"] — a linked GitHub issue or PR
   present in the provided context.
+- [confluence: "Page Title" — "brief excerpt"] — a Confluence page present in
+  the provided context.
 
 **Distinct from `source_citation`.** These bracket forms are INLINE prose
 citations — they make the rendered review text traceable to its source. They are

--- a/crates/trusty-review/changelog.d/5022-confluence-citation-form.md
+++ b/crates/trusty-review/changelog.d/5022-confluence-citation-form.md
@@ -1,0 +1,3 @@
+Fixed
+
+- `[confluence: "Page Title" — "excerpt"]` is now a recognised inline citation form. `BRACKET_CITATION_RE` matched four bracket forms and the two system prompts mandated the same four, but `duettoresearch/code-intelligence` emits a fifth — so a Confluence excerpt survived the pre-scan strip and was read as an ungrounded free-text code quote, tripping the fabrication check on prose the model had cited correctly. The regex and both prompt grammars now list all five. See #5022.

--- a/crates/trusty-review/changelog.d/6039-populated-section-not-a-gap.md
+++ b/crates/trusty-review/changelog.d/6039-populated-section-not-a-gap.md
@@ -1,0 +1,3 @@
+Fixed
+
+- The report's `Data gaps:` line no longer names a section the same report renders populated. Gaps are recorded as the polish pass walks the document, so dropping the Authorship & Key-Person Risk section's unsynthesised narrative paragraph recorded the enclosing heading as a gap — and nothing revisited that once the section's authorship table filled in with six authors, a bus factor and a trajectory. The gap list is now filtered against the finished body: a label matching a heading whose span carries content is dropped, while a genuinely collapsed section is still named. Same stale-emptiness class as #6029. See #6039.

--- a/crates/trusty-review/changelog.d/6062-empty-head-sha-fails-closed.md
+++ b/crates/trusty-review/changelog.d/6062-empty-head-sha-fails-closed.md
@@ -1,0 +1,3 @@
+Fixed
+
+- A review whose PR-metadata fetch produced no head SHA no longer posts. The dedup claim in `run_review` and the `complete()` call in `finalize_review` are both keyed on the head SHA, and `decide_action` never read it — so a failed `fetch_github_pr_meta` fell back to an empty SHA, continued, and could post live with the claim never taken and never completed; a retry after the same failure posted a duplicate, and the stranded-claim block could never engage. `run_review` now aborts before the diff is loaded when posting is reachable and the SHA is empty, and `finalize_review` downgrades such a run to log-only as a second guard for the webhook path. Same fail-open family as #5126/#5113/#5020. See #6062.

--- a/crates/trusty-review/src/pipeline/citation_check.rs
+++ b/crates/trusty-review/src/pipeline/citation_check.rs
@@ -58,18 +58,23 @@ use tracing::warn;
 use crate::models::{Finding, UNKNOWN_FILE_PLACEHOLDER};
 use crate::pipeline::diff_analyzer::models::{FileDisposition, FilteredDiff};
 
-/// The four inline bracket-citation forms the system prompt mandates
-/// (`[code: … ]`, `[jira: … ]`, `[gh: … ]`, `[apex: … ]`).
+/// The five inline bracket-citation forms the system prompt mandates
+/// (`[code: … ]`, `[jira: … ]`, `[gh: … ]`, `[apex: … ]`, `[confluence: … ]`).
 ///
 /// Why: used to strip ALL bracket citations before the generic backtick/quote
 /// scan, so a citation's `path:line` locator token is never mistaken for a
-/// free-text code quote. `jira:`/`gh:`/`apex:` citations ground in context
-/// (ticket/PR/spec-snippet text) this module has no index for and are left
-/// untouched (fail-open); `code:` citations are extracted and verified
+/// free-text code quote. `jira:`/`gh:`/`apex:`/`confluence:` citations ground
+/// in context (ticket/PR/spec/wiki-page text) this module has no index for and
+/// are left untouched (fail-open); `code:` citations are extracted and verified
 /// SEPARATELY, before this strip runs (see [`CODE_CITATION_RE`]).
-/// Test: `extract_spans_skips_prompt_mandated_citation_grammar`.
+/// This list and the prompt's grammar section
+/// (`assets/prompts/system_prompt_stock.md`) must stay in step — a form the
+/// prompt permits but this regex omits is scanned as an ungrounded quote.
+/// Test: `extract_spans_skips_prompt_mandated_citation_grammar`,
+/// `extract_spans_skips_confluence_citation_form`.
 static BRACKET_CITATION_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?i)\[(?:code|jira|gh|apex):[^\]]*\]")
+    // #5022: `confluence:` is the fifth form — code-intelligence emits it.
+    Regex::new(r"(?i)\[(?:code|jira|gh|apex|confluence):[^\]]*\]")
         .expect("bracket-citation regex is a valid literal")
 });
 

--- a/crates/trusty-review/src/pipeline/citation_check_tests.rs
+++ b/crates/trusty-review/src/pipeline/citation_check_tests.rs
@@ -418,6 +418,38 @@ fn extract_spans_skips_prompt_mandated_citation_grammar() {
     assert!(extracted.code_citations.is_empty());
 }
 
+/// REGRESSION (#5022): a `[confluence: …]` citation is stripped like the other
+/// bracket forms, so its excerpt never reaches the generic quote scan.
+///
+/// Why: `duettoresearch/code-intelligence` emits this fifth form
+/// (`pr_review_service.py:377,909`). `BRACKET_CITATION_RE` matched only four,
+/// so the excerpt inside the bracket survived the strip and was scanned as an
+/// ungrounded free-text code quote — tripping the #4042 fabrication check on
+/// prose the model cited correctly.
+/// What: a finding whose description carries only a `[confluence: …]` citation
+/// must extract no generic spans and no code citations.
+/// Test: this test. Fails pre-fix on the generic assertion — both the page
+/// title and the excerpt were extracted as quotes.
+#[test]
+fn extract_spans_skips_confluence_citation_form() {
+    let f = Finding::new(
+        "f",
+        "k",
+        "See [confluence: \"Rate Plan Ingestion Design\" — \"the loader retries \
+         each shard twice\"].",
+        "s",
+        0.5,
+        Effort::Low,
+    );
+    let extracted = extract_citations(&f);
+    assert!(
+        extracted.generic.is_empty(),
+        "a confluence citation's contents must not be treated as generic quotes: {:?}",
+        extracted.generic
+    );
+    assert!(extracted.code_citations.is_empty());
+}
+
 #[test]
 fn extract_spans_pulls_backtick_and_quotes() {
     let mut f = Finding::new(

--- a/crates/trusty-review/src/pipeline/post.rs
+++ b/crates/trusty-review/src/pipeline/post.rs
@@ -199,7 +199,9 @@ pub struct PostContext<'a> {
     pub repo: &'a str,
     /// Pull request number.
     pub pr: u64,
-    /// Head commit SHA (dedup key); empty when unknown.
+    /// Head commit SHA (dedup key). Empty when the PR-metadata fetch failed —
+    /// `finalize_review` then refuses to post, because an unkeyed claim cannot
+    /// be completed and a re-run would duplicate the comment (#6062).
     pub head_sha: &'a str,
     /// Run mode selecting the auth strategy (CLI=PAT/`gh`, Serve=App).
     pub run_mode: RunMode,
@@ -211,7 +213,10 @@ pub struct PostContext<'a> {
 ///
 /// Why: the single exit point for `run_review` so every code path applies the
 /// same post-or-log policy and the same fail-safe error handling.
-/// What: computes the action via `decide_action`; on `Post`, resolves a token
+/// What: computes the action via `decide_action`, then downgrades `Post` to
+/// `LogOnly` when the context carries no head SHA — the dedup claim is keyed on
+/// it, so posting unkeyed leaves the run with no defence against a duplicate on
+/// re-run (#6062). On `Post`, resolves a token
 /// through the auth abstraction and posts a PR review comment (setting
 /// `posted=true`, `dry_run=false` and marking the dedup claim complete on
 /// success); on `LogOnly` (or any post failure) writes the dry-run log.  Prints
@@ -220,7 +225,8 @@ pub struct PostContext<'a> {
 /// `findings.len()` (#1877) so every completed review (unified or map-reduce)
 /// carries the authoritative count regardless of exit path.
 /// Test: `decide_action_*` cover the branch; the live post is `#[ignore]`;
-/// `findings_count_matches_len_on_completed_review`.
+/// `findings_count_matches_len_on_completed_review`,
+/// `finalize_review_does_not_post_without_a_head_sha`.
 pub async fn finalize_review(
     mut result: ReviewResult,
     config: &ReviewConfig,
@@ -266,7 +272,25 @@ pub async fn finalize_review(
     result.review_body.push_str(&footer);
 
     let is_github = !post_ctx.owner.is_empty() && post_ctx.owner != "local";
-    let action = decide_action(config.dry_run, trigger, allow_posting, is_github);
+    let mut action = decide_action(config.dry_run, trigger, allow_posting, is_github);
+
+    // #6062: empty head_sha is fail-closed — no claim, no post
+    if action == FinalizeAction::Post && post_ctx.head_sha.is_empty() {
+        error!(
+            owner = post_ctx.owner,
+            repo = post_ctx.repo,
+            pr = post_ctx.pr,
+            "no head SHA to key the dedup claim — logging instead of posting (#6062)"
+        );
+        if result.error.is_none() {
+            result.error = Some(
+                "not posted: no head SHA, so the dedup claim cannot be completed and a \
+                 re-run could post a duplicate comment (#6062)"
+                    .to_string(),
+            );
+        }
+        action = FinalizeAction::LogOnly;
+    }
 
     match action {
         FinalizeAction::Post => {
@@ -383,6 +407,56 @@ mod tests {
         ];
         assert_eq!(count_unverified(&findings), 3);
         assert_eq!(count_unverified(&[]), 0);
+    }
+
+    // ── #6062: an empty head SHA is fail-closed ───────────────────────────────
+
+    /// REGRESSION (#6062): `finalize_review` never posts a review it cannot key
+    /// a dedup claim to.
+    ///
+    /// Why: `decide_action` reads only `is_github`, `allow_posting`, `trigger`
+    /// and `dry_run`, so a GitHub run whose PR-metadata fetch failed reached
+    /// `FinalizeAction::Post` with an empty `head_sha`; the `complete()` call is
+    /// itself gated on `!head_sha.is_empty()`, so the comment posted with the
+    /// claim never taken and never completed.
+    /// What: a GitHub `PostContext` with an empty `head_sha`, `allow_posting`
+    /// true and `dry_run` false — the exact shape that selects `Post`. The
+    /// result must stay unposted and say why.
+    /// Test: this test. Fails pre-fix: `post_live` ran and the error read
+    /// `post failed: …` rather than naming the missing head SHA.
+    #[tokio::test]
+    async fn finalize_review_does_not_post_without_a_head_sha() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut config = ReviewConfig::load(None);
+        config.dry_run = false;
+        config.log_dir = dir.path().to_path_buf();
+
+        let result = ReviewResult::new("acme", "backend", 42, "t", "u");
+        let out = finalize_review(
+            result,
+            &config,
+            TriggerDecision::None,
+            true,
+            false,
+            false,
+            PostContext {
+                owner: "acme",
+                repo: "backend",
+                pr: 42,
+                head_sha: "",
+                run_mode: RunMode::Serve,
+                dedup: None,
+            },
+        )
+        .await;
+
+        assert!(!out.posted, "an unkeyed review must never post");
+        assert!(out.dry_run, "the fail-closed path stays dry-run");
+        let error = out.error.expect("the downgrade must explain itself");
+        assert!(
+            error.contains("head SHA"),
+            "the error must name the missing dedup key: {error}"
+        );
     }
 
     // ── Footer rendering ──────────────────────────────────────────────────────

--- a/crates/trusty-review/src/pipeline/prompt_templates.rs
+++ b/crates/trusty-review/src/pipeline/prompt_templates.rs
@@ -68,9 +68,10 @@ mod tests {
         // citable-findings gate + author-gated rule + the `code_provable` field
         // docs; then the daemon-native inline citation grammar — Gap #1 of the
         // #PR84 follow-up; then the `code_provable` worked examples —
-        // adversarial-review item 4).
-        assert_eq!(SYSTEM_PROMPT_STOCK.len(), 14104);
-        assert_eq!(SYSTEM_PROMPT_COVERAGE_GATING.len(), 14420);
+        // adversarial-review item 4; then the `[confluence: …]` citation form,
+        // #5022).
+        assert_eq!(SYSTEM_PROMPT_STOCK.len(), 14210);
+        assert_eq!(SYSTEM_PROMPT_COVERAGE_GATING.len(), 14526);
 
         // The coverage-gating variant is distinguished by its coverage-floor note.
         assert!(SYSTEM_PROMPT_COVERAGE_GATING.contains("deterministic\ncoverage floor"));

--- a/crates/trusty-review/src/pipeline/runner.rs
+++ b/crates/trusty-review/src/pipeline/runner.rs
@@ -18,7 +18,7 @@ use tracing::{debug, error, info, warn};
 use super::runner_coverage::load_coverage_contrib;
 use super::runner_helpers::{
     DedupClaim, abort_dry, apply_grade_and_floor, attach_inline_comments, build_author_rationale,
-    fetch_github_pr_meta, finalize_run, resolve_diff_token,
+    fetch_github_pr_meta, finalize_run, mark_no_head_sha_abort, resolve_diff_token,
 };
 use crate::{
     config::{
@@ -170,7 +170,8 @@ pub struct ReviewDeps {
 /// Test: `run_review_with_fake_provider_approves`, `run_review_fail_safe_on_llm_error`,
 /// `run_review_search_down_skips_when_required`,
 /// `run_review_search_down_degraded_when_optout`,
-/// `run_review_posting_without_dedup_store_fails_closed`.
+/// `run_review_posting_without_dedup_store_fails_closed`,
+/// `run_review_empty_head_sha_fails_closed_before_posting`.
 pub async fn run_review(
     config: &ReviewConfig,
     input: ReviewInput,
@@ -243,11 +244,14 @@ pub async fn run_review(
     }
 
     // ── Step 2: fetch PR metadata (skip for local-diff mode) ──────────────
-    let (pr_meta, head_sha): (ReviewPrMeta, String) = if is_local {
-        (ReviewPrMeta::default(), String::new())
+    // #6062: the fetch failure's own reason travels with the empty head SHA —
+    // the guard below reports both the consequence and the cause, so a run that
+    // stops for a missing SHA still names the config an operator has to fix.
+    let (pr_meta, head_sha, meta_error): (ReviewPrMeta, String, Option<String>) = if is_local {
+        (ReviewPrMeta::default(), String::new(), None)
     } else {
         match fetch_github_pr_meta(config, &owner, &repo, pr_number, input.run_mode).await {
-            Ok((m, sha)) => (m, sha),
+            Ok((m, sha)) => (m, sha, None),
             Err(e) => {
                 warn!("failed to fetch PR metadata: {e} — using empty metadata");
                 (
@@ -258,6 +262,7 @@ pub async fn run_review(
                         url: pr_url.clone(),
                     },
                     String::new(),
+                    Some(e.to_string()),
                 )
             }
         }
@@ -272,6 +277,23 @@ pub async fn run_review(
         pr_url,
     );
     result.head_sha = head_sha.clone();
+
+    // ── Step 2a: no head SHA, no post (#6062) ─────────────────────────────
+    // The claim below and `finalize_review`'s `complete()` both key on the head
+    // SHA, and `decide_action` never reads it — so a failed metadata fetch used
+    // to review and post with the claim never taken and never completed, and a
+    // retry after the same failure posted a duplicate. Ask `decide_action`
+    // whether the post path is reachable, exactly as the #5113 guard does.
+    if !is_local
+        && head_sha.is_empty()
+        && decide_action(config.dry_run, input.trigger, input.allow_posting, true)
+            == FinalizeAction::Post
+    {
+        // #6062: empty head_sha is fail-closed — no claim, no post
+        mark_no_head_sha_abort(&mut result, meta_error.as_deref());
+        // NotHeld — no claim was ever attempted, let alone acquired.
+        return abort_dry(result, config, &input, &deps, DedupClaim::NotHeld).await;
+    }
 
     // ── Step 2b: dedup claim (Phase 1, #582) ──────────────────────────────
     // Claim the (owner,repo,pr,head_sha) slot before doing expensive work.  A

--- a/crates/trusty-review/src/pipeline/runner_helpers.rs
+++ b/crates/trusty-review/src/pipeline/runner_helpers.rs
@@ -10,7 +10,7 @@
 
 use std::sync::Arc;
 
-use tracing::warn;
+use tracing::{error, warn};
 
 use crate::integrations::github::{
     AuthStrategy, CommentableLines, GithubClient, GithubError, RunMode, build_inline_plan,
@@ -229,6 +229,37 @@ pub(super) enum DedupClaim {
     Held,
     /// This review never acquired the claim; the abort must not write.
     NotHeld,
+}
+
+/// Mark a review aborted because it has no head SHA to key its dedup claim to.
+///
+/// Why: the claim in `run_review` and the `complete()` in `finalize_review` are
+/// both keyed on the head SHA, and `decide_action` never reads it — so a failed
+/// `fetch_github_pr_meta` used to leave an empty SHA and still reach
+/// `FinalizeAction::Post`, posting with the claim never taken and never
+/// completed (#6062). The caller decides the post path is reachable and then
+/// calls this; it lives here to keep `runner.rs` under its SLOC cap.
+/// What: logs the abort and writes the verdict and the operator-facing reason
+/// onto `result`, appending the metadata-fetch error when there is one so the
+/// message names the cause as well as the consequence. The caller still owns
+/// the `abort_dry` exit, which releases nothing (the claim was never held).
+/// Test: `run_review_empty_head_sha_fails_closed_before_posting`,
+/// `run_review_serve_mode_empty_token_fails_closed_with_actionable_error`.
+pub(super) fn mark_no_head_sha_abort(result: &mut ReviewResult, meta_error: Option<&str>) {
+    error!(
+        owner = %result.owner,
+        repo = %result.repo,
+        pr = result.pr_number,
+        "PR metadata carried no head SHA and posting is enabled — aborting without posting (#6062)"
+    );
+    result.verdict = Verdict::Unknown;
+    let cause = meta_error
+        .map(|e| format!("; PR metadata fetch failed: {e}"))
+        .unwrap_or_default();
+    result.error = Some(format!(
+        "not reviewed: the PR metadata fetch produced no head SHA, so the dedup claim cannot \
+         be keyed and a re-run could post a duplicate comment (#6062){cause}"
+    ));
 }
 
 /// Finalise an *aborted* review as dry-run only, releasing the dedup claim.

--- a/crates/trusty-review/src/pipeline/runner_tests.rs
+++ b/crates/trusty-review/src/pipeline/runner_tests.rs
@@ -1328,6 +1328,10 @@ async fn run_review_serve_mode_empty_token_fails_closed_with_actionable_error() 
     // must fail CLOSED with an actionable error field — never proceed to
     // `load_diff` with an empty bearer token (which previously surfaced as an
     // opaque `401 Bad credentials` from GitHub instead of a clear diagnostic).
+    // #6062 moved the stop one step earlier: the same missing credentials fail
+    // the PR-metadata fetch first, so the run now halts on the empty head SHA
+    // and carries that fetch error's text along — which is what keeps the
+    // assertion below meaningful.
     let mut config = default_config();
     config.github_app_id = None;
     config.github_app_private_key = None;
@@ -2379,6 +2383,117 @@ async fn run_review_posting_without_dedup_store_fails_closed() {
     assert!(
         error.contains("dedup claim store"),
         "the error must name the missing claim gate so an operator can wire it: {error}"
+    );
+}
+
+// ─── #6062: an empty head SHA is fail-closed on a posting run ───────────────
+
+/// A config with no GitHub App credentials, so serve-mode token resolution —
+/// and therefore `fetch_github_pr_meta` — fails without touching the network.
+fn config_without_app_creds() -> ReviewConfig {
+    let mut config = ReviewConfig::load(None);
+    config.github_app_id = None;
+    config.github_app_private_key = None;
+    config.github_installations = Vec::new();
+    config
+}
+
+/// REGRESSION (#6062): a posting run whose PR-metadata fetch produced no head
+/// SHA aborts before the review runs, rather than proceeding unkeyed.
+///
+/// Why: `fetch_github_pr_meta` failing falls back to `head_sha = String::new()`
+/// and continues. Both the claim in `run_review` and the `complete()` in
+/// `finalize_review` gate on `!head_sha.is_empty()`, and `decide_action` never
+/// reads the SHA at all — so the run reached `FinalizeAction::Post` and posted
+/// live with the dedup claim never taken and never completed. A retry after the
+/// same fetch failure posts a duplicate.
+/// What: a GitHub source in serve mode with no App credentials (so the metadata
+/// fetch fails offline), `allow_posting: true`, `dry_run: false`, and a real
+/// dedup store present so the #5113 guard is not the one firing. The run must
+/// return UNKNOWN with an error naming the missing head SHA, and must not post.
+/// Test: this test. Fails pre-fix: the run continued past the fetch and the
+/// error named GitHub token resolution instead of the missing head SHA.
+#[tokio::test]
+async fn run_review_empty_head_sha_fails_closed_before_posting() {
+    use crate::store::DedupStore;
+
+    let dir = tempfile::tempdir().unwrap();
+    let mut config = config_without_app_creds();
+    config.dry_run = false; // the post path is reachable
+    config.log_dir = dir.path().to_path_buf();
+
+    let input = ReviewInput {
+        diff_source: DiffSource::Github {
+            owner: "acme".to_string(),
+            repo: "backend".to_string(),
+            pr: 42,
+            token: String::new(),
+        },
+        reviewer_model: "openai/gpt-5.4-nano-20260317".to_string(),
+        write_log: false,
+        print_result: false,
+        trigger: TriggerDecision::None,
+        run_mode: RunMode::Serve,
+        allow_posting: true,
+        caller_context: CallerContext::default(),
+        surface: InvocationSurface::default(),
+    };
+    let mut deps = ready_deps(Arc::new(FakeLlm::approves()), None);
+    deps.dedup = Some(Arc::new(
+        DedupStore::open(&dir.path().join("dedup.redb")).expect("open"),
+    ));
+
+    let result = run_review(&config, input, deps).await;
+
+    assert!(
+        !result.posted,
+        "a run with no dedup key must never post — a retry would duplicate it"
+    );
+    assert_eq!(
+        result.verdict,
+        Verdict::Unknown,
+        "a run that never happened must not report a verdict"
+    );
+    let error = result.error.expect("the abort must explain itself");
+    assert!(
+        error.contains("head SHA"),
+        "the error must name the missing dedup key, not a downstream symptom: {error}"
+    );
+}
+
+/// Why: the #6062 guard must not fire where nothing can be posted — a local
+/// diff has no head SHA by construction and reviews normally.
+/// What: a local diff source with `allow_posting: true` and `dry_run: false`
+/// must review rather than abort on the empty SHA.
+/// Test: this test.
+#[tokio::test]
+async fn run_review_local_source_with_empty_head_sha_is_not_blocked() {
+    let (source, _tmp) = local_diff_source("+fn x() {}\n");
+    let mut config = default_config();
+    config.dry_run = false;
+
+    let input = ReviewInput {
+        diff_source: source,
+        reviewer_model: "openai/gpt-5.4-nano-20260317".to_string(),
+        write_log: false,
+        print_result: false,
+        trigger: TriggerDecision::None,
+        run_mode: RunMode::Cli,
+        allow_posting: true,
+        caller_context: CallerContext::default(),
+        surface: InvocationSurface::default(),
+    };
+    let deps = ready_deps(Arc::new(FakeLlm::approves()), None);
+
+    let result = run_review(&config, input, deps).await;
+
+    assert!(
+        !result
+            .error
+            .as_deref()
+            .is_some_and(|e| e.contains("head SHA")),
+        "a local diff has no head SHA and nowhere to post: {:?}",
+        result.error
     );
 }
 

--- a/crates/trusty-review/src/report/polish.rs
+++ b/crates/trusty-review/src/report/polish.rs
@@ -54,6 +54,8 @@ pub fn polish(rendered: &str) -> String {
 pub fn polish_with_gaps(rendered: &str, declared: &[String]) -> String {
     let stripped = strip_template_comments(rendered);
     let (body, gaps) = omit_empty(&stripped);
+    // #6039: a gap recorded mid-pass is stale once the section fills in.
+    let gaps = drop_populated_section_gaps(&body, gaps);
     let out = render_gaps_section(&body, &gaps, declared);
     // The line-based passes join with `\n` and drop the trailing newline; restore
     // it when the input had one so exact-output expectations hold.
@@ -677,6 +679,79 @@ fn push_gap(gaps: &mut Vec<String>, label: &str) {
     if !label.is_empty() {
         gaps.push(label.to_string());
     }
+}
+
+/// Drop every gap label naming a section the polished body renders with content.
+///
+/// Why: gaps are recorded as the pass walks the document, so a label written
+/// while one part of a section was being dropped outlives the rest of the
+/// section filling in. The Authorship & Key-Person Risk section rendered six
+/// authors, a bus factor and a trajectory, and the same report's Data gaps line
+/// still counted it among 18 unpopulated sections — its unsynthesised narrative
+/// paragraph was the honesty marker, and dropping that paragraph recorded the
+/// enclosing HEADING as the gap (#6039). Same stale-emptiness class as #6029.
+/// What: reads the final body — the only authority on what the reader sees —
+/// and removes any label equal to a heading whose span carries content. A
+/// collapsed section's span holds only [`COLLAPSE_LINE`], so its gap survives;
+/// a row label (`Client`) matches no heading and is untouched.
+/// Test: `polish_tests.rs::{populated_section_is_not_listed_as_a_data_gap,
+/// collapsed_section_is_still_listed_when_a_sibling_is_populated}`.
+fn drop_populated_section_gaps(body: &str, gaps: Vec<String>) -> Vec<String> {
+    if gaps.is_empty() {
+        return gaps;
+    }
+    let populated = populated_sections(body);
+    gaps.into_iter()
+        .filter(|g| !populated.contains(g.as_str()))
+        .collect()
+}
+
+/// The headings (real and bold pseudo) whose spans carry rendered content.
+fn populated_sections(body: &str) -> std::collections::HashSet<String> {
+    let lines: Vec<&str> = body.lines().collect();
+    let mut out = std::collections::HashSet::new();
+    let mut in_fence = false;
+    for (idx, line) in lines.iter().enumerate() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("```") {
+            in_fence = !in_fence;
+            continue;
+        }
+        if in_fence {
+            continue;
+        }
+        if let Some((level, heading)) = boundary(trimmed)
+            && span_has_content(&lines[idx + 1..], level)
+        {
+            out.insert(heading.to_string());
+        }
+    }
+    out
+}
+
+/// True when a level-`level` boundary's span holds a line the reader reads as
+/// data — anything non-empty that is neither a nested heading nor the collapse
+/// line. A nested deeper section's own content counts toward its parent.
+fn span_has_content(rest: &[&str], level: usize) -> bool {
+    for line in rest {
+        let t = line.trim();
+        if t.starts_with("```") {
+            return true; // a fenced block is content, whatever it holds
+        }
+        if t == "---" {
+            return false;
+        }
+        if let Some((child_level, _)) = boundary(t) {
+            if child_level <= level {
+                return false;
+            }
+            continue; // a child's heading alone is not the parent's content
+        }
+        if !t.is_empty() && t != COLLAPSE_LINE {
+            return true;
+        }
+    }
+    false
 }
 
 /// De-duplicate gap labels, preserving first-seen order.

--- a/crates/trusty-review/src/report/polish_tests.rs
+++ b/crates/trusty-review/src/report/polish_tests.rs
@@ -179,6 +179,58 @@ fn collapses_empty_section() {
     assert!(out.contains("content"));
 }
 
+/// REGRESSION (#6039): a section that renders populated is never named in the
+/// Data gaps list, even when one part of it was dropped as empty.
+///
+/// Why: the Authorship & Key-Person Risk section rendered six authors, a bus
+/// factor and a trajectory, and the same report's Data gaps line still counted
+/// it among "18 unpopulated fields/sections". Its unsynthesised narrative
+/// paragraph was the honesty marker, so the drop recorded the SECTION heading
+/// as the gap label — bookkeeping that nothing revisited once the section's
+/// table filled in. Same stale-emptiness class as #6029.
+/// What: a section whose narrative paragraph is the marker but whose table has
+/// real rows. The rows must survive and the gaps line must not name the
+/// section.
+/// Test: this test. Fails pre-fix: the gaps line reads `Data gaps: 1
+/// unpopulated field/section — Authorship & Key-Person Risk.`
+#[test]
+fn populated_section_is_not_listed_as_a_data_gap() {
+    let input = format!(
+        "## Authorship & Key-Person Risk\n\n{HONESTY_MARKER}\n\n\
+         | Application | Distinct authors | Bus factor |\n|---|---|---|\n\
+         | backend | 6 | 1 |\n\n## 8. Gaps & Caveats\n\nplaceholder\n"
+    );
+    let out = polish(&input);
+    assert!(
+        out.contains("| backend | 6 | 1 |"),
+        "the measured row must survive: {out}"
+    );
+    let gaps_line = out
+        .lines()
+        .find(|l| l.starts_with("Data gaps:"))
+        .unwrap_or("No material data gaps");
+    assert!(
+        !gaps_line.contains("Authorship & Key-Person Risk"),
+        "a section the report renders populated must not be listed as a gap: {gaps_line}"
+    );
+}
+
+/// Why: dropping stale section gaps must not disarm the case the gaps list
+/// exists for — a section that really did collapse still has to be named.
+/// What: one collapsed section beside one populated section; only the collapsed
+/// one is listed.
+/// Test: this test.
+#[test]
+fn collapsed_section_is_still_listed_when_a_sibling_is_populated() {
+    let input = "## 6. Risk Registers\n\n## 7. Appendix\n\ncontent\n\n\
+                 ## 8. Gaps & Caveats\n\nplaceholder\n";
+    let out = polish(input);
+    assert!(
+        out.contains("Data gaps: 1 unpopulated field/section — 6. Risk Registers."),
+        "a genuinely empty section must still be named: {out}"
+    );
+}
+
 /// Why: the Gaps & Caveats section must list every dropped field compactly rather
 /// than as a wall of markers.
 /// What: asserts dropped fields from multiple sources appear in one Data gaps line


### PR DESCRIPTION
Three trusty-review correctness fixes. Read the issues for the full traces: #5022, #6039, #6062.

## What changed

**#5022 — the citation grammar knows five bracket forms, not four.**
`BRACKET_CITATION_RE` (`pipeline/citation_check.rs`) matched `code|jira|gh|apex`, and both system prompts mandated the same four. `duettoresearch/code-intelligence` emits a fifth, `[confluence: "Page Title" — "excerpt"]`, so that excerpt survived the pre-scan strip and reached the generic quote scan as an ungrounded free-text code quote — tripping the #4042 fabrication check on prose the model had cited correctly. The regex and both prompt assets now list all five, and the frozen prompt byte lengths in `prompt_assets_are_byte_identical` move with them.

**#6039 — a section the report renders populated is no longer listed as a data gap.**
Gaps are recorded as the polish pass walks the document, so dropping the Authorship & Key-Person Risk section's unsynthesised narrative paragraph recorded the enclosing HEADING as the gap — and nothing revisited that once the section's table filled in with six authors, a bus factor and a trajectory. `polish_with_gaps` now filters the list against the finished body: a label matching a heading whose span carries content is dropped; a genuinely collapsed section, whose span holds only the collapse line, is still named. Same stale-emptiness class as #6029.

**#6062 — an empty head SHA is fail-closed on a posting run.**
The dedup claim in `run_review` and the `complete()` in `finalize_review` are both keyed on the head SHA, and `decide_action` never reads it. A failed `fetch_github_pr_meta` fell back to `head_sha = String::new()`, continued, and could reach `FinalizeAction::Post` — posting live with the claim never taken and never completed, so a retry after the same failure duplicates the comment and the stranded-claim block can never engage. Two guards now:

- `run_review` aborts before the diff loads when the post path is reachable and the SHA is empty, carrying the metadata-fetch error's own text so the message names the cause as well as the consequence.
- `finalize_review` downgrades such a run from `Post` to `LogOnly`, which covers the webhook path and any future caller.

The abort body moved to `runner_helpers::mark_no_head_sha_abort` so `runner.rs` stays under the 500 SLOC cap (it hit 507 with the guard inline).

## Fail-open proof for #6062

Both #6062 regression tests were written first and run against `22852ed5c` — this branch's base, `origin/main` — with only the tests applied. Raw output:

```
---- pipeline::post::tests::finalize_review_does_not_post_without_a_head_sha stdout ----
thread 'pipeline::post::tests::finalize_review_does_not_post_without_a_head_sha' panicked at crates/trusty-review/src/pipeline/post.rs:432:9:
the error must name the missing dedup key: post failed: GitHub App auth error: GitHub App credentials (GITHUB_APP_ID + GITHUB_APP_PRIVATE_KEY) are required in service mode

---- pipeline::runner::tests::run_review_empty_head_sha_fails_closed_before_posting stdout ----
thread 'pipeline::runner::tests::run_review_empty_head_sha_fails_closed_before_posting' panicked at crates/trusty-review/src/pipeline/runner_tests.rs:2454:5:
the error must name the missing dedup key, not a downstream symptom: GitHub token resolution failed: GitHub App auth error: GitHub App credentials (GITHUB_APP_ID + GITHUB_APP_PRIVATE_KEY) are required in service mode
```

The `finalize_review` failure is the fail-open itself: pre-fix, `post_live` RAN with an empty head SHA — `post failed: …` is that live post attempt failing on credentials this test fixture withholds. With credentials present it would have posted, unkeyed. Post-fix the run never reaches `post_live`.

Two companion tests pin the guards' scope and pass on both sides of the fix: `run_review_local_source_with_empty_head_sha_is_not_blocked` (a local diff has no SHA and nowhere to post) and `collapsed_section_is_still_listed_when_a_sibling_is_populated` (#6039's filter does not disarm the gap list).

## Pre-fix proof for #5022 and #6039

Same run, same base commit:

```
---- pipeline::citation_check::tests::extract_spans_skips_confluence_citation_form stdout ----
panicked at crates/trusty-review/src/pipeline/citation_check_tests.rs:445:5:
a confluence citation's contents must not be treated as generic quotes: ["Rate Plan Ingestion Design", "the loader retries each shard twice"]

---- report::polish::tests::populated_section_is_not_listed_as_a_data_gap stdout ----
panicked at crates/trusty-review/src/report/polish_tests.rs:212:5:
a section the report renders populated must not be listed as a gap: Data gaps: 1 unpopulated field/section — Authorship & Key-Person Risk.
```

`test result: FAILED. 2 passed; 4 failed; 0 ignored; 1715 filtered out`

## Gate — test ladder rung 3 (localized behavior inside one crate)

```
cargo fmt --check                                     EXIT=0
cargo check -p trusty-review                          EXIT=0
cargo clippy -p trusty-review --all-targets -- -D warnings   EXIT=0
cargo test -p trusty-review                           EXIT=0
  test result: ok. 1716 passed; 0 failed; 5 ignored   (lib)
  plus 9 integration binaries, 0 failed
bash scripts/check_line_cap.sh                        EXIT=0
  4114 tracked .rs file(s); 4 allowlisted, 0 violations
bash scripts/check_changelog_fragment.sh              EXIT=0
  scanned 14 changed path(s); all 1 crate(s) with source changes are recorded
bash scripts/check_sld.sh                             EXIT=0
```

Two pre-existing tests changed with the behavior, neither by weakening it: `prompt_assets_are_byte_identical` re-freezes both prompt lengths (14104→14210, 14420→14526), and `run_review_serve_mode_empty_token_fails_closed_with_actionable_error` keeps its `GITHUB_APP_ID` assertion because the #6062 message carries the fetch error's text — the run now stops one step earlier, for the same cause.

Refs #5022
Refs #6039
Refs #6062

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
