### PR TITLE
feat(trusty-review): risk-ranked evidence selection — manifest inspect_priority interface, AnalyzeMetrics term, coverage percentage (#6078)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11788,7 +11788,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-review"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,7 +159,7 @@ trusty-mpm = { path = "crates/trusty-mpm", version = "1.0.0" }
 #      this line existed. Both consumers name what they need: trusty-analyze's
 #      `review` feature pulls `trusty-review/mcp`; trusty-mpm's dev-dependency
 #      only touches `integrations`, which is unconditional.
-trusty-review = { path = "crates/trusty-review", version = "0.20", default-features = false }
+trusty-review = { path = "crates/trusty-review", version = "0.21", default-features = false }
 # trusty-console: web dashboard for trusty services. As of #1318 the standalone
 # `trusty-console` crate is the SOLE producer of the `trusty-console` binary
 # (de-bundled from the host crates for single-owner-per-binary). It is still a

--- a/crates/trusty-review/Cargo.toml
+++ b/crates/trusty-review/Cargo.toml
@@ -14,7 +14,15 @@ name        = "trusty-review"
 # synthesize_prompt.rs's prompt text (adds a coverage-gaps instruction). No
 # public API changed; the `PR version bump vs crates.io` gate (#4421) still
 # requires the bump since `src/**` changed.
-version     = "0.20.0"
+#
+# #6078: MINOR bump — 0.20.0 is already published, and this PR edits `src/**`,
+# so the `PR version bump vs crates.io` gate (#4421) requires a bump. MINOR is
+# also the right position on its own merits: `RepositoryEntry` and
+# `RepositoryReport` each gain an `inspect_priority` field, and neither carries
+# `#[non_exhaustive]` (the note above covers three OTHER report types), so an
+# external struct literal breaks. For a `0.y.z` crate the breaking bump is the
+# MINOR position.
+version     = "0.21.0"
 edition     = "2024"
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/trusty-review/changelog.d/6078-risk-ranked-selection.md
+++ b/crates/trusty-review/changelog.d/6078-risk-ranked-selection.md
@@ -1,0 +1,4 @@
+Added
+- Report manifests may declare a per-repository `inspect_priority` list — ranked repo-relative paths, optionally with an explicit `weight` — that the DD-report investigation inspects ahead of its own path-name heuristics, still bounded by the same file/byte budget. This is the interface an external ranker (trusty-audit) writes its selection intelligence to, so tuning what gets inspected no longer changes trusty-review. Absent the key, selection is byte-identical to before.
+- File selection now folds in the trusty-analyze findings already loaded for a repository: a file a diagnostic or refactor suggestion names outranks an otherwise-equal file the heuristics cannot tell apart.
+- The Investigation Coverage line and the synthesis-prompt coverage summary state the examined share as a percentage alongside the raw counts.

--- a/crates/trusty-review/src/report/benchmark_tests.rs
+++ b/crates/trusty-review/src/report/benchmark_tests.rs
@@ -90,6 +90,7 @@ fn repo(slug: &str, m: Option<AnalyzeMetrics>) -> RepositoryReport {
         scan: None,
         metrics: m,
         authorship: None,
+        inspect_priority: Vec::new(),
     }
 }
 

--- a/crates/trusty-review/src/report/investigate/mod.rs
+++ b/crates/trusty-review/src/report/investigate/mod.rs
@@ -38,7 +38,7 @@ use crate::report::synthesize::{FindingProse, Synthesis};
 
 pub use batch::BatchStatus;
 pub use deps::{Dependency, DependencyInventory};
-pub use select::{Budget, Selection};
+pub use select::{Budget, RiskSignals, Selection};
 pub use verify::VerifiedFinding;
 
 // ─── Result types ─────────────────────────────────────────────────────────────
@@ -234,7 +234,14 @@ pub async fn run_investigation(
         let deps = deps::build_inventory(path);
 
         let files = crate::report::scan::list_tracked_files(path);
-        let selection = select::select_files(path, &files, instructions, budget);
+        // #6078: the manifest's declared ranking and the trusty-analyze findings
+        // already on this repo steer which files get read; absent both, the
+        // selection is byte-identical to the pre-#6078 one.
+        let signals = select::RiskSignals {
+            priorities: &repo.inspect_priority,
+            metrics: repo.metrics.as_ref(),
+        };
+        let selection = select::select_files(path, &files, instructions, budget, signals);
         if selection.is_empty() {
             repos.push(RepoInvestigation {
                 slug: repo.slug.clone(),

--- a/crates/trusty-review/src/report/investigate/render.rs
+++ b/crates/trusty-review/src/report/investigate/render.rs
@@ -100,10 +100,13 @@ fn coverage_lines(repo: &RepoInvestigation) -> String {
         }
     }
     let c: &Coverage = &repo.coverage;
+    // #6078: "12 of 200" left the reader to divide; the percentage is the figure
+    // a due-diligence reader actually weighs the findings against.
     out.push_str(&format!(
-        "- files examined: {} of {} tracked ({} skipped); {} bytes sent (budget {}/{})\n",
+        "- files examined: {} of {} tracked ({}% coverage, {} skipped); {} bytes sent (budget {}/{})\n",
         c.files_examined,
         c.total_files,
+        coverage_pct(c.files_examined, c.total_files),
         c.skipped,
         c.bytes_sent,
         c.budget.max_files,
@@ -160,6 +163,21 @@ fn batch_lines(c: &Coverage) -> String {
     out
 }
 
+/// Format `examined / total` as a one-decimal percentage (#6078).
+///
+/// Why: both coverage surfaces — the rendered section and the synthesis prompt —
+/// must state the SAME figure, so it is computed once here.
+/// What: one decimal place; `0.0` when nothing is tracked, which is the only
+/// division-by-zero case and reads correctly (nothing was examined).
+/// Test: `render_tests::{coverage_section_states_examined_and_rejected,
+/// coverage_percentage_handles_empty_repo}`.
+fn coverage_pct(examined: usize, total: usize) -> String {
+    if total == 0 {
+        return "0.0".to_string();
+    }
+    format!("{:.1}", (examined as f64 / total as f64) * 100.0)
+}
+
 /// Join a list with `, `, or render `none` when empty.
 fn join_or_none(items: &[String]) -> String {
     if items.is_empty() {
@@ -182,10 +200,11 @@ pub fn coverage_prompt_summary(inv: &Investigation) -> String {
         match &repo.status {
             InvestigationStatus::Available => {
                 out.push_str(&format!(
-                    "- {}: examined {} of {} files; {} verified finding(s); {} rejected; not investigated: {}\n",
+                    "- {}: examined {} of {} files ({}%); {} verified finding(s); {} rejected; not investigated: {}\n",
                     repo.name,
                     c.files_examined,
                     c.total_files,
+                    coverage_pct(c.files_examined, c.total_files),
                     repo.findings.len(),
                     c.rejected,
                     join_or_none(&c.dimensions_absent),

--- a/crates/trusty-review/src/report/investigate/render_tests.rs
+++ b/crates/trusty-review/src/report/investigate/render_tests.rs
@@ -97,7 +97,11 @@ fn coverage_section_states_examined_and_rejected() {
     };
     let out = coverage_section(&investigation);
     assert!(out.contains("## Investigation Coverage"));
-    assert!(out.contains("files examined: 12 of 200"));
+    // #6078: the percentage is part of this line, not a new section.
+    assert!(
+        out.contains("files examined: 12 of 200 tracked (6.0% coverage, 188 skipped)"),
+        "coverage line missing the percentage: {out}"
+    );
     assert!(out.contains("NOT investigated: scalability"));
     assert!(out.contains("2 finding(s) rejected (unverifiable evidence)"));
     assert!(out.contains("verified evidence-backed findings: 1"));
@@ -132,9 +136,24 @@ fn coverage_prompt_summary_lists_gaps() {
         )],
     };
     let summary = investigation.coverage_prompt_summary();
-    assert!(summary.contains("examined 12 of 200 files"));
+    // #6078: the exec-summary surface carries the SAME figure as the section.
+    assert!(
+        summary.contains("examined 12 of 200 files (6.0%)"),
+        "prompt summary missing the percentage: {summary}"
+    );
     assert!(summary.contains("not investigated: scalability"));
     assert!(summary.contains("Synthesise the executive summary FROM those findings"));
+}
+
+/// Why: a repository with nothing tracked would divide by zero; `0.0` is the
+/// correct reading (nothing was examined) and must not become `NaN` on the page.
+/// What: `coverage_pct` on a zero denominator, and the rounding of a third.
+/// Test: this test itself.
+#[test]
+fn coverage_percentage_handles_empty_repo() {
+    assert_eq!(coverage_pct(0, 0), "0.0");
+    assert_eq!(coverage_pct(1, 3), "33.3");
+    assert_eq!(coverage_pct(200, 200), "100.0");
 }
 
 /// Why: no dependencies must render an explicit empty note, not a broken table.

--- a/crates/trusty-review/src/report/investigate/select.rs
+++ b/crates/trusty-review/src/report/investigate/select.rs
@@ -8,6 +8,11 @@
 //! dimensions (auth/secrets, dependencies, state, error handling, scaling,
 //! tests) via path/name heuristics.  Determinism (a stable sort) means the same
 //! repo always yields the same selection, so a report is reproducible.
+//! Path heuristics are guesses, so #6078 lets better-informed rankers override
+//! them through [`RiskSignals`] — the manifest's declared `inspect_priority`
+//! (trusty-audit writes it; owner ruling 2026-08-19 makes it THE interface for
+//! external selection intelligence) and the trusty-analyze findings already on
+//! the model.  Absent both, the ranking is byte-identical to the pre-#6078 one.
 //! What: [`Budget`] holds the file/byte caps; [`select_files`] ranks the tracked
 //! file list, greedily fills the budget, reads (and truncates) content, and
 //! records coverage — which DD dimensions were actually reached and which were
@@ -18,6 +23,9 @@
 use std::path::{Path, PathBuf};
 
 use serde::Serialize;
+
+use crate::report::manifest::InspectionPriority;
+use crate::report::metrics::AnalyzeMetrics;
 
 /// The per-file content ceiling before truncation (~24 KiB).
 ///
@@ -283,17 +291,116 @@ pub fn instruction_keywords(instructions: Option<&str>) -> Vec<String> {
     out
 }
 
-/// Compute a file's relevance score against instruction keywords + DD dimensions.
+/// The relevance weight a file trusty-analyze already flagged receives (#6078).
+///
+/// Why: every other term guesses from the path name. A `MetricFinding` naming
+/// this file is a tool's direct observation that something is wrong in it, so it
+/// must weigh more than a DD-dimension name match (×2). It stays below two
+/// analyst-brief keyword hits (×3 each) because the analyst's stated focus is
+/// the one signal that outranks a machine's.
+/// What: added once per flagged file however many findings name it, so a single
+/// noisy linter rule cannot bury the rest of the ranking.
+const FLAGGED_WEIGHT: u32 = 4;
+
+/// External risk evidence that steers selection — every field optional (#6078).
+///
+/// Why: two independent rankers know more about a repository than any path-name
+/// heuristic: the manifest's declared `inspect_priority` (written by
+/// trusty-audit, the stable interface per the owner ruling of 2026-08-19) and
+/// the trusty-analyze findings already on the model. Passing them as one struct
+/// means a third signal later changes no call site.
+/// What: `priorities` is the ranked manifest list; `metrics` are the analyze
+/// findings. [`RiskSignals::default`] carries neither, which reproduces the
+/// pre-#6078 ranking exactly — that is the contract the absent-input tests pin.
+/// Test: `select_tests::{absent_signals_reproduce_baseline_order,
+/// manifest_priority_outranks_heuristics, analyze_flagged_file_outranks_peer}`.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct RiskSignals<'a> {
+    /// Manifest-declared ranked paths; empty means "no external ranking".
+    pub priorities: &'a [InspectionPriority],
+    /// Per-file findings from trusty-analyze; `None` when `--analyze` was off.
+    pub metrics: Option<&'a AnalyzeMetrics>,
+}
+
+/// Compute a file's relevance score against instruction keywords, DD dimensions,
+/// and whether a code-analysis tool already flagged it.
 ///
 /// Higher is more relevant: instruction-keyword hits weigh most (×3), each DD
-/// dimension match ×2, and a recognised source file gets +1 so code outranks
-/// data when nothing else separates them.
-fn score(path: &str, keywords: &[String], dims: &[String]) -> u32 {
+/// dimension match ×2, a tool-flagged file [`FLAGGED_WEIGHT`], and a recognised
+/// source file gets +1 so code outranks data when nothing else separates them.
+fn score(path: &str, keywords: &[String], dims: &[String], flagged: bool) -> u32 {
     let p = path.to_ascii_lowercase();
     let instr_hits = keywords.iter().filter(|k| p.contains(k.as_str())).count() as u32;
     let dim_hits = dims.len() as u32;
     let code = u32::from(is_code_file(path));
-    3 * instr_hits + 2 * dim_hits + code
+    3 * instr_hits + 2 * dim_hits + FLAGGED_WEIGHT * u32::from(flagged) + code
+}
+
+/// Normalise a path-ish string into the key both signal matchers compare on.
+///
+/// Why: a `MetricFinding.component` may be absolute or repo-relative and may
+/// carry a `:<line>` suffix (that is the shape `apply_investigation` writes),
+/// and a manifest author may use either separator. One normal form makes both
+/// comparisons a plain string test.
+/// What: backslashes to `/`, lower-cased, and a trailing `:<digits>` dropped.
+/// Lower-casing only ever ranks a file higher, never excludes one.
+/// Test: `select_tests::analyze_component_with_line_suffix_matches`.
+fn path_key(raw: &str) -> String {
+    let c = raw.replace('\\', "/").to_ascii_lowercase();
+    match c.rsplit_once(':') {
+        Some((file, line)) if !line.is_empty() && line.bytes().all(|b| b.is_ascii_digit()) => {
+            file.to_string()
+        }
+        _ => c,
+    }
+}
+
+/// True when `key` names the same file as the already-normalised `path`.
+///
+/// Matches exactly, or when `key` is a longer path ending in `/{path}` — which
+/// is how an absolute component from the analyze daemon names a repo-relative
+/// file. A bare basename never matches, so one `login.rs` cannot flag every
+/// other one.
+fn names_same_file(path: &str, key: &str) -> bool {
+    key == path
+        || (key.len() > path.len()
+            && key.ends_with(path)
+            && key.as_bytes()[key.len() - path.len() - 1] == b'/')
+}
+
+/// The normalised paths trusty-analyze flagged, or empty when it supplied none.
+fn flagged_keys(metrics: Option<&AnalyzeMetrics>) -> Vec<String> {
+    let Some(m) = metrics else {
+        return Vec::new();
+    };
+    let mut keys: Vec<String> = m
+        .findings
+        .iter()
+        .filter(|f| !f.component.is_empty())
+        .map(|f| path_key(&f.component))
+        .collect();
+    keys.sort();
+    keys.dedup();
+    keys
+}
+
+/// The manifest priorities as `(normalised path, weight)`, highest weight first.
+fn priority_keys(priorities: &[InspectionPriority]) -> Vec<(String, u32)> {
+    priorities
+        .iter()
+        .filter(|p| !p.path.is_empty())
+        .map(|p| (path_key(&p.path), p.weight))
+        .collect()
+}
+
+/// The highest manifest-declared weight naming `path`, or 0 when none does.
+fn priority_weight(path: &str, priorities: &[(String, u32)]) -> u32 {
+    priorities
+        .iter()
+        .filter(|(key, _)| names_same_file(path, key))
+        .map(|(_, w)| *w)
+        .max()
+        .unwrap_or(0)
 }
 
 /// Rank the repository's files and greedily fill the budget, capturing content
@@ -302,41 +409,60 @@ fn score(path: &str, keywords: &[String], dims: &[String]) -> u32 {
 /// Why: this is the single place that turns a raw tracked-file list into the
 /// bounded, relevance-ranked, coverage-annotated set the LLM will inspect; its
 /// determinism (a stable score-then-path sort) makes every report reproducible.
-/// What: scores each file (instruction keywords + DD dimensions + code boost),
-/// sorts by score desc then path asc, then walks the ranking reading content
-/// (per-file truncated to [`MAX_FILE_BYTES`], and to the remaining byte budget)
-/// until `max_files` or `max_bytes` is reached.  Records total/skipped counts,
-/// bytes sent, and the covered/absent DD dimensions (tests count as covered when
-/// any test path is present, even if unread).  Unreadable/binary files are
-/// skipped without consuming budget.
+/// What: scores each file (instruction keywords + DD dimensions + a trusty-analyze
+/// flag + code boost), sorts by manifest priority desc, then score desc, then path
+/// asc, then walks the ranking reading content (per-file truncated to
+/// [`MAX_FILE_BYTES`], and to the remaining byte budget) until `max_files` or
+/// `max_bytes` is reached.  Records total/skipped counts, bytes sent, and the
+/// covered/absent DD dimensions (tests count as covered when any test path is
+/// present, even if unread).  Unreadable/binary files are skipped without
+/// consuming budget.
+///
+/// `signals` carries the two external rankers (#6078); [`RiskSignals::default`]
+/// carries neither and reproduces the pre-#6078 ranking exactly.  A manifest
+/// priority is a SEPARATE, dominant sort key rather than another score term, so
+/// a declared path is inspected ahead of every heuristic-only file whatever its
+/// weight — the budget still bounds how many of them are actually read.
 /// Test: `select_tests::{ranks_relevant_first, budget_caps_file_count,
-/// budget_caps_total_bytes, coverage_reports_dimensions}`.
+/// budget_caps_total_bytes, coverage_reports_dimensions,
+/// absent_signals_reproduce_baseline_order, manifest_priority_outranks_heuristics,
+/// priorities_beyond_the_budget_truncate_in_rank_order}`.
 pub fn select_files(
     root: &Path,
     files: &[PathBuf],
     instructions: Option<&str>,
     budget: Budget,
+    signals: RiskSignals<'_>,
 ) -> Selection {
     let keywords = instruction_keywords(instructions);
     let total_files = files.len();
+    // #6078: both external rankings are normalised once, not per candidate.
+    let flagged = flagged_keys(signals.metrics);
+    let priorities = priority_keys(signals.priorities);
 
     // Score every candidate (skip obvious noise the scanner already excludes is
     // handled upstream; here we rank whatever the tracked list contains).
-    let mut ranked: Vec<(u32, String, Vec<String>)> = files
+    let mut ranked: Vec<(u32, u32, String, Vec<String>)> = files
         .iter()
         .map(|rel| {
             let path = rel.to_string_lossy().replace('\\', "/");
+            let key = path.to_ascii_lowercase();
             let dims = dimensions_for(&path);
-            let s = score(&path, &keywords, &dims);
-            (s, path, dims)
+            let is_flagged = flagged.iter().any(|f| names_same_file(&key, f));
+            let s = score(&path, &keywords, &dims, is_flagged);
+            (priority_weight(&key, &priorities), s, path, dims)
         })
         .collect();
-    // Deterministic: score desc, then path asc.
-    ranked.sort_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.cmp(&b.1)));
+    // Deterministic: declared priority desc, then score desc, then path asc.
+    ranked.sort_by(|a, b| {
+        b.0.cmp(&a.0)
+            .then_with(|| b.1.cmp(&a.1))
+            .then_with(|| a.2.cmp(&b.2))
+    });
 
     let mut selected: Vec<SelectedFile> = Vec::new();
     let mut bytes_sent = 0usize;
-    for (_, path, dims) in &ranked {
+    for (_, _, path, dims) in &ranked {
         if selected.len() >= budget.max_files {
             break;
         }

--- a/crates/trusty-review/src/report/investigate/select_tests.rs
+++ b/crates/trusty-review/src/report/investigate/select_tests.rs
@@ -11,7 +11,58 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use super::*;
+use crate::report::metrics::{MetricFinding, Severity};
 use crate::report::scan::list_tracked_files;
+
+/// The exact selection order the fixture produced BEFORE #6078, captured by
+/// running `select_files` on `origin/main` (bbc039b46).
+///
+/// Why: the ticket's hard requirement is that absent signals leave selection
+/// byte-identical. A recorded literal is the only assertion that can fail if a
+/// future scoring tweak silently changes the no-signal path.
+const BASELINE_ORDER: &[&str] = &[
+    "src/auth/login.rs",
+    "src/errors.rs",
+    "src/store/user_store.ts",
+    "package.json",
+    "tests/login_test.rs",
+    "README.md",
+];
+
+/// Build a priority list the way `load_manifest` would, from bare paths.
+fn priorities(paths: &[&str]) -> Vec<InspectionPriority> {
+    paths
+        .iter()
+        .enumerate()
+        .map(|(i, p)| InspectionPriority {
+            path: (*p).to_string(),
+            weight: 1000 - i as u32,
+        })
+        .collect()
+}
+
+/// An `AnalyzeMetrics` whose findings name `components`.
+fn metrics_flagging(components: &[&str]) -> AnalyzeMetrics {
+    AnalyzeMetrics {
+        findings: components
+            .iter()
+            .map(|c| MetricFinding {
+                title: "clippy diagnostic".to_string(),
+                severity: Severity::Amber,
+                category: "clippy".to_string(),
+                component: (*c).to_string(),
+                description: "d".to_string(),
+                remediation: String::new(),
+            })
+            .collect(),
+        ..Default::default()
+    }
+}
+
+/// The selected paths, in ranked order.
+fn order(sel: &Selection) -> Vec<String> {
+    sel.files.iter().map(|f| f.path.clone()).collect()
+}
 
 /// Create `root/rel` with `content`, making parent dirs.
 fn write(root: &Path, rel: &str, content: &str) {
@@ -61,6 +112,7 @@ fn ranks_relevant_first() {
         &files,
         Some("Focus on the login and authentication flow."),
         Budget::default(),
+        RiskSignals::default(),
     );
     assert!(!sel.is_empty());
     assert!(
@@ -86,6 +138,7 @@ fn budget_caps_file_count() {
             max_files: 2,
             max_bytes: DEFAULT_MAX_BYTES,
         },
+        RiskSignals::default(),
     );
     assert_eq!(sel.files.len(), 2);
     assert_eq!(sel.total_files, total);
@@ -107,6 +160,7 @@ fn budget_caps_total_bytes() {
             max_files: 40,
             max_bytes: 30,
         },
+        RiskSignals::default(),
     );
     assert!(sel.bytes_sent <= 30, "bytes_sent {} > cap", sel.bytes_sent);
     assert!(sel.files.len() < files.len());
@@ -122,7 +176,13 @@ fn truncates_oversize_file() {
     let big = "x".repeat(30 * 1024);
     write(tmp.path(), "src/big.rs", &big);
     let files = list_tracked_files(tmp.path());
-    let sel = select_files(tmp.path(), &files, None, Budget::default());
+    let sel = select_files(
+        tmp.path(),
+        &files,
+        None,
+        Budget::default(),
+        RiskSignals::default(),
+    );
     let f = sel
         .files
         .iter()
@@ -140,7 +200,13 @@ fn truncates_oversize_file() {
 fn coverage_reports_dimensions() {
     let tmp = fixture();
     let files = list_tracked_files(tmp.path());
-    let sel = select_files(tmp.path(), &files, None, Budget::default());
+    let sel = select_files(
+        tmp.path(),
+        &files,
+        None,
+        Budget::default(),
+        RiskSignals::default(),
+    );
     let covered = &sel.dimensions_covered;
     assert!(covered.iter().any(|d| d == "authentication & secrets"));
     assert!(covered.iter().any(|d| d == "dependencies"));
@@ -214,7 +280,164 @@ fn empty_repo_selects_nothing() {
         &[] as &[PathBuf],
         None,
         Budget::default(),
+        RiskSignals::default(),
     );
     assert!(sel.is_empty());
     assert_eq!(sel.total_files, 0);
+}
+
+// ─── #6078: risk-ranked selection ────────────────────────────────────────────
+
+/// Why: #6078 adds two ranking inputs, and absent both the selection must be
+/// what it was before — anything else silently rewrites every existing report.
+/// What: asserts the fixture's ranked order equals [`BASELINE_ORDER`], the
+/// literal captured from `origin/main`.
+/// Test: this test itself.
+#[test]
+fn absent_signals_reproduce_baseline_order() {
+    let tmp = fixture();
+    let files = list_tracked_files(tmp.path());
+    let sel = select_files(
+        tmp.path(),
+        &files,
+        None,
+        Budget::default(),
+        RiskSignals::default(),
+    );
+    assert_eq!(order(&sel), BASELINE_ORDER);
+}
+
+/// Why: a file trusty-analyze already flagged carries direct evidence of risk,
+/// so it must outrank an otherwise-identical unflagged file.
+/// What: two files that score identically on every path heuristic; flagging one
+/// moves it to the front, and the same call with `None` metrics does not.
+/// Test: this test itself.
+#[test]
+fn analyze_flagged_file_outranks_peer() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    // Same extension, same directory, no dimension or keyword hits: identical
+    // heuristic score, so `path asc` alone decides — `a.rs` before `b.rs`.
+    write(tmp.path(), "src/a.rs", "fn a() {}\n");
+    write(tmp.path(), "src/b.rs", "fn b() {}\n");
+    let files = list_tracked_files(tmp.path());
+
+    let plain = select_files(
+        tmp.path(),
+        &files,
+        None,
+        Budget::default(),
+        RiskSignals::default(),
+    );
+    assert_eq!(order(&plain), ["src/a.rs", "src/b.rs"]);
+
+    let m = metrics_flagging(&["src/b.rs"]);
+    let sel = select_files(
+        tmp.path(),
+        &files,
+        None,
+        Budget::default(),
+        RiskSignals {
+            metrics: Some(&m),
+            ..Default::default()
+        },
+    );
+    assert_eq!(order(&sel), ["src/b.rs", "src/a.rs"]);
+}
+
+/// Why: the analyze daemon may name a file absolutely and with a line suffix;
+/// both must still resolve to the tracked repo-relative path.
+/// What: an absolute `component` carrying `:41` flags the same file.
+/// Test: this test itself.
+#[test]
+fn analyze_component_with_line_suffix_matches() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    write(tmp.path(), "src/a.rs", "fn a() {}\n");
+    write(tmp.path(), "src/b.rs", "fn b() {}\n");
+    let files = list_tracked_files(tmp.path());
+    let m = metrics_flagging(&["/abs/checkout/src/b.rs:41"]);
+    let sel = select_files(
+        tmp.path(),
+        &files,
+        None,
+        Budget::default(),
+        RiskSignals {
+            metrics: Some(&m),
+            ..Default::default()
+        },
+    );
+    assert_eq!(order(&sel), ["src/b.rs", "src/a.rs"]);
+}
+
+/// Why: `inspect_priority` is the interface external selection intelligence
+/// writes to, so a declared path must be inspected ahead of every file the
+/// heuristics rank highly — including one the analyst brief names.
+/// What: the fixture's README, which scores lowest of all, is declared first and
+/// leads the ranking despite a brief that steers toward auth.
+/// Test: this test itself.
+#[test]
+fn manifest_priority_outranks_heuristics() {
+    let tmp = fixture();
+    let files = list_tracked_files(tmp.path());
+    let prio = priorities(&["README.md"]);
+    let sel = select_files(
+        tmp.path(),
+        &files,
+        Some("Focus on the login and authentication flow."),
+        Budget::default(),
+        RiskSignals {
+            priorities: &prio,
+            ..Default::default()
+        },
+    );
+    assert_eq!(sel.files[0].path, "README.md");
+    assert_eq!(sel.files[1].path, "src/auth/login.rs");
+}
+
+/// Why: the declared list is RANKED, and the budget must truncate it from the
+/// bottom — never scramble it — or an external ranker cannot predict what gets
+/// read.
+/// What: three priorities under a two-file budget select the first two in
+/// declared order, even though their paths sort the other way.
+/// Test: this test itself.
+#[test]
+fn priorities_beyond_the_budget_truncate_in_rank_order() {
+    let tmp = fixture();
+    let files = list_tracked_files(tmp.path());
+    let prio = priorities(&["src/store/user_store.ts", "package.json", "README.md"]);
+    let sel = select_files(
+        tmp.path(),
+        &files,
+        None,
+        Budget {
+            max_files: 2,
+            max_bytes: DEFAULT_MAX_BYTES,
+        },
+        RiskSignals {
+            priorities: &prio,
+            ..Default::default()
+        },
+    );
+    assert_eq!(order(&sel), ["src/store/user_store.ts", "package.json"]);
+}
+
+/// Why: a priority naming nothing in the repo must be inert, not a failure and
+/// not a displacement — an external ranker works from a stale index sometimes.
+/// What: an unmatched path leaves the baseline order untouched.
+/// Test: this test itself.
+#[test]
+fn unmatched_priority_is_inert() {
+    let tmp = fixture();
+    let files = list_tracked_files(tmp.path());
+    let prio = priorities(&["src/does/not/exist.rs"]);
+    let sel = select_files(
+        tmp.path(),
+        &files,
+        None,
+        Budget::default(),
+        RiskSignals {
+            priorities: &prio,
+            ..Default::default()
+        },
+    );
+    assert_eq!(order(&sel), BASELINE_ORDER);
 }

--- a/crates/trusty-review/src/report/manifest.rs
+++ b/crates/trusty-review/src/report/manifest.rs
@@ -5,9 +5,12 @@
 //! optional per-repo metrics.  Making the schema a typed struct with a
 //! `thiserror` loader means every malformed manifest fails loudly with a
 //! correctable message instead of silently producing an empty report.
-//! What: defines [`Manifest`], [`ReportSection`], [`RepositoryEntry`], and the
-//! [`RepositorySource`] enum, plus [`load_manifest`] which reads TOML, validates
-//! the exactly-one-of `path`/`remote` rule, and returns a resolved `Manifest`.
+//! What: defines [`Manifest`], [`ReportSection`], [`RepositoryEntry`],
+//! [`InspectionPriority`], and the [`RepositorySource`] enum, plus
+//! [`load_manifest`] which reads TOML, validates the exactly-one-of
+//! `path`/`remote` rule, and returns a resolved `Manifest`.  Per-repository
+//! `inspect_priority` (#6078) is the stable interface an external ranker writes
+//! its selection intelligence to — see [`InspectionPriority`].
 //! Test: `manifest_tests.rs` covers both source kinds, mutual-exclusion errors,
 //! the empty-manifest error, orphaned-username handling, and slug derivation.
 
@@ -139,13 +142,51 @@ pub struct ReportSection {
     pub analyze_url: Option<String>,
 }
 
+/// The weight the FIRST unweighted `inspect_priority` entry receives (#6078).
+///
+/// Why: a declared priority list is RANKED — entry 0 must be inspected before
+/// entry 1 — but the selection sort breaks weight ties by path, which would
+/// scramble that order. Giving entry `i` the weight `BASE - i` preserves the
+/// declared order exactly for the first 1000 entries and floors the rest at 1,
+/// where they still outrank every heuristic-only file.
+/// What: also the scale an explicit `weight` is written on; higher is inspected
+/// first.
+/// Test: `manifest_tests::inspect_priority_weights_follow_declared_rank`.
+const PRIORITY_BASE_WEIGHT: u32 = 1000;
+
+/// One manifest-declared inspection priority — THE interface external selection
+/// intelligence writes to (#6078, owner ruling 2026-08-19).
+///
+/// Why: `select_files`'s own path-name heuristics are guesses. A tool that has
+/// already ranked a repository by complexity, churn, or search relevance knows
+/// better, and that knowledge must arrive through the manifest rather than
+/// through trusty-review's code — so tuning what gets inspected never rebuilds
+/// this crate. `trusty-audit` is the intended writer; it computes the ranking
+/// and emits it here.
+/// What: `path` is repo-relative and matched against the tracked-file list;
+/// `weight` orders the priorities among themselves. Every priority outranks
+/// every heuristic-only file whatever its weight, and the file/byte budget
+/// still bounds what is actually read. A path matching no tracked file is
+/// inert — it neither errors nor displaces anything.
+/// Test: `manifest_tests::{parse_inspect_priority_shapes,
+/// inspect_priority_weights_follow_declared_rank}`;
+/// `select_tests::manifest_priority_outranks_heuristics`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct InspectionPriority {
+    /// Repo-relative path to inspect ahead of the heuristic ranking.
+    pub path: String,
+    /// Relative ordering weight among the priorities; higher goes first.
+    pub weight: u32,
+}
+
 /// One validated repository entry mapping to a single per-application block.
 ///
 /// Why: each entry becomes exactly one `per_application` section in the rendered
 /// report; the renderer iterates these in declared order.
 /// What: `name`/`slug` identify the application; `source` is the validated
 /// local-or-remote origin; `username` and `git_ref` are optional access /
-/// attribution hints; `metrics` optionally points at a trusty-analyze JSON file.
+/// attribution hints; `metrics` optionally points at a trusty-analyze JSON file;
+/// `inspect_priority` carries the external selection ranking (#6078).
 /// Test: `manifest_tests.rs::parse_local_path_entry`, `parse_remote_entry`.
 #[derive(Debug, Clone, Serialize)]
 pub struct RepositoryEntry {
@@ -167,6 +208,10 @@ pub struct RepositoryEntry {
     /// "declared metrics always win" precedence must not gate the
     /// authorship load too.
     pub authorship: Option<PathBuf>,
+    /// Ranked repo-relative paths the investigation pass must inspect first
+    /// (#6078). Empty — the default — leaves selection byte-identical to a
+    /// manifest without the key. See [`InspectionPriority`].
+    pub inspect_priority: Vec<InspectionPriority>,
 }
 
 /// The origin of a repository — a local checkout or a declared remote.
@@ -241,6 +286,53 @@ struct RawRepositoryEntry {
     metrics: Option<PathBuf>,
     #[serde(default)]
     authorship: Option<PathBuf>,
+    /// #6078: `inspect_priority = ["src/a.rs", { path = "src/b.rs", weight = 900 }]`
+    #[serde(default)]
+    inspect_priority: Vec<RawInspectionPriority>,
+}
+
+/// The two spellings one `inspect_priority` entry may take in TOML (#6078).
+///
+/// Why: a hand-written manifest wants a bare path list and takes its ranking
+/// from the declared order; a generator wants to state the weight it computed.
+/// Accepting both keeps the hand-written form short without a second key.
+/// What: a bare string, or a table with `path` and an optional `weight`.
+/// Test: `manifest_tests::parse_inspect_priority_shapes`.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum RawInspectionPriority {
+    /// A bare repo-relative path; its weight comes from its declared position.
+    Path(String),
+    /// A path with an optional explicit weight overriding the positional one.
+    Weighted {
+        /// Repo-relative path to inspect first.
+        path: String,
+        /// Explicit ordering weight; absent falls back to the position.
+        #[serde(default)]
+        weight: Option<u32>,
+    },
+}
+
+impl RawInspectionPriority {
+    /// Resolve one raw entry into its validated form, given its declared index.
+    ///
+    /// An absent `weight` becomes [`PRIORITY_BASE_WEIGHT`] minus the index (min
+    /// 1), which is what preserves the declared rank through the selection sort.
+    fn resolve(self, index: usize) -> InspectionPriority {
+        let positional = PRIORITY_BASE_WEIGHT
+            .saturating_sub(u32::try_from(index).unwrap_or(u32::MAX))
+            .max(1);
+        match self {
+            RawInspectionPriority::Path(path) => InspectionPriority {
+                path,
+                weight: positional,
+            },
+            RawInspectionPriority::Weighted { path, weight } => InspectionPriority {
+                path,
+                weight: weight.unwrap_or(positional),
+            },
+        }
+    }
 }
 
 // ─── Loader ─────────────────────────────────────────────────────────────────
@@ -314,6 +406,14 @@ fn validate(raw: RawManifest) -> std::result::Result<Manifest, ManifestError> {
         }
 
         let slug = entry.slug.unwrap_or_else(|| slugify(&entry.name));
+        // #6078: the declared order IS the ranking, so resolve each entry's
+        // weight from its index before the ordering is lost.
+        let inspect_priority = entry
+            .inspect_priority
+            .into_iter()
+            .enumerate()
+            .map(|(i, raw)| raw.resolve(i))
+            .collect();
         repositories.push(RepositoryEntry {
             name: entry.name,
             slug,
@@ -322,6 +422,7 @@ fn validate(raw: RawManifest) -> std::result::Result<Manifest, ManifestError> {
             git_ref: entry.git_ref,
             metrics: entry.metrics,
             authorship: entry.authorship,
+            inspect_priority,
         });
     }
 

--- a/crates/trusty-review/src/report/manifest_tests.rs
+++ b/crates/trusty-review/src/report/manifest_tests.rs
@@ -221,3 +221,68 @@ fn parse_ticketing_path() {
         "absent key defaults to None, which renders the section as unassessed"
     );
 }
+
+/// Why: `inspect_priority` is the interface trusty-audit writes its selection
+/// ranking to, and it must accept both a bare path list (hand-written) and a
+/// weighted table (generated) without a second key.
+/// What: parses a mixed list and asserts each entry's path and weight.
+/// Test: this test itself.
+#[test]
+fn parse_inspect_priority_shapes() {
+    let toml = r#"
+        [report]
+        title = "Acme DD"
+
+        [[repositories]]
+        name = "Website"
+        path = "/tmp/acme-web"
+        inspect_priority = [
+            "src/auth/login.rs",
+            { path = "src/billing.rs", weight = 5000 },
+            { path = "src/queue.rs" },
+        ]
+    "#;
+    let m = parse(toml).expect("parse ok");
+    let p = &m.repositories[0].inspect_priority;
+    assert_eq!(p.len(), 3);
+    assert_eq!(p[0].path, "src/auth/login.rs");
+    assert_eq!(p[1].path, "src/billing.rs");
+    assert_eq!(
+        p[1].weight, 5000,
+        "an explicit weight wins over the position"
+    );
+    assert_eq!(p[2].path, "src/queue.rs");
+}
+
+/// Why: the declared order IS the ranking, so an unweighted list must come out
+/// strictly descending — otherwise the selection sort breaks ties by path and
+/// scrambles what the ranker asked for.
+/// What: three bare paths get 1000/999/998; an absent key yields an empty list,
+/// which is what keeps selection byte-identical to a pre-#6078 manifest.
+/// Test: this test itself.
+#[test]
+fn inspect_priority_weights_follow_declared_rank() {
+    let toml = r#"
+        [report]
+        title = "Acme DD"
+
+        [[repositories]]
+        name = "Website"
+        path = "/tmp/acme-web"
+        inspect_priority = ["c.rs", "b.rs", "a.rs"]
+    "#;
+    let m = parse(toml).expect("parse ok");
+    let weights: Vec<u32> = m.repositories[0]
+        .inspect_priority
+        .iter()
+        .map(|p| p.weight)
+        .collect();
+    assert_eq!(weights, vec![1000, 999, 998]);
+
+    let none = parse("[report]\ntitle = \"T\"\n\n[[repositories]]\nname = \"A\"\npath = \"/x\"\n")
+        .expect("parses");
+    assert!(
+        none.repositories[0].inspect_priority.is_empty(),
+        "absent key must leave selection byte-identical to a pre-#6078 manifest"
+    );
+}

--- a/crates/trusty-review/src/report/model.rs
+++ b/crates/trusty-review/src/report/model.rs
@@ -196,6 +196,17 @@ pub struct RepositoryReport {
     /// Test: `model_tests::{authorship_loads_when_declared,
     /// unreadable_authorship_is_a_named_gap_not_a_build_failure}`.
     pub authorship: Option<super::authorship::AuthorshipSummary>,
+    /// Manifest-declared inspection ranking for the investigation pass (#6078).
+    ///
+    /// Why: `run_investigation` reads its selection inputs off the model, so the
+    /// external ranking has to travel here to reach `select_files`. Serialising
+    /// it keeps the JSON twin an honest record of WHY those files were read.
+    /// What: the resolved [`super::manifest::InspectionPriority`] list, in
+    /// declared order. Empty (the default) leaves selection and the JSON twin
+    /// byte-identical to a manifest without the key.
+    /// Test: `select_tests::manifest_priority_outranks_heuristics`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub inspect_priority: Vec<super::manifest::InspectionPriority>,
 }
 
 impl ReportModel {
@@ -343,6 +354,9 @@ fn build_repository(
             scan,
             metrics,
             authorship,
+            // #6078: the external selection ranking rides through to
+            // `select_files` unchanged; this crate never recomputes it.
+            inspect_priority: entry.inspect_priority.clone(),
         },
         authorship_gap,
     ))

--- a/crates/trusty-review/src/report/reporter_authorship_tests.rs
+++ b/crates/trusty-review/src/report/reporter_authorship_tests.rs
@@ -15,6 +15,7 @@ fn repo(authorship: Option<AuthorshipSummary>) -> RepositoryReport {
         scan: None,
         metrics: None,
         authorship,
+        inspect_priority: Vec::new(),
     }
 }
 

--- a/crates/trusty-review/src/report/reporter_codesec_tests.rs
+++ b/crates/trusty-review/src/report/reporter_codesec_tests.rs
@@ -18,6 +18,7 @@ fn repo(metrics: Option<AnalyzeMetrics>) -> RepositoryReport {
         scan: None,
         metrics,
         authorship: None,
+        inspect_priority: Vec::new(),
     }
 }
 

--- a/crates/trusty-review/src/report/reporter_facts_tests.rs
+++ b/crates/trusty-review/src/report/reporter_facts_tests.rs
@@ -22,6 +22,7 @@ fn repo_with(metrics: Option<AnalyzeMetrics>, scan: Option<RepoScan>) -> Reposit
         scan,
         metrics,
         authorship: None,
+        inspect_priority: Vec::new(),
     }
 }
 

--- a/crates/trusty-review/src/report/synthesize_digest_tests.rs
+++ b/crates/trusty-review/src/report/synthesize_digest_tests.rs
@@ -42,6 +42,7 @@ fn repo(slug: &str, findings: Vec<MetricFinding>) -> RepositoryReport {
             ..Default::default()
         }),
         authorship: None,
+        inspect_priority: Vec::new(),
     }
 }
 

--- a/crates/trusty-review/src/report/synthesize_tests.rs
+++ b/crates/trusty-review/src/report/synthesize_tests.rs
@@ -174,6 +174,7 @@ fn fixture_model(findings: Vec<MetricFinding>) -> ReportModel {
             scan: None,
             metrics: Some(metrics),
             authorship: None,
+            inspect_priority: Vec::new(),
         }],
         gaps: Vec::new(),
         synthesis: None,


### PR DESCRIPTION
Refs #6078

`select_files` ranked by path-name guesses alone. Two better-informed rankers were already available and unused; this wires both in behind one input, `RiskSignals`, whose `Default` reproduces the previous ranking byte for byte.

## The stable interface (owner ruling 2026-08-19)

The ruling — "All changes should only require work in audit for a quick rebuild" — landed mid-implementation and shapes the main deliverable. The manifest now carries a per-repository `inspect_priority` list:

```toml
[[repositories]]
name = "Website"
path = "/tmp/acme-web"
inspect_priority = [
    "src/auth/login.rs",
    { path = "src/billing.rs", weight = 5000 },
]
```

Bare paths take their weight from declared position (1000, 999, …), so an unweighted list keeps its rank through the selection sort. A priority is a **separate, dominant sort key** rather than another score term, so a declared path is inspected ahead of every heuristic-only file whatever its weight. The file/byte budget still bounds how many are read, and truncation takes the list from the bottom. trusty-audit computes the ranking from search/complexity/churn and writes it here — that half lands in trusty-audit later, not in this PR — so tuning what gets inspected never rebuilds trusty-review.

An absent key yields an empty list, which is the byte-identical path. A path matching no tracked file is inert.

## The internal term

A file named by a trusty-analyze `MetricFinding.component` scores +4: above a DD-dimension match (×2), because a tool observed something in that file rather than guessing from its name; below two analyst-brief keyword hits (×3 each), because the analyst's stated focus still wins. Added once per file however many findings name it, so one noisy lint rule cannot bury the ranking. Components are normalised — separators, lower-case, a trailing `:<line>` — so an absolute path from the daemon still resolves to the tracked repo-relative one.

## Coverage percentage

The Investigation Coverage line and the synthesis-prompt coverage summary state the examined share as a percentage next to the raw counts, computed once so both surfaces agree. It extends the existing line rather than adding a section:

```
- files examined: 12 of 200 tracked (6.0% coverage, 188 skipped); 40000 bytes sent (budget 40/409600)
```

## Pre-fix failure proofs

**Byte-identity (a).** `BASELINE_ORDER` in `select_tests.rs` is a literal captured by running `select_files` on `origin/main` at `bbc039b46`:

```
BASELINE_ORDER=["src/auth/login.rs", "src/errors.rs", "src/store/user_store.ts", "package.json", "tests/login_test.rs", "README.md"]
```

`absent_signals_reproduce_baseline_order` and `unmatched_priority_is_inert` assert the selection still equals it.

**Ranking (b).** Neutralising the two new terms (`FLAGGED_WEIGHT = 0`, `priority_weight` returning 0) fails exactly the four behavior tests while both byte-identity tests keep passing:

```
thread '...analyze_flagged_file_outranks_peer' panicked at select_tests.rs:344:5:
  left: ["src/a.rs", "src/b.rs"]
 right: ["src/b.rs", "src/a.rs"]

thread '...analyze_component_with_line_suffix_matches' panicked at select_tests.rs:368:5:
  left: ["src/a.rs", "src/b.rs"]
 right: ["src/b.rs", "src/a.rs"]

thread '...manifest_priority_outranks_heuristics' panicked at select_tests.rs:392:5:
  left: "src/auth/login.rs"
 right: "README.md"

thread '...priorities_beyond_the_budget_truncate_in_rank_order' panicked at select_tests.rs:420:5:
  left: ["src/auth/login.rs", "src/errors.rs"]
 right: ["src/store/user_store.ts", "package.json"]

test result: FAILED. 10 passed; 4 failed; 0 ignored; 0 measured; 1716 filtered out
```

**Coverage line (c).** The two render assertions against `origin/main`'s renderer:

```
thread '...coverage_section_states_examined_and_rejected' panicked at render_tests.rs:101:5:
coverage line missing the percentage:
- files examined: 12 of 200 tracked (188 skipped); 40000 bytes sent (budget 40/409600)

thread '...coverage_prompt_summary_lists_gaps' panicked at render_tests.rs:140:5:
prompt summary missing the percentage:
- Acme: examined 12 of 200 files; 1 verified finding(s); 2 rejected; not investigated: scalability

test result: FAILED. 6 passed; 2 failed
```

## Gates — rung 3 (localized behavior inside one crate)

| Gate | Result |
|---|---|
| `cargo fmt --check` | clean |
| `cargo check -p trusty-review --all-targets` | clean |
| `cargo clippy -p trusty-review --all-targets -- -D warnings` | exit 0 |
| `cargo test -p trusty-review` | `1725 passed; 0 failed; 5 ignored` (lib) plus 8 integration binaries, 94 passed, 0 failed |
| `scripts/check_line_cap.sh` | `4114 tracked .rs file(s); 0 violations` |
| `scripts/check_changelog_fragment.sh` | `all 1 crate(s) with source changes are recorded` |
| `scripts/check_test_pointers.sh` | `26181 Test: citation(s); 0 dangling pointers` |
| `scripts/check_sld.sh` | `0 error(s), 0 warning(s)` |

Rung 3 is the right rung: every change is inside `trusty-review`, and `RepositoryEntry` / `RepositoryReport` / `select_files` are crate-internal to the report pipeline — no other workspace crate constructs or calls them.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
