### PR TITLE
fix(trusty-common): a worktree's `.git` FILE resolves to its main checkout (Refs #5888)

### DIFF
--- a/crates/trusty-common/changelog.d/5888-worktree-dot-git-file.md
+++ b/crates/trusty-common/changelog.d/5888-worktree-dot-git-file.md
@@ -1,0 +1,15 @@
+Fixed
+
+- `find_project_root` no longer stops at a linked git worktree. Its marker check
+  asked only whether `.git` existed, which is true for the pointer FILE git
+  writes in a worktree as well as for a checkout's `.git` directory, so a
+  worktree answered with its own path while its main checkout answered with the
+  checkout — two project roots for one project, against ADR-0012 §1. A `.git`
+  file is now followed through its `gitdir:` pointer and the `commondir` file in
+  the admin directory it names, and the main checkout is returned. Callers that
+  read or lazily WRITE `.trusty-tools/trusty-memory.yaml` from inside a worktree
+  now reach the checkout's pin instead of creating a second one on the worktree
+  branch. A submodule or `--separate-git-dir` checkout carries a `.git` file of
+  the same shape but no `commondir`; those directories are still their own root,
+  and any unreadable or unresolvable `.git` file leaves the previous answer
+  unchanged. (#5888)

--- a/crates/trusty-common/src/palace_resolve.rs
+++ b/crates/trusty-common/src/palace_resolve.rs
@@ -210,16 +210,34 @@ pub enum PalaceResolveError {
 /// Walk upward from `start` to the first directory carrying a project marker.
 ///
 /// Why: the pin file is anchored at a project root, so every caller that wants
-/// to read it first needs to agree on where the project begins.
+/// to read it first needs to agree on where the project begins. That answer has
+/// to be the same from a worktree and from its main checkout — ADR-0012 §1, the
+/// same property the module docs give for level 4.
 /// What: canonicalises `start` (best-effort), then ascends checking
 /// [`PROJECT_MARKERS`] at each level. Returns `None` at the filesystem root.
-/// Test: `finds_git_root_from_nested_dir`, `no_markers_returns_none`.
+///
+/// A `.git` FILE is a pointer, not a root marker, and the old check
+/// (`current.join(marker).exists()`) could not tell the two apart: a linked
+/// worktree stopped at its own directory and every caller then read and WROTE
+/// the pin there instead of in the checkout the project actually lives in
+/// (#5888). A `.git` file is now followed to the main checkout via
+/// [`main_checkout_of_worktree`], which declines for the submodule and
+/// `--separate-git-dir` shapes that carry the same file — those directories ARE
+/// their own root, so the walk stops there as before.
+/// Test: `finds_git_root_from_nested_dir`, `no_markers_returns_none`,
+/// `a_worktree_resolves_to_its_main_checkout`,
+/// `a_separate_git_dir_checkout_is_its_own_root`.
 pub fn find_project_root(start: &Path) -> Option<PathBuf> {
     let mut current = start.to_path_buf();
     if let Ok(canonical) = std::fs::canonicalize(&current) {
         current = canonical;
     }
     loop {
+        // #5888: a `.git` file points elsewhere; a `.git` directory is the root.
+        let dot_git = current.join(".git");
+        if dot_git.is_file() {
+            return Some(main_checkout_of_worktree(&dot_git).unwrap_or(current));
+        }
         for marker in PROJECT_MARKERS {
             if current.join(marker).exists() {
                 return Some(current);
@@ -229,6 +247,61 @@ pub fn find_project_root(start: &Path) -> Option<PathBuf> {
             Some(parent) if parent != current => current = parent.to_path_buf(),
             _ => return None,
         }
+    }
+}
+
+/// Resolve a linked worktree's `.git` FILE to the main checkout that owns it.
+///
+/// Why (#5888): only a linked worktree may be redirected. A submodule and any
+/// `--separate-git-dir` checkout carry a `.git` file of the identical shape, and
+/// their own directory really is the project root — redirecting those would hand
+/// the caller `<outer>/.git/modules`, which is git internals, not a working tree
+/// (the failure #5819 fixed in [`main_worktree_root`]).
+/// What: reads the `gitdir:` pointer, then reads `commondir` from the admin
+/// directory it names. `commondir` exists ONLY in a linked worktree's admin
+/// directory, so its absence is what separates the two shapes without shelling
+/// out to git. The main checkout is the parent of the common dir, and only when
+/// that common dir is itself named `.git` — otherwise the main repository is a
+/// `--separate-git-dir` one whose parent is no working tree either. Any read,
+/// parse, or shape failure returns `None`, leaving the caller with the
+/// pre-existing answer.
+/// Test: `a_worktree_resolves_to_its_main_checkout`,
+/// `a_separate_git_dir_checkout_is_its_own_root`,
+/// `a_malformed_dot_git_file_leaves_the_directory_as_the_root`.
+fn main_checkout_of_worktree(dot_git_file: &Path) -> Option<PathBuf> {
+    let raw = std::fs::read_to_string(dot_git_file).ok()?;
+    let pointer = raw
+        .lines()
+        .find_map(|line| line.trim().strip_prefix("gitdir:"))?
+        .trim();
+    if pointer.is_empty() {
+        return None;
+    }
+    let admin = resolve_against(dot_git_file.parent()?, Path::new(pointer));
+
+    let common = std::fs::read_to_string(admin.join("commondir")).ok()?;
+    let common = common.trim();
+    if common.is_empty() {
+        return None;
+    }
+    let common_dir = std::fs::canonicalize(resolve_against(&admin, Path::new(common))).ok()?;
+
+    if common_dir.file_name() != Some(std::ffi::OsStr::new(".git")) {
+        return None;
+    }
+    let root = common_dir.parent()?;
+    root.is_dir().then(|| root.to_path_buf())
+}
+
+/// Interpret `path` relative to `base` when it is not already absolute.
+///
+/// Why: both `gitdir:` and `commondir` are documented as absolute-or-relative,
+/// and git writes the relative form for a worktree inside its own checkout.
+fn resolve_against(base: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        base.join(path)
     }
 }
 

--- a/crates/trusty-common/src/palace_resolve_tests.rs
+++ b/crates/trusty-common/src/palace_resolve_tests.rs
@@ -73,6 +73,149 @@ fn trusty_tools_dir_is_a_marker() {
     assert!(find_project_root(&root).is_some());
 }
 
+/// Build a repo at `<tmp>/my-project` with a linked worktree under
+/// `.claude/worktrees/agent-x`, mirroring this repo's own layout.
+///
+/// Why: a hand-written `.git` file would prove the parser and nothing else. Only
+/// a real `git worktree add` writes the admin directory — `commondir` included —
+/// that [`main_checkout_of_worktree`] reads.
+/// What: returns `(main, worktree)`, or `None` when git cannot do its part, so
+/// the caller skips rather than failing on a machine without git.
+fn repo_with_worktree(tmp: &Path) -> Option<(PathBuf, PathBuf)> {
+    let main = tmp.join("my-project");
+    fs::create_dir_all(&main).unwrap();
+    if !init_repo(&main, None) {
+        return None;
+    }
+    let run = |args: &[&str]| {
+        Command::new("git")
+            .arg("-C")
+            .arg(&main)
+            .args(args)
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    };
+    // A worktree needs at least one commit to branch from.
+    fs::write(main.join("README.md"), "x").unwrap();
+    if !run(&["add", "-A"]) || !run(&["commit", "-qm", "init"]) {
+        return None;
+    }
+    let wt = main.join(".claude").join("worktrees").join("agent-x");
+    if !run(&["worktree", "add", "-q", "-b", "wt-branch", wt.to_str()?]) {
+        return None;
+    }
+    Some((main, wt))
+}
+
+/// Why (#5888): THE defect. `current.join(".git").exists()` is true for the
+/// `.git` FILE git writes in a linked worktree, so the walk stopped at the
+/// worktree and every caller read — and lazily WROTE — the pin there instead of
+/// in the checkout the project lives in. A worktree and its main checkout must
+/// answer the same root (ADR-0012 §1).
+/// What: a real `git worktree add`, guarded by an `is_file` assertion on the
+/// fixture, resolved from the worktree root and from a directory nested inside
+/// it.
+/// Test: itself. Against `4a823a0b4` both assertions return the worktree.
+#[test]
+fn a_worktree_resolves_to_its_main_checkout() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let Some((main, wt)) = repo_with_worktree(tmp.path()) else {
+        eprintln!("skipping a_worktree_resolves_to_its_main_checkout: git unavailable");
+        return;
+    };
+    assert!(
+        wt.join(".git").is_file(),
+        "fixture must reproduce git's linked-worktree `.git` FILE"
+    );
+    let expected = fs::canonicalize(&main).expect("canonicalize main");
+
+    assert_eq!(
+        find_project_root(&wt).expect("worktree resolves"),
+        expected,
+        "a worktree must resolve to the checkout that owns it"
+    );
+
+    let nested = wt.join("crates").join("foo");
+    fs::create_dir_all(&nested).unwrap();
+    assert_eq!(
+        find_project_root(&nested).expect("nested dir resolves"),
+        expected,
+        "a directory inside a worktree must resolve to the same checkout"
+    );
+}
+
+/// Why (#5888): a submodule and any `--separate-git-dir` checkout carry a `.git`
+/// file of the identical shape, and their own directory IS the project root.
+/// Following that pointer would hand the caller `<outer>/.git/modules` — git
+/// internals, not a working tree, the same wrong answer #5819 removed from
+/// [`main_worktree_root`].
+/// What: builds the `--separate-git-dir` structure, asserts the fixture really
+/// wrote a `.git` file, and asserts the walk still stops at the checkout.
+#[test]
+fn a_separate_git_dir_checkout_is_its_own_root() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let outer = tmp.path().join("outer");
+    let sub = outer.join("sub");
+    fs::create_dir_all(&sub).unwrap();
+    if !init_repo(&outer, None) {
+        eprintln!("skipping a_separate_git_dir_checkout_is_its_own_root: git unavailable");
+        return;
+    }
+    let separate = outer.join(".git").join("modules").join("sub");
+    fs::create_dir_all(separate.parent().unwrap()).unwrap();
+    let init = Command::new("git")
+        .arg("-C")
+        .arg(&sub)
+        .args([
+            "init",
+            "-q",
+            &format!("--separate-git-dir={}", separate.display()),
+            ".",
+        ])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    if !init {
+        eprintln!("skipping a_separate_git_dir_checkout_is_its_own_root: cannot init");
+        return;
+    }
+    assert!(
+        sub.join(".git").is_file(),
+        "fixture must reproduce the `.git` FILE a submodule checkout carries"
+    );
+
+    assert_eq!(
+        find_project_root(&sub).expect("resolves"),
+        fs::canonicalize(&sub).expect("canonicalize sub"),
+        "a checkout whose git dir is elsewhere is still its own project root"
+    );
+}
+
+/// Why (#5888): the redirect is best-effort. A `.git` file that does not parse,
+/// or whose pointer names nothing, must leave the caller with the answer it had
+/// before rather than with `None` — losing the root is worse than not following
+/// the pointer.
+#[test]
+fn a_malformed_dot_git_file_leaves_the_directory_as_the_root() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    for (name, body) in [
+        ("garbage", "not a gitdir pointer at all\n"),
+        ("empty-pointer", "gitdir:   \n"),
+        ("dangling", "gitdir: /nonexistent-trusty-test-admin-5888\n"),
+    ] {
+        let root = tmp.path().join(name);
+        fs::create_dir_all(&root).unwrap();
+        fs::write(root.join(".git"), body).unwrap();
+
+        assert_eq!(
+            find_project_root(&root).expect("resolves"),
+            fs::canonicalize(&root).expect("canonicalize root"),
+            "a `.git` file that does not resolve ({name}) must leave the directory as the root"
+        );
+    }
+}
+
 /// Why: outside any project the caller must be told so, not handed a guess.
 #[test]
 fn no_markers_returns_none() {


### PR DESCRIPTION
Refs #5888

## What changed

`find_project_root` (`crates/trusty-common/src/palace_resolve.rs`) asked only
whether `.git` existed. That is true for the pointer FILE git writes in a linked
worktree as well as for a checkout's `.git` directory, so the walk stopped at the
worktree: a worktree answered with its own path while its main checkout answered
with the checkout — two project roots for one project, against ADR-0012 §1.

A `.git` file is now followed through its `gitdir:` pointer and the `commondir`
file in the admin directory it names, and the main checkout is returned.
`commondir` exists only in a linked worktree's admin directory, which is what
separates a worktree from the submodule and `--separate-git-dir` shapes that
carry a `.git` file of the identical form — those directories are still their own
root, and following their pointer would hand the caller `<outer>/.git/modules`,
the wrong answer #5819 removed from `main_worktree_root`. Any unreadable or
unresolvable `.git` file leaves the previous answer unchanged.

No shell-out: the redirect is two file reads, and only when `.git` is a file.

## Re-export shim decision (#5888's third closure condition)

`trusty_memory::project_root::detection`'s re-export stays. There is one
implementation, in `trusty_common::palace_resolve`, and the shim is a documented
thin facade over it — moving its five in-crate callers to the direct path would
be churn with no behaviour change.

## Regression proof

`a_worktree_resolves_to_its_main_checkout` builds a real `git worktree add` under
`.claude/worktrees/agent-x` and asserts `.git` is a FILE before asserting the
root. Against `4a823a0b4` (this branch's base), with only the production change
reverted:

```
test palace_resolve::tests::a_worktree_resolves_to_its_main_checkout ... FAILED

assertion `left == right` failed: a worktree must resolve to the checkout that owns it
  left: ".../my-project/.claude/worktrees/agent-x"
 right: ".../my-project"
```

Two more tests guard the shapes that must NOT change:
`a_separate_git_dir_checkout_is_its_own_root` and
`a_malformed_dot_git_file_leaves_the_directory_as_the_root`.

## Gates — ladder rung 4 (shared library, cross-crate)

Rung 3 on `trusty-common`, then `check --workspace` plus each direct dependent
that enables the `palace-resolve` feature.

| Command | Result |
|---|---|
| `cargo fmt --check` | clean |
| `cargo check -p trusty-common --features palace-resolve` | clean |
| `cargo clippy -p trusty-common --features palace-resolve --all-targets -- -D warnings` | clean |
| `cargo test -p trusty-common --features palace-resolve` | 392 passed; 0 failed; 6 ignored |
| `cargo check --workspace` | clean |
| `cargo test -p trusty-memory` | 815 + 92 across binaries; 0 failed |
| `cargo test -p trusty-mpm` | 5245 + 1781 passed; see flake note |
| `cargo test -p trusty-code` | 1652 passed; see flake note |
| `cargo test -p trusty-agents` | 3529 + 36 passed; 0 failed |
| `bash scripts/check_line_cap.sh` | 0 violations |
| `bash scripts/check_sld.sh` | 0 errors, 0 warnings |
| `bash scripts/check_changelog_fragment.sh` | fragment present and valid |

`cargo test -p trusty-common` without `--features` compiles almost none of the
crate, so the feature that gates `palace_resolve` is named on every run.

### Two load-induced flakes, both pre-existing

Both surfaced while three full cargo suites ran concurrently on this machine, and
both pass in isolation on this branch. Neither test reaches `find_project_root`:
each works in a bare `tempfile::tempdir()` with no `.git` of any kind, so the
change adds zero filesystem operations on their paths.

`trusty-mpm` — `tests_behavior_b::guided_fallback_non_git_dir_with_managed_env_settles_quickly_returns_promptly`
asserts wall-clock `elapsed < 300ms` against an HTTP mock:

```
panicked at crates/trusty-mpm/src/bin/tm/tests_behavior_b_tests.rs:1452:5:
a record that settles on the second poll must not pay the full retry budget; took 330.21575ms
```

The same test PASSED in the `tm` bin target and FAILED in the `trusty-mpm` bin
target within that one invocation — identical source, two bin targets. Re-run
alone: `1 passed`, 0.17s. Same family as #5840.

`trusty-code` — `cli::daemon_autospawn::daemon_autospawn_tests::spawns_a_daemon_when_none_is_running`
spawns a stub subprocess and reads the argv file it writes with no
condition-based wait:

```
panicked at crates/trusty-code/src/cli/daemon_autospawn_tests.rs:356:51:
stub must have recorded its argv: Os { code: 2, kind: NotFound, message: "No such file or directory" }
```

Re-run alone: `1 passed`.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
