### PR TITLE
fix(trusty-mpm): name the session worktree branch through worktree_branch_for (Refs #4165)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11713,7 +11713,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-mpm"
-version = "1.5.5"
+version = "1.5.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "trusty-mpm"
-# 1.5.5 (#6304): patch — 1.5.4 is already published on crates.io and this PR
+# 1.5.6 (#4165): patch — 1.5.5 is already published on crates.io and this PR
 # edits `src/**`, so the `PR version bump vs crates.io` gate (#4421) requires
-# the bump here. Patch because every changed item lives in the `tm` BIN target
-# (`src/bin/tm/commands/statusline/`); the library's public API is untouched.
-version = "1.5.5"
+# the bump here. Patch because the change is a bug fix inside
+# `provisioner::workspace::provision_in`; no public item changed signature.
+version = "1.5.6"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/trusty-mpm/changelog.d/4165-session-branch-naming.md
+++ b/crates/trusty-mpm/changelog.d/4165-session-branch-naming.md
@@ -1,0 +1,3 @@
+Fixed
+
+- **A session provisioned from a repo URL no longer leaks its git branch.** `provisioner::workspace::provision_in` named the worktree's branch bare (`<session-id>`) while `session_manager::decommission::remove_session_worktree` force-deletes `session/<session-id>`, so the delete missed and one branch accumulated in the base clone per session. The provisioner now names the branch through `core::worktree_naming::worktree_branch_for`, the single convention both sides read ([#4165](https://github.com/bobmatnyc/trusty-tools/issues/4165))

--- a/crates/trusty-mpm/src/provisioner/workspace.rs
+++ b/crates/trusty-mpm/src/provisioner/workspace.rs
@@ -767,10 +767,13 @@ impl<G: GitBackend> WorkspaceProvisioner<G> {
     /// `git worktree remove --force` it later), runs `prepare_session` (unless
     /// `prepare` is false), and returns the [`PreparedWorkspace`] — `branch` is
     /// the REQUESTED `git_ref`, not the internal per-session branch name
-    /// backing the worktree (that internal name is `session_id` itself, chosen
-    /// so `decommission`'s existing branch cleanup — which deletes a branch
-    /// named after the worktree's leaf directory — finds and removes it).
+    /// backing the worktree. That internal name is
+    /// `core::worktree_naming::worktree_branch_for(session_id)` =
+    /// `session/<session_id>`, the same spelling
+    /// `session_manager::decommission::remove_session_worktree` force-deletes
+    /// (#4165 — it used to be the bare `session_id`, which that step missed).
     /// Test: `provision_in_uses_explicit_project_dir`,
+    /// `provision_in_names_the_branch_with_the_session_prefix`,
     /// `provision_reuses_base_checkout_across_sessions`.
     pub fn provision_in(
         &self,
@@ -788,12 +791,14 @@ impl<G: GitBackend> WorkspaceProvisioner<G> {
         let workspace_path = project_dir
             .join(crate::session_manager::decommission::worktrees_dirname())
             .join(session_id.to_string());
-        // The branch backing this worktree is named after the session id
-        // itself (not e.g. "session/<id>") so that
-        // `session_manager::decommission::remove_session_worktree`'s branch
-        // cleanup step — which deletes a branch named after the worktree's
-        // leaf directory name — targets the right ref.
-        let branch_name = session_id.to_string();
+        // #4165: name the branch through the shared convention. It used to be
+        // the bare `session_id`, under a comment claiming
+        // `remove_session_worktree` deletes a branch named after the leaf
+        // directory; it deletes `worktree_branch_for(leaf)` = `session/<leaf>`,
+        // so every bare branch survived decommission and leaked in the base
+        // clone.
+        let branch_name =
+            crate::core::worktree_naming::worktree_branch_for(&session_id.to_string());
 
         debug!(
             session = %session_id,

--- a/crates/trusty-mpm/src/provisioner/workspace/tests.rs
+++ b/crates/trusty-mpm/src/provisioner/workspace/tests.rs
@@ -157,6 +157,41 @@ fn provision_in_uses_explicit_project_dir() {
     assert!(ws.path.starts_with(&project_dir));
 }
 
+/// #4165: the branch `provision_in` creates must carry the `session/` prefix.
+///
+/// Why: `remove_session_worktree` step 3 force-deletes
+/// `worktree_branch_for(leaf)` = `session/<leaf>`. The provisioner named its
+/// branch bare, so that delete missed and every provisioned session leaked a
+/// branch in the base clone. Pre-fix this assertion reads
+/// `gitdir: …/worktrees/<uuid>` and fails.
+/// What: provisions one session against `FakeGitBackend`, whose `worktree_add`
+/// records the branch name it was handed into the worktree's `.git` file, and
+/// asserts that name equals `worktree_branch_for(session_id)`.
+/// Test: this function IS the test.
+#[test]
+#[serial_test::serial]
+fn provision_in_names_the_branch_with_the_session_prefix() {
+    let root = crate::test_support::hermetic_temp_dir();
+    let _home = set_home(root.path());
+    let prov = make_provisioner(&root);
+    let id = ManagedSessionId::new();
+    let project_dir = root.path().join("owner").join("repo");
+
+    let ws = prov
+        .provision_in(&project_dir, &id, "https://github.com/owner/repo", "", "t")
+        .unwrap();
+
+    // `FakeGitBackend::worktree_add` writes `gitdir: <base>/worktrees/<branch>`.
+    let gitdir = std::fs::read_to_string(ws.path.join(".git")).expect("worktree .git file");
+    let expected = crate::core::worktree_naming::worktree_branch_for(&id.to_string());
+    assert_eq!(
+        gitdir.trim(),
+        format!("gitdir: {}/worktrees/{expected}", project_dir.display()),
+        "#4165: provision_in must name the branch through worktree_branch_for, \
+         so remove_session_worktree's `branch -D {expected}` finds it"
+    );
+}
+
 /// #4270 requirement 1: provisioning from a repo URL puts the worktree at
 /// `<project-root>/.worktrees/<name>`, not `<root>/.base/.worktrees/<name>`.
 ///

--- a/crates/trusty-mpm/src/session_manager/worktree_safety.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_safety.rs
@@ -91,8 +91,9 @@
 //! - **A repository nested inside a gitignored subtree OF a nested repository**
 //!   — the scan stops descending at the first repository root it finds.
 //! - **The bare-branch population, partially.** `count_session_branch_unpushed`
-//!   covers both `session/<leaf>` and the bare `<leaf>` spelling, but see its
-//!   own doc for which of the two `decommission` actually force-deletes today.
+//!   covers both `session/<leaf>` and the bare `<leaf>` spelling. Since #4165
+//!   every producer emits `session/<leaf>`; the bare arm covers worktrees
+//!   provisioned by an older build, whose branch `decommission` still misses.
 //! - **`DirtyWorktreePolicy::ForceDiscard`**, which destroys all of the above
 //!   by explicit operator opt-in.
 //!
@@ -605,26 +606,20 @@ fn count_unpushed(path: &Path) -> Result<usize, String> {
 /// the branch still carries the commit. HEAD-only counting therefore returned a
 /// false CLEAN for the one branch about to be force-deleted.
 /// What: BOTH spellings of "the branch named after this directory" are checked
-/// — `refs/heads/session/<leaf>` and the bare `refs/heads/<leaf>` — because the
-/// two halves of trusty-mpm disagree about which one it is, and have since
-/// before this guard existed:
-/// - `core::worktree_naming::worktree_branch_for` (used by
-///   `inproject::create_session_worktree` AND by `remove_session_worktree`'s
-///   `branch -D`) says `session/<leaf>`;
-/// - `provisioner/workspace.rs:803` names the branch for the
-///   `.base/.worktrees/<session-id>` shape **bare** — `session_id.to_string()`
-///   — which is the DOMINANT population of the ~95-worktree sweep.
+/// — `refs/heads/session/<leaf>` and the bare `refs/heads/<leaf>`. Every
+/// producer now emits the prefixed spelling: `worktree_branch_for` backs
+/// `inproject::create_session_worktree`, `remove_session_worktree`'s
+/// `branch -D`, and — since #4165 — `provisioner::workspace::provision_in`,
+/// which used to name the branch bare and so leaked one branch per session.
 ///
-/// Today that divergence is not a loss path: `branch -D session/<uuid>` simply
-/// misses, so a bare branch survives the removal. Checking it anyway is
-/// deliberate conservatism, and the reason is the point of this whole PR — the
-/// divergence is a live bug that will be fixed on ONE side or the other, and if
-/// it is fixed on the `remove_session_worktree` side then bare branches start
-/// being destroyed. A guard that silently goes from correct to inert because
-/// somebody repaired an unrelated naming bug is exactly the failure mode this
-/// module exists to prevent. Over-reporting costs an operator one look; the
-/// other direction costs the work. Tracked as a follow-up rather than fixed
-/// here, since renaming branches is not a safety-gate change.
+/// The bare check stays for the population already on disk. Worktrees
+/// provisioned before #4165 still carry a bare branch, `branch -D
+/// session/<uuid>` still misses it, and it still survives removal — so
+/// counting it here over-reports rather than under-reports, which is the
+/// direction this module errs in deliberately. Drop the bare arm only once
+/// no pre-#4165 worktree remains; a guard that goes quietly inert because
+/// somebody repaired a naming bug is the failure mode this module exists to
+/// prevent.
 ///
 /// 0 when neither ref exists (`for-each-ref` exits 0 with empty output, so
 /// absence is distinguishable from a spawn failure, which stays an `Err`).


### PR DESCRIPTION
`provisioner::workspace::provision_in` named the session worktree's branch bare (`<session-id>`), while `session_manager::decommission::remove_session_worktree` force-deletes `worktree_branch_for(leaf)` = `session/<session-id>`. The delete therefore missed, and one branch accumulated in the base clone per provisioned session. Both sides now read `core::worktree_naming::worktree_branch_for`. The stale doc comments in `worktree_safety.rs` that described the divergence as unresolved are corrected in the same change; its bare-branch check stays, because worktrees provisioned by a pre-#4165 build still carry a bare branch that decommission still misses.

Refs #4165

Version: `trusty-mpm` 1.5.5 -> 1.5.6 (patch). 1.5.5 is published on crates.io and this PR edits `src/**`, so `scripts/check-pr-version-bump.sh` requires the bump; no public item changed signature.

## Test ladder: rung 3

```
cargo fmt --check                                          EXIT=0
cargo check -p trusty-mpm                                  EXIT=0
cargo clippy -p trusty-mpm --all-targets -- -D warnings    EXIT=0
cargo test -p trusty-mpm                                   EXIT=0  -> 9375 passed; 0 failed; 18 ignored (50 test binaries)
bash scripts/check_line_cap.sh                             EXIT=0  -> 4203 files, 0 violations
bash scripts/check_changelog_fragment.sh                   EXIT=0
bash scripts/check_sld.sh                                  EXIT=0
bash scripts/check-pr-version-bump.sh                      EXIT=0  -> [ OK ] trusty-mpm - version bumped 1.5.5 -> 1.5.6
```

### Regression test provably fails without the fix

With `provisioner/workspace.rs` and `session_manager/worktree_safety.rs` reverted to `origin/main` and the new test left in place:

```
running 1 test
test provisioner::workspace::tests::provision_in_names_the_branch_with_the_session_prefix ... FAILED

---- provisioner::workspace::tests::provision_in_names_the_branch_with_the_session_prefix stdout ----
thread '...' panicked at crates/trusty-mpm/src/provisioner/workspace/tests.rs:187:5:
assertion `left == right` failed: #4165: provision_in must name the branch through worktree_branch_for, so remove_session_worktree's `branch -D session/9cccbb5f-bad6-48d3-82fe-af7a72f44bea` finds it
  left: "gitdir: /tmp/tm-test-R8MchQ/owner/repo/worktrees/9cccbb5f-bad6-48d3-82fe-af7a72f44bea"
 right: "gitdir: /tmp/tm-test-R8MchQ/owner/repo/worktrees/session/9cccbb5f-bad6-48d3-82fe-af7a72f44bea"

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 5284 filtered out
```

With the fix restored:

```
running 1 test
test provisioner::workspace::tests::provision_in_names_the_branch_with_the_session_prefix ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 5284 filtered out; finished in 0.01s
```

Changelog: `crates/trusty-mpm/changelog.d/4165-session-branch-naming.md`.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
