### PR TITLE
docs(website): correct the memory tool count and document the shipped report capabilities

### DIFF
--- a/docs/guides/audit-instructions.md
+++ b/docs/guides/audit-instructions.md
@@ -1,0 +1,107 @@
+# Engagement instructions (`instructions.md`)
+
+A due-diligence report is generated from measurements, not opinions. But two
+engagements over the same repository are rarely asking the same question — one
+cares about how an acquisition target's test coverage will age, another about
+whether a team can absorb a migration. `instructions.md` is where that question
+goes: a free-form markdown brief that travels with the engagement and tells the
+report what this particular review has to address.
+
+It is optional. Leave it out and the run produces exactly what it would have
+produced anyway.
+
+## How it is found
+
+Three sources, highest precedence first:
+
+1. `trusty-review report --instructions <path>` — an explicit path on the
+   command line.
+2. The `[report].instructions` key in `manifest.toml`, resolved relative to the
+   manifest's directory.
+3. A file named `instructions.md` sitting beside `manifest.toml`, discovered
+   with no flag and no key.
+
+The third is what makes an engagement self-contained. A client unzips the
+engagement directory, drops `instructions.md` next to the manifest, and
+`trusty-audit render` picks it up — that command runs a `trusty-review report`
+per manifest, so both entry points resolve the brief the same way.
+
+## What it does to the report
+
+- **Recorded verbatim.** The brief is reproduced as the report's *Analyst
+  Instructions* section, so every report states what it was asked to look for.
+  Nothing paraphrases it.
+- **Steers synthesis.** Under `--synthesize` the brief is also injected into the
+  synthesis prompt as focus directives, shifting where the prose spends its
+  attention.
+- **Never relaxes a guard.** Every number in synthesized prose must trace back to
+  a figure already in the collected data. A figure that cannot is withheld and
+  the report discloses the withholding — asking for it in the brief changes
+  nothing. Instructions steer emphasis; they do not authorize invention.
+
+## Failure behavior
+
+| Situation | Result |
+|---|---|
+| No `instructions.md`, no flag, no manifest key | Fail-open. The run is byte-identical to one that never had a brief. |
+| `--instructions <path>` naming a file that does not exist | Hard error. A mistyped path fails loudly rather than silently producing an unbriefed report. |
+| `instructions.md` present but unreadable — bad permissions, a dangling symlink, non-UTF-8 bytes | Hard error. Fail-open covers a missing input, never one the author put there and the run could not honour. |
+| Either source present but empty | Warning, then treated as absent. |
+
+## A template to start from
+
+The file is free-form markdown — there is no schema, and nothing below is a
+required heading. What follows is a starting point that matches how the brief is
+consumed: it is read as prose, so write it as prose a reviewer would understand.
+
+```markdown
+# Engagement instructions
+
+## Context
+
+One paragraph: what this review is for and who reads the output. A technical
+diligence ahead of an acquisition reads differently from an internal health
+check, and the report's tone should follow the reader.
+
+## Focus areas
+
+Rank these — the first is where depth is most valuable.
+
+1. <Area>. Why it matters for this engagement, and what a good or bad answer
+   would look like.
+2. <Area>. Same.
+3. <Area>. Same.
+
+## Known concerns to investigate
+
+Specific claims or worries to test against the code, one per bullet. Frame each
+as a question the report can answer from evidence.
+
+- <Concern>. What would confirm or dispel it?
+- <Concern>. What would confirm or dispel it?
+
+## De-emphasize
+
+Areas that are out of scope or already understood, so effort is not spent
+restating them.
+
+- <Area>, and why it does not need coverage here.
+
+## Audience and tone
+
+Who the report is written for and how much background to assume — a CTO, a deal
+team with limited engineering context, an internal platform group. Note any
+vocabulary to prefer or avoid.
+
+## Note on limits
+
+Findings stay grounded in what the tooling measured. Where the evidence does not
+support an answer to something asked for above, the report says so rather than
+filling the gap.
+```
+
+That last section is not decoration. The numeric guardrail withholds figures it
+cannot trace back to the data whatever the brief says, so a brief that asks for
+a conclusion the evidence does not support gets a disclosure, not a number.
+Writing that expectation into the brief keeps the reader and the tool agreed on
+what an unanswered question looks like.

--- a/docs/public-manifest.tsv
+++ b/docs/public-manifest.tsv
@@ -119,6 +119,7 @@ PAGE	guides	docs/trusty-agents/user/configuration.md	/guides/trusty-agents/confi
 PAGE	guides	docs/trusty-agents/user/agents-and-skills.md	/guides/trusty-agents/agents-and-skills	Agents and Skills
 PAGE	guides	docs/trusty-git-analytics/user/README.md	/guides/trusty-git-analytics	trusty-git-analytics User Guide
 PAGE	guides	docs/trusty-git-analytics/user/user-guide.md	/guides/trusty-git-analytics/user-guide	Using tga
+PAGE	guides	docs/guides/audit-instructions.md	/guides/audit-instructions	Engagement Instructions (instructions.md)
 
 SECTION	reference	Reference
 PAGE	reference	docs/architecture/harnesses.md	/reference/harnesses	Harnesses

--- a/website/src/lib/tools.test.ts
+++ b/website/src/lib/tools.test.ts
@@ -112,6 +112,47 @@ describe('flagship tool records are grounded in the repository', () => {
 		}
 	});
 
+	/**
+	 * The "MCP tools: N" fact card was wrong on `/tools/trusty-memory` — it said
+	 * 45 against a dispatcher carrying 47, because a tool added to the crate
+	 * changes nothing on the page. The count is the one fact-card number that is
+	 * mechanically re-derivable, so it is derived here rather than trusted.
+	 *
+	 * Each crate exposes its tool set in a different shape, so the pattern is
+	 * per-crate: trusty-memory dispatches by name in a match, trusty-search
+	 * declares a descriptor table. Both are counted from the crate source the
+	 * daemon actually serves.
+	 */
+	const TOOL_COUNT_SOURCES = [
+		{
+			slug: 'trusty-memory',
+			source: 'crates/trusty-memory/src/tools/mod.rs',
+			// Each dispatch arm: `"memory_remember" => handle_memory_remember(...)`.
+			// The `other =>` catch-all carries no quotes and is not counted.
+			pattern: /^\s*"[a-z_]+" =>/gm
+		},
+		{
+			slug: 'trusty-search',
+			source: 'crates/trusty-search/src/mcp/tools/descriptors.rs',
+			// Each descriptor in the tools/list JSON: `"name": "search_lexical"`.
+			pattern: /"name": "[a-z_]+"/g
+		}
+	];
+
+	it.each(TOOL_COUNT_SOURCES)(
+		'$slug fact card names the tool count its crate actually serves',
+		({ slug, source, pattern }) => {
+			const declared = readFileSync(path.join(REPO_ROOT, source), 'utf8').match(pattern);
+			expect(declared, source).not.toBeNull();
+
+			const page = readFileSync(path.join(HERE, '../routes/tools', slug, '+page.svelte'), 'utf8');
+			const card = page.match(/\{\s*label:\s*'MCP tools',\s*value:\s*'(\d+)'\s*\}/);
+			expect(card, `${slug} has an 'MCP tools' fact card`).not.toBeNull();
+
+			expect(Number(card![1]), `${slug} fact card vs ${source}`).toBe(declared!.length);
+		}
+	);
+
 	it('never names a retired binary or a `cp` install', () => {
 		const prose = JSON.stringify(TOOLS);
 		for (const banned of [

--- a/website/src/routes/tools/trusty-audit/+page.svelte
+++ b/website/src/routes/tools/trusty-audit/+page.svelte
@@ -120,6 +120,24 @@
 					downloads fails in the first thirty seconds, naming the URL it could not reach.</span
 				>
 			</li>
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="mt-[0.55em] h-1 w-1 shrink-0 bg-foundry-primary"></span>
+				<span
+					><span class="font-semibold text-foundry-text"
+						>An <code class="text-sm">instructions.md</code>, if this engagement has a brief.</span
+					>
+					Optional. A free-form markdown file sitting beside
+					<code class="text-sm">manifest.toml</code> naming the focus areas and concerns this review
+					has to address.
+					<code class="text-sm">trusty-audit render</code> finds it there on its own — no flag, no
+					manifest key — and records it verbatim in the report as its Analyst Instructions section.
+					Leave it out and the run is unchanged; put one there that cannot be read and the run stops
+					rather than quietly ignoring it.
+					<a class="underline hover:text-foundry-text" href="/docs/guides/audit-instructions"
+						>Guide and template</a
+					>.</span
+				>
+			</li>
 		</ul>
 	</div>
 

--- a/website/src/routes/tools/trusty-memory/+page.svelte
+++ b/website/src/routes/tools/trusty-memory/+page.svelte
@@ -7,7 +7,7 @@
 	const facts = [
 		{ label: 'Package', value: 'trusty-memory' },
 		{ label: 'Default port', value: '7070' },
-		{ label: 'MCP tools', value: '45' },
+		{ label: 'MCP tools', value: '47' },
 		{ label: 'Storage', value: 'usearch + redb, on disk' }
 	];
 </script>

--- a/website/src/routes/tools/trusty-mpm/+page.svelte
+++ b/website/src/routes/tools/trusty-mpm/+page.svelte
@@ -54,6 +54,17 @@
 					><code class="text-sm">tm gui</code> — an optional desktop shell over the same daemon.</span
 				>
 			</li>
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="mt-[0.55em] h-1 w-1 shrink-0 bg-foundry-primary"></span>
+				<span
+					><code class="text-sm">tm wait</code> — poll a condition rather than sleep on it:
+					<code class="text-sm">--for run</code> until a process exits,
+					<code class="text-sm">--for file</code> until a sentinel appears (optionally containing a
+					string), <code class="text-sm">--for check</code> until a pull request's checks settle. It exits
+					0 when the condition holds and 75 while it is still pending, so an agent whose turn has a ceiling
+					re-runs the identical command instead of losing the wait.</span
+				>
+			</li>
 		</ul>
 	</div>
 

--- a/website/src/routes/tools/trusty-review/+page.svelte
+++ b/website/src/routes/tools/trusty-review/+page.svelte
@@ -116,5 +116,44 @@
 			result. Every value carries a marker saying whether it was measured, declared, or inferred, and
 			a figure that appears nowhere in the underlying data is rejected before it can reach the page.
 		</p>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			The data appendix is not left as pipe tables alone. Each populated dataset carries a declared
+			chart type, and the renderer turns it into a Mermaid chart under its table — an
+			<code class="text-sm">xychart-beta</code> for bar and stacked-bar data, a
+			<code class="text-sm">radar-beta</code> for radar. That pass is pure rendering from the rows already
+			in the table: no model, no network. The table stays the authoritative source and the chart is a
+			derived view of it, so a dataset that stayed empty simply gets no chart.
+		</p>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			<code class="text-sm">--analyze</code> fills the complexity sections from a running trusty-analyze
+			daemon — the complexity distribution and the RED/AMBER finding bands, mapped from the daemon's own
+			measurements rather than from prose. It fails open per dataset: whatever answered is kept and whatever
+			did not is named under Gaps &amp; Caveats, and a run where the daemon is absent falls back to the
+			built-in scan and produces the same output a run without the flag would.
+		</p>
+	</div>
+
+	<div>
+		<h2 class="font-display text-2xl font-bold sm:text-3xl">Telling it what to look for</h2>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			A report can carry an analyst brief: a free-form markdown file naming the focus areas, the
+			concerns to chase, and the questions this particular review has to answer. Pass it with
+			<code class="text-sm">--instructions &lt;path&gt;</code>, name it under the manifest's
+			<code class="text-sm">[report].instructions</code> key, or drop a file called
+			<code class="text-sm">instructions.md</code> next to
+			<code class="text-sm">manifest.toml</code> and it is picked up with no flag and no key. Those three
+			are a precedence order, highest first.
+		</p>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			The brief is recorded verbatim in the report as its Analyst Instructions section, so every
+			report says what it was asked to look for. Under
+			<code class="text-sm">--synthesize</code> it also steers where the prose puts its emphasis.
+			What it cannot do is loosen a guard: a figure the numeric guardrail cannot trace back to the
+			collected data is withheld whether or not the brief asked for it, and the report discloses the
+			withholding. Leave the file out and the run is unchanged.
+			<a class="underline hover:text-foundry-text" href="/docs/guides/audit-instructions"
+				>The instructions.md guide</a
+			> has the mechanism and a template to start from.
+		</p>
 	</div>
 </ToolPage>


### PR DESCRIPTION
Docs and website only — no crate `src/**`, so no changelog fragment and no version bump. Test ladder **rung 1** (doc gates), plus the website suite because `website/` changed.

## What changed

- `/tools/trusty-memory` fact card: 45 → 47 MCP tools. `crates/trusty-memory/src/tools/mod.rs` dispatches 47 named arms.
- `website/src/lib/tools.test.ts`: a new case re-derives the count from crate source for both pages that carry one — trusty-memory's dispatch arms and trusty-search's descriptor table (21, already correct). Adding a tool to either crate now fails the website suite.
- `/tools/trusty-review`: adds the two shipped report capabilities the page omitted — Mermaid chart rendering from the §7 dataset markers (`report/mermaid.rs`), and `--analyze` complexity population from the trusty-analyze daemon (`report/analyze_adapter.rs`).
- `instructions.md`: a subsection on the trusty-review and trusty-audit pages, both linking to a new public guide. Mechanism per `report/instructions.rs` and `cli_report.rs` — precedence `--instructions` > `[report].instructions` > a file beside `manifest.toml`; recorded verbatim as Analyst Instructions; steers `--synthesize` focus; never relaxes a guard.
- `docs/guides/audit-instructions.md` + its `docs/public-manifest.tsv` row, published at `/docs/guides/audit-instructions`. Carries a generic copy-paste template.
- `/tools/trusty-mpm`: one bullet for `tm wait` — run/file/check conditions, exit 0 met, 75 pending.

## Gates

| Gate | Result |
|---|---|
| `bash scripts/check_public_docs.sh` | `27 page(s) across 5 section(s) — all resolve inside the public boundary.` |
| `bash scripts/check_sld.sh` | `scanned 61 spec doc(s) + 3393 code file(s); ... 0 error(s), 0 warning(s)` |
| `pnpm test` (from `website/`) | `Test Files 14 passed (14)`, `Tests 265 passed (265)` |
| `pnpm run lint` (from `website/`) | exit 0 |
| `pnpm run build` (from `website/`) | exit 0; `/docs/guides/audit-instructions` prerenders |

Ran on Node v22.23.2, pnpm 9.15.9. The documented `theme.test.ts` localStorage failure on a newer-than-CI Node did not occur.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools