### PR TITLE
fix(ci): the SemVer check says whether it compared anything (Refs #5688)

### DIFF
--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -100,6 +100,15 @@ jobs:
     # #5311: was 40. The tag path checks one crate; a release PR can declare
     # several, and they are compared serially in this one job.
     timeout-minutes: 60
+    # #5688: what this run actually did, in one sentence, for the `verdict` job
+    # below to wear as its check name. Every branch that can conclude sets it
+    # BEFORE it exits, including the failing ones, so the fallback fires only
+    # when a step this job does not control died first.
+    outputs:
+      verdict_label: >-
+        ${{ steps.noop.outputs.verdict_label
+            || steps.enforce.outputs.verdict_label
+            || 'SemVer: verdict unavailable — the gate job did not reach a conclusion' }}
     steps:
       # fetch-depth: 0 — the pull-request path needs `git merge-base` and
       # `git show <merge-base>:crates/<X>/Cargo.toml`, neither of which a
@@ -303,12 +312,24 @@ jobs:
       # this issue was filed for. Both fail the job — a non-verdict is not a
       # pass — but a reader must be able to tell which one they are looking at
       # from the annotation alone.
+      #
+      # #5688: EXIT 0 IS THREE DIFFERENT FACTS, and they used to render as one
+      # green tick. The gate exits 0 when it compared a crate and found nothing
+      # wrong, when every selected crate was a recorded skip, and when the
+      # advisory inventory could not be built (`NO INVENTORY`, tool exit 101 —
+      # observed on PR #5686's trusty-search run, where the `cuda` feature wanted
+      # nvcc). Only the first is coverage. The counts come from the gate's own
+      # `semver-gate-verdict:` line, so nothing here re-parses the prose summary
+      # that preflight-publish.sh CHECK 5 reads; a line this step cannot find is
+      # treated as blindness, never as a clean compare.
       - name: Enforce public-API SemVer against crates.io
+        id: enforce
         if: steps.crate.outputs.have_work == 'true'
         env:
           SKIP_UI_BUILD: '1'
           CRATES: ${{ steps.crate.outputs.crates }}
         run: |
+          set -uo pipefail
           # One `--crate` per selected crate: check_semver.sh accumulates them
           # and reports a single verdict over the whole set, so a release PR
           # that bumps several gets one pass through the tool rather than N.
@@ -317,15 +338,59 @@ jobs:
             args+=(--crate "$c")
           done
           rc=0
-          bash scripts/check_semver.sh "${args[@]}" || rc=$?
-          if [[ "$rc" -eq 0 ]]; then
-            exit 0
-          fi
-          if [[ "$rc" -eq 3 ]]; then
-            echo "::error title=SemVer gate could not run::No verdict was computed for ${CRATES}. cargo-semver-checks never completed a comparison (see the log), so whether this release breaks the public API is UNKNOWN. Do not read this as a required version bump, and do not publish on it."
-          else
+          # REDIRECTED, NOT PIPED. A pipeline's status is its last command's, and
+          # the gate's exit code is the entire verdict — `| tee` here would
+          # report every failing run as a pass.
+          bash scripts/check_semver.sh "${args[@]}" > "${RUNNER_TEMP}/gate.log" 2>&1 || rc=$?
+          cat "${RUNNER_TEMP}/gate.log"
+
+          verdict_line="$(grep -E '^semver-gate-verdict:' "${RUNNER_TEMP}/gate.log" | tail -1 || true)"
+          compared="$(printf '%s' "$verdict_line" | sed -nE 's/.*[[:space:]]compared=([0-9]+).*/\1/p')"
+          blind="$(printf '%s' "$verdict_line" | sed -nE 's/.*[[:space:]]blind=([0-9]+).*/\1/p')"
+          inventoried="$(printf '%s' "$verdict_line" | sed -nE 's/.*[[:space:]]inventoried=([0-9]+).*/\1/p')"
+
+          if [[ "$rc" -eq 1 ]]; then
+            label="SemVer: BREAK — a breaking public-API change without a breaking bump"
             echo "::error title=SemVer break::${CRATES} has a breaking public-API change without a breaking version bump. See the failing lints in the log."
+          elif [[ "$rc" -eq 3 ]]; then
+            label="SemVer: NO VERDICT — the gate never compared anything"
+            echo "::error title=SemVer gate could not run::No verdict was computed for ${CRATES}. cargo-semver-checks never completed a comparison (see the log), so whether this release breaks the public API is UNKNOWN. Do not read this as a required version bump, and do not publish on it."
+          elif [[ "$rc" -ne 0 ]]; then
+            label="SemVer: gate malfunctioned (exit ${rc})"
+            echo "::error title=SemVer gate malfunctioned::check_semver.sh exited ${rc}, which is not one of its documented statuses (0 clean, 1 break, 2 usage, 3 no verdict). Nothing was compared."
+          elif [[ -z "$compared" ]]; then
+            label="SemVer: NO COMPARISON — the gate printed no verdict line"
+            echo "::warning title=SemVer gate reported no counts::check_semver.sh exited 0 but printed no 'semver-gate-verdict:' line, so how much it compared is unknown. Treat this as uncompared, not as clean."
+          elif [[ "${blind:-0}" -gt 0 ]]; then
+            label="SemVer: INCOMPLETE — ${blind} crate(s) could not be compared"
+            echo "::warning title=SemVer comparison incomplete::${blind} crate(s) reached cargo-semver-checks and produced no inventory, so nothing examined their public API. Green here means the version numbers already permit a break, not that the break was reviewed."
+          elif [[ "$compared" -eq 0 ]]; then
+            label="SemVer: NO COMPARISON — every selected crate was skipped"
+            echo "::warning title=SemVer compared nothing::Every crate selected for this run was a recorded skip (unpublished, bin-only, or excluded), so no public API was examined. See the skip reasons in the log."
+          elif [[ "${inventoried:-0}" -gt 0 ]]; then
+            # An inventoried crate WAS compared, but its findings are advisory:
+            # the declared bump already permits a break, so "no break" would be
+            # the wrong sentence even though the gate is green.
+            label="SemVer: ${compared} crate(s) compared — ${inventoried} advisory inventory (breaking bump)"
+            echo "::notice title=SemVer inventory::${inventoried} crate(s) already carry a breaking version bump, so their findings are an advisory inventory rather than a pass/fail verdict. Read the listed breaks in the log and confirm each was intended."
+          else
+            label="SemVer: ${compared} crate(s) compared, no break"
+            echo "::notice title=SemVer compared::${compared} crate(s) were compared against their previous crates.io release and no break was found."
           fi
+
+          echo "verdict_label=${label}" >> "$GITHUB_OUTPUT"
+          {
+            echo "## ${label}"
+            echo
+            echo "Crates selected: \`${CRATES}\`"
+            echo
+            echo "\`\`\`"
+            echo "${verdict_line:-<no semver-gate-verdict line>}"
+            echo "\`\`\`"
+            echo
+            echo "\`compared\` counts crates whose public API was actually examined."
+            echo "See [#5688](https://github.com/bobmatnyc/trusty-tools/issues/5688) for why this is spelled out."
+          } >> "$GITHUB_STEP_SUMMARY"
           exit "$rc"
 
       # #5311: the no-op path, and it must EXECUTE rather than be skipped —
@@ -334,9 +399,60 @@ jobs:
       # compare against the registry. The verdict for the release itself is
       # still owned by scripts/preflight-publish.sh CHECK 5 and by the tag-push
       # run of this same workflow; neither is weakened by this branch.
+      #
+      # #5688: still `success`, and still for #5311's reason — but it now says so
+      # where a reader will see it. PR #5686 carried a real break (a public field
+      # added to `SearchAppState` without `#[non_exhaustive]`) past this branch,
+      # because the only place this path admitted to comparing nothing was the
+      # job log, which nobody opens on a green check.
       - name: No release under test — nothing to compare
+        id: noop
         if: steps.crate.outputs.have_work != 'true'
         run: |
           echo "No crate's declared version changed against the base branch, so this"
           echo "branch releases nothing and there is no registry baseline to compare."
           echo "Reporting success rather than not reporting at all — see #5311."
+          echo "verdict_label=SemVer: no comparison ran — this branch declares no version bump" >> "$GITHUB_OUTPUT"
+          {
+            echo "## SemVer: no comparison ran"
+            echo
+            echo "No crate's declared version changed against the base branch, so nothing"
+            echo "is being released and there is no registry baseline to compare against."
+            echo "**cargo-semver-checks did not examine this branch's public API.**"
+            echo
+            echo "This is a pass by design ([#5311](https://github.com/bobmatnyc/trusty-tools/issues/5311)),"
+            echo "not a statement that the API is unchanged. The verdict for a release is owned by"
+            echo "\`scripts/preflight-publish.sh\` CHECK 5 and by this workflow's tag-push run."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # #5688: the verdict as a CHECK NAME, which is the one surface `gh pr checks`
+  # and the merge box render without anyone opening a log. The gate job's own
+  # name cannot carry it — that string is the branch-protection context, and a
+  # context whose name moves is a context that never reports. So this second,
+  # deliberately UNREQUIRED job wears the sentence instead.
+  #
+  # It mirrors the gate's conclusion rather than always passing: a check named
+  # "SemVer: BREAK" that reports green would be a worse conflation than the one
+  # this issue is about.
+  verdict:
+    name: ${{ needs.semver-checks.outputs.verdict_label }}
+    needs: semver-checks
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # Both values reach the shell through `env:`, never through `${{ }}`
+      # interpolation inside `run:` — the label is assembled from this
+      # workflow's own constants and the gate's integer counts, and keeping the
+      # seam closed means a future edit that puts a crate name in it cannot
+      # become a script injection.
+      - name: Restate the verdict
+        env:
+          LABEL: ${{ needs.semver-checks.outputs.verdict_label }}
+          GATE: ${{ needs.semver-checks.result }}
+        run: |
+          echo "$LABEL"
+          if [ "$GATE" != "success" ]; then
+            echo "::error title=SemVer gate did not pass::The 'Public API / SemVer' job concluded '${GATE}'. Read it, not this job."
+            exit 1
+          fi

--- a/docs/reference/semver-gate.md
+++ b/docs/reference/semver-gate.md
@@ -521,6 +521,42 @@ together**, and each outcome gets its own label:
 because the reason is a fact about the crate that is already recorded in a
 reviewable file — but it says `NOT VERIFIED`, because nothing looked at the API.
 
+### The same question, asked of the GitHub check ([#5688](https://github.com/bobmatnyc/trusty-tools/issues/5688))
+
+The four labels above were CHECK 5's alone. The `Public API / SemVer` check on a
+pull request had none: a run that compared a crate and found nothing wrong and a
+run that never looked both rendered as `Public API / SemVer — pass`, same name,
+same colour, the distinction visible only inside a job log nobody opens on a
+green tick. [PR #5686](https://github.com/bobmatnyc/trusty-tools/pull/5686)
+shipped a real break under that tick — a public field added to `SearchAppState`
+without `#[non_exhaustive]` — and a human caught it, not the gate.
+
+`check_semver.sh` now prints its tallies in a fixed shape beside the human
+summary, and `semver-checks.yml` turns them into a sentence:
+
+```
+semver-gate-verdict: compared=1 examined=1 skipped=0 inventoried=0 blind=0
+```
+
+`compared` is the number of crates whose public API was actually examined — the
+pass/fail arm and the advisory inventory arm both examine one. That sentence
+becomes the name of a second, deliberately **unrequired** `verdict` job, so it
+reads in `gh pr checks` and in the merge box without opening anything:
+
+| Check name | What happened |
+|---|---|
+| `SemVer: no comparison ran — this branch declares no version bump` | the #5311 short-circuit. Nothing examined the API |
+| `SemVer: N crate(s) compared, no break` | a real comparison, clean |
+| `SemVer: N crate(s) compared — M advisory inventory (breaking bump)` | compared, and the findings are permitted by the declared bump |
+| `SemVer: INCOMPLETE — N crate(s) could not be compared` | reached `cargo-semver-checks` and got no inventory back (exit 101, a missing native toolchain) |
+| `SemVer: NO COMPARISON — every selected crate was skipped` | every selection was a recorded skip |
+| `SemVer: BREAK` / `SemVer: NO VERDICT` | the gate job's own two failure states |
+
+The gate job keeps the name `Public API / SemVer` and keeps reporting `success`
+on the no-bump path. That name is the branch-protection context, and a context
+whose name moves is a context that never reports — which is the deadlock #5311
+exists to avoid. The sentence rides on the extra job instead.
+
 ### The override, and what it is not for
 
 ```bash

--- a/scripts/check_semver.sh
+++ b/scripts/check_semver.sh
@@ -879,6 +879,34 @@ verdict_computed() {
   return 0
 }
 
+# emit_verdict_line <checked> <skipped> <inventoried> <blind> — restate the run's
+# tallies in a fixed, machine-readable shape.
+#
+# Why: `.github/workflows/semver-checks.yml` has to tell "compared and found
+#   nothing" apart from "declined to compare" and from "tried and could not", so
+#   its GitHub check stops rendering all three as the same green
+#   (issue #5688; PR #5686 shipped a real break under one of them). The gate
+#   already holds those numbers; the workflow reading them out of the prose
+#   SUMMARY line would be a SECOND parser of a format
+#   `scripts/preflight-publish.sh` CHECK 5 already parses, free to drift from it.
+#   This is the one that is meant to be parsed.
+#
+# What: one line on stdout, alongside the human summary and never instead of it.
+#   `compared` is the number of crates whose API was actually examined — the
+#   PASS/FAIL arm and the advisory INVENTORY arm both examine one — so a
+#   consumer needs no knowledge of the arms to ask the only question that
+#   matters. Deliberately carries neither `crate(s) checked` nor `N checks:`,
+#   the substrings CHECK 5 and verdict_computed grep for, so adding it cannot
+#   shift either of their answers.
+#
+# Test: `scripts/check_semver_selftest.sh` — the already-breaking, blind and
+#   404-skip cases each assert the counts this line reports.
+emit_verdict_line() {
+  local checked="$1" skipped="$2" inventoried="$3" blind="$4"
+  printf 'semver-gate-verdict: compared=%d examined=%d skipped=%d inventoried=%d blind=%d\n' \
+    "$((checked + inventoried))" "$checked" "$skipped" "$inventoried" "$blind"
+}
+
 # no_verdict_because — one clause naming why verdict_computed refused, so the two
 # causes never share a message. "it never ran" and "it ran and skipped every
 # lint" have different remedies, and #5440 is the second one.
@@ -987,6 +1015,7 @@ fi
 
 if [[ -z "$CANDIDATES" ]]; then
   echo "semver gate: scanned ${SCANNED}; no crate source changed (docs-only / CI-only) — OK."
+  emit_verdict_line 0 0 0 0
   exit 0
 fi
 
@@ -1298,3 +1327,4 @@ if [[ "$inventory_blind" -ne 0 ]]; then
   SUMMARY="${SUMMARY}, ${inventory_blind} inventory NOT computed"
 fi
 echo "${SUMMARY} — OK."
+emit_verdict_line "$checked" "$skipped" "$inventoried" "$inventory_blind"

--- a/scripts/check_semver_selftest.sh
+++ b/scripts/check_semver_selftest.sh
@@ -587,6 +587,11 @@ elif [[ "$out" != *"breaking change(s) listed above"* ]]; then
   fail_case "inventory/already-breaking: exit 0 but the breaks were never reported" "$out"
 elif [[ "$out" == *"VERDICT: BREAK"* ]]; then
   fail_case "inventory/already-breaking: a permitted break was rendered as a SemVer verdict" "$out"
+elif [[ "$out" != *"semver-gate-verdict: compared=1 examined=0 skipped=0 inventoried=1 blind=0"* ]]; then
+  # #5688: semver-checks.yml reads this line to decide what its GitHub check
+  # says. An inventoried crate WAS compared, so `compared` must count it —
+  # reporting 0 here would label a real comparison "no comparison ran".
+  fail_case "inventory/already-breaking: the machine-readable verdict line did not count the inventoried crate as compared (#5688)" "$out"
 else
   pass_case "an already-breaking bump is inventoried, advisory (#5297b)"
 fi
@@ -603,6 +608,11 @@ elif [[ "$out" != *"inventory NOT computed"* ]]; then
   fail_case "inventory/blind: the summary line hid the missing inventory" "$out"
 elif [[ "$out" == *"no breaking changes found"* ]]; then
   fail_case "inventory/blind: a run that produced nothing was reported as clean" "$out"
+elif [[ "$out" != *"semver-gate-verdict: compared=0 examined=0 skipped=0 inventoried=0 blind=1"* ]]; then
+  # #5688: this is the shape that rendered as a plain green check on PR #5686's
+  # trusty-search run. `compared=0 blind=1` is what makes semver-checks.yml
+  # label it INCOMPLETE instead of clean.
+  fail_case "inventory/blind: the machine-readable verdict line did not report the blind run as uncompared (#5688)" "$out"
 else
   pass_case "an inventory that could not run says so, in the line and in the summary"
 fi


### PR DESCRIPTION
Refs #5688.

## The shape

`Public API / SemVer` reported the same green tick for three different facts, and only one of them is coverage. `check_semver.sh` now prints its tallies in a fixed machine-readable shape beside the human summary, and `semver-checks.yml` turns them into a sentence:

```
semver-gate-verdict: compared=1 examined=1 skipped=0 inventoried=0 blind=0
```

`compared` counts crates whose public API was actually examined, so a consumer needs no knowledge of the pass/fail and inventory arms. The line deliberately carries neither `crate(s) checked` nor `N checks:` — the substrings CHECK 5 and `verdict_computed` grep for — so the workflow reads these counts instead of becoming a second parser of a prose format `preflight-publish.sh` already parses.

## Where the sentence shows up

The gate job keeps the name `Public API / SemVer` and keeps reporting `success` on the no-bump path. That name is the branch-protection context, and a context whose name moves is a context that never reports — the deadlock #5311 exists to avoid. The sentence rides on a second, deliberately **unrequired** `verdict` job, as that job's check name, so it reads in `gh pr checks` and the merge box without opening a log. It also goes to `$GITHUB_STEP_SUMMARY` with a notice or warning annotation.

| Check name | What happened |
|---|---|
| `SemVer: no comparison ran — this branch declares no version bump` | the #5311 short-circuit. Nothing examined the API |
| `SemVer: N crate(s) compared, no break` | a real comparison, clean |
| `SemVer: N crate(s) compared — M advisory inventory (breaking bump)` | compared; findings permitted by the declared bump |
| `SemVer: INCOMPLETE — N crate(s) could not be compared` | reached cargo-semver-checks and got no inventory back (exit 101, missing native toolchain — the third shape from [this comment](https://github.com/bobmatnyc/trusty-tools/issues/5688#issuecomment-5291012551)) |
| `SemVer: NO COMPARISON — every selected crate was skipped` | every selection was a recorded skip |
| `SemVer: BREAK` / `SemVer: NO VERDICT` | the gate job's own two failure states |

The `verdict` job mirrors the gate's conclusion rather than always passing — a check named `SemVer: BREAK` reporting green would be a worse conflation than the one this fixes.

## Gates

Test ladder **rung 3** — localized behavior in release-gate shell plus its workflow; no crate `src/**`, so no changelog fragment.

| Gate | Result |
|---|---|
| `bash scripts/check_semver_selftest.sh` | `29 passed, 0 failed` |
| the same, with `emit_verdict_line` commented out | `27 passed, 2 FAILED` — the two new assertions are the ones that fire |
| `bash scripts/preflight-check5-selftest.sh` | `17 passed, 0 failed` (required context; proves the new line does not shift CHECK 5's counts) |
| `actionlint .github/workflows/semver-checks.yml` | clean |
| `shellcheck scripts/check_semver.sh scripts/check_semver_selftest.sh` | clean (two pre-existing infos: SC1091, SC2016) |
| `bash scripts/check_sld.sh` | `0 error(s), 0 warning(s)` |
| `bash scripts/check_doc_numbers.sh` | `0 violations — OK` |
| `bash scripts/check_public_docs.sh` | `26 page(s) — all resolve inside the public boundary` |

The red-then-green, verbatim:

```
$ bash scripts/check_semver_selftest.sh     # emit_verdict_line commented out
SELF-TEST FAIL: inventory/already-breaking: the machine-readable verdict line did not count the inventoried crate as compared (#5688)
SELF-TEST FAIL: inventory/blind: the machine-readable verdict line did not report the blind run as uncompared (#5688)
check_semver_selftest: 27 passed, 2 FAILED.

$ bash scripts/check_semver_selftest.sh     # restored
check_semver_selftest: 29 passed, 0 failed.
```

End-to-end on this branch, real gate, real emit:

```
$ bash scripts/check_semver.sh
semver gate: scanned 4 changed path(s); no crate source changed (docs-only / CI-only) — OK.
semver-gate-verdict: compared=0 examined=0 skipped=0 inventoried=0 blind=0
```

Every one of the eight `(exit code, verdict line)` shapes was replayed through the workflow's classification chain and maps to a distinct label; the `compared=0 blind=1` case — PR #5686's — now reads `SemVer: INCOMPLETE — 1 crate(s) could not be compared` instead of a plain green.

## Note for the reviewer

`Public API / SemVer` is **not** currently in `required_status_checks.contexts` (read live), despite #5311's comment saying it is meant to be. This PR is written as if it were, so making it required later needs no rework here.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools