### PR TITLE
fix(ci): ci-apt-install recovers interrupted dpkg between retries (Refs #6064)

### DIFF
--- a/scripts/check-ci-helpers-selftest.sh
+++ b/scripts/check-ci-helpers-selftest.sh
@@ -518,23 +518,38 @@ assert_eq "all five disk-reclaim jobs call the helper" "5" \
 echo
 echo "ci-apt-install:"
 
-# apt_stub_dir <script-body> — a PATH dir holding a fake apt-get with that body
-# plus a `sudo` that just runs its arguments.
+# apt_stub_dir <script-body> — a PATH dir holding a fake apt-get with that body,
+# a `sudo` that just runs its arguments, and a `dpkg` whose `--configure -a`
+# clears the `broken` marker the install stub can set (#6064). The dpkg stub is
+# unconditional so no case reaches the host's real dpkg.
 apt_stub_dir() {
   local dir
   dir="$(mktemp -d "${TMPDIR:-/tmp}/aptstub.XXXXXX")"
   printf '#!/usr/bin/env bash\n%s\n' "$1" > "${dir}/apt-get"
   printf '#!/usr/bin/env bash\nexec "$@"\n' > "${dir}/sudo"
-  chmod +x "${dir}/apt-get" "${dir}/sudo"
+  cat > "${dir}/dpkg" <<'DPKG_STUB'
+#!/usr/bin/env bash
+d="${0%/*}"
+if [ "$1" = "--configure" ]; then
+  echo "configure" >> "${d}/dpkg-calls"
+  rm -f "${d}/broken"
+fi
+exit 0
+DPKG_STUB
+  chmod +x "${dir}/apt-get" "${dir}/sudo" "${dir}/dpkg"
   echo "${dir}"
 }
 
 # apt_run <stub-dir> — exit code of the wrapper, with the stub ahead on PATH.
-# Retry delay 0 and small ceilings so the failing cases cost nothing.
+# Retry delay 0 and small ceilings so the failing cases cost nothing. A caller
+# that asserts an exact attempt COUNT raises the ceiling first: at 2s a loaded
+# machine can take long enough to start the stub that a healthy attempt is
+# killed as a stall, which would add an attempt the case did not ask for.
 apt_run() {
   local dir="$1" rc=0
   PATH="${dir}:${PATH}" CI_APT_RETRY_DELAY_S=0 CI_APT_ATTEMPTS=3 \
-    CI_APT_UPDATE_TIMEOUT_S=2 CI_APT_INSTALL_TIMEOUT_S=2 \
+    CI_APT_UPDATE_TIMEOUT_S="${CI_APT_UPDATE_TIMEOUT_S:-2}" \
+    CI_APT_INSTALL_TIMEOUT_S="${CI_APT_INSTALL_TIMEOUT_S:-2}" \
     bash scripts/ci-apt-install.sh build-essential \
     >"${dir}/out" 2>&1 || rc=$?
   echo "$rc"
@@ -576,6 +591,38 @@ if command -v timeout >/dev/null 2>&1 || command -v gtimeout >/dev/null 2>&1; th
   assert_eq "  reported as a stall, not a plain failure" "3" \
     "$(grep -c 'STALLED — killed at the 2s ceiling' "${stall_dir}/out" || true)"
   rm -rf "${stall_dir}"
+
+  # #6064: the stall's aftermath. Killing `apt-get install` mid-unpack leaves
+  # dpkg interrupted, and every later attempt then exits 100 in seconds — so one
+  # stall used to consume the whole three-attempt budget. The stub reproduces
+  # that exactly: attempt 1 marks itself broken and hangs, and only a
+  # `dpkg --configure -a` between attempts clears the marker.
+  dpkg_dir="$(apt_stub_dir '
+d="${0%/*}"
+[ "$1" = "update" ] && exit 0
+if [ -f "${d}/broken" ]; then
+  echo "E: dpkg was interrupted, you must manually run dpkg --configure -a" >&2
+  exit 100
+fi
+if [ ! -f "${d}/stalled-once" ]; then
+  : > "${d}/stalled-once"
+  : > "${d}/broken"
+  exec sleep 300
+fi
+exit 0')"
+  # 6s, not the usual 2s: this case counts attempts, so a stub that is merely
+  # slow to start must not read as a stall and add one.
+  CI_APT_UPDATE_TIMEOUT_S=6
+  CI_APT_INSTALL_TIMEOUT_S=6
+  assert_eq "an interrupted dpkg is repaired, not inherited" "0" "$(apt_run "${dpkg_dir}")"
+  unset CI_APT_UPDATE_TIMEOUT_S CI_APT_INSTALL_TIMEOUT_S
+  assert_eq "  the repair ran once, between attempts"        "1" \
+    "$(grep -c 'to clear any interrupted dpkg state' "${dpkg_dir}/out" || true)"
+  assert_eq "  and dpkg --configure -a was what ran"         "1" \
+    "$(wc -l < "${dpkg_dir}/dpkg-calls" | tr -d ' ')"
+  assert_eq "  so attempt 2 installed instead of exiting 100" "2" \
+    "$(grep -c 'apt-get install, attempt' "${dpkg_dir}/out" || true)"
+  rm -rf "${dpkg_dir}"
 else
   echo "  skip 'stalled mirror' — no timeout(1) on PATH (GNU coreutils; present on the CI runners)"
 fi

--- a/scripts/ci-apt-install.sh
+++ b/scripts/ci-apt-install.sh
@@ -24,11 +24,21 @@
 #     CI_APT_ATTEMPTS=3          attempts per phase
 #     CI_APT_UPDATE_TIMEOUT_S=120  per-attempt ceiling for `apt-get update`
 #     CI_APT_INSTALL_TIMEOUT_S=420 per-attempt ceiling for `apt-get install`
-#     CI_APT_RETRY_DELAY_S=5     pause between attempts
+#     CI_APT_RETRY_DELAY_S=5     backoff unit; attempt N waits N*this seconds
 #     CI_APT_TOTAL_BUDGET_S=600  hard ceiling across both phases
+#     CI_APT_DPKG_REPAIR_TIMEOUT_S=120  ceiling for the between-attempt repair
 #
 #   The total budget is the number that answers the issue: worst case is ten
-#   minutes, not thirty, and the ten minutes are spent visibly.
+#   minutes, not thirty, and the ten minutes are spent visibly. Each attempt's
+#   ceiling is clamped to what is left of that budget, so the budget is a real
+#   ceiling rather than a value only sampled between attempts (#6064).
+#
+#   Between attempts the script runs `dpkg --configure -a` (#6064). Killing
+#   `apt-get install` at its ceiling mid-unpack leaves dpkg's database
+#   interrupted, and every later attempt then dies in seconds with "dpkg was
+#   interrupted, you must manually run 'sudo dpkg --configure -a'" — so one
+#   stall used to consume all three attempts. On a healthy system the repair is
+#   a fast no-op.
 #
 #   `timeout` is a GNU coreutils tool. It is present on the hosted Linux
 #   runners this script is written for; when it is absent (a bare macOS shell,
@@ -48,8 +58,9 @@
 #   adopt this the next time one of them is touched.
 #
 # Test: scripts/check-ci-helpers-selftest.sh (`ci-apt-install:` cases) drives
-#   the succeeds-first-try, succeeds-after-a-retry, exhausts-attempts, and
-#   stalls-then-times-out branches against a stubbed `apt-get` on PATH.
+#   the succeeds-first-try, succeeds-after-a-retry, exhausts-attempts,
+#   stalls-then-times-out, and stall-breaks-dpkg-then-recovers branches against
+#   a stubbed `apt-get` and `dpkg` on PATH.
 
 set -uo pipefail
 
@@ -63,6 +74,7 @@ UPDATE_TIMEOUT_S="${CI_APT_UPDATE_TIMEOUT_S:-120}"
 INSTALL_TIMEOUT_S="${CI_APT_INSTALL_TIMEOUT_S:-420}"
 RETRY_DELAY_S="${CI_APT_RETRY_DELAY_S:-5}"
 TOTAL_BUDGET_S="${CI_APT_TOTAL_BUDGET_S:-600}"
+DPKG_REPAIR_TIMEOUT_S="${CI_APT_DPKG_REPAIR_TIMEOUT_S:-120}"
 
 STARTED_AT="$(date +%s)"
 
@@ -78,6 +90,28 @@ if [ "$(id -u)" -ne 0 ] && command -v sudo >/dev/null 2>&1; then
   SUDO="sudo"
 fi
 
+# repair_dpkg — clear a dpkg database left "interrupted" by a killed apt-get.
+#
+# #6064: a `timeout`-killed `apt-get install` poisons every later attempt, which
+# then exits 100 in seconds telling the reader to run this by hand. Nothing is
+# gated on the failure text — on a healthy system the command is a fast no-op,
+# and its own failure is reported but never fatal, because the retry it precedes
+# is still worth making.
+repair_dpkg() {
+  command -v dpkg >/dev/null 2>&1 || return 0
+
+  echo "ci-apt-install: running 'dpkg --configure -a' to clear any interrupted dpkg state before the next attempt." >&2
+  local rc=0
+  if [ -n "$TIMEOUT_BIN" ]; then
+    "$TIMEOUT_BIN" "$DPKG_REPAIR_TIMEOUT_S" ${SUDO:+"$SUDO"} dpkg --configure -a || rc=$?
+  else
+    ${SUDO:+"$SUDO"} dpkg --configure -a || rc=$?
+  fi
+  [ "$rc" -eq 0 ] ||
+    echo "ci-apt-install: 'dpkg --configure -a' exited ${rc}; retrying the phase regardless." >&2
+  return 0
+}
+
 # run_phase <label> <per-attempt-timeout-s> <apt-get args...>
 #
 # Returns 0 on the first attempt that succeeds; 1 once the attempts or the total
@@ -87,7 +121,7 @@ run_phase() {
   local label="$1" per_attempt="$2"
   shift 2
 
-  local attempt=1 rc=0 spent
+  local attempt=1 rc=0 spent delay=0 ceiling="$per_attempt"
   while [ "$attempt" -le "$ATTEMPTS" ]; do
     spent="$(elapsed)"
     if [ "$spent" -ge "$TOTAL_BUDGET_S" ]; then
@@ -95,10 +129,17 @@ run_phase() {
       return 1
     fi
 
-    echo "ci-apt-install: ${label}, attempt ${attempt}/${ATTEMPTS} (${spent}s elapsed, ${per_attempt}s ceiling)" >&2
+    # #6064: clamp the attempt to what is left of the total budget, so a late
+    # attempt cannot run the job past a ceiling only sampled between attempts.
+    ceiling="$per_attempt"
+    if [ "$ceiling" -gt $(( TOTAL_BUDGET_S - spent )) ]; then
+      ceiling=$(( TOTAL_BUDGET_S - spent ))
+    fi
+
+    echo "ci-apt-install: ${label}, attempt ${attempt}/${ATTEMPTS} (${spent}s elapsed, ${ceiling}s ceiling)" >&2
     rc=0
     if [ -n "$TIMEOUT_BIN" ]; then
-      "$TIMEOUT_BIN" "$per_attempt" ${SUDO:+"$SUDO"} "$@" || rc=$?
+      "$TIMEOUT_BIN" "$ceiling" ${SUDO:+"$SUDO"} "$@" || rc=$?
     else
       ${SUDO:+"$SUDO"} "$@" || rc=$?
     fi
@@ -109,16 +150,22 @@ run_phase() {
     fi
 
     if [ "$rc" -eq 124 ]; then
-      echo "ci-apt-install: ${label} attempt ${attempt} STALLED — killed at the ${per_attempt}s ceiling." >&2
+      echo "ci-apt-install: ${label} attempt ${attempt} STALLED — killed at the ${ceiling}s ceiling." >&2
     else
       echo "ci-apt-install: ${label} attempt ${attempt} failed (exit ${rc})." >&2
     fi
 
+    delay=$(( RETRY_DELAY_S * attempt ))
     attempt=$((attempt + 1))
-    [ "$attempt" -le "$ATTEMPTS" ] && sleep "$RETRY_DELAY_S"
+    if [ "$attempt" -le "$ATTEMPTS" ]; then
+      # #6064: repair before the retry, not after the phase — the poisoned
+      # attempts are the ones inside this loop.
+      repair_dpkg
+      [ "$delay" -gt 0 ] && sleep "$delay"
+    fi
   done
 
-  echo "::error::ci-apt-install: ${label} failed ${ATTEMPTS} time(s), last exit ${rc}, $(elapsed)s elapsed. Exit 124 means the mirror stalled and the attempt was killed at its ${per_attempt}s ceiling."
+  echo "::error::ci-apt-install: ${label} failed ${ATTEMPTS} time(s), last exit ${rc}, $(elapsed)s elapsed. Exit 124 means the mirror stalled and the attempt was killed at its ${ceiling}s ceiling."
   return 1
 }
 


### PR DESCRIPTION
## Outcome

Makes `ci-apt-install` recover an interrupted `dpkg` between retries, addressing the current `ci-red-main` failure class. Refs #6064.

## What changed / out of scope

A per-attempt timeout killing `apt` mid-unpack left `dpkg` interrupted, so retries 2 and 3 died instantly at exit 100. The total time budget was also only sampled before an attempt started, never clamped onto it. `repair_dpkg` now runs `dpkg --configure -a` between attempts (bounded to 120s, non-fatal, skipped where `dpkg` is absent); the per-attempt ceiling clamps to the remaining budget; retry backoff is linear.

Files: `scripts/ci-apt-install.sh`, `scripts/check-ci-helpers-selftest.sh`.

Out of scope: no Rust source touched.

## Risk

Low-Normal. CI helper script only; directly addresses the active `ci-red-main` (#5911) failure class.

## Test evidence

`bash -n` clean on both files. `shellcheck` exit 0 on the helper. A failure-path stub simulation shows the pre-change script exiting 1 after 3 dead retries versus the fixed script recovering on attempt 2. Self-test suite: 190/190 passing, including the new interrupted-dpkg case. This script is exercised on every PR via `ci.yml`'s `check-ci-helpers-selftest` step.

## Baseline failures

None — CI-helper-only change with no crate dependency.

## Docs / changelog status

CI-only change; changelog fragment exempt per the per-PR changelog gate.

## Review-finding disposition

None yet — trusty-review gate pending.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
