### PR TITLE
fix(trusty-common): scan exactly to 1024 points and scale ef above it (Refs #5179)

### DIFF
--- a/crates/trusty-common/changelog.d/5179-hnsw-recall-above-256.md
+++ b/crates/trusty-common/changelog.d/5179-hnsw-recall-above-256.md
@@ -1,0 +1,18 @@
+Fixed
+
+- Memory-palace vector search no longer loses true nearest neighbours as a
+  palace grows past 256 drawers. `HnswStore::search` now answers exactly by
+  scanning every point up to 1024 live drawers (was 256), and above that scales
+  its HNSW `ef_search` with the live-drawer count instead of holding it at 64.
+  Measured on this repo's own palace embeddings, recall@10 misses fell from
+  17.4% of queries to 0% at 512 drawers, from 24.5% to 0% at 1024, and from
+  23.3% to 17.7% at 2048. Recall above 1024 drawers is improved, not closed —
+  and the wider search costs more per query there, roughly 0.5ms to 2.2ms at
+  2900 drawers. (#5179)
+- A palace above the exhaustive threshold that has deleted drawers within a
+  session can no longer return fewer results than asked for. The graph arm cut
+  its candidate list to `2k` before filtering tombstoned ids, so deleted drawers
+  spent the caller's result slots and a palace whose nearest neighbours had been
+  deleted could return nothing at all while live neighbours sat in the index.
+  Tombstones are now filtered before the candidate pool is judged deep enough,
+  and the pool widens until `k` live drawers survive. (#5179)

--- a/crates/trusty-common/src/memory_core/store/hnsw_store.rs
+++ b/crates/trusty-common/src/memory_core/store/hnsw_store.rs
@@ -33,6 +33,9 @@ use crate::memory_core::store::kg_store::{
 mod exhaustive;
 use exhaustive::{EXHAUSTIVE_SCAN_MAX_POINTS, exhaustive_nearest, resolve_shadowed};
 
+mod graph_arm;
+use graph_arm::graph_nearest;
+
 /// Default HNSW connectivity. Maps to `max_nb_connection` in `hnsw_rs`.
 ///
 /// Why: 16 is the recommended value from the original HNSW paper for
@@ -54,13 +57,6 @@ const HNSW_MAX_LAYER: usize = 16;
 /// Initial expected element count hint passed to `Hnsw::new`. Used only to
 /// pre-allocate; the index grows transparently.
 const HNSW_INITIAL_CAPACITY: usize = 1024;
-
-/// Default `ef_search` used when none is supplied by the caller.
-///
-/// Why: A small multiple of `top_k` (here, max(top_k, 64)) is the standard
-/// recommendation. We pick a baseline of 64 so the search quality stays
-/// stable for small `top_k`.
-const HNSW_DEFAULT_EF_SEARCH: usize = 64;
 
 /// How many candidate ids the allocator may probe before it gives up.
 ///
@@ -533,8 +529,16 @@ impl HnswStore {
     /// queries — and because `hnsw_rs` seeds its level RNG from OS entropy,
     /// *which* drawer went missing changed on every palace open. See
     /// [`exhaustive`] for the measurement and the threshold's rationale.
+    ///
+    /// #5179: above the threshold both graph budgets scale with the collection
+    /// rather than sitting at a constant — `ef_search` with the live-drawer
+    /// count, and the candidate pool with what survives the tombstone filter, so
+    /// deleted ids cannot spend the caller's `k` result slots. See
+    /// [`graph_arm`].
     /// Test: `upsert_and_search_round_trips`, `delete_filters_results`,
     /// `search_returns_the_exact_top_k_below_the_exhaustive_threshold`,
+    /// `search_is_exact_at_the_exhaustive_threshold`,
+    /// `search_above_the_threshold_fills_k_despite_tombstoned_nearest_neighbours`,
     /// `search_scores_a_re_upserted_drawer_by_its_current_vector`.
     pub fn search(&self, query: &[f32], k: usize) -> Result<Vec<(String, f32)>> {
         if query.len() != self.dim {
@@ -562,11 +566,6 @@ impl HnswStore {
             }
         }
 
-        // Over-fetch so tombstoning doesn't starve callers asking for k. 2x is
-        // sufficient in the common case; for pathological cases the caller can
-        // re-issue. Bounds the graph arm only — the scan returns everything.
-        let want = k.saturating_mul(2).max(k);
-        let ef = HNSW_DEFAULT_EF_SEARCH.max(k * 2);
         // #5171: `reverse.len()` is the LIVE drawer count — `get_nb_point()`
         // also counts tombstones and shadows, so a small palace could churn
         // past the threshold mid-session and silently revert to the approximate
@@ -580,11 +579,11 @@ impl HnswStore {
             if reverse.len() <= EXHAUSTIVE_SCAN_MAX_POINTS {
                 exhaustive_nearest(&index, query, &tombstones)
             } else {
-                index
-                    .search(query, want, ef)
-                    .into_iter()
-                    .map(|hit| (hit.d_id as u64, hit.distance))
-                    .collect()
+                // #5179: both budgets are functions of the collection, not
+                // constants — a fixed `ef` let recall decay as the palace grew,
+                // and a fixed `2k` candidate count let deleted points spend the
+                // caller's result slots. See [`graph_arm`].
+                graph_nearest(&index, query, &tombstones, k, reverse.len())
             }
         };
 

--- a/crates/trusty-common/src/memory_core/store/hnsw_store/exhaustive.rs
+++ b/crates/trusty-common/src/memory_core/store/hnsw_store/exhaustive.rs
@@ -32,15 +32,23 @@ use redb::ReadableTable;
 /// Live-drawer ceiling at or below which [`super::HnswStore::search`] scans
 /// exhaustively instead of traversing the graph.
 ///
-/// Why (#5171): the recall loss this scan removes is not confined to tiny
-/// collections — on real embeddings it was still 3.2% of queries at 256 points
-/// — but the scan has to stay cheap enough that it never becomes the reason a
-/// recall is slow. 256 is where the two curves meet on this workload: an
-/// in-memory scan of 256 384-dim vectors costs about the same as the
-/// `VECTOR_KEYS` reverse-map build `search` already performs on every call, and
-/// it covers 99% of this machine's real palaces. Above it the graph traversal's
-/// sublinear cost is worth its approximation, which is the trade HNSW exists to
-/// make.
+/// Why (#5171, raised 256 → 1024 by #5179): the recall loss this scan removes
+/// does not stop at 256 — #5171 set the bound on cost, not on where the defect
+/// ends, and the regime it left behind was measured on this repo's own palace
+/// embeddings at 17.4% of queries losing a true top-10 neighbour at 512 points
+/// and 24.5% at 1024. Exactness is worth buying wherever it is affordable, and
+/// at 1024 points the scan costs on the order of 400µs per query — the same
+/// order as the graph traversal it replaces there, because with a candidate
+/// budget scaled to the collection (see [`super::graph_arm`]) the traversal
+/// evaluates a comparable number of distances anyway. Past 1024 the scan's
+/// linear cost stops being repayable and HNSW's sublinear cost is worth its
+/// approximation, which is the trade the algorithm exists to make. The palace
+/// this repo keeps for itself holds ~2100 live vectors, so the regime above the
+/// bound is real and not hypothetical; #5179 narrows it rather than closing it.
+///
+/// Nothing migrates when this number changes: no graph is persisted, and
+/// `HnswStore::open_with_mode` rebuilds the index from the raw `VECTORS` rows on
+/// every open.
 /// What: compared against the number of LIVE drawers — `VECTOR_KEYS` rows, the
 /// `reverse` map `search` builds two statements earlier. Not
 /// `Hnsw::get_nb_point()`, which also counts tombstoned points and re-upsert
@@ -51,8 +59,11 @@ use redb::ReadableTable;
 /// per delete or re-upsert, and `HnswStore::open` rebuilds one point per live
 /// vector — so a bulk `palace_reembed` at most doubles it.
 /// Test: `search_uses_the_graph_above_the_exhaustive_threshold`,
+/// `search_is_exact_at_the_exhaustive_threshold`,
 /// `deleting_drawers_does_not_push_a_small_palace_off_the_exhaustive_path`.
-pub(super) const EXHAUSTIVE_SCAN_MAX_POINTS: usize = 256;
+// #5179: raised from 256 so the whole regime #5171 measured as still lossy is
+// answered exactly.
+pub(super) const EXHAUSTIVE_SCAN_MAX_POINTS: usize = 1024;
 
 /// Every live point in `index`, ranked by exact distance to `query`, best
 /// first — the whole ranking, not a prefix of it.

--- a/crates/trusty-common/src/memory_core/store/hnsw_store/graph_arm.rs
+++ b/crates/trusty-common/src/memory_core/store/hnsw_store/graph_arm.rs
@@ -1,0 +1,173 @@
+//! Graph-traversal candidate retrieval for collections above
+//! [`super::EXHAUSTIVE_SCAN_MAX_POINTS`] (#5179).
+//!
+//! Why: this arm had two budgets and both were constants that ignored the size
+//! and the state of the collection.
+//!
+//! `ef_search` was pinned at 64 whatever the point count, so the layer-0
+//! candidate heap covered a shrinking fraction of the index as a palace grew
+//! and recall decayed with no signal to the caller — measured on this repo's
+//! own palace embeddings, 17.4% of queries lost a true top-10 neighbour at 512
+//! points and 24.5% at 1024.
+//!
+//! The candidate count was pinned at `2k`, and `HnswStore::search` dropped
+//! tombstoned ids only AFTER `Hnsw::search` had already truncated to it. That
+//! bounds the result in GRAPH points while the caller asked for `k` LIVE
+//! drawers, and the two diverge whenever a palace has deleted since its last
+//! open: `hnsw_rs` cannot remove a point, so every delete leaves one behind. A
+//! palace whose nearest neighbours have all been deleted returned fewer than
+//! `k` hits, or none, with live neighbours still in the graph. This is the
+//! sibling of the cut #5178 removed from the exhaustive arm, which returns its
+//! full ranking for the same reason.
+//! What: [`graph_ef_search`] scales `ef_search` with the live-drawer count and
+//! clamps the scaled term at [`HNSW_MAX_EF_SEARCH`]. [`graph_nearest`] filters
+//! tombstones out of the candidate pool BEFORE asking whether the pool is deep
+//! enough, and widens it until `k` live drawers survive or the graph is
+//! exhausted — so filtering can no longer happen after the slot count is fixed.
+//! Test: `graph_ef_search_scales_with_live_count_and_stops_at_the_cap`,
+//! `graph_candidates_inflate_by_the_graphs_dead_weight`,
+//! `search_above_the_threshold_fills_k_despite_tombstoned_nearest_neighbours`.
+
+use std::collections::HashSet;
+
+use hnsw_rs::prelude::{DistCosine, Hnsw};
+
+/// Baseline `ef_search` — the floor the live-scaled term is measured against.
+///
+/// Why: a small multiple of `top_k` is the standard recommendation, and 64
+/// keeps search quality stable for the small `top_k` most callers ask for. It
+/// is the FLOOR rather than the value since #5179: as a fixed value it made the
+/// candidate heap a shrinking fraction of a growing collection.
+const HNSW_DEFAULT_EF_SEARCH: usize = 64;
+
+/// Divisor turning the live-drawer count into an `ef_search` budget.
+///
+/// Why (#5179): recall on this path is set by how much of the collection the
+/// layer-0 candidate heap can hold, so the budget has to grow with the
+/// collection rather than sit at a constant.
+const HNSW_EF_LIVE_DIVISOR: usize = 4;
+
+/// Ceiling on the live-scaled `ef_search` term.
+///
+/// Why (#5179): `live / 4` is unbounded, so without a ceiling a 100k-drawer
+/// palace would ask for `ef = 25_000`, and this budget is what a graph query
+/// costs. The number is chosen on measured latency: against real palace
+/// embeddings on an M-series laptop, a 384-dim query over ~2900 drawers takes
+/// about 0.5ms at `ef = 64` and about 2.2ms at `ef = 719`, and 1024 puts the
+/// ceiling at roughly 3ms — the most this store is willing to spend answering
+/// one recall. That the number also equals
+/// [`super::EXHAUSTIVE_SCAN_MAX_POINTS`] is a coincidence of two independent
+/// choices, NOT a cost equivalence: an `ef = 1024` traversal costs several times
+/// what scanning 1024 points costs, because each unit of `ef` carries heap and
+/// visited-set work a flat sequential scan does not. What the cap does buy is
+/// that per-query cost stops growing with the palace, which is the whole reason
+/// this arm exists. It binds from `live = 4096` upward.
+///
+/// The recall it buys is real but partial: on real embeddings the scaled `ef`
+/// took top-10 misses from 23.3% of queries to 17.7% at 2048 drawers and from
+/// 20.2% to 15.6% at 2879. #5179 narrows the gap above the exhaustive threshold;
+/// closing it needs a different index structure or a rerank pass, not a larger
+/// number here.
+/// What: clamps the SCALED term only. A caller asking for a large `top_k` still
+/// gets `2k`, because returning fewer results than asked for is a different
+/// defect from spending too long finding them.
+/// Test: `graph_ef_search_scales_with_live_count_and_stops_at_the_cap`.
+pub(super) const HNSW_MAX_EF_SEARCH: usize = 1024;
+
+/// `ef_search` for a graph-arm query over `live` drawers returning `k` hits.
+///
+/// Why (#5179): see [`HNSW_EF_LIVE_DIVISOR`] and [`HNSW_MAX_EF_SEARCH`] — a
+/// constant `ef` means recall decays as the palace grows, silently.
+/// What: `max(HNSW_DEFAULT_EF_SEARCH, 2k, min(live / 4, HNSW_MAX_EF_SEARCH))`.
+/// Test: `graph_ef_search_scales_with_live_count_and_stops_at_the_cap`.
+pub(super) fn graph_ef_search(k: usize, live: usize) -> usize {
+    let scaled = (live / HNSW_EF_LIVE_DIVISOR).min(HNSW_MAX_EF_SEARCH);
+    HNSW_DEFAULT_EF_SEARCH.max(k.saturating_mul(2)).max(scaled)
+}
+
+/// First-guess candidate count for a graph with `graph_points` points backing
+/// `live` drawers.
+///
+/// Why (#5179): the `2k` over-fetch is stated in graph points but spent in live
+/// drawers, and a graph carries one extra point per delete and per re-upsert
+/// since the last `HnswStore::open`. Scaling the first guess by that overhang
+/// means an ordinarily-churned palace answers in one traversal instead of
+/// entering [`graph_nearest`]'s widening loop.
+/// What: `2k * ceil(graph_points / live)`, clamped at `graph_points` — no query
+/// can return more points than the graph holds. In the steady state the ratio
+/// is 1 and this is exactly the old `2k`, so a palace that has not churned pays
+/// nothing.
+/// Test: `graph_candidates_inflate_by_the_graphs_dead_weight`.
+pub(super) fn graph_candidates(k: usize, live: usize, graph_points: usize) -> usize {
+    let want = k.saturating_mul(2).max(k);
+    let inflation = graph_points.div_ceil(live.max(1)).max(1);
+    want.saturating_mul(inflation).min(graph_points.max(1))
+}
+
+/// Candidates for `query` from the graph, with tombstoned ids already removed
+/// and the pool widened until `k` distinct live ids survive.
+///
+/// Why (#5179): `Hnsw::search` truncates to the count it is given, so a filter
+/// applied to its output is a filter applied after the slot count is fixed.
+/// Deciding how deep to go on the UNFILTERED count is what let a palace with
+/// deleted nearest neighbours return fewer than `k` live hits — and an
+/// over-fetch scaled to the average dead fraction does not repair it either,
+/// because the dead points that matter are the ones nearest the query, not a
+/// random sample of them. The only sound bound is the one measured on live
+/// candidates.
+/// What: filters tombstones out of each traversal's output, and while fewer than
+/// `k` DISTINCT live ids survive, doubles the requested candidate count and
+/// re-traverses. Terminates because the count strictly increases and stops at
+/// `graph_points`. Distinct rather than raw count because a re-upsert leaves two
+/// points under one `vector_id` and `HnswStore::search` emits each id once.
+/// Returns `(vector_id, distance)` pairs in the traversal's ascending-distance
+/// order.
+///
+/// What this does NOT repair: a live drawer the traversal cannot REACH from its
+/// descent pivot along pruned layer-0 neighbour lists. Widening the candidate
+/// budget cannot reach a point no path leads to, and at `want = graph_points`
+/// the traversal has still only seen the reachable component. That is #5171's
+/// limit, and the exhaustive threshold — not this function — is what answers it.
+///
+/// Cost: one traversal in the steady state, since [`graph_candidates`] already
+/// covers an ordinarily-churned palace. The loop is reached only when deleted
+/// points genuinely crowd out the query's live neighbours, and the doublings
+/// sum to about twice the final traversal — bounded above by one full-graph
+/// traversal, which is the honest price of not handing the caller an empty
+/// result while its neighbours sit in the index.
+/// Test: `search_above_the_threshold_fills_k_despite_tombstoned_nearest_neighbours`,
+/// `search_above_the_threshold_stops_widening_when_the_graph_is_exhausted`.
+pub(super) fn graph_nearest(
+    index: &Hnsw<'static, f32, DistCosine>,
+    query: &[f32],
+    tombstoned: &HashSet<u64>,
+    k: usize,
+    live: usize,
+) -> Vec<(u64, f32)> {
+    let graph_points = index.get_nb_point();
+    if graph_points == 0 || k == 0 {
+        return Vec::new();
+    }
+    let ef = graph_ef_search(k, live);
+    let mut want = graph_candidates(k, live, graph_points);
+    loop {
+        // `hnsw_rs` raises `ef` to the requested neighbour count internally
+        // (`hnsw.rs:1519`); passing the max explicitly keeps the widening this
+        // loop performs visible here rather than hidden in the library.
+        let hits: Vec<(u64, f32)> = index
+            .search(query, want, ef.max(want))
+            .into_iter()
+            .map(|hit| (hit.d_id as u64, hit.distance))
+            .filter(|(id, _)| !tombstoned.contains(id))
+            .collect();
+        let distinct = hits
+            .iter()
+            .map(|(id, _)| *id)
+            .collect::<HashSet<u64>>()
+            .len();
+        if distinct >= k || want >= graph_points {
+            return hits;
+        }
+        want = want.saturating_mul(2).min(graph_points);
+    }
+}

--- a/crates/trusty-common/src/memory_core/store/hnsw_store/tests.rs
+++ b/crates/trusty-common/src/memory_core/store/hnsw_store/tests.rs
@@ -851,7 +851,7 @@ fn search_returns_the_exact_top_k_below_the_exhaustive_threshold() {
 fn search_uses_the_graph_above_the_exhaustive_threshold() {
     assert_eq!(
         exhaustive::EXHAUSTIVE_SCAN_MAX_POINTS,
-        256,
+        1024,
         "changing this bound changes the cost profile of every recall; \
          update the measurement in exhaustive.rs before changing the number"
     );
@@ -1156,4 +1156,254 @@ fn upsert_marks_a_shadow_before_the_graph_can_serve_it() {
          through the graph — a search in the window between them would score \
          the drawer by its superseded vector (#5171)"
     );
+}
+
+/// Why (#5179): #5178 bought exactness up to 256 and left 17.4% of queries
+/// losing a true top-10 neighbour at 512 and 24.5% at 1024, measured on this
+/// repo's own palace embeddings. Raising the bound to 1024 is only worth
+/// anything if the whole range up to it is actually answered exactly, and the
+/// seam is where a rounding or `<` / `<=` slip would hide: a palace holding
+/// EXACTLY the threshold count must still take the scan.
+/// What: fills a store with exactly `EXHAUSTIVE_SCAN_MAX_POINTS` drawers and
+/// asserts `search` returns the brute-force top-10 for 20 queries, in order.
+/// Deterministic — the scan is exact, so this cannot flake. On `origin/main`,
+/// where the bound is 256, a 1024-drawer store takes the graph and this fails.
+/// Test: this test itself is the verification.
+#[test]
+fn search_is_exact_at_the_exhaustive_threshold() {
+    let dim = 32;
+    let n = exhaustive::EXHAUSTIVE_SCAN_MAX_POINTS;
+    let k = 10usize;
+    let pool: Vec<Vec<f32>> = (0..n)
+        .map(|i| spread_vec(dim, 600_000 + i as u64))
+        .collect();
+
+    let (_dir, store) = open_store(dim);
+    let uuids: Vec<String> = (0..n).map(|_| Uuid::new_v4().to_string()).collect();
+    for (u, v) in uuids.iter().zip(&pool) {
+        store.upsert(u, v).unwrap();
+    }
+    assert_eq!(store.len().unwrap(), n, "every drawer is live");
+
+    for q in 0..20u64 {
+        let query = spread_vec(dim, 700_000 + q);
+        let expected: Vec<String> = reference_ranking(&pool, &query)
+            .into_iter()
+            .take(k)
+            .map(|i| uuids[i].clone())
+            .collect();
+        let got: Vec<String> = store
+            .search(&query, k)
+            .unwrap()
+            .into_iter()
+            .map(|(u, _)| u)
+            .collect();
+        assert_eq!(
+            got, expected,
+            "query {q}: a palace holding exactly {n} drawers must be answered \
+             exactly (#5179)"
+        );
+    }
+}
+
+/// Why (#5179): `ef_search` was pinned at 64 whatever the collection held, so
+/// the layer-0 candidate heap covered a shrinking fraction of a growing palace
+/// and recall decayed with no signal. Scaling it is the fix; capping the scaled
+/// term is what stops a 100k-drawer palace from asking for `ef = 25_000` and
+/// spending more per query than the exhaustive scan it was routed away from.
+/// Both halves need pinning — an uncapped formula and a formula that never
+/// scales are each a regression, and neither shows up in an end-to-end recall
+/// assertion.
+/// What: asserts the floor holds for a small palace, that the live count drives
+/// the value between the floor and the cap, that the cap binds from 4096 live
+/// drawers upward, and that a large `top_k` is not clipped by the cap.
+/// Test: this test itself is the verification.
+#[test]
+fn graph_ef_search_scales_with_live_count_and_stops_at_the_cap() {
+    use graph_arm::{HNSW_MAX_EF_SEARCH, graph_ef_search};
+
+    assert_eq!(
+        HNSW_MAX_EF_SEARCH, 1024,
+        "the cap is a measured latency ceiling (~3ms per query); moving it needs \
+         a new measurement, not a guess"
+    );
+
+    assert_eq!(
+        graph_ef_search(10, 200),
+        64,
+        "the 64 floor holds for small palaces"
+    );
+    assert_eq!(graph_ef_search(10, 1025), 256, "1025 / 4 clears the floor");
+    assert_eq!(
+        graph_ef_search(10, 2112),
+        528,
+        "the real trusty-tools palace"
+    );
+    assert_eq!(
+        graph_ef_search(10, 4096),
+        1024,
+        "the cap binds exactly at 4096"
+    );
+    assert_eq!(
+        graph_ef_search(10, 100_000),
+        1024,
+        "a 100k-drawer palace must not ask for ef = 25_000 (#5179)"
+    );
+    assert_eq!(
+        graph_ef_search(5_000, 100_000),
+        10_000,
+        "the cap clamps the live-scaled term only — a caller asking for a large \
+         top_k still gets 2k, since returning too few results is a different \
+         defect from taking too long"
+    );
+}
+
+/// Why (#5179): the first-guess candidate count exists so an ordinarily-churned
+/// palace answers in one traversal instead of entering `graph_nearest`'s
+/// widening loop. If it stopped tracking the graph's overhang, the loop would
+/// still return correct results and nothing would fail — the regression would be
+/// silent and purely a cost one, which is exactly what a direct assertion
+/// catches.
+/// What: asserts the steady state is the historical `2k`, that the guess scales
+/// with the dead-and-shadow overhang, and that it never exceeds the point count.
+/// Test: this test itself is the verification.
+#[test]
+fn graph_candidates_inflate_by_the_graphs_dead_weight() {
+    use graph_arm::graph_candidates;
+
+    assert_eq!(
+        graph_candidates(10, 2000, 2000),
+        20,
+        "a palace with no churn since open pays exactly the historical 2k"
+    );
+    assert_eq!(
+        graph_candidates(10, 2000, 4000),
+        40,
+        "half the graph dead doubles the first guess"
+    );
+    assert_eq!(
+        graph_candidates(10, 100, 1000),
+        200,
+        "a ten-fold overhang inflates ten-fold"
+    );
+    assert_eq!(
+        graph_candidates(10, 10, 15),
+        15,
+        "the guess never exceeds the number of points the graph holds"
+    );
+}
+
+/// Why (#5179, promoted from #5178's round-2 review): above the exhaustive
+/// threshold `Hnsw::search` truncated to `2k` candidates and `HnswStore::search`
+/// dropped tombstoned ids afterwards, so the filter ran after the slot count was
+/// already fixed. A palace whose nearest neighbours have been deleted within the
+/// session therefore returned fewer than `k` live hits — or none — while live
+/// neighbours sat in the graph. The same defect class #5178 fixed on the
+/// exhaustive arm, left standing on this one.
+/// What: 1030 live drawers drawn from the isotropic `spread_vec` distribution,
+/// then 60 more that are near-copies of the query — so every deleted drawer
+/// outranks every live one and no over-fetch sized on the average dead fraction
+/// can reach past them. The near-copies are inserted LAST, into a graph that
+/// already holds every live drawer, so their layer-0 neighbour lists point at
+/// live drawers and the widening this test exercises is the candidate budget,
+/// not graph reachability — the separate limit #5171 owns and the exhaustive
+/// threshold exists to avoid. Live count stays above the threshold, so the graph
+/// arm is selected by the store's own rule rather than by a test hook. Asserts
+/// `search` still fills `k` with live drawers. Pre-fix this returns nothing at
+/// all: the `2k` cut lands entirely inside the deleted cluster.
+/// Test: this test itself is the verification.
+#[test]
+fn search_above_the_threshold_fills_k_despite_tombstoned_nearest_neighbours() {
+    let dim = 32;
+    let k = 5usize;
+    let live_n = exhaustive::EXHAUSTIVE_SCAN_MAX_POINTS + 6;
+    let dead_n = 60usize;
+    let (_dir, store) = open_store(dim);
+
+    let query = spread_vec(dim, 424_242);
+    let survivors: Vec<String> = (0..live_n)
+        .map(|i| {
+            let u = Uuid::new_v4().to_string();
+            store
+                .upsert(&u, &spread_vec(dim, 800_000 + i as u64))
+                .unwrap();
+            u
+        })
+        .collect();
+    // Each doomed drawer is the query nudged by 1%, so it outranks every
+    // isotropic live drawer by orders of magnitude.
+    let doomed: Vec<String> = (0..dead_n)
+        .map(|i| {
+            let noise = spread_vec(dim, 950_000 + i as u64);
+            let raw: Vec<f32> = query
+                .iter()
+                .zip(&noise)
+                .map(|(q, n)| q * 0.99 + n * 0.01)
+                .collect();
+            let norm: f32 = raw.iter().map(|x| x * x).sum::<f32>().sqrt();
+            let v: Vec<f32> = raw.into_iter().map(|x| x / norm).collect();
+            let u = Uuid::new_v4().to_string();
+            store.upsert(&u, &v).unwrap();
+            u
+        })
+        .collect();
+    for u in &doomed {
+        store.delete(u).unwrap();
+    }
+    assert_eq!(store.len().unwrap(), live_n, "only the survivors are live");
+    assert!(
+        live_n > exhaustive::EXHAUSTIVE_SCAN_MAX_POINTS,
+        "this test is about the graph arm; it must be the arm selected"
+    );
+
+    let hits = store.search(&query, k).unwrap();
+    assert_eq!(
+        hits.len(),
+        k,
+        "deleted drawers must not spend the caller's result slots — {dead_n} \
+         tombstoned points nearer than every live drawer left {} hits (#5179)",
+        hits.len()
+    );
+    for (u, _) in &hits {
+        assert!(
+            survivors.contains(u),
+            "every returned drawer must be live: {u} is tombstoned"
+        );
+    }
+}
+
+/// Why (#5179): `graph_nearest` widens its candidate pool until `k` live ids
+/// survive, so a palace that cannot supply `k` live drawers at all is where a
+/// widening loop written carelessly spins forever. The termination condition is
+/// the requested count reaching the graph's point count, and nothing else proves
+/// it holds.
+/// What: a palace above the threshold whose live drawers number fewer than the
+/// requested `k`. Asserts `search` returns every live drawer and terminates.
+/// Test: this test itself is the verification.
+#[test]
+fn search_above_the_threshold_stops_widening_when_the_graph_is_exhausted() {
+    let dim = 8;
+    let live_n = exhaustive::EXHAUSTIVE_SCAN_MAX_POINTS + 3;
+    let (_dir, store) = open_store(dim);
+    let survivors: Vec<String> = (0..live_n)
+        .map(|i| {
+            let u = Uuid::new_v4().to_string();
+            store
+                .upsert(&u, &spread_vec(dim, 310_000 + i as u64))
+                .unwrap();
+            u
+        })
+        .collect();
+
+    // Ask for far more than the palace can supply; the loop must stop at the
+    // graph's point count rather than doubling forever.
+    let hits = store.search(&spread_vec(dim, 999_999), live_n * 4).unwrap();
+    assert!(
+        !hits.is_empty() && hits.len() <= live_n,
+        "search must terminate and return at most the live drawers, got {}",
+        hits.len()
+    );
+    for (u, _) in &hits {
+        assert!(survivors.contains(u), "{u} is not a live drawer");
+    }
 }


### PR DESCRIPTION
## Outcome

Refs #5179. `HnswStore::search` now answers exactly up to 1024 live drawers
instead of 256, scales its HNSW `ef_search` with the collection above that, and
stops letting deleted drawers spend the caller's result slots on the graph arm.

Three changes in one PR, as #5179's comment thread scopes them.

## 1 — `EXHAUSTIVE_SCAN_MAX_POINTS` 256 → 1024

#5178 set the bound on cost, not on where the recall loss ends. The regime it
left open is the one measured below: on this repo's own palace embeddings, 17.4%
of queries lost a true top-10 neighbour at 512 live drawers and 24.5% at 1024.

Nothing migrates. No graph is persisted — `open_with_mode` rebuilds the index
from the raw `VECTORS` rows on every palace open — so the constant takes effect
at the next open with no reindex.

## 2 — `ef_search` scales with the live-drawer count

`max(64, 2k, min(live / 4, 1024))`. The cap applies to the live-scaled term
only, so a caller asking for a large `top_k` still gets `2k`.

**The cap is 1024 on measured latency, not on a cost equivalence.** An
`ef = 1024` traversal costs several times what scanning 1024 points costs — each
unit of `ef` carries heap and visited-set work a flat sequential scan does not.
Measured on real embeddings: a 384-dim query over ~2900 drawers takes ~0.5ms at
`ef = 64` and ~2.2ms at `ef = 719`, so 1024 puts the ceiling near 3ms. That the
number equals `EXHAUSTIVE_SCAN_MAX_POINTS` is a coincidence of two independent
choices; the doc comment says so rather than implying otherwise. The cap binds
from `live = 4096` upward.

## 3 — the graph arm no longer truncates before the tombstone filter

Promoted to this issue from #5178's round-2 review. `Hnsw::search` truncated to
`2k` candidates and `HnswStore::search` dropped tombstoned ids afterwards, so
the filter ran after the slot count was already fixed. A palace whose nearest
neighbours had been deleted within the session returned fewer than `k` live hits
— or none — while live neighbours sat in the graph.

An over-fetch scaled to the average dead fraction does not repair this: the dead
points that matter are the ones nearest the query, not a random sample. So
`graph_nearest` filters tombstones out of each traversal's output and widens the
candidate pool until `k` distinct live ids survive, terminating at the graph's
point count.

What it does NOT repair, stated in the code: a live drawer the traversal cannot
REACH from its descent pivot. Widening a budget cannot reach a point no path
leads to. That is #5171's limit, and the exhaustive threshold is what answers
it.

## Real-embedding measurement

**Methodology.** Nine live palaces' `index.usearch.redb` files were copied
read-only out of `~/Library/Application Support/trusty-memory/palaces/` into a
scratch directory and measured there; no live palace file was opened for write.
Decoding their `VECTORS` rows minus tombstones gives 2979 live 384-dim
production embeddings (the `trusty-tools` palace alone now holds 2112, up from
the 1354 #5178 measured). For each cell: 10 independently seeded graph builds ×
100 queries held out of the pool = 1000 queries, `k = 10`, truth computed by
brute-force f64 cosine independently of `hnsw_rs`. A query counts as a miss when
any member of the exact top-10 is absent from what `search` returned. Rebuilding
per cell is what samples `hnsw_rs`'s OS-seeded level RNG rather than assuming it
away.

Queries losing at least one true top-10 neighbour:

| live drawers | before | after |
|---|---|---|
| 256 | 0.0% | 0.0% |
| 512 | 17.4% | **0.0%** |
| 1024 | 24.5% | **0.0%** |
| 1025 | 16.9% | 14.8% |
| 1354 | 21.5% | 15.3% |
| 2048 | 23.3% | 17.7% |
| 2879 | 20.2% | 15.6% |

Individual true neighbours lost, of 10 000 per cell:

| live drawers | before | after |
|---|---|---|
| 512 | 1.98% | **0.00%** |
| 1024 | 3.54% | **0.00%** |
| 1025 | 2.25% | 2.07% |
| 1354 | 3.08% | 2.45% |
| 2048 | 4.33% | 3.09% |
| 2879 | 3.29% | 2.53% |

**Read it honestly.** Exact through 1024 — that half is closed. Above 1024 the
scaled `ef` removes roughly a quarter to a third of the remaining misses and
costs real time to do it (~0.5ms → ~2.2ms per query at 2879 drawers). The gap
above the threshold is narrowed, not closed, which is what #5179 says the
options are: a different index structure or a rerank pass, neither of which is
a parameter change. Per-size latency below 2879 was too noisy on this machine to
report as a comparison, so it is not claimed.

## Regression tests, with failing-before evidence

Demonstrated by reverting only the production behaviour on top of this
commit — `EXHAUSTIVE_SCAN_MAX_POINTS` back to 256, `graph_nearest` back to `2k`
candidates with `ef = max(64, 2k)` and no pre-filter — while keeping the tests:

```
test search_uses_the_graph_above_the_exhaustive_threshold ... FAILED
  assertion `left == right` failed: left: 256  right: 1024

test search_is_exact_at_the_exhaustive_threshold ... FAILED
  assertion `left == right` failed: query 8: a palace holding exactly 1024
  drawers must be answered exactly (#5179)
  (a true top-10 neighbour, c9110017-…, is absent from the returned set)

test search_above_the_threshold_fills_k_despite_tombstoned_nearest_neighbours ... FAILED
  assertion `left == right` failed: deleted drawers must not spend the caller's
  result slots — 60 tombstoned points nearer than every live drawer left 0 hits
  left: 0  right: 5

test result: FAILED. 24 passed; 3 failed; 0 ignored; 0 measured; 1125 filtered out
```

The tombstone test is deterministic rather than probabilistic — 5/5 pre-fix runs
failed, 12/12 post-fix runs passed, sampling `hnsw_rs`'s OS-seeded graph builds:

```
pre-fix:   test result: FAILED. 0 passed; 1 failed;  (×5)
post-fix:  test result: ok. 2 passed; 0 failed;      (×12, with its sibling)
```

New coverage: exactness at exactly 1024 drawers; the graph arm filling `k` with
60 deleted drawers nearer than every live one; the widening loop terminating
when the graph cannot supply `k`; and direct assertions on the computed
`ef_search` (floor at 64, `live / 4` between floor and cap, cap binding at 4096,
`2k` never clipped) and on the candidate budget.

## Gates — test ladder rung 4

Rung 3 on the library:

```
cargo fmt --check -p trusty-common                                               # clean
cargo check -p trusty-common --features memory-core                              # clean
cargo clippy -p trusty-common --features memory-core,embedder-test-support \
  --all-targets -- -D warnings                                                   # clean
cargo test -p trusty-common --features memory-core,embedder-test-support
  test result: ok. 1139 passed; 0 failed; 13 ignored; 0 measured; 0 filtered out
  (plus 6 / 11 / 4 / 3 passed across the integration test binaries, 0 failed)
```

Then the workspace check and every direct dependent of the `memory-core`
feature (`trusty-memory`, `trusty-mpm`, `trusty-agents`, `tga`,
`trusty-cto-db`):

```
cargo check --workspace                     # clean

cargo test -p trusty-memory   ok. 811 passed; 0 failed; 4 ignored  (+25 integration binaries, 0 failed)
cargo test -p trusty-mpm      ok. 5234 passed; 0 failed; 7 ignored  (+45 integration binaries, 0 failed)
cargo test -p trusty-agents   ok. 3529 passed; 0 failed; 13 ignored (+9 integration binaries, 0 failed)
cargo test -p tga             ok. 1342 passed; 0 failed; 7 ignored  (+6 integration binaries, 0 failed)
cargo test -p trusty-cto-db   ok. 12 passed; 0 failed; 0 ignored
```

`bash scripts/check_line_cap.sh` — 4165 files, 0 violations. Changelog fragment:
`crates/trusty-common/changelog.d/5179-hnsw-recall-above-256.md`.

## Version gate is RED by design

This PR does not bump `trusty-common`. Open PR #6221 carries the 0.43.1 bump, so
the version-gate check stays red until that merges. Nothing here is waiting on
it.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
