### PR TITLE
docs: the tm daemon is self-managed, and trusty-mpm is not a claude-mpm successor (Refs #6270)

### DIFF
--- a/docs/architecture/port-assignments.md
+++ b/docs/architecture/port-assignments.md
@@ -51,7 +51,7 @@ else's guard test too).
 | 7788 | `trusty-console` | `trusty-console/src/lib.rs::DEFAULT_PORT` | Yes |
 | 7878 | `trusty-search` | `trusty-search/src/service/constants.rs::DEFAULT_PORT` | Yes |
 | 7879 | `trusty-analyze` | `trusty-analyze/src/service/events.rs::DEFAULT_PORT` | Yes |
-| 7880 | `trusty-mpm` daemon (`trusty-mpmd` / `tm`) | `trusty-mpm/src/core/discovery.rs::DEFAULT_DAEMON_ADDR` | Yes |
+| 7880 | `trusty-mpm` daemon (`trusty-mpmd` / `tm`) | `trusty-mpm/src/core/discovery.rs::DEFAULT_DAEMON_ADDR` | No |
 | 7881 | `trusty-mpm` **supervisor** metrics/health listener — a distinct process from the 7880 daemon above | `trusty-mpm/src/supervisor/config.rs::DEFAULT_METRICS_ADDR` | Yes |
 | 7882 | `trusty-code` (`tcode serve --http`) | `trusty-code/src/serve/mod.rs::DEFAULT_HTTP_PORT` (mirrored by `trusty-code-gui/src/state.rs::DEFAULT_DAEMON_URL`) | No (#3364 follow-up) |
 | 7890 | `trusty-embedderd` `--http` mode (manual/dev-run only; auto-spawn always uses `--stdio`/UDS) | `trusty-embedderd/src/lib.rs::Args::http_addr` | No |

--- a/docs/getting-started/claude-mpm-vs-trusty-mpm.md
+++ b/docs/getting-started/claude-mpm-vs-trusty-mpm.md
@@ -2,7 +2,7 @@
 
 ## The 30-Second Answer
 
-**trusty-mpm** (`tm`) is the **Rust** successor to the Python `claude-mpm` project. Both are session orchestrators, but trusty-mpm is a rebuilt, production-grade system with:
+**trusty-mpm** (`tm`) is a **Rust** implementation of agent orchestration. It shares the same orchestration **concepts** with the Python `claude-mpm` project (session management, PM/agent/skill delegation), but is an independent implementation with no code relation, different maintainers, and different distribution channels. trusty-mpm is production-grade with:
 - **Single binary:** `tm` (instead of scattered Python packages)
 - **Managed daemons:** Runs trusty-memory and trusty-search as system services, not ad-hoc
 - **Main-checkout by default, worktrees on request:** A session runs on the project's main checkout unless launched with `--worktree`; a main-checkout session and every agent it dispatches may write documents and configuration only, and a dispatched agent that writes is automatically granted its own git worktree, cleaned up on decommission


### PR DESCRIPTION
## Summary
Two documentation corrections to align claims with source code and the canonical identity doc:

1. **port-assignments.md:** Fixed trusty-mpm daemon as self-managed (not launchd-managed) per `crates/trusty-installer/src/commands/stable_set.rs`
2. **claude-mpm-vs-trusty-mpm.md:** Corrected identity from "successor" to "independent implementation" per `crates/trusty-mpm/docs/WHAT-IS-TRUSTY-MPM.md`

Closes #6270.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools