### PR TITLE
feat(trusty-mpm): tm in a non-git directory initializes git and proceeds (Refs #6274)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11695,7 +11695,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-mpm"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-mpm"
-version = "1.5.1"
+version = "1.5.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/trusty-mpm/changelog.d/6274-non-git-auto-init.md
+++ b/crates/trusty-mpm/changelog.d/6274-non-git-auto-init.md
@@ -1,0 +1,13 @@
+Added
+
+- `tm` and `tm launch` in a directory that is not a git repository now run
+  `git init` there and carry on, instead of stopping at "not in a git project"
+  or "no git origin remote found"
+  ([#6274](https://github.com/bobmatnyc/trusty-tools/issues/6274)). The
+  repository lands in the invocation directory, a one-line
+  `tm: initialized git in <path>` notice says so, and everything after that runs
+  exactly as it does for a git repository with no origin remote. Three
+  directories are left alone: the home directory and the filesystem root refuse
+  with a stated reason, and a directory that already has a repository — its own,
+  an ancestor's work tree, or a bare repo — is untouched. A missing `git`
+  executable is a prerequisite error naming git; nothing is written in that case.

--- a/crates/trusty-mpm/src/bin/tm/commands/auto_git_init.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/auto_git_init.rs
@@ -1,0 +1,286 @@
+//! Auto-`git init` when `tm` is invoked in a directory that is not a git
+//! repository (#6274).
+//!
+//! Why: `tm` used to stop at the front door of a plain directory. Bare `tm`
+//! printed [`super::misc::NON_GIT_FALLBACK_HINT`] ("not in a git project") and
+//! did nothing; `tm launch` failed with "no git origin remote found". The
+//! operator's next move was always the same — run `git init`, re-run `tm`. This
+//! module takes that step for them and then lets the ordinary flow continue
+//! exactly as it does for a git repository with no origin remote.
+//! What: [`ensure_git_repo`] probes for an existing repository, applies the
+//! sanity guards, runs `git init`, and prints a one-line notice. The decision
+//! is the pure [`plan_auto_init`]; the "is there a repository here" stderr
+//! discrimination is the pure [`stderr_means_no_repository`]. Nothing here
+//! installs the `git` executable — a missing `git` is a prerequisite error.
+//! Test: `auto_git_init_tests.rs`.
+
+use std::path::Path;
+
+/// The git executable this module drives.
+const GIT_PROGRAM: &str = "git";
+
+/// The stderr phrase that means git found no repository at or above a
+/// directory.
+///
+/// Why: the SHORT phrase `not a git repository` is ambiguous in this codebase —
+/// git answers `fatal: not a git repository: (null)` for a STALE WORKTREE
+/// POINTER, which is a broken repository rather than no repository at all.
+/// Matching the long phrase is the same discrimination
+/// `trusty_agents_common::agents::vcs_claim` and `trusty_review::report::scan`
+/// already make. Anything else that fails is reported, never auto-initialized.
+const NO_REPO_STDERR: &str = "not a git repository (or any of the parent directories)";
+
+/// Whether git already has a repository for the directory.
+///
+/// Why: "is this a repo" must catch MORE than a work tree — a bare repository
+/// answers `rev-parse --show-toplevel` with a failure while being very much a
+/// repository, and `git init` there re-initializes it. `rev-parse --git-dir`
+/// answers the broader question once: a work tree at any depth, a bare repo, or
+/// the inside of a `.git` directory all report `Present`.
+/// Test: `auto_init_leaves_a_repo_root_alone`,
+/// `auto_init_does_not_init_inside_another_work_tree`,
+/// `auto_init_leaves_a_bare_repository_alone`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RepoContext {
+    /// Git reports a repository for this directory.
+    Present,
+    /// Git reports no repository at or above this directory.
+    Absent,
+}
+
+/// Why a sanity guard refused to create a repository.
+///
+/// Why: `git init` writes a `.git` directory that git then treats as a
+/// project root for every descendant. In `$HOME` or at `/` that is a
+/// long-lived mistake nobody asked for, so those two directories refuse
+/// rather than initialize.
+/// Test: `plan_refuses_the_home_directory`, `plan_refuses_the_filesystem_root`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AutoInitRefusal {
+    /// The directory is the operator's home directory.
+    HomeDirectory,
+    /// The directory is the filesystem root.
+    FilesystemRoot,
+}
+
+/// The decision [`ensure_git_repo`] acts on.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum AutoInitPlan {
+    /// A repository is already here — do nothing.
+    AlreadyGit,
+    /// No repository and no guard fired — run `git init`.
+    Init,
+    /// No repository, but a guard refused to create one.
+    Refuse(AutoInitRefusal),
+}
+
+/// What [`ensure_git_repo`] actually did.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum AutoInitOutcome {
+    /// The directory already had a repository; nothing was written.
+    AlreadyGit,
+    /// `git init` ran here.
+    Initialized,
+    /// A sanity guard refused; the reason was printed to stderr.
+    Refused(AutoInitRefusal),
+    /// The path is not an existing directory, so there is nothing to
+    /// initialize. The caller's own resolution error is the better message,
+    /// so this arm stays silent and writes nothing.
+    NotADirectory,
+}
+
+/// Does a failed `git rev-parse` stderr mean "there is no repository here"?
+///
+/// Why: see [`NO_REPO_STDERR`] — a substring test on the short phrase also
+/// matches a BROKEN repository, and auto-initializing over one of those is the
+/// worst thing this module could do. Fails closed: an unrecognised failure is
+/// not "no repository".
+/// What: `true` only when the long phrase appears in `stderr`.
+/// Test: `no_repo_stderr_matches_the_long_phrase`,
+/// `no_repo_stderr_rejects_the_stale_worktree_pointer`.
+pub(crate) fn stderr_means_no_repository(stderr: &str) -> bool {
+    stderr.contains(NO_REPO_STDERR)
+}
+
+/// Decide what to do about `dir`, given git's verdict and the home directory.
+///
+/// Why: the whole decision, free of process spawning and filesystem access, so
+/// every arm is asserted directly. `context` is checked FIRST so a home
+/// directory (or `/`) that IS already a repository keeps behaving exactly as it
+/// does today — the guards only ever prevent a NEW repository.
+/// What: `AlreadyGit` when git reports a repository; `Refuse` when `dir` is the
+/// filesystem root or the home directory; `Init` otherwise. `dir` and `home`
+/// are expected canonicalized by the caller so the comparison is not defeated
+/// by a symlinked `$HOME`.
+/// Test: `plan_initializes_a_plain_directory`, `plan_refuses_the_home_directory`,
+/// `plan_refuses_the_filesystem_root`,
+/// `plan_leaves_an_existing_repo_alone_even_in_the_home_directory`.
+pub(crate) fn plan_auto_init(
+    dir: &Path,
+    home: Option<&Path>,
+    context: RepoContext,
+) -> AutoInitPlan {
+    if context == RepoContext::Present {
+        return AutoInitPlan::AlreadyGit;
+    }
+    if dir.parent().is_none() {
+        return AutoInitPlan::Refuse(AutoInitRefusal::FilesystemRoot);
+    }
+    if home == Some(dir) {
+        return AutoInitPlan::Refuse(AutoInitRefusal::HomeDirectory);
+    }
+    AutoInitPlan::Init
+}
+
+/// The one-line notice printed after a successful `git init`.
+///
+/// Test: `initialized_message_names_the_directory`.
+pub(crate) fn initialized_message(dir: &Path) -> String {
+    format!("tm: initialized git in {}", dir.display())
+}
+
+/// The stderr notice printed when a sanity guard refuses.
+///
+/// Why: a refusal that does not say WHY reads as a malfunction. Each arm names
+/// the directory and the specific reason it is not a project.
+/// Test: `refusal_message_names_the_home_directory`,
+/// `refusal_message_names_the_filesystem_root`.
+pub(crate) fn refusal_message(refusal: AutoInitRefusal, dir: &Path) -> String {
+    let reason = match refusal {
+        AutoInitRefusal::HomeDirectory => "that is your home directory, not a project",
+        AutoInitRefusal::FilesystemRoot => "that is the filesystem root, not a project",
+    };
+    format!(
+        "tm: not initializing git in {} — {reason}. Run tm from a project directory.",
+        dir.display()
+    )
+}
+
+/// The prerequisite error for a missing `git` executable.
+///
+/// Why: the owner directive is "install git in the directory" — a repository,
+/// not the git binary. When `git` itself is absent there is nothing this
+/// module can do, and the error has to name git so the operator's next move is
+/// obvious. Nothing has been written at the point this fires.
+/// Test: `missing_git_error_names_git_and_the_directory`,
+/// `ensure_reports_a_missing_git_executable_without_writing`.
+pub(crate) fn missing_git_error(dir: &Path) -> anyhow::Error {
+    anyhow::anyhow!(
+        "`git` was not found on PATH — tm needs it to work in '{}'. \
+         Install git and re-run; nothing in that directory was changed.",
+        dir.display()
+    )
+}
+
+/// Run `git -C <dir> <args>` and capture its output.
+///
+/// Why: both git calls in this module need the same spawn-failure mapping, and
+/// a `NotFound` spawn error is the prerequisite case rather than a git failure.
+/// `program` is a parameter purely so the missing-executable path is testable
+/// without mutating `PATH` for the whole test binary.
+/// Test: `ensure_reports_a_missing_git_executable_without_writing`.
+fn run_git(program: &str, dir: &Path, args: &[&str]) -> anyhow::Result<std::process::Output> {
+    std::process::Command::new(program)
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        .output()
+        .map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                missing_git_error(dir)
+            } else {
+                anyhow::anyhow!(
+                    "could not run `git {}` in '{}': {e}",
+                    args.join(" "),
+                    dir.display()
+                )
+            }
+        })
+}
+
+/// Ask git whether `dir` already has a repository.
+///
+/// What: `git -C <dir> rev-parse --git-dir`. Success is [`RepoContext::Present`];
+/// a failure whose stderr carries [`NO_REPO_STDERR`] is
+/// [`RepoContext::Absent`]; any other failure is an `Err` carrying git's own
+/// stderr, so an unreadable repository is reported rather than initialized over.
+/// Test: `auto_init_leaves_a_bare_repository_alone`,
+/// `auto_init_initializes_a_plain_directory`.
+fn repo_context(program: &str, dir: &Path) -> anyhow::Result<RepoContext> {
+    let out = run_git(program, dir, &["rev-parse", "--git-dir"])?;
+    if out.status.success() {
+        return Ok(RepoContext::Present);
+    }
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    if stderr_means_no_repository(&stderr) {
+        return Ok(RepoContext::Absent);
+    }
+    Err(anyhow::anyhow!(
+        "cannot tell whether '{}' is a git repository: {}",
+        dir.display(),
+        stderr.trim()
+    ))
+}
+
+/// Make `dir` a git repository when it is a plain directory (#6274).
+///
+/// Why: the entry point both `tm` (guided default) and `tm launch` call before
+/// project detection, so a plain directory becomes an ordinary no-origin git
+/// project instead of a refusal. It never touches a directory that already has
+/// a repository, so every path that works today is unchanged.
+/// What: probes with [`repo_context`], decides with [`plan_auto_init`], runs
+/// `git init` and prints [`initialized_message`] for the `Init` arm, prints
+/// [`refusal_message`] for the `Refuse` arm. Errors only when `git` is missing
+/// (see [`missing_git_error`]), when git's verdict is unreadable, or when
+/// `git init` itself fails.
+/// Test: `auto_init_initializes_a_plain_directory` and the rest of
+/// `auto_git_init_tests.rs`.
+pub(crate) fn ensure_git_repo(dir: &Path) -> anyhow::Result<AutoInitOutcome> {
+    ensure_git_repo_with(dir, dirs::home_dir().as_deref(), GIT_PROGRAM)
+}
+
+/// [`ensure_git_repo`] with the home directory and the git executable injected.
+///
+/// Why: the two pieces of ambient state this decision depends on. Injecting
+/// them lets the guard and prerequisite arms be tested without mutating `$HOME`
+/// or `PATH` for the whole test binary.
+/// Test: `auto_init_refuses_the_home_directory`,
+/// `ensure_reports_a_missing_git_executable_without_writing`.
+pub(crate) fn ensure_git_repo_with(
+    dir: &Path,
+    home: Option<&Path>,
+    program: &str,
+) -> anyhow::Result<AutoInitOutcome> {
+    // A path that is not an existing directory is the caller's error to
+    // report — `tm launch --dir /nope` already says so, and creating anything
+    // there would be worse than that message.
+    if !dir.is_dir() {
+        return Ok(AutoInitOutcome::NotADirectory);
+    }
+    let context = repo_context(program, dir)?;
+    let canonical = dir.canonicalize().unwrap_or_else(|_| dir.to_path_buf());
+    let home_canonical = home.map(|h| h.canonicalize().unwrap_or_else(|_| h.to_path_buf()));
+    match plan_auto_init(&canonical, home_canonical.as_deref(), context) {
+        AutoInitPlan::AlreadyGit => Ok(AutoInitOutcome::AlreadyGit),
+        AutoInitPlan::Refuse(refusal) => {
+            eprintln!("{}", refusal_message(refusal, dir));
+            Ok(AutoInitOutcome::Refused(refusal))
+        }
+        AutoInitPlan::Init => {
+            let out = run_git(program, dir, &["init"])?;
+            if !out.status.success() {
+                anyhow::bail!(
+                    "`git init` failed in '{}': {}",
+                    dir.display(),
+                    String::from_utf8_lossy(&out.stderr).trim()
+                );
+            }
+            eprintln!("{}", initialized_message(dir));
+            Ok(AutoInitOutcome::Initialized)
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "auto_git_init_tests.rs"]
+mod tests;

--- a/crates/trusty-mpm/src/bin/tm/commands/auto_git_init_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/auto_git_init_tests.rs
@@ -1,0 +1,316 @@
+//! Tests for the auto-`git init` decision and driver (#6274).
+//!
+//! Why: the decision has four arms an operator can hit on their first ever
+//! `tm` run — initialize, leave alone, refuse, prerequisite error — and three
+//! of them write (or deliberately do not write) to a real directory.
+//! What: pure-decision tests for [`super::plan_auto_init`],
+//! [`super::stderr_means_no_repository`] and the message builders, plus
+//! driver tests that run real git against hermetic temp directories.
+//! Test: this file.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use super::{
+    AutoInitOutcome, AutoInitPlan, AutoInitRefusal, RepoContext, ensure_git_repo_with,
+    initialized_message, missing_git_error, plan_auto_init, refusal_message,
+    stderr_means_no_repository,
+};
+use crate::test_support::hermetic_temp_dir;
+
+/// A program name no PATH entry can resolve, for the prerequisite arm.
+const ABSENT_GIT: &str = "tm-test-no-such-git-executable-6274";
+
+/// Run a real git command that must succeed, for fixture setup.
+fn git_ok(dir: &Path, args: &[&str]) {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        .output()
+        .expect("git must be installed to run these tests");
+    assert!(
+        out.status.success(),
+        "git {args:?} failed in {}: {}",
+        dir.display(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// `git rev-parse --show-toplevel` from `dir`, or `None` when there is none.
+fn toplevel(dir: &Path) -> Option<PathBuf> {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())?;
+    Some(PathBuf::from(
+        String::from_utf8_lossy(&out.stdout).trim().to_owned(),
+    ))
+}
+
+// ── The pure decision ────────────────────────────────────────────────────────
+
+/// The feature itself: a plain directory that is nobody's home earns an init.
+#[test]
+fn plan_initializes_a_plain_directory() {
+    let plan = plan_auto_init(
+        Path::new("/Users/someone/scratch/notes"),
+        Some(Path::new("/Users/someone")),
+        RepoContext::Absent,
+    );
+    assert_eq!(plan, AutoInitPlan::Init);
+}
+
+/// `$HOME` never gets a repository it did not already have — a `.git` there
+/// silently adopts every descendant directory as part of one repo.
+#[test]
+fn plan_refuses_the_home_directory() {
+    let home = Path::new("/Users/someone");
+    assert_eq!(
+        plan_auto_init(home, Some(home), RepoContext::Absent),
+        AutoInitPlan::Refuse(AutoInitRefusal::HomeDirectory)
+    );
+}
+
+/// Same for `/`, which has no parent.
+#[test]
+fn plan_refuses_the_filesystem_root() {
+    assert_eq!(
+        plan_auto_init(
+            Path::new("/"),
+            Some(Path::new("/Users/someone")),
+            RepoContext::Absent
+        ),
+        AutoInitPlan::Refuse(AutoInitRefusal::FilesystemRoot)
+    );
+}
+
+/// The guards must not fire on a directory that ALREADY is a repository: an
+/// operator whose home directory is a dotfiles repo keeps today's behavior.
+#[test]
+fn plan_leaves_an_existing_repo_alone_even_in_the_home_directory() {
+    let home = Path::new("/Users/someone");
+    assert_eq!(
+        plan_auto_init(home, Some(home), RepoContext::Present),
+        AutoInitPlan::AlreadyGit
+    );
+}
+
+/// With no resolvable home directory the plain-directory case still initializes.
+#[test]
+fn plan_initializes_when_the_home_directory_is_unknown() {
+    assert_eq!(
+        plan_auto_init(Path::new("/srv/project"), None, RepoContext::Absent),
+        AutoInitPlan::Init
+    );
+}
+
+// ── The "is there a repository here" stderr discrimination ───────────────────
+
+/// The long phrase is the only thing that means "no repository".
+#[test]
+fn no_repo_stderr_matches_the_long_phrase() {
+    assert!(stderr_means_no_repository(
+        "fatal: not a git repository (or any of the parent directories): .git"
+    ));
+}
+
+/// A stale worktree pointer contains the SHORT phrase while meaning the
+/// opposite — matching it would `git init` over a broken repository.
+#[test]
+fn no_repo_stderr_rejects_the_stale_worktree_pointer() {
+    assert!(!stderr_means_no_repository(
+        "fatal: not a git repository: (null)"
+    ));
+}
+
+/// Any other failure (dubious ownership, permissions) is not "no repository".
+#[test]
+fn no_repo_stderr_rejects_an_unrelated_failure() {
+    assert!(!stderr_means_no_repository(
+        "fatal: detected dubious ownership in repository at '/srv/project'"
+    ));
+}
+
+// ── Operator-facing messages ─────────────────────────────────────────────────
+
+/// The notice says where the repository was created.
+#[test]
+fn initialized_message_names_the_directory() {
+    let msg = initialized_message(Path::new("/srv/project"));
+    assert_eq!(msg, "tm: initialized git in /srv/project");
+}
+
+/// A refusal states its reason, not just that it refused.
+#[test]
+fn refusal_message_names_the_home_directory() {
+    let msg = refusal_message(AutoInitRefusal::HomeDirectory, Path::new("/Users/someone"));
+    assert!(msg.contains("/Users/someone"), "{msg}");
+    assert!(msg.contains("home directory"), "{msg}");
+}
+
+/// Same for the filesystem-root arm.
+#[test]
+fn refusal_message_names_the_filesystem_root() {
+    let msg = refusal_message(AutoInitRefusal::FilesystemRoot, Path::new("/"));
+    assert!(msg.contains("filesystem root"), "{msg}");
+}
+
+/// The prerequisite error names `git` — this feature never installs the binary.
+#[test]
+fn missing_git_error_names_git_and_the_directory() {
+    let msg = missing_git_error(Path::new("/srv/project")).to_string();
+    assert!(msg.contains("`git` was not found on PATH"), "{msg}");
+    assert!(msg.contains("/srv/project"), "{msg}");
+}
+
+// ── The driver, against real git ─────────────────────────────────────────────
+
+/// The headline case: a plain directory becomes a repository rooted at itself.
+#[test]
+fn auto_init_initializes_a_plain_directory() {
+    let tmp = hermetic_temp_dir();
+    let dir = tmp.path().join("fresh-project");
+    std::fs::create_dir(&dir).unwrap();
+
+    let outcome = ensure_git_repo_with(&dir, Some(tmp.path()), "git").unwrap();
+
+    assert_eq!(outcome, AutoInitOutcome::Initialized);
+    assert!(dir.join(".git").is_dir(), "a .git directory must exist now");
+    assert_eq!(
+        toplevel(&dir).map(|p| p.canonicalize().unwrap()),
+        Some(dir.canonicalize().unwrap()),
+        "the repository root must be the invocation directory, not a parent"
+    );
+}
+
+/// Regression for the pre-fix refusal path: the directory `tm` used to answer
+/// "not in a git project" for is, after this call, exactly what
+/// `classify_cwd_project` calls a usable project — with no origin remote.
+#[test]
+fn non_git_directory_now_classifies_as_a_usable_project() {
+    use crate::commands::guided::{CwdProject, classify_cwd_project};
+
+    let tmp = hermetic_temp_dir();
+    let dir = tmp.path().join("plain");
+    std::fs::create_dir(&dir).unwrap();
+    assert!(
+        matches!(classify_cwd_project(&dir), CwdProject::NotGit),
+        "precondition: this is the directory tm used to refuse"
+    );
+
+    ensure_git_repo_with(&dir, Some(tmp.path()), "git").unwrap();
+
+    assert!(
+        matches!(classify_cwd_project(&dir), CwdProject::Usable(_)),
+        "after auto-init tm must see an ordinary project here"
+    );
+    assert_eq!(
+        trusty_mpm::daemon::managed_routes::inproject::get_origin_url(&dir).unwrap(),
+        None,
+        "a freshly initialized repo has no origin — the no-remote flow takes over"
+    );
+}
+
+/// An existing repository root is left exactly as it was.
+#[test]
+fn auto_init_leaves_a_repo_root_alone() {
+    let tmp = hermetic_temp_dir();
+    let repo = tmp.path().join("repo");
+    std::fs::create_dir(&repo).unwrap();
+    git_ok(&repo, &["init"]);
+
+    let outcome = ensure_git_repo_with(&repo, Some(tmp.path()), "git").unwrap();
+
+    assert_eq!(outcome, AutoInitOutcome::AlreadyGit);
+}
+
+/// A directory INSIDE another repository's work tree — untracked, so it is not
+/// part of that repo's tree — still must not get a nested repository: git is
+/// already present there.
+#[test]
+fn auto_init_does_not_init_inside_another_work_tree() {
+    let tmp = hermetic_temp_dir();
+    let repo = tmp.path().join("repo");
+    std::fs::create_dir(&repo).unwrap();
+    git_ok(&repo, &["init"]);
+    let nested = repo.join("untracked-notes");
+    std::fs::create_dir(&nested).unwrap();
+
+    let outcome = ensure_git_repo_with(&nested, Some(tmp.path()), "git").unwrap();
+
+    assert_eq!(outcome, AutoInitOutcome::AlreadyGit);
+    assert!(
+        !nested.join(".git").exists(),
+        "a nested repository must not be created inside another work tree"
+    );
+}
+
+/// A bare repository has no work tree, so a `--show-toplevel` check would call
+/// it a plain directory and re-initialize it. `--git-dir` does not.
+#[test]
+fn auto_init_leaves_a_bare_repository_alone() {
+    let tmp = hermetic_temp_dir();
+    let bare = tmp.path().join("origin.git");
+    std::fs::create_dir(&bare).unwrap();
+    git_ok(&bare, &["init", "--bare"]);
+
+    let outcome = ensure_git_repo_with(&bare, Some(tmp.path()), "git").unwrap();
+
+    assert_eq!(outcome, AutoInitOutcome::AlreadyGit);
+}
+
+/// The home-directory guard, end to end: nothing is written.
+#[test]
+fn auto_init_refuses_the_home_directory() {
+    let tmp = hermetic_temp_dir();
+    let home = tmp.path().join("home");
+    std::fs::create_dir(&home).unwrap();
+
+    let outcome = ensure_git_repo_with(&home, Some(&home), "git").unwrap();
+
+    assert_eq!(
+        outcome,
+        AutoInitOutcome::Refused(AutoInitRefusal::HomeDirectory)
+    );
+    assert!(
+        !home.join(".git").exists(),
+        "the home directory must not become a repository"
+    );
+}
+
+/// No git executable: a prerequisite error naming git, and nothing written.
+#[test]
+fn ensure_reports_a_missing_git_executable_without_writing() {
+    let tmp = hermetic_temp_dir();
+    let dir = tmp.path().join("plain");
+    std::fs::create_dir(&dir).unwrap();
+
+    let err = ensure_git_repo_with(&dir, Some(tmp.path()), ABSENT_GIT)
+        .expect_err("a missing git executable must be an error, not a silent skip");
+
+    assert!(
+        err.to_string().contains("`git` was not found on PATH"),
+        "{err}"
+    );
+    assert!(
+        !dir.join(".git").exists(),
+        "nothing may be written when git is unavailable"
+    );
+}
+
+/// A path that is not a directory is the caller's error to report; this call
+/// stays silent and writes nothing.
+#[test]
+fn auto_init_skips_a_path_that_is_not_a_directory() {
+    let tmp = hermetic_temp_dir();
+    let missing = tmp.path().join("does-not-exist");
+
+    let outcome = ensure_git_repo_with(&missing, Some(tmp.path()), "git").unwrap();
+
+    assert_eq!(outcome, AutoInitOutcome::NotADirectory);
+    assert!(!missing.exists(), "the path must not be created");
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/guided.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided.rs
@@ -281,6 +281,11 @@ pub(crate) async fn run_guided_default(
     let workdir = cwd.to_string_lossy().to_string();
     eprintln!("tm: no subcommand — using guided default for {workdir}");
 
+    // #6274: a plain directory becomes a git project here rather than dead-ending
+    // on `NON_GIT_FALLBACK_HINT` further down. Everything below then runs exactly
+    // as it does for a git repo with no origin remote.
+    super::auto_git_init::ensure_git_repo(&cwd)?;
+
     // Auto-register the git project root as a local path alias (non-fatal, silent).
     // Why: every `tm` invocation from a git directory populates `tm ls` with
     // the project's canonical name so operators can quickly find their projects.

--- a/crates/trusty-mpm/src/bin/tm/commands/launch.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/launch.rs
@@ -119,6 +119,13 @@ pub(crate) async fn launch(
     let live_path = resolve_dir(dir)?;
     let live_path = live_path.canonicalize().unwrap_or(live_path);
 
+    // #6274: a plain directory becomes a git project here, so step 2 below reads
+    // the origin remote of a real repository instead of failing on "not a git
+    // repo". A fresh repo has no origin, so `tm launch` still lands on the
+    // no-remote error that points at `tm connect` — the same answer it gives for
+    // any repo without a GitHub remote.
+    super::auto_git_init::ensure_git_repo(&live_path)?;
+
     // Auto-register the git project root as a local path alias (non-fatal, silent).
     super::managed_root::try_register_alias(&live_path);
     let live_workdir = live_path.to_string_lossy().to_string();

--- a/crates/trusty-mpm/src/bin/tm/commands/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/mod.rs
@@ -15,6 +15,9 @@
 
 pub(crate) mod agent;
 pub(crate) mod auth;
+// #6274: `tm` in a plain directory initializes a repository there instead of
+// refusing; both the guided default and `tm launch` call it before detection.
+pub(crate) mod auto_git_init;
 pub(crate) mod banner;
 pub(crate) mod compress;
 pub(crate) mod daemon;


### PR DESCRIPTION
`tm` (bare) and `tm launch` in a plain directory now run `git init` there,
print `tm: initialized git in <path>`, and continue exactly as they do for a
git repository with no origin remote. Before, one printed "not in a git
project" and the other "no git origin remote found". Refs #6274.

Guards, all in `commands::auto_git_init`:

- Already a repository — a work tree at any depth, a bare repository, or the
  inside of a `.git` directory — is left untouched. The probe is
  `rev-parse --git-dir`, not `--show-toplevel`, which a bare repository would
  fool.
- Only the long `not a git repository (or any of the parent directories)`
  phrase means "no repository", the same discrimination `vcs_claim` and
  `report::scan` make. A stale worktree pointer's `not a git repository:
  (null)` is reported instead.
- The home directory and the filesystem root refuse, each naming its reason.
- No `git` on PATH is a prerequisite error naming git, raised before anything
  is written. This initializes a repository, never the git binary.

Live run in a plain directory, after the change:

```
tm: no subcommand — using guided default for /private/tmp/tm-smoke-6274/plain
tm: initialized git in /private/tmp/tm-smoke-6274/plain
tm: not auto-managing this project — `tm` auto-manages GitHub repositories only.
```

The third line is the pre-existing no-remote path, unchanged.

## Gates — rung 3

```
cargo fmt --check                                          EXIT=0
cargo check -p trusty-mpm --all-targets                    EXIT=0
cargo clippy -p trusty-mpm --all-targets -- -D warnings    EXIT=0
cargo test -p trusty-mpm                                   EXIT=0 — 9340 passed, 0 failed, 18 ignored
```

20 of those are the new `commands::auto_git_init::tests`. The bare-repository
case was mutation-checked: swapping the probe to `--show-toplevel` fails
`auto_init_leaves_a_bare_repository_alone` and nothing else.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
