### PR TITLE
feat(trusty-common): multi-frame streaming responses over UDS (Refs #6286)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6519,7 +6519,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11411,7 +11411,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-common"
-version = "0.44.1"
+version = "0.44.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -14,7 +14,13 @@ name = "trusty-common"
 # `RpcRouter::fallback`. Both are additions inside an existing module: no public
 # item was removed or changed, and no existing trait gained a method, so nothing
 # here breaks a consumer.
-version = "0.44.1"
+# 0.44.2 (#6286): patch — multi-frame streaming responses over UDS. Everything
+# is an addition: a new `uds::stream_client` module, new items inside
+# `uds::server`, new `#[non_exhaustive]` `UdsRpcError` variants, and new
+# `RpcRouter` methods. `RpcRequest` is deliberately untouched — the `"stream"`
+# opt-in is read through a private probe struct rather than a new public field,
+# which would have made an additive feature a 0.x break.
+version = "0.44.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/trusty-common/changelog.d/6286-uds-streaming.md
+++ b/crates/trusty-common/changelog.d/6286-uds-streaming.md
@@ -1,0 +1,25 @@
+Added
+
+- A UDS RPC method can now answer in many frames instead of one, so a daemon
+  migrating to `uds::server` keeps a token stream rather than buffering it
+  (#6286). `RpcRouter::typed_stream` registers a handler that returns a
+  `tokio::sync::mpsc::Receiver` of items — the shape `trusty-memory`'s chat
+  handler already produces — and `uds::send_framed_stream_request` reads the
+  reply frame by frame as a `FramedStream`, which yields items through
+  `next_frame()` or adapts into a `futures_util::Stream`.
+- Streaming is opt-in per request, through one optional `"stream": true` field
+  on the existing JSON-RPC request frame. Without it the protocol is byte-for-byte
+  what it was, so an old client against a new server, and a new client calling a
+  method that does not stream, behave exactly as before.
+- A stream terminates on a frame, never on EOF: exactly one `"stream":"end"` or
+  `"stream":"error"` frame is written on every path, including a handler that
+  fails mid-stream, one that fails to open, and an item too large for
+  `RpcServeOptions::max_frame_bytes` (which now applies per frame). A client that
+  reaches EOF without a terminal frame reports it rather than returning a
+  truncated answer as a complete one.
+- The two protocol mismatches fail immediately in the shape the caller reads,
+  rather than hanging: a request without the flag against a streaming method gets
+  one ordinary response frame carrying `CODE_STREAM_REQUIRED`, and a streaming
+  request against anything that does not stream gets one terminal error frame
+  carrying `CODE_STREAM_UNSUPPORTED`, naming the methods this listener does
+  stream.

--- a/crates/trusty-common/src/uds/mod.rs
+++ b/crates/trusty-common/src/uds/mod.rs
@@ -60,6 +60,9 @@ pub mod rpc;
 // ADR-0032 supplies a method table rather than a fourth hand-rolled accept loop.
 pub mod server;
 pub mod singleton;
+// #6286: the reading half of a multi-frame response, so a token stream has one
+// definition of what terminates it rather than one per consumer.
+pub mod stream_client;
 
 /// On-demand supervision of a UDS-serving child process (#5089 step 2).
 ///
@@ -85,6 +88,9 @@ pub use rpc::{
     send_framed_request_capped, write_frame,
 };
 pub use singleton::bind_singleton_hardened;
+pub use stream_client::{
+    FramedStream, send_framed_stream_request, send_framed_stream_request_capped,
+};
 #[cfg(feature = "uds-supervisor")]
 pub use supervisor::{
     ServiceTimeouts, SpawnSpec, SupervisorConfig, SupervisorError, UdsServiceSupervisor,

--- a/crates/trusty-common/src/uds/rpc.rs
+++ b/crates/trusty-common/src/uds/rpc.rs
@@ -151,6 +151,37 @@ pub enum UdsRpcError {
         /// The budget that elapsed.
         timeout: Duration,
     },
+
+    // #6286: APPENDED, never inserted. `#[non_exhaustive]` makes a new variant
+    // additive, but it does not make a MOVED one additive — placing these ahead
+    // of `Timeout` shifted its implicit discriminant from 7 to 9, which
+    // `cargo-semver-checks` reports as a major break because a downstream
+    // `as isize` cast would change value. New variants go at the end.
+    /// A streaming response ended on a terminal error frame (#6286).
+    ///
+    /// The server's own code and message, unrewritten. Distinct from
+    /// [`UdsRpcError::NoResponse`] on purpose: the peer answered, and what it
+    /// said is the reason the stream stopped.
+    #[error("{path} ended the stream with {error}")]
+    Stream {
+        /// Socket the stream was read from.
+        path: PathBuf,
+        /// The server's terminal error.
+        error: crate::uds::server::RpcError,
+    },
+
+    /// A streaming request was answered with an ordinary response frame (#6286).
+    ///
+    /// The method does not stream. Boxed because [`super::server::RpcResponse`]
+    /// is much larger than every other variant's payload, and an enum is as big
+    /// as its widest arm.
+    #[error("{path} answered with a single response frame rather than a stream")]
+    NotAStream {
+        /// Socket that answered.
+        path: PathBuf,
+        /// The frame it sent, so the caller reads the server's own refusal.
+        response: Box<crate::uds::server::RpcResponse>,
+    },
 }
 
 /// Send one JSON frame to `path` and decode the one frame that comes back.
@@ -327,10 +358,14 @@ where
 
 /// Dial `path`, write one frame, and half-close the write side.
 ///
-/// Split out so [`send_framed_request_capped`] and [`send_framed_notification`]
-/// share one copy of the dial-and-write sequence; the returned stream is the
-/// still-open read half for callers that expect a reply.
-async fn dial_and_send<Req>(path: &Path, request: &Req) -> Result<UnixStream, UdsRpcError>
+/// Split out so [`send_framed_request_capped`], [`send_framed_notification`] and
+/// [`super::stream_client::send_framed_stream_request_capped`] share one copy of
+/// the dial-and-write sequence; the returned stream is the still-open read half
+/// for callers that expect a reply.
+pub(super) async fn dial_and_send<Req>(
+    path: &Path,
+    request: &Req,
+) -> Result<UnixStream, UdsRpcError>
 where
     Req: Serialize + ?Sized,
 {
@@ -436,7 +471,7 @@ where
 /// Test: `read_failure_from_an_abortive_close_reads_as_a_hang_up`,
 /// `read_failure_after_partial_bytes_stays_a_read_error`,
 /// `read_failure_from_an_unrelated_errno_stays_a_read_error`.
-fn classify_read_failure(
+pub(super) fn classify_read_failure(
     path: &Path,
     source: std::io::Error,
     nothing_buffered: bool,

--- a/crates/trusty-common/src/uds/server/mod.rs
+++ b/crates/trusty-common/src/uds/server/mod.rs
@@ -14,7 +14,9 @@
 //!   - [`RpcRouter`] is the caller's half: method names mapped to handlers over
 //!     the caller's own request and response types (see [`RpcRouter::typed`]).
 //!     A service that already has a generic `(method, params)` dispatcher
-//!     mounts it whole through [`RpcRouter::fallback`] instead (#6286).
+//!     mounts it whole through [`RpcRouter::fallback`] instead (#6286). A method
+//!     that answers in many frames rather than one is registered with
+//!     [`RpcRouter::typed_stream`] — see the wire contract below.
 //!   - [`RpcServer::run`] is the whole body of a daemon — bind, serve, unlink.
 //!   - [`serve_until`] and [`handle_connection`] are that body's two halves,
 //!     public so a caller with its own bind (say
@@ -26,6 +28,50 @@
 //! connection runs [`ensure_peer_is_self`] before a single byte is read. No
 //! CSRF, origin, or token machinery is ported from the HTTP shape those checks
 //! replace — on a UDS socket it would guard nothing (#6277 design review).
+//!
+//! ## The wire contract, including streams (#6286)
+//!
+//! A request is one newline-terminated JSON-RPC frame, unchanged:
+//!
+//! ```text
+//! {"jsonrpc":"2.0","id":7,"method":"chat","params":{…}}
+//! ```
+//!
+//! plus ONE optional field, `"stream": true`. Absent means false, and false is
+//! exactly the protocol as it stood — one request frame, one response frame,
+//! connection closed. An old client and a new server therefore behave as they
+//! always did, byte for byte, and so does a new client calling a method that
+//! does not stream.
+//!
+//! A request that asks for a stream, against a method registered with
+//! [`RpcRouter::typed_stream`], is answered with a SEQUENCE of frames on the
+//! same connection, each newline-terminated and each carrying a `"stream"`
+//! discriminant a plain response never has:
+//!
+//! ```text
+//! {"jsonrpc":"2.0","id":7,"stream":"item","result":"Hel"}
+//! {"jsonrpc":"2.0","id":7,"stream":"item","result":"lo"}
+//! {"jsonrpc":"2.0","id":7,"stream":"end"}
+//! ```
+//!
+//! **A stream terminates on a frame, never on EOF.** Exactly one terminal frame
+//! is written on every path — `"stream":"end"` when the producer finishes, and
+//! `"stream":"error"` carrying an [`RpcError`] when the handler fails mid-stream,
+//! when it fails to open at all, or when an item does not fit the frame budget.
+//! A client that reaches EOF without one reports it rather than returning what
+//! it happened to receive: a truncated token stream read as a complete answer is
+//! the Fail-Open branch this contract exists to close, and
+//! `stream_reports_a_truncated_stream_rather_than_an_empty_success` is its
+//! regression test.
+//!
+//! **The two mismatches both fail immediately, in the shape the caller reads.**
+//! A request WITHOUT the flag against a streaming method gets one ordinary
+//! response frame carrying [`CODE_STREAM_REQUIRED`]. A request WITH the flag
+//! against anything that does not stream — a unary method, a fallback-served
+//! name, an unknown name — gets one terminal `"stream":"error"` frame carrying
+//! [`CODE_STREAM_UNSUPPORTED`], naming the methods this listener does stream.
+//! Neither hangs, and neither leaves the caller decoding a frame shape it does
+//! not expect.
 //!
 //! **The socket file is unlinked explicitly.** [`bind_hardened`] binds and
 //! chmods; neither it nor `tokio::net::UnixListener`'s `Drop` removes the path,
@@ -39,6 +85,7 @@
 //! Test: `tests.rs` — `dispatch_*` for the decision, `serve_*` for the socket.
 
 mod router;
+mod stream;
 mod wire;
 
 #[cfg(test)]
@@ -55,9 +102,11 @@ use tokio::net::{UnixListener, UnixStream};
 use crate::uds::{MAX_FRAME_BYTES, UdsSecurityError, bind_hardened, ensure_peer_is_self};
 
 pub use router::{RpcFallback, RpcMethod, RpcRouter, typed_method};
+pub use stream::{RpcOutcome, RpcStreamItems, RpcStreamMethod, typed_stream_method, write_stream};
 pub use wire::{
     CODE_INTERNAL_ERROR, CODE_INVALID_PARAMS, CODE_INVALID_REQUEST, CODE_METHOD_NOT_FOUND,
-    CODE_PARSE_ERROR, JSONRPC_VERSION, RpcError, RpcRequest, RpcResponse,
+    CODE_PARSE_ERROR, CODE_STREAM_REQUIRED, CODE_STREAM_UNSUPPORTED, JSONRPC_VERSION, RpcError,
+    RpcRequest, RpcResponse, RpcStreamFrame, StreamPhase,
 };
 
 /// Everything that can stop this server, or stop one of its connections.
@@ -130,6 +179,15 @@ pub struct RpcServeOptions {
     /// whose method runs for minutes (`trusty-review`'s is the case #6277 is
     /// migrating) would otherwise need this raised to a figure that also lets a
     /// peer which connects and never writes hold a task for that long.
+    ///
+    /// **It does not apply between streamed response frames** (#6286). The gap
+    /// between two frames of a stream is the handler's own production latency —
+    /// an LLM deciding on the next token — and a budget there would kill a
+    /// legitimately slow stream. It bounds one thing: how long a peer may take
+    /// to deliver its REQUEST frame. A service that wants an idle-stream budget
+    /// enforces it in its producer, where the difference between "thinking" and
+    /// "stuck" is knowable; the client applies its own per-frame budget in
+    /// [`crate::uds::send_framed_stream_request`].
     pub read_timeout: Duration,
 
     /// Largest request frame accepted, counting its terminating newline.
@@ -148,12 +206,20 @@ pub struct RpcServeOptions {
     /// [`crate::uds::send_framed_request_capped`] — and must raise the client's
     /// to match, or it has only moved which side refuses.
     ///
+    /// **Per frame, in both directions** (#6286). On a streaming response it
+    /// governs each item frame separately, not the stream's total: an item that
+    /// would not fit is refused with a terminal error frame rather than
+    /// truncated, because the client applies the same budget to each frame it
+    /// reads and a frame it cannot buffer would desynchronise the rest of the
+    /// connection.
+    ///
     /// Not settable per method: the method name lives inside the frame this
     /// budget governs the reading of, so it is not known until after the budget
     /// has already been enforced.
     ///
     /// Test: `frame_of_exactly_the_budget_including_its_newline_is_accepted`,
-    /// `serve_rejects_an_oversized_frame`.
+    /// `serve_rejects_an_oversized_frame`,
+    /// `stream_refuses_an_item_larger_than_the_frame_budget`.
     pub max_frame_bytes: u64,
 }
 
@@ -194,17 +260,24 @@ pub enum Served {
 /// `UnixStream` pair without an accept loop.
 /// What: refuses a peer whose uid is not our own, reads bytes up to the first
 /// newline or EOF under [`RpcServeOptions::max_frame_bytes`], dispatches through
-/// `router`, and writes one newline-terminated response frame.
+/// `router`, and writes the answer — one response frame for a unary call, or the
+/// frame sequence the module docs' wire contract describes for a streaming one
+/// (#6286).
 ///
 /// # Errors
 ///
-/// Any [`RpcServerError`] variant except `Bind`. An error here means no
-/// response was written and the client sees a transport failure — which is why
-/// every failure the router can reason about is a response frame instead.
+/// Any [`RpcServerError`] variant except `Bind`. An error here means no complete
+/// answer was written and the client sees a transport failure — which is why
+/// every failure the router can reason about is a frame instead. On a stream,
+/// [`RpcServerError::Write`] mid-sequence is the client having gone away: the
+/// producer stops when its receiver drops here, and the accept loop is
+/// unaffected.
 ///
 /// Test: `serve_round_trips_a_request_over_a_real_socket`,
 /// `serve_rejects_an_oversized_frame`,
-/// `handle_connection_reports_a_liveness_probe_rather_than_a_failure`.
+/// `handle_connection_reports_a_liveness_probe_rather_than_a_failure`,
+/// `stream_round_trips_many_frames_over_a_real_socket`,
+/// `stream_survives_a_client_that_disconnects_mid_stream`.
 pub async fn handle_connection(
     mut stream: UnixStream,
     router: Arc<RpcRouter>,
@@ -234,20 +307,34 @@ pub async fn handle_connection(
         }
     }
 
-    let response = router.dispatch(&frame).await;
-    let errored = response.is_error();
-    // One owned, already-newline-terminated buffer, so the response leaves in a
-    // single write rather than a serialise-then-append pair.
-    let bytes =
-        crate::uds::encode_frame(&response).map_err(|source| RpcServerError::Encode { source })?;
-    stream
-        .write_all(&bytes)
-        .await
-        .map_err(|source| RpcServerError::Write { source })?;
-    stream
-        .flush()
-        .await
-        .map_err(|source| RpcServerError::Write { source })?;
+    let errored = match router.dispatch_streaming(&frame).await {
+        RpcOutcome::Single(response) => {
+            let errored = response.is_error();
+            // One owned, already-newline-terminated buffer, so the response
+            // leaves in a single write rather than a serialise-then-append pair.
+            let bytes = crate::uds::encode_frame(&response)
+                .map_err(|source| RpcServerError::Encode { source })?;
+            stream
+                .write_all(&bytes)
+                .await
+                .map_err(|source| RpcServerError::Write { source })?;
+            stream
+                .flush()
+                .await
+                .map_err(|source| RpcServerError::Write { source })?;
+            errored
+        }
+        // #6286: many frames, ending in exactly one terminal frame. A write
+        // failure part-way through is a dead client, not a server fault — it
+        // surfaces as `Write`, the connection is dropped, and the accept loop
+        // keeps serving. The handler's producer stops on its own when the
+        // receiver `write_stream` owns is dropped here.
+        RpcOutcome::Stream { id, items } => {
+            write_stream(&mut stream, id, items, options.max_frame_bytes)
+                .await
+                .map_err(|source| RpcServerError::Write { source })?
+        }
+    };
     Ok(Served::Answered { errored })
 }
 
@@ -393,6 +480,7 @@ impl RpcServer {
         tracing::info!(
             socket = %self.socket.display(),
             methods = ?self.router.method_names().collect::<Vec<_>>(),
+            streams = ?self.router.stream_names().collect::<Vec<_>>(),
             "uds rpc server bound"
         );
 

--- a/crates/trusty-common/src/uds/server/router.rs
+++ b/crates/trusty-common/src/uds/server/router.rs
@@ -17,22 +17,49 @@
 //! a service with its own generic dispatcher mounts instead of naming every
 //! method (#6286).
 //!
+//! [`RpcRouter::typed_stream`] registers a method that answers in many frames
+//! instead of one (#6286). Streaming and unary names live in separate tables, so
+//! one name is one or the other, and [`RpcRouter::dispatch_streaming`] is the
+//! wider entry point that can return either. [`RpcRouter::dispatch`] keeps
+//! answering with exactly one frame and refuses a streaming method rather than
+//! producing an answer its caller cannot read.
+//!
 //! Dispatch is `async` and takes `&self`, so one router serves every connection
 //! concurrently; nothing here holds a lock across a handler call.
 //!
-//! Test: `super::tests` — `dispatch_*`.
+//! Test: `super::tests` — `dispatch_*` and `stream_*`.
 
 use std::collections::BTreeMap;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use serde::Serialize;
 use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
 
+use super::stream::{RpcOutcome, RpcStreamMethod, typed_stream_method};
 use super::wire::{
     CODE_INVALID_REQUEST, CODE_PARSE_ERROR, JSONRPC_VERSION, RpcError, RpcRequest, RpcResponse,
 };
+
+/// The request field a caller sets to ask for a stream (#6286).
+///
+/// Why it is read separately rather than added to [`RpcRequest`]: that struct's
+/// fields are all public and it is not `#[non_exhaustive]`, so a new field would
+/// break every external crate that builds one with a literal — a major bump for
+/// an additive feature. Reading the flag through its own probe keeps
+/// [`RpcRequest`] byte-identical as a public type.
+///
+/// The second parse costs one pass over the frame and is paid ONLY on a request
+/// whose method is registered as a streaming one, which is about to do far more
+/// work than a parse. A unary request never reaches it.
+///
+/// Test: `stream_opt_in_is_read_from_the_request_frame`.
+#[derive(Deserialize)]
+struct StreamOptIn {
+    #[serde(default)]
+    stream: bool,
+}
 
 /// One method's implementation.
 ///
@@ -148,6 +175,7 @@ where
 #[derive(Default)]
 pub struct RpcRouter {
     methods: BTreeMap<String, Arc<dyn RpcMethod>>,
+    streams: BTreeMap<String, Arc<dyn RpcStreamMethod>>,
     fallback: Option<Arc<dyn RpcFallback>>,
 }
 
@@ -157,6 +185,7 @@ impl std::fmt::Debug for RpcRouter {
         // all fallback, so the flag is part of what this value is.
         f.debug_struct("RpcRouter")
             .field("methods", &self.method_names().collect::<Vec<_>>())
+            .field("streams", &self.stream_names().collect::<Vec<_>>())
             .field("fallback", &self.fallback.is_some())
             .finish()
     }
@@ -189,6 +218,41 @@ impl RpcRouter {
         self.method(name, typed_method::<Req, Resp, F, Fut>(call))
     }
 
+    /// Register a streaming `handler` under `name`, replacing any previous
+    /// streaming registration (#6286).
+    ///
+    /// Streaming and unary names live in SEPARATE tables, so one name is one or
+    /// the other and never both. Registering `"chat"` in both would leave the
+    /// answer depending on the request's `stream` flag, which is a protocol the
+    /// caller cannot reason about from the method name alone.
+    ///
+    /// Test: `stream_round_trips_many_frames_over_a_real_socket`.
+    pub fn stream_method(mut self, name: impl Into<String>, handler: impl RpcStreamMethod) -> Self {
+        self.streams.insert(name.into(), Arc::new(handler));
+        self
+    }
+
+    /// Register a streaming async function over the caller's own request type —
+    /// [`stream_method`] composed with [`typed_stream_method`].
+    ///
+    /// The function returns an `mpsc::Receiver`, so a producer that already
+    /// fills an `mpsc::Sender` from a background task — `trusty-memory`'s chat
+    /// handler is the case #6286 exists for — hands back its receiver and
+    /// changes nothing else.
+    ///
+    /// [`stream_method`]: RpcRouter::stream_method
+    ///
+    /// Test: `stream_round_trips_many_frames_over_a_real_socket`,
+    /// `stream_reports_invalid_params_before_opening_the_stream`.
+    pub fn typed_stream<Req, F, Fut>(self, name: impl Into<String>, call: F) -> Self
+    where
+        Req: DeserializeOwned + Send + 'static,
+        F: Fn(Req) -> Fut + Send + Sync + 'static,
+        Fut: std::future::Future<Output = Result<super::RpcStreamItems, RpcError>> + Send + 'static,
+    {
+        self.stream_method(name, typed_stream_method::<Req, F, Fut>(call))
+    }
+
     /// Serve every unregistered method through `fallback`, replacing any
     /// previous one (#6286).
     ///
@@ -215,7 +279,14 @@ impl RpcRouter {
         self.methods.keys().map(String::as_str)
     }
 
-    /// Decide the response for one request frame.
+    /// The registered streaming method names, in sorted order (#6286).
+    ///
+    /// Test: `stream_names_are_sorted_and_separate_from_unary_names`.
+    pub fn stream_names(&self) -> impl Iterator<Item = &str> {
+        self.streams.keys().map(String::as_str)
+    }
+
+    /// Decide the ONE response frame for one request frame.
     ///
     /// What, in order: parse the frame; refuse a `jsonrpc` that is not
     /// [`JSONRPC_VERSION`]; look the method up; run the handler. A name no
@@ -224,10 +295,21 @@ impl RpcRouter {
     /// answers with a `null` id because there was no readable id to echo —
     /// every other arm echoes the request's.
     ///
+    /// A method registered with [`typed_stream`] is refused here with
+    /// [`CODE_STREAM_REQUIRED`] rather than served (#6286): a caller of this
+    /// function writes one frame and reads one frame, so it could not read the
+    /// answer a stream produces. [`dispatch_streaming`] is the entry point that
+    /// can. A router with no streaming methods never reaches that arm and
+    /// behaves exactly as it did before #6286.
+    ///
     /// Never returns `Err`: a failure to serve is itself a response frame, so
     /// the caller always has something to write back. Hanging up instead would
     /// give the client a transport error where a reason exists. A fallback's
     /// error is no exception — it becomes this frame's error half verbatim.
+    ///
+    /// [`typed_stream`]: RpcRouter::typed_stream
+    /// [`dispatch_streaming`]: RpcRouter::dispatch_streaming
+    /// [`CODE_STREAM_REQUIRED`]: super::CODE_STREAM_REQUIRED
     ///
     /// Test: `dispatch_routes_to_the_registered_handler`,
     /// `dispatch_reports_method_not_found_for_an_unregistered_method`,
@@ -237,22 +319,138 @@ impl RpcRouter {
     /// `dispatch_propagates_a_handler_error_verbatim`,
     /// `dispatch_routes_an_unregistered_method_to_the_fallback`,
     /// `dispatch_prefers_a_registered_method_over_the_fallback`,
-    /// `dispatch_maps_a_fallback_error_to_an_rpc_error_response`.
+    /// `dispatch_maps_a_fallback_error_to_an_rpc_error_response`,
+    /// `unary_request_for_a_streaming_method_is_refused_in_one_frame`.
     ///
     /// [`fallback`]: RpcRouter::fallback
     pub async fn dispatch(&self, frame: &[u8]) -> RpcResponse {
+        let request = match self.envelope(frame) {
+            Ok(request) => request,
+            Err(response) => return response,
+        };
+
+        // A caller of `dispatch` writes one frame and reads one frame, so a
+        // streaming method has to refuse in that shape rather than answer in a
+        // shape the caller cannot read (#6286).
+        if self.streams.contains_key(&request.method) {
+            let method = request.method.clone();
+            return RpcResponse::failure(request.id, RpcError::stream_required(&method));
+        }
+
+        self.call_unary(request).await
+    }
+
+    /// Decide the response for one request frame, allowing a streaming answer
+    /// (#6286).
+    ///
+    /// Why: [`dispatch`] answers with a value, which cannot express "many frames
+    /// follow". This is the wider decision [`super::handle_connection`] drives,
+    /// kept separate so every existing caller of `dispatch` is untouched and a
+    /// transport that can write only one frame cannot accidentally be handed a
+    /// stream.
+    ///
+    /// What, in order: the same envelope checks [`dispatch`] runs, then the
+    /// four-way decision between the caller's `stream` flag and whether the
+    /// method is registered as streaming.
+    ///
+    /// | `"stream"` | method | answer |
+    /// |---|---|---|
+    /// | absent/false | unary or fallback | one [`RpcResponse`] — unchanged |
+    /// | absent/false | streaming | one [`RpcResponse`], [`CODE_STREAM_REQUIRED`] |
+    /// | true | streaming | the stream |
+    /// | true | anything else | one terminal error frame, [`CODE_STREAM_UNSUPPORTED`] |
+    ///
+    /// A [`fallback`] is never consulted for a streaming request: [`RpcFallback`]
+    /// answers with one value and has no way to produce a sequence, so a
+    /// streaming request it "served" would silently become a one-item stream.
+    ///
+    /// The `stream` flag is read only when this router registers at least one
+    /// streaming method. A router with none — every consumer that predates
+    /// #6286 — cannot reach a streaming answer, so the flag cannot change what
+    /// it says and is not parsed.
+    ///
+    /// Never returns `Err`, for the same reason [`dispatch`] does not: a refusal
+    /// is a frame, so the connection always has something to write.
+    ///
+    /// [`dispatch`]: RpcRouter::dispatch
+    /// [`fallback`]: RpcRouter::fallback
+    /// [`CODE_STREAM_REQUIRED`]: super::CODE_STREAM_REQUIRED
+    /// [`CODE_STREAM_UNSUPPORTED`]: super::CODE_STREAM_UNSUPPORTED
+    ///
+    /// Test: `dispatch_streaming_answers_a_unary_request_unchanged`,
+    /// `stream_round_trips_many_frames_over_a_real_socket`,
+    /// `stream_request_for_a_non_streaming_method_is_refused`,
+    /// `unary_request_for_a_streaming_method_is_refused_in_one_frame`,
+    /// `stream_opt_in_is_read_from_the_request_frame`.
+    pub async fn dispatch_streaming(&self, frame: &[u8]) -> RpcOutcome {
+        let request = match self.envelope(frame) {
+            Ok(request) => request,
+            Err(response) => return RpcOutcome::Single(response),
+        };
+
+        if self.streams.is_empty() {
+            return RpcOutcome::Single(self.call_unary(request).await);
+        }
+
+        let wants_stream = serde_json::from_slice::<StreamOptIn>(frame)
+            .map(|opt_in| opt_in.stream)
+            .unwrap_or(false);
+
+        match (wants_stream, self.streams.get(&request.method)) {
+            (true, Some(handler)) => {
+                // Cloned out of the map before the await for the same reason the
+                // unary arm does it: nothing borrowed from `self` is held across
+                // a handler call.
+                let handler = Arc::clone(handler);
+                match handler.call(request.params).await {
+                    Ok(items) => RpcOutcome::Stream {
+                        id: request.id,
+                        items,
+                    },
+                    Err(error) => RpcOutcome::refused(request.id, error),
+                }
+            }
+            (true, None) => {
+                let streaming: Vec<&str> = self.stream_names().collect();
+                RpcOutcome::refused(
+                    request.id,
+                    RpcError::stream_unsupported(&request.method, &streaming),
+                )
+            }
+            (false, Some(_)) => {
+                let method = request.method.clone();
+                RpcOutcome::Single(RpcResponse::failure(
+                    request.id,
+                    RpcError::stream_required(&method),
+                ))
+            }
+            (false, None) => RpcOutcome::Single(self.call_unary(request).await),
+        }
+    }
+
+    /// Parse one frame and check its envelope, or produce the refusal frame.
+    ///
+    /// Split out so [`dispatch`] and [`dispatch_streaming`] share exactly one
+    /// copy of the parse and version checks rather than drifting apart.
+    ///
+    /// [`dispatch`]: RpcRouter::dispatch
+    /// [`dispatch_streaming`]: RpcRouter::dispatch_streaming
+    ///
+    /// Test: `dispatch_rejects_an_unparseable_frame`,
+    /// `dispatch_rejects_a_wrong_jsonrpc_version`.
+    fn envelope(&self, frame: &[u8]) -> Result<RpcRequest, RpcResponse> {
         let request: RpcRequest = match serde_json::from_slice(frame) {
             Ok(r) => r,
             Err(e) => {
-                return RpcResponse::failure(
+                return Err(RpcResponse::failure(
                     serde_json::Value::Null,
                     RpcError::new(CODE_PARSE_ERROR, format!("unparseable request frame: {e}")),
-                );
+                ));
             }
         };
 
         if request.jsonrpc != JSONRPC_VERSION {
-            return RpcResponse::failure(
+            return Err(RpcResponse::failure(
                 request.id,
                 RpcError::new(
                     CODE_INVALID_REQUEST,
@@ -261,9 +459,15 @@ impl RpcRouter {
                         request.jsonrpc
                     ),
                 ),
-            );
+            ));
         }
 
+        Ok(request)
+    }
+
+    /// Run one already-checked request against the unary method table, falling
+    /// back where a fallback is mounted.
+    async fn call_unary(&self, request: RpcRequest) -> RpcResponse {
         let Some(handler) = self.methods.get(&request.method) else {
             return self.dispatch_unregistered(request).await;
         };

--- a/crates/trusty-common/src/uds/server/stream.rs
+++ b/crates/trusty-common/src/uds/server/stream.rs
@@ -1,0 +1,262 @@
+//! Multi-frame responses: the handler shape, and the writer that drains it
+//! (#6286).
+//!
+//! Why: `trusty-memory`'s `POST /api/v1/chat` streams LLM tokens off a
+//! `tokio::sync::mpsc::Receiver` wrapped in a `ReceiverStream`, and the
+//! one-frame-per-connection contract [`super::handle_connection`] enforces
+//! cannot carry that. #6287 deferred the multi-frame extension until a daemon
+//! had a real cross-crate SSE consumer; chat is that consumer, and degrading
+//! chat to a single buffered frame was ruled out. So the producer shape here is
+//! the shape chat already has: a handler hands back the RECEIVER and goes on
+//! filling the sender from wherever it likes.
+//!
+//! What, in the order a service uses them.
+//!   - [`RpcStreamItems`] is what a handler returns — an `mpsc::Receiver` of
+//!     per-item results. `tokio_stream::wrappers::ReceiverStream::new` takes the
+//!     same value, so a caller that already thinks in `Stream`s loses nothing.
+//!   - [`RpcStreamMethod`] is the object-safe handler trait, and
+//!     [`typed_stream_method`] builds one from an async function over the
+//!     caller's own request type.
+//!   - [`RpcOutcome`] is what [`super::RpcRouter::dispatch_streaming`] decides:
+//!     one response, or a stream to drain.
+//!   - [`write_stream`] drains that stream onto the socket in the frame contract
+//!     [`RpcStreamFrame`] documents.
+//!
+//! **Every stream ends in exactly one terminal frame.** `write_stream` has no
+//! path that returns `Ok` without having written an `end` or an `error` frame:
+//! a handler error becomes a terminal error frame, an item too large for the
+//! frame budget becomes a terminal error frame, and a producer that drops its
+//! sender without failing becomes a terminal `end`. A silently truncated stream
+//! would be a Fail-Open branch — the client would read a partial answer as a
+//! complete one — so the only way a stream ends without a terminal frame is a
+//! write failure, which the client sees as a hang-up rather than as data.
+//!
+//! Test: `super::tests` — `stream_*`.
+
+use std::marker::PhantomData;
+
+use async_trait::async_trait;
+use serde::de::DeserializeOwned;
+use tokio::io::{AsyncWrite, AsyncWriteExt};
+use tokio::sync::mpsc;
+
+use super::wire::{RpcError, RpcResponse, RpcStreamFrame};
+
+/// The channel a streaming handler produces into.
+///
+/// An `Ok` item becomes one [`StreamPhase::Item`] frame; an `Err` becomes the
+/// terminal error frame and stops the stream. Dropping the sender ends the
+/// stream successfully.
+///
+/// [`StreamPhase::Item`]: super::StreamPhase
+pub type RpcStreamItems = mpsc::Receiver<Result<serde_json::Value, RpcError>>;
+
+/// One streaming method's implementation (#6286).
+///
+/// Why: object-safe for the same reason [`RpcMethod`] is — the router holds a
+/// heterogeneous set behind `Arc<dyn RpcStreamMethod>`. Most callers never name
+/// it; [`typed_stream_method`] builds one from an ordinary async function.
+/// What: opens the stream and returns its receiver. Returning `Err` here is the
+/// "could not start" case — the caller never sent an item, so it becomes a
+/// terminal error frame with zero items ahead of it.
+///
+/// [`RpcMethod`]: super::RpcMethod
+///
+/// Test: `stream_round_trips_many_frames_over_a_real_socket`,
+/// `stream_reports_a_handler_error_as_a_terminal_frame`.
+#[async_trait]
+pub trait RpcStreamMethod: Send + Sync + 'static {
+    /// Open a stream for one decoded `params` payload.
+    async fn call(&self, params: serde_json::Value) -> Result<RpcStreamItems, RpcError>;
+}
+
+/// Adapter behind [`typed_stream_method`]; `PhantomData<fn(Req)>` keeps the
+/// struct `Send + Sync` whatever `Req` is.
+struct TypedStream<Req, F> {
+    call: F,
+    _req: PhantomData<fn(Req)>,
+}
+
+#[async_trait]
+impl<Req, F, Fut> RpcStreamMethod for TypedStream<Req, F>
+where
+    Req: DeserializeOwned + Send + 'static,
+    F: Fn(Req) -> Fut + Send + Sync + 'static,
+    Fut: std::future::Future<Output = Result<RpcStreamItems, RpcError>> + Send + 'static,
+{
+    async fn call(&self, params: serde_json::Value) -> Result<RpcStreamItems, RpcError> {
+        let request: Req = serde_json::from_value(params)
+            .map_err(|e| RpcError::invalid_params(format!("params do not decode: {e}")))?;
+        (self.call)(request).await
+    }
+}
+
+/// Build an [`RpcStreamMethod`] from an async function over the caller's own
+/// request type.
+///
+/// Why: the streaming counterpart of [`typed_method`] — the caller names `Req`
+/// and never touches `serde_json::Value` on the way in. Items stay `Value`
+/// deliberately: a token stream is heterogeneous in practice (a text delta, a
+/// usage record, a finish reason), and forcing one `Resp` type on every frame
+/// would push that union into every service.
+/// What: deserialises `params` into `Req` before `call` runs, reporting a decode
+/// failure as [`RpcError::invalid_params`] exactly as the unary path does.
+///
+/// [`typed_method`]: super::typed_method
+///
+/// Test: `stream_reports_invalid_params_before_opening_the_stream`.
+pub fn typed_stream_method<Req, F, Fut>(call: F) -> impl RpcStreamMethod
+where
+    Req: DeserializeOwned + Send + 'static,
+    F: Fn(Req) -> Fut + Send + Sync + 'static,
+    Fut: std::future::Future<Output = Result<RpcStreamItems, RpcError>> + Send + 'static,
+{
+    TypedStream::<Req, F> {
+        call,
+        _req: PhantomData,
+    }
+}
+
+/// What one request frame turned out to need (#6286).
+///
+/// Why: [`super::RpcRouter::dispatch`] answers with a value, which is right for
+/// a unary call and cannot express "many frames follow". This is the wider
+/// return the connection handler needs, kept out of `dispatch` so every existing
+/// caller of that function is untouched.
+/// What: either the single response frame to write, or the id to stamp on each
+/// frame plus the receiver to drain.
+///
+/// `#[non_exhaustive]`: a third outcome (a bidirectional exchange, say) would
+/// otherwise be a breaking change.
+///
+/// Test: `stream_round_trips_many_frames_over_a_real_socket`,
+/// `dispatch_streaming_answers_a_unary_request_unchanged`.
+#[non_exhaustive]
+pub enum RpcOutcome {
+    /// One response frame, exactly as a non-streaming exchange produces.
+    Single(RpcResponse),
+    /// A stream to drain onto the connection.
+    Stream {
+        /// The request id, echoed on every frame of the stream.
+        id: serde_json::Value,
+        /// The handler's items.
+        items: RpcStreamItems,
+    },
+}
+
+impl RpcOutcome {
+    /// A stream that carries nothing but its terminal error frame.
+    ///
+    /// Why: a streaming request the router refuses — an unstreamable method, or
+    /// a handler that failed before producing an item — must still answer in the
+    /// shape the caller is reading, and must still end in exactly one terminal
+    /// frame. Expressing the refusal as a one-item stream routes it through
+    /// [`write_stream`] rather than adding a second place that decides what
+    /// terminates a stream.
+    ///
+    /// Test: `stream_request_for_a_non_streaming_method_is_refused`,
+    /// `stream_reports_an_open_failure_as_a_terminal_frame`.
+    pub fn refused(id: serde_json::Value, error: RpcError) -> Self {
+        let (tx, items) = mpsc::channel(1);
+        // A fresh channel with capacity 1 and no other sender cannot be full or
+        // closed, so this send cannot fail.
+        let _ = tx.try_send(Err(error));
+        drop(tx);
+        Self::Stream { id, items }
+    }
+}
+
+impl std::fmt::Debug for RpcOutcome {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Single(response) => f.debug_tuple("Single").field(response).finish(),
+            // The receiver's contents are not inspectable without consuming
+            // them, so the id is the whole of what can honestly be shown.
+            Self::Stream { id, .. } => f.debug_struct("Stream").field("id", id).finish(),
+        }
+    }
+}
+
+/// Drain `items` onto `writer` as newline-terminated stream frames.
+///
+/// Why: the write half of the contract [`RpcStreamFrame`] states, in one place,
+/// so "what terminates a stream" is decided once rather than per service.
+/// What: one [`StreamPhase::Item`] frame per `Ok` item, then exactly one
+/// terminal frame — `end` when the producer finishes, `error` when it fails or
+/// when an item does not fit `max_frame_bytes`. Returns whether the terminal
+/// frame carried an error.
+///
+/// **`max_frame_bytes` is per frame, not per stream.** An item that would not
+/// fit is refused rather than truncated, because the client applies the same
+/// budget to each frame it reads and a frame it cannot buffer would desynchronise
+/// the rest of the connection.
+///
+/// The writer is flushed after every frame. Batching would be cheaper and would
+/// also defeat the point: a token stream the client sees only at completion is
+/// the buffered response streaming exists to replace.
+///
+/// # Errors
+///
+/// Only the underlying write error. A handler failure is data, not an error
+/// here — it leaves as the terminal error frame.
+///
+/// [`StreamPhase::Item`]: super::StreamPhase
+///
+/// Test: `stream_round_trips_many_frames_over_a_real_socket`,
+/// `stream_reports_a_handler_error_as_a_terminal_frame`,
+/// `stream_refuses_an_item_larger_than_the_frame_budget`,
+/// `stream_survives_a_client_that_disconnects_mid_stream`.
+pub async fn write_stream<W>(
+    writer: &mut W,
+    id: serde_json::Value,
+    mut items: RpcStreamItems,
+    max_frame_bytes: u64,
+) -> std::io::Result<bool>
+where
+    W: AsyncWrite + Unpin,
+{
+    while let Some(item) = items.recv().await {
+        let value = match item {
+            Ok(value) => value,
+            Err(error) => {
+                write_frame(writer, &RpcStreamFrame::error(id.clone(), error)).await?;
+                return Ok(true);
+            }
+        };
+
+        let frame = encode(&RpcStreamFrame::item(id.clone(), value))?;
+        if frame.len() as u64 > max_frame_bytes {
+            // Fail closed: the client's reader refuses a frame over its own
+            // budget, so writing this one would strand the connection
+            // mid-stream with no terminal frame in it.
+            let refusal = RpcError::internal(format!(
+                "stream item of {} bytes exceeds the {max_frame_bytes}-byte frame budget",
+                frame.len()
+            ));
+            write_frame(writer, &RpcStreamFrame::error(id.clone(), refusal)).await?;
+            return Ok(true);
+        }
+        writer.write_all(&frame).await?;
+        writer.flush().await?;
+    }
+
+    write_frame(writer, &RpcStreamFrame::end(id)).await?;
+    Ok(false)
+}
+
+/// [`crate::uds::encode_frame`] with its serde failure mapped to an io error,
+/// so `write_stream` has one error type rather than two.
+fn encode(frame: &RpcStreamFrame) -> std::io::Result<Vec<u8>> {
+    crate::uds::encode_frame(frame)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+}
+
+/// Encode one frame and push it, flushed, so the client sees it immediately.
+async fn write_frame<W>(writer: &mut W, frame: &RpcStreamFrame) -> std::io::Result<()>
+where
+    W: AsyncWrite + Unpin,
+{
+    let bytes = encode(frame)?;
+    writer.write_all(&bytes).await?;
+    writer.flush().await
+}

--- a/crates/trusty-common/src/uds/server/tests.rs
+++ b/crates/trusty-common/src/uds/server/tests.rs
@@ -455,6 +455,453 @@ async fn server_round_trips_and_removes_its_socket_on_shutdown() {
     );
 }
 
+// ── streaming (#6286) ───────────────────────────────────────────────────────
+
+/// A request that opts into a stream. The flag is the whole negotiation: a
+/// frame without it is the protocol exactly as it stood.
+fn stream_frame(id: u64, method: &str, params: serde_json::Value) -> serde_json::Value {
+    json!({ "jsonrpc": "2.0", "id": id, "method": method, "params": params, "stream": true })
+}
+
+/// A router that streams `count` tokens on `"tokens"`, plus the unary methods,
+/// so the two tables are exercised against one another.
+///
+/// `count` of zero streams nothing and still ends on a terminal frame, which is
+/// the case a "the end is implied by silence" design would get wrong.
+fn token_router(count: usize) -> RpcRouter {
+    greeting_router().typed_stream("tokens", move |_req: ()| async move {
+        let (tx, rx) = tokio::sync::mpsc::channel(4);
+        // Produced from a task, exactly as an LLM client feeds its channel:
+        // the handler returns the receiver before a single token exists.
+        tokio::spawn(async move {
+            for n in 0..count {
+                if tx.send(Ok(json!(format!("t{n}")))).await.is_err() {
+                    return;
+                }
+            }
+        });
+        Ok(rx)
+    })
+}
+
+#[test]
+fn stream_frames_carry_the_phase_discriminant() {
+    // A plain response has no `stream` field at all; that absence is what lets a
+    // reader tell the two envelopes apart on one socket.
+    let item = serde_json::to_value(RpcStreamFrame::item(json!(1), json!("tok"))).expect("encode");
+    assert_eq!(item["stream"], json!("item"));
+    assert_eq!(item["result"], json!("tok"));
+
+    let end = serde_json::to_value(RpcStreamFrame::end(json!(1))).expect("encode");
+    assert_eq!(end["stream"], json!("end"));
+    assert!(end.get("result").is_none() && end.get("error").is_none());
+
+    let failed =
+        serde_json::to_value(RpcStreamFrame::error(json!(1), RpcError::internal("no"))).expect("e");
+    assert_eq!(failed["stream"], json!("error"));
+    assert_eq!(failed["error"]["message"], json!("no"));
+
+    let unary = serde_json::to_value(RpcResponse::success(json!(1), json!("x"))).expect("encode");
+    assert!(
+        unary.get("stream").is_none(),
+        "a unary response must never carry the discriminant"
+    );
+}
+
+#[test]
+fn stream_names_are_sorted_and_separate_from_unary_names() {
+    let router = token_router(1);
+    assert_eq!(router.stream_names().collect::<Vec<_>>(), vec!["tokens"]);
+    assert_eq!(
+        router.method_names().collect::<Vec<_>>(),
+        vec!["explode", "greet"],
+        "a streaming name must not appear in the unary table"
+    );
+}
+
+#[tokio::test]
+async fn dispatch_streaming_answers_a_unary_request_unchanged() {
+    // Backward compatibility, at the decision layer: the wider entry point must
+    // produce byte-identical answers for every request that predates #6286.
+    for (id, method, params) in [
+        (1u64, "greet", json!({ "name": "ada" })),
+        (2, "explode", json!(null)),
+        (3, "nope", json!(null)),
+    ] {
+        let raw = frame(id, method, params.clone());
+        let unary = greeting_router().dispatch(&raw).await;
+        let wide = match greeting_router().dispatch_streaming(&raw).await {
+            RpcOutcome::Single(response) => response,
+            other => panic!("a request without the flag must not stream: {other:?}"),
+        };
+        assert_eq!(
+            serde_json::to_value(&unary).expect("encode"),
+            serde_json::to_value(&wide).expect("encode"),
+            "dispatch_streaming changed the answer for {method}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn stream_opt_in_is_read_from_the_request_frame() {
+    // The negotiation itself: the same method, the same params, and only the
+    // flag decides which shape comes back.
+    let router = token_router(1);
+
+    let without = frame(1, "tokens", json!(null));
+    match router.dispatch_streaming(&without).await {
+        RpcOutcome::Single(response) => {
+            assert_eq!(response.error.expect("an error").code, CODE_STREAM_REQUIRED)
+        }
+        other => panic!("no flag must not produce a stream: {other:?}"),
+    }
+
+    let with = serde_json::to_vec(&stream_frame(1, "tokens", json!(null))).expect("encode");
+    match router.dispatch_streaming(&with).await {
+        RpcOutcome::Stream { id, .. } => assert_eq!(id, json!(1)),
+        other => panic!("the flag must produce a stream: {other:?}"),
+    }
+}
+
+/// Read every frame of a streaming call, returning the items and the terminal
+/// frame. Uses the production client half, so the contract is proven end to end.
+async fn collect_stream(
+    socket: &std::path::Path,
+    id: u64,
+    method: &str,
+    params: serde_json::Value,
+) -> Result<Vec<String>, crate::uds::UdsRpcError> {
+    let request = stream_frame(id, method, params);
+    let mut stream: crate::uds::FramedStream<String> =
+        crate::uds::send_framed_stream_request(socket, &request, Duration::from_secs(10)).await?;
+    let mut items = Vec::new();
+    while let Some(item) = stream.next_frame().await {
+        items.push(item?);
+    }
+    Ok(items)
+}
+
+#[tokio::test]
+async fn stream_round_trips_many_frames_over_a_real_socket() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let (socket, _stop, _handle) =
+        spawn_server(tmp.path(), token_router(3), RpcServeOptions::default());
+    await_socket(&socket).await;
+
+    let items = collect_stream(&socket, 1, "tokens", json!(null))
+        .await
+        .expect("the stream must complete");
+
+    assert_eq!(items, vec!["t0", "t1", "t2"]);
+}
+
+#[tokio::test]
+async fn stream_of_zero_items_still_ends_on_a_terminal_frame() {
+    // "No items" and "truncated" must not look the same on the wire, or an empty
+    // answer and a lost one are indistinguishable.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let (socket, _stop, _handle) =
+        spawn_server(tmp.path(), token_router(0), RpcServeOptions::default());
+    await_socket(&socket).await;
+
+    let items = collect_stream(&socket, 1, "tokens", json!(null))
+        .await
+        .expect("an empty stream is still a complete one");
+
+    assert!(items.is_empty());
+}
+
+#[tokio::test]
+async fn stream_reports_a_handler_error_as_a_terminal_frame() {
+    // The Fail-Open branch: a producer that fails after two items must reach the
+    // client as a REASON, never as a stream that quietly stopped at two.
+    let router = RpcRouter::new().typed_stream("tokens", |_req: ()| async move {
+        let (tx, rx) = tokio::sync::mpsc::channel(4);
+        tokio::spawn(async move {
+            let _ = tx.send(Ok(json!("t0"))).await;
+            let _ = tx.send(Ok(json!("t1"))).await;
+            let _ = tx
+                .send(Err(RpcError::new(-32003, "the model gave up")))
+                .await;
+        });
+        Ok(rx)
+    });
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let (socket, _stop, _handle) = spawn_server(tmp.path(), router, RpcServeOptions::default());
+    await_socket(&socket).await;
+
+    let err = collect_stream(&socket, 1, "tokens", json!(null))
+        .await
+        .expect_err("a mid-stream failure must not read as a complete answer");
+
+    match err {
+        crate::uds::UdsRpcError::Stream { error, .. } => {
+            assert_eq!(error, RpcError::new(-32003, "the model gave up"),);
+        }
+        other => panic!("expected Stream, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn stream_reports_an_open_failure_as_a_terminal_frame() {
+    // A handler that refuses before producing anything answers in the same shape
+    // as one that fails half way — the caller has one thing to read either way.
+    let router = RpcRouter::new().typed_stream("tokens", |_req: ()| async move {
+        Err(RpcError::new(-32004, "no model configured"))
+    });
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let (socket, _stop, _handle) = spawn_server(tmp.path(), router, RpcServeOptions::default());
+    await_socket(&socket).await;
+
+    let err = collect_stream(&socket, 1, "tokens", json!(null))
+        .await
+        .expect_err("an open failure is still an error");
+
+    assert!(
+        matches!(&err, crate::uds::UdsRpcError::Stream { error, .. } if error.code == -32004),
+        "expected the handler's own code, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn stream_reports_invalid_params_before_opening_the_stream() {
+    let router = RpcRouter::new().typed_stream("tokens", |_req: Greet| async move {
+        let (_tx, rx) = tokio::sync::mpsc::channel(1);
+        Ok(rx)
+    });
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let (socket, _stop, _handle) = spawn_server(tmp.path(), router, RpcServeOptions::default());
+    await_socket(&socket).await;
+
+    let err = collect_stream(&socket, 1, "tokens", json!({ "name": 17 }))
+        .await
+        .expect_err("bad params must not open a stream");
+
+    assert!(
+        matches!(&err, crate::uds::UdsRpcError::Stream { error, .. }
+            if error.code == CODE_INVALID_PARAMS),
+        "expected invalid_params, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn stream_request_for_a_non_streaming_method_is_refused() {
+    // The streaming client API against a unary method. It must fail with a
+    // reason and finish — never hang waiting for a terminal frame that a unary
+    // answer does not contain.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let (socket, _stop, _handle) =
+        spawn_server(tmp.path(), token_router(1), RpcServeOptions::default());
+    await_socket(&socket).await;
+
+    for method in ["greet", "no-such-method"] {
+        let err = tokio::time::timeout(
+            Duration::from_secs(5),
+            collect_stream(&socket, 1, method, json!({ "name": "ada" })),
+        )
+        .await
+        .unwrap_or_else(|_| panic!("{method} hung instead of failing"))
+        .expect_err("a method that does not stream must refuse");
+
+        match err {
+            crate::uds::UdsRpcError::Stream { error, .. } => {
+                assert_eq!(error.code, CODE_STREAM_UNSUPPORTED);
+                assert!(
+                    error.message.contains("tokens"),
+                    "the refusal must name what this listener does stream: {}",
+                    error.message
+                );
+            }
+            other => panic!("expected a terminal error frame for {method}, got {other:?}"),
+        }
+    }
+}
+
+#[tokio::test]
+async fn unary_request_for_a_streaming_method_is_refused_in_one_frame() {
+    // The other direction: an old client, which writes one frame and reads one
+    // frame, must get exactly that — not a stream it cannot parse, and not a
+    // hang.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let (socket, _stop, _handle) =
+        spawn_server(tmp.path(), token_router(3), RpcServeOptions::default());
+    await_socket(&socket).await;
+
+    let response = tokio::time::timeout(
+        Duration::from_secs(5),
+        call(&socket, 1, "tokens", json!(null)),
+    )
+    .await
+    .expect("a unary call on a streaming method must not hang");
+
+    let error = response.error.expect("an error");
+    assert_eq!(error.code, CODE_STREAM_REQUIRED);
+    assert!(
+        error.message.contains("stream"),
+        "the refusal must say how to ask again: {}",
+        error.message
+    );
+}
+
+#[tokio::test]
+async fn stream_refuses_an_item_larger_than_the_frame_budget() {
+    // Per frame, not per stream: an item the client could not buffer becomes a
+    // terminal error rather than a frame that desynchronises the connection.
+    let router = RpcRouter::new().typed_stream("tokens", |_req: ()| async move {
+        let (tx, rx) = tokio::sync::mpsc::channel(2);
+        tokio::spawn(async move {
+            let _ = tx.send(Ok(json!("small"))).await;
+            let _ = tx.send(Ok(json!("x".repeat(4096)))).await;
+        });
+        Ok(rx)
+    });
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let (socket, _stop, _handle) = spawn_server(
+        tmp.path(),
+        router,
+        RpcServeOptions {
+            max_frame_bytes: 512,
+            ..RpcServeOptions::default()
+        },
+    );
+    await_socket(&socket).await;
+
+    let request = stream_frame(1, "tokens", json!(null));
+    let mut stream: crate::uds::FramedStream<String> =
+        crate::uds::send_framed_stream_request_capped(
+            &socket,
+            &request,
+            Duration::from_secs(10),
+            512,
+        )
+        .await
+        .expect("open");
+
+    assert_eq!(
+        stream.next_frame().await.expect("an item").expect("ok"),
+        "small",
+        "the frames before the oversized one still arrive"
+    );
+    let err = stream
+        .next_frame()
+        .await
+        .expect("a report")
+        .expect_err("an oversized item must not be written");
+    assert!(
+        matches!(&err, crate::uds::UdsRpcError::Stream { error, .. }
+            if error.message.contains("frame budget")),
+        "expected a terminal budget refusal, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn stream_serves_one_frame_requests_on_other_connections_while_running() {
+    // A stream holds one connection for as long as its producer runs. The accept
+    // loop must keep answering everything else meanwhile — the property a server
+    // that drained streams inline would lose.
+    let (release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
+    let release = Arc::new(tokio::sync::Mutex::new(Some(release_rx)));
+    let router = greeting_router().typed_stream("tokens", move |_req: ()| {
+        let release = Arc::clone(&release);
+        async move {
+            let (tx, rx) = tokio::sync::mpsc::channel(4);
+            tokio::spawn(async move {
+                let _ = tx.send(Ok(json!("first"))).await;
+                // Hold the stream open until the unary calls have been served.
+                if let Some(gate) = release.lock().await.take() {
+                    let _ = gate.await;
+                }
+                let _ = tx.send(Ok(json!("last"))).await;
+            });
+            Ok(rx)
+        }
+    });
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let (socket, _stop, _handle) = spawn_server(tmp.path(), router, RpcServeOptions::default());
+    await_socket(&socket).await;
+
+    let request = stream_frame(1, "tokens", json!(null));
+    let mut stream: crate::uds::FramedStream<String> =
+        crate::uds::send_framed_stream_request(&socket, &request, Duration::from_secs(10))
+            .await
+            .expect("open");
+    assert_eq!(
+        stream.next_frame().await.expect("an item").expect("ok"),
+        "first",
+        "the stream is live before the interleaved calls"
+    );
+
+    for n in 0..3u64 {
+        let response = tokio::time::timeout(
+            Duration::from_secs(5),
+            call(&socket, 100 + n, "greet", json!({ "name": "ada" })),
+        )
+        .await
+        .expect("a one-frame call must not queue behind a live stream");
+        assert_eq!(response.result, Some(json!({ "text": "hello ada" })));
+    }
+
+    release_tx.send(()).expect("release the stream");
+    assert_eq!(
+        stream.next_frame().await.expect("an item").expect("ok"),
+        "last"
+    );
+    assert!(
+        stream.next_frame().await.is_none(),
+        "the terminal frame ends the stream"
+    );
+}
+
+#[tokio::test]
+async fn stream_survives_a_client_that_disconnects_mid_stream() {
+    // Dropping a reader mid-stream must not wedge the accept loop or take the
+    // process down. The producer stops on its own when its receiver is dropped;
+    // what is asserted here is that the server still serves afterwards.
+    let router = greeting_router().typed_stream("tokens", |_req: ()| async move {
+        let (tx, rx) = tokio::sync::mpsc::channel(1);
+        tokio::spawn(async move {
+            // Far more items than the client will read, so the write fails
+            // part-way rather than at a convenient boundary.
+            for n in 0..10_000u32 {
+                if tx.send(Ok(json!(format!("t{n}")))).await.is_err() {
+                    return;
+                }
+            }
+        });
+        Ok(rx)
+    });
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let (socket, _stop, _handle) = spawn_server(tmp.path(), router, RpcServeOptions::default());
+    await_socket(&socket).await;
+
+    {
+        let request = stream_frame(1, "tokens", json!(null));
+        let mut stream: crate::uds::FramedStream<String> =
+            crate::uds::send_framed_stream_request(&socket, &request, Duration::from_secs(10))
+                .await
+                .expect("open");
+        assert_eq!(
+            stream.next_frame().await.expect("an item").expect("ok"),
+            "t0"
+        );
+        // Drop the reader with thousands of frames still to come.
+    }
+
+    let response = tokio::time::timeout(
+        Duration::from_secs(5),
+        call(&socket, 2, "greet", json!({ "name": "ada" })),
+    )
+    .await
+    .expect("an abandoned stream must not wedge the accept loop");
+    assert_eq!(response.result, Some(json!({ "text": "hello ada" })));
+}
+
 // ── one connection, driven directly ─────────────────────────────────────────
 
 #[tokio::test]

--- a/crates/trusty-common/src/uds/server/wire.rs
+++ b/crates/trusty-common/src/uds/server/wire.rs
@@ -14,7 +14,13 @@
 //! `result` payloads stay `serde_json::Value` here; the caller's own request and
 //! response types are decoded one layer up, in [`super::typed_method`].
 //!
-//! Test: `super::tests` — `dispatch_*` for the codes, `wire_*` for the shapes.
+//! [`RpcStreamFrame`] is the multi-frame half (#6286): the envelope a streaming
+//! response is written in, and the only shape that carries a `stream`
+//! discriminant. A non-streaming exchange never produces one, which is what
+//! keeps the two protocols distinguishable on the same socket.
+//!
+//! Test: `super::tests` — `dispatch_*` for the codes,
+//! `stream_frames_carry_the_phase_discriminant` for the streaming shapes.
 
 use serde::{Deserialize, Serialize};
 
@@ -39,6 +45,22 @@ pub const CODE_INVALID_PARAMS: i64 = -32602;
 
 /// JSON-RPC code for a handler that failed for its own reasons.
 pub const CODE_INTERNAL_ERROR: i64 = -32603;
+
+/// A request asked for a stream from a method that does not produce one (#6286).
+///
+/// In JSON-RPC's implementation-defined server range (`-32099..=-32000`), so it
+/// cannot collide with the reserved codes above. Reported in the `error` half of
+/// a terminal [`RpcStreamFrame`], because a caller that asked for a stream reads
+/// stream frames and would not recognise a plain [`RpcResponse`].
+pub const CODE_STREAM_UNSUPPORTED: i64 = -32010;
+
+/// A request reached a streaming method without asking for a stream (#6286).
+///
+/// Reported in an ordinary [`RpcResponse`] — the caller writes one frame and
+/// reads one frame, so the refusal has to arrive in the shape it can read. This
+/// is what stops an old client hanging on a method that would otherwise answer
+/// in frames it cannot parse.
+pub const CODE_STREAM_REQUIRED: i64 = -32011;
 
 /// One request frame, as it arrives on the wire.
 ///
@@ -108,6 +130,105 @@ impl RpcResponse {
     }
 }
 
+/// Which of the three things a streaming response frame is (#6286).
+///
+/// Why: one connection carries many frames, so a reader needs to know from the
+/// frame itself whether more are coming. Encoding that as a discriminant rather
+/// than as "a frame with no `result` means the end" keeps a handler free to
+/// stream `null` items.
+/// What: serialises as the lowercase string a `"stream"` field holds.
+/// Test: `stream_frames_carry_the_phase_discriminant`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum StreamPhase {
+    /// One payload; more frames follow.
+    Item,
+    /// The stream completed. Terminal — nothing follows on this connection.
+    End,
+    /// The stream failed. Terminal, and carries the reason.
+    Error,
+}
+
+/// One frame of a streaming response (#6286).
+///
+/// Why: `POST /api/v1/chat` in `trusty-memory` streams LLM tokens, and the
+/// one-frame-per-connection contract [`RpcResponse`] states cannot carry that.
+/// #6287 deferred the multi-frame shape until a daemon had a real cross-crate
+/// consumer; chat is that consumer.
+///
+/// What: the same `jsonrpc` / `id` envelope [`RpcResponse`] carries, plus a
+/// [`StreamPhase`] discriminant that a plain response never has. The wire
+/// contract in full:
+///
+/// - Zero or more `{"jsonrpc":"2.0","id":<id>,"stream":"item","result":<value>}`
+/// - Then EXACTLY ONE terminal frame: `…,"stream":"end"` on success, or
+///   `…,"stream":"error","error":{…}` on failure.
+///
+/// A stream that reaches EOF without a terminal frame is a protocol violation,
+/// not an empty success — the client reports it rather than returning what it
+/// happened to receive. That is the Fail-Open branch this shape exists to close:
+/// a truncated token stream must never read as a complete answer.
+///
+/// `#[non_exhaustive]`: build one through [`RpcStreamFrame::item`],
+/// [`RpcStreamFrame::end`] or [`RpcStreamFrame::error`], so a later envelope
+/// field is not a breaking change.
+///
+/// Test: `stream_frames_carry_the_phase_discriminant`,
+/// `stream_round_trips_many_frames_over_a_real_socket`,
+/// `stream_reports_a_truncated_stream_rather_than_an_empty_success`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct RpcStreamFrame {
+    /// Always [`JSONRPC_VERSION`].
+    pub jsonrpc: String,
+    /// The request's id, echoed on every frame of the stream.
+    pub id: serde_json::Value,
+    /// Which phase this frame is. Absent from a non-streaming [`RpcResponse`],
+    /// which is what lets a reader tell the two apart.
+    pub stream: StreamPhase,
+    /// The payload, on a [`StreamPhase::Item`] frame.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub result: Option<serde_json::Value>,
+    /// The reason, on a [`StreamPhase::Error`] frame.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<RpcError>,
+}
+
+impl RpcStreamFrame {
+    /// One payload frame. More frames follow.
+    pub fn item(id: serde_json::Value, result: serde_json::Value) -> Self {
+        Self {
+            jsonrpc: JSONRPC_VERSION.to_string(),
+            id,
+            stream: StreamPhase::Item,
+            result: Some(result),
+            error: None,
+        }
+    }
+
+    /// The terminal success frame.
+    pub fn end(id: serde_json::Value) -> Self {
+        Self {
+            jsonrpc: JSONRPC_VERSION.to_string(),
+            id,
+            stream: StreamPhase::End,
+            result: None,
+            error: None,
+        }
+    }
+
+    /// The terminal failure frame, carrying `error` verbatim.
+    pub fn error(id: serde_json::Value, error: RpcError) -> Self {
+        Self {
+            jsonrpc: JSONRPC_VERSION.to_string(),
+            id,
+            stream: StreamPhase::Error,
+            result: None,
+            error: Some(error),
+        }
+    }
+}
+
 /// The error half of a response frame, and what a handler returns to refuse.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RpcError {
@@ -148,6 +269,33 @@ impl RpcError {
         Self::new(
             CODE_METHOD_NOT_FOUND,
             format!("unknown method {method:?}; this listener serves {known:?}"),
+        )
+    }
+
+    /// [`CODE_STREAM_UNSUPPORTED`], naming what this server does stream (#6286).
+    ///
+    /// Listing the streaming methods is what makes this refusal actionable: it
+    /// covers both "that name streams nothing" and "that name does not exist",
+    /// and the caller reads which from the list.
+    ///
+    /// Test: `stream_request_for_a_non_streaming_method_is_refused`.
+    pub fn stream_unsupported(method: &str, streaming: &[&str]) -> Self {
+        Self::new(
+            CODE_STREAM_UNSUPPORTED,
+            format!("method {method:?} does not stream; this listener streams {streaming:?}"),
+        )
+    }
+
+    /// [`CODE_STREAM_REQUIRED`] — this method answers only in a stream (#6286).
+    ///
+    /// Test: `unary_request_for_a_streaming_method_is_refused_in_one_frame`.
+    pub fn stream_required(method: &str) -> Self {
+        Self::new(
+            CODE_STREAM_REQUIRED,
+            format!(
+                "method {method:?} answers only as a stream; resend with \"stream\": true \
+                 and read frames until a terminal one"
+            ),
         )
     }
 }

--- a/crates/trusty-common/src/uds/stream_client.rs
+++ b/crates/trusty-common/src/uds/stream_client.rs
@@ -1,0 +1,509 @@
+//! The reading half of a multi-frame UDS response (#6286).
+//!
+//! Why: [`super::send_framed_request`] writes one frame and reads one frame,
+//! which is the whole of what a request/response client needs and none of what a
+//! token stream needs. `trusty-memory`'s chat endpoint pushes LLM tokens as they
+//! arrive, so its client has to see frame N before frame N+1 exists. Putting the
+//! reader here rather than in each consumer keeps ONE definition of what
+//! terminates a stream — the property a truncated-stream bug hides behind.
+//!
+//! What: [`send_framed_stream_request`] dials, writes the request frame, and
+//! hands back a [`FramedStream`]. Each [`FramedStream::next_frame`] yields the
+//! next `"stream":"item"` payload; the stream finishes on the terminal frame the
+//! server always writes. [`FramedStream::into_stream`] adapts the same value
+//! into a `futures_util::Stream` for a consumer that composes.
+//!
+//! **EOF is never success.** A stream that ends without a terminal frame yields
+//! [`UdsRpcError::NoResponse`], not `None`. A half-received answer read as a
+//! complete one is the Fail-Open branch the [`RpcStreamFrame`] contract exists
+//! to close, and it is asserted rather than assumed —
+//! `stream_reports_a_truncated_stream_rather_than_an_empty_success`.
+//!
+//! **A non-streamed answer is reported, not decoded.** A server that answers a
+//! streaming request with an ordinary response frame — the shape a method that
+//! does not stream produces — yields [`UdsRpcError::NotAStream`] carrying that
+//! response, so the caller reads the server's own refusal instead of a decode
+//! failure about a missing field.
+//!
+//! Test: `stream_*` in this file's `tests` module, plus
+//! `crate::uds::server::tests`' `stream_*` against a real server.
+
+use std::marker::PhantomData;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use futures_util::Stream;
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+use tokio::io::{AsyncBufReadExt, AsyncReadExt as _, BufReader};
+use tokio::net::UnixStream;
+
+use super::rpc::{MAX_FRAME_BYTES, UdsRpcError, dial_and_send};
+use super::server::{RpcResponse, RpcStreamFrame, StreamPhase};
+
+/// Dial `path`, ask for a stream, and read the answer frame by frame (#6286).
+///
+/// Why: the streaming counterpart of [`super::send_framed_request`], sharing its
+/// dial, its hardening check and its framing so a streaming consumer is not a
+/// second implementation of the transport.
+///
+/// What: writes `request` as one newline-terminated JSON frame — the caller is
+/// responsible for the `"stream": true` field the server negotiates on; see the
+/// [`server`] module's wire contract — then returns a [`FramedStream`] over the
+/// still-open read half.
+///
+/// **`timeout` is per step, not per stream.** It bounds the dial and the request
+/// write, and then each individual frame read. It deliberately does NOT bound
+/// the stream's total duration: a token stream runs as long as the model does,
+/// and a total budget would cut off a working answer. A caller that wants a
+/// wall-clock ceiling wraps its own consumption loop.
+///
+/// # Errors
+///
+/// [`UdsRpcError::Dial`], [`UdsRpcError::Encode`], [`UdsRpcError::Write`] or
+/// [`UdsRpcError::Timeout`] while opening. Everything after that is reported per
+/// frame, through the stream.
+///
+/// [`server`]: super::server
+///
+/// Test: `stream_round_trips_many_frames_over_a_real_socket`,
+/// `stream_client_reports_a_dial_failure_for_a_missing_socket`.
+pub async fn send_framed_stream_request<Req, T>(
+    path: &Path,
+    request: &Req,
+    timeout: Duration,
+) -> Result<FramedStream<T>, UdsRpcError>
+where
+    Req: Serialize + ?Sized,
+    T: DeserializeOwned,
+{
+    send_framed_stream_request_capped(path, request, timeout, MAX_FRAME_BYTES).await
+}
+
+/// [`send_framed_stream_request`] with an explicit per-frame budget.
+///
+/// Why: the same reason [`super::send_framed_request_capped`] exists — a bulk
+/// payload outgrows [`MAX_FRAME_BYTES`], and the budget is the caller's to
+/// state. It applies to EACH frame of the stream, not to their sum; the server
+/// applies the same figure on its side through
+/// [`super::server::RpcServeOptions::max_frame_bytes`], and the two must match
+/// or one end merely moves which side refuses.
+///
+/// # Errors
+///
+/// The same set as [`send_framed_stream_request`].
+///
+/// Test: `stream_client_honours_a_caller_supplied_frame_budget`.
+pub async fn send_framed_stream_request_capped<Req, T>(
+    path: &Path,
+    request: &Req,
+    timeout: Duration,
+    max_frame_bytes: u64,
+) -> Result<FramedStream<T>, UdsRpcError>
+where
+    Req: Serialize + ?Sized,
+    T: DeserializeOwned,
+{
+    let stream = match tokio::time::timeout(timeout, dial_and_send(path, request)).await {
+        Ok(result) => result?,
+        Err(_) => {
+            return Err(UdsRpcError::Timeout {
+                path: path.to_path_buf(),
+                timeout,
+            });
+        }
+    };
+
+    Ok(FramedStream {
+        reader: BufReader::new(stream),
+        path: path.to_path_buf(),
+        max_frame_bytes,
+        frame_timeout: timeout,
+        finished: false,
+        _item: PhantomData,
+    })
+}
+
+/// The frames of one streaming response, read as they arrive (#6286).
+///
+/// Why: an async iterator rather than a collected `Vec` is the whole point — a
+/// consumer that could wait for the last token would not need a stream.
+/// What: [`next_frame`] yields the next item payload decoded as `T`, `None` once
+/// the terminal frame has been read, and exactly one `Err` for a terminal error,
+/// a protocol violation, or a read failure. After any of those the stream is
+/// finished and every later call returns `None` — an error is reported once, not
+/// on every poll.
+///
+/// [`into_stream`] adapts the same value into a `futures_util::Stream` for a
+/// caller that composes with combinators; the two are the same reader, so use
+/// one or the other.
+///
+/// [`next_frame`]: FramedStream::next_frame
+/// [`into_stream`]: FramedStream::into_stream
+///
+/// Test: `stream_round_trips_many_frames_over_a_real_socket`,
+/// `stream_reports_a_handler_error_as_a_terminal_frame`,
+/// `stream_reports_a_truncated_stream_rather_than_an_empty_success`,
+/// `stream_is_finished_after_it_reports_an_error`.
+pub struct FramedStream<T> {
+    reader: BufReader<UnixStream>,
+    path: PathBuf,
+    max_frame_bytes: u64,
+    frame_timeout: Duration,
+    finished: bool,
+    _item: PhantomData<fn() -> T>,
+}
+
+/// Hand-written rather than derived: `#[derive(Debug)]` would add a spurious
+/// `T: Debug` bound, and `T` is only ever a `PhantomData` marker here.
+impl<T> std::fmt::Debug for FramedStream<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FramedStream")
+            .field("path", &self.path)
+            .field("max_frame_bytes", &self.max_frame_bytes)
+            .field("finished", &self.finished)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<T> FramedStream<T>
+where
+    T: DeserializeOwned,
+{
+    /// The socket this stream is reading from.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Read the next item, or `None` once the stream has ended.
+    ///
+    /// # Errors
+    ///
+    /// [`UdsRpcError::Stream`] for the server's own terminal error;
+    /// [`UdsRpcError::NotAStream`] when the answer was an ordinary response
+    /// frame; [`UdsRpcError::NoResponse`] for EOF without a terminal frame;
+    /// [`UdsRpcError::FrameTooLarge`], [`UdsRpcError::Decode`],
+    /// [`UdsRpcError::Read`] and [`UdsRpcError::Timeout`] per frame.
+    ///
+    /// Test: `stream_round_trips_many_frames_over_a_real_socket`,
+    /// `stream_reports_a_truncated_stream_rather_than_an_empty_success`,
+    /// `stream_client_reports_a_unary_answer_as_not_a_stream`.
+    pub async fn next_frame(&mut self) -> Option<Result<T, UdsRpcError>> {
+        if self.finished {
+            return None;
+        }
+        match self.read_next().await {
+            Ok(Some(item)) => Some(Ok(item)),
+            Ok(None) => {
+                self.finished = true;
+                None
+            }
+            Err(e) => {
+                // One report per failure: a caller looping to exhaustion must
+                // not spin on a socket that will never produce another frame.
+                self.finished = true;
+                Some(Err(e))
+            }
+        }
+    }
+
+    /// Adapt this reader into a `futures_util::Stream`.
+    ///
+    /// Test: `stream_into_stream_yields_the_same_items_as_next_frame`.
+    pub fn into_stream(self) -> impl Stream<Item = Result<T, UdsRpcError>> {
+        futures_util::stream::unfold(self, |mut reader| async move {
+            reader.next_frame().await.map(|item| (item, reader))
+        })
+    }
+
+    /// One frame: `Ok(Some(item))`, `Ok(None)` for a clean end, or the failure.
+    async fn read_next(&mut self) -> Result<Option<T>, UdsRpcError> {
+        let line = match tokio::time::timeout(self.frame_timeout, self.read_line()).await {
+            Ok(result) => result?,
+            Err(_) => {
+                return Err(UdsRpcError::Timeout {
+                    path: self.path.clone(),
+                    timeout: self.frame_timeout,
+                });
+            }
+        };
+
+        let Some(line) = line else {
+            // EOF with no terminal frame. Reporting this as a clean end would
+            // hand the caller a truncated answer as a complete one.
+            return Err(UdsRpcError::NoResponse {
+                path: self.path.clone(),
+            });
+        };
+
+        let frame: RpcStreamFrame = match serde_json::from_slice(&line) {
+            Ok(frame) => frame,
+            Err(source) => return Err(self.classify_non_stream_frame(&line, source)),
+        };
+
+        match frame.stream {
+            StreamPhase::Item => {
+                let payload = frame.result.unwrap_or(serde_json::Value::Null);
+                serde_json::from_value(payload)
+                    .map(Some)
+                    .map_err(|source| UdsRpcError::Decode {
+                        path: self.path.clone(),
+                        source,
+                    })
+            }
+            StreamPhase::End => Ok(None),
+            StreamPhase::Error => Err(UdsRpcError::Stream {
+                path: self.path.clone(),
+                // A terminal error frame without an `error` half is a server
+                // that broke its own contract; saying so beats a silent end.
+                error: frame.error.unwrap_or_else(|| {
+                    super::server::RpcError::internal(
+                        "terminal stream error frame carried no error",
+                    )
+                }),
+            }),
+        }
+    }
+
+    /// A frame that is not an [`RpcStreamFrame`]: say which of the two things it
+    /// was.
+    ///
+    /// An ordinary [`RpcResponse`] here means the method does not stream, and
+    /// the server's own message is worth more to the caller than serde's
+    /// complaint about a missing `stream` field.
+    fn classify_non_stream_frame(&self, line: &[u8], source: serde_json::Error) -> UdsRpcError {
+        match serde_json::from_slice::<RpcResponse>(line) {
+            Ok(response) => UdsRpcError::NotAStream {
+                path: self.path.clone(),
+                response: Box::new(response),
+            },
+            Err(_) => UdsRpcError::Decode {
+                path: self.path.clone(),
+                source,
+            },
+        }
+    }
+
+    /// Read up to and including the next newline, bounded per frame.
+    ///
+    /// `Ok(None)` is EOF with nothing buffered. `take` is re-applied for each
+    /// frame, so the budget is per frame rather than per connection — bytes past
+    /// the limit stay in the `BufReader` for the next call.
+    async fn read_line(&mut self) -> Result<Option<Vec<u8>>, UdsRpcError> {
+        let mut line: Vec<u8> = Vec::new();
+        let mut bounded = (&mut self.reader).take(self.max_frame_bytes);
+        let read = match bounded.read_until(b'\n', &mut line).await {
+            Ok(read) => read,
+            Err(source) => {
+                return Err(super::rpc::classify_read_failure(
+                    &self.path,
+                    source,
+                    line.is_empty(),
+                ));
+            }
+        };
+
+        if read == 0 && line.is_empty() {
+            return Ok(None);
+        }
+        if !line.ends_with(b"\n") && line.len() as u64 >= self.max_frame_bytes {
+            return Err(UdsRpcError::FrameTooLarge {
+                path: self.path.clone(),
+                limit: self.max_frame_bytes,
+            });
+        }
+        Ok(Some(line))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::uds::bind_hardened;
+    use serde_json::json;
+    use tokio::io::AsyncWriteExt as _;
+    use tokio::net::UnixListener;
+
+    /// Bind a hardened socket and answer one connection with `bytes` verbatim,
+    /// then hang up. That is enough to drive every reader arm: the server half
+    /// is exercised end to end in `uds::server::tests`.
+    fn spawn_replaying(dir: &Path, bytes: Vec<u8>) -> PathBuf {
+        let sock = dir.join("sockets").join("stream.sock");
+        let listener: UnixListener = bind_hardened(&sock).expect("bind");
+        tokio::spawn(async move {
+            let Ok((mut conn, _)) = listener.accept().await else {
+                return;
+            };
+            let mut sink = Vec::new();
+            let _ = conn.read_to_end(&mut sink).await;
+            let _ = conn.write_all(&bytes).await;
+            let _ = conn.flush().await;
+        });
+        sock
+    }
+
+    async fn open(sock: &Path) -> FramedStream<String> {
+        send_framed_stream_request(sock, &json!({ "stream": true }), Duration::from_secs(5))
+            .await
+            .expect("open the stream")
+    }
+
+    #[tokio::test]
+    async fn stream_client_reads_items_until_the_terminal_frame() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let sock = spawn_replaying(
+            tmp.path(),
+            b"{\"jsonrpc\":\"2.0\",\"id\":1,\"stream\":\"item\",\"result\":\"Hel\"}\n\
+              {\"jsonrpc\":\"2.0\",\"id\":1,\"stream\":\"item\",\"result\":\"lo\"}\n\
+              {\"jsonrpc\":\"2.0\",\"id\":1,\"stream\":\"end\"}\n"
+                .to_vec(),
+        );
+
+        let mut stream = open(&sock).await;
+        let mut got = Vec::new();
+        while let Some(item) = stream.next_frame().await {
+            got.push(item.expect("no error expected"));
+        }
+
+        assert_eq!(got, vec!["Hel".to_string(), "lo".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn stream_reports_a_truncated_stream_rather_than_an_empty_success() {
+        // The Fail-Open branch this contract exists to close: two tokens then a
+        // hang-up must NOT read as a complete two-token answer.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let sock = spawn_replaying(
+            tmp.path(),
+            b"{\"jsonrpc\":\"2.0\",\"id\":1,\"stream\":\"item\",\"result\":\"Hel\"}\n".to_vec(),
+        );
+
+        let mut stream = open(&sock).await;
+        assert_eq!(
+            stream.next_frame().await.expect("an item").expect("ok"),
+            "Hel"
+        );
+
+        let err = stream
+            .next_frame()
+            .await
+            .expect("a truncated stream must report, not end")
+            .expect_err("EOF without a terminal frame is not a success");
+        assert!(
+            matches!(err, UdsRpcError::NoResponse { .. }),
+            "expected NoResponse, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn stream_is_finished_after_it_reports_an_error() {
+        // A caller looping to exhaustion must not spin on a dead socket.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let sock = spawn_replaying(tmp.path(), Vec::new());
+
+        let mut stream = open(&sock).await;
+        assert!(
+            stream.next_frame().await.expect("a report").is_err(),
+            "an empty answer is a protocol violation"
+        );
+        assert!(
+            stream.next_frame().await.is_none(),
+            "the failure is reported once, then the stream is done"
+        );
+    }
+
+    #[tokio::test]
+    async fn stream_client_reports_a_unary_answer_as_not_a_stream() {
+        // A method that does not stream answers in the unary shape. The caller
+        // must read the server's own refusal, not a serde complaint.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let sock = spawn_replaying(
+            tmp.path(),
+            b"{\"jsonrpc\":\"2.0\",\"id\":1,\"error\":{\"code\":-32010,\"message\":\"no\"}}\n"
+                .to_vec(),
+        );
+
+        let mut stream = open(&sock).await;
+        let err = stream
+            .next_frame()
+            .await
+            .expect("a report")
+            .expect_err("a unary frame is not a stream item");
+
+        match err {
+            UdsRpcError::NotAStream { response, .. } => {
+                assert_eq!(response.error.expect("an error").code, -32010);
+            }
+            other => panic!("expected NotAStream, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn stream_client_honours_a_caller_supplied_frame_budget() {
+        // The budget is per frame, and it is the caller's figure — a `capped`
+        // call that silently used MAX_FRAME_BYTES would look identical on the
+        // happy path and fail only on a big frame in production.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let sock = spawn_replaying(tmp.path(), vec![b'x'; 4096]);
+
+        let mut stream: FramedStream<String> = send_framed_stream_request_capped(
+            &sock,
+            &json!({ "stream": true }),
+            Duration::from_secs(5),
+            1024,
+        )
+        .await
+        .expect("open");
+
+        let err = stream
+            .next_frame()
+            .await
+            .expect("a report")
+            .expect_err("an unterminated flood past the budget must be refused");
+        assert!(
+            matches!(err, UdsRpcError::FrameTooLarge { limit, .. } if limit == 1024),
+            "expected FrameTooLarge at 1024, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn stream_into_stream_yields_the_same_items_as_next_frame() {
+        use futures_util::StreamExt as _;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let sock = spawn_replaying(
+            tmp.path(),
+            b"{\"jsonrpc\":\"2.0\",\"id\":1,\"stream\":\"item\",\"result\":\"a\"}\n\
+              {\"jsonrpc\":\"2.0\",\"id\":1,\"stream\":\"end\"}\n"
+                .to_vec(),
+        );
+
+        let items: Vec<String> = open(&sock)
+            .await
+            .into_stream()
+            .map(|item| item.expect("ok"))
+            .collect()
+            .await;
+
+        assert_eq!(items, vec!["a".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn stream_client_reports_a_dial_failure_for_a_missing_socket() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let sock = tmp.path().join("sockets").join("absent.sock");
+
+        let err = send_framed_stream_request::<_, String>(
+            &sock,
+            &json!({ "stream": true }),
+            Duration::from_secs(5),
+        )
+        .await
+        .expect_err("no listener means no stream");
+
+        assert!(
+            matches!(err, UdsRpcError::Dial { .. }),
+            "expected Dial, got {err:?}"
+        );
+    }
+}


### PR DESCRIPTION
Slice 2 of the trusty-memory UDS migration (Refs #6286; owner ruling: https://github.com/bobmatnyc/trusty-tools/issues/6286#issuecomment-5424905060 — chat keeps token streaming, so the extension #6287 deferred lands now).

Adds opt-in multi-frame streaming to `trusty_common::uds`: a `"stream": true` request flag, `RpcRouter::typed_stream` server methods, `send_framed_stream_request` client. Streams terminate on an explicit terminal frame — never EOF — so truncation reports as an error; mismatched unary/stream calls fail in one frame with dedicated codes. Absent flag = wire protocol unchanged byte for byte. trusty-common 0.44.1 → 0.44.2.

Test ladder rung 4 (shared library): `cargo test -p trusty-common --features uds` (462 passed, 0 failed; 21 new streaming tests incl. mid-stream disconnect, interleaved unary traffic, truncated-stream detection), `cargo clippy --features uds --all-targets -- -D warnings`, `cargo check --workspace`, `cargo fmt --check`, `scripts/check_test_pointers.sh`, `scripts/check_line_cap.sh`, `scripts/check_sld.sh`, `scripts/check_semver.sh --crate trusty-common` (196 pass — no semver update required).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools