### PR TITLE
fix(trusty-audit): the byte budget derives from the file budget (Refs #6148)

### DIFF
--- a/crates/trusty-audit/README.md
+++ b/crates/trusty-audit/README.md
@@ -244,11 +244,16 @@ inspect_priority = [
 ```
 
 The client also asks for a wider investigation budget than `trusty-review`'s own
-default — 120 files and 1.2 MiB per repository, overridable per machine with
+default — 240 files and 2.4 MiB per repository, overridable per machine with
 `TRUSTY_AUDIT_INVESTIGATE_MAX_FILES` and `TRUSTY_AUDIT_INVESTIGATE_MAX_BYTES`.
 It writes `investigate_max_files` and `investigate_max_bytes` into `[report]`
 per key, and only where the manifest declares none: an operator who set one of
 the two keeps it, and gets the audit's default for the other.
+
+The byte budget follows the file budget at 10 KiB per file unless something
+declares it. `trusty-review` stops reading at whichever of the two binds first,
+so raising files alone used to read fewer files than it asked for and say
+nothing about it.
 
 Every leg of that is fail-open: a daemon that will not start, a checkout
 `trusty-search` refuses, an index that matches no evidence, an index with

--- a/crates/trusty-audit/changelog.d/6148-byte-budget-scales.md
+++ b/crates/trusty-audit/changelog.d/6148-byte-budget-scales.md
@@ -1,0 +1,13 @@
+Fixed
+
+- The investigation byte budget now derives from the file budget at 10 KiB per
+  file unless the environment or the manifest declares one. `trusty-review`
+  stops selecting at whichever of the two caps binds first, so raising
+  `TRUSTY_AUDIT_INVESTIGATE_MAX_FILES` alone read fewer files than it asked for
+  and reported nothing about it — a 120-file lap read 76 files because the fixed
+  1.2 MiB cap bound first. An explicit `TRUSTY_AUDIT_INVESTIGATE_MAX_BYTES`, or
+  a declared `[report].investigate_max_bytes`, still wins outright.
+- The default investigation budget is 240 files and 2.4 MiB per repository, up
+  from 120 files and 1.2 MiB: 120 sampled about 1.8% of a workspace-sized
+  repository, below the coverage a due-diligence report is expected to reach.
+  The evidence caps follow it — 240 ranked paths and 34 files per dimension.

--- a/crates/trusty-audit/src/grounding/evidence_tests.rs
+++ b/crates/trusty-audit/src/grounding/evidence_tests.rs
@@ -466,9 +466,9 @@ fn the_default_budget_keeps_the_floor_semantics() {
 
     // The audit's own default budget is above the floor and still bounded.
     let default = Caps::for_budget(crate::grounding::priority::DEFAULT_MAX_FILES);
-    assert_eq!(default.priority_paths, 120);
-    assert_eq!(default.files_per_dimension, 17);
-    assert_eq!(default.top_k, 26);
+    assert_eq!(default.priority_paths, 240);
+    assert_eq!(default.files_per_dimension, 34);
+    assert_eq!(default.top_k, 51);
 }
 
 /// The daemon's own response shape parses, and chunk paths come back

--- a/crates/trusty-audit/src/grounding/priority.rs
+++ b/crates/trusty-audit/src/grounding/priority.rs
@@ -71,9 +71,12 @@ impl Priority {
 /// `trusty-audit audit` still takes no new step.
 /// What: written to `[report]` PER KEY, and only where the manifest declares
 /// none — an operator who set one of the two keeps it and gets the audit's
-/// default for the other, rather than falling back to trusty-review's.
+/// default for the other, rather than falling back to trusty-review's. The two
+/// numbers are not independent: trusty-review's selection stops at whichever
+/// binds first, so `max_bytes` is DERIVED from `max_files` unless something
+/// declares it (#6148).
 /// Test: `priority_tests::{the_budget_is_recorded_once,
-/// a_declared_budget_is_left_alone}`.
+/// a_declared_budget_is_left_alone, a_raised_file_budget_raises_the_byte_budget}`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct Budget {
@@ -84,10 +87,20 @@ pub struct Budget {
 }
 
 /// Files the audit asks the investigation pass to read per repository.
-pub const DEFAULT_MAX_FILES: usize = 120;
+///
+/// 240 rather than the 120 #6082 shipped: the owner's ruling is that a DD
+/// sample reads above 1% of the repository, and lap-2 measured 120 at roughly
+/// 1.8% of this workspace (#6148).
+pub const DEFAULT_MAX_FILES: usize = 240;
+
+/// Content bytes one budgeted file is assumed to carry.
+///
+/// The ratio the 120-file / 1.2 MiB pair shipped with, kept as the derivation
+/// constant so the two knobs move together.
+pub const BYTES_PER_FILE: usize = 10 * 1024;
 
 /// Content bytes the audit asks it to send per repository.
-pub const DEFAULT_MAX_BYTES: usize = 1_200 * 1024;
+pub const DEFAULT_MAX_BYTES: usize = DEFAULT_MAX_FILES * BYTES_PER_FILE;
 
 /// Environment override for [`DEFAULT_MAX_FILES`].
 pub const ENV_MAX_FILES: &str = "TRUSTY_AUDIT_INVESTIGATE_MAX_FILES";
@@ -105,9 +118,13 @@ impl Budget {
     /// on a manifest that declares one: the caps would size for 120 while
     /// trusty-review read 300. One resolver, one value, both consumers.
     /// What: a positive `[report].investigate_max_files` /
-    /// `investigate_max_bytes` wins per key; an unreadable manifest, a missing
-    /// key, and an unusable value all fall back to [`Budget::from_env`].
-    /// Test: `priority_tests::a_declared_budget_is_the_effective_budget`.
+    /// `investigate_max_bytes` wins per key, then the environment override for
+    /// that key, then the default — and an absent byte value derives from
+    /// whichever file value won, so raising files in the manifest raises bytes
+    /// with it. An unreadable manifest and an unusable value both behave as if
+    /// the key were absent.
+    /// Test: `priority_tests::{a_declared_budget_is_the_effective_budget,
+    /// a_manifest_file_budget_raises_the_byte_budget}`.
     #[must_use]
     pub fn for_manifest(manifest: &Path) -> Self {
         let declared = std::fs::read_to_string(manifest)
@@ -117,20 +134,16 @@ impl Budget {
             let value = declared.as_ref()?.get("report")?.get(name)?.as_integer()?;
             usize::try_from(value).ok().filter(|n| *n > 0)
         };
-        let machine = Self::from_env();
-        Self {
-            max_files: key("investigate_max_files").unwrap_or(machine.max_files),
-            max_bytes: key("investigate_max_bytes").unwrap_or(machine.max_bytes),
-        }
+        Self::resolve(
+            key("investigate_max_files").or_else(|| env_positive(ENV_MAX_FILES)),
+            key("investigate_max_bytes").or_else(|| env_positive(ENV_MAX_BYTES)),
+        )
     }
 
     /// The budget this machine asks for, defaults unless overridden.
     #[must_use]
     pub fn from_env() -> Self {
-        Self::resolved(
-            std::env::var(ENV_MAX_FILES).ok().as_deref(),
-            std::env::var(ENV_MAX_BYTES).ok().as_deref(),
-        )
+        Self::resolve(env_positive(ENV_MAX_FILES), env_positive(ENV_MAX_BYTES))
     }
 
     /// [`Budget::from_env`]'s rule, as a pure function.
@@ -139,13 +152,29 @@ impl Budget {
     /// an unparseable or zero override falls back rather than disabling the
     /// investigation — is testable without `std::env::set_var`, which is
     /// `unsafe` in edition 2024 and unsound under the parallel harness.
-    /// What: a positive integer wins; anything else takes the default.
-    /// Test: `priority_tests::an_unusable_override_falls_back_to_the_default`.
+    /// What: a positive integer wins; anything else takes the default, and an
+    /// absent byte override derives from the file count rather than pinning
+    /// [`DEFAULT_MAX_BYTES`].
+    /// Test: `priority_tests::{an_unusable_override_falls_back_to_the_default,
+    /// a_raised_file_budget_raises_the_byte_budget}`.
     #[must_use]
     pub fn resolved(files: Option<&str>, bytes: Option<&str>) -> Self {
+        Self::resolve(positive(files), positive(bytes))
+    }
+
+    /// The one resolution rule, over values both sources have already parsed.
+    ///
+    /// Why: trusty-review's selection stops at whichever of the two caps binds
+    /// first, so a raised file budget against a fixed byte budget reads fewer
+    /// files than it asked for and says nothing — lap-2 read 76 of 120 (#6148).
+    /// What: an explicit byte value always wins; otherwise bytes are
+    /// [`BYTES_PER_FILE`] times whatever file count won, so the default pair
+    /// stays exactly [`DEFAULT_MAX_FILES`] / [`DEFAULT_MAX_BYTES`].
+    fn resolve(files: Option<usize>, bytes: Option<usize>) -> Self {
+        let max_files = files.unwrap_or(DEFAULT_MAX_FILES);
         Self {
-            max_files: positive(files).unwrap_or(DEFAULT_MAX_FILES),
-            max_bytes: positive(bytes).unwrap_or(DEFAULT_MAX_BYTES),
+            max_files,
+            max_bytes: bytes.unwrap_or_else(|| max_files.saturating_mul(BYTES_PER_FILE)),
         }
     }
 }
@@ -153,6 +182,11 @@ impl Budget {
 /// A declared override, when it parses as a positive count.
 fn positive(value: Option<&str>) -> Option<usize> {
     value?.trim().parse::<usize>().ok().filter(|n| *n > 0)
+}
+
+/// A positive environment override for `name`, when one is set.
+fn env_positive(name: &str) -> Option<usize> {
+    positive(std::env::var(name).ok().as_deref())
 }
 
 /// Record `priorities`, `budget` and `gaps` in the manifest at `path`.
@@ -458,6 +492,79 @@ path = "/w/repos/acme-web"
         assert_eq!(Budget::resolved(Some(" 12 "), None).max_files, 12);
     }
 
+    /// #6148: the two caps bind together in trusty-review, so raising files
+    /// alone used to read fewer files than it asked for — lap-2 read 76 of 120.
+    #[test]
+    fn a_raised_file_budget_raises_the_byte_budget() {
+        let raised = Budget::resolved(Some("334"), None);
+        assert_eq!(raised.max_files, 334);
+        assert_eq!(
+            raised.max_bytes, 3_420_160,
+            "334 files earn 3.34 MiB, not the default cap"
+        );
+        assert!(
+            raised.max_bytes > DEFAULT_MAX_BYTES,
+            "a budget above the default must not be capped at it"
+        );
+    }
+
+    /// An explicit byte override is the one thing derivation must not overrule.
+    #[test]
+    fn an_explicit_byte_override_wins_over_the_derivation() {
+        let budget = Budget::resolved(Some("334"), Some("4096"));
+        assert_eq!(budget.max_files, 334);
+        assert_eq!(budget.max_bytes, 4096);
+    }
+
+    /// The default pair, and the ratio that ties them.
+    #[test]
+    fn the_default_budget_is_240_files_and_2_4_mib() {
+        assert_eq!(DEFAULT_MAX_FILES, 240);
+        assert_eq!(DEFAULT_MAX_BYTES, 2_457_600);
+        assert_eq!(
+            Budget::resolved(None, None),
+            Budget {
+                max_files: DEFAULT_MAX_FILES,
+                max_bytes: DEFAULT_MAX_BYTES,
+            }
+        );
+    }
+
+    /// #6148, through the manifest: the same derivation, and the same
+    /// precedence — a declared byte key still wins.
+    #[test]
+    fn a_manifest_file_budget_raises_the_byte_budget() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("manifest.toml");
+        let with = |keys: &str| {
+            SAMPLE.replace(
+                "title = \"Acme — Technical Due Diligence\"",
+                &format!("title = \"Acme\"\n{keys}"),
+            )
+        };
+
+        std::fs::write(&path, with("investigate_max_files = 334")).expect("write");
+        assert_eq!(
+            Budget::for_manifest(&path).max_bytes,
+            env_positive(ENV_MAX_BYTES).unwrap_or(3_420_160),
+            "a declared file budget carries the byte budget with it"
+        );
+
+        std::fs::write(
+            &path,
+            with("investigate_max_files = 334\ninvestigate_max_bytes = 4096"),
+        )
+        .expect("write");
+        assert_eq!(
+            Budget::for_manifest(&path),
+            Budget {
+                max_files: 334,
+                max_bytes: 4096,
+            },
+            "both declared keys win"
+        );
+    }
+
     /// #6082: the budget the audit asks for is recorded once, and only when the
     /// manifest is silent about it.
     #[test]
@@ -542,8 +649,8 @@ path = "/w/repos/acme-web"
         assert_eq!(budget.max_files, 300, "the declared key wins");
         assert_eq!(
             budget.max_bytes,
-            Budget::from_env().max_bytes,
-            "the undeclared key falls back"
+            env_positive(ENV_MAX_BYTES).unwrap_or(300 * BYTES_PER_FILE),
+            "the undeclared byte key derives from the declared file count (#6148)"
         );
         assert_eq!(
             crate::grounding::evidence::Caps::for_budget(budget.max_files).priority_paths,


### PR DESCRIPTION
`Budget` read `TRUSTY_AUDIT_INVESTIGATE_MAX_FILES` and `TRUSTY_AUDIT_INVESTIGATE_MAX_BYTES` independently, and trusty-review's selection stops at whichever cap binds first (`investigate/select.rs:574,583`). Raising files alone read fewer files than it asked for and reported nothing: lap-2 read 76 of 120 because the fixed 1.2 MiB cap bound first.

The byte budget now derives from the file budget at `BYTES_PER_FILE = 10 KiB` — the ratio the 120-file / 1.2 MiB pair already shipped with — whenever nothing declares bytes. An explicit env value or a declared `[report].investigate_max_bytes` still wins outright, and the per-key manifest semantics from #6133 are unchanged. Both `from_env` and `for_manifest` route through one private `Budget::resolve`, so the two sources cannot drift.

The default file budget moves 120 → 240 per the owner's above-1%-coverage ruling (120 measured ~1.8% on this workspace), so the default byte budget derives to 2.4 MiB. Cost: about 27 investigation batches per repository at 90 KiB each, up from ~13. The evidence caps follow the same budget — 240 ranked paths, 34 files per dimension, top_k 51.

Refs #6148.

## Gates — rung 3 on trusty-audit, plus a workspace check

```
cargo fmt --check                                    → FMT_EXIT=0
cargo clippy -p trusty-audit --all-targets -D warnings → EXIT=0
cargo test -p trusty-audit                           → 676 passed; 0 failed; 5 ignored (+33 in 6 integration bins, 0 failed)
cargo check --workspace --all-targets                → EXIT=0
scripts/check_line_cap.sh                            → 0 violations
scripts/check_sld.sh                                 → 0 errors, 0 warnings
scripts/check_changelog_fragment.sh                  → OK trusty-audit
scripts/check-pr-version-bump.sh                     → OK trusty-audit 0.8.0 (unpublished)
```

Regression proof — with the derivation reverted to the old fixed cap, both new tests fail:

```
test grounding::priority::priority_tests::a_raised_file_budget_raises_the_byte_budget ... FAILED
test grounding::priority::priority_tests::a_manifest_file_budget_raises_the_byte_budget ... FAILED
assertion `left == right` failed: 334 files earn 3.34 MiB, not the default cap
  left: 2457600
 right: 3420160
```

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
