### PR TITLE
fix(tga): authorship trajectory counts commits, not file touches (Refs #6082)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10262,7 +10262,7 @@ dependencies = [
 
 [[package]]
 name = "tga"
-version = "3.3.1"
+version = "3.3.2"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/crates/trusty-git-analytics/Cargo.toml
+++ b/crates/trusty-git-analytics/Cargo.toml
@@ -26,7 +26,7 @@ name = "tga"
 # the `tga` binary; trusty-audit resolves it by version at runtime, not through
 # a Cargo edge), so the gate has nobody to protect here. The exception is
 # recorded as a `tga` row in scripts/semver-checks-crate-exclusions.tsv.
-version = "3.3.1"
+version = "3.3.2"
 publish = true
 edition = "2021"
 # Aligned with the workspace MSRV (1.94) per #254. Required for

--- a/crates/trusty-git-analytics/changelog.d/6082-authorship-commits-per-month.md
+++ b/crates/trusty-git-analytics/changelog.d/6082-authorship-commits-per-month.md
@@ -1,0 +1,8 @@
+Fixed
+
+- The authorship artifact's monthly trajectory counts commits per month, not
+  file touches ([#6082](https://github.com/bobmatnyc/trusty-tools/issues/6082)).
+  The source query joins `files`, so it returns one row per file a commit
+  touched, and the month counter incremented once per row. On a repository
+  whose commits average ten files each, a month with 824 commits reported 9416.
+  `active_authors` was always a distinct-set count and is unchanged.

--- a/crates/trusty-git-analytics/src/report/authorship.rs
+++ b/crates/trusty-git-analytics/src/report/authorship.rs
@@ -108,7 +108,13 @@ pub struct MonthlyActivity {
     pub month: String,
     /// Distinct non-bot authors with a non-merge commit in this month.
     pub active_authors: u64,
-    /// Non-merge, non-bot commits in this month.
+    /// Distinct non-merge, non-bot commits in this month.
+    ///
+    /// Why: the source query returns one row per file a commit touched, so
+    /// this figure is a count of distinct `commits.id` values, never of rows
+    /// (#6082 — a row count reported ~10x reality on a repository whose
+    /// commits average ten files each).
+    /// Test: `super::authorship_tests::commits_count_commits_not_file_touches`.
     pub commits: u64,
 }
 
@@ -180,6 +186,10 @@ fn month_of(timestamp: &str) -> Option<String> {
 /// subsystems), and per-month distinct-author/commit counts limited to the
 /// most recent 12 active months (for the trajectory).
 ///
+/// The `JOIN files` returns one row per file a commit touched, so every
+/// per-COMMIT figure deduplicates on `commits.id` while every per-TOUCH figure
+/// counts rows (#6082).
+///
 /// Authors are keyed on `authors.canonical_email` via a LEFT JOIN on
 /// `commits.author_id` — the identity resolver's own output (#5453 requires
 /// reusing it rather than re-grouping raw commit emails). A commit the resolver
@@ -195,7 +205,7 @@ fn month_of(timestamp: &str) -> Option<String> {
 /// Propagates [`crate::core::errors::TgaError::DbError`] from either query.
 pub fn build_authorship_summary(conn: &Connection, repository: &str) -> Result<AuthorshipSummary> {
     let mut stmt = conn.prepare(
-        "SELECT c.author_name, c.author_email, a.canonical_email, c.timestamp, f.path \
+        "SELECT c.id, c.author_name, c.author_email, a.canonical_email, c.timestamp, f.path \
          FROM commits c \
          JOIN files f ON f.commit_id = c.id \
          LEFT JOIN authors a ON a.id = c.author_id \
@@ -203,11 +213,12 @@ pub fn build_authorship_summary(conn: &Connection, repository: &str) -> Result<A
     )?;
     let rows = stmt.query_map(params![repository], |row| {
         Ok((
-            row.get::<_, String>(0)?,
+            row.get::<_, i64>(0)?,
             row.get::<_, String>(1)?,
-            row.get::<_, Option<String>>(2)?,
-            row.get::<_, String>(3)?,
+            row.get::<_, String>(2)?,
+            row.get::<_, Option<String>>(3)?,
             row.get::<_, String>(4)?,
+            row.get::<_, String>(5)?,
         ))
     })?;
 
@@ -215,11 +226,13 @@ pub fn build_authorship_summary(conn: &Connection, repository: &str) -> Result<A
     let mut authors_by_subsystem: BTreeMap<String, std::collections::BTreeSet<String>> =
         BTreeMap::new();
     let mut months: BTreeMap<String, std::collections::BTreeSet<String>> = BTreeMap::new();
-    let mut month_commits: BTreeMap<String, u64> = BTreeMap::new();
+    // #6082: keyed on `commits.id`, not incremented per row — one row arrives
+    // per file touched, so a counter here reports file-touches as commits.
+    let mut month_commits: BTreeMap<String, std::collections::BTreeSet<i64>> = BTreeMap::new();
     let mut unresolved: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
 
     for row in rows {
-        let (name, email, canonical_email, timestamp, path) = row?;
+        let (commit_id, name, email, canonical_email, timestamp, path) = row?;
         if is_bot(&name, &email) {
             continue;
         }
@@ -244,7 +257,7 @@ pub fn build_authorship_summary(conn: &Connection, repository: &str) -> Result<A
             .insert(author_key.clone());
         if let Some(month) = month_of(&timestamp) {
             months.entry(month.clone()).or_default().insert(author_key);
-            *month_commits.entry(month).or_insert(0) += 1;
+            month_commits.entry(month).or_default().insert(commit_id);
         }
     }
 
@@ -275,7 +288,10 @@ pub fn build_authorship_summary(conn: &Connection, repository: &str) -> Result<A
         .into_iter()
         .map(|month| MonthlyActivity {
             active_authors: months.get(&month).map(|s| s.len() as u64).unwrap_or(0),
-            commits: month_commits.get(&month).copied().unwrap_or(0),
+            commits: month_commits
+                .get(&month)
+                .map(|s| s.len() as u64)
+                .unwrap_or(0),
             month,
         })
         .collect();

--- a/crates/trusty-git-analytics/src/report/authorship_tests.rs
+++ b/crates/trusty-git-analytics/src/report/authorship_tests.rs
@@ -219,6 +219,48 @@ fn trajectory_caps_at_twelve_months() {
     assert_eq!(summary.monthly_trajectory.last().unwrap().month, "2025-12");
 }
 
+/// (#6082) A month's `commits` figure counts commits, not the file touches the
+/// `commits JOIN files` query returns one row of per file. Before the fix this
+/// read 7 (the row count) for 2 commits, which is how the trusty-tools
+/// self-audit reported ~9400 commits in a month that had 824.
+#[test]
+fn commits_count_commits_not_file_touches() {
+    let db = Database::open_in_memory().expect("open");
+    insert_commit(
+        &db,
+        "a1",
+        "Alice",
+        "alice@x.com",
+        "2026-01-15T00:00:00Z",
+        "repo",
+        false,
+        &["src/a.rs", "src/b.rs", "src/c.rs", "docs/d.md"],
+    );
+    insert_commit(
+        &db,
+        "b1",
+        "Bob",
+        "bob@x.com",
+        "2026-01-16T00:00:00Z",
+        "repo",
+        false,
+        &["src/e.rs", "src/f.rs", "docs/g.md"],
+    );
+
+    let summary = build_authorship_summary(db.connection(), "repo").expect("summary");
+    assert_eq!(summary.monthly_trajectory.len(), 1);
+    let january = &summary.monthly_trajectory[0];
+    assert_eq!(january.month, "2026-01");
+    assert_eq!(
+        january.commits, 2,
+        "2 commits touching 7 files must count 2, not 7"
+    );
+    assert_eq!(
+        january.active_authors, 2,
+        "active_authors was already correct and must stay so"
+    );
+}
+
 /// (#5453) One person committing under two emails is ONE author, because the
 /// aggregation joins `commits.author_id → authors.canonical_email` rather than
 /// grouping raw commit emails. Against the raw-email grouping this replaced,


### PR DESCRIPTION
The lap-12 grade of the trusty-audit self-audit found `authorship-0.json`
reporting ~10x the real commit count per month: 4699/5751/9425/9416 against a
ground truth of 463/584/1037/824 for a repository with 2908 commits total.
`active_authors` was correct in the same records.

## The bug

`crates/trusty-git-analytics/src/report/authorship.rs:247` (pre-fix):

```rust
*month_commits.entry(month).or_insert(0) += 1;
```

The query it iterates is `commits c JOIN files f ON f.commit_id = c.id`, so it
yields one row per file a commit touched. The counter therefore measured file
touches. The grader's arithmetic confirms it: `git log --name-only` over the
window gives 28,853 touches, ~7213/month against the reported 7322.8 average.

Every other figure in the module was already correct — `touches_by_author` and
`top_author_share_pct` are per-touch by design, and `months` was always a
`BTreeSet` of author keys, which is why `active_authors` never drifted.

`month_commits` is now a `BTreeSet<i64>` of `commits.id`. No other aggregation
changed. The sibling per-file query in `commands/backfill/effort_db.rs` already
groups by sha and is unaffected.

## Regression test

`commits_count_commits_not_file_touches` — 2 commits touching 7 files.

Failing before the fix:

```
test report::authorship::authorship_tests::commits_count_commits_not_file_touches ... FAILED
assertion `left == right` failed: 2 commits touching 7 files must count 2, not 7
  left: 7
 right: 2
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1348 filtered out
```

Every pre-existing test in the module seeded one file per commit, which is why
the defect survived them.

## Gates — test ladder rung 3

Localized behavior inside one crate; no public type or signature changed, so no
consumer needs recompiling beyond the workspace's own path resolution.

- `cargo fmt --check` — clean
- `cargo check -p tga` — `Finished dev profile in 8.40s`
- `cargo clippy -p tga --all-targets -- -D warnings` — `Finished dev profile in 12.13s`
- `cargo test -p tga` — `test result: ok. 1342 passed; 0 failed; 7 ignored` plus
  9 further binaries, all ok
- `scripts/check_line_cap.sh` — `4162 tracked .rs file(s); 0 violations`
- `scripts/check_sld.sh` — `0 error(s), 0 warning(s)`
- `scripts/check_changelog_fragment.sh` — `all 1 crate(s) with source changes are recorded`

## Version

tga 3.3.1 → 3.3.2. Patch: a wrong number becomes right, no API change. No tag,
no publish in this PR.

Refs #6082

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools