### PR TITLE
fix(scripts): preflight CHECK 8 reads a rerun's gate target from the attempt that recorded it

### DIFF
--- a/scripts/preflight-check8-selftest.sh
+++ b/scripts/preflight-check8-selftest.sh
@@ -78,6 +78,50 @@
 #                               check obtained, so the could-not-read override
 #                               must not reach it.
 #
+# THE SECOND HALF drives gate_run_target — the ATTRIBUTION, where gate_decide is
+#   the DECISION — over captured Actions-API bodies, with gate_api replaced by a
+#   fixture server. It exists for #6113: `gh run rerun <id> --failed` leaves the
+#   jobs API's default-attempt view holding a carried-over COPY of every job that
+#   did not re-execute — a fresh job id, `conclusion: success`, and `[]` where
+#   the annotation should be. CHECK 8 read that copy, found nothing, and called a
+#   genuinely green gate unreadable; trusty-audit 0.7.0 published on an
+#   owner-authorized PREFLIGHT_GATE_UNVERIFIED override because of it.
+#
+#     17. THE #6113 DEFECT      run 32355453111 verbatim: attempt-2 copy job
+#                               96395891848 answers `[]`, attempt-1 job
+#                               96383547325 carries "Verified commit e0dfd8d7b…".
+#                               gate_run_target must print that commit. Against
+#                               the pre-fix script this case prints UNREADABLE.
+#     18. …and it then passes   the recovered target, fed to gate_decide at that
+#                               HEAD, must [PASS] — the whole point is a publish
+#                               that no longer needs the override.
+#     19. latest attempt wins   when the latest attempt DOES answer, an earlier
+#                               attempt naming a different commit must not be
+#                               consulted. The walk is a fallback, not a vote.
+#     20. one attempt, no notice a run never rerun whose annotation is missing
+#                               stays UNREADABLE. There is no attempt 0, and the
+#                               pre-#6113 behaviour is unchanged here.
+#     21. failed resolve        latest attempt's resolve job did not succeed:
+#                               NOGATE, even with a green annotation on attempt
+#                               1. That run gated nothing on its current attempt,
+#                               and an earlier attempt cannot rescue it.
+#     22. job absent            no "Resolve target commit" job at all: NOGATE.
+#     23. unreadable jobs body  a body that is not a jobs list is UNREADABLE, not
+#                               NOGATE — an API error must never read as "this
+#                               run gated nothing".
+#     24. unreadable annotations a non-list annotations body on the latest
+#                               attempt routes to the walk, same as `[]`.
+#     25. attempts disagree     two earlier attempts naming DIFFERENT commits is
+#                               UNREADABLE. Attempts of one run share its `sha`
+#                               input, so a disagreement means the walk is
+#                               reading something other than what it thinks.
+#     26. the walk is bounded   GATE_ATTEMPT_SCAN_CAP attempts back and no
+#                               further; the answer beyond it stays UNREADABLE
+#                               rather than costing an unbounded API budget.
+#     27. unreachable API       the latest attempt's jobs read failing outright
+#                               is UNREADABLE, with no attempt number to walk
+#                               from. Unchanged by #6113.
+#
 # Usage: bash scripts/preflight-check8-selftest.sh
 # Exit: 0 when every case matches; 1 on the first mismatch, printing both sides.
 #
@@ -161,7 +205,7 @@ run_decide() {
     # Here-string, matching how check8_prepublish_gate feeds it in production —
     # a pipe would run gate_decide in a subshell and lose the GATE_NOT_VERIFIED
     # assignment the override arm depends on.
-    gate_decide "$HEAD_SHA" "$capped" 2>&1 >/dev/null <<< "$table"
+    gate_decide "${DECIDE_HEAD:-$HEAD_SHA}" "$capped" 2>&1 >/dev/null <<< "$table"
     printf '\nEXIT=%s' "$?"
   )"
   rc="$(printf '%s' "$out" | sed -n 's/^EXIT=//p' | tail -n1)"
@@ -288,6 +332,180 @@ assert_absent "15 red + override: no WARN" "[WARN]" "$(text_of "$raw")"
 raw="$(PREFLIGHT_GATE_UNVERIFIED="$REASON" run_decide "$(tbl "$OTHER_SHA" completed success https://gh/a)")"
 assert_eq "16 absent + override: still stops" "1" "$(status_of "$raw")"
 assert_absent "16 absent + override: no WARN" "[WARN]" "$(text_of "$raw")"
+
+# ===========================================================================
+# gate_run_target — the ATTRIBUTION half (#6113)
+# ===========================================================================
+# The three commits below are run 32355453111's, at full length: the release
+# that hit this, its two job ids, and the commit only attempt 1 records.
+RERUN_RUN=32355453111
+RERUN_SHA="e0dfd8d7b5db2383e62cbf949ed462b6dfc5ef19"
+RERUN_JOB_A2=96395891848   # the carried-over copy — success, `[]` annotations
+RERUN_JOB_A1=96383547325   # the job that actually ran, and reported the commit
+
+FIXTURE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/preflight-check8-fixtures.XXXXXX")"
+trap 'rm -rf "$FIXTURE_DIR"' EXIT
+
+# fixture_key <api-path> — the filename a path is stored under. Query strings
+# and slashes flatten; nothing else in these paths varies.
+fixture_key() { printf '%s' "$1" | tr '/?=&' '____'; }
+
+# fx <api-path> <json-body> — record what the API answers for one path. A path
+# with NO fixture is a FAILED read (gate_api exits nonzero), which is how an
+# attempt that does not exist, and an unreachable API, are both expressed.
+fx() { printf '%s' "$2" > "${FIXTURE_DIR}/$(fixture_key "$1")"; }
+fx_reset() { rm -f "${FIXTURE_DIR:?}"/*; }
+
+# fixture_api <path> — stands in for gate_api. Exit 22 (curl's HTTP-error code,
+# which `gh api` also returns) when the path was never recorded.
+fixture_api() {
+  local f
+  f="${FIXTURE_DIR}/$(fixture_key "$1")"
+  [ -f "$f" ] || return 22
+  cat "$f"
+}
+
+# jobs_body <job-id> <conclusion> <run-attempt> — a jobs-API body shaped like
+# the real one, including a second job so the name match is doing real work.
+jobs_body() {
+  printf '{"total_count":2,"jobs":[{"id":11,"name":"Rust tests (shard 1)","conclusion":"success","run_attempt":%s},{"id":%s,"name":"Resolve target commit","conclusion":"%s","run_attempt":%s}]}' \
+    "$3" "$1" "$2" "$3"
+}
+
+# ann_body [<sha>] — a check-run annotations body. With no sha it is `[]`, which
+# is verbatim what the carried-over copy answers.
+ann_body() {
+  if [ -z "${1:-}" ]; then printf '[]'; return; fi
+  printf '[{"path":".github","start_line":1,"end_line":1,"annotation_level":"notice","title":"Pre-publish gate target","message":"Verified commit %s"}]' "$1"
+}
+
+# jobs_path <run-id> [<attempt>] / ann_path <job-id> — the two paths CHECK 8
+# asks for, written once so a fixture and the code under test cannot disagree
+# about the shape.
+jobs_path() {
+  if [ -n "${2:-}" ]; then
+    printf 'actions/runs/%s/attempts/%s/jobs?per_page=100' "$1" "$2"
+  else
+    printf 'actions/runs/%s/jobs?per_page=100' "$1"
+  fi
+}
+ann_path() { printf 'check-runs/%s/annotations' "$1"; }
+
+# ---------------------------------------------------------------------------
+# run_target <run-id> — drive gate_run_target in a clean subshell with the
+# shipped functions extracted into it, over the fixtures recorded above.
+#
+# gate_api is DELIBERATELY NOT extracted: fixture_api takes its place, which is
+# the whole reason the shipped code has that one-line seam. Everything below it
+# — the attempt walk, the job match, the annotation parse — is the shipped code.
+# ---------------------------------------------------------------------------
+run_target() {
+  (
+    set +e
+    # GATE_REPO is deliberately NOT set: only gate_api reads it, and gate_api is
+    # the one function the fixture server replaces. Should a future extracted
+    # function reach for it, `set -u` aborts here loudly rather than letting this
+    # file test a path that quietly addressed the wrong repo.
+    #
+    # Read the constants from the script rather than restating them, so a rename
+    # of the resolve job or a change to the cap cannot leave this file testing a
+    # value the gate no longer uses.
+    eval "$(grep -E '^GATE_(JOB_NAME|ATTEMPT_SCAN_CAP)=' "$UNDER_TEST")"
+    eval "$(awk '/^gate_pick_job\(\) \{/,/^\}/' "$UNDER_TEST")"
+    eval "$(awk '/^gate_annotation_sha\(\) \{/,/^\}/' "$UNDER_TEST")"
+    eval "$(awk '/^gate_attempt_target\(\) \{/,/^\}/' "$UNDER_TEST")"
+    eval "$(awk '/^gate_run_target\(\) \{/,/^\}/' "$UNDER_TEST")"
+    gate_api() { fixture_api "$@"; }
+    gate_run_target "$1"
+  )
+}
+
+echo "gate_run_target — a partially-rerun run (#6113):"
+
+# --- 17. THE DEFECT: the answer lives on an earlier attempt -------------------
+# Verbatim run 32355453111. Pre-fix, gate_run_target read only the default
+# attempt's copy, got `[]`, and printed UNREADABLE — which routed a green gate
+# to the override arm.
+fx_reset
+fx "$(jobs_path "$RERUN_RUN")"      "$(jobs_body "$RERUN_JOB_A2" success 2)"
+fx "$(ann_path "$RERUN_JOB_A2")"    "$(ann_body)"
+fx "$(jobs_path "$RERUN_RUN" 1)"    "$(jobs_body "$RERUN_JOB_A1" success 1)"
+fx "$(ann_path "$RERUN_JOB_A1")"    "$(ann_body "$RERUN_SHA")"
+assert_eq "17 rerun carryover: reads attempt 1" "$RERUN_SHA" "$(run_target "$RERUN_RUN")"
+
+# --- 18. and the recovered target then earns a PASS --------------------------
+raw="$(DECIDE_HEAD="$RERUN_SHA" run_decide "$(tbl "$(run_target "$RERUN_RUN")" completed success https://gh/run/${RERUN_RUN})")"
+assert_eq "18 rerun carryover: publish permitted" "0" "$(status_of "$raw")"
+assert_contains "18 rerun carryover: label" "[PASS]" "$(text_of "$raw")"
+assert_absent "18 rerun carryover: no override needed" "[WARN]" "$(text_of "$raw")"
+
+# --- 19. the latest attempt's own answer is not put to a vote ----------------
+fx_reset
+fx "$(jobs_path "$RERUN_RUN")"      "$(jobs_body "$RERUN_JOB_A2" success 2)"
+fx "$(ann_path "$RERUN_JOB_A2")"    "$(ann_body "$RERUN_SHA")"
+fx "$(jobs_path "$RERUN_RUN" 1)"    "$(jobs_body "$RERUN_JOB_A1" success 1)"
+fx "$(ann_path "$RERUN_JOB_A1")"    "$(ann_body "$OTHER_SHA")"
+assert_eq "19 latest answers: earlier attempt ignored" "$RERUN_SHA" "$(run_target "$RERUN_RUN")"
+
+# --- 20. a run that was never rerun has no earlier attempt to ask ------------
+fx_reset
+fx "$(jobs_path "$RERUN_RUN")"      "$(jobs_body 7001 success 1)"
+fx "$(ann_path 7001)"               "$(ann_body)"
+assert_eq "20 single attempt, no notice: unreadable" "UNREADABLE" "$(run_target "$RERUN_RUN")"
+
+echo "gate_run_target — non-evidence and unreadable states:"
+
+# --- 21. a resolve job that did not succeed gated nothing --------------------
+fx_reset
+fx "$(jobs_path "$RERUN_RUN")"      "$(jobs_body "$RERUN_JOB_A2" failure 2)"
+fx "$(jobs_path "$RERUN_RUN" 1)"    "$(jobs_body "$RERUN_JOB_A1" success 1)"
+fx "$(ann_path "$RERUN_JOB_A1")"    "$(ann_body "$RERUN_SHA")"
+assert_eq "21 latest resolve failed: NOGATE not rescued" "NOGATE" "$(run_target "$RERUN_RUN")"
+
+# --- 22. no resolve job at all -----------------------------------------------
+fx_reset
+fx "$(jobs_path "$RERUN_RUN")" '{"total_count":1,"jobs":[{"id":11,"name":"Rust tests (shard 1)","conclusion":"success","run_attempt":1}]}'
+assert_eq "22 no resolve job: NOGATE" "NOGATE" "$(run_target "$RERUN_RUN")"
+
+# --- 23. an API error body is not a finding ----------------------------------
+fx_reset
+fx "$(jobs_path "$RERUN_RUN")" '{"message":"Not Found","status":"404"}'
+assert_eq "23 unreadable jobs body: not NOGATE" "UNREADABLE" "$(run_target "$RERUN_RUN")"
+
+# --- 24. an unreadable annotations body routes to the walk, same as [] -------
+fx_reset
+fx "$(jobs_path "$RERUN_RUN")"      "$(jobs_body "$RERUN_JOB_A2" success 2)"
+fx "$(ann_path "$RERUN_JOB_A2")"    '{"message":"Not Found"}'
+fx "$(jobs_path "$RERUN_RUN" 1)"    "$(jobs_body "$RERUN_JOB_A1" success 1)"
+fx "$(ann_path "$RERUN_JOB_A1")"    "$(ann_body "$RERUN_SHA")"
+assert_eq "24 unreadable annotations: walks back" "$RERUN_SHA" "$(run_target "$RERUN_RUN")"
+
+# --- 25. attempts that disagree are not an answer ----------------------------
+fx_reset
+fx "$(jobs_path "$RERUN_RUN")"      "$(jobs_body 7003 success 3)"
+fx "$(ann_path 7003)"               "$(ann_body)"
+fx "$(jobs_path "$RERUN_RUN" 2)"    "$(jobs_body 7002 success 2)"
+fx "$(ann_path 7002)"               "$(ann_body "$RERUN_SHA")"
+fx "$(jobs_path "$RERUN_RUN" 1)"    "$(jobs_body 7001 success 1)"
+fx "$(ann_path 7001)"               "$(ann_body "$OTHER_SHA")"
+assert_eq "25 attempts disagree: unreadable" "UNREADABLE" "$(run_target "$RERUN_RUN")"
+
+# --- 26. the walk stops at its cap, and stopping is not a green --------------
+# run_attempt 9 with the annotation only on attempt 1: the cap is reached first.
+fx_reset
+fx "$(jobs_path "$RERUN_RUN")" "$(jobs_body 7009 success 9)"
+fx "$(ann_path 7009)"          "$(ann_body)"
+for n in 8 7 6 5 4 3 2; do
+  fx "$(jobs_path "$RERUN_RUN" "$n")" "$(jobs_body "700${n}" success "$n")"
+  fx "$(ann_path "700${n}")"          "$(ann_body)"
+done
+fx "$(jobs_path "$RERUN_RUN" 1)" "$(jobs_body 7001 success 1)"
+fx "$(ann_path 7001)"            "$(ann_body "$RERUN_SHA")"
+assert_eq "26 beyond the attempt cap: unreadable" "UNREADABLE" "$(run_target "$RERUN_RUN")"
+
+# --- 27. the API not answering at all ----------------------------------------
+fx_reset
+assert_eq "27 unreachable API: unreadable" "UNREADABLE" "$(run_target "$RERUN_RUN")"
 
 echo
 if [ "$FAILURES" -eq 0 ]; then

--- a/scripts/preflight-check8-selftest.sh
+++ b/scripts/preflight-check8-selftest.sh
@@ -121,6 +121,15 @@
 #     27. unreachable API       the latest attempt's jobs read failing outright
 #                               is UNREADABLE, with no attempt number to walk
 #                               from. Unchanged by #6113.
+#     28. annotations fetch     the ANNOTATIONS read failing outright, on a run
+#         fails hard            with no earlier attempt: UNREADABLE. A different
+#                               branch from case 24 — that one is a body that
+#                               parsed to nothing, this one is gate_api itself
+#                               exiting nonzero — and the branch a review found
+#                               untested on PR #6115.
+#     29. …and on the walk      the same hard failure on the latest attempt of a
+#                               RERUN still walks back and recovers the commit
+#                               attempt 1 recorded.
 #
 # Usage: bash scripts/preflight-check8-selftest.sh
 # Exit: 0 when every case matches; 1 on the first mismatch, printing both sides.
@@ -506,6 +515,23 @@ assert_eq "26 beyond the attempt cap: unreadable" "UNREADABLE" "$(run_target "$R
 # --- 27. the API not answering at all ----------------------------------------
 fx_reset
 assert_eq "27 unreachable API: unreadable" "UNREADABLE" "$(run_target "$RERUN_RUN")"
+
+# --- 28. the ANNOTATIONS read failing outright -------------------------------
+# The jobs list answers, the resolve job succeeded, and the annotations call
+# itself exits nonzero — a transient API failure, not a body that parsed to
+# nothing. Case 24's malformed body reaches UNREADABLE through the parser;
+# this reaches it through gate_api's own exit, which is the other branch.
+# Omitting the ann_path fixture is what makes the fetch fail hard.
+fx_reset
+fx "$(jobs_path "$RERUN_RUN")" "$(jobs_body 7001 success 1)"
+assert_eq "28 annotations fetch fails hard: unreadable" "UNREADABLE" "$(run_target "$RERUN_RUN")"
+
+# --- 29. the same failure on a rerun still walks back ------------------------
+fx_reset
+fx "$(jobs_path "$RERUN_RUN")"      "$(jobs_body "$RERUN_JOB_A2" success 2)"
+fx "$(jobs_path "$RERUN_RUN" 1)"    "$(jobs_body "$RERUN_JOB_A1" success 1)"
+fx "$(ann_path "$RERUN_JOB_A1")"    "$(ann_body "$RERUN_SHA")"
+assert_eq "29 annotations fetch fails hard on rerun: walks back" "$RERUN_SHA" "$(run_target "$RERUN_RUN")"
 
 echo
 if [ "$FAILURES" -eq 0 ]; then

--- a/scripts/preflight-publish.sh
+++ b/scripts/preflight-publish.sh
@@ -185,6 +185,14 @@
 #     answer this check could not obtain is not a green one. A run whose target
 #     resolved but could not be read back is the same: unknown, not green.
 #
+#     A RERUN RECORDS ITS ANSWER ON THE ATTEMPT THAT PRODUCED IT (#6113). After
+#     `gh run rerun <id> --failed`, the jobs API's default-attempt view hands
+#     back a carried-over copy of every job that did not re-execute — success,
+#     no annotations. So this check walks back through earlier attempts when the
+#     latest one reports nothing, rather than calling a green gate unreadable
+#     and pushing the operator onto the override, which is what happened to
+#     trusty-audit 0.7.0 on run 32355453111.
+#
 #     DISPATCH IT WITH AN EXPLICIT SHA. The remedy this check prints is
 #
 #         gh workflow run pre-publish.yml --ref <branch> -f sha=$(git rev-parse HEAD)
@@ -1029,6 +1037,128 @@ GATE_REPO="bobmatnyc/trusty-tools"
 GATE_SCAN_DAYS=2
 GATE_SCAN_CAP=40
 
+# The display name of the job that resolves and reports the gated commit. It is
+# the `name:` in pre-publish.yml, because that is what the jobs API returns —
+# the YAML key `resolve-sha` never appears there.
+GATE_JOB_NAME="Resolve target commit"
+
+# How many earlier attempts the #6113 walk below will open. A run rerun more
+# than a handful of times does not happen, and an unbounded walk would let one
+# pathological run spend the whole API budget. Binding the cap yields
+# UNREADABLE, never a green.
+GATE_ATTEMPT_SCAN_CAP=5
+
+# ---------------------------------------------------------------------------
+# gate_api <path> — one authenticated read of the Actions API under
+# repos/${GATE_REPO}, printing the raw JSON body. Nonzero exit means the read
+# failed and callers route that to UNREADABLE.
+#
+# Split out from its callers so preflight-check8-selftest.sh can put captured
+# API bodies in its place. The attempt walk below is the part #6113 got wrong,
+# and a partially-rerun run is not something a test can conjure against the
+# live API on demand.
+# ---------------------------------------------------------------------------
+gate_api() {
+  gh api "repos/${GATE_REPO}/$1" 2>/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# gate_pick_job — stdin: a jobs-API body. Prints "<id>|<conclusion>|<attempt>"
+# for the first job named GATE_JOB_NAME.
+#
+# Exit 0 found, 1 this body has no such job, 3 the body could not be read as a
+# jobs list. Three exits because they are three different facts: no job means
+# the run never gated anything, an unreadable body means nothing is known, and
+# collapsing the second into the first would report an API error as evidence.
+# ---------------------------------------------------------------------------
+gate_pick_job() {
+  python3 -c '
+import json, sys
+name = sys.argv[1]
+try:
+    jobs = json.load(sys.stdin)["jobs"]
+    if not isinstance(jobs, list):
+        raise ValueError("jobs is not a list")
+except Exception:
+    sys.exit(3)
+for j in jobs:
+    if isinstance(j, dict) and j.get("name") == name:
+        print("%s|%s|%s" % (j.get("id") or "", j.get("conclusion") or "", j.get("run_attempt") or 1))
+        sys.exit(0)
+sys.exit(1)
+' "$GATE_JOB_NAME" 2>/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# gate_annotation_sha — stdin: a check-run annotations body. Prints the 40-hex
+# commit the "Pre-publish gate target" notice names.
+#
+# Exit 0 printed, 1 this body carries no such notice, 3 unreadable. Exit 1 is
+# the #6113 state: a job copy carried over by a partial rerun answers `[]`.
+# ---------------------------------------------------------------------------
+gate_annotation_sha() {
+  python3 -c '
+import json, re, sys
+try:
+    anns = json.load(sys.stdin)
+    if not isinstance(anns, list):
+        raise ValueError("annotations is not a list")
+except Exception:
+    sys.exit(3)
+for a in anns:
+    if isinstance(a, dict) and a.get("title") == "Pre-publish gate target":
+        m = re.match(r"^Verified commit ([0-9a-fA-F]{40})$", (a.get("message") or "").strip())
+        if m:
+            print(m.group(1))
+            sys.exit(0)
+sys.exit(1)
+' 2>/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# gate_attempt_target <run-id> <attempt> — which commit did ONE attempt of this
+# run report gating? An empty <attempt> reads the run's default (latest)
+# attempt, which is the only view the jobs API serves without an attempt path.
+#
+# Prints "<verdict>|<attempt-number>". <verdict> carries gate_run_target's
+# vocabulary below; <attempt-number> is the `run_attempt` the jobs API reported
+# for that job, and is empty when nothing could be read.
+# ---------------------------------------------------------------------------
+gate_attempt_target() {
+  local run_id="$1" attempt="${2:-}" path body row job_id concl at sha prc=0
+
+  if [ -n "$attempt" ]; then
+    path="actions/runs/${run_id}/attempts/${attempt}/jobs?per_page=100"
+  else
+    path="actions/runs/${run_id}/jobs?per_page=100"
+  fi
+
+  body="$(gate_api "$path")" || { printf 'UNREADABLE|\n'; return 0; }
+
+  row="$(printf '%s' "$body" | gate_pick_job)" || prc=$?
+  case "$prc" in
+    0) : ;;
+    1) printf 'NOGATE|\n'; return 0 ;;
+    *) printf 'UNREADABLE|\n'; return 0 ;;
+  esac
+
+  IFS='|' read -r job_id concl at <<< "$row"
+
+  if [ "$concl" != "success" ] || [ -z "$job_id" ]; then
+    printf 'NOGATE|%s\n' "$at"
+    return 0
+  fi
+
+  body="$(gate_api "check-runs/${job_id}/annotations")" \
+    || { printf 'UNREADABLE|%s\n' "$at"; return 0; }
+
+  sha="$(printf '%s' "$body" | gate_annotation_sha)" \
+    || { printf 'UNREADABLE|%s\n' "$at"; return 0; }
+
+  if [ -z "$sha" ]; then printf 'UNREADABLE|%s\n' "$at"; return 0; fi
+  printf '%s|%s\n' "$sha" "$at"
+}
+
 # ---------------------------------------------------------------------------
 # gate_run_target <run-id> — which commit did this run ACTUALLY gate?
 #
@@ -1039,31 +1169,58 @@ GATE_SCAN_CAP=40
 #   UNREADABLE    resolve-sha SUCCEEDED but its target could not be read.
 #                 An answer that could not be obtained, which is not a green one.
 #
-# The job is matched by its display name ("Resolve target commit", the `name:`
-# in pre-publish.yml) because that is what the jobs API returns — the YAML key
-# `resolve-sha` never appears there.
+# IT READS EARLIER ATTEMPTS WHEN THE LATEST ONE ANSWERS NOTHING (#6113). After
+# `gh run rerun <id> --failed`, the jobs API's default-attempt view returns a
+# CARRIED-OVER COPY of every job that was not re-executed: a fresh job id,
+# `conclusion: success`, and zero annotations. Measured on run 32355453111,
+# publishing trusty-audit 0.7.0 — attempt-1 job 96383547325 carries
+# "Verified commit e0dfd8d7b…", and its attempt-2 copy 96395891848 carries
+# `[]`. The commit that run gated is recorded only on the earlier attempt, so
+# this asks that attempt rather than reporting a genuinely green gate as
+# unreadable and pushing the operator onto the override.
+#
+# THE WALK STILL FAILS CLOSED, in both of its own directions. Nothing found
+# across the scanned attempts stays UNREADABLE. Two attempts that name
+# DIFFERENT commits also come back UNREADABLE: attempts of one run share its
+# `sha` input and must resolve the same commit, so a disagreement means this is
+# reading something other than what it thinks, and an answer that cannot be
+# trusted is not a green one.
 # ---------------------------------------------------------------------------
 gate_run_target() {
-  local run_id="$1" job job_id concl msg
+  local run_id="$1" res verdict attempt seen a found="" conflict=0 scanned=0
 
-  job="$(gh api "repos/${GATE_REPO}/actions/runs/${run_id}/jobs?per_page=100" \
-    --jq '[.jobs[] | select(.name == "Resolve target commit")] | first // empty' 2>/dev/null)" \
-    || { printf 'UNREADABLE\n'; return 0; }
+  res="$(gate_attempt_target "$run_id" "")"
+  verdict="${res%%|*}"
+  attempt="${res#*|}"
 
-  if [ -z "$job" ]; then printf 'NOGATE\n'; return 0; fi
+  # A sha or NOGATE is this run's own answer, and the latest attempt is the one
+  # entitled to give it. Only the absence of an answer reaches the walk.
+  if [ "$verdict" != "UNREADABLE" ]; then printf '%s\n' "$verdict"; return 0; fi
 
-  concl="$(printf '%s' "$job" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("conclusion") or "")' 2>/dev/null || echo "")"
-  job_id="$(printf '%s' "$job" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("id") or "")' 2>/dev/null || echo "")"
+  # No attempt number means the jobs list itself could not be read, so there is
+  # no earlier attempt to address.
+  case "$attempt" in
+    ''|*[!0-9]*) printf 'UNREADABLE\n'; return 0 ;;
+  esac
 
-  if [ "$concl" != "success" ] || [ -z "$job_id" ]; then printf 'NOGATE\n'; return 0; fi
+  a=$((attempt - 1))
+  while [ "$a" -ge 1 ] && [ "$scanned" -lt "$GATE_ATTEMPT_SCAN_CAP" ]; do
+    scanned=$((scanned + 1))
+    res="$(gate_attempt_target "$run_id" "$a")"
+    seen="${res%%|*}"
+    a=$((a - 1))
+    case "$seen" in
+      NOGATE|UNREADABLE) continue ;;
+    esac
+    if [ -z "$found" ]; then
+      found="$seen"
+    elif [ "$found" != "$seen" ]; then
+      conflict=1
+    fi
+  done
 
-  msg="$(gh api "repos/${GATE_REPO}/check-runs/${job_id}/annotations" \
-    --jq '[.[] | select(.title == "Pre-publish gate target") | .message] | first // empty' 2>/dev/null)" \
-    || { printf 'UNREADABLE\n'; return 0; }
-
-  msg="$(printf '%s' "$msg" | sed -n 's/^Verified commit \([0-9a-fA-F]\{40\}\)$/\1/p' | head -n1)"
-  if [ -z "$msg" ]; then printf 'UNREADABLE\n'; return 0; fi
-  printf '%s\n' "$msg"
+  if [ "$conflict" -ne 0 ] || [ -z "$found" ]; then printf 'UNREADABLE\n'; return 0; fi
+  printf '%s\n' "$found"
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
CHECK 8 asked the Actions jobs API for a run's default (latest) attempt only. After `gh run rerun <id> --failed`, that view returns a carried-over **copy** of every job that did not re-execute — a fresh job id, `conclusion: success`, and zero annotations. The `::notice title=Pre-publish gate target::` line naming the gated commit is recorded only on the attempt that actually ran the job, so CHECK 8 read nothing and reported a genuinely green gate as `resolved a target commit that could not be read back`. trusty-audit 0.7.0 published on an owner-authorized `PREFLIGHT_GATE_UNVERIFIED` override because of it.

## What changed

`gate_run_target` walks back through earlier attempts when the latest one answers nothing, bounded at `GATE_ATTEMPT_SCAN_CAP` (5). It still fails closed in both of its own directions: nothing found across the scanned attempts stays `UNREADABLE`, and two attempts naming **different** commits also come back `UNREADABLE` — attempts of one run share its `sha` input and must resolve the same commit, so a disagreement means the walk is reading something other than what it thinks.

A sha or `NOGATE` from the latest attempt is still that run's answer and returns immediately; only the absence of an answer reaches the walk. So a rerun whose resolve job genuinely failed is `NOGATE` and cannot be rescued by an earlier attempt's annotation.

The API read is split into a one-line `gate_api` seam so the walk is testable, and the job/annotation parsing moved to python3 with three exits — found, absent, unreadable — so an API error body can no longer read as "this run gated nothing".

## Regression coverage

`scripts/preflight-check8-selftest.sh` gains cases 17–27, driving `gate_run_target` over captured API bodies with `gate_api` replaced by a fixture server. Case 17 is run 32355453111 verbatim: attempt-2 copy job 96395891848 answering `[]` beside attempt-1 job 96383547325 carrying `Verified commit e0dfd8d7b…`.

Against `origin/main`'s `scripts/preflight-publish.sh` (`PREFLIGHT_SELFTEST_SCRIPT=<pre-fix copy>`), the new cases fail — and because the pre-fix `gate_run_target` has no `gate_api` seam, they fail by hitting the **live** API for the real run, reproducing the issue's exact message:

```
FAIL: 17 rerun carryover: reads attempt 1: expected 'e0dfd8d7b5db2383e62cbf949ed462b6dfc5ef19', got 'UNREADABLE'
FAIL: 18 rerun carryover: publish permitted: expected '0', got '1'
FAIL: 18 rerun carryover: label: output does not contain '[PASS]'. Got: [FAIL] prepublish-gate: could not
  determine whether the release gate passed — 1 'Pre-publish gate' run(s) resolved a target commit that
  could not be read back, so whether any of them gated e0dfd8d7b5db2383e62cbf949ed462b6dfc5ef19 is unknown.
FAIL: 19 latest answers: earlier attempt ignored: expected 'e0dfd8d7b…', got 'UNREADABLE'
FAIL: 21 latest resolve failed: NOGATE not rescued: expected 'NOGATE', got 'UNREADABLE'
FAIL: 22 no resolve job: NOGATE: expected 'NOGATE', got 'UNREADABLE'
FAIL: 24 unreadable annotations: walks back: expected 'e0dfd8d7b…', got 'UNREADABLE'
preflight-check8-selftest: 7 of 52 assertion(s) FAILED.
```

## Gates

Rung 5 (release tooling). Shell only — no Rust files changed, so no cargo gates and no changelog fragment.

```
bash -n scripts/preflight-publish.sh                   -> syntax preflight OK
bash -n scripts/preflight-check8-selftest.sh           -> syntax selftest OK

bash scripts/preflight-check8-selftest.sh              EXIT=0
  preflight-check8-selftest: 52 assertion(s) passed.

bash scripts/preflight-check5-selftest.sh              EXIT=0
  preflight-check5-selftest: 17 passed, 0 failed.

bash scripts/check-tag-publish-parity-selftest.sh      EXIT=0
  check-tag-publish-parity-selftest: 15 passed, 0 failed.
```

All three are the jobs `.github/workflows/tag-publish-parity.yml` runs on this PR.

ShellCheck is not a gate for these two files (CI runs it only on `crates/trusty-audit/install.sh` and its selftest), so no new gate was introduced. Run locally anyway at `--severity=warning`: `preflight-publish.sh` is clean, and the selftest's only remaining findings are three pre-existing SC2034s inside `run_decide` that this PR does not touch.

## Live verification against run 32355453111

The fixed functions, with the **real** `gate_api`, against the run in the issue:

```
latest-attempt view : UNREADABLE|2
attempt-1 view      : e0dfd8d7b5db2383e62cbf949ed462b6dfc5ef19|1
gate_run_target     : e0dfd8d7b5db2383e62cbf949ed462b6dfc5ef19
expected            : e0dfd8d7b5db2383e62cbf949ed462b6dfc5ef19
```

Refs #6113

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
