### PR TITLE
fix(trusty-review): a reachability rewrite fails closed on the debris it leaves (Refs #6082)

### DIFF
--- a/crates/trusty-review/changelog.d/6082-lap10-grade-fix.md
+++ b/crates/trusty-review/changelog.d/6082-lap10-grade-fix.md
@@ -1,0 +1,7 @@
+Fixed
+
+- A reachability rewrite can no longer ship ungrammatical debris ([#6082](https://github.com/bobmatnyc/trusty-tools/issues/6082))
+  - a replacement that opens with a determiner now takes the article in front of it, so `by a remote attacker` becomes `by any local process` rather than `by a any local process` — the last report's Security Posture lead shipped exactly that
+  - every rewritten sentence is read for grammar debris before it may ship: two adjacent determiners, or a contrast whose two sides describe the same reachability, send the field down the reject-and-disclose path instead of out to a reader
+- A corrected-wording disclosure now cites the §5.1/§5.2 number of the finding it is about ([#6082](https://github.com/bobmatnyc/trusty-tools/issues/6082))
+  - the withheld lines already carried "section 5.1, RED finding 2" while the corrected-wording line beside them named its finding by title only; the grounding check now hands that finding to the reporter, which resolves it to the rendered number

--- a/crates/trusty-review/src/report/synthesize_grounding.rs
+++ b/crates/trusty-review/src/report/synthesize_grounding.rs
@@ -66,7 +66,20 @@
 //! attributing access, attack, execution or exposure to the surface. A bare
 //! "network" in "a transient network error" still costs a reader nothing.
 //!
+//! #6082 lap 10 made the REWRITE itself fail closed. Until then a rewrite always
+//! shipped, and the graded report shipped "reachable by any process on the host
+//! rather than a any local process": the `remote attacker` rule spliced its
+//! replacement in without consuming the article in front of it, and the
+//! corrected clause then contrasted host-local reach with host-local reach.
+//! Two changes. A replacement opening with a determiner now takes the preceding
+//! article with the phrase it replaces, so no doubled article can be emitted;
+//! and every rewritten sentence is read by
+//! [`synthesize_grounding_text::grammar_debris`] before it may ship, which
+//! sends a doubled determiner or a self-contrast down the reject-and-disclose
+//! path instead. A visible withholding is the better of the two failures.
+//!
 //! [`synthesize_grounding_text::CLAIM_WORDS`]: super::synthesize_grounding_text::CLAIM_WORDS
+//! [`synthesize_grounding_text::grammar_debris`]: super::synthesize_grounding_text::grammar_debris
 //!
 //! Test: `synthesize_grounding_tests.rs`.
 
@@ -74,8 +87,8 @@ use std::collections::BTreeSet;
 
 use super::model::ReportModel;
 use super::synthesize_grounding_text::{
-    asserts_reachability, asserts_reachability_claim, contains_name, remove_sentence,
-    rewrite_reachability, sentences, subject_tokens,
+    asserts_reachability, asserts_reachability_claim, contains_name, grammar_debris,
+    remove_sentence, rewrite_reachability, sentences, subject_tokens,
 };
 use super::topology::CrateTopology;
 
@@ -274,15 +287,15 @@ struct Staged {
 /// keeps the model's paragraph with one claim corrected, the second drops it
 /// entirely — and the caller records a different note for each.
 /// What: `Clean` passes the text through untouched; `Rewritten` carries the
-/// corrected text plus one note per correction; `Rejected` carries the reason
-/// the field cannot ship.
+/// corrected text plus one [`Correction`] per correction; `Rejected` carries the
+/// reason the field cannot ship.
 /// Test: `synthesize_grounding_tests.rs`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum GroundingOutcome {
     /// Nothing contradicted the model's data.
     Clean,
-    /// The text was corrected; the notes name each correction.
-    Rewritten(String, Vec<String>),
+    /// The text was corrected; the corrections name what changed.
+    Rewritten(String, Vec<Correction>),
     /// The field cannot be corrected safely and must be dropped.
     ///
     /// `subject` is the §5.1/§5.2 finding the refused claim was about, when the
@@ -296,6 +309,27 @@ pub(crate) enum GroundingOutcome {
         /// The finding title the reporter resolves to a rendered number.
         subject: Option<String>,
     },
+}
+
+/// One disclosure that the guardrail changed the model's prose, and the finding
+/// it changed it about.
+///
+/// Why: a corrected-wording line and a withheld line are the same kind of
+/// disclosure to a reader, so both must point at the same numbered §5.1/§5.2
+/// row. Only the withheld path carried its subject, and the graded lap-10 report
+/// showed the split in one block: two lines reading "section 5.1, RED finding 2"
+/// beside a corrected-wording line that quoted a title and left the reader to
+/// find it (#6082 lap 10).
+/// What: `text` is the complete reader sentence; `subject` is the finding title
+/// the reporter resolves to a number, absent when the correction was about no
+/// single finding.
+/// Test: `synthesize_grounding_tests.rs::a_correction_note_carries_the_finding_it_is_about`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Correction {
+    /// The disclosure, as the reader sees it.
+    pub(crate) text: String,
+    /// The finding this correction was about, when it was about one.
+    pub(crate) subject: Option<String>,
 }
 
 /// The grounding facts one report's synthesis is checked against.
@@ -578,7 +612,7 @@ impl Grounding {
     /// otherwise-grounded prose.
     /// Test: `synthesize_grounding_tests.rs::{a_no_clean_signal_claim_is_dropped_when_signals_exist,
     /// a_no_clean_signal_claim_survives_when_there_are_none}`.
-    fn drop_false_no_clean_signal(&self, text: &str) -> (String, Vec<String>) {
+    fn drop_false_no_clean_signal(&self, text: &str) -> (String, Vec<Correction>) {
         if self.clean_signals == 0 {
             return (text.to_string(), Vec::new());
         }
@@ -596,11 +630,16 @@ impl Grounding {
                 continue;
             }
             out = remove_sentence(&out, sentence);
-            notes.push(format!(
-                "a sentence claiming no clean signal was credited was dropped — the Security \
-                 Posture section credits {} of them, each with the file it was read from",
-                self.clean_signals
-            ));
+            // A clean-signal claim is about the report's own GREEN list, not
+            // about any one §5.x finding, so there is no subject to number.
+            notes.push(Correction {
+                text: format!(
+                    "a sentence claiming no clean signal was credited was dropped — the Security \
+                     Posture section credits {} of them, each with the file it was read from",
+                    self.clean_signals
+                ),
+                subject: None,
+            });
         }
         (out.trim().to_string(), notes)
     }
@@ -684,22 +723,32 @@ impl Grounding {
                 },
             };
             let corrected = rewrite_reachability(sentence);
-            if asserts_reachability(&corrected) {
+            // #6082 lap 10: a rewrite that leaves the sentence ungrammatical, or
+            // contrasting one reachability class with itself, takes the same
+            // withhold path as a claim no rewrite reaches.
+            let debris = grammar_debris(&corrected);
+            if asserts_reachability(&corrected) || debris.is_some() {
+                let detail = debris.unwrap_or_else(|| {
+                    "the report's own evidence scopes that surface to localhost".to_string()
+                });
                 return GroundingOutcome::Rejected {
                     reason: format!(
                         "a beyond-the-host reachability claim about '{}' could not be corrected \
-                         safely — the report's own evidence scopes that surface to localhost",
+                         safely — {detail}",
                         finding.title
                     ),
                     subject: Some(finding.title.clone()),
                 };
             }
             out = out.replace(sentence, &corrected);
-            notes.push(format!(
-                "the beyond-the-host reachability wording was corrected — the report's own \
-                 evidence scopes '{}' to a loopback-only surface",
-                finding.title
-            ));
+            notes.push(Correction {
+                text: format!(
+                    "the beyond-the-host reachability wording was corrected — the report's own \
+                     evidence scopes '{}' to a loopback-only surface",
+                    finding.title
+                ),
+                subject: Some(finding.title.clone()),
+            });
         }
         match notes.is_empty() {
             true => GroundingOutcome::Clean,

--- a/crates/trusty-review/src/report/synthesize_grounding_tests.rs
+++ b/crates/trusty-review/src/report/synthesize_grounding_tests.rs
@@ -215,7 +215,7 @@ fn a_remote_claim_about_a_local_finding_is_rewritten() {
     assert!(fixed.contains("local-process-reachable code-execution"));
     assert!(fixed.contains("A JQL injection adds a query-tampering vector."));
     assert_eq!(notes.len(), 1);
-    assert!(notes[0].contains("reachability wording was corrected"));
+    assert!(notes[0].text.contains("reachability wording was corrected"));
 }
 
 /// A remote claim this module cannot rewrite fails the field closed and names
@@ -308,7 +308,7 @@ fn instructions_that_countermand_a_guard_do_not_disable_it() {
         !fixed.to_lowercase().contains("remote"),
         "the guard must still strip the remote claim: {fixed}"
     );
-    assert!(notes[0].contains("reachability wording was corrected"));
+    assert!(notes[0].text.contains("reachability wording was corrected"));
 }
 
 // ─── Load-bearing post-check ─────────────────────────────────────────────────
@@ -597,9 +597,9 @@ fn a_no_clean_signal_claim_is_dropped_when_signals_exist() {
     assert_eq!(text, "Error handling is frequently fail-open or lossy.");
     assert_eq!(notes.len(), 1, "notes were: {notes:?}");
     assert!(
-        notes[0].contains("credits 1 of them"),
+        notes[0].text.contains("credits 1 of them"),
         "the note must state the measured count: {}",
-        notes[0]
+        notes[0].text
     );
 }
 
@@ -699,7 +699,7 @@ fn a_sibling_finding_inherits_its_files_loopback_scope() {
         "remote survived: {fixed}"
     );
     assert!(fixed.contains("local-process-reachable code execution"));
-    assert!(notes[0].contains("reachability wording was corrected"));
+    assert!(notes[0].text.contains("reachability wording was corrected"));
 }
 
 /// Tier 3, and what the live report actually held: NO finding on that file
@@ -944,4 +944,93 @@ fn a_line_suffix_does_not_split_a_component() {
         CONTROL_ROUTES
     );
     assert_eq!(normalize_component("   "), "");
+}
+
+// ─── #6082 lap 10: a rewrite may not emit ungrammatical debris ───────────────
+
+/// The lap-10 blocking defect, reconstructed from its live output.
+///
+/// Why: the graded report's Security Posture lead shipped "reachable by any
+/// process on the host rather than a any local process". The model's own
+/// sentence was fine — it followed the prompt hint and contrasted the host-local
+/// surface with a remote attacker — and the `remote attacker` rewrite dropped
+/// its replacement in without consuming the article in front of it, leaving a
+/// clause that also contrasts host-local reach with host-local reach.
+/// What: the pre-rewrite sentence that live line came from. The fixed pipeline
+/// either ships a grammatical sentence or withholds the field; `a any` reaches
+/// a reader in neither case.
+/// Test: this test itself.
+#[test]
+fn a_rewrite_never_ships_a_doubled_article() {
+    let g = Grounding::from_model(&loopback_model());
+    let prose = "The trusty-mpm control_routes session handlers perform no authentication; \
+                 these surfaces are loopback/localhost-scoped and thus reachable by any process \
+                 on the host rather than a remote attacker, but that is still a serious local \
+                 privilege boundary failure.";
+    match g.check(prose, None) {
+        GroundingOutcome::Rewritten(fixed, _) => {
+            assert!(!fixed.to_lowercase().contains("a any"), "debris: {fixed}");
+        }
+        GroundingOutcome::Rejected { reason, subject } => {
+            assert!(
+                reason.contains("could not be corrected"),
+                "reason: {reason}"
+            );
+            assert_eq!(
+                subject.as_deref(),
+                Some(
+                    "Control-plane HTTP session endpoints have no authentication or authorization"
+                )
+            );
+        }
+        GroundingOutcome::Clean => panic!("the remote claim must not pass through unexamined"),
+    }
+}
+
+/// A rewritten sentence that contrasts host-local reach with host-local reach
+/// states nothing, so the field is withheld rather than shipped.
+#[test]
+fn a_rewrite_that_contrasts_a_class_with_itself_is_withheld() {
+    let g = Grounding::from_model(&loopback_model());
+    let prose = "The trusty-mpm control_routes endpoints are reachable by any process on the \
+                 host rather than a remote attacker.";
+    let GroundingOutcome::Rejected { reason, subject } = g.check(prose, None) else {
+        panic!("expected a withholding, got {:?}", g.check(prose, None));
+    };
+    assert!(
+        reason.contains("could not be corrected"),
+        "reason: {reason}"
+    );
+    assert!(subject.is_some(), "the withholding must name its finding");
+}
+
+/// The article half on its own: a replacement opening with a determiner
+/// consumes the article in front of it, and the sentence still ships.
+#[test]
+fn a_rewrite_consumes_the_article_its_replacement_doubles() {
+    let g = Grounding::from_model(&loopback_model());
+    let prose = "The trusty-mpm control_routes endpoints can be driven by a remote attacker.";
+    let GroundingOutcome::Rewritten(fixed, notes) = g.check(prose, None) else {
+        panic!("expected a rewrite, got {:?}", g.check(prose, None));
+    };
+    assert_eq!(
+        fixed,
+        "The trusty-mpm control_routes endpoints can be driven by any local process."
+    );
+    assert_eq!(notes.len(), 1);
+}
+
+/// A corrected-wording disclosure names the finding it is about, so the reporter
+/// numbers it the way it already numbers the withheld lines (#6082 lap 10).
+#[test]
+fn a_correction_note_carries_the_finding_it_is_about() {
+    let g = Grounding::from_model(&loopback_model());
+    let prose = "The trusty-mpm control_routes endpoints can be driven by a remote attacker.";
+    let GroundingOutcome::Rewritten(_, notes) = g.check(prose, None) else {
+        panic!("expected a rewrite");
+    };
+    assert_eq!(
+        notes[0].subject.as_deref(),
+        Some("Control-plane HTTP session endpoints have no authentication or authorization")
+    );
 }

--- a/crates/trusty-review/src/report/synthesize_grounding_text.rs
+++ b/crates/trusty-review/src/report/synthesize_grounding_text.rs
@@ -6,7 +6,8 @@
 //! findings, reports or reachability tiers, and nothing else in the module
 //! depends on them beyond calling them.
 //! What: sentence splitting and splicing, subject-token extraction,
-//! boundary-aware name matching, and the case-insensitive rewrite pass.
+//! boundary-aware name matching, the case-insensitive rewrite pass, and the
+//! grammar check that decides whether a rewritten sentence may ship.
 //! Test: `synthesize_grounding_tests.rs` exercises each through the guardrail
 //! and directly.
 
@@ -133,13 +134,186 @@ pub(super) fn contains_name(haystack: &str, needle: &str) -> bool {
     })
 }
 
