### PR TITLE
feat(trusty-mpm): a prune selector for records with no resolvable workspace (Refs #6118)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11694,7 +11694,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-mpm"
-version = "1.4.4"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-mpm"
-version = "1.4.4"
+version = "1.5.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/trusty-mpm/changelog.d/6118-prune-never-takes-the-invoker.md
+++ b/crates/trusty-mpm/changelog.d/6118-prune-never-takes-the-invoker.md
@@ -1,0 +1,7 @@
+Fixed
+
+- No prune path can select the session it was invoked from. The CLI now sends
+  `$TM_MANAGED_SESSION_ID` as `invoking_session`, and the prune engine excludes
+  that record for every filter, `--include-active` included. A present but
+  unparseable value is rejected with 400 rather than dropped, so the sweep never
+  runs with the self-exclusion silently switched off.

--- a/crates/trusty-mpm/changelog.d/6118-unresolvable-prune-selector.md
+++ b/crates/trusty-mpm/changelog.d/6118-unresolvable-prune-selector.md
@@ -1,0 +1,23 @@
+Added
+
+- `tm session prune --state unresolvable` selects managed records that name no
+  resolvable workspace — `cwd` is the `/unknown` sentinel and there is no
+  `workspace_path`
+  (refs [#6118](https://github.com/bobmatnyc/trusty-tools/issues/6118)).
+  These are the adoption ghosts #6126 stopped minting; nothing could select the
+  ones already in the store. On the reporting host 23 of them sat `Active`:
+  every existing `--state` value selected 0, `prune-idle` skipped all 23 on an
+  `errored` verdict, and the only command that reached them — `--state all
+  --include-active` — also selected 32 healthy working sessions including the
+  operator's own. The new filter is the one selector whose choice ignores tmux
+  liveness, because a live pane is what made the class unreachable; it needs no
+  `--include-active` and is not widened by it. Such a record has no
+  `workspace_path`, so this path can delete no file: it reclaims the leaked pane
+  and the store row. Two records sharing one pane (the #6117 race) are both
+  tombstoned in one pass.
+- `tm session decommission-ephemeral --dry-run` previews the sweep instead of
+  performing it. Preview and real sweep are one call differing in one boolean, so
+  they cannot select different sets. The daemon echoes `dry_run` and the CLI
+  refuses to report a preview the daemon did not confirm — a daemon predating
+  this change drops the unknown query param and sweeps for real while still
+  returning 200.

--- a/crates/trusty-mpm/src/bin/tm/cli/actions/session.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli/actions/session.rs
@@ -405,9 +405,17 @@ pub(crate) enum SessionAction {
     /// one-shot "clean up all my throwaway sessions" verb. REAL sessions default
     /// `ephemeral=false` and are unreachable, so durable work is never harmed.
     /// What: POSTs `/api/v1/sessions/managed/decommission-ephemeral` and prints the
-    /// count torn down.
-    /// Test: `cli_parses_session_decommission_ephemeral`.
-    DecommissionEphemeral,
+    /// count torn down. `--dry-run` (#6118) previews that same selection without
+    /// tearing anything down — one call, one boolean, so the preview and the
+    /// real sweep cannot disagree about what they picked.
+    /// Test: `cli_parses_session_decommission_ephemeral`,
+    /// `cli_parses_session_decommission_ephemeral_dry_run`.
+    DecommissionEphemeral {
+        /// Report which ephemeral sessions WOULD be torn down, without
+        /// stopping, removing, or tombstoning any of them.
+        #[arg(long)]
+        dry_run: bool,
+    },
     /// Print a cross-format catch-up digest for paused sessions (DOC-28 cutover bridge).
     ///
     /// Why: during migration from claude-mpm to trusty-mpm, paused sessions may
@@ -441,9 +449,20 @@ pub(crate) enum SessionAction {
     /// fail-closed default never touches a RUNNING session.
     /// What: POSTs `/api/v1/sessions/managed/prune` with the `--state` filter;
     /// `--dry-run` reports what WOULD be pruned without mutating.
-    /// Test: `cli_parses_session_prune`.
+    ///
+    /// `--state unresolvable` (#6118) is the targeted cleanup for adoption
+    /// ghosts: records naming no resolvable workspace (`cwd` is the `/unknown`
+    /// sentinel and no `workspace_path`), which every other filter missed
+    /// because their own live panes held them immune. It needs no
+    /// `--include-active` and is not widened by it — 23 such records were
+    /// measured on one host where `--state all --include-active` was the only
+    /// command that reached them, and it also selected 32 healthy working
+    /// sessions. Such a record has no workspace, so this can delete no file: it
+    /// reclaims the leaked pane and the store row.
+    /// Test: `cli_parses_session_prune`, `cli_parses_session_prune_unresolvable`.
     Prune {
-        /// Which records to target: `ephemeral` | `stopped` | `decommissioned` | `deleted` | `all`.
+        /// Which records to target: `ephemeral` | `stopped` | `decommissioned` |
+        /// `deleted` | `all` | `unresolvable`.
         #[arg(long)]
         state: String,
         /// Report what WOULD be pruned without killing, removing, or tombstoning

--- a/crates/trusty-mpm/src/bin/tm/commands/managed.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed.rs
@@ -606,25 +606,68 @@ pub(crate) async fn session_decommission(
 /// unreachable, so durable work is never harmed.
 /// What: POSTs `/api/v1/sessions/managed/decommission-ephemeral` and prints the
 /// returned `decommissioned` count.
+///
+/// 🔴 #6118: under `--dry-run` the daemon's echoed `dry_run` is CHECKED, not
+/// trusted. A daemon predating that route change has no `Query<EphemeralQuery>`
+/// extractor, so axum drops the param, the sweep really runs, and the response
+/// is still a 200 carrying a count — indistinguishable from an honoured preview
+/// by status alone. A missing or `false` echo is therefore an error, not a
+/// warning: reporting "would decommission N" for a teardown that already
+/// happened is worse than failing. Same skew and the same remedy as
+/// `session_picker_prune::decommission_dead_record`'s `workspace_removed`
+/// check.
 /// Test: HTTP path covered by `decommission_ephemeral_route_tears_down_only_ephemeral`
-/// in tests/session_manager_mvp.rs; CLI parse by `cli_parses_session_decommission_ephemeral`.
+/// in tests/session_manager_mvp.rs; CLI parse by `cli_parses_session_decommission_ephemeral`;
+/// the skew refusal by `decommission_ephemeral_refuses_a_dry_run_a_stale_daemon_ignored`.
 pub(crate) async fn session_decommission_ephemeral(
     client: &reqwest::Client,
     url: &str,
+    dry_run: bool,
 ) -> anyhow::Result<()> {
     let resp = client
         .post(format!(
             "{url}/api/v1/sessions/managed/decommission-ephemeral"
         ))
+        .query(&[("dry_run", if dry_run { "true" } else { "false" })])
         .send()
         .await?;
     let body: serde_json::Value = resp.error_for_status()?.json().await?;
+    println!("{}", ephemeral_sweep_line(&body, dry_run)?);
+    Ok(())
+}
+
+/// Render one `decommission-ephemeral` response, refusing a dry run the daemon
+/// did not confirm (#6118).
+///
+/// Why: extracted so the version-skew refusal is directly assertable. Inline in
+/// the HTTP function it could only be reached through a live daemon, which is
+/// exactly the daemon a test cannot build an OLD version of.
+/// What: `Err` when `dry_run` was requested and the body's `dry_run` is not
+/// `true`; otherwise the operator line, which says "would decommission" for a
+/// confirmed preview and "decommissioned" for a real sweep. A real sweep does
+/// not check the echo — an older daemon's real teardown is what it asked for.
+/// Test: `decommission_ephemeral_refuses_a_dry_run_a_stale_daemon_ignored`,
+/// `decommission_ephemeral_reports_a_confirmed_dry_run`.
+pub(crate) fn ephemeral_sweep_line(
+    body: &serde_json::Value,
+    dry_run: bool,
+) -> anyhow::Result<String> {
     let count = body
         .get("decommissioned")
         .and_then(serde_json::Value::as_u64)
         .unwrap_or(0);
-    println!("decommissioned {count} ephemeral session(s)");
-    Ok(())
+    if dry_run && body.get("dry_run").and_then(serde_json::Value::as_bool) != Some(true) {
+        return Err(anyhow::anyhow!(
+            "the daemon did not confirm --dry-run (no `dry_run: true` in its response), so it \
+             may be running an older build that ignored the flag and TORE DOWN {count} \
+             ephemeral session(s). Restart the daemon (`tm daemon restart`) and re-run."
+        ));
+    }
+    Ok(if dry_run {
+        format!("would decommission {count} ephemeral session(s) (dry run)")
+    } else {
+        format!("decommissioned {count} ephemeral session(s)")
+    })
 }
 
 /// `tm session prune --state <filter> [--dry-run] [--include-active]` — by-state prune (#1508).
@@ -653,6 +696,11 @@ pub(crate) async fn session_prune(
             "state": state,
             "dry_run": dry_run,
             "include_active": include_active,
+            // #6118: the session this command was typed in is never a target.
+            // The daemon occupies no pane and cannot discover it, so the CLI
+            // reports it; absent means the operator is not inside a managed
+            // session.
+            "invoking_session": std::env::var("TM_MANAGED_SESSION_ID").ok(),
         }))
         .send()
         .await?;

--- a/crates/trusty-mpm/src/bin/tm/commands/managed_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed_tests.rs
@@ -1228,3 +1228,60 @@ fn ls_table_columns_align_when_a_row_carries_an_annotation() {
         );
     }
 }
+
+/// 🔴 #6118 FAIL-OPEN GUARD: a `--dry-run` the daemon did not confirm is an
+/// ERROR, never a reported preview.
+///
+/// Why: this daemon is long-lived by design — a CLI upgrade never bounces it —
+/// and axum silently drops a query param the running handler does not declare.
+/// A daemon predating the `?dry_run=` param therefore accepts the request, runs
+/// the REAL sweep, and returns 200 with a count. Rendering that as "would
+/// decommission 7" tells the operator nothing happened when seven sessions were
+/// just torn down. The echoed `dry_run` field is the only signal that can tell
+/// the two apart, so its absence has to fail the command.
+/// What: three bodies against the same requested `dry_run: true` — a missing
+/// echo, an explicit `false`, and a confirmed `true` — plus a real sweep, which
+/// deliberately does NOT require the echo (an older daemon's real teardown is
+/// what a real sweep asked for).
+/// Test: this function IS the test.
+#[test]
+fn decommission_ephemeral_refuses_a_dry_run_a_stale_daemon_ignored() {
+    use super::ephemeral_sweep_line;
+
+    let missing = serde_json::json!({ "decommissioned": 7 });
+    let err = ephemeral_sweep_line(&missing, true).expect_err("a silent daemon must fail the run");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("did not confirm --dry-run") && msg.contains('7'),
+        "the refusal must say what may have been torn down: {msg}"
+    );
+
+    let denied = serde_json::json!({ "decommissioned": 2, "dry_run": false });
+    assert!(
+        ephemeral_sweep_line(&denied, true).is_err(),
+        "an explicit `dry_run: false` is the same skew, stated outright"
+    );
+
+    // CONTROL: a real sweep never consults the echo, so the same silent body is
+    // rendered without complaint — otherwise the guard above would have broken
+    // the ordinary path rather than the skewed one.
+    let real = ephemeral_sweep_line(&missing, false).expect("a real sweep needs no echo");
+    assert_eq!(real, "decommissioned 7 ephemeral session(s)");
+}
+
+/// #6118: a confirmed dry run reports itself as one.
+///
+/// Why: the guard above must not be satisfiable by refusing everything — the
+/// honoured path has to render, and has to say "would" rather than claiming a
+/// teardown that never happened.
+/// Test: this function IS the test.
+#[test]
+fn decommission_ephemeral_reports_a_confirmed_dry_run() {
+    use super::ephemeral_sweep_line;
+
+    let body = serde_json::json!({ "decommissioned": 3, "dry_run": true });
+    assert_eq!(
+        ephemeral_sweep_line(&body, true).expect("a confirmed preview renders"),
+        "would decommission 3 ephemeral session(s) (dry run)"
+    );
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/session.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session.rs
@@ -395,8 +395,8 @@ pub(crate) async fn session(
         // #1508: bulk teardown + by-state prune go through direct HTTP (like
         // `PruneIdle`), not chat-core — they are fleet-wide store operations, not
         // single-session intents.
-        SessionAction::DecommissionEphemeral => {
-            crate::commands::managed::session_decommission_ephemeral(client, url).await?
+        SessionAction::DecommissionEphemeral { dry_run } => {
+            crate::commands::managed::session_decommission_ephemeral(client, url, dry_run).await?
         }
         SessionAction::Prune {
             state,

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_d_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_d_tests.rs
@@ -465,15 +465,19 @@ fn cli_parses_session_prune_idle_defaults() {
 
 #[test]
 fn cli_parses_session_decommission_ephemeral() {
-    // #1508: the bulk-teardown verb takes no arguments.
+    // #1508: the bulk-teardown verb takes no required arguments, and #6118's
+    // `--dry-run` must stay OFF by default — the pre-#6118 behaviour.
     let cli = Cli::try_parse_from(["trusty-mpm", "session", "decommission-ephemeral"]).unwrap();
     match cli.command.unwrap() {
         Command::Session {
-            action: SessionAction::DecommissionEphemeral,
-        } => {}
+            action: SessionAction::DecommissionEphemeral { dry_run },
+        } => assert!(!dry_run, "the sweep must not silently become a preview"),
         other => panic!("expected session decommission-ephemeral, got {other:?}"),
     }
 }
+
+// #6118: the rest of this issue's CLI-parse coverage lives in
+// `tests_prune_selector_cli_tests.rs` — this file is at the 3000-SLOC test cap.
 
 #[test]
 fn cli_parses_session_prune() {

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_e_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_e_tests.rs
@@ -707,3 +707,66 @@ fn ls_help_states_that_a_plain_listing_prunes() {
         );
     }
 }
+
+/// #6118: `--state unresolvable` parses, and needs no `--include-active`.
+///
+/// Why: `--state active` was rejected outright when an operator went looking for
+/// this class, so the new spelling has to reach the daemon from the CLI — and it
+/// has to do so without the blanket flag that also selects healthy sessions.
+///
+/// This test and its sibling below live HERE rather than beside the rest of the
+/// `cli_parses_session_*` family: `tests_behavior_d_tests.rs` sits at the
+/// 3000-SLOC test cap, and adding them there pushed it to 3013.
+/// Test: this function IS the test.
+#[test]
+fn cli_parses_session_prune_unresolvable() {
+    let cli = Cli::try_parse_from([
+        "trusty-mpm",
+        "session",
+        "prune",
+        "--state",
+        "unresolvable",
+        "--dry-run",
+    ])
+    .unwrap();
+    match cli.command.unwrap() {
+        Command::Session {
+            action:
+                SessionAction::Prune {
+                    state,
+                    dry_run,
+                    include_active,
+                },
+        } => {
+            assert_eq!(state, "unresolvable");
+            assert!(dry_run);
+            assert!(
+                !include_active,
+                "the unresolvable selector must not need the blanket flag"
+            );
+        }
+        other => panic!("expected session prune, got {other:?}"),
+    }
+}
+
+/// #6118: `decommission-ephemeral` accepts `--dry-run`.
+///
+/// Why: the verb had no preview flag at all, so an operator's only way to learn
+/// what it would tear down was to tear it down.
+/// Test: this function IS the test.
+#[test]
+fn cli_parses_session_decommission_ephemeral_dry_run() {
+    let cli = Cli::try_parse_from([
+        "trusty-mpm",
+        "session",
+        "decommission-ephemeral",
+        "--dry-run",
+    ])
+    .unwrap();
+    match cli.command.unwrap() {
+        Command::Session {
+            action: SessionAction::DecommissionEphemeral { dry_run },
+        } => assert!(dry_run),
+        other => panic!("expected session decommission-ephemeral, got {other:?}"),
+    }
+}

--- a/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
@@ -78,7 +78,8 @@ pub use proxy::{
     proxy_unfocus,
 };
 pub use prune::{
-    PruneRequest, decommission_ephemeral_route, prune_managed_route, prune_worktrees_route,
+    EphemeralQuery, PruneRequest, decommission_ephemeral_route, prune_managed_route,
+    prune_worktrees_route,
 };
 pub use reactivate::reactivate_managed_session;
 pub use rename::{RenameRequest, rename_managed_session};

--- a/crates/trusty-mpm/src/daemon/managed_routes/prune.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/prune.rs
@@ -29,12 +29,15 @@ use crate::session_manager::{DirtyWorktreePolicy, PruneFilter};
 /// only when they really mean it — also include RUNNING sessions via
 /// `include_active`. Modelling it as a typed body keeps the safety defaults
 /// explicit (running sessions are spared unless `include_active` is `true`).
-/// What: `state` (the [`PruneFilter`] spelling), `dry_run` (default false), and
-/// `include_active` (default false).
-/// Test: `prune_route_dry_run_reports`, `prune_route_rejects_bad_state`.
+/// What: `state` (the [`PruneFilter`] spelling), `dry_run` (default false),
+/// `include_active` (default false), and `invoking_session` (#6118, default
+/// absent).
+/// Test: `prune_route_dry_run_reports`, `prune_route_rejects_bad_state`,
+/// `prune_route_rejects_an_unparseable_invoking_session`.
 #[derive(Debug, Deserialize)]
 pub struct PruneRequest {
-    /// Which records to target: `ephemeral` | `stopped` | `decommissioned` | `all`.
+    /// Which records to target: `ephemeral` | `stopped` | `decommissioned` |
+    /// `deleted` | `all` | `unresolvable`.
     pub state: String,
     /// When true, report what WOULD be pruned without mutating anything.
     #[serde(default)]
@@ -43,6 +46,34 @@ pub struct PruneRequest {
     /// Defaults to false — the fail-closed safety default.
     #[serde(default)]
     pub include_active: bool,
+    /// The managed session id this prune was invoked FROM, which is then never
+    /// a target (#6118).
+    ///
+    /// Why: the daemon cannot discover this — it occupies no pane — so the
+    /// caller supplies it. The CLI sends `$TM_MANAGED_SESSION_ID` when the
+    /// operator is inside a managed session. Absent means "the caller is not a
+    /// session", which is correct for the MCP tool and for an ad-hoc shell.
+    /// A value present but unparseable is REJECTED rather than dropped: silently
+    /// ignoring it would run the sweep with the protection the caller asked for
+    /// switched off.
+    #[serde(default)]
+    pub invoking_session: Option<String>,
+}
+
+/// Query string for POST …/managed/decommission-ephemeral (#6118).
+///
+/// Why: the verb had no preview mode, so an operator could only learn its
+/// selection by running it. A query param rather than a body keeps every
+/// existing bodyless caller working — axum's `Json` extractor rejects an empty
+/// body, so adding a body would have broken the CLI, the MCP path, and any
+/// script that POSTs nothing.
+/// What: `dry_run` (default false — the pre-#6118 behaviour).
+/// Test: `ephemeral_route_dry_run_reports_without_tearing_down`.
+#[derive(Debug, Deserialize)]
+pub struct EphemeralQuery {
+    /// When true, report what WOULD be torn down and mutate nothing.
+    #[serde(default)]
+    pub dry_run: bool,
 }
 
 /// POST /api/v1/sessions/managed/decommission-ephemeral — bulk-tear-down ephemeral (#1508).
@@ -51,16 +82,33 @@ pub struct PruneRequest {
 /// harnesses and operators. REAL sessions default `ephemeral=false` and are
 /// unreachable, so this can never harm durable work.
 /// What: delegates to
-/// [`SessionManager::decommission_all_ephemeral`](crate::session_manager::SessionManager::decommission_all_ephemeral)
-/// and returns `{ decommissioned: <count> }`.
+/// [`SessionManager::sweep_all_ephemeral`](crate::session_manager::SessionManager::sweep_all_ephemeral)
+/// and returns `{ decommissioned: <count>, dry_run: <bool> }`.
+///
+/// 🔴 #6118: `dry_run` is ECHOED, and that echo is load-bearing, not cosmetic.
+/// This daemon is long-lived by design — a CLI upgrade never bounces it — and
+/// axum silently drops a query param the handler does not declare, so a daemon
+/// predating this change accepts `?dry_run=true` and performs a REAL teardown,
+/// returning 200. The status alone cannot tell that apart from an honoured
+/// preview; only the echoed field can, which is why the CLI refuses to report a
+/// dry run the daemon did not confirm. Same failure shape, and the same remedy,
+/// as `session_picker_prune::decommission_dead_record`'s `workspace_removed`
+/// check.
 /// Test: `decommission_ephemeral_route_tears_down_only_ephemeral` in
-/// tests/session_manager_mvp.rs.
+/// tests/session_manager_mvp.rs;
+/// `ephemeral_route_dry_run_reports_without_tearing_down` in this file;
+/// the CLI's refusal by `decommission_ephemeral_refuses_a_dry_run_a_stale_daemon_ignored`.
 pub async fn decommission_ephemeral_route(
     State(state): State<Arc<DaemonState>>,
+    axum::extract::Query(q): axum::extract::Query<EphemeralQuery>,
 ) -> impl IntoResponse {
     let mgr = state.session_manager().await;
-    match mgr.decommission_all_ephemeral().await {
-        Ok(count) => Json(serde_json::json!({ "decommissioned": count })).into_response(),
+    match mgr.sweep_all_ephemeral(q.dry_run).await {
+        Ok(outcome) => Json(serde_json::json!({
+            "decommissioned": outcome.count(),
+            "dry_run": q.dry_run,
+        }))
+        .into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
 }
@@ -304,8 +352,14 @@ pub async fn prune_worktrees_route(
 /// with the request's `dry_run`/`include_active`. Returns the
 /// [`crate::session_manager::PruneOutcome`] JSON (its `dry_run`, `filter`, and
 /// per-session `action` list).
+///
+/// #6118: a present-but-unparseable `invoking_session` is a 400. Dropping it
+/// would run the sweep with the self-exclusion the caller explicitly asked for
+/// silently disabled — the failure arm has to be louder than the success arm it
+/// protects.
 /// Test: `prune_route_dry_run_reports`, `prune_route_rejects_bad_state` in
-/// tests/session_manager_mvp.rs.
+/// tests/session_manager_mvp.rs;
+/// `prune_route_rejects_an_unparseable_invoking_session` in this file.
 pub async fn prune_managed_route(
     State(state): State<Arc<DaemonState>>,
     Json(req): Json<PruneRequest>,
@@ -317,11 +371,26 @@ pub async fn prune_managed_route(
             return (StatusCode::BAD_REQUEST, e).into_response();
         }
     };
+    let invoker = match req
+        .invoking_session
+        .as_deref()
+        .map(str::parse::<uuid::Uuid>)
+    {
+        None => None,
+        Some(Ok(u)) => Some(crate::session_manager::record::ManagedSessionId::from(u)),
+        Some(Err(_)) => {
+            let msg = "invalid invoking_session: not a UUID — refusing the prune rather than \
+                       running it without the requested self-exclusion (#6118)"
+                .to_string();
+            warn!("prune route: {msg}");
+            return (StatusCode::BAD_REQUEST, msg).into_response();
+        }
+    };
     let mgr = state.session_manager().await;
     // `caller: None` — the HTTP route is an operator surface, never a session
     // acting on its own behalf; the #3649 owner gate does not apply here.
     match mgr
-        .prune_managed(filter, req.dry_run, req.include_active, None)
+        .prune_managed(filter, req.dry_run, req.include_active, None, invoker)
         .await
     {
         Ok(outcome) => Json(outcome).into_response(),
@@ -359,6 +428,94 @@ mod tests {
                 .expect("explicit body parses");
         assert!(explicit.discard_dirty, "the opt-in must round-trip");
         assert!(explicit.merged_prs, "the #2919 opt-in must round-trip");
+    }
+
+    /// 🔴 #6118 FAIL-OPEN GUARD: an unparseable `invoking_session` REFUSES the
+    /// prune rather than running it without the self-exclusion.
+    ///
+    /// Why: the field's whole purpose is keeping the sweep off the caller's own
+    /// session. Dropping a malformed value and proceeding would run exactly the
+    /// sweep the caller asked to be protected from — the measured `--state all
+    /// --include-active` case that selected the operator's own running session.
+    /// A 400 costs one retry; the open arm costs the terminal the command was
+    /// typed in.
+    /// What: posts a well-formed body whose `invoking_session` is not a UUID and
+    /// asserts 400. The CONTROL sends the same body with the field ABSENT and
+    /// asserts it is accepted, so the test cannot pass merely because the route
+    /// rejects everything.
+    /// Test: this function IS the test.
+    #[tokio::test]
+    async fn prune_route_rejects_an_unparseable_invoking_session() {
+        let root = crate::test_support::hermetic_temp_dir();
+        let state =
+            Arc::new(DaemonState::with_root_isolated_managed(root.path().to_path_buf()).await);
+
+        let bad = prune_managed_route(
+            State(state.clone()),
+            Json(PruneRequest {
+                state: "unresolvable".into(),
+                dry_run: true,
+                include_active: false,
+                invoking_session: Some("not-a-uuid".into()),
+            }),
+        )
+        .await
+        .into_response();
+        assert_eq!(
+            bad.status(),
+            StatusCode::BAD_REQUEST,
+            "a malformed self-exclusion must stop the prune, not be dropped"
+        );
+
+        // CONTROL: absent is legitimate (an ad-hoc shell, the MCP tool).
+        let ok = prune_managed_route(
+            State(state),
+            Json(PruneRequest {
+                state: "unresolvable".into(),
+                dry_run: true,
+                include_active: false,
+                invoking_session: None,
+            }),
+        )
+        .await
+        .into_response();
+        assert_eq!(ok.status(), StatusCode::OK);
+    }
+
+    /// #6118: the ephemeral route's `dry_run` is honoured AND echoed.
+    ///
+    /// Why: the echo is what lets the CLI tell a real preview from an older
+    /// daemon that dropped the param and swept for real. A route that honours
+    /// the flag but does not report it is indistinguishable from one that
+    /// ignored it.
+    /// What: posts `?dry_run=true` against an empty store and asserts both keys
+    /// come back, with `dry_run: true`.
+    /// Test: this function IS the test.
+    #[tokio::test]
+    async fn ephemeral_route_dry_run_reports_without_tearing_down() {
+        let root = crate::test_support::hermetic_temp_dir();
+        let state =
+            Arc::new(DaemonState::with_root_isolated_managed(root.path().to_path_buf()).await);
+        let body = body_json(
+            decommission_ephemeral_route(
+                State(state),
+                axum::extract::Query(EphemeralQuery { dry_run: true }),
+            )
+            .await
+            .into_response(),
+        )
+        .await;
+        assert_eq!(
+            body.get("dry_run").and_then(serde_json::Value::as_bool),
+            Some(true),
+            "the route must echo the honoured preview flag: {body}"
+        );
+        assert_eq!(
+            body.get("decommissioned")
+                .and_then(serde_json::Value::as_u64),
+            Some(0),
+            "an empty store sweeps nothing: {body}"
+        );
     }
 
     /// Read a route response's JSON body.

--- a/crates/trusty-mpm/src/daemon/mcp_session.rs
+++ b/crates/trusty-mpm/src/daemon/mcp_session.rs
@@ -301,8 +301,10 @@ pub async fn session_prune(
     let filter = PruneFilter::parse(filter)?;
     let mgr = state.session_manager().await;
     // TODO(#3649): populate `caller` once the MCP transport threads it through.
+    // #6118: `invoker` stays `None` here — an MCP call occupies no pane, so
+    // there is no invoking session to exclude.
     let outcome = mgr
-        .prune_managed(filter, dry_run, include_active, None)
+        .prune_managed(filter, dry_run, include_active, None, None)
         .await
         .map_err(managed_err)?;
     serde_json::to_value(&outcome).map_err(|e| format!("failed to serialize prune outcome: {e}"))

--- a/crates/trusty-mpm/src/session_manager/adopt.rs
+++ b/crates/trusty-mpm/src/session_manager/adopt.rs
@@ -99,7 +99,9 @@ pub(super) fn derive_source_id_for_record(record: &SessionRecord) -> Option<Stri
         .filter(|p| p.is_dir())
         .or_else(|| {
             let c = record.cwd.as_path();
-            (c != Path::new("/unknown") && c.is_dir()).then_some(c)
+            // #6118: one spelling of the sentinel, shared with every other
+            // reader of it.
+            (c != Path::new(super::record::UNRESOLVED_PATH_SENTINEL) && c.is_dir()).then_some(c)
         })?;
     let gh = trusty_common::github_path::derive_github_path(path)?;
     Some(format!("{}/{}", gh.owner, gh.repo))

--- a/crates/trusty-mpm/src/session_manager/decommission_worktree_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/decommission_worktree_tests.rs
@@ -377,6 +377,7 @@ async fn prune_reports_dirty_worktree_retained() {
             false,
             false,
             None,
+            None,
         )
         .await
         .expect("prune stopped");

--- a/crates/trusty-mpm/src/session_manager/dedup.rs
+++ b/crates/trusty-mpm/src/session_manager/dedup.rs
@@ -300,7 +300,8 @@ fn group_key(record: &SessionRecord) -> Option<String> {
 /// `is_resolved_existing_false_for_none_and_unknown_sentinel`.
 pub(crate) fn is_resolved_existing(record: &SessionRecord) -> bool {
     match &record.workspace_path {
-        Some(p) => p.as_path() != Path::new("/unknown") && p.exists(),
+        // #6118: one spelling of the sentinel, shared with every other reader.
+        Some(p) => p.as_path() != Path::new(super::record::UNRESOLVED_PATH_SENTINEL) && p.exists(),
         None => false,
     }
 }

--- a/crates/trusty-mpm/src/session_manager/liveness_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/liveness_tests.rs
@@ -95,7 +95,13 @@ async fn prune_stale_active_removable_without_force_when_tmux_dead() {
         .expect("simulate tmux death");
 
     let outcome = mgr
-        .prune_managed(crate::session_manager::PruneFilter::All, false, false, None)
+        .prune_managed(
+            crate::session_manager::PruneFilter::All,
+            false,
+            false,
+            None,
+            None,
+        )
         .await
         .expect("prune all");
     assert_eq!(
@@ -181,7 +187,13 @@ async fn prune_refuses_when_the_tmux_probe_fails() {
     *fake.list_sessions_should_fail.lock().unwrap() = true;
 
     let err = mgr
-        .prune_managed(crate::session_manager::PruneFilter::All, false, false, None)
+        .prune_managed(
+            crate::session_manager::PruneFilter::All,
+            false,
+            false,
+            None,
+            None,
+        )
         .await
         .expect_err("an unobservable liveness probe must refuse the prune (#5859)");
     assert!(
@@ -196,7 +208,13 @@ async fn prune_refuses_when_the_tmux_probe_fails() {
 
     // `include_active` never consults the probe, so it is unaffected.
     let outcome = mgr
-        .prune_managed(crate::session_manager::PruneFilter::All, false, true, None)
+        .prune_managed(
+            crate::session_manager::PruneFilter::All,
+            false,
+            true,
+            None,
+            None,
+        )
         .await
         .expect("include_active skips the liveness gate entirely");
     assert_eq!(outcome.count(), 1);

--- a/crates/trusty-mpm/src/session_manager/prune.rs
+++ b/crates/trusty-mpm/src/session_manager/prune.rs
@@ -230,7 +230,9 @@ fn is_tombstone(record: &SessionRecord) -> bool {
 /// each rule readable and individually testable.
 /// What: `Ephemeral` → `ephemeral && state != Decommissioned`; `Stopped` →
 /// `state == Stopped`; `Decommissioned` → `state == Decommissioned`; `All` → any
-/// non-running record (the caller still applies [`is_running`] as the final gate).
+/// non-running record (the caller still applies [`is_running`] as the final
+/// gate); `Unresolvable` → the record names no resolvable workspace (#6118),
+/// which is the one arm the caller does NOT gate on liveness.
 /// Test: the per-filter `prune_*` tests.
 fn matches_filter(record: &SessionRecord, filter: PruneFilter) -> bool {
     match filter {
@@ -241,6 +243,9 @@ fn matches_filter(record: &SessionRecord, filter: PruneFilter) -> bool {
         PruneFilter::Decommissioned => record.state == ManagedSessionState::Decommissioned,
         PruneFilter::Deleted => record.state == ManagedSessionState::Deleted,
         PruneFilter::All => true,
+        // #6118: the class no state-keyed filter could express — a record with
+        // no resolvable workspace, held immune by its own live pane.
+        PruneFilter::Unresolvable => record.workspace_unresolvable(),
     }
 }
 
@@ -357,14 +362,28 @@ impl SessionManager {
     /// Test: `decommission_all_ephemeral_ignores_non_ephemeral` (asserts the
     /// ephemeral-only decommission path and the non-ephemeral safety exclusion).
     pub async fn decommission_all_ephemeral(&self) -> Result<usize, ManagedError> {
-        // Ephemeral sessions are throwaway by definition: include running ones so a
-        // panicking test that left an Active ephemeral session is still cleaned up.
-        // `caller: None` — this is an operator/daemon-internal bulk sweep, never a
-        // session acting on its own behalf; the #3649 owner gate does not apply.
-        let outcome = self
-            .prune_managed(PruneFilter::Ephemeral, false, true, None)
-            .await?;
-        Ok(outcome.count())
+        Ok(self.sweep_all_ephemeral(false).await?.count())
+    }
+
+    /// [`decommission_all_ephemeral`](Self::decommission_all_ephemeral) with a
+    /// preview mode, returning the full outcome rather than a bare count
+    /// (#6118).
+    ///
+    /// Why: `tm session decommission-ephemeral` had no `--dry-run` at all, so
+    /// its selection could not be inspected before it ran — an operator's only
+    /// way to learn what it would tear down was to tear it down. Because the
+    /// preview and the real sweep are ONE call differing in one boolean, they
+    /// cannot select different sets; a separate "what would this do" query is
+    /// exactly how a dry run drifts from the thing it previews.
+    /// What: delegates to [`prune_managed`](Self::prune_managed) with
+    /// `PruneFilter::Ephemeral` and `include_active = true` — a running
+    /// ephemeral session is throwaway by definition, so a panicking test that
+    /// left one Active is still cleaned up. `caller`/`invoker` are `None`: this
+    /// is an operator/daemon-internal bulk sweep occupying no pane.
+    /// Test: `ephemeral_dry_run_selects_exactly_what_the_real_run_does`.
+    pub async fn sweep_all_ephemeral(&self, dry_run: bool) -> Result<PruneOutcome, ManagedError> {
+        self.prune_managed(PruneFilter::Ephemeral, dry_run, true, None, None)
+            .await
     }
 
     /// Prune managed sessions by state — bulk teardown + compaction (#1508).
@@ -379,6 +398,14 @@ impl SessionManager {
     /// NEVER killed or removed unless `include_active` is explicitly `true`. The
     /// `Decommissioned` filter only ever removes tombstones (it cannot reach a
     /// running record by construction).
+    ///
+    /// #6118 amends that invariant in exactly one place, and narrows it in
+    /// another. `PruneFilter::Unresolvable` reaches a running record without
+    /// `include_active`, because its predicate — no resolvable workspace at all
+    /// — cannot hold for a healthy session and does hold for a leaked pane;
+    /// nothing on disk is reachable through such a record, since it has no
+    /// `workspace_path` to remove. In the other direction, `invoker` is now
+    /// excluded from the target set for EVERY filter, `include_active` included.
     ///
     /// What: snapshots `store.all()`, selects records that both
     /// [`matches_filter`] AND pass the running-state gate (unless `include_active`),
@@ -407,7 +434,13 @@ impl SessionManager {
     /// running-state safety gate), `prune_decommissioned_compacts` (compaction),
     /// `prune_all_targets_non_running`, `prune_dry_run_reports_without_mutating`,
     /// `prune_compaction_releases_the_slot`,
-    /// `prune_compaction_keeps_the_slot_when_the_worktree_is_still_on_disk`.
+    /// `prune_compaction_keeps_the_slot_when_the_worktree_is_still_on_disk`;
+    /// the #6118 additions by `unresolvable_filter_selects_a_live_ghost_pane`,
+    /// `healthy_active_session_is_never_selected_by_the_unresolvable_filter`,
+    /// `unresolvable_dry_run_selects_exactly_what_the_real_run_does`,
+    /// `prune_never_selects_the_invoking_session`, and
+    /// `unresolvable_duplicates_sharing_a_pane_are_both_tombstoned` in
+    /// `super::prune_unresolvable_tests`.
     ///
     /// `caller` (#3649, Option B): threaded straight through to
     /// [`decommission`](Self::decommission) for each non-tombstone target —
@@ -416,12 +449,23 @@ impl SessionManager {
     /// `Some(id)` applies the owner gate per-target, so a fleet-wide prune
     /// invoked on behalf of a specific session still cannot reclaim a peer
     /// session's actively-owned worktree.
+    ///
+    /// `invoker` (#6118) is the SELF-EXCLUSION, and it is a different question
+    /// from `caller`: `caller` gates which worktrees a target may give up,
+    /// while `invoker` removes one record from the target set entirely, for
+    /// every filter and regardless of `include_active`. It exists because the
+    /// measured `--state all --include-active` sweep selected the operator's own
+    /// running session — a tidy-up that takes down the terminal it was typed in
+    /// is an outage, not a cleanup. `None` (the daemon's own sweeps, the MCP
+    /// tool) excludes nothing, because those callers occupy no pane; the CLI
+    /// fills it from `$TM_MANAGED_SESSION_ID`.
     pub async fn prune_managed(
         &self,
         filter: PruneFilter,
         dry_run: bool,
         include_active: bool,
         caller: Option<ManagedSessionId>,
+        invoker: Option<ManagedSessionId>,
     ) -> Result<PruneOutcome, ManagedError> {
         // Snapshot the full set ONCE (reloads-on-read so out-of-process writes are
         // seen). We then mutate per record below, each of which re-reads/saves.
@@ -442,10 +486,21 @@ impl SessionManager {
         // `include_active` short-circuits before the probe, so the bulk
         // ephemeral sweep (which ignores liveness by design) still runs on a
         // host with no reachable tmux.
+        //
+        // #6118: `Unresolvable` skips the probe rather than passing it. Its
+        // members are live BY DEFINITION — that liveness is exactly what made
+        // them unreachable — so liveness is not an input to the decision. See
+        // `PruneFilter::selects_regardless_of_liveness`.
         let tmux = self.tmux.as_ref();
+        let ignore_liveness = include_active || filter.selects_regardless_of_liveness();
         let mut targets: Vec<SessionRecord> = Vec::new();
         for record in all.into_iter().filter(|r| matches_filter(r, filter)) {
-            if include_active || !is_running(&record, tmux)? {
+            // #6118: the invoking session is never a target, on any filter.
+            if invoker == Some(record.id) {
+                info!(id = %record.id, "prune: skipping the invoking session");
+                continue;
+            }
+            if ignore_liveness || !is_running(&record, tmux)? {
                 targets.push(record);
             }
         }
@@ -1193,3 +1248,7 @@ mod orphan_tests;
 #[cfg(test)]
 #[path = "prune_slot_tests.rs"]
 mod slot_tests;
+
+#[cfg(test)]
+#[path = "prune_unresolvable_tests.rs"]
+mod prune_unresolvable_tests;

--- a/crates/trusty-mpm/src/session_manager/prune_slot_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/prune_slot_tests.rs
@@ -92,7 +92,7 @@ async fn prune_compaction_releases_the_slot() {
     let keeper_slot = find(&before, keeper.id).expect("keeper observed");
 
     let outcome = mgr
-        .prune_managed(PruneFilter::Decommissioned, false, false, None)
+        .prune_managed(PruneFilter::Decommissioned, false, false, None, None)
         .await
         .expect("prune decommissioned");
     assert_eq!(outcome.count(), 1, "the tombstone is the only target");
@@ -181,7 +181,7 @@ async fn prune_compaction_keeps_the_slot_when_the_worktree_is_still_on_disk() {
         .slot;
 
     let outcome = mgr
-        .prune_managed(PruneFilter::Decommissioned, false, false, None)
+        .prune_managed(PruneFilter::Decommissioned, false, false, None, None)
         .await
         .expect("prune decommissioned");
     assert_eq!(outcome.count(), 1, "the record is still compacted");
@@ -330,7 +330,7 @@ async fn prune_dry_run_releases_no_slot() {
     .await;
     let before = slots_held(&mgr).await;
 
-    mgr.prune_managed(PruneFilter::Decommissioned, true, false, None)
+    mgr.prune_managed(PruneFilter::Decommissioned, true, false, None, None)
         .await
         .expect("dry-run prune");
 

--- a/crates/trusty-mpm/src/session_manager/prune_types.rs
+++ b/crates/trusty-mpm/src/session_manager/prune_types.rs
@@ -27,7 +27,9 @@ use std::fmt;
 /// records; [`Decommissioned`](PruneFilter::Decommissioned) and
 /// [`Deleted`](PruneFilter::Deleted) select existing tombstones (for compaction
 /// only); [`All`](PruneFilter::All) selects every NON-running record (ephemeral,
-/// stopped, errored, decommissioned, and deleted).
+/// stopped, errored, decommissioned, and deleted);
+/// [`Unresolvable`](PruneFilter::Unresolvable) selects records naming no
+/// resolvable workspace, whether or not their pane is alive (#6118).
 /// Test: `prune_filter_parse_round_trip`, and the per-filter `prune_*` tests.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PruneFilter {
@@ -43,6 +45,27 @@ pub enum PruneFilter {
     /// Every NON-running record: ephemeral, stopped, errored, decommissioned,
     /// and deleted.
     All,
+    /// Only records naming no resolvable workspace —
+    /// [`SessionRecord::workspace_unresolvable`](super::record::SessionRecord::workspace_unresolvable)
+    /// (#6118).
+    ///
+    /// Why this exists as its own variant rather than as a flag on the others:
+    /// the class is defined by the RECORD, not by a lifecycle state, and every
+    /// state-keyed filter above therefore misses it. The 23 such records
+    /// measured on the reporting host were `Active` with live panes, so
+    /// `ephemeral`, `stopped`, `decommissioned` and `deleted` each selected 0 of
+    /// them, and the one command that did reach them — `--state all
+    /// --include-active` — also selected 32 healthy working sessions including
+    /// the operator's own.
+    ///
+    /// 🔴 This is the ONE filter whose selection ignores tmux liveness (see
+    /// [`selects_regardless_of_liveness`](Self::selects_regardless_of_liveness)),
+    /// because a live pane is the DEFINING property of the class — that is
+    /// precisely why nothing could reach it. The blast radius is bounded by the
+    /// predicate instead: an unresolvable record has no `workspace_path`, so its
+    /// teardown cannot remove a directory, a worktree, or a branch. What it does
+    /// reclaim is the leaked pane and the store row.
+    Unresolvable,
 }
 
 impl PruneFilter {
@@ -63,8 +86,9 @@ impl PruneFilter {
             "decommissioned" => Ok(Self::Decommissioned),
             "deleted" => Ok(Self::Deleted),
             "all" => Ok(Self::All),
+            "unresolvable" => Ok(Self::Unresolvable),
             other => Err(format!(
-                "unknown prune filter `{other}` (expected: ephemeral | stopped | decommissioned | deleted | all)"
+                "unknown prune filter `{other}` (expected: ephemeral | stopped | decommissioned | deleted | all | unresolvable)"
             )),
         }
     }
@@ -81,7 +105,31 @@ impl PruneFilter {
             Self::Decommissioned => "decommissioned",
             Self::Deleted => "deleted",
             Self::All => "all",
+            Self::Unresolvable => "unresolvable",
         }
+    }
+
+    /// Whether this filter's selection stands on the record alone, so the tmux
+    /// liveness probe is skipped rather than applied (#6118).
+    ///
+    /// Why: `include_active` is a BLANKET lift of the liveness gate — it is what
+    /// turned a targeted cleanup into a 55-session sweep that included the
+    /// operator's own working session. [`Unresolvable`](Self::Unresolvable)
+    /// needs the gate lifted for a class whose members are live BY DEFINITION,
+    /// and forcing the operator to reach for `include_active` to get there means
+    /// typing the flag whose default behaviour is the footgun. Answering the
+    /// question per-filter keeps the lift narrow: the predicate, not a flag,
+    /// bounds what a live-pane teardown can reach.
+    ///
+    /// This does NOT reintroduce the #5859 fail-closed hazard, which was about
+    /// an UNDETERMINABLE probe reading as "not running" and tearing down a live
+    /// pane thought dead. Here liveness is not an input to the decision at all,
+    /// so there is no verdict to get wrong.
+    /// What: `true` for `Unresolvable`, `false` for every other filter.
+    /// Test: `unresolvable_filter_selects_a_live_ghost_pane`,
+    /// `unresolvable_filter_needs_no_include_active`.
+    pub fn selects_regardless_of_liveness(&self) -> bool {
+        matches!(self, Self::Unresolvable)
     }
 }
 

--- a/crates/trusty-mpm/src/session_manager/prune_unresolvable_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/prune_unresolvable_tests.rs
@@ -1,0 +1,526 @@
+//! Coverage for the `unresolvable` prune selector and the prune engine's
+//! self-exclusion (#6118).
+//!
+//! Why: #6126 stopped MINTING adoption ghosts — records whose `cwd` is the
+//! `/unknown` sentinel and whose `workspace_path` is unset — but nothing could
+//! SELECT the ones already in the store. Measured on the reporting host: 23 such
+//! records, every state filter selecting 0 of them, `prune-idle` skipping all 23
+//! on an `errored` verdict, and the one command that did reach them (`--state
+//! all --include-active`) also selecting 32 healthy live sessions including the
+//! operator's own. Both halves of that need pinning: the selector must find the
+//! ghosts, and it must not find anything else.
+//!
+//! What: the positive case (a live ghost pane IS selected, with no
+//! `--include-active`), the negative case (a healthy Active session with a
+//! resolvable workspace is NOT), the partial case (one resolvable coordinate is
+//! enough to keep a record), dry-run parity for both this filter and the
+//! ephemeral sweep, the invoking-session exclusion under the widest possible
+//! filter, and the duplicate-pane behaviour the #6117 race produced.
+//! Test: this file IS the test module; run with `cargo test -p trusty-mpm`.
+
+use std::path::PathBuf;
+
+use chrono::Utc;
+
+use super::super::record::{
+    ManagedSessionId, ManagedSessionState, SessionRecord, UNRESOLVED_PATH_SENTINEL,
+};
+use super::super::tests::{make_manager, seed_record};
+use super::PruneFilter;
+
+/// Seed one record with an explicit `cwd`/`workspace_path`/`tmux_name`, and a
+/// LIVE tmux session backing it.
+///
+/// Why: [`super::super::tests::seed_record`] always writes a real on-disk `cwd`
+/// and derives the tmux name from the id, so it cannot express either shape this
+/// module needs — the `/unknown` ghost, or two records sharing one pane.
+/// What: upserts the record and registers `tmux_name` on the fake driver, so
+/// every record seeded here is genuinely live in tmux (which is what made the
+/// real ghosts unreachable).
+async fn seed_live(
+    mgr: &super::SessionManager,
+    id: ManagedSessionId,
+    tmux_name: &str,
+    cwd: PathBuf,
+    workspace_path: Option<PathBuf>,
+    pane_id: Option<&str>,
+) {
+    let record = SessionRecord {
+        id,
+        tmux_name: tmux_name.to_owned(),
+        cwd,
+        task: "adopted session (unmanaged — workspace path could not be resolved)".into(),
+        state: ManagedSessionState::Active,
+        created_at: Utc::now(),
+        last_activity_at: None,
+        workspace_path,
+        repo_url: None,
+        branch: None,
+        pending_decision: None,
+        proposed_default: None,
+        correlation: Default::default(),
+        runtime: Default::default(),
+        ephemeral: false,
+        workspace_owned: false,
+        source_id: None,
+        claude_session_id: None,
+        scrollback_path: None,
+        last_cwd: None,
+        deliverable_id: None,
+        pane_id: pane_id.map(str::to_owned),
+        injection_status: Default::default(),
+        worktree_owner: None,
+        terminal_at: None,
+    };
+    mgr.tmux
+        .create_session(tmux_name, "/tmp")
+        .expect("seed: register live tmux session");
+    mgr.store
+        .write()
+        .await
+        .upsert(record)
+        .await
+        .expect("seed: persist record");
+}
+
+/// A ghost exactly as the pre-#6126 adopt path wrote it: `/unknown` cwd, no
+/// workspace, `Active`, live pane.
+async fn seed_ghost(mgr: &super::SessionManager, id: ManagedSessionId, tmux_name: &str) {
+    seed_live(
+        mgr,
+        id,
+        tmux_name,
+        PathBuf::from(UNRESOLVED_PATH_SENTINEL),
+        None,
+        Some("%1"),
+    )
+    .await;
+}
+
+/// The ids a prune outcome selected, sorted so comparisons are order-free.
+fn selected(outcome: &super::PruneOutcome) -> Vec<String> {
+    let mut ids: Vec<String> = outcome.sessions.iter().map(|s| s.id.clone()).collect();
+    ids.sort();
+    ids
+}
+
+/// ACCEPTANCE 2 (#6118): the ghost IS selected, and its live pane does not save
+/// it from the one filter written for it.
+///
+/// Why: a live pane is the DEFINING property of this class — `is_running`
+/// returning `true` is exactly what made all 23 records immune. A selector that
+/// respected the liveness gate here would select nothing, which is the state
+/// this issue describes.
+/// What: seeds one ghost with a live tmux session, prunes `unresolvable` with
+/// `include_active = false`, and asserts it was selected and tombstoned.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn unresolvable_filter_selects_a_live_ghost_pane() {
+    let dir = crate::test_support::hermetic_temp_dir();
+    let (mgr, _fake) = make_manager(&dir).await;
+    let ghost = ManagedSessionId::new();
+    seed_ghost(&mgr, ghost, "tm-ghost-live").await;
+
+    // PREMISE: the pane really is live, so the liveness gate really is the thing
+    // being bypassed. Without this the test could pass against a dead pane and
+    // prove nothing about the class it exists for.
+    assert!(
+        super::is_running(
+            &mgr.get(&ghost).await.expect("ghost record"),
+            mgr.tmux.as_ref()
+        )
+        .expect("probe"),
+        "PREMISE: the ghost's tmux session must be live"
+    );
+
+    let outcome = mgr
+        .prune_managed(PruneFilter::Unresolvable, false, false, None, None)
+        .await
+        .expect("prune unresolvable");
+
+    assert_eq!(
+        selected(&outcome),
+        vec![ghost.to_string()],
+        "the live ghost must be selected with no --include-active"
+    );
+    assert_eq!(
+        mgr.get(&ghost)
+            .await
+            .expect("record survives as tombstone")
+            .state,
+        ManagedSessionState::Decommissioned
+    );
+}
+
+/// ACCEPTANCE 1 (#6118): a HEALTHY Active session with a resolvable workspace is
+/// never selected.
+///
+/// Why: this is the whole difference between the new selector and the measured
+/// `--state all --include-active` sweep, which took 32 healthy sessions along
+/// with the 23 ghosts. Remove the staleness predicate from `matches_filter` —
+/// make the `Unresolvable` arm `true`, as `All` is — and this test goes red on
+/// the healthy session while the control below keeps proving the fixture is
+/// otherwise selectable.
+/// What: seeds one healthy Active session (real on-disk cwd and workspace) and
+/// one ghost, prunes `unresolvable`, and asserts the selection is the ghost
+/// alone and the healthy session is still `Active`.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn healthy_active_session_is_never_selected_by_the_unresolvable_filter() {
+    let dir = crate::test_support::hermetic_temp_dir();
+    let (mgr, _fake) = make_manager(&dir).await;
+
+    let healthy = ManagedSessionId::new();
+    seed_record(&mgr, &dir, healthy, ManagedSessionState::Active, false).await;
+    // CONTROL: a ghost in the same store, so a selector that has stopped
+    // selecting ANYTHING cannot pass this test by selecting nothing.
+    let ghost = ManagedSessionId::new();
+    seed_ghost(&mgr, ghost, "tm-ghost-beside-healthy").await;
+
+    let outcome = mgr
+        .prune_managed(PruneFilter::Unresolvable, false, false, None, None)
+        .await
+        .expect("prune unresolvable");
+
+    assert_eq!(
+        selected(&outcome),
+        vec![ghost.to_string()],
+        "CONTROL: the ghost must be selected and the healthy session must not"
+    );
+    assert_eq!(
+        mgr.get(&healthy).await.expect("healthy record").state,
+        ManagedSessionState::Active,
+        "a healthy Active session must be untouched"
+    );
+}
+
+/// One resolvable coordinate keeps the record (#6118).
+///
+/// Why: the predicate is deliberately an AND. A record whose `cwd` is the
+/// sentinel but which still names a `workspace_path` has somewhere a caller can
+/// go, so it is not this class — and a record naming a real directory on an
+/// unmounted volume must never be reachable here at all, which is what keeps
+/// this selector clear of the mass-tombstone hazard a probe-based rule carries.
+/// What: seeds a record with `/unknown` cwd but a real workspace path, prunes
+/// `unresolvable`, and asserts nothing was selected.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn unresolvable_filter_keeps_a_record_that_still_names_a_workspace() {
+    let dir = crate::test_support::hermetic_temp_dir();
+    let (mgr, _fake) = make_manager(&dir).await;
+
+    let half = ManagedSessionId::new();
+    seed_live(
+        &mgr,
+        half,
+        "tm-half-resolvable",
+        PathBuf::from(UNRESOLVED_PATH_SENTINEL),
+        Some(dir.path().join("still-here")),
+        None,
+    )
+    .await;
+
+    let outcome = mgr
+        .prune_managed(PruneFilter::Unresolvable, false, false, None, None)
+        .await
+        .expect("prune unresolvable");
+    assert!(
+        outcome.sessions.is_empty(),
+        "a record still naming a workspace is not unresolvable: {:?}",
+        selected(&outcome)
+    );
+    assert_eq!(
+        mgr.get(&half).await.expect("record").state,
+        ManagedSessionState::Active
+    );
+}
+
+/// `--include-active` neither enables nor widens this filter (#6118).
+///
+/// Why: the flag is a BLANKET lift of the liveness gate, and needing it would
+/// mean typing the flag whose default behaviour is the footgun. Asserting the
+/// two selections are IDENTICAL pins both halves at once: the filter works
+/// without it, and passing it pulls in nothing extra.
+/// What: seeds a ghost plus a healthy Active session, dry-runs `unresolvable`
+/// with `include_active` false and then true, and compares selections.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn unresolvable_filter_needs_no_include_active() {
+    let dir = crate::test_support::hermetic_temp_dir();
+    let (mgr, _fake) = make_manager(&dir).await;
+    let ghost = ManagedSessionId::new();
+    seed_ghost(&mgr, ghost, "tm-ghost-flagless").await;
+    seed_record(
+        &mgr,
+        &dir,
+        ManagedSessionId::new(),
+        ManagedSessionState::Active,
+        false,
+    )
+    .await;
+
+    let without = mgr
+        .prune_managed(PruneFilter::Unresolvable, true, false, None, None)
+        .await
+        .expect("dry-run without the flag");
+    let with = mgr
+        .prune_managed(PruneFilter::Unresolvable, true, true, None, None)
+        .await
+        .expect("dry-run with the flag");
+
+    assert_eq!(selected(&without), vec![ghost.to_string()]);
+    assert_eq!(
+        selected(&without),
+        selected(&with),
+        "--include-active must not change what `unresolvable` selects"
+    );
+}
+
+/// ACCEPTANCE 3 (#6118): the dry run reports exactly what the real run does.
+///
+/// Why: a 2026-08-03 finding claimed prune's dry run misreported its outcome.
+/// The class it named is fixed (`PruneAction::DecommissionedWorktreeRetained`,
+/// pinned by `prune_reports_dirty_worktree_retained` and
+/// `prune_dry_run_reports_without_mutating`), but nothing asserted the two
+/// selections are the SAME selection — which is the property an operator relies
+/// on when they preview a destructive sweep before running it.
+/// What: dry-runs against the fixture, asserts nothing moved, then runs for real
+/// against the SAME fixture and asserts an identical id set and identical
+/// per-record actions.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn unresolvable_dry_run_selects_exactly_what_the_real_run_does() {
+    let dir = crate::test_support::hermetic_temp_dir();
+    let (mgr, _fake) = make_manager(&dir).await;
+    let a = ManagedSessionId::new();
+    let b = ManagedSessionId::new();
+    seed_ghost(&mgr, a, "tm-ghost-parity-a").await;
+    seed_ghost(&mgr, b, "tm-ghost-parity-b").await;
+    seed_record(
+        &mgr,
+        &dir,
+        ManagedSessionId::new(),
+        ManagedSessionState::Active,
+        false,
+    )
+    .await;
+
+    let preview = mgr
+        .prune_managed(PruneFilter::Unresolvable, true, false, None, None)
+        .await
+        .expect("dry run");
+    assert!(
+        preview.dry_run,
+        "the outcome must report itself as a dry run"
+    );
+    // NON-VACUITY: parity between two EMPTY selections is not parity. Pin the
+    // preview to both ghosts, so a selector that stops selecting anything fails
+    // here instead of passing by symmetry.
+    assert_eq!(
+        selected(&preview).len(),
+        2,
+        "both ghosts must be previewed, or the comparison below proves nothing: {:?}",
+        selected(&preview)
+    );
+    // A preview mutates nothing — otherwise the "same fixture" claim below is
+    // false and the comparison is meaningless.
+    for id in [a, b] {
+        assert_eq!(
+            mgr.get(&id).await.expect("record").state,
+            ManagedSessionState::Active,
+            "the dry run must not have touched {id}"
+        );
+    }
+
+    let real = mgr
+        .prune_managed(PruneFilter::Unresolvable, false, false, None, None)
+        .await
+        .expect("real run");
+
+    assert_eq!(
+        selected(&preview),
+        selected(&real),
+        "the preview and the real run must select the same records"
+    );
+    let actions = |o: &super::PruneOutcome| {
+        let mut v: Vec<String> = o
+            .sessions
+            .iter()
+            .map(|s| format!("{} {}", s.id, s.action.as_str()))
+            .collect();
+        v.sort();
+        v
+    };
+    assert_eq!(
+        actions(&preview),
+        actions(&real),
+        "the preview must predict the same action per record"
+    );
+}
+
+/// ACCEPTANCE 4 (#6118): `decommission-ephemeral`'s new preview selects exactly
+/// what its real sweep does.
+///
+/// Why: the verb had no `--dry-run` at all, so its selection could not be
+/// inspected before it ran. Routing both through one call differing in one
+/// boolean is what makes them agree; this asserts they do, and that the preview
+/// leaves the fleet alone.
+/// What: seeds one ephemeral and one durable session, previews, asserts both
+/// records survive and only the ephemeral was reported, then sweeps for real and
+/// compares.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn ephemeral_dry_run_selects_exactly_what_the_real_run_does() {
+    let dir = crate::test_support::hermetic_temp_dir();
+    let (mgr, _fake) = make_manager(&dir).await;
+    let eph = ManagedSessionId::new();
+    let durable = ManagedSessionId::new();
+    seed_record(&mgr, &dir, eph, ManagedSessionState::Active, true).await;
+    seed_record(&mgr, &dir, durable, ManagedSessionState::Active, false).await;
+
+    let preview = mgr.sweep_all_ephemeral(true).await.expect("preview");
+    assert_eq!(selected(&preview), vec![eph.to_string()]);
+    assert_eq!(
+        mgr.get(&eph).await.expect("record").state,
+        ManagedSessionState::Active,
+        "the preview must not tear the ephemeral session down"
+    );
+
+    let real = mgr.sweep_all_ephemeral(false).await.expect("real sweep");
+    assert_eq!(
+        selected(&preview),
+        selected(&real),
+        "the ephemeral preview and sweep must select the same records"
+    );
+    assert_eq!(
+        mgr.get(&durable).await.expect("record").state,
+        ManagedSessionState::Active,
+        "a durable session is unreachable by this path"
+    );
+}
+
+/// 🔴 ACCEPTANCE 5 (#6118): no prune path selects the INVOKING session.
+///
+/// Why: the measured `--state all --include-active` sweep selected 55 sessions,
+/// the operator's own current session among them. A tidy-up that takes down the
+/// terminal it was typed in is an outage. This is asserted under the WIDEST
+/// filter and the widest flag — `All` with `include_active` — because a guard
+/// that only holds on the narrow selector protects nothing.
+/// What: seeds two live Active sessions, prunes `All` with `include_active` and
+/// `invoker = Some(mine)`, and asserts the peer was taken and the invoker was
+/// not — including that the invoker's record is still `Active`.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn prune_never_selects_the_invoking_session() {
+    let dir = crate::test_support::hermetic_temp_dir();
+    let (mgr, _fake) = make_manager(&dir).await;
+    let mine = ManagedSessionId::new();
+    let peer = ManagedSessionId::new();
+    seed_record(&mgr, &dir, mine, ManagedSessionState::Active, false).await;
+    seed_record(&mgr, &dir, peer, ManagedSessionState::Active, false).await;
+
+    let outcome = mgr
+        .prune_managed(PruneFilter::All, false, true, None, Some(mine))
+        .await
+        .expect("prune all");
+
+    assert_eq!(
+        selected(&outcome),
+        vec![peer.to_string()],
+        "CONTROL: the peer must be taken (so the sweep really ran) and the invoker spared"
+    );
+    assert_eq!(
+        mgr.get(&mine).await.expect("invoker record").state,
+        ManagedSessionState::Active,
+        "the invoking session must still be running"
+    );
+}
+
+/// ACCEPTANCE 6 (#6118): two records sharing one pane are BOTH tombstoned, and
+/// the pane is reclaimed once.
+///
+/// Why: 3 of the 23 measured ghosts were double-registered under a second id by
+/// the #6117 race, so the duplicate case is real data this selector will meet.
+/// The behaviour is worth pinning either way it lands: `decommission`'s
+/// `graceful_terminate_runtime` self-guards on `session_exists`, so the second
+/// record's teardown finds the pane already gone and is a no-op rather than an
+/// error — which is why both rows clear in one pass instead of one clearing and
+/// one failing.
+/// What: seeds two ghosts sharing one `tmux_name` and one `pane_id`, prunes
+/// `unresolvable`, and asserts both are selected, both are tombstoned, and the
+/// tmux session is gone.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn unresolvable_duplicates_sharing_a_pane_are_both_tombstoned() {
+    let dir = crate::test_support::hermetic_temp_dir();
+    let (mgr, _fake) = make_manager(&dir).await;
+    let first = ManagedSessionId::new();
+    let second = ManagedSessionId::new();
+    seed_ghost(&mgr, first, "tm-ghost-dup").await;
+    // The #6117 shape: a second id for the SAME pane and the same tmux name.
+    seed_ghost(&mgr, second, "tm-ghost-dup").await;
+
+    let outcome = mgr
+        .prune_managed(PruneFilter::Unresolvable, false, false, None, None)
+        .await
+        .expect("prune unresolvable");
+
+    let mut expected = vec![first.to_string(), second.to_string()];
+    expected.sort();
+    assert_eq!(
+        selected(&outcome),
+        expected,
+        "both duplicate records must be selected in one pass"
+    );
+    for id in [first, second] {
+        assert_eq!(
+            mgr.get(&id).await.expect("record").state,
+            ManagedSessionState::Decommissioned,
+            "{id} must be tombstoned"
+        );
+    }
+    assert!(
+        !mgr.tmux
+            .session_exists_checked("tm-ghost-dup")
+            .expect("probe"),
+        "the shared pane must be reclaimed"
+    );
+}
+
+/// `PruneFilter::parse` accepts the new spelling and still rejects garbage
+/// (#6118).
+///
+/// Why: `--state active` was rejected outright when an operator went looking for
+/// this class, and the error message is the only place the supported values are
+/// listed. A new variant that parses but is absent from that message is a
+/// selector nobody can find.
+/// Test: this function IS the test.
+#[test]
+fn unresolvable_filter_parses_and_is_listed_in_the_error() {
+    assert_eq!(
+        PruneFilter::parse("unresolvable").expect("parses"),
+        PruneFilter::Unresolvable
+    );
+    assert_eq!(PruneFilter::Unresolvable.as_str(), "unresolvable");
+    let err = PruneFilter::parse("active").expect_err("`active` is still not a filter");
+    assert!(
+        err.contains("unresolvable"),
+        "the rejection must name the new filter: {err}"
+    );
+    assert!(
+        PruneFilter::Unresolvable.selects_regardless_of_liveness(),
+        "this is the one filter that ignores liveness"
+    );
+    for f in [
+        PruneFilter::Ephemeral,
+        PruneFilter::Stopped,
+        PruneFilter::Decommissioned,
+        PruneFilter::Deleted,
+        PruneFilter::All,
+    ] {
+        assert!(
+            !f.selects_regardless_of_liveness(),
+            "{f} must keep its liveness gate"
+        );
+    }
+}

--- a/crates/trusty-mpm/src/session_manager/reconcile.rs
+++ b/crates/trusty-mpm/src/session_manager/reconcile.rs
@@ -221,7 +221,9 @@ impl SessionManager {
             .iter()
             .filter(|r| !matches!(r.state, ManagedSessionState::Decommissioned))
             .filter_map(|r| r.workspace_path.clone())
-            .filter(|p| p.as_path() != Path::new("/unknown"))
+            // #6118: one spelling of the sentinel, shared with every other
+            // reader of it.
+            .filter(|p| p.as_path() != Path::new(super::record::UNRESOLVED_PATH_SENTINEL))
             .map(|p| std::fs::canonicalize(&p).unwrap_or(p))
             .collect();
 

--- a/crates/trusty-mpm/src/session_manager/record.rs
+++ b/crates/trusty-mpm/src/session_manager/record.rs
@@ -12,11 +12,26 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::fmt;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use thiserror::Error;
 use uuid::Uuid;
 
 use super::injection_status::InjectionStatus;
+
+/// The literal path a record carries when its working directory could not be
+/// resolved at all.
+///
+/// Why: this string was spelled out four times — `adopt::derive_source_id`,
+/// `reconcile`'s known-workspace set, `dedup::is_resolved_existing`, and (since
+/// #6118) [`SessionRecord::workspace_unresolvable`] — and every one of them is
+/// deciding the same question about the same value. A fifth spelling is how the
+/// four drift apart, so they now read one constant.
+/// What: `/unknown`, the value the pre-#6126 external-adopt path stubbed into
+/// `cwd`/`workspace_path` when `get_pane_cwd` returned nothing. It is not a real
+/// path and is never created on disk.
+/// Test: `unresolvable_record_is_selected_by_the_unresolvable_filter`,
+/// `is_resolved_existing_false_for_none_and_unknown_sentinel`.
+pub const UNRESOLVED_PATH_SENTINEL: &str = "/unknown";
 
 /// Opaque identifier for a managed session.
 ///
@@ -495,6 +510,48 @@ impl SessionRecord {
         } else if !was_terminal || self.terminal_at.is_none() {
             self.terminal_at = Some(now);
         }
+    }
+
+    /// Whether this record names no workspace a caller could ever resume,
+    /// attach to, or reason about (#6118).
+    ///
+    /// Why: the pre-#6126 external-adopt path minted a record for every
+    /// unrecognised tmux pane, and stubbed `cwd` to
+    /// [`UNRESOLVED_PATH_SENTINEL`] with `workspace_path` unset whenever
+    /// `get_pane_cwd` came back empty. #6126 stopped MINTING those, but nothing
+    /// could SELECT the ones already in the store: 23 of them sat `Active` on
+    /// the reporting host, and every existing selector missed them — `--state`
+    /// has no variant for them, `prune-idle` keys on an activity verdict, and
+    /// the `tm ls` auto-prune requires a dead pane. This predicate is the
+    /// missing question, asked once so the prune engine and its tests agree on
+    /// the answer.
+    ///
+    /// 🔴 It is deliberately a RECORD-SHAPE test with no filesystem probe. A
+    /// record naming a real directory on an unmounted volume is NOT unresolvable
+    /// by this rule, which is what keeps the selector out of the mass-tombstone
+    /// hazard `session_picker_prune::workspace_verified_gone` documents at
+    /// length: `try_exists` answers `Ok(false)` for every path on an unplugged
+    /// drive, so any probe-based widening would select a whole volume's sessions
+    /// at once. The sentinel cannot be produced that way — only by an adopt that
+    /// already failed to resolve anything.
+    ///
+    /// A healthy session therefore never satisfies this, whatever its state or
+    /// liveness: it was spawned with a real `cwd`, and a provisioned one also
+    /// carries a `workspace_path`.
+    /// What: `true` only when BOTH coordinates are unresolvable — `cwd` is the
+    /// sentinel, AND `workspace_path` is absent or is itself the sentinel. One
+    /// resolvable coordinate is enough to keep the record.
+    /// Test: `unresolvable_record_is_selected_by_the_unresolvable_filter`,
+    /// `healthy_active_session_is_never_selected_by_the_unresolvable_filter`,
+    /// `unresolvable_filter_keeps_a_record_that_still_names_a_workspace`.
+    pub fn workspace_unresolvable(&self) -> bool {
+        let sentinel = Path::new(UNRESOLVED_PATH_SENTINEL);
+        let cwd_unresolvable = self.cwd == sentinel;
+        let workspace_unresolvable = match &self.workspace_path {
+            None => true,
+            Some(p) => p == sentinel,
+        };
+        cwd_unresolvable && workspace_unresolvable
     }
 }
 

--- a/crates/trusty-mpm/src/session_manager/record.rs
+++ b/crates/trusty-mpm/src/session_manager/record.rs
@@ -29,7 +29,7 @@ use super::injection_status::InjectionStatus;
 /// What: `/unknown`, the value the pre-#6126 external-adopt path stubbed into
 /// `cwd`/`workspace_path` when `get_pane_cwd` returned nothing. It is not a real
 /// path and is never created on disk.
-/// Test: `unresolvable_record_is_selected_by_the_unresolvable_filter`,
+/// Test: `unresolvable_filter_selects_a_live_ghost_pane`,
 /// `is_resolved_existing_false_for_none_and_unknown_sentinel`.
 pub const UNRESOLVED_PATH_SENTINEL: &str = "/unknown";
 
@@ -541,7 +541,7 @@ impl SessionRecord {
     /// What: `true` only when BOTH coordinates are unresolvable — `cwd` is the
     /// sentinel, AND `workspace_path` is absent or is itself the sentinel. One
     /// resolvable coordinate is enough to keep the record.
-    /// Test: `unresolvable_record_is_selected_by_the_unresolvable_filter`,
+    /// Test: `unresolvable_filter_selects_a_live_ghost_pane`,
     /// `healthy_active_session_is_never_selected_by_the_unresolvable_filter`,
     /// `unresolvable_filter_keeps_a_record_that_still_names_a_workspace`.
     pub fn workspace_unresolvable(&self) -> bool {

--- a/crates/trusty-mpm/src/session_manager/tests.rs
+++ b/crates/trusty-mpm/src/session_manager/tests.rs
@@ -2128,6 +2128,7 @@ async fn prune_by_state_never_touches_active() {
             false,
             false,
             None,
+            None,
         )
         .await
         .expect("prune stopped");
@@ -2168,6 +2169,7 @@ async fn prune_decommissioned_compacts() {
             crate::session_manager::PruneFilter::Decommissioned,
             false,
             false,
+            None,
             None,
         )
         .await
@@ -2225,6 +2227,7 @@ async fn prune_deleted_compacts() {
             false,
             false,
             None,
+            None,
         )
         .await
         .expect("compact deleted");
@@ -2270,7 +2273,13 @@ async fn prune_all_targets_non_running() {
     seed_record(&mgr, &dir, tomb, ManagedSessionState::Decommissioned, false).await;
 
     let outcome = mgr
-        .prune_managed(crate::session_manager::PruneFilter::All, false, false, None)
+        .prune_managed(
+            crate::session_manager::PruneFilter::All,
+            false,
+            false,
+            None,
+            None,
+        )
         .await
         .expect("prune all");
     assert_eq!(
@@ -2319,6 +2328,7 @@ async fn prune_dry_run_reports_without_mutating() {
             true,
             false,
             None,
+            None,
         )
         .await
         .expect("dry run");
@@ -2348,6 +2358,8 @@ fn prune_filter_parse_round_trip() {
         PruneFilter::Decommissioned,
         PruneFilter::Deleted,
         PruneFilter::All,
+        // #6118: the unresolvable-workspace selector round-trips like the rest.
+        PruneFilter::Unresolvable,
     ] {
         assert_eq!(PruneFilter::parse(f.as_str()).unwrap(), f);
     }
@@ -2378,6 +2390,7 @@ async fn prune_outcome_serializes() {
             crate::session_manager::PruneFilter::Ephemeral,
             true,
             false,
+            None,
             None,
         )
         .await

--- a/crates/trusty-mpm/tests/session_manager_mvp.rs
+++ b/crates/trusty-mpm/tests/session_manager_mvp.rs
@@ -1406,7 +1406,7 @@ async fn decode_response(
 /// Test: this function IS the test.
 #[tokio::test]
 async fn decommission_ephemeral_route_tears_down_only_ephemeral() {
-    use trusty_mpm::daemon::managed_routes::decommission_ephemeral_route;
+    use trusty_mpm::daemon::managed_routes::{EphemeralQuery, decommission_ephemeral_route};
     use trusty_mpm::session_manager::ManagedSessionState;
 
     // FakeNoopTmuxDriver: no real tmux sessions are created — nothing can escape
@@ -1442,9 +1442,35 @@ async fn decommission_ephemeral_route_tears_down_only_ephemeral() {
     // No real tmux sessions were created (FakeNoopTmuxDriver), so no reap
     // guards are needed (#1790).
 
-    let (status, body) =
-        decode_response(decommission_ephemeral_route(axum::extract::State(state.clone())).await)
-            .await;
+    // #6118: the PREVIEW runs first, against the same seeded fleet, and must
+    // report the same two sessions while mutating nothing — otherwise the flag
+    // that now guards this destructive verb is unproven end-to-end.
+    let (preview_status, preview) = decode_response(
+        decommission_ephemeral_route(
+            axum::extract::State(state.clone()),
+            axum::extract::Query(EphemeralQuery { dry_run: true }),
+        )
+        .await,
+    )
+    .await;
+    assert_eq!(preview_status, axum::http::StatusCode::OK);
+    assert_eq!(
+        preview["decommissioned"], 2,
+        "the preview must report the same two sessions, got {preview}"
+    );
+    assert_eq!(
+        preview["dry_run"], true,
+        "the route must echo the honoured preview flag, got {preview}"
+    );
+
+    let (status, body) = decode_response(
+        decommission_ephemeral_route(
+            axum::extract::State(state.clone()),
+            axum::extract::Query(EphemeralQuery { dry_run: false }),
+        )
+        .await,
+    )
+    .await;
     assert_eq!(status, axum::http::StatusCode::OK);
     assert_eq!(
         body["decommissioned"], 2,


### PR DESCRIPTION
Refs #6118

## The gap

#6126 stopped MINTING adoption ghosts — records whose `cwd` is the `/unknown`
sentinel and whose `workspace_path` is unset. Nothing could SELECT the ones
already in the store. The selector matrix measured on the reporting host, with 23
such records present:

| command | selected |
|---|---|
| `prune --state ephemeral\|stopped\|decommissioned\|deleted\|all` | 0 |
| `prune --state active` | rejected — not a valid value |
| `prune-idle --dry-run` | 0 (all 23 classify `verdict=errored`) |
| `prune-worktrees` | 0 (OS temp paths, not `.worktrees/`) |
| `prune --state all --include-active` | 55 — the 23 plus 32 healthy live sessions, including the operator's own |

## Design, and why

**A new `PruneFilter::Unresolvable` variant, `tm session prune --state
unresolvable`.** Three alternatives were on the table — a separate
`--stale-assets` flag, extending `session_picker_prune::is_clearable_state`, or a
new filter — and the record decides it:

- The class is defined by the RECORD, not by a lifecycle state, so every
  state-keyed filter misses it structurally. A new variant is the only place that
  question fits.
- `is_clearable_state` is the wrong home. It gates the automatic `tm ls` sweep,
  which must never touch a live pane; these records are live by definition.
  Widening it would make an unattended path destructive.
- A separate flag would have to compose with `--state`, and every combination
  would need its own meaning. One filter, one predicate.

**The predicate is record-shape only, with no filesystem probe**
(`SessionRecord::workspace_unresolvable`): `cwd` is the sentinel AND
`workspace_path` is absent or is the sentinel. A real path on an unmounted volume
therefore can never satisfy it — which is what keeps this clear of the
mass-tombstone hazard `session_picker_prune::workspace_verified_gone` documents at
length, where `try_exists` answers `Ok(false)` for a whole unplugged drive.

**It is the one filter whose selection ignores tmux liveness**
(`PruneFilter::selects_regardless_of_liveness`). That is the constraint the
research named: a live pane is the DEFINING property of this class, so the
selector has to act on one — but it must not inherit `--include-active`'s blanket
behaviour. Answering the question per-filter is what keeps the lift narrow. The
predicate, not a flag, bounds the blast radius: an unresolvable record has no
`workspace_path`, so its teardown can remove no directory, worktree, or branch.
It reclaims the leaked pane and the store row, nothing else. `--include-active` is
neither needed nor widening here, asserted directly.

**Not changed: `prune-idle`.** Its domain is activity verdicts. Teaching it about
stale assets would be a second implementation of this predicate.

## Also in this PR

- `tm session decommission-ephemeral --dry-run`. Preview and real sweep are ONE
  call differing in one boolean (`sweep_all_ephemeral`), so they cannot select
  different sets.
- 🔴 **No prune path can select the invoking session.** The CLI sends
  `$TM_MANAGED_SESSION_ID` as `invoking_session`; the engine excludes that record
  for EVERY filter, `--include-active` included. This is the 55-session sweep's
  actual damage: a tidy-up that takes down the terminal it was typed in.
- The four spellings of the `/unknown` sentinel converge on one
  `UNRESOLVED_PATH_SENTINEL` constant (`adopt`, `reconcile`, `dedup`, and the new
  predicate).

## Fail-open check

Two new branches downgrade a failure, and both are closed with a regression test
that fails against the pre-fix behaviour (verified by mutation, below):

1. **The ephemeral route's `dry_run` echo.** This daemon is long-lived by design —
   a CLI upgrade never bounces it — and axum silently drops a query param the
   running handler does not declare. A daemon predating this change accepts
   `?dry_run=true`, runs the REAL sweep, and returns 200. Status alone cannot tell
   that apart from an honoured preview, so the route echoes `dry_run` and the CLI
   REFUSES to report a preview the daemon did not confirm. Same skew and same
   remedy as `session_picker_prune::decommission_dead_record`'s
   `workspace_removed` check.
2. **An unparseable `invoking_session` is a 400, not a dropped field.** Dropping
   it would run the sweep with the protection the caller explicitly asked for
   silently switched off.

## Dry-run parity, confirmed rather than assumed

The 2026-08-03 finding that prune's dry run misreported its outcome was
re-checked. The class it named is fixed
(`PruneAction::DecommissionedWorktreeRetained`), but nothing asserted the two
selections were the SAME selection. `unresolvable_dry_run_selects_exactly_what_the_real_run_does`
now runs both against one fixture and compares ids AND per-record actions, with a
non-vacuity assertion so parity between two empty selections cannot pass it.

## Acceptance tests

| # | criterion | test | result |
|---|---|---|---|
| 1 | healthy active session NOT selected | `healthy_active_session_is_never_selected_by_the_unresolvable_filter` | ok |
| 2 | stale record IS selected, live pane | `unresolvable_filter_selects_a_live_ghost_pane` | ok |
| 3 | dry-run == real run | `unresolvable_dry_run_selects_exactly_what_the_real_run_does` | ok |
| 4 | `decommission-ephemeral --dry-run` | `ephemeral_dry_run_selects_exactly_what_the_real_run_does`, `cli_parses_session_decommission_ephemeral_dry_run`, `ephemeral_route_dry_run_reports_without_tearing_down` | ok |
| 5 | 🔴 never selects the invoking session | `prune_never_selects_the_invoking_session` | ok |
| 6 | duplicate `pane_id` behaves predictably | `unresolvable_duplicates_sharing_a_pane_are_both_tombstoned` | ok |

Criterion 6's documented behaviour: both records are tombstoned in one pass. The
pane is reclaimed once — `decommission`'s `graceful_terminate_runtime` self-guards
on `session_exists`, so the second record's teardown finds the pane already gone
and is a no-op rather than an error.

Supporting: `unresolvable_filter_keeps_a_record_that_still_names_a_workspace`,
`unresolvable_filter_needs_no_include_active`,
`unresolvable_filter_parses_and_is_listed_in_the_error`,
`prune_route_rejects_an_unparseable_invoking_session`,
`decommission_ephemeral_refuses_a_dry_run_a_stale_daemon_ignored`,
`decommission_ephemeral_reports_a_confirmed_dry_run`,
`cli_parses_session_prune_unresolvable`.

### Non-vacuity, by mutation

Each guard was removed and the tests re-run:

```
matches_filter's Unresolvable arm -> `true`, and the invoker guard -> `if false &&`:
  test result: FAILED. 4 passed; 5 failed
    unresolvable_filter_needs_no_include_active FAILED
    unresolvable_filter_keeps_a_record_that_still_names_a_workspace FAILED
    healthy_active_session_is_never_selected_by_the_unresolvable_filter FAILED
    prune_never_selects_the_invoking_session FAILED
    unresolvable_dry_run_selects_exactly_what_the_real_run_does FAILED

ignore_liveness -> `include_active` alone:
  test result: FAILED. 5 passed; 4 failed
    unresolvable_filter_selects_a_live_ghost_pane FAILED
    unresolvable_filter_needs_no_include_active FAILED
    unresolvable_duplicates_sharing_a_pane_are_both_tombstoned FAILED
    healthy_active_session_is_never_selected_by_the_unresolvable_filter FAILED

the dry_run echo check -> `if false`:
  decommission_ephemeral_refuses_a_dry_run_a_stale_daemon_ignored FAILED

the 400 arm -> `Some(Err(_)) => None` (silently drop):
  prune_route_rejects_an_unparseable_invoking_session FAILED
```

## Gates — test ladder RUNG 5

Session/process lifecycle plus a destructive path, so rung 5, not rung 3.

```
cargo fmt --check                                       EXIT=0
cargo check -p trusty-mpm --all-targets                 EXIT=0
cargo clippy -p trusty-mpm --all-targets -- -D warnings EXIT=0
cargo test -p trusty-mpm                                EXIT=0
  test result: ok. 5245 passed; 0 failed; 7 ignored
  test result: ok. 1781 passed; 0 failed; 1 ignored     (bin tm)
  test result: ok. 1781 passed; 0 failed; 1 ignored     (bin trusty-mpm)
  + 47 further targets, all ok
cargo check --workspace                                 EXIT=0
bash scripts/check_line_cap.sh                          EXIT=0
  4165 tracked .rs file(s); 4 allowlisted, 0 violations
bash scripts/check_sld.sh                               EXIT=0
bash scripts/check_changelog_fragment.sh                EXIT=0
```

No crate depends on the `trusty-mpm` library, so rung 4's per-dependent test set
is empty; `cargo check --workspace` still ran.

### `--include-ignored` integration coverage

```
cargo test -p trusty-mpm --test session_manager_mvp -- --include-ignored
  test result: FAILED. 29 passed; 1 failed
  failures: live_pane_scoped_send_targets_original_pane_not_sibling
    tmux access refused: $HOME is /var/folders/... but this user's real home is
    /Users/masa — ... Set TRUSTY_MPM_ALLOW_HOST_STATE=1 to allow it. (#5784)
```

PRE-EXISTING, reproduced on `origin/main` by stashing this branch:

```
(at 9fe56f1ca, clean tree)
cargo test -p trusty-mpm --test session_manager_mvp -- --include-ignored
  test result: FAILED. 29 passed; 1 failed
  failures: live_pane_scoped_send_targets_original_pane_not_sibling
```

It passes when run alone on either tree, so it is order-dependent: a sibling test
overrides `$HOME` and the #5784 host-state guard then refuses real tmux. With that
one test skipped, this branch is green:

```
cargo test -p trusty-mpm --test session_manager_mvp -- --include-ignored \
  --skip live_pane_scoped_send_targets_original_pane_not_sibling
  test result: ok. 29 passed; 0 failed
```

### SLOC cap

Adding two CLI-parse tests pushed `tests_behavior_d_tests.rs` to 3013 SLOC, over
the 3000 test cap. Split in THIS PR per the no-standalone-cap-fix rule: both moved
to `tests_behavior_e_tests.rs` (481 SLOC), with a pointer left behind. `main.rs`
was NOT used to mount a new test module — that would have taken it to 501 SLOC,
over the production cap.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
