### PR TITLE
fix(trusty-mpm): give the reconcile adopt path the create path's hygiene (Refs #6117, #6118)

### DIFF
--- a/crates/trusty-mpm/changelog.d/6117-adopt-path-hygiene.md
+++ b/crates/trusty-mpm/changelog.d/6117-adopt-path-hygiene.md
@@ -17,10 +17,17 @@ Fixed
   keeps any pane a registry names — so adopting the pane is precisely what made
   it permanent. 55 of the 103 records in the reporting store were these. The
   pane is now left untracked and named in the daemon's boot log, which hands it
-  to the orphan-GC: it reaps a managed-prefix pane only when the pane is an idle
+  to the orphan-GC: it kills a managed-prefix pane only when the pane is an idle
   shell with no live child process, seen idle on two consecutive sweeps, and it
   keeps one still running an agent. Adoption of a pane whose cwd does resolve is
   unchanged.
+- The working-directory probe behind that decision retries before giving up. It
+  is a kill decision now — a declined pane is orphan-GC input — and
+  `TmuxDriver::pane_current_path` reports a failed spawn, a non-zero exit and
+  empty output all as `None` with no retry, while boot reconciliation runs once
+  per daemon process. One flaky answer would have cost a live pane inside two
+  minutes.
 - `ReconcileReport` carries `adoption_declined`, the tmux names reconciliation
-  declined this pass, so a pane that stops appearing in `tm ls` is accounted for
-  rather than silently absent.
+  declined this pass, and the daemon's boot summary logs the count and fires on
+  it, so a pane that stops appearing in `tm ls` is accounted for rather than
+  silently absent.

--- a/crates/trusty-mpm/changelog.d/6117-adopt-path-hygiene.md
+++ b/crates/trusty-mpm/changelog.d/6117-adopt-path-hygiene.md
@@ -1,0 +1,26 @@
+Fixed
+
+- Boot reconciliation adopts a live tmux pane under an id derived from the
+  pane's tmux name, so one pane can only ever occupy one store row
+  ([#6117](https://github.com/bobmatnyc/trusty-tools/issues/6117)). The
+  external-adopt loop decides from a snapshot of store names taken once, before
+  the loop; a second adopter holding its own copy saw the same pane as unknown
+  and wrote a second record under a fresh random id. The store is keyed by id,
+  so both survived — 11 tmux names carried two records apiece in the reporting
+  store, several pairs written 30-60 ms apart. A name-derived id makes the
+  second write land on the first's key instead of beside it.
+- Boot reconciliation no longer adopts a pane whose working directory it cannot
+  resolve ([#6118](https://github.com/bobmatnyc/trusty-tools/issues/6118)). Such
+  a pane used to become an `Active` record with a `/unknown` cwd and an
+  `unmanaged` note in `task`, and that record could never be retired: the
+  `tm ls` auto-prune keeps any record whose tmux name is live, and the orphan-GC
+  keeps any pane a registry names — so adopting the pane is precisely what made
+  it permanent. 55 of the 103 records in the reporting store were these. The
+  pane is now left untracked and named in the daemon's boot log, which hands it
+  to the orphan-GC: it reaps a managed-prefix pane only when the pane is an idle
+  shell with no live child process, seen idle on two consecutive sweeps, and it
+  keeps one still running an agent. Adoption of a pane whose cwd does resolve is
+  unchanged.
+- `ReconcileReport` carries `adoption_declined`, the tmux names reconciliation
+  declined this pass, so a pane that stops appearing in `tm ls` is accounted for
+  rather than silently absent.

--- a/crates/trusty-mpm/src/daemon/state/core.rs
+++ b/crates/trusty-mpm/src/daemon/state/core.rs
@@ -821,13 +821,23 @@ impl DaemonState {
                         let n_stopped = report.stopped.len();
                         let n_external = report.external_adopted.len();
                         let n_stale_decisions = report.stale_decisions_cleared.len();
-                        if n_adopted > 0 || n_stopped > 0 || n_external > 0 || n_stale_decisions > 0
+                        // #6118: a declined pane leaves no record, so this
+                        // summary is the only place the boot accounts for it.
+                        // It must gate the log too — a boot whose ONLY finding
+                        // was declined panes would otherwise print nothing.
+                        let n_declined = report.adoption_declined.len();
+                        if n_adopted > 0
+                            || n_stopped > 0
+                            || n_external > 0
+                            || n_stale_decisions > 0
+                            || n_declined > 0
                         {
                             tracing::info!(
                                 adopted = n_adopted,
                                 stopped = n_stopped,
                                 external = n_external,
                                 stale_decisions_cleared = n_stale_decisions,
+                                adoption_declined = n_declined,
                                 "session-manager reconcile complete"
                             );
                         }

--- a/crates/trusty-mpm/src/session_manager/adopt.rs
+++ b/crates/trusty-mpm/src/session_manager/adopt.rs
@@ -14,12 +14,69 @@
 //! `derive_source_id_*` unit tests at the bottom of this module.
 
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use chrono::Utc;
-use tracing::info;
+use tracing::{info, warn};
 
+use super::driver::ManagedTmuxDriver;
 use super::manager::{ManagedError, SessionManager};
 use super::record::{ManagedSessionId, ManagedSessionState, SessionRecord};
+
+/// Backoff between the boot-adopt path's working-directory probes; its length
+/// plus one is how many times [`resolve_adoptable_cwd`] asks.
+const CWD_PROBE_BACKOFF: [Duration; 2] = [Duration::from_millis(50), Duration::from_millis(150)];
+
+/// Resolve the working directory boot reconciliation will adopt a pane under,
+/// retrying a failed probe before reporting the pane unresolvable.
+///
+/// Why: declining a pane (#6118) leaves it untracked, and untracked is exactly
+/// what `daemon::orphan_gc` reaps — an idle-shell pane with no live child is
+/// killed after two 60-second sweeps. So the probe that decides this is now a
+/// kill decision, and a single false `None` costs a live pane within about two
+/// minutes. `TmuxDriver::pane_current_path` collapses spawn failure, a non-zero
+/// exit and empty output into one `None` with no retry, and
+/// [`SessionManager::reconcile_on_boot`] runs ONCE per daemon process (a
+/// `OnceCell` in `daemon::state::core`), so without a retry that one flaky
+/// answer is the pane's only hearing until the daemon next restarts.
+///
+/// Retrying inside the call, rather than declining only on a second boot
+/// observation, is what actually protects the pane. A cross-boot debounce
+/// cannot: the pane is untracked from the moment of the first decline, so the
+/// orphan-GC reaches it in 60-120 seconds while the second observation waits on
+/// a daemon restart that may be days away — and holding the observation by
+/// adopting provisionally just recreates the #6118 ghost.
+///
+/// What: asks `get_pane_cwd` up to `CWD_PROBE_BACKOFF.len() + 1` times, sleeping
+/// the matching backoff between attempts, and returns the first answer that
+/// names an existing directory. A pane that is genuinely unresolvable costs the
+/// full backoff once, at boot only.
+/// Test: `flaky_cwd_probe_still_adopts_within_one_reconcile`,
+/// `unresolvable_cwd_probe_is_retried_a_bounded_number_of_times` in
+/// `naming_tests.rs`.
+pub(super) async fn resolve_adoptable_cwd(
+    tmux: &dyn ManagedTmuxDriver,
+    name: &str,
+) -> Option<PathBuf> {
+    for attempt in 0..=CWD_PROBE_BACKOFF.len() {
+        if let Some(cwd) = tmux.get_pane_cwd(name).filter(|p| p.is_dir()) {
+            if attempt > 0 {
+                warn!(
+                    name = %name,
+                    attempt = attempt + 1,
+                    "reconcile: pane working directory resolved only on retry — the first probe \
+                     was a transient failure, and declining on it would have exposed a live pane \
+                     to the orphan-GC (#6118)"
+                );
+            }
+            return Some(cwd);
+        }
+        if let Some(backoff) = CWD_PROBE_BACKOFF.get(attempt) {
+            tokio::time::sleep(*backoff).await;
+        }
+    }
+    None
+}
 
 /// Derive the `source_id` (`"owner/repo"`) for a session record from its workspace git remote.
 ///

--- a/crates/trusty-mpm/src/session_manager/manager.rs
+++ b/crates/trusty-mpm/src/session_manager/manager.rs
@@ -175,6 +175,13 @@ pub struct ReconcileReport {
     /// stale `pending_decision`/`proposed_default` were cleared this boot
     /// (#4400 backfill for rows tombstoned before the decommission-path fix).
     pub stale_decisions_cleared: Vec<String>,
+    /// Live managed tmux names reconciliation DECLINED to adopt because the
+    /// pane's working directory could not be resolved (#6118).
+    ///
+    /// Why: these panes are the ones the daemon deliberately leaves untracked,
+    /// so the boot log has to name them — otherwise a pane simply stops
+    /// appearing in `tm ls` with nothing said about where it went.
+    pub adoption_declined: Vec<String>,
 }
 
 /// Manages the lifecycle of daemon-owned tmux sessions.

--- a/crates/trusty-mpm/src/session_manager/naming_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/naming_tests.rs
@@ -318,6 +318,144 @@ async fn reconcile_resolves_adopted_session_cwd_from_pane() {
     assert_eq!(adopted.task, "adopted session");
 }
 
+/// A `ManagedTmuxDriver` whose `get_pane_cwd` fails the first `flaky_for`
+/// calls and succeeds afterwards, counting every call.
+///
+/// Why (#6118 review): every other fixture here fixes `pane_cwd` for its
+/// lifetime, so the case that actually matters — a probe that fails once and
+/// then works — had no coverage at all. That is the case where declining kills
+/// a live pane: `TmuxDriver::pane_current_path` reports spawn failure, a
+/// non-zero exit and empty output all as `None`, and a declined pane is
+/// orphan-GC input.
+/// What: `list_sessions` returns `alive`; `get_pane_cwd` returns `None` for the
+/// first `flaky_for` calls and `Some(pane_cwd)` after, incrementing `calls`
+/// every time. `pane_cwd: None` makes it permanently unresolvable, which is how
+/// the retry BOUND is asserted.
+/// Test: `flaky_cwd_probe_still_adopts_within_one_reconcile`,
+/// `unresolvable_cwd_probe_is_retried_a_bounded_number_of_times`.
+struct FlakyPaneCwdTmux {
+    alive: Vec<String>,
+    pane_cwd: Option<PathBuf>,
+    flaky_for: usize,
+    calls: std::sync::atomic::AtomicUsize,
+    /// What `get_pane_id` reports — `flaky_for: 0` plus a distinct value here
+    /// makes this a plain fixture standing in for a DIFFERENT physical pane
+    /// under a reused tmux name.
+    pane_id: Option<String>,
+}
+
+impl ManagedTmuxDriver for FlakyPaneCwdTmux {
+    fn create_session(
+        &self,
+        _name: &str,
+        _workdir: &str,
+    ) -> Result<(), super::manager::ManagedError> {
+        unimplemented!("not exercised by FlakyPaneCwdTmux tests")
+    }
+    fn kill_session(&self, _name: &str) -> Result<(), super::manager::ManagedError> {
+        unimplemented!("not exercised by FlakyPaneCwdTmux tests")
+    }
+    fn send_line(&self, _name: &str, _text: &str) -> Result<(), super::manager::ManagedError> {
+        unimplemented!("not exercised by FlakyPaneCwdTmux tests")
+    }
+    fn capture(&self, _name: &str, _lines: usize) -> Result<String, super::manager::ManagedError> {
+        unimplemented!("not exercised by FlakyPaneCwdTmux tests")
+    }
+    fn list_sessions(&self) -> Result<Vec<String>, super::manager::ManagedError> {
+        Ok(self.alive.clone())
+    }
+    fn get_pane_cwd(&self, _name: &str) -> Option<PathBuf> {
+        let n = self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        if n < self.flaky_for {
+            return None;
+        }
+        self.pane_cwd.clone()
+    }
+    fn get_pane_id(&self, _name: &str) -> Option<String> {
+        self.pane_id.clone()
+    }
+}
+
+/// #6118 review, CRITICAL: one transient probe failure must not cost a live
+/// pane.
+///
+/// Why: declining hands the pane to the orphan-GC, which kills an idle-shell
+/// pane with no live child after two 60-second sweeps — and `reconcile_on_boot`
+/// runs once per daemon process, so a single flaky `get_pane_cwd` would be that
+/// pane's only hearing until the next daemon restart. The retry in
+/// `resolve_adoptable_cwd` has to close that inside one reconcile pass.
+/// What: a probe that fails once then succeeds; asserts ONE `reconcile_on_boot`
+/// adopts the pane normally — real cwd, real workspace, nothing declined.
+/// Test: this function IS the test.
+#[tokio::test]
+#[serial_test::serial]
+async fn flaky_cwd_probe_still_adopts_within_one_reconcile() {
+    let dir = TempDir::new().unwrap();
+    let workspace = TempDir::new().unwrap();
+    let _home = set_home(dir.path());
+    let fake = std::sync::Arc::new(FlakyPaneCwdTmux {
+        alive: vec!["tm-flaky-01".into()],
+        pane_cwd: Some(workspace.path().to_path_buf()),
+        flaky_for: 1,
+        calls: std::sync::atomic::AtomicUsize::new(0),
+        pane_id: None,
+    });
+
+    let mgr = SessionManager::new(dir.path(), fake.clone()).await.unwrap();
+    let report = mgr.reconcile_on_boot(false).await.expect("reconcile");
+
+    assert!(
+        report.adoption_declined.is_empty(),
+        "a probe that recovers on retry must not be declined; report: {report:?}"
+    );
+    let listed = mgr.list().await;
+    assert_eq!(
+        listed.len(),
+        1,
+        "the pane must be adopted within one reconcile pass: {listed:?}"
+    );
+    assert_eq!(listed[0].tmux_name, "tm-flaky-01");
+    assert_eq!(listed[0].cwd, workspace.path());
+    assert_eq!(listed[0].workspace_path.as_deref(), Some(workspace.path()));
+    assert!(
+        fake.calls.load(std::sync::atomic::Ordering::SeqCst) >= 2,
+        "the first probe must have been retried"
+    );
+}
+
+/// The retry is bounded — a genuinely unresolvable pane is declined, not
+/// probed forever.
+///
+/// Why: the retry exists to survive a flake, not to hang boot on a pane that
+/// will never resolve. Boot holds the store write lock while it runs.
+/// What: a probe that never succeeds; asserts the pane is declined and that
+/// `get_pane_cwd` was called exactly three times (`CWD_PROBE_BACKOFF.len() + 1`).
+/// Test: this function IS the test.
+#[tokio::test]
+#[serial_test::serial]
+async fn unresolvable_cwd_probe_is_retried_a_bounded_number_of_times() {
+    let dir = TempDir::new().unwrap();
+    let _home = set_home(dir.path());
+    let fake = std::sync::Arc::new(FlakyPaneCwdTmux {
+        alive: vec!["tm-never-01".into()],
+        pane_cwd: None,
+        flaky_for: usize::MAX,
+        calls: std::sync::atomic::AtomicUsize::new(0),
+        pane_id: None,
+    });
+
+    let mgr = SessionManager::new(dir.path(), fake.clone()).await.unwrap();
+    let report = mgr.reconcile_on_boot(false).await.expect("reconcile");
+
+    assert_eq!(report.adoption_declined, vec!["tm-never-01".to_string()]);
+    assert_eq!(mgr.list().await.len(), 0);
+    assert_eq!(
+        fake.calls.load(std::sync::atomic::Ordering::SeqCst),
+        3,
+        "the probe must be attempted exactly 3 times, then give up"
+    );
+}
+
 /// #6118: a live pane whose cwd will not resolve is NOT adopted.
 ///
 /// Why: #2158 adopted it as an `Active` record with a `/unknown` cwd and an
@@ -624,6 +762,128 @@ async fn adopting_the_same_pane_twice_writes_one_record() {
         "re-adopting one tmux name must land on the same store key, so two \
          concurrent adopters overwrite each other instead of both surviving"
     );
+}
+
+/// #6117 review: a reused tmux name derives a reused id, so the record written
+/// under it must carry nothing from the pane that held the name before.
+///
+/// Why: a name-derived id is only safe if the id is not a handle onto state
+/// that outlives the record. Adoption can reach a previously-used id only after
+/// the earlier record LEFT the store — a terminal tombstone keeps its name in
+/// the known-name set and blocks re-adoption outright, so the reachable case is
+/// removal (retention, `tm sessions prune`, a manual delete). `decommission`
+/// clears no PID-registry entry and no correlation, so this pins what a
+/// re-adopted record actually sees.
+/// What: adopts `tm-recycled-01`, loads it with per-id residue (correlation,
+/// deliverable, claude session, scrollback, activity), registers a PID under
+/// its derived id, removes the record, then re-adopts the SAME name backed by a
+/// different pane and workspace. Asserts the id is reused, every residual field
+/// is clear, the record tracks the NEW pane, and that adoption neither reads nor
+/// writes the PID registry — `SessionRecord` carries no PID field, so a stale
+/// entry cannot reach it.
+/// Test: this function IS the test.
+#[tokio::test]
+#[serial_test::serial]
+async fn a_reused_adopted_id_carries_no_residual_state() {
+    let dir = TempDir::new().unwrap();
+    let first_ws = TempDir::new().unwrap();
+    let second_ws = TempDir::new().unwrap();
+    let _home = set_home(dir.path());
+
+    let first_pane = std::sync::Arc::new(FlakyPaneCwdTmux {
+        alive: vec!["tm-recycled-01".into()],
+        pane_cwd: Some(first_ws.path().to_path_buf()),
+        flaky_for: 0,
+        calls: std::sync::atomic::AtomicUsize::new(0),
+        pane_id: Some("%11".into()),
+    });
+    let mgr = SessionManager::new(dir.path(), first_pane).await.unwrap();
+    mgr.reconcile_on_boot(false).await.expect("first reconcile");
+
+    let listed = mgr.list().await;
+    assert_eq!(listed.len(), 1);
+    let reused_id = listed[0].id;
+    assert_eq!(
+        reused_id,
+        super::record::ManagedSessionId::for_adopted_tmux_name("tm-recycled-01")
+    );
+
+    // Load the record with every per-id field a later adoption could inherit.
+    {
+        let mut store = mgr.store.write().await;
+        let mut rec = store.get(&reused_id).await.expect("get adopted");
+        rec.deliverable_id = Some(crate::deliverable::record::DeliverableId::new());
+        rec.claude_session_id = Some("claude-abc".into());
+        rec.scrollback_path = Some(dir.path().join("scrollback.log"));
+        rec.last_activity_at = Some(chrono::Utc::now());
+        rec.correlation.branch = Some("feature/old".into());
+        store.upsert(rec).await.expect("seed residue");
+    }
+
+    // A PID recorded under the derived id, the residue `decommission` never
+    // clears. It must stay inert, not become the new record's.
+    let pids = crate::core::pid_registry::PidRegistry::new(dir.path().join("pids"));
+    pids.register(&reused_id.to_string(), 4242)
+        .expect("register pid");
+
+    // Removal is the only path that frees the name for re-adoption.
+    mgr.store
+        .write()
+        .await
+        .remove(&reused_id)
+        .await
+        .expect("remove record");
+
+    // A DIFFERENT physical pane now answers to the same tmux name.
+    let second_pane = std::sync::Arc::new(FlakyPaneCwdTmux {
+        alive: vec!["tm-recycled-01".into()],
+        pane_cwd: Some(second_ws.path().to_path_buf()),
+        flaky_for: 0,
+        calls: std::sync::atomic::AtomicUsize::new(0),
+        pane_id: Some("%22".into()),
+    });
+    let mgr2 = SessionManager::new(dir.path(), second_pane).await.unwrap();
+    mgr2.reconcile_on_boot(false)
+        .await
+        .expect("second reconcile");
+
+    let after = mgr2.list().await;
+    assert_eq!(after.len(), 1, "one record for one pane: {after:?}");
+    let fresh = &after[0];
+    assert_eq!(fresh.id, reused_id, "the derived id is reused by design");
+    assert_eq!(
+        fresh.pane_id.as_deref(),
+        Some("%22"),
+        "the record must track the NEW pane, not the one that held the name"
+    );
+    assert_eq!(fresh.workspace_path.as_deref(), Some(second_ws.path()));
+    assert_eq!(
+        fresh.deliverable_id, None,
+        "deliverable link must not carry over"
+    );
+    assert_eq!(
+        fresh.claude_session_id, None,
+        "claude session must not carry over"
+    );
+    assert_eq!(
+        fresh.scrollback_path, None,
+        "scrollback must not carry over"
+    );
+    assert_eq!(fresh.last_activity_at, None, "activity must not carry over");
+    assert_eq!(
+        fresh.correlation,
+        Default::default(),
+        "correlation must not carry over: {:?}",
+        fresh.correlation
+    );
+
+    // The stale PID entry is untouched by adoption — neither consumed nor
+    // cleared. `SessionRecord` has no PID field, so it cannot reach the record;
+    // reaping it belongs to the PID sweep, not here.
+    let entries = pids.entries().expect("read pid registry");
+    assert_eq!(entries.len(), 1, "adoption must not write PID entries");
+    assert_eq!(entries[0].session_id, reused_id.to_string());
+    assert_eq!(entries[0].pid, 4242);
 }
 
 /// Requirement 3 of the fix: nothing changes for a resolvable pane.

--- a/crates/trusty-mpm/src/session_manager/naming_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/naming_tests.rs
@@ -208,17 +208,26 @@ async fn manager_serial_reuses_decommissioned_gap() {
 /// vulnerable to the orphan-GC).
 /// What: seeds a live `tm-`-prefixed tmux session unknown to the store, runs
 /// reconcile, and asserts it appears in `external_adopted` as `Active`.
+///
+/// #6118: the pane resolves a working directory. Adoption now requires that —
+/// a pane whose cwd will not resolve is declined, covered by
+/// `reconcile_declines_to_adopt_a_pane_whose_cwd_cannot_be_resolved` — so this
+/// test uses [`PaneCwdTmux`] rather than the shared `FakeTmuxDriver`, whose
+/// `get_pane_cwd` is the trait default (`None`).
 /// Test: this function IS the test.
 #[tokio::test]
+#[serial_test::serial]
 async fn manager_reconcile_adopts_new_prefix_session() {
     let dir = TempDir::new().unwrap();
-    let fake = FakeTmuxDriver::new();
-    fake.seeded_names
-        .lock()
-        .unwrap()
-        .push("tm-trusty-tools-01".into());
+    let workspace = TempDir::new().unwrap();
+    // #3965: `#[serial]` + `$HOME` override — see `HomeGuard` above.
+    let _home = set_home(dir.path());
+    let fake = std::sync::Arc::new(PaneCwdTmux {
+        alive: vec!["tm-trusty-tools-01".into()],
+        pane_cwd: Some(workspace.path().to_path_buf()),
+    });
 
-    let mgr = SessionManager::new(dir.path(), fake.clone()).await.unwrap();
+    let mgr = SessionManager::new(dir.path(), fake).await.unwrap();
 
     let report = mgr.reconcile_on_boot(false).await.expect("reconcile");
     assert!(
@@ -309,20 +318,26 @@ async fn reconcile_resolves_adopted_session_cwd_from_pane() {
     assert_eq!(adopted.task, "adopted session");
 }
 
-/// Why (#2158): an adopted session whose pane cwd cannot be resolved (the
-/// driver returns `None`, or resolves to a path that does not exist) must
-/// keep the `/unknown` sentinel AND carry a task string that clearly flags it
-/// as unmanaged — never an indistinguishable-from-normal "adopted session".
+/// #6118: a live pane whose cwd will not resolve is NOT adopted.
+///
+/// Why: #2158 adopted it as an `Active` record with a `/unknown` cwd and an
+/// `unmanaged` note in `task`, and that record could never be retired. The
+/// `tm ls` auto-prune keeps any record whose tmux name is live, and the
+/// orphan-GC keeps any pane a registry names — so the act of adopting the pane
+/// is what made the pane unreapable and the record permanent. 55 of the 103
+/// records in the reporting store were these. Declining hands the pane back to
+/// the orphan-GC, which already knows how to reap an idle one safely.
+/// What: one live pane, `get_pane_cwd` returning `None`; asserts no record was
+/// written, the name is reported in `adoption_declined`, and it is absent from
+/// `external_adopted`.
 /// Test: this function IS the test.
 #[tokio::test]
 #[serial_test::serial]
-async fn reconcile_flags_unresolvable_adopted_session_as_unmanaged() {
+async fn reconcile_declines_to_adopt_a_pane_whose_cwd_cannot_be_resolved() {
     let dir = TempDir::new().unwrap();
-    // #3965: `#[serial]` + `$HOME` override — see `HomeGuard` above. This
-    // particular case never reaches `validate_and_repair` today (an
-    // unresolved pane cwd short-circuits before `newly_resolved` is
-    // populated), but pin `$HOME` anyway so a future refactor of that
-    // short-circuit can't silently reopen the real-`$HOME` write.
+    // #3965: `#[serial]` + `$HOME` override — see `HomeGuard` above. A declined
+    // pane never reaches `validate_and_repair`, but pin `$HOME` anyway so a
+    // future refactor cannot silently reopen the real-`$HOME` write.
     let _home = set_home(dir.path());
     let fake = std::sync::Arc::new(PaneCwdTmux {
         alive: vec!["tm-unresolvable-01".into()],
@@ -330,19 +345,113 @@ async fn reconcile_flags_unresolvable_adopted_session_as_unmanaged() {
     });
 
     let mgr = SessionManager::new(dir.path(), fake).await.unwrap();
+    let report = mgr.reconcile_on_boot(false).await.expect("reconcile");
+
+    assert_eq!(
+        mgr.list().await.len(),
+        0,
+        "a pane with no resolvable cwd must leave no record behind"
+    );
+    assert!(
+        report
+            .adoption_declined
+            .contains(&"tm-unresolvable-01".to_string()),
+        "the declined pane must be named in the report; report: {report:?}"
+    );
+    assert!(
+        report.external_adopted.is_empty(),
+        "nothing was adopted; report: {report:?}"
+    );
+}
+
+/// #6118 + #6117 together: reconciling the same unresolvable pane over and over
+/// never accumulates records.
+///
+/// Why: this is the shape the reporting store was in — a pane re-encountered on
+/// every daemon boot, each pass free to write another row for it. The count
+/// after N passes must be the count after one.
+/// What: three reconcile passes over one unresolvable pane; asserts the store
+/// is still empty and every pass declined it.
+/// Test: this function IS the test.
+#[tokio::test]
+#[serial_test::serial]
+async fn repeated_reconcile_of_one_unresolvable_pane_stays_at_zero_records() {
+    let dir = TempDir::new().unwrap();
+    let _home = set_home(dir.path());
+    let fake = std::sync::Arc::new(PaneCwdTmux {
+        alive: vec!["tm-ghosty-01".into()],
+        pane_cwd: None,
+    });
+
+    let mgr = SessionManager::new(dir.path(), fake).await.unwrap();
+    for pass in 1..=3 {
+        let report = mgr.reconcile_on_boot(false).await.expect("reconcile");
+        assert_eq!(
+            report.adoption_declined,
+            vec!["tm-ghosty-01".to_string()],
+            "pass {pass} must decline the pane; report: {report:?}"
+        );
+        assert_eq!(
+            mgr.list().await.len(),
+            0,
+            "pass {pass} must leave the store empty"
+        );
+    }
+}
+
+/// #6118 reclaim path: a declined pane is one the orphan-GC can reap.
+///
+/// Why: declining adoption is only a fix if something else can then retire the
+/// pane. The orphan-GC's criterion is "managed prefix, absent from BOTH
+/// registries, idle shell, no live child" — and adoption is what used to put
+/// the pane in the managed registry. This asserts the whole chain: after a
+/// reconcile pass that declined it, the pane's name is absent from
+/// `known_tmux_names` (what the GC's protected set is built from), and
+/// `classify_session` returns `ReapCandidate` for an idle `sh` pane.
+/// What: reconcile with an unresolvable pane, feed the resulting
+/// `known_tmux_names` into `TrackedNames::managed`, classify an idle pane.
+/// Test: this function IS the test.
+#[cfg(feature = "daemon")]
+#[tokio::test]
+#[serial_test::serial]
+async fn a_declined_pane_is_reapable_by_the_orphan_gc() {
+    use crate::daemon::orphan_gc::{
+        AlwaysIdleProbe, GcDecision, PaneInfo, TrackedNames, classify_session,
+    };
+
+    let dir = TempDir::new().unwrap();
+    let _home = set_home(dir.path());
+    let fake = std::sync::Arc::new(PaneCwdTmux {
+        alive: vec!["tm-leaked-01".into()],
+        pane_cwd: None,
+    });
+
+    let mgr = SessionManager::new(dir.path(), fake).await.unwrap();
     mgr.reconcile_on_boot(false).await.expect("reconcile");
 
-    let listed = mgr.list().await;
-    let adopted = listed
-        .iter()
-        .find(|r| r.tmux_name == "tm-unresolvable-01")
-        .expect("adopted record present");
-    assert_eq!(adopted.cwd, PathBuf::from("/unknown"));
-    assert!(adopted.workspace_path.is_none());
+    let managed = mgr.known_tmux_names().await.expect("known names");
     assert!(
-        adopted.task.contains("unmanaged"),
-        "task must clearly flag the record as unmanaged, got: {}",
-        adopted.task
+        !managed.contains("tm-leaked-01"),
+        "a declined pane must not be in the orphan-GC's protected set: {managed:?}"
+    );
+
+    let decision = classify_session(
+        &PaneInfo {
+            session_name: "tm-leaked-01".into(),
+            pane_current_command: "sh".into(),
+            pane_pid: None,
+            pane_id: None,
+        },
+        &TrackedNames {
+            managed,
+            ..Default::default()
+        },
+        &AlwaysIdleProbe,
+    );
+    assert_eq!(
+        decision,
+        GcDecision::ReapCandidate,
+        "an idle leaked pane the daemon declined to adopt must be reapable"
     );
 }
 
@@ -437,6 +546,115 @@ async fn reconcile_skips_external_adopt_when_workspace_already_tracked() {
         !listed.iter().any(|r| r.tmux_name == "tm-crossed-01"),
         "no record must carry the crossed tmux_name"
     );
+}
+
+// ── #6117: one adopted record per tmux pane, however often adoption runs ────
+
+/// The adopted id derives from the tmux name, so it is the same every time.
+///
+/// Why: this is the whole mechanism behind #6117. Two adopters that never saw
+/// each other's write must still land on one store key.
+/// Test: this function IS the test.
+#[test]
+fn adopted_id_is_stable_for_one_tmux_name() {
+    let a = super::record::ManagedSessionId::for_adopted_tmux_name("tm-stable-01");
+    let b = super::record::ManagedSessionId::for_adopted_tmux_name("tm-stable-01");
+    assert_eq!(a, b, "the same tmux name must derive the same id");
+}
+
+/// Two different panes still get two different ids.
+///
+/// Why: a name-derived id would be worthless if it collapsed distinct panes.
+/// Test: this function IS the test.
+#[test]
+fn adopted_id_differs_per_tmux_name() {
+    let a = super::record::ManagedSessionId::for_adopted_tmux_name("tm-one-01");
+    let b = super::record::ManagedSessionId::for_adopted_tmux_name("tm-two-01");
+    assert_ne!(a, b, "distinct tmux names must derive distinct ids");
+}
+
+/// #6117 regression: an adopter that never saw the first adopter's record
+/// targets the SAME store key.
+///
+/// Why: `reconcile_on_boot` builds its known-names set once, before the adopt
+/// loop, and a concurrent daemon holds its own copy. Both then see the pane as
+/// unknown, and the store is keyed by id — so a random id per adoption meant
+/// both writes survived. The reporting store carried 11 such pairs, several
+/// written 30-60 ms apart. A single-threaded test cannot stage that
+/// interleaving through the public API, so it asserts the property that makes
+/// the interleaving harmless: whichever adopter writes, and in whatever order,
+/// the record identity for one tmux name is the same one. Pre-fix the second
+/// adoption returns a fresh random id here, which is the assertion that fails.
+/// What: adopts `tm-raced-01`, removes the record so the next pass is as blind
+/// as a concurrent daemon's snapshot, adopts again, and compares ids.
+/// Test: this function IS the test.
+#[tokio::test]
+#[serial_test::serial]
+async fn adopting_the_same_pane_twice_writes_one_record() {
+    let dir = TempDir::new().unwrap();
+    let workspace = TempDir::new().unwrap();
+    let _home = set_home(dir.path());
+    let fake = std::sync::Arc::new(PaneCwdTmux {
+        alive: vec!["tm-raced-01".into()],
+        pane_cwd: Some(workspace.path().to_path_buf()),
+    });
+
+    let mgr = SessionManager::new(dir.path(), fake).await.unwrap();
+    mgr.reconcile_on_boot(false).await.expect("first reconcile");
+    let first = mgr.list().await;
+    assert_eq!(first.len(), 1, "first adoption wrote one record");
+
+    // Blind the second pass exactly as a concurrent adopter's stale snapshot
+    // would: it does not know this pane is already tracked.
+    mgr.store
+        .write()
+        .await
+        .remove(&first[0].id)
+        .await
+        .expect("drop the record the second adopter never saw");
+
+    mgr.reconcile_on_boot(false)
+        .await
+        .expect("second reconcile");
+
+    let after = mgr.list().await;
+    assert_eq!(after.len(), 1, "one pane, one record: {after:?}");
+    assert_eq!(
+        after[0].id, first[0].id,
+        "re-adopting one tmux name must land on the same store key, so two \
+         concurrent adopters overwrite each other instead of both surviving"
+    );
+}
+
+/// Requirement 3 of the fix: nothing changes for a resolvable pane.
+///
+/// Why: the #6118 decline and the #6117 id change both sit in the adopt loop,
+/// so the ordinary path needs a guard that says it still behaves as before —
+/// one record, `Active`, real cwd and workspace, and stable across passes.
+/// Test: this function IS the test.
+#[tokio::test]
+#[serial_test::serial]
+async fn repeated_reconcile_of_one_resolvable_pane_keeps_one_record() {
+    let dir = TempDir::new().unwrap();
+    let workspace = TempDir::new().unwrap();
+    let _home = set_home(dir.path());
+    let fake = std::sync::Arc::new(PaneCwdTmux {
+        alive: vec!["tm-steady-01".into()],
+        pane_cwd: Some(workspace.path().to_path_buf()),
+    });
+
+    let mgr = SessionManager::new(dir.path(), fake).await.unwrap();
+    for _ in 0..3 {
+        mgr.reconcile_on_boot(false).await.expect("reconcile");
+    }
+
+    let listed = mgr.list().await;
+    assert_eq!(listed.len(), 1, "three passes, one record: {listed:?}");
+    assert_eq!(listed[0].tmux_name, "tm-steady-01");
+    assert_eq!(listed[0].state, ManagedSessionState::Active);
+    assert_eq!(listed[0].cwd, workspace.path());
+    assert_eq!(listed[0].workspace_path.as_deref(), Some(workspace.path()));
+    assert_eq!(listed[0].task, "adopted session");
 }
 
 // ── #3692: create-path final safety net + suffixed-length cap ───────────────

--- a/crates/trusty-mpm/src/session_manager/reconcile.rs
+++ b/crates/trusty-mpm/src/session_manager/reconcile.rs
@@ -34,6 +34,17 @@
 //! reasons and this keeps it one — the loop logs the contradiction and the
 //! command that resolves it.
 //!
+//! **The adopt path owes the same hygiene the create path gives.** It did not,
+//! and the two defects that came of that share one shape: the loop decided
+//! from a snapshot instead of from the pane in front of it. It minted a random
+//! id for every name its pre-loop snapshot did not carry, so a second adopter
+//! holding its own stale snapshot wrote a second record for one pane (#6117 —
+//! the id now derives from the tmux name, see
+//! [`ManagedSessionId::for_adopted_tmux_name`]); and it adopted a pane whose
+//! cwd would not resolve, which made that pane permanently unreapable because
+//! being tracked is exactly what the orphan-GC keys on (#6118 — such a pane is
+//! now declined, and reported in [`ReconcileReport::adoption_declined`]).
+//!
 //! Test: `manager_reconcile_gone_tmux_yields_stopped`,
 //! `manager_reconcile_adopts_new_prefix_session` in `tests.rs`;
 //! `reconcile_refuses_to_stop_sessions_when_tmux_cannot_be_observed`,
@@ -60,8 +71,9 @@ impl SessionManager {
     /// or legacy `tmpm-`/`trusty-mpm-`, issue #1955) via
     /// [`crate::core::names::is_managed_session_name`], cross-references
     /// against the store: live → `Active`; gone → `Stopped` (unless already
-    /// `Decommissioned`). External managed sessions unknown to the store are
-    /// adopted as `Active`.
+    /// `Decommissioned`). A managed session unknown to the store is adopted as
+    /// `Active` under an id derived from its tmux name (#6117), and only when
+    /// its pane resolves a working directory (#6118) — see this module's doc.
     /// When `auto_resume` is true, all `Stopped` sessions are immediately resumed.
     ///
     /// When tmux cannot be observed at all, every liveness-derived decision is
@@ -73,7 +85,11 @@ impl SessionManager {
     /// makes its own decision about a tmux it cannot see.
     /// Test: `manager_reconcile_gone_tmux_yields_stopped`,
     /// `manager_reconcile_adopts_new_prefix_session`;
-    /// `reconcile_refuses_to_stop_sessions_when_tmux_cannot_be_observed`.
+    /// `reconcile_refuses_to_stop_sessions_when_tmux_cannot_be_observed`;
+    /// `reconcile_declines_to_adopt_a_pane_whose_cwd_cannot_be_resolved`,
+    /// `repeated_reconcile_of_one_unresolvable_pane_stays_at_zero_records`,
+    /// `a_declined_pane_is_reapable_by_the_orphan_gc`,
+    /// `repeated_reconcile_of_one_resolvable_pane_keeps_one_record`.
     pub async fn reconcile_on_boot(
         &self,
         auto_resume: bool,
@@ -208,97 +224,106 @@ impl SessionManager {
         // cwd/workspace_path permanently stubbed to "/unknown" — re-resolve
         // the pane's real working directory via `get_pane_cwd` (the same
         // primitive the idle-auto-stop snapshot uses) so it can be validated
-        // and provisioned like any other managed workspace; a pane whose cwd
-        // cannot be resolved is left CLEARLY flagged as unmanaged in `task`
-        // rather than an indistinguishable-from-normal "adopted session".
+        // and provisioned like any other managed workspace.
         // #5856: `flatten` yields nothing when liveness was never observed, so
         // an unreachable tmux adopts no external session either.
         let mut newly_resolved: Vec<(ManagedSessionId, PathBuf)> = Vec::new();
         for name in live_names.iter().flatten() {
-            if !known_names.contains(name) {
-                let resolved_cwd = self.tmux.get_pane_cwd(name).filter(|p| p.is_dir());
-                // #3396: a live tmux session unknown BY NAME can still resolve
-                // to a workspace an EXISTING record already tracks — e.g. a
-                // renamed/second tmux session fronting the same worktree.
-                // Minting a second record here is exactly the duplicate-record
-                // defect; skip adoption and surface the crossed mapping loudly
-                // instead so an operator can reconcile the tmux_name drift
-                // (`tm sessions ls`, `tmux list-panes`) rather than the daemon
-                // silently doubling the identity.
-                if let Some(path) = &resolved_cwd {
-                    let canon = std::fs::canonicalize(path).unwrap_or_else(|_| path.clone());
-                    if known_workspaces.contains(&canon) {
-                        warn!(
-                            name = %name,
-                            workspace = %path.display(),
-                            "reconcile: skipping external-adopt — live tmux session resolves to \
-                             a workspace already tracked by another managed session record; its \
-                             tmux_name may be stale/crossed (#3396) — investigate with `tm sessions \
-                             ls` and `tmux list-panes` rather than auto-adopting a duplicate"
-                        );
-                        continue;
-                    }
-                }
-                let (cwd, workspace_path, task) = match &resolved_cwd {
-                    Some(path) => (
-                        path.clone(),
-                        Some(path.clone()),
-                        "adopted session".to_string(),
-                    ),
-                    None => (
-                        PathBuf::from("/unknown"),
-                        None,
-                        "adopted session (unmanaged — workspace path could not be resolved)"
-                            .to_string(),
-                    ),
-                };
-                let id = ManagedSessionId::new();
-                let external = SessionRecord {
-                    id,
-                    tmux_name: name.clone(),
-                    cwd,
-                    task,
-                    state: ManagedSessionState::Active,
-                    created_at: Utc::now(),
-                    last_activity_at: None,
-                    workspace_path,
-                    repo_url: None,
-                    branch: None,
-                    pending_decision: None,
-                    proposed_default: None,
-                    correlation: Default::default(),
-                    // Externally-created tmux sessions have unknown provenance;
-                    // assume the default (claude-code) backend.
-                    runtime: crate::runtime::RuntimeKind::default(),
-                    // Adopted external sessions are NEVER ephemeral: their
-                    // provenance is unknown, so they must never be auto-reaped.
-                    ephemeral: false,
-                    // Externally-adopted sessions are NEVER SM-owned — the SM
-                    // did not create the workspace; decommission must not delete
-                    // it (#1511).
-                    workspace_owned: false,
-                    // External sessions have no tracked source project.
-                    source_id: None,
-                    claude_session_id: None,
-                    scrollback_path: None,
-                    last_cwd: None,
-                    // External sessions have no known Deliverable linkage.
-                    deliverable_id: None,
-                    // Best-effort capture (#2453 review finding 1, round 2) —
-                    // the adopted pane already exists, so this is available
-                    // immediately, mirroring `adopt.rs`'s explicit adoption path.
-                    pane_id: self.tmux.get_pane_id(name),
-                    injection_status: Default::default(),
-                    worktree_owner: None,
-                    terminal_at: None,
-                };
-                if let Some(path) = resolved_cwd {
-                    newly_resolved.push((id, path));
-                }
-                guard.upsert(external).await?;
-                report.external_adopted.push(name.clone());
-                info!(name = %name, "reconcile: adopted external managed session");
+            if known_names.contains(name) {
+                continue;
             }
+            // #6118: a pane whose cwd will not resolve is NOT adopted. #2158
+            // adopted it anyway, flagged `unmanaged` in `task` with a
+            // `/unknown` cwd, and that record was unkillable by design: the
+            // `tm ls` auto-prune keeps any record whose tmux name is live, and
+            // the orphan-GC keeps any pane a registry names — so adoption
+            // itself is what granted a leaked idle `sh` pane permanent
+            // immunity. 55 of 103 records in the reporting store were these.
+            // Declining leaves the pane untracked, which is exactly the input
+            // `daemon::orphan_gc` exists to handle: it reaps a managed-prefix
+            // pane only when it is idle, has no live child process, and has
+            // been seen idle on two consecutive sweeps, and it KEEPS (warns
+            // about) one still running an agent. Nothing here kills anything.
+            let Some(resolved_cwd) = self.tmux.get_pane_cwd(name).filter(|p| p.is_dir()) else {
+                warn!(
+                    name = %name,
+                    "reconcile: declining external-adopt — the pane's working directory could \
+                     not be resolved, so there is nothing to track, resume or attach to (#6118). \
+                     The pane is left to the orphan-GC, which reaps it only if it is an idle \
+                     shell on two consecutive sweeps; `tmux attach -t <name>` still reaches it"
+                );
+                report.adoption_declined.push(name.clone());
+                continue;
+            };
+            // #3396: a live tmux session unknown BY NAME can still resolve
+            // to a workspace an EXISTING record already tracks — e.g. a
+            // renamed/second tmux session fronting the same worktree.
+            // Minting a second record here is exactly the duplicate-record
+            // defect; skip adoption and surface the crossed mapping loudly
+            // instead so an operator can reconcile the tmux_name drift
+            // (`tm sessions ls`, `tmux list-panes`) rather than the daemon
+            // silently doubling the identity.
+            let canon =
+                std::fs::canonicalize(&resolved_cwd).unwrap_or_else(|_| resolved_cwd.clone());
+            if known_workspaces.contains(&canon) {
+                warn!(
+                    name = %name,
+                    workspace = %resolved_cwd.display(),
+                    "reconcile: skipping external-adopt — live tmux session resolves to \
+                     a workspace already tracked by another managed session record; its \
+                     tmux_name may be stale/crossed (#3396) — investigate with `tm sessions \
+                     ls` and `tmux list-panes` rather than auto-adopting a duplicate"
+                );
+                continue;
+            }
+            // #6117: derived from the tmux name, never random — `known_names`
+            // is a pre-loop snapshot, and a concurrent adopter holding its own
+            // stale copy would otherwise write a SECOND record for this pane
+            // under a fresh id. Same name, same store key, one record.
+            let id = ManagedSessionId::for_adopted_tmux_name(name);
+            let external = SessionRecord {
+                id,
+                tmux_name: name.clone(),
+                cwd: resolved_cwd.clone(),
+                task: "adopted session".to_string(),
+                state: ManagedSessionState::Active,
+                created_at: Utc::now(),
+                last_activity_at: None,
+                workspace_path: Some(resolved_cwd.clone()),
+                repo_url: None,
+                branch: None,
+                pending_decision: None,
+                proposed_default: None,
+                correlation: Default::default(),
+                // Externally-created tmux sessions have unknown provenance;
+                // assume the default (claude-code) backend.
+                runtime: crate::runtime::RuntimeKind::default(),
+                // Adopted external sessions are NEVER ephemeral: their
+                // provenance is unknown, so they must never be auto-reaped.
+                ephemeral: false,
+                // Externally-adopted sessions are NEVER SM-owned — the SM
+                // did not create the workspace; decommission must not delete
+                // it (#1511).
+                workspace_owned: false,
+                // External sessions have no tracked source project.
+                source_id: None,
+                claude_session_id: None,
+                scrollback_path: None,
+                last_cwd: None,
+                // External sessions have no known Deliverable linkage.
+                deliverable_id: None,
+                // Best-effort capture (#2453 review finding 1, round 2) —
+                // the adopted pane already exists, so this is available
+                // immediately, mirroring `adopt.rs`'s explicit adoption path.
+                pane_id: self.tmux.get_pane_id(name),
+                injection_status: Default::default(),
+                worktree_owner: None,
+                terminal_at: None,
+            };
+            newly_resolved.push((id, resolved_cwd));
+            guard.upsert(external).await?;
+            report.external_adopted.push(name.clone());
+            info!(name = %name, "reconcile: adopted external managed session");
         }
 
         // Release write guard before auto-resume (which needs its own locks).

--- a/crates/trusty-mpm/src/session_manager/reconcile.rs
+++ b/crates/trusty-mpm/src/session_manager/reconcile.rs
@@ -45,6 +45,12 @@
 //! being tracked is exactly what the orphan-GC keys on (#6118 — such a pane is
 //! now declined, and reported in [`ReconcileReport::adoption_declined`]).
 //!
+//! **Declining is a kill decision, so the probe behind it retries.** An
+//! undeclared pane is orphan-GC input, and that GC kills an idle-shell pane
+//! with no live child after two sweeps. See
+//! [`super::adopt::resolve_adoptable_cwd`] for why the retry lives inside the
+//! single boot observation rather than across two of them.
+//!
 //! Test: `manager_reconcile_gone_tmux_yields_stopped`,
 //! `manager_reconcile_adopts_new_prefix_session` in `tests.rs`;
 //! `reconcile_refuses_to_stop_sessions_when_tmux_cannot_be_observed`,
@@ -239,18 +245,22 @@ impl SessionManager {
             // the orphan-GC keeps any pane a registry names — so adoption
             // itself is what granted a leaked idle `sh` pane permanent
             // immunity. 55 of 103 records in the reporting store were these.
-            // Declining leaves the pane untracked, which is exactly the input
-            // `daemon::orphan_gc` exists to handle: it reaps a managed-prefix
-            // pane only when it is idle, has no live child process, and has
-            // been seen idle on two consecutive sweeps, and it KEEPS (warns
-            // about) one still running an agent. Nothing here kills anything.
-            let Some(resolved_cwd) = self.tmux.get_pane_cwd(name).filter(|p| p.is_dir()) else {
+            //
+            // Declining leaves the pane untracked, which hands it to
+            // `daemon::orphan_gc`. That is a reap path, not a no-op: an idle
+            // shell with no live child is KILLED after two 60-second sweeps
+            // (a pane running an agent is kept and warned about instead). The
+            // probe therefore decides a pane's life, which is why
+            // `resolve_adoptable_cwd` retries a failed one — see its doc.
+            let Some(resolved_cwd) = super::adopt::resolve_adoptable_cwd(&*self.tmux, name).await
+            else {
                 warn!(
                     name = %name,
-                    "reconcile: declining external-adopt — the pane's working directory could \
-                     not be resolved, so there is nothing to track, resume or attach to (#6118). \
-                     The pane is left to the orphan-GC, which reaps it only if it is an idle \
-                     shell on two consecutive sweeps; `tmux attach -t <name>` still reaches it"
+                    "reconcile: declining external-adopt — the pane's working directory did not \
+                     resolve on any attempt, so there is nothing to track, resume or attach to \
+                     (#6118). The pane is left to the orphan-GC, which kills it only if it is an \
+                     idle shell with no live child on two consecutive sweeps; `tmux attach -t \
+                     <name>` still reaches it until then"
                 );
                 report.adoption_declined.push(name.clone());
                 continue;

--- a/crates/trusty-mpm/src/session_manager/record.rs
+++ b/crates/trusty-mpm/src/session_manager/record.rs
@@ -40,6 +40,34 @@ impl ManagedSessionId {
         Self(Uuid::new_v4())
     }
 
+    /// Derive the id boot reconciliation adopts a live tmux pane under (#6117).
+    ///
+    /// Why: the external-adopt loop used to mint `new()` for every pane its
+    /// snapshot of the store did not name. That snapshot is taken once, before
+    /// the loop, and a second daemon (or a second pass racing the first) holds
+    /// its own — so two adopters of one pane each saw the name as unknown and
+    /// each wrote a record under a fresh random id. The store is keyed by id,
+    /// so both survived: 11 tmux names carried two records apiece in the
+    /// reporting store, several pairs written 30-60 ms apart. Deriving the id
+    /// from the tmux name instead makes the second write land on the SAME key
+    /// as the first, so the store collapses the pair to one record without any
+    /// cross-process locking. Re-adoption is then idempotent by construction,
+    /// not by whichever snapshot happened to be fresh.
+    /// What: UUIDv5 of `name` under a fixed namespace — same name, same id,
+    /// forever, on every machine. Random `new()` stays the constructor for
+    /// every path that mints a genuinely new session.
+    /// Test: `adopted_id_is_stable_for_one_tmux_name`,
+    /// `adopted_id_differs_per_tmux_name`,
+    /// `adopting_the_same_pane_twice_writes_one_record` in `naming_tests.rs`.
+    pub fn for_adopted_tmux_name(name: &str) -> Self {
+        /// Fixed UUIDv5 namespace for reconciliation-adopted tmux panes.
+        /// Never change it: the value IS the identity of every already-adopted
+        /// record, so a new namespace re-mints them all as duplicates.
+        const ADOPTED_PANE_NAMESPACE: Uuid =
+            Uuid::from_u128(0xe23a_84ff_432c_4007_a690_e7d4_43ba_2050);
+        Self(Uuid::new_v5(&ADOPTED_PANE_NAMESPACE, name.as_bytes()))
+    }
+
     /// Return the inner UUID value.
     ///
     /// Why: some callers (e.g. name derivation via `name_from_uuid`) need the


### PR DESCRIPTION
Both defects live in `reconcile_on_boot`'s external-adopt loop, and both come from the same thing: the loop decides from a snapshot of store names taken once, before the loop, instead of from the pane in front of it.

## #6117 — one pane, two records

A second adopter holding its own copy of that snapshot sees a pane as unknown and writes a second record for it under a fresh `ManagedSessionId::new()`. The store is keyed by id, so both writes survive. The reporting store carried 11 tmux names with two records apiece, several pairs written 30-60 ms apart — including a pair whose cwd *did* resolve, so #3396's collision guard is not the whole story either: `known_workspaces` is the same stale snapshot.

The adopted id now derives from the tmux name (`ManagedSessionId::for_adopted_tmux_name`, UUIDv5 under a fixed namespace). Whoever writes, in whatever order, both writes target one store key. That closes the race without cross-process locking, which the store has none of.

## #6118 — the disposition, and why

**Chosen: refuse to adopt a pane whose cwd cannot be resolved.**

Adopting it was what made it permanent. `tm ls`'s auto-prune keeps any record whose tmux name is live (`is_clearable_state`'s `live_tmux_names` guard), and `orphan_gc::classify_session` keeps any pane a registry names (`KeepReason::TrackedManaged`, built from `known_tmux_names`, which deliberately includes tombstones). A leaked idle `sh` pane with a record satisfies both keeps at once, so neither machine can act — 55 of the 103 records in the reporting store were these.

The alternative — adopt into a distinct prunable state — does not break that cycle. The pane is alive, so the auto-prune still refuses on `live_tmux_names` no matter what state the record is in. Only removing the record frees the pane, and only freeing the pane lets the record die.

Declining leaves the pane untracked, which hands it to the orphan-GC. **Correcting this PR's earlier claim that "nothing in this change kills anything": that is wrong.** The orphan-GC is a reap path. `run_sweep` calls `kill_session` on any managed-prefix pane that is an idle shell (`is_idle_shell`), has no live child process, and was a candidate on two consecutive 60-second sweeps. A pane running an agent gets `WarnUntrackedActive` and is kept. So declining does not kill the pane, but it does move the pane into the set the GC may kill, and that is the honest description.

Which makes the cwd probe a kill decision, and it was not built as one. `TmuxDriver::pane_current_path` (`daemon/tmux.rs:657`) is a single `tmux display-message` spawn that collapses a failed spawn, a non-zero exit, and empty output into one `None` with no retry. `reconcile_on_boot` runs exactly once per daemon process — a `OnceCell::get_or_init` in `daemon/state/core.rs:781`. So one transient probe failure was a live pane's only hearing, and the GC could reach it 60-120 seconds later.

`session_manager::adopt::resolve_adoptable_cwd` now asks three times, with a 50 ms then 150 ms backoff, and declines only if every attempt fails.

**Why the retry rather than the two-observation debounce.** A cross-boot debounce cannot protect the pane. It is untracked from the moment of the first decline, so the GC reaches it within two sweeps while the second observation waits on a daemon restart that may be days away. Holding the observation by adopting provisionally instead just recreates the #6118 ghost for that whole window. The retry closes the gap inside the single observation that actually exists. It is bounded — a genuinely unresolvable pane costs 200 ms once, at boot, and `unresolvable_cwd_probe_is_retried_a_bounded_number_of_times` pins the attempt count at three.

`tmux attach -t <name>` still reaches a declined pane; what it loses is a `tm ls` row that carried a `/unknown` cwd and could not be resumed or attached through the record anyway.

Declined names go into `ReconcileReport::adoption_declined`, and the daemon's boot summary (`daemon/state/core.rs:818`) logs the count and fires on it — without that second half a boot whose only finding was declined panes printed nothing at all, so the visibility this PR promised was half-wired.

No sweep of existing records is included, per #6118. Note for whoever runs that cleanup: a cwd-less ghost is *already* auto-prune-eligible once its pane dies — `cwd` is `/unknown`, which `workdir_candidates` puts on the wire, and `workspace_verified_gone` returns true for it. The 11 still-Active ghosts are blocked only by their live panes.

## Gates — rung 5

| Command | Result |
|---|---|
| `cargo fmt --check` | clean |
| `cargo check -p trusty-mpm --all-targets` | EXIT=0 |
| `cargo clippy -p trusty-mpm --all-targets -- -D warnings` | EXIT=0 |
| `cargo test -p trusty-mpm` | `5208 passed; 0 failed; 7 ignored` (lib) + 49 further targets, all ok |
| `cargo check --workspace --all-targets` | EXIT=0 |
| `bash scripts/check_line_cap.sh` | `4127 files, 0 violations` |
| `bash scripts/check_changelog_fragment.sh` | `all 1 crate(s) with source changes are recorded` |
| `bash scripts/check_sld.sh` | `0 error(s), 0 warning(s)` |

`cargo test -p trusty-mpm --test session_manager_mvp -- --include-ignored` (rung 5's failure-path coverage) is **29 passed, 1 failed** — `live_pane_scoped_send_targets_original_pane_not_sibling`, on a baseline failure this branch did not cause:

```
tmux must be installed for this live test: Protocol("tmux access refused: $HOME is
/var/folders/.../T/.tmpU3DTs0 but this user's real home is /Users/masa — ... (#5784).
Set TRUSTY_MPM_ALLOW_HOST_STATE=1 to allow it.")
```

A sibling `#[serial]` test's `$HOME` override leaks into it and the #5784 host-state guard then refuses tmux. Reproduced identically on `origin/main` with the branch stashed (same test, same message, different `TempDir` path), so it is pre-existing, not a regression here. It has no canonical issue — search on the test name, the panic text, and `TRUSTY_MPM_ALLOW_HOST_STATE` returns nothing.

## Regression evidence

Four of the six new tests fail against the pre-fix behavior. Verified by temporarily restoring the old adopt loop (random id, `/unknown` fallback) and re-running:

```
test reconcile_declines_to_adopt_a_pane_whose_cwd_cannot_be_resolved ... FAILED
  assertion `left == right` failed: a pane with no resolvable cwd must leave no record behind
test repeated_reconcile_of_one_unresolvable_pane_stays_at_zero_records ... FAILED
  pass 1 must decline the pane; report: ReconcileReport { external_adopted: ["tm-ghosty-01"], adoption_declined: [] }
test a_declined_pane_is_reapable_by_the_orphan_gc ... FAILED
test adopting_the_same_pane_twice_writes_one_record ... FAILED
  assertion `left == right` failed: re-adopting one tmux name must land on the same store key
test result: FAILED. 10 passed; 4 failed
```

And on this branch:

```
test session_manager::naming_tests::adopted_id_is_stable_for_one_tmux_name ... ok
test session_manager::naming_tests::adopted_id_differs_per_tmux_name ... ok
test session_manager::naming_tests::adopting_the_same_pane_twice_writes_one_record ... ok
test session_manager::naming_tests::reconcile_declines_to_adopt_a_pane_whose_cwd_cannot_be_resolved ... ok
test session_manager::naming_tests::repeated_reconcile_of_one_unresolvable_pane_stays_at_zero_records ... ok
test session_manager::naming_tests::a_declined_pane_is_reapable_by_the_orphan_gc ... ok
test session_manager::naming_tests::repeated_reconcile_of_one_resolvable_pane_keeps_one_record ... ok
test session_manager::naming_tests::reconcile_resolves_adopted_session_cwd_from_pane ... ok
test session_manager::naming_tests::manager_reconcile_adopts_new_prefix_session ... ok
test session_manager::naming_tests::reconcile_skips_external_adopt_when_workspace_already_tracked ... ok
```

`repeated_reconcile_of_one_resolvable_pane_keeps_one_record` passes both before and after by design — it is the guard on the unchanged path (one record, `Active`, real cwd and workspace, `task: "adopted session"`, stable across three passes).

Two existing tests changed:

- `reconcile_flags_unresolvable_adopted_session_as_unmanaged` pinned the ghost this PR removes. It is replaced by `reconcile_declines_to_adopt_a_pane_whose_cwd_cannot_be_resolved`.
- `manager_reconcile_adopts_new_prefix_session` (#1955 prefix recognition) drove `FakeTmuxDriver`, whose `get_pane_cwd` is the trait default `None`. It now uses `PaneCwdTmux` with a real temp dir, so it still tests prefix recognition rather than accidentally testing the decline path.

All tests use the crate's isolated drivers; none spawns real tmux. `managed_tests.rs` and `tests_behavior_d_tests.rs` are untouched (#6116 is in flight there).


### Review round 2 — the two new tests

Both were added because the critic named cases no existing fixture covered.

`flaky_cwd_probe_still_adopts_within_one_reconcile` — a `FlakyPaneCwdTmux` whose `get_pane_cwd` returns `None` on the first call and the real directory afterwards, counting calls. Every other fixture here fixes `pane_cwd` for its lifetime, so the transient-failure case had no coverage. It asserts one `reconcile_on_boot` adopts the pane normally and nothing is declined.

`a_reused_adopted_id_carries_no_residual_state` — adopts `tm-recycled-01`, loads the record with per-id residue (correlation branch, deliverable id, claude session id, scrollback path, last activity), registers a PID under the derived id, removes the record, then re-adopts the same name backed by a different pane (`%22`) and workspace. Asserts the id is reused, every residual field is clear, the record tracks the new pane, and the stale PID entry is untouched — `SessionRecord` has no PID field, so a registry entry cannot reach it, and reaping it belongs to the PID sweep. Removal is the only path that reaches id reuse at all: a terminal tombstone keeps its name in the known-name set and blocks re-adoption outright.

Both fail without the retry, verified by shortening `CWD_PROBE_BACKOFF` to an empty array (one attempt):

```
test flaky_cwd_probe_still_adopts_within_one_reconcile ... FAILED
test unresolvable_cwd_probe_is_retried_a_bounded_number_of_times ... FAILED
  assertion `left == right` failed: the probe must be attempted exactly 3 times, then give up
test result: FAILED. 15 passed; 2 failed
```

Round-2 run on the branch, all 17 in the module:

```
test session_manager::naming_tests::flaky_cwd_probe_still_adopts_within_one_reconcile ... ok
test session_manager::naming_tests::unresolvable_cwd_probe_is_retried_a_bounded_number_of_times ... ok
test session_manager::naming_tests::a_reused_adopted_id_carries_no_residual_state ... ok
test session_manager::naming_tests::reconcile_declines_to_adopt_a_pane_whose_cwd_cannot_be_resolved ... ok
test session_manager::naming_tests::repeated_reconcile_of_one_unresolvable_pane_stays_at_zero_records ... ok
test session_manager::naming_tests::a_declined_pane_is_reapable_by_the_orphan_gc ... ok
test session_manager::naming_tests::adopting_the_same_pane_twice_writes_one_record ... ok
test session_manager::naming_tests::adopted_id_is_stable_for_one_tmux_name ... ok
test session_manager::naming_tests::adopted_id_differs_per_tmux_name ... ok
test session_manager::naming_tests::repeated_reconcile_of_one_resolvable_pane_keeps_one_record ... ok
test session_manager::naming_tests::reconcile_resolves_adopted_session_cwd_from_pane ... ok
test session_manager::naming_tests::manager_reconcile_adopts_new_prefix_session ... ok
test session_manager::naming_tests::reconcile_skips_external_adopt_when_workspace_already_tracked ... ok
test result: ok. 17 passed; 0 failed; 0 ignored; 0 measured; 5198 filtered out; finished in 4.28s
```

Refs #6117
Refs #6118

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
