### PR TITLE
fix(trusty-audit): audit index ids are collision-resistant per checkout (Refs #6149)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6519,7 +6519,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -10262,7 +10262,7 @@ dependencies = [
 
 [[package]]
 name = "tga"
-version = "3.3.0"
+version = "3.3.1"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -11298,7 +11298,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-audit"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -11405,7 +11405,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-common"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11790,7 +11790,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-review"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,7 @@ trusty-code = { path = "crates/trusty-code", version = "0.3.0" }
 # epic #3411). Not yet published (Slice 1, #3425).
 trusty-tui = { path = "crates/trusty-tui", version = "0.1.0" }
 trusty-agents-common = { path = "crates/trusty-agents-common", version = "0.6.0" }
-trusty-common = { path = "crates/trusty-common", version = "0.40" }
+trusty-common = { path = "crates/trusty-common", version = "0.41" }
 # Shared JSON-RPC 2.0 / MCP protocol primitives, extracted from
 # `trusty_common::mcp` by ADR-0040 (#5803).
 trusty-mcp = { path = "crates/trusty-mcp", version = "0.1.0" }

--- a/crates/trusty-audit/Cargo.toml
+++ b/crates/trusty-audit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-audit"
-version = "0.8.0"
+version = "0.8.1"
 description = "Auditor client — installs its pinned audit tooling and drives an audit engagement on the recipient's own codebases."
 readme = "README.md"
 homepage = "https://github.com/bobmatnyc/trusty-tools"

--- a/crates/trusty-audit/changelog.d/6149-checkout-index-id.md
+++ b/crates/trusty-audit/changelog.d/6149-checkout-index-id.md
@@ -1,0 +1,19 @@
+Fixed
+
+- The grounding pass indexes each audited checkout under an id derived from its
+  canonical path (`trusty_common::derive_checkout_index_id`) instead of the
+  checkout basename, so a machine already serving an index of the same name for
+  a different tree no longer collides. The confirmation run of 2026-08-21 hit
+  exactly that: the engagement clone at `…/repos/local/trusty-tools` derived
+  `trusty-tools`, the daemon was serving `~/Projects/trusty-tools` under it, and
+  the root-mismatch guard correctly refused — which cost the report both its
+  evidence discovery and its complexity hotspots. That guard stays, as the
+  backstop for an index registered under the old scheme or a tree that has since
+  moved. Existing indexes registered under a bare basename are not renamed;
+  the first audit of a checkout re-indexes it under the new id.
+- The investigation budget reaches `[report].investigate_max_files` /
+  `investigate_max_bytes` even when both grounding legs degrade. The budget is
+  configuration, not evidence, and it used to be written only alongside a
+  non-empty ranking — so a run that lost its index also lost its 240-file budget
+  and trusty-review fell back to its own 40-file default, compounding one
+  failure into two.

--- a/crates/trusty-audit/src/grounding/daemons.rs
+++ b/crates/trusty-audit/src/grounding/daemons.rs
@@ -45,9 +45,9 @@ pub const ENV_ANALYZE_BIN: &str = "TRUSTY_ANALYZE_BIN";
 /// `tga`, which owns the same three names (`tga::audit::ENV_ANALYZE_URL`), and
 /// linking a workspace-version `tga` into a client whose entire discipline is
 /// running PINNED binaries would defeat the pinning. It is a copied
-/// cross-process contract, the same deliberate copy `tga::audit::index_id_for`
-/// is of trusty-review's id rule, and it is pinned by
-/// `daemon_tests::the_analyze_defaults_match_the_contract_tga_uses`.
+/// cross-process contract — unlike the index id, which since #6149 is one
+/// shared function in `trusty-common` rather than three copies — and it is
+/// pinned by `daemon_tests::the_analyze_defaults_match_the_contract_tga_uses`.
 pub const ENV_ANALYZE_URL: &str = "TRUSTY_ANALYZE_URL";
 
 /// The trusty-analyze daemon's address when nothing overrides it.

--- a/crates/trusty-audit/src/grounding/grounding_tests.rs
+++ b/crates/trusty-audit/src/grounding/grounding_tests.rs
@@ -284,7 +284,10 @@ async fn an_unindexable_checkout_is_a_named_gap() {
     )
     .await;
     assert!(out.priorities.is_empty());
-    assert_eq!(out.index_id.as_deref(), Some("acme-api"));
+    assert_eq!(
+        out.index_id,
+        index::index_id_for(Path::new("/w/repos/acme-api"))
+    );
     assert_eq!(out.gaps.len(), 1, "{:?}", out.gaps);
     assert!(out.gaps[0].contains("acme-api"), "{:?}", out.gaps);
     assert!(out.gaps[0].contains("not allowlisted"), "{:?}", out.gaps);

--- a/crates/trusty-audit/src/grounding/index.rs
+++ b/crates/trusty-audit/src/grounding/index.rs
@@ -8,13 +8,16 @@
 //!
 //! ## The index id is a cross-process contract
 //!
-//! trusty-review derives the id it looks up from the checkout path's basename
-//! (`trusty_review::report::analyze_adapter::derive_index_id`), and
-//! `tga::audit::repo_index::index_id_for` applies that same rule from the other
-//! side. [`index_id_for`] is the third copy of one rule, and it is a copy
-//! deliberately: this crate has a Cargo edge to neither, and an id derived any
-//! other way would index every repository under a name nobody ever queries —
-//! leaving the reports exactly as hollow as before while looking fixed.
+//! Three crates derive the id independently — this one when it indexes,
+//! `trusty_review::report::analyze_adapter::derive_index_id` when the renderer
+//! looks it up, `tga::audit::repo_index::index_id_for` from the sweep's other
+//! side — and an id derived any other way indexes a repository under a name
+//! nobody ever queries. Until #6149 the rule was the checkout BASENAME, copied
+//! into all three; two checkouts of one repository therefore collided on one id
+//! and the daemon served whichever tree registered first. All three now call
+//! [`trusty_common::derive_checkout_index_id`], which hashes the canonical path
+//! into the id, so the agreement is a call rather than a copy and two checkouts
+//! can no longer collide.
 //!
 //! ## Two verbs, not one
 //!
@@ -48,12 +51,15 @@ pub enum IndexStatus {
 
 /// The trusty-search index id for a checkout path.
 ///
-/// Why/What/Test: see the module docs — the final path component, exactly as
-/// `derive_index_id` returns it. `None` for a path with no basename, e.g. `/`.
-/// Test: `index_tests::the_index_id_is_the_checkout_basename`.
+/// Why/What/Test: see the module docs. A thin forward to
+/// [`trusty_common::derive_checkout_index_id`], kept as a named function here
+/// because the module's callers and tests read better against it and because it
+/// is the seam a future scheme change moves. `None` for a path with no final
+/// component, e.g. `/`.
+/// Test: `index_tests::the_index_id_distinguishes_two_checkouts_of_one_repo`.
 #[must_use]
 pub fn index_id_for(path: &Path) -> Option<String> {
-    path.file_name().map(|n| n.to_string_lossy().into_owned())
+    trusty_common::derive_checkout_index_id(path)
 }
 
 /// Wall-clock budget for the index-root probe.
@@ -61,17 +67,17 @@ const ROOT_PROBE_BUDGET: std::time::Duration = std::time::Duration::from_secs(10
 
 /// Refuse an index that is rooted at a DIFFERENT checkout than the audited one.
 ///
-/// Why: the index id is the checkout BASENAME (see the module docs), so two
-/// checkouts of the same repository collide on one id. The graded self-audit of
-/// 2026-08-21 hit exactly that: the audited tree was the engagement's own
-/// clone, the daemon was already serving an index of the same name rooted at
-/// `~/Projects/trusty-tools` at a different branch and commit, and every
-/// complexity hotspot the report stamped "measured" was measured against code
-/// that was never audited. Nothing in the pipeline compared the two roots, so
-/// the wrong tree's measurements arrived indistinguishable from the right
-/// tree's. An id collision cannot be fixed by choosing a better id here — the
-/// id is a cross-process contract three crates derive independently — so the
-/// fix is to CHECK the root and degrade loudly.
+/// Why: this is the BACKSTOP, not the primary defence. The primary defence is
+/// the id itself: since #6149 it hashes the canonical checkout path, so two
+/// checkouts of one repository can no longer collide by construction. What is
+/// left for this guard is everything a derivation cannot see — an id registered
+/// under the old basename scheme, a directory that moved after it was indexed,
+/// and a daemon whose registry disagrees with this machine's filesystem. The
+/// graded self-audit of 2026-08-21 is what both defences answer: the audited
+/// tree was the engagement's own clone, the daemon was already serving an index
+/// of the same name rooted at `~/Projects/trusty-tools` at a different branch
+/// and commit, and every complexity hotspot the report stamped "measured" was
+/// measured against code that was never audited.
 ///
 /// What: reads `root_path` off `GET /indexes/{id}/status` and compares it to
 /// `checkout`, canonicalising both so a symlinked or `..`-laden path still
@@ -117,9 +123,8 @@ pub async fn root_matches(base_url: &str, index_id: &str, checkout: &Path) -> Re
         return Ok(());
     }
     Err(format!(
-        "the trusty-search index '{index_id}' is rooted at {served}, not at {} — the index id is \
-         the checkout basename, so another checkout of the same repository is being served under \
-         it",
+        "the trusty-search index '{index_id}' is rooted at {served}, not at {} — another checkout \
+         is registered under this id, so its content would be reported as this one's",
         checkout.display()
     ))
 }
@@ -244,15 +249,37 @@ mod index_tests {
         }
     }
 
-    /// The rule three crates apply independently. A drift here indexes every
-    /// repository under a name nobody queries.
+    /// #6149: the rule three crates apply, now via one shared implementation.
+    /// A drift here indexes every repository under a name nobody queries.
     #[test]
-    fn the_index_id_is_the_checkout_basename() {
-        assert_eq!(
-            index_id_for(Path::new("/w/repos/acme-api")).as_deref(),
-            Some("acme-api")
-        );
+    fn the_index_id_distinguishes_two_checkouts_of_one_repo() {
+        let engagement = Path::new("/w/dogfood-audit-final/repos/local/trusty-tools");
+        let working = Path::new("/Users/masa/Projects/trusty-tools");
+
+        let a = index_id_for(engagement).expect("id");
+        let b = index_id_for(working).expect("id");
+        assert_ne!(a, b, "{a} vs {b}");
+        assert!(a.starts_with("trusty-tools-"), "{a}");
         assert_eq!(index_id_for(Path::new("/")), None);
+    }
+
+    /// The three sites are one function now, so the agreement is checkable
+    /// rather than asserted: this crate's id IS trusty-common's.
+    #[test]
+    fn the_index_id_is_the_shared_derivation() {
+        for path in [
+            "/w/repos/acme-api",
+            "/Users/masa/Projects/trusty-tools",
+            "/",
+        ] {
+            let path = Path::new(path);
+            assert_eq!(
+                index_id_for(path),
+                trusty_common::derive_checkout_index_id(path),
+                "{}",
+                path.display()
+            );
+        }
     }
 
     #[test]
@@ -366,9 +393,9 @@ mod index_tests {
         assert!(seen.contains("index /w/repos/xsv --name xsv"), "{seen}");
     }
 
-    /// The id is a basename, so two checkouts of one repository collide. The
-    /// comparison has to resolve symlinks and `..`, or a legitimate root reads
-    /// as a mismatch and the repository loses its code analysis for nothing.
+    /// The backstop still has to be precise: the comparison resolves symlinks
+    /// and `..`, or a legitimate root reads as a mismatch and the repository
+    /// loses its code analysis for nothing.
     #[test]
     fn same_tree_resolves_before_it_compares() {
         let tmp = tempfile::tempdir().expect("tempdir");

--- a/crates/trusty-audit/src/grounding/priority.rs
+++ b/crates/trusty-audit/src/grounding/priority.rs
@@ -224,11 +224,20 @@ fn env_positive(name: &str) -> Option<usize> {
 /// thing that MUST reach the report. The two are independent — `[report].gaps`
 /// belongs to the run, `inspect_priority` to one repository — so a gap is
 /// recorded whether or not the repository entry can be found.
+///
+/// Why the BUDGET is written even when the ranking is not (#6149): the budget is
+/// CONFIGURATION, not evidence. It used to sit inside the `priorities`
+/// non-empty branch, so a run whose grounding legs degraded wrote its gaps and
+/// nothing else — and trusty-review, finding no `investigate_max_files`, fell
+/// back to its own 40-file default. The evidence failure silently took the
+/// investigation depth with it: exactly the compounding the confirmation run of
+/// 2026-08-21 hit, where the index collision cost the grounding AND left the
+/// 240-file budget unwritten.
 /// What: appends each gap to `[report].gaps`, skipping duplicates so a resumed
 /// sweep does not restate them, fills the investigation budget keys when the
 /// manifest declares none, and replaces the matched repository's
-/// `inspect_priority` with the ranking. Nothing is written when there is nothing
-/// to record.
+/// `inspect_priority` with the ranking. Nothing is written when there is no
+/// ranking, no gap and no budget to record.
 ///
 /// # Errors
 ///
@@ -250,7 +259,7 @@ pub fn write_into(
     attributed_only: bool,
     gaps: &[String],
 ) -> Result<(), String> {
-    if priorities.is_empty() && gaps.is_empty() {
+    if priorities.is_empty() && gaps.is_empty() && budget.is_none() {
         return Ok(());
     }
     let text = std::fs::read_to_string(path)
@@ -260,11 +269,13 @@ pub fn write_into(
         .map_err(|e| format!("{} is not readable as TOML ({e})", path.display()))?;
 
     record_gaps(&mut doc, gaps)?;
+    // #6149: configuration first, and unconditionally — a degraded evidence leg
+    // must not silently drop the investigation budget with it.
+    if let Some(budget) = budget {
+        record_budget(&mut doc, budget)?;
+    }
     if !priorities.is_empty() {
         record_priorities(&mut doc, checkout, priorities)?;
-        if let Some(budget) = budget {
-            record_budget(&mut doc, budget)?;
-        }
         if attributed_only {
             record_attributed_only(&mut doc)?;
         }
@@ -704,6 +715,47 @@ path = "/w/repos/acme-web"
         assert_eq!(
             parsed["report"]["investigate_max_bytes"].as_integer(),
             Some(1_200_000)
+        );
+    }
+
+    /// #6149: the budget is configuration, not evidence. A run whose grounding
+    /// legs both failed produces gaps and no ranking, and it must STILL declare
+    /// the budget — otherwise trusty-review falls back to its own 40-file
+    /// default and the evidence failure quietly costs the investigation depth
+    /// too. Fails against the pre-fix code, which wrote the budget only inside
+    /// the non-empty-ranking branch.
+    #[test]
+    fn a_degraded_grounding_still_declares_the_budget() {
+        let out = recorded(
+            SAMPLE,
+            "/w/repos/acme-api",
+            &[],
+            Some(Budget {
+                max_files: DEFAULT_MAX_FILES,
+                max_bytes: DEFAULT_MAX_BYTES,
+            }),
+            &[
+                "acme-api: complexity data unavailable: index root mismatch",
+                "acme-api: the search index matched no evidence for any dimension",
+            ],
+        );
+        let parsed: toml::Value = toml::from_str(&out).expect("valid TOML");
+        assert_eq!(
+            parsed["report"]["investigate_max_files"].as_integer(),
+            Some(240),
+            "{out}"
+        );
+        assert_eq!(
+            parsed["report"]["investigate_max_bytes"].as_integer(),
+            Some(2_457_600),
+            "{out}"
+        );
+        assert_eq!(parsed["report"]["gaps"].as_array().expect("array").len(), 3);
+        assert!(
+            parsed["repositories"].as_array().expect("array")[0]
+                .get("inspect_priority")
+                .is_none(),
+            "a degraded run declares no ranking: {out}"
         );
     }
 

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "trusty-common"
 # 0.40.0 (#5809): the MCP extraction (ADR-0040 Phase 1) removed the public
 # `src/mcp/*` modules. Cargo's 0.x rule makes that a MINOR bump, not a patch.
-version = "0.40.1"
+version = "0.41.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/trusty-common/changelog.d/6149-checkout-index-id.md
+++ b/crates/trusty-common/changelog.d/6149-checkout-index-id.md
@@ -1,0 +1,15 @@
+Added
+
+- `derive_checkout_index_id` derives a collision-resistant trusty-search index
+  id for one checkout: the slugified basename plus 8 hex digits over the
+  canonical path, e.g. `trusty-tools-3fa9c1d2`. `derive_index_id` is the bare
+  basename, so two checkouts of one repository — an audit engagement's clone and
+  the operator's own tree — collide on a single id, and trusty-search's registry
+  is one `root_path` per id: the second checkout is silently served the first
+  one's content. It is deliberately pure, a function of the path and nothing
+  else, because `trusty-audit`, `trusty-review` and `tga` each derive this id in
+  a separate process and a component read from live git state (as
+  `derive_project_index_id` reads origin and operator) would let two of them
+  disagree. A path that cannot be canonicalised is normalised through
+  `Path::components`, so a trailing separator and a `path = "."` entry's
+  `<base>/.` still name one tree. `None` for a path with no final component.

--- a/crates/trusty-common/src/index_id.rs
+++ b/crates/trusty-common/src/index_id.rs
@@ -104,6 +104,87 @@ pub fn derive_index_id(project_root: &Path) -> String {
         .into_owned()
 }
 
+/// Version tag mixed into every checkout-id digest preimage.
+///
+/// Why: a future change to this derivation must move every id wholesale into a
+/// disjoint space rather than re-pointing an already-registered id at different
+/// content — the same property [`crate::project_index_id`] mixes its own tag in
+/// for. What: the literal `"checkout-v1"`. Test:
+/// `derive_checkout_index_id_is_pinned_for_a_known_input`.
+const CHECKOUT_SCHEME_VERSION: &str = "checkout-v1";
+
+/// Hex digits of digest appended to a checkout index id.
+///
+/// 8 (32 bits) keeps the id readable in a log line and a URL path segment while
+/// leaving collision probability negligible for the tens of checkouts one
+/// machine holds. Uniqueness lives entirely here; the label is cosmetic.
+const CHECKOUT_DIGEST_HEX: usize = 8;
+
+/// Label used when a checkout's basename slugifies to nothing at all.
+const CHECKOUT_FALLBACK_LABEL: &str = "checkout";
+
+/// Derive a collision-resistant trusty-search index id for ONE checkout (#6149).
+///
+/// Why: [`derive_index_id`] is the bare basename, so two checkouts of one
+/// repository — an audit engagement's clone and the operator's working tree —
+/// collide on a single id. trusty-search's registry is one-`root_path`-per-id,
+/// so the second checkout is silently served the FIRST one's content: the graded
+/// self-audit of 2026-08-21 measured complexity against a tree it never audited.
+/// The id is a cross-process contract that `trusty-audit`, `trusty-review` and
+/// `tga` each derive independently, and this is the one implementation all three
+/// call, so they cannot drift.
+///
+/// It is deliberately PURE — a function of the path and nothing else. No git
+/// shell-out, no environment, no daemon. [`crate::derive_project_index_id`]
+/// partitions on richer inputs, but two of them (`origin`, `operator`) are live
+/// git state resolved per process, and three separate processes must agree on
+/// this id; a component that varies with a process's `HOME` would reintroduce
+/// exactly the divergence being fixed.
+///
+/// What: `"<slugified basename>-<8 hex>"` over the CANONICAL path, so a
+/// symlinked or `..`-laden spelling of one tree derives one id. `None` for a
+/// path with no final component, e.g. `/` — every caller already treats that as
+/// "no index id could be derived". A path that cannot be canonicalised (it does
+/// not exist yet) is normalised through [`Path::components`] instead, which
+/// still collapses a trailing separator, a repeated separator and a `.`
+/// component — `tga` anchors a `path = "."` config entry as `<base>/.`, and
+/// that must not derive a second id for the tree `<base>` already names.
+///
+/// Known limitation: the id changes when the directory MOVES, because the path
+/// is the whole partitioning input. That orphans the old index rather than
+/// merging two trees — the strictly weaker of the two failures, and the same
+/// tradeoff [`crate::project_index_id`] documents at length.
+///
+/// # Postconditions
+/// Non-empty; a single URL path segment matching `[a-z0-9][a-z0-9-]*`; and a
+/// pure function of the canonical path — identical input, identical id, in every
+/// process and across daemon restarts.
+///
+/// Test: `derive_checkout_index_id_distinguishes_same_named_checkouts`,
+/// `derive_checkout_index_id_is_stable_across_calls`,
+/// `derive_checkout_index_id_is_a_single_url_safe_segment`,
+/// `derive_checkout_index_id_is_pinned_for_a_known_input`.
+#[must_use]
+pub fn derive_checkout_index_id(checkout: &Path) -> Option<String> {
+    let canonical = std::fs::canonicalize(checkout)
+        .unwrap_or_else(|_| checkout.components().collect::<PathBuf>());
+    let name = canonical.file_name()?.to_string_lossy().into_owned();
+    let slug = crate::slug::slugify_string(&name);
+    let label = if slug.is_empty() {
+        CHECKOUT_FALLBACK_LABEL
+    } else {
+        slug.as_str()
+    };
+    let mut preimage: Vec<u8> = Vec::with_capacity(128);
+    crate::project_index_id::push_field(&mut preimage, CHECKOUT_SCHEME_VERSION.as_bytes());
+    crate::project_index_id::push_field(
+        &mut preimage,
+        &crate::project_index_id::path_bytes(&canonical),
+    );
+    let digest = format!("{:016x}", crate::project_index_id::fnv1a_64(&preimage));
+    Some(format!("{label}-{}", &digest[..CHECKOUT_DIGEST_HEX]))
+}
+
 /// Decide whether `a` and `b` name the same on-disk directory tree.
 ///
 /// Why: a trusty-search index identifies a searchable DIRECTORY TREE, so every
@@ -191,6 +272,105 @@ mod tests {
     #[test]
     fn derive_index_id_empty_for_root() {
         assert_eq!(derive_index_id(Path::new("/")), "");
+    }
+
+    /// #6149, the defect itself: the engagement clone and the operator's own
+    /// checkout share a basename, and under [`derive_index_id`] they share an
+    /// id — which is how a report measured a tree nobody audited. This assertion
+    /// fails against the pre-fix derivation.
+    #[test]
+    fn derive_checkout_index_id_distinguishes_same_named_checkouts() {
+        let engagement = Path::new("/w/dogfood-audit-final/repos/local/trusty-tools");
+        let working = Path::new("/Users/masa/Projects/trusty-tools");
+
+        let a = derive_checkout_index_id(engagement).expect("has a basename");
+        let b = derive_checkout_index_id(working).expect("has a basename");
+
+        assert_eq!(
+            derive_index_id(engagement),
+            derive_index_id(working),
+            "the basename rule is what collides"
+        );
+        assert_ne!(a, b, "the checkout rule must not: {a} vs {b}");
+        assert!(a.starts_with("trusty-tools-"), "still readable: {a}");
+        assert!(b.starts_with("trusty-tools-"), "still readable: {b}");
+    }
+
+    /// The id is a cross-process contract, so it has to be the same value on
+    /// every call, in every process — including for two spellings of one tree.
+    #[test]
+    fn derive_checkout_index_id_is_stable_across_calls() {
+        let tmp = scratch_dir("checkout-stable");
+        let real = tmp.join("repos/acme-api");
+        fs::create_dir_all(&real).unwrap();
+
+        let first = derive_checkout_index_id(&real).expect("id");
+        assert_eq!(derive_checkout_index_id(&real), Some(first.clone()));
+        assert_eq!(
+            derive_checkout_index_id(&tmp.join("repos/../repos/acme-api")),
+            Some(first.clone()),
+            "a `..`-laden spelling names the same tree and must derive one id"
+        );
+        assert!(first.starts_with("acme-api-"), "{first}");
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    /// A path that does not exist cannot be canonicalised, and the spellings
+    /// that reach this function are the ones a config file wrote: a trailing
+    /// separator, and the `<base>/.` a `path = "."` entry anchors to. All three
+    /// name one tree, so all three must derive one id.
+    #[test]
+    fn derive_checkout_index_id_normalises_an_uncanonicalisable_path() {
+        let plain = derive_checkout_index_id(Path::new("/w/repos/acme-api")).expect("id");
+        for spelling in [
+            "/w/repos/acme-api/",
+            "/w/repos/acme-api/.",
+            "/w//repos/acme-api",
+        ] {
+            assert_eq!(
+                derive_checkout_index_id(Path::new(spelling)).as_deref(),
+                Some(plain.as_str()),
+                "{spelling}"
+            );
+        }
+    }
+
+    /// An index id is a URL path segment and a filename component; a basename
+    /// that slugifies to nothing must still produce a well-formed id, and `/`
+    /// must still say "no id", which is what every caller branches on.
+    #[test]
+    fn derive_checkout_index_id_is_a_single_url_safe_segment() {
+        for path in [
+            "/w/repos/My Project!",
+            "/w/repos/Repo_With_Underscores",
+            "/w/repos/…",
+        ] {
+            let id = derive_checkout_index_id(Path::new(path)).expect("id");
+            assert!(
+                id.chars()
+                    .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-'),
+                "{path} → {id}"
+            );
+            assert!(!id.starts_with('-') && !id.ends_with('-'), "{path} → {id}");
+        }
+        assert!(
+            derive_checkout_index_id(Path::new("/w/repos/…"))
+                .expect("id")
+                .starts_with("checkout-"),
+            "a basename with no slug-able character falls back to a label"
+        );
+        assert_eq!(derive_checkout_index_id(Path::new("/")), None);
+    }
+
+    /// The digest rule is a wire format: changing it re-points every registered
+    /// id at nothing. This pins one input so a silent change fails here.
+    #[test]
+    fn derive_checkout_index_id_is_pinned_for_a_known_input() {
+        assert_eq!(
+            derive_checkout_index_id(Path::new("/w/repos/acme-api")).as_deref(),
+            Some("acme-api-05d116f5")
+        );
     }
 
     #[test]

--- a/crates/trusty-common/src/lib.rs
+++ b/crates/trusty-common/src/lib.rs
@@ -601,7 +601,10 @@ pub use slug::slugify_string;
 /// Test: `cargo test -p trusty-common --features unconditional-only --
 /// index_id::tests`.
 pub mod index_id;
-pub use index_id::{derive_index_id, find_git_root, identifies_same_path, resolve_project_root};
+pub use index_id::{
+    derive_checkout_index_id, derive_index_id, find_git_root, identifies_same_path,
+    resolve_project_root,
+};
 
 /// Project-derived trusty-search index identity — the PARTITIONING key
 /// (epic #4207; supersedes the approach closed as won't-do in #4063).

--- a/crates/trusty-common/src/project_index_id.rs
+++ b/crates/trusty-common/src/project_index_id.rs
@@ -395,7 +395,7 @@ pub fn resolve_operator_identity(root: &Path) -> Option<String> {
 /// the boundary unambiguous regardless of the field's own contents.
 /// What: writes `<decimal len>:<bytes>` to `buf`.
 /// Test: covered by `label_ambiguity_does_not_collide`.
-fn push_field(buf: &mut Vec<u8>, value: &[u8]) {
+pub(crate) fn push_field(buf: &mut Vec<u8>, value: &[u8]) {
     buf.extend_from_slice(value.len().to_string().as_bytes());
     buf.push(b':');
     buf.extend_from_slice(value);
@@ -427,7 +427,7 @@ fn push_opt(buf: &mut Vec<u8>, value: Option<String>) {
 /// What: the underlying `OsStr` bytes on unix; the lossy UTF-8 encoding
 /// elsewhere (Windows `OsStr` is UTF-16 and has no byte view).
 /// Test: covered by `sibling_clones_of_same_repo_derive_distinct_ids`.
-fn path_bytes(p: &Path) -> Vec<u8> {
+pub(crate) fn path_bytes(p: &Path) -> Vec<u8> {
     #[cfg(unix)]
     {
         use std::os::unix::ffi::OsStrExt;
@@ -453,7 +453,7 @@ fn path_bytes(p: &Path) -> Vec<u8> {
 /// What: standard FNV-1a over `bytes`, then a splitmix64 finalizer so that
 /// paths differing in a single character still differ in most output bits.
 /// Test: `digest_is_stable_for_identical_inputs`.
-fn fnv1a_64(bytes: &[u8]) -> u64 {
+pub(crate) fn fnv1a_64(bytes: &[u8]) -> u64 {
     const OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
     const PRIME: u64 = 0x0000_0100_0000_01b3;
     let mut hash = OFFSET_BASIS;

--- a/crates/trusty-git-analytics/Cargo.toml
+++ b/crates/trusty-git-analytics/Cargo.toml
@@ -26,7 +26,7 @@ name = "tga"
 # the `tga` binary; trusty-audit resolves it by version at runtime, not through
 # a Cargo edge), so the gate has nobody to protect here. The exception is
 # recorded as a `tga` row in scripts/semver-checks-crate-exclusions.tsv.
-version = "3.3.0"
+version = "3.3.1"
 publish = true
 edition = "2021"
 # Aligned with the workspace MSRV (1.94) per #254. Required for

--- a/crates/trusty-git-analytics/changelog.d/6149-checkout-index-id.md
+++ b/crates/trusty-git-analytics/changelog.d/6149-checkout-index-id.md
@@ -1,0 +1,8 @@
+Fixed
+
+- `tga audit` indexes each repository under the per-checkout id
+  `trusty_common::derive_checkout_index_id` derives, the same function
+  trusty-review's renderer now calls, instead of a copy of the basename rule.
+  Two checkouts of one repository used to collide on a single id, so the sweep
+  indexed one tree and the renderer read the other's measurements. The agreement
+  between the two crates is a call now rather than a copied rule.

--- a/crates/trusty-git-analytics/src/audit/repo_index.rs
+++ b/crates/trusty-git-analytics/src/audit/repo_index.rs
@@ -31,12 +31,12 @@
 //!
 //! ## The index id is a cross-process contract
 //!
-//! trusty-review derives the id it looks up from the checkout path's basename
-//! (`report::analyze_adapter::derive_index_id`). [`index_id_for`] applies that
-//! same rule to the same value — the path written into `manifest.toml`, which is
-//! the only thing the renderer reads. An id derived any other way would index
-//! every repository under a name nobody ever queries, leaving the reports
-//! exactly as hollow as before while looking fixed.
+//! trusty-review derives the id it looks up from the checkout path written into
+//! `manifest.toml`, which is the only thing the renderer reads. [`index_id_for`]
+//! derives it from the same value through the same function
+//! ([`trusty_common::derive_checkout_index_id`], #6149) — an id derived any
+//! other way indexes every repository under a name nobody ever queries, leaving
+//! the reports exactly as hollow as before while looking fixed.
 //!
 //! ## What the wait does, and does not, guarantee
 //!
@@ -144,16 +144,17 @@ pub(super) fn binary_from_override(override_value: Option<&str>) -> String {
 /// The trusty-search index id for a checkout path.
 ///
 /// Why: this must agree with `trusty_review::report::analyze_adapter::
-/// derive_index_id`, which is what the renderer looks the index up by. The two
-/// crates share no Cargo edge (DOC-67 §5), so the agreement is a copied rule
-/// rather than a call — copied deliberately, and pinned by
-/// `super::tests::the_index_id_is_the_checkout_basename`.
-/// What: the final path component, exactly as `derive_index_id` returns it —
-/// `None` for a path with no basename, e.g. `/`.
-/// Test: `super::tests::{the_index_id_is_the_checkout_basename,
+/// derive_index_id`, which is what the renderer looks the index up by. Until
+/// #6149 both were the checkout BASENAME, copied rather than called — and two
+/// checkouts of one repository therefore collided on one id, so the sweep
+/// indexed one tree and the renderer read another. Both now call
+/// [`trusty_common::derive_checkout_index_id`], so the agreement is a call.
+/// What: `"<slugified basename>-<8 hex over the canonical path>"` — `None` for a
+/// path with no final component, e.g. `/`.
+/// Test: `super::tests::{the_index_id_distinguishes_two_checkouts_of_one_repo,
 /// index_ids_match_the_manifest_paths_the_renderer_reads}`.
 pub fn index_id_for(path: &Path) -> Option<String> {
-    path.file_name().map(|n| n.to_string_lossy().into_owned())
+    trusty_common::derive_checkout_index_id(path)
 }
 
 /// The membership probe's argument vector.

--- a/crates/trusty-git-analytics/src/audit/tests.rs
+++ b/crates/trusty-git-analytics/src/audit/tests.rs
@@ -1534,33 +1534,51 @@ fn search_binary_resolution_prefers_the_env_override() {
     assert!(!crate::audit::resolve_search_binary().is_empty());
 }
 
-/// The cross-process contract, pinned as a rule.
+/// The cross-process contract, pinned as a rule (#6149).
 ///
-/// trusty-review looks the index up by the checkout path's basename
-/// (`report::analyze_adapter::derive_index_id`, a `path.file_name()` mapped to a
-/// `String`). No Cargo edge joins the two crates, so this is a copy of that
-/// rule — including the two shapes that are easy to get wrong: a trailing `.`,
-/// which `Path` normalises away rather than treating as the final component, and
-/// a root path, which has no basename at all and which BOTH sides must decline.
+/// trusty-review looks the index up through the same function this calls
+/// (`trusty_common::derive_checkout_index_id`), so the assertions here are the
+/// shapes that are easy to get wrong: two checkouts of one repository, which
+/// must NOT share an id; a trailing separator and a trailing `.`, which `Path`
+/// normalises away rather than treating as the final component and which must
+/// therefore derive the SAME id; and a root path, which has no final component
+/// at all and which both sides must decline.
 #[test]
-fn the_index_id_is_the_checkout_basename() {
+fn the_index_id_distinguishes_two_checkouts_of_one_repo() {
     use std::path::Path;
 
-    assert_eq!(
-        index_id_for(Path::new("/src/northwind-web")).as_deref(),
-        Some("northwind-web")
-    );
+    let one = index_id_for(Path::new("/src/northwind-web")).expect("id");
+    let other = index_id_for(Path::new("/w/repos/local/northwind-web")).expect("id");
+    assert_ne!(one, other, "{one} vs {other}");
+    assert!(one.starts_with("northwind-web-"), "{one}");
+
     assert_eq!(
         index_id_for(Path::new("/src/northwind-web/")).as_deref(),
-        Some("northwind-web"),
+        Some(one.as_str()),
         "a trailing separator is not a component"
     );
     assert_eq!(
         index_id_for(Path::new("/src/northwind-web/.")).as_deref(),
-        Some("northwind-web"),
+        Some(one.as_str()),
         "`base_dir.join(\".\")` is what a `path: .` config entry anchors to"
     );
     assert_eq!(index_id_for(Path::new("/")), None);
+}
+
+/// The agreement with trusty-review is a call now, not a copied rule.
+#[test]
+fn the_index_id_is_the_shared_derivation() {
+    use std::path::Path;
+
+    for path in ["/src/northwind-web", "/w/repos/local/northwind-web", "/"] {
+        let path = Path::new(path);
+        assert_eq!(
+            index_id_for(path),
+            trusty_common::derive_checkout_index_id(path),
+            "{}",
+            path.display()
+        );
+    }
 }
 
 /// The ids indexed are derived from the paths the renderer reads.
@@ -1608,11 +1626,24 @@ fn index_ids_match_the_manifest_paths_the_renderer_reads() {
     let ids: Vec<Option<String>> = entries.iter().map(|e| index_id_for(&e.path)).collect();
     assert_eq!(
         ids,
-        vec![
-            Some("northwind-web".to_string()),
-            Some("northwind-api".to_string())
-        ],
-        "each id is the basename of the path written into manifest.toml"
+        entries
+            .iter()
+            .map(|e| trusty_common::derive_checkout_index_id(&e.path))
+            .collect::<Vec<_>>(),
+        "each id derives from the path written into manifest.toml, through the \
+         function the renderer calls"
+    );
+    assert!(
+        ids[0]
+            .as_deref()
+            .is_some_and(|id| id.starts_with("northwind-web-")),
+        "{ids:?}"
+    );
+    assert!(
+        ids[1]
+            .as_deref()
+            .is_some_and(|id| id.starts_with("northwind-api-")),
+        "{ids:?}"
     );
 }
 
@@ -1696,12 +1727,13 @@ async fn an_unindexed_repository_is_indexed_before_the_render() {
 
     assert_eq!(outcomes.len(), 1);
     assert_eq!(outcomes[0].status, RepoIndexStatus::Indexed);
-    assert_eq!(outcomes[0].index_id.as_deref(), Some("acme-web"));
+    let id = index_id_for(&dir.path().join("acme-web")).expect("id");
+    assert_eq!(outcomes[0].index_id.as_deref(), Some(id.as_str()));
     let calls = stub_log(&log);
     assert_eq!(calls.len(), 2, "one probe, then one index: {calls:?}");
-    assert_eq!(calls[0], "index-status acme-web");
+    assert_eq!(calls[0], format!("index-status {id}"));
     assert!(
-        calls[1].starts_with("index ") && calls[1].ends_with("--name acme-web"),
+        calls[1].starts_with("index ") && calls[1].ends_with(&format!("--name {id}")),
         "the index is built under the id the renderer looks up: {calls:?}"
     );
     assert!(
@@ -1725,10 +1757,11 @@ async fn an_already_indexed_repository_is_not_reindexed() {
     let outcomes = crate::audit::repo_index::ensure_repositories_indexed_with(stub, &entries).await;
 
     assert_eq!(outcomes[0].status, RepoIndexStatus::AlreadyServed);
+    let id = index_id_for(&dir.path().join("acme-served")).expect("id");
     let calls = stub_log(&log);
     assert_eq!(
         calls,
-        vec!["index-status acme-served".to_string()],
+        vec![format!("index-status {id}")],
         "the probe is the only invocation — no reindex: {calls:?}"
     );
 }

--- a/crates/trusty-gworkspace/Cargo.toml
+++ b/crates/trusty-gworkspace/Cargo.toml
@@ -15,7 +15,7 @@ name = "trusty-gworkspace-mcp"
 path = "src/bin/trusty-gworkspace-mcp.rs"
 
 [dependencies]
-trusty-common = { path = "../trusty-common", version = "0.40" }
+trusty-common = { path = "../trusty-common", version = "0.41" }
 # JSON-RPC / MCP primitives, extracted from `trusty_common::mcp` by ADR-0040 (#5803).
 trusty-mcp = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/trusty-memory/Cargo.toml
+++ b/crates/trusty-memory/Cargo.toml
@@ -82,7 +82,7 @@ path = "src/bin/mcp_bridge.rs"
 # `uds-supervisor` is NOT dropped — trusty-console and trusty-agents still
 # depend on the shared `UdsServiceSupervisor` for trusty-review / trusty-analyze.
 trusty-mcp = { workspace = true }  # JSON-RPC / MCP primitives (ADR-0040, #5803)
-trusty-common = { path = "../trusty-common", version = "0.40", default-features = false, features = ["memory-core", "monitor-tui", "bm25", "cli-help", "update-check", "bug-capture", "console-metrics", "config-cli", "crate-config", "palace-resolve", "codex-config"] }
+trusty-common = { path = "../trusty-common", version = "0.41", default-features = false, features = ["memory-core", "monitor-tui", "bm25", "cli-help", "update-check", "bug-capture", "console-metrics", "config-cli", "crate-config", "palace-resolve", "codex-config"] }
 # `bug-capture` enables Phase 1 ERROR event capture to JSONL + in-memory ring (bug-reporting #478)
 # Why (issue #1318): the `trusty-console` dependency was REMOVED. The console
 # is no longer bundled into trusty-memory (single-owner-per-binary); the
@@ -174,7 +174,7 @@ serial_test = { workspace = true }
 # the production library (mirrors the trusty-mpm and trusty-search pattern).
 # `docgen` (#5205 follow-up): `tests/generated_docs.rs` renders the MCP tool
 # section of README.md from `tool_definitions()`.
-trusty-common = { path = "../trusty-common", version = "0.40", default-features = false, features = ["memory-core", "embedder-test-support", "docgen"] }
+trusty-common = { path = "../trusty-common", version = "0.41", default-features = false, features = ["memory-core", "embedder-test-support", "docgen"] }
 chrono = { workspace = true }
 
 [features]

--- a/crates/trusty-review/Cargo.toml
+++ b/crates/trusty-review/Cargo.toml
@@ -22,7 +22,7 @@ name        = "trusty-review"
 # `#[non_exhaustive]` (the note above covers three OTHER report types), so an
 # external struct literal breaks. For a `0.y.z` crate the breaking bump is the
 # MINOR position.
-version     = "0.22.0"
+version     = "0.22.1"
 edition     = "2024"
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/trusty-review/changelog.d/6149-checkout-index-id.md
+++ b/crates/trusty-review/changelog.d/6149-checkout-index-id.md
@@ -1,0 +1,12 @@
+Fixed
+
+- `report::derive_index_id` now returns the per-checkout id
+  `trusty_common::derive_checkout_index_id` derives (slugified basename plus 8
+  hex digits over the canonical path) rather than the bare basename. The
+  renderer and the audit that indexed the tree run as separate processes sharing
+  only the manifest's checkout path, so both deriving the basename meant a
+  machine holding two checkouts of one repository served whichever registered
+  first — which is how a report presented another tree's complexity as a
+  measurement of the audited one. The out-of-tree component check in
+  `report::analyze_scope` stays as the backstop for an index registered under
+  the old scheme.

--- a/crates/trusty-review/src/report/analyze_adapter.rs
+++ b/crates/trusty-review/src/report/analyze_adapter.rs
@@ -807,15 +807,18 @@ impl AnalyzeMetricsSource for HttpAnalyzeMetricsSource {
 
 /// Derive the trusty-search/analyze index id for a local checkout path.
 ///
-/// Why: trusty-search registers an index under the repo directory's basename
-/// (`trusty-search index .` and the git hooks both derive the id from the
-/// directory name), so the report can address the same index without extra
-/// configuration.
-/// What: returns the final path component as a `String`, or `None` for a
-/// path with no basename (e.g. `/`).
-/// Test: `derive_index_id_uses_basename`.
+/// Why: the renderer must address the SAME index the audit indexed, and the two
+/// run as separate processes with no shared state but the manifest's checkout
+/// path. Until #6149 both derived the repo directory's BASENAME, so a machine
+/// holding two checkouts of one repository served whichever registered first and
+/// the report measured a tree it never audited. Both sides now call
+/// [`trusty_common::derive_checkout_index_id`], which hashes the canonical path
+/// into the id.
+/// What: forwards to that function — `"<slugified basename>-<8 hex>"`, or `None`
+/// for a path with no final component (e.g. `/`).
+/// Test: `derive_index_id_distinguishes_same_named_checkouts`.
 pub fn derive_index_id(path: &Path) -> Option<String> {
-    path.file_name().map(|n| n.to_string_lossy().into_owned())
+    trusty_common::derive_checkout_index_id(path)
 }
 
 // ─── Model enrichment (precedence seam, #2448) ───────────────────────────────

--- a/crates/trusty-review/src/report/analyze_adapter_tests.rs
+++ b/crates/trusty-review/src/report/analyze_adapter_tests.rs
@@ -599,12 +599,34 @@ fn new_trims_trailing_slash() {
     assert_eq!(src.base_url, "http://127.0.0.1:7879");
 }
 
+/// #6149: the renderer and the audit are separate processes agreeing on one id.
+/// Two checkouts of one repository must not derive the same one — that is the
+/// collision that had this crate reading another tree's measurements.
 #[test]
-fn derive_index_id_uses_basename() {
-    assert_eq!(
-        derive_index_id(std::path::Path::new("/home/me/northwind-web")).as_deref(),
-        Some("northwind-web")
-    );
+fn derive_index_id_distinguishes_same_named_checkouts() {
+    let engagement = std::path::Path::new("/w/dogfood/repos/local/northwind-web");
+    let working = std::path::Path::new("/home/me/northwind-web");
+
+    let a = derive_index_id(engagement).expect("id");
+    let b = derive_index_id(working).expect("id");
+    assert_ne!(a, b, "{a} vs {b}");
+    assert!(b.starts_with("northwind-web-"), "still readable: {b}");
+    assert_eq!(derive_index_id(std::path::Path::new("/")), None);
+}
+
+/// The agreement is a call, not a copy: this crate's id IS trusty-common's, so
+/// the audit that indexed under it and this renderer cannot drift.
+#[test]
+fn derive_index_id_is_the_shared_derivation() {
+    for path in ["/home/me/northwind-web", "/w/repos/acme-api", "/"] {
+        let path = std::path::Path::new(path);
+        assert_eq!(
+            derive_index_id(path),
+            trusty_common::derive_checkout_index_id(path),
+            "{}",
+            path.display()
+        );
+    }
 }
 
 #[test]

--- a/crates/trusty-review/src/report/analyze_scope.rs
+++ b/crates/trusty-review/src/report/analyze_scope.rs
@@ -1,15 +1,16 @@
 //! Does the analyze data describe the tree this report audits? (#6137)
 //!
-//! Why: `analyze_adapter::derive_index_id` addresses a trusty-analyze index by
-//! the checkout directory's BASENAME, so two checkouts of the same repository
-//! at different paths — `/Users/x/Projects/trusty-tools` and
-//! `.../repos/local/trusty-tools` — resolve to the same index id. The daemon
-//! answers with whichever one it indexed. That is how one due-diligence run
-//! stamped twenty complexity findings ⁽ᵐ⁾ measured whose component paths all
-//! pointed at a different checkout on a different branch: the report presented
-//! another tree's code as a measurement of the audited one. An out-of-tree path
-//! is stale-index evidence, not measurement, and there is no way to tell from
-//! the data alone which commit it describes.
+//! Why: this is the BACKSTOP for a data-scope question the id derivation cannot
+//! answer. `analyze_adapter::derive_index_id` used to address an index by the
+//! checkout directory's BASENAME, so two checkouts of one repository —
+//! `/Users/x/Projects/trusty-tools` and `.../repos/local/trusty-tools` —
+//! resolved to the same id and the daemon answered with whichever it had
+//! indexed. That is how one due-diligence run stamped twenty complexity findings
+//! ⁽ᵐ⁾ measured whose component paths all pointed at a different checkout on a
+//! different branch. #6149 removed that collision from the id itself, but an
+//! index registered under the OLD scheme, or one whose tree has since moved,
+//! still answers; and an out-of-tree path is stale-index evidence either way,
+//! with no way to tell from the data alone which commit it describes.
 //! What: [`out_of_tree_components`] reports the ABSOLUTE component paths in a
 //! fetched [`AnalyzeMetrics`] that do not live under the audited checkout.
 //! Relative paths are in-tree by construction (they are read against the

--- a/crates/trusty-review/tests/report_analyze_e2e.rs
+++ b/crates/trusty-review/tests/report_analyze_e2e.rs
@@ -21,13 +21,16 @@ use trusty_review::report::{
 
 // ─── In-process analyze mock ─────────────────────────────────────────────────
 
-/// The index id the mock serves; must equal the repo checkout basename so
-/// `derive_index_id` resolves to it.
-const INDEX_ID: &str = "acme-core";
+/// Basename of the fixture checkout.
+///
+/// #6149: this is no longer the index id. The id is derived from the checkout's
+/// CANONICAL PATH, which is inside a per-run tempdir, so the mock is told which
+/// id to serve rather than knowing one at compile time.
+const REPO_DIR: &str = "acme-core";
 
 /// Body for `GET /indexes` — one served index (analyze shape: array of objects).
-fn indexes_body() -> String {
-    format!(r#"[{{"id":"{INDEX_ID}","root_path":null}}]"#)
+fn indexes_body(index_id: &str) -> String {
+    format!(r#"[{{"id":"{index_id}","root_path":null}}]"#)
 }
 
 /// Body for `/complexity_distribution` — the whole-corpus A-F histogram (#5320).
@@ -60,7 +63,7 @@ fn refactor_body() -> String {
 }
 
 /// Route the request path to the right fixture body.
-fn body_for(path: &str) -> String {
+fn body_for(path: &str, index_id: &str) -> String {
     if path.starts_with("/indexes/") && path.contains("/complexity_distribution") {
         distribution_body()
     } else if path.contains("/diagnostics") {
@@ -68,7 +71,7 @@ fn body_for(path: &str) -> String {
     } else if path.contains("/refactor-suggestions") {
         refactor_body()
     } else if path == "/indexes" || path.starts_with("/indexes?") {
-        indexes_body()
+        indexes_body(index_id)
     } else {
         "{}".to_string()
     }
@@ -76,7 +79,7 @@ fn body_for(path: &str) -> String {
 
 /// Spawn a blocking HTTP/1.1 mock serving the analyze endpoints; returns its
 /// base URL. The listener thread runs for the process lifetime (daemonised).
-fn spawn_mock() -> String {
+fn spawn_mock(index_id: String) -> String {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock");
     let addr = listener.local_addr().expect("addr");
     std::thread::spawn(move || {
@@ -92,7 +95,7 @@ fn spawn_mock() -> String {
                 .and_then(|l| l.split_whitespace().nth(1))
                 .unwrap_or("/")
                 .to_string();
-            let body = body_for(&path);
+            let body = body_for(&path, &index_id);
             let resp = format!(
                 "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
                 body.len(),
@@ -111,7 +114,7 @@ fn spawn_mock() -> String {
 /// built-in scan is non-empty and `local_path` resolves. Returns the temp dir
 /// (kept alive) and the manifest path.
 fn write_fixture(dir: &std::path::Path) -> std::path::PathBuf {
-    let repo = dir.join(INDEX_ID);
+    let repo = dir.join(REPO_DIR);
     std::fs::create_dir_all(repo.join("src")).expect("mkdir repo");
     std::fs::write(repo.join("src").join("a.rs"), "fn a() {}\n").expect("write src");
 
@@ -140,9 +143,18 @@ fn write_fixture(dir: &std::path::Path) -> std::path::PathBuf {
 /// Test: this test itself.
 #[tokio::test]
 async fn analyze_populates_complexity_and_findings() {
-    let base_url = spawn_mock();
     let tmp = tempfile::TempDir::new().expect("tempdir");
     let manifest_path = write_fixture(tmp.path());
+    // #6149: the id is derived from the checkout's canonical path, so the mock
+    // is told which index to serve — deriving it here through the same public
+    // function the enrichment calls is also what proves the two agree.
+    let index_id = trusty_review::report::derive_index_id(&tmp.path().join(REPO_DIR))
+        .expect("the fixture checkout has a final path component");
+    assert!(
+        index_id.starts_with("acme-core-"),
+        "readable, and per-checkout: {index_id}"
+    );
+    let base_url = spawn_mock(index_id);
 
     let manifest = load_manifest(&manifest_path).expect("manifest loads");
     let template = TemplateLoader::new()

--- a/scripts/check_semver_selftest.sh
+++ b/scripts/check_semver_selftest.sh
@@ -378,15 +378,41 @@ chmod +x "${STUB_DIR}/cargo"
 # Build the breaking predecessor from the same rule release_type applies:
 # drop the major when there is one, otherwise drop the minor.
 #
+# AN EXCLUDED CRATE CANNOT BE THE STUB (#6149). Every row in
+# semver-checks-crate-exclusions.tsv makes the gate SKIP that crate before it
+# reaches a check, so a stub picked from that list turns each case that asserts
+# on a verdict into "the gate never reached the check — this case proves
+# nothing". That is the #5717 failure recurring through a different door: a
+# trusty-common MINOR bump lands on patch == 0, which drops it from the
+# candidate list by the `z == 0` rule below, and the sorted fallback then picked
+# `tga` — excluded since 2026-08-19. Filtering the exclusions here fixes the
+# class rather than the instance; the alternative, never bumping trusty-common's
+# minor, is not a rule anyone can keep.
+#
 # trusty-common is preferred for continuity with the captured fixtures; any
 # qualifying crate works, and none qualifying is a loud failure rather than a
 # quietly degraded run.
 PICK="$("$REAL_CARGO" metadata --no-deps --format-version 1 2>/dev/null | python3 -c '
 import json, sys
 
+# Same parse the gate applies: tab-separated, `#` comments and blanks skipped,
+# crate name in field 1.
+excluded = set()
+try:
+    with open(sys.argv[1], encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            excluded.add(line.split("\t", 1)[0].strip())
+except OSError:
+    pass
+
 cands = []
 for p in json.load(sys.stdin)["packages"]:
     if p.get("publish") == []:
+        continue
+    if p["name"] in excluded:
         continue
     kinds = {k for t in p["targets"] for k in t["kind"]}
     if not kinds & {"lib", "rlib", "cdylib", "proc-macro"}:
@@ -406,7 +432,7 @@ cands.sort()
 preferred = [c for c in cands if c[0] == "trusty-common"] or cands
 if preferred:
     print(" ".join(preferred[0]))
-')"
+' "${REPO_ROOT}/scripts/semver-checks-crate-exclusions.tsv")"
 # shellcheck disable=SC2086
 set -- $PICK
 STUB_CRATE="${1:-}"


### PR DESCRIPTION
The index id is a cross-process contract three crates derive independently, and
the rule was the checkout basename. Two checkouts of one repository therefore
collided on one id, and trusty-search's registry holds one `root_path` per id —
so the second checkout is served the first one's content.

Tonight's confirmation run hit it end to end: the engagement clone at
`…/dogfood-audit-final/repos/local/trusty-tools` derived `trusty-tools`, the
daemon was already serving `~/Projects/trusty-tools` under that id, the #6140
root-mismatch guard fired correctly, and both grounding legs degraded. The
report then fell back to path-name heuristics AND to trusty-review's own 40-file
default, because the 240-file budget was written only alongside a non-empty
ranking. One failure compounded into two.

## The derivation, and where it lives

`trusty_common::index_id::derive_checkout_index_id` — a new public function in
the crate all three consumers already depend on. `trusty-audit`'s
`index_id_for`, `trusty_review::report::analyze_adapter::derive_index_id` and
`tga::audit::repo_index::index_id_for` are now one-line forwards to it, so the
agreement between them is a call rather than three copies of a rule.

It returns `"<slugified basename>-<8 hex over the canonical path>"` —
`trusty-tools-3fa9c1d2`. Readable enough to recognise in a log line, unique per
content tree.

It is deliberately PURE: a function of the path and nothing else. This workspace
already has `derive_project_index_id`, which partitions on richer inputs, and it
was the obvious candidate to reuse. Two of its three components (`origin`,
`operator`) are live git state resolved per process, and its own module doc
warns that a partial rollout partitions one tree into two indexes. Three
separate processes must agree on this id from the manifest path alone, so a
component that varies with a process's `HOME` would reintroduce exactly the
divergence being fixed. `derive_project_index_id` stays where it is, unwired,
for #4207.

The hash is FNV-1a with a splitmix64 finalizer — `project_index_id`'s existing
helpers, promoted from private to `pub(crate)` rather than reimplemented, so the
crate has one hash. A path that cannot be canonicalised (it does not exist yet)
is normalised through `Path::components` instead, which collapses a trailing
separator, a repeated separator and a `.` component. `tga` anchors a
`path = "."` config entry as `<base>/.`, and that must not derive a second id
for the tree `<base>` already names — the first draft hashed raw bytes and the
tga suite caught it.

## The guard stays, as the backstop

`index::root_matches` and `report::analyze_scope` are no longer the primary
defence, and neither is removed. What is left for them is what a derivation
cannot see: an index registered under the old basename scheme, a directory that
moved after it was indexed, and a daemon whose registry disagrees with this
machine's filesystem.

## The budget is configuration, not evidence

`priority::write_into` wrote `investigate_max_files` / `investigate_max_bytes`
inside the `priorities` non-empty branch. It now writes them whenever a budget
is supplied, before the ranking, so a run whose legs both degraded still
declares the depth it asked for. Pinned by
`a_degraded_grounding_still_declares_the_budget`, which fails against the
pre-fix code.

## Index hygiene — what happens to the per-engagement index

Stated rather than implemented, deliberately. Ids now accumulate per checkout
PATH, so a machine that audits N engagement clones of one repository ends up
with N indexes instead of one contended id. That is the point of the change, and
it is also a real disk cost: this workspace alone is ~105k chunks / 2.1 GB redb.

trusty-audit should NOT delete its index on package or cleanup:

- `crate::rerender` re-renders a delivered package on the recipient's machine
  and reads the index to do it. Deleting at package time turns every re-render
  into a degraded one.
- `ensure_indexed` already distinguishes `IndexStatus::Indexed` from
  `AlreadyServed`, so a future cleanup verb has the information it needs to
  delete only what this run created — a pre-existing index it merely found must
  never be touched.

A cleanup verb, if one is wanted, is its own issue: it needs a retention rule
(after the report is delivered? after the engagement directory is deleted?) that
this change has no basis to pick.

## Gates — rung 4

Cross-crate change to a shared library, so rung 3 on `trusty-common` plus
`check --workspace` and `test -p <consumer>` for each direct dependent.

```
cargo fmt --check                                                   clean
cargo check --workspace --all-targets                               EXIT=0
cargo clippy -p trusty-common -p trusty-audit -p trusty-review -p tga \
  --all-targets -- -D warnings                                      EXIT=0
cargo test -p trusty-common --features unconditional-only           ok. 366 passed; 0 failed; 6 ignored
cargo test -p trusty-audit                                          ok. 684 passed; 0 failed; 5 ignored (+ 6 integration binaries)
cargo test -p trusty-review                                         ok. 1820 passed; 0 failed; 5 ignored (+ 9 integration binaries)
cargo test -p tga                                                   ok. 1341 passed; 0 failed; 7 ignored
bash scripts/check_line_cap.sh                                      0 violations
bash scripts/check_sld.sh                                           0 errors, 0 warnings
bash scripts/check_changelog_fragment.sh                            4 crates recorded
bash scripts/check-pr-version-bump.sh                               4 bumps OK
bash scripts/check_semver.sh --crate trusty-common                  196 checks, 196 pass — no semver update required
```

## Regression tests

| Test | Crate | Proves |
|---|---|---|
| `derive_checkout_index_id_distinguishes_same_named_checkouts` | trusty-common | two checkouts sharing a basename derive different ids, and asserts the basename rule collides for the same pair |
| `derive_checkout_index_id_is_stable_across_calls` | trusty-common | one canonical path, one id, across calls and across spellings |
| `derive_checkout_index_id_normalises_an_uncanonicalisable_path` | trusty-common | `<base>/`, `<base>/.` and `<base>//` derive one id |
| `derive_checkout_index_id_is_pinned_for_a_known_input` | trusty-common | the digest is a wire format; a silent change fails here |
| `the_index_id_is_the_shared_derivation` | trusty-audit, tga | each site's id IS trusty-common's, for the same inputs |
| `derive_index_id_is_the_shared_derivation` | trusty-review | the third site agrees |
| `a_degraded_grounding_still_declares_the_budget` | trusty-audit | gaps and no ranking still writes both budget keys |

`report_analyze_e2e.rs` now derives the mock's served id from the fixture
checkout through the public `derive_index_id`, which makes the end-to-end test
itself a check that the renderer and the indexer agree.

## Versions

`trusty-common` 0.40.1 → 0.41.0 (minor: new public function). Crossed the `0.40`
pins in the root `[workspace.dependencies]` table, `trusty-gworkspace` and
`trusty-memory`. `trusty-audit` 0.8.0 → 0.8.1, `trusty-review` 0.22.0 → 0.22.1,
`tga` 3.3.0 → 3.3.1 — behaviour changes, no public signature moved.

Refs #6149.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
