### PR TITLE
fix(trusty-review): reachability follows the component, and Synthesis Status speaks to the reader (Refs #6082)

### DIFF
--- a/crates/trusty-review/changelog.d/6082-lap8-acceptance-fixes.md
+++ b/crates/trusty-review/changelog.d/6082-lap8-acceptance-fixes.md
@@ -1,0 +1,10 @@
+Fixed
+
+- A finding's reachability now follows the file it sits in, not the words its own text happens to use ([#6082](https://github.com/bobmatnyc/trusty-tools/issues/6082))
+  - every finding on a file some finding scopes to localhost inherits that scope
+  - a beyond-the-host reach claim about a file the collected data says nothing about is withheld and disclosed, never rewritten
+  - a finding is judged by its own component, so an unrelated finding's title words can no longer empty its business impact
+- Every Synthesis Status line is now written for the reader ([#6082](https://github.com/bobmatnyc/trusty-tools/issues/6082))
+  - the bare `synthesis: available` banner is gone, and the block is omitted when there is nothing to disclose
+  - a line about a finding cites the §5.1/§5.2 number the reader can look up instead of naming it by title alone
+  - citations for RED findings say section 5.1; they used to say 5.2

--- a/crates/trusty-review/src/cli_report.rs
+++ b/crates/trusty-review/src/cli_report.rs
@@ -282,13 +282,12 @@ pub async fn cmd_report(config_path: Option<&Path>, args: ReportArgs) -> Result<
                 args.out.display()
             )
         })?;
+    // #6082 lap 8: this used to echo the report's own `synthesis: available`
+    // banner, which the Synthesis Status block no longer carries. The operator's
+    // question here is how much the guardrails withheld.
     eprintln!(
-        "[trusty-review report] {}",
-        synthesis
-            .status_lines()
-            .first()
-            .cloned()
-            .unwrap_or_default()
+        "[trusty-review report] synthesis complete — {} guardrail disclosure(s)",
+        synthesis.notes.len()
     );
     model.synthesis = Some(synthesis);
 

--- a/crates/trusty-review/src/report/mod.rs
+++ b/crates/trusty-review/src/report/mod.rs
@@ -63,6 +63,8 @@ pub mod synthesize_guard;
 // prompt hints plus a fail-closed post-check for reachability and load-bearing
 // claims. Used only by `synthesize` and `synthesize_prompt`.
 pub(crate) mod synthesize_grounding;
+mod synthesize_grounding_text;
+mod synthesize_guardrail;
 // #6009 shape 3: whitelist-based synonym normalization, used only by
 // `synthesize::parse_raw` — not part of the public report API.
 pub(crate) mod synthesize_normalize;

--- a/crates/trusty-review/src/report/reporter.rs
+++ b/crates/trusty-review/src/report/reporter.rs
@@ -29,7 +29,7 @@ use super::reporter_facts::fill_key_facts;
 use super::reporter_fill::{
     crate_version, fill_profile, instructions_block, set_executive_summary, set_scoring_model,
 };
-use super::reporter_findings::{push_finding_band, unplaced_narrative_lines};
+use super::reporter_findings::{finding_citations, push_finding_band, unplaced_narrative_lines};
 use super::reporter_graph_datasets::{
     inject_complexity_distribution_dataset, inject_loc_by_technology_dataset,
 };
@@ -606,27 +606,50 @@ fn green_topic_line(finding: &super::metrics::MetricFinding) -> String {
     format!("{} — `{}`", finding.title, finding.component.trim())
 }
 
-/// Append the visible `synthesis:` status note to the rendered markdown.
+/// Append the Synthesis Status block to the rendered markdown.
 ///
 /// Why: a reader must never mistake a deterministically-composed section for one
-/// the model wrote; the note names every field the numeric guardrail rejected.
-/// What: when `model.synthesis` is present, appends a status block whose lines
-/// come from `Synthesis::status_lines`, followed by one line per narrative the
-/// finding bands could not place (#6082 lap 6, see
-/// [`unplaced_narrative_lines`]).  The absent branch survives only for
+/// the model wrote, and the block is where this report discloses what the
+/// guardrails refused. #6082 lap 8 made every line of it one voice: the block
+/// used to open with the raw log line `synthesis: available` and carry
+/// log-prefixed rejections beside reader-voiced withheld-narrative lines. The
+/// banner is gone — a report that reaches a reader always had a successful
+/// synthesis pass behind it (#5454), so its presence was never news — and each
+/// remaining line names the §5.1/§5.2 finding it is about by the number the
+/// reader can look up.
+/// What: when `model.synthesis` is present AND has something to disclose,
+/// appends one line per [`StatusNote`] — cited by [`finding_citations`] when its
+/// subject renders as a numbered row — then one line per narrative the finding
+/// bands could not place (#6082 lap 6, see [`unplaced_narrative_lines`]). An
+/// empty block is omitted entirely. The absent branch survives only for
 /// [`Reporter::render`], which stays infallible for unit tests —
 /// [`Reporter::write`] rejects a synthesis-free model outright (#5454).
 /// Test: `reporter_tests.rs::{reporter_appends_guardrail_rejection_note,
+/// a_status_note_cites_its_finding_number, an_empty_synthesis_status_is_omitted,
 /// an_unmeasured_orphan_narrative_is_not_numbered}`.
 fn append_synthesis_note(out: &mut String, model: &ReportModel) {
     let Some(syn) = &model.synthesis else {
         return;
     };
-    out.push_str("\n\n## Synthesis Status\n\n");
-    for line in syn.status_lines() {
-        out.push_str(&format!("- {line}\n"));
+    let citations = finding_citations(model);
+    let mut lines: Vec<String> = syn
+        .notes
+        .iter()
+        .map(|n| {
+            let cite = n
+                .subject
+                .as_deref()
+                .and_then(|s| citations.get(s.trim()))
+                .and_then(Option::as_deref);
+            n.render(cite)
+        })
+        .collect();
+    lines.extend(unplaced_narrative_lines(model));
+    if lines.is_empty() {
+        return;
     }
-    for line in unplaced_narrative_lines(model) {
+    out.push_str("\n\n## Synthesis Status\n\n");
+    for line in lines {
         out.push_str(&format!("- {line}\n"));
     }
 }

--- a/crates/trusty-review/src/report/reporter_findings.rs
+++ b/crates/trusty-review/src/report/reporter_findings.rs
@@ -668,10 +668,9 @@ pub(super) fn unplaced_narrative_lines(model: &super::model::ReportModel) -> Vec
 fn disclosure_line(band_label: &str, base: usize, u: &Unplaced) -> String {
     match u.row {
         Some(i) => format!(
-            "section 5.2, {band_label} finding {}: the model's added narrative ('{}') was \
-             withheld because it could not be verified against the collected data, so that \
-             finding shows the measured data only",
-            base + i + 1,
+            "{}: the model's added narrative ('{}') was withheld because it could not be \
+             verified against the collected data, so that finding shows the measured data only",
+            cite(band_label, base + i + 1),
             u.title,
         ),
         None => format!(
@@ -681,4 +680,52 @@ fn disclosure_line(band_label: &str, base: usize, u: &Unplaced) -> String {
             u.title,
         ),
     }
+}
+
+/// How a Synthesis Status line points at one numbered finding.
+///
+/// Why: RED findings render under `### 5.1` and AMBER under `### 5.2`, and every
+/// citation said 5.2 — so a line about a RED finding sent the reader to the
+/// wrong section (#6082 lap 8).
+fn cite(band_label: &str, number: usize) -> String {
+    let section = match band_label {
+        "RED" => "5.1",
+        _ => "5.2",
+    };
+    format!("section {section}, {band_label} finding {number}")
+}
+
+/// The rendered §5.1/§5.2 citation for each finding title, for the Synthesis
+/// Status block to point at.
+///
+/// Why: a guardrail note names the finding it is about by title, because the
+/// number does not exist yet when the note is recorded — the rows are numbered
+/// at render (#6082 lap 8).
+/// What: replays [`band_rows`] with the same per-band counters
+/// [`push_finding_band`] numbers with, mapping title to citation. A title that
+/// renders more than once maps to `None`: there is no one number to name, which
+/// is the same conservative rule [`cited_row`] applies.
+/// Test: `reporter_tests::a_status_note_cites_its_finding_number`.
+pub(super) fn finding_citations(
+    model: &super::model::ReportModel,
+) -> std::collections::HashMap<String, Option<String>> {
+    let syn = model.synthesis.as_ref();
+    let mut out: std::collections::HashMap<String, Option<String>> = Default::default();
+    let mut counters = [0usize; 2];
+    for repo in &model.repositories {
+        for (slot, (band, label)) in [(Severity::Red, "RED"), (Severity::Amber, "AMBER")]
+            .into_iter()
+            .enumerate()
+        {
+            let (rows, _) = band_rows(repo, syn, band, label);
+            for (i, row) in rows.iter().enumerate() {
+                let citation = cite(label, counters[slot] + i + 1);
+                out.entry(row.title.trim().to_string())
+                    .and_modify(|slot| *slot = None)
+                    .or_insert(Some(citation));
+            }
+            counters[slot] += rows.len();
+        }
+    }
+    out
 }

--- a/crates/trusty-review/src/report/reporter_tests.rs
+++ b/crates/trusty-review/src/report/reporter_tests.rs
@@ -490,7 +490,9 @@ fn reporter_injects_synthesis_prose() {
     assert!(md.contains("A grounded acquirer-relevant summary."));
     assert!(md.contains("Injection risk"));
     assert!(md.contains("Raw query concatenation"));
-    assert!(md.contains("synthesis: available"));
+    // #6082 lap 8: a pass with nothing withheld has nothing to disclose, so the
+    // block is omitted rather than carrying a bare `synthesis: available` line.
+    assert!(!md.contains("## Synthesis Status"));
     // Defect #1: every synthesized field carries the inferred marker.
     assert!(md.contains(crate::report::provenance::INFERRED_TAG.trim()));
     let inferred_count = md
@@ -526,9 +528,10 @@ fn reporter_appends_guardrail_rejection_note() {
         code_quality_summary: None,
         security_summary: None,
         authorship_summary: None,
-        notes: vec![
-            "synthesis: rejected (unverified figure) in executive summary: 9999".to_string(),
-        ],
+        notes: vec![crate::report::synthesize::StatusNote::plain(
+            "the model's executive summary was withheld because it carried the figure 9999, \
+             which is not in the collected data",
+        )],
         ..Default::default()
     });
 
@@ -537,14 +540,73 @@ fn reporter_appends_guardrail_rejection_note() {
         .expect("bundled template");
     let md = Reporter::new(tmp.path()).render(&model, &template);
 
-    assert!(md.contains("synthesis: available"));
-    assert!(md.contains("rejected (unverified figure) in executive summary: 9999"));
+    assert!(md.contains("## Synthesis Status"));
+    assert!(md.contains("the model's executive summary was withheld"));
+    assert!(md.contains("the figure 9999"));
+    // #6082 lap 8: no line of the block carries a raw log prefix any more.
+    assert!(!md.contains("- synthesis:"));
     // The rejected exec summary was never injected — under the omit-empty default
     // the un-synthesised paragraph is dropped (not a marker wall) and recorded
     // under Data gaps.
     assert!(!md.contains("A grounded"));
     assert!(md.contains("Data gaps:"));
     assert!(!md.contains("{{"));
+}
+
+/// #6082 lap 8: a Synthesis Status line about a numbered finding cites its
+/// number, and no line of the block carries a raw log prefix.
+///
+/// Why: the graded report's rejection line named its finding by title only —
+/// "in investigation finding 'Hotspot HTTP client function has cyclomatic
+/// complexity 98'" — while that finding rendered as §5.2 item 47 two thousand
+/// lines above. A reader had to search the document to find out what the line
+/// was about.
+/// What: seeds one note about a uniquely-titled AMBER row and one about a title
+/// two rows share; asserts the first is cited by number and the second is not,
+/// because there is no one number to name.
+/// Test: this test itself.
+#[test]
+fn a_status_note_cites_its_finding_number() {
+    use crate::report::synthesize::StatusNote;
+
+    let md = render_colliding_with_notes(
+        vec![],
+        vec![
+            StatusNote::about(
+                "Extract method — dispatch",
+                "the model's business impact was withheld — the claim cannot be verified",
+            ),
+            StatusNote::about(
+                "Split oversized impl block",
+                "the model's remediation was withheld — the claim cannot be verified",
+            ),
+        ],
+    );
+    let status = md
+        .split("## Synthesis Status")
+        .nth(1)
+        .expect("status block");
+    assert!(
+        status.contains("section 5.2, AMBER finding 2: the model's business impact was withheld"),
+        "the uniquely-titled finding must be cited by its rendered number:\n{status}"
+    );
+    assert!(
+        status.contains("- the model's remediation was withheld"),
+        "an ambiguous title renders bare rather than guessing a number:\n{status}"
+    );
+    assert!(!status.contains("synthesis:"), "no log prefix:\n{status}");
+}
+
+/// #6082 lap 8: a pass with nothing withheld writes no Synthesis Status block.
+///
+/// Why: the block used to open with `synthesis: available`, which since #5454 is
+/// never news — a report that reaches a reader always had a successful pass
+/// behind it — so the section existed to say nothing.
+/// Test: this test itself.
+#[test]
+fn an_empty_synthesis_status_is_omitted() {
+    let md = render_colliding(vec![]);
+    assert!(!md.contains("## Synthesis Status"));
 }
 
 /// Why: #5454 — inference is required, so nothing may reach DISK without a
@@ -2963,6 +3025,17 @@ fn amber_prose(
 
 /// Render the colliding-title fixture with `findings` attached as synthesis.
 fn render_colliding(findings: Vec<crate::report::synthesize::FindingProse>) -> String {
+    render_colliding_with_notes(findings, vec![])
+}
+
+/// `render_colliding`, with guardrail disclosures seeded on the synthesis.
+///
+/// Why: since #6082 lap 8 a Synthesis Status block with nothing to disclose is
+/// omitted, so a test about that block has to give it something to say.
+fn render_colliding_with_notes(
+    findings: Vec<crate::report::synthesize::FindingProse>,
+    notes: Vec<crate::report::synthesize::StatusNote>,
+) -> String {
     use crate::report::synthesize::Synthesis;
 
     let tmp = tempfile::TempDir::new().expect("tempdir");
@@ -2982,7 +3055,7 @@ fn render_colliding(findings: Vec<crate::report::synthesize::FindingProse>) -> S
         executive_summary: None,
         top_risks: vec![],
         findings,
-        notes: vec![],
+        notes,
     });
     let template = TemplateLoader::bundled_only()
         .load("report-technical-dd")
@@ -3174,11 +3247,17 @@ fn an_unplaced_narrative_is_disclosed_not_numbered() {
 /// Test: this test itself.
 #[test]
 fn the_signature_is_the_last_content_in_the_document() {
-    let md = render_colliding(vec![amber_prose(
-        "Split oversized impl block",
-        "crates/trusty-common/src/memory_core/store/hnsw_store.rs:41",
-        "let mut guard = self.index.write();",
-    )]);
+    let md = render_colliding_with_notes(
+        vec![amber_prose(
+            "Split oversized impl block",
+            "crates/trusty-common/src/memory_core/store/hnsw_store.rs:41",
+            "let mut guard = self.index.write();",
+        )],
+        vec![crate::report::synthesize::StatusNote::plain(
+            "the model's executive summary was withheld because it carried the figure 9999, \
+             which is not in the collected data",
+        )],
+    );
     let last = md
         .lines()
         .rfind(|l| !l.trim().is_empty())

--- a/crates/trusty-review/src/report/synthesize.rs
+++ b/crates/trusty-review/src/report/synthesize.rs
@@ -27,8 +27,13 @@ use tracing::{debug, warn};
 
 use crate::llm::LlmProvider;
 use crate::report::model::ReportModel;
-use crate::report::synthesize_grounding::{Grounding, GroundingOutcome};
-use crate::report::synthesize_guard::{allowed_numbers_with, verify_prose};
+use crate::report::synthesize_grounding::Grounding;
+
+// #6082 lap 8: the guardrail layer moved into `synthesize_guardrail` to keep
+// this file under the production SLOC cap. Re-exported so the public path
+// callers already use stays exactly where it was.
+pub use super::synthesize_guardrail::ground_investigation_prose;
+use crate::report::synthesize_guard::allowed_numbers_with;
 use crate::report::synthesize_prompt::{
     SYNTHESIS_DEFAULT_MAX_TOKENS, SYNTHESIS_TIER_LADDER, SynthesisTier, build_synthesis_prompt,
 };
@@ -47,17 +52,6 @@ const DEFAULT_SYNTHESIS_TIMEOUT: Duration = Duration::from_secs(120);
 /// aid, not an audit trail) so operators know where to look without parsing a
 /// timestamp out of a WARN line.
 const UNPARSEABLE_CAPTURE_FILENAME: &str = "synthesis-unparseable-response.txt";
-
-/// The literal prefix every guardrail-rejection note carries, so the reporter and
-/// tests can assert on it.
-const REJECTED_NOTE: &str = "synthesis: rejected (unverified figure)";
-
-/// The literal prefix every grounding-rejection note carries (#6082 lap 4).
-///
-/// Kept distinct from [`REJECTED_NOTE`]: a numeric rejection means a figure was
-/// not in the data, a grounding rejection means a CLAIM contradicted it, and a
-/// reader who sees one should not have to guess which happened.
-const UNGROUNDED_NOTE: &str = "synthesis: rejected (claim contradicts the report's own data)";
 
 // ─── Injected result types ──────────────────────────────────────────────────
 
@@ -98,9 +92,56 @@ pub struct Synthesis {
     /// Verified per-finding elaboration prose (rejected findings are dropped).
     #[serde(default)]
     pub findings: Vec<FindingProse>,
-    /// Human-readable guardrail/routing notes recorded during injection.
+    /// Reader-facing guardrail/routing notes recorded during injection.
     #[serde(default)]
-    pub notes: Vec<String>,
+    pub notes: Vec<StatusNote>,
+}
+
+/// One Synthesis Status disclosure, and the finding it is about.
+///
+/// Why: every line of that block is written for a diligence reader, so it must
+/// name the numbered finding it concerns rather than a pipeline label —
+/// and the §5.2 number is not knowable when the note is recorded, because the
+/// reporter has not numbered the rows yet (#6082 lap 8). Carrying the title
+/// separately from the prose lets the reporter resolve the number at render.
+/// What: `text` is a complete reader sentence on its own; `subject` is the
+/// finding title the reporter looks up, absent for report-level prose.
+/// Test: `reporter_tests.rs::{a_status_note_cites_its_finding_number,
+/// a_status_note_without_a_numbered_finding_renders_bare}`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct StatusNote {
+    /// The disclosure, as the reader sees it.
+    pub text: String,
+    /// The finding this disclosure is about, when it is about one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subject: Option<String>,
+}
+
+impl StatusNote {
+    /// A disclosure about no particular finding.
+    pub fn plain(text: impl Into<String>) -> Self {
+        StatusNote {
+            text: text.into(),
+            subject: None,
+        }
+    }
+
+    /// A disclosure about `subject`, which the reporter numbers if it renders.
+    pub fn about(subject: &str, text: impl Into<String>) -> Self {
+        StatusNote {
+            text: text.into(),
+            subject: Some(subject.trim().to_string()),
+        }
+    }
+
+    /// Render one status line, prefixed with `cite` when the reporter resolved
+    /// the subject to a numbered finding.
+    pub fn render(&self, cite: Option<&str>) -> String {
+        match cite {
+            Some(c) => format!("{c}: {}", self.text),
+            None => self.text.clone(),
+        }
+    }
 }
 
 /// Why one synthesis pass produced no verified narrative.
@@ -225,25 +266,6 @@ pub struct FindingProse {
     /// travel with it to reach the rendered evidence block.
     #[serde(default)]
     pub trace_verdict: String,
-}
-
-impl Synthesis {
-    /// The visible status note lines for the rendered report.
-    ///
-    /// Why: the report states which fields the numeric guardrail rejected, so a
-    /// reader can tell a section written by the model from one that fell back to
-    /// the deterministic composition (#5374).  #5454 removed the
-    /// `unavailable (<reason>)` banner: a report that reaches a reader always had
-    /// a successful synthesis pass behind it, so the only news left is the
-    /// per-field rejections.
-    /// What: a leading `synthesis: available` line, then one line per note.
-    /// Test: `synthesize_tests.rs::status_lines_render_banners`.
-    pub fn status_lines(&self) -> Vec<String> {
-        let mut lines = Vec::with_capacity(1 + self.notes.len());
-        lines.push("synthesis: available".to_string());
-        lines.extend(self.notes.iter().cloned());
-        lines
-    }
 }
 
 // ─── Synthesizer ────────────────────────────────────────────────────────────
@@ -385,7 +407,10 @@ impl Synthesizer {
         for (i, tier) in SYNTHESIS_TIER_LADDER.iter().enumerate() {
             match self.try_once(model, *tier).await {
                 Attempt::Ok(raw, norm_notes) => {
-                    return apply_guardrail(raw, &allowed, norm_notes, &grounding);
+                    let seed = norm_notes.into_iter().map(StatusNote::plain).collect();
+                    return super::synthesize_guardrail::apply_guardrail(
+                        raw, &allowed, seed, &grounding,
+                    );
                 }
                 Attempt::Failed(e) => return Err(e),
                 Attempt::Truncated => match SYNTHESIS_TIER_LADDER.get(i + 1) {
@@ -499,22 +524,22 @@ enum Attempt {
 
 /// The raw JSON contract the provider is asked to emit (pre-verification).
 #[derive(Debug, Deserialize)]
-struct RawSynthesis {
+pub(super) struct RawSynthesis {
     #[serde(default)]
-    executive_summary: String,
+    pub(super) executive_summary: String,
     /// #6004: same schema/call/guardrail as `executive_summary`.
     #[serde(default)]
-    code_quality_summary: String,
+    pub(super) code_quality_summary: String,
     /// #6004: same schema/call/guardrail as `executive_summary`.
     #[serde(default)]
-    security_summary: String,
+    pub(super) security_summary: String,
     /// #5453/#6004: same schema/call/guardrail as `executive_summary`.
     #[serde(default)]
-    authorship_summary: String,
+    pub(super) authorship_summary: String,
     #[serde(default)]
-    top_risks: Vec<RiskRow>,
+    pub(super) top_risks: Vec<RiskRow>,
     #[serde(default)]
-    findings: Vec<FindingProse>,
+    pub(super) findings: Vec<FindingProse>,
 }
 
 /// Parse the provider response into [`RawSynthesis`] plus any normalization
@@ -663,302 +688,6 @@ fn heading_section(text: &str, wanted: &str) -> Option<String> {
         .collect();
     let joined = body.join("\n").trim().to_string();
     (!joined.is_empty()).then_some(joined)
-}
-
-/// Apply the numeric guardrail to the raw synthesis, field by field.
-///
-/// Why: a field whose prose cites a figure not in the source is dropped (never
-/// repaired), so the deterministic composition (#5374) fills that placeholder and
-/// a visible rejection note is recorded.  Per-FIELD rejection stays a correctness
-/// property under #5454's required-inference rule; what changed is that a
-/// response with nothing left after the pass is an error rather than a
-/// deterministic-only report.
-/// What: verifies the executive summary and every risk row / finding against
-/// `allowed`; keeps only clean fields.  Findings must carry a RED/AMBER severity
-/// (defence-in-depth greens exclusion).  `seed_notes` (the normalization
-/// drop-notes recorded by [`crate::report::synthesize_normalize`], #6009 shape
-/// 3) are recorded first, so an unrecognized-field drop is visible in the
-/// rendered status lines alongside a numeric-guardrail rejection.  `Ok` iff at
-/// least one field survived.
-///
-/// # Errors
-///
-/// [`SynthesisError::NoVerifiableContent`] when every field was rejected.
-///
-/// Test: `synthesize_tests.rs::{synthesize_rejects_unverified_figure,
-/// synthesize_happy_path_injects}`.
-fn apply_guardrail(
-    raw: RawSynthesis,
-    allowed: &std::collections::HashSet<String>,
-    seed_notes: Vec<String>,
-    grounding: &Grounding,
-) -> Result<Synthesis, SynthesisError> {
-    let mut out = Synthesis {
-        notes: seed_notes,
-        ..Synthesis::default()
-    };
-    let notes = &mut out.notes;
-
-    // Executive summary.
-    out.executive_summary = admit_field(
-        "executive summary",
-        &raw.executive_summary,
-        allowed,
-        grounding,
-        notes,
-    );
-
-    // #6004: Code Quality & Architecture and Security Posture narratives — same
-    // per-field guardrail path as the executive summary.
-    out.code_quality_summary = admit_field(
-        "code quality summary",
-        &raw.code_quality_summary,
-        allowed,
-        grounding,
-        notes,
-    );
-    out.security_summary = admit_field(
-        "security summary",
-        &raw.security_summary,
-        allowed,
-        grounding,
-        notes,
-    );
-    out.authorship_summary = admit_field(
-        "authorship summary",
-        &raw.authorship_summary,
-        allowed,
-        grounding,
-        notes,
-    );
-
-    // Top-risk rows. The row's description is narrative and takes the same
-    // grounding pass the paragraphs do (#6082 lap 4) — row 1 of the last report
-    // carried the same reachability contradiction the executive summary did.
-    for (i, mut r) in raw.top_risks.into_iter().enumerate() {
-        let label = format!("top-risk row {}", i + 1);
-        let Some(description) = admit_field(&label, &r.description, allowed, grounding, notes)
-        else {
-            continue;
-        };
-        r.description = description;
-        match verify_all(&[&r.severity, &r.cost, &r.apps], allowed) {
-            Ok(()) => out.top_risks.push(r),
-            Err(tok) => notes.push(format!("{REJECTED_NOTE} in {label}: {tok}")),
-        }
-    }
-
-    // RED/AMBER finding elaborations.
-    for mut f in raw.findings {
-        let sev = f.severity.to_uppercase();
-        if sev != "RED" && sev != "AMBER" {
-            notes.push(format!(
-                "synthesis: dropped finding '{}' (non-RED/AMBER severity '{}')",
-                f.title, f.severity
-            ));
-            continue;
-        }
-        // #6082 lap 5: a finding's OWN narrative fields take the same grounding
-        // pass the paragraphs do. Wiring the guard to the summaries and the
-        // top-risk rows alone left RED finding 3's business impact stating
-        // "remote/local code execution" two lines from a Security Posture
-        // paragraph the same guard had corrected to "not remotely".
-        // `evidence` is excluded deliberately: it is a verbatim quote verified
-        // against the file, so rewriting it would make the displayed quote
-        // diverge from the one that was checked. `component` is routing data,
-        // not narrative.
-        let label = format!("finding '{}'", f.title);
-        f.description = ground_field(
-            &format!("{label} description"),
-            &f.description,
-            grounding,
-            notes,
-        );
-        f.business_impact = ground_field(
-            &format!("{label} business impact"),
-            &f.business_impact,
-            grounding,
-            notes,
-        );
-        f.remediation = ground_field(
-            &format!("{label} remediation"),
-            &f.remediation,
-            grounding,
-            notes,
-        );
-        f.cost_effort = ground_field(
-            &format!("{label} cost/effort"),
-            &f.cost_effort,
-            grounding,
-            notes,
-        );
-        match verify_all(
-            &[
-                &f.description,
-                &f.evidence,
-                &f.component,
-                &f.business_impact,
-                &f.remediation,
-                &f.cost_effort,
-            ],
-            allowed,
-        ) {
-            Ok(()) => out.findings.push(f),
-            Err(tok) => notes.push(format!("{REJECTED_NOTE} in finding '{}': {tok}", f.title)),
-        }
-    }
-
-    if out.executive_summary.is_none()
-        && out.code_quality_summary.is_none()
-        && out.security_summary.is_none()
-        && out.authorship_summary.is_none()
-        && out.top_risks.is_empty()
-        && out.findings.is_empty()
-    {
-        return Err(SynthesisError::NoVerifiableContent);
-    }
-    Ok(out)
-}
-
-/// Run the grounding guardrail over the verified investigation's own prose.
-///
-/// Why: the guard used to run on synthesis prose only, and
-/// `merge_investigation_prose` overwrites that prose with the investigation's
-/// for every RED/AMBER finding — so the guarded copy was discarded before
-/// render. That is how RED finding 2 of the lap-6 report shipped "a remote code
-/// execution risk" in its business impact while the guard's own note in the same
-/// document recorded a correction it had made elsewhere. Correcting `inv` BEFORE
-/// `apply_investigation` fixes every downstream copy at once: the injected
-/// `metrics.findings` rows, `model.investigation` in the JSON twin, the
-/// synthesis prompt, and the merged prose that renders.
-/// What: builds the [`Grounding`] from the model plus `inv` (the model has not
-/// recorded it yet), then runs [`ground_field`] over each RED/AMBER finding's
-/// description, business impact, remediation and cost/effort. `evidence_quote`
-/// is excluded for the same reason it is in [`apply_guardrail`]: it is verified
-/// verbatim against the file. Returns one status line per correction or
-/// rejection, for the caller to fold into [`Synthesis::notes`].
-/// Test: `synthesize_tests.rs::{investigation_business_impact_states_host_local_reach,
-/// investigation_grounding_leaves_a_clean_finding_alone}`.
-pub fn ground_investigation_prose(
-    model: &ReportModel,
-    inv: &mut crate::report::investigate::Investigation,
-) -> Vec<String> {
-    let grounding = Grounding::from_model_with(model, Some(inv));
-    let mut notes = Vec::new();
-    for repo in &mut inv.repos {
-        for f in &mut repo.findings {
-            if f.severity == crate::report::metrics::Severity::Green {
-                continue; // greens are title-only topics; they carry no narrative
-            }
-            let label = format!("investigation finding '{}'", f.title);
-            f.description = ground_field(
-                &format!("{label} description"),
-                &f.description,
-                &grounding,
-                &mut notes,
-            );
-            f.business_impact = ground_field(
-                &format!("{label} business impact"),
-                &f.business_impact,
-                &grounding,
-                &mut notes,
-            );
-            f.remediation = ground_field(
-                &format!("{label} remediation"),
-                &f.remediation,
-                &grounding,
-                &mut notes,
-            );
-            f.cost_effort = ground_field(
-                &format!("{label} cost/effort"),
-                &f.cost_effort,
-                &grounding,
-                &mut notes,
-            );
-        }
-    }
-    notes
-}
-
-/// Run the grounding guardrail alone over one narrative field of a finding.
-///
-/// Why: a finding is verified as a WHOLE by [`verify_all`] — one bad figure
-/// anywhere rejects the entire finding — so its fields cannot go through
-/// [`admit_field`], which rejects per field. This is the grounding half on its
-/// own, leaving that all-or-nothing numeric contract untouched (#6082 lap 5).
-/// What: returns the text with any reachability claim corrected, or an empty
-/// string when the claim could not be corrected safely. An emptied field falls
-/// through to the reporter's honesty marker, which is what an absent field has
-/// always rendered as.
-/// Test: `synthesize_tests.rs::{synthesize_grounds_a_finding_business_impact,
-/// synthesize_empties_an_uncorrectable_remote_claim_in_a_finding}`.
-fn ground_field(label: &str, raw: &str, grounding: &Grounding, notes: &mut Vec<String>) -> String {
-    let text = raw.trim();
-    if text.is_empty() {
-        return String::new();
-    }
-    match grounding.check(text) {
-        GroundingOutcome::Clean => text.to_string(),
-        GroundingOutcome::Rewritten(fixed, corrections) => {
-            notes.extend(corrections);
-            fixed
-        }
-        GroundingOutcome::Rejected(reason) => {
-            notes.push(format!("{UNGROUNDED_NOTE} in {label}: {reason}"));
-            String::new()
-        }
-    }
-}
-
-/// Run both guardrails over one narrative field and return what may ship.
-///
-/// Why: the grounding check (#6082 lap 4) and the numeric check are two
-/// independent reasons a field cannot be trusted, and running them from one
-/// place is what stops a future field from being wired to only one of them.
-/// What: `None` for an empty field, for a grounding rejection, and for a numeric
-/// rejection — each of the last two recording its own note under its own prefix.
-/// Otherwise the text to keep, which is the model's own unless the grounding
-/// pass corrected a claim in it; the numeric check then runs on the CORRECTED
-/// text, so a rewrite can never smuggle a figure past it.
-/// Test: `synthesize_tests.rs::{synthesize_rewrites_a_remote_claim_about_a_local_finding,
-/// synthesize_rejects_a_load_bearing_claim_about_a_leaf_crate}`.
-fn admit_field(
-    label: &str,
-    raw: &str,
-    allowed: &std::collections::HashSet<String>,
-    grounding: &Grounding,
-    notes: &mut Vec<String>,
-) -> Option<String> {
-    let text = raw.trim();
-    if text.is_empty() {
-        return None;
-    }
-    let grounded = match grounding.check(text) {
-        GroundingOutcome::Clean => text.to_string(),
-        GroundingOutcome::Rewritten(fixed, corrections) => {
-            notes.extend(corrections);
-            fixed
-        }
-        GroundingOutcome::Rejected(reason) => {
-            notes.push(format!("{UNGROUNDED_NOTE} in {label}: {reason}"));
-            return None;
-        }
-    };
-    match verify_prose(&grounded, allowed) {
-        Ok(()) => Some(grounded),
-        Err(tok) => {
-            notes.push(format!("{REJECTED_NOTE} in {label}: {tok}"));
-            None
-        }
-    }
-}
-
-/// Verify every field of a group; returns the first offending token on failure.
-fn verify_all(fields: &[&str], allowed: &std::collections::HashSet<String>) -> Result<(), String> {
-    for field in fields {
-        verify_prose(field, allowed)?;
-    }
-    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/trusty-review/src/report/synthesize_grounding.rs
+++ b/crates/trusty-review/src/report/synthesize_grounding.rs
@@ -31,11 +31,40 @@
 //! [`REACHABILITY_WORDS`] vocabulary rather than the [`REACHABILITY_REWRITES`]
 //! phrase table, so an unrecognised spelling is rejected instead of skipped.
 //!
+//! #6082 lap 8 moved the reachability question off the finding's own wording and
+//! onto its COMPONENT, because a finding whose text happened to carry no
+//! loopback marker was never classified and so was never checked at all. A
+//! component now falls in one of three tiers, and [`Grounding::check`] takes the
+//! checked field's owning component so the tier is decided by the file the
+//! finding sits in rather than by which words the sentence happens to share with
+//! some other finding's title:
+//!
+//! 1. LOOPBACK-ESTABLISHED — some finding on that file carries a
+//!    [`LOOPBACK_MARKERS`] word. Every finding on the file inherits it, and every
+//!    [`REACHABILITY_WORDS`] occurrence in that finding's own narrative is
+//!    rewritten where [`REACHABILITY_REWRITES`] can and rejected where it cannot.
+//! 2. REMOTE-ESTABLISHED — some finding on that file carries a
+//!    [`REMOTE_MARKERS`] word. Left alone; remote wins over local on one file.
+//! 3. UNESTABLISHED — the collected data says nothing either way. A sentence
+//!    making a positive beyond-the-host reach claim (one [`REACHABILITY_REWRITES`]
+//!    recognises) is REJECTED, never rewritten: the report has no evidence the
+//!    surface is host-local either, so substituting a host-local phrase would
+//!    trade one unsupported claim for another.
+//!
+//! Tier 3 is what stops the lap-8 line. No finding on
+//! `crates/trusty-mpm/src/daemon/api/control_routes.rs` carried any reachability
+//! marker, so tier 1 could not reach it however far inheritance spread, and its
+//! business impact shipped "permits remote code execution" unexamined.
+//!
 //! Test: `synthesize_grounding_tests.rs`.
 
 use std::collections::BTreeSet;
 
 use super::model::ReportModel;
+use super::synthesize_grounding_text::{
+    asserts_reachability, contains_name, remove_sentence, rewrite_reachability, sentences,
+    subject_tokens,
+};
 use super::topology::CrateTopology;
 
 /// Text markers that scope a finding to a loopback-only surface.
@@ -88,7 +117,7 @@ const REMOTE_MARKERS: &[&str] = &[
 /// This table is a CONVENIENCE, not the gate. [`REACHABILITY_WORDS`] decides
 /// what gets checked and what may ship; a claim this table cannot rewrite is
 /// rejected rather than passed through.
-const REACHABILITY_REWRITES: &[(&str, &str)] = &[
+pub(super) const REACHABILITY_REWRITES: &[(&str, &str)] = &[
     // #6082 lap 5: the hedged form. RED finding 3's business impact read
     // "enabling remote/local code execution" — no pattern below matches it,
     // because the `/local` sits between the two words every other pattern
@@ -165,7 +194,7 @@ const REACHABILITY_REWRITES: &[(&str, &str)] = &[
 /// the embedder") is rejected too, and its field falls back to the honesty
 /// marker with a note in Synthesis Status. A due-diligence report claiming
 /// network reach for a loopback-bound daemon is the worse of the two errors.
-const REACHABILITY_WORDS: &[&str] = &["remote", "network", "internet"];
+pub(super) const REACHABILITY_WORDS: &[&str] = &["remote", "network", "internet"];
 
 /// The two words every "this dimension has no clean signal" sentence is built
 /// around (#6082 lap 7).
@@ -192,22 +221,39 @@ const LOAD_BEARING_PHRASES: &[&str] = &[
 ];
 
 /// Path and title words too generic to identify a finding's subject.
-const GENERIC_TOKENS: &[&str] = &[
+pub(super) const GENERIC_TOKENS: &[&str] = &[
     "crates", "src", "main", "lib", "mod", "test", "tests", "with", "this", "that", "from", "into",
     "have", "http", "https", "file", "line", "code", "data", "self", "type", "used", "when",
     "over", "path", "call", "rust",
 ];
 
 /// Shortest path/title word admitted as a subject token.
-const MIN_TOKEN_LEN: usize = 4;
+pub(super) const MIN_TOKEN_LEN: usize = 4;
 
-/// One finding the report's own text scopes to a loopback-only surface.
+/// One finding the report's own data scopes to a loopback-only surface.
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct LocalOnly {
     /// The finding's title, for the note the guardrail records.
     title: String,
+    /// The file this finding sits in, normalized by [`normalize_component`].
+    ///
+    /// This is what makes the classification shared: every finding on a
+    /// loopback-established file gets an entry here, whatever its own text says.
+    component: String,
     /// The words a sentence must share to be about this finding.
     tokens: BTreeSet<String>,
+}
+
+/// One finding as read, before its component's tier is known.
+///
+/// Why: a file's tier depends on EVERY finding on it, so no single finding can
+/// be classified while the walk is still running (#6082 lap 8).
+struct Staged {
+    title: String,
+    component: String,
+    tokens: BTreeSet<String>,
+    local: bool,
+    remote: bool,
 }
 
 /// What the grounding guardrail decided about one narrative field.
@@ -243,6 +289,8 @@ pub(crate) struct Grounding {
     local_only: Vec<LocalOnly>,
     /// Subject tokens belonging to at least one network-reachable finding.
     remote_tokens: BTreeSet<String>,
+    /// Files some finding establishes as network-reachable (#6082 lap 8).
+    remote_components: BTreeSet<String>,
     /// Crates admitted as load-bearing, most-depended first, with their counts.
     load_bearing: Vec<(String, usize)>,
     /// Every declared crate name — the match vocabulary for the post-check.
@@ -282,16 +330,17 @@ impl Grounding {
         inv: Option<&super::investigate::Investigation>,
     ) -> Self {
         let mut out = Grounding::default();
+        let mut staged: Vec<Staged> = Vec::new();
         let mut from_metrics = 0usize;
         let mut from_inv = 0usize;
         for repo in &model.repositories {
             if let Some(metrics) = &repo.metrics {
                 for f in &metrics.findings {
-                    out.ingest(
+                    staged.push(stage(
                         &f.title,
                         &f.component,
                         &[&f.description, &f.remediation, &f.component],
-                    );
+                    ));
                     if is_clean_security_signal(f.category.as_str(), f.severity, &f.component) {
                         from_metrics += 1;
                     }
@@ -301,7 +350,7 @@ impl Grounding {
         if let Some(inv) = inv {
             for repo in &inv.repos {
                 for f in &repo.findings {
-                    out.ingest(
+                    staged.push(stage(
                         &f.title,
                         &f.file,
                         &[
@@ -311,7 +360,7 @@ impl Grounding {
                             &f.evidence_quote,
                             &f.file,
                         ],
-                    );
+                    ));
                     if is_clean_security_signal(f.dimension.as_str(), f.severity, &f.file) {
                         from_inv += 1;
                     }
@@ -322,6 +371,7 @@ impl Grounding {
         // `apply_investigation`, so after that pass both loops see the same
         // signals. The larger count is the real one either way.
         out.clean_signals = from_metrics.max(from_inv);
+        out.classify(staged);
         for topology in model
             .repositories
             .iter()
@@ -332,30 +382,59 @@ impl Grounding {
         out
     }
 
-    /// Record one finding's reachability, if its own text states one.
-    fn ingest(&mut self, title: &str, component: &str, texts: &[&String]) {
-        let joined = texts
-            .iter()
-            .map(|t| t.to_lowercase())
-            .collect::<Vec<_>>()
-            .join(" ");
-        let remote = REMOTE_MARKERS.iter().any(|m| joined.contains(m));
-        let local = LOOPBACK_MARKERS.iter().any(|m| joined.contains(m));
-        if !remote && !local {
-            return;
+    /// Settle every staged finding's tier, then spread it across its file.
+    ///
+    /// Why: reachability is a property of the surface, not of the sentence that
+    /// happens to describe it. One finding on a file stating "localhost" states
+    /// it for every finding on that file (#6082 lap 8).
+    /// What: collects the loopback- and remote-established files, lets remote win
+    /// where both fired, then records every finding on a loopback-established
+    /// file as [`LocalOnly`] — including the ones whose own text said nothing.
+    /// A finding with no component is classified by its own text alone, as
+    /// before: there is no file to share the classification with.
+    /// Test: `synthesize_grounding_tests.rs::{a_sibling_finding_inherits_its_files_loopback_scope,
+    /// a_remote_finding_on_the_file_wins_over_a_loopback_sibling}`.
+    fn classify(&mut self, staged: Vec<Staged>) {
+        let mut local_files = BTreeSet::new();
+        for s in &staged {
+            if s.component.is_empty() {
+                continue;
+            }
+            if s.remote {
+                self.remote_components.insert(s.component.clone());
+            } else if s.local {
+                local_files.insert(s.component.clone());
+            }
         }
-        let tokens = subject_tokens(title, component);
-        if tokens.is_empty() {
-            return;
+        for f in &self.remote_components {
+            local_files.remove(f);
         }
-        if remote {
-            self.remote_tokens.extend(tokens);
-            return;
+        let mut seen = BTreeSet::new();
+        for s in staged {
+            let has_file = !s.component.is_empty();
+            let remote = if has_file {
+                self.remote_components.contains(&s.component)
+            } else {
+                s.remote
+            };
+            if remote {
+                self.remote_tokens.extend(s.tokens);
+                continue;
+            }
+            let local = if has_file {
+                local_files.contains(&s.component)
+            } else {
+                s.local
+            };
+            if !local || !seen.insert((s.title.clone(), s.component.clone())) {
+                continue;
+            }
+            self.local_only.push(LocalOnly {
+                title: s.title,
+                component: s.component,
+                tokens: s.tokens,
+            });
         }
-        self.local_only.push(LocalOnly {
-            title: title.trim().to_string(),
-            tokens,
-        });
     }
 
     /// Fold one workspace's topology into the load-bearing set and vocabulary.
@@ -429,13 +508,21 @@ impl Grounding {
     /// nothing to rewrite afterwards), then drops any false no-clean-signal
     /// claim, then runs the reachability check over what is left. Returns
     /// `Clean` when none fired.
+    ///
+    /// `owner` is the component of the finding this field belongs to, and `None`
+    /// for report-level prose that belongs to no single finding — the executive,
+    /// code-quality, security and authorship summaries, and the top-risk rows.
+    /// A named owner decides the reachability tier on its own; ownerless prose
+    /// falls back to matching sentences against every loopback-scoped finding's
+    /// subject tokens, which is the only thing available when the prose is about
+    /// the whole estate (#6082 lap 8).
     /// Test: `synthesize_grounding_tests.rs`.
-    pub(crate) fn check(&self, text: &str) -> GroundingOutcome {
+    pub(crate) fn check(&self, text: &str, owner: Option<&str>) -> GroundingOutcome {
         if let Some(reason) = self.load_bearing_violation(text) {
             return GroundingOutcome::Rejected(reason);
         }
         let (text, mut notes) = self.drop_false_no_clean_signal(text);
-        match self.reachability(&text) {
+        match self.reachability(&text, owner) {
             GroundingOutcome::Clean if notes.is_empty() => GroundingOutcome::Clean,
             GroundingOutcome::Clean => GroundingOutcome::Rewritten(text, notes),
             GroundingOutcome::Rewritten(fixed, more) => {
@@ -482,8 +569,8 @@ impl Grounding {
             }
             out = remove_sentence(&out, sentence);
             notes.push(format!(
-                "synthesis: a sentence claiming no clean signal was credited was dropped — the \
-                 Security Posture section credits {} of them, each with the file it was read from",
+                "a sentence claiming no clean signal was credited was dropped — the Security \
+                 Posture section credits {} of them, each with the file it was read from",
                 self.clean_signals
             ));
         }
@@ -522,16 +609,35 @@ impl Grounding {
         None
     }
 
-    /// Correct — or refuse — a beyond-the-host reachability claim about a
-    /// local-only finding.
+    /// Correct — or refuse — a beyond-the-host reachability claim.
     ///
-    /// Why/What: see the module doc. A sentence is about a local-only finding
-    /// when it shares one of that finding's subject tokens and no
-    /// network-reachable finding claims the same token. The trigger and the
-    /// ship/reject decision read the SAME [`REACHABILITY_WORDS`] vocabulary, so
-    /// a spelling [`REACHABILITY_REWRITES`] cannot correct is rejected instead
-    /// of skipped.
-    fn reachability(&self, text: &str) -> GroundingOutcome {
+    /// Why/What: the three tiers in the module doc, in one pass. A field whose
+    /// owning component is loopback-established is checked against that
+    /// component, with no token matching at all: the field belongs to the
+    /// finding, so guessing which finding a sentence is about can only get it
+    /// wrong. Ownerless prose keeps the token match. A field whose owning
+    /// component has no reachability evidence is tier 3 — a positive reach claim
+    /// there is rejected rather than rewritten, because "host-local" would be
+    /// just as unsupported as "remote".
+    /// Test: `synthesize_grounding_tests.rs::{a_sibling_finding_inherits_its_files_loopback_scope,
+    /// an_unevidenced_component_cannot_claim_beyond_host_reach,
+    /// an_unevidenced_component_keeps_a_non_reach_mention_of_the_network}`.
+    fn reachability(&self, text: &str, owner: Option<&str>) -> GroundingOutcome {
+        let key = owner.map(normalize_component).filter(|k| !k.is_empty());
+        let owned = key
+            .as_deref()
+            .and_then(|k| self.local_only.iter().find(|f| f.component == k));
+        // Tier 3: an owner the collected data places neither on loopback nor on
+        // the network. Tier 2 (remote-established) and an owner with no usable
+        // path both fall through to `Clean` below.
+        if let Some(k) = key.as_deref()
+            && owned.is_none()
+        {
+            return match self.remote_components.contains(k) {
+                true => GroundingOutcome::Clean,
+                false => self.refuse_unevidenced_reach(text, owner.unwrap_or_default()),
+            };
+        }
         if self.local_only.is_empty() {
             return GroundingOutcome::Clean;
         }
@@ -542,21 +648,25 @@ impl Grounding {
             if !asserts_reachability(&lower) {
                 continue;
             }
-            let Some(finding) = self.local_subject(&lower) else {
-                continue;
+            let finding = match owned {
+                Some(f) => f,
+                None => match self.local_subject(&lower) {
+                    Some(f) => f,
+                    None => continue,
+                },
             };
             let corrected = rewrite_reachability(sentence);
             if asserts_reachability(&corrected) {
                 return GroundingOutcome::Rejected(format!(
                     "a beyond-the-host reachability claim about '{}' could not be corrected \
-                     safely — that finding's own text scopes it to localhost",
+                     safely — the report's own evidence scopes that surface to localhost",
                     finding.title
                 ));
             }
             out = out.replace(sentence, &corrected);
             notes.push(format!(
-                "synthesis: reachability corrected — '{}' is loopback-scoped by its own text, so \
-                 the beyond-the-host reachability wording was rewritten",
+                "the beyond-the-host reachability wording was corrected — the report's own \
+                 evidence scopes '{}' to a loopback-only surface",
                 finding.title
             ));
         }
@@ -564,6 +674,34 @@ impl Grounding {
             true => GroundingOutcome::Clean,
             false => GroundingOutcome::Rewritten(out, notes),
         }
+    }
+
+    /// Tier 3: refuse a positive beyond-the-host reach claim about a component
+    /// the collected data says nothing about.
+    ///
+    /// Why: rewriting needs evidence the surface is host-local, and there is
+    /// none — so the only honest outcomes are ship-unexamined or withhold. A
+    /// due-diligence report withholds.
+    /// What: `Rejected` for a sentence [`REACHABILITY_REWRITES`] recognises as a
+    /// reach claim (the rewrite changes it), `Clean` otherwise. The rewrite table
+    /// rather than [`REACHABILITY_WORDS`] is the trigger here deliberately: with
+    /// no evidence either way, a bare "network" in "a transient network error"
+    /// asserts nothing about reachability and must not cost a reader the field.
+    fn refuse_unevidenced_reach(&self, text: &str, component: &str) -> GroundingOutcome {
+        for sentence in sentences(text) {
+            if !asserts_reachability(&sentence.to_lowercase()) {
+                continue;
+            }
+            if rewrite_reachability(sentence) == sentence {
+                continue;
+            }
+            return GroundingOutcome::Rejected(format!(
+                "a beyond-the-host reachability claim about `{}` cannot be verified — the \
+                 collected data records no evidence of how that surface is reached",
+                component.trim()
+            ));
+        }
+        GroundingOutcome::Clean
     }
 
     /// The local-only finding a lower-cased sentence is about, if exactly that.
@@ -574,6 +712,44 @@ impl Grounding {
                 .any(|t| contains_name(lower_sentence, t) && !self.remote_tokens.contains(t))
         })
     }
+}
+
+/// Read one finding's reachability markers, deferring the verdict to
+/// [`Grounding::classify`].
+fn stage(title: &str, component: &str, texts: &[&String]) -> Staged {
+    let joined = texts
+        .iter()
+        .map(|t| t.to_lowercase())
+        .collect::<Vec<_>>()
+        .join(" ");
+    Staged {
+        title: title.trim().to_string(),
+        component: normalize_component(component),
+        tokens: subject_tokens(title, component),
+        local: LOOPBACK_MARKERS.iter().any(|m| joined.contains(m)),
+        remote: REMOTE_MARKERS.iter().any(|m| joined.contains(m)),
+    }
+}
+
+/// Reduce a component reference to the bare file path it names.
+///
+/// Why: the same file arrives as `crates/…/control_routes.rs` from the
+/// investigation and `crates/…/control_routes.rs:268` from the metrics rows, and
+/// two findings on one file must land on one key or they cannot share a tier.
+/// What: separators normalized to `/`, any trailing `:<line>[:<column>]` dropped,
+/// lower-cased. An empty or non-path component yields an empty string, which
+/// [`Grounding::classify`] reads as "no file to share with".
+/// Test: `synthesize_grounding_tests.rs::a_line_suffix_does_not_split_a_component`.
+fn normalize_component(raw: &str) -> String {
+    let normalized = raw.trim().replace('\\', "/");
+    let mut path = normalized.as_str();
+    while let Some((head, tail)) = path.rsplit_once(':') {
+        if tail.is_empty() || !tail.bytes().all(|b| b.is_ascii_digit()) {
+            break;
+        }
+        path = head;
+    }
+    path.trim().to_lowercase()
 }
 
 /// The crates admitted as load-bearing: the top quartile by dependent count.
@@ -611,119 +787,6 @@ fn is_clean_security_signal(
     severity == super::metrics::Severity::Green
         && dimension == super::investigate::SECURITY_DIMENSION
         && !cite.trim().is_empty()
-}
-
-/// Cut `sentence` out of `text`, taking the space that separated it from its
-/// neighbour so the remaining prose keeps single spacing.
-fn remove_sentence(text: &str, sentence: &str) -> String {
-    let spaced = format!("{sentence} ");
-    if text.contains(&spaced) {
-        return text.replace(&spaced, "");
-    }
-    text.replace(sentence, "")
-}
-
-/// The words that identify one finding's subject: its component path segments
-/// and its title words, minus the generic ones.
-fn subject_tokens(title: &str, component: &str) -> BTreeSet<String> {
-    let mut out = BTreeSet::new();
-    for raw in component
-        .split(['/', '\\', '.', ':'])
-        .chain(title.split_whitespace())
-    {
-        let word: String = raw
-            .trim_matches(|c: char| !c.is_alphanumeric() && c != '-' && c != '_')
-            .to_lowercase();
-        if word.len() < MIN_TOKEN_LEN || GENERIC_TOKENS.contains(&word.as_str()) {
-            continue;
-        }
-        if word.chars().all(|c| c.is_ascii_digit()) {
-            continue;
-        }
-        out.insert(word);
-    }
-    out
-}
-
-/// True when `haystack` contains `needle` bounded by non-identifier characters.
-///
-/// Why: a bare `contains` would match `trusty-mpm` inside `trusty-mpm-gui` and
-/// blame the wrong crate.
-fn contains_name(haystack: &str, needle: &str) -> bool {
-    if needle.is_empty() {
-        return false;
-    }
-    let bytes = haystack.as_bytes();
-    let ident = |b: u8| b.is_ascii_alphanumeric() || b == b'_' || b == b'-';
-    haystack.match_indices(needle).any(|(i, _)| {
-        let before_ok = i == 0 || !ident(bytes[i - 1]);
-        let after = i + needle.len();
-        let after_ok = after >= bytes.len() || !ident(bytes[after]);
-        before_ok && after_ok
-    })
-}
-
-/// Apply every known reachability rewrite to one sentence, case-insensitively.
-fn rewrite_reachability(sentence: &str) -> String {
-    let mut out = sentence.to_string();
-    for (phrase, replacement) in REACHABILITY_REWRITES {
-        out = replace_ignore_case(&out, phrase, replacement);
-    }
-    out
-}
-
-/// Case-insensitive literal replacement preserving everything else verbatim.
-fn replace_ignore_case(haystack: &str, needle: &str, replacement: &str) -> String {
-    let lower = haystack.to_lowercase();
-    let mut out = String::with_capacity(haystack.len());
-    let mut cursor = 0usize;
-    while let Some(rel) = lower[cursor..].find(needle) {
-        let at = cursor + rel;
-        out.push_str(&haystack[cursor..at]);
-        out.push_str(replacement);
-        cursor = at + needle.len();
-    }
-    out.push_str(&haystack[cursor..]);
-    out
-}
-
-/// True when a sentence asserts reachability beyond this host.
-///
-/// A plain substring test, not a word-boundary one: every rewrite in
-/// [`REACHABILITY_REWRITES`] removes its own reachability word, so any
-/// occurrence left belongs to a phrase this module does not know how to
-/// correct — including a hyphenated one like `remote-management` or
-/// `network-attached`, which a boundary test would miss.
-fn asserts_reachability(sentence: &str) -> bool {
-    let lower = sentence.to_lowercase();
-    REACHABILITY_WORDS.iter().any(|w| lower.contains(w))
-}
-
-/// Split prose into sentences on `. `, `? ` and `! ` boundaries, keeping each
-/// sentence's own text so the caller can splice a correction back in.
-fn sentences(text: &str) -> Vec<&str> {
-    let mut out = Vec::new();
-    let mut start = 0usize;
-    let bytes = text.as_bytes();
-    for (i, b) in bytes.iter().enumerate() {
-        if !matches!(b, b'.' | b'?' | b'!' | b'\n') {
-            continue;
-        }
-        let next_is_break = bytes.get(i + 1).is_none_or(|n| n.is_ascii_whitespace());
-        if !next_is_break {
-            continue;
-        }
-        let piece = text[start..=i].trim();
-        if !piece.is_empty() {
-            out.push(piece);
-        }
-        start = i + 1;
-    }
-    let tail = text[start..].trim();
-    if !tail.is_empty() {
-        out.push(tail);
-    }
-    out
 }
 
 #[cfg(test)]

--- a/crates/trusty-review/src/report/synthesize_grounding_tests.rs
+++ b/crates/trusty-review/src/report/synthesize_grounding_tests.rs
@@ -6,6 +6,7 @@ use crate::report::investigate::{
 };
 use crate::report::metrics::{AnalyzeMetrics, MetricFinding, Severity};
 use crate::report::model::{ReportModel, RepositoryReport};
+use crate::report::synthesize_grounding_text::replace_ignore_case;
 use crate::report::topology::CrateNode;
 
 fn node(name: &str, inbound: usize) -> CrateNode {
@@ -144,7 +145,10 @@ fn a_remote_finding_vetoes_its_tokens() {
     let g = Grounding::from_model(&model);
     assert!(g.remote_tokens.contains("trusty-mpm"));
     assert_eq!(
-        g.check("The trusty-mpm daemon is an unauthenticated remote-code-execution path."),
+        g.check(
+            "The trusty-mpm daemon is an unauthenticated remote-code-execution path.",
+            None
+        ),
         GroundingOutcome::Clean
     );
 }
@@ -201,8 +205,8 @@ fn a_remote_claim_about_a_local_finding_is_rewritten() {
                  session HTTP endpoints with no auth, and a handler that spawns processes — \
                  together an unauthenticated remote-code-execution path. A JQL injection adds \
                  a query-tampering vector.";
-    let GroundingOutcome::Rewritten(fixed, notes) = g.check(prose) else {
-        panic!("expected a rewrite, got {:?}", g.check(prose));
+    let GroundingOutcome::Rewritten(fixed, notes) = g.check(prose, None) else {
+        panic!("expected a rewrite, got {:?}", g.check(prose, None));
     };
     assert!(
         !fixed.to_lowercase().contains("remote"),
@@ -211,7 +215,7 @@ fn a_remote_claim_about_a_local_finding_is_rewritten() {
     assert!(fixed.contains("local-process-reachable code-execution"));
     assert!(fixed.contains("A JQL injection adds a query-tampering vector."));
     assert_eq!(notes.len(), 1);
-    assert!(notes[0].contains("reachability corrected"));
+    assert!(notes[0].contains("reachability wording was corrected"));
 }
 
 /// A remote claim this module cannot rewrite fails the field closed and names
@@ -221,8 +225,8 @@ fn an_uncorrectable_remote_claim_rejects_the_field() {
     let g = Grounding::from_model(&loopback_model());
     let prose = "The trusty-mpm control-plane offers remote code execution and a remote-management \
                  surface to anyone on the internet.";
-    let GroundingOutcome::Rejected(reason) = g.check(prose) else {
-        panic!("expected a rejection, got {:?}", g.check(prose));
+    let GroundingOutcome::Rejected(reason) = g.check(prose, None) else {
+        panic!("expected a rejection, got {:?}", g.check(prose, None));
     };
     assert!(reason.contains("could not be corrected safely"));
     assert!(reason.contains("Control-plane HTTP session endpoints"));
@@ -234,7 +238,10 @@ fn an_uncorrectable_remote_claim_rejects_the_field() {
 fn a_remote_claim_about_an_unrelated_subject_is_left_alone() {
     let g = Grounding::from_model(&loopback_model());
     assert_eq!(
-        g.check("The Telegram bot token grants remote control over managed daemons."),
+        g.check(
+            "The Telegram bot token grants remote control over managed daemons.",
+            None
+        ),
         GroundingOutcome::Clean
     );
 }
@@ -244,7 +251,10 @@ fn a_remote_claim_about_an_unrelated_subject_is_left_alone() {
 fn reachability_is_inert_without_a_local_finding() {
     let g = Grounding::from_model(&model_with(vec![repo("estate", vec![], None)]));
     assert_eq!(
-        g.check("An unauthenticated remote-code-execution path exists in trusty-mpm."),
+        g.check(
+            "An unauthenticated remote-code-execution path exists in trusty-mpm.",
+            None
+        ),
         GroundingOutcome::Clean
     );
 }
@@ -288,17 +298,17 @@ fn instructions_that_countermand_a_guard_do_not_disable_it() {
     let g = Grounding::from_model(&model);
     let prose = "The trusty-mpm control_routes session endpoints are an unauthenticated \
                  remote-code-execution path.";
-    let GroundingOutcome::Rewritten(fixed, notes) = g.check(prose) else {
+    let GroundingOutcome::Rewritten(fixed, notes) = g.check(prose, None) else {
         panic!(
             "instructions must not disable the reachability guard, got {:?}",
-            g.check(prose)
+            g.check(prose, None)
         );
     };
     assert!(
         !fixed.to_lowercase().contains("remote"),
         "the guard must still strip the remote claim: {fixed}"
     );
-    assert!(notes[0].contains("reachability corrected"));
+    assert!(notes[0].contains("reachability wording was corrected"));
 }
 
 // ─── Load-bearing post-check ─────────────────────────────────────────────────
@@ -308,9 +318,10 @@ fn instructions_that_countermand_a_guard_do_not_disable_it() {
 fn a_load_bearing_claim_about_a_leaf_crate_is_rejected() {
     let model = model_with(vec![repo("estate", vec![], Some(eight_crate_topology()))]);
     let g = Grounding::from_model(&model);
-    let GroundingOutcome::Rejected(reason) =
-        g.check("trusty-common and trusty-mpm are the load-bearing crates the estate depends on.")
-    else {
+    let GroundingOutcome::Rejected(reason) = g.check(
+        "trusty-common and trusty-mpm are the load-bearing crates the estate depends on.",
+        None,
+    ) else {
         panic!("expected a rejection");
     };
     assert!(reason.contains("trusty-mpm"), "reason was: {reason}");
@@ -323,7 +334,8 @@ fn a_load_bearing_claim_about_the_shared_core_passes() {
     let model = model_with(vec![repo("estate", vec![], Some(eight_crate_topology()))]);
     assert_eq!(
         Grounding::from_model(&model).check(
-            "trusty-common and trusty-mcp are the load-bearing crates the estate depends on."
+            "trusty-common and trusty-mcp are the load-bearing crates the estate depends on.",
+            None
         ),
         GroundingOutcome::Clean
     );
@@ -334,8 +346,10 @@ fn a_load_bearing_claim_about_the_shared_core_passes() {
 fn naming_a_leaf_crate_outside_a_load_bearing_claim_passes() {
     let model = model_with(vec![repo("estate", vec![], Some(eight_crate_topology()))]);
     assert_eq!(
-        Grounding::from_model(&model)
-            .check("trusty-mpm is a multi-process manager daemon with 0 dependents."),
+        Grounding::from_model(&model).check(
+            "trusty-mpm is a multi-process manager daemon with 0 dependents.",
+            None
+        ),
         GroundingOutcome::Clean
     );
 }
@@ -344,9 +358,10 @@ fn naming_a_leaf_crate_outside_a_load_bearing_claim_passes() {
 #[test]
 fn a_crate_name_is_matched_on_its_own_boundaries() {
     let model = model_with(vec![repo("estate", vec![], Some(eight_crate_topology()))]);
-    let GroundingOutcome::Rejected(reason) = Grounding::from_model(&model)
-        .check("trusty-mpm-gui is the load-bearing crate the estate depends on.")
-    else {
+    let GroundingOutcome::Rejected(reason) = Grounding::from_model(&model).check(
+        "trusty-mpm-gui is the load-bearing crate the estate depends on.",
+        None,
+    ) else {
         panic!("expected a rejection");
     };
     assert!(reason.contains("trusty-mpm-gui"), "reason was: {reason}");
@@ -419,7 +434,7 @@ fn the_live_remote_code_execution_claim_is_rewritten() {
     let mut model = model_with(vec![repo("estate", vec![], None)]);
     model.investigation = Some(control_routes_investigation());
     let GroundingOutcome::Rewritten(text, notes) =
-        Grounding::from_model(&model).check(LIVE_BUSINESS_IMPACT)
+        Grounding::from_model(&model).check(LIVE_BUSINESS_IMPACT, None)
     else {
         panic!("expected the live business impact to be rewritten");
     };
@@ -500,7 +515,7 @@ fn the_live_network_reachability_claim_is_rewritten() {
     let mut model = model_with(vec![repo("estate", vec![], None)]);
     model.investigation = Some(network_claim_investigation());
     let GroundingOutcome::Rewritten(text, notes) =
-        Grounding::from_model(&model).check(LIVE_NETWORK_IMPACT)
+        Grounding::from_model(&model).check(LIVE_NETWORK_IMPACT, None)
     else {
         panic!("expected the live network claim to be rewritten");
     };
@@ -524,8 +539,10 @@ fn the_live_network_reachability_claim_is_rewritten() {
 fn an_unrewritable_network_claim_is_rejected() {
     let mut model = model_with(vec![repo("estate", vec![], None)]);
     model.investigation = Some(network_claim_investigation());
-    let outcome = Grounding::from_model(&model)
-        .check("Any host with network line-of-sight can stop a running session.");
+    let outcome = Grounding::from_model(&model).check(
+        "Any host with network line-of-sight can stop a running session.",
+        None,
+    );
     assert!(
         matches!(outcome, GroundingOutcome::Rejected(_)),
         "expected rejection, got: {outcome:?}"
@@ -573,7 +590,7 @@ fn a_no_clean_signal_claim_is_dropped_when_signals_exist() {
     let prose = "Error handling is frequently fail-open or lossy. No clean security signal is \
                  credited here.";
     let GroundingOutcome::Rewritten(text, notes) =
-        Grounding::from_model(&clean_signal_model()).check(prose)
+        Grounding::from_model(&clean_signal_model()).check(prose, None)
     else {
         panic!("expected the false no-clean-signal claim to be dropped");
     };
@@ -591,7 +608,7 @@ fn a_no_clean_signal_claim_is_dropped_when_signals_exist() {
 fn a_no_clean_signal_claim_survives_when_there_are_none() {
     let model = model_with(vec![repo("estate", vec![], None)]);
     assert_eq!(
-        Grounding::from_model(&model).check("No clean security signal is credited here."),
+        Grounding::from_model(&model).check("No clean security signal is credited here.", None),
         GroundingOutcome::Clean
     );
 }
@@ -608,7 +625,7 @@ fn an_uncited_green_is_not_counted_as_a_clean_signal() {
         .findings[0]
         .component = String::new();
     assert_eq!(
-        Grounding::from_model(&model).check("No clean security signal is credited here."),
+        Grounding::from_model(&model).check("No clean security signal is credited here.", None),
         GroundingOutcome::Clean
     );
 }
@@ -619,4 +636,195 @@ fn prompt_facts_state_the_clean_signal_count() {
     let facts = Grounding::from_model(&clean_signal_model()).prompt_facts();
     assert!(facts.contains("credits 1 GREEN security finding(s)"));
     assert!(facts.contains("Never write that no clean signal was found"));
+}
+
+// ─── #6082 lap 8: reachability is a property of the component ────────────────
+
+/// The lap-8 line, verbatim: §5.1 item 3's business impact.
+const LIVE_ARBITRARY_EXEC_IMPACT: &str = "Combined with the lack of auth, this permits remote code execution by pointing the session \
+     at any binary on the host.";
+
+/// The file both control-plane findings sit in.
+const CONTROL_ROUTES: &str = "crates/trusty-mpm/src/daemon/api/control_routes.rs";
+
+/// The finding that shipped the lap-8 line, with the sibling it shares a file
+/// with. `local_sibling` decides whether that sibling states a loopback scope.
+fn control_plane_model(local_sibling: bool) -> ReportModel {
+    let sibling_remediation = match local_sibling {
+        true => "Bind the control routes to localhost and add an auth middleware layer",
+        false => {
+            "Add an authentication/authorization layer (token or mTLS middleware) in front \
+                  of these control-plane routes"
+        }
+    };
+    model_with(vec![repo(
+        "estate",
+        vec![
+            finding(
+                "Control-plane HTTP handlers accept unauthenticated callers",
+                &format!("{CONTROL_ROUTES}:259"),
+                sibling_remediation,
+            ),
+            finding(
+                "Arbitrary executable path accepted from HTTP request body",
+                &format!("{CONTROL_ROUTES}:268"),
+                "Validate/allow-list the executable path and prompt file location before \
+                 constructing RunParams",
+            ),
+        ],
+        None,
+    )])
+}
+
+/// Tier 1: a finding whose own wording carries no loopback marker inherits the
+/// scope its file's sibling finding establishes.
+///
+/// This is the class the lap-8 defect belongs to. Before the fix the guard
+/// classified per finding TEXT, so item 3 was never local-only, never had a
+/// subject to be checked against, and the sentence below shipped as written.
+#[test]
+fn a_sibling_finding_inherits_its_files_loopback_scope() {
+    let g = Grounding::from_model(&control_plane_model(true));
+    let owner = format!("{CONTROL_ROUTES}:268");
+    let GroundingOutcome::Rewritten(fixed, notes) =
+        g.check(LIVE_ARBITRARY_EXEC_IMPACT, Some(&owner))
+    else {
+        panic!(
+            "expected a rewrite, got {:?}",
+            g.check(LIVE_ARBITRARY_EXEC_IMPACT, Some(&owner))
+        );
+    };
+    assert!(
+        !fixed.to_lowercase().contains("remote"),
+        "remote survived: {fixed}"
+    );
+    assert!(fixed.contains("local-process-reachable code execution"));
+    assert!(notes[0].contains("reachability wording was corrected"));
+}
+
+/// Tier 3, and what the live report actually held: NO finding on that file
+/// carries any reachability marker, so there is nothing for tier 1 to inherit.
+///
+/// The claim cannot be corrected — the report has no evidence the surface is
+/// host-local either — so it is withheld and disclosed rather than shipped.
+#[test]
+fn an_unevidenced_component_cannot_claim_beyond_host_reach() {
+    let g = Grounding::from_model(&control_plane_model(false));
+    let owner = format!("{CONTROL_ROUTES}:268");
+    let GroundingOutcome::Rejected(reason) = g.check(LIVE_ARBITRARY_EXEC_IMPACT, Some(&owner))
+    else {
+        panic!(
+            "expected a rejection, got {:?}",
+            g.check(LIVE_ARBITRARY_EXEC_IMPACT, Some(&owner))
+        );
+    };
+    assert!(reason.contains("cannot be verified"), "{reason}");
+    assert!(reason.contains(CONTROL_ROUTES), "{reason}");
+}
+
+/// Tier 3 costs a reader nothing when the sentence never claimed reach.
+///
+/// All three are live business impacts from the same report. A bare "network"
+/// in "a transient network error" states nothing about who can reach the
+/// surface, and emptying those fields would be the guard doing more damage than
+/// the claim it exists to stop.
+#[test]
+fn an_unevidenced_component_keeps_a_non_reach_mention_of_the_network() {
+    let g = Grounding::from_model(&control_plane_model(false));
+    let owner = format!("{CONTROL_ROUTES}:268");
+    for prose in [
+        "Intermittent network or daemon load can quietly degrade audit completeness without any \
+         operator signal beyond a gap line.",
+        "High complexity in the network error path raises maintenance cost and the risk that a \
+         new endpoint mishandles an error status.",
+        "Release process cannot proceed when the external registry or network is unavailable.",
+    ] {
+        assert_eq!(
+            g.check(prose, Some(&owner)),
+            GroundingOutcome::Clean,
+            "withheld a sentence that claims no reach: {prose}"
+        );
+    }
+}
+
+/// A finding is judged by its OWN component, never by a word it happens to
+/// share with another finding's title.
+///
+/// The graded report emptied §5.2 item 47's business impact — an Azure DevOps
+/// complexity hotspot — by matching its "endpoint" against the trusty-search
+/// admin finding's title tokens, then refusing a claim that finding never made.
+#[test]
+fn a_finding_is_not_judged_by_another_findings_tokens() {
+    let model = model_with(vec![repo(
+        "estate",
+        vec![
+            finding(
+                "Admin stop endpoint trusts every caller with no authentication",
+                "crates/trusty-search/src/service/server/admin.rs:74",
+                "Require an auth token or local socket ownership check on privileged admin \
+                 endpoints",
+            ),
+            finding(
+                "Hotspot HTTP client function has cyclomatic complexity 98",
+                "crates/trusty-git-analytics/src/collect/azdo/client.rs:36",
+                "Route all responses through the existing map_response_error helper",
+            ),
+        ],
+        None,
+    )]);
+    assert_eq!(
+        Grounding::from_model(&model).check(
+            "High complexity in the network error path raises maintenance cost and the risk \
+             that a new endpoint mishandles an error status.",
+            Some("crates/trusty-git-analytics/src/collect/azdo/client.rs:36"),
+        ),
+        GroundingOutcome::Clean
+    );
+}
+
+/// Tier 2 wins on a shared file: one finding binding every interface stops the
+/// whole file inheriting a loopback sibling's scope.
+#[test]
+fn a_remote_finding_on_the_file_wins_over_a_loopback_sibling() {
+    let model = model_with(vec![repo(
+        "estate",
+        vec![
+            finding(
+                "Session endpoints have no auth",
+                &format!("{CONTROL_ROUTES}:259"),
+                "Add auth before exposing them beyond localhost",
+            ),
+            finding(
+                "Daemon binds every interface",
+                &format!("{CONTROL_ROUTES}:12"),
+                "Bind loopback instead of 0.0.0.0",
+            ),
+        ],
+        None,
+    )]);
+    let g = Grounding::from_model(&model);
+    assert!(g.local_only.is_empty(), "{:?}", g.local_only);
+    assert_eq!(
+        g.check(
+            LIVE_ARBITRARY_EXEC_IMPACT,
+            Some(&format!("{CONTROL_ROUTES}:259"))
+        ),
+        GroundingOutcome::Clean
+    );
+}
+
+/// The metrics rows carry a `:line` suffix and the investigation does not, so
+/// both spellings must land on one file key or they cannot share a tier.
+#[test]
+fn a_line_suffix_does_not_split_a_component() {
+    assert_eq!(normalize_component(CONTROL_ROUTES), CONTROL_ROUTES);
+    assert_eq!(
+        normalize_component(&format!("{CONTROL_ROUTES}:268")),
+        CONTROL_ROUTES
+    );
+    assert_eq!(
+        normalize_component(&format!("{CONTROL_ROUTES}:268:9")),
+        CONTROL_ROUTES
+    );
+    assert_eq!(normalize_component("   "), "");
 }

--- a/crates/trusty-review/src/report/synthesize_grounding_text.rs
+++ b/crates/trusty-review/src/report/synthesize_grounding_text.rs
@@ -1,0 +1,130 @@
+//! Text primitives the grounding guardrail is built from.
+//!
+//! Why: [`super::synthesize_grounding`] crossed the 500-SLOC production cap when
+//! #6082 lap 8 added component-anchored classification. These are the natural
+//! seam: every item here is a pure function over strings, with no knowledge of
+//! findings, reports or reachability tiers, and nothing else in the module
+//! depends on them beyond calling them.
+//! What: sentence splitting and splicing, subject-token extraction,
+//! boundary-aware name matching, and the case-insensitive rewrite pass.
+//! Test: `synthesize_grounding_tests.rs` exercises each through the guardrail
+//! and directly.
+
+use std::collections::BTreeSet;
+
+use super::synthesize_grounding::{
+    GENERIC_TOKENS, MIN_TOKEN_LEN, REACHABILITY_REWRITES, REACHABILITY_WORDS,
+};
+
+/// Cut `sentence` out of `text`, taking the space that separated it from its
+/// neighbour so the remaining prose keeps single spacing.
+pub(super) fn remove_sentence(text: &str, sentence: &str) -> String {
+    let spaced = format!("{sentence} ");
+    if text.contains(&spaced) {
+        return text.replace(&spaced, "");
+    }
+    text.replace(sentence, "")
+}
+
+/// The words that identify one finding's subject: its component path segments
+/// and its title words, minus the generic ones.
+pub(super) fn subject_tokens(title: &str, component: &str) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    for raw in component
+        .split(['/', '\\', '.', ':'])
+        .chain(title.split_whitespace())
+    {
+        let word: String = raw
+            .trim_matches(|c: char| !c.is_alphanumeric() && c != '-' && c != '_')
+            .to_lowercase();
+        if word.len() < MIN_TOKEN_LEN || GENERIC_TOKENS.contains(&word.as_str()) {
+            continue;
+        }
+        if word.chars().all(|c| c.is_ascii_digit()) {
+            continue;
+        }
+        out.insert(word);
+    }
+    out
+}
+
+/// True when `haystack` contains `needle` bounded by non-identifier characters.
+///
+/// Why: a bare `contains` would match `trusty-mpm` inside `trusty-mpm-gui` and
+/// blame the wrong crate.
+pub(super) fn contains_name(haystack: &str, needle: &str) -> bool {
+    if needle.is_empty() {
+        return false;
+    }
+    let bytes = haystack.as_bytes();
+    let ident = |b: u8| b.is_ascii_alphanumeric() || b == b'_' || b == b'-';
+    haystack.match_indices(needle).any(|(i, _)| {
+        let before_ok = i == 0 || !ident(bytes[i - 1]);
+        let after = i + needle.len();
+        let after_ok = after >= bytes.len() || !ident(bytes[after]);
+        before_ok && after_ok
+    })
+}
+
+/// Apply every known reachability rewrite to one sentence, case-insensitively.
+pub(super) fn rewrite_reachability(sentence: &str) -> String {
+    let mut out = sentence.to_string();
+    for (phrase, replacement) in REACHABILITY_REWRITES {
+        out = replace_ignore_case(&out, phrase, replacement);
+    }
+    out
+}
+
+/// Case-insensitive literal replacement preserving everything else verbatim.
+pub(super) fn replace_ignore_case(haystack: &str, needle: &str, replacement: &str) -> String {
+    let lower = haystack.to_lowercase();
+    let mut out = String::with_capacity(haystack.len());
+    let mut cursor = 0usize;
+    while let Some(rel) = lower[cursor..].find(needle) {
+        let at = cursor + rel;
+        out.push_str(&haystack[cursor..at]);
+        out.push_str(replacement);
+        cursor = at + needle.len();
+    }
+    out.push_str(&haystack[cursor..]);
+    out
+}
+
+/// True when a sentence asserts reachability beyond this host.
+///
+/// A plain substring test, not a word-boundary one: every rewrite in
+/// [`REACHABILITY_REWRITES`] removes its own reachability word, so any
+/// occurrence left belongs to a phrase this module does not know how to
+/// correct — including a hyphenated one like `remote-management` or
+/// `network-attached`, which a boundary test would miss.
+pub(super) fn asserts_reachability(sentence: &str) -> bool {
+    let lower = sentence.to_lowercase();
+    REACHABILITY_WORDS.iter().any(|w| lower.contains(w))
+}
+
+/// Split prose into sentences on `. `, `? ` and `! ` boundaries, keeping each
+/// sentence's own text so the caller can splice a correction back in.
+pub(super) fn sentences(text: &str) -> Vec<&str> {
+    let mut out = Vec::new();
+    let mut start = 0usize;
+    let bytes = text.as_bytes();
+    for (i, b) in bytes.iter().enumerate() {
+        if !matches!(b, b'.' | b'?' | b'!' | b'\n') {
+            continue;
+        }
+        let next_is_break = bytes.get(i + 1).is_none_or(|n| n.is_ascii_whitespace());
+        if !next_is_break {
+            continue;
+        }
+        let piece = text[start..=i].trim();
+        if !piece.is_empty() {
+            out.push(piece);
+        }
+        start = i + 1;
+    }
+    let tail = text[start..].trim();
+    if !tail.is_empty() {
+        out.push(tail);
+    }
+    out
+}

--- a/crates/trusty-review/src/report/synthesize_guardrail.rs
+++ b/crates/trusty-review/src/report/synthesize_guardrail.rs
@@ -1,0 +1,373 @@
+//! The guardrail layer over one parsed synthesis response.
+//!
+//! Why: `synthesize.rs` crossed the 500-SLOC production cap when #6082 lap 8
+//! reworked the status notes. This is the natural seam — the numeric guardrail
+//! and the grounding guardrail are one unit that takes a [`RawSynthesis`] and
+//! returns the [`Synthesis`] that may ship, and nothing above it does anything
+//! but call [`apply_guardrail`].
+//! What: [`apply_guardrail`], [`ground_investigation_prose`], the per-field
+//! `admit`/`ground` pair both go through, and the reader-facing note each
+//! rejection records.
+//! Test: `synthesize_tests.rs`.
+
+use super::model::ReportModel;
+use super::synthesize::{RawSynthesis, StatusNote, Synthesis, SynthesisError};
+use crate::report::synthesize_grounding::{Grounding, GroundingOutcome};
+use crate::report::synthesize_guard::verify_prose;
+
+/// One reader-facing disclosure that a figure the model wrote is not in the data.
+///
+/// #6082 lap 8 replaced the former `synthesis: rejected (unverified figure)` log
+/// prefix. Half the Synthesis Status block was already reader prose and half was
+/// this, so the same block told a diligence reader two different things about
+/// how much of it was written for them.
+fn unverified_figure_note(field: &str, subject: Option<&str>, token: &str) -> StatusNote {
+    let text = format!(
+        "the model's {field} was withheld because it carried the figure {token}, which is not \
+         in the collected data"
+    );
+    match subject {
+        Some(s) => StatusNote::about(s, text),
+        None => StatusNote::plain(text),
+    }
+}
+
+/// One reader-facing disclosure that a CLAIM the model wrote contradicts the
+/// report's own data (#6082 lap 4).
+///
+/// Kept distinct from [`unverified_figure_note`]: a numeric rejection means a
+/// figure was not in the data, a grounding rejection means a claim contradicted
+/// it, and a reader who sees one should not have to guess which happened.
+fn ungrounded_claim_note(field: &str, subject: Option<&str>, reason: &str) -> StatusNote {
+    let text = format!("the model's {field} was withheld — {reason}");
+    match subject {
+        Some(s) => StatusNote::about(s, text),
+        None => StatusNote::plain(text),
+    }
+}
+
+/// What one narrative field is, for the disclosure that names it.
+///
+/// Why: the guardrails record a note per field, and the note has to say which
+/// field of which finding — a bundle keeps the two halves together instead of
+/// growing another positional argument on every call (#6082 lap 8).
+/// What: the reader-facing field name, the §5.2 finding it belongs to (absent
+/// for report-level prose), and that finding's component, which decides its
+/// reachability tier in [`Grounding::check`].
+struct FieldCtx<'a> {
+    field: &'a str,
+    subject: Option<&'a str>,
+    component: Option<&'a str>,
+}
+
+impl<'a> FieldCtx<'a> {
+    /// Report-level prose belonging to no single finding.
+    fn report(field: &'a str) -> Self {
+        FieldCtx {
+            field,
+            subject: None,
+            component: None,
+        }
+    }
+
+    /// One field of one finding, carrying the component its tier is read from.
+    fn finding(field: &'a str, title: &'a str, component: &'a str) -> Self {
+        FieldCtx {
+            field,
+            subject: Some(title),
+            component: Some(component),
+        }
+    }
+}
+
+/// Apply the numeric guardrail to the raw synthesis, field by field.
+///
+/// Why: a field whose prose cites a figure not in the source is dropped (never
+/// repaired), so the deterministic composition (#5374) fills that placeholder and
+/// a visible rejection note is recorded.  Per-FIELD rejection stays a correctness
+/// property under #5454's required-inference rule; what changed is that a
+/// response with nothing left after the pass is an error rather than a
+/// deterministic-only report.
+/// What: verifies the executive summary and every risk row / finding against
+/// `allowed`; keeps only clean fields.  Findings must carry a RED/AMBER severity
+/// (defence-in-depth greens exclusion).  `seed_notes` (the normalization
+/// drop-notes recorded by [`crate::report::synthesize_normalize`], #6009 shape
+/// 3) are recorded first, so an unrecognized-field drop is visible in the
+/// rendered status lines alongside a numeric-guardrail rejection.  `Ok` iff at
+/// least one field survived.
+///
+/// # Errors
+///
+/// [`SynthesisError::NoVerifiableContent`] when every field was rejected.
+///
+/// Test: `synthesize_tests.rs::{synthesize_rejects_unverified_figure,
+/// synthesize_happy_path_injects}`.
+pub(super) fn apply_guardrail(
+    raw: RawSynthesis,
+    allowed: &std::collections::HashSet<String>,
+    seed_notes: Vec<StatusNote>,
+    grounding: &Grounding,
+) -> Result<Synthesis, SynthesisError> {
+    let mut out = Synthesis {
+        notes: seed_notes,
+        ..Synthesis::default()
+    };
+    let notes = &mut out.notes;
+
+    // Executive summary.
+    out.executive_summary = admit_field(
+        &FieldCtx::report("executive summary"),
+        &raw.executive_summary,
+        allowed,
+        grounding,
+        notes,
+    );
+
+    // #6004: Code Quality & Architecture and Security Posture narratives — same
+    // per-field guardrail path as the executive summary.
+    out.code_quality_summary = admit_field(
+        &FieldCtx::report("code quality summary"),
+        &raw.code_quality_summary,
+        allowed,
+        grounding,
+        notes,
+    );
+    out.security_summary = admit_field(
+        &FieldCtx::report("security summary"),
+        &raw.security_summary,
+        allowed,
+        grounding,
+        notes,
+    );
+    out.authorship_summary = admit_field(
+        &FieldCtx::report("authorship summary"),
+        &raw.authorship_summary,
+        allowed,
+        grounding,
+        notes,
+    );
+
+    // Top-risk rows. The row's description is narrative and takes the same
+    // grounding pass the paragraphs do (#6082 lap 4) — row 1 of the last report
+    // carried the same reachability contradiction the executive summary did.
+    for (i, mut r) in raw.top_risks.into_iter().enumerate() {
+        let field = format!("description for top risk {}", i + 1);
+        let ctx = FieldCtx::report(&field);
+        let Some(description) = admit_field(&ctx, &r.description, allowed, grounding, notes) else {
+            continue;
+        };
+        r.description = description;
+        match verify_all(&[&r.severity, &r.cost, &r.apps], allowed) {
+            Ok(()) => out.top_risks.push(r),
+            Err(tok) => notes.push(unverified_figure_note(&field, None, &tok)),
+        }
+    }
+
+    // RED/AMBER finding elaborations.
+    for mut f in raw.findings {
+        let sev = f.severity.to_uppercase();
+        if sev != "RED" && sev != "AMBER" {
+            notes.push(StatusNote::about(
+                &f.title,
+                format!(
+                    "the model's narrative was dropped because it declared severity '{}', and \
+                     only RED and AMBER findings carry one",
+                    f.severity
+                ),
+            ));
+            continue;
+        }
+        // #6082 lap 5: a finding's OWN narrative fields take the same grounding
+        // pass the paragraphs do. Wiring the guard to the summaries and the
+        // top-risk rows alone left RED finding 3's business impact stating
+        // "remote/local code execution" two lines from a Security Posture
+        // paragraph the same guard had corrected to "not remotely".
+        // `evidence` is excluded deliberately: it is a verbatim quote verified
+        // against the file, so rewriting it would make the displayed quote
+        // diverge from the one that was checked. `component` is routing data,
+        // not narrative — and since #6082 lap 8 it is also what decides the
+        // finding's reachability tier.
+        let (title, component) = (f.title.clone(), f.component.clone());
+        for (field, value) in [
+            ("description", &mut f.description),
+            ("business impact", &mut f.business_impact),
+            ("remediation", &mut f.remediation),
+            ("cost/effort", &mut f.cost_effort),
+        ] {
+            *value = ground_field(
+                &FieldCtx::finding(field, &title, &component),
+                value,
+                grounding,
+                notes,
+            );
+        }
+        match verify_all(
+            &[
+                &f.description,
+                &f.evidence,
+                &f.component,
+                &f.business_impact,
+                &f.remediation,
+                &f.cost_effort,
+            ],
+            allowed,
+        ) {
+            Ok(()) => out.findings.push(f),
+            Err(tok) => notes.push(unverified_figure_note("narrative", Some(&f.title), &tok)),
+        }
+    }
+
+    if out.executive_summary.is_none()
+        && out.code_quality_summary.is_none()
+        && out.security_summary.is_none()
+        && out.authorship_summary.is_none()
+        && out.top_risks.is_empty()
+        && out.findings.is_empty()
+    {
+        return Err(SynthesisError::NoVerifiableContent);
+    }
+    Ok(out)
+}
+
+/// Run the grounding guardrail over the verified investigation's own prose.
+///
+/// Why: the guard used to run on synthesis prose only, and
+/// `merge_investigation_prose` overwrites that prose with the investigation's
+/// for every RED/AMBER finding — so the guarded copy was discarded before
+/// render. That is how RED finding 2 of the lap-6 report shipped "a remote code
+/// execution risk" in its business impact while the guard's own note in the same
+/// document recorded a correction it had made elsewhere. Correcting `inv` BEFORE
+/// `apply_investigation` fixes every downstream copy at once: the injected
+/// `metrics.findings` rows, `model.investigation` in the JSON twin, the
+/// synthesis prompt, and the merged prose that renders.
+/// What: builds the [`Grounding`] from the model plus `inv` (the model has not
+/// recorded it yet), then runs [`ground_field`] over each RED/AMBER finding's
+/// description, business impact, remediation and cost/effort. `evidence_quote`
+/// is excluded for the same reason it is in [`apply_guardrail`]: it is verified
+/// verbatim against the file. Returns one status line per correction or
+/// rejection, for the caller to fold into [`Synthesis::notes`].
+/// Test: `synthesize_tests.rs::{investigation_business_impact_states_host_local_reach,
+/// investigation_grounding_leaves_a_clean_finding_alone}`.
+pub fn ground_investigation_prose(
+    model: &ReportModel,
+    inv: &mut crate::report::investigate::Investigation,
+) -> Vec<StatusNote> {
+    let grounding = Grounding::from_model_with(model, Some(inv));
+    let mut notes = Vec::new();
+    for repo in &mut inv.repos {
+        for f in &mut repo.findings {
+            if f.severity == crate::report::metrics::Severity::Green {
+                continue; // greens are title-only topics; they carry no narrative
+            }
+            let (title, file) = (f.title.clone(), f.file.clone());
+            for (field, value) in [
+                ("description", &mut f.description),
+                ("business impact", &mut f.business_impact),
+                ("remediation", &mut f.remediation),
+                ("cost/effort", &mut f.cost_effort),
+            ] {
+                *value = ground_field(
+                    &FieldCtx::finding(field, &title, &file),
+                    value,
+                    &grounding,
+                    &mut notes,
+                );
+            }
+        }
+    }
+    notes
+}
+
+/// Run the grounding guardrail alone over one narrative field of a finding.
+///
+/// Why: a finding is verified as a WHOLE by [`verify_all`] — one bad figure
+/// anywhere rejects the entire finding — so its fields cannot go through
+/// [`admit_field`], which rejects per field. This is the grounding half on its
+/// own, leaving that all-or-nothing numeric contract untouched (#6082 lap 5).
+/// What: returns the text with any reachability claim corrected, or an empty
+/// string when the claim could not be corrected safely. An emptied field falls
+/// through to the reporter's honesty marker, which is what an absent field has
+/// always rendered as.
+/// Test: `synthesize_tests.rs::{synthesize_grounds_a_finding_business_impact,
+/// synthesize_empties_an_uncorrectable_remote_claim_in_a_finding}`.
+fn ground_field(
+    ctx: &FieldCtx<'_>,
+    raw: &str,
+    grounding: &Grounding,
+    notes: &mut Vec<StatusNote>,
+) -> String {
+    let text = raw.trim();
+    if text.is_empty() {
+        return String::new();
+    }
+    match grounding.check(text, ctx.component) {
+        GroundingOutcome::Clean => text.to_string(),
+        GroundingOutcome::Rewritten(fixed, corrections) => {
+            notes.extend(corrections.into_iter().map(|c| note_for(ctx, c)));
+            fixed
+        }
+        GroundingOutcome::Rejected(reason) => {
+            notes.push(ungrounded_claim_note(ctx.field, ctx.subject, &reason));
+            String::new()
+        }
+    }
+}
+
+/// Attach one grounding correction to the finding whose field carried it.
+fn note_for(ctx: &FieldCtx<'_>, text: String) -> StatusNote {
+    match ctx.subject {
+        Some(s) => StatusNote::about(s, text),
+        None => StatusNote::plain(text),
+    }
+}
+
+/// Run both guardrails over one narrative field and return what may ship.
+///
+/// Why: the grounding check (#6082 lap 4) and the numeric check are two
+/// independent reasons a field cannot be trusted, and running them from one
+/// place is what stops a future field from being wired to only one of them.
+/// What: `None` for an empty field, for a grounding rejection, and for a numeric
+/// rejection — each of the last two recording its own note under its own prefix.
+/// Otherwise the text to keep, which is the model's own unless the grounding
+/// pass corrected a claim in it; the numeric check then runs on the CORRECTED
+/// text, so a rewrite can never smuggle a figure past it.
+/// Test: `synthesize_tests.rs::{synthesize_rewrites_a_remote_claim_about_a_local_finding,
+/// synthesize_rejects_a_load_bearing_claim_about_a_leaf_crate}`.
+fn admit_field(
+    ctx: &FieldCtx<'_>,
+    raw: &str,
+    allowed: &std::collections::HashSet<String>,
+    grounding: &Grounding,
+    notes: &mut Vec<StatusNote>,
+) -> Option<String> {
+    let text = raw.trim();
+    if text.is_empty() {
+        return None;
+    }
+    let grounded = match grounding.check(text, ctx.component) {
+        GroundingOutcome::Clean => text.to_string(),
+        GroundingOutcome::Rewritten(fixed, corrections) => {
+            notes.extend(corrections.into_iter().map(|c| note_for(ctx, c)));
+            fixed
+        }
+        GroundingOutcome::Rejected(reason) => {
+            notes.push(ungrounded_claim_note(ctx.field, ctx.subject, &reason));
+            return None;
+        }
+    };
+    match verify_prose(&grounded, allowed) {
+        Ok(()) => Some(grounded),
+        Err(tok) => {
+            notes.push(unverified_figure_note(ctx.field, ctx.subject, &tok));
+            None
+        }
+    }
+}
+
+/// Verify every field of a group; returns the first offending token on failure.
+fn verify_all(fields: &[&str], allowed: &std::collections::HashSet<String>) -> Result<(), String> {
+    for field in fields {
+        verify_prose(field, allowed)?;
+    }
+    Ok(())
+}

--- a/crates/trusty-review/src/report/synthesize_normalize.rs
+++ b/crates/trusty-review/src/report/synthesize_normalize.rs
@@ -154,7 +154,8 @@ fn normalize_object(
     for k in unknown {
         obj.remove(&k);
         notes.push(format!(
-            "synthesis: dropped unrecognized field '{k}' in {context}"
+            "the model returned an unrecognised field '{k}' in the {context} of its response, \
+             so that field was dropped"
         ));
     }
 }

--- a/crates/trusty-review/src/report/synthesize_tests.rs
+++ b/crates/trusty-review/src/report/synthesize_tests.rs
@@ -15,6 +15,8 @@ use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use crate::report::synthesize::StatusNote;
+
 use async_trait::async_trait;
 
 use crate::llm::{LlmError, LlmProvider, LlmRequest, LlmResponse};
@@ -1034,7 +1036,7 @@ async fn synthesize_still_rejects_a_wrong_authorship_figure() {
         result
             .notes
             .iter()
-            .any(|n| n.contains("authorship summary: 84")),
+            .any(|n| n.text.contains("authorship summary") && n.text.contains("figure 84")),
         "the rejection note must name the offending token: {:?}",
         result.notes
     );
@@ -1218,7 +1220,7 @@ async fn synthesize_rejects_unverified_figure() {
         result
             .notes
             .iter()
-            .any(|n| n.contains("rejected (unverified figure)") && n.contains("9999")),
+            .any(|n| n.text.contains("not in the collected data") && n.text.contains("9999")),
         "a guardrail rejection note must be recorded: {:?}",
         result.notes
     );
@@ -1252,8 +1254,13 @@ fn code_quality_summary_guardrail_rejects_unverified_figure() {
         findings: vec![],
     };
 
-    let result = super::apply_guardrail(raw, &allowed, Vec::new(), &Default::default())
-        .expect("the clean top-risk row keeps this Ok");
+    let result = crate::report::synthesize_guardrail::apply_guardrail(
+        raw,
+        &allowed,
+        Vec::new(),
+        &Default::default(),
+    )
+    .expect("the clean top-risk row keeps this Ok");
 
     assert!(
         result.code_quality_summary.is_none(),
@@ -1261,10 +1268,9 @@ fn code_quality_summary_guardrail_rejects_unverified_figure() {
     );
     assert_eq!(result.top_risks.len(), 1, "the clean row must survive");
     assert!(
-        result
-            .notes
-            .iter()
-            .any(|n| n.contains("rejected (unverified figure)") && n.contains("code quality")),
+        result.notes.iter().any(
+            |n| n.text.contains("not in the collected data") && n.text.contains("code quality")
+        ),
         "a guardrail rejection note must name the code quality summary: {:?}",
         result.notes
     );
@@ -1297,8 +1303,13 @@ fn security_summary_guardrail_rejects_unverified_figure() {
         findings: vec![],
     };
 
-    let result = super::apply_guardrail(raw, &allowed, Vec::new(), &Default::default())
-        .expect("the clean top-risk row keeps this Ok");
+    let result = crate::report::synthesize_guardrail::apply_guardrail(
+        raw,
+        &allowed,
+        Vec::new(),
+        &Default::default(),
+    )
+    .expect("the clean top-risk row keeps this Ok");
 
     assert!(
         result.security_summary.is_none(),
@@ -1309,7 +1320,7 @@ fn security_summary_guardrail_rejects_unverified_figure() {
         result
             .notes
             .iter()
-            .any(|n| n.contains("rejected (unverified figure)") && n.contains("security")),
+            .any(|n| n.text.contains("not in the collected data") && n.text.contains("security")),
         "a guardrail rejection note must name the security summary: {:?}",
         result.notes
     );
@@ -1384,22 +1395,27 @@ async fn synthesize_with_many_findings_produces_exec_summary() {
     assert!(!result.executive_summary.unwrap().is_empty());
 }
 
-/// Why: the status note carries the `synthesis:` banner the report's readers key
-/// on, plus every guardrail rejection.
-/// What: asserts the banner line and that notes follow it in order.
+/// Why: #6082 lap 8 — a status note renders as the reader's own sentence, and
+/// gains a §5.1/§5.2 citation only when the reporter resolved its subject to a
+/// numbered row.
+/// What: asserts both render arms of [`StatusNote`].
 /// Test: this test itself.
 #[test]
-fn status_lines_render_banners() {
-    let syn = Synthesis {
-        code_quality_summary: None,
-        security_summary: None,
-        authorship_summary: None,
-        notes: vec!["synthesis: rejected (unverified figure) in top-risk row 1: 42".to_string()],
-        ..Default::default()
-    };
-    let lines = syn.status_lines();
-    assert_eq!(lines[0], "synthesis: available");
-    assert_eq!(lines[1], syn.notes[0]);
+fn a_status_note_renders_with_and_without_a_citation() {
+    let note = StatusNote::about(
+        "Hotspot HTTP client function has cyclomatic complexity 98",
+        "the model's business impact was withheld — the claim cannot be verified",
+    );
+    assert_eq!(
+        note.render(Some("section 5.2, AMBER finding 47")),
+        "section 5.2, AMBER finding 47: the model's business impact was withheld — the claim \
+         cannot be verified"
+    );
+    assert_eq!(
+        note.render(None),
+        "the model's business impact was withheld — the claim cannot be verified"
+    );
+    assert!(!note.render(None).contains("synthesis:"));
 }
 
 // ── #6009: markdown-heading fallback + raw-capture regression ──────────────
@@ -1767,7 +1783,7 @@ async fn synthesize_recovers_shape3_end_to_end() {
         result
             .notes
             .iter()
-            .any(|n| n.contains("rejected (unverified figure)") && n.contains("32")),
+            .any(|n| n.text.contains("not in the collected data") && n.text.contains("32")),
         "the rejection must be recorded: {:?}",
         result.notes
     );
@@ -2323,8 +2339,9 @@ fn synthesize_rewrites_a_remote_claim_about_a_local_finding() {
         findings: vec![],
     };
 
-    let result = super::apply_guardrail(raw, &allowed, Vec::new(), &grounding)
-        .expect("the corrected summary keeps this Ok");
+    let result =
+        crate::report::synthesize_guardrail::apply_guardrail(raw, &allowed, Vec::new(), &grounding)
+            .expect("the corrected summary keeps this Ok");
 
     let exec = result
         .executive_summary
@@ -2338,7 +2355,7 @@ fn synthesize_rewrites_a_remote_claim_about_a_local_finding() {
         result
             .notes
             .iter()
-            .any(|n| n.contains("reachability corrected")),
+            .any(|n| n.text.contains("reachability wording was corrected")),
         "the correction must be recorded: {:?}",
         result.notes
     );
@@ -2368,14 +2385,16 @@ fn synthesize_rejects_an_uncorrectable_remote_claim() {
         findings: vec![],
     };
 
-    let result = super::apply_guardrail(raw, &allowed, Vec::new(), &grounding)
-        .expect("the authorship paragraph keeps this Ok");
+    let result =
+        crate::report::synthesize_guardrail::apply_guardrail(raw, &allowed, Vec::new(), &grounding)
+            .expect("the authorship paragraph keeps this Ok");
 
     assert!(result.security_summary.is_none());
     assert!(
-        result.notes.iter().any(|n| {
-            n.contains("claim contradicts the report's own data") && n.contains("security summary")
-        }),
+        result
+            .notes
+            .iter()
+            .any(|n| { n.text.contains("security summary was withheld") }),
         "the rejection must be recorded: {:?}",
         result.notes
     );
@@ -2405,15 +2424,16 @@ fn synthesize_rejects_a_load_bearing_claim_about_a_leaf_crate() {
         findings: vec![],
     };
 
-    let result = super::apply_guardrail(raw, &allowed, Vec::new(), &grounding)
-        .expect("the authorship paragraph keeps this Ok");
+    let result =
+        crate::report::synthesize_guardrail::apply_guardrail(raw, &allowed, Vec::new(), &grounding)
+            .expect("the authorship paragraph keeps this Ok");
 
     assert!(result.executive_summary.is_none());
     assert!(
         result
             .notes
             .iter()
-            .any(|n| n.contains("acme-leaf") && n.contains("most-depended-on")),
+            .any(|n| n.text.contains("acme-leaf") && n.text.contains("most-depended-on")),
         "the rejection must name the crate: {:?}",
         result.notes
     );
@@ -2442,8 +2462,9 @@ fn synthesize_grounds_the_top_risk_row_description() {
         findings: vec![],
     };
 
-    let result = super::apply_guardrail(raw, &allowed, Vec::new(), &grounding)
-        .expect("the corrected row keeps this Ok");
+    let result =
+        crate::report::synthesize_guardrail::apply_guardrail(raw, &allowed, Vec::new(), &grounding)
+            .expect("the corrected row keeps this Ok");
 
     assert_eq!(result.top_risks.len(), 1);
     assert!(
@@ -2504,8 +2525,9 @@ fn synthesize_grounds_a_finding_business_impact() {
         )],
     };
 
-    let result = super::apply_guardrail(raw, &allowed, Vec::new(), &grounding)
-        .expect("the corrected finding keeps this Ok");
+    let result =
+        crate::report::synthesize_guardrail::apply_guardrail(raw, &allowed, Vec::new(), &grounding)
+            .expect("the corrected finding keeps this Ok");
 
     assert_eq!(result.findings.len(), 1, "{:?}", result.notes);
     let impact = &result.findings[0].business_impact;
@@ -2521,7 +2543,7 @@ fn synthesize_grounds_a_finding_business_impact() {
         result
             .notes
             .iter()
-            .any(|n| n.contains("reachability corrected")),
+            .any(|n| n.text.contains("reachability wording was corrected")),
         "the correction must be recorded: {:?}",
         result.notes
     );
@@ -2554,8 +2576,9 @@ fn synthesize_empties_an_uncorrectable_remote_claim_in_a_finding() {
         )],
     };
 
-    let result = super::apply_guardrail(raw, &allowed, Vec::new(), &grounding)
-        .expect("the finding's other fields keep this Ok");
+    let result =
+        crate::report::synthesize_guardrail::apply_guardrail(raw, &allowed, Vec::new(), &grounding)
+            .expect("the finding's other fields keep this Ok");
 
     assert_eq!(result.findings.len(), 1, "{:?}", result.notes);
     assert!(
@@ -2564,9 +2587,10 @@ fn synthesize_empties_an_uncorrectable_remote_claim_in_a_finding() {
         result.findings[0].business_impact
     );
     assert!(
-        result.notes.iter().any(|n| {
-            n.contains("claim contradicts the report's own data") && n.contains("business impact")
-        }),
+        result
+            .notes
+            .iter()
+            .any(|n| { n.text.contains("business impact was withheld") }),
         "the rejection must be recorded: {:?}",
         result.notes
     );


### PR DESCRIPTION
Lap-8 acceptance fixes. Refs #6082.

## Defect 1 — reachability was classified per finding text

`Grounding::ingest` read loopback markers out of each finding's own wording, so a finding whose text carried none was never classified and never checked. Live report, `.md` line 133, §5.1 item 3 on `control_routes.rs:268`: "Combined with the lack of auth, this permits remote code execution by pointing the session at any binary on the host" — while the executive summary described the same surface as "reachable by any process on the host."

Classification is now anchored to the component, in three tiers:

1. **Loopback-established** — some finding on that file carries a loopback marker. Every finding on the file inherits it; every reachability word in that finding's own narrative is rewritten where the table can and rejected where it cannot.
2. **Remote-established** — some finding on that file carries a remote marker. Left alone; remote wins over local on one file.
3. **Unestablished** — the collected data says nothing either way. A sentence making a positive reach claim (one `REACHABILITY_REWRITES` recognises) is **rejected and disclosed**, never rewritten: the report has no evidence the surface is host-local either, so a substitution would trade one unsupported claim for another.

A finding's own narrative is judged by its own component now, never by a word it shares with another finding's title. Token matching survives only for report-level prose, which is about no single component.

**Correction to the brief:** no finding on `control_routes.rs` carries any reachability marker in the live data — verified against `investigation.json` and the report twin. Tier 1 could not have reached item 3 however far inheritance spread. **Tier 3 is what stops the live line.**

### Limits

- The inheritance unit is the **file**. Crate-level was rejected: a crate can hold both a loopback daemon and a genuinely outbound surface (`trusty-console`'s proxy is the live example).
- The pipeline collects **no bind-address evidence**, so "the repo's own bind-address evidence" is not a source available today.
- Tier 3's trigger is the rewrite table, so a reach claim in a spelling the table has never seen still ships on an unevidenced component. Tier 1 remains the fail-closed one.
- Tier 3 applies to a finding's own narrative only, not to the report-level summaries, which name no component the disclosure could point at.
- Tier 3 costs nothing where the sentence claims no reach — "a transient network error", "external network access" — verified against all three such live business impacts.

## Defect 2 — Synthesis Status had two voices

The block opened with `- synthesis: available` and carried log-prefixed rejections beside reader-voiced withheld-narrative lines. Now: the banner is gone and the block is omitted when there is nothing to disclose; every line is a plain sentence; a line about a finding cites the number the reader can look up. Citations for RED findings say section 5.1 — they used to say 5.2, sending the reader to the wrong section.

## Failing-before evidence

Both probes run on `266cf2ac`, the pre-fix commit, with the live texts:

```
prefix_probe_sibling_inheritance ... FAILED
  assertion `left != right` failed: the sibling finding's loopback evidence must reach this finding
  left: Clean

prefix_probe_azdo_false_rejection ... FAILED
  left: Rejected("a beyond-the-host reachability claim about 'Admin stop endpoint trusts every
        caller with no authentication' could not be corrected safely — that finding's own text
        scopes it to localhost")
  right: Clean

prefix_probe_status_lines_are_reader_prose ... FAILED
  Synthesis Status must carry no raw log prefix
```

The azdo probe reproduces the live false rejection verbatim: §5.2 item 47's business impact rendered as "not stated in source data" because "endpoint" matched the trusty-search admin finding's title tokens.

## Gates — test ladder rung 3

Localized behavior inside one crate. Nothing in the workspace depends on `trusty-review` as a library (the eight `Cargo.toml` hits are comments), so rung 4 does not apply.

```
cargo fmt --check                                     EXIT=0
cargo clippy -p trusty-review --all-targets -D warnings  EXIT=0
cargo test -p trusty-review                           1984 passed; 0 failed; 5 ignored (+8 new)
                                                      77 / 3 / 3 / 2 / 5 / 2 / 3 / 3 passed
bash scripts/check_line_cap.sh                        4162 files, 0 violations
bash scripts/check_sld.sh                             0 errors, 0 warnings
bash scripts/check_changelog_fragment.sh              OK trusty-review
```

`synthesize.rs` (543) and `synthesize_grounding.rs` (541) crossed the 500-SLOC cap, so the guardrail layer and the text primitives split into `synthesize_guardrail.rs` and `synthesize_grounding_text.rs` in this PR.

Version stays 0.25.0 (unpublished). No tag, no publish.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools