### PR TITLE
feat(trusty-common): generic framed-JSON-RPC UDS server loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11406,7 +11406,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-common"
-version = "0.43.2"
+version = "0.44.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,7 @@ trusty-code = { path = "crates/trusty-code", version = "0.3.0" }
 # epic #3411). Not yet published (Slice 1, #3425).
 trusty-tui = { path = "crates/trusty-tui", version = "0.1.0" }
 trusty-agents-common = { path = "crates/trusty-agents-common", version = "0.6.0" }
-trusty-common = { path = "crates/trusty-common", version = "0.43" }
+trusty-common = { path = "crates/trusty-common", version = "0.44" }
 # Shared JSON-RPC 2.0 / MCP protocol primitives, extracted from
 # `trusty_common::mcp` by ADR-0040 (#5803).
 trusty-mcp = { path = "crates/trusty-mcp", version = "0.1.0" }

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -7,7 +7,10 @@ name = "trusty-common"
 # 0.43.2 (#6198): patch — the Jira backend resolves a milestone id to its
 # version name internally; every changed item is `pub(super)`, so no public
 # item was removed or changed.
-version = "0.43.2"
+# 0.44.0 (#6277): minor — the new public `uds::server` module is additive, and
+# nothing existing was removed or changed. Under Cargo's 0.x rule a MINOR bump
+# is what a published crate owes a new public module.
+version = "0.44.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/trusty-common/changelog.d/6277-uds-rpc-server.md
+++ b/crates/trusty-common/changelog.d/6277-uds-rpc-server.md
@@ -6,5 +6,6 @@ Added
   checks the peer uid on every accepted connection, dispatches each in its own
   task, and unlinks the socket on shutdown (#6277). An unknown method answers a
   JSON-RPC method-not-found frame rather than dropping the connection, so a
-  drifted client reads the reason instead of a transport failure. Existing
+  drifted client reads the reason instead of a transport failure, and a handler
+  that panics is logged by name instead of vanishing with its task. Existing
   callers are unaffected — `webhook_relay` keeps its own single-method listener.

--- a/crates/trusty-common/changelog.d/6277-uds-rpc-server.md
+++ b/crates/trusty-common/changelog.d/6277-uds-rpc-server.md
@@ -1,0 +1,10 @@
+Added
+
+- `uds::server` serves the other end of `uds::rpc`: a caller registers method
+  names against handlers over its own request and response types
+  (`RpcRouter::typed`), and `RpcServer::run` binds through `bind_hardened`,
+  checks the peer uid on every accepted connection, dispatches each in its own
+  task, and unlinks the socket on shutdown (#6277). An unknown method answers a
+  JSON-RPC method-not-found frame rather than dropping the connection, so a
+  drifted client reads the reason instead of a transport failure. Existing
+  callers are unaffected — `webhook_relay` keeps its own single-method listener.

--- a/crates/trusty-common/src/uds/mod.rs
+++ b/crates/trusty-common/src/uds/mod.rs
@@ -56,6 +56,9 @@ pub mod dir;
 mod peer;
 pub mod probe;
 pub mod rpc;
+// #6277: the serving half of `rpc`, so a daemon migrating off HTTP under
+// ADR-0032 supplies a method table rather than a fourth hand-rolled accept loop.
+pub mod server;
 pub mod singleton;
 
 /// On-demand supervision of a UDS-serving child process (#5089 step 2).

--- a/crates/trusty-common/src/uds/server/mod.rs
+++ b/crates/trusty-common/src/uds/server/mod.rs
@@ -1,0 +1,375 @@
+//! The serving half of [`crate::uds::rpc`]: a generic framed JSON-RPC server
+//! over a hardened Unix socket (#6277, ADR-0032).
+//!
+//! Why: `uds::rpc` is the client — it dials, writes one frame, reads one back —
+//! and nothing in this workspace owned the other end generically. The only
+//! server-side accept loop was `webhook_relay::serve`, which is a single-purpose
+//! durable-delivery contract: one method, an ack conditioned on an fsync, an
+//! inbox. ADR-0032 puts every trusty-* service's own transport on UDS, so the
+//! next service to migrate needed either a fourth hand-rolled accept loop or
+//! this. `webhook_relay` is deliberately left untouched; its ordering rule is
+//! the reason it exists and is not a thing to generalise.
+//!
+//! What, in the order a daemon uses them.
+//!   - [`RpcRouter`] is the caller's half: method names mapped to handlers over
+//!     the caller's own request and response types (see [`RpcRouter::typed`]).
+//!   - [`RpcServer::run`] is the whole body of a daemon — bind, serve, unlink.
+//!   - [`serve_until`] and [`handle_connection`] are that body's two halves,
+//!     public so a caller with its own bind (say
+//!     [`crate::uds::bind_singleton_hardened`], which takes over a stale socket
+//!     file where [`crate::uds::bind_hardened`] refuses) drives the loop itself.
+//!
+//! **The trust boundary is the socket, not the payload.** [`bind_hardened`]
+//! puts the socket at `0600` inside a `0700` directory, and every accepted
+//! connection runs [`ensure_peer_is_self`] before a single byte is read. No
+//! CSRF, origin, or token machinery is ported from the HTTP shape those checks
+//! replace — on a UDS socket it would guard nothing (#6277 design review).
+//!
+//! **The socket file is unlinked explicitly.** [`bind_hardened`] binds and
+//! chmods; neither it nor `tokio::net::UnixListener`'s `Drop` removes the path,
+//! so a server that just returned would leave a file the next start fails to
+//! bind. [`RpcServer::run`] removes it — before dropping the listener, for the
+//! reason `webhook_relay::listener` records: with the order reversed there is a
+//! window where nothing answers the path but the file is still there, and a
+//! successor that rebinds in that window has its fresh socket deleted by this
+//! process's `remove_file`.
+//!
+//! Test: `tests.rs` — `dispatch_*` for the decision, `serve_*` for the socket.
+
+mod router;
+mod wire;
+
+#[cfg(test)]
+#[path = "tests.rs"]
+mod tests;
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::io::{AsyncBufReadExt, AsyncReadExt as _, AsyncWriteExt, BufReader};
+use tokio::net::{UnixListener, UnixStream};
+
+use crate::uds::{MAX_FRAME_BYTES, UdsSecurityError, bind_hardened, ensure_peer_is_self};
+
+pub use router::{RpcMethod, RpcRouter, typed_method};
+pub use wire::{
+    CODE_INTERNAL_ERROR, CODE_INVALID_PARAMS, CODE_INVALID_REQUEST, CODE_METHOD_NOT_FOUND,
+    CODE_PARSE_ERROR, JSONRPC_VERSION, RpcError, RpcRequest, RpcResponse,
+};
+
+/// Everything that can stop this server, or stop one of its connections.
+///
+/// `#[non_exhaustive]` for the same reason [`UdsSecurityError`] carries it: the
+/// list grows as the transport tightens, and no consumer matches it
+/// exhaustively — they log it or convert it.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum RpcServerError {
+    /// The socket could not be bound or hardened.
+    #[error("bind the rpc socket at {path}: {source}")]
+    Bind {
+        /// Socket that could not be bound.
+        path: PathBuf,
+        /// Why the bind failed.
+        #[source]
+        source: UdsSecurityError,
+    },
+
+    /// The connected peer failed the uid check, or its credentials could not be
+    /// read. Fatal to the connection by design — see the module docs.
+    #[error("refuse an accepted connection: {source}")]
+    Peer {
+        /// Which check failed.
+        #[source]
+        source: UdsSecurityError,
+    },
+
+    /// Reading the request frame failed.
+    #[error("read request frame: {source}")]
+    Read {
+        /// Underlying OS error.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// The peer sent `limit` bytes without a newline.
+    #[error("request frame exceeded {limit} bytes without a newline")]
+    FrameTooLarge {
+        /// The budget, in bytes.
+        limit: u64,
+    },
+
+    /// The response frame could not be serialised.
+    #[error("serialize response frame: {source}")]
+    Encode {
+        /// Underlying serde error.
+        #[source]
+        source: serde_json::Error,
+    },
+
+    /// Writing the response frame failed.
+    #[error("write response frame: {source}")]
+    Write {
+        /// Underlying OS error.
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+/// Per-connection budgets for [`serve_until`].
+///
+/// Test: `serve_rejects_an_oversized_frame`.
+#[derive(Debug, Clone, Copy)]
+pub struct RpcServeOptions {
+    /// Longest one connection may take to deliver a complete request frame.
+    ///
+    /// Bounds the READ only. A handler is not covered, deliberately: a service
+    /// whose method runs for minutes (`trusty-review`'s is the case #6277 is
+    /// migrating) would otherwise need this raised to a figure that also lets a
+    /// peer which connects and never writes hold a task for that long.
+    pub read_timeout: Duration,
+
+    /// Largest request frame accepted without a newline.
+    ///
+    /// Defaults to [`MAX_FRAME_BYTES`], the same control-plane budget
+    /// [`crate::uds::send_framed_request`] applies on the client side. A service
+    /// exchanging bulk payloads raises it here, mirroring
+    /// [`crate::uds::send_framed_request_capped`] — the two ends must agree, so
+    /// raising one without the other only moves which side refuses.
+    ///
+    /// Not settable per method: the method name lives inside the frame this
+    /// budget governs the reading of, so it is not known until after the budget
+    /// has already been enforced.
+    pub max_frame_bytes: u64,
+}
+
+impl Default for RpcServeOptions {
+    /// Thirty seconds, and [`MAX_FRAME_BYTES`].
+    ///
+    /// The read covers a local socket writing one already-serialised frame, so
+    /// thirty seconds is headroom for a stalled writer rather than a latency
+    /// budget.
+    fn default() -> Self {
+        Self {
+            read_timeout: Duration::from_secs(30),
+            max_frame_bytes: MAX_FRAME_BYTES,
+        }
+    }
+}
+
+/// What one accepted connection turned out to be.
+///
+/// Why: a peer that connects and closes without writing is a liveness probe —
+/// [`crate::uds::probe::socket_is_serving`] and `UdsServiceSupervisor` both do
+/// exactly that. Collapsing it into the failure arm makes the one warning an
+/// operator greps for fire on every successful health check.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Served {
+    /// A frame arrived and a response frame was written.
+    Answered {
+        /// Whether that response carried a JSON-RPC error.
+        errored: bool,
+    },
+    /// The peer connected and closed without sending a byte.
+    LivenessProbe,
+}
+
+/// Serve one accepted connection: verify the peer, read one frame, answer one.
+///
+/// Why: split out so a test can drive the wire behaviour against a plain
+/// `UnixStream` pair without an accept loop.
+/// What: refuses a peer whose uid is not our own, reads bytes up to the first
+/// newline or EOF under [`RpcServeOptions::max_frame_bytes`], dispatches through
+/// `router`, and writes one newline-terminated response frame.
+///
+/// # Errors
+///
+/// Any [`RpcServerError`] variant except `Bind`. An error here means no
+/// response was written and the client sees a transport failure — which is why
+/// every failure the router can reason about is a response frame instead.
+///
+/// Test: `serve_round_trips_a_request_over_a_real_socket`,
+/// `serve_rejects_an_oversized_frame`,
+/// `handle_connection_reports_a_liveness_probe_rather_than_a_failure`.
+pub async fn handle_connection(
+    mut stream: UnixStream,
+    router: Arc<RpcRouter>,
+    options: RpcServeOptions,
+) -> Result<Served, RpcServerError> {
+    ensure_peer_is_self(&stream).map_err(|source| RpcServerError::Peer { source })?;
+
+    let mut frame: Vec<u8> = Vec::new();
+    {
+        let mut reader = BufReader::new((&mut stream).take(options.max_frame_bytes));
+        let read = tokio::time::timeout(options.read_timeout, reader.read_until(b'\n', &mut frame))
+            .await
+            .map_err(|_| RpcServerError::Read {
+                source: std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    format!("no complete frame within {:?}", options.read_timeout),
+                ),
+            })?
+            .map_err(|source| RpcServerError::Read { source })?;
+        if read == 0 && frame.is_empty() {
+            return Ok(Served::LivenessProbe);
+        }
+        if !frame.ends_with(b"\n") && frame.len() as u64 >= options.max_frame_bytes {
+            return Err(RpcServerError::FrameTooLarge {
+                limit: options.max_frame_bytes,
+            });
+        }
+    }
+
+    let response = router.dispatch(&frame).await;
+    let errored = response.is_error();
+    // One owned, already-newline-terminated buffer, so the response leaves in a
+    // single write rather than a serialise-then-append pair.
+    let bytes =
+        crate::uds::encode_frame(&response).map_err(|source| RpcServerError::Encode { source })?;
+    stream
+        .write_all(&bytes)
+        .await
+        .map_err(|source| RpcServerError::Write { source })?;
+    stream
+        .flush()
+        .await
+        .map_err(|source| RpcServerError::Write { source })?;
+    Ok(Served::Answered { errored })
+}
+
+/// Accept and serve connections until `shutdown` resolves.
+///
+/// Why: the whole loop of a UDS daemon, so a service supplies a [`RpcRouter`]
+/// and nothing else.
+///
+/// What: each connection is handed to `tokio::spawn` rather than served inline.
+/// That is a REQUIREMENT, not a throughput preference: `uds::probe`'s
+/// `SocketVerdict` docs record that on macOS a bound listener with a saturated
+/// accept queue answers ECONNREFUSED, which a prober classifies as `NotServing`.
+/// A server that dispatched inline would be read as dead under exactly the load
+/// it was handling.
+///
+/// The listener is borrowed, not consumed, so a caller can unlink the socket
+/// while it is still bound — see the module docs for why that order matters.
+///
+/// A connection that errors is logged and dropped without answering.
+///
+/// Test: `serve_round_trips_a_request_over_a_real_socket`,
+/// `serve_stops_on_shutdown`,
+/// `serve_handles_concurrent_connections_without_serialising`.
+pub async fn serve_until(
+    listener: &UnixListener,
+    router: Arc<RpcRouter>,
+    options: RpcServeOptions,
+    shutdown: impl std::future::Future<Output = ()> + Send,
+) {
+    tokio::pin!(shutdown);
+    loop {
+        let accepted = tokio::select! {
+            biased;
+            () = &mut shutdown => return,
+            accepted = listener.accept() => accepted,
+        };
+        let stream = match accepted {
+            Ok((stream, _)) => stream,
+            Err(e) => {
+                tracing::warn!(error = %e, "uds rpc listener accept failed");
+                continue;
+            }
+        };
+        let router = Arc::clone(&router);
+        tokio::spawn(async move {
+            match handle_connection(stream, router, options).await {
+                Ok(Served::Answered { .. }) => {}
+                Ok(Served::LivenessProbe) => {
+                    tracing::debug!("liveness probe connected and closed without a frame");
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "uds rpc connection failed; nothing was answered");
+                }
+            }
+        });
+    }
+}
+
+/// A framed JSON-RPC server bound to one hardened socket.
+///
+/// Why: the shape a daemon's `serve` command wants — one value carrying the
+/// path, the methods and the budgets, with [`run`] as its whole body.
+/// What: [`RpcServer::run`] binds through [`bind_hardened`], serves until the
+/// caller's shutdown future resolves, then unlinks the socket file.
+/// Test: `server_round_trips_and_removes_its_socket_on_shutdown`.
+///
+/// [`run`]: RpcServer::run
+#[derive(Debug)]
+pub struct RpcServer {
+    socket: PathBuf,
+    router: Arc<RpcRouter>,
+    options: RpcServeOptions,
+}
+
+impl RpcServer {
+    /// A server that will bind `socket` and serve `router`.
+    pub fn new(socket: impl Into<PathBuf>, router: RpcRouter) -> Self {
+        Self {
+            socket: socket.into(),
+            router: Arc::new(router),
+            options: RpcServeOptions::default(),
+        }
+    }
+
+    /// Override the per-connection budgets.
+    pub fn with_options(mut self, options: RpcServeOptions) -> Self {
+        self.options = options;
+        self
+    }
+
+    /// Socket this server binds.
+    pub fn socket(&self) -> &Path {
+        &self.socket
+    }
+
+    /// Bind and serve until `shutdown` resolves, then unlink the socket.
+    ///
+    /// [`bind_hardened`] refuses a path a socket file already occupies rather
+    /// than clobbering what might be a live owner. A service that is respawned
+    /// on demand, and so has to take over the corpse a killed predecessor left,
+    /// binds with [`crate::uds::bind_singleton_hardened`] itself and drives
+    /// [`serve_until`] directly — that decision is the caller's, which is the
+    /// same split `bind_hardened`'s own docs make.
+    ///
+    /// # Errors
+    ///
+    /// [`RpcServerError::Bind`] when the path cannot be bound or hardened.
+    /// Per-connection failures never reach here; they are logged and the loop
+    /// continues.
+    ///
+    /// Test: `server_round_trips_and_removes_its_socket_on_shutdown`.
+    pub async fn run(
+        self,
+        shutdown: impl std::future::Future<Output = ()> + Send,
+    ) -> Result<(), RpcServerError> {
+        let listener = bind_hardened(&self.socket).map_err(|source| RpcServerError::Bind {
+            path: self.socket.clone(),
+            source,
+        })?;
+
+        tracing::info!(
+            socket = %self.socket.display(),
+            methods = ?self.router.method_names().collect::<Vec<_>>(),
+            "uds rpc server bound"
+        );
+
+        serve_until(&listener, Arc::clone(&self.router), self.options, shutdown).await;
+
+        // Unlink BEFORE dropping the listener — see the module docs. A failure
+        // is not worth an exit code: the file is either already gone or belongs
+        // to whoever rebound the path.
+        if let Err(e) = std::fs::remove_file(&self.socket) {
+            tracing::debug!(socket = %self.socket.display(), error = %e, "socket already gone");
+        }
+        drop(listener);
+        Ok(())
+    }
+}

--- a/crates/trusty-common/src/uds/server/mod.rs
+++ b/crates/trusty-common/src/uds/server/mod.rs
@@ -130,17 +130,28 @@ pub struct RpcServeOptions {
     /// peer which connects and never writes hold a task for that long.
     pub read_timeout: Duration,
 
-    /// Largest request frame accepted without a newline.
+    /// Largest request frame accepted, counting its terminating newline.
+    ///
+    /// Precisely: a frame is accepted when its JSON body plus the `\n` is at
+    /// most `max_frame_bytes`, so the usable payload is `max_frame_bytes - 1`.
+    /// The terminator counting against the budget is not an accident to be
+    /// tidied away — [`crate::uds::rpc`]'s `read_one_frame` reads with the same
+    /// `take(max_frame_bytes)` and the same comparison, and the two ends have to
+    /// draw the line at the same byte. Moving it here alone would produce a
+    /// frame one end sends happily and the other refuses.
     ///
     /// Defaults to [`MAX_FRAME_BYTES`], the same control-plane budget
-    /// [`crate::uds::send_framed_request`] applies on the client side. A service
-    /// exchanging bulk payloads raises it here, mirroring
-    /// [`crate::uds::send_framed_request_capped`] — the two ends must agree, so
-    /// raising one without the other only moves which side refuses.
+    /// [`crate::uds::send_framed_request`] applies. A service exchanging bulk
+    /// payloads raises it here, mirroring
+    /// [`crate::uds::send_framed_request_capped`] — and must raise the client's
+    /// to match, or it has only moved which side refuses.
     ///
     /// Not settable per method: the method name lives inside the frame this
     /// budget governs the reading of, so it is not known until after the budget
     /// has already been enforced.
+    ///
+    /// Test: `frame_of_exactly_the_budget_including_its_newline_is_accepted`,
+    /// `serve_rejects_an_oversized_frame`.
     pub max_frame_bytes: u64,
 }
 
@@ -253,11 +264,13 @@ pub async fn handle_connection(
 /// The listener is borrowed, not consumed, so a caller can unlink the socket
 /// while it is still bound — see the module docs for why that order matters.
 ///
-/// A connection that errors is logged and dropped without answering.
+/// A connection that errors — or whose handler panics — is logged and dropped
+/// without answering, and the loop keeps accepting.
 ///
 /// Test: `serve_round_trips_a_request_over_a_real_socket`,
 /// `serve_stops_on_shutdown`,
-/// `serve_handles_concurrent_connections_without_serialising`.
+/// `serve_handles_concurrent_connections_without_serialising`,
+/// `serve_survives_a_panicking_handler_and_answers_the_next_connection`.
 pub async fn serve_until(
     listener: &UnixListener,
     router: Arc<RpcRouter>,
@@ -280,13 +293,33 @@ pub async fn serve_until(
         };
         let router = Arc::clone(&router);
         tokio::spawn(async move {
-            match handle_connection(stream, router, options).await {
-                Ok(Served::Answered { .. }) => {}
-                Ok(Served::LivenessProbe) => {
+            // #6277 review: the connection runs in an INNER task whose
+            // `JoinHandle` is awaited, because a panicking handler is otherwise
+            // invisible. Tokio stores the panic payload in the handle and drops
+            // it with the handle, so a dropped handle turns a caller-visible
+            // hang-up into a server that logged nothing at all. Awaiting it
+            // costs one task per connection and buys the one log line that says
+            // which method took the process down a path nobody expected.
+            let inner = tokio::spawn(handle_connection(stream, router, options));
+            match inner.await {
+                Ok(Ok(Served::Answered { .. })) => {}
+                Ok(Ok(Served::LivenessProbe)) => {
                     tracing::debug!("liveness probe connected and closed without a frame");
                 }
-                Err(e) => {
+                Ok(Err(e)) => {
                     tracing::warn!(error = %e, "uds rpc connection failed; nothing was answered");
+                }
+                // A panic is the handler's bug, not the client's, so it is an
+                // ERROR rather than the WARN a refused or broken connection
+                // gets. `JoinError`'s `Display` carries the panic message.
+                Err(join) if join.is_panic() => {
+                    tracing::error!(
+                        error = %join,
+                        "uds rpc handler panicked; the connection was dropped unanswered"
+                    );
+                }
+                Err(join) => {
+                    tracing::warn!(error = %join, "uds rpc connection task was cancelled");
                 }
             }
         });

--- a/crates/trusty-common/src/uds/server/router.rs
+++ b/crates/trusty-common/src/uds/server/router.rs
@@ -1,0 +1,215 @@
+//! Method-name dispatch: the decision half of the server, over bytes.
+//!
+//! Why: `webhook_relay::serve::dispatch_frame` is a synchronous function over a
+//! byte slice precisely so every arm — including the ones that must never
+//! succeed — is assertable without a socket. That property is worth keeping and
+//! is why the decision lives here rather than inside the accept loop. What
+//! changes is the number of methods: `webhook_relay` serves exactly one and
+//! hardcodes it, so its dispatcher cannot be reused by a service with three.
+//!
+//! What: [`RpcRouter`] maps a method name to an [`RpcMethod`]. [`typed_method`]
+//! wraps an `async fn(Req) -> Result<Resp, RpcError>` so the caller names its
+//! own request and response types and never touches `serde_json::Value`.
+//! [`RpcRouter::dispatch`] parses one frame, checks the envelope, looks up the
+//! method, and returns the response frame to write — every failure as a coded
+//! JSON-RPC error rather than a dropped connection, so a drifted client reads
+//! the reason instead of a transport failure.
+//!
+//! Dispatch is `async` and takes `&self`, so one router serves every connection
+//! concurrently; nothing here holds a lock across a handler call.
+//!
+//! Test: `super::tests` — `dispatch_*`.
+
+use std::collections::BTreeMap;
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+
+use super::wire::{
+    CODE_INVALID_REQUEST, CODE_PARSE_ERROR, JSONRPC_VERSION, RpcError, RpcRequest, RpcResponse,
+};
+
+/// One method's implementation.
+///
+/// Why: object-safe so a router can hold a heterogeneous set of methods behind
+/// `Arc<dyn RpcMethod>`. Most callers never name this trait — [`typed_method`]
+/// builds an implementation from an ordinary async function.
+/// What: takes the raw `params` value and returns the raw `result` value, or an
+/// [`RpcError`] that becomes the response's error half verbatim.
+/// Test: `dispatch_routes_to_the_registered_handler`.
+#[async_trait]
+pub trait RpcMethod: Send + Sync + 'static {
+    /// Run this method against one decoded `params` payload.
+    async fn call(&self, params: serde_json::Value) -> Result<serde_json::Value, RpcError>;
+}
+
+/// Adapter behind [`typed_method`]; `PhantomData<fn(Req) -> Resp>` keeps the
+/// struct `Send + Sync` whatever `Req` and `Resp` are.
+struct Typed<Req, Resp, F> {
+    call: F,
+    _types: PhantomData<fn(Req) -> Resp>,
+}
+
+#[async_trait]
+impl<Req, Resp, F, Fut> RpcMethod for Typed<Req, Resp, F>
+where
+    Req: DeserializeOwned + Send + 'static,
+    Resp: Serialize + Send + 'static,
+    F: Fn(Req) -> Fut + Send + Sync + 'static,
+    Fut: std::future::Future<Output = Result<Resp, RpcError>> + Send + 'static,
+{
+    async fn call(&self, params: serde_json::Value) -> Result<serde_json::Value, RpcError> {
+        let request: Req = serde_json::from_value(params)
+            .map_err(|e| RpcError::invalid_params(format!("params do not decode: {e}")))?;
+        let response = (self.call)(request).await?;
+        // A handler whose own response type will not serialise is a programmer
+        // error on this side of the wire, so it reports as internal rather than
+        // as anything the caller could have sent differently.
+        serde_json::to_value(&response)
+            .map_err(|e| RpcError::internal(format!("serialize response: {e}")))
+    }
+}
+
+/// Build an [`RpcMethod`] from an async function over the caller's own types.
+///
+/// Why: this is what keeps the server generic without pushing `serde_json::
+/// Value` into every service that uses it. The caller defines `Req` and `Resp`;
+/// the decode failure becomes [`RpcError::invalid_params`] with the serde
+/// message attached, which is the error shape an axum `Json` extractor produces
+/// for the same bad body.
+/// What: wraps `call` so `params` is deserialised into `Req` before it runs and
+/// its `Resp` is serialised back into the response's `result`.
+/// Test: `dispatch_reports_invalid_params_for_an_undecodable_payload`,
+/// `dispatch_routes_to_the_registered_handler`.
+pub fn typed_method<Req, Resp, F, Fut>(call: F) -> impl RpcMethod
+where
+    Req: DeserializeOwned + Send + 'static,
+    Resp: Serialize + Send + 'static,
+    F: Fn(Req) -> Fut + Send + Sync + 'static,
+    Fut: std::future::Future<Output = Result<Resp, RpcError>> + Send + 'static,
+{
+    Typed::<Req, Resp, F> {
+        call,
+        _types: PhantomData,
+    }
+}
+
+/// The set of methods one socket serves.
+///
+/// Why: the caller-supplied half of the server. Everything else in this module
+/// family — hardening, framing, the accept loop — is fixed; this is the only
+/// part a service defines.
+/// What: a name-to-handler map with a consuming builder, and [`dispatch`] over
+/// one raw frame. `BTreeMap` rather than `HashMap` so
+/// [`RpcError::method_not_found`] lists the known methods in a stable order and
+/// two runs of a test compare equal.
+/// Test: `dispatch_*`.
+///
+/// [`dispatch`]: RpcRouter::dispatch
+#[derive(Default)]
+pub struct RpcRouter {
+    methods: BTreeMap<String, Arc<dyn RpcMethod>>,
+}
+
+impl std::fmt::Debug for RpcRouter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RpcRouter")
+            .field("methods", &self.method_names().collect::<Vec<_>>())
+            .finish()
+    }
+}
+
+impl RpcRouter {
+    /// An empty router. Every method it is asked for reports
+    /// [`RpcError::method_not_found`] until one is registered.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register `handler` under `name`, replacing any previous registration.
+    pub fn method(mut self, name: impl Into<String>, handler: impl RpcMethod) -> Self {
+        self.methods.insert(name.into(), Arc::new(handler));
+        self
+    }
+
+    /// Register an async function over the caller's own request and response
+    /// types — [`method`] composed with [`typed_method`].
+    ///
+    /// [`method`]: RpcRouter::method
+    pub fn typed<Req, Resp, F, Fut>(self, name: impl Into<String>, call: F) -> Self
+    where
+        Req: DeserializeOwned + Send + 'static,
+        Resp: Serialize + Send + 'static,
+        F: Fn(Req) -> Fut + Send + Sync + 'static,
+        Fut: std::future::Future<Output = Result<Resp, RpcError>> + Send + 'static,
+    {
+        self.method(name, typed_method::<Req, Resp, F, Fut>(call))
+    }
+
+    /// The registered method names, in sorted order.
+    pub fn method_names(&self) -> impl Iterator<Item = &str> {
+        self.methods.keys().map(String::as_str)
+    }
+
+    /// Decide the response for one request frame.
+    ///
+    /// What, in order: parse the frame; refuse a `jsonrpc` that is not
+    /// [`JSONRPC_VERSION`]; refuse a method no handler is registered for; then
+    /// run the handler. A parse failure answers with a `null` id because there
+    /// was no readable id to echo — every other arm echoes the request's.
+    ///
+    /// Never returns `Err`: a failure to serve is itself a response frame, so
+    /// the caller always has something to write back. Hanging up instead would
+    /// give the client a transport error where a reason exists.
+    ///
+    /// Test: `dispatch_routes_to_the_registered_handler`,
+    /// `dispatch_reports_method_not_found_for_an_unregistered_method`,
+    /// `dispatch_rejects_an_unparseable_frame`,
+    /// `dispatch_rejects_a_wrong_jsonrpc_version`,
+    /// `dispatch_reports_invalid_params_for_an_undecodable_payload`,
+    /// `dispatch_propagates_a_handler_error_verbatim`.
+    pub async fn dispatch(&self, frame: &[u8]) -> RpcResponse {
+        let request: RpcRequest = match serde_json::from_slice(frame) {
+            Ok(r) => r,
+            Err(e) => {
+                return RpcResponse::failure(
+                    serde_json::Value::Null,
+                    RpcError::new(CODE_PARSE_ERROR, format!("unparseable request frame: {e}")),
+                );
+            }
+        };
+
+        if request.jsonrpc != JSONRPC_VERSION {
+            return RpcResponse::failure(
+                request.id,
+                RpcError::new(
+                    CODE_INVALID_REQUEST,
+                    format!(
+                        "unsupported jsonrpc version {:?}; this listener speaks {JSONRPC_VERSION}",
+                        request.jsonrpc
+                    ),
+                ),
+            );
+        }
+
+        let Some(handler) = self.methods.get(&request.method) else {
+            let known: Vec<&str> = self.method_names().collect();
+            return RpcResponse::failure(
+                request.id,
+                RpcError::method_not_found(&request.method, &known),
+            );
+        };
+
+        // Cloned out of the map before the await so the borrow of `self.methods`
+        // ends here — a handler is free to run for as long as it needs without
+        // holding anything the next connection wants.
+        let handler = Arc::clone(handler);
+        match handler.call(request.params).await {
+            Ok(result) => RpcResponse::success(request.id, result),
+            Err(error) => RpcResponse::failure(request.id, error),
+        }
+    }
+}

--- a/crates/trusty-common/src/uds/server/tests.rs
+++ b/crates/trusty-common/src/uds/server/tests.rs
@@ -205,15 +205,19 @@ async fn call(
         .expect("round trip")
 }
 
-/// Poll until the server has bound, so a test never races the accept loop.
+/// Poll until the server is answering, so a test never races the accept loop.
+///
+/// `socket.exists()` is not the readiness question: `bind_hardened` creates the
+/// file before `serve_until` reaches its first `accept`, so an existence check
+/// can hand the test a socket nothing is serving yet.
 async fn await_socket(socket: &std::path::Path) {
     for _ in 0..200 {
-        if socket.exists() {
+        if crate::uds::socket_is_serving(socket, Duration::from_millis(200)).await {
             return;
         }
         tokio::time::sleep(Duration::from_millis(10)).await;
     }
-    panic!("server never bound {}", socket.display());
+    panic!("server never began serving {}", socket.display());
 }
 
 #[tokio::test]
@@ -288,6 +292,47 @@ async fn serve_handles_concurrent_connections_without_serialising() {
 }
 
 #[tokio::test]
+async fn serve_survives_a_panicking_handler_and_answers_the_next_connection() {
+    // #6277 review: a panicking handler used to be swallowed whole — the
+    // client saw a dropped connection and the server logged nothing. The log
+    // line itself needs a global tracing subscriber to assert, which is not
+    // worth the cross-test interference; what is worth asserting is that one
+    // panicking connection neither answers nor takes the accept loop with it.
+    let router = RpcRouter::new()
+        .typed("boom", |_req: ()| async move {
+            panic!("a handler exploded");
+            #[allow(unreachable_code)]
+            Ok::<(), RpcError>(())
+        })
+        .typed("greet", |req: Greet| async move {
+            Ok(Greeting {
+                text: format!("hello {}", req.name),
+            })
+        });
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let (socket, _stop, _handle) = spawn_server(tmp.path(), router, RpcServeOptions::default());
+    await_socket(&socket).await;
+
+    let request = json!({ "jsonrpc": "2.0", "id": 1, "method": "boom", "params": null });
+    let panicked: Result<RpcResponse, _> =
+        crate::uds::send_framed_request(&socket, &request, Duration::from_secs(10)).await;
+    assert!(
+        panicked.is_err(),
+        "a panicking handler answers nothing; the client must see a transport \
+         failure rather than hang: {panicked:?}"
+    );
+
+    // The property that matters: the server is still serving.
+    let response = call(&socket, 2, "greet", json!({ "name": "ada" })).await;
+    assert_eq!(
+        response.result,
+        Some(json!({ "text": "hello ada" })),
+        "one panicking connection must not stop the accept loop"
+    );
+}
+
+#[tokio::test]
 async fn serve_stops_on_shutdown() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let (socket, stop, handle) =
@@ -355,6 +400,55 @@ async fn serve_rejects_an_oversized_frame() {
         other => panic!("expected FrameTooLarge, got {other:?}"),
     }
     writer.abort();
+}
+
+/// Serve one frame over a socket pair under `max_frame_bytes`, holding the
+/// write half open so the outcome comes from the budget rather than an EOF.
+async fn serve_one_frame(body: Vec<u8>, max_frame_bytes: u64) -> Result<Served, RpcServerError> {
+    let (mut client, server) = tokio::net::UnixStream::pair().expect("socketpair");
+    let writer = tokio::spawn(async move {
+        use tokio::io::AsyncWriteExt as _;
+        let _ = client.write_all(&body).await;
+        let _ = client.flush().await;
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    });
+    let options = RpcServeOptions {
+        max_frame_bytes,
+        ..RpcServeOptions::default()
+    };
+    let outcome = handle_connection(server, Arc::new(greeting_router()), options).await;
+    writer.abort();
+    outcome
+}
+
+#[tokio::test]
+async fn frame_of_exactly_the_budget_including_its_newline_is_accepted() {
+    // The documented boundary, asserted from both sides: `max_frame_bytes`
+    // counts the terminator, so a JSON body of `max_frame_bytes - 1` is the
+    // largest one that fits. `uds::rpc`'s reader draws the line at the same
+    // byte, and a test here is what stops the two ends drifting apart.
+    let empty = frame(1, "greet", json!({ "name": "" })).len();
+    let budget = (empty + 40) as u64;
+    let padding = "x".repeat(budget as usize - 1 - empty);
+    let mut body = frame(1, "greet", json!({ "name": padding }));
+    assert_eq!(
+        body.len() as u64,
+        budget - 1,
+        "the JSON body must be one byte short of the budget"
+    );
+    body.push(b'\n');
+
+    assert_eq!(
+        serve_one_frame(body.clone(), budget)
+            .await
+            .expect("a frame that exactly fills the budget is accepted"),
+        Served::Answered { errored: false }
+    );
+
+    match serve_one_frame(body, budget - 1).await {
+        Err(RpcServerError::FrameTooLarge { limit }) => assert_eq!(limit, budget - 1),
+        other => panic!("one byte over the budget must be refused, got {other:?}"),
+    }
 }
 
 #[tokio::test]

--- a/crates/trusty-common/src/uds/server/tests.rs
+++ b/crates/trusty-common/src/uds/server/tests.rs
@@ -1,0 +1,401 @@
+//! Coverage for the #6277 generic UDS JSON-RPC server.
+//!
+//! The `dispatch_*` tests drive [`RpcRouter::dispatch`] over raw bytes, so every
+//! refusal arm is asserted without a socket. The `serve_*` and `server_*` tests
+//! stand up a real listener bound through `bind_hardened` and dial it with
+//! `uds::send_framed_request`, which is the client half production callers use —
+//! so the framing contract is proven end to end rather than against a bespoke
+//! test writer.
+//!
+//! The foreign-peer refusal is not reproduced here: rejecting a connection from
+//! another uid needs a second account, and the decision behind it is already
+//! covered as a pure function by `uds::tests`' `peer_uid_verdict_*`. What this
+//! file proves is that [`handle_connection`] calls it before reading a byte.
+
+use super::*;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+/// A test request/response pair, so the typed-handler path is exercised with
+/// real caller-defined types rather than `serde_json::Value`.
+#[derive(Debug, Serialize, Deserialize)]
+struct Greet {
+    name: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+struct Greeting {
+    text: String,
+}
+
+/// A router with one typed method and one that always fails.
+fn greeting_router() -> RpcRouter {
+    RpcRouter::new()
+        .typed("greet", |req: Greet| async move {
+            Ok(Greeting {
+                text: format!("hello {}", req.name),
+            })
+        })
+        .typed("explode", |_req: ()| async move {
+            Err::<(), _>(RpcError::new(-32001, "handler said no"))
+        })
+}
+
+/// One request frame as bytes, newline excluded — `dispatch` takes the frame
+/// body, and the framing is `encode_frame`'s job.
+fn frame(id: u64, method: &str, params: serde_json::Value) -> Vec<u8> {
+    serde_json::to_vec(&json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": method,
+        "params": params,
+    }))
+    .expect("serialize test frame")
+}
+
+// ── dispatch: the decision, without a socket ────────────────────────────────
+
+#[tokio::test]
+async fn dispatch_routes_to_the_registered_handler() {
+    let response = greeting_router()
+        .dispatch(&frame(7, "greet", json!({ "name": "ada" })))
+        .await;
+
+    assert_eq!(response.id, json!(7), "the request id must be echoed back");
+    assert!(response.error.is_none(), "unexpected error: {response:?}");
+    let greeting: Greeting =
+        serde_json::from_value(response.result.expect("a result")).expect("decode result");
+    assert_eq!(
+        greeting,
+        Greeting {
+            text: "hello ada".to_string()
+        }
+    );
+}
+
+#[tokio::test]
+async fn dispatch_reports_method_not_found_for_an_unregistered_method() {
+    // Why: the whole point of a method table. A server that hung up instead
+    // would give a drifted client a transport error where a name exists.
+    let response = greeting_router()
+        .dispatch(&frame(1, "review", json!(null)))
+        .await;
+
+    let error = response.error.expect("an error");
+    assert_eq!(error.code, CODE_METHOD_NOT_FOUND);
+    assert!(
+        error.message.contains("review") && error.message.contains("greet"),
+        "the refusal must name both the bad method and the served ones: {}",
+        error.message
+    );
+    assert_eq!(response.id, json!(1));
+}
+
+#[tokio::test]
+async fn dispatch_rejects_an_unparseable_frame() {
+    let response = greeting_router().dispatch(b"{not json").await;
+
+    assert_eq!(
+        response.error.expect("an error").code,
+        CODE_PARSE_ERROR,
+        "an unreadable frame is a parse error, not a method-not-found"
+    );
+    assert_eq!(
+        response.id,
+        serde_json::Value::Null,
+        "there was no readable id to echo"
+    );
+}
+
+#[tokio::test]
+async fn dispatch_rejects_a_wrong_jsonrpc_version() {
+    let raw = serde_json::to_vec(&json!({
+        "jsonrpc": "1.0",
+        "id": 3,
+        "method": "greet",
+        "params": { "name": "ada" },
+    }))
+    .expect("serialize");
+
+    let response = greeting_router().dispatch(&raw).await;
+
+    assert_eq!(response.error.expect("an error").code, CODE_INVALID_REQUEST);
+}
+
+#[tokio::test]
+async fn dispatch_reports_invalid_params_for_an_undecodable_payload() {
+    // `greet` needs `{ "name": String }`; a number is the shape an axum `Json`
+    // extractor would reject with a 422, and must not reach the handler.
+    let response = greeting_router()
+        .dispatch(&frame(4, "greet", json!({ "name": 17 })))
+        .await;
+
+    let error = response.error.expect("an error");
+    assert_eq!(error.code, CODE_INVALID_PARAMS);
+    assert!(
+        error.message.contains("params do not decode"),
+        "the serde reason must survive: {}",
+        error.message
+    );
+}
+
+#[tokio::test]
+async fn dispatch_propagates_a_handler_error_verbatim() {
+    let response = greeting_router()
+        .dispatch(&frame(5, "explode", json!(null)))
+        .await;
+
+    assert_eq!(
+        response.error.expect("an error"),
+        RpcError::new(-32001, "handler said no"),
+        "a handler's own code and message must not be rewritten"
+    );
+}
+
+#[test]
+fn method_names_are_sorted_and_complete() {
+    let router = greeting_router();
+    assert_eq!(
+        router.method_names().collect::<Vec<_>>(),
+        vec!["explode", "greet"]
+    );
+}
+
+// ── the socket ──────────────────────────────────────────────────────────────
+
+/// Bind a server on a fresh temp socket and serve it until the returned sender
+/// is fired or dropped. Returns the socket path, the shutdown trigger, and the
+/// join handle for the serving task.
+fn spawn_server(
+    dir: &std::path::Path,
+    router: RpcRouter,
+    options: RpcServeOptions,
+) -> (
+    std::path::PathBuf,
+    tokio::sync::oneshot::Sender<()>,
+    tokio::task::JoinHandle<Result<(), RpcServerError>>,
+) {
+    let socket = dir.join("rpc.sock");
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    let server = RpcServer::new(socket.clone(), router).with_options(options);
+    let handle = tokio::spawn(async move {
+        server
+            .run(async move {
+                let _ = rx.await;
+            })
+            .await
+    });
+    (socket, tx, handle)
+}
+
+/// Dial `socket` with the production client half and return the response frame.
+async fn call(
+    socket: &std::path::Path,
+    id: u64,
+    method: &str,
+    params: serde_json::Value,
+) -> RpcResponse {
+    let request = json!({ "jsonrpc": "2.0", "id": id, "method": method, "params": params });
+    crate::uds::send_framed_request(socket, &request, Duration::from_secs(10))
+        .await
+        .expect("round trip")
+}
+
+/// Poll until the server has bound, so a test never races the accept loop.
+async fn await_socket(socket: &std::path::Path) {
+    for _ in 0..200 {
+        if socket.exists() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("server never bound {}", socket.display());
+}
+
+#[tokio::test]
+async fn serve_round_trips_a_request_over_a_real_socket() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let (socket, _stop, _handle) =
+        spawn_server(tmp.path(), greeting_router(), RpcServeOptions::default());
+    await_socket(&socket).await;
+
+    let response = call(&socket, 42, "greet", json!({ "name": "grace" })).await;
+
+    assert_eq!(response.id, json!(42));
+    let greeting: Greeting =
+        serde_json::from_value(response.result.expect("a result")).expect("decode");
+    assert_eq!(greeting.text, "hello grace");
+}
+
+#[tokio::test]
+async fn serve_answers_an_unknown_method_rather_than_hanging_up() {
+    // Over the wire, not just in `dispatch`: the client must get a frame back,
+    // because a dropped connection surfaces as `UdsRpcError::NoResponse` and
+    // tells the caller nothing about why.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let (socket, _stop, _handle) =
+        spawn_server(tmp.path(), greeting_router(), RpcServeOptions::default());
+    await_socket(&socket).await;
+
+    let response = call(&socket, 1, "nope", json!(null)).await;
+
+    assert_eq!(
+        response.error.expect("an error").code,
+        CODE_METHOD_NOT_FOUND
+    );
+}
+
+#[tokio::test]
+async fn serve_handles_concurrent_connections_without_serialising() {
+    // A handler that cannot finish until every peer has arrived can only
+    // complete if the connections run in parallel. A loop that dispatched
+    // inline deadlocks here — and would also read as `NotServing` to a prober
+    // under load, which is why the per-connection spawn is a requirement rather
+    // than a throughput choice.
+    let peers = 4usize;
+    let barrier = Arc::new(tokio::sync::Barrier::new(peers));
+    let router = RpcRouter::new().typed("wait", move |_req: ()| {
+        let barrier = Arc::clone(&barrier);
+        async move {
+            barrier.wait().await;
+            Ok::<bool, RpcError>(true)
+        }
+    });
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let (socket, _stop, _handle) = spawn_server(tmp.path(), router, RpcServeOptions::default());
+    await_socket(&socket).await;
+
+    let mut calls = Vec::new();
+    for n in 0..peers {
+        let socket = socket.clone();
+        calls.push(tokio::spawn(async move {
+            call(&socket, n as u64, "wait", json!(null)).await
+        }));
+    }
+    for handle in calls {
+        let response = handle.await.expect("join");
+        assert_eq!(
+            response.result,
+            Some(json!(true)),
+            "a serialised server deadlocks here instead of answering"
+        );
+    }
+}
+
+#[tokio::test]
+async fn serve_stops_on_shutdown() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let (socket, stop, handle) =
+        spawn_server(tmp.path(), greeting_router(), RpcServeOptions::default());
+    await_socket(&socket).await;
+
+    stop.send(()).expect("signal shutdown");
+
+    tokio::time::timeout(Duration::from_secs(5), handle)
+        .await
+        .expect("the server must return once shutdown resolves")
+        .expect("join")
+        .expect("clean shutdown");
+}
+
+#[tokio::test]
+async fn server_round_trips_and_removes_its_socket_on_shutdown() {
+    // `bind_hardened` binds and chmods; nothing in it or in tokio's `Drop`
+    // unlinks the path, so without the explicit `remove_file` the next start
+    // fails to bind. This is the regression proof for that cleanup.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let (socket, stop, handle) =
+        spawn_server(tmp.path(), greeting_router(), RpcServeOptions::default());
+    await_socket(&socket).await;
+
+    let response = call(&socket, 9, "greet", json!({ "name": "ada" })).await;
+    assert!(response.error.is_none());
+
+    stop.send(()).expect("signal shutdown");
+    handle.await.expect("join").expect("clean shutdown");
+
+    assert!(
+        !socket.exists(),
+        "the socket file must be gone after shutdown, or the next bind fails"
+    );
+}
+
+// ── one connection, driven directly ─────────────────────────────────────────
+
+#[tokio::test]
+async fn serve_rejects_an_oversized_frame() {
+    // The budget is the server's half of the contract `send_framed_request_capped`
+    // states on the client side. Over budget must be a refusal, not an
+    // unbounded read.
+    let options = RpcServeOptions {
+        max_frame_bytes: 64,
+        ..RpcServeOptions::default()
+    };
+    let (mut client, server) = tokio::net::UnixStream::pair().expect("socketpair");
+
+    let writer = tokio::spawn(async move {
+        use tokio::io::AsyncWriteExt as _;
+        let huge = frame(1, "greet", json!({ "name": "x".repeat(4096) }));
+        let _ = client.write_all(&huge).await;
+        let _ = client.flush().await;
+        // Hold the write half open: the refusal must come from the budget, not
+        // from an EOF that happened to arrive first.
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    });
+
+    let outcome = handle_connection(server, Arc::new(greeting_router()), options).await;
+
+    match outcome {
+        Err(RpcServerError::FrameTooLarge { limit }) => assert_eq!(limit, 64),
+        other => panic!("expected FrameTooLarge, got {other:?}"),
+    }
+    writer.abort();
+}
+
+#[tokio::test]
+async fn handle_connection_reports_a_liveness_probe_rather_than_a_failure() {
+    // `uds::probe::socket_is_serving` connects and closes without writing. If
+    // that read as a failed request, the one warning an operator greps for
+    // would fire on every health check.
+    let (client, server) = tokio::net::UnixStream::pair().expect("socketpair");
+    drop(client);
+
+    let served = handle_connection(
+        server,
+        Arc::new(greeting_router()),
+        RpcServeOptions::default(),
+    )
+    .await
+    .expect("a closed probe is not an error");
+
+    assert_eq!(served, Served::LivenessProbe);
+}
+
+#[tokio::test]
+async fn handle_connection_reports_an_error_response_as_answered() {
+    let (mut client, server) = tokio::net::UnixStream::pair().expect("socketpair");
+    let writer = tokio::spawn(async move {
+        use tokio::io::AsyncWriteExt as _;
+        let mut bytes = frame(1, "nope", json!(null));
+        bytes.push(b'\n');
+        let _ = client.write_all(&bytes).await;
+        let _ = client.flush().await;
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    });
+
+    let served = handle_connection(
+        server,
+        Arc::new(greeting_router()),
+        RpcServeOptions::default(),
+    )
+    .await
+    .expect("a refusal is still an answer");
+
+    assert_eq!(served, Served::Answered { errored: true });
+    writer.abort();
+}

--- a/crates/trusty-common/src/uds/server/wire.rs
+++ b/crates/trusty-common/src/uds/server/wire.rs
@@ -1,0 +1,161 @@
+//! The JSON-RPC 2.0 envelope [`super::RpcRouter`] reads and writes.
+//!
+//! Why: [`crate::uds::rpc`] is framing-only on purpose — `Req` and `Resp` are
+//! whatever the caller names, and no envelope is imposed. That is right for a
+//! client helper and wrong for a server that must answer an unknown method by
+//! name rather than hanging up. `webhook_relay` proved the shape a server needs
+//! (a `jsonrpc` version check, a method check, a coded error frame), but it
+//! spells that shape out for exactly one method and binds it to a durable-
+//! delivery contract. These are the same fields with the single-method
+//! assumption removed.
+//!
+//! What: [`RpcRequest`] in, [`RpcResponse`] out, [`RpcError`] for the failure
+//! half, and the five JSON-RPC codes a dispatcher can produce. The `params` and
+//! `result` payloads stay `serde_json::Value` here; the caller's own request and
+//! response types are decoded one layer up, in [`super::typed_method`].
+//!
+//! Test: `super::tests` — `dispatch_*` for the codes, `wire_*` for the shapes.
+
+use serde::{Deserialize, Serialize};
+
+/// The only `jsonrpc` version this server answers.
+pub const JSONRPC_VERSION: &str = "2.0";
+
+/// JSON-RPC code for a frame that is not valid JSON.
+pub const CODE_PARSE_ERROR: i64 = -32700;
+
+/// JSON-RPC code for a frame whose envelope is wrong (unsupported `jsonrpc`).
+pub const CODE_INVALID_REQUEST: i64 = -32600;
+
+/// JSON-RPC code for a method no handler is registered for.
+///
+/// Mirrors `webhook_relay::serve::CODE_METHOD_NOT_FOUND` deliberately: a client
+/// that drifts must see the same code from every UDS server in this workspace.
+pub const CODE_METHOD_NOT_FOUND: i64 = -32601;
+
+/// JSON-RPC code for a frame whose `params` do not decode into the handler's
+/// request type.
+pub const CODE_INVALID_PARAMS: i64 = -32602;
+
+/// JSON-RPC code for a handler that failed for its own reasons.
+pub const CODE_INTERNAL_ERROR: i64 = -32603;
+
+/// One request frame, as it arrives on the wire.
+///
+/// Every field carries `#[serde(default)]` except `method`, so a frame missing
+/// its `jsonrpc` version reaches the version check and is refused there with a
+/// message naming the problem, rather than dying in serde with a message about
+/// a missing field.
+#[derive(Debug, Clone, Deserialize)]
+pub struct RpcRequest {
+    /// Protocol version. Anything but [`JSONRPC_VERSION`] is refused.
+    #[serde(default)]
+    pub jsonrpc: String,
+    /// Correlation id, echoed verbatim on the response.
+    #[serde(default)]
+    pub id: serde_json::Value,
+    /// Method name, matched against the router's registered handlers.
+    pub method: String,
+    /// Handler payload, decoded by the handler rather than here.
+    #[serde(default)]
+    pub params: serde_json::Value,
+}
+
+/// One response frame.
+///
+/// `result` and `error` are mutually exclusive and both skipped when absent, so
+/// the serialised frame matches what a JSON-RPC client expects rather than
+/// carrying a `"error": null` alongside a result.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RpcResponse {
+    /// Always [`JSONRPC_VERSION`].
+    pub jsonrpc: String,
+    /// The request's id, echoed back. `null` when the frame was too broken to
+    /// read an id out of.
+    pub id: serde_json::Value,
+    /// Present when the call succeeded.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub result: Option<serde_json::Value>,
+    /// Present when the call failed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<RpcError>,
+}
+
+impl RpcResponse {
+    /// A successful response carrying `result`.
+    pub fn success(id: serde_json::Value, result: serde_json::Value) -> Self {
+        Self {
+            jsonrpc: JSONRPC_VERSION.to_string(),
+            id,
+            result: Some(result),
+            error: None,
+        }
+    }
+
+    /// A failed response carrying `error`.
+    pub fn failure(id: serde_json::Value, error: RpcError) -> Self {
+        Self {
+            jsonrpc: JSONRPC_VERSION.to_string(),
+            id,
+            result: None,
+            error: Some(error),
+        }
+    }
+
+    /// Whether this frame reports a failure.
+    pub fn is_error(&self) -> bool {
+        self.error.is_some()
+    }
+}
+
+/// The error half of a response frame, and what a handler returns to refuse.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RpcError {
+    /// JSON-RPC error code.
+    pub code: i64,
+    /// Human-readable reason, reported to the caller verbatim.
+    pub message: String,
+}
+
+impl RpcError {
+    /// An error with a caller-chosen code.
+    ///
+    /// Application-defined codes belong in the JSON-RPC implementation-defined
+    /// range (`-32099..=-32000`); the reserved codes above have constants.
+    pub fn new(code: i64, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+        }
+    }
+
+    /// [`CODE_INVALID_PARAMS`] — the frame was well-formed but its `params`
+    /// were not usable.
+    pub fn invalid_params(message: impl Into<String>) -> Self {
+        Self::new(CODE_INVALID_PARAMS, message)
+    }
+
+    /// [`CODE_INTERNAL_ERROR`] — the handler ran and failed.
+    pub fn internal(message: impl Into<String>) -> Self {
+        Self::new(CODE_INTERNAL_ERROR, message)
+    }
+
+    /// [`CODE_METHOD_NOT_FOUND`], naming what this server does serve.
+    ///
+    /// Listing the registered methods is the difference between a client author
+    /// seeing a typo and seeing an opaque refusal.
+    pub fn method_not_found(method: &str, known: &[&str]) -> Self {
+        Self::new(
+            CODE_METHOD_NOT_FOUND,
+            format!("unknown method {method:?}; this listener serves {known:?}"),
+        )
+    }
+}
+
+impl std::fmt::Display for RpcError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "[{}] {}", self.code, self.message)
+    }
+}
+
+impl std::error::Error for RpcError {}

--- a/crates/trusty-gworkspace/Cargo.toml
+++ b/crates/trusty-gworkspace/Cargo.toml
@@ -15,7 +15,7 @@ name = "trusty-gworkspace-mcp"
 path = "src/bin/trusty-gworkspace-mcp.rs"
 
 [dependencies]
-trusty-common = { path = "../trusty-common", version = "0.43" }
+trusty-common = { path = "../trusty-common", version = "0.44" }
 # JSON-RPC / MCP primitives, extracted from `trusty_common::mcp` by ADR-0040 (#5803).
 trusty-mcp = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/trusty-memory/Cargo.toml
+++ b/crates/trusty-memory/Cargo.toml
@@ -83,7 +83,7 @@ path = "src/bin/mcp_bridge.rs"
 # `uds-supervisor` is NOT dropped — trusty-console and trusty-agents still
 # depend on the shared `UdsServiceSupervisor` for trusty-review / trusty-analyze.
 trusty-mcp = { workspace = true }  # JSON-RPC / MCP primitives (ADR-0040, #5803)
-trusty-common = { path = "../trusty-common", version = "0.43", default-features = false, features = ["memory-core", "monitor-tui", "bm25", "cli-help", "update-check", "bug-capture", "console-metrics", "config-cli", "crate-config", "palace-resolve", "codex-config"] }
+trusty-common = { path = "../trusty-common", version = "0.44", default-features = false, features = ["memory-core", "monitor-tui", "bm25", "cli-help", "update-check", "bug-capture", "console-metrics", "config-cli", "crate-config", "palace-resolve", "codex-config"] }
 # `bug-capture` enables Phase 1 ERROR event capture to JSONL + in-memory ring (bug-reporting #478)
 # Why (issue #1318): the `trusty-console` dependency was REMOVED. The console
 # is no longer bundled into trusty-memory (single-owner-per-binary); the
@@ -175,7 +175,7 @@ serial_test = { workspace = true }
 # the production library (mirrors the trusty-mpm and trusty-search pattern).
 # `docgen` (#5205 follow-up): `tests/generated_docs.rs` renders the MCP tool
 # section of README.md from `tool_definitions()`.
-trusty-common = { path = "../trusty-common", version = "0.43", default-features = false, features = ["memory-core", "embedder-test-support", "docgen"] }
+trusty-common = { path = "../trusty-common", version = "0.44", default-features = false, features = ["memory-core", "embedder-test-support", "docgen"] }
 chrono = { workspace = true }
 
 [features]


### PR DESCRIPTION
## Summary

PR 1 of the #6277 UDS migration (ADR-0032): reusable accept/dispatch server over trusty_common::uds — bind_hardened + peer-uid check per connection, newline-framed JSON-RPC 2.0, per-connection task spawn, configurable frame budget (default MAX_FRAME_BYTES), explicit socket unlink on shutdown. Caller-defined Req/Resp; no consumers in this PR (they arrive in the combined trusty-review+console+tctl PR).

## Test plan

- Test ladder: rung 4 (shared library, no consumers yet).
- Gates: cargo fmt --check; check/clippy -D warnings/test -p trusty-common --features uds (434 passed, 0 failed; 15 new uds::server tests); cargo check --workspace clean; check_line_cap OK; changelog fragment valid; check_sld clean.

Refs #6277

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools