### PR TITLE
chore: ignore root engagement.toml manifests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,6 @@ docs/certificates/*.mobileprovision
 .trusty-mpm/last-instructions.md
 # <<< trusty-mpm harness scaffolding <<<
 
+# trusty-audit engagement manifests carry provider keys — never commit
+/engagement.toml
+/engagement.toml.lock


### PR DESCRIPTION
## What
Root-anchored `.gitignore` entries for `engagement.toml` and `engagement.toml.lock`. A trusty-audit engagement manifest carries the provider key, and the one in the repo-root working tree is one `git add -A` from a commit.

## Test ladder
Rung 1 (config-only). `git check-ignore -v` matches both names; `git ls-files` shows no tracked file affected.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools