### PR TITLE
fix(trusty-review): reach claims are caught by vocabulary, and disclosures carry their finding number (Refs #6082)

### DIFF
--- a/crates/trusty-review/changelog.d/6082-lap9-acceptance-fixes.md
+++ b/crates/trusty-review/changelog.d/6082-lap9-acceptance-fixes.md
@@ -1,0 +1,7 @@
+Fixed
+
+- An unevidenced component's reach claim is now caught by vocabulary, not by a table of known phrases ([#6082](https://github.com/bobmatnyc/trusty-tools/issues/6082))
+  - `remote`, `network` and `internet` are read as tokens, so a hyphenated compound (`remote-execution`) and a morphological variant (`remotely`, `network-reachable`) are examined; the last report shipped "a critical remote-execution and privilege risk" because no rewrite pattern matched it
+  - only CLAIM-shaped uses are withheld — the word must sit within three tokens of an access, attack, execution or exposure word — so "a transient network error" and "network and streaming logic" keep their field
+- A Synthesis Status disclosure about a report-level paragraph now cites the §5.1/§5.2 number of the finding it is about ([#6082](https://github.com/bobmatnyc/trusty-tools/issues/6082))
+  - the executive, code-quality, security and authorship summaries belong to no single finding, so their rejections quoted a finding title with no number; the grounding check now hands that finding to the reporter, which resolves it to the rendered number

--- a/crates/trusty-review/src/report/synthesize_grounding.rs
+++ b/crates/trusty-review/src/report/synthesize_grounding.rs
@@ -46,15 +46,27 @@
 //! 2. REMOTE-ESTABLISHED — some finding on that file carries a
 //!    [`REMOTE_MARKERS`] word. Left alone; remote wins over local on one file.
 //! 3. UNESTABLISHED — the collected data says nothing either way. A sentence
-//!    making a positive beyond-the-host reach claim (one [`REACHABILITY_REWRITES`]
-//!    recognises) is REJECTED, never rewritten: the report has no evidence the
-//!    surface is host-local either, so substituting a host-local phrase would
-//!    trade one unsupported claim for another.
+//!    making a positive beyond-the-host reach claim is REJECTED, never
+//!    rewritten: the report has no evidence the surface is host-local either, so
+//!    substituting a host-local phrase would trade one unsupported claim for
+//!    another.
 //!
 //! Tier 3 is what stops the lap-8 line. No finding on
 //! `crates/trusty-mpm/src/daemon/api/control_routes.rs` carried any reachability
 //! marker, so tier 1 could not reach it however far inheritance spread, and its
 //! business impact shipped "permits remote code execution" unexamined.
+//!
+//! #6082 lap 9 changed what makes a tier-3 sentence a reach claim. It used to be
+//! the [`REACHABILITY_REWRITES`] table, and the same file shipped again — this
+//! time "a critical remote-execution and privilege risk", a hyphenated compound
+//! no pattern matches, so the sentence was skipped rather than examined. The
+//! trigger is now the [`REACHABILITY_WORDS`] vocabulary read as tokens, which
+//! sees inside a compound and across morphological variants, narrowed to CLAIM
+//! shape by [`synthesize_grounding_text::CLAIM_WORDS`]: the word must be
+//! attributing access, attack, execution or exposure to the surface. A bare
+//! "network" in "a transient network error" still costs a reader nothing.
+//!
+//! [`synthesize_grounding_text::CLAIM_WORDS`]: super::synthesize_grounding_text::CLAIM_WORDS
 //!
 //! Test: `synthesize_grounding_tests.rs`.
 
@@ -62,8 +74,8 @@ use std::collections::BTreeSet;
 
 use super::model::ReportModel;
 use super::synthesize_grounding_text::{
-    asserts_reachability, contains_name, remove_sentence, rewrite_reachability, sentences,
-    subject_tokens,
+    asserts_reachability, asserts_reachability_claim, contains_name, remove_sentence,
+    rewrite_reachability, sentences, subject_tokens,
 };
 use super::topology::CrateTopology;
 
@@ -272,7 +284,18 @@ pub(crate) enum GroundingOutcome {
     /// The text was corrected; the notes name each correction.
     Rewritten(String, Vec<String>),
     /// The field cannot be corrected safely and must be dropped.
-    Rejected(String),
+    ///
+    /// `subject` is the §5.1/§5.2 finding the refused claim was about, when the
+    /// check identified one. Report-level prose — the executive, code-quality,
+    /// security and authorship summaries, and the top-risk rows — belongs to no
+    /// finding, so its disclosure had no subject to number and the reader was
+    /// left to search the document for the title it quoted (#6082 lap 9).
+    Rejected {
+        /// Why the field cannot ship, as the reader sees it.
+        reason: String,
+        /// The finding title the reporter resolves to a rendered number.
+        subject: Option<String>,
+    },
 }
 
 /// The grounding facts one report's synthesis is checked against.
@@ -519,7 +542,12 @@ impl Grounding {
     /// Test: `synthesize_grounding_tests.rs`.
     pub(crate) fn check(&self, text: &str, owner: Option<&str>) -> GroundingOutcome {
         if let Some(reason) = self.load_bearing_violation(text) {
-            return GroundingOutcome::Rejected(reason);
+            // A load-bearing violation names a CRATE, not a finding, so there is
+            // no §5.x row to send the reader to.
+            return GroundingOutcome::Rejected {
+                reason,
+                subject: None,
+            };
         }
         let (text, mut notes) = self.drop_false_no_clean_signal(text);
         match self.reachability(&text, owner) {
@@ -529,7 +557,7 @@ impl Grounding {
                 notes.extend(more);
                 GroundingOutcome::Rewritten(fixed, notes)
             }
-            rejected @ GroundingOutcome::Rejected(_) => rejected,
+            rejected @ GroundingOutcome::Rejected { .. } => rejected,
         }
     }
 
@@ -657,11 +685,14 @@ impl Grounding {
             };
             let corrected = rewrite_reachability(sentence);
             if asserts_reachability(&corrected) {
-                return GroundingOutcome::Rejected(format!(
-                    "a beyond-the-host reachability claim about '{}' could not be corrected \
-                     safely — the report's own evidence scopes that surface to localhost",
-                    finding.title
-                ));
+                return GroundingOutcome::Rejected {
+                    reason: format!(
+                        "a beyond-the-host reachability claim about '{}' could not be corrected \
+                         safely — the report's own evidence scopes that surface to localhost",
+                        finding.title
+                    ),
+                    subject: Some(finding.title.clone()),
+                };
             }
             out = out.replace(sentence, &corrected);
             notes.push(format!(
@@ -682,24 +713,37 @@ impl Grounding {
     /// Why: rewriting needs evidence the surface is host-local, and there is
     /// none — so the only honest outcomes are ship-unexamined or withhold. A
     /// due-diligence report withholds.
-    /// What: `Rejected` for a sentence [`REACHABILITY_REWRITES`] recognises as a
-    /// reach claim (the rewrite changes it), `Clean` otherwise. The rewrite table
-    /// rather than [`REACHABILITY_WORDS`] is the trigger here deliberately: with
-    /// no evidence either way, a bare "network" in "a transient network error"
-    /// asserts nothing about reachability and must not cost a reader the field.
+    /// What: `Rejected` for a sentence that CLAIMS reach, `Clean` otherwise. A
+    /// sentence claims reach when [`asserts_reachability_claim`] reads a
+    /// [`REACHABILITY_WORDS`] token — inside a hyphenated compound or a
+    /// morphological variant, not only as a bare word — attributing access,
+    /// attack, execution or exposure to the surface, or when
+    /// [`REACHABILITY_REWRITES`] recognises the phrase outright.
+    ///
+    /// The trigger used to be the rewrite table alone, which is how
+    /// `remote-execution` shipped: it matches no pattern, so the sentence was
+    /// skipped (#6082 lap 9). The vocabulary alone is the other error — it would
+    /// take "a transient network error" with it, and withholding a field over a
+    /// word that asserts nothing about reach costs a reader more than it saves.
+    /// The claim shape is what separates the two.
     fn refuse_unevidenced_reach(&self, text: &str, component: &str) -> GroundingOutcome {
         for sentence in sentences(text) {
             if !asserts_reachability(&sentence.to_lowercase()) {
                 continue;
             }
-            if rewrite_reachability(sentence) == sentence {
+            if !asserts_reachability_claim(sentence) && rewrite_reachability(sentence) == sentence {
                 continue;
             }
-            return GroundingOutcome::Rejected(format!(
-                "a beyond-the-host reachability claim about `{}` cannot be verified — the \
-                 collected data records no evidence of how that surface is reached",
-                component.trim()
-            ));
+            // The component has no finding this check can name — that is what
+            // "unevidenced" means here — so the disclosure cites the file.
+            return GroundingOutcome::Rejected {
+                reason: format!(
+                    "a beyond-the-host reachability claim about `{}` cannot be verified — the \
+                     collected data records no evidence of how that surface is reached",
+                    component.trim()
+                ),
+                subject: None,
+            };
         }
         GroundingOutcome::Clean
     }

--- a/crates/trusty-review/src/report/synthesize_grounding_tests.rs
+++ b/crates/trusty-review/src/report/synthesize_grounding_tests.rs
@@ -225,7 +225,7 @@ fn an_uncorrectable_remote_claim_rejects_the_field() {
     let g = Grounding::from_model(&loopback_model());
     let prose = "The trusty-mpm control-plane offers remote code execution and a remote-management \
                  surface to anyone on the internet.";
-    let GroundingOutcome::Rejected(reason) = g.check(prose, None) else {
+    let GroundingOutcome::Rejected { reason, .. } = g.check(prose, None) else {
         panic!("expected a rejection, got {:?}", g.check(prose, None));
     };
     assert!(reason.contains("could not be corrected safely"));
@@ -318,7 +318,7 @@ fn instructions_that_countermand_a_guard_do_not_disable_it() {
 fn a_load_bearing_claim_about_a_leaf_crate_is_rejected() {
     let model = model_with(vec![repo("estate", vec![], Some(eight_crate_topology()))]);
     let g = Grounding::from_model(&model);
-    let GroundingOutcome::Rejected(reason) = g.check(
+    let GroundingOutcome::Rejected { reason, .. } = g.check(
         "trusty-common and trusty-mpm are the load-bearing crates the estate depends on.",
         None,
     ) else {
@@ -358,7 +358,7 @@ fn naming_a_leaf_crate_outside_a_load_bearing_claim_passes() {
 #[test]
 fn a_crate_name_is_matched_on_its_own_boundaries() {
     let model = model_with(vec![repo("estate", vec![], Some(eight_crate_topology()))]);
-    let GroundingOutcome::Rejected(reason) = Grounding::from_model(&model).check(
+    let GroundingOutcome::Rejected { reason, .. } = Grounding::from_model(&model).check(
         "trusty-mpm-gui is the load-bearing crate the estate depends on.",
         None,
     ) else {
@@ -544,7 +544,7 @@ fn an_unrewritable_network_claim_is_rejected() {
         None,
     );
     assert!(
-        matches!(outcome, GroundingOutcome::Rejected(_)),
+        matches!(outcome, GroundingOutcome::Rejected { .. }),
         "expected rejection, got: {outcome:?}"
     );
 }
@@ -711,7 +711,8 @@ fn a_sibling_finding_inherits_its_files_loopback_scope() {
 fn an_unevidenced_component_cannot_claim_beyond_host_reach() {
     let g = Grounding::from_model(&control_plane_model(false));
     let owner = format!("{CONTROL_ROUTES}:268");
-    let GroundingOutcome::Rejected(reason) = g.check(LIVE_ARBITRARY_EXEC_IMPACT, Some(&owner))
+    let GroundingOutcome::Rejected { reason, .. } =
+        g.check(LIVE_ARBITRARY_EXEC_IMPACT, Some(&owner))
     else {
         panic!(
             "expected a rejection, got {:?}",
@@ -738,6 +739,10 @@ fn an_unevidenced_component_keeps_a_non_reach_mention_of_the_network() {
         "High complexity in the network error path raises maintenance cost and the risk that a \
          new endpoint mishandles an error status.",
         "Release process cannot proceed when the external registry or network is unavailable.",
+        // #6082 lap 9: the vocabulary trigger reaches these too, so the
+        // claim-shape discriminator is the only thing keeping them.
+        "The client gives up after a transient network error.",
+        "Engine-side network and streaming logic lacks in-batch unit tests.",
     ] {
         assert_eq!(
             g.check(prose, Some(&owner)),
@@ -745,6 +750,118 @@ fn an_unevidenced_component_keeps_a_non_reach_mention_of_the_network() {
             "withheld a sentence that claims no reach: {prose}"
         );
     }
+}
+
+/// The lap-9 line, verbatim: §5.1 item 3's business impact.
+///
+/// `remote-execution` is a hyphenated compound no [`REACHABILITY_REWRITES`]
+/// pattern matches, which is why tier 3 shipped it. It is the fifth rephrasing
+/// of the same claim to reach a reader.
+const LIVE_REMOTE_EXECUTION_IMPACT: &str = "An unauthenticated client reaching the daemon can execute arbitrary commands and control \
+     sessions, a critical remote-execution and privilege risk.";
+
+/// Tier 3 rejects a reach claim whose spelling the rewrite table never saw.
+///
+/// Fails before the fix: tier 3 asked whether [`REACHABILITY_REWRITES`] could
+/// change the sentence, and no pattern matches `remote-execution`, so the
+/// sentence was skipped and the field shipped as written.
+#[test]
+fn an_unevidenced_component_rejects_a_hyphenated_reach_compound() {
+    let g = Grounding::from_model(&control_plane_model(false));
+    let owner = format!("{CONTROL_ROUTES}:259");
+    let outcome = g.check(LIVE_REMOTE_EXECUTION_IMPACT, Some(&owner));
+    let GroundingOutcome::Rejected { reason, .. } = &outcome else {
+        panic!("expected a rejection, got {outcome:?}");
+    };
+    assert!(reason.contains("cannot be verified"), "{reason}");
+    assert!(reason.contains(CONTROL_ROUTES), "{reason}");
+}
+
+/// The morphological variants the vocabulary trigger now covers.
+///
+/// Each is a positive reach claim in a spelling no rewrite pattern matches, and
+/// each is the shape a future lap would otherwise ship.
+#[test]
+fn an_unevidenced_component_rejects_reachability_word_variants() {
+    let g = Grounding::from_model(&control_plane_model(false));
+    let owner = format!("{CONTROL_ROUTES}:259");
+    for prose in [
+        "The handler is remotely exploitable by any caller.",
+        "A network-reachable attacker can spawn sessions at will.",
+        "The endpoint offers remote-execution to unauthenticated callers.",
+        "Internet exposure of this route permits arbitrary command execution.",
+    ] {
+        assert!(
+            matches!(
+                g.check(prose, Some(&owner)),
+                GroundingOutcome::Rejected { .. }
+            ),
+            "shipped an unevidenced reach claim: {prose}"
+        );
+    }
+}
+
+/// A component some finding establishes as network-reachable is tier 2, so a
+/// reach claim about it ships untouched.
+///
+/// This is the half that keeps the vocabulary trigger from swallowing genuinely
+/// remote surfaces: the discriminator decides WHETHER a sentence claims reach,
+/// and the tier decides whether the report may say so.
+#[test]
+fn a_remote_established_component_keeps_its_reach_claim() {
+    let model = model_with(vec![repo(
+        "estate",
+        vec![finding(
+            "Bot accepts commands from any chat",
+            "crates/trusty-mpm/src/telegram/mod.rs:488",
+            "Restrict the bot to an allow-list; it is publicly reachable today",
+        )],
+        None,
+    )]);
+    let g = Grounding::from_model(&model);
+    assert_eq!(
+        g.check(
+            "When the bot is left unrestricted a message from any chat could trigger real fleet \
+             operations, a significant remote-control exposure.",
+            Some("crates/trusty-mpm/src/telegram/mod.rs:488"),
+        ),
+        GroundingOutcome::Clean,
+    );
+}
+
+/// The same sentence on an UNEVIDENCED component is withheld, and that is the
+/// discriminator's cost stated plainly.
+///
+/// The live §5.2 item 114 sits on `crates/trusty-mpm/src/telegram/mod.rs`, and
+/// no finding on that file carries a [`LOOPBACK_MARKERS`] or [`REMOTE_MARKERS`]
+/// word — a Telegram bot is genuinely network-facing, but nothing the audit
+/// COLLECTED says so. Tier 3 therefore withholds "a significant remote-control
+/// exposure" and discloses the withholding. That is the policy working, not a
+/// misfire: the report has no evidence of how that surface is reached, and a
+/// visible gap beats an unexamined claim. The fix is evidence on the file — the
+/// test above shows one marker on one sibling finding is enough.
+#[test]
+fn an_unevidenced_component_withholds_a_genuine_remote_claim() {
+    let model = model_with(vec![repo(
+        "estate",
+        vec![finding(
+            "Free-text messages drive the fleet with side-effecting actions enabled",
+            "crates/trusty-mpm/src/telegram/mod.rs:488",
+            "Require explicit per-chat authorization before enabling action execution",
+        )],
+        None,
+    )]);
+    assert!(
+        matches!(
+            Grounding::from_model(&model).check(
+                "When the bot is left unrestricted a message from any chat could trigger real \
+                 fleet operations, a significant remote-control exposure.",
+                Some("crates/trusty-mpm/src/telegram/mod.rs:488"),
+            ),
+            GroundingOutcome::Rejected { .. }
+        ),
+        "an unevidenced component's reach claim must be withheld, not shipped",
+    );
 }
 
 /// A finding is judged by its OWN component, never by a word it happens to

--- a/crates/trusty-review/src/report/synthesize_grounding_text.rs
+++ b/crates/trusty-review/src/report/synthesize_grounding_text.rs
@@ -16,6 +16,73 @@ use super::synthesize_grounding::{
     GENERIC_TOKENS, MIN_TOKEN_LEN, REACHABILITY_REWRITES, REACHABILITY_WORDS,
 };
 
+/// The nouns and verbs a reachability word must be near to be making a CLAIM
+/// about the finding's surface (#6082 lap 9).
+///
+/// Why: tier 3 in [`super::synthesize_grounding`] has no evidence either way, so
+/// it withholds rather than corrects, and withholding a field the reader would
+/// have kept is a real cost. What separates "a critical remote-execution risk"
+/// from "a transient network error" is not the word `network` — both carry one —
+/// but whether that word is attributing access, attack, execution or exposure to
+/// the surface. These are the words that attribute it.
+///
+/// What: matched as whole tokens, because a prefix match on `access` would take
+/// `accessory` with it. The reachability word itself is matched by PREFIX
+/// instead — see [`asserts_reachability_claim`] — so `remotely`, `networked` and
+/// a hyphenated `remote-execution` all count.
+pub(super) const CLAIM_WORDS: &[&str] = &[
+    "access",
+    "accessed",
+    "accessible",
+    "attack",
+    "attacker",
+    "attackers",
+    "attacks",
+    "breach",
+    "compromise",
+    "compromised",
+    "control",
+    "controlled",
+    "escalation",
+    "execute",
+    "executed",
+    "executes",
+    "execution",
+    "exploit",
+    "exploitable",
+    "exploitation",
+    "exploited",
+    "expose",
+    "exposed",
+    "exposes",
+    "exposure",
+    "hijack",
+    "hijacked",
+    "injection",
+    "intrusion",
+    "rce",
+    "reach",
+    "reachable",
+    "reached",
+    "reaching",
+    "takeover",
+    "tamper",
+    "unauthenticated",
+    "unauthorised",
+    "unauthorized",
+];
+
+/// How many tokens either side of a reachability word [`CLAIM_WORDS`] is
+/// searched over.
+///
+/// Three covers every claim shape the graded reports produced — the compound
+/// (`remote-execution`), the modifier (`network-reachable attacker`) and the
+/// short prepositional phrase (`exploitable over the network`) — while leaving a
+/// claim word in a different clause of the same sentence out of reach, which is
+/// what keeps "the network error path raises maintenance cost and the risk that
+/// a new endpoint mishandles an error status" a clean sentence.
+const CLAIM_WINDOW: usize = 3;
+
 /// Cut `sentence` out of `text`, taking the space that separated it from its
 /// neighbour so the remaining prose keeps single spacing.
 pub(super) fn remove_sentence(text: &str, sentence: &str) -> String {
@@ -100,6 +167,46 @@ pub(super) fn replace_ignore_case(haystack: &str, needle: &str, replacement: &st
 pub(super) fn asserts_reachability(sentence: &str) -> bool {
     let lower = sentence.to_lowercase();
     REACHABILITY_WORDS.iter().any(|w| lower.contains(w))
+}
+
+/// True when a sentence uses a reachability word to CLAIM reach, rather than
+/// merely mentioning a network (#6082 lap 9).
+///
+/// Why: [`asserts_reachability`] is the right trigger where the report has
+/// evidence the surface is host-local — every occurrence there contradicts the
+/// data. Tier 3 has no evidence either way, so it must tell a claim from a
+/// mention, or every finding whose prose says "a transient network error" loses
+/// its field. The lap-9 report shipped the opposite failure: tier 3 asked
+/// whether [`REACHABILITY_REWRITES`] could rewrite the sentence, and
+/// `remote-execution` matches no pattern, so §5.1 item 3's business impact went
+/// out claiming remote code execution on a surface with no evidence of reach.
+///
+/// What: splits the sentence on non-alphanumerics, so a hyphenated compound
+/// becomes two tokens and `remote-execution` reads as `remote` beside
+/// `execution`. A token counts as a reachability word when it STARTS with one,
+/// which admits `remotely`, `networked` and `networking` without a stem table.
+/// It is a claim when a [`CLAIM_WORDS`] token sits within [`CLAIM_WINDOW`]
+/// tokens of it.
+///
+/// Test: `synthesize_grounding_tests.rs::{an_unevidenced_component_rejects_a_hyphenated_reach_compound,
+/// an_unevidenced_component_rejects_reachability_word_variants,
+/// an_unevidenced_component_keeps_a_non_reach_mention_of_the_network}`.
+pub(super) fn asserts_reachability_claim(sentence: &str) -> bool {
+    let words: Vec<String> = sentence
+        .split(|c: char| !c.is_ascii_alphanumeric())
+        .filter(|w| !w.is_empty())
+        .map(str::to_lowercase)
+        .collect();
+    words.iter().enumerate().any(|(i, word)| {
+        if !REACHABILITY_WORDS.iter().any(|r| word.starts_with(r)) {
+            return false;
+        }
+        let from = i.saturating_sub(CLAIM_WINDOW);
+        let to = (i + CLAIM_WINDOW + 1).min(words.len());
+        words[from..to]
+            .iter()
+            .any(|near| CLAIM_WORDS.contains(&near.as_str()))
+    })
 }
 
 /// Split prose into sentences on `. `, `? ` and `! ` boundaries, keeping each

--- a/crates/trusty-review/src/report/synthesize_guardrail.rs
+++ b/crates/trusty-review/src/report/synthesize_guardrail.rs
@@ -38,6 +38,12 @@ fn unverified_figure_note(field: &str, subject: Option<&str>, token: &str) -> St
 /// Kept distinct from [`unverified_figure_note`]: a numeric rejection means a
 /// figure was not in the data, a grounding rejection means a claim contradicted
 /// it, and a reader who sees one should not have to guess which happened.
+///
+/// `subject` is what the reporter resolves to a §5.1/§5.2 number. For a
+/// finding's own field it is that finding; for report-level prose it is the
+/// finding the grounding check identified the refused claim as being about
+/// (#6082 lap 9) — without which the line quoted a title the reader then had to
+/// search nine hundred lines of document to find.
 fn ungrounded_claim_note(field: &str, subject: Option<&str>, reason: &str) -> StatusNote {
     let text = format!("the model's {field} was withheld — {reason}");
     match subject {
@@ -306,8 +312,9 @@ fn ground_field(
             notes.extend(corrections.into_iter().map(|c| note_for(ctx, c)));
             fixed
         }
-        GroundingOutcome::Rejected(reason) => {
-            notes.push(ungrounded_claim_note(ctx.field, ctx.subject, &reason));
+        GroundingOutcome::Rejected { reason, subject } => {
+            let about = ctx.subject.or(subject.as_deref());
+            notes.push(ungrounded_claim_note(ctx.field, about, &reason));
             String::new()
         }
     }
@@ -350,8 +357,9 @@ fn admit_field(
             notes.extend(corrections.into_iter().map(|c| note_for(ctx, c)));
             fixed
         }
-        GroundingOutcome::Rejected(reason) => {
-            notes.push(ungrounded_claim_note(ctx.field, ctx.subject, &reason));
+        GroundingOutcome::Rejected { reason, subject } => {
+            let about = ctx.subject.or(subject.as_deref());
+            notes.push(ungrounded_claim_note(ctx.field, about, &reason));
             return None;
         }
     };

--- a/crates/trusty-review/src/report/synthesize_tests.rs
+++ b/crates/trusty-review/src/report/synthesize_tests.rs
@@ -2400,6 +2400,53 @@ fn synthesize_rejects_an_uncorrectable_remote_claim() {
     );
 }
 
+/// #6082 lap 9: a report-level rejection names the finding it is about, so the
+/// reporter can cite that finding's §5.1/§5.2 number.
+///
+/// Why: the graded report's line read "the model's security summary was
+/// withheld — a beyond-the-host reachability claim about 'Admin stop endpoint
+/// trusts every caller with no authentication' could not be corrected safely".
+/// That finding renders as §5.2 item 92, nine hundred lines above, and the line
+/// gave the reader no way to get there. The security summary belongs to no
+/// single finding, so its `FieldCtx` carries no subject and the note was plain —
+/// but the grounding pass knew exactly which finding the claim was about.
+/// What: the same shape as `synthesize_rejects_an_uncorrectable_remote_claim`,
+/// asserting the recorded note carries the finding title as its subject — which
+/// is what `reporter_findings::finding_citations` resolves to a number.
+/// Test: this test itself, with
+/// `reporter_tests::a_status_note_cites_its_finding_number` closing the chain.
+#[test]
+fn a_report_level_rejection_names_the_finding_it_is_about() {
+    let model = grounded_fixture_model();
+    let grounding = crate::report::synthesize_grounding::Grounding::from_model(&model);
+    let allowed = allowed_numbers(&serde_json::to_value(&model).unwrap());
+    let raw = super::RawSynthesis {
+        executive_summary: String::new(),
+        code_quality_summary: String::new(),
+        security_summary: "The acme-daemon control_routes surface offers remote code execution \
+                           and remote-management access to the internet."
+            .to_string(),
+        authorship_summary: "Two authors carry the estate.".to_string(),
+        top_risks: vec![],
+        findings: vec![],
+    };
+
+    let result =
+        crate::report::synthesize_guardrail::apply_guardrail(raw, &allowed, Vec::new(), &grounding)
+            .expect("the authorship paragraph keeps this Ok");
+
+    let note = result
+        .notes
+        .iter()
+        .find(|n| n.text.contains("security summary was withheld"))
+        .expect("the rejection must be recorded");
+    assert_eq!(
+        note.subject.as_deref(),
+        Some("Control-plane HTTP session endpoints have no authentication"),
+        "the disclosure must name the finding so the reporter can number it: {note:?}"
+    );
+}
+
 /// #6082 lap 4 (FIX 2): a crate with zero dependents called load-bearing
 /// contradicts the report's own topology table and drops the field.
 ///


### PR DESCRIPTION
Two lap-9 acceptance defects. Refs #6082.

## Defect 1 — tier 3's trigger was the rewrite table

Tier 3 (a component the collected data places neither on loopback nor on the network) asked whether `REACHABILITY_REWRITES` could change a sentence before it would withhold it. `remote-execution` is a hyphenated compound no pattern matches, so §5.1 item 3's business impact shipped:

> An unauthenticated client reaching the daemon can execute arbitrary commands and control sessions, a critical **remote-execution** and privilege risk

while the exec summary (line 33) and the top-risk table (line 57) of the same document said "any process on the host". Fifth rephrasing of the same claim to reach a reader.

**Trigger design — claim-shaped, not blanket.** The trigger is now the `REACHABILITY_WORDS` vocabulary read as TOKENS: the sentence is split on non-alphanumerics, so `remote-execution` reads as `remote` beside `execution`, and a token counts when it *starts with* a reachability word, which admits `remotely`, `networked`, `network-reachable` without a stem table. That alone would take every field that mentions a network, so it is narrowed to CLAIM shape: the reachability word must sit within three tokens of a `CLAIM_WORDS` entry — an access, attack, execution or exposure word. The old rewrite-table trigger stays as a union term, so nothing tier 3 already caught is lost.

The blanket fallback was not needed. Policy is unchanged: reject-and-disclose on an unevidenced component, never rewrite.

## Defect 2 — disclosures cited findings by title, never by number

Live line 1981 named `'Admin stop endpoint trusts every caller with no authentication'`, which renders as §5.2 item 92 nine hundred lines above. The security summary belongs to no single finding, so its `FieldCtx` carried no subject and the note was plain — but the grounding check knew exactly which finding the refused claim was about. `GroundingOutcome::Rejected` now carries that finding, and the reporter resolves it through the `finding_citations` map it already computes for finding-owned notes.

## Failing-before evidence

Both on the pre-fix behaviour, `-p trusty-review`:

```
---- report::synthesize_grounding::tests::an_unevidenced_component_rejects_a_hyphenated_reach_compound stdout ----
expected a rejection, got Clean

---- report::synthesize_grounding::tests::an_unevidenced_component_rejects_reachability_word_variants stdout ----
shipped an unevidenced reach claim: The endpoint offers remote-execution to unauthenticated callers.

---- report::synthesize::tests::a_report_level_rejection_names_the_finding_it_is_about stdout ----
assertion `left == right` failed: the disclosure must name the finding so the reporter can number it:
  StatusNote { text: "the model's security summary was withheld — a beyond-the-host reachability claim about 'Control-plane HTTP session endpoints have no authentication' could not be corrected safely …", subject: None }
  left: None
 right: Some("Control-plane HTTP session endpoints have no authentication")
```

## Negative tests

`an_unevidenced_component_keeps_a_non_reach_mention_of_the_network` now carries five live texts, all `Clean`: "a transient network error", "the external registry or network is unavailable", "the network error path", "network and streaming logic", "Intermittent network or daemon load".

The Telegram case is the one the acceptance note assumed was tier-2. It is not — see the trade-off note below.

## Tier-1 for daemon route files — what I found

No clean deterministic source exists, and I did not invent a collector. The report model records `scan`, `metrics`, `crate_topology`, `authorship`, `git_info` and `inspect_priority`; none carries a bind address, port, host or socket (209 keys in the live JSON twin, zero matching `bind|addr|port|host|socket`). The only reachability evidence in the pipeline is free text inside a finding's own description / remediation / evidence quote — 4 of 207 live findings carry a marker, and `control_routes.rs` is not one of them. The report's own exec-summary scoping is model prose generated after grounding runs and itself guarded, so using it would ground the model's guess with the model's guess.

## Gates — rung 3

| Gate | Result |
|---|---|
| `cargo fmt --check` | exit 0 |
| `cargo check -p trusty-review --all-targets` | exit 0 |
| `cargo clippy -p trusty-review --all-targets -- -D warnings` | exit 0 |
| `cargo test -p trusty-review` | `ok. 1989 passed; 0 failed; 5 ignored` + 9 integration binaries, all ok |
| `scripts/check_line_cap.sh` | 4162 files, 0 violations |
| `scripts/check_changelog_fragment.sh` | fragment present and valid |
| `scripts/check_sld.sh` | 0 errors, 0 warnings |

`synthesize_grounding.rs` hit 512 SLOC; `CLAIM_WORDS` moved to `synthesize_grounding_text.rs`, where its only consumer lives.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools