### PR TITLE
chore(trusty-memory): bump to 0.24.0 — CHECK 5 semver break, minor position

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11651,7 +11651,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-memory"
-version = "0.23.2"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-agents/Cargo.toml
+++ b/crates/trusty-agents/Cargo.toml
@@ -66,7 +66,7 @@ trusty-common = { workspace = true, features = ["symgraph-parser", "memory-core"
 #      `default-features = false` drops the `axum-server` feature so we don't
 #      compile the trusty-memory HTTP daemon code paths just to pick up a
 #      zero-sized service descriptor.
-trusty-memory = { path = "../trusty-memory", version = "0.23", default-features = false }
+trusty-memory = { path = "../trusty-memory", version = "0.24", default-features = false }
 trusty-search = { path = "../trusty-search", version = "0.49" }
 # Gmail/Calendar eventstream listeners (#3820, DOC-54 SPEC-AGENTS-06) call
 # trusty-gworkspace's connector layer (`api::client::BaseClient` +

--- a/crates/trusty-memory/Cargo.toml
+++ b/crates/trusty-memory/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "trusty-memory"
-# #4421: patch bump — 0.23.0 already published on crates.io and this PR
-# touches src/**. Every hunk is a doc-comment edit (module docs moved to the
-# inner `//!` standard, #5754) — no item signature or behavior changed.
-version = "0.23.2"
+# CHECK 5 semver break at 9fe56f1ca: commits 82366ef2d (#5811/#5831) and
+# 3c9fa3ee8 (#6024) removed find_project_root, ProjectPin, and four
+# project_root consts from the public surface. Cargo's 0.x rule puts a
+# breaking change in the MINOR position, so the bump lands here, not patch.
+version = "0.24.0"
 edition = "2021"
 description = "MCP server (stdio + HTTP/SSE) for trusty-memory"
 license.workspace = true


### PR DESCRIPTION
## Summary

`scripts/preflight-publish.sh` CHECK 5 (`cargo-semver-checks`) at `9fe56f1ca` failed against published trusty-memory 0.23.1:

```
Checked 196 checks: 193 pass, 3 fail, 0 warn, 58 skip
--- function_missing --- trusty_memory::project_root::find_project_root — removed
--- struct_missing    --- trusty_memory::project_root::ProjectPin — removed
--- pub_module_level_const_missing --- TRUSTY_TOOLS_DIR, PIN_FILE_REL, PROJECT_MARKERS, PIN_SCHEMA_VERSION
Summary: 3 major and 0 minor checks failed
```

`82366ef2d` (#5811/#5831) and `3c9fa3ee8` (#6024) reshaped `crates/trusty-memory/src/project_root/`, dropping those symbols from the public surface. Cargo's 0.x rule puts a breaking change in the MINOR position, so 0.23.2 (already at `9fe56f1ca`) is the wrong number for this content — this PR bumps to 0.24.0. No API change: only the declared version and one cross-crate pin move.

- `crates/trusty-memory/Cargo.toml`: `version = "0.23.2"` → `"0.24.0"`
- `crates/trusty-agents/Cargo.toml`: path-dependency pin `trusty-memory = { version = "0.23", ... }` → `"0.24"` — the only other workspace manifest declaring a version requirement on trusty-memory
- `Cargo.lock` updated via `cargo check -p trusty-memory`

## Test plan

- Rung 1 (version/manifest-only change, no crate `src/**` touched)
- `cargo check -p trusty-memory` — EXIT=0
- `cargo check -p trusty-agents` — EXIT=0 (dependent crate resolves against the new pin)
- `bash scripts/check_changelog_fragment.sh` — EXIT=0: "no crate source changed (docs-only / CI-only / test-only) — OK" (no fragment owed)
- `bash scripts/check_semver.sh --crate trusty-memory` — confirms 0.23.1 -> 0.24.0 is already a breaking release with exactly the 3 expected lints (advisory, gate reports OK)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools