### PR TITLE
fix(trusty-common): compact_orphans deletes a concurrently-upserted vector row (TOCTOU) (Refs #6195)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6519,7 +6519,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11405,7 +11405,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-common"
-version = "0.41.1"
+version = "0.41.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "trusty-common"
 # 0.40.0 (#5809): the MCP extraction (ADR-0040 Phase 1) removed the public
 # `src/mcp/*` modules. Cargo's 0.x rule makes that a MINOR bump, not a patch.
-version = "0.41.1"
+version = "0.41.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/trusty-common/changelog.d/6195-compact-orphans-toctou.md
+++ b/crates/trusty-common/changelog.d/6195-compact-orphans-toctou.md
@@ -1,0 +1,7 @@
+Fixed
+
+- `compact_orphans` no longer deletes a concurrently-upserted vector row as a
+  false orphan. It re-checks each candidate's liveness inside the delete
+  transaction, so a `VECTORS` row that is live at the moment of deletion is
+  never removed — closing a TOCTOU window where a drawer's embedding could be
+  dropped and the drawer left permanently unsearchable (#6195).

--- a/crates/trusty-common/src/memory_core/store/hnsw_store.rs
+++ b/crates/trusty-common/src/memory_core/store/hnsw_store.rs
@@ -217,12 +217,12 @@ fn allocate_vector_id(
 ///
 /// Why: both the allocator's collision jump and its missing-counter fallback
 /// need a bound above which NO id is taken. `VECTORS` alone is not that bound.
-/// A `VECTOR_KEYS` row can outlive its `VECTORS` row: `compact_orphans` reads
-/// the live-id set, computes orphans, and deletes them in three separate
-/// transactions, so an `upsert` that lands between the first and the third has
-/// its brand-new id treated as an orphan and its `VECTORS` row removed while
-/// the key survives. Under the in-process concurrency this store supports that
-/// is a reachable state, and a `VECTORS`-only bound would hand the id straight
+/// A `VECTOR_KEYS` row can outlive its `VECTORS` row: a palace written by a
+/// binary predating #6195 could have `compact_orphans` delete a
+/// concurrently-upserted `VECTORS` row as a false orphan while the key survived
+/// (that window is now closed — see [`HnswStore::compact_orphans`]), and a
+/// hand-edited file can present the same shape. Such a state is still reachable
+/// on disk, and a `VECTORS`-only bound would hand the id straight
 /// back out — the same aliasing this module exists to prevent, arrived at from
 /// the other table.
 /// What: `max(last VECTORS key, largest mapped VECTOR_KEYS value) + 1`, or 1
@@ -869,12 +869,22 @@ impl HnswStore {
     /// method reclaims the storage. The in-memory graph still contains
     /// those points, but they are no longer addressable; a full
     /// rebuild via `open` reclaims the graph as well.
-    /// What: Builds the set of live vector_ids by scanning `VECTOR_KEYS`,
-    /// then iterates `VECTORS` and `DELETED_VECTORS` and removes any row
-    /// whose id is not in that set, or which is tombstoned. Runs in a
-    /// single write transaction so partial progress can never be observed.
-    /// Returns the number of `VECTORS` rows removed.
-    /// Test: `compact_orphans_removes_dangling`.
+    /// What: Scans `VECTOR_KEYS` for the live-id set and `VECTORS` for orphan
+    /// candidates in read transactions (so the O(N) `VECTORS` scan holds no
+    /// write lock), then in a single write transaction re-reads `VECTOR_KEYS`
+    /// and removes only the candidates that are STILL not live, plus any
+    /// tombstoned rows with no mapping. Returns the number of `VECTORS` rows
+    /// actually removed.
+    ///
+    /// #6195: the earlier three-transaction form deleted every candidate the
+    /// read-txn snapshot found, so an `upsert` committing between the snapshot
+    /// and the delete had its brand-new `VECTORS` row deleted as a false orphan
+    /// while its `VECTOR_KEYS` mapping survived — leaving the drawer out of the
+    /// HNSW graph on the next `open`. Re-checking liveness inside the delete
+    /// transaction, which redb serialises against every writer, closes that
+    /// window: a row live at the moment of deletion is never deleted.
+    /// Test: `compact_orphans_removes_dangling`,
+    /// `compact_orphans_keeps_a_vector_upserted_after_the_live_snapshot`.
     pub fn compact_orphans(&self) -> Result<usize> {
         if self.read_only {
             return Err(HnswStoreError::ReadOnly);
@@ -913,22 +923,49 @@ impl HnswStore {
             orphans
         };
 
-        let removed = orphan_ids.len();
         if orphan_ids.is_empty() && tombstoned_ids.is_empty() {
             return Ok(0);
         }
 
         let wtx = self.db.begin_write()?;
+        let mut removed = 0usize;
         {
+            // #6195: re-read the live-id set INSIDE the write transaction and
+            // re-check every candidate against it immediately before deleting.
+            // The `orphan_ids`/`live_ids` above come from read-txn snapshots
+            // taken earlier; an `upsert` committing after the first snapshot
+            // wrote a fresh `VECTORS` row whose brand-new id appears in the
+            // orphan scan as a false orphan while its `VECTOR_KEYS` mapping is
+            // live. redb permits one writer at a time, so this read reflects
+            // every upsert committed before this txn opened and blocks any that
+            // would commit after — a row that is live at the moment of deletion
+            // is therefore never deleted. The expensive `VECTORS` scan stays in
+            // the read txn above; only the small `VECTOR_KEYS` table is re-read
+            // under the write lock, so the lock is not held over the O(N) scan.
+            let live_now: std::collections::HashSet<u64> = {
+                let keys = wtx.open_table(VECTOR_KEYS)?;
+                let mut set = std::collections::HashSet::new();
+                for entry in keys.iter()? {
+                    let (_, v) = entry?;
+                    set.insert(v.value());
+                }
+                set
+            };
             let mut vectors = wtx.open_table(VECTORS)?;
             let mut dead = wtx.open_table(DELETED_VECTORS)?;
             for id in &orphan_ids {
+                if live_now.contains(id) {
+                    // #6195: a concurrent upsert claimed this id between the
+                    // snapshot and now — it is no longer an orphan.
+                    continue;
+                }
                 let _ = vectors.remove(id)?;
                 // If this orphan was also tombstoned, clear the tombstone.
                 let _ = dead.remove(id)?;
+                removed += 1;
             }
             for id in &tombstoned_ids {
-                if live_ids.contains(id) {
+                if live_now.contains(id) {
                     // Tombstoned but still mapped — leave the vector row
                     // intact (re-upsert flow); only clear the tombstone if
                     // it has no mapping. This branch is defensive: in the

--- a/crates/trusty-common/src/memory_core/store/hnsw_store/tests.rs
+++ b/crates/trusty-common/src/memory_core/store/hnsw_store/tests.rs
@@ -165,6 +165,106 @@ fn compact_orphans_removes_dangling() {
     assert_eq!(hits[0].0, u1);
 }
 
+/// Why (#6195): `compact_orphans` classes orphan candidates from read-txn
+/// snapshots taken before its delete transaction. An `upsert` that commits
+/// after the live snapshot but before the delete leaves its brand-new
+/// `VECTORS` row in the orphan scan while its `VECTOR_KEYS` mapping is live.
+/// The pre-fix delete removed the row as a false orphan, so on the next
+/// `open` the drawer never entered the HNSW graph and vector search could
+/// never return it — silent data loss. That row must survive.
+/// What: seeds a genuine orphan `VECTORS` row (an id with no mapping), then
+/// uses a held redb write transaction as a hard rendezvous. redb permits one
+/// writer at a time, so `compact_orphans` on a second thread completes both
+/// read snapshots — classing the id as an orphan — and then parks at its
+/// delete `begin_write()` behind the held transaction. The test commits the
+/// drawer's `VECTOR_KEYS` mapping THROUGH that transaction (the deterministic
+/// stand-in for the racing upsert landing in the window) and releasing the
+/// lock lets the delete run. Asserts the `VECTORS` row survives and the drawer
+/// is searchable after a reopen. Fails on the pre-fix commit.
+/// Test: this test itself is the verification.
+#[test]
+fn compact_orphans_keeps_a_vector_upserted_after_the_live_snapshot() {
+    let dir = tempdir().expect("tempdir");
+    let path = dir.path().join("hnsw.redb");
+    let dim = 8;
+
+    let raced_uuid = Uuid::new_v4().to_string();
+    let raced_id: u64 = 4242;
+    let raced_vec = unit_vec(dim, 77);
+
+    {
+        let db = Arc::new(Database::create(&path).expect("create db"));
+        let store = Arc::new(HnswStore::open(db, dim).expect("open store"));
+
+        // A live anchor drawer so the live snapshot is non-trivial.
+        let anchor = Uuid::new_v4().to_string();
+        store.upsert(&anchor, &unit_vec(dim, 1)).unwrap();
+
+        // Seed a genuine orphan: a `VECTORS` row with no `VECTOR_KEYS`
+        // mapping — the row the racing upsert will claim.
+        let encoded = postcard::to_allocvec(&raced_vec).unwrap();
+        {
+            let wtx = store.db.begin_write().unwrap();
+            {
+                let mut vectors = wtx.open_table(VECTORS).unwrap();
+                vectors.insert(raced_id, encoded.as_slice()).unwrap();
+            }
+            wtx.commit().unwrap();
+        }
+
+        // Hold a write transaction open and stage the racing upsert's mapping
+        // inside it (uncommitted). `compact_orphans`' delete `begin_write()`
+        // will block on this until we commit — the single-writer lock is the
+        // rendezvous, so correctness does not depend on timing.
+        let blocker = store.db.begin_write().unwrap();
+        {
+            let mut keys = blocker.open_table(VECTOR_KEYS).unwrap();
+            keys.insert(raced_uuid.as_str(), raced_id).unwrap();
+        }
+
+        // compact runs on another thread: its read snapshots see the orphan
+        // `VECTORS` row but NOT the still-uncommitted mapping, so it classes
+        // `raced_id` as an orphan, then parks at its delete `begin_write()`.
+        let compactor = {
+            let store = Arc::clone(&store);
+            std::thread::spawn(move || store.compact_orphans().unwrap())
+        };
+
+        // Give the compact thread ample time to pass BOTH read snapshots and
+        // park on the write lock before we commit. The snapshots are two tiny
+        // table scans (microseconds); this margin is ~5 orders larger, so the
+        // ordering — compact classes the orphan before the mapping is visible —
+        // is deterministic in practice. Committing earlier would make the
+        // mapping visible to the live snapshot and mask the bug.
+        std::thread::sleep(std::time::Duration::from_millis(300));
+
+        // Land the racing upsert and release the lock: the "upsert committed
+        // after the live snapshot but before the delete" interleaving.
+        blocker.commit().unwrap();
+
+        let _removed = compactor.join().expect("compact thread");
+
+        // The raced mapping is live, so its `VECTORS` row must remain.
+        let rtx = store.db.begin_read().unwrap();
+        let vectors = rtx.open_table(VECTORS).unwrap();
+        assert!(
+            vectors.get(raced_id).unwrap().is_some(),
+            "#6195: a vector upserted before the delete must not be compacted \
+             away as a false orphan"
+        );
+    }
+
+    // Reopen: the drawer must rebuild into the HNSW graph and be searchable.
+    let db = Arc::new(Database::create(&path).expect("reopen"));
+    let store = HnswStore::open(db, dim).expect("reopen store");
+    let hits = store.search(&raced_vec, 1).unwrap();
+    assert_eq!(hits.len(), 1, "#6195: the raced drawer must be searchable");
+    assert_eq!(
+        hits[0].0, raced_uuid,
+        "#6195: reopen must surface the raced drawer via vector search"
+    );
+}
+
 /// Write `(uuid → id)` and `(id → vector)` straight into redb, bypassing
 /// `upsert` and its allocator. Models a palace written by a pre-#5005
 /// binary — including one whose ids already collide.


### PR DESCRIPTION
Fixes the TOCTOU in `HnswStore::compact_orphans` described in #6195: orphan candidates were classed from read-txn snapshots taken before the delete, so an `upsert` committing after the live snapshot but before the delete had its brand-new `VECTORS` row deleted as a false orphan while its `VECTOR_KEYS` mapping survived — leaving the drawer out of the HNSW graph and unsearchable on the next `open`, with no error surfaced.

## Mechanism chosen — approach (b), re-check liveness inside the delete txn

The expensive O(N) `VECTORS` scan stays in a read transaction (no write lock held over it). The delete write transaction re-reads the small `VECTOR_KEYS` table and skips any candidate that is live there. redb serialises the write txn against every `upsert`, so the re-read reflects every upsert committed before the txn opened and blocks any that would commit after — a row live at the moment of deletion is never deleted. Approach (a) (whole compaction in one write txn) was rejected because it would hold the write lock over the O(N) `VECTORS` scan, blocking upserts for the duration.

Does not regress the #5005 id-reuse/`high_water` fix: not deleting a now-live row only strengthens `VECTORS`/`VECTOR_KEYS` consistency; `high_water` still bounds over both tables defensively for pre-fix on-disk palaces.

## Test — deterministic, fails on pre-fix

`compact_orphans_keeps_a_vector_upserted_after_the_live_snapshot` reproduces the interleaving with a held redb write transaction as a hard rendezvous (no timing dependence for correctness): `compact_orphans` runs on a second thread, completes both read snapshots classing the seeded id as an orphan, then parks at its delete `begin_write()`; the test commits the drawer's mapping through the held txn (the racing upsert) before releasing. Asserts the `VECTORS` row survives and the drawer is searchable after reopen.

Reverting the production change and keeping the test:
```
test ...compact_orphans_keeps_a_vector_upserted_after_the_live_snapshot ... FAILED
panicked at .../tests.rs:250:9:
#6195: a vector upserted before the delete must not be compacted away as a false orphan
test result: FAILED. 0 passed; 1 failed; ...
```

## Test-ladder rung — RUNG 4 (shared library, persistence path)

- `cargo fmt --check -p trusty-common` → clean
- `cargo clippy -p trusty-common --all-targets --features memory-core,embedder-test-support -- -D warnings` → clean
- `cargo test -p trusty-common --features memory-core,embedder-test-support` → `1123 passed; 0 failed; 13 ignored` (+ sub-suites, 0 failed)
- `cargo check --workspace` → clean
- `cargo test -p trusty-memory` → 0 failed
- `check_line_cap.sh`, `check_sld.sh`, `check_changelog_fragment.sh` → pass

Refs #6195

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools