### PR TITLE
fix(trusty-agents): audit findings — memory-store crash consistency (lock ordering, move_segment atomicity, score clamp)

### DIFF
--- a/crates/trusty-agents/changelog.d/audit-memory-store-consistency.md
+++ b/crates/trusty-agents/changelog.d/audit-memory-store-consistency.md
@@ -1,0 +1,24 @@
+Fixed
+
+- **A failed vector write no longer leaves a memory that `get` returns and
+  `search` can never find.** `insert` committed its redb transaction before
+  touching the usearch index under a separate lock, so any failure between the
+  two — or a crash — recorded the payload and label with no vector behind them.
+  The segment mutex is now taken before `begin_write` and redb commits last, so
+  a failed vector write aborts the transaction and leaves redb untouched; the
+  only residue is an orphan vector whose label has no redb row, which `search`
+  already skips
+- **`move_segment` can no longer duplicate a record across two segments.** It
+  inserted into the destination and deleted from the source in two independent
+  transactions, biased toward duplication when the second step failed. Both
+  halves now share one redb transaction, with the destination vector flushed
+  before the commit and the source vector dropped after it, so a failure leaves
+  the record whole in exactly one segment. A crash between the commit and the
+  source flush still strands an unreachable vector in the source index, which
+  the next write to that label reclaims
+- **Search scores are clamped to `[0.0, 1.0]`.** `1.0 - distance` went to
+  `-1.0` for a vector antipodal to the query, because cosine distance reaches
+  `2.0`
+
+Found by the 2026-08-19 trusty-tools self-audit, whose summary named
+crash-consistency weaknesses in the semantic-memory store as a top concern.

--- a/crates/trusty-agents/src/memory/redb_usearch/store_impl.rs
+++ b/crates/trusty-agents/src/memory/redb_usearch/store_impl.rs
@@ -11,6 +11,7 @@
 use anyhow::{Context, Result, anyhow};
 use async_trait::async_trait;
 use redb::{ReadableDatabase, ReadableTable, ReadableTableMetadata};
+use usearch::Index;
 
 use super::{PAYLOAD_TABLE, RedbUsearchStore, ensure_capacity, next_label, save_index};
 use crate::memory::store::{MemoryResult, MemoryStore, Segment};
@@ -24,64 +25,47 @@ impl MemoryStore for RedbUsearchStore {
         vector: &[f32],
         payload: serde_json::Value,
     ) -> Result<()> {
-        // 1. Persist payload + label mapping inside one redb txn.
         let payload_json =
             serde_json::to_string(&payload).context("serializing memory payload to JSON")?;
-        let payload_key = format!("{}:{}", segment.prefix(), id);
-        let (label_to_id_def, id_to_label_def) = Self::label_tables(segment);
 
-        let label = {
-            let write_txn = self.db.begin_write()?;
-            let label = {
-                // Reuse existing label if this id has been written before,
-                // otherwise allocate a new one.
-                let existing = {
-                    let id_to_label = write_txn.open_table(id_to_label_def)?;
-                    id_to_label.get(id)?.map(|v| v.value())
-                };
-                let label = match existing {
-                    Some(l) => l,
-                    None => next_label(&write_txn, segment)?,
-                };
-
-                {
-                    let mut payloads = write_txn.open_table(PAYLOAD_TABLE)?;
-                    payloads.insert(payload_key.as_str(), payload_json.as_str())?;
-                }
-                {
-                    let mut label_to_id = write_txn.open_table(label_to_id_def)?;
-                    label_to_id.insert(label, id)?;
-                }
-                {
-                    let mut id_to_label = write_txn.open_table(id_to_label_def)?;
-                    id_to_label.insert(id, label)?;
-                }
-                label
-            };
-            write_txn.commit()?;
-            label
-        };
-
-        // 2. Add vector to usearch and flush to disk. Mutations happen under
-        //    the mutex so concurrent inserts can't race on capacity growth.
-        //    `ensure_loaded` transparently re-hydrates an evicted index so the
-        //    file watcher path keeps writing through cool-down windows.
+        // audit 2026-08-19: the segment mutex is taken BEFORE `begin_write`, so
+        // the redb rows and the usearch vector are written in one critical
+        // section, and redb commits LAST.
+        //
+        // Ordering rationale. The two stores can disagree in two directions and
+        // they are not equally bad. A record redb knows about but usearch
+        // cannot find is returned by `get` and missed by `search` — a
+        // half-visible memory, and the one a reader notices. A vector whose
+        // label has no redb row is inert: `search` already skips labels that
+        // `label_to_id` cannot resolve, and the next write to that label
+        // overwrites it. Committing redb only after the vector is on disk makes
+        // the first direction unreachable, because every failure below drops
+        // `write_txn` uncommitted and leaves redb exactly as it was. That is
+        // the empty window; the residue is always the inert direction.
+        //
+        // `ensure_loaded` transparently re-hydrates an evicted index, so the
+        // file-watcher path keeps writing through cool-down windows.
         let (_, index_path) = self.index_for(segment);
         let guard = self.ensure_loaded(segment).await?;
         let index = guard.as_ref().expect("ensure_loaded guarantees Some");
-        ensure_capacity(index)?;
-        // If the label is already present (re-insert of same id), remove
-        // first so usearch doesn't end up with stale duplicates.
-        if index.contains(label) {
-            let _ = index
-                .remove(label)
-                .map_err(|e| anyhow!("removing stale usearch entry: {e}"))?;
-        }
-        index
-            .add(label, vector)
-            .map_err(|e| anyhow!("adding vector to usearch: {e}"))?;
-        save_index(index, &index_path)?;
 
+        let write_txn = self.db.begin_write()?;
+        let label = write_rows(&write_txn, segment, id, &payload_json)?;
+
+        ensure_capacity(index)?;
+        let displaced = take_displaced(index, label)?;
+        let vector_stored = index
+            .add(label, vector)
+            .map_err(|e| anyhow!("adding vector to usearch: {e}"))
+            .and_then(|_| save_index(index, &index_path));
+        if let Err(e) = vector_stored {
+            // `write_txn` is dropped uncommitted below, so the id's previous
+            // redb row survives and must keep pointing at a real vector.
+            restore_displaced(index, label, displaced);
+            return Err(e);
+        }
+
+        write_txn.commit()?;
         Ok(())
     }
 
@@ -122,7 +106,11 @@ impl MemoryStore for RedbUsearchStore {
                 .context("deserializing stored payload JSON")?;
             results.push(MemoryResult {
                 id,
-                score: 1.0 - *distance,
+                // audit 2026-08-19: cosine distance reaches 2.0 for an
+                // antipodal vector, so the raw `1.0 - distance` went to -1.0.
+                // Clamp so callers can treat the score as a similarity in
+                // [0.0, 1.0] without re-validating it.
+                score: (1.0 - *distance).clamp(0.0, 1.0),
                 payload,
                 segment: segment.prefix().to_string(),
             });
@@ -170,11 +158,30 @@ impl MemoryStore for RedbUsearchStore {
         // Why: Reclassify a record (e.g., brief -> history) without losing
         // the original embedding. Reading payload + vector first means we
         // can avoid recomputing the embedding in the destination segment.
+        //
+        // audit 2026-08-19: the redb half of the move is now ONE transaction —
+        // the destination rows are written and the source rows removed
+        // together, so no failure can leave the record in both segments or in
+        // neither. This replaces an insert-then-delete pair that ran two
+        // independent transactions and documented a duplicate-over-loss bias.
+        //
+        // The two vector indexes cannot join that transaction, so they bracket
+        // it, each on the side that keeps the residue inert: the destination
+        // vector is flushed BEFORE the commit, because an addition must be
+        // durable before metadata points at it; the source vector is dropped
+        // AFTER, because a removal must not outrun its metadata or the
+        // surviving row would point at nothing. Either bracket failing leaves
+        // at worst an orphan vector with no redb row, which `search` skips.
+        //
+        // Achieved: atomic metadata move, no duplicate and no loss. Not
+        // achieved: full cross-store atomicity. A crash between the commit and
+        // the source flush leaves a stale vector in the source index —
+        // unreachable from every read path, reclaimed by the next write to
+        // that label.
         if from == to {
             return Ok(());
         }
 
-        // 1. Fetch payload from source.
         let payload = match self.get(from, id).await? {
             Some(p) => p,
             None => {
@@ -184,12 +191,28 @@ impl MemoryStore for RedbUsearchStore {
                 ));
             }
         };
+        let payload_json =
+            serde_json::to_string(&payload).context("serializing memory payload to JSON")?;
 
-        // 2. Fetch vector from source's usearch index.
+        // Lock both segment indexes lowest-rank-first so two moves running in
+        // opposite directions cannot deadlock on each other's mutex.
+        let (lo, hi) = if lock_rank(from) < lock_rank(to) {
+            (from, to)
+        } else {
+            (to, from)
+        };
+        let lo_guard = self.ensure_loaded(lo).await?;
+        let hi_guard = self.ensure_loaded(hi).await?;
+        let (src_guard, dst_guard) = if lo == from {
+            (&lo_guard, &hi_guard)
+        } else {
+            (&hi_guard, &lo_guard)
+        };
+        let src_index = src_guard.as_ref().expect("ensure_loaded guarantees Some");
+        let dst_index = dst_guard.as_ref().expect("ensure_loaded guarantees Some");
+
+        // Source vector, read before anything mutates.
         let vector: Vec<f32> = {
-            let guard = self.ensure_loaded(from).await?;
-            let index = guard.as_ref().expect("ensure_loaded guarantees Some");
-            let dim = index.dimensions();
             let (_, id_to_label_def) = Self::label_tables(from);
             let read_txn = self.db.begin_read()?;
             let id_to_label = read_txn.open_table(id_to_label_def)?;
@@ -197,8 +220,8 @@ impl MemoryStore for RedbUsearchStore {
                 .get(id)?
                 .map(|v| v.value())
                 .ok_or_else(|| anyhow!("move_segment: missing label for id {id:?}"))?;
-            let mut buf = vec![0.0f32; dim];
-            let n = index
+            let mut buf = vec![0.0f32; src_index.dimensions()];
+            let n = src_index
                 .get(label, &mut buf)
                 .map_err(|e| anyhow!("usearch get during move: {e}"))?;
             if n == 0 {
@@ -209,37 +232,57 @@ impl MemoryStore for RedbUsearchStore {
             buf
         };
 
-        // 3. Insert into destination, then delete from source. Best-effort
-        //    atomicity — if delete fails after insert, the record is briefly
-        //    duplicated rather than lost.
-        self.insert(to, id, &vector, payload).await?;
-        self.delete(from, id).await?;
+        let write_txn = self.db.begin_write()?;
+        let src_label = remove_rows(&write_txn, from, id)?
+            .ok_or_else(|| anyhow!("move_segment: missing label for id {id:?}"))?;
+        let dst_label = write_rows(&write_txn, to, id, &payload_json)?;
+
+        let (_, dst_path) = self.index_for(to);
+        ensure_capacity(dst_index)?;
+        let displaced = take_displaced(dst_index, dst_label)?;
+        let dst_stored = dst_index
+            .add(dst_label, &vector)
+            .map_err(|e| anyhow!("adding vector to usearch: {e}"))
+            .and_then(|_| save_index(dst_index, &dst_path));
+        if let Err(e) = dst_stored {
+            // `write_txn` drops uncommitted, so the record stays whole in the
+            // source segment and the destination never sees it.
+            restore_displaced(dst_index, dst_label, displaced);
+            return Err(e);
+        }
+
+        write_txn.commit()?;
+
+        // Past the commit the move has happened. Dropping the source vector is
+        // cleanup: a failure here leaves an orphan no read path can reach, so
+        // it is logged rather than reported as a failed move.
+        let (_, src_path) = self.index_for(from);
+        if src_index.contains(src_label)
+            && let Err(e) = src_index.remove(src_label)
+        {
+            tracing::warn!(
+                id, label = src_label, error = %e,
+                "move committed but the source vector could not be removed"
+            );
+        }
+        if let Err(e) = save_index(src_index, &src_path) {
+            tracing::warn!(
+                id, error = %e,
+                "move committed but the source index could not be flushed"
+            );
+        }
         Ok(())
     }
 
     async fn delete(&self, segment: Segment, id: &str) -> Result<()> {
-        let (label_to_id_def, id_to_label_def) = Self::label_tables(segment);
-        let key = format!("{}:{}", segment.prefix(), id);
-
-        // 1. Look up label and drop all redb rows in one transaction.
+        // 1. Look up label and drop all redb rows in one transaction. The
+        //    metadata goes first on purpose: a vector left behind by a failure
+        //    in step 2 has no `label_to_id` row, so `search` skips it. Removing
+        //    the vector first would instead strand a live row pointing at
+        //    nothing.
         let label_opt = {
             let write_txn = self.db.begin_write()?;
-            let label_opt = {
-                let mut id_to_label = write_txn.open_table(id_to_label_def)?;
-                let label = id_to_label.get(id)?.map(|v| v.value());
-                if label.is_some() {
-                    id_to_label.remove(id)?;
-                }
-                label
-            };
-            if let Some(label) = label_opt {
-                let mut label_to_id = write_txn.open_table(label_to_id_def)?;
-                label_to_id.remove(label)?;
-            }
-            {
-                let mut payloads = write_txn.open_table(PAYLOAD_TABLE)?;
-                payloads.remove(key.as_str())?;
-            }
+            let label_opt = remove_rows(&write_txn, segment, id)?;
             write_txn.commit()?;
             label_opt
         };
@@ -306,5 +349,153 @@ impl MemoryStore for RedbUsearchStore {
             Segment::History => &self.hist_index,
         };
         Ok(mutex_ref.lock().await.is_some())
+    }
+}
+
+// --- caller-owned-transaction helpers -----------------------------------
+//
+// audit 2026-08-19: `insert`, `delete` and `move_segment` all have to place
+// their redb rows in a transaction the CALLER commits, so the vector writes
+// can be sequenced around the commit. These helpers hold the row layout once
+// so the three paths cannot drift apart.
+
+/// Write the payload row and both label rows for `id`, returning the label the
+/// record now occupies.
+///
+/// Why: `insert` and the destination half of `move_segment` need the same
+/// three rows, and both must be able to abandon them by dropping the
+/// transaction unommitted.
+/// What: reuses the id's existing label when it has one, otherwise allocates
+/// the next label for `segment`, then writes `payloads`, `label_to_id` and
+/// `id_to_label`.
+/// Test: `roundtrip_insert_and_search`, `move_segment_transfers_and_deletes`.
+fn write_rows(
+    write_txn: &redb::WriteTransaction,
+    segment: Segment,
+    id: &str,
+    payload_json: &str,
+) -> Result<u64> {
+    let (label_to_id_def, id_to_label_def) = RedbUsearchStore::label_tables(segment);
+
+    // Reuse the existing label if this id has been written before, otherwise
+    // allocate a new one.
+    let existing = {
+        let id_to_label = write_txn.open_table(id_to_label_def)?;
+        id_to_label.get(id)?.map(|v| v.value())
+    };
+    let label = match existing {
+        Some(l) => l,
+        None => next_label(write_txn, segment)?,
+    };
+
+    {
+        let key = format!("{}:{}", segment.prefix(), id);
+        let mut payloads = write_txn.open_table(PAYLOAD_TABLE)?;
+        payloads.insert(key.as_str(), payload_json)?;
+    }
+    {
+        let mut label_to_id = write_txn.open_table(label_to_id_def)?;
+        label_to_id.insert(label, id)?;
+    }
+    {
+        let mut id_to_label = write_txn.open_table(id_to_label_def)?;
+        id_to_label.insert(id, label)?;
+    }
+    Ok(label)
+}
+
+/// Drop the payload row and both label rows for `id`, returning the label the
+/// record occupied, or `None` when the id was not present.
+///
+/// Why: `delete` and the source half of `move_segment` need the same removal,
+/// and `move_segment` needs it in the same transaction as the destination
+/// write.
+/// What: removes `id_to_label`, `label_to_id` and the `payloads` row.
+/// Test: `delete_removes_from_both_stores`, `move_segment_transfers_and_deletes`.
+fn remove_rows(
+    write_txn: &redb::WriteTransaction,
+    segment: Segment,
+    id: &str,
+) -> Result<Option<u64>> {
+    let (label_to_id_def, id_to_label_def) = RedbUsearchStore::label_tables(segment);
+
+    let label_opt = {
+        let mut id_to_label = write_txn.open_table(id_to_label_def)?;
+        let label = id_to_label.get(id)?.map(|v| v.value());
+        if label.is_some() {
+            id_to_label.remove(id)?;
+        }
+        label
+    };
+    if let Some(label) = label_opt {
+        let mut label_to_id = write_txn.open_table(label_to_id_def)?;
+        label_to_id.remove(label)?;
+    }
+    {
+        let key = format!("{}:{}", segment.prefix(), id);
+        let mut payloads = write_txn.open_table(PAYLOAD_TABLE)?;
+        payloads.remove(key.as_str())?;
+    }
+    Ok(label_opt)
+}
+
+/// Clear whatever vector sits under `label`, handing it back to the caller.
+///
+/// Why: usearch `add` appends rather than replaces, so re-inserting an id has
+/// to remove the old entry first. If the write that follows fails, the redb
+/// transaction aborts and the old row survives — it must keep pointing at a
+/// real vector, so the caller needs the removed one back.
+/// What: reads the current vector for `label`, removes it, and returns the
+/// snapshot. `Ok(None)` means there was nothing stored under `label`.
+/// Test: `insert_index_write_failure_leaves_no_phantom_redb_row`.
+fn take_displaced(index: &Index, label: u64) -> Result<Option<Vec<f32>>> {
+    if !index.contains(label) {
+        return Ok(None);
+    }
+    let mut buf = vec![0.0f32; index.dimensions()];
+    let snapshot = match index.get(label, &mut buf) {
+        Ok(n) if n > 0 => Some(buf),
+        _ => None,
+    };
+    index
+        .remove(label)
+        .map_err(|e| anyhow!("removing stale usearch entry: {e}"))?;
+    Ok(snapshot)
+}
+
+/// Put a displaced vector back after the write that replaced it failed.
+///
+/// Why: restores the pre-write state so an aborted transaction leaves both
+/// stores exactly as they were.
+/// What: re-adds `displaced` under `label`. A failure here cannot be
+/// propagated — the caller is already returning the original error — so it is
+/// logged at `error` level instead of being swallowed.
+/// Test: `insert_index_write_failure_leaves_no_phantom_redb_row`.
+fn restore_displaced(index: &Index, label: u64, displaced: Option<Vec<f32>>) {
+    if let Some(old) = displaced
+        && let Err(e) = index.add(label, &old)
+    {
+        tracing::error!(
+            label, error = %e,
+            "could not restore the usearch vector displaced by a failed write"
+        );
+    }
+}
+
+/// Stable total order over segments, used when one operation holds two
+/// segment mutexes.
+///
+/// Why: `move_segment` locks both the source and the destination index. Two
+/// concurrent moves in opposite directions would deadlock if each locked its
+/// own source first; locking in rank order makes a cycle impossible.
+/// What: assigns each variant a fixed rank.
+/// Test: `move_segment_transfers_and_deletes` exercises the locking path.
+fn lock_rank(segment: Segment) -> u8 {
+    match segment {
+        Segment::AgentMemory => 0,
+        Segment::CodeIndex => 1,
+        Segment::Context => 2,
+        Segment::Brief => 3,
+        Segment::History => 4,
     }
 }

--- a/crates/trusty-agents/src/memory/redb_usearch/tests.rs
+++ b/crates/trusty-agents/src/memory/redb_usearch/tests.rs
@@ -16,6 +16,24 @@ fn vec4(a: f32, b: f32, c: f32, d: f32) -> Vec<f32> {
     vec![a, b, c, d]
 }
 
+/// Replace a segment's `.usearch` file with a directory so every subsequent
+/// `Index::save` to that path fails.
+///
+/// Why: the store exposes no injection seam for a vector-side write failure,
+/// and that failure is exactly what the crash-consistency fixes guard. A
+/// directory at the file's path makes `save` fail deterministically on every
+/// platform, without depending on permission semantics.
+/// What: removes the file if present, then creates a directory in its place.
+/// The in-memory index is untouched, so only the flush-to-disk step breaks.
+/// Test: used by `insert_index_write_failure_leaves_no_phantom_redb_row` and
+/// `move_segment_destination_write_failure_keeps_record_in_source`.
+fn wedge_index_file(path: &std::path::Path) {
+    if path.exists() {
+        std::fs::remove_file(path).unwrap();
+    }
+    std::fs::create_dir(path).unwrap();
+}
+
 #[tokio::test]
 async fn roundtrip_insert_and_search() {
     let dir = tempdir().unwrap();
@@ -266,4 +284,155 @@ async fn move_segment_transfers_and_deletes() {
         .unwrap();
     assert_eq!(hits.len(), 1);
     assert_eq!(hits[0].id, "rec-1");
+}
+
+/// A failed vector flush must not leave a payload row behind.
+///
+/// Why: `insert` used to commit the redb transaction before touching usearch,
+/// so a failure in the vector half produced a record that `get` returns and
+/// `search` can never find. Audit 2026-08-19 flagged that split.
+/// What: wedges the segment's index file, drives one failing insert, and
+/// asserts redb carries nothing for the failed id.
+/// Test: this function.
+#[tokio::test]
+async fn insert_index_write_failure_leaves_no_phantom_redb_row() {
+    let dir = tempdir().unwrap();
+    let store = RedbUsearchStore::open(dir.path(), 4).unwrap();
+
+    store
+        .insert(
+            Segment::AgentMemory,
+            "kept",
+            &vec4(1.0, 0.0, 0.0, 0.0),
+            json!({"n": 1}),
+        )
+        .await
+        .unwrap();
+
+    wedge_index_file(&dir.path().join("mem.usearch"));
+
+    let result = store
+        .insert(
+            Segment::AgentMemory,
+            "phantom",
+            &vec4(0.0, 1.0, 0.0, 0.0),
+            json!({"n": 2}),
+        )
+        .await;
+    assert!(
+        result.is_err(),
+        "insert must fail when the index cannot be persisted"
+    );
+
+    assert!(
+        store
+            .get(Segment::AgentMemory, "phantom")
+            .await
+            .unwrap()
+            .is_none(),
+        "failed insert left a payload row that search can never resolve"
+    );
+
+    // The vector that did reach the in-memory index has no redb row, so it is
+    // invisible to every read path rather than a half-visible record.
+    let hits = store
+        .search(Segment::AgentMemory, &vec4(0.0, 1.0, 0.0, 0.0), 5)
+        .await
+        .unwrap();
+    assert!(
+        hits.iter().all(|h| h.id != "phantom"),
+        "orphaned vector surfaced as a search hit"
+    );
+
+    // The record written before the wedge is untouched.
+    assert_eq!(
+        store.get(Segment::AgentMemory, "kept").await.unwrap(),
+        Some(json!({"n": 1}))
+    );
+}
+
+/// A failed destination write must leave the record in the source segment only.
+///
+/// Why: `move_segment` used to insert into the destination and delete from the
+/// source in two independent transactions, so a destination failure left the
+/// record in both places. Audit 2026-08-19 flagged the duplicate window.
+/// What: wedges the destination index file and asserts exactly one surviving
+/// copy, in the source.
+/// Test: this function.
+#[tokio::test]
+async fn move_segment_destination_write_failure_keeps_record_in_source() {
+    let dir = tempdir().unwrap();
+    let store = RedbUsearchStore::open(dir.path(), 4).unwrap();
+
+    store
+        .insert(
+            Segment::AgentMemory,
+            "rec",
+            &vec4(0.25, 0.5, 0.75, 1.0),
+            json!({"note": "stay"}),
+        )
+        .await
+        .unwrap();
+
+    wedge_index_file(&dir.path().join("hist.usearch"));
+
+    let result = store
+        .move_segment("rec", Segment::AgentMemory, Segment::History)
+        .await;
+    assert!(
+        result.is_err(),
+        "move must fail when the destination index cannot be persisted"
+    );
+
+    assert_eq!(
+        store.get(Segment::AgentMemory, "rec").await.unwrap(),
+        Some(json!({"note": "stay"})),
+        "source copy must survive a failed move"
+    );
+    assert!(
+        store.get(Segment::History, "rec").await.unwrap().is_none(),
+        "failed move left a duplicate in the destination segment"
+    );
+
+    // The source vector is collateral-damage free: still searchable.
+    let hits = store
+        .search(Segment::AgentMemory, &vec4(0.25, 0.5, 0.75, 1.0), 1)
+        .await
+        .unwrap();
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].id, "rec");
+}
+
+/// Similarity scores stay inside `[0.0, 1.0]`.
+///
+/// Why: the score was computed as `1.0 - distance` with no clamp, and cosine
+/// distance reaches 2.0 for an antipodal vector, so callers could receive
+/// `-1.0`. Audit 2026-08-19 flagged the unclamped arithmetic.
+/// What: stores one vector and queries with its exact antipode.
+/// Test: this function.
+#[tokio::test]
+async fn search_score_is_clamped_for_antipodal_vectors() {
+    let dir = tempdir().unwrap();
+    let store = RedbUsearchStore::open(dir.path(), 4).unwrap();
+
+    store
+        .insert(
+            Segment::AgentMemory,
+            "north",
+            &vec4(1.0, 0.0, 0.0, 0.0),
+            json!({"pole": "n"}),
+        )
+        .await
+        .unwrap();
+
+    let hits = store
+        .search(Segment::AgentMemory, &vec4(-1.0, 0.0, 0.0, 0.0), 1)
+        .await
+        .unwrap();
+    assert_eq!(hits.len(), 1);
+    assert!(
+        (0.0..=1.0).contains(&hits[0].score),
+        "score {} escaped [0.0, 1.0]",
+        hits[0].score
+    );
 }


### PR DESCRIPTION
Three crash-consistency defects in the redb+usearch semantic-memory store
(`crates/trusty-agents/src/memory/redb_usearch/store_impl.rs`), from the
2026-08-19 trusty-tools self-audit — its executive summary names
"crash-consistency weaknesses in the semantic-memory store" as a top concern.
No issues exist for these; the audit report is the citation.

## What changed

**1. `insert` — lock ordering.** The redb transaction committed before the
usearch mutation ran under a separate lock. A failure or crash between the two
recorded a payload and label with no vector behind them: a memory `get` returns
and `search` can never find. The segment mutex is now taken before
`begin_write` and redb commits LAST, so any vector-write failure drops the
transaction uncommitted and leaves redb exactly as it was.

The ordering is chosen because the two divergence directions are not equally
bad. redb-knows-but-usearch-doesn't is half-visible to readers. A vector whose
label has no redb row is inert — `search` already skips labels `label_to_id`
cannot resolve, and the next write to that label overwrites it. Commit-last
makes the first direction unreachable and leaves only the second. A re-insert
additionally snapshots the vector it displaces and restores it if the write
fails, so an abort cannot strand the surviving row.

**2. `move_segment` — atomicity.** Insert-then-delete ran two independent
transactions with a documented duplicate-over-loss bias. Both halves now share
ONE redb transaction, so no failure leaves the record in both segments or in
neither. The vector indexes cannot join that transaction, so they bracket it on
the side that keeps the residue inert: the destination vector is flushed BEFORE
the commit (an addition must be durable before metadata points at it), the
source vector dropped AFTER (a removal must not outrun its metadata). Both
index mutexes are taken in a fixed rank order so two opposite-direction moves
cannot deadlock.

*Achieved:* atomic metadata move — no duplicate, no loss.
*Not achieved:* full cross-store atomicity. A crash between the commit and the
source flush strands a vector in the source index that no read path can reach;
the next write to that label reclaims it.

**3. `search` — score clamp.** `1.0 - distance` was unclamped, and cosine
distance reaches 2.0 for an antipodal vector, so callers could receive `-1.0`.
Now `.clamp(0.0, 1.0)`.

`insert`, `delete` and `move_segment` now share `write_rows` / `remove_rows`
helpers that place their redb rows in a caller-owned transaction, so the three
paths cannot drift.

## Test ladder — rung 3

Each of the two transactional fixes carries an error-arm regression test. There
is no injection seam for a vector-write failure, so the tests replace a
segment's `.usearch` file with a directory, which makes `Index::save` fail
deterministically without depending on permission semantics.

**Against `origin/main` (bbc039b46), all three fail on the defect:**

```
running 10 tests
thread '...::search_score_is_clamped_for_antipodal_vectors' panicked at tests.rs:433:5:
score -1 escaped [0.0, 1.0]
thread '...::move_segment_destination_write_failure_keeps_record_in_source' panicked at tests.rs:392:5:
failed move left a duplicate in the destination segment
thread '...::insert_index_write_failure_leaves_no_phantom_redb_row' panicked at tests.rs:327:5:
failed insert left a payload row that search can never resolve

test result: FAILED. 7 passed; 3 failed; 0 ignored; 0 measured; 3522 filtered out
```

**On this branch:**

```
test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 3522 filtered out
```

## Gates

| Gate | Result |
|---|---|
| `cargo fmt --check` | exit 0 |
| `cargo check -p trusty-agents --all-targets` | exit 0 |
| `cargo clippy -p trusty-agents --all-targets -- -D warnings` | exit 0 |
| `cargo test -p trusty-agents` | 3519 passed / 0 failed / 13 ignored (lib); all 12 targets ok |
| `scripts/check_line_cap.sh` | 4114 files, 0 violations |
| `scripts/check_changelog_fragment.sh` | fragment present and valid |
| `scripts/check_test_pointers.sh` | 26183 citations, 0 dangling |
| `scripts/check_sld.sh` | 0 errors, 0 warnings |

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
