### PR TITLE
chore: trusty-common 0.42.0, trusty-mpm 1.4.4 (semver break correction)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6519,7 +6519,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11405,7 +11405,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-common"
-version = "0.41.2"
+version = "0.42.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11694,7 +11694,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-mpm"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,7 @@ trusty-code = { path = "crates/trusty-code", version = "0.3.0" }
 # epic #3411). Not yet published (Slice 1, #3425).
 trusty-tui = { path = "crates/trusty-tui", version = "0.1.0" }
 trusty-agents-common = { path = "crates/trusty-agents-common", version = "0.6.0" }
-trusty-common = { path = "crates/trusty-common", version = "0.41" }
+trusty-common = { path = "crates/trusty-common", version = "0.42" }
 # Shared JSON-RPC 2.0 / MCP protocol primitives, extracted from
 # `trusty_common::mcp` by ADR-0040 (#5803).
 trusty-mcp = { path = "crates/trusty-mcp", version = "0.1.0" }

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "trusty-common"
 # 0.40.0 (#5809): the MCP extraction (ADR-0040 Phase 1) removed the public
 # `src/mcp/*` modules. Cargo's 0.x rule makes that a MINOR bump, not a patch.
-version = "0.41.2"
+version = "0.42.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/trusty-gworkspace/Cargo.toml
+++ b/crates/trusty-gworkspace/Cargo.toml
@@ -15,7 +15,7 @@ name = "trusty-gworkspace-mcp"
 path = "src/bin/trusty-gworkspace-mcp.rs"
 
 [dependencies]
-trusty-common = { path = "../trusty-common", version = "0.41" }
+trusty-common = { path = "../trusty-common", version = "0.42" }
 # JSON-RPC / MCP primitives, extracted from `trusty_common::mcp` by ADR-0040 (#5803).
 trusty-mcp = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/trusty-memory/Cargo.toml
+++ b/crates/trusty-memory/Cargo.toml
@@ -82,7 +82,7 @@ path = "src/bin/mcp_bridge.rs"
 # `uds-supervisor` is NOT dropped — trusty-console and trusty-agents still
 # depend on the shared `UdsServiceSupervisor` for trusty-review / trusty-analyze.
 trusty-mcp = { workspace = true }  # JSON-RPC / MCP primitives (ADR-0040, #5803)
-trusty-common = { path = "../trusty-common", version = "0.41", default-features = false, features = ["memory-core", "monitor-tui", "bm25", "cli-help", "update-check", "bug-capture", "console-metrics", "config-cli", "crate-config", "palace-resolve", "codex-config"] }
+trusty-common = { path = "../trusty-common", version = "0.42", default-features = false, features = ["memory-core", "monitor-tui", "bm25", "cli-help", "update-check", "bug-capture", "console-metrics", "config-cli", "crate-config", "palace-resolve", "codex-config"] }
 # `bug-capture` enables Phase 1 ERROR event capture to JSONL + in-memory ring (bug-reporting #478)
 # Why (issue #1318): the `trusty-console` dependency was REMOVED. The console
 # is no longer bundled into trusty-memory (single-owner-per-binary); the
@@ -174,7 +174,7 @@ serial_test = { workspace = true }
 # the production library (mirrors the trusty-mpm and trusty-search pattern).
 # `docgen` (#5205 follow-up): `tests/generated_docs.rs` renders the MCP tool
 # section of README.md from `tool_definitions()`.
-trusty-common = { path = "../trusty-common", version = "0.41", default-features = false, features = ["memory-core", "embedder-test-support", "docgen"] }
+trusty-common = { path = "../trusty-common", version = "0.42", default-features = false, features = ["memory-core", "embedder-test-support", "docgen"] }
 chrono = { workspace = true }
 
 [features]

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-mpm"
-version = "1.4.3"
+version = "1.4.4"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## What

Version-only correction after `preflight-publish.sh` CHECK 5 blocked the
publish wave for #6203/#6204/#6205/#6206.

`#6203` added `ChatSessionStoreError::CorruptHistory` to a public,
non-`#[non_exhaustive]` enum (also shifting the `Timestamp` variant's
discriminant 8 → 9). `cargo-semver-checks` correctly flagged this as a
breaking change:

```
--- failure enum_no_repr_variant_discriminant_changed ---
variant ChatSessionStoreError::Timestamp 8 -> 9

--- failure enum_variant_added: enum variant added on exhaustive enum ---
variant ChatSessionStoreError:CorruptHistory

Summary semver requires new major version: 2 major and 0 minor checks failed
VERDICT: BREAK. 0.x crates: a break needs the MINOR position.
```

Per CLAUDE.md ("Internal consistency is the bar — pick the version that keeps
the workspace consistent and move on"), the code stays exactly as merged;
only the version numbers move:

- `trusty-common`: 0.41.2 → 0.42.0 (minor, per the 0.x breaking-change rule).
  Every direct version pin on `trusty-common` moves from `"0.41"` to `"0.42"`
  to match: root `[workspace.dependencies]`, `trusty-memory` (x2), and
  `trusty-gworkspace`.
- `trusty-mpm`: 1.4.3 → 1.4.4 (patch). Its `1.4.3` tag is pinned at the same
  now-superseded commit and tags are immutable, so the version moves forward;
  its published manifest's `trusty-common` dependency also needs the new floor.

Tags `trusty-common-v0.41.2` and `trusty-mpm-v1.4.3` stay in git history,
unpublished and unused — fresh tags (`trusty-common-v0.42.0`,
`trusty-mpm-v1.4.4`) get cut at this PR's merge commit once green.

## Test plan

- Rung 1 (version/manifest-only change, no `src/**` touched):
  - `git diff --stat` — 6 files, all `Cargo.toml`/`Cargo.lock`, 9+/9- lines.
  - `cargo update -p trusty-common --precise 0.42.0` — clean, `EXIT=0`.
  - `cargo update -p trusty-mpm --precise 1.4.4` — clean, `EXIT=0`.
  - `bash scripts/check_changelog_fragment.sh` — `EXIT=0`, "no crate source
    changed (docs-only / CI-only / test-only) — OK." Confirms no fragment is
    owed for a `Cargo.toml`-only PR.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools