### PR TITLE
fix(trusty-installer): port-guard names the LISTEN holder, not a client connection (Refs #6264)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11590,7 +11590,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-installer"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/crates/trusty-installer/Cargo.toml
+++ b/crates/trusty-installer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-installer"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 description = "Thin control plane for the claude-mpm stack: install, upgrade, restart, health, and config coordination across all trusty-* tools."
 readme = "README.md"

--- a/crates/trusty-installer/changelog.d/6264-port-guard-listen-holder.md
+++ b/crates/trusty-installer/changelog.d/6264-port-guard-listen-holder.md
@@ -1,0 +1,17 @@
+Fixed
+
+- The #4470 foreign-port guard now names the process holding a daemon's port in
+  LISTEN, not the first process `lsof` printed. A client connected TO the port
+  is not a holder of it, and `lsof` lists in PID order, so any client older than
+  the daemon sorted ahead of it — `tctl install` then refused to bootstrap
+  trusty-search with "port 7878 is held by pid ..., which launchd does not
+  supervise" while the launchd-supervised daemon was the actual listener. The
+  probe now asks `lsof` for the per-file TCP state (`-FpT`) and confirms LISTEN
+  itself instead of trusting the `-sTCP:LISTEN` selector to have filtered.
+  - Fail-closed is unchanged: output naming no LISTEN holder is `Unknown` and
+    still refuses, and an `lsof` build that reports no TCP state at all falls
+    back to the previous every-PID reading rather than going blind.
+  - The per-service port table is unchanged. Every daemon `tctl` guards
+    (trusty-search, trusty-memory, trusty-analyze, trusty-review,
+    trusty-console, the trusty-mpm supervisor) still binds a TCP port in its
+    current source, so no entry was stale.

--- a/crates/trusty-installer/src/commands/port_guard.rs
+++ b/crates/trusty-installer/src/commands/port_guard.rs
@@ -44,6 +44,15 @@
 //! the explicit [`ALLOW_FOREIGN_PORT_ENV`] operator override, which downgrades
 //! a refusal to a loud warning and is named in every refusal message.
 //!
+//! #6264: the probe reads `lsof`'s per-file TCP state and reports only a
+//! process holding the port in LISTEN. It used to take the first PID in the
+//! dump and trust `-sTCP:LISTEN` to have removed the clients connected TO the
+//! port; `lsof` lists in PID order, so a client older than the daemon sorted
+//! first and the guard refused a bootstrap over a process that was not holding
+//! the port at all. Every trusty daemon this guard covers still binds TCP
+//! (verified against each crate's source for #6264), so the port table itself
+//! is not stale — only the holder attribution was.
+//!
 //! Test: `port_guard_tests.rs` covers the full [`decide`] table (every
 //! holder × owner combination, both override states), the `lsof` parser, and
 //! the port-resolution precedence. The two subprocess probes are side-effecting
@@ -222,20 +231,62 @@ fn clear_recipe(port: u16, pid: u32) -> String {
     )
 }
 
-/// Extract listening PIDs from `lsof -F p` field output.
+/// Extract the PIDs that hold a LISTEN socket from `lsof -F pT` field output.
 ///
-/// Why: keeping the parse pure and separate from the spawn is what lets the
-/// `Unknown` (fail-closed) branch be reasoned about at all — output that
-/// exists but yields no PID is a parse failure, not an empty port.
-/// What: `lsof -F` emits one field per line, `p<pid>` starting each process
-/// block. Returns every parsed PID in order, ignoring all other field lines.
-/// Test: `parse_lsof_pids_reads_process_blocks`, `parse_lsof_pids_empty`,
-/// `parse_lsof_pids_ignores_other_fields`.
-pub fn parse_lsof_pids(text: &str) -> Vec<u32> {
-    text.lines()
-        .filter_map(|l| l.trim().strip_prefix('p'))
-        .filter_map(|n| n.trim().parse::<u32>().ok())
-        .collect()
+/// Why (#6264): the pre-fix parser returned EVERY PID in the dump and the
+/// caller took the first, trusting the `-sTCP:LISTEN` selector to have removed
+/// the client connections. A process connected TO the port is not a holder of
+/// it, and `lsof` lists processes in PID order, so any client with a lower PID
+/// than the daemon sorts ahead of it — the guard then accuses a client of
+/// squatting and refuses a bootstrap the supervised daemon would have survived.
+/// Reading `lsof`'s own per-file `TST=` state makes LISTEN the parser's
+/// decision instead of a selector's, so a dump that reaches this function with
+/// client rows still in it yields the listener.
+///
+/// What: `lsof -F` emits one field per line; `p<pid>` opens a process block,
+/// `f<fd>` opens a file within it, and `TST=<state>` carries that file's TCP
+/// state. A PID is returned only when one of its files is in `LISTEN`, in
+/// first-seen order, deduplicated (a daemon has several files on its port).
+/// When the dump carries NO `TST=` line at all — an `lsof` build that does not
+/// report TCP state — every PID is returned, which is exactly the pre-fix
+/// behaviour and keeps `-sTCP:LISTEN` as the only filter rather than
+/// classifying a visible holder as invisible.
+///
+/// Test: `parse_lsof_listen_pids_reads_process_blocks`,
+/// `parse_lsof_listen_pids_empty`, `parse_lsof_listen_pids_ignores_other_fields`,
+/// `parse_lsof_listen_pids_skips_client_connections`,
+/// `parse_lsof_listen_pids_without_state_fields_falls_back_to_every_pid`.
+pub fn parse_lsof_listen_pids(text: &str) -> Vec<u32> {
+    let mut current: Option<u32> = None;
+    let mut every: Vec<u32> = Vec::new();
+    let mut listening: Vec<u32> = Vec::new();
+    let mut saw_state = false;
+    for line in text.lines() {
+        let line = line.trim();
+        if let Some(pid) = line
+            .strip_prefix('p')
+            .and_then(|n| n.trim().parse::<u32>().ok())
+        {
+            current = Some(pid);
+            if !every.contains(&pid) {
+                every.push(pid);
+            }
+        } else if let Some(state) = line.strip_prefix("TST=") {
+            saw_state = true;
+            if state.trim() == "LISTEN" {
+                if let Some(pid) = current {
+                    if !listening.contains(&pid) {
+                        listening.push(pid);
+                    }
+                }
+            }
+        }
+    }
+    if saw_state {
+        listening
+    } else {
+        every
+    }
 }
 
 /// The port range a member auto-walks when its default port is taken.
@@ -361,8 +412,11 @@ pub fn decide_over_range(
 /// culprit, but it can distinguish "nothing is there" from "something is there
 /// that I cannot see", which is exactly the missing bit.
 ///
-/// What: runs `lsof -nP -iTCP:<port> -sTCP:LISTEN -Fp`. A parseable PID →
-/// [`PortHolder::Held`] (the first; a port with several listeners is still not
+/// What: runs `lsof -nP -iTCP:<port> -sTCP:LISTEN -FpT`. The `T` field carries
+/// each file's TCP state, so [`parse_lsof_listen_pids`] can confirm LISTEN
+/// itself rather than trusting `-sTCP:LISTEN` to have filtered (#6264). A
+/// listening PID → [`PortHolder::Held`] (the first; a port with several
+/// listeners is still not
 /// ours). No PID → cross-check by binding `127.0.0.1:<port>`: a successful bind
 /// (immediately dropped) is the only thing that yields [`PortHolder::Free`];
 /// `AddrInUse` yields [`PortHolder::Unknown`] naming the invisible holder; any
@@ -381,7 +435,9 @@ pub fn decide_over_range(
 /// the interpretation of each outcome is covered through `decide`.
 fn probe_port_holder(port: u16) -> PortHolder {
     let lsof = std::process::Command::new("lsof")
-        .args(["-nP", &format!("-iTCP:{port}"), "-sTCP:LISTEN", "-Fp"])
+        // #6264: `-FpT` adds the per-file TCP state so the LISTEN decision is
+        // this crate's, not the `-sTCP:LISTEN` selector's.
+        .args(["-nP", &format!("-iTCP:{port}"), "-sTCP:LISTEN", "-FpT"])
         .output();
     let observation = match &lsof {
         Ok(out) => Ok((String::from_utf8_lossy(&out.stdout), out.status.to_string())),
@@ -410,26 +466,27 @@ fn probe_port_holder(port: u16) -> PortHolder {
 /// is precisely the non-root blindness, and makes deleting the cross-check a
 /// test failure.
 ///
-/// What: `Err` (spawn failure) → [`PortHolder::Unknown`]. A parseable PID →
-/// [`PortHolder::Held`]. Non-empty output with no parseable PID →
-/// `Unknown`. EMPTY output → defer to [`port_is_bindable`]; never `Free`
-/// directly.
+/// What: `Err` (spawn failure) → [`PortHolder::Unknown`]. A LISTENING PID →
+/// [`PortHolder::Held`]. Non-empty output naming no listener — unparseable
+/// text, or (since #6264) a dump carrying only client connections → `Unknown`.
+/// EMPTY output → defer to [`port_is_bindable`]; never `Free` directly.
 ///
 /// Test: `empty_lsof_output_on_an_occupied_port_is_unknown_not_free`,
 /// `empty_lsof_output_on_a_free_port_is_free`,
 /// `lsof_naming_a_pid_reports_it_held`, `lsof_spawn_failure_is_unknown`,
-/// `unparseable_lsof_output_is_unknown`.
+/// `unparseable_lsof_output_is_unknown`,
+/// `a_supervised_listener_among_client_rows_is_the_holder`.
 fn probe_port_holder_from(port: u16, observation: Result<(&str, &str), &str>) -> PortHolder {
     let (stdout, status) = match observation {
         Ok(v) => v,
         Err(e) => return PortHolder::Unknown(format!("could not run `lsof`: {e}")),
     };
-    if let Some(pid) = parse_lsof_pids(stdout).first() {
+    if let Some(pid) = parse_lsof_listen_pids(stdout).first() {
         return PortHolder::Held(*pid);
     }
     if !stdout.trim().is_empty() {
         return PortHolder::Unknown(format!(
-            "`lsof` printed output with no parseable pid (exit {status})"
+            "`lsof` printed output naming no LISTEN holder of port {port} (exit {status})"
         ));
     }
     // `lsof` named nobody. That is NOT proof the port is free — see this

--- a/crates/trusty-installer/src/commands/port_guard_tests.rs
+++ b/crates/trusty-installer/src/commands/port_guard_tests.rs
@@ -477,6 +477,37 @@ fn lsof_naming_a_pid_reports_it_held() {
     );
 }
 
+/// Why (#6264): the end-to-end shape of the reported failure. `tctl install`
+/// refused to bootstrap trusty-search with "port 7878 is held by pid 76275,
+/// which launchd does not supervise" while the launchd-supervised daemon was
+/// the actual listener — the PID in the message was a client connected to the
+/// daemon. Asserting through `decide` (not just the parser) is what pins the
+/// operator-visible outcome: the bootstrap must PROCEED.
+/// What: a dump carrying client rows ahead of the supervised listener
+/// classifies as `Held(listener)`, and `decide` with launchd running that same
+/// listener returns `Proceed`.
+/// Test: This is the test.
+#[test]
+fn a_supervised_listener_among_client_rows_is_the_holder() {
+    let holder = probe_port_holder_from(7878, Ok((LISTENER_AMONG_CLIENTS, "exit status: 0")));
+    assert_eq!(
+        holder,
+        PortHolder::Held(77860),
+        "the LISTEN holder is the daemon, not the client that connected to it"
+    );
+    assert_eq!(
+        decide(
+            "trusty-search",
+            7878,
+            &holder,
+            LaunchdOwner::Running(77860),
+            false
+        ),
+        PortVerdict::Proceed,
+        "a bootstrap over the supervised daemon's own port must not be refused"
+    );
+}
+
 /// Why: `lsof` missing from `PATH` or failing to spawn is an unanswerable
 /// probe, which the fail-closed contract turns into a refusal — never a pass.
 /// What: an `Err` observation classifies as `Unknown` relaying the cause.
@@ -506,15 +537,49 @@ fn unparseable_lsof_output_is_unknown() {
 
 // ── the lsof field parser ───────────────────────────────────────────────────
 
+/// A real `lsof -nP -iTCP:7878 -FpT` dump, captured on the reporting machine
+/// while the launchd-supervised trusty-search daemon served six live clients.
+///
+/// Why: the #6264 refusal named a PID that was never the listener, and a
+/// hand-written fixture could have encoded the wrong shape and agreed with the
+/// bug. The only edit to the captured bytes is the listener's PID, lowered from
+/// `19554` to `77860` so it sorts AFTER the clients — the ordering that makes
+/// the pre-fix `first()` pick a client. Clients `19554` and `19555` stand in
+/// for the trusty-review and trusty-analyze processes that were connected.
+const LISTENER_AMONG_CLIENTS: &str = "\
+p19554
+f13
+TST=ESTABLISHED
+TQR=0
+TQS=0
+p19555
+f9
+TST=ESTABLISHED
+TQR=0
+TQS=0
+p77860
+f10
+TST=LISTEN
+TQR=0
+TQS=0
+f71
+TST=ESTABLISHED
+TQR=0
+TQS=0
+";
+
 /// Why: the PID the refusal names comes straight out of this parser; a wrong
 /// PID makes the guard's remediation dangerous (it would tell an operator to
 /// kill the wrong process).
-/// What: parses a realistic `lsof -Fp` block and recovers the PID.
+/// What: parses a realistic `lsof -FpT` block and recovers the PID.
 /// Test: This is the test.
 #[test]
-fn parse_lsof_pids_reads_process_blocks() {
-    assert_eq!(parse_lsof_pids("p4242\n"), vec![4242]);
-    assert_eq!(parse_lsof_pids("p4242\np555\n"), vec![4242, 555]);
+fn parse_lsof_listen_pids_reads_process_blocks() {
+    assert_eq!(parse_lsof_listen_pids("p4242\nTST=LISTEN\n"), vec![4242]);
+    assert_eq!(
+        parse_lsof_listen_pids("p4242\nTST=LISTEN\np555\nTST=LISTEN\n"),
+        vec![4242, 555]
+    );
 }
 
 /// Why: `lsof` prints nothing when the filter matches no listener; that empty
@@ -523,21 +588,50 @@ fn parse_lsof_pids_reads_process_blocks() {
 /// What: empty and whitespace-only input parse to no pids.
 /// Test: This is the test.
 #[test]
-fn parse_lsof_pids_empty() {
-    assert!(parse_lsof_pids("").is_empty());
-    assert!(parse_lsof_pids("\n \n").is_empty());
+fn parse_lsof_listen_pids_empty() {
+    assert!(parse_lsof_listen_pids("").is_empty());
+    assert!(parse_lsof_listen_pids("\n \n").is_empty());
 }
 
-/// Why: `-Fp` is a request, not a guarantee — `lsof` still emits other field
+/// Why: `-FpT` is a request, not a guarantee — `lsof` still emits other field
 /// lines in some configurations, and a parser that accepted them would produce
 /// garbage PIDs (an `f` descriptor number read as a process id).
-/// What: only `p`-prefixed numeric lines are read; command/user/descriptor
-/// fields are ignored.
+/// What: only `p`-prefixed numeric lines are read as PIDs; command, user,
+/// descriptor and name fields are ignored.
 /// Test: This is the test.
 #[test]
-fn parse_lsof_pids_ignores_other_fields() {
-    let text = "p4242\ncmd-trusty-search\nu501\nf7\nn127.0.0.1:7878\n";
-    assert_eq!(parse_lsof_pids(text), vec![4242]);
+fn parse_lsof_listen_pids_ignores_other_fields() {
+    let text = "p4242\ncmd-trusty-search\nu501\nf7\nn127.0.0.1:7878\nTST=LISTEN\n";
+    assert_eq!(parse_lsof_listen_pids(text), vec![4242]);
+}
+
+/// Why (#6264): THE regression test. `lsof` lists processes in PID order, so a
+/// client connected TO the port that started before the daemon sorts ahead of
+/// it. The pre-fix parser returned every PID and the caller took the first, so
+/// the guard named a client as the port's holder — and since launchd does not
+/// supervise that client, `decide` produced the #4230 orphan refusal against a
+/// healthy install. Under the pre-fix parser this asserts `77860` and gets
+/// `19554`.
+/// What: a captured dump whose listener sorts last still yields the listener,
+/// and no client PID appears at all.
+/// Test: This is the test.
+#[test]
+fn parse_lsof_listen_pids_skips_client_connections() {
+    assert_eq!(parse_lsof_listen_pids(LISTENER_AMONG_CLIENTS), vec![77860]);
+}
+
+/// Why: an `lsof` build that reports no TCP state at all would otherwise make
+/// every visible holder invisible, turning a guard that names the squatter into
+/// one that can only say "something is there" — a worse refusal, not a safer
+/// one. `-sTCP:LISTEN` remains the filter in that case, exactly as before.
+/// What: a dump with no `TST=` line yields every PID in it.
+/// Test: This is the test.
+#[test]
+fn parse_lsof_listen_pids_without_state_fields_falls_back_to_every_pid() {
+    assert_eq!(
+        parse_lsof_listen_pids("p4242\nf7\np555\nf9\n"),
+        vec![4242, 555]
+    );
 }
 
 // ── port resolution ─────────────────────────────────────────────────────────


### PR DESCRIPTION
Refs #6264.

The reported refusal was not a stale port-table entry. The guard named a process
connected TO port 7878, not the process holding it: `probe_port_holder` took the
first PID `lsof` printed and trusted the `-sTCP:LISTEN` selector to have removed
the clients. `lsof` lists in PID order, so any client older than the daemon sorts
ahead of it, and the launchd-supervised listener then reads as an unsupervised
orphan. The probe now requests the per-file TCP state (`-FpT`) and confirms
LISTEN itself.

Fail-closed is unchanged: a dump naming no LISTEN holder is `Unknown` and still
refuses; an `lsof` build reporting no TCP state falls back to the previous
every-PID reading rather than going blind.

## Transport map — verified against each crate's current source

| Service | Transport today | Source | Guard |
|---|---|---|---|
| trusty-search | TCP 7878, walks up to 64 ports | `service/daemon.rs:673` `bind_with_auto_port` | stays |
| trusty-memory | TCP 7070 | `http_server.rs:315`, `foreground.rs:42` | stays |
| trusty-analyze | TCP 7879 | `commands/run.rs:110`, `commands/daemon.rs` | stays |
| trusty-review | TCP 7890/7891 | `service/mod.rs:151` | stays |
| trusty-console | TCP 7788 | `bind.rs:224` | stays |
| trusty-mpm | TCP 7880; supervisor metrics 7881 | `bin/tm/commands/daemon_run.rs:131` | stays |
| tga | no daemon | no bind site outside tests | n/a |
| trusty-installer | no daemon | n/a | n/a |

No installer-guarded service is UDS-only, so no port-table entry was deleted or
narrowed. UDS in this workspace is confined to trusty-agents (ctrl socket, bus),
trusty-embedderd, and the trusty-common webhook relay — none of them installer
members. The live fleet agrees: every daemon on this machine is TCP on loopback
and no UDS socket file exists for it.

"Only trusty-console holds a TCP port" is therefore target architecture, not the
code's present state. Migrating the daemons themselves is the remaining
architecture work under #6264 and is not in this PR.

## Follow-ups, not built here

- `walk_range_for` records trusty-memory as the only stable-set walker.
  trusty-search's daemon walks 64 ports from its start port, so a busy 7878 is
  not the hard failure the guard treats it as — and a walk from 7878 reaches
  7879, trusty-analyze's port.
- UDS services, once any exist, need the analogous guard: a stale socket file or
  a foreign process bound to the path.

## Gates — test ladder rung 3 (localized behavior in one crate)

```
cargo fmt --check                                      EXIT=0
cargo check -p trusty-installer                        EXIT=0
cargo clippy -p trusty-installer --all-targets -- -D warnings   EXIT=0
cargo test -p trusty-installer                         EXIT=0
  test result: ok. 660 passed; 0 failed; 4 ignored
bash scripts/check_line_cap.sh                         0 violations
bash scripts/check_changelog_fragment.sh               OK
bash scripts/check_sld.sh                              0 errors
```

Regression proof — with the parser reverted to its pre-fix every-PID reading,
both new tests fail with the reported symptom:

```
parse_lsof_listen_pids_skips_client_connections ... FAILED
  left: [19554, 19555, 77860]
 right: [77860]
a_supervised_listener_among_client_rows_is_the_holder ... FAILED
  left: Held(19554)
 right: Held(77860)
```

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
