### PR TITLE
fix(scripts): parity selftest reads SIGPIPE as a missing TAG-DRIFT

### DIFF
--- a/scripts/check-tag-publish-parity-selftest.sh
+++ b/scripts/check-tag-publish-parity-selftest.sh
@@ -112,7 +112,9 @@ run_case() {
     fail_case "${label}: expected exit ${want_exit}, got ${rc}" "$out"
     return
   fi
-  if [ "$want_sub" != "-" ] && ! printf '%s' "$out" | grep -qF -- "$want_sub"; then
+  # Here-string, never `printf … | grep -q` — see case 11 for what that costs
+  # once the gate's output outgrows the pipe buffer.
+  if [ "$want_sub" != "-" ] && ! grep -qF -- "$want_sub" <<< "$out"; then
     fail_case "${label}: exit ${rc} but stderr never said '${want_sub}'" "$out"
     return
   fi
@@ -143,11 +145,11 @@ run_case "fast-forward drift" 1 "TAG-DRIFT" "$repo" trusty-example
 # The remedy has to name the fast-forward, or whoever hits this at 2am reads it
 # as a botched tag and re-tags the wrong commit.
 out="$(bash "$GATE" --repo "$repo" --no-fetch trusty-example 2>&1 || true)"
-if ! printf '%s' "$out" | grep -qF "ANCESTOR of HEAD"; then
+if ! grep -qF "ANCESTOR of HEAD" <<< "$out"; then
   fail_case "fast-forward diagnosis: the failure did not identify the fast-forward" "$out"
-elif ! printf '%s' "$out" | grep -qF "git tag -f"; then
+elif ! grep -qF "git tag -f" <<< "$out"; then
   fail_case "fast-forward diagnosis: no re-tag remedy given" "$out"
-elif ! printf '%s' "$out" | grep -qF "unrelated commit 2"; then
+elif ! grep -qF "unrelated commit 2" <<< "$out"; then
   fail_case "fast-forward diagnosis: the commits added since the tag were not listed" "$out"
 else
   pass_case "the fast-forward failure names the cause, lists the drift, and gives the re-tag remedy"
@@ -170,7 +172,7 @@ git -C "$repo" add -A
 git -C "$repo" commit --quiet -m "feat(other): divergent commit"
 run_case "divergent tag" 1 "TAG-DRIFT" "$repo" trusty-example
 out="$(bash "$GATE" --repo "$repo" --no-fetch trusty-example 2>&1 || true)"
-if printf '%s' "$out" | grep -qF "ANCESTOR of HEAD"; then
+if grep -qF "ANCESTOR of HEAD" <<< "$out"; then
   fail_case "divergent diagnosis: a divergent tag was reported as a fast-forward" "$out"
 else
   pass_case "a divergent tag is not misreported as a fast-forward"
@@ -241,7 +243,7 @@ cat > "${repo}/target/package/trusty-example-1.2.3/.cargo_vcs_info.json" <<JSON
 JSON
 run_case "published commit != tag commit" 1 "VCS-INFO-MISMATCH" "$repo" trusty-example --vcs-info auto
 out="$(bash "$GATE" --repo "$repo" --no-fetch trusty-example --vcs-info auto 2>&1 || true)"
-if ! printf '%s' "$out" | grep -qF "$published_sha"; then
+if ! grep -qF "$published_sha" <<< "$out"; then
   fail_case "vcs-info mismatch: the failure did not name the commit that actually shipped" "$out"
 else
   pass_case "the vcs-info mismatch names the commit that actually shipped"
@@ -289,9 +291,17 @@ else
   out="$(bash "$GATE" --repo "$REPO_ROOT" --no-fetch tga 2.17.0 2>&1)" || rc=$?
   if [ "$rc" -eq 0 ]; then
     fail_case "real-history: the gate passed ${REAL_TAG} (${REAL_TAG_SHA}) against HEAD (${REAL_HEAD})" "$out"
-  elif ! printf '%s' "$out" | grep -qF "TAG-DRIFT"; then
+  # Here-strings, NOT `printf … | grep -qF`. `grep -q` exits on the FIRST match
+  # and TAG-DRIFT is on the gate's third line, so printf is left writing into a
+  # closed pipe; past the pipe buffer it dies on SIGPIPE, `set -o pipefail`
+  # promotes that 141 to the pipeline's status, and the test reads "the needle
+  # was absent" from output that plainly contains it. The gate's output grows
+  # with every commit between tga-v2.17.0 and HEAD — it reached ~43 KB and the
+  # job started failing with `printf: write error: Broken pipe` beside a
+  # verbatim "FAIL: TAG-DRIFT" line.
+  elif ! grep -qF "TAG-DRIFT" <<< "$out"; then
     fail_case "real-history: exit ${rc} but not reported as TAG-DRIFT" "$out"
-  elif ! printf '%s' "$out" | grep -qF "$REAL_TAG_SHA"; then
+  elif ! grep -qF "$REAL_TAG_SHA" <<< "$out"; then
     fail_case "real-history: the failure did not name the tagged commit" "$out"
   else
     pass_case "real ${REAL_TAG} (${REAL_TAG_SHA}) vs real HEAD -> TAG-DRIFT"


### PR DESCRIPTION
`Tag/publish parity` has been going red on the real-history case with `real-history: exit 1 but not reported as TAG-DRIFT`, printed directly above gate output containing a verbatim `FAIL: TAG-DRIFT` line. The line before the verdict names the cause:

```
scripts/check-tag-publish-parity-selftest.sh: line 292: printf: write error: Broken pipe
SELF-TEST FAIL: real-history: exit 1 but not reported as TAG-DRIFT
       check-tag-publish-parity: tag tga-v2.17.0 -> 246e4ca2e7861e3521a0b855fe68d32fadfd818f
       FAIL: TAG-DRIFT — tga-v2.17.0 names 246e4ca2e7861e3521a0b855fe68d32fadfd818f, but a publish from this
             checkout ships afc0ad2427a077878727351072efe679f8fe07b1.
```

## Cause

`printf '%s' "$out" | grep -qF "TAG-DRIFT"` under the file's `set -euo pipefail`. `grep -q` exits on the first match, `TAG-DRIFT` is on the gate's third line, and `printf` is left writing into a closed pipe. Past the pipe buffer it dies on SIGPIPE, `pipefail` promotes that 141 to the pipeline's status, and `! pipeline` reads as "the needle was absent".

Nothing in the code changed. The real-history case runs the gate against the real `tga-v2.17.0` tag versus HEAD, and the gate lists every commit between them — that output is now ~43 KB and crossing the buffer, so a race the case used to win it now loses, more often as `main` grows.

Mechanism, reproduced independently of the race (same shell options, a consumer that always exits early):

```
producer blocked, consumer exited early -> pipefail status: 141
here-string, no pipe                    -> status: 0
```

141 is `128 + SIGPIPE`, with the needle present on line 1.

## Fix

Every needle check in the file reads `$out` through a here-string — no pipe, so no producer to die in one. Six sites; only the real-history case has unbounded output today, but it is one defect with five more copies.

## The assertion keeps its teeth

Mutating the needle to a string the gate never prints, the case still fails:

```
SELF-TEST FAIL: real-history: exit 1 but not reported as TAG-DRIFT
check-tag-publish-parity-selftest: 14 passed, 1 FAILED.
```

## Gates

Rung 2 (test-only stabilization). Shell only — no crate source, so no cargo gates and no changelog fragment.

```
bash -n scripts/check-tag-publish-parity-selftest.sh   SYNTAX=0

bash scripts/check-tag-publish-parity-selftest.sh      EXIT=0
  check-tag-publish-parity-selftest: 15 passed, 0 failed.
  ok  real tga-v2.17.0 (246e4ca2e7861e3521a0b855fe68d32fadfd818f) vs real HEAD -> TAG-DRIFT

bash scripts/preflight-check5-selftest.sh              EXIT=0
  preflight-check5-selftest: 17 passed, 0 failed.

bash scripts/preflight-check8-selftest.sh              EXIT=0
  preflight-check8-selftest: 54 assertion(s) passed.

shellcheck --shell=bash --severity=warning scripts/check-tag-publish-parity-selftest.sh   EXIT=0
```

All three selftests are the jobs `.github/workflows/tag-publish-parity.yml` runs.

## Note on severity

This fails CLOSED — a false alarm on a correct gate, never a missed drift. What it costs is a job that goes red on every PR touching `scripts/preflight-publish.sh` or the parity scripts, which trains readers to ignore it. It is not a required status check, so it blocks nothing: #6115 merged with it red.

Refs #6120

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
