### PR TITLE
fix(trusty-mpm): the worktree bookkeeping repair runs below every decommission caller (Refs #5949)

### DIFF
--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -7,6 +7,9 @@ name = "trusty-mpm"
 # #5044 rides the same 1.5.6: it adds `ImportOptions::refresh`, two
 # `ImportStatus` variants and `core::memory_import::refresh`, and the crate
 # has no out-of-workspace consumer to break.
+# #5949 rides the same 1.5.6: the worktree registry repair it adds to
+# `session_manager::decommission` is `pub(super)`, so no public item changed
+# signature.
 version = "1.5.6"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/trusty-mpm/changelog.d/5949-decommission-prune-repair.md
+++ b/crates/trusty-mpm/changelog.d/5949-decommission-prune-repair.md
@@ -1,0 +1,11 @@
+Fixed
+
+- Decommissioning a tm-owned worktree through the MCP `session_decommission`
+  tool or the idle reaper no longer leaves a stale entry in `git worktree list`
+  (refs [#5949](https://github.com/bobmatnyc/trusty-tools/issues/5949)). Both
+  call `SessionManager::decommission` in-process, below the client layer that
+  carried the repair for the routed HTTP paths, so the owned-workspace branch
+  removed the directory with `remove_dir_all` and git kept listing it — the
+  reaper unattended. The repair now runs inside `decommission_with_root`, which
+  every caller reaches regardless of transport, and it targets the checkout git
+  itself reports as owning the worktree rather than the parent directory.

--- a/crates/trusty-mpm/src/daemon/mcp_session.rs
+++ b/crates/trusty-mpm/src/daemon/mcp_session.rs
@@ -544,4 +544,147 @@ mod tests {
         .unwrap_err();
         assert!(err.contains("unknown runtime"), "{err}");
     }
+
+    /// Point `$HOME` at a temp directory and restore it on drop, panic or not.
+    ///
+    /// Why: `SessionManager::decommission` resolves its containment root from
+    /// the ambient environment, so a test that wants a real removal to happen
+    /// must seed its workspace under a redirected root. The redirect is
+    /// process-wide, hence `#[serial_test::serial]` on the only user.
+    /// What: swaps `$HOME` and puts the prior value back on drop.
+    /// Test: `session_decommission_prunes_stale_worktree_bookkeeping`.
+    struct HomeGuard(Option<String>);
+
+    impl HomeGuard {
+        fn redirect(to: &std::path::Path) -> Self {
+            let prior = std::env::var("HOME").ok();
+            // SAFETY: the only caller is `#[serial_test::serial]`.
+            unsafe { std::env::set_var("HOME", to) };
+            Self(prior)
+        }
+    }
+
+    impl Drop for HomeGuard {
+        fn drop(&mut self) {
+            // SAFETY: the only caller is `#[serial_test::serial]`.
+            match self.0 {
+                Some(ref prior) => unsafe { std::env::set_var("HOME", prior) },
+                None => unsafe { std::env::remove_var("HOME") },
+            }
+        }
+    }
+
+    /// #5949: the MCP `session_decommission` tool leaves the base checkout's
+    /// worktree bookkeeping clean.
+    ///
+    /// Why: this tool calls `SessionManager::decommission` in-process, below the
+    /// client layer that carried the repair for the routed HTTP paths, so it
+    /// removed an owned workspace and left git still listing it. The idle reaper
+    /// reaches the same function the same way and runs unattended.
+    /// What: a real checkout with a real registered worktree under a redirected
+    /// `$HOME`, an owned record pointing at that worktree, then the MCP tool.
+    /// Asserts the tombstone came back and that git no longer lists the leaf.
+    /// Against the pre-fix code the last assertion fails.
+    /// Test: this function IS the test.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn session_decommission_prunes_stale_worktree_bookkeeping() {
+        fn git(dir: &std::path::Path, args: &[&str]) -> std::process::Output {
+            std::process::Command::new("git")
+                .arg("-C")
+                .arg(dir)
+                .args(args)
+                .output()
+                .unwrap_or_else(|e| panic!("git {args:?} could not run: {e}"))
+        }
+
+        let home = tempfile::tempdir().expect("home tempdir");
+        let _home_guard = HomeGuard::redirect(home.path());
+        let workspace_root = trusty_common::workspace_layout::resolve_workspace_root(None);
+
+        let base = workspace_root.join("tm-5949-base");
+        std::fs::create_dir_all(&base).expect("create base repo dir");
+        if !git(&base, &["init", "--quiet"]).status.success() {
+            eprintln!("session_decommission_prunes_stale_worktree_bookkeeping: no git, skipping");
+            return;
+        }
+        assert!(
+            git(&base, &["config", "user.email", "ci@test.invalid"])
+                .status
+                .success()
+        );
+        assert!(git(&base, &["config", "user.name", "CI"]).status.success());
+        assert!(
+            git(&base, &["config", "commit.gpgsign", "false"])
+                .status
+                .success()
+        );
+        std::fs::write(base.join("README.md"), "seed\n").expect("write README");
+        assert!(git(&base, &["add", "README.md"]).status.success());
+        assert!(
+            git(&base, &["commit", "--quiet", "-m", "seed"])
+                .status
+                .success()
+        );
+
+        let id = crate::session_manager::ManagedSessionId::new();
+        let leaf = format!("tm-5949-{id}");
+        let ws = base.join(".worktrees").join(&leaf);
+        assert!(
+            git(
+                &base,
+                &[
+                    "worktree",
+                    "add",
+                    "--quiet",
+                    "-b",
+                    &format!("session/{leaf}"),
+                    &ws.to_string_lossy(),
+                ],
+            )
+            .status
+            .success(),
+            "fixture: the worktree must be registered"
+        );
+        let listed = |dir: &std::path::Path| {
+            String::from_utf8_lossy(&git(dir, &["worktree", "list", "--porcelain"]).stdout)
+                .into_owned()
+        };
+        assert!(
+            listed(&base).contains(&leaf),
+            "fixture invariant: git must list the worktree before decommission"
+        );
+
+        let (_root, s) = state().await;
+        s.session_manager()
+            .await
+            .create_with_id(
+                id,
+                "regression: #5949 MCP decommission".to_string(),
+                Some(ws.clone()),
+                None,
+                Some(ws.clone()),
+                None,
+                None,
+                crate::runtime::RuntimeKind::default(),
+                false,
+                // Owned: the branch that removes with `remove_dir_all`.
+                true,
+            )
+            .await
+            .expect("seed session");
+
+        let json = session_decommission(&s, &id.to_string())
+            .await
+            .expect("decommission");
+        assert_eq!(json["state"], "decommissioned", "{json}");
+        assert!(!ws.exists(), "the workspace must be gone: {}", ws.display());
+        assert!(
+            !listed(&base).contains(&leaf),
+            "the MCP decommission left a stale worktree entry for {leaf} — the \
+             bookkeeping repair did not run (#5949)"
+        );
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
 }

--- a/crates/trusty-mpm/src/session_manager/decommission.rs
+++ b/crates/trusty-mpm/src/session_manager/decommission.rs
@@ -25,6 +25,7 @@ use super::record::{ManagedSessionId, ManagedSessionState, SessionRecord};
 use super::search_gc;
 use super::workspace_guard::is_safe_to_remove;
 use super::worktree_protection;
+use super::worktree_registry;
 use super::worktree_safety::{DirtyWorktree, inspect_dirt};
 
 /// Sentinel file written by [`create_session_worktree`] into every SM-created
@@ -465,6 +466,67 @@ fn prune_refs_after_removal(repo_root: &Path, path: &Path) {
     }
 }
 
+/// The base checkout whose worktree registry a decommission will strand (#5949).
+///
+/// Why: an SM-OWNED workspace is removed with `remove_dir_all`, which git never
+/// learns about — the entry survives in the base checkout's worktree list until
+/// something prunes it. The client layer already repaired this for the routed
+/// HTTP paths, so the MCP tool and the idle reaper — both of which call
+/// `decommission` in-process, below that layer — accumulated stale entries
+/// instead, the reaper unattended. Answering the question here means every
+/// caller inherits the repair regardless of transport.
+/// What: `None` unless the record names an owned workspace that git reports a
+/// DIFFERENT checkout as owning. A workspace that is its own checkout root has
+/// no external registry to repair, and an unowned one is removed by
+/// [`remove_session_worktree`], which prunes for itself. Must be called BEFORE
+/// the removal: git can only answer from a directory that still exists.
+/// Test: `decommission_prunes_the_base_repo_worktree_registry`,
+/// `registry_root_to_repair_ignores_a_standalone_owned_clone`.
+pub(super) fn registry_root_to_repair(record: &SessionRecord) -> Option<std::path::PathBuf> {
+    if !record.workspace_owned {
+        return None;
+    }
+    let ws = record.workspace_path.as_deref()?;
+    let root = worktree_registry::registry_root_for(ws)?;
+    // git reports a resolved path; the record's may still carry a symlinked
+    // spelling of the same directory (every macOS temp path does), so compare
+    // both in canonical form or the two would never look equal.
+    let ws_resolved = std::fs::canonicalize(ws).unwrap_or_else(|_| ws.to_path_buf());
+    (root != ws_resolved).then_some(root)
+}
+
+/// Clear the stale registry entry a removed worktree leaves behind (#5949).
+///
+/// Why: git keeps reporting a worktree whose directory was deleted out from
+/// under it, and every consumer of that listing — this crate's own reclaim
+/// sweep included — then reasons about a directory that is not there.
+/// What: runs the prune subcommand in `root`. Best-effort: a failure leaves a
+/// stale entry in git's output, never data loss, so it is logged and the
+/// teardown that already succeeded continues.
+/// Test: `decommission_prunes_the_base_repo_worktree_registry`.
+fn prune_worktree_registry(root: &Path) {
+    match std::process::Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["worktree", "prune"])
+        .output()
+    {
+        Ok(out) if out.status.success() => {
+            info!(root = %root.display(), "decommission: worktree registry pruned");
+        }
+        Ok(out) => warn!(
+            root = %root.display(),
+            "decommission: worktree prune exited {}: {}",
+            out.status,
+            String::from_utf8_lossy(&out.stderr).trim()
+        ),
+        Err(e) => warn!(
+            root = %root.display(),
+            "decommission: worktree prune failed to spawn: {e}"
+        ),
+    }
+}
+
 impl SessionManager {
     /// Decommission a session: stop the runtime, remove the workspace from disk
     /// (ONLY if the SM provisioned it), and mark the record `Decommissioned`.
@@ -687,6 +749,13 @@ impl SessionManager {
             record.workspace_owned,
         );
 
+        // #5949: resolve the checkout that owns this workspace's worktree
+        // registry BEFORE anything is removed. `registry_root_for` asks git
+        // from the workspace itself, so it can only be answered while the
+        // directory still exists — the same ordering contract `search_index_id`
+        // above is bound by, for the same reason.
+        let registry_root = registry_root_to_repair(&record);
+
         // Gracefully terminate the runtime before removing the workspace (#1975):
         // SIGTERM the claude process and give it a grace window to flush state,
         // then reclaim the pane — instead of an abrupt `kill_session`. Best-effort:
@@ -826,6 +895,12 @@ impl SessionManager {
                             workspace = %ws.display(),
                             "decommission: owned workspace removed from disk"
                         );
+                        // #5949: `remove_dir_all` is invisible to git, so the
+                        // base checkout still lists this worktree. Repair it
+                        // here — below every caller, in-process ones included.
+                        if let Some(ref root) = registry_root {
+                            prune_worktree_registry(root);
+                        }
                     }
                 }
             }

