### PR TITLE
fix(trusty-search): swap resolution restores a truthful hnsw_path/is_view on the live store (Refs #6299)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11831,7 +11831,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-search"
-version = "0.49.2"
+version = "0.49.3"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -9,7 +9,11 @@ name = "trusty-search"
 # forbids moving or deleting a pushed tag — so 0.49.0/its tag are a burned,
 # never-published marker and this release ships as 0.49.1 instead. No src
 # change beyond this version bump.
-version = "0.49.2"
+# 0.49.3 (#6299): staged HNSW swap resolution repairs the live store's
+# hnsw_path/is_view; promote self-heals from the mapping when the recorded
+# snapshot is gone. Patch position per Cargo's 0.x rule — the public API gains
+# one defaulted `VectorStore` method and one new enum, nothing breaking.
+version = "0.49.3"
 edition = "2021"
 description = "Machine-wide hybrid code search service: BM25 + vector + KG, zero cold-start, MCP server"
 readme = "README.md"

--- a/crates/trusty-search/changelog.d/6299-hnsw-swap-reset.md
+++ b/crates/trusty-search/changelog.d/6299-hnsw-swap-reset.md
@@ -1,0 +1,13 @@
+Fixed
+- A reindex could leave an index unable to accept any further vector write for
+  the life of the daemon. Each reindex checkpoint saved to a staging file and
+  recorded it as the store's snapshot source; an idle or memory-pressure
+  demotion then re-viewed the store from that file; resolving the swap renamed
+  or deleted it without telling the store, so every later write failed
+  `usearch failed to promote view → mutable load: No such file or directory`,
+  and a failed promote never clears `is_view`, so the store could not heal
+  itself. Committing the swap now re-points the store at the live path, and
+  aborting it restores the store from the live snapshot. As a backstop for a
+  recorded snapshot that vanishes for any other reason, promoting a view whose
+  file can no longer be read rebuilds the graph from the mapping still held in
+  memory instead of failing forever (#6299).

--- a/crates/trusty-search/src/core/indexer/persist_hnsw.rs
+++ b/crates/trusty-search/src/core/indexer/persist_hnsw.rs
@@ -47,6 +47,32 @@ impl CodeIndexer {
         Ok(true)
     }
 
+    /// Tell the wired vector store how a reindex's staged→live HNSW swap
+    /// resolved, so it can repair a snapshot path the swap moved or deleted
+    /// (issue #6299).
+    ///
+    /// Why: `service::reindex::hnsw_swap` renames or deletes the staging file
+    /// the store's periodic checkpoints were written to, and the store has no
+    /// other way to learn that the path it recorded is gone. Without this the
+    /// store keeps that dangling path, and every write after it fails
+    /// `No such file or directory` for the life of the daemon.
+    /// What: forwards to [`crate::core::store::VectorStore::resolve_staged_snapshot`],
+    /// which owns the repair. Returns `Ok(false)` when no store is wired
+    /// (BM25-only index) so the caller can chain without checking.
+    /// Test: `service::reindex::hnsw_swap_tests::write_after_commit_swap_succeeds_when_store_was_demoted_to_staging_view`.
+    pub async fn resolve_staged_hnsw_swap(
+        &self,
+        staged: &std::path::Path,
+        live: &std::path::Path,
+        outcome: crate::core::store::StagedSwapOutcome,
+    ) -> Result<bool> {
+        let Some(store) = &self.store else {
+            return Ok(false);
+        };
+        store.resolve_staged_snapshot(staged, live, outcome).await?;
+        Ok(true)
+    }
+
     /// Rewrite the HNSW key map from absolute to root-relative chunk IDs, and
     /// flush the updated sidecar to disk atomically.
     ///

--- a/crates/trusty-search/src/core/store/mod.rs
+++ b/crates/trusty-search/src/core/store/mod.rs
@@ -23,5 +23,5 @@ mod usearch_impl;
 mod usearch_recover;
 mod usearch_store;
 
-pub use self::types::{VectorHit, VectorStore};
+pub use self::types::{StagedSwapOutcome, VectorHit, VectorStore};
 pub use self::usearch_store::UsearchStore;

--- a/crates/trusty-search/src/core/store/tests.rs
+++ b/crates/trusty-search/src/core/store/tests.rs
@@ -9,7 +9,7 @@
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
-use super::types::VectorStore;
+use super::types::{StagedSwapOutcome, VectorStore};
 use super::usearch_store::{staging_path, UsearchStore, POPULATED_SNAPSHOT_THRESHOLD_BYTES};
 
 /// Why (#4395's second defect): both writers used the same deterministic
@@ -1368,5 +1368,163 @@ async fn test_adopt_declines_on_dim_mismatch() {
         empty.len().await.unwrap(),
         0,
         "a dim-mismatched snapshot must never be adopted"
+    );
+}
+
+/// Why (issue #6299): a reindex checkpoint retargets the store at the staging
+/// file, and committing the swap renames that file onto the live path. Unless
+/// the store is told, it keeps naming a path that no longer exists.
+/// What: saves to a staging path, renames it onto live the way
+/// `commit_staged_hnsw_swap` does, resolves the swap, and asserts the store now
+/// names `live` and still accepts a write.
+/// Test: this IS the test.
+#[tokio::test]
+async fn test_resolve_staged_snapshot_commit_repoints_to_live() {
+    let dir = tempfile::tempdir().unwrap();
+    let live = dir.path().join("hnsw.usearch");
+    let staging = dir.path().join("hnsw.reindex-staging.usearch");
+
+    let store = UsearchStore::new(4).unwrap();
+    store.upsert("a", vec![1.0, 0.0, 0.0, 0.0]).await.unwrap();
+    store.save(&staging).await.unwrap();
+    assert!(
+        store.demote_to_view().await.unwrap(),
+        "demote to staging view"
+    );
+
+    std::fs::rename(
+        staging.with_extension("keys.json"),
+        live.with_extension("keys.json"),
+    )
+    .unwrap();
+    std::fs::rename(&staging, &live).unwrap();
+
+    store
+        .resolve_staged_snapshot(&staging, &live, StagedSwapOutcome::Committed)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        store.hnsw_path.read().await.as_deref(),
+        Some(live.as_path()),
+        "commit must re-point the store at the live path"
+    );
+    store
+        .upsert("b", vec![0.0, 1.0, 0.0, 0.0])
+        .await
+        .expect("a write after a committed swap must not fail ENOENT");
+    assert_eq!(store.len().await.unwrap(), 2);
+}
+
+/// Why (issue #6299): aborting deletes the staging file, so a store that
+/// recorded it holds a dangling path AND a graph the rolled-back corpus no
+/// longer matches. The live snapshot is authoritative again.
+/// What: seeds a live snapshot, advances the store past it into staging,
+/// deletes staging the way `abort_staged_hnsw_swap` does, and asserts the store
+/// falls back to the live snapshot and stays writable.
+/// Test: this IS the test.
+#[tokio::test]
+async fn test_resolve_staged_snapshot_abort_restores_live_snapshot() {
+    let dir = tempfile::tempdir().unwrap();
+    let live = dir.path().join("hnsw.usearch");
+    let staging = dir.path().join("hnsw.reindex-staging.usearch");
+
+    let store = UsearchStore::new(4).unwrap();
+    store.upsert("a", vec![1.0, 0.0, 0.0, 0.0]).await.unwrap();
+    store.save(&live).await.unwrap();
+    store.upsert("b", vec![0.0, 1.0, 0.0, 0.0]).await.unwrap();
+    store.save(&staging).await.unwrap();
+    assert!(
+        store.demote_to_view().await.unwrap(),
+        "demote to staging view"
+    );
+
+    std::fs::remove_file(&staging).unwrap();
+    std::fs::remove_file(staging.with_extension("keys.json")).unwrap();
+
+    store
+        .resolve_staged_snapshot(&staging, &live, StagedSwapOutcome::Aborted)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        store.len().await.unwrap(),
+        1,
+        "abort must roll the store back to the live snapshot"
+    );
+    store
+        .upsert("c", vec![0.0, 0.0, 1.0, 0.0])
+        .await
+        .expect("a write after an aborted swap must not fail ENOENT");
+    assert_eq!(store.len().await.unwrap(), 2);
+}
+
+/// Why (issue #6299): a store still pointing at its own live snapshot was
+/// never affected by the swap. Re-pointing it anyway would be the lie the
+/// repair exists to remove.
+/// What: records an unrelated path, resolves a swap, asserts nothing moved.
+/// Test: this IS the test.
+#[tokio::test]
+async fn test_resolve_staged_snapshot_leaves_unrelated_path_alone() {
+    let dir = tempfile::tempdir().unwrap();
+    let live = dir.path().join("hnsw.usearch");
+    let staging = dir.path().join("hnsw.reindex-staging.usearch");
+    let other = dir.path().join("someone-elses.usearch");
+
+    let store = UsearchStore::new(4).unwrap();
+    store.upsert("a", vec![1.0, 0.0, 0.0, 0.0]).await.unwrap();
+    store.save(&other).await.unwrap();
+
+    store
+        .resolve_staged_snapshot(&staging, &live, StagedSwapOutcome::Committed)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        store.hnsw_path.read().await.as_deref(),
+        Some(other.as_path()),
+        "a store that never recorded the staging path must be left alone"
+    );
+}
+
+/// Why (issue #6299): the recorded snapshot can vanish for reasons this crate
+/// does not control (an operator deleting it, a future stager). A failed
+/// promote never clears `is_view`, so without a fallback the store could never
+/// heal itself and every write failed forever.
+/// What: views a snapshot, deletes the file out from under it, then writes —
+/// the promote must rebuild the graph from the mapping it still holds, keeping
+/// every vector searchable.
+/// Test: this IS the test.
+#[tokio::test]
+async fn test_promote_rebuilds_from_view_when_snapshot_vanished() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("hnsw.usearch");
+
+    let seed = UsearchStore::new(4).unwrap();
+    seed.upsert("a", vec![1.0, 0.0, 0.0, 0.0]).await.unwrap();
+    seed.upsert("b", vec![0.0, 1.0, 0.0, 0.0]).await.unwrap();
+    seed.save(&path).await.unwrap();
+    drop(seed);
+
+    let store = UsearchStore::load_from(&path).await.unwrap().expect("some");
+    assert!(store.in_view_mode(), "load_from serves from the mmap view");
+
+    std::fs::remove_file(&path).unwrap();
+
+    store
+        .upsert("c", vec![0.0, 0.0, 1.0, 0.0])
+        .await
+        .expect("a write must self-heal rather than fail ENOENT forever");
+    assert!(
+        !store.in_view_mode(),
+        "the rebuild leaves the store mutable"
+    );
+    assert_eq!(store.len().await.unwrap(), 3, "no vector may be lost");
+
+    let hits = store.search(&[1.0, 0.0, 0.0, 0.0], 1).await.unwrap();
+    assert_eq!(
+        hits.first().map(|h| h.chunk_id.as_str()),
+        Some("a"),
+        "the rebuilt graph must still answer the seeded vectors"
     );
 }

--- a/crates/trusty-search/src/core/store/types.rs
+++ b/crates/trusty-search/src/core/store/types.rs
@@ -39,6 +39,28 @@ pub struct VectorHit {
     pub score: f32,
 }
 
+/// How a staged→live HNSW snapshot swap resolved (issue #6299).
+///
+/// Why: during a reindex every periodic checkpoint is written to a staging
+/// file, and `UsearchStore::save` records the file it wrote as the store's
+/// snapshot source. Resolving the swap makes that file vanish under the
+/// store — renamed onto the live path, or deleted — so the store must be told
+/// which of the two happened before it next tries to open the path it
+/// recorded. The two outcomes need different repairs: after a commit the
+/// bytes still exist under the live name, after an abort they are gone and
+/// the live snapshot is the pre-reindex one.
+/// What: the discriminator passed to [`VectorStore::resolve_staged_snapshot`].
+/// Test: `service::reindex::hnsw_swap_tests::write_after_commit_swap_succeeds_when_store_was_demoted_to_staging_view`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StagedSwapOutcome {
+    /// The staging file was renamed over the live path; the bytes the store
+    /// may still be mapping are now the live snapshot.
+    Committed,
+    /// The staging file was deleted; the live snapshot is whatever it was
+    /// before the reindex started.
+    Aborted,
+}
+
 /// Abstract vector store interface. Concrete impls (in-process HNSW today,
 /// possibly remote tomorrow) plug in here so the rest of the indexer never
 /// imports `usearch` directly.
@@ -172,6 +194,33 @@ pub trait VectorStore: Send + Sync {
     /// in `store::tests`.
     async fn demote_to_view(&self) -> Result<bool> {
         Ok(false)
+    }
+
+    /// Re-point a store that recorded `staged` as its snapshot source at
+    /// `live`, once a staged→live swap has resolved (issue #6299).
+    ///
+    /// Why: `UsearchStore::save` records the path it wrote, so every reindex
+    /// checkpoint retargets the store at the staging file; an idle or
+    /// memory-pressure demotion then re-views the store FROM that staging
+    /// file. `service::reindex::hnsw_swap` renames or deletes it moments
+    /// later, leaving the store holding a path that no longer exists — and
+    /// the next write's `promote_view_to_mutable` failed `No such file or
+    /// directory` on every attempt, permanently, because a failed promote
+    /// never clears `is_view`. Three production indexes wedged this way.
+    /// Telling the store how the swap resolved is what keeps `hnsw_path` and
+    /// `is_view` truthful across it.
+    /// What: default = no-op (mock / BM25-only stores record no path).
+    /// `UsearchStore` overrides: a store that recorded some OTHER path is
+    /// left alone; one that recorded `staged` is re-pointed at `live` after a
+    /// commit, and restored from the live snapshot after an abort.
+    /// Test: `UsearchStore` — `store::tests::test_resolve_staged_snapshot_*`.
+    async fn resolve_staged_snapshot(
+        &self,
+        _staged: &Path,
+        _live: &Path,
+        _outcome: StagedSwapOutcome,
+    ) -> Result<()> {
+        Ok(())
     }
 
     /// Returns `true` when `id` already has a stored vector.

--- a/crates/trusty-search/src/core/store/usearch_impl.rs
+++ b/crates/trusty-search/src/core/store/usearch_impl.rs
@@ -13,6 +13,7 @@ use std::sync::atomic::Ordering;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 
+use super::types::StagedSwapOutcome;
 use super::types::VectorHit;
 use super::types::VectorStore;
 use super::usearch_store::{hnsw_max_elements, validate_embedding, UsearchStore};
@@ -537,5 +538,18 @@ impl VectorStore for UsearchStore {
     /// [`UsearchStore::try_demote_to_view`] (issue #2164).
     async fn demote_to_view(&self) -> Result<bool> {
         self.try_demote_to_view().await
+    }
+
+    /// Issue #6299: keep `hnsw_path` / `is_view` truthful across a reindex's
+    /// staged→live HNSW swap. See
+    /// [`UsearchStore::resolve_staged_snapshot_inner`] for the mechanics.
+    async fn resolve_staged_snapshot(
+        &self,
+        staged: &Path,
+        live: &Path,
+        outcome: StagedSwapOutcome,
+    ) -> Result<()> {
+        self.resolve_staged_snapshot_inner(staged, live, outcome)
+            .await
     }
 }

--- a/crates/trusty-search/src/core/store/usearch_recover.rs
+++ b/crates/trusty-search/src/core/store/usearch_recover.rs
@@ -15,13 +15,22 @@
 //! Test: `super::tests::test_save_refusal_adopts_populated_snapshot`,
 //! `super::tests::test_adopt_declines_when_snapshot_is_unrecoverable`,
 //! `super::tests::test_adopt_declines_on_dim_mismatch`.
+//!
+//! Issue #6299 added a second recovery to the same file, for the opposite
+//! failure: the snapshot the store recorded is not merely stale, it is GONE.
+//! [`UsearchStore::resolve_staged_snapshot_inner`] repairs the store when a
+//! reindex's staged→live swap renames or deletes the file underneath it, and
+//! [`UsearchStore::rebuild_mutable_from_view`] is the last-resort promote
+//! fallback for a recorded path that has vanished for any other reason.
 
 use std::path::Path;
 use std::sync::atomic::Ordering;
 
 use anyhow::{anyhow, Result};
+use usearch::Index;
 
 use super::super::store_config::MmapServeMode;
+use super::types::StagedSwapOutcome;
 use super::usearch_store::UsearchStore;
 
 /// Outcome of the guarded write inside [`UsearchStore::save`].
@@ -152,5 +161,151 @@ impl UsearchStore {
             hnsw_path.display(),
         );
         Ok(true)
+    }
+
+    /// Repair this store's `hnsw_path` / `is_view` after a reindex's staged
+    /// HNSW swap resolved (issue #6299).
+    ///
+    /// Why: see [`super::types::VectorStore::resolve_staged_snapshot`]. A
+    /// store whose recorded path was renamed or deleted under it fails every
+    /// subsequent write with `No such file or directory`, forever.
+    ///
+    /// What: does nothing unless the store actually recorded `staged` — a
+    /// store still pointing at its live snapshot was never affected by the
+    /// swap, and re-pointing it would be the lie this method exists to
+    /// remove. When it did record `staged`:
+    /// - [`StagedSwapOutcome::Committed`]: the staging file was renamed onto
+    ///   `live`, so the bytes are unchanged and only the name moved. Record
+    ///   `live`. Any mmap the store holds is of that same inode and stays
+    ///   valid, and a later promote or demote now names a file that exists.
+    /// - [`StagedSwapOutcome::Aborted`]: the staging file was deleted and the
+    ///   reindex's state is discarded (the redb corpus rolls back in the same
+    ///   step — `finish_teardown::resolve_hnsw_swap` shares one
+    ///   `StagingResolution` with `resolve_corpus_swap`), so the pre-reindex
+    ///   live snapshot is authoritative again. Adopt it through
+    ///   [`Self::adopt_on_disk_snapshot`], which re-validates it through every
+    ///   ordinary load guard. When there is no adoptable live snapshot — a
+    ///   first-ever reindex that aborted before one existed — keep the
+    ///   in-memory graph, record `live` as where a future save belongs, and
+    ///   mark the store dirty so the idle sweep never re-views a file that
+    ///   does not match what is in memory.
+    ///
+    /// Test: `super::tests::test_resolve_staged_snapshot_commit_repoints_to_live`,
+    /// `super::tests::test_resolve_staged_snapshot_abort_restores_live_snapshot`,
+    /// `super::tests::test_resolve_staged_snapshot_leaves_unrelated_path_alone`.
+    pub(super) async fn resolve_staged_snapshot_inner(
+        &self,
+        staged: &Path,
+        live: &Path,
+        outcome: StagedSwapOutcome,
+    ) -> Result<()> {
+        let recorded_staged = {
+            let guard = self.hnsw_path.read().await;
+            guard.as_deref() == Some(staged)
+        };
+        if !recorded_staged {
+            return Ok(());
+        }
+
+        if outcome == StagedSwapOutcome::Committed {
+            *self.hnsw_path.write().await = Some(live.to_path_buf());
+            tracing::info!(
+                "usearch: re-pointed store from the committed staging snapshot {} to {} \
+                 (issue #6299)",
+                staged.display(),
+                live.display(),
+            );
+            return Ok(());
+        }
+
+        let adopted = match self.adopt_on_disk_snapshot(live).await {
+            Ok(adopted) => adopted,
+            Err(e) => {
+                tracing::warn!(
+                    "usearch: could not adopt the live snapshot {} after an aborted reindex \
+                     ({e}) — keeping the in-memory graph (issue #6299)",
+                    live.display(),
+                );
+                false
+            }
+        };
+        if !adopted {
+            *self.hnsw_path.write().await = Some(live.to_path_buf());
+            // Nothing on disk matches the in-memory graph: the idle sweep must
+            // not re-view `live` (it would silently roll the graph back), and a
+            // future save has somewhere truthful to write.
+            self.dirty.store(true, Ordering::Release);
+            tracing::warn!(
+                "usearch: aborted reindex deleted the staging snapshot {} and no live snapshot \
+                 at {} could be adopted — keeping the in-memory graph, marked dirty \
+                 (issue #6299)",
+                staged.display(),
+                live.display(),
+            );
+        }
+        Ok(())
+    }
+
+    /// Last-resort promote fallback: rebuild a mutable heap graph out of the
+    /// mmap view this store is already holding (issue #6299).
+    ///
+    /// Why: [`UsearchStore::promote_view_to_mutable`] re-reads the recorded
+    /// snapshot with `Index::load`, so a recorded path that no longer exists
+    /// made every write fail permanently — a failed promote leaves `is_view`
+    /// set, so the store could never heal itself. The vectors themselves are
+    /// not lost when that happens: a mapping outlives the unlink or rename of
+    /// the file it was made from, so the graph is still readable in memory
+    /// even though no path names it any more. Rebuilding from what is mapped
+    /// turns a permanent wedge into a self-heal that costs one serialize plus
+    /// one deserialize.
+    ///
+    /// What: serializes the mapped index into a heap buffer
+    /// (`serialized_length` + `save_to_buffer`) and deserializes it back into
+    /// the same handle with `load_from_buffer`, which — unlike
+    /// `view_from_buffer` — copies into owned memory, so the graph survives
+    /// the buffer being dropped. Called with the caller's `index` write guard
+    /// already held; it does not touch `is_view` / `dirty`, which the caller
+    /// sets. Returns the original load error alongside its own on failure, so
+    /// the log names both the vanished path and why the fallback could not
+    /// stand in for it.
+    ///
+    /// Test: `super::tests::test_promote_rebuilds_from_view_when_snapshot_vanished`.
+    pub(super) fn rebuild_mutable_from_view(
+        &self,
+        index: &Index,
+        source: &Path,
+        load_err: &str,
+    ) -> Result<()> {
+        let vectors = index.size();
+        let mut buffer = vec![0u8; index.serialized_length()];
+        index.save_to_buffer(&mut buffer).map_err(|e| {
+            anyhow!(
+                "usearch failed to promote view → mutable load: {load_err}; and the mapped \
+                 snapshot {} could not be serialized for an in-memory rebuild either: {e} \
+                 (issue #6299)",
+                source.display(),
+            )
+        })?;
+        index.load_from_buffer(&buffer).map_err(|e| {
+            anyhow!(
+                "usearch failed to promote view → mutable load: {load_err}; and the in-memory \
+                 rebuild of {} could not be deserialized: {e} (issue #6299)",
+                source.display(),
+            )
+        })?;
+        let size = index.size();
+        if index.capacity() < size {
+            index
+                .reserve(size.max(1))
+                .map_err(|e| anyhow!("usearch reserve after in-memory rebuild failed: {e}"))?;
+        }
+        tracing::error!(
+            "usearch: snapshot {} could not be re-read to promote this index ({load_err}) — \
+             rebuilt {vectors} vector(s) from the mapping still held in memory so writes \
+             proceed instead of failing forever (issue #6299). The next save re-creates the \
+             snapshot.",
+            source.display(),
+        );
+        Ok(())
     }
 }

--- a/crates/trusty-search/src/core/store/usearch_store.rs
+++ b/crates/trusty-search/src/core/store/usearch_store.rs
@@ -935,8 +935,13 @@ impl UsearchStore {
     /// What: relaxed-load `is_view` (fast path); when set, take the HNSW write
     /// lock, `Index::load`, reserve to the restored size, clear `is_view`. The
     /// flag is double-checked under the write lock so racing writers promote at
-    /// most once. Returns `Err` if the file is unreadable or the path is unknown.
-    /// Test: `tests::test_view_promotes_to_mutable_on_write`.
+    /// most once. When the recorded file can no longer be read, the promote
+    /// falls back to rebuilding the graph from the mapping already held in
+    /// memory (issue #6299 — see [`Self::rebuild_mutable_from_view`]); it
+    /// returns `Err` only when that fallback also fails, or when no source
+    /// path was ever recorded.
+    /// Test: `tests::test_view_promotes_to_mutable_on_write`,
+    /// `tests::test_promote_rebuilds_from_view_when_snapshot_vanished`.
     pub(super) async fn ensure_mutable(&self) -> Result<()> {
         // Fast path — fresh / already-promoted store. Acquire pairs with the
         // `Release` stores in `load_from` / `promote_view_to_mutable`.
@@ -966,9 +971,17 @@ impl UsearchStore {
         if !self.is_view.load(Ordering::Acquire) {
             return Ok(());
         }
-        index
-            .load(&path_str)
-            .map_err(|e| anyhow!("usearch failed to promote view → mutable load: {e}"))?;
+        if let Err(e) = index.load(&path_str) {
+            // #6299: the recorded snapshot is gone — a staged→live swap
+            // renamed or deleted it, or something outside the daemon removed
+            // it. Rebuild from the mapping we still hold rather than failing
+            // this and every future write forever.
+            self.rebuild_mutable_from_view(&index, &path, &e.to_string())?;
+            self.is_view.store(false, Ordering::Release);
+            // Nothing on disk matches the rebuilt graph until the next save.
+            self.dirty.store(true, Ordering::Release);
+            return Ok(());
+        }
         let size = index.size();
         if index.capacity() < size {
             index

--- a/crates/trusty-search/src/service/reindex/hnsw_swap.rs
+++ b/crates/trusty-search/src/service/reindex/hnsw_swap.rs
@@ -51,9 +51,20 @@
 //!    periodic-persist task that outlived the reindex's batch loop could
 //!    still observe the flag flip and write partial state straight to live.
 //!
+//! Issue #6299 — resolving the swap must also repair the LIVE STORE, not just
+//! the files. Each checkpoint save records the staging file as the store's
+//! snapshot source (`UsearchStore::save`), and an idle or memory-pressure
+//! demotion can re-view the store from it; renaming or deleting that file
+//! without telling the store left it holding a path that no longer exists, so
+//! `promote_view_to_mutable` failed `No such file or directory` on every
+//! later write — permanently, because a failed promote never clears
+//! `is_view`. Both resolutions now call [`resolve_store_snapshot_path`] once
+//! the on-disk side has settled.
+//!
 //! Test: `tests` submodule below.
 
 use crate::core::registry::{IndexHandle, IndexId};
+use crate::core::store::StagedSwapOutcome;
 use std::path::{Path, PathBuf};
 
 /// The (live, staging) HNSW snapshot path pair for one index.
@@ -302,6 +313,12 @@ pub(super) async fn commit_staged_hnsw_swap(
                 paths.live.display(),
                 index_id_for_task
             );
+            // #6299: the staging file the live store recorded (and may be
+            // mmap-viewing) now only exists under the live name. Only on a
+            // SUCCESSFUL rename — a failed one leaves staging in place, and
+            // re-pointing at `live` would then name a stale snapshot.
+            resolve_store_snapshot_path(handle, index_id, paths, StagedSwapOutcome::Committed)
+                .await;
         }
         Ok(Err(e)) => tracing::warn!(
             "staged hnsw swap: rename failed for '{}' ({e}) — live snapshot left at its \
@@ -388,7 +405,11 @@ pub(super) async fn abort_staged_hnsw_swap(
     })
     .await;
     match removed {
-        Ok(Ok(())) => {}
+        // #6299: the staging file the live store recorded (and may be
+        // mmap-viewing) is gone; the live snapshot is authoritative again.
+        Ok(Ok(())) => {
+            resolve_store_snapshot_path(handle, index_id, paths, StagedSwapOutcome::Aborted).await;
+        }
         Ok(Err(e)) => tracing::warn!(
             "staged hnsw swap: could not delete staging hnsw snapshot for '{}': {e} — will be \
              overwritten by the next reindex attempt",
@@ -403,6 +424,45 @@ pub(super) async fn abort_staged_hnsw_swap(
     // Round-2 CRITICAL 2: only clear the flag once staging cleanup has fully
     // resolved — never before.
     handle.indexer.read().await.end_reindex_staging();
+}
+
+/// Tell the live vector store how the swap resolved, so a store that recorded
+/// (or is mmap-viewing) the staging file stops naming a path that no longer
+/// exists (issue #6299).
+///
+/// Why: every periodic checkpoint during a reindex writes to the staging file,
+/// and `UsearchStore::save` records the file it wrote as the store's snapshot
+/// source; an idle or memory-pressure demotion then re-views the store FROM
+/// that file. Resolving the swap makes it vanish, and until this call the live
+/// store was never told — so the next write's `promote_view_to_mutable` failed
+/// `No such file or directory` on every attempt for the life of the daemon.
+/// Three production indexes wedged that way.
+/// What: forwards to `CodeIndexer::resolve_staged_hnsw_swap` under the same
+/// read lock the rest of this module uses. Best-effort: a failure here is
+/// logged, never propagated — the swap itself has already resolved on disk.
+/// Test: `tests::write_after_commit_swap_succeeds_when_store_was_demoted_to_staging_view`,
+/// `tests::write_after_abort_swap_succeeds_when_store_was_demoted_to_staging_view`.
+async fn resolve_store_snapshot_path(
+    handle: &IndexHandle,
+    index_id: &IndexId,
+    paths: &HnswSwapPaths,
+    outcome: StagedSwapOutcome,
+) {
+    let resolved = handle
+        .indexer
+        .read()
+        .await
+        .resolve_staged_hnsw_swap(&paths.staging, &paths.live, outcome)
+        .await;
+    if let Err(e) = resolved {
+        tracing::warn!(
+            "staged hnsw swap: could not repair the live store's snapshot path for '{}' after \
+             a {:?} swap ({e}) — a later write may have to rebuild the graph in memory \
+             (issue #6299)",
+            index_id.0,
+            outcome,
+        );
+    }
 }
 
 /// Remove `path` if present, treating `NotFound` as success.

--- a/crates/trusty-search/src/service/reindex/hnsw_swap_tests.rs
+++ b/crates/trusty-search/src/service/reindex/hnsw_swap_tests.rs
@@ -554,6 +554,155 @@ async fn commit_staged_hnsw_swap_renames_sidecar_before_binary() {
     unsafe { std::env::remove_var("TRUSTY_DATA_DIR") };
 }
 
+/// Drive one index through the exact production sequence that wedged three
+/// live indexes (issue #6299): a checkpoint save redirects the store at the
+/// staging file, an idle/memory-pressure demotion re-views the store FROM that
+/// file, and then the swap resolves and the file stops existing under that
+/// name. Returns the store and the resolved paths so each caller can assert on
+/// what a write does next.
+async fn store_demoted_onto_staging(
+    id_str: &str,
+    root: &std::path::Path,
+    seed_live: bool,
+) -> (
+    std::sync::Arc<UsearchStore>,
+    IndexId,
+    IndexHandle,
+    HnswSwapPaths,
+) {
+    let store = std::sync::Arc::new(store_with_vectors(20).await);
+    let id = IndexId::new(id_str.to_string());
+    let mut indexer = CodeIndexer::new(id.0.clone(), root);
+    indexer.set_store(store.clone());
+    let handle = IndexHandle::bare(
+        id.clone(),
+        std::sync::Arc::new(tokio::sync::RwLock::new(indexer)),
+        root.to_path_buf(),
+    );
+
+    let paths = begin_staged_hnsw_swap(&handle, &id)
+        .await
+        .expect("resolves");
+    if seed_live {
+        // A complete pre-reindex snapshot, as any already-indexed project has.
+        store.save(&paths.live).await.expect("seed live");
+    }
+    // A periodic reindex checkpoint: `spawn_incremental_persist` writes to
+    // staging, and `UsearchStore::save` records staging as the store's source.
+    store.save(&paths.staging).await.expect("checkpoint save");
+    assert!(
+        store.demote_to_view().await.expect("demote"),
+        "the idle/pressure sweep demotes a clean, promoted store to a view of \
+         whatever path it last saved to — here, the staging file"
+    );
+    (store, id, handle, paths)
+}
+
+/// Why (issue #6299 — the regression this fix exists for): committing the swap
+/// renames the staging file away. The live store was still recording (and
+/// mmap-viewing) that file, so the next write's `ensure_mutable` →
+/// `promote_view_to_mutable` failed `No such file or directory` — and kept
+/// failing forever, because a failed promote never clears `is_view`. Against
+/// the pre-fix code this test fails on the `upsert` below.
+/// What: demote onto staging, commit the swap, then write.
+/// Test: this IS the test.
+#[tokio::test]
+#[serial_test::serial]
+async fn write_after_commit_swap_succeeds_when_store_was_demoted_to_staging_view() {
+    let data_dir = tempfile::tempdir().unwrap();
+    unsafe { std::env::set_var("TRUSTY_DATA_DIR", data_dir.path()) };
+    let root_dir = tempfile::tempdir().unwrap();
+
+    let (store, id, handle, paths) =
+        store_demoted_onto_staging("hnsw-swap-6299-commit", root_dir.path(), true).await;
+
+    commit_staged_hnsw_swap(&handle, &id, &paths).await;
+    assert!(!paths.staging.exists(), "commit renames staging away");
+
+    store
+        .upsert("post-commit".to_string().as_str(), vec![9.0, 0.0, 0.0, 0.0])
+        .await
+        .expect(
+            "a write after a committed swap must not fail 'No such file or directory' — \
+             issue #6299",
+        );
+    assert_eq!(
+        store.len().await.unwrap(),
+        21,
+        "the committed snapshot's vectors must survive the write"
+    );
+
+    unsafe { std::env::remove_var("TRUSTY_DATA_DIR") };
+}
+
+/// Why (issue #6299, abort half): aborting DELETES the staging file, wedging
+/// the same store the same way. The rolled-back corpus matches the live
+/// snapshot, so the store must fall back to it and stay writable.
+/// What: demote onto staging with a live snapshot seeded, abort the swap, then
+/// write. Against the pre-fix code the `upsert` fails ENOENT.
+/// Test: this IS the test.
+#[tokio::test]
+#[serial_test::serial]
+async fn write_after_abort_swap_succeeds_when_store_was_demoted_to_staging_view() {
+    let data_dir = tempfile::tempdir().unwrap();
+    unsafe { std::env::set_var("TRUSTY_DATA_DIR", data_dir.path()) };
+    let root_dir = tempfile::tempdir().unwrap();
+
+    let (store, id, handle, paths) =
+        store_demoted_onto_staging("hnsw-swap-6299-abort", root_dir.path(), true).await;
+
+    abort_staged_hnsw_swap(&handle, &id, &paths).await;
+    assert!(!paths.staging.exists(), "abort deletes staging");
+    assert!(paths.live.exists(), "abort leaves the live snapshot alone");
+
+    store
+        .upsert("post-abort", vec![9.0, 0.0, 0.0, 0.0])
+        .await
+        .expect(
+            "a write after an aborted swap must not fail 'No such file or directory' — \
+             issue #6299",
+        );
+    assert_eq!(
+        store.len().await.unwrap(),
+        21,
+        "the store must be serving the live snapshot's 20 vectors plus the new one"
+    );
+
+    unsafe { std::env::remove_var("TRUSTY_DATA_DIR") };
+}
+
+/// Why (issue #6299): a first-ever reindex that aborts has no live snapshot to
+/// fall back on, so nothing on disk can repair the store. The write must still
+/// succeed — `promote_view_to_mutable` rebuilds the graph from the mapping it
+/// still holds — and no vector may be lost doing it.
+/// What: demote onto staging with NO live snapshot, abort, then write.
+/// Test: this IS the test.
+#[tokio::test]
+#[serial_test::serial]
+async fn write_after_abort_swap_rebuilds_when_no_live_snapshot_exists() {
+    let data_dir = tempfile::tempdir().unwrap();
+    unsafe { std::env::set_var("TRUSTY_DATA_DIR", data_dir.path()) };
+    let root_dir = tempfile::tempdir().unwrap();
+
+    let (store, id, handle, paths) =
+        store_demoted_onto_staging("hnsw-swap-6299-abort-bare", root_dir.path(), false).await;
+    assert!(!paths.live.exists(), "no live snapshot in this scenario");
+
+    abort_staged_hnsw_swap(&handle, &id, &paths).await;
+
+    store
+        .upsert("post-abort", vec![9.0, 0.0, 0.0, 0.0])
+        .await
+        .expect("a write must self-heal rather than fail ENOENT forever — issue #6299");
+    assert_eq!(
+        store.len().await.unwrap(),
+        21,
+        "the in-memory graph must survive the rebuild"
+    );
+
+    unsafe { std::env::remove_var("TRUSTY_DATA_DIR") };
+}
+
 /// Save `store_with_vectors(5)` directly to `path` — a bare helper for
 /// tests that need a plausible pre-existing staging checkpoint without
 /// caring about its exact content.


### PR DESCRIPTION
Fixes the wedge that degraded the cto index (Refs #6299; root cause: https://github.com/bobmatnyc/trusty-tools/issues/6291#issuecomment-5430335403). Two halves: commit/abort swap resolution now re-points the live store at the settled snapshot (wedge impossible at its known producer), and a promote that still finds its recorded file missing rebuilds the graph from the mapping it holds instead of failing every future write (self-healing for any other producer). Four regression tests reproduce the exact production ENOENT and were proven failing pre-fix. Deliberate behavior change, test-pinned: an aborted reindex now rolls the in-memory store back to the live snapshot, pairing with the corpus rollback in the same step. trusty-search 0.49.2 → 0.49.3.

Test ladder rung 3+4: `cargo test -p trusty-search` (1805 lib + 435 integration + 30 suites, 0 failed), clippy -D warnings, `cargo check --workspace`, doc-pointer/line-cap/SLD gates, `check_semver.sh --crate trusty-search` (196 pass, compared=1 blind=0), `check-pr-version-bump.sh` OK.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools