### PR TITLE
fix(trusty-mpm): gh account enforcement verifies the identity, not the transcript (Refs #5849)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11694,7 +11694,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-mpm"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-mpm"
-version = "1.5.0"
+version = "1.5.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/trusty-mpm/changelog.d/5849-gh-identity-from-api.md
+++ b/crates/trusty-mpm/changelog.d/5849-gh-identity-from-api.md
@@ -1,0 +1,17 @@
+Fixed
+
+- Per-project `gh` account enforcement now confirms the identity with
+  `gh api user`, not by parsing `gh auth status` text
+  (refs [#5849](https://github.com/bobmatnyc/trusty-tools/issues/5849)).
+  `gh auth status` echoes whatever the scoped `GH_CONFIG_DIR`'s `hosts.yml`
+  claims, so a `hosts.yml` naming an account that exists nowhere on the machine
+  printed a green checkmark, live token scopes and `Active account: true` — and
+  `ensure_gh_account_in_dir` / `ensure_gh_account_for_project` reported success
+  for an identity nobody had verified. Both now compare the expected account
+  against `gh api user --jq .login`, the login GitHub attributes to the
+  credential the scoped `gh` actually resolves, and every probe failure —
+  `gh` missing, a non-zero exit, blank output, or the 5s bound — is a
+  verification failure rather than a pass. When the transcript and the
+  credential name different accounts (the divergence tracked in
+  [#5656](https://github.com/bobmatnyc/trusty-tools/issues/5656)) the API
+  answer decides and the disagreement is logged at WARN.

--- a/crates/trusty-mpm/changelog.d/5849-gh-identity-from-api.md
+++ b/crates/trusty-mpm/changelog.d/5849-gh-identity-from-api.md
@@ -17,7 +17,12 @@ Fixed
   cannot rewrite the project's config dir. Enforcement additionally refuses
   outright when an ambient `GH_TOKEN`/`GITHUB_TOKEN` is set: that token outranks
   `GH_CONFIG_DIR` for every later `gh` call, so no scoped probe can speak for
-  what those calls will do. When the transcript and the
+  what those calls will do — including a whitespace-only token, which `gh`
+  selects rather than ignores. Enforcement also now runs on the project's
+  configured `github.host` instead of assuming github.com, so a project pointed
+  at an enterprise instance is verified on the host its work actually uses;
+  `configured_account_pair` returns an `AccountTarget` carrying that host
+  alongside the config dir and account. When the transcript and the
   credential name different accounts (the divergence tracked in
   [#5656](https://github.com/bobmatnyc/trusty-tools/issues/5656)) the API
   answer decides and the disagreement is logged at WARN.

--- a/crates/trusty-mpm/changelog.d/5849-gh-identity-from-api.md
+++ b/crates/trusty-mpm/changelog.d/5849-gh-identity-from-api.md
@@ -11,7 +11,13 @@ Fixed
   against `gh api user --jq .login`, the login GitHub attributes to the
   credential the scoped `gh` actually resolves, and every probe failure —
   `gh` missing, a non-zero exit, blank output, or the 5s bound — is a
-  verification failure rather than a pass. When the transcript and the
+  verification failure rather than a pass — including a lost network, which now
+  blocks enforcement instead of passing it (every operation it gates needs the
+  network anyway). A failed probe also stops before `gh auth switch`, so a blip
+  cannot rewrite the project's config dir. Enforcement additionally refuses
+  outright when an ambient `GH_TOKEN`/`GITHUB_TOKEN` is set: that token outranks
+  `GH_CONFIG_DIR` for every later `gh` call, so no scoped probe can speak for
+  what those calls will do. When the transcript and the
   credential name different accounts (the divergence tracked in
   [#5656](https://github.com/bobmatnyc/trusty-tools/issues/5656)) the API
   answer decides and the disagreement is logged at WARN.

--- a/crates/trusty-mpm/src/bin/tm/env_isolation_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/env_isolation_tests.rs
@@ -72,8 +72,12 @@ const BANNED_ENV_WRITES: &[&str] = &["HOME", "CLAUDE_CONFIG_DIR"];
 /// after comment stripping. `set_current_dir` names no variable, so it is
 /// counted in the total and never in the indirect column.
 const ENV_MUTATION_BUDGET: &[(&str, usize, usize)] = &[
-    // Production: PATH manipulation around a `gh` invocation.
-    ("tm/gh_identity.rs", 3, 0),
+    // Production: PATH manipulation around a `gh` invocation (3 sites), plus
+    // 6 TEST-ONLY sites added by #5849: the enforcement path now REFUSES under
+    // an ambient GH_TOKEN/GITHUB_TOKEN, so these tests must control that input
+    // instead of inheriting whatever the shell exports. Every key is a literal,
+    // so the indirect budget stays 0.
+    ("tm/gh_identity.rs", 9, 0),
     // Production: daemonisation chdir.
     ("tm/commands/daemon_run.rs", 2, 0),
     // Test-only: TRUSTY_MPM_ROOT / XDG_CONFIG_HOME, via this target's own

--- a/crates/trusty-mpm/src/bin/tm/gh_identity.rs
+++ b/crates/trusty-mpm/src/bin/tm/gh_identity.rs
@@ -267,8 +267,14 @@ mod tests {
         let script = format!(
             r#"#!/bin/sh
 STATE="$GH_CONFIG_DIR/.fake_active"
+if [ -f "$STATE" ]; then ACTIVE=$(cat "$STATE"); else ACTIVE="{initial}"; fi
+# #5849: enforcement verifies with `gh api user`, so the fake must answer it —
+# here the honest machine, where the config dir and the credential agree.
+if [ "$1" = "api" ] && [ "$2" = "user" ]; then
+  echo "$ACTIVE"
+  exit 0
+fi
 if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
-  if [ -f "$STATE" ]; then ACTIVE=$(cat "$STATE"); else ACTIVE="{initial}"; fi
   echo "github.com"
   echo "  - Logged in to github.com account $ACTIVE (keyring)"
   echo "  - Active account: true"

--- a/crates/trusty-mpm/src/bin/tm/gh_identity.rs
+++ b/crates/trusty-mpm/src/bin/tm/gh_identity.rs
@@ -315,6 +315,44 @@ exit 1
         prior
     }
 
+    /// Remove any ambient `GH_TOKEN`/`GITHUB_TOKEN`, returning them to restore.
+    ///
+    /// #5849: an ambient token makes `ensure_gh_account_in_dir` refuse, so a
+    /// shell or CI job that exports one would otherwise decide these outcomes.
+    /// Keys are spelled as literals (never a loop variable) so
+    /// `env_isolation_tests`' rule-1 source scan can read what these write.
+    #[cfg(unix)]
+    type AmbientTokens = (Option<std::ffi::OsString>, Option<std::ffi::OsString>);
+
+    #[cfg(unix)]
+    fn strip_ambient_tokens() -> AmbientTokens {
+        let prior = (
+            std::env::var_os("GH_TOKEN"),
+            std::env::var_os("GITHUB_TOKEN"),
+        );
+        // SAFETY: guarded by `fake_gh_lock` in every caller.
+        unsafe {
+            std::env::remove_var("GH_TOKEN");
+            std::env::remove_var("GITHUB_TOKEN");
+        }
+        prior
+    }
+
+    #[cfg(unix)]
+    fn restore_ambient_tokens(prior: AmbientTokens) {
+        // SAFETY: guarded by `fake_gh_lock` in every caller.
+        unsafe {
+            match prior.0 {
+                Some(v) => std::env::set_var("GH_TOKEN", v),
+                None => std::env::remove_var("GH_TOKEN"),
+            }
+            match prior.1 {
+                Some(v) => std::env::set_var("GITHUB_TOKEN", v),
+                None => std::env::remove_var("GITHUB_TOKEN"),
+            }
+        }
+    }
+
     #[cfg(unix)]
     fn restore_path(prior: Option<String>) {
         // SAFETY: guarded by `fake_gh_lock` in every caller.
@@ -341,12 +379,14 @@ exit 1
         let config_dir = tempfile::tempdir().expect("config tempdir");
         write_fake_gh(bin_dir.path(), "wrong-account", false);
         let prior_path = prepend_path(bin_dir.path());
+        let prior_tokens = strip_ambient_tokens();
 
         let mut cfg = gh(&config_dir.path().display().to_string());
         cfg.account = Some("bobmatnyc".to_string());
         let config = cfg_of(Some(cfg), Vec::new());
         let result = resolve_project_aware(&config, None);
 
+        restore_ambient_tokens(prior_tokens);
         restore_path(prior_path);
         assert!(result.is_ok(), "expected self-heal to succeed: {result:?}");
         let state = std::fs::read_to_string(config_dir.path().join(".fake_active"))
@@ -372,12 +412,14 @@ exit 1
         let config_dir = tempfile::tempdir().expect("config tempdir");
         write_fake_gh(bin_dir.path(), "wrong-account", true);
         let prior_path = prepend_path(bin_dir.path());
+        let prior_tokens = strip_ambient_tokens();
 
         let mut cfg = gh(&config_dir.path().display().to_string());
         cfg.account = Some("bobmatnyc".to_string());
         let config = cfg_of(Some(cfg), Vec::new());
         let result = resolve_project_aware(&config, None);
 
+        restore_ambient_tokens(prior_tokens);
         restore_path(prior_path);
         let err = result.expect_err("mismatched account with a failed switch must be an Err");
         assert!(err.to_string().contains("bobmatnyc"), "err: {err}");

--- a/crates/trusty-mpm/src/bin/tm/gh_identity.rs
+++ b/crates/trusty-mpm/src/bin/tm/gh_identity.rs
@@ -91,8 +91,13 @@ pub(crate) fn resolve_project_aware(
     // call, when the project pairs `config_dir` with an explicit `account`.
     // A project that never configures `account` alongside `config_dir` sees
     // no behaviour change here.
-    if let Some((dir, account)) = trusty_mpm::core::gh_account::configured_account_pair(selected) {
-        trusty_mpm::core::gh_account::ensure_gh_account_in_dir(&account, &dir)?;
+    if let Some(target) = trusty_mpm::core::gh_account::configured_account_pair(selected) {
+        // #5849: enforce on the project's configured host, not an assumed one.
+        trusty_mpm::core::gh_account::ensure_gh_account_in_dir(
+            &target.account,
+            &target.config_dir,
+            &target.host,
+        )?;
     }
 
     resolve_gh_env_anyhow(selected)

--- a/crates/trusty-mpm/src/core/gh_account.rs
+++ b/crates/trusty-mpm/src/core/gh_account.rs
@@ -99,7 +99,9 @@ impl GhAccountStatus {
     /// `verify_active_account` compares them byte-for-byte — so a `gh_user`
     /// persisted as `Acme-Bot` against a `gh` that reports `acme-bot` would
     /// pass a naive membership test here and then fail that later exact match.
-    /// Returning the canonical form makes the two agree by construction.
+    /// Returning the canonical form makes the two agree by construction. Since
+    /// #5849 that later match is against `gh api user --jq .login`, GitHub's
+    /// own spelling, so the canonical form is what it will be compared to.
     /// What: case-insensitive lookup over `logged_in`, returning `gh`'s
     /// spelling. `active` is deliberately not consulted — a project may name
     /// any logged-in account, not only the currently active one.

--- a/crates/trusty-mpm/src/core/gh_account.rs
+++ b/crates/trusty-mpm/src/core/gh_account.rs
@@ -410,7 +410,7 @@ const GH_ENFORCE_TIMEOUT: Duration = Duration::from_secs(5);
 #[path = "gh_account_enforce.rs"]
 mod enforce;
 pub use enforce::{
-    GH_CONFIG_DIR_ENV, configured_account_pair, ensure_gh_account_for_project,
+    AccountTarget, GH_CONFIG_DIR_ENV, configured_account_pair, ensure_gh_account_for_project,
     ensure_gh_account_in_dir,
 };
 

--- a/crates/trusty-mpm/src/core/gh_account_enforce.rs
+++ b/crates/trusty-mpm/src/core/gh_account_enforce.rs
@@ -44,7 +44,20 @@
 //! question; this module reports the divergence rather than papering over it.
 //!
 //! Every probe failure — `gh` missing, a non-zero exit, blank output, or the
-//! `GH_ENFORCE_TIMEOUT` bound — is a verification FAILURE, never a pass.
+//! `GH_ENFORCE_TIMEOUT` bound — is a verification FAILURE, never a pass. A
+//! failed probe also stops before `gh auth switch`: a network blip must not
+//! rewrite the project's config dir.
+//!
+//! ## The one thing a scoped probe cannot answer for
+//!
+//! An AMBIENT `GH_TOKEN`/`GITHUB_TOKEN` outranks `GH_CONFIG_DIR` in `gh`'s
+//! resolution order, and `gh_identity::resolve_gh_env` emits only
+//! `GH_CONFIG_DIR` for a pinned project — every other `gh` call overlays that
+//! onto the inherited environment. The probes here strip both token vars, so
+//! they would report the config-dir credential while the real work ran as the
+//! token's owner. `ensure_gh_account_in_dir` therefore REFUSES outright when
+//! either variable is set, rather than verifying something it cannot speak
+//! for.
 //!
 //! ## Production wiring (#3312)
 //!
@@ -94,6 +107,11 @@ pub const GH_CONFIG_DIR_ENV: &str = "GH_CONFIG_DIR";
 /// cannot silently outrank the isolated config dir.
 const GH_TOKEN_ENV_VARS: [&str; 2] = ["GH_TOKEN", "GITHUB_TOKEN"];
 
+/// Env var that selects which GitHub host `gh` talks to; pinned on every
+/// scoped call so a probe cannot answer for a different host than the
+/// `gh auth switch --hostname github.com` this module runs (#5849).
+const GH_HOST_ENV: &str = "GH_HOST";
+
 /// Ensure `gh` is authenticated as `expected_user` for `config_dir`, WITHOUT
 /// mutating any other gh config store — the #2081 per-project mechanism.
 ///
@@ -109,21 +127,26 @@ const GH_TOKEN_ENV_VARS: [&str; 2] = ["GH_TOKEN", "GITHUB_TOKEN"];
 /// active, so this also corrects (and then re-verifies) the active-user
 /// pointer INSIDE that store rather than assuming a config-dir switch is
 /// sufficient.
-/// What: probes the identity scoped to `config_dir` (with `GH_TOKEN` /
-/// `GITHUB_TOKEN` stripped from the child env so a stray token cannot outrank
-/// the config-dir identity) with BOTH `gh auth status` and `gh api user --jq
-/// .login`; `gh api user` decides (#5849), the transcript only supplies the
-/// env-token-override guard and the diagnostic. If `expected_user` is the
-/// authenticated identity, returns immediately with no mutation. Otherwise
-/// runs `gh auth switch --user <expected_user>` under the same scoped,
-/// token-stripped env, re-probes, and fails loudly (never silently proceeds)
-/// unless the re-check confirms `expected_user`.
-/// Test: `verify_active_account_*`, `parse_active_account_from_status_*`
-/// cover the pure decision logic; `ensure_gh_account_for_project_*` cover the
-/// public entry point's refusal path without a live `gh`;
-/// `ensure_gh_account_in_dir_*` (#3312, #5849) exercise this function directly
-/// against a fake `gh` on `PATH`, covering the self-heal, switch-failure,
-/// already-active no-op, contradicted-transcript, and failed-probe outcomes.
+/// What: refuses outright when an AMBIENT `GH_TOKEN`/`GITHUB_TOKEN` is set,
+/// because that token outranks `GH_CONFIG_DIR` for every unscoped `gh` call
+/// this process later makes and no probe here can speak for those calls (see
+/// [`ambient_token_override`]). Otherwise probes the identity scoped to
+/// `config_dir` (with both token vars stripped and `GH_HOST` pinned in the
+/// child env) using `gh auth status` and `gh api user --jq .login`; `gh api
+/// user` decides (#5849), the transcript supplies only the belt-and-braces
+/// override guard and the diagnostic. If `expected_user` is the authenticated
+/// identity, returns immediately with no mutation. A probe that could not
+/// answer returns an error WITHOUT switching — a network blip must never
+/// rewrite the project's config dir. A genuine mismatch runs `gh auth switch
+/// --user <expected_user>` under the same scoped env, re-probes, and fails
+/// loudly unless the re-check confirms `expected_user`.
+/// Test: `verify_active_account_*`, `parse_active_account_from_status_*`,
+/// `identity_divergence_*` cover the pure decision logic;
+/// `ensure_gh_account_for_project_*` cover the public entry point's refusal
+/// path without a live `gh`; `ensure_gh_account_in_dir_*` (#3312, #5849)
+/// exercise this function directly against a fake `gh` on `PATH`, covering the
+/// self-heal, switch-failure, already-active no-op, contradicted-transcript,
+/// failed-probe, blank-probe and ambient-token outcomes.
 ///
 /// Public (#3312) so every wired production call site — the CLI's
 /// `gh_identity::resolve_project_aware` and the daemon's
@@ -141,34 +164,52 @@ pub fn ensure_gh_account_in_dir(
     let dir = config_dir.to_string_lossy().to_string();
     let host = crate::core::trusty_tools_config::DEFAULT_GITHUB_HOST;
 
+    // #5849: an ambient token outranks GH_CONFIG_DIR for every later `gh` call,
+    // so nothing verified inside this directory would describe them.
+    if let Some(name) = ambient_token_override() {
+        anyhow::bail!(
+            "{name} is set in this environment and outranks {GH_CONFIG_DIR_ENV} in gh's \
+             credential resolution, so `gh` operations would run as whatever account that \
+             token belongs to — not necessarily '{expected_user}' — whatever {dir} contains. \
+             Unset {name} (or drop this project's `github.account` pin) and retry."
+        );
+    }
+
     let status_text = run_gh_scoped(&dir, ["auth", "status"])
         .context("failed to run `gh auth status` scoped to the project's GH_CONFIG_DIR")?;
     // #5849: the transcript echoes hosts.yml; `gh api user` is the identity the
     // API calls actually run as, and it decides.
     let probe = api_login_scoped(&dir);
-    if verify_active_account(
+    let verdict = verify_active_account(
         &status_text,
         probe.as_deref().map_err(String::as_str),
         expected_user,
-    )
-    .is_ok()
-    {
+    );
+    if verdict.is_ok() {
         warn_on_identity_divergence(&status_text, &probe);
         return Ok(());
     }
+    // #5849: correcting on an unanswerable probe would rewrite the project's
+    // config dir over a network blip, then blame the switch for the failure.
+    if probe.is_err() {
+        anyhow::bail!(
+            "refusing to switch accounts inside {dir}: {}",
+            verdict.unwrap_err()
+        );
+    }
 
-    // #5475: single `gh` entry point; the scoping env is unchanged.
-    let switch = trusty_common::gh::GhCommand::new([
-        "auth",
-        "switch",
-        "--hostname",
-        host,
-        "--user",
-        expected_user,
-    ])
-    .env(GH_CONFIG_DIR_ENV, &dir)
-    .env_remove(GH_TOKEN_ENV_VARS[0])
-    .env_remove(GH_TOKEN_ENV_VARS[1])
+    // #5475: single `gh` entry point; the scoping env is `scoped_gh`'s.
+    let switch = scoped_gh(
+        [
+            "auth",
+            "switch",
+            "--hostname",
+            host,
+            "--user",
+            expected_user,
+        ],
+        &dir,
+    )
     .output_blocking()
     .with_context(|| format!("failed to spawn `gh auth switch --user {expected_user}`"))?;
     if !switch.success {
@@ -222,10 +263,7 @@ fn api_login_scoped(config_dir: &str) -> Result<String, String> {
         // #5475: single `gh` entry point. `nonempty_stdout_blocking` folds a
         // non-zero exit and a blank login into the same `Err`.
         Some(
-            trusty_common::gh::GhCommand::new(["api", "user", "--jq", ".login"])
-                .env(GH_CONFIG_DIR_ENV, &dir)
-                .env_remove(GH_TOKEN_ENV_VARS[0])
-                .env_remove(GH_TOKEN_ENV_VARS[1])
+            scoped_gh(["api", "user", "--jq", ".login"], &dir)
                 .nonempty_stdout_blocking()
                 .map_err(|e| format!("`gh api user --jq .login` failed: {e}")),
         )
@@ -246,15 +284,13 @@ fn api_login_scoped(config_dir: &str) -> Result<String, String> {
 /// they configured is not the isolation they have. Enforcement is still
 /// correct to proceed (the effective identity is the expected one), but the
 /// divergence is worth a loud line in the log rather than silence.
-/// What: no-op unless the probe succeeded AND the transcript names an active
-/// login that differs from it; emits one WARN naming both.
-/// Test: side-effect logging only; the decision it guards is covered by
-/// `ensure_gh_account_in_dir_accepts_the_api_answer_over_a_stale_transcript`.
+/// What: emits one WARN naming both logins whenever [`identity_divergence`]
+/// finds one; nothing otherwise.
+/// Test: the decision is [`identity_divergence`]'s
+/// (`identity_divergence_*`); this wrapper is the logging side effect.
 fn warn_on_identity_divergence(status_text: &str, probe: &Result<String, String>) {
     let Ok(api_login) = probe else { return };
-    if let Some(claimed) = parse_active_account_from_status(status_text)
-        && &claimed != api_login
-    {
+    if let Some(claimed) = identity_divergence(status_text, api_login) {
         tracing::warn!(
             claimed_by_config_dir = %claimed,
             authenticated_as = %api_login,
@@ -262,6 +298,19 @@ fn warn_on_identity_divergence(status_text: &str, probe: &Result<String, String>
              the credential did not come from this GH_CONFIG_DIR (see #5656)"
         );
     }
+}
+
+/// The login the transcript claims, when it contradicts the probed identity.
+///
+/// Why: keeping the divergence DECISION out of the logging wrapper is what
+/// makes it testable — a `tracing` side effect is not.
+/// What: `Some(claimed)` only when the transcript marks some login active AND
+/// that login differs from `api_login`; `None` when they agree or when the
+/// transcript marks nothing active.
+/// Test: `identity_divergence_reports_a_contradicting_claim`,
+/// `identity_divergence_is_none_when_they_agree`.
+fn identity_divergence(status_text: &str, api_login: &str) -> Option<String> {
+    parse_active_account_from_status(status_text).filter(|claimed| claimed != api_login)
 }
 
 /// Run a bounded `gh` subprocess scoped to `config_dir`, with any env-token
@@ -273,22 +322,70 @@ fn warn_on_identity_divergence(status_text: &str, probe: &Result<String, String>
 /// one place.
 /// What: bounded by [`GH_ENFORCE_TIMEOUT`]; returns an error on a spawn
 /// failure or timeout.
-/// Test: exercised indirectly via `ensure_gh_account_for_project_*` (no live
-/// `gh` in CI, so only the refusal path — which never reaches this
-/// function — is asserted there).
+/// Test: `ensure_gh_account_in_dir_self_heals_mismatch` and its siblings drive
+/// this against a fake `gh` on `PATH`; `ensure_gh_account_for_project_*` cover
+/// the refusal path that never reaches it.
 fn run_gh_scoped(config_dir: &str, args: [&'static str; 2]) -> anyhow::Result<String> {
     let config_dir = config_dir.to_string();
     run_bounded(GH_ENFORCE_TIMEOUT, move || {
-        // #5475: single `gh` entry point.
-        let out = trusty_common::gh::GhCommand::new(args)
-            .env(GH_CONFIG_DIR_ENV, &config_dir)
-            .env_remove(GH_TOKEN_ENV_VARS[0])
-            .env_remove(GH_TOKEN_ENV_VARS[1])
-            .output_blocking()
-            .ok()?;
-        Some(out.combined())
+        // #5475: single `gh` entry point. A non-zero exit still yields text —
+        // only a spawn failure is an error here.
+        Some(
+            scoped_gh(args, &config_dir)
+                .output_blocking()
+                .map(|out| out.combined())
+                .map_err(|e| format!("failed to spawn `gh {}`: {e}", args.join(" "))),
+        )
     })
-    .ok_or_else(|| anyhow::anyhow!("`gh` did not respond within {GH_ENFORCE_TIMEOUT:?}"))
+    .unwrap_or_else(|| {
+        Err(format!(
+            "`gh {}` did not respond within {GH_ENFORCE_TIMEOUT:?}",
+            args.join(" ")
+        ))
+    })
+    .map_err(|msg| anyhow::anyhow!(msg))
+}
+
+/// Build a `gh` invocation pinned to one config dir, host, and no env token.
+///
+/// Why: the probes and the switch must all speak about the SAME identity.
+/// Leaving `GH_HOST` to the ambient environment let a probe answer for a
+/// different host than the `gh auth switch --hostname github.com` this module
+/// runs, so the check and the correction could disagree (#5849). Pinning it
+/// here keeps every scoped call in one place.
+/// What: sets `GH_CONFIG_DIR` and `GH_HOST` (always
+/// `DEFAULT_GITHUB_HOST` — this enforcement is github.com-only; a GHE project
+/// would need the host threaded through from `GithubConfig`), and removes both
+/// env-token overrides.
+/// Test: covered through `run_gh_scoped` and [`api_login_scoped`] by the
+/// `ensure_gh_account_in_dir_*` fake-`gh` tests.
+fn scoped_gh<const N: usize>(args: [&str; N], config_dir: &str) -> trusty_common::gh::GhCommand {
+    trusty_common::gh::GhCommand::new(args)
+        .env(GH_CONFIG_DIR_ENV, config_dir)
+        .env(
+            GH_HOST_ENV,
+            crate::core::trusty_tools_config::DEFAULT_GITHUB_HOST,
+        )
+        .env_remove(GH_TOKEN_ENV_VARS[0])
+        .env_remove(GH_TOKEN_ENV_VARS[1])
+}
+
+/// Name any ambient env token that outranks a scoped `GH_CONFIG_DIR`.
+///
+/// Why (#5849): the probes strip `GH_TOKEN`/`GITHUB_TOKEN` from their own child
+/// env, so they report the config-dir credential — but `gh_identity`'s
+/// `resolve_gh_env` emits only `GH_CONFIG_DIR` for a pinned project and every
+/// other `gh` call overlays that onto the INHERITED environment. An ambient
+/// token therefore decides those calls while the probes never see it: the check
+/// passes for one identity and the work runs as another. Refusing is the only
+/// honest outcome, since nothing inside the config dir can change it.
+/// What: the first of `GH_TOKEN`/`GITHUB_TOKEN` present in this process's
+/// environment with a non-blank value, else `None`.
+/// Test: `ensure_gh_account_in_dir_refuses_under_an_ambient_token`.
+fn ambient_token_override() -> Option<&'static str> {
+    GH_TOKEN_ENV_VARS
+        .into_iter()
+        .find(|name| std::env::var_os(name).is_some_and(|v| !v.to_string_lossy().trim().is_empty()))
 }
 
 /// Parse the login marked `Active account: true` from a `gh auth status` transcript.
@@ -367,8 +464,7 @@ pub(crate) fn verify_active_account(
     }
     // #5849: name the transcript's claim too when it disagrees — that gap is
     // the #5656 divergence, and it is the operator's next lead.
-    let claimed = parse_active_account_from_status(status_text)
-        .filter(|c| c != active)
+    let claimed = identity_divergence(status_text, active)
         .map(|c| format!(" (`gh auth status` claims '{c}' is active — see #5656)"))
         .unwrap_or_default();
     Err(format!(
@@ -707,7 +803,9 @@ github.com
     /// the honest machine, where the config dir and the credential agree.
     /// `FAKE_GH_API_LOGIN=X` makes it answer `X` regardless, which is how the
     /// transcript and the credential are made to DISAGREE; `FAKE_GH_API_FAILS=1`
-    /// makes it exit 1, standing in for an unreachable/unauthenticated probe.
+    /// makes it exit 1, standing in for an unreachable/unauthenticated probe;
+    /// `FAKE_GH_API_EMPTY=1` makes it exit 0 printing nothing, the blank-login
+    /// case `nonempty_stdout_blocking` must reject.
     #[cfg(unix)]
     fn write_fake_gh(bin_dir: &std::path::Path, initial: &str) {
         use std::os::unix::fs::PermissionsExt;
@@ -723,6 +821,9 @@ if [ "$1" = "api" ] && [ "$2" = "user" ]; then
   if [ "$FAKE_GH_API_FAILS" = "1" ]; then
     echo "fake gh: api refused" >&2
     exit 1
+  fi
+  if [ "$FAKE_GH_API_EMPTY" = "1" ]; then
+    exit 0
   fi
   if [ -n "$FAKE_GH_API_LOGIN" ]; then
     echo "$FAKE_GH_API_LOGIN"
@@ -784,6 +885,38 @@ exit 1
             std::env::remove_var("FAKE_GH_SWITCH_FAILS");
             std::env::remove_var("FAKE_GH_API_LOGIN");
             std::env::remove_var("FAKE_GH_API_FAILS");
+            std::env::remove_var("FAKE_GH_API_EMPTY");
+        }
+    }
+
+    /// Remove any ambient `GH_TOKEN`/`GITHUB_TOKEN`, returning them to restore.
+    ///
+    /// Since #5849 an ambient token is a REFUSAL input to
+    /// [`ensure_gh_account_in_dir`], so a developer shell (or a CI job) that
+    /// exports one would otherwise decide the outcome of every test below.
+    #[cfg(unix)]
+    fn strip_ambient_tokens() -> Vec<(&'static str, Option<std::ffi::OsString>)> {
+        GH_TOKEN_ENV_VARS
+            .into_iter()
+            .map(|name| {
+                let prior = std::env::var_os(name);
+                // SAFETY: guarded by `fake_gh_lock` in every caller.
+                unsafe { std::env::remove_var(name) };
+                (name, prior)
+            })
+            .collect()
+    }
+
+    #[cfg(unix)]
+    fn restore_ambient_tokens(prior: Vec<(&'static str, Option<std::ffi::OsString>)>) {
+        for (name, value) in prior {
+            // SAFETY: guarded by `fake_gh_lock` in every caller.
+            unsafe {
+                match value {
+                    Some(v) => std::env::set_var(name, v),
+                    None => std::env::remove_var(name),
+                }
+            }
         }
     }
 
@@ -811,10 +944,12 @@ exit 1
         let config_dir = tempfile::tempdir().expect("config tempdir");
         write_fake_gh(bin_dir.path(), "wrong-account");
         let prior_path = prepend_path(bin_dir.path());
+        let prior_tokens = strip_ambient_tokens();
         clear_fake_gh_env();
 
         let result = ensure_gh_account_in_dir("bobmatnyc", config_dir.path());
 
+        restore_ambient_tokens(prior_tokens);
         restore_path(prior_path);
         assert!(result.is_ok(), "expected self-heal to succeed: {result:?}");
         let state = std::fs::read_to_string(config_dir.path().join(".fake_active"))
@@ -835,6 +970,7 @@ exit 1
         let config_dir = tempfile::tempdir().expect("config tempdir");
         write_fake_gh(bin_dir.path(), "wrong-account");
         let prior_path = prepend_path(bin_dir.path());
+        let prior_tokens = strip_ambient_tokens();
         clear_fake_gh_env();
         // SAFETY: guarded by fake_gh_lock; cleared below.
         unsafe { std::env::set_var("FAKE_GH_SWITCH_FAILS", "1") };
@@ -842,6 +978,7 @@ exit 1
         let result = ensure_gh_account_in_dir("bobmatnyc", config_dir.path());
 
         clear_fake_gh_env();
+        restore_ambient_tokens(prior_tokens);
         restore_path(prior_path);
         let err = result.expect_err("switch failure must be a hard error");
         assert!(err.to_string().contains("bobmatnyc"), "err: {err}");
@@ -861,6 +998,7 @@ exit 1
         let config_dir = tempfile::tempdir().expect("config tempdir");
         write_fake_gh(bin_dir.path(), "bobmatnyc");
         let prior_path = prepend_path(bin_dir.path());
+        let prior_tokens = strip_ambient_tokens();
         clear_fake_gh_env();
         // SAFETY: guarded by fake_gh_lock; cleared below. A switch attempt
         // would fail if (incorrectly) invoked, proving the no-op path.
@@ -869,6 +1007,7 @@ exit 1
         let result = ensure_gh_account_in_dir("bobmatnyc", config_dir.path());
 
         clear_fake_gh_env();
+        restore_ambient_tokens(prior_tokens);
         restore_path(prior_path);
         assert!(
             result.is_ok(),
@@ -897,6 +1036,7 @@ exit 1
         let config_dir = tempfile::tempdir().expect("config tempdir");
         write_fake_gh(bin_dir.path(), "nonexistent-user-xyz");
         let prior_path = prepend_path(bin_dir.path());
+        let prior_tokens = strip_ambient_tokens();
         clear_fake_gh_env();
         // SAFETY: guarded by fake_gh_lock; cleared below.
         unsafe { std::env::set_var("FAKE_GH_API_LOGIN", "bobmatnyc") };
@@ -904,6 +1044,7 @@ exit 1
         let result = ensure_gh_account_in_dir("nonexistent-user-xyz", config_dir.path());
 
         clear_fake_gh_env();
+        restore_ambient_tokens(prior_tokens);
         restore_path(prior_path);
         let err = result.expect_err("a transcript the credential contradicts must not pass");
         let msg = err.to_string();
@@ -923,6 +1064,7 @@ exit 1
         let config_dir = tempfile::tempdir().expect("config tempdir");
         write_fake_gh(bin_dir.path(), "bobmatnyc");
         let prior_path = prepend_path(bin_dir.path());
+        let prior_tokens = strip_ambient_tokens();
         clear_fake_gh_env();
         // SAFETY: guarded by fake_gh_lock; cleared below.
         unsafe { std::env::set_var("FAKE_GH_API_FAILS", "1") };
@@ -930,12 +1072,106 @@ exit 1
         let result = ensure_gh_account_in_dir("bobmatnyc", config_dir.path());
 
         clear_fake_gh_env();
+        restore_ambient_tokens(prior_tokens);
         restore_path(prior_path);
         let err = result.expect_err("an unverifiable identity must never pass");
         assert!(
             err.to_string().contains("could not establish"),
             "err: {err}"
         );
+        // #5849: an unanswerable probe must not trigger a correction — a
+        // network blip may not rewrite the project's config dir.
+        assert!(
+            !config_dir.path().join(".fake_active").exists(),
+            "no switch may be attempted on an unverifiable probe"
+        );
+    }
+
+    /// Why (#5849): `gh api user --jq .login` can exit 0 printing nothing (a
+    /// response without the field, a blank credential). A blank login is not
+    /// an identity, so it must refuse rather than compare the empty string.
+    /// Test: itself.
+    #[cfg(unix)]
+    #[test]
+    fn ensure_gh_account_in_dir_fails_closed_on_a_blank_probe_answer() {
+        let _g = fake_gh_lock();
+        let bin_dir = tempfile::tempdir().expect("bin tempdir");
+        let config_dir = tempfile::tempdir().expect("config tempdir");
+        write_fake_gh(bin_dir.path(), "bobmatnyc");
+        let prior_path = prepend_path(bin_dir.path());
+        let prior_tokens = strip_ambient_tokens();
+        clear_fake_gh_env();
+        // SAFETY: guarded by fake_gh_lock; cleared below.
+        unsafe { std::env::set_var("FAKE_GH_API_EMPTY", "1") };
+
+        let result = ensure_gh_account_in_dir("bobmatnyc", config_dir.path());
+
+        clear_fake_gh_env();
+        restore_ambient_tokens(prior_tokens);
+        restore_path(prior_path);
+        let err = result.expect_err("a blank login is not an identity");
+        assert!(
+            err.to_string().contains("could not establish"),
+            "err: {err}"
+        );
+        assert!(
+            !config_dir.path().join(".fake_active").exists(),
+            "no switch may be attempted on an unverifiable probe"
+        );
+    }
+
+    /// Why (#5849): the probes strip `GH_TOKEN`/`GITHUB_TOKEN` from their own
+    /// child env, but `gh_identity::resolve_gh_env` emits only `GH_CONFIG_DIR`
+    /// for a pinned project and every other `gh` call overlays that onto the
+    /// INHERITED environment — where an ambient token outranks the config dir.
+    /// The probe would answer for the config-dir credential and the real work
+    /// would run as the token's owner, so enforcement must refuse outright.
+    /// Test: itself.
+    #[cfg(unix)]
+    #[test]
+    fn ensure_gh_account_in_dir_refuses_under_an_ambient_token() {
+        let _g = fake_gh_lock();
+        let bin_dir = tempfile::tempdir().expect("bin tempdir");
+        let config_dir = tempfile::tempdir().expect("config tempdir");
+        // The fake `gh` would report the expected account for BOTH probes, so
+        // only the ambient-token guard can produce a refusal here.
+        write_fake_gh(bin_dir.path(), "bobmatnyc");
+        let prior_path = prepend_path(bin_dir.path());
+        let prior_tokens = strip_ambient_tokens();
+        clear_fake_gh_env();
+        // SAFETY: guarded by fake_gh_lock; restored below.
+        unsafe { std::env::set_var("GH_TOKEN", "gho_someoneelses_token") };
+
+        let result = ensure_gh_account_in_dir("bobmatnyc", config_dir.path());
+
+        clear_fake_gh_env();
+        restore_ambient_tokens(prior_tokens);
+        restore_path(prior_path);
+        let err = result.expect_err("an ambient token outranks the config dir");
+        let msg = err.to_string();
+        assert!(msg.contains("GH_TOKEN"), "err: {msg}");
+        assert!(msg.contains(GH_CONFIG_DIR_ENV), "err: {msg}");
+    }
+
+    /// Why: the divergence decision must be readable without a subscriber —
+    /// a transcript naming a different active login than the credential is the
+    /// #5656 case worth reporting.
+    /// Test: itself.
+    #[test]
+    fn identity_divergence_reports_a_contradicting_claim() {
+        assert_eq!(
+            identity_divergence(SINGLE_AUTH_STATUS, "someone-else").as_deref(),
+            Some("bobmatnyc")
+        );
+    }
+
+    /// Why: agreement, and a transcript that marks nothing active, are both
+    /// silence — never a spurious warning.
+    /// Test: itself.
+    #[test]
+    fn identity_divergence_is_none_when_they_agree() {
+        assert_eq!(identity_divergence(SINGLE_AUTH_STATUS, "bobmatnyc"), None);
+        assert_eq!(identity_divergence("", "bobmatnyc"), None);
     }
 
     /// Why (#5849): the API answer is authoritative in BOTH directions. A
@@ -951,6 +1187,7 @@ exit 1
         let config_dir = tempfile::tempdir().expect("config tempdir");
         write_fake_gh(bin_dir.path(), "stale-account");
         let prior_path = prepend_path(bin_dir.path());
+        let prior_tokens = strip_ambient_tokens();
         clear_fake_gh_env();
         // SAFETY: guarded by fake_gh_lock; cleared below.
         unsafe {
@@ -961,6 +1198,7 @@ exit 1
         let result = ensure_gh_account_in_dir("bobmatnyc", config_dir.path());
 
         clear_fake_gh_env();
+        restore_ambient_tokens(prior_tokens);
         restore_path(prior_path);
         assert!(
             result.is_ok(),

--- a/crates/trusty-mpm/src/core/gh_account_enforce.rs
+++ b/crates/trusty-mpm/src/core/gh_account_enforce.rs
@@ -15,7 +15,7 @@
 //! `GH_CONFIG_DIR` (the convention this codebase's `gh_identity` module and
 //! the operator's own shell tooling already use to scope `gh` state per
 //! project/context) and only ever mutates the "active" pointer INSIDE that
-//! one directory, verifying the result with a fresh `gh auth status` before
+//! one directory, verifying the result with a fresh `gh api user` probe before
 //! returning success. No `GH_CONFIG_DIR` in the environment → refusal, never
 //! a fall-through to the shared global store.
 //!
@@ -23,6 +23,28 @@
 //! `verify_active_account`) is unit-tested inline; the public entry point's
 //! refusal path is covered without a live `gh` by
 //! `ensure_gh_account_for_project_refuses_without_config_dir`.
+//!
+//! ## What verification establishes (#5849)
+//!
+//! Verification asks `gh api user --jq .login` — the login GitHub itself
+//! attributes to the credential `gh` resolves inside this `GH_CONFIG_DIR` —
+//! and compares THAT to the expected account. It previously parsed the text of
+//! a `gh auth status` transcript, which only echoes what the scoped `hosts.yml`
+//! claims: a hand-written `hosts.yml` naming an account that exists nowhere on
+//! the machine printed a green checkmark, live token scopes and `Active
+//! account: true`, and enforcement passed it.
+//!
+//! So the identity this module confirms is the one an API call runs as, not the
+//! one the config file names. When the two disagree — the #5656 divergence,
+//! where a credential can resolve from the macOS keyring rather than the scoped
+//! config dir — the API answer decides and the disagreement is logged at WARN.
+//! That is the right side to take here: every downstream `gh` call is an API
+//! call, so the API answer is what "operating as the wrong account" means.
+//! Whether `GH_CONFIG_DIR` can isolate a credential at all stays #5656's
+//! question; this module reports the divergence rather than papering over it.
+//!
+//! Every probe failure — `gh` missing, a non-zero exit, blank output, or the
+//! `GH_ENFORCE_TIMEOUT` bound — is a verification FAILURE, never a pass.
 //!
 //! ## Production wiring (#3312)
 //!
@@ -87,19 +109,21 @@ const GH_TOKEN_ENV_VARS: [&str; 2] = ["GH_TOKEN", "GITHUB_TOKEN"];
 /// active, so this also corrects (and then re-verifies) the active-user
 /// pointer INSIDE that store rather than assuming a config-dir switch is
 /// sufficient.
-/// What: runs `gh auth status` scoped to `config_dir` (with `GH_TOKEN` /
+/// What: probes the identity scoped to `config_dir` (with `GH_TOKEN` /
 /// `GITHUB_TOKEN` stripped from the child env so a stray token cannot outrank
-/// the config-dir identity); if `expected_user` is already active, returns
-/// immediately with no mutation. Otherwise runs `gh auth switch --user
-/// <expected_user>` under the same scoped, token-stripped env, then re-runs
-/// `gh auth status` and fails loudly (never silently proceeds) unless the
-/// re-check confirms `expected_user` is now active.
+/// the config-dir identity) with BOTH `gh auth status` and `gh api user --jq
+/// .login`; `gh api user` decides (#5849), the transcript only supplies the
+/// env-token-override guard and the diagnostic. If `expected_user` is the
+/// authenticated identity, returns immediately with no mutation. Otherwise
+/// runs `gh auth switch --user <expected_user>` under the same scoped,
+/// token-stripped env, re-probes, and fails loudly (never silently proceeds)
+/// unless the re-check confirms `expected_user`.
 /// Test: `verify_active_account_*`, `parse_active_account_from_status_*`
 /// cover the pure decision logic; `ensure_gh_account_for_project_*` cover the
 /// public entry point's refusal path without a live `gh`;
-/// `ensure_gh_account_in_dir_*` (#3312) exercise this function directly
-/// against a fake `gh` on `PATH`, covering the self-heal, switch-failure, and
-/// already-active no-op outcomes.
+/// `ensure_gh_account_in_dir_*` (#3312, #5849) exercise this function directly
+/// against a fake `gh` on `PATH`, covering the self-heal, switch-failure,
+/// already-active no-op, contradicted-transcript, and failed-probe outcomes.
 ///
 /// Public (#3312) so every wired production call site — the CLI's
 /// `gh_identity::resolve_project_aware` and the daemon's
@@ -119,7 +143,17 @@ pub fn ensure_gh_account_in_dir(
 
     let status_text = run_gh_scoped(&dir, ["auth", "status"])
         .context("failed to run `gh auth status` scoped to the project's GH_CONFIG_DIR")?;
-    if verify_active_account(&status_text, expected_user).is_ok() {
+    // #5849: the transcript echoes hosts.yml; `gh api user` is the identity the
+    // API calls actually run as, and it decides.
+    let probe = api_login_scoped(&dir);
+    if verify_active_account(
+        &status_text,
+        probe.as_deref().map_err(String::as_str),
+        expected_user,
+    )
+    .is_ok()
+    {
+        warn_on_identity_divergence(&status_text, &probe);
         return Ok(());
     }
 
@@ -149,11 +183,85 @@ pub fn ensure_gh_account_in_dir(
 
     let recheck = run_gh_scoped(&dir, ["auth", "status"])
         .context("failed to re-verify `gh auth status` after switching")?;
-    verify_active_account(&recheck, expected_user).map_err(|msg| {
+    let recheck_probe = api_login_scoped(&dir);
+    let verdict = verify_active_account(
+        &recheck,
+        recheck_probe.as_deref().map_err(String::as_str),
+        expected_user,
+    );
+    if verdict.is_ok() {
+        warn_on_identity_divergence(&recheck, &recheck_probe);
+    }
+    verdict.map_err(|msg| {
         anyhow::anyhow!(
             "gh account switch to '{expected_user}' did not take effect inside {dir}: {msg}"
         )
     })
+}
+
+/// Ask GitHub which login the credential scoped to `config_dir` belongs to.
+///
+/// Why (#5849): `gh auth status` reports what the scoped `hosts.yml` CLAIMS —
+/// it prints a green checkmark and live token scopes for an account that
+/// exists nowhere on the machine. `gh api user` is answered by GitHub itself
+/// using the credential `gh` resolves, so it is the identity every subsequent
+/// `gh` call will actually operate as. That is the only fact worth checking
+/// before enforcement reports success.
+/// What: `gh api user --jq .login`, scoped to `config_dir` and with the
+/// env-token overrides stripped exactly as [`run_gh_scoped`] does, bounded by
+/// [`GH_ENFORCE_TIMEOUT`]. Every failure mode — `gh` missing, a non-zero exit
+/// (unauthenticated, network, rate limit), blank output, or the timeout —
+/// returns `Err`, which [`verify_active_account`] treats as verification
+/// failure. It never yields a login it did not read from GitHub.
+/// Test: `ensure_gh_account_in_dir_fails_closed_when_the_api_probe_fails` and
+/// `ensure_gh_account_in_dir_rejects_a_transcript_the_api_contradicts` drive
+/// it through a fake `gh` on `PATH`.
+fn api_login_scoped(config_dir: &str) -> Result<String, String> {
+    let dir = config_dir.to_string();
+    run_bounded(GH_ENFORCE_TIMEOUT, move || {
+        // #5475: single `gh` entry point. `nonempty_stdout_blocking` folds a
+        // non-zero exit and a blank login into the same `Err`.
+        Some(
+            trusty_common::gh::GhCommand::new(["api", "user", "--jq", ".login"])
+                .env(GH_CONFIG_DIR_ENV, &dir)
+                .env_remove(GH_TOKEN_ENV_VARS[0])
+                .env_remove(GH_TOKEN_ENV_VARS[1])
+                .nonempty_stdout_blocking()
+                .map_err(|e| format!("`gh api user --jq .login` failed: {e}")),
+        )
+    })
+    .unwrap_or_else(|| {
+        Err(format!(
+            "`gh api user --jq .login` did not respond within {GH_ENFORCE_TIMEOUT:?}"
+        ))
+    })
+}
+
+/// Log when the scoped `hosts.yml` and the credential name different logins.
+///
+/// Why (#5656, #5849): verification now passes on the API answer alone, so a
+/// config dir whose transcript claims a DIFFERENT account would otherwise go
+/// unremarked — the credential resolved from somewhere other than the config
+/// dir (a machine keyring, per #5656), and the isolation the operator believes
+/// they configured is not the isolation they have. Enforcement is still
+/// correct to proceed (the effective identity is the expected one), but the
+/// divergence is worth a loud line in the log rather than silence.
+/// What: no-op unless the probe succeeded AND the transcript names an active
+/// login that differs from it; emits one WARN naming both.
+/// Test: side-effect logging only; the decision it guards is covered by
+/// `ensure_gh_account_in_dir_accepts_the_api_answer_over_a_stale_transcript`.
+fn warn_on_identity_divergence(status_text: &str, probe: &Result<String, String>) {
+    let Ok(api_login) = probe else { return };
+    if let Some(claimed) = parse_active_account_from_status(status_text)
+        && &claimed != api_login
+    {
+        tracing::warn!(
+            claimed_by_config_dir = %claimed,
+            authenticated_as = %api_login,
+            "gh auth status and gh api user name different accounts; \
+             the credential did not come from this GH_CONFIG_DIR (see #5656)"
+        );
+    }
 }
 
 /// Run a bounded `gh` subprocess scoped to `config_dir`, with any env-token
@@ -185,9 +293,11 @@ fn run_gh_scoped(config_dir: &str, args: [&'static str; 2]) -> anyhow::Result<St
 
 /// Parse the login marked `Active account: true` from a `gh auth status` transcript.
 ///
-/// Why: [`verify_active_account`] needs the SPECIFIC active login (not just
-/// "who is logged in", which `parse_logged_in_accounts` already answers) to
-/// confirm a switch actually took effect.
+/// Why: what the scoped config dir CLAIMS is no longer the verification
+/// itself (#5849 moved that to `gh api user`), but it is still the specific
+/// fact worth reporting when the claim and the credential disagree — the
+/// #5656 divergence. `parse_logged_in_accounts` answers "who is logged in",
+/// which is a different question.
 /// What: scans line-by-line, tracking the login introduced by the most recent
 /// "Logged in to ..." line, and returns it the first time a following
 /// "Active account: true" line is seen. Returns `None` when no login is ever
@@ -211,22 +321,32 @@ pub(crate) fn parse_active_account_from_status(auth_status: &str) -> Option<Stri
     None
 }
 
-/// Decide whether a `gh auth status` transcript confirms `expected` is active.
+/// Decide whether the scoped `gh` really authenticates as `expected`.
 ///
-/// Why: isolates the verification decision — including the defensive check
-/// for an env-token override that would make the config-dir identity
-/// unverifiable — so it is unit-testable without a live `gh` and so
-/// [`ensure_gh_account_in_dir`] never has to guess at the meaning of raw
-/// status text.
+/// Why (#5849): this decision used to rest on `status_text` alone, and a
+/// `gh auth status` transcript is not evidence of an identity — it echoes the
+/// scoped `hosts.yml`, so a `hosts.yml` naming an account that exists nowhere
+/// on the machine produced `Active account: true` and passed. `api_login` is
+/// GitHub's own answer for the credential `gh` resolved, so it is what
+/// downstream `gh` calls will operate as. Keeping the decision in one pure
+/// function keeps it unit-testable without a live `gh`.
 /// What: `Err` when the transcript mentions an environment-variable token
-/// override (defence in depth: `GH_TOKEN`/`GITHUB_TOKEN` should already be
-/// stripped from the child env, but this catches the case where `gh` reports
-/// one anyway); `Err` when no account or a DIFFERENT account is active;
-/// `Ok(())` only when [`parse_active_account_from_status`] returns exactly
-/// `expected`.
+/// override (defence in depth: `GH_TOKEN`/`GITHUB_TOKEN` are already stripped
+/// from the child env, but this catches `gh` reporting one anyway); `Err` when
+/// `api_login` is `Err`, i.e. the probe could not establish an identity at all
+/// (fail closed — an unverifiable identity is never a pass); `Err` when the
+/// probed login differs from `expected`, naming what the transcript claimed
+/// when the two disagree. `Ok(())` only when the probe returned exactly
+/// `expected`. The transcript never overrides the probe in either direction.
 /// Test: `verify_active_account_matches`, `verify_active_account_mismatch`,
-/// `verify_active_account_rejects_env_token_override`.
-pub(crate) fn verify_active_account(status_text: &str, expected: &str) -> Result<(), String> {
+/// `verify_active_account_rejects_env_token_override`,
+/// `verify_active_account_follows_the_api_over_the_transcript`,
+/// `verify_active_account_fails_closed_when_the_probe_failed`.
+pub(crate) fn verify_active_account(
+    status_text: &str,
+    api_login: Result<&str, &str>,
+    expected: &str,
+) -> Result<(), String> {
     let lower = status_text.to_lowercase();
     if lower.contains("environment variable")
         && (lower.contains("gh_token") || lower.contains("github_token"))
@@ -236,15 +356,24 @@ pub(crate) fn verify_active_account(status_text: &str, expected: &str) -> Result
              so the active account inside this GH_CONFIG_DIR cannot be verified as '{expected}'"
         ));
     }
-    match parse_active_account_from_status(status_text) {
-        Some(active) if active == expected => Ok(()),
-        Some(active) => Err(format!(
-            "active account is '{active}', expected '{expected}'"
-        )),
-        None => Err(format!(
-            "could not determine an active gh account (expected '{expected}')"
-        )),
+    let active = api_login.map_err(|why| {
+        format!(
+            "could not establish which account gh authenticates as \
+             (expected '{expected}'): {why}"
+        )
+    })?;
+    if active == expected {
+        return Ok(());
     }
+    // #5849: name the transcript's claim too when it disagrees — that gap is
+    // the #5656 divergence, and it is the operator's next lead.
+    let claimed = parse_active_account_from_status(status_text)
+        .filter(|c| c != active)
+        .map(|c| format!(" (`gh auth status` claims '{c}' is active — see #5656)"))
+        .unwrap_or_default();
+    Err(format!(
+        "gh authenticates as '{active}', expected '{expected}'{claimed}"
+    ))
 }
 
 /// Ensure `gh` operations for a project default to `gh_user` — the #2081
@@ -261,7 +390,9 @@ pub(crate) fn verify_active_account(status_text: &str, expected: &str) -> Result
 /// → a loud, actionable error (never falls through to mutating the shared
 /// default gh config). When present, delegates to
 /// [`ensure_gh_account_in_dir`], which is itself a no-op when `gh_user` is
-/// already the active account inside that directory.
+/// already the account `gh` authenticates as inside that directory. `Ok(())`
+/// means `gh api user` reported `gh_user` (#5849) — not merely that the
+/// directory's `hosts.yml` names it.
 /// Test: `ensure_gh_account_for_project_refuses_without_config_dir` proves the
 /// refusal path never attempts any `gh` call (so it can never perform a
 /// global switch) when no isolated config dir is available.
@@ -385,23 +516,56 @@ github.com
         );
     }
 
-    /// Why: [`verify_active_account`] must succeed only when the expected
-    /// login is the one marked active.
+    /// Why: [`verify_active_account`] must succeed when the probed identity is
+    /// the expected login.
     /// Test: itself.
     #[test]
     fn verify_active_account_matches() {
-        assert!(verify_active_account(SINGLE_AUTH_STATUS, "bobmatnyc").is_ok());
+        assert!(verify_active_account(SINGLE_AUTH_STATUS, Ok("bobmatnyc"), "bobmatnyc").is_ok());
     }
 
-    /// Why: a mismatched active account (the exact #2081 incident shape —
-    /// `bob-duetto` active when `bobmatnyc` was expected) must be a loud `Err`,
-    /// never a silent pass.
+    /// Why: a mismatched account (the exact #2081 incident shape —
+    /// `bob-duetto` authenticated when `bobmatnyc` was expected) must be a loud
+    /// `Err`, never a silent pass.
     /// Test: itself.
     #[test]
     fn verify_active_account_mismatch() {
-        let err = verify_active_account(MULTI_AUTH_STATUS, "bobmatnyc").unwrap_err();
+        let err =
+            verify_active_account(MULTI_AUTH_STATUS, Ok("bob-duetto"), "bobmatnyc").unwrap_err();
         assert!(err.contains("bob-duetto"), "err: {err}");
         assert!(err.contains("bobmatnyc"), "err: {err}");
+    }
+
+    /// Why (#5849): the transcript is not evidence of an identity. When
+    /// `hosts.yml` claims the expected account is active but the credential
+    /// resolves to someone else, the API answer must decide and the error must
+    /// name BOTH logins — that gap is the #5656 divergence and the operator's
+    /// next lead.
+    /// Test: itself.
+    #[test]
+    fn verify_active_account_follows_the_api_over_the_transcript() {
+        let claims_ghost = "\
+github.com
+  ✓ Logged in to github.com account nonexistent-user-xyz (keyring)
+  - Active account: true
+";
+        let err = verify_active_account(claims_ghost, Ok("bobmatnyc"), "nonexistent-user-xyz")
+            .unwrap_err();
+        assert!(err.contains("bobmatnyc"), "err: {err}");
+        assert!(err.contains("nonexistent-user-xyz"), "err: {err}");
+        assert!(err.contains("5656"), "err: {err}");
+    }
+
+    /// Why (#5849): a probe that could not answer — `gh` missing, a non-zero
+    /// exit, a timeout — leaves the identity unverified, which must fail
+    /// CLOSED even when the transcript looks perfect.
+    /// Test: itself.
+    #[test]
+    fn verify_active_account_fails_closed_when_the_probe_failed() {
+        let err = verify_active_account(SINGLE_AUTH_STATUS, Err("gh: not found"), "bobmatnyc")
+            .unwrap_err();
+        assert!(err.contains("could not establish"), "err: {err}");
+        assert!(err.contains("gh: not found"), "err: {err}");
     }
 
     /// Why: if `gh` reports it is authenticating via an environment-variable
@@ -413,7 +577,7 @@ github.com
     #[test]
     fn verify_active_account_rejects_env_token_override() {
         let text = "The value of the GH_TOKEN environment variable is being used for authentication.\ngithub.com\n  ✓ Logged in to github.com account bobmatnyc\n  - Active account: true\n";
-        let err = verify_active_account(text, "bobmatnyc").unwrap_err();
+        let err = verify_active_account(text, Ok("bobmatnyc"), "bobmatnyc").unwrap_err();
         assert!(err.contains("environment variable"), "err: {err}");
     }
 
@@ -538,18 +702,36 @@ github.com
     /// holds (or `initial` if absent); `auth switch --user X` writes `X` to
     /// the state file and exits 0, unless `FAKE_GH_SWITCH_FAILS=1` is set in
     /// the environment, in which case it exits 1 without writing anything.
+    ///
+    /// `api user --jq .login` (#5849) answers with the same state by default —
+    /// the honest machine, where the config dir and the credential agree.
+    /// `FAKE_GH_API_LOGIN=X` makes it answer `X` regardless, which is how the
+    /// transcript and the credential are made to DISAGREE; `FAKE_GH_API_FAILS=1`
+    /// makes it exit 1, standing in for an unreachable/unauthenticated probe.
     #[cfg(unix)]
     fn write_fake_gh(bin_dir: &std::path::Path, initial: &str) {
         use std::os::unix::fs::PermissionsExt;
         let script = format!(
             r#"#!/bin/sh
 STATE="$GH_CONFIG_DIR/.fake_active"
-if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
-  if [ -f "$STATE" ]; then
-    ACTIVE=$(cat "$STATE")
-  else
-    ACTIVE="{initial}"
+if [ -f "$STATE" ]; then
+  ACTIVE=$(cat "$STATE")
+else
+  ACTIVE="{initial}"
+fi
+if [ "$1" = "api" ] && [ "$2" = "user" ]; then
+  if [ "$FAKE_GH_API_FAILS" = "1" ]; then
+    echo "fake gh: api refused" >&2
+    exit 1
   fi
+  if [ -n "$FAKE_GH_API_LOGIN" ]; then
+    echo "$FAKE_GH_API_LOGIN"
+  else
+    echo "$ACTIVE"
+  fi
+  exit 0
+fi
+if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
   echo "github.com"
   echo "  - Logged in to github.com account $ACTIVE (keyring)"
   echo "  - Active account: true"
@@ -594,6 +776,17 @@ exit 1
         prior
     }
 
+    /// Reset every `FAKE_GH_*` knob so one test's env cannot leak into the next.
+    #[cfg(unix)]
+    fn clear_fake_gh_env() {
+        // SAFETY: guarded by `fake_gh_lock` in every caller.
+        unsafe {
+            std::env::remove_var("FAKE_GH_SWITCH_FAILS");
+            std::env::remove_var("FAKE_GH_API_LOGIN");
+            std::env::remove_var("FAKE_GH_API_FAILS");
+        }
+    }
+
     #[cfg(unix)]
     fn restore_path(prior: Option<String>) {
         // SAFETY: guarded by `fake_gh_lock` in every caller.
@@ -618,8 +811,7 @@ exit 1
         let config_dir = tempfile::tempdir().expect("config tempdir");
         write_fake_gh(bin_dir.path(), "wrong-account");
         let prior_path = prepend_path(bin_dir.path());
-        // SAFETY: guarded by fake_gh_lock.
-        unsafe { std::env::remove_var("FAKE_GH_SWITCH_FAILS") };
+        clear_fake_gh_env();
 
         let result = ensure_gh_account_in_dir("bobmatnyc", config_dir.path());
 
@@ -643,12 +835,13 @@ exit 1
         let config_dir = tempfile::tempdir().expect("config tempdir");
         write_fake_gh(bin_dir.path(), "wrong-account");
         let prior_path = prepend_path(bin_dir.path());
-        // SAFETY: guarded by fake_gh_lock; removed below.
+        clear_fake_gh_env();
+        // SAFETY: guarded by fake_gh_lock; cleared below.
         unsafe { std::env::set_var("FAKE_GH_SWITCH_FAILS", "1") };
 
         let result = ensure_gh_account_in_dir("bobmatnyc", config_dir.path());
 
-        unsafe { std::env::remove_var("FAKE_GH_SWITCH_FAILS") };
+        clear_fake_gh_env();
         restore_path(prior_path);
         let err = result.expect_err("switch failure must be a hard error");
         assert!(err.to_string().contains("bobmatnyc"), "err: {err}");
@@ -668,17 +861,110 @@ exit 1
         let config_dir = tempfile::tempdir().expect("config tempdir");
         write_fake_gh(bin_dir.path(), "bobmatnyc");
         let prior_path = prepend_path(bin_dir.path());
-        // SAFETY: guarded by fake_gh_lock; removed below. A switch attempt
+        clear_fake_gh_env();
+        // SAFETY: guarded by fake_gh_lock; cleared below. A switch attempt
         // would fail if (incorrectly) invoked, proving the no-op path.
         unsafe { std::env::set_var("FAKE_GH_SWITCH_FAILS", "1") };
 
         let result = ensure_gh_account_in_dir("bobmatnyc", config_dir.path());
 
-        unsafe { std::env::remove_var("FAKE_GH_SWITCH_FAILS") };
+        clear_fake_gh_env();
         restore_path(prior_path);
         assert!(
             result.is_ok(),
             "already-active must be a no-op Ok: {result:?}"
+        );
+        assert!(
+            !config_dir.path().join(".fake_active").exists(),
+            "no switch should have been attempted"
+        );
+    }
+
+    // ── the API answer, not the transcript, decides (#5849) ──────────────
+
+    /// Why (#5849): the reported bug. A `hosts.yml` naming an account that
+    /// exists nowhere on the machine still prints `Active account: true`, and
+    /// enforcement used to pass on that text alone. Here the transcript claims
+    /// `nonexistent-user-xyz` — exactly what is expected — while the credential
+    /// resolves to `bobmatnyc`, and enforcement must REFUSE, naming both
+    /// logins. Before this fix the same fixture returned `Ok(())`.
+    /// Test: itself.
+    #[cfg(unix)]
+    #[test]
+    fn ensure_gh_account_in_dir_rejects_a_transcript_the_api_contradicts() {
+        let _g = fake_gh_lock();
+        let bin_dir = tempfile::tempdir().expect("bin tempdir");
+        let config_dir = tempfile::tempdir().expect("config tempdir");
+        write_fake_gh(bin_dir.path(), "nonexistent-user-xyz");
+        let prior_path = prepend_path(bin_dir.path());
+        clear_fake_gh_env();
+        // SAFETY: guarded by fake_gh_lock; cleared below.
+        unsafe { std::env::set_var("FAKE_GH_API_LOGIN", "bobmatnyc") };
+
+        let result = ensure_gh_account_in_dir("nonexistent-user-xyz", config_dir.path());
+
+        clear_fake_gh_env();
+        restore_path(prior_path);
+        let err = result.expect_err("a transcript the credential contradicts must not pass");
+        let msg = err.to_string();
+        assert!(msg.contains("bobmatnyc"), "err: {msg}");
+        assert!(msg.contains("nonexistent-user-xyz"), "err: {msg}");
+    }
+
+    /// Why (#5849): a probe that cannot answer leaves the identity unverified,
+    /// which must fail CLOSED — including when the transcript looks perfect
+    /// and names exactly the expected account.
+    /// Test: itself.
+    #[cfg(unix)]
+    #[test]
+    fn ensure_gh_account_in_dir_fails_closed_when_the_api_probe_fails() {
+        let _g = fake_gh_lock();
+        let bin_dir = tempfile::tempdir().expect("bin tempdir");
+        let config_dir = tempfile::tempdir().expect("config tempdir");
+        write_fake_gh(bin_dir.path(), "bobmatnyc");
+        let prior_path = prepend_path(bin_dir.path());
+        clear_fake_gh_env();
+        // SAFETY: guarded by fake_gh_lock; cleared below.
+        unsafe { std::env::set_var("FAKE_GH_API_FAILS", "1") };
+
+        let result = ensure_gh_account_in_dir("bobmatnyc", config_dir.path());
+
+        clear_fake_gh_env();
+        restore_path(prior_path);
+        let err = result.expect_err("an unverifiable identity must never pass");
+        assert!(
+            err.to_string().contains("could not establish"),
+            "err: {err}"
+        );
+    }
+
+    /// Why (#5849): the API answer is authoritative in BOTH directions. A
+    /// stale transcript naming the wrong account must not force a switch when
+    /// the credential already authenticates as the expected user. Proven by
+    /// making a switch attempt fail: `Ok` is only reachable without one.
+    /// Test: itself.
+    #[cfg(unix)]
+    #[test]
+    fn ensure_gh_account_in_dir_accepts_the_api_answer_over_a_stale_transcript() {
+        let _g = fake_gh_lock();
+        let bin_dir = tempfile::tempdir().expect("bin tempdir");
+        let config_dir = tempfile::tempdir().expect("config tempdir");
+        write_fake_gh(bin_dir.path(), "stale-account");
+        let prior_path = prepend_path(bin_dir.path());
+        clear_fake_gh_env();
+        // SAFETY: guarded by fake_gh_lock; cleared below.
+        unsafe {
+            std::env::set_var("FAKE_GH_API_LOGIN", "bobmatnyc");
+            std::env::set_var("FAKE_GH_SWITCH_FAILS", "1");
+        }
+
+        let result = ensure_gh_account_in_dir("bobmatnyc", config_dir.path());
+
+        clear_fake_gh_env();
+        restore_path(prior_path);
+        assert!(
+            result.is_ok(),
+            "the credential already matches; no switch is owed: {result:?}"
         );
         assert!(
             !config_dir.path().join(".fake_active").exists(),

--- a/crates/trusty-mpm/src/core/gh_account_enforce.rs
+++ b/crates/trusty-mpm/src/core/gh_account_enforce.rs
@@ -160,9 +160,9 @@ const GH_HOST_ENV: &str = "GH_HOST";
 pub fn ensure_gh_account_in_dir(
     expected_user: &str,
     config_dir: &std::path::Path,
+    host: &str,
 ) -> anyhow::Result<()> {
     let dir = config_dir.to_string_lossy().to_string();
-    let host = crate::core::trusty_tools_config::DEFAULT_GITHUB_HOST;
 
     // #5849: an ambient token outranks GH_CONFIG_DIR for every later `gh` call,
     // so nothing verified inside this directory would describe them.
@@ -175,27 +175,26 @@ pub fn ensure_gh_account_in_dir(
         );
     }
 
-    let status_text = run_gh_scoped(&dir, ["auth", "status"])
+    let status_text = run_gh_scoped(&dir, host, ["auth", "status"])
         .context("failed to run `gh auth status` scoped to the project's GH_CONFIG_DIR")?;
     // #5849: the transcript echoes hosts.yml; `gh api user` is the identity the
     // API calls actually run as, and it decides.
-    let probe = api_login_scoped(&dir);
-    let verdict = verify_active_account(
+    let probe = api_login_scoped(&dir, host);
+    match verify_active_account(
         &status_text,
         probe.as_deref().map_err(String::as_str),
         expected_user,
-    );
-    if verdict.is_ok() {
-        warn_on_identity_divergence(&status_text, &probe);
-        return Ok(());
-    }
-    // #5849: correcting on an unanswerable probe would rewrite the project's
-    // config dir over a network blip, then blame the switch for the failure.
-    if probe.is_err() {
-        anyhow::bail!(
-            "refusing to switch accounts inside {dir}: {}",
-            verdict.unwrap_err()
-        );
+    ) {
+        Ok(()) => {
+            warn_on_identity_divergence(&status_text, &probe);
+            return Ok(());
+        }
+        // #5849: correcting on an unanswerable probe would rewrite the
+        // project's config dir over a network blip, then blame the switch.
+        Err(msg) if probe.is_err() => {
+            anyhow::bail!("refusing to switch accounts inside {dir}: {msg}")
+        }
+        Err(_) => {}
     }
 
     // #5475: single `gh` entry point; the scoping env is `scoped_gh`'s.
@@ -209,6 +208,7 @@ pub fn ensure_gh_account_in_dir(
             expected_user,
         ],
         &dir,
+        host,
     )
     .output_blocking()
     .with_context(|| format!("failed to spawn `gh auth switch --user {expected_user}`"))?;
@@ -222,9 +222,9 @@ pub fn ensure_gh_account_in_dir(
         );
     }
 
-    let recheck = run_gh_scoped(&dir, ["auth", "status"])
+    let recheck = run_gh_scoped(&dir, host, ["auth", "status"])
         .context("failed to re-verify `gh auth status` after switching")?;
-    let recheck_probe = api_login_scoped(&dir);
+    let recheck_probe = api_login_scoped(&dir, host);
     let verdict = verify_active_account(
         &recheck,
         recheck_probe.as_deref().map_err(String::as_str),
@@ -257,13 +257,14 @@ pub fn ensure_gh_account_in_dir(
 /// Test: `ensure_gh_account_in_dir_fails_closed_when_the_api_probe_fails` and
 /// `ensure_gh_account_in_dir_rejects_a_transcript_the_api_contradicts` drive
 /// it through a fake `gh` on `PATH`.
-fn api_login_scoped(config_dir: &str) -> Result<String, String> {
+fn api_login_scoped(config_dir: &str, host: &str) -> Result<String, String> {
     let dir = config_dir.to_string();
+    let host = host.to_string();
     run_bounded(GH_ENFORCE_TIMEOUT, move || {
         // #5475: single `gh` entry point. `nonempty_stdout_blocking` folds a
         // non-zero exit and a blank login into the same `Err`.
         Some(
-            scoped_gh(["api", "user", "--jq", ".login"], &dir)
+            scoped_gh(["api", "user", "--jq", ".login"], &dir, &host)
                 .nonempty_stdout_blocking()
                 .map_err(|e| format!("`gh api user --jq .login` failed: {e}")),
         )
@@ -325,13 +326,14 @@ fn identity_divergence(status_text: &str, api_login: &str) -> Option<String> {
 /// Test: `ensure_gh_account_in_dir_self_heals_mismatch` and its siblings drive
 /// this against a fake `gh` on `PATH`; `ensure_gh_account_for_project_*` cover
 /// the refusal path that never reaches it.
-fn run_gh_scoped(config_dir: &str, args: [&'static str; 2]) -> anyhow::Result<String> {
+fn run_gh_scoped(config_dir: &str, host: &str, args: [&'static str; 2]) -> anyhow::Result<String> {
     let config_dir = config_dir.to_string();
+    let host = host.to_string();
     run_bounded(GH_ENFORCE_TIMEOUT, move || {
         // #5475: single `gh` entry point. A non-zero exit still yields text —
         // only a spawn failure is an error here.
         Some(
-            scoped_gh(args, &config_dir)
+            scoped_gh(args, &config_dir, &host)
                 .output_blocking()
                 .map(|out| out.combined())
                 .map_err(|e| format!("failed to spawn `gh {}`: {e}", args.join(" "))),
@@ -348,24 +350,24 @@ fn run_gh_scoped(config_dir: &str, args: [&'static str; 2]) -> anyhow::Result<St
 
 /// Build a `gh` invocation pinned to one config dir, host, and no env token.
 ///
-/// Why: the probes and the switch must all speak about the SAME identity.
-/// Leaving `GH_HOST` to the ambient environment let a probe answer for a
-/// different host than the `gh auth switch --hostname github.com` this module
-/// runs, so the check and the correction could disagree (#5849). Pinning it
-/// here keeps every scoped call in one place.
-/// What: sets `GH_CONFIG_DIR` and `GH_HOST` (always
-/// `DEFAULT_GITHUB_HOST` — this enforcement is github.com-only; a GHE project
-/// would need the host threaded through from `GithubConfig`), and removes both
-/// env-token overrides.
+/// Why: the probes and the switch must all speak about the SAME identity on the
+/// SAME host. Leaving `GH_HOST` to the ambient environment let a probe answer
+/// for a different host than the `gh auth switch --hostname` this module runs
+/// (#5849), and hardcoding github.com would have attested the wrong host for a
+/// project whose `github.host` points at an enterprise instance — which is the
+/// host `gh_identity::resolve_gh_env` emits for its real `gh` calls.
+/// What: sets `GH_CONFIG_DIR` and `GH_HOST` (the project's configured host, via
+/// [`AccountTarget::host`]), and removes both env-token overrides.
 /// Test: covered through `run_gh_scoped` and [`api_login_scoped`] by the
 /// `ensure_gh_account_in_dir_*` fake-`gh` tests.
-fn scoped_gh<const N: usize>(args: [&str; N], config_dir: &str) -> trusty_common::gh::GhCommand {
+fn scoped_gh<const N: usize>(
+    args: [&str; N],
+    config_dir: &str,
+    host: &str,
+) -> trusty_common::gh::GhCommand {
     trusty_common::gh::GhCommand::new(args)
         .env(GH_CONFIG_DIR_ENV, config_dir)
-        .env(
-            GH_HOST_ENV,
-            crate::core::trusty_tools_config::DEFAULT_GITHUB_HOST,
-        )
+        .env(GH_HOST_ENV, host)
         .env_remove(GH_TOKEN_ENV_VARS[0])
         .env_remove(GH_TOKEN_ENV_VARS[1])
 }
@@ -380,12 +382,18 @@ fn scoped_gh<const N: usize>(args: [&str; N], config_dir: &str) -> trusty_common
 /// passes for one identity and the work runs as another. Refusing is the only
 /// honest outcome, since nothing inside the config dir can change it.
 /// What: the first of `GH_TOKEN`/`GITHUB_TOKEN` present in this process's
-/// environment with a non-blank value, else `None`.
-/// Test: `ensure_gh_account_in_dir_refuses_under_an_ambient_token`.
+/// environment with a value that is not the empty string. Deliberately NOT
+/// trimmed: `gh` is Go and its own test is `!= ""`, so it SELECTS a whitespace
+/// token — with `GH_TOKEN="   "` gh 2.89.0 exits zero and hands `"   "` on as
+/// the credential (`trusty_common::gh::GhCommand::nonempty_stdout` records the
+/// measurement). Trimming here would read that as absent and let the check
+/// proceed under a token `gh` is already using.
+/// Test: `ambient_token_override_counts_a_whitespace_token`,
+/// `ensure_gh_account_in_dir_refuses_under_an_ambient_token`.
 fn ambient_token_override() -> Option<&'static str> {
     GH_TOKEN_ENV_VARS
         .into_iter()
-        .find(|name| std::env::var_os(name).is_some_and(|v| !v.to_string_lossy().trim().is_empty()))
+        .find(|name| std::env::var_os(name).is_some_and(|v| !v.is_empty()))
 }
 
 /// Parse the login marked `Active account: true` from a `gh auth status` transcript.
@@ -510,14 +518,43 @@ pub fn ensure_gh_account_for_project(gh_user: &str) -> anyhow::Result<()> {
             )
         })?;
 
-    ensure_gh_account_in_dir(gh_user, &config_dir)
+    // #5849: this entry point reads only an env var, so it has no project
+    // config to take a host from — github.com is the only answer available.
+    ensure_gh_account_in_dir(
+        gh_user,
+        &config_dir,
+        crate::core::trusty_tools_config::DEFAULT_GITHUB_HOST,
+    )
+}
+
+/// What enforcement checks, for one project: an account, inside a config dir,
+/// on a host.
+///
+/// Why (#5849): the host used to be assumed `github.com`, so a project whose
+/// `github.host` names an enterprise instance had its account verified on a
+/// host its real `gh` calls never touch. Carrying all three together means the
+/// probes, the `gh auth switch --hostname`, and
+/// `gh_identity::resolve_gh_env`'s `GH_HOST` cannot drift apart.
+/// What: `config_dir` and `account` come straight from [`GithubConfig`];
+/// `host` is its `host` when set to a non-blank value, else
+/// `DEFAULT_GITHUB_HOST`.
+/// Test: `configured_account_pair_both_set`,
+/// `configured_account_pair_carries_a_custom_host`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct AccountTarget {
+    /// The isolated `GH_CONFIG_DIR` enforcement operates inside.
+    pub config_dir: PathBuf,
+    /// The login every `gh` call for this project must authenticate as.
+    pub account: String,
+    /// The GitHub host that identity is checked (and switched) on.
+    pub host: String,
 }
 
 /// Decide WHETHER `#2081` account enforcement applies to a resolved
-/// [`GithubConfig`], and extract the `(config_dir, account)` pair to enforce
-/// when it does — the single decision point every wired call site (#3312)
-/// shares, so the CLI and the daemon can never diverge on when enforcement
-/// runs.
+/// [`GithubConfig`], and extract the [`AccountTarget`] to enforce when it
+/// does — the single decision point every wired call site (#3312) shares, so
+/// the CLI and the daemon can never diverge on when enforcement runs.
 ///
 /// Why: `account` alone documents intent (see `gh_identity`'s module docs and
 /// its `account_with_config_dir_is_ok` test) and `config_dir` alone is just an
@@ -529,28 +566,44 @@ pub fn ensure_gh_account_for_project(gh_user: &str) -> anyhow::Result<()> {
 /// chain already refuses to select alone) must see NO behaviour change: this
 /// returns `None` and the caller skips enforcement entirely, never spawning a
 /// `gh` subprocess and never failing a project that never opted in.
-/// What: `Some((dir, account))` only when `config.config_dir` is set AND
+/// What: `Some(target)` only when `config.config_dir` is set AND
 /// `config.account` is set to a non-blank value (trimmed); `None` for a
 /// `None` `config`, a blank/whitespace-only `account`, or either field
-/// missing.
+/// missing. The target's `host` follows `config.host`, falling back to
+/// `DEFAULT_GITHUB_HOST` (#5849).
 /// Test: `configured_account_pair_both_set`,
+/// `configured_account_pair_carries_a_custom_host`,
 /// `configured_account_pair_config_dir_only`,
 /// `configured_account_pair_account_only`,
 /// `configured_account_pair_blank_account`, `configured_account_pair_none`.
-pub fn configured_account_pair(config: Option<&GithubConfig>) -> Option<(PathBuf, String)> {
+pub fn configured_account_pair(config: Option<&GithubConfig>) -> Option<AccountTarget> {
     let cfg = config?;
-    let dir = cfg.config_dir.clone()?;
+    let config_dir = cfg.config_dir.clone()?;
     let account = cfg
         .account
         .as_deref()
         .map(str::trim)
         .filter(|s| !s.is_empty())?;
-    Some((dir, account.to_string()))
+    let host = cfg
+        .host
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or(crate::core::trusty_tools_config::DEFAULT_GITHUB_HOST);
+    Some(AccountTarget {
+        config_dir,
+        account: account.to_string(),
+        host: host.to_string(),
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The host the fake-`gh` tests enforce on; the fake ignores it, so any
+    /// value works — this names github.com to match the common project.
+    const TEST_HOST: &str = crate::core::trusty_tools_config::DEFAULT_GITHUB_HOST;
 
     /// Real `gh auth status` output with two github.com accounts logged in.
     const MULTI_AUTH_STATUS: &str = "\
@@ -734,7 +787,26 @@ github.com
         let cfg = github_cfg(Some("/cfg/acct"), Some("bobmatnyc"));
         assert_eq!(
             configured_account_pair(Some(&cfg)),
-            Some((PathBuf::from("/cfg/acct"), "bobmatnyc".to_string()))
+            Some(AccountTarget {
+                config_dir: PathBuf::from("/cfg/acct"),
+                account: "bobmatnyc".to_string(),
+                host: crate::core::trusty_tools_config::DEFAULT_GITHUB_HOST.to_string(),
+            })
+        );
+    }
+
+    /// Why (#5849): a project pointing `github.host` at an enterprise instance
+    /// must have its account verified THERE — `resolve_gh_env` emits that host
+    /// for the project's real `gh` calls, so enforcing against github.com would
+    /// attest a host the work never touches.
+    /// Test: itself.
+    #[test]
+    fn configured_account_pair_carries_a_custom_host() {
+        let mut cfg = github_cfg(Some("/cfg/acct"), Some("bobmatnyc"));
+        cfg.host = Some("github.acme.example".to_string());
+        assert_eq!(
+            configured_account_pair(Some(&cfg)).map(|t| t.host),
+            Some("github.acme.example".to_string())
         );
     }
 
@@ -947,7 +1019,7 @@ exit 1
         let prior_tokens = strip_ambient_tokens();
         clear_fake_gh_env();
 
-        let result = ensure_gh_account_in_dir("bobmatnyc", config_dir.path());
+        let result = ensure_gh_account_in_dir("bobmatnyc", config_dir.path(), TEST_HOST);
 
         restore_ambient_tokens(prior_tokens);
         restore_path(prior_path);
@@ -975,7 +1047,7 @@ exit 1
         // SAFETY: guarded by fake_gh_lock; cleared below.
         unsafe { std::env::set_var("FAKE_GH_SWITCH_FAILS", "1") };
 
-        let result = ensure_gh_account_in_dir("bobmatnyc", config_dir.path());
+        let result = ensure_gh_account_in_dir("bobmatnyc", config_dir.path(), TEST_HOST);
 
         clear_fake_gh_env();
         restore_ambient_tokens(prior_tokens);
@@ -1004,7 +1076,7 @@ exit 1
         // would fail if (incorrectly) invoked, proving the no-op path.
         unsafe { std::env::set_var("FAKE_GH_SWITCH_FAILS", "1") };
 
-        let result = ensure_gh_account_in_dir("bobmatnyc", config_dir.path());
+        let result = ensure_gh_account_in_dir("bobmatnyc", config_dir.path(), TEST_HOST);
 
         clear_fake_gh_env();
         restore_ambient_tokens(prior_tokens);
@@ -1041,7 +1113,7 @@ exit 1
         // SAFETY: guarded by fake_gh_lock; cleared below.
         unsafe { std::env::set_var("FAKE_GH_API_LOGIN", "bobmatnyc") };
 
-        let result = ensure_gh_account_in_dir("nonexistent-user-xyz", config_dir.path());
+        let result = ensure_gh_account_in_dir("nonexistent-user-xyz", config_dir.path(), TEST_HOST);
 
         clear_fake_gh_env();
         restore_ambient_tokens(prior_tokens);
@@ -1069,7 +1141,7 @@ exit 1
         // SAFETY: guarded by fake_gh_lock; cleared below.
         unsafe { std::env::set_var("FAKE_GH_API_FAILS", "1") };
 
-        let result = ensure_gh_account_in_dir("bobmatnyc", config_dir.path());
+        let result = ensure_gh_account_in_dir("bobmatnyc", config_dir.path(), TEST_HOST);
 
         clear_fake_gh_env();
         restore_ambient_tokens(prior_tokens);
@@ -1104,7 +1176,7 @@ exit 1
         // SAFETY: guarded by fake_gh_lock; cleared below.
         unsafe { std::env::set_var("FAKE_GH_API_EMPTY", "1") };
 
-        let result = ensure_gh_account_in_dir("bobmatnyc", config_dir.path());
+        let result = ensure_gh_account_in_dir("bobmatnyc", config_dir.path(), TEST_HOST);
 
         clear_fake_gh_env();
         restore_ambient_tokens(prior_tokens);
@@ -1142,7 +1214,7 @@ exit 1
         // SAFETY: guarded by fake_gh_lock; restored below.
         unsafe { std::env::set_var("GH_TOKEN", "gho_someoneelses_token") };
 
-        let result = ensure_gh_account_in_dir("bobmatnyc", config_dir.path());
+        let result = ensure_gh_account_in_dir("bobmatnyc", config_dir.path(), TEST_HOST);
 
         clear_fake_gh_env();
         restore_ambient_tokens(prior_tokens);
@@ -1151,6 +1223,25 @@ exit 1
         let msg = err.to_string();
         assert!(msg.contains("GH_TOKEN"), "err: {msg}");
         assert!(msg.contains(GH_CONFIG_DIR_ENV), "err: {msg}");
+    }
+
+    /// Why (#5849): `gh` is Go and tests its token variables with `!= ""`, so
+    /// `GH_TOKEN="   "` is a credential it SELECTS — measured on gh 2.89.0,
+    /// which exits zero and hands the whitespace on. A trimmed emptiness test
+    /// here would read that as absent and verify an identity `gh` is not using.
+    /// Test: itself.
+    #[cfg(unix)]
+    #[test]
+    fn ambient_token_override_counts_a_whitespace_token() {
+        let _g = fake_gh_lock();
+        let prior_tokens = strip_ambient_tokens();
+        // SAFETY: guarded by fake_gh_lock; restored below.
+        unsafe { std::env::set_var("GH_TOKEN", "   ") };
+
+        let seen = ambient_token_override();
+
+        restore_ambient_tokens(prior_tokens);
+        assert_eq!(seen, Some("GH_TOKEN"));
     }
 
     /// Why: the divergence decision must be readable without a subscriber —
@@ -1195,7 +1286,7 @@ exit 1
             std::env::set_var("FAKE_GH_SWITCH_FAILS", "1");
         }
 
-        let result = ensure_gh_account_in_dir("bobmatnyc", config_dir.path());
+        let result = ensure_gh_account_in_dir("bobmatnyc", config_dir.path(), TEST_HOST);
 
         clear_fake_gh_env();
         restore_ambient_tokens(prior_tokens);

--- a/crates/trusty-mpm/src/core/git_identity.rs
+++ b/crates/trusty-mpm/src/core/git_identity.rs
@@ -474,8 +474,14 @@ mod tests {
         let script = format!(
             r#"#!/bin/sh
 STATE="$GH_CONFIG_DIR/.fake_active"
+if [ -f "$STATE" ]; then ACTIVE=$(cat "$STATE"); else ACTIVE="{initial}"; fi
+# #5849: enforcement verifies with `gh api user`, so the fake must answer it —
+# here the honest machine, where the config dir and the credential agree.
+if [ "$1" = "api" ] && [ "$2" = "user" ]; then
+  echo "$ACTIVE"
+  exit 0
+fi
 if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
-  if [ -f "$STATE" ]; then ACTIVE=$(cat "$STATE"); else ACTIVE="{initial}"; fi
   echo "github.com"
   echo "  - Logged in to github.com account $ACTIVE (keyring)"
   echo "  - Active account: true"

--- a/crates/trusty-mpm/src/core/git_identity.rs
+++ b/crates/trusty-mpm/src/core/git_identity.rs
@@ -510,6 +510,36 @@ exit 1
         std::fs::set_permissions(&path, perms).expect("chmod fake gh");
     }
 
+    /// Remove any ambient `GH_TOKEN`/`GITHUB_TOKEN`, returning them to restore.
+    ///
+    /// #5849: an ambient token makes `ensure_gh_account_in_dir` refuse, so a
+    /// shell or CI job that exports one would otherwise decide these outcomes.
+    #[cfg(unix)]
+    fn strip_ambient_tokens() -> Vec<(&'static str, Option<std::ffi::OsString>)> {
+        ["GH_TOKEN", "GITHUB_TOKEN"]
+            .into_iter()
+            .map(|name| {
+                let prior = std::env::var_os(name);
+                // SAFETY: guarded by `fake_gh_lock` in every caller.
+                unsafe { std::env::remove_var(name) };
+                (name, prior)
+            })
+            .collect()
+    }
+
+    #[cfg(unix)]
+    fn restore_ambient_tokens(prior: Vec<(&'static str, Option<std::ffi::OsString>)>) {
+        for (name, value) in prior {
+            // SAFETY: guarded by `fake_gh_lock` in every caller.
+            unsafe {
+                match value {
+                    Some(v) => std::env::set_var(name, v),
+                    None => std::env::remove_var(name),
+                }
+            }
+        }
+    }
+
     #[cfg(unix)]
     fn prepend_path(dir: &std::path::Path) -> Option<String> {
         let prior = std::env::var("PATH").ok();
@@ -559,6 +589,7 @@ exit 1
         let config_dir = tempfile::tempdir().expect("config tempdir");
         write_fake_gh(bin_dir.path(), "wrong-account", false);
         let prior_path = prepend_path(bin_dir.path());
+        let prior_tokens = strip_ambient_tokens();
 
         let config = account_paired_config(config_dir.path(), "bobmatnyc");
         let result = block_on(resolve_for_config_enforced(
@@ -566,6 +597,7 @@ exit 1
             "https://github.com/acme/widget",
         ));
 
+        restore_ambient_tokens(prior_tokens);
         restore_path(prior_path);
         assert!(result.is_ok(), "expected self-heal to succeed: {result:?}");
         let state = std::fs::read_to_string(config_dir.path().join(".fake_active"))
@@ -590,6 +622,7 @@ exit 1
         let config_dir = tempfile::tempdir().expect("config tempdir");
         write_fake_gh(bin_dir.path(), "wrong-account", true);
         let prior_path = prepend_path(bin_dir.path());
+        let prior_tokens = strip_ambient_tokens();
 
         let config = account_paired_config(config_dir.path(), "bobmatnyc");
 
@@ -607,6 +640,7 @@ exit 1
             "https://github.com/acme/widget",
         ));
 
+        restore_ambient_tokens(prior_tokens);
         restore_path(prior_path);
         let err = enforced.expect_err("mismatched account with a failed switch must be an Err");
         assert!(err.to_string().contains("bobmatnyc"), "err: {err}");

--- a/crates/trusty-mpm/src/core/git_identity.rs
+++ b/crates/trusty-mpm/src/core/git_identity.rs
@@ -242,12 +242,14 @@ pub async fn resolve_for_config_enforced(
 ) -> anyhow::Result<GitIdentity> {
     let identity = resolve_for_config(config, repo_url)?;
 
-    if let Some((dir, account)) =
-        configured_account_pair(select_github_config_for(config, repo_url))
-    {
-        tokio::task::spawn_blocking(move || ensure_gh_account_in_dir(&account, &dir))
-            .await
-            .map_err(|e| anyhow::anyhow!("gh account enforcement task panicked: {e}"))??;
+    if let Some(target) = configured_account_pair(select_github_config_for(config, repo_url)) {
+        // #5849: the host travels with the account, so enforcement attests the
+        // host this project's `gh` calls actually run on.
+        tokio::task::spawn_blocking(move || {
+            ensure_gh_account_in_dir(&target.account, &target.config_dir, &target.host)
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("gh account enforcement task panicked: {e}"))??;
     }
 
     Ok(identity)


### PR DESCRIPTION
Refs #5849

## What the check is for

`ensure_gh_account_in_dir` / `ensure_gh_account_for_project` exist so a project
configured with `github.config_dir` + `github.account` cannot have its `gh`
operations run under some other identity. `Ok(())` from that path is the claim
"every subsequent `gh` call for this project acts as `<account>`".

That claim used to rest on parsing `gh auth status` text. The transcript echoes
whatever the scoped `GH_CONFIG_DIR`'s `hosts.yml` claims — it does not verify
that the credential resolves to that identity. A hand-written `hosts.yml`
naming an account that exists nowhere on the machine printed a green checkmark,
a keyring attribution, live token scopes and `Active account: true`, and
enforcement passed it.

The check now asks `gh api user --jq .login`, scoped to the same config dir and
with `GH_TOKEN`/`GITHUB_TOKEN` stripped exactly as before. That is the login
GitHub attributes to the credential `gh` actually resolves, so it is the
identity every downstream `gh` call operates as.

## The #5656 divergence: which identity this reports, and why

#5656 asks whether `GH_CONFIG_DIR` isolates a credential at all on macOS, where
`gh auth token` was observed returning a keyring credential unrelated to the
scoped config. That question is not settled here and this PR does not settle it.

What this PR does settle is which of the two answers enforcement reports:

- **API-derived** (`gh api user`) — what this check now reports.
- **Config-derived** (`hosts.yml` via `gh auth status`) — what it reported before.

The API-derived identity is the right one for this enforcement's purpose. The
harm being prevented is "an operation ran as the wrong GitHub account", and
every such operation is an API call, so the account GitHub attributes the
credential to is the account the operation runs as. A config file that names a
different login is not a second opinion about the identity; it is a statement
about a file.

The divergence is reported, not swallowed. When the transcript names an active
login that differs from the probed one, `warn_on_identity_divergence` emits a
WARN naming both and pointing at #5656 — so the case where the credential did
not come from the config dir is visible in the log instead of silent. When the
divergence is also a mismatch against the expected account, the error text names
both logins and cites #5656.

## Fail-closed table

| Condition | Verdict | Covered by |
|---|---|---|
| ambient `GH_TOKEN`/`GITHUB_TOKEN` set | **refuse before any probe** | `ensure_gh_account_in_dir_refuses_under_an_ambient_token` |
| `gh api user` returns the expected login | **pass** (WARN if the transcript names another login) | `..._noop_when_already_active`, `..._accepts_the_api_answer_over_a_stale_transcript` |
| `gh api user` returns a different login | **fail**, then switch + re-probe; names both logins and cites #5656 | `..._rejects_a_transcript_the_api_contradicts`, `..._self_heals_mismatch` |
| `gh` missing / non-zero exit | **fail**, and no switch is attempted | `..._fails_closed_when_the_api_probe_fails` |
| probe exits 0 with blank output | **fail**, and no switch is attempted | `..._fails_closed_on_a_blank_probe_answer` |
| probe exceeds the 5s `GH_ENFORCE_TIMEOUT` | **fail** — same path as a failed probe | **untested** (no fake-`gh` hang fixture; shares the `Err` arm the two rows above prove) |
| transcript reports a `GH_TOKEN`/`GITHUB_TOKEN` override | **fail** — belt-and-braces, checked first | `verify_active_account_rejects_env_token_override` |

The ambient-token row is the one that changed at review. The probes strip both
token variables, so they answer for the config-dir credential — but
`gh_identity::resolve_gh_env` emits only `GH_CONFIG_DIR` for a pinned project,
and every other `gh` call overlays that onto the INHERITED environment, where an
ambient token outranks the config dir. The check would pass for one identity
while the work ran as another, and the transcript's override branch could never
fire in production (the transcript is produced in the stripped env). Nothing
inside the config dir can fix that, so enforcement refuses.

`GH_HOST` is pinned on both probes to the host the correction targets, and that
host is now the project's configured `github.host` — the one
`gh_identity::resolve_gh_env` emits for the project's real `gh` calls — rather
than an assumed github.com. `configured_account_pair` returns an `AccountTarget`
(`config_dir`, `account`, `host`) and both call sites pass all three through.
Every scoped invocation goes through one `scoped_gh` builder.

The ambient-token test is `!= ""`, not a trimmed emptiness check: `gh` is Go and
tests its token variables the same way, so `GH_TOKEN="   "` is a credential it
SELECTS (gh 2.89.0 exits zero and hands the whitespace on — the measurement is
recorded in `trusty_common::gh::GhCommand::nonempty_stdout`). Trimming here would
read that as absent and verify an identity `gh` is not using.

An unverifiable identity is never a pass, and an unverifiable identity never
triggers a correction either: a failed probe returns before `gh auth switch`, so
a network blip cannot rewrite the project's config dir and then blame the switch
for the failure. A genuine mismatch still switches, re-probes, and hard-fails
unless the re-check confirms.

## Callers

`verify_active_account` is `pub(crate)` and has exactly two call sites, both
inside `ensure_gh_account_in_dir` (pre-check, post-switch re-check). Nothing
outside the module consumed its text-parsing behaviour — `git_identity.rs:246`
and `bin/tm/gh_identity.rs:95` call `ensure_gh_account_in_dir`, whose signature
and `anyhow::Result<()>` contract are unchanged. `parse_active_account_from_status`
is retained and still `pub(crate)`, now serving the divergence diagnostic rather
than the decision.

Two other fake-`gh` fixtures had to learn the `api user` arm, since the code
under test now runs that command: `core::git_identity`'s and
`bin/tm/gh_identity`'s. Both answer with the same state file their `auth status`
arm reads, i.e. the honest machine where config dir and credential agree.

## Tests

Three new integration tests drive `ensure_gh_account_in_dir` against a fake `gh`
on `PATH` (the crate's existing seam, extended with `FAKE_GH_API_LOGIN` /
`FAKE_GH_API_FAILS`), plus two new pure-decision unit tests:

- `ensure_gh_account_in_dir_rejects_a_transcript_the_api_contradicts` — the
  reported bug: transcript claims `nonexistent-user-xyz` is active, expected is
  `nonexistent-user-xyz`, credential resolves to `bobmatnyc` → must refuse.
- `ensure_gh_account_in_dir_fails_closed_when_the_api_probe_fails` — perfect
  transcript, probe exits non-zero → must refuse.
- `ensure_gh_account_in_dir_accepts_the_api_answer_over_a_stale_transcript` —
  API authority in the other direction: stale transcript, credential already
  correct → pass with no switch attempted.
- `verify_active_account_follows_the_api_over_the_transcript`,
  `verify_active_account_fails_closed_when_the_probe_failed`.

Provably failing before the fix. With `verify_active_account`'s body temporarily
reverted to the pre-#5849 text-parse decision, the same three tests fail:

```
---- ensure_gh_account_in_dir_rejects_a_transcript_the_api_contradicts stdout ----
panicked at crates/trusty-mpm/src/core/gh_account_enforce.rs:919:26:
a transcript the credential contradicts must not pass: ()

---- ensure_gh_account_in_dir_fails_closed_when_the_api_probe_fails stdout ----
panicked at crates/trusty-mpm/src/core/gh_account_enforce.rs:945:26:
an unverifiable identity must never pass: ()

test result: FAILED. 0 passed; 3 failed; 0 ignored; 0 measured; 5273 filtered out
```


Second fail-first proof, for the ambient-token guard. With
`ambient_token_override`'s result discarded (pre-guard behaviour) and the fake
`gh` reporting the expected account for both probes, so only the guard can
produce a refusal:

```
---- ensure_gh_account_in_dir_refuses_under_an_ambient_token stdout ----
panicked at crates/trusty-mpm/src/core/gh_account_enforce.rs:1154:26:
an ambient token outranks the config dir: ()

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 5279 filtered out
```

Both temporary reverts were removed before committing; `grep TEMP-PROOF` is empty.

## Gates — rung 5 (trust boundary)

```
cargo fmt --check                                    EXIT=0
cargo check -p trusty-mpm --all-targets              EXIT=0
cargo clippy -p trusty-mpm --all-targets -- -D warnings   EXIT=0
cargo test -p trusty-mpm --no-fail-fast              EXIT=0
cargo check --workspace --all-targets                EXIT=0
bash scripts/check_line_cap.sh                       0 violations
bash scripts/check_changelog_fragment.sh             OK trusty-mpm
bash scripts/check_sld.sh                            0 errors, 0 warnings
bash scripts/check-pr-version-bump.sh                OK 1.5.0 -> 1.5.1
```

`cargo test -p trusty-mpm --no-fail-fast`: lib `5275 passed; 0 failed; 7 ignored`,
`tm` bin `1828 passed; 0 failed; 1 ignored`, and every other target green
(50 result lines, 0 FAILED).

No `--include-ignored` run: the crate's ignored tests are live-tmux, live-Bedrock
and a static roster composition, none of which touch the enforcement path. The
fake-`gh`-on-`PATH` tests are this change's integration coverage and run
unconditionally.

## Version

`trusty-mpm` 1.5.0 is live on crates.io and this PR changes `src/**`, so the
version-parity gate requires a bump: 1.5.0 → 1.5.1 here. #6237 is open but
touches no `Cargo.toml`, so 1.5.1 is unclaimed.

## Public API

`configured_account_pair` returns `Option<AccountTarget>` instead of
`Option<(PathBuf, String)>`, and `ensure_gh_account_in_dir` takes a third `host`
argument. Both are `pub` under `trusty_mpm::core::gh_account`, so this is a
breaking change to the published crate's API surface: the release-time
`cargo-semver-checks` gate will require a major bump when `trusty-mpm` next
publishes. The version here stays 1.5.1 — that call belongs to the release, not
to this PR.

## Env-mutation budget

`tm/gh_identity.rs`'s entry in `ENV_MUTATION_BUDGET` rises 3 -> 9. The six new
sites are test-only: an ambient token now DECIDES the outcome of the enforcement
tests, so those tests must control it rather than inherit whatever the shell or
CI job exports. Every key is a string literal, so the indirect (rule-2) budget
stays 0.

## Not changed

Login comparison stays byte-for-byte. `gh api user` returns GitHub's canonical
spelling and `GhAccountStatus::canonical_logged_in_login` (#2121) already stores
that spelling, so the two agree by construction; loosening the comparison was
not needed and would have widened the check.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
