### PR TITLE
fix(trusty-audit): render reconciles the engagement's pin like run does (Refs #6173)

### DIFF
--- a/crates/trusty-audit/changelog.d/6173-render-reconciles-pins.md
+++ b/crates/trusty-audit/changelog.d/6173-render-reconciles-pins.md
@@ -1,0 +1,12 @@
+Fixed
+- `render` now refuses when the engagement's own `tools/trusty-review` is at a
+  different version from the engagement's `trusty-review` pin, naming both. It
+  used to render at whatever that copy happened to be and exit 0. `install`,
+  `run` and `guided` all reconcile pins; `render` never did, and its default
+  renderer IS that engagement-local copy — so bumping a pin and re-rendering
+  silently produced the report at the old version, with the only trace a version
+  in the report metadata, read after the report had been believed.
+- The reconciliation covers only the engagement's copy. `--review-bin` stays the
+  escape hatch and is never reconciled, and a `PATH`-resolved renderer keeps the
+  disclosure it already carried rather than gaining a refusal. A re-render where
+  no `engagement.toml` loads pins nothing and is unaffected.

--- a/crates/trusty-audit/src/rerender.rs
+++ b/crates/trusty-audit/src/rerender.rs
@@ -231,6 +231,7 @@ pub async fn rerender(
     key: &SecretKey,
     inference: &crate::inference::Inference,
     options: &RerenderOptions,
+    pinned_review: Option<&str>,
     progress: &Progress,
 ) -> Result<RerenderReport, AuditError> {
     let choice = resolve_source(options.from.clone(), cwd, config, work.root());
@@ -254,6 +255,9 @@ pub async fn rerender(
     // known before the first child rather than only after the last one. The
     // index reads the same answer rather than spawning a second `--version`.
     let review_version = crate::index_report::tool_version(&review);
+    // #6173: reconcile the engagement's own copy against the engagement's own
+    // pin, which nothing on this path did.
+    reconcile_review_pin(review_source, review_version.as_deref(), pinned_review)?;
     // #6081: this is the tga-free render path, and nothing on it started a
     // daemon or indexed anything — so `--analyze` fetched nothing and every
     // analyze-derived section rendered empty over a clean exit. Resolved once,
@@ -564,6 +568,52 @@ fn resolve_review(
     let resolved =
         trusty_common::bin_resolve::resolve_binary(name).unwrap_or_else(|| PathBuf::from(name));
     (resolved, ReviewSource::Path)
+}
+
+/// Refuse an engagement-local renderer that is not at the engagement's pin.
+///
+/// Why: #6173. `install`, `run`, and `guided` all reconcile pins through
+/// [`crate::run::pins::pinned_binaries`], which refuses on a mismatch. `render`
+/// never called it, and its default resolves the engagement's own
+/// `tools/trusty-review`. So bumping the pin 0.23.0 -> 0.23.1 and re-rendering
+/// executed the 0.23.0 copy and exited 0; the only trace was the version in the
+/// report metadata, read after the report had been believed. `describe_renderer`
+/// (#6080) discloses a version only for a `PATH`-resolved renderer, which is a
+/// different branch and stays silent here.
+///
+/// `pinned_binaries` itself is the wrong instrument for this path: it demands
+/// all four tools be installed and verified, and a recipient re-rendering a
+/// delivered package has only `trusty-review`. This checks the one binary
+/// `render` actually drives.
+///
+/// What: refuses only on a KNOWN difference against a KNOWN pin, and only for
+/// [`ReviewSource::Engagement`]. `Explicit` is the operator naming a copy on
+/// purpose — the documented escape hatch, and refusing it would leave no way
+/// out. `Path` is nobody's choice and already discloses itself. No pin (a
+/// package re-rendered where no `engagement.toml` loads) and no version (a
+/// binary that will not answer `--version`) are both absences, not differences.
+/// Test: `super::rerender_tests::a_stale_engagement_copy_is_refused_against_the_pin`,
+/// `super::rerender_tests::an_engagement_copy_at_the_pin_renders`,
+/// `super::rerender_tests::an_explicit_renderer_is_never_reconciled`.
+fn reconcile_review_pin(
+    source: ReviewSource,
+    version: Option<&str>,
+    pinned: Option<&str>,
+) -> Result<(), AuditError> {
+    if source != ReviewSource::Engagement {
+        return Ok(());
+    }
+    let (Some(version), Some(pinned)) = (version, pinned) else {
+        return Ok(());
+    };
+    if version == pinned {
+        return Ok(());
+    }
+    Err(AuditError::VersionMismatch {
+        tool: RequiredTool::TrustyReview.crate_name(),
+        pinned: pinned.to_owned(),
+        installed: version.to_owned(),
+    })
 }
 
 /// Render one manifest, recording rather than propagating its failure.
@@ -904,6 +954,8 @@ mod rerender_tests {
                 out: None,
                 review: Some(review.to_path_buf()),
             },
+            // These drive an EXPLICIT renderer, which #6173 never reconciles.
+            None,
             &Progress::none(),
         )
         .await
@@ -1524,6 +1576,9 @@ mod rerender_tests {
             &key(),
             &crate::inference::Inference::default(),
             &RerenderOptions::default(),
+            // The pin this stub answers with, so reconciliation is satisfied
+            // rather than skipped — see #6173.
+            Some("0.21.0"),
             &Progress::none(),
         )
         .await
@@ -1537,6 +1592,87 @@ mod rerender_tests {
             !crate::cli::render(&crate::session::Outcome::Rerendered(report)).contains("NOTE:"),
             "a chosen renderer owes no unchosen-renderer disclosure"
         );
+    }
+
+    /// 🔴 THE #6173 REGRESSION TEST — the engagement bumped its pin, the
+    /// engagement's own `tools/` copy is still the old one, and `render` drove
+    /// it and exited 0.
+    ///
+    /// This is the live 2026-08-22 sequence: pin bumped 0.23.0 -> 0.23.1, the
+    /// `tools/trusty-review` left by the last `install` still at 0.23.0, and
+    /// the only trace a version in the report metadata read afterwards.
+    /// `describe_renderer` (#6080) says nothing here, because the renderer WAS
+    /// chosen — it is the engagement's, just not the engagement's current one.
+    /// Against `fa8afbccc` this returns `Ok` and renders at 0.23.0.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_stale_engagement_copy_is_refused_against_the_pin() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let engagement = tmp.path().join("dogfood-audit");
+        let config = engagement_config_in(&engagement);
+        report_dir(&engagement.join("work").join("out"), "01-acme-api");
+        let engagement_work = WorkDir::new(engagement.join("work"));
+        engagement_work.create().expect("the engagement's work dir");
+        stub_review(
+            &engagement_work.path(crate::workdir::Area::Tools),
+            &WRITES_A_REPORT.replace(
+                "#!/bin/sh\n",
+                "#!/bin/sh\ncase \"$1\" in --version) echo 'trusty-review 0.23.0'; exit 0;; esac\n",
+            ),
+        );
+        let session = work_in(tmp.path());
+
+        let refusal = super::rerender(
+            &session,
+            &engagement,
+            &config,
+            &key(),
+            &crate::inference::Inference::default(),
+            &RerenderOptions::default(),
+            Some("0.23.1"),
+            &Progress::none(),
+        )
+        .await
+        .expect_err("a copy off the pin must not render");
+
+        assert!(
+            matches!(
+                &refusal,
+                AuditError::VersionMismatch { tool, pinned, installed }
+                    if *tool == "trusty-review" && pinned == "0.23.1" && installed == "0.23.0"
+            ),
+            "the refusal must name both versions, got {refusal:?}"
+        );
+    }
+
+    /// An engagement copy AT the pin renders — the refusal above is about drift,
+    /// not about the engagement branch existing.
+    #[test]
+    fn an_engagement_copy_at_the_pin_renders() {
+        reconcile_review_pin(ReviewSource::Engagement, Some("0.23.1"), Some("0.23.1"))
+            .expect("a copy at the pin is what the engagement asked for");
+    }
+
+    /// `--review-bin` is the documented escape hatch (#6173's own workaround),
+    /// so reconciling it would leave no way past a bad pin. `PATH` is nobody's
+    /// choice and discloses itself instead (#6080).
+    #[test]
+    fn an_explicit_renderer_is_never_reconciled() {
+        for source in [ReviewSource::Explicit, ReviewSource::Path] {
+            reconcile_review_pin(source, Some("0.23.0"), Some("0.23.1"))
+                .unwrap_or_else(|e| panic!("{source:?} must not be reconciled: {e}"));
+        }
+    }
+
+    /// An absence is not a difference: a package re-rendered where no
+    /// `engagement.toml` loads pins nothing, and a binary that will not answer
+    /// `--version` states nothing to compare.
+    #[test]
+    fn an_absent_pin_or_version_is_not_a_mismatch() {
+        reconcile_review_pin(ReviewSource::Engagement, Some("0.23.0"), None)
+            .expect("no pin, nothing to reconcile against");
+        reconcile_review_pin(ReviewSource::Engagement, None, Some("0.23.1"))
+            .expect("no version, nothing to reconcile");
     }
 
     /// 🔴 #6080: with nothing installed and no flag, the renderer is whatever

--- a/crates/trusty-audit/src/session.rs
+++ b/crates/trusty-audit/src/session.rs
@@ -1022,6 +1022,14 @@ impl Session {
                 env: run::ENV_INFERENCE_CREDENTIAL,
                 config: self.config_path.clone(),
             })?;
+        // #6173: `render` drives the engagement's own `tools/trusty-review`,
+        // so it owes the same pin reconciliation `run` performs. The pin is
+        // read here, where the config is already loaded, and is `None` when no
+        // engagement config loads — a delivered package re-rendered on a
+        // machine that never ran the engagement pins nothing.
+        let pinned_review = config
+            .as_ref()
+            .map(|c| c.tools.trusty_review.version().to_owned());
         let models = config.map(|c| c.models).unwrap_or_default();
         // #6135: both halves — the pairs the child inherits, and the identity
         // the index states when no manifest declares its own.
@@ -1033,6 +1041,7 @@ impl Session {
             &key,
             &inference,
             options,
+            pinned_review.as_deref(),
             &self.progress,
         )
         .await


### PR DESCRIPTION
`trusty-audit render` drove the engagement's own `tools/trusty-review` at
whatever version that copy happened to be, and exited 0. During the 2026-08-22
dogfood run the pin was bumped 0.23.0 -> 0.23.1 and `render` still executed
0.23.0. It surfaced only because someone read the version out of the report
metadata afterwards.

`install`, `run` and `guided` all reconcile pins through
`run::pins::pinned_binaries`, which refuses on a mismatch. `render` never called
it — and `render`'s default renderer is exactly the binary that check exists to
police. `describe_renderer` (#6080) discloses a version only when the renderer
was PATH-resolved, so this branch stayed quiet: the renderer WAS chosen, just
not the engagement's current one.

## Why not `pinned_binaries` itself

It demands all four tools be installed AND verified. A recipient re-rendering a
delivered package has only `trusty-review`, so calling it here would refuse
every legitimate recipient render. `reconcile_review_pin` checks the one binary
`render` actually drives.

## What it refuses, and what it deliberately does not

| Renderer source | Behaviour |
|---|---|
| `Engagement`, both versions known, they differ | `VersionMismatch`, naming pin and installed |
| `Engagement`, at the pin | renders |
| `Explicit` (`--review-bin`) | never reconciled — the documented escape hatch, and #6173's own workaround. Reconciling it leaves no way past a bad pin. |
| `Path` | keeps its #6080 disclosure; no new refusal |
| no `engagement.toml` (nothing pinned), or the binary will not answer `--version` | absences, not differences — unchanged |

## Regression test

`rerender_tests::a_stale_engagement_copy_is_refused_against_the_pin` drives the
live sequence: config pinning 0.23.1, a `tools/trusty-review` answering 0.23.0.

Against `fa8afbccc` it renders and exits 0 — the defect, verbatim:

```
$ cargo test -p trusty-audit a_stale_engagement_copy_is_refused_against_the_pin
thread '...a_stale_engagement_copy_is_refused_against_the_pin' panicked at crates/trusty-audit/src/rerender.rs:1636:10:
a copy off the pin must not render: RerenderReport { ... review_source: Engagement,
review_version: Some("0.23.0"), reports: [RenderedReport { ... result: Succeeded }] }
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 740 filtered out
```

Three companion tests pin the non-refusal branches so a later tightening cannot
quietly swallow `--review-bin`.

## Gates — rung 3 (localized behaviour, one crate)

```
$ cargo fmt --check                                        EXIT=0
$ cargo check -p trusty-audit --all-targets                 EXIT=0
$ cargo clippy -p trusty-audit --all-targets -- -D warnings EXIT=0
$ cargo test -p trusty-audit
test result: ok. 736 passed; 0 failed; 5 ignored; 0 measured; 0 filtered out
$ bash scripts/check_test_pointers.sh                       EXIT=0
$ bash scripts/check_line_cap.sh                            EXIT=0
$ bash scripts/check_changelog_fragment.sh
OK   trusty-audit: changelog.d fragment present and valid
```

No version bump: trusty-audit 0.10.0 in-tree is already ahead of crates.io.

Refs #6173

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
