### PR TITLE
feat(trusty-common): RpcRouter fallback seam for generic dispatchers (Refs #6286)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6519,7 +6519,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11411,7 +11411,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-common"
-version = "0.44.0"
+version = "0.44.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -10,7 +10,11 @@ name = "trusty-common"
 # 0.44.0 (#6277): minor — the new public `uds::server` module is additive, and
 # nothing existing was removed or changed. Under Cargo's 0.x rule a MINOR bump
 # is what a published crate owes a new public module.
-version = "0.44.0"
+# 0.44.1 (#6286): patch — `uds::server` gains the `RpcFallback` trait and
+# `RpcRouter::fallback`. Both are additions inside an existing module: no public
+# item was removed or changed, and no existing trait gained a method, so nothing
+# here breaks a consumer.
+version = "0.44.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/trusty-common/changelog.d/6286-rpc-fallback.md
+++ b/crates/trusty-common/changelog.d/6286-rpc-fallback.md
@@ -1,0 +1,10 @@
+Added
+
+- `uds::server::RpcRouter::fallback` mounts a service's own generic
+  `(method, params)` dispatcher as the router's catch-all, so a daemon with an
+  existing dispatch table serves it whole instead of re-registering every method
+  by name (#6286). The fallback is consulted only after the registered-method
+  lookup misses, so a name registered with `RpcRouter::method` still wins, and an
+  error it returns crosses the wire as a JSON-RPC error frame with its own code
+  and message intact. A router that sets no fallback is unchanged: an unknown
+  method still answers method-not-found naming the methods it does serve.

--- a/crates/trusty-common/src/uds/server/mod.rs
+++ b/crates/trusty-common/src/uds/server/mod.rs
@@ -13,6 +13,8 @@
 //! What, in the order a daemon uses them.
 //!   - [`RpcRouter`] is the caller's half: method names mapped to handlers over
 //!     the caller's own request and response types (see [`RpcRouter::typed`]).
+//!     A service that already has a generic `(method, params)` dispatcher
+//!     mounts it whole through [`RpcRouter::fallback`] instead (#6286).
 //!   - [`RpcServer::run`] is the whole body of a daemon — bind, serve, unlink.
 //!   - [`serve_until`] and [`handle_connection`] are that body's two halves,
 //!     public so a caller with its own bind (say
@@ -52,7 +54,7 @@ use tokio::net::{UnixListener, UnixStream};
 
 use crate::uds::{MAX_FRAME_BYTES, UdsSecurityError, bind_hardened, ensure_peer_is_self};
 
-pub use router::{RpcMethod, RpcRouter, typed_method};
+pub use router::{RpcFallback, RpcMethod, RpcRouter, typed_method};
 pub use wire::{
     CODE_INTERNAL_ERROR, CODE_INVALID_PARAMS, CODE_INVALID_REQUEST, CODE_METHOD_NOT_FOUND,
     CODE_PARSE_ERROR, JSONRPC_VERSION, RpcError, RpcRequest, RpcResponse,

--- a/crates/trusty-common/src/uds/server/router.rs
+++ b/crates/trusty-common/src/uds/server/router.rs
@@ -13,7 +13,9 @@
 //! [`RpcRouter::dispatch`] parses one frame, checks the envelope, looks up the
 //! method, and returns the response frame to write — every failure as a coded
 //! JSON-RPC error rather than a dropped connection, so a drifted client reads
-//! the reason instead of a transport failure.
+//! the reason instead of a transport failure. [`RpcFallback`] is the catch-all
+//! a service with its own generic dispatcher mounts instead of naming every
+//! method (#6286).
 //!
 //! Dispatch is `async` and takes `&self`, so one router serves every connection
 //! concurrently; nothing here holds a lock across a handler call.
@@ -44,6 +46,40 @@ use super::wire::{
 pub trait RpcMethod: Send + Sync + 'static {
     /// Run this method against one decoded `params` payload.
     async fn call(&self, params: serde_json::Value) -> Result<serde_json::Value, RpcError>;
+}
+
+/// The catch-all consulted when no registered method matches (#6286).
+///
+/// Why: a daemon that already owns a transport-agnostic dispatcher over
+/// `(method, params)` — `trusty-memory`'s `transport::rpc::dispatch` is the
+/// case this exists for — would otherwise have to re-register its ~75 methods
+/// one at a time to mount on an [`RpcRouter`]. Registering the same table twice
+/// is exactly the silent-drift risk the workspace's common-entry-point rule
+/// exists to prevent, so the router grows a pass-through instead.
+/// What: takes the method NAME as well as the params, because the fallback is
+/// the thing that has to decide what the name means. Object-safe, so a router
+/// holds it behind `Arc<dyn RpcFallback>` alongside its typed methods.
+///
+/// A fallback never sees a method the router itself serves: [`dispatch`]
+/// consults it only after the [`BTreeMap`] lookup misses, so a name registered
+/// with [`RpcRouter::method`] wins and a service can override one method of its
+/// own dispatcher by registering it. An error the fallback returns becomes the
+/// response's error half verbatim, the same as [`RpcMethod`]'s — a fallback
+/// that refuses answers with a reason rather than dropping the connection.
+///
+/// [`dispatch`]: RpcRouter::dispatch
+///
+/// Test: `dispatch_routes_an_unregistered_method_to_the_fallback`,
+/// `dispatch_prefers_a_registered_method_over_the_fallback`,
+/// `dispatch_maps_a_fallback_error_to_an_rpc_error_response`.
+#[async_trait]
+pub trait RpcFallback: Send + Sync + 'static {
+    /// Run `method` against one decoded `params` payload.
+    async fn call(
+        &self,
+        method: &str,
+        params: serde_json::Value,
+    ) -> Result<serde_json::Value, RpcError>;
 }
 
 /// Adapter behind [`typed_method`]; `PhantomData<fn(Req) -> Resp>` keeps the
@@ -112,12 +148,16 @@ where
 #[derive(Default)]
 pub struct RpcRouter {
     methods: BTreeMap<String, Arc<dyn RpcMethod>>,
+    fallback: Option<Arc<dyn RpcFallback>>,
 }
 
 impl std::fmt::Debug for RpcRouter {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // `method_names` alone reads as "serves nothing" for a router that is
+        // all fallback, so the flag is part of what this value is.
         f.debug_struct("RpcRouter")
             .field("methods", &self.method_names().collect::<Vec<_>>())
+            .field("fallback", &self.fallback.is_some())
             .finish()
     }
 }
@@ -149,7 +189,28 @@ impl RpcRouter {
         self.method(name, typed_method::<Req, Resp, F, Fut>(call))
     }
 
+    /// Serve every unregistered method through `fallback`, replacing any
+    /// previous one (#6286).
+    ///
+    /// Why: mounts a service's own generic dispatcher without restating its
+    /// method table here — see [`RpcFallback`] for what that buys and why the
+    /// name is passed through.
+    /// What: a router with a fallback answers
+    /// [`RpcError::method_not_found`] for nothing; every name the [`BTreeMap`]
+    /// misses goes to `fallback` instead. Registered methods still win.
+    /// Test: `dispatch_routes_an_unregistered_method_to_the_fallback`,
+    /// `dispatch_prefers_a_registered_method_over_the_fallback`.
+    pub fn fallback(mut self, fallback: impl RpcFallback) -> Self {
+        self.fallback = Some(Arc::new(fallback));
+        self
+    }
+
     /// The registered method names, in sorted order.
+    ///
+    /// Names a [`fallback`] serves are not listed — the router does not know
+    /// them, which is the point of the seam.
+    ///
+    /// [`fallback`]: RpcRouter::fallback
     pub fn method_names(&self) -> impl Iterator<Item = &str> {
         self.methods.keys().map(String::as_str)
     }
@@ -157,20 +218,28 @@ impl RpcRouter {
     /// Decide the response for one request frame.
     ///
     /// What, in order: parse the frame; refuse a `jsonrpc` that is not
-    /// [`JSONRPC_VERSION`]; refuse a method no handler is registered for; then
-    /// run the handler. A parse failure answers with a `null` id because there
-    /// was no readable id to echo — every other arm echoes the request's.
+    /// [`JSONRPC_VERSION`]; look the method up; run the handler. A name no
+    /// handler is registered for goes to the [`fallback`] if one is mounted and
+    /// is refused with [`RpcError::method_not_found`] otherwise. A parse failure
+    /// answers with a `null` id because there was no readable id to echo —
+    /// every other arm echoes the request's.
     ///
     /// Never returns `Err`: a failure to serve is itself a response frame, so
     /// the caller always has something to write back. Hanging up instead would
-    /// give the client a transport error where a reason exists.
+    /// give the client a transport error where a reason exists. A fallback's
+    /// error is no exception — it becomes this frame's error half verbatim.
     ///
     /// Test: `dispatch_routes_to_the_registered_handler`,
     /// `dispatch_reports_method_not_found_for_an_unregistered_method`,
     /// `dispatch_rejects_an_unparseable_frame`,
     /// `dispatch_rejects_a_wrong_jsonrpc_version`,
     /// `dispatch_reports_invalid_params_for_an_undecodable_payload`,
-    /// `dispatch_propagates_a_handler_error_verbatim`.
+    /// `dispatch_propagates_a_handler_error_verbatim`,
+    /// `dispatch_routes_an_unregistered_method_to_the_fallback`,
+    /// `dispatch_prefers_a_registered_method_over_the_fallback`,
+    /// `dispatch_maps_a_fallback_error_to_an_rpc_error_response`.
+    ///
+    /// [`fallback`]: RpcRouter::fallback
     pub async fn dispatch(&self, frame: &[u8]) -> RpcResponse {
         let request: RpcRequest = match serde_json::from_slice(frame) {
             Ok(r) => r,
@@ -196,11 +265,7 @@ impl RpcRouter {
         }
 
         let Some(handler) = self.methods.get(&request.method) else {
-            let known: Vec<&str> = self.method_names().collect();
-            return RpcResponse::failure(
-                request.id,
-                RpcError::method_not_found(&request.method, &known),
-            );
+            return self.dispatch_unregistered(request).await;
         };
 
         // Cloned out of the map before the await so the borrow of `self.methods`
@@ -210,6 +275,40 @@ impl RpcRouter {
         match handler.call(request.params).await {
             Ok(result) => RpcResponse::success(request.id, result),
             Err(error) => RpcResponse::failure(request.id, error),
+        }
+    }
+
+    /// The method-lookup miss: hand the request to the fallback, or refuse it.
+    ///
+    /// Split out of [`dispatch`] so the `let … else` arm stays one line and the
+    /// two answers a miss can have sit next to each other.
+    ///
+    /// Test: `dispatch_routes_an_unregistered_method_to_the_fallback`,
+    /// `dispatch_maps_a_fallback_error_to_an_rpc_error_response`,
+    /// `dispatch_reports_method_not_found_for_an_unregistered_method`.
+    ///
+    /// [`dispatch`]: RpcRouter::dispatch
+    async fn dispatch_unregistered(&self, request: RpcRequest) -> RpcResponse {
+        let Some(fallback) = self.fallback.as_ref() else {
+            let known: Vec<&str> = self.method_names().collect();
+            return RpcResponse::failure(
+                request.id,
+                RpcError::method_not_found(&request.method, &known),
+            );
+        };
+
+        // Cloned out before the await for the same reason the method arm does
+        // it: nothing borrowed from `self` is held across a handler call.
+        let fallback = Arc::clone(fallback);
+        let RpcRequest {
+            id, method, params, ..
+        } = request;
+        match fallback.call(&method, params).await {
+            Ok(result) => RpcResponse::success(id, result),
+            // The fallback owns its own refusal codes, so its error crosses the
+            // wire unrewritten — a downgrade to a generic internal error would
+            // cost the caller the reason it was given.
+            Err(error) => RpcResponse::failure(id, error),
         }
     }
 }

--- a/crates/trusty-common/src/uds/server/tests.rs
+++ b/crates/trusty-common/src/uds/server/tests.rs
@@ -156,6 +156,91 @@ async fn dispatch_propagates_a_handler_error_verbatim() {
     );
 }
 
+// ── the fallback seam (#6286) ───────────────────────────────────────────────
+
+/// A fallback that answers every name, echoing back what it was handed.
+///
+/// `refuse` names the one method it fails on, so the success and error arms are
+/// driven by the same implementation rather than two near-identical stubs.
+struct EchoFallback {
+    refuse: &'static str,
+}
+
+#[async_trait::async_trait]
+impl RpcFallback for EchoFallback {
+    async fn call(
+        &self,
+        method: &str,
+        params: serde_json::Value,
+    ) -> Result<serde_json::Value, RpcError> {
+        if method == self.refuse {
+            return Err(RpcError::new(-32002, format!("fallback refused {method}")));
+        }
+        Ok(json!({ "method": method, "params": params }))
+    }
+}
+
+#[tokio::test]
+async fn dispatch_routes_an_unregistered_method_to_the_fallback() {
+    // The seam #6286 exists for: a name the router never registered reaches the
+    // service's own dispatcher, with the METHOD NAME intact — a fallback that
+    // saw only the params could not decide what to run.
+    let router = greeting_router().fallback(EchoFallback { refuse: "" });
+
+    let response = router
+        .dispatch(&frame(11, "review", json!({ "n": 1 })))
+        .await;
+
+    assert!(response.error.is_none(), "unexpected error: {response:?}");
+    assert_eq!(
+        response.result,
+        Some(json!({ "method": "review", "params": { "n": 1 } })),
+        "the fallback must receive both the method name and the params"
+    );
+    assert_eq!(response.id, json!(11), "the request id is still echoed");
+}
+
+#[tokio::test]
+async fn dispatch_prefers_a_registered_method_over_the_fallback() {
+    // Registered wins. Mounting a dispatcher must not silently take over a
+    // method the service deliberately registered separately — that would make
+    // the override direction depend on registration order.
+    let router = greeting_router().fallback(EchoFallback { refuse: "" });
+
+    let response = router
+        .dispatch(&frame(12, "greet", json!({ "name": "ada" })))
+        .await;
+
+    assert_eq!(
+        response.result,
+        Some(json!({ "text": "hello ada" })),
+        "the registered handler answered, not the fallback"
+    );
+}
+
+#[tokio::test]
+async fn dispatch_maps_a_fallback_error_to_an_rpc_error_response() {
+    // Fail-open check: a fallback that returns `Err` must produce a coded error
+    // FRAME. Dropping the connection instead would hand the caller a transport
+    // failure with no reason in it, and rewriting the code would lose the
+    // service's own refusal.
+    let router = greeting_router().fallback(EchoFallback { refuse: "review" });
+
+    let response = router.dispatch(&frame(13, "review", json!(null))).await;
+
+    assert_eq!(
+        response.error.expect("an error"),
+        RpcError::new(-32002, "fallback refused review"),
+        "the fallback's own code and message must survive verbatim"
+    );
+    assert!(response.result.is_none());
+    assert_eq!(response.id, json!(13));
+}
+
+// A router with no fallback still answers `method_not_found` — proven by
+// `dispatch_reports_method_not_found_for_an_unregistered_method` above, which
+// #6286 left untouched. It is not restated here.
+
 #[test]
 fn method_names_are_sorted_and_complete() {
     let router = greeting_router();


### PR DESCRIPTION
Slice 1 of the trusty-memory UDS migration (Refs #6286; design amendment: https://github.com/bobmatnyc/trusty-tools/issues/6286#issuecomment-5424783658, finding 4).

Adds an `RpcFallback` trait and `RpcRouter::fallback(...)` to `trusty_common::uds::server`, consulted only when the method lookup misses — registered methods always win, and a fallback error maps verbatim to an RPC error response. Purely additive; routers without a fallback are unchanged. trusty-common 0.44.0 → 0.44.1.

Test ladder rung 4 (shared library): `cargo test -p trusty-common --features uds` (441 passed, 0 failed), `cargo clippy -p trusty-common --features uds --all-targets -- -D warnings`, `cargo check --workspace`, `cargo fmt --check`, `bash scripts/check_test_pointers.sh`, `bash scripts/check_line_cap.sh`, `bash scripts/check_semver.sh --crate trusty-common` (196 checks pass — no semver update required).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools