### PR TITLE
fix(trusty-mpm): launch no longer walks the real $HOME stripping hooks — unhangs guided_fallback tests (Refs #6070, Refs #5875)

### DIFF
--- a/.test-pointer-allowlist.tsv
+++ b/.test-pointer-allowlist.tsv
@@ -445,7 +445,6 @@ crates/trusty-mpm/src/core/sm/goals/store.rs	note_appends_and_persists
 crates/trusty-mpm/src/core/sm/goals/store.rs	update_appends_note
 crates/trusty-mpm/src/core/sm/goals/store.rs	update_sets_state_and_evidence
 crates/trusty-mpm/src/core/sm/providers/resolve.rs	resolve_tests
-crates/trusty-mpm/src/core/standalone/hooks/mod.rs	test_remove_global_trusty_mpm_hooks_removes_only_mpm_entries
 crates/trusty-mpm/src/core/standalone/registry.rs	test_alias_validation
 crates/trusty-mpm/src/core/standalone/run.rs	test_check_credentials_with_env_var
 crates/trusty-mpm/src/core/trusty_tools_config.rs	config_dir_is_trusty_mpm

--- a/crates/trusty-mpm/changelog.d/6070-guided-fallback-deadlock.md
+++ b/crates/trusty-mpm/changelog.d/6070-guided-fallback-deadlock.md
@@ -1,0 +1,23 @@
+Fixed
+
+- `tm launch` no longer walks the entire home directory before starting a
+  session ([#5875](https://github.com/bobmatnyc/trusty-tools/issues/5875),
+  [#6070](https://github.com/bobmatnyc/trusty-tools/issues/6070)). Step 8 calls
+  `remove_global_trusty_mpm_hooks`, which reached `~/.claude/settings.json` and
+  `~/.claude/settings.local.json` by recursing eight levels into `$HOME`. On a
+  real developer machine one `opendir()` inside that walk blocked indefinitely,
+  so the launch never returned; a stack sample showed 2328 of 2328 samples in a
+  single `open$NOCANCEL`. The strip now names the two global files directly.
+  Project settings files elsewhere under `$HOME` are no longer rewritten as a
+  side effect of launching — `tm hooks clean` owns that machine-wide sweep, the
+  same split `tm install` adopted in #2940.
+- The eight `guided_fallback_*` tests in `--bin tm` terminate again. They drive
+  `launch()` end to end, so they inherited the hang, and because they hold the
+  process-wide `serial_test` lock while stuck they starved every other
+  `#[serial]` test in the binary — which is why `cargo test -p trusty-mpm`
+  needed `--skip guided_fallback` to complete at all. That workaround is no
+  longer required.
+- `remove_global_trusty_mpm_hooks_at` takes the home directory as a parameter,
+  which gives the removal path its first real test coverage. Four doc comments
+  cited `test_remove_global_trusty_mpm_hooks_removes_only_mpm_entries`, a test
+  that did not exist.

--- a/crates/trusty-mpm/src/bin/tm/commands/launch.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/launch.rs
@@ -249,6 +249,8 @@ pub(crate) async fn launch(
 
     // 8. Write project-scoped MPM hooks into the managed clone (NOT the live checkout).
     //    Both steps are best-effort — a failure is logged but never fatal.
+    // #5875: this strips the two `~/.claude/settings*.json` files only. It used
+    // to walk the whole `$HOME` tree here, which blocked a launch indefinitely.
     if let Err(e) = crate::commands::install::remove_global_trusty_mpm_hooks() {
         eprintln!("warning: could not remove global MPM hooks: {e:#}");
     }

--- a/crates/trusty-mpm/src/core/standalone/hooks/mod.rs
+++ b/crates/trusty-mpm/src/core/standalone/hooks/mod.rs
@@ -10,13 +10,14 @@
 //! What: [`mpm_hook_command`] resolves the absolute binary path (falling back to
 //! the bare name when resolution fails); [`mpm_hook_additions`] returns the hook
 //! triad JSON block; [`ensure_managed_hooks`] reads `<claude_config_dir>/settings.json`,
-//! deep-merges the triad idempotently, and writes back; [`remove_global_trusty_mpm_hooks`]
-//! strips MPM hook entries from all global settings files; [`write_project_hooks`]
-//! writes project-scoped hooks into a given settings file.
+//! deep-merges the triad idempotently, and writes back;
+//! [`remove_global_trusty_mpm_hooks_at`] strips MPM hook entries from the two
+//! global settings files; [`write_project_hooks`] writes project-scoped hooks
+//! into a given settings file.
 //! Test: `test_ensure_managed_hooks_writes_triad`,
 //! `test_ensure_managed_hooks_is_idempotent`,
 //! `test_hook_command_uses_absolute_path`,
-//! `test_remove_global_trusty_mpm_hooks_removes_only_mpm_entries`,
+//! `remove_global_hooks_at_strips_only_the_two_global_files`,
 //! `test_write_project_hooks_targets_project_dir`,
 //! `test_is_mpm_hook_command_recognises_tm_bin_name`,
 //! `test_write_project_hooks_replaces_stale_exe_path_group`,
@@ -331,7 +332,7 @@ fn is_mpm_hash_suffixed_artifact(path: &Path) -> bool {
 /// `"/opt/bin/trusty-mpm hook"`) OR the full prefix is recognised by
 /// [`is_mpm_hash_suffixed_artifact`] (hash-suffixed build artifacts under a
 /// `deps/` directory — `".../deps/trusty_mpm-<hash> hook"`).
-/// Test: `test_remove_global_trusty_mpm_hooks_removes_only_mpm_entries`,
+/// Test: `remove_global_hooks_at_strips_only_the_two_global_files`,
 /// `test_is_mpm_hook_command_recognises_tm_bin_name`,
 /// `test_is_mpm_hook_command_recognises_stale_hash_and_mvp_variants`,
 /// `test_is_mpm_hook_command_rejects_hash_suffixed_binary_outside_deps_dir`,
@@ -383,26 +384,67 @@ pub fn is_claude_mpm_hook_command(cmd: &str) -> bool {
     lower.contains("claude-mpm") || lower.contains("claude_mpm")
 }
 
-/// Strip trusty-mpm hook entries from every global Claude settings file.
+/// The two GLOBAL Claude settings files under `home`.
+///
+/// Why (#5875, #6070): Claude Code reads exactly `~/.claude/settings.json` and
+/// `~/.claude/settings.local.json` as the user's GLOBAL settings. Everything
+/// else a `$HOME` walk reaches is a PROJECT file that the project itself owns.
+/// Naming the two paths directly costs two `open()` calls; discovering them by
+/// recursive walk costs the whole home tree, and that walk is what
+/// [`remove_global_trusty_mpm_hooks`] used to pay on every `tm launch`.
+/// What: joins the two well-known file names under `<home>/.claude` without
+/// touching the filesystem — existence is decided by the caller's read.
+/// Test: `remove_global_hooks_at_strips_only_the_two_global_files`.
+fn global_settings_files(home: &Path) -> Vec<PathBuf> {
+    let claude = home.join(".claude");
+    vec![
+        claude.join("settings.json"),
+        claude.join("settings.local.json"),
+    ]
+}
+
+/// Strip trusty-mpm hook entries from the global Claude settings files.
 ///
 /// Why: after switching from global hooks to project-scoped hooks, any
 /// previously installed global hook triad must be cleaned up so it does not
 /// fire in unrelated projects. This mirrors the `remove_global_trusty_memory_hooks`
 /// pattern from trusty-memory — strip first, then write project-scoped hooks.
-/// What: discovers all `.claude/settings*.json` files under `$HOME` via
-/// [`trusty_common::claude_config::discover_claude_settings`], and for each file
-/// removes any hook group whose `command` field matches a trusty-mpm hook pattern
-/// (see [`is_mpm_hook_command`]). Writes back atomically only when something
-/// actually changed. Returns the count of files modified.
-/// Test: `test_remove_global_trusty_mpm_hooks_removes_only_mpm_entries`.
+/// What: resolves the home directory and delegates to
+/// [`remove_global_trusty_mpm_hooks_at`].
+/// Test: `remove_global_hooks_at_strips_only_the_two_global_files`,
+/// `remove_global_hooks_at_ignores_project_settings_below_home`.
 pub fn remove_global_trusty_mpm_hooks() -> anyhow::Result<usize> {
-    use trusty_common::claude_config::{
-        default_settings_max_depth, discover_claude_settings, write_json_atomic,
-    };
-
     let home =
         dirs::home_dir().ok_or_else(|| anyhow::anyhow!("could not resolve home directory"))?;
-    let files = discover_claude_settings(&home, default_settings_max_depth());
+    remove_global_trusty_mpm_hooks_at(&home)
+}
+
+/// [`remove_global_trusty_mpm_hooks`] against an explicit home directory.
+///
+/// Why (#5875): the no-argument form resolved the real `$HOME` and recursively
+/// walked it to depth 8, so `launch()` step 8 paid an O(entire home tree) scan
+/// on every session start. On a real developer machine one `opendir()` inside
+/// that walk blocked indefinitely, hanging `tm launch` — and every test that
+/// drives it, which is how the eight `guided_fallback_*` tests came to run
+/// forever (#6070). Issue #2940 already made this call for the WRITE side:
+/// `tm install` stopped walking `$HOME` and writes only the managed config dir,
+/// leaving the machine-wide sweep to the explicit, user-invoked `tm hooks
+/// clean`. This is the symmetric fix for the REMOVE side. Taking `home` as a
+/// parameter is also what makes the behaviour testable at all — every `Test:`
+/// line in this module previously named a test that did not exist, because the
+/// only entry point read a process-global.
+/// What: for each of [`global_settings_files`], removes every hook group whose
+/// `command` matches a trusty-mpm hook pattern (see [`is_mpm_hook_command`]) and
+/// writes the file back atomically only when something actually changed.
+/// Missing, empty, unparseable, and non-object files are skipped silently.
+/// Returns the count of files modified. PROJECT settings files under `home` are
+/// deliberately NOT touched — `tm hooks clean` owns that sweep.
+/// Test: `remove_global_hooks_at_strips_only_the_two_global_files`,
+/// `remove_global_hooks_at_ignores_project_settings_below_home`.
+pub fn remove_global_trusty_mpm_hooks_at(home: &Path) -> anyhow::Result<usize> {
+    use trusty_common::claude_config::write_json_atomic;
+
+    let files = global_settings_files(home);
 
     let mut changed = 0usize;
     for path in &files {
@@ -436,7 +478,7 @@ pub fn remove_global_trusty_mpm_hooks() -> anyhow::Result<usize> {
 /// (issue #2940's `tm hooks clean`), and tests.
 /// What: delegates to [`strip_mpm_hook_entries_for_events`] with `events =
 /// None`, which strips MPM-owned groups from every event key present.
-/// Test: `test_remove_global_trusty_mpm_hooks_removes_only_mpm_entries`.
+/// Test: `remove_global_hooks_at_strips_only_the_two_global_files`.
 pub fn strip_mpm_hook_entries(val: &mut serde_json::Value) -> bool {
     strip_mpm_hook_entries_for_events(val, None)
 }
@@ -454,7 +496,7 @@ pub fn strip_mpm_hook_entries(val: &mut serde_json::Value) -> bool {
 /// MPM group per event survives regardless of exe-path churn.
 /// What: delegates to [`strip_hook_entries_matching_for_events`] with
 /// [`is_mpm_hook_command`] as the predicate.
-/// Test: `test_remove_global_trusty_mpm_hooks_removes_only_mpm_entries`,
+/// Test: `remove_global_hooks_at_strips_only_the_two_global_files`,
 /// `test_write_project_hooks_replaces_stale_exe_path_group`,
 /// `test_strip_mpm_hook_entries_removes_only_tm_entry_from_mixed_group`.
 fn strip_mpm_hook_entries_for_events(
@@ -489,7 +531,7 @@ fn strip_mpm_hook_entries_for_events(
 /// event key emptied of all groups is removed. Groups with a non-array/absent
 /// `hooks` field (unrecognised shape) are always retained untouched. Returns
 /// `true` if anything was removed.
-/// Test: `test_remove_global_trusty_mpm_hooks_removes_only_mpm_entries`,
+/// Test: `remove_global_hooks_at_strips_only_the_two_global_files`,
 /// `test_write_project_hooks_replaces_stale_exe_path_group`,
 /// `test_strip_mpm_hook_entries_removes_only_tm_entry_from_mixed_group`.
 pub(crate) fn strip_hook_entries_matching_for_events(

--- a/crates/trusty-mpm/src/core/standalone/hooks/tests.rs
+++ b/crates/trusty-mpm/src/core/standalone/hooks/tests.rs
@@ -847,3 +847,121 @@ fn test_write_project_hooks_replaces_stale_exe_path_group() {
         );
     }
 }
+
+/// Plant a settings file at `path` carrying one tm hook group and one foreign
+/// group under `PreToolUse`.
+///
+/// Why: both `remove_global_trusty_mpm_hooks_at` tests need the same shape — a
+/// file where a correct strip is visibly distinguishable both from a wholesale
+/// wipe and from no write at all.
+/// What: creates the parent directory and writes the two-group JSON.
+/// Test: used by `remove_global_hooks_at_strips_only_the_two_global_files` and
+/// `remove_global_hooks_at_ignores_project_settings_below_home`.
+fn plant_mixed_settings(path: &Path) {
+    std::fs::create_dir_all(path.parent().expect("settings path has a parent"))
+        .expect("settings parent dir creatable");
+    let json = serde_json::json!({
+        "hooks": {
+            "PreToolUse": [
+                { "hooks": [ { "type": "command", "command": "/opt/bin/trusty-mpm hook" } ] },
+                { "hooks": [ { "type": "command", "command": "/usr/bin/other-tool run" } ] }
+            ]
+        }
+    });
+    std::fs::write(
+        path,
+        serde_json::to_string_pretty(&json).expect("json serialises"),
+    )
+    .expect("settings file writable");
+}
+
+/// Every `PreToolUse` command still present in the settings file at `path`.
+fn pre_tool_use_commands(path: &Path) -> Vec<String> {
+    let text = std::fs::read_to_string(path).expect("settings file readable");
+    let val: serde_json::Value = serde_json::from_str(&text).expect("settings file parses");
+    val["hooks"]["PreToolUse"]
+        .as_array()
+        .expect("PreToolUse is an array")
+        .iter()
+        .filter_map(|g| g["hooks"][0]["command"].as_str().map(str::to_string))
+        .collect()
+}
+
+/// Why (#5875, #6070): the removal path must strip tm's own hook groups from
+/// both global settings files and leave every foreign group in place.
+/// What: plants a mixed file at `<home>/.claude/settings.json` and another at
+/// `<home>/.claude/settings.local.json`, runs the strip against that home, and
+/// asserts two files changed and only the foreign command survives in each.
+#[test]
+fn remove_global_hooks_at_strips_only_the_two_global_files() {
+    let home = TempDir::new().expect("tempdir");
+    let global = home.path().join(".claude").join("settings.json");
+    let global_local = home.path().join(".claude").join("settings.local.json");
+    plant_mixed_settings(&global);
+    plant_mixed_settings(&global_local);
+
+    let changed = remove_global_trusty_mpm_hooks_at(home.path()).expect("strip succeeds");
+
+    assert_eq!(changed, 2, "both global settings files carried a tm group");
+    for path in [&global, &global_local] {
+        assert_eq!(
+            pre_tool_use_commands(path),
+            vec!["/usr/bin/other-tool run".to_string()],
+            "only the foreign group may survive in {}",
+            path.display()
+        );
+    }
+}
+
+/// Why (#5875): this is the regression test for the hang. Before the fix the
+/// removal path reached its targets by a depth-8 recursive walk of the whole
+/// home tree, so it rewrote every PROJECT settings file on the machine and paid
+/// an unbounded scan to find them — the `opendir()` that blocked `tm launch`,
+/// and with it the eight `guided_fallback_*` tests, forever. `tm hooks clean`
+/// owns the machine-wide sweep (#2940); this path must not.
+/// What: plants a project settings file three levels below `home` carrying the
+/// same tm hook group as the global file, strips, and asserts the project file
+/// is byte-identical afterwards while the global file was still cleaned.
+#[test]
+fn remove_global_hooks_at_ignores_project_settings_below_home() {
+    let home = TempDir::new().expect("tempdir");
+    let global = home.path().join(".claude").join("settings.json");
+    let project = home
+        .path()
+        .join("code")
+        .join("acme")
+        .join("widget")
+        .join(".claude")
+        .join("settings.json");
+    plant_mixed_settings(&global);
+    plant_mixed_settings(&project);
+    let project_before = std::fs::read_to_string(&project).expect("project settings readable");
+
+    let changed = remove_global_trusty_mpm_hooks_at(home.path()).expect("strip succeeds");
+
+    assert_eq!(changed, 1, "only the global settings file may be rewritten");
+    assert_eq!(
+        std::fs::read_to_string(&project).expect("project settings still readable"),
+        project_before,
+        "a project settings file below home must be left untouched: {}",
+        project.display()
+    );
+    assert_eq!(
+        pre_tool_use_commands(&global),
+        vec!["/usr/bin/other-tool run".to_string()],
+        "the global file must still have its tm group stripped"
+    );
+}
+
+/// Why (#5875): a home with no `.claude` directory is the common case on a
+/// machine that never carried legacy global hooks. `launch()` calls this on
+/// every session start, so it must be a silent no-op rather than an error.
+/// What: strips against an empty tempdir and asserts `Ok(0)`.
+#[test]
+fn remove_global_hooks_at_reports_zero_when_no_global_settings_exist() {
+    let home = TempDir::new().expect("tempdir");
+    assert_eq!(
+        remove_global_trusty_mpm_hooks_at(home.path()).expect("strip succeeds"),
+        0
+    );
+}


### PR DESCRIPTION
## Outcome

Fixes #6070 (eight `guided_fallback_*` tests hang, starving `serial_test` peers) and #5875 (`launch()` hangs on unbounded real-`$HOME` walk) — one root cause. `launch()` step 8's `remove_global_trusty_mpm_hooks` recursed eight levels into the real `$HOME` via `discover_claude_settings`; stack sampling showed 2328/2328 samples inside that walk with `serial_test`'s lock held above the hang. Now scoped to the two global files via new `remove_global_trusty_mpm_hooks_at(home)` (the injection-seam shape #6089 recommends). Symmetric completion of #2940, which removed the same walk from the write side.

## What changed

- `hooks/mod.rs` — new `global_settings_files(home)` + `_at` seam
- `launch.rs` — call-site now passes the resolved home through the seam
- `hooks/tests.rs` — 3 new tests (regression: a project settings file three levels below home is byte-identical after the strip)
- changelog fragment

Out of scope: #6089 (trusty-agents, a genuinely different two-lock race) and dropping `--skip guided_fallback` from docs (follow-up).

**Behavior change for reviewer attention:** `tm launch` no longer cleans legacy tm hooks out of project settings files machine-wide — that is `tm hooks clean`'s job only (the #2940 boundary). Previously every real launch also rewrote project settings files across the machine (the stray `.claude/settings.json.bak-*` files are that side effect).

## Risk

Normal-High — launch path, but the change removes traversal only; fail behavior unchanged for the two global files.

## Test evidence

Rung 3, full suite restored.

- `guided_fallback` target: green 5 consecutive runs (12 passed each, 4.7-14.7s)
- `cargo test -p trusty-mpm`, no `--skip`: 9103 passed / 0 failed / 18 ignored across 50 targets
- `fmt --check` / `cargo check` / `cargo clippy` clean
- line-cap: 0 violations
- SLD: clean
- changelog-fragment check: OK

## Baseline

One pre-existing 1-in-6 flake, `worktree_name_collides_detects_existing_dir_and_branch`, reproduced green twice at `origin/main` baseline — unrelated to this change. Disposition with ticketing.

## Changelog

`crates/trusty-mpm/changelog.d/6070-guided-fallback-deadlock.md` present and valid.

## Review-finding disposition

trusty-review gate pending.

Refs #6070
Refs #5875

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
