### PR TITLE
fix(trusty-mpm): bound the claude --version probe — WNOHANG polling + 5s timeout (Refs #5969)

### DIFF
--- a/crates/trusty-mpm/changelog.d/5969-version-probe-timeout.md
+++ b/crates/trusty-mpm/changelog.d/5969-version-probe-timeout.md
@@ -1,0 +1,3 @@
+Fixed
+
+- The `claude --version` probe behind output-style detection now gives up after 5 seconds, killing and reaping the probe child, instead of waiting forever — a wedged `claude` binary used to hang session launch and every prompt-composition path and leave orphaned probe processes behind (#5969).

--- a/crates/trusty-mpm/src/core/output_style.rs
+++ b/crates/trusty-mpm/src/core/output_style.rs
@@ -32,6 +32,21 @@ use crate::core::config::MpmConfig;
 /// Test: `version_gate_*` in `output_style_tests.rs`.
 pub const NATIVE_OUTPUT_STYLE_MIN_VERSION: (u32, u32, u32) = (1, 0, 83);
 
+/// How long [`claude_supports_native_output_style`] waits for `claude
+/// --version` before giving up on it.
+///
+/// Why: the probe sits on the session-launch and prompt-composition paths, and
+/// a wedged `claude` binary used to hang them forever (#5969). `claude
+/// --version` answers in well under a second on a healthy host, so five
+/// seconds is generous for the answer and short enough that a wedged binary
+/// costs a launch five seconds rather than the whole session.
+/// What: the deadline handed to
+/// [`crate::core::spawn_disclaim::disclaimed_stdout_with_timeout`]; past it the
+/// probe child is killed and the probe fails safe to "no native support".
+/// Test: `spawn_disclaim::timeout`'s
+/// `disclaimed_stdout_with_timeout_kills_and_reaps_wedged_child`.
+pub const CLAUDE_VERSION_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
 /// A failure resolving a requested output-style id.
 ///
 /// Why: an unknown style id is a user-facing error (a typo in config or the
@@ -195,16 +210,24 @@ pub fn version_supports_native(version: (u32, u32, u32)) -> bool {
 /// inject the style into the PM prompt instead of relying on the settings key.
 /// What: runs `claude --version`, parses the first semver triple, and compares
 /// it to [`NATIVE_OUTPUT_STYLE_MIN_VERSION`]. **Fails safe**: any error (binary
-/// missing, non-zero exit, unparseable output) is logged to stderr and treated
-/// as "does NOT support native" so the style is always applied via injection.
-/// All logging goes to stderr (the daemon/MCP stdout-clean rule).
+/// missing, non-zero exit, unparseable output, or a `claude` that never exits)
+/// is logged to stderr and treated as "does NOT support native" so the style is
+/// always applied via injection. All logging goes to stderr (the daemon/MCP
+/// stdout-clean rule).
 /// Test: pure logic is in [`version_supports_native`] /
 /// [`detect_native_support_from_output`]; this thin wrapper is side-effecting
-/// (spawns a process) and is covered by `detect_from_output_*`.
+/// (spawns a process) and is covered by `detect_from_output_*`. The bounded
+/// wait itself is covered by `spawn_disclaim::timeout`'s tests.
 pub fn claude_supports_native_output_style() -> bool {
     // Spawn through the disclaim helper so this direct child of the signed
     // daemon is its own TCC responsible process, not `trusty-mpm` (issue #2819).
-    match crate::core::spawn_disclaim::disclaimed_output("claude", &["--version".to_string()]) {
+    // #5969: bound the wait — an unbounded one hung every session launch and
+    // prompt-composition path when `claude --version` wedged.
+    match crate::core::spawn_disclaim::disclaimed_stdout_with_timeout(
+        "claude",
+        &["--version".to_string()],
+        CLAUDE_VERSION_PROBE_TIMEOUT,
+    ) {
         Ok(out) if out.status.success() => {
             let stdout = String::from_utf8_lossy(&out.stdout);
             detect_native_support_from_output(&stdout)

--- a/crates/trusty-mpm/src/core/spawn_disclaim/macos/mod.rs
+++ b/crates/trusty-mpm/src/core/spawn_disclaim/macos/mod.rs
@@ -115,6 +115,34 @@ pub(super) fn wait_for(pid: libc::pid_t) -> io::Result<ExitStatus> {
     }
 }
 
+/// Poll `pid` without blocking: `Some(status)` once it has exited.
+///
+/// Why: [`wait_for`] blocks with no bound, so a wedged child hangs its caller
+/// forever — a `claude --version` probe stalled a live `tm` session launch
+/// (#5969). A `WNOHANG` variant lets the `timeout` module bound the wait and
+/// kill the child when the deadline passes.
+/// What: `waitpid(pid, WNOHANG)` through `EINTR`; `rc == 0` means the child is
+/// still running, so `Ok(None)`.
+/// Test: `spawn_disclaim::timeout`'s `disclaimed_stdout_with_timeout_*` tests.
+pub(super) fn try_wait_for(pid: libc::pid_t) -> io::Result<Option<ExitStatus>> {
+    loop {
+        let mut status: libc::c_int = 0;
+        // SAFETY: `waitpid` writes only into `status`; `pid` is our child.
+        let rc = unsafe { libc::waitpid(pid, &mut status, libc::WNOHANG) };
+        if rc == -1 {
+            let e = io::Error::last_os_error();
+            if e.raw_os_error() == Some(libc::EINTR) {
+                continue;
+            }
+            return Err(e);
+        }
+        if rc == 0 {
+            return Ok(None);
+        }
+        return Ok(Some(ExitStatus::from_raw(status)));
+    }
+}
+
 /// Create a pipe whose BOTH ends are `FD_CLOEXEC`.
 ///
 /// Why: the read (or write) end kept by the parent must not leak into

--- a/crates/trusty-mpm/src/core/spawn_disclaim/mod.rs
+++ b/crates/trusty-mpm/src/core/spawn_disclaim/mod.rs
@@ -213,6 +213,11 @@ pub use stderr_piped::{StderrPipedSpawn, disclaimed_stderr_piped_spawn};
 mod stdout_piped;
 pub use stdout_piped::{StdoutPipedSpawn, disclaimed_stdout_piped_spawn};
 
+// #5969: every other spawn shape here waits unbounded, which hung `tm` on a
+// wedged `claude --version`; this one carries a deadline.
+mod timeout;
+pub use timeout::disclaimed_stdout_with_timeout;
+
 /// Trait-object alias for a spawned child's writable stdin, uniform across
 /// the native (`tokio::process::ChildStdin`) and macOS-disclaimed
 /// (`tokio::net::unix::pipe::Sender`) spawn paths so callers ([`PipedSpawn`])

--- a/crates/trusty-mpm/src/core/spawn_disclaim/timeout.rs
+++ b/crates/trusty-mpm/src/core/spawn_disclaim/timeout.rs
@@ -1,0 +1,244 @@
+//! Bounded-wait capture spawn — the deadline-carrying sibling of
+//! [`super::disclaimed_output`].
+//!
+//! Why: every other spawn shape in this module waits on its child with no
+//! bound. `core::output_style::claude_supports_native_output_style` probes
+//! `claude --version` on the session-launch path, and a wedged `claude` binary
+//! made that wait never return — a live `tm session` launch, and every surface
+//! that composes a prompt, hung indefinitely and left the probe child orphaned
+//! to PID 1 when the operator killed `tm` (issue #5969).
+//! What: [`disclaimed_stdout_with_timeout`] spawns through
+//! [`super::disclaimed_stdout_piped_spawn`] — so the child is still TCC-
+//! disclaimed on macOS — drains stdout on a helper thread, and polls the
+//! child's exit non-blockingly (`waitpid(WNOHANG)` on the disclaimed path,
+//! `Child::try_wait` on the native path) until `timeout` elapses. On the
+//! deadline it SIGKILLs the child and reaps it before returning
+//! `io::ErrorKind::TimedOut`, so no probe process outlives the call. Only the
+//! thread that polls ever waits on the pid, so no kill can ever race a reap
+//! onto a recycled pid. `stderr` is discarded (this spawn shape sends it to
+//! `/dev/null`) and the returned `Output::stderr` is always empty; stdin is
+//! inherited rather than `/dev/null`, which differs from
+//! [`super::disclaimed_output`] and suits the probe this exists for — a
+//! `--version` call that reads no input and is now killed on a deadline
+//! either way.
+//! Test: `tests::disclaimed_stdout_with_timeout_returns_output_for_fast_child`,
+//! `tests::disclaimed_stdout_with_timeout_kills_and_reaps_wedged_child`,
+//! `tests::disclaimed_stdout_with_timeout_reports_spawn_error_for_missing_binary`.
+
+use std::io::{self, Read as _};
+use std::process::{Command, ExitStatus, Output};
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+use super::stdout_piped::{StdoutPipedHandle, StdoutPipedSpawn, disclaimed_stdout_piped_spawn};
+
+/// How often the bounded wait re-checks whether the child has exited.
+const POLL_INTERVAL: Duration = Duration::from_millis(20);
+
+/// How long the stdout drain thread may still be finishing after the child
+/// exited before its bytes are given up on. A pipe that has both hit EOF and
+/// been closed by the child drains in microseconds; this only matters when a
+/// grandchild inherited the write end, and giving up there is strictly better
+/// than the unbounded wait it replaces.
+const DRAIN_GRACE: Duration = Duration::from_secs(1);
+
+/// Run `program` with `args`, capturing stdout, and give up after `timeout`.
+///
+/// Why: see the module docs — the `claude --version` probe needs a wait it can
+/// lose (issue #5969).
+/// What: spawns via [`super::disclaimed_stdout_piped_spawn`] (stdout piped,
+/// stderr to `/dev/null`, TCC disclaimed on macOS), then polls for exit until
+/// `timeout` elapses. A child that outlives the deadline is SIGKILLed and
+/// reaped, and the call returns `io::ErrorKind::TimedOut`. `Output::stderr` is
+/// always empty.
+/// Test: `tests::disclaimed_stdout_with_timeout_returns_output_for_fast_child`,
+/// `tests::disclaimed_stdout_with_timeout_kills_and_reaps_wedged_child`,
+/// `tests::disclaimed_stdout_with_timeout_reports_spawn_error_for_missing_binary`.
+pub fn disclaimed_stdout_with_timeout(
+    program: &str,
+    args: &[String],
+    timeout: Duration,
+) -> io::Result<Output> {
+    let mut cmd = Command::new(program);
+    cmd.args(args);
+    let StdoutPipedSpawn {
+        id,
+        mut stdout,
+        handle,
+    } = disclaimed_stdout_piped_spawn(cmd)?;
+
+    // Drain stdout off-thread: `read_to_end` blocks until EOF, which a wedged
+    // child never delivers, so the deadline below must not sit behind it.
+    let (tx, rx) = mpsc::channel::<Vec<u8>>();
+    std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        let _ = stdout.read_to_end(&mut buf);
+        let _ = tx.send(buf);
+    });
+
+    let mut waiter = Waiter(handle);
+    let deadline = Instant::now() + timeout;
+    loop {
+        match waiter.try_wait() {
+            Ok(Some(status)) => {
+                let stdout = rx.recv_timeout(DRAIN_GRACE).unwrap_or_default();
+                return Ok(Output {
+                    status,
+                    stdout,
+                    stderr: Vec::new(),
+                });
+            }
+            Ok(None) => {}
+            // A poll that cannot answer must not leave the child running
+            // either — that is the whole point of #5969. `ECHILD` is the one
+            // exception: it says the pid is already gone, so signalling it
+            // could only reach a recycled one.
+            Err(err) => {
+                if err.raw_os_error() != Some(libc::ECHILD) {
+                    waiter.kill_and_reap();
+                }
+                return Err(err);
+            }
+        }
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        std::thread::sleep(POLL_INTERVAL.min(remaining));
+    }
+
+    waiter.kill_and_reap();
+    Err(io::Error::new(
+        io::ErrorKind::TimedOut,
+        format!("`{program}` (pid {id}) did not exit within {timeout:?}; child killed"),
+    ))
+}
+
+/// The exit side of a [`StdoutPipedSpawn`], reduced to the three operations
+/// the bounded wait needs, uniform across the native and disclaimed paths.
+///
+/// Why: the two spawn paths reap differently — `std::process::Child` owns its
+/// own wait state, the disclaimed path holds a bare pid — but the deadline
+/// logic above is identical for both.
+/// What: wraps [`StdoutPipedHandle`] with a non-blocking poll, plus a
+/// kill-then-blocking-reap used only once the deadline has passed.
+/// Test: see [`disclaimed_stdout_with_timeout`].
+struct Waiter(StdoutPipedHandle);
+
+impl Waiter {
+    /// `Some(status)` once the child has exited; `None` while it still runs.
+    fn try_wait(&mut self) -> io::Result<Option<ExitStatus>> {
+        match &mut self.0 {
+            StdoutPipedHandle::Native(child) => child.try_wait(),
+            #[cfg(target_os = "macos")]
+            StdoutPipedHandle::Disclaimed(pid) => super::macos::try_wait_for(*pid),
+        }
+    }
+
+    /// SIGKILL the child, then block until it is reaped.
+    ///
+    /// The blocking reap is safe precisely because nothing else waits on this
+    /// pid: SIGKILL cannot be caught or ignored, so the wait returns as soon
+    /// as the kernel tears the process down. Best-effort — a child that
+    /// already exited between the last poll and here is simply reaped.
+    fn kill_and_reap(&mut self) {
+        match &mut self.0 {
+            StdoutPipedHandle::Native(child) => {
+                let _ = child.kill();
+                let _ = child.wait();
+            }
+            #[cfg(target_os = "macos")]
+            StdoutPipedHandle::Disclaimed(pid) => {
+                // SAFETY: `pid` is our own child and has not been reaped —
+                // `try_wait` returned `None` for it and nothing else waits on
+                // it, so the pid cannot have been recycled.
+                unsafe { libc::kill(*pid, libc::SIGKILL) };
+                let _ = super::macos::wait_for(*pid);
+            }
+        }
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    fn args(list: &[&str]) -> Vec<String> {
+        list.iter().map(|s| (*s).to_string()).collect()
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn disclaimed_stdout_with_timeout_returns_output_for_fast_child() {
+        let out = disclaimed_stdout_with_timeout(
+            "/bin/sh",
+            &args(&["-c", "echo probe-output; exit 7"]),
+            Duration::from_secs(10),
+        )
+        .expect("a child that exits well inside the deadline must not error");
+        assert_eq!(out.status.code(), Some(7));
+        assert_eq!(String::from_utf8_lossy(&out.stdout), "probe-output\n");
+        assert!(out.stderr.is_empty(), "this spawn shape discards stderr");
+    }
+
+    /// The #5969 regression: before the fix this call shape (`disclaimed_output`
+    /// on a wedged binary) never returned, and killing the caller orphaned the
+    /// child to PID 1. The bounded wait must return promptly AND leave no live
+    /// process behind.
+    #[test]
+    #[serial_test::serial]
+    fn disclaimed_stdout_with_timeout_kills_and_reaps_wedged_child() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let pidfile = dir.path().join("pid");
+        // `exec` so the recorded pid IS the long sleep, not a shell wrapper.
+        let script = format!("echo $$ > {}; exec sleep 300", pidfile.display());
+
+        let started = Instant::now();
+        let err = disclaimed_stdout_with_timeout(
+            "/bin/sh",
+            &args(&["-c", &script]),
+            Duration::from_millis(300),
+        )
+        .expect_err("a wedged child must surface a timeout, not hang");
+        let elapsed = started.elapsed();
+
+        assert_eq!(err.kind(), io::ErrorKind::TimedOut, "err: {err}");
+        assert!(
+            elapsed < Duration::from_secs(10),
+            "bounded wait must return promptly, took {elapsed:?}"
+        );
+
+        let pid: libc::pid_t = std::fs::read_to_string(&pidfile)
+            .expect("child must have recorded its pid before wedging")
+            .trim()
+            .parse()
+            .expect("pid file must hold a pid");
+        // SAFETY: signal 0 performs the existence/permission check only.
+        let alive = unsafe { libc::kill(pid, 0) };
+        assert_eq!(
+            alive, -1,
+            "no wedged child may outlive the timeout (pid {pid} still exists)"
+        );
+        assert_eq!(
+            io::Error::last_os_error().raw_os_error(),
+            Some(libc::ESRCH),
+            "the child must be gone, not merely unsignalable"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn disclaimed_stdout_with_timeout_reports_spawn_error_for_missing_binary() {
+        let err = disclaimed_stdout_with_timeout(
+            "/nonexistent/definitely-not-a-real-binary-5969",
+            &[],
+            Duration::from_secs(1),
+        )
+        .expect_err("spawning a missing binary must error, not time out");
+        assert_ne!(
+            err.kind(),
+            io::ErrorKind::TimedOut,
+            "a spawn failure must not be reported as a timeout: {err}"
+        );
+    }
+}


### PR DESCRIPTION
## Outcome

Bounds the `claude --version` probe used by `claude_supports_native_output_style` so a stuck `claude` process can no longer hang session launch forever. Refs #5969.

## What changed / out of scope

`disclaimed_output`'s macOS `wait_for` looped on a blocking `waitpid` with no deadline — a stuck `claude` child hung the probe indefinitely. New `spawn_disclaim/timeout.rs` adds `disclaimed_stdout_with_timeout`: the child stays TCC-disclaimed, stdout drains on a helper thread, exit is polled via a new `try_wait_for` WNOHANG sibling, and the child is SIGKILL'd and reaped at a 5s deadline. On timeout the probe fails safe to "no native support" — the same path already taken for a missing binary.

Files: `core/output_style.rs`, `core/spawn_disclaim/{mod.rs,timeout.rs,macos/mod.rs}`, `changelog.d/5969-version-probe-timeout.md`.

Out of scope: no other probe paths were touched.

## Risk

Normal. Change is localized to the version-probe path; the failure mode moves from an infinite hang to a bounded 5s degraded launch.

## Test evidence

Rung 3. `cargo fmt --check` and `cargo clippy -p trusty-mpm --all-targets -- -D warnings` clean. `cargo test -p trusty-mpm -- --skip guided_fallback` exit 0: lib 5194 passed/0 failed, bin `tm` 1761 passed, 45 integration targets ok. The pre-fix hang was proven with a temporary test that blocked 503s until externally SIGTERMed. 3 new bounded-wait tests pass (`spawn_disclaim` suite: 38 passed).

## Baseline failures

Eight `guided_fallback_*` tests deadlock on `origin/main` — canonical issue #6070. This branch touches neither test file (empty three-dot diff over both). Change-specific gates pass; full-crate serial run blocked by canonical issue #6070.

## Docs / changelog status

Changelog fragment present at `crates/trusty-mpm/changelog.d/5969-version-probe-timeout.md`; check green.

## Review-finding disposition

None yet — trusty-review gate pending.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
