### PR TITLE
feat(trusty-audit): the documented sequence runs without a terminal (Refs #6159)

### DIFF
--- a/crates/trusty-audit/README.md
+++ b/crates/trusty-audit/README.md
@@ -72,6 +72,7 @@ never reads it.
 
 ```
 trusty-audit                    # guided flow: register targets, install, sweep
+trusty-audit init               # write engagement.toml with no terminal, for a script
 trusty-audit workdir            # create the working directory, print what lands where
 trusty-audit add repo OWNER/NAME    # register a repository, after checking it can be read
 trusty-audit add board jira:KEY     # register a JIRA project or Linear team
@@ -88,6 +89,24 @@ trusty-audit run --fresh        # audit every selected repository again
 trusty-audit package            # assemble the deliverable zip to send back
 trusty-audit audit              # all four of the above, in one invocation
 ```
+
+Every verb below `init` needs an `engagement.toml`, and the bare launch above is
+the only one that writes it interactively — `add repo` on a fresh directory
+refuses with `NoEngagementConfig`. `trusty-audit init` is the write on its own:
+it reads `OPENROUTER_API_KEY` from the environment, never prompts, records the
+latest published version of each pinned tool, and leaves an existing engagement
+exactly as it is. That makes the sequence runnable from a script or a CI job:
+
+```
+export OPENROUTER_API_KEY=…
+trusty-audit init
+trusty-audit install
+trusty-audit add repo acme/api
+trusty-audit audit
+```
+
+`init` writes the file and nothing else — `install` is the download, so a caller
+decides for itself when to pay for it.
 
 `targets` and `repos` answer different questions, and reaching for the wrong one
 is the mistake worth naming. `targets` lists the REGISTRY — what `add` wrote, and

--- a/crates/trusty-audit/changelog.d/6159-init-verb.md
+++ b/crates/trusty-audit/changelog.d/6159-init-verb.md
@@ -1,0 +1,8 @@
+Added
+
+- `trusty-audit init` writes the first `engagement.toml` with no terminal
+  involved, reading the key from `OPENROUTER_API_KEY`. Only the interactive
+  cold start ever wrote that file, so the README's documented sequence failed at
+  `add repo` with `NoEngagementConfig` for every scripted and CI caller, whose
+  workaround was faking a pty with `script -q /dev/null`. Re-running it over an
+  existing engagement is a no-op, so it can sit at the top of a script.

--- a/crates/trusty-audit/src/cli.rs
+++ b/crates/trusty-audit/src/cli.rs
@@ -74,6 +74,16 @@ pub struct Cli {
 pub enum Verb {
     /// Walk the pre-run steps: repository selection, then tooling.
     Guided,
+    /// Create `engagement.toml` without a terminal, for a scripted run.
+    ///
+    /// The README's sequence — workdir, add repo, targets, audit — begins at a
+    /// step that needs a config, and until now only a bare `trusty-audit` on a
+    /// real terminal ever wrote one. A CI or scripted caller had no way to get
+    /// past `add repo` except by faking a pty. This is that way: it reads
+    /// `OPENROUTER_API_KEY` from the environment, never prompts, and writes the
+    /// same file the interactive cold start writes. A directory that is already
+    /// an engagement is left exactly as it is.
+    Init,
     /// Create the working directory and print what lands where.
     Workdir,
     /// Print the engagement metadata from the companion manifest.
@@ -262,6 +272,10 @@ impl Cli {
     pub fn to_command(&self) -> Command {
         match &self.verb {
             None | Some(Verb::Guided) => Command::Guided,
+            // #6159: the non-interactive half of the cold start. It takes no
+            // flags — every value it writes comes from the environment or the
+            // pinned release list, which is what makes it scriptable.
+            Some(Verb::Init) => Command::Init,
             Some(Verb::Workdir) => Command::WorkDir,
             Some(Verb::Manifest) => Command::Manifest,
             Some(Verb::Tools) => Command::Tools,
@@ -402,6 +416,7 @@ mod cli_tests {
     fn argv_for(command: &Command) -> Vec<&'static str> {
         match command {
             Command::Guided => vec!["taudit", "guided"],
+            Command::Init => vec!["taudit", "init"],
             Command::WorkDir => vec!["taudit", "workdir"],
             Command::Manifest => vec!["taudit", "manifest"],
             Command::Tools => vec!["taudit", "tools"],
@@ -434,6 +449,7 @@ mod cli_tests {
     fn all_commands() -> Vec<Command> {
         vec![
             Command::Guided,
+            Command::Init,
             Command::WorkDir,
             Command::Manifest,
             Command::Tools,

--- a/crates/trusty-audit/src/cli/render.rs
+++ b/crates/trusty-audit/src/cli/render.rs
@@ -68,6 +68,24 @@ pub fn render(outcome: &Outcome) -> String {
             }
             out
         }
+        // #6159: `created` is the line that matters. A caller re-running `init`
+        // must be able to see that the key in its environment is NOT the key
+        // this engagement runs on, which "wrote the config" would hide.
+        Outcome::Initialized(report) => {
+            if !report.created {
+                return format!(
+                    "Engagement already configured: {}\n  (left as it is; delete it to start \
+                     over)\n",
+                    report.path.display()
+                );
+            }
+            let mut out = format!("Engagement created: {}\n", report.path.display());
+            for (crate_name, version) in &report.pins {
+                out.push_str(&format!("  pinned {crate_name} {version}\n"));
+            }
+            out.push_str("Next: taudit install, then taudit add repo <owner/name>\n");
+            out
+        }
         Outcome::WorkDir(report) => {
             // #5915: this used to say "everything this client wrote". Approving
             // a clone for indexing writes a row to `trusty-search`'s own

--- a/crates/trusty-audit/src/session.rs
+++ b/crates/trusty-audit/src/session.rs
@@ -22,7 +22,13 @@
 
 use std::path::{Path, PathBuf};
 
+// #6159: creating an engagement without a terminal. Its own module because this
+// file is at the 500-SLOC production cap.
+pub mod init;
+
 use crate::chain::{self, ChainOptions, ChainReport};
+// #6159: `PinResolver` is the seam that keeps `init`'s test off the release list.
+use crate::cli::bootstrap::PinResolver;
 use crate::clone::{self, CloneOptions, CloneReport};
 use crate::config::{EngagementConfig, SecretKey};
 use crate::discover::{self, DiscoveredRepo};
@@ -37,6 +43,7 @@ use crate::run::{self, RunOptions, RunReport};
 use crate::tools::{self, InstalledTool, RequiredTool, ToolStatus};
 use crate::validate;
 use crate::workdir::{Area, WorkDir};
+use init::InitReport;
 
 /// Everything `trusty-audit` can be asked to do.
 ///
@@ -50,6 +57,19 @@ use crate::workdir::{Area, WorkDir};
 pub enum Command {
     /// What a bare invocation runs: the guided flow, starting at repo selection.
     Guided,
+    /// Write the first `engagement.toml` with no terminal involved (#6159).
+    ///
+    /// Why: `crate::cli::bootstrap::cold_start` is the only thing that ever
+    /// synthesised an engagement, and it needs a `/dev/tty` to ask for the key
+    /// on. So the README's documented sequence failed at `add repo` with
+    /// [`AuditError::NoEngagementConfig`] for every scripted and CI caller, and
+    /// the observed workaround was allocating a pty with `script -q /dev/null`.
+    /// This is the same write with the prompt removed: the key comes from the
+    /// environment, and nothing else about the file differs.
+    ///
+    /// Carries no argument for the same reason it is scriptable — every value
+    /// it writes comes from the environment or the pinned release list.
+    Init,
     /// Create the working directory and report its layout.
     WorkDir,
     /// Read the companion `manifest.toml` and report the engagement metadata.
@@ -184,7 +204,11 @@ impl Command {
             // key into does not exist. An exported key, or the config's when
             // there is one — `Session::rerender` owns that second fallback,
             // exactly as `Session::engagement_config` owns it for the sweep.
-            Self::Package { .. } | Self::Distribute(_) | Self::Rerender(_) => {
+            // #6159: `init` writes the key into the config it creates, so it
+            // needs one — but it must never PROMPT, because being runnable
+            // without a terminal is the entire capability. The environment is
+            // therefore its only source; there is no config yet to fall back on.
+            Self::Package { .. } | Self::Distribute(_) | Self::Rerender(_) | Self::Init => {
                 CredentialNeed::Environment
             }
             Self::Guided
@@ -274,6 +298,9 @@ pub struct GuidedStatus {
 pub enum Outcome {
     /// From [`Command::Guided`].
     Guided(GuidedStatus),
+    /// From [`Command::Init`] — where the config is, and whether this call
+    /// wrote it.
+    Initialized(InitReport),
     /// From [`Command::WorkDir`].
     WorkDir(WorkDirReport),
     /// From [`Command::Manifest`].
@@ -428,6 +455,12 @@ pub struct Session {
     /// Test: `super::session_tests::a_credential_in_the_environment_is_the_one_packaged`,
     /// `super::session_tests::a_supplied_credential_beats_the_configs_own`.
     credential: Option<SecretKey>,
+    /// Where [`Command::Init`] gets the versions it pins (#6159).
+    ///
+    /// A field for the reason [`Session::repo_probe`] is one: resolving the
+    /// latest published release reaches the network, and the branches above
+    /// that call have to be provable from a test binary that has none.
+    pins: PinResolver,
     /// Where live progress goes while a long capability runs (#5823).
     ///
     /// A field rather than a parameter on [`Session::execute`] because progress
@@ -459,8 +492,23 @@ impl Session {
             auto_install: true,
             repo_probe: validate::RepoProbe::real(),
             credential: None,
+            pins: PinResolver::LatestPublished,
             progress: Progress::none(),
         }
+    }
+
+    /// Pin [`Command::Init`] to exact versions instead of asking the release
+    /// list.
+    ///
+    /// `#[cfg(test)]` for the same reason [`Session::with_repo_probe`] is: it is
+    /// the injection seam that makes the no-network branches provable, and it
+    /// does not exist in a shipped build, so `execute` stays the only door.
+    /// Test: `super::session_tests::init_writes_an_engagement_without_a_terminal`.
+    #[cfg(test)]
+    #[must_use]
+    pub(crate) fn with_pins(mut self, pins: crate::config::ToolPins) -> Self {
+        self.pins = PinResolver::Fixed(pins);
+        self
     }
 
     /// Point the repository check at a different pair of `gh` invocations.
@@ -622,6 +670,17 @@ impl Session {
     pub async fn execute(&self, command: Command) -> Result<Outcome, AuditError> {
         match command {
             Command::Guided => self.guided().await.map(Outcome::Guided),
+            // #6159: the cold start without the prompt. It shares
+            // `bootstrap::create_engagement` with the interactive path rather
+            // than growing a second writer of a plaintext key.
+            Command::Init => init::init(
+                &self.config_path,
+                &self.work,
+                self.credential.as_ref(),
+                &self.pins,
+            )
+            .await
+            .map(Outcome::Initialized),
             Command::WorkDir => self.work_dir_report().map(Outcome::WorkDir),
             Command::Manifest => AuditManifest::load(&self.manifest_path).map(Outcome::Manifest),
             Command::Tools => tools::status(&self.work).map(Outcome::Tools),
@@ -1184,6 +1243,137 @@ path = "/work/repos/acme-api"
 
     fn session_in(dir: &Path) -> Session {
         Session::new(WorkDir::new(dir.join("work")))
+    }
+
+    /// #6159: a session that can run `init` with no terminal and no network —
+    /// the key the front end would have resolved from the environment, and pins
+    /// that answer without a release list.
+    fn init_session_in(dir: &Path, key: Option<&str>) -> Session {
+        let mut session = session_in(dir)
+            .with_config_path(dir.join("engagement.toml"))
+            .with_pins(crate::cli::bootstrap::fixed_pins("9.9.9"));
+        if let Some(key) = key {
+            session = session.with_credential(Some(SecretKey::new(key.to_owned())));
+        }
+        session
+    }
+
+    /// 🔴 #6159, the regression this ticket is: the README's sequence begins at
+    /// a step that needs `engagement.toml`, and before `init` the only thing
+    /// that wrote one asked for the key on `/dev/tty`. Against `main` this test
+    /// cannot even be written — there is no `Command::Init` — which is the
+    /// defect: a scripted caller's only route was faking a pty.
+    ///
+    /// Everything here runs with no terminal, no network, and no process
+    /// environment read, and the file must come out owner-readable with the key
+    /// in it and the four pins recorded.
+    #[tokio::test]
+    async fn init_writes_an_engagement_without_a_terminal() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let session = init_session_in(tmp.path(), Some("sk-or-v1-test"));
+
+        let Outcome::Initialized(report) = session.execute(Command::Init).await.expect("init runs")
+        else {
+            panic!("init must report what it wrote");
+        };
+        assert!(report.created, "a fresh directory must be written into");
+        assert_eq!(report.path, tmp.path().join("engagement.toml"));
+        assert_eq!(
+            report.pins,
+            vec![
+                ("tga".to_owned(), "9.9.9".to_owned()),
+                ("trusty-search".to_owned(), "9.9.9".to_owned()),
+                ("trusty-analyze".to_owned(), "9.9.9".to_owned()),
+                ("trusty-review".to_owned(), "9.9.9".to_owned()),
+            ]
+        );
+
+        // The file loads, carries the key, and is owner-readable only — the
+        // three properties `create_engagement` owes, asserted through `init`
+        // because that is the path a scripted caller takes.
+        let config = EngagementConfig::load_if_present(&report.path)
+            .expect("readable")
+            .expect("written");
+        assert_eq!(config.openrouter_key.expose(), "sk-or-v1-test");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            let mode = std::fs::metadata(&report.path)
+                .expect("metadata")
+                .permissions()
+                .mode();
+            assert_eq!(mode & 0o777, 0o600, "the key must not be world-readable");
+        }
+
+        // And the sequence the README documents now gets past its first step:
+        // `add repo` refused with `NoEngagementConfig` before this existed.
+        let refusal = session
+            .execute(Command::AddTarget {
+                kind: TargetKind::Repo,
+                spec: "not a spec at all".to_owned(),
+            })
+            .await
+            .expect_err("the spec is still nonsense");
+        assert!(
+            !matches!(refusal, AuditError::NoEngagementConfig { .. }),
+            "the missing config must no longer be what stops registration: {refusal}"
+        );
+    }
+
+    /// Idempotent means no-op. A script with `taudit init` at the top runs it on
+    /// every invocation, and a second run must not replace the key the
+    /// engagement has been running on with whatever is exported today.
+    #[tokio::test]
+    async fn init_over_an_existing_engagement_changes_nothing() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        init_session_in(tmp.path(), Some("sk-or-v1-first"))
+            .execute(Command::Init)
+            .await
+            .expect("first init");
+        let before = std::fs::read_to_string(tmp.path().join("engagement.toml")).expect("written");
+
+        let Outcome::Initialized(report) = init_session_in(tmp.path(), Some("sk-or-v1-second"))
+            .execute(Command::Init)
+            .await
+            .expect("second init")
+        else {
+            panic!("init reports");
+        };
+        assert!(!report.created, "the second call must write nothing");
+        assert_eq!(
+            std::fs::read_to_string(&report.path).expect("still there"),
+            before,
+            "an existing engagement must survive byte for byte"
+        );
+    }
+
+    /// There is no config to fall back on and no terminal to ask on, so a
+    /// missing key is the end of the line — and the refusal names both sources
+    /// rather than leaving a CI log saying only that something failed.
+    #[tokio::test]
+    async fn init_without_a_key_in_the_environment_refuses() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let refusal = init_session_in(tmp.path(), None)
+            .execute(Command::Init)
+            .await
+            .expect_err("no key anywhere must refuse");
+
+        let rendered = refusal.to_string();
+        assert!(
+            rendered.contains(run::ENV_INFERENCE_CREDENTIAL),
+            "{rendered}"
+        );
+        assert!(
+            !tmp.path().join("engagement.toml").exists(),
+            "a refusal must leave no half-written engagement"
+        );
+    }
+
+    /// #6159: `init` must never prompt — being runnable without a terminal is
+    /// the whole capability — so the environment is its only source.
+    #[test]
+    fn init_reads_the_environment_and_never_prompts() {
+        assert_eq!(Command::Init.credential_need(), CredentialNeed::Environment);
     }
 
     /// 🔴 #6080: the re-render calls a model, so a run with no key anywhere must

--- a/crates/trusty-audit/src/session/init.rs
+++ b/crates/trusty-audit/src/session/init.rs
@@ -1,0 +1,124 @@
+//! Creating an engagement without a terminal (#6159).
+//!
+//! Why: `crate::cli::bootstrap::cold_start` was the only thing in the crate
+//! that ever wrote an `engagement.toml`, and it asks for the OpenRouter key on
+//! `/dev/tty`. Every capability after it needs that file — `add repo` refuses
+//! with [`AuditError::NoEngagementConfig`] without one — so the README's
+//! documented sequence could not be completed by a scripted or CI caller at
+//! all, and the observed workaround was allocating a pty with
+//! `script -q /dev/null`. This is the same write with the prompt removed.
+//!
+//! A separate module rather than another method on `Session` because
+//! `session.rs` reached the 500-SLOC production cap; the split is along the one
+//! line that was available, which is this capability.
+//!
+//! What: [`InitReport`] and [`init`]. The write itself is
+//! [`bootstrap::create_engagement`], shared with the interactive path — the
+//! crate keeps exactly ONE writer of a plaintext key into a config.
+//!
+//! Test: `super::session_tests::{init_writes_an_engagement_without_a_terminal,
+//! init_over_an_existing_engagement_changes_nothing,
+//! init_without_a_key_in_the_environment_refuses}`.
+
+use std::path::{Path, PathBuf};
+
+use crate::cli::bootstrap::{self, PinResolver};
+use crate::config::{EngagementConfig, SecretKey};
+use crate::error::AuditError;
+use crate::run::ENV_INFERENCE_CREDENTIAL;
+use crate::workdir::WorkDir;
+
+/// What [`init`] found or wrote.
+///
+/// Why: `created` is the whole reason this is a struct rather than a path. The
+/// capability is idempotent, so a caller can put `trusty-audit init` at the top
+/// of a script and run it repeatedly — and the two cases have to be
+/// distinguishable, because one of them means the key in the environment did
+/// NOT become the key the engagement runs on.
+/// What: the config's path, whether this call wrote it, and the tool versions
+/// the engagement is pinned to. The pins are empty when nothing was written,
+/// since this call did not choose them.
+/// Test: see the module docs.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct InitReport {
+    /// Where the engagement config is.
+    pub path: PathBuf,
+    /// True when this call wrote it; false when one was already there.
+    pub created: bool,
+    /// Crate name and version per pinned tool: tga, trusty-search,
+    /// trusty-analyze, trusty-review, in that order.
+    pub pins: Vec<(String, String)>,
+}
+
+/// Write the first `engagement.toml` at `config_path`.
+///
+/// # Postconditions
+/// On `Ok` with `created`, an `engagement.toml` exists at `config_path`,
+/// owner-readable only, carrying `credential` and an exact version per tool. On
+/// `Ok` without `created`, nothing was written and the file that was already
+/// there is untouched — including its key, which is why the report
+/// distinguishes the two. On `Err`, nothing was written.
+///
+/// What: `credential` is whatever the front end resolved, which for
+/// `CredentialNeed::Environment` is `OPENROUTER_API_KEY` and nothing else.
+/// Tools are NOT installed here: `init` is the file, `install` is the download,
+/// and a CI caller wants to decide when it pays for the second.
+/// Test: see the module docs.
+///
+/// # Errors
+///
+/// [`AuditError::NoCredentialSource`] when nothing exported a key — there is no
+/// config to fall back on and no terminal to ask on, so this is the end of the
+/// line rather than a prompt. [`AuditError::PinsUnresolved`] when the release
+/// list could not be read, and [`AuditError::EngagementNotCreated`] when the
+/// file could not be written.
+pub(super) async fn init(
+    config_path: &Path,
+    work: &WorkDir,
+    credential: Option<&SecretKey>,
+    pins: &PinResolver,
+) -> Result<InitReport, AuditError> {
+    // Idempotent: `trusty-audit init` at the top of a script runs on every
+    // invocation, so a second call must be a no-op rather than a rewrite that
+    // replaces the key the engagement has been running on.
+    if EngagementConfig::load_if_present(config_path)?.is_some() {
+        return Ok(InitReport {
+            path: config_path.to_path_buf(),
+            created: false,
+            pins: Vec::new(),
+        });
+    }
+
+    let key = credential.ok_or_else(|| AuditError::NoCredentialSource {
+        env: ENV_INFERENCE_CREDENTIAL,
+        config: config_path.to_path_buf(),
+    })?;
+
+    // The working directory first, so the config lands beside a layout that
+    // exists — `workdir` is otherwise a step a scripted caller has to remember
+    // before this one.
+    work.create()?;
+    let pins = pins.resolve().await?;
+    bootstrap::create_engagement(config_path, key, &pins)?;
+
+    Ok(InitReport {
+        path: config_path.to_path_buf(),
+        created: true,
+        pins: vec![
+            ("tga".to_owned(), pins.tga.version().to_owned()),
+            (
+                "trusty-search".to_owned(),
+                pins.trusty_search.version().to_owned(),
+            ),
+            (
+                "trusty-analyze".to_owned(),
+                pins.trusty_analyze.version().to_owned(),
+            ),
+            (
+                "trusty-review".to_owned(),
+                pins.trusty_review.version().to_owned(),
+            ),
+        ],
+    })
+}


### PR DESCRIPTION
The README's sequence — `workdir` → `add repo` → `targets` → `audit` — begins at
a step that needs `engagement.toml`, and the only thing that ever wrote one was
`cli::bootstrap::cold_start`, which asks for the OpenRouter key on `/dev/tty`.
A scripted or CI caller hit `NoEngagementConfig` at `add repo` with no way past
it except allocating a pty with `script -q /dev/null`.

`trusty-audit init` is the same write with the prompt removed:

- `Command::Init` carries `CredentialNeed::Environment`, so `OPENROUTER_API_KEY`
  is its only source and no code path can reach a prompt. There is no config to
  fall back on either, so a missing key is a refusal naming the variable.
- It calls `bootstrap::create_engagement` — the crate's one writer of a
  plaintext key into a config — rather than growing a second.
- Re-running over an existing engagement writes nothing and reports
  `created: false`, so it can sit at the top of a script without replacing the
  key the engagement has been running on.
- It writes the file only. `install` is the download, so a CI caller decides
  when to pay for it.

`init` and `InitReport` live in a new `src/session/init.rs`: the addition put
`session.rs` at 525 SLOC, over the 500 production cap, and this capability was
the clean split line.

## Gates — rung 3 (localized behavior in one crate)

```
cargo fmt --check                                          → EXIT=0
cargo check -p trusty-audit --all-targets                  → EXIT=0
cargo clippy -p trusty-audit --all-targets -- -D warnings  → EXIT=0
cargo test -p trusty-audit                                 → 736 passed; 0 failed; 5 ignored (+9 target suites, 0 failed)
bash scripts/check_line_cap.sh                             → 0 violations
bash scripts/check_test_pointers.sh                        → 0 dangling pointers
bash scripts/check_sld.sh                                  → 0 errors, 0 warnings
bash scripts/check_changelog_fragment.sh                   → recorded
```

### Regression proof

`init_writes_an_engagement_without_a_terminal` runs with no terminal, no
network (`PinResolver::Fixed`), and no process-environment read. It asserts the
file loads, carries the key, is mode 0600, and then that `add repo` no longer
fails with `NoEngagementConfig` — which is the exact failure #6159 reports.
Against `main` the test cannot be written at all, because there is no
`Command::Init`; that absence is the defect.

`init_over_an_existing_engagement_changes_nothing` pins idempotence byte for
byte. `init_without_a_key_in_the_environment_refuses` pins that a refusal
leaves no half-written engagement.

Refs #6159

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
