### PR TITLE
fix(trusty-agents): audit findings — atomic config save, serde/Default mismatch, dead branch

### DIFF
--- a/crates/trusty-agents/changelog.d/audit-config-durability.md
+++ b/crates/trusty-agents/changelog.d/audit-config-durability.md
@@ -1,0 +1,5 @@
+Fixed
+
+- `GlobalConfig::save` now publishes `~/.trusty-agents/config.toml` by writing a scratch file beside the target and renaming it into place. It ran a plain `tokio::fs::write`, which truncates the live config first, so a crash between truncate and the last byte left a torn file that the next load silently replaced with defaults — every registered MCP service, GitHub identity, and listener gone. The doc comment had claimed an atomic write since #244. The scratch name comes from the same `temp_path` generator the agent-manifest writer uses, so the two cannot drift on the per-process, per-attempt naming that #4409 established
+- a `[local_inference]` section that omits `enabled` now inherits the documented default of `true`. The field carried `#[serde(default)]`, which resolves to `false` for a bool, while the doc comment and `LocalInferenceConfig::default()` both said `true` — so a hand-edited config that changed only `model` silently turned the Ollama fast-path off. An explicit `enabled = false` still wins
+- `truncate_history` lost a nested `max_turns == 0` check whose two arms both returned an empty vector. Behavior is unchanged

--- a/crates/trusty-agents/src/compress/context.rs
+++ b/crates/trusty-agents/src/compress/context.rs
@@ -38,12 +38,11 @@ impl Default for TokenBudget {
 /// Test: `truncate_*` cases in `tests` module.
 pub fn truncate_history<T: Clone>(turns: &[T], budget: &TokenBudget) -> Vec<T> {
     let n = turns.len();
+    // `max_turns == 0` with `pin_turn_zero` is an edge case: the pinned turn 0
+    // would exceed the budget; we honor `max_turns` and return empty.
+    // audit 2026-08-19: collapsed a nested `max_turns == 0` check whose two
+    // arms both returned `Vec::new()`.
     if n == 0 || budget.max_turns == 0 {
-        // max_turns == 0 with pin_turn_zero is an edge case: pinned turn 0
-        // would exceed the budget; we choose to honor max_turns and return empty.
-        if budget.max_turns == 0 {
-            return Vec::new();
-        }
         return Vec::new();
     }
     if n <= budget.max_turns {

--- a/crates/trusty-agents/src/mcp/config/mod.rs
+++ b/crates/trusty-agents/src/mcp/config/mod.rs
@@ -85,12 +85,15 @@ pub struct GlobalConfig {
     ///
     /// Why: Routing qualifying queries (TM status, simple chat) to a local
     /// Ollama instance shaves the remote round-trip + token cost from the
-    /// hot path. Defaults to disabled so the feature is opt-in: a user must
-    /// explicitly toggle `enabled = true` (or run `/local on`) before any
-    /// remote-bound traffic gets diverted.
+    /// hot path. Enabled by default since #345 — `/local off` or
+    /// `enabled = false` turns it back off. (The pre-#345 opt-in wording this
+    /// comment carried was corrected by the 2026-08-19 audit, which found the
+    /// same claim contradicting `LocalInferenceConfig::default`.)
     /// What: Holds enable flag, model id (`ollama/<name>` form), fallback
     /// behavior, host URL, and a max-token cap to keep local responses snappy.
-    /// Test: `local_inference_defaults_apply` round-trips the section.
+    /// Test: `local_inference_defaults_apply` round-trips the section;
+    /// `local_inference_enabled_defaults_true_when_key_omitted` pins the
+    /// default that applies when the section omits `enabled`.
     #[serde(default)]
     pub local_inference: LocalInferenceConfig,
     /// `[tool_registry]` section (#453) — OpenRPC tool registry config.
@@ -246,9 +249,20 @@ impl GlobalConfig {
     /// mutate the in-memory config and need to immediately write it back to
     /// `~/.trusty-agents/config.toml` so subsequent processes (and the next
     /// prompt build) see the change.
-    /// What: Serializes `self` to pretty TOML and atomically writes to
-    /// `config_path()`. Creates the parent directory if absent.
-    /// Test: `tests::save_and_reload_roundtrip`.
+    /// What: Serializes `self` to pretty TOML, writes it to a scratch file
+    /// beside the target, then renames that file onto `config_path()` —
+    /// publishing the new config in one atomic directory operation. Creates
+    /// the parent directory if absent. A failed write or rename removes the
+    /// scratch file rather than leaving it behind.
+    ///
+    /// The scratch name comes from
+    /// [`trusty_agents_common::agents::manifest::temp_path`] so this writer
+    /// cannot drift from the per-process, per-attempt naming that #4409
+    /// established — a shared fixed `.tmp` name is its own corruption bug when
+    /// two writers interleave.
+    /// Test: `tests::save_and_reload_roundtrip`,
+    /// `tests::save_publishes_by_rename_leaving_the_old_file_intact`,
+    /// `tests::save_leaves_no_scratch_file_behind`.
     pub async fn save(&self) -> Result<()> {
         let path = Self::config_path()?;
         if let Some(parent) = path.parent() {
@@ -257,9 +271,19 @@ impl GlobalConfig {
                 .with_context(|| format!("failed to create config dir {}", parent.display()))?;
         }
         let content = toml::to_string_pretty(self).context("failed to serialize mcp config")?;
-        tokio::fs::write(&path, content)
-            .await
-            .with_context(|| format!("failed to write config {}", path.display()))?;
+        // audit 2026-08-19: was a plain `tokio::fs::write`, which truncates the
+        // live config in place — a crash mid-write left a torn file.
+        let tmp = trusty_agents_common::agents::manifest::temp_path(&path);
+        if let Err(e) = tokio::fs::write(&tmp, &content).await {
+            let _ = tokio::fs::remove_file(&tmp).await;
+            return Err(anyhow::Error::new(e)
+                .context(format!("failed to write config scratch {}", tmp.display())));
+        }
+        if let Err(e) = tokio::fs::rename(&tmp, &path).await {
+            let _ = tokio::fs::remove_file(&tmp).await;
+            return Err(anyhow::Error::new(e)
+                .context(format!("failed to publish config {}", path.display())));
+        }
         Ok(())
     }
 

--- a/crates/trusty-agents/src/mcp/config/tests/mod.rs
+++ b/crates/trusty-agents/src/mcp/config/tests/mod.rs
@@ -244,6 +244,87 @@ async fn save_and_reload_roundtrip() {
 }
 
 #[tokio::test]
+async fn save_publishes_by_rename_leaving_the_old_file_intact() {
+    // audit 2026-08-19: `save()` documented an atomic write but ran a plain
+    // `tokio::fs::write`, which truncates the live config in place — a crash
+    // between truncate and the last byte leaves a torn config that the next
+    // `load()` silently replaces with defaults. Temp-then-rename swaps the
+    // directory entry instead, so the previously published inode is never
+    // written to and stays a complete, parseable config.
+    //
+    // The hard link is the observer: it names the inode that `save()` #1
+    // published. After `save()` #2 it must still read the OLD content. Under
+    // an in-place `fs::write` it would read the NEW content, because both
+    // names point at the one inode being overwritten.
+    let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let home = tempdir();
+    unsafe {
+        std::env::set_var("HOME", &home);
+    }
+
+    let mut cfg = GlobalConfig::default();
+    cfg.mcp.inject_for_roles = vec!["ctrl".to_string()];
+    cfg.save().await.expect("first save");
+
+    let path = home.join(".trusty-agents").join("config.toml");
+    let published = std::fs::read_to_string(&path).expect("read first save");
+
+    let witness = home.join(".trusty-agents").join("witness.toml");
+    std::fs::hard_link(&path, &witness).expect("hard link the published inode");
+
+    cfg.mcp.inject_for_roles = vec!["pm".to_string()];
+    cfg.save().await.expect("second save");
+
+    let republished = std::fs::read_to_string(&path).expect("read second save");
+    assert_ne!(
+        republished, published,
+        "the target must carry the second save's content"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&witness).expect("read witness"),
+        published,
+        "the inode published by the first save must be untouched — proof the \
+         second save published by rename rather than truncating in place"
+    );
+}
+
+#[tokio::test]
+async fn save_leaves_no_scratch_file_behind() {
+    // audit 2026-08-19: temp-then-rename must clean up after itself — a
+    // scratch file left in `~/.trusty-agents/` is visible clutter, and an
+    // orphaned one is indistinguishable from an interrupted write.
+    let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let home = tempdir();
+    unsafe {
+        std::env::set_var("HOME", &home);
+    }
+
+    let mut cfg = GlobalConfig::default();
+    cfg.mcp.inject_for_roles = vec!["ctrl".to_string()];
+    cfg.save().await.expect("save should succeed");
+
+    let dir = home.join(".trusty-agents");
+    let mut names: Vec<String> = std::fs::read_dir(&dir)
+        .expect("read config dir")
+        .map(|e| {
+            e.expect("dir entry")
+                .file_name()
+                .to_string_lossy()
+                .into_owned()
+        })
+        .collect();
+    names.sort();
+    assert_eq!(
+        names,
+        vec!["config.toml".to_string()],
+        "save() must leave exactly the published config, no scratch files"
+    );
+
+    let reloaded = GlobalConfig::load().await;
+    assert_eq!(reloaded.mcp.inject_for_roles, vec!["ctrl".to_string()]);
+}
+
+#[tokio::test]
 async fn add_service_replaces_existing() {
     // (#244) add_service with a name that already exists replaces, not appends.
     let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());

--- a/crates/trusty-agents/src/mcp/config/tests/render_tests.rs
+++ b/crates/trusty-agents/src/mcp/config/tests/render_tests.rs
@@ -222,6 +222,42 @@ max_tokens = 4096
 }
 
 #[test]
+fn local_inference_enabled_defaults_true_when_key_omitted() {
+    // audit 2026-08-19: `enabled` carried `#[serde(default)]`, so a
+    // `[local_inference]` section that omits the key parsed as `false` while
+    // both the doc comment and `LocalInferenceConfig::default()` said `true`.
+    // A hand-edited config that only changed `model` silently turned the
+    // fast-path off.
+    let cfg = GlobalConfig::from_toml_str(
+        r#"
+[local_inference]
+model = "ollama/qwen3:8b"
+"#,
+    )
+    .expect("section without `enabled` parses");
+    assert!(
+        cfg.local_inference.enabled,
+        "a [local_inference] section omitting `enabled` must inherit the \
+         documented default (true), not serde's bool default (false)"
+    );
+    assert_eq!(cfg.local_inference.model, "ollama/qwen3:8b");
+}
+
+#[test]
+fn local_inference_explicit_false_still_wins() {
+    // The default only fills an ABSENT key — an operator who wrote
+    // `enabled = false` keeps the fast-path off.
+    let cfg = GlobalConfig::from_toml_str(
+        r#"
+[local_inference]
+enabled = false
+"#,
+    )
+    .expect("explicit false parses");
+    assert!(!cfg.local_inference.enabled);
+}
+
+#[test]
 fn default_config_includes_local_inference_section() {
     // (#319, #345) The DEFAULT_CONFIG_TOML literal must include a usable
     // [local_inference] block so users have an obvious place to flip

--- a/crates/trusty-agents/src/mcp/config/types.rs
+++ b/crates/trusty-agents/src/mcp/config/types.rs
@@ -36,11 +36,16 @@ pub(super) fn default_true() -> bool {
 /// model id. `fallback_on_error` controls whether a local failure retries
 /// remotely. `ollama_host` overrides the default localhost URL.
 /// `max_tokens` caps the local response (small for speed).
-/// Test: Defaults exercised via `LocalInferenceConfig::default`.
+/// Test: Defaults exercised via `LocalInferenceConfig::default`;
+/// `local_inference_enabled_defaults_true_when_key_omitted` and
+/// `local_inference_explicit_false_still_wins` pin the `enabled` serde default
+/// to the documented value.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct LocalInferenceConfig {
     /// Enable local Ollama fast-path (default: true — enabled by default, #345).
-    #[serde(default)]
+    // audit 2026-08-19: was `#[serde(default)]`, which resolves to `false` and
+    // silently disabled the fast-path for any section omitting the key.
+    #[serde(default = "default_true")]
     pub enabled: bool,
     /// Ollama model id, in `ollama/<name>` form (default: ollama/qwen3:30b).
     #[serde(default = "default_local_model")]


### PR DESCRIPTION
Three config-durability defects in `trusty-agents`, found by the 2026-08-19 trusty-tools self-audit (`~/Audit/output/2026-08-19-trusty-tools-technical-due-diligence.md`). No GitHub issues exist for these; the audit report is the citation. Rung 3 — localized behavior inside one crate.

## 1. `GlobalConfig::save` was not atomic (`src/mcp/config/mod.rs:259`)

The doc comment had claimed "atomically writes" since #244; the body ran a plain `tokio::fs::write`, which truncates the live config first. A crash between the truncate and the last byte leaves a torn `~/.trusty-agents/config.toml`, and `load()` answers a parse failure by silently substituting defaults — so every registered MCP service, GitHub identity, and listener disappears with no error surfaced.

`save()` now writes a scratch file beside the target and renames it onto the target. The scratch name comes from `trusty_agents_common::agents::manifest::temp_path`, the generator the agent-manifest writer already uses, so the two cannot drift on the per-process, per-attempt naming that #4409 established after a fixed `.tmp` name caused real corruption. A failed write or rename removes the scratch file.

An atomicity test that fails pre-fix cannot simulate a crash, so the regression test proves the mechanism instead. `save_publishes_by_rename_leaving_the_old_file_intact` hard-links the inode published by the first `save()`, runs a second `save()`, and asserts the hard link still reads the *old* content. Under an in-place `fs::write` both names address the one inode being overwritten, so the link reads the new content and the test fails. Under temp-then-rename only the directory entry moves, so the old inode is never written to — which is exactly the crash-safety property. `save_leaves_no_scratch_file_behind` asserts the config directory holds exactly the published file afterwards.

Pre-fix run:

```
thread 'mcp::config::tests::save_publishes_by_rename_leaving_the_old_file_intact' panicked at crates/trusty-agents/src/mcp/config/tests/mod.rs:283:5:
assertion `left == right` failed: the inode published by the first save must be untouched — proof the second save published by rename rather than truncating in place
test mcp::config::tests::save_publishes_by_rename_leaving_the_old_file_intact ... FAILED
```

## 2. `LocalInferenceConfig.enabled` — serde default contradicted `impl Default` (`src/mcp/config/types.rs:42`)

The field carried `#[serde(default)]`, which resolves to `false` for a bool, while the doc comment and `impl Default` (line 74) both said `true`. The shipped `default-config.toml` writes `enabled = true` explicitly, so the mismatch only bites a hand-edited config: a user who added a `[local_inference]` section to change `model` and nothing else silently turned the Ollama fast-path off, with the doc comment telling them it was on.

Now `#[serde(default = "default_true")]`, using the helper already at `types.rs:24`. An explicit `enabled = false` still wins — `local_inference_explicit_false_still_wins` pins that. The `GlobalConfig.local_inference` field doc still described the pre-#345 opt-in default, and is corrected to match.

Pre-fix run of the new test against unmodified source:

```
thread 'mcp::config::tests::render_tests::local_inference_enabled_defaults_true_when_key_omitted' panicked at crates/trusty-agents/src/mcp/config/tests/render_tests.rs:238:5:
a [local_inference] section omitting `enabled` must inherit the documented default (true), not serde's bool default (false)
test mcp::config::tests::render_tests::local_inference_enabled_defaults_true_when_key_omitted ... FAILED
```

## 3. Dead nested branch in `truncate_history` (`src/compress/context.rs:41`)

The inner `max_turns == 0` check had two arms that both returned `Vec::new()`. Collapsed to one early return. Behavior is identical and both arms were already covered — `truncate_empty_returns_empty` reaches it with `n == 0`, `truncate_max_turns_zero_with_pin` with `max_turns == 0`. Both stay green.

## Gate — rung 3

```
cargo fmt --check                                     EXIT=0
cargo check -p trusty-agents --all-targets            EXIT=0
cargo clippy -p trusty-agents --all-targets -- -D warnings   EXIT=0
cargo test -p trusty-agents                           EXIT=0
  test result: ok. 3520 passed; 0 failed; 13 ignored; 0 measured; 0 filtered out
  (plus 11 integration binaries, all ok, 0 failed)
bash scripts/check_line_cap.sh                        EXIT=0
bash scripts/check_changelog_fragment.sh              EXIT=0
  OK   trusty-agents: changelog.d fragment present and valid
bash scripts/check_test_pointers.sh                   EXIT=0
  test-pointers: resolved 26178 Test: citation(s) — 0 dangling pointers
```

Changelog fragment: `crates/trusty-agents/changelog.d/audit-config-durability.md`.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
