### PR TITLE
fix(trusty-common): a milestone id resolves to the version name JQL matches (Refs #6198)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11405,7 +11405,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-common"
-version = "0.43.1"
+version = "0.43.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -4,7 +4,10 @@ name = "trusty-common"
 # `src/mcp/*` modules. Cargo's 0.x rule makes that a MINOR bump, not a patch.
 # 0.42.1 (#6208): patch — additive `PalaceHandle::compact_vector_orphans` fixes
 # a data-loss race; no public item removed or changed, so not a 0.x break.
-version = "0.43.1"
+# 0.43.2 (#6198): patch — the Jira backend resolves a milestone id to its
+# version name internally; every changed item is `pub(super)`, so no public
+# item was removed or changed.
+version = "0.43.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/trusty-common/changelog.d/6198-fixversion-name-lookup.md
+++ b/crates/trusty-common/changelog.d/6198-fixversion-name-lookup.md
@@ -1,0 +1,13 @@
+Fixed
+
+- The Jira tickets backend's `get_milestone_issues` now resolves a milestone id
+  to its version name before querying (#6198). JQL matches a quoted
+  `fixVersion = "…"` term against the version NAME; only the unquoted form
+  matches a numeric version id. The injection fix quoted every JQL term, so a
+  milestone-by-id lookup silently returned no issues — or, worse, the issues of
+  a version whose name happened to equal the id. The backend now reads
+  `GET /project/{key}/versions`, maps the id to that version's name, and builds
+  the same escaped, quoted term from the name. A caller that already passes a
+  name still works, and an id matching no version is a hard error rather than an
+  empty issue list, which would be indistinguishable from a real but empty
+  milestone. Unquoting was never an option: it would reopen the injection.

--- a/crates/trusty-common/src/tickets/api/backends/jira/backend.rs
+++ b/crates/trusty-common/src/tickets/api/backends/jira/backend.rs
@@ -19,7 +19,7 @@ use crate::tickets::api::models::*;
 
 use super::types::{
     JiraBackend, adf_paragraph, build_epic_issues_jql, build_list_epics_jql, build_list_jql,
-    build_milestone_issues_jql, build_search_jql, parse_comment, parse_issue,
+    build_milestone_issues_jql, build_search_jql, parse_comment, parse_issue, resolve_version_name,
 };
 
 #[async_trait]
@@ -334,8 +334,13 @@ impl Backend for JiraBackend {
     }
 
     async fn get_milestone_issues(&self, id: &str) -> Result<Vec<Issue>> {
-        // #6198: build via build_milestone_issues_jql so id is quoted + escaped.
-        let jql = build_milestone_issues_jql(id);
+        // #6198: a quoted fixVersion term matches on version NAME, so resolve the
+        // id to its name first; unquoting would reopen the JQL injection.
+        let versions = self
+            .get(&format!("/project/{}/versions", self.project_key))
+            .await?;
+        let version_name = resolve_version_name(&versions, id)?;
+        let jql = build_milestone_issues_jql(&version_name);
         let body = json!({ "jql": jql, "maxResults": 100 });
         let v = self.post("/search/jql", body).await?;
         let issues = v

--- a/crates/trusty-common/src/tickets/api/backends/jira/tests.rs
+++ b/crates/trusty-common/src/tickets/api/backends/jira/tests.rs
@@ -7,14 +7,18 @@
 //! reading issues from another project.
 //! What: exercises the pure `build_*_jql` builders — which produce the exact
 //! `jql` string handed to the HTTP client — asserting injected values are
-//! quoted + escaped and legitimate values still produce correct JQL.
+//! quoted + escaped and legitimate values still produce correct JQL. Also covers
+//! `resolve_version_name`, the id→name lookup the quoted `fixVersion` term
+//! requires, over a mocked `/project/{key}/versions` response body.
 //! Test: this file is the coverage.
+
+use serde_json::json;
 
 use crate::tickets::api::backends::{ListIssuesParams, SearchIssuesParams};
 
 use super::types::{
     build_epic_issues_jql, build_list_epics_jql, build_list_jql, build_milestone_issues_jql,
-    build_search_jql, escape_jql_string,
+    build_search_jql, escape_jql_string, resolve_version_name,
 };
 
 /// A payload that, unescaped, closes the `text`/`assignee` term and appends an
@@ -223,5 +227,96 @@ fn list_epics_jql_legit_value() {
     assert_eq!(
         build_list_epics_jql("PROJ"),
         r#"project = "PROJ" AND issuetype = Epic"#
+    );
+}
+
+// ---- get_milestone_issues: id resolves to the NAME the quote matches on -----
+// The #6198 escaping quotes the `fixVersion` term, and a quoted term matches by
+// version NAME. Passing the numeric id straight through therefore matched
+// nothing, so the backend resolves it against `/project/{key}/versions` first.
+
+/// A stand-in for the `GET /project/{key}/versions` response body.
+fn versions_fixture() -> serde_json::Value {
+    json!([
+        { "id": "10041", "name": "1.0" },
+        { "id": "10042", "name": "Sprint 12" },
+    ])
+}
+
+#[test]
+fn resolve_version_name_maps_numeric_id() {
+    assert_eq!(
+        resolve_version_name(&versions_fixture(), "10042").unwrap(),
+        "Sprint 12"
+    );
+}
+
+#[test]
+fn milestone_jql_uses_resolved_name() {
+    // The regression: a numeric id must reach JQL as the version's NAME.
+    let name = resolve_version_name(&versions_fixture(), "10042").unwrap();
+    let jql = build_milestone_issues_jql(&name);
+    // What the pre-fix backend emitted — a quoted id, which matches no version.
+    assert_ne!(jql, r#"fixVersion = "10042""#, "id reached JQL unresolved");
+    assert_eq!(jql, r#"fixVersion = "Sprint 12""#);
+}
+
+#[test]
+fn resolved_name_needing_escape_stays_quoted() {
+    // A version NAME can itself carry a quote — the escaper still contains it.
+    let versions = json!([{ "id": "10043", "name": r#"1.0" OR project = "SECRET"# }]);
+    let name = resolve_version_name(&versions, "10043").unwrap();
+    let jql = build_milestone_issues_jql(&name);
+    assert!(!jql.contains(r#"1.0" OR"#), "breakout survived: {jql}");
+    assert_eq!(jql, r#"fixVersion = "1.0\" OR project = \"SECRET""#);
+}
+
+#[test]
+fn resolve_version_name_accepts_numeric_json_id() {
+    let versions = json!([{ "id": 10042, "name": "Sprint 12" }]);
+    assert_eq!(
+        resolve_version_name(&versions, "10042").unwrap(),
+        "Sprint 12"
+    );
+}
+
+#[test]
+fn resolve_version_name_prefers_id_over_name() {
+    // A version NAMED like another version's id must not win the lookup.
+    let versions = json!([
+        { "id": "9", "name": "10042" },
+        { "id": "10042", "name": "Sprint 12" },
+    ]);
+    assert_eq!(
+        resolve_version_name(&versions, "10042").unwrap(),
+        "Sprint 12"
+    );
+}
+
+#[test]
+fn resolve_version_name_accepts_direct_name() {
+    // Callers that already pass a name keep working.
+    assert_eq!(
+        resolve_version_name(&versions_fixture(), "Sprint 12").unwrap(),
+        "Sprint 12"
+    );
+}
+
+#[test]
+fn resolve_version_name_errors_on_unknown_id() {
+    // An unknown id must be an error, not a silently empty issue list.
+    let err = resolve_version_name(&versions_fixture(), "99999").unwrap_err();
+    assert!(
+        err.to_string().contains("no project version matches"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn resolve_version_name_errors_on_non_array() {
+    let err = resolve_version_name(&json!({ "errorMessages": ["nope"] }), "10042").unwrap_err();
+    assert!(
+        err.to_string().contains("was not an array"),
+        "unexpected error: {err}"
     );
 }

--- a/crates/trusty-common/src/tickets/api/backends/jira/types.rs
+++ b/crates/trusty-common/src/tickets/api/backends/jira/types.rs
@@ -204,18 +204,68 @@ pub(super) fn build_search_jql(project_key: &str, p: &SearchIssuesParams) -> Str
     jql
 }
 
+/// Resolve a milestone identifier to the JIRA version NAME that JQL matches on.
+///
+/// Why: JQL compares a QUOTED `fixVersion` term against the version NAME, and a
+/// numeric version id only matches when the term is UNQUOTED. The #6198 escaping
+/// quotes every term, so an id passed straight through matched nothing.
+/// Unquoting would reopen the injection, so the id is resolved to its name here
+/// instead.
+/// What: scans the `GET /project/{key}/versions` array for a version whose `id`
+/// equals `milestone`, then falls back to one whose `name` equals it so a caller
+/// that already passes a name keeps working. A miss is an error, never an empty
+/// result — an empty issue list is indistinguishable from a real milestone that
+/// happens to have no issues.
+/// Test: `super::tests::resolve_version_name_maps_numeric_id`,
+/// `resolve_version_name_accepts_numeric_json_id`,
+/// `resolve_version_name_prefers_id_over_name`,
+/// `resolve_version_name_accepts_direct_name`,
+/// `resolve_version_name_errors_on_unknown_id`,
+/// `resolve_version_name_errors_on_non_array`.
+pub(super) fn resolve_version_name(versions: &Value, milestone: &str) -> Result<String> {
+    let Some(arr) = versions.as_array() else {
+        bail!("jira: project versions response was not an array");
+    };
+    // JIRA Cloud sends ids as strings; accept a bare number defensively.
+    fn field(v: &Value, key: &str) -> Option<String> {
+        match v.get(key) {
+            Some(Value::String(s)) => Some(s.clone()),
+            Some(Value::Number(n)) => Some(n.to_string()),
+            _ => None,
+        }
+    }
+    let matched = arr
+        .iter()
+        .find(|v| field(v, "id").as_deref() == Some(milestone))
+        .or_else(|| {
+            arr.iter()
+                .find(|v| field(v, "name").as_deref() == Some(milestone))
+        });
+    let Some(version) = matched else {
+        bail!("jira: no project version matches milestone '{milestone}'");
+    };
+    match field(version, "name") {
+        Some(name) if !name.is_empty() => Ok(name),
+        _ => bail!("jira: project version '{milestone}' has no name for fixVersion to match"),
+    }
+}
+
 /// Build the JQL for `Backend::get_milestone_issues`.
 ///
-/// Why: `id` arrives from the MCP `milestone_id` string arg — an attacker trust
-/// boundary. The prior `fixVersion = {id}` was UNQUOTED and unescaped, so
-/// `id = "1 OR project = SECRET"` needed no quote-breakout at all — the bare
-/// `OR` clause injected directly and read another project's issues (#6198).
+/// Why: `version_name` arrives from the MCP `milestone_id` string arg — an
+/// attacker trust boundary. The prior `fixVersion = {id}` was UNQUOTED and
+/// unescaped, so `id = "1 OR project = SECRET"` needed no quote-breakout at all —
+/// the bare `OR` clause injected directly and read another project's issues
+/// (#6198).
 /// What: wraps the value in quotes AND escapes it, so it is one self-contained
-/// JQL string literal a `"` cannot break out of.
+/// JQL string literal a `"` cannot break out of. The quote makes the term match
+/// on version NAME, which is why the caller resolves an id through
+/// `resolve_version_name` first.
 /// Test: `super::tests::milestone_issues_jql_escapes_injection`,
-/// `milestone_issues_jql_escapes_embedded_quote`, `milestone_issues_jql_legit_value`.
-pub(super) fn build_milestone_issues_jql(id: &str) -> String {
-    format!("fixVersion = \"{}\"", escape_jql_string(id))
+/// `milestone_issues_jql_escapes_embedded_quote`, `milestone_issues_jql_legit_value`,
+/// `milestone_jql_uses_resolved_name`, `resolved_name_needing_escape_stays_quoted`.
+pub(super) fn build_milestone_issues_jql(version_name: &str) -> String {
+    format!("fixVersion = \"{}\"", escape_jql_string(version_name))
 }
 
 /// Build the JQL for `Backend::get_epic_issues`.


### PR DESCRIPTION
Follow-up to PR #6211, which quoted every JQL string term to close the injection. `build_milestone_issues_jql` emits `fixVersion = "<id>"`, and JQL matches a QUOTED `fixVersion` term against the version NAME — only the unquoted form matches a numeric version id. So milestone-by-id lookups matched nothing, or matched a version whose name happened to equal the id. #6211's own note flagged this and named the remedy: resolve id to name, never unquote.

## Finding: the id is a real numeric version id, not a name

Traced the callers rather than assuming. `milestone_id` genuinely carries the Jira version id everywhere in this backend, so this is a code fix and not a rename:

- `list_milestones` (`backend.rs:249-254`) fills `Milestone.id` from the `id` field of `GET /project/{key}/versions`, and `Milestone.name` from `name` — two distinct values.
- `create_milestone` (`backend.rs:294`) returns the id the `POST /version` response gives back.
- `close_milestone` (`backend.rs:318`) puts to `/version/{id}` — a numeric-id path.
- `server.rs:249` passes the MCP `milestone_id` string arg straight to `get_milestone_issues`.

## Change

`get_milestone_issues` reads `GET /project/{key}/versions` — the endpoint `list_milestones` already uses — and resolves the id through a new pure `resolve_version_name` before building the same escaped, quoted term from the name. Unquoting was never on the table.

- Id not found is an error, not an empty result. An empty issue list is indistinguishable from a real milestone that has no issues.
- A name that itself contains a quote goes through `escape_jql_string`, the escaper #6211 added.
- The direct-name path keeps working: id match is tried first, then name match, so a version NAMED like another version's id cannot win the lookup (`resolve_version_name_prefers_id_over_name`).
- Ids arriving as a bare JSON number rather than a string are accepted.

## Tests

8 new tests in `crates/trusty-common/src/tickets/api/backends/jira/tests.rs`, over a mocked `/project/{key}/versions` body. The crate has no HTTP mock harness for this backend and does not depend on wiremock; its existing Jira coverage tests the pure builders over `serde_json::Value`, so these follow that shape rather than adding a dependency.

`milestone_jql_uses_resolved_name` is the regression: it asserts the JQL is NOT `fixVersion = "10042"` — exactly what the pre-fix backend emitted — and IS `fixVersion = "Sprint 12"`.

All 20 pre-existing injection tests pass unchanged; `build_milestone_issues_jql`'s body is untouched, only its parameter renamed to `version_name`.

**No live Jira access exists on this machine, so this is mock-only.** Live confirmation of the id-to-name behavior against a real instance remains open on #6198.

## Rung 3 (localized behavior inside one crate)

Blast radius is provably inside `trusty-common`: `resolve_version_name` is `pub(super)`, `get_milestone_issues`'s signature is unchanged, and no other crate enables the `tickets` feature — `grep -rn 'features = \[[^]]*"tickets"' crates/*/Cargo.toml` returns only `trusty-common`'s own `tickets-mcp` binary target.

| Gate | Result |
|---|---|
| `cargo fmt --check` | exit 0 |
| `cargo check -p trusty-common --features tickets --locked` | exit 0 |
| `cargo clippy -p trusty-common --features tickets --all-targets -- -D warnings` | exit 0 |
| `cargo test -p trusty-common --features tickets` | `test result: ok. 454 passed; 0 failed; 6 ignored` (28 jira tests, all green) |
| `bash scripts/check_line_cap.sh` | `4175 tracked .rs file(s); 0 violations` |
| `bash scripts/check_changelog_fragment.sh` | `all 1 crate(s) with source changes are recorded` |
| `bash scripts/check_sld.sh` | `0 error(s), 0 warning(s)` |

## Version

`trusty-common` 0.43.1 → 0.43.2. Patch: every changed item is `pub(super)`, so no public item was removed or changed. The `Cargo.lock` edit is that one line — `--locked` verified.

Refs #6198

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
