### PR TITLE
fix(trusty-review, trusty-mpm): refuse a model id whose shape names a different provider (Refs #6114)

### DIFF
--- a/crates/trusty-common/changelog.d/6114-model-shape-inference.md
+++ b/crates/trusty-common/changelog.d/6114-model-shape-inference.md
@@ -1,14 +1,21 @@
 Added
 
-- `inference::shape` (feature `inference-client`): `infer_provider_from_model_shape`
-  answers which provider a model id belongs to from its spelling —
-  `accounts/fireworks/models/…` is Fireworks, any other `vendor/model` slug is
-  OpenRouter, and a region-profiled or dotted `vendor.model` id is Bedrock —
-  returning `None` for an id that could be several providers'.
-  `shape_mismatch` turns that into the check a resolver needs before it runs a
-  call: `Some(inferred)` when the id names a provider other than the one about
-  to execute it. Call it only after stripping your own routing prefixes; the
-  same `anthropic/…` string is an OpenRouter slug to this module and the
-  Anthropic first-party family to `ProviderId::from_slug_prefix`.
+- `inference::shape` (feature `inference-client`): `classify_model_shape`
+  answers which provider a model id belongs to from its spelling, and how
+  strongly. `accounts/fireworks/models/…` is Fireworks, any other
+  `vendor/model` slug is OpenRouter, and a region-scoped inference profile is
+  Bedrock — all `ShapeEvidence::Conclusive`, because each belongs to exactly one
+  catalogue. A dotted `vendor.model` id whose first segment is a known Bedrock
+  vendor is `Probable`: a vendor-name guess, not a catalogue fact.
+  `infer_provider_from_model_shape` is the same answer with the evidence
+  dropped, and returns `None` for an id that could be several providers'.
+  Two reconciliation checks read that: `shape_mismatch` reports any disagreement
+  with the provider about to execute the call, and `conclusive_shape_mismatch`
+  reports only the catalogue-fact kind. Which to call depends on where the
+  provider came from — a standing config default loses to any shape, while an
+  explicit per-call routing prefix is a human's statement about that call and
+  loses only to a catalogue fact. Call either only after stripping your own
+  routing prefixes; the same `anthropic/…` string is an OpenRouter slug to this
+  module and the Anthropic first-party family to `ProviderId::from_slug_prefix`.
   `BEDROCK_INFERENCE_PROFILE_PREFIXES` moves here so trusty-review's Bedrock
   model-id validator and this inference cannot disagree about the same string.

--- a/crates/trusty-common/changelog.d/6114-model-shape-inference.md
+++ b/crates/trusty-common/changelog.d/6114-model-shape-inference.md
@@ -1,0 +1,14 @@
+Added
+
+- `inference::shape` (feature `inference-client`): `infer_provider_from_model_shape`
+  answers which provider a model id belongs to from its spelling —
+  `accounts/fireworks/models/…` is Fireworks, any other `vendor/model` slug is
+  OpenRouter, and a region-profiled or dotted `vendor.model` id is Bedrock —
+  returning `None` for an id that could be several providers'.
+  `shape_mismatch` turns that into the check a resolver needs before it runs a
+  call: `Some(inferred)` when the id names a provider other than the one about
+  to execute it. Call it only after stripping your own routing prefixes; the
+  same `anthropic/…` string is an OpenRouter slug to this module and the
+  Anthropic first-party family to `ProviderId::from_slug_prefix`.
+  `BEDROCK_INFERENCE_PROFILE_PREFIXES` moves here so trusty-review's Bedrock
+  model-id validator and this inference cannot disagree about the same string.

--- a/crates/trusty-common/src/inference/mod.rs
+++ b/crates/trusty-common/src/inference/mod.rs
@@ -17,7 +17,10 @@
 //! [`Configurator`]), and the [`test_support`] doubles. Concrete provider HTTP
 //! adapters land in #2403/#2407. Issue #5971 adds [`tier`] beside the
 //! configurator: the configurator answers "which provider and how do I reach
-//! it", [`ModelTier::resolve`] answers "which model on that provider".
+//! it", [`ModelTier::resolve`] answers "which model on that provider". Issue
+//! #6114 adds [`shape`], which runs that last question backwards — "which
+//! provider does this model id name" — so a resolver can refuse a run whose id
+//! and provider disagree instead of quietly substituting the default model.
 //!
 //! Test: the `inference-client` surface is covered by each submodule's inline
 //! tests and `crates/trusty-common/tests/inference_foundation.rs`; the
@@ -31,6 +34,7 @@
 //! [`configurator`]: crate::inference::configurator
 //! [`Configurator`]: configurator::Configurator
 //! [`test_support`]: crate::inference::test_support
+//! [`shape`]: crate::inference::shape
 //! [`tier`]: crate::inference::tier
 //! [`ModelTier::resolve`]: crate::inference::tier::ModelTier::resolve
 
@@ -67,6 +71,8 @@ pub mod providers;
 #[cfg(feature = "inference-client")]
 pub mod registry;
 #[cfg(feature = "inference-client")]
+pub mod shape;
+#[cfg(feature = "inference-client")]
 pub mod streaming;
 #[cfg(feature = "inference-client")]
 pub mod test_support;
@@ -94,6 +100,10 @@ pub use providers::{OpenAiCompatAdapter, OpenAiCompatConfig, register_default_fa
 pub use registry::{
     Pricing, ProviderCapabilities, ProviderId, ToolDialect, capabilities, capabilities_for,
     context_window, pricing,
+};
+#[cfg(feature = "inference-client")]
+pub use shape::{
+    BEDROCK_INFERENCE_PROFILE_PREFIXES, infer_provider_from_model_shape, shape_mismatch,
 };
 #[cfg(feature = "inference-client")]
 pub use streaming::{

--- a/crates/trusty-common/src/inference/mod.rs
+++ b/crates/trusty-common/src/inference/mod.rs
@@ -103,7 +103,8 @@ pub use registry::{
 };
 #[cfg(feature = "inference-client")]
 pub use shape::{
-    BEDROCK_INFERENCE_PROFILE_PREFIXES, infer_provider_from_model_shape, shape_mismatch,
+    BEDROCK_INFERENCE_PROFILE_PREFIXES, ShapeEvidence, classify_model_shape,
+    conclusive_shape_mismatch, infer_provider_from_model_shape, shape_mismatch,
 };
 #[cfg(feature = "inference-client")]
 pub use streaming::{

--- a/crates/trusty-common/src/inference/shape.rs
+++ b/crates/trusty-common/src/inference/shape.rs
@@ -17,6 +17,13 @@
 //! needs — `Some(inferred)` when the id names a DIFFERENT provider than the one
 //! about to execute it.
 //!
+//! Which mismatch function to call depends on where the provider came from. A
+//! standing config default loses to any shape; an explicit per-call routing
+//! prefix is a human's statement about THIS call and loses only to a catalogue
+//! fact, never to the dotted-vendor guess. So: no prefix given →
+//! [`shape_mismatch`]; prefix given → [`conclusive_shape_mismatch`]. The two
+//! strengths are [`ShapeEvidence`].
+//!
 //! This is the mirror of [`crate::inference::tier`]: `ModelTier::resolve` maps
 //! a provider to a model id, this maps a model id back to its provider.
 //!
@@ -73,18 +80,73 @@ const BEDROCK_VENDOR_SEGMENTS: &[&str] = &[
 /// The provider-native prefix every Fireworks model id carries.
 const FIREWORKS_NATIVE_PREFIX: &str = "accounts/fireworks/models/";
 
+/// How strongly a model id's spelling names its provider.
+///
+/// Why: not every signal here is equally good, and the difference decides
+/// whether inference may overrule a human. A slash-form slug or a region-scoped
+/// inference profile belongs to exactly one provider's catalogue. A dotted
+/// `vendor.model` id is a guess from a vendor-name list, and a guess must not
+/// veto an operator who typed a routing prefix on this very call.
+/// What: the two strengths [`classify_model_shape`] reports.
+/// Test: `dotted_vendor_evidence_is_probable`,
+/// `slug_and_profile_evidence_is_conclusive`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShapeEvidence {
+    /// The spelling belongs to exactly one provider's catalogue: a
+    /// `vendor/model` slug, the Fireworks-native path, or a region-scoped
+    /// Bedrock inference profile.
+    Conclusive,
+    /// A dotted `vendor.model` id whose first segment is a known Bedrock
+    /// vendor. Strong enough to outrank a standing config default, not strong
+    /// enough to outrank an explicit per-call routing prefix.
+    Probable,
+}
+
+/// Classify `model`'s provider and how strongly its spelling says so.
+///
+/// Why: [`infer_provider_from_model_shape`] answers "whose is this", but a
+/// resolver deciding whether to REJECT an operator's explicit prefix needs to
+/// know whether the answer is a catalogue fact or a vendor-name guess (#6114).
+/// What: `Some((provider, evidence))`, or `None` when the id could belong to
+/// several providers (`claude-opus-4-5-20260101`, `gpt-5.4-mini`) — the case
+/// where a caller's configured default legitimately decides.
+///
+/// The input must already have had the caller's own routing prefix stripped —
+/// see the module docs.
+/// Test: `slug_and_profile_evidence_is_conclusive`,
+/// `dotted_vendor_evidence_is_probable`.
+pub fn classify_model_shape(model: &str) -> Option<(ProviderId, ShapeEvidence)> {
+    let id = model.trim();
+    if id.is_empty() {
+        return None;
+    }
+    if id.starts_with(FIREWORKS_NATIVE_PREFIX) {
+        return Some((ProviderId::Fireworks, ShapeEvidence::Conclusive));
+    }
+    if id.contains('/') {
+        return Some((ProviderId::OpenRouter, ShapeEvidence::Conclusive));
+    }
+    if BEDROCK_INFERENCE_PROFILE_PREFIXES
+        .iter()
+        .any(|pfx| id.starts_with(pfx))
+    {
+        return Some((ProviderId::Bedrock, ShapeEvidence::Conclusive));
+    }
+    let vendor = id.split('.').next().unwrap_or(id);
+    if vendor.len() < id.len() && BEDROCK_VENDOR_SEGMENTS.contains(&vendor) {
+        return Some((ProviderId::Bedrock, ShapeEvidence::Probable));
+    }
+    None
+}
+
 /// Infer the provider whose namespace `model` belongs to, from its shape alone.
 ///
 /// Why: a resolver that cannot tell `anthropic/claude-opus-4.8` from
 /// `us.anthropic.claude-opus-4-8` has no way to notice that the id and the
 /// provider about to run it disagree, so it runs the wrong model silently
-/// (#6114).
-/// What: `Some(provider)` when the spelling is unambiguous —
-/// `accounts/fireworks/models/…` is Fireworks, any other `vendor/model`
-/// slash-form is an OpenRouter slug, and a region-profiled or dotted
-/// `vendor.model` id is Bedrock. `None` when the id is bare and could belong to
-/// several providers (`claude-opus-4-5-20260101`, `gpt-5.4-mini`), which is the
-/// case where a caller's configured default legitimately decides.
+/// (#6114). This is the form to use when NO explicit routing prefix was given —
+/// there is no human choice to overrule, so both evidence strengths count.
+/// What: [`classify_model_shape`] with the evidence discarded.
 ///
 /// The input must already have had the caller's own routing prefix stripped —
 /// see the module docs.
@@ -92,27 +154,7 @@ const FIREWORKS_NATIVE_PREFIX: &str = "accounts/fireworks/models/";
 /// `dotted_vendor_id_is_bedrock`, `fireworks_native_id_is_fireworks`,
 /// `bare_ids_are_ambiguous`.
 pub fn infer_provider_from_model_shape(model: &str) -> Option<ProviderId> {
-    let id = model.trim();
-    if id.is_empty() {
-        return None;
-    }
-    if id.starts_with(FIREWORKS_NATIVE_PREFIX) {
-        return Some(ProviderId::Fireworks);
-    }
-    if id.contains('/') {
-        return Some(ProviderId::OpenRouter);
-    }
-    if BEDROCK_INFERENCE_PROFILE_PREFIXES
-        .iter()
-        .any(|pfx| id.starts_with(pfx))
-    {
-        return Some(ProviderId::Bedrock);
-    }
-    let vendor = id.split('.').next().unwrap_or(id);
-    if vendor.len() < id.len() && BEDROCK_VENDOR_SEGMENTS.contains(&vendor) {
-        return Some(ProviderId::Bedrock);
-    }
-    None
+    classify_model_shape(model).map(|(provider, _)| provider)
 }
 
 /// Report the provider `model`'s shape names, when that is not `provider`.
@@ -122,12 +164,34 @@ pub fn infer_provider_from_model_shape(model: &str) -> Option<ProviderId> {
 /// model than the one requested (#6114).
 /// What: `Some(inferred)` when [`infer_provider_from_model_shape`] names a
 /// provider other than `provider`; `None` when they agree or the id is
-/// ambiguous.
+/// ambiguous. Both evidence strengths count, so use this only where `provider`
+/// came from a config default — see [`conclusive_shape_mismatch`] for the
+/// explicit-prefix case.
 /// Test: `mismatch_flags_openrouter_slug_on_bedrock`,
 /// `mismatch_is_none_when_shape_agrees`, `mismatch_is_none_for_ambiguous_id`.
 pub fn shape_mismatch(provider: ProviderId, model: &str) -> Option<ProviderId> {
     match infer_provider_from_model_shape(model) {
         Some(inferred) if inferred != provider => Some(inferred),
+        _ => None,
+    }
+}
+
+/// The same reconciliation, but only on evidence strong enough to overrule a
+/// human.
+///
+/// Why: an operator who writes `openrouter/anthropic.claude-x` has stated the
+/// provider for this call. Rejecting that because a dotted first segment
+/// happens to match a Bedrock vendor name would turn a working configuration
+/// into a hard error on a guess. The catalogue-fact shapes still win: nothing
+/// makes `bedrock/anthropic/claude-opus-4.8` runnable, and refusing it is the
+/// whole point of #6114.
+/// What: `Some(inferred)` only when the shape disagrees with `provider` AND the
+/// evidence is [`ShapeEvidence::Conclusive`].
+/// Test: `conclusive_mismatch_ignores_a_probable_shape`,
+/// `conclusive_mismatch_still_flags_a_slug_on_bedrock`.
+pub fn conclusive_shape_mismatch(provider: ProviderId, model: &str) -> Option<ProviderId> {
+    match classify_model_shape(model) {
+        Some((inferred, ShapeEvidence::Conclusive)) if inferred != provider => Some(inferred),
         _ => None,
     }
 }
@@ -235,5 +299,81 @@ mod tests {
     fn mismatch_is_none_for_ambiguous_id() {
         assert_eq!(shape_mismatch(ProviderId::Bedrock, "claude-opus-4-8"), None);
         assert_eq!(shape_mismatch(ProviderId::Anthropic, ""), None);
+    }
+
+    #[test]
+    fn slug_and_profile_evidence_is_conclusive() {
+        for id in [
+            "anthropic/claude-opus-4.8",
+            "us.anthropic.claude-sonnet-4-6",
+            "accounts/fireworks/models/llama-v3p1-70b-instruct",
+        ] {
+            let (_, evidence) = classify_model_shape(id).expect("{id} must classify");
+            assert_eq!(
+                evidence,
+                ShapeEvidence::Conclusive,
+                "{id} belongs to exactly one catalogue"
+            );
+        }
+    }
+
+    #[test]
+    fn dotted_vendor_evidence_is_probable() {
+        let (provider, evidence) =
+            classify_model_shape("anthropic.claude-sonnet-4-6").expect("must classify");
+        assert_eq!(provider, ProviderId::Bedrock);
+        assert_eq!(
+            evidence,
+            ShapeEvidence::Probable,
+            "a vendor-name match is a guess, not a catalogue fact"
+        );
+    }
+
+    /// #6114 (code-critic MEDIUM 2): the dotted-vendor guess must not veto an
+    /// operator's explicit routing prefix.
+    ///
+    /// Why: `openrouter/anthropic.claude-x` states the provider for this call.
+    /// Turning it into a hard error because `anthropic` appears in a Bedrock
+    /// vendor list would break a working configuration on a guess.
+    /// What: asserts the conclusive-only check stays silent on a `Probable`
+    /// shape, in both directions.
+    /// Test: this test itself; the resolver-level proof lives in both consumer
+    /// crates' `*_prefix_survives_a_probable_*` tests.
+    #[test]
+    fn conclusive_mismatch_ignores_a_probable_shape() {
+        assert_eq!(
+            conclusive_shape_mismatch(ProviderId::OpenRouter, "anthropic.claude-sonnet-4-6"),
+            None,
+            "an explicit prefix outranks the dotted-vendor guess"
+        );
+        assert_eq!(
+            conclusive_shape_mismatch(ProviderId::Anthropic, "amazon.nova-pro-v1:0"),
+            None
+        );
+        // The plain form still reports it — a config default does NOT outrank it.
+        assert_eq!(
+            shape_mismatch(ProviderId::OpenRouter, "anthropic.claude-sonnet-4-6"),
+            Some(ProviderId::Bedrock)
+        );
+    }
+
+    #[test]
+    fn conclusive_mismatch_still_flags_a_slug_on_bedrock() {
+        assert_eq!(
+            conclusive_shape_mismatch(ProviderId::Bedrock, "anthropic/claude-opus-4.8"),
+            Some(ProviderId::OpenRouter),
+            "nothing makes an OpenRouter slug runnable on Bedrock"
+        );
+        assert_eq!(
+            conclusive_shape_mismatch(ProviderId::OpenRouter, "us.anthropic.claude-sonnet-4-6"),
+            Some(ProviderId::Bedrock)
+        );
+        assert_eq!(
+            conclusive_shape_mismatch(
+                ProviderId::OpenRouter,
+                "accounts/fireworks/models/llama-v3p1-70b-instruct"
+            ),
+            Some(ProviderId::Fireworks)
+        );
     }
 }

--- a/crates/trusty-common/src/inference/shape.rs
+++ b/crates/trusty-common/src/inference/shape.rs
@@ -1,0 +1,239 @@
+//! Which provider a bare model id names, judged from its SHAPE (#6114).
+//!
+//! Why: a model id only means something inside one provider's namespace, but
+//! every resolver in this workspace routed on an explicit `bedrock/` /
+//! `openrouter/` prefix alone and passed anything else through to whatever the
+//! default provider happened to be. On the #6093 mitigation run that sent an
+//! OpenRouter slug (`anthropic/claude-opus-4.8`) into a Bedrock-default path:
+//! Bedrock rejected the id, and the render that eventually completed ran
+//! Bedrock's `us.anthropic.claude-sonnet-4-6` default instead of the model the
+//! operator asked for. Two resolvers carried that fall-through
+//! (`trusty-review`'s `llm::resolve_provider_and_model` and `trusty-mpm`'s
+//! `core::sm::providers::resolve`), so the rule lives here once.
+//!
+//! What: [`infer_provider_from_model_shape`] answers "whose namespace is this
+//! id in", returning `None` when the id is genuinely ambiguous;
+//! [`shape_mismatch`] turns that into the reconciliation check a resolver
+//! needs — `Some(inferred)` when the id names a DIFFERENT provider than the one
+//! about to execute it.
+//!
+//! This is the mirror of [`crate::inference::tier`]: `ModelTier::resolve` maps
+//! a provider to a model id, this maps a model id back to its provider.
+//!
+//! 🔴 **Call this only on an id whose routing prefix you have already
+//! stripped.** Slash-form is read as an OpenRouter slug here, while
+//! [`ProviderId::from_slug_prefix`] reads the same `anthropic/…` string as the
+//! Anthropic first-party family. Both are right for their own question — a
+//! routing prefix is what the OPERATOR wrote to pin a provider, an id shape is
+//! what the PROVIDER's own catalogue looks like. A consumer strips its own
+//! prefix table first, then asks this module about what remains.
+//!
+//! [`ProviderId::from_slug_prefix`]: crate::inference::registry::ProviderId::from_slug_prefix
+//!
+//! Test: the inline `tests` module below.
+
+use super::registry::ProviderId;
+
+/// Bedrock cross-region inference-profile prefixes.
+///
+/// Why: a Bedrock model id that carries one of these is unmistakably Bedrock —
+/// no other provider in the registry uses region-scoped dotted ids. Bedrock
+/// itself REQUIRES one on Anthropic models, so `trusty-review`'s Bedrock
+/// provider validates against this same list rather than keeping a second copy.
+/// What: the region scopes AWS publishes inference profiles under.
+/// Test: `us_profile_id_is_bedrock`; consumer-side,
+/// `trusty_review::llm::bedrock::tests::bedrock_us_prefix_validation`.
+pub const BEDROCK_INFERENCE_PROFILE_PREFIXES: &[&str] = &["us.", "eu.", "ap.", "jp.", "global."];
+
+/// Vendor segments that open a Bedrock foundation-model id.
+///
+/// Why: an un-profiled Bedrock id (`anthropic.claude-sonnet-4-6`) is still
+/// unmistakably Bedrock — the dotted `vendor.model` spelling belongs to no
+/// other provider here. Matching it lets the resolver name the mismatch
+/// instead of handing the id to an aggregator that would 404 on it.
+/// What: the vendors AWS publishes foundation models under. A dotted id whose
+/// first segment is not in this list stays ambiguous.
+/// Test: `dotted_vendor_id_is_bedrock`, `unknown_dotted_prefix_is_ambiguous`.
+const BEDROCK_VENDOR_SEGMENTS: &[&str] = &[
+    "ai21",
+    "amazon",
+    "anthropic",
+    "cohere",
+    "deepseek",
+    "luma",
+    "meta",
+    "mistral",
+    "openai",
+    "qwen",
+    "stability",
+    "twelvelabs",
+    "writer",
+];
+
+/// The provider-native prefix every Fireworks model id carries.
+const FIREWORKS_NATIVE_PREFIX: &str = "accounts/fireworks/models/";
+
+/// Infer the provider whose namespace `model` belongs to, from its shape alone.
+///
+/// Why: a resolver that cannot tell `anthropic/claude-opus-4.8` from
+/// `us.anthropic.claude-opus-4-8` has no way to notice that the id and the
+/// provider about to run it disagree, so it runs the wrong model silently
+/// (#6114).
+/// What: `Some(provider)` when the spelling is unambiguous —
+/// `accounts/fireworks/models/…` is Fireworks, any other `vendor/model`
+/// slash-form is an OpenRouter slug, and a region-profiled or dotted
+/// `vendor.model` id is Bedrock. `None` when the id is bare and could belong to
+/// several providers (`claude-opus-4-5-20260101`, `gpt-5.4-mini`), which is the
+/// case where a caller's configured default legitimately decides.
+///
+/// The input must already have had the caller's own routing prefix stripped —
+/// see the module docs.
+/// Test: `openrouter_slug_is_openrouter`, `us_profile_id_is_bedrock`,
+/// `dotted_vendor_id_is_bedrock`, `fireworks_native_id_is_fireworks`,
+/// `bare_ids_are_ambiguous`.
+pub fn infer_provider_from_model_shape(model: &str) -> Option<ProviderId> {
+    let id = model.trim();
+    if id.is_empty() {
+        return None;
+    }
+    if id.starts_with(FIREWORKS_NATIVE_PREFIX) {
+        return Some(ProviderId::Fireworks);
+    }
+    if id.contains('/') {
+        return Some(ProviderId::OpenRouter);
+    }
+    if BEDROCK_INFERENCE_PROFILE_PREFIXES
+        .iter()
+        .any(|pfx| id.starts_with(pfx))
+    {
+        return Some(ProviderId::Bedrock);
+    }
+    let vendor = id.split('.').next().unwrap_or(id);
+    if vendor.len() < id.len() && BEDROCK_VENDOR_SEGMENTS.contains(&vendor) {
+        return Some(ProviderId::Bedrock);
+    }
+    None
+}
+
+/// Report the provider `model`'s shape names, when that is not `provider`.
+///
+/// Why: this is the reconciliation a resolver owes its caller — the run must
+/// fail naming both the id and the provider rather than execute a different
+/// model than the one requested (#6114).
+/// What: `Some(inferred)` when [`infer_provider_from_model_shape`] names a
+/// provider other than `provider`; `None` when they agree or the id is
+/// ambiguous.
+/// Test: `mismatch_flags_openrouter_slug_on_bedrock`,
+/// `mismatch_is_none_when_shape_agrees`, `mismatch_is_none_for_ambiguous_id`.
+pub fn shape_mismatch(provider: ProviderId, model: &str) -> Option<ProviderId> {
+    match infer_provider_from_model_shape(model) {
+        Some(inferred) if inferred != provider => Some(inferred),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn openrouter_slug_is_openrouter() {
+        // The #6114 id itself: an OpenRouter slug that used to fall through to
+        // whatever default provider the path carried.
+        assert_eq!(
+            infer_provider_from_model_shape("anthropic/claude-opus-4.8"),
+            Some(ProviderId::OpenRouter)
+        );
+        assert_eq!(
+            infer_provider_from_model_shape("openai/gpt-5.4-mini-20260317"),
+            Some(ProviderId::OpenRouter)
+        );
+    }
+
+    #[test]
+    fn us_profile_id_is_bedrock() {
+        for id in [
+            "us.anthropic.claude-sonnet-4-6",
+            "eu.anthropic.claude-haiku-4-5",
+            "global.anthropic.claude-opus-4-8",
+        ] {
+            assert_eq!(
+                infer_provider_from_model_shape(id),
+                Some(ProviderId::Bedrock),
+                "{id} must read as Bedrock"
+            );
+        }
+    }
+
+    #[test]
+    fn dotted_vendor_id_is_bedrock() {
+        assert_eq!(
+            infer_provider_from_model_shape("anthropic.claude-sonnet-4-6"),
+            Some(ProviderId::Bedrock)
+        );
+        assert_eq!(
+            infer_provider_from_model_shape("amazon.nova-pro-v1:0"),
+            Some(ProviderId::Bedrock)
+        );
+    }
+
+    #[test]
+    fn fireworks_native_id_is_fireworks() {
+        assert_eq!(
+            infer_provider_from_model_shape("accounts/fireworks/models/llama-v3p1-70b-instruct"),
+            Some(ProviderId::Fireworks),
+            "the fireworks-native id must not be read as an OpenRouter slug"
+        );
+    }
+
+    #[test]
+    fn bare_ids_are_ambiguous() {
+        for id in ["", "   ", "claude-opus-4-5-20260101", "gpt-5.4-mini"] {
+            assert_eq!(
+                infer_provider_from_model_shape(id),
+                None,
+                "{id:?} must stay ambiguous so the configured default decides"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_dotted_prefix_is_ambiguous() {
+        // A dot alone is not a Bedrock signal — version-dotted slugs are common.
+        assert_eq!(infer_provider_from_model_shape("llama-3.1-70b"), None);
+    }
+
+    #[test]
+    fn mismatch_flags_openrouter_slug_on_bedrock() {
+        assert_eq!(
+            shape_mismatch(ProviderId::Bedrock, "anthropic/claude-opus-4.8"),
+            Some(ProviderId::OpenRouter),
+            "#6114: this pair must be reportable, not silently run on Bedrock"
+        );
+        assert_eq!(
+            shape_mismatch(ProviderId::OpenRouter, "us.anthropic.claude-sonnet-4-6"),
+            Some(ProviderId::Bedrock)
+        );
+    }
+
+    #[test]
+    fn mismatch_is_none_when_shape_agrees() {
+        assert_eq!(
+            shape_mismatch(ProviderId::Bedrock, "us.anthropic.claude-sonnet-4-6"),
+            None
+        );
+        assert_eq!(
+            shape_mismatch(
+                ProviderId::Fireworks,
+                "accounts/fireworks/models/llama-v3p1-70b-instruct"
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn mismatch_is_none_for_ambiguous_id() {
+        assert_eq!(shape_mismatch(ProviderId::Bedrock, "claude-opus-4-8"), None);
+        assert_eq!(shape_mismatch(ProviderId::Anthropic, ""), None);
+    }
+}

--- a/crates/trusty-mpm/changelog.d/6114-sm-provider-model-mismatch.md
+++ b/crates/trusty-mpm/changelog.d/6114-sm-provider-model-mismatch.md
@@ -9,6 +9,14 @@ Fixed
   an unambiguous id shape before the default or the credential precedence chain
   gets it, and returns `SmLlmError::Validation` naming both the id and the
   provider when they disagree. Credentials decide which provider is reachable,
-  never which model the operator asked for. Explicit `anthropic/` / `bedrock/` /
-  `openrouter/` prefixes still win, and are still stripped before the shape is
-  read. The function is now fallible.
+  never which model the operator asked for. An explicit `anthropic/` /
+  `bedrock/` / `openrouter/` prefix still wins, is still stripped before the
+  shape is read, and is overruled only by a shape that belongs to exactly one
+  provider's catalogue — never by the dotted `vendor.model` guess, so
+  `openrouter/anthropic.claude-x` keeps working. The function is now fallible.
+- A rejected model id no longer suggests a `provider` value the config parser
+  refuses. When the id belongs to a provider the SM has no client for, the error
+  says so and names the accepted set instead of telling the operator to set
+  `provider = "fireworks"`. `ProviderKind::parse`, its error, and the
+  shape-mismatch remedy all read one list (`ProviderKind::ALL`), so the accepted
+  values and the routing-prefix hint cannot drift from what the parser takes.

--- a/crates/trusty-mpm/changelog.d/6114-sm-provider-model-mismatch.md
+++ b/crates/trusty-mpm/changelog.d/6114-sm-provider-model-mismatch.md
@@ -1,0 +1,14 @@
+Fixed
+
+- The Session Manager no longer sends a model id to a provider that has never
+  heard of it. A tier model with no routing prefix took the configured
+  `provider` whatever it looked like, so a `us.anthropic.*` inference profile
+  under `provider = "openrouter"` — or an OpenRouter slug under an `auto` chain
+  that picked Anthropic — went upstream unchanged.
+  `core::sm::providers::resolve_provider_and_model` now infers the provider from
+  an unambiguous id shape before the default or the credential precedence chain
+  gets it, and returns `SmLlmError::Validation` naming both the id and the
+  provider when they disagree. Credentials decide which provider is reachable,
+  never which model the operator asked for. Explicit `anthropic/` / `bedrock/` /
+  `openrouter/` prefixes still win, and are still stripped before the shape is
+  read. The function is now fallible.

--- a/crates/trusty-mpm/src/core/sm/agent/mock.rs
+++ b/crates/trusty-mpm/src/core/sm/agent/mock.rs
@@ -289,7 +289,7 @@ fn resolved_call(
 ) -> Result<ResolvedCall, SmLlmError> {
     let tier_model = crate::core::sm::providers::resolve_tier_model(cfg, tier)?;
     let (_kind, bare) =
-        crate::core::sm::providers::resolve_provider_and_model(&tier_model, ProviderKind::Auto);
+        crate::core::sm::providers::resolve_provider_and_model(&tier_model, ProviderKind::Auto)?;
     Ok(ResolvedCall {
         provider: Arc::new(provider.clone()),
         model: bare,

--- a/crates/trusty-mpm/src/core/sm/providers/mod.rs
+++ b/crates/trusty-mpm/src/core/sm/providers/mod.rs
@@ -97,16 +97,84 @@ impl ProviderKind {
     /// Anything else returns [`SmLlmError::Validation`].
     /// Test: `provider_kind_parse_ok`, `provider_kind_parse_rejects_unknown`.
     pub fn parse(s: &str) -> Result<Self, SmLlmError> {
-        match s.trim().to_ascii_lowercase().as_str() {
-            "" | "auto" => Ok(ProviderKind::Auto),
-            "anthropic" => Ok(ProviderKind::Anthropic),
-            "bedrock" => Ok(ProviderKind::Bedrock),
-            "openrouter" => Ok(ProviderKind::OpenRouter),
-            other => Err(SmLlmError::Validation(format!(
-                "unknown [session_manager.inference] provider {other:?}; \
-                 expected one of: auto, anthropic, bedrock, openrouter"
-            ))),
+        let wanted = s.trim().to_ascii_lowercase();
+        if wanted.is_empty() {
+            return Ok(ProviderKind::Auto);
         }
+        Self::ALL
+            .iter()
+            .copied()
+            .find(|kind| kind.name() == wanted)
+            .ok_or_else(|| {
+                SmLlmError::Validation(format!(
+                    "unknown [session_manager.inference] provider {wanted:?}; \
+                     expected one of: {}",
+                    Self::accepted_values()
+                ))
+            })
+    }
+
+    /// Every legal `provider` value, in the order the error message lists them.
+    ///
+    /// Why: #6114 (code-critic MEDIUM 1) — [`ProviderKind::parse`]'s error and
+    /// the shape-mismatch remedy both have to name the accepted set, and two
+    /// hand-written lists drift. Adding a variant is already a compile error in
+    /// [`ProviderKind::name`]; routing both messages through one list means it
+    /// cannot be a SILENT error here.
+    /// What: the four variants. `parse` matches against `name()` over this list,
+    /// so a variant missing from it is unparseable rather than misdescribed.
+    /// Test: `provider_kind_all_covers_every_variant`,
+    /// `provider_kind_name_round_trips`.
+    pub const ALL: &'static [ProviderKind] = &[
+        ProviderKind::Auto,
+        ProviderKind::Anthropic,
+        ProviderKind::Bedrock,
+        ProviderKind::OpenRouter,
+    ];
+
+    /// The accepted `provider` values as one comma-separated string.
+    ///
+    /// Why: an error that suggests a value the config parser rejects sends the
+    /// operator in a circle (#6114).
+    /// What: `"auto, anthropic, bedrock, openrouter"`, derived from
+    /// [`ProviderKind::ALL`].
+    /// Test: `provider_kind_accepted_values_are_all_parseable`.
+    pub fn accepted_values() -> String {
+        Self::ALL
+            .iter()
+            .map(|kind| kind.name())
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+
+    /// The routing prefix that pins this kind on a single call, if it has one.
+    ///
+    /// Why: the shape-mismatch remedy tells the operator which prefixes exist,
+    /// and a hand-written list there would drift from the constants the parser
+    /// actually strips (#6114).
+    /// What: `None` for [`ProviderKind::Auto`], which pins nothing.
+    /// Test: `provider_kind_prefixes_match_the_constants`.
+    pub fn model_prefix(self) -> Option<&'static str> {
+        match self {
+            ProviderKind::Auto => None,
+            ProviderKind::Anthropic => Some(ANTHROPIC_MODEL_PREFIX),
+            ProviderKind::Bedrock => Some(BEDROCK_MODEL_PREFIX),
+            ProviderKind::OpenRouter => Some(OPENROUTER_MODEL_PREFIX),
+        }
+    }
+
+    /// The routing prefixes an operator may write, as one quoted list.
+    ///
+    /// Why: same single-source reason as [`ProviderKind::accepted_values`].
+    /// What: `"\"anthropic/…\", \"bedrock/…\", \"openrouter/…\""`.
+    /// Test: `provider_kind_prefixes_match_the_constants`.
+    pub fn routing_prefix_hint() -> String {
+        Self::ALL
+            .iter()
+            .filter_map(|kind| kind.model_prefix())
+            .map(|prefix| format!("\"{prefix}…\""))
+            .collect::<Vec<_>>()
+            .join(", ")
     }
 
     /// The stable lowercase name of this provider kind.
@@ -297,15 +365,70 @@ mod tests {
     /// Test: this is the test.
     #[test]
     fn provider_kind_name_round_trips() {
+        for kind in ProviderKind::ALL.iter().copied() {
+            assert_eq!(ProviderKind::parse(kind.name()).unwrap(), kind);
+        }
+        assert_eq!(ProviderKind::Anthropic.name(), "anthropic");
+    }
+
+    /// #6114: `ALL` must list every variant, because `parse` now matches
+    /// against it — a variant missing from the list is unparseable.
+    ///
+    /// Why: `ALL` is hand-written, so the exhaustive match in `name()` is what
+    /// catches a new variant at compile time. This test catches the other half:
+    /// a variant that has a name but was never added to the list.
+    /// What: asserts the count, and that every variant appears.
+    /// Test: this is the test.
+    #[test]
+    fn provider_kind_all_covers_every_variant() {
         for kind in [
             ProviderKind::Auto,
             ProviderKind::Anthropic,
             ProviderKind::Bedrock,
             ProviderKind::OpenRouter,
         ] {
-            assert_eq!(ProviderKind::parse(kind.name()).unwrap(), kind);
+            assert!(
+                ProviderKind::ALL.contains(&kind),
+                "{} is missing from ProviderKind::ALL, so parse() rejects it",
+                kind.name()
+            );
         }
-        assert_eq!(ProviderKind::Anthropic.name(), "anthropic");
+        assert_eq!(ProviderKind::ALL.len(), 4, "ALL must list every variant");
+    }
+
+    /// #6114: every value `accepted_values` advertises must actually parse.
+    #[test]
+    fn provider_kind_accepted_values_are_all_parseable() {
+        let advertised = ProviderKind::accepted_values();
+        for value in advertised.split(", ") {
+            assert!(
+                ProviderKind::parse(value).is_ok(),
+                "accepted_values() offers {value:?}, which parse() rejects"
+            );
+        }
+        assert_eq!(advertised, "auto, anthropic, bedrock, openrouter");
+    }
+
+    /// #6114: the prefix hint must quote the constants the resolver strips.
+    #[test]
+    fn provider_kind_prefixes_match_the_constants() {
+        assert_eq!(
+            ProviderKind::Anthropic.model_prefix(),
+            Some(ANTHROPIC_MODEL_PREFIX)
+        );
+        assert_eq!(
+            ProviderKind::Bedrock.model_prefix(),
+            Some(BEDROCK_MODEL_PREFIX)
+        );
+        assert_eq!(
+            ProviderKind::OpenRouter.model_prefix(),
+            Some(OPENROUTER_MODEL_PREFIX)
+        );
+        assert_eq!(ProviderKind::Auto.model_prefix(), None, "auto pins nothing");
+        assert_eq!(
+            ProviderKind::routing_prefix_hint(),
+            "\"anthropic/…\", \"bedrock/…\", \"openrouter/…\""
+        );
     }
 
     /// #6114: the bridge to the shared `ProviderId` must round-trip every kind

--- a/crates/trusty-mpm/src/core/sm/providers/mod.rs
+++ b/crates/trusty-mpm/src/core/sm/providers/mod.rs
@@ -124,6 +124,49 @@ impl ProviderKind {
             ProviderKind::OpenRouter => "openrouter",
         }
     }
+
+    /// The shared `trusty-common` identity for this kind, when it has one.
+    ///
+    /// Why: #6114's model-shape inference speaks [`ProviderId`], the workspace's
+    /// one provider identity. Bridging here keeps the mapping in a single place
+    /// instead of at each resolver call site.
+    /// What: `None` for [`ProviderKind::Auto`], which names no concrete provider
+    /// until the credential precedence chain has run.
+    /// Test: `provider_kind_bridges_to_the_shared_provider_id`.
+    ///
+    /// [`ProviderId`]: trusty_common::inference::ProviderId
+    pub fn provider_id(self) -> Option<trusty_common::inference::ProviderId> {
+        use trusty_common::inference::ProviderId;
+        match self {
+            ProviderKind::Auto => None,
+            ProviderKind::Anthropic => Some(ProviderId::Anthropic),
+            ProviderKind::Bedrock => Some(ProviderId::Bedrock),
+            ProviderKind::OpenRouter => Some(ProviderId::OpenRouter),
+        }
+    }
+
+    /// The kind for a shared [`ProviderId`], when the SM can build one.
+    ///
+    /// Why: the inverse of [`ProviderKind::provider_id`]. The shared identity
+    /// covers eight providers; the SM has clients for three, and a shape that
+    /// names one of the other five must be reported rather than coerced.
+    /// What: `None` for every `ProviderId` the SM has no client for.
+    /// Test: `provider_kind_bridges_to_the_shared_provider_id`.
+    ///
+    /// [`ProviderId`]: trusty_common::inference::ProviderId
+    pub fn from_provider_id(id: trusty_common::inference::ProviderId) -> Option<Self> {
+        use trusty_common::inference::ProviderId;
+        match id {
+            ProviderId::Anthropic => Some(ProviderKind::Anthropic),
+            ProviderId::Bedrock => Some(ProviderKind::Bedrock),
+            ProviderId::OpenRouter => Some(ProviderKind::OpenRouter),
+            ProviderId::Fireworks
+            | ProviderId::OpenAI
+            | ProviderId::Together
+            | ProviderId::AtlasCloud
+            | ProviderId::Local => None,
+        }
+    }
 }
 
 // ─── Chat / request / response shapes ──────────────────────────────────────────
@@ -263,6 +306,30 @@ mod tests {
             assert_eq!(ProviderKind::parse(kind.name()).unwrap(), kind);
         }
         assert_eq!(ProviderKind::Anthropic.name(), "anthropic");
+    }
+
+    /// #6114: the bridge to the shared `ProviderId` must round-trip every kind
+    /// the SM can actually build, and map `Auto` to nothing.
+    ///
+    /// Why: model-shape inference speaks `ProviderId`; a lossy bridge would let a
+    /// shape resolve to the wrong client, which is the substitution the ticket
+    /// removes.
+    /// What: asserts the round trip for the three concrete kinds, `None` for
+    /// `Auto`, and `None` for a `ProviderId` the SM has no client for.
+    /// Test: this is the test.
+    #[test]
+    fn provider_kind_bridges_to_the_shared_provider_id() {
+        use trusty_common::inference::ProviderId;
+        for kind in [
+            ProviderKind::Anthropic,
+            ProviderKind::Bedrock,
+            ProviderKind::OpenRouter,
+        ] {
+            let id = kind.provider_id().expect("a concrete kind has an id");
+            assert_eq!(ProviderKind::from_provider_id(id), Some(kind));
+        }
+        assert_eq!(ProviderKind::Auto.provider_id(), None);
+        assert_eq!(ProviderKind::from_provider_id(ProviderId::Fireworks), None);
     }
 
     /// Why: SM-1 review carry-forward — an unknown `provider` string must be a

--- a/crates/trusty-mpm/src/core/sm/providers/resolve.rs
+++ b/crates/trusty-mpm/src/core/sm/providers/resolve.rs
@@ -27,7 +27,9 @@ use tracing::debug;
 use tracing::info;
 #[cfg(feature = "bedrock")]
 use tracing::warn;
-use trusty_common::inference::{ProviderId, infer_provider_from_model_shape, shape_mismatch};
+use trusty_common::inference::{
+    ProviderId, conclusive_shape_mismatch, infer_provider_from_model_shape,
+};
 
 use super::{
     ANTHROPIC_MODEL_PREFIX, AnthropicProvider, BEDROCK_MODEL_PREFIX, LlmProvider,
@@ -133,14 +135,21 @@ pub fn resolve_provider_and_model(
 /// [`ProviderKind::Auto`] (nothing to contradict yet — the chain runs later, and
 /// it only ever reaches here on an ambiguous id). Otherwise a
 /// [`SmLlmError::Validation`] naming `requested` and both providers.
-/// Test: `route_prefix_contradicting_the_shape_is_an_error`.
+///
+/// Uses [`conclusive_shape_mismatch`], not the plain form: every caller here
+/// reaches this with a kind the operator pinned by prefix, or with a default
+/// that only sees ids no shape claimed. Rejecting a pinned kind on the
+/// dotted-vendor guess would break `openrouter/anthropic.claude-x`, a working
+/// configuration, on a vendor-name coincidence.
+/// Test: `route_prefix_contradicting_the_shape_is_an_error`,
+/// `route_explicit_prefix_survives_a_probable_bedrock_shape`.
 fn reconcile(
     kind: ProviderKind,
     bare: &str,
     requested: &str,
 ) -> Result<(ProviderKind, String), SmLlmError> {
     if let Some(id) = kind.provider_id()
-        && let Some(inferred) = shape_mismatch(id, bare)
+        && let Some(inferred) = conclusive_shape_mismatch(id, bare)
     {
         return Err(shape_error(requested, inferred, kind));
     }
@@ -152,14 +161,32 @@ fn reconcile(
 /// Why: the message is the deliverable of #6114 — it must name the id AND the
 /// provider that would have run it, so an operator can see what was substituted
 /// instead of discovering it in a bill.
-/// What: a [`SmLlmError::Validation`] carrying all three facts.
-/// Test: `route_prefix_contradicting_the_shape_is_an_error`.
+/// What: a [`SmLlmError::Validation`] carrying all three facts, plus a remedy.
+/// The remedy branches on whether the SM can actually build `inferred`: naming a
+/// provider [`ProviderKind::parse`] rejects would send the operator in a circle
+/// (#6114, code-critic MEDIUM 1), so an unbuildable one is reported as such and
+/// the accepted set comes from [`ProviderKind::accepted_values`].
+/// Test: `route_prefix_contradicting_the_shape_is_an_error`,
+/// `route_shape_the_sm_cannot_build_is_an_error`,
+/// `shape_error_only_suggests_parseable_provider_values`.
 fn shape_error(requested: &str, inferred: ProviderId, kind: ProviderKind) -> SmLlmError {
+    let remedy = match ProviderKind::from_provider_id(inferred) {
+        Some(target) => format!(
+            "Either set [session_manager.inference].provider to \"{target}\", or pin one \
+             explicitly with a routing prefix ({prefixes}).",
+            target = target.name(),
+            prefixes = ProviderKind::routing_prefix_hint()
+        ),
+        None => format!(
+            "The session manager has no client for {inferred}; provider accepts only \
+             {accepted}. Use a model id published by one of those providers.",
+            inferred = inferred.as_str(),
+            accepted = ProviderKind::accepted_values()
+        ),
+    };
     SmLlmError::Validation(format!(
         "model id {requested:?} names the {inferred} provider by its shape, but this call would \
-         run on {kind}. Refusing to substitute a different model than the one requested. \
-         Either set [session_manager.inference].provider to {inferred}, or pin one explicitly \
-         with a routing prefix (\"anthropic/…\", \"bedrock/…\", \"openrouter/…\").",
+         run on {kind}. Refusing to substitute a different model than the one requested. {remedy}",
         inferred = inferred.as_str(),
         kind = kind.name()
     ))

--- a/crates/trusty-mpm/src/core/sm/providers/resolve.rs
+++ b/crates/trusty-mpm/src/core/sm/providers/resolve.rs
@@ -22,10 +22,12 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use tracing::debug;
+// #6114: the workspace's one answer to "which provider does this model id name".
 #[cfg(not(feature = "bedrock"))]
 use tracing::info;
 #[cfg(feature = "bedrock")]
 use tracing::warn;
+use trusty_common::inference::{ProviderId, infer_provider_from_model_shape, shape_mismatch};
 
 use super::{
     ANTHROPIC_MODEL_PREFIX, AnthropicProvider, BEDROCK_MODEL_PREFIX, LlmProvider,
@@ -68,27 +70,99 @@ pub enum SmModelTier {
 /// prefix to pin a provider for that call, overriding the active `provider`
 /// (D5.3); a bare id routes to `default_provider`. This is the single source of
 /// truth for that rule.
-/// What: strips a known prefix (returning the matching kind + bare id) or
-/// returns `(default_provider, model)` unchanged for a bare id. Note: when
-/// `default_provider` is [`ProviderKind::Auto`], the *kind* stays `Auto` here —
-/// the credential-aware precedence chain is applied later by
-/// [`ProviderRegistry::build`].
+///
+/// Until #6114 a bare id took `default_provider` whatever it looked like, so a
+/// `us.anthropic.*` inference profile under `provider = "openrouter"` — or an
+/// OpenRouter slug under an `auto` chain that picked Anthropic — went upstream
+/// as a model that provider has never heard of. An unambiguous id shape now
+/// names its own provider, and a pair that cannot be reconciled is an error.
+///
+/// What: strips a known prefix (returning the matching kind + bare id), else
+/// infers the kind from the id's shape via
+/// [`trusty_common::inference::infer_provider_from_model_shape`], else returns
+/// `(default_provider, model)`. Whichever route is taken, the pair is checked
+/// for a shape conflict first. Note: when `default_provider` is
+/// [`ProviderKind::Auto`] AND the shape is ambiguous, the *kind* stays `Auto`
+/// here — the credential-aware precedence chain is applied later by
+/// [`ProviderRegistry::build`]. An unambiguous shape outranks that chain, which
+/// is the point: credentials decide which provider is REACHABLE, never which
+/// model the operator asked for.
+///
+/// # Errors
+///
+/// [`SmLlmError::Validation`], naming both the requested id and the provider
+/// that would execute it, when the two disagree.
+///
 /// Test: `route_anthropic_prefix`, `route_bedrock_prefix`,
-/// `route_openrouter_prefix`, `route_bare_uses_default`.
+/// `route_openrouter_prefix`, `route_bare_uses_default`,
+/// `route_bare_openrouter_slug_beats_the_default`,
+/// `route_bare_bedrock_profile_beats_the_default`,
+/// `route_prefix_contradicting_the_shape_is_an_error`.
 pub fn resolve_provider_and_model(
     model: &str,
     default_provider: ProviderKind,
-) -> (ProviderKind, String) {
+) -> Result<(ProviderKind, String), SmLlmError> {
     if let Some(bare) = model.strip_prefix(ANTHROPIC_MODEL_PREFIX) {
-        return (ProviderKind::Anthropic, bare.to_string());
+        return reconcile(ProviderKind::Anthropic, bare, model);
     }
     if let Some(bare) = model.strip_prefix(BEDROCK_MODEL_PREFIX) {
-        return (ProviderKind::Bedrock, bare.to_string());
+        return reconcile(ProviderKind::Bedrock, bare, model);
     }
     if let Some(bare) = model.strip_prefix(OPENROUTER_MODEL_PREFIX) {
-        return (ProviderKind::OpenRouter, bare.to_string());
+        return reconcile(ProviderKind::OpenRouter, bare, model);
     }
-    (default_provider, model.to_string())
+    // #6114: no routing prefix — an unambiguous id shape names its own provider
+    // before `default_provider` (or the `auto` precedence chain) gets it.
+    if let Some(inferred) = infer_provider_from_model_shape(model) {
+        return match ProviderKind::from_provider_id(inferred) {
+            Some(kind) => Ok((kind, model.to_string())),
+            // The shape names a provider the SM has no client for. Saying so is
+            // the whole point — the alternative is running it somewhere else.
+            None => Err(shape_error(model, inferred, default_provider)),
+        };
+    }
+    reconcile(default_provider, model, model)
+}
+
+/// Refuse a `(kind, model)` pair whose id names a different provider.
+///
+/// Why: #6114 — the id and the provider that will execute it must agree, and
+/// when they do not the only safe outcome is a loud stop rather than a call to
+/// the wrong backend.
+/// What: `Ok((kind, bare))` when the shape agrees, is ambiguous, or `kind` is
+/// [`ProviderKind::Auto`] (nothing to contradict yet — the chain runs later, and
+/// it only ever reaches here on an ambiguous id). Otherwise a
+/// [`SmLlmError::Validation`] naming `requested` and both providers.
+/// Test: `route_prefix_contradicting_the_shape_is_an_error`.
+fn reconcile(
+    kind: ProviderKind,
+    bare: &str,
+    requested: &str,
+) -> Result<(ProviderKind, String), SmLlmError> {
+    if let Some(id) = kind.provider_id()
+        && let Some(inferred) = shape_mismatch(id, bare)
+    {
+        return Err(shape_error(requested, inferred, kind));
+    }
+    Ok((kind, bare.to_string()))
+}
+
+/// The one wording for "this id and this provider do not agree".
+///
+/// Why: the message is the deliverable of #6114 — it must name the id AND the
+/// provider that would have run it, so an operator can see what was substituted
+/// instead of discovering it in a bill.
+/// What: a [`SmLlmError::Validation`] carrying all three facts.
+/// Test: `route_prefix_contradicting_the_shape_is_an_error`.
+fn shape_error(requested: &str, inferred: ProviderId, kind: ProviderKind) -> SmLlmError {
+    SmLlmError::Validation(format!(
+        "model id {requested:?} names the {inferred} provider by its shape, but this call would \
+         run on {kind}. Refusing to substitute a different model than the one requested. \
+         Either set [session_manager.inference].provider to {inferred}, or pin one explicitly \
+         with a routing prefix (\"anthropic/…\", \"bedrock/…\", \"openrouter/…\").",
+        inferred = inferred.as_str(),
+        kind = kind.name()
+    ))
 }
 
 // ─── Per-task tier selection (DOC-14 §5.4) ──────────────────────────────────────
@@ -365,7 +439,7 @@ impl ProviderRegistry {
     ) -> Result<(ProviderKind, String), SmLlmError> {
         let default_provider = ProviderKind::parse(&cfg.provider)?;
         let tier_model = resolve_tier_model(cfg, tier)?;
-        let (routed_kind, bare_model) = resolve_provider_and_model(&tier_model, default_provider);
+        let (routed_kind, bare_model) = resolve_provider_and_model(&tier_model, default_provider)?;
 
         let effective_kind = match routed_kind {
             ProviderKind::Auto => self.auto_precedence()?,

--- a/crates/trusty-mpm/src/core/sm/providers/resolve_tests.rs
+++ b/crates/trusty-mpm/src/core/sm/providers/resolve_tests.rs
@@ -33,17 +33,22 @@ fn empty_cfg() -> SmInferenceConfig {
 
 // ── Prefix routing (D5.3) ──────────────────────────────────────────────────
 
+/// Route, treating an error as a test failure.
+fn routed(model: &str, default_provider: ProviderKind) -> (ProviderKind, String) {
+    resolve_provider_and_model(model, default_provider)
+        .unwrap_or_else(|e| panic!("{model:?} must route: {e}"))
+}
+
 #[test]
 fn route_anthropic_prefix() {
-    let (kind, model) =
-        resolve_provider_and_model("anthropic/claude-sonnet-4-6", ProviderKind::OpenRouter);
+    let (kind, model) = routed("anthropic/claude-sonnet-4-6", ProviderKind::OpenRouter);
     assert_eq!(kind, ProviderKind::Anthropic);
     assert_eq!(model, "claude-sonnet-4-6");
 }
 
 #[test]
 fn route_bedrock_prefix() {
-    let (kind, model) = resolve_provider_and_model(
+    let (kind, model) = routed(
         "bedrock/us.anthropic.claude-sonnet-4-6",
         ProviderKind::Anthropic,
     );
@@ -53,22 +58,106 @@ fn route_bedrock_prefix() {
 
 #[test]
 fn route_openrouter_prefix() {
-    let (kind, model) =
-        resolve_provider_and_model("openrouter/anthropic/claude-haiku", ProviderKind::Bedrock);
+    let (kind, model) = routed("openrouter/anthropic/claude-haiku", ProviderKind::Bedrock);
     assert_eq!(kind, ProviderKind::OpenRouter);
     assert_eq!(model, "anthropic/claude-haiku");
 }
 
 #[test]
 fn route_bare_uses_default() {
-    // Bare id keeps the supplied default provider verbatim.
-    let (kind, model) = resolve_provider_and_model("claude-sonnet-4-6", ProviderKind::OpenRouter);
+    // A bare id with no unambiguous shape keeps the supplied default provider.
+    let (kind, model) = routed("claude-sonnet-4-6", ProviderKind::OpenRouter);
     assert_eq!(kind, ProviderKind::OpenRouter);
     assert_eq!(model, "claude-sonnet-4-6");
 
-    // Bare id with Auto default stays Auto (precedence applied later).
-    let (kind, _) = resolve_provider_and_model("claude-haiku", ProviderKind::Auto);
+    // Same, with Auto default: stays Auto (precedence applied later).
+    let (kind, _) = routed("claude-haiku", ProviderKind::Auto);
     assert_eq!(kind, ProviderKind::Auto);
+}
+
+// ── Model-shape inference (#6114) ──────────────────────────────────────────
+
+/// #6114: an unprefixed OpenRouter slug names OpenRouter, whatever the default.
+///
+/// Why: the slug shape belongs to no other provider the SM builds, so handing it
+/// to the configured default sends an id upstream that the default has never
+/// heard of — or, under `auto`, to whichever provider happened to have a
+/// credential.
+/// What: asserts the routed kind is OpenRouter for a Bedrock default and for the
+/// `auto` chain, with the id passed through unchanged. The slugs here
+/// deliberately do NOT open with one of the SM's own routing prefixes: `anthropic/`
+/// is a prefix in this crate (it pins the first-party API), so shape inference
+/// never sees such an id — it only ever judges what is left after stripping.
+/// Test: this test itself.
+#[test]
+fn route_bare_openrouter_slug_beats_the_default() {
+    let (kind, model) = routed("google/gemini-3-pro", ProviderKind::Bedrock);
+    assert_eq!(kind, ProviderKind::OpenRouter);
+    assert_eq!(model, "google/gemini-3-pro");
+
+    let (kind, _) = routed("openai/gpt-5.4-mini-20260317", ProviderKind::Auto);
+    assert_eq!(
+        kind,
+        ProviderKind::OpenRouter,
+        "an unambiguous shape outranks the credential precedence chain (#6114)"
+    );
+}
+
+/// #6114: the mirror case — a Bedrock inference profile names Bedrock.
+#[test]
+fn route_bare_bedrock_profile_beats_the_default() {
+    let (kind, model) = routed("us.anthropic.claude-sonnet-4-6", ProviderKind::OpenRouter);
+    assert_eq!(kind, ProviderKind::Bedrock);
+    assert_eq!(model, "us.anthropic.claude-sonnet-4-6");
+}
+
+/// #6114: a prefix that contradicts the id's shape is an error naming both,
+/// never a silent call to the prefixed provider.
+#[test]
+fn route_prefix_contradicting_the_shape_is_an_error() {
+    let err = resolve_provider_and_model(
+        "bedrock/anthropic/claude-opus-4.8",
+        ProviderKind::OpenRouter,
+    )
+    .expect_err("a bedrock/ prefix on an OpenRouter slug must not route");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("anthropic/claude-opus-4.8"),
+        "the error must name the requested id: {msg}"
+    );
+    assert!(
+        msg.contains("bedrock") && msg.contains("openrouter"),
+        "the error must name both providers: {msg}"
+    );
+
+    // The Anthropic first-party provider cannot run a Bedrock profile id either.
+    resolve_provider_and_model(
+        "anthropic/us.anthropic.claude-sonnet-4-6",
+        ProviderKind::Auto,
+    )
+    .expect_err("a bedrock profile id must not be sent to api.anthropic.com");
+}
+
+/// #6114: a shape naming a provider the SM has no client for stops the call.
+///
+/// Why: the SM builds Anthropic, Bedrock, and OpenRouter. A Fireworks-native id
+/// belongs to none of them, and running it on whichever one the config named is
+/// the substitution this ticket removes.
+/// What: asserts the error names the id and the fireworks provider.
+/// Test: this test itself.
+#[test]
+fn route_shape_the_sm_cannot_build_is_an_error() {
+    let err = resolve_provider_and_model(
+        "accounts/fireworks/models/llama-v3p1-70b-instruct",
+        ProviderKind::OpenRouter,
+    )
+    .expect_err("a fireworks-native id must not run on OpenRouter");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("accounts/fireworks/models/llama-v3p1-70b-instruct")
+            && msg.contains("fireworks"),
+        "the error must name the id and the provider it belongs to: {msg}"
+    );
 }
 
 // ── Tier selection + alias fallback (§5.4) ─────────────────────────────────

--- a/crates/trusty-mpm/src/core/sm/providers/resolve_tests.rs
+++ b/crates/trusty-mpm/src/core/sm/providers/resolve_tests.rs
@@ -138,6 +138,98 @@ fn route_prefix_contradicting_the_shape_is_an_error() {
     .expect_err("a bedrock profile id must not be sent to api.anthropic.com");
 }
 
+/// #6114 (code-critic MEDIUM 2): an explicit routing prefix survives a
+/// merely-probable Bedrock shape.
+///
+/// Why: `openrouter/anthropic.claude-x` states the provider for this call. The
+/// dotted-vendor rule is a guess from a vendor-name list, and a guess must not
+/// turn a working configuration into a hard error. The catalogue-fact shapes
+/// still veto — `route_prefix_contradicting_the_shape_is_an_error` proves that
+/// half is intact.
+/// What: pins the dotted remainder through the public resolver under each of
+/// the three prefixes, and asserts the prefix wins every time.
+/// Test: this test itself.
+#[test]
+fn route_explicit_prefix_survives_a_probable_bedrock_shape() {
+    let cases = [
+        ("openrouter/anthropic.claude-x", ProviderKind::OpenRouter),
+        ("anthropic/anthropic.claude-x", ProviderKind::Anthropic),
+        ("bedrock/anthropic.claude-x", ProviderKind::Bedrock),
+    ];
+    for (requested, expected) in cases {
+        let (kind, model) = routed(requested, ProviderKind::Bedrock);
+        assert_eq!(kind, expected, "the prefix on {requested:?} must win");
+        assert_eq!(
+            model, "anthropic.claude-x",
+            "only the routing prefix is stripped"
+        );
+    }
+
+    // With NO prefix the same id still reads as Bedrock — a config default does
+    // not outrank the shape, only an explicit per-call prefix does.
+    let (kind, _) = routed("anthropic.claude-x", ProviderKind::OpenRouter);
+    assert_eq!(kind, ProviderKind::Bedrock);
+}
+
+/// #6114 (code-critic MEDIUM 1): the remedy never names a `provider` value the
+/// config parser rejects.
+///
+/// Why: telling an operator to set `provider = "fireworks"` when
+/// [`ProviderKind::parse`] rejects it sends them in a circle.
+/// What: takes both shape errors, isolates the REMEDY half of each (the quoted
+/// model id in the diagnosis half is not a suggestion), and asserts every
+/// double-quoted token the remedy offers is either a parseable `provider` value
+/// or a routing prefix the resolver strips.
+/// Test: this test itself.
+#[test]
+fn shape_error_only_suggests_parseable_provider_values() {
+    /// The remedy starts after the refusal sentence; everything before it is
+    /// diagnosis, including the operator's own (unparseable) model id.
+    const REFUSAL: &str = "than the one requested. ";
+
+    let unbuildable = resolve_provider_and_model(
+        "accounts/fireworks/models/llama-v3p1-70b-instruct",
+        ProviderKind::OpenRouter,
+    )
+    .expect_err("a fireworks-native id must not run on OpenRouter")
+    .to_string();
+    let buildable = resolve_provider_and_model(
+        "bedrock/anthropic/claude-opus-4.8",
+        ProviderKind::OpenRouter,
+    )
+    .expect_err("an OpenRouter slug must not run on Bedrock")
+    .to_string();
+
+    for msg in [&unbuildable, &buildable] {
+        let (_, remedy) = msg
+            .split_once(REFUSAL)
+            .unwrap_or_else(|| panic!("the message must carry a remedy: {msg}"));
+        for token in remedy.split('"').skip(1).step_by(2) {
+            let is_prefix = ProviderKind::ALL
+                .iter()
+                .filter_map(|k| k.model_prefix())
+                .any(|p| token.starts_with(p));
+            assert!(
+                is_prefix || ProviderKind::parse(token).is_ok(),
+                "the remedy offers {token:?}, which is neither a parseable provider \
+                 value nor a routing prefix: {msg}"
+            );
+        }
+    }
+
+    // The unbuildable case must say so and name the set, rather than suggesting
+    // a `provider` value that parse() rejects (the #6114 MEDIUM-1 defect).
+    assert!(
+        unbuildable.contains("has no client for fireworks")
+            && unbuildable.contains(&ProviderKind::accepted_values()),
+        "the unbuildable remedy must name the accepted set: {unbuildable}"
+    );
+    assert!(
+        !unbuildable.contains("provider to \"fireworks\""),
+        "must never suggest a provider value parse() rejects: {unbuildable}"
+    );
+}
+
 /// #6114: a shape naming a provider the SM has no client for stops the call.
 ///
 /// Why: the SM builds Anthropic, Bedrock, and OpenRouter. A Fireworks-native id

--- a/crates/trusty-review/changelog.d/6114-fail-on-provider-model-mismatch.md
+++ b/crates/trusty-review/changelog.d/6114-fail-on-provider-model-mismatch.md
@@ -10,6 +10,9 @@ Fixed
   `accounts/fireworks/models/*` to Fireworks — and returns
   `LlmError::Validation` naming both the id and the provider when the two cannot
   be reconciled. A genuinely ambiguous bare id still uses the configured
-  default. `resolve_provider_and_model` is now fallible; `build_provider`
+  default, and an explicit routing prefix is overruled only by a shape that
+  belongs to exactly one provider's catalogue — never by the dotted
+  `vendor.model` guess, so `openrouter/anthropic.claude-x` keeps working.
+  `resolve_provider_and_model` is now fallible; `build_provider`
   propagates the error, and `trusty-review report` raises it in its preflight,
   before a sweep spends minutes on a render that would use the wrong model.

--- a/crates/trusty-review/changelog.d/6114-fail-on-provider-model-mismatch.md
+++ b/crates/trusty-review/changelog.d/6114-fail-on-provider-model-mismatch.md
@@ -1,0 +1,15 @@
+Fixed
+
+- A model id whose shape names one provider no longer runs on another. An
+  unprefixed OpenRouter slug (`anthropic/claude-opus-4.8`) used to take whatever
+  `provider` the path defaulted to; on the #6093 mitigation run that was
+  Bedrock, which rejected the id, and the render that completed used Bedrock's
+  `us.anthropic.claude-sonnet-4-6` default instead. `resolve_provider_and_model`
+  now routes an unambiguous shape to its own provider — slash-form slugs to
+  OpenRouter, `us.anthropic.*` / `anthropic.*` ids to Bedrock,
+  `accounts/fireworks/models/*` to Fireworks — and returns
+  `LlmError::Validation` naming both the id and the provider when the two cannot
+  be reconciled. A genuinely ambiguous bare id still uses the configured
+  default. `resolve_provider_and_model` is now fallible; `build_provider`
+  propagates the error, and `trusty-review report` raises it in its preflight,
+  before a sweep spends minutes on a render that would use the wrong model.

--- a/crates/trusty-review/changelog.d/6114-mcp-override-fails-loud.md
+++ b/crates/trusty-review/changelog.d/6114-mcp-override-fails-loud.md
@@ -1,0 +1,8 @@
+Changed
+
+- The MCP `review_pr` / `review_diff` tools fail a `reviewer_model` override
+  they cannot honour. #1357 made this case detectable — it ran the review on the
+  startup provider and reported a `reviewer_model_fallback` string — but that is
+  still a verdict from a model the caller did not ask for. The tool call now
+  returns an error naming the requested model, and the `reviewer_model_fallback`
+  envelope and payload field is removed, since nothing can set it any more.

--- a/crates/trusty-review/src/cli_report.rs
+++ b/crates/trusty-review/src/cli_report.rs
@@ -448,7 +448,9 @@ fn resolve_budget(args: &ReportArgs, manifest: &Manifest) -> Budget {
 /// Test: the rule itself, via [`credential_rule`].
 fn preflight_inference_credential(config: &ReviewConfig) -> Result<()> {
     let role = &config.role_models.reviewer;
-    let (provider, _) = resolve_provider_and_model(&role.model, &role.provider);
+    // #6114: an id whose shape contradicts the provider stops here, before the
+    // sweep spends minutes on a render that would run a different model.
+    let (provider, _) = resolve_provider_and_model(&role.model, &role.provider)?;
     credential_rule(provider, &config.openrouter_api_key)
 }
 

--- a/crates/trusty-review/src/config/config_tests.rs
+++ b/crates/trusty-review/src/config/config_tests.rs
@@ -530,6 +530,49 @@ fn provider_maps_to_common_provider_id() {
     assert_eq!(Provider::Fireworks.provider_id(), ProviderId::Fireworks);
 }
 
+/// #6114: the bridge back from the shared identity must round-trip.
+///
+/// Why: model-shape inference speaks `ProviderId`. A lossy inverse would let an
+/// inferred shape resolve to the wrong client, which is the substitution the
+/// ticket removes.
+/// What: asserts `from_provider_id(provider_id(p)) == Some(p)` for all three.
+/// Test: this is the test.
+#[test]
+fn provider_id_round_trips_both_ways() {
+    for provider in [Provider::OpenRouter, Provider::Bedrock, Provider::Fireworks] {
+        assert_eq!(
+            Provider::from_provider_id(provider.provider_id()),
+            Some(provider.clone()),
+            "{provider} must survive the round trip"
+        );
+    }
+}
+
+/// #6114: a `ProviderId` this crate builds no client for maps to nothing.
+///
+/// Why: `None` is what makes the resolver report an unrunnable shape instead of
+/// coercing it onto whichever provider happened to be configured.
+/// What: asserts the five non-buildable identities.
+/// Test: this is the test.
+#[test]
+fn unbuildable_provider_ids_map_to_none() {
+    use trusty_common::inference::ProviderId;
+    for id in [
+        ProviderId::Anthropic,
+        ProviderId::OpenAI,
+        ProviderId::Together,
+        ProviderId::AtlasCloud,
+        ProviderId::Local,
+    ] {
+        assert_eq!(
+            Provider::from_provider_id(id),
+            None,
+            "{} has no trusty-review client",
+            id.as_str()
+        );
+    }
+}
+
 /// Why: the reviewer is the role that does the judging, and the owner ruled it
 /// runs on the opus tier. On OpenRouter — the provider the trusty-audit path
 /// uses for all inference — that tier has a verified id, so the reviewer must

--- a/crates/trusty-review/src/config/mod.rs
+++ b/crates/trusty-review/src/config/mod.rs
@@ -101,6 +101,33 @@ impl Provider {
             Provider::Fireworks => ProviderId::Fireworks,
         }
     }
+
+    /// The narrow `Provider` for a shared [`ProviderId`], when one exists.
+    ///
+    /// Why: #6114 infers a provider from a model id's shape, and that inference
+    /// speaks `ProviderId` — the shared identity covers eight providers while
+    /// this crate builds clients for three. Mapping back in one place keeps a
+    /// call site from having to decide what an unbuildable provider means.
+    /// What: the inverse of [`Provider::provider_id`]; `None` for a
+    /// `ProviderId` this crate has no client for (Anthropic, OpenAI, Together,
+    /// AtlasCloud, Local).
+    /// Test: `provider_id_round_trips_both_ways`,
+    /// `unbuildable_provider_ids_map_to_none`.
+    ///
+    /// [`ProviderId`]: trusty_common::inference::ProviderId
+    pub fn from_provider_id(id: trusty_common::inference::ProviderId) -> Option<Self> {
+        use trusty_common::inference::ProviderId;
+        match id {
+            ProviderId::OpenRouter => Some(Provider::OpenRouter),
+            ProviderId::Bedrock => Some(Provider::Bedrock),
+            ProviderId::Fireworks => Some(Provider::Fireworks),
+            ProviderId::Anthropic
+            | ProviderId::OpenAI
+            | ProviderId::Together
+            | ProviderId::AtlasCloud
+            | ProviderId::Local => None,
+        }
+    }
 }
 
 impl std::fmt::Display for Provider {

--- a/crates/trusty-review/src/llm/bedrock/mod.rs
+++ b/crates/trusty-review/src/llm/bedrock/mod.rs
@@ -66,7 +66,14 @@ const DEFAULT_REGION: &str = "us-east-1";
 /// at runtime with a ValidationException.  Cross-region inference profiles
 /// (`us.anthropic.*`, `eu.anthropic.*`, etc.) route to the best-available
 /// region and are the recommended way to invoke Anthropic models on Bedrock.
-pub(crate) const INFERENCE_PROFILE_PREFIXES: &[&str] = &["us.", "eu.", "ap.", "jp.", "global."];
+///
+/// #6114 moved the list itself to `trusty-common`, where the shared model-shape
+/// inference reads the same prefixes to decide that an id is Bedrock's. Two
+/// copies would let this validator and that inference disagree about the same
+/// string; this alias keeps the crate-local spelling with one definition behind
+/// it.
+pub(crate) const INFERENCE_PROFILE_PREFIXES: &[&str] =
+    trusty_common::inference::BEDROCK_INFERENCE_PROFILE_PREFIXES;
 
 /// Retry attempts for transient errors (Transport, RateLimited, Upstream 5xx).
 const MAX_RETRIES: u32 = 3;

--- a/crates/trusty-review/src/llm/mod.rs
+++ b/crates/trusty-review/src/llm/mod.rs
@@ -310,14 +310,25 @@ pub fn resolve_provider_and_model(
 /// [`LlmError::Validation`] naming `requested`, the inferred provider, and
 /// `provider` otherwise. `requested` is the operator's original string (prefix
 /// included) so the message quotes what they actually typed.
+///
+/// Uses [`conclusive_shape_mismatch`], not the plain form: every caller here
+/// reaches this with a provider the operator pinned by prefix, or with a
+/// default that only sees ids no shape claimed. Rejecting a pinned provider on
+/// the dotted-vendor guess would break `openrouter/anthropic.claude-x`, a
+/// working configuration, on a vendor-name coincidence.
+///
+/// [`conclusive_shape_mismatch`]: trusty_common::inference::conclusive_shape_mismatch
 /// Test: `prefix_that_contradicts_the_id_shape_is_an_error`,
-/// `every_contradicting_pair_is_refused`.
+/// `every_contradicting_pair_is_refused`,
+/// `explicit_prefix_survives_a_probable_bedrock_shape`.
 fn reconcile(
     provider: Provider,
     bare: &str,
     requested: &str,
 ) -> Result<(Provider, String), LlmError> {
-    if let Some(inferred) = trusty_common::inference::shape_mismatch(provider.provider_id(), bare) {
+    if let Some(inferred) =
+        trusty_common::inference::conclusive_shape_mismatch(provider.provider_id(), bare)
+    {
         return Err(LlmError::Validation(format!(
             "model id {requested:?} names the {inferred} provider by its shape, but this call \
              would run on {provider}. Refusing to substitute a different model than the one \
@@ -631,6 +642,66 @@ mod tests {
             &Provider::OpenRouter,
         );
         assert_eq!(prov, Provider::Fireworks);
+    }
+
+    /// #6114 (code-critic MEDIUM 2): an explicit routing prefix survives a
+    /// merely-probable Bedrock shape.
+    ///
+    /// Why: `openrouter/anthropic.claude-x` states the provider for this call.
+    /// The dotted-vendor rule is a guess from a vendor-name list, and a guess
+    /// must not turn a working configuration into a hard error. The
+    /// catalogue-fact shapes still veto — the test below this one proves that
+    /// half is intact.
+    /// What: pins the dotted remainder through the public resolver under each
+    /// of the three prefixes, and asserts the prefix wins every time.
+    /// Test: this test itself.
+    #[test]
+    fn explicit_prefix_survives_a_probable_bedrock_shape() {
+        let cases = [
+            ("openrouter/anthropic.claude-x", Provider::OpenRouter),
+            ("fireworks/anthropic.claude-x", Provider::Fireworks),
+            ("bedrock/anthropic.claude-x", Provider::Bedrock),
+        ];
+        for (requested, expected) in cases {
+            let (prov, model) = resolved(requested, &Provider::Bedrock);
+            assert_eq!(prov, expected, "the prefix on {requested:?} must win");
+            assert_eq!(
+                model, "anthropic.claude-x",
+                "only the routing prefix is stripped"
+            );
+        }
+
+        // With NO prefix the same id still reads as Bedrock — a config default
+        // does not outrank the shape, only an explicit per-call prefix does.
+        let (prov, _) = resolved("anthropic.claude-x", &Provider::OpenRouter);
+        assert_eq!(prov, Provider::Bedrock);
+    }
+
+    /// #6114: every provider the shape module can infer is one this crate's
+    /// config parser accepts, so an error's remedy never names an unusable value.
+    ///
+    /// Why: the mismatch message tells the operator to set the provider to the
+    /// inferred one. Naming a value `Provider: FromStr` rejects would send them
+    /// in a circle (the trusty-mpm half of this was code-critic MEDIUM 1).
+    /// What: round-trips each inferable `ProviderId` through `Display` and
+    /// `FromStr`.
+    /// Test: this test itself.
+    #[test]
+    fn every_inferable_provider_is_parseable_here() {
+        use std::str::FromStr;
+        for id in [
+            trusty_common::inference::ProviderId::OpenRouter,
+            trusty_common::inference::ProviderId::Bedrock,
+            trusty_common::inference::ProviderId::Fireworks,
+        ] {
+            let provider = Provider::from_provider_id(id)
+                .unwrap_or_else(|| panic!("{} must map here", id.as_str()));
+            assert_eq!(
+                Provider::from_str(&provider.to_string()).as_ref(),
+                Ok(&provider),
+                "the name the error prints must parse back"
+            );
+        }
     }
 
     /// #6114: an id whose shape names no provider still uses the default —

--- a/crates/trusty-review/src/llm/mod.rs
+++ b/crates/trusty-review/src/llm/mod.rs
@@ -251,24 +251,82 @@ pub fn strip_provider_prefix(model: &str) -> &str {
 /// model id string and an explicit provider hint.
 ///
 /// Why: `--reviewer-model bedrock/us.anthropic.claude-sonnet-4-6` must route to
-/// Bedrock regardless of the default provider; a bare `us.anthropic.*` id should
-/// use the default provider; `openrouter/openai/gpt-5.4-mini` must route to
-/// OpenRouter; `fireworks/accounts/fireworks/models/*` must route to Fireworks.
-/// This function is the single source of truth for that logic.
-/// What: strips known prefixes and returns `(Provider, bare_model_id)`.
-/// Precedence: explicit prefix in model id > `default_provider` argument.
-/// Test: `provider_factory_prefix_routing`.
-pub fn resolve_provider_and_model(model: &str, default_provider: &Provider) -> (Provider, String) {
+/// Bedrock regardless of the default provider; `openrouter/openai/gpt-5.4-mini`
+/// must route to OpenRouter; `fireworks/accounts/fireworks/models/*` must route
+/// to Fireworks. This function is the single source of truth for that logic.
+///
+/// Until #6114 an id with NO prefix was handed to `default_provider` whatever it
+/// looked like, so an OpenRouter slug against a Bedrock-default path resolved to
+/// Bedrock, which then rejected the id — and the run that eventually completed
+/// used Bedrock's own default model rather than the one asked for. An
+/// unambiguous shape now names its own provider, and a pair that cannot be
+/// reconciled is an error instead of a substitution.
+///
+/// What: strips a known prefix, else infers the provider from the id's shape via
+/// [`trusty_common::inference::infer_provider_from_model_shape`], else falls
+/// back to `default_provider`. Whichever route is taken, the resulting pair is
+/// checked for a shape conflict before it is returned. Precedence: explicit
+/// prefix > unambiguous id shape > `default_provider`.
+///
+/// # Errors
+///
+/// [`LlmError::Validation`], naming both the requested id and the provider that
+/// would execute it, when the two disagree.
+///
+/// Test: `provider_factory_prefix_routing`,
+/// `bare_openrouter_slug_routes_to_openrouter_not_the_default`,
+/// `bare_bedrock_profile_id_routes_to_bedrock_not_the_default`,
+/// `prefix_that_contradicts_the_id_shape_is_an_error`,
+/// `ambiguous_bare_id_still_uses_the_default_provider`.
+pub fn resolve_provider_and_model(
+    model: &str,
+    default_provider: &Provider,
+) -> Result<(Provider, String), LlmError> {
     if let Some(bare) = model.strip_prefix(BEDROCK_MODEL_PREFIX) {
-        return (Provider::Bedrock, bare.to_string());
+        return reconcile(Provider::Bedrock, bare, model);
     }
     if let Some(bare) = model.strip_prefix(OPENROUTER_MODEL_PREFIX) {
-        return (Provider::OpenRouter, bare.to_string());
+        return reconcile(Provider::OpenRouter, bare, model);
     }
     if let Some(bare) = model.strip_prefix(FIREWORKS_MODEL_PREFIX) {
-        return (Provider::Fireworks, bare.to_string());
+        return reconcile(Provider::Fireworks, bare, model);
     }
-    (default_provider.clone(), model.to_string())
+    // #6114: no routing prefix — let an unambiguous id shape name its provider
+    // before the configured default gets it.
+    if let Some(inferred) = trusty_common::inference::infer_provider_from_model_shape(model)
+        .and_then(Provider::from_provider_id)
+    {
+        return Ok((inferred, model.to_string()));
+    }
+    reconcile(default_provider.clone(), model, model)
+}
+
+/// Refuse a `(provider, model)` pair whose id names a different provider.
+///
+/// Why: #6114 — the id and the provider that will execute it must agree, and
+/// when they do not the only safe outcome is a loud stop. Silently running the
+/// provider's default model is the failure this exists to prevent.
+/// What: `Ok((provider, bare))` when the shape agrees or is ambiguous;
+/// [`LlmError::Validation`] naming `requested`, the inferred provider, and
+/// `provider` otherwise. `requested` is the operator's original string (prefix
+/// included) so the message quotes what they actually typed.
+/// Test: `prefix_that_contradicts_the_id_shape_is_an_error`,
+/// `every_contradicting_pair_is_refused`.
+fn reconcile(
+    provider: Provider,
+    bare: &str,
+    requested: &str,
+) -> Result<(Provider, String), LlmError> {
+    if let Some(inferred) = trusty_common::inference::shape_mismatch(provider.provider_id(), bare) {
+        return Err(LlmError::Validation(format!(
+            "model id {requested:?} names the {inferred} provider by its shape, but this call \
+             would run on {provider}. Refusing to substitute a different model than the one \
+             requested. Either set the provider to {inferred}, or pin one explicitly with a \
+             routing prefix (\"bedrock/…\", \"openrouter/…\", \"fireworks/…\").",
+            inferred = inferred.as_str()
+        )));
+    }
+    Ok((provider, bare.to_string()))
 }
 
 /// Build an `Arc<dyn LlmProvider>` from the resolved role config.
@@ -282,8 +340,9 @@ pub fn resolve_provider_and_model(model: &str, default_provider: &Provider) -> (
 /// What: resolves the effective provider via `resolve_provider_and_model`,
 /// constructs the appropriate concrete type, and returns it as a trait object.
 /// Returns `LlmError::AccessDenied` if OpenRouter or Fireworks is selected but
-/// its API key is empty.  Returns `LlmError::Validation` if Bedrock is
-/// selected but the model id is missing an inference-profile prefix.
+/// its API key is empty.  Returns `LlmError::Validation` if the model id and the
+/// resolved provider disagree (#6114), or if Bedrock is selected but the model
+/// id is missing an inference-profile prefix.
 /// Test: `provider_factory_builds_bedrock`, `provider_factory_builds_openrouter`,
 /// `provider_factory_prefix_routing`.
 pub async fn build_provider(
@@ -291,7 +350,7 @@ pub async fn build_provider(
     default_provider: &Provider,
     config: &ReviewConfig,
 ) -> Result<Arc<dyn LlmProvider>, LlmError> {
-    let (provider, bare_model) = resolve_provider_and_model(model, default_provider);
+    let (provider, bare_model) = resolve_provider_and_model(model, default_provider)?;
     match provider {
         Provider::Bedrock => {
             let p = BedrockProvider::new(bare_model, None).await?;
@@ -450,10 +509,16 @@ mod tests {
 
     // ── Provider factory routing tests ────────────────────────────────────
 
+    /// Resolve, treating an error as a test failure.
+    fn resolved(model: &str, default_provider: &Provider) -> (Provider, String) {
+        resolve_provider_and_model(model, default_provider)
+            .unwrap_or_else(|e| panic!("{model:?} must resolve: {e}"))
+    }
+
     #[test]
     fn provider_factory_prefix_routing() {
         // bedrock/ prefix forces Bedrock.
-        let (prov, model) = resolve_provider_and_model(
+        let (prov, model) = resolved(
             "bedrock/us.anthropic.claude-sonnet-4-6",
             &Provider::OpenRouter,
         );
@@ -461,28 +526,21 @@ mod tests {
         assert_eq!(model, "us.anthropic.claude-sonnet-4-6");
 
         // openrouter/ prefix forces OpenRouter.
-        let (prov, model) = resolve_provider_and_model(
+        let (prov, model) = resolved(
             "openrouter/openai/gpt-5.4-mini-20260317",
             &Provider::Bedrock,
         );
         assert_eq!(prov, Provider::OpenRouter);
         assert_eq!(model, "openai/gpt-5.4-mini-20260317");
 
-        // Bare id uses the default provider.
-        let (prov, model) =
-            resolve_provider_and_model("us.anthropic.claude-sonnet-4-6", &Provider::Bedrock);
+        // Bare id whose shape matches the default keeps the default.
+        let (prov, model) = resolved("us.anthropic.claude-sonnet-4-6", &Provider::Bedrock);
         assert_eq!(prov, Provider::Bedrock);
         assert_eq!(model, "us.anthropic.claude-sonnet-4-6");
 
-        // Bare OpenRouter id with Bedrock default stays on Bedrock.
-        let (prov, model) =
-            resolve_provider_and_model("openai/gpt-5.4-mini-20260317", &Provider::Bedrock);
-        assert_eq!(prov, Provider::Bedrock);
-        assert_eq!(model, "openai/gpt-5.4-mini-20260317");
-
         // fireworks/ prefix forces Fireworks and strips only the routing
         // prefix (the provider-native accounts/fireworks/models/* id remains).
-        let (prov, model) = resolve_provider_and_model(
+        let (prov, model) = resolved(
             "fireworks/accounts/fireworks/models/llama-v3p1-70b-instruct",
             &Provider::Bedrock,
         );
@@ -490,10 +548,106 @@ mod tests {
         assert_eq!(model, "accounts/fireworks/models/llama-v3p1-70b-instruct");
     }
 
+    /// #6114 regression: the id from the #6093 mitigation run.
+    ///
+    /// Why: `anthropic/claude-opus-4.8` carries no routing prefix, so it used to
+    /// resolve to whatever the path's default provider was — Bedrock, which
+    /// rejected the id, after which the run that completed used Bedrock's own
+    /// default model. The slug shape names OpenRouter; nothing else does.
+    /// What: asserts the pair resolves to OpenRouter with the id unchanged.
+    /// Test: this test itself.
+    #[test]
+    fn bare_openrouter_slug_routes_to_openrouter_not_the_default() {
+        let (prov, model) = resolved("anthropic/claude-opus-4.8", &Provider::Bedrock);
+        assert_eq!(
+            prov,
+            Provider::OpenRouter,
+            "an unprefixed OpenRouter slug must not inherit the Bedrock default (#6114)"
+        );
+        assert_eq!(model, "anthropic/claude-opus-4.8");
+
+        let (prov, _) = resolved("openai/gpt-5.4-mini-20260317", &Provider::Bedrock);
+        assert_eq!(prov, Provider::OpenRouter);
+    }
+
+    /// #6114: the mirror case — a Bedrock inference profile under an OpenRouter
+    /// default resolves to Bedrock rather than being sent to OpenRouter.
+    #[test]
+    fn bare_bedrock_profile_id_routes_to_bedrock_not_the_default() {
+        let (prov, model) = resolved("us.anthropic.claude-sonnet-4-6", &Provider::OpenRouter);
+        assert_eq!(prov, Provider::Bedrock);
+        assert_eq!(model, "us.anthropic.claude-sonnet-4-6");
+
+        // The un-profiled dotted spelling is Bedrock's too. It fails the
+        // inference-profile check later, which is the right error to get.
+        let (prov, _) = resolved("anthropic.claude-sonnet-4-6", &Provider::OpenRouter);
+        assert_eq!(prov, Provider::Bedrock);
+    }
+
+    /// #6114: an explicit prefix that contradicts the id's shape is an error
+    /// naming both, never a silent run on the prefixed provider's default.
+    #[test]
+    fn prefix_that_contradicts_the_id_shape_is_an_error() {
+        let err =
+            resolve_provider_and_model("bedrock/anthropic/claude-opus-4.8", &Provider::OpenRouter)
+                .expect_err("a bedrock/ prefix on an OpenRouter slug must not resolve");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("anthropic/claude-opus-4.8"),
+            "the error must name the requested id: {msg}"
+        );
+        assert!(
+            msg.contains("bedrock") && msg.contains("openrouter"),
+            "the error must name both providers: {msg}"
+        );
+    }
+
+    /// #6114: the refusal is symmetric across all three backends, so no pairing
+    /// is left with a silent substitution.
+    #[test]
+    fn every_contradicting_pair_is_refused() {
+        // A Bedrock profile id pinned to Fireworks by prefix cannot run.
+        let err = resolve_provider_and_model(
+            "fireworks/us.anthropic.claude-sonnet-4-6",
+            &Provider::OpenRouter,
+        )
+        .expect_err("a bedrock profile id must not be sent to Fireworks");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("us.anthropic.claude-sonnet-4-6") && msg.contains("fireworks"),
+            "the error must name the id and the provider: {msg}"
+        );
+
+        // A fireworks-native id pinned to OpenRouter by prefix cannot run.
+        resolve_provider_and_model(
+            "openrouter/accounts/fireworks/models/llama-v3p1-70b-instruct",
+            &Provider::Bedrock,
+        )
+        .expect_err("a fireworks-native id must not be sent to OpenRouter");
+
+        // Unprefixed, that same id resolves to Fireworks on its shape alone.
+        let (prov, _) = resolved(
+            "accounts/fireworks/models/llama-v3p1-70b-instruct",
+            &Provider::OpenRouter,
+        );
+        assert_eq!(prov, Provider::Fireworks);
+    }
+
+    /// #6114: an id whose shape names no provider still uses the default —
+    /// inference narrows the fall-through, it does not remove it.
+    #[test]
+    fn ambiguous_bare_id_still_uses_the_default_provider() {
+        for default in [Provider::Bedrock, Provider::OpenRouter, Provider::Fireworks] {
+            let (prov, model) = resolved("claude-opus-4-5-20260101", &default);
+            assert_eq!(prov, default, "an ambiguous id must keep the default");
+            assert_eq!(model, "claude-opus-4-5-20260101");
+        }
+    }
+
     #[test]
     fn provider_factory_empty_bedrock_prefix_uses_bare_empty_string() {
         // Edge case: "bedrock/" with nothing after the slash.
-        let (prov, model) = resolve_provider_and_model("bedrock/", &Provider::OpenRouter);
+        let (prov, model) = resolved("bedrock/", &Provider::OpenRouter);
         assert_eq!(prov, Provider::Bedrock);
         assert_eq!(model, "");
     }
@@ -520,7 +674,7 @@ mod tests {
             ),
         ];
         for (candidate, (exp_prov, exp_model)) in candidates.iter().zip(expected.iter()) {
-            let (prov, model) = resolve_provider_and_model(candidate, &Provider::Bedrock);
+            let (prov, model) = resolved(candidate, &Provider::Bedrock);
             assert_eq!(prov, *exp_prov, "provider mismatch for {candidate}");
             assert_eq!(model, *exp_model, "model mismatch for {candidate}");
         }

--- a/crates/trusty-review/src/mcp/tools.rs
+++ b/crates/trusty-review/src/mcp/tools.rs
@@ -212,7 +212,7 @@ async fn call_review_pr(args: &Value, state: &AppState) -> Result<Value, ToolErr
         token,
     };
 
-    let (deps, reviewer_model_fallback) = deps_from_state(state, &reviewer_model).await;
+    let deps = deps_from_state(state, &reviewer_model).await?;
     let input = ReviewInput {
         diff_source,
         reviewer_model: reviewer_model.clone(),
@@ -231,7 +231,7 @@ async fn call_review_pr(args: &Value, state: &AppState) -> Result<Value, ToolErr
 
     info!(owner, repo, pr, reviewer_model, "mcp: review_pr");
     let result = run_review(&state.config, input, deps).await;
-    Ok(wrap_result(&result, reviewer_model_fallback.as_deref()))
+    Ok(wrap_result(&result))
 }
 
 // ─── review_diff ─────────────────────────────────────────────────────────────
@@ -269,7 +269,7 @@ async fn call_review_diff(args: &Value, state: &AppState) -> Result<Value, ToolE
     let path = tmp.path().to_path_buf();
     let diff_source = DiffSource::LocalFile { path };
 
-    let (deps, reviewer_model_fallback) = deps_from_state(state, &reviewer_model).await;
+    let deps = deps_from_state(state, &reviewer_model).await?;
     let input = ReviewInput {
         diff_source,
         reviewer_model: reviewer_model.clone(),
@@ -286,7 +286,7 @@ async fn call_review_diff(args: &Value, state: &AppState) -> Result<Value, ToolE
     info!(bytes = diff.len(), reviewer_model, "mcp: review_diff");
     let result = run_review(&state.config, input, deps).await;
     // `tmp` is dropped here — temp file cleaned up automatically.
-    Ok(wrap_result(&result, reviewer_model_fallback.as_deref()))
+    Ok(wrap_result(&result))
 }
 
 // ─── review_health ────────────────────────────────────────────────────────────
@@ -399,60 +399,66 @@ fn mcp_run_mode(config: &ReviewConfig) -> RunMode {
 /// the wrong API, wrong credentials, wrong cost.  Resolving the override's
 /// provider prefix and building a matching provider when it differs makes the
 /// per-call override actually route to the requested backend.
+///
+/// #1357 item 2 softened the build-failure path: it logged a `warn!`, ran the
+/// review on the startup provider anyway, and reported a `reviewer_model_fallback`
+/// string. That is still a review of the caller's diff by a model the caller did
+/// not ask for, and #6114 rules it out — a request that names a model either runs
+/// that model or fails. The fallback plumbing goes with it.
+///
 /// What: resolves the override's provider via `resolve_provider_and_model`; when
 /// it matches the startup provider, cheaply clones `state.llm` (no allocation).
-/// When it differs, builds a fresh provider via `build_provider` (async); on a
-/// build error it logs a `warn!` and falls back to the startup `state.llm` so a
-/// malformed override degrades gracefully rather than failing the whole review.
+/// When it differs, builds a fresh provider via `build_provider` (async). A
+/// resolution or build failure is returned as a `ToolError` and no review runs.
 /// The verifier / search / analyze / dedup handles are always cloned from state.
 ///
-/// Returns the built `ReviewDeps` alongside an OPTIONAL `reviewer_model_fallback`
-/// reason (closes #1357 item 2): `Some(reason)` when an override provider failed to
-/// build and we silently fell back to the startup provider, so the caller can
-/// surface it in the tool response metadata instead of getting the wrong backend
-/// with no signal.  `None` on the happy path (override matched startup, or built
-/// successfully).
+/// # Errors
+///
+/// [`ToolError::InvalidParams`] when `reviewer_model` cannot be reconciled with
+/// the provider that would execute it, or when the matching provider cannot be
+/// built (missing credential, invalid model id).
+///
 /// Test: `deps_from_state_openrouter_override_switches_provider`,
 /// `deps_from_state_no_override_reuses_startup_provider`,
-/// `deps_from_state_build_failure_reports_fallback` (in `tools_dispatch_tests.rs`).
-async fn deps_from_state(state: &AppState, reviewer_model: &str) -> (ReviewDeps, Option<String>) {
+/// `deps_from_state_build_failure_is_an_error`,
+/// `deps_from_state_rejects_a_model_the_startup_provider_cannot_run`
+/// (in `tools_dispatch_tests.rs`).
+async fn deps_from_state(state: &AppState, reviewer_model: &str) -> Result<ReviewDeps, ToolError> {
     let startup_provider = &state.config.role_models.reviewer.provider;
     let (override_provider, _bare) =
-        crate::llm::resolve_provider_and_model(reviewer_model, startup_provider);
+        crate::llm::resolve_provider_and_model(reviewer_model, startup_provider).map_err(|e| {
+            ToolError::InvalidParams(format!(
+                "reviewer_model {reviewer_model:?} cannot be resolved: {e}"
+            ))
+        })?;
 
-    let mut fallback_reason: Option<String> = None;
     let llm = if &override_provider == startup_provider {
         // Same backend as startup — reuse the already-built provider (no alloc).
         Arc::clone(&state.llm)
     } else {
         // Different backend — build a provider that matches the override prefix.
-        match crate::llm::build_provider(reviewer_model, startup_provider, &state.config).await {
-            Ok(p) => p,
-            Err(e) => {
-                let reason = format!(
-                    "failed to build provider for reviewer_model override '{reviewer_model}' \
-                     ({e}); fell back to the startup '{startup_provider}' provider"
-                );
+        crate::llm::build_provider(reviewer_model, startup_provider, &state.config)
+            .await
+            .map_err(|e| {
                 tracing::warn!(
                     reviewer_model,
                     error = %e,
-                    "mcp: failed to build provider for reviewer_model override — \
-                     falling back to startup provider"
+                    "mcp: failed to build provider for reviewer_model override"
                 );
-                fallback_reason = Some(reason);
-                Arc::clone(&state.llm)
-            }
-        }
+                ToolError::InvalidParams(format!(
+                    "failed to build the {override_provider} provider for reviewer_model \
+                     {reviewer_model:?}: {e}"
+                ))
+            })?
     };
 
-    let deps = ReviewDeps {
+    Ok(ReviewDeps {
         llm,
         verifier: state.verifier.clone(),
         search: Arc::clone(&state.search),
         analyze: state.analyze.clone(),
         dedup: state.dedup.clone(),
-    };
-    (deps, fallback_reason)
+    })
 }
 
 /// Extract a required string field from the tool arguments.
@@ -496,16 +502,16 @@ const MCP_STATUS_INFRA_UNAVAILABLE: &str = "infrastructure_unavailable";
 /// `wrap_result_degraded_stays_isError_false` (tools_tests.rs).
 const MCP_STATUS_DEGRADED_CONTEXT: &str = "degraded_context";
 
-/// Wrap a `ReviewResult` in the MCP content envelope, optionally surfacing a
-/// reviewer-model override-fallback reason (closes #1357 item 2).
+/// Wrap a `ReviewResult` in the MCP content envelope.
 ///
 /// Why: MCP `tools/call` responses must carry results inside a `content[]` array
-/// (per MCP spec) so the LLM can render them correctly.  When a `reviewer_model`
-/// override failed to build and the pipeline silently fell back to the startup
-/// provider, the caller would otherwise get the WRONG backend with no signal.
-/// Surfacing the fallback in the response metadata (and inside the serialised
-/// payload the LLM reads) makes it DETECTABLE without breaking the non-error
-/// contract — the review still ran, just on a different model than requested.
+/// (per MCP spec) so the LLM can render them correctly.
+///
+/// #1357 item 2 added a `reviewer_model_fallback` field here, for the case where
+/// an override provider failed to build and the review ran on the startup model
+/// anyway. #6114 removed that case — `deps_from_state` now returns an error
+/// instead of running a model the caller did not ask for — so the field is gone
+/// with it rather than left as a value the envelope can never carry.
 ///
 /// Search-unreachable semantics fix: when `result.infra_unavailable` is set (a
 /// REQUIRED context dependency was genuinely unreachable — see
@@ -517,24 +523,14 @@ const MCP_STATUS_DEGRADED_CONTEXT: &str = "degraded_context";
 /// `Skipped` producer, or the existing dedup/empty-diff short-circuits which
 /// never set `infra_unavailable`) and a normal/degraded verdict both keep
 /// `isError: false` — only a genuine infra outage gets the loud treatment.
-/// What: serialises `ReviewResult` to pretty JSON; when `fallback` is
-/// `Some(reason)` it injects a `reviewer_model_fallback` string into BOTH the
-/// serialised JSON object (so the LLM reading `content[0].text` sees it) and as a
-/// top-level envelope field (so programmatic callers can detect it without
-/// re-parsing the text).  `None` leaves that field unset.
-/// Test: `wrap_result_surfaces_reviewer_model_fallback`,
-/// `wrap_result_no_fallback_omits_field`,
+/// What: serialises `ReviewResult` to pretty JSON inside a text content block,
+/// then stamps the `mcp_status` sentinel for an infra outage or a degraded
+/// verdict.
+/// Test: `wrap_result_never_carries_a_reviewer_model_fallback`,
 /// `wrap_result_infra_unavailable_sets_error_and_sentinel`,
 /// `wrap_result_degraded_stays_isError_false` (in `tools_tests.rs`).
-fn wrap_result(result: &ReviewResult, fallback: Option<&str>) -> Value {
-    // Serialise to a JSON Value first so we can splice in the fallback marker.
-    let mut payload = serde_json::to_value(result).unwrap_or(Value::Null);
-    if let (Some(reason), Some(obj)) = (fallback, payload.as_object_mut()) {
-        obj.insert(
-            "reviewer_model_fallback".to_string(),
-            Value::String(reason.to_string()),
-        );
-    }
+fn wrap_result(result: &ReviewResult) -> Value {
+    let payload = serde_json::to_value(result).unwrap_or(Value::Null);
     let text = serde_json::to_string_pretty(&payload)
         .unwrap_or_else(|_| serde_json::to_string(&payload).unwrap_or_default());
 
@@ -565,12 +561,6 @@ fn wrap_result(result: &ReviewResult, fallback: Option<&str>) -> Value {
                 Value::String(reason.to_string()),
             );
         }
-    }
-    if let (Some(reason), Some(obj)) = (fallback, envelope.as_object_mut()) {
-        obj.insert(
-            "reviewer_model_fallback".to_string(),
-            Value::String(reason.to_string()),
-        );
     }
     envelope
 }

--- a/crates/trusty-review/src/mcp/tools_dispatch_tests.rs
+++ b/crates/trusty-review/src/mcp/tools_dispatch_tests.rs
@@ -473,16 +473,13 @@ async fn deps_from_state_openrouter_override_switches_provider() {
     // state must build a fresh OpenRouter provider, NOT silently reuse the startup
     // (Bedrock) provider.
     let state = bedrock_startup_state();
-    let (deps, fallback) =
-        super::deps_from_state(&state, "openrouter/openai/gpt-5.4-mini-20260317").await;
+    let deps = super::deps_from_state(&state, "openrouter/openai/gpt-5.4-mini-20260317")
+        .await
+        .expect("a valid override must resolve and build");
     assert_eq!(
         deps.llm.name(),
         "openrouter",
         "an openrouter/ override must route to the OpenRouter backend (#1233)"
-    );
-    assert!(
-        fallback.is_none(),
-        "a successful override build must NOT report a fallback (#1357)"
     );
 }
 
@@ -491,66 +488,99 @@ async fn deps_from_state_fireworks_override_switches_provider() {
     // A `fireworks/...` reviewer_model override against a Bedrock-startup state
     // must build a fresh Fireworks provider (same #1233 contract as OpenRouter).
     let state = bedrock_startup_state();
-    let (deps, fallback) = super::deps_from_state(
+    let deps = super::deps_from_state(
         &state,
         "fireworks/accounts/fireworks/models/llama-v3p1-70b-instruct",
     )
-    .await;
+    .await
+    .expect("a valid override must resolve and build");
     assert_eq!(
         deps.llm.name(),
         "fireworks",
         "a fireworks/ override must route to the Fireworks backend"
     );
-    assert!(
-        fallback.is_none(),
-        "a successful override build must NOT report a fallback (#1357)"
-    );
 }
 
 #[tokio::test]
 async fn deps_from_state_no_override_reuses_startup_provider() {
-    // Control: a bare model id (no routing prefix) keeps the startup provider —
+    // Control: a bare id whose shape matches the startup provider keeps it —
     // the stub `ApproveLlm`, whose name() is NOT "openrouter".
     let state = bedrock_startup_state();
-    let (deps, fallback) = super::deps_from_state(&state, "us.anthropic.claude-sonnet-4-6").await;
+    let deps = super::deps_from_state(&state, "us.anthropic.claude-sonnet-4-6")
+        .await
+        .expect("a bedrock id on a bedrock-startup state must resolve");
     assert_ne!(
         deps.llm.name(),
         "openrouter",
-        "a bare model id must reuse the startup (Bedrock) provider, not switch"
-    );
-    assert!(
-        fallback.is_none(),
-        "the no-override path must NOT report a fallback (#1357)"
+        "a bare Bedrock id must reuse the startup (Bedrock) provider, not switch"
     );
 }
 
-/// #1357 item 2: when an override provider fails to build, `deps_from_state` must
-/// report a `Some(reason)` fallback so the MCP caller can detect the wrong-backend
-/// silent fallback.
+/// #6114: an override whose provider cannot be built fails the tool call.
 ///
-/// Why: previously the failed-override path only `warn!`d and silently reused the
-/// startup provider; an MCP caller had no way to know it got the wrong backend.
+/// Why: until #6114 this path `warn!`d, reused the startup provider, and reported
+/// a `reviewer_model_fallback` string — a review of the caller's diff by a model
+/// they did not ask for. Detectability was never the fix; not doing it is.
 /// What: an `openrouter/...` override against a Bedrock-startup state whose config
-/// has an EMPTY OpenRouter key makes `build_provider` fail the empty-key guard;
-/// the result must fall back to the startup provider AND carry a fallback reason.
+/// has an EMPTY OpenRouter key makes `build_provider` fail its empty-key guard.
+/// The result must be an error naming the requested model.
 /// Test: this test itself.
 #[tokio::test]
-async fn deps_from_state_build_failure_reports_fallback() {
+async fn deps_from_state_build_failure_is_an_error() {
     let mut state = bedrock_startup_state();
     // Empty the key so OpenRouterProvider::new() fails its empty-key guard.
     state.config.openrouter_api_key = String::new();
 
-    let (deps, fallback) =
-        super::deps_from_state(&state, "openrouter/openai/gpt-5.4-mini-20260317").await;
-    // Fell back to the startup (Bedrock) provider, not the requested OpenRouter one.
-    assert_ne!(
+    // `ReviewDeps` is not `Debug` (it holds trait objects), so `expect_err` is
+    // unavailable here — match instead.
+    let msg = match super::deps_from_state(&state, "openrouter/openai/gpt-5.4-mini-20260317").await
+    {
+        Ok(_) => panic!("a failed override build must not fall back to the startup model"),
+        Err(e) => format!("{e:?}"),
+    };
+    assert!(
+        msg.contains("openai/gpt-5.4-mini-20260317"),
+        "the error must name the requested model: {msg}"
+    );
+}
+
+/// #6114: an unprefixed OpenRouter slug against a Bedrock-startup state must not
+/// be reviewed by Bedrock's model — the exact #6093 pairing, at the MCP surface.
+///
+/// Why: `anthropic/claude-opus-4.8` carries no routing prefix, so it used to
+/// resolve to the startup (Bedrock) provider and be reviewed by whatever model
+/// that provider was holding.
+/// What: asserts the override routes to OpenRouter on its shape alone.
+/// Test: this test itself.
+#[tokio::test]
+async fn deps_from_state_routes_a_bare_openrouter_slug_to_openrouter() {
+    let state = bedrock_startup_state();
+    let deps = super::deps_from_state(&state, "anthropic/claude-opus-4.8")
+        .await
+        .expect("an OpenRouter slug must resolve to OpenRouter, whose key is set here");
+    assert_eq!(
         deps.llm.name(),
         "openrouter",
-        "a failed override build must fall back to the startup provider"
+        "an unprefixed OpenRouter slug must not be reviewed by the Bedrock startup provider"
     );
-    let reason = fallback.expect("a failed override build must report a fallback reason (#1357)");
+}
+
+/// #6114: a model the resolved provider cannot run stops before any review.
+///
+/// Why: the error must name both halves so an operator sees what disagreed,
+/// rather than reading a verdict produced by a model they never selected.
+/// What: pins a Bedrock inference-profile id to Fireworks by prefix.
+/// Test: this test itself.
+#[tokio::test]
+async fn deps_from_state_rejects_a_model_the_startup_provider_cannot_run() {
+    let state = bedrock_startup_state();
+    let msg = match super::deps_from_state(&state, "fireworks/us.anthropic.claude-sonnet-4-6").await
+    {
+        Ok(_) => panic!("a bedrock profile id must not be sent to Fireworks"),
+        Err(e) => format!("{e:?}"),
+    };
     assert!(
-        reason.contains("reviewer_model") && reason.contains("fell back"),
-        "fallback reason must be actionable: {reason}"
+        msg.contains("us.anthropic.claude-sonnet-4-6") && msg.contains("fireworks"),
+        "the error must name the id and the provider: {msg}"
     );
 }

--- a/crates/trusty-review/src/mcp/tools_tests.rs
+++ b/crates/trusty-review/src/mcp/tools_tests.rs
@@ -367,64 +367,33 @@ async fn review_health_degraded_but_serving_search_stays_ok() {
     );
 }
 
-// ── reviewer_model override fallback surfacing (#1357 item 2) ───────────────────
+// ── reviewer_model override: no silent substitution (#6114) ────────────────────
 
-/// #1357: when an override provider build failed, `wrap_result` surfaces the
-/// fallback reason in BOTH the envelope and the serialised payload text.
+/// #6114: no envelope can announce that the review ran on a substitute model,
+/// because no review runs on one.
 ///
-/// Why: an MCP caller silently getting the wrong backend is the hazard #1357
-/// targets; the fallback must be DETECTABLE both programmatically (envelope) and
-/// by the LLM reading `content[0].text`.
-/// What: wraps a `ReviewResult` with `Some(reason)`; asserts the envelope-level
-/// `reviewer_model_fallback` field is present AND that the same key appears in the
-/// parsed payload JSON.
-/// Test: this test itself.
+/// Why: #1357 item 2 made the silent-wrong-backend case DETECTABLE by adding a
+/// `reviewer_model_fallback` field. #6114 removes the case instead —
+/// `deps_from_state` errors rather than reviewing a diff with a model the caller
+/// did not ask for — so the field must be gone from both the envelope and the
+/// payload the LLM reads. A field that can never be set is a promise the surface
+/// cannot keep.
+/// What: wraps a plain `ReviewResult` and asserts the key is absent from both.
+/// Test: this test itself; the refusal it depends on is
+/// `deps_from_state_build_failure_is_an_error` (tools_dispatch_tests.rs).
 #[test]
-fn wrap_result_surfaces_reviewer_model_fallback() {
-    let result = ReviewResult::new("acme", "backend", 7, "Add X", "https://example/pr/7");
-    let reason = "failed to build provider for reviewer_model override 'openrouter/x' \
-                  (key empty); fell back to the startup 'bedrock' provider";
-    let envelope = wrap_result(&result, Some(reason));
-
-    // Envelope-level metadata field for programmatic callers.
-    assert_eq!(
-        envelope["reviewer_model_fallback"], reason,
-        "envelope must carry reviewer_model_fallback for detection"
-    );
-    assert_eq!(
-        envelope["isError"], false,
-        "fallback is non-breaking, not an error"
-    );
-
-    // The same marker is spliced into the payload the LLM reads.
-    let text = envelope["content"][0]["text"].as_str().expect("text field");
-    let payload: Value = serde_json::from_str(text).expect("valid JSON payload");
-    assert_eq!(
-        payload["reviewer_model_fallback"], reason,
-        "payload JSON must also carry the fallback so the LLM sees it"
-    );
-}
-
-/// #1357: the happy path (no fallback) leaves the envelope clean — no extra field.
-///
-/// Why: only the failure path should advertise a fallback; a clean run must not
-/// emit a spurious marker that callers would misread as a degraded backend.
-/// What: wraps a `ReviewResult` with `None`; asserts the `reviewer_model_fallback`
-/// key is absent from both envelope and payload.
-/// Test: this test itself.
-#[test]
-fn wrap_result_no_fallback_omits_field() {
+fn wrap_result_never_carries_a_reviewer_model_fallback() {
     let result = ReviewResult::new("acme", "backend", 8, "Add Y", "https://example/pr/8");
-    let envelope = wrap_result(&result, None);
+    let envelope = wrap_result(&result);
     assert!(
         envelope.get("reviewer_model_fallback").is_none(),
-        "no fallback → envelope must NOT carry the marker"
+        "the envelope must not carry a substitution marker (#6114)"
     );
     let text = envelope["content"][0]["text"].as_str().expect("text field");
     let payload: Value = serde_json::from_str(text).expect("valid JSON payload");
     assert!(
         payload.get("reviewer_model_fallback").is_none(),
-        "no fallback → payload must NOT carry the marker"
+        "the payload must not carry a substitution marker (#6114)"
     );
 }
 
@@ -451,7 +420,7 @@ fn wrap_result_infra_unavailable_sets_error_and_sentinel() {
     result.verdict = Verdict::Unknown;
     result.error = Some("trusty-search unreachable at http://x — start it".to_string());
 
-    let envelope = wrap_result(&result, None);
+    let envelope = wrap_result(&result);
 
     assert_eq!(
         envelope["isError"], true,
@@ -481,7 +450,7 @@ fn wrap_result_policy_skip_without_infra_flag_stays_is_error_false() {
     // infra_unavailable intentionally left false (default) — simulates a
     // hypothetical future policy-driven skip.
 
-    let envelope = wrap_result(&result, None);
+    let envelope = wrap_result(&result);
 
     assert_eq!(
         envelope["isError"], false,
@@ -509,7 +478,7 @@ fn wrap_result_degraded_stays_is_error_false() {
     result.status = ReviewStatus::Degraded;
     result.verdict = Verdict::Approve;
 
-    let envelope = wrap_result(&result, None);
+    let envelope = wrap_result(&result);
 
     assert_eq!(
         envelope["isError"], false,
@@ -543,7 +512,7 @@ fn wrap_result_degraded_sets_sentinel_and_reason() {
             .to_string(),
     );
 
-    let envelope = wrap_result(&result, None);
+    let envelope = wrap_result(&result);
 
     assert_eq!(
         envelope["mcp_status"], "degraded_context",
@@ -561,7 +530,7 @@ fn wrap_result_degraded_sets_sentinel_and_reason() {
     // sentinel is a real signal and not noise attached to every response.
     let mut complete = ReviewResult::new("acme", "backend", 11, "Add Q", "https://example/pr/11");
     complete.verdict = Verdict::Approve;
-    let complete_envelope = wrap_result(&complete, None);
+    let complete_envelope = wrap_result(&complete);
     assert!(
         complete_envelope.get("mcp_status").is_none(),
         "a complete review must carry no status sentinel"


### PR DESCRIPTION
Refs #6114.

## What was wrong

A model id with no routing prefix took whatever provider the path defaulted to.
`resolve_provider_and_model` (crates/trusty-review/src/llm/mod.rs) matched only
`bedrock/`, `openrouter/`, `fireworks/`; anything else fell through unchanged.
On the #6093 mitigation run that put `anthropic/claude-opus-4.8` — an OpenRouter
slug — on a Bedrock-default path. Bedrock rejected the id at construction, and
the render that completed used Bedrock's `us.anthropic.claude-sonnet-4-6`
default instead of the model requested.

`crates/trusty-mpm/src/core/sm/providers/resolve.rs` carried the same shape,
with one extra way to go wrong: under `provider = "auto"` the credential
precedence chain picked the provider, so a slug could be handed to whichever
backend happened to have a key.

## What changed

**Consolidated, per the common-entry-point rule.** New
`trusty_common::inference::shape` (feature `inference-client`, which both crates
already enable) is the single place that reads a model id's spelling back to a
`ProviderId`:

- `accounts/fireworks/models/…` → Fireworks
- any other `vendor/model` slash-form → OpenRouter
- `us.` / `eu.` / `ap.` / `jp.` / `global.` profile ids, and dotted
  `vendor.model` ids for known Bedrock vendors → Bedrock
- everything else → `None`, and the configured default still decides

`BEDROCK_INFERENCE_PROFILE_PREFIXES` moved there too, so trusty-review's Bedrock
model-id validator and this inference cannot drift apart about the same string.

Both resolvers now: strip their own routing prefixes, ask the shared module
about what remains, and refuse a pair that disagrees with
`LlmError::Validation` / `SmLlmError::Validation` naming the id AND the
provider. Precedence is explicit prefix > unambiguous shape > default.

The prefix tables genuinely differ and stay per-crate: `anthropic/` is a routing
prefix in trusty-mpm (it pins the first-party API) and an OpenRouter slug in
trusty-review. That is why the shared module owns the shape rule and not the
whole resolver — its doc says out loud that it must be called only on an id
whose routing prefix is already stripped.

**No fallback-to-default-model on rejection.** The MCP `review_pr` /
`review_diff` tools used to `warn!`, run the review on the startup provider, and
report a `reviewer_model_fallback` string (#1357 item 2). Detectability was
never the fix — the caller still got a verdict from a model they did not ask
for. `deps_from_state` returns `Result<ReviewDeps, ToolError>`; the field is
removed from the envelope and payload because nothing can set it any more.

`trusty-review report` raises the mismatch in `preflight_inference_credential`,
before a `tga audit` sweep spends minutes on a render that would use the wrong
model.

## Regression tests that failed pre-fix

The proof for (a) is in the diff itself: `provider_factory_prefix_routing` used
to assert `("openai/gpt-5.4-mini-20260317", default = Bedrock) → Bedrock`. That
assertion is deleted and
`bare_openrouter_slug_routes_to_openrouter_not_the_default` asserts OpenRouter
for the same input — the two cannot both pass.

| # | Test | Crate |
|---|---|---|
| a | `bare_openrouter_slug_routes_to_openrouter_not_the_default` | trusty-review |
| a | `bare_bedrock_profile_id_routes_to_bedrock_not_the_default` | trusty-review |
| a | `route_bare_openrouter_slug_beats_the_default`, `route_bare_bedrock_profile_beats_the_default` | trusty-mpm |
| a | `deps_from_state_routes_a_bare_openrouter_slug_to_openrouter` | trusty-review (MCP) |
| b | `prefix_that_contradicts_the_id_shape_is_an_error`, `every_contradicting_pair_is_refused` | trusty-review |
| b | `route_prefix_contradicting_the_shape_is_an_error`, `route_shape_the_sm_cannot_build_is_an_error` | trusty-mpm |
| b | `deps_from_state_build_failure_is_an_error`, `deps_from_state_rejects_a_model_the_startup_provider_cannot_run` | trusty-review (MCP) |
| c | `provider_factory_prefix_routing`, `provider_factory_mixed_providers_in_compare_set`, `route_{anthropic,bedrock,openrouter}_prefix` | both |

Plus `ambiguous_bare_id_still_uses_the_default_provider` / `route_bare_uses_default`,
which pin that inference narrows the fall-through rather than removing it.

## Gates — rung 4 (cross-crate: `trusty-common` public API + two consumers)

```
cargo fmt --check                                              EXIT=0
cargo check --workspace                                        EXIT=0
cargo clippy -p trusty-review --all-targets -- -D warnings     EXIT=0
cargo clippy -p trusty-mpm --all-targets -- -D warnings        EXIT=0
cargo clippy -p trusty-common --features inference-client \
    --all-targets -- -D warnings                               EXIT=0
```

```
cargo test -p trusty-common --features inference-client
  test result: ok. 598 passed; 0 failed; 12 ignored
  test result: ok. 11 passed; 0 failed; 0 ignored

cargo test -p trusty-review
  test result: ok. 1739 passed; 0 failed; 5 ignored
  (+ 10 further binaries, all ok)

cargo test -p trusty-mpm
  test result: ok. 5204 passed; 0 failed; 7 ignored
  test result: ok. 1774 passed; 0 failed; 1 ignored  (x2)
  (+ 37 further binaries, all ok)

cargo test -p trusty-audit                # env-contract consumer
  test result: ok. 618 passed; 0 failed; 5 ignored
  (+ 9 further binaries, all ok)
```

`--features inference-client` names what changed in trusty-common, per the
CLAUDE.md rule that a bare `cargo test -p trusty-common` compiles none of the
gated modules.

Repo gates: `check_line_cap.sh` (4127 files, 0 violations), `check_sld.sh`
(0 errors, 0 warnings), `check_changelog_fragment.sh` (all 3 crates recorded).

## Not in this PR

`OpenRouterProvider::complete` and `FireworksProvider::complete` send
`self.model` and ignore `LlmRequest.model`, while `BedrockProvider` sends
`req.model`. A per-request model that differs from the constructed provider's is
therefore silently dropped on two of the three backends. Every in-tree caller
builds the provider from the same id it puts in the request, so nothing runs the
wrong model today — but it is the same class of defect and deserves its own
ticket rather than a rider on this one.

---

## Code-critic round (review 4982242554, APPROVE + 2 MEDIUM) — both fixed in `d60eab26b`

**MEDIUM 1 — the SM's remedy named values the config parser rejects.**
`shape_error` told the operator to set
`[session_manager.inference].provider` to the inferred provider, which for a
Fireworks-shaped id meant `provider = "fireworks"` — a value
`ProviderKind::parse` refuses. The remedy now branches: a provider the SM can
build is suggested by name; one it cannot is reported as unbuildable, with the
accepted set named instead. Accepted values and the routing-prefix hint both
derive from `ProviderKind::ALL`, which `parse` now matches against, so no third
list can drift from what the parser takes.
New: `shape_error_only_suggests_parseable_provider_values` (scans the remedy
half of BOTH error shapes and asserts every quoted token is either parseable or
a real routing prefix), `provider_kind_all_covers_every_variant`,
`provider_kind_accepted_values_are_all_parseable`,
`provider_kind_prefixes_match_the_constants`, and
`every_inferable_provider_is_parseable_here` pinning the same invariant on the
trusty-review side, where it held but was untested.

**MEDIUM 2 — real: the dotted-vendor guess vetoed an explicit prefix.**
Confirmed by trace. `openrouter/anthropic.claude-x` stripped to
`anthropic.claude-x`, whose first dotted segment matches a Bedrock vendor name,
so `reconcile` rejected the operator's own prefix — a working configuration
turned into a hard error on a vendor-name coincidence.

The contract is now explicit, as `ShapeEvidence`:

| Evidence | Shapes | Beats a config default | Beats an explicit prefix |
|---|---|---|---|
| `Conclusive` | `vendor/model` slug, `accounts/fireworks/models/…`, region-scoped profile | yes | yes |
| `Probable` | dotted `vendor.model` on a known Bedrock vendor | yes | no |

A standing config default is a setting; an explicit per-call prefix is a
statement about THIS call, so only a catalogue fact overrules it. Both
resolvers' `reconcile` now calls `conclusive_shape_mismatch`.
`bedrock/anthropic/claude-opus-4.8` still fails — that half is unchanged, and
`route_prefix_contradicting_the_shape_is_an_error` /
`prefix_that_contradicts_the_id_shape_is_an_error` still prove it.

New tests through BOTH crates' public resolvers, each pinning the dotted
remainder under all three prefixes plus the no-prefix control:
`explicit_prefix_survives_a_probable_bedrock_shape` (trusty-review),
`route_explicit_prefix_survives_a_probable_bedrock_shape` (trusty-mpm), and
`conclusive_mismatch_ignores_a_probable_shape` /
`conclusive_mismatch_still_flags_a_slug_on_bedrock` /
`slug_and_profile_evidence_is_conclusive` /
`dotted_vendor_evidence_is_probable` in trusty-common.

### Rung 4 re-run on `d60eab26b`

```
cargo fmt --check                                              EXIT=0
cargo check --workspace                                        EXIT=0
cargo clippy -p trusty-common --features inference-client \
    --all-targets -- -D warnings                               EXIT=0
cargo clippy -p trusty-review --all-targets -- -D warnings     EXIT=0
cargo clippy -p trusty-mpm --all-targets -- -D warnings        EXIT=0
```

```
cargo test -p trusty-common --features inference-client
  test result: ok. 602 passed; 0 failed; 12 ignored
  test result: ok. 11 passed; 0 failed; 0 ignored

cargo test -p trusty-review
  test result: ok. 1741 passed; 0 failed; 5 ignored
  (+ 10 further binaries, all ok)

cargo test -p trusty-mpm
  test result: ok. 5209 passed; 0 failed; 7 ignored
  test result: ok. 1774 passed; 0 failed; 1 ignored  (x2)
  (50 result lines, all ok)
```

Repo gates: `check_line_cap.sh` (4128 files, 0 violations), `check_sld.sh`
(0 errors, 0 warnings), `check_changelog_fragment.sh` (all 3 crates recorded).

One test failed during this round and was fixed rather than weakened:
`shape_error_only_suggests_parseable_provider_values` first scanned every quoted
token in the whole message, so it counted the operator's own model id — quoted
in the diagnosis half — as a suggestion. The message was already correct; the
test now scans only the remedy half.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
