### PR TITLE
fix: drop tga's SemVer-gate exclusion now that trusty-analyze depends on it; tga 4.0.1→4.0.2 (stranded tag)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10262,7 +10262,7 @@ dependencies = [
 
 [[package]]
 name = "tga"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,11 +140,12 @@ trusty-embedderd = { path = "crates/trusty-embedderd", version = "0.3.11", defau
 # per-palace subprocess never ran in any shipped configuration, and its index is
 # now `trusty_memory::bm25_lane::Bm25Lane`, in-process.
 # tga: trusty-git-analytics — developer productivity analytics, and (since
-# #5468) the sole owner of contributor profiling. No workspace member takes a
-# Cargo edge on it: #5466 removed trusty-review's, and the tga -> trusty-review
-# direction is a PATH lookup, not a manifest edge (#5236, DOC-67 §6). The entry
-# stays so a future in-tree consumer resolves from source rather than crates.io.
-tga = { path = "crates/trusty-git-analytics", version = "4.0.0" }
+# #5468) the sole owner of contributor profiling. #5466 removed trusty-review's
+# Cargo edge, and the tga -> trusty-review direction is a PATH lookup, not a
+# manifest edge (#5236, DOC-67 §6). One in-tree Cargo edge exists again: #6294
+# made `tga` a dev-dependency of trusty-analyze, which is why tga no longer has
+# a row in scripts/semver-checks-crate-exclusions.tsv (#6300).
+tga = { path = "crates/trusty-git-analytics", version = "4.0.2" }
 # trusty-mpm: unified crate (replaces the former trusty-mpm-{core,mcp,client,
 # daemon,cli,tui,telegram} sub-crates). The gui sub-crate is kept separate
 # because it owns Tauri's build.rs and tauri.conf.json.

--- a/crates/trusty-git-analytics/Cargo.toml
+++ b/crates/trusty-git-analytics/Cargo.toml
@@ -31,7 +31,13 @@ name = "tga"
 # PATCH — the derives change but the API surface does not: the same six structs
 # still implement `Serialize` over the same fields, with the same names and the
 # same types. What changes is the value written for a credential.
-version = "4.0.1"
+#
+# 4.0.1 → 4.0.2 (#6300): no code change. `tga-v4.0.1` is pinned by a protected
+# ruleset (#6178) to 8d9e5cfb9, and this branch's exclusion-row removal lands
+# after it, so `preflight-publish.sh` CHECK 6 (tag/publish commit parity) can
+# never be satisfied at that tag. 4.0.1 is a burned version number and the
+# release moves forward to a gate-clean commit.
+version = "4.0.2"
 publish = true
 edition = "2021"
 # Aligned with the workspace MSRV (1.94) per #254. Required for

--- a/crates/trusty-git-analytics/changelog.d/6300-semver-exclusion-4.0.2.md
+++ b/crates/trusty-git-analytics/changelog.d/6300-semver-exclusion-4.0.2.md
@@ -1,0 +1,10 @@
+Changed
+
+- Version skipped from 4.0.1 to 4.0.2 with no code change, and tga's row in
+  `scripts/semver-checks-crate-exclusions.tsv` is removed. The row claimed no
+  workspace package links tga as a library; #6294 made tga a dev-dependency of
+  trusty-analyze, so the gate refused the skip and `check_semver.sh --crate tga`
+  exited 3 with no verdict on every tga branch. tga is compared against the
+  registry like any other crate now. The `tga-v4.0.1` tag is pinned to the
+  commit that predates this fix, and #6178 makes a release tag here immovable,
+  so 4.0.1 is spent.

--- a/scripts/semver-checks-crate-exclusions.tsv
+++ b/scripts/semver-checks-crate-exclusions.tsv
@@ -29,9 +29,8 @@
 #
 # <crate>	<reason>
 trusty-mpm	binary-only consumer surface: installed as the `tm` executable via `cargo install trusty-mpm`, and a binary user gets a whole new executable, so library API compatibility is meaningless to them. Zero workspace packages depend on it (re-checked by the gate) and crates.io reported 0 reverse dependencies on 2026-08-12.
-# tga: owner ruling 2026-08-19 — no major bump; tga lib API has no external
-# linking consumers; ships 3.2.0. The 3.0.0 baseline delta that ruling covers is
-# `constructible_struct_adds_field` on `DdRepositoryEntry.authorship`
-# (src/report/dd_manifest.rs) and `struct_marked_non_exhaustive` on
-# `GithubConfig`, `JiraConfig` and `PmTicket`.
-tga	binary-only consumer surface: installed as the `tga` executable via `cargo install tga`, and a binary user gets a whole new executable, so library API compatibility is meaningless to them. trusty-audit drives `tga audit` as a child process and resolves it by version at runtime, which is a PATH lookup and not a Cargo edge (#5236, DOC-67 §6). Zero workspace packages depend on it (re-checked by the gate) and crates.io reported 0 reverse dependencies on 2026-08-19.
+# #6300: the `tga` row is REMOVED, not commented out. It claimed zero workspace
+# packages depend on tga's library; #6294 gave trusty-analyze a `tga` Cargo edge,
+# so the gate refused the skip and exited 3 on every tga run. The claim is dead,
+# and tga is gated like any other crate now. Do not re-add the row while that
+# edge exists — the gate re-checks the premise and will refuse again.


### PR DESCRIPTION
Refs #6300. `scripts/preflight-publish.sh tga` CHECK 5 failed closed during the 2026-08-27 publish train: `EXCLUSION NO LONGER HOLDS — tga is excluded from the SemVer gate because nothing depends on its library, but these workspace crates now do: trusty-analyze` (dev-dependency added by #6294). The `tga` row in `scripts/semver-checks-crate-exclusions.tsv` is removed (tombstone comment left); the check is untouched.

Tag `tga-v4.0.1` was pushed at 8d9e5cfb9 before the block surfaced; tags are immutable (#6178) and main moves past that commit, so 4.0.1 is skipped: tga → 4.0.2 (crate + root workspace pin + Cargo.lock). Changelog fragment `crates/trusty-git-analytics/changelog.d/6300-semver-exclusion-4.0.2.md`.

Evidence: `bash scripts/check_semver.sh --crate tga` now reports `compared=1 … blind=0` (3.3.3 → 4.0.2 is already a major; three breaking findings from #6294/#5775 are covered by it, advisory). Preflight CHECK 5 `[PASS]`. `cargo fmt --check`, `cargo check -p tga -p trusty-analyze`, `check_changelog_fragment.sh`, `check-version-parity.sh` all exit 0.

Test ladder rung 1–3 (metadata + gate config). HELD AS DRAFT until the running publish train completes; then ready + squash auto-merge, then publish tga 4.0.2.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools