### PR TITLE
feat(trusty-mpm): plain local repo with no origin remote proceeds to a working session

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11695,7 +11695,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-mpm"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-mpm"
-version = "1.5.2"
+version = "1.5.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/trusty-mpm/changelog.d/6276-no-origin-proceed.md
+++ b/crates/trusty-mpm/changelog.d/6276-no-origin-proceed.md
@@ -1,0 +1,12 @@
+Changed
+
+- `tm` and `tm launch` in a git repository with no origin remote now start a
+  session in that checkout instead of stopping at "no git origin remote found"
+  / "not auto-managing this project"
+  ([#6276](https://github.com/bobmatnyc/trusty-tools/issues/6276)). A two-line
+  notice still says there is no remote and that no managed clone is made, and
+  then the session runs. This is the end-state #6274's auto-`git init` left
+  open: a first-ever `tm` run in a plain directory created the repository and
+  the very next step refused it. Repositories that HAVE an origin remote are
+  unchanged — a GitHub remote still gets the protected managed clone, and a
+  non-GitHub remote is still refused with the live checkout untouched.

--- a/crates/trusty-mpm/src/bin/tm/cli/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli/mod.rs
@@ -613,6 +613,10 @@ pub(crate) enum Command {
     /// agents, skills, MCP config) into the project before starting or
     /// attaching to the session in the current terminal (behaves like running
     /// `claude-mpm`).
+    ///
+    /// A GitHub-backed project is provisioned into a managed clone. A local
+    /// repository with no origin remote runs its session in the checkout
+    /// itself — it is not refused.
     Launch {
         /// Project directory to launch in (defaults to the current directory).
         dir: Option<String>,

--- a/crates/trusty-mpm/src/bin/tm/commands/auto_git_init.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/auto_git_init.rs
@@ -6,7 +6,9 @@
 //! did nothing; `tm launch` failed with "no git origin remote found". The
 //! operator's next move was always the same — run `git init`, re-run `tm`. This
 //! module takes that step for them and then lets the ordinary flow continue
-//! exactly as it does for a git repository with no origin remote.
+//! exactly as it does for a git repository with no origin remote — which since
+//! #6276 means a working session in that checkout, not a second refusal (see
+//! [`super::origin_plan`]).
 //! What: [`ensure_git_repo`] probes for an existing repository, applies the
 //! sanity guards, runs `git init`, and prints a one-line notice. The decision
 //! is the pure [`plan_auto_init`]; the "is there a repository here" stderr

--- a/crates/trusty-mpm/src/bin/tm/commands/guided.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided.rs
@@ -11,8 +11,11 @@
 //! What: [`run_guided_default`] orchestrates detection, listing, and dispatch.
 //! [`derive_project`] derives the `source_id`, managed workspace, and git root.
 //! [`fallback_protected`] is the three-way dispatch for the daemon-unreachable
-//! path; it is also the target for non-GitHub projects. [`non_github_refusal_message`]
-//! is the pure helper that produces the accurate refusal text for the
+//! path; it is also the target for non-GitHub projects. What it does about the
+//! origin remote is the pure [`super::origin_plan::plan_for_origin`] (#6276):
+//! GitHub gets the managed clone, a local-only repository runs its session
+//! here, a non-GitHub host is refused. [`non_github_refusal_message`]
+//! is the pure helper that produces the accurate refusal text for that
 //! non-GitHub-remote case (see #1777). The TTY picker is split into a pure
 //! `parse_picker_choice` + an I/O driver `run_tty_picker`.
 //!
@@ -1172,8 +1175,14 @@ pub(crate) fn managed_pane_settle_pending_message(id: &str) -> String {
 ///       project registered with `worktree: false` (#3455) gets neither clone
 ///       nor worktree and launches in the repo root instead, matching what the
 ///       daemon's `spawn_managed_on_main` would have done had it been up.
-///   (2) Inside a non-GitHub git working tree (non-GitHub remote or no remote)
-///       → return an actionable `Err`; the live checkout is never touched.
+///   (2) Inside a git working tree whose origin remote is not GitHub → return
+///       an actionable `Err`; the live checkout is never touched.
+///   (2b) Inside a git working tree with NO origin remote → print
+///       [`super::origin_plan::live_checkout_notice`] and run
+///       [`super::launch::connect`] here (#6276). There is no remote to clone
+///       from, so the session runs in the checkout itself; before #6276 this
+///       shared arm (2)'s refusal, which after #6274's auto-`git init` was the
+///       end-state of a first-ever `tm` run in a plain directory.
 ///   (3) Not inside any git working tree (plain directory or bare repo) →
 ///       classic `tm launch` path; there is no live checkout to protect,
 ///       consistent with the daemon's local-path fast path.
@@ -1248,26 +1257,35 @@ pub(crate) async fn fallback_protected(
     let origin_url = trusty_mpm::daemon::managed_routes::inproject::get_origin_url(&git_root)
         .map_err(|e| anyhow::anyhow!(e))?;
 
-    if let Some(ref raw_url) = origin_url
-        && is_github_remote(raw_url)
-    {
+    // #6276: the no-remote case proceeds to a session in this checkout; the
+    // other two arms are what this code did inline before the decision moved.
+    match super::origin_plan::plan_for_origin(origin_url.as_deref()) {
         // GitHub project: redirect deploy to the protected managed clone
         // (or, when the project opted out of worktrees, to the repo root).
-        return launch_protected_workspace(client, url, &git_root, raw_url).await;
+        super::origin_plan::OriginPlan::ManagedClone(raw_url) => {
+            launch_protected_workspace(client, url, &git_root, raw_url).await
+        }
+        // Local-only repository: there is no remote to clone from, and nothing
+        // about this checkout to protect it from — `connect` runs the session
+        // here, which is what the old refusal told the operator to do by hand.
+        super::origin_plan::OriginPlan::LiveCheckout => {
+            eprintln!("{}", super::origin_plan::live_checkout_notice(&git_root));
+            super::launch::connect(client, url, Some(git_root.to_string_lossy().into_owned())).await
+        }
+        // Non-GitHub remote: refuse to write to the live tree.
+        // NOTE: the daemon's reachability is irrelevant here — this branch is
+        // reached even when the daemon is UP. The real reason for refusal is
+        // that `tm` only auto-manages GitHub repositories (#1777).
+        super::origin_plan::OriginPlan::RefuseNonGitHub(remote_desc) => {
+            eprintln!("{}", non_github_refusal_message(remote_desc));
+            anyhow::bail!(
+                "not auto-managing: live git checkout at '{}' is a non-GitHub repository — \
+                 auto-managed clones require a GitHub remote; \
+                 use an explicit `tm` subcommand to work here manually",
+                git_root.display()
+            );
+        }
     }
-
-    // Non-GitHub remote or no remote: refuse to write to the live tree.
-    // NOTE: the daemon's reachability is irrelevant here — this branch is
-    // reached even when the daemon is UP. The real reason for refusal is
-    // that `tm` only auto-manages GitHub repositories (#1777).
-    let remote_desc = origin_url.as_deref().unwrap_or("(no remote configured)");
-    eprintln!("{}", non_github_refusal_message(remote_desc));
-    anyhow::bail!(
-        "not auto-managing: live git checkout at '{}' is a non-GitHub repository — \
-         auto-managed clones require a GitHub remote; \
-         use an explicit `tm` subcommand to work here manually",
-        git_root.display()
-    );
 }
 
 /// Launch the guided-default fallback in the workspace this project is

--- a/crates/trusty-mpm/src/bin/tm/commands/launch.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/launch.rs
@@ -90,8 +90,10 @@ impl Drop for LaunchSessionGuard {
 /// `inproject::base_clone_path` the daemon uses, so both entry points agree — #1807)
 /// plus a per-session worktree, registers the
 /// session with the daemon, prints the banner, creates a detached tmux session
-/// running `claude` in the managed clone, and `attach`es to it. Errors with a
-/// `tm connect` hint when the directory has no parseable GitHub remote.
+/// running `claude` in the managed clone, and `attach`es to it. A remote that
+/// does not parse as `owner/repo` errors with a `tm connect` hint; a repository
+/// with NO origin remote prints a notice and runs [`connect`] against the
+/// checkout itself (#6276) rather than erroring.
 ///
 /// #5274: `worktree` is the operator's explicit request for isolation
 /// (`tm launch --worktree`). Without it the session runs in the project's own
@@ -121,9 +123,8 @@ pub(crate) async fn launch(
 
     // #6274: a plain directory becomes a git project here, so step 2 below reads
     // the origin remote of a real repository instead of failing on "not a git
-    // repo". A fresh repo has no origin, so `tm launch` still lands on the
-    // no-remote error that points at `tm connect` — the same answer it gives for
-    // any repo without a GitHub remote.
+    // repo". A fresh repo has no origin, and since #6276 step 2 starts a session
+    // in that checkout rather than stopping there.
     super::auto_git_init::ensure_git_repo(&live_path)?;
 
     // Auto-register the git project root as a local path alias (non-fatal, silent).
@@ -131,19 +132,25 @@ pub(crate) async fn launch(
     let live_workdir = live_path.to_string_lossy().to_string();
 
     // 2. Derive the GitHub identity from the origin remote.
-    //    Managed sessions REQUIRE a parseable GitHub remote (#1590). A missing or
+    //    Managed sessions REQUIRE a parseable GitHub remote (#1590). An
     //    unparseable remote is an immediate error that points the user to `tm connect`.
     //    #4734: a git failure gets its own error — telling the operator to run
     //    `tm connect` because there is "no remote" would be false advice.
-    let origin_url = trusty_mpm::daemon::managed_routes::inproject::get_origin_url(&live_path)
-        .map_err(|e| anyhow::anyhow!(e))?
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "no git origin remote found in '{live_workdir}'\n\
-                     Managed sessions require a GitHub remote. \
-                     Run `tm connect` to start a session in the live checkout instead."
-            )
-        })?;
+    // #6276: a repository with NO origin remote starts the session here instead
+    // of stopping — `connect` is the live-checkout path this used to name in a
+    // refusal, and it needs neither a remote nor a clean tree.
+    let raw_origin = trusty_mpm::daemon::managed_routes::inproject::get_origin_url(&live_path)
+        .map_err(|e| anyhow::anyhow!(e))?;
+    let origin_url = match super::origin_plan::plan_for_origin(raw_origin.as_deref()) {
+        super::origin_plan::OriginPlan::LiveCheckout => {
+            eprintln!("{}", super::origin_plan::live_checkout_notice(&live_path));
+            return connect(client, url, Some(live_workdir)).await;
+        }
+        // Any origin remote keeps the pre-#6276 path exactly: parse it as
+        // owner/repo, or stop with the hint below.
+        super::origin_plan::OriginPlan::ManagedClone(u)
+        | super::origin_plan::OriginPlan::RefuseNonGitHub(u) => u.to_string(),
+    };
     let gh = trusty_common::github_path::parse_github_path(&origin_url).ok_or_else(|| {
         anyhow::anyhow!(
             "could not parse a GitHub owner/repo from origin remote: {origin_url:?}\n\

--- a/crates/trusty-mpm/src/bin/tm/commands/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/mod.rs
@@ -60,6 +60,9 @@ pub(crate) mod mcp;
 pub(crate) mod memory;
 pub(crate) mod meta;
 pub(crate) mod misc;
+// #6276: the one decision about a repository's origin remote — a local-only
+// repository proceeds to a session in its own checkout instead of refusing.
+pub(crate) mod origin_plan;
 pub(crate) mod pane_identity;
 pub(crate) mod picker_delete;
 pub(crate) mod picker_delete_glob;

--- a/crates/trusty-mpm/src/bin/tm/commands/origin_plan.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/origin_plan.rs
@@ -1,0 +1,77 @@
+//! What the launch path does about a repository's `origin` remote (#6276).
+//!
+//! Why: `tm` used to end at a refusal whenever a git repository had no origin
+//! remote — bare `tm` bailed out of [`super::guided::fallback_protected`] and
+//! `tm launch` bailed with "no git origin remote found". After #6274 auto-`git
+//! init`, that refusal became the end-state of a first-ever `tm` run in a plain
+//! directory: the repository was created and the very next step refused it.
+//! Owner ruling 2026-08-25: a local-only repository proceeds to a working
+//! session in its own checkout. A repository that HAS an origin remote is
+//! unaffected — GitHub still gets the managed clone, and a non-GitHub host is
+//! still refused.
+//! What: [`plan_for_origin`] is the one decision, taken from the origin URL
+//! alone, plus [`live_checkout_notice`] — the message that used to terminate
+//! the launch and is now a notice printed before the session starts.
+//! Test: `origin_plan_tests.rs`.
+
+use std::path::Path;
+
+/// What the launch path does with a repository, given its `origin` remote.
+///
+/// Why: the two callers ([`super::guided::fallback_protected`] and
+/// [`super::launch::launch`]) each used to make this call inline, and each
+/// answered "no origin remote" with a refusal. One enum makes the answer
+/// reviewable and testable without a daemon, a tmux server, or a network.
+/// What: three arms, keyed only on the origin URL. `ManagedClone` and
+/// `RefuseNonGitHub` carry the remote so the caller does not re-derive it.
+/// Test: `plan_sends_a_repo_with_no_origin_to_the_live_checkout`,
+/// `plan_sends_a_github_origin_to_the_managed_clone`,
+/// `plan_refuses_a_non_github_origin`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum OriginPlan<'a> {
+    /// The origin names a GitHub repository — auto-managed clone, unchanged.
+    ManagedClone(&'a str),
+    /// There is no origin remote — run the session in this checkout (#6276).
+    LiveCheckout,
+    /// The origin names a host other than GitHub — refuse, unchanged.
+    RefuseNonGitHub(&'a str),
+}
+
+/// Decide what to do about `origin_url`.
+///
+/// Why: see the module doc — the `None` case is the one #6276 changed, and it
+/// is the only one that changed.
+/// What: `None` (no `remote.origin.url` configured) is
+/// [`OriginPlan::LiveCheckout`]. Any `Some` remote is classified by
+/// [`super::guided::is_github_remote`], exactly as `fallback_protected` did
+/// inline before this module existed.
+/// Test: see [`OriginPlan`].
+pub(crate) fn plan_for_origin(origin_url: Option<&str>) -> OriginPlan<'_> {
+    match origin_url {
+        // #6276: a local-only repository proceeds instead of being refused.
+        None => OriginPlan::LiveCheckout,
+        Some(url) if super::guided::is_github_remote(url) => OriginPlan::ManagedClone(url),
+        Some(url) => OriginPlan::RefuseNonGitHub(url),
+    }
+}
+
+/// The notice printed when a local-only repository starts its session.
+///
+/// Why: the no-origin case used to carry real information — that there is no
+/// remote, and that no managed clone will be made. #6276 keeps that
+/// information and drops the termination, so the operator still learns why
+/// this session runs where it does.
+/// What: a two-line notice naming `checkout`. The caller prints it with
+/// `eprintln!` and then starts the session; it is never an error.
+/// Test: `live_checkout_notice_names_the_checkout_and_does_not_read_as_a_refusal`.
+pub(crate) fn live_checkout_notice(checkout: &Path) -> String {
+    format!(
+        "tm: no git origin remote in '{}' — this is a local-only repository.\n\
+         tm: starting the session in this checkout; no managed clone is made.",
+        checkout.display()
+    )
+}
+
+#[cfg(test)]
+#[path = "origin_plan_tests.rs"]
+mod tests;

--- a/crates/trusty-mpm/src/bin/tm/commands/origin_plan_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/origin_plan_tests.rs
@@ -1,0 +1,109 @@
+//! Tests for the origin-remote decision (#6276).
+//!
+//! Why: this decision is what a first-ever `tm` run in a plain directory hits
+//! immediately after #6274's auto-`git init`. The no-origin arm must PROCEED;
+//! the two arms for a repository that has a remote must be byte-identical to
+//! the pre-#6276 behavior.
+//! What: pure tests for [`super::plan_for_origin`] across the three arms, an
+//! SSH-alias remote, and the notice text.
+//! Test: this file.
+
+use std::path::Path;
+
+use super::{OriginPlan, live_checkout_notice, plan_for_origin};
+
+/// A repository with no origin remote proceeds to a session in its own
+/// checkout.
+///
+/// Why: this is the whole of #6276. Before the fix both callers answered
+/// `None` with a refusal, so there was no proceed variant to return — this
+/// test does not compile against the pre-fix tree and fails against any
+/// implementation that keeps refusing.
+/// Test: this is the test.
+#[test]
+fn plan_sends_a_repo_with_no_origin_to_the_live_checkout() {
+    assert_eq!(
+        plan_for_origin(None),
+        OriginPlan::LiveCheckout,
+        "#6276: a local-only repository must proceed, not refuse"
+    );
+}
+
+/// A GitHub origin still takes the managed-clone path.
+///
+/// Why: #6276 must not touch the auto-managed case — regression coverage for
+/// "behavior for repos WITH an origin remote is unchanged".
+/// Test: this is the test.
+#[test]
+fn plan_sends_a_github_origin_to_the_managed_clone() {
+    let url = "https://github.com/bobmatnyc/trusty-tools.git";
+    assert_eq!(plan_for_origin(Some(url)), OriginPlan::ManagedClone(url));
+}
+
+/// A GitHub SSH host alias is still GitHub.
+///
+/// Why: `git@github-duetto:owner/repo.git` reaches the managed clone through
+/// `is_github_remote`'s alias rule; routing it to the live checkout would
+/// silently downgrade every multi-account setup.
+/// Test: this is the test.
+#[test]
+fn plan_sends_a_github_ssh_alias_origin_to_the_managed_clone() {
+    let url = "git@github-duetto:duettoresearch/aria.git";
+    assert_eq!(plan_for_origin(Some(url)), OriginPlan::ManagedClone(url));
+}
+
+/// A non-GitHub origin is still refused.
+///
+/// Why: the live-checkout guard for Gitea/GitLab/bare-SSH remotes (#1724,
+/// #1777) is untouched by #6276 — only the no-remote case changed.
+/// Test: this is the test.
+#[test]
+fn plan_refuses_a_non_github_origin() {
+    for url in [
+        "https://gitea.example.com/org/repo.git",
+        "git@gitlab.com:org/repo.git",
+        "https://bitbucket.org/org/repo.git",
+    ] {
+        assert_eq!(
+            plan_for_origin(Some(url)),
+            OriginPlan::RefuseNonGitHub(url),
+            "a remote on {url} must keep the pre-#6276 refusal"
+        );
+    }
+}
+
+/// An empty remote string is a remote, not an absent one.
+///
+/// Why: `plan_for_origin` keys on `Option`, never on emptiness — a caller that
+/// hands it `Some("")` has read something from git and must not be routed into
+/// the local-only arm.
+/// Test: this is the test.
+#[test]
+fn plan_treats_an_empty_remote_string_as_a_remote() {
+    assert_eq!(plan_for_origin(Some("")), OriginPlan::RefuseNonGitHub(""));
+}
+
+/// The notice names the checkout and reads as a notice.
+///
+/// Why: the message that used to terminate the launch keeps its information —
+/// where the session runs, and that no clone is made — without the "run `tm
+/// connect` instead" instruction, which is now what already happens.
+/// Test: this is the test.
+#[test]
+fn live_checkout_notice_names_the_checkout_and_does_not_read_as_a_refusal() {
+    let msg = live_checkout_notice(Path::new("/tmp/local-only-6276"));
+    assert!(
+        msg.contains("/tmp/local-only-6276"),
+        "the notice must name the checkout: {msg:?}"
+    );
+    assert!(
+        msg.contains("no git origin remote"),
+        "the notice must still say why there is no managed clone: {msg:?}"
+    );
+    for refusal_word in ["Run `tm connect`", "require", "not auto-managing"] {
+        assert!(
+            !msg.contains(refusal_word),
+            "#6276: the notice must not read as a refusal ({refusal_word:?}): {msg:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

The no-origin refusal end-state from #6274/#6275 is replaced by a notice + live-checkout session. Remote-bearing repos take the exact same path as before.

## Test Plan

- Test ladder: **Rung 3** (localized behavior inside one crate)
- Gates run: `cargo fmt --check` ✓ / `cargo check -p trusty-mpm` ✓ / `cargo clippy -p trusty-mpm --all-targets -- -D warnings` ✓ / `cargo test -p trusty-mpm` ✓
- Test results: tm binary 1858 passed, 0 failed
- `scripts/check_line_cap.sh` ✓ (no SLOC violations)
- Changelog fragment valid ✓
- `scripts/check_sld.sh` clean ✓

**Regression:** The test `plan_sends_a_repo_with_no_origin_to_the_live_checkout` fails against the pre-fix commit and passes with the fix applied (empirically demonstrated; implementation details in #6276).

Refs #6276

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools