### PR TITLE
docs: the re-tag recovery recipe cannot execute — tags here are immutable (Refs #6178)

### DIFF
--- a/.claude/skills/cargo-publish/SKILL.md
+++ b/.claude/skills/cargo-publish/SKILL.md
@@ -134,9 +134,21 @@ version instead). Runs six checks and fails loud on any of them:
    1. On 2026-08-11 that shipped `tga-v2.17.0` tagged at `246e4ca2` while the
    published `.cargo_vcs_info.json` recorded `7d5cf82e1`, with every gate green.
 
-   🔴 **If you fast-forward this checkout after tagging, re-tag before
-   publishing.** `git tag -f <tag> <new-head> && git push --force origin <tag>`.
+   🔴 **If you fast-forward this checkout after tagging, reset back onto the
+   tag before publishing.** `git reset --hard <tag>`, then re-run preflight.
    The gate prints that command with the SHAs filled in.
+
+   🔴 **Never reach for `git tag -f` or `git tag -d` here — tags on this repo
+   are immutable (#6178).** An enforcing ruleset rejects both a force-update
+   and a delete with `GH013`, `admin: true` does not lift it, and the ruleset
+   is invisible to the GitHub API, so you find out when the push fails. Move
+   the checkout onto the tag; never the tag onto the checkout.
+
+   If the tagged commit can never pass the publish gate, that version number is
+   **burned** — bump to the next version and tag fresh. Proven 2026-08-22:
+   `trusty-search-v0.49.0` and `trusty-review-v0.24.0` are permanently stranded
+   at `4af0ef8ee`, and the release shipped as `0.49.1` / `0.24.1`. Tag as late
+   as possible, immediately before `cargo publish`, so nothing can strand.
 
    After `cargo publish`, verify what cargo recorded rather than what it should
    have recorded — the only check that still works post-upload:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -462,9 +462,24 @@ whether HEAD EQUALS `origin/main`, so a tag several commits behind HEAD passes
 both. That is where a release lands whenever `main` moves and the run is
 fast-forwarded to satisfy CHECK 1 — which shipped `tga-v2.17.0` tagged at
 `246e4ca2` against a published `.cargo_vcs_info.json` of `7d5cf82e1` on
-2026-08-11, all gates green. **Fast-forwarded after tagging? Re-tag before
-publishing.** After `cargo publish`, run `make publish-verify CRATE=<crate>`.
+2026-08-11, all gates green. **Fast-forwarded after tagging? Reset the checkout
+back to the tagged commit and publish that** — `git reset --hard <tag>`. After
+`cargo publish`, run `make publish-verify CRATE=<crate>`.
 See [release-workflow.md](docs/reference/release-workflow.md#tagpublish-commit-parity-guard).
+
+🔴 **Release tags here are immutable — a stranded tag burns its version number
+(#6178).** An enforcing ruleset rejects both a force-update and a delete of a
+`*-v*` tag with GH013, and `admin: true` on the account does not lift it. The
+ruleset is invisible to the GitHub API, so nothing warns you before the push
+fails. Any recipe that says re-tag, move the tag, or delete and re-push cannot
+execute on this repo — reset the checkout to the tag instead of moving the tag
+to the checkout.
+
+When the tagged commit can never pass the publish gate, that version number is
+spent: **bump to the next version and tag fresh.** Proven 2026-08-22 —
+`trusty-search-v0.49.0` and `trusty-review-v0.24.0` are permanently stranded at
+`4af0ef8ee`, and the release shipped as `0.49.1` / `0.24.1` instead. Tag as late
+as you can, immediately before `cargo publish`, so there is nothing to strand.
 
 🔴 **CRITICAL macOS note:** never use `cp` to install a release binary on
 macOS — always `cargo install`. A plain `cp` over an on-PATH binary leaves a

--- a/docs/reference/release-workflow.md
+++ b/docs/reference/release-workflow.md
@@ -75,8 +75,10 @@ e.g. `trusty-mcp-core-v0.2.0`. The version comes from the crate's `Cargo.toml`.
    Its CHECK 6 is the one that catches a tag left behind by a fast-forward —
    see [Tag/Publish-Commit Parity Guard](#tagpublish-commit-parity-guard) below.
    🔴 If main moved between steps 5 and 7 and you fast-forwarded this checkout
-   to satisfy the merged-main check, the tag from step 5 is now stale. Re-tag
-   before publishing; do not publish with the two disagreeing.
+   to satisfy the merged-main check, the tag from step 5 is now stale. Reset the
+   checkout back to the tag (`git reset --hard <crate-name>-v<version>`) and
+   publish that commit; do not publish with the two disagreeing, and do not try
+   to move the tag — [tags here are immutable](#release-tags-are-immutable).
 8. Publish: `cargo publish -p <crate-name>`.
    - **UI-embedding crates** (trusty-search, trusty-memory, trusty-analyze): prefix with `SKIP_UI_BUILD=1`:
      ```bash
@@ -166,8 +168,8 @@ origin over local refs, accepting both the crate-dir and `tga` alias series)
 against `git rev-parse HEAD` — the sha1 `cargo package` writes into
 `.cargo_vcs_info.json`. Four named findings: `TAG-MISSING`, `TAG-SPLIT` (the
 two alias series disagree), `TAG-DRIFT` (the fast-forward case, whose message
-lists the commits added since the tag and gives the re-tag command), and
-`VCS-INFO-MISMATCH`.
+lists the commits added since the tag and tells you to reset the checkout onto
+it), and `VCS-INFO-MISMATCH`.
 
 **After publishing**, confirm what cargo recorded rather than what it was
 expected to record — this is the only check that still works once the upload
@@ -194,6 +196,35 @@ it, before the tag becomes something anyone has relied on.
 failure and asserts the finding code, not just a non-zero exit. CI runs the
 self-test rather than the gate: on a tag push the workflow checkout IS the
 tagged commit, so the comparison is true by construction and proves nothing.
+
+## Release Tags Are Immutable
+
+🔴 **A pushed `*-v*` tag cannot be moved, force-updated, or deleted.** An
+enforcing GitHub ruleset rejects all three with `GH013`, and `admin: true` on
+the account does not lift it. The ruleset does not appear in
+`gh api repos/bobmatnyc/trusty-tools/rulesets` or in the branch-protection
+endpoint, so the first sign of it is the rejected push.
+
+This repo documented a "re-tag before publishing" recovery for years. It never
+worked here. Issue #6178 proved it on 2026-08-22: a force-update and a delete
+were both attempted against real stranded tags and both were rejected.
+
+**What to do instead**, by situation:
+
+| Situation | Remedy |
+|---|---|
+| Tagged, then fast-forwarded; the tagged tree is fine to ship | `git reset --hard <tag>`, re-run preflight, publish. Move the checkout, never the tag. |
+| Tagged a commit that can never pass the publish gate | The version number is **burned**. Bump to the next version, tag fresh, publish that. |
+| Already published, and `--vcs-info` reports `VCS-INFO-MISMATCH` | The tag permanently misstates what shipped and cannot be corrected. Record it, and bump-and-re-release only if a truthful tag matters more than a spent version number. |
+
+**Proven 2026-08-22.** `trusty-search-v0.49.0` and `trusty-review-v0.24.0` are
+stranded at `4af0ef8ee` — a commit whose tree cannot pass the publish gate — so
+both version numbers are permanently spent. The release shipped as
+`trusty-search-v0.49.1` and `trusty-review-v0.24.1`.
+
+**The cheap prevention** is ordering: tag as late as possible, immediately
+before `cargo publish`, once every other gate is already green. A tag that
+exists for thirty seconds has nothing to strand.
 
 ## Version-Parity Guard (issue #3366)
 

--- a/scripts/check-tag-publish-parity-selftest.sh
+++ b/scripts/check-tag-publish-parity-selftest.sh
@@ -143,16 +143,25 @@ commit_more "$repo" 2
 run_case "fast-forward drift" 1 "TAG-DRIFT" "$repo" trusty-example
 
 # The remedy has to name the fast-forward, or whoever hits this at 2am reads it
-# as a botched tag and re-tags the wrong commit.
+# as a botched tag and tags the wrong commit.
+#
+# It must also give a remedy that can actually RUN here. Tags on this repo are
+# immutable (#6178): a `git tag -f` + force-push is rejected with GH013, so the
+# remedy is to move the checkout onto the tag. Asserting `git tag -f` is ABSENT
+# is the regression guard — the old text shipped a command that always fails.
 out="$(bash "$GATE" --repo "$repo" --no-fetch trusty-example 2>&1 || true)"
 if ! grep -qF "ANCESTOR of HEAD" <<< "$out"; then
   fail_case "fast-forward diagnosis: the failure did not identify the fast-forward" "$out"
-elif ! grep -qF "git tag -f" <<< "$out"; then
-  fail_case "fast-forward diagnosis: no re-tag remedy given" "$out"
+elif grep -qF "git tag -f" <<< "$out"; then
+  fail_case "fast-forward diagnosis: offered the inexecutable re-tag remedy (#6178)" "$out"
+elif ! grep -qF "git reset --hard" <<< "$out"; then
+  fail_case "fast-forward diagnosis: no executable remedy given" "$out"
+elif ! grep -qF "IMMUTABLE" <<< "$out"; then
+  fail_case "fast-forward diagnosis: did not say why the tag cannot be moved" "$out"
 elif ! grep -qF "unrelated commit 2" <<< "$out"; then
   fail_case "fast-forward diagnosis: the commits added since the tag were not listed" "$out"
 else
-  pass_case "the fast-forward failure names the cause, lists the drift, and gives the re-tag remedy"
+  pass_case "the fast-forward failure names the cause, lists the drift, and gives an executable remedy"
 fi
 
 # ===========================================================================

--- a/scripts/check-tag-publish-parity.sh
+++ b/scripts/check-tag-publish-parity.sh
@@ -271,7 +271,9 @@ if [ "$DISTINCT" -gt 1 ]; then
   echo "FAIL: TAG-SPLIT — the accepted alias tags for ${PKG_NAME} ${VERSION} name" >&2
   echo "      DIFFERENT commits, so at least one of them misrepresents the release:" >&2
   paste -d' ' <(printf '%s\n' $FOUND_TAGS) <(printf '%s\n' $FOUND_SHAS) | sed 's/^/        /' >&2
-  echo "      Delete and re-push the wrong one so both name the publish commit." >&2
+  echo "      Tags here are IMMUTABLE (#6178) — the wrong one cannot be deleted or" >&2
+  echo "      moved, so this version number is burned. Bump to the next version and" >&2
+  echo "      tag it fresh, at the commit you intend to publish." >&2
   exit 1
 fi
 
@@ -288,14 +290,18 @@ if [ "$TAG_SHA" != "$PUBLISH_SHA" ]; then
     echo "      published 7d5cf82e1 — and every other release gate stays green through" >&2
     echo "      it. Commits added since the tag:" >&2
     git log --oneline "${TAG_SHA}..${PUBLISH_SHA}" 2>/dev/null | sed 's/^/        /' >&2
-    echo "      Move the tag onto ${PUBLISH_SHA} and re-push it, or reset this" >&2
-    echo "      checkout back to ${TAG_SHA}. Do not publish with them disagreeing:" >&2
-    echo "        git tag -f ${MATCHED_TAG} ${PUBLISH_SHA}" >&2
-    echo "        git push --force origin ${MATCHED_TAG}" >&2
+    echo "      Tags here are IMMUTABLE (#6178): a force-update and a delete are both" >&2
+    echo "      rejected with GH013, so moving ${MATCHED_TAG} onto ${PUBLISH_SHA} is not" >&2
+    echo "      an option. Move the CHECKOUT onto the tag instead, then re-run:" >&2
+    echo "        git reset --hard ${TAG_SHA}" >&2
+    echo "      If ${TAG_SHA} cannot pass the publish gate, this version number is" >&2
+    echo "      burned — bump to the next version and tag it fresh." >&2
   else
     echo "      The tag is NOT an ancestor of HEAD — these are divergent histories," >&2
     echo "      so the tagged tree and the tree about to ship differ by more than" >&2
-    echo "      added commits. Re-tag the commit you intend to publish." >&2
+    echo "      added commits. Tags here are IMMUTABLE (#6178), so this version" >&2
+    echo "      number is burned: bump to the next version and tag the commit you" >&2
+    echo "      intend to publish." >&2
   fi
   exit 1
 fi
@@ -331,9 +337,10 @@ if [ -n "$VCS_INFO" ]; then
     echo "FAIL: VCS-INFO-MISMATCH — ${VCS_INFO} records ${recorded}, but" >&2
     echo "      ${MATCHED_TAG} names ${TAG_SHA}. The tag does not describe the" >&2
     echo "      published tree. This is the 2026-08-11 defect observed directly." >&2
-    echo "      Move the tag onto the published commit — leaving it is a permanent" >&2
-    echo "      misstatement of what shipped:" >&2
-    echo "        git tag -f ${MATCHED_TAG} ${recorded} && git push --force origin ${MATCHED_TAG}" >&2
+    echo "      The upload already happened and tags here are IMMUTABLE (#6178), so" >&2
+    echo "      this misstatement is PERMANENT for ${VERSION} — it cannot be corrected" >&2
+    echo "      in place. Bump and re-release only if a truthful tag is worth more" >&2
+    echo "      than a spent version number." >&2
     exit 1
   fi
   echo "PASS: ${VCS_INFO} records ${recorded}, matching ${MATCHED_TAG}." >&2


### PR DESCRIPTION
`CLAUDE.md`, the `cargo-publish` skill, `docs/reference/release-workflow.md`,
and `scripts/check-tag-publish-parity.sh` all told the reader to re-tag when a
release tag drifts off the publish commit. That command cannot run on this repo.

An enforcing GitHub ruleset rejects a force-update and a delete of any `*-v*`
tag with `GH013`. `admin: true` on the account does not lift it, and the ruleset
does not appear in the rulesets or branch-protection API, so the first sign of
it is the rejected push. #6178 proved both rejections against real tags on
2026-08-22.

## What replaces it

| Situation | Old text | New text |
|---|---|---|
| Tagged, then fast-forwarded | `git tag -f <tag> <head> && git push --force` | `git reset --hard <tag>` — move the checkout, never the tag |
| Tagged commit cannot pass the publish gate | (not covered) | the version number is burned; bump and tag fresh |
| Two alias tags disagree (TAG-SPLIT) | "delete and re-push the wrong one" | version burned; bump and tag fresh |
| Published with a mismatched tag (VCS-INFO-MISMATCH) | `git tag -f … && git push --force` | permanent; correctable only by spending another version |

`docs/reference/release-workflow.md` gains a `## Release Tags Are Immutable`
section carrying the ruleset behaviour, the per-situation table, the 2026-08-22
evidence, and the cheap prevention: tag immediately before `cargo publish`, so
there is nothing to strand.

## The regression guard

`scripts/check-tag-publish-parity-selftest.sh` case 2 used to assert the
TAG-DRIFT message CONTAINS `git tag -f`. It now asserts that string is ABSENT,
and that `git reset --hard` and `IMMUTABLE` are present. That inversion is what
stops the inexecutable recipe coming back.

It fails against the pre-fix script:

```
$ git stash push scripts/check-tag-publish-parity.sh
$ bash scripts/check-tag-publish-parity-selftest.sh; echo "EXIT=$?"
SELF-TEST FAIL: fast-forward diagnosis: offered the inexecutable re-tag remedy (#6178)
check-tag-publish-parity-selftest: 14 passed, 1 FAILED.
EXIT=1
```

## Gates

Rung 1 (docs) plus the changed script's own selftest. No crate `src/**` touched,
so no changelog fragment.

```
$ bash scripts/check-tag-publish-parity-selftest.sh; echo "EXIT=$?"
check-tag-publish-parity-selftest: 15 passed, 0 failed.
EXIT=0

$ bash scripts/check_sld.sh; echo "EXIT=$?"
EXIT=0
```

Refs #6178

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
