### PR TITLE
docs: the documented test command runs every target, and nextest's process model is recorded (Refs #4162, #5354)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,10 +28,22 @@ you changed; a bare workspace run is a hardening gate, not an inner loop.
 ```bash
 cargo build                                            # build all crates (dev)
 cargo check -p <crate>                                 # fastest — no codegen
-cargo test -p <crate>                                  # test one crate
+cargo test -p <crate> --no-fail-fast                   # test one crate — EVERY target
 cargo clippy -p <crate> --all-targets -- -D warnings   # lint one crate
 cargo fmt                                              # format (--check to verify only)
 ```
+
+🔴 **`--no-fail-fast` is not optional (#5354).** Cargo runs each test target as
+its own binary and stops issuing further targets the moment one target reports a
+failure — it does not run them all and report the aggregate. One failing `--lib`
+test therefore hides every integration target behind it, and the run exits
+having covered far less than its counts suggest, with nothing at the call site
+saying so. It has bitten twice: `--test tm_hook_pm_guard` never executed once
+across a full session of runs (#5324), and the
+`execute_doctor_against_test_daemon` timing flake masked 49 targets on PR #5904.
+Same family as #4307 (a filter matching zero tests reports `ok`) and #4901 (a
+non-default feature compiles a module out). Worked example and what a pasted
+count then proves: [test-ladder-baseline.md](docs/reference/test-ladder-baseline.md).
 
 - For anything else — release builds, feature-gated tests, `--include-ignored` /
   ONNX tests, a single test by name, the `trusty-search` performance suite,
@@ -67,9 +79,9 @@ change's blast radius. Risk labels map onto the rungs (1–2 Low, 3–4 Normal,
 | # | Change class | Risk | PR gate, in short |
 |---|---|---|---|
 | 1 | Docs, comments, changelog fragments only | Low | Doc gates only (`check_sld.sh`, plus doc-numbers / line-cap if touched). No Cargo test by default. |
-| 2 | Test-only stabilization — flake fix, fixture, test harness | Low | `fmt --check` + `test -p <crate>`, with the flake re-run ~10× |
-| 3 | Localized behavior inside one crate | Normal | `fmt --check` + `check` + `clippy` + `test`, all `-p <crate>`, plus one regression test that provably failed before |
-| 4 | **Cross-crate change** — public API or shared library (`trusty-common`, `trusty-embedderd`, …) | Normal → High | Rung 3 on the library, then `check --workspace` + `test -p <consumer>` for **each direct dependent** |
+| 2 | Test-only stabilization — flake fix, fixture, test harness | Low | `fmt --check` + `test -p <crate> --no-fail-fast`, with the flake re-run ~10× |
+| 3 | Localized behavior inside one crate | Normal | `fmt --check` + `check` + `clippy` + `test --no-fail-fast`, all `-p <crate>`, plus one regression test that provably failed before |
+| 4 | **Cross-crate change** — public API or shared library (`trusty-common`, `trusty-embedderd`, …) | Normal → High | Rung 3 on the library, then `check --workspace` + `test -p <consumer> --no-fail-fast` for **each direct dependent** |
 | 5 | Cross-crate contract, persistence, security, process lifecycle, **release tooling** | High | Rung 4, plus `--include-ignored` integration coverage, failure-path/concurrency tests, and a `code-critic` round |
 | 6 | **UI / API surface** — Svelte UIs, MCP tool schemas, HTTP routes | High | Rung 3 or 4 for the Rust side, plus the UI package's own test/build and one binary smoke run — with direct UI/API evidence, not just crate tests |
 
@@ -84,7 +96,8 @@ change's blast radius. Risk labels map onto the rungs (1–2 Low, 3–4 Normal,
   `#[ignore]`-ing, `cfg`-gating, `--exclude`-ing, or `--lib`-narrowing coverage.
 - **Evidence:** a PR body may summarise a **passing** gate as command + counts +
   scope; raw output stays **mandatory** for failures, flakes, performance claims,
-  and disputed results.
+  and disputed results. Counts from a run WITHOUT `--no-fail-fast` prove only the
+  targets that ran, so name the flag beside them (#5354).
 
 ### What CI actually gates
 
@@ -109,6 +122,14 @@ change's blast radius. Risk labels map onto the rungs (1–2 Low, 3–4 Normal,
 - 🔴 **`Rust tests (pre-publish gate)` — the eight shards — does not run on pull
   requests.** Not required, skipped outright on a PR; runs on push to `main` and
   `workflow_dispatch`. Do not wait for it.
+- 🔴 **Those shards run `cargo nextest`, which gives every test its own PROCESS,
+  so `#[serial_test::serial]` serializes nothing there (#4162).** The `$HOME`
+  isolation PR #4120 established survives — a `set_var("HOME")` is process-local,
+  so nextest's isolation is strictly stronger than an in-process lock for env
+  state. What lapses is any `#[serial]` guarding a resource shared ACROSS
+  processes (a fixed path, a fixed port, one real file): use
+  `#[serial_test::file_serial]` for those, and keep redirecting `$HOME` per test.
+  Measurements: [test-ladder-baseline.md](docs/reference/test-ladder-baseline.md).
 - 🟡 A PR proves every test target COMPILES; test EXECUTION defers to `main`, so
   run the ladder rung your change earns before merging. Full suite on a branch:
   Actions → CI → "Run workflow".

--- a/docs/reference/test-ladder-baseline.md
+++ b/docs/reference/test-ladder-baseline.md
@@ -18,15 +18,73 @@ was exercised.
 | # | Development proof | PR gate — the command to run | Hardening / release gate |
 |---|---|---|---|
 | 1 | Read the rendered file | `bash scripts/check_sld.sh` (plus `check_doc_numbers.sh` / `check_line_cap.sh` if those surfaces were touched). No Cargo test by default. | CI required checks only |
-| 2 | Fail-before / pass-after, repeated: `cargo test -p <crate> <test> -- --exact --nocapture` run ~10× | `cargo fmt --check` && `cargo test -p <crate>`; add `-- --test-threads=1` when the flake is isolation-shaped | `cargo test --workspace` **only** when shared test infrastructure changed |
-| 3 | One targeted regression test that provably fails before the change | `cargo fmt --check` && `cargo check -p <crate>` && `cargo clippy -p <crate> -- -D warnings` && `cargo test -p <crate>` | Workspace gate only when release policy requires it |
-| 4 | Targeted regression plus `cargo test -p <lib>` | rung 3 for the library, then `cargo check --workspace` && `cargo test -p <consumer>` for **each direct dependent** | `cargo test --workspace` && `cargo clippy --workspace --all-targets -- -D warnings` at HARDEN/release |
-| 5 | Targeted plus failure-path and concurrency tests | rung 4, plus `cargo test -p <crate> -- --include-ignored` for gated integration coverage, plus an adversarial review round (`code-critic`) | full workspace, `cargo audit`, and for release tooling `scripts/check-publish-ready.sh <crate>` && `scripts/preflight-publish.sh <crate>` |
+| 2 | Fail-before / pass-after, repeated: `cargo test -p <crate> <test> -- --exact --nocapture` run ~10× | `cargo fmt --check` && `cargo test -p <crate> --no-fail-fast`; add `-- --test-threads=1` when the flake is isolation-shaped | `cargo test --workspace` **only** when shared test infrastructure changed |
+| 3 | One targeted regression test that provably fails before the change | `cargo fmt --check` && `cargo check -p <crate>` && `cargo clippy -p <crate> -- -D warnings` && `cargo test -p <crate> --no-fail-fast` | Workspace gate only when release policy requires it |
+| 4 | Targeted regression plus `cargo test -p <lib>` | rung 3 for the library, then `cargo check --workspace` && `cargo test -p <consumer> --no-fail-fast` for **each direct dependent** | `cargo test --workspace` && `cargo clippy --workspace --all-targets -- -D warnings` at HARDEN/release |
+| 5 | Targeted plus failure-path and concurrency tests | rung 4, plus `cargo test -p <crate> --no-fail-fast -- --include-ignored` for gated integration coverage, plus an adversarial review round (`code-critic`) | full workspace, `cargo audit`, and for release tooling `scripts/check-publish-ready.sh <crate>` && `scripts/preflight-publish.sh <crate>` |
 | 6 | Rust crate tests **plus** direct UI/API evidence (curl the route, call the MCP tool, load the page) | rung 3 or 4 for the Rust side, plus `pnpm -C crates/<crate>/ui test` (where the package defines one; otherwise `… build`) and one smoke run of the binary | full product/e2e gate plus `cargo test -- --include-ignored` when hardening |
 
 Why `cargo test --workspace` is absent from rungs 1–3, and the "scope down,
 never scope away" line that constrains picking a lower rung, are stated with the
 ladder itself in [`CLAUDE.md`](../../CLAUDE.md) — not repeated here.
+
+### Every rung carries `--no-fail-fast`, and the reason is not politeness
+
+Cargo runs each test target as its own binary and, by default, stops issuing
+further targets as soon as one target reports a failing test. It does not run
+every target and report the aggregate. A single failing `--lib` test therefore
+zeroes out every integration target behind it, and the invocation exits having
+covered far less than its counts suggest.
+
+Worked example, on a two-target project whose `--lib` target fails:
+
+```
+$ cargo test                      # only the --lib target ran
+test result: FAILED. 0 passed; 1 failed; 0 ignored
+error: test failed, to rerun pass `--lib`
+
+$ cargo test --no-fail-fast       # the integration target ran as well
+test result: FAILED. 0 passed; 1 failed; 0 ignored
+error: test failed, to rerun pass `--lib`
+test result: ok. 1 passed; 0 failed; 0 ignored
+```
+
+This is not hypothetical here. The #5324 implementer found
+`--test tm_hook_pm_guard` — the regression test that fix depends on — had never
+executed once across a full session of `cargo test -p trusty-mpm` runs, because
+the `--lib` target kept failing first; `--no-fail-fast` ran all 46 targets
+green. It recurred on PR #5904, where the `execute_doctor_against_test_daemon`
+timing flake masked 49 other targets. `bench_stale_assets_for_many` and the
+`tm_hook_pm_guard` family (#5914) supply the same trigger.
+
+It also changes what a pasted count proves. `5280 passed; 0 failed` from a run
+WITHOUT the flag is evidence about the targets that ran, not about the crate —
+so name the flag beside the counts, or a reviewer cannot tell the two apart.
+
+### `#[serial]` does not serialize under nextest
+
+CI's `test-shard` job runs `cargo nextest run --workspace`, and nextest gives
+every test its own process. `serial_test`'s `#[serial]` is an in-process lock,
+so it serializes nothing there. Measured 2026-08-27: two `#[serial]` tests
+sharing a key interleaved across two pids under nextest
+(`one ENTER` / `two ENTER` / `two EXIT` / `one EXIT`) and ran strictly one after
+the other in a single pid under `cargo test`.
+
+The `$HOME` isolation PR #4120 established is not the casualty #4162 predicted.
+A `set_var("HOME")` is process-local, so process-per-test isolation is strictly
+STRONGER than the in-process lock for env state — measured, the sibling test
+read the real `$HOME` while the mutating test held its own redirect, and it
+cannot observe the redirect at all. Running the `$HOME`-touching targets
+(`session_manager_mvp`, `local_spawn`) under both runners added no entry to the
+real `~/.claude.json`: 2828 projects before and after, both times.
+
+What DOES lapse is any `#[serial]` guarding a resource shared ACROSS processes —
+a fixed path, a fixed port, one real file. Guard those with
+`#[serial_test::file_serial]`, which takes a filesystem lock and needs
+serial_test's `file_locks` feature; `#[serial]` and `#[file_serial]` lock
+independently, so a resource must pick one and use it everywhere. And keep
+redirecting `$HOME` per test: the redirect is what keeps a test out of the
+operator's real config, and always was — `#[serial]` never did that job.
 
 ### `-p <crate>` is only a gate when the crate's default features compile the code
 


### PR DESCRIPTION
Refs #4162, #5354.

Two invocation traps that both let a green run cover less than its caller
believes. `CLAUDE.md` and `docs/reference/test-ladder-baseline.md` are the two
files that name the gate commands, so both traps land there.

## #5354 — the documented command stops at the first failing target

Cargo runs each test target as its own binary and stops issuing further targets
the moment one reports a failure. The rung 2/3/4/5 chains named a bare
`cargo test -p <crate>`, so the documented gate inherited the gap. Every rung
command now carries `--no-fail-fast`; the trap is stated at the command in
`CLAUDE.md` rather than only in the linked reference; and the evidence rule now
says what a count from a run without the flag actually proves.

Worked example (closure condition 2), on a two-target project whose `--lib`
target fails:

```
$ cargo test                      # only the --lib target ran
test result: FAILED. 0 passed; 1 failed; 0 ignored
error: test failed, to rerun pass `--lib`

$ cargo test --no-fail-fast       # the integration target ran as well
test result: FAILED. 0 passed; 1 failed; 0 ignored
error: test failed, to rerun pass `--lib`
test result: ok. 1 passed; 0 failed; 0 ignored
```

## #4162 — the predicted `$HOME` breakage does not occur; a different one does

The issue predicted that adopting nextest would reintroduce the race #4120
fixed, because `#[serial]` is an in-process lock. CI adopted nextest (the
`test-shard` job), so I measured it instead of reasoning about it. Three probes,
2026-08-27, this machine:

1. **Process model.** Two tests, one mutating `$HOME`, one reading it after a
   delay. Under nextest they ran in pids 75528 and 77082, and the reader saw the
   real `$HOME`, not the mutation.
2. **`#[serial]` across processes.** Two `#[serial]` tests sharing a key, each
   logging enter/exit around a 400ms sleep:

   ```
   nextest:     one ENTER pid=20794 / two ENTER pid=20795 / two EXIT / one EXIT
   cargo test:  two ENTER pid=20802 / two EXIT / one ENTER pid=20802 / one EXIT
   ```

3. **The actual pollution.** `session_manager_mvp` and `local_spawn` — the
   `$HOME`-touching targets — under both runners, counting the real
   `~/.claude.json`: `projects 2828, tm-test-like 2686` before, and identical
   after each run. Neither runner added an entry.

So the reading this PR records: `$HOME` is process-local, which makes nextest's
process-per-test isolation strictly STRONGER than the in-process lock for env
state, and #4120's guards hold. What genuinely lapses is any `#[serial]`
guarding a resource shared ACROSS processes — a fixed path, a fixed port, one
real file. Those need `#[serial_test::file_serial]` (serial_test's `file_locks`
feature); I found none in this workspace, so this PR documents the rule rather
than converting call sites. The `$HOME` redirect stays mandatory per test: that
is what keeps a test out of the operator's real config, and `#[serial]` never
did that job.

The 2686 `tm-test`-like entries already in `~/.claude.json` are historical
debris and predate this session — neither run above added to them.

## Test ladder: rung 1

Documentation only; no crate source touched, so no changelog fragment and no
version bump (both gates agree).

```
bash scripts/check_sld.sh                 EXIT=0
bash scripts/check_line_cap.sh            EXIT=0
bash scripts/check_doc_numbers.sh         EXIT=0
bash scripts/check_public_docs.sh         EXIT=0
bash scripts/check_changelog_fragment.sh  EXIT=0
bash scripts/check_test_pointers.sh       EXIT=0
bash scripts/check-pr-version-bump.sh     EXIT=0
```

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
