### PR TITLE
fix(trusty-audit): the investigation budget an engagement declares reaches the sampler (Refs #6247)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11298,7 +11298,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-audit"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/trusty-audit/Cargo.toml
+++ b/crates/trusty-audit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-audit"
-version = "0.9.0"
+version = "0.10.0"
 description = "Auditor client — installs its pinned audit tooling and drives an audit engagement on the recipient's own codebases."
 readme = "README.md"
 homepage = "https://github.com/bobmatnyc/trusty-tools"

--- a/crates/trusty-audit/README.md
+++ b/crates/trusty-audit/README.md
@@ -244,11 +244,24 @@ inspect_priority = [
 ```
 
 The client also asks for a wider investigation budget than `trusty-review`'s own
-default — 240 files and 2.4 MiB per repository, overridable per machine with
-`TRUSTY_AUDIT_INVESTIGATE_MAX_FILES` and `TRUSTY_AUDIT_INVESTIGATE_MAX_BYTES`.
-It writes `investigate_max_files` and `investigate_max_bytes` into `[report]`
-per key, and only where the manifest declares none: an operator who set one of
-the two keeps it, and gets the audit's default for the other.
+default — 240 files and 2.4 MiB per repository. An engagement declares its own
+in `engagement.toml`, and that declaration wins over both the machine and the
+default:
+
+```toml
+[report]
+investigate_max_files = 240
+investigate_max_bytes = 2457600
+```
+
+Per key, the precedence is the declared value, then
+`TRUSTY_AUDIT_INVESTIGATE_MAX_FILES` / `TRUSTY_AUDIT_INVESTIGATE_MAX_BYTES` in
+the environment, then the default. The sweep resolves it once and hands the same
+number to every `tga audit` child and to the pass that writes
+`investigate_max_files` / `investigate_max_bytes` into each manifest's
+`[report]` — so the budget the file names is the budget the investigation ran
+under, not a second resolution of it. A manifest that already declares one of
+the two keys keeps it and gets the resolved value for the other.
 
 The byte budget follows the file budget at 10 KiB per file unless something
 declares it. `trusty-review` stops reading at whichever of the two binds first,

--- a/crates/trusty-audit/changelog.d/6247-engagement-investigation-budget.md
+++ b/crates/trusty-audit/changelog.d/6247-engagement-investigation-budget.md
@@ -1,0 +1,11 @@
+Fixed
+- The investigation budget an engagement declares now reaches the process that
+  samples the files. `engagement.toml` gains a `[report]` section carrying
+  `investigate_max_files` / `investigate_max_bytes`; the sweep resolves the
+  budget ONCE from it (declared key > environment override > default, per key,
+  with an absent byte budget derived from the file count) and hands that one
+  value both to every `tga audit` child and to the grounding pass that records
+  it. Before this the child read the environment inside its own spawn while the
+  manifest was written from a second, later resolution — so a run could hand
+  back a manifest declaring 240 files beside a report whose coverage section
+  claimed 40.

--- a/crates/trusty-audit/src/config.rs
+++ b/crates/trusty-audit/src/config.rs
@@ -319,6 +319,41 @@ pub struct BoardCredentials {
     pub linear: Option<LinearCredentials>,
 }
 
+/// What the engagement asks the investigation pass to read, per repository.
+///
+/// Why (#6247): the investigation budget had no declaration point an operator
+/// could write. `crate::grounding::priority::Budget` resolved it from the
+/// process environment and the compiled default, while the budget the sweep
+/// RECORDED was re-resolved later from the per-repository manifest — two
+/// resolutions of one value, computed at different times by different
+/// functions. An engagement that wanted a wider sample had nowhere to say so,
+/// and the manifest it got back could name a budget the sampler never ran
+/// under.
+/// What: the same two key names `trusty-review` reads from its own manifest
+/// `[report]` section, so an operator moving between the two files types the
+/// same thing. Both optional and both independent — see
+/// [`crate::grounding::priority::Budget::for_engagement`] for the precedence
+/// and for why an absent byte budget is derived rather than pinned.
+///
+/// ```toml
+/// [report]
+/// investigate_max_files = 240
+/// investigate_max_bytes = 2457600
+/// ```
+///
+/// Test: `super::config_tests::a_declared_investigation_budget_loads`,
+/// `super::config_tests::a_config_with_no_report_table_still_loads`.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[non_exhaustive]
+pub struct ReportSettings {
+    /// Files the investigation pass may read per repository.
+    #[serde(default)]
+    pub investigate_max_files: Option<usize>,
+    /// Total content bytes it may send per repository.
+    #[serde(default)]
+    pub investigate_max_bytes: Option<usize>,
+}
+
 /// The engagement config that travels inside the handoff package.
 ///
 /// Why: the recipient can read this file before running anything — that
@@ -346,6 +381,12 @@ pub struct EngagementConfig {
     /// engagement registers no boards.
     #[serde(default)]
     pub boards: BoardCredentials,
+    /// What this engagement asks the investigation pass to read (#6247).
+    ///
+    /// Absent means the machine's environment overrides, then the compiled
+    /// defaults — see [`crate::grounding::priority::Budget::for_engagement`].
+    #[serde(default)]
+    pub report: ReportSettings,
     /// What this engagement audits (#5979).
     ///
     /// Absent and empty are DIFFERENT states, which is why this is an `Option`
@@ -1172,6 +1213,32 @@ trusty-review = "0.15.1"
             EngagementConfig::from_toml(SAMPLE, Path::new("engagement.toml")).expect("parses");
         assert!(cfg.boards.jira.is_none());
         assert!(cfg.boards.linear.is_none());
+    }
+
+    /// 🔴 #6247: the engagement gets a place to declare the investigation
+    /// budget. Before this the two keys had no home in this file at all, so an
+    /// operator asking for a wider sample had nowhere to ask.
+    #[test]
+    fn a_declared_investigation_budget_loads() {
+        let cfg = EngagementConfig::from_toml(
+            &format!(
+                "{SAMPLE}\n[report]\ninvestigate_max_files = 240\ninvestigate_max_bytes = 2457600\n"
+            ),
+            Path::new("engagement.toml"),
+        )
+        .expect("parses");
+        assert_eq!(cfg.report.investigate_max_files, Some(240));
+        assert_eq!(cfg.report.investigate_max_bytes, Some(2_457_600));
+    }
+
+    /// Every config written before the section existed still loads, and reads
+    /// as "declares nothing" rather than as "declares zero".
+    #[test]
+    fn a_config_with_no_report_table_still_loads() {
+        let cfg =
+            EngagementConfig::from_toml(SAMPLE, Path::new("engagement.toml")).expect("parses");
+        assert!(cfg.report.investigate_max_files.is_none());
+        assert!(cfg.report.investigate_max_bytes.is_none());
     }
 
     #[test]

--- a/crates/trusty-audit/src/grounding.rs
+++ b/crates/trusty-audit/src/grounding.rs
@@ -382,10 +382,14 @@ fn discovery_gaps(discovery: &evidence::Discovery, display: &str) -> Vec<String>
 /// What: the gaps [`ground`] produced, plus one more when the manifest itself
 /// could not be updated. A write failure is a gap rather than an error for the
 /// same reason every other leg is: it costs this repository's ranking, not the
-/// sweep. The budget is resolved ONCE, by
-/// [`priority::Budget::for_manifest`], and the same value both sizes the
-/// evidence caps and reaches `[report]` — so a manifest that already declares
-/// one gets a ranking sized for what trusty-review will actually read (#6082).
+/// sweep.
+///
+/// `budget` is resolved ONCE PER SWEEP by
+/// [`priority::Budget::for_engagement`] and handed in, and it is the SAME value
+/// the caller gave the `tga audit` child. That is what makes the recorded
+/// `[report]` budget and the budget the investigation pass ran under one number
+/// rather than two independent resolutions of it (#6082, #6247). It both sizes
+/// the evidence caps and reaches `[report]`.
 /// Test: `super::grounding_tests::{hotspots_become_ranked_inspect_priority_in_the_manifest,
 /// a_manifest_that_cannot_be_written_is_a_named_gap}`.
 pub async fn ground_manifest(
@@ -393,9 +397,9 @@ pub async fn ground_manifest(
     tools: &Tools,
     checkout: &Path,
     display: &str,
+    budget: priority::Budget,
 ) -> Vec<String> {
     let instructions = instructions_from(manifest);
-    let budget = priority::Budget::for_manifest(manifest);
     let mut grounding = ground(tools, checkout, display, instructions.as_deref(), budget).await;
     // #6147: the crate graph is read from the checkout's own manifests, so it
     // depends on neither daemon and is measured whether or not either answered.

--- a/crates/trusty-audit/src/grounding/grounding_tests.rs
+++ b/crates/trusty-audit/src/grounding/grounding_tests.rs
@@ -508,7 +508,14 @@ async fn hotspots_and_search_hits_become_ranked_inspect_priority_in_the_manifest
         PathBuf::from("/nonexistent/trusty-analyze"),
         stub_daemon(Some(payload)).await,
     );
-    let gaps = ground_manifest(&manifest, &t, &checkout, "acme-api").await;
+    let gaps = ground_manifest(
+        &manifest,
+        &t,
+        &checkout,
+        "acme-api",
+        priority::Budget::from_env(),
+    )
+    .await;
     assert!(gaps.is_empty(), "{gaps:?}");
 
     let written = std::fs::read_to_string(&manifest).expect("read back");
@@ -660,7 +667,14 @@ async fn a_ranking_that_lands_after_the_render_says_so() {
 
     // No snapshot beside the manifest: nothing has rendered it yet, and the
     // ordinary path says nothing.
-    let quiet = ground_manifest(&manifest, &stubs().await, &checkout, "acme-api").await;
+    let quiet = ground_manifest(
+        &manifest,
+        &stubs().await,
+        &checkout,
+        "acme-api",
+        priority::Budget::from_env(),
+    )
+    .await;
     assert!(
         !quiet.iter().any(|g| g.contains("already been rendered")),
         "a manifest nobody has rendered is not a degradation: {quiet:?}"
@@ -668,7 +682,14 @@ async fn a_ranking_that_lands_after_the_render_says_so() {
 
     // The snapshot trusty-review writes when it investigates a manifest.
     std::fs::write(tmp.path().join("investigation.json"), "{}").expect("snapshot");
-    let late = ground_manifest(&manifest, &stubs().await, &checkout, "acme-api").await;
+    let late = ground_manifest(
+        &manifest,
+        &stubs().await,
+        &checkout,
+        "acme-api",
+        priority::Budget::from_env(),
+    )
+    .await;
     let named = late
         .iter()
         .find(|g| g.contains("already been rendered"))
@@ -737,7 +758,14 @@ async fn a_gap_is_recorded_in_the_manifest_the_renderer_reads() {
         PathBuf::from("/nonexistent/trusty-analyze"),
         dead,
     );
-    let gaps = ground_manifest(&manifest, &t, &checkout, "acme-api").await;
+    let gaps = ground_manifest(
+        &manifest,
+        &t,
+        &checkout,
+        "acme-api",
+        priority::Budget::from_env(),
+    )
+    .await;
     assert_eq!(gaps.len(), 1, "{gaps:?}");
 
     let written = std::fs::read_to_string(&manifest).expect("read back");
@@ -776,7 +804,14 @@ async fn a_manifest_that_cannot_be_written_is_a_named_gap() {
         PathBuf::from("/nonexistent/trusty-analyze"),
         stub_daemon(Some(payload)).await,
     );
-    let gaps = ground_manifest(&manifest, &t, &checkout, "acme-api").await;
+    let gaps = ground_manifest(
+        &manifest,
+        &t,
+        &checkout,
+        "acme-api",
+        priority::Budget::from_env(),
+    )
+    .await;
     assert_eq!(gaps.len(), 1, "{gaps:?}");
     assert!(gaps[0].contains("acme-api"), "{gaps:?}");
     assert!(gaps[0].contains("does not state"), "{gaps:?}");

--- a/crates/trusty-audit/src/grounding/priority.rs
+++ b/crates/trusty-audit/src/grounding/priority.rs
@@ -178,6 +178,35 @@ impl Budget {
         Self::resolve(env_positive(ENV_MAX_FILES), env_positive(ENV_MAX_BYTES))
     }
 
+    /// The budget THIS ENGAGEMENT runs under, resolved once for the sweep.
+    ///
+    /// Why (#6247): before this, the value the child ran under came from
+    /// [`Budget::from_env`] inside the spawn, and the value written into the
+    /// delivered manifest came from [`Budget::for_manifest`] afterwards. Two
+    /// resolutions of one number, and an operator had no way to declare it at
+    /// all — so a run could hand back a manifest naming a budget its own
+    /// investigation pass never used. `crate::run::sweep` now resolves here,
+    /// once, and hands the SAME value to every child and to every manifest it
+    /// records, which is what makes the two agree by construction rather than
+    /// by both happening to fall through to the same tier.
+    /// What: a positive declared key wins per key, then the environment
+    /// override for that key, then the default — the same ladder
+    /// [`Budget::for_manifest`] applies to a manifest's own keys, so an
+    /// operator moving a value between the two files gets the same answer. A
+    /// zero or absent value reads as undeclared rather than as a disabled
+    /// investigation.
+    /// Test: `priority_tests::{a_declared_engagement_budget_wins,
+    /// an_engagement_declaring_nothing_matches_the_machine,
+    /// an_engagement_file_budget_raises_the_byte_budget}`.
+    #[must_use]
+    pub fn for_engagement(settings: &crate::config::ReportSettings) -> Self {
+        let declared = |value: Option<usize>| value.filter(|n| *n > 0);
+        Self::resolve(
+            declared(settings.investigate_max_files).or_else(|| env_positive(ENV_MAX_FILES)),
+            declared(settings.investigate_max_bytes).or_else(|| env_positive(ENV_MAX_BYTES)),
+        )
+    }
+
     /// This budget as the environment pairs a `tga audit` child passes down.
     ///
     /// Why (#6082): the manifest is the interface, and on the sweep path the
@@ -898,6 +927,49 @@ path = "/w/repos/acme-web"
         assert_eq!(Budget::for_manifest(&path), Budget::from_env());
         assert_eq!(
             Budget::for_manifest(&tmp.path().join("absent.toml")),
+            Budget::from_env()
+        );
+    }
+
+    /// A `[report]` section carrying whichever keys the arguments name.
+    fn settings(files: Option<usize>, bytes: Option<usize>) -> crate::config::ReportSettings {
+        let mut declared = String::new();
+        if let Some(files) = files {
+            declared.push_str(&format!("investigate_max_files = {files}\n"));
+        }
+        if let Some(bytes) = bytes {
+            declared.push_str(&format!("investigate_max_bytes = {bytes}\n"));
+        }
+        toml::from_str(&declared).expect("parses")
+    }
+
+    /// 🔴 #6247: an engagement that declares a budget gets it, and gets it in
+    /// both dimensions — the file count it named and a byte count derived from
+    /// that count rather than pinned to the default.
+    #[test]
+    fn a_declared_engagement_budget_wins() {
+        let budget = Budget::for_engagement(&settings(Some(77), None));
+        assert_eq!(budget.max_files, 77, "the declared key wins");
+        assert_eq!(
+            budget.max_bytes,
+            env_positive(ENV_MAX_BYTES).unwrap_or(77 * BYTES_PER_FILE),
+            "the undeclared byte key derives from the declared file count (#6148)"
+        );
+        let both = Budget::for_engagement(&settings(Some(77), Some(4096)));
+        assert_eq!(both.max_bytes, 4096, "an explicit byte budget still wins");
+    }
+
+    /// An engagement that declares nothing — and one whose declaration is
+    /// unusable — falls through to the machine's answer, rather than reading as
+    /// a request for a zero-file investigation.
+    #[test]
+    fn an_engagement_declaring_nothing_matches_the_machine() {
+        assert_eq!(
+            Budget::for_engagement(&settings(None, None)),
+            Budget::from_env()
+        );
+        assert_eq!(
+            Budget::for_engagement(&settings(Some(0), Some(0))),
             Budget::from_env()
         );
     }

--- a/crates/trusty-audit/src/run.rs
+++ b/crates/trusty-audit/src/run.rs
@@ -371,6 +371,11 @@ where
     // identity the manifest records. See `inference::Inference`.
     let inference =
         inference::resolve(!config.openrouter_key.is_empty(), &config.models, operator)?;
+    // #6247: resolved ONCE for the sweep, for the same reason the inference
+    // selection above is — the budget is a property of the engagement, not of a
+    // repository. Every child is handed this value and every manifest records
+    // it, so the file cannot name a budget its own investigation never used.
+    let investigation = grounding::priority::Budget::for_engagement(&config.report);
     // #5857: ONE resolution per invocation. `crate::chain` resolved the boards
     // an hour ago to state its gaps and hands that result down, so the coverage
     // the report claims and the sections the child gets cannot diverge over a
@@ -435,6 +440,7 @@ where
                     index,
                     repo,
                     budget,
+                    investigation,
                     progress,
                     total,
                     &scrubber,
@@ -589,6 +595,7 @@ async fn run_one(
     index: usize,
     repo: SelectedRepo,
     budget: std::time::Duration,
+    investigation: grounding::priority::Budget,
     progress: &Progress,
     total: usize,
     scrubber: &Scrubber,
@@ -628,6 +635,7 @@ async fn run_one(
                 &log,
                 work.root(),
                 budget,
+                investigation,
                 progress,
                 &repo.name,
                 scrubber,
@@ -660,7 +668,10 @@ async fn run_one(
     let manifest = output.join(AuditManifest::FILE_NAME);
     if manifest.is_file() {
         let tools = grounding::Tools::pinned(binaries.search.clone(), binaries.analyze.clone());
-        gaps.extend(grounding::ground_manifest(&manifest, &tools, &checkout, &repo.name).await);
+        gaps.extend(
+            grounding::ground_manifest(&manifest, &tools, &checkout, &repo.name, investigation)
+                .await,
+        );
         // #6135: the provider and models this run used, written into the file
         // that ships. Without it a re-render on another machine resolves its own
         // provider from that machine's config — which is how a June-dated local
@@ -858,6 +869,114 @@ trusty-review = "0.15.1"
              printf '[report]\\ntitle = \"Acme\"\\n{gaps}\\n[[repositories]]\\n\
              name = \"acme\"\\npath = \"/r\"\\n' > \"$out/manifest.toml\"\nexit 0\n"
         )
+    }
+
+    /// A stub `tga` that records the investigation budget it was handed (#6247).
+    fn records_its_budget_env() -> String {
+        format!(
+            "{}{}",
+            writes_a_manifest(None).trim_end_matches("exit 0\n"),
+            "{\n  echo \"files=$TRUSTY_AUDIT_INVESTIGATE_MAX_FILES\"\n  \
+             echo \"bytes=$TRUSTY_AUDIT_INVESTIGATE_MAX_BYTES\"\n} \
+             > \"$out/budget-env.txt\"\nexit 0\n",
+        )
+    }
+
+    /// An engagement that asks for a wider investigation than the default.
+    ///
+    /// 77 rather than a round number: it matches neither
+    /// [`grounding::priority::DEFAULT_MAX_FILES`] nor `trusty-review`'s own
+    /// default, so a value arriving from either tier is visible as a wrong
+    /// number rather than as a coincidence.
+    fn config_declaring_a_budget() -> EngagementConfig {
+        EngagementConfig::from_toml(
+            &format!("{CONFIG}\n[report]\ninvestigate_max_files = 77\n"),
+            Path::new("engagement.toml"),
+        )
+        .expect("parses")
+    }
+
+    /// 🔴 #6247: the budget an engagement declares must reach the process that
+    /// samples the files, not just the manifest that describes the run.
+    ///
+    /// Asserts on the environment the SPAWNED PROCESS received, because that is
+    /// the only channel that reaches `trusty-review` before it renders — the
+    /// manifest is written by this child and edited afterwards, so a budget
+    /// recorded there reaches a re-render and never this run's report.
+    ///
+    /// Against `3771644d0` this fails on the first assertion: `spawn_tga` read
+    /// `Budget::from_env()`, so the child was handed the compiled default 240
+    /// whatever the engagement declared, and the operator's 240-file manifest
+    /// sat beside a report claiming 40.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn the_child_environment_carries_the_engagement_investigation_budget() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        install_stubs(&work, &records_its_budget_env());
+        make_repo(&work, "acme-api");
+        select(&work, &[("acme-api", "repos/acme-api")]);
+
+        let report = sweep(
+            &work,
+            &config_declaring_a_budget(),
+            &RunOptions::default(),
+            &Progress::none(),
+        )
+        .await
+        .expect("the sweep completes");
+        assert_eq!(report.status, RunStatus::AllSucceeded, "{report:?}");
+
+        let seen = std::fs::read_to_string(report.repos[0].output.join("budget-env.txt"))
+            .expect("the stub recorded its environment");
+        assert!(seen.contains("files=77"), "{seen}");
+        // Derived from the declared file count, so a raised file budget never
+        // meets an unraised byte budget (#6148).
+        assert!(
+            seen.contains(&format!(
+                "bytes={}",
+                77 * grounding::priority::BYTES_PER_FILE
+            )),
+            "{seen}"
+        );
+    }
+
+    /// 🔴 #6247: the manifest that ships must name the budget the investigation
+    /// actually ran under — one resolution, two consumers.
+    ///
+    /// Against `3771644d0` the two were resolved independently: the child got
+    /// `Budget::from_env()` and `ground_manifest` re-resolved from the manifest
+    /// the child had just written, so the file could state a budget no sampler
+    /// used. Here the child records 77 and the file must agree.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn the_recorded_budget_is_the_one_the_child_ran_under() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        install_stubs(&work, &records_its_budget_env());
+        make_repo(&work, "acme-api");
+        select(&work, &[("acme-api", "repos/acme-api")]);
+
+        let report = sweep(
+            &work,
+            &config_declaring_a_budget(),
+            &RunOptions::default(),
+            &Progress::none(),
+        )
+        .await
+        .expect("the sweep completes");
+
+        let written = std::fs::read_to_string(report.repos[0].output.join("manifest.toml"))
+            .expect("the child wrote a manifest");
+        let parsed: toml::Value = written.parse().expect("the manifest is TOML");
+        assert_eq!(
+            parsed["report"]["investigate_max_files"].as_integer(),
+            Some(77),
+            "{written}"
+        );
+        let seen = std::fs::read_to_string(report.repos[0].output.join("budget-env.txt"))
+            .expect("the stub recorded its environment");
+        assert!(seen.contains("files=77"), "{seen}");
     }
 
     /// A stub `tga` shaped like the child of the 2026-08-19 dogfood run: it

--- a/crates/trusty-audit/src/run/child.rs
+++ b/crates/trusty-audit/src/run/child.rs
@@ -85,6 +85,7 @@ pub(super) async fn spawn_tga(
     log: &Path,
     cwd: &Path,
     budget: std::time::Duration,
+    investigation: crate::grounding::priority::Budget,
     progress: &Progress,
     target: &str,
     scrubber: &Scrubber,
@@ -147,7 +148,11 @@ pub(super) async fn spawn_tga(
     // grounding pass edits that manifest only after the child exits — so the
     // budget it records there reaches a re-render and never this run's report.
     // See `grounding::priority::Budget::child_env`.
-    for (name, value) in crate::grounding::priority::Budget::from_env().child_env() {
+    // #6247: the sweep resolves it ONCE and hands it down, rather than this
+    // spawn re-reading the environment. The same value is what the grounding
+    // pass writes into the manifest, so the file cannot name a budget the
+    // investigation did not run under.
+    for (name, value) in investigation.child_env() {
         command.env(name, value);
     }
 


### PR DESCRIPTION
Refs #6247.

## What changed

`engagement.toml` gains a `[report]` section carrying `investigate_max_files`
and `investigate_max_bytes` — the same two key names `trusty-review` reads from
its own manifest, so an operator moving a value between the two files types the
same thing. `run::sweep` resolves the budget once from it (declared key >
`TRUSTY_AUDIT_INVESTIGATE_MAX_*` > default, per key, with an absent byte budget
derived from whichever file count won) and hands that value both to every
`tga audit` child and to `grounding::ground_manifest`, which records it.

Before this, `spawn_tga` called `Budget::from_env()` inside the spawn and
`ground_manifest` re-resolved from the manifest the child had just written.
Two resolutions of one number, taken at different times by different functions —
so a run could hand back a manifest declaring 240 files beside a report whose
coverage section claimed 40, and an operator had nowhere to declare a budget at
all.

Files: `src/config.rs` (`ReportSettings`), `src/grounding/priority.rs`
(`Budget::for_engagement`), `src/run.rs`, `src/run/child.rs`, `src/grounding.rs`.

## Fail-Open Check — the regression test that fails pre-fix

`run::run_tests::the_child_environment_carries_the_engagement_investigation_budget`.
It declares `investigate_max_files = 77` in the engagement config and asserts on
the environment the SPAWNED PROCESS received. Against `3771644d0` the child is
handed the compiled default 240 whatever the engagement declares, so the first
assertion fails. 77 is chosen because it matches neither this crate's default
(240) nor `trusty-review`'s (40) — a value arriving from either tier reads as a
wrong number rather than as a coincidence.

`run::run_tests::the_recorded_budget_is_the_one_the_child_ran_under` covers the
other half: the manifest that ships must name the budget the child ran under.

Supporting unit tests: `priority_tests::a_declared_engagement_budget_wins`,
`priority_tests::an_engagement_declaring_nothing_matches_the_machine`,
`config_tests::a_declared_investigation_budget_loads`,
`config_tests::a_config_with_no_report_table_still_loads`.

## Gates — rung 3 (localized behavior inside one crate)

```
cargo fmt --check                                        EXIT=0
cargo check -p trusty-audit                              EXIT=0
cargo clippy -p trusty-audit --all-targets -- -D warnings EXIT=0
cargo test -p trusty-audit                               EXIT=0
  test result: ok. 714 passed; 0 failed; 5 ignored (lib)
  + 33 passed across the 7 integration targets, 0 failed
bash scripts/check_test_pointers.sh                      EXIT=0
bash scripts/check_line_cap.sh                           EXIT=0
  line-cap: measured 4176 tracked .rs file(s); 0 violations — OK.
```

Changelog fragment: `crates/trusty-audit/changelog.d/6247-engagement-investigation-budget.md`.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools