### PR TITLE
docs(trusty-search): the shrink guard's gap is closed, stop citing #3970 as open

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11827,7 +11827,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-search"
-version = "0.49.1"
+version = "0.49.2"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -9,7 +9,7 @@ name = "trusty-search"
 # forbids moving or deleting a pushed tag — so 0.49.0/its tag are a burned,
 # never-published marker and this release ships as 0.49.1 instead. No src
 # change beyond this version bump.
-version = "0.49.1"
+version = "0.49.2"
 edition = "2021"
 description = "Machine-wide hybrid code search service: BM25 + vector + KG, zero cold-start, MCP server"
 readme = "README.md"

--- a/crates/trusty-search/changelog.d/6202-shrink-guard-3970-closed.md
+++ b/crates/trusty-search/changelog.d/6202-shrink-guard-3970-closed.md
@@ -1,0 +1,6 @@
+Documentation
+- Fixed the stale doc comment on `SHRINK_GUARD_RATIO_DIVISOR`
+  (`core::store::usearch_store`), which still described the periodic HNSW
+  persister's checkpoint race as open work tracked by #3970. #3970 is closed;
+  #3975 shipped the staged-write-then-swap the comment cited as a
+  recommendation, and the comment now describes that fix (#6202).

--- a/crates/trusty-search/src/core/store/usearch_store.rs
+++ b/crates/trusty-search/src/core/store/usearch_store.rs
@@ -157,27 +157,24 @@ pub(super) const SHRINK_GUARD_MIN_ON_DISK_VECTORS: usize = 1_000;
 /// graceful-shutdown path.
 ///
 /// This ratio guard remains in `save()` as defense-in-depth for every OTHER
-/// caller — but for the one that actually matters in practice, the periodic
+/// caller. For the one that used to matter in practice — the periodic
 /// incremental persister (`core::indexer::persist_hnsw::spawn_incremental_persist`,
 /// called every `HNSW_SNAPSHOT_BATCH_INTERVAL` batches during EVERY reindex,
-/// plus once forced after the batch loop), this guard provides essentially
-/// NO protection on any reindex large enough to matter — tracked as **issue
-/// #3970**. Reindex progress is monotonic, so on any reindex whose final
-/// vector count exceeds roughly double the on-disk starting count, the
-/// persister's own routine, healthy checkpoints WILL cross this guard's 50%
-/// threshold as completely normal forward progress — no interruption
-/// required. The moment that happens, the complete pre-reindex on-disk
-/// snapshot has already been overwritten by a partial, still-growing one,
-/// during ordinary healthy operation. From then on an ungraceful termination
-/// (SIGKILL, OOM-kill, process abort, power loss — none of which run
-/// `shutdown_flush`'s exact check) at ANY later point — including 99%
-/// complete — permanently strands the index at whatever fraction was last
-/// checkpointed, with no path back to the original complete snapshot. #3970
-/// records the recommended fix: a staged-write-then-swap for the HNSW
-/// snapshot, mirroring what the redb corpus already has via #603/#839 —
-/// explicitly NOT routing the periodic save through a skip-while-`Running`
-/// gate, which would defeat incremental persistence's entire purpose
-/// (checkpointing durability during a long-running reindex).
+/// plus once forced after the batch loop) — this guard alone provided
+/// essentially no protection on a reindex large enough to matter, because
+/// reindex progress is monotonic: on any reindex whose final vector count
+/// exceeds roughly double the on-disk starting count, the persister's own
+/// routine, healthy checkpoints WOULD cross this guard's 50% threshold as
+/// normal forward progress, overwriting the complete pre-reindex snapshot
+/// with a partial, still-growing one during ordinary operation. That gap is
+/// closed by #3975's staged-write-then-swap: while a reindex is in flight
+/// (`CodeIndexer::begin_reindex_staging`), every periodic checkpoint is
+/// redirected to a staging path instead of the live snapshot
+/// (`core::indexer::persist_hnsw::spawn_incremental_persist`), and the live
+/// snapshot is only replaced once by
+/// `service::reindex::hnsw_swap::commit_staged_hnsw_swap` after the reindex
+/// finishes and any in-flight checkpoint has quiesced. This ratio guard is no
+/// longer that path's only line of defense; see #3975.
 pub(super) const SHRINK_GUARD_RATIO_DIVISOR: usize = 2; // refuse below 50%
 
 /// Minimum plausible bytes-per-dimension-per-vector used to compute the


### PR DESCRIPTION
## Summary

The doc comment on `SHRINK_GUARD_RATIO_DIVISOR`
(`crates/trusty-search/src/core/store/usearch_store.rs:159-180`) described the
periodic HNSW incremental persister's checkpoint race as unprotected open
work, citing #3970 and a "recommended fix" of a staged-write-then-swap.

#3970 is closed, fixed by #3975 (merged 2026-07-26). That staged-write-then-swap
is live: `CodeIndexer::begin_reindex_staging` /
`CodeIndexer::end_reindex_staging`
(`crates/trusty-search/src/core/indexer/persist_hnsw.rs:150-175`) redirect
periodic checkpoints to a staging path while a reindex is in flight, and
`service::reindex::hnsw_swap::commit_staged_hnsw_swap` publishes the live
snapshot only once, after quiescing any in-flight persist task. Rewrote the
comment to describe that as shipped, not proposed.

## Test plan

Rung 1 (docs/comment-only, no Cargo test owed):

- `cargo fmt --check` — exit 0
- `bash scripts/check_sld.sh` — exit 0
- `bash scripts/check_changelog_fragment.sh` — FAILED before adding a fragment
  (the gate is path-based, not diff-content-based — any non-test `src/**`
  change owes one, comment-only or not); added
  `crates/trusty-search/changelog.d/6202-shrink-guard-3970-closed.md`, then
  exit 0.

Refs #6202

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools