### PR TITLE
fix(trusty-mpm): a test's leaked tmux session is never adopted into the picker (Refs #6116)

### DIFF
--- a/crates/trusty-common/changelog.d/6116-reserved-test-session-namespace.md
+++ b/crates/trusty-common/changelog.d/6116-reserved-test-session-namespace.md
@@ -1,0 +1,9 @@
+Added
+
+- `session_naming::RESERVED_TEST_PREFIX` (`tm-xtest-`) and
+  `is_reserved_test_session_name`, the namespace trusty-mpm's adoption sweep
+  refuses (#6116). It sits inside the managed `tm-` prefix, so a session in it
+  is still recognised by `is_managed_session_name` and still reapable by the
+  orphan-GC; what changes is that no automatic path adopts it into the session
+  store. The constant lives here because the daemon that refuses such a name and
+  the test fixture that mints one both read it, and a second copy would drift.

--- a/crates/trusty-common/changelog.d/6116-reserved-test-session-namespace.md
+++ b/crates/trusty-common/changelog.d/6116-reserved-test-session-namespace.md
@@ -7,3 +7,6 @@ Added
   orphan-GC; what changes is that no automatic path adopts it into the session
   store. The constant lives here because the daemon that refuses such a name and
   the test fixture that mints one both read it, and a second copy would drift.
+  Its doc states what a project legitimately named `xtest-…` pays: no automatic
+  adoption of its sessions, and — on a machine running trusty-mpm's own suite —
+  a tmux-level sweep that kills such a session after 30 minutes.

--- a/crates/trusty-common/src/session_naming/mod.rs
+++ b/crates/trusty-common/src/session_naming/mod.rs
@@ -138,10 +138,21 @@ pub fn is_managed_session_name(name: &str) -> bool {
 /// What: `tm-xtest-`. It starts with [`PREFIX`], so
 /// [`is_managed_session_name`] still recognises such a session as ours — the
 /// orphan-GC's first gate — while [`is_reserved_test_session_name`] separates
-/// it from anything an operator's work is in. A real project whose repo is
-/// named `xtest-…` would derive a name in this namespace and be refused
-/// adoption; no such repo exists here, and the alternative (a marker only a
-/// live tmux server can answer) cannot be read from a name at all.
+/// it from anything an operator's work is in.
+///
+/// **What a project legitimately named `xtest-…` pays.** Its sessions derive
+/// names in this namespace, and two consequences follow. Both are accepted; no
+/// such project exists in this workspace, and the alternative — a marker only a
+/// live tmux server can answer — cannot be read from a name at all.
+///
+/// 1. The daemon never AUTO-ADOPTS such a session. Sessions it created are
+///    unaffected: trusty-mpm's tombstone and no-auto-resume rules ask for an
+///    adopted provenance too (`SessionRecord::is_leaked_test_adoption`), so a
+///    created `tm-xtest-foo-01` still stops, resumes and lists normally.
+/// 2. On a machine that runs trusty-mpm's own test suite, that suite KILLS such
+///    a session once it is 30 minutes old — the tmux-level sweep sees a name
+///    and a creation time, and no provenance is recoverable from those.
+///
 /// Test: `reserved_test_prefix_is_a_managed_name`,
 /// `reserved_test_names_are_recognised`,
 /// `ordinary_managed_names_are_not_reserved`; the daemon half in

--- a/crates/trusty-common/src/session_naming/mod.rs
+++ b/crates/trusty-common/src/session_naming/mod.rs
@@ -117,6 +117,49 @@ pub fn is_managed_session_name(name: &str) -> bool {
         || name.starts_with(LEGACY_PREFIX_FULL)
 }
 
+/// Namespace reserved for tmux sessions this workspace's own test suite creates
+/// (#6116).
+///
+/// Why: a test that spawns a REAL tmux session leaks it whenever the test
+/// process dies hard — a SIGKILL, a `cargo test` timeout, an aborted run — none
+/// of which unwind, so no `Drop` guard runs. The leaked session keeps the `tm-`
+/// prefix, so the daemon's boot adoption sweep reads it as an ordinary managed
+/// session it has not seen yet, writes a record for it, and the operator's
+/// session picker grows an `(active)` ghost that outlives the tmux session.
+/// Three leaked on 2026-08-24 alone. A name prefix the sweep refuses closes that
+/// for every leak shape, past and future, because it decides from the name
+/// alone — no cleanup on the test side has to have run.
+///
+/// The refusal is also what returns a leaked pane to the reaper: an unadopted
+/// managed pane is `daemon::orphan_gc` input, and an idle shell with no live
+/// child is killed there after two sweeps. Adopting it is what granted it
+/// immunity.
+///
+/// What: `tm-xtest-`. It starts with [`PREFIX`], so
+/// [`is_managed_session_name`] still recognises such a session as ours — the
+/// orphan-GC's first gate — while [`is_reserved_test_session_name`] separates
+/// it from anything an operator's work is in. A real project whose repo is
+/// named `xtest-…` would derive a name in this namespace and be refused
+/// adoption; no such repo exists here, and the alternative (a marker only a
+/// live tmux server can answer) cannot be read from a name at all.
+/// Test: `reserved_test_prefix_is_a_managed_name`,
+/// `reserved_test_names_are_recognised`,
+/// `ordinary_managed_names_are_not_reserved`; the daemon half in
+/// trusty-mpm's `reconcile_refuses_to_adopt_a_reserved_test_session`.
+pub const RESERVED_TEST_PREFIX: &str = "tm-xtest-";
+
+/// True if `name` is in the test-owned namespace no automatic adoption may
+/// touch (#6116).
+///
+/// Why/What: see [`RESERVED_TEST_PREFIX`] — this is the one reader of it, so
+/// the daemon's refusal and the test fixture that mints such a name cannot
+/// drift apart.
+/// Test: `reserved_test_names_are_recognised`,
+/// `ordinary_managed_names_are_not_reserved`.
+pub fn is_reserved_test_session_name(name: &str) -> bool {
+    name.starts_with(RESERVED_TEST_PREFIX)
+}
+
 /// Strip whichever managed prefix `name` carries (current or legacy), for display.
 ///
 /// Why (#1955): the dashboard/coordinator short-prefix helpers
@@ -509,6 +552,30 @@ mod tests {
         assert!(!is_managed_session_name("my-tm-thing"));
         assert!(!is_managed_session_name("my-tmpm-thing"));
         assert!(!is_managed_session_name("not-trusty-mpm-x"));
+    }
+
+    /// #6116: the reserved namespace stays inside the managed one, so the
+    /// orphan-GC — whose first gate is `is_managed_session_name` — still reaps
+    /// a leaked test pane once adoption declines it.
+    #[test]
+    fn reserved_test_prefix_is_a_managed_name() {
+        assert!(RESERVED_TEST_PREFIX.starts_with(PREFIX));
+        assert!(is_managed_session_name(RESERVED_TEST_PREFIX));
+    }
+
+    #[test]
+    fn reserved_test_names_are_recognised() {
+        assert!(is_reserved_test_session_name("tm-xtest-deadrt1234-01"));
+        assert!(is_reserved_test_session_name(RESERVED_TEST_PREFIX));
+    }
+
+    #[test]
+    fn ordinary_managed_names_are_not_reserved() {
+        assert!(!is_reserved_test_session_name("tm-trusty-tools-01"));
+        assert!(!is_reserved_test_session_name("tmpm-live-session"));
+        // A true prefix, never a substring: an operator session merely
+        // mentioning the token keeps its adoption.
+        assert!(!is_reserved_test_session_name("tm-my-xtest-01"));
     }
 
     #[test]

--- a/crates/trusty-mpm/changelog.d/6116-reserved-test-session-namespace.md
+++ b/crates/trusty-mpm/changelog.d/6116-reserved-test-session-namespace.md
@@ -1,0 +1,25 @@
+Fixed
+
+- The daemon's boot adoption sweep no longer adopts a tmux session named under
+  the reserved test namespace `tm-xtest-` (#6116). A test that spawns a real
+  tmux session leaks it whenever the test process dies without unwinding — a
+  SIGKILL, a `cargo test` timeout, an aborted run — so PR #6125's kill-on-drop
+  guard, which covers the panic path, cannot cover that one. Three sessions
+  leaked that way on 2026-08-24, adoption turned each into a managed record, and
+  the session picker grew three `(active)` ghosts that outlived the tmux
+  sessions themselves. The refusal decides from the name alone, so it holds for
+  every leak shape whether or not any test-side cleanup ran, and it also returns
+  the leaked pane to `daemon::orphan_gc` — an untracked idle shell with no live
+  child is killed there after two sweeps, whereas being adopted made it
+  permanent.
+- A reserved-namespace record whose tmux session is gone is now tombstoned by
+  boot reconciliation instead of marked `Stopped` (#6116). A record adopted by a
+  daemon build predating the refusal survives in the durable store, and
+  `Stopped` left a picker row nothing could resume — the state that forced a
+  manual `session_delete force`. An ordinary session's gone-tmux handling is
+  unchanged: still `Stopped`, still resumable.
+- The `#3873` dead-runtime fixture now mints its real tmux session inside that
+  namespace, and the test-support guard sweeps reserved-namespace sessions older
+  than 30 minutes once per test process, so the next run on a machine reaps what
+  a hard-killed run left behind. Neither mechanism survives a SIGKILL on its
+  own; the daemon-side refusal is what makes a leak harmless while it lasts.

--- a/crates/trusty-mpm/changelog.d/6116-reserved-test-session-namespace.md
+++ b/crates/trusty-mpm/changelog.d/6116-reserved-test-session-namespace.md
@@ -12,12 +12,21 @@ Fixed
   the leaked pane to `daemon::orphan_gc` — an untracked idle shell with no live
   child is killed there after two sweeps, whereas being adopted made it
   permanent.
-- A reserved-namespace record whose tmux session is gone is now tombstoned by
-  boot reconciliation instead of marked `Stopped` (#6116). A record adopted by a
-  daemon build predating the refusal survives in the durable store, and
-  `Stopped` left a picker row nothing could resume — the state that forced a
-  manual `session_delete force`. An ordinary session's gone-tmux handling is
-  unchanged: still `Stopped`, still resumable.
+- An ADOPTED reserved-namespace record is now tombstoned by boot
+  reconciliation, whether its pane is live or gone, and no automatic path
+  resumes one (#6116). A record adopted by a daemon build predating the refusal
+  survives in the durable store, and leaving it alone had two outcomes: a gone
+  pane left a `Stopped` picker row nothing could resume — the state that forced
+  a manual `session_delete force` — while a LIVE one sustained a loop, since
+  re-adopting it restored its orphan-GC immunity, the reaper then stamped it
+  auto-resumable, the supervisor recreated the tmux session, and the next boot
+  re-adopted it. The daemon log shows that cycle three times in one day. Both
+  rules ask for an adopted provenance as well as a reserved name, so a session
+  the daemon CREATED for a project named `xtest-…` keeps ordinary stop, resume
+  and list behavior. An ordinary session's gone-tmux handling is unchanged:
+  still `Stopped`, still resumable.
+- The boot-reconcile summary log now counts refused and swept test sessions, so
+  a boot whose only finding was one of those no longer prints nothing.
 - The `#3873` dead-runtime fixture now mints its real tmux session inside that
   namespace, and the test-support guard sweeps reserved-namespace sessions older
   than 30 minutes once per test process, so the next run on a machine reaps what

--- a/crates/trusty-mpm/src/bin/tm/commands/managed_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed_tests.rs
@@ -601,9 +601,17 @@ async fn session_resume_headless_dead_runtime_reconciles_and_restarts() {
             // name lets one process's cleanup destroy the other process's session
             // mid-test — observed as an intermittent failure of the final
             // assertion below.
+            //
+            // #6116: the slug also puts the DERIVED name in the reserved test
+            // namespace, which the daemon's adoption sweep refuses — so a run
+            // killed hard enough to skip the guard's `Drop` leaks a session
+            // that never becomes a picker row.
             Some(format!(
-                "https://example.com/deadrt{}.git",
-                std::process::id()
+                "https://example.com/{}.git",
+                crate::test_support::tmux_session::reserved_project_slug(&format!(
+                    "deadrt{}",
+                    std::process::id()
+                ))
             )),
             Some("main".to_string()),
             RuntimeKind::default(),
@@ -616,6 +624,15 @@ async fn session_resume_headless_dead_runtime_reconciles_and_restarts() {
         record.state.to_string(),
         "provisioning",
         "sanity: create_with_id must leave a fresh record un-stopped/un-errored"
+    );
+
+    // #6116: the guard below covers a panic; nothing covers a SIGKILL. What
+    // makes a session leaked that way harmless is the namespace it is in, so
+    // assert the derived name actually landed there rather than assuming it.
+    assert!(
+        trusty_common::session_naming::is_reserved_test_session_name(&record.tmux_name),
+        "this fixture's real tmux session must be one the daemon refuses to adopt, got {}",
+        record.tmux_name
     );
 
     let tmux_bin = trusty_mpm::core::tmux::resolve_tmux_binary_or_bare();
@@ -638,7 +655,8 @@ async fn session_resume_headless_dead_runtime_reconciles_and_restarts() {
     // #6116: owned by an RAII guard. `wait_for_stable_dead_runtime` below
     // panics on a 10s timeout by design, and the post-hoc `kill-session` this
     // replaces never ran on that path — every such run leaked a real
-    // `tm-deadrt<pid>-01` session permanently.
+    // `tm-deadrt<pid>-01` session permanently. `Drop` still cannot run on a
+    // SIGKILL; `spawn` also sweeps what an earlier hard-killed run left behind.
     let scratch = crate::test_support::tmux_session::ScratchTmuxSession::spawn(
         &tmux_bin,
         &record.tmux_name,

--- a/crates/trusty-mpm/src/daemon/state/core.rs
+++ b/crates/trusty-mpm/src/daemon/state/core.rs
@@ -826,11 +826,19 @@ impl DaemonState {
                         // It must gate the log too — a boot whose ONLY finding
                         // was declined panes would otherwise print nothing.
                         let n_declined = report.adoption_declined.len();
+                        // #6116: same reasoning as `n_declined` — a refused
+                        // test session leaves no record, and a swept one
+                        // leaves only a tombstone, so a boot whose only
+                        // finding was either would otherwise print nothing.
+                        let n_test_refused = report.reserved_test_refused.len();
+                        let n_test_swept = report.reserved_test_swept.len();
                         if n_adopted > 0
                             || n_stopped > 0
                             || n_external > 0
                             || n_stale_decisions > 0
                             || n_declined > 0
+                            || n_test_refused > 0
+                            || n_test_swept > 0
                         {
                             tracing::info!(
                                 adopted = n_adopted,
@@ -838,6 +846,8 @@ impl DaemonState {
                                 external = n_external,
                                 stale_decisions_cleared = n_stale_decisions,
                                 adoption_declined = n_declined,
+                                reserved_test_refused = n_test_refused,
+                                reserved_test_swept = n_test_swept,
                                 "session-manager reconcile complete"
                             );
                         }

--- a/crates/trusty-mpm/src/session_manager/manager.rs
+++ b/crates/trusty-mpm/src/session_manager/manager.rs
@@ -182,6 +182,22 @@ pub struct ReconcileReport {
     /// so the boot log has to name them — otherwise a pane simply stops
     /// appearing in `tm ls` with nothing said about where it went.
     pub adoption_declined: Vec<String>,
+    /// Live tmux names reconciliation REFUSED to adopt because they are in the
+    /// test-owned namespace
+    /// [`trusty_common::session_naming::RESERVED_TEST_PREFIX`] (#6116).
+    ///
+    /// Why: separate from [`adoption_declined`](Self::adoption_declined)
+    /// because the two say different things — a declined pane is one whose cwd
+    /// would not resolve, a refused one is a leaked test session the daemon
+    /// will not track no matter what its pane says.
+    pub reserved_test_refused: Vec<String>,
+    /// Session ids of reserved-test-namespace records tombstoned this boot
+    /// because their tmux session was gone (#6116).
+    ///
+    /// Why: such a record was adopted by a daemon build predating the refusal
+    /// above and would otherwise sit in the picker as a `Stopped` row nothing
+    /// can resume.
+    pub reserved_test_swept: Vec<String>,
 }
 
 /// Manages the lifecycle of daemon-owned tmux sessions.

--- a/crates/trusty-mpm/src/session_manager/manager.rs
+++ b/crates/trusty-mpm/src/session_manager/manager.rs
@@ -191,12 +191,13 @@ pub struct ReconcileReport {
     /// would not resolve, a refused one is a leaked test session the daemon
     /// will not track no matter what its pane says.
     pub reserved_test_refused: Vec<String>,
-    /// Session ids of reserved-test-namespace records tombstoned this boot
-    /// because their tmux session was gone (#6116).
+    /// Session ids of adopted reserved-test-namespace records tombstoned this
+    /// boot, whether their pane was live or gone (#6116).
     ///
     /// Why: such a record was adopted by a daemon build predating the refusal
-    /// above and would otherwise sit in the picker as a `Stopped` row nothing
-    /// can resume.
+    /// above. Left alone it either sat in the picker as a `Stopped` row nothing
+    /// could resume, or — with a live pane — fed the re-adopt/reap/resume loop
+    /// this module's doc describes.
     pub reserved_test_swept: Vec<String>,
 }
 

--- a/crates/trusty-mpm/src/session_manager/naming_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/naming_tests.rs
@@ -1004,3 +1004,110 @@ async fn dedupe_name_against_caps_suffixed_length_at_64() {
     );
     assert_ne!(result, long, "the taken candidate must still be suffixed");
 }
+
+/// #6116: a live session in the test-owned namespace is never adopted, even
+/// though its pane resolves a working directory.
+///
+/// Why: a test that spawns a real tmux session leaks it when its process dies
+/// hard — SIGKILL, a `cargo test` timeout, an aborted run — none of which run
+/// `Drop`. Three such sessions leaked on 2026-08-24, this loop adopted each
+/// one, and the operator's picker grew three `(active)` ghosts. The refusal
+/// reads the NAME, so it holds whether or not any test-side cleanup ran.
+/// What: one live `tm-xtest-…` pane with a resolvable cwd — the shape #6118
+/// would otherwise adopt — asserting no record is written, the name lands in
+/// `reserved_test_refused`, and neither `external_adopted` nor
+/// `adoption_declined` claims it. Before this fix the pane was adopted.
+/// Test: this function IS the test.
+#[tokio::test]
+#[serial_test::serial]
+async fn reconcile_refuses_to_adopt_a_reserved_test_session() {
+    let dir = TempDir::new().unwrap();
+    let workspace = TempDir::new().unwrap();
+    // #3965: `#[serial]` + `$HOME` override — see `HomeGuard` above. A refused
+    // pane never reaches `validate_and_repair`; pin `$HOME` anyway so a future
+    // refactor cannot silently reopen the real-`$HOME` write.
+    let _home = set_home(dir.path());
+    let leaked = format!(
+        "{}deadrt4242-01",
+        trusty_common::session_naming::RESERVED_TEST_PREFIX
+    );
+    let fake = std::sync::Arc::new(PaneCwdTmux {
+        alive: vec![leaked.clone()],
+        pane_cwd: Some(workspace.path().to_path_buf()),
+    });
+
+    let mgr = SessionManager::new(dir.path(), fake).await.unwrap();
+    let report = mgr.reconcile_on_boot(false).await.expect("reconcile");
+
+    assert_eq!(
+        mgr.list().await.len(),
+        0,
+        "a leaked test session must leave no record for the picker to show"
+    );
+    assert!(
+        report.reserved_test_refused.contains(&leaked),
+        "the refused session must be named in the report; report: {report:?}"
+    );
+    assert!(
+        report.external_adopted.is_empty() && report.adoption_declined.is_empty(),
+        "refusal is by name, not a cwd-resolution decline; report: {report:?}"
+    );
+}
+
+/// #6116: a reserved-namespace record whose tmux session is gone is
+/// tombstoned, while an ordinary record in the same pass still becomes
+/// `Stopped`.
+///
+/// Why: such a record was adopted by a daemon build predating the refusal
+/// above — the store outlives that upgrade — and `Stopped` would leave a
+/// picker row nothing can ever resume, which is what forced the owner into
+/// `session_delete force`. The paired ordinary record is the over-reach guard:
+/// resumability is taken away from the test namespace only.
+/// What: two Active records, no live tmux; asserts `Deleted` plus a stamped
+/// `terminal_at` for the reserved one, `Stopped` for the other, and that each
+/// id lands in exactly one report list. Before this fix both were `Stopped`.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn reconcile_tombstones_a_reserved_test_record_whose_tmux_is_gone() {
+    let dir = crate::test_support::hermetic_temp_dir();
+    let fake = FakeTmuxDriver::new();
+    let mgr = SessionManager::new(dir.path(), fake).await.unwrap();
+
+    let leaked_name = format!(
+        "{}deadrt4242-01",
+        trusty_common::session_naming::RESERVED_TEST_PREFIX
+    );
+    let leaked = super::tests::make_active_test_record(&leaked_name, "leaked test", "/tmp/leak-ws");
+    let ordinary = super::tests::make_active_test_record("tm-trusty-tools-01", "real", "/tmp/ws");
+    {
+        let mut store = mgr.store.write().await;
+        store.upsert(leaked.clone()).await.unwrap();
+        store.upsert(ordinary.clone()).await.unwrap();
+    }
+
+    let report = mgr.reconcile_on_boot(false).await.expect("reconcile");
+
+    let after = mgr.get(&leaked.id).await.unwrap();
+    assert_eq!(
+        after.state,
+        ManagedSessionState::Deleted,
+        "a leaked test record with no tmux session must be tombstoned, not left resumable"
+    );
+    assert!(
+        after.terminal_at.is_some(),
+        "the retention clock must start when the record goes terminal"
+    );
+    assert!(
+        report.reserved_test_swept.contains(&leaked.id.to_string())
+            && !report.stopped.contains(&leaked.id.to_string()),
+        "the swept record belongs in exactly one list; report: {report:?}"
+    );
+
+    let untouched = mgr.get(&ordinary.id).await.unwrap();
+    assert_eq!(
+        untouched.state,
+        ManagedSessionState::Stopped,
+        "an ordinary gone session stays Stopped and resumable"
+    );
+    assert!(report.stopped.contains(&ordinary.id.to_string()));
+}

--- a/crates/trusty-mpm/src/session_manager/naming_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/naming_tests.rs
@@ -1054,35 +1054,43 @@ async fn reconcile_refuses_to_adopt_a_reserved_test_session() {
     );
 }
 
-/// #6116: a reserved-namespace record whose tmux session is gone is
-/// tombstoned, while an ordinary record in the same pass still becomes
-/// `Stopped`.
+/// #6116: an adopted reserved-namespace record whose tmux session is gone is
+/// tombstoned, while an ordinary record and a CREATED session in the same
+/// namespace both still become `Stopped`.
 ///
 /// Why: such a record was adopted by a daemon build predating the refusal
 /// above — the store outlives that upgrade — and `Stopped` would leave a
 /// picker row nothing can ever resume, which is what forced the owner into
-/// `session_delete force`. The paired ordinary record is the over-reach guard:
-/// resumability is taken away from the test namespace only.
-/// What: two Active records, no live tmux; asserts `Deleted` plus a stamped
-/// `terminal_at` for the reserved one, `Stopped` for the other, and that each
-/// id lands in exactly one report list. Before this fix both were `Stopped`.
+/// `session_delete force`. The two paired records are the over-reach guards:
+/// resumability is taken away from ADOPTED test sessions only, not from every
+/// record whose name happens to be in the namespace.
+/// What: three Active records, no live tmux; asserts `Deleted` plus a stamped
+/// `terminal_at` for the adopted one, `Stopped` for the other two, and that
+/// each id lands in exactly one report list. Before this fix all three were
+/// `Stopped`.
 /// Test: this function IS the test.
 #[tokio::test]
-async fn reconcile_tombstones_a_reserved_test_record_whose_tmux_is_gone() {
+async fn reconcile_tombstones_an_adopted_reserved_record_whose_tmux_is_gone() {
     let dir = crate::test_support::hermetic_temp_dir();
     let fake = FakeTmuxDriver::new();
     let mgr = SessionManager::new(dir.path(), fake).await.unwrap();
 
-    let leaked_name = format!(
-        "{}deadrt4242-01",
-        trusty_common::session_naming::RESERVED_TEST_PREFIX
+    let leaked_name = reserved_name("deadrt4242-01");
+    let leaked = super::tests::make_active_test_record(
+        &leaked_name,
+        super::record::ADOPTED_TASK,
+        "/tmp/leak-ws",
     );
-    let leaked = super::tests::make_active_test_record(&leaked_name, "leaked test", "/tmp/leak-ws");
     let ordinary = super::tests::make_active_test_record("tm-trusty-tools-01", "real", "/tmp/ws");
+    // A project legitimately named `xtest-…`: same namespace, created not
+    // adopted, so nothing here may touch it.
+    let created =
+        super::tests::make_active_test_record(&reserved_name("foo-01"), "real work", "/tmp/ws2");
     {
         let mut store = mgr.store.write().await;
         store.upsert(leaked.clone()).await.unwrap();
         store.upsert(ordinary.clone()).await.unwrap();
+        store.upsert(created.clone()).await.unwrap();
     }
 
     let report = mgr.reconcile_on_boot(false).await.expect("reconcile");
@@ -1103,11 +1111,87 @@ async fn reconcile_tombstones_a_reserved_test_record_whose_tmux_is_gone() {
         "the swept record belongs in exactly one list; report: {report:?}"
     );
 
-    let untouched = mgr.get(&ordinary.id).await.unwrap();
-    assert_eq!(
-        untouched.state,
-        ManagedSessionState::Stopped,
-        "an ordinary gone session stays Stopped and resumable"
+    for (record, why) in [
+        (&ordinary, "an ordinary gone session stays Stopped"),
+        (&created, "a CREATED session in the namespace stays Stopped"),
+    ] {
+        assert_eq!(
+            mgr.get(&record.id).await.unwrap().state,
+            ManagedSessionState::Stopped,
+            "{why}"
+        );
+        assert!(report.stopped.contains(&record.id.to_string()));
+        assert!(!report.reserved_test_swept.contains(&record.id.to_string()));
+    }
+}
+
+/// #6116 (code-critic HIGH): a leaked test adoption whose pane is LIVE exits
+/// the loop instead of feeding it.
+///
+/// Why: the guard used to sit only on the gone arm, so a live pane was
+/// re-adopted `Active` — which restored its orphan-GC immunity, let the reaper
+/// stamp it `Unexpected` once the pane died, let the supervisor RECREATE the
+/// tmux session, and handed the next boot the same pane to re-adopt. The
+/// daemon log shows that cycle three times in one day.
+/// What: one live pane with an adopted reserved record, reconciled with
+/// `auto_resume` ON — the loop's fuel. Asserts the record ends terminal and
+/// un-auto-resumable, is absent from `adopted`, and that no session was
+/// created or killed: the pane is left to the orphan-GC, which is the only
+/// thing allowed to end it. Before this fix the record ended `Active` and the
+/// name appeared in `report.adopted`.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn a_live_leaked_test_pane_is_never_readopted_or_recreated() {
+    let dir = crate::test_support::hermetic_temp_dir();
+    let fake = FakeTmuxDriver::new();
+    let leaked_name = reserved_name("deadrt4242-01");
+    fake.seeded_names.lock().unwrap().push(leaked_name.clone());
+    let mgr = SessionManager::new(dir.path(), fake.clone()).await.unwrap();
+
+    let leaked = super::tests::make_active_test_record(
+        &leaked_name,
+        super::record::ADOPTED_TASK,
+        "/tmp/leak-ws",
     );
-    assert!(report.stopped.contains(&ordinary.id.to_string()));
+    {
+        let mut store = mgr.store.write().await;
+        store.upsert(leaked.clone()).await.unwrap();
+    }
+    let creates_before = fake.create_cwd_calls.lock().unwrap().len();
+
+    let report = mgr.reconcile_on_boot(true).await.expect("reconcile");
+
+    let after = mgr.get(&leaked.id).await.unwrap();
+    assert_eq!(
+        after.state,
+        ManagedSessionState::Deleted,
+        "a live leaked pane must not keep its record Active — that is what sustained the loop"
+    );
+    assert!(
+        !after.is_auto_resumable(),
+        "no automatic path may relaunch a leaked test session"
+    );
+    assert!(
+        !report.adopted.contains(&leaked_name),
+        "the live pane must not be re-adopted; report: {report:?}"
+    );
+    assert_eq!(
+        fake.create_cwd_calls.lock().unwrap().len(),
+        creates_before,
+        "nothing may recreate the pane"
+    );
+    assert!(
+        fake.kill_calls.lock().unwrap().is_empty(),
+        "reconcile drops the RECORD; killing the pane is the orphan-GC's decision, \
+         and it spares a pane that is not an idle shell"
+    );
+}
+
+/// A name in the reserved test namespace, built from the constant the daemon
+/// reads back (#6116).
+fn reserved_name(tag: &str) -> String {
+    format!(
+        "{}{tag}",
+        trusty_common::session_naming::RESERVED_TEST_PREFIX
+    )
 }

--- a/crates/trusty-mpm/src/session_manager/reconcile.rs
+++ b/crates/trusty-mpm/src/session_manager/reconcile.rs
@@ -64,9 +64,19 @@
 //! from the name alone, so it holds for every leak shape whether or not any
 //! test-side cleanup ran. Refusal also hands the leaked pane back to
 //! `daemon::orphan_gc`, which kills an idle shell with no live child; adopting
-//! it was what made it permanent. An already-adopted record in that namespace
-//! whose tmux session is gone is tombstoned rather than marked `Stopped`, since
-//! there is no test to resume — see the gone arm below.
+//! it was what made it permanent.
+//!
+//! **A record one of those already produced is tombstoned whether its pane
+//! lives or not**, via [`SessionRecord::is_leaked_test_adoption`], and that
+//! symmetry is the point: re-adopting a LIVE one as `Active` restored its
+//! orphan-GC immunity, the reaper then stamped the dead pane `Unexpected`
+//! (auto-resumable), the supervisor RECREATED the tmux session, and the next
+//! boot re-adopted it — a loop that ran three times in one day's daemon log.
+//! [`SessionRecord::is_auto_resumable`] refuses the same records, which closes
+//! the window between a reaper stop and the next boot. The predicate asks for
+//! an adopted PROVENANCE as well as a reserved name, so a session the daemon
+//! CREATED for a project legitimately named `xtest-…` keeps ordinary
+//! stop/resume behavior.
 //!
 //! **Declining is a kill decision, so the probe behind it retries.** An
 //! undeclared pane is orphan-GC input, and that GC kills an idle-shell pane
@@ -126,7 +136,8 @@ impl SessionManager {
     /// `boot_reconcile_still_auto_resumes_a_session_lost_with_the_daemon`
     /// (#6194) in `stop_cause_tests.rs`;
     /// `reconcile_refuses_to_adopt_a_reserved_test_session`,
-    /// `reconcile_tombstones_a_reserved_test_record_whose_tmux_is_gone`
+    /// `reconcile_tombstones_an_adopted_reserved_record_whose_tmux_is_gone`,
+    /// `a_live_leaked_test_pane_is_never_readopted_or_recreated`
     /// (#6116) in `naming_tests.rs`.
     pub async fn reconcile_on_boot(
         &self,
@@ -179,9 +190,14 @@ impl SessionManager {
                 // `"attached": true` beside `"state": "decommissioned"` — and
                 // the picker hides the row either way. Report it; never
                 // auto-revive it (see this module's doc).
+                // #6116: not for a tombstoned test adoption, where a live pane
+                // is the EXPECTED state — the record is dropped while the
+                // orphan-GC still has two sweeps of work to do on the pane —
+                // and the advice to reactivate it is exactly wrong.
                 if live_names
                     .as_ref()
                     .is_some_and(|live| live.contains(&record.tmux_name))
+                    && !record.is_leaked_test_adoption()
                 {
                     warn!(
                         id = %record.id,
@@ -213,6 +229,30 @@ impl SessionManager {
                 continue;
             }
 
+            // #6116: BEFORE the live/gone branch, because liveness is what the
+            // self-sustaining loop fed on — a live leaked pane was re-adopted
+            // Active, which restored its orphan-GC immunity, and once the pane
+            // died the reaper stamped it auto-resumable and the supervisor
+            // recreated the tmux session for the next pass to re-adopt. The
+            // record is a leaked test adoption either way, so the answer is the
+            // same either way: tombstone it and let the orphan-GC have the pane.
+            // Needs no live set, so it also runs when tmux is unobservable.
+            if record.is_leaked_test_adoption() {
+                record.set_lifecycle_state(ManagedSessionState::Deleted, Utc::now());
+                record.pending_decision = None;
+                record.proposed_default = None;
+                report.reserved_test_swept.push(record.id.to_string());
+                warn!(
+                    id = %record.id,
+                    name = %record.tmux_name,
+                    "reconcile: tombstoned an adopted reserved test-namespace record (#6116) — \
+                     a leaked test session is not a session to keep, resume or relaunch; its \
+                     pane goes back to the orphan-GC"
+                );
+                guard.upsert(record).await?;
+                continue;
+            }
+
             // #5856: without an observed live set there is no evidence either
             // way, so the record keeps whatever state it already has. The
             // pre-#5856 code fell through to the `else` arm here and marked
@@ -230,24 +270,6 @@ impl SessionManager {
                 record.stop_cause = None;
                 report.adopted.push(record.tmux_name.clone());
                 info!(name = %record.tmux_name, "reconcile: re-adopted live session");
-            } else if crate::core::names::is_reserved_test_session_name(&record.tmux_name) {
-                // #6116: a test's session that is gone leaves nothing to
-                // resume, so `Stopped` would keep a row in the picker no
-                // automatic path can ever clear. This reaches records a daemon
-                // build predating the refusal above already adopted — the
-                // store is durable across the upgrade that adds the refusal.
-                record.set_lifecycle_state(ManagedSessionState::Deleted, Utc::now());
-                record.pending_decision = None;
-                record.proposed_default = None;
-                report.reserved_test_swept.push(record.id.to_string());
-                warn!(
-                    id = %record.id,
-                    name = %record.tmux_name,
-                    "reconcile: tombstoned a reserved test-namespace record whose tmux session \
-                     is gone (#6116) — a leaked test session is not a stopped session"
-                );
-                guard.upsert(record).await?;
-                continue;
             } else {
                 // Session is gone — mark Stopped (resumable), never Orphaned.
                 record.state = ManagedSessionState::Stopped;
@@ -370,7 +392,9 @@ impl SessionManager {
                 id,
                 tmux_name: name.clone(),
                 cwd: resolved_cwd.clone(),
-                task: "adopted session".to_string(),
+                // #6116: one spelling, shared with the predicate that reads it
+                // back as this record's adopted provenance.
+                task: super::record::ADOPTED_TASK.to_string(),
                 state: ManagedSessionState::Active,
                 created_at: Utc::now(),
                 last_activity_at: None,

--- a/crates/trusty-mpm/src/session_manager/reconcile.rs
+++ b/crates/trusty-mpm/src/session_manager/reconcile.rs
@@ -52,6 +52,22 @@
 //! being tracked is exactly what the orphan-GC keys on (#6118 — such a pane is
 //! now declined, and reported in [`ReconcileReport::adoption_declined`]).
 //!
+//! **A test's tmux session is never adopted, however it leaked.** A test that
+//! spawns a real tmux session cannot clean it up when its process dies hard —
+//! a SIGKILL, a `cargo test` timeout and an aborted run all skip `Drop`, so the
+//! RAII guard PR #6125 added covers the panic path and nothing beyond it. Three
+//! `tm-deadrt<pid>-01` sessions leaked that way on 2026-08-24, this loop adopted
+//! each one, and the operator's picker grew three `(active)` ghosts that
+//! outlived the tmux sessions. Names carrying
+//! [`trusty_common::session_naming::RESERVED_TEST_PREFIX`] are now refused here
+//! and reported in [`ReconcileReport::reserved_test_refused`] — a decision made
+//! from the name alone, so it holds for every leak shape whether or not any
+//! test-side cleanup ran. Refusal also hands the leaked pane back to
+//! `daemon::orphan_gc`, which kills an idle shell with no live child; adopting
+//! it was what made it permanent. An already-adopted record in that namespace
+//! whose tmux session is gone is tombstoned rather than marked `Stopped`, since
+//! there is no test to resume — see the gone arm below.
+//!
 //! **Declining is a kill decision, so the probe behind it retries.** An
 //! undeclared pane is orphan-GC input, and that GC kills an idle-shell pane
 //! with no live child after two sweeps. See
@@ -86,7 +102,8 @@ impl SessionManager {
     /// against the store: live → `Active`; gone → `Stopped` (unless already
     /// `Decommissioned`). A managed session unknown to the store is adopted as
     /// `Active` under an id derived from its tmux name (#6117), and only when
-    /// its pane resolves a working directory (#6118) — see this module's doc.
+    /// its pane resolves a working directory (#6118) and its name is not in the
+    /// test-owned reserved namespace (#6116) — see this module's doc.
     /// When `auto_resume` is true, every session this pass marked `Stopped`
     /// whose stop was not asked for is immediately resumed (#6194 — a record
     /// already carrying [`StopCause::Deliberate`] keeps it and is left down).
@@ -107,7 +124,10 @@ impl SessionManager {
     /// `repeated_reconcile_of_one_resolvable_pane_keeps_one_record`;
     /// `boot_reconcile_never_requeues_a_deliberately_stopped_session`,
     /// `boot_reconcile_still_auto_resumes_a_session_lost_with_the_daemon`
-    /// (#6194) in `stop_cause_tests.rs`.
+    /// (#6194) in `stop_cause_tests.rs`;
+    /// `reconcile_refuses_to_adopt_a_reserved_test_session`,
+    /// `reconcile_tombstones_a_reserved_test_record_whose_tmux_is_gone`
+    /// (#6116) in `naming_tests.rs`.
     pub async fn reconcile_on_boot(
         &self,
         auto_resume: bool,
@@ -210,6 +230,24 @@ impl SessionManager {
                 record.stop_cause = None;
                 report.adopted.push(record.tmux_name.clone());
                 info!(name = %record.tmux_name, "reconcile: re-adopted live session");
+            } else if crate::core::names::is_reserved_test_session_name(&record.tmux_name) {
+                // #6116: a test's session that is gone leaves nothing to
+                // resume, so `Stopped` would keep a row in the picker no
+                // automatic path can ever clear. This reaches records a daemon
+                // build predating the refusal above already adopted — the
+                // store is durable across the upgrade that adds the refusal.
+                record.set_lifecycle_state(ManagedSessionState::Deleted, Utc::now());
+                record.pending_decision = None;
+                record.proposed_default = None;
+                report.reserved_test_swept.push(record.id.to_string());
+                warn!(
+                    id = %record.id,
+                    name = %record.tmux_name,
+                    "reconcile: tombstoned a reserved test-namespace record whose tmux session \
+                     is gone (#6116) — a leaked test session is not a stopped session"
+                );
+                guard.upsert(record).await?;
+                continue;
             } else {
                 // Session is gone — mark Stopped (resumable), never Orphaned.
                 record.state = ManagedSessionState::Stopped;
@@ -260,6 +298,19 @@ impl SessionManager {
         let mut newly_resolved: Vec<(ManagedSessionId, PathBuf)> = Vec::new();
         for name in live_names.iter().flatten() {
             if known_names.contains(name) {
+                continue;
+            }
+            // #6116: the test suite owns this namespace; a session in it is a
+            // leak from a hard-killed test run, never work to track.
+            if crate::core::names::is_reserved_test_session_name(name) {
+                warn!(
+                    name = %name,
+                    "reconcile: refusing to adopt a reserved test-namespace session (#6116) — \
+                     it leaked from a test process that died before its cleanup ran. Left \
+                     untracked for the orphan-GC, which kills an idle shell with no live child \
+                     on two consecutive sweeps"
+                );
+                report.reserved_test_refused.push(name.clone());
                 continue;
             }
             // #6118: a pane whose cwd will not resolve is NOT adopted. #2158

--- a/crates/trusty-mpm/src/session_manager/record.rs
+++ b/crates/trusty-mpm/src/session_manager/record.rs
@@ -44,9 +44,8 @@ pub const UNRESOLVED_PATH_SENTINEL: &str = "/unknown";
 /// [`SessionRecord::is_leaked_test_adoption`] matches it as a PREFIX, because
 /// `SessionManager::mark_errored` appends `[error: …]` to whatever task a
 /// record already carries.
-/// Test: `an_adopted_reserved_record_is_a_leaked_test_adoption`,
-/// `a_created_reserved_session_is_not_a_leaked_test_adoption` in
-/// `record_tests.rs`.
+/// Test: `leaked_test_adoption_requires_both_a_reserved_name_and_an_adopted_task`
+/// in `record_tests.rs`.
 pub const ADOPTED_TASK: &str = "adopted session";
 
 /// Opaque identifier for a managed session.
@@ -574,7 +573,9 @@ impl SessionRecord {
     /// Test: `only_a_stop_nobody_asked_for_is_auto_resumable` (the full state ×
     /// cause matrix) and
     /// `legacy_record_without_stop_cause_deserializes_as_auto_resumable` in
-    /// `stop_cause_tests.rs`; the two automatic callers by
+    /// `stop_cause_tests.rs`; the #6116 clause by
+    /// `a_stopped_leaked_test_adoption_is_never_auto_resumable` in
+    /// `record_tests.rs`; the two automatic callers by
     /// `tick_never_resumes_a_deliberately_stopped_session` in
     /// `supervisor::tests` and
     /// `boot_reconcile_never_requeues_a_deliberately_stopped_session` in
@@ -603,10 +604,12 @@ impl SessionRecord {
     /// What: the tmux name is in
     /// [`trusty_common::session_naming::RESERVED_TEST_PREFIX`] AND the task
     /// begins with [`ADOPTED_TASK`], which only an automatic adoption writes.
-    /// Test: `an_adopted_reserved_record_is_a_leaked_test_adoption`,
-    /// `a_created_reserved_session_is_not_a_leaked_test_adoption`,
-    /// `an_ordinary_adopted_record_is_not_a_leaked_test_adoption` in
-    /// `record_tests.rs`.
+    /// Test: `leaked_test_adoption_requires_both_a_reserved_name_and_an_adopted_task`
+    /// (the adopted / created / ordinary-adoption matrix) and
+    /// `a_stopped_leaked_test_adoption_is_never_auto_resumable` in
+    /// `record_tests.rs`;
+    /// `a_live_leaked_test_pane_is_never_readopted_or_recreated` in
+    /// `naming_tests.rs`.
     pub fn is_leaked_test_adoption(&self) -> bool {
         trusty_common::session_naming::is_reserved_test_session_name(&self.tmux_name)
             && self.task.starts_with(ADOPTED_TASK)

--- a/crates/trusty-mpm/src/session_manager/record.rs
+++ b/crates/trusty-mpm/src/session_manager/record.rs
@@ -33,6 +33,22 @@ use super::injection_status::InjectionStatus;
 /// `is_resolved_existing_false_for_none_and_unknown_sentinel`.
 pub const UNRESOLVED_PATH_SENTINEL: &str = "/unknown";
 
+/// The `task` an AUTOMATIC adoption writes into the record it mints (#6116).
+///
+/// Why: it is the only field distinguishing a session the daemon ADOPTED from
+/// one it CREATED, and #6116's tombstone arm must act on the first and never on
+/// the second — a project legitimately named `xtest-…` derives a name in the
+/// reserved namespace, and its own sessions stay ordinary resumable sessions.
+/// What: `adopted session`, written by
+/// [`super::SessionManager::reconcile_on_boot`]'s external-adopt loop.
+/// [`SessionRecord::is_leaked_test_adoption`] matches it as a PREFIX, because
+/// `SessionManager::mark_errored` appends `[error: …]` to whatever task a
+/// record already carries.
+/// Test: `an_adopted_reserved_record_is_a_leaked_test_adoption`,
+/// `a_created_reserved_session_is_not_a_leaked_test_adoption` in
+/// `record_tests.rs`.
+pub const ADOPTED_TASK: &str = "adopted session";
+
 /// Opaque identifier for a managed session.
 ///
 /// Why: a newtype over [`Uuid`] prevents accidental confusion with other
@@ -549,7 +565,8 @@ impl SessionRecord {
     /// only `tm session decommission` stopped the loop. This predicate is the
     /// single place both paths ask the question, so the two cannot drift.
     /// What: `true` only for a `Stopped` record whose stop was not
-    /// [`StopCause::Deliberate`]. Every other state is `false`, including
+    /// [`StopCause::Deliberate`] and which is not a leaked test adoption
+    /// ([`Self::is_leaked_test_adoption`], #6116). Every other state is `false`, including
     /// `Errored` — neither caller relaunches those today, and this predicate
     /// answers "may an automatic path relaunch it", not "may it be resumed":
     /// an operator's own `tm session resume` is unaffected by this and still
@@ -565,6 +582,34 @@ impl SessionRecord {
     pub fn is_auto_resumable(&self) -> bool {
         matches!(self.state, ManagedSessionState::Stopped)
             && self.stop_cause != Some(StopCause::Deliberate)
+            // #6116: never relaunch a test's session. The reaper stamps a
+            // gone-tmux record `Unexpected` when other sessions are live, which
+            // is auto-resumable — so without this the supervisor RECREATES the
+            // leaked pane, reconcile re-adopts it, and the loop sustains itself
+            // (observed three times in one day's daemon log).
+            && !self.is_leaked_test_adoption()
+    }
+
+    /// Whether this record is an AUTOMATIC adoption of a session in the
+    /// test-owned namespace (#6116).
+    ///
+    /// Why: the one predicate every #6116 decision asks, so the boot
+    /// reconciler's tombstone arm and [`Self::is_auto_resumable`] cannot
+    /// disagree about which records are leaked test sessions. It deliberately
+    /// asks TWO questions: a reserved NAME alone would also match a session the
+    /// daemon created for a project legitimately named `xtest-…`, and that
+    /// session is real work — tombstoning or refusing to resume it would be the
+    /// defect, not the fix.
+    /// What: the tmux name is in
+    /// [`trusty_common::session_naming::RESERVED_TEST_PREFIX`] AND the task
+    /// begins with [`ADOPTED_TASK`], which only an automatic adoption writes.
+    /// Test: `an_adopted_reserved_record_is_a_leaked_test_adoption`,
+    /// `a_created_reserved_session_is_not_a_leaked_test_adoption`,
+    /// `an_ordinary_adopted_record_is_not_a_leaked_test_adoption` in
+    /// `record_tests.rs`.
+    pub fn is_leaked_test_adoption(&self) -> bool {
+        trusty_common::session_naming::is_reserved_test_session_name(&self.tmux_name)
+            && self.task.starts_with(ADOPTED_TASK)
     }
 
     /// Set this record's lifecycle state, keeping [`Self::terminal_at`]

--- a/crates/trusty-mpm/src/session_manager/record_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/record_tests.rs
@@ -574,6 +574,78 @@ fn from_wire_round_trips_every_variant() {
     assert_eq!(ManagedSessionState::from_wire(""), None);
 }
 
+/// #6116: the predicate's whole job is telling an ADOPTED test session apart
+/// from one the daemon created, so the matrix is asserted rather than assumed.
+///
+/// Why: keying on the reserved name alone would tombstone — and refuse to
+/// resume — the sessions of a project legitimately named `xtest-…`.
+/// Test: this function IS the test.
+#[test]
+fn leaked_test_adoption_requires_both_a_reserved_name_and_an_adopted_task() {
+    let reserved = format!(
+        "{}deadrt1234-01",
+        trusty_common::session_naming::RESERVED_TEST_PREFIX
+    );
+
+    let mut adopted = terminal_fixture();
+    adopted.tmux_name = reserved.clone();
+    adopted.task = ADOPTED_TASK.into();
+    assert!(adopted.is_leaked_test_adoption());
+
+    // `mark_errored` appends to the task, which must not shed the provenance.
+    let mut errored = adopted.clone();
+    errored.task = format!("{ADOPTED_TASK} [error: boom]");
+    assert!(errored.is_leaked_test_adoption());
+
+    // A session the daemon CREATED for a project named `xtest-…`.
+    let mut created = terminal_fixture();
+    created.tmux_name = reserved;
+    created.task = "implement feature X".into();
+    assert!(
+        !created.is_leaked_test_adoption(),
+        "a created session in the namespace is real work, not a leak"
+    );
+
+    // An ordinary adoption keeps every ordinary privilege.
+    let mut ordinary = terminal_fixture();
+    ordinary.tmux_name = "tm-trusty-tools-01".into();
+    ordinary.task = ADOPTED_TASK.into();
+    assert!(!ordinary.is_leaked_test_adoption());
+}
+
+/// #6116: the supervisor's per-tick sweep asks `is_auto_resumable`, and a `yes`
+/// there is what RECREATED a leaked test pane after the reaper stopped it —
+/// the loop that ran three times in one day's daemon log.
+///
+/// What: the exact record shape the reaper leaves behind (`Stopped` +
+/// `Unexpected`) for both a leaked adoption and a created session in the same
+/// namespace; only the first is refused.
+/// Test: this function IS the test.
+#[test]
+fn a_stopped_leaked_test_adoption_is_never_auto_resumable() {
+    let reserved = format!(
+        "{}deadrt1234-01",
+        trusty_common::session_naming::RESERVED_TEST_PREFIX
+    );
+
+    let mut leaked = terminal_fixture();
+    leaked.tmux_name = reserved.clone();
+    leaked.task = ADOPTED_TASK.into();
+    leaked.state = ManagedSessionState::Stopped;
+    leaked.stop_cause = Some(StopCause::Unexpected);
+    assert!(
+        !leaked.is_auto_resumable(),
+        "resuming this recreates the tmux session the next reconcile re-adopts"
+    );
+
+    let mut created = leaked.clone();
+    created.task = "implement feature X".into();
+    assert!(
+        created.is_auto_resumable(),
+        "an ordinary session in the namespace keeps post-reboot restore"
+    );
+}
+
 /// Build a minimal Active record for the `set_lifecycle_state` cases.
 fn terminal_fixture() -> SessionRecord {
     SessionRecord {

--- a/crates/trusty-mpm/src/session_manager/tests.rs
+++ b/crates/trusty-mpm/src/session_manager/tests.rs
@@ -1145,7 +1145,10 @@ async fn decommission_full_still_terminates_the_runtime() {
 
 // Build a minimal Active session record for reconcile tests (avoids repeating
 // 20-field struct literals when only tmux_name / task / ws_path vary).
-fn make_active_test_record(tmux_name: &str, task: &str, ws_path: &str) -> SessionRecord {
+// `pub(super)` since #6116: the sibling `naming_tests` reconcile coverage seeds
+// the same shape, and a second copy of a 27-field literal is one field addition
+// away from drifting.
+pub(super) fn make_active_test_record(tmux_name: &str, task: &str, ws_path: &str) -> SessionRecord {
     SessionRecord {
         id: ManagedSessionId::new(),
         tmux_name: tmux_name.into(),

--- a/crates/trusty-mpm/src/test_tmux_session.rs
+++ b/crates/trusty-mpm/src/test_tmux_session.rs
@@ -63,6 +63,14 @@ use std::sync::Once;
 /// an hour, so a survivor this old cannot belong to a run still in progress —
 /// which is what makes the sweep safe to run while sibling test binaries and
 /// other engineers' `cargo test` processes are using the same tmux server.
+///
+/// What it cannot tell apart: a tmux listing carries a name and a creation
+/// time, no provenance. On a machine running this suite, a session the DAEMON
+/// created for a project legitimately named `xtest-…` is killed here at 30
+/// minutes like any other. The daemon-side rules avoid that class of mistake by
+/// also requiring an adopted provenance
+/// ([`crate::session_manager::SessionRecord::is_leaked_test_adoption`]); this
+/// sweep has no record to ask.
 const STALE_SESSION_AGE_SECS: i64 = 1_800;
 
 /// Runs [`sweep_stale_reserved_sessions`] once per test process.

--- a/crates/trusty-mpm/src/test_tmux_session.rs
+++ b/crates/trusty-mpm/src/test_tmux_session.rs
@@ -28,10 +28,137 @@
 //! spelled `crate::…` in the lib and `trusty_mpm::…` in the bin, and no single
 //! spelling compiles in both.
 //!
+//! **What `Drop` cannot cover, and what does.** A `Drop` guard runs on an
+//! unwinding panic and on nothing else: a SIGKILL, a `cargo test` timeout, an
+//! aborted run and a killed terminal all end the process without unwinding, so
+//! the session survives. Three did on 2026-08-24. Two mechanisms cover that gap,
+//! and neither is this guard:
+//!
+//! * The daemon refuses to adopt any session named under
+//!   [`trusty_common::session_naming::RESERVED_TEST_PREFIX`] (#6116), so a
+//!   leaked one never becomes a record or a picker row, and stays visible to
+//!   `daemon::orphan_gc`, which kills an idle shell with no live child.
+//!   [`reserved_session_name`] and [`reserved_project_slug`] are the two ways a
+//!   fixture lands in that namespace — both build from the same constant the
+//!   daemon reads, so the mint and the refusal cannot drift.
+//! * [`ScratchTmuxSession::spawn`] sweeps stale reserved-namespace sessions
+//!   once per test process, so the NEXT run on this machine reaps what the last
+//!   one leaked. It is bounded by age
+//!   ([`STALE_SESSION_AGE_SECS`]) so a concurrently running suite is never
+//!   touched. What it does NOT do: reap anything before that next run happens,
+//!   reap on a machine where the suite never runs again, or help at all if tmux
+//!   is unreachable. It reduces how long a leak lives; the daemon-side refusal
+//!   is what makes the leak harmless while it does.
+//!
 //! Test: [`tests`] below — a session that outlives a panicking closure is gone
-//! afterwards, and a guard never touches a name it did not create.
+//! afterwards, a guard never touches a name it did not create, and the stale
+//! sweep selects by age and namespace.
 
 use std::process::Command;
+use std::sync::Once;
+
+/// Age past which a reserved-namespace session is certainly leaked (#6116).
+///
+/// Why: no test in this suite holds a tmux session for anything close to half
+/// an hour, so a survivor this old cannot belong to a run still in progress —
+/// which is what makes the sweep safe to run while sibling test binaries and
+/// other engineers' `cargo test` processes are using the same tmux server.
+const STALE_SESSION_AGE_SECS: i64 = 1_800;
+
+/// Runs [`sweep_stale_reserved_sessions`] once per test process.
+static SWEEP_ONCE: Once = Once::new();
+
+/// A tmux session name in the namespace the daemon refuses to adopt (#6116).
+///
+/// What: `tm-xtest-<tag>-<pid>`, unique per process so the two targets this
+/// file compiles into cannot collide in the machine-global tmux namespace when
+/// cargo runs them concurrently.
+/// Test: [`tests::a_minted_name_is_one_the_daemon_refuses`].
+pub(crate) fn reserved_session_name(tag: &str) -> String {
+    format!(
+        "{}{tag}-{}",
+        trusty_common::session_naming::RESERVED_TEST_PREFIX,
+        std::process::id()
+    )
+}
+
+/// The repo/project slug a fixture passes to `create_with_id` so the tmux name
+/// the daemon DERIVES lands in the reserved namespace (#6116).
+///
+/// Why: a fixture that seeds a record does not choose its `tmux_name` —
+/// `build_managed_session_name` derives `tm-<project>-NN` from the repo url. So
+/// the namespace has to be reached through the project slug, not by naming the
+/// session directly.
+/// What: the reserved prefix with `tm-` and the trailing dash removed
+/// (`xtest`), joined to `tag`. Feed it as the repo segment of a url and the
+/// derived name is `tm-xtest-<tag>-NN`.
+/// Test: [`tests::a_derived_project_slug_yields_a_reserved_name`]; end to end
+/// by `session_resume_headless_dead_runtime_reconciles_and_restarts`, which
+/// asserts the name it actually got is reserved.
+pub(crate) fn reserved_project_slug(tag: &str) -> String {
+    let leaf = trusty_common::session_naming::RESERVED_TEST_PREFIX
+        .strip_prefix(trusty_common::session_naming::PREFIX)
+        .unwrap_or(trusty_common::session_naming::RESERVED_TEST_PREFIX)
+        .trim_end_matches('-');
+    format!("{leaf}-{tag}")
+}
+
+/// Pick the reserved-namespace sessions in a `tmux list-sessions` listing that
+/// are older than `max_age_secs`.
+///
+/// Why: the selection is the whole risk in the sweep — killing a session a
+/// concurrent run still needs would be worse than the leak it cleans up — so it
+/// is a pure function over the listing text, testable without a tmux server.
+/// What: reads `<created-epoch> <session-name>` lines (the format
+/// [`sweep_stale_reserved_sessions`] requests, created first because a session
+/// name may contain spaces), and keeps names in the reserved namespace whose
+/// age exceeds `max_age_secs`. An unparseable line is skipped, never killed.
+/// Test: [`tests::stale_sweep_selects_only_old_reserved_sessions`].
+fn stale_reserved_names(listing: &str, now_epoch: i64, max_age_secs: i64) -> Vec<String> {
+    listing
+        .lines()
+        .filter_map(|line| line.trim_end().split_once(' '))
+        .filter_map(|(created, name)| Some((created.trim().parse::<i64>().ok()?, name)))
+        .filter(|(created, name)| {
+            now_epoch - created > max_age_secs
+                && trusty_common::session_naming::is_reserved_test_session_name(name)
+        })
+        .map(|(_, name)| name.to_string())
+        .collect()
+}
+
+/// Kill reserved-namespace sessions left behind by an earlier, hard-killed test
+/// process (#6116).
+///
+/// Why/What: see this module's docs — `Drop` cannot run after a SIGKILL, so the
+/// next run cleans up instead. Best-effort throughout: a tmux that will not
+/// answer (no server yet, no binary) simply sweeps nothing.
+/// Test: the selection half via [`stale_reserved_names`]; the kill half is the
+/// same `kill-session -t =<name>` call [`ScratchTmuxSession::drop`] makes.
+fn sweep_stale_reserved_sessions(tmux_bin: &str) {
+    let Ok(out) = Command::new(tmux_bin)
+        .args(["list-sessions", "-F", "#{session_created} #{session_name}"])
+        .output()
+    else {
+        return;
+    };
+    if !out.status.success() {
+        return;
+    }
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs() as i64);
+    for name in stale_reserved_names(
+        &String::from_utf8_lossy(&out.stdout),
+        now,
+        STALE_SESSION_AGE_SECS,
+    ) {
+        eprintln!("test-support: killing leaked test tmux session '{name}' (#6116)");
+        let _ = Command::new(tmux_bin)
+            .args(["kill-session", "-t", &format!("={name}")])
+            .output();
+    }
+}
 
 /// A real tmux session owned by a test, killed when this value drops.
 ///
@@ -56,6 +183,10 @@ impl ScratchTmuxSession {
     /// ownership claim honest: the caller gets no guard, so nothing later kills
     /// a session someone else created.
     pub(crate) fn spawn(tmux_bin: &str, name: &str, pane_command: &str) -> Self {
+        // #6116: reap what an earlier hard-killed run leaked, before adding to
+        // the namespace. Once per process, mirroring `test_support`'s
+        // `sweep_stale_test_dirs`.
+        SWEEP_ONCE.call_once(|| sweep_stale_reserved_sessions(tmux_bin));
         let status = Command::new(tmux_bin)
             .args(["new-session", "-d", "-s", name, pane_command])
             .status()
@@ -120,11 +251,62 @@ mod tests {
     /// Process-unique, so the two targets this file compiles into cannot
     /// collide in the machine-global tmux namespace when cargo runs them
     /// concurrently.
+    ///
+    /// #6116: minted through [`reserved_session_name`] — these tests spawn real
+    /// sessions, so a hard kill leaks THEM too, and the leak has to land in the
+    /// namespace the daemon refuses to adopt.
     fn scratch_name(tag: &str) -> String {
         let nanos = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map_or(0, |d| d.subsec_nanos());
-        format!("tm-scratchguard-{tag}-{}-{nanos}", std::process::id())
+        reserved_session_name(&format!("guard-{tag}-{nanos}"))
+    }
+
+    /// The mint and the daemon's refusal read the same constant, so a fixture
+    /// cannot drift out of the namespace that protects it.
+    #[test]
+    fn a_minted_name_is_one_the_daemon_refuses() {
+        let name = reserved_session_name("mint");
+        assert!(trusty_common::session_naming::is_reserved_test_session_name(&name));
+        // Still managed, so the orphan-GC keeps its first gate on the pane.
+        assert!(trusty_common::session_naming::is_managed_session_name(
+            &name
+        ));
+    }
+
+    /// A fixture that reaches the namespace through a derived name gets there
+    /// too: `tm-<project>-NN` built from the slug is reserved.
+    #[test]
+    fn a_derived_project_slug_yields_a_reserved_name() {
+        let derived = trusty_common::session_naming::build_managed_session_name(
+            Some(&reserved_project_slug("deadrt1234")),
+            std::path::Path::new("/tmp"),
+            &[],
+        )
+        .expect("derive a name");
+        assert!(
+            trusty_common::session_naming::is_reserved_test_session_name(&derived),
+            "a fixture's derived name must land in the reserved namespace, got {derived}"
+        );
+    }
+
+    /// The sweep's whole risk is what it selects: only the reserved namespace,
+    /// only past the age bound, and never a line it could not parse.
+    #[test]
+    fn stale_sweep_selects_only_old_reserved_sessions() {
+        let now = 1_000_000;
+        let listing = "\
+900000 tm-xtest-deadrt1-01
+999999 tm-xtest-running-now-01
+900000 tm-trusty-tools-01
+900000 work
+not-an-epoch tm-xtest-garbage-01
+";
+        assert_eq!(
+            stale_reserved_names(listing, now, STALE_SESSION_AGE_SECS),
+            vec!["tm-xtest-deadrt1-01".to_string()],
+            "only the aged, reserved, parseable session may be killed"
+        );
     }
 
     /// The defect #6116 reports, inverted into an assertion: the fixture panics


### PR DESCRIPTION
Refs #6116

## What leaked, and which half closes it

PR #6125's `ScratchTmuxSession` kills a test's real tmux session on panic. It
cannot run on a SIGKILL, a `cargo test` timeout, or an aborted run — those end
the process without unwinding. Three `tm-deadrt<pid>-01` sessions leaked that
way on 2026-08-24, the daemon's boot adoption sweep wrote a record for each, and
the picker grew three `(active)` ghosts whose records outlived the tmux
sessions.

**Half A — daemon (the fix).** Three rules, all reading one predicate:

- `reconcile_on_boot` refuses to adopt a live session whose name is under
  `trusty_common::session_naming::RESERVED_TEST_PREFIX` (`tm-xtest-`).
- A record one of those already produced is tombstoned, **whether its pane is
  live or gone** (`SessionRecord::is_leaked_test_adoption`).
- `is_auto_resumable` refuses the same records, closing the window between a
  reaper stop and the next boot.

Covers: every leak shape, past and future, because the decision reads the name
and needs no test-side cleanup to have run. It also returns the leaked pane to
`daemon::orphan_gc` — an untracked idle shell with no live child is killed there
after two sweeps, whereas adoption granted it immunity (#6118's finding, same
mechanism).

Does not cover: a leaked session outside the namespace, including the
`guided_fallback_prepares_the_session_in_the_worktree_not_the_base_clone`
fixture named in an earlier comment on this issue — its session is created
inside `launch()` rather than by the test, and moving it into the namespace
needs the fallback path's name derivation checked first. Left as a follow-up
rather than guessed at here.

**Why the live arm matters (code-critic HIGH, fixed).** The first cut guarded
only the unknown-name and gone-pane arms. A known record with a LIVE pane was
re-adopted `Active`, which restored its orphan-GC immunity; the reaper then
stamped the dead pane `Unexpected` (auto-resumable), the supervisor recreated
the tmux session, and the next reconcile re-adopted it. Today's daemon log shows
that cycle three times (`resume: kill stale session failed … managed session
resumed: recreated pane`, 10:24:55 / 18:48:15 / 20:09:02), and
`reap_managed_against` never escapes it because the pane is alive. The tombstone
now runs before the live/gone branch: the record is a leaked test adoption
either way, so the answer is the same either way.

**Scoping (code-critic MEDIUM, fixed).** `is_leaked_test_adoption` asks for a
reserved name AND an adopted provenance (`task` starting with `ADOPTED_TASK`,
which only the automatic adopt path writes). A session the daemon CREATED for a
project legitimately named `xtest-…` therefore keeps ordinary stop, resume and
list behavior. Two consequences remain and are now stated in the constant's doc:
such a project's sessions are never auto-adopted, and on a machine running this
suite the tmux-level sweep kills one after 30 minutes — a tmux listing carries a
name and a creation time, no provenance.

**Observability (code-critic MEDIUM, fixed).** `reserved_test_refused` and
`reserved_test_swept` now count in the boot summary's log gate and fields, so a
boot whose only finding was a refusal no longer prints nothing — the omission
shape #6118 fixed with `n_declined`.

**Known asymmetry (code-critic Parent LOW, recorded, no code change).**
`adopt_existing` (`adopt.rs:214-217`) still accepts a reserved name an operator
names explicitly. That path's standing contract is that it adopts ANY name the
operator asks for; only the automatic sweep is narrowed here.

**Half B — test side (defense in depth, incomplete by construction).** The
`#3873` fixture mints its session inside the namespace (asserted in the test, so
a drift in name derivation fails loudly), and `ScratchTmuxSession::spawn` sweeps
reserved sessions older than 30 minutes once per test process.

- Covers: a leak from an earlier hard-killed run gets reaped by the next run on
  that machine.
- Does not cover: anything before that next run happens, a machine where the
  suite never runs again, or an unreachable tmux. **No test-side mechanism
  survives a SIGKILL of its own process.** The age bound is what keeps a
  concurrently running suite untouched.

## Where the constant lives

`RESERVED_TEST_PREFIX` sits in `trusty_common::session_naming` beside `PREFIX`
and `is_managed_session_name` — the daemon that refuses the name and the
test-support helpers that mint one (`reserved_session_name`,
`reserved_project_slug`) both read it, so the two cannot drift. It starts with
`tm-`, so a session in it is still managed and still orphan-GC eligible.

## Gates — rung 5

Cross-crate contract plus daemon process lifecycle, so rung 4 on the library
plus failure-path coverage and a critic round. Re-run after the critic fixes.
Auto-merge deliberately not armed.

```
cargo fmt --check                                              EXIT=0
cargo check --workspace --all-targets                          EXIT=0
cargo clippy -p trusty-mpm --all-targets -- -D warnings        EXIT=0
cargo clippy -p trusty-common --features session-naming \
      --all-targets -- -D warnings                             EXIT=0
bash scripts/check_line_cap.sh      4169 files, 0 violations — OK
bash scripts/check_sld.sh           0 errors, 0 warnings
bash scripts/check_changelog_fragment.sh   trusty-common OK, trusty-mpm OK
```

```
cargo test -p trusty-common --features session-naming
test result: ok. 421 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out

cargo test -p trusty-mpm
test result: ok. 5264 passed; 0 failed; 7 ignored   (lib)
test result: ok. 1784 passed; 0 failed; 1 ignored   (bin tm)
test result: ok. 1784 passed; 0 failed; 1 ignored   (bin trusty-mpm)
+ 47 integration binaries — 50 `test result: ok` lines, 0 FAILED

cargo test -p trusty-mpm --lib -- --include-ignored session_manager daemon::state
test result: ok. 679 passed; 0 failed; 0 ignored; 0 measured; 4592 filtered out
```

The three known flakes (`hook_flags_idle_parking`, `live_pane_scoped_send`, the
#6230 timing flake) passed in that full run.

## Fail-first proof

**Loop exit (the critic's HIGH).** With the guard moved back onto the gone arm
only — the shape the critic flagged — and everything else in place:

```
test session_manager::naming_tests::a_live_leaked_test_pane_is_never_readopted_or_recreated ... FAILED
assertion `left == right` failed: a live leaked pane must not keep its record Active — that is what sustained the loop
  left: Active
 right: Deleted
```

The test reconciles with `auto_resume` ON — the loop's fuel — and pins the exit:
the record ends terminal and un-auto-resumable, the name is absent from
`report.adopted`, no session is created (the supervisor's recreate), and no
session is killed (ending the pane stays the orphan-GC's decision, which spares
a pane that is not an idle shell).

**No automatic relaunch.** With the `is_auto_resumable` clause removed:

```
test session_manager::record::tests::a_stopped_leaked_test_adoption_is_never_auto_resumable ... FAILED
resuming this recreates the tmux session the next reconcile re-adopts
```

**Original two, from the first round** (only the `reconcile.rs` behavior
reverted, report fields kept so they compiled):

```
test session_manager::naming_tests::reconcile_tombstones_a_reserved_test_record_whose_tmux_is_gone ... FAILED
  left: Stopped   right: Deleted

test session_manager::naming_tests::reconcile_refuses_to_adopt_a_reserved_test_session ... FAILED
  left: 1   right: 0   (a leaked test session must leave no record for the picker to show)
```

All four pass with the change in place. The adoption test hands the pane a
resolvable cwd, so it proves the refusal is by name and not #6118's decline; the
tombstone test now carries two paired records — an ordinary session and a
CREATED `tm-xtest-foo-01` — that must both still end `Stopped`.

## Live check

`cargo test -p trusty-mpm --bin tm session_resume_headless_dead_runtime_reconciles_and_restarts`
passed, and `tmux ls` reported 0 `xtest` sessions and an unchanged session count
afterwards. New hermetic tests use `FakeTmuxDriver` / `PaneCwdTmux` and temp
state; no live daemon was touched.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
