### PR TITLE
test(trusty-mpm): sync bundled skill heading pin with #5843

### DIFF
--- a/crates/trusty-mpm/src/core/bundle_tests.rs
+++ b/crates/trusty-mpm/src/core/bundle_tests.rs
@@ -1040,7 +1040,7 @@ fn idle_park_mitigation_2833_guidance_survives_composition() {
          guidance the prompt now points at (#2833)"
     );
     assert!(
-        skill.contains("## PM Re-Engagement (issues #2833, #4792)"),
+        skill.contains("## PM Re-Engagement (issues #2833, #4792, #5843)"),
         "tm-delegation-patterns must carry the PM Re-Engagement section the \
          prompt names by title (#2833, #4792)"
     );


### PR DESCRIPTION
## Summary
- `idle_park_mitigation_2833_guidance_survives_composition` in `crates/trusty-mpm/src/core/bundle_tests.rs` pins the exact text of `tm-delegation-patterns.md`'s `## PM Re-Engagement` heading.
- #6237 added `#5843` to that heading but did not update the pinned assertion, so the test fails on every push to `main` — including the `Rust tests (pre-publish gate)` shard suite (shard 4 of 8) that gates every crate release via `scripts/preflight-publish.sh`.
- One-line fix: the assertion now expects `## PM Re-Engagement (issues #2833, #4792, #5843)`, matching the doc as it stands.

## Test plan
- Rung 2 (test-only stabilization): `cargo fmt --check -p trusty-mpm` — clean.
- `cargo test -p trusty-mpm --lib core::bundle::tests::idle_park_mitigation_2833_guidance_survives_composition -- --exact` — was FAILED, now `ok`.
- `cargo test -p trusty-mpm` (full crate suite) — `5275 passed; 0 failed; 7 ignored` (plus all other lib/integration binaries green).

Refs #5843

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools