### PR TITLE
docs: fix five broken intra-doc links failing the pre-publish rustdoc gate

### DIFF
--- a/crates/trusty-common/changelog.d/6112-memory-rpc-doc-links.md
+++ b/crates/trusty-common/changelog.d/6112-memory-rpc-doc-links.md
@@ -1,0 +1,13 @@
+Documentation
+
+- `memory_rpc`'s own module doc (`//!`) no longer breaks `cargo doc` for the
+  whole workspace. As with #6027's `http_client` fix, `memory_rpc.rs` carries
+  docs in two places — the `//!` header in the file and the `///` block on
+  `pub mod memory_rpc;` in `lib.rs` — and rustdoc merges both into one doc
+  string whose link-resolution scope comes from the first fragment, the
+  `lib.rs` one. The four bare `[`resolve_memory_base_url`]`-style links in the
+  `//!` header therefore resolved against the crate root and were not found,
+  which `#![deny(rustdoc::broken_intra_doc_links)]` turned into
+  `error: could not document trusty-common` under the full-feature build
+  `check_contracts.sh` runs. The four links are now crate-absolute
+  (`memory_rpc::…`).

--- a/crates/trusty-common/src/memory_rpc.rs
+++ b/crates/trusty-common/src/memory_rpc.rs
@@ -14,12 +14,13 @@
 //! (gated behind `monitor-tui`, which trusty-mpm does not enable) or the
 //! subprocess-oriented `stdio_mcp_client` / `daemon_bridge` (no generic call
 //! surface).
-//! What: [`resolve_memory_base_url`] resolves the base URL (env override
-//! first, discovery fallback, `Err` when neither is available);
-//! [`resolve_memory_base_url_or_unreachable`] is the fail-open convenience
-//! wrapper callers that must never error use. [`call_memory_tool`] resolves
-//! the address and POSTs a JSON-RPC request for `method`/`params`, returning
-//! the envelope's `result`. [`call_memory_tool_at`] is the same call against
+//! What: [`memory_rpc::resolve_memory_base_url`] resolves the base URL (env
+//! override first, discovery fallback, `Err` when neither is available);
+//! [`memory_rpc::resolve_memory_base_url_or_unreachable`] is the fail-open
+//! convenience wrapper callers that must never error use.
+//! [`memory_rpc::call_memory_tool`] resolves the address and POSTs a
+//! JSON-RPC request for `method`/`params`, returning the envelope's
+//! `result`. [`memory_rpc::call_memory_tool_at`] is the same call against
 //! an explicit, already-resolved base URL (used by callers — e.g. catch-up's
 //! `CatchupOptions::memory_url` — that thread their own resolved/overridable
 //! address through, including tests that point at a controlled unreachable

--- a/crates/trusty-mpm/changelog.d/6112-doctor-worktrees-doc-link.md
+++ b/crates/trusty-mpm/changelog.d/6112-doctor-worktrees-doc-link.md
@@ -1,0 +1,7 @@
+Documentation
+
+- `doctor_worktrees.rs`'s `[`run_doctor`]` intra-doc link no longer breaks
+  `cargo doc` for the workspace. `run_doctor` lives in the sibling module
+  `daemon::doctor` and was never imported into `doctor_worktrees.rs`, so the
+  bare link did not resolve; it now reads
+  `[`crate::daemon::doctor::run_doctor`]`.

--- a/crates/trusty-mpm/src/daemon/doctor_worktrees.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_worktrees.rs
@@ -32,7 +32,8 @@ pub const WORKTREE_REMEDIATION_COMMAND: &str = "tm session prune-worktrees";
 /// The reconciled worktree inventory, reduced to the four numbers doctor
 /// reports (#5947).
 ///
-/// Why: [`run_doctor`] is public and the reconciled report is crate-internal,
+/// Why: [`crate::daemon::doctor::run_doctor`] is public and the reconciled
+/// report is crate-internal,
 /// so the check takes this instead — and taking only counts also makes the
 /// no-inventory case (`None`) explicit at the call site rather than something
 /// the probe has to infer.


### PR DESCRIPTION
## Summary

`check_rustdoc_links.sh` (Gate 1) and `check_contracts.sh` (Gates 5-6) are red
on `main`, blocking tonight's publish chain — first observed on
[run 32332304328](https://github.com/bobmatnyc/trusty-tools/actions/runs/32332304328)
(`trusty-mcp-v0.1.0` pre-publish gate: Gate 5 fails, Gate 6 never runs).

Regressed by two PRs, each leaving a bare intra-doc link that resolves in
the writer's own module scope but not in rustdoc's actual link-resolution
scope for a module documented from two places:

- **#5809** (ADR-0040 `trusty-mcp` extraction) moved `memory_rpc` and left
  `crates/trusty-common/src/memory_rpc.rs`'s own `//!` module header linking
  four of its own `pub fn`s (`resolve_memory_base_url`,
  `resolve_memory_base_url_or_unreachable`, `call_memory_tool`,
  `call_memory_tool_at`) by bare name.
- **#6097** split `crates/trusty-mpm/src/daemon/doctor_worktrees.rs` out of
  `daemon/doctor.rs`, leaving a `[`run_doctor`]` link to a function that now
  lives in a sibling module and was never imported here.

## Root cause

rustdoc merges a module's `//!` doc with the `///` doc on its `pub mod`
declaration into one doc string, and resolves links against the FIRST
fragment's scope — the declaration site's (`lib.rs`, i.e. the crate root) —
not the module's own scope. `check_rustdoc_links.sh` reports the diagnostic
at that declaration line (`lib.rs:232`), which is what makes the actual
`//!` text easy to miss. Same shape as #6027's `http_client` fix, which
landed the identical pattern for `trusty-common` already.

`check_contracts.sh` builds trusty-common with all 44 features (`memory-rpc`
included), so it hits the same broken links `check_rustdoc_links.sh`'s
default-features build cannot see, and fails the whole rustdoc JSON build —
Gate 6 (cross-version contract diff) never runs as a result, which is why
both gates read red together.

## Fix

- `crates/trusty-common/src/memory_rpc.rs`: the four links are now
  crate-absolute (`memory_rpc::resolve_memory_base_url`, etc.).
- `crates/trusty-mpm/src/daemon/doctor_worktrees.rs`: qualified as
  `[`crate::daemon::doctor::run_doctor`]`.

No baseline rows added — both gates report zero broken links / clean drift
on this branch.

## Commands run

```
bash scripts/check_rustdoc_links.sh
  -> SUMMARY 26 crate(s) examined by rustdoc, 0 broken link(s), baseline 0, 0 diagnostic(s) examined
  -> EXIT=0

bash scripts/check_contracts.sh --crate trusty-common
  -> 15 contract(s) extracted, artifact matches source — OK.
  -> EXIT=0

cargo fmt --check          -> clean (EXIT=0)
bash scripts/check_sld.sh  -> scanned 60 spec doc(s) + 3362 code file(s); 0 error(s), 0 warning(s)
bash scripts/check_changelog_fragment.sh --base origin/main
  -> OK trusty-common: changelog.d fragment present and valid
  -> OK trusty-mpm: changelog.d fragment present and valid
  -> EXIT=0
```

## Test plan

- [x] `check_rustdoc_links.sh` reports 0 broken links workspace-wide
- [x] `check_contracts.sh --crate trusty-common` passes (44-feature rustdoc build succeeds, artifact matches source)
- [x] `cargo fmt --check` clean
- [x] `check_sld.sh` clean
- [x] `check_changelog_fragment.sh` — fragments present for both touched crates

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools