### PR TITLE
feat(trusty-review): the investigation collects its own test and reachability evidence (Refs #6193, Refs #6191)

### DIFF
--- a/crates/trusty-review/changelog.d/6193-6191-deterministic-investigation-evidence.md
+++ b/crates/trusty-review/changelog.d/6193-6191-deterministic-investigation-evidence.md
@@ -1,0 +1,5 @@
+Added
+The investigation record carries two deterministic evidence sources it previously lacked: a test census enumerated over the whole tracked file list, so the `test coverage` dimension's counts no longer move with the byte budget (#6193); and bind/exposure facts read from the examined files' own source, so reachability classification has something to read besides markers in finding text — a network-facing component now classifies as evidenced instead of having its true reach claims withheld (#6191).
+
+Fixed
+`is_test_path` recognises a repository-root `tests/`, `test/`, `spec/` or `__tests__/` directory. The tracked list is repo-relative, so the directory checks — which all wanted a leading separator — matched none of them, and a Cargo crate whose tests live in the root `tests/` reported no test coverage.

--- a/crates/trusty-review/src/cli_report.rs
+++ b/crates/trusty-review/src/cli_report.rs
@@ -1057,6 +1057,7 @@ mod tests {
                 deps: Default::default(),
                 traces: None,
                 coverage: Default::default(),
+                exposure: Vec::new(),
             }],
         }
     }

--- a/crates/trusty-review/src/report/figures_tests.rs
+++ b/crates/trusty-review/src/report/figures_tests.rs
@@ -65,6 +65,7 @@ fn printed_figures_carry_the_coverage_percentage() {
             findings: Vec::new(),
             deps: Default::default(),
             traces: None,
+            exposure: Vec::new(),
         }],
     });
 

--- a/crates/trusty-review/src/report/investigate/batch_tests.rs
+++ b/crates/trusty-review/src/report/investigate/batch_tests.rs
@@ -208,6 +208,7 @@ fn full_selection(files: &[SelectedFile]) -> Selection {
         dimensions_covered: vec!["authentication & secrets".to_string()],
         dimensions_absent: vec![],
         per_dimension: vec![],
+        test_census: Default::default(),
         attributed_files: 0,
         attributed_only: false,
     }

--- a/crates/trusty-review/src/report/investigate/exposure.rs
+++ b/crates/trusty-review/src/report/investigate/exposure.rs
@@ -1,0 +1,250 @@
+//! Bind and exposure evidence, collected from source (#6191).
+//!
+//! Why: the reachability guard in [`synthesize_grounding`] decides whether a
+//! finding's surface is host-local, network-reachable, or unestablished — and
+//! until now it had no evidence source at all. It read the FINDING TEXT for a
+//! `localhost` or `0.0.0.0` marker, so a genuinely network-facing component
+//! whose findings happened not to spell one classified as UNESTABLISHED, and
+//! every true reach claim about it was withheld rather than stated. A check of
+//! the report model found zero bind or exposure keys among its 209.
+//!
+//! What: [`collect`] reads the investigation's own captured file contents — the
+//! bytes already in memory, no second pass over the tree — for bind literals and
+//! outbound absolute URLs, and returns one [`ExposureFact`] per file it can
+//! classify. [`ExposureIndex`] is the lookup the guard consults BEFORE its text
+//! markers, so a file measured from source is never re-decided by a sentence.
+//!
+//! Precedence within one file: a public bind beats a loopback bind, and either
+//! beats an outbound call. A file that binds loopback and also calls an external
+//! API is a loopback-listening surface; its outbound traffic does not make it
+//! reachable.
+//!
+//! Bound: only files the investigation actually read carry facts. That is the
+//! same byte budget the coverage section already states, and the coverage line
+//! names the collected count so the bound is visible rather than implied.
+//!
+//! [`synthesize_grounding`]: crate::report::synthesize_grounding
+//!
+//! Test: `exposure_tests.rs`.
+
+use std::collections::BTreeMap;
+
+use serde::Serialize;
+
+use super::select::SelectedFile;
+
+/// Longest evidence line the record keeps, in bytes.
+const MAX_EVIDENCE: usize = 200;
+
+/// Tokens that mark a line as a socket-binding site.
+///
+/// Deliberately literal and framework-named. A line merely mentioning an address
+/// is not a bind; the address in a comment or a doc example must not decide a
+/// file's reachability.
+const BIND_MARKERS: &[&str] = &[
+    "tcplistener",
+    "unixlistener",
+    "udpsocket",
+    "socketaddr",
+    ".bind(",
+    "bind_addr",
+    "axum::serve",
+    "httpserver::new",
+    "listen(",
+    "listener::bind",
+    "app.listen",
+    "server.listen",
+    "uvicorn.run",
+];
+
+/// Address literals that state a host-local listening surface.
+const LOOPBACK_LITERALS: &[&str] = &["127.0.0.1", "[::1]", "::1", "localhost"];
+
+/// Address literals that state a listening surface on every interface.
+const PUBLIC_LITERALS: &[&str] = &["0.0.0.0", "[::]"];
+
+/// What the source says about one file's reachability (#6191).
+///
+/// Why: the guard needs the three states its tiers already model, told apart by
+/// what was measured rather than by what a sentence said.
+/// What: a bind on loopback, a bind on every interface, or an outbound call to a
+/// non-loopback host. Ordered so `max` is the strongest claim about the file.
+/// Test: `exposure_tests::a_public_bind_beats_a_loopback_bind_on_one_file`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExposureKind {
+    /// The file calls out to a non-loopback host over HTTP(S).
+    NetworkClient,
+    /// The file binds a socket to a loopback address.
+    LoopbackBind,
+    /// The file binds a socket to every interface.
+    PublicBind,
+}
+
+impl ExposureKind {
+    /// True when this evidence places the surface beyond this host.
+    ///
+    /// A loopback bind does not; the other two do. This is the one question the
+    /// grounding guard asks of a fact.
+    pub fn is_beyond_host(self) -> bool {
+        !matches!(self, ExposureKind::LoopbackBind)
+    }
+
+    /// The reader-facing name for the coverage line.
+    pub fn label(self) -> &'static str {
+        match self {
+            ExposureKind::NetworkClient => "outbound network call",
+            ExposureKind::LoopbackBind => "loopback bind",
+            ExposureKind::PublicBind => "public bind",
+        }
+    }
+}
+
+/// One file's collected reachability evidence (#6191).
+///
+/// Why: the count alone would let the report say evidence was collected without
+/// saying what it was; a diligence reader checking a reach claim needs the line
+/// it rests on.
+/// What: the repository-relative path, the strongest kind found in it, and the
+/// source line that stated it, trimmed and capped at [`MAX_EVIDENCE`] bytes.
+/// Test: `exposure_tests::a_loopback_bind_is_collected_with_its_line`.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ExposureFact {
+    /// Repository-relative path of the file the evidence came from.
+    pub file: String,
+    /// The strongest exposure this file's source states.
+    pub kind: ExposureKind,
+    /// The source line the classification rests on.
+    pub evidence: String,
+}
+
+/// Every collected fact, keyed for the grounding guard's lookup (#6191).
+///
+/// Why: the guard normalises a finding's component to a lower-cased path before
+/// comparing, so the index must be keyed the same way or a fact would never
+/// match the finding it is about.
+/// What: built by [`ExposureIndex::from_facts`]; [`ExposureIndex::kind`] answers
+/// for one normalised component, `None` when nothing was measured for it.
+/// Test: `exposure_tests::the_index_is_keyed_by_lowercased_path`.
+#[derive(Debug, Clone, Default)]
+pub struct ExposureIndex {
+    by_file: BTreeMap<String, ExposureKind>,
+}
+
+impl ExposureIndex {
+    /// Index a collected fact set.
+    pub fn from_facts<'a>(facts: impl IntoIterator<Item = &'a ExposureFact>) -> Self {
+        let mut by_file: BTreeMap<String, ExposureKind> = BTreeMap::new();
+        for f in facts {
+            let key = f.file.replace('\\', "/").to_lowercase();
+            let slot = by_file.entry(key).or_insert(f.kind);
+            *slot = (*slot).max(f.kind);
+        }
+        ExposureIndex { by_file }
+    }
+
+    /// What the source measured for this normalised component, if anything.
+    pub fn kind(&self, component: &str) -> Option<ExposureKind> {
+        self.by_file.get(component).copied()
+    }
+
+    /// True when nothing was collected — every consumer then behaves as before.
+    pub fn is_empty(&self) -> bool {
+        self.by_file.is_empty()
+    }
+}
+
+/// Collect one repository's bind/exposure facts from the examined files.
+///
+/// Why/What: see the module doc. One fact per file that states anything, the
+/// strongest kind winning; a file whose source says nothing about reachability
+/// produces no fact, which is what leaves the guard's text-marker path in place
+/// for it.
+/// Test: `exposure_tests::{a_loopback_bind_is_collected_with_its_line,
+/// a_public_bind_beats_a_loopback_bind_on_one_file,
+/// an_outbound_url_is_weaker_than_a_bind, a_file_stating_nothing_yields_no_fact,
+/// a_commented_address_without_a_bind_marker_is_not_evidence}`.
+pub fn collect(files: &[SelectedFile]) -> Vec<ExposureFact> {
+    let mut out = Vec::new();
+    for f in files {
+        if let Some((kind, evidence)) = strongest(&f.content) {
+            out.push(ExposureFact {
+                file: f.path.clone(),
+                kind,
+                evidence,
+            });
+        }
+    }
+    out
+}
+
+/// The strongest exposure one file's text states, with the line that stated it.
+fn strongest(content: &str) -> Option<(ExposureKind, String)> {
+    let mut best: Option<(ExposureKind, String)> = None;
+    for line in content.lines() {
+        let Some(kind) = classify_line(line) else {
+            continue;
+        };
+        if best.as_ref().is_none_or(|(seen, _)| kind > *seen) {
+            best = Some((kind, cap(line)));
+        }
+    }
+    best
+}
+
+/// What one source line states about reachability, if anything.
+fn classify_line(line: &str) -> Option<ExposureKind> {
+    let lower = line.to_lowercase();
+    if BIND_MARKERS.iter().any(|m| lower.contains(m)) {
+        if PUBLIC_LITERALS.iter().any(|a| lower.contains(a)) {
+            return Some(ExposureKind::PublicBind);
+        }
+        if LOOPBACK_LITERALS.iter().any(|a| lower.contains(a)) {
+            return Some(ExposureKind::LoopbackBind);
+        }
+        // A bind site with no address literal states nothing about where it
+        // binds — the address arrived from config, and guessing is what #6191
+        // exists to stop.
+        return None;
+    }
+    if outbound_url(&lower) {
+        return Some(ExposureKind::NetworkClient);
+    }
+    None
+}
+
+/// True when the line carries an absolute HTTP(S) URL to a non-loopback host.
+fn outbound_url(lower: &str) -> bool {
+    for scheme in ["https://", "http://"] {
+        let mut rest = lower;
+        while let Some(i) = rest.find(scheme) {
+            let host = &rest[i + scheme.len()..];
+            let host = host
+                .split(['/', '"', '\'', ' ', ')', '`'])
+                .next()
+                .unwrap_or("");
+            if !host.is_empty() && !LOOPBACK_LITERALS.iter().any(|a| host.starts_with(a)) {
+                return true;
+            }
+            rest = &rest[i + scheme.len()..];
+        }
+    }
+    false
+}
+
+/// Trim a source line and cap it at [`MAX_EVIDENCE`] bytes on a char boundary.
+fn cap(line: &str) -> String {
+    let t = line.trim();
+    if t.len() <= MAX_EVIDENCE {
+        return t.to_string();
+    }
+    let mut end = MAX_EVIDENCE;
+    while end > 0 && !t.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}…", &t[..end])
+}
+
+#[cfg(test)]
+#[path = "exposure_tests.rs"]
+mod tests;

--- a/crates/trusty-review/src/report/investigate/exposure_tests.rs
+++ b/crates/trusty-review/src/report/investigate/exposure_tests.rs
@@ -1,0 +1,162 @@
+//! Tests for the bind/exposure collector (#6191).
+
+use super::*;
+
+fn file(path: &str, content: &str) -> SelectedFile {
+    SelectedFile {
+        path: path.to_string(),
+        content: content.to_string(),
+        truncated: false,
+        dimensions: Vec::new(),
+        selected_by: None,
+        hotspot: None,
+        declared_for: None,
+    }
+}
+
+/// The base case the whole issue rests on: the bind address is IN the source,
+/// and the collector reads it there rather than waiting for a finding to spell
+/// `localhost`.
+#[test]
+fn a_loopback_bind_is_collected_with_its_line() {
+    let facts = collect(&[file(
+        "src/daemon.rs",
+        "fn main() {\n    let l = TcpListener::bind(\"127.0.0.1:7878\").unwrap();\n}\n",
+    )]);
+    assert_eq!(facts.len(), 1, "{facts:?}");
+    assert_eq!(facts[0].kind, ExposureKind::LoopbackBind);
+    assert_eq!(facts[0].file, "src/daemon.rs");
+    assert!(facts[0].evidence.contains("127.0.0.1:7878"), "{facts:?}");
+    assert!(!facts[0].kind.is_beyond_host());
+}
+
+/// One file, two binds. The public one is the fact about the surface — a
+/// loopback bind elsewhere in the same file does not make it host-local.
+#[test]
+fn a_public_bind_beats_a_loopback_bind_on_one_file() {
+    let facts = collect(&[file(
+        "src/serve.rs",
+        "let dev = TcpListener::bind(\"127.0.0.1:0\")?;\nlet prod = TcpListener::bind(\"0.0.0.0:8080\")?;\n",
+    )]);
+    assert_eq!(facts[0].kind, ExposureKind::PublicBind);
+    assert!(facts[0].kind.is_beyond_host());
+}
+
+/// The Telegram-gateway shape from the issue: no bind at all, an outbound call
+/// to a third-party API. It used to classify as unestablished, which withheld
+/// every true reach claim about it.
+#[test]
+fn a_collected_outbound_call_is_reach_evidence() {
+    let facts = collect(&[file(
+        "src/telegram.rs",
+        "const API: &str = \"https://api.telegram.org/bot\";\n",
+    )]);
+    assert_eq!(facts.len(), 1, "{facts:?}");
+    assert_eq!(facts[0].kind, ExposureKind::NetworkClient);
+    assert!(facts[0].kind.is_beyond_host());
+}
+
+/// A file that both binds loopback and calls out is a loopback-LISTENING
+/// surface. Its outbound traffic does not make it reachable.
+#[test]
+fn an_outbound_url_is_weaker_than_a_bind() {
+    let facts = collect(&[file(
+        "src/gateway.rs",
+        "let l = TcpListener::bind(\"127.0.0.1:9000\")?;\nlet api = \"https://api.example.com/v1\";\n",
+    )]);
+    assert_eq!(facts[0].kind, ExposureKind::LoopbackBind);
+}
+
+/// A loopback URL is not an outbound call.
+#[test]
+fn a_loopback_url_is_not_an_outbound_call() {
+    let facts = collect(&[file(
+        "src/client.rs",
+        "let base = \"http://127.0.0.1:7879\";\nlet other = \"http://localhost:7878/health\";\n",
+    )]);
+    assert!(facts.is_empty(), "{facts:?}");
+}
+
+/// No evidence is a real answer. A file stating nothing produces no fact, which
+/// is what leaves the guard's text-marker path in place for it.
+#[test]
+fn a_file_stating_nothing_yields_no_fact() {
+    let facts = collect(&[file(
+        "src/util.rs",
+        "pub fn add(a: u8, b: u8) -> u8 { a + b }\n",
+    )]);
+    assert!(facts.is_empty(), "{facts:?}");
+}
+
+/// An address in prose is not a bind. Without a bind marker on the line the
+/// collector says nothing rather than guessing — guessing is what #6191 exists
+/// to stop.
+#[test]
+fn a_commented_address_without_a_bind_marker_is_not_evidence() {
+    let facts = collect(&[file(
+        "src/notes.rs",
+        "// the daemon answers on 0.0.0.0 in production\npub const PORT: u16 = 8080;\n",
+    )]);
+    assert!(facts.is_empty(), "{facts:?}");
+}
+
+/// A bind site whose address came from config states nothing about where it
+/// binds, so it is not evidence either way.
+#[test]
+fn a_bind_with_no_address_literal_is_not_evidence() {
+    let facts = collect(&[file(
+        "src/serve.rs",
+        "let l = TcpListener::bind(cfg.addr).await?;\n",
+    )]);
+    assert!(facts.is_empty(), "{facts:?}");
+}
+
+/// The guard normalises a component to a lower-cased path before it looks up,
+/// so the index must be keyed the same way or a fact never matches its finding.
+#[test]
+fn the_index_is_keyed_by_lowercased_path() {
+    let facts = vec![ExposureFact {
+        file: "Crates/App/Src/Serve.rs".to_string(),
+        kind: ExposureKind::PublicBind,
+        evidence: "bind(\"0.0.0.0:80\")".to_string(),
+    }];
+    let index = ExposureIndex::from_facts(&facts);
+    assert_eq!(
+        index.kind("crates/app/src/serve.rs"),
+        Some(ExposureKind::PublicBind)
+    );
+    assert_eq!(index.kind("crates/app/src/other.rs"), None);
+    assert!(!index.is_empty());
+    assert!(ExposureIndex::default().is_empty());
+}
+
+/// Two facts about one file collapse to the strongest.
+#[test]
+fn the_index_keeps_the_strongest_fact_per_file() {
+    let facts = vec![
+        ExposureFact {
+            file: "a.rs".to_string(),
+            kind: ExposureKind::LoopbackBind,
+            evidence: "x".to_string(),
+        },
+        ExposureFact {
+            file: "a.rs".to_string(),
+            kind: ExposureKind::PublicBind,
+            evidence: "y".to_string(),
+        },
+    ];
+    let index = ExposureIndex::from_facts(&facts);
+    assert_eq!(index.kind("a.rs"), Some(ExposureKind::PublicBind));
+}
+
+/// A long bind line is capped, and the cap lands on a char boundary.
+#[test]
+fn a_long_evidence_line_is_capped() {
+    let padding = "é".repeat(400);
+    let facts = collect(&[file(
+        "src/serve.rs",
+        &format!("let l = TcpListener::bind(\"127.0.0.1:1\"); // {padding}\n"),
+    )]);
+    assert!(facts[0].evidence.len() <= MAX_EVIDENCE + 4, "{facts:?}");
+    assert!(facts[0].evidence.ends_with('…'), "{facts:?}");
+}

--- a/crates/trusty-review/src/report/investigate/mod.rs
+++ b/crates/trusty-review/src/report/investigate/mod.rs
@@ -23,9 +23,11 @@
 pub mod analyze;
 mod batch;
 pub mod deps;
+pub mod exposure;
 mod regions;
 mod render;
 pub mod select;
+pub mod test_census;
 pub mod trace;
 pub mod trace_client;
 pub mod trace_symbol;
@@ -43,9 +45,11 @@ use crate::report::synthesize::{FindingProse, Synthesis};
 
 pub use batch::BatchStatus;
 pub use deps::{Dependency, DependencyInventory};
+pub use exposure::{ExposureFact, ExposureIndex, ExposureKind};
 pub use select::{
     Budget, DimensionCoverage, RiskSignals, SCALABILITY_DIMENSION, SECURITY_DIMENSION, Selection,
 };
+pub use test_census::TestCensus;
 pub use trace::{FindingTrace, TraceAnchor, TraceLimits, TraceSet};
 pub use verdict::{FindingVerdict, Verdict, VerdictSet, Verifier};
 pub use verify::VerifiedFinding;
@@ -119,6 +123,15 @@ pub struct Coverage {
     pub dimensions_absent: Vec<String>,
     /// Per-dimension coverage of the examined set (#6082).
     pub per_dimension: Vec<select::DimensionCoverage>,
+    /// Test presence enumerated over the whole tracked list (#6193).
+    ///
+    /// Why: the `test coverage` dimension used to count EXAMINED files, so its
+    /// figures moved with the byte budget rather than with the repository. This
+    /// is the deterministic replacement; the LLM narrates it and no longer
+    /// supplies it.
+    /// Test: `counts_test_files_over_the_whole_tracked_list`, and
+    /// `render_tests::the_test_coverage_row_states_the_enumeration`.
+    pub test_census: TestCensus,
     /// Examined files the manifest named as evidence, with a reason (#6082).
     pub attributed_files: usize,
     /// True when selection was restricted to manifest-declared paths (#6082).
@@ -185,6 +198,7 @@ impl Coverage {
             dimensions_covered,
             dimensions_absent,
             per_dimension: sel.per_dimension.clone(),
+            test_census: sel.test_census.clone(),
             attributed_files: sel.attributed_files,
             attributed_only: sel.attributed_only,
             rejected,
@@ -235,6 +249,19 @@ pub struct RepoInvestigation {
     /// per candidate — a candidate leg 1 refused is UNVERIFIABLE carrying that
     /// refusal, so the counts cover the traced set and not only its successes.
     pub verdicts: Option<VerdictSet>,
+    /// Bind/exposure facts read out of the examined files' own source (#6191).
+    ///
+    /// Why: reachability classification had no collection-side evidence at all —
+    /// it inferred a surface's reach from markers in finding text, so a
+    /// network-facing component whose findings did not spell one was withheld
+    /// rather than stated. This is that evidence source.
+    /// What: one entry per examined file whose source states a bind address or
+    /// an outbound absolute URL; empty for a repository whose examined files
+    /// state neither, which leaves the text-marker path exactly as it was.
+    /// Test: `a_loopback_bind_is_collected_with_its_line`, and
+    /// `collected_bind_evidence_outranks_a_text_marker`.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub exposure: Vec<ExposureFact>,
 }
 
 /// The aggregate investigation result recorded on the [`ReportModel`].
@@ -321,9 +348,14 @@ pub async fn run_investigation(
                 deps,
                 traces: None,
                 verdicts: None,
+                exposure: Vec::new(),
             });
             continue;
         }
+
+        // #6191: read from the bytes already captured by selection, before the
+        // batches consume them — no second pass over the tree.
+        let exposure = exposure::collect(&selection.files);
 
         let batches = batch::partition_batches(&selection.files);
         let (mut findings, rejected, outcomes) = batch::run_batches(
@@ -364,6 +396,7 @@ pub async fn run_investigation(
             deps,
             traces,
             verdicts,
+            exposure,
         });
     }
 
@@ -755,6 +788,7 @@ mod batch_gap_tests {
             },
             traces: None,
             verdicts: None,
+            exposure: Vec::new(),
         }
     }
 

--- a/crates/trusty-review/src/report/investigate/render.rs
+++ b/crates/trusty-review/src/report/investigate/render.rs
@@ -17,7 +17,8 @@ use crate::report::model::ReportModel;
 use crate::report::provenance::{INFERRED_TAG, MEASURED_TAG};
 
 use super::{
-    Coverage, DependencyInventory, Investigation, InvestigationStatus, RepoInvestigation, Verdict,
+    Coverage, DependencyInventory, ExposureKind, Investigation, InvestigationStatus,
+    RepoInvestigation, Verdict,
 };
 
 /// Render the appended Dependency Inventory + Investigation Coverage sections.
@@ -247,6 +248,7 @@ fn coverage_lines(repo: &RepoInvestigation, rendered: Option<RenderedCounts>) ->
         "- verified findings: {total} ({risk} RED/AMBER evidence-backed, {clean} clean signals)\n"
     ));
     out.push_str(&reconciliation_line(repo, rendered));
+    out.push_str(&exposure_lines(repo));
     out.push_str(&trace_line(repo));
     out.push_str(&verdict_lines(repo));
     out.push_str(&batch_lines(c));
@@ -373,6 +375,13 @@ fn discovery_lines(c: &Coverage) -> String {
         ));
     }
     for d in &c.per_dimension {
+        // #6193: the test-coverage row is enumerated, not sampled, so it states
+        // its own basis rather than borrowing the "N file(s) examined — e.g."
+        // shape of the five rows that ARE sampled.
+        if d.dimension == super::select::TEST_DIMENSION {
+            out.push_str(&format!("  - {}: {}\n", d.dimension, c.test_census.line()));
+            continue;
+        }
         out.push_str(&format!(
             "  - {}: {} file(s) examined{}\n",
             d.dimension,
@@ -381,6 +390,51 @@ fn discovery_lines(c: &Coverage) -> String {
                 .as_deref()
                 .map(|e| format!(" — e.g. {e}"))
                 .unwrap_or_default(),
+        ));
+    }
+    out
+}
+
+/// Render what the source said about this repository's reachability (#6191).
+///
+/// Why: the reachability guard now has an evidence source, and a guard whose
+/// evidence a reader cannot see is indistinguishable from the text-marker
+/// inference it replaced. This line states how much was collected and from where,
+/// which is also what makes the bound visible: only examined files carry facts.
+/// What: one line with the per-kind counts, and a sub-bullet naming each file
+/// the source placed beyond this host — the class that used to be withheld.
+/// Nothing at all when no fact was collected, so a repository whose examined
+/// files state neither renders exactly as before.
+/// Test: `render_tests::{coverage_section_states_the_exposure_evidence,
+/// coverage_section_omits_the_exposure_line_without_evidence}`.
+fn exposure_lines(repo: &RepoInvestigation) -> String {
+    if repo.exposure.is_empty() {
+        return String::new();
+    }
+    let mut counts: Vec<(ExposureKind, usize)> = Vec::new();
+    for f in &repo.exposure {
+        match counts.iter_mut().find(|(k, _)| *k == f.kind) {
+            Some(entry) => entry.1 += 1,
+            None => counts.push((f.kind, 1)),
+        }
+    }
+    counts.sort_by_key(|(k, _)| std::cmp::Reverse(*k));
+    let parts: Vec<String> = counts
+        .iter()
+        .map(|(k, n)| format!("{n} {}", k.label()))
+        .collect();
+    let mut out = format!(
+        "- reachability evidence: {} file(s) of the examined set state a bind address or an \
+         outbound call in their own source ({})\n",
+        repo.exposure.len(),
+        parts.join(", "),
+    );
+    for f in repo.exposure.iter().filter(|f| f.kind.is_beyond_host()) {
+        out.push_str(&format!(
+            "  - beyond this host: {} ({}) — `{}`\n",
+            f.file,
+            f.kind.label(),
+            f.evidence,
         ));
     }
     out

--- a/crates/trusty-review/src/report/investigate/render_tests.rs
+++ b/crates/trusty-review/src/report/investigate/render_tests.rs
@@ -85,6 +85,7 @@ fn repo(
             dimensions_covered: vec!["authentication & secrets".to_string()],
             dimensions_absent: vec!["scalability".to_string()],
             per_dimension: vec![],
+            test_census: Default::default(),
             attributed_files: 0,
             attributed_only: false,
             rejected: 2,
@@ -94,6 +95,7 @@ fn repo(
             batches_failed: vec![],
         },
         traces: None,
+        exposure: Vec::new(),
     }
 }
 
@@ -646,4 +648,83 @@ fn coverage_omits_the_reconciliation_when_it_would_not_add_up() {
     };
     let out = coverage_section(&model_rendering(0, 1, 0), &inv);
     assert!(!out.contains("reconciliation"), "{out}");
+}
+
+// ── #6193: the enumerated test-coverage row ─────────────────────────────────
+
+/// The five sampled dimensions render as "N file(s) examined"; test coverage
+/// does not, because its answer is a property of the repository rather than of
+/// what the budget let the LLM read. The row must SAY that, or a reader takes
+/// its count for a sixth sample.
+#[test]
+fn the_test_coverage_row_states_the_enumeration() {
+    let mut r = repo(InvestigationStatus::Available, vec![finding()], deps_none());
+    r.coverage.test_census = crate::report::investigate::TestCensus {
+        test_files: 412,
+        packages_total: 21,
+        packages_with_tests: 18,
+        packages_without_tests: vec!["crates/x".to_string()],
+    };
+    r.coverage.per_dimension = vec![crate::report::investigate::DimensionCoverage {
+        dimension: crate::report::investigate::select::TEST_DIMENSION.to_string(),
+        files_examined: 412,
+        example: Some(r.coverage.test_census.line()),
+    }];
+
+    let out = coverage_lines(&r, None);
+    assert!(out.contains("412 test file(s) enumerated"), "{out}");
+    assert!(out.contains("not sampled"), "{out}");
+    assert!(out.contains("18 of 21 package(s) carry tests"), "{out}");
+    assert!(
+        !out.contains("test coverage: 412 file(s) examined"),
+        "the row must not borrow the sampled shape: {out}"
+    );
+}
+
+// ── #6191: the collected reachability evidence ──────────────────────────────
+
+/// A guard whose evidence a reader cannot see is indistinguishable from the
+/// text-marker inference it replaced. The section states the counts and names
+/// every file the source placed beyond this host — the class that used to be
+/// withheld.
+#[test]
+fn coverage_section_states_the_exposure_evidence() {
+    use crate::report::investigate::{ExposureFact, ExposureKind};
+    let mut r = repo(InvestigationStatus::Available, vec![finding()], deps_none());
+    r.exposure = vec![
+        ExposureFact {
+            file: "src/daemon.rs".to_string(),
+            kind: ExposureKind::LoopbackBind,
+            evidence: "TcpListener::bind(\"127.0.0.1:7878\")".to_string(),
+        },
+        ExposureFact {
+            file: "src/telegram.rs".to_string(),
+            kind: ExposureKind::NetworkClient,
+            evidence: "https://api.telegram.org/bot".to_string(),
+        },
+    ];
+
+    let out = coverage_lines(&r, None);
+    assert!(out.contains("- reachability evidence: 2 file(s)"), "{out}");
+    assert!(out.contains("1 loopback bind"), "{out}");
+    assert!(out.contains("1 outbound network call"), "{out}");
+    assert!(
+        out.contains("beyond this host: src/telegram.rs"),
+        "the network-facing file must be named: {out}"
+    );
+    assert!(
+        !out.contains("beyond this host: src/daemon.rs"),
+        "a loopback bind is not beyond this host: {out}"
+    );
+}
+
+/// A repository whose examined files state nothing renders byte-identically to
+/// a pre-#6191 report.
+#[test]
+fn coverage_section_omits_the_exposure_line_without_evidence() {
+    let out = coverage_lines(
+        &repo(InvestigationStatus::Available, vec![finding()], deps_none()),
+        None,
+    );
+    assert!(!out.contains("reachability evidence"), "{out}");
 }

--- a/crates/trusty-review/src/report/investigate/select.rs
+++ b/crates/trusty-review/src/report/investigate/select.rs
@@ -151,6 +151,8 @@ pub struct Selection {
     pub dimensions_absent: Vec<String>,
     /// Per-dimension coverage of the examined set (#6082).
     pub per_dimension: Vec<DimensionCoverage>,
+    /// Test presence over the WHOLE tracked list, not the examined set (#6193).
+    pub test_census: super::test_census::TestCensus,
     /// Examined files the manifest itself named, with a reason (#6082). Zero
     /// means the ranking was path names and complexity alone — which is what
     /// the coverage section must SAY rather than imply.
@@ -197,6 +199,10 @@ pub const SECURITY_DIMENSION: &str = DIMENSIONS[0];
 /// cross-references (#6137) — that section has no data source of its own, but
 /// §5 does carry these findings and must be pointed at.
 pub const SCALABILITY_DIMENSION: &str = DIMENSIONS[4];
+
+/// The one dimension of [`DIMENSIONS`] whose figures are ENUMERATED rather than
+/// sampled (#6193). See [`super::test_census`].
+pub const TEST_DIMENSION: &str = DIMENSIONS[5];
 
 /// The DD dimensions a file matches by path/name heuristics (excluding tests,
 /// which are presence-only and handled separately).
@@ -273,8 +279,18 @@ pub fn dimensions_for(path: &str) -> Vec<String> {
 }
 
 /// True when a path looks like a test file/dir (presence-only coverage signal).
-fn is_test_path(path: &str) -> bool {
-    let p = path.to_ascii_lowercase();
+///
+/// Shared with [`super::test_census`] (#6193), which enumerates the same
+/// recognition over the whole tracked list so the dimension's counts stop moving
+/// with the byte budget. One predicate, so the coverage split and the census can
+/// never disagree about what a test file is.
+pub(super) fn is_test_path(path: &str) -> bool {
+    // The directory checks below all wanted a LEADING separator, so a repository
+    // whose tests live in a root `tests/` — the Cargo default — matched none of
+    // them: the tracked list is repo-relative, and `tests/api.rs` has no slash
+    // in front. Prefixing one makes the first segment a segment like any other
+    // (#6193).
+    let p = format!("/{}", path.to_ascii_lowercase());
     p.contains("/test/")
         || p.contains("/tests/")
         || p.contains("/__tests__/")
@@ -286,7 +302,7 @@ fn is_test_path(path: &str) -> bool {
         || p.ends_with(".spec.ts")
         || p.ends_with("_test.go")
         || p.ends_with("_test.py")
-        || p.starts_with("test_")
+        || p.contains("/test_")
 }
 
 /// True when the path has a recognised source-code extension (a relevance boost
@@ -623,8 +639,12 @@ pub fn select_files(
 
     let (dimensions_covered, dimensions_absent) = coverage_split(&selected, files);
     let skipped = total_files.saturating_sub(selected.len());
+    // #6193: enumerated over `files`, the whole tracked list — so it does not
+    // move when the budget does.
+    let test_census = super::test_census::census(files);
     Selection {
-        per_dimension: per_dimension(&selected, &dimensions_covered),
+        per_dimension: per_dimension(&selected, &dimensions_covered, &test_census),
+        test_census,
         attributed_files: selected.iter().filter(|f| f.selected_by.is_some()).count(),
         attributed_only: signals.attributed_only,
         files: selected,
@@ -651,12 +671,31 @@ pub fn select_files(
 /// 150-line function that carries it" are not the same claim. "test coverage"
 /// can be covered by an unexamined test directory, so a row with zero files and
 /// no example is a real state.
+///
+/// #6193: the `test coverage` row is the exception, and now the only one that
+/// is. Its `files_examined` is the census's enumerated test-file count and its
+/// `example` is the census line, because that dimension's answer is a property
+/// of the repository rather than of what the budget let the LLM read — two runs
+/// with different budgets used to report different test-coverage figures for an
+/// unchanged checkout.
 /// Test: `select_tests::{per_dimension_coverage_names_why_a_file_was_read,
-/// coverage_names_the_measured_function}`.
-fn per_dimension(selected: &[SelectedFile], covered: &[String]) -> Vec<DimensionCoverage> {
+/// coverage_names_the_measured_function,
+/// the_test_coverage_row_is_enumerated_not_sampled}`.
+fn per_dimension(
+    selected: &[SelectedFile],
+    covered: &[String],
+    census: &super::test_census::TestCensus,
+) -> Vec<DimensionCoverage> {
     covered
         .iter()
         .map(|dimension| {
+            if dimension == TEST_DIMENSION {
+                return DimensionCoverage {
+                    dimension: dimension.clone(),
+                    files_examined: census.test_files,
+                    example: Some(census.line()),
+                };
+            }
             let hits: Vec<&SelectedFile> = selected
                 .iter()
                 .filter(|f| f.dimensions.iter().any(|d| d == dimension))
@@ -757,7 +796,7 @@ fn coverage_split(selected: &[SelectedFile], all_files: &[PathBuf]) -> (Vec<Stri
     let mut covered = Vec::new();
     let mut absent = Vec::new();
     for &dim in DIMENSIONS {
-        let hit = if dim == "test coverage" {
+        let hit = if dim == TEST_DIMENSION {
             has_tests
         } else {
             selected

--- a/crates/trusty-review/src/report/investigate/select_tests.rs
+++ b/crates/trusty-review/src/report/investigate/select_tests.rs
@@ -751,3 +751,56 @@ fn a_declared_hotspot_reaches_the_selected_file_and_the_coverage_row() {
         .expect("an example");
     assert!(example.contains("hottest fn drain_queue"), "{example}");
 }
+
+/// #6193: the test-coverage row used to count EXAMINED files, so shrinking the
+/// budget shrank the dimension's figures for an unchanged repository. It is now
+/// enumerated over the whole tracked list, and a one-file budget proves it: the
+/// count survives a selection that reads almost nothing.
+#[test]
+fn the_test_coverage_row_is_enumerated_not_sampled() {
+    let tmp = fixture();
+    let files = list_tracked_files(tmp.path());
+
+    let full = select_files(
+        tmp.path(),
+        &files,
+        None,
+        Budget::default(),
+        RiskSignals::default(),
+    );
+    let starved = select_files(
+        tmp.path(),
+        &files,
+        None,
+        Budget {
+            max_files: 1,
+            max_bytes: 64,
+        },
+        RiskSignals::default(),
+    );
+
+    assert!(
+        starved.files.len() < full.files.len(),
+        "the budget must bite"
+    );
+    assert_eq!(
+        full.test_census, starved.test_census,
+        "the census must not move with the budget"
+    );
+    assert_eq!(full.test_census.test_files, 1, "{:?}", full.test_census);
+
+    let row = |sel: &Selection| {
+        sel.per_dimension
+            .iter()
+            .find(|d| d.dimension == super::TEST_DIMENSION)
+            .cloned()
+            .expect("a test-coverage row")
+    };
+    assert_eq!(row(&full).files_examined, row(&starved).files_examined);
+    assert!(
+        row(&full)
+            .example
+            .is_some_and(|e| e.contains("not sampled")),
+        "the row must state its own basis"
+    );
+}

--- a/crates/trusty-review/src/report/investigate/test_census.rs
+++ b/crates/trusty-review/src/report/investigate/test_census.rs
@@ -1,0 +1,194 @@
+//! Deterministic test-coverage enumeration over the tracked file list (#6193).
+//!
+//! Why: the "test coverage" row of the investigation coverage section counted
+//! EXAMINED files — the ones the byte budget let the LLM read. Two runs over an
+//! unchanged repository with a different budget therefore reported different
+//! test-coverage figures, and an external engagement user read the dimension as
+//! under-grounded because of it. Test presence is a repo-level fact: it is
+//! knowable from the tracked file list alone, at no I/O cost, and it does not
+//! move when the sample does.
+//!
+//! What: [`TestCensus`] counts test files and per-package test presence over the
+//! full tracked list; [`census`] computes it. The LLM still narrates the
+//! dimension — it no longer supplies its counts.
+//!
+//! Scope: presence, not adequacy. Nothing here reads a test file, counts
+//! assertions, or claims a coverage percentage; a package with one smoke test
+//! counts as carrying tests, and the row says exactly that.
+//!
+//! Test: `test_census_tests.rs`.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use serde::Serialize;
+
+/// The manifest filenames that mark a directory as a package root.
+///
+/// One entry per ecosystem the DD dimensions already name elsewhere. A
+/// repository with none of them has one implicit package — the repository — and
+/// the census says so rather than reporting zero packages.
+const PACKAGE_MANIFESTS: &[&str] = &[
+    "Cargo.toml",
+    "package.json",
+    "pyproject.toml",
+    "setup.py",
+    "go.mod",
+    "pom.xml",
+    "build.gradle",
+    "build.gradle.kts",
+    "Gemfile",
+    "composer.json",
+];
+
+/// How many package names the census names when they carry no tests.
+///
+/// A due-diligence reader needs the untested packages by name; a list of forty
+/// is noise in a bullet, so the row names the first few and states the rest as a
+/// count.
+const MAX_NAMED: usize = 5;
+
+/// One repository's test presence, enumerated rather than sampled (#6193).
+///
+/// Why: see the module doc. Every field is derived from the tracked file list,
+/// so two runs over an unchanged checkout produce identical values whatever the
+/// investigation budget was.
+/// What: `test_files` counts tracked paths that look like tests;
+/// `packages_total` counts the package roots found (at least 1);
+/// `packages_with_tests` counts those with at least one test path beneath them;
+/// `packages_without_tests` names the rest, in path order.
+/// Test: `test_census_tests::{counts_test_files_over_the_whole_tracked_list,
+/// attributes_a_test_to_its_nearest_package}`.
+#[derive(Debug, Clone, Default, Serialize, PartialEq, Eq)]
+pub struct TestCensus {
+    /// Tracked paths recognised as test files.
+    pub test_files: usize,
+    /// Package roots found, or 1 for a repository declaring no manifest.
+    pub packages_total: usize,
+    /// Package roots with at least one test path beneath them.
+    pub packages_with_tests: usize,
+    /// The package roots carrying no test path, in path order.
+    pub packages_without_tests: Vec<String>,
+}
+
+impl TestCensus {
+    /// The coverage-section line for the `test coverage` dimension.
+    ///
+    /// Why: the row must state its own basis. A reader who sees a count next to
+    /// five sampled-file counts will read it as a sixth sampled count unless the
+    /// line says otherwise.
+    /// What: the test-file total, the package split, and up to [`MAX_NAMED`]
+    /// untested package names with the remainder as a count.
+    /// Test: `test_census_tests::{the_line_states_the_enumeration_basis,
+    /// the_line_names_untested_packages}`.
+    pub fn line(&self) -> String {
+        let mut out = format!(
+            "{} test file(s) enumerated across the whole tracked list (not sampled); {} of {} \
+             package(s) carry tests",
+            self.test_files, self.packages_with_tests, self.packages_total,
+        );
+        if !self.packages_without_tests.is_empty() {
+            let named: Vec<&str> = self
+                .packages_without_tests
+                .iter()
+                .take(MAX_NAMED)
+                .map(String::as_str)
+                .collect();
+            out.push_str(&format!(" — without tests: {}", named.join(", ")));
+            let rest = self
+                .packages_without_tests
+                .len()
+                .saturating_sub(named.len());
+            if rest > 0 {
+                out.push_str(&format!(", and {rest} more"));
+            }
+        }
+        out
+    }
+}
+
+/// Enumerate `files` for test presence.
+///
+/// Why/What: see the module doc and [`TestCensus`]. Package roots come from
+/// [`PACKAGE_MANIFESTS`]; every other path is attributed to the deepest package
+/// root that is a prefix of it, so a test under `crates/a/tests/` counts for
+/// `crates/a` and not for the workspace root above it. A repository declaring no
+/// manifest is one package named `.`.
+/// Test: `test_census_tests::{counts_test_files_over_the_whole_tracked_list,
+/// attributes_a_test_to_its_nearest_package,
+/// a_repository_with_no_manifest_is_one_package}`.
+pub fn census(files: &[PathBuf]) -> TestCensus {
+    let paths: Vec<String> = files
+        .iter()
+        .map(|f| f.to_string_lossy().replace('\\', "/"))
+        .collect();
+
+    // Package roots: the directory holding a recognised manifest. `""` is the
+    // repository root, rendered as `.`.
+    let mut packages: BTreeMap<String, bool> = BTreeMap::new();
+    for p in &paths {
+        let base = p.rsplit('/').next().unwrap_or(p);
+        if PACKAGE_MANIFESTS.contains(&base) {
+            let dir = p
+                .rsplit_once('/')
+                .map_or(String::new(), |(d, _)| d.to_string());
+            packages.entry(dir).or_insert(false);
+        }
+    }
+    if packages.is_empty() {
+        packages.insert(String::new(), false);
+    }
+
+    let mut test_files = 0usize;
+    for p in &paths {
+        if !super::select::is_test_path(p) {
+            continue;
+        }
+        test_files += 1;
+        if let Some(owner) = owning_package(p, &packages) {
+            packages.insert(owner, true);
+        }
+    }
+
+    let packages_without_tests: Vec<String> = packages
+        .iter()
+        .filter(|(_, has)| !**has)
+        .map(|(dir, _)| display_package(dir))
+        .collect();
+    TestCensus {
+        packages_total: packages.len(),
+        packages_with_tests: packages.len() - packages_without_tests.len(),
+        packages_without_tests,
+        test_files,
+    }
+}
+
+/// The deepest package root that is a directory prefix of `path`.
+fn owning_package(path: &str, packages: &BTreeMap<String, bool>) -> Option<String> {
+    packages
+        .keys()
+        .filter(|dir| under(path, dir))
+        .max_by_key(|dir| dir.len())
+        .cloned()
+}
+
+/// True when `path` sits at or beneath the package directory `dir`.
+fn under(path: &str, dir: &str) -> bool {
+    if dir.is_empty() {
+        return true;
+    }
+    path.starts_with(dir) && path.as_bytes().get(dir.len()) == Some(&b'/')
+}
+
+/// The repository root renders as `.`; every other package as its own directory.
+fn display_package(dir: &str) -> String {
+    if dir.is_empty() {
+        ".".to_string()
+    } else {
+        dir.to_string()
+    }
+}
+
+#[cfg(test)]
+#[path = "test_census_tests.rs"]
+mod tests;

--- a/crates/trusty-review/src/report/investigate/test_census_tests.rs
+++ b/crates/trusty-review/src/report/investigate/test_census_tests.rs
@@ -1,0 +1,105 @@
+//! Tests for the deterministic test-coverage enumeration (#6193).
+
+use super::*;
+
+fn paths(list: &[&str]) -> Vec<PathBuf> {
+    list.iter().map(PathBuf::from).collect()
+}
+
+/// The count is over the WHOLE tracked list, not a sample of it — which is the
+/// property that makes it reproducible across runs with different budgets.
+#[test]
+fn counts_test_files_over_the_whole_tracked_list() {
+    let c = census(&paths(&[
+        "Cargo.toml",
+        "src/lib.rs",
+        "src/main.rs",
+        "tests/api.rs",
+        "tests/cli.rs",
+        "src/thing_tests.rs",
+    ]));
+    assert_eq!(c.test_files, 3);
+    assert_eq!(c.packages_total, 1);
+    assert_eq!(c.packages_with_tests, 1);
+    assert!(c.packages_without_tests.is_empty());
+}
+
+/// A test under a nested package counts for that package, not for the workspace
+/// root above it — otherwise one tested crate would report the whole workspace
+/// as tested.
+#[test]
+fn attributes_a_test_to_its_nearest_package() {
+    let c = census(&paths(&[
+        "Cargo.toml",
+        "crates/a/Cargo.toml",
+        "crates/a/src/lib.rs",
+        "crates/a/tests/it.rs",
+        "crates/b/Cargo.toml",
+        "crates/b/src/lib.rs",
+    ]));
+    assert_eq!(c.packages_total, 3, "{c:?}");
+    assert_eq!(c.packages_with_tests, 1, "{c:?}");
+    assert_eq!(c.packages_without_tests, vec![".", "crates/b"]);
+}
+
+/// A repository declaring no manifest is one package, named `.` — never zero
+/// packages, which would render as "0 of 0 carry tests".
+#[test]
+fn a_repository_with_no_manifest_is_one_package() {
+    let c = census(&paths(&["README.md", "main.py"]));
+    assert_eq!(c.packages_total, 1);
+    assert_eq!(c.packages_with_tests, 0);
+    assert_eq!(c.packages_without_tests, vec!["."]);
+    assert_eq!(c.test_files, 0);
+}
+
+/// Non-Cargo ecosystems are package roots too.
+#[test]
+fn other_ecosystems_declare_packages() {
+    let c = census(&paths(&[
+        "web/package.json",
+        "web/src/index.ts",
+        "web/src/index.test.ts",
+        "api/pyproject.toml",
+        "api/app.py",
+    ]));
+    assert_eq!(c.packages_total, 2, "{c:?}");
+    assert_eq!(c.packages_with_tests, 1, "{c:?}");
+    assert_eq!(c.packages_without_tests, vec!["api"]);
+}
+
+/// The row must say it was enumerated. A bare count next to five sampled counts
+/// reads as a sixth sampled count.
+#[test]
+fn the_line_states_the_enumeration_basis() {
+    let c = census(&paths(&["Cargo.toml", "src/lib.rs", "tests/it.rs"]));
+    let line = c.line();
+    assert!(line.contains("1 test file(s) enumerated"), "{line}");
+    assert!(line.contains("not sampled"), "{line}");
+    assert!(line.contains("1 of 1 package(s) carry tests"), "{line}");
+}
+
+/// Untested packages are named, and a long list states the remainder as a count
+/// rather than filling the bullet.
+#[test]
+fn the_line_names_untested_packages() {
+    let mut list = vec!["Cargo.toml".to_string()];
+    for i in 0..8 {
+        list.push(format!("crates/p{i}/Cargo.toml"));
+        list.push(format!("crates/p{i}/src/lib.rs"));
+    }
+    let refs: Vec<&str> = list.iter().map(String::as_str).collect();
+    let c = census(&paths(&refs));
+    let line = c.line();
+    assert!(line.contains("without tests:"), "{line}");
+    assert!(line.contains("crates/p0"), "{line}");
+    assert!(line.contains("and 4 more"), "{line}");
+}
+
+/// Two runs over the same list agree exactly — the reproducibility the issue's
+/// closure condition names.
+#[test]
+fn the_census_is_reproducible() {
+    let files = paths(&["Cargo.toml", "src/lib.rs", "tests/a.rs", "tests/b.rs"]);
+    assert_eq!(census(&files), census(&files));
+}

--- a/crates/trusty-review/src/report/investigate/verdict_tests.rs
+++ b/crates/trusty-review/src/report/investigate/verdict_tests.rs
@@ -561,6 +561,7 @@ fn repo_with(verdicts: Option<VerdictSet>) -> super::super::RepoInvestigation {
         coverage: super::super::Coverage::default(),
         traces: None,
         verdicts,
+        exposure: Vec::new(),
     }
 }
 

--- a/crates/trusty-review/src/report/investigate/verify_tests.rs
+++ b/crates/trusty-review/src/report/investigate/verify_tests.rs
@@ -27,6 +27,7 @@ fn selection(path: &str, content: &str) -> Selection {
         dimensions_covered: vec![],
         dimensions_absent: vec![],
         per_dimension: vec![],
+        test_census: Default::default(),
         attributed_files: 0,
         attributed_only: false,
     }

--- a/crates/trusty-review/src/report/mod.rs
+++ b/crates/trusty-review/src/report/mod.rs
@@ -64,6 +64,7 @@ pub mod synthesize_guard;
 // claims. Used only by `synthesize` and `synthesize_prompt`.
 pub(crate) mod synthesize_grounding;
 mod synthesize_grounding_text;
+mod synthesize_grounding_vocab;
 mod synthesize_guardrail;
 // #6009 shape 3: whitelist-based synonym normalization, used only by
 // `synthesize::parse_raw` — not part of the public report API.

--- a/crates/trusty-review/src/report/redact_tests.rs
+++ b/crates/trusty-review/src/report/redact_tests.rs
@@ -280,6 +280,7 @@ fn leaky_investigation(slug: &str) -> Investigation {
                 dimensions_covered: vec![format!("secrets {FAKE_TOKEN}")],
                 ..Default::default()
             },
+            exposure: Vec::new(),
         }],
     }
 }

--- a/crates/trusty-review/src/report/synthesize_digest_tests.rs
+++ b/crates/trusty-review/src/report/synthesize_digest_tests.rs
@@ -161,6 +161,7 @@ fn enriches_from_investigation() {
             deps: Default::default(),
             traces: None,
             coverage: coverage(),
+            exposure: Vec::new(),
         }],
     };
     let model = model_with(
@@ -262,6 +263,7 @@ fn elaboration_targets_exclude_verified_and_cap_at_10() {
             deps: Default::default(),
             traces: None,
             coverage: coverage(),
+            exposure: Vec::new(),
         }],
     };
     let model = model_with(vec![repo("a", metric_findings)], Some(inv));
@@ -346,6 +348,7 @@ fn renders_elaboration_targets_or_none() {
             deps: Default::default(),
             traces: None,
             coverage: coverage(),
+            exposure: Vec::new(),
         }],
     };
     let model = model_with(

--- a/crates/trusty-review/src/report/synthesize_grounding.rs
+++ b/crates/trusty-review/src/report/synthesize_grounding.rs
@@ -93,175 +93,24 @@
 
 use std::collections::BTreeSet;
 
+use super::investigate::ExposureIndex;
 use super::model::ReportModel;
 use super::synthesize_grounding_text::{
     asserts_reachability, asserts_reachability_claim, contains_name, grammar_debris,
     remove_sentence, rewrite_reachability, sentences, subject_tokens,
 };
+use super::synthesize_grounding_vocab::{
+    CLEAN_SIGNAL_NEGATIONS, CLEAN_SIGNAL_WORDS, LOAD_BEARING_PHRASES, LOOPBACK_MARKERS,
+    REMOTE_MARKERS,
+};
 use super::topology::CrateTopology;
 
-/// Text markers that scope a finding to a loopback-only surface.
-///
-/// Deliberately short and literal. A finding whose own remediation or evidence
-/// says "localhost" is stating its reachability; inferring one from softer
-/// words would make the check fire on findings it was never about.
-///
-/// #6082 lap 6: the socket spellings state the same fact without the word
-/// localhost. The graded report's RED finding 2 shipped "a remote code execution
-/// risk" because its remediation proposed "token or local-socket verification"
-/// and none of the four original markers matched — the finding never entered
-/// [`Grounding::local_only`], so the sentence had no owner and the check never
-/// ran on it. A remediation that proposes verifying the peer over a local socket
-/// is stating that the peer is on this host, which is a reachability statement
-/// as literal as "localhost".
-const LOOPBACK_MARKERS: &[&str] = &[
-    "localhost",
-    "loopback",
-    "127.0.0.1",
-    "::1",
-    "local-socket",
-    "local socket",
-    "unix socket",
-    "unix-socket",
-    "unix domain socket",
-    "unix-domain socket",
-];
-
-/// Text markers that scope a finding to a network-reachable surface.
-///
-/// A finding carrying one of these vetoes the contradiction check for every
-/// subject token it shares, so a genuinely remote endpoint in the same
-/// repository can still be described as remote.
-const REMOTE_MARKERS: &[&str] = &[
-    "0.0.0.0",
-    "internet-facing",
-    "publicly reachable",
-    "publicly accessible",
-    "all interfaces",
-];
-
-/// Phrases that assert reachability beyond the host, with the host-local form
-/// each is rewritten to.
-///
-/// Longest first: `remote-code-execution` must be matched before a bare
-/// `remote`, and every plural before its singular, or the rewrite would leave a
-/// broken fragment behind (`remote attackers` → `any local processs`).
-///
-/// This table is a CONVENIENCE, not the gate. [`REACHABILITY_WORDS`] decides
-/// what gets checked and what may ship; a claim this table cannot rewrite is
-/// rejected rather than passed through.
-pub(super) const REACHABILITY_REWRITES: &[(&str, &str)] = &[
-    // #6082 lap 5: the hedged form. RED finding 3's business impact read
-    // "enabling remote/local code execution" — no pattern below matches it,
-    // because the `/local` sits between the two words every other pattern
-    // expects to be adjacent, so the sentence never even triggered the check.
-    (
-        "remote/local code execution",
-        "local-process-reachable code execution",
-    ),
-    (
-        "remote/local code-execution",
-        "local-process-reachable code-execution",
-    ),
-    ("remote/local", "local-process-reachable"),
-    (
-        "unauthenticated remote-code-execution",
-        "unauthenticated local-process-reachable code-execution",
-    ),
-    (
-        "unauthenticated remote code execution",
-        "unauthenticated local-process-reachable code execution",
-    ),
-    (
-        "remote-code-execution",
-        "local-process-reachable code-execution",
-    ),
-    (
-        "remote code execution",
-        "local-process-reachable code execution",
-    ),
-    (
-        "remote code-execution",
-        "local-process-reachable code-execution",
-    ),
-    ("remotely exploitable", "exploitable by any local process"),
-    ("remote attackers", "any local process"),
-    ("remote attacker", "any local process"),
-    ("remote control over", "control over"),
-    ("remote unauthenticated", "unauthenticated local-process"),
-    // #6082 lap 7: the network family. RED finding 2's business impact shipped
-    // "An unauthenticated actor on the network or host can launch arbitrary
-    // claude commands" — a reachability claim carrying no `remote` token, so
-    // the pattern table above never matched it and the check never ran.
-    ("on the network or on the host", "on the host"),
-    ("on the network or host", "on the host"),
-    ("over the network", "on the host"),
-    ("across the network", "on the host"),
-    ("from the network", "from any process on the host"),
-    ("network-reachable", "reachable by any process on the host"),
-    ("network reachable", "reachable by any process on the host"),
-    ("network attackers", "any local process"),
-    ("network attacker", "any local process"),
-    ("unauthenticated network", "unauthenticated local-process"),
-    ("network-facing", "host-local"),
-    ("on the network", "on the host"),
-];
-
-/// Every word that asserts reachability beyond this host.
-///
-/// This list is the guardrail, and [`REACHABILITY_REWRITES`] only softens it.
-/// A sentence about a local-only finding is CHECKED when it carries one of these
-/// words, and may SHIP only when none survives the rewrite pass — so a spelling
-/// this module has never seen is rejected and disclosed rather than passed
-/// through unexamined.
-///
-/// #6082 lap 7 replaced a phrase blocklist with this vocabulary. Three laps in a
-/// row shipped the same defect in a new spelling (`RCE`, then `remote/local`,
-/// then `on the network`), each time because the trigger was a list of known
-/// phrases: an unrecognised phrase was not corrected AND not checked. Keying
-/// both halves off one word list inverts that — an unrecognised phrase is now
-/// the case that fails closed.
-///
-/// The cost is real and deliberate: a sentence about a local-only finding that
-/// mentions a network for an unrelated reason ("network I/O", "network calls to
-/// the embedder") is rejected too, and its field falls back to the honesty
-/// marker with a note in Synthesis Status. A due-diligence report claiming
-/// network reach for a loopback-bound daemon is the worse of the two errors.
-pub(super) const REACHABILITY_WORDS: &[&str] = &["remote", "network", "internet"];
-
-/// The two words every "this dimension has no clean signal" sentence is built
-/// around (#6082 lap 7).
-///
-/// Two words rather than one phrase, because the model puts the dimension
-/// between them — the graded report wrote "No clean security signal is credited
-/// here", and a literal `clean signal` match misses that. Paired with
-/// [`CLEAN_SIGNAL_NEGATIONS`], which is what turns the noun phrase into a claim
-/// of absence.
-const CLEAN_SIGNAL_WORDS: (&str, &str) = ("clean", "signal");
-
-/// The negations that turn [`CLEAN_SIGNAL_WORDS`] into a claim of absence.
-const CLEAN_SIGNAL_NEGATIONS: &[&str] = &[
-    "no ", "not ", "none", "nothing", "never", "n't", "zero ", "absent", "without",
-];
-
-/// Phrases that claim a crate is what the rest of the estate is built on.
-const LOAD_BEARING_PHRASES: &[&str] = &[
-    "load-bearing",
-    "load bearing",
-    "most depended",
-    "most-depended",
-    "depended on by the rest",
-];
-
-/// Path and title words too generic to identify a finding's subject.
-pub(super) const GENERIC_TOKENS: &[&str] = &[
-    "crates", "src", "main", "lib", "mod", "test", "tests", "with", "this", "that", "from", "into",
-    "have", "http", "https", "file", "line", "code", "data", "self", "type", "used", "when",
-    "over", "path", "call", "rust",
-];
-
-/// Shortest path/title word admitted as a subject token.
-pub(super) const MIN_TOKEN_LEN: usize = 4;
+// The four tables `synthesize_grounding_text` reads keep their existing path
+// through this module, so the split that moved them (#6191, SLOC cap) changed no
+// import anywhere else.
+pub(super) use super::synthesize_grounding_vocab::{
+    GENERIC_TOKENS, MIN_TOKEN_LEN, REACHABILITY_REWRITES, REACHABILITY_WORDS,
+};
 
 /// One finding the report's own data scopes to a loopback-only surface.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -436,7 +285,14 @@ impl Grounding {
         // `apply_investigation`, so after that pass both loops see the same
         // signals. The larger count is the real one either way.
         out.clean_signals = from_metrics.max(from_inv);
-        out.classify(staged);
+        // #6191: the investigation's collected bind/exposure facts decide a
+        // file's tier before any text marker gets a vote.
+        let evidence = ExposureIndex::from_facts(
+            inv.into_iter()
+                .flat_map(|i| i.repos.iter())
+                .flat_map(|r| r.exposure.iter()),
+        );
+        out.classify(staged, &evidence);
         for topology in model
             .repositories
             .iter()
@@ -457,12 +313,29 @@ impl Grounding {
     /// file as [`LocalOnly`] — including the ones whose own text said nothing.
     /// A finding with no component is classified by its own text alone, as
     /// before: there is no file to share the classification with.
+    ///
+    /// #6191: `evidence` is the collection-side answer, read from the files'
+    /// own source, and it settles a file's tier OUTRIGHT — a measured bind
+    /// address is a fact about the surface, and a marker in some finding's prose
+    /// is a guess about it. Only a file the collector said nothing about falls
+    /// through to the marker walk below, which is what leaves an
+    /// evidence-free run byte-identical to the pre-#6191 one.
     /// Test: `synthesize_grounding_tests.rs::{a_sibling_finding_inherits_its_files_loopback_scope,
-    /// a_remote_finding_on_the_file_wins_over_a_loopback_sibling}`.
-    fn classify(&mut self, staged: Vec<Staged>) {
+    /// a_remote_finding_on_the_file_wins_over_a_loopback_sibling,
+    /// collected_bind_evidence_outranks_a_text_marker,
+    /// a_collected_outbound_call_establishes_reach_a_marker_never_stated}`.
+    fn classify(&mut self, staged: Vec<Staged>, evidence: &ExposureIndex) {
         let mut local_files = BTreeSet::new();
         for s in &staged {
             if s.component.is_empty() {
+                continue;
+            }
+            if let Some(kind) = evidence.kind(&s.component) {
+                if kind.is_beyond_host() {
+                    self.remote_components.insert(s.component.clone());
+                } else {
+                    local_files.insert(s.component.clone());
+                }
                 continue;
             }
             if s.remote {

--- a/crates/trusty-review/src/report/synthesize_grounding_tests.rs
+++ b/crates/trusty-review/src/report/synthesize_grounding_tests.rs
@@ -421,6 +421,7 @@ fn control_routes_investigation() -> Investigation {
             coverage: Default::default(),
             traces: None,
             verdicts: None,
+            exposure: Vec::new(),
         }],
     }
 }
@@ -1117,4 +1118,60 @@ fn subjectless_prose_keeps_the_finding_the_token_match_named() {
         "{reason}"
     );
     assert!(subject.is_some());
+}
+
+// ── #6191: collected bind/exposure evidence ─────────────────────────────────
+
+/// A measured bind address beats a marker in someone's prose. The finding's own
+/// remediation proposes local-socket verification — the tier-1 marker #6082
+/// lap 6 added — but the file's source binds every interface, so the file is
+/// remote-established and its reach claims may ship.
+#[test]
+fn collected_bind_evidence_outranks_a_text_marker() {
+    use crate::report::investigate::{ExposureFact, ExposureKind};
+    let mut model = model_with(vec![repo("estate", vec![], None)]);
+    let mut inv = control_routes_investigation();
+    inv.repos[0].exposure = vec![ExposureFact {
+        file: "crates/trusty-mpm/src/daemon/api/control_routes.rs".to_string(),
+        kind: ExposureKind::PublicBind,
+        evidence: "TcpListener::bind(\"0.0.0.0:8080\")".to_string(),
+    }];
+    model.investigation = Some(inv);
+
+    let g = Grounding::from_model(&model);
+    assert!(
+        g.local_only.is_empty(),
+        "a measured public bind must not be classified host-local: {:?}",
+        g.local_only
+    );
+}
+
+/// The Telegram-gateway shape. Nothing in the finding text says `0.0.0.0` or
+/// `internet-facing`, so before #6191 the file was UNESTABLISHED and every true
+/// reach claim about it was withheld. An outbound call collected from source is
+/// evidence the file is not host-local.
+#[test]
+fn a_collected_outbound_call_establishes_reach_a_marker_never_stated() {
+    use crate::report::investigate::{ExposureFact, ExposureKind};
+    let mut model = model_with(vec![repo("estate", vec![], None)]);
+    let mut inv = control_routes_investigation();
+    inv.repos[0].exposure = vec![ExposureFact {
+        file: "crates/trusty-mpm/src/daemon/api/control_routes.rs".to_string(),
+        kind: ExposureKind::NetworkClient,
+        evidence: "https://api.telegram.org/bot".to_string(),
+    }];
+    model.investigation = Some(inv);
+
+    let g = Grounding::from_model(&model);
+    assert!(g.local_only.is_empty(), "{:?}", g.local_only);
+}
+
+/// The silent half: with no collected fact the file falls through to the marker
+/// walk, so an evidence-free run classifies exactly as it did before #6191.
+#[test]
+fn no_collected_evidence_leaves_the_marker_path_in_place() {
+    let mut model = model_with(vec![repo("estate", vec![], None)]);
+    model.investigation = Some(control_routes_investigation());
+    let g = Grounding::from_model(&model);
+    assert_eq!(g.local_only.len(), 1, "{:?}", g.local_only);
 }

--- a/crates/trusty-review/src/report/synthesize_grounding_vocab.rs
+++ b/crates/trusty-review/src/report/synthesize_grounding_vocab.rs
@@ -1,0 +1,180 @@
+//! The word and phrase tables the grounding guardrail matches against.
+//!
+//! Why: split out of `synthesize_grounding.rs` when #6191 gave that file a
+//! collection-side evidence source and pushed it to 514 SLOC, over the 500
+//! production cap. This is the natural seam — everything here is DATA the guard
+//! reads, with no logic and no dependency on the guard's own types, and the two
+//! consumers (`synthesize_grounding` and `synthesize_grounding_text`) already
+//! imported it as a table rather than calling into it.
+//!
+//! What: the loopback and remote markers, the reachability rewrite table and the
+//! vocabulary that gates it, the clean-signal words, the load-bearing phrases,
+//! and the subject-token filters. Every entry keeps the issue history that put
+//! it there.
+//!
+//! Test: exercised through both consumers — `synthesize_grounding_tests.rs`.
+//!
+//! [`Grounding::local_only`]: super::synthesize_grounding::Grounding
+
+/// Text markers that scope a finding to a loopback-only surface.
+///
+/// Deliberately short and literal. A finding whose own remediation or evidence
+/// says "localhost" is stating its reachability; inferring one from softer
+/// words would make the check fire on findings it was never about.
+///
+/// #6082 lap 6: the socket spellings state the same fact without the word
+/// localhost. The graded report's RED finding 2 shipped "a remote code execution
+/// risk" because its remediation proposed "token or local-socket verification"
+/// and none of the four original markers matched — the finding never entered
+/// [`Grounding::local_only`], so the sentence had no owner and the check never
+/// ran on it. A remediation that proposes verifying the peer over a local socket
+/// is stating that the peer is on this host, which is a reachability statement
+/// as literal as "localhost".
+pub(super) const LOOPBACK_MARKERS: &[&str] = &[
+    "localhost",
+    "loopback",
+    "127.0.0.1",
+    "::1",
+    "local-socket",
+    "local socket",
+    "unix socket",
+    "unix-socket",
+    "unix domain socket",
+    "unix-domain socket",
+];
+
+/// Text markers that scope a finding to a network-reachable surface.
+///
+/// A finding carrying one of these vetoes the contradiction check for every
+/// subject token it shares, so a genuinely remote endpoint in the same
+/// repository can still be described as remote.
+pub(super) const REMOTE_MARKERS: &[&str] = &[
+    "0.0.0.0",
+    "internet-facing",
+    "publicly reachable",
+    "publicly accessible",
+    "all interfaces",
+];
+
+/// Phrases that assert reachability beyond the host, with the host-local form
+/// each is rewritten to.
+///
+/// Longest first: `remote-code-execution` must be matched before a bare
+/// `remote`, and every plural before its singular, or the rewrite would leave a
+/// broken fragment behind (`remote attackers` → `any local processs`).
+///
+/// This table is a CONVENIENCE, not the gate. [`REACHABILITY_WORDS`] decides
+/// what gets checked and what may ship; a claim this table cannot rewrite is
+/// rejected rather than passed through.
+pub(super) const REACHABILITY_REWRITES: &[(&str, &str)] = &[
+    // #6082 lap 5: the hedged form. RED finding 3's business impact read
+    // "enabling remote/local code execution" — no pattern below matches it,
+    // because the `/local` sits between the two words every other pattern
+    // expects to be adjacent, so the sentence never even triggered the check.
+    (
+        "remote/local code execution",
+        "local-process-reachable code execution",
+    ),
+    (
+        "remote/local code-execution",
+        "local-process-reachable code-execution",
+    ),
+    ("remote/local", "local-process-reachable"),
+    (
+        "unauthenticated remote-code-execution",
+        "unauthenticated local-process-reachable code-execution",
+    ),
+    (
+        "unauthenticated remote code execution",
+        "unauthenticated local-process-reachable code execution",
+    ),
+    (
+        "remote-code-execution",
+        "local-process-reachable code-execution",
+    ),
+    (
+        "remote code execution",
+        "local-process-reachable code execution",
+    ),
+    (
+        "remote code-execution",
+        "local-process-reachable code-execution",
+    ),
+    ("remotely exploitable", "exploitable by any local process"),
+    ("remote attackers", "any local process"),
+    ("remote attacker", "any local process"),
+    ("remote control over", "control over"),
+    ("remote unauthenticated", "unauthenticated local-process"),
+    // #6082 lap 7: the network family. RED finding 2's business impact shipped
+    // "An unauthenticated actor on the network or host can launch arbitrary
+    // claude commands" — a reachability claim carrying no `remote` token, so
+    // the pattern table above never matched it and the check never ran.
+    ("on the network or on the host", "on the host"),
+    ("on the network or host", "on the host"),
+    ("over the network", "on the host"),
+    ("across the network", "on the host"),
+    ("from the network", "from any process on the host"),
+    ("network-reachable", "reachable by any process on the host"),
+    ("network reachable", "reachable by any process on the host"),
+    ("network attackers", "any local process"),
+    ("network attacker", "any local process"),
+    ("unauthenticated network", "unauthenticated local-process"),
+    ("network-facing", "host-local"),
+    ("on the network", "on the host"),
+];
+
+/// Every word that asserts reachability beyond this host.
+///
+/// This list is the guardrail, and [`REACHABILITY_REWRITES`] only softens it.
+/// A sentence about a local-only finding is CHECKED when it carries one of these
+/// words, and may SHIP only when none survives the rewrite pass — so a spelling
+/// this module has never seen is rejected and disclosed rather than passed
+/// through unexamined.
+///
+/// #6082 lap 7 replaced a phrase blocklist with this vocabulary. Three laps in a
+/// row shipped the same defect in a new spelling (`RCE`, then `remote/local`,
+/// then `on the network`), each time because the trigger was a list of known
+/// phrases: an unrecognised phrase was not corrected AND not checked. Keying
+/// both halves off one word list inverts that — an unrecognised phrase is now
+/// the case that fails closed.
+///
+/// The cost is real and deliberate: a sentence about a local-only finding that
+/// mentions a network for an unrelated reason ("network I/O", "network calls to
+/// the embedder") is rejected too, and its field falls back to the honesty
+/// marker with a note in Synthesis Status. A due-diligence report claiming
+/// network reach for a loopback-bound daemon is the worse of the two errors.
+pub(super) const REACHABILITY_WORDS: &[&str] = &["remote", "network", "internet"];
+
+/// The two words every "this dimension has no clean signal" sentence is built
+/// around (#6082 lap 7).
+///
+/// Two words rather than one phrase, because the model puts the dimension
+/// between them — the graded report wrote "No clean security signal is credited
+/// here", and a literal `clean signal` match misses that. Paired with
+/// [`CLEAN_SIGNAL_NEGATIONS`], which is what turns the noun phrase into a claim
+/// of absence.
+pub(super) const CLEAN_SIGNAL_WORDS: (&str, &str) = ("clean", "signal");
+
+/// The negations that turn [`CLEAN_SIGNAL_WORDS`] into a claim of absence.
+pub(super) const CLEAN_SIGNAL_NEGATIONS: &[&str] = &[
+    "no ", "not ", "none", "nothing", "never", "n't", "zero ", "absent", "without",
+];
+
+/// Phrases that claim a crate is what the rest of the estate is built on.
+pub(super) const LOAD_BEARING_PHRASES: &[&str] = &[
+    "load-bearing",
+    "load bearing",
+    "most depended",
+    "most-depended",
+    "depended on by the rest",
+];
+
+/// Path and title words too generic to identify a finding's subject.
+pub(super) const GENERIC_TOKENS: &[&str] = &[
+    "crates", "src", "main", "lib", "mod", "test", "tests", "with", "this", "that", "from", "into",
+    "have", "http", "https", "file", "line", "code", "data", "self", "type", "used", "when",
+    "over", "path", "call", "rust",
+];
+
+/// Shortest path/title word admitted as a subject token.
+pub(super) const MIN_TOKEN_LEN: usize = 4;

--- a/crates/trusty-review/src/report/synthesize_tests.rs
+++ b/crates/trusty-review/src/report/synthesize_tests.rs
@@ -2803,6 +2803,7 @@ fn control_routes_investigation() -> crate::report::investigate::Investigation {
             coverage: Default::default(),
             traces: None,
             verdicts: None,
+            exposure: Vec::new(),
         }],
     }
 }


### PR DESCRIPTION
Refs #6193, Refs #6191.

## Why these two share a PR

One outcome: the investigation record carries deterministic evidence for the two
dimensions that were inferring it. Both add a collector, both hang the result on
`Selection` / `Coverage` / `RepoInvestigation`, and both add a line to the same
coverage renderer. Splitting them would put two PRs through the same three
structs and one of them would rebase on the other.

## #6193 — the test-coverage dimension is enumerated

`test_census::census` walks the whole tracked file list and counts test files
plus per-package test presence. Package roots come from ten manifest filenames;
a test is attributed to the deepest package root above it, so one tested crate
does not mark a workspace tested. The `test coverage` row now carries that count
and states its basis, so a reader cannot read it as a sixth sampled count.

`the_test_coverage_row_is_enumerated_not_sampled` is the proof: it runs the same
fixture at the default budget and at `max_files: 1, max_bytes: 64`, and asserts
the census is byte-identical across the two while the examined set shrinks.

Scope: presence, not adequacy. Nothing reads a test file or claims a percentage.

## #6191 — reachability has a collection-side evidence source

`exposure::collect` reads the bytes selection already captured — no second pass
over the tree — for bind literals and outbound absolute URLs, and returns one
fact per file it can classify. Precedence within a file: a public bind beats a
loopback bind, and either beats an outbound call, because a file that binds
loopback and also calls an API is a loopback-listening surface.

`Grounding::classify` consults `ExposureIndex` **before** its text markers. A
file the collector said nothing about still falls through to the marker walk —
`no_collected_evidence_leaves_the_marker_path_in_place` pins that, so an
evidence-free run classifies exactly as it did before.

The collector is deliberately literal. A bind site with no address literal is
not evidence (the address came from config); an address in a comment with no
bind marker is not evidence. Guessing is what the issue exists to stop.

Bound: only files the investigation actually read carry facts. That is the byte
budget the coverage section already states, and the new line names the collected
count so the bound is visible.

## Two things carried along

- `is_test_path` matched no repository-root `tests/` directory: the tracked list
  is repo-relative and every directory check wanted a leading separator, so a
  Cargo crate with a root `tests/` reported no test coverage. The census
  surfaced it; leaving it would have made the census wrong on this repo.
- `synthesize_grounding.rs` reached 514 SLOC with the #6191 change. Its word and
  phrase tables moved to `synthesize_grounding_vocab.rs`; both consumers keep
  their existing import paths.

## Rung and gates

Rung 3 — localized behavior inside `trusty-review`. No other crate reads these
types.

```
cargo fmt --check                                           EXIT=0
cargo clippy -p trusty-review --all-targets -- -D warnings  EXIT=0
cargo test -p trusty-review                                 EXIT=0
                                                            lib: 2025 passed; 0 failed; 5 ignored
                                                            + 10 integration binaries, all ok
bash scripts/check_test_pointers.sh   26749 citations, 0 dangling — OK
bash scripts/check_line_cap.sh        4181 files, 0 violations — OK
```

New coverage: 9 tests in `exposure_tests.rs`, 7 in `test_census_tests.rs`, 3 in
`render_tests.rs`, 1 in `select_tests.rs`, 3 in `synthesize_grounding_tests.rs`.

## Version gate

The wave's `trusty-review` bump to 0.26.0 lands in #6251. This branch predates
it; it will ride the landed bump via `update-branch`.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
