### PR TITLE
fix(trusty-common): guard vector reclamation against a remember race (Refs #6208)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11405,7 +11405,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-common"
-version = "0.42.0"
+version = "0.42.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -2,7 +2,9 @@
 name = "trusty-common"
 # 0.40.0 (#5809): the MCP extraction (ADR-0040 Phase 1) removed the public
 # `src/mcp/*` modules. Cargo's 0.x rule makes that a MINOR bump, not a patch.
-version = "0.42.0"
+# 0.42.1 (#6208): patch — additive `PalaceHandle::compact_vector_orphans` fixes
+# a data-loss race; no public item removed or changed, so not a 0.x break.
+version = "0.42.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/trusty-common/changelog.d/6208-compact-remember-race.md
+++ b/crates/trusty-common/changelog.d/6208-compact-remember-race.md
@@ -1,0 +1,13 @@
+Fixed
+
+- Vector reclamation no longer deletes the vector of a drawer whose `remember`
+  is still in flight. A remember upserts the new drawer's vector before it
+  registers the drawer, and three reclamation paths snapshotted the valid-drawer
+  set and reclaimed "orphans" without the palace write lock: `palace_compact`,
+  the idle dream cycle's `compact_pass`, and its fallback index rebuild
+  (`rebuild_index_from_drawers`, which `reset()`s the whole index and re-adds
+  only the snapshotted drawers). A reclamation landing in the upsert→register
+  window saw the vector with no matching drawer and dropped it permanently. All
+  three now hold the write mutex across the snapshot and the reclamation
+  (`palace_compact` via the new `PalaceHandle::compact_vector_orphans`), so a
+  mid-flight drawer's vector can never be dropped under any interleaving (#6208).

--- a/crates/trusty-common/src/memory_core/dream/cycle.rs
+++ b/crates/trusty-common/src/memory_core/dream/cycle.rs
@@ -20,6 +20,7 @@ use crate::memory_core::semantic_consolidation::{
     SemanticConsolidator, inference_available, resolve_openrouter_api_key, validate_ollama_model,
 };
 use crate::memory_core::store::vector::VectorStore;
+use crate::memory_core::timeouts;
 use anyhow::Result;
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -100,24 +101,42 @@ pub(super) async fn compact_pass(
     started: std::time::Instant,
     budget: Duration,
 ) -> Result<usize> {
-    let drawer_ids: HashSet<Uuid> = handle.drawers.read().iter().map(|d| d.id).collect();
-
-    // Addressable pass: walk every id our key_map knows about and drop
-    // anything missing from the drawer table.
-    let vector_ids = handle.vector_store.all_ids();
     let mut removed: usize = 0;
-    for vid in vector_ids {
-        if started.elapsed() >= budget {
-            break;
+    // #6208: snapshot the drawer set and reclaim orphans while holding the
+    // palace write mutex — the same lock `remember`/`forget` hold. Without it,
+    // a `remember` mid-flight (vector upserted at handle.rs:~686, drawer not yet
+    // pushed at ~708) exposes a vector with no matching drawer, which this pass
+    // would remove as a false orphan and lose permanently. The guard makes that
+    // intermediate state unobservable here; it is released before the rebuild
+    // below, which re-takes it independently (no reentrancy — tokio::Mutex is
+    // not reentrant). `remember` never holds this across `compact_pass`, and the
+    // idle dreamer holds only the `is_compacting` flag, so this cannot deadlock.
+    let (drawer_count, index_size_after) = {
+        let _write_guard = timeouts::lock_with_timeout(
+            &handle.write_mutex,
+            timeouts::write_lock_timeout(),
+            handle.id.as_str(),
+        )
+        .await?;
+        let drawer_ids: HashSet<Uuid> = handle.drawers.read().iter().map(|d| d.id).collect();
+
+        // Addressable pass: walk every id our key_map knows about and drop
+        // anything missing from the drawer table.
+        let vector_ids = handle.vector_store.all_ids();
+        for vid in vector_ids {
+            if started.elapsed() >= budget {
+                break;
+            }
+            if drawer_ids.contains(&vid) {
+                continue;
+            }
+            match handle.vector_store.remove(vid).await {
+                Ok(()) => removed += 1,
+                Err(e) => tracing::warn!(?vid, "dream compact: vector remove failed: {e:#}"),
+            }
         }
-        if drawer_ids.contains(&vid) {
-            continue;
-        }
-        match handle.vector_store.remove(vid).await {
-            Ok(()) => removed += 1,
-            Err(e) => tracing::warn!(?vid, "dream compact: vector remove failed: {e:#}"),
-        }
-    }
+        (drawer_ids.len(), handle.vector_store.index_size())
+    };
 
     // Fallback rebuild: if the index still reports significantly more
     // vectors than the drawer table holds (e.g. pre-fix orphans we can't
@@ -125,8 +144,6 @@ pub(super) async fn compact_pass(
     // from scratch. Costly but bounded — only runs when the divergence is
     // material, and re-embedding 100s of drawers takes <1s on the local
     // ONNX model.
-    let drawer_count = drawer_ids.len();
-    let index_size_after = handle.vector_store.index_size();
     // Only rebuild when we have drawers to re-embed AND the index has at
     // least 1 + 2*drawer_count entries (well past noise). Avoids tight
     // rebuild loops on a healthy small palace.

--- a/crates/trusty-common/src/memory_core/dream/helpers.rs
+++ b/crates/trusty-common/src/memory_core/dream/helpers.rs
@@ -9,6 +9,7 @@
 use crate::memory_core::palace::Drawer;
 use crate::memory_core::retrieval::{PalaceHandle, shared_embedder};
 use crate::memory_core::store::vector::VectorStore;
+use crate::memory_core::timeouts;
 use anyhow::{Context, Result};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -156,12 +157,28 @@ pub(crate) fn merge_into(handle: &Arc<PalaceHandle>, survivor: &Drawer, loser: &
 /// What: Snapshots drawers, calls `UsearchStore::reset` to truncate the
 /// index, then re-embeds and re-upserts each drawer. Respects the budget by
 /// stopping early — incomplete rebuilds are still safe (the next cycle picks
-/// up where this one left off).
+/// up where this one left off). #6208: the snapshot→reset→re-upsert runs under
+/// the palace write mutex so a concurrent `remember` cannot land a vector that
+/// `reset()` then wipes without re-adding.
 pub(crate) async fn rebuild_index_from_drawers(
     handle: &Arc<PalaceHandle>,
     started: std::time::Instant,
     budget: Duration,
 ) -> Result<usize> {
+    // #6208: hold the write mutex across the whole rebuild. `reset()` truncates
+    // the entire index; a `remember` that upserts between the snapshot and the
+    // re-upsert loop would be dropped by the reset and never re-added, because
+    // only the snapshotted drawers are re-embedded. Guarding snapshot→reset→
+    // re-upsert makes a mid-flight remember impossible during this region — its
+    // vector is either in the snapshot (re-added) or lands after release (never
+    // reset). The sole caller, `compact_pass`, releases its own guard before
+    // calling this, so there is no reentrancy.
+    let _write_guard = timeouts::lock_with_timeout(
+        &handle.write_mutex,
+        timeouts::write_lock_timeout(),
+        handle.id.as_str(),
+    )
+    .await?;
     let snapshot: Vec<Drawer> = handle.drawers.read().clone();
     handle
         .vector_store

--- a/crates/trusty-common/src/memory_core/dream/tests.rs
+++ b/crates/trusty-common/src/memory_core/dream/tests.rs
@@ -2,13 +2,14 @@ use super::guard::CompactionGuard;
 use super::helpers::{MERGED_CONTENT_CAP, char_safe_prefix, merge_into, now_secs};
 use super::*;
 use crate::credentials::env_guard::EnvVarGuard;
-use crate::memory_core::palace::{Palace, PalaceId, RoomType};
+use crate::memory_core::palace::{Drawer, Palace, PalaceId, RoomType};
 use crate::memory_core::retrieval::{PalaceHandle, seed_shared_embedder_with_mock};
+use crate::memory_core::store::vector::VectorStore;
 use chrono::{Duration as ChronoDuration, Utc};
 use serial_test::serial;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tempfile::tempdir;
 use uuid::Uuid;
 
@@ -2010,5 +2011,140 @@ async fn merge_into_keeps_the_content_hash_in_step() {
         merged.content_hash(),
         memory_content_hash(merged.content()),
         "the digest must describe the body the drawer now holds"
+    );
+}
+
+/// Why: #6208 — the dream cycle's `compact_pass` snapshots the drawer-id set
+/// from `handle.drawers` and removes any vector absent from it, WITHOUT the
+/// palace write mutex. `remember` upserts a vector before it registers the
+/// drawer (both inside its own write-mutex section) and does not gate on
+/// `is_compacting`, so the idle dreamer's `compact_pass` running in that window
+/// deleted the freshly-remembered vector as a false orphan. `compact_pass` now
+/// snapshots + removes under the write mutex, so that intermediate state is
+/// unobservable to it.
+/// What: mirrors `remember_racing_compact_never_loses_a_vector` for the dream
+/// path. Holds the write mutex (as `remember` does), upserts drawer B's vector
+/// but leaves B unregistered — the mid-flight window — then runs `compact_pass`
+/// concurrently. With the guard, `compact_pass` blocks until B is registered and
+/// the guard drops, then keeps B; without it, `compact_pass` snapshots (B
+/// absent) and removes B inside the window. Deterministic: the mutex, not the
+/// sleep, orders the two.
+/// Test: this test itself.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn remember_racing_dream_compact_pass_never_loses_a_vector() {
+    let handle = open_test_handle("dream-race-compact").await;
+
+    // A committed baseline drawer so the index is non-empty.
+    let anchor_id = handle
+        .remember(
+            "anchor drawer stays put".into(),
+            RoomType::Backend,
+            vec![],
+            0.7,
+        )
+        .await
+        .unwrap();
+
+    // Racing drawer B: model `remember`'s two write steps by hand under the
+    // real write mutex.
+    let drawer_b = Drawer::new(uuid::Uuid::new_v4(), "racing drawer B must survive");
+    let b_id = drawer_b.id;
+    let mut b_vec = vec![0.0f32; 384];
+    b_vec[7] = 1.0;
+
+    let write_mutex = handle.write_mutex_for_test();
+    let guard = write_mutex.lock().await;
+
+    // Step 1 of remember: vector upserted; step 2 (register) deferred.
+    handle.vector_store.upsert(b_id, b_vec).await.unwrap();
+
+    let compact_handle = handle.clone();
+    let compact = tokio::spawn(async move {
+        super::cycle::compact_pass(&compact_handle, Instant::now(), Duration::from_secs(60)).await
+    });
+
+    // Give a pre-guard (unguarded) compact_pass time to snapshot + remove B.
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    // Complete remember: register B, then release the write mutex.
+    handle.drawers.write().push(drawer_b);
+    drop(guard);
+
+    compact.await.unwrap().unwrap();
+
+    let ids = handle.vector_store.all_ids();
+    assert!(
+        ids.contains(&b_id),
+        "#6208: drawer B's vector was reclaimed by a dream compact_pass racing \
+         its remember (ids={ids:?}, want {b_id})"
+    );
+    assert!(
+        ids.contains(&anchor_id),
+        "the anchor vector must survive too"
+    );
+}
+
+/// Why: #6208 — the dream cycle's fallback `rebuild_index_from_drawers`
+/// snapshots `handle.drawers`, `reset()`s the whole index, then re-upserts only
+/// the snapshotted drawers — WITHOUT the write mutex. A `remember` upserting in
+/// that window has its vector wiped by `reset()` and never re-added, because it
+/// was not in the snapshot. The rebuild now runs snapshot→reset→re-upsert under
+/// the write mutex, so a mid-flight remember cannot be lost.
+/// What: mirrors the compact_pass race for the rebuild path. Holds the write
+/// mutex, upserts B, leaves B unregistered, then runs `rebuild_index_from_drawers`
+/// concurrently. With the guard the rebuild blocks until B is registered, so B is
+/// in the snapshot and is re-embedded; without it the rebuild resets and re-adds
+/// only the anchor, dropping B. Deterministic via the mutex.
+/// Test: this test itself.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn remember_racing_dream_rebuild_never_loses_a_vector() {
+    let handle = open_test_handle("dream-race-rebuild").await;
+
+    let anchor_id = handle
+        .remember(
+            "anchor drawer stays put".into(),
+            RoomType::Backend,
+            vec![],
+            0.7,
+        )
+        .await
+        .unwrap();
+
+    let drawer_b = Drawer::new(uuid::Uuid::new_v4(), "racing drawer B must survive");
+    let b_id = drawer_b.id;
+    let mut b_vec = vec![0.0f32; 384];
+    b_vec[9] = 1.0;
+
+    let write_mutex = handle.write_mutex_for_test();
+    let guard = write_mutex.lock().await;
+
+    handle.vector_store.upsert(b_id, b_vec).await.unwrap();
+
+    let rebuild_handle = handle.clone();
+    let rebuild = tokio::spawn(async move {
+        super::helpers::rebuild_index_from_drawers(
+            &rebuild_handle,
+            Instant::now(),
+            Duration::from_secs(60),
+        )
+        .await
+    });
+
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    handle.drawers.write().push(drawer_b);
+    drop(guard);
+
+    rebuild.await.unwrap().unwrap();
+
+    let ids = handle.vector_store.all_ids();
+    assert!(
+        ids.contains(&b_id),
+        "#6208: drawer B's vector was wiped by a dream index rebuild racing its \
+         remember (ids={ids:?}, want {b_id})"
+    );
+    assert!(
+        ids.contains(&anchor_id),
+        "the anchor vector must survive too"
     );
 }

--- a/crates/trusty-common/src/memory_core/retrieval/handle.rs
+++ b/crates/trusty-common/src/memory_core/retrieval/handle.rs
@@ -26,11 +26,11 @@ use crate::memory_core::store::kg::KnowledgeGraph;
 use crate::memory_core::store::l1_cache::L1Cache;
 use crate::memory_core::store::palace_store::PalaceStore;
 use crate::memory_core::store::rooms::resolve_or_create_room_in_wing;
-use crate::memory_core::store::vector::{UsearchStore, VectorStore};
+use crate::memory_core::store::vector::{CompactionResult, UsearchStore, VectorStore};
 use crate::memory_core::timeouts;
 use anyhow::{Context, Result};
 use parking_lot::RwLock;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use uuid::Uuid;
@@ -726,6 +726,44 @@ impl PalaceHandle {
         self.rebuild_closets();
 
         Ok(id)
+    }
+
+    /// Reclaim orphaned vectors, serialised against the write pipeline.
+    ///
+    /// Why: #6208 — `remember_with_options` upserts a new drawer's vector
+    /// (line ~686) and only later pushes the drawer into `self.drawers`
+    /// (line ~708), both inside ONE `write_mutex` critical section. A compact
+    /// that snapshotted its valid-id set from `self.drawers` in that window saw
+    /// the vector row with no matching drawer and reclaimed it permanently —
+    /// silent data loss, DELETED_VECTORS=0, live-reproduced at 10/60 racing
+    /// drawers. Snapshotting under NO lock made "vector present, drawer absent"
+    /// an observable state.
+    /// What: acquires the same `write_mutex` `remember`/`forget` hold, THEN
+    /// snapshots `valid_ids` and runs the store's orphan reclamation — both
+    /// under the guard. Because a remember's upsert AND push are atomic w.r.t.
+    /// this guard, a compact here observes either the pre-remember state (no
+    /// vector, no drawer) or the post-remember state (vector present, drawer id
+    /// in `valid_ids`) — never the intermediate one — so an in-flight drawer's
+    /// vector cannot be reclaimed under any interleaving, not merely a narrowed
+    /// window. The bound is `remember`'s: reclamation runs on a blocking thread
+    /// but holds the guard for its duration, matching the existing write path.
+    /// Test: `remember_racing_compact_never_loses_a_vector`,
+    /// `compact_vector_orphans_still_reclaims_true_orphans`.
+    pub async fn compact_vector_orphans(&self) -> Result<CompactionResult> {
+        // #6208: hold the palace write mutex across BOTH the valid-id snapshot
+        // and the reclamation so a mid-flight remember (upsert done, drawer not
+        // yet pushed) cannot have its vector reclaimed as a false orphan.
+        let _write_guard = timeouts::lock_with_timeout(
+            &self.write_mutex,
+            timeouts::write_lock_timeout(),
+            self.id.as_str(),
+        )
+        .await?;
+        let valid_ids: HashSet<Uuid> = self.drawers.read().iter().map(|d| d.id).collect();
+        let vector_store = self.vector_store.clone();
+        tokio::task::spawn_blocking(move || vector_store.compact_orphans(&valid_ids))
+            .await
+            .context("join compact_vector_orphans")?
     }
 
     /// Background embed + vector-store backfill for a drawer written while the

--- a/crates/trusty-common/src/memory_core/retrieval/tests.rs
+++ b/crates/trusty-common/src/memory_core/retrieval/tests.rs
@@ -2406,3 +2406,142 @@ async fn l2_rank_trace_emits_one_event_per_candidate() {
         "every candidate must be traced, including the ones truncation drops"
     );
 }
+
+/// Why: #6208 — `remember_with_options` upserts a new drawer's vector before it
+/// registers the drawer in `self.drawers`, both inside one `write_mutex`
+/// critical section. `palace_compact` used to snapshot its valid-id set from
+/// `self.drawers` and reclaim orphans WITHOUT taking that mutex, so a compact
+/// landing in the upsert→push window saw the vector with no matching drawer and
+/// deleted it permanently — live-reproduced at 10/60 racing drawers with
+/// DELETED_VECTORS=0. `compact_vector_orphans` now holds `write_mutex` across
+/// the whole reclamation, making that intermediate state unobservable to it.
+/// What: models the exact race deterministically. The test takes the palace
+/// write mutex (as `remember` does), upserts drawer B's vector but does NOT yet
+/// register B — the precise mid-flight state — then launches a compact
+/// concurrently and gives it time to run. With the fix the compact BLOCKS on the
+/// mutex the whole time and cannot delete B; only after B is registered and the
+/// guard drops does compact proceed, and it keeps B. Without the fix the compact
+/// never blocks: it snapshots (B absent) and deletes B inside the window, which
+/// the final search catches. Deterministic because the mutex — not the sleep —
+/// orders the two: a fixed compact can never observe the registered state before
+/// the guard is released, and an unfixed compact runs its whole snapshot+delete
+/// well within the window (a lockless redb scan of a two-row index). The sleep
+/// only bounds how long the unfixed compact is given; it never decides the fixed
+/// arm's outcome.
+/// Test: this test itself.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn remember_racing_compact_never_loses_a_vector() {
+    init_embedder();
+    let dir = tempdir().unwrap();
+    let handle = Arc::new(make_handle(dir.path()));
+    let room_id = uuid::Uuid::new_v4();
+
+    // A committed baseline drawer so the palace and index are non-empty.
+    let anchor = Drawer::new(room_id, "anchor drawer stays put");
+    let anchor_id = anchor.id;
+    let mut anchor_vec = vec![0.0f32; 384];
+    anchor_vec[1] = 1.0;
+    handle
+        .vector_store
+        .upsert(anchor_id, anchor_vec)
+        .await
+        .unwrap();
+    handle.drawers.write().push(anchor);
+
+    // The racing drawer B: build it first so we know its id, then drive the two
+    // halves of `remember`'s write section by hand under the real write mutex.
+    let drawer_b = Drawer::new(room_id, "racing drawer B must survive");
+    let b_id = drawer_b.id;
+    let mut b_vec = vec![0.0f32; 384];
+    b_vec[7] = 1.0;
+
+    let write_mutex = handle.write_mutex_for_test();
+    let guard = write_mutex.lock().await;
+
+    // Step 1 of remember: vector upserted...
+    handle
+        .vector_store
+        .upsert(b_id, b_vec.clone())
+        .await
+        .unwrap();
+    // ...step 2 (drawer registration) deliberately deferred: this IS the window.
+
+    // Launch the compact while B is mid-flight.
+    let compact_handle = handle.clone();
+    let compact = tokio::spawn(async move { compact_handle.compact_vector_orphans().await });
+
+    // Give a non-blocking (pre-fix) compact ample time to snapshot + delete B.
+    // A fixed compact is blocked on the mutex here, so this changes nothing for it.
+    tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+
+    // Complete remember: register B, then release the write mutex.
+    handle.drawers.write().push(drawer_b);
+    drop(guard);
+
+    compact.await.unwrap().unwrap();
+
+    // B's vector must still be retrievable after the racing compaction.
+    let hits = handle.vector_store.search(&b_vec, 10).await.unwrap();
+    assert!(
+        hits.iter().any(|h| uuid_prefix_eq(h.drawer_id, b_id)),
+        "#6208: drawer B's vector was reclaimed by a compact racing its remember \
+         (hits={:?}, want {b_id})",
+        hits.iter().map(|h| h.drawer_id).collect::<Vec<_>>(),
+    );
+}
+
+/// Why: #6208's fix must not over-correct into never reclaiming. A vector whose
+/// drawer genuinely does not exist (a real orphan from a crashed write) must
+/// still be removed by `compact_vector_orphans`, exactly as before.
+/// What: upserts an orphan vector with no drawer, plus one live drawer, then
+/// compacts and asserts the orphan is gone while the live drawer's vector stays.
+/// Test: this test itself.
+#[tokio::test]
+async fn compact_vector_orphans_still_reclaims_true_orphans() {
+    init_embedder();
+    let dir = tempdir().unwrap();
+    let handle = Arc::new(make_handle(dir.path()));
+    let room_id = uuid::Uuid::new_v4();
+
+    let live = Drawer::new(room_id, "live drawer with a home");
+    let live_id = live.id;
+    let mut live_vec = vec![0.0f32; 384];
+    live_vec[2] = 1.0;
+    handle
+        .vector_store
+        .upsert(live_id, live_vec.clone())
+        .await
+        .unwrap();
+    handle.drawers.write().push(live);
+
+    // A homeless vector: no drawer is ever registered for it.
+    let orphan_id = uuid::Uuid::new_v4();
+    let mut orphan_vec = vec![0.0f32; 384];
+    orphan_vec[3] = 1.0;
+    handle
+        .vector_store
+        .upsert(orphan_id, orphan_vec.clone())
+        .await
+        .unwrap();
+
+    let res = handle.compact_vector_orphans().await.unwrap();
+    assert_eq!(
+        res.orphans_removed, 1,
+        "the homeless vector must be reclaimed"
+    );
+
+    let live_hits = handle.vector_store.search(&live_vec, 10).await.unwrap();
+    assert!(
+        live_hits
+            .iter()
+            .any(|h| uuid_prefix_eq(h.drawer_id, live_id)),
+        "the live drawer's vector must survive compaction"
+    );
+    let orphan_hits = handle.vector_store.search(&orphan_vec, 10).await.unwrap();
+    assert!(
+        !orphan_hits
+            .iter()
+            .any(|h| uuid_prefix_eq(h.drawer_id, orphan_id)),
+        "the orphan vector must not be retrievable after compaction"
+    );
+}

--- a/crates/trusty-memory/changelog.d/6208-compact-remember-race.md
+++ b/crates/trusty-memory/changelog.d/6208-compact-remember-race.md
@@ -1,0 +1,3 @@
+Fixed
+
+- `palace_compact` now routes through `PalaceHandle::compact_vector_orphans`, which holds the palace write lock across the orphan snapshot and reclaim — closing a race where a concurrent `remember` could have its just-upserted vector reclaimed as a false orphan before its drawer record was pushed (#6208).

--- a/crates/trusty-memory/src/tools/palace_ops.rs
+++ b/crates/trusty-memory/src/tools/palace_ops.rs
@@ -424,15 +424,12 @@ fn alias_audit_state(audit: &trusty_common::memory_core::retrieval::AliasAudit) 
 pub(crate) async fn handle_palace_compact(state: &AppState, args: Value) -> Result<Value> {
     let palace = resolve_palace(state, &args, "palace_compact")?;
     let handle = open_palace_handle(state, &palace)?;
-    // Use the live drawer table (sourced from redb at palace open) as
-    // the authoritative valid-id set, then run the vector store's
-    // synchronous compaction on a blocking thread.
-    let valid_ids: std::collections::HashSet<Uuid> =
-        handle.drawers.read().iter().map(|d| d.id).collect();
-    let vector_store = handle.vector_store.clone();
-    let res = tokio::task::spawn_blocking(move || vector_store.compact_orphans(&valid_ids))
-        .await
-        .context("join palace_compact")??;
+    // #6208: route through the handle's locked reclamation. It snapshots the
+    // valid-id set and reclaims orphans while holding the palace write mutex,
+    // so a concurrent `remember` (vector upserted, drawer not yet registered)
+    // cannot have its brand-new vector reclaimed as a false orphan. Snapshotting
+    // the valid-ids here without that lock is exactly the window #6208 closes.
+    let res = handle.compact_vector_orphans().await?;
     Ok(json!({
         "palace": palace,
         "total_checked": res.total_checked,


### PR DESCRIPTION
## Summary

`remember_with_options` upserts a new drawer's vector before pushing the drawer record into `handle.drawers` — both inside one `write_mutex` critical section. Three vector-reclamation paths (`palace_compact`, the idle dream cycle's `compact_pass`, and its fallback `rebuild_index_from_drawers`) used to snapshot the valid-drawer set and reclaim "orphans" without holding that mutex, so a reclamation landing inside the upsert-to-push window saw the vector with no matching drawer and dropped it permanently. All three now acquire `write_mutex` across the snapshot and the reclaim (`palace_compact` via the new `PalaceHandle::compact_vector_orphans`), so the intermediate state is never observable.

## Test plan

Rung 5 (cross-crate contract, persistence, concurrency):
- `cargo test -p trusty-common --features memory-core,embedder-test-support` — 1130 passed
- `cargo check --workspace` — clean
- `cargo test -p trusty-memory` — 811 passed

code-critic: round 1 BLOCK (two dream-path holes — `compact_pass` and `rebuild_index_from_drawers` reclaiming without the lock), both closed; round 2 APPROVE.

Changelog fragment: `crates/trusty-common/changelog.d/6208-compact-remember-race.md`.

Refs #6208

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools