### PR TITLE
fix(trusty-common): every palace on the fleet is answered exactly (Refs #5179)

### DIFF
--- a/crates/trusty-common/changelog.d/5179-exhaustive-ceiling-4096.md
+++ b/crates/trusty-common/changelog.d/5179-exhaustive-ceiling-4096.md
@@ -1,0 +1,12 @@
+Fixed
+
+- Memory-palace vector search is now exact for every palace this fleet holds.
+  `HnswStore::search` scans every point up to 4096 live drawers (was 1024), so
+  the sizes that still went through the HNSW graph are answered exactly.
+  Measured on this repo's own palace embeddings, queries losing a true top-10
+  neighbour fell from 28.1% to 0% at 1025 live vectors, 14.9% to 0% at 1354,
+  14.9% to 0% at 2048 and 20.5% to 0% at 2879 — the largest palace on this
+  machine holds about 2900. The scan is linear, so a query over 4096 points
+  costs about 1.4ms against 0.43ms over 1024; above 4096 the graph arm is still
+  approximate. Nothing migrates: no graph is persisted, and every palace open
+  rebuilds the index from its stored vectors. (#5179)

--- a/crates/trusty-common/src/memory_core/store/hnsw_store/exhaustive.rs
+++ b/crates/trusty-common/src/memory_core/store/hnsw_store/exhaustive.rs
@@ -32,19 +32,21 @@ use redb::ReadableTable;
 /// Live-drawer ceiling at or below which [`super::HnswStore::search`] scans
 /// exhaustively instead of traversing the graph.
 ///
-/// Why (#5171, raised 256 → 1024 by #5179): the recall loss this scan removes
-/// does not stop at 256 — #5171 set the bound on cost, not on where the defect
-/// ends, and the regime it left behind was measured on this repo's own palace
-/// embeddings at 17.4% of queries losing a true top-10 neighbour at 512 points
-/// and 24.5% at 1024. Exactness is worth buying wherever it is affordable, and
-/// at 1024 points the scan costs on the order of 400µs per query — the same
-/// order as the graph traversal it replaces there, because with a candidate
-/// budget scaled to the collection (see [`super::graph_arm`]) the traversal
-/// evaluates a comparable number of distances anyway. Past 1024 the scan's
-/// linear cost stops being repayable and HNSW's sublinear cost is worth its
-/// approximation, which is the trade the algorithm exists to make. The palace
-/// this repo keeps for itself holds ~2100 live vectors, so the regime above the
-/// bound is real and not hypothetical; #5179 narrows it rather than closing it.
+/// Why (#5171, raised 256 → 1024 → 4096 under #5179): the recall loss this scan
+/// removes does not stop where a previous ceiling was placed. Each raise set the
+/// bound on cost, not on where the defect ends. Above 1024 the graph arm still
+/// lost a true top-10 neighbour on 14.9% of queries at 1354 live vectors, 14.9%
+/// at 2048 and 20.5% at 2879, measured on this repo's own palace embeddings with
+/// `ef` already scaled to the collection (see [`super::graph_arm`]) — scaling
+/// narrows that regime, it does not close it.
+///
+/// The price is a linear scan, timed against the same real 384-dim embeddings:
+/// 428µs per query at 1024 points, 711µs at 2048, 986µs at 2879, and 1.40ms at
+/// 4096. 4096 is where that price stops being worth paying, and it is above
+/// every palace on this machine — the largest holds ~2900 live vectors — so the
+/// whole fleet is now answered exactly. The graph arm keeps the regime past
+/// 4096, where a linear scan is no longer repayable and HNSW's sublinear cost is
+/// worth its approximation; that is the trade the algorithm exists to make.
 ///
 /// Nothing migrates when this number changes: no graph is persisted, and
 /// `HnswStore::open_with_mode` rebuilds the index from the raw `VECTORS` rows on
@@ -52,8 +54,8 @@ use redb::ReadableTable;
 /// What: compared against the number of LIVE drawers — `VECTOR_KEYS` rows, the
 /// `reverse` map `search` builds two statements earlier. Not
 /// `Hnsw::get_nb_point()`, which also counts tombstoned points and re-upsert
-/// shadows: those accumulate within a session, so a palace of 200 real drawers
-/// could drift past 256 graph points mid-session and silently revert to the
+/// shadows: those accumulate within a session, so a palace of 2900 real drawers
+/// could drift past 4096 graph points mid-session and silently revert to the
 /// path this module exists to replace. Scan cost does follow the graph count,
 /// but the overhang is bounded by churn since the last open — one extra point
 /// per delete or re-upsert, and `HnswStore::open` rebuilds one point per live
@@ -61,9 +63,9 @@ use redb::ReadableTable;
 /// Test: `search_uses_the_graph_above_the_exhaustive_threshold`,
 /// `search_is_exact_at_the_exhaustive_threshold`,
 /// `deleting_drawers_does_not_push_a_small_palace_off_the_exhaustive_path`.
-// #5179: raised from 256 so the whole regime #5171 measured as still lossy is
-// answered exactly.
-pub(super) const EXHAUSTIVE_SCAN_MAX_POINTS: usize = 1024;
+// #5179: raised to 4096 so every palace on the fleet — the largest holds ~2900
+// live vectors — is answered exactly rather than approximately.
+pub(super) const EXHAUSTIVE_SCAN_MAX_POINTS: usize = 4096;
 
 /// Every live point in `index`, ranked by exact distance to `query`, best
 /// first — the whole ranking, not a prefix of it.

--- a/crates/trusty-common/src/memory_core/store/hnsw_store/graph_arm.rs
+++ b/crates/trusty-common/src/memory_core/store/hnsw_store/graph_arm.rs
@@ -55,19 +55,25 @@ const HNSW_EF_LIVE_DIVISOR: usize = 4;
 /// embeddings on an M-series laptop, a 384-dim query over ~2900 drawers takes
 /// about 0.5ms at `ef = 64` and about 2.2ms at `ef = 719`, and 1024 puts the
 /// ceiling at roughly 3ms — the most this store is willing to spend answering
-/// one recall. That the number also equals
-/// [`super::EXHAUSTIVE_SCAN_MAX_POINTS`] is a coincidence of two independent
-/// choices, NOT a cost equivalence: an `ef = 1024` traversal costs several times
-/// what scanning 1024 points costs, because each unit of `ef` carries heap and
-/// visited-set work a flat sequential scan does not. What the cap does buy is
-/// that per-query cost stops growing with the palace, which is the whole reason
-/// this arm exists. It binds from `live = 4096` upward.
+/// one recall. It is not a cost equivalence with a 1024-point scan: an
+/// `ef = 1024` traversal costs several times what scanning 1024 points costs,
+/// because each unit of `ef` carries heap and visited-set work a flat sequential
+/// scan does not. What the cap does buy is that per-query cost stops growing
+/// with the palace, which is the whole reason this arm exists.
 ///
-/// The recall it buys is real but partial: on real embeddings the scaled `ef`
-/// took top-10 misses from 23.3% of queries to 17.7% at 2048 drawers and from
-/// 20.2% to 15.6% at 2879. #5179 narrows the gap above the exhaustive threshold;
-/// closing it needs a different index structure or a rerank pass, not a larger
-/// number here.
+/// The cap binds from `live = 4096` upward, and since #5179 raised
+/// [`super::EXHAUSTIVE_SCAN_MAX_POINTS`] to 4096 that is every collection this
+/// arm sees: the `live / 4` ramp now lies entirely inside the exhaustive
+/// regime, so in practice `ef` here is this constant. The ramp is kept because
+/// it is what the ceiling would fall back onto if the scan's cost ever forces
+/// the ceiling down again, and because the divisor is the thing that would have
+/// to change for the cap to bind later rather than immediately.
+///
+/// The recall it buys is real but partial: with the scaled `ef` in place, real
+/// embeddings still lost a true top-10 neighbour on 14.9% of queries at 2048
+/// live drawers and 20.5% at 2879 — sizes now answered by the scan. Closing the
+/// gap that remains above 4096 needs a different index structure or a rerank
+/// pass, not a larger number here.
 /// What: clamps the SCALED term only. A caller asking for a large `top_k` still
 /// gets `2k`, because returning fewer results than asked for is a different
 /// defect from spending too long finding them.

--- a/crates/trusty-common/src/memory_core/store/hnsw_store/tests.rs
+++ b/crates/trusty-common/src/memory_core/store/hnsw_store/tests.rs
@@ -851,7 +851,7 @@ fn search_returns_the_exact_top_k_below_the_exhaustive_threshold() {
 fn search_uses_the_graph_above_the_exhaustive_threshold() {
     assert_eq!(
         exhaustive::EXHAUSTIVE_SCAN_MAX_POINTS,
-        1024,
+        4096,
         "changing this bound changes the cost profile of every recall; \
          update the measurement in exhaustive.rs before changing the number"
     );
@@ -996,7 +996,8 @@ fn search_drops_a_shadowed_candidate_whose_vector_row_is_gone() {
 /// churn past the threshold within one session and silently revert to the
 /// approximate path — the fix disabling itself with no signal.
 /// What: fills a store past the threshold, deletes back down to a handful of
-/// live drawers (leaving 300 points in the graph), and asserts search is exact
+/// live drawers (every inserted point stays in the graph, so it holds
+/// `EXHAUSTIVE_SCAN_MAX_POINTS + 44` of them), and asserts search is exact
 /// again — which only holds on the scan path.
 /// Test: this test itself is the verification.
 #[test]
@@ -1158,16 +1159,17 @@ fn upsert_marks_a_shadow_before_the_graph_can_serve_it() {
     );
 }
 
-/// Why (#5179): #5178 bought exactness up to 256 and left 17.4% of queries
-/// losing a true top-10 neighbour at 512 and 24.5% at 1024, measured on this
-/// repo's own palace embeddings. Raising the bound to 1024 is only worth
-/// anything if the whole range up to it is actually answered exactly, and the
-/// seam is where a rounding or `<` / `<=` slip would hide: a palace holding
-/// EXACTLY the threshold count must still take the scan.
+/// Why (#5179): the ceiling has been raised twice — to 1024, then to 4096 —
+/// because the graph arm kept losing a true top-10 neighbour above it: 14.9% of
+/// queries at 1354 live vectors, 14.9% at 2048 and 20.5% at 2879, measured on
+/// this repo's own palace embeddings. A raise is only worth anything if the
+/// whole range up to the new number is actually answered exactly, and the seam
+/// is where a rounding or `<` / `<=` slip would hide: a palace holding EXACTLY
+/// the threshold count must still take the scan.
 /// What: fills a store with exactly `EXHAUSTIVE_SCAN_MAX_POINTS` drawers and
 /// asserts `search` returns the brute-force top-10 for 20 queries, in order.
-/// Deterministic — the scan is exact, so this cannot flake. On `origin/main`,
-/// where the bound is 256, a 1024-drawer store takes the graph and this fails.
+/// Deterministic — the scan is exact, so this cannot flake. Against the previous
+/// bound of 1024 a 4096-drawer store takes the graph and this fails.
 /// Test: this test itself is the verification.
 #[test]
 fn search_is_exact_at_the_exhaustive_threshold() {
@@ -1217,6 +1219,12 @@ fn search_is_exact_at_the_exhaustive_threshold() {
 /// What: asserts the floor holds for a small palace, that the live count drives
 /// the value between the floor and the cap, that the cap binds from 4096 live
 /// drawers upward, and that a large `top_k` is not clipped by the cap.
+///
+/// The floor and ramp cases are assertions about the formula, not about live
+/// behaviour: since #5179 put `EXHAUSTIVE_SCAN_MAX_POINTS` at 4096, every
+/// collection that reaches this arm is already at the cap, so `graph_ef_search`
+/// answers `HNSW_MAX_EF_SEARCH` for all of them. They are pinned anyway because
+/// the ramp is what a lowered ceiling would fall back onto.
 /// Test: this test itself is the verification.
 #[test]
 fn graph_ef_search_scales_with_live_count_and_stops_at_the_cap() {
@@ -1243,6 +1251,12 @@ fn graph_ef_search_scales_with_live_count_and_stops_at_the_cap() {
         graph_ef_search(10, 4096),
         1024,
         "the cap binds exactly at 4096"
+    );
+    assert_eq!(
+        graph_ef_search(10, exhaustive::EXHAUSTIVE_SCAN_MAX_POINTS + 1),
+        1024,
+        "the smallest collection this arm actually sees is already at the cap \
+         (#5179)"
     );
     assert_eq!(
         graph_ef_search(10, 100_000),


### PR DESCRIPTION
Refs #5179

Raises `EXHAUSTIVE_SCAN_MAX_POINTS` (`crates/trusty-common/src/memory_core/store/hnsw_store/exhaustive.rs`) from 1024 to 4096, so `HnswStore::search` answers every palace on this fleet by exact scan instead of by HNSW traversal. #6226 made recall exact through 1024 and scaled `ef` above it; the regime it left is what this closes. Nothing migrates — no graph is persisted, and `open_with_mode` rebuilds the index from the stored vectors on every open.

## Recall on real palace embeddings

Read-only copies of nine palace `.redb` files, 3269 real 384-dim embeddings. For each size: 4 independently seeded store builds × 250 held-out real vectors as queries, k=10, compared against a brute-force ranking over the same index set. A query is "lossy" when its returned top-10 is not the brute-force top-10.

| live vectors | before: queries missing a true top-10 neighbour | after | before: mean search | after: mean search |
|---|---|---|---|---|
| 1024 (control — scan both sides) | 0.0% | 0.0% | 332µs | 349µs |
| 1025 | 28.1% | 0.0% | 331µs | 349µs |
| 1354 | 14.9% | 0.4%* | 451µs | 444µs |
| 2048 | 14.9% | 0.0% | 629µs | 664µs |
| 2879 (largest real palace) | 20.5% | 0.0% | 854µs | 853µs |

\* Ties, not losses. `positions_degraded` is 0 at every size after the change: for every rank i the returned distance equals the true distance, so the returned ranking IS the exact top-10 and the id difference is two drawers holding identical embeddings.

Raw:

```
BEFORE (ceiling 1024)
n= 1024  queries= 1000  not_exact=    0 (  0.00%)  missed_a_true_neighbour=    0 (  0.00%)  neighbours_missed=    0/10000  ( 0.00%)  positions_degraded=    0  short=0  mean_search=331.6µs
n= 1025  queries= 1000  not_exact=  268 ( 26.80%)  missed_a_true_neighbour=  281 ( 28.10%)  neighbours_missed=  701/10000  ( 7.01%)  positions_degraded= 1813  short=0  mean_search=330.9µs
n= 1354  queries= 1000  not_exact=  141 ( 14.10%)  missed_a_true_neighbour=  149 ( 14.90%)  neighbours_missed=  199/10000  ( 1.99%)  positions_degraded=  768  short=0  mean_search=451.1µs
n= 2048  queries= 1000  not_exact=  123 ( 12.30%)  missed_a_true_neighbour=  149 ( 14.90%)  neighbours_missed=  291/10000  ( 2.91%)  positions_degraded=  746  short=0  mean_search=629.0µs
n= 2879  queries= 1000  not_exact=  143 ( 14.30%)  missed_a_true_neighbour=  205 ( 20.50%)  neighbours_missed=  504/10000  ( 5.04%)  positions_degraded=  766  short=0  mean_search=853.9µs

AFTER (ceiling 4096)
n= 1024  queries= 1000  not_exact=    0 (  0.00%)  missed_a_true_neighbour=    0 (  0.00%)  neighbours_missed=    0/10000  ( 0.00%)  positions_degraded=    0  short=0  mean_search=348.7µs
n= 1025  queries= 1000  not_exact=    0 (  0.00%)  missed_a_true_neighbour=    0 (  0.00%)  neighbours_missed=    0/10000  ( 0.00%)  positions_degraded=    0  short=0  mean_search=348.8µs
n= 1354  queries= 1000  not_exact=    0 (  0.00%)  missed_a_true_neighbour=    4 (  0.40%)  neighbours_missed=    8/10000  ( 0.08%)  positions_degraded=    0  short=0  mean_search=443.7µs
n= 2048  queries= 1000  not_exact=    0 (  0.00%)  missed_a_true_neighbour=    0 (  0.00%)  neighbours_missed=    0/10000  ( 0.00%)  positions_degraded=    0  short=0  mean_search=663.8µs
n= 2879  queries= 1000  not_exact=    0 (  0.00%)  missed_a_true_neighbour=    4 (  0.40%)  neighbours_missed=    4/10000  ( 0.04%)  positions_degraded=    0  short=0  mean_search=853.2µs
```

Graph construction is seeded from OS entropy, so the before numbers move a few points between runs; an earlier run of the same probe reported 28.1% at 1025 as 32.4%. The after numbers are structurally 0 — the scan is exact, not lucky.

## Cost

Linear cosine scan over the same real embeddings, 500 reps:

```
n= 1024  per-scan=   427.9µs
n= 2048  per-scan=   711.4µs
n= 2879  per-scan=   986.3µs
n= 4096  per-scan=  1404.3µs
```

Mean end-to-end search barely moves in the table above, because at these sizes the traversal the scan replaces was already evaluating a comparable number of distances and both arms pay the same redb reverse-map build.

## Consequence recorded, not fixed

`HNSW_MAX_EF_SEARCH` is 1024 and `graph_ef_search` scales as `live / 4`, so the cap binds from `live = 4096` upward. With the ceiling now at 4096, every collection that reaches the graph arm is already at the cap: the ramp lies entirely inside the exhaustive regime and `ef` there is effectively constant. Behaviour is unchanged; `graph_arm.rs` now says so, and a new assertion pins that the smallest collection this arm sees is at the cap.

## Tests

- `search_uses_the_graph_above_the_exhaustive_threshold` — the ceiling guard now pins 4096, and the graph arm still answers at ceiling + 1.
- `search_is_exact_at_the_exhaustive_threshold` — a store of exactly 4096 drawers returns the brute-force top-10 for 20 queries. Against the old ceiling of 1024 this test fails on the real defect, not on the guard assertion:

```
assertion `left == right` failed: query 3: a palace holding exactly 4096 drawers must be answered exactly (#5179)
  left: [..., "8fca9598-b975-4f7e-a28e-34f256bf68f3", "2c8fd3d8-bc5f-4af8-8ec7-2cbfd67bf729", ...]
 right: [..., "8fca9598-b975-4f7e-a28e-34f256bf68f3", "aded3059-8729-41f5-bc0f-fc2adf278e07", "2c8fd3d8-bc5f-4af8-8ec7-2cbfd67bf729", ...]
test result: FAILED. 0 passed; 1 failed
```

- `graph_ef_search_scales_with_live_count_and_stops_at_the_cap` — adds the ceiling + 1 case.
- The three tests that must sit above the threshold now build ceiling-sized stores, so the `hnsw_store` module takes 115s where it took 28s. The cost is redb's per-upsert commit, and it is the price of testing the arm boundary where the boundary actually is.

## Gates — rung 4 (`trusty-common` is a shared library)

| gate | result |
|---|---|
| `cargo fmt --check` | EXIT=0 |
| `cargo clippy -p trusty-common --features memory-core,embedder-test-support --all-targets -- -D warnings` | EXIT=0 |
| `cargo test -p trusty-common --features memory-core,embedder-test-support` | 1163 passed; 0 failed; 14 ignored |
| `cargo check --workspace` | EXIT=0 |
| `cargo test -p trusty-memory` | 932 passed; 0 failed; 14 ignored |
| `cargo test -p trusty-mpm` | 9190 passed; 0 failed; 18 ignored |
| `cargo test -p trusty-agents` | 3565 passed; 0 failed; 16 ignored |
| `cargo test -p tga` | 1358 passed; 0 failed; 9 ignored |
| `cargo test -p trusty-cto-db` | 12 passed; 0 failed; 0 ignored |
| `scripts/check_line_cap.sh` | 0 violations |
| `scripts/check_changelog_fragment.sh` | fragment present and valid |
| `scripts/check_sld.sh` | 0 errors, 0 warnings |

Consumers are every crate enabling `trusty-common`'s `memory-core` feature. No version bump: in-tree `trusty-common` is 0.43.1, ahead of the published 0.43.0.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
