### PR TITLE
docs(trusty-common): fix two broken intra-doc links failing the pre-publish gate

### DIFF
--- a/crates/trusty-common/changelog.d/pre-publish-doc-links.md
+++ b/crates/trusty-common/changelog.d/pre-publish-doc-links.md
@@ -1,0 +1,10 @@
+Fixed
+
+- Two broken intra-doc links that failed the pre-publish rustdoc gate
+  (`scripts/check_rustdoc_links.sh`): `secret::check_secret`'s doc comment
+  pointed at `[\`FilterConfig::apply\`]` without `FilterConfig` in scope, and
+  `KgStoreRedb::load_drawers`'s doc comment pointed at
+  `[\`load_drawers_with_skipped\`]` without the `Self::` qualifier its sibling
+  method needs. Both now resolve — the first via the fully-qualified path
+  `crate::memory_core::filter::FilterConfig::apply`, the second via
+  `Self::load_drawers_with_skipped`.

--- a/crates/trusty-common/src/memory_core/filter/secret.rs
+++ b/crates/trusty-common/src/memory_core/filter/secret.rs
@@ -76,7 +76,8 @@ pub fn find_secret_token(content: &str) -> Option<String> {
 /// ratio) but must never bypass secret detection — otherwise an automated
 /// writer that always passes `force: true` (e.g. trusty-code's per-turn
 /// recorder) would persist raw credentials with zero screening. Extracting
-/// this single-purpose check out of [`FilterConfig::apply`] lets
+/// this single-purpose check out of
+/// [`crate::memory_core::filter::FilterConfig::apply`] lets
 /// `PalaceHandle::remember_with_options` call it on its own when `force` is
 /// set but the caller has NOT also set the explicit `allow_secret_like`
 /// opt-in.

--- a/crates/trusty-common/src/memory_core/store/kg_redb/read_ops.rs
+++ b/crates/trusty-common/src/memory_core/store/kg_redb/read_ops.rs
@@ -248,7 +248,7 @@ impl KgStoreRedb {
     ///
     /// Why: Cold-start retrieval needs the full drawer table to map every HNSW
     /// vector hit back to metadata.
-    /// What: Thin wrapper over [`load_drawers_with_skipped`] that drops the
+    /// What: Thin wrapper over [`Self::load_drawers_with_skipped`] that drops the
     /// skipped-row count. Callers that only want the rows (e.g. `kg_rebuild`,
     /// `backfill_report`) keep a bare `Vec<Drawer>` return.
     /// Test: `upsert_drawer_then_load_drawers_round_trips`.


### PR DESCRIPTION
Two broken intra-doc links in trusty-common (`FilterConfig::apply` in filter/secret.rs, `load_drawers_with_skipped` in kg_redb/read_ops.rs, from the #6199/#6201 code moves) failed the pre-publish gate's cargo-doc broken-intra-doc-links check. Fixed to a fully-qualified path and `Self::` respectively. Verified with `scripts/check_rustdoc_links.sh` — 0 broken links workspace-wide.

This gate runs only on push to main (never on PRs), so the PR pipeline can't catch it — the fix's real proof is the local gate run plus the pre-publish gate going green on main after merge.

Changelog fragment included.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools