### PR TITLE
fix(trusty-mpm): three test-flake fixes — shared DaemonState, pm_guard cwd, timing budget (#5813, #5839, #5840)

### DIFF
--- a/crates/trusty-mpm/changelog.d/5840-fetch-retry-budget-parameter.md
+++ b/crates/trusty-mpm/changelog.d/5840-fetch-retry-budget-parameter.md
@@ -1,0 +1,9 @@
+Changed
+
+- `fetch_managed_session_until_stopped` (bare-`tm` in-place relaunch) takes its
+  retry budget as a parameter instead of reading `FETCH_RETRY_BUDGET` directly.
+  The one production call site passes the same 400ms, so the in-place relaunch
+  path behaves exactly as before; the parameter exists so the retry tests can
+  drive a budget no loopback round trip can consume, which is what made
+  `fetch_until_stopped_gives_up_after_budget_when_never_stopped` flaky under CI
+  load (#5840).

--- a/crates/trusty-mpm/src/bin/tm/commands/guided_inplace.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_inplace.rs
@@ -282,8 +282,8 @@ async fn fetch_managed_session(
     resp.json().await.ok()
 }
 
-/// Poll [`fetch_managed_session`] until the record reads `"stopped"` or the
-/// [`FETCH_RETRY_BUDGET`] is exhausted (#2148 race hardening).
+/// Poll [`fetch_managed_session`] until the record reads `"stopped"` or
+/// `budget` is exhausted (#2148 race hardening).
 ///
 /// Why: [`plan_inplace`] requires the FIRST fetch to already show `"stopped"`;
 /// a record that is transitioning `Active` -> `Stopped` (the `SessionEnd` stop
@@ -293,17 +293,28 @@ async fn fetch_managed_session(
 /// a small, bounded budget lets the transition land before giving up.
 /// What: fetches once immediately; returns as soon as `state == "stopped"`.
 /// Otherwise sleeps [`FETCH_RETRY_INTERVAL`] and retries, stopping the moment
-/// the elapsed time reaches [`FETCH_RETRY_BUDGET`] — returning whatever the
-/// LAST attempt produced (`Some` non-stopped record, or `None` if the fetch
-/// itself kept failing). Never blocks longer than the budget, so a genuinely
+/// the elapsed time reaches `budget` — returning whatever the LAST attempt
+/// produced (`Some` non-stopped record, or `None` if the fetch itself kept
+/// failing). Never blocks longer than the budget, so a genuinely
 /// unresolved/unknown id still falls through promptly.
+///
+/// `budget` is a parameter rather than a read of [`FETCH_RETRY_BUDGET`]
+/// (#5840): the production 400ms is short enough that one slow first fetch on
+/// a loaded CI runner can exhaust it, in which case this returns after a
+/// single attempt — correct behaviour, but it made
+/// `fetch_until_stopped_gives_up_after_budget_when_never_stopped`'s "it
+/// retried" assertion a coin flip. The tests pass a budget no single loopback
+/// round trip can consume, so the retry they assert is the code's, not the
+/// scheduler's. The one production call site passes [`FETCH_RETRY_BUDGET`].
 /// Test: `fetch_until_stopped_returns_immediately_when_already_stopped`,
-/// `fetch_until_stopped_gives_up_after_budget_when_never_stopped` (both use a
+/// `fetch_until_stopped_retries_past_transitioning_state`,
+/// `fetch_until_stopped_gives_up_after_budget_when_never_stopped` (all use a
 /// local one-shot/counting mock, mirroring `spawn_mock`'s convention).
 async fn fetch_managed_session_until_stopped(
     client: &reqwest::Client,
     url: &str,
     id: &str,
+    budget: std::time::Duration,
 ) -> Option<trusty_mpm::client::ManagedSessionSummary> {
     let start = std::time::Instant::now();
     loop {
@@ -311,7 +322,7 @@ async fn fetch_managed_session_until_stopped(
         if record.as_ref().map(|r| r.state.as_str()) == Some("stopped") {
             return record;
         }
-        if start.elapsed() >= FETCH_RETRY_BUDGET {
+        if start.elapsed() >= budget {
             return record;
         }
         tokio::time::sleep(FETCH_RETRY_INTERVAL).await;
@@ -719,7 +730,8 @@ pub(crate) async fn try_inplace_relaunch(
     };
     // #2148: bounded retry absorbs the Active->Stopped transition race instead
     // of giving up on a single unlucky fetch — see `fetch_managed_session_until_stopped`.
-    let record = fetch_managed_session_until_stopped(client, url, &env_id).await;
+    let record =
+        fetch_managed_session_until_stopped(client, url, &env_id, FETCH_RETRY_BUDGET).await;
     let record_state = record.as_ref().map(|r| r.state.as_str());
     match plan_inplace(Some(&env_id), record_state) {
         Some(ResumeAction::InPlace) => {

--- a/crates/trusty-mpm/src/bin/tm/commands/guided_inplace/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_inplace/tests.rs
@@ -190,22 +190,47 @@ async fn spawn_state_mock(states: Vec<&'static str>) -> (String, Arc<AtomicUsize
     (format!("http://{addr}"), hits)
 }
 
+/// The retry budget the `fetch_until_stopped_*` cases drive the loop with
+/// (#5840).
+///
+/// Why: the production [`FETCH_RETRY_BUDGET`] is 400ms, and one loopback fetch
+/// on a loaded CI runner can consume all of it — the loop then returns after a
+/// single attempt, which is its documented contract but leaves "it retried"
+/// untestable. A budget an order of magnitude above any plausible loopback
+/// round trip makes the retry the code's decision rather than the scheduler's,
+/// so the assertions below hold regardless of runner load.
+/// What: 1 second, paired with the production 80ms
+/// [`FETCH_RETRY_INTERVAL`] — roughly 12 polls, where the flake needed the
+/// first fetch alone to blow the whole budget.
+/// Test: the three `fetch_until_stopped_*` cases below.
+const TEST_RETRY_BUDGET: std::time::Duration = std::time::Duration::from_secs(1);
+
+/// A liveness ceiling for a call that must terminate on its own (#5840).
+///
+/// Why: "gives up rather than retrying forever" needs an upper bound, but a
+/// TIGHT one (the former `budget + interval * 3`) fails on a slow runner
+/// without a regression in sight — it measures the machine, not the code. A
+/// bound 30x the budget still catches a loop that never exits, and cannot be
+/// tripped by load.
+const TEST_LIVENESS_CEILING: std::time::Duration =
+    std::time::Duration::from_secs(TEST_RETRY_BUDGET.as_secs() * 30);
+
 #[tokio::test]
 async fn fetch_until_stopped_returns_immediately_when_already_stopped() {
     // #2148: the common case — no race — must not pay any retry delay.
     let (url, hits) = spawn_state_mock(vec!["stopped"]).await;
     let client = reqwest::Client::new();
-    let start = std::time::Instant::now();
-    let record = fetch_managed_session_until_stopped(&client, &url, TEST_ID).await;
+    let record =
+        fetch_managed_session_until_stopped(&client, &url, TEST_ID, TEST_RETRY_BUDGET).await;
     assert_eq!(record.map(|r| r.state), Some("stopped".to_string()));
+    // #5840: one hit IS "paid no retry delay" — the loop's only delay is the
+    // sleep between fetches, so a single fetch cannot have slept. The former
+    // wall-clock `elapsed < budget` said the same thing while also failing
+    // whenever the runner made one fetch slow.
     assert_eq!(
         hits.load(Ordering::SeqCst),
         1,
         "must not retry once the first fetch already reads stopped"
-    );
-    assert!(
-        start.elapsed() < FETCH_RETRY_BUDGET,
-        "must return promptly, not wait out the whole retry budget"
     );
 }
 
@@ -216,7 +241,12 @@ async fn fetch_until_stopped_retries_past_transitioning_state() {
     // on "stopped" a couple of polls later.
     let (url, hits) = spawn_state_mock(vec!["active", "active", "stopped"]).await;
     let client = reqwest::Client::new();
-    let record = fetch_managed_session_until_stopped(&client, &url, TEST_ID).await;
+    let record = tokio::time::timeout(
+        TEST_LIVENESS_CEILING,
+        fetch_managed_session_until_stopped(&client, &url, TEST_ID, TEST_RETRY_BUDGET),
+    )
+    .await
+    .expect("must settle on stopped, not poll forever");
     assert_eq!(record.map(|r| r.state), Some("stopped".to_string()));
     assert!(
         hits.load(Ordering::SeqCst) >= 3,
@@ -232,16 +262,21 @@ async fn fetch_until_stopped_gives_up_after_budget_when_never_stopped() {
     let (url, hits) = spawn_state_mock(vec!["active"]).await;
     let client = reqwest::Client::new();
     let start = std::time::Instant::now();
-    let record = fetch_managed_session_until_stopped(&client, &url, TEST_ID).await;
+    // #5840: the "does not retry forever" bound is a generous liveness
+    // ceiling, not a tight window — a real regression (a loop with no exit)
+    // trips it, a slow runner does not.
+    let record = tokio::time::timeout(
+        TEST_LIVENESS_CEILING,
+        fetch_managed_session_until_stopped(&client, &url, TEST_ID, TEST_RETRY_BUDGET),
+    )
+    .await
+    .expect("must give up once the budget elapses, not poll forever");
     let elapsed = start.elapsed();
     assert_eq!(record.map(|r| r.state), Some("active".to_string()));
+    // A LOWER bound only gets safer under load, so this one stays wall-clock.
     assert!(
-        elapsed >= FETCH_RETRY_BUDGET,
+        elapsed >= TEST_RETRY_BUDGET,
         "must not give up before the retry budget elapses"
-    );
-    assert!(
-        elapsed < FETCH_RETRY_BUDGET + FETCH_RETRY_INTERVAL * 3,
-        "must not overrun the budget by more than a poll or two"
     );
     assert!(
         hits.load(Ordering::SeqCst) > 1,

--- a/crates/trusty-mpm/src/daemon/api_tests.rs
+++ b/crates/trusty-mpm/src/daemon/api_tests.rs
@@ -448,7 +448,17 @@ async fn spawn_session_without_claude_returns_422() {
     );
 }
 
+/// Why serial (#5813): every tmux path in this crate runs through
+/// `TmuxDriver::discover`, which consults the #5784 host-state gate. That gate
+/// reads the PROCESS `$HOME` and compares it against the password-database
+/// home for this uid — so while any of the ~40 `$HOME`-overriding tests in this
+/// binary holds its temp home, `discover` classifies a scratch environment and
+/// returns `DaemonError::TmuxUnavailable`, which is a 500. The assertion below
+/// then reads `left: 500, right: 422` for a reason that has nothing to do with
+/// tmux. `#[serial]`'s crate-wide default group is the remedy this crate
+/// already documents for that global — see `test_support::tests::HomeOverride`.
 #[tokio::test]
+#[serial]
 async fn spawn_session_without_tmux_returns_422_on_no_tmux_host() {
     // Force the `claude` lookup positive so the spawn proceeds past the
     // binary check, then assert that the daemon degrades gracefully when
@@ -998,7 +1008,12 @@ fn apply_compression_summarise() {
     assert_eq!(result.stats.original_bytes, 100);
 }
 
+/// Why serial (#5813): `TmuxService::adopt` shares
+/// `tmux_snapshot_unknown_session_is_404`'s exposure to the host-state gate —
+/// it also reaches tmux through `discover_or_session_error`, so a concurrent
+/// `$HOME` override turns this 404 into a 500.
 #[tokio::test]
+#[serial]
 async fn adopt_tmux_session_handles_missing() {
     // Adopting a session that does not exist (or with tmux absent) is 404.
     let state = DaemonState::shared();
@@ -1012,7 +1027,12 @@ async fn adopt_tmux_session_handles_missing() {
     assert_eq!(result.unwrap_err().status(), StatusCode::NOT_FOUND);
 }
 
+/// Why serial (#5813): same `$HOME`-vs-host-state-gate race as
+/// `spawn_session_without_tmux_returns_422_on_no_tmux_host` — a concurrent
+/// `$HOME` override makes `TmuxService::snapshot` return `TmuxUnavailable`
+/// (500) instead of the `SessionNotFound` (404) this asserts.
 #[tokio::test]
+#[serial]
 async fn tmux_snapshot_unknown_session_is_404() {
     let state = DaemonState::shared();
     let result = tmux_snapshot(State(state), Path("no-such-session-xyz".into())).await;


### PR DESCRIPTION
Three CI-only flakes in `trusty-mpm`, fixed as one PR. **Rung 2** of the test
ladder (test-only stabilization), plus one production testability seam — see
"Scope note" below.

Refs #5813
Refs #5839
Refs #5840

## #5813 — the shared global is `$HOME`, not `DaemonState`

The issue's hypothesis was that `daemon::api::tests` race on
`DaemonState::shared()`. They do not: `tmux_snapshot` and `adopt_tmux_session`
take `State<Arc<DaemonState>>` and never read it.

The actual global is the process `$HOME`. Every tmux path runs through
`TmuxDriver::discover`, which consults the #5784 host-state gate
(`core/host_state_gate.rs`). That gate compares the process `$HOME` against the
password-database home for this uid; a mismatch classifies
`ScratchEnvironment`, `discover_or_session_error` returns
`DaemonError::TmuxUnavailable`, and that maps to **500** (`daemon/error.rs:183`).
While any of the ~40 `$HOME`-overriding tests in this binary holds its temp
home, a concurrent api test reads 500 where it asserts 404 or 422 — exactly the
reported `left: 500, right: 404` / `left: 500, right: 422`.

Reproduced locally by running the api tests alongside the `$HOME` mutators:

```
$ for i in $(seq 1 15); do cargo test -p trusty-mpm --lib -- \
    tmux_snapshot_unknown_session_is_404 \
    spawn_session_without_tmux_returns_422_on_no_tmux_host home_ _home \
    2>&1 | grep -E "^test result"; done
test result: FAILED. 43 passed; 2 failed; ...   <- 11 of 15 runs red
...
---- daemon::api::tests::tmux_snapshot_unknown_session_is_404 stdout ----
thread '...' panicked at crates/trusty-mpm/src/daemon/api_tests.rs:1019:5:
assertion `left == right` failed
  left: 500
 right: 404
```

Fix: tag the two reported tests with `#[serial]` — the crate-wide default group
this crate already documents as the remedy for exactly this global
(`test_support.rs`, `HomeOverride`: "`#[serial_test::serial]`'s shared default
group … closes that gap crate-wide"). Isolation was preferred but is not
reachable: the verdict is computed from the process `$HOME` on every call, with
no seam. `adopt_tmux_session_handles_missing` carries the identical exposure in
the same file and is tagged too, rather than left to be reported next.

## #5839 — no change owed; already fixed on `main`

Commit `c34dfbb3e` ("pin a working directory for three cwd-sensitive pm-guard
tests", #5910) routes all three named tests through
`run_pm_guard_outside_a_checkout`, which pins a fresh tempdir so
`is_main_checkout` answers false regardless of the runner's checkout shape.

Verified rather than assumed, by running the suite from both shapes off the
same binary:

```
# worktree checkout (.git is a FILE) — how a contributor runs it
$ cargo test -p trusty-mpm --test tm_hook_pm_guard
test result: ok. 98 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

# CI shape (.git is a DIRECTORY, cwd = <root>/crates/trusty-mpm)
$ cd /tmp/ci-shape-repo/crates/trusty-mpm && ./tm_hook_pm_guard-<hash>
test result: ok. 98 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

The 95 remaining `run_pm_guard` call sites still inherit the runner's cwd. That
is deliberate and documented on the helper, and all 98 tests pass in both
shapes, so nothing further is changed here.

## #5840 — the retry budget is now a parameter

`fetch_managed_session_until_stopped` gave up after `FETCH_RETRY_BUDGET`
(400ms). One slow first fetch on a loaded runner consumes that whole budget, and
the loop then returns having made a single attempt — its documented contract,
but it makes `hits > 1` ("must have retried at least once") a coin flip. That is
the reported flake.

The budget is now a parameter. The one production call site passes
`FETCH_RETRY_BUDGET` unchanged, so the in-place relaunch path behaves exactly as
before. The tests drive a 1s budget that no loopback round trip can consume, so
the retry they assert is the code's decision rather than the scheduler's.

Two other wall-clock assertions in the same module were the same defect and are
converted with it:

- the tight upper bound `elapsed < budget + interval * 3` measured the machine,
  not the code. Replaced by a `tokio::time::timeout` liveness ceiling 30x the
  budget — a loop that never exits still trips it, a slow runner does not.
- `returns_immediately_when_already_stopped`'s `elapsed < FETCH_RETRY_BUDGET` is
  redundant with its own `hits == 1`: the loop's only delay is the sleep between
  fetches, so a single fetch cannot have slept.

The lower bound `elapsed >= budget` stays wall-clock — load only makes a lower
bound safer.

## Scope note

No assertion is weakened, `#[ignore]`d, `cfg`-gated, or deleted. Each test still
verifies the behaviour it was written for.

One production file changes: `commands/guided_inplace.rs`, for the budget
parameter and its single call site. Behaviour is identical, but it puts the PR
over the `src/**` line, so a changelog fragment is included
(`5840-fetch-retry-budget-parameter.md`).

## Gate — rung 2

```
$ cargo fmt --check                                              # clean
$ cargo clippy -p trusty-mpm --all-targets -- -D warnings        # EXIT=0
$ cargo test -p trusty-mpm --lib
test result: ok. 5191 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out
$ cargo test -p trusty-mpm --test tm_hook_pm_guard
test result: ok. 98 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
$ bash scripts/check_line_cap.sh          # 0 violations
$ bash scripts/check_sld.sh               # 0 errors, 0 warnings
$ bash scripts/check_changelog_fragment.sh # OK trusty-mpm
```

Each formerly-flaky test re-run 10x, all green:

```
# #5813 — under the same filter that was 11/15 red before the fix
$ for i in $(seq 1 10); do cargo test -p trusty-mpm --lib -- \
    tmux_snapshot_unknown_session_is_404 \
    spawn_session_without_tmux_returns_422_on_no_tmux_host \
    adopt_tmux_session_handles_missing home_ _home; done
test result: ok. 46 passed; 0 failed; ...      x10

# #5839 — from a worktree checkout (.git is a file)
$ for i in $(seq 1 10); do cargo test -p trusty-mpm --test tm_hook_pm_guard -- \
    pm_guard_allows_git_status_and_task pm_guard_allows_agent_dispatch_from_pm \
    pm_guard_fanout_fails_open_on_indeterminate_caller; done
test result: ok. 3 passed; 0 failed; ...       x10

# #5840
$ for i in $(seq 1 10); do cargo test -p trusty-mpm --bin tm -- fetch_until_stopped; done
test result: ok. 3 passed; 0 failed; ...       x10
```

### One pre-existing baseline exclusion

`cargo test -p trusty-mpm` was run with `-- --skip guided_fallback`. That is a
run-time filter on the invocation — no `#[ignore]`, no `cfg`-gate, no
`--exclude`; the tests remain in the tree and CI still runs them.

The `guided_fallback_*` family deadlocks on `serial_test`'s local lock
(`serial_test::serial_code_lock::local_serial_core`) and never terminates. This
is PRE-EXISTING and unrelated to this PR: it was reproduced on clean
`origin/main` at `22852ed5c` by the wave-3 bundle-2 agent, which is filing it
(recorded on PR #6069). I hit it independently before that report — a sampled
stack of the stuck binary showed no frame from any file this PR touches, and a
second, unrelated agent worktree sat in the same state for 45+ minutes at the
same time. Runs without the filter report `failures: 0` and are killed mid-hang
rather than failing an assertion.

With the filter, every target is green:

```
$ cargo test -p trusty-mpm -- --skip guided_fallback
EXIT=0
test result: ok. 5191 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out   # --lib
test result: ok. 1754 passed; 0 failed; 1 ignored; 0 measured; 12 filtered out  # --bin tm
test result: ok. 98 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out     # tm_hook_pm_guard
... 47 further integration targets, all ok, 0 failed
```

The 12 filtered-out tests in the `tm` binary are the deadlocking family.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
