### PR TITLE
fix: repair two intra-doc links failing the pre-publish gate; trusty-mcp 0.1.1→0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11644,7 +11644,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-mcp"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ trusty-agents-common = { path = "crates/trusty-agents-common", version = "0.6.0"
 trusty-common = { path = "crates/trusty-common", version = "0.45" }
 # Shared JSON-RPC 2.0 / MCP protocol primitives, extracted from
 # `trusty_common::mcp` by ADR-0040 (#5803).
-trusty-mcp = { path = "crates/trusty-mcp", version = "0.1.1" }
+trusty-mcp = { path = "crates/trusty-mcp", version = "0.1.2" }
 # trusty-embedderd: embedding daemon — referenced by trusty-search so
 # `cargo install trusty-search` produces both binaries from one command.
 # Why: `default-features = false` HERE, not only on the member entry (mirrors

--- a/crates/trusty-audit/changelog.d/6287-analyze-socket-doc-link.md
+++ b/crates/trusty-audit/changelog.d/6287-analyze-socket-doc-link.md
@@ -1,0 +1,6 @@
+Documentation
+
+- `Tools::pinned`'s doc links `daemons::analyze_socket` instead of the
+  `daemons::analyze_base_url` that #6287 removed, and says the resolved pair is
+  a search URL plus an analyze socket path. The broken link failed Gate 1 of
+  the pre-publish workflow.

--- a/crates/trusty-audit/src/grounding.rs
+++ b/crates/trusty-audit/src/grounding.rs
@@ -101,8 +101,10 @@ impl Tools {
     /// them in keeps the daemon this starts and the binary the sweep checked
     /// from ever being two different installs — the same reason
     /// `tga::audit::SearchGuard` resolves its binary once at the entry point.
-    /// What: the two paths as given, with both addresses resolved by
-    /// [`daemons::search_base_url`] and [`daemons::analyze_base_url`].
+    /// What: the two paths as given, with the search URL resolved by
+    /// [`daemons::search_base_url`] and the analyze socket by
+    /// [`daemons::analyze_socket`] — #6287 retired the analyze daemon's HTTP
+    /// base URL, so that half of the pair is a Unix socket path now.
     /// Test: `super::grounding_tests::pinned_tools_keep_the_paths_they_were_given`.
     #[must_use]
     pub fn pinned(search: PathBuf, analyze: PathBuf) -> Self {

--- a/crates/trusty-mcp/Cargo.toml
+++ b/crates/trusty-mcp/Cargo.toml
@@ -1,6 +1,12 @@
 [package]
 name = "trusty-mcp"
-version = "0.1.1"
+# 0.1.1 -> 0.1.2 carries no code change. The `trusty-mcp-v0.1.1` tag is pinned
+# by a protected ruleset to c66fb18ff, and that commit fails Gate 1 of the
+# pre-publish workflow (two broken intra-doc links, fixed in this same commit),
+# so it can never satisfy `check-publish-ready.sh` CHECK 7. #6178: a release tag
+# here cannot be moved or deleted, so the version number is spent and the
+# release moves forward to a gate-clean commit instead.
+version = "0.1.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/trusty-mcp/changelog.d/6178-burned-0.1.1-tag.md
+++ b/crates/trusty-mcp/changelog.d/6178-burned-0.1.1-tag.md
@@ -1,0 +1,5 @@
+Changed
+
+- Version skipped from 0.1.1 to 0.1.2 with no code change. The
+  `trusty-mcp-v0.1.1` tag is pinned to a commit that fails the pre-publish
+  gate, and #6178 makes a release tag here immovable, so 0.1.1 is spent.

--- a/crates/trusty-review/changelog.d/6287-subprocess-analyze-doc-link.md
+++ b/crates/trusty-review/changelog.d/6287-subprocess-analyze-doc-link.md
@@ -1,0 +1,6 @@
+Documentation
+
+- `build_review_state`'s doc describes the `SubprocessAnalyzeClient` it
+  actually builds — spawning the `trusty-analyze` binary per call, no daemon —
+  rather than the loopback `DEFAULT_ANALYZER_URL` default that #6287 deleted.
+  The broken link failed Gate 1 of the pre-publish workflow.

--- a/crates/trusty-review/src/mcp/mod.rs
+++ b/crates/trusty-review/src/mcp/mod.rs
@@ -220,9 +220,11 @@ pub(crate) async fn dispatch_deferred(
 /// the reviewer LLM provider (Bedrock or OpenRouter, per config), optionally
 /// builds the verifier provider (degrading to `None` on failure — embedded use
 /// must not hard-fail a host daemon over a missing verifier model), builds the
-/// HTTP search + analyze clients from config (the analyze client defaults to
-/// [`crate::config::DEFAULT_ANALYZER_URL`], i.e. loopback to the hosting analyze daemon, so
-/// embedded reviews get authoritative static-analysis context), and returns the
+/// HTTP search client and a [`SubprocessAnalyzeClient`] from config (#6287
+/// deleted the HTTP analyze client and its loopback default URL; the subprocess
+/// client spawns the `trusty-analyze` binary per call — `TRUSTY_ANALYZE_BIN`,
+/// else `trusty-analyze` on PATH — so embedded reviews get authoritative
+/// static-analysis context with no analyze daemon running), and returns the
 /// assembled `AppState`. #5064: the dedup requirement is declared through
 /// `DedupNeed::NotNeeded` rather than by passing a bare `None` — embedded
 /// callers never post (`allow_posting=false` in every tool handler), so the


### PR DESCRIPTION
What: repairs the two broken intra-doc links that fail `Pre-publish gate` Gate 1 on main (`crates/trusty-audit/src/grounding.rs` → `daemons::analyze_socket`; `crates/trusty-review/src/mcp/mod.rs` rewritten to describe `SubprocessAnalyzeClient`), both left dangling by the analyze UDS migration (Refs #6287). Bumps trusty-mcp to 0.1.2 because tag `trusty-mcp-v0.1.1` is stranded at c66fb18ff, a commit that cannot pass that gate (Refs #6178 — immutable tags).

Evidence: failing run https://github.com/bobmatnyc/trusty-tools/actions/runs/33021092665; local reproduction `SKIP_UI_BUILD=1 RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links" cargo doc --no-deps -p trusty-audit -p trusty-review` → exit 0, 0 unresolved links.

Test ladder: rung 1–3 (doc comments + version metadata); gates run: fmt --check, check -p trusty-mcp -p trusty-audit -p trusty-review, clippy -p trusty-audit -p trusty-review --all-targets -D warnings, check-version-parity.sh, check_changelog_fragment.sh, check_line_cap.sh — all exit 0.

Unblocks the eleven-crate publish train.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools