### PR TITLE
fix(ci,scripts,website): red-main notify coverage, shared source classifier + release-gated fragment consumption, website lint, changelog link base (#5657, #5674, #5765, #5918, #5640)

### DIFF
--- a/.github/workflows/changelog-fragment.yml
+++ b/.github/workflows/changelog-fragment.yml
@@ -84,6 +84,26 @@ jobs:
       - name: Crate-attribution selftest (must not drop nested crate source)
         run: bash scripts/check_changelog_attribution_selftest.sh
 
+      # Shared-classification selftest (#5765): this gate's test-file exemption
+      # and `check-pr-version-bump.sh`'s lack of one used to be two independent
+      # path matches, so the same file — `crates/trusty-review/src/report/
+      # reporter_tests.rs` on PR #5764 — was source to one gate and not the
+      # other by accident. Both now read scripts/lib/source_class.sh. This
+      # re-proves the classification AND that neither gate has grown a private
+      # copy again, which is the only way the definitions can drift apart.
+      - name: Source-classification selftest (both gates share one definition)
+        run: bash scripts/check_source_class_selftest.sh
+
+      # Bump-mode selftest (#5674): `bump-version.sh` used to consume this
+      # crate's changelog.d/ fragments unconditionally, so a bump landing in the
+      # same PR as its source change deleted the fragments THIS gate then failed
+      # the PR for lacking (PR #5673). It runs here because the two scripts are
+      # two halves of one contract — the gate demands a fragment the bump must
+      # not eat — and proves both directions: --no-changelog leaves fragments in
+      # place, and a release cut still assembles them.
+      - name: Bump-mode selftest (a mid-PR bump must not eat fragments)
+        run: bash scripts/bump_version_selftest.sh
+
       # #4688: diff against the base branch AS IT IS NOW, not the frozen
       # `base.sha` snapshot. checkout leaves refs/remotes/origin/<base> at
       # whatever it fetched; re-fetching pins it to the live tip so the merge

--- a/.github/workflows/test-pointers.yml
+++ b/.github/workflows/test-pointers.yml
@@ -9,6 +9,12 @@
 #
 # Pure text scanning — no Rust toolchain or build needed, so this runs as
 # its own lightweight job (matches ci.yml / line-cap.yml's checkout style).
+#
+# On a push to main the `notify-main-failure` job at the bottom files or
+# comments on the `ci-red-main` tracking issue when the lint does not come out
+# green. `ci.yml`'s notifier cannot do that for this workflow — a `needs:` list
+# cannot cross workflow files — and for 24 hours in August 2026 that meant a red
+# lint on main with no alarm at all (#5657).
 name: Test pointers
 
 # `push` stays path-filtered to the lint's actual inputs.
@@ -135,3 +141,111 @@ jobs:
           echo "the gate scripts, or this workflow), so scripts/check_test_pointers.sh"
           echo "would report exactly what it reported on the base branch."
           echo "Reporting success rather than not reporting at all — see #5311."
+
+  # Loudness on main (#5657). `ci.yml`'s `notify-main-failure` is the repo's
+  # only red-main detector, and a `needs:` list cannot name a job in another
+  # workflow file — so this workflow's result was structurally invisible to it.
+  # That is not a theory: this lint was red on `main` continuously from run
+  # 31587713536 (2026-08-12 10:30) to 31688534235 (2026-08-13 09:52), over 24
+  # hours spanning every PR opened in that window, and no `ci-red-main` issue
+  # was ever filed. A human eventually found it by hand and opened #5520.
+  #
+  # WHY ITS OWN NOTIFY JOB rather than folding the lint into `ci.yml`. The two
+  # workflows disagree on every structural choice this job depends on: this one
+  # keeps a `paths:` filter on `push` (`ci.yml` has none, so the lint would run
+  # on every merge), carries its own per-commit concurrency group, and its job
+  # name is the REQUIRED branch-protection context "Doc-comment pointer lint
+  # (Why/What/Test)" — a move would have to preserve that string exactly while
+  # inheriting a trigger set built for a different question. `version-parity.yml`
+  # already answered this the other way with `notify-main-drift` (#4688), so
+  # copying that shape is the change the existing structure supports, and it
+  # generalises: the other 13 push-to-main workflows can each take this job.
+  #
+  # It files on the SAME `ci-red-main` label `ci.yml` uses, so a red lint lands
+  # on the one tracking issue a reader already watches instead of a second one.
+  # `always()` so a cancelled or skipped lint still reports — a non-green
+  # verdict is never silence.
+  notify-main-failure:
+    name: Notify on red main
+    if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [test-pointers]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/checkout@v5
+
+      # Same classifier `ci.yml` uses, fed this workflow's own job conclusion:
+      # `failure`/`timed_out` are red, `cancelled`/`skipped` are inconclusive,
+      # and only `success` is green (#4179).
+      - name: Classify the lint's conclusion
+        id: verdict
+        env:
+          CI_JOB_RESULTS: test-pointers=${{ needs['test-pointers'].result }}
+        run: bash scripts/classify-ci-results.sh > /dev/null
+
+      - name: File or update tracking issue
+        if: steps.verdict.outputs.verdict != 'green'
+        uses: actions/github-script@v7
+        env:
+          CI_VERDICT: ${{ steps.verdict.outputs.verdict }}
+          CI_SUMMARY: ${{ steps.verdict.outputs.summary }}
+        with:
+          script: |
+            const label = 'ci-red-main';
+            const title = 'CI red on main';
+            const verdict = process.env.CI_VERDICT;
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              verdict === 'red'
+                ? `The doc-comment pointer lint FAILED on a push to \`main\` at ${context.sha}.`
+                : `The doc-comment pointer lint did NOT conclude successfully on a push to \`main\` at ${context.sha} (verdict: ${verdict}).`,
+              '',
+              `Job conclusions: ${process.env.CI_SUMMARY}`,
+              '',
+              `Run: ${runUrl}`,
+              '',
+              'A `Test:` doc-comment pointer cites a test that does not exist in the',
+              'citing file’s crate, or an allowlisted pointer is no longer dangling.',
+              'Run `bash scripts/check_test_pointers.sh` locally for the exact lines.',
+              '',
+              'This lint runs in its own workflow, so `ci.yml`’s notifier cannot see it',
+              'and reports green regardless (issue #5657).',
+            ].join('\n');
+
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: label,
+            });
+
+            if (existing.data.length > 0) {
+              const issue = existing.data[0];
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body,
+              });
+              core.notice(`Updated existing tracking issue #${issue.number}`);
+            } else {
+              const created = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: [label],
+              });
+              core.notice(`Filed new tracking issue #${created.data.number}`);
+            }
+
+      # The run's own conclusion must match what the lint actually did, the same
+      # rule `ci.yml`'s notifier enforces: without this a cancelled lint still
+      # ends the run green and `gh run view` reports a verified commit.
+      - name: Fail this job on any non-green verdict
+        if: steps.verdict.outputs.verdict != 'green'
+        run: |
+          echo "::error::pointer lint verdict on main: ${{ steps.verdict.outputs.verdict }}"
+          exit 1

--- a/.github/workflows/version-parity.yml
+++ b/.github/workflows/version-parity.yml
@@ -74,6 +74,8 @@ on:
       - "Cargo.lock"
       - "scripts/check-version-parity.sh"
       - "scripts/check-pr-version-bump.sh"
+      - "scripts/lib/source_class.sh"
+      - "scripts/check_source_class_selftest.sh"
       - "scripts/check_scan_floor_selftest.sh"
       - ".github/workflows/version-parity.yml"
   # Every three hours. Fine-grained enough that a publish is caught in one
@@ -180,6 +182,18 @@ jobs:
       - name: Publish-order selftest (optional + dev dep edges must order first)
         if: steps.gate.outputs.run_check == 'true'
         run: bash scripts/publish-dry-run-order_selftest.sh
+
+      # Shared-classification selftest (#5765). This gate decides which crates
+      # it examines from `scripts/lib/source_class.sh`, shared with
+      # `scripts/check_changelog_fragment.sh` — the two used to carry
+      # independent path matches that disagreed about a test file under src/.
+      # Run here as well as in changelog-fragment.yml because both consumers
+      # should refuse to run against a broken definition, and this is the
+      # required context of the two. Pure shell, no network, well under a
+      # second.
+      - name: Source-classification selftest (both gates share one definition)
+        if: steps.gate.outputs.run_check == 'true'
+        run: bash scripts/check_source_class_selftest.sh
 
       # #4688: diff against the base branch AS IT IS NOW, not the frozen
       # `base.sha` snapshot. checkout leaves refs/remotes/origin/<base> at

--- a/.github/workflows/website-tests.yml
+++ b/.github/workflows/website-tests.yml
@@ -1,4 +1,7 @@
 # #5200: nothing in CI ran `website/`'s Vitest suite — this workflow does.
+# #5918: nothing ran `pnpm lint` over it either — the `Prettier + ESLint` job
+# at the bottom does, as a second, independent job. Both are ADVISORY: neither
+# is a required branch-protection context.
 #
 # The gap this closes: `scripts/detect-docs-only.sh` buckets `website/**` as
 # inert (same as `docs/**`) on the strength of a comment claiming the site
@@ -47,10 +50,12 @@
 # field keeps one source of truth, and the assertion makes a mis-resolution
 # fail loudly instead of running the suite under some other pnpm.
 #
-# NODE 20 — `website/` declares no `engines` field and has no `.nvmrc`. 20 is
-# the version every sibling workflow uses AND the lowest one all three
-# floors accept: vitest 4 wants `^20 || ^22 || >=24`, vite 6 wants
-# `^18 || ^20 || >=22`, SvelteKit 2 wants `>=18.13`.
+# NODE 22 — `website/` declares no `engines` field and has no `.nvmrc`. Both
+# jobs pin 22, which every floor accepts: vitest 4 wants `^20 || ^22 || >=24`,
+# vite 6 wants `^18 || ^20 || >=22`, SvelteKit 2 wants `>=18.13`. A local Node
+# on a different line can report `localStorage` failures in
+# `tests/theme.test.ts` that this runner does not — match the pin before
+# treating one as real.
 #
 # CHROMIUM — `tests/mobile-overflow.test.ts` launches a real browser to
 # measure `scrollWidth`; jsdom has no layout engine and cannot. That file's
@@ -157,3 +162,78 @@ jobs:
       - name: Run the website test suite
         working-directory: website
         run: pnpm run test
+
+  # #5918: nothing in CI ran `pnpm lint` over `website/`, and `main` carried a
+  # Prettier violation because of it. The gap is the same shape as the one this
+  # workflow was created for (#5200): `ci.yml`'s `ui-checks` matrix is the only
+  # other pnpm surface, every step in it is gated on `docs_only != 'true'`, and
+  # `scripts/detect-docs-only.sh:114` buckets `website/**` as docs-only — so a
+  # lint leg bolted onto that matrix would skip on exactly the PRs it exists to
+  # check. It goes here, beside the suite that already solved that.
+  #
+  # A SEPARATE JOB, not a step in `website-tests`. Two reasons. A Prettier nit
+  # and a broken assertion are different problems and deserve different red
+  # squares — as one job, whichever ran first would mask the other. And this job
+  # needs neither Chromium nor a `vite build`, so it settles in well under a
+  # minute while the suite takes up to twenty.
+  #
+  # ADVISORY, stated explicitly (#5918's third closure condition). Neither job
+  # in this workflow is a required branch-protection context — read the live
+  # list with `gh api repos/bobmatnyc/trusty-tools/branches/main/protection
+  # --jq '.required_status_checks.contexts'`, never a copy of it. A red lint
+  # here does not block a merge; it is a signal a reviewer is expected to read.
+  website-lint:
+    name: Prettier + ESLint
+    if: github.event_name != 'pull_request' || github.event.action != 'edited' || github.event.changes.base != null
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+
+      # Same pin-then-verify sequence as the job above, and for the same reason:
+      # `website/` pins an exact pnpm in `packageManager` and a shell at the repo
+      # root has no pin at all, so the version is READ rather than hardcoded.
+      - name: Read the pinned pnpm version from website/package.json
+        id: pin
+        run: |
+          set -euo pipefail
+          version="$(sed -n 's/.*"packageManager"[[:space:]]*:[[:space:]]*"pnpm@\([0-9][0-9.]*\).*/\1/p' website/package.json)"
+          if [ -z "$version" ]; then
+            echo "::error::no pnpm@<version> found in website/package.json packageManager" >&2
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ steps.pin.outputs.version }}
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+          cache-dependency-path: website/pnpm-lock.yaml
+
+      - name: Verify the resolved pnpm is the pinned one
+        run: |
+          set -euo pipefail
+          resolved="$(pnpm --version)"
+          expected="${{ steps.pin.outputs.version }}"
+          if [ "$resolved" != "$expected" ]; then
+            echo "::error::pnpm $resolved resolved, but website/package.json pins $expected" >&2
+            exit 1
+          fi
+          echo "pnpm $resolved matches the pin"
+
+      - name: Install dependencies
+        working-directory: website
+        run: pnpm install --frozen-lockfile
+
+      # `prettier --check . && eslint .` — the script `website/package.json`
+      # already defines, so a developer running `pnpm lint` locally runs exactly
+      # what this job runs. `pnpm format` writes the fixes.
+      - name: Lint the website
+        working-directory: website
+        run: pnpm run lint

--- a/docs/reference/changelog-fragments.md
+++ b/docs/reference/changelog-fragments.md
@@ -61,6 +61,12 @@ heading between releases. At release time `scripts/bump-version.sh` calls
 fragments by category, writes one `## [<version>] — <date>` section, and deletes
 the consumed fragments in the same operation.
 
+A bump that is not a release cut must not do that. Pass
+`scripts/bump-version.sh <crate-dir> <level> --no-changelog` when the bump rides
+along in the PR carrying its source change: the fragments there belong to work
+still in flight, and consuming them makes this gate fail the PR for lacking a
+fragment the bump deleted (issue #5674).
+
 ## Recovering a Stale Section (`--merge`)
 
 Assembling is not coupled to publishing, so a `## [<version>]` section can exist

--- a/docs/reference/release-workflow.md
+++ b/docs/reference/release-workflow.md
@@ -44,6 +44,21 @@ e.g. `trusty-mcp-core-v0.2.0`. The version comes from the crate's `Cargo.toml`.
 > scripts/bump-version.sh trusty-git-analytics minor
 > ```
 >
+> 🔴 **A bump that is NOT a release cut takes `--no-changelog`** (issue #5674).
+> Fragment consumption is correct at a release cut and wrong when the bump lands
+> in the same PR as the source change it accompanies — a `cargo-semver-checks`
+> BREAK forcing one mid-PR, say. Those fragments belong to work still in flight,
+> and eating them makes `scripts/check_changelog_fragment.sh` fail the PR for
+> lacking a fragment the bump just deleted. That happened on PR #5673 and was
+> repaired by hand (commit `879b5fe2`). `--no-changelog` bumps the manifest and
+> syncs `Cargo.lock`, leaves `changelog.d/` untouched, and prints no tag
+> command — the release cut still runs the flagless form and assembles the
+> fragments this run left behind.
+>
+> ```bash
+> scripts/bump-version.sh trusty-review minor --no-changelog
+> ```
+>
 > The `--suggest` auto-bump-from-commit-types enhancement noted in #1322/#1345
 > is intentionally deferred and not yet implemented.
 3. Run `cargo test -p <name>` and `cargo clippy --workspace -- -D warnings`.

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -22,18 +22,36 @@
 # easy-to-extend place that derives it). Finally it prints — but does NOT
 # execute — the `git tag` and `git push` commands.
 #
-# Test: `bash -n scripts/bump-version.sh` for syntax and `shellcheck
-# scripts/bump-version.sh` for lint. Functionally, the pure version-bump logic
-# lives in bump_semver()/read_package_version()/write_package_version(), which
-# can be exercised against a throwaway copy of a Cargo.toml without mutating any
-# real crate manifest (see the PR's verification notes).
+# FRAGMENT CONSUMPTION IS THE RELEASE CUT'S JOB, AND ONLY ITS JOB (#5674).
+# Assembly used to run unconditionally, right after `cargo update`, with no way
+# to ask for a bump without it. That is correct at a release cut and wrong every
+# other time: a bump landing in the same PR as its source change — a
+# cargo-semver-checks BREAK forcing one mid-PR, say — ate four in-flight
+# fragments on PR #5673, and `scripts/check_changelog_fragment.sh` then failed
+# that PR for lacking a fragment this script had just deleted. The repair was
+# manual (commit 879b5fe2 restored the fragments and reverted the CHANGELOG
+# section).
+#
+# `--no-changelog` is the opt-OUT, deliberately not an opt-in. A forgotten
+# opt-out costs a red gate on the PR — loud, and the fragments are recoverable
+# from git. A forgotten opt-in would publish a release whose CHANGELOG has no
+# section for it, which nothing checks and nobody sees until a reader looks for
+# an entry that is not there. The default therefore stays exactly what the
+# release path already relies on.
+#
+# Test: scripts/bump_version_selftest.sh drives the real script against a
+# throwaway workspace (WORKSPACE_ROOT derives from the script's own location)
+# with a stub `cargo` on PATH, and asserts both directions: the default consumes
+# fragments and writes the section, --no-changelog bumps the manifest and leaves
+# changelog.d/ untouched. `bash -n` and `shellcheck` cover syntax and lint.
 #
 # Usage:
-#   scripts/bump-version.sh <crate-dir> <major|minor|patch>
+#   scripts/bump-version.sh <crate-dir> <major|minor|patch> [--no-changelog]
 #
 # Example:
 #   scripts/bump-version.sh trusty-search patch
 #   scripts/bump-version.sh trusty-git-analytics minor
+#   scripts/bump-version.sh trusty-review minor --no-changelog
 
 set -euo pipefail
 
@@ -52,15 +70,21 @@ tag_prefix_for() {
 }
 
 usage() {
-  echo "Usage: scripts/bump-version.sh <crate-dir> <major|minor|patch>" >&2
+  echo "Usage: scripts/bump-version.sh <crate-dir> <major|minor|patch> [--no-changelog]" >&2
   echo "" >&2
   echo "  <crate-dir>            directory under crates/ (e.g. trusty-search)" >&2
   echo "  <major|minor|patch>    semver component to increment" >&2
+  echo "  --no-changelog         bump the manifest only; leave changelog.d/ alone" >&2
   echo "" >&2
   echo "Reads the package version from crates/<crate-dir>/Cargo.toml, bumps it," >&2
   echo "syncs Cargo.lock (cargo update -p <package> --precise <next>), assembles" >&2
   echo "the crate's changelog.d/ fragments into a [<next>] CHANGELOG section, and" >&2
   echo "PRINTS the tag/push commands for you to run (it never tags or pushes)." >&2
+  echo "" >&2
+  echo "Pass --no-changelog when the bump lands in the same PR as the source" >&2
+  echo "change it accompanies: the fragments belong to work still in flight, and" >&2
+  echo "consuming them fails that PR's changelog-fragment gate (issue #5674)." >&2
+  echo "A release cut takes no flag — assembly is what it is for." >&2
   exit 2
 }
 
@@ -158,6 +182,25 @@ write_package_version() {
 }
 
 main() {
+  # #5674: `--no-changelog` is the only flag, and it may sit anywhere in the
+  # argument list. Everything else is positional, exactly as before.
+  local assemble_changelog=1
+  local arg
+  local -a positional=()
+  for arg in "$@"; do
+    case "${arg}" in
+      --no-changelog) assemble_changelog=0 ;;
+      -*)
+        echo "ERROR: unknown option '${arg}'" >&2
+        usage
+        ;;
+      *) positional+=("${arg}") ;;
+    esac
+  done
+  # `${a[@]+"${a[@]}"}` — bash 3.2 treats an empty array as unbound under
+  # `set -u`, and the no-argument case must reach usage(), not a crash.
+  set -- ${positional[@]+"${positional[@]}"}
+
   [[ $# -ne 2 ]] && usage
 
   local crate_dir="$1" level="$2"
@@ -185,8 +228,9 @@ main() {
   # Pre-flight (BEFORE mutating any Cargo.toml): the changelog assembler must
   # exist and be executable. Failing here keeps the repo unmodified rather than
   # leaving it half-bumped (version edited but CHANGELOG never staged).
+  # Skipped under --no-changelog, which never calls the assembler at all.
   local changelog_script="${WORKSPACE_ROOT}/scripts/assemble-changelog.sh"
-  if [[ ! -x "${changelog_script}" ]]; then
+  if [[ "${assemble_changelog}" -eq 1 && ! -x "${changelog_script}" ]]; then
     echo "ERROR: ${changelog_script} is missing or not executable — refusing to" >&2
     echo "       bump ${manifest} to avoid leaving the repo half-bumped." >&2
     exit 1
@@ -210,10 +254,12 @@ main() {
   # re-run this script" warning. Validating first — fragments exist, categories
   # are known, no leftover `## [Unreleased]` section, `[next]` not already cut —
   # means a changelog problem costs nothing to recover from.
-  if ! "${changelog_script}" "${crate_dir}" "${next}" --check; then
-    echo "ERROR: changelog pre-flight failed for crates/${crate_dir}." >&2
-    echo "       Nothing has been modified — fix the fragments and re-run." >&2
-    exit 1
+  if [[ "${assemble_changelog}" -eq 1 ]]; then
+    if ! "${changelog_script}" "${crate_dir}" "${next}" --check; then
+      echo "ERROR: changelog pre-flight failed for crates/${crate_dir}." >&2
+      echo "       Nothing has been modified — fix the fragments and re-run." >&2
+      exit 1
+    fi
   fi
 
   write_package_version "${manifest}" "${current}" "${next}"
@@ -270,8 +316,13 @@ main() {
   # validated this exact operation, so a failure here is unexpected rather than
   # routine — but it is still fatal, and the fragments are left untouched on
   # any failure path inside the assembler.
-  echo "Assembling CHANGELOG section from changelog.d/ fragments ..." >&2
-  "${changelog_script}" "${crate_dir}" "${next}"
+  if [[ "${assemble_changelog}" -eq 1 ]]; then
+    echo "Assembling CHANGELOG section from changelog.d/ fragments ..." >&2
+    "${changelog_script}" "${crate_dir}" "${next}"
+  else
+    echo "Skipping changelog assembly (--no-changelog): crates/${crate_dir}/changelog.d/" >&2
+    echo "fragments are left in place for the release cut to consume." >&2
+  fi
 
   # No duplicate-`## [Unreleased]`-heading stopgap is needed any more. The old
   # one (issue #2793) existed because generate-changelog.sh ran
@@ -282,14 +333,26 @@ main() {
   # while a leftover one survives. The failure mode is not reachable.
 
   # Print — but DO NOT RUN — the manual tag/push commands (human stays in loop).
+  # Under --no-changelog there is no CHANGELOG.md edit to stage and no release
+  # to tag: the bump rides along in the PR that carries the source change, so
+  # naming a tag here would invite one to be cut off an unmerged branch.
   local tag="${prefix}-v${next}"
   echo "" >&2
   echo "Next steps (review, then run these yourself):" >&2
   echo "" >&2
-  echo "  git add crates/${crate_dir}/Cargo.toml crates/${crate_dir}/CHANGELOG.md Cargo.lock" >&2
-  echo "  git commit -m \"chore(release): ${crate_dir} ${next}\"" >&2
-  echo "  git tag ${tag}" >&2
-  echo "  git push origin ${tag}" >&2
+  if [[ "${assemble_changelog}" -eq 1 ]]; then
+    echo "  git add crates/${crate_dir}/Cargo.toml crates/${crate_dir}/CHANGELOG.md Cargo.lock" >&2
+    echo "  git commit -m \"chore(release): ${crate_dir} ${next}\"" >&2
+    echo "  git tag ${tag}" >&2
+    echo "  git push origin ${tag}" >&2
+  else
+    echo "  git add crates/${crate_dir}/Cargo.toml Cargo.lock" >&2
+    echo "  git commit -m \"chore: bump ${crate_dir} to ${next}\"" >&2
+    echo "" >&2
+    echo "No tag: --no-changelog bumps the manifest only. The release cut runs" >&2
+    echo "this script WITHOUT that flag, which assembles the fragments — the" >&2
+    echo "ones this run left in place — and prints the tag commands." >&2
+  fi
 }
 
 main "$@"

--- a/scripts/bump_version_selftest.sh
+++ b/scripts/bump_version_selftest.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+#
+# bump_version_selftest.sh — fixtures for scripts/bump-version.sh's two
+# changelog modes (issue #5674).
+#
+# Why: fragment consumption used to be unconditional and untested, and both
+#   halves of that mattered. On PR #5673 a mid-PR bump ate four in-flight
+#   `changelog.d/` fragments, the per-PR changelog gate then failed the PR for
+#   lacking a fragment the script had just deleted, and the repair was manual
+#   (commit 879b5fe2). The flag that fixes it is only worth having while
+#   something proves BOTH directions still hold — a release cut that stops
+#   assembling would ship a CHANGELOG with no section for the release, which
+#   nothing else checks.
+#
+# What: copies the REAL bump-version.sh and assemble-changelog.sh into a
+#   throwaway workspace (WORKSPACE_ROOT derives from the script's own location,
+#   so a temp `<tmp>/scripts/` + `<tmp>/crates/` tree exercises main() end to
+#   end with zero risk to the checkout), puts a stub `cargo` first on PATH so
+#   the Cargo.lock sync is observed rather than performed, and asserts:
+#
+#     default            version bumped, fragments consumed, `## [0.2.0]`
+#                        section written, tag commands printed
+#     --no-changelog     version bumped, fragments SURVIVE, CHANGELOG.md
+#                        byte-identical, no tag command printed
+#     flag order         `--no-changelog` before the positionals behaves the same
+#     unknown flag       refused with exit 2, manifest untouched
+#     missing assembler  refused under the default, ACCEPTED under
+#                        --no-changelog (that path never calls it)
+#
+#   Same throwaway-workspace pattern as scripts/assemble_changelog_selftest.sh.
+#
+# Test: this IS the test. Run directly:
+#   bash scripts/bump_version_selftest.sh
+#
+# Portability: bash 3.2 (macOS system bash) and bash 5 (Linux CI). POSIX tools
+#   only. Same constraints as the script under test.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/bump-version-selftest.XXXXXX")"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+FAILURES=0
+CASES=0
+
+pass() {
+  CASES=$((CASES + 1))
+  printf '  ok   %s\n' "$1"
+}
+
+fail() {
+  CASES=$((CASES + 1))
+  FAILURES=$((FAILURES + 1))
+  echo "  FAIL: $1"
+}
+
+# assert_eq <label> <expected> <actual>
+assert_eq() {
+  if [ "$2" = "$3" ]; then pass "$1"; else fail "$1: expected '$2', got '$3'"; fi
+}
+
+# assert_contains <label> <needle> <haystack>
+assert_contains() {
+  case "$3" in
+    *"$2"*) pass "$1" ;;
+    *) fail "$1: output does not contain '$2'" ;;
+  esac
+}
+
+# assert_absent <label> <needle> <haystack>
+assert_absent() {
+  case "$3" in
+    *"$2"*) fail "$1: output unexpectedly contains '$2'" ;;
+    *) pass "$1" ;;
+  esac
+}
+
+# A stub `cargo` so the lock sync is observable and costs nothing. The real one
+# would need a workspace manifest and a registry; what this selftest is about is
+# which files the script touches, not what cargo does with them.
+mkdir -p "$TMP_ROOT/bin"
+cat >"$TMP_ROOT/bin/cargo" <<'EOF'
+#!/usr/bin/env bash
+echo "stub cargo $*"
+EOF
+chmod +x "$TMP_ROOT/bin/cargo"
+
+# new_workspace <name> [--no-assembler] — builds a throwaway workspace holding a
+# copy of both scripts and one crate with a single fragment, and prints its root.
+new_workspace() {
+  local name="$1" with_assembler="${2:-with-assembler}"
+  local root="$TMP_ROOT/$name"
+  mkdir -p "$root/scripts" "$root/crates/demo-crate/changelog.d"
+  cp "$SCRIPT_DIR/bump-version.sh" "$root/scripts/bump-version.sh"
+  if [ "$with_assembler" = "with-assembler" ]; then
+    cp "$SCRIPT_DIR/assemble-changelog.sh" "$root/scripts/assemble-changelog.sh"
+    chmod +x "$root/scripts/assemble-changelog.sh"
+  fi
+  cat >"$root/crates/demo-crate/Cargo.toml" <<'EOF'
+[package]
+name = "demo-crate"
+version = "0.1.0"
+edition = "2021"
+EOF
+  cat >"$root/crates/demo-crate/CHANGELOG.md" <<'EOF'
+# Changelog
+
+---
+EOF
+  cat >"$root/crates/demo-crate/changelog.d/5674-in-flight.md" <<'EOF'
+Fixed
+
+- an in-flight bullet that a mid-PR bump must not eat
+EOF
+  echo "$root"
+}
+
+# run_bump <workspace-root> <args...> — runs the copied script with the stub
+# cargo on PATH, then sets RC and OUT in THIS shell. Not a command substitution:
+# a `$(...)` runs in a subshell, so an exit status assigned inside it is lost
+# and every status assertion would read 0.
+RC=0
+OUT=""
+run_bump() {
+  local root="$1"
+  shift
+  RC=0
+  PATH="$TMP_ROOT/bin:$PATH" bash "$root/scripts/bump-version.sh" "$@" \
+    >"$TMP_ROOT/run.out" 2>&1 || RC=$?
+  OUT="$(cat "$TMP_ROOT/run.out")"
+}
+
+manifest_version() {
+  grep -m1 -E '^version[[:space:]]*=' "$1/crates/demo-crate/Cargo.toml" |
+    sed -E 's/^version[[:space:]]*=[[:space:]]*"([^"]*)".*/\1/'
+}
+
+fragment_count() {
+  find "$1/crates/demo-crate/changelog.d" -name '*.md' | grep -c . || true
+}
+
+# ---------------------------------------------------------------------------
+# The release cut: unchanged behaviour, and the half that must never regress.
+# ---------------------------------------------------------------------------
+echo "default (release cut):"
+ws="$(new_workspace default)"
+run_bump "$ws" demo-crate minor
+assert_eq "exits 0" "0" "$RC"
+assert_eq "version bumped" "0.2.0" "$(manifest_version "$ws")"
+assert_eq "fragment consumed" "0" "$(fragment_count "$ws")"
+assert_contains "CHANGELOG gained the section" "## [0.2.0]" \
+  "$(cat "$ws/crates/demo-crate/CHANGELOG.md")"
+assert_contains "the bullet survived into the section" "an in-flight bullet" \
+  "$(cat "$ws/crates/demo-crate/CHANGELOG.md")"
+assert_contains "Cargo.lock sync ran" "stub cargo update -p demo-crate --precise 0.2.0" "$OUT"
+assert_contains "prints the tag command" "git tag demo-crate-v0.2.0" "$OUT"
+
+# ---------------------------------------------------------------------------
+# The #5674 case: a bump riding along with its source change.
+# ---------------------------------------------------------------------------
+echo "--no-changelog (bump inside a source PR):"
+ws="$(new_workspace noassemble)"
+before="$(cat "$ws/crates/demo-crate/CHANGELOG.md")"
+run_bump "$ws" demo-crate minor --no-changelog
+assert_eq "exits 0" "0" "$RC"
+assert_eq "version bumped" "0.2.0" "$(manifest_version "$ws")"
+assert_eq "fragment survives" "1" "$(fragment_count "$ws")"
+assert_eq "CHANGELOG.md byte-identical" "$before" \
+  "$(cat "$ws/crates/demo-crate/CHANGELOG.md")"
+assert_contains "Cargo.lock sync still ran" "stub cargo update -p demo-crate --precise 0.2.0" "$OUT"
+assert_contains "says why nothing was assembled" "Skipping changelog assembly" "$OUT"
+# A tag cut from an unmerged branch is the hazard this suppression exists for.
+assert_absent "prints no tag command" "git tag" "$OUT"
+
+echo "flag order:"
+ws="$(new_workspace flagfirst)"
+run_bump "$ws" --no-changelog demo-crate minor
+assert_eq "exits 0 with the flag first" "0" "$RC"
+assert_eq "fragment survives" "1" "$(fragment_count "$ws")"
+
+echo "unknown flag:"
+ws="$(new_workspace badflag)"
+run_bump "$ws" demo-crate minor --no-changelogs
+assert_eq "exits 2" "2" "$RC"
+assert_eq "manifest untouched" "0.1.0" "$(manifest_version "$ws")"
+assert_contains "names the offending option" "unknown option '--no-changelogs'" "$OUT"
+
+# ---------------------------------------------------------------------------
+# The assembler pre-flight is gated on the mode that uses it, not on nothing.
+# ---------------------------------------------------------------------------
+echo "missing assembler:"
+ws="$(new_workspace noassembler no-assembler)"
+run_bump "$ws" demo-crate minor
+assert_eq "default refuses" "1" "$RC"
+assert_eq "manifest untouched" "0.1.0" "$(manifest_version "$ws")"
+
+ws="$(new_workspace noassembler2 no-assembler)"
+run_bump "$ws" demo-crate minor --no-changelog
+assert_eq "--no-changelog proceeds without it" "0" "$RC"
+assert_eq "version bumped" "0.2.0" "$(manifest_version "$ws")"
+
+echo ""
+if [ "$FAILURES" -eq 0 ]; then
+  echo "bump_version_selftest: ${CASES} case(s), all pass"
+  exit 0
+fi
+echo "bump_version_selftest: ${FAILURES} of ${CASES} case(s) FAILED" >&2
+exit 1

--- a/scripts/check-ci-helpers-selftest.sh
+++ b/scripts/check-ci-helpers-selftest.sh
@@ -114,6 +114,32 @@ assert_eq "notify classifies the doctest result directly (#5998)" "1" \
 assert_eq "a cancelled shard is not laundered into red (#5998)" "1" \
   "$(grep -cF "needs['test-shard'].result == 'cancelled'" <<<"${notify_job}" || true)"
 
+# #5657: `notify-main-failure`'s `needs:` cannot name a job in another workflow
+# file, so `test-pointers.yml` was invisible to it — the doc-pointer lint sat red
+# on main for over 24 hours (runs 31587713536 to 31688534235) and no
+# `ci-red-main` issue was ever filed. That workflow now carries its own notifier,
+# on the same label and through the same classifier. Asserted by grep for the
+# same reason the ci.yml wiring above is: the script being correct proves
+# nothing while no workflow calls it.
+pointers_notify="$(sed -n '/^  notify-main-failure:/,$p' .github/workflows/test-pointers.yml)"
+assert_eq "test-pointers.yml has its own notifier (#5657)" "1" \
+  "$(grep -c '^  notify-main-failure:$' .github/workflows/test-pointers.yml || true)"
+assert_eq "it waits on the lint job itself" "1" \
+  "$(grep -cF "needs: [test-pointers]" <<<"${pointers_notify}" || true)"
+assert_eq "it classifies through classify-ci-results.sh" "1" \
+  "$(grep -c 'bash scripts/classify-ci-results\.sh' <<<"${pointers_notify}" || true)"
+assert_eq "it feeds the lint's own conclusion, unlaundered" "1" \
+  "$(grep -cF "test-pointers=\${{ needs['test-pointers'].result }}" <<<"${pointers_notify}" || true)"
+assert_eq "it files on the same ci-red-main label" "1" \
+  "$(grep -cF "const label = 'ci-red-main';" <<<"${pointers_notify}" || true)"
+# `always()` or the notifier itself is skipped by the very failure it reports.
+assert_eq "it runs even when the lint did not succeed" "1" \
+  "$(grep -c "if: always() && github.event_name == 'push'" <<<"${pointers_notify}" || true)"
+# And the run's own conclusion must follow the verdict, the same rule ci.yml's
+# notifier enforces — otherwise a cancelled lint still ends the run green.
+assert_eq "it fails the run on a non-green verdict" "1" \
+  "$(grep -c 'Fail this job on any non-green verdict' <<<"${pointers_notify}" || true)"
+
 # ---------------------------------------------------------------------------
 # detect-docs-only.sh
 # ---------------------------------------------------------------------------
@@ -256,8 +282,13 @@ EOF
 # run_gate <dir> <stub> [base-ref]  — base defaults to the `base-ref` branch.
 run_gate() {
   local dir="$1" stub="$2" base="${3:-base-ref}"
-  mkdir -p "${dir}/scripts"
+  # #5765: the gate sources scripts/lib/source_class.sh from its OWN directory,
+  # so the library travels with it into the throwaway repo. Copying the gate
+  # alone leaves it unable to start, and every case that expects exit 0 fails
+  # for a reason that has nothing to do with what it is testing.
+  mkdir -p "${dir}/scripts/lib"
   cp scripts/check-pr-version-bump.sh "${dir}/scripts/check-pr-version-bump.sh"
+  cp scripts/lib/source_class.sh "${dir}/scripts/lib/source_class.sh"
   (
     cd "${dir}" &&
       PR_VERSION_BUMP_BASE="${base}" \
@@ -757,16 +788,40 @@ pr_trigger_block() {
   ' "$1"
 }
 
-for wf in .github/workflows/test-pointers.yml .github/workflows/semver-checks.yml; do
-  assert_eq "${wf##*/}: pull_request trigger has no paths filter" "0" \
+# One job's block: from `  <name>:` to the next job at the same indent. Scoping
+# matters since #5657 gave test-pointers.yml a SECOND job — a notifier whose
+# job-level `if:` is required (it must run on push-to-main only, and never on a
+# PR). Counting `    if:` across the whole file would read that as the banned
+# thing. The ban is about the GATE job, which is a required context and must
+# never conclude `skipped`.
+job_block() {
+  awk -v job="  $2:" '
+    $0 == job { inblk = 1; next }
+    inblk && /^  [^[:space:]]/ { exit }
+    inblk { print }
+  ' "$1"
+}
+
+for entry in "test-pointers.yml test-pointers" "semver-checks.yml semver-checks"; do
+  # shellcheck disable=SC2086  # two fields, both known-safe literals
+  set -- ${entry}
+  wf=".github/workflows/$1"
+  gate="$(job_block "${wf}" "$2")"
+  assert_eq "$1: pull_request trigger has no paths filter" "0" \
     "$(grep -cE '^    paths(-ignore)?:' <<<"$(pr_trigger_block "${wf}")" || true)"
   # `    if:` at four-space indent is a JOB-level condition; step-level ones are
   # indented six and are the prescribed mechanism, so they must not be counted.
-  assert_eq "${wf##*/}: no job-level if: can skip the gate" "0" \
-    "$(grep -cE '^    if:' "${wf}" || true)"
-  assert_eq "${wf##*/}: has a no-op step that reports success" "1" \
-    "$(grep -cE "^      - name: No .* — nothing to (lint|compare)$" "${wf}" || true)"
+  assert_eq "$1: no job-level if: can skip the gate" "0" \
+    "$(grep -cE '^    if:' <<<"${gate}" || true)"
+  assert_eq "$1: has a no-op step that reports success" "1" \
+    "$(grep -cE "^      - name: No .* — nothing to (lint|compare)$" <<<"${gate}" || true)"
 done
+
+# The other half of that scoping: every job-level `if:` left in
+# test-pointers.yml belongs to the notifier, so the ban above cannot be evaded
+# by moving a condition onto a new job.
+assert_eq "test-pointers.yml: only the notifier carries a job-level if:" "1" \
+  "$(grep -cE '^    if:' .github/workflows/test-pointers.yml || true)"
 
 assert_eq "semver-checks runs on pull requests at all" "1" \
   "$(grep -c '^  pull_request:' .github/workflows/semver-checks.yml || true)"

--- a/scripts/check-pr-version-bump.sh
+++ b/scripts/check-pr-version-bump.sh
@@ -30,6 +30,13 @@
 #        still goes red, which is the cost #4421 is about. (The louder half
 #        landed anyway — see ci.yml's notify job, #4179.)
 #
+# SOURCE CLASSIFICATION (#5765): what counts as `crates/<X>/src/**` is
+#   `scripts/lib/source_class.sh`, shared with
+#   `scripts/check_changelog_fragment.sh`. Read that file's THE RULING section
+#   before changing this gate's reach — it records why this gate counts a test
+#   file as source and the changelog gate does not, which is the disagreement
+#   the shared definition exists to keep deliberate.
+#
 # What: for every crate whose `crates/<X>/src/**` changed between the merge
 #   base and HEAD:
 #     - crate absent at HEAD (deleted by the PR)  -> SKIP
@@ -79,11 +86,15 @@
 # Test: scripts/check-ci-helpers-selftest.sh (`check-pr-version-bump:` cases)
 #   exercises the crate-extraction and version-decision logic against synthetic
 #   diffs with the registry lookup stubbed; the live crates.io path is covered
-#   by running this script against a real branch (see the #4421 PR body).
+#   by running this script against a real branch (see the #4421 PR body). The
+#   shared path classification has its own fixtures in
+#   scripts/check_source_class_selftest.sh.
 
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=lib/source_class.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib/source_class.sh"
 cd "${REPO_ROOT}"
 
 BASE="${PR_VERSION_BUMP_BASE:-origin/main}"
@@ -173,10 +184,18 @@ main() {
     return 1
   fi
 
+  # #5765: the definition of "crate source" is `scripts/lib/source_class.sh`,
+  # shared with scripts/check_changelog_fragment.sh. This gate applies
+  # `is_crate_src_path` ALONE and does NOT exempt test files: a crates.io
+  # tarball ships them, so editing one under an already-published version is
+  # the drift this gate exists to catch. That ruling, and why the changelog
+  # gate applies the opposite one to the same path, are recorded in that file.
   touched="$(
-    grep -E '^crates/[^/]+/src/' <<<"${changed}" |
-      cut -d/ -f2 |
-      sort -u
+    while IFS= read -r path; do
+      [ -n "${path}" ] || continue
+      is_crate_src_path "${path}" || continue
+      crate_of_src_path "${path}"
+    done <<<"${changed}" | sort -u
   )" || true
 
   if [ -z "${touched}" ]; then

--- a/scripts/check_changelog_attribution_selftest.sh
+++ b/scripts/check_changelog_attribution_selftest.sh
@@ -112,9 +112,12 @@ g() { git -C "$REPO" "$@"; }
 #   - every non-source shape the gate must keep ignoring
 # plus a second crate (`doomed`) that a later case dissolves.
 # ---------------------------------------------------------------------------
-mkdir -p "$REPO/scripts"
+mkdir -p "$REPO/scripts/lib"
 cp "$GATE_SOURCE" "$REPO/scripts/check_changelog_fragment.sh"
 cp "$SCRIPT_DIR/assemble-changelog.sh" "$REPO/scripts/"
+# #5765: the gate sources its path classification from `scripts/lib/` beside
+# itself, so the library travels with it into the synthetic repo.
+cp "$SCRIPT_DIR/lib/source_class.sh" "$REPO/scripts/lib/"
 
 new_crate() {
   local name="$1" dir="$REPO/crates/$1"

--- a/scripts/check_changelog_base_selftest.sh
+++ b/scripts/check_changelog_base_selftest.sh
@@ -62,9 +62,12 @@ g() { git -C "$REPO" "$@"; }
 # Fixture: two crates, a branch that touches only crate-a, and a release on
 # main that changes crate-b's source and CONSUMES its fragments.
 # ---------------------------------------------------------------------------
-mkdir -p "$REPO/scripts"
+mkdir -p "$REPO/scripts/lib"
 cp "$SCRIPT_DIR/check_changelog_fragment.sh" "$REPO/scripts/"
 cp "$SCRIPT_DIR/assemble-changelog.sh" "$REPO/scripts/"
+# #5765: the gate sources its path classification from `scripts/lib/` beside
+# itself, so the library travels with it into the synthetic repo.
+cp "$SCRIPT_DIR/lib/source_class.sh" "$REPO/scripts/lib/"
 
 new_crate() {
   local name="$1" dir="$REPO/crates/$1"

--- a/scripts/check_changelog_fragment.sh
+++ b/scripts/check_changelog_fragment.sh
@@ -18,7 +18,11 @@
 #   only that a NESTED one (`crates/trusty-audit/ui/src-tauri/src/main.rs`,
 #   `crates/trusty-agents/ui/src/App.svelte`) is now attributed to the crate that
 #   ships it instead of being silently dropped. See ATTRIBUTION BY STRUCTURE.
-#   Accepted evidence, per crate:
+#   Test files under src/** are EXEMPT, and what counts as one is
+#   `scripts/lib/source_class.sh` — shared with
+#   `scripts/check-pr-version-bump.sh`, which reads the same definition and
+#   deliberately does not apply the exemption (#5765; the ruling is in that
+#   file). Accepted evidence, per crate:
 #     1. an ADDED-or-MODIFIED `crates/<crate>/changelog.d/<name>.md` fragment
 #        that the release assembler ACCEPTS                        (the rule)
 #     2. a `crates/<crate>/CHANGELOG.md` edit that adds a bullet   (TRANSITIONAL)
@@ -140,8 +144,9 @@
 #   scripts/check_changelog_attribution_selftest.sh replays the #4576 shape:
 #   a nested crate source path must be attributed, not dropped, and an
 #   unattributable one must fail the gate. Fragment validation is covered by
-#   scripts/assemble_changelog_selftest.sh and the scan floor by
-#   scripts/check_scan_floor_selftest.sh.
+#   scripts/assemble_changelog_selftest.sh, the scan floor by
+#   scripts/check_scan_floor_selftest.sh, and the shared test-file
+#   classification by scripts/check_source_class_selftest.sh.
 #
 # Portability: bash 3.2 (macOS system bash) and bash 5 (Linux CI). POSIX tools
 #   only — `git`, `grep`, `sed`, `sort`.
@@ -149,6 +154,11 @@
 set -euo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
+# The shared source/test path classification (#5765). Sourced from this script's
+# OWN directory, not from $REPO_ROOT, so a copy of the gate run out of tree
+# picks up the library beside it rather than a different checkout's.
+# shellcheck source=lib/source_class.sh
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/source_class.sh"
 cd "$REPO_ROOT"
 
 BASE="${CHANGELOG_GATE_BASE:-origin/main}"
@@ -286,22 +296,14 @@ else
   TRANSITIONAL=1
 fi
 
-# Why: a test-only edit under src/** has no user-visible change to describe.
-# Classification is copied from check_line_cap.sh so the two gates agree on what
-# "a test file" means.
-# What: returns 0 when $1 is a test/benchmark path.
-is_test_path() {
-  local path="$1" base
-  base="$(basename "$path")"
-  [[ "$base" == "tests.rs" ]] && return 0
-  case "$base" in
-    *_test.rs | *_tests.rs) return 0 ;;
-  esac
-  case "$path" in
-    */tests/* | */benches/* | */testdata/*) return 0 ;;
-  esac
-  return 1
-}
+# #5765: `is_test_path` used to be a private copy here, and
+# scripts/check-pr-version-bump.sh carried a different match with no test arm at
+# all — so the two gates disagreed about the same path and nothing recorded
+# which was meant to. Both now read the definition from
+# scripts/lib/source_class.sh, whose THE RULING section states why this gate
+# EXEMPTS a test file (a test-only edit has no user-visible change to describe)
+# while the version-bump gate counts one as source (a crates.io tarball ships
+# it). Sourced above with the rest of this gate's setup.
 
 # #4576: attribute a source path to its crate by STRUCTURE, not by path depth.
 #

--- a/scripts/check_scan_floor_selftest.sh
+++ b/scripts/check_scan_floor_selftest.sh
@@ -244,7 +244,7 @@ fi
 # ===========================================================================
 if want changelog_fragment; then
   f="$(new_fixture)"
-  install_gate "$f" check_changelog_fragment.sh
+  install_gate "$f" check_changelog_fragment.sh lib
   echo "placeholder" > "$f/README.md"
   git -C "$f" add -A && git -C "$f" commit -qm fixture
   expect_rejects "check_changelog_fragment.sh (0 changed paths)" "$f" \
@@ -260,7 +260,7 @@ fi
 # ===========================================================================
 if want pr_version_bump; then
   f="$(new_fixture)"
-  install_gate "$f" check-pr-version-bump.sh
+  install_gate "$f" check-pr-version-bump.sh lib
   echo "placeholder" > "$f/README.md"
   git -C "$f" add -A && git -C "$f" commit -qm fixture
   expect_rejects "check-pr-version-bump.sh (0 changed paths)" "$f" \
@@ -311,7 +311,7 @@ fi
 # ===========================================================================
 if want changelog_fragment_tool_error; then
   f="$(new_fixture)"
-  install_gate "$f" check_changelog_fragment.sh
+  install_gate "$f" check_changelog_fragment.sh lib
   mkdir -p "$f/crates/demo/src" "$f/scripts"
   echo "placeholder" > "$f/README.md"
   printf '[package]\nname = "demo"\n' > "$f/crates/demo/Cargo.toml"

--- a/scripts/check_source_class_selftest.sh
+++ b/scripts/check_source_class_selftest.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+#
+# check_source_class_selftest.sh — fixtures for the shared source/test path
+# classification in scripts/lib/source_class.sh (issue #5765).
+#
+# Why: this library exists because two gates classified the same path two ways
+#   and neither carried a test that said what the right answer was. A shared
+#   definition with no fixtures would be the same defect with one fewer copy —
+#   the next edit to `is_test_path` silently changes what both gates do. It also
+#   asserts the WIRING: a gate that quietly grows a private copy again puts the
+#   repo back where #5765 found it, and only a grep can see that.
+#
+# What: three groups.
+#   is_test_path       every shape that qualifies, and the near-misses that must
+#                      not (`tests_helper.rs`, `contests/`, `src/testdata.rs`)
+#   is_crate_src_path  the depth-1 shape, and the nested/adjacent paths that are
+#                      deliberately outside it
+#   wiring             both gates source the library; neither redefines it
+#
+# Usage: bash scripts/check_source_class_selftest.sh
+# Exit: 0 when every case matches; 1 listing each mismatch.
+#
+# Portability: bash 3.2 (macOS system bash) and bash 5 (Linux CI), same as the
+#   library under test.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+# shellcheck source=lib/source_class.sh
+. "${REPO_ROOT}/scripts/lib/source_class.sh"
+
+FAILURES=0
+CASES=0
+
+# assert <label> <expected: yes|no> <actual-exit-status>
+assert() {
+  local label="$1" want="$2" rc="$3" got
+  CASES=$((CASES + 1))
+  if [ "$rc" -eq 0 ]; then got="yes"; else got="no"; fi
+  if [ "$got" = "$want" ]; then
+    printf '  ok   %-58s -> %s\n' "$label" "$got"
+  else
+    FAILURES=$((FAILURES + 1))
+    echo "  FAIL: $label: expected '$want', got '$got'"
+  fi
+}
+
+test_path() {
+  local path="$1" want="$2" rc=0
+  is_test_path "$path" || rc=$?
+  assert "is_test_path $path" "$want" "$rc"
+}
+
+src_path() {
+  local path="$1" want="$2" rc=0
+  is_crate_src_path "$path" || rc=$?
+  assert "is_crate_src_path $path" "$want" "$rc"
+}
+
+echo "is_test_path:"
+test_path "crates/trusty-review/src/report/reporter_tests.rs" yes
+test_path "crates/trusty-common/src/embedder/mod_test.rs" yes
+test_path "crates/trusty-mpm/src/session/tests.rs" yes
+test_path "crates/trusty-search/src/index/tests/fixture.rs" yes
+test_path "crates/trusty-search/benches/query.rs" yes
+test_path "crates/trusty-audit/src/testdata/report.json" yes
+# The near-misses. Each is production code whose NAME merely resembles a test
+# file; classifying one as a test would exempt a real change from the changelog
+# gate, which is the direction that loses coverage.
+test_path "crates/trusty-mpm/src/session/tests_helper.rs" no
+test_path "crates/trusty-mpm/src/testdata.rs" no
+test_path "crates/trusty-mpm/src/contests/mod.rs" no
+test_path "crates/trusty-mpm/src/lib.rs" no
+test_path "crates/trusty-mpm/src/attest.rs" no
+
+echo "is_crate_src_path:"
+src_path "crates/trusty-mpm/src/lib.rs" yes
+src_path "crates/trusty-mpm/src/a/b/c.rs" yes
+src_path "crates/trusty-review/src/report/reporter_tests.rs" yes
+# NESTED members are deliberately outside this predicate — `cargo package`
+# excludes a nested package from its parent's tarball, so a nested edit is not
+# drift against the parent's published version. scripts/check_changelog_fragment.sh
+# reaches them by structural attribution instead (#4576).
+src_path "crates/trusty-audit/ui/src-tauri/src/main.rs" no
+src_path "crates/trusty-agents/ui/src/App.svelte" no
+# Adjacent shapes that must not read as crate source.
+src_path "crates/trusty-mpm/Cargo.toml" no
+src_path "crates/trusty-mpm/changelog.d/1-x.md" no
+src_path "crates/trusty-mpm/srcx/a.rs" no
+src_path "crates/trusty-mpm/src" no
+src_path "crates/trusty-mpm" no
+src_path "docs/reference/crate-map.md" no
+src_path "scripts/bump-version.sh" no
+src_path "" no
+
+echo "crate_of_src_path:"
+CASES=$((CASES + 1))
+got="$(crate_of_src_path "crates/trusty-review/src/report/reporter_tests.rs" 2>/dev/null)"
+if [ "$got" = "trusty-review" ]; then
+  printf '  ok   %-58s -> %s\n' "names the top-level crate" "$got"
+else
+  FAILURES=$((FAILURES + 1))
+  echo "  FAIL: crate_of_src_path: expected 'trusty-review', got '$got'"
+fi
+
+CASES=$((CASES + 1))
+if crate_of_src_path "docs/x.md" >/dev/null 2>&1; then
+  FAILURES=$((FAILURES + 1))
+  echo "  FAIL: crate_of_src_path accepted a non-source path"
+else
+  printf '  ok   %-58s -> %s\n' "refuses a non-source path" "no"
+fi
+
+# ---------------------------------------------------------------------------
+# Wiring. The library is only a fix while both gates actually read it.
+# ---------------------------------------------------------------------------
+echo "wiring:"
+wiring() {
+  local label="$1" want="$2" got="$3"
+  CASES=$((CASES + 1))
+  if [ "$got" = "$want" ]; then
+    printf '  ok   %-58s -> %s\n' "$label" "$got"
+  else
+    FAILURES=$((FAILURES + 1))
+    echo "  FAIL: $label: expected '$want', got '$got'"
+  fi
+}
+
+# The `.` line itself, not a mention of the filename in a comment.
+wiring "check-pr-version-bump.sh sources the library" "1" \
+  "$(grep -c '^\. .*lib/source_class\.sh"$' scripts/check-pr-version-bump.sh || true)"
+wiring "check_changelog_fragment.sh sources the library" "1" \
+  "$(grep -c '^\. .*lib/source_class\.sh"$' scripts/check_changelog_fragment.sh || true)"
+# A private redefinition is how the two definitions drifted apart in the first
+# place, so neither gate may declare one of its own again.
+wiring "check-pr-version-bump.sh defines no is_test_path" "0" \
+  "$(grep -c '^is_test_path()' scripts/check-pr-version-bump.sh || true)"
+wiring "check_changelog_fragment.sh defines no is_test_path" "0" \
+  "$(grep -c '^is_test_path()' scripts/check_changelog_fragment.sh || true)"
+wiring "check-pr-version-bump.sh keeps no private src/ regex" "0" \
+  "$(grep -c 'crates/\[\^/\]+/src/' scripts/check-pr-version-bump.sh || true)"
+
+echo ""
+if [ "$FAILURES" -eq 0 ]; then
+  echo "check_source_class_selftest: ${CASES} case(s), all pass"
+  exit 0
+fi
+echo "check_source_class_selftest: ${FAILURES} of ${CASES} case(s) FAILED" >&2
+exit 1

--- a/scripts/lib/source_class.sh
+++ b/scripts/lib/source_class.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+#
+# source_class.sh — the one definition of "crate source" and "test file" that
+# the release-adjacent gates share (issue #5765).
+#
+# Why: two gates that run on nearly every PR classified the SAME path
+# differently, and nothing said which was meant to govern.
+# `scripts/check-pr-version-bump.sh` matched `^crates/[^/]+/src/` with no test
+# exemption; `scripts/check_changelog_fragment.sh` carried its own copy of a
+# test-file match and exempted those paths. PR #5764 edited
+# `crates/trusty-review/src/report/reporter_tests.rs` and hit both readings at
+# once: the version-bump gate demanded a 0.17.0 -> 0.18.0 bump while the
+# changelog gate said no fragment was owed. Neither answer is wrong on its own.
+# What was wrong is that the two definitions lived in two places and could drift
+# without anyone deciding they should.
+#
+# What: three predicates, and the ruling on which gate applies which.
+#
+#   is_test_path <path>       test / benchmark / testdata file
+#   is_crate_src_path <path>  crates/<crate>/src/**, exactly one level under
+#                             crates/
+#   crate_of_src_path <path>  the <crate> of such a path, on stdout
+#
+# THE RULING (#5765). The two gates ask different questions, so they apply
+# different predicates — deliberately, and stated here rather than implied by
+# two independent regexes:
+#
+#   check-pr-version-bump.sh  applies is_crate_src_path ALONE. A crates.io
+#                             tarball ships a crate's test files, so editing one
+#                             under an already-published version is exactly the
+#                             drift that gate exists to catch. A test-only edit
+#                             legitimately earns a version bump.
+#   check_changelog_fragment.sh  applies is_crate_src_path AND is_test_path. A
+#                             fragment describes a user-visible change, and a
+#                             test-only edit has none to describe.
+#
+# So a test file under src/ IS crate source and is NOT a user-visible change.
+# Both gates now say that in the same words.
+#
+# SCOPE, honestly. This file holds the definitions, not every path each gate
+# reaches. `check_changelog_fragment.sh` additionally attributes NESTED crate
+# members (`crates/trusty-audit/ui/src-tauri/src/**`) by walking up to the
+# nearest Cargo.toml (#4576); `check-pr-version-bump.sh` deliberately does not,
+# because `cargo package` excludes a nested package from its parent's tarball,
+# so a nested edit is not drift against the parent's published version. That
+# difference is about REACH and stays in the gates. `is_crate_src_path` is the
+# depth-1 shape both agree on.
+#
+# `scripts/check_line_cap.sh` keeps its own `cap_for_path`, which is not this
+# question: it decides which SLOC cap a file gets, has no `testdata/` arm, and
+# runs against every tracked `.rs` file rather than a diff.
+#
+# Portability: bash 3.2 (macOS system bash) and bash 5 (Linux CI). Parameter
+# expansion and `case` only — no external commands, so this is cheap to call
+# once per changed path.
+#
+# Usage: `. "$(dirname "${BASH_SOURCE[0]}")/lib/source_class.sh"` from a script
+# in scripts/. Defines functions only; sets no variables and runs nothing.
+#
+# Test: scripts/check_source_class_selftest.sh, which also asserts that both
+# gates still source this file rather than growing a private copy again.
+
+# is_test_path <path> — 0 when the path is a test, benchmark, or testdata file.
+#
+# A file qualifies when its basename is `tests.rs`, ends `_test.rs` or
+# `_tests.rs`, or when any directory segment is `tests/`, `benches/`, or
+# `testdata/`. Language-agnostic on purpose: the changelog gate sees non-Rust
+# fixtures under `testdata/` too.
+is_test_path() {
+  local path="$1" base
+  base="${path##*/}"
+  case "$base" in
+    tests.rs | *_test.rs | *_tests.rs) return 0 ;;
+  esac
+  case "$path" in
+    */tests/* | */benches/* | */testdata/*) return 0 ;;
+  esac
+  return 1
+}
+
+# is_crate_src_path <path> — 0 when the path is `crates/<crate>/src/<...>`.
+#
+# `case` globs let `*` span `/`, which is how a nested member's source once
+# slipped through a pattern meant for depth 1 (#4576). The check is written as
+# a strip-and-compare so exactly one directory level sits under `crates/`.
+is_crate_src_path() {
+  local path="$1" rest crate sub
+  case "$path" in
+    crates/*) rest="${path#crates/}" ;;
+    *) return 1 ;;
+  esac
+  crate="${rest%%/*}"
+  # Empty means `crates//…`; equal means `crates/<name>` with nothing under it.
+  [ -n "$crate" ] || return 1
+  [ "$crate" != "$rest" ] || return 1
+  sub="${rest#*/}"
+  case "$sub" in
+    src/?*) return 0 ;;
+  esac
+  return 1
+}
+
+# crate_of_src_path <path> — prints the crate directory name, or fails.
+crate_of_src_path() {
+  local path="$1" rest
+  is_crate_src_path "$path" || return 1
+  rest="${path#crates/}"
+  printf '%s\n' "${rest%%/*}"
+}

--- a/website/src/lib/changelog/README.md
+++ b/website/src/lib/changelog/README.md
@@ -52,6 +52,13 @@ sections are populated.
 Every finding in a build is collected and reported together, one per line, as
 `FAIL <CODE> <file>:<line>: <problem> — <remedy>`.
 
+One code is NON-fatal. It is written to the build log as
+`WARN <CODE> <file>:<line>: <problem> — <remedy>` and never throws:
+
+| Code                           | Fires when                                                        |
+| ------------------------------ | ----------------------------------------------------------------- |
+| `CHANGELOG-ROOT-RELATIVE-LINK` | A link resolved against the repository root, not beside the file. |
+
 ## Links inside changelog prose
 
 A relative link in a changelog (`[spec](../../docs/specs/foo.md)`) is written to
@@ -74,6 +81,27 @@ zero failures reported. That falsifies the only guarantee this gate offers — a
 green build means every link resolved AS WRITTEN. The one real off-by-one in the
 corpus (`crates/trusty-mpm/CHANGELOG.md` line 1982) was corrected at the source
 instead, which is what a typo deserves.
+
+**The one second reading there is, and its three limits.** A bare path carrying
+a directory — `docs/adr/0043-cargo-bin-policy.md`, no leading `./` or `../` —
+that resolves to nothing beside the changelog is tried again against the
+repository ROOT. A fragment author writes that shape meaning the repo root, and
+refusing it took every Vercel deploy down from `d1774c81` on (issue #5640).
+
+It is a second reading, never a guess:
+
+1. **The changelog-relative reading wins wherever it resolves.** The fallback
+   only runs where the first reading found nothing, so no link that already
+   worked can change meaning.
+2. **A bare FILENAME gets no fallback at all.** `README.md`, `LICENSE` and
+   `CHANGELOG.md` exist at the repository root AND in most crate directories, so
+   a crate-local `[readme](README.md)` would silently repoint at the root twin
+   the day the crate file is renamed. Those stay `CHANGELOG-BAD-LINK`.
+3. **Every fallback that fires is logged** as `CHANGELOG-ROOT-RELATIVE-LINK`,
+   naming both candidates. A link whose base the build chose is never silent.
+
+An escaping link (`../../../README.md`) is still refused before any of this — the
+paragraph above is unchanged by it.
 
 ## The one thing that recovers instead of failing
 

--- a/website/src/lib/changelog/errors.ts
+++ b/website/src/lib/changelog/errors.ts
@@ -21,6 +21,21 @@ import { formatFailure, type DocFailure } from '../docs/errors';
 /** One build-stopping finding in a crate's `CHANGELOG.md`. */
 export type ChangelogFailure = DocFailure;
 
+/**
+ * Why: one resolution decision is neither clean nor fatal — the repo-root link
+ * fallback (#5640) accepts a link the changelog's own directory cannot resolve.
+ * Failing it would undo that fix; passing it in silence would let a renamed
+ * crate-local file hand its link to a same-named root file with a green build.
+ * A warning is the only honest report of "accepted, and here is what I decided".
+ *
+ * What: the same record shape as a failure, so it renders identically in a build
+ * log, carried on a separate channel that never throws.
+ *
+ * Test: `parse.test.ts` (`records a warning whenever the repo-root fallback
+ * fires`), `site.test.ts` (the build logs them and stays green).
+ */
+export type ChangelogWarning = DocFailure;
+
 /** Every code this gate can emit, with what provokes it. */
 export const CHANGELOG_CODES = {
 	/** The crate's `CHANGELOG.md` is absent or unreadable. */
@@ -34,6 +49,29 @@ export const CHANGELOG_CODES = {
 	/** A link in the prose points somewhere this site cannot send a reader. */
 	BAD_LINK: 'CHANGELOG-BAD-LINK'
 } as const;
+
+/** Every NON-fatal code. Reported in the build log; never throws. */
+export const CHANGELOG_WARNING_CODES = {
+	/** A link resolved only against the repository root, not beside the file. */
+	ROOT_RELATIVE_LINK: 'CHANGELOG-ROOT-RELATIVE-LINK'
+} as const;
+
+/**
+ * Why: SvelteKit gives a build no reporting channel but the log, and a warning
+ * nobody prints is a warning that does not exist.
+ * What: one line per warning, same fields and order as `formatFailure` but
+ * prefixed `WARN` — that formatter hardcodes `FAIL`, and a build that did not
+ * fail must not print the word. A no-op on an empty list.
+ */
+export function formatWarning(warning: ChangelogWarning): string {
+	const location = warning.line === undefined ? warning.file : `${warning.file}:${warning.line}`;
+	return `WARN ${warning.code} ${location}: ${warning.problem} — ${warning.remedy}`;
+}
+
+/** Writes every warning to the build log. A no-op on an empty list. */
+export function reportWarnings(warnings: readonly ChangelogWarning[]): void {
+	for (const warning of warnings) console.warn(formatWarning(warning));
+}
 
 /**
  * Why: SvelteKit surfaces a thrown error's `message` in the build log and

--- a/website/src/lib/changelog/parse.test.ts
+++ b/website/src/lib/changelog/parse.test.ts
@@ -313,6 +313,68 @@ describe('links and metavariables inside an item', () => {
 		);
 	});
 
+	/**
+	 * The collision the #5640 fallback would otherwise open. `README.md`,
+	 * `LICENSE` and `CHANGELOG.md` each exist at the repo root AND in most crate
+	 * directories (22, 19 and 27 of them). So a crate-local `[readme](README.md)`
+	 * that used to resolve beside the changelog would silently repoint at the
+	 * ROOT twin the day the crate file is renamed — a green build shipping a link
+	 * to the wrong document. A bare filename gets no second reading at all.
+	 */
+	it('refuses a bare filename rather than repointing it at the repo root', () => {
+		const { failures, releases } = withProbe(item('[readme](README.md)'), ['README.md']);
+		expect(failures).toHaveLength(1);
+		expect(failures[0].code).toBe('CHANGELOG-BAD-LINK');
+		expect(failures[0].problem).toContain('crates/trusty-mpm/README.md');
+		expect(releases[0].categories[0].items[0].html).not.toContain('blob/main');
+	});
+
+	// The same rule after normalisation, so `docs/../README.md` cannot smuggle a
+	// bare filename past the check by carrying a slash.
+	it('refuses a path that normalises to a bare filename', () => {
+		const { failures } = withProbe(item('[readme](docs/../README.md)'), ['README.md']);
+		expect(failures).toHaveLength(1);
+		expect(failures[0].code).toBe('CHANGELOG-BAD-LINK');
+	});
+
+	// The fallback is a resolution decision the build makes on the author's
+	// behalf, so it is never silent: a warning names the file, the line, and both
+	// candidates, and reaches the build log through `site.ts`.
+	it('records a warning whenever the repo-root fallback fires', () => {
+		const { failures, warnings } = withProbe(
+			item('see [ADR-0043](docs/adr/0043-cargo-bin-policy.md)'),
+			['docs/adr/0043-cargo-bin-policy.md']
+		);
+		expect(failures).toEqual([]);
+		expect(warnings).toHaveLength(1);
+		expect(warnings[0].code).toBe('CHANGELOG-ROOT-RELATIVE-LINK');
+		expect(warnings[0].file).toBe('crates/trusty-mpm/CHANGELOG.md');
+		expect(warnings[0].problem).toContain('crates/trusty-mpm/docs/adr/0043-cargo-bin-policy.md');
+		expect(warnings[0].problem).toContain('docs/adr/0043-cargo-bin-policy.md');
+	});
+
+	// The critic's case, in the shape a rename actually produces: a link that
+	// used to resolve beside the changelog now resolves only at the root. It is
+	// still accepted — refusing it would undo #5640 — but it cannot pass quietly.
+	it('warns when a crate-local target is gone and a same-named root file takes over', () => {
+		const { releases, failures, warnings } = withProbe(item('[guide](docs/guide.md)'), [
+			'docs/guide.md'
+		]);
+		expect(failures).toEqual([]);
+		expect(warnings.map((w) => w.code)).toEqual(['CHANGELOG-ROOT-RELATIVE-LINK']);
+		expect(releases[0].categories[0].items[0].html).toContain('blob/main/docs/guide.md');
+	});
+
+	// The ordinary path stays quiet — a warning on every resolving link would be
+	// noise, and noise is how a real one gets missed.
+	it('records no warning when the changelog-relative reading resolves', () => {
+		const { failures, warnings } = withProbe(item('see [spec](../../docs/specs/foo.md)'), [
+			'docs/specs/foo.md'
+		]);
+		expect(failures).toEqual([]);
+		expect(warnings).toEqual([]);
+	});
+
 	// An href that states its base explicitly gets one reading. `./` and `../`
 	// mean "from here", so a root file with the same name must not rescue them.
 	it('does not fall back to the repository root for an explicitly relative link', () => {

--- a/website/src/lib/changelog/parse.test.ts
+++ b/website/src/lib/changelog/parse.test.ts
@@ -281,6 +281,57 @@ describe('links and metavariables inside an item', () => {
 		}
 	});
 
+	/**
+	 * The exact entry `d1774c81` added, replayed verbatim. Every Vercel deploy
+	 * from that commit on failed on it: `docs/adr/0043-cargo-bin-policy.md` is
+	 * the path from the repository root, and the checker only ever tried
+	 * `crates/trusty-mpm/docs/adr/…` (#5640).
+	 */
+	it('resolves a repo-root-relative link that does not exist beside the changelog', () => {
+		const { releases, failures } = withProbe(
+			item('see [ADR-0043](docs/adr/0043-cargo-bin-policy.md)'),
+			['docs/adr/0043-cargo-bin-policy.md']
+		);
+		expect(failures).toEqual([]);
+		expect(releases[0].categories[0].items[0].html).toContain(
+			'href="https://github.com/bobmatnyc/trusty-tools/blob/main/docs/adr/0043-cargo-bin-policy.md"'
+		);
+	});
+
+	// Precedence, not preference: the fallback fires only where the first
+	// reading found nothing, so a link that already resolved beside the
+	// changelog keeps resolving there even when the same path exists at the
+	// root. Without this the #5640 widening would silently re-point links.
+	it('prefers the changelog-relative reading when both readings exist', () => {
+		const { releases, failures } = withProbe(item('see [readme](README.md)'), [
+			'crates/trusty-mpm/README.md',
+			'README.md'
+		]);
+		expect(failures).toEqual([]);
+		expect(releases[0].categories[0].items[0].html).toContain(
+			'blob/main/crates/trusty-mpm/README.md'
+		);
+	});
+
+	// An href that states its base explicitly gets one reading. `./` and `../`
+	// mean "from here", so a root file with the same name must not rescue them.
+	it('does not fall back to the repository root for an explicitly relative link', () => {
+		for (const href of ['./docs/x.md', '../docs/x.md']) {
+			const { failures } = withProbe(item(`[x](${href})`), ['docs/x.md']);
+			expect(
+				failures.map((f) => f.code),
+				href
+			).toEqual(['CHANGELOG-BAD-LINK']);
+		}
+	});
+
+	it('names both readings it tried when neither resolves', () => {
+		const { failures } = withProbe(item('[x](docs/specs/gone.md)'), []);
+		expect(failures).toHaveLength(1);
+		expect(failures[0].problem).toContain('crates/trusty-mpm/docs/specs/gone.md');
+		expect(failures[0].problem).toContain('`docs/specs/gone.md` against the repository root');
+	});
+
 	it('fails the build on a relative link whose target is not in the repository', () => {
 		const { failures } = withProbe(item('[gone](../../docs/specs/gone.md)'), []);
 		expect(failures).toHaveLength(1);

--- a/website/src/lib/changelog/parse.ts
+++ b/website/src/lib/changelog/parse.ts
@@ -321,6 +321,15 @@ export function parseChangelog(
  * own path, and fails the build on anything it cannot resolve. Mutates the
  * tree in place, before any of it is serialised.
  *
+ * A link resolves against the changelog's own directory first. A BARE path
+ * (`docs/adr/0043-cargo-bin-policy.md` — no leading `./` or `../`) that
+ * resolves to nothing there is tried a second time against the repository
+ * root, which is what a fragment author writing that path meant (#5640). The
+ * order matters: the fallback fires only where the first reading found
+ * nothing, so a link that already resolved cannot change meaning. An href that
+ * states its base explicitly gets one reading, and an escaping link is refused
+ * before any fallback — `rootRelativeCandidate` below holds both rules.
+ *
  * Case 2 RECOVERS rather than failing, unlike the identical hazard in the doc
  * reader. The difference is who can fix it: a published page's author can add
  * the backticks, but a changelog is append-only history that this site must
@@ -399,35 +408,48 @@ function harden(
 			return;
 		}
 
-		const target = path.posix.normalize(path.posix.join(dir, rawTarget));
+		const relativeTarget = path.posix.normalize(path.posix.join(dir, rawTarget));
 
 		// A target outside the repository is a dead stop, never a guess. An
 		// earlier revision stripped the leading `../` and accepted whatever it
 		// landed on if that path existed — which turned
 		// `[the README](../../../README.md)` in a trusty-search changelog into a
 		// confident link to the repo-root README, with zero failures reported.
-		// A green build has to mean every link resolved as written.
-		if (target.startsWith('..')) {
+		// A green build has to mean every link resolved as written. The #5640
+		// fallback below is deliberately not reachable from here: an escaping
+		// link is refused before any second reading is attempted.
+		if (relativeTarget.startsWith('..')) {
 			failures.push({
 				code: CHANGELOG_CODES.BAD_LINK,
 				file,
 				line,
-				problem: `\`${href}\` resolves to \`${target}\`, outside the repository`,
+				problem: `\`${href}\` resolves to \`${relativeTarget}\`, outside the repository`,
 				remedy: `count the \`../\` from \`${dir}/\`, or write it as an absolute https:// URL`
 			});
 			return;
 		}
 
-		if (!probe(target)) {
-			failures.push({
-				code: CHANGELOG_CODES.BAD_LINK,
-				file,
-				line,
-				problem: `\`${href}\` resolves to \`${target}\`, which is not in the repository`,
-				remedy:
-					'point it at the file’s current path, write an absolute https:// URL, or drop the link and keep its text'
-			});
-			return;
+		// `undefined` once the two readings coincide (a changelog at the repo
+		// root), so the diagnostic never names one path as two candidates.
+		const candidate = rootRelativeCandidate(rawTarget);
+		const rootTarget = candidate === relativeTarget ? undefined : candidate;
+		let target = relativeTarget;
+		if (!probe(relativeTarget)) {
+			if (rootTarget === undefined || !probe(rootTarget)) {
+				failures.push({
+					code: CHANGELOG_CODES.BAD_LINK,
+					file,
+					line,
+					problem:
+						rootTarget === undefined
+							? `\`${href}\` resolves to \`${relativeTarget}\`, which is not in the repository`
+							: `\`${href}\` resolves to \`${relativeTarget}\` against \`${dir}/\` and to \`${rootTarget}\` against the repository root, and neither is in the repository`,
+					remedy:
+						'point it at the file’s current path, write an absolute https:// URL, or drop the link and keep its text'
+				});
+				return;
+			}
+			target = rootTarget;
 		}
 
 		// `blob/main`, not a pinned SHA: see `changelogUrl` in `site.ts`.
@@ -437,6 +459,38 @@ function harden(
 			rel: ['noreferrer', 'noopener']
 		};
 	});
+}
+
+/**
+ * Why: a fragment author writing `docs/adr/0043-cargo-bin-policy.md` means the
+ * path from the repository ROOT, and that reading is the one this checker had
+ * no way to try. Resolved only against `crates/<crate>/`, the link pointed at
+ * `crates/trusty-mpm/docs/adr/…`, the build gate failed the whole site, and
+ * every Vercel deploy from `d1774c81` on was red — six unrelated PRs inherited
+ * a check they had not caused and could only diagnose from raw Vercel logs
+ * (#5640).
+ *
+ * What: returns the repo-root reading of an href worth trying as a SECOND
+ * candidate, or `undefined` when there is no second reading to try. An href
+ * that opens with `./` or `../` states its base explicitly, so it gets one
+ * reading and one only; a bare path is the ambiguous shape, and its root
+ * reading is returned normalized. A root reading that escapes the repository
+ * is discarded here rather than offered, so the caller can never resolve a
+ * link to somewhere outside the tree.
+ *
+ * The caller tries the changelog-relative reading FIRST and falls back only
+ * when it resolves to nothing, so no link that already resolved can change
+ * meaning — which keeps this a strictly widening change to a release-adjacent
+ * gate.
+ *
+ * Test: `parse.test.ts` (`resolves a repo-root-relative link …` and the
+ * precedence and escape cases beside it).
+ */
+function rootRelativeCandidate(rawTarget: string): string | undefined {
+	if (rawTarget.startsWith('./') || rawTarget.startsWith('../')) return undefined;
+	const normalized = path.posix.normalize(rawTarget);
+	if (normalized.startsWith('..')) return undefined;
+	return normalized;
 }
 
 /** Turns one `h2` into a release, or records why it is not one. */

--- a/website/src/lib/changelog/parse.ts
+++ b/website/src/lib/changelog/parse.ts
@@ -49,7 +49,12 @@ import type { Element, Root, RootContent } from 'hast';
 import { classifyAbsoluteHref } from '../docs/links';
 import { ALLOWED_ELEMENTS, parsePage, stringifyHast } from '../docs/render';
 import { GITHUB_REPO } from '../docs/repo';
-import { CHANGELOG_CODES, type ChangelogFailure } from './errors';
+import {
+	CHANGELOG_CODES,
+	CHANGELOG_WARNING_CODES,
+	type ChangelogFailure,
+	type ChangelogWarning
+} from './errors';
 
 /** One bullet under a category heading. */
 export interface ChangelogItem {
@@ -95,6 +100,8 @@ export interface ChangelogRelease {
 export interface ParsedChangelog {
 	releases: ChangelogRelease[];
 	failures: ChangelogFailure[];
+	/** Accepted, but worth saying out loud. Never stops a build — see `errors.ts`. */
+	warnings: ChangelogWarning[];
 }
 
 /**
@@ -233,9 +240,10 @@ export function parseChangelog(
 ): ParsedChangelog {
 	const { tree } = parsePage(stripLinkDefinitions(markdown));
 	const failures: ChangelogFailure[] = [];
+	const warnings: ChangelogWarning[] = [];
 	const releases: ChangelogRelease[] = [];
 
-	harden(tree, file, probe, failures);
+	harden(tree, file, probe, failures, warnings);
 
 	let release: ChangelogRelease | undefined;
 	let category: ChangelogCategory | undefined;
@@ -296,7 +304,7 @@ export function parseChangelog(
 		entry.itemCount = entry.categories.reduce((total, cat) => total + cat.items.length, 0);
 	}
 
-	return { releases, failures };
+	return { releases, failures, warnings };
 }
 
 /**
@@ -322,13 +330,14 @@ export function parseChangelog(
  * tree in place, before any of it is serialised.
  *
  * A link resolves against the changelog's own directory first. A BARE path
- * (`docs/adr/0043-cargo-bin-policy.md` — no leading `./` or `../`) that
- * resolves to nothing there is tried a second time against the repository
- * root, which is what a fragment author writing that path meant (#5640). The
- * order matters: the fallback fires only where the first reading found
- * nothing, so a link that already resolved cannot change meaning. An href that
- * states its base explicitly gets one reading, and an escaping link is refused
- * before any fallback — `rootRelativeCandidate` below holds both rules.
+ * carrying a directory (`docs/adr/0043-cargo-bin-policy.md` — no leading `./`
+ * or `../`) that resolves to nothing there is tried a second time against the
+ * repository root, which is what a fragment author writing that path meant
+ * (#5640). Three rules keep that from becoming a guess, all held by
+ * `rootRelativeCandidate` below: the fallback fires only where the first
+ * reading found nothing, an href that states its base gets one reading, and a
+ * bare FILENAME gets none. Every fallback that does fire is recorded as a
+ * warning, so a link that changed base is visible in the build log.
  *
  * Case 2 RECOVERS rather than failing, unlike the identical hazard in the doc
  * reader. The difference is who can fix it: a published page's author can add
@@ -343,7 +352,8 @@ function harden(
 	tree: Root,
 	file: string,
 	probe: (relative: string) => boolean,
-	failures: ChangelogFailure[]
+	failures: ChangelogFailure[],
+	warnings: ChangelogWarning[]
 ): void {
 	const dir = path.posix.dirname(file);
 
@@ -450,6 +460,17 @@ function harden(
 				return;
 			}
 			target = rootTarget;
+			// Accepted, never silent. The build just resolved this link against a
+			// base the author did not write, and the day a crate-local file is
+			// renamed that decision is the difference between a red build and a
+			// published link to the wrong document (#5640 review).
+			warnings.push({
+				code: CHANGELOG_WARNING_CODES.ROOT_RELATIVE_LINK,
+				file,
+				line,
+				problem: `\`${href}\` does not resolve to \`${relativeTarget}\` beside this file; it was resolved against the repository root as \`${rootTarget}\``,
+				remedy: `write it relative to \`${dir}/\` if it meant a file beside this one, or as an absolute https:// URL`
+			});
 		}
 
 		// `blob/main`, not a pinned SHA: see `changelogUrl` in `site.ts`.
@@ -471,25 +492,33 @@ function harden(
  * (#5640).
  *
  * What: returns the repo-root reading of an href worth trying as a SECOND
- * candidate, or `undefined` when there is no second reading to try. An href
- * that opens with `./` or `../` states its base explicitly, so it gets one
- * reading and one only; a bare path is the ambiguous shape, and its root
- * reading is returned normalized. A root reading that escapes the repository
- * is discarded here rather than offered, so the caller can never resolve a
- * link to somewhere outside the tree.
+ * candidate, or `undefined` when there is no second reading to try. Three
+ * shapes get no second reading: an href opening `./` or `../` (it states its
+ * base), a reading that escapes the repository, and a bare filename with no
+ * directory (see the comment on that check — it is the collision guard).
  *
  * The caller tries the changelog-relative reading FIRST and falls back only
- * when it resolves to nothing, so no link that already resolved can change
- * meaning — which keeps this a strictly widening change to a release-adjacent
- * gate.
+ * when it resolves to nothing, and every fallback that fires is recorded as a
+ * warning. So no link that already resolved can change meaning, and no link
+ * that changed base does so silently.
  *
- * Test: `parse.test.ts` (`resolves a repo-root-relative link …` and the
- * precedence and escape cases beside it).
+ * Test: `parse.test.ts` (`resolves a repo-root-relative link …`, `refuses a
+ * bare filename …`, `records a warning whenever the repo-root fallback fires`,
+ * and the precedence and escape cases beside them).
  */
 function rootRelativeCandidate(rawTarget: string): string | undefined {
 	if (rawTarget.startsWith('./') || rawTarget.startsWith('../')) return undefined;
 	const normalized = path.posix.normalize(rawTarget);
 	if (normalized.startsWith('..')) return undefined;
+	// A BARE FILENAME names a sibling of the changelog and has no second reading.
+	// `README.md`, `LICENSE` and `CHANGELOG.md` each exist at the repository root
+	// AND in most crate directories (22, 19 and 27 of them), so a fallback here
+	// would hand a crate-local link to the root twin the day the crate file is
+	// renamed — accepted, published, and wrong. A fragment author writing a
+	// repo-root path always writes a directory with it (`docs/…`, `scripts/…`),
+	// which is the shape #5640 is about. Checked after normalising so
+	// `docs/../README.md` cannot carry a slash past this.
+	if (!normalized.includes('/')) return undefined;
 	return normalized;
 }
 

--- a/website/src/lib/changelog/site.test.ts
+++ b/website/src/lib/changelog/site.test.ts
@@ -199,6 +199,49 @@ describe('the build gates', () => {
 		]);
 	});
 
+	/**
+	 * The non-fatal half of the #5640 fix, end to end. A root-resolved link must
+	 * keep the build green — refusing it is what took the public site down — and
+	 * must reach the build log, because a resolution the build chose on the
+	 * author's behalf that nobody can see is the finding this test exists for.
+	 */
+	it('logs a root-resolved link and still builds', () => {
+		const root = fixture({
+			'trusty-mpm':
+				'## [1.0.0] — 2026-01-01\n\n### Added\n\n- see [ADR-0043](docs/adr/0043-cargo-bin-policy.md)\n'
+		});
+		const adr = path.join(root, 'docs/adr/0043-cargo-bin-policy.md');
+		mkdirSync(path.dirname(adr), { recursive: true });
+		writeFileSync(adr, '# ADR-0043\n');
+
+		const logged: string[] = [];
+		const original = console.warn;
+		console.warn = (...args: unknown[]) => void logged.push(args.join(' '));
+		try {
+			const site = buildChangelogSite(root);
+			expect(site.crates).toHaveLength(RELEASED_FLAGSHIPS.length);
+		} finally {
+			console.warn = original;
+		}
+
+		expect(logged).toHaveLength(1);
+		expect(logged[0]).toContain('WARN CHANGELOG-ROOT-RELATIVE-LINK');
+		expect(logged[0]).toContain('crates/trusty-mpm/CHANGELOG.md');
+		expect(logged[0]).toContain('docs/adr/0043-cargo-bin-policy.md');
+	});
+
+	it('logs nothing when every link resolves beside its changelog', () => {
+		const logged: string[] = [];
+		const original = console.warn;
+		console.warn = (...args: unknown[]) => void logged.push(args.join(' '));
+		try {
+			buildChangelogSite(fixture());
+		} finally {
+			console.warn = original;
+		}
+		expect(logged).toEqual([]);
+	});
+
 	it('does not fail on an unrecognised category, which is hand-written history', () => {
 		const site = buildChangelogSite(
 			fixture({ 'trusty-search': '## [1.0.0] — 2026-01-01\n\n### Highlights\n\n- a\n' })

--- a/website/src/lib/changelog/site.ts
+++ b/website/src/lib/changelog/site.ts
@@ -25,6 +25,14 @@
  * string anywhere below. A green build is therefore itself the evidence that
  * every section is populated.
  *
+ * ONE finding is non-fatal and is logged rather than thrown:
+ * `CHANGELOG-ROOT-RELATIVE-LINK`, a link the build resolved against the
+ * repository root because the changelog's own directory could not resolve it
+ * (#5640). It is accepted because refusing it would take the public site down
+ * over a link shape a fragment author writes naturally, and it is logged
+ * because the alternative is a green build quietly publishing a link to a
+ * document nobody chose.
+ *
  * This runs in Node at BUILD time only. Its output is prerendered into static
  * HTML, so the published page reads no file and opens no connection.
  *
@@ -37,7 +45,13 @@ import path from 'node:path';
 
 import { RELEASED_FLAGSHIPS } from '../site';
 import { GITHUB_REPO, findRepoRoot } from '../docs/repo';
-import { CHANGELOG_CODES, throwIfFailed, type ChangelogFailure } from './errors';
+import {
+	CHANGELOG_CODES,
+	reportWarnings,
+	throwIfFailed,
+	type ChangelogFailure,
+	type ChangelogWarning
+} from './errors';
 import { parseChangelog, type ChangelogRelease } from './parse';
 
 export interface CrateChangelog {
@@ -93,6 +107,7 @@ export function buildChangelogSite(repoRootOverride?: string): ChangelogSite {
 
 	const repoRoot = repoRootOverride ?? findRepoRoot();
 	const failures: ChangelogFailure[] = [];
+	const warnings: ChangelogWarning[] = [];
 	const crates: CrateChangelog[] = [];
 
 	for (const flagship of RELEASED_FLAGSHIPS) {
@@ -104,6 +119,7 @@ export function buildChangelogSite(repoRootOverride?: string): ChangelogSite {
 			existsSync(path.join(repoRoot, relative))
 		);
 		failures.push(...parsed.failures);
+		warnings.push(...parsed.warnings);
 
 		const latest = parsed.releases[0];
 		if (!latest) {
@@ -140,6 +156,9 @@ export function buildChangelogSite(repoRootOverride?: string): ChangelogSite {
 		});
 	}
 
+	// Warnings first: a build that is about to throw should still say what it
+	// accepted on the way, and the log is the only channel either report has.
+	reportWarnings(warnings);
 	throwIfFailed(failures);
 
 	const site: ChangelogSite = { crates, cratesDirUrl: CRATES_DIR_URL };

--- a/website/src/routes/tools/trusty-audit/+page.svelte
+++ b/website/src/routes/tools/trusty-audit/+page.svelte
@@ -161,16 +161,16 @@
 		<h2 class="font-display text-2xl font-bold sm:text-3xl">2 · First run</h2>
 		<p class="mt-4 max-w-3xl text-foundry-secondary">
 			Whether the installer launched it for you or you type <code class="text-sm">trusty-audit</code
-			> by itself, a bare invocation is a status check, not a sweep. It reports the working
-			directory it will use, that no audit has run there yet, that none of the four pinned tools are
-			installed, and reminds you to register what to audit. It asks for nothing and downloads
-			nothing yet — that starts with the next two steps.
+			> by itself, a bare invocation is a status check, not a sweep. It reports the working directory
+			it will use, that no audit has run there yet, that none of the four pinned tools are installed,
+			and reminds you to register what to audit. It asks for nothing and downloads nothing yet — that
+			starts with the next two steps.
 		</p>
 		<p class="mt-4 max-w-3xl text-foundry-secondary">
-			It does not need <code class="text-sm">engagement.toml</code> to show you this — only installing
-			tools and running the audit do. Its reminder to register targets does not go away once you have
-			registered some; check <code class="text-sm">trusty-audit targets</code> for the registry itself,
-			not this status line.
+			It does not need <code class="text-sm">engagement.toml</code> to show you this — only
+			installing tools and running the audit do. Its reminder to register targets does not go away
+			once you have registered some; check <code class="text-sm">trusty-audit targets</code> for the registry
+			itself, not this status line.
 		</p>
 	</div>
 
@@ -212,12 +212,12 @@ trusty-audit targets</pre>
 			targets never touch it. The audit renders its report through a language model, so before the
 			sweep can start it resolves a key: an <code class="text-sm">OPENROUTER_API_KEY</code> already
 			exported in your shell wins; otherwise a key already in
-			<code class="text-sm">engagement.toml</code> — your auditor may have put theirs there — is used;
-			otherwise trusty-audit asks at the terminal, with the typing hidden, and asks twice so a mistyped
-			key is caught immediately. Either way the run prints which of the three it used. What you type at
-			the prompt is written back into <code class="text-sm">engagement.toml</code>, readable only by
-			your account, and is not asked for again. The key never reaches a log line, an error message, or
-			the package you send back.
+			<code class="text-sm">engagement.toml</code> — your auditor may have put theirs there — is
+			used; otherwise trusty-audit asks at the terminal, with the typing hidden, and asks twice so a
+			mistyped key is caught immediately. Either way the run prints which of the three it used. What
+			you type at the prompt is written back into <code class="text-sm">engagement.toml</code>,
+			readable only by your account, and is not asked for again. The key never reaches a log line,
+			an error message, or the package you send back.
 		</p>
 		<p class="mt-4 max-w-3xl text-foundry-secondary">
 			If there is no terminal to ask on — a script, a CI job — it refuses and names both ways to

--- a/website/src/routes/tools/trusty-git-analytics/audit/+page.svelte
+++ b/website/src/routes/tools/trusty-git-analytics/audit/+page.svelte
@@ -183,9 +183,9 @@ tctl install trusty-review</pre>
 				<p class="mt-2 text-sm text-foundry-secondary">
 					Without it the sweep still runs and still writes
 					<code class="text-xs">manifest.toml</code>, then stops with an error naming that file.
-					Nothing collected is lost — see the recovery command below. A copy too old to
-					require inference is rejected before stage 1, with the upgrade command, rather
-					than delivering a report with no written analysis.
+					Nothing collected is lost — see the recovery command below. A copy too old to require
+					inference is rejected before stage 1, with the upgrade command, rather than delivering a
+					report with no written analysis.
 				</p>
 			</div>
 			<div class="card bg-foundry-card">
@@ -194,9 +194,9 @@ tctl install trusty-review</pre>
 					<code class="text-base">OPENROUTER_API_KEY</code>
 				</h3>
 				<p class="mt-2 text-sm text-foundry-secondary">
-					The renderer writes the report's analysis with a model, so an audit cannot finish
-					without a key. It is checked before stage 1, not at the end, so an unset one costs
-					you the error and not the sweep:
+					The renderer writes the report's analysis with a model, so an audit cannot finish without
+					a key. It is checked before stage 1, not at the end, so an unset one costs you the error
+					and not the sweep:
 					<code class="text-xs">export OPENROUTER_API_KEY=…</code>
 				</p>
 			</div>
@@ -334,9 +334,8 @@ tctl install trusty-review</pre>
 			</p>
 			<p class="mt-4 max-w-3xl text-foundry-secondary">
 				If the sweep stopped at the render — the renderer was not installed, or the model call
-				failed — the manifest survived it, because it is written before the renderer is called.
-				Fix the cause and run the last stage by hand; this is exactly what the sweep would have
-				run:
+				failed — the manifest survived it, because it is written before the renderer is called. Fix
+				the cause and run the last stage by hand; this is exactly what the sweep would have run:
 			</p>
 
 			<div class="mt-6 max-w-xl min-w-0">
@@ -500,11 +499,11 @@ tctl install trusty-review</pre>
 		<div class="min-w-0">
 			<h2 class="font-display text-2xl font-bold sm:text-3xl">The report, section by section</h2>
 			<p class="mt-4 max-w-3xl text-foundry-secondary">
-				Eight sections, in this order. A model writes the executive summary, the top-risk
-				rationale, and the RED/AMBER finding prose, working only from what the sweep collected —
-				every figure it cites is checked against that data and the sentence is dropped if the
-				figure is not there. Section 2 falls back to a roll-up composed from the report's own
-				counts whenever that check rejects the written one.
+				Eight sections, in this order. A model writes the executive summary, the top-risk rationale,
+				and the RED/AMBER finding prose, working only from what the sweep collected — every figure
+				it cites is checked against that data and the sentence is dropped if the figure is not
+				there. Section 2 falls back to a roll-up composed from the report's own counts whenever that
+				check rejects the written one.
 			</p>
 
 			<div class="doc-prose doc-table max-w-3xl">

--- a/website/src/routes/whats-new/+page.svelte
+++ b/website/src/routes/whats-new/+page.svelte
@@ -171,8 +171,8 @@
 	<div class="card">
 		<h2 class="font-display text-xl font-semibold">The rest of the workspace</h2>
 		<p class="mt-2 text-sm text-foundry-secondary">
-			Only the flagship crates are published here. Every other crate keeps its changelog
-			alongside its source — see
+			Only the flagship crates are published here. Every other crate keeps its changelog alongside
+			its source — see
 			<a
 				href={data.cratesDirUrl}
 				rel="noreferrer noopener"


### PR DESCRIPTION
Five gaps in CI, the release scripts, and the website build. No crate `src/**`
changes, so no changelog fragment is owed. Test ladder: **rung 1** for the Rust
side (nothing under `crates/*/src/`); the real gates here are the script
selftests, the website suite, and `actionlint`, all run below.

One of these is release tooling (`scripts/bump-version.sh`), so this PR is
built for a `code-critic` round before merge — the release path is
byte-for-byte unchanged and both directions are pinned by a new selftest.

---

## `Refs #5657` — `test-pointers.yml` had no red-main detector

`ci.yml`'s `notify-main-failure` can only name jobs defined in `ci.yml`, so the
doc-pointer lint was structurally invisible to it. It sat red on `main` from run
31587713536 to 31688534235 — over 24 hours — and no `ci-red-main` issue was ever
filed; a human found it by hand and opened #5520.

`test-pointers.yml` now carries its own `notify-main-failure` job, mirroring
`version-parity.yml`'s `notify-main-drift` (#4688). It classifies the lint's own
conclusion through `scripts/classify-ci-results.sh`, files or comments on the
**same** `ci-red-main` label so a reader watches one issue, and fails its own run
on any non-green verdict.

**Why not fold the lint into `ci.yml`.** The two workflows disagree on every
structural choice this depends on: `test-pointers.yml` keeps a `paths:` filter on
`push` (`ci.yml` has none, so the lint would run on every merge), it carries its
own per-commit concurrency group, and its job name is the required
branch-protection context `Doc-comment pointer lint (Why/What/Test)`. Copying
`version-parity.yml`'s shape is what the existing structure supports, and it
generalises — the other 13 push-to-main workflows can each take this job.

**Test.** `scripts/check-ci-helpers-selftest.sh` gained seven wiring assertions
(the notifier exists, waits on the lint job itself, classifies through the shared
script, feeds the raw conclusion, uses the `ci-red-main` label, runs under
`always()`, and fails the run on non-green). The existing "no job-level `if:` can
skip the gate" assertion was **scoped to the gate job** rather than weakened —
the notifier's job-level `if:` is required, and a new assertion pins that the
notifier is the only job allowed to carry one.

## `Refs #5674` + `Refs #5765` — one shared classifier, and release-gated fragment consumption

**#5674.** `scripts/bump-version.sh` ran changelog assembly unconditionally, so a
bump landing in the same PR as its source change ate four in-flight fragments on
PR #5673 and `check_changelog_fragment.sh` then failed that PR for lacking a
fragment the bump had just deleted. Repaired by hand at the time (`879b5fe2`).

It now takes `--no-changelog`, which bumps the manifest, syncs `Cargo.lock`,
leaves `changelog.d/` untouched, and prints no tag command.

**Opt-OUT, deliberately not opt-in.** A forgotten opt-out costs a red gate on the
PR — loud, and the fragments are recoverable from git. A forgotten opt-in would
publish a release whose `CHANGELOG.md` has no section for it, which nothing
checks and nobody sees until a reader looks for an entry that is not there. The
default therefore stays exactly what the release path already relies on.

**#5765.** `check-pr-version-bump.sh:177` matched `^crates/[^/]+/src/` with no
test exemption; `check_changelog_fragment.sh:281,284` carried its own test-file
match and exempted those paths. The same file on PR #5764 was source to one gate
and not the other by accident. Both now read `scripts/lib/source_class.sh`, whose
`THE RULING` section records why they still answer differently:

| Gate | Predicate | Because |
|---|---|---|
| `check-pr-version-bump.sh` | `is_crate_src_path` alone | a crates.io tarball ships test files, so editing one under a published version is real drift |
| `check_changelog_fragment.sh` | `is_crate_src_path` **and** `is_test_path` | a test-only edit has no user-visible change to describe |

**Neither gate's verdict changes on any path.** What changes is that the
definitions live in one file with the decision written beside them, which is
#5765's closure condition.

The file also states what it does *not* cover: `check_changelog_fragment.sh`
additionally attributes nested members (`crates/trusty-audit/ui/src-tauri/src/**`)
by walking to the nearest `Cargo.toml` (#4576), and `check-pr-version-bump.sh`
deliberately does not, because `cargo package` excludes a nested package from its
parent's tarball. That is a difference in *reach*, and it stays in the gates.

**Tests.** Two new selftests, both wired into CI:

- `scripts/check_source_class_selftest.sh` — 31 cases: every test-path shape and
  the near-misses that must not match (`tests_helper.rs`, `contests/`,
  `src/testdata.rs`), the depth-1 `src/` shape and the nested/adjacent paths
  outside it, plus **wiring** assertions that neither gate has grown a private
  copy again. Run by `changelog-fragment.yml` and by `version-parity.yml`'s
  required `pr-version-bump` job.
- `scripts/bump_version_selftest.sh` — 23 cases against the real script in a
  throwaway workspace with a stub `cargo` on PATH: the default consumes
  fragments and writes `## [0.2.0]`; `--no-changelog` bumps and leaves them;
  flag order; an unknown flag exits 2 with the manifest untouched; a missing
  assembler is refused under the default and accepted under `--no-changelog`.

Four existing selftests copy a gate into a synthetic repo and had to copy the
new library alongside it (`check-ci-helpers`, `check_changelog_attribution`,
`check_changelog_base`, and `check_scan_floor`'s `install_gate … lib`). They
caught the omission by failing.

## `Refs #5918` — no CI job linted `website/`

`pnpm lint` failed on `main`. `website-tests.yml` ran install + vitest only, and
`ci.yml`'s `ui-checks` matrix skips `website/**` because
`scripts/detect-docs-only.sh:114` buckets it as docs-only — a lint leg there
would skip on exactly the PRs it exists to check.

Added a **separate** `Prettier + ESLint` job to `website-tests.yml`: a formatting
nit and a broken assertion deserve different red squares, and this job needs
neither Chromium nor a `vite build`, so it settles in under a minute against the
suite's twenty. Its **advisory status is stated explicitly** in the workflow
header — neither job here is a required branch-protection context.

Three pre-existing Prettier violations fixed (`tools/trusty-audit`,
`tools/trusty-git-analytics/audit`, `whats-new`) — reflow only, no content
change. The workflow's stale `NODE 20` comment was corrected to the 22 it
actually pins.

## `Refs #5640` — changelog link resolved only against the crate directory

Every Vercel deploy from `d1774c81` on failed because a `CHANGELOG.md` entry
linked `docs/adr/0043-cargo-bin-policy.md` — the path from the **repository
root** — and the checker only ever tried `crates/trusty-mpm/docs/adr/…`. The
issue's own suggested durable fix is to teach the checker that reading; the bad
link itself was already corrected by #5647.

`website/src/lib/changelog/parse.ts` now tries a **bare** path (no leading `./`
or `../`) a second time against the repository root when it resolves to nothing
beside the changelog. Three properties keep this a strictly widening change:

1. **Changelog-relative wins.** The fallback fires only where the first reading
   found nothing, so no link that already resolved can change meaning.
2. **An explicitly relative href gets one reading.** `./x` and `../x` state their
   base; a root file of the same name must not rescue them.
3. **An escaping link is still a dead stop.** `../../../README.md` is refused
   before any fallback — the earlier regression test is untouched and still
   passes.

The diagnostic now names both readings it tried.

**Proof, with the previously-failing link present.** A new vitest case replays
`d1774c81`'s entry verbatim. Reverting only `parse.ts` and re-running:

```
 × resolves a repo-root-relative link that does not exist beside the changelog 4ms
      Tests  1 failed | 35 passed (36)
```

With the fix, and with the full suite including the real `vite build` smoke:

```
 Test Files  14 passed (14)
      Tests  256 passed (256)
```

**Not in this PR:** the issue's second defect — a PR-time gate over unconsumed
`changelog.d/` fragments, which can carry this bug latently. `website-tests.yml`
already triggers on `crates/*/CHANGELOG.md`, so an assembled bad link is caught
pre-merge; a fragment is not. Left for #5640 to keep tracking.

---

## Verification

Every command run in the worktree at `5c9fea096`.

| Gate | Result |
|---|---|
| `bash scripts/check_source_class_selftest.sh` | `31 case(s), all pass` |
| `bash scripts/bump_version_selftest.sh` | `23 case(s), all pass` |
| `bash scripts/check-ci-helpers-selftest.sh` | `all 184 cases passed` |
| `bash scripts/assemble_changelog_selftest.sh` | `all fragment-validation cases passed.` |
| `bash scripts/check_changelog_attribution_selftest.sh` | `all crate-attribution cases passed.` |
| `bash scripts/check_changelog_base_selftest.sh` | `all base-attribution cases passed.` |
| `bash scripts/check_scan_floor_selftest.sh changelog_fragment changelog_fragment_tool_error` | `2 gate(s) correctly refuse a vacuous scan — OK.` |
| `bash scripts/check_scan_floor_selftest.sh pr_version_bump` | `1 gate(s) correctly refuse a vacuous scan — OK.` |
| `bash scripts/check_sld.sh` | `0 error(s), 0 warning(s)` over 60 specs + 3350 code files |
| `bash scripts/check_line_cap.sh` | `4114 tracked .rs file(s); 0 violations — OK.` |
| `CHANGELOG_GATE_BASE=origin/main bash scripts/check_changelog_fragment.sh` | `21 changed path(s); … no crate source changed — OK.` |
| `PR_VERSION_BUMP_BASE=origin/main bash scripts/check-pr-version-bump.sh` | `[ OK ] 21 changed path(s) examined; none under crates/<crate>/src/**` |
| `actionlint` on all four edited workflows | exit 0, no findings |
| `pnpm run lint` (from inside `website/`) | exit 0, `All matched files use Prettier code style!` |
| `pnpm run test` (from inside `website/`) | `Test Files 14 passed (14) / Tests 256 passed (256)` |

Regression proofs — each new selftest was run against the pre-fix script and
fails:

- `bump_version_selftest.sh` vs `origin/main`'s `bump-version.sh`:
  `8 of 23 case(s) FAILED`
- `parse.test.ts` vs `origin/main`'s `parse.ts`: `1 failed | 35 passed (36)`

**Credential scan.** `git diff origin/main...HEAD` grepped for key/secret/token/
password/private-key/`ghp_`/`sk-`/`AKIA` shapes: no secrets. The only hits are
prose on two marketing pages describing how `OPENROUTER_API_KEY` is resolved,
reflowed by Prettier.

**Environment note.** Local Node is v22.23.2, matching the pin both jobs use, so
no `theme.test.ts` `localStorage` mismatch arose.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
