### PR TITLE
fix(ci): the PR version-bump gate never reports a verdict it did not compute

### DIFF
--- a/.github/workflows/version-parity.yml
+++ b/.github/workflows/version-parity.yml
@@ -62,8 +62,9 @@ name: Version parity
 # sees changed paths but zero of them under `crates/*/src/`, so a docs-only
 # or website-only PR still costs one shell scan-floor check, not a
 # skipped-forever gate. The SAME "required context must never go pending/
-# skipped" reasoning is why the job's `edited`-action guard below lives in a
-# step, not a job-level `if:` — see the job's own header comment.
+# skipped" reasoning is why `pr-version-bump` carries no job-level `if:` —
+# see the job's own header comment, which also records why every ACTION in
+# that list runs the real check rather than short-circuiting (#6243).
 on:
   push:
     branches: [main]
@@ -77,6 +78,7 @@ on:
       - "scripts/lib/source_class.sh"
       - "scripts/check_source_class_selftest.sh"
       - "scripts/check_scan_floor_selftest.sh"
+      - "scripts/check_version_bump_verdict_selftest.sh"
       - ".github/workflows/version-parity.yml"
   # Every three hours. Fine-grained enough that a publish is caught in one
   # working session, coarse enough to stay well inside crates.io's API-usage
@@ -100,9 +102,17 @@ on:
 # old `${{ github.ref }}` group, since it is push-to-main only and therefore
 # only ever saw the LAST commit of a merge train. Per-ref group on pull_request
 # so a new push still supersedes the superseded run. Matches ci.yml.
+#
+# #6243: the `edited` carve-out is gone. It was there because an `edited` run
+# used to be a no-op that must not cancel a real in-flight evaluation — with
+# the no-op removed, every `pull_request` run is a real evaluation, so the
+# newest one is always the one worth keeping. Collapsing duplicates is now
+# the safe default rather than a hazard. It is not by itself the fix for
+# #6243: in that incident the first run had already COMPLETED when the second
+# was created, so nothing was in progress to cancel.
 concurrency:
   group: version-parity-${{ github.event_name == 'push' && github.sha || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action != 'edited' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # Pre-merge guard (#4421). Pure shell + one HTTP GET per touched crate: no
@@ -125,37 +135,66 @@ jobs:
   # in its own header comment.
   #
   # So the job always runs and always concludes `success` or `failure` —
-  # never `skipped` — and the `edited`-without-base-change case (and any
-  # non-`pull_request` trigger, e.g. `workflow_dispatch`) is handled by the
-  # first step below, which exits 0 and sets an output that gates every
-  # subsequent step. `edited` WITH a base change (a retarget, #3838) still
-  # runs the real check — the gate step only short-circuits the no-op case.
+  # never `skipped`.
+  #
+  # #6243 — WHY EVERY STEP'S `if:` IS `github.event_name == 'pull_request'`
+  # AND NOTHING NARROWER. This job used to carry a first step that set a
+  # `run_check` output and reported `success` WITHOUT running the check
+  # whenever a `pull_request: edited` event arrived with no base change. That
+  # is a real check run at the PR's head SHA, and branch protection reads the
+  # LATEST check run per (app, name, head_sha) — so the no-op published a
+  # `success` ON TOP OF a completed real verdict at the same SHA and became
+  # the answer an armed auto-merge would act on.
+  #
+  # Live on PR #6241, head `19f206de`: a `synchronize` run (32803218879) ran
+  # the real check and concluded `failure` at 02:55:42Z; a title/body `edited`
+  # event fired 17 seconds later, and run 32803235300 skipped every real step
+  # and concluded `success` at 02:55:50Z. `origin/main` genuinely carried
+  # `trusty-mpm 1.5.0` and `trusty-agents-common 0.6.0` unbumped against
+  # crates.io — the `failure` was correct and the `success` overwrote it. The
+  # two runs were two distinct trigger events, not a duplicate webhook
+  # delivery, so no concurrency setting could have collapsed them: the first
+  # had already completed when the second was created.
+  #
+  # The rule this job now holds: a run that did not evaluate the check does
+  # not report a verdict on a pull request. Every `pull_request` action —
+  # `edited` with no base change included — runs the real check. It costs
+  # ~11 seconds and produces the same answer as the `synchronize` run at that
+  # head, so two runs on one head_sha agree by construction instead of
+  # racing. The `skipped`-vs-`success` trade PR #5434 had to make is gone
+  # rather than re-decided: on a pull request neither is reachable.
+  #
+  # The remaining `if:` covers only the events that have no pull request at
+  # all (`push`, `schedule`, `workflow_dispatch`), where "no PR drift" is a
+  # true statement rather than a fabricated one. It stays a step-level `if:`
+  # and not a job-level one for the #5434 reason above.
+  #
+  # Mechanically enforced: `scripts/check_version_bump_verdict_selftest.sh`
+  # refuses any step `if:` in this job other than that exact expression, and
+  # refuses a step that publishes a `$GITHUB_OUTPUT` flag for other steps to
+  # branch on. It runs as a step of this job, so the invariant is re-proven
+  # on every PR.
   pr-version-bump:
     name: "PR version bump vs crates.io (issue #4421)"
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Skip the real check on a title/body-only edit (never `skipped` — always `success`)
-        id: gate
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          EVENT_ACTION: ${{ github.event.action }}
-          BASE_CHANGED: ${{ toJSON(github.event.changes.base) }}
-        run: |
-          if [[ "$EVENT_NAME" == "pull_request" && ( "$EVENT_ACTION" != "edited" || "$BASE_CHANGED" != "null" ) ]]; then
-            echo "run_check=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "run_check=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Nothing to check here (event=$EVENT_NAME action=$EVENT_ACTION, base unchanged) — reporting success without running the real check."
-          fi
-
       # fetch-depth: 0 — the guard needs `git merge-base` against the base
       # branch and `git show <merge-base>:crates/<X>/Cargo.toml`, neither of
       # which a shallow checkout can resolve.
       - uses: actions/checkout@v5
-        if: steps.gate.outputs.run_check == 'true'
+        if: github.event_name == 'pull_request'
         with:
           fetch-depth: 0
+
+      # Verdict-integrity selftest (#6243). Asserts against this very file
+      # that no step in this job can skip the real check while the job still
+      # reports `success` on a pull request. Runs before the real gate for the
+      # same reason the scan-floor selftest does: a gate whose green can be
+      # fabricated makes the real run's green meaningless.
+      - name: Verdict-integrity selftest (no success without running the check)
+        if: github.event_name == 'pull_request'
+        run: bash scripts/check_version_bump_verdict_selftest.sh
 
       # Scan-floor mutation self-test (issue #4618): re-proves in CI that this
       # gate REFUSES a vacuous scan. Without it the floor is untested code and a
@@ -163,7 +202,7 @@ jobs:
       # Runs before the real gate — a gate that cannot fail makes the real run's
       # green meaningless. Mirrors line-cap.yml's selftest-then-gate ordering.
       - name: Scan-floor selftest (must refuse an empty scan)
-        if: steps.gate.outputs.run_check == 'true'
+        if: github.event_name == 'pull_request'
         run: bash scripts/check_scan_floor_selftest.sh pr_version_bump
 
       # Publish-ORDER selftest (issue #5358). Different question from this
@@ -180,7 +219,7 @@ jobs:
       # a checked-in cargo-metadata fixture, no cargo, no network, well under
       # a second. It never runs `cargo publish` — every case is --list-only.
       - name: Publish-order selftest (optional + dev dep edges must order first)
-        if: steps.gate.outputs.run_check == 'true'
+        if: github.event_name == 'pull_request'
         run: bash scripts/publish-dry-run-order_selftest.sh
 
       # Shared-classification selftest (#5765). This gate decides which crates
@@ -192,7 +231,7 @@ jobs:
       # required context of the two. Pure shell, no network, well under a
       # second.
       - name: Source-classification selftest (both gates share one definition)
-        if: steps.gate.outputs.run_check == 'true'
+        if: github.event_name == 'pull_request'
         run: bash scripts/check_source_class_selftest.sh
 
       # #4688: diff against the base branch AS IT IS NOW, not the frozen
@@ -202,7 +241,7 @@ jobs:
       # ATTRIBUTION note in scripts/check-pr-version-bump.sh for the failure
       # this removes (PR #4666 / run 30839255128).
       - name: Refresh the base branch ref
-        if: steps.gate.outputs.run_check == 'true'
+        if: github.event_name == 'pull_request'
         run: |
           git fetch --no-tags --quiet origin \
             "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
@@ -211,7 +250,7 @@ jobs:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
 
       - name: Check PR version bumps against crates.io
-        if: steps.gate.outputs.run_check == 'true'
+        if: github.event_name == 'pull_request'
         env:
           PR_VERSION_BUMP_BASE: origin/${{ github.event.pull_request.base.ref }}
         run: bash scripts/check-pr-version-bump.sh

--- a/.github/workflows/version-parity.yml
+++ b/.github/workflows/version-parity.yml
@@ -164,16 +164,29 @@ jobs:
   # racing. The `skipped`-vs-`success` trade PR #5434 had to make is gone
   # rather than re-decided: on a pull request neither is reachable.
   #
-  # The remaining `if:` covers only the events that have no pull request at
-  # all (`push`, `schedule`, `workflow_dispatch`), where "no PR drift" is a
-  # true statement rather than a fabricated one. It stays a step-level `if:`
-  # and not a job-level one for the #5434 reason above.
+  # The remaining `if:` is false on three triggers, and they are NOT equally
+  # safe. `push` is filtered to `main` and `schedule` runs on the default
+  # branch, so neither can produce a check run at an open PR's head SHA —
+  # skipping the check there states something true. `workflow_dispatch: {}`
+  # is different: it takes any ref, so dispatching this workflow on a PR's own
+  # head branch publishes a `success` at that head SHA having evaluated
+  # nothing, which is the #6243 overwrite by another route. That residue is
+  # ACCEPTED, not fixed. Closing it needs either a job-level `if:` — which
+  # reopens PR #5434's skipped-required-context hazard — or running the PR
+  # gate on non-PR events, where HEAD equals the base and the scan floor
+  # turns `main` red. A manual dispatch on a PR branch is a deliberate act,
+  # so the trade is: keep the two structural hazards closed, and leave this
+  # one documented.
+  #
+  # It stays a step-level `if:` and not a job-level one for the #5434 reason
+  # above.
   #
   # Mechanically enforced: `scripts/check_version_bump_verdict_selftest.sh`
-  # refuses any step `if:` in this job other than that exact expression, and
-  # refuses a step that publishes a `$GITHUB_OUTPUT` flag for other steps to
-  # branch on. It runs as a step of this job, so the invariant is re-proven
-  # on every PR.
+  # refuses an `if:` anywhere in this job other than that exact expression at
+  # step indent, refuses a job-level `if:` outright, and refuses a step that
+  # publishes a `$GITHUB_OUTPUT` flag for other steps to branch on. Its own
+  # mutation battery re-proves that those refusals actually fire. It runs as
+  # a step of this job, so the invariant is re-proven on every PR.
   pr-version-bump:
     name: "PR version bump vs crates.io (issue #4421)"
     runs-on: ubuntu-latest

--- a/scripts/check_version_bump_verdict_selftest.sh
+++ b/scripts/check_version_bump_verdict_selftest.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+#
+# check_version_bump_verdict_selftest.sh — verdict-integrity fixtures for the
+# `pr-version-bump` job in .github/workflows/version-parity.yml (issue #6243).
+#
+# Why: `pr-version-bump` is a REQUIRED branch-protection context, and branch
+#   protection reads the LATEST check run per (app, name, head_sha). A run that
+#   concludes `success` without evaluating the check therefore does not merely
+#   add a meaningless green — it OVERWRITES a completed real verdict at the
+#   same SHA.
+#
+#   That happened on PR #6241, head `19f206de`. A `synchronize` run
+#   (32803218879) ran `scripts/check-pr-version-bump.sh`, found `trusty-mpm
+#   1.5.0` and `trusty-agents-common 0.6.0` changed under versions crates.io
+#   already carried, and concluded `failure` at 02:55:42Z. A title/body edit 17
+#   seconds later fired `pull_request: edited` with `changes.base == null`; run
+#   32803235300 took the job's "report success without running the real check"
+#   branch, skipped every real step, and concluded `success` at 02:55:50Z. The
+#   false green is what an armed auto-merge would have acted on. Both runs were
+#   `run_attempt: 1` on distinct trigger events, so no concurrency setting could
+#   have collapsed them — the first had already completed when the second was
+#   created.
+#
+#   This is the repo's canonical bug shape: a failure branch downgraded to
+#   success (#5620 for the SemVer gate, #4618 for the scan floors, #4576 for
+#   the changelog attribution). The gate's own logic was never wrong; the
+#   workflow published a verdict the gate never produced.
+#
+# What: extracts the `pr-version-bump` job from the workflow and asserts the
+#   one structural property that makes the incident unreachable — on a pull
+#   request, no step in that job can be skipped, so the job cannot conclude
+#   `success` without the real check having run. Concretely:
+#
+#     job-block-present         the job exists and carries steps (scan floor —
+#                               an extraction that silently matches nothing
+#                               would make every assertion below vacuous)
+#     runs-the-real-gate        exactly one step runs check-pr-version-bump.sh
+#     no-conditional-skip       EVERY step `if:` in the job is exactly
+#                               `github.event_name == 'pull_request'`. A step
+#                               gated on anything narrower can be skipped on a
+#                               pull request while the job stays green.
+#     no-verdict-flag           no step writes `$GITHUB_OUTPUT`. That is how
+#                               the pre-#6243 gate step published the boolean
+#                               every other step branched on; forbidding the
+#                               mechanism stops the shape from being rebuilt
+#                               under a different condition string.
+#     no-fabricated-success     the job contains no step that announces a
+#                               success it did not compute (the pre-fix
+#                               "reporting success without running the real
+#                               check" notice).
+#     duplicates-collapse       workflow-level `cancel-in-progress` no longer
+#                               carves `edited` out, so a duplicate PR run
+#                               supersedes rather than races (#6243 closure
+#                               condition 2).
+#
+#   Every case fails against the pre-#6243 file. Prove it with `--workflow`:
+#
+#     git show <pre-fix-rev>:.github/workflows/version-parity.yml > /tmp/pre.yml
+#     bash scripts/check_version_bump_verdict_selftest.sh --workflow /tmp/pre.yml
+#
+#   The job-level `if:` is deliberately NOT asserted away. PR #5434 established
+#   that a job-level `if:` which can be false at a PR head SHA produces a
+#   `skipped` check run alongside a real one; the fix keeps the job
+#   unconditional and gates its steps instead.
+#
+# Usage:
+#   bash scripts/check_version_bump_verdict_selftest.sh
+#   bash scripts/check_version_bump_verdict_selftest.sh --workflow <path>
+#
+# Exit: 0 when every case matches; 1 on the first mismatch, printing both sides.
+#
+# Test: this file IS the test. It runs as a step of the job it constrains
+#   (.github/workflows/version-parity.yml, "Verdict-integrity selftest"), so
+#   the invariant is re-proven on every pull request.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ORIG_PWD="${PWD}"
+
+WORKFLOW=".github/workflows/version-parity.yml"
+JOB="pr-version-bump"
+EXPECTED_STEP_IF="github.event_name == 'pull_request'"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --workflow)
+      # Resolve against the CALLER's directory, not the repo root the script
+      # is about to cd into — the mutation demo points this at a scratch copy.
+      case "${2:?--workflow needs a path}" in
+        /*) WORKFLOW="$2" ;;
+        *) WORKFLOW="${ORIG_PWD}/$2" ;;
+      esac
+      shift 2
+      ;;
+    *)
+      echo "usage: $0 [--workflow <path>]" >&2
+      exit 2
+      ;;
+  esac
+done
+
+cd "${REPO_ROOT}" || exit 1
+
+if [ ! -f "${WORKFLOW}" ]; then
+  echo "check_version_bump_verdict_selftest: no such workflow: ${WORKFLOW}" >&2
+  exit 1
+fi
+
+FAILURES=0
+CASES=0
+
+assert_eq() {
+  CASES=$((CASES + 1))
+  if [ "$2" = "$3" ]; then
+    printf '  ok   %-56s -> %s\n' "$1" "$3"
+  else
+    FAILURES=$((FAILURES + 1))
+    echo "  FAIL: $1: expected '$2', got '$3'"
+  fi
+}
+
+# The job block: from `  <job>:` at two-space indent up to the next key at that
+# same indent. Comment lines above the next job belong to that job, not this
+# one, but they carry no `if:`/`run:` keys so they cannot affect any count.
+job_block="$(
+  awk -v job="  ${JOB}:" '
+    $0 == job { inside = 1; next }
+    inside && /^  [A-Za-z_#-]/ && $0 !~ /^  #/ { exit }
+    inside { print }
+  ' "${WORKFLOW}"
+)"
+
+echo "pr-version-bump verdict integrity (${WORKFLOW}):"
+
+# Scan floor. Without it a renamed job would silently zero every count below
+# and the whole selftest would read as a clean bill of health (#4618's shape).
+assert_eq "job-block-present: job found" "yes" \
+  "$([ -n "${job_block}" ] && echo yes || echo no)"
+step_count="$(printf '%s\n' "${job_block}" | grep -cE '^      - (name|uses):' || true)"
+assert_eq "job-block-present: step count > 0" "yes" \
+  "$([ "${step_count:-0}" -gt 0 ] && echo yes || echo no)"
+
+assert_eq "runs-the-real-gate: check-pr-version-bump.sh invoked once" "1" \
+  "$(printf '%s\n' "${job_block}" |
+    grep -c 'bash scripts/check-pr-version-bump\.sh' || true)"
+
+# Every step `if:` must be the event guard and nothing narrower. Counting the
+# non-conforming ones (rather than asserting the conforming count) means a
+# newly added step with a novel condition is caught too.
+assert_eq "no-conditional-skip: step ifs other than the event guard" "0" \
+  "$(printf '%s\n' "${job_block}" |
+    grep -E '^        if:' |
+    grep -vcF "if: ${EXPECTED_STEP_IF}" || true)"
+
+assert_eq "no-verdict-flag: steps writing \$GITHUB_OUTPUT" "0" \
+  "$(printf '%s\n' "${job_block}" | grep -c 'GITHUB_OUTPUT' || true)"
+
+assert_eq "no-fabricated-success: success announced without checking" "0" \
+  "$(printf '%s\n' "${job_block}" |
+    grep -ci 'success without running the real check' || true)"
+
+# #6243 closure condition 2 — workflow level, outside the job block.
+assert_eq "duplicates-collapse: no edited carve-out in cancel-in-progress" "0" \
+  "$(grep -E '^  cancel-in-progress:' "${WORKFLOW}" |
+    grep -c "github.event.action" || true)"
+
+echo
+if [ "${FAILURES}" -gt 0 ]; then
+  echo "check_version_bump_verdict_selftest: ${FAILURES}/${CASES} case(s) FAILED."
+  exit 1
+fi
+echo "check_version_bump_verdict_selftest: ${CASES}/${CASES} cases passed."

--- a/scripts/check_version_bump_verdict_selftest.sh
+++ b/scripts/check_version_bump_verdict_selftest.sh
@@ -27,18 +27,26 @@
 #   workflow published a verdict the gate never produced.
 #
 # What: extracts the `pr-version-bump` job from the workflow and asserts the
-#   one structural property that makes the incident unreachable — on a pull
-#   request, no step in that job can be skipped, so the job cannot conclude
-#   `success` without the real check having run. Concretely:
+#   properties that keep a `pull_request` run from concluding `success` without
+#   `scripts/check-pr-version-bump.sh` having run:
 #
 #     job-block-present         the job exists and carries steps (scan floor —
 #                               an extraction that silently matches nothing
 #                               would make every assertion below vacuous)
 #     runs-the-real-gate        exactly one step runs check-pr-version-bump.sh
-#     no-conditional-skip       EVERY step `if:` in the job is exactly
-#                               `github.event_name == 'pull_request'`. A step
-#                               gated on anything narrower can be skipped on a
-#                               pull request while the job stays green.
+#     no-job-level-if           the job header (job key down to `steps:`) has no
+#                               `if:` key at all. A job-level `if:` that
+#                               evaluates false makes the WHOLE job report
+#                               `skipped`, reopening PR #5434's
+#                               skipped-required-context hazard, and it sits
+#                               above every step-scoped assertion here.
+#     no-conditional-skip       every `if:`-shaped line in the job is EXACTLY
+#                               `        if: github.event_name == 'pull_request'`,
+#                               matched whole-line at its own indent. Anything
+#                               narrower — a clause appended to that expression,
+#                               a step output, an `if:` at another indent — can
+#                               skip a step on a pull request while the job
+#                               stays green.
 #     no-verdict-flag           no step writes `$GITHUB_OUTPUT`. That is how
 #                               the pre-#6243 gate step published the boolean
 #                               every other step branched on; forbidding the
@@ -53,43 +61,58 @@
 #                               supersedes rather than races (#6243 closure
 #                               condition 2).
 #
-#   Every case fails against the pre-#6243 file. Prove it with `--workflow`:
+#   These cover the shapes that make a step skippable or the job non-running.
+#   They do NOT cover every conceivable route to a fabricated green — a second
+#   job elsewhere deliberately publishing a check run under this job's `name:`
+#   would race a real verdict and is not defended against here.
 #
-#     git show <pre-fix-rev>:.github/workflows/version-parity.yml > /tmp/pre.yml
-#     bash scripts/check_version_bump_verdict_selftest.sh --workflow /tmp/pre.yml
+#   WHAT THE ASSERTIONS ARE PROVEN AGAINST. A bare grep guarantee is worth
+#   whatever its pattern actually anchors, which is the defect the first cut of
+#   this file shipped: `grep -vcF "if: <expected>"` matched as a SUBSTRING, so
+#   `if: github.event_name == 'pull_request' && github.event.action != 'edited'`
+#   counted as conforming and the file reported 7/7 on a workflow that
+#   recreated the #6241 incident. A default run therefore does not just check
+#   the live workflow — it builds mutant copies that each recreate a known
+#   evasion and asserts this checker REJECTS them:
 #
-#   The job-level `if:` is deliberately NOT asserted away. PR #5434 established
-#   that a job-level `if:` which can be false at a PR head SHA produces a
-#   `skipped` check run alongside a real one; the fix keeps the job
-#   unconditional and gates its steps instead.
+#     mutant/narrowed-step-if    the real check step's `if:` gains
+#                                `&& github.event.action != 'edited'`
+#     mutant/job-level-if        the same narrowing clause as a job-level `if:`
+#     mutant/no-real-gate        the check-pr-version-bump.sh step is deleted
+#
+#   The first two are the mutations that passed the pre-fix checker.
 #
 # Usage:
 #   bash scripts/check_version_bump_verdict_selftest.sh
 #   bash scripts/check_version_bump_verdict_selftest.sh --workflow <path>
 #
+#   `--workflow` checks ONE file and skips the mutation battery — that is how
+#   the battery invokes this script per mutant, and how to point it at a copy
+#   of an older revision by hand.
+#
 # Exit: 0 when every case matches; 1 on the first mismatch, printing both sides.
 #
-# Test: this file IS the test. It runs as a step of the job it constrains
+# Test: this file IS the test, and the mutation battery is its own coverage
+#   proof. It runs as a step of the job it constrains
 #   (.github/workflows/version-parity.yml, "Verdict-integrity selftest"), so
 #   the invariant is re-proven on every pull request.
 
 set -uo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SELF="${REPO_ROOT}/scripts/$(basename "${BASH_SOURCE[0]}")"
 ORIG_PWD="${PWD}"
 
-WORKFLOW=".github/workflows/version-parity.yml"
-JOB="pr-version-bump"
-EXPECTED_STEP_IF="github.event_name == 'pull_request'"
+SINGLE_WORKFLOW=""
 
 while [ $# -gt 0 ]; do
   case "$1" in
     --workflow)
       # Resolve against the CALLER's directory, not the repo root the script
-      # is about to cd into — the mutation demo points this at a scratch copy.
+      # is about to cd into — the battery points this at a scratch copy.
       case "${2:?--workflow needs a path}" in
-        /*) WORKFLOW="$2" ;;
-        *) WORKFLOW="${ORIG_PWD}/$2" ;;
+        /*) SINGLE_WORKFLOW="$2" ;;
+        *) SINGLE_WORKFLOW="${ORIG_PWD}/$2" ;;
       esac
       shift 2
       ;;
@@ -102,10 +125,12 @@ done
 
 cd "${REPO_ROOT}" || exit 1
 
-if [ ! -f "${WORKFLOW}" ]; then
-  echo "check_version_bump_verdict_selftest: no such workflow: ${WORKFLOW}" >&2
-  exit 1
-fi
+WORKFLOW=".github/workflows/version-parity.yml"
+JOB="pr-version-bump"
+# The one permitted step condition, as a whole line at its own indent. Both the
+# expression AND the indent are part of the assertion: an `if:` anywhere else in
+# the job is a shape this file has not reasoned about, so it fails closed.
+STEP_IF_LINE="        if: github.event_name == 'pull_request'"
 
 FAILURES=0
 CASES=0
@@ -113,57 +138,145 @@ CASES=0
 assert_eq() {
   CASES=$((CASES + 1))
   if [ "$2" = "$3" ]; then
-    printf '  ok   %-56s -> %s\n' "$1" "$3"
+    printf '  ok   %-58s -> %s\n' "$1" "$3"
   else
     FAILURES=$((FAILURES + 1))
     echo "  FAIL: $1: expected '$2', got '$3'"
   fi
 }
 
-# The job block: from `  <job>:` at two-space indent up to the next key at that
-# same indent. Comment lines above the next job belong to that job, not this
-# one, but they carry no `if:`/`run:` keys so they cannot affect any count.
-job_block="$(
+# job_block <file> — the job's body: from `  <job>:` at two-space indent up to
+# the next key at that indent. Full-line comments are dropped so a comment that
+# merely QUOTES a forbidden shape cannot trip an assertion, and so the trailing
+# comment block belonging to the next job cannot either.
+job_block() {
   awk -v job="  ${JOB}:" '
     $0 == job { inside = 1; next }
-    inside && /^  [A-Za-z_#-]/ && $0 !~ /^  #/ { exit }
+    inside && /^  [^ #]/ { exit }
+    inside && /^[[:space:]]*#/ { next }
     inside { print }
-  ' "${WORKFLOW}"
-)"
+  ' "$1"
+}
 
-echo "pr-version-bump verdict integrity (${WORKFLOW}):"
+# job_header <file> — the job's own keys, above `steps:`. A job-level `if:`
+# lives here and is invisible to every step-scoped assertion.
+job_header() {
+  job_block "$1" | awk '/^    steps:/ { exit } { print }'
+}
 
-# Scan floor. Without it a renamed job would silently zero every count below
-# and the whole selftest would read as a clean bill of health (#4618's shape).
-assert_eq "job-block-present: job found" "yes" \
-  "$([ -n "${job_block}" ] && echo yes || echo no)"
-step_count="$(printf '%s\n' "${job_block}" | grep -cE '^      - (name|uses):' || true)"
-assert_eq "job-block-present: step count > 0" "yes" \
-  "$([ "${step_count:-0}" -gt 0 ] && echo yes || echo no)"
+check_workflow() {
+  local wf="$1" block header step_count if_lines conforming_if
+  block="$(job_block "${wf}")"
+  header="$(job_header "${wf}")"
 
-assert_eq "runs-the-real-gate: check-pr-version-bump.sh invoked once" "1" \
-  "$(printf '%s\n' "${job_block}" |
-    grep -c 'bash scripts/check-pr-version-bump\.sh' || true)"
+  echo "pr-version-bump verdict integrity (${wf}):"
 
-# Every step `if:` must be the event guard and nothing narrower. Counting the
-# non-conforming ones (rather than asserting the conforming count) means a
-# newly added step with a novel condition is caught too.
-assert_eq "no-conditional-skip: step ifs other than the event guard" "0" \
-  "$(printf '%s\n' "${job_block}" |
-    grep -E '^        if:' |
-    grep -vcF "if: ${EXPECTED_STEP_IF}" || true)"
+  # Scan floor. Without it a renamed job would silently zero every count below
+  # and the whole selftest would read as a clean bill of health (#4618's shape).
+  assert_eq "job-block-present: job found" "yes" \
+    "$([ -n "${block}" ] && echo yes || echo no)"
+  step_count="$(printf '%s\n' "${block}" | grep -cE '^      - (name|uses):' || true)"
+  assert_eq "job-block-present: step count > 0" "yes" \
+    "$([ "${step_count:-0}" -gt 0 ] && echo yes || echo no)"
 
-assert_eq "no-verdict-flag: steps writing \$GITHUB_OUTPUT" "0" \
-  "$(printf '%s\n' "${job_block}" | grep -c 'GITHUB_OUTPUT' || true)"
+  assert_eq "runs-the-real-gate: check-pr-version-bump.sh invoked once" "1" \
+    "$(printf '%s\n' "${block}" |
+      grep -c 'bash scripts/check-pr-version-bump\.sh' || true)"
 
-assert_eq "no-fabricated-success: success announced without checking" "0" \
-  "$(printf '%s\n' "${job_block}" |
-    grep -ci 'success without running the real check' || true)"
+  assert_eq "no-job-level-if: \`if:\` keys in the job header" "0" \
+    "$(printf '%s\n' "${header}" | grep -cE '^[[:space:]]+if:' || true)"
 
-# #6243 closure condition 2 — workflow level, outside the job block.
-assert_eq "duplicates-collapse: no edited carve-out in cancel-in-progress" "0" \
-  "$(grep -E '^  cancel-in-progress:' "${WORKFLOW}" |
-    grep -c "github.event.action" || true)"
+  # Count every `if:`-shaped line in the job, then count the ones that are
+  # EXACTLY the permitted line. The difference is what evades the guarantee —
+  # a narrowing clause appended to the expected expression, a step-output
+  # condition, or an `if:` at an unexpected indent. Whole-line `-x` matching is
+  # the point: the pre-fix substring form counted the first of those three as
+  # conforming and reported a clean pass on a workflow that recreated #6241.
+  if_lines="$(printf '%s\n' "${block}" | grep -cE '^[[:space:]]+if:' || true)"
+  conforming_if="$(printf '%s\n' "${block}" | grep -cxF "${STEP_IF_LINE}" || true)"
+  assert_eq "no-conditional-skip: ifs that are not the event guard" "0" \
+    "$((if_lines - conforming_if))"
+
+  assert_eq "no-verdict-flag: steps writing \$GITHUB_OUTPUT" "0" \
+    "$(printf '%s\n' "${block}" | grep -c 'GITHUB_OUTPUT' || true)"
+
+  assert_eq "no-fabricated-success: success announced without checking" "0" \
+    "$(printf '%s\n' "${block}" |
+      grep -ci 'success without running the real check' || true)"
+
+  # #6243 closure condition 2 — workflow level, outside the job block.
+  assert_eq "duplicates-collapse: no edited carve-out in cancel-in-progress" "0" \
+    "$(grep -E '^  cancel-in-progress:' "${wf}" |
+      grep -c "github.event.action" || true)"
+}
+
+# --- single-file mode: check one workflow, no battery -----------------------
+
+if [ -n "${SINGLE_WORKFLOW}" ]; then
+  if [ ! -f "${SINGLE_WORKFLOW}" ]; then
+    echo "check_version_bump_verdict_selftest: no such workflow: ${SINGLE_WORKFLOW}" >&2
+    exit 1
+  fi
+  check_workflow "${SINGLE_WORKFLOW}"
+  echo
+  if [ "${FAILURES}" -gt 0 ]; then
+    echo "check_version_bump_verdict_selftest: ${FAILURES}/${CASES} case(s) FAILED."
+    exit 1
+  fi
+  echo "check_version_bump_verdict_selftest: ${CASES}/${CASES} cases passed."
+  exit 0
+fi
+
+# --- default mode: the live workflow, then the mutation battery -------------
+
+check_workflow "${WORKFLOW}"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/vbverdict.XXXXXX")"
+trap 'rm -rf "${TMP}"' EXIT
+
+# mutate_narrowed_step_if — append the #6241 narrowing clause to the real check
+# step's own `if:`. This is the mutation the pre-fix substring match accepted.
+awk '
+  /^      - name: Check PR version bumps against crates\.io$/ { arm = 1 }
+  arm && /^        if: / {
+    print $0 " && github.event.action != '\''edited'\''"
+    arm = 0
+    next
+  }
+  { print }
+' "${WORKFLOW}" > "${TMP}/narrowed-step-if.yml"
+
+# mutate_job_level_if — the same clause hoisted to the job header, where no
+# step-scoped assertion can see it.
+awk -v job="  pr-version-bump:" '
+  { print }
+  $0 == job {
+    print "    if: github.event_name == '\''pull_request'\'' && github.event.action != '\''edited'\''"
+  }
+' "${WORKFLOW}" > "${TMP}/job-level-if.yml"
+
+# mutate_no_real_gate — delete the invocation the whole job exists to make.
+grep -v 'bash scripts/check-pr-version-bump\.sh' "${WORKFLOW}" \
+  > "${TMP}/no-real-gate.yml"
+
+echo
+echo "mutation battery (each mutant must be REJECTED):"
+for mutant in narrowed-step-if job-level-if no-real-gate; do
+  # Sanity floor: a mutation that did not change the file proves nothing.
+  if cmp -s "${WORKFLOW}" "${TMP}/${mutant}.yml"; then
+    CASES=$((CASES + 1))
+    FAILURES=$((FAILURES + 1))
+    echo "  FAIL: mutant/${mutant}: mutation produced an unchanged file"
+    continue
+  fi
+  bash "${SELF}" --workflow "${TMP}/${mutant}.yml" > "${TMP}/${mutant}.out" 2>&1
+  rc=$?
+  assert_eq "mutant/${mutant}: rejected" "1" "${rc}"
+  if [ "${rc}" -ne 1 ]; then
+    echo "         checker output for the accepted mutant:"
+    sed 's/^/         | /' "${TMP}/${mutant}.out"
+  fi
+done
 
 echo
 if [ "${FAILURES}" -gt 0 ]; then


### PR DESCRIPTION
Refs #6243 — root-cause analysis is in the issue comment.

The false green on PR #6241 was a `pull_request: edited` run (title/body edit, `changes.base == null`) taking a no-op branch that announced success with every real step skipped; branch protection kept that later verdict over the real failure. This PR deletes the fabricated-success mechanism: every step in `pr-version-bump` now runs on every `pull_request` action, the `edited` carve-out in `cancel-in-progress` is dropped, and a new mutation-proof selftest (`scripts/check_version_bump_verdict_selftest.sh`, run as a step of the job it constrains) forbids conditional step-skips, `$GITHUB_OUTPUT` verdict flags, and success-without-checking.

Test ladder: rung 2 (CI/scripts change, no crate src). Gates run:
- `bash scripts/check_version_bump_verdict_selftest.sh` — 7/7 post-fix; 4/7 FAIL against the pre-fix workflow (regression proof)
- `shellcheck` clean, YAML parse verified, `check-ci-helpers-selftest.sh` 190/190, `check_scan_floor_selftest.sh` OK, `check_source_class_selftest.sh` 31/31, `check_sld.sh` 0 errors
- Changelog fragment: exempt (CI-only; `check_changelog_fragment.sh` confirms)

Known residue, documented in-file: a manual `workflow_dispatch` on a PR branch still reports success at that head without checking; closing it would re-open the #5434 skipped-check problem.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools