### PR TITLE
fix(tga): GitHub collection is bounded under secondary rate limits (Refs #6084)

### DIFF
--- a/crates/trusty-git-analytics/changelog.d/6084-bounded-github-fetch.md
+++ b/crates/trusty-git-analytics/changelog.d/6084-bounded-github-fetch.md
@@ -1,0 +1,19 @@
+Fixed
+
+- **GitHub collection is bounded under secondary rate limits (#6084)** — both
+  fetch paths could sustain a 429 storm indefinitely: PR-review collection
+  retried each of 2625 pull requests on a fixed 1s/2s/4s ladder that never read
+  `Retry-After`, and `fetch_on_reference` (default `true`) issued one Issues-API
+  call per unique `#N` in commit history — 3681 of them on this repository —
+  swallowing each rate-limit response as "this issue carries no classification
+  signal". Nothing carried state between requests, so every remaining item paid
+  four more rejected calls; a self-audit sat in that loop for 45+ minutes. Both
+  paths now share a run-wide `FetchBudget`: `Retry-After` (and a drained
+  `x-ratelimit-remaining`) drives the wait, each wait is clamped to 60s and
+  charged against a 120s per-run allowance, and exhausting the allowance latches
+  a breaker so every later call fails immediately without sending a request.
+  Paginated walks stop at 100 pages and reference lookups at 500 per batch.
+  Every cap and every early stop is reported — as a `CollectionFault` on the PR
+  and reviewer passes, and as `IssueBatch::stopped_early` on the reference path —
+  so a trimmed result is never presented as a complete one. A rate-limited
+  reference is no longer cached as a resolved "no signal".

--- a/crates/trusty-git-analytics/src/classify/sources/github_issue_tests.rs
+++ b/crates/trusty-git-analytics/src/classify/sources/github_issue_tests.rs
@@ -1,0 +1,208 @@
+//! Coverage for the bounded `fetch_on_reference` lookup path (#6084).
+//!
+//! This is the second of the two paths in the live repro: one Issues-API call
+//! per unique `#N` in commit history — 3681 of them on the repository that
+//! reproduced the spiral. Every test drives a local `wiremock` server.
+
+use super::*;
+
+use std::collections::HashMap as StdHashMap;
+
+use wiremock::matchers::method;
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use crate::collect::errors::CollectError;
+
+/// A config whose `bug` label maps to a category, so a fetched issue produces
+/// a signal and an unfetched one visibly does not.
+fn config() -> GithubIssuesSourceConfig {
+    let mut label_mappings = StdHashMap::new();
+    label_mappings.insert("bug".to_string(), "bug_fix".to_string());
+    GithubIssuesSourceConfig {
+        repo: "acme/widgets".to_string(),
+        // A name no test environment exports, so the lookup runs unauthenticated
+        // and never depends on the developer's real GITHUB_TOKEN.
+        token_env: "TGA_TEST_GITHUB_TOKEN_ABSENT".to_string(),
+        label_mappings,
+    }
+}
+
+/// `n` bare references, `#1` through `#n`.
+fn refs(n: u64) -> Vec<GitHubRef> {
+    (1..=n)
+        .map(|number| GitHubRef { repo: None, number })
+        .collect()
+}
+
+/// How many requests the server actually received.
+async fn request_count(server: &MockServer) -> usize {
+    server
+        .received_requests()
+        .await
+        .map(|r| r.len())
+        .unwrap_or_default()
+}
+
+/// Why: this is the exact fail-open the issue names. Before #6084 a 429 was
+/// folded into `None`, the resolver cached that as "this issue carries no
+/// classification signal", and the run kept issuing rejected requests for
+/// every remaining reference. A throttle is an unknown answer and must not be
+/// cached, and it must stop the batch.
+/// What: the server always answers `429`, with a `Retry-After` larger than the
+/// run's whole allowance so no test waits on it. Asserts the batch stops, says
+/// why, and records NOTHING — not even a `None` — for the reference it could
+/// not resolve.
+#[tokio::test]
+async fn a_rate_limited_batch_stops_and_caches_nothing() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(429).insert_header("retry-after", "300"))
+        .mount(&server)
+        .await;
+
+    let budget = FetchBudget::with_sleep_budget(std::time::Duration::from_secs(1));
+    let batch = fetch_issues_batch(
+        &reqwest::Client::new(),
+        &config(),
+        &refs(50),
+        Some(&server.uri()),
+        &budget,
+    )
+    .await;
+
+    assert!(
+        batch.signals.is_empty(),
+        "a throttled lookup is an unknown answer; caching it as `no signal` is the bug"
+    );
+    let reason = batch
+        .stopped_early
+        .expect("a batch cut short by a rate limit must say so");
+    assert!(
+        reason.contains("UNCLASSIFIED"),
+        "the stop must name what is missing, got: {reason}"
+    );
+    assert_eq!(
+        request_count(&server).await,
+        1,
+        "50 references must not cost 50 rejected lookups once the budget is spent"
+    );
+}
+
+/// Why: the reference count scales with commit history, not with anything the
+/// operator chose, so the batch needs a ceiling of its own even when GitHub is
+/// answering normally.
+#[tokio::test]
+async fn the_batch_stops_at_the_reference_lookup_cap() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+
+    let budget = FetchBudget::new();
+    let over_cap = (MAX_REFERENCE_LOOKUPS + 25) as u64;
+    let batch = fetch_issues_batch(
+        &reqwest::Client::new(),
+        &config(),
+        &refs(over_cap),
+        Some(&server.uri()),
+        &budget,
+    )
+    .await;
+
+    assert_eq!(batch.signals.len(), MAX_REFERENCE_LOOKUPS);
+    assert_eq!(request_count(&server).await, MAX_REFERENCE_LOOKUPS);
+    let reason = batch
+        .stopped_early
+        .expect("hitting the lookup cap must be reported, never silent");
+    assert!(reason.contains("UNCLASSIFIED"), "got: {reason}");
+    assert_eq!(
+        budget.notices().len(),
+        1,
+        "the cap must also reach the run's truncation ledger"
+    );
+}
+
+/// Why: bounding the path must not cost the ordinary case. A label that maps
+/// to a category still has to classify.
+#[tokio::test]
+async fn a_labelled_issue_still_classifies() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_string(r#"{"number":7,"labels":[{"name":"bug"}]}"#),
+        )
+        .mount(&server)
+        .await;
+
+    let budget = FetchBudget::new();
+    let batch = fetch_issues_batch(
+        &reqwest::Client::new(),
+        &config(),
+        &refs(1),
+        Some(&server.uri()),
+        &budget,
+    )
+    .await;
+
+    assert!(batch.stopped_early.is_none());
+    let signal = batch
+        .signals
+        .get("acme/widgets#1")
+        .expect("the reference was looked up")
+        .as_ref()
+        .expect("a `bug` label maps to a category");
+    assert_eq!(signal.category, "bug_fix");
+}
+
+/// Why: a genuinely missing issue is a real, cacheable answer — folding it in
+/// with a throttle would make the run re-ask for it forever.
+#[tokio::test]
+async fn a_missing_issue_is_a_cacheable_no_signal() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+
+    let budget = FetchBudget::new();
+    let issue = fetch_issue(
+        &reqwest::Client::new(),
+        &config(),
+        "acme/widgets",
+        404,
+        Some(&server.uri()),
+        &budget,
+    )
+    .await
+    .expect("a 404 is an answer, not a failure");
+    assert!(issue.is_none());
+    assert!(budget.tripped_error().is_none());
+}
+
+/// Why: the error arm is what the resolver keys its don't-cache decision on,
+/// so it has to be a `Throttled` rather than a generic transport error.
+#[tokio::test]
+async fn a_rate_limited_single_fetch_returns_throttled() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(429).insert_header("retry-after", "0"))
+        .mount(&server)
+        .await;
+
+    let budget = FetchBudget::new();
+    let err = fetch_issue(
+        &reqwest::Client::new(),
+        &config(),
+        "acme/widgets",
+        1,
+        Some(&server.uri()),
+        &budget,
+    )
+    .await
+    .expect_err("a persistent rate limit must not read as `no signal`");
+    assert!(
+        matches!(err, CollectError::Throttled { status: 429, .. }),
+        "got {err:?}"
+    );
+}

--- a/crates/trusty-git-analytics/src/classify/sources/github_issues.rs
+++ b/crates/trusty-git-analytics/src/classify/sources/github_issues.rs
@@ -21,6 +21,8 @@ use serde::Deserialize;
 use tracing::warn;
 
 use super::{ExternalSignal, GithubIssuesSourceConfig, EXTERNAL_SOURCE_CONFIDENCE};
+use crate::collect::github::budget::{FetchBudget, MAX_REFERENCE_LOOKUPS};
+use crate::collect::github::retry::retry_send;
 
 /// A parsed GitHub issue reference extracted from a commit message.
 ///
@@ -145,18 +147,33 @@ pub fn classify_github_issue(
 /// Fetch a GitHub issue by owner/repo/number.
 ///
 /// Why: the HTTP call must be isolated here so the resolver can inject a
-/// mock client for testing.
-/// What: issues `GET /repos/{owner}/{repo}/issues/{number}` with an
-/// optional Bearer token. Returns `None` on any error or if the token env
-/// var is unset.
-/// Test: integration-tested via the resolver with wiremock.
+/// mock client for testing. Before #6084 it also collapsed every failure into
+/// `None`, which the resolver then cached as "this issue carries no
+/// classification signal" — so under a rate limit the run cached 3681 wrong
+/// answers and kept issuing rejected requests to collect them. A throttle has
+/// to be a different answer from an absent label.
+/// What: issues `GET /repos/{owner}/{repo}/issues/{number}` with an optional
+/// Bearer token, through [`retry_send`] so `Retry-After` is honoured and every
+/// wait is charged to `budget`. `Ok(None)` means the issue genuinely carries
+/// nothing usable — a 404, a scope-less 403, an unparseable body — and is safe
+/// to cache. `Err` means the answer is unknown and must not be cached.
+/// Test: `crate::classify::sources::resolver::resolver_tests` and
+/// `github_issue_tests` in this module.
+///
+/// # Errors
+///
+/// [`CollectError::Throttled`](crate::collect::errors::CollectError::Throttled)
+/// once GitHub is rate-limiting and the run's budget is spent;
+/// [`CollectError::Http`](crate::collect::errors::CollectError::Http) on a
+/// transport failure that outlived its retries.
 pub async fn fetch_issue(
     client: &reqwest::Client,
     config: &GithubIssuesSourceConfig,
     owner_repo: &str,
     number: u64,
     api_base_override: Option<&str>,
-) -> Option<GitHubIssue> {
+    budget: &FetchBudget,
+) -> crate::collect::errors::Result<Option<GitHubIssue>> {
     let token = std::env::var(&config.token_env)
         .ok()
         .filter(|t| !t.is_empty());
@@ -169,58 +186,118 @@ pub async fn fetch_issue(
         req = req.bearer_auth(t);
     }
 
-    match req.send().await {
-        Ok(resp) if resp.status().is_success() => match resp.json::<GitHubIssue>().await {
-            Ok(issue) => Some(issue),
-            Err(e) => {
-                warn!(owner_repo, number, error = %e, "failed to parse GitHub issue response");
-                None
-            }
-        },
-        Ok(resp) => {
-            warn!(
-                owner_repo,
-                number,
-                status = %resp.status(),
-                "GitHub Issues API returned non-success; skipping"
-            );
-            None
-        }
+    let resp = retry_send(req, budget).await?;
+    if !resp.status().is_success() {
+        warn!(
+            owner_repo,
+            number,
+            status = %resp.status(),
+            "GitHub Issues API returned non-success; skipping this reference"
+        );
+        return Ok(None);
+    }
+    match resp.json::<GitHubIssue>().await {
+        Ok(issue) => Ok(Some(issue)),
         Err(e) => {
-            warn!(owner_repo, number, error = %e, "GitHub Issues API request failed; skipping");
-            None
+            warn!(owner_repo, number, error = %e, "failed to parse GitHub issue response");
+            Ok(None)
         }
     }
 }
 
-/// Build a map from `"owner/repo#number"` to `Option<ExternalSignal>`.
+/// What one [`fetch_issues_batch`] pass produced, and whether it finished.
 ///
-/// Why: same cache-before-fetch rationale as the JIRA batch helper — avoid
-/// re-fetching the same issue when multiple commits reference it.
-/// What: deduplicates `refs`, fetches each unique `(repo, number)` pair, and
-/// returns a map keyed by `"{repo}#{number}"`.
-/// Test: covered by resolver integration tests.
+/// Why (#6084): the batch used to return a bare map, so a pass that stopped at
+/// a cap or a rate limit was indistinguishable from one that looked every
+/// reference up and found nothing. The two need different handling — the
+/// second is a cacheable answer, the first is a gap the run must report.
+/// What: the signals actually resolved, plus `stopped_early` naming the bound
+/// that ended the pass. References never attempted are simply absent from
+/// `signals`, so nothing unfetched is cached as "no signal".
+/// Test: `github_issue_tests::a_rate_limited_batch_stops_and_caches_nothing`,
+/// `github_issue_tests::the_batch_stops_at_the_reference_lookup_cap`.
+#[derive(Debug, Default)]
+pub struct IssueBatch {
+    /// Resolved signals, keyed `"{repo}#{number}"`.
+    pub signals: HashMap<String, Option<ExternalSignal>>,
+    /// Set when a bound ended the pass before every reference was looked up.
+    pub stopped_early: Option<String>,
+}
+
+/// Look up every unique reference in `refs`, bounded.
+///
+/// Why: this is the `fetch_on_reference` path — one Issues-API call per unique
+/// `#N` in commit history, a count that scales with the repository rather than
+/// with anything the operator asked for. On this repo it was 3681 lookups, and
+/// under a secondary rate limit every one of them retried and failed.
+/// What: deduplicates `refs`, then stops at the first of three bounds —
+/// [`MAX_REFERENCE_LOOKUPS`] unique lookups, the shared `budget` latching, or
+/// the reference list running out. Either early stop is named in
+/// [`IssueBatch::stopped_early`] rather than left silent.
+/// Test: `github_issue_tests::*`.
 pub async fn fetch_issues_batch(
     client: &reqwest::Client,
     config: &GithubIssuesSourceConfig,
     refs: &[GitHubRef],
     api_base_override: Option<&str>,
-) -> HashMap<String, Option<ExternalSignal>> {
-    let mut out: HashMap<String, Option<ExternalSignal>> = HashMap::new();
+    budget: &FetchBudget,
+) -> IssueBatch {
+    let mut out = IssueBatch::default();
+    let mut looked_up = 0usize;
 
     for gh_ref in refs {
         let repo = gh_ref.repo.as_deref().unwrap_or(config.repo.as_str());
         let cache_key = format!("{repo}#{}", gh_ref.number);
-        if out.contains_key(&cache_key) {
+        if out.signals.contains_key(&cache_key) {
             continue;
         }
-        let issue = fetch_issue(client, config, repo, gh_ref.number, api_base_override).await;
-        let signal = issue.and_then(|iss| classify_github_issue(&iss, config));
-        out.insert(cache_key, signal);
+        if looked_up >= MAX_REFERENCE_LOOKUPS {
+            let notice = format!(
+                "GitHub reference lookups stopped at the {MAX_REFERENCE_LOOKUPS}-lookup cap; \
+                 the remaining references in this batch are UNCLASSIFIED"
+            );
+            warn!(cap = MAX_REFERENCE_LOOKUPS, "{notice}");
+            budget.note_truncation(notice.clone());
+            out.stopped_early = Some(notice);
+            break;
+        }
+
+        looked_up += 1;
+        match fetch_issue(
+            client,
+            config,
+            repo,
+            gh_ref.number,
+            api_base_override,
+            budget,
+        )
+        .await
+        {
+            Ok(issue) => {
+                let signal = issue.and_then(|iss| classify_github_issue(&iss, config));
+                out.signals.insert(cache_key, signal);
+            }
+            Err(e) => {
+                // Unknown, not absent. Recording nothing for this key is what
+                // keeps the resolver from caching a throttle as "no signal".
+                let notice = format!(
+                    "GitHub reference lookups stopped after {looked_up} of {} references: {e}. \
+                     The remaining references are UNCLASSIFIED",
+                    refs.len()
+                );
+                warn!("{notice}");
+                out.stopped_early = Some(notice);
+                break;
+            }
+        }
     }
 
     out
 }
+
+#[cfg(test)]
+#[path = "github_issue_tests.rs"]
+mod github_issue_tests;
 
 #[cfg(test)]
 mod tests {

--- a/crates/trusty-git-analytics/src/classify/sources/resolver/mod.rs
+++ b/crates/trusty-git-analytics/src/classify/sources/resolver/mod.rs
@@ -22,7 +22,7 @@
 use std::collections::HashMap;
 use std::sync::Mutex;
 
-use tracing::debug;
+use tracing::{debug, warn};
 
 use super::{
     confluence, datadog,
@@ -90,6 +90,11 @@ enum SourceState {
 pub struct ExternalSourceResolver {
     client: reqwest::Client,
     sources: Vec<SourceState>,
+    /// #6084: one GitHub fetch budget for the whole resolver, shared by the
+    /// warm pass and every per-commit `resolve`. The `fetch_on_reference` path
+    /// issues one lookup per unique `#N` in commit history, so the bound that
+    /// matters spans calls rather than sitting inside any one of them.
+    github_budget: crate::collect::github::budget::FetchBudget,
 }
 
 impl ExternalSourceResolver {
@@ -140,7 +145,13 @@ impl ExternalSourceResolver {
         Self {
             client,
             sources: states,
+            github_budget: crate::collect::github::budget::FetchBudget::new(),
         }
+    }
+
+    /// The GitHub fetch budget this resolver's sources share (#6084).
+    pub(crate) fn github_budget(&self) -> &crate::collect::github::budget::FetchBudget {
+        &self.github_budget
     }
 
     /// Resolve a commit message against all configured sources.
@@ -265,13 +276,21 @@ impl ExternalSourceResolver {
                     config,
                     &refs,
                     api_base_override.as_deref(),
+                    &self.github_budget,
                 )
                 .await;
+
+                // #6084: only references actually looked up are cached. A pass
+                // cut short by a rate limit reports the gap instead of writing
+                // "no signal" for references it never asked about.
+                if let Some(reason) = &fetched.stopped_early {
+                    warn!(reason = %reason, "GitHub reference classification is incomplete");
+                }
 
                 // Populate cache.
                 {
                     let mut guard = cache.lock().expect("github cache lock");
-                    for (k, sig) in &fetched {
+                    for (k, sig) in &fetched.signals {
                         guard.insert(k.clone(), sig.clone());
                     }
                 }
@@ -280,7 +299,7 @@ impl ExternalSourceResolver {
                 for gh_ref in &refs {
                     let repo = gh_ref.repo.as_deref().unwrap_or(&config.repo);
                     let key = format!("{repo}#{}", gh_ref.number);
-                    if let Some(Some(sig)) = fetched.get(&key) {
+                    if let Some(Some(sig)) = fetched.signals.get(&key) {
                         return Some(sig.clone());
                     }
                 }

--- a/crates/trusty-git-analytics/src/classify/sources/resolver/warm.rs
+++ b/crates/trusty-git-analytics/src/classify/sources/resolver/warm.rs
@@ -31,9 +31,11 @@ use std::future::Future;
 use std::sync::Mutex;
 
 use futures::stream::StreamExt;
+use tracing::warn;
 
 use super::{confluence, datadog, github_issues, jira, linear, shortcut};
 use super::{Cache, ExternalSignal, ExternalSourceResolver, GitHubRef, SourceState};
+use crate::collect::github::budget::FetchBudget;
 
 impl ExternalSourceResolver {
     /// Pre-resolve every ticket key referenced across `messages`, for every
@@ -51,7 +53,14 @@ impl ExternalSourceResolver {
     pub async fn warm_cache(&self, messages: &[String], concurrency: usize) {
         let concurrency = concurrency.max(1);
         for state in &self.sources {
-            warm_source(&self.client, state, messages, concurrency).await;
+            warm_source(
+                &self.client,
+                state,
+                messages,
+                concurrency,
+                self.github_budget(),
+            )
+            .await;
         }
     }
 }
@@ -70,6 +79,7 @@ async fn warm_source(
     state: &SourceState,
     messages: &[String],
     concurrency: usize,
+    github_budget: &FetchBudget,
 ) {
     match state {
         SourceState::Jira {
@@ -104,7 +114,7 @@ async fn warm_source(
                         base_url_override,
                     )
                     .await;
-                    result.remove(&k).flatten()
+                    result.remove(&k)
                 },
             )
             .await;
@@ -141,9 +151,13 @@ async fn warm_source(
                         config,
                         std::slice::from_ref(&r),
                         api_base_override,
+                        github_budget,
                     )
                     .await;
-                    result.remove(&key).flatten()
+                    if let Some(reason) = &result.stopped_early {
+                        warn!(key = %key, reason = %reason, "GitHub warm lookup was cut short");
+                    }
+                    result.signals.remove(&key)
                 },
             )
             .await;
@@ -175,7 +189,7 @@ async fn warm_source(
                         api_base_override,
                     )
                     .await;
-                    result.remove(&k).flatten()
+                    result.remove(&k)
                 },
             )
             .await;
@@ -207,7 +221,7 @@ async fn warm_source(
                         api_base_override,
                     )
                     .await;
-                    result.remove(&key).flatten()
+                    result.remove(&key)
                 },
             )
             .await;
@@ -239,7 +253,7 @@ async fn warm_source(
                         api_base_override,
                     )
                     .await;
-                    result.remove(&key).flatten()
+                    result.remove(&key)
                 },
             )
             .await;
@@ -270,7 +284,7 @@ async fn warm_source(
                         api_base_override,
                     )
                     .await;
-                    result.remove(&s).flatten()
+                    result.remove(&s)
                 },
             )
             .await;
@@ -300,7 +314,11 @@ async fn warm_generic<T, K, F, Fut>(
 ) where
     K: Fn(&T) -> String,
     F: Fn(T) -> Fut,
-    Fut: Future<Output = Option<ExternalSignal>>,
+    // #6084: the outer `Option` is "did we get an answer at all". A fetch that
+    // was rate-limited or never attempted yields `None` and is left out of the
+    // cache; caching it would record "this ticket has no signal" on the
+    // strength of a request the server refused.
+    Fut: Future<Output = Option<Option<ExternalSignal>>>,
 {
     if items.is_empty() {
         return;
@@ -318,7 +336,7 @@ async fn warm_generic<T, K, F, Fut>(
 
     let key_of = &key_of;
     let fetch_one = &fetch_one;
-    let fetched: Vec<(String, Option<ExternalSignal>)> =
+    let fetched: Vec<(String, Option<Option<ExternalSignal>>)> =
         futures::stream::iter(misses.into_iter().map(|item| async move {
             let key = key_of(&item);
             let signal = fetch_one(item).await;
@@ -330,7 +348,10 @@ async fn warm_generic<T, K, F, Fut>(
 
     let mut guard = cache.lock().expect("cache lock");
     for (k, sig) in fetched {
-        guard.insert(k, sig);
+        // Only a key we actually got an answer for is cached (#6084).
+        if let Some(sig) = sig {
+            guard.insert(k, sig);
+        }
     }
 }
 

--- a/crates/trusty-git-analytics/src/collect/github/budget.rs
+++ b/crates/trusty-git-analytics/src/collect/github/budget.rs
@@ -1,0 +1,235 @@
+//! The one bound on how much GitHub fetching a single `tga` run may do (#6084).
+//!
+//! Why: every GitHub call in this crate retried 429 on a fixed 1s/2s/4s ladder
+//! and then moved on to the next call, which retried the same way. Nothing
+//! carried state ACROSS calls, so a secondary rate limit made every remaining
+//! item pay four more rejected requests: a self-audit of this repo sat in a
+//! continuous 429 loop for 45+ minutes across 2625 pull requests, and the
+//! per-`#N` reference path reproduced it across 3681 references. A per-request
+//! attempt cap cannot stop that — only a budget the whole run shares can.
+//! What: [`FetchBudget`] is that shared state. It holds a total sleep
+//! allowance, latches a breaker the first time the allowance is exhausted so
+//! every later call fails fast instead of issuing another rejected request,
+//! and carries the ledger of bounds the run actually hit so a truncated result
+//! is reported as truncated rather than presented as complete.
+//! [`rate_limit_delay`] is the single place a GitHub response is classified as
+//! rate-limited and its `Retry-After` turned into a bounded wait.
+//! Test: `budget_tests` in this directory.
+
+use std::sync::Mutex;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use reqwest::header::{HeaderMap, RETRY_AFTER};
+
+use crate::collect::errors::CollectError;
+
+/// Hard ceiling on pages any one paginated GitHub listing will walk.
+///
+/// At [`super::client::PAGE_SIZE`] (100) per page this is 10,000 items — far
+/// past any repository this tool profiles, and finite even when GitHub keeps
+/// answering with full pages.
+pub(crate) const MAX_PAGES: u32 = 100;
+
+/// Hard ceiling on per-reference issue lookups in one classification batch.
+///
+/// The `fetch_on_reference` path issues one Issues-API call per unique `#N`
+/// found in commit messages, and that count scales with repository history
+/// rather than with anything the operator chose.
+pub(crate) const MAX_REFERENCE_LOOKUPS: usize = 500;
+
+/// Total wall-clock one run may spend asleep waiting out GitHub.
+pub(crate) const RATE_LIMIT_SLEEP_BUDGET: Duration = Duration::from_secs(120);
+
+/// Longest single wait honoured, however large `Retry-After` is.
+///
+/// GitHub answers a drained primary limit with a reset up to an hour out.
+/// Sleeping that long inside a collection run is indistinguishable from a
+/// hang, so the budget stops the run instead.
+pub(crate) const MAX_RETRY_AFTER: Duration = Duration::from_secs(60);
+
+/// Wait used when a rate-limited response names no delay of its own.
+pub(crate) const DEFAULT_RATE_LIMIT_DELAY: Duration = Duration::from_secs(1);
+
+/// Classify a GitHub response and, when it is rate-limited, say how long to wait.
+///
+/// Why: GitHub signals its two rate limits differently and neither is just
+/// "429". A secondary limit arrives as 403 or 429 carrying `Retry-After`; a
+/// drained primary limit arrives as 403 with `x-ratelimit-remaining: 0` and an
+/// `x-ratelimit-reset` epoch. A plain 403 — a token without the scope — is
+/// neither, and retrying it is pure waste, so the classification has to be
+/// narrower than "the status was 403".
+/// What: returns `Some(delay)` only for those two shapes, preferring
+/// `Retry-After`, then `x-ratelimit-reset`, then [`DEFAULT_RATE_LIMIT_DELAY`],
+/// clamped to [`MAX_RETRY_AFTER`]. Returns `None` for everything else,
+/// including a 403 with no rate-limit evidence.
+/// Test: `budget_tests::retry_after_is_preferred_over_every_other_hint`,
+/// `budget_tests::a_403_without_rate_limit_evidence_is_not_a_rate_limit`,
+/// `budget_tests::a_reset_epoch_is_used_when_retry_after_is_absent`,
+/// `budget_tests::a_very_long_retry_after_is_clamped`.
+pub(crate) fn rate_limit_delay(status: u16, headers: &HeaderMap) -> Option<Duration> {
+    let retry_after = header_u64(headers, RETRY_AFTER.as_str()).map(Duration::from_secs);
+    let quota_drained = header_u64(headers, "x-ratelimit-remaining") == Some(0);
+
+    let rate_limited = status == 429 || (status == 403 && (retry_after.is_some() || quota_drained));
+    if !rate_limited {
+        return None;
+    }
+
+    let delay = retry_after
+        .or_else(|| reset_delay(headers))
+        .unwrap_or(DEFAULT_RATE_LIMIT_DELAY);
+    Some(delay.min(MAX_RETRY_AFTER))
+}
+
+/// Read a header as an unsigned integer, or `None` when absent or unparseable.
+fn header_u64(headers: &HeaderMap, name: &str) -> Option<u64> {
+    headers
+        .get(name)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.trim().parse::<u64>().ok())
+}
+
+/// Turn an `x-ratelimit-reset` epoch into a delay from now.
+///
+/// A reset already in the past yields `Duration::ZERO` rather than `None`, so a
+/// clock skew shortens the wait instead of falling through to the default.
+fn reset_delay(headers: &HeaderMap) -> Option<Duration> {
+    let reset = header_u64(headers, "x-ratelimit-reset")?;
+    let now = SystemTime::now().duration_since(UNIX_EPOCH).ok()?.as_secs();
+    Some(Duration::from_secs(reset.saturating_sub(now)))
+}
+
+/// Mutable half of a [`FetchBudget`], guarded by one lock.
+#[derive(Default)]
+struct BudgetState {
+    /// Rate-limit and backoff sleep already committed by this run.
+    slept: Duration,
+    /// Set once the breaker latches: the status and delay that exhausted it.
+    tripped: Option<(u16, Option<Duration>)>,
+    /// Bounds this run hit, in operator-facing wording.
+    notices: Vec<String>,
+}
+
+/// The run-wide bound every GitHub call in this crate charges against.
+///
+/// Why: see the module header — a spiral is what happens when each request
+/// bounds only itself. Sharing one budget is what converts "45 minutes of
+/// rejected requests" into a terminal outcome the caller can report.
+/// What: a sleep allowance plus a latching breaker plus a truncation ledger.
+/// [`Self::reserve`] is the only way to spend the allowance; once it refuses,
+/// [`Self::tripped_error`] answers for every later call without a request
+/// leaving the process.
+/// Test: `budget_tests::*`.
+pub struct FetchBudget {
+    /// Total sleep this budget will authorise across its whole lifetime.
+    sleep_budget: Duration,
+    state: Mutex<BudgetState>,
+}
+
+impl FetchBudget {
+    /// A budget with the standard [`RATE_LIMIT_SLEEP_BUDGET`] allowance.
+    pub fn new() -> Self {
+        Self::with_sleep_budget(RATE_LIMIT_SLEEP_BUDGET)
+    }
+
+    /// A budget with a caller-chosen allowance, so tests can exhaust it without
+    /// sleeping for two minutes.
+    pub fn with_sleep_budget(sleep_budget: Duration) -> Self {
+        Self {
+            sleep_budget,
+            state: Mutex::new(BudgetState::default()),
+        }
+    }
+
+    /// Take the lock, treating a poisoned mutex as usable.
+    ///
+    /// A panic while holding this lock leaves counters, not invariants, so
+    /// refusing to fetch afterwards would be a worse outcome than continuing.
+    fn lock(&self) -> std::sync::MutexGuard<'_, BudgetState> {
+        self.state.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    /// Commit `delay` of waiting against the allowance.
+    ///
+    /// Why: this is the single choke point that turns an unbounded retry storm
+    /// into a terminal error. A caller that sleeps without reserving first has
+    /// reintroduced the bug.
+    /// What: returns the delay to sleep when it fits. When it does not — or
+    /// when the breaker already latched — latches the breaker and returns
+    /// [`CollectError::Throttled`], which the caller propagates.
+    /// Test: `budget_tests::the_budget_latches_after_the_allowance_is_spent`,
+    /// `budget_tests::a_latched_budget_refuses_every_later_reservation`.
+    ///
+    /// # Errors
+    ///
+    /// [`CollectError::Throttled`] once the allowance cannot cover `delay`.
+    pub(crate) fn reserve(&self, delay: Duration, status: u16) -> Result<Duration, CollectError> {
+        let mut state = self.lock();
+        if let Some((status, retry_after)) = state.tripped {
+            return Err(CollectError::Throttled {
+                status,
+                retry_after,
+            });
+        }
+        if state.slept + delay > self.sleep_budget {
+            state.tripped = Some((status, Some(delay)));
+            return Err(CollectError::Throttled {
+                status,
+                retry_after: Some(delay),
+            });
+        }
+        state.slept += delay;
+        Ok(delay)
+    }
+
+    /// Latch the breaker because a request exhausted its own attempt cap while
+    /// still rate-limited, and return the error to propagate.
+    ///
+    /// Test: `budget_tests::tripping_on_the_attempt_cap_latches_the_breaker`.
+    pub(crate) fn trip(&self, status: u16, retry_after: Option<Duration>) -> CollectError {
+        let mut state = self.lock();
+        if state.tripped.is_none() {
+            state.tripped = Some((status, retry_after));
+        }
+        CollectError::Throttled {
+            status,
+            retry_after,
+        }
+    }
+
+    /// The error every call should fail with once the breaker has latched, or
+    /// `None` while the run may still fetch.
+    pub(crate) fn tripped_error(&self) -> Option<CollectError> {
+        self.lock()
+            .tripped
+            .map(|(status, retry_after)| CollectError::Throttled {
+                status,
+                retry_after,
+            })
+    }
+
+    /// Record that a bound trimmed the result set.
+    ///
+    /// Why: a cap that silently shortens a listing produces data that reads
+    /// exactly like a complete collection. Every caller that breaks out of a
+    /// walk early records why here so the run can say so.
+    /// Test: `budget_tests::truncation_notices_are_recorded_in_order`.
+    pub(crate) fn note_truncation(&self, message: impl Into<String>) {
+        self.lock().notices.push(message.into());
+    }
+
+    /// Every truncation recorded so far, in the order it happened.
+    pub(crate) fn notices(&self) -> Vec<String> {
+        self.lock().notices.clone()
+    }
+}
+
+impl Default for FetchBudget {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+#[path = "budget_tests.rs"]
+mod budget_tests;

--- a/crates/trusty-git-analytics/src/collect/github/budget_tests.rs
+++ b/crates/trusty-git-analytics/src/collect/github/budget_tests.rs
@@ -1,0 +1,152 @@
+//! Unit coverage for the run-wide GitHub fetch budget (#6084).
+//!
+//! Every test here is pure — no HTTP, no sleeping. The wiring that puts these
+//! decisions on the request path is covered in `retry_tests.rs`.
+
+use super::*;
+
+use reqwest::header::{HeaderMap, HeaderValue};
+
+/// Build a header map from `(name, value)` pairs.
+fn headers(pairs: &[(&str, &str)]) -> HeaderMap {
+    let mut h = HeaderMap::new();
+    for (k, v) in pairs {
+        let name: reqwest::header::HeaderName =
+            k.parse().expect("test header name is a valid header name");
+        h.insert(
+            name,
+            HeaderValue::from_str(v).expect("test header value is valid"),
+        );
+    }
+    h
+}
+
+/// Why: `Retry-After` is the server's own instruction and it must win over the
+/// fixed ladder that produced the spiral.
+#[test]
+fn retry_after_is_preferred_over_every_other_hint() {
+    let h = headers(&[
+        ("retry-after", "7"),
+        ("x-ratelimit-remaining", "0"),
+        ("x-ratelimit-reset", "99999999999"),
+    ]);
+    assert_eq!(rate_limit_delay(429, &h), Some(Duration::from_secs(7)));
+}
+
+/// Why: a 403 from a token missing a scope will never succeed, and retrying it
+/// spends the budget that a genuine rate limit needs.
+#[test]
+fn a_403_without_rate_limit_evidence_is_not_a_rate_limit() {
+    let h = headers(&[("x-ratelimit-remaining", "4999")]);
+    assert_eq!(rate_limit_delay(403, &h), None);
+}
+
+/// Why: a drained primary limit arrives as 403 with the quota at zero and no
+/// `Retry-After` at all; missing it is how the storm starts.
+#[test]
+fn a_drained_quota_makes_a_403_a_rate_limit() {
+    let h = headers(&[("x-ratelimit-remaining", "0")]);
+    assert!(rate_limit_delay(403, &h).is_some());
+}
+
+/// Why: with no `Retry-After`, the reset epoch is the only delay GitHub gives.
+#[test]
+fn a_reset_epoch_is_used_when_retry_after_is_absent() {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock is after the epoch")
+        .as_secs();
+    let h = headers(&[
+        ("x-ratelimit-remaining", "0"),
+        ("x-ratelimit-reset", &(now + 5).to_string()),
+    ]);
+    let delay = rate_limit_delay(403, &h).expect("a drained quota is a rate limit");
+    // The clock advances between building the header and reading it.
+    assert!(
+        delay <= Duration::from_secs(5) && delay >= Duration::from_secs(3),
+        "expected ~5s, got {delay:?}"
+    );
+}
+
+/// Why: GitHub can name an hour-long reset. Sleeping that long inside a
+/// collection run is indistinguishable from a hang.
+#[test]
+fn a_very_long_retry_after_is_clamped() {
+    let h = headers(&[("retry-after", "3600")]);
+    assert_eq!(rate_limit_delay(429, &h), Some(MAX_RETRY_AFTER));
+}
+
+/// Why: a rate-limited response with no usable hint still needs a delay, not a
+/// tight loop.
+#[test]
+fn a_429_with_no_hints_falls_back_to_the_default_delay() {
+    assert_eq!(
+        rate_limit_delay(429, &HeaderMap::new()),
+        Some(DEFAULT_RATE_LIMIT_DELAY)
+    );
+}
+
+/// Why: a success must never be classified as throttled.
+#[test]
+fn a_success_is_never_a_rate_limit() {
+    let h = headers(&[("retry-after", "5")]);
+    assert_eq!(rate_limit_delay(200, &h), None);
+}
+
+/// Why: this is the bound the whole fix rests on — the run stops paying for
+/// waits once the allowance is gone.
+#[test]
+fn the_budget_latches_after_the_allowance_is_spent() {
+    let budget = FetchBudget::with_sleep_budget(Duration::from_secs(3));
+    assert!(budget.reserve(Duration::from_secs(2), 429).is_ok());
+    assert!(budget.tripped_error().is_none());
+
+    let refused = budget.reserve(Duration::from_secs(2), 429);
+    assert!(
+        matches!(refused, Err(CollectError::Throttled { status: 429, .. })),
+        "expected Throttled, got {refused:?}"
+    );
+    assert!(budget.tripped_error().is_some());
+}
+
+/// Why: the latch is what makes every remaining call fail without a request.
+/// A budget that recovered would restart the storm.
+#[test]
+fn a_latched_budget_refuses_every_later_reservation() {
+    let budget = FetchBudget::with_sleep_budget(Duration::from_millis(1));
+    assert!(budget.reserve(Duration::from_secs(1), 429).is_err());
+    for _ in 0..5 {
+        assert!(budget.reserve(Duration::from_millis(0), 429).is_err());
+    }
+}
+
+/// Why: a request that used all its attempts and is still rate-limited proves
+/// the limit outlives one request, so nothing after it should try.
+#[test]
+fn tripping_on_the_attempt_cap_latches_the_breaker() {
+    let budget = FetchBudget::new();
+    let err = budget.trip(429, Some(Duration::from_secs(2)));
+    assert!(matches!(err, CollectError::Throttled { status: 429, .. }));
+    assert!(budget.tripped_error().is_some());
+}
+
+/// Why: a cap that trims results silently is the failure this ledger exists to
+/// prevent.
+#[test]
+fn truncation_notices_are_recorded_in_order() {
+    let budget = FetchBudget::new();
+    assert!(budget.notices().is_empty());
+    budget.note_truncation("first");
+    budget.note_truncation("second");
+    assert_eq!(budget.notices(), vec!["first", "second"]);
+}
+
+/// Why: the shipped constants are the operator-visible contract; a silent
+/// change to any of them changes what a run will and will not do.
+#[test]
+fn the_shipped_bounds_are_the_documented_ones() {
+    assert_eq!(MAX_PAGES, 100);
+    assert_eq!(MAX_REFERENCE_LOOKUPS, 500);
+    assert_eq!(RATE_LIMIT_SLEEP_BUDGET, Duration::from_secs(120));
+    assert_eq!(MAX_RETRY_AFTER, Duration::from_secs(60));
+}

--- a/crates/trusty-git-analytics/src/collect/github/client.rs
+++ b/crates/trusty-git-analytics/src/collect/github/client.rs
@@ -7,6 +7,7 @@ use tracing::{debug, warn};
 use async_trait::async_trait;
 
 use crate::collect::errors::{CollectError, Result};
+use crate::collect::github::budget::{FetchBudget, MAX_PAGES};
 use crate::collect::github::repo_resolver::{build_http_client, parse_slug};
 use crate::collect::github::retry::retry_get;
 use crate::collect::github::types::{ApiPull, GitHubIssue, GitHubPrCommit, GitHubReview};
@@ -50,6 +51,10 @@ pub struct GitHubClient {
     /// client's credential (or lack of one) can see the primary repo — see
     /// [`Self::ensure_repo_visible`].
     repo_visible: tokio::sync::OnceCell<bool>,
+    /// #6084: the run-wide bound every call this client makes charges against.
+    /// One budget per client means the whole PR sweep — every page of every
+    /// repo, every review, every issue — shares one ceiling and one breaker.
+    budget: FetchBudget,
 }
 
 /// Compute the JSON-encoded `commit_shas` value for a PR row.
@@ -99,6 +104,7 @@ impl GitHubClient {
             repos: vec![(owner, repo)],
             api_base: GITHUB_API_BASE.to_string(),
             repo_visible: tokio::sync::OnceCell::new(),
+            budget: FetchBudget::new(),
         })
     }
 
@@ -136,6 +142,7 @@ impl GitHubClient {
             repos,
             api_base: GITHUB_API_BASE.to_string(),
             repo_visible: tokio::sync::OnceCell::new(),
+            budget: FetchBudget::new(),
         })
     }
 
@@ -163,6 +170,7 @@ impl GitHubClient {
             repos: Vec::new(),
             api_base: GITHUB_API_BASE.to_string(),
             repo_visible: tokio::sync::OnceCell::new(),
+            budget: FetchBudget::new(),
         })
     }
 
@@ -284,6 +292,9 @@ impl GitHubClient {
                 break;
             }
             page += 1;
+            if self.page_cap_reached("pulls", &format!("{owner}/{repo}"), page) {
+                break;
+            }
         }
         Ok(out)
     }
@@ -450,10 +461,57 @@ impl GitHubClient {
     /// Why: GitHub occasionally returns 502/504 under load and 429 when the
     /// per-token rate limit drains; a tiny retry loop avoids surfacing those
     /// as pipeline failures.
-    /// What: delegates to the free [`retry_get`] helper, passing `self.client`.
+    /// What: delegates to the free [`retry_get`] helper, passing `self.client`
+    /// and this client's shared [`FetchBudget`] so every call on it charges
+    /// against one run-wide ceiling (#6084).
     /// Test: covered indirectly by callers and by `wiremock` integration tests.
     async fn retry_request(&self, url: &str) -> Result<reqwest::Response> {
-        retry_get(&self.client, url).await
+        retry_get(&self.client, url, &self.budget).await
+    }
+
+    /// Whether a paginated walk has reached [`MAX_PAGES`] and must stop.
+    ///
+    /// Why (#6084): every listing here looped until GitHub returned a short
+    /// page, which trusts the server to eventually end the walk. A cap makes
+    /// each walk finite; recording the stop is what keeps the shortened result
+    /// from reading downstream exactly like a complete one.
+    /// What: returns `false` below the cap. At the cap, warns, appends a
+    /// truncation notice to the budget, and returns `true` for the caller to
+    /// break on.
+    /// Test: `client_tests::a_listing_that_never_ends_stops_at_the_page_cap_and_says_so`.
+    fn page_cap_reached(&self, endpoint: &str, scope: &str, page: u32) -> bool {
+        if page <= MAX_PAGES {
+            return false;
+        }
+        warn!(
+            endpoint,
+            scope,
+            pages = MAX_PAGES,
+            "GitHub listing hit the page cap; results for this scope are partial"
+        );
+        self.budget.note_truncation(format!(
+            "GitHub {endpoint} listing for {scope} stopped at the {MAX_PAGES}-page cap \
+             ({} items); these results are PARTIAL",
+            MAX_PAGES * PAGE_SIZE
+        ));
+        true
+    }
+
+    /// Bounds this client hit while fetching, in operator-facing wording.
+    ///
+    /// Empty when nothing was truncated. Non-empty means the data this client
+    /// returned is incomplete and the caller must say so (#6084).
+    pub(crate) fn fetch_notices(&self) -> Vec<String> {
+        self.budget.notices()
+    }
+
+    /// Whether this client's budget latched, meaning it stopped fetching early.
+    ///
+    /// A caller that continued past per-item failures uses this to tell "the
+    /// items I skipped were individually bad" from "GitHub stopped answering
+    /// and everything after the trip was never attempted" (#6084).
+    pub(crate) fn throttled(&self) -> bool {
+        self.budget.tripped_error().is_some()
     }
 
     /// Fetch all reviews for a given pull request, paginating until exhausted.
@@ -495,6 +553,9 @@ impl GitHubClient {
                 break;
             }
             page += 1;
+            if self.page_cap_reached("reviews", &format!("{owner}/{repo}#{pr_number}"), page) {
+                break;
+            }
         }
         Ok(out)
     }
@@ -540,6 +601,10 @@ impl GitHubClient {
                 break;
             }
             page += 1;
+            let scope = format!("{}/{}#{pr_number}", self.owner, self.repo);
+            if self.page_cap_reached("pr commits", &scope, page) {
+                break;
+            }
         }
         Ok(out)
     }
@@ -588,6 +653,10 @@ impl GitHubClient {
                 break;
             }
             page += 1;
+            let scope = format!("{}/{}", self.owner, self.repo);
+            if self.page_cap_reached("issues", &scope, page) {
+                break;
+            }
         }
         Ok(out)
     }
@@ -609,6 +678,10 @@ impl PrProvider for GitHubClient {
         prs: &[PullRequest],
     ) -> crate::core::Result<usize> {
         GitHubClient::store_pull_requests(self, db, prs)
+    }
+
+    fn fetch_notices(&self) -> Vec<String> {
+        GitHubClient::fetch_notices(self)
     }
 }
 

--- a/crates/trusty-git-analytics/src/collect/github/client_tests.rs
+++ b/crates/trusty-git-analytics/src/collect/github/client_tests.rs
@@ -660,3 +660,131 @@ mod fetch_issue_tests {
         // drops at the end of this test — a second probe call panics there.
     }
 }
+
+// ─── Bounded pagination and rate-limit termination (#6084) ────────────────────
+
+mod bounded_fetch_tests {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::*;
+    use crate::collect::github::budget::MAX_PAGES;
+    use crate::collect::github::client::PAGE_SIZE;
+    use crate::collect::pr_provider::PrProvider;
+
+    fn client_at(base: &str) -> GitHubClient {
+        GitHubClient::new(&gh(Some("acme/widgets"), None))
+            .expect("client builds")
+            .with_api_base(base)
+    }
+
+    /// One full page of issues — the answer that keeps a pre-fix walk going.
+    fn full_page() -> serde_json::Value {
+        let items: Vec<serde_json::Value> = (0..PAGE_SIZE)
+            .map(|i| {
+                serde_json::json!({
+                    "number": i + 1,
+                    "title": "t",
+                    "state": "open",
+                    "html_url": "https://example.invalid/1",
+                })
+            })
+            .collect();
+        serde_json::Value::Array(items)
+    }
+
+    /// Why: every listing here looped until the server returned a short page,
+    /// which trusts the server to end the walk. A server that always answers
+    /// with a full page never does — this test does not terminate against the
+    /// pre-fix code.
+    /// What: asserts the walk stops at exactly [`MAX_PAGES`] requests and that
+    /// the shortened result is reported rather than presented as complete.
+    #[tokio::test]
+    async fn a_listing_that_never_ends_stops_at_the_page_cap_and_says_so() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/repos/acme/widgets/issues"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(full_page()))
+            .mount(&server)
+            .await;
+
+        let client = client_at(&server.uri());
+        let issues = client.list_issues("all", None).await.expect("walk returns");
+
+        assert_eq!(issues.len(), (MAX_PAGES * PAGE_SIZE) as usize);
+        let requests = server
+            .received_requests()
+            .await
+            .map(|r| r.len())
+            .unwrap_or_default();
+        assert_eq!(requests, MAX_PAGES as usize, "the walk must be finite");
+
+        let notices = client.fetch_notices();
+        assert_eq!(notices.len(), 1, "a trimmed walk must be reported");
+        assert!(
+            notices[0].contains("PARTIAL"),
+            "the notice must say the result is incomplete, got: {}",
+            notices[0]
+        );
+    }
+
+    /// Why: the notice has to reach the pipeline through the trait the
+    /// collector actually drives, not only through the concrete client.
+    #[tokio::test]
+    async fn truncation_notices_reach_the_provider_trait() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/repos/acme/widgets/issues"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(full_page()))
+            .mount(&server)
+            .await;
+
+        let client = client_at(&server.uri());
+        assert!(PrProvider::fetch_notices(&client).is_empty());
+        let _ = client.list_issues("all", None).await.expect("walk returns");
+        assert_eq!(PrProvider::fetch_notices(&client).len(), 1);
+    }
+
+    /// Why: on the live repro each of 2625 pull requests paid four rejected
+    /// requests, because a rate limit that outlived one call had no way to stop
+    /// the next. Once this client's budget latches, every remaining call must
+    /// terminate without sending anything.
+    #[tokio::test]
+    async fn a_rate_limit_terminates_the_client_instead_of_repeating_per_item() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(429).insert_header("retry-after", "0"))
+            .mount(&server)
+            .await;
+
+        let client = client_at(&server.uri());
+        let first = client
+            .fetch_pr_reviews_for_repo("acme", "widgets", 1)
+            .await
+            .expect_err("a permanent rate limit must not read as `no reviews`");
+        assert!(matches!(first, CollectError::Throttled { status: 429, .. }));
+        assert!(client.throttled());
+
+        let before = server
+            .received_requests()
+            .await
+            .map(|r| r.len())
+            .unwrap_or_default();
+        for pr in 2..=50u64 {
+            let e = client
+                .fetch_pr_reviews_for_repo("acme", "widgets", pr)
+                .await
+                .expect_err("every later PR must fail fast");
+            assert!(matches!(e, CollectError::Throttled { .. }));
+        }
+        let after = server
+            .received_requests()
+            .await
+            .map(|r| r.len())
+            .unwrap_or_default();
+        assert_eq!(
+            before, after,
+            "49 further PRs must cost zero requests once the breaker has latched"
+        );
+    }
+}

--- a/crates/trusty-git-analytics/src/collect/github/mod.rs
+++ b/crates/trusty-git-analytics/src/collect/github/mod.rs
@@ -1,5 +1,6 @@
 //! GitHub REST API client for pull-request metadata.
 
+pub mod budget;
 pub mod client;
 pub mod issue_writer;
 pub mod org_discovery;

--- a/crates/trusty-git-analytics/src/collect/github/org_discovery.rs
+++ b/crates/trusty-git-analytics/src/collect/github/org_discovery.rs
@@ -20,6 +20,7 @@
 
 use tracing::{debug, warn};
 
+use super::budget::{FetchBudget, MAX_PAGES};
 use super::client::{GITHUB_API_BASE, PAGE_SIZE};
 use super::retry::retry_get;
 use crate::collect::errors::{CollectError, Result};
@@ -58,6 +59,31 @@ pub async fn discover_org_repos(
     client: &reqwest::Client,
     org: &str,
 ) -> Result<Vec<(String, String)>> {
+    discover_org_repos_within(client, org, &FetchBudget::new()).await
+}
+
+/// [`discover_org_repos`] against a caller-supplied budget.
+///
+/// Why (#6084): the multi-org pass walks one org after another, and a rate
+/// limit hit on the first org applies to every org after it. Sharing one
+/// budget across the whole pass is what stops the second org from re-running
+/// the storm the first one just terminated on.
+/// What: identical to [`discover_org_repos`], except the run-wide bound is
+/// passed in rather than created per call, and the page walk stops at
+/// [`MAX_PAGES`].
+/// Test: `crate::collect::github::retry_tests` covers the budget behaviour
+/// this shares with every other GitHub call.
+///
+/// # Errors
+///
+/// Same as [`discover_org_repos`], plus
+/// [`CollectError::Throttled`](crate::collect::errors::CollectError::Throttled)
+/// once the shared budget is exhausted.
+pub(crate) async fn discover_org_repos_within(
+    client: &reqwest::Client,
+    org: &str,
+    budget: &FetchBudget,
+) -> Result<Vec<(String, String)>> {
     let mut out = Vec::new();
     let mut page = 1u32;
     loop {
@@ -66,7 +92,7 @@ pub async fn discover_org_repos(
         debug!(url = %url, "GET (org repo discovery)");
         // Route through the shared retry helper so transient 5xx/429 are
         // retried with the same backoff as the main PR client.
-        let resp = retry_get(client, &url).await?;
+        let resp = retry_get(client, &url, budget).await?;
 
         // Respect rate-limit hints (same pattern as the main client).
         if let Some(rem) = resp
@@ -108,6 +134,15 @@ pub async fn discover_org_repos(
             break;
         }
         page += 1;
+        if page > MAX_PAGES {
+            warn!(org = %org, pages = MAX_PAGES, "org repo discovery hit the page cap");
+            budget.note_truncation(format!(
+                "GitHub org repo discovery for {org} stopped at the {MAX_PAGES}-page cap \
+                 ({} repositories); the repository set is PARTIAL",
+                MAX_PAGES * PAGE_SIZE
+            ));
+            break;
+        }
     }
     debug!(org = %org, count = out.len(), "org repo discovery complete");
     Ok(out)

--- a/crates/trusty-git-analytics/src/collect/github/retry.rs
+++ b/crates/trusty-git-analytics/src/collect/github/retry.rs
@@ -1,70 +1,150 @@
-//! Shared HTTP retry helper for all GitHub API calls.
+//! Shared HTTP retry helper for every GitHub API call in this crate.
 //!
-//! Why: the main PR client (`GitHubClient`) and the org-discovery path
-//! both need exponential backoff on transient failures (5xx, 429). A single
-//! free function here avoids duplicating the logic and makes the retry
-//! policy easy to change in one place.
-//! What: [`retry_get`] retries a GET request up to [`MAX_RETRIES`] times
-//! with exponential backoff delays (`RETRY_BASE_MS * 2^attempt`).
-//! Test: covered indirectly by all callers; `GitHubClient::retry_request`
-//! delegates here; wiremock integration tests exercise it end-to-end.
+//! Why: the PR client, org discovery, and the per-reference issue lookup all
+//! need backoff on transient failures, and before #6084 each bounded only
+//! itself — a per-request attempt cap with no memory across requests, which is
+//! what let a secondary rate limit sustain itself for 45+ minutes. One helper
+//! that charges every wait against a shared [`FetchBudget`] is what makes the
+//! whole run bounded rather than each request individually bounded.
+//! What: [`retry_send`] retries a request up to [`MAX_RETRIES`] times, honouring
+//! `Retry-After` on rate-limited responses and using exponential backoff
+//! (`RETRY_BASE_MS * 2^attempt`) on 5xx and transport errors. Every wait is
+//! reserved from the budget first, so the run has a total ceiling; when the
+//! ceiling is reached the budget latches and this helper stops issuing requests
+//! at all. [`retry_get`] is the GET convenience wrapper.
+//! Test: `retry_tests` in this directory drives both paths against `wiremock`.
 
 use std::time::Duration;
 
 use tracing::{debug, warn};
 
 use crate::collect::errors::{CollectError, Result};
+use crate::collect::github::budget::{rate_limit_delay, FetchBudget};
 
-/// Maximum retry attempts for transient failures (5xx, 429).
+/// Maximum retry attempts for one request.
 pub(crate) const MAX_RETRIES: u32 = 3;
 /// Base delay (in milliseconds) for exponential backoff: 1s, 2s, 4s.
 pub(crate) const RETRY_BASE_MS: u64 = 1000;
 
-/// Send a GET with exponential backoff on transient HTTP failures.
+/// Exponential backoff delay for `attempt`, starting at [`RETRY_BASE_MS`].
+fn backoff(attempt: u32) -> Duration {
+    Duration::from_millis(RETRY_BASE_MS * (1u64 << attempt))
+}
+
+/// Send a GET with bounded, rate-limit-aware retries.
 ///
-/// Why: GitHub occasionally returns 502/504 under load and 429 when the
-/// per-token rate limit drains. Both the main PR client and the org-discovery
-/// path need this behaviour; sharing one free function avoids duplicating the
-/// backoff logic. `GitHubClient::retry_request` delegates here so all retry
-/// behaviour lives in a single place.
-/// What: retries up to [`MAX_RETRIES`] times on HTTP 429 or any 5xx; delays
-/// follow `RETRY_BASE_MS * 2^attempt` (1s, 2s, 4s). Returns the final
-/// non-transient response; caller is responsible for calling
-/// `.error_for_status()` on it.
-/// Test: covered indirectly by all callers and by `wiremock` integration tests.
-pub(crate) async fn retry_get(client: &reqwest::Client, url: &str) -> Result<reqwest::Response> {
+/// Why/What/Test: see [`retry_send`], which this delegates to.
+///
+/// # Errors
+///
+/// Whatever [`retry_send`] returns.
+pub(crate) async fn retry_get(
+    client: &reqwest::Client,
+    url: &str,
+    budget: &FetchBudget,
+) -> Result<reqwest::Response> {
+    debug!(url = %url, "GET (with retry)");
+    retry_send(client.get(url), budget).await
+}
+
+/// Send `req` with bounded, rate-limit-aware retries against a shared budget.
+///
+/// Why: the caller must never be able to spin. Three bounds apply at once — a
+/// per-request attempt cap, a per-wait clamp, and the run-wide sleep allowance
+/// in `budget` — and the last is the one that stops a storm, because it is the
+/// only bound that survives from one request to the next.
+/// What: on a rate-limited response (see
+/// [`rate_limit_delay`](crate::collect::github::budget::rate_limit_delay))
+/// waits the server's own `Retry-After`; on 5xx or a transport error waits
+/// [`backoff`]. Every wait is reserved from `budget` first, so exhausting the
+/// allowance returns [`CollectError::Throttled`] instead of sleeping. Once the
+/// budget has latched, this returns that error without sending anything —
+/// which is what converts the remaining thousands of doomed calls into an
+/// immediate terminal outcome. A non-transient response is returned as-is;
+/// calling `.error_for_status()` on it stays the caller's job.
+/// Test: `retry_tests::a_secondary_rate_limit_is_retried_then_terminates`,
+/// `retry_tests::retry_after_is_honoured_instead_of_the_fixed_ladder`,
+/// `retry_tests::a_latched_budget_sends_no_further_requests`,
+/// `retry_tests::a_transient_5xx_still_recovers`.
+///
+/// # Errors
+///
+/// - [`CollectError::Throttled`] when GitHub is still rate-limiting after
+///   [`MAX_RETRIES`], or when the run's sleep allowance is exhausted.
+/// - [`CollectError::Http`] on a transport failure that outlived its retries.
+pub(crate) async fn retry_send(
+    req: reqwest::RequestBuilder,
+    budget: &FetchBudget,
+) -> Result<reqwest::Response> {
+    if let Some(e) = budget.tripped_error() {
+        return Err(e);
+    }
+
     let mut last_err: Option<reqwest::Error> = None;
     for attempt in 0..=MAX_RETRIES {
-        debug!(url = %url, attempt, "GET (with retry)");
-        match client.get(url).send().await {
+        // A GET carries no body and always clones. A request that does not is
+        // given its single attempt rather than being silently dropped.
+        let Some(this_attempt) = req.try_clone() else {
+            return req.send().await.map_err(CollectError::Http);
+        };
+
+        match this_attempt.send().await {
             Ok(resp) => {
-                let status = resp.status();
-                let transient = status.as_u16() == 429 || (500..=599).contains(&status.as_u16());
+                let status = resp.status().as_u16();
+
+                if let Some(delay) = rate_limit_delay(status, resp.headers()) {
+                    if attempt == MAX_RETRIES {
+                        warn!(
+                            status,
+                            attempt,
+                            "GitHub is still rate-limiting after the attempt cap; \
+                                      stopping GitHub collection for this run"
+                        );
+                        return Err(budget.trip(status, Some(delay)));
+                    }
+                    let delay = budget.reserve(delay, status)?;
+                    warn!(
+                        status,
+                        attempt,
+                        delay_ms = delay.as_millis() as u64,
+                        "GitHub rate-limited the request; waiting out Retry-After"
+                    );
+                    tokio::time::sleep(delay).await;
+                    continue;
+                }
+
+                let transient = (500..=599).contains(&status);
                 if !transient || attempt == MAX_RETRIES {
                     return Ok(resp);
                 }
-                let delay = RETRY_BASE_MS * (1u64 << attempt);
+                let delay = budget.reserve(backoff(attempt), status)?;
                 warn!(
-                    status = %status,
+                    status,
                     attempt,
-                    delay_ms = delay,
-                    "GitHub returned transient status; retrying"
+                    delay_ms = delay.as_millis() as u64,
+                    "GitHub returned a transient status; retrying"
                 );
-                tokio::time::sleep(Duration::from_millis(delay)).await;
+                tokio::time::sleep(delay).await;
             }
             Err(e) => {
                 if attempt == MAX_RETRIES {
                     return Err(CollectError::Http(e));
                 }
-                let delay = RETRY_BASE_MS * (1u64 << attempt);
-                warn!(error = %e, attempt, delay_ms = delay, "transport error; retrying");
+                let delay = budget.reserve(backoff(attempt), 0)?;
+                warn!(error = %e, attempt, delay_ms = delay.as_millis() as u64,
+                      "transport error; retrying");
                 last_err = Some(e);
-                tokio::time::sleep(Duration::from_millis(delay)).await;
+                tokio::time::sleep(delay).await;
             }
         }
     }
+
     // Unreachable in practice: the loop returns by `attempt == MAX_RETRIES`.
     Err(CollectError::Http(
         last_err.expect("retry loop preserved error"),
     ))
 }
+
+#[cfg(test)]
+#[path = "retry_tests.rs"]
+mod retry_tests;

--- a/crates/trusty-git-analytics/src/collect/github/retry_tests.rs
+++ b/crates/trusty-git-analytics/src/collect/github/retry_tests.rs
@@ -1,0 +1,206 @@
+//! Request-path coverage for bounded GitHub retries (#6084).
+//!
+//! Every test drives a local `wiremock` server — no live GitHub call, and no
+//! test waits on a real backoff longer than the first 1s rung.
+
+use super::*;
+
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use crate::collect::github::budget::MAX_RETRY_AFTER;
+
+/// How many requests the server actually received.
+async fn request_count(server: &MockServer) -> usize {
+    server
+        .received_requests()
+        .await
+        .map(|r| r.len())
+        .unwrap_or_default()
+}
+
+/// Why: this is the spiral from #6084 in miniature. A server that never stops
+/// rate-limiting must produce a bounded number of requests and one terminal
+/// error, not an open-ended loop.
+/// What: every response is `429 Retry-After: 0`, so the wait is real logic but
+/// costs no wall-clock. Asserts exactly `MAX_RETRIES + 1` requests and a
+/// `Throttled` error.
+#[tokio::test]
+async fn a_secondary_rate_limit_is_retried_then_terminates() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/issues/1"))
+        .respond_with(ResponseTemplate::new(429).insert_header("retry-after", "0"))
+        .mount(&server)
+        .await;
+
+    let budget = FetchBudget::new();
+    let url = format!("{}/issues/1", server.uri());
+    let err = retry_get(&reqwest::Client::new(), &url, &budget)
+        .await
+        .expect_err("a permanently rate-limited endpoint must not return Ok");
+
+    assert!(
+        matches!(err, CollectError::Throttled { status: 429, .. }),
+        "expected Throttled, got {err:?}"
+    );
+    assert_eq!(
+        request_count(&server).await,
+        (MAX_RETRIES + 1) as usize,
+        "the attempt cap must bound how many requests one call makes"
+    );
+    assert!(
+        budget.tripped_error().is_some(),
+        "exhausting the attempt cap while still rate-limited must latch the breaker"
+    );
+}
+
+/// Why: before #6084 the delay came from a fixed 1s/2s/4s ladder and
+/// `Retry-After` was never read, so the client kept asking well before GitHub
+/// would answer. Proving the header is honoured without sleeping for it: name
+/// a delay larger than the run's whole allowance and assert the call stops on
+/// the FIRST rate-limited response rather than retrying three more times.
+#[tokio::test]
+async fn retry_after_is_honoured_instead_of_the_fixed_ladder() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/issues/2"))
+        .respond_with(ResponseTemplate::new(429).insert_header("retry-after", "45"))
+        .mount(&server)
+        .await;
+
+    // Smaller than the 45s the server asks for, so the very first wait cannot
+    // be afforded.
+    let budget = FetchBudget::with_sleep_budget(Duration::from_secs(5));
+    let url = format!("{}/issues/2", server.uri());
+    let err = retry_get(&reqwest::Client::new(), &url, &budget)
+        .await
+        .expect_err("a wait the budget cannot afford must terminate the call");
+
+    match err {
+        CollectError::Throttled {
+            status,
+            retry_after,
+        } => {
+            assert_eq!(status, 429);
+            assert_eq!(
+                retry_after,
+                Some(Duration::from_secs(45)),
+                "the error must carry the server's own delay, not the fixed ladder"
+            );
+        }
+        other => panic!("expected Throttled, got {other:?}"),
+    }
+    assert_eq!(
+        request_count(&server).await,
+        1,
+        "an unaffordable Retry-After must stop the call, not spend three more attempts on it"
+    );
+}
+
+/// Why: the latch is the whole cure. On the live repro every one of 2625 pull
+/// requests paid four rejected requests because nothing carried state between
+/// calls; once the budget has tripped, no further request may leave.
+#[tokio::test]
+async fn a_latched_budget_sends_no_further_requests() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/issues/3"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("{}"))
+        .mount(&server)
+        .await;
+
+    let budget = FetchBudget::new();
+    budget.trip(429, Some(Duration::from_secs(30)));
+
+    let url = format!("{}/issues/3", server.uri());
+    for _ in 0..25 {
+        let err = retry_get(&reqwest::Client::new(), &url, &budget)
+            .await
+            .expect_err("a latched budget must refuse every call");
+        assert!(matches!(err, CollectError::Throttled { .. }));
+    }
+    assert_eq!(
+        request_count(&server).await,
+        0,
+        "not one request may leave the process after the breaker latches"
+    );
+}
+
+/// Why: bounding the storm must not cost the ordinary recovery a retry exists
+/// for — a single 502 still has to succeed on the next attempt.
+#[tokio::test]
+async fn a_transient_5xx_still_recovers() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/issues/4"))
+        .respond_with(ResponseTemplate::new(502))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/issues/4"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("{}"))
+        .mount(&server)
+        .await;
+
+    let budget = FetchBudget::new();
+    let url = format!("{}/issues/4", server.uri());
+    let resp = retry_get(&reqwest::Client::new(), &url, &budget)
+        .await
+        .expect("a single transient 502 must still recover");
+    assert_eq!(resp.status().as_u16(), 200);
+    assert_eq!(request_count(&server).await, 2);
+}
+
+/// Why: a token missing a scope answers 403 forever. Retrying it spends the
+/// allowance a genuine rate limit needs, and the caller's `error_for_status`
+/// is what should report it.
+#[tokio::test]
+async fn a_403_without_rate_limit_evidence_is_returned_immediately() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/issues/5"))
+        .respond_with(
+            ResponseTemplate::new(403)
+                .insert_header("x-ratelimit-remaining", "4999")
+                .set_body_string("Resource not accessible by personal access token"),
+        )
+        .mount(&server)
+        .await;
+
+    let budget = FetchBudget::new();
+    let url = format!("{}/issues/5", server.uri());
+    let resp = retry_get(&reqwest::Client::new(), &url, &budget)
+        .await
+        .expect("a scope failure is a response, not a retry");
+    assert_eq!(resp.status().as_u16(), 403);
+    assert_eq!(request_count(&server).await, 1);
+    assert!(budget.tripped_error().is_none());
+}
+
+/// Why: a drained primary limit arrives as 403 with the quota at zero, which
+/// the pre-fix classifier (status 429 only) did not recognise at all.
+#[tokio::test]
+async fn a_drained_primary_quota_terminates_rather_than_spinning() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/issues/6"))
+        .respond_with(
+            ResponseTemplate::new(403)
+                .insert_header("x-ratelimit-remaining", "0")
+                .insert_header("x-ratelimit-reset", "99999999999"),
+        )
+        .mount(&server)
+        .await;
+
+    // A reset far in the future clamps to MAX_RETRY_AFTER, which no run-wide
+    // allowance this small can cover.
+    let budget = FetchBudget::with_sleep_budget(MAX_RETRY_AFTER / 2);
+    let url = format!("{}/issues/6", server.uri());
+    let err = retry_get(&reqwest::Client::new(), &url, &budget)
+        .await
+        .expect_err("a drained quota must terminate the run's GitHub fetching");
+    assert!(matches!(err, CollectError::Throttled { status: 403, .. }));
+    assert_eq!(request_count(&server).await, 1);
+}

--- a/crates/trusty-git-analytics/src/collect/github_pipeline.rs
+++ b/crates/trusty-git-analytics/src/collect/github_pipeline.rs
@@ -16,7 +16,8 @@
 use futures::StreamExt as _;
 use tracing::{info, warn};
 
-use crate::collect::github::org_discovery::{discover_org_repos, effective_orgs};
+use crate::collect::github::budget::FetchBudget;
+use crate::collect::github::org_discovery::{discover_org_repos_within, effective_orgs};
 use crate::collect::github::repo_resolver::build_http_client;
 use crate::collect::github::reviewer_store::upsert_github_pr_reviewer;
 use crate::collect::github::types::GitHubReview;
@@ -54,11 +55,14 @@ pub(super) async fn run_github_org_discovery(gh_cfg: &GithubConfig) -> Vec<(Stri
         }
     };
 
+    // #6084: one budget for the whole multi-org pass, so a rate limit that
+    // terminates the first org does not let the second start the storm again.
+    let budget = FetchBudget::new();
     let mut all: Vec<(String, String)> = Vec::new();
     let mut seen = std::collections::HashSet::new();
     for org in &orgs {
         info!(org = %org, "discovering repositories for GitHub org");
-        match discover_org_repos(&http, org).await {
+        match discover_org_repos_within(&http, org, &budget).await {
             Ok(repos) => {
                 info!(org = %org, count = repos.len(), "org discovery complete");
                 for p in repos {
@@ -213,6 +217,21 @@ pub(super) async fn fetch_and_store_github_reviewers(
                 );
             }
         }
+    }
+
+    // #6084: per-PR review failures are logged and skipped, which is right for
+    // one bad PR and wrong for a rate limit — under a limit every remaining PR
+    // "fails" and the pass would report a clean run holding partial data.
+    for notice in gh_client.fetch_notices() {
+        stats.skip_item(format!("github reviewers: {notice}"));
+    }
+    if gh_client.throttled() {
+        stats.fail_stage(
+            "GitHub rate-limited the reviewer pass, which stopped early; pr_reviewers is \
+             incomplete for this run. Retry later, or set github.fetch_pr_reviews: false \
+             (see #6084)"
+                .to_string(),
+        );
     }
 
     if stats.reviewers_fetched > 0 {

--- a/crates/trusty-git-analytics/src/collect/pr_pipeline.rs
+++ b/crates/trusty-git-analytics/src/collect/pr_pipeline.rs
@@ -75,6 +75,11 @@ pub(super) async fn drain_and_store_pull_requests(
             continue;
         };
         record_blank_head_refs(stats, &provider_name, &prs);
+        // #6084: a walk that stopped at a cap returns rows that look complete.
+        // Recording each notice is what keeps the shortfall visible.
+        for notice in provider.fetch_notices() {
+            stats.skip_item(format!("{provider_name}: {notice}"));
+        }
         match provider.store_pull_requests(db, &prs) {
             Ok(n) => {
                 info!(provider = %provider_name, prs = n, "stored pull requests");

--- a/crates/trusty-git-analytics/src/collect/pr_provider.rs
+++ b/crates/trusty-git-analytics/src/collect/pr_provider.rs
@@ -54,4 +54,16 @@ pub trait PrProvider: Send + Sync {
     /// Propagates [`crate::core::TgaError::DbError`] on SQL failures.
     fn store_pull_requests(&self, db: &Database, prs: &[PullRequest])
         -> crate::core::Result<usize>;
+
+    /// Bounds this provider hit while fetching, in operator-facing wording.
+    ///
+    /// Why (#6084): a provider that stops at a page or budget cap returns rows
+    /// that read exactly like a complete fetch. Reporting the stop is what
+    /// keeps a trimmed sweep from being presented as the whole repository.
+    /// What: empty by default — a provider with no caps has nothing to say.
+    /// Overridden by [`crate::collect::github::GitHubClient`].
+    /// Test: `crate::collect::github::client_tests::a_listing_that_never_ends_stops_at_the_page_cap_and_says_so`.
+    fn fetch_notices(&self) -> Vec<String> {
+        Vec::new()
+    }
 }


### PR DESCRIPTION
Refs #6084. Both spiral paths live in tga's collection/classification layers (trusty-audit only drives them): PR-review fetching retried per-PR with no shared memory, and per-`#N` issue lookups had no retry and cached a throttled refusal as "no signal". Both now route through one run-wide `FetchBudget`: Retry-After/x-ratelimit-driven waits (60s single-wait clamp, 120s run allowance, then a latching breaker), 4 attempts per request, 100 pages per listing, 500 reference lookups per batch — and nothing that stops early reads as complete (truncation ledger → CollectionFault / `IssueBatch::stopped_early`). The fail-open cache poisoning (throttle cached as no-signal) is fixed for GitHub and the five other warm_generic providers. 10 of 26 new tests proven failing pre-fix. tga 4.0.0 → 4.0.1. Note: #6084 carried a backlog-freeze note from the engagement period; the owner's 2026-08-27 wave authorization named this issue explicitly.

Rung 4: `cargo test -p tga` (1375, 0 failed), `-p trusty-analyze` (0 failed), clippy -D warnings, `cargo check --workspace`, doc-pointer/line-cap/SLD gates, `check-pr-version-bump.sh` OK. `check_semver.sh --crate tga` blocked by the same pre-existing #6300 row; with the row removed locally the real comparison passes.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools