### PR TITLE
fix(trusty-mpm): denylist /private/var spelling, project list empty read, session ls --json purity (#5924, #5994, #5950)

### DIFF
--- a/crates/trusty-mpm/changelog.d/5924-cli-correctness-wave3-fixed.md
+++ b/crates/trusty-mpm/changelog.d/5924-cli-correctness-wave3-fixed.md
@@ -1,0 +1,20 @@
+Fixed
+
+- `tm hook --pm-guard` now denies a `git worktree add` under
+  `/private/var/folders`, the spelling macOS's `/var` symlink resolves to
+  (refs [#5924](https://github.com/bobmatnyc/trusty-tools/issues/5924)).
+  The denylist carried `/var/folders` only, and `current_dir()` inside
+  `$TMPDIR` returns the `/private/var/...` form — so a worktree target given
+  relative to a `$TMPDIR` working directory matched nothing and the guard let
+  it through. `/tmp` and `/private/tmp` were already paired this way; `/var`
+  now is too.
+- `tm project list` reads the persistent project registry
+  (`GET /api/v1/projects`) instead of the daemon's in-memory, session-derived
+  project map (refs
+  [#5994](https://github.com/bobmatnyc/trusty-tools/issues/5994)). That map is
+  rebuilt on every daemon start and seeded only from `config.yaml` and session
+  history, so the command reported "no projects registered" on a host whose
+  `projects.json`, `project_list` MCP tool, and `/api/v1/projects` route all
+  listed five. Rows now render like `tm projects list` (name, repo URL,
+  default branch) and keep the `[mcp-trusted]` marker, resolved through the
+  local project-path alias store.

--- a/crates/trusty-mpm/changelog.d/5950-no-prune-flag-added.md
+++ b/crates/trusty-mpm/changelog.d/5950-no-prune-flag-added.md
@@ -1,0 +1,9 @@
+Added
+
+- `tm ls --no-prune` and `tm sessions ls --no-prune` make a listing a pure
+  read: no dead-record decommission, no confirmation-marker write, no prune
+  notice (refs [#5950](https://github.com/bobmatnyc/trusty-tools/issues/5950)).
+  Auto-pruning every listing stays the default (#4702) and is now stated in
+  both commands' `--help` rather than only in a doc comment. The prune's
+  operator lines were already on stderr, so `--json` stdout is parseable JSON
+  either way.

--- a/crates/trusty-mpm/src/bin/tm/cli/actions/session.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli/actions/session.rs
@@ -180,7 +180,8 @@ pub(crate) enum SessionAction {
         #[arg(long)]
         deliverable: Option<String>,
     },
-    /// List managed sessions (session-manager MVP).
+    /// List managed sessions (session-manager MVP). Auto-prunes dead records;
+    /// pass `--no-prune` for a read that changes nothing.
     ///
     /// Why: operators need to see every managed session and its pending decision.
     /// What: GETs `/api/v1/sessions/managed` (with optional source_id filter) and
@@ -234,6 +235,18 @@ pub(crate) enum SessionAction {
         /// Has no effect on `--json` output (raw daemon response is always complete).
         #[arg(long)]
         all: bool,
+        /// Do NOT auto-prune dead records on this listing (#5950).
+        ///
+        /// Every listing decommissions confirmed-dead records by default
+        /// (#4702) — records whose workspace is gone, never a live session —
+        /// so `tm ls` stays usable instead of filling with tombstones. That
+        /// makes a read verb mutate, which is surprising during a census, so
+        /// this flag turns it off for one invocation: no decommission call, no
+        /// confirmation-marker write, no prune notice. The listing then shows
+        /// dead rows it would otherwise have hidden, because nothing swept
+        /// them.
+        #[arg(long)]
+        no_prune: bool,
     },
     /// Show recent activity for a managed session.
     ///

--- a/crates/trusty-mpm/src/bin/tm/cli/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli/mod.rs
@@ -865,7 +865,9 @@ pub(crate) enum Command {
         root: Option<String>,
     },
 
-    /// Interactive managed-session connector — list sessions and connect (#2311).
+    /// Interactive managed-session connector — list sessions and connect
+    /// (#2311). Auto-prunes dead records; `--no-prune` for a read that
+    /// changes nothing.
     ///
     /// Why: bare `tm ls` should do the most useful fleet action for the operator's
     /// current context. On a real terminal it opens the interactive session picker
@@ -956,6 +958,17 @@ pub(crate) enum Command {
         /// `filter_attached_*`, `ls_connector_should_show_picker_attached_static`.
         #[arg(long, short = 'a')]
         attached: bool,
+        /// Do NOT auto-prune dead records on this listing (session mode only,
+        /// #5950).
+        ///
+        /// Every listing decommissions confirmed-dead records by default
+        /// (#4702) — records whose workspace is gone, never a live session.
+        /// This flag turns that off for one invocation, making the listing a
+        /// pure read: no decommission call, no confirmation-marker write, no
+        /// prune notice. Dead rows the sweep would have hidden stay visible,
+        /// because nothing classified them.
+        #[arg(long)]
+        no_prune: bool,
         /// Override the managed root (default: `~/.trusty-mpm`). `--projects` only.
         ///
         /// Precedence: this flag > `TRUSTY_MPM_ROOT` env var >

--- a/crates/trusty-mpm/src/bin/tm/commands/managed.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed.rs
@@ -188,12 +188,19 @@ pub(crate) fn filter_live_sessions(
 /// unsorted passthrough, matching `--all`'s existing "no effect on --json"
 /// precedent.
 ///
-/// #4702: this path — every piped, scripted, and `--json` listing — now runs
-/// the same dead-record auto-prune the interactive picker runs. It previously
-/// ran none, which is why dead records accumulated without bound for anyone not
+/// #4702: this path — every piped, scripted, and `--json` listing — runs the
+/// same dead-record auto-prune the interactive picker runs. It previously ran
+/// none, which is why dead records accumulated without bound for anyone not
 /// using the TTY picker. See
 /// [`session_picker_prune::prune_and_report`](crate::commands::session_picker_prune::prune_and_report)
-/// for why doing this unconditionally is safe.
+/// for why doing this by default is safe.
+///
+/// #5950: a listing verb that mutates surprised an operator taking a fleet
+/// census, so `no_prune` (`tm ls --no-prune`, `tm sessions ls --no-prune`)
+/// turns it off for one invocation and the default is stated in the `ls`
+/// help rather than only in this doc comment. The prune's own operator lines
+/// go to STDERR (`prune_and_report_at`), so `--json` stdout is parseable JSON
+/// with or without the flag.
 /// Test: HTTP path covered by the integration test; filter logic unit-tested by
 /// `ls_source_id_filter_selects_correct_slug`,
 /// `picker_filter_excludes_decommissioned_keeps_active`; sort/filter logic by
@@ -211,8 +218,15 @@ pub(crate) async fn session_ls(
     attached: bool,
     sort: crate::commands::session_picker::SessionSortArg,
     term: Option<crate::commands::session_picker::SessionFilter>,
+    no_prune: bool,
 ) -> anyhow::Result<()> {
-    let ctx = crate::commands::session_picker_prune::PruneContext::production();
+    // #5950: `--no-prune` is the operator's explicit "this read must not
+    // mutate" — it selects a context that sweeps nothing.
+    let ctx = if no_prune {
+        crate::commands::session_picker_prune::PruneContext::disabled()
+    } else {
+        crate::commands::session_picker_prune::PruneContext::production()
+    };
     session_ls_at(
         client, url, json, source_id, all, attached, sort, term, &ctx,
     )

--- a/crates/trusty-mpm/src/bin/tm/commands/managed_route.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed_route.rs
@@ -452,6 +452,7 @@ mod tests {
                 source_id: None,
                 current: false,
                 all: false,
+                no_prune: false,
             }),
             Some(TrustyCommand::ManagedList)
         ));

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/mod.rs
@@ -531,12 +531,25 @@ pub(crate) const WORKTREE_TMP_REASON: &str = "`git worktree add` must not target
 /// symlink) but both are listed literally because [`resolves_under_denylisted_tmp`]
 /// does a lexical prefix match, not a filesystem-resolving one (see that
 /// function's doc for why). `/var/folders` is the root `$TMPDIR` resolves
-/// under on macOS (e.g. `/var/folders/x1/…/T/`), and the harness scratchpad
-/// (`/private/tmp/claude-502/…`) is already covered by the `/private/tmp`
-/// entry — it is called out separately in the deny message (not here) because
-/// agents are told to prefer it "instead of /tmp", making it the subtle case
-/// that looks compliant while still landing in a denylisted zone.
-const WORKTREE_TMP_DENYLIST_ROOTS: &[&str] = &["/tmp", "/private/tmp", "/var/folders"];
+/// under on macOS (e.g. `/var/folders/x1/…/T/`), and `/var` is itself a
+/// symlink to `/private/var`, so `/private/var/folders` is the SAME location
+/// under its resolved spelling and needs the same paired entry `/tmp` already
+/// has. `current_dir()` inside `$TMPDIR` returns that resolved spelling, so
+/// without this entry a cwd-relative target resolved from a
+/// `/private/var/folders` working directory slipped past the guard (#5924).
+/// The harness scratchpad (`/private/tmp/claude-502/…`) is already covered by
+/// the `/private/tmp` entry — it is called out separately in the deny message
+/// (not here) because agents are told to prefer it "instead of /tmp", making
+/// it the subtle case that looks compliant while still landing in a
+/// denylisted zone.
+const WORKTREE_TMP_DENYLIST_ROOTS: &[&str] = &[
+    "/tmp",
+    "/private/tmp",
+    "/var/folders",
+    // #5924: /var is a symlink to /private/var, so $TMPDIR's resolved spelling
+    // needs the same paired entry /tmp already has.
+    "/private/var/folders",
+];
 
 /// `git worktree add`'s own flags that consume a following argv token.
 ///
@@ -589,10 +602,11 @@ const WORKTREE_ADD_FLAGS_WITH_ARG: &[&str] = &["-b", "-B", "--reason"];
 ///   yet and a guard must stay fast and side-effect-free.
 ///   `resolves_under_denylisted_tmp` therefore cannot see through a symlink
 ///   the way the OS eventually would.
-///   `/tmp` itself being a symlink to `/private/tmp` is NOT in this bucket —
-///   both spellings are literal entries in [`WORKTREE_TMP_DENYLIST_ROOTS`],
-///   so a literal `/tmp/...` argument is caught without needing to resolve
-///   the symlink.
+///   `/tmp` itself being a symlink to `/private/tmp`, and `/var` to
+///   `/private/var`, are NOT in this bucket — both spellings of each are
+///   literal entries in [`WORKTREE_TMP_DENYLIST_ROOTS`] (#5924), so a literal
+///   `/tmp/...` or `/private/var/folders/...` argument is caught without
+///   needing to resolve the symlink.
 /// - Multiple/cumulative `git -C` flags are collapsed to "the last one
 ///   present"; real git applies them successively relative to each other.
 ///   Realistic invocations use at most one `-C`.

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/tests.rs
@@ -789,6 +789,45 @@ fn evaluate_worktree_add_command_resolves_relative_target_against_cwd() {
     );
 }
 
+/// Both spellings of macOS's `$TMPDIR` root deny, cwd-relative included (#5924).
+///
+/// Why: `/var` is a symlink to `/private/var`, and `current_dir()` inside
+/// `$TMPDIR` returns the resolved `/private/var/folders/...` spelling. The
+/// denylist carried only `/var/folders`, so a relative target resolved from
+/// that cwd matched nothing and the guard let it through — the same paired-entry
+/// treatment `/tmp` and `/private/tmp` already had was never applied to `/var`.
+#[test]
+fn evaluate_worktree_add_command_denies_both_var_folders_spellings() {
+    for cwd in [
+        Path::new("/var/folders/x1/abc/T"),
+        Path::new("/private/var/folders/x1/abc/T"),
+    ] {
+        assert_eq!(
+            evaluate_worktree_add_command("git worktree add wt-x", cwd),
+            Some(WORKTREE_TMP_REASON),
+            "cwd-relative target must deny from: {}",
+            cwd.display()
+        );
+    }
+    let proj = Path::new("/Users/x/proj");
+    for cmd in [
+        "git worktree add /private/var/folders/x1/abc/T/wt-x",
+        "cd /private/var/folders/x1/abc/T && git worktree add wt-x",
+        "git -C /private/var/folders/x1/abc/T worktree add wt-x",
+    ] {
+        assert_eq!(
+            evaluate_worktree_add_command(cmd, proj),
+            Some(WORKTREE_TMP_REASON),
+            "expected deny for: {cmd}"
+        );
+    }
+    // `/private/var` outside `folders/` is ordinary system state, not scratch.
+    assert_eq!(
+        evaluate_worktree_add_command("git worktree add /private/var/lib/wt-x", proj),
+        None
+    );
+}
+
 #[test]
 fn evaluate_worktree_add_command_follows_cd_prefix() {
     // `cd /tmp && git worktree add wt-foo` — the cwd change must be tracked

--- a/crates/trusty-mpm/src/bin/tm/commands/project.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/project.rs
@@ -11,10 +11,7 @@
 //! `project_init_keeps_existing_config` in `tests_behavior_a.rs`,
 //! `project_trust_grants_and_revokes` in `tests_project_trust_tests.rs`.
 
-use serde::Deserialize;
-
 use crate::cli::ProjectAction;
-use crate::types::ProjectRow;
 
 /// Resolve a `--dir` option to an absolute path, defaulting to the cwd.
 ///
@@ -36,10 +33,11 @@ pub(crate) fn resolve_dir(dir: Option<String>) -> anyhow::Result<std::path::Path
 /// hand-crafting HTTP requests. `Trust` additionally lets them consent to
 /// project-scope custom MCP bridging (issue #3033).
 /// What: `Init` registers the directory (`POST /projects`) and scaffolds a
-/// local `.trusty-mpm/`; `List` prints `GET /projects` with an
-/// `[mcp-trusted]` marker per project; `Info` prints the current directory's
-/// project via `GET /projects/current` plus its trust status; `Trust` is
-/// handled entirely locally by [`trust_cmd`] (no daemon round-trip — see its
+/// local `.trusty-mpm/`; `List` prints the persistent registry
+/// (`GET /api/v1/projects`, see [`list_rows`] for why not `GET /projects`)
+/// with an `[mcp-trusted]` marker per project; `Info` prints the current
+/// directory's project via `GET /projects/current` plus its trust status;
+/// `Trust` is handled entirely locally by [`trust_cmd`] (no daemon round-trip — see its
 /// own doc). Trust status in `List`/`Info` is read from the SAME local
 /// `core::project_trust` store `Trust` writes, never from the daemon.
 /// Test: `cli_parses_project_init`, `cli_parses_project_list`,
@@ -71,27 +69,10 @@ pub(crate) async fn project(
             println!("registered project '{name}' at {}", path.display());
         }
         ProjectAction::List => {
-            #[derive(Deserialize)]
-            struct Body {
-                projects: Vec<ProjectRow>,
-            }
-            let body: Body = client
-                .get(format!("{url}/projects"))
-                .send()
-                .await?
-                .error_for_status()?
-                .json()
-                .await?;
-            if body.projects.is_empty() {
-                println!("no projects registered");
-            }
-            for p in &body.projects {
-                let trust_marker = if trusty_mpm::core::project_trust::is_project_trusted(&p.path) {
-                    " [mcp-trusted]"
-                } else {
-                    ""
-                };
-                println!("{} {}{trust_marker}", p.name, p.path.display());
+            // #5994: rows come from the persistent registry, not the daemon's
+            // in-memory session-derived project map.
+            for row in list_rows(client, url).await? {
+                println!("{row}");
             }
         }
         ProjectAction::Info { dir } => {
@@ -116,6 +97,67 @@ pub(crate) async fn project(
         ProjectAction::Trust { dir, revoke } => trust_cmd(dir, revoke)?,
     }
     Ok(())
+}
+
+/// The lines `tm project list` prints, read from the PERSISTENT registry.
+///
+/// Why (#5994): this verb used to `GET /projects`, which is
+/// `DaemonState::projects` — an in-memory `HashMap` rebuilt on every daemon
+/// start and populated only from `config.yaml` and session history. On a host
+/// whose `~/.trusty-mpm/project-registry/projects.json`, `project_list` MCP
+/// tool, and `GET /api/v1/projects` route all listed five projects, that map
+/// was empty and the command printed "no projects registered". `/api/v1/projects`
+/// is the authoritative surface — it is served straight from the on-disk
+/// registry, and it is the same store the MCP tool reads — so this reads there.
+/// What: `GET /api/v1/projects` via [`trusty_mpm::client::DaemonClient::registry_list_projects`],
+/// rendered by the SAME [`crate::commands::projects::registry::render_project_line`]
+/// `tm projects list` uses, plus the `[mcp-trusted]` marker this verb has always
+/// carried. Trust is keyed on a local PATH and the registry record holds none,
+/// so the local alias store (`~/.trusty-mpm/project-paths.json`) supplies it;
+/// a project with no local alias simply gets no marker. Returns the rows
+/// instead of printing them so a test can assert both the endpoint and the text.
+/// Test: `project_list_reads_the_persistent_registry`,
+/// `project_list_row_marks_a_trusted_local_path`.
+pub(crate) async fn list_rows(client: &reqwest::Client, url: &str) -> anyhow::Result<Vec<String>> {
+    let projects = trusty_mpm::client::DaemonClient::with_client(client.clone(), url.to_string())
+        .registry_list_projects(None)
+        .await?;
+    if projects.is_empty() {
+        return Ok(vec!["no projects registered".to_string()]);
+    }
+    let aliases = local_project_paths();
+    Ok(projects
+        .iter()
+        .map(|p| {
+            let trusted = aliases
+                .get(&p.name)
+                .is_some_and(|path| trusty_mpm::core::project_trust::is_project_trusted(path));
+            project_list_row(p, trusted)
+        })
+        .collect())
+}
+
+/// One `tm project list` row: the shared registry line plus the trust marker.
+pub(crate) fn project_list_row(p: &trusty_mpm::project::Project, trusted: bool) -> String {
+    let marker = if trusted { " [mcp-trusted]" } else { "" };
+    format!(
+        "{}{marker}",
+        crate::commands::projects::registry::render_project_line(p)
+    )
+}
+
+/// `alias → local path` from `~/.trusty-mpm/project-paths.json`, best-effort.
+///
+/// Why: an unreadable or absent alias store must degrade to "no marker", never
+/// fail the listing — the registry rows are the answer the operator asked for.
+fn local_project_paths() -> std::collections::HashMap<String, std::path::PathBuf> {
+    let root = trusty_mpm::core::paths::FrameworkPaths::default().root;
+    trusty_mpm::core::project_aliases::ProjectAliasStore::load(&root)
+        .unwrap_or_default()
+        .list()
+        .iter()
+        .map(|e| (e.alias.clone(), e.path.clone()))
+        .collect()
 }
 
 /// `project trust` / `project trust --revoke` handler (issue #3033).

--- a/crates/trusty-mpm/src/bin/tm/commands/projects/registry.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/projects/registry.rs
@@ -367,10 +367,12 @@ fn normalize_bool_flag(value: &str) -> anyhow::Result<String> {
 
 /// Render one project as a compact `name  repo_url  (branch)` line.
 ///
-/// Why: shared between `list` and `show`; a pure helper keeps it testable.
+/// Why: shared between `list`, `show`, and the singular `tm project list`
+/// (#5994), which appends its own `[mcp-trusted]` marker to this line rather
+/// than growing a second renderer that could drift from it.
 /// What: name, repo URL, and default branch on one line.
 /// Test: `render_project_line_basic`.
-fn render_project_line(p: &Project) -> String {
+pub(crate) fn render_project_line(p: &Project) -> String {
     format!("{}\t{}\t({})", p.name, p.repo_url, p.default_branch)
 }
 

--- a/crates/trusty-mpm/src/bin/tm/commands/session.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session.rs
@@ -357,6 +357,7 @@ pub(crate) async fn session(
             source_id,
             current,
             all,
+            no_prune,
         } => {
             let sid: Option<String> = if current {
                 derive_source_id_from_cwd()
@@ -377,6 +378,8 @@ pub(crate) async fn session(
                 false,
                 sort,
                 filter,
+                // #5950: explicit opt-out from the default listing auto-prune.
+                no_prune,
             )
             .await?
         }

--- a/crates/trusty-mpm/src/bin/tm/commands/session_ls_connector.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_ls_connector.rs
@@ -78,6 +78,7 @@ pub(crate) async fn run_ls_connector(
     attached: bool,
     sort: SessionSortArg,
     term: Option<SessionFilter>,
+    no_prune: bool,
 ) -> anyhow::Result<()> {
     // `--current` derives the source_id from the cwd git remote, exactly like
     // `tm session ls --current`. `--source-id` and `--current` are mutually
@@ -107,6 +108,8 @@ pub(crate) async fn run_ls_connector(
             attached,
             sort,
             term,
+            // #5950: the operator's explicit "this read must not mutate".
+            no_prune,
         )
         .await;
     }
@@ -126,6 +129,7 @@ pub(crate) async fn run_ls_connector(
                 false,
                 sort,
                 term,
+                no_prune,
             )
             .await;
         }

--- a/crates/trusty-mpm/src/bin/tm/commands/session_picker_filter.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_picker_filter.rs
@@ -304,6 +304,8 @@ pub(crate) async fn run_f_command(
             false,
             SessionSortArg::Recent,
             filter,
+            // `tm f` has no `--no-prune` flag; its fallback keeps the #4702 default.
+            false,
         )
         .await;
     }

--- a/crates/trusty-mpm/src/bin/tm/commands/session_picker_prune.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_picker_prune.rs
@@ -243,6 +243,15 @@ pub(crate) struct PruneContext {
     /// Live tmux session names, or `None` when tmux could not be enumerated at
     /// all — which [`auto_prune_dead_records_at`] treats as "prune nothing".
     pub(crate) live_tmux_names: Option<HashSet<String>>,
+    /// Whether the listing may prune at all (`tm ls --no-prune` clears it).
+    ///
+    /// Why (#5950): auto-pruning every listing is deliberate (#4702) and stays
+    /// the default, but `tm sessions ls` is a READ verb and an operator taking
+    /// a census — or a script sampling the fleet — is entitled to a run that
+    /// provably changes nothing. `false` skips the sweep entirely: no
+    /// decommission call, no marker write, and no operator notice, so the
+    /// listing is a pure read.
+    pub(crate) enabled: bool,
 }
 
 impl PruneContext {
@@ -252,6 +261,19 @@ impl PruneContext {
         Self {
             marker_path: default_marker_path(),
             live_tmux_names: live_tmux_session_names(),
+            enabled: true,
+        }
+    }
+
+    /// A context that prunes nothing — `tm ls --no-prune` (#5950).
+    ///
+    /// Why: neither input is resolved, so the read path never touches the
+    /// marker file and never shells out to tmux either.
+    pub(crate) fn disabled() -> Self {
+        Self {
+            marker_path: PathBuf::new(),
+            live_tmux_names: None,
+            enabled: false,
         }
     }
 
@@ -264,7 +286,20 @@ impl PruneContext {
         Self {
             marker_path,
             live_tmux_names,
+            enabled: true,
         }
+    }
+
+    /// Clear [`enabled`](Self::enabled), leaving every other input untouched.
+    ///
+    /// Why: lets a test hold the marker file and tmux set fixed and vary ONLY
+    /// the `--no-prune` bit, so `session_ls_no_prune_makes_the_read_non_mutating`
+    /// differs from `session_ls_json_passthrough_prunes_dead_records` by that
+    /// bit alone.
+    #[cfg(test)]
+    pub(crate) fn without_prune(mut self) -> Self {
+        self.enabled = false;
+        self
     }
 }
 
@@ -327,8 +362,11 @@ pub(crate) async fn prune_and_report(
 /// `~/.trusty-mpm/auto-prune-seen.json`, and must never depend on whether the
 /// machine running it has tmux. See [`PruneContext`] for the CI failure that
 /// made the second half of that non-negotiable.
-/// What: see [`prune_and_report`].
-/// Test: `session_ls_prunes_dead_records_on_piped_invocation`.
+/// What: see [`prune_and_report`]. A context built by [`PruneContext::disabled`]
+/// (`tm ls --no-prune`, #5950) returns `sessions` untouched with an empty
+/// `dead_ids` — nothing is swept, so nothing is classified.
+/// Test: `session_ls_prunes_dead_records_on_piped_invocation`,
+/// `session_ls_no_prune_makes_the_read_non_mutating`.
 pub(crate) async fn prune_and_report_at(
     client: &reqwest::Client,
     url: &str,
@@ -336,6 +374,16 @@ pub(crate) async fn prune_and_report_at(
     ctx: &PruneContext,
     hides_dead_rows: bool,
 ) -> PrunedListing {
+    // #5950: `--no-prune` makes the listing a pure read — no sweep, no
+    // decommission call, no marker write, and no operator notice.
+    // #5950: `--no-prune` makes the listing a pure read — no sweep, no
+    // decommission call, no marker write, and no operator notice.
+    if !ctx.enabled {
+        return PrunedListing {
+            sessions,
+            dead_ids: HashSet::new(),
+        };
+    }
     let outcome = auto_prune_dead_records_at(
         client,
         url,

--- a/crates/trusty-mpm/src/bin/tm/main.rs
+++ b/crates/trusty-mpm/src/bin/tm/main.rs
@@ -575,6 +575,7 @@ async fn main() -> anyhow::Result<()> {
             current,
             all,
             attached,
+            no_prune,
             root,
         }) => {
             if projects {
@@ -589,7 +590,7 @@ async fn main() -> anyhow::Result<()> {
                 // #3483 scope: `tm ls <term>` matches every visible column.
                 let filter = term.map(commands::session_picker::SessionFilter::visible);
                 commands::session_ls_connector::run_ls_connector(
-                    &client, &url, json, source_id, current, all, attached, sort, filter,
+                    &client, &url, json, source_id, current, all, attached, sort, filter, no_prune,
                 )
                 .await
             }

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_d_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_d_tests.rs
@@ -782,6 +782,7 @@ fn cli_parses_ls_connector_bare() {
             current,
             all,
             attached,
+            no_prune,
             root,
         } => {
             assert!(
@@ -794,6 +795,7 @@ fn cli_parses_ls_connector_bare() {
             assert!(!current);
             assert!(!all);
             assert!(!attached, "bare `tm ls` must not set --attached");
+            assert!(!no_prune, "bare `tm ls` keeps the #4702 auto-prune");
             assert!(root.is_none());
         }
         other => panic!("expected top-level ls, got {other:?}"),
@@ -2993,6 +2995,85 @@ async fn session_ls_json_passthrough_prunes_dead_records() {
     assert!(
         !live.iter().any(|s| s.id == id.to_string()),
         "`tm ls --json` must clear a confirmed dead record from the registry"
+    );
+}
+
+/// `--no-prune` makes the listing a pure read (#5950).
+///
+/// Why: `tm sessions ls --all --json` is a READ verb, and it decommissioned
+/// three records during a fleet census without being asked to. The default
+/// stays as #4702 set it — the two tests above pin that — but an operator who
+/// needs a listing that provably changes nothing now has a flag for it. This
+/// is the exact setup of `session_ls_json_passthrough_prunes_dead_records`
+/// with `PruneContext::disabled()` swapped in, so the ONLY difference between
+/// "record gone" and "record intact" is the flag.
+#[tokio::test]
+async fn session_ls_no_prune_makes_the_read_non_mutating() {
+    let root = tempfile::TempDir::new().expect("tempdir");
+    let marker_path = root.path().join("seen.json");
+    let state = std::sync::Arc::new(
+        DaemonState::with_root_isolated_managed(root.path().to_path_buf()).await,
+    );
+    let mgr = state.session_manager().await;
+    let id = seed_dead_session(&mgr, root.path(), "no-prune").await;
+
+    let server = LocalTestServer::spawn(state).await;
+    let client = reqwest::Client::new();
+
+    let ls_json = async |ctx: &crate::commands::session_picker_prune::PruneContext| {
+        crate::commands::managed::session_ls_at(
+            &client,
+            &server.url,
+            true, // json = true: the raw passthrough path
+            None,
+            false,
+            false,
+            crate::commands::session_picker::SessionSortArg::Recent,
+            None,
+            ctx,
+        )
+        .await
+        .expect("session_ls --json --no-prune");
+    };
+
+    // Pre-seed the record as already CONFIRMED (sighted long ago), so a single
+    // listing with the prune on would clear it. The only thing standing between
+    // this record and a tombstone is the flag.
+    let mut seen = std::collections::HashMap::new();
+    seen.insert(id.to_string(), "2020-01-01T00:00:00Z".to_string());
+    std::fs::write(
+        &marker_path,
+        serde_json::to_string(&seen).expect("serialize marker"),
+    )
+    .expect("write marker");
+
+    // Identical context to the passing sibling test above, with ONLY the
+    // `--no-prune` bit cleared — same marker file, same tmux set.
+    ls_json(&hermetic_prune_ctx(&marker_path).without_prune()).await;
+    ls_json(&hermetic_prune_ctx(&marker_path).without_prune()).await;
+
+    let live = default_view_pre_4994(fetch_raw_live(&client, &server.url).await);
+    assert!(
+        live.iter().any(|s| s.id == id.to_string()),
+        "`--no-prune` must leave the record live, not tombstoned"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&marker_path).expect("read marker"),
+        serde_json::to_string(&seen).expect("serialize marker"),
+        "`--no-prune` must not rewrite the confirmation marker either"
+    );
+}
+
+/// `--no-prune` is what selects that context, and nothing else does (#5950).
+#[test]
+fn no_prune_flag_selects_the_non_mutating_prune_context() {
+    assert!(
+        !crate::commands::session_picker_prune::PruneContext::disabled().enabled,
+        "--no-prune must disable the sweep"
+    );
+    assert!(
+        crate::commands::session_picker_prune::PruneContext::production().enabled,
+        "the default listing keeps the #4702 auto-prune"
     );
 }
 

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_e_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_e_tests.rs
@@ -631,3 +631,79 @@ fn scope_for_display_hides_tombstone_by_default_and_all_shows_it() {
         "--all must list the tombstone at its original slot, in slot order"
     );
 }
+
+// ── `--no-prune` on both listing surfaces (#5950) ────────────────────────────
+
+/// Both `ls` surfaces accept `--no-prune`, and neither prunes-by-default flips.
+///
+/// Why (#5950): auto-pruning every listing is deliberate (#4702), but it makes
+/// a read verb mutate — three records were decommissioned during a fleet census
+/// that only asked for `--all --json`. The opt-out has to exist on the surface
+/// the operator actually types, which is `tm ls` as often as `tm sessions ls`.
+#[test]
+fn cli_parses_no_prune_on_both_listing_surfaces() {
+    let top = Cli::try_parse_from(["trusty-mpm", "ls", "--json", "--no-prune"]).unwrap();
+    match top.command.unwrap() {
+        Command::Ls { no_prune, json, .. } => {
+            assert!(no_prune, "top-level `tm ls --no-prune` must parse to true");
+            assert!(json);
+        }
+        other => panic!("expected top-level ls, got {other:?}"),
+    }
+
+    let sessions =
+        Cli::try_parse_from(["trusty-mpm", "sessions", "ls", "--all", "--no-prune"]).unwrap();
+    match sessions.command.unwrap() {
+        Command::Sessions {
+            action: SessionAction::Ls { no_prune, all, .. },
+        } => {
+            assert!(no_prune, "`tm sessions ls --no-prune` must parse to true");
+            assert!(all);
+        }
+        other => panic!("expected sessions ls, got {other:?}"),
+    }
+
+    // Absent the flag, the #4702 default is unchanged on both surfaces.
+    match Cli::try_parse_from(["trusty-mpm", "ls"])
+        .unwrap()
+        .command
+        .unwrap()
+    {
+        Command::Ls { no_prune, .. } => assert!(!no_prune),
+        other => panic!("expected top-level ls, got {other:?}"),
+    }
+    match Cli::try_parse_from(["trusty-mpm", "sessions", "ls"])
+        .unwrap()
+        .command
+        .unwrap()
+    {
+        Command::Sessions {
+            action: SessionAction::Ls { no_prune, .. },
+        } => assert!(!no_prune),
+        other => panic!("expected sessions ls, got {other:?}"),
+    }
+}
+
+/// The `ls` help states that a plain listing prunes (#5950 closure condition).
+///
+/// Why: the reporter's objection was not that pruning happens but that nothing
+/// at the call site said it would. A doc comment in `managed.rs` is not the
+/// call site an operator sees; `--help` is.
+#[test]
+fn ls_help_states_that_a_plain_listing_prunes() {
+    let render = |argv: &[&str]| {
+        Cli::try_parse_from(argv)
+            .expect_err("--help exits through clap's error channel")
+            .to_string()
+    };
+    for argv in [
+        ["trusty-mpm", "ls", "--help"].as_slice(),
+        ["trusty-mpm", "sessions", "ls", "--help"].as_slice(),
+    ] {
+        let help = render(argv);
+        assert!(
+            help.contains("prune"),
+            "`{argv:?}` help must tell the operator this listing prunes: {help}"
+        );
+    }
+}

--- a/crates/trusty-mpm/src/bin/tm/tests_projects.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_projects.rs
@@ -442,3 +442,92 @@ fn cli_parses_projects_milestones_show() {
         other => panic!("expected show, got {other:?}"),
     }
 }
+
+// ── `tm project list` reads the persistent registry (#5994) ──────────────────
+
+/// Build a minimal registry record without restating all twelve fields.
+fn registry_project() -> trusty_mpm::project::Project {
+    serde_json::from_value(serde_json::json!({
+        "name": "widget",
+        "repo_url": "https://github.com/acme/widget",
+        "default_branch": "main"
+    }))
+    .expect("deserialize a minimal Project")
+}
+
+/// `tm project list` must query the registry that actually holds the projects.
+///
+/// Why (#5994): the verb used to `GET /projects`, the daemon's in-memory
+/// session-derived project map. On a live host that route answered
+/// `{"projects":[]}` while `GET /api/v1/projects` — the on-disk registry the
+/// `project_list` MCP tool also reads — answered with five projects, so the
+/// command reported "no projects registered" against a fully populated
+/// registry. This stub serves ONLY `/api/v1/projects` and records every path it
+/// is asked for: against the pre-fix code the request lands on `/projects`, the
+/// stub answers 404, and `list_rows` returns an error instead of a row.
+#[tokio::test]
+async fn project_list_reads_the_persistent_registry() {
+    use std::sync::{Arc, Mutex};
+
+    let seen: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let recorder = seen.clone();
+    let app = axum::Router::new()
+        .route(
+            "/api/v1/projects",
+            axum::routing::get(|| async {
+                axum::Json(serde_json::json!({ "projects": [ {
+                    "name": "widget",
+                    "repo_url": "https://github.com/acme/widget",
+                    "default_branch": "main"
+                } ] }))
+            }),
+        )
+        .layer(axum::middleware::from_fn(
+            move |req: axum::extract::Request, next: axum::middleware::Next| {
+                let recorder = recorder.clone();
+                async move {
+                    if let Ok(mut paths) = recorder.lock() {
+                        paths.push(req.uri().path().to_string());
+                    }
+                    next.run(req).await
+                }
+            },
+        ));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind loopback port");
+    let addr = listener.local_addr().expect("resolve bound addr");
+    let handle = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    let url = format!("http://{addr}");
+
+    let rows = crate::commands::project::list_rows(&reqwest::Client::new(), &url)
+        .await
+        .expect("list_rows against the registry route");
+    handle.abort();
+
+    assert_eq!(rows.len(), 1, "one registered project, one row: {rows:?}");
+    assert!(
+        rows[0].starts_with("widget\thttps://github.com/acme/widget"),
+        "row must carry the registry record: {}",
+        rows[0]
+    );
+    assert_eq!(
+        seen.lock().expect("recorded request paths").as_slice(),
+        ["/api/v1/projects"],
+        "`tm project list` must read the persistent registry, never the \
+         in-memory session-derived map at /projects"
+    );
+}
+
+/// The `[mcp-trusted]` marker survives the move to the registry route (#5994).
+#[test]
+fn project_list_row_marks_a_trusted_local_path() {
+    let p = registry_project();
+    assert!(
+        crate::commands::project::project_list_row(&p, true).ends_with(" [mcp-trusted]"),
+        "a trusted project keeps the marker this verb has always carried"
+    );
+    assert!(!crate::commands::project::project_list_row(&p, false).contains("mcp-trusted"));
+}

--- a/crates/trusty-mpm/src/bin/tm/types.rs
+++ b/crates/trusty-mpm/src/bin/tm/types.rs
@@ -3,8 +3,10 @@
 //! Why: the thin CLI handlers deserialize daemon API responses into typed
 //! structs; centralising them keeps the handler files free of boilerplate
 //! and avoids duplicate definitions.
-//! What: `SessionRow`, `ProjectRow`, and `EventRow` mirror the shapes returned
-//! by `GET /sessions`, `GET /projects`, and `GET /events/poll`.
+//! What: `SessionRow` and `EventRow` mirror the shapes returned by
+//! `GET /sessions` and `GET /events/poll`. `ProjectRow` (the `GET /projects`
+//! shape) went away with #5994 — `tm project list` reads the persistent
+//! registry through `DaemonClient` and its typed `Project` record instead.
 //! Test: deserialization is exercised indirectly by the handler unit tests.
 
 use serde::Deserialize;
@@ -21,15 +23,6 @@ pub(crate) struct SessionRow {
     /// Number of active delegations.
     #[serde(default)]
     pub(crate) active_delegations: u32,
-}
-
-/// One project row as returned by `GET /projects`.
-#[derive(Debug, Deserialize)]
-pub(crate) struct ProjectRow {
-    /// Absolute project path.
-    pub(crate) path: std::path::PathBuf,
-    /// Human-readable project name.
-    pub(crate) name: String,
 }
 
 /// One event row as returned by `GET /events`.


### PR DESCRIPTION
Three localized CLI/diagnostics defects in `trusty-mpm`, one crate, one PR.

Refs #5924
Refs #5994
Refs #5950

## #5924 — the worktree denylist missed the `/private/var` spelling

`WORKTREE_TMP_DENYLIST_ROOTS` carried `/var/folders` but not
`/private/var/folders`. `/var` is a symlink to `/private/var`, and
`current_dir()` inside `$TMPDIR` returns the resolved form, so a `git worktree
add` target given relative to a `$TMPDIR` working directory matched nothing and
the guard allowed it. `/tmp` and `/private/tmp` were already paired this way for
exactly this reason; `/var` now is too. The match stays lexical — no
`fs::canonicalize`, because the target usually does not exist yet.

## #5994 — `tm project list` read the wrong registry

The verb hit `GET /projects`, which is `DaemonState::projects`: a `HashMap`
rebuilt on every daemon start, seeded only from `config.yaml` and session
history. Reproduced live against the running daemon:

```
$ curl -s http://127.0.0.1:7880/projects
{"projects":[]}
$ curl -s http://127.0.0.1:7880/api/v1/projects
{"projects":[{"name":"hotstats-knowledgebase",...}, ...]}
```

`/api/v1/projects` is served from `~/.trusty-mpm/project-registry/projects.json`
and is what the `project_list` MCP tool reads. `tm project list` now reads it,
renders the same line `tm projects list` renders (name, repo URL, default
branch — one shared helper, not a second renderer), and keeps its
`[mcp-trusted]` marker: trust is keyed on a local path and the registry record
holds none, so the local alias store `~/.trusty-mpm/project-paths.json` supplies
it. A project with no local alias simply gets no marker. `ProjectRow`, the old
`GET /projects` wire shape, had no remaining consumer and is deleted.

## #5950 — `tm session ls --json` prunes, and its stdout

Two halves, and only one was a defect.

**(a) The read mutates — real, and deliberate.** #4702 moved the dead-record
auto-prune out of the TTY-only path into every listing on purpose, because
records otherwise accumulated without bound for anyone not driving the picker
(48 of 66 stale on the reporting machine). That default is unchanged. What was
missing is a way to opt out and any statement at the call site the operator
sees: `tm ls --no-prune` and `tm sessions ls --no-prune` now make a listing a
pure read — no decommission call, no confirmation-marker write, no notice — and
both commands' `--help` state that a plain listing prunes.

**(b) Status text in the JSON stream — not reproducible.** The prune's operator
lines are `eprintln!` (`session_picker_prune.rs:348,355`), and a live run of the
installed `tm` 1.4.3 confirms it:

```
$ tm sessions ls --all --json > /tmp/sess.json 2>/tmp/sess.err
$ python3 -c "import json;json.load(open('/tmp/sess.json'))"   # parses clean
$ cat /tmp/sess.err
tm: pruned 2 dead records (workspace gone)
```

stdout was already pure JSON; the reporter saw the two streams interleaved on a
terminal. No code change was warranted for that half, and none was made.

## Regression tests — how each was proven to fail first

Each was run against the pre-fix behavior before the fix landed.

| Issue | Test | Pre-fix proof |
|---|---|---|
| #5924 | `evaluate_worktree_add_command_denies_both_var_folders_spellings` | Ran with the denylist const reverted: `assertion left == right failed: cwd-relative target must deny from: /private/var/folders/x1/abc/T`, `test result: FAILED. 0 passed; 1 failed` |
| #5994 | `project_list_reads_the_persistent_registry` | Ran with `list_rows` pointed back at `GET /projects`: `list_rows against the registry route: HTTP status client error (404 Not Found) for url (http://127.0.0.1:49652/projects)`, `test result: FAILED. 0 passed; 1 failed` |
| #5950 | `session_ls_no_prune_makes_the_read_non_mutating` | Ran with the `if !ctx.enabled` early return deleted: ``--no-prune` must leave the record live, not tombstoned`, `test result: FAILED. 0 passed; 1 failed` |

The #5950 test is `session_ls_json_passthrough_prunes_dead_records` with one bit
changed — same marker file, same tmux set, `enabled` cleared — so the only thing
standing between the record and a tombstone is the flag. Supporting tests:
`project_list_row_marks_a_trusted_local_path`,
`no_prune_flag_selects_the_non_mutating_prune_context`,
`cli_parses_no_prune_on_both_listing_surfaces`,
`ls_help_states_that_a_plain_listing_prunes`.

## Gate — test ladder rung 3

Localized behavior inside one crate.

```
cargo fmt --check                                      EXIT=0
cargo check -p trusty-mpm                              EXIT=0
cargo clippy -p trusty-mpm --all-targets -- -D warnings EXIT=0
cargo test -p trusty-mpm -- --skip guided_fallback     EXIT=0
bash scripts/check_line_cap.sh                         EXIT=0
bash scripts/check_changelog_fragment.sh               EXIT=0
```

```
test result: ok. 5191 passed; 0 failed; 7 ignored     (lib)
test result: ok. 1761 passed; 0 failed; 1 ignored     (bin tm)
test result: ok. 1761 passed; 0 failed; 1 ignored     (bin trusty-mpm)
50 `test result: ok` lines, 0 FAILED across every target
line-cap: measured 4114 tracked .rs file(s); 4 allowlisted, 0 violations — OK.
changelog-fragment gate: scanned 19 changed path(s); all 1 crate(s) with source changes are recorded.
```

### Why `--skip guided_fallback`

The eight `guided_fallback_*` tests deadlock on `serial_test`'s local lock and
never finish. **This is pre-existing on `origin/main`, not caused by this
branch.** Baseline, run in this worktree detached at `22852ed5c` with a clean
tree:

```
test tests_behavior_b::guided_fallback_blocks_github_git_from_subdirectory has been running for over 60 seconds
test tests_behavior_b::guided_fallback_never_pollutes_github_git_checkout has been running for over 60 seconds
test tests_behavior_b::guided_fallback_non_git_dir_no_managed_env_is_fast has been running for over 60 seconds
test tests_behavior_b::guided_fallback_non_git_dir_with_managed_env_settles_quickly_returns_promptly has been running for over 60 seconds
test tests_behavior_b::guided_fallback_prepares_the_session_in_the_worktree_not_the_base_clone has been running for over 60 seconds
test tests_behavior_c::guided_fallback_does_not_refuse_github_ssh_alias_remote has been running for over 60 seconds
```

A `sample` of the hung binary puts every waiting thread in
`serial_test::serial_code_lock::local_serial_core`. No coverage was deleted,
ignored, or `cfg`-gated — the skip is a run-time filter for one invocation and
the tests remain in the tree. Nothing in this diff touches `guided.rs`, session
launch, or first-run clone. Filing this separately is left to the PM.

## Credential scan

`git diff origin/main...HEAD` scanned for key/secret/token/password patterns and
private-key headers: one hit, the phrase "argv token" in an existing doc
comment. No credential-shaped content.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
