### PR TITLE
fix(trusty-audit): ground a manifest that outlived its child (#6081)

### DIFF
--- a/crates/trusty-audit/changelog.d/6099-grounding-failopen.md
+++ b/crates/trusty-audit/changelog.d/6099-grounding-failopen.md
@@ -1,0 +1,2 @@
+Fixed
+- A sweep now grounds every repository whose `tga audit` child left a manifest, rather than only those whose child exited 0. A child that failed at a later stage — a render whose synthesis failed, for instance — still wrote the manifest, and gating on its exit status skipped the `inspect_priority` ranking together with the gap line that would have said so. The failure the grounding legs promise to name always was named; the skip that stopped them running never was.

--- a/crates/trusty-audit/src/run.rs
+++ b/crates/trusty-audit/src/run.rs
@@ -618,12 +618,17 @@ async fn run_one(
     // trusty-analyze, and write the ranking into the manifest the child just
     // wrote — the interface trusty-review's investigation pass reads (#6078).
     // It runs AFTER the child because the manifest is what it edits and the
-    // child is what writes it, and only on a success because a repository with
-    // no manifest has nothing to ground. Fail-open: a leg that degrades adds a
-    // gap line here and in the manifest, never a failed repository.
-    if result.succeeded() {
+    // child is what writes it, and it asks for that FILE rather than for the
+    // child's exit status: a child that failed at a later stage still left a
+    // manifest, and re-rendering it is the documented recovery. Gating on the
+    // status skipped grounding for exactly that repository, and skipped its gap
+    // with it. A repository with no manifest has nothing to ground and nothing
+    // to write a gap into — its recorded failure is the trace. Fail-open: a leg
+    // that degrades adds a gap line here and in the manifest, never a failed
+    // repository.
+    let manifest = output.join(AuditManifest::FILE_NAME);
+    if manifest.is_file() {
         let tools = grounding::Tools::pinned(binaries.search.clone(), binaries.analyze.clone());
-        let manifest = output.join(AuditManifest::FILE_NAME);
         gaps.extend(grounding::ground_manifest(&manifest, &tools, &checkout, &repo.name).await);
     }
     progress.unit_finished(
@@ -1019,6 +1024,13 @@ trusty-review = "0.15.1"
              printf '[report]\\ntitle = \"Acme\"\\n{gaps}\\n[[repositories]]\\n\
              name = \"acme\"\\npath = \"/r\"\\n' > \"$out/manifest.toml\"\nexit 0\n"
         )
+    }
+
+    /// A stub `tga` shaped like the child of the 2026-08-19 dogfood run: it
+    /// writes the manifest a real one would, and THEN fails — the shape of a
+    /// render stage that failed after everything before it was collected.
+    fn writes_a_manifest_then_fails() -> String {
+        writes_a_manifest(None).replace("\nexit 0\n", "\nexit 1\n")
     }
 
     /// A stub `trusty-search` that approves whatever it is asked to approve.
@@ -2046,6 +2058,45 @@ trusty-review = "0.15.1"
         assert!(
             report.repos[0].gaps.iter().any(|g| g.contains("jira sync")),
             "the gap must be surfaced: {:?}",
+            report.repos[0].gaps
+        );
+    }
+
+    /// 🔴 #6081: a child that failed AFTER writing its manifest must still be
+    /// grounded, and must still say so.
+    ///
+    /// Why: the dogfood sweep of 2026-08-19. `tga audit` wrote the manifest,
+    /// then its render stage failed on a truncated LLM response and the child
+    /// exited 1. The call site asked the child's EXIT STATUS whether there was a
+    /// manifest to ground, so grounding never ran — and because it never ran, it
+    /// stated no gap either. No `inspect_priority`, no gap, no log line: the one
+    /// combination `crate::grounding`'s "degrade, never silently" contract says
+    /// cannot happen. The manifest survives that failure and re-rendering it is
+    /// the documented recovery, so it is the file, not the status, that decides.
+    /// What: a stub that writes the manifest and then exits 1. The repository
+    /// still fails, and its manifest still carries a ranking or a named gap.
+    /// Test: this is the test. Against `origin/main` the final assertion fails —
+    /// `gaps` is empty and the manifest declares no `inspect_priority`.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_child_that_fails_after_writing_a_manifest_is_still_grounded() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        install_stubs(&work, &writes_a_manifest_then_fails());
+        make_repo(&work, "acme-api");
+        select(&work, &[("acme-api", "repos/acme-api")]);
+
+        let report = sweep(&work, &config(), &RunOptions::default(), &Progress::none())
+            .await
+            .expect("a failing child is a recorded failure, not an error");
+
+        assert_eq!(report.status, RunStatus::AllFailed, "{report:?}");
+        let manifest = std::fs::read_to_string(report.repos[0].output.join("manifest.toml"))
+            .expect("the manifest the child wrote survives its failure");
+        assert!(
+            !report.repos[0].gaps.is_empty() || manifest.contains("inspect_priority"),
+            "grounding must leave a ranking or a named gap on a manifest that outlived its \
+             child, never neither: gaps={:?}\n{manifest}",
             report.repos[0].gaps
         );
     }


### PR DESCRIPTION
## Root cause

The 2026-08-19 dogfood sweep produced a manifest with no `inspect_priority` and no grounding gap. #6098's grounding legs never ran.

`run_one` gated the grounding call on the tga child's exit status (`crates/trusty-audit/src/run.rs:624`, pre-fix):

```rust
if result.succeeded() {
    let tools = grounding::Tools::pinned(...);
    let manifest = output.join(AuditManifest::FILE_NAME);
    gaps.extend(grounding::ground_manifest(&manifest, &tools, &checkout, &repo.name).await);
}
```

In that run the child wrote its manifest, then failed at its render stage — `trusty-review report` exited 1 on a truncated LLM response — so `spawn_tga` returned `RepoResult::Failed` and the block never ran. The `audit index repositories [ok]` line in the run log is tga's own `repo_index` step, not this crate's grounding; grounding emits no progress line at all, which is why the skip left no trace anywhere.

The comment justified the gate as "only on a success because a repository with no manifest has nothing to ground", but a non-zero exit does not mean there is no manifest. The child's own failure message says as much: "the manifest ... survives this, so once the cause is addressed re-run just the render". A manifest that outlives its child is exactly the one a re-render will read, and it was the one guaranteed never to be grounded.

That is a fail-open skip: `crate::grounding`'s contract is that every degradation is named twice, in the run's gaps and in the manifest's `[report].gaps`. A leg that never runs names nothing. `verify_output` reaching `Err` with a manifest on disk (a failed `collect` stage, for instance) took the same path.

## Fix

Ask for the file, not the status. `crates/trusty-audit/src/run.rs:624-633` now grounds whenever `<output>/manifest.toml` exists. A repository with no manifest has nothing to ground and nothing to write a gap into — its recorded failure is the trace.

## Regression test

`run::run_tests::a_child_that_fails_after_writing_a_manifest_is_still_grounded` — a stub tga that writes the manifest and then exits 1. Against the pre-fix call site:

```
running 1 test
test run::run_tests::a_child_that_fails_after_writing_a_manifest_is_still_grounded ... FAILED

thread '...' panicked at crates/trusty-audit/src/run.rs:2096:9:
grounding must leave a ranking or a named gap on a manifest that outlived its child, never neither: gaps=[]
[report]
title = "Acme"

[[repositories]]
name = "acme"
path = "/r"

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 589 filtered out
```

That panic is the dogfood anomaly reproduced: empty gaps, no `inspect_priority`.

## Gates — ladder rung 3

```
cargo fmt --check                                     FMT_EXIT=0
cargo clippy -p trusty-audit --all-targets -D warnings CLIPPY_EXIT=0
cargo test -p trusty-audit                            585 passed; 0 failed; 5 ignored (lib)
                                                      3 / 5 / 4 / 4 / 9 passed across the 5 integration targets
scripts/check_line_cap.sh                             0 violations
scripts/check_changelog_fragment.sh                   OK
scripts/check_sld.sh                                  0 errors
```

## Out of scope, reported not fixed

Grounding runs after the whole tga child, and tga renders the report inside that child. So even on the success path the sweep's own report is rendered before `inspect_priority` is written — the ranking reaches only a later `trusty-audit render` or the recipient's re-render. Closing that gap means changing where tga's render sits relative to the manifest write, which is a tga change, not a trusty-audit one.

Refs #6081

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
