### PR TITLE
chore(trusty-common): bump to 0.40.0 — clear the parity red from #5809's post-publish extraction merge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11403,7 +11403,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-common"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,7 @@ trusty-code = { path = "crates/trusty-code", version = "0.3.0" }
 # epic #3411). Not yet published (Slice 1, #3425).
 trusty-tui = { path = "crates/trusty-tui", version = "0.1.0" }
 trusty-agents-common = { path = "crates/trusty-agents-common", version = "0.6.0" }
-trusty-common = { path = "crates/trusty-common", version = "0.39" }
+trusty-common = { path = "crates/trusty-common", version = "0.40" }
 # Shared JSON-RPC 2.0 / MCP protocol primitives, extracted from
 # `trusty_common::mcp` by ADR-0040 (#5803).
 trusty-mcp = { path = "crates/trusty-mcp", version = "0.1.0" }

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "trusty-common"
-version = "0.39.0"
+# 0.40.0 (#5809): the MCP extraction (ADR-0040 Phase 1) removed the public
+# `src/mcp/*` modules. Cargo's 0.x rule makes that a MINOR bump, not a patch.
+version = "0.40.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/trusty-gworkspace/Cargo.toml
+++ b/crates/trusty-gworkspace/Cargo.toml
@@ -15,7 +15,7 @@ name = "trusty-gworkspace-mcp"
 path = "src/bin/trusty-gworkspace-mcp.rs"
 
 [dependencies]
-trusty-common = { path = "../trusty-common", version = "0.39" }
+trusty-common = { path = "../trusty-common", version = "0.40" }
 # JSON-RPC / MCP primitives, extracted from `trusty_common::mcp` by ADR-0040 (#5803).
 trusty-mcp = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/trusty-memory/Cargo.toml
+++ b/crates/trusty-memory/Cargo.toml
@@ -82,7 +82,7 @@ path = "src/bin/mcp_bridge.rs"
 # `uds-supervisor` is NOT dropped — trusty-console and trusty-agents still
 # depend on the shared `UdsServiceSupervisor` for trusty-review / trusty-analyze.
 trusty-mcp = { workspace = true }  # JSON-RPC / MCP primitives (ADR-0040, #5803)
-trusty-common = { path = "../trusty-common", version = "0.39", default-features = false, features = ["memory-core", "monitor-tui", "bm25", "cli-help", "update-check", "bug-capture", "console-metrics", "config-cli", "crate-config", "palace-resolve", "codex-config"] }
+trusty-common = { path = "../trusty-common", version = "0.40", default-features = false, features = ["memory-core", "monitor-tui", "bm25", "cli-help", "update-check", "bug-capture", "console-metrics", "config-cli", "crate-config", "palace-resolve", "codex-config"] }
 # `bug-capture` enables Phase 1 ERROR event capture to JSONL + in-memory ring (bug-reporting #478)
 # Why (issue #1318): the `trusty-console` dependency was REMOVED. The console
 # is no longer bundled into trusty-memory (single-owner-per-binary); the
@@ -174,7 +174,7 @@ serial_test = { workspace = true }
 # the production library (mirrors the trusty-mpm and trusty-search pattern).
 # `docgen` (#5205 follow-up): `tests/generated_docs.rs` renders the MCP tool
 # section of README.md from `tool_definitions()`.
-trusty-common = { path = "../trusty-common", version = "0.39", default-features = false, features = ["memory-core", "embedder-test-support", "docgen"] }
+trusty-common = { path = "../trusty-common", version = "0.40", default-features = false, features = ["memory-core", "embedder-test-support", "docgen"] }
 chrono = { workspace = true }
 
 [features]


### PR DESCRIPTION
## Summary

main's `Publish-version parity` gate is red. PR #5809 (the ADR-0040 Phase 1
MCP-primitive extraction) merged at 18:37Z removing the public `src/mcp/*`
modules from `trusty-common`'s `src/`, after `trusty-common` 0.39.0 had
already published to crates.io at 15:39Z the same day — a publish race, not
a coding defect. The parity gate compares the local source tree against the
published tarball for the crate's *own declared* version, and the tree no
longer matches 0.39.0's published contents.

- Bump `crates/trusty-common/Cargo.toml`: 0.39.0 → 0.40.0. The extraction is
  a breaking change (public modules removed) on a 0.x crate, so under
  Cargo's 0.x rule that's the MINOR position, not a patch — noted inline at
  the version field.
- Move the root `[workspace.dependencies]` pin `trusty-common = { …,
  version = "0.39" }` → `"0.40"`.
- Two crates bypass that workspace pin with their own hardcoded
  `version = "0.39"` on the path dependency instead of `{ workspace = true
  }`: `trusty-gworkspace` and `trusty-memory` (two `[dependencies]` /
  `[dev-dependencies]` entries). Left at 0.39 they make the workspace
  unresolvable (`failed to select a version for the requirement
  trusty-common = "^0.39"` — candidate found was 0.40.0), so all three moved
  to 0.40 as well.
- `Cargo.lock`: only the single `version = "0.39.0"` line under
  `trusty-common`'s own `[[package]]` entry (a path dependency, no
  checksum) is updated to `0.40.0`. No `cargo update` was run.
- No changelog fragment: no `src/**` changed, only manifests/lock —
  confirmed by the gate itself (see below).

## Test plan

Rung 4 (cross-crate manifest change, many `trusty-common` consumers):

- `bash scripts/check_changelog_fragment.sh` → `EXIT=0`: "scanned 5 changed
  path(s); attributed 0 crate-source path(s); ... no crate source changed
  ... — OK."
- `bash scripts/check-version-parity.sh` → `EXIT=0`: `[ OK ] trusty-common
  0.40.0 — not yet published, nothing to compare`; `publish-guard: checked
  19 publishable crate(s) (floor 10) — 0 drifted, 0 unverifiable.`
- `cargo check --workspace` → `EXIT=0` (rebuilds every direct/indirect
  `trusty-common` consumer against the new pin).
- `cargo fmt --check` → `EXIT=0` (only pre-existing nightly-feature-unstable
  warnings, no diff).

- [x] Version-parity gate clears locally
- [x] Workspace resolves and checks clean under the new pin
- [ ] CI: `Publish-version parity` required check turns green on `main` after merge

Refs #5809

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools