### PR TITLE
feat(website): kuzu-memory data migration section on /claude-mpm-migration (Refs #6268)

### DIFF
--- a/website/src/routes/claude-mpm-migration/+page.svelte
+++ b/website/src/routes/claude-mpm-migration/+page.svelte
@@ -31,6 +31,16 @@
 	 *     is, and the code is the one that decides.
 	 *   - ports and the loopback guards — `docs/architecture/port-assignments.md`
 	 *     and `docs/reference/threat-model.md`
+	 *   - the kuzu-memory targets, their required flags, and the idempotency
+	 *     claims — `crates/trusty-memory/src/commands/migrate.rs` and
+	 *     `src/main.rs`'s `Migrate` variant; the importer's behaviour and the
+	 *     four refused predicates —
+	 *     `crates/trusty-memory/src/commands/kuzu_migrate.rs` and
+	 *     `crates/trusty-memory/src/prompt_facts.rs::HOT_PREDICATES`, pinned by
+	 *     `kuzu_migrate_refuses_hot_predicates_and_passes_cold_ones`. There is
+	 *     no default `--from` path: the handler errors when it is absent, so
+	 *     the `~/.open-mpm/...` path in the example is kuzu-memory's own
+	 *     convention rather than a default this command applies.
 	 *
 	 * claude-mpm claims are deliberately general — a Python package on PyPI
 	 * that discovers everything through the real `~/.claude`. Nothing about its
@@ -478,6 +488,86 @@ tm --version</pre>
 			</p>
 		</div>
 
+		<!-- ============ kuzu-memory ============ -->
+		<div class="min-w-0">
+			<h2 id="kuzu" class="scroll-mt-24 font-display text-2xl font-bold sm:text-3xl">
+				Migrating your kuzu-memory data
+			</h2>
+			<p class="mt-4 max-w-3xl text-foundry-secondary">
+				If the memory server you were running is <code class="text-sm">kuzu-memory</code>,
+				trusty-memory migrates it for you rather than leaving you to re-enter anything.
+				<code class="text-sm">trusty-memory migrate</code> takes two targets, and they are independent:
+				one rewrites configuration, the other moves data. Most people want both, in that order.
+			</p>
+
+			<h3 class="mt-8 font-display text-lg font-semibold text-foundry-text">
+				<code class="text-base">kuzu-memory</code> — the configuration
+			</h3>
+			<p class="mt-3 max-w-3xl text-foundry-secondary">
+				Scans every <code class="text-sm">.claude/settings.json</code> and
+				<code class="text-sm">settings.local.json</code> under your home directory, drops any
+				<code class="text-sm">kuzu-memory</code> or <code class="text-sm">kuzu_memory</code>
+				entry from the <code class="text-sm">mcpServers</code> block, and inserts a canonical
+				<code class="text-sm">trusty-memory</code> one in its place. Unrelated keys survive, each
+				write is atomic with a <code class="text-sm">.bak</code> alongside it, and a file already
+				carrying a <code class="text-sm">trusty-memory</code> entry is left byte-for-byte alone — so running
+				it twice is safe.
+			</p>
+
+			<div class="mt-6 max-w-xl min-w-0">
+				<p class="eyebrow">shell — look first, then write</p>
+				<pre
+					class="mt-2 overflow-x-auto rounded-sm border border-foundry-border bg-foundry-card p-3 text-xs leading-relaxed text-foundry-text">trusty-memory migrate kuzu-memory --dry-run
+trusty-memory migrate kuzu-memory</pre>
+			</div>
+
+			<h3 class="mt-8 font-display text-lg font-semibold text-foundry-text">
+				<code class="text-base">kuzu-data</code> — the memories themselves
+			</h3>
+			<p class="mt-3 max-w-3xl text-foundry-secondary">
+				Reads a kuzu-memory <code class="text-sm">store.redb</code> and imports it into a palace:
+				every entity becomes a drawer, every relation becomes a knowledge-graph triple. There is no
+				default source path — <code class="text-sm">--from</code> and
+				<code class="text-sm">--palace</code> are both required, and the command errors naming the missing
+				one rather than guessing. The palace is created if it does not exist yet. Re-running it changes
+				nothing: drawer ids come from a stable hash of the entity id and the palace name, and an existing
+				triple is skipped rather than duplicated.
+			</p>
+
+			<div class="mt-6 max-w-xl min-w-0">
+				<p class="eyebrow">shell</p>
+				<pre
+					class="mt-2 overflow-x-auto rounded-sm border border-foundry-border bg-foundry-card p-3 text-xs leading-relaxed text-foundry-text">trusty-memory migrate kuzu-data \
+  --from ~/.open-mpm/memory/store.redb \
+  --palace your-project --dry-run</pre>
+			</div>
+
+			<p class="mt-4 max-w-3xl text-sm text-foundry-secondary">
+				<code class="text-sm">--dry-run</code> prints the schema it found and the plan without
+				writing. <code class="text-sm">--limit &lt;N&gt;</code> caps how many entities are imported,
+				which is the way to try it on a slice before committing to the whole store. Drop
+				<code class="text-sm">--dry-run</code> to run it for real.
+			</p>
+
+			<div class="card mt-8 max-w-3xl">
+				<p class="eyebrow">One class of triple does not come across</p>
+				<p class="mt-3 text-foundry-secondary">
+					Four predicates — <code class="text-sm">is_alias_for</code>,
+					<code class="text-sm">has_convention</code>, <code class="text-sm">is_fact</code>, and
+					<code class="text-sm">is_shorthand_for</code> — put a fact on the surface injected into
+					every turn of every session, and the importer refuses them outright. A bulk import of a
+					legacy file is not somebody deciding a standing rule should be in front of every session,
+					so a relation whose type collides with one of the four is logged and skipped while the
+					rest of the import continues. Ordinary relation types —
+					<code class="text-sm">relates_to</code>, <code class="text-sm">mentions</code>,
+					<code class="text-sm">derived_from</code>, <code class="text-sm">part_of</code>,
+					<code class="text-sm">alias_of</code> — are unaffected. If one of the four really was a
+					standing rule, re-assert it with <code class="text-sm">kg_assert</code>, which is the
+					deliberate path and carries the real gate.
+				</p>
+			</div>
+		</div>
+
 		<!-- ============ where sessions run ============ -->
 		<div class="min-w-0">
 			<h2 class="font-display text-2xl font-bold sm:text-3xl">Where the work happens</h2>
@@ -535,6 +625,29 @@ tm --version</pre>
 				<span aria-hidden="true" class="w-5 shrink-0 font-mono text-sm text-foundry-primary">3</span
 				>
 				<div class="min-w-0">
+					<p class="font-semibold text-foundry-text">
+						Bring your kuzu-memory data across — only if you ran it.
+					</p>
+					<p class="mt-1 text-sm">
+						<code class="text-xs">trusty-memory migrate kuzu-memory</code> repoints the MCP config,
+						then
+						<code class="text-xs"
+							>trusty-memory migrate kuzu-data --from &lt;store.redb&gt; --palace &lt;name&gt;</code
+						>
+						imports the memories. Both take
+						<code class="text-xs">--dry-run</code>, and both are safe to re-run.
+						<a
+							href="#kuzu"
+							class="text-foundry-primary underline decoration-1 underline-offset-2 hover:decoration-2"
+							>The full section</a
+						> covers what each one touches and the one class of triple it declines to import.
+					</p>
+				</div>
+			</li>
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="w-5 shrink-0 font-mono text-sm text-foundry-primary">4</span
+				>
+				<div class="min-w-0">
 					<p class="font-semibold text-foundry-text">Register the project.</p>
 					<p class="mt-1 text-sm">
 						From the project directory, <code class="text-xs">tm project init</code> registers it with
@@ -544,7 +657,7 @@ tm --version</pre>
 				</div>
 			</li>
 			<li class="flex gap-3">
-				<span aria-hidden="true" class="w-5 shrink-0 font-mono text-sm text-foundry-primary">4</span
+				<span aria-hidden="true" class="w-5 shrink-0 font-mono text-sm text-foundry-primary">5</span
 				>
 				<div class="min-w-0">
 					<p class="font-semibold text-foundry-text">Clear a stale output style.</p>
@@ -559,7 +672,7 @@ tm --version</pre>
 				</div>
 			</li>
 			<li class="flex gap-3">
-				<span aria-hidden="true" class="w-5 shrink-0 font-mono text-sm text-foundry-primary">5</span
+				<span aria-hidden="true" class="w-5 shrink-0 font-mono text-sm text-foundry-primary">6</span
 				>
 				<div class="min-w-0">
 					<p class="font-semibold text-foundry-text">Verify before you start work.</p>
@@ -573,7 +686,7 @@ tm --version</pre>
 				</div>
 			</li>
 			<li class="flex gap-3">
-				<span aria-hidden="true" class="w-5 shrink-0 font-mono text-sm text-foundry-primary">6</span
+				<span aria-hidden="true" class="w-5 shrink-0 font-mono text-sm text-foundry-primary">7</span
 				>
 				<div class="min-w-0">
 					<p class="font-semibold text-foundry-text">Start a session.</p>
@@ -590,6 +703,7 @@ tm --version</pre>
 			<p class="eyebrow">shell — the whole thing</p>
 			<pre
 				class="mt-2 overflow-x-auto rounded-sm border border-foundry-border bg-foundry-card p-3 text-xs leading-relaxed text-foundry-text">tm install
+trusty-memory migrate kuzu-memory      # only if you ran kuzu-memory
 cd ~/your-project
 tm project init
 tm doctor

--- a/website/tests/build-smoke.test.ts
+++ b/website/tests/build-smoke.test.ts
@@ -343,6 +343,21 @@ describe('production build', () => {
 		expect(text, 'tmux is not covered').toContain('tmux');
 		expect(text, 'the verification step is missing').toContain('tm doctor');
 
+		// The kuzu-memory section. Both targets are named because they do
+		// different jobs — one rewrites config, the other moves data — and a
+		// page carrying only one of them sends a reader away with half a
+		// migration. The two required flags are asserted with `kuzu-data`
+		// because the command hard-errors without them, so a page that omits
+		// them documents an invocation that cannot run.
+		expect(text, 'the config target is missing').toContain('trusty-memory migrate kuzu-memory');
+		expect(text, 'the data target is missing').toContain('trusty-memory migrate kuzu-data');
+		for (const flag of ['--from', '--palace', '--dry-run', '--limit']) {
+			expect(text, `${flag} is not documented`).toContain(flag);
+		}
+		// The refusal caveat, and the predicate that stands in for the four.
+		expect(text, 'the hot-predicate refusal is missing').toContain('is_alias_for');
+		expect(text, 'kg_assert is not named as the deliberate path').toContain('kg_assert');
+
 		// Reachable: from every page's nav/footer, and from the tool page.
 		expect(landingPage, 'nav does not link the migration page').toContain(
 			`href="${MIGRATION_ROUTE}"`


### PR DESCRIPTION
trusty-memory ships an auto-migration for kuzu-memory and the page said
nothing about it, so a reader coming off that server had no way to know their
memories could come across rather than be re-entered by hand.

## What the section covers

Both `trusty-memory migrate` targets, which do different jobs and are
independent of each other:

- **`kuzu-memory`** — scans every `.claude/settings.json` and
  `settings.local.json` under `$HOME`, drops any `kuzu-memory` /
  `kuzu_memory` entry from `mcpServers`, and inserts a canonical
  `trusty-memory` one. Unrelated keys survive, writes are atomic with a
  `.bak`, and an already-migrated file is left byte-for-byte alone.
- **`kuzu-data`** — reads a kuzu-memory `store.redb` and imports entities as
  drawers, relations as knowledge-graph triples. Idempotent: drawer ids come
  from a stable hash of the entity id and palace name.

Both `--from` and `--palace` are documented as required, because the handler
hard-errors naming the missing flag — a page that omitted them would document
an invocation that cannot run. `--dry-run` and `--limit <N>` are covered as
the way to look before committing.

**There is no default `--from` path.** The `~/.open-mpm/memory/store.redb` in
the example is named as kuzu-memory's own convention, not as a default this
command applies — `kuzu_migrate.rs`'s module doc is explicit that no live
store was available when the importer was written and the schema is inferred.

## The caveat, in a card

The importer refuses the four Tier S predicates — `is_alias_for`,
`has_convention`, `is_fact`, `is_shorthand_for` — outright. A bulk import of a
legacy file is not somebody deciding a standing rule belongs in front of every
session, so a colliding relation is logged and skipped while the rest of the
import continues. Ordinary relation types (`relates_to`, `mentions`,
`derived_from`, `part_of`, `alias_of`) are unaffected, and `kg_assert` is named
as the deliberate path for a fact that really was a standing rule.

## Checklist

Now seven steps. The migration lands after `tm install` and before
`tm project init`, marked as applying only if you ran kuzu-memory, and links
down to the full section. The closing copy-paste block carries the config
rewrite with an inline `# only if you ran kuzu-memory` comment.

## Sources verified against

`crates/trusty-memory/src/commands/migrate.rs` (targets, idempotency,
`.bak` + atomic write), `crates/trusty-memory/src/main.rs` (the `Migrate`
variant's flags and which are `Option`), `crates/trusty-memory/src/commands/
kuzu_migrate.rs` (the importer, the entity/relation mapping, the refusal
branch), `crates/trusty-common/src/claude_config.rs`
(`discover_claude_settings` — which files it actually walks), and
`crates/trusty-memory/src/prompt_facts.rs::HOT_PREDICATES` for the four
predicate names, pinned by
`kuzu_migrate_refuses_hot_predicates_and_passes_cold_ones`. The page's own
script block records all of it.

## Tests

`tests/build-smoke.test.ts`'s migration-page case gains assertions for both
target invocations, all four flags (`--from`, `--palace`, `--dry-run`,
`--limit`), the refusal caveat via `is_alias_for`, and `kg_assert` as the
named alternative. The page also stays in the 320/375px overflow matrix,
which matters here because the section adds two more `<pre>` blocks.

```
pnpm lint    → All matched files use Prettier code style! (+ eslint clean)
pnpm check   → COMPLETED 494 FILES 0 ERRORS 0 WARNINGS 0 FILES_WITH_PROBLEMS
pnpm build   → ✓ built in 3.27s · Using @sveltejs/adapter-vercel ✔ done
pnpm test    → Test Files 14 passed (14) · Tests 268 passed (268)
```

Website-only, so no crate changelog fragment and no cargo gates.

Refs #6268

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
