### PR TITLE
fix(trusty-common): make PalaceHandle drawer-load degrade observable

### DIFF
--- a/crates/trusty-common/changelog.d/6201-drawer-load-degraded-signal.md
+++ b/crates/trusty-common/changelog.d/6201-drawer-load-degraded-signal.md
@@ -1,0 +1,14 @@
+Fixed
+
+- `PalaceHandle` now records when its drawer table loaded incompletely (#6201).
+  When `open_with_intent` fails open on drawer-load trouble the palace still
+  opens, but the returned handle was previously indistinguishable from a
+  genuinely-empty or fully-loaded palace, so a caller had no signal it was
+  missing corpus. The new `PalaceHandle::drawer_load_degraded` field is `true`
+  whenever any drawer row failed to load — both the whole-table Err path (empty
+  fallback) and the more common per-row-skip path, where `load_drawers` drops an
+  undecodable row (bad key, malformed value, invalid room_id/timestamp) and
+  returns the rest. `KnowledgeGraph::load_drawers_with_skipped` threads the
+  skipped-row count out for the open to see; `load_drawers` keeps its bare
+  `Vec<Drawer>` return, and the existing per-row and whole-table `warn!` logs are
+  kept.

--- a/crates/trusty-common/src/memory_core/retrieval/handle.rs
+++ b/crates/trusty-common/src/memory_core/retrieval/handle.rs
@@ -70,6 +70,27 @@ pub struct PalaceHandle {
     pub vector_store: Arc<UsearchStore>,
     pub kg: Arc<KnowledgeGraph>,
     pub drawers: Arc<RwLock<Vec<Drawer>>>,
+    /// Whether any persisted drawer row failed to load, so this handle is
+    /// serving a degraded (incomplete) view of the palace.
+    ///
+    /// Why: #6201 — `open_with_intent` deliberately fails open on drawer-load
+    /// trouble so the palace still opens instead of becoming unopenable. Two
+    /// paths degrade the corpus: the whole `DRAWERS` table failing to open
+    /// (empty fallback), and individual rows being skipped as unreadable while
+    /// the rest load (partial fallback — the more common corruption case). Both
+    /// left the resulting handle indistinguishable from a genuinely empty or
+    /// complete palace, so a caller had no signal it was missing corpus. This
+    /// flag is that signal.
+    /// What: `true` whenever a drawer row failed to load — the whole-table Err
+    /// arm OR a per-row skip (`load_drawers_with_skipped` reporting `skipped >
+    /// 0`) in `open_with_intent`. `false` on a fully successful load (a
+    /// legitimately empty table included) and for in-memory handles built via
+    /// `new`. The `warn!` logs on both paths are kept — this is the structured
+    /// twin, not a replacement.
+    /// Test: `drawer_load_degraded_true_on_corrupt_table_false_when_empty`
+    /// (whole-table) and `drawer_load_degraded_true_on_partial_row_corruption`
+    /// (per-row skip).
+    pub drawer_load_degraded: bool,
     /// On-disk data directory for this palace (where palace.json,
     /// identity.txt, l1_cache.json, the usearch index, and the KG redb
     /// store all live). `None` for in-memory tests built via `new`.
@@ -219,6 +240,9 @@ impl PalaceHandle {
             vector_store: Arc::new(vector_store),
             kg: Arc::new(kg),
             drawers: Arc::new(RwLock::new(Vec::new())),
+            // #6201: an in-memory handle never loaded a persisted table, so it
+            // is empty-by-construction, not degraded.
+            drawer_load_degraded: false,
             data_dir: None,
             decay_config: DecayConfig::default(),
             recall_log: None,
@@ -316,9 +340,26 @@ impl PalaceHandle {
         // Load full drawer table from redb (the persistent source of truth).
         // Fall back to an empty list on error so a corrupt table doesn't make
         // the palace unopenable — the L1 snapshot still provides essentials.
-        let persisted_drawers = match kg.load_drawers() {
-            Ok(d) => d,
+        // #6201: record the degrade on the handle so a caller can tell a
+        // corrupt-table fallback apart from a genuinely empty palace, instead
+        // of silently running L1-only. Both degrade paths set the flag: a
+        // whole-table Err (empty fallback) AND a partial load where individual
+        // rows were skipped as unreadable (`load_drawers_with_skipped` counts
+        // them; the per-row warns stay inside that call).
+        let mut drawer_load_degraded = false;
+        let persisted_drawers = match kg.load_drawers_with_skipped() {
+            Ok((d, skipped)) => {
+                if skipped > 0 {
+                    drawer_load_degraded = true;
+                    tracing::warn!(
+                        palace = %palace.id, skipped,
+                        "load_drawers skipped unreadable rows; corpus is degraded (partial)"
+                    );
+                }
+                d
+            }
             Err(e) => {
+                drawer_load_degraded = true;
                 tracing::warn!(palace = %palace.id, "load_drawers failed, falling back to L1 only: {e:#}");
                 Vec::new()
             }
@@ -408,6 +449,7 @@ impl PalaceHandle {
             vector_store: Arc::new(vector_store),
             kg: Arc::new(kg),
             drawers,
+            drawer_load_degraded,
             data_dir: Some(data_dir.clone()),
             decay_config: DecayConfig::default(),
             recall_log,

--- a/crates/trusty-common/src/memory_core/retrieval/tests.rs
+++ b/crates/trusty-common/src/memory_core/retrieval/tests.rs
@@ -342,6 +342,160 @@ async fn forget_reports_deleted_and_the_drawer_stays_gone_after_reopen() {
     );
 }
 
+/// Regression test for issue #6201: a corrupt drawer table must surface as a
+/// degraded signal on the handle, not silently masquerade as an empty palace.
+///
+/// Why: `open_with_intent` deliberately fails open when `load_drawers` errors,
+/// substituting an empty list so a corrupt table can't make the palace
+/// unopenable. Before #6201 the returned handle was indistinguishable from one
+/// for a genuinely empty palace, so a caller had no signal it was running
+/// L1-only. `PalaceHandle::drawer_load_degraded` is that signal.
+/// What: forces the `load_drawers` Err arm deterministically without breaking
+/// the rest of the KG open. A fully-formed `kg.redb` is created (every table
+/// initialised), then only the `DRAWERS` table is dropped and the file's
+/// exclusive flock is held — so the ReadOnlyClient palace open falls back to a
+/// snapshot of that drawers-less image (`concurrent_open::OpenMode::Snapshot`,
+/// which skips the whole-schema re-init). Adjacency hydration still succeeds
+/// because `TRIPLES` and the rest survive, but `load_drawers` opens a read txn
+/// on a `DRAWERS` table that no longer exists and returns Err. Asserts the
+/// snapshot path was actually taken (anti-vacuous guard via `is_read_only`),
+/// that the degraded handle exposes `drawer_load_degraded == true`, and that a
+/// genuinely-empty-but-valid palace exposes it as `false`.
+/// Test: this test.
+#[test]
+fn drawer_load_degraded_true_on_corrupt_table_false_when_empty() {
+    use crate::memory_core::store::kg_redb::KgStoreRedb;
+    use crate::memory_core::store::kg_store::DRAWERS;
+    use redb::Database;
+
+    let dir = tempdir().unwrap();
+
+    // --- Degraded case: load_drawers Err -> the handle flags the degrade. ---
+    let degraded_palace = Palace {
+        id: PalaceId::new("degraded-corrupt"),
+        name: "degraded".into(),
+        description: None,
+        created_at: chrono::Utc::now(),
+        data_dir: dir.path().join("degraded-corrupt"),
+    };
+    std::fs::create_dir_all(&degraded_palace.data_dir).unwrap();
+
+    let kg_redb = degraded_palace.data_dir.join("kg.redb");
+    // Initialise the full KG schema (every table), then release the file.
+    drop(KgStoreRedb::open(&kg_redb).expect("init full kg.redb schema"));
+    // Remove ONLY the drawers table, then hold the exclusive flock so the next
+    // open cannot re-init it and must snapshot this drawers-less image instead.
+    let live = Database::create(&kg_redb).expect("reopen kg.redb and hold its flock");
+    {
+        let wtx = live
+            .begin_write()
+            .expect("begin write to drop drawers table");
+        wtx.delete_table(DRAWERS).expect("delete drawers table");
+        wtx.commit().expect("commit drawers-table removal");
+    }
+
+    let degraded =
+        PalaceHandle::open(&degraded_palace).expect("palace must still open when degraded");
+    assert!(
+        degraded.is_read_only(),
+        "anti-vacuous guard: the open must have fallen back to a snapshot, otherwise \
+         the load_drawers Err arm is never reached and this test proves nothing"
+    );
+    assert!(
+        degraded.drawer_load_degraded,
+        "an unreadable drawer table must set drawer_load_degraded on the handle"
+    );
+    drop(live);
+
+    // --- Empty-but-valid case: load succeeds -> the flag stays false. ---
+    let (_palace, empty) = open_disk_palace(dir.path(), "empty-valid");
+    assert!(
+        empty.drawers.read().is_empty(),
+        "precondition: a freshly-created palace has no drawers"
+    );
+    assert!(
+        !empty.drawer_load_degraded,
+        "a genuinely empty but valid palace must NOT be flagged as degraded"
+    );
+}
+
+/// Regression test for issue #6201 (partial corruption): a drawer table that
+/// loads SOME rows but skips others as unreadable must flag the handle degraded.
+///
+/// Why: `load_drawers` skips a row it cannot decode (non-16-byte key, malformed
+/// value, invalid room_id/created_at) with only a `warn!` and returns the rest
+/// as `Ok`. That is the more common corruption case, and before the #6201
+/// completeness fix it took `open_with_intent`'s Ok arm and left
+/// `drawer_load_degraded == false` — a consumer reading the flag would trust a
+/// partial corpus as complete. The load now threads a skipped-row count out
+/// (`load_drawers_with_skipped`) so the open flags the degrade on this path too.
+/// What: seeds one intact drawer row, then injects a second `DRAWERS` row with a
+/// valid 16-byte key but an undecodable value. A normal read-write open must
+/// return the intact row AND report `drawer_load_degraded == true`. The
+/// `is_read_only` guard confirms this exercises the partial-load (Ok) arm, not
+/// the whole-table snapshot path the sibling test covers.
+/// Test: this test.
+#[test]
+fn drawer_load_degraded_true_on_partial_row_corruption() {
+    use crate::memory_core::store::kg_redb::KgStoreRedb;
+    use crate::memory_core::store::kg_store::DRAWERS;
+    use redb::Database;
+
+    let dir = tempdir().unwrap();
+    let palace = Palace {
+        id: PalaceId::new("partial-corrupt"),
+        name: "partial".into(),
+        description: None,
+        created_at: chrono::Utc::now(),
+        data_dir: dir.path().join("partial-corrupt"),
+    };
+    std::fs::create_dir_all(&palace.data_dir).unwrap();
+    let kg_redb = palace.data_dir.join("kg.redb");
+
+    // One intact, round-trippable drawer row.
+    let good = Drawer::new(Uuid::new_v4(), "a genuinely valid intact drawer row");
+    let good_id = good.id;
+    {
+        let store = KgStoreRedb::open(&kg_redb).expect("open kg store to seed a good row");
+        store.upsert_drawer(&good).expect("write the good drawer");
+    }
+
+    // A second DRAWERS row: valid 16-byte key, but a value that cannot decode
+    // as a DrawerRecord — load_drawers skips it with a warn.
+    {
+        let db = Database::create(&kg_redb).expect("reopen kg.redb to inject a corrupt row");
+        let wtx = db.begin_write().expect("begin write for corrupt row");
+        {
+            let mut table = wtx.open_table(DRAWERS).expect("open drawers table");
+            let bad_key = Uuid::new_v4().into_bytes();
+            table
+                .insert(bad_key.as_slice(), [0xFFu8; 4].as_slice())
+                .expect("insert malformed drawer value");
+        }
+        wtx.commit().expect("commit corrupt row");
+    }
+
+    // A normal (read-write) open: the good row loads, the corrupt row is
+    // skipped, and the skip must surface as a degrade on the handle.
+    let handle = PalaceHandle::open(&palace).expect("palace opens with a partially-corrupt table");
+    assert!(
+        !handle.is_read_only(),
+        "anti-vacuous guard: this must be a normal read-write open, not the snapshot \
+         path — otherwise it does not exercise the partial-load (Ok) arm"
+    );
+    let loaded: Vec<Uuid> = handle.drawers.read().iter().map(|d| d.id).collect();
+    assert_eq!(
+        loaded,
+        vec![good_id],
+        "the intact row must still load even though a sibling row was unreadable"
+    );
+    assert!(
+        handle.drawer_load_degraded,
+        "a skipped (unreadable) drawer row must set drawer_load_degraded — a partial \
+         load is a degrade, not a clean empty/complete palace"
+    );
+}
+
 /// Regression test for issue #154: concurrent `remember_with_options`
 /// calls on the same palace must not race on the L1 snapshot write.
 ///

--- a/crates/trusty-common/src/memory_core/store/kg/ops.rs
+++ b/crates/trusty-common/src/memory_core/store/kg/ops.rs
@@ -249,6 +249,19 @@ impl KnowledgeGraph {
         self.store.load_drawers()
     }
 
+    /// Load all drawer metadata, reporting how many rows were unreadable.
+    ///
+    /// Why: #6201 — `open_with_intent` must flag a handle as degraded when a
+    /// partially-corrupt drawer table loads fewer rows than it holds, not only
+    /// when the whole table fails to open.
+    /// What: Delegates to `KgStoreRedb::load_drawers_with_skipped`, returning
+    /// `(rows, skipped)`.
+    /// Test: `drawer_load_degraded_true_on_partial_row_corruption` in
+    /// `retrieval::tests`.
+    pub fn load_drawers_with_skipped(&self) -> Result<(Vec<Drawer>, usize)> {
+        self.store.load_drawers_with_skipped()
+    }
+
     /// Identify community-shaped knowledge gaps in the active graph.
     ///
     /// Why: Convenience accessor so callers don't need to import the

--- a/crates/trusty-common/src/memory_core/store/kg_redb/read_ops.rs
+++ b/crates/trusty-common/src/memory_core/store/kg_redb/read_ops.rs
@@ -248,18 +248,40 @@ impl KgStoreRedb {
     ///
     /// Why: Cold-start retrieval needs the full drawer table to map every HNSW
     /// vector hit back to metadata.
-    /// What: Iterate DRAWERS, decode each `DrawerRecord` back into a `Drawer`.
-    /// Rows with malformed UUID/timestamp are skipped with a warning.
+    /// What: Thin wrapper over [`load_drawers_with_skipped`] that drops the
+    /// skipped-row count. Callers that only want the rows (e.g. `kg_rebuild`,
+    /// `backfill_report`) keep a bare `Vec<Drawer>` return.
     /// Test: `upsert_drawer_then_load_drawers_round_trips`.
     pub fn load_drawers(&self) -> Result<Vec<Drawer>> {
+        Ok(self.load_drawers_with_skipped()?.0)
+    }
+
+    /// Load all drawers, reporting how many rows were skipped as unreadable.
+    ///
+    /// Why: #6201 — a per-row decode failure (non-16-byte key, malformed value,
+    /// invalid room_id, invalid created_at_ms) is skipped with a warn and the
+    /// remaining rows returned, so a partially-corrupt table silently loads as
+    /// a smaller corpus. `load_drawers` alone cannot tell a caller that
+    /// happened. Threading the skip count out lets `PalaceHandle::open_with_intent`
+    /// flag the handle as degraded on the partial-load path too, not only on the
+    /// whole-table Err path.
+    /// What: Iterate DRAWERS, decode each `DrawerRecord` back into a `Drawer`;
+    /// each unreadable row increments `skipped` (keeping its existing warn) and
+    /// is dropped. Returns `(rows, skipped)`.
+    /// Test: `drawer_load_degraded_true_on_corrupt_table_false_when_empty`
+    /// (whole-table Err) and `drawer_load_degraded_true_on_partial_row_corruption`
+    /// (per-row skip), both in `retrieval::tests`.
+    pub fn load_drawers_with_skipped(&self) -> Result<(Vec<Drawer>, usize)> {
         let rtx = self.db().begin_read().context("begin load_drawers txn")?;
         let drawers = rtx.open_table(DRAWERS).context("open drawers table")?;
         let mut out = Vec::new();
+        let mut skipped = 0usize;
         for entry in drawers.iter().context("iter drawers")? {
             let (k, v) = entry.context("read drawer row")?;
             let id_bytes = k.value();
             if id_bytes.len() != 16 {
                 tracing::warn!(len = id_bytes.len(), "skip drawer with non-16-byte id key");
+                skipped += 1;
                 continue;
             }
             let mut id_arr = [0u8; 16];
@@ -272,6 +294,7 @@ impl KgStoreRedb {
                 Ok(r) => r,
                 Err(e) => {
                     tracing::warn!(id = %id, "skip drawer with malformed value: {e}");
+                    skipped += 1;
                     continue;
                 }
             };
@@ -279,6 +302,7 @@ impl KgStoreRedb {
                 Ok(u) => u,
                 Err(e) => {
                     tracing::warn!(id = %id, "skip drawer with invalid room_id: {e}");
+                    skipped += 1;
                     continue;
                 }
             };
@@ -286,6 +310,7 @@ impl KgStoreRedb {
                 Some(dt) => dt,
                 None => {
                     tracing::warn!(id = %id, "skip drawer with invalid created_at_ms");
+                    skipped += 1;
                     continue;
                 }
             };
@@ -314,7 +339,7 @@ impl KgStoreRedb {
             drawer.fact_key = record.fact_key;
             out.push(drawer);
         }
-        Ok(out)
+        Ok((out, skipped))
     }
 
     /// Load just the set of drawer IDs.


### PR DESCRIPTION
A corrupt drawer table (whole-table load error) OR any per-row skip (bad key, malformed value, invalid room_id, invalid timestamp) silently degraded the palace to a reduced drawer set with only a `warn!`, indistinguishable from a genuinely empty palace. A new `pub drawer_load_degraded` flag on `PalaceHandle` now signals both degrade paths (whole-table `Err` and per-row skip via `load_drawers_with_skipped`), staying `false` only on genuine-empty and full success.

Additive `pub` field, non-breaking: `load_drawers`'s signature is unchanged and both `trusty-memory` callers are untouched.

Rung 5 (persistence + fail-open) — code-critic APPROVE after a round-1 BLOCK that caught the per-row path needing the same coverage as the whole-table path.

Gates green:
- 2 new regression tests: whole-table corruption + partial-row corruption
- `cargo test -p trusty-common --features memory-core,embedder-test-support` — 1134 passed, 0 failed, 13 ignored
- `cargo check --workspace` — clean
- `cargo test -p trusty-memory` — 811 passed, 0 failed, 4 ignored
- Changelog fragment: `crates/trusty-common/changelog.d/6201-drawer-load-degraded-signal.md`

Refs #6201

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools