### PR TITLE
fix(trusty-audit): a repository that failed leaves a record in the package (Refs #6245)

### DIFF
--- a/crates/trusty-audit/changelog.d/6245-failure-records.md
+++ b/crates/trusty-audit/changelog.d/6245-failure-records.md
@@ -1,0 +1,12 @@
+Fixed
+- A repository that failed now leaves a trace in the return package. Each one
+  ships its child's own log as `failures/<stem>.log`, copied through the same
+  symlink, hardlink and credential guards every other member goes through, and a
+  generated `failures/index.md` names the repository, what went wrong, how long
+  it ran, and the gaps it stated before it stopped. A failure with no log says
+  so rather than being absent. Before this a failed target left nothing at all —
+  "failed" and "never attempted" were the same observation from the outside, and
+  diagnosing either meant re-running the sweep on the machine that had it.
+- The generated members are scanned for the engagement's credentials before they
+  are written, rather than trusted because this crate wrote them. The failure
+  record quotes reason strings, and a reason can carry text a child produced.

--- a/crates/trusty-audit/src/package.rs
+++ b/crates/trusty-audit/src/package.rs
@@ -7,7 +7,7 @@
 //! email. This module reduces them to one file and prints its path.
 //!
 //! What: [`assemble`] collects what a completed sweep produced, generates the
-//! three files that explain it ([`generated`]), and writes a single zip.
+//! files that explain it ([`generated`]), and writes a single zip.
 //! [`ReturnPackage`] is what a front end renders — the path, every member, and
 //! every repository left out.
 //!
@@ -98,13 +98,16 @@ use crate::workdir::{Area, WorkDir};
 // visibility change — so it moved rather than anything else splitting.
 mod credential_scan;
 
-// #6080: the three members this crate generates rather than collects — the
-// README, `package.toml`, and the new `reports/index.md`. Split out when the
-// index pushed this file past the 500-SLOC production cap. This file decides
-// what goes into the archive; that one writes the files describing the result.
+// #6080, #6245: the members this crate generates rather than collects — the
+// README, `package.toml`, `reports/index.md`, and `failures/index.md`. Split
+// out when the index pushed this file past the 500-SLOC production cap. This
+// file decides what goes into the archive; that one writes the files describing
+// the result.
 mod generated;
 
-use generated::{Generated, exclusions, render_index, render_metadata, render_readme};
+use generated::{
+    Generated, exclusions, render_failures, render_index, render_metadata, render_readme,
+};
 
 /// Filename of the return package, when the recipient does not choose one.
 pub const PACKAGE_FILE_NAME: &str = "audit-return-package.zip";
@@ -130,6 +133,24 @@ pub const INDEX_ENTRY: &str = "reports/index.md";
 
 /// Directory inside the zip holding the tga extract databases (#5479).
 pub const EXTRACT_PREFIX: &str = "extract";
+
+/// Directory inside the zip holding the record of every repository that failed.
+///
+/// Why (#6245): a failed target used to leave NOTHING in the package — no log,
+/// no record, just absence from `reports/`. A recipient could not tell "this
+/// repository failed" from "this repository was never attempted", and
+/// diagnosing either meant re-running the sweep on the machine that had it. Two
+/// of 59 repositories exited 1 on the 2026-08-25 run and shipped no trace at
+/// all.
+/// What: one `failures/<stem>.log` per failed repository — the child's own
+/// combined output, copied through the same credential scan every other
+/// collected member goes through — plus a generated [`FAILURES_ENTRY`] naming
+/// each one, why it failed, and where its log is.
+/// Test: `super::package_tests::a_failed_repository_ships_its_log_and_a_record`.
+pub const FAILURES_PREFIX: &str = "failures";
+
+/// The generated member that names every repository that failed, and why.
+pub const FAILURES_ENTRY: &str = "failures/index.md";
 
 /// Where the package lands when nothing overrides it.
 ///
@@ -324,6 +345,13 @@ pub fn assemble(
         )?;
         collect_extract(work, &stem, &run.repo.name, &mut collected)?;
     }
+    // #6245: the log of every repository that failed, as a collected member —
+    // so it goes through the same symlink, hardlink and credential guards the
+    // reports do. A log that is not on disk is simply absent; the generated
+    // record below still names the repository and why it failed.
+    for run in report.failures() {
+        collect_log(run, &mut collected)?;
+    }
     collected.sort_by(|a, b| a.0.cmp(&b.0));
 
     // #5824: the sweep's own failures, then the targets that never reached it.
@@ -336,6 +364,9 @@ pub fn assemble(
         // actually going into this archive rather than the files the sweep left
         // on disk. Before `fill_archive`, because it is one of the members.
         index: render_index(work, report, &collected),
+        // #6245: `None` on a clean sweep — a `failures/` directory holding an
+        // index that says "none" is worse than no directory.
+        failures: render_failures(report, &collected),
     };
 
     write_archive(
@@ -459,6 +490,45 @@ fn collect_dir(
             entry.path().to_path_buf(),
         ));
     }
+    Ok(())
+}
+
+/// One failed repository's child log, as a member under [`FAILURES_PREFIX`].
+///
+/// Why (#6245): the log is the only thing that says what the child was doing
+/// when it stopped, and it was staying on the machine that ran the sweep — so a
+/// recipient holding the package could not diagnose a failed repository without
+/// re-running it. It ships through the collected-member path rather than as
+/// generated text because it is bytes ANOTHER program wrote, and every such byte
+/// goes through [`credential_scan::copy_member`]'s scan.
+/// What: the same symlink and hardlink refusals [`collect_dir`] applies, then
+/// `failures/<stem>.log`. A log that is not on disk — a child that never got far
+/// enough to have one — is skipped in silence; [`render_failures`] names the
+/// repository either way.
+///
+/// # Errors
+///
+/// [`AuditError::UnsafePackageEntry`] when the log is a symlink or is
+/// hardlinked, for the same reason a report under `out/` would be.
+/// Test: `super::package_tests::a_failed_repository_ships_its_log_and_a_record`.
+fn collect_log(run: &RepoRun, into: &mut Vec<(String, PathBuf)>) -> Result<(), AuditError> {
+    let Ok(metadata) = std::fs::symlink_metadata(&run.log) else {
+        return Ok(());
+    };
+    if metadata.file_type().is_symlink() {
+        return Err(AuditError::UnsafePackageEntry {
+            path: run.log.clone(),
+            kind: "symlink",
+        });
+    }
+    if !metadata.is_file() {
+        return Ok(());
+    }
+    refuse_if_hardlinked(&run.log)?;
+    into.push((
+        format!("{FAILURES_PREFIX}/{}.log", output_stem(run)),
+        run.log.clone(),
+    ));
     Ok(())
 }
 
@@ -595,11 +665,19 @@ fn fill_archive(
     let mut zip = zip::ZipWriter::new(std::io::BufWriter::new(file));
     let mut files = Vec::with_capacity(collected.len() + 3);
 
-    for (entry, text) in [
-        (README_ENTRY, generated.readme),
-        (METADATA_ENTRY, generated.metadata),
-        (INDEX_ENTRY, generated.index),
-    ] {
+    let members = [
+        (README_ENTRY, Some(generated.readme)),
+        (METADATA_ENTRY, Some(generated.metadata)),
+        (INDEX_ENTRY, Some(generated.index)),
+        // #6245: absent on a clean sweep — see `Generated::failures`.
+        (FAILURES_ENTRY, generated.failures),
+    ];
+    for (entry, text) in members.into_iter().filter_map(|(e, t)| t.map(|t| (e, t))) {
+        // #6245: this member quotes the reason strings recorded for each failed
+        // repository, and a reason can carry text a child produced. Generated or
+        // not, it is scanned before it is written — the same bar every collected
+        // member meets.
+        credential_scan::refuse_if_credential(&text, entry, config, github_token)?;
         start(&mut zip, entry, text.len() as u64, temporary)?;
         zip.write_all(text.as_bytes())
             .map_err(|source| AuditError::Package {
@@ -1464,13 +1542,118 @@ api_key = "lin_api_do-not-package-me"
         let metadata = read_entry(&destination, METADATA_ENTRY);
         assert!(metadata.contains("repositories_excluded = 1"), "{metadata}");
 
-        // The failed repository's own output must not ride along.
+        // The failed repository's own REPORT must not ride along. Its log does,
+        // under `failures/` — see `a_failed_repository_ships_its_log_and_a_record`.
         assert!(
             !entries(&destination)
                 .iter()
-                .any(|e| e.contains("01-acme-web")),
-            "the excluded repository's files are in the package"
+                .any(|e| e.starts_with(&format!("{REPORTS_PREFIX}/01-acme-web"))),
+            "the excluded repository's report files are in the package"
         );
+    }
+
+    /// 🔴 #6245: a repository that failed must leave a trace in the package —
+    /// its own log, and a record naming what went wrong.
+    ///
+    /// Against `3771644d0` a failed target left NOTHING: no `failures/`
+    /// directory, no log, only absence from `reports/`. Two of 59 repositories
+    /// exited 1 on the 2026-08-25 run and shipped no trace at all, so "failed"
+    /// and "never attempted" were the same observation from the outside.
+    #[test]
+    fn a_failed_repository_ships_its_log_and_a_record() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        install_record(&work);
+        let report = RunReport::of(vec![
+            audited(&work, "00-acme-api", "acme-api"),
+            failed(&work, "01-acme-web", "acme-web"),
+        ]);
+        std::fs::write(
+            &report.repos[1].log,
+            "stage: collect\nfatal: could not read\n",
+        )
+        .expect("the child left a log");
+        let destination = default_destination(&work);
+
+        assemble(&work, &config(), &report, &[], &destination, None).expect("assembles");
+
+        let log = read_entry(&destination, "failures/01-acme-web.log");
+        assert!(log.contains("fatal: could not read"), "{log}");
+
+        let record = read_entry(&destination, FAILURES_ENTRY);
+        for expected in ["acme-web", "exited with code 3", "failures/01-acme-web.log"] {
+            assert!(record.contains(expected), "{record}");
+        }
+    }
+
+    /// A repository whose child never wrote a log still gets a record, and the
+    /// record says so — silence about a missing log is the defect one level
+    /// down from the one #6245 is about.
+    #[test]
+    fn a_failure_with_no_log_still_gets_a_record() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        install_record(&work);
+        let report = RunReport::of(vec![
+            audited(&work, "00-acme-api", "acme-api"),
+            failed(&work, "01-acme-web", "acme-web"),
+        ]);
+        let destination = default_destination(&work);
+
+        assemble(&work, &config(), &report, &[], &destination, None).expect("assembles");
+        let record = read_entry(&destination, FAILURES_ENTRY);
+        assert!(record.contains("no log survived"), "{record}");
+        assert!(
+            !entries(&destination).iter().any(|e| e.ends_with(".log")),
+            "there was no log to package"
+        );
+    }
+
+    /// A clean sweep gets no `failures/` directory: an index that says "none"
+    /// reads worse than no directory at all.
+    #[test]
+    fn a_clean_sweep_has_no_failures_directory() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        install_record(&work);
+        let report = RunReport::of(vec![audited(&work, "00-acme-api", "acme-api")]);
+        let destination = default_destination(&work);
+
+        assemble(&work, &config(), &report, &[], &destination, None).expect("assembles");
+        assert!(
+            !entries(&destination)
+                .iter()
+                .any(|e| e.starts_with(FAILURES_PREFIX)),
+            "{:?}",
+            entries(&destination)
+        );
+    }
+
+    /// The generated failure record quotes reason strings, and a reason can
+    /// carry text a child produced — so it is scanned like every other member
+    /// rather than trusted because this crate wrote it.
+    #[test]
+    fn a_failure_record_carrying_a_credential_is_refused() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        install_record(&work);
+        let mut leaking = failed(&work, "01-acme-web", "acme-web");
+        leaking.result = RepoResult::Failed {
+            reason: format!(
+                "provider rejected the key {}",
+                config().openrouter_key.expose()
+            ),
+        };
+        let report = RunReport::of(vec![audited(&work, "00-acme-api", "acme-api"), leaking]);
+        let destination = default_destination(&work);
+
+        let err = assemble(&work, &config(), &report, &[], &destination, None)
+            .expect_err("a generated member carrying the key is refused");
+        assert!(
+            matches!(err, AuditError::CredentialInPackage { .. }),
+            "{err:?}"
+        );
+        assert!(!destination.exists(), "a refused assembly leaves no zip");
     }
 
     /// The default lands inside the root that `rm -rf <work-dir>` removes, and

--- a/crates/trusty-audit/src/package/credential_scan.rs
+++ b/crates/trusty-audit/src/package/credential_scan.rs
@@ -68,6 +68,38 @@ fn secret_needles<'a>(
     needles
 }
 
+/// Refuse text this crate GENERATED if it carries any credential (#6245).
+///
+/// Why: the generated members used to be trusted by construction — this crate
+/// wrote every byte of them, and [`crate::config::SecretKey`] has no
+/// `Serialize`, so no credential could reach them through a type. `failures`
+/// breaks that assumption: it quotes the reason string recorded for each failed
+/// repository, and a reason can carry text a child produced. Trust by
+/// construction is only trust while the construction holds.
+/// What: the same needle set and the same refusal [`copy_member`] applies, over
+/// a string already in memory. `entry` names the member in the error, since
+/// there is no source file to name.
+///
+/// # Errors
+///
+/// [`AuditError::CredentialInPackage`] when `text` carries any configured
+/// secret or the `gh`-derived token.
+/// Test: `super::super::package_tests::a_failure_record_carrying_a_credential_is_refused`.
+pub(super) fn refuse_if_credential(
+    text: &str,
+    entry: &str,
+    config: &EngagementConfig,
+    github_token: Option<&str>,
+) -> Result<(), AuditError> {
+    let needles = secret_needles(config, github_token);
+    if CredentialScan::over(&needles).feed(text.as_bytes()) {
+        return Err(AuditError::CredentialInPackage {
+            path: std::path::PathBuf::from(entry),
+        });
+    }
+    Ok(())
+}
+
 /// Copy one file into the archive, refusing it if it carries any credential.
 pub(super) fn copy_member(
     zip: &mut Archive,

--- a/crates/trusty-audit/src/package/generated.rs
+++ b/crates/trusty-audit/src/package/generated.rs
@@ -1,15 +1,16 @@
-//! The three members this crate GENERATES into the return package.
+//! The members this crate GENERATES into the return package.
 //!
 //! Why: split out of `crate::package` when the packaged index (#6080) pushed
 //! that file past the 500-SLOC production cap — the second split, after
 //! `credential_scan`. It separates on a real line: `package.rs` decides what
 //! goes into the archive and refuses what must not, and this file writes the
-//! three files that describe the result. Nothing here reads the filesystem
+//! files that describe the result. Nothing here reads the filesystem
 //! except the tool record, and nothing here writes.
 //!
 //! What: [`render_readme`] (the page the recipient reads before sending),
-//! [`render_metadata`] (`package.toml`), and [`render_index`]
-//! (`reports/index.md`, #6080), plus [`exclusions`], the one line per
+//! [`render_metadata`] (`package.toml`), [`render_index`]
+//! (`reports/index.md`, #6080) and [`render_failures`]
+//! (`failures/index.md`, #6245), plus [`exclusions`], the one line per
 //! repository the package does not cover that the first two share.
 //!
 //! Test: `super::package_tests`.
@@ -25,7 +26,7 @@ use crate::run::{RepoRun, RunReport};
 use crate::tools;
 use crate::workdir::WorkDir;
 
-/// The three members this crate writes into the archive itself.
+/// The members this crate writes into the archive itself.
 ///
 /// Why: one value rather than three `String` parameters threaded through
 /// `super::write_archive` and `super::fill_archive` — the index (#6080) was the
@@ -40,6 +41,11 @@ pub(super) struct Generated {
     pub(super) metadata: String,
     /// [`super::INDEX_ENTRY`] — what the reports are, and a link to each.
     pub(super) index: String,
+    /// [`super::FAILURES_ENTRY`] — every repository that failed, and why.
+    ///
+    /// `None` when the sweep had no failures: a `failures/` directory holding
+    /// an index that says "none" reads worse than no directory at all (#6245).
+    pub(super) failures: Option<String>,
 }
 
 /// The generated `package.toml`.
@@ -176,6 +182,66 @@ fn declared_inference(report: &RunReport) -> Option<crate::index_report::Inferen
             .as_ref()
             .map(crate::index_report::InferenceRecord::declared)
     })
+}
+
+/// The record of every repository that failed, or `None` if none did.
+///
+/// Why (#6245): a failed target left NOTHING in the package — no log, no record,
+/// only absence from `reports/`. "Failed" and "never attempted" were the same
+/// observation from the outside, and diagnosing either meant re-running the
+/// sweep on the machine that had it. Two of 59 repositories exited 1 on the
+/// 2026-08-25 run and shipped no trace at all.
+/// What: one section per failure, naming the repository, the reason the sweep
+/// recorded (which carries the exit code, the timeout, or why the child never
+/// started), how long it ran, any gaps its manifest stated, and the log member
+/// carrying its own output — or the fact that no log survived, which is itself
+/// the answer to "how far did it get".
+///
+/// `packaged` is the member list, so the log is linked only when it is actually
+/// in this archive rather than when it happened to be on disk — the same rule
+/// [`render_index`] follows.
+/// Test: `super::package_tests::a_failed_repository_ships_its_log_and_a_record`,
+/// `super::package_tests::a_clean_sweep_has_no_failures_directory`.
+pub(super) fn render_failures(
+    report: &RunReport,
+    packaged: &[(String, PathBuf)],
+) -> Option<String> {
+    let failures: Vec<&RepoRun> = report.failures().collect();
+    if failures.is_empty() {
+        return None;
+    }
+    let mut out = String::from(
+        "# Repositories this audit did not cover\n\n\
+         Each section below is a repository the sweep attempted and did not finish. \
+         It is here so a failure reads as a failure rather than as an absence — \
+         a repository missing from `reports/` with no section here was never attempted.\n",
+    );
+    for run in failures {
+        let entry = format!("{}/{}.log", super::FAILURES_PREFIX, super::output_stem(run));
+        out.push_str(&format!("\n## {}\n\n", run.repo.name));
+        out.push_str(&format!("- Checkout: `{}`\n", run.repo.path.display()));
+        if let crate::run::RepoResult::Failed { reason } = &run.result {
+            out.push_str(&format!("- What went wrong: {reason}\n"));
+        }
+        if let Some(ms) = run.duration_ms {
+            out.push_str(&format!("- Ran for: {} s\n", ms / 1000));
+        }
+        if packaged.iter().any(|(name, _)| name == &entry) {
+            out.push_str(&format!("- Its own output: [`{entry}`]({entry})\n"));
+        } else {
+            out.push_str(
+                "- Its own output: no log survived, so the child stopped before it \
+                 wrote one\n",
+            );
+        }
+        if !run.gaps.is_empty() {
+            out.push_str("\nGaps it stated before it stopped:\n\n");
+            for gap in &run.gaps {
+                out.push_str(&format!("- {gap}\n"));
+            }
+        }
+    }
+    Some(out)
 }
 
 /// One line per repository the package does not cover.


### PR DESCRIPTION
Refs #6245.

## What changed

`package::assemble` collected only the SUCCEEDED repositories' output. A failed
target reached the package as one line in `excluded` and nothing else — no log,
no record, only absence from `reports/`.

Now each failed repository contributes:

- `failures/<stem>.log` — the child's own combined output, pushed through the
  collected-member path so it meets the same symlink refusal, hardlink refusal
  and byte-by-byte credential scan every report and extract database does.
- a section in the generated `failures/index.md` naming the repository, the
  reason the sweep recorded (which carries the exit code, the timeout, or why
  the child never started), how long it ran, the gaps it stated, and a link to
  its log — or the fact that no log survived, which is itself the answer to
  "how far did it get".

A clean sweep gets no `failures/` directory: an index that says "none" reads
worse than no directory.

**Security note.** The generated members used to be trusted by construction —
this crate wrote every byte and `SecretKey` has no `Serialize`. The failure
record breaks that assumption because it quotes reason strings, and a reason can
carry text a child produced. `credential_scan::refuse_if_credential` now scans
every generated member before it is written, using the same needle set
`copy_member` uses.

## Fail-Open Check — the regression test that fails pre-fix

`package::package_tests::a_failed_repository_ships_its_log_and_a_record`. It
runs a partial sweep with a log on disk and asserts both `failures/01-acme-web.log`
and the record naming `acme-web`, `exited with code 3`, and the log path are in
the zip. Against `3771644d0` neither member exists — `read_entry` fails on the
first one.

Supporting: `a_failure_with_no_log_still_gets_a_record`,
`a_clean_sweep_has_no_failures_directory`,
`a_failure_record_carrying_a_credential_is_refused`.

One existing assertion in `a_partial_sweep_names_what_the_package_omits` was
tightened rather than removed: it asserted the failed repository's files were
absent entirely; it now asserts its REPORT files are absent, since its log
deliberately ships under `failures/`.

## Gates — rung 3 (localized behavior inside one crate)

```
cargo fmt --check                                         EXIT=0
cargo check -p trusty-audit --all-targets                 EXIT=0
cargo clippy -p trusty-audit --all-targets -- -D warnings EXIT=0
cargo test -p trusty-audit                                EXIT=0
  test result: ok. 712 passed; 0 failed; 5 ignored (lib)
  + 33 passed across the 7 integration targets, 0 failed
bash scripts/check_test_pointers.sh                       EXIT=0
  resolved 26747 Test: citation(s) — 0 dangling pointers — OK.
bash scripts/check_line_cap.sh                            EXIT=0
  measured 4176 tracked .rs file(s); 0 violations — OK.
```

Changelog fragment: `crates/trusty-audit/changelog.d/6245-failure-records.md`.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools