### PR TITLE
fix(trusty-mpm): --merged-prs outlives the client's 10s request bound (Refs #5830)

### DIFF
--- a/crates/trusty-mpm/changelog.d/5830-merged-prs-request-timeout.md
+++ b/crates/trusty-mpm/changelog.d/5830-merged-prs-request-timeout.md
@@ -1,0 +1,3 @@
+Fixed
+
+- `tm session prune-worktrees --merged-prs` no longer fails with "operation timed out" on every invocation. The merged-PR survey runs synchronously inside the daemon handler and takes minutes — over 600 seconds byte-walking 46 worktrees on a large workspace — while the request inherited the client's 10-second default bound, so the CLI hung up before the daemon could ever answer. The request now carries a 1800-second per-request override (`RECLAIM_SURVEY_REQUEST_TIMEOUT`), and prints a one-line notice up front so a long silent wait is distinguishable from a wedged daemon. Only the `--merged-prs` opt-in raises the bound; the orphan-only sweep keeps failing fast at 10 seconds (Refs #5830).

--- a/crates/trusty-mpm/src/bin/tm/commands/managed_merged_prs.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed_merged_prs.rs
@@ -140,7 +140,8 @@ fn diagnostic_lines(merged: &serde_json::Value) -> Vec<String> {
 /// deal with by hand.
 /// Test: HTTP path covered by integration test; CLI parse by
 /// `cli_parses_session_prune_worktrees` and
-/// `cli_prune_worktrees_discard_dirty_is_opt_in`.
+/// `cli_prune_worktrees_discard_dirty_is_opt_in`; the #5830 timeout override by
+/// `merged_pr_request_outlives_the_default_client_timeout`.
 pub(crate) async fn session_prune_worktrees(
     client: &reqwest::Client,
     url: &str,
@@ -148,16 +149,28 @@ pub(crate) async fn session_prune_worktrees(
     discard_dirty: bool,
     merged_prs: bool,
 ) -> anyhow::Result<()> {
-    let resp = client
+    let mut request = client
         .post(format!("{url}/api/v1/sessions/managed/prune-worktrees"))
         .json(&serde_json::json!({
             "dry_run": dry_run,
             "discard_dirty": discard_dirty,
             // #2919: the merged-PR reclaim pass, off unless explicitly asked for.
             "merged_prs": merged_prs,
-        }))
-        .send()
-        .await?;
+        }));
+    if merged_prs {
+        // #5830: the merged-PR survey runs synchronously in the handler and
+        // takes minutes, so the client's 10s default aborted every invocation.
+        request = request.timeout(trusty_mpm::client::http_client::RECLAIM_SURVEY_REQUEST_TIMEOUT);
+        // The wait is long and the daemon streams nothing, so say what is
+        // happening — an operator with no output cannot tell a running survey
+        // from a wedged one.
+        eprintln!(
+            "merged-PR pass: surveying every registered worktree (classify, then byte-walk) \
+             — this takes minutes on a large workspace and prints nothing until it \
+             finishes (#5830)"
+        );
+    }
+    let resp = request.send().await?;
     let body: serde_json::Value = resp.error_for_status()?.json().await?;
     let paths = body
         .get("paths")

--- a/crates/trusty-mpm/src/bin/tm/commands/managed_merged_prs_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed_merged_prs_tests.rs
@@ -7,7 +7,7 @@
 //! What: exercises the null/absent short-circuit, the dry-run and real
 //! summaries, and every stderr diagnostic branch.
 
-use super::{diagnostic_lines, print_merged_pr_pass};
+use super::{diagnostic_lines, print_merged_pr_pass, session_prune_worktrees};
 
 #[test]
 fn merged_pr_pass_surfaces_an_agent_owned_skip() {
@@ -104,6 +104,106 @@ fn merged_pr_pass_reports_a_failed_pass_rather_than_a_zero_count() {
     // would read as a healthy no-op rather than a failure.
     let body = serde_json::json!({ "error": "task panicked" });
     print_merged_pr_pass(Some(&body), false);
+}
+
+/// 🔴 #5830 REGRESSION: `--merged-prs` must outlive the client's default
+/// request timeout.
+///
+/// Why: the survey runs synchronously inside the handler and takes minutes
+/// (over 600 seconds byte-walking 46 worktrees, per `SurveyBudget`'s own doc).
+/// Against the 10s `DEFAULT_REQUEST_TIMEOUT` the CLI hung up on every single
+/// invocation — "operation timed out", deterministically, never once
+/// completing. The fix is a per-request override, and an override only helps if
+/// it actually reaches the wire.
+/// What: scales the real shape down by 1000x. A one-shot HTTP server answers
+/// after `SERVER_DELAY`; the client is built with a `CLIENT_BOUND` shorter than
+/// that, standing in for the production 10s. With `merged_prs: true` the
+/// request must survive to read the response, because the override replaced the
+/// client bound.
+///
+/// Non-vacuity: the CONTROL sends the SAME body with `merged_prs: false` against
+/// an identical server and asserts it FAILS — so the test cannot pass merely
+/// because the client bound was never applied at all. That control is also the
+/// behavioural claim itself: the orphan-only sweep keeps failing fast against a
+/// wedged daemon.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn merged_pr_request_outlives_the_default_client_timeout() {
+    use std::time::Duration;
+
+    // Comfortably longer than `CLIENT_BOUND`, short enough to keep the test
+    // fast; the gap absorbs scheduler jitter on a loaded runner.
+    const SERVER_DELAY: Duration = Duration::from_millis(1200);
+    const CLIENT_BOUND: Duration = Duration::from_millis(250);
+
+    let client = reqwest::Client::builder()
+        .connect_timeout(Duration::from_millis(500))
+        .timeout(CLIENT_BOUND)
+        .build()
+        .expect("build a short-bounded test client");
+
+    let (url, server) = slow_prune_server(SERVER_DELAY).await;
+    let overridden = session_prune_worktrees(&client, &url, true, false, true).await;
+    server.await.expect("server task must not panic");
+    assert!(
+        overridden.is_ok(),
+        "`--merged-prs` must carry a per-request timeout longer than the client \
+         default; got {overridden:?}"
+    );
+
+    // CONTROL: without the opt-in the client default still bounds the call.
+    let (url, server) = slow_prune_server(SERVER_DELAY).await;
+    let plain = session_prune_worktrees(&client, &url, true, false, false).await;
+    server.await.expect("server task must not panic");
+    assert!(
+        plain.is_err(),
+        "the orphan-only sweep must keep the short default bound, otherwise this \
+         test proves nothing about the override"
+    );
+}
+
+/// A one-shot HTTP server that answers a prune-worktrees POST after `delay`.
+///
+/// Why: reproducing "the daemon is still working when the client's clock runs
+/// out" needs a peer that eventually ANSWERS — a never-answering socket (the
+/// `build_client_bounds_a_stalled_connection` shape) cannot tell a raised bound
+/// from an unraised one, because both end in an error.
+/// What: binds an ephemeral loopback port, returns its URL plus the join handle
+/// for the accept task. The task reads until the request headers end, sleeps,
+/// then writes a minimal 200 carrying the `merged_prs: null` body the route
+/// returns when the pass was not requested.
+async fn slow_prune_server(delay: std::time::Duration) -> (String, tokio::task::JoinHandle<()>) {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind slow prune server");
+    let url = format!("http://{}", listener.local_addr().expect("local_addr"));
+    let handle = tokio::spawn(async move {
+        let (mut sock, _) = listener.accept().await.expect("accept one connection");
+        let mut seen = Vec::new();
+        let mut buf = [0u8; 1024];
+        // Read only as far as the end of the headers: the body is a few dozen
+        // bytes and reqwest sends it immediately, so nothing is left to block
+        // the response write.
+        while !seen.windows(4).any(|w| w == b"\r\n\r\n") {
+            match sock.read(&mut buf).await {
+                Ok(0) | Err(_) => return,
+                Ok(n) => seen.extend_from_slice(&buf[..n]),
+            }
+        }
+        tokio::time::sleep(delay).await;
+        let body = br#"{"dry_run":true,"paths":[],"skipped_dirty":[],"merged_prs":null}"#;
+        let head = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\
+             Connection: close\r\n\r\n",
+            body.len()
+        );
+        let _ = sock.write_all(head.as_bytes()).await;
+        let _ = sock.write_all(body).await;
+        let _ = sock.flush().await;
+    });
+    (url, handle)
 }
 
 #[test]

--- a/crates/trusty-mpm/src/client/http_client/config.rs
+++ b/crates/trusty-mpm/src/client/http_client/config.rs
@@ -101,6 +101,34 @@ pub(super) const CHAT_REQUEST_TIMEOUT: Duration = Duration::from_secs(130);
 /// second copy of the constant there would be free to drift.
 pub(crate) const PROVISION_REQUEST_TIMEOUT: Duration = Duration::from_secs(180);
 
+/// Per-request timeout override for `POST …/managed/prune-worktrees` when the
+/// merged-PR reclaim pass is requested (#5830).
+///
+/// Why: that request runs the whole merged-PR survey synchronously inside the
+/// handler. The survey classifies every registered worktree (~92s measured
+/// against the real store) and then byte-walks each one, including its
+/// multi-gigabyte `target/` — a walk that
+/// [`SurveyBudget`](crate::session_manager::worktree_reclaim_sweep::SurveyBudget)'s
+/// own doc measures at over 600 seconds for 46 worktrees. Under
+/// [`DEFAULT_REQUEST_TIMEOUT`] the client hung up at 10s on EVERY invocation, so
+/// `tm session prune-worktrees --merged-prs` had never once completed on this
+/// repository. Retrying could not help — the bound was 60x short of the work.
+/// 1800s is roughly 3x the measured worst case, and stays a hard, finite bound.
+/// What: passed to `reqwest::RequestBuilder::timeout` at the
+/// `session_prune_worktrees` call site, and ONLY when `merged_prs` is set — the
+/// orphan-only sweep keeps the 10s default, so a wedged daemon still fails fast
+/// for every other prune. Mirrors [`CHAT_REQUEST_TIMEOUT`] and
+/// [`PROVISION_REQUEST_TIMEOUT`], which exist for the same reason.
+/// Test: `tests::default_client_uses_default_bounds` pins the value;
+/// `merged_pr_request_outlives_the_default_client_timeout` (in
+/// `bin/tm/commands/managed_merged_prs_tests.rs`) proves the override reaches
+/// the wire.
+///
+/// `pub` (re-exported by [`super`]): a `[[bin]]` target is a distinct crate from
+/// the library, so `tm`'s own command module cannot see `pub(crate)` — the same
+/// crate boundary [`super::default_client`] exists to cross.
+pub const RECLAIM_SURVEY_REQUEST_TIMEOUT: Duration = Duration::from_secs(1800);
+
 /// Build the `reqwest::Client` [`super::DaemonClient::new`] uses by default.
 ///
 /// Why: the one production call site for [`build_client`], pinned to this
@@ -205,6 +233,15 @@ mod tests {
         assert!(
             PROVISION_REQUEST_TIMEOUT > DEFAULT_REQUEST_TIMEOUT,
             "the provisioning override must be longer than the default, not shorter"
+        );
+        // #5830: the merged-PR survey outruns every other override here, so it
+        // must be the longest of them — shrinking it back toward the provision
+        // bound reinstates the always-times-out failure.
+        assert_eq!(RECLAIM_SURVEY_REQUEST_TIMEOUT, Duration::from_secs(1800));
+        assert!(
+            RECLAIM_SURVEY_REQUEST_TIMEOUT > PROVISION_REQUEST_TIMEOUT,
+            "the merged-PR survey outlasts a first-clone provision, so its bound \
+             must exceed the provisioning one"
         );
         let _ = default_client();
     }

--- a/crates/trusty-mpm/src/client/http_client/mod.rs
+++ b/crates/trusty-mpm/src/client/http_client/mod.rs
@@ -34,6 +34,11 @@ mod types;
 // `DaemonClient::spawn_managed_session` rather than keeping its own copy.
 pub(crate) use config::PROVISION_REQUEST_TIMEOUT;
 
+// #5830: the `tm` binary is a separate crate from this library, so the
+// merged-PR survey bound is re-exported publicly for the same reason
+// `default_client` below is a public seam.
+pub use config::RECLAIM_SURVEY_REQUEST_TIMEOUT;
+
 pub use types::{
     BreakerRow, ChatMessage, ConfigRecommendation, CoordinatorChatOutcome, CoordinatorContext,
     CoordinatorSession, DiscoveredProjectRow, EventRow, FleetByProjectWireResponse,


### PR DESCRIPTION
`Refs #5830`

`tm session prune-worktrees --merged-prs` failed with "operation timed out" on
every invocation. The merged-PR survey runs synchronously inside the daemon's
prune-worktrees handler: it classifies every registered worktree (~92s measured)
and then byte-walks each one, a walk `SurveyBudget`'s own doc measures at over
600 seconds for 46 worktrees. The request carried `DEFAULT_REQUEST_TIMEOUT` —
10 seconds — so the client hung up roughly 60x short of the work,
deterministically. No retry could help.

## Change

- `RECLAIM_SURVEY_REQUEST_TIMEOUT` (1800s) joins `CHAT_REQUEST_TIMEOUT` and
  `PROVISION_REQUEST_TIMEOUT` in `client/http_client/config.rs`, and
  `session_prune_worktrees` applies it via `RequestBuilder::timeout` — but only
  when `merged_prs` is set. The orphan-only sweep keeps the 10s default, so a
  wedged daemon still fails fast for every other prune.
- The CLI prints one line before the call. The daemon streams nothing, so a
  silent multi-minute wait is otherwise indistinguishable from a hang.

The constant is `pub` and re-exported from `client::http_client` for the reason
`default_client` already is: a `[[bin]]` target is a distinct crate from the
library, so `pub(crate)` does not reach `tm`'s own command module.

Not addressed here: the `spawn_blocking` survey is still uncancellable if an
operator interrupts the CLI. That is inherent to the blocking walk and is safe
in Report mode, which never deletes.

## Rung

**Rung 3** (localized behavior inside one crate), widened with
`cargo check --workspace` because the fix adds a `pub` const to the library
surface. That addition is additive and no other crate consumes it.

## Regression proof

`merged_pr_request_outlives_the_default_client_timeout` scales the real shape
down 1000x: a one-shot HTTP server answers after 1200ms against a client bound
at 250ms. Deleting the one-line fix reproduces the issue's exact error text:

```
thread '...::merged_pr_request_outlives_the_default_client_timeout' panicked at
crates/trusty-mpm/src/bin/tm/commands/managed_merged_prs_tests.rs:148:5:
`--merged-prs` must carry a per-request timeout longer than the client default; got Err(error sending request for url (http://127.0.0.1:51148/api/v1/sessions/managed/prune-worktrees)

Caused by:
    operation timed out)
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1782 filtered out; finished in 1.23s
```

The test's CONTROL sends the same body with `merged_prs: false` and asserts it
still FAILS, so it cannot pass merely because the client bound was never applied.

## Gates

| Command | Result |
|---|---|
| `cargo fmt --check` | clean |
| `cargo check -p trusty-mpm --all-targets` | `EXIT=0` |
| `cargo clippy -p trusty-mpm --all-targets -- -D warnings` | `EXIT=0` |
| `cargo test -p trusty-mpm` | `EXIT=0` — 5245 + 1782 + 1782 + 28 + 98 + … passed; 0 failed across 50 targets |
| `cargo check --workspace` | `EXIT=0` |
| `bash scripts/check_line_cap.sh` | 4167 files, 0 violations |

Largest suite line: `test result: ok. 5245 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out; finished in 329.19s`.
The known-flaky `hook_flags_idle_parking` and `live_pane_scoped_send` both passed.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools