### PR TITLE
chore(trusty-search): re-bump to 0.49.1 — 0.49.0's tag is burned

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11827,7 +11827,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-search"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -3,7 +3,13 @@ name = "trusty-search"
 # #4421: patch bump — 0.47.0 already published on crates.io and this PR
 # touches src/**. Every hunk is a doc-comment edit (module docs moved to the
 # inner `//!` standard, #5754) — no item signature or behavior changed.
-version = "0.49.0"
+# Re-bump to 0.49.1: the trusty-search-v0.49.0 tag was pushed against the
+# pre-#6174 tip (which still had trusty-review's broken rustdoc link, failing
+# the workspace-wide pre-publish gate) and this repo's tag-protection ruleset
+# forbids moving or deleting a pushed tag — so 0.49.0/its tag are a burned,
+# never-published marker and this release ships as 0.49.1 instead. No src
+# change beyond this version bump.
+version = "0.49.1"
 edition = "2021"
 description = "Machine-wide hybrid code search service: BM25 + vector + KG, zero cold-start, MCP server"
 readme = "README.md"


### PR DESCRIPTION
## Summary
- `trusty-search-v0.49.0` was tagged and pushed against the pre-#6174 tip (`4af0ef8ee`), which still carried trusty-review's broken rustdoc intra-doc link — so the workspace-wide pre-publish gate could never go green for a publish gated at that tag.
- This repo's tag-protection ruleset rejects both `git push --force` (re-point) and tag deletion on an existing tag (`GH013: Repository rule violations`), confirmed against both the git-push and REST `DELETE /git/refs/tags/...` paths. The 0.49.0 tag cannot be moved to the post-#6174 tip.
- Version-only bump, `0.49.0` → `0.49.1`, no source change. `trusty-search-v0.49.0` and its tag stay as a burned, never-published marker.

## Test plan
- `PR_VERSION_BUMP_BASE=origin/main bash scripts/check-pr-version-bump.sh` → `[ OK ] 2 changed path(s) examined; none under crates/<crate>/src/**`
- `bash scripts/check_changelog_fragment.sh` → `no crate source changed (docs-only / CI-only / test-only) — OK` (no fragment owed)
- `cargo check -p trusty-search` → clean (Cargo.lock version bump only)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools