### PR TITLE
fix(trusty-mpm): doctor worktrees check uses reconciled inventory; remediation command now parses (Refs #5947)

### DIFF
--- a/crates/trusty-mpm/changelog.d/5947-doctor-worktree-orphans.md
+++ b/crates/trusty-mpm/changelog.d/5947-doctor-worktree-orphans.md
@@ -1,0 +1,3 @@
+Fixed
+- `tm doctor`'s `worktrees` check counted every git-registered worktree no live session claimed as an orphan, reporting 198 where `tm session prune-worktrees` and `tm session reconcile-worktrees` both found zero. It now reports the ORPHANED count from the reconciled inventory those two verbs already share, so an agent-owned, locked, dirty, or sentinel-less worktree is no longer called an orphan (#5947).
+- That check's remediation hint named `tm session prune --worktrees`, a flag that does not exist — `tm session prune` takes `--state` only. It now names `tm session prune-worktrees`, and a test parses the hint against the real CLI so a renamed flag cannot leave it pointing at nothing (#5947).

--- a/crates/trusty-mpm/src/bin/tm/generate/doctor.rs
+++ b/crates/trusty-mpm/src/bin/tm/generate/doctor.rs
@@ -213,7 +213,7 @@ mod tests {
     /// goes further by also asserting name equality, not just length.
     #[tokio::test]
     async fn doctor_checks_match_run_doctor_names() {
-        let report = run_doctor(None, None, &[]).await;
+        let report = run_doctor(None, None, &[], None).await;
         let actual: Vec<&str> = report.checks.iter().map(|c| c.name.as_str()).collect();
         let expected: Vec<&str> = DOCTOR_CHECKS.iter().map(|(name, _)| *name).collect();
         assert_eq!(

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_d_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_d_tests.rs
@@ -600,6 +600,27 @@ fn cli_prune_worktrees_discard_dirty_is_opt_in() {
     }
 }
 
+/// #5947: the command `tm doctor` hands the operator must parse on this CLI.
+///
+/// Why: doctor's worktrees hint said `tm session prune --worktrees` for as long
+/// as the check existed, and `tm session prune` has only ever taken `--state` —
+/// so the suggested fix errored out. Nothing connected the hint string to the
+/// parser, so nothing could notice. This test is that connection: it feeds
+/// doctor's own constant to the real `Cli` and fails if it no longer resolves.
+#[test]
+fn doctor_worktree_remediation_command_parses() {
+    let command = trusty_mpm::daemon::doctor::WORKTREE_REMEDIATION_COMMAND;
+    let cli = Cli::try_parse_from(command.split_whitespace()).unwrap_or_else(|e| {
+        panic!("`tm doctor`'s worktree remediation hint `{command}` does not parse: {e}")
+    });
+    match cli.command.unwrap() {
+        Command::Session {
+            action: SessionAction::PruneWorktrees { force, .. },
+        } => assert!(!force, "the hint must preview, never delete unasked"),
+        other => panic!("expected session prune-worktrees, got {other:?}"),
+    }
+}
+
 /// #2919: the merged-pull-request reclaim pass requires its own explicit flag.
 ///
 /// Why: it is the only reclaim path that acts on GitHub state, so an operator

--- a/crates/trusty-mpm/src/daemon/api.rs
+++ b/crates/trusty-mpm/src/daemon/api.rs
@@ -1797,11 +1797,14 @@ pub async fn doctor(
     // Derive the managed workspace root from config (same precedence as decommission).
     let config = crate::core::trusty_tools_config::TrustyToolsConfig::load();
     let repos_root = crate::core::trusty_tools_config::workspace_root(&config);
+    // #5947: the orphan count comes from the reconciled inventory — the same
+    // classification `prune-worktrees` and `reconcile-worktrees` share.
     Json(
         super::doctor::run_doctor(
             query.project.as_deref(),
             Some(&repos_root),
             &active_workspace_paths,
+            super::doctor::gather_worktree_counts(&mgr, &repos_root).await,
         )
         .await,
     )

--- a/crates/trusty-mpm/src/daemon/doctor.rs
+++ b/crates/trusty-mpm/src/daemon/doctor.rs
@@ -20,6 +20,15 @@ use std::time::Duration;
 use crate::core::doctor::{CheckStatus, DoctorCheck, DoctorReport};
 use crate::core::paths::FrameworkPaths;
 
+// Split out to keep this file under the 500-SLOC production cap (#5947 — the
+// worktrees probe now reads the reconciled inventory, and its counts type and
+// remediation constant came with it).
+#[path = "doctor_worktrees.rs"]
+mod doctor_worktrees;
+use doctor_worktrees::check_worktrees;
+pub(crate) use doctor_worktrees::gather_worktree_counts;
+pub use doctor_worktrees::{WORKTREE_REMEDIATION_COMMAND, WorktreeOrphanCounts};
+
 use super::discover::{TRUSTY_MEMORY_DEFAULT_ADDR, TRUSTY_SEARCH_DEFAULT_ADDR, discover_addr};
 
 // Split out to keep this file under the 500-SLOC production cap (DOC-28 R4(a)).
@@ -302,6 +311,9 @@ pub async fn run_doctor(
     project_dir: Option<&Path>,
     repos_root: Option<&Path>,
     active_workspace_paths: &[PathBuf],
+    // #5947: the caller gathers the reconciled inventory, so doctor reports the
+    // same orphan count `prune-worktrees` and `reconcile-worktrees` agree on.
+    worktree_counts: Option<WorktreeOrphanCounts>,
 ) -> DoctorReport {
     let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
     // #5867: only a project that IS a managed workspace gets the workspace
@@ -378,7 +390,7 @@ pub async fn run_doctor(
     // resolves the id `.mcp.json` actually pins, which is what every `search`
     // call in the session sends.
     checks.push(check_search_index_pin(&home, project_dir).await);
-    checks.push(check_worktrees(repos_root, active_workspace_paths).await);
+    checks.push(check_worktrees(repos_root, worktree_counts).await);
     // #2919: `check_worktrees` above counts ORPHANS and has never reported a
     // byte, so it read identically whether the worktree store held 4 GiB or the
     // 1.1 TiB measured on 2026-07-21. This is the disk half.
@@ -524,85 +536,6 @@ fn build_oauth_token_check(
             "oauth_token",
             CheckStatus::Ok,
             "managed-session auth looks configured",
-        )
-    }
-}
-
-/// Probe for orphaned per-session git worktrees under the managed workspace root.
-///
-/// Why: `decommission` now calls `git worktree remove` (#1840), but sessions
-/// that were decommissioned before this fix—or where `git worktree remove`
-/// failed—may leave stale `.worktrees/<session-id>/` directories on disk. This
-/// probe surfaces orphaned dirs so operators know to run
-/// `tm session prune --worktrees`. Discovery is delegated to
-/// [`crate::session_manager::prune::find_orphaned_worktrees`] inside
-/// `spawn_blocking` so the async executor is not blocked by the synchronous
-/// git subprocesses it spawns.
-/// What: builds a canonicalized active-path set, then spawns a blocking task
-/// that asks GIT for the worktrees of each managed project (#4207 — this is no
-/// longer a filesystem walk of `.worktrees/`, and a candidate is no longer "any
-/// leaf directory"): a git-registered worktree counts as an orphan when it is
-/// not main/bare/prunable/locked, IS a strict descendant of the project whose
-/// registry named it, and is absent from the active set. Reports `Ok` (no
-/// orphans), `Warn` (orphans found), or `Ok` (repos_root absent /
-/// unconfigured).
-///
-/// Note this probe is REPORT-ONLY — it counts, it never removes — so it
-/// deliberately reports candidates the reclaim path would refuse to delete
-/// (owner-unknown, dirty). Conversely a directory git does not register is not
-/// counted at all, so an unregistered husk is invisible here; reclaiming those
-/// is a separate open concern, deliberately out of scope for #4207.
-/// Test: `worktrees_no_orphans_is_ok`, `worktrees_with_orphan_is_warn`.
-async fn check_worktrees(
-    repos_root: Option<&Path>,
-    active_workspace_paths: &[PathBuf],
-) -> DoctorCheck {
-    let Some(root) = repos_root else {
-        // No managed workspace root configured — this is a normal state for
-        // operators who don't use in-project worktree sessions (#1840).
-        return DoctorCheck::new(
-            "worktrees",
-            CheckStatus::Ok,
-            "no managed workspace root configured — worktree scan skipped",
-        );
-    };
-    if !root.is_dir() {
-        return DoctorCheck::new(
-            "worktrees",
-            CheckStatus::Ok,
-            format!("{} does not exist — no worktrees to check", root.display()),
-        );
-    }
-
-    // Build a canonicalized HashSet for O(1) lookup and symlink safety (Fix 1b, #1840).
-    let root = root.to_path_buf();
-    let active_set: std::collections::HashSet<PathBuf> = active_workspace_paths
-        .iter()
-        .map(|p| std::fs::canonicalize(p).unwrap_or_else(|_| p.clone()))
-        .collect();
-
-    // Delegate the blocking scan to spawn_blocking so the async executor is not
-    // stalled (#1840 F). Since #4207 what blocks is not directory I/O but the
-    // git subprocesses `find_orphaned_worktrees` spawns per managed project.
-    let orphans = tokio::task::spawn_blocking(move || {
-        crate::session_manager::prune::find_orphaned_worktrees(&root, &active_set)
-    })
-    .await
-    .unwrap_or_else(|e| {
-        tracing::error!("doctor: worktree scan panicked: {e}");
-        Vec::new()
-    });
-
-    if orphans.is_empty() {
-        DoctorCheck::new("worktrees", CheckStatus::Ok, "no orphaned worktrees found")
-    } else {
-        DoctorCheck::new(
-            "worktrees",
-            CheckStatus::Warn,
-            format!(
-                "{} orphaned worktree dir(s) found — run `tm session prune --worktrees` to remove",
-                orphans.len()
-            ),
         )
     }
 }

--- a/crates/trusty-mpm/src/daemon/doctor_tests.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_tests.rs
@@ -104,7 +104,7 @@ async fn agents_check_probes_the_managed_config_tier_not_the_workspace() {
     // legitimately disagree. `doctor_fs_checks`'s `agents_*` tests cover every
     // status branch hermetically.
     let project = tempfile::tempdir().unwrap();
-    let report = run_doctor(Some(project.path()), None, &[]).await;
+    let report = run_doctor(Some(project.path()), None, &[], None).await;
     let agents_check = report
         .checks
         .iter()
@@ -150,7 +150,7 @@ async fn unmanaged_cwd_audits_the_operator_home_tier() {
     // Before the fix this asserted false: the message read
     // "<tmp>/.claude/skills does not exist".
     let project = tempfile::tempdir().unwrap();
-    let report = run_doctor(Some(project.path()), None, &[]).await;
+    let report = run_doctor(Some(project.path()), None, &[], None).await;
     let skills = report
         .checks
         .iter()
@@ -176,7 +176,7 @@ async fn a_registered_workspace_still_gets_the_workspace_layout() {
     // own populated `$HOME/.claude`.
     let project = tempfile::tempdir().unwrap();
     let active = vec![project.path().to_path_buf()];
-    let report = run_doctor(Some(project.path()), None, &active).await;
+    let report = run_doctor(Some(project.path()), None, &active, None).await;
     let skills = report
         .checks
         .iter()
@@ -352,7 +352,7 @@ async fn run_doctor_produces_thirty_two_checks() {
     // thirty-one).
     // #1905's stale-skill cleanup is deliberately NOT a `run_doctor` probe
     // — see the `run_doctor` doc.
-    let report = run_doctor(None, None, &[]).await;
+    let report = run_doctor(None, None, &[], None).await;
     let names: Vec<&str> = report.checks.iter().map(|c| c.name.as_str()).collect();
     let expected = [
         "instructions",
@@ -448,37 +448,93 @@ fn oauth_token_check_ok_when_not_relocated() {
     assert_eq!(check.status, CheckStatus::Ok);
 }
 
+/// Counts for `repos_root`, taken from the SHARED reconciled inventory (#5947).
+///
+/// Why: the whole point of the fix is that doctor no longer has its own orphan
+/// rule, so every worktree test here must feed it the same classification
+/// `prune-worktrees` and `reconcile-worktrees` read. Computing the counts any
+/// other way in a test would re-introduce the third implementation the fix
+/// removed, in the one place nobody would look for it.
+fn counts_for(repos_root: &std::path::Path) -> WorktreeOrphanCounts {
+    let report = crate::session_manager::worktree_reconcile::reconcile_worktrees(
+        repos_root,
+        &[],
+        &[],
+        chrono::Utc::now(),
+    );
+    WorktreeOrphanCounts::from_reconcile(&report)
+}
+
 #[tokio::test]
 async fn worktrees_no_repos_root_is_ok() {
     // Fix 7 (#1840): absence of a managed workspace root is NORMAL — not every
     // operator uses in-project worktree sessions. Return Ok, not Warn.
-    let check = check_worktrees(None, &[]).await;
+    let check = check_worktrees(None, None).await;
     assert_eq!(check.status, CheckStatus::Ok);
     assert!(check.message.contains("no managed workspace"));
 }
 
 #[tokio::test]
 async fn worktrees_no_orphans_is_ok() {
-    // #4207: a REAL `git worktree add`, since discovery is now derived from
-    // git's registry — a `mkdir` is not a candidate and would make this pass
-    // for the wrong reason. The fixture canonicalizes its own root, so the
-    // /tmp vs /private/tmp symlink hazard (#1845 item 2) is handled there.
+    // #4207: a REAL `git worktree add`, since discovery is derived from git's
+    // registry — a `mkdir` is not a candidate and would make this pass for the
+    // wrong reason. The fixture canonicalizes its own root, so the /tmp vs
+    // /private/tmp symlink hazard (#1845 item 2) is handled there.
     let fx = crate::session_manager::worktree_git_fixture::GitWorktreeFixture::new();
-    let wt = fx.add_worktree("session-abc");
-    let check = check_worktrees(Some(&fx.repos_root), &[wt]).await;
-    assert_eq!(check.status, CheckStatus::Ok);
+    let _wt = fx.add_worktree("session-abc");
+    let check = check_worktrees(Some(&fx.repos_root), Some(counts_for(&fx.repos_root))).await;
+    assert_eq!(check.status, CheckStatus::Ok, "{}", check.message);
+}
+
+#[tokio::test]
+async fn worktrees_unowned_worktree_is_not_an_orphan() {
+    // #5947 (fault 2): THE false positive. Two real worktrees, neither carrying
+    // an ownership sentinel. The old probe counted every git-registered
+    // worktree no live session claimed, so it warned "1 orphaned" here — and on
+    // the dogfood fleet, "198 orphaned" where `prune-worktrees` and
+    // `reconcile-worktrees` both found zero. A worktree with no sentinel is
+    // never auto-reclaimable, so it is not an orphan.
+    let fx = crate::session_manager::worktree_git_fixture::GitWorktreeFixture::new();
+    let _a = fx.add_worktree("session-live");
+    let _b = fx.add_worktree("session-dead");
+    let counts = counts_for(&fx.repos_root);
+    assert_eq!(counts.orphaned, 0, "reconcile must report zero orphans");
+    let check = check_worktrees(Some(&fx.repos_root), Some(counts)).await;
+    assert_eq!(check.status, CheckStatus::Ok, "{}", check.message);
+    assert!(check.message.contains("no orphaned worktrees found"));
 }
 
 #[tokio::test]
 async fn worktrees_with_orphan_is_warn() {
-    // #4207: two REAL worktrees; only one has an active session.
+    // A GENUINE orphan: admitted by git, sentinel names a provably-gone owner,
+    // tree clean — the same shape `clean_ownerless_admitted_worktree_is_orphaned`
+    // pins on the reconcile side.
     let fx = crate::session_manager::worktree_git_fixture::GitWorktreeFixture::new();
-    let live = fx.add_worktree("session-live");
-    let _dead = fx.add_worktree("session-dead");
-    let check = check_worktrees(Some(&fx.repos_root), &[live]).await;
-    assert_eq!(check.status, CheckStatus::Warn);
+    let _live = fx.add_worktree("session-live");
+    let dead = fx.add_worktree("session-dead");
+    crate::session_manager::worktree_git_fixture::GitWorktreeFixture::stamp_reclaimable_sentinel(
+        &dead,
+    );
+    let check = check_worktrees(Some(&fx.repos_root), Some(counts_for(&fx.repos_root))).await;
+    assert_eq!(check.status, CheckStatus::Warn, "{}", check.message);
     assert!(check.message.contains("1 orphaned"));
-    assert!(check.message.contains("tm session prune --worktrees"));
+    // #5947 (fault 1): the hint must name the verb that exists.
+    assert!(check.message.contains(WORKTREE_REMEDIATION_COMMAND));
+    assert!(
+        !check.message.contains("prune --worktrees"),
+        "the nonexistent flag must not come back: {}",
+        check.message
+    );
+}
+
+#[tokio::test]
+async fn worktrees_without_a_reconciled_inventory_is_unknown() {
+    // #5947: no inventory means no count. Reporting Ok would hide real orphans
+    // and Warn would invent them, so the probe says it could not observe.
+    let fx = crate::session_manager::worktree_git_fixture::GitWorktreeFixture::new();
+    let check = check_worktrees(Some(&fx.repos_root), None).await;
+    assert_eq!(check.status, CheckStatus::Unknown, "{}", check.message);
+    assert!(check.message.contains("not established"));
 }
 
 // ---- Issues #4005 / #4001: doctor must observe, not infer ----

--- a/crates/trusty-mpm/src/daemon/doctor_worktrees.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_worktrees.rs
@@ -1,0 +1,170 @@
+//! `tm doctor`'s `worktrees` probe — orphan count and its remediation hint.
+//!
+//! Why: split out of `doctor.rs` to keep that file under the 500-SLOC
+//! production cap when #5947 replaced the probe's own orphan heuristic with the
+//! reconciled inventory's classification.
+//! What: [`WORKTREE_REMEDIATION_COMMAND`], [`WorktreeOrphanCounts`],
+//! [`gather_worktree_counts`], and [`check_worktrees`].
+//! Test: `worktrees_no_orphans_is_ok`, `worktrees_unowned_worktree_is_not_an_orphan`,
+//! `worktrees_with_orphan_is_warn`, `worktrees_without_a_reconciled_inventory_is_unknown`
+//! (all in `doctor_tests.rs`), plus `doctor_worktree_remediation_command_parses`
+//! in the `tm` binary's CLI suite.
+
+use std::path::Path;
+
+use crate::core::doctor::{CheckStatus, DoctorCheck};
+use crate::session_manager::worktree_reconcile::ReconcileReport;
+
+/// The command `tm doctor` tells an operator to run when it finds orphaned
+/// worktrees (#5947).
+///
+/// Why: the hint used to read `tm session prune --worktrees`, and that flag has
+/// never existed — `tm session prune` takes `--state` only, so the suggested
+/// fix did not parse. A named constant is what lets the CLI's own clap parser
+/// assert the string still resolves, so a renamed or removed flag fails a test
+/// instead of silently leaving the hint pointing at nothing.
+/// What: the dry-run form of the real reclaim verb. It previews and removes
+/// nothing; `--force` is the operator's separate decision.
+/// Test: `doctor_worktree_remediation_command_parses` (in the `tm` binary's
+/// suite, against the real `Cli`), `worktrees_with_orphan_is_warn`.
+pub const WORKTREE_REMEDIATION_COMMAND: &str = "tm session prune-worktrees";
+
+/// The reconciled worktree inventory, reduced to the four numbers doctor
+/// reports (#5947).
+///
+/// Why: [`run_doctor`] is public and the reconciled report is crate-internal,
+/// so the check takes this instead — and taking only counts also makes the
+/// no-inventory case (`None`) explicit at the call site rather than something
+/// the probe has to infer.
+/// What: `orphaned` is the ONLY count that drives the verdict; the other three
+/// are report text, so an operator can see how many worktrees were examined and
+/// why the rest were spared.
+/// Test: `worktrees_unowned_worktree_is_not_an_orphan`,
+/// `worktrees_with_orphan_is_warn`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct WorktreeOrphanCounts {
+    /// Every worktree the inventory classified.
+    pub total: usize,
+    /// Classified LIVE — some signal vetoes reclamation.
+    pub live: usize,
+    /// Classified UNKNOWN — not established as reclaimable, so not an orphan.
+    pub unknown: usize,
+    /// Classified ORPHANED — the count doctor warns on.
+    pub orphaned: usize,
+}
+
+impl WorktreeOrphanCounts {
+    /// Reduce a reconciled inventory to the counts doctor reports (#5947).
+    pub(crate) fn from_reconcile(report: &ReconcileReport) -> Self {
+        Self {
+            total: report.counts.total,
+            live: report.counts.live,
+            unknown: report.counts.unknown,
+            orphaned: report.counts.orphaned,
+        }
+    }
+}
+
+/// Gather the reconciled worktree counts for [`run_doctor`] (#5947).
+///
+/// Why: the inventory needs the session store and live tmux panes, which only
+/// the manager has — and a failure to gather it must reach doctor as `None`
+/// (reported `Unknown`) rather than as a zero that would read as healthy.
+/// What: runs the same report-only reconciliation `tm session
+/// reconcile-worktrees` serves, reduced to counts. Reads only.
+/// Test: `worktrees_unowned_worktree_is_not_an_orphan` covers the classification
+/// this feeds; `doctor_endpoint_returns_report` covers the wiring.
+pub(crate) async fn gather_worktree_counts(
+    mgr: &crate::session_manager::SessionManager,
+    repos_root: &Path,
+) -> Option<WorktreeOrphanCounts> {
+    match mgr.reconcile_worktree_inventory(repos_root).await {
+        Ok(report) => Some(WorktreeOrphanCounts::from_reconcile(&report)),
+        Err(e) => {
+            tracing::error!("doctor: worktree inventory unavailable: {e}");
+            None
+        }
+    }
+}
+
+/// Probe for orphaned per-session git worktrees under the managed workspace root.
+///
+/// Why: `decommission` now calls `git worktree remove` (#1840), but sessions
+/// that were decommissioned before this fix—or where `git worktree remove`
+/// failed—may leave stale `.worktrees/<session-id>/` directories on disk. This
+/// probe surfaces orphaned dirs so operators know to reclaim them.
+///
+/// #5947: it used to count orphans itself, as "every git-registered worktree
+/// under a managed project that no live session lists as its workspace". That
+/// is not what an orphan is, and it reported 198 of them on a fleet where
+/// `tm session prune-worktrees` and `tm session reconcile-worktrees` both found
+/// zero — because a worktree owned by a running agent, locked by the operator,
+/// holding unsaved work, or carrying no ownership sentinel at all is not
+/// reclaimable and never was. Doctor now reads the SAME classification those
+/// two verbs share
+/// ([`crate::session_manager::worktree_reconcile::reconcile_worktrees`]) and
+/// reports its `ORPHANED` count, so a third independent answer to "is this
+/// worktree an orphan" no longer exists.
+/// What: reports `Ok` (no managed workspace root, or root absent), `Unknown`
+/// (the reconciled inventory could not be gathered — a count was never
+/// established, so neither `Ok` nor `Warn` would be honest), `Ok` (zero
+/// orphans, with the LIVE/UNKNOWN split so the operator can see what was
+/// examined), or `Warn` naming [`WORKTREE_REMEDIATION_COMMAND`].
+///
+/// Still REPORT-ONLY — it counts, it never removes.
+/// Test: `worktrees_no_orphans_is_ok`,
+/// `worktrees_unowned_worktree_is_not_an_orphan`, `worktrees_with_orphan_is_warn`,
+/// `worktrees_without_a_reconciled_inventory_is_unknown`.
+pub(super) async fn check_worktrees(
+    repos_root: Option<&Path>,
+    reconcile: Option<WorktreeOrphanCounts>,
+) -> DoctorCheck {
+    let Some(root) = repos_root else {
+        // No managed workspace root configured — this is a normal state for
+        // operators who don't use in-project worktree sessions (#1840).
+        return DoctorCheck::new(
+            "worktrees",
+            CheckStatus::Ok,
+            "no managed workspace root configured — worktree scan skipped",
+        );
+    };
+    if !root.is_dir() {
+        return DoctorCheck::new(
+            "worktrees",
+            CheckStatus::Ok,
+            format!("{} does not exist — no worktrees to check", root.display()),
+        );
+    }
+    // #5947: no inventory means no count — say so rather than reporting a
+    // number nothing produced.
+    let Some(counts) = reconcile else {
+        return DoctorCheck::new(
+            "worktrees",
+            CheckStatus::Unknown,
+            "worktree inventory unavailable — orphan count not established; run \
+             `tm session reconcile-worktrees`",
+        );
+    };
+
+    if counts.orphaned == 0 {
+        DoctorCheck::new(
+            "worktrees",
+            CheckStatus::Ok,
+            format!(
+                "no orphaned worktrees found ({} worktree(s) examined: {} live, {} not \
+                 reclaimable — `tm session reconcile-worktrees` explains each)",
+                counts.total, counts.live, counts.unknown
+            ),
+        )
+    } else {
+        DoctorCheck::new(
+            "worktrees",
+            CheckStatus::Warn,
+            format!(
+                "{} orphaned worktree dir(s) found — run `{WORKTREE_REMEDIATION_COMMAND}` to \
+                 preview, then `--force` to remove",
+                counts.orphaned
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## Outcome

Fixes the doctor worktrees check to use the reconciled worktree inventory instead of its own orphan heuristic, and fixes the printed remediation command so it actually parses. Refs #5947.

## What changed / out of scope

Two defects.

(a) `check_worktrees` counted orphans with its own heuristic — git-registered worktrees minus live-session workspaces — ignoring ownership, lock, and sentinel state, so agent-owned worktrees read as orphans (fixture: old heuristic reported 2 orphans, the reconciled inventory reports 0). Doctor now sources its counts from `session_manager::worktree_reconcile`, the same classification `prune`/`reconcile` already use, with an `Unknown` state when the inventory can't be gathered.

(b) The printed remediation command `tm session prune --worktrees` doesn't parse. It's now the constant `WORKTREE_REMEDIATION_COMMAND = "tm session prune-worktrees"`, with a CLI test asserting it parses.

Files: `daemon/doctor.rs`, `daemon/doctor_worktrees.rs` (new — split out to hold the file under the 500-SLOC cap), `daemon/api.rs`, `daemon/doctor_tests.rs`, `bin/tm/tests_behavior_d_tests.rs`, `bin/tm/generate/doctor.rs`, `changelog.d/5947-doctor-worktree-orphans.md`.

Out of scope: doctor's other checks are untouched.

## Risk

Normal. Doctor reporting path only.

## Test evidence

Rung 3. `cargo fmt --check`, `cargo check -p trusty-mpm`, `cargo clippy -p trusty-mpm --all-targets -- -D warnings` clean. `cargo test -p trusty-mpm -- --skip guided_fallback` exit 0: lib 5193 passed/0 failed, bin `tm` 1762 passed, 46 integration targets ok. Line-cap check: 0 violations. Changelog fragment valid. SLD clean. New regression tests: `worktrees_unowned_worktree_is_not_an_orphan`, `worktrees_without_a_reconciled_inventory_is_unknown`, `doctor_worktree_remediation_command_parses`.

## Baseline failures

`guided_fallback_*` tests deadlock on `origin/main` — canonical issue #6070. This branch does not touch those test files.

## Docs / changelog status

Changelog fragment present at `crates/trusty-mpm/changelog.d/5947-doctor-worktree-orphans.md`; check green.

## Review-finding disposition

None yet — trusty-review gate pending.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
