### PR TITLE
fix(trusty-common): surface corrupt chat-session history instead of dropping it

### DIFF
--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "trusty-common"
 # 0.40.0 (#5809): the MCP extraction (ADR-0040 Phase 1) removed the public
 # `src/mcp/*` modules. Cargo's 0.x rule makes that a MINOR bump, not a patch.
-version = "0.41.1"
+version = "0.41.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/trusty-common/changelog.d/6196-chat-history-corrupt-surface.md
+++ b/crates/trusty-common/changelog.d/6196-chat-history-corrupt-surface.md
@@ -1,0 +1,12 @@
+Fixed
+
+- `ChatSessionStore` no longer silently discards a corrupt `history` blob as an
+  empty conversation (#6196). All three load paths previously did
+  `serde_json::from_str(...).unwrap_or_default()`, so a corrupt session was
+  indistinguishable from a genuinely-empty one — `get_session` returned
+  `Ok(Some(session))` with `history: []` and a chat-resume caller saw a normal
+  new session. Now `get_session` and `append_message`/`append_messages` return
+  the new `ChatSessionStoreError::CorruptHistory { id, source }` (append aborts
+  its write transaction, so the corrupt row is left intact for recovery rather
+  than clobbered), and `list_sessions` skips a corrupt row with a warn and a
+  count instead of listing it as a valid empty session.

--- a/crates/trusty-common/src/memory_core/store/chat_sessions/mod.rs
+++ b/crates/trusty-common/src/memory_core/store/chat_sessions/mod.rs
@@ -62,6 +62,18 @@ mod tests {
         wtx.commit().unwrap();
     }
 
+    /// Read the raw stored bytes for one SESSIONS row (the postcard-encoded
+    /// `ChatSessionRecord`), or `None` if the row is absent. Used to prove the
+    /// #6196 fail-closed path leaves a corrupt row byte-identical — untouched,
+    /// not merely still-unparseable.
+    fn read_raw_row(store: &ChatSessionStore, id: &str) -> Option<Vec<u8>> {
+        use crate::memory_core::store::kg_store::SESSIONS;
+        use redb::ReadableDatabase;
+        let rtx = store.db.begin_read().unwrap();
+        let table = rtx.open_table(SESSIONS).unwrap();
+        table.get(id).unwrap().map(|g| g.value().to_vec())
+    }
+
     /// Why (#6196): a session whose `history` JSON is corrupt must surface as an
     /// error, not `Ok(Some(session))` with an empty history — otherwise a
     /// chat-resume caller cannot tell "prior conversation lost" from "new empty
@@ -118,13 +130,15 @@ mod tests {
     /// message, permanently destroying the corrupt blob. Fails on the pre-fix
     /// commit (which returned `Ok` and clobbered the row).
     /// What: writes a corrupt row, asserts `append_message` returns `Err` and
-    /// the corrupt bytes are left intact (`get_session` still errors after).
+    /// the stored row bytes are BYTE-IDENTICAL before and after the failed call
+    /// (the corrupt blob is untouched, not merely still-unparseable).
     /// Test: this function.
     #[test]
     fn append_message_on_corrupt_history_fails_closed() {
         let (_d, store) = open();
         let id = "corrupt-append-1";
         write_corrupt_row(&store, id, "corrupt");
+        let before = read_raw_row(&store, id).expect("corrupt row was written");
 
         let result = store.append_message(
             id,
@@ -137,9 +151,11 @@ mod tests {
             result.is_err(),
             "append onto corrupt history must fail closed, got {result:?}"
         );
-        assert!(
-            store.get_session(id).is_err(),
-            "the corrupt row must be left intact, not clobbered by the failed append"
+        let after = read_raw_row(&store, id).expect("corrupt row must still exist");
+        assert_eq!(
+            before, after,
+            "the corrupt row bytes must be byte-identical after the failed append \
+             — the aborted write transaction must not have touched them"
         );
     }
 

--- a/crates/trusty-common/src/memory_core/store/chat_sessions/mod.rs
+++ b/crates/trusty-common/src/memory_core/store/chat_sessions/mod.rs
@@ -39,6 +39,110 @@ mod tests {
         (dir, store)
     }
 
+    /// Write a SESSIONS row whose `history` blob is unparseable JSON, directly
+    /// through the store's redb handle. There is no public API that produces a
+    /// corrupt row, so the #6196 regression tests craft one here (white-box:
+    /// this test module is a descendant of `chat_sessions`, so it can reach the
+    /// `pub(super)` `db` field and `ChatSessionRecord`).
+    fn write_corrupt_row(store: &ChatSessionStore, id: &str, title: &str) {
+        use crate::memory_core::store::kg_store::SESSIONS;
+        let now = chrono::Utc::now().to_rfc3339();
+        let record = super::types::ChatSessionRecord {
+            title: Some(title.to_string()),
+            created_at: now.clone(),
+            updated_at: now,
+            history: "{ this is not valid history json".to_string(),
+        };
+        let bytes = postcard::to_allocvec(&record).unwrap();
+        let wtx = store.db.begin_write().unwrap();
+        {
+            let mut table = wtx.open_table(SESSIONS).unwrap();
+            table.insert(id, bytes.as_slice()).unwrap();
+        }
+        wtx.commit().unwrap();
+    }
+
+    /// Why (#6196): a session whose `history` JSON is corrupt must surface as an
+    /// error, not `Ok(Some(session))` with an empty history — otherwise a
+    /// chat-resume caller cannot tell "prior conversation lost" from "new empty
+    /// session". Fails on the pre-fix commit (which returned `Ok(Some(empty))`).
+    /// What: writes a corrupt row, asserts `get_session` returns `Err`.
+    /// Test: this function.
+    #[test]
+    fn get_session_surfaces_corrupt_history_as_error() {
+        let (_d, store) = open();
+        let id = "corrupt-get-1";
+        write_corrupt_row(&store, id, "corrupt");
+        let result = store.get_session(id);
+        assert!(
+            result.is_err(),
+            "corrupt history must surface as an error, got {result:?}"
+        );
+    }
+
+    /// Why (#6196): in the list path a corrupt row must not masquerade as a
+    /// valid empty session. It is skipped with a warn/count instead. Fails on
+    /// the pre-fix commit (which listed the corrupt row with message_count 0).
+    /// What: persists one valid session and one corrupt row, asserts the corrupt
+    /// row is absent from the list and only the valid session remains.
+    /// Test: this function.
+    #[test]
+    fn list_sessions_skips_corrupt_row_not_render_empty() {
+        let (_d, store) = open();
+        let good = store.create_session(Some("good".into())).unwrap();
+        store
+            .upsert_session(
+                &good,
+                &[ChatMessage {
+                    role: "user".into(),
+                    content: "hi".into(),
+                }],
+            )
+            .unwrap();
+        write_corrupt_row(&store, "corrupt-list-1", "corrupt");
+
+        let metas = store.list_sessions().unwrap();
+        assert!(
+            metas.iter().all(|m| m.id != "corrupt-list-1"),
+            "corrupt row must be skipped, not rendered as a valid empty session: {metas:?}"
+        );
+        assert!(
+            metas.iter().any(|m| m.id == good),
+            "the valid session must still be listed"
+        );
+        assert_eq!(metas.len(), 1, "only the valid session should be listed");
+    }
+
+    /// Why (#6196): appending to a session with corrupt history must fail closed
+    /// rather than `unwrap_or_default()` and overwrite the row with only the new
+    /// message, permanently destroying the corrupt blob. Fails on the pre-fix
+    /// commit (which returned `Ok` and clobbered the row).
+    /// What: writes a corrupt row, asserts `append_message` returns `Err` and
+    /// the corrupt bytes are left intact (`get_session` still errors after).
+    /// Test: this function.
+    #[test]
+    fn append_message_on_corrupt_history_fails_closed() {
+        let (_d, store) = open();
+        let id = "corrupt-append-1";
+        write_corrupt_row(&store, id, "corrupt");
+
+        let result = store.append_message(
+            id,
+            ChatMessage {
+                role: "user".into(),
+                content: "new".into(),
+            },
+        );
+        assert!(
+            result.is_err(),
+            "append onto corrupt history must fail closed, got {result:?}"
+        );
+        assert!(
+            store.get_session(id).is_err(),
+            "the corrupt row must be left intact, not clobbered by the failed append"
+        );
+    }
+
     #[test]
     fn create_then_get_session_round_trips() {
         let (_d, store) = open();

--- a/crates/trusty-common/src/memory_core/store/chat_sessions/store.rs
+++ b/crates/trusty-common/src/memory_core/store/chat_sessions/store.rs
@@ -157,6 +157,7 @@ impl ChatSessionStore {
             })?;
 
         let mut out: Vec<ChatSessionMeta> = Vec::new();
+        let mut corrupt = 0usize;
         for entry in table.iter().map_err(|e| ChatSessionStoreError::Storage {
             path: self.path.clone(),
             source: Box::new(e),
@@ -170,8 +171,21 @@ impl ChatSessionStore {
                 .map_err(|e| ChatSessionStoreError::Postcard { source: e })?;
             let created_at = parse_timestamp(&record.created_at, "created_at")?;
             let updated_at = parse_timestamp(&record.updated_at, "updated_at")?;
-            let history: Vec<ChatMessage> =
-                serde_json::from_str(&record.history).unwrap_or_default();
+            // #6196: a corrupt-history row must not masquerade as a valid empty
+            // session. One bad row must not fail the whole list, so skip it
+            // with a warn and a running count instead of `unwrap_or_default()`.
+            let history: Vec<ChatMessage> = match serde_json::from_str(&record.history) {
+                Ok(h) => h,
+                Err(source) => {
+                    corrupt += 1;
+                    tracing::warn!(
+                        session_id = %id,
+                        error = %source,
+                        "skipping chat session with corrupt history json in list_sessions",
+                    );
+                    continue;
+                }
+            };
             out.push(ChatSessionMeta {
                 id,
                 title: record.title,
@@ -179,6 +193,12 @@ impl ChatSessionStore {
                 updated_at,
                 message_count: history.len(),
             });
+        }
+        if corrupt > 0 {
+            tracing::warn!(
+                corrupt_rows = corrupt,
+                "list_sessions skipped {corrupt} chat session(s) with corrupt history json",
+            );
         }
         out.sort_by_key(|s| Reverse(s.updated_at.timestamp_millis()));
         Ok(out)
@@ -220,7 +240,16 @@ impl ChatSessionStore {
             .map_err(|e| ChatSessionStoreError::Postcard { source: e })?;
         let created_at = parse_timestamp(&record.created_at, "created_at")?;
         let updated_at = parse_timestamp(&record.updated_at, "updated_at")?;
-        let history: Vec<ChatMessage> = serde_json::from_str(&record.history).unwrap_or_default();
+        // #6196: propagate a parse failure instead of `unwrap_or_default()`, so
+        // a chat-resume caller can tell "prior conversation lost" from "new
+        // empty session" rather than seeing a normal-looking empty history.
+        let history: Vec<ChatMessage> =
+            serde_json::from_str(&record.history).map_err(|source| {
+                ChatSessionStoreError::CorruptHistory {
+                    id: id.to_string(),
+                    source: Box::new(source),
+                }
+            })?;
         Ok(Some(ChatSession {
             id: id.to_string(),
             title: record.title,
@@ -375,10 +404,20 @@ impl ChatSessionStore {
             }
         };
 
+        // #6196: fail closed on a corrupt existing history rather than
+        // `unwrap_or_default()` — the old default silently dropped the corrupt
+        // blob and overwrote the row with only the new messages, destroying the
+        // evidence permanently. `?` aborts this write transaction, so the
+        // corrupt row is left intact for recovery.
         let (title, created_at, mut history) = match existing_record {
             Some(r) => {
                 let history: Vec<ChatMessage> =
-                    serde_json::from_str(&r.history).unwrap_or_default();
+                    serde_json::from_str(&r.history).map_err(|source| {
+                        ChatSessionStoreError::CorruptHistory {
+                            id: id.to_string(),
+                            source: Box::new(source),
+                        }
+                    })?;
                 (r.title, r.created_at, history)
             }
             None => (None, now.clone(), Vec::new()),
@@ -419,7 +458,9 @@ impl ChatSessionStore {
 
         let created_at = parse_timestamp(&record.created_at, "created_at")?;
         let updated_at = parse_timestamp(&record.updated_at, "updated_at")?;
-        let history: Vec<ChatMessage> = serde_json::from_str(&record.history).unwrap_or_default();
+        // #6196: reuse the in-memory `history` we just serialised into `record`
+        // rather than re-parsing `record.history` — it cannot be corrupt (we
+        // encoded it) and the reparse was another `unwrap_or_default()` site.
         Ok(ChatSession {
             id: id.to_string(),
             title: record.title,

--- a/crates/trusty-common/src/memory_core/store/chat_sessions/types.rs
+++ b/crates/trusty-common/src/memory_core/store/chat_sessions/types.rs
@@ -139,6 +139,19 @@ pub enum ChatSessionStoreError {
         #[source]
         source: Box<serde_json::Error>,
     },
+    /// A stored session's `history` JSON blob failed to parse on load.
+    ///
+    /// Why (#6196): the load paths previously did `unwrap_or_default()`,
+    /// substituting an empty history and hiding data loss — a corrupt session
+    /// was then indistinguishable from a genuinely empty one. Surfacing this
+    /// lets a chat-resume caller tell "prior conversation lost" from "new empty
+    /// session". Carries `id` so the operator knows which row is corrupt.
+    #[error("chat session {id} has corrupt history json: {source}")]
+    CorruptHistory {
+        id: String,
+        #[source]
+        source: Box<serde_json::Error>,
+    },
     #[error("chat session store timestamp parse error for {field}: {source}")]
     Timestamp {
         field: &'static str,


### PR DESCRIPTION
## What

`ChatSessionStore`'s three load paths did `serde_json::from_str(&record.history).unwrap_or_default()`, swallowing a JSON parse failure into an empty `Vec` with no log. A corrupt session was indistinguishable from a genuinely-empty one — `get_session` returned `Ok(Some(session))` with `history: []`, so a chat-resume caller saw a normal new session with no signal the prior conversation was lost.

## Fix — error shape per path

- **`get_session_inner` (single-session read):** propagate. Returns the new typed variant `ChatSessionStoreError::CorruptHistory { id, source }` (converts to `anyhow::Error` at the public boundary via `?`). A chat-resume flow now distinguishes `Err` ("prior conversation lost") from `Ok(Some)` with an empty history ("new empty session"). Chosen over a `Corrupt` marker field on `ChatSession` to avoid widening the public struct — every consumer already uses `?`, so no signatures change.
- **`list_sessions_inner` (list path):** per-row skip-with-warn-and-count. A corrupt row is skipped (not pushed) with a `tracing::warn!` carrying its id, plus a summary warn with the count. One bad row does not fail the whole list, and the corrupt row does **not** masquerade as a valid empty session.
- **`append_messages_inner` (in-scope extension):** fail closed. Appending onto a corrupt history previously `unwrap_or_default()`-ed to empty and overwrote the row with only the new message — permanently destroying the corrupt blob. Now returns `CorruptHistory` and `?` aborts the write transaction, leaving the corrupt row intact for recovery. Also drops the redundant post-write reparse of the just-serialised history (another `unwrap_or_default` site) by reusing the in-memory `Vec`.

New error variant `CorruptHistory { id, source: Box<serde_json::Error> }` — `serde_json::Error` stays boxed behind `#[source]`, not leaked into the public signature.

## Failing-before evidence (against `origin/main`)

Reverted the two production files to `origin/main`, kept the tests:

```
get_session_surfaces_corrupt_history_as_error ... FAILED
  corrupt history must surface as an error, got Ok(Some(ChatSession { ... history: [] }))
append_message_on_corrupt_history_fails_closed ... FAILED
  append onto corrupt history must fail closed, got Ok(ChatSession { ... history: [ChatMessage { role: "user", content: "new" }] })
list_sessions_skips_corrupt_row_not_render_empty ... FAILED
test result: FAILED. 10 passed; 3 failed
```

## Test ladder — RUNG 4 (shared library, `trusty-common`)

- `cargo fmt -p trusty-common --check` → clean
- `cargo clippy -p trusty-common --all-targets --features memory-core,embedder-test-support -- -D warnings` → 0 warnings
- `cargo test -p trusty-common --features memory-core,embedder-test-support chat_sessions` → `test result: ok. 13 passed; 0 failed`
- `cargo check --workspace` → clean
- `cargo test -p trusty-memory` (direct dependent) → all pass (2/4/1/5/15)
- `scripts/check_line_cap.sh`, `scripts/check_sld.sh`, `scripts/check_changelog_fragment.sh` → all pass
- Secret-scan of the diff → no matches

Refs #6196

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools