### PR TITLE
fix(ui): the build that empties dist/ re-stamps ui-source-hash.txt (Refs #5936)

### DIFF
--- a/crates/trusty-analyze/ui/dist/ui-source-hash.txt
+++ b/crates/trusty-analyze/ui/dist/ui-source-hash.txt
@@ -1,4 +1,4 @@
 # Digest of the UI source this bundle was built from (#3606).
 # Written by scripts/stamp-ui-bundle.sh — regenerate by rebuilding, never by hand.
 # Verified by scripts/check-ui-bundle-freshness.sh (preflight-publish.sh CHECK 7).
-614b891e3b4e179ef13cefaec98a24aeb1c40874 21
+20f3f779ebb07fa06f2e5d872d049c65c1575152 21

--- a/crates/trusty-analyze/ui/vite.config.js
+++ b/crates/trusty-analyze/ui/vite.config.js
@@ -1,5 +1,8 @@
 import { defineConfig } from 'vite';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
+// #5936: emptyOutDir below deletes the tracked ui-source-hash.txt; this
+// re-writes it after the build that removed it.
+import { stampUiBundle } from '../../../scripts/lib/vite-stamp-bundle.mjs';
 
 // Why: trusty-analyzer embeds the built dist/ directly in the Rust binary via
 // include_dir!, so we want a self-contained, relative-path-friendly bundle.
@@ -8,7 +11,7 @@ import { svelte } from '@sveltejs/vite-plugin-svelte';
 // during `pnpm dev`.
 // Test: `pnpm build` produces ui/dist/index.html and ui/dist/assets/*.
 export default defineConfig({
-  plugins: [svelte()],
+  plugins: [svelte(), stampUiBundle('trusty-analyze')],
   base: './',
   // Why: Svelte 5 exports map 'browser' → real client runtime and 'default' →
   // throwing SSR stub. Without pinning 'browser', Vite resolves to the SSR

--- a/crates/trusty-console/ui/dist/ui-source-hash.txt
+++ b/crates/trusty-console/ui/dist/ui-source-hash.txt
@@ -1,4 +1,4 @@
 # Digest of the UI source this bundle was built from (#3606).
 # Written by scripts/stamp-ui-bundle.sh — regenerate by rebuilding, never by hand.
 # Verified by scripts/check-ui-bundle-freshness.sh (preflight-publish.sh CHECK 7).
-57cb1a4f3b6c19a25d2f27ce5fb5e2afe14e4d66 21
+5a5849ce69ada4089d7c1b3aee52b0f5b7d954b8 21

--- a/crates/trusty-console/ui/vite.config.js
+++ b/crates/trusty-console/ui/vite.config.js
@@ -1,5 +1,8 @@
 import { defineConfig } from 'vite';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
+// #5936: emptyOutDir below deletes the tracked ui-source-hash.txt; this
+// re-writes it after the build that removed it.
+import { stampUiBundle } from '../../../scripts/lib/vite-stamp-bundle.mjs';
 
 // Why: Svelte 5 ships separate browser and server export conditions in its
 // package.json exports map. Without pinning the 'browser' condition, Vite
@@ -12,7 +15,7 @@ import { svelte } from '@sveltejs/vite-plugin-svelte';
 // Test: Build with `pnpm run build`; the resulting bundle must not contain
 // the SSR stub and must mount without throwing in a browser.
 export default defineConfig({
-  plugins: [svelte()],
+  plugins: [svelte(), stampUiBundle('trusty-console')],
   base: '/ui/',
   resolve: {
     conditions: ['browser', 'module', 'import', 'default'],

--- a/crates/trusty-memory/ui/dist/ui-source-hash.txt
+++ b/crates/trusty-memory/ui/dist/ui-source-hash.txt
@@ -1,4 +1,4 @@
 # Digest of the UI source this bundle was built from (#3606).
 # Written by scripts/stamp-ui-bundle.sh — regenerate by rebuilding, never by hand.
 # Verified by scripts/check-ui-bundle-freshness.sh (preflight-publish.sh CHECK 7).
-2280db7d8d060f53d5a9f9aa6e3242c092824347 25
+9b8524e48bb0fcb7bddf2de059506d369ca5c64e 25

--- a/crates/trusty-memory/ui/vite.config.js
+++ b/crates/trusty-memory/ui/vite.config.js
@@ -1,5 +1,8 @@
 import { defineConfig } from 'vite';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
+// #5936: emptyOutDir below deletes the tracked ui-source-hash.txt; this
+// re-writes it after the build that removed it.
+import { stampUiBundle } from '../../../scripts/lib/vite-stamp-bundle.mjs';
 
 // Why: trusty-memory embeds the built dist/ directly in the Rust binary via
 // rust-embed, so we want a self-contained, relative-path-friendly bundle.
@@ -9,7 +12,7 @@ import { svelte } from '@sveltejs/vite-plugin-svelte';
 // binds elsewhere).
 // Test: `pnpm build` produces ui/dist/index.html and ui/dist/assets/*.
 export default defineConfig({
-  plugins: [svelte()],
+  plugins: [svelte(), stampUiBundle('trusty-memory')],
   base: './',
   // Why: Svelte 5 exports map 'browser' → real client runtime and 'default' →
   // throwing SSR stub. Without pinning 'browser', Vite resolves to the SSR

--- a/scripts/check-ui-bundle-freshness-selftest.sh
+++ b/scripts/check-ui-bundle-freshness-selftest.sh
@@ -491,6 +491,45 @@ printf '# nothing here\n\n' > "${R}/crates/cratea/ui-dist/ui-source-hash.txt"
 commit_all "$R" "digest-less stamp"
 run_case "case22 stamp with no digest" 1 "STAMP-MISSING" "$R"
 
+# ---------------------------------------------------------------------------
+# Case 23 — #5936: every crate that builds its bundle IN PLACE must re-stamp
+# from its Vite config. Runs against THIS repo, not a fixture.
+#
+# `build.emptyOutDir: true` deletes the tracked ui-source-hash.txt on every
+# `pnpm build`, so the crates whose bundle_dir IS the Vite outDir
+# (<src_dir>/dist) need scripts/lib/vite-stamp-bundle.mjs wired in to put it
+# back. trusty-search is exempt and must stay exempt: it builds into ui/dist
+# and mirrors to a separate ui-dist/, which its Makefile's sync-ui stamps.
+#
+# This asserts the WIRING, not the stamping — the stamping itself is cases 20
+# and 21. #5936 recurred four times precisely because a fix that reached one
+# crate left the other two exposed, so the uniformity is what needs a gate.
+# ---------------------------------------------------------------------------
+WIRED_CHECKED=0
+while IFS="$(printf '\t')" read -r crate src_dir bundle_dir _rest; do
+  case "${crate:-}" in '' | \#*) continue ;; esac
+  # Only crates whose committed bundle is the Vite outDir are exposed.
+  [ "$bundle_dir" = "${src_dir}/dist" ] || continue
+  WIRED_CHECKED=$((WIRED_CHECKED + 1))
+  config="${REPO_ROOT}/${src_dir}/vite.config.js"
+  if [ ! -f "$config" ]; then
+    fail_case "case23 ${crate}: ${src_dir}/vite.config.js is missing"
+  elif ! grep -qF "stampUiBundle('${crate}')" "$config"; then
+    fail_case "case23 ${crate}: ${src_dir}/vite.config.js does not call stampUiBundle('${crate}')" \
+      "emptyOutDir deletes ${bundle_dir}/ui-source-hash.txt and nothing re-stamps it (#5936)."
+  else
+    pass_case "case23 ${crate} re-stamps its bundle from vite.config.js"
+  fi
+done < "${SCRIPT_DIR}/ui-bundle-manifest.tsv"
+
+# A loop that matched nothing would report all-clear having inspected nothing —
+# the vacuous-scan shape every case above exists to refuse.
+if [ "$WIRED_CHECKED" -eq 0 ]; then
+  fail_case "case23 inspected no crates — the manifest has no in-place bundle rows to check"
+else
+  pass_case "case23 inspected ${WIRED_CHECKED} in-place bundle crate(s)"
+fi
+
 echo
 echo "check-ui-bundle-freshness-selftest: ${PASSED} passed, ${FAILED} failed, ${SKIPPED} skipped"
 [ "$FAILED" -eq 0 ] || exit 1

--- a/scripts/lib/vite-stamp-bundle.mjs
+++ b/scripts/lib/vite-stamp-bundle.mjs
@@ -1,0 +1,78 @@
+// vite-stamp-bundle.mjs — re-write ui-source-hash.txt after Vite empties the
+// bundle directory (#5936).
+//
+// Why: `build.emptyOutDir: true` deletes everything under `dist/`, and the
+//   freshness stamp lives inside the bundle so it travels with the packaged
+//   tarball (see `ui_stamp_path` in scripts/lib/ui_source_digest.sh). Every
+//   `pnpm build` therefore deletes a tracked file, and the deletion lands in
+//   whatever commit follows — it reached `main` once through PR #5819 and
+//   recurred three more times on 2026-08-18.
+//
+//   `build.rs` already calls `scripts/stamp-ui-bundle.sh` after a build it ran
+//   itself (#6060), but that path cannot recover this deletion. The #5078
+//   guard it consults is `check-ui-bundle-freshness.sh`, which reads the stamp
+//   from disk when the file is there and falls back to `git show HEAD:<stamp>`
+//   when it is not — so a deleted stamp is answered from HEAD's copy, the
+//   bundle reports fresh, build.rs returns early, and the re-stamp never fires.
+//   Stamping here instead puts the repair at the step that does the damage —
+//   the same shape as
+//   `crates/trusty-search/Makefile`'s `sync-ui`, where the mirror that wipes
+//   `ui-dist/` is followed immediately by the stamp.
+//
+// What: a build-only Vite plugin whose `closeBundle` hook shells out to
+//   `scripts/stamp-ui-bundle.sh <crate>`. `closeBundle` runs once, after every
+//   output file is on disk, and only when a build actually produced a bundle —
+//   which is exactly the precondition `stamp-ui-bundle.sh` documents, since a
+//   stamp written without a rebuild is a claim the publish gate cannot
+//   re-verify. A missing script (an extracted crate tarball has no `scripts/`)
+//   is a silent no-op; a failing one warns and lets the build finish, matching
+//   `restamp_bundle`'s behaviour in build.rs.
+//
+// Test: scripts/check-ui-bundle-freshness-selftest.sh case 23 runs a real
+//   `pnpm build` in each of the three UI projects and asserts the stamp is
+//   present and unchanged afterward.
+
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * Build a Vite plugin that re-stamps `<outDir>/ui-source-hash.txt` after the
+ * build writes its output.
+ *
+ * @param {string} crate Crate directory name under `crates/`, as it appears in
+ *   the first column of `scripts/ui-bundle-manifest.tsv`.
+ */
+export function stampUiBundle(crate) {
+  let uiRoot = process.cwd();
+  return {
+    name: 'trusty:stamp-ui-bundle',
+    apply: 'build',
+    configResolved(config) {
+      // config.root is the UI project directory (crates/<crate>/ui), which is
+      // the one path that is stable regardless of the invoking CWD. Deriving
+      // the repo root from `import.meta.url` would not be: Vite bundles
+      // vite.config.js into a temp file inside the UI directory, which inlines
+      // this module and rewrites that URL.
+      uiRoot = config.root;
+    },
+    closeBundle() {
+      const repoRoot = resolve(uiRoot, '../../..');
+      const script = resolve(repoRoot, 'scripts/stamp-ui-bundle.sh');
+      if (!existsSync(script)) {
+        return;
+      }
+      try {
+        execFileSync('bash', [script, crate], {
+          cwd: repoRoot,
+          stdio: ['ignore', 'ignore', 'inherit'],
+        });
+      } catch {
+        console.warn(
+          `[trusty:stamp-ui-bundle] ${crate}: the bundle was rebuilt but ` +
+            'stamp-ui-bundle.sh failed — run it by hand before committing.',
+        );
+      }
+    },
+  };
+}


### PR DESCRIPTION
Refs #5936

## What broke

`build.emptyOutDir: true` deletes everything under `dist/` on every `pnpm build`. For trusty-memory, trusty-analyze, and trusty-console the committed bundle **is** the Vite `outDir`, so each build deletes the tracked `ui-source-hash.txt` and the deletion lands in whatever commit follows. Reproduced on a clean checkout of `main`:

```
$ cd crates/trusty-memory/ui && pnpm build
✓ built in 371ms
$ git status --porcelain -- crates/trusty-memory/ui/
 D crates/trusty-memory/ui/dist/ui-source-hash.txt
```

## Why the existing re-stamp never fired

`build.rs` already calls `scripts/stamp-ui-bundle.sh` after a build it ran itself (#6060/#6092, present in all four crates). That path cannot recover this deletion, and the reason is not obvious from reading `build.rs`.

`committed_bundle_is_fresh` delegates to `scripts/check-ui-bundle-freshness.sh`, which reads the stamp like this (`check-ui-bundle-freshness.sh:327-331`):

```bash
if [ "$WORKTREE_MODE" -eq 1 ] && [ -f "${REPO_ROOT}/${stamp_rel}" ]; then
  stamp_content="$(cat "${REPO_ROOT}/${stamp_rel}")"
else
  stamp_content="$(g show "${REV}:${stamp_rel}" 2>/dev/null || true)"
fi
```

When the stamp is missing from disk it falls back to HEAD's copy. So a deleted stamp is answered out of git, the bundle reports fresh, `build.rs` returns early at the #5078 guard, and the re-stamp never runs. Confirmed directly — with the stamp deleted, the gate still passes:

```
$ bash scripts/check-ui-bundle-freshness.sh trusty-memory
PASS: trusty-memory — ... recorded source digest 2280db7d8d06 matches
EXIT=0
$ cargo check -p trusty-memory     # build.rs runs, returns early, no warning
$ git status --porcelain -- crates/trusty-memory/ui/
 D crates/trusty-memory/ui/dist/ui-source-hash.txt      # still deleted
```

## The design choice

The issue left three options open. Two are not available here:

- **Preserve it through `emptyOutDir`** — Vite has no config knob for this. Its skip list is hard-coded to `[...skipDirs, '.git']` (`prepareOutDir`, vite 6.4.3), so the only config-level route is `emptyOutDir: false`, which leaves stale content-hashed assets accumulating in a committed bundle. That is a worse defect than the one being fixed.
- **Move the stamp outside `dist/`** — contradicts the stamp's stated design. `ui_stamp_path` in `scripts/lib/ui_source_digest.sh` puts it inside the bundle deliberately, so it travels with the packaged tarball and the published crate stays checkable after the fact.

So: **re-stamp after the build**, which is also what trusty-search already does. Its `Makefile` `sync-ui` target puts the stamp immediately after the step that wipes the directory, with the reason in a comment:

```make
rm -rf $(UI_EMBED)
cp -r $(UI_DIST) $(UI_EMBED)
# #3606: the mirror above wipes ui-dist/, so the stamp recording which source
# this bundle came from is written after it, never before.
@bash $(MAKEFILE_DIR)../../scripts/stamp-ui-bundle.sh trusty-search
```

This PR applies that shape at the step that does the damage — a shared Vite plugin (`scripts/lib/vite-stamp-bundle.mjs`) whose `closeBundle` hook runs `scripts/stamp-ui-bundle.sh`, wired into all three configs.

Putting it in the Vite layer rather than in `build.rs` buys two things. It covers a hand-run `pnpm build`, which no cargo-side fix reaches and which is how CI's `ui-checks` job builds these three. And `closeBundle` fires once, after every output file is written, and only when a build actually produced a bundle — which is exactly the precondition `stamp-ui-bundle.sh` documents, since a stamp written without a rebuild is a claim the publish gate cannot re-verify.

One implementation, three consumers, per the common-entry-point rule. **trusty-search stays exempt and must**: it builds into `ui/dist` and mirrors to a separate `ui-dist/`, so `emptyOutDir` never touches its stamp.

## Per-UI build evidence

All three `dist/` directories deleted outright, then rebuilt from scratch:

```
$ rm -rf crates/{trusty-memory,trusty-analyze,trusty-console}/ui/dist
$ git status --porcelain -- crates/          # 12 deletions, incl. all 3 stamps
 D crates/trusty-analyze/ui/dist/ui-source-hash.txt
 D crates/trusty-console/ui/dist/ui-source-hash.txt
 D crates/trusty-memory/ui/dist/ui-source-hash.txt
 ... (9 more bundle files)
```

```
$ cd crates/trusty-memory/ui && pnpm build
✓ built in 386ms
stamp-ui-bundle: trusty-memory — 9b8524e48bb0fcb7bddf2de059506d369ca5c64e over 25 source file(s) -> crates/trusty-memory/ui/dist/ui-source-hash.txt

$ cd crates/trusty-analyze/ui && pnpm build
✓ built in 644ms
stamp-ui-bundle: trusty-analyze — 20f3f779ebb07fa06f2e5d872d049c65c1575152 over 21 source file(s) -> crates/trusty-analyze/ui/dist/ui-source-hash.txt

$ cd crates/trusty-console/ui && pnpm build
✓ built in 327ms
stamp-ui-bundle: trusty-console — 5a5849ce69ada4089d7c1b3aee52b0f5b7d954b8 over 21 source file(s) -> crates/trusty-console/ui/dist/ui-source-hash.txt
```

```
$ git status --porcelain -- crates/
 M crates/trusty-analyze/ui/dist/ui-source-hash.txt
 M crates/trusty-analyze/ui/vite.config.js
 M crates/trusty-console/ui/dist/ui-source-hash.txt
 M crates/trusty-console/ui/vite.config.js
 M crates/trusty-memory/ui/dist/ui-source-hash.txt
 M crates/trusty-memory/ui/vite.config.js
```

No deletions. Every one of the 12 bundle files came back; the 9 asset/index files are byte-identical, and the 3 stamps show `M` because editing `vite.config.js` moves the source digest they record — the coupled change, which is the mechanism working.

And the tree stays clean through the cargo path (issue closure condition 1):

```
$ cargo check -p trusty-memory && cargo check -p trusty-analyze && cargo check -p trusty-console
EXIT=0 (each)
$ git status --porcelain
(empty)
```

## Regression test

Selftest case 23 asserts every manifest crate whose `bundle_dir` is its Vite `outDir` wires `stampUiBundle('<crate>')`, and refuses to pass having inspected nothing. #5936 recurred four times because a fix reaching one crate left the other two exposed, so uniformity is what needs the gate; the stamping behaviour itself is already cases 20/21.

Negative control — with the plugin removed from one config only:

```
SELF-TEST FAIL: case23 trusty-memory: crates/trusty-memory/ui/vite.config.js does not call stampUiBundle('trusty-memory')
       emptyOutDir deletes crates/trusty-memory/ui/dist/ui-source-hash.txt and nothing re-stamps it (#5936).
check-ui-bundle-freshness-selftest: 30 passed, 1 failed, 0 skipped
```

With the fix in place:

```
  ok  case23 trusty-memory re-stamps its bundle from vite.config.js
  ok  case23 trusty-analyze re-stamps its bundle from vite.config.js
  ok  case23 trusty-console re-stamps its bundle from vite.config.js
  ok  case23 inspected 3 in-place bundle crate(s)
check-ui-bundle-freshness-selftest: 31 passed, 0 failed, 0 skipped
```

## Gates — ladder rung 3, per touched crate

| Gate | Result |
|---|---|
| `cargo check -p trusty-memory` | EXIT=0 |
| `cargo check -p trusty-analyze` | EXIT=0 |
| `cargo check -p trusty-console` | EXIT=0 |
| `cargo fmt --check` | EXIT=0 |
| `bash scripts/check-ui-bundle-freshness-selftest.sh` | 31 passed, 0 failed, 0 skipped |
| `bash scripts/check-ui-bundle-freshness.sh` | OK at HEAD — 4 crates, 95 source files, 16 bundle files, 8 asset refs |
| `bash scripts/check_line_cap.sh` | EXIT=0 |
| `bash scripts/check_sld.sh` | EXIT=0 |
| `bash scripts/check_changelog_fragment.sh` | EXIT=0 — scanned 8 paths, attributed 0 crate-source paths |

No `cargo clippy`/`cargo test` beyond the above: this PR changes no Rust source. `cargo check` is included because `build.rs` consumes these directories and the bundles are embedded via `rust-embed`/`include_dir!`.

## No version bumps

All three crates are live with in-tree matching published — trusty-memory `0.24.1`, trusty-analyze `0.10.0`, trusty-console `0.5.0` (`cargo search`, each). No bump is owed: this PR touches no crate's `src/**`, which `check_changelog_fragment.sh` confirms independently ("attributed 0 crate-source path(s)"). The only files under `crates/` are `ui/vite.config.js` and `ui/dist/ui-source-hash.txt`. Nothing here reaches a public API, so `cargo-semver-checks` has nothing to compare even at the next release.

## Follow-up, not fixed here

The HEAD fallback at `check-ui-bundle-freshness.sh:327-331` is a fail-open in its own right: asked about the working tree, the gate answers about a file that is no longer on disk. With this PR the stamp is never missing after a build, so the fallback stops being reachable by this route — but it is still there. Closing it would make `committed_bundle_is_fresh` return false whenever the stamp is absent, which triggers a full pnpm rebuild inside `build.rs` on any cargo invocation and undoes what #5078 set out to do. That trade deserves its own issue rather than a rider on this one.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
