### PR TITLE
fix(trusty-audit, trusty-review): evidence scores, the budget channel, and the gaps that never fired (Refs #6082)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11298,7 +11298,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-audit"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -11405,7 +11405,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-common"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-audit/Cargo.toml
+++ b/crates/trusty-audit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-audit"
-version = "0.8.2"
+version = "0.9.0"
 description = "Auditor client — installs its pinned audit tooling and drives an audit engagement on the recipient's own codebases."
 readme = "README.md"
 homepage = "https://github.com/bobmatnyc/trusty-tools"

--- a/crates/trusty-audit/changelog.d/6082-evidence-floor-and-budget-channel.md
+++ b/crates/trusty-audit/changelog.d/6082-evidence-floor-and-budget-channel.md
@@ -28,9 +28,3 @@ Fixed
   so on the console, and names `taudit render` as the recovery. That degradation
   previously had no line anywhere: the same run shipped 37 ranked paths beside an
   investigation whose every examined file read "path-name heuristic".
-
-Changed
-
-- `grounding::quality::MIN_EVIDENCE_SCORE` is replaced by `MIN_EVIDENCE_SHARE`,
-  and `is_evidence` takes the floor its query earned as a second argument.
-  `evidence_floor` derives that floor.

--- a/crates/trusty-audit/changelog.d/6082-evidence-floor-and-budget-channel.md
+++ b/crates/trusty-audit/changelog.d/6082-evidence-floor-and-budget-channel.md
@@ -1,0 +1,36 @@
+Fixed
+
+- Evidence discovery scores hits against a share of their own query's best hit
+  instead of an absolute 0.15 floor. `POST /indexes/{id}/search` fuses its lanes
+  with Reciprocal Rank Fusion, so a hit's score is `Σ weight / (60 + rank)` and
+  can never exceed `1/61 ≈ 0.0164` — an order of magnitude below the floor. Every
+  hit of every query was therefore dropped on every run, and the discovery leg
+  produced nothing whatever the index held: the 2026-08-22 dogfood audit searched
+  an 85 840-chunk index and wrote zero search-derived evidence rows. The relative
+  floor drops the same filler beside a strong hit and can no longer empty a
+  result set, because the best hit always clears it.
+- A search leg that matched nothing now states its gap even when the repository
+  has a build manifest. The deterministic `Cargo.toml` enumeration ran before the
+  gap check read the dimension list, so it created a dimension on a run where
+  search answered nothing at all — and the manifest then declared
+  `attributed_only = true`, telling `trusty-review` to decline its path-name
+  top-up over a sample with no search evidence in it. Both the gap line and
+  `attributed_only` are now decided by the search result alone.
+- The investigation budget reaches the renderer through the `tga audit` child's
+  environment as well as through the manifest. `tga audit` renders from the
+  manifest in the same process that wrote it, and this crate's grounding pass
+  edits that file only after the child exits — so the recorded budget reached a
+  re-render and never the sweep's own report. The 2026-08-22 run shipped a
+  manifest declaring `investigate_max_files = 240` over an investigation that
+  recorded `max_files: 40`. An explicit flag and a declared manifest key both
+  still win.
+- A ranking written into a manifest that has already been rendered from now says
+  so on the console, and names `taudit render` as the recovery. That degradation
+  previously had no line anywhere: the same run shipped 37 ranked paths beside an
+  investigation whose every examined file read "path-name heuristic".
+
+Changed
+
+- `grounding::quality::MIN_EVIDENCE_SCORE` is replaced by `MIN_EVIDENCE_SHARE`,
+  and `is_evidence` takes the floor its query earned as a second argument.
+  `evidence_floor` derives that floor.

--- a/crates/trusty-audit/changelog.d/6082-evidence-floor-changed.md
+++ b/crates/trusty-audit/changelog.d/6082-evidence-floor-changed.md
@@ -1,0 +1,5 @@
+Changed
+
+- `grounding::quality::MIN_EVIDENCE_SCORE` is replaced by `MIN_EVIDENCE_SHARE`,
+  and `is_evidence` takes the floor its query earned as a second argument.
+  `evidence_floor` derives that floor from the query's best hit.

--- a/crates/trusty-audit/src/grounding.rs
+++ b/crates/trusty-audit/src/grounding.rs
@@ -274,6 +274,14 @@ pub async fn ground(
             failures: vec![cause],
         },
     };
+    // #6082: judged BEFORE the manifest backfill below, because that backfill
+    // finds `Cargo.toml` in every Rust repository and would therefore create a
+    // dimension on a run where search answered nothing at all. Reading the
+    // backfilled list is how the 2026-08-22 dogfood audit shipped a report whose
+    // every file was a path-name heuristic with no gap line saying so.
+    let mut gaps = discovery_gaps(&discovery, display);
+    let search_answered = !discovery.dimensions.is_empty();
+
     let mut discovery = discovery;
     // #6082: the dependencies dimension is enumerable, not semantic. Search
     // returned three files that MENTION dependencies and no manifest, and the
@@ -283,7 +291,6 @@ pub async fn ground(
         checkout,
         caps.files_per_dimension,
     );
-    let mut gaps = discovery_gaps(&discovery, display);
 
     let hotspots = complexity(tools, &index_id, checkout, display, &mut gaps).await;
     let priorities = evidence::blend(&hotspots, &discovery.dimensions, caps.priority_paths);
@@ -296,9 +303,10 @@ pub async fn ground(
     Grounding {
         index_id: Some(index_id),
         // #6082: the ranking may decline trusty-review's heuristic top-up only
-        // when the search leg actually answered — a complexity-only ranking has
-        // no business suppressing the heuristics that are then all it has.
-        attributed: !discovery.dimensions.is_empty() && !priorities.is_empty(),
+        // when the SEARCH leg actually answered — a complexity-only ranking has
+        // no business suppressing the heuristics that are then all it has, and
+        // neither has a list the manifest enumeration alone put a dimension on.
+        attributed: search_answered && !priorities.is_empty(),
         priorities,
         gaps,
     }
@@ -394,6 +402,9 @@ pub async fn ground_manifest(
     // It writes its own key, after the ranking, so one leg's write failure
     // cannot take the other's data with it.
     let topology_gaps = topology::ground_into(manifest, checkout, display);
+    // #6082: read BEFORE the write, which is what would otherwise make the two
+    // states indistinguishable afterwards.
+    let already_rendered = investigation_exists(manifest);
     if let Err(cause) = priority::write_into(
         manifest,
         checkout,
@@ -419,7 +430,46 @@ pub async fn ground_manifest(
         ));
     }
     grounding.gaps.extend(topology_gaps);
+    if already_rendered && !grounding.priorities.is_empty() {
+        // Returned to the caller and deliberately NOT written into
+        // `[report].gaps`: the manifest now carries the ranking, so a re-render
+        // of this package does use it and the line would be false there.
+        grounding.gaps.push(format!(
+            "{display}: the evidence ranking reached the manifest after the report had already \
+             been rendered from it, so that report's investigation selected files by path name. \
+             Re-render the engagement (`taudit render`) to produce one that reads the {} ranked \
+             path(s).",
+            grounding.priorities.len()
+        ));
+    }
     grounding.gaps
+}
+
+/// Name of the snapshot trusty-review writes beside a manifest it investigated.
+///
+/// Spelled here rather than shared because it is read as EVIDENCE THAT A RENDER
+/// ALREADY HAPPENED, never as an interface — trusty-review owns the file and
+/// this only looks for it. Producer: `trusty_review::report::investigate`.
+const INVESTIGATION_SNAPSHOT: &str = "investigation.json";
+
+/// True when a render has already investigated this manifest.
+///
+/// Why: `tga audit` writes the manifest and runs `trusty-review report` against
+/// it inside ONE process, and `crate::run` grounds that manifest only once the
+/// child has exited — so on the sweep path every ranking this module produces
+/// lands in a file the report was already generated from. That degradation had
+/// no gap line anywhere: the 2026-08-22 dogfood run shipped a manifest declaring
+/// 37 ranked paths beside an `investigation.json` whose every examined file said
+/// "path-name heuristic".
+/// What: whether [`INVESTIGATION_SNAPSHOT`] sits beside `manifest`. False when
+/// the manifest has no parent and false on every path that renders later, which
+/// is the state this is meant to say nothing about.
+/// Test: `super::grounding_tests::a_ranking_that_lands_after_the_render_says_so`,
+/// which drives both states in order.
+fn investigation_exists(manifest: &Path) -> bool {
+    manifest
+        .parent()
+        .is_some_and(|dir| dir.join(INVESTIGATION_SNAPSHOT).is_file())
 }
 
 /// Longest analyst brief the discovery leg derives queries from.

--- a/crates/trusty-audit/src/grounding/evidence.rs
+++ b/crates/trusty-audit/src/grounding/evidence.rs
@@ -510,11 +510,20 @@ pub async fn discover<C: SearchClient>(
 
 /// Merge one query's hits into a dimension's running best-per-file list.
 ///
-/// #6082: a hit below [`quality::MIN_EVIDENCE_SCORE`] never enters the list. A
-/// hybrid search returns its top-N whether or not it found anything, so an
-/// empty-handed query returns filler rows rather than no rows.
+/// #6082: a hit far below its own query's best never enters the list. A hybrid
+/// search returns its top-N whether or not it found anything, so an empty-handed
+/// query returns filler rows rather than no rows. The floor is derived from THIS
+/// query's hits ([`quality::evidence_floor`]) rather than from a constant,
+/// because the score scale is the daemon's to choose and an absolute floor on
+/// the wrong scale rejects everything — which is what it did.
 fn merge(scored: &mut Vec<(f32, FileEvidence)>, hits: &[Hit], query: &str) {
-    for hit in hits.iter().filter(|h| quality::is_evidence(h.score)) {
+    let best = hits
+        .iter()
+        .map(|h| h.score)
+        .filter(|s| s.is_finite())
+        .fold(f32::NEG_INFINITY, f32::max);
+    let floor = quality::evidence_floor(best);
+    for hit in hits.iter().filter(|h| quality::is_evidence(h.score, floor)) {
         if hit.path.is_empty() {
             continue;
         }

--- a/crates/trusty-audit/src/grounding/evidence_tests.rs
+++ b/crates/trusty-audit/src/grounding/evidence_tests.rs
@@ -555,6 +555,62 @@ fn the_query_url_names_the_index() {
     assert_eq!(client.url, "http://127.0.0.1:7878/indexes/acme-api/search");
 }
 
+/// #6082: the whole discovery pass, against the score scale the daemon really
+/// answers on.
+///
+/// Why this is the regression: `POST /indexes/{id}/search` fuses its lanes with
+/// Reciprocal Rank Fusion, so a hit's score is `Σ weight / (60 + rank)` and can
+/// never exceed `1/61 ≈ 0.0164`. The floor this replaced was an absolute `0.15`,
+/// which no hit of any query could ever clear — so `discover` returned an empty
+/// `dimensions` whatever the index held, and every assertion below fails against
+/// that code. The scores are the real head and tail of a `hybrid` response over
+/// the 2026-08-22 dogfood run's 85 840-chunk index.
+#[test]
+fn rrf_scored_hits_still_become_evidence() {
+    let stub = StubSearch::default()
+        .answering(
+            "credential handling",
+            &[
+                ("crates/x/src/api/server/auth.rs", 0.012_94),
+                ("crates/x/src/credentials/authority.rs", 0.009_7),
+            ],
+        )
+        .answering(
+            "shared mutable state",
+            &[("crates/x/src/store/handle.rs", 0.011_2)],
+        );
+
+    let discovery = block_on(discover(&stub, None, Caps::default()));
+
+    assert!(
+        discovery.failures.is_empty(),
+        "nothing failed: {:?}",
+        discovery.failures
+    );
+    let named: Vec<&str> = discovery
+        .dimensions
+        .iter()
+        .map(|d| d.dimension.as_str())
+        .collect();
+    assert_eq!(
+        named,
+        vec!["authentication & secrets", "state management"],
+        "an RRF-scored hit is evidence for the dimension whose query found it"
+    );
+    assert_eq!(
+        discovery.dimensions[0]
+            .files
+            .iter()
+            .map(|f| f.path.as_str())
+            .collect::<Vec<_>>(),
+        vec![
+            "crates/x/src/api/server/auth.rs",
+            "crates/x/src/credentials/authority.rs"
+        ],
+        "both hits clear a floor derived from their own query's best"
+    );
+}
+
 /// A daemon that is not listening is a reason, never a panic.
 #[test]
 fn a_dead_daemon_is_a_reason_not_a_panic() {

--- a/crates/trusty-audit/src/grounding/grounding_tests.rs
+++ b/crates/trusty-audit/src/grounding/grounding_tests.rs
@@ -575,6 +575,124 @@ async fn hotspots_and_search_hits_become_ranked_inspect_priority_in_the_manifest
     );
 }
 
+/// #6082: a search leg that answered nothing still says so when the tree has a
+/// build manifest to backfill the dependencies dimension with.
+///
+/// Why this is the regression: `quality::lead_with_manifests` ran BEFORE
+/// `discovery_gaps` read the dimension list, and it finds `Cargo.toml` in every
+/// Rust repository — so an empty search produced a non-empty `dimensions`, the
+/// "matched no evidence" line never fired, and `attributed` was computed from
+/// the backfilled list and came out TRUE. Against that code both assertions
+/// below fail, and the manifest declares `attributed_only = true` over a sample
+/// that has no search evidence in it at all. That combination shipped on
+/// 2026-08-22: a report whose every examined file said "path-name heuristic",
+/// with nothing in Gaps & Caveats saying why.
+#[cfg(unix)]
+#[tokio::test]
+async fn a_search_that_found_nothing_is_a_gap_even_when_a_manifest_backfills_it() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let checkout = tmp.path().join("repos").join("acme-api");
+    std::fs::create_dir_all(&checkout).expect("mkdir checkout");
+    std::fs::write(checkout.join("Cargo.toml"), "[package]\nname = \"acme\"\n").expect("manifest");
+
+    let t = tools(
+        approving_search(tmp.path()),
+        stub_daemon_with(None, Some(r#"{"results":[]}"#)).await,
+        PathBuf::from("/nonexistent/trusty-analyze"),
+        stub_daemon(Some(EMPTY_HOTSPOTS)).await,
+    );
+    let out = ground(
+        &t,
+        &checkout,
+        "acme-api",
+        None,
+        priority::Budget::from_env(),
+    )
+    .await;
+
+    assert!(
+        !out.priorities.is_empty(),
+        "the enumerated build manifest is still ranked"
+    );
+    assert!(
+        out.gaps
+            .iter()
+            .any(|g| g.contains("matched no evidence for any due-diligence dimension")),
+        "the backfill must not swallow the search leg's silence: {:?}",
+        out.gaps
+    );
+    assert!(
+        !out.attributed,
+        "a dimension the enumeration created is not search-derived evidence, so the ranking may \
+         not decline trusty-review's heuristic top-up"
+    );
+}
+
+/// #6082: a ranking written into a manifest that has already been rendered from
+/// says so, and names the recovery.
+///
+/// Why this is the regression: `tga audit` writes the manifest and runs
+/// `trusty-review report` against it inside one process, and `crate::run`
+/// grounds that manifest only after the child exits. Against the pre-fix code
+/// this degradation had no line anywhere — console, manifest or report — so the
+/// 2026-08-22 run shipped 37 ranked paths beside an investigation that read none
+/// of them and declared no gap.
+#[cfg(unix)]
+#[tokio::test]
+async fn a_ranking_that_lands_after_the_render_says_so() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let checkout = tmp.path().join("repos").join("acme-api");
+    std::fs::create_dir_all(&checkout).expect("mkdir checkout");
+    let manifest = manifest_naming(tmp.path(), &checkout);
+    let payload: &'static str = Box::leak(
+        HOTSPOTS
+            .replace("CHECKOUT", &checkout.display().to_string())
+            .into_boxed_str(),
+    );
+    let stubs = || async {
+        tools(
+            approving_search(tmp.path()),
+            stub_daemon_with(None, Some(SEARCH_HITS)).await,
+            PathBuf::from("/nonexistent/trusty-analyze"),
+            stub_daemon(Some(payload)).await,
+        )
+    };
+
+    // No snapshot beside the manifest: nothing has rendered it yet, and the
+    // ordinary path says nothing.
+    let quiet = ground_manifest(&manifest, &stubs().await, &checkout, "acme-api").await;
+    assert!(
+        !quiet.iter().any(|g| g.contains("already been rendered")),
+        "a manifest nobody has rendered is not a degradation: {quiet:?}"
+    );
+
+    // The snapshot trusty-review writes when it investigates a manifest.
+    std::fs::write(tmp.path().join("investigation.json"), "{}").expect("snapshot");
+    let late = ground_manifest(&manifest, &stubs().await, &checkout, "acme-api").await;
+    let named = late
+        .iter()
+        .find(|g| g.contains("already been rendered"))
+        .unwrap_or_else(|| panic!("the degradation must be named: {late:?}"));
+    assert!(
+        named.contains("taudit render"),
+        "and must name the recovery: {named}"
+    );
+
+    // The line is for the operator only — a re-render DOES read the ranking the
+    // manifest now carries, so stating it there would be false.
+    let written = std::fs::read_to_string(&manifest).expect("read back");
+    let parsed: toml::Value = toml::from_str(&written).expect("still valid TOML");
+    let declared: Vec<&str> = parsed["report"]
+        .get("gaps")
+        .and_then(toml::Value::as_array)
+        .map(|a| a.iter().filter_map(toml::Value::as_str).collect())
+        .unwrap_or_default();
+    assert!(
+        !declared.iter().any(|g| g.contains("already been rendered")),
+        "{written}"
+    );
+}
+
 /// #6082: the brief the manifest declares becomes queries of its own — and a
 /// manifest with no brief is the ordinary case, not a failure.
 #[test]

--- a/crates/trusty-audit/src/grounding/priority.rs
+++ b/crates/trusty-audit/src/grounding/priority.rs
@@ -132,10 +132,13 @@ pub const BYTES_PER_FILE: usize = 10 * 1024;
 pub const DEFAULT_MAX_BYTES: usize = DEFAULT_MAX_FILES * BYTES_PER_FILE;
 
 /// Environment override for [`DEFAULT_MAX_FILES`].
-pub const ENV_MAX_FILES: &str = "TRUSTY_AUDIT_INVESTIGATE_MAX_FILES";
+///
+/// Spelled once in `trusty_common::env_vars` (#6082) because trusty-review reads
+/// the same variable — see [`Budget::child_env`].
+pub const ENV_MAX_FILES: &str = trusty_common::env_vars::ENV_AUDIT_INVESTIGATE_MAX_FILES;
 
 /// Environment override for [`DEFAULT_MAX_BYTES`].
-pub const ENV_MAX_BYTES: &str = "TRUSTY_AUDIT_INVESTIGATE_MAX_BYTES";
+pub const ENV_MAX_BYTES: &str = trusty_common::env_vars::ENV_AUDIT_INVESTIGATE_MAX_BYTES;
 
 impl Budget {
     /// The budget THIS manifest runs under: what it declares, else the machine's.
@@ -173,6 +176,30 @@ impl Budget {
     #[must_use]
     pub fn from_env() -> Self {
         Self::resolve(env_positive(ENV_MAX_FILES), env_positive(ENV_MAX_BYTES))
+    }
+
+    /// This budget as the environment pairs a `tga audit` child passes down.
+    ///
+    /// Why (#6082): the manifest is the interface, and on the sweep path the
+    /// manifest arrives too late. `tga audit` writes the manifest and then, in
+    /// the SAME process, runs `trusty-review report` against it; the audit's
+    /// grounding pass only edits the file once that child has exited. So the
+    /// 240-file budget [`write_into`] records reaches a re-render and never the
+    /// report the sweep itself produces — the 2026-08-22 dogfood run declared
+    /// `investigate_max_files = 240` in its manifest over an investigation whose
+    /// own snapshot recorded `{"max_files": 40}`, trusty-review's bare default.
+    /// The environment reaches the grandchild BEFORE the file does.
+    /// What: both variables, always both, so a raised file budget never meets an
+    /// unraised byte budget (#6148). It is the lowest tier trusty-review
+    /// consults — an explicit `--investigate-max-files` and a manifest key both
+    /// still win — so this adds a floor and overrides nothing.
+    /// Test: `priority_tests::the_child_environment_carries_both_halves`.
+    #[must_use]
+    pub fn child_env(self) -> [(&'static str, String); 2] {
+        [
+            (ENV_MAX_FILES, self.max_files.to_string()),
+            (ENV_MAX_BYTES, self.max_bytes.to_string()),
+        ]
     }
 
     /// [`Budget::from_env`]'s rule, as a pure function.
@@ -715,6 +742,39 @@ path = "/w/repos/acme-web"
         assert_eq!(
             parsed["report"]["investigate_max_bytes"].as_integer(),
             Some(1_200_000)
+        );
+    }
+
+    /// #6082: the budget also travels by environment, because the manifest key
+    /// arrives too late on the sweep path — `tga audit` renders from the
+    /// manifest in the same process that wrote it, and grounding edits that file
+    /// only after the child exits. Both halves go, always: a raised file budget
+    /// against an unraised byte budget reads fewer files than it asked for and
+    /// says nothing (#6148). Fails against the pre-fix code, which had no such
+    /// channel — the 2026-08-22 run declared `investigate_max_files = 240` in a
+    /// manifest whose investigation recorded `max_files: 40`.
+    #[test]
+    fn the_child_environment_carries_both_halves() {
+        let pairs = Budget {
+            max_files: 240,
+            max_bytes: 2_457_600,
+        }
+        .child_env();
+        assert_eq!(
+            pairs,
+            [
+                ("TRUSTY_AUDIT_INVESTIGATE_MAX_FILES", "240".to_owned()),
+                ("TRUSTY_AUDIT_INVESTIGATE_MAX_BYTES", "2457600".to_owned()),
+            ]
+        );
+        assert_eq!(
+            pairs[0].0,
+            trusty_common::env_vars::ENV_AUDIT_INVESTIGATE_MAX_FILES,
+            "trusty-review reads the same constant, so the spelling cannot drift"
+        );
+        assert_eq!(
+            pairs[1].0,
+            trusty_common::env_vars::ENV_AUDIT_INVESTIGATE_MAX_BYTES
         );
     }
 

--- a/crates/trusty-audit/src/grounding/quality.rs
+++ b/crates/trusty-audit/src/grounding/quality.rs
@@ -21,7 +21,7 @@
 //!
 //! | Rule | Effect |
 //! |---|---|
-//! | [`MIN_EVIDENCE_SCORE`] | a hit below it is noise, and is dropped |
+//! | [`MIN_EVIDENCE_SHARE`] | a hit far below its own query's best hit is noise, and is dropped |
 //! | [`demoted_for`] | a test file sorts after every production file, except under "test coverage" |
 //! | [`dependency_manifests`] | the build manifests present in the tree lead the dependencies dimension |
 //!
@@ -31,15 +31,28 @@ use std::path::Path;
 
 use super::evidence::FileEvidence;
 
-/// Relevance below which a hit is a top-N filler row, not evidence.
+/// Share of its own query's best hit below which a hit is a filler row.
 ///
-/// Why 0.15: the promotion this rule exists to stop scored 0.02, and the
-/// genuine hits in the same run scored 0.6–0.9. A floor an order of magnitude
-/// above the observed noise and well below the observed signal drops the filler
-/// without adjudicating between real hits — which is the search lane's job, not
-/// this constant's. It is deliberately not tunable: a per-run knob would turn a
-/// correctness rule into a setting nobody sets.
-pub const MIN_EVIDENCE_SCORE: f32 = 0.15;
+/// Why RELATIVE rather than absolute (#6082): the floor shipped as an absolute
+/// `0.15`, calibrated against a run whose filler scored 0.02 and whose signal
+/// scored 0.6–0.9. The endpoint the discovery leg actually calls does not
+/// produce scores on that scale. `POST /indexes/{id}/search` fuses its lanes
+/// with Reciprocal Rank Fusion — `Σ weight / (60 + rank)` over lane weights that
+/// sum to one — so the highest score any hit can carry is `1/61 ≈ 0.0164`, an
+/// order of magnitude BELOW the floor. Every hit of every query failed it, on
+/// every run, and the discovery leg returned nothing whatever the index held:
+/// the 2026-08-22 dogfood audit read 85 840 indexed chunks and wrote zero
+/// search-derived evidence rows. An absolute constant cannot be right for both
+/// score spaces, and a floor that can reject a whole result set is a floor that
+/// will.
+///
+/// Why 0.5: measured against its own query's best hit, the rule is scale-free —
+/// it drops the 0.02 filler beside a 0.9 hit exactly as the absolute floor did,
+/// and keeps the head of an RRF list. The head is kept by construction: `best`
+/// always clears `best * 0.5`, so no query can be silently emptied by this rule
+/// again. Still deliberately not tunable, for the reason the absolute constant
+/// was not.
+pub const MIN_EVIDENCE_SHARE: f32 = 0.5;
 
 /// The dimension for which a test file IS the evidence.
 pub const TEST_DIMENSION: &str = "test coverage";
@@ -47,13 +60,35 @@ pub const TEST_DIMENSION: &str = "test coverage";
 /// The dimension whose evidence is enumerable rather than searchable.
 pub const DEPENDENCY_DIMENSION: &str = "dependencies";
 
-/// True when this hit is worth ranking at all.
+/// The floor one query's hits are judged against: a share of its own best hit.
+///
+/// Why: see [`MIN_EVIDENCE_SHARE`]. Taking `best` as an argument is what keeps
+/// the rule scale-free, and what makes "this filter emptied the result set"
+/// unreachable rather than merely unlikely.
+/// What: `best * MIN_EVIDENCE_SHARE` for a finite positive best; `0.0` for
+/// anything else, so a query whose scores are all zero, negative or `NaN` is
+/// judged by [`is_evidence`]'s own finiteness check alone rather than by a
+/// floor derived from a number that means nothing.
+/// Test: `super::quality_tests::the_floor_scales_with_the_best_hit`.
+#[must_use]
+pub fn evidence_floor(best: f32) -> f32 {
+    if best.is_finite() && best > 0.0 {
+        best * MIN_EVIDENCE_SHARE
+    } else {
+        0.0
+    }
+}
+
+/// True when this hit is worth ranking, against `floor` for the same query.
 ///
 /// A `NaN` score fails this, which is the safe direction: the daemon should
 /// never send one, and a comparison against `NaN` is false in both directions.
+/// `floor` comes from [`evidence_floor`] over the same query's hits.
+/// Test: `super::quality_tests::{rrf_scale_hits_clear_a_relative_floor,
+/// a_filler_row_beside_a_real_hit_is_dropped}`.
 #[must_use]
-pub fn is_evidence(score: f32) -> bool {
-    score >= MIN_EVIDENCE_SCORE
+pub fn is_evidence(score: f32, floor: f32) -> bool {
+    score.is_finite() && score >= floor
 }
 
 /// True when `path` should sort behind every production file for `dimension`.

--- a/crates/trusty-audit/src/grounding/quality_tests.rs
+++ b/crates/trusty-audit/src/grounding/quality_tests.rs
@@ -8,14 +8,53 @@ use super::*;
 use crate::grounding::evidence::DimensionEvidence;
 
 /// The promotion this floor exists to stop: the auth dimension's HEADLINE
-/// evidence was a call-graph test file at score 0.02.
+/// evidence was a call-graph test file at score 0.02, in a run whose genuine
+/// hits scored 0.6–0.9.
 #[test]
-fn a_noise_score_is_not_evidence() {
-    assert!(!is_evidence(0.02), "the observed noise promotion");
-    assert!(!is_evidence(0.0));
-    assert!(!is_evidence(f32::NAN), "a NaN score is never evidence");
-    assert!(is_evidence(0.62), "a genuine hit from the same run");
-    assert!(is_evidence(MIN_EVIDENCE_SCORE), "the floor itself passes");
+fn a_filler_row_beside_a_real_hit_is_dropped() {
+    let floor = evidence_floor(0.9);
+    assert!(!is_evidence(0.02, floor), "the observed noise promotion");
+    assert!(!is_evidence(0.0, floor));
+    assert!(
+        !is_evidence(f32::NAN, floor),
+        "a NaN score is never evidence"
+    );
+    assert!(is_evidence(0.62, floor), "a genuine hit from the same run");
+    assert!(is_evidence(0.9, floor), "the best hit always survives");
+}
+
+/// #6082: the floor tracks the scale the daemon actually answers on.
+///
+/// `POST /indexes/{id}/search` fuses its lanes with RRF, so no hit can score
+/// above `1/61 ≈ 0.0164`. Against the absolute `0.15` this replaced, every
+/// assertion below fails: the whole result set is rejected and the discovery leg
+/// returns nothing however good the index is.
+#[test]
+fn rrf_scale_hits_clear_a_relative_floor() {
+    // The head and tail of a real `hybrid` response over an 85 840-chunk index.
+    let (best, tail) = (0.012_94_f32, 0.007_8_f32);
+    let floor = evidence_floor(best);
+    assert!(is_evidence(best, floor), "the best RRF hit is evidence");
+    assert!(is_evidence(tail, floor), "so is the head of its tail");
+    assert!(
+        !is_evidence(best * 0.1, floor),
+        "an order-of-magnitude weaker row is still filler"
+    );
+}
+
+/// The floor is a share of the best hit, and never a number the caller must
+/// know the daemon's scale to pick.
+#[test]
+fn the_floor_scales_with_the_best_hit() {
+    assert!((evidence_floor(0.9) - 0.45).abs() < 1e-6);
+    assert!((evidence_floor(0.012_94) - 0.006_47).abs() < 1e-6);
+    for unusable in [0.0, -1.0, f32::NAN, f32::INFINITY] {
+        assert_eq!(
+            evidence_floor(unusable),
+            0.0,
+            "an unusable best yields no floor, never one that rejects everything"
+        );
+    }
 }
 
 /// A test file matches the query that looks for the thing it tests, so without

--- a/crates/trusty-audit/src/run/child.rs
+++ b/crates/trusty-audit/src/run/child.rs
@@ -141,6 +141,15 @@ pub(super) async fn spawn_tga(
     if let Some((name, value)) = github_access.env() {
         command.env(name, value);
     }
+    // #6082: the investigation budget, down the one channel that reaches the
+    // grandchild in time. `tga audit` writes the manifest and runs
+    // `trusty-review report` against it in the same process, and this crate's
+    // grounding pass edits that manifest only after the child exits — so the
+    // budget it records there reaches a re-render and never this run's report.
+    // See `grounding::priority::Budget::child_env`.
+    for (name, value) in crate::grounding::priority::Budget::from_env().child_env() {
+        command.env(name, value);
+    }
 
     let spawned = command.spawn();
 

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "trusty-common"
 # 0.40.0 (#5809): the MCP extraction (ADR-0040 Phase 1) removed the public
 # `src/mcp/*` modules. Cargo's 0.x rule makes that a MINOR bump, not a patch.
-version = "0.41.0"
+version = "0.41.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/trusty-common/changelog.d/6082-audit-investigation-budget-env-names.md
+++ b/crates/trusty-common/changelog.d/6082-audit-investigation-budget-env-names.md
@@ -1,0 +1,6 @@
+Added
+
+- `env_vars::ENV_AUDIT_INVESTIGATE_MAX_FILES` and
+  `ENV_AUDIT_INVESTIGATE_MAX_BYTES`. `trusty-audit` writes these variables into
+  the `tga audit` child's environment and `trusty-review` reads them, so the two
+  spellings have to agree and neither crate may hold a literal of its own.

--- a/crates/trusty-common/src/env_vars.rs
+++ b/crates/trusty-common/src/env_vars.rs
@@ -27,6 +27,30 @@ pub const ENV_OPENROUTER_API_KEY: &str = "OPENROUTER_API_KEY";
 /// Test: `env_var_names_are_stable`.
 pub const ENV_GITHUB_TOKEN: &str = "GITHUB_TOKEN";
 
+/// Investigation file budget an audit asks its renderer for
+/// (`TRUSTY_AUDIT_INVESTIGATE_MAX_FILES`).
+///
+/// Why (#6082): `trusty-audit` writes this budget into the manifest, but on the
+/// sweep path the manifest edit lands after the `tga audit` child has already
+/// run `trusty-review report` — so the renderer read its own 40-file default and
+/// the audit's 240 never arrived. The environment reaches the grandchild before
+/// the file does, so the same number travels both ways and the two spellings
+/// have to agree; a literal in each crate is the drift this module exists to
+/// stop.
+/// What: the exact env-var name; pass to `std::env::var`. Read by
+/// `trusty_audit::grounding::priority::Budget` and by `trusty-review`'s
+/// `resolve_budget`, in both cases BELOW an explicit flag and below the
+/// manifest key.
+/// Test: `env_var_names_are_stable`.
+pub const ENV_AUDIT_INVESTIGATE_MAX_FILES: &str = "TRUSTY_AUDIT_INVESTIGATE_MAX_FILES";
+
+/// Investigation byte budget an audit asks its renderer for
+/// (`TRUSTY_AUDIT_INVESTIGATE_MAX_BYTES`).
+///
+/// Why/What/Test: the byte half of [`ENV_AUDIT_INVESTIGATE_MAX_FILES`], resolved
+/// under the same precedence.
+pub const ENV_AUDIT_INVESTIGATE_MAX_BYTES: &str = "TRUSTY_AUDIT_INVESTIGATE_MAX_BYTES";
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -37,5 +61,13 @@ mod tests {
     fn env_var_names_are_stable() {
         assert_eq!(ENV_OPENROUTER_API_KEY, "OPENROUTER_API_KEY");
         assert_eq!(ENV_GITHUB_TOKEN, "GITHUB_TOKEN");
+        assert_eq!(
+            ENV_AUDIT_INVESTIGATE_MAX_FILES,
+            "TRUSTY_AUDIT_INVESTIGATE_MAX_FILES"
+        );
+        assert_eq!(
+            ENV_AUDIT_INVESTIGATE_MAX_BYTES,
+            "TRUSTY_AUDIT_INVESTIGATE_MAX_BYTES"
+        );
     }
 }

--- a/crates/trusty-review/changelog.d/6082-investigation-budget-from-environment.md
+++ b/crates/trusty-review/changelog.d/6082-investigation-budget-from-environment.md
@@ -1,0 +1,10 @@
+Fixed
+
+- `report` reads `TRUSTY_AUDIT_INVESTIGATE_MAX_FILES` and
+  `TRUSTY_AUDIT_INVESTIGATE_MAX_BYTES` as the tier below the manifest's
+  `[report].investigate_max_*` keys. `trusty-audit` records the budget it wants in
+  the manifest, but `tga audit` has already run this binary against that manifest
+  by the time the key is written — so an audit declaring 240 files rendered its
+  report under this crate's 40-file default and said nothing. An explicit
+  `--investigate-max-files` and a declared manifest key both still win; a
+  non-numeric, zero or negative variable reads as absent.

--- a/crates/trusty-review/src/cli_report.rs
+++ b/crates/trusty-review/src/cli_report.rs
@@ -438,20 +438,66 @@ fn target_snapshots(model: &ReportModel) -> Vec<CorpusSnapshot> {
 /// Why: the wave-3 investigation caps how much of a repo is sent to the LLM;
 /// operators tune it via a CLI flag or a manifest key, falling back to sane
 /// defaults, in one place so both budget dimensions resolve consistently.
-/// What: CLI flag > manifest `[report].investigate_max_*` > [`Budget::default`].
-/// Test: `tests::report_args_parse_investigate_budget`.
+///
+/// #6082 adds the environment tier, BELOW both. `trusty-audit` writes the budget
+/// it wants into `[report]`, but on the sweep path that write lands after the
+/// `tga audit` child has already run this binary — so the key was in the shipped
+/// manifest and never in the run that produced the report, and the investigation
+/// silently used the 40-file default over a manifest declaring 240. The
+/// environment crosses both process boundaries before the file does. It is the
+/// lowest tier because an operator's flag and an operator's manifest key are
+/// both explicit and this is not.
+///
+/// What: CLI flag > manifest `[report].investigate_max_*` >
+/// `TRUSTY_AUDIT_INVESTIGATE_MAX_*` > [`Budget::default`]. A non-numeric, zero
+/// or negative variable reads as absent rather than disabling the
+/// investigation.
+/// Test: `tests::{report_args_parse_investigate_budget,
+/// the_environment_budget_is_read_below_the_manifest}`.
 fn resolve_budget(args: &ReportArgs, manifest: &Manifest) -> Budget {
+    resolve_budget_from(
+        args,
+        manifest,
+        env_budget(trusty_common::env_vars::ENV_AUDIT_INVESTIGATE_MAX_FILES),
+        env_budget(trusty_common::env_vars::ENV_AUDIT_INVESTIGATE_MAX_BYTES),
+    )
+}
+
+/// [`resolve_budget`]'s precedence rule, over values already read.
+///
+/// Why: taking the environment tier as a parameter is what lets the precedence
+/// be tested without `std::env::set_var`, which is `unsafe` in edition 2024 and
+/// unsound under the parallel test harness.
+/// Test: `tests::the_environment_budget_is_read_below_the_manifest`.
+fn resolve_budget_from(
+    args: &ReportArgs,
+    manifest: &Manifest,
+    env_files: Option<usize>,
+    env_bytes: Option<usize>,
+) -> Budget {
     let default = Budget::default();
     Budget {
         max_files: args
             .investigate_max_files
             .or(manifest.report.investigate_max_files)
+            .or(env_files)
             .unwrap_or(default.max_files),
         max_bytes: args
             .investigate_max_bytes
             .or(manifest.report.investigate_max_bytes)
+            .or(env_bytes)
             .unwrap_or(default.max_bytes),
     }
+}
+
+/// A positive integer from `name`, or `None` for absent/unusable.
+fn env_budget(name: &str) -> Option<usize> {
+    std::env::var(name)
+        .ok()?
+        .trim()
+        .parse::<usize>()
+        .ok()
+        .filter(|n| *n > 0)
 }
 
 /// Fail before any work when the required inference credential is absent.
@@ -751,6 +797,46 @@ mod tests {
         assert_eq!(
             budget.max_bytes, 1024,
             "manifest key fills the unset CLI flag"
+        );
+    }
+
+    /// #6082: the environment is the tier below the manifest, and it is what
+    /// carries an audit's budget across the two process boundaries in time.
+    ///
+    /// Why this is the regression: `trusty-audit` records the budget in
+    /// `[report]`, but on the sweep path `tga audit` has already run this binary
+    /// against that manifest by the time the key is written — so the shipped
+    /// manifest declared `investigate_max_files = 240` while the investigation
+    /// that produced the report recorded `{"max_files": 40}`, this crate's bare
+    /// default. Against the pre-fix `resolve_budget`, which had no environment
+    /// tier at all, the first assertion below reads 40 and fails.
+    #[test]
+    fn the_environment_budget_is_read_below_the_manifest() {
+        let args = ReportArgs::try_parse_from(["report", "--manifest", "m.toml", "--synthesize"])
+            .expect("parse");
+        let bare = load_manifest_from_str(
+            "[report]\ntitle = \"T\"\n\n[[repositories]]\nname = \"A\"\npath = \"/x\"\n",
+        );
+
+        let from_env = resolve_budget_from(&args, &bare, Some(240), Some(2_457_600));
+        assert_eq!(from_env.max_files, 240, "the audit's budget arrives");
+        assert_eq!(from_env.max_bytes, 2_457_600);
+
+        let declared = load_manifest_from_str(
+            "[report]\ntitle = \"T\"\ninvestigate_max_files = 3\n\n[[repositories]]\nname = \"A\"\npath = \"/x\"\n",
+        );
+        let mixed = resolve_budget_from(&args, &declared, Some(240), Some(2_457_600));
+        assert_eq!(mixed.max_files, 3, "an operator's manifest key still wins");
+        assert_eq!(
+            mixed.max_bytes, 2_457_600,
+            "and the environment fills only what the manifest left unset"
+        );
+
+        let none = resolve_budget_from(&args, &bare, None, None);
+        assert_eq!(
+            none.max_files,
+            Budget::default().max_files,
+            "no manifest key and no variable is still the default"
         );
     }
 


### PR DESCRIPTION
The 2026-08-22 hands-off audit (`/Users/masa/dogfood-audit-rerun3`, published
trusty-audit 0.8.1 + trusty-review 0.22.1) silently degraded its grounding.
Three independent causes, each fixed here.

## 1. Zero evidence rows: the score floor was unsatisfiable

`grounding::quality::MIN_EVIDENCE_SCORE` was an absolute `0.15`
(`crates/trusty-audit/src/grounding/quality.rs:42`, pre-fix), applied in
`evidence::merge` (`evidence.rs:516`). The endpoint the discovery leg calls,
`POST /indexes/{id}/search`, fuses its lanes with Reciprocal Rank Fusion —
`Σ weight / (60 + rank)` over lane weights that sum to one
(`crates/trusty-search/src/core/search/rrf.rs:14,38-45`) — so the highest score
any hit can carry is `1/61 ≈ 0.0164`.

Replayed against the run's own index, live:

```
POST /indexes/trusty-tools-56d1273b/search  "credential handling: api key, …"
n=48   max score 0.01293995976448059
0.0129 hybrid crates/trusty-audit/src/session.rs
0.0129 hybrid crates/trusty-audit/src/cli/credential.rs
0.0117 hybrid crates/trusty-audit/src/session.rs
```

Every hit of every query failed the floor, on every run, over an index holding
85 840 chunks with `vector` and `kg` both `ready`. The only rows that survived
into `inspect_priority` were the deterministic `quality::dependency_manifests`
enumeration and the trusty-analyze hotspots — which is exactly what the shipped
manifest contains: 25 hotspot rows and 12 `dimension = "dependencies"` rows
reading "build manifest present in the repository", and nothing else.

The floor is now a share of each query's own best hit
(`quality::evidence_floor` / `quality::MIN_EVIDENCE_SHARE`). Scale-free: it
drops the 0.02 filler beside a 0.9 hit exactly as the absolute floor did, and
the best hit always clears it, so this rule can no longer empty a result set.

## 2. The budget keys never reached the investigation

The key names match on both sides — `[report].investigate_max_files` /
`investigate_max_bytes`, written by `grounding::priority::record_budget`
(`priority.rs:315-334`) and parsed by
`trusty_review::report::manifest::ReportSection` (`manifest.rs:156,161`). The
problem is ordering.

`crates/trusty-audit/src/run.rs:620` spawns `tga audit`, and `tga audit` writes
the manifest and then runs `trusty-review report` against it **in the same
process** (`crates/trusty-git-analytics/src/commands/audit.rs:293-300`).
`run.rs:663` calls `grounding::ground_manifest` only after that child exits. So
everything grounding writes — the budget, `inspect_priority`, `attributed_only`
— lands in a file the report was already generated from.

The artifact mtimes are the proof:

```
07:26:43  investigation.json     ← trusty-review's investigation
07:28:10  …-technical-due-diligence.md
07:28:18  manifest.toml          ← trusty-audit's grounding write
```

and the two files disagree accordingly: the manifest declares
`investigate_max_files = 240`, `attributed_only = true`, 37 ranked paths; the
investigation records `"budget": {"max_files": 40, "max_bytes": 409600}`,
`"attributed_files": 0`, and `"(path-name heuristic)"` on every examined file.

Fixing the ordering needs `tga` to defer its own render, which is a third crate
and a `tga` release — see "Not fixed here" below. What this PR does fix is the
budget, by giving it a channel that crosses both process boundaries in time:
`trusty-audit` puts the resolved budget in the `tga audit` child's environment
(`run/child.rs`, `priority::Budget::child_env`) and `trusty-review` reads it as
the tier below the manifest key (`cli_report::resolve_budget`). An explicit
`--investigate-max-files` and a declared manifest key both still win. The two
variable names live in `trusty_common::env_vars` so the crates cannot drift.

## 3. No gap line

Two separate silences.

`quality::lead_with_manifests` ran at `grounding.rs:281-285`, **before**
`discovery_gaps` read the dimension list at `:286`. It finds `Cargo.toml` in
every Rust repository, so it created a `dependencies` dimension on a run where
search answered nothing at all — and `discovery_gaps` (`:356`) only fires on an
empty list. The same post-backfill list fed `attributed` at `:301`, so the
manifest declared `attributed_only = true` over a sample containing no search
evidence, telling trusty-review to decline the heuristic top-up that was all it
had. Both are now decided by the search result alone, read before the backfill.

The ordering degradation of §2 had no line anywhere. `ground_manifest` now
detects it (a `investigation.json` already sitting beside the manifest means a
render has consumed it) and returns a gap naming `taudit render` as the
recovery. It goes to the console and deliberately not into `[report].gaps`,
because the manifest now carries the ranking and a re-render does read it.

## Failing-before tests

Each was run against a reverted copy of its own production fix; all four
reverts produce `cargo exit = 101`.

| Branch fixed | Test | Fails before because |
|---|---|---|
| Relative evidence floor | `grounding::quality::quality_tests::rrf_scale_hits_clear_a_relative_floor` | no RRF-scale score clears `0.15` |
| Relative evidence floor | `grounding::quality::quality_tests::the_floor_scales_with_the_best_hit` | the floor is a constant, not a share |
| Relative evidence floor (end to end) | `grounding::evidence::evidence_tests::rrf_scored_hits_still_become_evidence` | `discover` returns an empty `dimensions` |
| Gap masked by the manifest backfill | `grounding::grounding_tests::a_search_that_found_nothing_is_a_gap_even_when_a_manifest_backfills_it` | no "matched no evidence" gap, and `attributed` is `true` |
| Ranking landing after the render | `grounding::grounding_tests::a_ranking_that_lands_after_the_render_says_so` | no gap is produced at all |
| Budget on the child environment | `grounding::priority::priority_tests::the_child_environment_carries_both_halves` | `Budget::child_env` does not exist |
| Budget read by the renderer | `cli_report::tests::the_environment_budget_is_read_below_the_manifest` | reads 40, the bare default |

## Not fixed here

The ordering itself. `tga audit` renders inside the process that writes the
manifest, so `inspect_priority` and `attributed_only` still reach only a
re-render, and the sweep's own report still selects by path name — now with a
gap line saying so and naming the recovery. Closing it needs `tga` to gain a
"write the manifest, do not render" mode and `trusty-audit` to own the render
after grounding, plus a `tga` release, since the engagement installs pinned
tools from crates.io. That is its own PR.

## Gates

Rung 4 (`trusty-common` gained two public constants; `trusty-audit` and
`trusty-review` both consume them).

```
cargo fmt --check                                                    EXIT=0
cargo clippy -p trusty-audit -p trusty-review --all-targets -- -D warnings   EXIT=0
cargo test -p trusty-audit -p trusty-review                          EXIT=0
    trusty-audit  lib: 708 passed; 0 failed; 5 ignored
    trusty-review lib: 1837 passed; 0 failed; 5 ignored
    trusty-review bin: 77 passed; 0 failed
cargo check --workspace                                              EXIT=0
cargo test -p trusty-common --features unconditional-only env_var    EXIT=0
    env_vars::tests::env_var_names_are_stable ... ok
bash scripts/check_test_pointers.sh    26441 citations, 0 dangling — OK
bash scripts/check_line_cap.sh         4145 files, 0 violations — OK
bash scripts/check_changelog_fragment.sh                             EXIT=0
PR_VERSION_BUMP_BASE=origin/main bash scripts/check-pr-version-bump.sh EXIT=0
```

Versions:

- `trusty-audit` 0.8.2 → **0.9.0**. `grounding::quality::is_evidence` gains a
  parameter and `MIN_EVIDENCE_SCORE` is gone; `cargo-semver-checks` reports both
  against the live 0.8.1 baseline, and for a 0.x crate the breaking bump is the
  MINOR position. Taken here rather than at release because publish follows this
  merge immediately and preflight CHECK 5 is an absolute stop.
- `trusty-common` 0.41.0 → **0.41.1**. Additive only, and 0.41.0 is live, so the
  gate requires the bump.
- `trusty-review` 0.23.0, riding #6156's bump unchanged.

```
bash scripts/check_semver.sh --crate trusty-audit                    EXIT=0
    function_parameter_count_changed: is_evidence now takes 2 parameters
    pub_module_level_const_missing:   MIN_EVIDENCE_SCORE
    INVENTORY trusty-audit: breaking change(s) listed above — permitted by the
    major bump.
```

Both listed breaks are the two intended by this PR; there is no third.

`Cargo.lock` carries those two version entries and nothing else. A bare
`cargo check` additionally re-resolved `num_enum_derive`'s `proc-macro-crate`
from 2.0.0 to 1.3.1 — unrelated drift, reverted rather than smuggled in.

Refs #6082
