### PR TITLE
fix(trusty-mpm): regenerate tm-capabilities CLI reference after #6069 — clears the red drift gate on main

### DIFF
--- a/crates/trusty-mpm/changelog.d/regen-capabilities-cli.md
+++ b/crates/trusty-mpm/changelog.d/regen-capabilities-cli.md
@@ -1,0 +1,3 @@
+Documentation
+
+- Regenerated the `tm-capabilities` CLI reference so it carries `ls`'s `--no-prune` help text from [#6069](https://github.com/bobmatnyc/trusty-tools/pull/6069), clearing the drift-check gate that PR left red on main

--- a/crates/trusty-mpm/src/assets/skills/tm-capabilities/references/cli.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-capabilities/references/cli.md
@@ -51,7 +51,7 @@ Generated from `Cli::command()` (clap's command-tree introspection) — every `t
 - `launch` — Launch a session with full setup: deploys instructions, agents, and skills, then starts Claude
 - `load` — Clone or refresh the managed workspace for a registered alias (DOC-24)
 - `login` — One-time keychain login for managed `tm run` sessions (WI-10, DOC-24)
-- `ls` — Interactive managed-session connector — list sessions and connect (#2311)
+- `ls` — Interactive managed-session connector — list sessions and connect (#2311). Auto-prunes dead records; `--no-prune` for a read that changes nothing
 - `manager` — Layer-3 portfolio manager — cross-project status, digest, and chat (DOC-36, epic #2109, WI-6 #2583)
   - `chat` — One-shot chat turn against the portfolio manager persona
   - `digest` — LLM-authored portfolio (or single-project) narrative, with a deterministic fallback when no inference provider is configured
@@ -135,7 +135,7 @@ Generated from `Cli::command()` (clap's command-tree introspection) — every `t
   - `info` — Show detailed info for a specific session
   - `instructions` — Print the composed launch instructions a session would receive
   - `list` — List sessions for the current project
-  - `ls` — List managed sessions (session-manager MVP)
+  - `ls` — List managed sessions (session-manager MVP). Auto-prunes dead records; pass `--no-prune` for a read that changes nothing
   - `managed-resume` — \[DEPRECATED\] Resume a stopped managed session — use `resume` instead
   - `managed-stop` — \[DEPRECATED\] Stop a managed session's runtime — use `stop` instead
   - `new` — Spawn a new managed session from a repo + ref (session-manager MVP)
@@ -168,7 +168,7 @@ Generated from `Cli::command()` (clap's command-tree introspection) — every `t
   - `info` — Show detailed info for a specific session
   - `instructions` — Print the composed launch instructions a session would receive
   - `list` — List sessions for the current project
-  - `ls` — List managed sessions (session-manager MVP)
+  - `ls` — List managed sessions (session-manager MVP). Auto-prunes dead records; pass `--no-prune` for a read that changes nothing
   - `managed-resume` — \[DEPRECATED\] Resume a stopped managed session — use `resume` instead
   - `managed-stop` — \[DEPRECATED\] Stop a managed session's runtime — use `stop` instead
   - `new` — Spawn a new managed session from a repo + ref (session-manager MVP)


### PR DESCRIPTION
## Summary
- PR #6069 added `--no-prune` help text to tm's `ls` / `session ls` clap commands but did not regenerate `crates/trusty-mpm/src/assets/skills/tm-capabilities/references/cli.md`, leaving main's `tm-capabilities generated-skill drift check` gate red.
- Ran `SKIP_UI_BUILD=1 cargo run -p trusty-mpm --bin tm -- generate capabilities` (no `--check`) to regenerate the asset. The diff picks up exactly the three drifted help-text lines gaining the "Auto-prunes dead records; `--no-prune` for a read that changes nothing" suffix — nothing else changed.
- Added a changelog fragment (`crates/trusty-mpm/changelog.d/regen-capabilities-cli.md`) since the changed asset lives under `crates/trusty-mpm/src/**` and the fragment gate has no exemption for generated skill assets.

Refs #6069

## Test plan (Rung 3 — localized behavior inside one crate)
- `cargo check -p trusty-mpm`: exit 0
- `cargo fmt --check`: exit 0
- `bash scripts/check_changelog_fragment.sh --base origin/main`: exit 0 — `OK trusty-mpm: changelog.d fragment present and valid`
- `SKIP_UI_BUILD=1 cargo run --quiet -p trusty-mpm --bin tm -- generate capabilities --check`: exit 0 — `tm-capabilities: up to date (7 generated files).`

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools