### PR TITLE
chore(trusty-search): bump to 0.48.0 — breaking API changes found by semver gate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11827,7 +11827,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-search"
-version = "0.47.1"
+version = "0.48.0"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/crates/trusty-agents/Cargo.toml
+++ b/crates/trusty-agents/Cargo.toml
@@ -67,7 +67,7 @@ trusty-common = { workspace = true, features = ["symgraph-parser", "memory-core"
 #      compile the trusty-memory HTTP daemon code paths just to pick up a
 #      zero-sized service descriptor.
 trusty-memory = { path = "../trusty-memory", version = "0.23", default-features = false }
-trusty-search = { path = "../trusty-search", version = "0.47" }
+trusty-search = { path = "../trusty-search", version = "0.48" }
 # Gmail/Calendar eventstream listeners (#3820, DOC-54 SPEC-AGENTS-06) call
 # trusty-gworkspace's connector layer (`api::client::BaseClient` +
 # `api::services::gmail::*`) DIRECTLY as library functions — the same code

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -3,7 +3,7 @@ name = "trusty-search"
 # #4421: patch bump — 0.47.0 already published on crates.io and this PR
 # touches src/**. Every hunk is a doc-comment edit (module docs moved to the
 # inner `//!` standard, #5754) — no item signature or behavior changed.
-version = "0.47.1"
+version = "0.48.0"
 edition = "2021"
 description = "Machine-wide hybrid code search service: BM25 + vector + KG, zero cold-start, MCP server"
 readme = "README.md"


### PR DESCRIPTION
## Summary

`trusty-search` bumps 0.47.1 → 0.48.0. The publish preflight's semver gate
(CHECK 5) correctly found two breaking public-API changes between published
0.47.0 and candidate 0.47.1:

- `GrandfatherOutcome.skipped_existing` removed/renamed to
  `skipped_already_done` (`allowlist/grandfather.rs:61`)
- `WarmBootSummary` gained two new pub fields, `indexes_skipped_unapproved`
  and `indexes_stage_failed` (`service/server/state.rs:575,669`)

Per the workspace's 0.x rule (CLAUDE.md, "Internal consistency is the bar"),
the breaking bump for a `0.y.z` crate lands in the MINOR position: 0.47.1 →
0.48.0.

Also updates the one version-carrying pin on `trusty-search` in
`crates/trusty-agents/Cargo.toml:70` (`version = "0.47"` → `"0.48"`) — its
precision crossed the bumped minor, and `cargo update -p trusty-search
--precise 0.48.0` failed against the stale `^0.47` requirement until it was
updated.

## Known orphan tag

The tag `trusty-search-v0.47.1` was pushed during the paused publish attempt
and points at content that was never published to crates.io (protected,
harmless). It is orphaned by this bump and is not being deleted — the correct
tag for this release, `trusty-search-v0.48.0`, gets cut after this PR merges.

## Test plan

- [x] `bash scripts/bump-version.sh trusty-search minor --no-changelog` — 0.47.1 -> 0.48.0, Cargo.lock synced (after updating the trusty-agents pin)
- [x] `cargo check --workspace --locked` — clean
- [x] `bash scripts/check-pr-version-bump.sh` — OK, 3 changed paths examined, none under `crates/<crate>/src/**`
- [x] `bash scripts/check_semver.sh --crate trusty-search` — advisory pass: "0.47.0 -> 0.48.0 is already a breaking release — no bump can be owed"; both known breaks (GrandfatherOutcome field rename, WarmBootSummary new fields) listed and permitted by the major-position bump. Baseline and current both built cleanly on this machine (no CUDA-blind limitation hit).

No tag, no publish in this PR — the paused publish train resumes tag + `cargo publish` after this merges.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
