### PR TITLE
fix(trusty-review): escape backticks in a doc code span, not with backslash

### DIFF
--- a/crates/trusty-review/changelog.d/6172-rustdoc-entry-link-escape.md
+++ b/crates/trusty-review/changelog.d/6172-rustdoc-entry-link-escape.md
@@ -1,0 +1,3 @@
+Fixed
+
+- A doc comment on `parse_entry_node` in `trace_client.rs` tried to escape backticks inside a markdown code span with `\``, but backslash does not escape inside a CommonMark code span — the span closed early and `[ENTRY]` fell outside it, where rustdoc read it as an unresolved intra-doc link. The span now uses a longer backtick-run delimiter (` `` ` instead of `` ` ``) so the inner backticks need no escaping. Caught by the pre-publish rustdoc broken-link gate ahead of the 0.24.0 release.

--- a/crates/trusty-review/src/report/investigate/trace_client.rs
+++ b/crates/trusty-review/src/report/investigate/trace_client.rs
@@ -326,7 +326,7 @@ fn bound(s: &str, max: usize) -> String {
 ///
 /// Why: the endpoint answers `text/plain`, so this is the parse. Only the entry
 /// node is read — see [`CallChainEntry`] for why the edges below it are dropped.
-/// What: finds the `## \`<symbol>\` [ENTRY]  <file>:<line>` header and the
+/// What: finds the ``## `<symbol>` [ENTRY]  <file>:<line>`` header and the
 /// `Signature:` line under it. `None` when no entry header is present, which the
 /// caller treats as the symbol being absent.
 /// Test: `trace_client_tests::{the_entry_node_parses_out_of_a_call_chain_report,


### PR DESCRIPTION
## Summary
- `parse_entry_node`'s doc comment on `trace_client.rs:329` tried to keep `[ENTRY]` inside a code span by escaping its flanking backticks with `\``. Backslash does not escape inside a CommonMark code span, so the span closed one backtick early and `[ENTRY]` fell outside it — rustdoc read it as an unresolved intra-doc link.
- Fix: use a longer backtick-run delimiter (` `` `) so the inner single backticks around `<symbol>` need no escaping. Verified `bash scripts/check_rustdoc_links.sh` now reports 0 broken links (was 1, unbaselined, blocking the pre-publish gate).

Found while running the pre-publish gate ahead of the trusty-review 0.24.0 / trusty-search 0.49.0 release (tags already pushed at the pre-fix tip; will be re-pointed at the merge commit once this lands).

## Test plan
- Rung 1 (doc/comment-only change to a single doc comment): `bash scripts/check_rustdoc_links.sh` → `0 broken link(s)` (was 1)
- `cargo fmt --check` → clean
- `cargo clippy -p trusty-review --all-targets -- -D warnings` → clean

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools