### PR TITLE
fix(trusty-review): a per-request model override reaches the wire (Refs #6123)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11790,7 +11790,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-review"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-review/Cargo.toml
+++ b/crates/trusty-review/Cargo.toml
@@ -38,7 +38,12 @@ name        = "trusty-review"
 # `reporter_findings` and `synthesize_grounding` are crate-private, and the one
 # new `synthesize` helper is a private free function; no public type changes
 # shape.
-version     = "0.25.0"
+#
+# #6123: PATCH bump — 0.25.0 is published on crates.io and this change touches
+# `src/**`, so the pre-merge guard requires the next free position. The public
+# surface only grows: `LlmRequest::effective_model` and
+# `OpenRouterProvider::with_base_url` are added, nothing changes shape or moves.
+version     = "0.25.1"
 edition     = "2024"
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/trusty-review/changelog.d/6123-request-model-reaches-the-wire.md
+++ b/crates/trusty-review/changelog.d/6123-request-model-reaches-the-wire.md
@@ -1,0 +1,13 @@
+Fixed
+
+- A per-request model override now reaches the provider. `OpenRouterProvider`
+  and `FireworksProvider` serialised the id they were constructed with and
+  dropped `LlmRequest.model`, so a request naming a different model ran on the
+  constructor's model and the response echoed the wrong id with nothing
+  reporting the substitution; `BedrockProvider` already read `req.model`. All
+  three now resolve the same way through `LlmRequest::effective_model`, which
+  returns the request's id and falls back to the constructor's only when the
+  request names none. `OpenRouterProvider::with_base_url` is new — the
+  endpoint was a hardcoded constant, so nothing could assert on the bytes the
+  provider actually sends; the regression tests now read the model out of a
+  mock server's received body.

--- a/crates/trusty-review/src/llm/bedrock/mod.rs
+++ b/crates/trusty-review/src/llm/bedrock/mod.rs
@@ -243,6 +243,10 @@ impl BedrockProvider {
     async fn call_once(&self, req: &LlmRequest) -> Result<LlmResponse, LlmError> {
         let start = Instant::now();
 
+        // #6123: one resolver decides the model for all three providers; this
+        // one already read the request, and now says so in the same words.
+        let model = req.effective_model(&self.model);
+
         // Build system blocks and conversation messages from the LlmRequest.
         let mut system_blocks: Vec<SystemContentBlock> = Vec::new();
         if !req.system.is_empty() {
@@ -278,7 +282,7 @@ impl BedrockProvider {
         let mut sdk_req = self
             .client
             .converse()
-            .model_id(&req.model)
+            .model_id(model)
             .inference_config(inference)
             .set_messages(Some(converse_messages));
 
@@ -297,17 +301,17 @@ impl BedrockProvider {
             let lower = msg.to_lowercase();
             // Map SDK errors to LlmError variants using the error message text.
             if lower.contains("resourcenotfound") || lower.contains("no such model") {
-                LlmError::ModelNotFound(format!("model={}: {msg}", req.model))
+                LlmError::ModelNotFound(format!("model={model}: {msg}"))
             } else if lower.contains("accessdenied")
                 || lower.contains("unauthorized")
                 || lower.contains("credential")
                 || lower.contains("not authorized")
             {
                 LlmError::AccessDenied(format!(
-                    "AWS Bedrock access denied (model={}, region={}): {msg}. \
+                    "AWS Bedrock access denied (model={model}, region={}): {msg}. \
                      Ensure AWS credentials are configured and the account has \
                      bedrock:InvokeModel permission.",
-                    req.model, self.region
+                    self.region
                 ))
             } else if lower.contains("validationexception") || lower.contains("validation") {
                 LlmError::Validation(msg)
@@ -329,8 +333,8 @@ impl BedrockProvider {
                 LlmError::ModelNotReady(msg)
             } else {
                 LlmError::Transport(format!(
-                    "Bedrock Converse SDK error (model={}, region={}): {msg}",
-                    req.model, self.region
+                    "Bedrock Converse SDK error (model={model}, region={}): {msg}",
+                    self.region
                 ))
             }
         })?;
@@ -350,7 +354,7 @@ impl BedrockProvider {
         };
 
         let (input_tokens, output_tokens) = extract_token_usage(&resp);
-        let cost_usd = estimate_bedrock_cost_usd(&req.model, input_tokens, output_tokens);
+        let cost_usd = estimate_bedrock_cost_usd(model, input_tokens, output_tokens);
 
         // Bedrock Converse surfaces a stop reason (`end_turn`, `max_tokens`, …);
         // thread it through as the PRIMARY truncation signal (#1357).  `max_tokens`
@@ -359,7 +363,7 @@ impl BedrockProvider {
 
         Ok(LlmResponse {
             text,
-            model: req.model.clone(),
+            model: model.to_string(),
             input_tokens,
             output_tokens,
             latency_ms,
@@ -385,7 +389,7 @@ impl LlmProvider for BedrockProvider {
     /// Test: `bedrock_converse_request_construction` (unit, no real AWS calls).
     async fn complete(&self, req: LlmRequest) -> Result<LlmResponse, LlmError> {
         debug!(
-            model = %req.model,
+            model = %req.effective_model(&self.model),
             provider = "bedrock",
             region = %self.region,
             structured = req.response_schema.is_some(),
@@ -412,7 +416,7 @@ impl LlmProvider for BedrockProvider {
                     warn!(
                         attempt,
                         backoff_ms,
-                        model = %req.model,
+                        model = %req.effective_model(&self.model),
                         "bedrock transient error — retrying: {err}"
                     );
                     tokio::time::sleep(std::time::Duration::from_millis(backoff_ms)).await;

--- a/crates/trusty-review/src/llm/fireworks.rs
+++ b/crates/trusty-review/src/llm/fireworks.rs
@@ -284,12 +284,12 @@ impl FireworksProvider {
     /// Construct a provider with an explicit base URL.
     ///
     /// Why: lets tests point the provider at a mock HTTP server for a real
-    /// request/response round-trip — the coverage the hardcoded-URL OpenRouter
-    /// provider cannot get.
+    /// request/response round-trip.
     /// What: builds a `reqwest::Client` with connect and read timeouts;
     /// returns `LlmError::AccessDenied` if the key is empty.  A trailing `/`
     /// on `base_url` is trimmed so path joining is uniform.
-    /// Test: `complete_round_trips_through_mock_server`.
+    /// Test: `complete_round_trips_through_mock_server`,
+    /// `complete_sends_the_request_model_not_the_constructor_model`.
     pub fn with_base_url(
         api_key: impl Into<String>,
         model: impl Into<String>,
@@ -346,11 +346,20 @@ impl LlmProvider for FireworksProvider {
     /// "json_schema", json_schema: { name, schema } }` (no `strict` — see
     /// module docs) to force the model to emit structured JSON; the assistant
     /// message content will be the clean JSON object.
-    /// Test: `complete_round_trips_through_mock_server`,
+    ///
+    /// The model sent is [`LlmRequest::effective_model`] — the request's own
+    /// id, falling back to the constructor's only when the request names none
+    /// (#6123).
+    /// Test: `complete_sends_the_request_model_not_the_constructor_model`,
+    /// `complete_round_trips_through_mock_server`,
     /// `complete_with_schema_sends_response_format_without_strict`.
     async fn complete(&self, req: LlmRequest) -> Result<LlmResponse, LlmError> {
+        // #6123: the request's model is the model for this call; the id passed
+        // to the constructor is only the fallback when the request names none.
+        let model = req.effective_model(&self.model);
+
         debug!(
-            model = %self.model,
+            model = %model,
             structured = req.response_schema.is_some(),
             "fireworks complete request"
         );
@@ -389,7 +398,7 @@ impl LlmProvider for FireworksProvider {
         };
 
         let body = FwRequest {
-            model: &self.model,
+            model,
             messages: &messages,
             stream: false,
             temperature: req.temperature,
@@ -417,7 +426,7 @@ impl LlmProvider for FireworksProvider {
             let body_text = http_resp.text().await.unwrap_or_default();
             return Err(match status.as_u16() {
                 401 | 403 => LlmError::AccessDenied(body_text),
-                404 => LlmError::ModelNotFound(format!("model={}: {body_text}", self.model)),
+                404 => LlmError::ModelNotFound(format!("model={model}: {body_text}")),
                 422 => LlmError::Validation(body_text),
                 429 => LlmError::RateLimited,
                 _ => LlmError::Upstream {
@@ -450,7 +459,7 @@ impl LlmProvider for FireworksProvider {
             .map(|u| (u.prompt_tokens, u.completion_tokens))
             .unwrap_or((0, 0));
 
-        let model_used = fw.model.unwrap_or_else(|| self.model.clone());
+        let model_used = fw.model.unwrap_or_else(|| model.to_string());
         let cost_usd = estimate_cost_usd(&model_used, input_tokens, output_tokens);
 
         Ok(LlmResponse {

--- a/crates/trusty-review/src/llm/fireworks_tests.rs
+++ b/crates/trusty-review/src/llm/fireworks_tests.rs
@@ -214,9 +214,9 @@ fn reasoning_effort_from_passthrough() {
 
 /// Full request/response round-trip against a local mock HTTP server.
 ///
-/// Why: unlike the OpenRouter provider (hardcoded URL, so its "mock server"
-/// test never actually connects), the injectable base URL lets this test
-/// exercise the REAL request path: URL joining, bearer auth, JSON body,
+/// Why: the injectable base URL lets this test exercise the REAL request
+/// path rather than a struct the test built itself: URL joining, bearer auth,
+/// JSON body,
 /// response parsing, usage extraction, and finish_reason normalisation.
 /// What: binds a TcpListener, points the provider at it, sends a structured
 /// request, and asserts on both the captured request (path, auth header, bare
@@ -349,6 +349,143 @@ async fn complete_round_trips_through_mock_server() {
         resp.model,
         "accounts/fireworks/models/llama-v3p1-70b-instruct"
     );
+}
+
+/// The model on the wire is the request's, not the constructor's (#6123).
+///
+/// Why: `complete` used to serialise `self.model` and drop
+/// [`LlmRequest::model`], so a per-request override ran on the constructor's
+/// model and the response echoed the wrong id with nothing reporting the
+/// substitution. This is the only assertion that reaches the actual bytes.
+/// What: constructs the provider with one id, sends a request naming a
+/// different one, and reads the model field out of the POST body a mock
+/// server received. Also asserts the fallback: a blank request model still
+/// sends the constructor's id.
+/// Test: fails on `origin/main` with `left: "constructor/model-should-not-win"`.
+#[tokio::test]
+async fn complete_sends_the_request_model_not_the_constructor_model() {
+    let (addr, mock) = spawn_capturing_mock().await;
+    let provider = FireworksProvider::with_base_url(
+        "fw-mock-key", // pragma: allowlist secret
+        "constructor/model-should-not-win",
+        format!("http://{addr}"),
+    )
+    .expect("provider construction");
+
+    let resp = provider
+        .complete(request_naming("request/model-must-win"))
+        .await
+        .expect("mock round-trip");
+    let sent = mock.await.expect("mock server task");
+
+    assert_eq!(
+        sent["model"], "request/model-must-win",
+        "the wire model must be LlmRequest.model, not the constructor's id"
+    );
+    assert_eq!(
+        resp.model, "request/model-must-win",
+        "the response must echo the model actually called"
+    );
+
+    // A request naming no model keeps the constructor's id as the fallback.
+    let (addr, mock) = spawn_capturing_mock().await;
+    let provider = FireworksProvider::with_base_url(
+        "fw-mock-key", // pragma: allowlist secret
+        "constructor/model-is-the-fallback",
+        format!("http://{addr}"),
+    )
+    .expect("provider construction");
+    provider
+        .complete(request_naming("   "))
+        .await
+        .expect("mock round-trip");
+    let sent = mock.await.expect("mock server task");
+    assert_eq!(
+        sent["model"], "constructor/model-is-the-fallback",
+        "a blank request model must fall back to the constructor's id"
+    );
+}
+
+/// An `LlmRequest` that names `model` and nothing else of interest.
+fn request_naming(model: &str) -> LlmRequest {
+    LlmRequest {
+        model: model.to_string(),
+        system: "You are a verifier.".to_string(),
+        messages: vec![ChatMessage {
+            role: "user".to_string(),
+            content: "Verify this finding.".to_string(),
+        }],
+        temperature: 0.0,
+        max_tokens: 128,
+        response_schema: None,
+    }
+}
+
+/// Serve one canned completion and hand back the request body as JSON.
+///
+/// Why: `complete_round_trips_through_mock_server` asserts many fields of one
+/// fixed request; this returns the parsed body so a caller can vary the model
+/// and assert only that.
+/// What: binds an ephemeral loopback port, reads one request to its
+/// `Content-Length`, replies 200 with a minimal completion body that omits
+/// `model` (so `LlmResponse.model` falls through to the id the provider chose),
+/// and returns the parsed request body.
+async fn spawn_capturing_mock() -> (
+    std::net::SocketAddr,
+    tokio::task::JoinHandle<serde_json::Value>,
+) {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind loopback");
+    let addr = listener.local_addr().expect("local addr");
+
+    let handle = tokio::spawn(async move {
+        let (mut sock, _) = listener.accept().await.expect("accept");
+        let mut raw = Vec::new();
+        let mut buf = vec![0u8; 8192];
+        loop {
+            let n = sock.read(&mut buf).await.expect("read");
+            if n == 0 {
+                break;
+            }
+            raw.extend_from_slice(&buf[..n]);
+            let text = String::from_utf8_lossy(&raw);
+            if let Some(header_end) = text.find("\r\n\r\n") {
+                let content_length = text.lines().find_map(|l| {
+                    l.to_ascii_lowercase()
+                        .strip_prefix("content-length:")
+                        .and_then(|v| v.trim().parse::<usize>().ok())
+                });
+                if content_length.is_none_or(|cl| raw.len() - (header_end + 4) >= cl) {
+                    break;
+                }
+            }
+        }
+        let raw = String::from_utf8(raw).expect("utf-8 request");
+
+        let resp_body = serde_json::json!({
+            "choices": [{"message": {"content": "LGTM"}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 2}
+        })
+        .to_string();
+        let http_resp = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            resp_body.len(),
+            resp_body
+        );
+        sock.write_all(http_resp.as_bytes()).await.expect("write");
+        sock.shutdown().await.expect("shutdown");
+
+        let body_start = raw
+            .find("\r\n\r\n")
+            .map(|i| i + 4)
+            .expect("header terminator");
+        serde_json::from_str(&raw[body_start..]).expect("request body must be JSON")
+    });
+
+    (addr, handle)
 }
 
 // ── Live smoke test ─────────────────────────────────────────────────────────

--- a/crates/trusty-review/src/llm/mod.rs
+++ b/crates/trusty-review/src/llm/mod.rs
@@ -138,6 +138,28 @@ pub struct LlmRequest {
     pub response_schema: Option<ResponseSchema>,
 }
 
+impl LlmRequest {
+    /// The model id a provider must actually call for this request.
+    ///
+    /// Why: #6123 — `OpenRouterProvider` and `FireworksProvider` sent the id
+    /// they were constructed with and dropped [`LlmRequest::model`], so a
+    /// per-request override ran on the constructor's model with nothing in the
+    /// response saying so. `BedrockProvider` already read `req.model`. One
+    /// resolver gives all three providers the same answer.
+    /// What: returns [`LlmRequest::model`] when it carries a non-blank id, and
+    /// `provider_default` — the id the provider was constructed with — only
+    /// when the request names no model at all.
+    /// Test: `request_model_overrides_the_provider_default`,
+    /// `blank_request_model_falls_back_to_the_provider_default`.
+    pub fn effective_model<'a>(&'a self, provider_default: &'a str) -> &'a str {
+        if self.model.trim().is_empty() {
+            provider_default
+        } else {
+            &self.model
+        }
+    }
+}
+
 /// Output from `LlmProvider::complete`.
 ///
 /// Why: captures the response text plus all telemetry fields required by
@@ -544,6 +566,39 @@ pub async fn build_verifier_required(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn request_naming(model: &str) -> LlmRequest {
+        LlmRequest {
+            model: model.to_string(),
+            system: String::new(),
+            messages: Vec::new(),
+            temperature: 0.0,
+            max_tokens: 16,
+            response_schema: None,
+        }
+    }
+
+    /// #6123: the request's model wins over the provider's constructor id.
+    #[test]
+    fn request_model_overrides_the_provider_default() {
+        let req = request_naming("request/model-must-win");
+        assert_eq!(
+            req.effective_model("constructor/model-should-not-win"),
+            "request/model-must-win"
+        );
+    }
+
+    /// #6123: only a request naming no model at all defers to the provider.
+    #[test]
+    fn blank_request_model_falls_back_to_the_provider_default() {
+        for blank in ["", "   ", "\t\n"] {
+            assert_eq!(
+                request_naming(blank).effective_model("constructor/model"),
+                "constructor/model",
+                "{blank:?} names no model and must defer to the provider"
+            );
+        }
+    }
 
     #[test]
     fn llm_response_serde_roundtrip() {

--- a/crates/trusty-review/src/llm/openrouter.rs
+++ b/crates/trusty-review/src/llm/openrouter.rs
@@ -19,8 +19,13 @@
 //! in the response body.  This avoids the complexity of two calls or of
 //! parsing streamed usage frames.
 //!
-//! Test: `complete_builds_correct_request` verifies the request structure
-//! against a mock HTTP server (no real network calls in tests).
+//! The base URL is a constructor field (default `OPENROUTER_BASE_URL`) so
+//! tests can do a real mock-server round-trip, mirroring `fireworks.rs`.
+//!
+//! Test: `complete_sends_the_request_model_not_the_constructor_model` reads the
+//! model out of the POST body a mock server received;
+//! `complete_builds_correct_request` verifies the rest of the request structure
+//! (no real network calls in tests).
 
 use std::time::Instant;
 
@@ -30,7 +35,7 @@ use tracing::{debug, warn};
 
 use super::{LlmProvider, LlmRequest, LlmResponse, error::LlmError};
 
-const OPENROUTER_URL: &str = "https://openrouter.ai/api/v1/chat/completions";
+const OPENROUTER_BASE_URL: &str = "https://openrouter.ai/api/v1";
 const CONNECT_TIMEOUT_SECS: u64 = 10;
 const READ_TIMEOUT_SECS: u64 = 120;
 const HTTP_REFERER: &str = "https://github.com/bobmatnyc/trusty-tools";
@@ -218,6 +223,7 @@ pub fn estimate_cost_usd(model: &str, input_tokens: u32, output_tokens: u32) -> 
 pub struct OpenRouterProvider {
     api_key: String,
     model: String,
+    base_url: String,
     client: reqwest::Client,
 }
 
@@ -226,10 +232,28 @@ impl OpenRouterProvider {
     ///
     /// Why: callers obtain the api_key from `ReviewConfig::openrouter_api_key`
     /// and the model from a resolved `RoleConfig::model`.
-    /// What: builds a `reqwest::Client` with connect and read timeouts;
-    /// returns `LlmError::AccessDenied` if the key is empty.
+    /// What: delegates to [`Self::with_base_url`] against the public
+    /// OpenRouter endpoint.
     /// Test: `new_returns_error_on_empty_key`.
     pub fn new(api_key: impl Into<String>, model: impl Into<String>) -> Result<Self, LlmError> {
+        Self::with_base_url(api_key, model, OPENROUTER_BASE_URL)
+    }
+
+    /// Construct a provider with an explicit base URL.
+    ///
+    /// Why: lets tests point the provider at a mock HTTP server and assert on
+    /// the bytes it actually sends — the round-trip coverage the hardcoded URL
+    /// made impossible, and what proves #6123's model override reaches the
+    /// wire. Mirrors `FireworksProvider::with_base_url`.
+    /// What: builds a `reqwest::Client` with connect and read timeouts;
+    /// returns `LlmError::AccessDenied` if the key is empty. A trailing `/` on
+    /// `base_url` is trimmed so path joining is uniform.
+    /// Test: `complete_sends_the_request_model_not_the_constructor_model`.
+    pub fn with_base_url(
+        api_key: impl Into<String>,
+        model: impl Into<String>,
+        base_url: impl Into<String>,
+    ) -> Result<Self, LlmError> {
         let api_key = api_key.into();
         if api_key.is_empty() {
             return Err(LlmError::AccessDenied(
@@ -244,6 +268,7 @@ impl OpenRouterProvider {
         Ok(Self {
             api_key,
             model: model.into(),
+            base_url: base_url.into().trim_end_matches('/').to_string(),
             client,
         })
     }
@@ -277,11 +302,20 @@ impl LlmProvider for OpenRouterProvider {
     /// set, sends `response_format: { type: "json_schema", json_schema: { name,
     /// strict: true, schema } }` to force the model to emit structured JSON;
     /// the assistant message content will be the clean JSON object.
-    /// Test: `complete_builds_correct_request`,
+    ///
+    /// The model sent is [`LlmRequest::effective_model`] — the request's own
+    /// id, falling back to the constructor's only when the request names none
+    /// (#6123).
+    /// Test: `complete_sends_the_request_model_not_the_constructor_model`,
+    /// `complete_builds_correct_request`,
     /// `complete_with_schema_sends_response_format` (mock server in tests).
     async fn complete(&self, req: LlmRequest) -> Result<LlmResponse, LlmError> {
+        // #6123: the request's model is the model for this call; the id passed
+        // to the constructor is only the fallback when the request names none.
+        let model = req.effective_model(&self.model);
+
         debug!(
-            model = %self.model,
+            model = %model,
             structured = req.response_schema.is_some(),
             "openrouter complete request"
         );
@@ -312,7 +346,7 @@ impl LlmProvider for OpenRouterProvider {
         });
 
         let body = OrcRequest {
-            model: &self.model,
+            model,
             messages: &messages,
             stream: false,
             temperature: req.temperature,
@@ -324,7 +358,7 @@ impl LlmProvider for OpenRouterProvider {
 
         let http_resp = self
             .client
-            .post(OPENROUTER_URL)
+            .post(format!("{}/chat/completions", self.base_url))
             .bearer_auth(&self.api_key)
             .header("HTTP-Referer", HTTP_REFERER)
             .header("X-Title", X_TITLE)
@@ -341,7 +375,7 @@ impl LlmProvider for OpenRouterProvider {
             let body_text = http_resp.text().await.unwrap_or_default();
             return Err(match status.as_u16() {
                 401 | 403 => LlmError::AccessDenied(body_text),
-                404 => LlmError::ModelNotFound(format!("model={}: {body_text}", self.model)),
+                404 => LlmError::ModelNotFound(format!("model={model}: {body_text}")),
                 422 => LlmError::Validation(body_text),
                 429 => LlmError::RateLimited,
                 _ => LlmError::Upstream {
@@ -374,7 +408,7 @@ impl LlmProvider for OpenRouterProvider {
             .map(|u| (u.prompt_tokens, u.completion_tokens))
             .unwrap_or((0, 0));
 
-        let model_used = orc.model.unwrap_or_else(|| self.model.clone());
+        let model_used = orc.model.unwrap_or_else(|| model.to_string());
         let cost_usd = estimate_cost_usd(&model_used, input_tokens, output_tokens);
 
         Ok(LlmResponse {

--- a/crates/trusty-review/src/llm/openrouter_tests.rs
+++ b/crates/trusty-review/src/llm/openrouter_tests.rs
@@ -183,6 +183,142 @@ fn complete_without_schema_omits_response_format() {
     );
 }
 
+/// The model on the wire is the request's, not the constructor's (#6123).
+///
+/// Why: `complete` used to serialise `self.model` and drop
+/// [`LlmRequest::model`], so a per-request override ran on the constructor's
+/// model and the response echoed the wrong id with nothing reporting the
+/// substitution. This is the only assertion that reaches the actual bytes.
+/// What: constructs the provider with one id, sends a request naming a
+/// different one, and reads the model field out of the POST body a mock
+/// server received. Also asserts the fallback: a blank request model still
+/// sends the constructor's id.
+/// Test: fails on `origin/main` with `left: "constructor/model-should-not-win"`.
+#[tokio::test]
+async fn complete_sends_the_request_model_not_the_constructor_model() {
+    let (addr, mock) = spawn_capturing_mock().await;
+    let provider = OpenRouterProvider::with_base_url(
+        "sk-mock-key", // pragma: allowlist secret
+        "constructor/model-should-not-win",
+        format!("http://{addr}"),
+    )
+    .expect("provider construction");
+
+    let resp = provider
+        .complete(request_naming("request/model-must-win"))
+        .await
+        .expect("mock round-trip");
+    let sent = mock.await.expect("mock server task");
+
+    assert_eq!(
+        sent["model"], "request/model-must-win",
+        "the wire model must be LlmRequest.model, not the constructor's id"
+    );
+    assert_eq!(
+        resp.model, "request/model-must-win",
+        "the response must echo the model actually called"
+    );
+
+    // A request naming no model keeps the constructor's id as the fallback.
+    let (addr, mock) = spawn_capturing_mock().await;
+    let provider = OpenRouterProvider::with_base_url(
+        "sk-mock-key", // pragma: allowlist secret
+        "constructor/model-is-the-fallback",
+        format!("http://{addr}"),
+    )
+    .expect("provider construction");
+    provider
+        .complete(request_naming("   "))
+        .await
+        .expect("mock round-trip");
+    let sent = mock.await.expect("mock server task");
+    assert_eq!(
+        sent["model"], "constructor/model-is-the-fallback",
+        "a blank request model must fall back to the constructor's id"
+    );
+}
+
+/// An `LlmRequest` that names `model` and nothing else of interest.
+fn request_naming(model: &str) -> LlmRequest {
+    LlmRequest {
+        model: model.to_string(),
+        system: "You are a code reviewer.".to_string(),
+        messages: vec![ChatMessage {
+            role: "user".to_string(),
+            content: "Review this diff.".to_string(),
+        }],
+        temperature: 0.3,
+        max_tokens: 128,
+        response_schema: None,
+    }
+}
+
+/// Serve one canned completion and hand back the request body as JSON.
+///
+/// Why: the provider's endpoint is now injectable, so a test can assert on the
+/// bytes it sends rather than on a struct the test built itself.
+/// What: binds an ephemeral loopback port, reads one request to its
+/// `Content-Length`, replies 200 with a minimal completion body that omits
+/// `model` (so `LlmResponse.model` falls through to the id the provider chose),
+/// and returns the parsed request body.
+async fn spawn_capturing_mock() -> (
+    std::net::SocketAddr,
+    tokio::task::JoinHandle<serde_json::Value>,
+) {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind loopback");
+    let addr = listener.local_addr().expect("local addr");
+
+    let handle = tokio::spawn(async move {
+        let (mut sock, _) = listener.accept().await.expect("accept");
+        let mut raw = Vec::new();
+        let mut buf = vec![0u8; 8192];
+        loop {
+            let n = sock.read(&mut buf).await.expect("read");
+            if n == 0 {
+                break;
+            }
+            raw.extend_from_slice(&buf[..n]);
+            let text = String::from_utf8_lossy(&raw);
+            if let Some(header_end) = text.find("\r\n\r\n") {
+                let content_length = text.lines().find_map(|l| {
+                    l.to_ascii_lowercase()
+                        .strip_prefix("content-length:")
+                        .and_then(|v| v.trim().parse::<usize>().ok())
+                });
+                if content_length.is_none_or(|cl| raw.len() - (header_end + 4) >= cl) {
+                    break;
+                }
+            }
+        }
+        let raw = String::from_utf8(raw).expect("utf-8 request");
+
+        let resp_body = serde_json::json!({
+            "choices": [{"message": {"content": "LGTM"}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 2}
+        })
+        .to_string();
+        let http_resp = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            resp_body.len(),
+            resp_body
+        );
+        sock.write_all(http_resp.as_bytes()).await.expect("write");
+        sock.shutdown().await.expect("shutdown");
+
+        let body_start = raw
+            .find("\r\n\r\n")
+            .map(|i| i + 4)
+            .expect("header terminator");
+        serde_json::from_str(&raw[body_start..]).expect("request body must be JSON")
+    });
+
+    (addr, handle)
+}
+
 #[tokio::test]
 async fn complete_builds_correct_request() {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};


### PR DESCRIPTION
Refs #6123.

`OpenRouterProvider::complete` and `FireworksProvider::complete` serialised the
model id they were constructed with and dropped `LlmRequest.model`. A request
naming a different model ran on the constructor's model, and the response echoed
the wrong id with nothing reporting the substitution. `BedrockProvider` already
read `req.model`.

All three providers now resolve the model through one method,
`LlmRequest::effective_model`: it returns the request's id, and falls back to
the constructor's only when the request names no model at all. The id it picks
is what goes on the wire, what the 404 error text names, and what
`LlmResponse.model` carries when the provider does not echo one back. Bedrock is
included because it is the third adapter in the same module and now reads the
same resolver — its behaviour changes only for a request whose `model` is blank,
which previously reached AWS as an empty `model_id`.

`OpenRouterProvider::with_base_url` is new. The endpoint was a hardcoded
constant, so nothing could assert on the bytes that provider actually sends —
its existing `complete_builds_correct_request` builds a struct and never
connects. Fireworks already had this constructor; OpenRouter now mirrors it, and
that is what makes the regression test real.

## Test ladder: rung 4

Rung 3 on `trusty-review`, then `cargo check --workspace` plus the direct
dependent, because `LlmRequest` is public API.

```
cargo fmt --check                                          → exit 0
cargo check -p trusty-review --all-targets                 → exit 0
cargo clippy -p trusty-review --all-targets -- -D warnings → exit 0
cargo test -p trusty-review                                → 2000 passed; 0 failed; 5 ignored (lib)
                                                             + 98 passed across 9 integration targets
SKIP_UI_BUILD=1 cargo check --workspace --all-targets      → exit 0
cargo test -p trusty-analyze --features review             → 496 + 27 + 2 + 5 + 2 passed; 0 failed
bash scripts/check_changelog_fragment.sh                   → OK trusty-review
bash scripts/check_line_cap.sh                             → 0 violations
bash scripts/check_sld.sh                                  → 0 errors, 0 warnings
```

`trusty-mpm` carries `trusty-review` as a dev-dependency only; the workspace
`--all-targets` check compiles that edge.

## The regression tests fail on the pre-fix code

Reverting only the one-line model selection in each provider (`model` back to
`&self.model`), with the tests and the injectable base URL in place:

```
running 2 tests
test llm::fireworks::tests::complete_sends_the_request_model_not_the_constructor_model ... FAILED
test llm::openrouter::tests::complete_sends_the_request_model_not_the_constructor_model ... FAILED

---- llm::fireworks::tests::complete_sends_the_request_model_not_the_constructor_model stdout ----
assertion `left == right` failed: the wire model must be LlmRequest.model, not the constructor's id
  left: String("constructor/model-should-not-win")
 right: "request/model-must-win"

---- llm::openrouter::tests::complete_sends_the_request_model_not_the_constructor_model stdout ----
assertion `left == right` failed: the wire model must be LlmRequest.model, not the constructor's id
  left: String("constructor/model-should-not-win")
 right: "request/model-must-win"

test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 2003 filtered out
```

Each test also asserts the fallback: a request whose `model` is blank still
sends the constructor's id. `llm::tests::request_model_overrides_the_provider_default`
and `blank_request_model_falls_back_to_the_provider_default` cover the resolver
directly, which is the coverage Bedrock gets — its wire path needs real AWS.

## Version bump

trusty-review 0.25.0 is published on crates.io, so a `src/**` change under it
fails `PR version bump vs crates.io (issue #4421)` and would turn main's
version-parity workflow red on merge. Bumped to 0.25.1 — PATCH, because the
public surface only grows: `LlmRequest::effective_model` and
`OpenRouterProvider::with_base_url` are added, and nothing changes shape or
moves. `Cargo.lock` regenerated with `cargo update -p trusty-review --precise
0.25.1`, which touched one line.

```
PR_VERSION_BUMP_BASE=origin/main bash scripts/check-pr-version-bump.sh
[ OK ] trusty-review — version bumped 0.25.0 -> 0.25.1
```

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
