### PR TITLE
chore(trusty-audit): make the crate publishable — owner reversal of #5483

### DIFF
--- a/crates/trusty-audit/Cargo.toml
+++ b/crates/trusty-audit/Cargo.toml
@@ -11,8 +11,6 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
-# #5483: not published to crates.io. The delivery path is the signed/notarized client .app plus config and README, not `cargo install` by the recipient.
-publish = false
 
 [lib]
 name = "trusty_audit"

--- a/crates/trusty-audit/changelog.d/5483-publishable.md
+++ b/crates/trusty-audit/changelog.d/5483-publishable.md
@@ -1,0 +1,2 @@
+Changed
+- `trusty-audit` is now published to crates.io like every other workspace crate, reversing #5483's original call. Owner ruling: the client is ordinarily `cargo install`-able rather than distributed solely as the signed `.app`.


### PR DESCRIPTION
Owner ruling change (supersedes #5483): trusty-audit becomes an ordinarily published crates.io crate.

Removed `publish = false` and its accompanying comment from `crates/trusty-audit/Cargo.toml`. The manifest already carried every field crates.io requires (description, license/repository/authors via workspace inheritance, readme, homepage, keywords, categories) — nothing else needed adding.

**Dry-run result** (`SKIP_UI_BUILD=1 cargo publish --dry-run --allow-dirty -p trusty-audit`):
```
   Packaging trusty-audit v0.6.0 (…/crates/trusty-audit)
    Updating crates.io index
error: failed to prepare local package for uploading

Caused by:
  failed to select a version for the requirement `trusty-common = "^0.40"`
  candidate versions found which didn't match: 0.39.0, 0.35.0, 0.34.0, ...
  location searched: crates.io index
  required by package `trusty-audit v0.6.0 (…)`
```
Expected: trusty-common 0.40.0 isn't live on crates.io yet (it publishes first tonight). Packaging itself succeeded — no other metadata/path/included-files error.

**Publish order** (`scripts/publish-dry-run-order.sh --list-only`): trusty-audit now appears, at position 18 of 21, between trusty-analyze and trusty-mpm.

Gates run: `cargo check -p trusty-audit` (pass), `cargo fmt --check` (pass), `scripts/check_changelog_fragment.sh` (pass).

Refs #5483

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools