### PR TITLE
chore(trusty-analyze): bump to 0.10.0 — breaking API changes found by semver gate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11238,7 +11238,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-analyze"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-analyze/Cargo.toml
+++ b/crates/trusty-analyze/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "trusty-analyze"
-version     = "0.9.2"
+version     = "0.10.0"
 edition     = "2021"
 license.workspace    = true
 authors.workspace    = true


### PR DESCRIPTION
## Summary

`trusty-analyze` bumps 0.9.2 → 0.10.0. The publish preflight's semver gate
(CHECK 5) correctly found two breaking public-API changes between published
0.9.1 and candidate 0.9.2:

- `DiagnosticsReport` gained a new pub field `cutoff` (`core/tools.rs:82`)
- `StaticTool::run_project` went from 1 to 2 parameters (`core/tools.rs:211`)

Per the workspace's 0.x rule (CLAUDE.md, "Internal consistency is the bar"),
the breaking bump for a `0.y.z` crate lands in the MINOR position: 0.9.2 →
0.10.0.

## Known orphan tag

The tag `trusty-analyze-v0.9.2` was pushed during the paused publish attempt
and points at content that was never published to crates.io (protected,
harmless). It is orphaned by this bump and is not being deleted — the correct
tag for this release, `trusty-analyze-v0.10.0`, gets cut after this PR merges.

## Test plan

- [x] `bash scripts/bump-version.sh trusty-analyze minor --no-changelog` — 0.9.2 -> 0.10.0, Cargo.lock synced
- [x] `cargo check --workspace --locked` — clean
- [x] `bash scripts/check-pr-version-bump.sh` — OK, 2 changed paths examined, none under `crates/<crate>/src/**`
- [x] `bash scripts/check_semver.sh --crate trusty-analyze` — advisory pass: "0.9.1 -> 0.10.0 is already a breaking release — no bump can be owed"; both known breaks (DiagnosticsReport.cutoff, StaticTool::run_project) listed and permitted by the major-position bump

No tag, no publish in this PR — the paused publish train resumes tag + `cargo publish` after this merges.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
