### PR TITLE
fix(trusty-audit): per-repo completion marker so an interrupted repository is re-audited (Refs #6141)

### DIFF
--- a/crates/trusty-audit/changelog.d/6141-per-repo-completion-marker.md
+++ b/crates/trusty-audit/changelog.d/6141-per-repo-completion-marker.md
@@ -1,0 +1,16 @@
+Fixed
+
+- A repository's output directory carries an `audit-complete.toml` marker,
+  written last and only for a repository the run got all the way through, and a
+  re-run re-collects any recorded output that does not have one. `manifest.toml`
+  was the only evidence a directory held, and it is written by the `tga audit`
+  child before the grounding pass and the inference stamp edit it — so a run
+  killed in between left real collection data and a report that was never
+  finished, which `verify_output` accepts and a re-run carried over as complete.
+  Completion was recorded only in `state/run-progress.toml`, one document for the
+  whole sweep, so nothing about the directory itself said which it was; the
+  marker makes that answer travel with the data, for a directory copied,
+  inspected or re-rendered on its own. The re-collection is announced with its
+  reason rather than being silent, and a record written before the marker existed
+  is re-collected once — the same direction `RunProgress::complete` takes for the
+  same reason (#6141)

--- a/crates/trusty-audit/src/run.rs
+++ b/crates/trusty-audit/src/run.rs
@@ -139,7 +139,7 @@ pub(crate) mod git_credentials;
 use approve::approve_for_indexing;
 use child::spawn_tga;
 use pins::{PinnedBinaries, pinned_binaries};
-use verify::verify_output;
+use verify::{mark_complete, verify_output};
 
 // Re-exported at its historical path: `crate::rerender`, `crate::distribute`,
 // `crate::session` and both `cli` submodules name it as `crate::run::…`.
@@ -716,6 +716,13 @@ async fn run_one(
                 repo.name
             ));
         }
+    }
+    // #6141: the marker is the LAST thing written, and only for a repository
+    // that got all the way through. Until it is there the directory holds
+    // collection data and an unfinished report, which is what an interrupted run
+    // leaves and what used to be indistinguishable from a finished one.
+    if matches!(result, RepoResult::Succeeded) {
+        mark_complete(&output, &repo.name)?;
     }
     progress.unit_finished(
         Operation::Sweep,
@@ -3025,6 +3032,64 @@ trusty-review = "0.15.1"
             "a repository at a new position writes a new output and must be re-audited"
         );
         assert_eq!(second.resumed().count(), 0, "{second:?}");
+    }
+
+    /// Why (#6141): the interrupted-run case. `tga audit` writes the manifest,
+    /// then the grounding pass and the inference stamp edit it — kill the run in
+    /// between and the directory holds real collection data and a report that was
+    /// never finished, which `verify_output` accepts because the manifest is
+    /// there and names a repository. A re-run then carried it over and the
+    /// engagement shipped a repository nothing had finished.
+    /// What: audit one repository, remove its completion marker to leave exactly
+    /// what an interrupted run leaves, and re-run. It must be audited again
+    /// rather than resumed, and the reason must be stated rather than silent.
+    /// Test: this is the test.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn an_interrupted_repository_is_re_audited_not_carried_over() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        two_repos_ready(&work, NEVER);
+        select(&work, &[("acme-api", "repos/acme-api")]);
+
+        let first = sweep(&work, &config(), &RunOptions::default(), &Progress::none())
+            .await
+            .expect("the sweep completes");
+        assert_eq!(first.status, RunStatus::AllSucceeded, "{first:?}");
+        assert_eq!(invocations(&work).len(), 1);
+        let output = first.repos[0].output.clone();
+        assert!(
+            output.join(verify::COMPLETION_FILE).is_file(),
+            "a finished repository must say so in its own directory: {output:?}"
+        );
+
+        // Exactly what a run killed after the child and before the end leaves:
+        // the manifest is there, the marker is not.
+        std::fs::remove_file(output.join(verify::COMPLETION_FILE)).expect("remove the marker");
+        assert!(
+            output.join(AuditManifest::FILE_NAME).is_file(),
+            "{output:?}"
+        );
+
+        let (recorder, progress) = Recorder::new();
+        let second = sweep(&work, &config(), &RunOptions::default(), &progress)
+            .await
+            .expect("the sweep completes");
+        assert_eq!(
+            invocations(&work).len(),
+            2,
+            "an unfinished repository must be audited again, not carried over"
+        );
+        assert!(!second.repos[0].resumed, "{:?}", second.repos[0]);
+        assert_eq!(second.resumed().count(), 0, "{second:?}");
+        assert!(
+            recorder.stages().iter().any(|e| e
+                .detail
+                .as_deref()
+                .is_some_and(|d| d.contains("did not finish"))),
+            "the re-collection must be announced: {:?}",
+            recorder.stages()
+        );
     }
 
     /// Why (#5494): the operator's override. A recipient who re-cloned their

--- a/crates/trusty-audit/src/run/checkpoint.rs
+++ b/crates/trusty-audit/src/run/checkpoint.rs
@@ -44,6 +44,7 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 
 use super::github_issues::GithubCredentialRecord;
+use super::verify::is_complete;
 use super::{RepoRun, RunReport, RunStatus, SelectedRepo, stem, verify_output};
 use crate::error::AuditError;
 use crate::workdir::{self, Area, WorkDir};
@@ -198,6 +199,9 @@ pub enum Recollect {
     OutputGone(String),
     /// The operator asked for a full re-collection.
     Forced,
+    /// The recorded output has no completion marker: an earlier run wrote it and
+    /// did not get to the end of that repository (#6141).
+    Unfinished,
 }
 
 impl Recollect {
@@ -208,6 +212,9 @@ impl Recollect {
             Self::Failed => "the earlier run recorded it as failed — retrying".to_owned(),
             Self::OutputGone(why) => format!("its recorded output is no longer usable: {why}"),
             Self::Forced => "`--fresh` was asked for".to_owned(),
+            Self::Unfinished => {
+                "an earlier run did not finish this repository — re-collecting".to_owned()
+            }
         }
     }
 }
@@ -275,6 +282,17 @@ pub(super) fn plan(
             // still has. Re-verifying re-reads the gaps too, so a carried-over
             // entry states what its manifest states today.
             match verify_output(&entry.output) {
+                // #6141: the manifest alone is not completion. The grounding
+                // pass and the inference stamp both run after `tga audit` wrote
+                // it, so a run killed between them leaves a directory this check
+                // accepts and no finished report. The marker is written last,
+                // and its absence is what says so. Asked AFTER `verify_output`
+                // so a deleted or unreadable output still gets that check's
+                // specific reason rather than this one's. A record from before
+                // the marker existed has none either, and is re-collected once —
+                // the same direction `RunProgress::complete` takes, for the same
+                // reason.
+                Ok(_) if !is_complete(&entry.output) => Err(Recollect::Unfinished),
                 Ok(gaps) => Ok(RepoRun {
                     gaps,
                     resumed: true,

--- a/crates/trusty-audit/src/run/verify.rs
+++ b/crates/trusty-audit/src/run/verify.rs
@@ -15,6 +15,7 @@
 
 use std::path::Path;
 
+use crate::error::AuditError;
 use crate::manifest::AuditManifest;
 
 /// The gap line `tga` writes when a collection stage failed but the sweep
@@ -94,4 +95,53 @@ pub(super) fn verify_output(output: &Path) -> Result<Vec<String>, String> {
         ));
     }
     Ok(manifest.report.gaps)
+}
+
+/// The file a repository's output directory carries once its audit finished.
+///
+/// Why (#6141): `manifest.toml` says a `tga audit` child wrote something, not
+/// that the run got through the rest of the repository — the grounding pass and
+/// the inference stamp both run after it, and both edit that same manifest. A
+/// run killed in between leaves a directory holding real collection data and no
+/// finished report, which at a glance is what a completed repository looks
+/// like. Completion was recorded only in `state/run-progress.toml`, one document
+/// for the whole sweep, so nothing about the DIRECTORY said which it was.
+/// What: a marker file inside the output directory itself, so the answer travels
+/// with the data — a directory copied, inspected or re-rendered on its own still
+/// says whether it is finished.
+pub(super) const COMPLETION_FILE: &str = "audit-complete.toml";
+
+/// Record that this repository's output directory is finished.
+///
+/// Why/What: see [`COMPLETION_FILE`]. Written LAST, after the child, the
+/// grounding pass and the inference stamp, so its presence means every writer of
+/// this directory has run. Written atomically, because a half-written marker on
+/// a killed run is the ambiguity this removes.
+/// Test: `super::run_tests::an_interrupted_repository_is_re_audited_not_carried_over`.
+///
+/// # Errors
+///
+/// [`AuditError::WorkDir`] naming the marker that could not be written. This is
+/// a sweep-level failure rather than a per-repository one: a run that cannot
+/// record completion would carry the repository over next time on the strength
+/// of a marker that is not there, which is the defect in reverse.
+pub(super) fn mark_complete(output: &Path, repo: &str) -> Result<(), AuditError> {
+    let text = format!(
+        "repository = {repo:?}\nfinished = {finished:?}\ntrusty_audit = {version:?}\n",
+        finished = crate::index_report::local_now(),
+        version = env!("CARGO_PKG_VERSION"),
+    );
+    crate::workdir::write_atomically(&output.join(COMPLETION_FILE), &text)
+}
+
+/// Whether this output directory carries the completion marker.
+///
+/// A directory with no marker is not necessarily broken — one written before
+/// this file existed has none — so the caller decides what to do about it.
+/// [`super::checkpoint::plan`] re-audits it, which is the safe direction: it
+/// costs one repository's collection once, where believing it costs a report
+/// that was never rendered.
+/// Test: `super::run_tests::an_interrupted_repository_is_re_audited_not_carried_over`.
+pub(super) fn is_complete(output: &Path) -> bool {
+    output.join(COMPLETION_FILE).is_file()
 }


### PR DESCRIPTION
## What
a repository writes `out/<stem>/audit-complete.toml` last and only on success; `checkpoint::plan` re-collects any recorded output without one via `Recollect::Unfinished`, announced with its reason; the marker check sits after `verify_output`.

Refs #6141

## Test ladder
Rung 3 (localized to `crates/trusty-audit`). Ran `cargo fmt --check`, `cargo clippy -p trusty-audit --all-targets -- -D warnings`, `cargo test -p trusty-audit`: 740 passed; 0 failed; 5 ignored, 10 targets `test result: ok`, fragment gate OK.
Regression: `an_interrupted_repository_is_re_audited_not_carried_over` → `assertion left == right failed: an unfinished repository must be audited again, not carried over — left: 1, right: 2`.
Version bump is carried by #6321; if the version-bump gate is red here, update-branch after that PR lands.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools