### PR TITLE
chore(trusty-agents-common): bump to 0.6.2 — 0.6.1 stranded

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11191,7 +11191,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-agents-common"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-agents-common/Cargo.toml
+++ b/crates/trusty-agents-common/Cargo.toml
@@ -7,7 +7,7 @@ name = "trusty-agents-common"
 # preview_unmanaged_bundled_skills, audit_agent_tier all gained a fallible
 # Result-wrapped return; TierAuditError is a new public type) — for a 0.y.z
 # crate, Cargo's rule makes the MINOR position the breaking position.
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary
- `trusty-agents-common-v0.6.1` was tagged against `6f714a233`, which carried a permanently-red `Rust tests (pre-publish gate)` shard (shard 4/8, fixed on main by #6266). Because release tags are ruleset-immutable here, that commit's gate run can never be re-run green, so the tag is stranded per the repo's documented protocol (CLAUDE.md, "Release tags here are immutable").
- Version line only: `0.6.1` -> `0.6.2` in `crates/trusty-agents-common/Cargo.toml`, and the matching `Cargo.lock` entry. No source change.

## Test plan
- `cargo check -p trusty-agents-common --locked` — clean, confirms the lockfile update is exact (no incidental refresh).

Part of the trusty-agents-common/trusty-common/trusty-mpm/trusty-audit/trusty-review/trusty-installer/tga/trusty-analyze publish wave.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools