### PR TITLE
fix(trusty-review): a withholding disclosure names its own finding (Refs #6082)

### DIFF
--- a/crates/trusty-review/changelog.d/6082-lap11-grade-fix.md
+++ b/crates/trusty-review/changelog.d/6082-lap11-grade-fix.md
@@ -1,0 +1,5 @@
+Fixed
+
+- A withholding disclosure now names the finding whose field it is ([#6082](https://github.com/bobmatnyc/trusty-tools/issues/6082))
+  - the reachability tier is read from the FILE, so the grounding check resolved it through that file's first loopback-scoped record and quoted that record's title; the last report's RED findings 2 and 3 both sit in `control_routes.rs`, so their two Synthesis Status lines shipped byte-identical, both naming finding 2
+  - the check now takes the field's own finding title and prefers it over the shared record, for both the withheld and the corrected-wording line; report-level prose, which names no finding, still cites the one the subject-token match found for it

--- a/crates/trusty-review/src/report/synthesize_grounding.rs
+++ b/crates/trusty-review/src/report/synthesize_grounding.rs
@@ -16,7 +16,7 @@
 //! What: [`Grounding`] is built from the deterministic model and does two
 //! things. It renders [`prompt_facts`] — the reachability hints and the
 //! authoritative load-bearing list — into the synthesis prompt, so the model is
-//! told the answer rather than left to guess it. And it runs [`Grounding::check`]
+//! told the answer rather than left to guess it. And it runs [`Grounding::check_field`]
 //! over each narrative field afterwards, because a prompt instruction is a hope
 //! and this is the mechanical half: a reachability contradiction is REWRITTEN
 //! when the phrase is one this module knows how to rewrite, and the field is
@@ -34,7 +34,7 @@
 //! #6082 lap 8 moved the reachability question off the finding's own wording and
 //! onto its COMPONENT, because a finding whose text happened to carry no
 //! loopback marker was never classified and so was never checked at all. A
-//! component now falls in one of three tiers, and [`Grounding::check`] takes the
+//! component now falls in one of three tiers, and [`Grounding::check_field`] takes the
 //! checked field's owning component so the tier is decided by the file the
 //! finding sits in rather than by which words the sentence happens to share with
 //! some other finding's title:
@@ -77,6 +77,14 @@
 //! [`synthesize_grounding_text::grammar_debris`] before it may ship, which
 //! sends a doubled determiner or a self-contrast down the reject-and-disclose
 //! path instead. A visible withholding is the better of the two failures.
+//!
+//! #6082 lap 11 made a disclosure name the finding whose field it is. The tier
+//! is read from the FILE, so [`Grounding::reachability`] resolves it through
+//! that file's first loopback record — and it quoted that record's title. The
+//! graded report's RED findings 2 and 3 both sit in `control_routes.rs`, so
+//! their two withholding lines shipped byte-identical, both naming finding 2.
+//! [`Grounding::check_field`] now takes the field's own subject, and
+//! [`named_subject`] prefers it over the shared record.
 //!
 //! [`synthesize_grounding_text::CLAIM_WORDS`]: super::synthesize_grounding_text::CLAIM_WORDS
 //! [`synthesize_grounding_text::grammar_debris`]: super::synthesize_grounding_text::grammar_debris
@@ -573,8 +581,18 @@ impl Grounding {
     /// falls back to matching sentences against every loopback-scoped finding's
     /// subject tokens, which is the only thing available when the prose is about
     /// the whole estate (#6082 lap 8).
+    ///
+    /// `subject` is that finding's own title. The tier is read from the FILE, so
+    /// two findings on one file share the record it is read from — but each
+    /// disclosure must name the finding whose field it is, not that shared
+    /// record's (#6082 lap 11).
     /// Test: `synthesize_grounding_tests.rs`.
-    pub(crate) fn check(&self, text: &str, owner: Option<&str>) -> GroundingOutcome {
+    pub(crate) fn check_field(
+        &self,
+        text: &str,
+        owner: Option<&str>,
+        subject: Option<&str>,
+    ) -> GroundingOutcome {
         if let Some(reason) = self.load_bearing_violation(text) {
             // A load-bearing violation names a CRATE, not a finding, so there is
             // no §5.x row to send the reader to.
@@ -584,7 +602,7 @@ impl Grounding {
             };
         }
         let (text, mut notes) = self.drop_false_no_clean_signal(text);
-        match self.reachability(&text, owner) {
+        match self.reachability(&text, owner, subject) {
             GroundingOutcome::Clean if notes.is_empty() => GroundingOutcome::Clean,
             GroundingOutcome::Clean => GroundingOutcome::Rewritten(text, notes),
             GroundingOutcome::Rewritten(fixed, more) => {
@@ -686,10 +704,21 @@ impl Grounding {
     /// component has no reachability evidence is tier 3 — a positive reach claim
     /// there is rejected rather than rewritten, because "host-local" would be
     /// just as unsupported as "remote".
+    ///
+    /// `subject` names the finding the field belongs to. The record `owned`
+    /// finds is keyed by FILE, so every finding on one file resolves to the
+    /// first of them — correct for the tier, wrong for the disclosure, which
+    /// quotes a title (#6082 lap 11).
     /// Test: `synthesize_grounding_tests.rs::{a_sibling_finding_inherits_its_files_loopback_scope,
     /// an_unevidenced_component_cannot_claim_beyond_host_reach,
-    /// an_unevidenced_component_keeps_a_non_reach_mention_of_the_network}`.
-    fn reachability(&self, text: &str, owner: Option<&str>) -> GroundingOutcome {
+    /// an_unevidenced_component_keeps_a_non_reach_mention_of_the_network,
+    /// two_findings_on_one_file_are_each_withheld_under_their_own_title}`.
+    fn reachability(
+        &self,
+        text: &str,
+        owner: Option<&str>,
+        subject: Option<&str>,
+    ) -> GroundingOutcome {
         let key = owner.map(normalize_component).filter(|k| !k.is_empty());
         let owned = key
             .as_deref()
@@ -722,6 +751,10 @@ impl Grounding {
                     None => continue,
                 },
             };
+            // #6082 lap 11: the disclosure names the finding whose field this is
+            // — `finding` is the file's first loopback record, which is the same
+            // record for every finding on that file.
+            let named = named_subject(subject, finding);
             let corrected = rewrite_reachability(sentence);
             // #6082 lap 10: a rewrite that leaves the sentence ungrammatical, or
             // contrasting one reachability class with itself, takes the same
@@ -733,21 +766,19 @@ impl Grounding {
                 });
                 return GroundingOutcome::Rejected {
                     reason: format!(
-                        "a beyond-the-host reachability claim about '{}' could not be corrected \
-                         safely — {detail}",
-                        finding.title
+                        "a beyond-the-host reachability claim about '{named}' could not be \
+                         corrected safely — {detail}"
                     ),
-                    subject: Some(finding.title.clone()),
+                    subject: Some(named.to_string()),
                 };
             }
             out = out.replace(sentence, &corrected);
             notes.push(Correction {
                 text: format!(
                     "the beyond-the-host reachability wording was corrected — the report's own \
-                     evidence scopes '{}' to a loopback-only surface",
-                    finding.title
+                     evidence scopes '{named}' to a loopback-only surface"
                 ),
-                subject: Some(finding.title.clone()),
+                subject: Some(named.to_string()),
             });
         }
         match notes.is_empty() {
@@ -805,6 +836,23 @@ impl Grounding {
                 .any(|t| contains_name(lower_sentence, t) && !self.remote_tokens.contains(t))
         })
     }
+}
+
+/// The finding title a disclosure quotes: the field's own, or the record the
+/// tier was read from when the field belongs to no named finding.
+///
+/// Why: [`Grounding::reachability`] resolves the tier through a record keyed by
+/// FILE. Two findings on one file resolve to the same record, so quoting that
+/// record's title gave RED findings 2 and 3 of the graded report byte-identical
+/// withholding disclosures, both naming finding 2 (#6082 lap 11).
+/// What: the caller's `subject` when it is non-empty, else `fallback`'s title —
+/// which is what report-level prose, matched by subject token, still needs.
+/// Test: `synthesize_grounding_tests.rs::two_findings_on_one_file_are_each_withheld_under_their_own_title`.
+fn named_subject<'a>(subject: Option<&'a str>, fallback: &'a LocalOnly) -> &'a str {
+    subject
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or(fallback.title.as_str())
 }
 
 /// Read one finding's reachability markers, deferring the verdict to

--- a/crates/trusty-review/src/report/synthesize_grounding_tests.rs
+++ b/crates/trusty-review/src/report/synthesize_grounding_tests.rs
@@ -9,6 +9,22 @@ use crate::report::model::{ReportModel, RepositoryReport};
 use crate::report::synthesize_grounding_text::replace_ignore_case;
 use crate::report::topology::CrateNode;
 
+/// The subject-less form of [`Grounding::check_field`]: prose owned by a file,
+/// or by nothing, but by no NAMED finding.
+///
+/// Why: every test below predates the subject parameter (#6082 lap 11) and none
+/// of them exercises it — spelling `None` at 36 call sites would say nothing the
+/// name does not. The tests that do exercise it call `check_field` directly.
+trait CheckAtComponent {
+    fn check(&self, text: &str, owner: Option<&str>) -> GroundingOutcome;
+}
+
+impl CheckAtComponent for Grounding {
+    fn check(&self, text: &str, owner: Option<&str>) -> GroundingOutcome {
+        self.check_field(text, owner, None)
+    }
+}
+
 fn node(name: &str, inbound: usize) -> CrateNode {
     CrateNode {
         name: name.to_string(),
@@ -1033,4 +1049,72 @@ fn a_correction_note_carries_the_finding_it_is_about() {
         notes[0].subject.as_deref(),
         Some("Control-plane HTTP session endpoints have no authentication or authorization")
     );
+}
+
+// ─── #6082 lap 11: a disclosure names the finding whose field it is ──────────
+
+/// The lap-11 graded defect, reconstructed from its live output.
+///
+/// Why: the graded report's Synthesis Status block carried two byte-identical
+/// withholding lines — "section 5.1, RED finding 2" and "section 5.1, RED
+/// finding 3" — both quoting finding 2's title. The two findings sit on one
+/// file, `reachability` resolves the tier through the file's FIRST loopback
+/// record, and the disclosure quoted that record's title instead of the
+/// finding's own. The reader was sent to a title that names the other finding.
+/// What: both findings of the two-finding control-plane fixture, each field
+/// withheld under its own title, and the two disclosures differing.
+/// Test: this test itself, with
+/// `synthesize_tests::two_withheld_findings_on_one_file_carry_their_own_titles`
+/// closing the chain through `apply_guardrail`.
+#[test]
+fn two_findings_on_one_file_are_each_withheld_under_their_own_title() {
+    let g = Grounding::from_model(&control_plane_model(true));
+    let prose = "The trusty-mpm control-plane offers remote code execution and a remote-management \
+                 surface to anyone on the internet.";
+    let mut reasons = Vec::new();
+    for (line, title) in [
+        (
+            259,
+            "Control-plane HTTP handlers accept unauthenticated callers",
+        ),
+        (
+            268,
+            "Arbitrary executable path accepted from HTTP request body",
+        ),
+    ] {
+        let owner = format!("{CONTROL_ROUTES}:{line}");
+        let outcome = g.check_field(prose, Some(&owner), Some(title));
+        let GroundingOutcome::Rejected { reason, subject } = &outcome else {
+            panic!("expected a withholding for {title}, got {outcome:?}");
+        };
+        assert!(
+            reason.contains(title),
+            "the disclosure must quote its own finding: {reason}"
+        );
+        assert_eq!(subject.as_deref(), Some(title));
+        reasons.push(reason.clone());
+    }
+    assert_ne!(
+        reasons[0], reasons[1],
+        "two findings with different titles must not share one disclosure"
+    );
+}
+
+/// Report-level prose still names the finding the token match found for it.
+///
+/// The fix above must not turn the subject-less path into an unnamed
+/// disclosure — that was the lap-9 defect, and it is a different one.
+#[test]
+fn subjectless_prose_keeps_the_finding_the_token_match_named() {
+    let g = Grounding::from_model(&loopback_model());
+    let prose = "The trusty-mpm control-plane offers remote code execution and a remote-management \
+                 surface to anyone on the internet.";
+    let GroundingOutcome::Rejected { reason, subject } = g.check_field(prose, None, None) else {
+        panic!("expected a withholding");
+    };
+    assert!(
+        reason.contains("Control-plane HTTP session endpoints"),
+        "{reason}"
+    );
+    assert!(subject.is_some());
 }

--- a/crates/trusty-review/src/report/synthesize_guardrail.rs
+++ b/crates/trusty-review/src/report/synthesize_guardrail.rs
@@ -59,7 +59,7 @@ fn ungrounded_claim_note(field: &str, subject: Option<&str>, reason: &str) -> St
 /// growing another positional argument on every call (#6082 lap 8).
 /// What: the reader-facing field name, the §5.2 finding it belongs to (absent
 /// for report-level prose), and that finding's component, which decides its
-/// reachability tier in [`Grounding::check`].
+/// reachability tier in [`Grounding::check_field`].
 struct FieldCtx<'a> {
     field: &'a str,
     subject: Option<&'a str>,
@@ -306,7 +306,7 @@ fn ground_field(
     if text.is_empty() {
         return String::new();
     }
-    match grounding.check(text, ctx.component) {
+    match grounding.check_field(text, ctx.component, ctx.subject) {
         GroundingOutcome::Clean => text.to_string(),
         GroundingOutcome::Rewritten(fixed, corrections) => {
             notes.extend(corrections.into_iter().map(|c| note_for(ctx, &c)));
@@ -357,7 +357,7 @@ fn admit_field(
     if text.is_empty() {
         return None;
     }
-    let grounded = match grounding.check(text, ctx.component) {
+    let grounded = match grounding.check_field(text, ctx.component, ctx.subject) {
         GroundingOutcome::Clean => text.to_string(),
         GroundingOutcome::Rewritten(fixed, corrections) => {
             notes.extend(corrections.into_iter().map(|c| note_for(ctx, &c)));

--- a/crates/trusty-review/src/report/synthesize_tests.rs
+++ b/crates/trusty-review/src/report/synthesize_tests.rs
@@ -2530,6 +2530,28 @@ fn synthesize_grounds_the_top_risk_row_description() {
     );
 }
 
+/// The live lap-11 shape: two RED findings on ONE loopback-established file.
+///
+/// Why: the graded report's RED findings 2 and 3 both sit in
+/// `control_routes.rs`, which is the only condition the defect needs — one file
+/// carrying more than one finding (#6082 lap 11).
+fn two_findings_on_one_file_model() -> ReportModel {
+    let mut model = grounded_fixture_model();
+    let metrics = model.repositories[0]
+        .metrics
+        .as_mut()
+        .expect("the grounded fixture carries metrics");
+    metrics.findings.push(MetricFinding {
+        title: "Run handler executes an arbitrary caller-supplied executable".to_string(),
+        severity: Severity::Red,
+        category: "security".to_string(),
+        component: "crates/acme-daemon/src/control_routes.rs".to_string(),
+        description: "the request body overrides the executable path".to_string(),
+        remediation: "validate the path before constructing RunParams".to_string(),
+    });
+    model
+}
+
 /// One RED narrative against the grounded fixture, varying only the field the
 /// test is about.
 fn grounded_finding(business_impact: &str) -> super::FindingProse {
@@ -2647,6 +2669,69 @@ fn synthesize_empties_an_uncorrectable_remote_claim_in_a_finding() {
         "the rejection must be recorded: {:?}",
         result.notes
     );
+}
+
+/// #6082 lap 11: two findings on one file are withheld under their own titles.
+///
+/// Why: the graded report's Synthesis Status block listed "RED finding 2" and
+/// "RED finding 3" with byte-identical text, both quoting finding 2's title.
+/// The reachability tier is read from the FILE, so both findings resolved to
+/// the same loopback record and the disclosure quoted that record's title.
+/// What: the invariant the reader depends on, over the notes `apply_guardrail`
+/// actually produced — two notes with different subjects never share one text,
+/// and each text names its own subject.
+/// Test: this test itself, with
+/// `synthesize_grounding_tests::two_findings_on_one_file_are_each_withheld_under_their_own_title`
+/// covering the check in isolation.
+#[test]
+fn two_withheld_findings_on_one_file_carry_their_own_titles() {
+    let model = two_findings_on_one_file_model();
+    let grounding = crate::report::synthesize_grounding::Grounding::from_model(&model);
+    let allowed = allowed_numbers(&serde_json::to_value(&model).unwrap());
+    let impact = "The acme-daemon control_routes surface offers remote code execution and \
+                  remote-management access to the internet.";
+    let mut second = grounded_finding(impact);
+    second.title = "Control-plane HTTP session endpoints have no authentication".to_string();
+    let raw = super::RawSynthesis {
+        executive_summary: String::new(),
+        code_quality_summary: String::new(),
+        security_summary: String::new(),
+        authorship_summary: String::new(),
+        top_risks: vec![],
+        findings: vec![grounded_finding(impact), second],
+    };
+
+    let result =
+        crate::report::synthesize_guardrail::apply_guardrail(raw, &allowed, Vec::new(), &grounding)
+            .expect("the findings' other fields keep this Ok");
+
+    let withheld: Vec<_> = result
+        .notes
+        .iter()
+        .filter(|n| n.text.contains("business impact was withheld"))
+        .collect();
+    assert_eq!(
+        withheld.len(),
+        2,
+        "both fields must be withheld: {withheld:?}"
+    );
+    for note in &withheld {
+        let subject = note
+            .subject
+            .as_deref()
+            .expect("a withholding names its finding");
+        assert!(
+            note.text.contains(subject),
+            "the disclosure must quote its own subject: {note:?}"
+        );
+    }
+    for (a, b) in withheld.iter().zip(withheld.iter().skip(1)) {
+        assert_ne!(a.subject, b.subject, "the fixture needs distinct subjects");
+        assert_ne!(
+            a.text, b.text,
+            "two findings with different titles must not share one disclosure"
+        );
+    }
 }
 
 /// #6082 lap 4: the prompt states both grounding facts, so the model is told


### PR DESCRIPTION
Refs #6082 — lap-11 adversarial grade, one defect.

## The defect

Live report, `.md` lines 2167-2168: RED finding 2 and RED finding 3 carry
byte-identical withholding disclosures, both quoting RED-2's title
('Control-plane HTTP endpoints expose session management with no
authentication'). In the JSON, `.synthesis.notes[3].subject` reads RED-3's real
title while `.synthesis.notes[3].text` duplicates `notes[2].text` verbatim.

## Construction site

Neither a shared buffer nor a clone — a **wrong-record lookup on a non-unique
key**. `Grounding::reachability` (`synthesize_grounding.rs:697`) resolves the
finding it quotes with

```rust
self.local_only.iter().find(|f| f.component == k)
```

`component` is the FILE. That is correct for the reachability tier, which lap 8
deliberately made a file property — but two findings on one file resolve to the
same record, and the disclosure quotes `finding.title` from it. The two live
REDs both sit in `control_routes.rs`. The subject came out right only because
`ground_field` overrides it with `ctx.subject`; the text had no such override.

## The fix

`check` becomes `check_field(text, owner, subject)` and carries the field's own
finding title. `named_subject` prefers it over the shared record, on both the
withheld line and the corrected-wording line. Report-level prose passes
`None` and still cites the finding its subject-token match found — the lap-9
behavior is untouched.

## Failing before

Both new tests fail on the pre-fix construction (`named` = `finding.title`):

```
---- report::synthesize_grounding::tests::two_findings_on_one_file_are_each_withheld_under_their_own_title ----
the disclosure must quote its own finding: a beyond-the-host reachability claim
about 'Control-plane HTTP handlers accept unauthenticated callers' could not be
corrected safely — the report's own evidence scopes that surface to localhost

---- report::synthesize::tests::two_withheld_findings_on_one_file_carry_their_own_titles ----
the disclosure must quote its own subject: StatusNote { text: "the model's
business impact was withheld — a beyond-the-host reachability claim about
'Control-plane HTTP session endpoints have no authentication' could not be
corrected safely — …", subject: Some("Run handler executes an arbitrary
caller-supplied executable") }
```

The second is the live shape exactly: text names one finding, subject names the
other. It asserts the invariant over the notes `apply_guardrail` actually
produced — two notes with different subjects never share one text, and each text
contains its own subject.

## Gates — rung 3

| Gate | Result |
|---|---|
| `cargo fmt --check` | clean |
| `cargo check -p trusty-review --all-targets` | clean |
| `cargo clippy -p trusty-review --all-targets -- -D warnings` | clean |
| `cargo test -p trusty-review` | `ok. 1996 passed; 0 failed; 5 ignored` + 9 integration targets, all ok |
| `scripts/check_line_cap.sh` | pass |
| `scripts/check_changelog_fragment.sh` | pass |
| `scripts/check_sld.sh` | pass |

Version stays 0.25.0 (unpublished). No publish, no tag.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools