### PR TITLE
fix(trusty-audit): the git credential the sweep holds reaches the fetch, and its absence stops the run (Refs #6244)

### DIFF
--- a/crates/trusty-audit/changelog.d/6244-git-credential-preflight.md
+++ b/crates/trusty-audit/changelog.d/6244-git-credential-preflight.md
@@ -1,0 +1,16 @@
+Fixed
+- The `gh` login now reaches the child's git transport. The sweep already read
+  `gh auth token` once and handed it over as `TRUSTY_AUDIT_GITHUB_TOKEN`, which
+  only tga's `github:` config section references; the fetch that runs before
+  every collection reads `GITHUB_TOKEN`. A recipient logged in with `gh` and
+  nothing else had every fetch fail and got a header-only `pr-metrics.csv` per
+  repository, over a usable credential this process was holding. An
+  operator-exported token is never replaced — the forward happens only when the
+  `gh` login is the sole source.
+- A sweep with no non-interactive git credential at all refuses before any child
+  runs, naming how many repositories would have been fetched and every way to
+  supply one (`gh auth login`, `GITHUB_TOKEN`/`GH_TOKEN`, an SSH key,
+  `ssh-agent`). It fires only when the selected checkouts provably name a
+  `github.com` remote, so an engagement over paths on disk still runs. Before
+  this the run reported success having collected no pull-request data at all,
+  and said so only in one repeated line inside each repository's own manifest.

--- a/crates/trusty-audit/src/error.rs
+++ b/crates/trusty-audit/src/error.rs
@@ -312,6 +312,36 @@ pub enum AuditError {
         path: PathBuf,
     },
 
+    /// No non-interactive git credential, on an engagement that must fetch.
+    ///
+    /// Why: #6244. `tga audit` fetches each repository before it collects, and
+    /// its fetch resolves a credential non-interactively or not at all. On a
+    /// machine with none, every fetch failed, pull-request collection produced a
+    /// header-only `pr-metrics.csv` for all 59 repositories of a real
+    /// engagement, and the run reported success — the only trace was the same
+    /// one-line gap repeated inside 59 separate manifests. The failure is
+    /// engagement-global and knowable before any child runs, so it is raised
+    /// once, up front, rather than 59 times where nobody reads it.
+    /// What: the count, one repository by name, and each way to supply a
+    /// credential without a prompt. Raised only when the engagement provably
+    /// fetches — see `crate::run::git_credentials::GitCredential::refuse_if_fetching`.
+    /// Test: `crate::run::git_credentials::git_credential_tests::nothing_at_all_refuses_a_fetching_engagement`.
+    #[error(
+        "no non-interactive git credential is available, and {repositories} of this \
+         engagement's repositories are cloned from github.com (starting with {first}). \
+         `tga audit` fetches each one before it collects, so pull-request collection would \
+         produce an empty `pr-metrics.csv` for every repository and the run would still \
+         report success. Supply a credential and run again — any one of: `gh auth login`; \
+         a personal access token in GITHUB_TOKEN or GH_TOKEN; an SSH key at \
+         ~/.ssh/id_ed25519 or ~/.ssh/id_rsa; an ssh-agent (SSH_AUTH_SOCK)"
+    )]
+    NoGitCredential {
+        /// How many selected checkouts name a `github.com` remote.
+        repositories: usize,
+        /// One of them, by registered name, so the message is concrete.
+        first: String,
+    },
+
     /// The selection file carries fewer entries than it declares.
     ///
     /// Why: #5555. A producer that crashes part-way through writing the file

--- a/crates/trusty-audit/src/run.rs
+++ b/crates/trusty-audit/src/run.rs
@@ -131,6 +131,11 @@ mod report;
 // which repositories are audited, `child.rs` runs one.
 mod child;
 
+// #6244: whether a `git fetch` can authenticate without a prompt — the
+// engagement-global preflight, and the one credential this crate holds that the
+// child's git transport would otherwise never see.
+pub(crate) mod git_credentials;
+
 use approve::approve_for_indexing;
 use child::spawn_tga;
 use pins::{PinnedBinaries, pinned_binaries};
@@ -369,6 +374,10 @@ where
     // every repository, so failing per-repo would just repeat one misconfiguration.
     // #6135: both halves at once — the pairs the child inherits, and the
     // identity the manifest records. See `inference::Inference`.
+    // #6244: read from the injected lookup, BEFORE it is consumed below. What is
+    // resolved here is only the operator's half — the `gh` login is folded in
+    // after `resolve_github_access`, which is where it is read.
+    let declared_credential = git_credentials::GitCredential::of_environment(&operator);
     let inference =
         inference::resolve(!config.openrouter_key.is_empty(), &config.models, operator)?;
     // #5857: ONE resolution per invocation. `crate::chain` resolved the boards
@@ -402,6 +411,25 @@ where
     // per-repository one. See `github_issues`'s module docs for why a `gh`
     // that cannot answer still lets the sweep proceed.
     let github_access = github_issues::resolve_github_access().await;
+    // #6244: whether a `git fetch` can authenticate at all, resolved once for
+    // the same reason the inference selection and the boards are — a machine
+    // with no credential is a fact about the engagement, not about a repository,
+    // and repeating the discovery 59 times is how it ended up stated 59 times
+    // and read none. The `gh` login is folded in LAST, matching tga's own order.
+    let git_credential = declared_credential.with_gh_login(github_access.raw_token());
+    if git_credential.sources().is_empty() {
+        // Only now is the remote probe worth its subprocess per repository: with
+        // a credential in hand there is nothing to refuse, so nothing to ask.
+        let checkouts: Vec<(String, PathBuf)> = selected
+            .iter()
+            .map(|repo| (repo.name.clone(), absolute_checkout(work, &repo.path)))
+            .collect();
+        git_credential.refuse_if_fetching(&git_credentials::github_backed(&checkouts).await)?;
+    }
+    // #6244: the child's git transport reads `GITHUB_TOKEN`, which is not the
+    // variable `GithubAccess::env` sets. See `GithubAccess::git_transport_env`.
+    let github_access =
+        github_access.supplying_git_transport(git_credential.supplies_github_token());
     // #5869: materialized once for the whole sweep — resolving reads
     // `.env.local` and opens the secure store, which is not a per-child cost,
     // let alone a per-line one.
@@ -858,6 +886,29 @@ trusty-review = "0.15.1"
              printf '[report]\\ntitle = \"Acme\"\\n{gaps}\\n[[repositories]]\\n\
              name = \"acme\"\\npath = \"/r\"\\n' > \"$out/manifest.toml\"\nexit 0\n"
         )
+    }
+
+    /// #6244: the preflight refuses on a machine with no credential, and only
+    /// when the engagement provably fetches. These checkouts name no remote, so
+    /// the sweep must run whatever this machine happens to have — a refusal here
+    /// would strand every engagement over paths on disk.
+    ///
+    /// The lookup answers for nothing, so no source is declared: on a machine
+    /// where `gh` cannot answer either, this is the arm that reaches the remote
+    /// probe and finds nothing to fetch.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_sweep_over_checkouts_with_no_remote_needs_no_credential() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        install_stubs(&work, &writes_a_manifest(None));
+        make_repo(&work, "acme-api");
+        select(&work, &[("acme-api", "repos/acme-api")]);
+
+        let report = sweep_with_operator(&work, |_| None)
+            .await
+            .expect("a sweep that fetches nothing needs no credential");
+        assert_eq!(report.status, RunStatus::AllSucceeded, "{report:?}");
     }
 
     /// A stub `tga` shaped like the child of the 2026-08-19 dogfood run: it

--- a/crates/trusty-audit/src/run/child.rs
+++ b/crates/trusty-audit/src/run/child.rs
@@ -141,6 +141,16 @@ pub(super) async fn spawn_tga(
     if let Some((name, value)) = github_access.env() {
         command.env(name, value);
     }
+    // #6244: the same credential again, under the name tga's GIT TRANSPORT
+    // reads. The line above serves the REST client that reads issues; the fetch
+    // that runs before every collection resolves `GITHUB_TOKEN` instead, so
+    // without this a recipient logged in only with `gh` had every fetch fail and
+    // got a header-only `pr-metrics.csv` per repository. Set only when the sweep
+    // resolved that the `gh` login is the only source — see
+    // `github_issues::GithubAccess::git_transport_env`.
+    if let Some((name, value)) = github_access.git_transport_env() {
+        command.env(name, value);
+    }
     // #6082: the investigation budget, down the one channel that reaches the
     // grandchild in time. `tga audit` writes the manifest and runs
     // `trusty-review report` against it in the same process, and this crate's

--- a/crates/trusty-audit/src/run/git_credentials.rs
+++ b/crates/trusty-audit/src/run/git_credentials.rs
@@ -1,0 +1,291 @@
+//! Whether this machine can authenticate a `git fetch` without a prompt (#6244).
+//!
+//! Why: `tga audit` fetches every repository before it collects, and its fetch
+//! resolves a credential non-interactively or not at all. On a machine with
+//! none, every fetch fails, pull-request collection produces a header-only
+//! `pr-metrics.csv`, and the sweep reports success — 59 repositories deep, the
+//! only trace was the same one-line gap repeated in 59 separate manifests.
+//! Nothing said it once, up front, where an operator would see it before
+//! spending the hours.
+//!
+//! Two halves, and the second is the one that actually fixes the common case:
+//!
+//! 1. **The `gh` login reaches the fetch.** [`super::github_issues`] already
+//!    reads `gh auth token` once per sweep, but hands it to the child as
+//!    `TRUSTY_AUDIT_GITHUB_TOKEN` — a name only tga's `github:` config section
+//!    references. tga's git transport reads `GITHUB_TOKEN` / `GH_TOKEN`, so a
+//!    recipient logged in with `gh` and nothing else had a usable credential
+//!    this crate held and never passed on. [`GitCredential::supplies_github_token`]
+//!    is what closes that.
+//! 2. **No credential at all is an up-front refusal**, not 59 empty CSVs. See
+//!    [`refuse_if_fetching`].
+//!
+//! ## The source list mirrors tga's, deliberately
+//!
+//! The four sources below are `tga::collect::git::fetch`'s
+//! `non_interactive_credentials`, in its order: SSH agent, `~/.ssh/id_ed25519`,
+//! `~/.ssh/id_rsa`, `GITHUB_TOKEN`/`GH_TOKEN`, platform credential helper. This
+//! module cannot call that function — it builds `git2::Cred` values inside the
+//! fetch callback — so it answers the weaker question the preflight needs: is
+//! there anything here at all for that callback to find. It is deliberately
+//! OPTIMISTIC, and both directions of the gap are worth naming: a source
+//! present here can still be REJECTED by the remote (an expired token, a key
+//! the remote does not know), and the platform credential helper is not probed
+//! at all, so a machine whose only credential lives in the keychain reads as
+//! having none. That is why the refusal fires only when NOTHING is found and
+//! the engagement provably needs a fetch.
+//!
+//! Test: `git_credential_tests`.
+
+use std::path::{Path, PathBuf};
+
+use crate::error::AuditError;
+
+/// The HTTPS token variable tga's fetch reads first.
+pub const ENV_GITHUB_TOKEN: &str = trusty_common::env_vars::ENV_GITHUB_TOKEN;
+
+/// The `gh` CLI's own spelling of the same thing, which tga's fetch also reads.
+pub const ENV_GH_TOKEN: &str = "GH_TOKEN";
+
+/// Where an `ssh-agent` advertises itself.
+const ENV_SSH_AGENT: &str = "SSH_AUTH_SOCK";
+
+/// The two private keys tga's fetch tries by name, in its order.
+const SSH_KEY_FILES: [&str; 2] = ["id_ed25519", "id_rsa"];
+
+/// What this machine can authenticate a `git fetch` with, and from where.
+///
+/// Why: the sweep needs two different answers out of one resolution — whether
+/// to refuse before spending hours, and whether it must hand its own `gh` token
+/// to the child under the name the git transport reads. Resolving twice would
+/// let those two disagree.
+/// What: the named sources, in the order they were found, and whether the `gh`
+/// login is the only one — which is exactly when this process has a credential
+/// the child would not otherwise see.
+/// Test: `git_credential_tests`.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub(crate) struct GitCredential {
+    sources: Vec<String>,
+    from_gh_login: bool,
+}
+
+impl GitCredential {
+    /// What the operator's own environment offers, before `gh` is consulted.
+    ///
+    /// `operator` is the injected environment lookup `super::sweep_with_env`
+    /// already carries, so every arm is provable without `std::env::set_var` —
+    /// `unsafe` in edition 2024 and unsound under the parallel harness.
+    pub(crate) fn of_environment<F>(operator: F) -> Self
+    where
+        F: Fn(&str) -> Option<String>,
+    {
+        let mut sources = Vec::new();
+        for name in [ENV_GITHUB_TOKEN, ENV_GH_TOKEN] {
+            if nonblank(operator(name)).is_some() {
+                sources.push(format!("{name} in this environment"));
+            }
+        }
+        if nonblank(operator(ENV_SSH_AGENT)).is_some() {
+            sources.push(format!("an SSH agent ({ENV_SSH_AGENT})"));
+        }
+        if let Some(home) = nonblank(operator("HOME")) {
+            sources.extend(ssh_keys_under(Path::new(&home)));
+        }
+        Self {
+            sources,
+            from_gh_login: false,
+        }
+    }
+
+    /// The same resolution, with the sweep's `gh auth token` result folded in.
+    ///
+    /// Why: `gh` is consulted LAST, matching tga's own order — an operator who
+    /// exported a token meant that token, and overriding it with a keychain
+    /// login they may not have thought about is not this crate's call. The
+    /// consequence is [`Self::supplies_github_token`]: this process forwards the
+    /// `gh` login only when nothing else answered, so it can add a credential
+    /// the child would otherwise lack but never replace one it already has.
+    #[must_use]
+    pub(crate) fn with_gh_login(mut self, token: Option<&str>) -> Self {
+        if nonblank(token.map(str::to_owned)).is_none() {
+            return self;
+        }
+        self.from_gh_login = self.sources.is_empty();
+        self.sources.push("your `gh` login".to_owned());
+        self
+    }
+
+    /// Every credential source found, in the order they were looked for.
+    pub(crate) fn sources(&self) -> &[String] {
+        &self.sources
+    }
+
+    /// Whether this process must hand the child a `GITHUB_TOKEN` of its own.
+    ///
+    /// True exactly when the `gh` login is the only source: the child inherits
+    /// this process's environment, so an operator-exported token already
+    /// reaches it, while a token read out of `gh`'s keychain does not.
+    pub(crate) fn supplies_github_token(&self) -> bool {
+        self.from_gh_login
+    }
+
+    /// Refuse the sweep when nothing can authenticate a fetch it needs.
+    ///
+    /// # Errors
+    ///
+    /// [`AuditError::NoGitCredential`] when no source was found AND
+    /// `fetching` names at least one repository. Both halves are required: an
+    /// engagement over checkouts with no `github.com` remote fetches nothing, so
+    /// refusing it would strand a legitimate run over a credential it never
+    /// needed.
+    /// Test: `git_credential_tests::{nothing_at_all_refuses_a_fetching_engagement,
+    /// nothing_at_all_still_runs_an_engagement_that_fetches_nothing}`.
+    pub(crate) fn refuse_if_fetching(&self, fetching: &[String]) -> Result<(), AuditError> {
+        if !self.sources.is_empty() || fetching.is_empty() {
+            return Ok(());
+        }
+        Err(AuditError::NoGitCredential {
+            repositories: fetching.len(),
+            first: fetching[0].clone(),
+        })
+    }
+}
+
+/// The private keys under `home/.ssh` that tga's fetch would try, named.
+fn ssh_keys_under(home: &Path) -> Vec<String> {
+    SSH_KEY_FILES
+        .iter()
+        .map(|name| (name, home.join(".ssh").join(name)))
+        .filter(|(_, path)| path.is_file())
+        .map(|(name, _)| format!("~/.ssh/{name}"))
+        .collect()
+}
+
+/// A value with surrounding whitespace removed, or `None` when nothing is left.
+///
+/// A blank token is not a token: `gh auth token` under an unusable login exits
+/// zero printing whitespace, which is the shape #5475 already had to guard.
+fn nonblank(value: Option<String>) -> Option<String> {
+    value.map(|v| v.trim().to_owned()).filter(|v| !v.is_empty())
+}
+
+/// The selected repositories whose checkout names a `github.com` remote.
+///
+/// Why: the refusal must fire on the engagements that actually fetch and stay
+/// silent on the ones that do not, and the checkout's own `origin` is the only
+/// thing that answers that — not the registered name, which is `owner/name` for
+/// a repository this client cloned and a bare basename for a path on disk.
+/// What: [`crate::local_repo::github_slug`] per checkout, which is the crate's
+/// one entry point for that read. A checkout `git` could not be run against at
+/// all is left OUT: this list drives a refusal, and a refusal must not rest on
+/// a question nothing managed to ask.
+/// Test: `super::run_tests::a_sweep_over_checkouts_with_no_remote_needs_no_credential`.
+pub(crate) async fn github_backed(checkouts: &[(String, PathBuf)]) -> Vec<String> {
+    let mut named = Vec::new();
+    for (name, path) in checkouts {
+        if matches!(crate::local_repo::github_slug(path).await, Ok(Some(_))) {
+            named.push(name.clone());
+        }
+    }
+    named
+}
+
+#[cfg(test)]
+mod git_credential_tests {
+    use super::*;
+
+    /// An environment lookup that answers for exactly one name.
+    fn only(wanted: &'static str, value: &'static str) -> impl Fn(&str) -> Option<String> {
+        move |name| (name == wanted).then(|| value.to_owned())
+    }
+
+    /// 🔴 #6244: the whole point. Nothing on the machine can authenticate a
+    /// fetch, the engagement provably needs one, and the run must say so before
+    /// it spends four hours producing 59 header-only `pr-metrics.csv` files and
+    /// reporting success.
+    ///
+    /// Against `3771644d0` there was no preflight of any kind — the sweep
+    /// started, every child's fetch failed, and the only trace was one gap line
+    /// repeated inside 59 separate manifests.
+    #[test]
+    fn nothing_at_all_refuses_a_fetching_engagement() {
+        let credential = GitCredential::of_environment(|_| None).with_gh_login(None);
+        assert!(credential.sources().is_empty(), "{credential:?}");
+        let err = credential
+            .refuse_if_fetching(&["acme/api".to_owned(), "acme/web".to_owned()])
+            .expect_err("a fetching engagement with no credential is refused");
+        let message = err.to_string();
+        for expected in ["acme/api", "gh auth login", ENV_GITHUB_TOKEN, "id_ed25519"] {
+            assert!(message.contains(expected), "{message}");
+        }
+    }
+
+    /// The other half of the gate: an engagement over checkouts with no
+    /// `github.com` remote fetches nothing, so it must not be refused over a
+    /// credential it never needed.
+    #[test]
+    fn nothing_at_all_still_runs_an_engagement_that_fetches_nothing() {
+        GitCredential::of_environment(|_| None)
+            .with_gh_login(None)
+            .refuse_if_fetching(&[])
+            .expect("nothing to fetch, nothing to refuse");
+    }
+
+    /// A token the operator exported already reaches the child, because the
+    /// child inherits this process's environment — so it is a source, and this
+    /// process adds nothing of its own.
+    #[test]
+    fn an_exported_token_is_a_source_this_process_need_not_forward() {
+        for name in [ENV_GITHUB_TOKEN, ENV_GH_TOKEN] {
+            let credential =
+                GitCredential::of_environment(only(name, "t")).with_gh_login(Some("gh"));
+            assert_eq!(credential.sources().len(), 2, "{credential:?}");
+            assert!(
+                !credential.supplies_github_token(),
+                "an operator's own token must not be replaced: {credential:?}"
+            );
+            credential
+                .refuse_if_fetching(&["acme/api".to_owned()])
+                .expect("a source is a source");
+        }
+    }
+
+    /// 🔴 #6244: a recipient logged in with `gh` and nothing else. The token
+    /// exists, this crate already reads it, and before this it reached the child
+    /// only under `TRUSTY_AUDIT_GITHUB_TOKEN` — a name tga's git transport does
+    /// not read. That is the fetch failing while a usable credential sat in this
+    /// process's own memory.
+    #[test]
+    fn a_gh_login_alone_is_forwarded_as_the_transport_token() {
+        let credential = GitCredential::of_environment(|_| None).with_gh_login(Some("gho_x"));
+        assert!(credential.supplies_github_token(), "{credential:?}");
+        credential
+            .refuse_if_fetching(&["acme/api".to_owned()])
+            .expect("the gh login is a credential");
+    }
+
+    /// A blank `gh auth token` — the exit-zero-printing-whitespace shape — is
+    /// not a credential, and must not silence the refusal.
+    #[test]
+    fn a_blank_gh_token_is_not_a_source() {
+        let credential = GitCredential::of_environment(|_| None).with_gh_login(Some("  \n"));
+        assert!(credential.sources().is_empty(), "{credential:?}");
+        credential
+            .refuse_if_fetching(&["acme/api".to_owned()])
+            .expect_err("a blank token is no token");
+    }
+
+    /// An agent socket and a key file are each a source on their own.
+    #[test]
+    fn an_agent_or_a_key_file_is_a_source() {
+        let agent = GitCredential::of_environment(only(ENV_SSH_AGENT, "/tmp/agent.sock"));
+        assert_eq!(agent.sources().len(), 1, "{agent:?}");
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(tmp.path().join(".ssh")).expect("mkdir");
+        std::fs::write(tmp.path().join(".ssh").join("id_ed25519"), "k").expect("write");
+        let home = tmp.path().to_string_lossy().into_owned();
+        let keyed = GitCredential::of_environment(|name| (name == "HOME").then(|| home.clone()));
+        assert_eq!(keyed.sources(), ["~/.ssh/id_ed25519"], "{keyed:?}");
+    }
+}

--- a/crates/trusty-audit/src/run/github_issues.rs
+++ b/crates/trusty-audit/src/run/github_issues.rs
@@ -108,6 +108,13 @@ pub struct GithubAccess {
     /// disk — only exposed into a child's environment, the same shape as
     /// `super::boards::Boards::env`.
     token: Option<String>,
+    /// Whether this process must ALSO hand the token to the child's git
+    /// transport, under the name that transport reads (#6244).
+    ///
+    /// Set by `super::sweep_with_env` from
+    /// [`super::git_credentials::GitCredential::supplies_github_token`]; see
+    /// [`Self::git_transport_env`].
+    supply_git_transport: bool,
 }
 
 impl GithubAccess {
@@ -115,6 +122,35 @@ impl GithubAccess {
     /// credential was read.
     pub fn env(&self) -> Option<(&'static str, &str)> {
         self.token.as_deref().map(|t| (ENV_GITHUB_TOKEN, t))
+    }
+
+    /// The same token again, under the name tga's GIT TRANSPORT reads (#6244).
+    ///
+    /// Why: [`Self::env`] sets `TRUSTY_AUDIT_GITHUB_TOKEN`, which only the
+    /// generated config's `github:` section references — that is the REST client
+    /// that reads issues. `tga`'s `git fetch` resolves its credential from
+    /// `GITHUB_TOKEN` / `GH_TOKEN` instead, so a recipient logged in with `gh`
+    /// and nothing else had a usable credential this crate held and never passed
+    /// on: every fetch failed and pull-request collection came back empty.
+    /// What: `Some` only when the sweep resolved that the `gh` login is the ONLY
+    /// source — an operator who exported their own token already reaches the
+    /// child through inheritance, and replacing it is not this crate's call.
+    /// Test: `github_issues_tests::{the_gh_login_reaches_the_git_transport,
+    /// an_operators_own_token_is_not_replaced}`.
+    pub(crate) fn git_transport_env(&self) -> Option<(&'static str, &str)> {
+        if !self.supply_git_transport {
+            return None;
+        }
+        self.token
+            .as_deref()
+            .map(|t| (super::git_credentials::ENV_GITHUB_TOKEN, t))
+    }
+
+    /// The same access, told whether it must supply the git transport (#6244).
+    #[must_use]
+    pub(crate) fn supplying_git_transport(mut self, needed: bool) -> Self {
+        self.supply_git_transport = needed;
+        self
     }
 
     /// The real token value, for the outbound credential guards ONLY (#5980
@@ -204,6 +240,7 @@ impl GithubAccess {
     pub(crate) fn with_token(token: impl Into<String>) -> Self {
         Self {
             token: Some(token.into()),
+            supply_git_transport: false,
         }
     }
 }
@@ -232,7 +269,10 @@ pub async fn resolve_github_access() -> GithubAccess {
 /// an_ok_result_is_carried_through}`.
 fn from_probe_result(result: Result<String, trusty_common::gh::GhError>) -> GithubAccess {
     match result {
-        Ok(token) => GithubAccess { token: Some(token) },
+        Ok(token) => GithubAccess {
+            token: Some(token),
+            supply_git_transport: false,
+        },
         Err(_) => GithubAccess::default(),
     }
 }
@@ -321,11 +361,41 @@ pub(crate) fn verify_unchanged(
 mod github_issues_tests {
     use super::*;
 
+    /// 🔴 #6244: the `gh` login must reach the child's GIT TRANSPORT, not only
+    /// the REST client that reads issues.
+    ///
+    /// Against `3771644d0` there was no second variable: the token went out as
+    /// `TRUSTY_AUDIT_GITHUB_TOKEN` alone, which tga's fetch does not read, so a
+    /// recipient logged in only with `gh` had every fetch fail while a usable
+    /// credential sat in this process's memory.
+    #[test]
+    fn the_gh_login_reaches_the_git_transport() {
+        let access = GithubAccess::with_token("gho_x").supplying_git_transport(true);
+        assert_eq!(
+            access.git_transport_env(),
+            Some((super::super::git_credentials::ENV_GITHUB_TOKEN, "gho_x"))
+        );
+        // The REST client's own variable is unchanged — this adds a channel.
+        assert_eq!(access.env(), Some((ENV_GITHUB_TOKEN, "gho_x")));
+    }
+
+    /// An operator's own exported token already reaches the child by
+    /// inheritance, so this crate writes nothing over it.
+    #[test]
+    fn an_operators_own_token_is_not_replaced() {
+        assert_eq!(GithubAccess::with_token("gho_x").git_transport_env(), None);
+        assert_eq!(
+            GithubAccess::default()
+                .supplying_git_transport(true)
+                .git_transport_env(),
+            None,
+            "there is no token to supply"
+        );
+    }
+
     #[test]
     fn a_repo_with_a_token_gets_the_placeholder_never_the_value() {
-        let access = GithubAccess {
-            token: Some("ghp_real-token-do-not-write-me-down".to_owned()),
-        };
+        let access = GithubAccess::with_token("ghp_real-token-do-not-write-me-down");
         let section = access.section(GithubLeg::Present("acme/api"));
         assert_eq!(section.repo.as_deref(), Some("acme/api"));
         assert_eq!(


### PR DESCRIPTION
Refs #6244.

## Root cause

Two halves of one defect, both in the run path.

1. `run::github_issues::resolve_github_access` already reads `gh auth token`
   once per sweep and `child.rs` hands it to the child as
   `TRUSTY_AUDIT_GITHUB_TOKEN` — the name only tga's `github:` config section
   references, which drives the REST client that reads issues. tga's git
   transport (`tga::collect::git::fetch::non_interactive_credentials`) resolves
   from `GITHUB_TOKEN` / `GH_TOKEN`. So a recipient logged in with `gh` and
   nothing else had every fetch fail while a usable credential sat in this
   process's own memory. `GithubAccess::git_transport_env` forwards it under
   that name, and only when the `gh` login is the sole source — an
   operator-exported token already reaches the child by inheritance and is
   never replaced.
2. Nothing checked, up front, whether a fetch could authenticate at all. The
   new `run::git_credentials` module resolves that once per sweep and
   `AuditError::NoGitCredential` stops the run before any child, naming the
   repository count and every non-interactive way to supply one.

The refusal fires only when the selected checkouts provably name a `github.com`
remote, read through `local_repo::github_slug` — the crate's existing entry
point for that. That probe runs ONLY when no credential source was found, so a
healthy sweep pays nothing for it, and an engagement over paths on disk still
runs.

The source list mirrors tga's fetch order and is deliberately optimistic: a
source present can still be rejected by the remote, and the platform credential
helper is not probed at all. Both directions are stated in the module docs.
That is why the refusal needs BOTH "nothing found" and "provably fetches".

## Fail-Open Check — the regression test that fails pre-fix

`run::git_credentials::git_credential_tests::nothing_at_all_refuses_a_fetching_engagement`
— no source on the machine, an engagement that fetches, and the run must refuse
with an actionable message. Against `3771644d0` there is no preflight of any
kind: the sweep starts, every child's fetch fails, and the only trace is one gap
line repeated inside 59 separate manifests.

`run::github_issues::github_issues_tests::the_gh_login_reaches_the_git_transport`
covers the other half — pre-fix there is no second variable at all, so the token
never reaches the transport.

Supporting: `nothing_at_all_still_runs_an_engagement_that_fetches_nothing`,
`an_exported_token_is_a_source_this_process_need_not_forward`,
`a_gh_login_alone_is_forwarded_as_the_transport_token`,
`a_blank_gh_token_is_not_a_source`, `an_agent_or_a_key_file_is_a_source`,
`an_operators_own_token_is_not_replaced`,
`run::run_tests::a_sweep_over_checkouts_with_no_remote_needs_no_credential`.

## Gates — rung 3 (localized behavior inside one crate)

```
cargo fmt --check                                         EXIT=0
cargo check -p trusty-audit --all-targets                 EXIT=0
cargo clippy -p trusty-audit --all-targets -- -D warnings EXIT=0
cargo test -p trusty-audit                                EXIT=0
  test result: ok. 717 passed; 0 failed; 5 ignored (lib)
  + 33 passed across the 7 integration targets, 0 failed
bash scripts/check_test_pointers.sh                       EXIT=0
  resolved 26746 Test: citation(s) — 0 dangling pointers — OK.
bash scripts/check_line_cap.sh                            EXIT=0
  measured 4177 tracked .rs file(s); 0 violations — OK.
```

Changelog fragment: `crates/trusty-audit/changelog.d/6244-git-credential-preflight.md`.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools