### PR TITLE
fix(trusty-mpm): a prune-filter doc link resolves the module it actually lives in

### DIFF
--- a/crates/trusty-mpm/changelog.d/6118-fix-dangling-doc-link.md
+++ b/crates/trusty-mpm/changelog.d/6118-fix-dangling-doc-link.md
@@ -1,0 +1,3 @@
+Fixed
+
+- **`PruneFilter::Unresolvable`'s doc comment now links to a symbol that actually exists.** The link pointed to `super::record::SessionRecord::workspace_unresolvable`, but `prune_types.rs` loads as the `types` submodule of `prune` (via `#[path = "prune_types.rs"]`), so `super` resolved to `prune`, which has no `record` submodule — `cargo doc`'s broken-intra-doc-link gate failed deterministically. The link now uses the crate-absolute path `crate::session_manager::record::SessionRecord::workspace_unresolvable` ([#6118](https://github.com/bobmatnyc/trusty-tools/issues/6118))

--- a/crates/trusty-mpm/src/session_manager/prune_types.rs
+++ b/crates/trusty-mpm/src/session_manager/prune_types.rs
@@ -46,7 +46,7 @@ pub enum PruneFilter {
     /// and deleted.
     All,
     /// Only records naming no resolvable workspace —
-    /// [`SessionRecord::workspace_unresolvable`](super::record::SessionRecord::workspace_unresolvable)
+    /// [`SessionRecord::workspace_unresolvable`](crate::session_manager::record::SessionRecord::workspace_unresolvable)
     /// (#6118).
     ///
     /// Why this exists as its own variant rather than as a flag on the others:


### PR DESCRIPTION
## Summary

Refs #6118. Follow-up to #6219, which added `PruneFilter::Unresolvable` with a doc link to `super::record::SessionRecord::workspace_unresolvable`. `prune_types.rs` loads as the `types` submodule of `prune` (`#[path = "prune_types.rs"] mod types;` in `prune.rs`), so `super` there resolves to `prune`, not `session_manager` — `prune` has no `record` submodule. The pre-publish rustdoc-links gate (Gate 1) failed deterministically: "no item named `record` in module `prune`". The link now points at the crate-absolute path `crate::session_manager::record::SessionRecord::workspace_unresolvable`.

No version bump — comment-only change to `crates/trusty-mpm/src/session_manager/prune_types.rs`.

## Test plan

Rung 1 (doc-only symbol reference inside a src file) plus the exact gate this PR fixes:

```
$ SKIP_UI_BUILD=1 RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links" cargo doc -p trusty-mpm --no-deps --keep-going
...
EXIT=0   (previously: EXIT=101, "error: unresolved link to `super::record::SessionRecord::workspace_unresolvable`")

$ cargo check -p trusty-mpm
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.22s
EXIT=0

$ cargo fmt --check -p trusty-mpm
EXIT=0

$ bash scripts/check_test_pointers.sh
test-pointers: resolved 26662 Test: citation(s) (floor 5000) — 0 dangling pointers — OK.
```

Changelog fragment added at `crates/trusty-mpm/changelog.d/6118-fix-dangling-doc-link.md` (Fixed category) since this is a `src/**` change per `scripts/check_changelog_fragment.sh`'s path-based rule.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools