### PR TITLE
fix(trusty-memory): a KG fact already rendered in tier S is not rendered again (Refs #5879)

### DIFF
--- a/crates/trusty-memory/changelog.d/5879-kg-facts-dedup.md
+++ b/crates/trusty-memory/changelog.d/5879-kg-facts-dedup.md
@@ -1,0 +1,3 @@
+Fixed
+
+- The injected "Relevant KG facts" section no longer reprints a fact the Tier S block above it already showed. Tier S gathers hot predicates across every palace and the KG section gathers them from the current one, so the second was a subset of the first and every overlapping fact was rendered twice on every prompt of every session. It cost nothing only while no palace held a hot triple — the first `kg_assert` with a hot predicate started the bill. Both sides now render a bullet through one `prompt_facts::hot_fact_bullet`, so the comparison cannot drift, and the section is kept rather than dropped because the two sources genuinely disagree when a palace's KG fails to read or the global fetch fails ([#5879](https://github.com/bobmatnyc/trusty-tools/issues/5879))

--- a/crates/trusty-memory/src/commands/prompt_context/format.rs
+++ b/crates/trusty-memory/src/commands/prompt_context/format.rs
@@ -103,6 +103,34 @@ pub(super) const KG_SECTION_BYTE_CAP: usize = 256;
 /// `compose_injection_is_silent_when_everything_was_withheld`,
 /// `compose_injection_empty_inputs_yields_empty`,
 /// `prompt_context_recalls_palace_drawers`.
+/// The bullet lines the Tier S block already printed.
+///
+/// Why (#5879): `gather_hot_facts` admits hot predicates from EVERY palace and
+/// `select_relevant_triples` admits them from the CURRENT one, so the KG section
+/// is a subset of the Tier S block above it and re-rendered whatever the two
+/// shared. That cost nothing only while no palace held a hot triple; the first
+/// `kg_assert` with a hot predicate makes every prompt of every session pay for
+/// the duplicate.
+///
+/// The section stays rather than being deleted, because the two sources can
+/// genuinely disagree: `gather_hot_facts` logs and SKIPS a palace whose KG fails
+/// to read, and this whole block is `None` when the global fetch fails, and in
+/// both cases the KG section is the only thing carrying the fact.
+///
+/// What: the trimmed text of every `- ` line in the block, as a set. Comparing
+/// whole lines rather than substrings is deliberate — a short object like
+/// `- tm` would substring-match half the block.
+/// Test: `compose_injection_drops_a_kg_fact_tier_s_already_rendered`,
+/// `compose_injection_keeps_a_kg_fact_tier_s_did_not_render`.
+fn tier_s_bullets(global_facts: Option<&str>) -> std::collections::HashSet<&str> {
+    global_facts
+        .into_iter()
+        .flat_map(|facts| facts.lines())
+        .map(str::trim)
+        .filter(|line| line.starts_with("- "))
+        .collect()
+}
+
 pub(super) fn compose_injection(
     global_facts: Option<&str>,
     drawers: &[RecalledDrawer],
@@ -139,9 +167,16 @@ pub(super) fn compose_injection(
         push_section(&mut out, section.trim_end());
     }
     if !triples.is_empty() {
+        // #5879: what Tier S already printed must not be printed again.
+        let already_shown = tier_s_bullets(global_facts);
         let mut section = String::from("## Relevant KG facts\n");
         let mut rendered = 0usize;
         for t in triples {
+            if already_shown.contains(
+                crate::prompt_facts::hot_fact_bullet(&t.subject, &t.predicate, &t.object).trim(),
+            ) {
+                continue;
+            }
             let line = format!("- {} **{}** {}\n", t.subject, t.predicate, t.object);
             // #5819 (ADR-0028 D7): the KG section gets its own byte budget, so
             // a palace with many hot triples cannot crowd out drawer recall.

--- a/crates/trusty-memory/src/commands/prompt_context/tests.rs
+++ b/crates/trusty-memory/src/commands/prompt_context/tests.rs
@@ -2135,3 +2135,92 @@ async fn prompt_context_logs_recall_query_shape() {
 
     addr_handle.shutdown().await;
 }
+
+// ---------------------------------------------------------------------------
+// #5879 — the KG section must not reprint what Tier S already printed
+// ---------------------------------------------------------------------------
+
+/// Why (#5879): `gather_hot_facts` admits hot predicates across every palace and
+/// `select_relevant_triples` admits them from the current one, so every triple
+/// the "Relevant KG facts" section can emit is already in the Tier S block above
+/// it. It cost nothing only while no palace held a hot triple — the first
+/// `kg_assert` with a hot predicate makes every prompt of every session pay for
+/// the duplicate render.
+/// What: renders a Tier S block through the real `build_prompt_context`, hands
+/// `compose_injection` the same triple, and asserts the fact appears once.
+/// Test: itself.
+#[test]
+fn compose_injection_drops_a_kg_fact_tier_s_already_rendered() {
+    use filter::RawTriple;
+    let tier_s = crate::prompt_facts::build_prompt_context(&[(
+        "tga".to_string(),
+        "is_alias_for".to_string(),
+        "trusty-git-analytics".to_string(),
+    )]);
+    assert!(
+        tier_s.contains("trusty-git-analytics"),
+        "the fixture must actually render the fact: {tier_s}"
+    );
+
+    let out = format::compose_injection(
+        Some(&tier_s),
+        &[],
+        0,
+        &[RawTriple {
+            subject: "tga".into(),
+            predicate: "is_alias_for".into(),
+            object: "trusty-git-analytics".into(),
+        }],
+        None,
+    );
+
+    assert_eq!(
+        out.matches("trusty-git-analytics").count(),
+        1,
+        "the fact must be rendered once, not once per section: {out}"
+    );
+    assert!(
+        !out.contains("## Relevant KG facts"),
+        "a section with nothing left to say must not emit its heading: {out}"
+    );
+}
+
+/// Why (#5879): dropping the section outright was the other way out and is
+/// wrong — `gather_hot_facts` logs and SKIPS a palace whose KG fails to read,
+/// and the whole Tier S block is absent when the global fetch fails. In both
+/// cases the KG section is the only thing carrying the fact.
+/// What: gives Tier S one fact and the KG section a different one; asserts both
+/// survive.
+/// Test: itself.
+#[test]
+fn compose_injection_keeps_a_kg_fact_tier_s_did_not_render() {
+    use filter::RawTriple;
+    let tier_s = crate::prompt_facts::build_prompt_context(&[(
+        "tga".to_string(),
+        "is_alias_for".to_string(),
+        "trusty-git-analytics".to_string(),
+    )]);
+
+    let out = format::compose_injection(
+        Some(&tier_s),
+        &[],
+        0,
+        &[RawTriple {
+            subject: "ts".into(),
+            predicate: "is_alias_for".into(),
+            object: "trusty-search".into(),
+        }],
+        None,
+    );
+
+    assert!(
+        out.contains("## Relevant KG facts"),
+        "a fact Tier S never showed still earns the section: {out}"
+    );
+    assert!(out.contains("trusty-search"), "{out}");
+    assert_eq!(
+        out.matches("trusty-git-analytics").count(),
+        1,
+        "the Tier S fact is still rendered exactly once: {out}"
+    );
+}

--- a/crates/trusty-memory/src/prompt_facts.rs
+++ b/crates/trusty-memory/src/prompt_facts.rs
@@ -200,6 +200,28 @@ fn section_heading(predicate: &str) -> &str {
 /// internals.
 /// Test: `build_prompt_context_groups_and_formats`,
 /// `build_prompt_context_empty_when_no_hot_triples`.
+/// Render one hot triple as the bullet the Tier S block shows it as.
+///
+/// Why (#5879): [`build_prompt_context`] and the injected "Relevant KG facts"
+/// section can both reach the same triple — Tier S gathers hot predicates across
+/// every palace, the KG section gathers them from the current one, so the second
+/// is a subset of the first and every overlapping triple was rendered twice on
+/// every prompt of every session. The KG section drops what Tier S already
+/// showed, and it can only recognise that if both sides spell a bullet the same
+/// way. One function is what makes them the same by construction rather than by
+/// two string literals staying in step.
+/// What: aliases and shorthands read as `- short → full`; every other hot
+/// predicate drops the subject, which is typically a synthetic `convention-1` id
+/// with no value to the model. No trailing newline — the caller owns spacing.
+/// Test: `build_prompt_context_groups_and_formats`,
+/// `compose_injection_drops_a_kg_fact_tier_s_already_rendered`.
+pub fn hot_fact_bullet(subject: &str, predicate: &str, object: &str) -> String {
+    match predicate {
+        "is_alias_for" | "is_shorthand_for" => format!("- {subject} → {object}"),
+        _ => format!("- {object}"),
+    }
+}
+
 pub fn build_prompt_context(triples: &[(String, String, String)]) -> String {
     // Filter and group preserving HOT_PREDICATES ordering.
     // `(predicate, triples-in-that-section)`; aliased to satisfy clippy's
@@ -228,24 +250,8 @@ pub fn build_prompt_context(triples: &[(String, String, String)]) -> String {
         out.push_str(section_heading(predicate));
         out.push('\n');
         for (subject, _predicate, object) in items {
-            // Aliases / shorthands read best as "short → full"; conventions
-            // and facts are self-contained so we drop the subject (which is
-            // typically a synthetic "convention-1" id with no value to the
-            // model).
-            match predicate {
-                "is_alias_for" | "is_shorthand_for" => {
-                    out.push_str("- ");
-                    out.push_str(subject);
-                    out.push_str(" → ");
-                    out.push_str(object);
-                    out.push('\n');
-                }
-                _ => {
-                    out.push_str("- ");
-                    out.push_str(object);
-                    out.push('\n');
-                }
-            }
+            out.push_str(&hot_fact_bullet(subject, predicate, object));
+            out.push('\n');
         }
     }
     out


### PR DESCRIPTION
## What
`compose_injection` renders a KG fact once, not once per section.

Refs #5879

## Test ladder
Rung 3 (localized to `crates/trusty-memory`). Ran `cargo fmt --check`, `cargo clippy -p trusty-memory --all-targets -- -D warnings`, `cargo test -p trusty-memory`: `918 passed; 0 failed`. `cargo check --workspace` exit 0.
Regression test `compose_injection_drops_a_kg_fact_tier_s_already_rendered` fails on the pre-fix commit with: `the fact must be rendered once, not once per section … left: 2 / right: 1`.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
