### PR TITLE
fix(trusty-audit): configuration this version does not act on is declared, not dropped (Refs #6246)

### DIFF
--- a/crates/trusty-audit/changelog.d/6246-unsupported-config-declared.md
+++ b/crates/trusty-audit/changelog.d/6246-unsupported-config-declared.md
@@ -1,0 +1,13 @@
+Fixed
+- An engagement config key this version does not act on is declared instead of
+  discarded. The keys are captured at parse time, named in `package.toml` as
+  `config_not_acted_on` (always emitted, so an empty array is a positive claim
+  of full coverage), and stated in the return package's README and in the
+  `excluded` lines a front end prints. Before this, a config requesting extra
+  export families — per-commit tables, CODEOWNERS metadata, branch-protection
+  metadata — produced output byte-identical to a run that requested none, with
+  no skip or unsupported marker anywhere, so the operator was left inferring
+  silence as "the config did nothing".
+- The limit is stated rather than implied: this covers TOP-LEVEL keys. A stray
+  key written after a table header belongs to that table in TOML and is still
+  absorbed by that table's own type.

--- a/crates/trusty-audit/src/config.rs
+++ b/crates/trusty-audit/src/config.rs
@@ -365,11 +365,71 @@ pub struct EngagementConfig {
     /// Engagement label, when the generator recorded one.
     #[serde(default)]
     pub engagement: Option<String>,
+    /// Every top-level key this version does not recognise (#6246).
+    ///
+    /// Why: unknown keys are tolerated so a config written by a newer generator
+    /// still loads (#5478) — but tolerated used to mean DISCARDED IN SILENCE.
+    /// An engagement that asked for three extra export families got output
+    /// byte-identical to one that asked for nothing, with no warning anywhere:
+    /// the operator was left inferring silence as "the config did nothing".
+    /// Capturing them is what lets [`Self::unsupported_declaration`] say so.
+    /// What: serde's catch-all for unmatched keys. Read it through
+    /// [`Self::unsupported_keys`], never directly — the raw map is ordered by
+    /// the file and carries values this crate has no meaning for.
+    ///
+    /// The honest limit: TOP-LEVEL keys only. A stray key inside a table this
+    /// crate does understand — an `exports` written after `[tools]`, which TOML
+    /// reads as `tools.exports` — is still absorbed by that table's own type and
+    /// still discarded in silence. `[models]` is the one exception, and it
+    /// refuses such a key outright (see [`ModelPins`]).
+    /// Test: `super::config_tests::a_key_this_version_does_not_act_on_is_captured`.
+    #[serde(flatten)]
+    extra: toml::Table,
 }
 
 impl EngagementConfig {
     /// Filename the handoff package uses.
     pub const FILE_NAME: &'static str = "engagement.toml";
+
+    /// Top-level keys this version does not act on, sorted and named.
+    ///
+    /// Sorted rather than in file order so two runs over the same config produce
+    /// the same line, which is what makes the declaration diffable.
+    /// Test: `super::config_tests::a_key_this_version_does_not_act_on_is_captured`.
+    pub fn unsupported_keys(&self) -> Vec<String> {
+        let mut keys: Vec<String> = self.extra.keys().cloned().collect();
+        keys.sort();
+        keys
+    }
+
+    /// One line declaring what the config asked for and this version ignored.
+    ///
+    /// Why (#6246): the deliverable must state an unsupported request, because
+    /// its absence from the output is otherwise indistinguishable from the
+    /// output of a run that never asked. An engagement requesting per-commit
+    /// tables, CODEOWNERS metadata and branch-protection metadata got a file set
+    /// byte-identical to one requesting none, and nothing in either bundle said
+    /// which had happened.
+    /// What: `None` when every key was recognised — an empty declaration is
+    /// worse than no declaration. The line names the keys and says plainly that
+    /// nothing in the package covers them, so a reader is not left inferring
+    /// whether the capability ran and found nothing.
+    /// Test: `super::config_tests::the_declaration_names_every_ignored_key`,
+    /// `crate::package::package_tests::a_config_asking_for_the_unsupported_says_so`.
+    pub fn unsupported_declaration(&self) -> Option<String> {
+        let keys = self.unsupported_keys();
+        if keys.is_empty() {
+            return None;
+        }
+        Some(format!(
+            "the engagement config declares {} — this version of trusty-audit acts on none of \
+             them, so nothing in this package covers what they asked for",
+            keys.iter()
+                .map(|k| format!("`{k}`"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ))
+    }
 
     /// The target set this file declares, or `None` when it declares none.
     ///
@@ -1172,6 +1232,60 @@ trusty-review = "0.15.1"
             EngagementConfig::from_toml(SAMPLE, Path::new("engagement.toml")).expect("parses");
         assert!(cfg.boards.jira.is_none());
         assert!(cfg.boards.linear.is_none());
+    }
+
+    /// 🔴 #6246: a key this version does not act on is CAPTURED, not discarded.
+    ///
+    /// Against `3771644d0` serde dropped every unmatched key on the floor: an
+    /// engagement asking for per-commit tables, CODEOWNERS metadata and
+    /// branch-protection metadata parsed identically to one asking for nothing,
+    /// and no later stage had anything to report.
+    #[test]
+    fn a_key_this_version_does_not_act_on_is_captured() {
+        let cfg = EngagementConfig::from_toml(
+            // Bare keys go BEFORE the first table header: in TOML a bare key
+            // after one belongs to that table, not to the document.
+            &format!("exports = [\"per-commit\"]\n{SAMPLE}\n[branch_protection]\ncollect = true\n"),
+            Path::new("engagement.toml"),
+        )
+        .expect("an unknown key still loads — a newer generator's config must not be refused");
+        assert_eq!(cfg.unsupported_keys(), ["branch_protection", "exports"]);
+    }
+
+    /// The declaration names every ignored key and says plainly that nothing
+    /// covers them — a recipient must not be left inferring whether the
+    /// capability ran and found nothing.
+    #[test]
+    fn the_declaration_names_every_ignored_key() {
+        let cfg = EngagementConfig::from_toml(
+            &format!("codeowners = true\nexports = [\"per-commit\"]\n{SAMPLE}"),
+            Path::new("engagement.toml"),
+        )
+        .expect("parses");
+        let line = cfg
+            .unsupported_declaration()
+            .expect("two keys were not acted on");
+        for expected in [
+            "`codeowners`",
+            "`exports`",
+            "nothing in this package covers",
+        ] {
+            assert!(line.contains(expected), "{line}");
+        }
+    }
+
+    /// A config this version fully understands declares nothing: an empty
+    /// declaration is worse than no declaration.
+    #[test]
+    fn a_fully_understood_config_declares_nothing() {
+        let cfg =
+            EngagementConfig::from_toml(SAMPLE, Path::new("engagement.toml")).expect("parses");
+        assert!(
+            cfg.unsupported_keys().is_empty(),
+            "{:?}",
+            cfg.unsupported_keys()
+        );
+        assert_eq!(cfg.unsupported_declaration(), None);
     }
 
     #[test]

--- a/crates/trusty-audit/src/package.rs
+++ b/crates/trusty-audit/src/package.rs
@@ -329,6 +329,11 @@ pub fn assemble(
     // #5824: the sweep's own failures, then the targets that never reached it.
     let mut excluded = exclusions(report);
     excluded.extend(unattempted.iter().cloned());
+    // #6246: and what the config asked for that this version does not act on. It
+    // belongs in the same list because it answers the same question a recipient
+    // asks of it — what is NOT in here — and because silence about an ignored
+    // request is indistinguishable from a request never made.
+    excluded.extend(config.unsupported_declaration());
     let generated = Generated {
         metadata: render_metadata(work, config, report, &audited, unattempted)?,
         readme: render_readme(config, &audited, &excluded),
@@ -681,6 +686,79 @@ trusty-review = "0.15.1"
         let work = WorkDir::new(dir.join("work"));
         work.create().expect("create");
         work
+    }
+
+    /// 🔴 #6246: a config asking for something this version does not do must say
+    /// so in the deliverable, not produce output identical to a config that
+    /// asked for nothing.
+    ///
+    /// Against `3771644d0` the three requested export families were dropped by
+    /// serde before anything could report them: the file set came back
+    /// byte-identical to a run made without the config, and neither bundle's
+    /// manifest carried a skip or unsupported marker.
+    #[test]
+    fn a_config_asking_for_the_unsupported_says_so() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        install_record(&work);
+        let asking = EngagementConfig::from_toml(
+            // Bare keys go BEFORE the first table header: in TOML a bare key
+            // after one belongs to that table, not to the document.
+            &format!(
+                "exports = [\"per-commit\"]\ncodeowners = true\n{CONFIG}\n\
+                 [branch_protection]\ncollect = true\n"
+            ),
+            Path::new("engagement.toml"),
+        )
+        .expect("parses");
+        let report = RunReport::of(vec![audited(&work, "00-acme-api", "acme-api")]);
+        let destination = default_destination(&work);
+
+        let package =
+            assemble(&work, &asking, &report, &[], &destination, None).expect("assembles");
+
+        let declared = package
+            .excluded
+            .iter()
+            .find(|line| line.contains("engagement config declares"))
+            .unwrap_or_else(|| panic!("{:?}", package.excluded));
+        for key in ["`branch_protection`", "`codeowners`", "`exports`"] {
+            assert!(declared.contains(key), "{declared}");
+        }
+
+        let metadata = read_entry(&destination, METADATA_ENTRY);
+        let declared_in_metadata: toml::Value = metadata.parse().expect("package.toml is TOML");
+        assert_eq!(
+            declared_in_metadata["config_not_acted_on"]
+                .as_array()
+                .map(|a| a.iter().filter_map(toml::Value::as_str).collect::<Vec<_>>()),
+            Some(vec!["branch_protection", "codeowners", "exports"]),
+            "{metadata}"
+        );
+        let readme = read_entry(&destination, README_ENTRY);
+        assert!(readme.contains("`exports`"), "{readme}");
+    }
+
+    /// A config this version fully understands makes a positive claim of it —
+    /// an empty array, never an absent key a reader has to interpret.
+    #[test]
+    fn a_fully_understood_config_claims_so_in_the_metadata() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        install_record(&work);
+        let report = RunReport::of(vec![audited(&work, "00-acme-api", "acme-api")]);
+        let destination = default_destination(&work);
+
+        let package =
+            assemble(&work, &config(), &report, &[], &destination, None).expect("assembles");
+        assert!(package.excluded.is_empty(), "{:?}", package.excluded);
+        let metadata = read_entry(&destination, METADATA_ENTRY);
+        let parsed: toml::Value = metadata.parse().expect("package.toml is TOML");
+        assert_eq!(
+            parsed["config_not_acted_on"].as_array().map(Vec::len),
+            Some(0),
+            "an empty array is the positive claim; an absent key is not: {metadata}"
+        );
     }
 
     /// A repository that ran, with the report and database a real sweep leaves.

--- a/crates/trusty-audit/src/package/generated.rs
+++ b/crates/trusty-audit/src/package/generated.rs
@@ -68,6 +68,14 @@ struct PackageMetadata {
     /// emitted, so an empty array is a positive claim of full coverage rather
     /// than an absent key a reader has to interpret.
     not_attempted: Vec<String>,
+    /// Top-level engagement-config keys this version does not act on (#6246).
+    ///
+    /// Always emitted, for the same reason `not_attempted` is: an empty array is
+    /// a positive claim that everything the config asked for was acted on, where
+    /// an absent key leaves the reader to interpret a silence. An engagement
+    /// that requested three extra export families got output byte-identical to
+    /// one that requested none, and nothing in either bundle said which.
+    config_not_acted_on: Vec<String>,
     tools: Vec<ToolVersion>,
     repositories: Vec<PackagedRepo>,
 }
@@ -226,6 +234,7 @@ pub(super) fn render_metadata(
         repositories_audited: audited.len(),
         repositories_excluded: report.repos.len() - audited.len(),
         not_attempted: unattempted.to_vec(),
+        config_not_acted_on: config.unsupported_keys(),
         tools,
         repositories,
     };


### PR DESCRIPTION
Refs #6246.

## Root cause

`EngagementConfig` derives `Deserialize` with no catch-all, so serde dropped
every unmatched top-level key on the floor. That is deliberate for
forward-compatibility (#5478 — a config written by a newer generator must still
load), but "tolerated" had come to mean "discarded in silence": an engagement
requesting per-commit tables, CODEOWNERS metadata and branch-protection metadata
parsed identically to one requesting nothing, and no later stage had anything to
report. The operator was left inferring silence as "the config did nothing".

## What changed

A `#[serde(flatten)] extra: toml::Table` captures the unmatched keys, and
`unsupported_keys` / `unsupported_declaration` expose them. They surface in
three places a reader actually looks:

- `package.toml` gains `config_not_acted_on`, always emitted — an empty array is
  a positive claim of full coverage, the same rationale `not_attempted` already
  carries. This is the "declare them unsupported in the manifest" the issue asks
  for.
- The return package's README, through the existing `excluded` list.
- `ReturnPackage::excluded`, which a front end prints.

The config still LOADS — an unknown key is not a refusal, because refusing would
break the forward-compatibility the tolerance exists for.

**Stated limit.** This covers TOP-LEVEL keys. A stray key written after a table
header belongs to that table in TOML (`exports` after `[tools]` reads as
`tools.exports`) and is still absorbed by that table's own type. `[models]` is
the one exception and refuses such a key outright. That boundary is documented on
the field rather than left for the next reader to discover.

## Fail-Open Check — the regression test that fails pre-fix

`package::package_tests::a_config_asking_for_the_unsupported_says_so`. It
assembles a package from a config declaring `exports`, `codeowners` and
`[branch_protection]`, and asserts the declaration reaches `excluded`,
`package.toml`'s `config_not_acted_on`, and the README. Against `3771644d0` all
three assertions fail — the keys never survive parsing, so there is nothing to
report anywhere.

Supporting: `config_tests::a_key_this_version_does_not_act_on_is_captured`,
`config_tests::the_declaration_names_every_ignored_key`,
`config_tests::a_fully_understood_config_declares_nothing`,
`package_tests::a_fully_understood_config_claims_so_in_the_metadata`.

## Gates — rung 3 (localized behavior inside one crate)

```
cargo fmt --check                                         EXIT=0
cargo check -p trusty-audit --all-targets                 EXIT=0
cargo clippy -p trusty-audit --all-targets -- -D warnings EXIT=0
cargo test -p trusty-audit                                EXIT=0
  test result: ok. 713 passed; 0 failed; 5 ignored (lib)
  + 33 passed across the 7 integration targets, 0 failed
bash scripts/check_test_pointers.sh                       EXIT=0
  resolved 26747 Test: citation(s) — 0 dangling pointers — OK.
bash scripts/check_line_cap.sh                            EXIT=0
  measured 4176 tracked .rs file(s); 0 violations — OK.
```

Changelog fragment: `crates/trusty-audit/changelog.d/6246-unsupported-config-declared.md`.

Note for merge order: #6250 (Refs #6247) adds a `[report]` section to this same
struct. Until that lands, a config declaring `[report]` would be reported here as
not-acted-on, which is accurate for a build without it.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools