### PR TITLE
test(trusty-search): stop leaking tempdirs into $HOME from restore.rs tests (Refs #6333)

### DIFF
--- a/crates/trusty-search/changelog.d/6333-restore-tests-tempdir-leak.md
+++ b/crates/trusty-search/changelog.d/6333-restore-tests-tempdir-leak.md
@@ -1,0 +1,4 @@
+Fixed
+
+- **Two `commands/start/restore.rs` tests left 6 empty directories in `$HOME` on every run.** `warmboot_counts_every_entry_the_allowlist_excluded` and `a_partial_pre_gate_allowlist_does_not_cost_indexes_on_upgrade` built their fixture roots with `tempdir_in(dirs::home_dir())` inside a `.map()` and then called `std::mem::forget(dir)` to keep each guard alive past the closure. `mem::forget` skips `TempDir::drop`, so `~/ts-warmboot-count*` and `~/ts-upgrade-partial*` accumulated one pair of triples per `cargo test -p trusty-search` — 120 of them on the reporter's machine over nine days (refs [#6333](https://github.com/bobmatnyc/trusty-tools/issues/6333))
+  - the guards now `unzip` out of the same `map` into a `Vec<TempDir>` bound in the test body, so the roots still exist while `retain_approved_entries` canonicalizes them and `Drop` removes them at return. The sibling `warmboot_drops_unapproved_entries` already held its guards this way

--- a/crates/trusty-search/src/commands/start/restore.rs
+++ b/crates/trusty-search/src/commands/start/restore.rs
@@ -880,18 +880,19 @@ mod tests {
             .save_to(&paths.allowlist_file())
             .expect("write empty allowlist");
 
-        let entries: Vec<PersistedIndex> = (0..3)
+        // #6333: the guards live in this scope so `Drop` removes them at
+        // return. The previous `mem::forget` kept them alive by leaking one
+        // `~/ts-warmboot-count*` directory per entry, every run.
+        let (guards, entries): (Vec<tempfile::TempDir>, Vec<PersistedIndex>) = (0..3)
             .map(|i| {
                 let dir = tempfile::Builder::new()
                     .prefix("ts-warmboot-count")
                     .tempdir_in(dirs::home_dir().expect("home"))
                     .expect("tempdir");
                 let root = dir.path().canonicalize().expect("canonicalize");
-                // Keep the tempdir alive for the length of the call.
-                std::mem::forget(dir);
-                PersistedIndex::new(format!("e{i}"), root)
+                (dir, PersistedIndex::new(format!("e{i}"), root))
             })
-            .collect();
+            .unzip();
 
         let out = retain_approved_entries(entries, &paths);
         assert!(out.kept.is_empty(), "{:?}", out.kept);
@@ -899,6 +900,7 @@ mod tests {
             out.excluded, 3,
             "every excluded entry must be counted so the summary can report the cause"
         );
+        drop(guards);
     }
 
     /// The #5926 end-to-end shape: an upgrade whose `allowlist.toml` already
@@ -917,17 +919,18 @@ mod tests {
             .with_project_paths(fx.path().join("projects.json"));
         let registry_path = fx.path().join("indexes.toml");
 
-        let roots: Vec<std::path::PathBuf> = (0..3)
+        // #6333: same leak as above — hold the guards instead of forgetting
+        // them, so the three `~/ts-upgrade-partial*` directories are removed.
+        let (guards, roots): (Vec<tempfile::TempDir>, Vec<std::path::PathBuf>) = (0..3)
             .map(|_| {
                 let dir = tempfile::Builder::new()
                     .prefix("ts-upgrade-partial")
                     .tempdir_in(dirs::home_dir().expect("home"))
                     .expect("tempdir");
                 let root = dir.path().canonicalize().expect("canonicalize");
-                std::mem::forget(dir);
-                root
+                (dir, root)
             })
-            .collect();
+            .unzip();
         let entries: Vec<PersistedIndex> = roots
             .iter()
             .enumerate()
@@ -960,6 +963,7 @@ mod tests {
             out.kept
         );
         assert_eq!(out.kept.len(), 3, "{:?}", out.kept);
+        drop(guards);
     }
 
     /// An unreadable allowlist keeps every entry. Un-indexing the whole fleet


### PR DESCRIPTION
Two `#[cfg(test)]` tests in `crates/trusty-search/src/commands/start/restore.rs` built fixture roots with `tempdir_in(dirs::home_dir())` inside a `.map()` and then called `std::mem::forget(dir)` to keep each guard alive past the closure. `mem::forget` skips `TempDir::drop`, so every `cargo test -p trusty-search` left 6 empty `~/ts-warmboot-count*` / `~/ts-upgrade-partial*` directories behind. Introduced by `ed197cf3f` (#5932).

The guards now `unzip` out of the same `map` into a `Vec<TempDir>` bound in the test body. The roots still exist while `retain_approved_entries` canonicalizes them, and `Drop` removes them at return. The sibling `warmboot_drops_unapproved_entries` already held its guards this way.

Refs #6333

## Leak evidence

Counted with `find "$HOME" -maxdepth 1 -type d \( -name 'ts-warmboot-count*' -o -name 'ts-upgrade-partial*' \) | wc -l` around each pair of test runs.

| | before | after |
|---|---|---|
| pre-fix (`origin/main` file restored) | 0 | **6** |
| post-fix run 1 | 0 | 0 |
| post-fix run 2 | 0 | 0 |
| post-fix run 3 | 0 | 0 |

The 6 the pre-fix run created were removed; the reporter's 120 pre-existing directories were left in place for the owner to clear.

## Test ladder: rung 2 (test-only stabilization)

```
cargo fmt --check                                                    EXIT=0
cargo test -p trusty-search warmboot_counts_every_entry_the_allowlist_excluded
  test result: ok. 1 passed; 0 failed; 0 ignored; 439 filtered out
cargo test -p trusty-search a_partial_pre_gate_allowlist_does_not_cost_indexes_on_upgrade
  test result: ok. 1 passed; 0 failed; 0 ignored; 439 filtered out
cargo test -p trusty-search                                          EXIT=0
  test result: ok. 1805 passed; 0 failed; 1 ignored   (lib)
  test result: ok. 437 passed; 0 failed; 3 ignored    (bin)
  + 20 integration binaries, all ok
cargo clippy -p trusty-search --all-targets -- -D warnings           EXIT=0
bash scripts/check_line_cap.sh                                       EXIT=0
bash scripts/check_test_pointers.sh                                  EXIT=0
  resolved 26975 Test: citation(s) — 0 dangling pointers
bash scripts/check_sld.sh                                            EXIT=0
bash scripts/check_changelog_fragment.sh                             EXIT=0
PR_VERSION_BUMP_BASE=origin/main bash scripts/check-pr-version-bump.sh  EXIT=0
  [ OK ] trusty-search 0.49.4 — src changed, version not yet published
```

No known environmental flakes fired.

## Version bump

None. `check-pr-version-bump.sh` counts a test file under `src/**` as crate source (`scripts/lib/source_class.sh`, THE RULING), but `0.49.4` is not yet on crates.io (latest published is `0.49.3`), so there is nothing to drift from and the gate passes as-is.

## Changelog

`check_changelog_fragment.sh` classifies by path, and `restore.rs` is a production path, so the test-only exemption does not reach an inline `#[cfg(test)]` module. Fragment added: `crates/trusty-search/changelog.d/6333-restore-tests-tempdir-leak.md`.

## Risk

Test-only. No production code path changed.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
