### PR TITLE
fix(trusty-agents): audit findings — recall error visibility, credential variants, blocking lock, allowlist validation

### DIFF
--- a/crates/trusty-agents/changelog.d/audit-failopen-access.md
+++ b/crates/trusty-agents/changelog.d/audit-failopen-access.md
@@ -1,0 +1,17 @@
+Fixed
+
+- Memory recall no longer hides a broken store: store-open and embedder-init
+  failures log at `warn!` with the error chain instead of `debug!`. Recall stays
+  best-effort and still returns an empty result (audit 2026-08-19, finding 19).
+- `/provider bedrock` and `/provider local` get their own `LlmCredentials`
+  variants instead of reusing `OpenRouter` as a placeholder, so the deployment
+  footer and startup banner name the transport actually in use. Routing is
+  unchanged — the adapter dispatches on the model prefix (audit 2026-08-19,
+  finding 18).
+- The code-index advisory file lock is acquired on `spawn_blocking`. The
+  blocking `flock` call no longer parks a Tokio worker thread while another
+  process holds the lock (audit 2026-08-19, finding 21).
+- `GET /api/agents/:name/stores` validates the agent name against an allowlist
+  (ASCII alphanumeric, `_`, `-`, bounded length) rather than a four-item
+  denylist that admitted NUL bytes, control characters, and Unicode separator
+  look-alikes into a filesystem path join (audit 2026-08-19, finding 12).

--- a/crates/trusty-agents/src/api/server/agent_stores.rs
+++ b/crates/trusty-agents/src/api/server/agent_stores.rs
@@ -61,6 +61,35 @@ pub(super) async fn agent_stores_route(
     .await
 }
 
+/// Maximum accepted agent-name length. Matches `agent_create::is_valid_slug`'s
+/// cap, so a name this route accepts is one the create path could have written.
+const MAX_AGENT_NAME_LEN: usize = 64;
+
+/// Is `name` a safe single path segment to join onto an agents directory?
+///
+/// Why: this used to be a DENYLIST — `/`, `\`, `.`, `..` (audit 2026-08-19,
+/// finding 12). A denylist has to anticipate every hostile spelling, and the
+/// name is joined straight onto a filesystem path by `resolve_agent_paths`.
+/// It admitted NUL bytes, control characters, whitespace-only names,
+/// unbounded lengths, and Unicode look-alikes for the separators it did
+/// reject (`＼` U+FF3C, `∕` U+2215, `․` U+2024) — every one of which reaches
+/// the join. An allowlist inverts the burden: only characters that can never
+/// change a path's meaning get through, so an unanticipated spelling fails
+/// closed.
+/// What: non-empty, at most [`MAX_AGENT_NAME_LEN`] bytes, and every character
+/// is ASCII alphanumeric, `_`, or `-`. That admits every bundled agent name
+/// (see `agent_name_allowlist_accepts_every_bundled_agent`) and every name
+/// `POST /api/agents` can create.
+/// Test: `agent_name_allowlist_rejects_traversal_and_unicode_tricks`,
+/// `agent_name_allowlist_accepts_every_bundled_agent`.
+pub(super) fn is_valid_agent_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= MAX_AGENT_NAME_LEN
+        && name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+}
+
 /// Core store-resolution logic against explicit agents dirs + daemon URLs.
 ///
 /// Why: Same testability rationale as `agent_patch::patch_agent_at`.
@@ -79,7 +108,7 @@ pub(super) async fn stores_at(
     search_base: Option<&str>,
     memory_base: Option<&str>,
 ) -> Response {
-    if name.is_empty() || name.contains(['/', '\\']) || name == "." || name == ".." {
+    if !is_valid_agent_name(name) {
         return (
             StatusCode::BAD_REQUEST,
             Json(serde_json::json!({ "error": "invalid agent name" })),
@@ -315,6 +344,102 @@ search_indexes = ["real-index", "store-label"]
             attached_indexes_deduped(&stores, &tools),
             vec!["store-label".to_string()],
             "dedupe keys on resolved_index, not the store's display name"
+        );
+    }
+
+    /// audit 2026-08-19 (finding 12): the name reaches `dir.join(name)`, so
+    /// anything that can alter a path's meaning must fail closed.
+    ///
+    /// Why: the previous denylist named four spellings and let everything else
+    /// through. These cases are the ones it missed — Unicode separator
+    /// look-alikes, percent-encoded traversal, NUL and control bytes,
+    /// whitespace-only names, and an unbounded length — alongside the four it
+    /// did catch, so neither class can regress.
+    /// Test: itself.
+    #[test]
+    fn agent_name_allowlist_rejects_traversal_and_unicode_tricks() {
+        let rejected = [
+            // What the old denylist already caught.
+            "",
+            ".",
+            "..",
+            "../etc/passwd",
+            "a/b",
+            "a\\b",
+            // What it did not.
+            "\u{FF3C}etc",      // fullwidth reverse solidus
+            "a\u{2215}b",       // division slash
+            "a\u{2044}b",       // fraction slash
+            "a\u{2024}b",       // one-dot leader
+            "..%2fetc",         // percent-encoded traversal
+            "%2e%2e%2fetc",     // fully encoded `../`
+            "izzie\0",          // NUL byte
+            "izzie\n",          // control character
+            "izzie ",           // trailing space
+            "   ",              // whitespace only
+            "izzie.toml",       // extension smuggling
+            "cto\u{2011}agent", // non-breaking hyphen
+            "\u{0430}ssistant", // Cyrillic а homoglyph
+        ];
+        for name in rejected {
+            assert!(
+                !is_valid_agent_name(name),
+                "must reject {name:?} — it is joined onto a filesystem path"
+            );
+        }
+        assert!(
+            !is_valid_agent_name(&"a".repeat(MAX_AGENT_NAME_LEN + 1)),
+            "length must be bounded"
+        );
+        assert!(is_valid_agent_name(&"a".repeat(MAX_AGENT_NAME_LEN)));
+    }
+
+    /// audit 2026-08-19 (finding 12): tightening to an allowlist must not lock
+    /// any shipped agent out of its own stores panel.
+    ///
+    /// Why: a validator that rejects real names is a worse outage than the
+    /// traversal it prevents. Reading the roster off disk (rather than pasting
+    /// a list here) means a newly bundled agent whose name the allowlist would
+    /// reject fails this test the day it is added.
+    /// What: walks the bundled `.trusty-agents/agents/` directory, deriving the
+    /// name the router sees for both layouts `resolve_agent_paths` supports —
+    /// a directory package (`<name>/agent.toml`) and a flat `<name>.toml`.
+    /// Test: itself.
+    #[test]
+    fn agent_name_allowlist_accepts_every_bundled_agent() {
+        let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join(".trusty-agents")
+            .join("agents");
+        let mut checked = 0usize;
+        for entry in std::fs::read_dir(&dir).expect("bundled agents dir") {
+            let entry = entry.expect("dir entry");
+            let path = entry.path();
+            let name = if path.is_dir() {
+                if !path.join("agent.toml").is_file() {
+                    continue;
+                }
+                path.file_name()
+                    .expect("dir name")
+                    .to_string_lossy()
+                    .into_owned()
+            } else if path.extension().is_some_and(|e| e == "toml") {
+                path.file_stem()
+                    .expect("file stem")
+                    .to_string_lossy()
+                    .into_owned()
+            } else {
+                continue;
+            };
+            assert!(
+                is_valid_agent_name(&name),
+                "bundled agent {name:?} must remain reachable"
+            );
+            checked += 1;
+        }
+        assert!(
+            checked >= 20,
+            "expected the full bundled roster, only saw {checked} names in {}",
+            dir.display()
         );
     }
 

--- a/crates/trusty-agents/src/ctrl/config.rs
+++ b/crates/trusty-agents/src/ctrl/config.rs
@@ -74,19 +74,23 @@ pub struct SessionOverrides {
 /// path instead. Centralising the override-vs-env decision here keeps both
 /// dispatch entrypoints (`run_pm_task_with_history`, `run_pm_task_with_persona`)
 /// in lock-step.
-/// What: Three valid override values:
+/// What: Four valid override values:
 ///   - `"claude-code"` → `LlmCredentials::ClaudeCode` (claude CLI subprocess)
 ///   - `"openrouter"` → `LlmCredentials::OpenRouter` (REST client)
 ///   - `"bedrock"`    → ensures the model id carries the `bedrock/` prefix
-///     (auto-prepending when absent) and returns `LlmCredentials::OpenRouter`
-///     as a placeholder. Bedrock dispatch is driven by the `bedrock/` model
-///     prefix in `chat_with_tools_gated`, not by a credential variant — see
-///     `src/llm/mod.rs` Bedrock branch.
+///     (auto-prepending when absent) and returns `LlmCredentials::Bedrock`.
+///   - `"local"`      → ensures the `ollama/` prefix and returns
+///     `LlmCredentials::Ollama`.
+/// Dispatch for the last two is driven by the MODEL PREFIX in
+/// `chat_with_tools_gated` (see `src/llm/mod.rs`), not by the credential
+/// variant; the variant exists so the type names the real transport (audit
+/// 2026-08-19, finding 18).
 /// Any other override value returns an error so the user's typo doesn't
 /// silently fall through to env defaults. When `provider_override` is `None`
 /// we delegate to `pick_credentials()` exactly as before.
-/// Test: `cargo check`; `apply_credential_routing` tests still pass since
-/// this helper is composed before that point.
+/// Test: `provider_override_bedrock_and_local_get_their_own_variants`;
+/// `apply_credential_routing` tests still pass since this helper is composed
+/// before that point.
 pub(crate) fn resolve_overridden_credentials(
     cfg: &mut AgentConfig,
     provider_override: Option<&str>,
@@ -120,25 +124,24 @@ pub(crate) fn resolve_overridden_credentials(
             if !cfg.agent.model.starts_with("bedrock/") {
                 cfg.agent.model = format!("bedrock/{}", cfg.agent.model);
             }
-            // Placeholder credential — adapter inspects the model prefix and
-            // routes to AWS Bedrock; the OpenRouter variant just lets
-            // `apply_credential_routing` skip the use_anthropic_direct flag
-            // and the claude-cli short-circuit. The OpenRouter path's bare-
-            // model qualification is a no-op since the model already starts
-            // with `bedrock/` (see `qualify_openrouter_model`).
-            Ok(LlmCredentials::OpenRouter)
+            // audit 2026-08-19: was `OpenRouter` as a placeholder. The adapter
+            // still routes on the `bedrock/` model prefix; only the credential
+            // type changed, and `qualify_openrouter_model` was already a no-op
+            // for a `bedrock/`-prefixed id, so routing is byte-identical.
+            Ok(LlmCredentials::Bedrock)
         }
         Some("local") => {
             // Ollama dispatch is also model-prefix driven (`ollama/<name>`).
             // The adapter detects the prefix and overrides the OpenAI-compatible
-            // base URL to point at the local ollama server. We piggyback on the
-            // OpenRouter credential variant since ollama needs no auth header;
-            // the LLM HTTP layer will skip auth when the endpoint's
-            // `auth_header_value` is empty (see `OllamaAdapter::api_endpoint`).
+            // base URL to point at the local ollama server. Ollama needs no auth
+            // header; the LLM HTTP layer skips auth when the endpoint's
+            // `auth_header_value` is empty (see `OllamaAdapter::api_endpoint`),
+            // which is keyed on the endpoint, not on this variant.
             if !cfg.agent.model.starts_with("ollama/") {
                 cfg.agent.model = format!("ollama/{}", cfg.agent.model);
             }
-            Ok(LlmCredentials::OpenRouter)
+            // audit 2026-08-19: was `OpenRouter` as a placeholder.
+            Ok(LlmCredentials::Ollama)
         }
         // Bookmarked for future wiring: "anthropic-api", "openai-api".
         Some(other) => anyhow::bail!(
@@ -318,9 +321,18 @@ pub(crate) fn build_user_context_prefix(
 /// JSON payload when no `content` field is present). Any error — store
 /// missing, embedder init failure, search error — collapses to an empty Vec
 /// so prompt building never blocks on memory recall.
-/// Test: Both call sites (PM `run_pm_task_with_history` and ctrl
-/// `run_ctrl`) exercise the empty-Vec path on any cold project; populated
-/// recall is covered by `memory_recall` integration tests in `tools/memory.rs`.
+///
+/// Log level is NOT uniform across those error arms (audit 2026-08-19,
+/// finding 19). A broken store and a cold project both return an empty Vec,
+/// so the log record is the only thing that tells them apart: store-open and
+/// embedder-init failures — the two an operator can actually fix — emit
+/// `warn!` carrying the anyhow error chain. Embed and search failures stay at
+/// `debug!`; they are per-query and do not indicate misconfiguration.
+/// Test: `recall_project_memories_warns_when_store_open_fails` asserts the
+/// WARN event fires AND that the empty-Vec fallback is unchanged. Both call
+/// sites (PM `run_pm_task_with_history` and ctrl `run_ctrl`) exercise the
+/// empty-Vec path on any cold project; populated recall is covered by
+/// `memory_recall` integration tests in `tools/memory.rs`.
 pub(crate) async fn recall_project_memories(
     project_dir: &Path,
     query: &str,
@@ -336,14 +348,24 @@ pub(crate) async fn recall_project_memories(
     let store = match crate::memory::open_memory_store(&session_dir) {
         Ok(s) => s,
         Err(e) => {
-            tracing::debug!(error = %e, "recall_project_memories: store open failed");
+            // audit 2026-08-19: `debug!` hid a broken store behind the same
+            // empty Vec a cold project returns. `?e` prints anyhow's cause chain.
+            tracing::warn!(
+                error = ?e,
+                session_dir = %session_dir.display(),
+                "recall_project_memories: store open failed; continuing without project memory"
+            );
             return Vec::new();
         }
     };
     let embedder = match crate::memory::FastEmbedder::new() {
         Ok(e) => e,
         Err(e) => {
-            tracing::debug!(error = %e, "recall_project_memories: embedder unavailable");
+            // audit 2026-08-19: same reasoning as the store-open arm above.
+            tracing::warn!(
+                error = ?e,
+                "recall_project_memories: embedder unavailable; continuing without project memory"
+            );
             return Vec::new();
         }
     };
@@ -528,6 +550,11 @@ pub(crate) fn apply_credential_routing(
             }
             false
         }
+        // audit 2026-08-19: both arms are deliberately no-ops. Each model id
+        // already carries its routing prefix (`bedrock/`, `ollama/`), which is
+        // what the adapter dispatches on; model qualification was already a
+        // no-op for both when they rode the `OpenRouter` variant.
+        LlmCredentials::Bedrock | LlmCredentials::Ollama => false,
     }
 }
 

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/history.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/history.rs
@@ -107,6 +107,11 @@ pub async fn run_pm_task_with_history(
             llm::credentials::LlmCredentials::ClaudeCode => "claude-code (ClaudeCodeAgentRunner)",
             llm::credentials::LlmCredentials::AnthropicDirect => "anthropic-direct",
             llm::credentials::LlmCredentials::OpenRouter => "openrouter",
+            // audit 2026-08-19: these two used to report "openrouter" because
+            // they shared its variant, so the deployment footer named the wrong
+            // transport back to the user.
+            llm::credentials::LlmCredentials::Bedrock => "bedrock",
+            llm::credentials::LlmCredentials::Ollama => "ollama",
         };
         let skills_count = pm_cfg
             .system_prompt

--- a/crates/trusty-agents/src/ctrl/tests/config_tests.rs
+++ b/crates/trusty-agents/src/ctrl/tests/config_tests.rs
@@ -6,7 +6,7 @@ use crate::llm;
 use super::super::claude_cli::{filter_project_index_in_prompt, strip_cli_artifacts};
 use super::super::config::{
     AgentIdentity, apply_credential_routing, build_deployment_footer, build_user_context_prefix,
-    render_user_context_block, render_user_datetime, resolve_agent_config,
+    recall_project_memories, render_user_context_block, render_user_datetime, resolve_agent_config,
 };
 
 /// Fixed identity used by tests that don't care about its specific values —
@@ -496,5 +496,138 @@ fn provider_override_still_works_on_an_unpinned_agent() {
         cfg.agent.model.starts_with("bedrock/"),
         "{}",
         cfg.agent.model
+    );
+}
+
+/// audit 2026-08-19 (finding 18): `/provider bedrock` and `/provider local`
+/// get credential variants that name their real transport.
+///
+/// Why: both used to return `LlmCredentials::OpenRouter` as a placeholder, so
+/// the credential type disagreed with the transport the adapter actually used.
+/// What: asserts the variant, the model prefix that drives dispatch, and — the
+/// part that matters — that `apply_credential_routing` still does nothing for
+/// either: no `use_anthropic_direct`, no claude-CLI short-circuit, no model
+/// rewrite. That triple is the routing behavior the placeholder produced.
+/// Test: itself.
+#[test]
+fn provider_override_bedrock_and_local_get_their_own_variants() {
+    use llm::credentials::LlmCredentials;
+
+    for (override_name, expected, prefix, label) in [
+        ("bedrock", LlmCredentials::Bedrock, "bedrock/", "bedrock"),
+        ("local", LlmCredentials::Ollama, "ollama/", "ollama"),
+    ] {
+        let mut cfg = AgentConfig::ctrl_default();
+        cfg.agent.provider_id = None;
+        cfg.llm.use_anthropic_direct = false;
+
+        let creds =
+            super::super::config::resolve_overridden_credentials(&mut cfg, Some(override_name))
+                .expect("override resolves");
+        assert_eq!(creds, expected, "/provider {override_name}");
+        assert_eq!(creds.label(), label);
+        assert!(
+            cfg.agent.model.starts_with(prefix),
+            "dispatch is prefix-driven: {}",
+            cfg.agent.model
+        );
+
+        let model_before = cfg.agent.model.clone();
+        let short_circuit = apply_credential_routing(&mut cfg, &creds);
+        assert!(!short_circuit, "{override_name} never uses the claude CLI");
+        assert!(
+            !cfg.llm.use_anthropic_direct,
+            "{override_name} must not flip use_anthropic_direct"
+        );
+        assert_eq!(
+            cfg.agent.model, model_before,
+            "{override_name} model id must survive routing untouched"
+        );
+    }
+}
+
+/// Collects every WARN-level event emitted while it is the default
+/// subscriber, flattening each event's fields into one string.
+///
+/// Why: `recall_project_memories` is fail-open by design — it returns an empty
+/// `Vec` on every error path — so the ONLY observable difference between "the
+/// store is broken" and "this project has no memories yet" is the log record.
+/// Asserting on the returned value can therefore never catch the regression;
+/// the test has to read the tracing event itself.
+/// What: a `tracing_subscriber::Layer` that pushes the field set of each WARN
+/// event into a shared `Vec<String>`.
+#[derive(Default, Clone)]
+struct WarnCollector(std::sync::Arc<std::sync::Mutex<Vec<String>>>);
+
+impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for WarnCollector {
+    fn on_event(
+        &self,
+        event: &tracing::Event<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        if *event.metadata().level() != tracing::Level::WARN {
+            return;
+        }
+        struct Flatten(String);
+        impl tracing::field::Visit for Flatten {
+            fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+                self.0.push_str(&format!("{}={:?} ", field.name(), value));
+            }
+        }
+        let mut flat = Flatten(String::new());
+        event.record(&mut flat);
+        self.0
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .push(flat.0);
+    }
+}
+
+/// audit 2026-08-19 (finding 19): a store-open failure must reach operator
+/// logs at WARN, not vanish at `debug!`.
+///
+/// Why: before the fix every error arm logged at `debug!`, so a corrupted or
+/// misconfigured store produced an agent with no memory context and no signal
+/// anywhere at the default log level — indistinguishable from a cold project.
+/// What: injects a store-open failure by making `sessions/default` a regular
+/// FILE, so the `exists()` guard passes and `RedbUsearchStore::open`'s
+/// `create_dir_all` fails. Asserts the empty-Vec fallback is UNCHANGED (recall
+/// stays best-effort) and that a WARN event naming the failure was emitted.
+/// Test: itself.
+#[test]
+fn recall_project_memories_warns_when_store_open_fails() {
+    use tracing_subscriber::layer::SubscriberExt;
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let sessions = tmp.path().join(".trusty-agents").join("sessions");
+    std::fs::create_dir_all(&sessions).expect("create sessions dir");
+    // A FILE where the store expects a directory: `session_dir.exists()` is
+    // true, so recall proceeds, and the store open then fails.
+    std::fs::write(sessions.join("default"), b"not a directory").expect("write blocker file");
+
+    let collector = WarnCollector::default();
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .expect("current-thread runtime");
+    let out = {
+        let _guard = tracing::subscriber::set_default(
+            tracing_subscriber::registry().with(collector.clone()),
+        );
+        rt.block_on(recall_project_memories(tmp.path(), "anything", 3))
+    };
+
+    assert!(
+        out.is_empty(),
+        "recall stays fail-open: the empty-Vec fallback must not change"
+    );
+    let warnings = collector
+        .0
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .clone();
+    assert!(
+        warnings.iter().any(|w| w.contains("store open failed")),
+        "a store-open failure must be visible at WARN with its error chain; \
+         captured WARN events: {warnings:?}"
     );
 }

--- a/crates/trusty-agents/src/llm/credentials.rs
+++ b/crates/trusty-agents/src/llm/credentials.rs
@@ -33,12 +33,13 @@
 
 /// Resolved LLM backend for the ctrl/PM in-process LLM calls.
 ///
-/// Why: Three discrete routing paths require three different downstream
-/// behaviors: the OpenRouter HTTP client, the direct Anthropic API, or the
-/// `claude` CLI subprocess. Encoding the choice as an enum keeps the wiring
-/// honest across `ctrl::run_pm_task_with_history`.
+/// Why: Each routing path requires a different downstream behavior: the
+/// OpenRouter HTTP client, the direct Anthropic API, the `claude` CLI
+/// subprocess, AWS Bedrock, or a local Ollama server. Encoding the choice as
+/// an enum keeps the wiring honest across `ctrl::run_pm_task_with_history`.
 /// What: One variant per supported credential source.
-/// Test: See module-level tests.
+/// Test: See module-level tests, notably
+/// `every_variant_has_a_distinct_label`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LlmCredentials {
     /// `CLAUDE_CODE_OAUTH_TOKEN` is set — route via the local `claude` CLI
@@ -49,6 +50,22 @@ pub enum LlmCredentials {
     AnthropicDirect,
     /// `OPENROUTER_API_KEY` is set — the original OpenRouter routing path.
     OpenRouter,
+    /// `/provider bedrock` — dispatch to AWS Bedrock, driven by the
+    /// `bedrock/` model prefix `resolve_overridden_credentials` guarantees.
+    ///
+    /// audit 2026-08-19 (finding 18): this path used to reuse
+    /// [`LlmCredentials::OpenRouter`] as a placeholder, so the credential type
+    /// named a transport the call was not using. No auth header or signing
+    /// decision reads this enum — the model prefix does — so the variant is
+    /// about the type telling the truth, not about changing routing.
+    Bedrock,
+    /// `/provider local` — dispatch to a local Ollama server, driven by the
+    /// `ollama/` model prefix. Needs no auth header: `OllamaAdapter::api_endpoint`
+    /// leaves `auth_header_value` empty and the HTTP layer skips it.
+    ///
+    /// audit 2026-08-19 (finding 18): same placeholder history as
+    /// [`LlmCredentials::Bedrock`].
+    Ollama,
 }
 
 impl LlmCredentials {
@@ -58,6 +75,8 @@ impl LlmCredentials {
             LlmCredentials::ClaudeCode => "claude-code",
             LlmCredentials::AnthropicDirect => "anthropic-direct",
             LlmCredentials::OpenRouter => "openrouter",
+            LlmCredentials::Bedrock => "bedrock",
+            LlmCredentials::Ollama => "ollama",
         }
     }
 }
@@ -433,6 +452,76 @@ mod tests {
         assert_eq!(LlmCredentials::ClaudeCode.label(), "claude-code");
         assert_eq!(LlmCredentials::AnthropicDirect.label(), "anthropic-direct");
         assert_eq!(LlmCredentials::OpenRouter.label(), "openrouter");
+        assert_eq!(LlmCredentials::Bedrock.label(), "bedrock");
+        assert_eq!(LlmCredentials::Ollama.label(), "ollama");
+    }
+
+    /// audit 2026-08-19 (finding 18): every variant must serialize to a label
+    /// of its own, and adding a variant must not be possible without deciding
+    /// what it is called.
+    ///
+    /// Why: the label is what reaches the user — the startup banner, the
+    /// `## Deployment Configuration` footer, and the self-identification line
+    /// the agent answers "what am I running on?" with. Two variants sharing a
+    /// label reintroduces exactly the drift the dedicated variants removed.
+    /// What: `expected` re-states the mapping in an EXHAUSTIVE match, so a new
+    /// variant fails this test at compile time; `ALL` then forces every variant
+    /// through it and asserts the labels are pairwise distinct.
+    /// Test: itself.
+    #[test]
+    fn every_variant_has_a_distinct_label() {
+        const ALL: &[LlmCredentials] = &[
+            LlmCredentials::ClaudeCode,
+            LlmCredentials::AnthropicDirect,
+            LlmCredentials::OpenRouter,
+            LlmCredentials::Bedrock,
+            LlmCredentials::Ollama,
+        ];
+        fn expected(c: &LlmCredentials) -> &'static str {
+            match c {
+                LlmCredentials::ClaudeCode => "claude-code",
+                LlmCredentials::AnthropicDirect => "anthropic-direct",
+                LlmCredentials::OpenRouter => "openrouter",
+                LlmCredentials::Bedrock => "bedrock",
+                LlmCredentials::Ollama => "ollama",
+            }
+        }
+        let mut seen: Vec<&'static str> = Vec::new();
+        for c in ALL {
+            assert_eq!(c.label(), expected(c), "label drifted for {c:?}");
+            assert!(
+                !seen.contains(&c.label()),
+                "{:?} reuses the label {:?}",
+                c,
+                c.label()
+            );
+            seen.push(c.label());
+        }
+        assert_eq!(seen.len(), ALL.len());
+    }
+
+    /// audit 2026-08-19 (finding 18): the dedicated variants must not change
+    /// what goes on the wire.
+    ///
+    /// Why: `Bedrock` / `Ollama` replaced an `OpenRouter` placeholder. Under
+    /// that placeholder `qualify_openrouter_model` ran but was a no-op — a
+    /// `bedrock/` id is excluded explicitly and an `ollama/` id already
+    /// contains a `/`. This pins that equivalence so the rename stayed a
+    /// rename.
+    /// Test: itself.
+    #[test]
+    fn new_variants_leave_their_prefixed_model_ids_alone() {
+        for (creds, model) in [
+            (LlmCredentials::Bedrock, "bedrock/claude-sonnet-4-6"),
+            (LlmCredentials::Ollama, "ollama/qwen3:8b"),
+        ] {
+            assert_eq!(qualify_openrouter_model(&creds, model), model);
+            // …and identical to what the old placeholder produced.
+            assert_eq!(
+                qualify_openrouter_model(&LlmCredentials::OpenRouter, model),
+                model
+            );
+        }
     }
 
     #[test]

--- a/crates/trusty-agents/src/memory/code_store.rs
+++ b/crates/trusty-agents/src/memory/code_store.rs
@@ -11,7 +11,8 @@
 //! What: Opens a `RedbUsearchStore` at `<dir>/` and uses `<dir>/.write.lock`
 //! as an advisory `fs4` lock. Implements `MemoryStore` for `Segment::CodeIndex`
 //! only; using it with `Segment::AgentMemory` returns an error so mis-wired
-//! callers fail loudly.
+//! callers fail loudly. Acquiring that lock is a blocking syscall and runs on
+//! `spawn_blocking`, never on a runtime worker — see [`CodeStore::acquire_lock`].
 //! Test: See `tests` module — round-trip insert+search and "second open of
 //! same dir still works" (advisory lock doesn't prevent reopen).
 
@@ -70,30 +71,61 @@ impl CodeStore {
         Ok(Self { inner, lock_file })
     }
 
+    /// Open the lock file and take an advisory lock on it, off the async
+    /// runtime.
+    ///
+    /// Why: `fs4`'s `lock` / `lock_shared` are blocking syscalls (`flock` /
+    /// `LockFileEx`) that PARK the calling thread for as long as another
+    /// process holds the lock. Calling them straight from an async fn stalls a
+    /// tokio worker thread for that whole time (audit 2026-08-19, finding 21):
+    /// with several trusty-agents processes contending on one code index, that
+    /// starves every other task on the runtime. `File::open` is blocking I/O
+    /// too, so it moves across with them.
+    /// What: runs open + lock inside `spawn_blocking` and hands the locked
+    /// `File` back. `exclusive` selects `FileExt::lock` over
+    /// `FileExt::lock_shared`. A panic in the blocking task surfaces as an
+    /// error rather than being swallowed.
+    /// Test: `code_store_insert_search_round_trip` exercises both lock kinds
+    /// end to end; `concurrent_write_lock_prevents_corruption` drives the
+    /// contended path, where the parked thread is now a blocking-pool thread
+    /// rather than a runtime worker.
+    async fn acquire_lock(&self, exclusive: bool) -> Result<File> {
+        let path = self.lock_file.clone();
+        tokio::task::spawn_blocking(move || -> Result<File> {
+            let f = File::open(&path)
+                .with_context(|| format!("opening lock file {}", path.display()))?;
+            if exclusive {
+                // fs4 1.0 renamed `lock_exclusive` -> `lock`.
+                FileExt::lock(&f).map_err(|e| anyhow!("acquiring exclusive lock: {e}"))?;
+            } else {
+                FileExt::lock_shared(&f).map_err(|e| anyhow!("acquiring shared lock: {e}"))?;
+            }
+            Ok(f)
+        })
+        .await
+        .map_err(|e| anyhow!("lock acquisition task failed: {e}"))?
+    }
+
     /// Guard `op` with an exclusive advisory lock on the lock file.
     ///
-    /// Why: `fs4` exposes blocking syscalls (`flock` / `LockFileEx`); calling
-    /// them from an async context would risk blocking the tokio runtime. We
-    /// wrap the lock acquire/release around the actual inner operation on the
-    /// current (already-async) task because the acquire is expected to be
-    /// short-lived for a typical developer workflow. Callers who need to batch
-    /// many writes should take the lock themselves around the batch — which
-    /// isn't exposed by this API yet because we haven't needed it.
-    /// What: Opens the lock file, acquires exclusive lock, runs `op`,
-    /// unconditionally unlocks, returns `op`'s result.
+    /// Why: serializes cross-process writes to the shared code index. The
+    /// acquire itself runs on a blocking thread — see [`Self::acquire_lock`].
+    /// Callers who need to batch many writes should take the lock themselves
+    /// around the batch, which isn't exposed by this API yet because we
+    /// haven't needed it.
+    /// What: acquires the exclusive lock, runs `op`, unconditionally unlocks,
+    /// returns `op`'s result.
     async fn with_write_lock<T, F, Fut>(&self, op: F) -> Result<T>
     where
         F: FnOnce() -> Fut,
         Fut: std::future::Future<Output = Result<T>>,
     {
-        let f = File::open(&self.lock_file)
-            .with_context(|| format!("opening lock file {}", self.lock_file.display()))?;
-        // fs4 1.0 renamed `lock_exclusive` -> `lock`.
-        FileExt::lock(&f).map_err(|e| anyhow!("acquiring exclusive lock: {e}"))?;
+        let f = self.acquire_lock(true).await?;
         let result = op().await;
         // Always unlock; an explicit unlock is preferable to relying on drop
         // so errors surface. If unlock fails the file descriptor drop will
-        // still release eventually.
+        // still release eventually. Unlocking never blocks on another holder,
+        // so it stays on the async task.
         let _ = FileExt::unlock(&f);
         result
     }
@@ -104,9 +136,7 @@ impl CodeStore {
         F: FnOnce() -> Fut,
         Fut: std::future::Future<Output = Result<T>>,
     {
-        let f = File::open(&self.lock_file)
-            .with_context(|| format!("opening lock file {}", self.lock_file.display()))?;
-        FileExt::lock_shared(&f).map_err(|e| anyhow!("acquiring shared lock: {e}"))?;
+        let f = self.acquire_lock(false).await?;
         let result = op().await;
         let _ = FileExt::unlock(&f);
         result


### PR DESCRIPTION
Four defects from tonight's self-audit
(`~/Audit/output/2026-08-19-trusty-tools-technical-due-diligence.md`, findings
12, 18, 19, 21). No issues exist for these; the report is the reference.

## What changed

**Finding 19 — recall failures were invisible** (`src/ctrl/config.rs:318`).
Every error arm in `recall_project_memories` logged at `debug!` and returned an
empty `Vec`, so a corrupted store, a missing embedder, and a project with no
memories yet all produced the same thing: no memory context and no signal at
the default log level. Store-open and embedder-init failures — the two an
operator can act on — now log at `warn!` with anyhow's cause chain. The
empty-`Vec` fallback is unchanged; recall stays best-effort. Embed and search
failures stay at `debug!` (per-query, not misconfiguration).

**Finding 18 — credential type named the wrong transport**
(`src/ctrl/config.rs:123`). `/provider bedrock` and `/provider local` both
returned `LlmCredentials::OpenRouter` as a placeholder. Each gets its own
variant (`Bedrock`, `Ollama`).

Routing is unchanged. Nothing reads this enum to decide an auth header or
signing — the adapter dispatches on the model prefix
(`bedrock/…`, `ollama/…`), which `resolve_overridden_credentials` still
guarantees, and Ollama still skips auth because `OllamaAdapter::api_endpoint`
leaves `auth_header_value` empty. The old `OpenRouter` arm ran
`qualify_openrouter_model`, which was already a no-op for both prefixes
(`bedrock/` is excluded explicitly; `ollama/` contains a `/`), so the new
no-op arms are equivalent. Compiler-surfaced match sites updated:
`LlmCredentials::label()` and `pm_task/dispatch/history.rs`'s `runner_label`.

One user-visible change follows from the fix: the deployment footer and startup
banner now print `bedrock` / `ollama` where they used to print `openrouter`.
That is the drift the dedicated variants exist to close.

**Finding 21 — blocking lock in async** (`src/memory/code_store.rs:91`).
`FileExt::lock` / `lock_shared` are blocking syscalls that park the calling
thread for as long as another process holds the lock. They ran directly inside
`with_write_lock` / `with_read_lock`, so contention between a PM session, an
agent subprocess, and a `--watch` daemon on one code index stalled a Tokio
worker. Both now acquire through one `acquire_lock` helper that runs open + lock
on `spawn_blocking`. `File::open` moved across with them; unlock stays on the
async task because it never waits on another holder.

**Finding 12 — denylist path validation** (`src/api/server/agent_stores.rs:82`).
The name is joined onto a filesystem path by `resolve_agent_paths`, and
validation rejected only `/`, `\`, `.`, and `..`. It admitted NUL bytes, control
characters, whitespace-only names, unbounded lengths, and Unicode separator
look-alikes (`＼` U+FF3C, `∕` U+2215, `⁄` U+2044, `․` U+2024). Replaced with an
allowlist: non-empty, at most 64 bytes, every character ASCII alphanumeric or
`_`/`-`.

**The allowlist admits every bundled agent.** All 26 names in
`crates/trusty-agents/.trusty-agents/agents/` pass — the 22 flat `<name>.toml`
agents and the 4 directory packages (`assistant`, `cto-assistant`, `ctrl`,
`izzie`). The widest characters in use are digits (`gpt5-codex-engineer`) and
hyphens (`claude-code-engineer`, longest at 20 characters). Rather than pasting
that list into a test, `agent_name_allowlist_accepts_every_bundled_agent` reads
the roster off disk, so a future bundled agent whose name the allowlist would
reject fails the test the day it is added. The cap also matches
`agent_create::is_valid_slug`, so every name `POST /api/agents` can create
remains readable here.

## Tests

| Fix | Regression test |
|---|---|
| 19 | `recall_project_memories_warns_when_store_open_fails` — injects a store-open failure, asserts the WARN event fires AND the empty-`Vec` fallback is unchanged |
| 18 | `every_variant_has_a_distinct_label` (exhaustive match — a new variant breaks compilation), `new_variants_leave_their_prefixed_model_ids_alone`, `provider_override_bedrock_and_local_get_their_own_variants` |
| 21 | Existing `code_store_insert_search_round_trip` and `concurrent_write_lock_prevents_corruption` stay green; doc note added |
| 12 | `agent_name_allowlist_rejects_traversal_and_unicode_tricks`, `agent_name_allowlist_accepts_every_bundled_agent` |

Fix 19's test asserts on the tracing event rather than the return value, because
the return value cannot distinguish the two states — that is the whole defect.

Pre-fix failure, run against `origin/main`'s `config.rs`:

```
---- ctrl::tests::config_tests::recall_project_memories_warns_when_store_open_fails stdout ----
thread '…' panicked at crates/trusty-agents/src/ctrl/tests/config_tests.rs:582:5:
a store-open failure must be visible at WARN with its error chain; captured WARN events: []

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 3529 filtered out
```

## Gate — rung 3

```
cargo fmt --check                                     EXIT=0
cargo check -p trusty-agents --all-targets            EXIT=0
cargo clippy -p trusty-agents --all-targets -D warnings   EXIT=0
cargo test -p trusty-agents        test result: ok. 3522 passed; 0 failed; 13 ignored
bash scripts/check_line_cap.sh     4114 files, 0 violations — OK
bash scripts/check_test_pointers.sh   26181 citations, 0 dangling — OK
bash scripts/check_changelog_fragment.sh   trusty-agents fragment present and valid
bash scripts/check_sld.sh          0 errors, 0 warnings
```

Rung 3 is the right rung: all four changes are local to `trusty-agents`, and the
one type that changed shape (`LlmCredentials`) has no consumer outside this
crate — `cargo check -p trusty-agents --all-targets` surfaced every match site.

## Pre-existing flake seen once, not caused here

`assistants::tests::home_tests::okg_store_path_matches_the_owners_spelling`
failed on one of four full-suite runs, comparing paths under two different
tempdirs:

```
  left: "/…/T/.tmp9EGTWd/izzie"
 right: "/…/T/.tmpfupt45/trusty-agents/izzie"
```

It read a `$HOME` that another test had swapped. That test guards its
`set_var("HOME")` with `#[serial]`, while `config_tests::with_sandboxed_home`
guards the same global with `crate::test_env::HOME_LOCK` — two disjoint
exclusion mechanisms over one process-global, which is audit findings 16 and
17. It passes in isolation, passed on three subsequent full-suite runs on this
branch, and this PR touches nothing under `src/assistants/` and mutates no
environment variable.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
