### PR TITLE
fix(trusty-common): escape JQL string interpolation in the Jira backend (Refs #6198)

### DIFF
--- a/crates/trusty-common/changelog.d/6198-jira-jql-injection.md
+++ b/crates/trusty-common/changelog.d/6198-jira-jql-injection.md
@@ -1,0 +1,12 @@
+Fixed
+
+- The JIRA tickets backend no longer interpolates filter values into JQL
+  unescaped (#6198). `search_issues` (`query`, `assignee`, `labels`,
+  `priority`) and `list_issues` (`assignee`, `labels`) built the `jql` string
+  with raw `format!`, so a value containing `"` closed its quoted term and
+  injected arbitrary JQL — for example an `assignee` of `foo" OR project =
+  "SECRET` read issues from a project the caller could not otherwise reach.
+  JQL construction now runs through pure `build_search_jql` / `build_list_jql`
+  builders that escape every attacker-controlled value (backslash, double
+  quote, and control characters) so a `"` can no longer break out of its term.
+  `state` was never affected — it maps through a closed match to fixed literals.

--- a/crates/trusty-common/changelog.d/6198-jira-jql-injection.md
+++ b/crates/trusty-common/changelog.d/6198-jira-jql-injection.md
@@ -1,12 +1,15 @@
 Fixed
 
 - The JIRA tickets backend no longer interpolates filter values into JQL
-  unescaped (#6198). `search_issues` (`query`, `assignee`, `labels`,
-  `priority`) and `list_issues` (`assignee`, `labels`) built the `jql` string
-  with raw `format!`, so a value containing `"` closed its quoted term and
-  injected arbitrary JQL — for example an `assignee` of `foo" OR project =
-  "SECRET` read issues from a project the caller could not otherwise reach.
-  JQL construction now runs through pure `build_search_jql` / `build_list_jql`
-  builders that escape every attacker-controlled value (backslash, double
-  quote, and control characters) so a `"` can no longer break out of its term.
+  unescaped (#6198). Four methods built the `jql` string with raw `format!`:
+  `search_issues` (`query`, `assignee`, `labels`, `priority`) and `list_issues`
+  (`assignee`, `labels`) quoted their terms but did not escape, so a value with
+  a `"` closed the term and injected clauses; `get_milestone_issues`
+  (`fixVersion = {id}`) and `get_epic_issues` (`parent = {epic_id}`) were worse
+  — unquoted, so an `id`/`epic_id` of `1 OR project = SECRET` injected a live
+  clause with no quote-breakout needed, reading issues from a project the caller
+  could not otherwise reach. All four now build via pure `build_*_jql` helpers
+  that route every attacker-controlled value through a new `escape_jql_string`
+  (escapes backslash, double quote, and control characters) and quote every
+  term. `list_epics`' config-derived project key is escaped too for uniformity.
   `state` was never affected — it maps through a closed match to fixed literals.

--- a/crates/trusty-common/src/tickets/api/backends/jira/backend.rs
+++ b/crates/trusty-common/src/tickets/api/backends/jira/backend.rs
@@ -17,7 +17,9 @@ use crate::tickets::api::backends::{
 };
 use crate::tickets::api::models::*;
 
-use super::types::{JiraBackend, adf_paragraph, parse_comment, parse_issue};
+use super::types::{
+    JiraBackend, adf_paragraph, build_list_jql, build_search_jql, parse_comment, parse_issue,
+};
 
 #[async_trait]
 impl Backend for JiraBackend {
@@ -115,22 +117,8 @@ impl Backend for JiraBackend {
     }
 
     async fn list_issues(&self, p: ListIssuesParams) -> Result<Vec<Issue>> {
-        let mut jql = format!("project = \"{}\"", self.project_key);
-        if let Some(s) = &p.state {
-            let cat = match s.as_str() {
-                "done" | "closed" => "Done",
-                "in_progress" => "In Progress",
-                _ => "To Do",
-            };
-            jql.push_str(&format!(" AND statusCategory = \"{cat}\""));
-        }
-        if let Some(a) = &p.assignee {
-            jql.push_str(&format!(" AND assignee = \"{a}\""));
-        }
-        for l in &p.labels {
-            jql.push_str(&format!(" AND labels = \"{l}\""));
-        }
-        jql.push_str(" ORDER BY created DESC");
+        // #6198: build via build_list_jql so every filter value is JQL-escaped.
+        let jql = build_list_jql(&self.project_key, &p);
         let body = json!({
             "jql": jql,
             "maxResults": p.limit.max(1),
@@ -146,27 +134,8 @@ impl Backend for JiraBackend {
     }
 
     async fn search_issues(&self, p: SearchIssuesParams) -> Result<Vec<Issue>> {
-        let mut jql = format!("project = \"{}\"", self.project_key);
-        if let Some(q) = &p.query {
-            jql.push_str(&format!(" AND text ~ \"{q}\""));
-        }
-        if let Some(s) = &p.state {
-            let cat = match s.as_str() {
-                "done" | "closed" => "Done",
-                "in_progress" => "In Progress",
-                _ => "To Do",
-            };
-            jql.push_str(&format!(" AND statusCategory = \"{cat}\""));
-        }
-        if let Some(a) = &p.assignee {
-            jql.push_str(&format!(" AND assignee = \"{a}\""));
-        }
-        for l in &p.labels {
-            jql.push_str(&format!(" AND labels = \"{l}\""));
-        }
-        if let Some(pri) = &p.priority {
-            jql.push_str(&format!(" AND priority = \"{pri}\""));
-        }
+        // #6198: build via build_search_jql so every filter value is JQL-escaped.
+        let jql = build_search_jql(&self.project_key, &p);
         let body = json!({
             "jql": jql,
             "maxResults": p.limit.max(1),

--- a/crates/trusty-common/src/tickets/api/backends/jira/backend.rs
+++ b/crates/trusty-common/src/tickets/api/backends/jira/backend.rs
@@ -18,7 +18,8 @@ use crate::tickets::api::backends::{
 use crate::tickets::api::models::*;
 
 use super::types::{
-    JiraBackend, adf_paragraph, build_list_jql, build_search_jql, parse_comment, parse_issue,
+    JiraBackend, adf_paragraph, build_epic_issues_jql, build_list_epics_jql, build_list_jql,
+    build_milestone_issues_jql, build_search_jql, parse_comment, parse_issue,
 };
 
 #[async_trait]
@@ -333,7 +334,8 @@ impl Backend for JiraBackend {
     }
 
     async fn get_milestone_issues(&self, id: &str) -> Result<Vec<Issue>> {
-        let jql = format!("fixVersion = {id}");
+        // #6198: build via build_milestone_issues_jql so id is quoted + escaped.
+        let jql = build_milestone_issues_jql(id);
         let body = json!({ "jql": jql, "maxResults": 100 });
         let v = self.post("/search/jql", body).await?;
         let issues = v
@@ -392,7 +394,8 @@ impl Backend for JiraBackend {
     }
 
     async fn list_epics(&self) -> Result<Vec<Issue>> {
-        let jql = format!("project = \"{}\" AND issuetype = Epic", self.project_key);
+        // #6198: build via build_list_epics_jql so the project key is escaped.
+        let jql = build_list_epics_jql(&self.project_key);
         let v = self
             .post("/search/jql", json!({ "jql": jql, "maxResults": 100 }))
             .await?;
@@ -405,7 +408,8 @@ impl Backend for JiraBackend {
     }
 
     async fn get_epic_issues(&self, epic_id: &str) -> Result<Vec<Issue>> {
-        let jql = format!("parent = {epic_id}");
+        // #6198: build via build_epic_issues_jql so epic_id is quoted + escaped.
+        let jql = build_epic_issues_jql(epic_id);
         let v = self
             .post("/search/jql", json!({ "jql": jql, "maxResults": 100 }))
             .await?;

--- a/crates/trusty-common/src/tickets/api/backends/jira/mod.rs
+++ b/crates/trusty-common/src/tickets/api/backends/jira/mod.rs
@@ -9,4 +9,7 @@ mod backend;
 mod client;
 mod types;
 
+#[cfg(test)]
+mod tests;
+
 pub use types::JiraBackend;

--- a/crates/trusty-common/src/tickets/api/backends/jira/tests.rs
+++ b/crates/trusty-common/src/tickets/api/backends/jira/tests.rs
@@ -1,16 +1,21 @@
 //! JQL-injection regression tests for the JIRA backend (#6198).
 //!
-//! Why: `search_issues` / `list_issues` interpolate attacker-controlled filter
-//! values into a JQL string. An unescaped `"` breaks out of a quoted term and
-//! injects arbitrary clauses (e.g. reading issues from another project).
-//! What: exercises the pure `build_search_jql` / `build_list_jql` builders —
-//! which produce the exact `jql` string handed to the HTTP client — asserting
-//! injected quotes are escaped and legitimate values still produce correct JQL.
+//! Why: `search_issues`, `list_issues`, `get_milestone_issues`, and
+//! `get_epic_issues` interpolated attacker-controlled values into a JQL string.
+//! A `"` broke out of a quoted term; the milestone/epic terms were unquoted, so
+//! a bare `OR` clause injected with no quote-breakout at all — either way
+//! reading issues from another project.
+//! What: exercises the pure `build_*_jql` builders — which produce the exact
+//! `jql` string handed to the HTTP client — asserting injected values are
+//! quoted + escaped and legitimate values still produce correct JQL.
 //! Test: this file is the coverage.
 
 use crate::tickets::api::backends::{ListIssuesParams, SearchIssuesParams};
 
-use super::types::{build_list_jql, build_search_jql, escape_jql_string};
+use super::types::{
+    build_epic_issues_jql, build_list_epics_jql, build_list_jql, build_milestone_issues_jql,
+    build_search_jql, escape_jql_string,
+};
 
 /// A payload that, unescaped, closes the `text`/`assignee` term and appends an
 /// attacker-chosen `OR` clause reaching a project the caller cannot see.
@@ -154,5 +159,69 @@ fn list_jql_legit_values() {
         jql,
         "project = \"PROJ\" AND statusCategory = \"Done\" \
          AND assignee = \"bob\" AND labels = \"backend\" ORDER BY created DESC"
+    );
+}
+
+// ---- get_milestone_issues / get_epic_issues: UNQUOTED injection ------------
+// These terms were `fixVersion = {id}` / `parent = {epic_id}` — no surrounding
+// quotes, so an attacker needs no quote-breakout at all: a bare ` OR ` clause
+// injects directly. The fix both quotes and escapes the value.
+
+/// The critic's documented vector: a bare `OR` clause, no quote needed.
+const INJECT_UNQUOTED: &str = "1 OR project = SECRET";
+
+#[test]
+fn milestone_issues_jql_escapes_injection() {
+    let jql = build_milestone_issues_jql(INJECT_UNQUOTED);
+    assert!(
+        !jql.contains("fixVersion = 1 OR"),
+        "unquoted injection survived: {jql}"
+    );
+    assert_eq!(jql, r#"fixVersion = "1 OR project = SECRET""#);
+}
+
+#[test]
+fn milestone_issues_jql_escapes_embedded_quote() {
+    // A quote in the payload cannot break out of the newly-added quotes either.
+    let jql = build_milestone_issues_jql(r#"1" OR x = "y"#);
+    assert_eq!(jql, r#"fixVersion = "1\" OR x = \"y""#);
+}
+
+#[test]
+fn milestone_issues_jql_legit_value() {
+    assert_eq!(
+        build_milestone_issues_jql("10042"),
+        r#"fixVersion = "10042""#
+    );
+}
+
+#[test]
+fn epic_issues_jql_escapes_injection() {
+    let jql = build_epic_issues_jql(INJECT_UNQUOTED);
+    assert!(
+        !jql.contains("parent = 1 OR"),
+        "unquoted injection survived: {jql}"
+    );
+    assert_eq!(jql, r#"parent = "1 OR project = SECRET""#);
+}
+
+#[test]
+fn epic_issues_jql_escapes_embedded_quote() {
+    let jql = build_epic_issues_jql(r#"ABC-1" OR x = "y"#);
+    assert_eq!(jql, r#"parent = "ABC-1\" OR x = \"y""#);
+}
+
+#[test]
+fn epic_issues_jql_legit_value() {
+    assert_eq!(build_epic_issues_jql("ABC-123"), r#"parent = "ABC-123""#);
+}
+
+// ---- list_epics: config-only project key, escaped for uniformity -----------
+
+#[test]
+fn list_epics_jql_legit_value() {
+    assert_eq!(
+        build_list_epics_jql("PROJ"),
+        r#"project = "PROJ" AND issuetype = Epic"#
     );
 }

--- a/crates/trusty-common/src/tickets/api/backends/jira/tests.rs
+++ b/crates/trusty-common/src/tickets/api/backends/jira/tests.rs
@@ -1,0 +1,158 @@
+//! JQL-injection regression tests for the JIRA backend (#6198).
+//!
+//! Why: `search_issues` / `list_issues` interpolate attacker-controlled filter
+//! values into a JQL string. An unescaped `"` breaks out of a quoted term and
+//! injects arbitrary clauses (e.g. reading issues from another project).
+//! What: exercises the pure `build_search_jql` / `build_list_jql` builders —
+//! which produce the exact `jql` string handed to the HTTP client — asserting
+//! injected quotes are escaped and legitimate values still produce correct JQL.
+//! Test: this file is the coverage.
+
+use crate::tickets::api::backends::{ListIssuesParams, SearchIssuesParams};
+
+use super::types::{build_list_jql, build_search_jql, escape_jql_string};
+
+/// A payload that, unescaped, closes the `text`/`assignee` term and appends an
+/// attacker-chosen `OR` clause reaching a project the caller cannot see.
+const INJECT: &str = r#"foo" OR project = "SECRET"#;
+
+/// The raw breakout substring that must NOT survive escaping: `foo"` (quote
+/// immediately after `foo`, with no preceding backslash) followed by ` OR`.
+const BREAKOUT: &str = r#"foo" OR"#;
+
+/// The escaped form the fix must produce: the quote carries a leading backslash.
+const ESCAPED: &str = r#"foo\" OR"#;
+
+// ---- escape_jql_string unit coverage ---------------------------------------
+
+#[test]
+fn escape_neutralises_quote_and_backslash() {
+    // Backslash is escaped first, then the quote — order matters so the
+    // backslash escaping never doubles an already-escaped quote's backslash.
+    assert_eq!(escape_jql_string(r#"a"b\c"#), r#"a\"b\\c"#);
+}
+
+#[test]
+fn escape_handles_control_chars() {
+    assert_eq!(escape_jql_string("a\nb\r\tc"), r#"a\nb\r\tc"#);
+}
+
+#[test]
+fn escape_passes_plain_text_unchanged() {
+    assert_eq!(escape_jql_string("bug in ui"), "bug in ui");
+}
+
+// ---- search_issues: injection is neutralised -------------------------------
+
+#[test]
+fn search_jql_escapes_injected_query() {
+    let p = SearchIssuesParams {
+        query: Some(INJECT.to_string()),
+        ..Default::default()
+    };
+    let jql = build_search_jql("PROJ", &p);
+    // The injected clause must not be executable: no raw quote breakout.
+    assert!(
+        !jql.contains(BREAKOUT),
+        "raw quote breakout survived in query term: {jql}"
+    );
+    // The payload is preserved, but fully contained inside its quoted term.
+    assert!(
+        jql.contains(ESCAPED),
+        "expected escaped query term, got: {jql}"
+    );
+}
+
+#[test]
+fn search_jql_escapes_injected_assignee() {
+    let p = SearchIssuesParams {
+        assignee: Some(INJECT.to_string()),
+        ..Default::default()
+    };
+    let jql = build_search_jql("PROJ", &p);
+    assert!(!jql.contains(BREAKOUT), "assignee breakout survived: {jql}");
+    assert!(jql.contains(ESCAPED), "assignee not escaped: {jql}");
+}
+
+#[test]
+fn search_jql_escapes_injected_label() {
+    let p = SearchIssuesParams {
+        labels: vec![INJECT.to_string()],
+        ..Default::default()
+    };
+    let jql = build_search_jql("PROJ", &p);
+    assert!(!jql.contains(BREAKOUT), "label breakout survived: {jql}");
+    assert!(jql.contains(ESCAPED), "label not escaped: {jql}");
+}
+
+#[test]
+fn search_jql_escapes_injected_priority() {
+    let p = SearchIssuesParams {
+        priority: Some(INJECT.to_string()),
+        ..Default::default()
+    };
+    let jql = build_search_jql("PROJ", &p);
+    assert!(!jql.contains(BREAKOUT), "priority breakout survived: {jql}");
+    assert!(jql.contains(ESCAPED), "priority not escaped: {jql}");
+}
+
+// ---- list_issues: injection is neutralised ---------------------------------
+
+#[test]
+fn list_jql_escapes_injected_assignee() {
+    let p = ListIssuesParams {
+        assignee: Some(INJECT.to_string()),
+        ..Default::default()
+    };
+    let jql = build_list_jql("PROJ", &p);
+    assert!(!jql.contains(BREAKOUT), "assignee breakout survived: {jql}");
+    assert!(jql.contains(ESCAPED), "assignee not escaped: {jql}");
+}
+
+#[test]
+fn list_jql_escapes_injected_label() {
+    let p = ListIssuesParams {
+        labels: vec![INJECT.to_string()],
+        ..Default::default()
+    };
+    let jql = build_list_jql("PROJ", &p);
+    assert!(!jql.contains(BREAKOUT), "label breakout survived: {jql}");
+    assert!(jql.contains(ESCAPED), "label not escaped: {jql}");
+}
+
+// ---- non-regression: legitimate values produce correct JQL -----------------
+
+#[test]
+fn search_jql_legit_values() {
+    let p = SearchIssuesParams {
+        query: Some("crash".to_string()),
+        state: Some("in_progress".to_string()),
+        assignee: Some("alice".to_string()),
+        labels: vec!["ui".to_string(), "urgent".to_string()],
+        priority: Some("High".to_string()),
+        ..Default::default()
+    };
+    let jql = build_search_jql("PROJ", &p);
+    assert_eq!(
+        jql,
+        "project = \"PROJ\" AND text ~ \"crash\" \
+         AND statusCategory = \"In Progress\" AND assignee = \"alice\" \
+         AND labels = \"ui\" AND labels = \"urgent\" AND priority = \"High\""
+    );
+}
+
+#[test]
+fn list_jql_legit_values() {
+    let p = ListIssuesParams {
+        state: Some("done".to_string()),
+        assignee: Some("bob".to_string()),
+        labels: vec!["backend".to_string()],
+        ..Default::default()
+    };
+    let jql = build_list_jql("PROJ", &p);
+    assert_eq!(
+        jql,
+        "project = \"PROJ\" AND statusCategory = \"Done\" \
+         AND assignee = \"bob\" AND labels = \"backend\" ORDER BY created DESC"
+    );
+}

--- a/crates/trusty-common/src/tickets/api/backends/jira/types.rs
+++ b/crates/trusty-common/src/tickets/api/backends/jira/types.rs
@@ -11,6 +11,7 @@ use chrono::{DateTime, Utc};
 use reqwest::Client;
 use serde_json::{Value, json};
 
+use crate::tickets::api::backends::{ListIssuesParams, SearchIssuesParams};
 use crate::tickets::api::models::*;
 
 pub(super) const USER_AGENT: &str = "trusty-tickets/0.1";
@@ -105,6 +106,102 @@ pub(super) fn map_state(category: &str) -> IssueState {
         "In Progress" | "indeterminate" => IssueState::InProgress,
         _ => IssueState::Open,
     }
+}
+
+/// Map a caller-supplied state name to a fixed JQL `statusCategory` literal.
+///
+/// Why: keeps the closed set of category literals in one place, shared by the
+/// list and search JQL builders.
+/// What: matches a small closed set and returns a hard-coded, injection-safe
+/// literal — the input string is never interpolated.
+/// Test: `super::tests::search_jql_legit_values`.
+fn status_category(state: &str) -> &'static str {
+    match state {
+        "done" | "closed" => "Done",
+        "in_progress" => "In Progress",
+        _ => "To Do",
+    }
+}
+
+/// Escape a value for safe inclusion inside a JQL double-quoted string literal.
+///
+/// Why: JQL string terms are delimited by `"`; an unescaped `"` in an
+/// attacker-controlled filter value closes the term early and injects arbitrary
+/// clauses — JQL injection (#6198). Interpolating raw values is the defect.
+/// What: escapes the JQL quoted-string metacharacters — backslash FIRST (so a
+/// later quote's inserted backslash is never itself re-doubled), then the
+/// double-quote, then the control characters JQL forbids in a quoted literal
+/// (newline, carriage return, tab). The result is always one self-contained
+/// quoted term: a `"` from the caller can no longer break out of it.
+/// Test: `super::tests::escape_neutralises_quote_and_backslash`,
+/// `escape_handles_control_chars`, `escape_passes_plain_text_unchanged`.
+pub(super) fn escape_jql_string(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
+/// Build the JQL query string for `Backend::list_issues`.
+///
+/// Why: keeping construction pure makes the injection escaping directly
+/// testable — this returns exactly the `jql` string handed to the HTTP client
+/// (#6198), with no HTTP round-trip needed to verify it.
+/// What: interpolates every attacker-controlled value through
+/// `escape_jql_string`; `state` alone maps through `status_category`'s closed
+/// match to a fixed literal and is never interpolated.
+/// Test: `super::tests::list_jql_escapes_injected_assignee`,
+/// `list_jql_escapes_injected_label`, `list_jql_legit_values`.
+pub(super) fn build_list_jql(project_key: &str, p: &ListIssuesParams) -> String {
+    let mut jql = format!("project = \"{}\"", escape_jql_string(project_key));
+    if let Some(s) = &p.state {
+        jql.push_str(&format!(" AND statusCategory = \"{}\"", status_category(s)));
+    }
+    if let Some(a) = &p.assignee {
+        jql.push_str(&format!(" AND assignee = \"{}\"", escape_jql_string(a)));
+    }
+    for l in &p.labels {
+        jql.push_str(&format!(" AND labels = \"{}\"", escape_jql_string(l)));
+    }
+    jql.push_str(" ORDER BY created DESC");
+    jql
+}
+
+/// Build the JQL query string for `Backend::search_issues`.
+///
+/// Why: same as `build_list_jql` — a pure builder whose output is the exact
+/// `jql` sent to JIRA, so the escaping is unit-testable (#6198).
+/// What: escapes `query`, `assignee`, each `label`, and `priority`; `state`
+/// maps through `status_category`'s closed set to a fixed literal.
+/// Test: `super::tests::search_jql_escapes_injected_query`,
+/// `search_jql_escapes_injected_assignee`, `search_jql_escapes_injected_label`,
+/// `search_jql_escapes_injected_priority`, `search_jql_legit_values`.
+pub(super) fn build_search_jql(project_key: &str, p: &SearchIssuesParams) -> String {
+    let mut jql = format!("project = \"{}\"", escape_jql_string(project_key));
+    if let Some(q) = &p.query {
+        jql.push_str(&format!(" AND text ~ \"{}\"", escape_jql_string(q)));
+    }
+    if let Some(s) = &p.state {
+        jql.push_str(&format!(" AND statusCategory = \"{}\"", status_category(s)));
+    }
+    if let Some(a) = &p.assignee {
+        jql.push_str(&format!(" AND assignee = \"{}\"", escape_jql_string(a)));
+    }
+    for l in &p.labels {
+        jql.push_str(&format!(" AND labels = \"{}\"", escape_jql_string(l)));
+    }
+    if let Some(pri) = &p.priority {
+        jql.push_str(&format!(" AND priority = \"{}\"", escape_jql_string(pri)));
+    }
+    jql
 }
 
 /// Convert a JIRA issue JSON blob into the canonical `Issue`.

--- a/crates/trusty-common/src/tickets/api/backends/jira/types.rs
+++ b/crates/trusty-common/src/tickets/api/backends/jira/types.rs
@@ -204,6 +204,47 @@ pub(super) fn build_search_jql(project_key: &str, p: &SearchIssuesParams) -> Str
     jql
 }
 
+/// Build the JQL for `Backend::get_milestone_issues`.
+///
+/// Why: `id` arrives from the MCP `milestone_id` string arg — an attacker trust
+/// boundary. The prior `fixVersion = {id}` was UNQUOTED and unescaped, so
+/// `id = "1 OR project = SECRET"` needed no quote-breakout at all — the bare
+/// `OR` clause injected directly and read another project's issues (#6198).
+/// What: wraps the value in quotes AND escapes it, so it is one self-contained
+/// JQL string literal a `"` cannot break out of.
+/// Test: `super::tests::milestone_issues_jql_escapes_injection`,
+/// `milestone_issues_jql_escapes_embedded_quote`, `milestone_issues_jql_legit_value`.
+pub(super) fn build_milestone_issues_jql(id: &str) -> String {
+    format!("fixVersion = \"{}\"", escape_jql_string(id))
+}
+
+/// Build the JQL for `Backend::get_epic_issues`.
+///
+/// Why: `epic_id` arrives from the MCP `epic_id` string arg — attacker
+/// controlled. The prior `parent = {epic_id}` was unquoted and unescaped,
+/// injectable exactly like `build_milestone_issues_jql` (#6198).
+/// What: quotes and escapes the value into one JQL string literal.
+/// Test: `super::tests::epic_issues_jql_escapes_injection`,
+/// `epic_issues_jql_escapes_embedded_quote`, `epic_issues_jql_legit_value`.
+pub(super) fn build_epic_issues_jql(epic_id: &str) -> String {
+    format!("parent = \"{}\"", escape_jql_string(epic_id))
+}
+
+/// Build the JQL for `Backend::list_epics`.
+///
+/// Why: uniformity — `project_key` is config-derived (JIRA_PROJECT_KEY), not an
+/// attacker vector, but routing it through `escape_jql_string` keeps every JQL
+/// term in this file escaped so a later edit cannot reintroduce a raw one (#6198).
+/// What: escapes the project key inside its quoted term; the issuetype clause is
+/// a fixed literal.
+/// Test: `super::tests::list_epics_jql_legit_value`.
+pub(super) fn build_list_epics_jql(project_key: &str) -> String {
+    format!(
+        "project = \"{}\" AND issuetype = Epic",
+        escape_jql_string(project_key)
+    )
+}
+
 /// Convert a JIRA issue JSON blob into the canonical `Issue`.
 ///
 /// Why: Decouples JSON shape knowledge from the Backend impl methods.


### PR DESCRIPTION
JQL injection where attacker-controlled filter values were interpolated raw into JQL. All five JQL-building sites in the Jira backend now route values through a single `escape_jql_string` helper — code-critic found and the fix closed 4 injection sites total (2 cited in the original report, 2 more found in review), plus 1 config-value escape as defense-in-depth.

Rung 3, injection-defense class, so code-critic APPROVE was required and given (two rounds). 20 jira tests pass; `cargo test -p trusty-common --features tickets` green. Changelog fragment included (`crates/trusty-common/changelog.d/6198-jira-jql-injection.md`).

**NOTE:** `get_milestone_issues` now quotes the numeric `fixVersion` id. Some Jira deployments treat a quoted number as a version name rather than id — the quote is required for the fix, so if numeric-ID milestone lookups regress, the remedy is a separate id→name change, not unquoting. Flagged for the owner to confirm against a live instance.

Refs #6198

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