--- a/crates/trusty-mpm/src/session_manager/decommission_worktree_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/decommission_worktree_tests.rs
@@ -557,3 +557,215 @@ fn remove_still_removes_a_healthy_worktree() {
         "the session branch must be deleted too"
     );
 }
+
+// ─────────────────────────────────────────────────────────────────────────
+// #5949: the bookkeeping repair lives below every caller
+// ─────────────────────────────────────────────────────────────────────────
+
+/// Build a real checkout at `dir` with one commit. Returns `false` when git is
+/// unavailable, matching the skip convention the tests above already use.
+///
+/// Why: the #5949 tests assert on what git itself reports, so a mocked git
+/// would test nothing.
+/// What: `git init` plus a committed `README.md`, with the identity and signing
+/// config every sandboxed commit needs.
+/// Test: `decommission_prunes_the_base_repo_worktree_registry`.
+fn init_repo_with_commit(dir: &std::path::Path) -> bool {
+    let git = |args: &[&str]| {
+        std::process::Command::new("git")
+            .arg("-C")
+            .arg(dir)
+            .args(args)
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+    };
+    std::fs::create_dir_all(dir).expect("create repo dir");
+    if !git(&["init", "--quiet"]) {
+        return false;
+    }
+    assert!(git(&["config", "user.email", "ci@test.invalid"]));
+    assert!(git(&["config", "user.name", "CI"]));
+    assert!(git(&["config", "commit.gpgsign", "false"]));
+    std::fs::write(dir.join("README.md"), "seed\n").expect("write README");
+    assert!(git(&["add", "README.md"]));
+    assert!(git(&["commit", "--quiet", "-m", "seed"]));
+    true
+}
+
+/// `git -C <dir> worktree list --porcelain`, as a string.
+fn worktree_list(dir: &std::path::Path) -> String {
+    let out = std::process::Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(["worktree", "list", "--porcelain"])
+        .output()
+        .expect("git worktree list");
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+/// #5949: decommissioning an SM-OWNED workspace that git registers as a worktree
+/// leaves the base checkout's registry clean.
+///
+/// Why: the owned branch removes the directory with `remove_dir_all`, which git
+/// never learns about, so the entry survived in the base checkout's listing. The
+/// repair existed only in the client layer, which the MCP tool and the idle
+/// reaper never pass through — this asserts it from `SessionManager` itself, the
+/// one function every caller reaches regardless of transport.
+/// What: a real base checkout inside the managed root, a real registered
+/// worktree under it, an owned record pointing at that worktree, then
+/// `decommission_with_root`. Asserts the removal happened and that git no longer
+/// lists the leaf. Against the pre-fix code the last assertion fails: the
+/// directory is gone and the entry is still listed.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn decommission_prunes_the_base_repo_worktree_registry() {
+    let dir = crate::test_support::hermetic_temp_dir();
+    let mgr = SessionManager::new(dir.path(), FakeTmuxDriver::new())
+        .await
+        .expect("manager");
+
+    let managed_root = crate::test_support::hermetic_temp_dir();
+    let base = managed_root.path().join("owner").join("repo");
+    if !init_repo_with_commit(&base) {
+        eprintln!("decommission_prunes_the_base_repo_worktree_registry: git unavailable, skipping");
+        return;
+    }
+
+    let leaf = "tm-5949-session";
+    let ws = base.join(".worktrees").join(leaf);
+    let added = std::process::Command::new("git")
+        .arg("-C")
+        .arg(&base)
+        .args([
+            "worktree",
+            "add",
+            "--quiet",
+            "-b",
+            "session/tm-5949-session",
+        ])
+        .arg(&ws)
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    assert!(added, "fixture: the worktree must be registered");
+    assert!(
+        worktree_list(&base).contains(leaf),
+        "fixture invariant: git must list the worktree before decommission"
+    );
+
+    let record = mgr
+        .create_with_id(
+            ManagedSessionId::new(),
+            "regression: #5949 in-process decommission".into(),
+            Some(ws.clone()),
+            None,
+            Some(ws.clone()),
+            None,
+            None,
+            crate::runtime::RuntimeKind::default(),
+            false,
+            // Owned: this is the branch that removes with `remove_dir_all` and
+            // therefore the one that strands git's bookkeeping.
+            true,
+        )
+        .await
+        .expect("create");
+
+    let (tombstone, workspace_removed) = mgr
+        .decommission_with_root(&record.id, managed_root.path(), None)
+        .await
+        .expect("decommission");
+
+    assert!(
+        workspace_removed,
+        "fixture invariant: an owned, existing workspace must be removed"
+    );
+    assert_eq!(tombstone.state, ManagedSessionState::Decommissioned);
+    assert!(!ws.exists(), "the workspace must be gone: {}", ws.display());
+    assert!(
+        !worktree_list(&base).contains(leaf),
+        "decommission left a stale worktree entry for {leaf} — the bookkeeping \
+         repair did not run below the caller (#5949)"
+    );
+}
+
+/// #5949: an owned workspace that IS its own checkout has no registry to repair.
+///
+/// Why: the repair resolves the checkout git says owns the workspace. For a
+/// plain SM-provisioned clone that answer is the workspace itself, which is
+/// about to be deleted — pruning there would only log a failure against a
+/// directory that no longer exists.
+/// What: an owned record pointing at a standalone checkout, asserted to select
+/// no registry root; the worktree case is asserted to select the base checkout.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn registry_root_to_repair_ignores_a_standalone_owned_clone() {
+    let dir = crate::test_support::hermetic_temp_dir();
+    let mgr = SessionManager::new(dir.path(), FakeTmuxDriver::new())
+        .await
+        .expect("manager");
+
+    let managed_root = crate::test_support::hermetic_temp_dir();
+    let clone = managed_root.path().join("owner").join("standalone");
+    if !init_repo_with_commit(&clone) {
+        eprintln!(
+            "registry_root_to_repair_ignores_a_standalone_owned_clone: git unavailable, skipping"
+        );
+        return;
+    }
+
+    let standalone = mgr
+        .create_with_id(
+            ManagedSessionId::new(),
+            "standalone clone".into(),
+            Some(clone.clone()),
+            None,
+            Some(clone.clone()),
+            None,
+            None,
+            crate::runtime::RuntimeKind::default(),
+            false,
+            true,
+        )
+        .await
+        .expect("create standalone");
+    assert!(
+        super::decommission::registry_root_to_repair(&standalone).is_none(),
+        "a checkout that owns itself has no external registry to repair"
+    );
+
+    let ws = clone.join(".worktrees").join("tm-5949-leaf");
+    let added = std::process::Command::new("git")
+        .arg("-C")
+        .arg(&clone)
+        .args(["worktree", "add", "--quiet", "-b", "session/tm-5949-leaf"])
+        .arg(&ws)
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    assert!(added, "fixture: the worktree must be registered");
+
+    let linked = mgr
+        .create_with_id(
+            ManagedSessionId::new(),
+            "linked worktree".into(),
+            Some(ws.clone()),
+            None,
+            Some(ws.clone()),
+            None,
+            None,
+            crate::runtime::RuntimeKind::default(),
+            false,
+            true,
+        )
+        .await
+        .expect("create linked");
+    let resolved = super::decommission::registry_root_to_repair(&linked)
+        .expect("a linked worktree resolves to its owning checkout");
+    let expected = std::fs::canonicalize(&clone).unwrap_or(clone);
+    assert_eq!(
+        resolved, expected,
+        "the repair must target the checkout git says owns the worktree"
+    );
+}


### PR DESCRIPTION
Refs #5949.

## What and why

The MCP `session_decommission` tool (`daemon/mcp_session.rs`) and the idle
reaper (`daemon/idle_reaper.rs`) call `SessionManager::decommission` in-process,
below the client layer PR #5925 converged for the routed HTTP paths. The
owned-workspace branch removes the directory with `remove_dir_all`, git never
learns about it, and the entry survives in the base checkout's worktree listing.
The reaper runs unattended, so it accumulates those entries with nobody watching.

`decommission_with_root` now resolves the checkout git reports as owning the
workspace — before the removal, since git can only answer from a directory that
still exists — and prunes that checkout's registry after. Every caller inherits
the repair regardless of transport.

Two deliberate choices:

- The owner comes from `worktree_registry::registry_root_for` (#4207), not the
  parent directory the client layer guesses. That is also correct for a worktree
  parked outside its owning checkout.
- The client-side repair in `client/executor/managed.rs` stays. A long-running
  daemon and a freshly `cargo install`ed `tm` are routinely different builds here;
  the CLI-side prune keeps working against a daemon that predates this change,
  and a second prune is a no-op.

## Owner ruling

The 2026-08-19 ruling asked for a reproducing fixture first, with the layering
decision made against it. Both fixtures below reproduce the stale entry against
the pre-fix code, and both put the repair inside `session_manager/` — the
direction the issue names, confirmed rather than assumed.

## Test ladder: rung 3

```
cargo fmt --check                                          EXIT=0
cargo check -p trusty-mpm                                  EXIT=0
cargo clippy -p trusty-mpm --all-targets -- -D warnings     EXIT=0
cargo test -p trusty-mpm --no-fail-fast                    EXIT=0
```

`cargo test -p trusty-mpm --no-fail-fast`: lib `5280 passed; 0 failed; 7 ignored`,
bin `tm` `1868 passed; 0 failed; 1 ignored`, every other target ok, 0 failures
across all targets.

Repo gates: `check_line_cap.sh`, `check_changelog_fragment.sh`,
`check_test_pointers.sh`, `check_sld.sh`, `check_teardown_guard.sh`,
`check-pr-version-bump.sh` — all exit 0. Version 1.5.5 -> 1.5.6 (1.5.5 is live
on crates.io).

## Failing before the fix

Both new tests were run with only the repair call site disabled — helpers and
tests otherwise identical.

```
test session_manager::decommission_worktree_tests::decommission_prunes_the_base_repo_worktree_registry ... FAILED
decommission left a stale worktree entry for tm-5949-session — the bookkeeping repair did not run below the caller (#5949)

test daemon::mcp_session::tests::session_decommission_prunes_stale_worktree_bookkeeping ... FAILED
the MCP decommission left a stale worktree entry for tm-5949-e569c27d-adce-4946-b600-6a8bc13a837d — the bookkeeping repair did not run (#5949)
```

Both pass with the fix in place. A third test,
`registry_root_to_repair_ignores_a_standalone_owned_clone`, pins the other
branch: an owned clone that is its own checkout selects no registry to repair.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
