### PR TITLE
perf(scripts): sccache auto-detect for publish preflight + persistent semver-check target dir

### DIFF
--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -289,6 +289,14 @@ jobs:
         if: steps.crate.outputs.have_work == 'true' || steps.machinery.outputs.semver_gate_inputs_changed == 'true'
         run: bash scripts/check_semver_types_selftest.sh
 
+      # The build-acceleration resolver both scripts above source. It compiles
+      # nothing and reaches no network, so it is gated only to keep the step list
+      # consistent with its siblings, not for cost. Ungated by the toolchain step
+      # for the same reason: none of its cases needs a cargo.
+      - name: Build-acceleration selftest (an absent accelerator must change nothing)
+        if: steps.crate.outputs.have_work == 'true' || steps.machinery.outputs.semver_gate_inputs_changed == 'true'
+        run: bash scripts/build_accel_selftest.sh
+
       # The two nonzero statuses are annotated differently ON PURPOSE (#5289).
       # Exit 1 is a computed verdict that says break; exit 3 means the gate never
       # compared anything, and reporting that as "your API changed" is the lie

--- a/docs/reference/release-workflow.md
+++ b/docs/reference/release-workflow.md
@@ -318,6 +318,28 @@ The baseline half of the cache (`<target>/semver-checks/cache/`) *is* placed
 correctly under `CARGO_TARGET_DIR`; only the current crate's document moves.
 That asymmetry is why the problem does not show up as an obvious failure.
 
+**An ambient `CARGO_TARGET_DIR` does the same damage, so the gate unsets it.**
+Not setting one ourselves is a weaker guarantee than it looks: an *inherited*
+value relocates the rustdoc JSON identically. This repo sanctions exporting one
+— DOC-66 §6.2/§6.4 lists a shared `CARGO_TARGET_DIR` as an opt-in disk-saving
+strategy for worktrees, and `vmtest-harness/lib/provision.sh` exports one
+specifically so it survives into cargo's children — so a developer who adopts
+either would silently lose CHECK 5b. `semver_checks_run` therefore neutralises
+it for that one subprocess.
+
+It uses `env -u CARGO_TARGET_DIR`, **not** `CARGO_TARGET_DIR=`. An empty value
+is not "use the default" to cargo, it is a hard error:
+
+```
+error: the target directory is set to an empty string in the `CARGO_TARGET_DIR` environment variable
+```
+
+(verified against `cargo metadata`, exit 101). The empty spelling would turn an
+ambient variable into a failed gate. Verified end to end: with
+`CARGO_TARGET_DIR=/tmp/ambient-ctd` exported, the gate passes, the rustdoc JSON
+lands at the versioned path under `<repo>/target/semver-checks/`, the differ
+compares 143 items and exits 0, and `/tmp/ambient-ctd/doc/` is never created.
+
 **Tested by** `scripts/build_accel_selftest.sh` (detection, the opt-out, the
 mode line, and an assertion that the library sets no `CARGO_TARGET_DIR`) and
 `scripts/check_semver_selftest.sh` cases 25-27 (the wiring: that the wrapper

--- a/docs/reference/release-workflow.md
+++ b/docs/reference/release-workflow.md
@@ -215,6 +215,116 @@ dependency of the binary build/release jobs (a failing crates.io dry-run says
 nothing about whether the GitHub binary tarball is safe to build), but its
 own failure still turns the tag's workflow run red.
 
+## Preflight Build Acceleration
+
+The preflight's one compiling step is CHECK 5, which runs `cargo semver-checks`
+through `scripts/check_semver.sh`. It builds rustdoc for the crate under test
+and for its whole dependency closure. A fresh worktree has no `target/`, so it
+compiles `openssl-sys` and the rest of the closure from zero — and this repo's
+worktree discipline makes fresh worktrees the normal case.
+
+When `sccache` is on PATH, that subprocess runs under `RUSTC_WRAPPER=sccache`.
+sccache caches compiler outputs keyed by input hash, so a worktree cargo has
+never seen still gets its dependency closure from cache instead of recompiling
+it. `scripts/lib/build_accel.sh` resolves it; `scripts/check_semver.sh` prints
+one `build-accel:` line per run saying which mode it is in.
+
+| Knob | Default | Turn it off with |
+|---|---|---|
+| `RUSTC_WRAPPER=sccache` on the semver-checks subprocess | on when `sccache` is on PATH | `PREFLIGHT_NO_SCCACHE=1` |
+
+`PREFLIGHT_NO_SCCACHE=0` is **not** an opt-out — only a non-empty value other
+than `0` disables the wrapper.
+
+**One-time per-machine prerequisite.** sccache is not vendored and nothing
+installs it for you. On a laptop that wants the speedup:
+
+```bash
+brew install sccache
+```
+
+Nothing else to configure. A machine without it runs the preflight exactly as
+before and says so in the `build-accel:` line; that is not a warning to act on.
+
+Measured on this workspace, `bash scripts/check_semver.sh --crate
+trusty-embedderd` (196 checks, gate green in every row):
+
+| State | Wall clock |
+|---|---|
+| Cold `target/`, cold sccache | 49.8s |
+| Cold `target/`, warm sccache — 347 of 347 compile requests served from cache | 18.9s |
+| Warm `target/` (cargo's own reuse, unchanged by this) | 3.1s |
+
+The middle row is what the wrapper buys: a target directory cargo has never seen
+still gets its dependency closure from cache rather than rebuilding it. The
+third row is cargo's existing behaviour within one checkout and owes nothing to
+sccache.
+
+**It cannot change a verdict.** A wrapper changes which process invokes rustc,
+not what rustc is invoked on, what the crate's public API is, or what
+cargo-semver-checks compares. A cache that served a wrong object would fail the
+build; a failed build prints no `N checks:` summary line; and
+`check_semver.sh` classifies a missing summary as NO VERDICT (exit 3) — the same
+loud stop a rustdoc crash gets, never a skip and never a pass. The `0 compared`
++ `[PASS]`-is-unreachable contract (#5620) is untouched.
+
+**Nothing is exported.** The assignment is built as an `env` prefix on the
+`cargo semver-checks` subprocess alone, so the `cargo publish` you run after the
+preflight passes inherits nothing from it.
+
+### Why there is no persistent target directory
+
+A persistent `CARGO_TARGET_DIR` for the SemVer gate was built, measured, and
+rejected. This section records the measurement so it is not re-attempted.
+
+`cargo-semver-checks` 0.50.0 has **no `--target-dir` flag** — checked against
+the installed binary's `check-release --help`. The only mechanism is the
+`CARGO_TARGET_DIR` environment variable, and the tool's *inner* `cargo doc`
+invocation honours it too. Setting it moves the current crate's rustdoc JSON
+out of
+
+```
+<target>/semver-checks/local-<pkg>-<ver>-<triple>-<hash>/target/doc/<pkg>.json
+```
+
+and into a flat
+
+```
+<target>/doc/<pkg>.json
+```
+
+keyed by crate **name alone** — no version, no feature-set hash. Verified in
+both directions on `trusty-embedderd`: with the variable unset the differ reads
+the versioned path and exits 0 having compared 143 public items; with it set the
+versioned directory contains only `Cargo.toml`, `lib.rs` and `Cargo.lock`, and
+the differ exits 3. Two consequences:
+
+1. `scripts/check_semver_types.sh` globs the versioned path, finds nothing, and
+   reports NO VERDICT. Preflight CHECK 5b is advisory, so it does not block a
+   publish — it just silently stops covering the type substitutions
+   `cargo-semver-checks` is known to miss.
+2. The flat path is **shared**. The whole point of a persistent directory is
+   that worktrees share it, and this repo runs gates in parallel worktrees. Two
+   concurrent runs on the same crate write the same file, so the differ can read
+   another worktree's source and report a result about the wrong tree.
+
+The differ's per-version, per-feature-hash directory and its
+refuse-on-ambiguity guard are what prevent that mixing, and `CARGO_TARGET_DIR`
+flattens both away. A stale cache changing an answer is the one thing this
+change was not allowed to introduce, so the knob was dropped. sccache gets the
+cross-worktree win without moving any artifact.
+
+The baseline half of the cache (`<target>/semver-checks/cache/`) *is* placed
+correctly under `CARGO_TARGET_DIR`; only the current crate's document moves.
+That asymmetry is why the problem does not show up as an obvious failure.
+
+**Tested by** `scripts/build_accel_selftest.sh` (detection, the opt-out, the
+mode line, and an assertion that the library sets no `CARGO_TARGET_DIR`) and
+`scripts/check_semver_selftest.sh` cases 25-27 (the wiring: that the wrapper
+reaches the cargo subprocess and `CARGO_TARGET_DIR` does not, that the opt-out
+reaches it, and that a build failure under the wrapper still exits 3). Both run
+in `.github/workflows/semver-checks.yml`.
+
 ## macOS Code-Signing Critical Alert
 
 🔴 **Never `cp target/release/<binary> ~/.cargo/bin/<binary>` on macOS.**

--- a/scripts/build_accel_selftest.sh
+++ b/scripts/build_accel_selftest.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+#
+# build_accel_selftest.sh — self-test for scripts/lib/build_accel.sh.
+#
+# Why: the knob this library resolves sits on the release path, and the failure
+#   mode that matters is not "the speedup did not happen" — it is a resolver that
+#   changes what the SemVer gate does on a machine where the speedup is
+#   unavailable. Every case below asks the same question in a different
+#   environment: does an absent or opted-out accelerator resolve to EMPTY, so the
+#   caller issues the command it issued before this library existed?
+#
+# What: four detection cases and four mode-line cases. Nothing here compiles,
+#   and nothing reaches the network.
+#   1. sccache absent from PATH                  -> empty
+#   2. sccache on PATH                           -> its absolute path
+#   3. PREFLIGHT_NO_SCCACHE=1 with sccache there -> empty (opt-out honoured)
+#   4. PREFLIGHT_NO_SCCACHE=0                    -> NOT an opt-out
+#
+#   The integration half — that this resolution actually reaches the
+#   `cargo semver-checks` subprocess, that the opt-out reaches it, that
+#   CARGO_TARGET_DIR is not injected alongside it, and that a build failure under
+#   the wrapper still exits 3 — lives in scripts/check_semver_selftest.sh cases
+#   25-27, because that file already carries the stub cargo, stub registry and
+#   stub crate those cases need.
+#
+# Portability: bash 3.2 (macOS system bash) and bash 5 (Linux CI).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+LIB="${REPO_ROOT}/scripts/lib/build_accel.sh"
+
+PASSED=0
+FAILED=0
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/build-accel-selftest.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+fail_case() {
+  echo "SELF-TEST FAIL: $1" >&2
+  shift
+  printf '%s\n' "$@" | sed 's/^/       /' >&2
+  FAILED=$((FAILED + 1))
+}
+
+pass_case() {
+  echo "  ok  $1"
+  PASSED=$((PASSED + 1))
+}
+
+# A stub sccache. Never executed — the resolver only asks PATH whether the name
+# exists — but it must be executable, because `command -v` says nothing about a
+# non-executable file.
+STUB_BIN="${WORK}/bin"
+mkdir -p "$STUB_BIN"
+printf '#!/bin/sh\nexec "$@"\n' > "${STUB_BIN}/sccache"
+chmod +x "${STUB_BIN}/sccache"
+
+# A PATH with no sccache anywhere on it. Case 1 must not be quietly satisfied by
+# the absence of a real sccache install on whoever's machine is running this, nor
+# broken by its presence.
+EMPTY_BIN="${WORK}/empty-bin"
+mkdir -p "$EMPTY_BIN"
+
+# resolve <fn> — run one resolver in a clean subshell, printing stdout only. Each
+# case sets the variables it is about through the caller's environment; the
+# subshell keeps one case from leaking into the next, which is the whole reason
+# these functions print instead of exporting.
+resolve() {
+  # shellcheck source=lib/build_accel.sh
+  ( . "$LIB" && "$1" )
+}
+
+# ===========================================================================
+# 1-4. sccache detection and its opt-out.
+# ===========================================================================
+
+# --- 1. Absent from PATH. The common case on a CI runner, and the one that must
+#        cost nothing: no error, no warning, no wrapper.
+out="$(PATH="$EMPTY_BIN" resolve build_accel_sccache 2>&1)"
+if [[ -n "$out" ]]; then
+  fail_case "sccache/absent: resolved '${out}' with no sccache on PATH — the gate would run under a wrapper that is not there"
+else
+  pass_case "sccache absent from PATH resolves to empty"
+fi
+
+# --- 2. Present. `command -v` returns the path PATH resolved, so the assertion
+#        is on the value the caller would actually put in RUSTC_WRAPPER.
+out="$(PATH="${STUB_BIN}:${EMPTY_BIN}" resolve build_accel_sccache 2>&1)"
+if [[ "$out" != "${STUB_BIN}/sccache" ]]; then
+  fail_case "sccache/present: expected '${STUB_BIN}/sccache', got '${out}'"
+else
+  pass_case "sccache on PATH resolves to its absolute path"
+fi
+
+# --- 3. Opt-out. This is the escape hatch a release operator reaches for when
+#        they suspect the wrapper, so it has to win over detection rather than
+#        merely be consulted alongside it.
+out="$(PATH="${STUB_BIN}:${EMPTY_BIN}" PREFLIGHT_NO_SCCACHE=1 resolve build_accel_sccache 2>&1)"
+if [[ -n "$out" ]]; then
+  fail_case "sccache/opt-out: PREFLIGHT_NO_SCCACHE=1 still resolved '${out}'"
+else
+  pass_case "PREFLIGHT_NO_SCCACHE=1 suppresses a present sccache"
+fi
+
+# --- 4. `0` is not an opt-out. A variable named NO_<thing> set to zero reads as
+#        "do not disable" to whoever writes it; silently meaning the opposite
+#        would turn the accelerator off for someone who thought they had turned
+#        it on, and they would find out from a release timing, not an error.
+out="$(PATH="${STUB_BIN}:${EMPTY_BIN}" PREFLIGHT_NO_SCCACHE=0 resolve build_accel_sccache 2>&1)"
+if [[ "$out" != "${STUB_BIN}/sccache" ]]; then
+  fail_case "sccache/zero: PREFLIGHT_NO_SCCACHE=0 was treated as an opt-out; got '${out}'"
+else
+  pass_case "PREFLIGHT_NO_SCCACHE=0 is not an opt-out"
+fi
+
+# --- 5. Nothing on stdout but the path. A caller reads stdout as the value for
+#        RUSTC_WRAPPER, so any diagnostic that leaked there would be used as one.
+out="$(PATH="$EMPTY_BIN" resolve build_accel_sccache 2> /dev/null)"
+if [[ -n "$out" ]]; then
+  fail_case "sccache/stdout: the absent case put '${out}' on stdout"
+else
+  pass_case "the absent case leaves stdout empty"
+fi
+
+# ===========================================================================
+# 6-9. The mode line. One line in every mode, including the modes where nothing
+# is accelerated — that line is the only report this library makes, so a mode it
+# cannot describe is a mode nobody can diagnose.
+# ===========================================================================
+mode_line() {
+  # shellcheck source=lib/build_accel.sh
+  ( . "$LIB" && build_accel_mode_line "$1" )
+}
+
+out="$(mode_line '/usr/bin/sccache')"
+if [[ "$out" != *"sccache /usr/bin/sccache"* || "$out" != *"RUSTC_WRAPPER"* ]]; then
+  fail_case "mode-line/present: did not name the wrapper it applied" "$out"
+else
+  pass_case "the mode line names the sccache it applied"
+fi
+
+out="$(PATH="$EMPTY_BIN" mode_line '')"
+if [[ "$out" != *"no sccache on PATH"* ]]; then
+  fail_case "mode-line/absent: did not state the unaccelerated mode" "$out"
+else
+  pass_case "the mode line states the unaccelerated mode"
+fi
+
+# An opt-out and an absent binary are different facts. Reporting the opt-out as
+# "not installed" would send an operator to `brew install` over a variable they
+# set themselves.
+out="$(PREFLIGHT_NO_SCCACHE=1 mode_line '')"
+if [[ "$out" != *"disabled by PREFLIGHT_NO_SCCACHE"* ]]; then
+  fail_case "mode-line/opt-out: reported the opt-out as an absent binary" "$out"
+else
+  pass_case "the mode line distinguishes the opt-out from an absent binary"
+fi
+
+# Exactly one line, always. A caller prints this unconditionally on the release
+# path; two lines today is a paragraph after the next edit.
+lengths_ok=1
+for arg in '/usr/bin/sccache' ''; do
+  n="$(mode_line "$arg" | wc -l | tr -d ' ')"
+  if [[ "$n" != "1" ]]; then
+    fail_case "mode-line/length: emitted ${n} lines for '${arg}'"
+    lengths_ok=0
+  fi
+done
+if [[ "$lengths_ok" -eq 1 ]]; then
+  pass_case "the mode line is exactly one line in every state"
+fi
+
+# --- 10. The library must not reintroduce a persistent CARGO_TARGET_DIR. It was
+#         built, measured and rejected: CARGO_TARGET_DIR moves the current
+#         crate's rustdoc JSON to a flat, name-keyed path, which blinds
+#         check_semver_types.sh and lets parallel worktrees overwrite each
+#         other's document. The rationale is a comment, and a comment does not
+#         fail a build — this assertion does.
+if grep -q '^[^#]*CARGO_TARGET_DIR' "$LIB"; then
+  fail_case "no-target-dir: build_accel.sh has live CARGO_TARGET_DIR code again — see the rejection note in its header" \
+    "$(grep -n '^[^#]*CARGO_TARGET_DIR' "$LIB")"
+else
+  pass_case "the library sets no CARGO_TARGET_DIR (rejected on evidence, see header)"
+fi
+
+echo
+if [[ "$FAILED" -ne 0 ]]; then
+  echo "build_accel_selftest: ${PASSED} passed, ${FAILED} FAILED." >&2
+  exit 1
+fi
+echo "build_accel_selftest: ${PASSED} passed, 0 failed."

--- a/scripts/check-ci-helpers-selftest.sh
+++ b/scripts/check-ci-helpers-selftest.sh
@@ -614,6 +614,8 @@ assert_eq "the gate's self-test"      "true"  "$(gate_inputs_of 'scripts/check_s
 assert_eq "the type differ"           "true"  "$(gate_inputs_of 'scripts/check_semver_types.sh')"
 assert_eq "the type differ's tests"   "true"  "$(gate_inputs_of 'scripts/check_semver_types_selftest.sh')"
 assert_eq "the rustdoc walk it imports" "true" "$(gate_inputs_of 'scripts/lib/rustdoc_walk.py')"
+assert_eq "the build-accel resolver"  "true"  "$(gate_inputs_of 'scripts/lib/build_accel.sh')"
+assert_eq "the build-accel self-test" "true"  "$(gate_inputs_of 'scripts/build_accel_selftest.sh')"
 assert_eq "crate selection"           "true"  "$(gate_inputs_of 'scripts/detect-version-bumps.sh')"
 assert_eq "this classifier"           "true"  "$(gate_inputs_of 'scripts/detect-semver-gate-inputs.sh')"
 assert_eq "the crate exclusions"      "true"  "$(gate_inputs_of 'scripts/semver-checks-crate-exclusions.tsv')"
@@ -795,12 +797,13 @@ assert_eq "no gate in semver-checks branches on the activity type" "0" \
 # here to catch.
 assert_eq "semver-checks gates its costly steps on there being work" "4" \
   "$(grep -cE "if: steps\.crate\.outputs\.have_work == 'true'$" .github/workflows/semver-checks.yml || true)"
-# #5501: the three CHEAP steps run on either trigger — a declared bump, or a
-# change to the gate's own machinery. Gating them on the bump alone skipped the
-# self-tests on every PR that changed the gate, which is every gate-fix PR (PR
-# #5496 is the observed case). The three: Install stable toolchain (both
-# self-tests need a `cargo` on PATH), SemVer gate selftest, Type-differ selftest.
-assert_eq "semver-checks runs its self-tests when the gate itself changed" "3" \
+# #5501: the CHEAP steps run on either trigger — a declared bump, or a change to
+# the gate's own machinery. Gating them on the bump alone skipped the self-tests
+# on every PR that changed the gate, which is every gate-fix PR (PR #5496 is the
+# observed case). The four: Install stable toolchain (two of the self-tests need
+# a `cargo` on PATH), SemVer gate selftest, Type-differ selftest, and the
+# build-acceleration selftest.
+assert_eq "semver-checks runs its self-tests when the gate itself changed" "4" \
   "$(grep -c "have_work == 'true' || steps.machinery.outputs.semver_gate_inputs_changed == 'true'" .github/workflows/semver-checks.yml || true)"
 assert_eq "semver-checks classifies its own machinery from the diff" "1" \
   "$(grep -c 'bash scripts/detect-semver-gate-inputs.sh' .github/workflows/semver-checks.yml || true)"

--- a/scripts/check_semver.sh
+++ b/scripts/check_semver.sh
@@ -168,6 +168,26 @@
 #   SEMVER_GATE_TOOLCHAIN_BIN=       (set but empty) keep the ambient toolchain.
 #   SEMVER_GATE_CRATE_EXCLUSIONS=<file>  read crate exclusions from <file>. A
 #                                    self-test seam; no caller sets it.
+#   PREFLIGHT_NO_SCCACHE=1           do not wrap rustc with sccache even when it
+#                                    is installed.
+#
+# Build acceleration: when sccache is on PATH this gate runs cargo-semver-checks
+#   under RUSTC_WRAPPER=sccache, so a fresh worktree gets its dependency closure
+#   from cache instead of recompiling openssl-sys and the rest. It is applied
+#   ONLY to that subprocess, as an `env` prefix — see semver_checks_run below —
+#   and never exported, so nothing else this script or its callers spawn inherits
+#   it. No sccache means this gate issues exactly the command it issued before.
+#
+#   IT CANNOT MAKE THE GATE PASS. A wrapper changes which process invokes rustc,
+#   not what rustc is invoked on. A cache that served a wrong object fails the
+#   build, which prints no `N checks:` summary, which verdict_computed
+#   classifies as NO VERDICT — the same loud exit 3 a rustdoc crash gets, never
+#   a skip and never a pass. check_semver_selftest.sh case 27 pins that.
+#
+#   A persistent CARGO_TARGET_DIR was tried and rejected: it moves the current
+#   crate's rustdoc JSON to a flat, name-keyed path, blinding
+#   check_semver_types.sh and letting parallel worktrees overwrite each other's
+#   document. The measurement is in scripts/lib/build_accel.sh; do not re-add it.
 #
 # Exit (#5289 split 1 from 3 — a verdict and a non-verdict are different facts):
 #   0  every checked crate is SemVer-clean, or is a recorded skip.
@@ -207,6 +227,12 @@ set -euo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
+
+# Build acceleration (sccache wrapper). Resolves to empty on a machine without
+# sccache, and empty means this gate runs exactly the command it ran before.
+# See scripts/lib/build_accel.sh.
+# shellcheck source=lib/build_accel.sh
+. "${REPO_ROOT}/scripts/lib/build_accel.sh"
 
 BASE="${SEMVER_GATE_BASE:-origin/main}"
 EXPLICIT_CRATES=""
@@ -979,6 +1005,43 @@ inventory_blind=0
 # scan for every candidate would just re-answer the same question.
 select_toolchain
 
+# Resolved once for the same reason, and printed for the same reason the
+# toolchain line is printed: which environment a release-blocking gate ran under
+# is part of its result. Empty means no sccache, and no sccache means the run is
+# byte-for-byte the one this gate made before the knob existed.
+BUILD_ACCEL_SCCACHE="$(build_accel_sccache)"
+build_accel_mode_line "$BUILD_ACCEL_SCCACHE"
+
+# ---------------------------------------------------------------------------
+# semver_checks_run <args...> — `cargo semver-checks <args>` under the resolved
+# acceleration environment.
+#
+# Why a wrapper rather than an inline env prefix: the two call sites below must
+# not drift, and `${VAR:+NAME="$VAR"}` word-splits a path containing a space,
+# which an sccache installed under a home directory can carry. Building the
+# prefix as an `env` argument vector quotes each assignment exactly once.
+#
+# Why `env` and not `export`: the assignment reaches THIS subprocess and nothing
+# else. Nothing the preflight spawns afterwards — and nothing a human runs after
+# the preflight passes, `cargo publish` included — inherits RUSTC_WRAPPER from
+# here. The acceleration is scoped to the one command it was reasoned about.
+#
+# WHAT IS DELIBERATELY ABSENT: CARGO_TARGET_DIR. It relocates the current crate's
+# rustdoc JSON to a flat, name-keyed path and blinds check_semver_types.sh; the
+# full measurement is in scripts/lib/build_accel.sh. Do not add it here.
+#
+# The vector always carries `env SKIP_UI_BUILD=1`, so it is never empty and
+# `"${envv[@]}"` is safe under `set -u` on bash 3.2.
+# ---------------------------------------------------------------------------
+semver_checks_run() {
+  local -a envv
+  envv=(env SKIP_UI_BUILD=1)
+  if [[ -n "$BUILD_ACCEL_SCCACHE" ]]; then
+    envv+=("RUSTC_WRAPPER=${BUILD_ACCEL_SCCACHE}")
+  fi
+  "${envv[@]}" cargo semver-checks "$@"
+}
+
 while IFS= read -r crate; do
   [[ -z "$crate" ]] && continue
 
@@ -1095,7 +1158,7 @@ while IFS= read -r crate; do
     echo "INVENTORY ${crate}: ${baseline} -> ${current} is already a breaking release — no bump can be owed, so this run is advisory: what does it break?"
     rc=0
     RUN_LOG="${SCRATCH}/inventory-${crate}.txt"
-    SKIP_UI_BUILD=1 cargo semver-checks \
+    semver_checks_run \
       --package "$crate" \
       --baseline-version "$baseline" \
       --release-type minor \
@@ -1127,7 +1190,7 @@ while IFS= read -r crate; do
   # printed, and so preflight-publish.sh's captured log is unchanged in content.
   rc=0
   RUN_LOG="${SCRATCH}/run-${crate}.txt"
-  SKIP_UI_BUILD=1 cargo semver-checks \
+  semver_checks_run \
     --package "$crate" \
     --baseline-version "$baseline" \
     --only-explicit-features "$@" > "$RUN_LOG" 2>&1 || rc=$?

--- a/scripts/check_semver.sh
+++ b/scripts/check_semver.sh
@@ -188,6 +188,8 @@
 #   crate's rustdoc JSON to a flat, name-keyed path, blinding
 #   check_semver_types.sh and letting parallel worktrees overwrite each other's
 #   document. The measurement is in scripts/lib/build_accel.sh; do not re-add it.
+#   An AMBIENT CARGO_TARGET_DIR does the same damage, and this repo sanctions
+#   exporting one, so semver_checks_run unsets it for that subprocess.
 #
 # Exit (#5289 split 1 from 3 — a verdict and a non-verdict are different facts):
 #   0  every checked crate is SemVer-clean, or is a recorded skip.
@@ -1026,16 +1028,29 @@ build_accel_mode_line "$BUILD_ACCEL_SCCACHE"
 # the preflight passes, `cargo publish` included — inherits RUSTC_WRAPPER from
 # here. The acceleration is scoped to the one command it was reasoned about.
 #
-# WHAT IS DELIBERATELY ABSENT: CARGO_TARGET_DIR. It relocates the current crate's
-# rustdoc JSON to a flat, name-keyed path and blinds check_semver_types.sh; the
-# full measurement is in scripts/lib/build_accel.sh. Do not add it here.
+# CARGO_TARGET_DIR IS UNSET, NOT MERELY UNSET-BY-US. Setting it relocates the
+# current crate's rustdoc JSON to a flat, name-keyed path and blinds
+# check_semver_types.sh — the measurement is in scripts/lib/build_accel.sh — and
+# an AMBIENT one does that just as thoroughly as one this script added. This repo
+# sanctions exporting a shared CARGO_TARGET_DIR (DOC-66 §6.2/§6.4 lists it as an
+# opt-in disk-saving strategy; vmtest-harness/lib/provision.sh exports one into
+# cargo's children), so an inherited value is a real configuration, not a
+# hypothetical. `env -u` neutralises it for this subprocess only and leaves the
+# caller's environment alone.
 #
-# The vector always carries `env SKIP_UI_BUILD=1`, so it is never empty and
-# `"${envv[@]}"` is safe under `set -u` on bash 3.2.
+# `env -u`, NOT `CARGO_TARGET_DIR=`. An empty value is not "use the default" to
+# cargo — it is a hard error:
+#     error: the target directory is set to an empty string in the
+#            `CARGO_TARGET_DIR` environment variable
+# (verified against `cargo metadata`, exit 101). Setting it empty would turn an
+# ambient variable into a failed gate.
+#
+# The vector always carries `env -u CARGO_TARGET_DIR SKIP_UI_BUILD=1`, so it is
+# never empty and `"${envv[@]}"` is safe under `set -u` on bash 3.2.
 # ---------------------------------------------------------------------------
 semver_checks_run() {
   local -a envv
-  envv=(env SKIP_UI_BUILD=1)
+  envv=(env -u CARGO_TARGET_DIR SKIP_UI_BUILD=1)
   if [[ -n "$BUILD_ACCEL_SCCACHE" ]]; then
     envv+=("RUSTC_WRAPPER=${BUILD_ACCEL_SCCACHE}")
   fi

--- a/scripts/check_semver_selftest.sh
+++ b/scripts/check_semver_selftest.sh
@@ -305,6 +305,19 @@ if [[ "${1:-}" == "semver-checks" ]]; then
   case " $* " in
     *" --version "*) echo "cargo-semver-checks 0.50.0"; exit 0 ;;
   esac
+
+  # Build-acceleration probe (cases 25-27). Records what actually reached THIS
+  # subprocess's environment, which is the only place the question "did the
+  # wrapper get applied?" has an answer — the gate builds the assignments as an
+  # `env` prefix, so nothing upstream of here can be inspected for it.
+  if [[ -n "${SEMVER_SELFTEST_ENV_OUT:-}" ]]; then
+    {
+      echo "RUSTC_WRAPPER=${RUSTC_WRAPPER:-}"
+      echo "CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-}"
+      echo "SKIP_UI_BUILD=${SKIP_UI_BUILD:-}"
+    } > "$SEMVER_SELFTEST_ENV_OUT"
+  fi
+
   fixture="${SEMVER_SELFTEST_FIXTURE:-}"
   rc="${SEMVER_SELFTEST_RC:-0}"
 
@@ -748,6 +761,121 @@ elif [[ "$out" == *"SKIP trusty-agents-common"* ]]; then
   fail_case "exclusion/premise-died: granted the skip anyway" "$out"
 else
   pass_case "an exclusion contradicted by a workspace dependency refuses the skip (exit 3)"
+fi
+
+# ===========================================================================
+# 25-27. Build acceleration reaches the subprocess, and cannot change a verdict.
+#
+# scripts/build_accel_selftest.sh already proves the RESOLVER answers correctly
+# in every environment. What it cannot prove is that those answers are wired to
+# anything: a resolver whose output the gate never applies passes every one of
+# its cases. These three ask the wiring question instead, against the real gate
+# and its real code path.
+#
+# The stub cargo writes its own environment to a file, so the assertion is on
+# what the `cargo semver-checks` process actually received — not on a log line
+# the gate printed about what it intended to send.
+# ===========================================================================
+ACCEL_SCCACHE_DIR="${STUB_DIR}/accel-bin"
+mkdir -p "$ACCEL_SCCACHE_DIR"
+printf '#!/bin/sh\nexec "$@"\n' > "${ACCEL_SCCACHE_DIR}/sccache"
+chmod +x "${ACCEL_SCCACHE_DIR}/sccache"
+
+ENV_OUT="${STUB_DIR}/accel-env.txt"
+
+# accel_gate <extra-env-assignments...> — one gate run with the acceleration
+# probe armed. The stub sccache goes on PATH AHEAD of the stub cargo's directory
+# so neither the presence nor the absence of a real sccache install can decide
+# the outcome on whoever's machine is running this.
+accel_gate() {
+  (cd "$REPO_ROOT" &&
+    env "$@" \
+      PATH="${ACCEL_SCCACHE_DIR}:${STUB_DIR}:${PATH}" \
+      SEMVER_GATE_TOOLCHAIN_BIN='' \
+      SEMVER_SELFTEST_REAL_CARGO="$REAL_CARGO" \
+      SEMVER_SELFTEST_ENV_OUT="$ENV_OUT" \
+      SEMVER_GATE_INDEX_BASE="http://127.0.0.1:${PORT}/v/${STUB_PREV}" \
+      bash "$GATE" --crate "$STUB_CRATE" 2>&1)
+}
+
+# --- 25. The wrapper reaches the subprocess, and CARGO_TARGET_DIR does not.
+#
+#         The second half is the regression test, not a stylistic assertion. A
+#         persistent CARGO_TARGET_DIR was built and then rejected on evidence:
+#         cargo-semver-checks honours it in its INNER `cargo doc` too, which
+#         moves the current crate's rustdoc JSON out of
+#         semver-checks/local-<pkg>-<ver>-<triple>-<hash>/target/doc/ and into a
+#         flat <target>/doc/<pkg>.json keyed by crate name alone. That blinds
+#         check_semver_types.sh, and because the whole point of a persistent
+#         directory is that worktrees share it, two parallel gate runs on the
+#         same crate would overwrite each other's document — a stale cache
+#         changing an answer. See scripts/lib/build_accel.sh for the full note.
+rm -f "$ENV_OUT"
+rc=0
+out="$(accel_gate \
+  "SEMVER_SELFTEST_FIXTURE=${FIXTURES}/clean.out" \
+  "SEMVER_SELFTEST_RC=0")" || rc=$?
+if [[ ! -f "$ENV_OUT" ]]; then
+  fail_case "accel/applied: the gate never reached cargo semver-checks, so this case proves nothing" "$out"
+elif [[ "$rc" -ne 0 ]]; then
+  fail_case "accel/applied: a clean run under the wrapper exited ${rc}" "$out"
+elif ! grep -qx "RUSTC_WRAPPER=${ACCEL_SCCACHE_DIR}/sccache" "$ENV_OUT"; then
+  fail_case "accel/applied: RUSTC_WRAPPER never reached the subprocess" "$(cat "$ENV_OUT")" "$out"
+elif ! grep -qx "CARGO_TARGET_DIR=" "$ENV_OUT"; then
+  fail_case "accel/applied: CARGO_TARGET_DIR reached cargo-semver-checks — it relocates the current rustdoc JSON and blinds the type differ" "$(cat "$ENV_OUT")"
+elif ! grep -qx "SKIP_UI_BUILD=1" "$ENV_OUT"; then
+  # The env prefix REPLACED an existing `SKIP_UI_BUILD=1 cargo ...` assignment.
+  # Dropping it would trade a build-time saving for a UI build on every run.
+  fail_case "accel/applied: the env prefix lost the pre-existing SKIP_UI_BUILD=1" "$(cat "$ENV_OUT")" "$out"
+elif [[ "$out" != *"build-accel: sccache"* ]]; then
+  fail_case "accel/applied: the run did not print its mode line" "$out"
+else
+  pass_case "sccache reaches the cargo subprocess, and CARGO_TARGET_DIR does not"
+fi
+
+# --- 26. The opt-out reaches it too. A knob proven only in the resolver is a
+#         knob an operator cannot rely on mid-release.
+rm -f "$ENV_OUT"
+rc=0
+out="$(accel_gate \
+  "PREFLIGHT_NO_SCCACHE=1" \
+  "SEMVER_SELFTEST_FIXTURE=${FIXTURES}/clean.out" \
+  "SEMVER_SELFTEST_RC=0")" || rc=$?
+if [[ ! -f "$ENV_OUT" ]]; then
+  fail_case "accel/opt-out: the gate never reached cargo semver-checks" "$out"
+elif ! grep -qx "RUSTC_WRAPPER=" "$ENV_OUT"; then
+  fail_case "accel/opt-out: PREFLIGHT_NO_SCCACHE=1 did not stop the wrapper reaching cargo" "$(cat "$ENV_OUT")"
+elif [[ "$rc" -ne 0 ]]; then
+  fail_case "accel/opt-out: the opted-out run exited ${rc} where the accelerated one exited 0" "$out"
+elif [[ "$out" != *"disabled by PREFLIGHT_NO_SCCACHE"* ]]; then
+  fail_case "accel/opt-out: the mode line did not report the opt-out" "$out"
+else
+  pass_case "PREFLIGHT_NO_SCCACHE=1 reaches the subprocess and is reported"
+fi
+
+# --- 27. A FAILING BUILD UNDER THE WRAPPER STILL FAILS THE GATE.
+#         This is the case the whole change is answerable for. A cache that can
+#         turn a broken build into a skip, or into a pass, would be worse than
+#         the rebuild it replaced — so the rustdoc-failure fixture is replayed
+#         with the wrapper on, and the gate must reach exactly the exit 3 it
+#         reaches without it.
+rm -f "$ENV_OUT"
+rc=0
+out="$(accel_gate \
+  "SEMVER_SELFTEST_FIXTURE=${FIXTURES}/build-error.out" \
+  "SEMVER_SELFTEST_RC=101")" || rc=$?
+if [[ "$rc" -eq 0 ]]; then
+  fail_case "accel/build-failure: the gate PASSED a build failure that ran under the wrapper" "$out"
+elif [[ "$rc" -ne 3 ]]; then
+  fail_case "accel/build-failure: expected exit 3 (no verdict), got ${rc}" "$out"
+elif [[ "$out" != *"NO SEMVER VERDICT WAS COMPUTED"* ]]; then
+  fail_case "accel/build-failure: exited 3 without saying no verdict was computed" "$out"
+elif [[ "$out" == *"requires a matching version bump"* ]]; then
+  fail_case "accel/build-failure: rendered a build failure as a SemVer verdict" "$out"
+elif ! grep -qx "RUSTC_WRAPPER=${ACCEL_SCCACHE_DIR}/sccache" "$ENV_OUT" 2> /dev/null; then
+  fail_case "accel/build-failure: the run was not wrapped, so it did not test the wrapper" "$(cat "$ENV_OUT" 2> /dev/null)"
+else
+  pass_case "a build failure under the wrapper still exits 3 (no verdict)"
 fi
 
 rm -rf "$STUB_DIR"

--- a/scripts/check_semver_selftest.sh
+++ b/scripts/check_semver_selftest.sh
@@ -313,7 +313,16 @@ if [[ "${1:-}" == "semver-checks" ]]; then
   if [[ -n "${SEMVER_SELFTEST_ENV_OUT:-}" ]]; then
     {
       echo "RUSTC_WRAPPER=${RUSTC_WRAPPER:-}"
-      echo "CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-}"
+      # PRESENCE, not value. `env -u CARGO_TARGET_DIR` and `CARGO_TARGET_DIR=`
+      # both yield an empty ${CARGO_TARGET_DIR:-}, and only the first is
+      # correct — cargo rejects an empty value outright. This stub replaces the
+      # real cargo, so it is the only place that difference is observable at
+      # all; recording `${VAR+x}` is what lets cases 25 and 28 tell them apart.
+      if [[ -n "${CARGO_TARGET_DIR+x}" ]]; then
+        echo "CARGO_TARGET_DIR_PRESENT=yes(${CARGO_TARGET_DIR})"
+      else
+        echo "CARGO_TARGET_DIR_PRESENT=no"
+      fi
       echo "SKIP_UI_BUILD=${SKIP_UI_BUILD:-}"
     } > "$SEMVER_SELFTEST_ENV_OUT"
   fi
@@ -821,7 +830,7 @@ elif [[ "$rc" -ne 0 ]]; then
   fail_case "accel/applied: a clean run under the wrapper exited ${rc}" "$out"
 elif ! grep -qx "RUSTC_WRAPPER=${ACCEL_SCCACHE_DIR}/sccache" "$ENV_OUT"; then
   fail_case "accel/applied: RUSTC_WRAPPER never reached the subprocess" "$(cat "$ENV_OUT")" "$out"
-elif ! grep -qx "CARGO_TARGET_DIR=" "$ENV_OUT"; then
+elif ! grep -qx "CARGO_TARGET_DIR_PRESENT=no" "$ENV_OUT"; then
   fail_case "accel/applied: CARGO_TARGET_DIR reached cargo-semver-checks — it relocates the current rustdoc JSON and blinds the type differ" "$(cat "$ENV_OUT")"
 elif ! grep -qx "SKIP_UI_BUILD=1" "$ENV_OUT"; then
   # The env prefix REPLACED an existing `SKIP_UI_BUILD=1 cargo ...` assignment.
@@ -876,6 +885,46 @@ elif ! grep -qx "RUSTC_WRAPPER=${ACCEL_SCCACHE_DIR}/sccache" "$ENV_OUT" 2> /dev/
   fail_case "accel/build-failure: the run was not wrapped, so it did not test the wrapper" "$(cat "$ENV_OUT" 2> /dev/null)"
 else
   pass_case "a build failure under the wrapper still exits 3 (no verdict)"
+fi
+
+# --- 28. AN AMBIENT CARGO_TARGET_DIR DOES NOT REACH THE SUBPROCESS.
+#
+#         Case 25 proves this gate does not ADD one. That is a weaker claim than
+#         it looks, because the damage does not care who set the variable: an
+#         inherited value relocates the current crate's rustdoc JSON to the same
+#         flat, name-keyed path and blinds check_semver_types.sh exactly as a
+#         locally-added one would.
+#
+#         And it is inheritable here in practice, not in theory. DOC-66 §6.2/§6.4
+#         lists a shared CARGO_TARGET_DIR as a sanctioned opt-in disk-saving
+#         strategy for this repo's worktrees, and vmtest-harness/lib/provision.sh
+#         exports one specifically so it survives into cargo's child processes.
+#         A developer who adopts either would silently lose CHECK 5b.
+#
+#         semver_checks_run uses `env -u`, not `CARGO_TARGET_DIR=`: cargo treats
+#         an empty value as a hard error ("the target directory is set to an
+#         empty string in the `CARGO_TARGET_DIR` environment variable", exit
+#         101), so setting it empty would convert an ambient variable into a
+#         failed gate rather than a clean one.
+rm -f "$ENV_OUT"
+rc=0
+out="$(accel_gate \
+  "CARGO_TARGET_DIR=${STUB_DIR}/ambient-target-dir" \
+  "SEMVER_SELFTEST_FIXTURE=${FIXTURES}/clean.out" \
+  "SEMVER_SELFTEST_RC=0")" || rc=$?
+if [[ ! -f "$ENV_OUT" ]]; then
+  fail_case "accel/ambient-target-dir: the gate never reached cargo semver-checks, so this case proves nothing" "$out"
+elif grep -q "CARGO_TARGET_DIR_PRESENT=yes" "$ENV_OUT"; then
+  # Catches BOTH wrong spellings, which is why the stub records presence rather
+  # than value. No neutralisation at all leaves the ambient path visible;
+  # `CARGO_TARGET_DIR=` leaves the variable present-but-empty, which cargo
+  # rejects outright — and the stub replaces cargo, so an empty value would
+  # otherwise sail through this file and fail only at a real release.
+  fail_case "accel/ambient-target-dir: CARGO_TARGET_DIR still reached cargo-semver-checks — it must be UNSET (env -u), not set to empty" "$(cat "$ENV_OUT")"
+elif [[ "$rc" -ne 0 ]]; then
+  fail_case "accel/ambient-target-dir: neutralising the ambient value broke the run (exit ${rc})" "$out"
+else
+  pass_case "an ambient CARGO_TARGET_DIR is unset for the subprocess without failing the run"
 fi
 
 rm -rf "$STUB_DIR"

--- a/scripts/detect-semver-gate-inputs.sh
+++ b/scripts/detect-semver-gate-inputs.sh
@@ -37,9 +37,9 @@
 #     scripts/check_semver_types.sh             the subject of the type-differ
 #                                               self-test
 #     scripts/lib/build_accel.sh                the build-acceleration resolver
-#                                               check_semver.sh and
-#                                               check_semver_types.sh both source
-#     scripts/build_accel_selftest.sh           its self-test, run at workflow L292
+#                                               check_semver.sh sources
+#     scripts/build_accel_selftest.sh           its self-test, run by the
+#                                               "Build-acceleration selftest" step
 #     scripts/lib/rustdoc_walk.py               the walk check_semver_types.sh
 #                                               imports (ADR-0047)
 #     scripts/semver-checks-*-exclusions.tsv    the crate and feature exclusion

--- a/scripts/detect-semver-gate-inputs.sh
+++ b/scripts/detect-semver-gate-inputs.sh
@@ -36,6 +36,10 @@
 #                                               subject of check_semver_selftest
 #     scripts/check_semver_types.sh             the subject of the type-differ
 #                                               self-test
+#     scripts/lib/build_accel.sh                the build-acceleration resolver
+#                                               check_semver.sh and
+#                                               check_semver_types.sh both source
+#     scripts/build_accel_selftest.sh           its self-test, run at workflow L292
 #     scripts/lib/rustdoc_walk.py               the walk check_semver_types.sh
 #                                               imports (ADR-0047)
 #     scripts/semver-checks-*-exclusions.tsv    the crate and feature exclusion
@@ -82,6 +86,8 @@ is_gate_input() {
     scripts/detect-version-bumps.sh) return 0 ;;
     scripts/detect-semver-gate-inputs.sh) return 0 ;;
     scripts/lib/rustdoc_walk.py) return 0 ;;
+    scripts/lib/build_accel.sh) return 0 ;;
+    scripts/build_accel_selftest.sh) return 0 ;;
     scripts/semver-checks-crate-exclusions.tsv) return 0 ;;
     scripts/semver-checks-feature-exclusions.tsv) return 0 ;;
     scripts/test-data/semver-gate/*) return 0 ;;

--- a/scripts/lib/build_accel.sh
+++ b/scripts/lib/build_accel.sh
@@ -1,0 +1,115 @@
+# scripts/lib/build_accel.sh — shared build-acceleration resolver for the
+# publish preflight path.
+#
+# Why: the preflight's one compiling step is `cargo semver-checks`, run by
+#   scripts/check_semver.sh. It builds rustdoc for the crate under test and for
+#   its whole dependency closure, in a scratch project under the workspace's
+#   target directory. A fresh worktree has no such directory, so every worktree
+#   compiles openssl-sys and the rest of the closure from zero — and this repo's
+#   worktree discipline means fresh worktrees are the normal case, not the
+#   exception.
+#
+#   sccache fixes exactly that: it caches compiler OUTPUTS keyed by input hash,
+#   so a worktree cargo has never seen still gets its dependency closure from
+#   cache instead of recompiling it. Measured on trusty-embedderd, a cold target
+#   directory went from 49.8s to 18.9s with a warm sccache, at 347 of 347
+#   compile requests served from cache.
+#
+#   OFF BY CONSTRUCTION WHEN UNAVAILABLE. No sccache on PATH resolves to empty,
+#   and empty means the caller runs exactly the command it ran before this file
+#   existed — no error, no warning, one log line saying which mode it is in.
+#
+# What: two functions. They read the environment and PATH and PRINT; neither
+#   exports a variable into the caller's environment, and neither compiles
+#   anything. The caller applies what they print as a per-command `env` prefix,
+#   which is what keeps the wrapper off every other process the preflight spawns.
+#
+#     build_accel_sccache             -> absolute path to sccache, or nothing
+#     build_accel_mode_line <sccache> -> one line naming the mode
+#
+# A WRAPPER CANNOT MAKE A GATE PASS. RUSTC_WRAPPER changes which process invokes
+#   rustc; it does not change what rustc is invoked on, what the crate's public
+#   API is, or what cargo-semver-checks compares. A cache that served a wrong
+#   object would fail the build, and a failed build prints no `N checks:` summary
+#   line, which check_semver.sh's verdict_computed classifies as NO VERDICT
+#   (exit 3) — the same loud stop a rustdoc crash gets, never a skip and never a
+#   pass. scripts/check_semver_selftest.sh case 27 pins that.
+#
+# WHY THERE IS NO PERSISTENT CARGO_TARGET_DIR HERE. A persistent target directory
+#   for the SemVer gate was designed, built and then REJECTED on evidence; this
+#   note exists so the next person does not rediscover the same trap.
+#   cargo-semver-checks 0.50.0 has no --target-dir flag, so the only mechanism is
+#   the CARGO_TARGET_DIR environment variable — and it is honoured by the tool's
+#   INNER `cargo doc` invocation as well as its own bookkeeping. Setting it moves
+#   the current crate's rustdoc JSON out of
+#       <target>/semver-checks/local-<pkg>-<ver>-<triple>-<hash>/target/doc/<pkg>.json
+#   and into a flat
+#       <target>/doc/<pkg>.json
+#   keyed by crate NAME alone — no version, no feature-set hash. Two
+#   consequences, both measured, neither acceptable:
+#     1. scripts/check_semver_types.sh globs the versioned path, finds nothing,
+#        and reports NO VERDICT. Preflight CHECK 5b is advisory, so it does not
+#        block a publish — it just silently stops covering the type substitutions
+#        cargo-semver-checks is known to miss.
+#     2. Worse, the flat path is SHARED. The whole point of a persistent
+#        directory is that worktrees share it, and this repo runs gates in
+#        parallel worktrees. Two concurrent runs on the same crate write the same
+#        file, so the differ can read another worktree's source and report a
+#        result about the wrong tree. That is a stale cache changing an answer,
+#        which is the one thing this file is not allowed to introduce.
+#   The differ's per-version, per-feature-hash directory and its
+#   refuse-on-ambiguity guard are what prevent exactly that mixing, and
+#   CARGO_TARGET_DIR flattens both away. sccache gets the cross-worktree win
+#   without touching where any artifact lands.
+#
+# Portability: bash 3.2 (macOS system bash) and bash 5 (Linux CI).
+#
+# Test: `scripts/build_accel_selftest.sh` covers detection, the opt-out, and the
+#   mode line. `scripts/check_semver_selftest.sh` cases 25-27 cover the wiring:
+#   what reaches the cargo subprocess, that the opt-out reaches it, that
+#   CARGO_TARGET_DIR is NOT injected, and that a build failure under the wrapper
+#   still exits 3.
+
+# ---------------------------------------------------------------------------
+# build_accel_sccache — print the absolute path to sccache, or nothing.
+#
+# Auto-detect, with one explicit opt-out. PREFLIGHT_NO_SCCACHE disables the
+# wrapper when it is set to anything other than empty or `0`; `0` is spelled out
+# as "not an opt-out" because a variable named NO_<thing> set to zero reads as
+# "do not disable" to everyone who writes it, and silently meaning the opposite
+# is the kind of trap that only surfaces during a release.
+#
+# Absence is not an error and not a warning. A machine without sccache runs the
+# preflight exactly as it did before; the mode line says which mode it is in, and
+# that one line is the whole report.
+# ---------------------------------------------------------------------------
+build_accel_sccache() {
+  case "${PREFLIGHT_NO_SCCACHE:-}" in
+    "" | 0) ;;
+    *) return 0 ;;
+  esac
+  command -v sccache 2> /dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# build_accel_mode_line <sccache-path> — the one line a caller prints to say
+# which mode it is in. The argument may be empty.
+#
+# One line, always, in every mode. The absent case is the common one on a CI
+# runner and must not read as a problem to fix. An opt-out and an absent binary
+# are reported as different facts: calling the opt-out "not installed" would send
+# an operator to `brew install` over a variable they set themselves.
+# ---------------------------------------------------------------------------
+build_accel_mode_line() {
+  local sccache="${1:-}"
+
+  if [ -n "$sccache" ]; then
+    echo "build-accel: sccache ${sccache} (RUSTC_WRAPPER)"
+    return 0
+  fi
+
+  case "${PREFLIGHT_NO_SCCACHE:-}" in
+    "" | 0) echo "build-accel: no sccache on PATH; rustc runs unwrapped" ;;
+    *) echo "build-accel: sccache disabled by PREFLIGHT_NO_SCCACHE; rustc runs unwrapped" ;;
+  esac
+}

--- a/scripts/preflight-publish.sh
+++ b/scripts/preflight-publish.sh
@@ -545,6 +545,17 @@ check4_version_not_live() {
 # inventing a result, and telling the operator to bump the breaking position
 # would be advising a version change on no evidence. Either way the publish
 # still stops.
+#
+# BUILD ACCELERATION. check_semver.sh is the only compiling step on this whole
+# path, and when sccache is installed it runs its own `cargo semver-checks`
+# subprocess under RUSTC_WRAPPER=sccache — see scripts/lib/build_accel.sh and the
+# `build-accel:` line in the log. It is applied as an `env` prefix on that one
+# command and never exported, so the `cargo publish` a human runs after this
+# script passes inherits nothing from it. It cannot move a verdict: a wrapper
+# changes which process invokes rustc, not what rustc is invoked on, and a cache
+# that served a wrong object fails the build — which prints no summary line, and
+# that is the NO VERDICT above rather than a skip. No sccache on the machine is
+# byte-for-byte the previous behaviour.
 check5_semver() {
   local log="${TMP_SEMVER}" rc=0 decision=0
 


### PR DESCRIPTION
Owner request, no issue filed. Rung 5 (release tooling).

Head `cb579cc2c` includes the fixes for code-critic's WARN on `0dd1c8c31`.

## What changed

`scripts/check_semver.sh` runs its `cargo semver-checks` subprocess under
`RUSTC_WRAPPER=sccache` when sccache is on PATH. That subprocess is the
preflight's only compiling step: it builds rustdoc for the crate under test and
its whole dependency closure, and a fresh worktree has no `target/`, so it
compiles openssl-sys and the rest from zero. This repo's worktree discipline
makes fresh worktrees the normal case.

- **Auto-detect.** sccache present → wrapper applied. Absent → the gate issues
  exactly the command it issued before, no error, no warning.
- **One log line either way**, e.g. `build-accel: sccache /opt/homebrew/bin/sccache (RUSTC_WRAPPER)`
  or `build-accel: no sccache on PATH; rustc runs unwrapped`.
- **Opt-out:** `PREFLIGHT_NO_SCCACHE=1`. `=0` is deliberately *not* an opt-out —
  a `NO_<thing>=0` that disables reads backwards to whoever sets it.
- **One-time per-machine prerequisite:** `brew install sccache`. Nothing else.

New shared resolver `scripts/lib/build_accel.sh`; new self-test
`scripts/build_accel_selftest.sh`; four integration cases added to
`scripts/check_semver_selftest.sh`. Both self-tests wired into
`.github/workflows/semver-checks.yml` and into `detect-semver-gate-inputs.sh`,
so a change to either file triggers them on a PR that bumps nothing.

## Scoping: why the wrapper cannot reach `cargo publish`

Applied as an `env` argument vector on the one subprocess, never `export`ed:

```
env -u CARGO_TARGET_DIR SKIP_UI_BUILD=1 RUSTC_WRAPPER=<sccache> cargo semver-checks …
```

Nothing else this script or its callers spawn inherits it. Neither
`preflight-publish.sh` nor `check-publish-ready.sh` runs `cargo publish` or
`cargo package` — a human runs those after the preflight passes, in a shell this
change never touches.

Even if it did reach the verify build, it would be safe: `cargo package`
assembles the `.crate` tarball from the source tree and computes its checksum
*before* unpacking and compiling it to verify. `RUSTC_WRAPPER` changes which
process invokes rustc during that compile; it cannot change what went into a
tarball that already exists on disk.

## The persistent target dir was rejected on evidence

The request asked for a persistent target dir for the SemVer check, and to
verify the mechanism rather than guess. I built it, measured it, and dropped it.

`cargo-semver-checks` 0.50.0 has **no `--target-dir` flag** (checked against the
installed binary's `check-release --help`). The only mechanism is
`CARGO_TARGET_DIR`, and the tool's **inner `cargo doc` honours it too**. Setting
it moves the current crate's rustdoc JSON out of

```
<target>/semver-checks/local-<pkg>-<ver>-<triple>-<hash>/target/doc/<pkg>.json
```

into a flat `<target>/doc/<pkg>.json`, keyed by crate **name alone** — no
version, no feature-set hash. Verified both directions on `trusty-embedderd`:

| `CARGO_TARGET_DIR` | `check_semver_types.sh --crate trusty-embedderd` |
|---|---|
| unset | exit 0, `compared: 143 public item(s)` at the versioned path |
| set | exit 3, versioned dir holds only `Cargo.toml`, `lib.rs`, `Cargo.lock`; JSON is at `<target>/doc/trusty_embedderd.json` |

Two consequences, neither acceptable:

1. Preflight **CHECK 5b goes blind**. It is advisory, so it does not block a
   publish — it silently stops covering the type substitutions
   cargo-semver-checks is known to miss (the reason that differ exists).
2. The flat path is **shared**, which is the entire point of a persistent
   directory. This repo runs gates in parallel worktrees; two concurrent runs on
   the same crate write the same file, so the differ can read another worktree's
   source and report a result about the wrong tree.

"A stale cache must not turn the gate's verdict wrong" was the request's own
hard rule, and the only available mechanism violates it. The baseline half of
the cache *is* placed correctly under `CARGO_TARGET_DIR`; only the current
document moves, which is why this does not present as an obvious failure.

**Cargo's own `target/` reuse across consecutive crate checks in one checkout is
unchanged** — that already worked and owes nothing to this PR. What did not work
was a fresh worktree, and sccache is what addresses it.

## An ambient `CARGO_TARGET_DIR` is unset, not merely not-set-by-us

code-critic HIGH, verified and fixed in `cb579cc2c`.

Not setting one ourselves is a weaker guarantee than it looks. An **inherited**
value relocates the rustdoc JSON identically, reproducing through a side channel
the exact failure rejected above. It is inheritable here in practice, not
theory:

- `docs/specs/DOC-66-session-workstream-model.md` §6.2 lists a shared
  `CARGO_TARGET_DIR` per project as a disk-saving strategy for worktrees, and
  §6.4 commits to it "last, opt-in only".
- `vmtest-harness/lib/provision.sh:106` exports one, with the comment "these
  must survive into cargo's child processes."

A developer who adopts either would silently lose CHECK 5b. `semver_checks_run`
now neutralises it for that one subprocess.

**`env -u`, not `CARGO_TARGET_DIR=`.** An empty value is not "use the default"
to cargo — it is a hard error:

```
$ CARGO_TARGET_DIR= cargo metadata --no-deps --format-version 1
error: the target directory is set to an empty string in the `CARGO_TARGET_DIR` environment variable
EXIT=101
```

The empty spelling would convert an ambient variable into a failed gate. `env -u`
restores the workspace default cleanly (verified: `cargo metadata` reports the
worktree's own `target/`).

Verified end to end with no stub, `CARGO_TARGET_DIR=/tmp/ambient-ctd` exported:

```
GATE_EXIT=0    build-accel: sccache /opt/homebrew/bin/sccache (RUSTC_WRAPPER)
               Checked [0.008s] 196 checks: 196 pass, 58 skip
               semver gate: scanned (explicit); 1 crate(s) checked, 0 skipped — OK.
DIFFER_EXIT=0  current: …/target/semver-checks/local-trusty_embedderd-0_3_11-…/target/doc/trusty_embedderd.json
               compared: 143 public item(s); 0 changed, 0 removed, 0 added
$ ls /tmp/ambient-ctd/doc/
ls: /tmp/ambient-ctd/doc/: No such file or directory
```

Before the fix that differ run was exit 3.

### The first version of this test was itself defective

Worth recording, because it is the trap the critic named. Case 28 originally
asserted on the recorded *value* of `CARGO_TARGET_DIR`, and the stub cargo
replaces the very cargo that would reject an empty value — so `env -u` and
`CARGO_TARGET_DIR=` were indistinguishable through it. The mutation run proved
it: the wrong spelling passed **29/29**.

The stub now records **presence** (`${VAR+x}`) rather than value. Both mutations
fail:

| Mutation | Result |
|---|---|
| drop `-u` (inherit the ambient value) | `accel/ambient-target-dir: CARGO_TARGET_DIR still reached cargo semver-checks` — 28 passed, 1 FAILED |
| `CARGO_TARGET_DIR=` instead of `env -u` | `accel/applied` + `accel/ambient-target-dir` — 27 passed, 2 FAILED |

## Gate semantics unchanged

A wrapper changes which process invokes rustc, not what rustc is invoked on,
what the crate's public API is, or what cargo-semver-checks compares. A cache
serving a wrong object fails the build; a failed build prints no `N checks:`
summary line; `verdict_computed` classifies that as NO VERDICT (exit 3). The
`0 compared` + `[PASS]`-unreachable contract (#5620) is untouched. Case 27
replays the rustdoc-failure fixture *with the wrapper on* and asserts exit 3.

## Self-test cases 25-28 (`check_semver_selftest.sh`)

| # | Asserts |
|---|---|
| 25 | the wrapper reaches the cargo subprocess, `CARGO_TARGET_DIR` is absent from it, and the pre-existing `SKIP_UI_BUILD=1` survived the rewrite |
| 26 | `PREFLIGHT_NO_SCCACHE=1` reaches the subprocess and is reported in the mode line |
| 27 | a build failure under the wrapper still exits 3 (NO VERDICT), and does not render as a SemVer verdict |
| 28 | an ambient `CARGO_TARGET_DIR` is unset for the subprocess without failing the run |

`build_accel_selftest.sh` covers detection, the opt-out (including `=0`), stdout
hygiene, the mode line in all three states and its one-line length, plus an
assertion that the library never grows live `CARGO_TARGET_DIR` code again.

No crate `src/**` touched, so no changelog fragment is owed.

## Timing

`bash scripts/check_semver.sh --crate trusty-embedderd` (196 checks, gate green
in every row). `trusty-embedderd` is not in the live publish train.

**Cold dependency closure** — the fresh-worktree case this PR targets. Target
dir empty, nothing to reuse:

| State | Wall clock | sccache |
|---|---|---|
| cold sccache | 49.8s | 0 hits / 347 misses |
| warm sccache | 18.9s | 347 hits / 347 requests |

**Warm machine** — `target/debug` and the cargo registry already populated, only
`target/semver-checks` cleared. This is the honest counter-measurement:

| State | Wall clock | sccache |
|---|---|---|
| `PREFLIGHT_NO_SCCACHE=1` | 22.1s (`Finished [22.061s]`) | — |
| wrapper on | 23.5s (`Finished [23.481s]`) | 282 hits / 410 misses |

**Read both rows honestly:** the win is real when the dependency closure is
genuinely cold (2.6x), and it is absent-to-slightly-negative on an already-warm
machine, where wrapper overhead is within noise of the saving. The wrapper is
not free and this PR does not claim it always pays; it pays in the scenario the
owner named — fresh temp dirs and worktrees — and the opt-out exists for anyone
who measures otherwise on their own machine.

## Also fixed (code-critic LOW)

`scripts/detect-semver-gate-inputs.sh` claimed `check_semver_types.sh` sources
`build_accel.sh` — it does not; that was stale prose left over from the reverted
target-dir design. It also cited workflow line L292 for a step that sits at
L296/L298. Replaced the line number with the step name, which cannot drift.

## Gates run

```
bash scripts/build_accel_selftest.sh        -> 10 passed, 0 failed
bash scripts/check_semver_selftest.sh       -> 29 passed, 0 failed
bash scripts/check_semver_types_selftest.sh -> 15 passed, 0 failed
bash scripts/check-ci-helpers-selftest.sh   -> all 178 cases passed
bash scripts/preflight-check5-selftest.sh   -> 17 passed, 0 failed
bash scripts/check_sld.sh                   -> 0 error(s), 0 warning(s)
bash scripts/check_line_cap.sh              -> 0 violations
```

Both self-tests were mutation-checked rather than merely run. Five mutations,
all caught: removing the opt-out; removing the target-dir creation (pre-revert);
reverting the differ's cache root (pre-revert); dropping `env -u`; and
substituting `CARGO_TARGET_DIR=` for it.

Live behavioural check of the unaccelerated path, which is the "changes nothing
when absent" claim:

```
$ PREFLIGHT_NO_SCCACHE=1 bash scripts/check_semver.sh --crate trusty-embedderd
build-accel: sccache disabled by PREFLIGHT_NO_SCCACHE; rustc runs unwrapped
CHECK trusty-embedderd: 0.3.10 -> 0.3.11 (minor release), 3 feature(s)
     Checked [   0.004s] 196 checks: 196 pass, 58 skip
semver gate: scanned (explicit); 1 crate(s) checked, 0 skipped — OK.
```

`cargo publish` was never run in any form, including `--dry-run`, against any
crate.

## Not merged

Merges are held for the concurrent publish train. Auto-merge is not armed.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
