### PR TITLE
fix(trusty-review): an unplaceable narrative is disclosed, and investigation prose takes the guard (Refs #6082)

### DIFF
--- a/crates/trusty-review/changelog.d/6082-lap6-acceptance-fixes.md
+++ b/crates/trusty-review/changelog.d/6082-lap6-acceptance-fixes.md
@@ -1,0 +1,17 @@
+Fixed
+
+- A component carrying whitespace or parentheses is read as a topic phrase, not
+  a file. `trusty-common (memory_core/store)` slipped through as a path because
+  its parenthesised half carries a slash, and the narrative citing it rendered as
+  a numbered AMBER finding whose entire evidence was the file's own path. (Refs
+  #6082)
+- A synthesis narrative the finding bands refuse is now recorded under Synthesis
+  Status with the component that matched nothing, instead of disappearing without
+  a line. (Refs #6082)
+- The reachability guard now runs over the verified investigation's own prose,
+  before that prose is copied onto the model and merged over the synthesis
+  narrative. A RED finding's business impact reached the page stating "a remote
+  code execution risk" about a loopback-bound daemon because only the synthesis
+  copy was guarded and the merge discarded it. (Refs #6082)
+- A finding whose own text says "local-socket" or "unix socket" is read as
+  loopback-scoped, the same as one that says "localhost". (Refs #6082)

--- a/crates/trusty-review/src/cli_report.rs
+++ b/crates/trusty-review/src/cli_report.rs
@@ -28,6 +28,7 @@ use trusty_review::report::{
     parse_section_instructions, run_investigation,
     synthesize::Synthesis,
     synthesize::Synthesizer,
+    synthesize::ground_investigation_prose,
     template::DEFAULT_TEMPLATE,
 };
 
@@ -667,7 +668,7 @@ async fn run_synthesis(
     // here (unlike the reviewer's): the pass fails closed, recording every traced
     // finding as unverifiable, which is a stated gap rather than a lost render.
     let verifier = build_verdict_verifier(config).await;
-    if let Some(inv) = run_investigation(
+    if let Some(mut inv) = run_investigation(
         provider.clone(),
         &role.model,
         verifier.as_ref(),
@@ -686,6 +687,14 @@ async fn run_synthesis(
         // landed a failure discarded the whole investigation — minutes of real
         // LLM spend, unrecoverable.
         persist_investigation(out_dir, &inv);
+        // #6082 lap 6: guard the investigation's own prose BEFORE it is copied
+        // anywhere. `merge_investigation_prose` below overwrites the guarded
+        // synthesis prose with this text, so guarding only the synthesis half
+        // left the rendered finding stating the claim the guard had rejected.
+        // Correcting here reaches every copy: the injected `metrics.findings`
+        // rows, `model.investigation` in the JSON twin, the synthesis prompt,
+        // and the merged prose.
+        let inv_notes = ground_investigation_prose(model, &mut inv);
         apply_investigation(model, &inv);
         // #6009: capture the raw response next to the report output on an
         // unparseable-response failure, so a future occurrence is diagnosable
@@ -695,6 +704,7 @@ async fn run_synthesis(
             .with_raw_capture_dir(out_dir)
             .synthesize(model)
             .await?;
+        synthesis.notes.extend(inv_notes);
         merge_investigation_prose(&mut synthesis, &inv);
         Ok(synthesis)
     } else {

--- a/crates/trusty-review/src/report/reporter.rs
+++ b/crates/trusty-review/src/report/reporter.rs
@@ -29,7 +29,7 @@ use super::reporter_facts::fill_key_facts;
 use super::reporter_fill::{
     crate_version, fill_profile, instructions_block, set_executive_summary, set_scoring_model,
 };
-use super::reporter_findings::push_finding_band;
+use super::reporter_findings::{push_finding_band, unplaced_narrative_lines};
 use super::reporter_graph_datasets::{
     inject_complexity_distribution_dataset, inject_loc_by_technology_dataset,
 };
@@ -607,16 +607,22 @@ fn green_topic_line(finding: &super::metrics::MetricFinding) -> String {
 /// Why: a reader must never mistake a deterministically-composed section for one
 /// the model wrote; the note names every field the numeric guardrail rejected.
 /// What: when `model.synthesis` is present, appends a status block whose lines
-/// come from `Synthesis::status_lines`.  The absent branch survives only for
+/// come from `Synthesis::status_lines`, followed by one line per narrative the
+/// finding bands could not place (#6082 lap 6, see
+/// [`unplaced_narrative_lines`]).  The absent branch survives only for
 /// [`Reporter::render`], which stays infallible for unit tests —
 /// [`Reporter::write`] rejects a synthesis-free model outright (#5454).
-/// Test: `reporter_tests.rs::reporter_appends_guardrail_rejection_note`.
+/// Test: `reporter_tests.rs::{reporter_appends_guardrail_rejection_note,
+/// an_unmeasured_orphan_narrative_is_not_numbered}`.
 fn append_synthesis_note(out: &mut String, model: &ReportModel) {
     let Some(syn) = &model.synthesis else {
         return;
     };
     out.push_str("\n\n## Synthesis Status\n\n");
     for line in syn.status_lines() {
+        out.push_str(&format!("- {line}\n"));
+    }
+    for line in unplaced_narrative_lines(model) {
         out.push_str(&format!("- {line}\n"));
     }
 }

--- a/crates/trusty-review/src/report/reporter_findings.rs
+++ b/crates/trusty-review/src/report/reporter_findings.rs
@@ -279,10 +279,23 @@ fn normalized_path(component: &str) -> String {
 /// A path separator or a file extension is enough — `Cargo.toml` and `deny.toml`
 /// are real root-level citations with neither a directory nor a line number, and
 /// must not be mistaken for prose.
+///
+/// #6082 lap 6: interior whitespace or a parenthesis disqualifies it first. A
+/// tracked path has neither, and the graded report's AMBER #156 cited
+/// `trusty-common (memory_core/store)` — a topic phrase that slipped through
+/// because the parenthesised half carries a slash. That one row was the whole
+/// difference between the 155 AMBER findings the metrics measured and the 156
+/// the render numbered.
 fn names_a_file(component: &str) -> bool {
     let path = component.rsplit_once(':').map_or(component, |(p, _)| p);
     let path = path.trim();
     if path.is_empty() {
+        return false;
+    }
+    if path
+        .chars()
+        .any(|c| c.is_whitespace() || c == '(' || c == ')')
+    {
         return false;
     }
     path.contains('/')
@@ -481,6 +494,49 @@ pub(super) fn push_finding_band(
     finding_block: &str,
     index: &mut usize,
 ) {
+    let (rows, _) = band_rows(repo, syn, band, band_label);
+    if rows.is_empty() {
+        return;
+    }
+
+    let mut app_scope = Scope::new();
+    app_scope.set("app_name", repo.name.clone());
+    for row in rows {
+        *index += 1;
+        app_scope.push_block(finding_block, row.into_scope(*index));
+    }
+    root.push_block(app_block, app_scope);
+}
+
+/// The status-note prefix every unrendered narrative is disclosed under.
+///
+/// Distinct from the two synthesis-time prefixes in `synthesize.rs`: those name
+/// a claim the guardrail refused, this names a narrative the render could not
+/// place. A reader who sees one should not have to guess which happened.
+const UNPLACED_NOTE: &str = "synthesis: narrative not rendered";
+
+/// Build one severity band's rows for one repository, with a disclosure line for
+/// every narrative that reached no row.
+///
+/// Why: [`push_finding_band`] and [`unplaced_narrative_lines`] must agree
+/// exactly on which narratives render — a second implementation of the pairing
+/// would drift, and the whole point of the disclosure is that it accounts for
+/// what the numbered list leaves out.
+/// What: one bare row per `metrics.findings` entry of `band`, then each
+/// `FindingProse` overlaid onto the row [`match_row`] pairs it with. A narrative
+/// with no row still renders as its own, unless [`is_self_restatement`] refuses
+/// it — in which case it is DISCLOSED rather than dropped in silence (#6082
+/// lap 6). The graded report numbered one such entry as AMBER #156, citing the
+/// topic phrase `trusty-common (memory_core/store)` with the file's own path as
+/// its entire Evidence body.
+/// Test: `reporter_tests::{an_unplaced_narrative_is_disclosed_not_numbered,
+/// a_narrative_citing_a_real_file_still_renders}`.
+fn band_rows(
+    repo: &RepositoryReport,
+    syn: Option<&super::synthesize::Synthesis>,
+    band: Severity,
+    band_label: &str,
+) -> (Vec<FindingRow>, Vec<String>) {
     let mut rows: Vec<FindingRow> = repo
         .metrics
         .iter()
@@ -488,6 +544,7 @@ pub(super) fn push_finding_band(
         .filter(|f| f.severity == band)
         .map(FindingRow::from_metric)
         .collect();
+    let mut notes = Vec::new();
 
     if let Some(syn) = syn {
         for f in syn
@@ -511,27 +568,56 @@ pub(super) fn push_finding_band(
                         rows[i] = merged;
                     }
                 }
-                // A synthesis-only row has no measurement behind it, so a
-                // restatement here is dropped: nothing else would render.
                 None => {
                     let row = FindingRow::from_prose(f);
-                    if !is_self_restatement(&row) {
-                        rows.push(row);
+                    match unplaced_reason(&row) {
+                        Some(reason) => {
+                            notes.push(format!("{UNPLACED_NOTE} — '{}': {reason}", f.title));
+                        }
+                        None => rows.push(row),
                     }
                 }
             }
         }
     }
+    (rows, notes)
+}
 
-    if rows.is_empty() {
-        return;
+/// Why a narrative matching no metrics row must not be numbered, if it must not.
+///
+/// Why: a refused narrative that lands on a metrics row still renders that row's
+/// measurement, so the reader loses nothing. A refused narrative with no row
+/// behind it renders as nothing at all, and until #6082 lap 6 that happened in
+/// silence — which is what the Synthesis Status list exists to prevent.
+/// What: `None` for a narrative that cites a file and quotes out of it, which
+/// renders as its own row. Otherwise the reason, phrased for the status list.
+fn unplaced_reason(row: &FindingRow) -> Option<String> {
+    if !is_self_restatement(row) {
+        return None;
     }
+    let component = row.component.as_deref().unwrap_or("none stated");
+    Some(format!(
+        "component '{component}' matches no measured finding, and its evidence restates the \
+         finding instead of quoting a line out of the file"
+    ))
+}
 
-    let mut app_scope = Scope::new();
-    app_scope.set("app_name", repo.name.clone());
-    for row in rows {
-        *index += 1;
-        app_scope.push_block(finding_block, row.into_scope(*index));
+/// Every synthesis narrative this render leaves out of the numbered lists.
+///
+/// Why: a narrative the reporter cannot place used to be either numbered with no
+/// measurement behind it or dropped in silence. Both hide the same fact from the
+/// reader; the Synthesis Status list is where this report already discloses what
+/// the guardrails refused.
+/// What: replays [`band_rows`] over every repository and both bands, returning
+/// its disclosure lines. Pure — it renders nothing.
+/// Test: `reporter_tests::an_unplaced_narrative_is_disclosed_not_numbered`.
+pub(super) fn unplaced_narrative_lines(model: &super::model::ReportModel) -> Vec<String> {
+    let syn = model.synthesis.as_ref();
+    let mut out = Vec::new();
+    for repo in &model.repositories {
+        for (band, label) in [(Severity::Red, "RED"), (Severity::Amber, "AMBER")] {
+            out.extend(band_rows(repo, syn, band, label).1);
+        }
     }
-    root.push_block(app_block, app_scope);
+    out
 }

--- a/crates/trusty-review/src/report/reporter_tests.rs
+++ b/crates/trusty-review/src/report/reporter_tests.rs
@@ -713,11 +713,14 @@ fn a_self_quoting_finding_is_suppressed() {
     // A real path, so only the self-quote can be what suppresses it.
     f.component = "crates/trusty-common/src/memory_core/store/hnsw_store.rs".to_string();
 
-    let md = render_with_finding(f);
+    // Scoped to the report body: since #6082 lap 6 a refused narrative is
+    // DISCLOSED under Synthesis Status, so its title appears in the document by
+    // design. What must not survive is the rendered finding.
+    let body = report_body(&render_with_finding(f));
 
     assert!(
-        !md.contains("Extract method — hnsw_store"),
-        "a finding quoting its own label must not survive:\n{md}"
+        !body.contains("Extract method — hnsw_store"),
+        "a finding quoting its own label must not survive:\n{body}"
     );
 }
 
@@ -725,12 +728,24 @@ fn a_self_quoting_finding_is_suppressed() {
 /// shape — the reader is given nothing to open.
 #[test]
 fn a_finding_with_a_non_path_component_is_suppressed() {
-    let md = render_with_finding(restating_finding());
+    let body = report_body(&render_with_finding(restating_finding()));
 
     assert!(
-        !md.contains("Extract method — hnsw_store"),
-        "a finding citing a topic instead of a file must not survive:\n{md}"
+        !body.contains("Extract method — hnsw_store"),
+        "a finding citing a topic instead of a file must not survive:\n{body}"
     );
+}
+
+/// The rendered document without its appended Synthesis Status list.
+///
+/// A refused narrative is disclosed there by title (#6082 lap 6), so a
+/// document-wide `!contains(title)` assertion can no longer tell a suppressed
+/// finding from a rendered one.
+fn report_body(md: &str) -> String {
+    md.split("## Synthesis Status")
+        .next()
+        .unwrap_or(md)
+        .to_string()
 }
 
 /// The filter must not reach a genuine finding: a real path plus a quote of real
@@ -743,11 +758,11 @@ fn a_genuine_finding_survives_the_self_quote_filter() {
     f.component = "crates/trusty-mpm/src/tui/health/screen.rs:384".to_string();
     f.evidence = "const MEM_CEILING_MB: u64 = 8 * 1024;".to_string();
 
-    let md = render_with_finding(f);
+    let amber = amber_section(&render_with_finding(f)).to_string();
 
     assert!(
-        md.contains("Hardcoded illustrative resource ceilings"),
-        "a genuine finding must survive:\n{md}"
+        amber.contains("Hardcoded illustrative resource ceilings"),
+        "a genuine finding must survive:\n{amber}"
     );
 }
 
@@ -760,11 +775,11 @@ fn a_root_level_manifest_component_is_not_a_topic() {
     f.component = "Cargo.toml".to_string();
     f.evidence = "aws-config = \"^1\"".to_string();
 
-    let md = render_with_finding(f);
+    let amber = amber_section(&render_with_finding(f)).to_string();
 
     assert!(
-        md.contains("Unpinned caret-range AWS SDK dependencies"),
-        "Cargo.toml is a real citation:\n{md}"
+        amber.contains("Unpinned caret-range AWS SDK dependencies"),
+        "Cargo.toml is a real citation:\n{amber}"
     );
 }
 
@@ -3081,5 +3096,94 @@ fn a_self_restating_narrative_never_deletes_its_metrics_row() {
     assert!(
         !amber.contains("harder to change over time"),
         "the restating narrative must still be refused:\n{amber}"
+    );
+}
+
+/// #6082 lap 6: an unmatched narrative citing a topic phrase must not be
+/// numbered as a finding.
+///
+/// Why: the graded report listed 156 AMBER items against the 155 AMBER findings
+/// its own metrics measured. The extra one — "Split oversized impl block
+/// (hnsw_store)", component `trusty-common (memory_core/store)`, Evidence body
+/// the file's own path — is the exact shape `is_self_restatement` exists to
+/// refuse, and it slipped through because the parenthesised half of that topic
+/// phrase carries a slash, so `names_a_file` read it as a path.
+/// What: the live orphan's shape against the three-row colliding-title fixture.
+/// Asserts the numbered list stops at the third measured row, that the orphan's
+/// prose does not render, and that Synthesis Status names it.
+/// Test: this test itself.
+#[test]
+fn an_unplaced_narrative_is_disclosed_not_numbered() {
+    let mut orphan = amber_prose(
+        "Split oversized impl block (hnsw_store)",
+        "trusty-common (memory_core/store)",
+        "crates/trusty-common/src/memory_core/store/hnsw_store.rs",
+    );
+    orphan.business_impact = "vector-store logic sits in one oversized block".to_string();
+
+    let md = render_colliding(vec![orphan]);
+    let amber = amber_section(&md);
+
+    assert!(
+        amber.contains("\n3. **"),
+        "the three measured rows must still render:\n{amber}"
+    );
+    assert!(
+        !amber.contains("\n4. **"),
+        "the unplaced narrative must not be numbered:\n{amber}"
+    );
+    assert!(
+        !amber.contains("vector-store logic sits in one oversized block"),
+        "the orphan's prose must not render as a finding:\n{amber}"
+    );
+
+    let status = md
+        .split("## Synthesis Status")
+        .nth(1)
+        .expect("Synthesis Status section present");
+    assert!(
+        status.contains(
+            "synthesis: narrative not rendered — 'Split oversized impl block \
+                         (hnsw_store)'"
+        ),
+        "the dropped narrative must be disclosed:\n{status}"
+    );
+    assert!(
+        status.contains(
+            "component 'trusty-common (memory_core/store)' matches no measured \
+                         finding"
+        ),
+        "the disclosure must name the component that matched nothing:\n{status}"
+    );
+}
+
+/// #6082 lap 6, other arm: a narrative that cites a real file and quotes a line
+/// out of it still renders on its own.
+///
+/// Why: most of the graded report's findings arrive this way — the investigation
+/// injects a metrics row per verified finding, but a narrative whose title the
+/// row does not carry still has a file, a line and a quote behind it. Refusing
+/// every unmatched narrative would delete those, which is the failure the lap-5
+/// fix was about.
+/// Test: this test itself.
+#[test]
+fn a_narrative_citing_a_real_file_still_renders() {
+    let mut verified = amber_prose(
+        "compact_orphans deletes across three transactions",
+        "crates/trusty-common/src/memory_core/store/hnsw_store.rs:221",
+        "let live = self.live_ids()?;",
+    );
+    verified.business_impact = "a just-inserted vector can be silently deleted".to_string();
+
+    let amber_md = render_colliding(vec![verified]);
+    let amber = amber_section(&amber_md);
+
+    assert!(
+        amber.contains("a just-inserted vector can be silently deleted"),
+        "a verified narrative with no metrics row must still render:\n{amber}"
+    );
+    assert!(
+        amber.contains("\n4. **"),
+        "it is numbered alongside the three measured rows:\n{amber}"
     );
 }

--- a/crates/trusty-review/src/report/synthesize.rs
+++ b/crates/trusty-review/src/report/synthesize.rs
@@ -820,6 +820,66 @@ fn apply_guardrail(
     Ok(out)
 }
 
+/// Run the grounding guardrail over the verified investigation's own prose.
+///
+/// Why: the guard used to run on synthesis prose only, and
+/// `merge_investigation_prose` overwrites that prose with the investigation's
+/// for every RED/AMBER finding — so the guarded copy was discarded before
+/// render. That is how RED finding 2 of the lap-6 report shipped "a remote code
+/// execution risk" in its business impact while the guard's own note in the same
+/// document recorded a correction it had made elsewhere. Correcting `inv` BEFORE
+/// `apply_investigation` fixes every downstream copy at once: the injected
+/// `metrics.findings` rows, `model.investigation` in the JSON twin, the
+/// synthesis prompt, and the merged prose that renders.
+/// What: builds the [`Grounding`] from the model plus `inv` (the model has not
+/// recorded it yet), then runs [`ground_field`] over each RED/AMBER finding's
+/// description, business impact, remediation and cost/effort. `evidence_quote`
+/// is excluded for the same reason it is in [`apply_guardrail`]: it is verified
+/// verbatim against the file. Returns one status line per correction or
+/// rejection, for the caller to fold into [`Synthesis::notes`].
+/// Test: `synthesize_tests.rs::{investigation_business_impact_states_host_local_reach,
+/// investigation_grounding_leaves_a_clean_finding_alone}`.
+pub fn ground_investigation_prose(
+    model: &ReportModel,
+    inv: &mut crate::report::investigate::Investigation,
+) -> Vec<String> {
+    let grounding = Grounding::from_model_with(model, Some(inv));
+    let mut notes = Vec::new();
+    for repo in &mut inv.repos {
+        for f in &mut repo.findings {
+            if f.severity == crate::report::metrics::Severity::Green {
+                continue; // greens are title-only topics; they carry no narrative
+            }
+            let label = format!("investigation finding '{}'", f.title);
+            f.description = ground_field(
+                &format!("{label} description"),
+                &f.description,
+                &grounding,
+                &mut notes,
+            );
+            f.business_impact = ground_field(
+                &format!("{label} business impact"),
+                &f.business_impact,
+                &grounding,
+                &mut notes,
+            );
+            f.remediation = ground_field(
+                &format!("{label} remediation"),
+                &f.remediation,
+                &grounding,
+                &mut notes,
+            );
+            f.cost_effort = ground_field(
+                &format!("{label} cost/effort"),
+                &f.cost_effort,
+                &grounding,
+                &mut notes,
+            );
+        }
+    }
+    notes
+}
+
 /// Run the grounding guardrail alone over one narrative field of a finding.
 ///
 /// Why: a finding is verified as a WHOLE by [`verify_all`] — one bad figure

--- a/crates/trusty-review/src/report/synthesize_grounding.rs
+++ b/crates/trusty-review/src/report/synthesize_grounding.rs
@@ -36,7 +36,27 @@ use super::topology::CrateTopology;
 /// Deliberately short and literal. A finding whose own remediation or evidence
 /// says "localhost" is stating its reachability; inferring one from softer
 /// words would make the check fire on findings it was never about.
-const LOOPBACK_MARKERS: &[&str] = &["localhost", "loopback", "127.0.0.1", "::1"];
+///
+/// #6082 lap 6: the socket spellings state the same fact without the word
+/// localhost. The graded report's RED finding 2 shipped "a remote code execution
+/// risk" because its remediation proposed "token or local-socket verification"
+/// and none of the four original markers matched — the finding never entered
+/// [`Grounding::local_only`], so the sentence had no owner and the check never
+/// ran on it. A remediation that proposes verifying the peer over a local socket
+/// is stating that the peer is on this host, which is a reachability statement
+/// as literal as "localhost".
+const LOOPBACK_MARKERS: &[&str] = &[
+    "localhost",
+    "loopback",
+    "127.0.0.1",
+    "::1",
+    "local-socket",
+    "local socket",
+    "unix socket",
+    "unix-socket",
+    "unix domain socket",
+    "unix-domain socket",
+];
 
 /// Text markers that scope a finding to a network-reachable surface.
 ///
@@ -176,12 +196,30 @@ impl Grounding {
     /// Why: every input is already in the report — the findings' own prose and
     /// the measured cargo topology — so nothing here is a second source of
     /// truth that could drift from what the report renders.
-    /// What: walks every repository's metric findings and its verified
-    /// investigation findings for loopback/remote markers, and folds every
-    /// declared [`CrateTopology`] into the load-bearing set.
+    /// What: [`Self::from_model_with`] over the investigation the model already
+    /// carries.
     /// Test: `synthesize_grounding_tests.rs::{a_loopback_finding_is_indexed,
     /// a_remote_finding_vetoes_its_tokens}`.
     pub(crate) fn from_model(model: &ReportModel) -> Self {
+        Self::from_model_with(model, model.investigation.as_ref())
+    }
+
+    /// Gather the grounding facts, reading the investigation from `inv` rather
+    /// than from the model's own copy.
+    ///
+    /// Why: the investigation prose is guarded BEFORE `apply_investigation`
+    /// records it on the model (#6082 lap 6), so at that point
+    /// `model.investigation` is still `None` and the two loopback-scoped
+    /// findings this report has would be invisible to the guard checking them.
+    /// What: walks every repository's metric findings and `inv`'s verified
+    /// findings for loopback/remote markers, and folds every declared
+    /// [`CrateTopology`] into the load-bearing set.
+    /// Test: `synthesize_grounding_tests.rs::a_loopback_finding_is_indexed`,
+    /// `synthesize_tests.rs::investigation_business_impact_states_host_local_reach`.
+    pub(crate) fn from_model_with(
+        model: &ReportModel,
+        inv: Option<&super::investigate::Investigation>,
+    ) -> Self {
         let mut out = Grounding::default();
         for repo in &model.repositories {
             if let Some(metrics) = &repo.metrics {
@@ -194,7 +232,7 @@ impl Grounding {
                 }
             }
         }
-        if let Some(inv) = &model.investigation {
+        if let Some(inv) = inv {
             for repo in &inv.repos {
                 for f in &repo.findings {
                     out.ingest(

--- a/crates/trusty-review/src/report/synthesize_grounding_tests.rs
+++ b/crates/trusty-review/src/report/synthesize_grounding_tests.rs
@@ -1,6 +1,9 @@
 //! Tests for the claim-level grounding guardrail (#6082 lap 4).
 
 use super::*;
+use crate::report::investigate::{
+    Investigation, InvestigationStatus, RepoInvestigation, VerifiedFinding,
+};
 use crate::report::metrics::{AnalyzeMetrics, MetricFinding, Severity};
 use crate::report::model::{ReportModel, RepositoryReport};
 use crate::report::topology::CrateNode;
@@ -347,6 +350,88 @@ fn a_crate_name_is_matched_on_its_own_boundaries() {
         panic!("expected a rejection");
     };
     assert!(reason.contains("trusty-mpm-gui"), "reason was: {reason}");
+}
+
+// ─── Loopback scope stated without the word localhost (#6082 lap 6) ──────────
+
+/// The lap-6 live defect, verbatim.
+///
+/// RED finding 2 of the graded report shipped "a remote code execution risk" in
+/// its business impact. The sentence matched the `remote code execution` rewrite
+/// pattern fine — what failed was SCOPE: the finding's own text says
+/// "local-socket verification", not "localhost", so it never entered
+/// `local_only` and the sentence had no owner to be checked against.
+fn control_routes_investigation() -> Investigation {
+    Investigation {
+        repos: vec![RepoInvestigation {
+            slug: "estate".to_string(),
+            name: "Estate".to_string(),
+            status: InvestigationStatus::Available,
+            findings: vec![VerifiedFinding {
+                trace_verdict: String::new(),
+                title: "Control-plane HTTP handlers have no authentication or authorization"
+                    .to_string(),
+                severity: Severity::Red,
+                dimension: "authentication & secrets".to_string(),
+                file: "crates/trusty-mpm/src/daemon/api/control_routes.rs".to_string(),
+                line: Some(259),
+                evidence_quote: "pub async fn ctl_run_session(".to_string(),
+                description: "The session run/connect/stop/auth endpoints accept requests with \
+                              no auth check, allowing anyone reaching the daemon to spawn \
+                              processes and control sessions."
+                    .to_string(),
+                business_impact: LIVE_BUSINESS_IMPACT.to_string(),
+                remediation: "Add an authentication/authorization middleware layer (token or \
+                              local-socket verification) in front of the control routes."
+                    .to_string(),
+                cost_effort: "medium".to_string(),
+            }],
+            deps: Default::default(),
+            coverage: Default::default(),
+            traces: None,
+            verdicts: None,
+        }],
+    }
+}
+
+/// The sentence as it rendered at line 115 of the graded report.
+const LIVE_BUSINESS_IMPACT: &str = "An attacker who reaches the daemon port can execute arbitrary \
+                                    claude/tmux processes in operator-controlled workdirs, a \
+                                    remote code execution risk.";
+
+/// A remediation proposing local-socket verification states the same
+/// reachability "localhost" does, so the finding is indexed local-only.
+#[test]
+fn a_local_socket_remediation_scopes_its_finding() {
+    let mut model = model_with(vec![repo("estate", vec![], None)]);
+    model.investigation = Some(control_routes_investigation());
+    let g = Grounding::from_model(&model);
+    assert_eq!(g.local_only.len(), 1, "local_only was: {:?}", g.local_only);
+    assert!(g.local_only[0].tokens.contains("daemon"));
+}
+
+/// The live sentence is rewritten to state host-local reach.
+///
+/// Fails before the fix: `local_only` is empty, `local_subject` finds no owner
+/// for the sentence, and `check` returns `Clean` with the claim intact.
+#[test]
+fn the_live_remote_code_execution_claim_is_rewritten() {
+    let mut model = model_with(vec![repo("estate", vec![], None)]);
+    model.investigation = Some(control_routes_investigation());
+    let GroundingOutcome::Rewritten(text, notes) =
+        Grounding::from_model(&model).check(LIVE_BUSINESS_IMPACT)
+    else {
+        panic!("expected the live business impact to be rewritten");
+    };
+    assert!(
+        !text.to_lowercase().contains("remote"),
+        "the corrected sentence still asserts remote reach: {text}"
+    );
+    assert!(
+        text.contains("local-process-reachable code execution"),
+        "the correction must state host-local reach: {text}"
+    );
+    assert_eq!(notes.len(), 1, "notes were: {notes:?}");
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────

--- a/crates/trusty-review/src/report/synthesize_tests.rs
+++ b/crates/trusty-review/src/report/synthesize_tests.rs
@@ -2594,3 +2594,94 @@ fn prompt_carries_the_grounding_facts() {
         "a leaf crate must not be offered as load-bearing"
     );
 }
+
+// ── Investigation prose takes the grounding pass (#6082 lap 6) ──────────────
+
+/// The rendered half of the lap-6 reachability defect.
+///
+/// Why: the guard ran over the synthesis narrative only, and
+/// `merge_investigation_prose` overwrites that narrative with the
+/// investigation's own prose for every RED/AMBER finding — so the guarded copy
+/// never reached the page. Line 115 of the graded report carried the raw claim,
+/// and so did both of its JSON storage sites.
+/// What: grounds the investigation, then merges it exactly as the report
+/// pipeline does, and reads the prose that would render.
+fn control_routes_investigation() -> crate::report::investigate::Investigation {
+    use crate::report::investigate::{
+        Investigation, InvestigationStatus, RepoInvestigation, VerifiedFinding,
+    };
+    Investigation {
+        repos: vec![RepoInvestigation {
+            slug: "acme-core".to_string(),
+            name: "Acme Core".to_string(),
+            status: InvestigationStatus::Available,
+            findings: vec![VerifiedFinding {
+                trace_verdict: String::new(),
+                title: "Control-plane HTTP handlers have no authentication or authorization"
+                    .to_string(),
+                severity: Severity::Red,
+                dimension: "authentication & secrets".to_string(),
+                file: "crates/trusty-mpm/src/daemon/api/control_routes.rs".to_string(),
+                line: Some(259),
+                evidence_quote: "pub async fn ctl_run_session(".to_string(),
+                description: "The session run/connect/stop/auth endpoints accept requests with \
+                              no auth check, allowing anyone reaching the daemon to spawn \
+                              processes and control sessions."
+                    .to_string(),
+                business_impact: "An attacker who reaches the daemon port can execute arbitrary \
+                                  claude/tmux processes in operator-controlled workdirs, a \
+                                  remote code execution risk."
+                    .to_string(),
+                remediation: "Add an authentication/authorization middleware layer (token or \
+                              local-socket verification) in front of the control routes."
+                    .to_string(),
+                cost_effort: "medium".to_string(),
+            }],
+            deps: Default::default(),
+            coverage: Default::default(),
+            traces: None,
+            verdicts: None,
+        }],
+    }
+}
+
+/// The prose that reaches the page states host-local reach, not remote.
+#[test]
+fn investigation_business_impact_states_host_local_reach() {
+    let model = fixture_model(vec![red("Unrelated")]);
+    let mut inv = control_routes_investigation();
+    let notes = super::ground_investigation_prose(&model, &mut inv);
+
+    let impact = &inv.repos[0].findings[0].business_impact;
+    assert!(
+        !impact.to_lowercase().contains("remote"),
+        "the investigation record still asserts remote reach: {impact}"
+    );
+    assert!(
+        impact.contains("local-process-reachable code execution"),
+        "the correction must state host-local reach: {impact}"
+    );
+    assert_eq!(notes.len(), 1, "notes were: {notes:?}");
+
+    // The merged prose is what renders, and it inherits the correction.
+    let mut synthesis = Synthesis::default();
+    crate::report::investigate::merge_investigation_prose(&mut synthesis, &inv);
+    let merged = synthesis
+        .findings
+        .iter()
+        .find(|f| f.title.starts_with("Control-plane"))
+        .expect("the RED finding must merge into the synthesis prose");
+    assert_eq!(&merged.business_impact, impact);
+}
+
+/// A finding with no reachability claim is passed through untouched.
+#[test]
+fn investigation_grounding_leaves_a_clean_finding_alone() {
+    let model = fixture_model(vec![red("Unrelated")]);
+    let mut inv = control_routes_investigation();
+    let clean = "Callers cannot tell a failed write from a skipped one.".to_string();
+    inv.repos[0].findings[0].business_impact = clean.clone();
+    let notes = super::ground_investigation_prose(&model, &mut inv);
+    assert_eq!(inv.repos[0].findings[0].business_impact, clean);
+    assert!(notes.is_empty(), "notes were: {notes:?}");
+}


### PR DESCRIPTION
Two render-pipeline defects from the lap-6 acceptance run, both observed live in `2026-08-22-technical-due-diligence.{md,json}`. Both fail open — the render exited 0 in each case.

## Unplaced narrative numbered as a finding

The render listed 156 AMBER items against the 155 its own metrics measured. The extra one — "Split oversized impl block (hnsw_store)", component `trusty-common (memory_core/store)`, evidence body the file's own path — is exactly the shape `is_self_restatement` exists to refuse. It slipped through because `names_a_file` saw the slash inside the parenthesised half and read the topic phrase as a path. A path with interior whitespace or a parenthesis is now a topic.

A refused narrative that lands on a metrics row still renders that row's measurement. One with no row behind it used to disappear without a line; it is now recorded under Synthesis Status naming the component that matched nothing.

## Reachability guard reached the wrong copy

RED finding 2's business impact shipped "a remote code execution risk" about a loopback-bound daemon (ADR-0018), two lines from a Security Posture paragraph the same guard had corrected. Two causes, both fixed:

- **Scope.** The guard indexes a finding as loopback-scoped from four literal markers in its own text. This finding's remediation says "token or local-socket verification", not "localhost", so it never entered `local_only` and the sentence had no owner. The sentence matched the `remote code execution` rewrite pattern fine — the pattern set was not the problem. The socket spellings are markers now.
- **Order.** The guard ran over synthesis prose only, while `merge_investigation_prose` overwrites that prose with the investigation's own for every RED/AMBER finding — so the guarded copy was discarded before render. That is why both JSON storage sites carried the raw claim. The pass now runs over the investigation record itself, before `apply_investigation` copies it, reaching every downstream site at once: the injected `metrics.findings` rows, `model.investigation` in the JSON twin, the synthesis prompt, and the merged prose that renders.

## Gates — test ladder rung 3

```
cargo fmt --check                                       EXIT=0
cargo check -p trusty-review --all-targets              EXIT=0
cargo clippy -p trusty-review --all-targets -- -D warnings   EXIT=0
cargo test -p trusty-review                             EXIT=0
  test result: ok. 1960 passed; 0 failed; 5 ignored
  (plus 9 further binaries/integration targets, all ok)
bash scripts/check_line_cap.sh                          0 violations
bash scripts/check_changelog_fragment.sh                OK
bash scripts/check_sld.sh                               0 errors, 0 warnings
```

Three regression tests fail on the pre-fix commit (source reverted, tests kept):

```
test report::reporter::tests::an_unplaced_narrative_is_disclosed_not_numbered ... FAILED
  the unplaced narrative must not be numbered:
  4. **Split oversized impl block (hnsw_store)** — the block has grown past ...
  - **Component:** trusty-common (memory_core/store)
  - **Evidence** (`trusty-common (memory_core/store)`) :
  ```
  crates/trusty-common/src/memory_core/store/hnsw_store.rs
  ```
test report::synthesize_grounding::tests::a_local_socket_remediation_scopes_its_finding ... FAILED
  assertion `left == right` failed: local_only was: []
test report::synthesize_grounding::tests::the_live_remote_code_execution_claim_is_rewritten ... FAILED
  expected the live business impact to be rewritten

test result: FAILED. 1 passed; 3 failed
```

The one that passes pre-fix, `a_narrative_citing_a_real_file_still_renders`, is the over-correction guard: a narrative with a real `file:line` and a quote out of that file must keep rendering.

Refs #6082

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools