### PR TITLE
test: own every real tmux session a trusty-mpm test creates with a kill-on-drop guard

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/commands/managed_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed_tests.rs
@@ -385,8 +385,9 @@ async fn session_resume_restart_failure_errors() {
 /// and asserts: (1) `Ok(())` — headless success; (2) the daemon's own record
 /// of the session state is UNCHANGED afterward (still `provisioning`) — the
 /// only way to prove NO `/resume` POST landed, since a successful restart
-/// always flips state to `active`. The real tmux session is killed
-/// unconditionally (even on assertion failure) before returning.
+/// always flips state to `active`. The real tmux session is owned by a
+/// `ScratchTmuxSession` guard, so it is killed on every exit path — normal
+/// return, assertion failure, and panic alike (#6116).
 #[tokio::test]
 async fn session_resume_headless_active_live_tmux_skips_restart_and_attach() {
     use trusty_mpm::daemon::{api, state::DaemonState};
@@ -433,13 +434,13 @@ async fn session_resume_headless_active_live_tmux_skips_restart_and_attach() {
     // live agent process deterministically. Without it this fixture's verdict
     // depended on whether the login shell happened to still have a child mid-init
     // when the probe ran, making the test genuinely flaky under the new logic.
-    let create_status = std::process::Command::new(&tmux_bin)
-        .args(["new-session", "-d", "-s", &record.tmux_name, "sleep 300"])
-        .status()
-        .expect("spawn real tmux session for the liveness probe");
-    assert!(
-        create_status.success(),
-        "failed to create the real scratch tmux session"
+    //
+    // #6116: owned by an RAII guard, so the session dies with this test whether
+    // it returns, fails an assertion, or panics inside the wait below.
+    let scratch = crate::test_support::tmux_session::ScratchTmuxSession::spawn(
+        &tmux_bin,
+        &record.tmux_name,
+        "sleep 300",
     );
     // tmux runs the command through a shell, so there is a brief window after
     // `new-session` in which the pane still reports `sh`/`zsh` rather than
@@ -458,11 +459,10 @@ async fn session_resume_headless_active_live_tmux_skips_restart_and_attach() {
 
     let result = session_resume(&client, &url, id.to_string()).await;
 
-    // Unconditional cleanup of the real tmux session, even if an assertion
-    // below panics.
-    let _ = std::process::Command::new(&tmux_bin)
-        .args(["kill-session", "-t", &record.tmux_name])
-        .output();
+    // Killed here, before the assertions, as it always has been. Dropping the
+    // guard is now only the EARLIEST it can happen — an assertion failure or
+    // panic above already unwound through it.
+    drop(scratch);
 
     result.expect(
         "headless resume of an already-live, non-stopped/errored session must succeed (Ok), \
@@ -567,7 +567,10 @@ fn wait_for_stable_dead_runtime(session_name: &str) {
 /// shell — the exact dead-runtime shape — and asserts the daemon record flipped
 /// to `active`, which only a `/runtime-stop` + `/resume` round-trip can do. The
 /// daemon here is `FakeNoopTmuxDriver`-backed, so its `kill_session` is a no-op
-/// and the real scratch session is torn down by this test, unconditionally.
+/// and the real scratch session is torn down by this test. #6116: that teardown
+/// is a `ScratchTmuxSession` guard rather than a trailing `kill-session`,
+/// because `wait_for_stable_dead_runtime` below panics on timeout by design and
+/// a trailing kill never runs on that path.
 #[tokio::test]
 async fn session_resume_headless_dead_runtime_reconciles_and_restarts() {
     use trusty_mpm::daemon::{api, state::DaemonState};
@@ -595,9 +598,9 @@ async fn session_resume_headless_dead_runtime_reconciles_and_restarts() {
             // (which would otherwise also derive `tm-r-01`) AND across test
             // BINARIES: this crate compiles the same sources into two bin targets
             // (`tm` and `trusty-mpm`) that cargo may run concurrently, so a fixed
-            // name lets one process's unconditional `kill-session` cleanup
-            // destroy the other process's session mid-test — observed as an
-            // intermittent failure of the final assertion below.
+            // name lets one process's cleanup destroy the other process's session
+            // mid-test — observed as an intermittent failure of the final
+            // assertion below.
             Some(format!(
                 "https://example.com/deadrt{}.git",
                 std::process::id()
@@ -631,13 +634,15 @@ async fn session_resume_headless_dead_runtime_reconciles_and_restarts() {
     // `orphan_gc::IDLE_SHELL_COMMANDS` is equally an idle shell, and the point of
     // the argument is only to skip login/rc processing so the pane settles
     // immediately and stays childless.
-    let create_status = std::process::Command::new(&tmux_bin)
-        .args(["new-session", "-d", "-s", &record.tmux_name, "sh"])
-        .status()
-        .expect("spawn real tmux session for the liveness probe");
-    assert!(
-        create_status.success(),
-        "failed to create the real scratch tmux session"
+    //
+    // #6116: owned by an RAII guard. `wait_for_stable_dead_runtime` below
+    // panics on a 10s timeout by design, and the post-hoc `kill-session` this
+    // replaces never ran on that path — every such run leaked a real
+    // `tm-deadrt<pid>-01` session permanently.
+    let scratch = crate::test_support::tmux_session::ScratchTmuxSession::spawn(
+        &tmux_bin,
+        &record.tmux_name,
+        "sh",
     );
     // Belt-and-braces on top of the deterministic fixture: require the "runtime
     // dead" reading to be STABLE (three consecutive probes) before proceeding,
@@ -654,9 +659,9 @@ async fn session_resume_headless_dead_runtime_reconciles_and_restarts() {
 
     let result = session_resume(&client, &url, id.to_string()).await;
 
-    let _ = std::process::Command::new(&tmux_bin)
-        .args(["kill-session", "-t", &record.tmux_name])
-        .output();
+    // The daemon here is `FakeNoopTmuxDriver`-backed, so its `kill_session` is a
+    // no-op and this guard is what actually tears the real session down.
+    drop(scratch);
 
     // Deliberately NOT asserted as `Ok`. Whether the daemon can actually spawn a
     // runtime is environment-dependent (CI has no agent binary on PATH, so

--- a/crates/trusty-mpm/src/bin/tm/test_support.rs
+++ b/crates/trusty-mpm/src/bin/tm/test_support.rs
@@ -26,6 +26,16 @@ use std::path::PathBuf;
 
 use tempfile::TempDir;
 
+/// RAII ownership of a real tmux session created by a test (#6116).
+///
+/// Unlike `hermetic_temp_dir` above, this one is NOT duplicated for the binary:
+/// the lib's copy and this one are the same source file, included from both.
+/// A kill-on-drop guardrail written twice is one edit away from drifting, and
+/// the file needs nothing from either crate root, so `#[path]` costs nothing
+/// here that the duplication above pays for.
+#[path = "../../test_tmux_session.rs"]
+pub(crate) mod tmux_session;
+
 /// Same prefix the lib's fixture uses, so its sweep reaps these too.
 const TEST_DIR_PREFIX: &str = "tm-test-";
 

--- a/crates/trusty-mpm/src/core/process.rs
+++ b/crates/trusty-mpm/src/core/process.rs
@@ -388,23 +388,23 @@ mod tests {
         .unwrap();
 
         let session = format!("tmpm-disclaim-pid-{}", std::process::id());
-        let tmux = |args: &[&str]| Command::new("tmux").args(args).status();
-        let _ = tmux(&["kill-session", "-t", &session]);
-        tmux(&[
-            "new-session",
-            "-d",
-            "-s",
+        // #6116: RAII, so a panic anywhere below still tears the session down.
+        // The pre-emptive `kill-session` this replaces went with it: the name is
+        // process-unique, and a genuine duplicate is better surfaced as a failed
+        // `new-session` than silently killed — that kill used a bare `-t` target,
+        // which prefix-matches and can destroy an unrelated session.
+        let scratch = crate::test_support::tmux_session::ScratchTmuxSession::spawn(
+            "tmux",
             &session,
             &format!("sh {}", drv.display()),
-        ])
-        .unwrap();
+        );
 
         let pid = find_claude_pid_in_tmux(&session, 25, Duration::from_millis(200));
         // Verify the resolved pid IS the claude grandchild WHILE the session is
-        // still alive — kill-session below tears down the whole tree, so this
+        // still alive — dropping the guard tears down the whole tree, so this
         // check must precede cleanup.
         let named_claude = pid.map(process_name_is_claude);
-        let _ = tmux(&["kill-session", "-t", &session]);
+        drop(scratch);
 
         let pid = pid.expect("claude pid must resolve through the disclaim wrapper");
         assert_eq!(

--- a/crates/trusty-mpm/src/test_support.rs
+++ b/crates/trusty-mpm/src/test_support.rs
@@ -39,6 +39,13 @@ use std::time::{Duration, SystemTime};
 
 use tempfile::TempDir;
 
+/// RAII ownership of a real tmux session created by a test (#6116).
+///
+/// The same file backs the `tm` binary's copy of this module — see its own
+/// docs for why one source file serves both targets.
+#[path = "test_tmux_session.rs"]
+pub(crate) mod tmux_session;
+
 /// The loopback port every dead-daemon test points at (#4306, #4415).
 ///
 /// Why this specific port, rather than one the fixture binds for itself: the

--- a/crates/trusty-mpm/src/test_tmux_session.rs
+++ b/crates/trusty-mpm/src/test_tmux_session.rs
@@ -1,0 +1,214 @@
+//! RAII ownership of a REAL tmux session created by a test (#6116).
+//!
+//! Why: three fixtures in this crate shelled out to `tmux new-session` and
+//! cleaned up with a bare `kill-session` placed after the code under test. That
+//! kill is skipped whenever anything between the two panics, and one of those
+//! fixtures panics by design — `wait_for_stable_dead_runtime` gives up at a 10s
+//! deadline. tmux sessions are machine-global and outlive the test process, so
+//! every panicked or cancelled run left one behind permanently: 29 `tm-deadrt*`
+//! sessions accumulated on the owner's machine over 30 hours. #1790 isolated the
+//! session STORE and said nothing about raw tmux spawns; this module is the
+//! missing half.
+//!
+//! What: [`ScratchTmuxSession`] owns the session it created and kills it in
+//! `Drop`, so normal return, `?`, assertion failure, and unwinding panic all
+//! tear it down. It targets tmux with the `=<name>` EXACT-match form rather
+//! than the bare `<name>` the old call sites used — a bare target falls through
+//! to prefix and `fnmatch` matching, so `kill-session -t tm-deadrt99-01` will
+//! happily destroy `tm-deadrt99-01-sibling` when the exact name is gone.
+//! Verified on tmux 3.6b: with only the sibling alive, the bare form killed it
+//! and the `=` form left it untouched.
+//!
+//! This file is compiled into TWO targets — the `trusty-mpm` lib and the `tm`
+//! binary — through a `#[path]` include from each one's `test_support` module,
+//! because a fixture reachable from only one of them would have to be written
+//! twice, and a kill-on-drop guardrail that exists in two copies is one edit
+//! away from drifting. The binary it drives is passed in rather than resolved
+//! here for the same reason: `core::tmux::resolve_tmux_binary_or_bare` is
+//! spelled `crate::…` in the lib and `trusty_mpm::…` in the bin, and no single
+//! spelling compiles in both.
+//!
+//! Test: [`tests`] below — a session that outlives a panicking closure is gone
+//! afterwards, and a guard never touches a name it did not create.
+
+use std::process::Command;
+
+/// A real tmux session owned by a test, killed when this value drops.
+///
+/// Why: see the module docs — the panic path, not the happy path, is the whole
+/// point.
+/// What: [`ScratchTmuxSession::spawn`] creates the session and takes ownership
+/// of exactly the name it passed to `new-session`; `Drop` kills that one name.
+/// A failed `new-session` panics instead of yielding a guard, so a guard never
+/// claims a session it did not create.
+/// Test: [`tests::drop_kills_the_session_even_when_the_body_panics`],
+/// [`tests::drop_kills_only_the_exact_name_it_created`].
+pub(crate) struct ScratchTmuxSession {
+    tmux_bin: String,
+    name: String,
+}
+
+impl ScratchTmuxSession {
+    /// Create `name` as a detached tmux session running `pane_command`.
+    ///
+    /// Panics if `new-session` cannot be spawned or exits non-zero. A duplicate
+    /// name is one such non-zero exit, which is the behaviour that keeps the
+    /// ownership claim honest: the caller gets no guard, so nothing later kills
+    /// a session someone else created.
+    pub(crate) fn spawn(tmux_bin: &str, name: &str, pane_command: &str) -> Self {
+        let status = Command::new(tmux_bin)
+            .args(["new-session", "-d", "-s", name, pane_command])
+            .status()
+            .unwrap_or_else(|e| panic!("spawn `{tmux_bin} new-session -s {name}`: {e}"));
+        assert!(
+            status.success(),
+            "`{tmux_bin} new-session -d -s {name}` failed with {status}; the session was NOT \
+             created, so no guard may claim it"
+        );
+        Self {
+            tmux_bin: tmux_bin.to_string(),
+            name: name.to_string(),
+        }
+    }
+
+    /// The exact session name this guard owns.
+    pub(crate) fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Whether a session named exactly `name` is live right now.
+    ///
+    /// `=` pins tmux to an exact match; see the module docs for why the bare
+    /// form is unsafe here.
+    pub(crate) fn exists(tmux_bin: &str, name: &str) -> bool {
+        Command::new(tmux_bin)
+            .args(["has-session", "-t", &format!("={name}")])
+            .output()
+            .is_ok_and(|out| out.status.success())
+    }
+
+    /// Whether `tmux_bin` runs at all, for fixtures that skip rather than fail
+    /// where tmux is absent (the convention `core::process`'s ignored
+    /// disclaim-wrapper test already follows).
+    pub(crate) fn tmux_available(tmux_bin: &str) -> bool {
+        Command::new(tmux_bin)
+            .arg("-V")
+            .output()
+            .is_ok_and(|out| out.status.success())
+    }
+}
+
+impl Drop for ScratchTmuxSession {
+    fn drop(&mut self) {
+        // Best-effort by construction: `Drop` runs during unwinding, where a
+        // panic would abort the process and bury the original failure.
+        let _ = Command::new(&self.tmux_bin)
+            .args(["kill-session", "-t", &format!("={}", self.name)])
+            .output();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Bare `tmux`, matching what `core::tmux::resolve_tmux_binary_or_bare`
+    /// falls back to. These tests only need the `PATH` lookup a `cargo test`
+    /// shell already has.
+    const TMUX: &str = "tmux";
+
+    /// Process-unique, so the two targets this file compiles into cannot
+    /// collide in the machine-global tmux namespace when cargo runs them
+    /// concurrently.
+    fn scratch_name(tag: &str) -> String {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0, |d| d.subsec_nanos());
+        format!("tm-scratchguard-{tag}-{}-{nanos}", std::process::id())
+    }
+
+    /// The defect #6116 reports, inverted into an assertion: the fixture panics
+    /// mid-test — exactly what `wait_for_stable_dead_runtime`'s 10s deadline
+    /// does — and the session must still be gone afterwards.
+    ///
+    /// The panic message reaching stderr during this run is expected output,
+    /// not a failure.
+    #[test]
+    fn drop_kills_the_session_even_when_the_body_panics() {
+        if !ScratchTmuxSession::tmux_available(TMUX) {
+            eprintln!("tmux not available; skipping");
+            return;
+        }
+        let name = scratch_name("panic");
+        let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let session = ScratchTmuxSession::spawn(TMUX, &name, "sh");
+            assert!(
+                ScratchTmuxSession::exists(TMUX, session.name()),
+                "fixture precondition: the session must be live before the panic"
+            );
+            panic!("simulated mid-test failure while the guard is alive");
+        }));
+        assert!(
+            outcome.is_err(),
+            "the closure must actually have panicked, or this proves nothing"
+        );
+        assert!(
+            !ScratchTmuxSession::exists(TMUX, &name),
+            "session '{name}' survived a panicking test — this is #6116, where a \
+             post-hoc kill-session placed after the code under test never ran"
+        );
+    }
+
+    /// The guard must kill the one name it created and nothing else. A bare
+    /// `-t <name>` target does not satisfy this: with the exact name already
+    /// gone, tmux prefix-matches and kills `<name>-sibling` instead.
+    #[test]
+    fn drop_kills_only_the_exact_name_it_created() {
+        if !ScratchTmuxSession::tmux_available(TMUX) {
+            eprintln!("tmux not available; skipping");
+            return;
+        }
+        let owned_name = scratch_name("exact");
+        let sibling_name = format!("{owned_name}-sibling");
+        let sibling = ScratchTmuxSession::spawn(TMUX, &sibling_name, "sh");
+        {
+            let _owned = ScratchTmuxSession::spawn(TMUX, &owned_name, "sh");
+        }
+        assert!(
+            !ScratchTmuxSession::exists(TMUX, &owned_name),
+            "the guard must kill its own session on drop"
+        );
+        assert!(
+            ScratchTmuxSession::exists(TMUX, &sibling_name),
+            "'{sibling_name}' shares a prefix with the dropped guard's name but was created \
+             by someone else; a bare `-t` target would have killed it"
+        );
+        drop(sibling);
+    }
+
+    /// A guard is only handed out for a session that was actually created, so
+    /// a name already taken yields a panic rather than an ownership claim over
+    /// someone else's session.
+    #[test]
+    fn spawning_a_duplicate_name_panics_instead_of_claiming_it() {
+        if !ScratchTmuxSession::tmux_available(TMUX) {
+            eprintln!("tmux not available; skipping");
+            return;
+        }
+        let name = scratch_name("dup");
+        let owner = ScratchTmuxSession::spawn(TMUX, &name, "sh");
+        let second = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            ScratchTmuxSession::spawn(TMUX, &name, "sh")
+        }));
+        assert!(
+            second.is_err(),
+            "a duplicate `new-session` must panic, not hand out a second owner"
+        );
+        assert!(
+            ScratchTmuxSession::exists(TMUX, &name),
+            "the failed spawn must leave the original owner's session untouched"
+        );
+        drop(owner);
+        assert!(!ScratchTmuxSession::exists(TMUX, &name));
+    }
+}


### PR DESCRIPTION
Refs #6116.

## What changed

`ScratchTmuxSession` (`crates/trusty-mpm/src/test_tmux_session.rs`) owns the tmux session it created and kills it in `Drop`. Every test in the crate that spawns a real tmux session now goes through it:

- `managed_tests.rs` — `session_resume_headless_dead_runtime_reconciles_and_restarts` (the one the issue names) and its live-runtime sibling `session_resume_headless_active_live_tmux_skips_restart_and_attach`.
- `core/process.rs` — `claude_pid_resolves_through_disclaim_wrapper`, the crate's third raw `new-session` spawn, found by sweeping for `new-session` in test code. It is `#[ignore]`d, so it leaks rarely, but it leaks the same way.

The sibling named in the issue, `tests_behavior_d_tests.rs`, spawns nothing: it uses `tm-deadrt40493-01` as a literal string in an in-memory prune test. No change needed there.

## The guard kills only what it created

It targets tmux as `=<name>`. A bare `-t <name>` falls through to prefix and `fnmatch` matching, so once the exact name is gone tmux kills a neighbour instead. Measured on tmux 3.6b with two sessions I created for the purpose:

```
$ tmux kill-session -t "=zz-guardprobe-01"      # exact form
$ tmux ls | grep zz-guardprobe
zz-guardprobe-01-sibling: 1 windows             # sibling survives

$ tmux kill-session -t "zz-guardprobe-01"       # bare form, exact name now gone
$ tmux ls | grep zz-guardprobe || echo "(sibling GONE — prefix match killed it)"
(sibling GONE — prefix match killed it)
```

`spawn` panics rather than returning a guard when `new-session` fails, so a duplicate name never yields an ownership claim over someone else's session (`spawning_a_duplicate_name_panics_instead_of_claiming_it`).

## One implementation, two compile units

No RAII tmux guard existed anywhere in the workspace — searched `trusty-common`, `trusty-mpm`'s lib and bin `test_support` modules, and every `impl Drop` in `crates/`. The nearest relatives are `tga`'s `KillOnDrop` (a pid-file reaper) and the `kill_on_drop(true)` calls on `tokio::process::Command`; neither covers a tmux session, which outlives the process that created it.

The two call sites live in different compile units (the `trusty-mpm` lib and the `tm` binary), which is why `bin/tm/test_support.rs` duplicates `hermetic_temp_dir` today. One source file serves both here instead, via a `#[path]` include from each `test_support` module — a kill-on-drop guardrail written twice is one edit away from drifting. The file takes the tmux binary as an argument rather than resolving it, since `resolve_tmux_binary_or_bare` has no spelling that compiles in both.

## Proof the guard fires on panic

Before/after on the real fixture, with a `panic!` injected after `wait_for_stable_dead_runtime` to stand in for its 10s-timeout panic. Both runs fail the test, as intended; the question is what survives.

Pre-fix shape (raw spawn + trailing `kill-session`):

```
test commands::managed::tests::session_resume_headless_dead_runtime_reconciles_and_restarts ... FAILED
#6116 EVIDENCE PANIC session=tm-deadrt86792-01
test result: FAILED. 0 passed; 1 failed; ...

$ tmux ls -F '#{session_name}' | grep tm-deadrt86792-01
tm-deadrt86792-01                      <- LEAKED
```

With the guard:

```
test commands::managed::tests::session_resume_headless_dead_runtime_reconciles_and_restarts ... FAILED
#6116 EVIDENCE PANIC session=tm-deadrt86169-01
test result: FAILED. 0 passed; 1 failed; ...

$ tmux has-session -t '=tm-deadrt86169-01'
can't find session: tm-deadrt86169-01   <- GONE
```

The injected panic was reverted; the session the pre-fix control leaked was killed by name. The nine pre-existing `tm-deadrt*` sessions on the machine were left untouched — they are the issue's evidence, not this PR's to clean up.

That before/after is also encoded as a permanent test, `drop_kills_the_session_even_when_the_body_panics`, so the regression cannot return silently.

## Gates — ladder rung 2 (test-only stabilization)

```
cargo fmt --check                                     EXIT=0
cargo clippy -p trusty-mpm --all-targets -- -D warnings   EXIT=0
bash scripts/check_line_cap.sh    4128 tracked .rs files, 0 violations — OK
cargo test -p trusty-mpm          ok. 5202 passed; 0 failed; 7 ignored   (lib)
                                  ok. 1777 passed; 0 failed; 1 ignored   (bin tm)
                                  ok. 1777 passed; 0 failed; 1 ignored   (bin trusty-mpm)
                                  + 43 integration targets, all ok, 0 failed
```

The `#[ignore]`d third call site, run explicitly:

```
cargo test -p trusty-mpm --lib claude_pid_resolves_through_disclaim_wrapper -- --include-ignored
test core::process::tests::claude_pid_resolves_through_disclaim_wrapper ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 5208 filtered out
```

Stability, 10 iterations of both touched filters:

```
run 1..10: session_resume_headless=0 tmux_session::tests=0
LOOP_FAIL=0
```

And the leak check the change exists for: two full `cargo test -p trusty-mpm` runs added zero `tm-deadrt*` sessions. One unrelated session appeared during the session three seconds after my suite exited, while a sibling agent was running `trusty-mpm` tests from an unguarded checkout on the same machine; it is not reproducible under this branch and was left alone.

No changelog fragment: test-only change.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