+/// Determiners a replacement may open with.
+///
+/// A replacement starting with one of these cannot follow an article: splicing
+/// `any local process` in where `remote attacker` stood leaves `a any local
+/// process` unless the article in front is consumed with the phrase (#6082 lap
+/// 10).
+const LEADING_DETERMINERS: &[&str] = &["a", "an", "the", "any", "every", "each", "some", "no"];
+
+/// The articles [`splice_ignore_case`] consumes ahead of such a replacement.
+const CONSUMED_ARTICLES: &[&str] = &["a", "an", "the"];
+
+/// Contrast joiners a rewritten sentence is read across for a self-contrast.
+const CONTRAST_MARKERS: &[&str] = &[" rather than ", " instead of "];
+
+/// Phrases that place a surface on this host.
+///
+/// Read only on a sentence the rewrite pass changed, and only to ask whether
+/// both sides of a contrast landed in the same class.
+const HOST_LOCAL_PHRASES: &[&str] = &[
+    "on the host",
+    "on this host",
+    "any local process",
+    "local process",
+    "local-process",
+    "host-local",
+    "localhost",
+    "loopback",
+    "local socket",
+    "local-socket",
+];
+
 /// Apply every known reachability rewrite to one sentence, case-insensitively.
 pub(super) fn rewrite_reachability(sentence: &str) -> String {
     let mut out = sentence.to_string();
     for (phrase, replacement) in REACHABILITY_REWRITES {
-        out = replace_ignore_case(&out, phrase, replacement);
+        out = splice_ignore_case(&out, phrase, replacement);
     }
     out
+}
+
+/// The grammatical debris a rewrite left behind, as the reason to withhold.
+///
+/// Why: [`rewrite_reachability`] substitutes a phrase into a sentence it did not
+/// write, and the graded lap-10 report shipped the result — "reachable by any
+/// process on the host rather than a any local process". Two things went wrong
+/// at once: the replacement doubled the article in front of it, and the
+/// corrected clause contrasted host-local reach with host-local reach, which
+/// tells a reader nothing. Neither is repairable from here, so a tripped check
+/// falls back to the withhold path the module already uses for a claim it cannot
+/// correct — a visible withholding reads better than shipped nonsense.
+/// What: `Some(reason)` for two adjacent determiners, or for a contrast whose
+/// two sides carry the same reachability class. `None` when the sentence reads
+/// cleanly. Run on the REWRITTEN sentence only, so prose the module left alone
+/// is never judged by it.
+/// Test: `synthesize_grounding_tests.rs::{a_rewrite_never_ships_a_doubled_article,
+/// a_rewrite_that_contrasts_a_class_with_itself_is_withheld}`.
+pub(super) fn grammar_debris(sentence: &str) -> Option<String> {
+    if let Some(pair) = doubled_determiner(sentence) {
+        return Some(format!("the correction left '{pair}' in the sentence"));
+    }
+    if contrasts_one_class_with_itself(sentence) {
+        return Some(
+            "the correction left both sides of a contrast describing the same reachability"
+                .to_string(),
+        );
+    }
+    None
+}
+
+/// The first pair of adjacent determiners in a sentence, lower-cased.
+fn doubled_determiner(sentence: &str) -> Option<String> {
+    let raw: Vec<&str> = sentence.split_whitespace().collect();
+    raw.windows(2).find_map(|pair| {
+        // Punctuation between the two words means they are not one noun phrase.
+        if !pair[0].ends_with(|c: char| c.is_ascii_alphanumeric()) {
+            return None;
+        }
+        let (first, second) = (word_of(pair[0])?, word_of(pair[1])?);
+        let is_det = |w: &String| LEADING_DETERMINERS.contains(&w.as_str());
+        (is_det(&first) && is_det(&second)).then(|| format!("{first} {second}"))
+    })
+}
+
+/// True when a contrast in `sentence` has the same reachability class on both
+/// sides, so it draws no distinction.
+fn contrasts_one_class_with_itself(sentence: &str) -> bool {
+    let lower = sentence.to_lowercase();
+    CONTRAST_MARKERS.iter().any(|marker| {
+        let Some(at) = lower.find(marker) else {
+            return false;
+        };
+        let before = reach_class(&lower[..at]);
+        before.is_some() && before == reach_class(&lower[at + marker.len()..])
+    })
+}
+
+/// Which reachability class a clause describes, if it names one at all.
+///
+/// `Some(true)` is beyond this host and `Some(false)` is on it; a reachability
+/// word wins, because a clause carrying one is making the wider claim.
+fn reach_class(clause: &str) -> Option<bool> {
+    if REACHABILITY_WORDS.iter().any(|w| clause.contains(w)) {
+        return Some(true);
+    }
+    HOST_LOCAL_PHRASES
+        .iter()
+        .any(|p| clause.contains(p))
+        .then_some(false)
+}
+
+/// One whitespace-separated word reduced to its lower-cased letters, or `None`
+/// when nothing is left.
+fn word_of(raw: &str) -> Option<String> {
+    let word: String = raw
+        .trim_matches(|c: char| !c.is_ascii_alphanumeric())
+        .to_lowercase();
+    (!word.is_empty()).then_some(word)
+}
+
+/// Replace `needle` with `replacement`, consuming an article the replacement's
+/// own determiner would double.
+///
+/// Why: the rewrite table's replacements were written as standalone noun
+/// phrases, and the sentences they land in already carry an article — so
+/// `by a remote attacker` became `by a any local process` (#6082 lap 10).
+/// What: [`replace_ignore_case`], plus: when the replacement opens with a
+/// [`LEADING_DETERMINERS`] word, any [`CONSUMED_ARTICLES`] word immediately
+/// before the match is dropped, and its capitalization carries onto the
+/// replacement so a sentence-initial article does not lower-case the sentence.
+/// Test: `synthesize_grounding_tests.rs::a_rewrite_consumes_the_article_its_replacement_doubles`.
+fn splice_ignore_case(haystack: &str, needle: &str, replacement: &str) -> String {
+    let doubles = replacement
+        .split_whitespace()
+        .next()
+        .and_then(word_of)
+        .is_some_and(|w| LEADING_DETERMINERS.contains(&w.as_str()));
+    if !doubles {
+        return replace_ignore_case(haystack, needle, replacement);
+    }
+    let lower = haystack.to_lowercase();
+    let mut out = String::with_capacity(haystack.len());
+    let mut cursor = 0usize;
+    while let Some(rel) = lower[cursor..].find(needle) {
+        let at = cursor + rel;
+        out.push_str(&haystack[cursor..at]);
+        match take_trailing_article(&mut out) {
+            true => out.push_str(&capitalize(replacement)),
+            false => out.push_str(replacement),
+        }
+        cursor = at + needle.len();
+    }
+    out.push_str(&haystack[cursor..]);
+    out
+}
+
+/// Drop a trailing article from `out`; `true` when the one dropped was
+/// capitalized, so the caller capitalizes what replaces it.
+fn take_trailing_article(out: &mut String) -> bool {
+    let trimmed = out.trim_end();
+    if trimmed.len() == out.len() {
+        return false; // the match abuts the previous word: no article to take
+    }
+    let Some(last) = trimmed.split_whitespace().next_back() else {
+        return false;
+    };
+    if !CONSUMED_ARTICLES.contains(&last.to_lowercase().as_str()) {
+        return false;
+    }
+    let capitalized = last.starts_with(|c: char| c.is_ascii_uppercase());
+    out.truncate(trimmed.len() - last.len());
+    capitalized
+}
+
+/// Upper-case the first character of `text`.
+fn capitalize(text: &str) -> String {
+    let mut chars = text.chars();
+    match chars.next() {
+        Some(c) => c.to_uppercase().chain(chars).collect(),
+        None => String::new(),
+    }
 }
 
 /// Case-insensitive literal replacement preserving everything else verbatim.

--- a/crates/trusty-review/src/report/synthesize_guardrail.rs
+++ b/crates/trusty-review/src/report/synthesize_guardrail.rs
@@ -309,7 +309,7 @@ fn ground_field(
     match grounding.check(text, ctx.component) {
         GroundingOutcome::Clean => text.to_string(),
         GroundingOutcome::Rewritten(fixed, corrections) => {
-            notes.extend(corrections.into_iter().map(|c| note_for(ctx, c)));
+            notes.extend(corrections.into_iter().map(|c| note_for(ctx, &c)));
             fixed
         }
         GroundingOutcome::Rejected { reason, subject } => {
@@ -321,10 +321,16 @@ fn ground_field(
 }
 
 /// Attach one grounding correction to the finding whose field carried it.
-fn note_for(ctx: &FieldCtx<'_>, text: String) -> StatusNote {
-    match ctx.subject {
-        Some(s) => StatusNote::about(s, text),
-        None => StatusNote::plain(text),
+///
+/// #6082 lap 10: report-level prose has no `ctx.subject`, so a correction made
+/// in it used to ship with no subject at all and cited its finding by title
+/// while the withheld lines beside it carried a §5.1/§5.2 number. The grounding
+/// check knows which finding it corrected — fall back to that, exactly as
+/// [`ground_field`] already does for a rejection.
+fn note_for(ctx: &FieldCtx<'_>, c: &crate::report::synthesize_grounding::Correction) -> StatusNote {
+    match ctx.subject.or(c.subject.as_deref()) {
+        Some(s) => StatusNote::about(s, c.text.clone()),
+        None => StatusNote::plain(c.text.clone()),
     }
 }
 
@@ -354,7 +360,7 @@ fn admit_field(
     let grounded = match grounding.check(text, ctx.component) {
         GroundingOutcome::Clean => text.to_string(),
         GroundingOutcome::Rewritten(fixed, corrections) => {
-            notes.extend(corrections.into_iter().map(|c| note_for(ctx, c)));
+            notes.extend(corrections.into_iter().map(|c| note_for(ctx, &c)));
             fixed
         }
         GroundingOutcome::Rejected { reason, subject } => {

--- a/crates/trusty-review/src/report/synthesize_tests.rs
+++ b/crates/trusty-review/src/report/synthesize_tests.rs
@@ -2351,13 +2351,19 @@ fn synthesize_rewrites_a_remote_claim_about_a_local_finding() {
         "the remote claim must not survive: {exec}"
     );
     assert!(exec.contains("local-process-reachable code-execution"));
-    assert!(
-        result
-            .notes
-            .iter()
-            .any(|n| n.text.contains("reachability wording was corrected")),
-        "the correction must be recorded: {:?}",
-        result.notes
+    let corrected = result
+        .notes
+        .iter()
+        .find(|n| n.text.contains("reachability wording was corrected"))
+        .unwrap_or_else(|| panic!("the correction must be recorded: {:?}", result.notes));
+    // #6082 lap 10: report-level prose belongs to no finding, so this note used
+    // to ship with no subject and cited its finding by title alone while the
+    // withheld lines beside it carried "section 5.1, RED finding 2". The
+    // grounding check knows which finding it corrected; carry that.
+    assert_eq!(
+        corrected.subject.as_deref(),
+        Some("Control-plane HTTP session endpoints have no authentication"),
+        "the corrected-wording note must name its finding: {corrected:?}"
     );
 }
 


### PR DESCRIPTION
Refs #6082 — two fixes from the lap-10 adversarial grade of
`2026-08-22-technical-due-diligence.md`.

## 1. The rewrite path shipped ungrammatical debris (blocker)

Live `.md` line 1966, Security Posture:

> …these surfaces are loopback/localhost-scoped and thus reachable by any process
> on the host rather than **a any local process**, but that is still a serious
> local privilege boundary failure.

**The rule that fired:** `("remote attacker", "any local process")` in
`REACHABILITY_REWRITES`. The model's own sentence was correct — it followed the
prompt hint ("describe it as reachable by any process on the host") and
contrasted the host-local surface with a remote attacker. The rewrite then
substituted its replacement without consuming the article in front of it, and
the corrected clause contrasts host-local reach with host-local reach, which
draws no distinction at all.

Both layers are fixed:

- **Substitution.** `splice_ignore_case` consumes a preceding `a`/`an`/`the`
  when the replacement opens with a determiner, carrying the article's
  capitalization onto the replacement. No doubled article can be emitted.
- **Fail-closed sanity check.** `grammar_debris` reads every rewritten sentence
  before it may ship: two adjacent determiners, or a contrast (`rather than`,
  `instead of`) whose two sides carry the same reachability class. A trip sends
  the field down the reject-and-disclose path the module already uses for a
  claim no rewrite reaches — the withhold path, which is proven safe and
  reader-acceptable.

The regression test reconstructs the pre-rewrite input and reproduces the live
output byte-for-byte on the pre-fix commit.

## 2. The corrected-wording disclosure cites by title only

The two withheld lines carried "section 5.1, RED finding 2" / "section 5.2,
AMBER finding 124"; the corrected-wording line beside them named
'SSRF loopback guard uses prefix string matching' and left the reader to find
it. That third emission path missed #6185's numbering plumbing.
`GroundingOutcome::Rewritten` now carries `Correction { text, subject }` rather
than a bare string, and `note_for` falls back to the correction's own subject
the way `ground_field` already does for a rejection.

## Failing before

`cargo test -p trusty-review --lib` at `39256b8`, with the four new tests
applied:

```
running 4 tests
test report::synthesize_grounding::tests::a_rewrite_never_ships_a_doubled_article ... FAILED
test report::synthesize_grounding::tests::a_rewrite_consumes_the_article_its_replacement_doubles ... FAILED
test report::synthesize_grounding::tests::a_rewrite_that_contrasts_a_class_with_itself_is_withheld ... FAILED
test report::synthesize::tests::synthesize_rewrites_a_remote_claim_about_a_local_finding ... FAILED

---- a_rewrite_never_ships_a_doubled_article stdout ----
debris: The trusty-mpm control_routes session handlers perform no authentication;
these surfaces are loopback/localhost-scoped and thus reachable by any process on
the host rather than a any local process, but that is still a serious local
privilege boundary failure.

---- a_rewrite_consumes_the_article_its_replacement_doubles stdout ----
  left: "The trusty-mpm control_routes endpoints can be driven by a any local process."
 right: "The trusty-mpm control_routes endpoints can be driven by any local process."

---- a_rewrite_that_contrasts_a_class_with_itself_is_withheld stdout ----
expected a withholding, got Rewritten("The trusty-mpm control_routes endpoints are
reachable by any process on the host rather than a any local process.", [...])

---- synthesize_rewrites_a_remote_claim_about_a_local_finding stdout ----
the corrected-wording note must name its finding: StatusNote { text: "the
beyond-the-host reachability wording was corrected — …", subject: None }
  left: None
 right: Some("Control-plane HTTP session endpoints have no authentication")

test result: FAILED. 0 passed; 4 failed
```

## Gates — ladder rung 3

| Gate | Result |
|---|---|
| `cargo fmt --check` | clean |
| `cargo clippy -p trusty-review --all-targets -- -D warnings` | EXIT=0 |
| `cargo test -p trusty-review` | `1993 passed; 0 failed; 5 ignored` (lib) + 98 across 8 integration targets, 0 failed |
| `bash scripts/check_line_cap.sh` | 4162 files, 0 violations |
| `bash scripts/check_changelog_fragment.sh` | `OK trusty-review: fragment present and valid` |
| `bash scripts/check_sld.sh` | 0 errors, 0 warnings |

Rung 3 covers it: the change is localized to `trusty-review`'s synthesis
guardrail, and `GroundingOutcome` is `pub(crate)` — no cross-crate surface moves.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
