### PR TITLE
feat: deterministic crate topology grounds the architecture section (Refs #6147)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11298,7 +11298,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-audit"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -11790,7 +11790,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-review"
-version = "0.22.1"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,7 +159,7 @@ trusty-mpm = { path = "crates/trusty-mpm", version = "1.0.0" }
 #      this line existed. Both consumers name what they need: trusty-analyze's
 #      `review` feature pulls `trusty-review/mcp`; trusty-mpm's dev-dependency
 #      only touches `integrations`, which is unconditional.
-trusty-review = { path = "crates/trusty-review", version = "0.22", default-features = false }
+trusty-review = { path = "crates/trusty-review", version = "0.23", default-features = false }
 # trusty-console: web dashboard for trusty services. As of #1318 the standalone
 # `trusty-console` crate is the SOLE producer of the `trusty-console` binary
 # (de-bundled from the host crates for single-owner-per-binary). It is still a

--- a/crates/trusty-audit/Cargo.toml
+++ b/crates/trusty-audit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-audit"
-version = "0.8.1"
+version = "0.8.2"
 description = "Auditor client — installs its pinned audit tooling and drives an audit engagement on the recipient's own codebases."
 readme = "README.md"
 homepage = "https://github.com/bobmatnyc/trusty-tools"

--- a/crates/trusty-audit/changelog.d/6147-crate-topology.md
+++ b/crates/trusty-audit/changelog.d/6147-crate-topology.md
@@ -1,0 +1,21 @@
+Added
+
+- A grounding leg measures the crate topology of any audited repository whose
+  root `Cargo.toml` declares a `[workspace]`, and writes it into that
+  repository's `manifest.toml` as a `crate_topology` table: member count, each
+  member's direct internal dependencies and how many members depend on it, the
+  total edge count, and any dependency cycle over those edges. It runs
+  `cargo metadata --no-deps --format-version 1` — no dependency resolution, no
+  network — and reads three keys out of the result, so it adds no dependency to
+  the crate. `trusty-review` renders those numbers as a deterministic table in
+  Code Quality & Architecture and states them to the architecture paragraph, so
+  that paragraph comments on the workspace's real shape instead of inferring one
+  from complexity buckets and a language list.
+- Dev-dependencies are deliberately not counted as architecture edges: cargo
+  permits a dev-dependency cycle, so counting them would report a routine
+  test-only arrangement as a cycle. A cycle over the edges that remain is one
+  cargo itself rejects, which the report states as such.
+- A repository that is not a Cargo workspace is a declared skip, not a gap — it
+  has no crate topology to miss, and its report is unchanged. A repository that
+  IS a workspace whose metadata could not be read is a named gap, naming the
+  repository and what its report therefore will not carry.

--- a/crates/trusty-audit/src/grounding.rs
+++ b/crates/trusty-audit/src/grounding.rs
@@ -25,6 +25,7 @@
 //! | [`index`] | is this checkout in trusty-search, and indexing it if not |
 //! | [`hotspots`] | asking trusty-analyze which files are worst, and ranking them |
 //! | [`evidence`] | asking trusty-search where each DD dimension's evidence is (#6082) |
+//! | [`topology`] | reading a Cargo workspace's own crate graph (#6147) |
 //! | [`priority`] | writing that ranking, and the gaps, into the manifest |
 //!
 //! ## Fail-open, and never silently
@@ -59,6 +60,7 @@ pub mod hotspots;
 pub mod index;
 pub mod priority;
 pub mod quality;
+pub mod topology;
 
 #[cfg(test)]
 mod grounding_tests;
@@ -387,6 +389,11 @@ pub async fn ground_manifest(
     let instructions = instructions_from(manifest);
     let budget = priority::Budget::for_manifest(manifest);
     let mut grounding = ground(tools, checkout, display, instructions.as_deref(), budget).await;
+    // #6147: the crate graph is read from the checkout's own manifests, so it
+    // depends on neither daemon and is measured whether or not either answered.
+    // It writes its own key, after the ranking, so one leg's write failure
+    // cannot take the other's data with it.
+    let topology_gaps = topology::ground_into(manifest, checkout, display);
     if let Err(cause) = priority::write_into(
         manifest,
         checkout,
@@ -400,6 +407,18 @@ pub async fn ground_manifest(
              evidence ranking"
         ));
     }
+    // Recorded through the same `[report].gaps` key every other leg uses, which
+    // `priority::write_into` above owns — so they are appended after it ran.
+    if !topology_gaps.is_empty()
+        && let Err(cause) =
+            priority::write_into(manifest, checkout, &[], None, false, &topology_gaps)
+    {
+        grounding.gaps.push(format!(
+            "{display}: {cause} — the rendered report does not state why its crate topology \
+             is missing"
+        ));
+    }
+    grounding.gaps.extend(topology_gaps);
     grounding.gaps
 }
 

--- a/crates/trusty-audit/src/grounding/priority.rs
+++ b/crates/trusty-audit/src/grounding/priority.rs
@@ -379,7 +379,7 @@ fn record_priorities(
 /// the same directory by a symlinked or non-normalised path still matches. A
 /// path that cannot be canonicalised — the checkout has since been deleted —
 /// falls back to the textual comparison rather than erroring.
-fn names_checkout(entry: &Table, checkout: &Path) -> bool {
+pub(super) fn names_checkout(entry: &Table, checkout: &Path) -> bool {
     let Some(declared) = entry.get("path").and_then(Item::as_str) else {
         return false;
     };

--- a/crates/trusty-audit/src/grounding/topology.rs
+++ b/crates/trusty-audit/src/grounding/topology.rs
@@ -1,0 +1,539 @@
+//! The crate graph a Rust workspace already declares (#6147).
+//!
+//! Why: the report's Code Quality & Architecture paragraph had no deterministic
+//! architecture input. An LLM inferred the shape of the codebase from complexity
+//! buckets, a language list and a LoC count — none of which says which crates
+//! exist, which depends on which, or which one everything else is built on. A
+//! Cargo workspace states all three in its own manifests, so they can be
+//! measured rather than guessed (owner ruling: crate design is a factor for Rust
+//! projects, and the report owes high-level architecture more attention).
+//!
+//! What: one leg, `cargo metadata --no-deps --format-version 1`, reduced to four
+//! facts — member count, the direct internal dependency edges, any cycle over
+//! them, and the most-depended-on members. [`write_into`] puts them under the
+//! audited repository's manifest entry, where trusty-review reads them.
+//!
+//! ## Why this shells out rather than adding `cargo_metadata`
+//!
+//! `cargo_metadata` reaches this workspace's lock file only as a transitive
+//! dependency of `tauri-utils`; no crate here depends on it directly. The facts
+//! below need three JSON keys, `serde_json` is already a dependency of this
+//! crate, and [`super::index`] next door already spawns its tool exactly this
+//! way. A direct dependency would pin a second crate to cargo's metadata format
+//! in exchange for a typed shape this module collapses on the next line.
+//!
+//! ## What counts as an edge
+//!
+//! A normal or build dependency whose name is another member's. Dev
+//! dependencies are excluded because cargo PERMITS a dev-dependency cycle, so
+//! counting them would report a routine test-only arrangement as an
+//! architectural defect. A cycle over the edges that remain is one cargo itself
+//! rejects, so finding one means the workspace does not build — worth saying.
+//!
+//! ## Degradation
+//!
+//! Three outcomes, and only one of them is a gap ([`Outcome`]). A repository
+//! that is not a Cargo workspace is a DECLARED SKIP, not a degradation: a
+//! TypeScript repository has no crate topology to miss, and a gap line claiming
+//! otherwise would be noise in its report. A repository that IS a workspace and
+//! whose metadata could not be read is a named gap, never a silent zero (#5620).
+//!
+//! Test: `super::topology_tests`.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+use std::process::Command;
+
+use toml_edit::{Array, DocumentMut, InlineTable, Item, Table, Value};
+
+/// How many most-depended-on members the shared-core list names.
+///
+/// Five, because the list answers "what is this workspace built on" — a
+/// question a longer list stops answering. The full per-crate table carries
+/// every member's inbound count regardless, so nothing is lost by capping this.
+pub const SHARED_CORE_COUNT: usize = 5;
+
+/// One member of the workspace and its place in the internal graph.
+///
+/// Why: the two numbers a reader wants per crate point in opposite directions.
+/// `deps` is how much this crate depends ON — its coupling. `inbound` is how
+/// much depends on IT — its blast radius. A crate high in both is the one worth
+/// asking about.
+/// What: the package name, its direct internal dependency names in sorted
+/// order, and how many members name it.
+/// Test: `super::topology_tests::edges_and_inbound_counts_come_from_the_metadata`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct CrateNode {
+    /// The cargo package name.
+    pub name: String,
+    /// Direct dependencies on other members, sorted, deduplicated.
+    pub deps: Vec<String>,
+    /// How many members declare a direct dependency on this one.
+    pub inbound: usize,
+}
+
+/// The whole workspace graph, reduced to what a report can state.
+///
+/// Why: see the module docs. This is the deterministic input the architecture
+/// paragraph was missing.
+/// What: member count, total distinct internal edges, one [`CrateNode`] per
+/// member sorted by name, and one entry per cycle found over the edge list.
+/// Test: `super::topology_tests`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct Topology {
+    /// How many crates the workspace declares as members.
+    pub members: usize,
+    /// Distinct `(from, to)` internal dependency edges.
+    pub edges: usize,
+    /// Every member, sorted by name.
+    pub crates: Vec<CrateNode>,
+    /// Each cycle found over the internal edges, members sorted within a cycle
+    /// and cycles sorted among themselves. Empty for any workspace cargo
+    /// itself will build.
+    pub cycles: Vec<Vec<String>>,
+}
+
+impl Topology {
+    /// The members the most other members depend on, most first.
+    ///
+    /// Why: the shared core is the thing a buyer's engineer asks about first —
+    /// changing it touches everything downstream, and a workspace with no such
+    /// crate has a different (flatter, more duplicative) shape than one with a
+    /// dominant one. Either answer is worth the report stating.
+    /// What: up to [`SHARED_CORE_COUNT`] members with at least one inbound
+    /// edge, by inbound count descending then name ascending so the order is
+    /// total and reproducible.
+    /// Test: `super::topology_tests::the_shared_core_is_the_most_depended_on_members`.
+    #[must_use]
+    pub fn shared_core(&self) -> Vec<&CrateNode> {
+        let mut ranked: Vec<&CrateNode> = self.crates.iter().filter(|c| c.inbound > 0).collect();
+        ranked.sort_by(|a, b| b.inbound.cmp(&a.inbound).then_with(|| a.name.cmp(&b.name)));
+        ranked.truncate(SHARED_CORE_COUNT);
+        ranked
+    }
+}
+
+/// What the leg produced for one repository.
+///
+/// Why: "no topology" has two meanings that must not share a variant. A
+/// TypeScript repository has none to produce and owes the report no
+/// explanation; a Cargo workspace whose metadata failed to read owes one. #5620
+/// is the same distinction one level up: a recorded skip permits, a blind
+/// result does not.
+/// What: the measurement, a declared skip carrying why the leg did not apply,
+/// or a failure carrying the one line the caller turns into a gap.
+/// Test: `super::topology_tests::{a_directory_with_no_cargo_toml_is_a_declared_skip,
+/// a_single_crate_manifest_is_a_declared_skip}`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Outcome {
+    /// The repository is not a Cargo workspace; the reason it does not apply.
+    NotAWorkspace(String),
+    /// The graph, measured.
+    Measured(Topology),
+    /// It IS a workspace and the graph could not be read; why not.
+    Unavailable(String),
+}
+
+/// Measure `checkout`'s crate topology, or say why there is none.
+///
+/// Why/What: see the module docs. Runs nothing at all unless the checkout's own
+/// root `Cargo.toml` declares `[workspace]`, so a repository in any other
+/// language costs one `read_to_string` and no subprocess.
+///
+/// # Postconditions
+/// Never panics and never returns an error: every failure is an
+/// [`Outcome::Unavailable`] reason string, safe to show the recipient.
+///
+/// Test: `super::topology_tests`.
+#[must_use]
+pub fn measure(checkout: &Path) -> Outcome {
+    let manifest = checkout.join("Cargo.toml");
+    let Ok(text) = std::fs::read_to_string(&manifest) else {
+        return Outcome::NotAWorkspace(
+            "the repository root declares no Cargo.toml, so it is not a Cargo workspace"
+                .to_string(),
+        );
+    };
+    if !declares_workspace(&text) {
+        return Outcome::NotAWorkspace(
+            "the repository's root Cargo.toml declares no `[workspace]`, so it has no crate \
+             topology to measure"
+                .to_string(),
+        );
+    }
+    match cargo_metadata(&manifest) {
+        Ok(json) => match parse(&json) {
+            Ok(topology) => Outcome::Measured(topology),
+            Err(cause) => Outcome::Unavailable(cause),
+        },
+        Err(cause) => Outcome::Unavailable(cause),
+    }
+}
+
+/// True when this manifest text declares a `[workspace]` table.
+///
+/// Parsed rather than grepped: a `[workspace]` inside a string value, and the
+/// `workspace = true` keys every member manifest carries, both defeat a
+/// substring test.
+fn declares_workspace(text: &str) -> bool {
+    text.parse::<toml_edit::DocumentMut>()
+        .is_ok_and(|doc| doc.get("workspace").is_some())
+}
+
+/// Run `cargo metadata --no-deps` against one manifest.
+///
+/// `--no-deps` is what keeps this offline and fast: cargo reads the member
+/// manifests and never resolves or fetches the dependency graph. `CARGO` is
+/// preferred over the bare name for the same reason every cargo subcommand
+/// prefers it — it names the toolchain that is actually driving this process.
+fn cargo_metadata(manifest: &Path) -> Result<String, String> {
+    let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
+    let output = Command::new(&cargo)
+        .arg("metadata")
+        .arg("--no-deps")
+        .arg("--format-version")
+        .arg("1")
+        .arg("--manifest-path")
+        .arg(manifest)
+        .output()
+        .map_err(|e| format!("`{cargo} metadata` could not be run ({e})"))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!(
+            "`{cargo} metadata` failed for {} ({})",
+            manifest.display(),
+            stderr.lines().next().unwrap_or("no diagnostic").trim()
+        ));
+    }
+    String::from_utf8(output.stdout)
+        .map_err(|e| format!("`{cargo} metadata` produced output that is not UTF-8 ({e})"))
+}
+
+/// Reduce one `cargo metadata --no-deps` document to a [`Topology`].
+///
+/// Why: split from [`measure`] so every graph shape — a cycle, a hub, an
+/// isolated member — is testable against a literal document, with no cargo, no
+/// checkout and no subprocess in the test.
+/// What: members are the `packages` array (`--no-deps` emits workspace members
+/// only); an edge is a `dependencies` entry whose `name` is another member's
+/// and whose `kind` is normal or `build` (see the module docs on dev
+/// dependencies). Self-edges and duplicates collapse.
+///
+/// # Errors
+/// One line when the document is not JSON, or carries no `packages` array.
+///
+/// Test: `super::topology_tests::{edges_and_inbound_counts_come_from_the_metadata,
+/// dev_dependencies_are_not_architecture_edges, metadata_that_is_not_json_is_a_reason}`.
+pub fn parse(json: &str) -> Result<Topology, String> {
+    let doc: serde_json::Value = serde_json::from_str(json)
+        .map_err(|e| format!("`cargo metadata` output is not readable as JSON ({e})"))?;
+    let packages = doc
+        .get("packages")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| "`cargo metadata` output declares no `packages` array".to_string())?;
+
+    let names: BTreeSet<&str> = packages
+        .iter()
+        .filter_map(|p| p.get("name").and_then(serde_json::Value::as_str))
+        .collect();
+
+    let mut deps_of: BTreeMap<&str, BTreeSet<&str>> =
+        names.iter().map(|n| (*n, BTreeSet::new())).collect();
+    for package in packages {
+        let Some(name) = package.get("name").and_then(serde_json::Value::as_str) else {
+            continue;
+        };
+        let declared = package
+            .get("dependencies")
+            .and_then(serde_json::Value::as_array)
+            .map(Vec::as_slice)
+            .unwrap_or_default();
+        for dependency in declared {
+            let Some(target) = dependency.get("name").and_then(serde_json::Value::as_str) else {
+                continue;
+            };
+            if target == name || !names.contains(target) || !is_architecture_kind(dependency) {
+                continue;
+            }
+            deps_of.entry(name).or_default().insert(target);
+        }
+    }
+
+    let mut inbound: BTreeMap<&str, usize> = names.iter().map(|n| (*n, 0)).collect();
+    let mut edges = 0usize;
+    for targets in deps_of.values() {
+        edges += targets.len();
+        for target in targets {
+            *inbound.entry(target).or_default() += 1;
+        }
+    }
+
+    let crates: Vec<CrateNode> = names
+        .iter()
+        .map(|name| CrateNode {
+            name: (*name).to_string(),
+            deps: deps_of
+                .get(name)
+                .into_iter()
+                .flatten()
+                .map(|d| (*d).to_string())
+                .collect(),
+            inbound: inbound.get(name).copied().unwrap_or_default(),
+        })
+        .collect();
+
+    Ok(Topology {
+        members: names.len(),
+        edges,
+        cycles: cycles(&crates),
+        crates,
+    })
+}
+
+/// True when this dependency entry is a normal or build dependency.
+///
+/// `kind` is `null` for a normal dependency and `"build"` / `"dev"` otherwise.
+/// A missing key reads as normal, which is the shape cargo emits.
+fn is_architecture_kind(dependency: &serde_json::Value) -> bool {
+    match dependency.get("kind") {
+        None | Some(serde_json::Value::Null) => true,
+        Some(serde_json::Value::String(kind)) => kind == "build",
+        Some(_) => false,
+    }
+}
+
+/// Every cycle over the internal edges, as sorted member-name lists.
+///
+/// Tarjan's algorithm: each strongly-connected component of more than one
+/// member IS a cycle, and one pass finds all of them rather than the first.
+/// Recursion depth is bounded by the member count — tens of crates for the
+/// largest workspace this has been run against.
+fn cycles(crates: &[CrateNode]) -> Vec<Vec<String>> {
+    let index: BTreeMap<&str, usize> = crates
+        .iter()
+        .enumerate()
+        .map(|(i, c)| (c.name.as_str(), i))
+        .collect();
+    let adjacency: Vec<Vec<usize>> = crates
+        .iter()
+        .map(|c| {
+            c.deps
+                .iter()
+                .filter_map(|d| index.get(d.as_str()).copied())
+                .collect()
+        })
+        .collect();
+
+    let mut tarjan = Tarjan::new(adjacency.len());
+    for node in 0..adjacency.len() {
+        if tarjan.order[node].is_none() {
+            tarjan.walk(node, &adjacency);
+        }
+    }
+
+    let mut found: Vec<Vec<String>> = tarjan
+        .components
+        .into_iter()
+        .filter(|component| component.len() > 1)
+        .map(|component| {
+            let mut names: Vec<String> = component
+                .into_iter()
+                .map(|i| crates[i].name.clone())
+                .collect();
+            names.sort();
+            names
+        })
+        .collect();
+    found.sort();
+    found
+}
+
+/// Tarjan's strongly-connected-components state.
+struct Tarjan {
+    /// Discovery order per node, `None` until visited.
+    order: Vec<Option<usize>>,
+    /// Lowest discovery order reachable from each node.
+    low: Vec<usize>,
+    /// Whether each node is currently on the stack.
+    stacked: Vec<bool>,
+    /// The current component stack.
+    stack: Vec<usize>,
+    /// Next discovery order to assign.
+    next: usize,
+    /// Every component found so far.
+    components: Vec<Vec<usize>>,
+}
+
+impl Tarjan {
+    fn new(nodes: usize) -> Self {
+        Self {
+            order: vec![None; nodes],
+            low: vec![0; nodes],
+            stacked: vec![false; nodes],
+            stack: Vec::new(),
+            next: 0,
+            components: Vec::new(),
+        }
+    }
+
+    fn walk(&mut self, node: usize, adjacency: &[Vec<usize>]) {
+        self.order[node] = Some(self.next);
+        self.low[node] = self.next;
+        self.next += 1;
+        self.stack.push(node);
+        self.stacked[node] = true;
+
+        for &next in &adjacency[node] {
+            match self.order[next] {
+                None => {
+                    self.walk(next, adjacency);
+                    self.low[node] = self.low[node].min(self.low[next]);
+                }
+                Some(order) if self.stacked[next] => {
+                    self.low[node] = self.low[node].min(order);
+                }
+                Some(_) => {}
+            }
+        }
+
+        if Some(self.low[node]) == self.order[node] {
+            let mut component = Vec::new();
+            while let Some(member) = self.stack.pop() {
+                self.stacked[member] = false;
+                component.push(member);
+                if member == node {
+                    break;
+                }
+            }
+            self.components.push(component);
+        }
+    }
+}
+
+/// Declare `topology` on the `[[repositories]]` entry whose path is `checkout`.
+///
+/// Why: the manifest is the interface (owner ruling 2026-08-19). A graph this
+/// process measures and does not write reaches no renderer — not the sweep's,
+/// and not the recipient's own re-render of the delivered package.
+/// What: a `crate_topology` sub-table carrying `members`, `edges`, `cycles` and
+/// one `crates` row per member. Written format-preserving, exactly as
+/// [`super::priority::write_into`] writes its ranking, so the two other crates
+/// that own this document keep their key order and their comments.
+///
+/// # Errors
+///
+/// One line, safe to show the recipient, when the manifest cannot be read,
+/// parsed, matched, or written back. The caller turns it into a gap of its own.
+///
+/// # Postconditions
+/// On `Ok`, the repository whose `path` is `checkout` declares exactly this
+/// topology, and nothing else in the document changed.
+///
+/// Test: `super::topology_tests::{the_topology_lands_on_the_matching_repository,
+/// a_written_topology_round_trips, a_topology_with_no_matching_entry_is_refused}`.
+pub fn write_into(manifest: &Path, checkout: &Path, topology: &Topology) -> Result<(), String> {
+    let text = std::fs::read_to_string(manifest)
+        .map_err(|e| format!("{} could not be read ({e})", manifest.display()))?;
+    let mut doc: DocumentMut = text
+        .parse()
+        .map_err(|e| format!("{} is not readable as TOML ({e})", manifest.display()))?;
+
+    let repositories = doc
+        .get_mut("repositories")
+        .and_then(Item::as_array_of_tables_mut)
+        .ok_or_else(|| "the manifest declares no `[[repositories]]` entry".to_string())?;
+    let entry = repositories
+        .iter_mut()
+        .find(|table| super::priority::names_checkout(table, checkout))
+        .ok_or_else(|| {
+            format!(
+                "no `[[repositories]]` entry names the checkout at {}",
+                checkout.display()
+            )
+        })?;
+    entry.insert("crate_topology", Item::Table(as_table(topology)));
+
+    std::fs::write(manifest, doc.to_string())
+        .map_err(|e| format!("{} could not be written ({e})", manifest.display()))
+}
+
+/// The topology as a TOML sub-table.
+fn as_table(topology: &Topology) -> Table {
+    let mut table = Table::new();
+    table.insert(
+        "members",
+        Item::Value(Value::from(
+            i64::try_from(topology.members).unwrap_or(i64::MAX),
+        )),
+    );
+    table.insert(
+        "edges",
+        Item::Value(Value::from(
+            i64::try_from(topology.edges).unwrap_or(i64::MAX),
+        )),
+    );
+    let mut cycles = Array::new();
+    for cycle in &topology.cycles {
+        cycles.push(cycle.iter().map(String::as_str).collect::<Array>());
+    }
+    table.insert("cycles", Item::Value(Value::Array(cycles)));
+    table.insert("crates", Item::Value(Value::Array(rows(&topology.crates))));
+    table
+}
+
+/// The per-member rows as a multi-line TOML array of inline tables.
+fn rows(crates: &[CrateNode]) -> Array {
+    let mut array = Array::new();
+    for node in crates {
+        let mut row = InlineTable::new();
+        row.insert("name", Value::from(node.name.as_str()));
+        row.insert(
+            "deps",
+            Value::Array(node.deps.iter().map(String::as_str).collect::<Array>()),
+        );
+        row.insert(
+            "inbound",
+            Value::from(i64::try_from(node.inbound).unwrap_or(i64::MAX)),
+        );
+        let mut value = Value::InlineTable(row);
+        value.decor_mut().set_prefix("\n    ");
+        array.push_formatted(value);
+    }
+    if !crates.is_empty() {
+        array.set_trailing("\n");
+        array.set_trailing_comma(true);
+    }
+    array
+}
+
+/// [`measure`], then write what it produced into `manifest`.
+///
+/// Why: the same shape [`super::ground_manifest`] gives every other leg — the
+/// caller gets gap lines and nothing else to decide about.
+/// What: the declared skip writes nothing and says nothing; a measurement is
+/// written and a write failure becomes a gap of its own; an unavailable graph
+/// is one gap naming `display` and what the report therefore will not carry.
+/// Test: `super::topology_tests::{a_declared_skip_writes_nothing_and_says_nothing,
+/// an_unreadable_graph_is_a_named_gap}`.
+pub fn ground_into(manifest: &Path, checkout: &Path, display: &str) -> Vec<String> {
+    match measure(checkout) {
+        Outcome::NotAWorkspace(_) => Vec::new(),
+        Outcome::Unavailable(cause) => vec![format!(
+            "{display}: {cause} — the report's Code Quality & Architecture section states no \
+             crate topology for it, and its architecture paragraph is inferred without one"
+        )],
+        Outcome::Measured(topology) => match write_into(manifest, checkout, &topology) {
+            Ok(()) => Vec::new(),
+            Err(cause) => vec![format!(
+                "{display}: {cause} — the report's Code Quality & Architecture section states no \
+                 crate topology for it"
+            )],
+        },
+    }
+}
+
+#[cfg(test)]
+#[path = "topology_tests.rs"]
+mod topology_tests;

--- a/crates/trusty-audit/src/grounding/topology_tests.rs
+++ b/crates/trusty-audit/src/grounding/topology_tests.rs
@@ -1,0 +1,444 @@
+//! Tests for the crate-topology grounding leg (#6147).
+//!
+//! The graph shapes are driven from literal `cargo metadata` documents so every
+//! arm — a hub, a dev-only edge, a cycle cargo would itself reject — is
+//! reachable without a checkout. One test does build a real fixture workspace on
+//! disk and run cargo against it, which is what proves the document this module
+//! parses is the document cargo actually emits.
+
+use std::fs;
+use std::path::Path;
+
+use super::{CrateNode, Outcome, Topology, ground_into, measure, parse, write_into};
+
+/// A `cargo metadata --no-deps` document over the named packages.
+///
+/// Each entry is `(name, [(dep, kind)])`, where `kind` is the JSON `kind` value
+/// verbatim: `null` for a normal dependency, `"dev"` or `"build"` otherwise.
+fn metadata(packages: &[(&str, &[(&str, &str)])]) -> String {
+    let rendered: Vec<String> = packages
+        .iter()
+        .map(|(name, deps)| {
+            let deps: Vec<String> = deps
+                .iter()
+                .map(|(dep, kind)| format!(r#"{{"name":"{dep}","kind":{kind}}}"#))
+                .collect();
+            format!(r#"{{"name":"{name}","dependencies":[{}]}}"#, deps.join(","))
+        })
+        .collect();
+    format!(r#"{{"packages":[{}]}}"#, rendered.join(","))
+}
+
+fn node<'a>(topology: &'a Topology, name: &str) -> &'a CrateNode {
+    topology
+        .crates
+        .iter()
+        .find(|c| c.name == name)
+        .unwrap_or_else(|| panic!("{name} is not a member: {:?}", topology.crates))
+}
+
+/// The three headline numbers come from the document, not from a guess.
+#[test]
+fn edges_and_inbound_counts_come_from_the_metadata() {
+    let json = metadata(&[
+        ("core", &[]),
+        ("mid", &[("core", "null")]),
+        ("app", &[("core", "null"), ("mid", "null")]),
+        // An external dependency shares no name with a member, so it is not an
+        // internal edge however many packages declare it.
+        ("tool", &[("serde", "null"), ("core", "null")]),
+    ]);
+
+    let topology = parse(&json).expect("parses");
+
+    assert_eq!(topology.members, 4);
+    assert_eq!(topology.edges, 4);
+    assert_eq!(node(&topology, "core").inbound, 3);
+    assert_eq!(node(&topology, "mid").inbound, 1);
+    assert_eq!(node(&topology, "app").inbound, 0);
+    assert_eq!(node(&topology, "app").deps, vec!["core", "mid"]);
+    assert!(node(&topology, "tool").deps.iter().all(|d| d != "serde"));
+    assert!(topology.cycles.is_empty(), "{:?}", topology.cycles);
+}
+
+/// A dev-dependency is not an architecture edge — cargo permits a cycle through
+/// one, so counting them would report a routine test arrangement as a defect.
+#[test]
+fn dev_dependencies_are_not_architecture_edges() {
+    let json = metadata(&[
+        ("core", &[("harness", r#""dev""#)]),
+        ("harness", &[("core", "null")]),
+    ]);
+
+    let topology = parse(&json).expect("parses");
+
+    assert_eq!(topology.edges, 1);
+    assert!(node(&topology, "core").deps.is_empty());
+    assert_eq!(node(&topology, "harness").deps, vec!["core"]);
+    assert!(
+        topology.cycles.is_empty(),
+        "a dev-dependency back-edge is not a cycle: {:?}",
+        topology.cycles
+    );
+}
+
+/// A build dependency IS an architecture edge: it is compiled and it constrains
+/// the build order exactly as a normal dependency does.
+#[test]
+fn build_dependencies_are_architecture_edges() {
+    let json = metadata(&[("core", &[]), ("app", &[("core", r#""build""#)])]);
+
+    let topology = parse(&json).expect("parses");
+
+    assert_eq!(topology.edges, 1);
+    assert_eq!(node(&topology, "core").inbound, 1);
+}
+
+/// The deliberate cycle: three crates in a ring, and a fourth outside it.
+#[test]
+fn a_deliberate_cycle_is_detected() {
+    let json = metadata(&[
+        ("a", &[("b", "null")]),
+        ("b", &[("c", "null")]),
+        ("c", &[("a", "null")]),
+        ("outside", &[("a", "null")]),
+    ]);
+
+    let topology = parse(&json).expect("parses");
+
+    assert_eq!(
+        topology.cycles,
+        vec![vec!["a".to_string(), "b".to_string(), "c".to_string()]]
+    );
+    assert!(
+        !topology
+            .cycles
+            .iter()
+            .any(|c| c.contains(&"outside".to_string())),
+        "a crate that only points INTO the ring is not in it: {:?}",
+        topology.cycles
+    );
+}
+
+/// Two independent rings are two cycles, not one.
+#[test]
+fn independent_cycles_are_reported_separately() {
+    let json = metadata(&[
+        ("a", &[("b", "null")]),
+        ("b", &[("a", "null")]),
+        ("y", &[("z", "null")]),
+        ("z", &[("y", "null")]),
+    ]);
+
+    let topology = parse(&json).expect("parses");
+
+    assert_eq!(
+        topology.cycles,
+        vec![
+            vec!["a".to_string(), "b".to_string()],
+            vec!["y".to_string(), "z".to_string()]
+        ]
+    );
+}
+
+/// The shared core is the most-depended-on members, capped, ties by name.
+#[test]
+fn the_shared_core_is_the_most_depended_on_members() {
+    let json = metadata(&[
+        ("core", &[]),
+        ("util", &[]),
+        ("a", &[("core", "null"), ("util", "null")]),
+        ("b", &[("core", "null")]),
+        ("c", &[("core", "null")]),
+        ("lonely", &[]),
+    ]);
+
+    let topology = parse(&json).expect("parses");
+    let core: Vec<(&str, usize)> = topology
+        .shared_core()
+        .iter()
+        .map(|c| (c.name.as_str(), c.inbound))
+        .collect();
+
+    assert_eq!(core, vec![("core", 3), ("util", 1)]);
+}
+
+/// A document that is not JSON is a reason, not a panic.
+#[test]
+fn metadata_that_is_not_json_is_a_reason() {
+    let cause = parse("error: could not read manifest").expect_err("must not parse");
+    assert!(cause.contains("not readable as JSON"), "{cause}");
+}
+
+/// A JSON document with no `packages` array is a reason, not an empty graph.
+#[test]
+fn metadata_with_no_packages_array_is_a_reason() {
+    let cause = parse(r#"{"version":1}"#).expect_err("must not parse");
+    assert!(cause.contains("no `packages` array"), "{cause}");
+}
+
+/// A repository with no `Cargo.toml` is a declared skip, never a gap: it has no
+/// crate topology to miss, and saying so in its report would be noise.
+#[test]
+fn a_directory_with_no_cargo_toml_is_a_declared_skip() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    fs::write(dir.path().join("package.json"), "{}").expect("write");
+
+    match measure(dir.path()) {
+        Outcome::NotAWorkspace(reason) => assert!(reason.contains("no Cargo.toml"), "{reason}"),
+        other => panic!("expected a declared skip, got {other:?}"),
+    }
+}
+
+/// A single-crate Rust repository is a declared skip for the same reason.
+#[test]
+fn a_single_crate_manifest_is_a_declared_skip() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        "[package]\nname = \"solo\"\nversion = \"0.1.0\"\n",
+    )
+    .expect("write");
+
+    match measure(dir.path()) {
+        Outcome::NotAWorkspace(reason) => assert!(reason.contains("`[workspace]`"), "{reason}"),
+        other => panic!("expected a declared skip, got {other:?}"),
+    }
+}
+
+/// A workspace whose members do not exist is a NAMED gap — it is a workspace,
+/// so the report owes its reader an explanation for the missing section.
+#[test]
+fn a_workspace_cargo_cannot_read_is_unavailable() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        "[workspace]\nmembers = [\"absent\"]\nresolver = \"2\"\n",
+    )
+    .expect("write");
+
+    match measure(dir.path()) {
+        Outcome::Unavailable(cause) => assert!(cause.contains("metadata"), "{cause}"),
+        other => panic!("expected an unavailable graph, got {other:?}"),
+    }
+}
+
+/// Write a three-crate fixture workspace: `core` <- `mid` <- `app`, plus one
+/// dev-only back edge from `core` onto `app` that must not count.
+fn fixture_workspace(root: &Path) {
+    fs::write(
+        root.join("Cargo.toml"),
+        "[workspace]\nmembers = [\"core\", \"mid\", \"app\"]\nresolver = \"2\"\n",
+    )
+    .expect("root manifest");
+    for (name, body) in [
+        (
+            "core",
+            "[dev-dependencies]\nfixture-app = { path = \"../app\" }\n",
+        ),
+        (
+            "mid",
+            "[dependencies]\nfixture-core = { path = \"../core\" }\n",
+        ),
+        (
+            "app",
+            "[dependencies]\nfixture-core = { path = \"../core\" }\nfixture-mid = { path = \"../mid\" }\n",
+        ),
+    ] {
+        let dir = root.join(name);
+        fs::create_dir_all(dir.join("src")).expect("member dir");
+        fs::write(
+            dir.join("Cargo.toml"),
+            format!(
+                "[package]\nname = \"fixture-{name}\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n{body}"
+            ),
+        )
+        .expect("member manifest");
+        fs::write(dir.join("src/lib.rs"), "").expect("member source");
+    }
+}
+
+/// The end-to-end producer arm: a real workspace on disk, measured by the real
+/// cargo. This is what proves the document [`parse`] reads is the one cargo
+/// emits — every other graph test drives a literal.
+#[test]
+fn a_fixture_workspace_on_disk_is_measured() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    fixture_workspace(dir.path());
+
+    let topology = match measure(dir.path()) {
+        Outcome::Measured(topology) => topology,
+        other => panic!("expected a measurement, got {other:?}"),
+    };
+
+    assert_eq!(topology.members, 3);
+    assert_eq!(topology.edges, 3);
+    assert_eq!(node(&topology, "fixture-core").inbound, 2);
+    assert_eq!(node(&topology, "fixture-mid").inbound, 1);
+    assert_eq!(
+        node(&topology, "fixture-app").deps,
+        vec!["fixture-core", "fixture-mid"]
+    );
+    assert!(
+        node(&topology, "fixture-core").deps.is_empty(),
+        "the dev-only back edge must not be an architecture edge: {:?}",
+        node(&topology, "fixture-core").deps
+    );
+    assert!(topology.cycles.is_empty(), "{:?}", topology.cycles);
+    assert_eq!(topology.shared_core()[0].name, "fixture-core");
+}
+
+/// A manifest with one repository entry, `{path}`-substituted by the caller.
+const SAMPLE: &str = r#"[report]
+title = "Audit"
+
+[[repositories]]
+name = "Demo"
+path = "{path}"
+"#;
+
+fn sample_manifest(dir: &Path, checkout: &Path) -> std::path::PathBuf {
+    let manifest = dir.join("manifest.toml");
+    fs::write(
+        &manifest,
+        SAMPLE.replace("{path}", &checkout.display().to_string()),
+    )
+    .expect("write manifest");
+    manifest
+}
+
+fn two_crate_topology() -> Topology {
+    parse(&metadata(&[("core", &[]), ("app", &[("core", "null")])])).expect("parses")
+}
+
+/// The topology lands on the entry naming the checkout, and nothing else moves.
+#[test]
+fn the_topology_lands_on_the_matching_repository() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let checkout = dir.path().join("demo");
+    fs::create_dir_all(&checkout).expect("checkout");
+    let manifest = sample_manifest(dir.path(), &checkout);
+
+    write_into(&manifest, &checkout, &two_crate_topology()).expect("writes");
+
+    let text = fs::read_to_string(&manifest).expect("read back");
+    assert!(text.contains("title = \"Audit\""), "{text}");
+    assert!(text.contains("crate_topology"), "{text}");
+}
+
+/// The round trip: what was written parses back as the same four facts.
+#[test]
+fn a_written_topology_round_trips() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let checkout = dir.path().join("demo");
+    fs::create_dir_all(&checkout).expect("checkout");
+    let manifest = sample_manifest(dir.path(), &checkout);
+    let written = parse(&metadata(&[
+        ("a", &[("b", "null")]),
+        ("b", &[("a", "null")]),
+        ("c", &[("a", "null")]),
+    ]))
+    .expect("parses");
+
+    write_into(&manifest, &checkout, &written).expect("writes");
+
+    let text = fs::read_to_string(&manifest).expect("read back");
+    let doc: toml::Value = toml::from_str(&text).expect("valid TOML");
+    let table = doc["repositories"][0]["crate_topology"]
+        .as_table()
+        .expect("a crate_topology table");
+    assert_eq!(table["members"].as_integer(), Some(3));
+    assert_eq!(table["edges"].as_integer(), Some(3));
+    assert_eq!(
+        table["cycles"][0]
+            .as_array()
+            .expect("a cycle")
+            .iter()
+            .filter_map(toml::Value::as_str)
+            .collect::<Vec<_>>(),
+        vec!["a", "b"]
+    );
+    let rows = table["crates"].as_array().expect("crate rows");
+    assert_eq!(rows.len(), 3);
+    assert_eq!(rows[0]["name"].as_str(), Some("a"));
+    assert_eq!(rows[0]["inbound"].as_integer(), Some(2));
+    assert_eq!(
+        rows[0]["deps"]
+            .as_array()
+            .expect("deps")
+            .iter()
+            .filter_map(toml::Value::as_str)
+            .collect::<Vec<_>>(),
+        vec!["b"]
+    );
+}
+
+/// A manifest naming a different checkout is refused rather than written to the
+/// wrong repository — a topology attributed to the wrong repo is worse than none.
+#[test]
+fn a_topology_with_no_matching_entry_is_refused() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let declared = dir.path().join("declared");
+    fs::create_dir_all(&declared).expect("checkout");
+    let manifest = sample_manifest(dir.path(), &declared);
+
+    let cause = write_into(&manifest, &dir.path().join("other"), &two_crate_topology())
+        .expect_err("must refuse");
+
+    assert!(cause.contains("no `[[repositories]]` entry"), "{cause}");
+}
+
+/// A declared skip writes nothing and says nothing: a non-Rust repository's
+/// report is byte-identical to what it was before this leg existed.
+#[test]
+fn a_declared_skip_writes_nothing_and_says_nothing() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let checkout = dir.path().join("demo");
+    fs::create_dir_all(&checkout).expect("checkout");
+    fs::write(checkout.join("package.json"), "{}").expect("write");
+    let manifest = sample_manifest(dir.path(), &checkout);
+    let before = fs::read_to_string(&manifest).expect("read");
+
+    let gaps = ground_into(&manifest, &checkout, "Demo");
+
+    assert!(gaps.is_empty(), "{gaps:?}");
+    assert_eq!(fs::read_to_string(&manifest).expect("read"), before);
+}
+
+/// A workspace whose graph cannot be read is one gap naming the repository and
+/// what its report will therefore not carry.
+#[test]
+fn an_unreadable_graph_is_a_named_gap() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let checkout = dir.path().join("demo");
+    fs::create_dir_all(&checkout).expect("checkout");
+    fs::write(
+        checkout.join("Cargo.toml"),
+        "[workspace]\nmembers = [\"absent\"]\nresolver = \"2\"\n",
+    )
+    .expect("write");
+    let manifest = sample_manifest(dir.path(), &checkout);
+
+    let gaps = ground_into(&manifest, &checkout, "Demo");
+
+    assert_eq!(gaps.len(), 1, "{gaps:?}");
+    assert!(gaps[0].starts_with("Demo: "), "{}", gaps[0]);
+    assert!(gaps[0].contains("crate topology"), "{}", gaps[0]);
+}
+
+/// A measured workspace reaches the manifest through `ground_into` with no gap.
+#[test]
+fn a_measured_workspace_reaches_the_manifest() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let checkout = dir.path().join("demo");
+    fs::create_dir_all(&checkout).expect("checkout");
+    fixture_workspace(&checkout);
+    let manifest = sample_manifest(dir.path(), &checkout);
+
+    let gaps = ground_into(&manifest, &checkout, "Demo");
+
+    assert!(gaps.is_empty(), "{gaps:?}");
+    let text = fs::read_to_string(&manifest).expect("read back");
+    assert!(text.contains("members = 3"), "{text}");
+    assert!(text.contains("fixture-core"), "{text}");
+}

--- a/crates/trusty-review/Cargo.toml
+++ b/crates/trusty-review/Cargo.toml
@@ -22,7 +22,7 @@ name        = "trusty-review"
 # `#[non_exhaustive]` (the note above covers three OTHER report types), so an
 # external struct literal breaks. For a `0.y.z` crate the breaking bump is the
 # MINOR position.
-version     = "0.22.1"
+version     = "0.23.0"
 edition     = "2024"
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/trusty-review/changelog.d/6147-crate-topology-changed.md
+++ b/crates/trusty-review/changelog.d/6147-crate-topology-changed.md
@@ -1,0 +1,7 @@
+Changed
+- BREAKING: `RepositoryEntry` (report::manifest) and `RepositoryReport`
+  (report::model) each gain a public `crate_topology` field. Both are
+  exhaustively constructible through the public API, so any external struct
+  literal over either one stops compiling and must add the field (`None` keeps
+  the previous behavior). This is why the crate goes to 0.23.0 rather than a
+  patch release — for a `0.y.z` crate the breaking bump is the MINOR position.

--- a/crates/trusty-review/changelog.d/6147-crate-topology.md
+++ b/crates/trusty-review/changelog.d/6147-crate-topology.md
@@ -1,0 +1,17 @@
+Added
+
+- Code Quality & Architecture gains a deterministic crate-topology table for any
+  repository whose manifest declares one (trusty-audit measures it from cargo
+  metadata). A summary line states the member count, the internal dependency
+  edge count, the cycle verdict, and the most-depended-on crates; the table lists
+  up to 15 crates — most depended on and shallowest first, so the shared core
+  leads — with each one's direct internal dependencies and inbound count. The
+  synthesised paragraph renders above it and is told to comment on that
+  structure rather than re-derive one.
+- The same facts reach the synthesis prompt as a measured block, and the numbers
+  are admitted by the numeric guardrail because they are rendered into the fill
+  scope the guardrail reads — so the paragraph may quote a member or inbound
+  count without the guardrail rejecting the whole field.
+- A repository that declares no topology renders a report byte-identical to one
+  produced before this existed: the block is omitted whole, never filled with
+  honesty markers, and the prompt gains no heading.

--- a/crates/trusty-review/src/report/benchmark_tests.rs
+++ b/crates/trusty-review/src/report/benchmark_tests.rs
@@ -92,6 +92,7 @@ fn repo(slug: &str, m: Option<AnalyzeMetrics>) -> RepositoryReport {
         analyze_gap: None,
         authorship: None,
         inspect_priority: Vec::new(),
+        crate_topology: None,
     }
 }
 

--- a/crates/trusty-review/src/report/figures_tests.rs
+++ b/crates/trusty-review/src/report/figures_tests.rs
@@ -18,6 +18,7 @@ fn repo() -> RepositoryReport {
         analyze_gap: None,
         authorship: None,
         inspect_priority: Vec::new(),
+        crate_topology: None,
     }
 }
 

--- a/crates/trusty-review/src/report/manifest.rs
+++ b/crates/trusty-review/src/report/manifest.rs
@@ -369,6 +369,11 @@ pub struct RepositoryEntry {
     /// (#6078). Empty — the default — leaves selection byte-identical to a
     /// manifest without the key. See [`InspectionPriority`].
     pub inspect_priority: Vec<InspectionPriority>,
+    /// The crate graph trusty-audit measured from this repository's own Cargo
+    /// workspace (#6147). `None` for every repository that is not one, which
+    /// renders as nothing rather than as a gap — see
+    /// [`super::topology::CrateTopology`].
+    pub crate_topology: Option<super::topology::CrateTopology>,
 }
 
 /// The origin of a repository — a local checkout or a declared remote.
@@ -450,6 +455,9 @@ struct RawRepositoryEntry {
     /// #6078: `inspect_priority = ["src/a.rs", { path = "src/b.rs", weight = 900 }]`
     #[serde(default)]
     inspect_priority: Vec<RawInspectionPriority>,
+    /// #6147: `[repositories.crate_topology]`, written by trusty-audit.
+    #[serde(default)]
+    crate_topology: Option<super::topology::CrateTopology>,
 }
 
 /// The two spellings one `inspect_priority` entry may take in TOML (#6078).
@@ -607,6 +615,7 @@ fn validate(raw: RawManifest) -> std::result::Result<Manifest, ManifestError> {
             metrics: entry.metrics,
             authorship: entry.authorship,
             inspect_priority,
+            crate_topology: entry.crate_topology,
         });
     }
 

--- a/crates/trusty-review/src/report/mod.rs
+++ b/crates/trusty-review/src/report/mod.rs
@@ -64,6 +64,9 @@ pub mod synthesize_prompt;
 pub mod template;
 // #5405: the board-correlation figures tga hands over beside the manifest.
 pub mod ticketing;
+/// #6147: the crate graph trusty-audit measures, rendered into the Code Quality
+/// & Architecture section and stated to synthesis.
+pub mod topology;
 
 // ── Re-exports for convenience ─────────────────────────────────────────────
 

--- a/crates/trusty-review/src/report/model.rs
+++ b/crates/trusty-review/src/report/model.rs
@@ -336,6 +336,18 @@ pub struct RepositoryReport {
     /// Test: `select_tests::manifest_priority_outranks_heuristics`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub inspect_priority: Vec<super::manifest::InspectionPriority>,
+    /// The crate graph trusty-audit measured for this repository (#6147).
+    ///
+    /// Why: it has to reach both the reporter (which renders the deterministic
+    /// table) and the synthesis prompt (which states the same facts for the
+    /// architecture paragraph to comment on), so it travels on the model like
+    /// every other per-repository measurement. Serialising it keeps the JSON
+    /// twin an honest record of what the architecture section was built from.
+    /// `None` for any repository that is not a Cargo workspace, which renders
+    /// as nothing.
+    /// Test: `topology_tests::a_declared_topology_renders_rows`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub crate_topology: Option<super::topology::CrateTopology>,
 }
 
 impl ReportModel {
@@ -490,6 +502,9 @@ fn build_repository(
             // #6078: the external selection ranking rides through to
             // `select_files` unchanged; this crate never recomputes it.
             inspect_priority: entry.inspect_priority.clone(),
+            // #6147: measured by trusty-audit from the checkout's own Cargo
+            // manifests; this crate renders it and never recomputes it.
+            crate_topology: entry.crate_topology.clone(),
         },
         authorship_gap,
     ))

--- a/crates/trusty-review/src/report/reporter.rs
+++ b/crates/trusty-review/src/report/reporter.rs
@@ -439,6 +439,10 @@ pub(super) fn build_scope(model: &ReportModel) -> Scope {
     // LLM involvement in the rows themselves. Performance & Scalability is
     // FIXED text (DOC-67 §3: no performance data source exists at all).
     push_code_quality_rows(&mut root, model);
+    // #6147: the same section's deterministic architecture input — the crate
+    // graph trusty-audit measured. Absent for every repository that is not a
+    // Cargo workspace, and then it renders as nothing.
+    super::topology::push_crate_topology(&mut root, model);
     push_security_violation_rows(&mut root, model);
     fill_performance_note(&mut root, model);
     // #5453/#6004: key-man risk rows render IN this section, never scattered

--- a/crates/trusty-review/src/report/reporter_authorship_tests.rs
+++ b/crates/trusty-review/src/report/reporter_authorship_tests.rs
@@ -17,6 +17,7 @@ fn repo(authorship: Option<AuthorshipSummary>) -> RepositoryReport {
         analyze_gap: None,
         authorship,
         inspect_priority: Vec::new(),
+        crate_topology: None,
     }
 }
 

--- a/crates/trusty-review/src/report/reporter_codesec_tests.rs
+++ b/crates/trusty-review/src/report/reporter_codesec_tests.rs
@@ -20,6 +20,7 @@ fn repo(metrics: Option<AnalyzeMetrics>) -> RepositoryReport {
         analyze_gap: None,
         authorship: None,
         inspect_priority: Vec::new(),
+        crate_topology: None,
     }
 }
 

--- a/crates/trusty-review/src/report/reporter_facts_tests.rs
+++ b/crates/trusty-review/src/report/reporter_facts_tests.rs
@@ -24,6 +24,7 @@ fn repo_with(metrics: Option<AnalyzeMetrics>, scan: Option<RepoScan>) -> Reposit
         analyze_gap: None,
         authorship: None,
         inspect_priority: Vec::new(),
+        crate_topology: None,
     }
 }
 

--- a/crates/trusty-review/src/report/reporter_performance_tests.rs
+++ b/crates/trusty-review/src/report/reporter_performance_tests.rs
@@ -32,6 +32,7 @@ fn model_with(findings: Vec<MetricFinding>) -> ReportModel {
             analyze_gap: None,
             authorship: None,
             inspect_priority: Vec::new(),
+            crate_topology: None,
         }],
         gaps: vec![],
         synthesis: None,

--- a/crates/trusty-review/src/report/section_instructions.rs
+++ b/crates/trusty-review/src/report/section_instructions.rs
@@ -102,12 +102,21 @@ pub fn default_instruction(id: &str) -> Option<&'static str> {
              list entirely; re-elaborating it wastes output budget and cannot improve \
              on already-verified prose.",
         ),
+        // #6147: the crate-topology block is the section's only deterministic
+        // architecture input. Before it existed the paragraph inferred a
+        // structure from complexity buckets and a language list, which is a
+        // guess; where a workspace states its own graph, comment on that graph.
         CODE_QUALITY_SUMMARY => Some(
             "Write ONE paragraph on code quality and architecture, grounded strictly in \
-             the complexity distribution, code-smell/refactor findings, and LoC/tech-stack \
-             data provided. Take the acquirer's skeptical side on maintainability risk \
-             while naming genuine strengths the data supports, evenhandedly. Never invent \
-             an architectural pattern or a metric not present in the data.",
+             the complexity distribution, code-smell/refactor findings, LoC/tech-stack \
+             and crate-topology data provided. Where a crate topology is given, comment on \
+             the structure it shows — how many crates, how coupled, whether a shared core \
+             carries the workspace or the members are independent, and any dependency cycle \
+             — and treat it as measured fact, never as something to re-derive. Where none is \
+             given, do not speculate about module structure at all. Take the acquirer's \
+             skeptical side on maintainability risk while naming genuine strengths the data \
+             supports, evenhandedly. Never invent an architectural pattern or a metric not \
+             present in the data.",
         ),
         SECURITY_SUMMARY => Some(
             // #6080: "lint-graded" described the findings as a linter's output.

--- a/crates/trusty-review/src/report/synthesize_digest_tests.rs
+++ b/crates/trusty-review/src/report/synthesize_digest_tests.rs
@@ -44,6 +44,7 @@ fn repo(slug: &str, findings: Vec<MetricFinding>) -> RepositoryReport {
         analyze_gap: None,
         authorship: None,
         inspect_priority: Vec::new(),
+        crate_topology: None,
     }
 }
 

--- a/crates/trusty-review/src/report/synthesize_prompt.rs
+++ b/crates/trusty-review/src/report/synthesize_prompt.rs
@@ -604,6 +604,13 @@ fn build_digest(model: &ReportModel, elaboration_cap: usize) -> String {
         msg.push('\n');
     }
 
+    // #6147: the architecture section's one deterministic input. Stated as its
+    // own block rather than as per-repository profile bullets because the
+    // architecture paragraph reads it as a whole — a member count means little
+    // without the edge count and the shared core beside it. Empty (and so
+    // absent) unless a repository declared one.
+    msg.push_str(&super::topology::prompt_facts(model));
+
     // #2357 follow-up: ONE combined compact-findings digest across all repos,
     // replacing the old per-repo full-title bullet list. Greens are excluded
     // structurally by `gather_compact_findings` (the no-green rule, unchanged).

--- a/crates/trusty-review/src/report/synthesize_tests.rs
+++ b/crates/trusty-review/src/report/synthesize_tests.rs
@@ -180,6 +180,7 @@ fn fixture_model(findings: Vec<MetricFinding>) -> ReportModel {
             analyze_gap: None,
             authorship: None,
             inspect_priority: Vec::new(),
+            crate_topology: None,
         }],
         gaps: Vec::new(),
         synthesis: None,
@@ -2093,5 +2094,79 @@ fn narrative_only_tier_omits_findings_from_schema() {
     assert!(
         !digest.contains("every RED/AMBER finding already has verified"),
         "that line would be false here: {digest}"
+    );
+}
+
+/// Why (#6147): the architecture paragraph is only as good as what the prompt
+/// states. Before this the digest carried complexity buckets and a language
+/// list, so the model inferred a structure; now a Cargo workspace's own graph
+/// reaches it as measured fact.
+/// What: attaches a topology to the fixture model and asserts the digest names
+/// its member count, its shared core, and the section heading that marks the
+/// facts as measured.
+/// Test: this test itself.
+#[test]
+fn prompt_carries_the_crate_topology() {
+    use crate::report::topology::{CrateNode, CrateTopology};
+
+    let mut model = fixture_model(vec![]);
+    model.repositories[0].crate_topology = Some(CrateTopology {
+        members: 3,
+        edges: 3,
+        cycles: Vec::new(),
+        crates: vec![
+            CrateNode {
+                name: "acme-core".to_string(),
+                deps: Vec::new(),
+                inbound: 2,
+            },
+            CrateNode {
+                name: "acme-app".to_string(),
+                deps: vec!["acme-core".to_string()],
+                inbound: 0,
+            },
+        ],
+    });
+
+    let req = build_synthesis_prompt(
+        &model,
+        "stub/model",
+        SynthesisTier::Full,
+        SYNTHESIS_DEFAULT_MAX_TOKENS,
+    );
+    let digest = &req.messages[0].content;
+
+    assert!(
+        digest.contains("Crate topology (measured from cargo metadata"),
+        "the facts must be marked measured, not inferred: {digest}"
+    );
+    assert!(digest.contains("3 crates"), "{digest}");
+    assert!(
+        digest.contains("Most depended on: acme-core (2)"),
+        "{digest}"
+    );
+    assert!(
+        digest.contains("`acme-core`: depends on 0 internal crate(s); depended on by 2"),
+        "{digest}"
+    );
+}
+
+/// Why: a repository with no Cargo workspace must add no headed-but-empty
+/// section to the digest — an empty heading invites the model to fill it.
+/// What: asserts the fixture model, which declares no topology, carries none.
+/// Test: this test itself.
+#[test]
+fn prompt_omits_the_topology_block_when_there_is_none() {
+    let model = fixture_model(vec![]);
+    let req = build_synthesis_prompt(
+        &model,
+        "stub/model",
+        SynthesisTier::Full,
+        SYNTHESIS_DEFAULT_MAX_TOKENS,
+    );
+
+    assert!(
+        !req.messages[0].content.contains("Crate topology"),
+        "no topology, no heading"
     );
 }

--- a/crates/trusty-review/src/report/topology.rs
+++ b/crates/trusty-review/src/report/topology.rs
@@ -1,0 +1,262 @@
+//! The crate topology a manifest declares, rendered and fed to synthesis (#6147).
+//!
+//! Why: the Code Quality & Architecture section had no deterministic
+//! architecture input. Its paragraph was inferred from complexity buckets, a
+//! language list and a LoC count — none of which says which crates exist, which
+//! depends on which, or which one the rest is built on. trusty-audit measures
+//! that from a Cargo workspace's own manifests and writes it here (owner ruling:
+//! crate design is a factor for Rust projects).
+//!
+//! What: the manifest shape, the deterministic table the section renders, and
+//! the fact block the synthesis prompt carries. All three in one module because
+//! they are one contract: a column this file stops rendering is a fact the
+//! prompt must stop asserting on the same edit.
+//!
+//! ## What absence means
+//!
+//! `crate_topology` is absent for every repository that is not a Cargo
+//! workspace, which is most of them. Absence therefore renders NOTHING — the
+//! whole sub-block is omitted and the section is byte-identical to what it was
+//! before this existed. It is never an honesty marker and never a gap; the
+//! producer decides what is worth a gap line, and a TypeScript repository has no
+//! crate topology to miss.
+//!
+//! Test: `topology_tests.rs`.
+
+use serde::{Deserialize, Serialize};
+
+use super::fill::Scope;
+use super::model::ReportModel;
+use super::provenance::{Provenance, tag};
+
+/// Most crates the deterministic table lists per repository.
+///
+/// Fifteen, because the table answers "what is the shape of this workspace",
+/// which a longer list stops answering — and the rows are ordered so the ones
+/// that answer it are the ones kept. The summary line above the table always
+/// states the true member count, so a truncated table never reads as a complete
+/// one.
+pub const TABLE_ROW_CAP: usize = 15;
+
+/// How many most-depended-on crates the summary line names.
+pub const SHARED_CORE_COUNT: usize = 5;
+
+/// One member of an audited workspace, as the manifest declares it.
+///
+/// Why: `deps` and `inbound` point in opposite directions and a reader wants
+/// both — `deps` is what this crate is coupled to, `inbound` is what breaks when
+/// it changes.
+/// What: the cargo package name, its direct internal dependency names, and how
+/// many members depend on it.
+/// Test: `topology_tests::rows_lead_with_the_shared_core`.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+pub struct CrateNode {
+    /// The cargo package name.
+    pub name: String,
+    /// Direct dependencies on other workspace members.
+    #[serde(default)]
+    pub deps: Vec<String>,
+    /// How many members declare a direct dependency on this one.
+    #[serde(default)]
+    pub inbound: usize,
+}
+
+/// One audited repository's crate graph, measured by trusty-audit (#6147).
+///
+/// Why: this is the DETERMINISTIC half of the architecture section. Everything
+/// here was read out of cargo's own metadata, so the report states it as
+/// measured and the model comments on it rather than inventing it.
+/// What: member count, total internal dependency edges, one node per member,
+/// and any cycle over those edges. A cycle is notable precisely because cargo
+/// rejects one: finding it means the workspace does not build.
+/// Test: `topology_tests`, including `a_manifest_crate_topology_is_parsed`,
+/// which parses the exact TOML trusty-audit writes.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+pub struct CrateTopology {
+    /// How many crates the workspace declares as members.
+    #[serde(default)]
+    pub members: usize,
+    /// Distinct internal dependency edges among those members.
+    #[serde(default)]
+    pub edges: usize,
+    /// Each cycle found over those edges. Empty for any workspace cargo builds.
+    #[serde(default)]
+    pub cycles: Vec<Vec<String>>,
+    /// Every member and its place in the graph.
+    #[serde(default)]
+    pub crates: Vec<CrateNode>,
+}
+
+impl CrateTopology {
+    /// The crates the table lists, foundation first.
+    ///
+    /// Why: "shallowest, most depended on first" puts the crates the workspace
+    /// is BUILT ON at the top, which is the order that answers the architecture
+    /// question. A crate with many dependents and few dependencies is a shared
+    /// core; one with the reverse is a leaf, and a reader who reads only the
+    /// first rows should meet the cores.
+    /// What: inbound descending, then direct-dependency count ascending, then
+    /// name — a total order, so the same manifest always renders the same table.
+    /// Capped at [`TABLE_ROW_CAP`].
+    /// Test: `topology_tests::rows_lead_with_the_shared_core`.
+    #[must_use]
+    pub fn table_rows(&self) -> Vec<&CrateNode> {
+        let mut rows: Vec<&CrateNode> = self.crates.iter().collect();
+        rows.sort_by(|a, b| {
+            b.inbound
+                .cmp(&a.inbound)
+                .then_with(|| a.deps.len().cmp(&b.deps.len()))
+                .then_with(|| a.name.cmp(&b.name))
+        });
+        rows.truncate(TABLE_ROW_CAP);
+        rows
+    }
+
+    /// The one-sentence characterisation above the table.
+    ///
+    /// Why: the table is per crate; the reader needs the whole-workspace facts
+    /// (how many crates, how coupled, does it build) before the rows mean
+    /// anything. It also states the true member count, so a table capped at
+    /// [`TABLE_ROW_CAP`] never reads as the complete list.
+    /// What: member and edge counts, the cycle verdict naming the members of
+    /// each cycle, and the [`SHARED_CORE_COUNT`] most-depended-on crates with
+    /// their inbound counts.
+    /// Test: `topology_tests::{the_summary_states_members_edges_and_cycles,
+    /// a_cycle_is_named_in_the_summary}`.
+    #[must_use]
+    pub fn summary(&self) -> String {
+        let mut out = format!(
+            "{} crates, {} internal dependency edge(s). ",
+            self.members, self.edges
+        );
+        if self.cycles.is_empty() {
+            out.push_str("No dependency cycles. ");
+        } else {
+            let named: Vec<String> = self.cycles.iter().map(|cycle| cycle.join(" ↔ ")).collect();
+            out.push_str(&format!(
+                "{} dependency cycle(s) — {} — which cargo itself rejects, so the workspace does \
+                 not build as declared. ",
+                self.cycles.len(),
+                named.join("; ")
+            ));
+        }
+        let core = self.shared_core();
+        if core.is_empty() {
+            out.push_str(
+                "No crate is depended on by another: the members are independent rather than \
+                 built on a shared core.",
+            );
+        } else {
+            let named: Vec<String> = core
+                .iter()
+                .map(|c| format!("{} ({})", c.name, c.inbound))
+                .collect();
+            out.push_str(&format!("Most depended on: {}.", named.join(", ")));
+        }
+        out
+    }
+
+    /// The most-depended-on members, most first, ties by name.
+    #[must_use]
+    pub fn shared_core(&self) -> Vec<&CrateNode> {
+        let mut ranked: Vec<&CrateNode> = self.crates.iter().filter(|c| c.inbound > 0).collect();
+        ranked.sort_by(|a, b| b.inbound.cmp(&a.inbound).then_with(|| a.name.cmp(&b.name)));
+        ranked.truncate(SHARED_CORE_COUNT);
+        ranked
+    }
+}
+
+/// Push the Code Quality & Architecture section's crate-topology sub-block.
+///
+/// Why: the section's numbers must be rendered deterministically, not asserted
+/// by a model. Filling a scope rather than writing markdown is also what admits
+/// these figures to the numeric guardrail — `figures::printed_figures` walks the
+/// filled scope, so every count below is in-model by construction and a
+/// synthesis paragraph may quote it (#6137).
+/// What: one `crate_topology` scope per repository declaring one, carrying the
+/// summary line and one nested `ct_row` per crate [`CrateTopology::table_rows`]
+/// kept. `ct_crate` is prefixed with the application name only when more than
+/// one repository has a topology, so a single-repository report does not repeat
+/// its own name down a column. Nothing is pushed when no repository declares
+/// one, and the whole block then renders as nothing (`fill::render_scope`'s
+/// omit-empty rule).
+/// Test: `topology_tests::{a_declared_topology_renders_rows,
+/// no_topology_pushes_no_block, several_repositories_are_named_in_the_rows}`.
+pub fn push_crate_topology(root: &mut Scope, model: &ReportModel) {
+    let declared: Vec<(&str, &CrateTopology)> = model
+        .repositories
+        .iter()
+        .filter_map(|repo| Some((repo.name.as_str(), repo.crate_topology.as_ref()?)))
+        .collect();
+    let qualify = declared.len() > 1;
+
+    for (app, topology) in declared {
+        let mut block = Scope::new();
+        block.set("ct_summary", tag(topology.summary(), Provenance::Measured));
+        for node in topology.table_rows() {
+            let mut row = Scope::new();
+            let name = match qualify {
+                true => format!("{app} / {}", node.name),
+                false => node.name.clone(),
+            };
+            row.set("ct_crate", name);
+            row.set(
+                "ct_deps",
+                match node.deps.is_empty() {
+                    true => "—".to_string(),
+                    false => node.deps.join(", "),
+                },
+            );
+            row.set("ct_inbound", node.inbound.to_string());
+            block.push_block("ct_row", row);
+        }
+        root.push_block("crate_topology", block);
+    }
+}
+
+/// The crate-topology facts the synthesis prompt carries, one block per
+/// repository that declares one.
+///
+/// Why: the architecture paragraph is only as good as what the prompt states.
+/// Feeding the same numbers the table renders is what lets the model comment on
+/// the workspace's real shape instead of inferring one — and every figure here
+/// is already in the guardrail's allowed set, because the table printed it.
+/// What: an empty string when no repository declares a topology, so the digest
+/// gains no headed-but-empty section; otherwise the summary line plus the
+/// leading table rows as `name: deps → inbound` lines.
+/// Test: `topology_tests::{prompt_facts_carry_the_summary_and_rows,
+/// prompt_facts_are_empty_without_a_topology}`.
+#[must_use]
+pub fn prompt_facts(model: &ReportModel) -> String {
+    let mut out = String::new();
+    for repo in &model.repositories {
+        let Some(topology) = &repo.crate_topology else {
+            continue;
+        };
+        if out.is_empty() {
+            out.push_str(
+                "\n## Crate topology (measured from cargo metadata — deterministic, not inferred)\n\n",
+            );
+        }
+        out.push_str(&format!("### {}\n", repo.name));
+        out.push_str(&format!("- {}\n", topology.summary()));
+        for node in topology.table_rows() {
+            out.push_str(&format!(
+                "- `{}`: depends on {} internal crate(s){}; depended on by {}\n",
+                node.name,
+                node.deps.len(),
+                match node.deps.is_empty() {
+                    true => String::new(),
+                    false => format!(" ({})", node.deps.join(", ")),
+                },
+                node.inbound
+            ));
+        }
+        out.push('\n');
+    }
+    out
+}
+
+#[cfg(test)]
+#[path = "topology_tests.rs"]
+mod tests;

--- a/crates/trusty-review/src/report/topology.rs
+++ b/crates/trusty-review/src/report/topology.rs
@@ -21,7 +21,7 @@
 //! producer decides what is worth a gap line, and a TypeScript repository has no
 //! crate topology to miss.
 //!
-//! Test: `topology_tests.rs`.
+//! Test: `topology_tests`.
 
 use serde::{Deserialize, Serialize};
 
@@ -259,4 +259,4 @@ pub fn prompt_facts(model: &ReportModel) -> String {
 
 #[cfg(test)]
 #[path = "topology_tests.rs"]
-mod tests;
+mod topology_tests;

--- a/crates/trusty-review/src/report/topology_tests.rs
+++ b/crates/trusty-review/src/report/topology_tests.rs
@@ -1,0 +1,374 @@
+//! Tests for the crate-topology consumer (#6147).
+
+use super::*;
+use crate::report::model::RepositoryReport;
+
+fn node(name: &str, deps: &[&str], inbound: usize) -> CrateNode {
+    CrateNode {
+        name: name.to_string(),
+        deps: deps.iter().map(|d| (*d).to_string()).collect(),
+        inbound,
+    }
+}
+
+/// `core` is the shared core, `mid` sits between, `app` is the leaf.
+fn three_crate_topology() -> CrateTopology {
+    CrateTopology {
+        members: 3,
+        edges: 3,
+        cycles: Vec::new(),
+        crates: vec![
+            node("app", &["core", "mid"], 0),
+            node("core", &[], 2),
+            node("mid", &["core"], 1),
+        ],
+    }
+}
+
+fn repo(name: &str, topology: Option<CrateTopology>) -> RepositoryReport {
+    RepositoryReport {
+        name: name.to_string(),
+        slug: name.to_lowercase(),
+        source: format!("/tmp/{name}"),
+        source_kind: "local_path".to_string(),
+        username: None,
+        git_ref: None,
+        git_info: None,
+        local_path: None,
+        scan: None,
+        metrics: None,
+        analyze_gap: None,
+        authorship: None,
+        inspect_priority: Vec::new(),
+        crate_topology: topology,
+    }
+}
+
+fn model_with(repos: Vec<RepositoryReport>) -> ReportModel {
+    ReportModel {
+        title: "Test".to_string(),
+        template: "report-technical-dd".to_string(),
+        analyst: None,
+        client: None,
+        vendor_methodology: crate::report::model::vendor_methodology(),
+        inference: None,
+        instructions: None,
+        instructions_source: None,
+        report_date: "2026-08-21".to_string(),
+        generated_date: "2026-08-21".to_string(),
+        manifest_path: "manifest.toml".to_string(),
+        repositories: repos,
+        gaps: vec![],
+        synthesis: None,
+        benchmark: None,
+        investigation: None,
+        section_instructions: Default::default(),
+        ticketing: None,
+    }
+}
+
+/// The table leads with what the workspace is built ON, not with what depends
+/// on the most things.
+#[test]
+fn rows_lead_with_the_shared_core() {
+    let topology = three_crate_topology();
+    let rows: Vec<&str> = topology
+        .table_rows()
+        .iter()
+        .map(|c| c.name.as_str())
+        .collect();
+
+    assert_eq!(rows, vec!["core", "mid", "app"]);
+}
+
+/// A crate with the same inbound count as another sorts by fewest direct deps
+/// first — the shallower of two equally-depended-on crates is nearer the base.
+#[test]
+fn ties_break_toward_the_shallower_crate() {
+    let topology = CrateTopology {
+        members: 3,
+        edges: 3,
+        cycles: Vec::new(),
+        crates: vec![
+            node("deep", &["base", "other"], 1),
+            node("shallow", &[], 1),
+            node("base", &[], 0),
+        ],
+    };
+
+    let rows: Vec<&str> = topology
+        .table_rows()
+        .iter()
+        .map(|c| c.name.as_str())
+        .collect();
+
+    assert_eq!(rows, vec!["shallow", "deep", "base"]);
+}
+
+/// The table is capped, and the summary above it still states the true count —
+/// a truncated table must never read as the complete list.
+#[test]
+fn the_table_is_capped_and_the_summary_states_the_true_count() {
+    let crates: Vec<CrateNode> = (0..40)
+        .map(|i| node(&format!("crate-{i:02}"), &[], 0))
+        .collect();
+    let topology = CrateTopology {
+        members: 40,
+        edges: 0,
+        cycles: Vec::new(),
+        crates,
+    };
+
+    assert_eq!(topology.table_rows().len(), TABLE_ROW_CAP);
+    assert!(
+        topology.summary().contains("40 crates"),
+        "{}",
+        topology.summary()
+    );
+}
+
+/// The summary states all three whole-workspace facts.
+#[test]
+fn the_summary_states_members_edges_and_cycles() {
+    let summary = three_crate_topology().summary();
+
+    assert!(summary.contains("3 crates"), "{summary}");
+    assert!(
+        summary.contains("3 internal dependency edge(s)"),
+        "{summary}"
+    );
+    assert!(summary.contains("No dependency cycles"), "{summary}");
+    assert!(summary.contains("core (2)"), "{summary}");
+}
+
+/// A cycle is named, and stated for what it is: cargo rejects one, so a
+/// workspace that has one does not build.
+#[test]
+fn a_cycle_is_named_in_the_summary() {
+    let topology = CrateTopology {
+        members: 2,
+        edges: 2,
+        cycles: vec![vec!["a".to_string(), "b".to_string()]],
+        crates: vec![node("a", &["b"], 1), node("b", &["a"], 1)],
+    };
+
+    let summary = topology.summary();
+
+    assert!(summary.contains("1 dependency cycle(s)"), "{summary}");
+    assert!(summary.contains("a ↔ b"), "{summary}");
+    assert!(summary.contains("does not build"), "{summary}");
+}
+
+/// A workspace whose members depend on nothing internal says so, rather than
+/// leaving the reader to infer a shared core that is not there.
+#[test]
+fn a_workspace_with_no_shared_core_says_so() {
+    let topology = CrateTopology {
+        members: 2,
+        edges: 0,
+        cycles: Vec::new(),
+        crates: vec![node("a", &[], 0), node("b", &[], 0)],
+    };
+
+    assert!(
+        topology
+            .summary()
+            .contains("independent rather than built on a shared core"),
+        "{}",
+        topology.summary()
+    );
+}
+
+/// The rendered section carries the summary and one row per crate.
+#[test]
+fn a_declared_topology_renders_rows() {
+    let model = model_with(vec![repo("Demo", Some(three_crate_topology()))]);
+    let scope = crate::report::reporter::build_scope(&model);
+
+    let rendered = crate::report::fill::render(
+        "<!-- BEGIN crate_topology -->\n{{ct_summary}}\n<!-- BEGIN ct_row -->\n| {{ct_crate}} | \
+         {{ct_deps}} | {{ct_inbound}} |\n<!-- END ct_row -->\n<!-- END crate_topology -->",
+        &scope,
+    );
+
+    assert!(rendered.contains("3 crates"), "{rendered}");
+    assert!(rendered.contains("| core | — | 2 |"), "{rendered}");
+    assert!(rendered.contains("| mid | core | 1 |"), "{rendered}");
+    assert!(rendered.contains("| app | core, mid | 0 |"), "{rendered}");
+}
+
+/// The shipped template renders the same table, so the block markers in it and
+/// the block names this module pushes cannot drift apart.
+#[test]
+fn the_shipped_template_renders_the_table() {
+    let model = model_with(vec![repo("Demo", Some(three_crate_topology()))]);
+    let scope = crate::report::reporter::build_scope(&model);
+
+    let template = crate::report::TemplateLoader::bundled_only()
+        .load(crate::report::DEFAULT_TEMPLATE)
+        .expect("the bundled template loads");
+    let rendered = crate::report::fill::render(&template, &scope);
+
+    assert!(
+        rendered.contains("| Crate | Direct internal deps | Depended on by |"),
+        "{rendered}"
+    );
+    assert!(rendered.contains("| core | — | 2 |"), "{rendered}");
+}
+
+/// A repository that is not a Cargo workspace renders a report BYTE-IDENTICAL
+/// to one produced by a template with no topology block in it at all. No table,
+/// no header, and no honesty marker standing in for the missing data — a
+/// non-Rust repository's Code Quality & Architecture section is exactly what it
+/// was before this existed.
+#[test]
+fn no_topology_renders_nothing() {
+    let model = model_with(vec![repo("Demo", None)]);
+    let scope = crate::report::reporter::build_scope(&model);
+    let template = crate::report::TemplateLoader::bundled_only()
+        .load(crate::report::DEFAULT_TEMPLATE)
+        .expect("the bundled template loads");
+
+    let rendered = crate::report::fill::render(&template, &scope);
+    let without = crate::report::fill::render(&strip_topology_block(&template), &scope);
+
+    assert!(
+        !rendered.contains("Direct internal deps"),
+        "the topology table must not render at all"
+    );
+    assert_eq!(rendered, without);
+}
+
+/// The shipped template with the topology block excised — the "before this
+/// existed" template the test above compares against.
+fn strip_topology_block(template: &str) -> String {
+    const BEGIN: &str = "<!-- BEGIN crate_topology -->";
+    const END: &str = "<!-- END crate_topology -->";
+    let start = template.find(BEGIN).expect("the block is in the template");
+    let end = template.find(END).expect("the block is closed") + END.len();
+    format!("{}{}", &template[..start], &template[end..])
+}
+
+/// With several workspaces in one report each row names its application, so a
+/// crate name is never ambiguous across two repositories.
+#[test]
+fn several_repositories_are_named_in_the_rows() {
+    let model = model_with(vec![
+        repo("Alpha", Some(three_crate_topology())),
+        repo("Beta", Some(three_crate_topology())),
+    ]);
+    let scope = crate::report::reporter::build_scope(&model);
+
+    let rendered = crate::report::fill::render(
+        "<!-- BEGIN crate_topology --><!-- BEGIN ct_row -->[{{ct_crate}}]<!-- END ct_row --><!-- \
+         END crate_topology -->",
+        &scope,
+    );
+
+    assert!(rendered.contains("[Alpha / core]"), "{rendered}");
+    assert!(rendered.contains("[Beta / core]"), "{rendered}");
+}
+
+/// The synthesis prompt carries the same facts the table renders.
+#[test]
+fn prompt_facts_carry_the_summary_and_rows() {
+    let model = model_with(vec![repo("Demo", Some(three_crate_topology()))]);
+
+    let facts = prompt_facts(&model);
+
+    assert!(facts.contains("Crate topology"), "{facts}");
+    assert!(facts.contains("### Demo"), "{facts}");
+    assert!(facts.contains("3 crates"), "{facts}");
+    assert!(
+        facts.contains("`core`: depends on 0 internal crate(s); depended on by 2"),
+        "{facts}"
+    );
+}
+
+/// No topology, no block: the digest gains no headed-but-empty section.
+#[test]
+fn prompt_facts_are_empty_without_a_topology() {
+    let model = model_with(vec![repo("Demo", None)]);
+
+    assert_eq!(prompt_facts(&model), "");
+}
+
+/// #6143's numeric guardrail must ADMIT these figures. They are rendered into
+/// the fill scope, and `figures::printed_figures` walks that scope, so the
+/// member count and the inbound counts are in-model by construction — without
+/// this the model would be asked to cite a number the guardrail then rejects,
+/// taking the whole architecture paragraph with it.
+#[test]
+fn topology_numbers_are_admitted_by_the_numeric_guardrail() {
+    let model = model_with(vec![repo("Demo", Some(three_crate_topology()))]);
+    let serialized = serde_json::to_value(&model).expect("model serialises");
+    let printed = crate::report::figures::printed_figures(&model);
+
+    let allowed = crate::report::synthesize_guard::allowed_numbers_with(&serialized, &printed);
+
+    assert!(
+        allowed.contains("3"),
+        "the member count must be citable: {allowed:?}"
+    );
+    assert!(
+        allowed.contains("2"),
+        "an inbound count must be citable: {allowed:?}"
+    );
+}
+
+/// The manifest shape trusty-audit writes parses back into the type this crate
+/// renders — the two crates' agreement about that TOML is the whole interface.
+#[test]
+fn a_manifest_crate_topology_is_parsed() {
+    let manifest = r#"
+[report]
+title = "Audit"
+
+[[repositories]]
+name = "Demo"
+path = "/tmp/demo"
+
+[repositories.crate_topology]
+members = 3
+edges = 3
+cycles = []
+crates = [
+    { name = "core", deps = [], inbound = 2 },
+    { name = "mid", deps = ["core"], inbound = 1 },
+    { name = "app", deps = ["core", "mid"], inbound = 0 },
+]
+"#;
+
+    let parsed: crate::report::manifest::Manifest =
+        crate::report::manifest::parse_manifest(manifest, std::path::Path::new("."))
+            .expect("parses");
+    let topology = parsed.repositories[0]
+        .crate_topology
+        .as_ref()
+        .expect("a crate topology");
+
+    assert_eq!(topology.members, 3);
+    assert_eq!(topology.edges, 3);
+    assert!(topology.cycles.is_empty());
+    assert_eq!(topology.table_rows()[0].name, "core");
+}
+
+/// A manifest with no `crate_topology` key parses to `None` — the key is
+/// additive, so every manifest written before this existed still loads.
+#[test]
+fn a_manifest_without_the_key_parses_to_none() {
+    let manifest = r#"
+[report]
+title = "Audit"
+
+[[repositories]]
+name = "Demo"
+path = "/tmp/demo"
+"#;
+
+    let parsed: crate::report::manifest::Manifest =
+        crate::report::manifest::parse_manifest(manifest, std::path::Path::new("."))
+            .expect("parses");
+
+    assert!(parsed.repositories[0].crate_topology.is_none());
+}

--- a/crates/trusty-review/templates/report-technical-dd.md
+++ b/crates/trusty-review/templates/report-technical-dd.md
@@ -231,6 +231,20 @@ report against others normalized through this same template.
 | {{cq_app_name}} | {{cq_loc}} | {{cq_tech}} | {{cq_complexity}} | {{cq_maintainability_count}} |
 <!-- END code_quality_row -->
 
+<!-- #6147: the crate topology, read from the audited workspace's own cargo
+     metadata. Absent for a repository that is not a Cargo workspace, and the
+     whole block then renders as nothing. -->
+
+<!-- BEGIN crate_topology -->
+{{ct_summary}}
+
+| Crate | Direct internal deps | Depended on by |
+|---|---|---|
+<!-- BEGIN ct_row -->
+| {{ct_crate}} | {{ct_deps}} | {{ct_inbound}} |
+<!-- END ct_row -->
+<!-- END crate_topology -->
+
 ## Security Posture
 
 *This table counts the RED and AMBER findings the repo-evidence investigation


### PR DESCRIPTION
The Code Quality & Architecture paragraph had no deterministic architecture
input: it inferred the shape of a codebase from complexity buckets, a language
list and a LoC count. A Cargo workspace states its own shape in its manifests,
so this measures it instead (owner ruling: crate design is a factor for Rust
projects; more attention to high-level architecture).

## Producer — `crates/trusty-audit/src/grounding/topology.rs`

A new grounding leg, sibling of the search/analyze legs, run from
`ground_manifest` independently of both daemons. When the audited checkout's
root `Cargo.toml` declares a `[workspace]`, it derives member count, each
member's direct internal dependency edges, cycles over that edge list, and the
most-depended-on members, then writes them measured-tagged into the repository's
manifest entry as a `crate_topology` table.

**Metadata acquisition: shelling out to `cargo metadata --no-deps
--format-version 1`, parsed with `serde_json`.** `cargo_metadata` reaches
`Cargo.lock` only as a transitive dependency of `tauri-utils`; no workspace
crate depends on it directly. The four facts need three JSON keys, `serde_json`
is already a `trusty-audit` dependency, and `grounding/index.rs` next door
already spawns its tool the same way. `--no-deps` resolves and fetches nothing.

Dev-dependencies are deliberately not architecture edges: cargo permits a
dev-dependency cycle, so counting them would report a routine test arrangement
as a defect. A cycle over the edges that remain is one cargo itself rejects.

Degradation follows the declared-skip model (#5620): a repository that is not a
Cargo workspace produces no gap — it has none to miss — while a workspace whose
metadata could not be read produces one named gap and the run proceeds.

## Consumer — trusty-review

`report/topology.rs` carries the manifest shape, the deterministic table, and
the prompt fact block, because they are one contract. The section renders the
LLM paragraph, then a summary line (members, edges, cycle verdict, shared core),
then up to 15 rows — most-inbound and shallowest first, so the shared core leads.
`section_instructions.rs` tells the paragraph to comment on that structure and
not to speculate about module structure when none is given.

The numeric guardrail admits these figures without a special case: they are set
into the fill scope, and `figures::printed_figures` walks that scope — verified
by `topology_numbers_are_admitted_by_the_numeric_guardrail`.

A repository declaring no topology renders a report BYTE-IDENTICAL to one from a
template with the block excised (`no_topology_renders_nothing`), and the prompt
gains no heading.

## Gates — rung 4

| Gate | Result |
|---|---|
| `cargo fmt --check` | clean |
| `cargo clippy -p trusty-audit --all-targets -- -D warnings` | clean |
| `cargo clippy -p trusty-review --all-targets -- -D warnings` | clean |
| `cargo test -p trusty-audit` | `ok. 700 passed; 0 failed; 5 ignored` (+ 9 integration suites ok) |
| `cargo test -p trusty-review` | `ok. 1836 passed; 0 failed; 5 ignored` (+ 10 suites ok) |
| `cargo check --workspace` | clean |
| `cargo test -p trusty-analyze` (direct dependent) | 6 suites ok |
| `cargo test -p trusty-mpm` (direct dependent) | `ok. 5221 passed; 0 failed; 7 ignored` |
| `scripts/check_line_cap.sh` | `4145 tracked .rs file(s); 0 violations` |
| `scripts/check_sld.sh` | `0 error(s), 0 warning(s)` |
| `scripts/check_changelog_fragment.sh` | both crates recorded |
| `scripts/check-pr-version-bump.sh` | clear — both versions unpublished |

New coverage: 18 producer tests (including a real fixture workspace on disk
measured by real cargo, and a deliberate three-crate cycle), 15 consumer tests,
2 synthesis-prompt tests.

Refs #6147

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
