### PR TITLE
docs(semver-gate): name the Linux native prerequisite the gate needs (Refs #5440)

### DIFF
--- a/docs/reference/semver-gate.md
+++ b/docs/reference/semver-gate.md
@@ -255,6 +255,35 @@ remedy, never a skip: on the release path this gate is the last barrier, so a
 missing tool reporting green would put the repo back where #4088 found it. CI
 installs the same pinned version as a prebuilt binary.
 
+### Native prerequisites on Linux ([#5440](https://github.com/bobmatnyc/trusty-tools/issues/5440))
+
+The gate builds rustdoc with `--only-explicit-features`, so every feature that
+is not in `scripts/semver-checks-feature-exclusions.tsv` is on and its build
+scripts run. That makes the crate's native dependencies the gate's
+prerequisites too, and a missing one aborts the build before a single API is
+compared — exit 3, NO VERDICT, which is not a pass.
+
+On Debian/Ubuntu, running the gate over `trusty-common` needs:
+
+```bash
+sudo apt-get install -y libdbus-1-dev
+```
+
+`keyring-store` pulls `libdbus-sys`, whose `build.rs` calls `pkg-config dbus-1`
+and panics when the headers are absent. The panic names the pkg-config package
+and never the cargo feature, which is what made #5440 hard to read.
+
+macOS needs nothing: `keyring` resolves to `security-framework` there and
+`libdbus-sys` is not in the dependency graph, so the local publish path
+(`preflight-publish.sh` CHECK 5, run on the maintainer's Mac) never wanted it.
+`.github/workflows/semver-checks.yml` installs the package on `ubuntu-latest`
+before the gate runs; run `32789222713` is the first release-tag run to compare
+under it, reporting `196 checks: 196 pass, 58 skip` for `trusty-common` 0.43.1.
+
+A native dependency a runner cannot supply at all is a different problem — see
+[#5690](https://github.com/bobmatnyc/trusty-tools/issues/5690) for
+`trusty-search`'s `cuda` feature, which wants `nvcc`.
+
 ## Skips, and why each one is a fact rather than an excuse
 
 | Condition | Behaviour |

--- a/scripts/check_semver.sh
+++ b/scripts/check_semver.sh
@@ -1281,6 +1281,16 @@ The tool's own output is above. The usual causes:
     the gate. The `toolchain:` line above says which rustc that was. Install a
     newer one (`rustup toolchain install stable`), or point the gate at one:
         SEMVER_GATE_TOOLCHAIN_BIN=<dir> bash scripts/check_semver.sh --crate <c>
+  * A NATIVE LIBRARY THE FEATURE SET NEEDS IS ABSENT (issue #5440). The gate
+    builds with --only-explicit-features, so every non-excluded feature is on
+    and its build scripts run. On Linux, trusty-common's `keyring-store` pulls
+    libdbus-sys, whose build.rs shells out to `pkg-config dbus-1` and panics
+    when the headers are missing. The error text names the pkg-config package,
+    not the cargo feature. Remedy on Debian/Ubuntu:
+        sudo apt-get install -y libdbus-1-dev
+    macOS needs nothing here — keyring resolves to security-framework there and
+    libdbus-sys is not in the graph at all. CI installs the package in
+    .github/workflows/semver-checks.yml.
   * the baseline could not be fetched from crates.io.
   * a genuine compile error in the crate — build it directly to see it.
 


### PR DESCRIPTION
Refs #5440.

## What this is, and what it is not

The CI half of #5440 was already fixed by PR #5564 (`f9f1c546`), which added `libdbus-1-dev` to `.github/workflows/semver-checks.yml`. It was merged unproven. It is proven now: run [32789222713](https://github.com/bobmatnyc/trusty-tools/actions/runs/32789222713) — the `trusty-common-v0.43.1` tag push, 2026-08-24 — installed the package and completed a real comparison.

```
Setting up libdbus-1-dev:amd64 (1.14.10-4ubuntu4.1) ...
     Checked [   1.868s] 196 checks: 196 pass, 58 skip
semver gate: scanned (explicit); 1 crate(s) checked, 0 skipped — OK.
```

So this PR adds no workflow change. `grep -rn "check_semver\|cargo-semver-checks" .github/` finds exactly one path that invokes the gate — `semver-checks.yml` — and there are no composite actions; `pre-publish.yml`, `ci.yml`, `tag-publish-parity.yml` and `release.yml` mention it only in comments. Adding a second install step would be redundant.

## What was actually left

A human running the gate on Linux. The gate builds with `--only-explicit-features`, so the crate's native dependencies are the gate's prerequisites too, and a missing one aborts the rustdoc build before any API is compared — exit 3, NO VERDICT, which is not a pass. `libdbus-sys`'s `build.rs` panics naming `pkg-config dbus-1`, never the `keyring-store` cargo feature that pulled it, which is what made this hard to read the first time.

Two places now say so: the NO VERDICT remedy block in `scripts/check_semver.sh` (the text a person actually sees when it fails) and a prerequisites section in `docs/reference/semver-gate.md`.

macOS is unaffected — `keyring` resolves to `security-framework` there and `libdbus-sys` is not in the dependency graph, so the local publish path (`preflight-publish.sh` CHECK 5, run on the maintainer's Mac) never wanted the package. The recurrences cited on #5440 were all on that machine and had a different cause.

## Gates

Test ladder **rung 1** — documentation and one shell comment block; no crate `src/**`, so no changelog fragment and no Cargo test.

| Gate | Result |
|---|---|
| `bash scripts/check_sld.sh` | `61 spec doc(s) + 3393 code file(s); 0 error(s), 0 warning(s)` |
| `bash scripts/check_doc_numbers.sh` | `131 doc(s) / 125 claim(s); 3 grandfathered, 0 violations — OK` |
| `bash scripts/check_public_docs.sh` | `26 page(s) across 5 section(s) — all resolve inside the public boundary` |
| `bash scripts/check_semver_selftest.sh` | `29 passed, 0 failed` |
| `shellcheck scripts/check_semver.sh` | clean (one pre-existing SC1091 info on a sourced lib) |
| `bash -n scripts/check_semver.sh` | exit 0 |

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools