### PR TITLE
fix(trusty-search,trusty-analyze): corpus read failures propagate instead of asserting an empty corpus (Refs #6043, Refs #5917)

### DIFF
--- a/crates/trusty-analyze/changelog.d/6043-zero-complexity-scores.md
+++ b/crates/trusty-analyze/changelog.d/6043-zero-complexity-scores.md
@@ -1,0 +1,9 @@
+Fixed
+
+The chunk export now walks trusty-search's cursor pagination (`?after=`) rather
+than offset pagination, and refuses an export that falls short of the `total`
+the daemon reports. Offset mode reads trusty-search's in-memory chunk cache — a
+map that is evicted after 300s idle, rehydrated on a detached task the request
+does not wait for, and capped by `TRUSTY_MAX_CHUNKS` — so a cold or unreadable
+corpus answered HTTP 200 with an empty page and every analyze endpoint then
+asserted a confident zero. Refs #6043, #5917.

--- a/crates/trusty-analyze/src/core/client.rs
+++ b/crates/trusty-analyze/src/core/client.rs
@@ -6,8 +6,7 @@
 //! obvious and lets us swap to a different transport later if needed.
 
 use crate::types::CodeChunk;
-use anyhow::{Context, Result};
-use futures_util::stream::{FuturesOrdered, StreamExt};
+use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
@@ -15,10 +14,8 @@ use std::time::Duration;
 /// page at 1000 chunks.
 const CHUNK_PAGE_LIMIT: usize = 1000;
 
-/// Number of chunk pages to fetch concurrently. Sized to match the connection
-/// pool depth so the HTTP/2 multiplexed stream stays saturated without
-/// queueing requests on the client side.
-const CHUNK_PAGE_CONCURRENCY: usize = 4;
+/// Connection-pool depth for the loopback HTTP/2 client.
+const CONNECTION_POOL_DEPTH: usize = 4;
 
 /// Summary of one registered index.
 ///
@@ -39,8 +36,7 @@ pub struct IndexSummary {
 }
 
 /// HTTP/2 client for trusty-search (port 7878).
-/// Uses `http2_prior_knowledge` (loopback, no TLS) for low-latency multiplexed
-/// chunk paging. Pool depth matches page concurrency (4).
+/// Uses `http2_prior_knowledge` (loopback, no TLS) for low-latency chunk paging.
 ///
 /// Cheap to clone — internally a `reqwest::Client` (which is already an `Arc`
 /// under the hood).
@@ -60,7 +56,7 @@ impl TrustySearchClient {
         }
         let http = reqwest::ClientBuilder::new()
             .tcp_keepalive(Duration::from_secs(60))
-            .pool_max_idle_per_host(CHUNK_PAGE_CONCURRENCY)
+            .pool_max_idle_per_host(CONNECTION_POOL_DEPTH)
             .http2_prior_knowledge() // both processes are on 127.0.0.1, no TLS needed
             .timeout(Duration::from_secs(30))
             .connect_timeout(Duration::from_secs(5))
@@ -179,49 +175,69 @@ impl TrustySearchClient {
     /// `GET /indexes/:id/chunks` — bulk export of every chunk for `index_id`.
     /// Trusty-search must expose this endpoint (added as part of issue #40).
     ///
-    /// Pipelines page fetches concurrently (window of `CHUNK_PAGE_CONCURRENCY`)
-    /// using `?offset=&limit=` (server caps each page at 1000). Pages are
-    /// returned in order to preserve a stable corpus iteration order.
+    /// Why (#6043): this used to page with `?offset=&limit=`, and that mode
+    /// reads trusty-search's *in-memory* chunk map — a cache the search daemon
+    /// evicts after 300s idle and rehydrates on a detached background task that
+    /// the request does not wait for. `total` in that mode is the map's length,
+    /// so an index whose corpus is cold, still rehydrating, or unreadable
+    /// answers HTTP 200 with `total: 0` and an empty page. The analyzer read
+    /// that as a complete, empty corpus and every downstream endpoint then
+    /// asserted a confident zero: `complexity_distribution` reported
+    /// `total: 0, skipped_non_code: 0` for an index holding 50,929 chunks. The
+    /// offset map is also capped by `TRUSTY_MAX_CHUNKS`, so even a warm index
+    /// exports fewer chunks than it holds.
+    ///
+    /// What: walks the cursor mode (`?after=&limit=`) instead, which seeks the
+    /// durable redb corpus directly and reports `total` from it, then refuses to
+    /// return a walk that fell short of that `total`. A response that carries no
+    /// `total` makes no completeness claim and is returned as-is. Pages are
+    /// sequential because each one needs the previous page's cursor; the seek is
+    /// O(page), against offset mode's O(N log N) re-sort of the whole corpus.
+    ///
+    /// Test: `cursor_walk_collects_every_page`,
+    /// `short_export_against_reported_total_is_an_error`,
+    /// `export_without_total_makes_no_completeness_claim`.
     pub async fn get_chunks(&self, index_id: &str) -> Result<Vec<CodeChunk>> {
         let base = format!("{}/indexes/{}/chunks", self.base_url, index_id);
 
         let mut all_chunks: Vec<CodeChunk> = Vec::new();
-        let mut next_offset: usize = 0;
-        let mut exhausted = false;
+        // An empty cursor means "start from the first chunk" — trusty-search
+        // treats `after=` as present-but-unset, which is how cursor mode is
+        // selected at all. Omitting the parameter would fall back to offset.
+        let mut cursor = String::new();
+        let mut reported_total: Option<usize> = None;
 
-        // Fetch in concurrent windows: launch up to CHUNK_PAGE_CONCURRENCY page
-        // requests in parallel, drain them in order, repeat until any page
-        // comes back short (signaling we've hit the end of the corpus).
-        while !exhausted {
-            let mut window: FuturesOrdered<_> = (0..CHUNK_PAGE_CONCURRENCY)
-                .map(|i| {
-                    let offset = next_offset + i * CHUNK_PAGE_LIMIT;
-                    fetch_chunk_page(&self.http, &base, offset, CHUNK_PAGE_LIMIT)
-                })
-                .collect();
-
-            let mut window_consumed: usize = 0;
-            while let Some(page) = window.next().await {
-                let page = page?;
-                let received = page.len();
-                all_chunks.extend(page);
-                window_consumed += 1;
-                // Short page (or empty page) means the server has no more
-                // chunks beyond this offset — stop scheduling more windows.
-                if received < CHUNK_PAGE_LIMIT {
-                    exhausted = true;
-                    // Drain any in-flight pages already issued (they're
-                    // ordered, so the rest will also be short/empty), but
-                    // do not start a new window.
-                    while let Some(extra) = window.next().await {
-                        all_chunks.extend(extra?);
-                    }
-                    break;
-                }
+        loop {
+            let page = fetch_chunk_page(&self.http, &base, &cursor, CHUNK_PAGE_LIMIT).await?;
+            if let Some(total) = page.total {
+                reported_total = Some(total);
             }
+            let received = page.chunks.len();
+            all_chunks.extend(page.chunks);
 
-            if !exhausted {
-                next_offset += window_consumed * CHUNK_PAGE_LIMIT;
+            let Some(next) = page.next_cursor.filter(|c| !c.is_empty()) else {
+                break;
+            };
+            // A cursor that repeats, or one offered alongside an empty page,
+            // cannot advance the walk. Stop rather than spin — the shortfall
+            // check below is what turns that into a reported failure.
+            if received == 0 || next == cursor {
+                break;
+            }
+            cursor = next;
+        }
+
+        // #6043: a short export must not pass as the whole corpus.
+        if let Some(total) = reported_total {
+            if all_chunks.len() < total {
+                bail!(
+                    "index '{index_id}': chunk export is incomplete — trusty-search reports \
+                     {total} chunks but the cursor walk returned {}. The corpus is cold, \
+                     still rehydrating, or unreadable; analysis over this partial corpus \
+                     would understate every metric, so it is refused rather than reported \
+                     as a result (see #6043, #5917)",
+                    all_chunks.len()
+                );
             }
         }
 
@@ -229,30 +245,42 @@ impl TrustySearchClient {
     }
 }
 
-/// Fetch a single chunk page. Extracted to a free function so it can be
-/// collected into a `FuturesOrdered` without capturing `&self` in the future.
+/// One page of `GET /indexes/:id/chunks` in cursor mode.
+///
+/// `total` and `next_cursor` are optional so a stub (or an older daemon) that
+/// answers with `chunks` alone still deserializes — an absent `total` is read as
+/// "this response makes no claim about the corpus size", never as zero.
+#[derive(Deserialize)]
+struct ChunksPage {
+    chunks: Vec<CodeChunk>,
+    #[serde(default)]
+    total: Option<usize>,
+    #[serde(default)]
+    next_cursor: Option<String>,
+}
+
+/// Fetch a single chunk page at `cursor`. Free function so the future borrows
+/// only the client, not the whole `TrustySearchClient`.
 async fn fetch_chunk_page(
     http: &reqwest::Client,
     base_url: &str,
-    offset: usize,
+    cursor: &str,
     limit: usize,
-) -> Result<Vec<CodeChunk>> {
-    #[derive(Deserialize)]
-    struct ChunksBody {
-        chunks: Vec<CodeChunk>,
-    }
-    let url = format!("{base_url}?offset={offset}&limit={limit}");
-    let body: ChunksBody = http
-        .get(&url)
+) -> Result<ChunksPage> {
+    let limit = limit.to_string();
+    let req = http
+        .get(base_url)
+        .query(&[("after", cursor), ("limit", limit.as_str())]);
+    let page: ChunksPage = req
         .send()
         .await
-        .with_context(|| format!("GET {url}"))?
+        .with_context(|| format!("GET {base_url}?after={cursor}"))?
         .error_for_status()
-        .with_context(|| format!("non-2xx from {url}"))?
+        .with_context(|| format!("non-2xx from {base_url}?after={cursor}"))?
         .json()
         .await
-        .with_context(|| format!("decode {url}"))?;
-    Ok(body.chunks)
+        .with_context(|| format!("decode {base_url}?after={cursor}"))?;
+    Ok(page)
 }
 
 #[cfg(test)]
@@ -289,6 +317,87 @@ mod tests {
         assert_eq!(listing.indexes[0].root_path.as_deref(), Some("/src/myapp"));
         assert_eq!(listing.indexes[1].id, "idx2");
         assert!(listing.indexes[1].root_path.is_none());
+    }
+
+    /// Spawn a stub trusty-search answering `GET /indexes/:id/chunks` with a
+    /// fixed body, and return its base URL.
+    async fn spawn_chunks_stub(body: serde_json::Value) -> String {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let app = axum::Router::new().route(
+            "/indexes/{id}/chunks",
+            axum::routing::get(move || {
+                let body = body.clone();
+                async move { axum::Json(body) }
+            }),
+        );
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.ok();
+        });
+        format!("http://{addr}")
+    }
+
+    fn chunk_json(id: &str) -> serde_json::Value {
+        serde_json::json!({
+            "id": id, "file": "src/lib.rs", "start_line": 1, "end_line": 2,
+            "content": "fn f() {}", "score": 0.0, "match_reason": "enumerate"
+        })
+    }
+
+    /// #6043: the exact response the live daemon served for the `trusty-tools`
+    /// index — `total: 50929` beside zero rows and `next_cursor: null`.
+    ///
+    /// Why: the walk reads `next_cursor: null` as "corpus exhausted", so before
+    /// this fix `get_chunks` returned `Ok(vec![])` and
+    /// `complexity_distribution` scored an empty corpus and published
+    /// `total: 0, skipped_non_code: 0` — a confident, wrong measurement of a
+    /// 50,929-chunk index.
+    /// What: asserts the shortfall against the server's own `total` is an error
+    /// naming both numbers.
+    /// Test: this function IS the test.
+    #[tokio::test]
+    async fn short_export_against_reported_total_is_an_error() {
+        let base = spawn_chunks_stub(serde_json::json!({
+            "index_id": "trusty-tools", "total": 50929,
+            "chunks": [], "next_cursor": null
+        }))
+        .await;
+        let err = TrustySearchClient::new(base)
+            .get_chunks("trusty-tools")
+            .await
+            .expect_err("a zero-row export against total: 50929 must not pass as the corpus");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("50929") && msg.contains("incomplete"),
+            "the error must name the shortfall, got: {msg}"
+        );
+    }
+
+    /// A response with no `total` makes no completeness claim, so there is
+    /// nothing to check it against — the export is returned as-is.
+    #[tokio::test]
+    async fn export_without_total_makes_no_completeness_claim() {
+        let base = spawn_chunks_stub(serde_json::json!({ "chunks": [chunk_json("a:1:2")] })).await;
+        let chunks = TrustySearchClient::new(base)
+            .get_chunks("idx")
+            .await
+            .expect("no total means no claim to verify");
+        assert_eq!(chunks.len(), 1);
+    }
+
+    /// A complete single-page export satisfies the reported total.
+    #[tokio::test]
+    async fn cursor_walk_accepts_a_complete_export() {
+        let base = spawn_chunks_stub(serde_json::json!({
+            "total": 2, "next_cursor": null,
+            "chunks": [chunk_json("a:1:2"), chunk_json("b:1:2")]
+        }))
+        .await;
+        let chunks = TrustySearchClient::new(base)
+            .get_chunks("idx")
+            .await
+            .expect("a complete export is accepted");
+        assert_eq!(chunks.len(), 2);
     }
 
     #[test]

--- a/crates/trusty-analyze/src/core/client.rs
+++ b/crates/trusty-analyze/src/core/client.rs
@@ -194,8 +194,17 @@ impl TrustySearchClient {
     /// sequential because each one needs the previous page's cursor; the seek is
     /// O(page), against offset mode's O(N log N) re-sort of the whole corpus.
     ///
+    /// `total` is taken from the most recent page that carried one. During a
+    /// concurrent reindex the count can move between pages, so a corpus that
+    /// shrinks mid-walk can report a shortfall that is really a mutation. That
+    /// is the intended bias: a report computed over a corpus that changed under
+    /// the walk is wrong either way, and an error tells the caller to retry.
+    ///
     /// Test: `cursor_walk_collects_every_page`,
+    /// `cursor_walk_accepts_a_complete_export`,
     /// `short_export_against_reported_total_is_an_error`,
+    /// `walk_truncated_after_the_first_page_is_an_error`,
+    /// `repeated_cursor_stops_the_walk_instead_of_spinning`,
     /// `export_without_total_makes_no_completeness_claim`.
     pub async fn get_chunks(&self, index_id: &str) -> Result<Vec<CodeChunk>> {
         let base = format!("{}/indexes/{}/chunks", self.base_url, index_id);
@@ -286,6 +295,7 @@ async fn fetch_chunk_page(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
 
     #[test]
     fn index_summary_deserializes_with_and_without_root_path() {
@@ -319,22 +329,55 @@ mod tests {
         assert!(listing.indexes[1].root_path.is_none());
     }
 
-    /// Spawn a stub trusty-search answering `GET /indexes/:id/chunks` with a
-    /// fixed body, and return its base URL.
-    async fn spawn_chunks_stub(body: serde_json::Value) -> String {
+    /// Spawn a cursor-aware stub trusty-search and return its base URL.
+    ///
+    /// Why: a stub that answers every request with the same body cannot
+    /// exercise a cursor walk at all — the loop's continuation, its
+    /// no-progress guard, and the post-walk shortfall check all stay dark
+    /// while the tests still pass. Keying the response on `after=` is what
+    /// makes a multi-page walk observable.
+    /// What: `pages` maps the `after` cursor value a request carries (`""` for
+    /// the first page) to the body to answer it with. An unmapped cursor is a
+    /// test bug, so it answers 500 rather than an empty page that would look
+    /// like a clean end of corpus.
+    /// Test: used by every `get_chunks` test below.
+    async fn spawn_chunks_stub(pages: Vec<(&'static str, serde_json::Value)>) -> String {
+        let pages: std::collections::HashMap<String, serde_json::Value> =
+            pages.into_iter().map(|(k, v)| (k.to_string(), v)).collect();
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let app = axum::Router::new().route(
             "/indexes/{id}/chunks",
-            axum::routing::get(move || {
-                let body = body.clone();
-                async move { axum::Json(body) }
-            }),
+            axum::routing::get(
+                move |axum::extract::Query(q): axum::extract::Query<HashMap<String, String>>| {
+                    let pages = pages.clone();
+                    async move {
+                        let cursor = q.get("after").cloned().unwrap_or_default();
+                        match pages.get(&cursor) {
+                            Some(body) => Ok(axum::Json(body.clone())),
+                            None => Err((
+                                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                                format!("stub has no page for cursor {cursor:?}"),
+                            )),
+                        }
+                    }
+                },
+            ),
         );
         tokio::spawn(async move {
             axum::serve(listener, app).await.ok();
         });
         format!("http://{addr}")
+    }
+
+    /// One page body: `chunks` for the given ids, plus `total` and the cursor
+    /// to follow (`None` ends the walk).
+    fn page(total: usize, ids: &[&str], next_cursor: Option<&str>) -> serde_json::Value {
+        serde_json::json!({
+            "total": total,
+            "chunks": ids.iter().map(|i| chunk_json(i)).collect::<Vec<_>>(),
+            "next_cursor": next_cursor,
+        })
     }
 
     fn chunk_json(id: &str) -> serde_json::Value {
@@ -357,10 +400,13 @@ mod tests {
     /// Test: this function IS the test.
     #[tokio::test]
     async fn short_export_against_reported_total_is_an_error() {
-        let base = spawn_chunks_stub(serde_json::json!({
-            "index_id": "trusty-tools", "total": 50929,
-            "chunks": [], "next_cursor": null
-        }))
+        let base = spawn_chunks_stub(vec![(
+            "",
+            serde_json::json!({
+                "index_id": "trusty-tools", "total": 50929,
+                "chunks": [], "next_cursor": null
+            }),
+        )])
         .await;
         let err = TrustySearchClient::new(base)
             .get_chunks("trusty-tools")
@@ -377,7 +423,11 @@ mod tests {
     /// nothing to check it against — the export is returned as-is.
     #[tokio::test]
     async fn export_without_total_makes_no_completeness_claim() {
-        let base = spawn_chunks_stub(serde_json::json!({ "chunks": [chunk_json("a:1:2")] })).await;
+        let base = spawn_chunks_stub(vec![(
+            "",
+            serde_json::json!({ "chunks": [chunk_json("a:1:2")] }),
+        )])
+        .await;
         let chunks = TrustySearchClient::new(base)
             .get_chunks("idx")
             .await
@@ -388,16 +438,93 @@ mod tests {
     /// A complete single-page export satisfies the reported total.
     #[tokio::test]
     async fn cursor_walk_accepts_a_complete_export() {
-        let base = spawn_chunks_stub(serde_json::json!({
-            "total": 2, "next_cursor": null,
-            "chunks": [chunk_json("a:1:2"), chunk_json("b:1:2")]
-        }))
-        .await;
+        let base = spawn_chunks_stub(vec![("", page(2, &["a:1:2", "b:1:2"], None))]).await;
         let chunks = TrustySearchClient::new(base)
             .get_chunks("idx")
             .await
             .expect("a complete export is accepted");
         assert_eq!(chunks.len(), 2);
+    }
+
+    /// The walk follows `next_cursor` across every page and stops on the page
+    /// that offers none.
+    ///
+    /// Why: a corpus larger than one page is the ordinary case — the live
+    /// `trusty-tools` index is 51 pages at the 1000-row server cap — and none
+    /// of the loop's continuation was exercised while the stub answered every
+    /// request identically. A walk that silently stopped after page one would
+    /// have looked correct in every other test here.
+    /// What: three pages chained by cursor, asserting all rows arrive exactly
+    /// once and in order.
+    /// Test: this function IS the test.
+    #[tokio::test]
+    async fn cursor_walk_collects_every_page() {
+        let base = spawn_chunks_stub(vec![
+            ("", page(5, &["a:1:2", "b:1:2"], Some("b:1:2"))),
+            ("b:1:2", page(5, &["c:1:2", "d:1:2"], Some("d:1:2"))),
+            ("d:1:2", page(5, &["e:1:2"], None)),
+        ])
+        .await;
+        let chunks = TrustySearchClient::new(base)
+            .get_chunks("idx")
+            .await
+            .expect("a three-page walk completes");
+        let ids: Vec<&str> = chunks.iter().map(|c| c.id.as_str()).collect();
+        assert_eq!(
+            ids,
+            vec!["a:1:2", "b:1:2", "c:1:2", "d:1:2", "e:1:2"],
+            "every page's rows arrive exactly once, in walk order"
+        );
+    }
+
+    /// A multi-page walk that dies partway is a shortfall, not a short corpus.
+    ///
+    /// Why: `chunks_after` turns a mid-walk redb read failure into an empty
+    /// page with `next_cursor: null`, which is bit-identical to a clean end of
+    /// corpus. Page one succeeding is what makes this the insidious shape — the
+    /// client has rows in hand and no reason to doubt them.
+    /// What: page one returns 2 of 5 rows, page two returns the empty
+    /// end-of-corpus shape. Asserts the walk refuses rather than returning 2.
+    /// Test: this function IS the test.
+    #[tokio::test]
+    async fn walk_truncated_after_the_first_page_is_an_error() {
+        let base = spawn_chunks_stub(vec![
+            ("", page(5, &["a:1:2", "b:1:2"], Some("b:1:2"))),
+            ("b:1:2", page(5, &[], None)),
+        ])
+        .await;
+        let err = TrustySearchClient::new(base)
+            .get_chunks("idx")
+            .await
+            .expect_err("2 of 5 rows must not pass as the whole corpus");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("5 chunks") && msg.contains("returned 2"),
+            "the error must name both numbers, got: {msg}"
+        );
+    }
+
+    /// A server that keeps handing back the cursor it was given must not spin.
+    ///
+    /// Why: the walk advances only because the cursor is exclusive and strictly
+    /// increasing. A daemon that repeats it — a bug, or a corpus mutating under
+    /// the walk — would otherwise loop forever inside a request handler.
+    /// What: a page whose `next_cursor` equals the cursor that fetched it. The
+    /// guard breaks the loop and the shortfall check reports it, so the test
+    /// terminating at all is half the assertion.
+    /// Test: this function IS the test.
+    #[tokio::test]
+    async fn repeated_cursor_stops_the_walk_instead_of_spinning() {
+        let base = spawn_chunks_stub(vec![
+            ("", page(9, &["a:1:2"], Some("a:1:2"))),
+            ("a:1:2", page(9, &["a:1:2"], Some("a:1:2"))),
+        ])
+        .await;
+        let err = TrustySearchClient::new(base)
+            .get_chunks("idx")
+            .await
+            .expect_err("a non-advancing cursor is a failed walk, not a complete one");
+        assert!(format!("{err:#}").contains("incomplete"), "got: {err:#}");
     }
 
     #[test]

--- a/crates/trusty-analyze/src/service/tests.rs
+++ b/crates/trusty-analyze/src/service/tests.rs
@@ -622,7 +622,10 @@ async fn spawn_mixed_corpus_search() -> String {
             move |axum::extract::Query(q): axum::extract::Query<HashMap<String, String>>| {
                 let body = body.clone();
                 async move {
-                    let first = q.get("offset").map(|o| o == "0").unwrap_or(true);
+                    let first = q
+                        .get("after")
+                        .map(|c: &String| c.is_empty())
+                        .unwrap_or(true);
                     axum::response::Json(if first {
                         body
                     } else {
@@ -821,7 +824,7 @@ async fn spawn_chunk_search_with_corpus() -> String {
         axum::routing::get(
             |q: axum::extract::Query<HashMap<String, String>>| async move {
                 let q = q.0;
-                if q.get("offset").map(String::as_str) != Some("0") {
+                if !q.get("after").map(String::as_str).unwrap_or("").is_empty() {
                     return axum::response::Json(serde_json::json!({ "chunks": [] }));
                 }
                 let bodies = [

--- a/crates/trusty-search/changelog.d/6043-chunk-enumeration-fail-open.md
+++ b/crates/trusty-search/changelog.d/6043-chunk-enumeration-fail-open.md
@@ -1,0 +1,11 @@
+Fixed
+
+`GET /indexes/{id}/chunks` no longer reports a failed corpus read as an empty
+index. Both enumeration paths absorbed the failure: the cursor path turned a
+redb read error into an empty page with `next_cursor: null`, which a paging
+client reads as "corpus exhausted", and the offset path reported the in-memory
+chunk map's length as `total` even when a rehydrate had not committed. An index
+holding 50,929 chunks exported zero of them at HTTP 200, and trusty-analyze
+scored the empty corpus and published `complexity_distribution total: 0`. Both
+paths now return `503 index_corpus_unavailable` with `retryable: true`. Refs
+#6043, #5917.

--- a/crates/trusty-search/changelog.d/6043-chunk-enumeration-fail-open.md
+++ b/crates/trusty-search/changelog.d/6043-chunk-enumeration-fail-open.md
@@ -7,5 +7,8 @@ client reads as "corpus exhausted", and the offset path reported the in-memory
 chunk map's length as `total` even when a rehydrate had not committed. An index
 holding 50,929 chunks exported zero of them at HTTP 200, and trusty-analyze
 scored the empty corpus and published `complexity_distribution total: 0`. Both
-paths now return `503 index_corpus_unavailable` with `retryable: true`. Refs
-#6043, #5917.
+paths now return `503 index_corpus_unavailable` with `retryable: true`. The
+offset path waits out a slow rehydrate first, retrying on the same
+`REHYDRATE_RACE_RETRIES` budget the BM25 and grep lanes use (~27s at the
+defaults), so a large cold index that simply takes 27-40s to rehydrate serves
+its corpus rather than erroring. Refs #6043, #5917.

--- a/crates/trusty-search/src/core/indexer/files.rs
+++ b/crates/trusty-search/src/core/indexer/files.rs
@@ -8,7 +8,8 @@
 //! Test: covered by `test_remove_chunk_removes_from_results`,
 //! `test_entity_exact_match_*` in `indexer::tests`.
 
-use anyhow::Result;
+use anyhow::{Context, Result};
+use std::sync::atomic::Ordering;
 
 use crate::core::chunker::RawChunk;
 use crate::core::entity::EntityType;
@@ -80,13 +81,40 @@ impl CodeIndexer {
     /// `(total_chunks, page)` so the caller can serialize the `total` field
     /// without a second pass.
     /// Test: `test_enumerate_chunks_paginates_stable_order` indexes a couple of
-    /// files, pages through them, and asserts no overlap and full coverage.
-    pub async fn enumerate_chunks(&self, offset: usize, limit: usize) -> (usize, Vec<CodeChunk>) {
+    /// files, pages through them, and asserts no overlap and full coverage;
+    /// `enumerate_chunks_errors_when_rehydrate_did_not_commit` covers the
+    /// #6043 refusal.
+    ///
+    /// Errors when the in-memory map is not a view of the corpus — see the
+    /// guard below.
+    pub async fn enumerate_chunks(
+        &self,
+        offset: usize,
+        limit: usize,
+    ) -> Result<(usize, Vec<CodeChunk>)> {
         self.ensure_chunks_loaded().await;
+        // #6043: the map this page is sliced from is a CACHE, not the corpus.
+        // `ensure_chunks_loaded` waits on a bounded budget and returns whether
+        // or not the detached rehydrate committed, and the rehydrate task
+        // reports a redb read failure only to the log. `chunks_evicted` stays
+        // set on every path that did not commit, so reading it here is the one
+        // place the caller can tell "this index holds nothing" apart from
+        // "this map has not been filled". Reporting `chunks.len()` as `total`
+        // across that gap is what published `total: 0` for an index holding
+        // 50,929 chunks and let trusty-analyze score an empty corpus.
+        if self.chunks_evicted.load(Ordering::Relaxed) {
+            anyhow::bail!(
+                "index '{}': the in-memory chunk map was evicted and has not been \
+                 repopulated — the durable corpus read either failed or is still in \
+                 flight, so enumerating it now would report a partial corpus as the \
+                 whole one (see #6043, #5917). Retry once the rehydrate commits.",
+                self.index_id
+            );
+        }
         let chunks = self.chunks.read().await;
         let total = chunks.len();
         if limit == 0 || offset >= total {
-            return (total, Vec::new());
+            return Ok((total, Vec::new()));
         }
         let mut ordered: Vec<&RawChunk> = chunks.values().collect();
         ordered.sort_by(|a, b| {
@@ -101,7 +129,7 @@ impl CodeIndexer {
             .iter()
             .map(|raw| raw_to_code_chunk(raw, 0.0, "enumerate", None, &root))
             .collect();
-        (total, page)
+        Ok((total, page))
     }
 
     /// Cursor-paginate the chunk corpus in ascending `chunk_id` order, doing an
@@ -126,34 +154,55 @@ impl CodeIndexer {
     /// `after`. `next_cursor` is `Some(last_id)` when a full `limit`-sized page
     /// was returned (more rows may follow) and `None` once the page is short
     /// (end reached) — so a client loops until `next_cursor` is `None`.
-    /// Test: `test_enumerate_chunks_after_cursor_pages_via_redb` and
-    /// `test_enumerate_chunks_after_cursor_in_memory_fallback`.
+    /// Test: `test_enumerate_chunks_after_cursor_pages_via_redb`,
+    /// `test_enumerate_chunks_after_cursor_in_memory_fallback`, and
+    /// `cursor_page_read_failure_is_an_error_not_an_empty_page` (#6043).
+    ///
+    /// Errors when the durable corpus cannot be read — see the #6043 note on
+    /// the failure arms below.
     pub async fn enumerate_chunks_after(
         &self,
         after: Option<&str>,
         limit: usize,
-    ) -> (usize, Vec<CodeChunk>, Option<String>) {
+    ) -> Result<(usize, Vec<CodeChunk>, Option<String>)> {
         let root = self.root_path.clone();
         // Durable path: indexed seek over redb, no full-corpus materialization.
         if let Some(corpus) = self.corpus.clone() {
-            let total = corpus.chunk_count().unwrap_or(0);
+            // #6043: the count and the rows must fail together. Reading the
+            // count through `unwrap_or(0)` while the rows below returned an
+            // empty page produced the worst of both — `total: 50929` beside
+            // zero rows and `next_cursor: null`, which a paging client reads
+            // as "the corpus is exhausted", not as "the read failed".
+            let total = corpus
+                .chunk_count()
+                .with_context(|| format!("index '{}': chunk count read failed", self.index_id))?;
             if limit == 0 || total == 0 {
-                return (total, Vec::new(), None);
+                return Ok((total, Vec::new(), None));
             }
             let after_owned = after.map(str::to_string);
             let raws = tokio::task::spawn_blocking(move || {
                 corpus.chunks_after(after_owned.as_deref(), limit)
             })
             .await;
+            // #6043: both arms used to `warn` and return an empty page with
+            // `next_cursor: None`. That is indistinguishable from a clean end
+            // of corpus, so a caller walking the cursor stopped early and
+            // treated a failed read as a complete one. A redb corpus that has
+            // entered its "Previous I/O error occurred" state fails every
+            // range read for the process's lifetime, which is how an index
+            // holding 50,929 chunks exported zero of them at HTTP 200.
             let raws = match raws {
                 Ok(Ok(raws)) => raws,
                 Ok(Err(e)) => {
-                    tracing::warn!("index '{}': cursor page read failed ({e})", self.index_id);
-                    return (total, Vec::new(), None);
+                    return Err(e).with_context(|| {
+                        format!("index '{}': cursor page read failed", self.index_id)
+                    });
                 }
                 Err(e) => {
-                    tracing::warn!("index '{}': cursor page task panicked ({e})", self.index_id);
-                    return (total, Vec::new(), None);
+                    return Err(anyhow::Error::new(e).context(format!(
+                        "index '{}': cursor page task panicked",
+                        self.index_id
+                    )));
                 }
             };
             let next_cursor = if raws.len() == limit {
@@ -165,7 +214,7 @@ impl CodeIndexer {
                 .iter()
                 .map(|raw| raw_to_code_chunk(raw, 0.0, "enumerate", None, &root))
                 .collect();
-            return (total, page, next_cursor);
+            return Ok((total, page, next_cursor));
         }
 
         // In-memory fallback (no durable corpus): reproduce the redb path's
@@ -178,7 +227,7 @@ impl CodeIndexer {
         let chunks = self.chunks.read().await;
         let total = chunks.len();
         if limit == 0 || total == 0 {
-            return (total, Vec::new(), None);
+            return Ok((total, Vec::new(), None));
         }
         let mut ordered: Vec<&RawChunk> = chunks.values().collect();
         ordered.sort_by(|a, b| a.id.cmp(&b.id));
@@ -197,7 +246,7 @@ impl CodeIndexer {
             .iter()
             .map(|raw| raw_to_code_chunk(raw, 0.0, "enumerate", None, &root))
             .collect();
-        (total, page, next_cursor)
+        Ok((total, page, next_cursor))
     }
 
     /// Run an HNSW-only similarity search against a precomputed embedding,

--- a/crates/trusty-search/src/core/indexer/files.rs
+++ b/crates/trusty-search/src/core/indexer/files.rs
@@ -83,7 +83,9 @@ impl CodeIndexer {
     /// Test: `test_enumerate_chunks_paginates_stable_order` indexes a couple of
     /// files, pages through them, and asserts no overlap and full coverage;
     /// `enumerate_chunks_errors_when_rehydrate_did_not_commit` covers the
-    /// #6043 refusal.
+    /// #6043 refusal and
+    /// `enumerate_chunks_waits_out_a_rehydrate_that_outlasts_one_budget` covers
+    /// the retry that keeps a healthy slow corpus out of it.
     ///
     /// Errors when the in-memory map is not a view of the corpus — see the
     /// guard below.
@@ -92,23 +94,40 @@ impl CodeIndexer {
         offset: usize,
         limit: usize,
     ) -> Result<(usize, Vec<CodeChunk>)> {
-        self.ensure_chunks_loaded().await;
         // #6043: the map this page is sliced from is a CACHE, not the corpus.
-        // `ensure_chunks_loaded` waits on a bounded budget and returns whether
-        // or not the detached rehydrate committed, and the rehydrate task
-        // reports a redb read failure only to the log. `chunks_evicted` stays
-        // set on every path that did not commit, so reading it here is the one
-        // place the caller can tell "this index holds nothing" apart from
-        // "this map has not been filled". Reporting `chunks.len()` as `total`
-        // across that gap is what published `total: 0` for an index holding
+        // `ensure_chunks_loaded` waits on a bounded budget (default 9s) and
+        // returns whether or not the detached rehydrate committed, and the
+        // rehydrate task reports a redb read failure only to the log.
+        // `chunks_evicted` stays set on every path that did not commit, so it
+        // is the one place a caller can tell "this index holds nothing" apart
+        // from "this map has not been filled". Reporting `chunks.len()` as
+        // `total` across that gap published `total: 0` for an index holding
         // 50,929 chunks and let trusty-analyze score an empty corpus.
-        if self.chunks_evicted.load(Ordering::Relaxed) {
+        //
+        // Retry on the same budget as the read lanes rather than refusing after
+        // one wait: #3683 measured a healthy 315K-chunk corpus taking 27-40s to
+        // rehydrate, so a single 9s wait would turn every large cold index into
+        // an error. Each iteration rejoins the SAME in-flight detached task (it
+        // is deduplicated, not re-triggered), so this waits roughly
+        // `REHYDRATE_RACE_RETRIES * rehydrate_wait_budget()` — ~27s at the
+        // defaults, matching `search::lanes::{bm25_search, grep_fallback_search}`.
+        let mut corpus_view_is_current = false;
+        for _ in 0..crate::core::indexer::search::lanes::REHYDRATE_RACE_RETRIES {
+            self.ensure_chunks_loaded().await;
+            if !self.chunks_evicted.load(Ordering::Relaxed) {
+                corpus_view_is_current = true;
+                break;
+            }
+        }
+        if !corpus_view_is_current {
             anyhow::bail!(
                 "index '{}': the in-memory chunk map was evicted and has not been \
-                 repopulated — the durable corpus read either failed or is still in \
-                 flight, so enumerating it now would report a partial corpus as the \
-                 whole one (see #6043, #5917). Retry once the rehydrate commits.",
-                self.index_id
+                 repopulated after {} bounded waits — the durable corpus read either \
+                 failed or is still in flight, so enumerating it now would report a \
+                 partial corpus as the whole one (see #6043, #5917). Retry once the \
+                 rehydrate commits.",
+                self.index_id,
+                crate::core::indexer::search::lanes::REHYDRATE_RACE_RETRIES,
             );
         }
         let chunks = self.chunks.read().await;
@@ -154,9 +173,15 @@ impl CodeIndexer {
     /// `after`. `next_cursor` is `Some(last_id)` when a full `limit`-sized page
     /// was returned (more rows may follow) and `None` once the page is short
     /// (end reached) — so a client loops until `next_cursor` is `None`.
-    /// Test: `test_enumerate_chunks_after_cursor_pages_via_redb`,
-    /// `test_enumerate_chunks_after_cursor_in_memory_fallback`, and
-    /// `cursor_page_read_failure_is_an_error_not_an_empty_page` (#6043).
+    /// Test: `test_enumerate_chunks_after_cursor_pages_via_redb` and
+    /// `test_enumerate_chunks_after_cursor_in_memory_fallback` cover the happy
+    /// paths. The #6043 read-failure arms have no direct unit test: redb enters
+    /// its "Previous I/O error occurred" state only through a real I/O fault,
+    /// and `CorpusStore::open` materializes every table eagerly, so neither a
+    /// missing table nor a corrupted-after-open database is reachable from a
+    /// fixture. They are covered indirectly by
+    /// `trusty_analyze::core::client::tests::short_export_against_reported_total_is_an_error`,
+    /// which replays the live failure body this arm produces.
     ///
     /// Errors when the durable corpus cannot be read — see the #6043 note on
     /// the failure arms below.

--- a/crates/trusty-search/src/core/indexer/search/lanes.rs
+++ b/crates/trusty-search/src/core/indexer/search/lanes.rs
@@ -71,7 +71,10 @@ use super::path_filter;
 /// (finding 5 — see `idle_evict::spawn_detached_rehydrate`'s commit-success
 /// branch). `TRUSTY_REHYDRATE_WAIT_MS` is the per-deployment knob for trading
 /// first-query latency against fewer degraded responses.
-const REHYDRATE_RACE_RETRIES: u32 = 3;
+// pub(crate): `files::enumerate_chunks` retries on the same budget (#6043) —
+// a chunk enumeration is subject to the identical cold-scan window as the
+// read lanes, so both must count to the same number.
+pub(crate) const REHYDRATE_RACE_RETRIES: u32 = 3;
 
 impl CodeIndexer {
     /// Batch-fetch the `RawChunk`s for a set of chunk ids, reading from the

--- a/crates/trusty-search/src/core/indexer/tests/eviction_kg_paths.rs
+++ b/crates/trusty-search/src/core/indexer/tests/eviction_kg_paths.rs
@@ -619,7 +619,7 @@ async fn enumerate_chunks_returns_resolved_absolute_paths() {
         .await
         .unwrap();
 
-    let (total, page) = idx.enumerate_chunks(0, 100).await;
+    let (total, page) = idx.enumerate_chunks(0, 100).await.unwrap();
     assert!(total > 0, "expected at least one chunk");
     for chunk in &page {
         assert!(

--- a/crates/trusty-search/src/core/indexer/tests/ranking_and_modes.rs
+++ b/crates/trusty-search/src/core/indexer/tests/ranking_and_modes.rs
@@ -812,7 +812,7 @@ async fn test_enumerate_chunks_paginates_stable_order() {
         .unwrap();
 
     // Full enumeration: sorted by (file, start_line).
-    let (total_all, all) = idx.enumerate_chunks(0, 100).await;
+    let (total_all, all) = idx.enumerate_chunks(0, 100).await.unwrap();
     assert_eq!(total_all, 4);
     let ids: Vec<_> = all.iter().map(|c| c.id.as_str()).collect();
     assert_eq!(
@@ -821,8 +821,8 @@ async fn test_enumerate_chunks_paginates_stable_order() {
     );
 
     // Page 1 (offset=0, limit=2) + Page 2 (offset=2, limit=2) cover all.
-    let (total_p1, page1) = idx.enumerate_chunks(0, 2).await;
-    let (total_p2, page2) = idx.enumerate_chunks(2, 2).await;
+    let (total_p1, page1) = idx.enumerate_chunks(0, 2).await.unwrap();
+    let (total_p2, page2) = idx.enumerate_chunks(2, 2).await.unwrap();
     assert_eq!(total_p1, 4);
     assert_eq!(total_p2, 4);
     assert_eq!(page1.len(), 2);
@@ -835,12 +835,12 @@ async fn test_enumerate_chunks_paginates_stable_order() {
     assert_eq!(combined, ids);
 
     // Offset past the end returns empty, but total is preserved.
-    let (total_end, end) = idx.enumerate_chunks(10, 5).await;
+    let (total_end, end) = idx.enumerate_chunks(10, 5).await.unwrap();
     assert_eq!(total_end, 4);
     assert!(end.is_empty());
 
     // limit=0 returns empty.
-    let (total_z, z) = idx.enumerate_chunks(0, 0).await;
+    let (total_z, z) = idx.enumerate_chunks(0, 0).await.unwrap();
     assert_eq!(total_z, 4);
     assert!(z.is_empty());
 }

--- a/crates/trusty-search/src/core/indexer/tests_cursor.rs
+++ b/crates/trusty-search/src/core/indexer/tests_cursor.rs
@@ -49,7 +49,10 @@ async fn test_enumerate_chunks_after_cursor_in_memory_fallback() {
     let mut cursor: Option<String> = None;
     let mut pages = 0;
     loop {
-        let (total, page, next) = idx.enumerate_chunks_after(cursor.as_deref(), 2).await;
+        let (total, page, next) = idx
+            .enumerate_chunks_after(cursor.as_deref(), 2)
+            .await
+            .unwrap();
         assert_eq!(total, 5, "total chunk count is stable across pages");
         for c in &page {
             seen.push(c.id.clone());
@@ -64,7 +67,7 @@ async fn test_enumerate_chunks_after_cursor_in_memory_fallback() {
     assert_eq!(seen, vec!["a:1:1", "b:1:1", "c:1:1", "d:1:1", "e:1:1"]);
 
     // limit == 0 → empty page, no cursor.
-    let (total_z, z, next_z) = idx.enumerate_chunks_after(None, 0).await;
+    let (total_z, z, next_z) = idx.enumerate_chunks_after(None, 0).await.unwrap();
     assert_eq!(total_z, 5);
     assert!(z.is_empty());
     assert!(next_z.is_none());
@@ -102,7 +105,10 @@ async fn test_enumerate_chunks_after_cursor_pages_via_redb() {
     let mut cursor: Option<String> = None;
     let mut pages = 0;
     loop {
-        let (total, page, next) = idx.enumerate_chunks_after(cursor.as_deref(), 2).await;
+        let (total, page, next) = idx
+            .enumerate_chunks_after(cursor.as_deref(), 2)
+            .await
+            .unwrap();
         assert_eq!(total, total_chunks, "total is the redb chunk_count");
         for c in &page {
             seen.push(c.id.clone());
@@ -124,4 +130,65 @@ async fn test_enumerate_chunks_after_cursor_pages_via_redb() {
     assert_eq!(seen, sorted, "redb cursor pages in ascending id order");
     sorted.dedup();
     assert_eq!(sorted.len(), seen.len(), "no chunk returned twice");
+}
+
+/// #6043: an evicted, not-yet-repopulated chunk map must not be enumerated as
+/// though it were the corpus.
+///
+/// Why: `enumerate_chunks` reported `chunks.len()` as `total`, and
+/// `ensure_chunks_loaded` returns on a bounded budget whether or not the
+/// detached rehydrate has committed. An index holding 50,929 chunks therefore
+/// answered `GET /indexes/trusty-tools/chunks` with `total: 0` and an empty
+/// page at HTTP 200; trusty-analyze read that as a complete empty corpus and
+/// published `complexity_distribution total: 0`. Issue #5917 recorded the same
+/// mechanism as an intermittent flap — 0 chunks, then 85,269 chunks 67 seconds
+/// later from the identical command.
+/// What: indexes a real corpus, evicts the in-memory map, and holds the
+/// rehydrate past the caller's wait budget with the test delay hook, so the
+/// call lands in exactly the state that produced the zero. Asserts `Err`.
+/// Before the fix this returned `Ok((0, vec![]))`.
+/// Test: this function IS the test.
+#[tokio::test]
+#[serial_test::serial]
+async fn enumerate_chunks_errors_when_rehydrate_did_not_commit() {
+    use std::sync::atomic::Ordering;
+
+    let dir = tempfile::tempdir().unwrap();
+    let mut idx = CodeIndexer::new("evicted-mid-rehydrate", "/tmp/evicted-mid-rehydrate");
+    idx.set_corpus_store(Arc::new(
+        CorpusStore::open(&dir.path().join("index.redb")).expect("open corpus"),
+    ));
+    idx.index_files_batch(&[("src/a.rs".into(), "fn a_one() {}\nfn a_two() {}".into())])
+        .await
+        .expect("index batch");
+    assert!(
+        idx.enumerate_chunks(0, 100).await.expect("warm read").0 > 0,
+        "the corpus is non-empty before eviction"
+    );
+
+    // Hold the rehydrate scan well past the wait budget so the call observes
+    // the in-flight state rather than the committed one.
+    // SAFETY: serialized against every other reader/writer of this var by
+    // `#[serial_test::serial]` on this test.
+    unsafe { std::env::set_var("TRUSTY_REHYDRATE_WAIT_MS", "25") };
+    super::idle_evict::TEST_REHYDRATE_DELAY_MS.store(5_000, Ordering::Relaxed);
+
+    let evicted = idx.clear_in_memory_chunks().await;
+    assert!(evicted > 0, "eviction dropped the in-memory chunks");
+
+    let result = idx.enumerate_chunks(0, 100).await;
+
+    super::idle_evict::TEST_REHYDRATE_DELAY_MS.store(0, Ordering::Relaxed);
+    // SAFETY: same serialization as the `set_var` above.
+    unsafe { std::env::remove_var("TRUSTY_REHYDRATE_WAIT_MS") };
+
+    let err = result.expect_err(
+        "an evicted, unrepopulated map must be an error — reporting it as a \
+         zero-chunk corpus is #6043",
+    );
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("evicted") && msg.contains("#6043"),
+        "the error must name the state and the ticket, got: {msg}"
+    );
 }

--- a/crates/trusty-search/src/core/indexer/tests_cursor.rs
+++ b/crates/trusty-search/src/core/indexer/tests_cursor.rs
@@ -144,9 +144,9 @@ async fn test_enumerate_chunks_after_cursor_pages_via_redb() {
 /// mechanism as an intermittent flap — 0 chunks, then 85,269 chunks 67 seconds
 /// later from the identical command.
 /// What: indexes a real corpus, evicts the in-memory map, and holds the
-/// rehydrate past the caller's wait budget with the test delay hook, so the
-/// call lands in exactly the state that produced the zero. Asserts `Err`.
-/// Before the fix this returned `Ok((0, vec![]))`.
+/// rehydrate past ALL `REHYDRATE_RACE_RETRIES` bounded waits with the test
+/// delay hook, so the call lands in exactly the state that produced the zero.
+/// Asserts `Err`. Before the fix this returned `Ok((0, vec![]))`.
 /// Test: this function IS the test.
 #[tokio::test]
 #[serial_test::serial]
@@ -191,4 +191,61 @@ async fn enumerate_chunks_errors_when_rehydrate_did_not_commit() {
         msg.contains("evicted") && msg.contains("#6043"),
         "the error must name the state and the ticket, got: {msg}"
     );
+}
+
+/// A rehydrate that outlasts ONE bounded wait but finishes within the retry
+/// budget must return the corpus, not an error.
+///
+/// Why: #3683 measured a healthy 315K-chunk corpus taking 27-40s to rehydrate
+/// against a 9s per-wait budget, so refusing after a single
+/// `ensure_chunks_loaded` would turn every large cold index into a hard error
+/// on its first read. That is why `bm25_search` and `grep_fallback_search`
+/// retry `REHYDRATE_RACE_RETRIES` times, and why `enumerate_chunks` counts to
+/// the same number — the #6043 refusal must fire for a corpus that cannot be
+/// read, never for one that is merely slow.
+/// What: sets a per-wait budget SHORTER than the rehydrate delay, so iteration
+/// one times out with `chunks_evicted` still set and a later iteration observes
+/// the commit. Asserts the full corpus comes back.
+/// Test: this function IS the test.
+#[tokio::test]
+#[serial_test::serial]
+async fn enumerate_chunks_waits_out_a_rehydrate_that_outlasts_one_budget() {
+    use std::sync::atomic::Ordering;
+
+    let dir = tempfile::tempdir().unwrap();
+    let mut idx = CodeIndexer::new("slow-rehydrate", "/tmp/slow-rehydrate");
+    idx.set_corpus_store(Arc::new(
+        CorpusStore::open(&dir.path().join("index.redb")).expect("open corpus"),
+    ));
+    idx.index_files_batch(&[("src/a.rs".into(), "fn a_one() {}\nfn a_two() {}".into())])
+        .await
+        .expect("index batch");
+    let warm_total = idx.enumerate_chunks(0, 100).await.expect("warm read").0;
+    assert!(warm_total > 0, "the corpus is non-empty before eviction");
+
+    // 600ms scan against a 500ms per-wait budget: iteration 1 must time out
+    // with the flag still set, and the commit lands inside iteration 2's wait —
+    // comfortably short of the 3-iteration ceiling.
+    // SAFETY: serialized against every other reader/writer of this var by
+    // `#[serial_test::serial]` on this test.
+    unsafe { std::env::set_var("TRUSTY_REHYDRATE_WAIT_MS", "500") };
+    super::idle_evict::TEST_REHYDRATE_DELAY_MS.store(600, Ordering::Relaxed);
+
+    assert!(
+        idx.clear_in_memory_chunks().await > 0,
+        "eviction dropped the in-memory chunks"
+    );
+
+    let result = idx.enumerate_chunks(0, 100).await;
+
+    super::idle_evict::TEST_REHYDRATE_DELAY_MS.store(0, Ordering::Relaxed);
+    // SAFETY: same serialization as the `set_var` above.
+    unsafe { std::env::remove_var("TRUSTY_REHYDRATE_WAIT_MS") };
+
+    let (total, page) = result.expect(
+        "a rehydrate that finishes within the retry budget must serve the corpus, \
+         not fail — the #6043 refusal is for a corpus that cannot be read",
+    );
+    assert_eq!(total, warm_total, "the whole corpus is back");
+    assert_eq!(page.len(), warm_total, "and the page carries it");
 }

--- a/crates/trusty-search/src/service/server/files.rs
+++ b/crates/trusty-search/src/service/server/files.rs
@@ -142,7 +142,11 @@ pub(super) async fn remove_file_handler(
 /// What: 503 with `retryable: true` — a rehydrate that has not committed does
 /// commit on a later access, and the redb error state clears on daemon
 /// restart, so waiting is a real remedy rather than a lie.
-/// Test: `cursor_page_read_failure_is_an_error_not_an_empty_page`.
+/// Test: the offset path's refusal reaches this builder via
+/// `core::indexer::tests_cursor::enumerate_chunks_errors_when_rehydrate_did_not_commit`.
+/// The cursor path's redb arm has no direct test — see
+/// `CodeIndexer::enumerate_chunks_after` for why fixture-injecting a redb read
+/// fault is not reachable.
 fn corpus_read_failure_response(
     index_id: &str,
     err: &anyhow::Error,

--- a/crates/trusty-search/src/service/server/files.rs
+++ b/crates/trusty-search/src/service/server/files.rs
@@ -128,6 +128,37 @@ pub(super) async fn remove_file_handler(
     })))
 }
 
+/// Build the 503 for a chunk enumeration whose corpus read failed (#6043).
+///
+/// Why: #4087's `index_corpus_unavailable` covers a corpus that fails to OPEN
+/// and quarantines the index at that point. A corpus that opens and then goes
+/// bad — redb's "Previous I/O error occurred" state, which fails every
+/// subsequent range read for the process's lifetime — passes that guard, and
+/// both enumeration paths used to absorb the failure into an empty page. An
+/// index holding 50,929 chunks exported zero of them at HTTP 200, and
+/// trusty-analyze scored the empty corpus and reported
+/// `complexity_distribution total: 0`. Reusing the same error code keeps one
+/// name for "the durable corpus cannot answer", whichever stage broke.
+/// What: 503 with `retryable: true` — a rehydrate that has not committed does
+/// commit on a later access, and the redb error state clears on daemon
+/// restart, so waiting is a real remedy rather than a lie.
+/// Test: `cursor_page_read_failure_is_an_error_not_an_empty_page`.
+fn corpus_read_failure_response(
+    index_id: &str,
+    err: &anyhow::Error,
+) -> (StatusCode, Json<serde_json::Value>) {
+    tracing::warn!("index '{index_id}': chunk enumeration failed: {err:#}");
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        Json(serde_json::json!({
+            "error": "index_corpus_unavailable",
+            "index_id": index_id,
+            "retryable": true,
+            "message": format!("{err:#}"),
+        })),
+    )
+}
+
 /// Query params for `GET /indexes/:id/chunks` (issue #54, #1325).
 ///
 /// Why: the original `offset`/`limit` pair forced an O(N log N) full-corpus
@@ -224,7 +255,10 @@ pub(super) async fn get_index_chunks_handler(
         } else {
             Some(cursor)
         };
-        let (total, chunks, next_cursor) = indexer.enumerate_chunks_after(after, limit).await;
+        let (total, chunks, next_cursor) = indexer
+            .enumerate_chunks_after(after, limit)
+            .await
+            .map_err(|e| corpus_read_failure_response(&index_id.0, &e))?;
         return Ok(Json(serde_json::json!({
             "index_id": index_id.0,
             "total": total,
@@ -240,7 +274,10 @@ pub(super) async fn get_index_chunks_handler(
     // not imply that a cursor walk can continue from an offset page (that would
     // drop or duplicate rows). Clients wanting fast deep pagination should use
     // the cursor mode from the start (`after=`).
-    let (total, chunks) = indexer.enumerate_chunks(params.offset, limit).await;
+    let (total, chunks) = indexer
+        .enumerate_chunks(params.offset, limit)
+        .await
+        .map_err(|e| corpus_read_failure_response(&index_id.0, &e))?;
     Ok(Json(serde_json::json!({
         "index_id": index_id.0,
         "total": total,

--- a/crates/trusty-search/src/service/server/tests_5349.rs
+++ b/crates/trusty-search/src/service/server/tests_5349.rs
@@ -65,7 +65,7 @@ async fn indexed_files(state: &Arc<SearchAppState>, id: &str) -> Vec<String> {
         .get(&IndexId::new(id.to_string()))
         .expect("index must be resident");
     let indexer = handle.indexer.read().await;
-    let (_total, chunks) = indexer.enumerate_chunks(0, 1_000).await;
+    let (_total, chunks) = indexer.enumerate_chunks(0, 1_000).await.unwrap();
     let mut files: Vec<String> = chunks.into_iter().map(|c| c.file).collect();
     files.sort();
     files.dedup();


### PR DESCRIPTION
## Outcome

Fixes the silent fail-open behind #6043 (complexity_distribution total:0 across
50,929 chunks at exit 0) and the /chunks half of #5917. Root cause reproduced
live: redb corpus in "Previous I/O error occurred" state; both enumeration
paths in `crates/trusty-search/src/core/indexer/files.rs` swallowed read
errors and returned empty at 200; trusty-analyze computed zeros over the
empty feed.

## What changed

`enumerate_chunks_after`/`enumerate_chunks` return `Result` — the cursor path
propagates `chunks_after`/`join`/`chunk_count` errors; the offset path
refuses only after the shared `REHYDRATE_RACE_RETRIES` bounded-retry budget
(same pattern as `bm25_search`/`grep_fallback_search`) when `chunks_evicted`
is still set. New `corpus_read_failure_response` maps both to a 503
`index_corpus_unavailable`, `retryable: true`. The trusty-analyze client
walks cursor pagination against the durable corpus and errors on an export
short of the daemon's reported total — offset mode was also capped by
`TRUSTY_MAX_CHUNKS`, silently under-exporting warm indexes.

Out of scope, recorded on #5917 (comment issuecomment-5350171127):
`corpus_ops.rs:348` row-skip cursor truncation; the retryable-vs-transient
field-shape divergence between the two `index_corpus_unavailable` producers;
and the same pre-existing single-wait assumption in `find_chunk_id`/
`all_chunks`/`raw_chunks_snapshot`. Also out of scope: the live trusty-tools
index stays broken until a daemon restart or repopulation (operational,
owner's call) — after this fix it reports a retryable 503 instead of a false
zero.

## Risk

High — cross-crate error contract on the persistence read path. Mitigations:
the bounded retry preserves slow-cold-index behavior, only in-repo consumers
of the two functions were updated and verified, and a code-critic round ran
(WARN, both findings fixed below).

## Test evidence (rung 4)

- trusty-search: 1771 passed / 0 failed (integration targets all ok)
- trusty-analyze: 492 passed / 0 failed
- trusty-agents (only real dependent): 3529 passed / 0 failed
- `cargo check --workspace --all-targets`: exit 0
- fmt / clippy: clean; line-cap: OK

Regression tests proven to fail pre-fix:
- `enumerate_chunks_errors_when_rehydrate_did_not_commit` — reproduces the
  `(0, [])` lie
- `short_export_against_reported_total_is_an_error` — replays the live
  `total: 50929` / zero-rows body
- `enumerate_chunks_waits_out_a_rehydrate_that_outlasts_one_budget` — fails
  with the retry loop cut to 1

## Baseline

Known trusty-search filesystem-watcher environmental flakes did not fire; no
other reds.

## Changelog

Fragments in both crates (trusty-search and trusty-analyze `changelog.d`),
extended to cover the retry behavior.

## Review disposition

trusty-review round 1 REQUEST_CHANGES (degraded context): confirmed finding (multi-page cursor walk untested + false test citation) FIXED in ca10de1da — cursor-keyed stub, 3 multi-page tests, full doc-citation audit (all 11 cited test names resolve); advisory reported_total last-write-wins documented as intended. code-critic WARN round: HIGH + MEDIUM fixed in 8d40e03ca; field-shape MEDIUM dispositioned to #5917.

Refs #6043, Refs #5917

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

