### PR TITLE
feat(trusty-audit): the ranking keeps the function it measured (Refs #6145)

### DIFF
--- a/crates/trusty-audit/changelog.d/6145-function-level-hotspots.md
+++ b/crates/trusty-audit/changelog.d/6145-function-level-hotspots.md
@@ -1,0 +1,17 @@
+Changed
+
+- The complexity leg keeps the function it measured. `/complexity_hotspots`
+  ranks chunks — one function each, with a name, a line range and a cyclomatic
+  count — and the reader here parsed the file path and the count only, so
+  collapsing chunks to files threw away the part that says WHERE in a 900-line
+  file the complexity is. Each `inspect_priority` entry the complexity leg
+  produces now carries a nested `hotspot = { function, start_line, end_line,
+  cyclomatic }` table naming that file's worst function, and its `reason` line
+  names it too. The file-level collapse is unchanged: one entry per file, the
+  winning chunk's measurement recorded, the losing chunks still dropped.
+  trusty-review reads the new key to point the investigation prompt at the
+  function rather than the file (#6146).
+- A manifest written before this parses exactly as it did — the key is absent,
+  and an entry that has nothing else to say is still a bare path string. A
+  daemon that ranks a chunk without locating it still ranks that chunk's file;
+  the measurement is an addition to the entry, never a precondition for it.

--- a/crates/trusty-audit/src/grounding.rs
+++ b/crates/trusty-audit/src/grounding.rs
@@ -309,7 +309,7 @@ async fn complexity(
     checkout: &Path,
     display: &str,
     gaps: &mut Vec<String>,
-) -> Vec<String> {
+) -> Vec<hotspots::RankedFile> {
     if let Err(cause) = daemons::ensure_analyze(tools).await {
         gaps.push(format!(
             "{display}: {cause} — the report's findings, complexity distribution and health \

--- a/crates/trusty-audit/src/grounding/evidence.rs
+++ b/crates/trusty-audit/src/grounding/evidence.rs
@@ -35,6 +35,7 @@ use std::time::Duration;
 
 use serde::Deserialize;
 
+use super::hotspots::RankedFile;
 use super::priority::Priority;
 use super::quality;
 
@@ -570,9 +571,14 @@ fn reason(query: &str, hit: &Hit) -> String {
 /// as both reasons, because it is the dimension that decides whether the report
 /// can count that file as covering it.
 /// Test: `super::evidence_tests::{blending_spreads_the_budget_across_dimensions,
-/// a_hotspot_that_is_also_dimension_evidence_keeps_its_dimension}`.
+/// a_hotspot_that_is_also_dimension_evidence_keeps_its_dimension,
+/// a_blended_hotspot_carries_its_measured_function}`.
 #[must_use]
-pub fn blend(hotspots: &[String], dimensions: &[DimensionEvidence], cap: usize) -> Vec<Priority> {
+pub fn blend(
+    hotspots: &[RankedFile],
+    dimensions: &[DimensionEvidence],
+    cap: usize,
+) -> Vec<Priority> {
     let mut out: Vec<Priority> = Vec::new();
     let attributed = attributions(dimensions);
     let depth = dimensions
@@ -583,8 +589,8 @@ pub fn blend(hotspots: &[String], dimensions: &[DimensionEvidence], cap: usize) 
         .unwrap_or(0);
 
     for round in 0..depth {
-        if let Some(path) = hotspots.get(round) {
-            push(&mut out, hotspot(path, round, &attributed));
+        if let Some(ranked) = hotspots.get(round) {
+            push(&mut out, hotspot(ranked, round, &attributed));
         }
         for dimension in dimensions {
             let Some(file) = dimension.files.get(round) else {
@@ -596,6 +602,7 @@ pub fn blend(hotspots: &[String], dimensions: &[DimensionEvidence], cap: usize) 
                     path: file.path.clone(),
                     dimension: Some(dimension.dimension.clone()),
                     reason: Some(file.reason.clone()),
+                    hotspot: None,
                 },
             );
         }
@@ -642,18 +649,35 @@ fn attributions(dimensions: &[DimensionEvidence]) -> Vec<(String, String, String
 }
 
 /// One complexity hotspot, carrying the search attribution when it has one.
-fn hotspot(path: &str, round: usize, attributed: &[(String, String, String)]) -> Priority {
-    let measured = format!("trusty-analyze complexity hotspot (rank {})", round + 1);
+///
+/// #6145: the measured function rides along whatever the attribution says. The
+/// reason line names it too, so a reader of the manifest sees the same fact the
+/// machine-readable key carries.
+fn hotspot(ranked: &RankedFile, round: usize, attributed: &[(String, String, String)]) -> Priority {
+    let path = ranked.path.as_str();
+    let mut measured = format!("trusty-analyze complexity hotspot (rank {})", round + 1);
+    if let Some(function) = &ranked.hotspot {
+        let named = function
+            .function
+            .as_deref()
+            .map_or_else(String::new, |name| format!("fn {name}, "));
+        measured.push_str(&format!(
+            ": {named}lines {}-{}, cyclomatic {}",
+            function.start_line, function.end_line, function.cyclomatic
+        ));
+    }
     match attributed.iter().find(|(p, _, _)| p == path) {
         Some((_, dimension, found)) => Priority {
             path: path.to_owned(),
             dimension: Some(dimension.clone()),
             reason: Some(format!("{measured}; {found}")),
+            hotspot: ranked.hotspot.clone(),
         },
         None => Priority {
             path: path.to_owned(),
             dimension: None,
             reason: Some(measured),
+            hotspot: ranked.hotspot.clone(),
         },
     }
 }

--- a/crates/trusty-audit/src/grounding/evidence_tests.rs
+++ b/crates/trusty-audit/src/grounding/evidence_tests.rs
@@ -6,6 +6,7 @@
 
 use std::collections::HashMap;
 
+use super::super::priority::FunctionHotspot;
 use super::*;
 
 /// A search client answering from a table of `query substring → hits`.
@@ -204,12 +205,25 @@ fn dimension(name: &str, paths: &[&str]) -> DimensionEvidence {
     }
 }
 
+/// Ranked files with no function-level measurement — the shape a daemon that
+/// locates nothing produces, and what most of these cases care about.
+fn hot(paths: &[&str]) -> Vec<RankedFile> {
+    paths
+        .iter()
+        .map(|path| RankedFile {
+            path: (*path).to_owned(),
+            hotspot: None,
+        })
+        .collect()
+}
+
 /// The regression this issue exists for: ranking complexity first spends the
 /// whole budget on one dimension. Round-robin reaches every dimension inside
 /// the same number of files.
 #[test]
 fn blending_spreads_the_budget_across_dimensions() {
-    let hotspots: Vec<String> = (0..10).map(|i| format!("src/hot{i}.rs")).collect();
+    let owned: Vec<String> = (0..10).map(|i| format!("src/hot{i}.rs")).collect();
+    let hotspots = hot(&owned.iter().map(String::as_str).collect::<Vec<_>>());
     let dimensions = [
         dimension("authentication & secrets", &["src/auth.rs", "src/token.rs"]),
         dimension("error handling", &["src/err.rs"]),
@@ -253,7 +267,7 @@ fn blending_spreads_the_budget_across_dimensions() {
 /// trusty-review's own heuristics and hidden the defect.
 #[test]
 fn a_hotspot_that_is_also_dimension_evidence_keeps_its_dimension() {
-    let hotspots = vec!["src/session_manager.rs".to_string()];
+    let hotspots = hot(&["src/session_manager.rs"]);
     let dimensions = [dimension(
         "authentication & secrets",
         &["src/session_manager.rs"],
@@ -275,7 +289,7 @@ fn a_hotspot_that_is_also_dimension_evidence_keeps_its_dimension() {
 /// dimension for a file the index never named.
 #[test]
 fn a_hotspot_no_query_found_carries_no_dimension() {
-    let hotspots = vec!["src/parser.rs".to_string()];
+    let hotspots = hot(&["src/parser.rs"]);
     let dimensions = [dimension("error handling", &["src/err.rs"])];
     let blended = blend(&hotspots, &dimensions, 60);
     let parser = blended
@@ -292,12 +306,44 @@ fn a_hotspot_no_query_found_carries_no_dimension() {
 /// The cap bounds the manifest, and never truncates to nothing.
 #[test]
 fn the_ranking_is_capped() {
-    let hotspots: Vec<String> = (0..80).map(|i| format!("src/hot{i}.rs")).collect();
+    let owned: Vec<String> = (0..80).map(|i| format!("src/hot{i}.rs")).collect();
+    let hotspots = hot(&owned.iter().map(String::as_str).collect::<Vec<_>>());
     assert_eq!(
         blend(&hotspots, &[], MIN_PRIORITY_PATHS).len(),
         MIN_PRIORITY_PATHS
     );
     assert!(blend(&[], &[], MIN_PRIORITY_PATHS).is_empty());
+}
+
+/// #6145: the measured function survives the blend — both as the structured key
+/// trusty-review reads and in the reason line a human reads. Pre-fix `blend`
+/// took paths only, so there was nothing to survive.
+#[test]
+fn a_blended_hotspot_carries_its_measured_function() {
+    let measured = FunctionHotspot {
+        function: Some("settle_invoice".to_owned()),
+        start_line: 40,
+        end_line: 190,
+        cyclomatic: 31,
+    };
+    let hotspots = vec![RankedFile {
+        path: "src/pay.rs".to_owned(),
+        hotspot: Some(measured.clone()),
+    }];
+
+    // Unattributed, and attributed to a dimension: both keep the measurement.
+    for dimensions in [
+        Vec::new(),
+        vec![dimension("error handling", &["src/pay.rs"])],
+    ] {
+        let blended = blend(&hotspots, &dimensions, 60);
+        assert_eq!(blended[0].hotspot.as_ref(), Some(&measured), "{blended:?}");
+        let reason = blended[0].reason.as_deref().expect("a reason");
+        assert!(
+            reason.contains("fn settle_invoice, lines 40-190, cyclomatic 31"),
+            "{reason}"
+        );
+    }
 }
 
 /// #6082: trusty-search expands the top hits along the symbol graph by default,

--- a/crates/trusty-audit/src/grounding/grounding_tests.rs
+++ b/crates/trusty-audit/src/grounding/grounding_tests.rs
@@ -147,11 +147,11 @@ fn tools(search: PathBuf, search_url: String, analyze: PathBuf, analyze_url: Str
 
 const HOTSPOTS: &str = r#"{"index_id":"acme-api","top_n":60,"hotspots":[
     {"id":"a","file":"CHECKOUT/src/pay.rs","start_line":1,"end_line":9,"content":"",
-     "cyclomatic":31,"cognitive":40},
+     "function_name":"settle_invoice","cyclomatic":31,"cognitive":40},
     {"id":"b","file":"CHECKOUT/src/pay.rs","start_line":20,"end_line":30,"content":"",
-     "cyclomatic":18,"cognitive":22},
+     "function_name":"refund","cyclomatic":18,"cognitive":22},
     {"id":"c","file":"CHECKOUT/src/auth.rs","start_line":1,"end_line":9,"content":"",
-     "cyclomatic":12,"cognitive":15}
+     "function_name":"verify","cyclomatic":12,"cognitive":15}
 ]}"#;
 
 const EMPTY_HOTSPOTS: &str = r#"{"index_id":"acme-api","top_n":60,"hotspots":[]}"#;
@@ -544,6 +544,26 @@ async fn hotspots_and_search_hits_become_ranked_inspect_priority_in_the_manifest
             .contains("trusty-search hit for"),
         "{written}"
     );
+    // #6145: the winning chunk's own name, range and cyclomatic count survive
+    // the collapse to files and reach the manifest trusty-review reads. The
+    // losing pay.rs chunk (`refund`, rank 2) must not be the one recorded.
+    let hotspot = &declared[0]["hotspot"];
+    assert_eq!(
+        hotspot["function"].as_str(),
+        Some("settle_invoice"),
+        "{written}"
+    );
+    assert_eq!(hotspot["start_line"].as_integer(), Some(1), "{written}");
+    assert_eq!(hotspot["end_line"].as_integer(), Some(9), "{written}");
+    assert_eq!(hotspot["cyclomatic"].as_integer(), Some(31), "{written}");
+    assert!(
+        declared
+            .iter()
+            .filter(|entry| entry.get("path").and_then(toml::Value::as_str) == Some("src/login.rs"))
+            .all(|entry| entry.get("hotspot").is_none()),
+        "a search-only entry carries no measurement: {written}"
+    );
+
     // #6082: the audit's investigation budget rides on the same interface.
     assert_eq!(
         parsed["report"]["investigate_max_files"].as_integer(),

--- a/crates/trusty-audit/src/grounding/hotspots.rs
+++ b/crates/trusty-audit/src/grounding/hotspots.rs
@@ -16,6 +16,12 @@
 //! FILES. Several chunks of one file collapse to the file's best rank, which is
 //! also what keeps one pathological file from filling the whole list.
 //!
+//! #6145: the collapse KEEPS the winning chunk rather than only its path. The
+//! chunks arrive already sorted descending, so the first chunk of a file is that
+//! file's hottest function, and carrying its name, line range and cyclomatic
+//! count is what lets trusty-review point the analysis at the function instead
+//! of the file (#6146).
+//!
 //! The client is [`trusty_common::http_client::loopback_client_builder`], not a
 //! bare `reqwest::Client::new()`: the target is a loopback daemon, and a client
 //! that honoured an exported `HTTP_PROXY` would send a recipient's index id to
@@ -27,6 +33,8 @@ use std::path::Path;
 use std::time::Duration;
 
 use serde::Deserialize;
+
+use super::priority::FunctionHotspot;
 
 /// How many chunks to ask for.
 ///
@@ -59,12 +67,57 @@ struct HotspotEnvelope {
 }
 
 /// One ranked chunk. Every other field of the flattened `CodeChunk` is ignored.
+///
+/// #6145: `function_name`, `start_line` and `end_line` were already on the wire
+/// and discarded here. A daemon that omits any of them still parses — the
+/// function-level record is then simply not built.
 #[derive(Debug, Deserialize)]
 struct Hotspot {
     #[serde(default)]
     file: String,
     #[serde(default)]
     cyclomatic: u32,
+    #[serde(default)]
+    function_name: Option<String>,
+    #[serde(default)]
+    start_line: u32,
+    #[serde(default)]
+    end_line: u32,
+}
+
+impl Hotspot {
+    /// This chunk as a function-level record, when its line range is usable.
+    ///
+    /// Why the range and not the name decides: the range is what an instruction
+    /// to "read this function" needs, and trusty-analyze's chunker names a
+    /// function only for the languages whose parser it has. A named chunk with
+    /// no range would produce "prioritize fn X" with nothing to point at.
+    fn measured_function(&self) -> Option<FunctionHotspot> {
+        if self.start_line == 0 || self.end_line < self.start_line {
+            return None;
+        }
+        Some(FunctionHotspot {
+            function: self
+                .function_name
+                .as_deref()
+                .map(str::trim)
+                .filter(|name| !name.is_empty())
+                .map(ToOwned::to_owned),
+            start_line: self.start_line,
+            end_line: self.end_line,
+            cyclomatic: self.cyclomatic,
+        })
+    }
+}
+
+/// One file of the ranking, with the worst function measured inside it (#6145).
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct RankedFile {
+    /// Repo-relative path (absolute when the chunk named a file outside it).
+    pub path: String,
+    /// The file's hottest measured function, when the chunk carried a range.
+    pub hotspot: Option<FunctionHotspot>,
 }
 
 /// The endpoint for one index, on one base address.
@@ -86,13 +139,16 @@ fn hotspots_url(base: &str, index_id: &str) -> String {
 /// trusty-review does accept an absolute one, but a manifest a human reads
 /// should not name the machine that produced it.
 /// What: descending order preserved (the endpoint already sorted), first
-/// occurrence wins, zero-complexity dropped, capped at [`MAX_PRIORITY_PATHS`].
-/// Test: `hotspot_tests::{ranking_collapses_chunks_to_files,
+/// occurrence wins — and since the sort is descending, that first occurrence IS
+/// the file's hottest function, which the entry keeps (#6145) — zero-complexity
+/// dropped, capped at [`MAX_PRIORITY_PATHS`].
+/// Test: `hotspot_tests::{ranking_collapses_chunks_to_files_keeping_the_best_rank,
+/// the_hottest_function_of_each_file_is_kept,
 /// zero_complexity_chunks_carry_no_ranking, the_ranking_is_capped}`.
-fn rank(hotspots: &[Hotspot], checkout: &Path) -> Vec<String> {
+fn rank(hotspots: &[Hotspot], checkout: &Path) -> Vec<RankedFile> {
     let root = checkout.to_string_lossy().replace('\\', "/");
     let root = root.trim_end_matches('/');
-    let mut out: Vec<String> = Vec::new();
+    let mut out: Vec<RankedFile> = Vec::new();
     for spot in hotspots {
         if spot.cyclomatic == 0 || spot.file.is_empty() {
             continue;
@@ -102,10 +158,13 @@ fn rank(hotspots: &[Hotspot], checkout: &Path) -> Vec<String> {
             .strip_prefix(root)
             .map_or(path.as_str(), |rest| rest.trim_start_matches('/'))
             .to_owned();
-        if relative.is_empty() || out.contains(&relative) {
+        if relative.is_empty() || out.iter().any(|ranked| ranked.path == relative) {
             continue;
         }
-        out.push(relative);
+        out.push(RankedFile {
+            path: relative,
+            hotspot: spot.measured_function(),
+        });
         if out.len() >= MAX_PRIORITY_PATHS {
             break;
         }
@@ -128,7 +187,7 @@ fn rank(hotspots: &[Hotspot], checkout: &Path) -> Vec<String> {
 /// Test: `super::grounding_tests::{an_unreachable_hotspots_endpoint_is_a_named_gap,
 /// an_empty_hotspot_list_is_a_named_gap,
 /// hotspots_become_ranked_inspect_priority_in_the_manifest}`.
-pub async fn fetch(base: &str, index_id: &str, checkout: &Path) -> Result<Vec<String>, String> {
+pub async fn fetch(base: &str, index_id: &str, checkout: &Path) -> Result<Vec<RankedFile>, String> {
     let url = hotspots_url(base, index_id);
     let client = trusty_common::http_client::loopback_client_builder()
         .timeout(REQUEST_BUDGET)
@@ -158,7 +217,26 @@ mod hotspot_tests {
         Hotspot {
             file: file.to_owned(),
             cyclomatic,
+            function_name: None,
+            start_line: 0,
+            end_line: 0,
         }
+    }
+
+    /// A chunk the daemon named and located, which is the ordinary case.
+    fn located(file: &str, cyclomatic: u32, function: &str, start: u32, end: u32) -> Hotspot {
+        Hotspot {
+            file: file.to_owned(),
+            cyclomatic,
+            function_name: Some(function.to_owned()),
+            start_line: start,
+            end_line: end,
+        }
+    }
+
+    /// The ranked paths alone, for the assertions that only care about order.
+    fn paths(ranked: &[RankedFile]) -> Vec<String> {
+        ranked.iter().map(|r| r.path.clone()).collect()
     }
 
     #[test]
@@ -188,10 +266,84 @@ mod hotspot_tests {
         let env: HotspotEnvelope = serde_json::from_str(body).expect("parses");
         assert_eq!(env.hotspots.len(), 1);
         assert_eq!(env.hotspots[0].cyclomatic, 31);
+        let ranked = rank(&env.hotspots, Path::new("/w/repos/acme-api"));
+        assert_eq!(paths(&ranked), vec!["src/pay.rs".to_string()]);
+        // #6145: the per-function fields the daemon already sent are kept.
+        let measured = ranked[0].hotspot.as_ref().expect("the chunk was located");
+        assert_eq!(measured.function.as_deref(), Some("f"));
+        assert_eq!((measured.start_line, measured.end_line), (1, 9));
+        assert_eq!(measured.cyclomatic, 31);
+    }
+
+    /// #6145: chunks arrive sorted descending, so the chunk that wins a file's
+    /// place in the ranking is that file's hottest function — and the entry
+    /// keeps it rather than only the path. Pre-fix this data reached the
+    /// manifest as two bare strings.
+    #[test]
+    fn the_hottest_function_of_each_file_is_kept() {
+        let spots = [
+            located("/w/repos/api/src/pay.rs", 31, "settle_invoice", 40, 190),
+            located("/w/repos/api/src/pay.rs", 22, "refund", 210, 260),
+            located("/w/repos/api/src/auth.rs", 18, "verify_token", 12, 60),
+        ];
+        let ranked = rank(&spots, Path::new("/w/repos/api"));
         assert_eq!(
-            rank(&env.hotspots, Path::new("/w/repos/acme-api")),
-            vec!["src/pay.rs".to_string()]
+            ranked
+                .iter()
+                .map(|r| {
+                    let h = r.hotspot.as_ref().expect("a measured function");
+                    (
+                        r.path.as_str(),
+                        h.function.as_deref(),
+                        h.start_line,
+                        h.end_line,
+                        h.cyclomatic,
+                    )
+                })
+                .collect::<Vec<_>>(),
+            vec![
+                ("src/pay.rs", Some("settle_invoice"), 40, 190, 31),
+                ("src/auth.rs", Some("verify_token"), 12, 60, 18),
+            ],
+            "the losing chunk of pay.rs must not displace the winner: {ranked:?}"
         );
+    }
+
+    /// A daemon that ranks a chunk without locating it still ranks its file —
+    /// the file-level collapse is what the manifest needs, and the function
+    /// record is an addition to it, never a precondition.
+    #[test]
+    fn a_chunk_with_no_usable_range_still_ranks_its_file() {
+        let spots = [
+            spot("/w/repos/api/src/a.rs", 30),
+            Hotspot {
+                start_line: 90,
+                end_line: 12,
+                ..located("/w/repos/api/src/b.rs", 20, "reversed", 0, 0)
+            },
+        ];
+        let ranked = rank(&spots, Path::new("/w/repos/api"));
+        assert_eq!(
+            paths(&ranked),
+            vec!["src/a.rs".to_string(), "src/b.rs".to_string()]
+        );
+        assert!(
+            ranked.iter().all(|r| r.hotspot.is_none()),
+            "an absent or inverted range carries no function: {ranked:?}"
+        );
+    }
+
+    /// An empty `function_name` is the daemon saying it could not name the
+    /// chunk, not a function called "". The range still carries the analysis.
+    #[test]
+    fn an_unnamed_chunk_keeps_its_range() {
+        let spots = [located("/w/repos/api/src/a.rs", 30, "  ", 4, 44)];
+        let measured = rank(&spots, Path::new("/w/repos/api"))[0]
+            .hotspot
+            .clone()
+            .expect("a located chunk");
+        assert_eq!(measured.function, None);
+        assert_eq!((measured.start_line, measured.end_line), (4, 44));
     }
 
     /// An envelope with no `hotspots` key at all is an empty measurement, not a
@@ -210,7 +362,7 @@ mod hotspot_tests {
             spot("/w/repos/api/src/auth.rs", 18),
         ];
         assert_eq!(
-            rank(&spots, Path::new("/w/repos/api")),
+            paths(&rank(&spots, Path::new("/w/repos/api"))),
             vec!["src/pay.rs".to_string(), "src/auth.rs".to_string()]
         );
     }
@@ -242,7 +394,7 @@ mod hotspot_tests {
     fn a_path_outside_the_checkout_is_left_absolute() {
         let spots = [spot("/elsewhere/src/a.rs", 12)];
         assert_eq!(
-            rank(&spots, Path::new("/w/repos/api")),
+            paths(&rank(&spots, Path::new("/w/repos/api"))),
             vec!["/elsewhere/src/a.rs".to_string()]
         );
     }

--- a/crates/trusty-audit/src/grounding/priority.rs
+++ b/crates/trusty-audit/src/grounding/priority.rs
@@ -33,12 +33,14 @@ use toml_edit::{Array, DocumentMut, InlineTable, Item, Table, Value};
 /// Why: a ranking that only says WHICH files to read cannot tell the report why
 /// any of them was read, and "why" is the whole difference between a coverage
 /// section that states a percentage and one a due-diligence reader can weigh.
-/// The two optional fields are what trusty-review renders per dimension.
+/// The three optional fields are what trusty-review renders per dimension.
 /// What: `path` is repo-relative; `dimension` is a DD dimension spelled as
 /// trusty-review spells it (absent for a signal that belongs to no single
 /// dimension, such as a complexity hotspot); `reason` is one line naming the
-/// query or measurement that selected it.
-/// Test: `priority_tests::a_dimension_and_reason_are_written_as_a_table`.
+/// query or measurement that selected it; `hotspot` is the file's worst
+/// measured function, when the complexity leg ranked this file (#6145).
+/// Test: `priority_tests::{a_dimension_and_reason_are_written_as_a_table,
+/// a_hotspot_is_written_as_a_nested_table}`.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 #[non_exhaustive]
 pub struct Priority {
@@ -48,6 +50,8 @@ pub struct Priority {
     pub dimension: Option<String>,
     /// One line naming the query or measurement that selected it.
     pub reason: Option<String>,
+    /// The file's hottest function, when trusty-analyze measured one (#6145).
+    pub hotspot: Option<FunctionHotspot>,
 }
 
 impl Priority {
@@ -56,10 +60,35 @@ impl Priority {
     pub fn bare(path: impl Into<String>) -> Self {
         Self {
             path: path.into(),
-            dimension: None,
-            reason: None,
+            ..Self::default()
         }
     }
+}
+
+/// The worst measured function inside one ranked file (#6145).
+///
+/// Why: `/complexity_hotspots` ranks FUNCTIONS and the manifest names FILES, so
+/// collapsing chunks to files discarded the only part of the measurement that
+/// says WHERE in a 900-line file the complexity is. The owner ruled that
+/// analysis must target the most complex functions, and a path alone cannot
+/// carry that instruction to the crate that acts on it (trusty-review, #6146).
+/// What: the winning chunk's own line range and cyclomatic count, plus its name
+/// when the daemon supplied one. The range is what makes it actionable; the
+/// name is what makes it readable, and a chunk the parser could not name still
+/// has a usable range.
+/// Test: `super::hotspot_tests::the_hottest_function_of_each_file_is_kept`,
+/// `priority_tests::a_hotspot_is_written_as_a_nested_table`.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[non_exhaustive]
+pub struct FunctionHotspot {
+    /// The function's name, when trusty-analyze named it.
+    pub function: Option<String>,
+    /// First line of the measured chunk, 1-based.
+    pub start_line: u32,
+    /// Last line of the measured chunk, 1-based and inclusive.
+    pub end_line: u32,
+    /// The chunk's cyclomatic complexity — the number that ranked it.
+    pub cyclomatic: u32,
 }
 
 /// The investigation budget the audit asks for, in files and content bytes.
@@ -352,7 +381,7 @@ fn ranked(priorities: &[Priority]) -> Array {
 
 /// One priority as TOML: a bare path, or a table when it carries attribution.
 fn entry(priority: &Priority) -> Value {
-    if priority.dimension.is_none() && priority.reason.is_none() {
+    if priority.dimension.is_none() && priority.reason.is_none() && priority.hotspot.is_none() {
         return Value::from(priority.path.as_str());
     }
     let mut table = InlineTable::new();
@@ -363,7 +392,29 @@ fn entry(priority: &Priority) -> Value {
     if let Some(reason) = &priority.reason {
         table.insert("reason", Value::from(reason.as_str()));
     }
+    // #6145: nested rather than four `hotspot_*` siblings, so the measurement
+    // reads as one fact and a reader can tell at a glance which keys came from
+    // the complexity leg.
+    if let Some(hotspot) = &priority.hotspot {
+        table.insert("hotspot", Value::InlineTable(hotspot_table(hotspot)));
+    }
     Value::InlineTable(table)
+}
+
+/// One measured function as a nested inline table (#6145).
+fn hotspot_table(hotspot: &FunctionHotspot) -> InlineTable {
+    let mut table = InlineTable::new();
+    if let Some(function) = &hotspot.function {
+        table.insert("function", Value::from(function.as_str()));
+    }
+    for (key, value) in [
+        ("start_line", hotspot.start_line),
+        ("end_line", hotspot.end_line),
+        ("cyclomatic", hotspot.cyclomatic),
+    ] {
+        table.insert(key, Value::from(i64::from(value)));
+    }
+    table
 }
 
 #[cfg(test)]
@@ -409,7 +460,73 @@ path = "/w/repos/acme-web"
             path: path.to_owned(),
             dimension: Some(dimension.to_owned()),
             reason: Some(reason.to_owned()),
+            hotspot: None,
         }
+    }
+
+    /// #6145: the complexity leg's entry — a path and the function it measured,
+    /// with no dimension, which is the shape `evidence::blend` produces.
+    #[test]
+    fn a_hotspot_is_written_as_a_nested_table() {
+        let out = recorded(
+            SAMPLE,
+            "/w/repos/acme-api",
+            &[Priority {
+                path: "src/pay.rs".to_owned(),
+                dimension: None,
+                reason: Some("trusty-analyze complexity hotspot (rank 1)".to_owned()),
+                hotspot: Some(FunctionHotspot {
+                    function: Some("settle_invoice".to_owned()),
+                    start_line: 40,
+                    end_line: 190,
+                    cyclomatic: 31,
+                }),
+            }],
+            None,
+            &[],
+        );
+        let parsed: toml::Value = toml::from_str(&out).expect("still valid TOML");
+        let first = &parsed["repositories"].as_array().expect("array")[0]["inspect_priority"]
+            .as_array()
+            .expect("declared")[0];
+        assert_eq!(first["path"].as_str(), Some("src/pay.rs"), "{out}");
+        let hotspot = &first["hotspot"];
+        assert_eq!(
+            hotspot["function"].as_str(),
+            Some("settle_invoice"),
+            "{out}"
+        );
+        assert_eq!(hotspot["start_line"].as_integer(), Some(40), "{out}");
+        assert_eq!(hotspot["end_line"].as_integer(), Some(190), "{out}");
+        assert_eq!(hotspot["cyclomatic"].as_integer(), Some(31), "{out}");
+    }
+
+    /// #6145: an unnamed chunk writes its range and omits the key rather than
+    /// declaring a function called "".
+    #[test]
+    fn an_unnamed_hotspot_omits_the_function_key() {
+        let out = recorded(
+            SAMPLE,
+            "/w/repos/acme-api",
+            &[Priority {
+                path: "src/pay.rs".to_owned(),
+                hotspot: Some(FunctionHotspot {
+                    function: None,
+                    start_line: 4,
+                    end_line: 44,
+                    cyclomatic: 12,
+                }),
+                ..Priority::default()
+            }],
+            None,
+            &[],
+        );
+        let parsed: toml::Value = toml::from_str(&out).expect("still valid TOML");
+        let hotspot = &parsed["repositories"].as_array().expect("array")[0]["inspect_priority"]
+            .as_array()
+            .expect("declared")[0]["hotspot"];
+        assert!(hotspot.get("function").is_none(), "{out}");
+        assert_eq!(hotspot["start_line"].as_integer(), Some(4), "{out}");
     }
 
     /// #6082: an attributed entry becomes a table carrying its dimension and the


### PR DESCRIPTION
Owner ruling this implements: "target analysis of the most complex functions."

`/complexity_hotspots` ranks chunks — one function each, carrying `function_name`, `start_line`, `end_line` and `cyclomatic`. `Hotspot` deserialized the file path and the cyclomatic count only, so collapsing chunks to files threw away the part that says where in a 900-line file the complexity is.

Each `inspect_priority` entry the complexity leg produces now carries a nested table naming that file's worst function:

```toml
{ path = "src/pay.rs", reason = "trusty-analyze complexity hotspot (rank 1): fn settle_invoice, lines 40-190, cyclomatic 31", hotspot = { function = "settle_invoice", start_line = 40, end_line = 190, cyclomatic = 31 } }
```

The file-level collapse is unchanged — one entry per file. The chunks arrive sorted descending, so the chunk that wins a file's place IS that file's hottest function, and it is the one recorded; the losing chunks are still dropped.

Back-compat: a manifest written before this parses as it did, since the key is absent and an entry with nothing else to say is still a bare path string. A daemon that ranks a chunk without locating it (no range, or an inverted one) still ranks that chunk's file — the measurement is an addition to the entry, never a precondition for it. An empty `function_name` writes no `function` key rather than a function called `""`.

trusty-review reads the new key in #6146.

## Gates — rung 4

Test ladder rung 4: public API of `grounding` changes (`blend`, `hotspots::fetch`, `Priority`). trusty-audit has no in-workspace dependents, so `cargo check --workspace` is the dependent leg.

| Gate | Result |
|---|---|
| `cargo fmt --check` | exit 0 |
| `cargo check -p trusty-audit --all-targets` | exit 0 |
| `cargo clippy -p trusty-audit --all-targets -- -D warnings` | exit 0 |
| `cargo test -p trusty-audit` | `678 passed; 0 failed; 5 ignored` (lib), plus 33 passed across 6 integration binaries, 0 failed |
| `cargo check --workspace` | exit 0 |
| `scripts/check_line_cap.sh` | 4141 files, 0 violations |
| `scripts/check_sld.sh` | 0 errors, 0 warnings |
| `scripts/check_changelog_fragment.sh` | OK — `6145-function-level-hotspots.md` |
| `scripts/check-pr-version-bump.sh` | OK — 0.8.0, src changed, version not yet published |

### Fail-pre-fix proof

Stubbing `Hotspot::measured_function` to return `None` — the pre-fix behaviour, since the old struct had no function fields to build one from — turns four assertions red:

```
test grounding::hotspots::hotspot_tests::the_daemons_own_envelope_parses ... FAILED
test grounding::hotspots::hotspot_tests::an_unnamed_chunk_keeps_its_range ... FAILED
test grounding::hotspots::hotspot_tests::the_hottest_function_of_each_file_is_kept ... FAILED
test grounding::grounding_tests::hotspots_and_search_hits_become_ranked_inspect_priority_in_the_manifest ... FAILED
test result: FAILED. 82 passed; 4 failed; 0 ignored; 0 measured; 597 filtered out
```

Restored: `test result: ok. 86 passed; 0 failed`.

Refs #6145.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools