### PR TITLE
feat(trusty-mpm): statusline drops the daemon port and shows the Claude Code account

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11699,7 +11699,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-mpm"
-version = "1.5.4"
+version = "1.5.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -1,6 +1,10 @@
 [package]
 name = "trusty-mpm"
-version = "1.5.4"
+# 1.5.5 (#6304): patch — 1.5.4 is already published on crates.io and this PR
+# edits `src/**`, so the `PR version bump vs crates.io` gate (#4421) requires
+# the bump here. Patch because every changed item lives in the `tm` BIN target
+# (`src/bin/tm/commands/statusline/`); the library's public API is untouched.
+version = "1.5.5"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/trusty-mpm/changelog.d/6304-statusline-account.md
+++ b/crates/trusty-mpm/changelog.d/6304-statusline-account.md
@@ -1,0 +1,19 @@
+Changed
+
+- `tm statusline` no longer renders the daemon's TCP port
+  ([#6304](https://github.com/bobmatnyc/trusty-tools/issues/6304)). The port was
+  not actionable from a status bar and invited port-based connection attempts;
+  its only other job was implicit, since it appeared only while the daemon was
+  reachable. That one bit is kept as a bare `●` after the version, so the
+  lead-in segment now reads `TM <ver> ●` when the daemon is up and `TM <ver>`
+  when it is not.
+- The statusline names the Claude Code account the session runs under, as
+  `✻<email>` between the `@<gh>` and model segments (#6304). Claude Code's
+  `statusLine` stdin payload carries session, cwd, model, cost, context-window
+  and rate-limit fields but no account, so the email is read from
+  `$CLAUDE_CONFIG_DIR/.claude.json` — the relocated personal tier every
+  daemon-managed session runs under — falling back to `~/.claude.json`. A
+  missing, unreadable, or malformed config, or one with no login recorded,
+  omits the segment rather than rendering a placeholder. The read is bounded at
+  100 ms on a detached thread, matching the sibling `gh` probe, so it can cost
+  the segment but never the render.

--- a/crates/trusty-mpm/src/bin/tm/cli/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli/mod.rs
@@ -1251,8 +1251,12 @@ pub(crate) enum Command {
     /// Why: Claude Code's `statusLine` hook calls this command on every render
     /// cycle; this handler parses the hook JSON and emits one compact segment
     /// string for the status bar.
-    /// What: reads a JSON object from stdin, renders segments (project, model,
-    /// daemon, cost), exits 0. Missing or invalid fields degrade gracefully.
+    /// What: reads a JSON object from stdin and renders
+    /// `TM <ver> ● | <project> ⎇ <branch> | @<gh> | ✻<account> | <model> |
+    /// ctx% | <cost> | <usage>`, then exits 0. Missing or invalid fields
+    /// degrade gracefully. `●` marks a reachable daemon; the account is the
+    /// Claude Code login, read from `.claude.json` since the stdin payload does
+    /// not carry it (#6304).
     /// Test: `cli_parses_statusline` in `tests.rs`.
     Statusline,
 

--- a/crates/trusty-mpm/src/bin/tm/commands/statusline/account.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/statusline/account.rs
@@ -1,0 +1,289 @@
+//! Claude Code account identity for the statusline (#6304).
+//!
+//! Why: the statusline already names the active `gh` identity (`@<login>`), but
+//! never named the Claude Code account the session itself runs under. An
+//! operator with a personal account and a work account has no way to tell which
+//! one is spending the session's tokens — the same class of silent wrong-identity
+//! error the `gh` segment exists to prevent. Claude Code does NOT send the
+//! account in the `statusLine` stdin payload (that object carries session, cwd,
+//! model, cost, context-window and rate-limit fields only), so the account has
+//! to come from the config file Claude Code persists it in.
+//!
+//! What: [`account_segment_from_path`] reads one JSON file and returns the
+//! `oauthAccount.emailAddress` rendered as `✻<email>`. [`claude_json_path`]
+//! resolves which file that is: `$CLAUDE_CONFIG_DIR/.claude.json` when
+//! `CLAUDE_CONFIG_DIR` is set — which is how every tm-managed session runs, and
+//! that file holds a DIFFERENT account block from the home one — else
+//! `~/.claude.json`. Every step is fail-soft: an unset home, a missing or
+//! unreadable file, malformed JSON, an absent `oauthAccount`, or a blank email
+//! all yield `None`, which omits the segment rather than rendering a
+//! placeholder. Taking the path as a parameter is what lets the tests drive
+//! real files without touching the operator's home directory.
+//!
+//! Test: `account_segment_renders_email_from_config`,
+//! `account_segment_absent_when_file_missing`,
+//! `account_segment_absent_when_json_is_malformed`,
+//! `account_segment_absent_when_email_is_blank`,
+//! `render_claude_account_segment_*`.
+
+use std::path::{Path, PathBuf};
+
+/// Marker prefixed to the account email in the rendered segment.
+///
+/// Why: the neighbouring `gh` segment renders `@<login>`, and a bare email also
+/// contains an `@` — without a distinct lead-in the two identity segments read
+/// as one another. `✻` is Claude Code's own glyph, so the segment says whose
+/// identity it is without spending width on a word.
+/// What: U+273B TEARDROP-SPOKED ASTERISK.
+/// Test: `render_claude_account_segment_single`.
+const CLAUDE_MARKER: char = '\u{273b}';
+
+/// Resolve the `.claude.json` Claude Code persists this session's account in.
+///
+/// Why: `CLAUDE_CONFIG_DIR` relocates Claude Code's entire personal tier, and
+/// every daemon-managed tm session sets it (`~/.trusty-tools/trusty-mpm/claude-config/`).
+/// Reading `~/.claude.json` unconditionally would name the account of a
+/// different, possibly stale, login on exactly the sessions tm launches itself.
+/// What: reads `CLAUDE_CONFIG_DIR` and the home directory, then defers to
+/// [`claude_json_path_from`]. The two inputs are read here and nowhere deeper
+/// so the decision itself stays testable without touching the process
+/// environment — this bin target bans writing either variable (#5544).
+/// Test: `claude_json_path_prefers_config_dir`, `claude_json_path_falls_back_to_home`.
+pub(crate) fn claude_json_path() -> Option<PathBuf> {
+    // #6304: honour the relocated personal tier, else fall back to $HOME.
+    claude_json_path_from(
+        std::env::var("CLAUDE_CONFIG_DIR").ok().as_deref(),
+        dirs::home_dir().as_deref(),
+    )
+}
+
+/// Choose the config file from an explicit config dir and home dir.
+///
+/// Why: taking both as parameters is what lets the precedence be asserted
+/// directly; the guard in `env_isolation_tests` bans a test from repointing
+/// `CLAUDE_CONFIG_DIR` or `HOME` in this target, because bin-target tests share
+/// one process and the write would be visible to every parallel sibling.
+/// What: `<config_dir>/.claude.json` when `config_dir` is present and not
+/// blank, else `<home>/.claude.json`, else `None`.
+/// Test: `claude_json_path_prefers_config_dir`, `claude_json_path_falls_back_to_home`.
+fn claude_json_path_from(config_dir: Option<&str>, home: Option<&Path>) -> Option<PathBuf> {
+    match config_dir {
+        Some(dir) if !dir.trim().is_empty() => Some(PathBuf::from(dir).join(".claude.json")),
+        _ => home.map(|h| h.join(".claude.json")),
+    }
+}
+
+/// The one field of `.claude.json` this module reads.
+///
+/// Why: `.claude.json` is large (~1 MB on a long-lived install) and its schema
+/// is Claude Code's to change; deserializing into a struct with a single
+/// optional field skips every other key without allocating for it, and an
+/// added or renamed sibling key cannot break the read.
+/// What: `oauthAccount`, itself optional (absent before first login).
+/// Test: `account_segment_renders_email_from_config`.
+#[derive(serde::Deserialize)]
+struct ClaudeJson {
+    #[serde(default, rename = "oauthAccount")]
+    oauth_account: Option<OauthAccount>,
+}
+
+/// The logged-in account block Claude Code writes into `.claude.json`.
+///
+/// Why: the block also carries `organizationName`, but for a personal account
+/// that is derived from the email (`"<email>'s Organization"`), so rendering
+/// both doubles the segment's width to say the same thing twice. The email is
+/// the identity Claude Code authenticates as, so it is the one field kept.
+/// What: `emailAddress`, defaulting to `""` when absent.
+/// Test: `account_segment_renders_email_from_config`.
+#[derive(serde::Deserialize)]
+struct OauthAccount {
+    #[serde(default, rename = "emailAddress")]
+    email_address: String,
+}
+
+/// Read `path` and render the Claude Code account segment.
+///
+/// Why: taking the path as a parameter (rather than resolving it internally)
+/// is what makes both branches — account present, account underivable —
+/// testable against real files in a temp directory, with no dependency on the
+/// operator's real home directory or login state.
+/// What: reads the file, parses `oauthAccount.emailAddress`, and renders it via
+/// [`render_claude_account_segment`]. Returns `None` for every failure mode
+/// (unreadable file, malformed JSON, no account block, blank email) so the
+/// segment is omitted rather than shown as a placeholder.
+/// Test: `account_segment_renders_email_from_config`,
+/// `account_segment_absent_when_file_missing`,
+/// `account_segment_absent_when_json_is_malformed`,
+/// `account_segment_absent_when_email_is_blank`.
+pub(crate) fn account_segment_from_path(path: &Path) -> Option<String> {
+    let raw = std::fs::read_to_string(path).ok()?;
+    let parsed: ClaudeJson = serde_json::from_str(&raw).ok()?;
+    let email = parsed.oauth_account?.email_address;
+    render_claude_account_segment(Some(&email))
+}
+
+/// Render the `✻<email>` segment from a resolved account email.
+///
+/// Why: keeping the render pure (no file I/O) pins the present/absent cases
+/// without a filesystem, and keeps the marker in one place.
+/// What: `Some("✻<email>")` for a non-blank email; `None` for `None` or a blank
+/// one, which omits the segment entirely.
+/// Test: `render_claude_account_segment_single`,
+/// `render_claude_account_segment_absent`.
+fn render_claude_account_segment(email: Option<&str>) -> Option<String> {
+    let email = email?.trim();
+    if email.is_empty() {
+        return None;
+    }
+    Some(format!("{CLAUDE_MARKER}{email}"))
+}
+
+/// Probe the Claude Code account at `path`, fail-soft, ≤100 ms.
+///
+/// Why (#6304): the render path Claude Code calls on every cycle must never
+/// block, and `.claude.json` can be a megabyte on a cold page cache. The
+/// bounded-thread pattern here matches the sibling `gh` and git/tmux probes:
+/// a read that outruns its budget costs the segment, never the statusline.
+/// What: spawns a detached thread that reads `path` via
+/// [`account_segment_from_path`], waits ≤100 ms, and returns `None` on timeout,
+/// on any read failure, or when `path` is `None` (no resolvable config).
+/// Test: `render_statusline_shows_claude_account_when_config_is_present` drives
+/// it through the renderer with an injected path; the read and render it wraps
+/// are unit-tested directly.
+pub(crate) fn claude_account_segment_probe(path: Option<&Path>) -> Option<String> {
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    let path = path?.to_path_buf();
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = tx.send(account_segment_from_path(&path));
+    });
+    rx.recv_timeout(Duration::from_millis(100)).ok().flatten()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write as _;
+
+    /// Write `body` to a fresh temp file and return it (kept alive by the caller).
+    fn temp_json(body: &str) -> tempfile::NamedTempFile {
+        let mut f = tempfile::NamedTempFile::new().expect("temp file");
+        f.write_all(body.as_bytes()).expect("write");
+        f.flush().expect("flush");
+        f
+    }
+
+    /// Why (#6304, branch b): the account must be rendered when the config file
+    /// Claude Code persists it in is present and readable. Uses the real key
+    /// spelling observed in `.claude.json` (`oauthAccount.emailAddress`) beside
+    /// the sibling keys that must be ignored.
+    /// Test: itself.
+    #[test]
+    fn account_segment_renders_email_from_config() {
+        let f = temp_json(
+            r#"{
+                "numStartups": 412,
+                "oauthAccount": {
+                    "accountUuid": "0000-1111",
+                    "emailAddress": "someone@example.com",
+                    "organizationName": "someone@example.com's Organization",
+                    "organizationRole": "admin"
+                },
+                "projects": {}
+            }"#,
+        );
+        assert_eq!(
+            account_segment_from_path(f.path()).as_deref(),
+            Some("\u{273b}someone@example.com")
+        );
+    }
+
+    /// Why (#6304, branch c): an absent config file — a first run, or a
+    /// `CLAUDE_CONFIG_DIR` that has not been provisioned — must omit the
+    /// segment, never render a placeholder.
+    /// Test: itself.
+    #[test]
+    fn account_segment_absent_when_file_missing() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let missing = dir.path().join("does-not-exist.json");
+        assert_eq!(account_segment_from_path(&missing), None);
+    }
+
+    /// Why (#6304, branch c): `.claude.json` is truncated or half-written often
+    /// enough that this repo keeps `.corrupt-*` quarantine copies of it. A
+    /// malformed file must omit the segment rather than panic on the hot render
+    /// path.
+    /// Test: itself.
+    #[test]
+    fn account_segment_absent_when_json_is_malformed() {
+        let f = temp_json(r#"{"oauthAccount": {"emailAddress": "trunc"#);
+        assert_eq!(account_segment_from_path(f.path()), None);
+
+        // Well-formed JSON with no account block at all (pre-login state).
+        let f = temp_json(r#"{"numStartups": 1}"#);
+        assert_eq!(account_segment_from_path(f.path()), None);
+    }
+
+    /// Why (#6304, branch c): a present-but-blank email must omit the segment
+    /// rather than emit a bare `✻`.
+    /// Test: itself.
+    #[test]
+    fn account_segment_absent_when_email_is_blank() {
+        let f = temp_json(r#"{"oauthAccount": {"emailAddress": "   "}}"#);
+        assert_eq!(account_segment_from_path(f.path()), None);
+
+        let f = temp_json(r#"{"oauthAccount": {"organizationName": "Acme"}}"#);
+        assert_eq!(account_segment_from_path(f.path()), None);
+    }
+
+    /// Why: the marker distinguishes this segment from the neighbouring
+    /// `@<login>` gh segment; pin both the marker and the layout.
+    /// Test: itself.
+    #[test]
+    fn render_claude_account_segment_single() {
+        let seg = render_claude_account_segment(Some("masa@matsuoka.com")).expect("segment");
+        assert_eq!(seg, "\u{273b}masa@matsuoka.com");
+        assert!(!seg.starts_with('@'), "must not read as a gh login: {seg}");
+    }
+
+    /// Why: an absent or blank email omits the segment entirely.
+    /// Test: itself.
+    #[test]
+    fn render_claude_account_segment_absent() {
+        assert_eq!(render_claude_account_segment(None), None);
+        assert_eq!(render_claude_account_segment(Some("")), None);
+        assert_eq!(render_claude_account_segment(Some("  \t ")), None);
+    }
+
+    /// Why (#6304): every daemon-managed tm session sets `CLAUDE_CONFIG_DIR`,
+    /// and the account block under it differs from the one in `$HOME`. The
+    /// resolver must prefer it. Both inputs are passed in rather than exported:
+    /// `env_isolation_tests` bans this target from writing either variable,
+    /// because its tests share one process (#5544).
+    /// Test: itself.
+    #[test]
+    fn claude_json_path_prefers_config_dir() {
+        let resolved = claude_json_path_from(Some("/cfg"), Some(Path::new("/home/user")));
+        assert_eq!(resolved.as_deref(), Some(Path::new("/cfg/.claude.json")));
+    }
+
+    /// Why (#6304): an unset — or blank — `CLAUDE_CONFIG_DIR` must fall back to
+    /// `~/.claude.json`, which is where an unmanaged `claude` session logs in.
+    /// A blank one must not resolve to `/.claude.json`.
+    /// Test: itself.
+    #[test]
+    fn claude_json_path_falls_back_to_home() {
+        let home = Path::new("/home/user");
+        for cfg in [None, Some(""), Some("   ")] {
+            assert_eq!(
+                claude_json_path_from(cfg, Some(home)).as_deref(),
+                Some(Path::new("/home/user/.claude.json")),
+                "cfg={cfg:?}"
+            );
+        }
+        // No home and no config dir → nothing to read, segment omitted.
+        assert_eq!(claude_json_path_from(None, None), None);
+    }
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/statusline/account.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/statusline/account.rs
@@ -243,8 +243,8 @@ mod tests {
     /// Test: itself.
     #[test]
     fn render_claude_account_segment_single() {
-        let seg = render_claude_account_segment(Some("masa@matsuoka.com")).expect("segment");
-        assert_eq!(seg, "\u{273b}masa@matsuoka.com");
+        let seg = render_claude_account_segment(Some("someone@example.com")).expect("segment");
+        assert_eq!(seg, "\u{273b}someone@example.com");
         assert!(!seg.starts_with('@'), "must not read as a gh login: {seg}");
     }
 

--- a/crates/trusty-mpm/src/bin/tm/commands/statusline/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/statusline/mod.rs
@@ -4,13 +4,15 @@
 //! command; this handler parses the hook JSON from stdin and emits a compact
 //! ` | `-separated segment string on stdout. All fields degrade gracefully.
 //! What: reads a JSON object from stdin and renders the fixed-order layout
-//! `TM <ver> <port> | <project> ⎇ <branch> | @<gh> | <model> | ctx% | <cost> |
-//! <usage>` (#2011, extended #2140 with the trailing account-usage% segment)
+//! `TM <ver> ● | <project> ⎇ <branch> | @<gh> | ✻<account> | <model> | ctx% |
+//! <cost> | <usage>` (#2011, extended #2140 with the trailing account-usage%
+//! segment, #6304 dropped the daemon port and added the Claude Code account)
 //! to stdout. Missing or invalid fields produce empty/omitted segments;
 //! nothing ever panics or blocks the render path.
 //! Test: `render_statusline_minimal_input`, `render_statusline_full_payload`,
 //! `assemble_statusline_pins_segment_order_with_markers` in tests.
 
+pub(crate) mod account;
 // `pub(crate)` since #5539: `picker_delete_glob` reuses `branch`'s bounded
 // `tmux_session_name` probe rather than growing a second copy of it.
 pub(crate) mod branch;
@@ -19,7 +21,10 @@ mod usage;
 
 use std::io::Read as _;
 
+use std::path::Path;
+
 use crate::formatters::info_box::DaemonInfo;
+use account::{claude_account_segment_probe, claude_json_path};
 use branch::project_segment;
 use compaction::{ContextWindow, colorize_ctx_segment, compaction_segment};
 use usage::{RateLimits, usage_segment};
@@ -98,19 +103,36 @@ pub(crate) fn run_statusline() -> anyhow::Result<()> {
 /// results to the pure [`assemble_statusline`] lets the fixed segment ORDER be
 /// pinned by a deterministic unit test with hand-supplied strings, independent
 /// of real git/gh/daemon state.
-/// What: probes each of the seven segments (version+port, project+branch, gh
-/// account, model, ctx%, cost, account-usage%) in spec order and joins them
-/// via [`assemble_statusline`].
+/// What: probes each of the eight segments (version+daemon dot, project+branch,
+/// gh account, Claude Code account, model, ctx%, cost, account-usage%) in spec
+/// order and joins them via [`assemble_statusline`].
 /// Test: `render_statusline_minimal_input`, `render_statusline_full_payload`,
 /// `render_statusline_full_payload_matches_pipe_format`.
 pub(crate) fn render_statusline(input: &StatusInput) -> String {
+    render_statusline_from(input, claude_json_path().as_deref())
+}
+
+/// [`render_statusline`] against an explicit Claude Code config path.
+///
+/// Why (#6304): the account segment is the one probe whose source is a single
+/// file, so passing that path in makes both of its branches — account present,
+/// account underivable — assertable end to end. It has to be an injected path
+/// rather than a repointed `CLAUDE_CONFIG_DIR`: `env_isolation_tests` bans this
+/// target from writing that variable, since its tests share one process (#5544).
+/// What: identical to [`render_statusline`], except the account is read from
+/// `account_config` (or omitted when that is `None` or unreadable).
+/// Test: `render_statusline_shows_claude_account_when_config_is_present`.
+fn render_statusline_from(input: &StatusInput, account_config: Option<&Path>) -> String {
     // Lock-file read only — cheap and non-blocking; no HTTP session-count probe
     // is needed since the reformatted layout (#2011) no longer surfaces a count.
     let daemon = DaemonInfo::from_lock_file();
-    let version_port = version_port_segment(&daemon);
+    let version = version_segment(&daemon);
 
     let project = project_segment(&input.cwd);
     let gh = gh_account_segment_probe();
+    // #6304: the Claude Code account the session runs under; absent from the
+    // stdin payload, so it comes from Claude Code's own persisted config.
+    let account = claude_account_segment_probe(account_config);
     let model = model_segment(&input.model);
 
     // Compaction efficiency / live context fill; falls back to a bare
@@ -130,69 +152,63 @@ pub(crate) fn render_statusline(input: &StatusInput) -> String {
     // accounts (Claude Code simply omits `rate_limits` in those cases).
     let usage = usage_segment(input.rate_limits.as_ref());
 
-    assemble_statusline(version_port, project, gh, model, ctx, cost, usage)
+    assemble_statusline(version, project, gh, account, model, ctx, cost, usage)
 }
 
-/// Join the seven statusline segments in spec order, omitting absent ones.
+/// Join the eight statusline segments in spec order, omitting absent ones.
 ///
-/// Why (#2011 follow-up, extended #2140): separating ORDER + JOIN from the
-/// I/O-bound probes that produce each segment value is what makes the exact
-/// layout — `TM <ver> <port> | <project> ⎇ <branch> | @<gh> | <model> | ctx% |
-/// <cost> | <usage>` — pinned by a deterministic test using hand-supplied
-/// synthetic strings. Without this split, a future refactor could transpose
-/// or silently drop a middle segment and no test would catch it.
-/// What: takes the seven segments in fixed spec order (`version_port` is
-/// always present; the rest are `Option<String>`), filters out `None`s, and
-/// joins the survivors with ` | `. Pure — no I/O, no panics.
+/// Why (#2011 follow-up, extended #2140 and #6304): separating ORDER + JOIN
+/// from the I/O-bound probes that produce each segment value is what makes the
+/// exact layout — `TM <ver> ● | <project> ⎇ <branch> | @<gh> | ✻<account> |
+/// <model> | ctx% | <cost> | <usage>` — pinned by a deterministic test using
+/// hand-supplied synthetic strings. Without this split, a future refactor could
+/// transpose or silently drop a middle segment and no test would catch it.
+/// What: takes the eight segments in fixed spec order (`version` is always
+/// present; the rest are `Option<String>`), filters out `None`s, and joins the
+/// survivors with ` | `. Pure — no I/O, no panics.
 /// Test: `assemble_statusline_full_payload_pins_order_and_format`,
 /// `assemble_statusline_pins_segment_order_with_markers`,
 /// `assemble_statusline_omits_none_segments`.
 #[allow(clippy::too_many_arguments)]
 fn assemble_statusline(
-    version_port: String,
+    version: String,
     project: Option<String>,
     gh: Option<String>,
+    account: Option<String>,
     model: Option<String>,
     ctx: Option<String>,
     cost: Option<String>,
     usage: Option<String>,
 ) -> String {
-    [Some(version_port), project, gh, model, ctx, cost, usage]
+    [Some(version), project, gh, account, model, ctx, cost, usage]
         .into_iter()
         .flatten()
         .collect::<Vec<_>>()
         .join(" | ")
 }
 
-/// Build the leading `TM <ver> <port>` segment.
+/// Build the leading `TM <ver> ●` segment.
 ///
-/// Why (#2011): the statusline reformat replaces the old `tm ●:<port>` /
-/// `tm ○` online-indicator glyphs with a plain-text `TM <ver> <port>` lead-in;
-/// the version always renders (it is a compile-time constant) so the segment
-/// degrades gracefully to just `TM <ver>` when the daemon is offline or its
-/// port cannot be parsed, rather than showing a stale or misleading port.
-/// What: reads `env!("CARGO_PKG_VERSION")` and appends the port parsed from
-/// `daemon.addr` (`host:port` → `port`) only when `daemon.online` is true and
-/// a port is present.
-/// Test: `version_port_segment_online_includes_port`,
-/// `version_port_segment_offline_omits_port`.
-fn version_port_segment(daemon: &DaemonInfo) -> String {
+/// Why (#6304): the port this segment used to append is not something an
+/// operator can act on from a status bar, and it invites port-based connection
+/// attempts the daemon's transport no longer guarantees. Its only other job was
+/// implicit — it appeared ONLY when the daemon was online, so its presence was
+/// the reachability indicator. Dropping it outright would take that bit with
+/// it, so the port is replaced by a bare `●`, which says the same thing in one
+/// column and names nothing that can go stale. (#2011 introduced the
+/// `TM <ver> <port>` form this replaces.)
+/// What: reads `env!("CARGO_PKG_VERSION")` and appends `●` when
+/// `daemon.online`; an offline or absent daemon renders `TM <ver>` alone.
+/// Test: `version_segment_online_shows_dot_not_port`,
+/// `version_segment_offline_omits_dot`,
+/// `render_statusline_never_contains_the_daemon_port`.
+fn version_segment(daemon: &DaemonInfo) -> String {
     let ver = env!("CARGO_PKG_VERSION");
-    match daemon_port(daemon) {
-        Some(port) if daemon.online => format!("TM {ver} {port}"),
-        _ => format!("TM {ver}"),
+    if daemon.online {
+        format!("TM {ver} \u{25cf}")
+    } else {
+        format!("TM {ver}")
     }
-}
-
-/// Extract the bare port substring from a `host:port` daemon address.
-///
-/// Why: centralises the `rfind(':')` parse so `version_port_segment` stays
-/// focused on assembly rather than string surgery.
-/// What: returns everything after the last `:`, or `None` when `addr` has no
-/// colon (e.g. empty/unset).
-/// Test: `version_port_segment_online_includes_port` (via the parsed port).
-fn daemon_port(daemon: &DaemonInfo) -> Option<&str> {
-    daemon.addr.rfind(':').map(|i| &daemon.addr[i + 1..])
 }
 
 // ── Segment builders ──────────────────────────────────────────────────────────
@@ -363,9 +379,10 @@ mod tests {
     #[test]
     fn assemble_statusline_full_payload_pins_order_and_format() {
         let out = assemble_statusline(
-            "TM 1.2.3 7880".to_string(),
+            "TM 1.2.3 \u{25cf}".to_string(),
             Some("bobmatnyc/trusty-tools \u{2387} main".to_string()),
             Some("@bobmatnyc".to_string()),
+            Some("\u{273b}someone@example.com".to_string()),
             Some("Claude Sonnet 4.6".to_string()),
             Some("ctx 41%".to_string()),
             Some("$1.23".to_string()),
@@ -373,7 +390,7 @@ mod tests {
         );
         assert_eq!(
             out,
-            "TM 1.2.3 7880 | bobmatnyc/trusty-tools \u{2387} main | @bobmatnyc | Claude Sonnet 4.6 | ctx 41% | $1.23 | \u{23f3}24% \u{1f4c5}41%"
+            "TM 1.2.3 \u{25cf} | bobmatnyc/trusty-tools \u{2387} main | @bobmatnyc | \u{273b}someone@example.com | Claude Sonnet 4.6 | ctx 41% | $1.23 | \u{23f3}24% \u{1f4c5}41%"
         );
     }
 
@@ -383,14 +400,15 @@ mod tests {
     /// model) produces a different, easily-diffed string rather than two
     /// plausible-looking segments that a reviewer might not notice swapped.
     /// What: asserts both the exact joined string AND the split-on-` | `
-    /// vector equal `[version_port, project, gh, model, ctx, cost]`.
+    /// vector equal `[version, project, gh, account, model, ctx, cost, usage]`.
     /// Test: itself.
     #[test]
     fn assemble_statusline_pins_segment_order_with_markers() {
         let out = assemble_statusline(
-            "VERSION_PORT".to_string(),
+            "VERSION".to_string(),
             Some("PROJECT".to_string()),
             Some("GH".to_string()),
+            Some("ACCOUNT".to_string()),
             Some("MODEL".to_string()),
             Some("CTX".to_string()),
             Some("COST".to_string()),
@@ -398,37 +416,42 @@ mod tests {
         );
         assert_eq!(
             out,
-            "VERSION_PORT | PROJECT | GH | MODEL | CTX | COST | USAGE"
+            "VERSION | PROJECT | GH | ACCOUNT | MODEL | CTX | COST | USAGE"
         );
         assert_eq!(
             out.split(" | ").collect::<Vec<_>>(),
             vec![
-                "VERSION_PORT",
-                "PROJECT",
-                "GH",
-                "MODEL",
-                "CTX",
-                "COST",
-                "USAGE"
+                "VERSION", "PROJECT", "GH", "ACCOUNT", "MODEL", "CTX", "COST", "USAGE"
             ],
-            "segment order must exactly match [version_port, project, gh, model, ctx, cost, usage]"
+            "segment order must exactly match [version, project, gh, account, model, ctx, cost, usage]"
         );
     }
 
-    /// Why (#2011 follow-up): every segment except `version_port` must be
-    /// omittable independently without leaving a stray/empty ` | ` pair, and
-    /// omitting all of them must fall back to just the lead-in segment.
+    /// Why (#2011 follow-up): every segment except `version` must be omittable
+    /// independently without leaving a stray/empty ` | ` pair, and omitting all
+    /// of them must fall back to just the lead-in segment.
     /// Test: itself.
     #[test]
     fn assemble_statusline_omits_none_segments() {
         // All optional segments absent → only the lead-in segment appears.
-        let out = assemble_statusline("TM 1.2.3".to_string(), None, None, None, None, None, None);
+        let out = assemble_statusline(
+            "TM 1.2.3".to_string(),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
         assert_eq!(out, "TM 1.2.3");
 
-        // A gap in the middle (gh absent) must not leave an empty separator pair.
+        // Gaps in the middle (gh and account absent) must not leave empty
+        // separator pairs.
         let out = assemble_statusline(
             "TM 1.2.3".to_string(),
             Some("proj".to_string()),
+            None,
             None,
             Some("model".to_string()),
             None,
@@ -438,28 +461,56 @@ mod tests {
         assert_eq!(out, "TM 1.2.3 | proj | model | $0.50");
     }
 
-    /// Why (#2011): `version_port_segment` must append the parsed port only
-    /// when the daemon is online, matching the `TM <ver> <port>` spec.
+    /// Why (#6304, branch a): an online daemon must render the bare `●`
+    /// reachability dot and NOT the port — the port is what this issue removes,
+    /// and this exact input (`127.0.0.1:7880`, online) is what used to produce
+    /// it.
     /// Test: itself.
     #[test]
-    fn version_port_segment_online_includes_port() {
+    fn version_segment_online_shows_dot_not_port() {
         let daemon = DaemonInfo {
             addr: "127.0.0.1:7880".to_string(),
             online: true,
             session_count: None,
         };
-        let seg = version_port_segment(&daemon);
-        assert_eq!(seg, format!("TM {} 7880", env!("CARGO_PKG_VERSION")));
+        let seg = version_segment(&daemon);
+        assert_eq!(seg, format!("TM {} \u{25cf}", env!("CARGO_PKG_VERSION")));
+        assert!(!seg.contains("7880"), "port must not appear: {seg}");
     }
 
-    /// Why (#2011): an offline/absent daemon must degrade to `TM <ver>` alone
-    /// rather than showing a stale or empty port.
+    /// Why (#2011, kept by #6304): an offline/absent daemon degrades to
+    /// `TM <ver>` alone — no dot, and still no port.
     /// Test: itself.
     #[test]
-    fn version_port_segment_offline_omits_port() {
+    fn version_segment_offline_omits_dot() {
         let daemon = DaemonInfo::default();
-        let seg = version_port_segment(&daemon);
+        let seg = version_segment(&daemon);
         assert_eq!(seg, format!("TM {}", env!("CARGO_PKG_VERSION")));
+        assert!(!seg.contains('\u{25cf}'), "no dot when offline: {seg}");
+    }
+
+    /// Why (#6304, branch a): the closure condition is that NO daemon state
+    /// renders a port, so drive the whole line for both states rather than only
+    /// the lead-in segment builder. The live daemon's address is supplied
+    /// explicitly so the assertion holds on a machine where the daemon is down.
+    /// Test: itself.
+    #[test]
+    fn render_statusline_never_contains_the_daemon_port() {
+        for online in [true, false] {
+            let daemon = DaemonInfo {
+                addr: "http://127.0.0.1:7880".to_string(),
+                online,
+                session_count: None,
+            };
+            let seg = version_segment(&daemon);
+            assert!(
+                !seg.contains("7880") && !seg.contains(':'),
+                "no port or host:port remnant (online={online}): {seg}"
+            );
+        }
+        // And end to end, with whatever the real lock file says.
+        let out = render_statusline(&full_input());
+        assert!(!out.contains("7880"), "no port in the rendered line: {out}");
     }
 
     /// Why: a single logged-in account renders `@<login>` with no warning mark.
@@ -503,7 +554,13 @@ mod tests {
         let mut input = full_input();
         input.model = ModelInfo::default();
         let out = render_statusline(&input);
-        assert!(!out.contains("claude"), "model segment must be omitted");
+        // #6304: assert the absence of the model strings themselves rather than
+        // the substring "claude" — the line now also carries the Claude Code
+        // account, whose email is outside this test's control.
+        assert!(
+            !out.contains("claude-sonnet-4-6") && !out.contains("Claude Sonnet 4.6"),
+            "model segment must be omitted: {out}"
+        );
         assert!(out.starts_with("TM "), "TM <ver> segment must still appear");
         assert!(out.contains("$1.23"), "cost must still appear");
     }
@@ -576,6 +633,43 @@ mod tests {
         let out = render_statusline(&input);
         // No compaction/ctx segment because session_id is empty
         assert!(!out.contains("ctx "), "no ctx segment without session_id");
+    }
+
+    /// Why (#6304, branches b and c): end-to-end proof that the Claude Code
+    /// account reaches the rendered line from Claude Code's own persisted
+    /// config, and that a config file that is not there omits the segment
+    /// instead of rendering a placeholder. The path is injected, so nothing
+    /// here depends on the operator's home directory or login state — and
+    /// nothing writes `CLAUDE_CONFIG_DIR`, which this target bans (#5544).
+    /// Test: itself.
+    #[test]
+    fn render_statusline_shows_claude_account_when_config_is_present() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let cfg = dir.path().join(".claude.json");
+
+        // Nothing at the path yet → segment omitted.
+        let absent = render_statusline_from(&full_input(), Some(&cfg));
+        assert!(
+            !absent.contains('\u{273b}'),
+            "account segment must be omitted with no config: {absent}"
+        );
+        // No path at all (neither CLAUDE_CONFIG_DIR nor a home dir resolvable).
+        let none = render_statusline_from(&full_input(), None);
+        assert!(
+            !none.contains('\u{273b}'),
+            "account segment must be omitted with no config path: {none}"
+        );
+
+        std::fs::write(
+            &cfg,
+            r#"{"oauthAccount": {"emailAddress": "someone@example.com"}}"#,
+        )
+        .expect("write config");
+        let present = render_statusline_from(&full_input(), Some(&cfg));
+        assert!(
+            present.contains("\u{273b}someone@example.com"),
+            "account segment must appear once the config names one: {present}"
+        );
     }
 
     /// Why (#2140): end-to-end check that `rate_limits` flows from


### PR DESCRIPTION
Refs #6304. Statusline `version` segment no longer renders the daemon TCP port; `●` marks daemon reachability (the one bit the port carried). New account segment `✻<email>` read from the `oauthAccount` block of `$CLAUDE_CONFIG_DIR/.claude.json` (fallback `~/.claude.json`) — Claude Code's statusline stdin contract carries no account field. Segment omitted when not derivable. Source injected as a path so tests never touch the real home directory.

Before: ` TM 1.5.3 7880`. After: `TM 1.5.4 ● | bobmatnyc/trusty-tools ⎇ tm-dogfood | @bobmatnyc⚠ | ✻<email> | Opus 5 | $1.23`.

Note: the tm daemon itself still binds TCP (UDS migration for trusty-mpm is #6288); the port is obsolete as statusline content, not yet as transport. The account email is visible on screen during screen shares — by design of the request.

Test ladder rung 3: `cargo fmt --check`, `cargo clippy -p trusty-mpm --all-targets -- -D warnings`, `cargo test -p trusty-mpm` (5277 lib + 1868 bin passed, 0 failed), `check_line_cap.sh`, `check_sld.sh`, `check_changelog_fragment.sh` — all exit 0. Regression tests that fail pre-change: `render_statusline_never_contains_the_daemon_port`, `render_statusline_shows_claude_account_when_config_is_present`, `account_segment_renders_email_from_config`.

Changelog fragment: `crates/trusty-mpm/changelog.d/6304-statusline-account.md`. No version bump (release train in progress).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools