### PR TITLE
feat: audit renders carry their provider in the manifest (Refs #6135)

### DIFF
--- a/crates/trusty-audit/README.md
+++ b/crates/trusty-audit/README.md
@@ -486,6 +486,36 @@ what it does **not** carry: it is written once, after the sweep completes, and
 records the *configured* repository set — not per-repo or per-phase completion.
 Run progress is a separate record this crate will own (#5494).
 
+## Writing the inference identity into the manifest (#6135)
+
+After each repository's child finishes, the sweep writes what it selected into
+that repository's manifest:
+
+```toml
+[inference]
+provider   = "openrouter"
+reviewer   = "anthropic/claude-opus-4.8"
+verifier   = "anthropic/claude-haiku-4.5"
+summarizer = "anthropic/claude-haiku-4.5"
+```
+
+`trusty-review report --manifest` resolves provider and models from this section
+**ahead of** the host's `~/.config/trusty-review/config.toml` — precedence is
+CLI flag > manifest > environment > local config > default. That is what makes
+`trusty-audit render` on a recipient's machine reproduce the provider the
+engagement ran on rather than whatever that machine happens to be pinned to.
+
+The same values still go to the child as `TRUSTY_REVIEW_*` environment
+variables. The manifest is authoritative when present; the variables remain for
+a renderer too old to read the section.
+
+The section carries **identity, never a credential** — the same boundary as
+Credentials above. The key travels in the environment and nowhere else, and a
+render whose declared provider has no credential stops with the provider named.
+
+`index.md` states the same selection for the whole directory, beside the tool
+versions, and every report states its own on the page and in its JSON twin.
+
 ## Development
 
 ```bash

--- a/crates/trusty-audit/changelog.d/6082-attributed-only-and-kg-lane.md
+++ b/crates/trusty-audit/changelog.d/6082-attributed-only-and-kg-lane.md
@@ -1,6 +1,2 @@
 Added
 - The manifest declares `[report].attributed_only = true` when the search leg produced per-dimension evidence. trusty-review then reads only the declared ranking instead of topping the file budget up with path-name heuristics. On every degraded path — no index, a dead daemon, a complexity-only ranking — the key is not written and the existing gap line names why.
-
-Changed
-- A search hit that the knowledge graph reached, rather than the query text, now says so in its reason: `via knowledge-graph expansion`. trusty-search labels the lane itself (`match_reason: "hybrid+kg"`); the evidence leg now reads that label instead of discarding it, so the report can distinguish "this file mentions credentials" from "this file is one call hop from the credential handler".
-- The evidence queries pin `expand_graph: true` explicitly. It is already the daemon's default, so behaviour is unchanged — the pin keeps a future default flip from silently dropping relationship evidence from every audit.

--- a/crates/trusty-audit/changelog.d/6082-kg-lane-and-graph-pin.md
+++ b/crates/trusty-audit/changelog.d/6082-kg-lane-and-graph-pin.md
@@ -1,0 +1,3 @@
+Changed
+- A search hit that the knowledge graph reached, rather than the query text, now says so in its reason: `via knowledge-graph expansion`. trusty-search labels the lane itself (`match_reason: "hybrid+kg"`); the evidence leg now reads that label instead of discarding it, so the report can distinguish "this file mentions credentials" from "this file is one call hop from the credential handler".
+- The evidence queries pin `expand_graph: true` explicitly. It is already the daemon's default, so behaviour is unchanged — the pin keeps a future default flip from silently dropping relationship evidence from every audit.

--- a/crates/trusty-audit/changelog.d/6135-provider-from-manifest.md
+++ b/crates/trusty-audit/changelog.d/6135-provider-from-manifest.md
@@ -1,0 +1,18 @@
+Added
+
+- The sweep writes the run's inference identity — provider plus the three role
+  model ids — into each repository's `manifest.toml` as an `[inference]` table,
+  beside the ranking it already writes there. `trusty-review` resolves from that
+  section ahead of the host's own config, so `trusty-audit render` on a
+  recipient's machine reproduces the provider the engagement ran on instead of
+  inheriting whatever that machine is pinned to (owner ruling 2026-08-21: "In
+  audit mode, trusty review should use the same provider as audit to make it
+  portable. From the manifest."). The same values still go to the child as
+  `TRUSTY_REVIEW_*` variables; the manifest is authoritative when present. The
+  section carries identity and never a credential — the key stays in the
+  environment. A manifest that cannot be written is a named gap, not a failed
+  repository, exactly as a ranking that cannot be written is.
+- `index.md` gains an Inference section stating which provider and models
+  produced the reports in that directory, and which layer selected them. A
+  re-render reads it from the manifests it renders, since those outrank anything
+  the run itself injects.

--- a/crates/trusty-audit/src/index_report.rs
+++ b/crates/trusty-audit/src/index_report.rs
@@ -115,6 +115,66 @@ impl ToolVersion {
     }
 }
 
+/// Which models produced the reports in this directory (#6135).
+///
+/// Why: owner ruling 2026-08-21 — "The report should include which models are
+/// used." The index states it beside the tool versions for the same reason it
+/// states those: a reader opening a delivered directory can otherwise not tell
+/// what judged the code. It is the run-level half of the attribution; each
+/// report states its own on the page and in its JSON twin.
+/// What: the provider, the three role model ids, and the layer they came from —
+/// a manifest that declares its own outranks anything the run would inject, so
+/// `source` is what tells a reader which of the two they are looking at.
+/// Test: `super::index_tests::the_index_states_which_models_rendered`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct InferenceRecord {
+    /// Provider id — `openrouter` unless the engagement pinned another.
+    pub provider: String,
+    /// Reviewer role model id.
+    pub reviewer: String,
+    /// Verifier role model id.
+    pub verifier: String,
+    /// Summarizer role model id.
+    pub summarizer: String,
+    /// The layer that selected them.
+    pub source: String,
+}
+
+impl InferenceRecord {
+    /// The record a resolved [`crate::inference::Selection`] states.
+    #[must_use]
+    pub fn of(selection: &crate::inference::Selection) -> Self {
+        Self {
+            provider: selection.provider.clone(),
+            reviewer: selection.reviewer.clone(),
+            verifier: selection.verifier.clone(),
+            summarizer: selection.summarizer.clone(),
+            source: selection.source.to_owned(),
+        }
+    }
+
+    /// The record a manifest declares, when it declares a whole one.
+    ///
+    /// A partially-declared section is reported as far as it goes: the
+    /// undeclared roles resolve through `trusty-review`'s own layers, and
+    /// "not declared" is the honest cell for them.
+    #[must_use]
+    pub fn declared(section: &crate::manifest::InferenceSection) -> Self {
+        let or_absent = |v: &Option<String>| {
+            v.clone()
+                .unwrap_or_else(|| "not declared — resolved by the renderer".to_owned())
+        };
+        Self {
+            provider: or_absent(&section.provider),
+            reviewer: or_absent(&section.reviewer),
+            verifier: or_absent(&section.verifier),
+            summarizer: or_absent(&section.summarizer),
+            source: "the manifest's [inference] section".to_owned(),
+        }
+    }
+}
+
 /// One unit of work the run drove, and what it left behind.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
@@ -162,6 +222,12 @@ pub struct IndexReport {
     pub generated_at: String,
     /// The tools responsible, in the order they are worth reading.
     pub tools: Vec<ToolVersion>,
+    /// Which models produced these reports (#6135).
+    ///
+    /// `None` when this run selected nothing — no credential, so no report was
+    /// rendered by any model — and the section then says so rather than being
+    /// omitted, for the same reason an unknown tool version is stated.
+    pub inference: Option<InferenceRecord>,
     /// One entry per unit the run drove, in the run's own order.
     pub entries: Vec<IndexEntry>,
     /// Wall clock around the whole run.
@@ -259,6 +325,7 @@ pub fn render(report: &IndexReport, dir: &Path) -> String {
     );
     summary(report, &mut out);
     versions(report, &mut out);
+    inference(report, &mut out);
     timings(report, &mut out);
     reports(report, dir, &mut out);
     contents(report.producer, &mut out);
@@ -309,6 +376,28 @@ fn versions(report: &IndexReport, out: &mut String) {
         "\n`trusty-audit` bakes no build-time git metadata, so its git revision is \
          **not recorded** — the version above is what it was compiled at.\n\n",
     );
+}
+
+/// Which models judged the code in this directory (#6135).
+fn inference(report: &IndexReport, out: &mut String) {
+    out.push_str("## Inference\n\n");
+    let Some(record) = &report.inference else {
+        out.push_str(
+            "Not recorded — this run selected no model, so nothing here was produced by \
+             inference.\n\n",
+        );
+        return;
+    };
+    out.push_str("| role | model |\n| --- | --- |\n");
+    out.push_str(&format!("| provider | `{}` |\n", record.provider));
+    out.push_str(&format!("| reviewer | `{}` |\n", record.reviewer));
+    out.push_str(&format!("| verifier | `{}` |\n", record.verifier));
+    out.push_str(&format!("| summarizer | `{}` |\n", record.summarizer));
+    out.push_str(&format!(
+        "\nSelected from {}. Each report states the same selection in its own metadata section \
+         and JSON twin, including any model id the renderer adjusted.\n\n",
+        record.source
+    ));
 }
 
 /// How long each piece took, and what that measurement covers.
@@ -642,6 +731,7 @@ pub fn recorded_tools(work: &crate::workdir::WorkDir) -> Vec<ToolVersion> {
 pub fn write_sweep(
     work: &crate::workdir::WorkDir,
     report: &crate::run::RunReport,
+    inference: Option<&crate::inference::Selection>,
     total: Duration,
 ) -> Result<(), AuditError> {
     let tools = recorded_tools(work);
@@ -665,6 +755,8 @@ pub fn write_sweep(
         producer: Producer::Sweep,
         generated_at: local_now(),
         tools,
+        // #6135: what judged the code, stated beside what ran it.
+        inference: inference.map(InferenceRecord::of),
         entries,
         total: Some(total),
     };
@@ -690,6 +782,7 @@ pub fn write_render(
     out_dir: &Path,
     review: &Path,
     version: Option<&str>,
+    inference: Option<InferenceRecord>,
     reports: &[crate::rerender::RenderedReport],
     total: Duration,
 ) -> Result<(), AuditError> {
@@ -726,6 +819,7 @@ pub fn write_render(
             review_version,
             ToolVersion::unknown("tga", "not recorded — a re-render runs no `tga`"),
         ],
+        inference,
         entries,
         total: Some(total),
     };
@@ -759,6 +853,7 @@ mod index_tests {
                 "2.9.4".to_owned(),
                 "recorded at install",
             )],
+            inference: None,
             entries,
             total: Some(Duration::from_secs(3_723)),
         }
@@ -788,6 +883,40 @@ mod index_tests {
         assert!(
             text.contains("[00-acme-api/00-acme-api.md](00-acme-api/00-acme-api.md)"),
             "the one report must be linked relatively: {text}"
+        );
+    }
+
+    /// Why: #6135, owner ruling 2026-08-21 — "The report should include which
+    /// models are used." The index is where a recipient sees it for the whole
+    /// directory, beside the tool versions.
+    /// What: renders an index with a record and one without, and asserts both
+    /// state something rather than one of them being silently shorter.
+    /// Test: this test itself.
+    #[test]
+    fn the_index_states_which_models_rendered() {
+        let mut index = report(Producer::Sweep, Vec::new());
+        index.inference = Some(InferenceRecord {
+            provider: "openrouter".to_owned(),
+            reviewer: "anthropic/claude-opus-4.8".to_owned(),
+            verifier: "anthropic/claude-haiku-4.5".to_owned(),
+            summarizer: "anthropic/claude-haiku-4.5".to_owned(),
+            source: "the manifest's [inference] section".to_owned(),
+        });
+        let text = render(&index, Path::new("out"));
+        assert!(text.contains("## Inference"), "{text}");
+        assert!(
+            text.contains("| reviewer | `anthropic/claude-opus-4.8` |"),
+            "{text}"
+        );
+        assert!(
+            text.contains("the manifest's [inference] section"),
+            "{text}"
+        );
+
+        let none = render(&report(Producer::Sweep, Vec::new()), Path::new("out"));
+        assert!(
+            none.contains("## Inference") && none.contains("Not recorded"),
+            "an absent selection is stated, not omitted: {none}"
         );
     }
 

--- a/crates/trusty-audit/src/inference.rs
+++ b/crates/trusty-audit/src/inference.rs
@@ -195,8 +195,85 @@ pub fn selection_env<F>(
 where
     F: Fn(&str) -> Option<String>,
 {
+    Ok(resolve(key_present, models, operator)?.env)
+}
+
+/// A run's inference identity: the provider and the three role model ids.
+///
+/// Why: #6135 — the identity must be written into the manifest, and the env
+/// pairs alone cannot carry it. They are EMPTY in the arm where the operator
+/// named all four, which is exactly the arm where the manifest most needs to
+/// record what was used. Owner ruling 2026-08-21: "In audit mode, trusty review
+/// should use the same provider as audit to make it portable. From the
+/// manifest."
+/// What: four values, always all four, whichever layer they came from.
+/// `source` names that layer so the index can state it.
+/// Test: `super::inference_tests::the_manifest_carries_what_the_env_carries`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct Selection {
+    /// Provider id — `openrouter` unless the engagement pinned another.
+    pub provider: String,
+    /// Reviewer role model id.
+    pub reviewer: String,
+    /// Verifier role model id.
+    pub verifier: String,
+    /// Summarizer role model id.
+    pub summarizer: String,
+    /// Which layer resolved it: the operator's environment, the engagement
+    /// config's `[models]` table, or the built-in defaults.
+    pub source: &'static str,
+}
+
+impl Selection {
+    /// The four values in `[inference]` key order.
+    #[must_use]
+    pub fn rows(&self) -> [(&'static str, &str); 4] {
+        [
+            ("provider", self.provider.as_str()),
+            ("reviewer", self.reviewer.as_str()),
+            ("verifier", self.verifier.as_str()),
+            ("summarizer", self.summarizer.as_str()),
+        ]
+    }
+}
+
+/// What one run selected, and what it must hand to a child.
+///
+/// Why: the two are not the same value. `env` is empty when the operator's
+/// environment already names all four — the child inherits it intact — while
+/// `selection` is what that environment resolved TO, which is what the manifest
+/// records. Returning both from one call keeps them from being resolved twice
+/// and disagreeing.
+/// What: `selection` is `None` only when there is no credential, in which case
+/// nothing is selected and nothing is injected.
+/// Test: `super::inference_tests::the_manifest_carries_what_the_env_carries`.
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
+pub struct Inference {
+    /// The `TRUSTY_REVIEW_*` pairs to set on a child — all four, or none.
+    pub env: Vec<(&'static str, String)>,
+    /// The identity this run renders with, when it has one.
+    pub selection: Option<Selection>,
+}
+
+/// Resolve both halves of a run's inference identity.
+///
+/// # Errors
+///
+/// Exactly [`inference_env`]'s.
+///
+/// Test: `super::inference_tests::the_manifest_carries_what_the_env_carries`.
+pub fn resolve<F>(
+    key_present: bool,
+    models: &ModelPins,
+    operator: F,
+) -> Result<Inference, AuditError>
+where
+    F: Fn(&str) -> Option<String>,
+{
     if !key_present {
-        return Ok(Vec::new());
+        return Ok(Inference::default());
     }
 
     let from_operator = SELECTION.map(&operator);
@@ -210,8 +287,19 @@ where
         SELECTION,
         "operator environment",
     )? {
-        // The operator named the whole selection; the child inherits it intact.
-        return Ok(Vec::new());
+        // The operator named the whole selection; the child inherits it intact,
+        // and the manifest records what that selection actually is (#6135).
+        let named = |i: usize| from_operator[i].clone().unwrap_or_default();
+        return Ok(Inference {
+            env: Vec::new(),
+            selection: Some(Selection {
+                provider: named(0),
+                reviewer: named(1),
+                verifier: named(2),
+                summarizer: named(3),
+                source: "the operator's environment",
+            }),
+        });
     }
 
     let pins: &ModelPins = models;
@@ -234,19 +322,75 @@ where
         DEFAULT_VERIFIER_MODEL,
         DEFAULT_SUMMARIZER_MODEL,
     ];
-    Ok(SELECTION
+    let values: Vec<String> = from_config
         .into_iter()
-        .zip(from_config)
         .zip(defaults)
-        .map(|((name, pinned), fallback)| {
-            let value = if use_config {
-                pinned.unwrap_or(fallback)
+        .map(|(pinned, fallback)| {
+            if use_config {
+                pinned.unwrap_or(fallback).to_owned()
             } else {
-                fallback
-            };
-            (name, value.to_owned())
+                fallback.to_owned()
+            }
         })
-        .collect())
+        .collect();
+    let env: Vec<(&'static str, String)> =
+        SELECTION.into_iter().zip(values.iter().cloned()).collect();
+    Ok(Inference {
+        selection: Some(Selection {
+            provider: values[0].clone(),
+            reviewer: values[1].clone(),
+            verifier: values[2].clone(),
+            summarizer: values[3].clone(),
+            source: if use_config {
+                "the engagement config's [models] table"
+            } else {
+                "this tool's built-in defaults"
+            },
+        }),
+        env,
+    })
+}
+
+/// Record `selection` in the manifest at `path` as its `[inference]` table.
+///
+/// Why: the manifest is what ships. `trusty-review` resolves provider and models
+/// from it ahead of the host's own `~/.config/trusty-review/config.toml`, so
+/// writing it here is what makes a delivered package re-render on the provider
+/// that produced it rather than on whatever the recipient's machine is pinned to
+/// (#6135, and #6080's portable re-render is the use case).
+/// What: an `[inference]` table with the four identity keys, replacing any
+/// previous one. NEVER a credential — a key stays in the environment, because
+/// this file is handed to the client.
+///
+/// The write is the same read-parse-write shape
+/// [`crate::grounding::priority::write_into`] uses on the same file, and runs
+/// after it for that reason: `toml_edit` preserves what it did not touch, so the
+/// two writers cannot erase each other.
+///
+/// # Errors
+///
+/// One line, safe to show the recipient, when the manifest cannot be read,
+/// parsed, or written back. The caller turns it into a gap of its own — a
+/// manifest without the section still renders, it just resolves its provider
+/// from the environment as it did before this key existed.
+///
+/// Test: `super::inference_tests::{the_section_lands_in_the_manifest,
+/// a_second_write_replaces_the_first}`.
+pub fn write_into_manifest(path: &std::path::Path, selection: &Selection) -> Result<(), String> {
+    let text = std::fs::read_to_string(path)
+        .map_err(|e| format!("{} could not be read ({e})", path.display()))?;
+    let mut doc: toml_edit::DocumentMut = text
+        .parse()
+        .map_err(|e| format!("{} is not readable as TOML ({e})", path.display()))?;
+
+    let mut table = toml_edit::Table::new();
+    for (key, value) in selection.rows() {
+        table.insert(key, toml_edit::value(value));
+    }
+    doc.insert("inference", toml_edit::Item::Table(table));
+
+    std::fs::write(path, doc.to_string())
+        .map_err(|e| format!("{} could not be written ({e})", path.display()))
 }
 
 #[cfg(test)]
@@ -498,6 +642,113 @@ trusty-review = "0.15.1"
 
     /// No credential, no provider selection — pointing the reviewer at
     /// OpenRouter with nothing to authenticate with just moves the failure.
+    /// Why: #6135 — the manifest is only a portable carrier if it says exactly
+    /// what the environment says. A drift between the two would render one
+    /// report on one provider and its re-render on another.
+    /// What: resolves both halves and asserts the four `[inference]` values are
+    /// the four `TRUSTY_REVIEW_*` values, in the same pairing.
+    /// Test: this test itself.
+    #[test]
+    fn the_manifest_carries_what_the_env_carries() {
+        let inference = resolve(true, &ModelPins::default(), nothing_set).expect("resolves");
+        let env: HashMap<&'static str, String> = inference.env.iter().cloned().collect();
+        let selection = inference.selection.expect("a key selects something");
+
+        assert_eq!(env.get(ENV_PROVIDER), Some(&selection.provider));
+        assert_eq!(env.get(ENV_REVIEWER_MODEL), Some(&selection.reviewer));
+        assert_eq!(env.get(ENV_VERIFIER_MODEL), Some(&selection.verifier));
+        assert_eq!(env.get(ENV_SUMMARIZER_MODEL), Some(&selection.summarizer));
+        assert_eq!(selection.provider, PROVIDER_OPENROUTER);
+    }
+
+    /// Why: the arm where the operator named all four emits NO variables, and
+    /// that is exactly the arm where the manifest is the only record of what ran.
+    /// What: an operator environment naming all four, resolved.
+    /// Test: this test itself.
+    #[test]
+    fn an_inherited_selection_is_still_recorded() {
+        let inference = resolve(true, &ModelPins::default(), |name| {
+            Some(match name {
+                ENV_PROVIDER => "bedrock".to_owned(),
+                _ => "us.anthropic.claude-sonnet-4-6".to_owned(),
+            })
+        })
+        .expect("a whole operator selection resolves");
+
+        assert!(inference.env.is_empty(), "the child inherits it untouched");
+        let selection = inference
+            .selection
+            .expect("but the manifest still records it");
+        assert_eq!(selection.provider, "bedrock");
+        assert_eq!(selection.reviewer, "us.anthropic.claude-sonnet-4-6");
+    }
+
+    /// Why: the section is what makes a delivered package render on the provider
+    /// that produced it, so it has to actually land in the file — and land once,
+    /// however many times a resumed sweep writes it.
+    /// What: writes into a manifest twice and reads the result back as TOML.
+    /// Test: this test itself.
+    #[test]
+    fn the_section_lands_in_the_manifest() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("manifest.toml");
+        std::fs::write(
+            &path,
+            "[report]\ntitle = \"Acme\"\n\n[[repositories]]\nname = \"api\"\npath = \"/r\"\n",
+        )
+        .expect("write");
+
+        let selection = resolve(true, &ModelPins::default(), nothing_set)
+            .expect("resolves")
+            .selection
+            .expect("selects");
+        write_into_manifest(&path, &selection).expect("the section is written");
+        write_into_manifest(&path, &selection).expect("a resumed sweep writes it again");
+
+        let text = std::fs::read_to_string(&path).expect("read back");
+        let doc: toml::Value = toml::from_str(&text).expect("still parses as TOML");
+        let section = doc.get("inference").expect("the section is there");
+        assert_eq!(
+            section.get("provider").and_then(toml::Value::as_str),
+            Some(PROVIDER_OPENROUTER)
+        );
+        assert_eq!(
+            section.get("reviewer").and_then(toml::Value::as_str),
+            Some(DEFAULT_REVIEWER_MODEL)
+        );
+        assert_eq!(
+            text.matches("[inference]").count(),
+            1,
+            "a second write replaces the section rather than appending one: {text}"
+        );
+        assert_eq!(
+            doc.get("report")
+                .and_then(|r| r.get("title"))
+                .and_then(toml::Value::as_str),
+            Some("Acme"),
+            "everything the other writer put here survives"
+        );
+        assert!(
+            !text.contains("key") && !text.contains("sk-or"),
+            "a credential must never reach a file the client receives: {text}"
+        );
+    }
+
+    /// Why: a manifest that cannot be written is a degraded render, never a
+    /// failed sweep — the caller turns this into a named gap.
+    /// What: writes into a path that does not exist.
+    /// Test: this test itself.
+    #[test]
+    fn a_manifest_that_cannot_be_written_says_so() {
+        let selection = resolve(true, &ModelPins::default(), nothing_set)
+            .expect("resolves")
+            .selection
+            .expect("selects");
+        let cause = write_into_manifest(Path::new("/nonexistent/manifest.toml"), &selection)
+            .expect_err("an absent manifest cannot be written");
+        assert!(cause.contains("could not be read"), "{cause}");
+    }
+
     #[test]
     fn a_blank_key_selects_nothing() {
         let text = CONFIG.replace("sk-or-v1-not-a-real-key", "   ");

--- a/crates/trusty-audit/src/manifest.rs
+++ b/crates/trusty-audit/src/manifest.rs
@@ -35,9 +35,41 @@ use crate::error::AuditError;
 pub struct AuditManifest {
     /// Engagement metadata.
     pub report: ReportSection,
+    /// The inference identity the run that wrote this manifest used (#6135).
+    ///
+    /// Absent in every manifest written before the key existed, and in any
+    /// hand-written one — which is why a render still resolves its own provider
+    /// when it is missing rather than refusing.
+    #[serde(default)]
+    pub inference: Option<InferenceSection>,
     /// The configured repository set, in config order.
     #[serde(default)]
     pub repositories: Vec<RepositoryEntry>,
+}
+
+/// The `[inference]` section: which provider and models rendered this report.
+///
+/// Why: `crate::inference::write_into_manifest` writes it and
+/// `trusty-review` resolves from it (#6135). This crate reads it back for one
+/// purpose — stating in `index.md` which models a re-render will actually use,
+/// since the manifest outranks anything the re-render itself would inject.
+/// What: four identity strings, never a credential.
+/// Test: `super::manifest_tests::reads_the_inference_section`.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[non_exhaustive]
+pub struct InferenceSection {
+    /// Provider id.
+    #[serde(default)]
+    pub provider: Option<String>,
+    /// Reviewer role model id.
+    #[serde(default)]
+    pub reviewer: Option<String>,
+    /// Verifier role model id.
+    #[serde(default)]
+    pub verifier: Option<String>,
+    /// Summarizer role model id.
+    #[serde(default)]
+    pub summarizer: Option<String>,
 }
 
 /// The `[report]` section: who the engagement is for and what it is called.
@@ -158,6 +190,33 @@ path = "/work/repos/acme-web"
                 .map(|r| r.name.as_str())
                 .collect::<Vec<_>>(),
             vec!["acme-api", "acme-web"]
+        );
+    }
+
+    /// Why: #6135 — the section a sweep writes is what a re-render resolves
+    /// from, and `index.md` states it, so this reader has to see it.
+    /// What: a manifest carrying the section, and one without.
+    /// Test: this test itself.
+    #[test]
+    fn reads_the_inference_section() {
+        let text = format!(
+            "{SAMPLE}\n[inference]\nprovider = \"openrouter\"\n\
+             reviewer = \"anthropic/claude-opus-4.8\"\n\
+             verifier = \"anthropic/claude-haiku-4.5\"\n\
+             summarizer = \"anthropic/claude-haiku-4.5\"\n"
+        );
+        let manifest = AuditManifest::from_toml(&text, Path::new("manifest.toml")).expect("parses");
+        let inference = manifest.inference.expect("declared");
+        assert_eq!(inference.provider.as_deref(), Some("openrouter"));
+        assert_eq!(
+            inference.reviewer.as_deref(),
+            Some("anthropic/claude-opus-4.8")
+        );
+
+        let older = AuditManifest::from_toml(SAMPLE, Path::new("manifest.toml")).expect("parses");
+        assert!(
+            older.inference.is_none(),
+            "a manifest written before the key existed still loads"
         );
     }
 

--- a/crates/trusty-audit/src/package/generated.rs
+++ b/crates/trusty-audit/src/package/generated.rs
@@ -148,10 +148,34 @@ pub(super) fn render_index(
         producer: crate::index_report::Producer::Package,
         generated_at: crate::index_report::local_now(),
         tools: crate::index_report::recorded_tools(work),
+        // #6135: read back from the manifests the package ships, because those
+        // are what a recipient's own re-render will resolve from.
+        inference: declared_inference(report),
         entries,
         total: (measured > 0).then(|| std::time::Duration::from_millis(measured)),
     };
     crate::index_report::render(&index, Path::new(REPORTS_PREFIX))
+}
+
+/// The inference identity the packaged manifests declare (#6135).
+///
+/// Why: the package carries manifests, and `trusty-review` resolves provider and
+/// models from them ahead of anything on the recipient's machine — so what they
+/// declare IS what a re-render will use, and the index states it rather than
+/// leaving the recipient to open a TOML file.
+/// What: the first manifest that declares a section. Every repository in one
+/// sweep gets the same selection, so the first is the run's. `None` — a sweep
+/// with no credential, or manifests written before the key existed — leaves the
+/// section stating that rather than omitting it.
+fn declared_inference(report: &RunReport) -> Option<crate::index_report::InferenceRecord> {
+    report.repos.iter().find_map(|run| {
+        let path = run.output.join(crate::manifest::AuditManifest::FILE_NAME);
+        let manifest = crate::manifest::AuditManifest::load_if_present(&path).ok()??;
+        manifest
+            .inference
+            .as_ref()
+            .map(crate::index_report::InferenceRecord::declared)
+    })
 }
 
 /// One line per repository the package does not cover.

--- a/crates/trusty-audit/src/rerender.rs
+++ b/crates/trusty-audit/src/rerender.rs
@@ -229,7 +229,7 @@ pub async fn rerender(
     cwd: &Path,
     config: &Path,
     key: &SecretKey,
-    inference: &[(&'static str, String)],
+    inference: &crate::inference::Inference,
     options: &RerenderOptions,
     progress: &Progress,
 ) -> Result<RerenderReport, AuditError> {
@@ -268,12 +268,33 @@ pub async fn rerender(
     progress.operation_started(Operation::Rerender, total);
     let mut reports = Vec::with_capacity(total);
     let mut taken = HashSet::new();
+    // #6135: what the delivered manifests declare is what the children will
+    // resolve from — it outranks the pairs this run injects — so the index
+    // states that, falling back to this run's own selection when no manifest
+    // declares one.
+    let mut declared: Option<crate::index_report::InferenceRecord> = None;
     for (index, manifest) in manifests.into_iter().enumerate() {
+        if declared.is_none()
+            && let Ok(Some(read)) = AuditManifest::load_if_present(&manifest)
+        {
+            declared = read
+                .inference
+                .as_ref()
+                .map(crate::index_report::InferenceRecord::declared);
+        }
         let name = unique_name(&manifest, index, &mut taken);
         progress.unit_started(Operation::Rerender, name.as_str(), index + 1, total);
         let unit_started = std::time::Instant::now();
-        let mut rendered =
-            render_one(&review, &tools, &manifest, &output, name, key, inference).await?;
+        let mut rendered = render_one(
+            &review,
+            &tools,
+            &manifest,
+            &output,
+            name,
+            key,
+            &inference.env,
+        )
+        .await?;
         // Timed here rather than inside `render_one`, which returns from two
         // places — a manifest that will not parse is still a unit that took time.
         rendered.duration_ms = Some(millis(unit_started.elapsed()));
@@ -299,6 +320,12 @@ pub async fn rerender(
         &output,
         &review,
         review_version.as_deref(),
+        declared.or_else(|| {
+            inference
+                .selection
+                .as_ref()
+                .map(crate::index_report::InferenceRecord::of)
+        }),
         &reports,
         started.elapsed(),
     )?;
@@ -871,7 +898,7 @@ mod rerender_tests {
             cwd,
             config,
             &key(),
-            &[],
+            &crate::inference::Inference::default(),
             &RerenderOptions {
                 from: from.map(Path::to_path_buf),
                 out: None,
@@ -1495,7 +1522,7 @@ mod rerender_tests {
             &engagement,
             &config,
             &key(),
-            &[],
+            &crate::inference::Inference::default(),
             &RerenderOptions::default(),
             &Progress::none(),
         )

--- a/crates/trusty-audit/src/run.rs
+++ b/crates/trusty-audit/src/run.rs
@@ -367,7 +367,10 @@ where
     let binaries = pinned_binaries(work, &config.tools)?;
     // Resolved once, before any child: a half-named selection is identical for
     // every repository, so failing per-repo would just repeat one misconfiguration.
-    let inference = inference::inference_env(config, operator)?;
+    // #6135: both halves at once — the pairs the child inherits, and the
+    // identity the manifest records. See `inference::Inference`.
+    let inference =
+        inference::resolve(!config.openrouter_key.is_empty(), &config.models, operator)?;
     // #5857: ONE resolution per invocation. `crate::chain` resolved the boards
     // an hour ago to state its gaps and hands that result down, so the coverage
     // the report claims and the sections the child gets cannot diverge over a
@@ -468,7 +471,12 @@ where
     // the checkpoint so the index describes a run that is on the record. A
     // partial sweep still gets one — it is where the repositories with no report
     // are named.
-    crate::index_report::write_sweep(work, &report, sweep_started.elapsed())?;
+    crate::index_report::write_sweep(
+        work,
+        &report,
+        inference.selection.as_ref(),
+        sweep_started.elapsed(),
+    )?;
     Ok(report)
 }
 
@@ -575,7 +583,7 @@ async fn run_one(
     work: &WorkDir,
     config: &EngagementConfig,
     binaries: &PinnedBinaries,
-    inference: &[(&'static str, String)],
+    inference: &inference::Inference,
     boards: &boards::Boards,
     github_access: &github_issues::GithubAccess,
     index: usize,
@@ -612,7 +620,7 @@ async fn run_one(
             match spawn_tga(
                 binaries,
                 config,
-                inference,
+                &inference.env,
                 boards,
                 github_access,
                 &config_path,
@@ -653,6 +661,22 @@ async fn run_one(
     if manifest.is_file() {
         let tools = grounding::Tools::pinned(binaries.search.clone(), binaries.analyze.clone());
         gaps.extend(grounding::ground_manifest(&manifest, &tools, &checkout, &repo.name).await);
+        // #6135: the provider and models this run used, written into the file
+        // that ships. Without it a re-render on another machine resolves its own
+        // provider from that machine's config — which is how a June-dated local
+        // `provider = "bedrock"` hijacked an OpenRouter engagement's render.
+        // After grounding, so the two writers of this file serialise; fail-open
+        // for the same reason grounding is, because a manifest without the
+        // section renders exactly as it did before the key existed.
+        if let Some(selection) = &inference.selection
+            && let Err(cause) = inference::write_into_manifest(&manifest, selection)
+        {
+            gaps.push(format!(
+                "{}: {cause} — a re-render of this report resolves its own inference provider \
+                 instead of reproducing this run's",
+                repo.name
+            ));
+        }
     }
     progress.unit_finished(
         Operation::Sweep,

--- a/crates/trusty-audit/src/session.rs
+++ b/crates/trusty-audit/src/session.rs
@@ -1023,8 +1023,9 @@ impl Session {
                 config: self.config_path.clone(),
             })?;
         let models = config.map(|c| c.models).unwrap_or_default();
-        let inference =
-            crate::inference::selection_env(true, &models, |name| std::env::var(name).ok())?;
+        // #6135: both halves — the pairs the child inherits, and the identity
+        // the index states when no manifest declares its own.
+        let inference = crate::inference::resolve(true, &models, |name| std::env::var(name).ok())?;
         rerender::rerender(
             &self.work,
             &self.cwd,

--- a/crates/trusty-review/README.md
+++ b/crates/trusty-review/README.md
@@ -408,7 +408,43 @@ Override via:
 Provider prefix convention:
 - `bedrock/<id>` — AWS Bedrock Converse API (no API key needed, uses AWS credential chain)
 - `openrouter/<id>` — OpenRouter (requires `OPENROUTER_API_KEY`)
-- Bare id — uses the configured default provider
+- Bare id — the id's own shape decides when it belongs to exactly one
+  provider's catalogue; otherwise the configured default provider
+
+A prefix that contradicts the id's shape resolves rather than failing (#6135):
+the same model in the pinned provider's own dialect wins where one is verified
+(`bedrock/anthropic/claude-sonnet-4.6` runs `us.anthropic.claude-sonnet-4-6` on
+Bedrock), and otherwise the call routes to the provider whose catalogue the id
+belongs to. Every adjustment is logged and, for `report`, printed on the page as
+`requested → ran`.
+
+### `report --manifest`: the manifest decides (#6135)
+
+A report manifest may declare the run's inference identity:
+
+```toml
+[inference]
+provider   = "openrouter"
+reviewer   = "anthropic/claude-opus-4.8"
+verifier   = "anthropic/claude-haiku-4.5"
+summarizer = "anthropic/claude-haiku-4.5"
+```
+
+Precedence for `report` is **CLI flag > manifest `[inference]` > env var >
+config file > built-in default**, per field. `trusty-audit` writes this section
+into every manifest it grounds, so a delivered package re-renders on the
+provider that produced it instead of inheriting the host's
+`~/.config/trusty-review/config.toml` — the failure this replaced was a
+June-dated local `provider = "bedrock"` hijacking an OpenRouter engagement.
+
+The manifest carries identity, **never a credential**: the key stays in the
+environment (`OPENROUTER_API_KEY`). A render whose declared provider has no
+credential stops before any repository is walked, and the message names the
+provider — no other provider is substituted for the one selected.
+
+The rendered report's Report Metadata table and its JSON twin both state which
+models ran, per role, with `requested → ran` wherever the resolver adjusted an
+id.
 
 ## Per-project config & review templates
 

--- a/crates/trusty-review/changelog.d/6135-provider-from-manifest.md
+++ b/crates/trusty-review/changelog.d/6135-provider-from-manifest.md
@@ -1,0 +1,17 @@
+Added
+
+- `report --manifest` resolves the provider and per-role models from the
+  manifest's new `[inference]` section, ahead of this host's environment and
+  `~/.config/trusty-review/config.toml`. Precedence per field is CLI flag >
+  manifest > env var > config file > built-in default, so a delivered audit
+  package re-renders on the provider that produced it — the failure this
+  replaced was a June-dated local `provider = "bedrock"` hijacking an OpenRouter
+  engagement's render. A manifest with no `[inference]` section (every manifest
+  written before this) resolves exactly as it did before. The section carries
+  identity only: a credential still comes from the environment, and a render
+  whose declared provider has no key stops before any repository is walked, with
+  the provider named in the message.
+- The report states which models ran. Its Report Metadata table gains an
+  `Inference models` row and the JSON twin an `inference` object, both listing
+  provider and per-role model — and both showing `requested → ran` wherever the
+  resolver adjusted an id.

--- a/crates/trusty-review/changelog.d/6135-resolve-model-naming.md
+++ b/crates/trusty-review/changelog.d/6135-resolve-model-naming.md
@@ -1,0 +1,18 @@
+Changed
+
+- A model id whose shape contradicts the provider pinned for the call now
+  resolves instead of failing (owner ruling 2026-08-21: "Models selection should
+  be robust. We shouldn't fail on naming/id issue. The report should include
+  which models are used."). Where the pinned provider publishes the same model,
+  the id is translated into that provider's own **verified** spelling —
+  `bedrock/anthropic/claude-sonnet-4.6` runs `us.anthropic.claude-sonnet-4-6`;
+  where it does not, the call routes to the provider whose catalogue the id
+  belongs to. The translation reads the verified `ModelTier` catalogue and never
+  derives an id by string surgery, so an unmappable direction (Bedrock publishes
+  no Opus 4.8 profile) resolves by routing rather than by inventing an id. The
+  #6114 guarantee is unchanged in substance and moves from refusal to
+  attribution: every adjustment is logged and printed in the report as
+  `requested → ran`. `LlmError::Validation` remains for the one case with no
+  reasonable resolution — an id belonging to a provider this build cannot call,
+  with no verified equivalent in one it can. The MCP `review_pr` / `review_diff`
+  `reviewer_model` override follows the same rule.

--- a/crates/trusty-review/src/cli_report.rs
+++ b/crates/trusty-review/src/cli_report.rs
@@ -17,13 +17,13 @@ use anyhow::{Context as _, Result};
 use clap::Parser;
 
 use trusty_review::config::{Provider, ReviewConfig};
-use trusty_review::llm::{build_provider, resolve_provider_and_model};
+use trusty_review::llm::{build_provider, resolve_model, resolve_provider_and_model};
 use trusty_review::report::{
     Budget, CorpusSnapshot, Instructions, Reporter, TemplateLoader, benchmark,
     investigate::{Investigation, apply_investigation, merge_investigation_prose},
     load_instructions, load_manifest,
     manifest::Manifest,
-    model::ReportModel,
+    model::{InferenceAttribution, ReportModel, RoleAttribution},
     parse_section_instructions, run_investigation,
     synthesize::Synthesis,
     synthesize::Synthesizer,
@@ -130,24 +130,39 @@ pub struct ReportArgs {
 /// the markdown + JSON pair.  Progress → STDERR; written paths → STDOUT.
 /// Test: arg parsing via `tests::report_args_parse_defaults`; full render via
 /// `tests/report_e2e.rs`.
-pub async fn cmd_report(config: ReviewConfig, args: ReportArgs) -> Result<()> {
-    // #5454: the credential is checked FIRST, before the manifest is read or a
-    // single repository is walked. A DD render takes minutes, and discovering an
-    // unset key at the end of it wastes all of them.
-    preflight_inference_credential(&config)?;
-
+pub async fn cmd_report(config_path: Option<&Path>, args: ReportArgs) -> Result<()> {
     if args.synthesize {
         eprintln!(
             "[trusty-review report] --synthesize is deprecated and ignored: synthesis is always on"
         );
     }
 
+    // #6135: the manifest is read BEFORE the config, because it is a config
+    // layer — it carries the provider and per-role models of the run that
+    // produced it, and those outrank this host's `config.toml`. Reading one
+    // small TOML file keeps #5454's promise intact: the credential is still
+    // checked before a single repository is walked.
     eprintln!(
         "[trusty-review report] Loading manifest: {}",
         args.manifest.display()
     );
     let manifest = load_manifest(&args.manifest)
         .with_context(|| format!("failed to load manifest {}", args.manifest.display()))?;
+    let declared = manifest.inference.as_ref().map(|i| i.as_role_layer());
+    let config = ReviewConfig::from_env_and_manifest(config_path, None, declared.as_ref());
+    let attribution = resolve_attribution(
+        &config,
+        match &declared {
+            Some(_) => "the manifest's [inference] section",
+            None => "this host's environment and config",
+        },
+    )?;
+    eprintln!("[trusty-review report] Inference: {}", attribution.line());
+
+    // #5454: the credential is checked before any repository is walked. A DD
+    // render takes minutes, and discovering an unset key at the end of it wastes
+    // all of them.
+    preflight_inference_credential(&config)?;
 
     // Template precedence: CLI flag > manifest [report].template > default.
     let template_name = args
@@ -181,6 +196,8 @@ pub async fn cmd_report(config: ReviewConfig, args: ReportArgs) -> Result<()> {
         instructions.as_ref(),
     )
     .context("failed to assemble report model")?;
+    // #6135: what ran, on the page and in the JSON twin.
+    model.inference = Some(attribution);
 
     // #2357 layered instructions: parse the active template's own
     // `<!-- instruct:<section_id> ... -->` overrides (if any) BEFORE the render
@@ -452,10 +469,45 @@ fn resolve_budget(args: &ReportArgs, manifest: &Manifest) -> Budget {
 /// Test: the rule itself, via [`credential_rule`].
 fn preflight_inference_credential(config: &ReviewConfig) -> Result<()> {
     let role = &config.role_models.reviewer;
-    // #6114: an id whose shape contradicts the provider stops here, before the
-    // sweep spends minutes on a render that would run a different model.
+    // #6135: the id resolves rather than refusing, so what this checks is the
+    // credential for the provider the resolution landed on.
     let (provider, _) = resolve_provider_and_model(&role.model, &role.provider)?;
     credential_rule(provider, &config.openrouter_api_key)
+}
+
+/// Resolve every role and record what will run (#6135).
+///
+/// Why: owner ruling 2026-08-21 — the report states which models are used, and
+/// an id the resolver adjusted shows both halves. Resolving all three roles here
+/// (rather than only the reviewer the synthesis pass builds) is what lets the
+/// manifest's whole declared selection be attributed.
+/// What: one [`ModelResolution`] per role, folded into the record the page and
+/// the JSON twin carry. `source` names the layer the selection came from, which
+/// is the fact that distinguishes a portable render from one that inherited the
+/// host's config.
+///
+/// # Errors
+///
+/// Only when a role's id names a provider this build cannot call and has no
+/// verified equivalent — see [`trusty_review::llm::resolve_model`].
+///
+/// Test: `tests::attribution_names_every_role`,
+/// `tests::attribution_shows_a_translated_id_as_requested_then_ran`.
+fn resolve_attribution(config: &ReviewConfig, source: &str) -> Result<InferenceAttribution> {
+    let roles = &config.role_models;
+    let mut rows = Vec::with_capacity(3);
+    for (name, role) in [
+        ("reviewer", &roles.reviewer),
+        ("verifier", &roles.verifier),
+        ("summarizer", &roles.summarizer),
+    ] {
+        let resolved = resolve_model(&role.model, &role.provider)?;
+        if let Some(note) = &resolved.note {
+            eprintln!("[trusty-review report] {name} model: {note}");
+        }
+        rows.push(RoleAttribution::of(name, &role.model, &resolved));
+    }
+    Ok(InferenceAttribution::of(source, rows))
 }
 
 /// The preflight rule itself, as a pure function.
@@ -475,10 +527,15 @@ fn credential_rule(provider: Provider, openrouter_api_key: &str) -> Result<()> {
         return Ok(());
     }
     if openrouter_api_key.trim().is_empty() {
+        // #6135: the provider is named, because it may have come from the
+        // manifest rather than from anything on this machine — an operator
+        // reading "set OPENROUTER_API_KEY" on a host configured for Bedrock
+        // needs to see WHICH provider asked for it.
         anyhow::bail!(
-            "{key} is not set, and a due-diligence report requires inference. Set it before \
-             starting the run:\n\n    export {key}=<your OpenRouter API key>\n\nKeys are issued at \
-             https://openrouter.ai/keys.",
+            "this render runs on the {provider} provider, and {key} is not set. A due-diligence \
+             report requires inference, and no other provider is substituted for the one \
+             selected. Set it before starting the run:\n\n    export {key}=<your OpenRouter API \
+             key>\n\nKeys are issued at https://openrouter.ai/keys.",
             key = trusty_common::env_vars::ENV_OPENROUTER_API_KEY,
         );
     }
@@ -721,7 +778,75 @@ mod tests {
                 msg.contains("OPENROUTER_API_KEY") && msg.contains("export OPENROUTER_API_KEY="),
                 "the message must name the variable and how to set it: {msg}"
             );
+            // #6135: the provider may have come from the manifest rather than
+            // from anything on this machine, so the message names it.
+            assert!(
+                msg.contains("openrouter"),
+                "the message must name the provider that asked for the key: {msg}"
+            );
         }
+    }
+
+    /// Why: #6135 — the report states which models ran, and that record starts
+    /// here. All three roles are resolved, not only the reviewer the synthesis
+    /// pass builds, so the manifest's whole declared selection is attributed.
+    /// What: resolves against a config whose role models are the built-in
+    /// OpenRouter defaults, and asserts one row per role.
+    /// Test: this test itself.
+    #[test]
+    fn attribution_names_every_role() {
+        let manifest = trusty_review::config::RoleManifest {
+            reviewer_model: Some("anthropic/claude-opus-4.8".to_string()),
+            verifier_model: Some("anthropic/claude-haiku-4.5".to_string()),
+            summarizer_model: Some("anthropic/claude-haiku-4.5".to_string()),
+            provider: Some("openrouter".to_string()),
+        };
+        let config = ReviewConfig::from_env_and_manifest(None, None, Some(&manifest));
+        let record = resolve_attribution(&config, "the manifest's [inference] section")
+            .expect("the declared selection resolves");
+
+        assert_eq!(record.provider, "openrouter");
+        assert_eq!(
+            record
+                .roles
+                .iter()
+                .map(|r| r.role.as_str())
+                .collect::<Vec<_>>(),
+            vec!["reviewer", "verifier", "summarizer"]
+        );
+        assert!(
+            record.roles.iter().all(|r| r.requested == r.ran),
+            "nothing was adjusted here: {:?}",
+            record.roles
+        );
+        assert_eq!(record.roles[0].ran, "anthropic/claude-opus-4.8");
+    }
+
+    /// Why: the resolver adjusting an id must never be invisible — that is the
+    /// whole anti-silent-wrong-model guarantee once refusal is gone.
+    /// What: a manifest whose reviewer id is pinned to Bedrock but spelled for
+    /// OpenRouter, resolved and attributed.
+    /// Test: this test itself.
+    #[test]
+    fn attribution_shows_a_translated_id_as_requested_then_ran() {
+        let manifest = trusty_review::config::RoleManifest {
+            reviewer_model: Some("bedrock/anthropic/claude-sonnet-4.6".to_string()),
+            provider: Some("bedrock".to_string()),
+            ..Default::default()
+        };
+        let config = ReviewConfig::from_env_and_manifest(None, None, Some(&manifest));
+        let record =
+            resolve_attribution(&config, "the manifest's [inference] section").expect("resolves");
+
+        let reviewer = &record.roles[0];
+        assert_eq!(reviewer.requested, "bedrock/anthropic/claude-sonnet-4.6");
+        assert_eq!(reviewer.ran, "us.anthropic.claude-sonnet-4-6");
+        assert!(reviewer.note.is_some(), "the adjustment must be recorded");
+        assert!(
+            record.line().contains(" → "),
+            "the page shows both halves: {}",
+            record.line()
+        );
     }
 
     /// Why: the preflight must not stand between an operator with a key and a run.

--- a/crates/trusty-review/src/config/config_tests.rs
+++ b/crates/trusty-review/src/config/config_tests.rs
@@ -338,7 +338,7 @@ fn repo_config_voice_overrides_env() {
     )
     .expect("write repo config");
 
-    let config = ReviewConfig::from_env_and_file_inner(None, None, Some(&repo_config));
+    let config = ReviewConfig::from_env_and_file_inner(None, None, Some(&repo_config), None);
 
     unsafe {
         std::env::remove_var("TRUSTY_REVIEW_VOICE_PACKAGE");
@@ -368,7 +368,7 @@ fn repo_config_review_template_overrides_env() {
     std::fs::write(&repo_config, "[review]\ntemplate = \"repo-template\"\n")
         .expect("write repo config");
 
-    let config = ReviewConfig::from_env_and_file_inner(None, None, Some(&repo_config));
+    let config = ReviewConfig::from_env_and_file_inner(None, None, Some(&repo_config), None);
 
     unsafe {
         std::env::remove_var("TRUSTY_REVIEW_TEMPLATE");
@@ -397,7 +397,8 @@ fn repo_config_cli_review_template_wins() {
         ..Default::default()
     };
 
-    let config = ReviewConfig::from_env_and_file_inner(None, Some(&overrides), Some(&repo_config));
+    let config =
+        ReviewConfig::from_env_and_file_inner(None, Some(&overrides), Some(&repo_config), None);
 
     assert_eq!(config.review_template.as_deref(), Some("cli-template"));
 }
@@ -425,7 +426,7 @@ fn no_repo_config_preserves_pre_2995_env_over_file_precedence() {
     std::fs::write(&explicit_config, "[voice]\npackage = \"file-voice\"\n")
         .expect("write explicit config");
 
-    let config = ReviewConfig::from_env_and_file_inner(Some(&explicit_config), None, None);
+    let config = ReviewConfig::from_env_and_file_inner(Some(&explicit_config), None, None, None);
 
     unsafe {
         std::env::remove_var("TRUSTY_REVIEW_VOICE_PACKAGE");
@@ -693,6 +694,112 @@ fn role_models_fireworks_falls_back_to_pinned_defaults() {
     assert_eq!(
         roles.verifier.model,
         crate::llm::models::DEFAULT_VERIFIER_MODEL
+    );
+}
+
+// ── #6135: the manifest layer ────────────────────────────────────────────────
+
+/// Why: the observed failure — a June-dated `~/.config/trusty-review/config.toml`
+/// pinning `provider = "bedrock"` hijacked a render of an OpenRouter engagement.
+/// The manifest travels with the package and states what produced the run, so it
+/// must outrank both the host's environment and its config file.
+/// What: a manifest declaring OpenRouter plus all three models, against an env
+/// layer and a config file that both say Bedrock.
+/// Test: this test itself.
+#[test]
+fn role_models_manifest_beats_env_and_config_file() {
+    let manifest = RoleManifest {
+        reviewer_model: Some("anthropic/claude-opus-4.8".to_string()),
+        verifier_model: Some("anthropic/claude-haiku-4.5".to_string()),
+        summarizer_model: Some("anthropic/claude-haiku-4.5".to_string()),
+        provider: Some("openrouter".to_string()),
+    };
+    let env = RoleEnv {
+        reviewer_model: Some("us.anthropic.claude-sonnet-4-6".to_string()),
+        provider: Some("bedrock".to_string()),
+        ..Default::default()
+    };
+    let file = FileModels {
+        reviewer: Some(RoleConfigOverride {
+            provider: Some("bedrock".to_string()),
+            model: Some("us.anthropic.claude-sonnet-4-6".to_string()),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let roles = RoleModels::resolve_with_manifest(None, Some(&manifest), &env, Some(&file));
+    assert_eq!(roles.reviewer.provider, Provider::OpenRouter);
+    assert_eq!(roles.reviewer.model, "anthropic/claude-opus-4.8");
+    assert_eq!(roles.verifier.provider, Provider::OpenRouter);
+    assert_eq!(roles.summarizer.model, "anthropic/claude-haiku-4.5");
+}
+
+/// Why: an explicit CLI flag is the operator's statement about THIS call, so the
+/// manifest sits below it.
+/// What: `--provider bedrock` against an OpenRouter manifest.
+/// Test: this test itself.
+#[test]
+fn role_models_cli_still_beats_the_manifest() {
+    let cli = RoleCliOverrides {
+        provider: Some("bedrock".to_string()),
+        ..Default::default()
+    };
+    let manifest = RoleManifest {
+        provider: Some("openrouter".to_string()),
+        ..Default::default()
+    };
+    let roles =
+        RoleModels::resolve_with_manifest(Some(&cli), Some(&manifest), &RoleEnv::default(), None);
+    assert_eq!(roles.reviewer.provider, Provider::Bedrock);
+}
+
+/// Why: back-compat — a manifest with no `[inference]` section must resolve
+/// exactly as it did before #6135, so an already-delivered package keeps
+/// rendering.
+/// What: the same layers resolved with and without a `None` manifest.
+/// Test: this test itself.
+#[test]
+fn role_models_without_a_manifest_layer_are_unchanged() {
+    let env = RoleEnv {
+        reviewer_model: Some("us.anthropic.claude-sonnet-4-6".to_string()),
+        provider: Some("bedrock".to_string()),
+        ..Default::default()
+    };
+    let with_none = RoleModels::resolve_with_manifest(None, None, &env, None);
+    let without = RoleModels::resolve(None, &env, None);
+    assert_eq!(with_none.reviewer.model, without.reviewer.model);
+    assert_eq!(with_none.reviewer.provider, without.reviewer.provider);
+    assert_eq!(with_none.reviewer.provider, Provider::Bedrock);
+}
+
+/// Why: the layer has to survive the whole `ReviewConfig` load, which is what a
+/// render actually calls — not only the `RoleModels` resolver.
+/// What: a config file pinning Bedrock in a tempdir, loaded first with no
+/// manifest (it decides) and then with an OpenRouter manifest (it does not). No
+/// env var is set or cleared: the manifest outranks the environment either way,
+/// which is what keeps this test independent of the machine running it.
+/// Test: this test itself.
+#[test]
+fn config_manifest_layer_beats_a_local_config_file() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("config.toml");
+    std::fs::write(
+        &path,
+        "[models.reviewer]\nprovider = \"bedrock\"\nmodel = \"us.anthropic.claude-sonnet-4-6\"\n",
+    )
+    .expect("write config");
+
+    let manifest = RoleManifest {
+        reviewer_model: Some("anthropic/claude-opus-4.8".to_string()),
+        provider: Some("openrouter".to_string()),
+        ..Default::default()
+    };
+    let portable = ReviewConfig::from_env_and_manifest(Some(&path), None, Some(&manifest));
+    assert_eq!(portable.role_models.reviewer.provider, Provider::OpenRouter);
+    assert_eq!(
+        portable.role_models.reviewer.model,
+        "anthropic/claude-opus-4.8"
     );
 }
 

--- a/crates/trusty-review/src/config/mod.rs
+++ b/crates/trusty-review/src/config/mod.rs
@@ -39,7 +39,7 @@ pub use context::{ContextConfig, ContextFileConfig, InvocationSurface};
 pub use repo_config::find_repo_config_path;
 pub use review_template::ReviewFileConfig;
 pub use role_models::{
-    FileModels, RoleCliOverrides, RoleConfig, RoleConfigOverride, RoleEnv, RoleModels,
+    FileModels, RoleCliOverrides, RoleConfig, RoleConfigOverride, RoleEnv, RoleManifest, RoleModels,
 };
 pub use verification::{VerificationConfig, VerificationFileConfig};
 
@@ -388,8 +388,32 @@ impl ReviewConfig {
         config_path: Option<&std::path::Path>,
         cli_overrides: Option<&RoleCliOverrides>,
     ) -> Self {
+        Self::from_env_and_manifest(config_path, cli_overrides, None)
+    }
+
+    /// [`Self::from_env_and_file`] with a report manifest's declared inference
+    /// identity as a precedence layer (#6135).
+    ///
+    /// Why: `trusty-review report --manifest <m>` is handed a file that states
+    /// which provider and models produced the run. That statement must outrank
+    /// the host's own `~/.config/trusty-review/config.toml`, which knows nothing
+    /// about the engagement — a stale local `provider = "bedrock"` is what
+    /// hijacked a render on 2026-08-21.
+    /// What: threads `manifest` into [`RoleModels::resolve_with_manifest`];
+    /// everything else is unchanged. `None` is exactly today's behaviour.
+    /// Test: `config_tests::config_manifest_layer_beats_a_local_config_file`.
+    pub fn from_env_and_manifest(
+        config_path: Option<&std::path::Path>,
+        cli_overrides: Option<&RoleCliOverrides>,
+        manifest: Option<&RoleManifest>,
+    ) -> Self {
         let repo_config_path = resolve_repo_config_path(config_path);
-        Self::from_env_and_file_inner(config_path, cli_overrides, repo_config_path.as_deref())
+        Self::from_env_and_file_inner(
+            config_path,
+            cli_overrides,
+            repo_config_path.as_deref(),
+            manifest,
+        )
     }
 
     /// Injectable core of `from_env_and_file` — takes the repo-scoped config
@@ -414,6 +438,7 @@ impl ReviewConfig {
         config_path: Option<&std::path::Path>,
         cli_overrides: Option<&RoleCliOverrides>,
         repo_config_path: Option<&std::path::Path>,
+        manifest: Option<&RoleManifest>,
     ) -> Self {
         // Try to load the config file; silently fall back to defaults.  Parse
         // it once so both the `[models]` and `[verification]` tables come from
@@ -433,7 +458,8 @@ impl ReviewConfig {
             toml_file.as_ref().map(|f| &f.coverage);
 
         let env = RoleEnv::from_env();
-        let role_models = RoleModels::resolve(cli_overrides, &env, file_models.as_ref());
+        let role_models =
+            RoleModels::resolve_with_manifest(cli_overrides, manifest, &env, file_models.as_ref());
         let verification = VerificationConfig::from_env_and_file(file_verification.as_ref());
         let context = ContextConfig::from_env_and_file(file_context.as_ref());
         let context_sources = crate::integrations::context::ContextSourcesConfig::from_env_and_file(

--- a/crates/trusty-review/src/config/role_models.rs
+++ b/crates/trusty-review/src/config/role_models.rs
@@ -101,9 +101,39 @@ impl RoleModels {
         env: &RoleEnv,
         file_models: Option<&FileModels>,
     ) -> Self {
+        Self::resolve_with_manifest(cli_overrides, None, env, file_models)
+    }
+
+    /// [`Self::resolve`] with the manifest layer #6135 added above the env one.
+    ///
+    /// Why: a report manifest carries the inference identity of the run that
+    /// produced it, and that identity must survive travelling to another machine
+    /// — which the environment and the host's config file do not. Owner ruling
+    /// 2026-08-21: "In audit mode, trusty review should use the same provider as
+    /// audit to make it portable. From the manifest."
+    /// What: the chain becomes CLI flag → manifest → env var → config file →
+    /// built-in default, per field. `manifest = None` (or a manifest with no
+    /// `[inference]` section) leaves resolution byte-identical to before, which
+    /// is what keeps an old package rendering as it always did.
+    ///
+    /// The manifest sits ABOVE the environment deliberately: `trusty-audit` sets
+    /// both to the same values, so the order only matters for a re-render on a
+    /// host whose own environment disagrees — and there the manifest is the one
+    /// that knows what produced the report.
+    /// Test: `config_tests::role_models_manifest_beats_env_and_config_file`,
+    /// `config_tests::role_models_without_a_manifest_layer_are_unchanged`.
+    pub fn resolve_with_manifest(
+        cli_overrides: Option<&RoleCliOverrides>,
+        manifest: Option<&RoleManifest>,
+        env: &RoleEnv,
+        file_models: Option<&FileModels>,
+    ) -> Self {
+        let manifest_provider = manifest.and_then(|m| m.provider.as_deref());
         let reviewer = resolve_role(
             cli_overrides.and_then(|c| c.reviewer_model.as_deref()),
             cli_overrides.and_then(|c| c.provider.as_deref()),
+            manifest.and_then(|m| m.reviewer_model.as_deref()),
+            manifest_provider,
             env.reviewer_model.as_deref(),
             env.provider.as_deref(),
             file_models.and_then(|f| f.reviewer.as_ref()),
@@ -116,6 +146,8 @@ impl RoleModels {
         let verifier = resolve_role(
             cli_overrides.and_then(|c| c.verifier_model.as_deref()),
             cli_overrides.and_then(|c| c.provider.as_deref()),
+            manifest.and_then(|m| m.verifier_model.as_deref()),
+            manifest_provider,
             env.verifier_model.as_deref(),
             env.provider.as_deref(),
             file_models.and_then(|f| f.verifier.as_ref()),
@@ -128,6 +160,8 @@ impl RoleModels {
         let summarizer = resolve_role(
             cli_overrides.and_then(|c| c.summarizer_model.as_deref()),
             cli_overrides.and_then(|c| c.provider.as_deref()),
+            manifest.and_then(|m| m.summarizer_model.as_deref()),
+            manifest_provider,
             env.summarizer_model.as_deref(),
             env.provider.as_deref(),
             file_models.and_then(|f| f.summarizer.as_ref()),
@@ -192,6 +226,27 @@ pub struct RoleEnv {
     pub reviewer_model: Option<String>,
     pub verifier_model: Option<String>,
     pub summarizer_model: Option<String>,
+    pub provider: Option<String>,
+}
+
+/// Per-role model ids a report manifest declares (#6135).
+///
+/// Why: the manifest is the durable carrier of a run's inference identity — it
+/// travels with the package, so a re-render on another machine reproduces the
+/// provider and models the original run used instead of inheriting the host's
+/// config. See [`RoleModels::resolve_with_manifest`] for where it sits.
+/// What: the same four fields as [`RoleEnv`], deliberately: they are the same
+/// selection, arriving through a different channel. A key is NEVER among them.
+/// Test: `config_tests::role_models_manifest_beats_env_and_config_file`.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct RoleManifest {
+    /// Reviewer model id declared by the manifest.
+    pub reviewer_model: Option<String>,
+    /// Verifier model id declared by the manifest.
+    pub verifier_model: Option<String>,
+    /// Summarizer model id declared by the manifest.
+    pub summarizer_model: Option<String>,
+    /// Provider id declared by the manifest.
     pub provider: Option<String>,
 }
 
@@ -272,6 +327,8 @@ fn parse_provider_layer(raw: Option<&str>, source: &str) -> Option<Provider> {
 pub(super) fn resolve_role(
     cli_model: Option<&str>,
     cli_provider: Option<&str>,
+    manifest_model: Option<&str>,
+    manifest_provider: Option<&str>,
     env_model: Option<&str>,
     env_provider: Option<&str>,
     file: Option<&RoleConfigOverride>,
@@ -281,9 +338,10 @@ pub(super) fn resolve_role(
     default_temp: f32,
     default_max_tokens: u32,
 ) -> RoleConfig {
-    // Provider: CLI → env → config file → built-in default.
+    // Provider: CLI → manifest (#6135) → env → config file → built-in default.
     // #5679: each layer parses on its own so a bad value yields the next layer, not the default.
     let provider = parse_provider_layer(cli_provider, "--provider")
+        .or_else(|| parse_provider_layer(manifest_provider, "manifest [inference].provider"))
         .or_else(|| parse_provider_layer(env_provider, "TRUSTY_REVIEW_PROVIDER"))
         .or_else(|| {
             parse_provider_layer(
@@ -293,12 +351,14 @@ pub(super) fn resolve_role(
         })
         .unwrap_or(default_provider);
 
-    // Model: CLI → env → config file → tier default → pinned built-in default.
+    // Model: CLI → manifest → env → config file → tier default → pinned built-in
+    // default.
     // #5971: the tier is the built-in layer, so an explicitly-named id at any of
-    // the three layers above still wins. `default_model` remains the fallback
+    // the layers above still wins. `default_model` remains the fallback
     // for a (tier, provider) pair with no verified id — notably Bedrock's opus
     // tiers, which are deliberately unmapped.
     let model = cli_model
+        .or(manifest_model)
         .or(env_model)
         .or(file.and_then(|f| f.model.as_deref()))
         .or_else(|| default_tier.resolve(provider.provider_id()))

--- a/crates/trusty-review/src/llm/dialect.rs
+++ b/crates/trusty-review/src/llm/dialect.rs
@@ -1,0 +1,161 @@
+//! Reading a model id written in another provider's dialect (#6135).
+//!
+//! Why: the same Claude model is spelled three ways — `anthropic/claude-opus-4.8`
+//! on OpenRouter, `us.anthropic.claude-haiku-4-5-20251001-v1:0` on Bedrock,
+//! `claude-opus-4-8` on the first-party API. Until now a pair whose id and
+//! provider disagreed was a hard stop (#6114). The owner ruling of 2026-08-21 is
+//! that a naming difference must resolve to the operator's evident intent and
+//! the run must proceed: "Models selection should be robust. We shouldn't fail
+//! on naming/id issue."
+//!
+//! What: [`translate_model_dialect`] answers "the same model, in this provider's
+//! spelling" — and answers it from the VERIFIED catalogue in
+//! [`trusty_common::inference::ModelTier`], never by string surgery on the id.
+//! That distinction is the whole safety property: Bedrock's Haiku 4.5 profile
+//! needs a date stamp and a `-v1:0` suffix while its Sonnet 4.6 profile does
+//! not, and its Opus 4.8 profile is deliberately unmapped because nobody could
+//! verify it. A mechanically-derived id would fail at call time, not here.
+//! `None` — no verified counterpart — is an ordinary answer, and the caller
+//! routes to the provider the id's own shape names instead.
+//! Test: the inline `tests` module below.
+
+use trusty_common::inference::{ModelTier, ProviderId};
+
+/// Every tier a model id can belong to.
+const TIERS: [ModelTier; 3] = [
+    ModelTier::Analysis,
+    ModelTier::Interaction,
+    ModelTier::Classification,
+];
+
+/// The dialects a known id may be written in.
+///
+/// Anthropic is included even though `trusty-review` cannot call it directly:
+/// an operator who pasted a first-party id into a config still named a model
+/// this workspace knows, and reading it is what lets the run proceed.
+const DIALECTS: [ProviderId; 3] = [
+    ProviderId::OpenRouter,
+    ProviderId::Bedrock,
+    ProviderId::Anthropic,
+];
+
+/// The capability tier `model` names, whichever dialect it is written in.
+///
+/// Why: a tier is the only provider-independent identity this workspace has for
+/// a model, so it is the hinge every translation turns on.
+/// What: an exact match against every `(tier, dialect)` id in the verified
+/// catalogue. `None` for an id the catalogue does not carry — a newer model, a
+/// non-Claude one, a typo.
+/// Test: `every_catalogue_id_reports_its_tier`, `an_unknown_id_has_no_tier`.
+pub fn tier_of_model(model: &str) -> Option<ModelTier> {
+    let id = model.trim();
+    TIERS.into_iter().find(|tier| {
+        DIALECTS
+            .into_iter()
+            .any(|dialect| tier.resolve(dialect) == Some(id))
+    })
+}
+
+/// The same model as `model`, spelled the way `to` spells it.
+///
+/// Why: an engagement that pinned OpenRouter slugs and a host configured for
+/// Bedrock used to be irreconcilable. Translating through the catalogue keeps
+/// the operator's model — the actual intent — while honouring the provider they
+/// pinned for this call.
+/// What: `Some(id)` when `model` is a catalogue id AND `to` has a verified id
+/// for the same tier AND that id differs from the input. `None` otherwise, which
+/// includes every unverifiable direction (Bedrock has no Opus 4.8 profile) and
+/// every provider hosting no Claude model (Fireworks).
+/// Test: `an_openrouter_slug_translates_to_bedrock`,
+/// `a_bedrock_profile_translates_to_openrouter`,
+/// `an_unverifiable_direction_does_not_translate`,
+/// `a_provider_with_no_claude_models_does_not_translate`.
+pub fn translate_model_dialect(model: &str, to: ProviderId) -> Option<String> {
+    let tier = tier_of_model(model)?;
+    let translated = tier.resolve(to)?;
+    (translated != model.trim()).then(|| translated.to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_catalogue_id_reports_its_tier() {
+        for tier in TIERS {
+            for dialect in DIALECTS {
+                let Some(id) = tier.resolve(dialect) else {
+                    continue;
+                };
+                assert_eq!(
+                    tier_of_model(id),
+                    Some(tier),
+                    "{id} ({dialect:?}) must read back as its own tier"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn an_unknown_id_has_no_tier() {
+        for id in [
+            "",
+            "gpt-5.4-mini",
+            "anthropic/claude-opus-9.9",
+            "accounts/fireworks/models/llama-v3",
+        ] {
+            assert_eq!(tier_of_model(id), None, "{id} is not a catalogue id");
+        }
+    }
+
+    #[test]
+    fn an_openrouter_slug_translates_to_bedrock() {
+        // Sonnet and Haiku have verified profiles on both sides.
+        assert_eq!(
+            translate_model_dialect("anthropic/claude-sonnet-4.6", ProviderId::Bedrock).as_deref(),
+            Some("us.anthropic.claude-sonnet-4-6")
+        );
+        assert_eq!(
+            translate_model_dialect("anthropic/claude-haiku-4.5", ProviderId::Bedrock).as_deref(),
+            Some("us.anthropic.claude-haiku-4-5-20251001-v1:0"),
+            "the translation must be the VERIFIED profile, date stamp and all"
+        );
+    }
+
+    #[test]
+    fn a_bedrock_profile_translates_to_openrouter() {
+        assert_eq!(
+            translate_model_dialect("us.anthropic.claude-sonnet-4-6", ProviderId::OpenRouter)
+                .as_deref(),
+            Some("anthropic/claude-sonnet-4.6")
+        );
+    }
+
+    #[test]
+    fn an_unverifiable_direction_does_not_translate() {
+        // Bedrock's Opus 4.8 profile id is unmapped by owner ruling (#5971), so
+        // there is nothing to translate INTO — and inventing one is the failure
+        // this module exists to avoid.
+        assert_eq!(
+            translate_model_dialect("anthropic/claude-opus-4.8", ProviderId::Bedrock),
+            None
+        );
+    }
+
+    #[test]
+    fn a_provider_with_no_claude_models_does_not_translate() {
+        assert_eq!(
+            translate_model_dialect("anthropic/claude-sonnet-4.6", ProviderId::Fireworks),
+            None
+        );
+    }
+
+    #[test]
+    fn an_id_already_in_the_target_dialect_is_not_a_translation() {
+        assert_eq!(
+            translate_model_dialect("anthropic/claude-sonnet-4.6", ProviderId::OpenRouter),
+            None,
+            "nothing changed, so there is nothing to report as an adjustment"
+        );
+    }
+}

--- a/crates/trusty-review/src/llm/mod.rs
+++ b/crates/trusty-review/src/llm/mod.rs
@@ -12,6 +12,7 @@
 //! object-safe; `provider_factory_*` tests cover the routing logic.
 
 pub mod bedrock;
+pub mod dialect;
 pub mod error;
 pub mod fireworks;
 pub mod models;
@@ -265,23 +266,96 @@ pub fn strip_provider_prefix(model: &str) -> &str {
 /// What: strips a known prefix, else infers the provider from the id's shape via
 /// [`trusty_common::inference::infer_provider_from_model_shape`], else falls
 /// back to `default_provider`. Whichever route is taken, the resulting pair is
-/// checked for a shape conflict before it is returned. Precedence: explicit
-/// prefix > unambiguous id shape > `default_provider`.
+/// reconciled before it is returned. Precedence: explicit prefix > unambiguous
+/// id shape > `default_provider`.
+///
+/// #6135 changed the terminal arm: a pair that cannot be reconciled is RESOLVED
+/// and the run proceeds — see [`resolve_model`], which additionally reports what
+/// the resolution changed. This function discards that record and is the form to
+/// call when only the pair is wanted.
 ///
 /// # Errors
 ///
-/// [`LlmError::Validation`], naming both the requested id and the provider that
-/// would execute it, when the two disagree.
+/// [`LlmError::Validation`] only when no reasonable resolution exists — the id
+/// names a provider this crate cannot call and has no counterpart in one it can.
 ///
 /// Test: `provider_factory_prefix_routing`,
 /// `bare_openrouter_slug_routes_to_openrouter_not_the_default`,
 /// `bare_bedrock_profile_id_routes_to_bedrock_not_the_default`,
-/// `prefix_that_contradicts_the_id_shape_is_an_error`,
+/// `a_contradicting_pair_resolves_instead_of_failing`,
 /// `ambiguous_bare_id_still_uses_the_default_provider`.
 pub fn resolve_provider_and_model(
     model: &str,
     default_provider: &Provider,
 ) -> Result<(Provider, String), LlmError> {
+    let resolved = resolve_model(model, default_provider)?;
+    Ok((resolved.provider, resolved.model))
+}
+
+/// What a model id resolved to, and how that differs from what was asked for.
+///
+/// Why: the owner ruling of 2026-08-21 replaced #6114's refusal with an
+/// attribution guarantee — a naming difference resolves and the run proceeds,
+/// but the report must state what actually ran. A `(provider, model)` pair alone
+/// cannot say that, because it has forgotten the request.
+/// What: the provider and bare id that will execute, the operator's original
+/// string, and `note` — present only when the two differ, carrying the one line
+/// the report and the log both show.
+/// Test: `a_contradicting_pair_resolves_instead_of_failing`,
+/// `a_translatable_id_keeps_the_pinned_provider`,
+/// `an_exact_resolution_records_no_adjustment`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ModelResolution {
+    /// The provider that will execute the call.
+    pub provider: Provider,
+    /// The bare model id that will run, prefix stripped.
+    pub model: String,
+    /// What the caller asked for, verbatim, prefix included.
+    pub requested: String,
+    /// Why the resolved pair differs from the request, when it does.
+    pub note: Option<String>,
+}
+
+impl ModelResolution {
+    /// Whether the resolver changed anything about the request.
+    #[must_use]
+    pub fn adjusted(&self) -> bool {
+        self.note.is_some()
+    }
+
+    /// `requested → ran`, or just the id when nothing was adjusted.
+    ///
+    /// One place decides how an adjustment reads, so the report body, the JSON
+    /// twin, and the log line cannot describe the same resolution differently.
+    #[must_use]
+    pub fn attribution(&self) -> String {
+        if self.adjusted() {
+            format!("{} → {} ({})", self.requested, self.model, self.provider)
+        } else {
+            format!("{} ({})", self.model, self.provider)
+        }
+    }
+}
+
+/// Resolve a model id to the provider and id that will actually run it.
+///
+/// Why: this is [`resolve_provider_and_model`] with the record kept. Owner
+/// ruling 2026-08-21: "Models selection should be robust. We shouldn't fail on
+/// naming/id issue. The report should include which models are used."
+/// What: the same precedence — explicit prefix > unambiguous id shape >
+/// `default_provider` — with the reconciliation in [`reconcile`].
+///
+/// # Errors
+///
+/// [`LlmError::Validation`] when the id belongs to a provider this crate cannot
+/// call and no verified counterpart exists in one it can.
+///
+/// Test: see [`ModelResolution`].
+pub fn resolve_model(
+    model: &str,
+    default_provider: &Provider,
+) -> Result<ModelResolution, LlmError> {
     if let Some(bare) = model.strip_prefix(BEDROCK_MODEL_PREFIX) {
         return reconcile(Provider::Bedrock, bare, model);
     }
@@ -292,52 +366,110 @@ pub fn resolve_provider_and_model(
         return reconcile(Provider::Fireworks, bare, model);
     }
     // #6114: no routing prefix — let an unambiguous id shape name its provider
-    // before the configured default gets it.
+    // before the configured default gets it. Nothing is adjusted here: the id
+    // runs exactly as written, on the provider whose catalogue it is in.
     if let Some(inferred) = trusty_common::inference::infer_provider_from_model_shape(model)
         .and_then(Provider::from_provider_id)
     {
-        return Ok((inferred, model.to_string()));
+        return Ok(ModelResolution {
+            provider: inferred,
+            model: model.to_string(),
+            requested: model.to_string(),
+            note: None,
+        });
     }
     reconcile(default_provider.clone(), model, model)
 }
 
-/// Refuse a `(provider, model)` pair whose id names a different provider.
+/// Resolve a `(provider, model)` pair whose id names a different provider.
 ///
-/// Why: #6114 — the id and the provider that will execute it must agree, and
-/// when they do not the only safe outcome is a loud stop. Silently running the
-/// provider's default model is the failure this exists to prevent.
-/// What: `Ok((provider, bare))` when the shape agrees or is ambiguous;
-/// [`LlmError::Validation`] naming `requested`, the inferred provider, and
-/// `provider` otherwise. `requested` is the operator's original string (prefix
-/// included) so the message quotes what they actually typed.
+/// Why: #6114 made this pair a hard stop, because running the provider's own
+/// default instead is the silent-wrong-model failure of the #6093 incident. The
+/// owner ruling of 2026-08-21 keeps that guarantee but moves it from refusal to
+/// attribution: the run proceeds on the operator's evident intent, and the
+/// report states what ran. A stop that blocks a due-diligence render over a
+/// spelling is the worse outcome now that the report cannot hide the answer.
+/// What: three arms, in order.
+///
+/// 1. The shape agrees, or is only a dotted-vendor guess: the pair stands.
+/// 2. The id has a verified counterpart in the pinned provider's own dialect:
+///    the provider the operator pinned wins and the id is translated
+///    ([`dialect::translate_model_dialect`]).
+/// 3. Otherwise the id keeps its own catalogue and the call routes to the
+///    provider that catalogue belongs to.
+///
+/// `requested` is the operator's original string (prefix included) so the note
+/// quotes what they actually typed.
 ///
 /// Uses [`conclusive_shape_mismatch`], not the plain form: every caller here
 /// reaches this with a provider the operator pinned by prefix, or with a
-/// default that only sees ids no shape claimed. Rejecting a pinned provider on
-/// the dotted-vendor guess would break `openrouter/anthropic.claude-x`, a
-/// working configuration, on a vendor-name coincidence.
+/// default that only sees ids no shape claimed. Overruling a pinned provider on
+/// the dotted-vendor guess would move `openrouter/anthropic.claude-x`, a working
+/// configuration, onto another provider on a vendor-name coincidence.
+///
+/// # Errors
+///
+/// [`LlmError::Validation`] when arm 3 has nowhere to route to — the shape names
+/// a provider `trusty-review` cannot call. Unreachable through
+/// [`classify_model_shape`]'s current answers, and kept as the honest terminal
+/// arm rather than a silent substitution.
 ///
 /// [`conclusive_shape_mismatch`]: trusty_common::inference::conclusive_shape_mismatch
-/// Test: `prefix_that_contradicts_the_id_shape_is_an_error`,
-/// `every_contradicting_pair_is_refused`,
+/// [`classify_model_shape`]: trusty_common::inference::classify_model_shape
+/// Test: `a_contradicting_pair_resolves_instead_of_failing`,
+/// `a_translatable_id_keeps_the_pinned_provider`,
+/// `every_contradicting_pair_resolves`,
 /// `explicit_prefix_survives_a_probable_bedrock_shape`.
-fn reconcile(
-    provider: Provider,
-    bare: &str,
-    requested: &str,
-) -> Result<(Provider, String), LlmError> {
-    if let Some(inferred) =
+fn reconcile(provider: Provider, bare: &str, requested: &str) -> Result<ModelResolution, LlmError> {
+    let Some(inferred) =
         trusty_common::inference::conclusive_shape_mismatch(provider.provider_id(), bare)
-    {
+    else {
+        return Ok(ModelResolution {
+            provider,
+            model: bare.to_string(),
+            requested: requested.to_string(),
+            note: None,
+        });
+    };
+
+    // #6135 arm 2: the same model, spelled the way the pinned provider spells
+    // it. Only ever a VERIFIED id — see `dialect`.
+    if let Some(translated) = dialect::translate_model_dialect(bare, provider.provider_id()) {
+        let note = format!(
+            "requested {requested:?}, which is {inferred}'s spelling; ran {translated:?}, the \
+             same model as {provider} publishes it",
+            inferred = inferred.as_str()
+        );
+        tracing::warn!(%requested, resolved = %translated, provider = %provider, "model id translated to the pinned provider's dialect");
+        return Ok(ModelResolution {
+            provider,
+            model: translated,
+            requested: requested.to_string(),
+            note: Some(note),
+        });
+    }
+
+    // #6135 arm 3: no counterpart to translate to, so keep the model the
+    // operator named and run it where it exists.
+    let Some(routed) = Provider::from_provider_id(inferred) else {
         return Err(LlmError::Validation(format!(
-            "model id {requested:?} names the {inferred} provider by its shape, but this call \
-             would run on {provider}. Refusing to substitute a different model than the one \
-             requested. Either set the provider to {inferred}, or pin one explicitly with a \
-             routing prefix (\"bedrock/…\", \"openrouter/…\", \"fireworks/…\").",
+            "model id {requested:?} belongs to the {inferred} catalogue, which this build cannot \
+             call, and no verified equivalent exists on {provider}. Name a model one of \
+             bedrock/openrouter/fireworks publishes.",
             inferred = inferred.as_str()
         )));
-    }
-    Ok((provider, bare.to_string()))
+    };
+    let note = format!(
+        "requested {requested:?} on {provider}; ran on {routed} instead — the id belongs to its \
+         catalogue and {provider} publishes no verified equivalent"
+    );
+    tracing::warn!(%requested, provider = %routed, "model id routed to the provider whose catalogue it belongs to");
+    Ok(ModelResolution {
+        provider: routed,
+        model: bare.to_string(),
+        requested: requested.to_string(),
+        note: Some(note),
+    })
 }
 
 /// Build an `Arc<dyn LlmProvider>` from the resolved role config.
@@ -595,53 +727,106 @@ mod tests {
         assert_eq!(prov, Provider::Bedrock);
     }
 
-    /// #6114: an explicit prefix that contradicts the id's shape is an error
-    /// naming both, never a silent run on the prefixed provider's default.
+    /// #6135 (owner ruling 2026-08-21): an explicit prefix that contradicts the
+    /// id's shape RESOLVES and the run proceeds — #6114's refusal became an
+    /// attribution. The model stays the one the operator named; only where it
+    /// runs changes, and the resolution says so.
     #[test]
-    fn prefix_that_contradicts_the_id_shape_is_an_error() {
-        let err =
-            resolve_provider_and_model("bedrock/anthropic/claude-opus-4.8", &Provider::OpenRouter)
-                .expect_err("a bedrock/ prefix on an OpenRouter slug must not resolve");
-        let msg = err.to_string();
+    fn a_contradicting_pair_resolves_instead_of_failing() {
+        let resolution = resolve_model("bedrock/anthropic/claude-opus-4.8", &Provider::OpenRouter)
+            .expect(
+                "a bedrock/ prefix on an OpenRouter slug resolves rather than stopping the run",
+            );
+        assert_eq!(
+            resolution.provider,
+            Provider::OpenRouter,
+            "Bedrock publishes no verified Opus 4.8 profile, so the id keeps its own catalogue"
+        );
+        assert_eq!(resolution.model, "anthropic/claude-opus-4.8");
+        assert!(resolution.adjusted(), "the change must be recorded");
+        let note = resolution.note.clone().unwrap_or_default();
         assert!(
-            msg.contains("anthropic/claude-opus-4.8"),
-            "the error must name the requested id: {msg}"
+            note.contains("anthropic/claude-opus-4.8")
+                && note.contains("bedrock")
+                && note.contains("openrouter"),
+            "the note must name the id and both providers: {note}"
         );
         assert!(
-            msg.contains("bedrock") && msg.contains("openrouter"),
-            "the error must name both providers: {msg}"
+            resolution
+                .attribution()
+                .contains("bedrock/anthropic/claude-opus-4.8 → anthropic/claude-opus-4.8"),
+            "the attribution must show requested → ran: {}",
+            resolution.attribution()
         );
     }
 
-    /// #6114: the refusal is symmetric across all three backends, so no pairing
-    /// is left with a silent substitution.
+    /// #6135: where the pinned provider publishes the same model, IT wins and
+    /// the id is translated into its dialect — the operator pinned the provider
+    /// for this call, and the model survives the translation intact.
     #[test]
-    fn every_contradicting_pair_is_refused() {
-        // A Bedrock profile id pinned to Fireworks by prefix cannot run.
-        let err = resolve_provider_and_model(
-            "fireworks/us.anthropic.claude-sonnet-4-6",
-            &Provider::OpenRouter,
-        )
-        .expect_err("a bedrock profile id must not be sent to Fireworks");
-        let msg = err.to_string();
-        assert!(
-            msg.contains("us.anthropic.claude-sonnet-4-6") && msg.contains("fireworks"),
-            "the error must name the id and the provider: {msg}"
+    fn a_translatable_id_keeps_the_pinned_provider() {
+        let resolution =
+            resolve_model("bedrock/anthropic/claude-sonnet-4.6", &Provider::OpenRouter)
+                .expect("a translatable slug resolves");
+        assert_eq!(resolution.provider, Provider::Bedrock);
+        assert_eq!(
+            resolution.model, "us.anthropic.claude-sonnet-4-6",
+            "the id must be Bedrock's VERIFIED profile, never a derived spelling"
         );
+        assert!(resolution.adjusted());
+    }
 
-        // A fireworks-native id pinned to OpenRouter by prefix cannot run.
-        resolve_provider_and_model(
-            "openrouter/accounts/fireworks/models/llama-v3p1-70b-instruct",
-            &Provider::Bedrock,
-        )
-        .expect_err("a fireworks-native id must not be sent to OpenRouter");
+    /// #6135: the resolution is symmetric across all three backends, so no
+    /// pairing is left as a hard stop — and none is left as a silent
+    /// substitution either, because every one records what it changed.
+    #[test]
+    fn every_contradicting_pair_resolves() {
+        for (requested, default, expect_provider) in [
+            (
+                "fireworks/us.anthropic.claude-sonnet-4-6",
+                Provider::OpenRouter,
+                Provider::Bedrock,
+            ),
+            (
+                "openrouter/accounts/fireworks/models/llama-v3p1-70b-instruct",
+                Provider::Bedrock,
+                Provider::Fireworks,
+            ),
+        ] {
+            let resolution =
+                resolve_model(requested, &default).expect("every contradiction has a resolution");
+            assert_eq!(
+                resolution.provider, expect_provider,
+                "{requested:?} must route to the catalogue its id belongs to"
+            );
+            assert!(
+                resolution.adjusted(),
+                "{requested:?} changed provider and must say so"
+            );
+        }
 
-        // Unprefixed, that same id resolves to Fireworks on its shape alone.
-        let (prov, _) = resolved(
+        // Unprefixed, the fireworks-native id resolves to Fireworks on its shape
+        // alone — nothing was adjusted, because nothing contradicted it.
+        let resolution = resolve_model(
             "accounts/fireworks/models/llama-v3p1-70b-instruct",
             &Provider::OpenRouter,
+        )
+        .expect("resolves");
+        assert_eq!(resolution.provider, Provider::Fireworks);
+        assert!(!resolution.adjusted());
+    }
+
+    /// #6135: an ordinary resolution records nothing, so the report shows one id
+    /// rather than a `requested → ran` pair that changed nothing.
+    #[test]
+    fn an_exact_resolution_records_no_adjustment() {
+        let resolution = resolve_model("anthropic/claude-opus-4.8", &Provider::OpenRouter)
+            .expect("an agreeing pair resolves");
+        assert!(!resolution.adjusted());
+        assert_eq!(
+            resolution.attribution(),
+            "anthropic/claude-opus-4.8 (openrouter)"
         );
-        assert_eq!(prov, Provider::Fireworks);
     }
 
     /// #6114 (code-critic MEDIUM 2): an explicit routing prefix survives a

--- a/crates/trusty-review/src/main.rs
+++ b/crates/trusty-review/src/main.rs
@@ -225,15 +225,32 @@ fn main() -> Result<()> {
 }
 
 async fn async_main(cli: Cli) -> Result<()> {
-    let config = ReviewConfig::from_env_and_file(cli.config.as_deref(), None);
+    let Cli {
+        config: config_path,
+        command,
+    } = cli;
 
-    match cli.command {
+    // #6135: `report` builds its own config, because the manifest it is given is
+    // itself a config layer — it declares the provider and models of the run
+    // that produced it, and those must be resolved before the rest of the chain.
+    #[cfg(feature = "report")]
+    let command = match command {
+        Commands::Report(args) => {
+            return cli_report::cmd_report(config_path.as_deref(), args).await;
+        }
+        other => other,
+    };
+
+    let config = ReviewConfig::from_env_and_file(config_path.as_deref(), None);
+
+    match command {
         Commands::Run(args) => cmd_run(config, args).await,
         Commands::Compare(args) => cmd_compare(config, args).await,
         #[cfg(feature = "http-server")]
         Commands::Serve(args) => cmd_serve(config, args).await,
+        // `report` is dispatched above, before the config is built.
         #[cfg(feature = "report")]
-        Commands::Report(args) => cli_report::cmd_report(config, args).await,
+        Commands::Report(_) => unreachable!("report dispatched before the config is built"),
         Commands::Calibrate(args) => cmd_calibrate(config, args).await,
         Commands::WebhookListen => trusty_review::webhook_listener::run(config).await,
         Commands::Config(cmd) => cmd.run().await,

--- a/crates/trusty-review/src/mcp/tools.rs
+++ b/crates/trusty-review/src/mcp/tools.rs
@@ -404,7 +404,10 @@ fn mcp_run_mode(config: &ReviewConfig) -> RunMode {
 /// review on the startup provider anyway, and reported a `reviewer_model_fallback`
 /// string. That is still a review of the caller's diff by a model the caller did
 /// not ask for, and #6114 rules it out — a request that names a model either runs
-/// that model or fails. The fallback plumbing goes with it.
+/// that model or fails. The fallback plumbing goes with it. #6135 keeps the model
+/// and moves only the provider: a prefix the id contradicts routes to the
+/// catalogue the id belongs to, or takes that provider's own spelling of the same
+/// model, so the caller still never gets a verdict from a model they did not name.
 ///
 /// What: resolves the override's provider via `resolve_provider_and_model`; when
 /// it matches the startup provider, cheaply clones `state.llm` (no allocation).
@@ -414,14 +417,14 @@ fn mcp_run_mode(config: &ReviewConfig) -> RunMode {
 ///
 /// # Errors
 ///
-/// [`ToolError::InvalidParams`] when `reviewer_model` cannot be reconciled with
-/// the provider that would execute it, or when the matching provider cannot be
-/// built (missing credential, invalid model id).
+/// [`ToolError::InvalidParams`] when `reviewer_model` names a provider this build
+/// cannot call with no verified equivalent in one it can, or when the resolved
+/// provider cannot be built (missing credential, invalid model id).
 ///
 /// Test: `deps_from_state_openrouter_override_switches_provider`,
 /// `deps_from_state_no_override_reuses_startup_provider`,
 /// `deps_from_state_build_failure_is_an_error`,
-/// `deps_from_state_rejects_a_model_the_startup_provider_cannot_run`
+/// `deps_from_state_resolves_a_prefix_the_id_contradicts`
 /// (in `tools_dispatch_tests.rs`).
 async fn deps_from_state(state: &AppState, reviewer_model: &str) -> Result<ReviewDeps, ToolError> {
     let startup_provider = &state.config.role_models.reviewer.provider;

--- a/crates/trusty-review/src/mcp/tools_dispatch_tests.rs
+++ b/crates/trusty-review/src/mcp/tools_dispatch_tests.rs
@@ -565,22 +565,26 @@ async fn deps_from_state_routes_a_bare_openrouter_slug_to_openrouter() {
     );
 }
 
-/// #6114: a model the resolved provider cannot run stops before any review.
+/// #6135: a prefix the id contradicts resolves to the catalogue the id belongs
+/// to, and the review runs there.
 ///
-/// Why: the error must name both halves so an operator sees what disagreed,
-/// rather than reading a verdict produced by a model they never selected.
-/// What: pins a Bedrock inference-profile id to Fireworks by prefix.
+/// Why: #6114 stopped this call. The owner ruling of 2026-08-21 replaced the
+/// refusal with a resolution — the caller still never gets a verdict from a
+/// model they did not name, because the model itself is preserved; only the
+/// provider that runs it is corrected.
+/// What: pins a Bedrock inference-profile id to Fireworks by prefix against a
+/// Bedrock-startup state, and asserts the review runs on Bedrock.
 /// Test: this test itself.
 #[tokio::test]
-async fn deps_from_state_rejects_a_model_the_startup_provider_cannot_run() {
+async fn deps_from_state_resolves_a_prefix_the_id_contradicts() {
     let state = bedrock_startup_state();
-    let msg = match super::deps_from_state(&state, "fireworks/us.anthropic.claude-sonnet-4-6").await
-    {
-        Ok(_) => panic!("a bedrock profile id must not be sent to Fireworks"),
-        Err(e) => format!("{e:?}"),
-    };
-    assert!(
-        msg.contains("us.anthropic.claude-sonnet-4-6") && msg.contains("fireworks"),
-        "the error must name the id and the provider: {msg}"
+    let deps = super::deps_from_state(&state, "fireworks/us.anthropic.claude-sonnet-4-6")
+        .await
+        .expect("a contradicting prefix resolves rather than stopping the call");
+    assert_eq!(
+        deps.llm.name(),
+        "approve-dispatch-stub",
+        "the id belongs to Bedrock's catalogue, which is the startup provider — so the \
+         already-built one is reused rather than a second being constructed"
     );
 }

--- a/crates/trusty-review/src/report/figures_tests.rs
+++ b/crates/trusty-review/src/report/figures_tests.rs
@@ -27,6 +27,7 @@ fn model_with(repos: Vec<RepositoryReport>) -> ReportModel {
         analyst: None,
         client: None,
         vendor_methodology: crate::report::model::vendor_methodology(),
+        inference: None,
         instructions: None,
         instructions_source: None,
         report_date: "2026-08-21".to_string(),

--- a/crates/trusty-review/src/report/manifest.rs
+++ b/crates/trusty-review/src/report/manifest.rs
@@ -34,8 +34,75 @@ use super::error::ManifestError;
 pub struct Manifest {
     /// The top-level `[report]` metadata section.
     pub report: ReportSection,
+    /// The run's declared inference identity, when the manifest carries one
+    /// (#6135). `None` for every manifest written before this key existed, which
+    /// is what keeps an old package rendering exactly as it did.
+    pub inference: Option<InferenceSection>,
     /// One or more validated repository entries (never empty after loading).
     pub repositories: Vec<RepositoryEntry>,
+}
+
+/// The `[inference]` section: which provider and models a run is rendered with.
+///
+/// Why: owner ruling 2026-08-21 — "In audit mode, trusty review should use the
+/// same provider as audit to make it portable. From the manifest." Until now the
+/// identity travelled only as environment variables on the child `trusty-review`
+/// process, so a package re-rendered on another machine — the #6080 use case —
+/// fell through to whatever `~/.config/trusty-review/config.toml` happened to
+/// say. A June-dated local config pinning `provider = "bedrock"` is what hijacked
+/// a render on 2026-08-21 and misdirected the #6093 mitigation before it. The
+/// manifest ships with the package; the host's config does not.
+/// What: the provider and the three per-role model ids `trusty-audit` resolved,
+/// each optional so a partially-declared section still loads and the undeclared
+/// roles fall through to the layers below. Never a credential — a key stays in
+/// the environment (`OPENROUTER_API_KEY`), because a manifest is delivered to
+/// the client.
+/// Test: `manifest_tests::{parse_inference_section, an_absent_inference_section_is_none}`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[non_exhaustive]
+pub struct InferenceSection {
+    /// Provider id — `openrouter`, `bedrock`, `fireworks`.
+    #[serde(default)]
+    pub provider: Option<String>,
+    /// Model id for the reviewer role (the pass that does the judging).
+    #[serde(default)]
+    pub reviewer: Option<String>,
+    /// Model id for the verifier role.
+    #[serde(default)]
+    pub verifier: Option<String>,
+    /// Model id for the summarizer role.
+    #[serde(default)]
+    pub summarizer: Option<String>,
+}
+
+impl InferenceSection {
+    /// Whether this section declares anything at all.
+    ///
+    /// A section present but empty must behave exactly like an absent one, so
+    /// the resolution layer is skipped rather than applied with four `None`s.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.provider.is_none()
+            && self.reviewer.is_none()
+            && self.verifier.is_none()
+            && self.summarizer.is_none()
+    }
+
+    /// This section as the config precedence layer it becomes.
+    ///
+    /// Why: `config::RoleManifest` is where resolution happens, and it must not
+    /// depend on the `report` feature this type lives behind. Converting here
+    /// keeps the dependency pointing one way.
+    /// Test: `manifest_tests::the_section_becomes_a_resolution_layer`.
+    #[must_use]
+    pub fn as_role_layer(&self) -> crate::config::RoleManifest {
+        crate::config::RoleManifest {
+            reviewer_model: self.reviewer.clone(),
+            verifier_model: self.verifier.clone(),
+            summarizer_model: self.summarizer.clone(),
+            provider: self.provider.clone(),
+        }
+    }
 }
 
 /// The `[report]` metadata section of a manifest.
@@ -288,6 +355,10 @@ impl RepositorySource {
 #[derive(Debug, Deserialize)]
 struct RawManifest {
     report: ReportSection,
+    /// #6135: the run's declared provider/model identity, absent in every
+    /// manifest written before it existed.
+    #[serde(default)]
+    inference: Option<InferenceSection>,
     #[serde(default)]
     repositories: Vec<RawRepositoryEntry>,
 }
@@ -470,6 +541,9 @@ fn validate(raw: RawManifest) -> std::result::Result<Manifest, ManifestError> {
 
     Ok(Manifest {
         report: raw.report,
+        // #6135: an empty `[inference]` table declares nothing, so it must reach
+        // the resolver as absent rather than as four unset overrides.
+        inference: raw.inference.filter(|i| !i.is_empty()),
         repositories,
     })
 }

--- a/crates/trusty-review/src/report/manifest_tests.rs
+++ b/crates/trusty-review/src/report/manifest_tests.rs
@@ -325,3 +325,85 @@ fn inspect_priority_weights_follow_declared_rank() {
         "absent key must leave selection byte-identical to a pre-#6078 manifest"
     );
 }
+
+/// Why: #6135 — the manifest is the durable carrier of a run's inference
+/// identity, so the section has to parse into the four values the resolver
+/// consumes.
+/// What: a full `[inference]` table, read back field by field.
+/// Test: this test itself.
+#[test]
+fn parse_inference_section() {
+    let toml = r#"
+        [report]
+        title = "Acme"
+
+        [inference]
+        provider = "openrouter"
+        reviewer = "anthropic/claude-opus-4.8"
+        verifier = "anthropic/claude-haiku-4.5"
+        summarizer = "anthropic/claude-haiku-4.5"
+
+        [[repositories]]
+        name = "API"
+        path = "/tmp/acme-api"
+    "#;
+    let m = parse(toml).expect("parse ok");
+    let inference = m.inference.expect("the section is declared");
+    assert_eq!(inference.provider.as_deref(), Some("openrouter"));
+    assert_eq!(
+        inference.reviewer.as_deref(),
+        Some("anthropic/claude-opus-4.8")
+    );
+    assert_eq!(
+        inference.verifier.as_deref(),
+        Some("anthropic/claude-haiku-4.5")
+    );
+    assert_eq!(
+        inference.summarizer.as_deref(),
+        Some("anthropic/claude-haiku-4.5")
+    );
+    assert!(!inference.is_empty());
+}
+
+/// Why: back-compat is the whole reason the key is optional — every manifest
+/// written before #6135 must load unchanged and resolve through the layers it
+/// always did.
+/// What: a manifest with no section, and one with an empty table, both read as
+/// absent.
+/// Test: this test itself.
+#[test]
+fn an_absent_inference_section_is_none() {
+    let without =
+        parse("[report]\ntitle = \"T\"\n\n[[repositories]]\nname = \"A\"\npath = \"/x\"\n")
+            .expect("parses");
+    assert!(without.inference.is_none());
+
+    let empty = parse(
+        "[report]\ntitle = \"T\"\n\n[inference]\n\n[[repositories]]\nname = \"A\"\npath = \"/x\"\n",
+    )
+    .expect("parses");
+    assert!(
+        empty.inference.is_none(),
+        "a section that declares nothing must not become four unset overrides"
+    );
+}
+
+/// Why: the section reaches the resolver as a `RoleManifest`, and a field
+/// mis-mapped there would silently select the wrong model for a role.
+/// What: converts a partially-declared section and checks every field lands.
+/// Test: this test itself.
+#[test]
+fn the_section_becomes_a_resolution_layer() {
+    let toml = "[report]\ntitle = \"T\"\n\n[inference]\nprovider = \"openrouter\"\n\
+                reviewer = \"anthropic/claude-opus-4.8\"\n\n\
+                [[repositories]]\nname = \"A\"\npath = \"/x\"\n";
+    let m = parse(toml).expect("parses");
+    let layer = m.inference.expect("declared").as_role_layer();
+    assert_eq!(layer.provider.as_deref(), Some("openrouter"));
+    assert_eq!(
+        layer.reviewer_model.as_deref(),
+        Some("anthropic/claude-opus-4.8")
+    );
+    assert_eq!(layer.verifier_model, None);
+    assert_eq!(layer.summarizer_model, None);
+}

--- a/crates/trusty-review/src/report/model.rs
+++ b/crates/trusty-review/src/report/model.rs
@@ -36,6 +36,109 @@ pub fn vendor_methodology() -> String {
     )
 }
 
+/// Which models this render actually ran, per role (#6135).
+///
+/// Why: owner ruling 2026-08-21 — "The report should include which models are
+/// used." That is the guarantee replacing #6114's refusal: a naming difference
+/// no longer stops the run, so the report is what makes a wrong model
+/// impossible to hide. Recording it on the model puts it in the JSON twin as
+/// well as the page.
+/// What: the provider every role resolved to, one row per role, and the layer
+/// the selection came from. `requested` and `ran` differ only when the resolver
+/// adjusted the id; both are kept so the page can show `requested → ran`.
+/// Test: `model_tests::attribution_renders_requested_and_ran`.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct InferenceAttribution {
+    /// The provider the reviewer role runs on — the pass that does the judging.
+    pub provider: String,
+    /// Where this selection came from: the manifest, or the host's own layers.
+    pub source: String,
+    /// One row per role, in reviewer/verifier/summarizer order.
+    pub roles: Vec<RoleAttribution>,
+}
+
+/// One role's resolved model (#6135).
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct RoleAttribution {
+    /// `reviewer`, `verifier`, or `summarizer`.
+    pub role: String,
+    /// The id the configuration asked for, verbatim.
+    pub requested: String,
+    /// The id that will run.
+    pub ran: String,
+    /// The provider that will run it.
+    pub provider: String,
+    /// Why `requested` and `ran` differ, when they do.
+    pub note: Option<String>,
+}
+
+impl RoleAttribution {
+    /// One role's row, from the resolution that decided it.
+    ///
+    /// Why: the mapping from a [`ModelResolution`](crate::llm::ModelResolution)
+    /// to the recorded row lives here, so the CLI cannot spell an attribution
+    /// differently from anything else that records one.
+    /// Test: `model_tests::attribution_renders_requested_and_ran`.
+    #[must_use]
+    pub fn of(role: &str, requested: &str, resolved: &crate::llm::ModelResolution) -> Self {
+        Self {
+            role: role.to_string(),
+            requested: requested.to_string(),
+            ran: resolved.model.clone(),
+            provider: resolved.provider.to_string(),
+            note: resolved.note.clone(),
+        }
+    }
+}
+
+impl InferenceAttribution {
+    /// The whole record, from the per-role rows and the layer that selected them.
+    ///
+    /// The provider is the first row's — the reviewer's, in call order — because
+    /// that is the pass that does the judging and the one the credential
+    /// preflight checks.
+    #[must_use]
+    pub fn of(source: &str, roles: Vec<RoleAttribution>) -> Self {
+        let provider = roles
+            .first()
+            .map_or_else(|| "not recorded".to_string(), |r| r.provider.clone());
+        Self {
+            provider,
+            source: source.to_string(),
+            roles,
+        }
+    }
+
+    /// The one-line form the report metadata table shows.
+    ///
+    /// Why: the page has one row for this, and a reader scanning it wants the
+    /// provider first and the adjustments visible without opening the JSON.
+    /// What: `provider — reviewer <id>; verifier <id>; summarizer <id>`, with an
+    /// adjusted role rendered as `requested → ran`.
+    /// Test: `model_tests::attribution_renders_requested_and_ran`.
+    #[must_use]
+    pub fn line(&self) -> String {
+        let roles = self
+            .roles
+            .iter()
+            .map(|r| {
+                if r.requested == r.ran {
+                    format!("{}: {}", r.role, r.ran)
+                } else {
+                    format!("{}: {} → {}", r.role, r.requested, r.ran)
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("; ");
+        format!(
+            "{} — {roles} (selected from {})",
+            self.provider, self.source
+        )
+    }
+}
+
 /// The fully assembled, render-ready report model.
 ///
 /// Why: a single source of truth for both the markdown fill and the JSON output;
@@ -67,6 +170,16 @@ pub struct ReportModel {
     /// The source path the instructions were loaded from, if any (#2340).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub instructions_source: Option<String>,
+    /// Which models this render ran, per role (#6135).
+    ///
+    /// Why: the anti-silent-wrong-model guarantee. Set by `cmd_report` from the
+    /// resolved config, so both the page and the JSON twin state what actually
+    /// ran — including any id the resolver adjusted.
+    /// What: `None` only for a model built outside the report command (a test
+    /// fixture, a caller that never resolved inference); the CLI always sets it.
+    /// Test: `reporter_tests::inference_models_row_states_what_ran`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub inference: Option<InferenceAttribution>,
     /// Report date (ISO-8601, generation day).
     pub report_date: String,
     /// Generation timestamp date (ISO-8601, generation day).
@@ -255,6 +368,9 @@ impl ReportModel {
             analyst: manifest.report.analyst.clone(),
             client: manifest.report.client.clone(),
             vendor_methodology: vendor_methodology(),
+            // #6135: filled by `cmd_report` once the config layers have resolved
+            // — this constructor knows the manifest, not the inference chain.
+            inference: None,
             instructions: instructions.map(|i| i.text.clone()),
             instructions_source: instructions.map(|i| i.source.display().to_string()),
             report_date: today.clone(),

--- a/crates/trusty-review/src/report/model_tests.rs
+++ b/crates/trusty-review/src/report/model_tests.rs
@@ -122,3 +122,48 @@ fn a_missing_authorship_file_is_the_same_named_gap() {
         model.gaps
     );
 }
+
+/// Why: #6135 replaced #6114's refusal with an attribution, so the line the
+/// report shows IS the guarantee — an adjusted id must read `requested → ran`
+/// and an unadjusted one must not pretend anything changed.
+/// What: builds the record from two resolutions, one of each kind.
+/// Test: this test itself.
+#[test]
+fn attribution_renders_requested_and_ran() {
+    use crate::config::Provider;
+    use crate::llm::resolve_model;
+    use crate::report::model::{InferenceAttribution, RoleAttribution};
+
+    let straight = resolve_model("anthropic/claude-opus-4.8", &Provider::OpenRouter)
+        .expect("an agreeing pair resolves");
+    let adjusted = resolve_model("bedrock/anthropic/claude-sonnet-4.6", &Provider::OpenRouter)
+        .expect("a translatable id resolves");
+
+    let record = InferenceAttribution::of(
+        "the manifest's [inference] section",
+        vec![
+            RoleAttribution::of("reviewer", "anthropic/claude-opus-4.8", &straight),
+            RoleAttribution::of("verifier", "bedrock/anthropic/claude-sonnet-4.6", &adjusted),
+        ],
+    );
+
+    assert_eq!(
+        record.provider, "openrouter",
+        "the reviewer's provider leads"
+    );
+    let line = record.line();
+    assert!(
+        line.contains("reviewer: anthropic/claude-opus-4.8"),
+        "an unadjusted role shows one id: {line}"
+    );
+    assert!(
+        line.contains(
+            "verifier: bedrock/anthropic/claude-sonnet-4.6 → us.anthropic.claude-sonnet-4-6"
+        ),
+        "an adjusted role shows both halves: {line}"
+    );
+    assert!(
+        line.contains("the manifest's [inference] section"),
+        "the line states which layer selected the models: {line}"
+    );
+}

--- a/crates/trusty-review/src/report/reporter.rs
+++ b/crates/trusty-review/src/report/reporter.rs
@@ -303,6 +303,17 @@ pub(super) fn build_scope(model: &ReportModel) -> Scope {
         tag(&model.vendor_methodology, Provenance::Measured),
     );
     root.set("report_version", tag(crate_version(), Provenance::Measured));
+    // #6135: which models produced this report. Measured — the tool resolved it
+    // and knows it. A model built outside the report command carries none, and
+    // the row then says so rather than reading as a report with no inference.
+    root.set(
+        "inference_models",
+        match &model.inference {
+            Some(attribution) => tag(attribution.line(), Provenance::Measured),
+            None => "not recorded — this report was rendered without a resolved model selection"
+                .to_string(),
+        },
+    );
     root.set("provenance_legend", provenance::LEGEND);
     root.set("analyst_instructions_block", instructions_block(model));
     // #6004: the Key Facts block frontloads density/complexity/author/

--- a/crates/trusty-review/src/report/reporter_authorship_tests.rs
+++ b/crates/trusty-review/src/report/reporter_authorship_tests.rs
@@ -26,6 +26,7 @@ fn model_with(repos: Vec<RepositoryReport>) -> ReportModel {
         analyst: None,
         client: None,
         vendor_methodology: crate::report::model::vendor_methodology(),
+        inference: None,
         instructions: None,
         instructions_source: None,
         report_date: "2026-08-18".to_string(),

--- a/crates/trusty-review/src/report/reporter_codesec_tests.rs
+++ b/crates/trusty-review/src/report/reporter_codesec_tests.rs
@@ -29,6 +29,7 @@ fn model_with(repos: Vec<RepositoryReport>) -> ReportModel {
         analyst: None,
         client: None,
         vendor_methodology: crate::report::model::vendor_methodology(),
+        inference: None,
         instructions: None,
         instructions_source: None,
         report_date: "2026-08-18".to_string(),

--- a/crates/trusty-review/src/report/reporter_facts_tests.rs
+++ b/crates/trusty-review/src/report/reporter_facts_tests.rs
@@ -40,6 +40,7 @@ fn model_with(repos: Vec<RepositoryReport>) -> ReportModel {
         analyst: None,
         client: None,
         vendor_methodology: crate::report::model::vendor_methodology(),
+        inference: None,
         instructions: None,
         instructions_source: None,
         report_date: "2026-08-18".to_string(),

--- a/crates/trusty-review/src/report/reporter_performance_tests.rs
+++ b/crates/trusty-review/src/report/reporter_performance_tests.rs
@@ -9,6 +9,7 @@ fn model_with(findings: Vec<MetricFinding>) -> ReportModel {
         analyst: None,
         client: None,
         vendor_methodology: crate::report::model::vendor_methodology(),
+        inference: None,
         instructions: None,
         instructions_source: None,
         report_date: "2026-08-21".to_string(),

--- a/crates/trusty-review/src/report/reporter_tests.rs
+++ b/crates/trusty-review/src/report/reporter_tests.rs
@@ -147,6 +147,54 @@ fn render_contains_expected() {
     assert!(!md.contains("{{"));
 }
 
+/// Why: #6135 — the report is what makes a wrong model impossible to hide, now
+/// that a naming difference resolves instead of stopping the run. The Report
+/// Metadata row is where a reader sees it, so it must carry the provider, every
+/// role, and both halves of any id the resolver adjusted.
+/// What: renders the bundled template with an attribution set, then again with
+/// none, and asserts the second states its absence rather than rendering blank.
+/// Test: this test itself.
+#[test]
+fn inference_models_row_states_what_ran() {
+    use crate::config::Provider;
+    use crate::llm::resolve_model;
+    use crate::report::model::{InferenceAttribution, RoleAttribution};
+
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let mut model = fixture_model(tmp.path());
+    let straight = resolve_model("anthropic/claude-opus-4.8", &Provider::OpenRouter)
+        .expect("an agreeing pair resolves");
+    let adjusted = resolve_model("bedrock/anthropic/claude-sonnet-4.6", &Provider::OpenRouter)
+        .expect("a translatable id resolves");
+    model.inference = Some(InferenceAttribution::of(
+        "the manifest's [inference] section",
+        vec![
+            RoleAttribution::of("reviewer", "anthropic/claude-opus-4.8", &straight),
+            RoleAttribution::of("verifier", "bedrock/anthropic/claude-sonnet-4.6", &adjusted),
+        ],
+    ));
+
+    let template = TemplateLoader::bundled_only()
+        .load("report-technical-dd")
+        .expect("bundled template");
+    let md = Reporter::new(tmp.path()).render(&model, &template);
+
+    assert!(md.contains("| Inference models |"), "{md}");
+    assert!(md.contains("reviewer: anthropic/claude-opus-4.8"), "{md}");
+    assert!(
+        md.contains(
+            "verifier: bedrock/anthropic/claude-sonnet-4.6 → us.anthropic.claude-sonnet-4-6"
+        ),
+        "an adjusted id renders as requested → ran: {md}"
+    );
+    assert!(md.contains("the manifest's [inference] section"), "{md}");
+
+    // A model with no resolved selection states that, rather than leaving a row
+    // a reader would take for "no inference was involved".
+    let bare = Reporter::new(tmp.path()).render(&fixture_model(tmp.path()), &template);
+    assert!(bare.contains("not recorded"), "{bare}");
+}
+
 /// (a) #6004: a model WITH analyze data yields both the Code Quality &
 /// Architecture and Security Posture sections populated — never blank
 /// scaffolding.

--- a/crates/trusty-review/src/report/synthesize_digest_tests.rs
+++ b/crates/trusty-review/src/report/synthesize_digest_tests.rs
@@ -53,6 +53,7 @@ fn model_with(repos: Vec<RepositoryReport>, investigation: Option<Investigation>
         analyst: None,
         client: None,
         vendor_methodology: crate::report::model::vendor_methodology(),
+        inference: None,
         instructions: None,
         instructions_source: None,
         report_date: "2026-07-10".to_string(),

--- a/crates/trusty-review/src/report/synthesize_tests.rs
+++ b/crates/trusty-review/src/report/synthesize_tests.rs
@@ -160,6 +160,7 @@ fn fixture_model(findings: Vec<MetricFinding>) -> ReportModel {
         analyst: Some("bobmatnyc".to_string()),
         client: None,
         vendor_methodology: crate::report::model::vendor_methodology(),
+        inference: None,
         instructions: None,
         instructions_source: None,
         report_date: "2026-07-10".to_string(),

--- a/crates/trusty-review/templates/report-technical-dd-cast.md
+++ b/crates/trusty-review/templates/report-technical-dd-cast.md
@@ -80,6 +80,7 @@ in the coverage data provided — and name it specifically.
 | Source document | {{source_document_reference}} |
 | Vendor / methodology | CAST (CAST Software) — CAST Highlight + CAST Imaging |
 | Report date / version | {{report_date}} / {{report_version}} |
+| Inference models | {{inference_models}} |
 | Target / deal codename | {{target_codename}} |
 | Client | {{client_name}} |
 | Applications / systems assessed | {{applications_list}} |

--- a/crates/trusty-review/templates/report-technical-dd.md
+++ b/crates/trusty-review/templates/report-technical-dd.md
@@ -76,6 +76,7 @@
 | Source document | {{source_document_filename}} |
 | Vendor / methodology | {{vendor_methodology}} |
 | Report date / version | {{report_date}} |
+| Inference models | {{inference_models}} |
 | Target / deal codename | {{target_codename}} |
 | Client | {{client_name}} |
 | Applications / systems assessed | {{applications_list}} |


### PR DESCRIPTION
Refs #6135.

Owner ruling 2026-08-21, verbatim: "In audit mode, trusty review should use the same provider as audit to make it portable. From the manifest."

## What changed

`trusty-audit` writes an `[inference]` table — provider plus the three role model ids — into each repository's `manifest.toml`, beside the ranking it already writes there. `trusty-review report --manifest` resolves from that section ahead of the host's environment and `~/.config/trusty-review/config.toml`. Precedence per field is CLI flag > manifest > env var > config file > built-in default. A manifest with no section resolves exactly as before, so already-delivered packages keep rendering.

Schema chosen: a top-level `[inference]` table with `provider` / `reviewer` / `verifier` / `summarizer`, mirroring the engagement config's `[models]` key names so the round-trip reads as one thing. It is a separate table from `[report]`, which keeps it clear of the concurrent `inspect_priority` work; the writer is a separate function from `grounding::priority::write_into` and runs after it, and `toml_edit` preserves what neither touched.

The section carries identity, never a credential. The key stays in `OPENROUTER_API_KEY`, and a render whose declared provider has no credential stops before any repository is walked with the provider named in the message.

## Scope change — second owner ruling, verbatim

"Models selection should be robust. We shouldn't fail on naming/id issue. The report should include which models are used."

That moved #6114's terminal arm from refusal to attribution:

- A prefix that contradicts the id's shape now resolves. Where the pinned provider publishes the same model, the id is translated into that provider's own **verified** spelling (`bedrock/anthropic/claude-sonnet-4.6` → `us.anthropic.claude-sonnet-4-6`); otherwise the call routes to the provider whose catalogue the id belongs to. Translation reads the verified `ModelTier` catalogue and never derives an id by string surgery — Bedrock's Haiku profile needs a date stamp and a `-v1:0` suffix, and its Opus 4.8 profile is deliberately unmapped, so an invented id would fail at call time. `LlmError::Validation` survives only for an id belonging to a provider this build cannot call with no verified equivalent in one it can.
- The report states which models ran. New `Inference models` row in the Report Metadata table, new `inference` object in the JSON twin, new `## Inference` section in `trusty-audit`'s `index.md` beside the tool versions. An adjusted id shows both halves as `requested → ran`, and every adjustment is logged.

Previously-planned "irreconcilable → error" tests became "resolved → runs, attribution shows requested → ran". The hard-fail tests kept are the unresolvable arm and the missing-credential arm.

## Tests

- Manifest `provider = "openrouter"` renders on OpenRouter against a fixture config file pinning Bedrock (`config_manifest_layer_beats_a_local_config_file`, `role_models_manifest_beats_env_and_config_file`).
- No `[inference]` section → today's behaviour (`role_models_without_a_manifest_layer_are_unchanged`, `an_absent_inference_section_is_none`).
- Missing credential fails loud naming the provider (`preflight_rejects_a_blank_openrouter_key`).
- The manifest round-trips what env injection carries (`the_manifest_carries_what_the_env_carries`, `an_inherited_selection_is_still_recorded`, `the_section_lands_in_the_manifest`).
- Resolution and attribution (`a_contradicting_pair_resolves_instead_of_failing`, `a_translatable_id_keeps_the_pinned_provider`, `every_contradicting_pair_resolves`, `attribution_renders_requested_and_ran`, `attribution_shows_a_translated_id_as_requested_then_ran`, `the_index_states_which_models_rendered`, plus the `llm::dialect` unit tests).

## Gates — rung 4

```
cargo fmt --check                                              → clean
cargo clippy -p trusty-review -p trusty-audit --all-targets -- -D warnings → clean
cargo test -p trusty-review   → 1764 passed; 0 failed; 5 ignored (+ 98 across integration targets)
cargo test -p trusty-audit    → 659 passed; 0 failed; 5 ignored (+ 33 across integration targets)
cargo check --workspace --all-targets                          → clean
bash scripts/check_line_cap.sh                                 → 0 violations
bash scripts/check_changelog_fragment.sh                       → both crates recorded
bash scripts/check_sld.sh                                      → 0 errors, 0 warnings
bash scripts/check-pr-version-bump.sh                          → clear (both crates already bumped, unpublished)
```

Changelog fragments: `crates/trusty-review/changelog.d/6135-provider-from-manifest.md`, `crates/trusty-review/changelog.d/6135-resolve-model-naming.md`, `crates/trusty-audit/changelog.d/6135-provider-from-manifest.md`.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
