### PR TITLE
fix(trusty-review): synthesis converges on a large finding set (#6093)

### DIFF
--- a/crates/trusty-review/changelog.d/6093-synthesis-large-findings-added.md
+++ b/crates/trusty-review/changelog.d/6093-synthesis-large-findings-added.md
@@ -1,0 +1,2 @@
+Added
+- The verified investigation is written to `investigation.json` in the report's output directory before synthesis begins, so a synthesis failure no longer discards the run's expensive half.

--- a/crates/trusty-review/changelog.d/6093-synthesis-large-findings.md
+++ b/crates/trusty-review/changelog.d/6093-synthesis-large-findings.md
@@ -1,6 +1,3 @@
 Fixed
 - Report synthesis no longer fails outright on a large finding set. The request's output-token ceiling was a hardcoded 3072 that ignored `[models.reviewer].max_tokens`, and the single truncation retry shrank the top-risks table from five rows to three while leaving ten per-finding elaborations — the dominant output cost — untouched at the same ceiling, so it could not converge. A 44- and a 45-finding investigation both truncated twice and exited with no report; 26 findings rendered clean. The retry is now a three-rung ladder that raises the budget and shrinks the ask together: full ask at the configured ceiling, then a concise ask at double it, then a narrative-only ask at quadruple it with no elaboration array in the schema at all. No finding is dropped — every RED/AMBER finding still renders from the deterministic composition and from the investigation's own verified prose.
 - `[models.reviewer].max_tokens` now reaches the synthesis request instead of being overridden by a constant.
-
-Added
-- The verified investigation is written to `investigation.json` in the report's output directory before synthesis begins, so a synthesis failure no longer discards the run's expensive half.

--- a/crates/trusty-review/changelog.d/6093-synthesis-large-findings.md
+++ b/crates/trusty-review/changelog.d/6093-synthesis-large-findings.md
@@ -1,0 +1,6 @@
+Fixed
+- Report synthesis no longer fails outright on a large finding set. The request's output-token ceiling was a hardcoded 3072 that ignored `[models.reviewer].max_tokens`, and the single truncation retry shrank the top-risks table from five rows to three while leaving ten per-finding elaborations — the dominant output cost — untouched at the same ceiling, so it could not converge. A 44- and a 45-finding investigation both truncated twice and exited with no report; 26 findings rendered clean. The retry is now a three-rung ladder that raises the budget and shrinks the ask together: full ask at the configured ceiling, then a concise ask at double it, then a narrative-only ask at quadruple it with no elaboration array in the schema at all. No finding is dropped — every RED/AMBER finding still renders from the deterministic composition and from the investigation's own verified prose.
+- `[models.reviewer].max_tokens` now reaches the synthesis request instead of being overridden by a constant.
+
+Added
+- The verified investigation is written to `investigation.json` in the report's output directory before synthesis begins, so a synthesis failure no longer discards the run's expensive half.

--- a/crates/trusty-review/src/cli_report.rs
+++ b/crates/trusty-review/src/cli_report.rs
@@ -20,7 +20,7 @@ use trusty_review::config::{Provider, ReviewConfig};
 use trusty_review::llm::{build_provider, resolve_provider_and_model};
 use trusty_review::report::{
     Budget, CorpusSnapshot, Instructions, Reporter, TemplateLoader, benchmark,
-    investigate::{apply_investigation, merge_investigation_prose},
+    investigate::{Investigation, apply_investigation, merge_investigation_prose},
     load_instructions, load_manifest,
     manifest::Manifest,
     model::ReportModel,
@@ -518,11 +518,16 @@ async fn run_synthesis(
             "[trusty-review report] Investigation: {verified} verified finding(s) across {} local repo(s)",
             inv.repos.len()
         );
+        // #6093: persist BEFORE synthesis. Synthesis can fail, and until this
+        // landed a failure discarded the whole investigation — minutes of real
+        // LLM spend, unrecoverable.
+        persist_investigation(out_dir, &inv);
         apply_investigation(model, &inv);
         // #6009: capture the raw response next to the report output on an
         // unparseable-response failure, so a future occurrence is diagnosable
         // without spending another live call to find out what the model sent.
         let mut synthesis = Synthesizer::new(provider, role.model.clone())
+            .with_max_tokens(role.max_tokens)
             .with_raw_capture_dir(out_dir)
             .synthesize(model)
             .await?;
@@ -530,9 +535,52 @@ async fn run_synthesis(
         Ok(synthesis)
     } else {
         Ok(Synthesizer::new(provider, role.model.clone())
+            .with_max_tokens(role.max_tokens)
             .with_raw_capture_dir(out_dir)
             .synthesize(model)
             .await?)
+    }
+}
+
+/// Filename the pre-synthesis investigation snapshot is written under, inside
+/// the report's own output directory.
+const INVESTIGATION_SNAPSHOT_FILENAME: &str = "investigation.json";
+
+/// Write the verified investigation next to the report output before synthesis
+/// runs (#6093).
+///
+/// Why: the investigation is the expensive half of a report run — several
+/// minutes of selection, LLM calls, and mechanical evidence verification. A
+/// synthesis failure used to throw all of it away, so recovering meant paying
+/// for the whole investigation again. The snapshot lands before the first
+/// synthesis call, so it survives every failure downstream of it.
+/// What: serialises [`Investigation`] to
+/// `<out_dir>/`[`INVESTIGATION_SNAPSHOT_FILENAME`], creating the directory if
+/// needed, and prints the path. Any failure is a warning, never an error: a
+/// recovery aid must not itself abort a run that would otherwise succeed.
+/// Test: `tests::investigation_snapshot_is_written_and_reloadable`,
+/// `tests::investigation_snapshot_failure_is_not_fatal`.
+fn persist_investigation(out_dir: &Path, inv: &Investigation) {
+    let path = out_dir.join(INVESTIGATION_SNAPSHOT_FILENAME);
+    let json = match serde_json::to_string_pretty(inv) {
+        Ok(j) => j,
+        Err(e) => {
+            tracing::warn!(error = %e, "investigation snapshot: could not serialise");
+            return;
+        }
+    };
+    if let Err(e) = std::fs::create_dir_all(out_dir) {
+        tracing::warn!(error = %e, dir = %out_dir.display(), "investigation snapshot: could not create output directory");
+        return;
+    }
+    match std::fs::write(&path, json) {
+        Ok(()) => eprintln!(
+            "[trusty-review report] Investigation snapshot: {}",
+            path.display()
+        ),
+        Err(e) => {
+            tracing::warn!(error = %e, path = %path.display(), "investigation snapshot: could not write")
+        }
     }
 }
 
@@ -699,5 +747,71 @@ mod tests {
             !msg.contains("sk-or"),
             "no key-shaped text may appear: {msg}"
         );
+    }
+
+    /// A one-repo investigation with a single verified finding.
+    fn snapshot_fixture() -> Investigation {
+        use trusty_review::report::investigate::{
+            InvestigationStatus, RepoInvestigation, VerifiedFinding,
+        };
+        Investigation {
+            repos: vec![RepoInvestigation {
+                slug: "acme-core".to_string(),
+                name: "Acme Core".to_string(),
+                status: InvestigationStatus::Available,
+                findings: vec![VerifiedFinding {
+                    title: "Hardcoded credential".to_string(),
+                    severity: trusty_review::report::metrics::Severity::Red,
+                    dimension: "security".to_string(),
+                    file: "src/auth.rs".to_string(),
+                    line: Some(12),
+                    evidence_quote: "let api_key = \"…\";".to_string(),
+                    description: "A credential is committed in source.".to_string(),
+                    business_impact: String::new(),
+                    remediation: "Move it to the secret store.".to_string(),
+                    cost_effort: String::new(),
+                }],
+                deps: Default::default(),
+                coverage: Default::default(),
+            }],
+        }
+    }
+
+    /// Why: #6093 — a synthesis failure used to discard the whole investigation,
+    /// the expensive half of a report run. The snapshot must land before the
+    /// first synthesis call and must be readable afterwards.
+    /// What: writes a fixture investigation to a temp dir; asserts the file
+    /// exists at the documented name and that its JSON still carries the
+    /// verified finding's title and file.
+    /// Test: this test itself.
+    #[test]
+    fn investigation_snapshot_is_written_and_reloadable() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        persist_investigation(dir.path(), &snapshot_fixture());
+
+        let path = dir.path().join(INVESTIGATION_SNAPSHOT_FILENAME);
+        let raw = std::fs::read_to_string(&path).expect("the snapshot must exist");
+        let parsed: serde_json::Value = serde_json::from_str(&raw).expect("valid JSON");
+        assert_eq!(parsed["repos"][0]["slug"], "acme-core");
+        assert_eq!(
+            parsed["repos"][0]["findings"][0]["title"],
+            "Hardcoded credential"
+        );
+        assert_eq!(parsed["repos"][0]["findings"][0]["file"], "src/auth.rs");
+    }
+
+    /// Why: a recovery aid must never turn a run that would have succeeded into
+    /// a failure of its own.
+    /// What: points the snapshot at a path that cannot be a directory (an
+    /// existing file); asserts the call returns normally rather than panicking
+    /// or propagating.
+    /// Test: this test itself.
+    #[test]
+    fn investigation_snapshot_failure_is_not_fatal() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let blocked = dir.path().join("not-a-dir");
+        std::fs::write(&blocked, b"x").expect("write blocker");
+        persist_investigation(&blocked, &snapshot_fixture());
+        assert!(blocked.is_file(), "the blocking file is untouched");
     }
 }

--- a/crates/trusty-review/src/llm/all_schemas_tests.rs
+++ b/crates/trusty-review/src/llm/all_schemas_tests.rs
@@ -44,7 +44,7 @@ fn all_sent_schemas() -> Vec<(&'static str, ResponseSchema)> {
         ),
         (
             "synthesis_schema",
-            crate::report::synthesize_prompt::synthesis_schema(5),
+            crate::report::synthesize_prompt::synthesis_schema(5, 10),
         ),
         (
             "investigation_schema",
@@ -86,7 +86,7 @@ fn every_sent_schema_is_openai_strict_compliant() {
 /// Test: this test itself.
 #[test]
 fn synthesis_findings_items_is_strict() {
-    let spec = crate::report::synthesize_prompt::synthesis_schema(5);
+    let spec = crate::report::synthesize_prompt::synthesis_schema(5, 10);
     let items = spec
         .schema
         .pointer("/properties/findings/items")

--- a/crates/trusty-review/src/report/synthesize.rs
+++ b/crates/trusty-review/src/report/synthesize.rs
@@ -28,7 +28,9 @@ use tracing::{debug, warn};
 use crate::llm::LlmProvider;
 use crate::report::model::ReportModel;
 use crate::report::synthesize_guard::{allowed_numbers, verify_prose};
-use crate::report::synthesize_prompt::build_synthesis_prompt;
+use crate::report::synthesize_prompt::{
+    SYNTHESIS_DEFAULT_MAX_TOKENS, SYNTHESIS_TIER_LADDER, SynthesisTier, build_synthesis_prompt,
+};
 
 /// Default wall-clock ceiling for one synthesis pass before failing closed.
 const DEFAULT_SYNTHESIS_TIMEOUT: Duration = Duration::from_secs(120);
@@ -240,6 +242,7 @@ pub struct Synthesizer {
     model: String,
     timeout: Duration,
     raw_capture_dir: Option<PathBuf>,
+    max_tokens: u32,
 }
 
 impl Synthesizer {
@@ -247,8 +250,9 @@ impl Synthesizer {
     ///
     /// Why: the CLI builds the provider from the reviewer role config; tests
     /// inject stubs.
-    /// What: stores the provider + model with the default timeout and no raw
-    /// capture directory (opt-in via [`Self::with_raw_capture_dir`]).
+    /// What: stores the provider + model with the default timeout, the default
+    /// output budget, and no raw capture directory (opt-in via
+    /// [`Self::with_raw_capture_dir`]).
     /// Test: exercised by every synthesize test.
     pub fn new(llm: Arc<dyn LlmProvider>, model: impl Into<String>) -> Self {
         Self {
@@ -256,7 +260,24 @@ impl Synthesizer {
             model: model.into(),
             timeout: DEFAULT_SYNTHESIS_TIMEOUT,
             raw_capture_dir: None,
+            max_tokens: SYNTHESIS_DEFAULT_MAX_TOKENS,
         }
+    }
+
+    /// Set the output-token ceiling synthesis asks for on its first attempt.
+    ///
+    /// Why: #6093 — `[models.reviewer].max_tokens` never reached this path.
+    /// `Synthesizer::new(provider, role.model.clone())` took the model id and
+    /// nothing else, and the request carried a hardcoded 3072 regardless of
+    /// what the operator configured, so raising the configured ceiling did
+    /// not change the request that truncated.
+    /// What: stores the ceiling used as the base of the retry ladder's budget
+    /// (see [`SynthesisTier::budget`], which clamps it into a supported range
+    /// and escalates it on each retry rung).
+    /// Test: `synthesize_tests.rs::configured_max_tokens_reaches_the_request`.
+    pub fn with_max_tokens(mut self, max_tokens: u32) -> Self {
+        self.max_tokens = max_tokens;
+        self
     }
 
     /// Override the fail-closed timeout (used by tests).
@@ -291,18 +312,27 @@ impl Synthesizer {
     /// Why: the single entry point the CLI awaits; it NEVER fabricates and NEVER
     /// partial-trusts a malformed response.  A live-QA acceptance run found that a
     /// large, real finding count could still hit the output-token ceiling even
-    /// with the #2357-follow-up compact digest and bounded schema; a single cheap
-    /// retry (mirroring the wave-3 batch investigation's truncation retry) asks for
-    /// a shorter response before giving up, rather than discarding the whole
-    /// narrative on the first truncation.  #5454 changed only what happens when
-    /// that retry is exhausted: the failure propagates instead of degrading the
-    /// report to deterministic-only.
-    /// What: builds the numeric allow-set from the deterministic model, calls the
-    /// provider under a timeout; on `finish_reason = length`/`max_tokens`, retries
-    /// ONCE with `retry_concise = true` (a smaller `top_risks` cap + a shorter-
-    /// paragraph directive).  A parsed response is passed through the numeric
-    /// guardrail field-by-field, dropping any field whose prose cites a figure
-    /// absent from the source.
+    /// with the #2357-follow-up compact digest and bounded schema.  #6093 is what
+    /// that retry could not fix: it shrank `top_risks` from five rows to three
+    /// while leaving ten per-finding elaborations — the dominant output cost —
+    /// and the request's hardcoded 3072-token ceiling both untouched, so a
+    /// 45-finding investigation truncated on both calls and exited with no
+    /// report.  The retry is now a three-rung ladder in which every rung raises
+    /// the budget AND shrinks the ask, ending in a narrative-only rung that
+    /// requests no elaboration prose at all.  #5454 still decides what happens
+    /// when the ladder is spent: the failure propagates rather than degrading
+    /// the report to deterministic-only.
+    /// What: builds the numeric allow-set from the deterministic model, then
+    /// walks [`SYNTHESIS_TIER_LADDER`], calling the provider under a timeout at
+    /// each rung; a `finish_reason` of `length`/`max_tokens` advances to the
+    /// next rung, and exhausting the ladder is [`SynthesisError::Truncated`].
+    /// A parsed response is passed through the numeric guardrail field-by-field,
+    /// dropping any field whose prose cites a figure absent from the source.
+    ///
+    /// Dropping elaboration on the last rung drops no finding: every RED/AMBER
+    /// finding still renders from the deterministic composition (#5374), and the
+    /// investigation's verified prose is merged over synthesis prose afterwards
+    /// regardless (`cli_report::merge_investigation_prose`).
     ///
     /// # Errors
     ///
@@ -314,6 +344,7 @@ impl Synthesizer {
     /// synthesize_malformed_json_is_a_hard_error,
     /// synthesize_provider_error_is_a_hard_error, synthesize_rejects_unverified_figure,
     /// synthesize_retry_recovers_from_truncation,
+    /// synthesize_ladder_recovers_a_large_finding_set,
     /// synthesize_still_truncated_after_retry_is_a_hard_error}`.
     pub async fn synthesize(&self, model: &ReportModel) -> Result<Synthesis, SynthesisError> {
         // Ground truth for the guardrail comes from the DETERMINISTIC model only.
@@ -325,27 +356,28 @@ impl Synthesizer {
             }
         };
 
-        match self.try_once(model, false).await {
-            Attempt::Ok(raw, norm_notes) => apply_guardrail(raw, &allowed, norm_notes),
-            Attempt::Truncated => {
-                warn!("synthesis: response truncated — retrying once, concise");
-                match self.try_once(model, true).await {
-                    Attempt::Ok(raw, norm_notes) => apply_guardrail(raw, &allowed, norm_notes),
-                    // #5454: the retry is unchanged; only its exhaustion is now fatal.
-                    Attempt::Truncated => {
-                        warn!("synthesis: still truncated after retry");
-                        Err(SynthesisError::Truncated)
-                    }
-                    Attempt::Failed(e) => Err(e),
-                }
+        for (i, tier) in SYNTHESIS_TIER_LADDER.iter().enumerate() {
+            match self.try_once(model, *tier).await {
+                Attempt::Ok(raw, norm_notes) => return apply_guardrail(raw, &allowed, norm_notes),
+                Attempt::Failed(e) => return Err(e),
+                Attempt::Truncated => match SYNTHESIS_TIER_LADDER.get(i + 1) {
+                    Some(next) => warn!(
+                        next_tier = ?next,
+                        next_budget = next.budget(self.max_tokens),
+                        next_elaborations = next.elaboration_cap(),
+                        "synthesis: response truncated — retrying with a larger budget and a smaller ask"
+                    ),
+                    None => warn!("synthesis: still truncated after the narrative-only attempt"),
+                },
             }
-            Attempt::Failed(e) => Err(e),
         }
+        // #5454: the ladder is spent; the failure is fatal, never a degraded report.
+        Err(SynthesisError::Truncated)
     }
 
-    /// Make one provider call (initial or concise retry) and classify the result.
-    async fn try_once(&self, model: &ReportModel, retry_concise: bool) -> Attempt {
-        let req = build_synthesis_prompt(model, &self.model, retry_concise);
+    /// Make one provider call at one rung of the ladder and classify the result.
+    async fn try_once(&self, model: &ReportModel, tier: SynthesisTier) -> Attempt {
+        let req = build_synthesis_prompt(model, &self.model, tier, self.max_tokens);
         let resp = match tokio::time::timeout(self.timeout, self.llm.complete(req)).await {
             Err(_) => {
                 warn!("synthesis: provider timed out");

--- a/crates/trusty-review/src/report/synthesize_digest.rs
+++ b/crates/trusty-review/src/report/synthesize_digest.rs
@@ -189,20 +189,40 @@ pub struct DigestSplit {
     pub elaboration_overflow: usize,
 }
 
-/// Build the capped context + elaboration-target splits from a gathered list.
+/// Build the capped context + elaboration-target splits at the default
+/// elaboration cap.
+///
+/// Why: the shape every caller wanted before the output budget became a ladder
+/// (#6093); kept so a caller that does not vary the cap needs no argument.
+/// What: [`build_split_with_cap`] at [`ELABORATION_TARGETS_CAP`].
+/// Test: `synthesize_digest_tests::{caps_context_at_40_red_first,
+/// elaboration_targets_exclude_verified_and_cap_at_10}`.
+pub fn build_split(all: &[CompactFinding]) -> DigestSplit {
+    build_split_with_cap(all, ELABORATION_TARGETS_CAP)
+}
+
+/// Build the capped context + elaboration-target splits from a gathered list,
+/// at a caller-chosen elaboration cap.
 ///
 /// Why: this is the single place both output-size bounds are enforced —
 /// CONTEXT bounds prompt input size; ELABORATION bounds the genuinely
 /// expensive per-finding prose the model is asked to produce, and structurally
-/// excludes anything wave-3 already verified.
+/// excludes anything wave-3 already verified.  #6093 made the elaboration cap
+/// a parameter: each rung of the synthesis retry ladder asks for fewer
+/// elaborations than the last, and the final rung asks for none, because that
+/// array is the dominant output cost and a truncated response yields nothing
+/// at all.
 /// What: sorts a clone of `all` by severity (RED first, stable so same-severity
 /// order is preserved) for context; takes the top [`CONTEXT_FINDINGS_CAP`] and
 /// records the remainder as `context_overflow`.  Filters to `!verified`, sorts
-/// the same way, takes the top [`ELABORATION_TARGETS_CAP`] for
-/// `elaboration_targets`, recording `elaboration_overflow`.
-/// Test: `synthesize_digest_tests::{caps_context_at_40_red_first,
+/// the same way, takes the top `elaboration_cap` for `elaboration_targets`,
+/// recording `elaboration_overflow`.  A cap of 0 leaves `elaboration_targets`
+/// empty with every unverified finding counted as overflow, which
+/// [`render_elaboration_section`] reports honestly rather than as
+/// "everything is already verified".
+/// Test: `synthesize_digest_tests::{elaboration_cap_zero_reports_every_target_as_overflow,
 /// elaboration_targets_exclude_verified_and_cap_at_10}`.
-pub fn build_split(all: &[CompactFinding]) -> DigestSplit {
+pub fn build_split_with_cap(all: &[CompactFinding], elaboration_cap: usize) -> DigestSplit {
     let mut by_severity: Vec<CompactFinding> = all.to_vec();
     by_severity.sort_by_key(CompactFinding::severity_rank);
 
@@ -216,11 +236,9 @@ pub fn build_split(all: &[CompactFinding]) -> DigestSplit {
     let mut unverified: Vec<CompactFinding> =
         by_severity.into_iter().filter(|f| !f.verified).collect();
     unverified.sort_by_key(CompactFinding::severity_rank);
-    let elaboration_overflow = unverified.len().saturating_sub(ELABORATION_TARGETS_CAP);
-    let elaboration_targets: Vec<CompactFinding> = unverified
-        .into_iter()
-        .take(ELABORATION_TARGETS_CAP)
-        .collect();
+    let elaboration_overflow = unverified.len().saturating_sub(elaboration_cap);
+    let elaboration_targets: Vec<CompactFinding> =
+        unverified.into_iter().take(elaboration_cap).collect();
 
     DigestSplit {
         context,
@@ -282,15 +300,28 @@ pub fn render_context_section(split: &DigestSplit) -> String {
 /// model supplies the prose); an explicit "none" line when investigation
 /// already verified everything (the common case for a wave-3 run); a tail note
 /// when the unverified set itself exceeded the cap.
-/// Test: `synthesize_digest_tests::renders_elaboration_targets_or_none`.
+///
+/// #6093: an empty target list with a non-zero overflow means the retry ladder
+/// suppressed elaboration to buy output budget for the narrative, NOT that
+/// everything is verified.  Saying "already verified" there would be a false
+/// statement in the prompt, so the two cases print different lines.
+/// Test: `synthesize_digest_tests::{renders_elaboration_targets_or_none,
+/// elaboration_cap_zero_reports_every_target_as_overflow}`.
 pub fn render_elaboration_section(split: &DigestSplit) -> String {
     let mut out = String::from(
         "\n## Findings requiring elaboration (populate `findings` for EXACTLY these — leave verified findings above out entirely)\n\n",
     );
     if split.elaboration_targets.is_empty() {
-        out.push_str(
-            "- none — every RED/AMBER finding already has verified evidence-grounded prose elsewhere in this report; return an empty `findings` array.\n",
-        );
+        if split.elaboration_overflow > 0 {
+            out.push_str(&format!(
+                "- none this pass — {} unverified finding(s) keep the deterministic prose already in the report body; return an empty `findings` array and spend the response on the narrative sections.\n",
+                split.elaboration_overflow
+            ));
+        } else {
+            out.push_str(
+                "- none — every RED/AMBER finding already has verified evidence-grounded prose elsewhere in this report; return an empty `findings` array.\n",
+            );
+        }
         return out;
     }
     for f in &split.elaboration_targets {

--- a/crates/trusty-review/src/report/synthesize_digest_tests.rs
+++ b/crates/trusty-review/src/report/synthesize_digest_tests.rs
@@ -274,6 +274,34 @@ fn elaboration_targets_exclude_verified_and_cap_at_10() {
     );
 }
 
+/// Why: #6093's final retry rung asks for no elaboration at all. A cap of 0
+/// must count every unverified finding as overflow, so the rendered digest can
+/// say elaboration was deferred instead of claiming everything is verified —
+/// which would be a false statement in the prompt.
+/// What: 6 unverified findings at cap 0; asserts an empty target list, an
+/// overflow of 6, and the deferred wording in the rendered section.
+/// Test: this test itself.
+#[test]
+fn elaboration_cap_zero_reports_every_target_as_overflow() {
+    let findings: Vec<MetricFinding> = (0..6)
+        .map(|i| mf(&format!("f-{i}"), Severity::Red, "cat", "c.rs"))
+        .collect();
+    let model = model_with(vec![repo("a", findings)], None);
+    let compact = gather_compact_findings(&model);
+
+    let split = build_split_with_cap(&compact, 0);
+    assert!(split.elaboration_targets.is_empty());
+    assert_eq!(split.elaboration_overflow, 6);
+
+    let rendered = render_elaboration_section(&split);
+    assert!(rendered.contains("none this pass"), "{rendered}");
+    assert!(rendered.contains("6 unverified finding(s)"), "{rendered}");
+    assert!(
+        !rendered.contains("every RED/AMBER finding already has verified"),
+        "{rendered}"
+    );
+}
+
 // ── Rendering ────────────────────────────────────────────────────────────────
 
 /// Why: the tail note must name the count of additional findings, never just

--- a/crates/trusty-review/src/report/synthesize_prompt.rs
+++ b/crates/trusty-review/src/report/synthesize_prompt.rs
@@ -18,9 +18,11 @@
 //! What: [`build_synthesis_prompt`] assembles the [`LlmRequest`] (a system
 //! prompt built from the resolved, layered section instructions — see
 //! [`super::section_instructions`] — plus the compact data digest and the
-//! forced [`ResponseSchema`]).  `retry_concise` shrinks the schema's `top_risks`
-//! cap and asks for a shorter paragraph — the same one-shot truncation-retry
-//! shape used by the wave-3 batch investigation.  The `bedrock/`/`openrouter/`
+//! forced [`ResponseSchema`]).  #6093: the active [`SynthesisTier`] decides
+//! both array caps AND the request's `max_tokens` — a rung of the retry ladder
+//! raises the budget while shrinking the ask, and the reviewer role's own
+//! configured ceiling reaches the request instead of a constant overriding it.
+//! The `bedrock/`/`openrouter/`
 //! routing prefix is stripped so the bare id reaches the provider API.  #6009
 //! shape 3: [`schema_contract_statement`] renders the required field names
 //! and a canonical example object directly from the same [`ResponseSchema`]
@@ -42,22 +44,114 @@ use crate::report::section_instructions::{
     SECURITY_SUMMARY, TOP_RISKS,
 };
 use crate::report::synthesize_digest::{
-    build_split, gather_compact_findings, render_context_section, render_elaboration_section,
+    build_split_with_cap, gather_compact_findings, render_context_section,
+    render_elaboration_section,
 };
 
 /// Temperature for synthesis — low, to keep the analytic voice grounded.
 pub(super) const SYNTHESIS_TEMPERATURE: f32 = 0.2;
-/// Output-token ceiling for one synthesis pass.
-pub(super) const SYNTHESIS_MAX_TOKENS: u32 = 3072;
 
-/// `top_risks` array cap on the first attempt.
-const TOP_RISKS_CAP: usize = 5;
-/// `top_risks` array cap on the one concise retry (#2357 follow-up).
-const TOP_RISKS_RETRY_CAP: usize = 3;
-/// `findings` (elaboration) array cap — see [`super::synthesize_digest::ELABORATION_TARGETS_CAP`],
-/// which this mirrors so the schema structurally cannot exceed what the digest
-/// ever asks for.
-const FINDINGS_CAP: usize = super::synthesize_digest::ELABORATION_TARGETS_CAP;
+/// Output-token floor for one synthesis pass, below which no configured
+/// ceiling may take the request.
+///
+/// Why: this was the whole ceiling until #6093 — a hardcoded 3072 that ignored
+/// `[models.reviewer].max_tokens` entirely. It survives as a FLOOR because a
+/// smaller budget cannot fit four narrative paragraphs plus a top-risks table
+/// on any model, so honouring a tiny configured value literally would only
+/// produce a truncation the operator cannot diagnose.
+pub(super) const SYNTHESIS_MIN_MAX_TOKENS: u32 = 3072;
+
+/// Output-token budget used when no role ceiling is plumbed in (tests, and any
+/// caller that constructs a [`super::synthesize::Synthesizer`] directly).
+///
+/// Matches the reviewer role's own `max_tokens` default in
+/// `config::role_models`, so an unconfigured run and a default-configured run
+/// ask for the same budget.
+pub(super) const SYNTHESIS_DEFAULT_MAX_TOKENS: u32 = 4096;
+
+/// Hard ceiling the escalating retry rungs may reach.
+///
+/// Why: #6093 closure condition 3 — the truncation retry must escalate the
+/// ceiling, not only shrink the content. It still needs a bound, because a
+/// provider bills every token an escalation buys.
+pub(super) const SYNTHESIS_ESCALATED_MAX_TOKENS: u32 = 16384;
+
+/// One rung of the synthesis retry ladder: how much output budget the request
+/// asks for, and how large an ask it spends that budget on.
+///
+/// Why: a 45-finding investigation truncated twice against the pre-#6093 fixed
+/// 3072-token ceiling, and the single "concise" retry shrank only `top_risks`
+/// (5 → 3) while leaving the ten per-finding elaborations — nine prose fields
+/// each, and by far the dominant output cost — untouched at the same ceiling.
+/// So the retry could not converge, and an ~8-minute investigation exited 1
+/// with no report. Each rung here both RAISES the budget and SHRINKS the ask,
+/// so the ladder converges by construction: the last rung asks only for the
+/// four narrative paragraphs and three risk rows, at four times the configured
+/// budget.
+/// What: [`Self::top_risks_cap`] and [`Self::elaboration_cap`] bound the two
+/// arrays (schema `maxItems` AND the digest's own target list, so the two can
+/// never disagree); [`Self::budget`] scales the caller's configured ceiling.
+/// Dropping elaboration on the last rung drops no FINDING — every RED/AMBER
+/// finding still renders from the deterministic composition (#5374) and from
+/// the investigation's own verified prose, which wins over synthesis prose
+/// regardless (see `cli_report::merge_investigation_prose`).
+/// Test: `synthesize_tests.rs::{tier_ladder_raises_budget_and_shrinks_ask,
+/// narrative_only_tier_omits_findings_from_schema,
+/// synthesize_ladder_recovers_a_large_finding_set}`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SynthesisTier {
+    /// First attempt: the full ask at the configured budget.
+    Full,
+    /// Second attempt: fewer risk rows, fewer elaborations, double the budget.
+    Concise,
+    /// Final attempt: narrative + risk rows only, quadruple the budget.
+    NarrativeOnly,
+}
+
+/// The rungs tried in order, cheapest ask first.
+pub(super) const SYNTHESIS_TIER_LADDER: [SynthesisTier; 3] = [
+    SynthesisTier::Full,
+    SynthesisTier::Concise,
+    SynthesisTier::NarrativeOnly,
+];
+
+impl SynthesisTier {
+    /// `top_risks` array cap for this rung.
+    pub(crate) fn top_risks_cap(self) -> usize {
+        match self {
+            SynthesisTier::Full => 5,
+            SynthesisTier::Concise | SynthesisTier::NarrativeOnly => 3,
+        }
+    }
+
+    /// `findings` (elaboration) array cap for this rung; 0 omits the array
+    /// from both the schema and the digest.
+    pub(crate) fn elaboration_cap(self) -> usize {
+        match self {
+            SynthesisTier::Full => super::synthesize_digest::ELABORATION_TARGETS_CAP,
+            SynthesisTier::Concise => 3,
+            SynthesisTier::NarrativeOnly => 0,
+        }
+    }
+
+    /// The request's `max_tokens` for this rung, from the caller's configured
+    /// ceiling, clamped into
+    /// `[SYNTHESIS_MIN_MAX_TOKENS, SYNTHESIS_ESCALATED_MAX_TOKENS]`.
+    pub(crate) fn budget(self, configured: u32) -> u32 {
+        let scaled = match self {
+            SynthesisTier::Full => configured,
+            SynthesisTier::Concise => configured.saturating_mul(2),
+            SynthesisTier::NarrativeOnly => configured.saturating_mul(4),
+        };
+        scaled.clamp(SYNTHESIS_MIN_MAX_TOKENS, SYNTHESIS_ESCALATED_MAX_TOKENS)
+    }
+
+    /// True for every rung after the first — the response was truncated, so the
+    /// prompt says so and asks for a shorter answer.
+    fn is_retry(self) -> bool {
+        self != SynthesisTier::Full
+    }
+}
 
 /// The JSON Schema the provider forces the model to emit.
 ///
@@ -68,21 +162,21 @@ const FINDINGS_CAP: usize = super::synthesize_digest::ELABORATION_TARGETS_CAP;
 /// investigation's `maxItems`/`maxLength` fix for the identical class of
 /// output-truncation failure.
 /// What: returns a [`ResponseSchema`] named `report_synthesis`; `top_risks_cap`
-/// bounds the top-risks array (5 normally, 3 on the concise retry); the
-/// `findings` array is always capped at
-/// [`super::synthesize_digest::ELABORATION_TARGETS_CAP`] — the digest never
-/// lists more elaboration targets than that, so the model never has reason to
-/// exceed it.
-/// Test: `synthesize_tests.rs::{synthesis_schema_shape, schema_shrinks_on_retry}`.
+/// and `findings_cap` bound the two arrays at whatever the active
+/// [`SynthesisTier`] asks for, so the schema structurally cannot exceed what
+/// the digest lists. `findings_cap == 0` removes the `findings` property
+/// altogether (#6093's final rung), which also removes it from
+/// [`schema_contract_statement`] — the model is then never invited to spend
+/// output budget on prose the report body already carries.
+/// Test: `synthesize_tests.rs::{synthesis_schema_shape, schema_shrinks_on_retry,
+/// narrative_only_tier_omits_findings_from_schema}`.
 ///
 /// #5675: built via [`ResponseSchema::new`], which applies `enforce_strict_mode`.
 /// This schema previously used a struct literal and so never got that pass —
 /// `findings.items` carried no `additionalProperties`, and OpenAI strict mode
 /// (forwarded by OpenRouter for `openai/*`) rejected every synthesis call.
-pub(crate) fn synthesis_schema(top_risks_cap: usize) -> ResponseSchema {
-    ResponseSchema::new(
-        "report_synthesis",
-        serde_json::json!({
+pub(crate) fn synthesis_schema(top_risks_cap: usize, findings_cap: usize) -> ResponseSchema {
+    let mut schema = serde_json::json!({
             "type": "object",
             "properties": {
                 // #6030: the summary opens with what the system is and does and
@@ -123,7 +217,7 @@ pub(crate) fn synthesis_schema(top_risks_cap: usize) -> ResponseSchema {
                 },
                 "findings": {
                     "type": "array",
-                    "maxItems": FINDINGS_CAP,
+                    "maxItems": findings_cap,
                     "items": {
                         "type": "object",
                         "properties": {
@@ -145,8 +239,14 @@ pub(crate) fn synthesis_schema(top_risks_cap: usize) -> ResponseSchema {
                     "description": "Elaboration prose EXCLUSIVELY for the findings listed under \"Findings requiring elaboration\". Leave empty when that list says none. Never add a finding not in that list, and never re-elaborate a finding tagged [verified] elsewhere in the data."
                 }
             }
-        }),
-    )
+    });
+
+    if findings_cap == 0
+        && let Some(props) = schema["properties"].as_object_mut()
+    {
+        props.remove("findings");
+    }
+    ResponseSchema::new("report_synthesis", schema)
 }
 
 /// Render a deterministic statement of the required JSON shape directly from
@@ -341,37 +441,36 @@ Populate the structured response:
 /// What: resolves the active section instructions (template override else
 /// generic default, via [`section_instructions::resolve`]), assembles the
 /// dynamic system prompt, a compact data digest, and the size-bounded
-/// forced-output schema.  `retry_concise` (the one-shot truncation retry)
-/// shrinks `top_risks_cap` to [`TOP_RISKS_RETRY_CAP`] and appends the retry
-/// directive.  Strips any provider routing prefix from `llm_model`.
+/// forced-output schema.  `tier` decides both array caps and the request's
+/// `max_tokens` (see [`SynthesisTier`]); `configured_max_tokens` is the
+/// reviewer role's own ceiling, which reaches the request here rather than
+/// being overridden by a constant (#6093).  Strips any provider routing prefix
+/// from `llm_model`.
 /// Test: `synthesize_tests.rs::{prompt_excludes_greens, prompt_strips_prefix,
 /// synthesis_schema_shape, digest_uses_compact_findings,
-/// template_override_reaches_system_prompt}`.
+/// template_override_reaches_system_prompt,
+/// tier_ladder_raises_budget_and_shrinks_ask}`.
 pub(super) fn build_synthesis_prompt(
     model: &ReportModel,
     llm_model: &str,
-    retry_concise: bool,
+    tier: SynthesisTier,
+    configured_max_tokens: u32,
 ) -> LlmRequest {
     let resolved = section_instructions::resolve(&model.section_instructions);
-    let top_risks_cap = if retry_concise {
-        TOP_RISKS_RETRY_CAP
-    } else {
-        TOP_RISKS_CAP
-    };
     // #6009 shape 3: built from the SAME schema value forced via
     // `response_format` below, so the prompt-text contract and the schema can
     // never say different things — see `schema_contract_statement`.
-    let schema = synthesis_schema(top_risks_cap);
+    let schema = synthesis_schema(tier.top_risks_cap(), tier.elaboration_cap());
     let contract = schema_contract_statement(&schema.schema);
     LlmRequest {
         model: strip_provider_prefix(llm_model).to_string(),
-        system: synthesis_system_prompt(&resolved, retry_concise, &contract),
+        system: synthesis_system_prompt(&resolved, tier.is_retry(), &contract),
         messages: vec![ChatMessage {
             role: "user".to_string(),
-            content: build_digest(model),
+            content: build_digest(model, tier.elaboration_cap()),
         }],
         temperature: SYNTHESIS_TEMPERATURE,
-        max_tokens: SYNTHESIS_MAX_TOKENS,
+        max_tokens: tier.budget(configured_max_tokens),
         response_schema: Some(schema),
     }
 }
@@ -451,8 +550,10 @@ fn repo_profile_lines(repo: &super::model::RepositoryReport) -> String {
 /// [`super::synthesize_digest`]); then the wave-3 coverage summary
 /// (unchanged) and the analyst focus directives (unchanged, additive on top
 /// of whichever section instructions are active).
+/// `elaboration_cap` is the active [`SynthesisTier`]'s (#6093), so the digest's
+/// target list and the schema's `maxItems` are always the same number.
 /// Test: `synthesize_tests.rs::{prompt_excludes_greens, digest_stays_bounded_at_100_findings}`.
-fn build_digest(model: &ReportModel) -> String {
+fn build_digest(model: &ReportModel, elaboration_cap: usize) -> String {
     let mut msg = String::with_capacity(4096);
     msg.push_str(&format!("# Report: {}\n\n", model.title));
     msg.push_str(&format!(
@@ -507,7 +608,7 @@ fn build_digest(model: &ReportModel) -> String {
     // replacing the old per-repo full-title bullet list. Greens are excluded
     // structurally by `gather_compact_findings` (the no-green rule, unchanged).
     let compact = gather_compact_findings(model);
-    let split = build_split(&compact);
+    let split = build_split_with_cap(&compact, elaboration_cap);
     msg.push_str(&render_context_section(&split));
     msg.push_str(&render_elaboration_section(&split));
 

--- a/crates/trusty-review/src/report/synthesize_tests.rs
+++ b/crates/trusty-review/src/report/synthesize_tests.rs
@@ -24,7 +24,8 @@ use crate::report::metrics::{
 use crate::report::model::{ReportModel, RepositoryReport};
 use crate::report::synthesize_guard::{allowed_numbers, numbers_in, verify_prose};
 use crate::report::synthesize_prompt::{
-    build_synthesis_prompt, schema_contract_statement, synthesis_schema,
+    SYNTHESIS_DEFAULT_MAX_TOKENS, SYNTHESIS_ESCALATED_MAX_TOKENS, SYNTHESIS_MIN_MAX_TOKENS,
+    SynthesisTier, build_synthesis_prompt, schema_contract_statement, synthesis_schema,
 };
 
 use super::{Synthesis, SynthesisError, Synthesizer};
@@ -321,7 +322,12 @@ fn verify_prose_accepts_rounding() {
 #[test]
 fn prompt_excludes_greens() {
     let model = fixture_model(vec![red("SQL injection risk"), green("GREEN_SECRET_TOPIC")]);
-    let req = build_synthesis_prompt(&model, "stub/model", false);
+    let req = build_synthesis_prompt(
+        &model,
+        "stub/model",
+        SynthesisTier::Full,
+        SYNTHESIS_DEFAULT_MAX_TOKENS,
+    );
     let digest = &req.messages[0].content;
     assert!(
         digest.contains("SQL injection risk"),
@@ -339,9 +345,19 @@ fn prompt_excludes_greens() {
 #[test]
 fn prompt_strips_prefix() {
     let model = fixture_model(vec![]);
-    let req = build_synthesis_prompt(&model, "bedrock/us.anthropic.claude-sonnet-4-6", false);
+    let req = build_synthesis_prompt(
+        &model,
+        "bedrock/us.anthropic.claude-sonnet-4-6",
+        SynthesisTier::Full,
+        SYNTHESIS_DEFAULT_MAX_TOKENS,
+    );
     assert_eq!(req.model, "us.anthropic.claude-sonnet-4-6");
-    let req2 = build_synthesis_prompt(&model, "openrouter/openai/gpt-5.4-mini", false);
+    let req2 = build_synthesis_prompt(
+        &model,
+        "openrouter/openai/gpt-5.4-mini",
+        SynthesisTier::Full,
+        SYNTHESIS_DEFAULT_MAX_TOKENS,
+    );
     assert_eq!(req2.model, "openai/gpt-5.4-mini");
 }
 
@@ -353,7 +369,7 @@ fn prompt_strips_prefix() {
 /// Test: this test itself.
 #[test]
 fn synthesis_schema_shape() {
-    let schema = synthesis_schema(5);
+    let schema = synthesis_schema(5, 10);
     assert_eq!(schema.name, "report_synthesis");
     let props = &schema.schema["properties"];
     assert!(props["executive_summary"].is_object());
@@ -367,7 +383,12 @@ fn synthesis_schema_shape() {
     assert!(props["findings"].is_object());
     assert_eq!(props["top_risks"]["maxItems"], 5);
     assert_eq!(props["findings"]["maxItems"], 10);
-    let req = build_synthesis_prompt(&fixture_model(vec![]), "stub/model", false);
+    let req = build_synthesis_prompt(
+        &fixture_model(vec![]),
+        "stub/model",
+        SynthesisTier::Full,
+        SYNTHESIS_DEFAULT_MAX_TOKENS,
+    );
     assert!(
         req.response_schema.is_some(),
         "every synthesis request must force structured output"
@@ -377,12 +398,12 @@ fn synthesis_schema_shape() {
 /// Why: #6009 shape 3 — the prompt-text contract must be derived FROM the
 /// schema, not hand-typed beside it, or the two can drift exactly the way
 /// the three live shapes drifted from the schema itself.
-/// What: asserts the statement built from `synthesis_schema(5)` names every
+/// What: asserts the statement built from `synthesis_schema(5, 10)` names every
 /// canonical top-level field and every `top_risks`/`findings` item field.
 /// Test: this test itself.
 #[test]
 fn schema_contract_statement_lists_every_field_name() {
-    let schema = synthesis_schema(5);
+    let schema = synthesis_schema(5, 10);
     let contract = schema_contract_statement(&schema.schema);
     for needle in [
         "executive_summary",
@@ -421,7 +442,12 @@ fn schema_contract_statement_lists_every_field_name() {
 #[test]
 fn schema_contract_statement_reaches_system_prompt() {
     let model = fixture_model(vec![]);
-    let req = build_synthesis_prompt(&model, "stub/model", false);
+    let req = build_synthesis_prompt(
+        &model,
+        "stub/model",
+        SynthesisTier::Full,
+        SYNTHESIS_DEFAULT_MAX_TOKENS,
+    );
     assert!(req.system.contains("Required JSON object shape"));
     assert!(req.system.contains("executive_summary"));
     // #6004: the same derivation must carry the new narrative slots into the
@@ -442,7 +468,12 @@ fn schema_contract_statement_reaches_system_prompt() {
 #[test]
 fn retry_concise_shrinks_top_risks_cap_and_adds_directive() {
     let model = fixture_model(vec![]);
-    let req = build_synthesis_prompt(&model, "stub/model", true);
+    let req = build_synthesis_prompt(
+        &model,
+        "stub/model",
+        SynthesisTier::Concise,
+        SYNTHESIS_DEFAULT_MAX_TOKENS,
+    );
     let schema = req.response_schema.expect("schema present");
     assert_eq!(schema.schema["properties"]["top_risks"]["maxItems"], 3);
     assert!(req.system.contains("Retry directive"));
@@ -459,7 +490,12 @@ fn retry_concise_shrinks_top_risks_cap_and_adds_directive() {
 #[test]
 fn system_prompt_uses_generic_defaults_when_no_override() {
     let model = fixture_model(vec![]);
-    let req = build_synthesis_prompt(&model, "stub/model", false);
+    let req = build_synthesis_prompt(
+        &model,
+        "stub/model",
+        SynthesisTier::Full,
+        SYNTHESIS_DEFAULT_MAX_TOKENS,
+    );
     assert!(
         req.system.contains("deal-analytic paragraph"),
         "generic executive_summary default must appear verbatim: {}",
@@ -481,7 +517,12 @@ fn template_override_reaches_system_prompt() {
         "executive_summary".to_string(),
         "CAST-FLAVOURED OVERRIDE: lead with the TQI and health-factor posture.".to_string(),
     );
-    let req = build_synthesis_prompt(&model, "stub/model", false);
+    let req = build_synthesis_prompt(
+        &model,
+        "stub/model",
+        SynthesisTier::Full,
+        SYNTHESIS_DEFAULT_MAX_TOKENS,
+    );
     assert!(
         req.system.contains("CAST-FLAVOURED OVERRIDE"),
         "template override must reach the system prompt: {}",
@@ -503,7 +544,12 @@ fn partial_template_override_leaves_other_sections_generic() {
         "top_risks".to_string(),
         "TOP RISKS OVERRIDE TEXT".to_string(),
     );
-    let req = build_synthesis_prompt(&model, "stub/model", false);
+    let req = build_synthesis_prompt(
+        &model,
+        "stub/model",
+        SynthesisTier::Full,
+        SYNTHESIS_DEFAULT_MAX_TOKENS,
+    );
     assert!(req.system.contains("TOP RISKS OVERRIDE TEXT"));
     assert!(req.system.contains("deal-analytic paragraph"));
 }
@@ -526,7 +572,12 @@ fn system_prompt_asks_for_unregistered_target_gaps() {
         "executive_summary".to_string(),
         "OVERRIDE: lead with the TQI posture.".to_string(),
     );
-    let req = build_synthesis_prompt(&model, "stub/model", false);
+    let req = build_synthesis_prompt(
+        &model,
+        "stub/model",
+        SynthesisTier::Full,
+        SYNTHESIS_DEFAULT_MAX_TOKENS,
+    );
     for needle in [
         "Coverage gaps in the assessed set",
         "coverage-gaps note",
@@ -586,7 +637,12 @@ fn authorship_figures_reach_the_synthesis_prompt() {
         caveats: vec![],
     });
 
-    let req = build_synthesis_prompt(&model, "stub/model", false);
+    let req = build_synthesis_prompt(
+        &model,
+        "stub/model",
+        SynthesisTier::Full,
+        SYNTHESIS_DEFAULT_MAX_TOKENS,
+    );
     let digest = &req.messages[0].content;
     assert!(
         digest.contains("Authorship:"),
@@ -603,7 +659,12 @@ fn authorship_figures_reach_the_synthesis_prompt() {
         "the trailing-window trend must reach the prompt too: {digest}"
     );
 
-    let without = build_synthesis_prompt(&fixture_model(vec![]), "stub/model", false);
+    let without = build_synthesis_prompt(
+        &fixture_model(vec![]),
+        "stub/model",
+        SynthesisTier::Full,
+        SYNTHESIS_DEFAULT_MAX_TOKENS,
+    );
     assert!(
         !without.messages[0].content.contains("Authorship:"),
         "a repository with no artifact must contribute no authorship line at all: {}",
@@ -888,15 +949,19 @@ async fn synthesize_retry_recovers_from_truncation() {
     assert_eq!(llm.call_count(), 2, "exactly one retry must have occurred");
 }
 
-/// Why: the retry is a single cheap attempt, never an open-ended loop. #5454
-/// changed only what happens when it is spent — an error, not a degraded report.
-/// What: the queued stub truncates on both calls; asserts
-/// `Err(SynthesisError::Truncated)` and exactly 2 calls (no further retries).
+/// Why: the retry ladder is a bounded escalation, never an open-ended loop.
+/// #5454 decides what happens when it is spent — an error, not a degraded
+/// report. #6093 changed the bound from two calls to three (full → concise →
+/// narrative-only), so a provider that truncates unconditionally now costs
+/// three calls and no more.
+/// What: the queued stub truncates on every call; asserts
+/// `Err(SynthesisError::Truncated)` and exactly 3 calls.
 /// Test: this test itself.
 #[tokio::test]
 async fn synthesize_still_truncated_after_retry_is_a_hard_error() {
     let model = fixture_model(vec![red("x")]);
     let llm = Arc::new(QueuedLlm::new(vec![
+        ("{}", Some("length")),
         ("{}", Some("length")),
         ("{}", Some("length")),
     ]));
@@ -910,8 +975,8 @@ async fn synthesize_still_truncated_after_retry_is_a_hard_error() {
     );
     assert_eq!(
         llm.call_count(),
-        2,
-        "no more than one retry must be attempted"
+        3,
+        "the ladder must stop after its three rungs"
     );
 }
 
@@ -1575,7 +1640,12 @@ fn system_prompt_asks_what_the_codebase_does() {
         "executive_summary".to_string(),
         "OVERRIDE: lead with the TQI posture.".to_string(),
     );
-    let req = build_synthesis_prompt(&model, "stub/model", false);
+    let req = build_synthesis_prompt(
+        &model,
+        "stub/model",
+        SynthesisTier::Full,
+        SYNTHESIS_DEFAULT_MAX_TOKENS,
+    );
     for needle in [
         "What the codebase does",
         "what the audited system IS and what it DOES",
@@ -1630,7 +1700,13 @@ fn digest_carries_scan_profile_without_metrics() {
         frameworks: vec![],
     });
 
-    let digest = build_synthesis_prompt(&model, "stub/model", false).messages[0]
+    let digest = build_synthesis_prompt(
+        &model,
+        "stub/model",
+        SynthesisTier::Full,
+        SYNTHESIS_DEFAULT_MAX_TOKENS,
+    )
+    .messages[0]
         .content
         .clone();
     assert!(digest.contains("Total LoC: 1500000"), "{digest}");
@@ -1660,11 +1736,276 @@ fn digest_names_build_manifests_as_component_evidence() {
         }],
     });
 
-    let digest = build_synthesis_prompt(&model, "stub/model", false).messages[0]
+    let digest = build_synthesis_prompt(
+        &model,
+        "stub/model",
+        SynthesisTier::Full,
+        SYNTHESIS_DEFAULT_MAX_TOKENS,
+    )
+    .messages[0]
         .content
         .clone();
     assert!(digest.contains("Build manifests / frameworks:"), "{digest}");
     assert!(digest.contains("package.json"), "{digest}");
     assert!(digest.contains("acme-web"), "{digest}");
     assert!(digest.contains("react"), "{digest}");
+}
+
+// ── #6093: the output-budget retry ladder ───────────────────────────────────
+
+/// A provider that models a real output-token ceiling: it answers only when the
+/// response the request ASKS FOR fits inside the request's own `max_tokens`.
+///
+/// Why: the #6093 defect is not that a stub said "length" twice — it is that
+/// the ask stayed the same size while the ceiling stayed at a hardcoded 3072,
+/// so no retry could ever converge. A stub returning a scripted `finish_reason`
+/// cannot express that; this one derives the verdict from the request, so a fix
+/// that only shrinks content, or only raises the ceiling, still fails it if the
+/// two never meet.
+/// What: reads `max_tokens` and the schema's own `top_risks`/`findings`
+/// `maxItems` off the request, prices the response at
+/// `overhead + narrative + risks * per_risk + findings * per_finding`, and
+/// returns `finish_reason: "length"` with an empty body when that exceeds
+/// `max_tokens`. `overhead` stands in for the reasoning tokens an
+/// Anthropic-family model spends before the JSON starts.
+struct CeilingLlm {
+    overhead: u32,
+    narrative: u32,
+    per_risk: u32,
+    per_finding: u32,
+    calls: std::sync::atomic::AtomicUsize,
+    budgets: Mutex<Vec<u32>>,
+}
+
+impl CeilingLlm {
+    fn new(overhead: u32, narrative: u32, per_risk: u32, per_finding: u32) -> Self {
+        CeilingLlm {
+            overhead,
+            narrative,
+            per_risk,
+            per_finding,
+            calls: std::sync::atomic::AtomicUsize::new(0),
+            budgets: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn call_count(&self) -> usize {
+        self.calls.load(std::sync::atomic::Ordering::SeqCst)
+    }
+
+    /// The `max_tokens` seen on each call, in call order.
+    fn budgets(&self) -> Vec<u32> {
+        self.budgets.lock().unwrap().clone()
+    }
+
+    /// `maxItems` for one top-level array property, or 0 when the property is
+    /// absent from the schema entirely (the narrative-only rung).
+    fn max_items(req: &LlmRequest, property: &str) -> u32 {
+        req.response_schema
+            .as_ref()
+            .and_then(|s| s.schema["properties"][property]["maxItems"].as_u64())
+            .unwrap_or(0) as u32
+    }
+}
+
+#[async_trait]
+impl LlmProvider for CeilingLlm {
+    fn name(&self) -> &str {
+        "ceiling"
+    }
+    async fn complete(&self, req: LlmRequest) -> Result<LlmResponse, LlmError> {
+        self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        self.budgets.lock().unwrap().push(req.max_tokens);
+
+        let risks = Self::max_items(&req, "top_risks");
+        let findings = Self::max_items(&req, "findings");
+        let needed =
+            self.overhead + self.narrative + risks * self.per_risk + findings * self.per_finding;
+
+        let truncated = needed > req.max_tokens;
+        Ok(LlmResponse {
+            text: if truncated {
+                String::new()
+            } else {
+                good_response()
+            },
+            model: "ceiling".to_string(),
+            input_tokens: 4000,
+            output_tokens: needed.min(req.max_tokens),
+            latency_ms: 1,
+            cost_usd: 0.0,
+            finish_reason: Some(if truncated { "length" } else { "stop" }.to_string()),
+        })
+    }
+}
+
+/// Why: the reported defect (#6093, reproduced twice on 0.21.0 against a 44-
+/// and a 45-finding investigation). Before the ladder, the first call and its
+/// "concise" retry both asked for ten per-finding elaborations at a fixed
+/// 3072-token ceiling, so both truncated and an eight-minute investigation
+/// exited with no report at all.
+/// What: 45 RED findings, none verified, against a provider that truncates
+/// whenever the ask outgrows the request's own `max_tokens`. Asserts synthesis
+/// SUCCEEDS, that it took more than one call to get there, and that each retry
+/// raised the budget — pre-fix code sends 3072 on both calls and fails this.
+/// Test: this test itself.
+#[tokio::test]
+async fn synthesize_ladder_recovers_a_large_finding_set() {
+    let findings: Vec<MetricFinding> = (0..45).map(|i| red(&format!("finding {i}"))).collect();
+    let model = fixture_model(findings);
+    // Prices roughly matched to a real run: ~1200 tokens of narrative, ~120 per
+    // risk row, ~320 per nine-field elaboration, ~900 of reasoning overhead.
+    let llm = Arc::new(CeilingLlm::new(900, 1200, 120, 320));
+
+    let result = Synthesizer::new(llm.clone(), "stub/model")
+        .synthesize(&model)
+        .await
+        .expect("a 45-finding investigation must synthesize to a complete report");
+
+    assert!(
+        result.executive_summary.is_some(),
+        "the narrative must survive the ladder: {:?}",
+        result.notes
+    );
+    let budgets = llm.budgets();
+    assert!(
+        llm.call_count() > 1,
+        "this fixture must exercise a retry, not pass on the first call"
+    );
+    assert!(
+        budgets.windows(2).all(|w| w[1] > w[0]),
+        "each retry must raise the output budget, got {budgets:?}"
+    );
+}
+
+/// Why: the ladder must converge even when per-finding prose is ruinously
+/// expensive — that is what the final narrative-only rung exists for.
+/// What: a per-finding price no budget can absorb; asserts synthesis still
+/// succeeds and that it took all three rungs.
+/// Test: this test itself.
+#[tokio::test]
+async fn synthesize_ladder_falls_back_to_narrative_only() {
+    let findings: Vec<MetricFinding> = (0..45).map(|i| red(&format!("finding {i}"))).collect();
+    let model = fixture_model(findings);
+    let llm = Arc::new(CeilingLlm::new(900, 1200, 120, 100_000));
+
+    let result = Synthesizer::new(llm.clone(), "stub/model")
+        .synthesize(&model)
+        .await
+        .expect("the narrative-only rung must still produce a report");
+
+    assert!(result.executive_summary.is_some());
+    assert_eq!(
+        llm.call_count(),
+        3,
+        "the ladder is three rungs: full, concise, narrative-only"
+    );
+}
+
+/// Why: #6093 closure condition 2 — a configured `[models.reviewer].max_tokens`
+/// must demonstrably reach the synthesis request. It never did: the request
+/// carried a hardcoded 3072 whatever the operator configured.
+/// What: sets 9000 via `with_max_tokens` and asserts the first request carried
+/// exactly that; then sets a value below the floor and asserts it is raised to
+/// the floor rather than sent as an unmeetable ceiling.
+/// Test: this test itself.
+#[tokio::test]
+async fn configured_max_tokens_reaches_the_request() {
+    let model = fixture_model(vec![red("x")]);
+
+    let llm = Arc::new(CeilingLlm::new(0, 10, 1, 1));
+    Synthesizer::new(llm.clone(), "stub/model")
+        .with_max_tokens(9000)
+        .synthesize(&model)
+        .await
+        .expect("synthesis succeeds");
+    assert_eq!(llm.budgets().first().copied(), Some(9000));
+
+    let small = Arc::new(CeilingLlm::new(0, 10, 1, 1));
+    Synthesizer::new(small.clone(), "stub/model")
+        .with_max_tokens(64)
+        .synthesize(&model)
+        .await
+        .expect("synthesis succeeds");
+    assert_eq!(
+        small.budgets().first().copied(),
+        Some(SYNTHESIS_MIN_MAX_TOKENS),
+        "a configured ceiling below the floor is raised to it"
+    );
+}
+
+/// Why: the ladder only converges if every rung both raises the budget and
+/// shrinks the ask; a rung that does one without the other reintroduces #6093.
+/// What: asserts the budget rises and the two array caps fall across the
+/// ladder, and that the escalation stays bounded.
+/// Test: this test itself.
+#[test]
+fn tier_ladder_raises_budget_and_shrinks_ask() {
+    let tiers = [
+        SynthesisTier::Full,
+        SynthesisTier::Concise,
+        SynthesisTier::NarrativeOnly,
+    ];
+    let budgets: Vec<u32> = tiers.iter().map(|t| t.budget(4096)).collect();
+    assert!(
+        budgets.windows(2).all(|w| w[1] > w[0]),
+        "budgets must rise: {budgets:?}"
+    );
+    assert!(
+        budgets.iter().all(|b| *b <= SYNTHESIS_ESCALATED_MAX_TOKENS),
+        "escalation must stay bounded: {budgets:?}"
+    );
+
+    let asks: Vec<(usize, usize)> = tiers
+        .iter()
+        .map(|t| (t.top_risks_cap(), t.elaboration_cap()))
+        .collect();
+    assert!(
+        asks.windows(2).all(|w| w[1].0 <= w[0].0 && w[1].1 < w[0].1),
+        "each rung must ask for strictly fewer elaborations: {asks:?}"
+    );
+    assert_eq!(
+        SynthesisTier::NarrativeOnly.elaboration_cap(),
+        0,
+        "the final rung asks for no elaboration prose"
+    );
+}
+
+/// Why: on the final rung the `findings` array must be absent from the schema,
+/// not merely capped at zero — a zero-length array the model is still shown is
+/// an invitation to fill it.
+/// What: builds the narrative-only request; asserts the schema and its derived
+/// contract statement both omit `findings`, and that the digest says
+/// elaboration was deferred rather than claiming everything is verified.
+/// Test: this test itself.
+#[test]
+fn narrative_only_tier_omits_findings_from_schema() {
+    let findings: Vec<MetricFinding> = (0..12).map(|i| red(&format!("finding {i}"))).collect();
+    let req = build_synthesis_prompt(
+        &fixture_model(findings),
+        "stub/model",
+        SynthesisTier::NarrativeOnly,
+        SYNTHESIS_DEFAULT_MAX_TOKENS,
+    );
+    let schema = req.response_schema.as_ref().expect("schema forced");
+    assert!(
+        schema.schema["properties"]["findings"].is_null(),
+        "findings must be absent: {}",
+        schema.schema
+    );
+    assert!(
+        !schema_contract_statement(&schema.schema).contains("findings"),
+        "the prompt-text contract must not name a field the schema dropped"
+    );
+    assert!(schema.schema["properties"]["executive_summary"].is_object());
+
+    let digest = &req.messages[0].content;
+    assert!(
+        digest.contains("none this pass"),
+        "the digest must say elaboration was deferred, not that all are verified: {digest}"
+    );
+    assert!(
+        !digest.contains("every RED/AMBER finding already has verified"),
+        "that line would be false here: {digest}"
+    );
 }


### PR DESCRIPTION
Report synthesis failed outright once an investigation verified 44 or 45 findings — reproduced twice on 0.21.0 (#6093). Both the first call and its concise retry truncated, the run exited 1, and the whole ~8-minute investigation was discarded. 26 findings rendered clean on the same binary.

## Why the retry could not converge

Two things, and fixing either alone leaves the defect:

- The request's output ceiling was a hardcoded `SYNTHESIS_MAX_TOKENS: u32 = 3072` in `synthesize_prompt.rs`. `[models.reviewer].max_tokens` never reached the synthesis path — `Synthesizer::new(provider, role.model.clone())` took the model id and nothing else, so raising the configured ceiling did not change the request that truncated.
- The concise retry shrank only the top-risks table, five rows to three. It left ten per-finding elaborations — nine prose fields each, by far the dominant output cost — at that same 3072 ceiling. So the second call asked for essentially the first call's response and truncated the same way.

## The fix

The retry is a three-rung ladder in `SynthesisTier`. Every rung raises the budget and shrinks the ask together, so it converges by construction:

| Rung | `max_tokens` | top-risk rows | elaborations |
|---|---|---|---|
| Full | configured ceiling | 5 | 10 |
| Concise | 2x | 3 | 3 |
| NarrativeOnly | 4x | 3 | 0 (property removed from the schema) |

`Synthesizer::with_max_tokens` plumbs `role.max_tokens` in, so a configured ceiling reaches the request; `SYNTHESIS_MIN_MAX_TOKENS` (the old 3072) survives as a floor and `SYNTHESIS_ESCALATED_MAX_TOKENS` (16384) bounds the escalation. The cap is one number shared by the schema's `maxItems` and the digest's own target list, so the two cannot disagree.

Dropping elaboration on the last rung drops no finding. Every RED/AMBER finding still renders from the deterministic composition (#5374), and the investigation's verified prose is merged over synthesis prose afterwards regardless. The digest says so honestly — "none this pass", never the pre-existing "everything is already verified" line, which would be false there. Exhausting the ladder stays fatal per #5454, and the numeric guardrail, the greens exclusion, and the DOC-68 honesty markers are untouched.

## Investigation survives a failed synthesis

`persist_investigation` writes the verified investigation to `<out_dir>/investigation.json` before the first synthesis call. It lands next to the report the run is trying to produce, so any downstream failure leaves the expensive half of the run recoverable. A write failure warns and never aborts a run that would otherwise succeed.

## Regression test

`synthesize_ladder_recovers_a_large_finding_set` — 45 unverified RED findings against `CeilingLlm`, a stub that prices the response from the request's own `max_tokens` and schema `maxItems` and returns `finish_reason: "length"` when the ask does not fit. A scripted-`finish_reason` stub cannot express this defect; this one fails any fix that only raises the ceiling or only shrinks the ask.

Proven to fail pre-fix by temporarily restoring the old constants (fixed 3072 budget, elaboration cap 10 on the retry):

```
test report::synthesize::tests::synthesize_ladder_recovers_a_large_finding_set ... FAILED
panicked at crates/trusty-review/src/report/synthesize_tests.rs:1786:
a 45-finding investigation must synthesize to a complete report: Truncated
test result: FAILED. 0 passed; 1 failed
```

## Gates — test ladder rung 3

```
cargo fmt --check                                     EXIT=0
cargo clippy -p trusty-review --all-targets -- -D warnings   EXIT=0
cargo test -p trusty-review                           1731 + 74 + 1 + 21 passed; 0 failed; 5 ignored
bash scripts/check_line_cap.sh                        4123 files, 0 violations
bash scripts/check_sld.sh                             0 errors, 0 warnings
```

## Live verification

The exact failing invocation, against a release build of this branch:

```
trusty-audit render --from /Users/masa/dogfood-audit/work \
  --out /Users/masa/dogfood-audit/render4 \
  --config /Users/masa/dogfood-audit/engagement.toml \
  --review-bin <this branch, release>
EXIT=0
```

Report: `/Users/masa/dogfood-audit/render4/00-local-repo-full/2026-08-19-technical-due-diligence.md` (41,256 bytes; the JSON twin is 117,343). `investigation.json` (35,880 bytes) is timestamped 22:57 against the report's 22:59 — it landed before synthesis, as designed.

Coverage block:

```
- investigation: available
- files examined: 20 of 6638 tracked (0.3% coverage, 6618 skipped); 409600 bytes sent (budget 40/409600)
- dimensions covered: state management, test coverage
- dimensions NOT investigated: authentication & secrets, dependencies, error handling, scalability
- investigation: 1 finding(s) rejected (unverifiable evidence)
- verified evidence-backed findings: 37
- batches: 6 total, 6 succeeded, 0 truncated/failed
```

The guardrail is still enforcing on the live run — two fields were dropped for citing figures absent from the collected data, and the report rendered anyway:

```
- synthesis: available
- synthesis: rejected (unverified figure) in executive summary: 1.54
- synthesis: rejected (unverified figure) in authorship summary: 7120.5
```

### File selection

The examined set is exactly the manifest's `inspect_priority` ranks 1-20. All 18 files cited by verified findings are `inspect_priority` entries and none came from anywhere else; rank #1 `crates/trusty-common/src/memory_core/store/hnsw_store.rs` is among them and produced the report's #1 RED risk (the HNSW snapshot data-loss window). Ranks 13 (`crates/trusty-audit/src/session.rs`) and 18 (`scripts/lib/rustdoc_walk.py`) were examined and produced no verified finding; ranks 21-25 fell outside the 20-file budget.

Refs #6093
Refs #6081

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
