### PR TITLE
fix(trusty-common): a symgraph call edge needs grounds, not a bare-name match (Refs #6170)

### DIFF
--- a/crates/trusty-common/changelog.d/6170-symgraph-grounded-resolution.md
+++ b/crates/trusty-common/changelog.d/6170-symgraph-grounded-resolution.md
@@ -6,11 +6,18 @@ Fixed
   and a call becomes an edge only when one scope around the CALLER holds exactly
   one candidate: the caller's own file, then each ancestor directory, then the
   whole corpus. Two crates defining `run` is no longer grounds for an edge to
-  either, and a Rust call no longer binds to a `.ts` method of the same name. In
-  the reverse direction, a callee beside the caller now wins over a same-named
-  definition that was merely registered first — `upsert` calling `write` used to
-  land in whichever crate sorted earliest.
+  either, and a call no longer binds across languages — `.ts` and `.tsx` count
+  as one language, so twins in both keep each other ambiguous instead of one
+  looking unique. In the reverse direction, a callee beside the caller now wins
+  over a same-named definition that was merely registered first — `upsert`
+  calling `write` used to land in whichever crate sorted earliest.
+- A call no longer resolves to a symbol that cannot be called. The same-file
+  shortcut used to answer before the callable check, so a `Calls` edge could
+  land on a struct or an import sitting in the caller's own file; two symbols
+  sharing one `<file>::<symbol>` key now resolve to neither rather than to
+  whichever was inserted last.
 - `callers_of`, `callees_of` and `context_for` anchor through that same
-  resolution: a `<path>::<symbol>` name now anchors instead of missing, and a
+  resolution: `<path>::<symbol>` now anchors on the file it names — matched
+  against each candidate's own file, so a partial path suffix works too — and a
   bare name that several definitions answer to picks the most-connected one
   rather than the first registered.

--- a/crates/trusty-common/changelog.d/6170-symgraph-grounded-resolution.md
+++ b/crates/trusty-common/changelog.d/6170-symgraph-grounded-resolution.md
@@ -1,0 +1,22 @@
+Fixed
+
+- `symgraph::SymbolGraph` no longer resolves a callee against one global
+  bare-name map, first write wins (#6170) — the same defect PR #6169 fixed in
+  trusty-search's parallel graph. A definition is now keyed `<file>::<symbol>`,
+  and a call becomes an edge only when one scope around the CALLER holds exactly
+  one candidate: the caller's own file, then each ancestor directory, then the
+  whole corpus. Two crates defining `run` is no longer grounds for an edge to
+  either, and a Rust call no longer binds to a `.ts` method of the same name. In
+  the reverse direction, a callee beside the caller now wins over a same-named
+  definition that was merely registered first — `upsert` calling `write` used to
+  land in whichever crate sorted earliest.
+
+Added
+
+- `SymbolGraph::resolve_symbol` returns `SymbolMatch::{Unique, Ambiguous,
+  NotFound}` for a caller-supplied name, so a consumer anchoring a trace can
+  report which definition it took and what else matched. `callers_of`,
+  `callees_of` and `context_for` anchor through the same resolution: a
+  `<path>::<symbol>` name now anchors instead of missing, and a bare name that
+  several definitions answer to picks the most-connected one rather than the
+  first registered.

--- a/crates/trusty-common/changelog.d/6170-symgraph-grounded-resolution.md
+++ b/crates/trusty-common/changelog.d/6170-symgraph-grounded-resolution.md
@@ -10,13 +10,7 @@ Fixed
   the reverse direction, a callee beside the caller now wins over a same-named
   definition that was merely registered first — `upsert` calling `write` used to
   land in whichever crate sorted earliest.
-
-Added
-
-- `SymbolGraph::resolve_symbol` returns `SymbolMatch::{Unique, Ambiguous,
-  NotFound}` for a caller-supplied name, so a consumer anchoring a trace can
-  report which definition it took and what else matched. `callers_of`,
-  `callees_of` and `context_for` anchor through the same resolution: a
-  `<path>::<symbol>` name now anchors instead of missing, and a bare name that
-  several definitions answer to picks the most-connected one rather than the
-  first registered.
+- `callers_of`, `callees_of` and `context_for` anchor through that same
+  resolution: a `<path>::<symbol>` name now anchors instead of missing, and a
+  bare name that several definitions answer to picks the most-connected one
+  rather than the first registered.

--- a/crates/trusty-common/changelog.d/6170-symgraph-resolve-symbol-added.md
+++ b/crates/trusty-common/changelog.d/6170-symgraph-resolve-symbol-added.md
@@ -1,0 +1,6 @@
+Added
+
+- `SymbolGraph::resolve_symbol` returns `SymbolMatch::{Unique, Ambiguous,
+  NotFound}` for a caller-supplied name (#6170), so a consumer anchoring a trace
+  can report which definition it took and what else matched instead of silently
+  taking whichever was registered first.

--- a/crates/trusty-common/src/symgraph/graph.rs
+++ b/crates/trusty-common/src/symgraph/graph.rs
@@ -383,7 +383,7 @@ impl SymbolGraph {
     /// What: accepts a `<file>::<symbol>` key, a `<path suffix>::<symbol>`, or a
     /// bare name; ranks multiple hits by node degree so the most-connected
     /// definition leads, and reports the alternatives.
-    /// Test: `path_qualified_name_anchors_instead_of_missing`,
+    /// Test: `path_qualified_name_anchors_on_the_file_it_names`,
     /// `ambiguous_bare_name_reports_every_candidate`.
     pub fn resolve_symbol(&self, name: &str) -> SymbolMatch<'_> {
         let hits = self.ranked_indices(name);
@@ -689,7 +689,7 @@ mod tests {
         // Why: a Rust call reached a TypeScript method of the same name in the
         // sibling defect's measurement (`chatStream.ts::get`).
         // What: the only `get` in the corpus is a `.ts` symbol. Asserts the
-        // extension mismatch drops the edge even though the name is unique.
+        // language mismatch drops the edge even though the name is unique.
         let g = SymbolGraph::build_from_registry(&registry_of(vec![
             entry("ui::chat::get", "ui/src/chatStream.ts", &[]),
             entry("a::alpha::start", "crates/a/src/lib.rs", &["get"]),
@@ -702,9 +702,12 @@ mod tests {
     }
 
     #[test]
-    fn path_qualified_name_anchors_instead_of_missing() {
+    fn path_qualified_name_anchors_on_the_file_it_names() {
         // Why: `<path>::<symbol>` is how a caller names one of several
-        // same-named definitions; it used to resolve to nothing (#6167).
+        // same-named definitions. Asserting on the well-connected twin proves
+        // nothing — degree ranking returns it for a bare `write` too. This
+        // asks for the LONE definition in stamp.rs, which only real path
+        // anchoring can reach.
         let g = SymbolGraph::build_from_registry(&registry_of(vec![
             entry("agents::stamp::write", "crates/agents/src/stamp.rs", &[]),
             entry("search::store::write", "crates/search/src/store.rs", &[]),
@@ -714,9 +717,59 @@ mod tests {
                 &["write"],
             ),
         ]));
+        match g.resolve_symbol("crates/agents/src/stamp.rs::write") {
+            SymbolMatch::Unique(n) => assert_eq!(
+                n.file.display().to_string(),
+                "crates/agents/src/stamp.rs",
+                "anchored on the wrong file",
+            ),
+            other => panic!("expected Unique on stamp.rs, got {other:?}"),
+        }
+        // stamp.rs's `write` has no callers; the store.rs one does. Reaching
+        // the wrong twin would return `upsert` here.
+        assert!(
+            g.callers_of("crates/agents/src/stamp.rs::write").is_empty(),
+            "anchored on the store.rs twin: {:?}",
+            g.callers_of("crates/agents/src/stamp.rs::write"),
+        );
+        // A partial path suffix anchors the same way.
         let callers = g.callers_of("src/store.rs::write");
         assert_eq!(callers.len(), 1, "got {callers:?}");
         assert_eq!(callers[0].name, "upsert");
+    }
+
+    #[test]
+    fn a_call_never_lands_on_a_container_in_the_callers_file() {
+        // Why: the same-file exact-key shortcut returned before the callable
+        // filter, so a `Calls` edge could land on a struct sitting in the
+        // caller's own file (#6170).
+        let mut container = entry("m::Helper", "crates/a/src/lib.rs", &[]);
+        container.kind = RKind::Struct;
+        let g = SymbolGraph::build_from_registry(&registry_of(vec![
+            container,
+            entry("m::start", "crates/a/src/lib.rs", &["m::Helper"]),
+        ]));
+        assert!(
+            g.callees_of("start").is_empty(),
+            "call resolved to a container: {:?}",
+            callee_files(&g, "start"),
+        );
+    }
+
+    #[test]
+    fn sibling_extensions_of_one_language_stay_ambiguous() {
+        // Why: `.ts` and `.tsx` are one language, and treating them as two made
+        // the `.ts` twin falsely unique — an edge where the corpus is ambiguous.
+        let g = SymbolGraph::build_from_registry(&registry_of(vec![
+            entry("lib::a::get", "ui/lib/a.ts", &[]),
+            entry("widgets::b::get", "ui/widgets/b.tsx", &[]),
+            entry("app::main::start", "ui/app/main.ts", &["get"]),
+        ]));
+        assert!(
+            g.callees_of("start").is_empty(),
+            "sibling-extension twin resolved: {:?}",
+            callee_files(&g, "start"),
+        );
     }
 
     #[test]

--- a/crates/trusty-common/src/symgraph/graph.rs
+++ b/crates/trusty-common/src/symgraph/graph.rs
@@ -12,7 +12,7 @@
 //! Test: `kg_calls_edge_between_two_functions` builds a graph from a Rust
 //! source containing one function calling another and asserts the edge.
 
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{HashSet, VecDeque};
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
@@ -23,6 +23,7 @@ use serde::{Deserialize, Serialize};
 use tree_sitter::{Node, Parser};
 
 use crate::symgraph::registry::SymbolRegistry;
+use crate::symgraph::resolve::{NameIndex, bare_name, rank_matches, resolve_callee};
 use crate::symgraph::symbol::{SymbolKind, detect_language, extract_symbols};
 
 /// Lightweight node record — one per symbol the graph knows about.
@@ -70,31 +71,63 @@ pub struct SymbolEdge {
 /// Alias kept for the public API in `lib.rs`.
 pub type Edge = SymbolEdge;
 
+/// An edge before resolution: which node made the call, and the text it called.
+///
+/// Why: the caller must be a NODE, not a name — two functions in the corpus can
+/// share a name, and attributing a call to the wrong one is the defect #6170
+/// tracks. The callee stays text until [`SymbolGraph::add_edge_resolved`] finds
+/// grounds for a target.
+struct RawEdge {
+    caller: NodeIndex,
+    callee: String,
+    kind: EdgeKind,
+}
+
+/// What a caller-supplied symbol name resolved to.
+///
+/// Why: several definitions can answer to one name. A consumer that anchors a
+/// trace on a name needs to know it did, and to which alternatives — the map
+/// this replaces answered with whichever definition was registered first and
+/// said nothing (#6170, ports #6169).
+/// What: `Unique` when one definition matched, `Ambiguous` when several did —
+/// `chosen` is the most-connected one and `alternatives` holds the rest, best
+/// first — and `NotFound` when the graph knows no such name.
+/// Test: `ambiguous_bare_name_reports_every_candidate`.
+#[derive(Debug)]
+pub enum SymbolMatch<'a> {
+    NotFound,
+    Unique(&'a SymbolNode),
+    Ambiguous {
+        chosen: &'a SymbolNode,
+        alternatives: Vec<&'a SymbolNode>,
+    },
+}
+
 /// A symbol-level graph rooted at one or more files.
 ///
 /// Why: Replaces ad-hoc `grep`-style call-site searches with a structured
 /// query layer over a real graph backend (petgraph::StableGraph).
 /// What: Holds a `StableGraph<SymbolNode, EdgeKind>` as the source of
-/// truth plus a name → `NodeIndex` lookup map. Serde derives serialise the
-/// underlying `StableGraph` natively (petgraph "serde-1" feature). The
-/// name-index map is rebuilt after deserialisation via `rebuild_name_index`.
+/// truth plus a `<file>::<symbol>`-keyed name index. Serde derives serialise
+/// the underlying `StableGraph` natively (petgraph "serde-1" feature). The
+/// name index is rebuilt after deserialisation via `rebuild_name_index`.
 /// Test: `kg_calls_edge_between_two_functions`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SymbolGraph {
     /// Internal petgraph storage.
     #[serde(rename = "graph")]
     inner: StableGraph<SymbolNode, EdgeKind>,
-    /// First-occurrence lookup of node-name → NodeIndex. Skipped during
+    /// Qualified-identity lookup backing every name query. Skipped during
     /// serde and rebuilt on deserialisation by `rebuild_name_index`.
     #[serde(skip, default)]
-    name_to_idx: HashMap<String, NodeIndex>,
+    names: NameIndex,
 }
 
 impl Default for SymbolGraph {
     fn default() -> Self {
         Self {
             inner: StableGraph::new(),
-            name_to_idx: HashMap::new(),
+            names: NameIndex::default(),
         }
     }
 }
@@ -147,30 +180,60 @@ impl SymbolGraph {
             .collect()
     }
 
-    /// Insert a node, returning its `NodeIndex`. Updates the name lookup
-    /// only on first occurrence so multiple nodes sharing a name keep the
-    /// earliest index reachable (preserves prior `find by name` behaviour).
+    /// Insert a node under its own name, returning its `NodeIndex`.
     fn add_node(&mut self, node: SymbolNode) -> NodeIndex {
         let name = node.name.clone();
+        self.add_node_as(node, &name)
+    }
+
+    /// Insert a node, indexing it under `symbol` as well as its own name.
+    ///
+    /// Why: a registry entry's id (`api::handlers::write`) is what a dependency
+    /// cites, while the node keeps the bare name a consumer displays. Both have
+    /// to reach the same node (#6170).
+    /// What: adds the node, then records `<file>::<symbol>` plus the trailing
+    /// identifier in the name index. Every definition gets its own node and its
+    /// own index entry — nothing is collapsed onto a first occurrence.
+    /// Test: `same_file_callee_wins_over_an_earlier_registered_twin`.
+    fn add_node_as(&mut self, node: SymbolNode, symbol: &str) -> NodeIndex {
+        let file = node.file.display().to_string();
+        let callable = matches!(node.kind, SymbolKind::Function | SymbolKind::Method);
         let idx = self.inner.add_node(node);
-        self.name_to_idx.entry(name).or_insert(idx);
+        self.names.insert(&file, symbol, idx, callable);
         idx
     }
 
-    /// Add an edge between two named symbols. No-op if either endpoint is
-    /// unknown.
-    fn add_edge_by_name(&mut self, from: &str, to: &str, kind: EdgeKind) {
-        if let (Some(&a), Some(&b)) = (self.name_to_idx.get(from), self.name_to_idx.get(to)) {
-            self.inner.add_edge(a, b, kind);
+    /// Add an edge from `caller` to whatever `callee` resolves to, if anything.
+    ///
+    /// Why: resolving a callee against one global bare-name map bound calls to
+    /// unrelated crates (#6170). An edge now requires grounds.
+    /// What: delegates to `resolve::resolve_callee` from the caller's own file;
+    /// `Calls` edges additionally require a callable target. No grounds, no
+    /// edge — silence is the correct answer to an ambiguous name.
+    /// Test: `bare_name_collision_across_crates_creates_no_edge`.
+    fn add_edge_resolved(&mut self, caller: NodeIndex, callee: &str, kind: EdgeKind) {
+        let caller_file = self.inner[caller].file.display().to_string();
+        let require_callable = kind == EdgeKind::Calls;
+        if let Some((target, _grounds)) =
+            resolve_callee(&self.names, &caller_file, callee, require_callable)
+        {
+            self.inner.add_edge(caller, target, kind);
         }
     }
 
-    /// Repopulate `name_to_idx` from `inner` — used after deserialisation.
+    /// Repopulate the name index from `inner` — used after deserialisation.
+    ///
+    /// A graph that round-tripped through serde carries node names only, so the
+    /// registry ids `build_from_registry` indexed are not restored; name lookup
+    /// falls back to the trailing identifier for those.
     pub fn rebuild_name_index(&mut self) {
-        self.name_to_idx.clear();
+        self.names = NameIndex::default();
         for idx in self.inner.node_indices() {
-            let name = self.inner[idx].name.clone();
-            self.name_to_idx.entry(name).or_insert(idx);
+            let node = &self.inner[idx];
+            let file = node.file.display().to_string();
+            let name = node.name.clone();
+            let callable = matches!(node.kind, SymbolKind::Function | SymbolKind::Method);
+            self.names.insert(&file, &name, idx, callable);
         }
     }
 
@@ -195,31 +258,37 @@ impl SymbolGraph {
         sorted.sort_by_key(|a| a.start_line);
 
         let mut graph = SymbolGraph::default();
-        for s in &sorted {
-            graph.add_node(SymbolNode {
-                file: s.file.clone(),
-                name: s.name.clone(),
-                kind: s.kind,
-                start_line: s.start_line,
-            });
-        }
+        // #6170: keep each symbol's own node index — two symbols in one file can
+        // share a name, and a call must be attributed to the one that made it.
+        let placed: Vec<(&&crate::symgraph::symbol::Symbol, NodeIndex)> = sorted
+            .iter()
+            .map(|s| {
+                let idx = graph.add_node(SymbolNode {
+                    file: s.file.clone(),
+                    name: s.name.clone(),
+                    kind: s.kind,
+                    start_line: s.start_line,
+                });
+                (s, idx)
+            })
+            .collect();
 
-        // Collect raw edges first (by name), then resolve into petgraph.
-        let mut raw_edges: Vec<SymbolEdge> = Vec::new();
+        // Collect raw edges first, then resolve into petgraph.
+        let mut raw_edges: Vec<RawEdge> = Vec::new();
 
         let mut parser = Parser::new();
         if parser.set_language(&lang).is_ok()
             && let Some(tree) = parser.parse(&source, None)
         {
             let bytes = source.as_bytes();
-            for sym in &symbols {
+            for (sym, caller) in &placed {
                 if !matches!(sym.kind, SymbolKind::Function | SymbolKind::Method) {
                     continue;
                 }
                 if let Some(node) =
                     node_for_byte_range(tree.root_node(), sym.start_byte, sym.end_byte)
                 {
-                    collect_calls(node, bytes, lang_tag, &sym.name, &mut raw_edges);
+                    collect_calls(node, bytes, lang_tag, *caller, &mut raw_edges);
                 }
             }
 
@@ -230,26 +299,29 @@ impl SymbolGraph {
                 .and_then(|s| s.to_str())
                 .unwrap_or("")
                 .to_string();
-            let mut had_imports = false;
+            // Reuse a real symbol of that name if the file has one, as before.
+            let mut stem_idx: Option<NodeIndex> = placed
+                .iter()
+                .find(|(s, _)| s.name == file_stem)
+                .map(|(_, i)| *i);
             for sym in &symbols {
-                if matches!(sym.kind, SymbolKind::Import) {
-                    if !had_imports
-                        && !file_stem.is_empty()
-                        && !graph.name_to_idx.contains_key(&file_stem)
-                    {
-                        // Add a synthetic node for the file stem so import
-                        // edges have a resolvable source endpoint.
-                        graph.add_node(SymbolNode {
-                            file: file.to_path_buf(),
-                            name: file_stem.clone(),
-                            kind: SymbolKind::Unknown,
-                            start_line: 0,
-                        });
-                    }
-                    had_imports = true;
-                    raw_edges.push(SymbolEdge {
-                        from: file_stem.clone(),
-                        to: sym.name.clone(),
+                if !matches!(sym.kind, SymbolKind::Import) {
+                    continue;
+                }
+                if stem_idx.is_none() && !file_stem.is_empty() {
+                    // Add a synthetic node for the file stem so import
+                    // edges have a resolvable source endpoint.
+                    stem_idx = Some(graph.add_node(SymbolNode {
+                        file: file.to_path_buf(),
+                        name: file_stem.clone(),
+                        kind: SymbolKind::Unknown,
+                        start_line: 0,
+                    }));
+                }
+                if let Some(caller) = stem_idx {
+                    raw_edges.push(RawEdge {
+                        caller,
+                        callee: sym.name.clone(),
                         kind: EdgeKind::Imports,
                     });
                 }
@@ -257,7 +329,7 @@ impl SymbolGraph {
         }
 
         for e in raw_edges {
-            graph.add_edge_by_name(&e.from, &e.to, e.kind);
+            graph.add_edge_resolved(e.caller, &e.callee, e.kind);
         }
 
         Ok(graph)
@@ -270,54 +342,72 @@ impl SymbolGraph {
     /// queries against the substrate) need a `SymbolGraph` derived from
     /// that registry without re-walking source.
     /// What: Iterates `registry.iter()`, projects each `SymbolEntry` into
-    /// a `SymbolNode`, then walks `dependencies` to emit `Calls` edges
-    /// where the target resolves to another known symbol's bare name.
-    /// Test: `build_from_registry_smoke`.
+    /// a `SymbolNode` indexed under BOTH its registry id and its bare name,
+    /// then walks `dependencies` to emit a `Calls` edge wherever the callee
+    /// resolves with grounds from the caller's own file (#6170).
+    /// Test: `build_from_registry_smoke`,
+    /// `bare_name_collision_across_crates_creates_no_edge`.
     pub fn build_from_registry(registry: &SymbolRegistry) -> Self {
         let mut graph = SymbolGraph::default();
+        let entries: Vec<_> = registry.iter().collect();
 
-        for (id, entry) in registry.iter() {
-            let bare = id
-                .as_str()
-                .rsplit("::")
-                .next()
-                .unwrap_or(id.as_str())
-                .to_string();
-            let kind = registry_kind_to_symbol_kind(&entry.kind);
-            graph.add_node(SymbolNode {
-                file: entry
-                    .assigned_file
-                    .clone()
-                    .unwrap_or_else(|| PathBuf::from("")),
-                name: bare,
-                kind,
-                start_line: 0,
-            });
-        }
+        let placed: Vec<NodeIndex> = entries
+            .iter()
+            .map(|(id, entry)| {
+                let node = SymbolNode {
+                    file: entry
+                        .assigned_file
+                        .clone()
+                        .unwrap_or_else(|| PathBuf::from("")),
+                    name: bare_name(id.as_str()).to_string(),
+                    kind: registry_kind_to_symbol_kind(&entry.kind),
+                    start_line: 0,
+                };
+                graph.add_node_as(node, id.as_str())
+            })
+            .collect();
 
-        for (id, entry) in registry.iter() {
-            let from = id
-                .as_str()
-                .rsplit("::")
-                .next()
-                .unwrap_or(id.as_str())
-                .to_string();
+        for ((_, entry), &caller) in entries.iter().zip(placed.iter()) {
             for dep in &entry.dependencies {
-                let dep_bare = dep
-                    .as_str()
-                    .rsplit("::")
-                    .next()
-                    .unwrap_or(dep.as_str())
-                    .to_string();
-                graph.add_edge_by_name(&from, &dep_bare, EdgeKind::Calls);
+                graph.add_edge_resolved(caller, dep.as_str(), EdgeKind::Calls);
             }
         }
         graph
     }
 
-    /// Resolve a name to its first-occurrence `NodeIndex`.
+    /// Resolve a name to the definition it most likely means, naming the rest.
+    ///
+    /// Why: `trace_execution_flow` anchors on a name a user typed. When several
+    /// definitions answer to it, silently taking the first-registered one is
+    /// how a trace lands in the wrong crate (#6170).
+    /// What: accepts a `<file>::<symbol>` key, a `<path suffix>::<symbol>`, or a
+    /// bare name; ranks multiple hits by node degree so the most-connected
+    /// definition leads, and reports the alternatives.
+    /// Test: `path_qualified_name_anchors_instead_of_missing`,
+    /// `ambiguous_bare_name_reports_every_candidate`.
+    pub fn resolve_symbol(&self, name: &str) -> SymbolMatch<'_> {
+        let hits = self.ranked_indices(name);
+        match hits.len() {
+            0 => SymbolMatch::NotFound,
+            1 => SymbolMatch::Unique(&self.inner[hits[0]]),
+            _ => SymbolMatch::Ambiguous {
+                chosen: &self.inner[hits[0]],
+                alternatives: hits[1..].iter().map(|&i| &self.inner[i]).collect(),
+            },
+        }
+    }
+
+    /// Every definition `name` can mean, most-connected first.
+    fn ranked_indices(&self, name: &str) -> Vec<NodeIndex> {
+        rank_matches(&self.names, name, |i| {
+            self.inner.edges_directed(i, Direction::Outgoing).count()
+                + self.inner.edges_directed(i, Direction::Incoming).count()
+        })
+    }
+
+    /// Resolve a name to the best-ranked `NodeIndex`.
     fn idx_of(&self, name: &str) -> Option<NodeIndex> {
-        self.name_to_idx.get(name).copied()
+        self.ranked_indices(name).first().copied()
     }
 
     /// Symbols that call `name`.
@@ -451,7 +541,7 @@ fn node_for_byte_range<'a>(root: Node<'a>, start: usize, end: usize) -> Option<N
 }
 
 /// Walk a function body, find call expressions, attribute them to `caller`.
-fn collect_calls(node: Node, bytes: &[u8], lang: &str, caller: &str, out: &mut Vec<SymbolEdge>) {
+fn collect_calls(node: Node, bytes: &[u8], lang: &str, caller: NodeIndex, out: &mut Vec<RawEdge>) {
     let kind = node.kind();
     let is_call = match lang {
         "rust" | "javascript" | "go" => kind == "call_expression",
@@ -459,9 +549,9 @@ fn collect_calls(node: Node, bytes: &[u8], lang: &str, caller: &str, out: &mut V
         _ => false,
     };
     if is_call && let Some(callee) = call_target_name(node, bytes, lang) {
-        out.push(SymbolEdge {
-            from: caller.to_string(),
-            to: callee,
+        out.push(RawEdge {
+            caller,
+            callee,
             kind: EdgeKind::Calls,
         });
     }
@@ -490,8 +580,177 @@ fn call_target_name(node: Node, bytes: &[u8], lang: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::symgraph::registry::{SymbolEntry, SymbolId, SymbolKind as RKind, SymbolRegistry};
     use std::io::Write;
     use tempfile::NamedTempFile;
+
+    /// One registry entry: id, the file it lives in, and the names it calls.
+    fn entry(id: &str, file: &str, deps: &[&str]) -> SymbolEntry {
+        let mut e = SymbolEntry::new(
+            SymbolId(id.to_string()),
+            RKind::Function,
+            format!("fn {}() {{}}", bare_name(id)),
+            "rust",
+        );
+        e.assigned_file = Some(PathBuf::from(file));
+        e.dependencies = deps.iter().map(|d| SymbolId((*d).to_string())).collect();
+        e
+    }
+
+    fn registry_of(entries: Vec<SymbolEntry>) -> SymbolRegistry {
+        let mut reg = SymbolRegistry::new(PathBuf::from("/proj"));
+        for e in entries {
+            reg.insert(e);
+        }
+        reg
+    }
+
+    fn callee_files(g: &SymbolGraph, caller: &str) -> Vec<String> {
+        g.callees_of(caller)
+            .iter()
+            .map(|n| n.file.display().to_string())
+            .collect()
+    }
+
+    #[test]
+    fn same_file_callee_wins_over_an_earlier_registered_twin() {
+        // Why: `upsert` calls the `write` beside it. The registry is iterated in
+        // sorted-id order, so another crate's `write` is registered first; the
+        // old global first-write-wins map handed that one back (#6170).
+        // What: two `write` definitions, one in the caller's file. Asserts the
+        // edge lands on the caller's own file.
+        let g = SymbolGraph::build_from_registry(&registry_of(vec![
+            entry("agents::stamp::write", "crates/agents/src/stamp.rs", &[]),
+            entry("search::store::write", "crates/search/src/store.rs", &[]),
+            entry(
+                "search::store::upsert",
+                "crates/search/src/store.rs",
+                &["write"],
+            ),
+        ]));
+        assert_eq!(
+            callee_files(&g, "upsert"),
+            vec!["crates/search/src/store.rs".to_string()],
+        );
+    }
+
+    #[test]
+    fn bare_name_collision_across_crates_creates_no_edge() {
+        // Why: a name that two unrelated crates define is not grounds for an
+        // edge to either — that is how 74% of callee edges went cross-crate in
+        // the sibling defect (#6167).
+        // What: `start` calls `run`; two crates define `run`, neither in the
+        // caller's tree. Asserts no callee edge at all.
+        let g = SymbolGraph::build_from_registry(&registry_of(vec![
+            entry("a::alpha::run", "crates/a/src/lib.rs", &[]),
+            entry("b::beta::run", "crates/b/src/lib.rs", &[]),
+            entry("c::gamma::start", "crates/c/src/lib.rs", &["run"]),
+        ]));
+        assert!(
+            g.callees_of("start").is_empty(),
+            "ambiguous callee resolved anyway: {:?}",
+            callee_files(&g, "start"),
+        );
+    }
+
+    #[test]
+    fn directory_scope_beats_a_distant_twin() {
+        // Why: the caller's own directory is grounds even when the name is not
+        // corpus-unique; only a tie inside the narrowest matching scope is not.
+        // What: two `helper` definitions, one in the caller's directory. The
+        // distant one sorts first, so the pre-#6170 map returned it.
+        let g = SymbolGraph::build_from_registry(&registry_of(vec![
+            entry("far::helper", "crates/far/src/util.rs", &[]),
+            entry("near::helper", "crates/near/src/util.rs", &[]),
+            entry("near::start", "crates/near/src/lib.rs", &["helper"]),
+        ]));
+        assert_eq!(
+            callee_files(&g, "start"),
+            vec!["crates/near/src/util.rs".to_string()],
+        );
+    }
+
+    #[test]
+    fn corpus_unique_name_still_resolves_across_files() {
+        // Why: grounding must not silence real cross-file edges — a name only
+        // one definition answers to is grounds in itself.
+        let g = SymbolGraph::build_from_registry(&registry_of(vec![
+            entry("a::alpha::only_one", "crates/a/src/lib.rs", &[]),
+            entry("c::gamma::start", "crates/c/src/lib.rs", &["only_one"]),
+        ]));
+        assert_eq!(
+            callee_files(&g, "start"),
+            vec!["crates/a/src/lib.rs".to_string()],
+        );
+    }
+
+    #[test]
+    fn cross_language_twin_is_not_an_edge() {
+        // Why: a Rust call reached a TypeScript method of the same name in the
+        // sibling defect's measurement (`chatStream.ts::get`).
+        // What: the only `get` in the corpus is a `.ts` symbol. Asserts the
+        // extension mismatch drops the edge even though the name is unique.
+        let g = SymbolGraph::build_from_registry(&registry_of(vec![
+            entry("ui::chat::get", "ui/src/chatStream.ts", &[]),
+            entry("a::alpha::start", "crates/a/src/lib.rs", &["get"]),
+        ]));
+        assert!(
+            g.callees_of("start").is_empty(),
+            "cross-language callee resolved: {:?}",
+            callee_files(&g, "start"),
+        );
+    }
+
+    #[test]
+    fn path_qualified_name_anchors_instead_of_missing() {
+        // Why: `<path>::<symbol>` is how a caller names one of several
+        // same-named definitions; it used to resolve to nothing (#6167).
+        let g = SymbolGraph::build_from_registry(&registry_of(vec![
+            entry("agents::stamp::write", "crates/agents/src/stamp.rs", &[]),
+            entry("search::store::write", "crates/search/src/store.rs", &[]),
+            entry(
+                "search::store::upsert",
+                "crates/search/src/store.rs",
+                &["write"],
+            ),
+        ]));
+        let callers = g.callers_of("src/store.rs::write");
+        assert_eq!(callers.len(), 1, "got {callers:?}");
+        assert_eq!(callers[0].name, "upsert");
+    }
+
+    #[test]
+    fn ambiguous_bare_name_reports_every_candidate() {
+        // Why: anchoring on a name that several definitions answer to must say
+        // so rather than pick silently (#6170).
+        let g = SymbolGraph::build_from_registry(&registry_of(vec![
+            entry("agents::stamp::write", "crates/agents/src/stamp.rs", &[]),
+            entry("search::store::write", "crates/search/src/store.rs", &[]),
+            entry(
+                "search::store::upsert",
+                "crates/search/src/store.rs",
+                &["write"],
+            ),
+        ]));
+        match g.resolve_symbol("write") {
+            SymbolMatch::Ambiguous {
+                chosen,
+                alternatives,
+            } => {
+                // The called definition is the most-connected one.
+                assert_eq!(
+                    chosen.file.display().to_string(),
+                    "crates/search/src/store.rs"
+                );
+                assert_eq!(alternatives.len(), 1);
+            }
+            other => panic!("expected Ambiguous, got {other:?}"),
+        }
+        assert!(matches!(
+            g.resolve_symbol("no_such_symbol"),
+            SymbolMatch::NotFound
+        ));
+    }
 
     #[test]
     fn build_from_registry_smoke() {
@@ -501,9 +760,6 @@ mod tests {
         // `callee` in its dependencies. Asserts both nodes appear and the
         // `caller -> callee` Calls edge is present.
         // Test: this test.
-        use crate::symgraph::registry::{
-            SymbolEntry, SymbolId, SymbolKind as RKind, SymbolRegistry,
-        };
         use std::collections::BTreeSet;
 
         let tmp = tempfile::TempDir::new().unwrap();

--- a/crates/trusty-common/src/symgraph/mod.rs
+++ b/crates/trusty-common/src/symgraph/mod.rs
@@ -37,6 +37,9 @@ pub mod graph;
 pub mod parser;
 #[cfg(feature = "symgraph-parser")]
 pub mod registry;
+// #6170: grounded callee/name resolution behind `graph` — crate-internal.
+#[cfg(feature = "symgraph-parser")]
+pub(crate) mod resolve;
 #[cfg(feature = "symgraph-parser")]
 pub mod symbol;
 

--- a/crates/trusty-common/src/symgraph/mod.rs
+++ b/crates/trusty-common/src/symgraph/mod.rs
@@ -79,7 +79,7 @@ pub use editor::{
 #[cfg(feature = "symgraph-parser")]
 pub use emitter::{LayoutRules, apply_emit, assign_file, emit};
 #[cfg(feature = "symgraph-parser")]
-pub use graph::{Edge, EdgeKind, SymbolEdge, SymbolGraph, SymbolNode};
+pub use graph::{Edge, EdgeKind, SymbolEdge, SymbolGraph, SymbolMatch, SymbolNode};
 #[cfg(feature = "symgraph-parser")]
 pub use parser::{Language, file_to_module_path, parse_directory, parse_file};
 #[cfg(feature = "symgraph-parser")]

--- a/crates/trusty-common/src/symgraph/resolve.rs
+++ b/crates/trusty-common/src/symgraph/resolve.rs
@@ -1,0 +1,246 @@
+//! Grounded name resolution for `SymbolGraph` (#6170; ports #6169's semantics).
+//!
+//! Why: `SymbolGraph` kept one global bare-name → node map, first write wins, so
+//! a call to `write` became an edge to whichever `write` the registry happened
+//! to insert first — a different file, and often a different crate. That is the
+//! defect PR #6169 fixed in trusty-search's parallel `SymbolGraph`; this module
+//! is the same contract for trusty-common's.
+//! What: every definition is keyed `<file>::<symbol>`, and a callee becomes an
+//! edge only when one scope around the CALLER yields exactly one candidate —
+//! the caller's own file first, then each ancestor directory, then the whole
+//! corpus. Ambiguity at the narrowest scope that matched resolves to nothing
+//! rather than to a guess.
+//! Test: `same_file_callee_wins_over_an_earlier_registered_twin`,
+//! `bare_name_collision_across_crates_creates_no_edge`,
+//! `corpus_unique_name_still_resolves_across_files`.
+
+use std::collections::HashMap;
+
+use petgraph::stable_graph::NodeIndex;
+
+/// Qualified node identity: `<file>::<symbol>`.
+pub(crate) fn qualified_key(file: &str, symbol: &str) -> String {
+    format!("{file}::{symbol}")
+}
+
+/// Trailing identifier of a possibly-qualified symbol (`api::Foo::bar` → `bar`).
+pub(crate) fn bare_name(symbol: &str) -> &str {
+    symbol.rsplit("::").next().unwrap_or(symbol)
+}
+
+/// File extension, used to keep a Rust call from binding to a TypeScript method.
+fn extension(file: &str) -> &str {
+    let base = file.rsplit('/').next().unwrap_or(file);
+    base.rsplit_once('.').map(|(_, ext)| ext).unwrap_or("")
+}
+
+/// Scopes to try around `file`, narrowest first: the file itself, each ancestor
+/// directory, then `""` — the whole corpus.
+///
+/// Why: #6169 widens file → directory → package → corpus. "Package" there is a
+/// two-segment path guess, which is wrong for the absolute paths this crate's
+/// registry carries. Walking every ancestor is the same ladder without the
+/// guess: it stops at the nearest scope holding any candidate, so a directory
+/// hit still beats a crate-wide one.
+/// What: returns `[file, parent, grandparent, …, ""]`, or just `[""]` when the
+/// caller's file is unknown — an unknown file grounds nothing but uniqueness.
+/// Test: `directory_scope_beats_a_distant_twin`.
+fn scopes(file: &str) -> Vec<&str> {
+    if file.is_empty() {
+        return vec![""];
+    }
+    let mut out = vec![file];
+    let mut cur = file;
+    while let Some((parent, _)) = cur.rsplit_once('/') {
+        if parent.is_empty() {
+            break;
+        }
+        out.push(parent);
+        cur = parent;
+    }
+    out.push("");
+    out
+}
+
+/// Is `candidate` inside `scope`? `""` is the whole corpus.
+fn in_scope(candidate: &str, scope: &str) -> bool {
+    if scope.is_empty() {
+        return true;
+    }
+    candidate == scope
+        || (candidate.starts_with(scope) && candidate[scope.len()..].starts_with('/'))
+}
+
+/// Everything the resolver needs about one candidate definition.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Candidate {
+    pub idx: NodeIndex,
+    /// `false` for containers (struct, trait, import) — not call targets.
+    pub callable: bool,
+}
+
+/// How much evidence a resolution rests on, widest scope last.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Grounds {
+    /// The callee is defined in the caller's own file.
+    SameFile,
+    /// Exactly one definition inside an ancestor directory of the caller.
+    SharedScope,
+    /// Exactly one definition anywhere in the graph.
+    CorpusUnique,
+}
+
+/// Per-graph lookup tables backing [`resolve_callee`] and [`rank_matches`].
+#[derive(Debug, Default, Clone)]
+pub(crate) struct NameIndex {
+    /// `<file>::<symbol>` → node. One entry per definition.
+    pub by_key: HashMap<String, NodeIndex>,
+    /// Full symbol AND trailing identifier → every definition under that name.
+    pub by_name: HashMap<String, Vec<Candidate>>,
+    /// Node → the file that defines it, for scope comparisons.
+    pub file_of: HashMap<NodeIndex, String>,
+}
+
+impl NameIndex {
+    /// Record one definition under every name it can be reached by.
+    pub fn insert(&mut self, file: &str, symbol: &str, idx: NodeIndex, callable: bool) {
+        self.by_key.insert(qualified_key(file, symbol), idx);
+        self.file_of.insert(idx, file.to_string());
+
+        let cand = Candidate { idx, callable };
+        self.by_name
+            .entry(symbol.to_string())
+            .or_default()
+            .push(cand);
+        let bare = bare_name(symbol);
+        if bare != symbol {
+            self.by_name.entry(bare.to_string()).or_default().push(cand);
+        }
+    }
+
+    /// Every definition reachable by `name`, in registration order.
+    pub fn candidates(&self, name: &str) -> &[Candidate] {
+        self.by_name.get(name).map_or(&[], |v| v.as_slice())
+    }
+
+    fn file_of(&self, idx: NodeIndex) -> &str {
+        self.file_of.get(&idx).map_or("", |f| f.as_str())
+    }
+}
+
+/// Resolve a callee name to a node, or to nothing when no scope gives grounds.
+///
+/// Why: the map this replaces answered every `write` with the same node, so
+/// `trace_execution_flow` reported callees in crates the caller cannot even see
+/// (#6170). An edge now means the resolver had grounds for it.
+/// What: exact `<caller file>::<callee>` first, then the narrowest scope around
+/// the caller that holds any candidate at all — accepting it only when it holds
+/// exactly ONE. Widening from an ambiguous scope can only add candidates, so an
+/// ambiguous scope ends the search. Cross-file resolution additionally requires
+/// a matching file extension, and `require_callable` drops containers for
+/// `Calls` edges.
+/// Test: `bare_name_collision_across_crates_creates_no_edge`,
+/// `cross_language_twin_is_not_an_edge`.
+pub(crate) fn resolve_callee(
+    index: &NameIndex,
+    caller_file: &str,
+    callee: &str,
+    require_callable: bool,
+) -> Option<(NodeIndex, Grounds)> {
+    if let Some(&idx) = index.by_key.get(&qualified_key(caller_file, callee)) {
+        return Some((idx, Grounds::SameFile));
+    }
+
+    // A dependency is raw call text (`Foo::bar`), a definition is registered
+    // under its full id and its trailing identifier; try the written form
+    // before falling back to the identifier.
+    let mut named = index.candidates(callee);
+    if named.is_empty() {
+        named = index.candidates(bare_name(callee));
+    }
+    let caller_ext = extension(caller_file);
+    let cands: Vec<&Candidate> = named
+        .iter()
+        .filter(|c| !require_callable || c.callable)
+        .filter(|c| caller_ext.is_empty() || extension(index.file_of(c.idx)) == caller_ext)
+        .collect();
+    if cands.is_empty() {
+        return None;
+    }
+
+    for scope in scopes(caller_file) {
+        let mut hit = None;
+        let mut n = 0usize;
+        for c in &cands {
+            if in_scope(index.file_of(c.idx), scope) {
+                n += 1;
+                hit = Some(c.idx);
+            }
+        }
+        if n > 1 {
+            return None;
+        }
+        if n == 1 {
+            let idx = hit?;
+            let grounds = if index.file_of(idx) == caller_file && !caller_file.is_empty() {
+                Grounds::SameFile
+            } else if scope.is_empty() {
+                Grounds::CorpusUnique
+            } else {
+                Grounds::SharedScope
+            };
+            return Some((idx, grounds));
+        }
+    }
+    None
+}
+
+/// Rank every definition a caller-supplied name can mean, best first.
+///
+/// Why: a bare name that several definitions answer to must not silently anchor
+/// to whichever was registered first — the caller has to be able to say which
+/// one it took and what else matched (#6170).
+/// What: the qualified key first, then `<path>::<symbol>` where the path is a
+/// suffix of a real file path, then the name index (falling back to the
+/// trailing identifier). Multi-hit results are ordered by `rank` — the graph
+/// passes node degree, so the most-connected definition leads.
+/// Test: `path_qualified_name_anchors_instead_of_missing`,
+/// `ambiguous_bare_name_reports_every_candidate`.
+pub(crate) fn rank_matches(
+    index: &NameIndex,
+    name: &str,
+    rank: impl Fn(NodeIndex) -> usize,
+) -> Vec<NodeIndex> {
+    if let Some(&idx) = index.by_key.get(name) {
+        return vec![idx];
+    }
+
+    let mut hits: Vec<NodeIndex> = Vec::new();
+    if let Some((path, symbol)) = name.rsplit_once("::")
+        && (path.contains('/') || path.contains('.'))
+    {
+        hits = index
+            .by_key
+            .iter()
+            .filter(|(k, _)| {
+                k.rsplit_once("::").is_some_and(|(f, s)| {
+                    (s == symbol || bare_name(s) == symbol) && f.ends_with(path)
+                })
+            })
+            .map(|(_, &i)| i)
+            .collect();
+    }
+    if hits.is_empty() {
+        hits = index.candidates(name).iter().map(|c| c.idx).collect();
+    }
+    if hits.is_empty() {
+        hits = index
+            .candidates(bare_name(name))
+            .iter()
+            .map(|c| c.idx)
+            .collect();
+    }
+    hits.sort_by_key(|&i| (std::cmp::Reverse(rank(i)), i.index()));
+    hits.dedup();
+    hits
+}

--- a/crates/trusty-common/src/symgraph/resolve.rs
+++ b/crates/trusty-common/src/symgraph/resolve.rs
@@ -15,8 +15,11 @@
 //! `corpus_unique_name_still_resolves_across_files`.
 
 use std::collections::HashMap;
+use std::path::Path;
 
 use petgraph::stable_graph::NodeIndex;
+
+use crate::symgraph::symbol::detect_language;
 
 /// Qualified node identity: `<file>::<symbol>`.
 pub(crate) fn qualified_key(file: &str, symbol: &str) -> String {
@@ -28,10 +31,32 @@ pub(crate) fn bare_name(symbol: &str) -> &str {
     symbol.rsplit("::").next().unwrap_or(symbol)
 }
 
-/// File extension, used to keep a Rust call from binding to a TypeScript method.
+/// File extension, the fallback identity for a file no grammar recognises.
 fn extension(file: &str) -> &str {
     let base = file.rsplit('/').next().unwrap_or(file);
     base.rsplit_once('.').map(|(_, ext)| ext).unwrap_or("")
+}
+
+/// Language family of `file` — `.ts` and `.tsx` are both `typescript`.
+///
+/// Why: keeping a Rust call from binding to a TypeScript method needs a
+/// language comparison, and comparing raw extensions is not one: `.ts` and
+/// `.tsx` twins looked like different languages, so the filter dropped one and
+/// left the other falsely unique. A heuristic that narrows must never narrow to
+/// exactly one.
+/// What: `symgraph::symbol::detect_language`'s tag — the same extension table
+/// the parser uses — falling back to the raw extension when no grammar claims
+/// the file.
+/// Test: `sibling_extensions_of_one_language_stay_ambiguous`.
+fn language_of(file: &str) -> &str {
+    detect_language(Path::new(file))
+        .map(|(_, tag)| tag)
+        .unwrap_or_else(|| extension(file))
+}
+
+/// Does `file` end with `path` at a path-segment boundary?
+fn path_suffix_matches(file: &str, path: &str) -> bool {
+    file == path || (file.ends_with(path) && file[..file.len() - path.len()].ends_with('/'))
 }
 
 /// Scopes to try around `file`, narrowest first: the file itself, each ancestor
@@ -93,8 +118,11 @@ pub(crate) enum Grounds {
 /// Per-graph lookup tables backing [`resolve_callee`] and [`rank_matches`].
 #[derive(Debug, Default, Clone)]
 pub(crate) struct NameIndex {
-    /// `<file>::<symbol>` → node. One entry per definition.
-    pub by_key: HashMap<String, NodeIndex>,
+    /// `<file>::<symbol>` → the definition, or `None` when two symbols in one
+    /// file share that exact key (a `fn write` beside an import named `write`)
+    /// — ambiguous, so the exact-key shortcut declines rather than picking the
+    /// last one inserted.
+    pub by_key: HashMap<String, Option<Candidate>>,
     /// Full symbol AND trailing identifier → every definition under that name.
     pub by_name: HashMap<String, Vec<Candidate>>,
     /// Node → the file that defines it, for scope comparisons.
@@ -104,10 +132,19 @@ pub(crate) struct NameIndex {
 impl NameIndex {
     /// Record one definition under every name it can be reached by.
     pub fn insert(&mut self, file: &str, symbol: &str, idx: NodeIndex, callable: bool) {
-        self.by_key.insert(qualified_key(file, symbol), idx);
         self.file_of.insert(idx, file.to_string());
 
         let cand = Candidate { idx, callable };
+        // #6170: a second symbol under the same exact key poisons the entry —
+        // last write wins is how a call landed on an import.
+        self.by_key
+            .entry(qualified_key(file, symbol))
+            .and_modify(|slot| {
+                if slot.map(|c| c.idx) != Some(idx) {
+                    *slot = None;
+                }
+            })
+            .or_insert(Some(cand));
         self.by_name
             .entry(symbol.to_string())
             .or_default()
@@ -133,22 +170,28 @@ impl NameIndex {
 /// Why: the map this replaces answered every `write` with the same node, so
 /// `trace_execution_flow` reported callees in crates the caller cannot even see
 /// (#6170). An edge now means the resolver had grounds for it.
-/// What: exact `<caller file>::<callee>` first, then the narrowest scope around
-/// the caller that holds any candidate at all — accepting it only when it holds
-/// exactly ONE. Widening from an ambiguous scope can only add candidates, so an
-/// ambiguous scope ends the search. Cross-file resolution additionally requires
-/// a matching file extension, and `require_callable` drops containers for
-/// `Calls` edges.
+/// What: an unambiguous, callable exact `<caller file>::<callee>` first, then
+/// the narrowest scope around the caller that holds any candidate at all —
+/// accepting it only when it holds exactly ONE. Widening from an ambiguous
+/// scope can only add candidates, so an ambiguous scope ends the search.
+/// Cross-file resolution additionally requires the same language family, and
+/// `require_callable` drops containers for `Calls` edges.
 /// Test: `bare_name_collision_across_crates_creates_no_edge`,
-/// `cross_language_twin_is_not_an_edge`.
+/// `cross_language_twin_is_not_an_edge`,
+/// `an_exact_key_shared_by_two_symbols_is_not_grounds`.
 pub(crate) fn resolve_callee(
     index: &NameIndex,
     caller_file: &str,
     callee: &str,
     require_callable: bool,
 ) -> Option<(NodeIndex, Grounds)> {
-    if let Some(&idx) = index.by_key.get(&qualified_key(caller_file, callee)) {
-        return Some((idx, Grounds::SameFile));
+    // The shortcut answers only when the key names ONE definition and that
+    // definition can actually be called; otherwise fall through to the scope
+    // walk, which applies both rules itself.
+    if let Some(Some(c)) = index.by_key.get(&qualified_key(caller_file, callee))
+        && (!require_callable || c.callable)
+    {
+        return Some((c.idx, Grounds::SameFile));
     }
 
     // A dependency is raw call text (`Foo::bar`), a definition is registered
@@ -158,11 +201,11 @@ pub(crate) fn resolve_callee(
     if named.is_empty() {
         named = index.candidates(bare_name(callee));
     }
-    let caller_ext = extension(caller_file);
+    let caller_lang = language_of(caller_file);
     let cands: Vec<&Candidate> = named
         .iter()
         .filter(|c| !require_callable || c.callable)
-        .filter(|c| caller_ext.is_empty() || extension(index.file_of(c.idx)) == caller_ext)
+        .filter(|c| caller_file.is_empty() || language_of(index.file_of(c.idx)) == caller_lang)
         .collect();
     if cands.is_empty() {
         return None;
@@ -200,19 +243,22 @@ pub(crate) fn resolve_callee(
 /// Why: a bare name that several definitions answer to must not silently anchor
 /// to whichever was registered first — the caller has to be able to say which
 /// one it took and what else matched (#6170).
-/// What: the qualified key first, then `<path>::<symbol>` where the path is a
-/// suffix of a real file path, then the name index (falling back to the
-/// trailing identifier). Multi-hit results are ordered by `rank` — the graph
-/// passes node degree, so the most-connected definition leads.
-/// Test: `path_qualified_name_anchors_instead_of_missing`,
+/// What: the qualified key first, then `<path>::<symbol>` — matched against the
+/// FILE each candidate was defined in, never by splitting the key, because a
+/// registry key is `<file>::<module>::<name>` and splitting it at the last
+/// `::` leaves the module path where the file should be. Then the name index,
+/// falling back to the trailing identifier. Multi-hit results are ordered by
+/// `rank` — the graph passes node degree, so the most-connected definition
+/// leads.
+/// Test: `path_qualified_name_anchors_on_the_file_it_names`,
 /// `ambiguous_bare_name_reports_every_candidate`.
 pub(crate) fn rank_matches(
     index: &NameIndex,
     name: &str,
     rank: impl Fn(NodeIndex) -> usize,
 ) -> Vec<NodeIndex> {
-    if let Some(&idx) = index.by_key.get(name) {
-        return vec![idx];
+    if let Some(Some(c)) = index.by_key.get(name) {
+        return vec![c.idx];
     }
 
     let mut hits: Vec<NodeIndex> = Vec::new();
@@ -220,14 +266,10 @@ pub(crate) fn rank_matches(
         && (path.contains('/') || path.contains('.'))
     {
         hits = index
-            .by_key
+            .candidates(symbol)
             .iter()
-            .filter(|(k, _)| {
-                k.rsplit_once("::").is_some_and(|(f, s)| {
-                    (s == symbol || bare_name(s) == symbol) && f.ends_with(path)
-                })
-            })
-            .map(|(_, &i)| i)
+            .filter(|c| path_suffix_matches(index.file_of(c.idx), path))
+            .map(|c| c.idx)
             .collect();
     }
     if hits.is_empty() {
@@ -243,4 +285,45 @@ pub(crate) fn rank_matches(
     hits.sort_by_key(|&i| (std::cmp::Reverse(rank(i)), i.index()));
     hits.dedup();
     hits
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn an_exact_key_shared_by_two_symbols_is_not_grounds() {
+        // Why: one file can hold `fn write` and an import named `write`. Both
+        // key to `<file>::write`, and the shortcut used to return whichever was
+        // inserted last, ignoring `require_callable` (#6170).
+        // What: registers the import last, then asks for a callable `write`.
+        // Asserts the function is what resolves, by way of the scope walk.
+        let mut index = NameIndex::default();
+        let func = NodeIndex::new(0);
+        let import = NodeIndex::new(1);
+        index.insert("src/io.rs", "write", func, true);
+        index.insert("src/io.rs", "write", import, false);
+
+        let (idx, grounds) =
+            resolve_callee(&index, "src/io.rs", "write", true).expect("callable twin resolves");
+        assert_eq!(idx, func);
+        assert_eq!(grounds, Grounds::SameFile);
+
+        // With no callable requirement the key names two symbols and neither is
+        // grounds, so nothing resolves.
+        assert!(resolve_callee(&index, "src/io.rs", "write", false).is_none());
+    }
+
+    #[test]
+    fn sibling_extensions_of_one_language_stay_ambiguous() {
+        // Why: `.ts` and `.tsx` are one language. Comparing raw extensions
+        // dropped the `.tsx` twin and left the `.ts` one falsely unique.
+        let mut index = NameIndex::default();
+        index.insert("ui/lib/a.ts", "get", NodeIndex::new(0), true);
+        index.insert("ui/widgets/b.tsx", "get", NodeIndex::new(1), true);
+        assert!(resolve_callee(&index, "ui/app/main.ts", "get", true).is_none());
+
+        // A Rust caller still sees neither of them.
+        assert!(resolve_callee(&index, "crates/a/src/lib.rs", "get", true).is_none());
+    }
 }


### PR DESCRIPTION
Refs #6170.

## Where the defect lives

In trusty-common. `crates/trusty-common/src/symgraph/graph.rs` is reached only
through `symgraph-parser`, and `trusty-agents` is the sole crate enabling that
feature — its `trace_execution_flow` builds this graph. The fix is entirely on
the trusty-common side; no trusty-agents source is touched, and its test suite
is run here as the consumer gate.

## Root cause

`SymbolGraph` kept one global bare-name → node map with `or_insert`
(first write wins), and `add_edge_by_name` resolved BOTH endpoints through it.
`build_from_registry` stripped every registry id down to its trailing
identifier before the lookup. So a call to `write` became an edge to whichever
`write` the registry iterated first — a different file, usually a different
crate. Same shape PR #6169 fixed in trusty-search's parallel `SymbolGraph`.

## What changed

- Node identity is `<file>::<symbol>`. A registry entry is indexed under its
  full id AND its trailing identifier, so a dependency citing either reaches
  the same node.
- A callee becomes an edge only with grounds: the caller's own file, then each
  ancestor directory of it, then the whole corpus — accepting the first scope
  that holds exactly ONE candidate. More than one at that scope means no edge;
  widening can only add candidates.
  #6169's file → directory → package → corpus ladder guesses "package" from the
  first two path segments, which is wrong for the absolute paths this registry
  carries (`/Users/...` would read as the package). Walking every ancestor is
  the same ladder without the guess.
- Cross-file resolution requires a matching file extension, and a `Calls` edge
  requires a callable target (function or method, not a struct or an import).
- `resolve_symbol` returns `SymbolMatch::{Unique, Ambiguous, NotFound}`;
  `callers_of` / `callees_of` / `context_for` anchor through it, so a
  `<path>::<symbol>` name anchors instead of missing and a bare name with
  several definitions takes the most-connected one instead of the first
  registered.
- Resolution lives in a new `symgraph/resolve.rs` (crate-internal).

Not done: consolidating the two `SymbolGraph` implementations, option (b) in
the issue. The two have diverged past a drop-in swap — trusty-search's is built
from chunks with persistence, contributed subgraphs and node caps; this one is
built from a tree-sitter registry with an emitter and layout strategies over
it. That belongs in its own change; #6170 can stay open for it.

## Regression proof — the tests fail without the fix

Same test bodies, run against `origin/main`'s `graph.rs` (the `SymbolMatch`
test has no pre-fix equivalent and was left out of that run):

```
running 8 tests
test path_qualified_name_anchors_... ... FAILED   got [], left: 0, right: 1
test bare_name_collision_across_crates_creates_no_edge ... FAILED
      ambiguous callee resolved anyway: ["crates/a/src/lib.rs"]
test directory_scope_beats_a_distant_twin ... FAILED
      left: ["crates/far/src/util.rs"]
test cross_language_twin_is_not_an_edge ... FAILED
      cross-language callee resolved: ["ui/src/chatStream.ts"]
test same_file_callee_wins_over_an_earlier_registered_twin ... FAILED
      left:  ["crates/agents/src/stamp.rs"]
      right: ["crates/search/src/store.rs"]
test corpus_unique_name_still_resolves_across_files ... ok
test build_from_registry_smoke ... ok
test kg_calls_edge_between_two_functions ... ok

test result: FAILED. 3 passed; 5 failed; 0 ignored; 424 filtered out
```

`corpus_unique_name_still_resolves_across_files` passes on both by design — it
guards against over-restricting, so it must not fail before.

The five tests added or rewritten in the review round below fail the same way
against this PR's own first pass (production code from `32341ee5`, tests from
the current head):

```
path_qualified_name_anchors_on_the_file_it_names
  expected Unique on stamp.rs, got Ambiguous { chosen: store.rs::write,
  alternatives: [stamp.rs::write] }
sibling_extensions_of_one_language_stay_ambiguous (graph)
  sibling-extension twin resolved: ["ui/lib/a.ts"]
a_call_never_lands_on_a_container_in_the_callers_file
  call resolved to a container: ["crates/a/src/lib.rs"]
an_exact_key_shared_by_two_symbols_is_not_grounds
  left: NodeIndex(1)   right: NodeIndex(0)      (the import won)
sibling_extensions_of_one_language_stay_ambiguous (resolve)
  assertion failed: resolve_callee(&index, "ui/app/main.ts", "get", true).is_none()

test result: FAILED. 60 passed; 5 failed; 0 ignored; 372 filtered out
```

## Review round — four resolver defects fixed

- **`<path>::<symbol>` anchoring never matched a registry-built graph.** A key
  is `<file>::<module path>::<name>`, so splitting it at the last `::` leaves
  the module path where the file belongs and `ends_with(path)` cannot hold. The
  request fell through to a degree-ranked bare-name match and came back
  Ambiguous for an exact-file ask. Candidates are now matched against the file
  each was defined in, at a path-segment boundary; that also drops a scan of the
  whole key map.
- **The same-file exact-key shortcut returned before the callable filter and
  before the uniqueness rule,** and `by_key` was last-write-wins: a file holding
  `fn write` and an import named `write` resolved a call to the import. The key
  poisons to `None` on a second symbol, and the shortcut applies
  `require_callable`.
- **The extension filter treated `.ts` and `.tsx` as different languages,** so
  it dropped one twin and left the other falsely unique — a heuristic that
  narrowed to exactly one. Language family now comes from
  `symbol::detect_language`, the same extension table the parser uses.
  `require_callable` stays a pre-filter; it is a hard rule, not a heuristic.
- **`path_qualified_name_anchors_on_the_file_it_names` proved nothing** — it
  asserted on the high-degree twin, which degree ranking returns for a bare
  `write` too. It now asks for the lone definition in `stamp.rs` and checks that
  twin has no callers.

`SymbolMatch` is re-exported beside `SymbolGraph` in `symgraph/mod.rs`.

## Gates — rung 4 (public API on a shared library)

```
cargo fmt --all -- --check                                             EXIT=0
cargo clippy -p trusty-common --features symgraph-parser --all-targets -- -D warnings   EXIT=0
cargo test -p trusty-common --features symgraph-parser   431 passed; 0 failed; 6 ignored
cargo check --workspace --all-targets                                  EXIT=0
cargo test -p trusty-agents   3529 passed; 0 failed; 13 ignored (direct consumer)
scripts/check_line_cap.sh          4168 files, 0 violations
scripts/check_test_pointers.sh     26629 citations, 0 dangling
scripts/check_changelog_fragment.sh  all 1 crate(s) with source changes recorded
scripts/check_sld.sh               0 errors, 0 warnings
```

No version bump: in-tree `trusty-common` 0.43.1 is already ahead of the
published 0.43.0.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
