### PR TITLE
fix(trusty-review): render fixes from the graded self-audit

### DIFF
--- a/crates/trusty-review/changelog.d/6137-graded-self-audit-render-fixes.md
+++ b/crates/trusty-review/changelog.d/6137-graded-self-audit-render-fixes.md
@@ -1,0 +1,12 @@
+Fixed
+
+- The numeric guardrail now admits scaled-unit restatements of a large integer, so "1.55 million lines" for a measured 1,553,771 verifies instead of vetoing the whole field. It also admits the figures the report computes at render time and prints in its own sections (the investigation coverage percentage, the authorship trajectory average), which the synthesis prompt already quotes verbatim.
+- Code Quality & Architecture reads LoC and primary tech through the same source precedence Key Facts uses, so a `--analyze` run — whose fetch leaves `loc`/`counts` to the scanner by design — no longer prints "not stated in source data" beside a §4.1 that renders the scan's figures.
+- AMBER findings render their component path, so a complexity finding no longer reads "Extract the body of 'this function' (lines 23-512)" with no file named.
+- Analyze data whose component paths fall outside the audited checkout is rejected as stale-index evidence with a named gap, instead of being stamped measured. An index is addressed by directory basename, so a second checkout of the same repository answers for the audited one.
+- Every GREEN finding renders as its own topic line. The templates carried three fixed slots, so a run with 21 GREEN findings dropped 18 of them.
+- Security Posture counts only the security dimension's findings, credits that dimension's clean signals, states its actual provenance (verified LLM investigation findings, code-hygiene scope), and prints one table rather than one per row.
+- Executive-summary jump-list anchors match GitHub's rule (punctuation deleted, spaces mapped to dashes), so a heading containing `&` no longer links to an anchor that does not exist.
+- An empty Dependency Inventory renders as a named gap naming what was or was not examined, never as "no manifest-declared dependencies were found". `[workspace.dependencies]` is now inventoried, which is where a cargo workspace root declares its dependencies.
+- Performance & Scalability points at section 5 when the investigation raised scalability findings, rather than reading as though neither was assessed.
+- A verified evidence quote is completed to the end of the line it ends on, so a mitigating clause on that same line cannot be cut away from the finding it qualifies.

--- a/crates/trusty-review/src/report/analyze_adapter.rs
+++ b/crates/trusty-review/src/report/analyze_adapter.rs
@@ -868,6 +868,8 @@ pub async fn enrich_with_analyze_gaps(
     // iteration order (DOC-67 §9's determinism requirement).
     let mut missing: std::collections::BTreeMap<AnalyzeGap, Vec<String>> = Default::default();
     let mut partial: std::collections::BTreeMap<AnalyzeCaveat, Vec<String>> = Default::default();
+    // #6137: one line per repository whose index described a different checkout.
+    let mut stale: Vec<String> = Vec::new();
 
     // #5323: daemon-authored text lands in an acquirer-facing artifact, so it
     // crosses the redaction boundary before it reaches the model. Resolved once
@@ -891,14 +893,19 @@ pub async fn enrich_with_analyze_gaps(
                 mut metrics,
                 caveats,
             } => {
-                eprintln!(
-                    "[trusty-review report] --analyze: populated metrics for '{}' from index '{index_id}'",
-                    repo.name
-                );
                 super::redact::scrub_metrics(&mut metrics, &secrets);
-                repo.metrics = Some(*metrics);
-                for caveat in caveats {
-                    partial.entry(caveat).or_default().push(repo.name.clone());
+                // #6137: an index addressed by directory basename can serve a
+                // DIFFERENT checkout of the same repository. Data describing
+                // another tree is stale-index evidence, never a measurement of
+                // this one.
+                match super::analyze_scope::accept(&repo.name, &index_id, path, *metrics) {
+                    Ok(m) => {
+                        repo.metrics = Some(m);
+                        for caveat in caveats {
+                            partial.entry(caveat).or_default().push(repo.name.clone());
+                        }
+                    }
+                    Err(gap) => stale.push(gap),
                 }
             }
             AnalyzeFetch::Missing(gap) => {
@@ -925,6 +932,7 @@ pub async fn enrich_with_analyze_gaps(
             .into_iter()
             .map(|(caveat, repos)| format!("{caveat} — affects: {}.", repos.join(", "))),
     );
+    lines.extend(stale);
     lines
 }
 

--- a/crates/trusty-review/src/report/analyze_scope.rs
+++ b/crates/trusty-review/src/report/analyze_scope.rs
@@ -1,0 +1,116 @@
+//! Does the analyze data describe the tree this report audits? (#6137)
+//!
+//! Why: `analyze_adapter::derive_index_id` addresses a trusty-analyze index by
+//! the checkout directory's BASENAME, so two checkouts of the same repository
+//! at different paths — `/Users/x/Projects/trusty-tools` and
+//! `.../repos/local/trusty-tools` — resolve to the same index id. The daemon
+//! answers with whichever one it indexed. That is how one due-diligence run
+//! stamped twenty complexity findings ⁽ᵐ⁾ measured whose component paths all
+//! pointed at a different checkout on a different branch: the report presented
+//! another tree's code as a measurement of the audited one. An out-of-tree path
+//! is stale-index evidence, not measurement, and there is no way to tell from
+//! the data alone which commit it describes.
+//! What: [`out_of_tree_components`] reports the ABSOLUTE component paths in a
+//! fetched [`AnalyzeMetrics`] that do not live under the audited checkout.
+//! Relative paths are in-tree by construction (they are read against the
+//! checkout root) and never counted. [`stale_index_gap`] words the Gaps &
+//! Caveats line for a rejection.
+//! Test: `analyze_scope_tests.rs`.
+
+use std::path::Path;
+
+use super::metrics::AnalyzeMetrics;
+
+/// The absolute component paths in `metrics` that fall outside `root`.
+///
+/// Why/What: see the module doc. Comparison is a plain path-prefix test on the
+/// two paths as given — neither is canonicalised, because canonicalising would
+/// resolve a symlinked checkout onto its target and call a genuinely different
+/// tree in-tree. Returned in first-seen order, de-duplicated, so the gap line
+/// can name a few examples deterministically.
+/// Test: `analyze_scope_tests::{finds_a_component_outside_the_audited_tree,
+/// relative_components_are_always_in_tree,
+/// an_in_tree_absolute_component_is_not_flagged}`.
+pub fn out_of_tree_components(metrics: &AnalyzeMetrics, root: &Path) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    for finding in &metrics.findings {
+        // A component can carry a `:line` suffix; the path is what precedes it.
+        let path = finding
+            .component
+            .split_once(':')
+            .map_or(finding.component.as_str(), |(p, _)| p);
+        if path.is_empty() || !Path::new(path).is_absolute() || Path::new(path).starts_with(root) {
+            continue;
+        }
+        if !out.iter().any(|p| p == path) {
+            out.push(path.to_string());
+        }
+    }
+    out
+}
+
+/// Admit fetched metrics for the audited checkout, or reject them as stale.
+///
+/// Why: the single decision point — `enrich_with_analyze_gaps` should read as
+/// "accept or name the gap", not carry the path arithmetic. Keeping it here
+/// also keeps `analyze_adapter.rs` under the 500-SLOC production cap.
+/// What: `Ok(metrics)` when no component path falls outside `root`; otherwise
+/// `Err(`[`stale_index_gap`]`)`, so the caller drops the metrics entirely —
+/// complexity distribution included, since it came from the same index. Both
+/// outcomes print one operator line to stderr.
+/// Test: `analyze_scope_tests::{accept_passes_in_tree_metrics,
+/// accept_rejects_metrics_describing_another_checkout}`.
+pub fn accept(
+    repo: &str,
+    index_id: &str,
+    root: &Path,
+    metrics: AnalyzeMetrics,
+) -> Result<AnalyzeMetrics, String> {
+    let stale = out_of_tree_components(&metrics, root);
+    if stale.is_empty() {
+        eprintln!(
+            "[trusty-review report] --analyze: populated metrics for '{repo}' from index '{index_id}'"
+        );
+        return Ok(metrics);
+    }
+    eprintln!(
+        "[trusty-review report] --analyze: rejected metrics for '{repo}' — index '{index_id}' \
+         describes a checkout outside {} ({} path(s))",
+        root.display(),
+        stale.len()
+    );
+    Err(stale_index_gap(repo, index_id, &stale))
+}
+
+/// How many example paths the gap line names before it stops.
+const EXAMPLE_PATHS: usize = 2;
+
+/// The Gaps & Caveats line for a repository whose analyze data described a
+/// different checkout.
+///
+/// Why: the rejection must be visible as a NAMED gap. A section that silently
+/// loses its complexity data reads as "nothing to report" — the exact failure
+/// #5239 exists to prevent — and here the alternative is worse than silence,
+/// because the data it replaced was wrong and marked measured.
+/// What: names the repository, the count, and up to [`EXAMPLE_PATHS`] example
+/// paths, then states the operator's remedy.
+/// Test: `analyze_scope_tests::gap_line_names_the_repository_and_a_path`.
+pub fn stale_index_gap(repo: &str, index_id: &str, paths: &[String]) -> String {
+    let examples: Vec<&str> = paths
+        .iter()
+        .take(EXAMPLE_PATHS)
+        .map(String::as_str)
+        .collect();
+    format!(
+        "trusty-analyze data rejected as stale for {repo} — the index '{index_id}' describes a \
+         different checkout ({} of its component paths fall outside the audited tree, e.g. {}). \
+         Complexity distribution and analyze-derived findings are therefore not assessed for \
+         this application, not clean. Re-index the audited checkout under a distinct index id.",
+        paths.len(),
+        examples.join(", ")
+    )
+}
+
+#[cfg(test)]
+#[path = "analyze_scope_tests.rs"]
+mod tests;

--- a/crates/trusty-review/src/report/analyze_scope_tests.rs
+++ b/crates/trusty-review/src/report/analyze_scope_tests.rs
@@ -1,0 +1,87 @@
+use super::*;
+use crate::report::metrics::{MetricFinding, Severity};
+
+fn metrics_with(components: &[&str]) -> AnalyzeMetrics {
+    AnalyzeMetrics {
+        findings: components
+            .iter()
+            .map(|c| MetricFinding {
+                title: "Extract method".to_string(),
+                severity: Severity::Amber,
+                category: "maintainability".to_string(),
+                component: (*c).to_string(),
+                description: "grade F".to_string(),
+                remediation: "split it".to_string(),
+            })
+            .collect(),
+        ..Default::default()
+    }
+}
+
+/// The live defect: the daemon answered from a checkout at a different path.
+#[test]
+fn finds_a_component_outside_the_audited_tree() {
+    let m = metrics_with(&[
+        "/Users/masa/Projects/trusty-tools/crates/a/src/lib.rs",
+        "/Users/masa/Projects/trusty-tools/crates/b/src/lib.rs",
+    ]);
+    let stale = out_of_tree_components(&m, Path::new("/Users/masa/audit/repos/trusty-tools"));
+    assert_eq!(stale.len(), 2, "both components are out of tree: {stale:?}");
+}
+
+/// A relative component is read against the checkout root, so it is in-tree by
+/// construction and must never be flagged.
+#[test]
+fn relative_components_are_always_in_tree() {
+    let m = metrics_with(&["crates/a/src/lib.rs", "crates/b/src/lib.rs:67"]);
+    assert!(out_of_tree_components(&m, Path::new("/Users/masa/audit/repo")).is_empty());
+}
+
+/// An absolute component under the audited root is a genuine measurement.
+#[test]
+fn an_in_tree_absolute_component_is_not_flagged() {
+    let m = metrics_with(&["/Users/masa/audit/repo/crates/a/src/lib.rs:12"]);
+    assert!(out_of_tree_components(&m, Path::new("/Users/masa/audit/repo")).is_empty());
+}
+
+/// Duplicates collapse so the gap line names distinct paths.
+#[test]
+fn duplicate_paths_are_reported_once() {
+    let m = metrics_with(&["/elsewhere/a.rs", "/elsewhere/a.rs", "/elsewhere/b.rs"]);
+    assert_eq!(
+        out_of_tree_components(&m, Path::new("/audit")),
+        vec!["/elsewhere/a.rs".to_string(), "/elsewhere/b.rs".to_string()]
+    );
+}
+
+/// In-tree metrics pass through untouched.
+#[test]
+fn accept_passes_in_tree_metrics() {
+    let m = metrics_with(&["crates/a/src/lib.rs"]);
+    let out = accept("app", "repo", Path::new("/audit/repo"), m);
+    assert!(out.is_ok(), "in-tree metrics must be admitted");
+}
+
+/// Out-of-tree metrics are rejected whole — the complexity distribution came
+/// from the same index, so nothing from it is trustworthy.
+#[test]
+fn accept_rejects_metrics_describing_another_checkout() {
+    let m = metrics_with(&["/other/checkout/src/lib.rs"]);
+    let out = accept("app", "trusty-tools", Path::new("/audit/repo"), m);
+    let gap = out.expect_err("out-of-tree metrics must be rejected");
+    assert!(gap.contains("stale"), "gap: {gap}");
+}
+
+/// The gap line names the repository, the index, and an example path.
+#[test]
+fn gap_line_names_the_repository_and_a_path() {
+    let line = stale_index_gap(
+        "app",
+        "trusty-tools",
+        &["/other/a.rs".to_string(), "/other/b.rs".to_string()],
+    );
+    assert!(line.contains("app"), "line: {line}");
+    assert!(line.contains("trusty-tools"), "line: {line}");
+    assert!(line.contains("/other/a.rs"), "line: {line}");
+    assert!(line.contains("not clean"), "line: {line}");
+}

--- a/crates/trusty-review/src/report/contents_links.rs
+++ b/crates/trusty-review/src/report/contents_links.rs
@@ -21,7 +21,34 @@
 //! Test: `contents_links_tests.rs`.
 
 use super::fill::Scope;
-use super::manifest::slugify;
+
+/// Slug one heading exactly the way GitHub's markdown renderer anchors it.
+///
+/// Why: #6137 — this module used `manifest::slugify`, which collapses every
+/// non-alphanumeric RUN to a single dash. GitHub does something different: it
+/// DELETES punctuation and then maps each remaining space to a dash, so
+/// "Code Quality & Architecture" anchors as `code-quality--architecture` (two
+/// dashes, from the spaces either side of the deleted `&`) where slugify
+/// produced `code-quality-architecture`. Four of one report's twelve
+/// jump-list links pointed at anchors that did not exist. `slugify` is still
+/// right for what it is for — the report's output FILENAME — so this is a
+/// second function, not a change to that one.
+/// What: lowercases, keeps alphanumerics, `-` and `_`, maps ` ` to `-`, and
+/// drops everything else.
+/// Test: `contents_links_tests::{anchor_matches_github_for_ampersand_headings,
+/// anchor_matches_github_for_numbered_headings}`.
+fn github_anchor(heading: &str) -> String {
+    heading
+        .trim()
+        .to_lowercase()
+        .chars()
+        .filter_map(|c| match c {
+            ' ' => Some('-'),
+            c if c.is_alphanumeric() || c == '-' || c == '_' => Some(c),
+            _ => None,
+        })
+        .collect()
+}
 
 /// The scalar name the template carries the jump-list placeholder under.
 pub const PLACEHOLDER_FIELD: &str = "report_contents_block";
@@ -56,9 +83,9 @@ pub fn set_contents_placeholder(root: &mut Scope) {
 /// every heading that ends up in the document is a candidate.
 /// What: scans line-by-line for `## ` (level-2 only — deeper headings are
 /// per-application/per-finding detail, not top-level sections) in document
-/// order, skips [`SELF_HEADING_NEEDLE`], slugs each via [`slugify`] (the same
-/// algorithm GitHub's own renderer produces for a heading of this shape:
-/// lowercase, punctuation collapsed to `-`), de-duplicates a slug collision
+/// order, skips [`SELF_HEADING_NEEDLE`], anchors each via [`github_anchor`]
+/// (which reproduces GitHub's own rule — lowercase, punctuation DELETED,
+/// spaces mapped to `-`), de-duplicates a slug collision
 /// with a numeric suffix, and replaces [`SENTINEL`] with one bullet per
 /// heading found. No sentinel in `rendered` (a custom template that never
 /// included the placeholder) leaves the text unchanged. Zero other headings
@@ -97,10 +124,10 @@ pub fn inject(rendered: &str) -> String {
             continue;
         }
         let heading = text.trim();
-        let mut slug = slugify(heading);
+        let mut slug = github_anchor(heading);
         let mut n = 2;
         while seen_slugs.contains(&slug) {
-            slug = format!("{}-{n}", slugify(heading));
+            slug = format!("{}-{n}", github_anchor(heading));
             n += 1;
         }
         seen_slugs.push(slug.clone());

--- a/crates/trusty-review/src/report/contents_links_tests.rs
+++ b/crates/trusty-review/src/report/contents_links_tests.rs
@@ -9,8 +9,8 @@ fn links_every_top_level_heading() {
     let out = inject(&doc);
     assert!(!out.contains(SENTINEL));
     assert!(out.contains("[1. Report Metadata](#1-report-metadata)"));
-    assert!(out.contains("[3. Code Quality & Architecture](#3-code-quality-architecture)"));
-    assert!(out.contains("[9. Gaps & Caveats](#9-gaps-caveats)"));
+    assert!(out.contains("[3. Code Quality & Architecture](#3-code-quality--architecture)"));
+    assert!(out.contains("[9. Gaps & Caveats](#9-gaps--caveats)"));
     // Never a self-link to the section the list lives inside.
     assert!(!out.contains("[2. Executive Summary]"));
 }
@@ -65,10 +65,39 @@ fn fenced_evidence_hash_line_is_not_mistaken_for_a_heading() {
     );
     let out = inject(&doc);
     assert!(!out.contains(SENTINEL));
-    assert!(out.contains("[3. Code Quality & Architecture](#3-code-quality-architecture)"));
-    assert!(out.contains("[9. Gaps & Caveats](#9-gaps-caveats)"));
+    assert!(out.contains("[3. Code Quality & Architecture](#3-code-quality--architecture)"));
+    assert!(out.contains("[9. Gaps & Caveats](#9-gaps--caveats)"));
     // The fenced quote's own text survives untouched, but it must never be
     // linked as a heading (no bullet, no anchor).
     assert!(!out.contains("[Not A Real Section]"));
     assert!(!out.contains("(#not-a-real-section)"));
+}
+
+/// #6137: GitHub DELETES punctuation and then maps spaces to dashes, so a
+/// heading with an `&` anchors with TWO dashes. `manifest::slugify` collapsed
+/// the whole run to one, and four of a real report's twelve jump-list links
+/// pointed at anchors that did not exist.
+#[test]
+fn anchor_matches_github_for_ampersand_headings() {
+    assert_eq!(
+        github_anchor("Code Quality & Architecture"),
+        "code-quality--architecture"
+    );
+    assert_eq!(
+        github_anchor("Performance & Scalability"),
+        "performance--scalability"
+    );
+    assert_eq!(
+        github_anchor("8. Ticketing & Delivery Traceability"),
+        "8-ticketing--delivery-traceability"
+    );
+}
+
+/// A numbered heading's period is deleted, not turned into a dash — the same
+/// answer `slugify` gave, and it must stay that way.
+#[test]
+fn anchor_matches_github_for_numbered_headings() {
+    assert_eq!(github_anchor("1. Report Metadata"), "1-report-metadata");
+    assert_eq!(github_anchor("Key Facts"), "key-facts");
+    assert_eq!(github_anchor("Security Posture"), "security-posture");
 }

--- a/crates/trusty-review/src/report/figures.rs
+++ b/crates/trusty-review/src/report/figures.rs
@@ -1,0 +1,39 @@
+//! The figures the deterministic report prints, gathered for the numeric
+//! guardrail (#6137).
+//!
+//! Why: the guardrail's ground truth was the serialized [`ReportModel`] alone,
+//! and several figures a section renders are computed at RENDER time from
+//! counts the model carries rather than stored on it — the investigation
+//! coverage percentage (`73 of 6664 tracked (1.1% coverage…)`) and the
+//! authorship trajectory average (`avg 7213.5 commit(s)/mo`) are both derived.
+//! The synthesis prompt quotes the coverage percentage verbatim, so the model
+//! was asked to cite a figure the guardrail then rejected, taking the whole
+//! field with it. A figure the report prints in its own deterministic sections
+//! is in-model by definition, and this module is where that claim is made
+//! mechanical.
+//! What: [`printed_figures`] returns the deterministic report text — every
+//! filled scope value plus the appended investigation sections — as strings for
+//! [`synthesize_guard::allowed_numbers_with`](super::synthesize_guard::allowed_numbers_with)
+//! to tokenise. It walks the fill [`Scope`](super::fill::Scope) rather than
+//! rendered markdown, so the set does not depend on which template a run uses.
+//! Test: `figures_tests.rs`.
+
+use super::model::ReportModel;
+
+/// Every string the deterministic half of the report prints.
+///
+/// Why/What: see the module doc. Called once per synthesis run, before the
+/// first provider call; the scope build is pure and cheap next to an LLM
+/// round-trip.
+/// Test: `figures_tests::{printed_figures_carry_the_coverage_percentage,
+/// printed_figures_carry_the_authorship_trajectory_average}`.
+pub fn printed_figures(model: &ReportModel) -> Vec<String> {
+    let mut out = Vec::new();
+    super::reporter::build_scope(model).visit_scalars(&mut |v| out.push(v.to_string()));
+    out.push(super::investigate::report_sections(model));
+    out
+}
+
+#[cfg(test)]
+#[path = "figures_tests.rs"]
+mod tests;

--- a/crates/trusty-review/src/report/figures_tests.rs
+++ b/crates/trusty-review/src/report/figures_tests.rs
@@ -1,0 +1,101 @@
+use super::*;
+use crate::report::authorship::{AuthorshipSummary, MonthlyActivity};
+use crate::report::investigate::{Coverage, Investigation, InvestigationStatus, RepoInvestigation};
+use crate::report::model::RepositoryReport;
+
+fn repo() -> RepositoryReport {
+    RepositoryReport {
+        name: "app".to_string(),
+        slug: "app".to_string(),
+        source: "/tmp/app".to_string(),
+        source_kind: "local_path".to_string(),
+        username: None,
+        git_ref: None,
+        git_info: None,
+        local_path: None,
+        scan: None,
+        metrics: None,
+        authorship: None,
+        inspect_priority: Vec::new(),
+    }
+}
+
+fn model_with(repos: Vec<RepositoryReport>) -> ReportModel {
+    ReportModel {
+        title: "Test".to_string(),
+        template: "report-technical-dd".to_string(),
+        analyst: None,
+        client: None,
+        vendor_methodology: crate::report::model::vendor_methodology(),
+        instructions: None,
+        instructions_source: None,
+        report_date: "2026-08-21".to_string(),
+        generated_date: "2026-08-21".to_string(),
+        manifest_path: "manifest.toml".to_string(),
+        repositories: repos,
+        gaps: vec![],
+        synthesis: None,
+        benchmark: None,
+        investigation: None,
+        section_instructions: Default::default(),
+        ticketing: None,
+    }
+}
+
+/// The coverage percentage is computed at render time and appears nowhere in
+/// the serialized model — but the synthesis prompt quotes it, so the guardrail
+/// must know it.
+#[test]
+fn printed_figures_carry_the_coverage_percentage() {
+    let mut model = model_with(vec![repo()]);
+    model.investigation = Some(Investigation {
+        repos: vec![RepoInvestigation {
+            name: "app".to_string(),
+            slug: "app".to_string(),
+            status: InvestigationStatus::Available,
+            coverage: Coverage {
+                files_examined: 73,
+                total_files: 6664,
+                ..Default::default()
+            },
+            findings: Vec::new(),
+            deps: Default::default(),
+        }],
+    });
+
+    let printed = printed_figures(&model).join("\n");
+    assert!(
+        printed.contains("1.1% coverage"),
+        "the coverage percentage must be among the printed figures: {}",
+        &printed[printed.len().saturating_sub(400)..]
+    );
+}
+
+/// The trajectory average is likewise derived — the model carries per-month
+/// commit counts, never the average the Key Facts row prints.
+#[test]
+fn printed_figures_carry_the_authorship_trajectory_average() {
+    let mut r = repo();
+    r.authorship = Some(AuthorshipSummary {
+        monthly_trajectory: vec![
+            MonthlyActivity {
+                month: "2026-07".to_string(),
+                commits: 100,
+                active_authors: 2,
+            },
+            MonthlyActivity {
+                month: "2026-08".to_string(),
+                commits: 201,
+                active_authors: 4,
+            },
+        ],
+        ..Default::default()
+    });
+    let model = model_with(vec![r]);
+
+    let printed = printed_figures(&model).join("\n");
+    assert!(
+        printed.contains("150.5"),
+        "the trajectory average must be among the printed figures"
+    );
+}

--- a/crates/trusty-review/src/report/fill.rs
+++ b/crates/trusty-review/src/report/fill.rs
@@ -78,6 +78,27 @@ impl Scope {
     pub fn push_block(&mut self, name: impl Into<String>, scope: Scope) {
         self.blocks.entry(name.into()).or_default().push(scope);
     }
+
+    /// Call `f` once for every scalar value in this scope and, recursively, in
+    /// every block scope beneath it.
+    ///
+    /// Why: #6137 — the numeric guardrail needs the figures the deterministic
+    /// report actually prints, and a filled scope IS that set, ahead of any
+    /// template. Walking the scope rather than the rendered markdown keeps the
+    /// guardrail independent of which template a run uses.
+    /// What: visits this scope's scalars in key order, then each block's scopes
+    /// in push order. Block NAMES and scalar KEYS are not visited — only values.
+    /// Test: `fill_tests.rs::visit_scalars_reaches_nested_block_values`.
+    pub fn visit_scalars(&self, f: &mut impl FnMut(&str)) {
+        for value in self.scalars.values() {
+            f(value);
+        }
+        for scopes in self.blocks.values() {
+            for scope in scopes {
+                scope.visit_scalars(f);
+            }
+        }
+    }
 }
 
 /// Render a template against a root scope, honouring the honesty rule.

--- a/crates/trusty-review/src/report/fill_tests.rs
+++ b/crates/trusty-review/src/report/fill_tests.rs
@@ -171,3 +171,25 @@ fn strip_leading_comment_unterminated_is_untouched() {
     let template = "<!-- never closes\n# Title\n";
     assert_eq!(strip_leading_comment(template), template);
 }
+
+/// Why: #6137 — the numeric guardrail asks a filled scope which figures the
+/// report prints, and a figure inside a repeated block (a finding row, a
+/// per-application row) counts exactly as much as a root scalar.
+/// What: a nested block's scalar values are visited alongside the root's.
+/// Test: this test itself.
+#[test]
+fn visit_scalars_reaches_nested_block_values() {
+    let mut child = Scope::new();
+    child.set("inner", "1553771");
+    let mut row = Scope::new();
+    row.set("row_value", "42");
+    row.push_block("nested", child);
+    let mut root = Scope::new();
+    root.set("root_value", "7");
+    root.push_block("rows", row);
+
+    let mut seen: Vec<String> = Vec::new();
+    root.visit_scalars(&mut |v| seen.push(v.to_string()));
+    seen.sort();
+    assert_eq!(seen, vec!["1553771", "42", "7"]);
+}

--- a/crates/trusty-review/src/report/investigate/deps.rs
+++ b/crates/trusty-review/src/report/investigate/deps.rs
@@ -54,6 +54,16 @@ pub struct DependencyInventory {
     pub deps: Vec<Dependency>,
     /// Total dependencies discovered across all ecosystems (pre-cap).
     pub total: usize,
+    /// The manifest filenames actually read at the checkout root (#6137).
+    ///
+    /// Why: `total == 0` has two causes that read identically on the page —
+    /// "the manifests declare nothing" and "no manifest was examined" — and
+    /// the renderer used to state the first for both, printing "_No
+    /// manifest-declared dependencies were found_" for a workspace with 134 of
+    /// them. Recording what was read is what lets the section render a named
+    /// gap instead of a false clean claim.
+    /// Test: `deps_tests::records_the_manifests_it_examined`.
+    pub manifests_examined: Vec<String>,
 }
 
 impl DependencyInventory {
@@ -75,8 +85,10 @@ impl DependencyInventory {
 /// for a local checkout.
 /// What: collects direct dependencies from package.json, Cargo.toml, pyproject.toml,
 /// and go.mod, enriches each with a locked version from the matching lockfile when
-/// one parses, sorts by (ecosystem, name), and caps to [`MAX_ROWS`].
-/// Test: `deps_tests::multi_ecosystem_inventory`.
+/// one parses, sorts by (ecosystem, name), and caps to [`MAX_ROWS`]. Records which
+/// of those manifests existed in `manifests_examined` (#6137), so a zero total can
+/// be told apart from a root where nothing was read.
+/// Test: `deps_tests::{multi_ecosystem_inventory, records_the_manifests_it_examined}`.
 pub fn build_inventory(root: &Path) -> DependencyInventory {
     let mut all: Vec<Dependency> = Vec::new();
     all.extend(npm_deps(root));
@@ -91,8 +103,19 @@ pub fn build_inventory(root: &Path) -> DependencyInventory {
     });
     let total = all.len();
     all.truncate(MAX_ROWS);
-    DependencyInventory { deps: all, total }
+    DependencyInventory {
+        deps: all,
+        total,
+        manifests_examined: MANIFEST_FILENAMES
+            .iter()
+            .filter(|name| root.join(name).is_file())
+            .map(|name| (*name).to_string())
+            .collect(),
+    }
 }
+
+/// The root manifests [`build_inventory`] probes, in ecosystem order.
+const MANIFEST_FILENAMES: &[&str] = &["package.json", "Cargo.toml", "pyproject.toml", "go.mod"];
 
 /// Read a root manifest/lockfile as text, or `None` when absent/unreadable.
 fn read(root: &Path, name: &str) -> Option<String> {
@@ -164,7 +187,12 @@ fn npm_lock_versions(root: &Path) -> BTreeMap<String, String> {
 
 // ─── cargo ───────────────────────────────────────────────────────────────────
 
-/// Parse `Cargo.toml` `[dependencies]` and enrich with `Cargo.lock` versions.
+/// Parse `Cargo.toml` dependencies and enrich with `Cargo.lock` versions.
+///
+/// Reads `[dependencies]` and, since #6137, `[workspace.dependencies]`. A cargo
+/// WORKSPACE root declares its shared dependencies only in the latter table, so
+/// reading `[dependencies]` alone reported zero for a 134-dependency workspace
+/// and the section rendered that as a clean result.
 fn cargo_deps(root: &Path) -> Vec<Dependency> {
     let Some(text) = read(root, "Cargo.toml") else {
         return Vec::new();
@@ -173,10 +201,20 @@ fn cargo_deps(root: &Path) -> Vec<Dependency> {
         return Vec::new();
     };
     let locked = cargo_lock_versions(root);
-    let Some(deps) = value.get("dependencies").and_then(|v| v.as_table()) else {
-        return Vec::new();
-    };
-    deps.iter()
+    let mut tables: Vec<&toml::map::Map<String, toml::Value>> = Vec::new();
+    if let Some(t) = value.get("dependencies").and_then(|v| v.as_table()) {
+        tables.push(t);
+    }
+    if let Some(t) = value
+        .get("workspace")
+        .and_then(|w| w.get("dependencies"))
+        .and_then(|v| v.as_table())
+    {
+        tables.push(t);
+    }
+    tables
+        .into_iter()
+        .flatten()
         .map(|(name, spec)| {
             let spec_str = match spec {
                 toml::Value::String(s) => s.clone(),

--- a/crates/trusty-review/src/report/investigate/deps_tests.rs
+++ b/crates/trusty-review/src/report/investigate/deps_tests.rs
@@ -162,3 +162,39 @@ fn multi_ecosystem_inventory() {
     assert_eq!(inv.deps[0].ecosystem, "cargo");
     assert_eq!(inv.deps[1].ecosystem, "npm");
 }
+
+/// #6137: a cargo WORKSPACE root declares its shared dependencies under
+/// `[workspace.dependencies]` only. Reading `[dependencies]` alone reported
+/// zero for a 134-dependency workspace, which the section then stated as a
+/// clean result.
+#[test]
+fn workspace_dependencies_are_inventoried() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    write(
+        tmp.path(),
+        "Cargo.toml",
+        "[workspace]\nmembers = [\"crates/*\"]\n\n[workspace.dependencies]\n\
+         serde = \"1\"\ntokio = { version = \"1.40\", features = [\"full\"] }\n",
+    );
+    let inv = build_inventory(tmp.path());
+    assert_eq!(inv.total, 2, "inv: {:?}", inv.deps);
+    assert!(inv.deps.iter().any(|d| d.name == "serde"));
+    assert!(
+        inv.deps
+            .iter()
+            .any(|d| d.name == "tokio" && d.spec == "1.40")
+    );
+}
+
+/// #6137: "the manifests declare nothing" and "no manifest was examined" must
+/// be distinguishable at the render layer, so the probe records what it read.
+#[test]
+fn records_the_manifests_it_examined() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    assert!(build_inventory(tmp.path()).manifests_examined.is_empty());
+
+    write(tmp.path(), "Cargo.toml", "[workspace]\nmembers = []\n");
+    let inv = build_inventory(tmp.path());
+    assert_eq!(inv.total, 0, "an empty workspace declares nothing");
+    assert_eq!(inv.manifests_examined, vec!["Cargo.toml".to_string()]);
+}

--- a/crates/trusty-review/src/report/investigate/mod.rs
+++ b/crates/trusty-review/src/report/investigate/mod.rs
@@ -38,7 +38,9 @@ use crate::report::synthesize::{FindingProse, Synthesis};
 
 pub use batch::BatchStatus;
 pub use deps::{Dependency, DependencyInventory};
-pub use select::{Budget, DimensionCoverage, RiskSignals, Selection};
+pub use select::{
+    Budget, DimensionCoverage, RiskSignals, SCALABILITY_DIMENSION, SECURITY_DIMENSION, Selection,
+};
 pub use verify::VerifiedFinding;
 
 // ─── Result types ─────────────────────────────────────────────────────────────

--- a/crates/trusty-review/src/report/investigate/render.rs
+++ b/crates/trusty-review/src/report/investigate/render.rs
@@ -32,13 +32,18 @@ pub fn report_sections(model: &ReportModel) -> String {
 }
 
 /// Render the measured "Dependency Inventory" section across all repos.
+///
+/// #6137: an empty inventory is a NAMED GAP, never an assertion of zero. "No
+/// manifest-declared dependencies were found" was printed for a workspace with
+/// 134 of them — a false clean claim on the one section an acquirer reads to
+/// learn what the system is built on. When no repository had a manifest read at
+/// all, the section says the manifests were not examined; when manifests WERE
+/// read and declared nothing, it names them and says so.
 fn dependency_section(inv: &Investigation) -> String {
     let any = inv.repos.iter().any(|r| !r.deps.is_empty());
     let mut out = String::from("\n\n## Dependency Inventory\n\n");
     if !any {
-        out.push_str(
-            "_No manifest-declared dependencies were found in the inspected repositories._\n",
-        );
+        out.push_str(&empty_inventory_line(inv));
         return out;
     }
     out.push_str(&format!(
@@ -53,6 +58,40 @@ fn dependency_section(inv: &Investigation) -> String {
         out.push('\n');
     }
     out
+}
+
+/// The line an empty Dependency Inventory renders instead of a clean claim.
+///
+/// Why/What: see [`dependency_section`]. Distinguishes "no manifest was
+/// examined" (a gap in the pass) from "the manifests read declare nothing" (a
+/// fact about those manifests), and names the manifests in the second case.
+/// Test: `render_tests::{empty_inventory_with_no_manifest_is_a_named_gap,
+/// empty_inventory_names_the_manifests_it_read}`.
+fn empty_inventory_line(inv: &Investigation) -> String {
+    let mut manifests: Vec<&str> = Vec::new();
+    for name in inv
+        .repos
+        .iter()
+        .flat_map(|r| r.deps.manifests_examined.iter())
+    {
+        if !manifests.contains(&name.as_str()) {
+            manifests.push(name);
+        }
+    }
+    if manifests.is_empty() {
+        return format!(
+            "_Dependency manifests not examined{MEASURED_TAG} — no supported manifest \
+             (package.json, Cargo.toml, pyproject.toml, go.mod) was read at any inspected \
+             repository root, so this report states nothing about what the system depends on. \
+             Read this section as unassessed, not as a dependency-free codebase._\n"
+        );
+    }
+    format!(
+        "_Examined{MEASURED_TAG} {} and found no directly declared dependencies. Transitive \
+         dependencies, per-member manifests below the checkout root, and vendored code are \
+         outside this section's scope and are not assessed._\n",
+        manifests.join(", ")
+    )
 }
 
 /// Render one repository's dependency table (capped, with an "and N more" line).

--- a/crates/trusty-review/src/report/investigate/render_tests.rs
+++ b/crates/trusty-review/src/report/investigate/render_tests.rs
@@ -76,6 +76,7 @@ fn dependency_table_caps_and_overflows() {
     let inv = DependencyInventory {
         deps: vec![dep("serde", Some("1.0.203")), dep("tokio", None)],
         total: 5,
+        manifests_examined: vec!["Cargo.toml".to_string()],
     };
     let out = dependency_table(&inv);
     assert!(out.contains("| serde | cargo | 1.0 | 1.0.203 |"));
@@ -249,7 +250,7 @@ fn coverage_percentage_handles_empty_repo() {
 /// What: an all-empty inventory renders the "no dependencies" line.
 /// Test: this test itself.
 #[test]
-fn dependency_section_empty_note() {
+fn empty_inventory_with_no_manifest_is_a_named_gap() {
     let investigation = Investigation {
         repos: vec![repo(
             InvestigationStatus::Available,
@@ -258,7 +259,40 @@ fn dependency_section_empty_note() {
         )],
     };
     let out = dependency_section(&investigation);
-    assert!(out.contains("No manifest-declared dependencies"));
+    assert!(
+        out.contains("Dependency manifests not examined"),
+        "out: {out}"
+    );
+    assert!(
+        out.contains("unassessed, not as a dependency-free codebase"),
+        "out: {out}"
+    );
+    assert!(
+        !out.contains("No manifest-declared dependencies were found"),
+        "#6137: the false clean claim must be gone — out: {out}"
+    );
+}
+
+/// #6137: a manifest that WAS read and declares nothing is a different fact
+/// from a root where nothing was read, and the section names which manifest.
+#[test]
+fn empty_inventory_names_the_manifests_it_read() {
+    let investigation = Investigation {
+        repos: vec![repo(
+            InvestigationStatus::Available,
+            vec![],
+            DependencyInventory {
+                manifests_examined: vec!["Cargo.toml".to_string()],
+                ..Default::default()
+            },
+        )],
+    };
+    let out = dependency_section(&investigation);
+    assert!(out.contains("Cargo.toml"), "out: {out}");
+    assert!(
+        out.contains("no directly declared dependencies"),
+        "out: {out}"
+    );
 }
 
 /// Why: a truncated/failed batch must be NAMED — which files, which position,

--- a/crates/trusty-review/src/report/investigate/select.rs
+++ b/crates/trusty-review/src/report/investigate/select.rs
@@ -168,6 +168,21 @@ pub const DIMENSIONS: &[&str] = &[
     "test coverage",
 ];
 
+/// The one dimension of [`DIMENSIONS`] whose findings are security findings.
+///
+/// Why (#6137): the Security Posture section counted every non-maintainability
+/// finding, so error-handling and test-coverage findings were reported as
+/// security violations. Naming the dimension here — rather than spelling the
+/// string a second time in the reporter — is what keeps the two from drifting
+/// if the checklist is ever reworded.
+/// Test: `reporter_codesec_tests::security_rows_count_only_the_security_dimension`.
+pub const SECURITY_DIMENSION: &str = DIMENSIONS[0];
+
+/// The one dimension of [`DIMENSIONS`] the Performance & Scalability section
+/// cross-references (#6137) — that section has no data source of its own, but
+/// §5 does carry these findings and must be pointed at.
+pub const SCALABILITY_DIMENSION: &str = DIMENSIONS[4];
+
 /// The DD dimensions a file matches by path/name heuristics (excluding tests,
 /// which are presence-only and handled separately).
 ///

--- a/crates/trusty-review/src/report/investigate/verify.rs
+++ b/crates/trusty-review/src/report/investigate/verify.rs
@@ -134,14 +134,14 @@ pub fn verify_findings(raw: Vec<RawFinding>, selection: &Selection) -> VerifyOut
 
         // Evidence must mechanically match the file content.
         let quote = f.evidence_quote.trim();
-        match find_evidence_line(&sel.content, quote) {
-            Some(line) => out.verified.push(VerifiedFinding {
+        match find_evidence_match(&sel.content, quote) {
+            Some(m) => out.verified.push(VerifiedFinding {
                 title: title.to_string(),
                 severity,
                 dimension: f.dimension.trim().to_string(),
                 file: sel.path.clone(),
-                line: Some(line),
-                evidence_quote: quote.to_string(),
+                line: Some(m.line),
+                evidence_quote: complete_trailing_line(&sel.content, &m),
                 description: f.description.trim().to_string(),
                 business_impact: f.business_impact.trim().to_string(),
                 remediation: f.remediation.trim().to_string(),
@@ -173,6 +173,29 @@ pub fn verify_findings(raw: Vec<RawFinding>, selection: &Selection) -> VerifyOut
 /// whitespace) quote never matches.
 /// Test: `verify_tests::{accepts_and_corrects_line, matches_whitespace_insensitively}`.
 pub fn find_evidence_line(content: &str, quote: &str) -> Option<u64> {
+    find_evidence_match(content, quote).map(|m| m.line)
+}
+
+/// Where an evidence quote was found in a file.
+///
+/// Why: [`complete_trailing_line`] needs the match's byte span, not only its
+/// line, and returning both from one scan keeps the two in step.
+/// What: `line` is 1-based; `start`/`end` are byte offsets into the content,
+/// `end` exclusive and pointing just past the last matched non-whitespace char.
+pub struct EvidenceMatch {
+    /// 1-based line of the match start.
+    pub line: u64,
+    /// Byte offset of the match start.
+    pub start: usize,
+    /// Byte offset just past the last matched character.
+    pub end: usize,
+}
+
+/// The same whitespace-insensitive search as [`find_evidence_line`], returning
+/// the match's full span.
+///
+/// Test: `verify_tests::{accepts_and_corrects_line, matches_whitespace_insensitively}`.
+pub fn find_evidence_match(content: &str, quote: &str) -> Option<EvidenceMatch> {
     let needle: Vec<char> = quote.chars().filter(|c| !c.is_whitespace()).collect();
     if needle.is_empty() {
         return None;
@@ -186,6 +209,7 @@ pub fn find_evidence_line(content: &str, quote: &str) -> Option<u64> {
         }
         let mut hi = start_idx;
         let mut ni = 0usize;
+        let mut last = start_idx;
         while hi < hay.len() && ni < needle.len() {
             let c = hay[hi].1;
             if c.is_whitespace() {
@@ -193,6 +217,7 @@ pub fn find_evidence_line(content: &str, quote: &str) -> Option<u64> {
                 continue;
             }
             if c == needle[ni] {
+                last = hi;
                 hi += 1;
                 ni += 1;
             } else {
@@ -200,12 +225,52 @@ pub fn find_evidence_line(content: &str, quote: &str) -> Option<u64> {
             }
         }
         if ni == needle.len() {
-            let byte_off = hay[start_idx].0;
-            let line = content[..byte_off].bytes().filter(|&b| b == b'\n').count() as u64 + 1;
-            return Some(line);
+            let start = hay[start_idx].0;
+            let line = content[..start].bytes().filter(|&b| b == b'\n').count() as u64 + 1;
+            return Some(EvidenceMatch {
+                line,
+                start,
+                end: hay[last].0 + hay[last].1.len_utf8(),
+            });
         }
     }
     None
+}
+
+/// How far past the match end the quote may be extended to finish a line.
+///
+/// A generous sentence's worth. It bounds the damage a minified or generated
+/// single-line file could do — extending across 10k characters of one line
+/// would be a different defect, not a fix.
+const MAX_LINE_COMPLETION: usize = 240;
+
+/// Return the quote as the file's own bytes, extended to the end of the line
+/// the match ends on.
+///
+/// Why: #6137 — a quote that stops mid-line drops whatever the rest of that
+/// line says, and what it drops is systematically the part that qualifies the
+/// finding. One report quoted an installer's security note through "…download
+/// and review the script manually before running it." and cut the very next
+/// clause, on the SAME line: "All downloaded binaries are SHA-256 verified."
+/// The finding read as unmitigated remote code execution because the
+/// mitigation was outside the quote. The model chooses where to stop; the
+/// report does not have to honour a stop that lands mid-sentence.
+/// What: slices `content` from the match start to the end of the line the
+/// match ends on, so the returned quote is verbatim file text rather than the
+/// model's paraphrase of whitespace. Extension is skipped when the remainder
+/// of the line exceeds [`MAX_LINE_COMPLETION`] bytes, and when the match
+/// already ends at a line break.
+/// Test: `verify_tests::{quote_is_completed_to_the_end_of_its_line,
+/// quote_is_not_extended_across_a_very_long_line}`.
+fn complete_trailing_line(content: &str, m: &EvidenceMatch) -> String {
+    let rest = &content[m.end..];
+    let line_end = rest.find('\n').unwrap_or(rest.len());
+    let end = if line_end <= MAX_LINE_COMPLETION {
+        m.end + line_end
+    } else {
+        m.end
+    };
+    content[m.start..end].trim_end().to_string()
 }
 
 #[cfg(test)]

--- a/crates/trusty-review/src/report/investigate/verify_tests.rs
+++ b/crates/trusty-review/src/report/investigate/verify_tests.rs
@@ -151,3 +151,43 @@ fn rejects_empty_title() {
     assert!(out.verified.is_empty());
     assert_eq!(out.rejected, 1);
 }
+
+/// #6137: the live defect. An installer's security note was quoted through
+/// "…before running it." and the very next clause, on the SAME line, was cut:
+/// "All downloaded binaries are SHA-256 verified." The finding then read as
+/// unmitigated remote code execution.
+#[test]
+fn quote_is_completed_to_the_end_of_its_line() {
+    let content = "# require a higher assurance level, download and review the script manually\n\
+                   # before running it. All downloaded binaries are SHA-256 verified.\n\
+                   set -e\n";
+    let sel = selection("install.sh", content);
+    let r = raw("amber", "install.sh", "# before running it.", None);
+    let out = verify_findings(vec![r], &sel);
+
+    assert_eq!(out.rejected, 0);
+    assert!(
+        out.verified[0]
+            .evidence_quote
+            .contains("All downloaded binaries are SHA-256 verified."),
+        "the mitigation on the same line must survive: {:?}",
+        out.verified[0].evidence_quote
+    );
+    assert!(
+        !out.verified[0].evidence_quote.contains("set -e"),
+        "completion stops at the line end, never runs on"
+    );
+}
+
+/// The extension is bounded: a minified or generated single line must not drag
+/// its whole content into the quote.
+#[test]
+fn quote_is_not_extended_across_a_very_long_line() {
+    let tail = "x".repeat(400);
+    let content = format!("let a = 1; {tail}\n");
+    let sel = selection("a.js", &content);
+    let r = raw("amber", "a.js", "let a = 1;", None);
+    let out = verify_findings(vec![r], &sel);
+
+    assert_eq!(out.verified[0].evidence_quote, "let a = 1;");
+}

--- a/crates/trusty-review/src/report/mod.rs
+++ b/crates/trusty-review/src/report/mod.rs
@@ -16,6 +16,7 @@
 pub mod analyze_adapter;
 // #6041: per-endpoint paths, request budgets, and partial-fetch vocabulary.
 pub mod analyze_endpoints;
+pub mod analyze_scope;
 // #5453/#6004: the tga-authored authorship artifact, receiving half.
 pub mod authorship;
 pub mod benchmark;
@@ -23,6 +24,7 @@ pub mod benchmark;
 pub mod contents_links;
 pub mod error;
 pub mod exec_summary;
+pub mod figures;
 pub mod fill;
 pub mod git_info;
 pub mod instructions;

--- a/crates/trusty-review/src/report/reporter.rs
+++ b/crates/trusty-review/src/report/reporter.rs
@@ -281,8 +281,11 @@ fn atomic_write(path: &Path, bytes: &[u8]) -> Result<()> {
 /// names; everything it does not set falls through to the honesty marker.
 /// What: sets report-level scalars (codename, dates, analyst, applications list,
 /// source provenance) and pushes one `per_application` child scope per repo.
+///
+/// `pub(super)` since #6137: `figures::printed_figures` walks the same scope to
+/// tell the numeric guardrail which figures the report actually prints.
 /// Test: `reporter_tests.rs::render_contains_expected`.
-fn build_scope(model: &ReportModel) -> Scope {
+pub(super) fn build_scope(model: &ReportModel) -> Scope {
     let mut root = Scope::new();
 
     // Report metadata (report-level scalars).  Identity/title fields are left
@@ -426,7 +429,7 @@ fn build_scope(model: &ReportModel) -> Scope {
     // FIXED text (DOC-67 §3: no performance data source exists at all).
     push_code_quality_rows(&mut root, model);
     push_security_violation_rows(&mut root, model);
-    fill_performance_note(&mut root);
+    fill_performance_note(&mut root, model);
     // #5453/#6004: key-man risk rows render IN this section, never scattered
     // across Top Risks — the deterministic half of Authorship & Key-Person
     // Risk. A repository whose artifact failed to load contributes no row;
@@ -529,31 +532,37 @@ fn inject_synthesis_summary(root: &mut Scope, syn: &super::synthesize::Synthesis
     }
 }
 
-/// Fill the root GREEN-topic bullets (`{{green_topic_N}}`, N = 1..=3) from
-/// metrics.
+/// Fill the GREEN-topic bullets — one `green_topic` block repetition per GREEN
+/// finding.
 ///
-/// Why: the bundled templates model GREEN findings as three fixed report-level
-/// bullet placeholders (not a repeatable block); per the no-green-analysis rule
-/// they carry ONLY the finding title — no evidence, root cause, or remediation
-/// — and, unlike RED/AMBER, are never synthesized (M2 excludes greens
-/// structurally, so this fill is independent of synthesis availability).
-/// What: collects every `Severity::Green` finding across all repositories, in
-/// manifest order, and fills up to the first three titles; any remaining slot
-/// (or all three, when there are no green findings) falls through to the
-/// honesty marker.
+/// Why: per the no-green-analysis rule a GREEN topic carries ONLY the finding
+/// title — no evidence, root cause, or remediation — and, unlike RED/AMBER, is
+/// never synthesized (M2 excludes greens structurally, so this fill is
+/// independent of synthesis availability). #6137 made the bullets a repeatable
+/// block: the templates carried exactly three fixed `{{green_topic_N}}` slots,
+/// so a run with 21 GREEN findings silently dropped 18 of them — constant-time
+/// token comparison and atomic redb batch upserts among them. The
+/// no-elaboration rule is about DEPTH per topic, not about how many topics a
+/// reader is allowed to see, and this is the same fixed-slot defect #2373 fixed
+/// for the top-risk rows.
+/// What: pushes one `green_topic` scope (a single `green_topic` scalar, the
+/// finding title) per `Severity::Green` finding across all repositories, in
+/// manifest order. With no green findings no block is pushed and the section
+/// collapses via omit-empty.
 /// Test: `reporter_tests.rs::{reporter_fills_green_topics,
+/// reporter_renders_every_green_topic,
 /// reporter_leaves_findings_honesty_marked_without_metrics}`.
 fn push_green_topics(root: &mut Scope, model: &ReportModel) {
-    let greens: Vec<&str> = model
+    let greens = model
         .repositories
         .iter()
         .filter_map(|r| r.metrics.as_ref())
         .flat_map(|m| m.findings.iter())
-        .filter(|f| f.severity == Severity::Green)
-        .map(|f| f.title.as_str())
-        .collect();
-    for (i, title) in greens.iter().take(3).enumerate() {
-        root.set(format!("green_topic_{}", i + 1), (*title).to_string());
+        .filter(|f| f.severity == Severity::Green);
+    for finding in greens {
+        let mut row = Scope::new();
+        row.set("green_topic", finding.title.clone());
+        root.push_block("green_topic", row);
     }
 }
 

--- a/crates/trusty-review/src/report/reporter_codesec.rs
+++ b/crates/trusty-review/src/report/reporter_codesec.rs
@@ -15,90 +15,170 @@
 //! Test: `reporter_codesec_tests.rs`.
 
 use super::fill::Scope;
+use super::investigate::SECURITY_DIMENSION;
 use super::metrics::{AnalyzeMetrics, Severity};
-use super::model::ReportModel;
+use super::model::{ReportModel, RepositoryReport};
 use super::provenance::{Provenance, tag};
+use super::reporter_facts::{repo_languages, repo_loc};
 
 /// `MetricFinding.category` value `analyze_adapter::refactor_finding` always
 /// writes — refactor/code-smell findings are maintainability by construction,
 /// so this is the seam between "code quality" and "security posture" below.
 const MAINTAINABILITY_CATEGORY: &str = "maintainability";
 
+/// How many languages the Code Quality row names.
+const CQ_LANGUAGE_COUNT: usize = 3;
+
+/// The Security Posture text when the security dimension recorded no GREEN
+/// finding — an explicit statement, never a blank cell.
+const NO_CLEAN_SIGNALS: &str = "No clean security signals were recorded: the investigation raised no GREEN finding in \
+     this dimension. That is an absence of positive evidence, not a negative result.";
+
 /// Push one `code_quality_row` per repository carrying metrics.
 ///
 /// Why: re-projects complexity distribution, tech-stack/LoC, and the
 /// maintainability-finding count into a dedicated section (#6004) rather than
 /// requiring a reader to cross-reference §3/§4/§5.
-/// What: `cq_loc`/`cq_tech`/`cq_complexity` restate per-app profile data;
-/// `cq_maintainability_count` counts non-GREEN `maintainability`-category
-/// findings — a real zero is a stated fact (tagged, not omitted), never a gap.
-/// A repository with no metrics at all is skipped (its row would be 100%
-/// honesty markers, which the omit-empty pass would drop anyway).
-/// Test: `reporter_codesec_tests::code_quality_rows_reproject_metrics`.
+/// What: `cq_loc`/`cq_tech` take the SAME source precedence Key Facts and the
+/// §4 Profile table use ([`repo_loc`]/[`repo_languages`] — declared metrics
+/// when they carry a positive figure, else the built-in `RepoScan`), so the two
+/// sections cannot disagree about one repository's size. #6137: reading
+/// `metrics.loc.total`/`metrics.primary_languages` alone printed "not stated in
+/// source data" for both cells of a run whose `--analyze` fetch left `loc`
+/// empty by design (the adapter leaves it to the scanner) while §4.1 rendered
+/// 1,553,771 lines from the scan two sections earlier. `cq_complexity` and
+/// `cq_maintainability_count` have no scan equivalent and stay metrics-only; a
+/// real zero maintainability count is a stated fact (tagged, not omitted),
+/// never a gap. A repository carrying no data at all in any of the four cells
+/// is skipped (its row would be 100% honesty markers, which the omit-empty pass
+/// would drop anyway).
+/// Test: `reporter_codesec_tests::{code_quality_rows_reproject_metrics,
+/// code_quality_loc_and_tech_fall_back_to_the_scan}`.
 pub fn push_code_quality_rows(root: &mut Scope, model: &ReportModel) {
     for repo in &model.repositories {
-        let Some(m) = &repo.metrics else { continue };
+        let loc = repo_loc(repo);
+        let langs = top_languages(repo);
+        let complexity = repo.metrics.as_ref().and_then(bucket_summary);
+        let maintainability = repo.metrics.as_ref().map(maintainability_count);
+        if loc == 0 && langs.is_empty() && complexity.is_none() && maintainability.is_none() {
+            continue;
+        }
         let mut row = Scope::new();
         row.set("cq_app_name", repo.name.clone());
-        if m.loc.total > 0 {
-            row.set("cq_loc", tag(m.loc.total.to_string(), Provenance::Measured));
+        if loc > 0 {
+            row.set("cq_loc", tag(loc.to_string(), Provenance::Measured));
         }
-        let langs = m.primary_languages(3);
         if !langs.is_empty() {
             row.set("cq_tech", tag(langs.join(", "), Provenance::Measured));
         }
-        if let Some(summary) = bucket_summary(m) {
+        if let Some(summary) = complexity {
             row.set("cq_complexity", tag(summary, Provenance::Measured));
         }
-        let maint = m
-            .findings
-            .iter()
-            .filter(|f| f.severity != Severity::Green && f.category == MAINTAINABILITY_CATEGORY)
-            .count();
-        row.set(
-            "cq_maintainability_count",
-            tag(maint.to_string(), Provenance::Measured),
-        );
+        if let Some(count) = maintainability {
+            row.set(
+                "cq_maintainability_count",
+                tag(count.to_string(), Provenance::Measured),
+            );
+        }
         root.push_block("code_quality_row", row);
     }
 }
 
-/// Push one `security_violations_table` row per (application, tool/domain)
-/// with at least one RED/AMBER finding whose category is NOT maintainability.
+/// The top [`CQ_LANGUAGE_COUNT`] languages by LoC for one repository, from
+/// whichever source [`repo_languages`] selected.
+fn top_languages(repo: &RepositoryReport) -> Vec<String> {
+    let mut langs: Vec<&super::metrics::LanguageLoc> = repo_languages(repo).iter().collect();
+    langs.sort_by_key(|l| std::cmp::Reverse(l.loc));
+    langs
+        .into_iter()
+        .take(CQ_LANGUAGE_COUNT)
+        .map(|l| l.language.clone())
+        .collect()
+}
+
+/// Count one repository's non-GREEN maintainability findings.
+fn maintainability_count(m: &AnalyzeMetrics) -> usize {
+    m.findings
+        .iter()
+        .filter(|f| f.severity != Severity::Green && f.category == MAINTAINABILITY_CATEGORY)
+        .count()
+}
+
+/// Push one `security_violations_table` row per application carrying a RED or
+/// AMBER finding in the SECURITY dimension, and state that dimension's clean
+/// signals.
 ///
 /// Why (#6004): promotes §6.1 out of Risk Registers into its own top-level
-/// Security Posture section — the block name and column shape are unchanged
-/// (`app_name`/`violation_domain`/`violation_count`) so this is a straight
-/// re-projection of the RED/AMBER findings §5 already lists, grouped by the
-/// producing tool. This is the first reporter code that actually fills that
-/// block; before #6004 it was unfilled template scaffolding.
-/// What: excludes GREEN (no-green-analysis rule) and `maintainability`
-/// (Code Quality's finding class, not a lint/security domain).
-/// Test: `reporter_codesec_tests::security_rows_group_by_domain_excluding_maintainability`.
+/// Security Posture section. #6137 narrows what it counts: the table used to
+/// group EVERY non-maintainability finding by category, so a run whose
+/// investigation covers six due-diligence dimensions printed error-handling,
+/// state-management, scalability, test-coverage and dependency findings under a
+/// "Security Posture" heading labelled "Total violations" — 90 of one report's
+/// 110 rows were not security findings at all. Only
+/// [`SECURITY_DIMENSION`] findings are security findings. The GREEN findings in
+/// that same dimension are the clean signals a reader weighs the count against,
+/// and dropping them (the no-green-analysis rule bans ELABORATION, not
+/// acknowledgement) left the section reading as unmitigated risk.
+/// What: counts non-GREEN [`SECURITY_DIMENSION`] findings per repository,
+/// pushing one row (`app_name`/`violation_domain`/`violation_count`, the block's
+/// unchanged column shape) per repository with at least one; sets
+/// `security_clean_signals` from that dimension's GREEN finding titles, or
+/// [`NO_CLEAN_SIGNALS`] when it recorded none.
+/// Test: `reporter_codesec_tests::{security_rows_count_only_the_security_dimension,
+/// security_section_credits_clean_signals,
+/// security_section_states_when_no_clean_signal_exists}`.
 pub fn push_security_violation_rows(root: &mut Scope, model: &ReportModel) {
+    let mut clean: Vec<&str> = Vec::new();
+    let mut assessed = false;
     for repo in &model.repositories {
         let Some(m) = &repo.metrics else { continue };
-        let mut counts: Vec<(String, u64)> = Vec::new();
-        for f in &m.findings {
-            if f.severity == Severity::Green || f.category == MAINTAINABILITY_CATEGORY {
-                continue;
-            }
-            match counts.iter_mut().find(|(c, _)| *c == f.category) {
-                Some(entry) => entry.1 += 1,
-                None => counts.push((f.category.clone(), 1)),
+        assessed = true;
+        let mut count = 0u64;
+        for f in m
+            .findings
+            .iter()
+            .filter(|f| f.category == SECURITY_DIMENSION)
+        {
+            if f.severity == Severity::Green {
+                clean.push(&f.title);
+            } else {
+                count += 1;
             }
         }
-        for (domain, count) in counts {
-            let mut row = Scope::new();
-            row.set("app_name", repo.name.clone());
-            row.set("violation_domain", tag(domain, Provenance::Measured));
-            row.set(
-                "violation_count",
-                tag(count.to_string(), Provenance::Measured),
-            );
-            root.push_block("security_violations_table", row);
+        if count == 0 {
+            continue;
         }
+        let mut row = Scope::new();
+        row.set("app_name", repo.name.clone());
+        row.set(
+            "violation_domain",
+            tag(SECURITY_DIMENSION, Provenance::Measured),
+        );
+        row.set(
+            "violation_count",
+            tag(count.to_string(), Provenance::Measured),
+        );
+        root.push_block("security_violations_table", row);
     }
+    // A run that assessed nothing states nothing: the scalar is left unset, so
+    // the honesty rule collapses the line and Gaps & Caveats names the section.
+    // Claiming "no clean signal was recorded" for a run with no findings at all
+    // would be the same false-clean claim this section exists to avoid.
+    if !assessed {
+        return;
+    }
+    let signals = if clean.is_empty() {
+        tag(NO_CLEAN_SIGNALS, Provenance::NotStated)
+    } else {
+        tag(
+            format!(
+                "Clean signals found in this dimension: {}.",
+                clean.join("; ")
+            ),
+            Provenance::Measured,
+        )
+    };
+    root.set("security_clean_signals", signals);
 }
 
 /// A compact "label: count (pct%)" complexity summary for one repository's

--- a/crates/trusty-review/src/report/reporter_codesec_tests.rs
+++ b/crates/trusty-review/src/report/reporter_codesec_tests.rs
@@ -103,15 +103,20 @@ fn no_metrics_yields_no_code_quality_rows() {
     assert_eq!(rendered, "");
 }
 
-/// Security rows group by domain and exclude maintainability + GREEN.
+/// #6137: only the security dimension's RED/AMBER findings count. The table
+/// used to group EVERY non-maintainability finding by category, so
+/// error-handling and test-coverage findings were reported as security
+/// violations.
 #[test]
-fn security_rows_group_by_domain_excluding_maintainability() {
+fn security_rows_count_only_the_security_dimension() {
     let metrics = AnalyzeMetrics {
         findings: vec![
-            finding("clippy", Severity::Red),
-            finding("clippy", Severity::Amber),
+            finding(SECURITY_DIMENSION, Severity::Red),
+            finding(SECURITY_DIMENSION, Severity::Amber),
+            finding("error handling", Severity::Amber),
+            finding("test coverage", Severity::Amber),
             finding(MAINTAINABILITY_CATEGORY, Severity::Amber),
-            finding("ruff", Severity::Green),
+            finding(SECURITY_DIMENSION, Severity::Green),
         ],
         ..Default::default()
     };
@@ -121,8 +126,92 @@ fn security_rows_group_by_domain_excluding_maintainability() {
 
     let template = "<!-- BEGIN security_violations_table -->{{app_name}}|{{violation_domain}}|{{violation_count}}\n<!-- END security_violations_table -->";
     let rendered = crate::report::fill::render(template, &root);
-    assert!(rendered.contains("app|clippy"));
-    assert!(rendered.contains("|2 "), "rendered: {rendered}");
-    assert!(!rendered.contains("maintainability"));
-    assert!(!rendered.contains("ruff"));
+    assert!(rendered.contains("app|authentication & secrets"));
+    assert!(
+        rendered.contains("|2 "),
+        "only the two non-GREEN security findings count: {rendered}"
+    );
+    assert!(!rendered.contains("error handling"), "{rendered}");
+    assert!(!rendered.contains("test coverage"), "{rendered}");
+    assert!(!rendered.contains("maintainability"), "{rendered}");
+}
+
+/// #6137: GREEN findings in the security dimension are credited by title. The
+/// no-green-analysis rule bans elaboration, not acknowledgement.
+#[test]
+fn security_section_credits_clean_signals() {
+    let mut green = finding(SECURITY_DIMENSION, Severity::Green);
+    green.title = "Constant-time bearer token comparison".to_string();
+    let metrics = AnalyzeMetrics {
+        findings: vec![finding(SECURITY_DIMENSION, Severity::Amber), green],
+        ..Default::default()
+    };
+    let model = model_with(vec![repo(Some(metrics))]);
+    let mut root = Scope::new();
+    push_security_violation_rows(&mut root, &model);
+
+    let rendered = crate::report::fill::render("{{security_clean_signals}}", &root);
+    assert!(
+        rendered.contains("Constant-time bearer token comparison"),
+        "rendered: {rendered}"
+    );
+}
+
+/// #6137: no GREEN security finding is stated as an absence of evidence, never
+/// left blank or dropped to the honesty marker.
+#[test]
+fn security_section_states_when_no_clean_signal_exists() {
+    let metrics = AnalyzeMetrics {
+        findings: vec![finding(SECURITY_DIMENSION, Severity::Amber)],
+        ..Default::default()
+    };
+    let model = model_with(vec![repo(Some(metrics))]);
+    let mut root = Scope::new();
+    push_security_violation_rows(&mut root, &model);
+
+    let rendered = crate::report::fill::render("{{security_clean_signals}}", &root);
+    assert!(
+        rendered.contains("No clean security signals were recorded"),
+        "rendered: {rendered}"
+    );
+}
+
+/// #6137: the live defect. `--analyze` leaves `loc`/`counts` empty by design
+/// (the scanner owns them), so reading metrics alone printed "not stated in
+/// source data" for LoC and tech while §4.1 rendered the scan's figures two
+/// sections above.
+#[test]
+fn code_quality_loc_and_tech_fall_back_to_the_scan() {
+    let metrics = AnalyzeMetrics {
+        findings: vec![finding(MAINTAINABILITY_CATEGORY, Severity::Amber)],
+        ..Default::default()
+    };
+    let mut r = repo(Some(metrics));
+    r.scan = Some(crate::report::scan::RepoScan {
+        total_loc: 1_553_771,
+        file_count: 6664,
+        by_language: vec![
+            LanguageLoc {
+                language: "Rust".to_string(),
+                loc: 1_408_871,
+            },
+            LanguageLoc {
+                language: "HTML".to_string(),
+                loc: 33_376,
+            },
+        ],
+        frameworks: Vec::new(),
+    });
+    let model = model_with(vec![r]);
+    let mut root = Scope::new();
+    push_code_quality_rows(&mut root, &model);
+
+    let template = "<!-- BEGIN code_quality_row -->{{cq_app_name}}|{{cq_loc}}|{{cq_tech}}<!-- END code_quality_row -->";
+    let rendered = crate::report::fill::render(template, &root);
+    assert!(rendered.contains("1553771"), "rendered: {rendered}");
+    assert!(rendered.contains("Rust, HTML"), "rendered: {rendered}");
+    assert!(
+        !rendered.contains(crate::report::fill::HONESTY_MARKER),
+        "rendered: {rendered}"
+    );
 }

--- a/crates/trusty-review/src/report/reporter_facts.rs
+++ b/crates/trusty-review/src/report/reporter_facts.rs
@@ -121,7 +121,7 @@ pub fn fill_key_facts(root: &mut Scope, model: &ReportModel) {
 /// What: `0` when neither source carries a positive figure.
 /// Test: `reporter_facts_tests::{scan_only_model_fills_density_facts,
 /// metrics_win_over_scan_in_key_facts}`.
-fn repo_loc(repo: &RepositoryReport) -> u64 {
+pub(super) fn repo_loc(repo: &RepositoryReport) -> u64 {
     repo.metrics
         .as_ref()
         .map(|m| m.loc.total)
@@ -141,7 +141,7 @@ fn repo_files(repo: &RepositoryReport) -> u64 {
 }
 
 /// This repository's per-language LoC breakdown, with the same precedence.
-fn repo_languages(repo: &RepositoryReport) -> &[LanguageLoc] {
+pub(super) fn repo_languages(repo: &RepositoryReport) -> &[LanguageLoc] {
     match repo
         .metrics
         .as_ref()

--- a/crates/trusty-review/src/report/reporter_performance.rs
+++ b/crates/trusty-review/src/report/reporter_performance.rs
@@ -16,6 +16,9 @@
 //! Test: `reporter_performance_tests.rs`.
 
 use super::fill::Scope;
+use super::investigate::SCALABILITY_DIMENSION;
+use super::metrics::Severity;
+use super::model::ReportModel;
 
 /// The fixed Performance & Scalability section text.
 ///
@@ -29,16 +32,42 @@ pub const PERFORMANCE_NOTE: &str = "No performance or scalability assessment was
     latency and throughput percentiles, and capacity data showing how the system behaves \
     as load and data volume grow — none of which was collected or assessed here.";
 
-/// Set the Performance & Scalability section's fixed text.
+/// The sentence appended when §5 does carry scalability findings (#6137).
+///
+/// Why: "no assessment was made" is true of PERFORMANCE and read, on the page,
+/// as true of scalability too — while §5 listed nineteen scalability findings
+/// two sections above it. The reader is pointed at what the report does have
+/// rather than left to reconcile the two.
+const SCALABILITY_CROSS_REFERENCE: &str = " The repo-evidence investigation did raise \
+    scalability findings — sequential collection, connection and queue limits, unbounded \
+    growth — and they are listed by severity in section 5 under the scalability dimension. \
+    They are code-reading judgements about how the system is built to scale, not \
+    measurements of how it does.";
+
+/// Set the Performance & Scalability section's text.
 ///
 /// Why: single call site `reporter::build_scope` uses; kept out of
 /// `reporter.rs` for the same SLOC reason as its `reporter_*` siblings.
-/// What: unconditionally sets `performance_assessment_note` to
-/// [`PERFORMANCE_NOTE`] — never gated on model data, never touched by
-/// synthesis.
-/// Test: `reporter_performance_tests::note_is_fixed_regardless_of_synthesis`.
-pub fn fill_performance_note(root: &mut Scope) {
-    root.set("performance_assessment_note", PERFORMANCE_NOTE);
+/// What: sets `performance_assessment_note` to [`PERFORMANCE_NOTE`], plus
+/// [`SCALABILITY_CROSS_REFERENCE`] when any repository carries a non-GREEN
+/// finding in the scalability dimension. Neither string is computed from
+/// synthesis, so the section is byte-identical for a given finding set however
+/// synthesis went.
+/// Test: `reporter_performance_tests::{note_is_fixed_regardless_of_synthesis,
+/// note_cross_references_section_5_when_scalability_findings_exist}`.
+pub fn fill_performance_note(root: &mut Scope, model: &ReportModel) {
+    let has_scalability = model
+        .repositories
+        .iter()
+        .filter_map(|r| r.metrics.as_ref())
+        .flat_map(|m| m.findings.iter())
+        .any(|f| f.severity != Severity::Green && f.category == SCALABILITY_DIMENSION);
+    let note = if has_scalability {
+        format!("{PERFORMANCE_NOTE}{SCALABILITY_CROSS_REFERENCE}")
+    } else {
+        PERFORMANCE_NOTE.to_string()
+    };
+    root.set("performance_assessment_note", note);
 }
 
 #[cfg(test)]

--- a/crates/trusty-review/src/report/reporter_performance_tests.rs
+++ b/crates/trusty-review/src/report/reporter_performance_tests.rs
@@ -1,17 +1,94 @@
 use super::*;
+use crate::report::metrics::{AnalyzeMetrics, MetricFinding};
+use crate::report::model::RepositoryReport;
 
-/// (d): the Performance section text is byte-identical regardless of the
-/// model or whether synthesis ran — it never reads from the model at all.
+fn model_with(findings: Vec<MetricFinding>) -> ReportModel {
+    ReportModel {
+        title: "Test".to_string(),
+        template: "report-technical-dd".to_string(),
+        analyst: None,
+        client: None,
+        vendor_methodology: crate::report::model::vendor_methodology(),
+        instructions: None,
+        instructions_source: None,
+        report_date: "2026-08-21".to_string(),
+        generated_date: "2026-08-21".to_string(),
+        manifest_path: "manifest.toml".to_string(),
+        repositories: vec![RepositoryReport {
+            name: "app".to_string(),
+            slug: "app".to_string(),
+            source: "/tmp/app".to_string(),
+            source_kind: "local_path".to_string(),
+            username: None,
+            git_ref: None,
+            git_info: None,
+            local_path: None,
+            scan: None,
+            metrics: Some(AnalyzeMetrics {
+                findings,
+                ..Default::default()
+            }),
+            authorship: None,
+            inspect_priority: Vec::new(),
+        }],
+        gaps: vec![],
+        synthesis: None,
+        benchmark: None,
+        investigation: None,
+        section_instructions: Default::default(),
+        ticketing: None,
+    }
+}
+
+fn finding(category: &str, severity: Severity) -> MetricFinding {
+    MetricFinding {
+        title: "t".to_string(),
+        severity,
+        category: category.to_string(),
+        component: "src/lib.rs".to_string(),
+        description: "d".to_string(),
+        remediation: "r".to_string(),
+    }
+}
+
+fn render_note(model: &ReportModel) -> String {
+    let mut scope = Scope::new();
+    fill_performance_note(&mut scope, model);
+    crate::report::fill::render("{{performance_assessment_note}}", &scope)
+}
+
+/// (d): the Performance section text is byte-identical regardless of whether
+/// synthesis ran — it reads finding CATEGORIES, never synthesis prose.
 #[test]
 fn note_is_fixed_regardless_of_synthesis() {
-    let mut a = Scope::new();
-    fill_performance_note(&mut a);
-    let mut b = Scope::new();
-    fill_performance_note(&mut b);
+    let model = model_with(vec![finding("error handling", Severity::Amber)]);
+    let a = render_note(&model);
+    let b = render_note(&model);
+    assert_eq!(a, b);
+    assert_eq!(a, PERFORMANCE_NOTE);
+    assert!(a.contains("No performance or scalability assessment was made"));
+}
 
-    let rendered_a = crate::report::fill::render("{{performance_assessment_note}}", &a);
-    let rendered_b = crate::report::fill::render("{{performance_assessment_note}}", &b);
-    assert_eq!(rendered_a, rendered_b);
-    assert_eq!(rendered_a, PERFORMANCE_NOTE);
-    assert!(rendered_a.contains("No performance or scalability assessment was made"));
+/// #6137: "no assessment was made" read as true of scalability too, while §5
+/// listed nineteen scalability findings two sections above.
+#[test]
+fn note_cross_references_section_5_when_scalability_findings_exist() {
+    let model = model_with(vec![finding(SCALABILITY_DIMENSION, Severity::Amber)]);
+    let rendered = render_note(&model);
+    assert!(
+        rendered.starts_with(PERFORMANCE_NOTE),
+        "the fixed note still leads: {rendered}"
+    );
+    assert!(
+        rendered.contains("listed by severity in section 5"),
+        "rendered: {rendered}"
+    );
+}
+
+/// A GREEN scalability finding is not a finding §5 lists, so it earns no
+/// cross-reference.
+#[test]
+fn a_green_scalability_finding_earns_no_cross_reference() {
+    let model = model_with(vec![finding(SCALABILITY_DIMENSION, Severity::Green)]);
+    assert_eq!(render_note(&model), PERFORMANCE_NOTE);
 }

--- a/crates/trusty-review/src/report/reporter_tests.rs
+++ b/crates/trusty-review/src/report/reporter_tests.rs
@@ -55,10 +55,12 @@ fn fixture_model_with_findings(dir: &Path) -> ReportModel {
       "loc": { "total": 5000, "by_language": [ { "language": "Rust", "loc": 5000 } ] },
       "counts": { "files": 20, "functions": 150 },
       "findings": [
-        { "title": "SQL injection", "severity": "red", "category": "security", "component": "db.rs" },
+        { "title": "SQL injection", "severity": "red", "category": "authentication & secrets", "component": "db.rs" },
         { "title": "Stale dependency", "severity": "amber", "category": "maintainability", "component": "deps.toml" },
-        { "title": "Strong test coverage", "severity": "green", "category": "quality", "component": "" },
-        { "title": "Clean module boundaries", "severity": "green", "category": "architecture", "component": "" }
+        { "title": "Strong test coverage", "severity": "green", "category": "test coverage", "component": "" },
+        { "title": "Clean module boundaries", "severity": "green", "category": "state management", "component": "" },
+        { "title": "Constant-time token comparison", "severity": "green", "category": "authentication & secrets", "component": "" },
+        { "title": "Atomic redb batch upserts", "severity": "green", "category": "state management", "component": "" }
       ]
     }"#;
     std::fs::write(dir.join("acme.json"), metrics).expect("write metrics");
@@ -164,17 +166,80 @@ fn code_quality_and_security_sections_populate_from_analyze_data() {
     // Code Quality: the fixture's LoC/language/maintainability-finding data.
     assert!(md.contains("Acme Web"));
     assert!(md.contains("5000"));
-    // Security Posture: the fixture's RED "security"-category finding,
-    // re-projected as a violation-domain row — not the maintainability one.
-    assert!(md.contains("security"));
+    // Security Posture (#6137): the fixture's RED "authentication & secrets"
+    // finding, and nothing from the other dimensions.
     let security_section = md
         .split("## Security Posture")
         .nth(1)
         .and_then(|s| s.split("## Performance").next())
         .expect("Security Posture section present");
     assert!(!security_section.contains("_No data available"));
+    assert!(
+        security_section.contains("authentication & secrets"),
+        "section: {security_section}"
+    );
+    assert!(
+        !security_section.contains("maintainability"),
+        "section: {security_section}"
+    );
+    assert!(
+        security_section.contains("Constant-time token comparison"),
+        "the dimension's clean signals are credited: {security_section}"
+    );
     // Performance stays the fixed gap text regardless of the data present.
     assert!(md.contains(crate::report::reporter_performance::PERFORMANCE_NOTE));
+}
+
+/// #6137: every GREEN finding renders as its own topic line. The templates
+/// carried exactly three fixed `{{green_topic_N}}` slots, so a run with 21
+/// GREEN findings silently dropped 18 of them.
+#[test]
+fn reporter_renders_every_green_topic() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let model = fixture_model_with_findings(tmp.path());
+    let template = TemplateLoader::bundled_only()
+        .load("report-technical-dd")
+        .expect("bundled template");
+    let md = Reporter::new(tmp.path()).render(&model, &template);
+
+    for title in [
+        "Strong test coverage",
+        "Clean module boundaries",
+        "Constant-time token comparison",
+        "Atomic redb batch upserts",
+    ] {
+        assert!(
+            md.contains(&format!("- {title}")),
+            "every GREEN topic renders, including beyond the old three-slot cap: {title}"
+        );
+    }
+}
+
+/// The GREEN section carries titles ONLY — the no-green-analysis rule bans
+/// elaboration, and making the bullets repeatable must not smuggle any in.
+#[test]
+fn reporter_fills_green_topics() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let model = fixture_model_with_findings(tmp.path());
+    let template = TemplateLoader::bundled_only()
+        .load("report-technical-dd")
+        .expect("bundled template");
+    let md = Reporter::new(tmp.path()).render(&model, &template);
+
+    let green_section = md
+        .split("### 5.3 GREEN")
+        .nth(1)
+        .and_then(|s| s.split("\n## ").next())
+        .expect("GREEN section present");
+    assert!(green_section.contains("- Strong test coverage"));
+    assert!(
+        !green_section.contains("Remediation"),
+        "no elaboration: {green_section}"
+    );
+    assert!(
+        !green_section.contains(HONESTY_MARKER),
+        "no unfilled slot survives: {green_section}"
+    );
 }
 
 /// (b) #6004: a model WITHOUT analyze data leaves both sections as honesty

--- a/crates/trusty-review/src/report/synthesize.rs
+++ b/crates/trusty-review/src/report/synthesize.rs
@@ -27,7 +27,7 @@ use tracing::{debug, warn};
 
 use crate::llm::LlmProvider;
 use crate::report::model::ReportModel;
-use crate::report::synthesize_guard::{allowed_numbers, verify_prose};
+use crate::report::synthesize_guard::{allowed_numbers_with, verify_prose};
 use crate::report::synthesize_prompt::{
     SYNTHESIS_DEFAULT_MAX_TOKENS, SYNTHESIS_TIER_LADDER, SynthesisTier, build_synthesis_prompt,
 };
@@ -322,7 +322,8 @@ impl Synthesizer {
     /// requests no elaboration prose at all.  #5454 still decides what happens
     /// when the ladder is spent: the failure propagates rather than degrading
     /// the report to deterministic-only.
-    /// What: builds the numeric allow-set from the deterministic model, then
+    /// What: builds the numeric allow-set from the deterministic model and the
+    /// figures that model's own report prints (#6137), then
     /// walks [`SYNTHESIS_TIER_LADDER`], calling the provider under a timeout at
     /// each rung; a `finish_reason` of `length`/`max_tokens` advances to the
     /// next rung, and exhausting the ladder is [`SynthesisError::Truncated`].
@@ -347,9 +348,12 @@ impl Synthesizer {
     /// synthesize_ladder_recovers_a_large_finding_set,
     /// synthesize_still_truncated_after_retry_is_a_hard_error}`.
     pub async fn synthesize(&self, model: &ReportModel) -> Result<Synthesis, SynthesisError> {
-        // Ground truth for the guardrail comes from the DETERMINISTIC model only.
+        // Ground truth for the guardrail comes from the DETERMINISTIC model
+        // only — plus, since #6137, the figures the deterministic report
+        // computes at render time and prints in its own sections.
+        let printed = crate::report::figures::printed_figures(model);
         let allowed = match serde_json::to_value(model) {
-            Ok(v) => allowed_numbers(&v),
+            Ok(v) => allowed_numbers_with(&v, &printed),
             Err(e) => {
                 warn!(error = %e, "synthesis: could not serialise model for guardrail");
                 return Err(SynthesisError::ModelNotSerialisable(e.to_string()));

--- a/crates/trusty-review/src/report/synthesize_guard.rs
+++ b/crates/trusty-review/src/report/synthesize_guard.rs
@@ -11,8 +11,11 @@
 //! What: [`allowed_numbers`] builds the canonical set of numbers the source model
 //! actually contains (walking the serialized model); [`verify_prose`] checks that
 //! every number token in a candidate string is in that set, tolerating formatting
-//! variants (thousands separators, `$`, `%`, trailing-zero decimals) and
-//! conventional roundings of a measured value (#6030 — see [`rounded_forms`]).
+//! variants (thousands separators, `$`, `%`, trailing-zero decimals),
+//! conventional roundings of a measured value (#6030 — see [`rounded_forms`]),
+//! and scaled-unit restatements of a large integer (#6137 — see
+//! [`scaled_forms`]).  [`allowed_numbers_with`] additionally admits the figures
+//! the report computes at render time and prints in its own sections.
 //! Test: `synthesize_tests.rs` covers extraction, canonicalisation, the
 //! formatting-variant equivalences, the rounding equivalences, and the reject
 //! path.
@@ -104,8 +107,8 @@ fn join_parts(int_part: &str, frac: &str) -> String {
 /// What: for a key with a fraction, emits both the truncation and the
 /// round-half-up form at every precision coarser than the key's own — `85.19`
 /// yields `85.1`, `85.2`, and `85`.  Carries propagate (`9.99` yields `10`).  An
-/// integer key yields nothing: this widens decimal precision only, so a measured
-/// 8234 never admits "8,000".
+/// integer key yields nothing here — scaled-unit restatements of a large integer
+/// are [`scaled_forms`]' job, not this function's.
 /// Test: `allowed_numbers_admits_rounded_forms`, `verify_prose_accepts_rounding`.
 fn rounded_forms(canonical: &str) -> Vec<String> {
     let Some(dot) = canonical.find('.') else {
@@ -126,6 +129,67 @@ fn rounded_forms(canonical: &str) -> Vec<String> {
     out
 }
 
+/// The magnitudes at which a large integer is conventionally restated.
+///
+/// Thousand, million, billion, trillion — the decimal-point shift each implies.
+const SCALE_EXPONENTS: [usize; 4] = [3, 6, 9, 12];
+
+/// How many significant digits a scaled restatement must keep to be admitted.
+///
+/// Why: one significant digit is not a restatement, it is a different number.
+/// Measured 1,553,771 admits `1.55` and `1.6` million; it must not admit a bare
+/// `2`, which reads as a count in prose and would let a fabricated small integer
+/// through.
+const MIN_SCALED_SIGNIFICANT_DIGITS: usize = 2;
+
+/// Every scaled-unit restatement of a large integer key.
+///
+/// Why: #6137 — [`rounded_forms`] widens decimal precision only, so an integer
+/// key admitted nothing coarser than itself. A narrative that writes a measured
+/// 1,553,771 lines as "1.55 million lines" is restating the source figure, and
+/// rejecting it vetoed five LLM-written fields of one report (the executive
+/// summary, the code-quality, security and authorship paragraphs, and a
+/// top-risk row). The guardrail compares canonical STRINGS and the prose
+/// tokeniser never sees the unit word, so the only way `1.55` can verify is for
+/// the allowed set to carry it.
+/// What: for each magnitude in [`SCALE_EXPONENTS`] at which the value is still
+/// at least 1, shifts the decimal point and emits that scaled value plus every
+/// [`rounded_forms`] spelling of it — 1553771 yields `1.553771`, `1.55`, `1.6`,
+/// `1553.771`, `1554`, and the rest. Forms below
+/// [`MIN_SCALED_SIGNIFICANT_DIGITS`] are dropped. A key that is not a plain
+/// integer of at least four digits yields nothing.
+/// Test: `allowed_numbers_admits_scaled_unit_forms`,
+/// `verify_prose_accepts_a_million_scale_restatement`,
+/// `verify_prose_still_rejects_a_fabricated_figure`.
+fn scaled_forms(canonical: &str) -> Vec<String> {
+    if canonical.len() < 4 || !canonical.bytes().all(|b| b.is_ascii_digit()) {
+        return Vec::new();
+    }
+    let mut out = Vec::new();
+    for exp in SCALE_EXPONENTS {
+        if canonical.len() <= exp {
+            break;
+        }
+        let (int_part, frac) = canonical.split_at(canonical.len() - exp);
+        let scaled = canonicalize(&format!("{int_part}.{frac}"));
+        for form in rounded_forms(&scaled).into_iter().chain([scaled]) {
+            if significant_digits(&form) >= MIN_SCALED_SIGNIFICANT_DIGITS {
+                out.push(form);
+            }
+        }
+    }
+    out
+}
+
+/// Count a canonical key's significant digits — every digit after the leading
+/// zeros, decimal point ignored (`0.5` → 1, `1.55` → 3, `1553` → 4).
+fn significant_digits(key: &str) -> usize {
+    key.chars()
+        .filter(char::is_ascii_digit)
+        .skip_while(|c| *c == '0')
+        .count()
+}
+
 /// Build the set of numbers the deterministic source model legitimately contains.
 ///
 /// Why: the guardrail's ground truth is "what figures does the report's own data
@@ -134,11 +198,37 @@ fn rounded_forms(canonical: &str) -> Vec<String> {
 /// from, with no hand-maintained field list to drift.
 /// What: walks the serialized [`Value`], adding canonical keys for every JSON
 /// number node and every number token found inside every string node, plus each
-/// key's conventional roundings ([`rounded_forms`], #6030).
+/// key's conventional roundings ([`rounded_forms`], #6030) and scaled-unit
+/// restatements ([`scaled_forms`], #6137).
 /// Test: `allowed_numbers_covers_metrics`, `allowed_numbers_admits_rounded_forms`.
 pub fn allowed_numbers(model: &Value) -> HashSet<String> {
+    allowed_numbers_with(model, &[])
+}
+
+/// The same set, widened by the figures the report itself prints.
+///
+/// Why: #6137 — some figures a section renders are computed at RENDER time and
+/// exist nowhere in the serialized model: the investigation coverage
+/// percentage (`73 of 6664 tracked (1.1% coverage…)`) and the authorship
+/// trajectory average (`avg 7213.5 commit(s)/mo`) are both derived from counts
+/// the model does carry. The synthesis prompt quotes the coverage percentage
+/// verbatim, so the model was being asked to cite a figure the guardrail would
+/// then reject — which is what dropped the security and authorship paragraphs
+/// of one report. A figure the report prints in its own deterministic sections
+/// is in-model by definition.
+/// What: [`allowed_numbers`], plus every number token found in `printed` (the
+/// deterministic report text, from
+/// [`figures::printed_figures`](super::figures::printed_figures)), each widened
+/// the same way.
+/// Test: `allowed_numbers_admits_a_printed_derived_figure`.
+pub fn allowed_numbers_with(model: &Value, printed: &[String]) -> HashSet<String> {
     let mut set = HashSet::new();
     collect(model, &mut set);
+    for text in printed {
+        for key in numbers_in(text) {
+            insert_key(&mut set, key);
+        }
+    }
     set
 }
 
@@ -153,9 +243,11 @@ fn collect(value: &Value, set: &mut HashSet<String>) {
     }
 }
 
-/// Add a canonical key and every coarser rounding of it to the allowed set.
+/// Add a canonical key, every coarser rounding of it, and every scaled-unit
+/// restatement of it to the allowed set.
 fn insert_key(set: &mut HashSet<String>, key: String) {
     set.extend(rounded_forms(&key));
+    set.extend(scaled_forms(&key));
     set.insert(key);
 }
 

--- a/crates/trusty-review/src/report/synthesize_tests.rs
+++ b/crates/trusty-review/src/report/synthesize_tests.rs
@@ -22,7 +22,9 @@ use crate::report::metrics::{
     AnalyzeMetrics, CountMetrics, LanguageLoc, LocMetrics, MetricFinding, Severity,
 };
 use crate::report::model::{ReportModel, RepositoryReport};
-use crate::report::synthesize_guard::{allowed_numbers, numbers_in, verify_prose};
+use crate::report::synthesize_guard::{
+    allowed_numbers, allowed_numbers_with, numbers_in, verify_prose,
+};
 use crate::report::synthesize_prompt::{
     SYNTHESIS_DEFAULT_MAX_TOKENS, SYNTHESIS_ESCALATED_MAX_TOKENS, SYNTHESIS_MIN_MAX_TOKENS,
     SynthesisTier, build_synthesis_prompt, schema_contract_statement, synthesis_schema,
@@ -309,6 +311,88 @@ fn verify_prose_accepts_rounding() {
     assert_eq!(
         verify_prose("The top author owns 85.3% of the code.", &allowed),
         Err("85.3".to_string())
+    );
+}
+
+/// Why: #6137 — `rounded_forms` widens decimal precision only, so an integer
+/// key admitted nothing coarser than itself and "1.55 million lines" for a
+/// measured 1,553,771 was read as a fabricated 1.55. That rejection vetoed five
+/// LLM-written fields of one report.
+/// What: the million- and thousand-scale restatements are admitted; a
+/// single-significant-digit form and a genuinely different figure are not.
+/// Test: this test itself.
+#[test]
+fn allowed_numbers_admits_scaled_unit_forms() {
+    let allowed = allowed_numbers(&serde_json::json!({ "total_loc": 1553771 }));
+    for form in ["1553771", "1.55", "1.6", "1.553771", "1553", "1554"] {
+        assert!(
+            allowed.contains(form),
+            "{form} is a scaled restatement of 1,553,771"
+        );
+    }
+    for absent in ["2", "1.7", "1.4", "9999"] {
+        assert!(
+            !allowed.contains(absent),
+            "{absent} is no scaled restatement of 1,553,771"
+        );
+    }
+}
+
+/// Why: #6137 regression — the exact live rejection. The report's Key Facts row
+/// states 1553771 lines and the model wrote "1.55 million lines"; the status
+/// note read `rejected (unverified figure) in executive summary: 1.55`.
+/// What: the million-scale prose verifies, and a fabricated figure of the same
+/// shape still does not.
+/// Test: this test itself.
+#[test]
+fn verify_prose_accepts_a_million_scale_restatement() {
+    let allowed = allowed_numbers(&serde_json::json!({ "total_loc": 1553771 }));
+    for prose in [
+        "The codebase is roughly 1.55 million lines.",
+        "The codebase is roughly 1.6 million lines.",
+        "1,553,771 lines across the workspace.",
+    ] {
+        assert!(
+            verify_prose(prose, &allowed).is_ok(),
+            "a scaled restatement must verify: {prose}"
+        );
+    }
+}
+
+/// Why: widening the allowed set must not open a hole — a figure that restates
+/// nothing measured is still the thing the guardrail exists to catch.
+/// What: a fabricated million-scale figure and a fabricated small integer are
+/// both rejected, with the offending token surfaced.
+/// Test: this test itself.
+#[test]
+fn verify_prose_still_rejects_a_fabricated_figure() {
+    let allowed = allowed_numbers(&serde_json::json!({ "total_loc": 1553771 }));
+    assert_eq!(
+        verify_prose("The codebase is roughly 2.4 million lines.", &allowed),
+        Err("2.4".to_string())
+    );
+    assert_eq!(
+        verify_prose("There are 42 services.", &allowed),
+        Err("42".to_string())
+    );
+}
+
+/// Why: #6137 — the investigation coverage percentage is computed at render
+/// time, printed in the report's own Investigation Coverage section, and quoted
+/// verbatim into the synthesis prompt. The model was being asked to cite a
+/// figure the guardrail then rejected.
+/// What: a figure supplied as printed report text is admitted; one that is
+/// neither in the model nor printed is not.
+/// Test: this test itself.
+#[test]
+fn allowed_numbers_admits_a_printed_derived_figure() {
+    let printed = vec!["- files examined: 73 of 6664 tracked (1.1% coverage)".to_string()];
+    let allowed = allowed_numbers_with(&serde_json::json!({ "files": 73 }), &printed);
+    assert!(allowed.contains("1.1"), "a printed figure is in-model");
+    assert!(verify_prose("Coverage was 1.1%.", &allowed).is_ok());
+    assert_eq!(
+        verify_prose("Coverage was 9.7%.", &allowed),
+        Err("9.7".to_string())
     );
 }
 

--- a/crates/trusty-review/templates/report-technical-dd-cast.md
+++ b/crates/trusty-review/templates/report-technical-dd-cast.md
@@ -197,6 +197,7 @@ vs. All technologies (peer set size: {{all_tech_peer_set_size}}):
 
 <!-- BEGIN amber_finding -->
 {{finding_index}}. **{{finding_title}}** — {{finding_description}}
+- **Component:** {{finding_component}}
 - **Remediation:** {{finding_remediation}}
 {{finding_evidence_block}}
 <!-- END amber_finding -->
@@ -206,9 +207,9 @@ vs. All technologies (peer set size: {{all_tech_peer_set_size}}):
 
 <!-- Per the no-green-analysis rule: one line per topic, nothing else. -->
 
-- {{green_topic_1}}
-- {{green_topic_2}}
-- {{green_topic_3}}
+<!-- BEGIN green_topic -->
+- {{green_topic}}
+<!-- END green_topic -->
 
 ## 6. Risk Registers
 

--- a/crates/trusty-review/templates/report-technical-dd.md
+++ b/crates/trusty-review/templates/report-technical-dd.md
@@ -201,6 +201,7 @@ report against others normalized through this same template.
 
 <!-- BEGIN amber_finding -->
 {{finding_index}}. **{{finding_title}}** — {{finding_description}}
+- **Component:** {{finding_component}}
 - **Remediation:** {{finding_remediation}}
 {{finding_evidence_block}}
 <!-- END amber_finding -->
@@ -211,10 +212,9 @@ report against others normalized through this same template.
 <!-- Per the no-green-analysis rule: one line per topic, nothing else.
      Do not add root cause, evidence, or remediation for green items. -->
 
-- {{green_topic_1}}
-- {{green_topic_2}}
-- {{green_topic_3}}
-<!-- one bullet per positive topic -->
+<!-- BEGIN green_topic -->
+- {{green_topic}}
+<!-- END green_topic -->
 
 ## Code Quality & Architecture
 
@@ -232,19 +232,22 @@ report against others normalized through this same template.
 
 ## Security Posture
 
-*This table counts findings from general-purpose lint tools (clippy, ruff,
-biome, rubocop, PMD, and similar per language) that happened to be graded
-`error` or `critical`. It is not a SAST scan, not a dependency/CVE scan, and
-not a secrets scan. Treat it as a proxy for code-hygiene risk, not as
-evidence the codebase has been screened for exploitable vulnerabilities.*
+*This table counts the RED and AMBER findings the repo-evidence investigation
+raised in its "authentication & secrets" dimension — an LLM reading the
+selected source files, with every finding's evidence quote mechanically
+verified against the file it cites. Its scope is code hygiene around
+credentials, tokens, and authentication paths in the files that were read. It
+is not a SAST scan, not a dependency/CVE scan, and not a secrets scan of the
+whole tree; the share of files read is stated under Investigation Coverage.
+Read a low count as a small sample, not as a clean bill of health.*
 
 {{security_summary_paragraph}}
 
-<!-- BEGIN security_violations_table -->
-| Application | Domain | Total violations |
-|---|---|---|
-| {{app_name}} | {{violation_domain}} | {{violation_count}} |
-<!-- END security_violations_table -->
+| Application | Dimension | RED/AMBER findings |
+|---|---|---|<!-- BEGIN security_violations_table -->
+| {{app_name}} | {{violation_domain}} | {{violation_count}} |<!-- END security_violations_table -->
+
+{{security_clean_signals}}
 
 ## Performance & Scalability
 


### PR DESCRIPTION
Ten mechanical render defects from the graded self-audit of `2026-08-21-technical-due-diligence.md`. Each was reproduced from that report and its JSON twin before being fixed.

Refs #6080

## What was wrong

**The guardrail vetoed the analysis layer.** `synthesize_guard::rounded_forms` widens decimal precision only, so an integer key admitted nothing coarser than itself. The model wrote "1.55 million lines" for a measured 1,553,771 and the guardrail read `1.55` as fabricated — rejecting the executive summary, the code-quality paragraph, the security paragraph, the authorship paragraph, and top-risk row 1. Two further rejections (`1.1`, `7213.5`) were figures the report computes at render time and prints in its own sections; the synthesis prompt quotes the coverage percentage verbatim, so the model was being asked to cite a figure the guardrail would then reject.

Large integers now admit scaled-unit restatements at each magnitude, filtered to two significant digits so a bare `2` is still rejected. `allowed_numbers_with` additionally takes the deterministic report text — every filled scope value plus the appended investigation sections, walked from the `Scope` rather than rendered markdown so the set does not depend on which template a run uses.

**Code Quality printed "not stated in source data" twice.** `cq_loc`/`cq_tech` read `metrics.loc.total`/`metrics.counts.files`, which a `--analyze` fetch leaves empty by design — the adapter leaves LoC to the scanner. §4.1 rendered 1,553,771 lines from the scan two sections above. Both cells now use the same source precedence Key Facts and the §4 Profile table use, so the sections cannot disagree.

**Twenty findings named no file.** `metrics.findings[].component` is set on the row and only the RED template rendered it, so twenty complexity findings read "Extract the body of 'this function' (lines 23-512)". Both templates now render it on AMBER rows too.

**Those twenty paths pointed at a different checkout.** Every one was under `/Users/masa/Projects/trusty-tools` while the audited tree was `.../repos/local/trusty-tools` — and they were stamped ⁽ᵐ⁾ measured. `derive_index_id` addresses an index by directory basename, so a second checkout of the same repository answers for the audited one. Analyze data whose component paths fall outside the audited root is now rejected whole (the complexity distribution came from the same index) with a named Gaps & Caveats line.

**Eighteen of twenty-one GREEN findings were dropped.** The templates carried three fixed `{{green_topic_N}}` slots. Constant-time token comparison and atomic redb batch upserts were among the casualties. The bullets are a repeating block now — one line per finding, no elaboration, the same fix #2373 made for top-risk rows.

**Security Posture counted everything.** The table grouped every non-maintainability finding by category, so ninety of one hundred ten rows were error-handling, state-management, scalability, test-coverage and dependency findings reported as security "violations" — under a disclaimer describing a clippy/ruff lint pipeline that never ran. It now counts the security dimension only, states its real provenance, credits that dimension's GREEN findings, and prints one table instead of six one-row tables.

**Four of twelve contents links were broken.** `manifest::slugify` collapses a non-alphanumeric run to one dash; GitHub deletes punctuation and then maps spaces, so `Code Quality & Architecture` anchors as `#code-quality--architecture`. A dedicated `github_anchor` reproduces GitHub's rule; `slugify` keeps owning the output filename. The false claim in `contents_links.rs`'s doc comment is corrected.

**"No manifest-declared dependencies were found" on a 134-dependency workspace.** Two causes read identically on the page. `build_inventory` now records which manifests it read, and the section renders a named gap when none was — never an assertion of zero. `[workspace.dependencies]` is also parsed, which is where a cargo workspace root declares its dependencies.

**Two smaller ones.** Performance & Scalability's "no assessment was made" now cross-references section 5 when the investigation raised scalability findings. And a verified evidence quote is completed to the end of the line it ends on: finding 58 quoted an installer's security note through "…before running it." and cut the next clause on the same line — "All downloaded binaries are SHA-256 verified." — so the finding read as unmitigated remote code execution.

## Gates

Rung 3 on `trusty-review`, plus `cargo check --workspace`.

```
cargo fmt --check                                         → clean
cargo check -p trusty-review --all-targets                → clean
cargo clippy -p trusty-review --all-targets -- -D warnings → clean
cargo test -p trusty-review                                → 1778 passed; 0 failed; 5 ignored (lib)
                                                             + 12 integration binaries, all ok
cargo check --workspace                                    → clean
bash scripts/check_line_cap.sh          → 4138 files, 0 violations
bash scripts/check_sld.sh               → 0 errors, 0 warnings
bash scripts/check_changelog_fragment.sh → OK trusty-review
bash scripts/check-pr-version-bump.sh    → OK (0.22.0 unpublished)
```

Every fix carries a regression test that fails on `main`. The guardrail keeps its teeth: `verify_prose_still_rejects_a_fabricated_figure` pins that a fabricated 2.4 million and a fabricated 42 are both still rejected.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
