### PR TITLE
test(trusty-mpm): four flaky tests wait on conditions instead of racing them

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_b_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_b_tests.rs
@@ -1420,13 +1420,13 @@ async fn guided_fallback_non_git_dir_with_managed_env_settles_quickly_returns_pr
     let project = dir.path();
 
     let client = reqwest::Client::new();
-    let start = std::time::Instant::now();
+    // The 5s timeout is the anti-hang guard; promptness itself is asserted on
+    // the poll count below, not on wall clock (#6230).
     let result = tokio::time::timeout(
         std::time::Duration::from_secs(5),
         crate::commands::guided::fallback_protected(&client, &url, project),
     )
     .await;
-    let elapsed = start.elapsed();
 
     // Restore before any assertion can panic.
     unsafe {
@@ -1445,14 +1445,19 @@ async fn guided_fallback_non_git_dir_with_managed_env_settles_quickly_returns_pr
         !project.join("CLAUDE.md").exists(),
         "CLAUDE.md must not be written for this non-git cwd"
     );
+    // #6230: promptness is how many times the loop polled, not how long the
+    // machine took. The mock scripts "active" then "stopped", so a loop that
+    // stops the moment the record resolves polls twice; one that pays the full
+    // 400ms/80ms retry budget polls about six times. The previous
+    // `elapsed < 300ms` bound measured load rather than the loop and failed at
+    // 330ms under a concurrent suite run. One poll is also correct: a first
+    // fetch slow enough to consume the whole budget returns after a single
+    // attempt (see `fetch_managed_session_until_stopped`'s doc, #5840).
+    let polls = hits.load(std::sync::atomic::Ordering::SeqCst);
     assert!(
-        hits.load(std::sync::atomic::Ordering::SeqCst) >= 1,
-        "the retried in-place check must actually query the daemon"
-    );
-    assert!(
-        elapsed < std::time::Duration::from_millis(300),
-        "a record that settles on the second poll must not pay the full \
-         retry budget; took {elapsed:?}"
+        (1..=2).contains(&polls),
+        "the retried in-place check must query the daemon and stop as soon as \
+         the record settles: expected 1 or 2 polls, got {polls}"
     );
 }
 

--- a/crates/trusty-mpm/src/daemon/managed_routes/inproject/tests.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/inproject/tests.rs
@@ -827,24 +827,38 @@ fn worktree_name_collides_detects_existing_dir_and_branch() {
         "an in-use name (dir + branch both exist) must collide"
     );
 
-    // (c) Remove the worktree directory (but not the branch) via `git worktree
-    // remove`, which deletes the dir but leaves the branch ref intact — the
-    // branch-only check must still report a collision.
-    let remove = std::process::Command::new("git")
+    // (c) Remove the worktree directory (but not the branch) — the branch-only
+    // check must still report a collision.
+    //
+    // #6099: delete the directory directly rather than shelling out to
+    // `git worktree remove`. The unit under test, `worktree_name_collides`,
+    // reads exactly two things: whether the directory exists, and whether
+    // `git rev-parse` resolves the branch ref. It never consults git's
+    // worktree ADMIN list under `.git/worktrees/`. Routing this step through
+    // `git worktree remove` made the fixture depend on that admin entry
+    // surviving, and it does not always: once the entry is gone, `remove`
+    // exits 128 with `'<path>' is not a working tree`, which is the panic this
+    // test raised about once per six full-suite runs. A probe on git 2.54.0
+    // confirms the mapping — deleting the admin entry (or letting a prune
+    // delete it after the directory goes missing) reproduces that exact
+    // message, while deleting only the directory leaves `remove` succeeding.
+    // What removes the entry under load is still unidentified; this fix drops
+    // the dependency on it instead of guessing.
+    let worktree_dir = base.join(".worktrees").join("tm-fresh-01");
+    if worktree_dir.exists() {
+        std::fs::remove_dir_all(&worktree_dir).expect("remove the worktree directory");
+    }
+    // Best-effort, and deliberately not asserted: it only keeps git's admin
+    // list consistent with what is on disk, which no assertion below reads.
+    // This mirrors `decommission::remove_session_worktree`'s own teardown.
+    let _ = std::process::Command::new("git")
         .arg("-C")
         .arg(base)
-        .args(["worktree", "remove", "--force"])
-        .arg(base.join(".worktrees").join("tm-fresh-01"))
-        .output()
-        .expect("git worktree remove");
+        .args(["worktree", "prune"])
+        .output();
     assert!(
-        remove.status.success(),
-        "git worktree remove failed: {}",
-        String::from_utf8_lossy(&remove.stderr)
-    );
-    assert!(
-        !base.join(".worktrees").join("tm-fresh-01").exists(),
-        "worktree dir must be gone after `git worktree remove`"
+        !worktree_dir.exists(),
+        "worktree dir must be gone before the branch-only check"
     );
     assert!(
         worktree_name_collides(base, "tm-fresh-01"),

--- a/crates/trusty-mpm/tests/session_manager_mvp.rs
+++ b/crates/trusty-mpm/tests/session_manager_mvp.rs
@@ -2359,6 +2359,14 @@ impl Drop for KillSessionGuard<'_> {
 /// pointed at coverage which did not exist).
 #[test]
 #[ignore = "requires a live tmux binary; run with --include-ignored"]
+// #6127: `#[serial]` — the `#[serial]` `HomeGuard` tests above reassign the
+// process-global `$HOME`, and this test reads it through the #5784 host-state
+// gate, which refuses tmux whenever `$HOME` is not this uid's real home. Since
+// `serial_test` only excludes `#[serial]` tests from each OTHER, running
+// unmarked left this test free to observe a sibling's temp `$HOME` mid-flight
+// and fail with "tmux access refused". Serialising joins that same exclusion
+// set; the guard itself is untouched.
+#[serial_test::serial]
 fn live_pane_scoped_send_targets_original_pane_not_sibling() {
     let driver = TmuxDriver::discover().expect("tmux must be installed for this live test");
     let session_name = format!("trusty-mpm-test-pane-{}", std::process::id());

--- a/crates/trusty-mpm/tests/tm_hook_idle_parking.rs
+++ b/crates/trusty-mpm/tests/tm_hook_idle_parking.rs
@@ -45,6 +45,47 @@ fn run_hook(stdin_json: &str) -> (bool, String) {
     )
 }
 
+/// Run `tm hook` until its stderr contains `want`, or a generous deadline
+/// expires; returns the stderr that satisfied the condition.
+///
+/// Why (#6161): `tm hook` bounds its own work with two fail-open internal
+/// timeouts so it can never block the user's prompt — a 500ms stdin read
+/// (`read_stdin_hook_payload`) and a 300ms detection ceiling
+/// (`detect_idle_parking_from_payload`). Under concurrent suite load either can
+/// elapse, and the hook then exits 0 having written NOTHING to stderr. That is
+/// correct production behaviour, and it is indistinguishable from a real
+/// regression to a test that reads stderr exactly once — which is how this
+/// suite failed with `got: ""` on an otherwise-green commit.
+/// What: re-invokes the hook until `want` appears, checking the fail-open
+/// `exit 0` invariant on every attempt (that one must hold unconditionally, so
+/// it is never retried past). Deadline expiry panics with the attempt count and
+/// the last stderr observed, so a genuine regression still fails loudly rather
+/// than looping.
+/// Test: used by `hook_flags_idle_parking_final_message_on_subagent_stop` and
+/// `hook_flags_idle_parking_on_main_stop`.
+fn run_hook_until_stderr_contains(stdin_json: &str, want: &str) -> String {
+    const DEADLINE: std::time::Duration = std::time::Duration::from_secs(30);
+    let start = std::time::Instant::now();
+    let mut attempts = 0usize;
+    loop {
+        let (ok, stderr) = run_hook(stdin_json);
+        attempts += 1;
+        assert!(
+            ok,
+            "hook must exit 0 (fail-open) on every attempt, stderr={stderr}"
+        );
+        if stderr.contains(want) {
+            return stderr;
+        }
+        assert!(
+            start.elapsed() < DEADLINE,
+            "`tm hook` never wrote {want:?} to stderr within {DEADLINE:?} \
+             ({attempts} attempts); last stderr: {stderr:?}"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+}
+
 /// Write a single-line JSONL transcript with one assistant message and return
 /// the temp file (kept alive by the caller so the path stays valid).
 fn transcript_with_assistant(text: &str) -> tempfile::NamedTempFile {
@@ -72,12 +113,11 @@ fn hook_flags_idle_parking_final_message_on_subagent_stop() {
     let tf = transcript_with_assistant(
         "I've started a background polling monitor for the checks and will report back once green.",
     );
-    let (ok, stderr) = run_hook(&payload("SubagentStop", tf.path()));
-
-    assert!(ok, "hook must exit 0 (fail-open), stderr={stderr}");
-    assert!(
-        stderr.contains("IDLE-PARKING WARNING (#2610)"),
-        "expected idle-parking warning on stderr, got: {stderr:?}"
+    // #6161: poll for the warning rather than racing the hook's fail-open
+    // internal timeouts — see `run_hook_until_stderr_contains`.
+    let stderr = run_hook_until_stderr_contains(
+        &payload("SubagentStop", tf.path()),
+        "IDLE-PARKING WARNING (#2610)",
     );
     assert!(
         stderr.contains("session=sess-2610"),
@@ -88,13 +128,9 @@ fn hook_flags_idle_parking_final_message_on_subagent_stop() {
 #[test]
 fn hook_flags_idle_parking_on_main_stop() {
     let tf = transcript_with_assistant("Standing by for the CI run to complete.");
-    let (ok, stderr) = run_hook(&payload("Stop", tf.path()));
-
-    assert!(ok, "hook must exit 0 (fail-open), stderr={stderr}");
-    assert!(
-        stderr.contains("IDLE-PARKING WARNING (#2610)"),
-        "expected idle-parking warning on stderr for Stop, got: {stderr:?}"
-    );
+    // #6161: same fail-open-timeout race as the SubagentStop case above.
+    let _stderr =
+        run_hook_until_stderr_contains(&payload("Stop", tf.path()), "IDLE-PARKING WARNING (#2610)");
 }
 
 #[test]


### PR DESCRIPTION
Refs #6230, Refs #6161, Refs #6127, Refs #6099

Four flaky `trusty-mpm` tests, one defect class: each asserted against a snapshot of state a concurrent suite could still change, so load decided the result rather than the code under test. Test-only — no production source changed.

## What changed

**#6230** — `tests_behavior_b_tests.rs`, `guided_fallback_non_git_dir_with_managed_env_settles_quickly_returns_promptly`

The test asserted `elapsed < 300ms` and read 330ms under a concurrent suite run. What it actually protects is that the retried `try_inplace_relaunch` stops polling the moment the daemon record resolves, instead of paying the full retry budget. That is a poll count, not a duration: the mock scripts `active` then `stopped`, so a loop that exits on resolution polls twice, while one that runs the budget out polls about six times (400ms budget / 80ms interval). The assertion now reads the mock's hit counter. One poll is also accepted — a first fetch slow enough to consume the whole budget legitimately returns after a single attempt, which `fetch_managed_session_until_stopped`'s own doc records as correct behaviour (#5840). The 5s `tokio::time::timeout` stays as the anti-hang guard.

**#6161** — `tm_hook_idle_parking.rs`, `hook_flags_idle_parking_final_message_on_subagent_stop`

The empty stderr is not a flush race — `wait_with_output()` cannot race the child. `tm hook` bounds its own work with two fail-open internal timeouts so it never blocks the user's prompt: a 500ms stdin read (`read_stdin_hook_payload`, `misc.rs:419`) and a 300ms detection ceiling (`detect_idle_parking_from_payload`, `misc.rs:517`). Under load either elapses and the hook exits 0 having written nothing. That is correct production behaviour and indistinguishable from a regression to a test that reads stderr once.

`run_hook_until_stderr_contains` re-invokes the hook until the warning appears, against a 30s deadline; expiry panics with the attempt count and the last stderr observed, so a real regression still fails loudly. The fail-open `exit 0` invariant is checked on every attempt and never retried past. `hook_flags_idle_parking_on_main_stop` carries the identical positive assertion and the identical exposure, so it routes through the same helper.

**#6127** — `session_manager_mvp.rs`, `live_pane_scoped_send_targets_original_pane_not_sibling`

The test ran without `#[serial]`. `serial_test` only excludes `#[serial]` tests from each other, so the thirteen `#[serial]` `HomeGuard` tests in the same file could hold a temp `$HOME` while this one read it through the #5784 host-state gate — which then refused tmux. Adding `#[serial_test::serial]` joins that exclusion set. The #5784 guard is untouched, and no `TRUSTY_MPM_ALLOW_HOST_STATE` opt-out was added.

**#6099** — `inproject/tests.rs`, `worktree_name_collides_detects_existing_dir_and_branch`

Step (c) reached its branch-only case by shelling out to `git worktree remove --force`. A probe on git 2.54.0 maps the reported panic exactly: `'<path>' is not a working tree` appears when git's `.git/worktrees/<name>` admin entry is gone — either deleted directly, or pruned after the worktree directory went missing. Deleting only the directory leaves `remove` succeeding.

`worktree_name_collides` reads exactly two things: whether the directory exists, and whether `git rev-parse` resolves the branch ref. It never consults that admin list. The step now deletes the directory directly and prunes best-effort, so the fixture no longer depends on state it does not test. Both original assertions are unchanged.

What removes the admin entry under load is still unidentified — 8 pre-change full `--lib` runs on this machine produced no reproduction (the issue reports roughly 1 in 6). The fix removes the dependency rather than guessing at the cause.

## Test ladder — rung 2 (test-only stabilization)

`cargo fmt --check` → clean.

`cargo test -p trusty-mpm` (all targets) → all green, including lib `5264 passed; 0 failed; 7 ignored` and both `tm` bin targets at `1828 passed; 0 failed; 1 ignored`.

### Flake re-runs

| Issue | Gate re-run 10x | Result |
|---|---|---|
| #6230 | `cargo test -p trusty-mpm --bins` (both targets, 1828 tests each) | 10 passed / 0 failed |
| #6161 | `cargo test -p trusty-mpm --test tm_hook_idle_parking` | 10 passed / 0 failed |
| #6127 | `cargo test -p trusty-mpm --test session_manager_mvp -- --include-ignored` | 10 passed / 0 failed |
| #6099 | `cargo test -p trusty-mpm --lib` | 10 passed / 0 failed |

The #6230 and #6099 loops ran concurrently on purpose, which is the load condition the original failure needed: per-run wall time went from 20s to 65-73s for the bin targets and from 68s to 145-270s for the lib suite.

#6127 is the one that reproduced deterministically. Reverting only that hunk and re-running the same command fails every time:

```
test live_pane_scoped_send_targets_original_pane_not_sibling ... FAILED
panicked at crates/trusty-mpm/tests/session_manager_mvp.rs:2363:41:
tmux must be installed for this live test: Protocol("tmux access refused: $HOME is
/var/folders/7s/g9twvy8j0wl58ffgzsmrccv40000gp/T/.tmpv9NlHS but this user's real home
is /Users/masa — ... (#5784). Set TRUSTY_MPM_ALLOW_HOST_STATE=1 to allow it.")
test result: FAILED. 29 passed; 1 failed; 0 ignored
```

With the fix, the same command reports `30 passed; 0 failed` on all 10 runs.

## Changelog fragment

None — the gate reports this PR exempt:

```
changelog-fragment gate: scanned 4 changed path(s); attributed 0 crate-source
path(s); no crate source changed (docs-only / CI-only / test-only) — OK.
```

Two of the four files sit under `crates/trusty-mpm/src/**` but classify as test files (`tests.rs`, `_tests.rs`); the other two are under `crates/trusty-mpm/tests/`.

## Known blocker: the version-bump gate will fail

`PR version bump vs crates.io (issue #4421)` is a required check and it fails on this PR. No version bump was made, deliberately — trusty-mpm 1.5.0 just published and nothing user-visible changed here.

```
[FAIL] trusty-mpm 1.5.0 — src/** changed under a version that is ALREADY
       published on crates.io, and Cargo.toml was not bumped.
```

This is the #5765 divergence working as designed: `check-pr-version-bump.sh` deliberately does NOT apply the test-file exemption that `check_changelog_fragment.sh` does, so a test-only edit under `src/**` reads as source to it. Both scripts share `scripts/lib/source_class.sh` precisely to keep that disagreement explicit. Flagging for a decision rather than bumping a version for a change with no user-visible effect.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
