### PR TITLE
feat(trusty-mpm): tm memory import can refresh a drifted drawer, gated on findability (Refs #5044)

### DIFF
--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -4,6 +4,9 @@ name = "trusty-mpm"
 # edits `src/**`, so the `PR version bump vs crates.io` gate (#4421) requires
 # the bump here. Patch because the change is a bug fix inside
 # `provisioner::workspace::provision_in`; no public item changed signature.
+# #5044 rides the same 1.5.6: it adds `ImportOptions::refresh`, two
+# `ImportStatus` variants and `core::memory_import::refresh`, and the crate
+# has no out-of-workspace consumer to break.
 version = "1.5.6"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/trusty-mpm/changelog.d/5044-import-refresh-gate.md
+++ b/crates/trusty-mpm/changelog.d/5044-import-refresh-gate.md
@@ -1,0 +1,19 @@
+Added
+
+- `tm memory import --refresh` (#5044) replaces a drifted drawer with the
+  file's current text — `memory_forget` then `memory_remember`, since
+  trusty-memory has no update-in-place tool — instead of reporting the drift
+  and leaving the stale copy in the palace. The plain run is unchanged and
+  still refuses to touch a drifted drawer; its skip reason now names
+  `--refresh`. Two new report statuses, `refreshed` and `would-refresh`, and a
+  `refreshed` count in the JSON report and the summary line.
+- Under `--refresh`, every file whose drawer the run names is put through
+  `palace_verify_embedded` (#6328) and fails unless that drawer is retrievable
+  right now. The `#4834` flow deletes source files on a clean exit, so a drawer
+  that is stored but absent from vector search — or a gate that could not run
+  at all — blocks the run rather than passing it. `--dry-run --refresh` reports
+  the same verdicts without writing.
+- A refresh that removes the stale drawer and then fails to write its
+  replacement reports `DATA LOSS`, names the removed drawer, and says not to
+  delete the source. A refresh whose `memory_forget` fails reports that nothing
+  changed. The two arms never read alike.

--- a/crates/trusty-mpm/src/bin/tm/cli/actions/memory.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli/actions/memory.rs
@@ -23,10 +23,11 @@ pub(crate) enum MemoryAction {
     /// its slug tag, with drawers that merely link to that slug excluded, so
     /// the match does not depend on the file's prose: a file whose text has
     /// changed since it was imported is still skipped, and the report says its
-    /// drawer has drifted. This command does not refresh a drifted drawer —
-    /// delete it and re-import to replace it. When several drawers could be
-    /// the file's own, or the slug tag is shared by more drawers than one
-    /// lookup returns, the file is reported as failed rather than guessed at.
+    /// drawer has drifted. `--refresh` (issue #5044) replaces such a drawer
+    /// with the file's current text and requires every drawer the run names to
+    /// be retrievable. When several drawers could be the file's own, or the
+    /// slug tag is shared by more drawers than one lookup returns, the file is
+    /// reported as failed rather than guessed at.
     Import {
         /// Directory of memory `.md` files (scanned non-recursively).
         dir: PathBuf,
@@ -36,6 +37,11 @@ pub(crate) enum MemoryAction {
         /// Parse, derive, and dedup-check without writing anything.
         #[arg(long)]
         dry_run: bool,
+        /// Replace a drifted drawer with the file's current text, and fail any
+        /// file whose drawer is not retrievable — the mode to run immediately
+        /// before deleting the source files (issue #5044).
+        #[arg(long)]
+        refresh: bool,
         /// Print the full JSON report instead of the human summary.
         #[arg(long)]
         json: bool,

--- a/crates/trusty-mpm/src/bin/tm/commands/memory.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/memory.rs
@@ -27,6 +27,7 @@ pub(crate) async fn memory(action: MemoryAction) -> anyhow::Result<()> {
             dir,
             palace,
             dry_run,
+            refresh,
             json,
             allow_secret_like,
             memory_socket,
@@ -35,6 +36,7 @@ pub(crate) async fn memory(action: MemoryAction) -> anyhow::Result<()> {
                 dir,
                 palace,
                 dry_run,
+                refresh,
                 allow_secret_like,
                 memory_socket,
             };
@@ -67,8 +69,10 @@ fn print_summary(report: &ImportReport) {
         let status = match file.status {
             ImportStatus::Created => "created",
             ImportStatus::Skipped => "skipped",
+            ImportStatus::Refreshed => "refreshed",
             ImportStatus::WouldCreate => "would-create",
             ImportStatus::WouldSkip => "would-skip",
+            ImportStatus::WouldRefresh => "would-refresh",
             ImportStatus::Failed => "FAILED",
         };
         let drawer = file.drawer_id.as_deref().unwrap_or("-");
@@ -77,7 +81,13 @@ fn print_summary(report: &ImportReport) {
     }
     let mode = if report.dry_run { " (dry run)" } else { "" };
     println!(
-        "\n{} file(s) in {}{mode}: {} created, {} skipped, {} failed → palace {}",
-        report.total, report.dir, report.created, report.skipped, report.failed, report.palace,
+        "\n{} file(s) in {}{mode}: {} created, {} refreshed, {} skipped, {} failed → palace {}",
+        report.total,
+        report.dir,
+        report.created,
+        report.refreshed,
+        report.skipped,
+        report.failed,
+        report.palace,
     );
 }

--- a/crates/trusty-mpm/src/bin/tm/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests.rs
@@ -2182,6 +2182,7 @@ fn cli_parses_memory_import() {
                     dir,
                     palace,
                     dry_run,
+                    refresh,
                     json,
                     allow_secret_like,
                     memory_socket,
@@ -2190,6 +2191,7 @@ fn cli_parses_memory_import() {
             assert_eq!(dir, std::path::PathBuf::from("/tmp/mem"));
             assert_eq!(palace, "trusty-tools");
             assert!(!dry_run, "writes are the default mode");
+            assert!(!refresh, "#5044: replacing a drifted drawer stays opt-in");
             assert!(!json);
             assert!(!allow_secret_like);
             assert!(
@@ -2203,7 +2205,8 @@ fn cli_parses_memory_import() {
 
 /// Why (#4837): `--dry-run` is the safety flag an operator reaches for first,
 /// and `--json` is the machine-readable report a caller verifies with — both
-/// must round-trip, together with the explicit `--memory-socket` override.
+/// must round-trip, together with the explicit `--memory-socket` override and
+/// `--refresh` (#5044).
 #[test]
 fn cli_parses_memory_import_dry_run_json() {
     let cli = Cli::try_parse_from([
@@ -2214,6 +2217,7 @@ fn cli_parses_memory_import_dry_run_json() {
         "--palace",
         "p",
         "--dry-run",
+        "--refresh",
         "--json",
         "--allow-secret-like",
         "--memory-socket",
@@ -2225,6 +2229,7 @@ fn cli_parses_memory_import_dry_run_json() {
             action:
                 MemoryAction::Import {
                     dry_run,
+                    refresh,
                     json,
                     allow_secret_like,
                     memory_socket,
@@ -2232,6 +2237,7 @@ fn cli_parses_memory_import_dry_run_json() {
                 },
         } => {
             assert!(dry_run);
+            assert!(refresh);
             assert!(json);
             assert!(allow_secret_like);
             assert_eq!(

--- a/crates/trusty-mpm/src/core/memory_import/mod.rs
+++ b/crates/trusty-mpm/src/core/memory_import/mod.rs
@@ -35,9 +35,15 @@
 //! remainder is ambiguous, or the candidate set hit its ceiling, the file is
 //! reported as failed rather than guessed at.
 //!
+//! Drift is detected here but repaired in [`refresh`] (issue #5044): the plain
+//! run still refuses to touch a drifted drawer, and `ImportOptions::refresh`
+//! turns that refusal into a replace-in-place plus a findability gate, for the
+//! caller that is about to delete the source file.
+//!
 //! Test: `core::memory_import::tests`.
 
 pub mod parse;
+pub mod refresh;
 
 #[cfg(test)]
 mod tests;
@@ -55,8 +61,9 @@ pub use parse::{ParsedMemory, parse_memory_file};
 /// Why: the flag set is wide enough that a positional-argument signature would
 /// be unreadable at the call site, and threading a struct keeps the CLI layer
 /// a pure translation of clap args.
-/// What: source directory, target palace, and the three behaviour switches.
-/// Test: `dry_run_writes_nothing`, `import_is_idempotent`.
+/// What: source directory, target palace, and the behaviour switches.
+/// Test: `dry_run_writes_nothing`, `import_is_idempotent`,
+/// `refresh_replaces_a_drifted_drawer`.
 #[derive(Debug, Clone)]
 pub struct ImportOptions {
     /// Directory of memory `.md` files. Scanned non-recursively.
@@ -65,6 +72,11 @@ pub struct ImportOptions {
     pub palace: String,
     /// Parse, derive, and dedup-check, but never write.
     pub dry_run: bool,
+    /// Replace a drifted drawer with the file's current text, and require
+    /// every drawer this run maps a file to be retrievable (issue #5044).
+    /// Off by default: both halves are for the caller that is about to delete
+    /// the source files, not for an ordinary top-up import.
+    pub refresh: bool,
     /// Pass `allow_secret_like` on writes, so drawers whose prose trips
     /// trusty-memory's secret heuristic (a URL, a token-shaped identifier)
     /// still store instead of aborting the file.
@@ -89,10 +101,16 @@ pub enum ImportStatus {
     /// `drawer_id` carries the existing drawer when one was found, and `detail`
     /// says whether that drawer's text still matches the file.
     Skipped,
+    /// Refreshed under `refresh`: the drifted drawer was replaced in place and
+    /// `drawer_id` carries the new one (issue #5044).
+    Refreshed,
     /// Dry run: would have been written.
     WouldCreate,
     /// Dry run: would have been skipped.
     WouldSkip,
+    /// Dry run under `refresh`: the drifted drawer `drawer_id` names would
+    /// have been replaced.
+    WouldRefresh,
     /// Parse or write error; `error` carries the cause.
     Failed,
 }
@@ -138,6 +156,8 @@ pub struct ImportReport {
     pub created: usize,
     /// Files already present or not memory files.
     pub skipped: usize,
+    /// Drifted drawers replaced in place (or, in a dry run, that would be).
+    pub refreshed: usize,
     /// Files that failed to parse or write.
     pub failed: usize,
     /// Per-file detail, in filename order.
@@ -150,6 +170,7 @@ impl ImportReport {
         self.total = self.files.len();
         self.created = self.count(&[ImportStatus::Created, ImportStatus::WouldCreate]);
         self.skipped = self.count(&[ImportStatus::Skipped, ImportStatus::WouldSkip]);
+        self.refreshed = self.count(&[ImportStatus::Refreshed, ImportStatus::WouldRefresh]);
         self.failed = self.count(&[ImportStatus::Failed]);
     }
 
@@ -169,7 +190,9 @@ impl ImportReport {
 /// What: resolves the trusty-memory base URL (explicit override, else daemon
 /// discovery), lists `*.md` files in filename order, and for each one derives
 /// the drawer fields, checks for an existing drawer with the same slug tag,
-/// and — unless `dry_run` — writes it via `memory_remember`. Returns the
+/// and — unless `dry_run` — writes it via `memory_remember`. Under
+/// `opts.refresh` a drifted drawer is replaced in place and every row naming a
+/// drawer then passes [`refresh::verify_findable`]. Returns the
 /// [`ImportReport`]; a non-empty `failed` count is the caller's cue to exit
 /// non-zero.
 /// Test: `dry_run_writes_nothing`, `import_is_idempotent`,
@@ -189,12 +212,20 @@ pub async fn run_import(opts: &ImportOptions) -> anyhow::Result<ImportReport> {
         total: 0,
         created: 0,
         skipped: 0,
+        refreshed: 0,
         failed: 0,
         files: Vec::new(),
     };
 
     for path in markdown_files(&opts.dir)? {
-        report.files.push(import_one(&socket, opts, &path).await);
+        let mut result = import_one(&socket, opts, &path).await;
+        // #5044: under `refresh` the run's exit code is what authorises
+        // deleting the source, so every row that names a drawer has to prove
+        // that drawer is retrievable — including one this run only skipped.
+        if opts.refresh {
+            refresh::verify_findable(&socket, &opts.palace, &mut result).await;
+        }
+        report.files.push(result);
     }
     report.tally();
     Ok(report)
@@ -238,8 +269,9 @@ fn markdown_files(dir: &Path) -> anyhow::Result<Vec<PathBuf>> {
 /// What: reads and parses the file; a file with no frontmatter is a clean skip
 /// (`MEMORY.md` and other index files land here). Otherwise asks
 /// [`existing_drawer`] whether the palace already holds this file's own drawer
-/// and skips when it does — whether or not that drawer's text still matches;
-/// otherwise writes via `memory_remember` with `force` set (the established
+/// and skips when it does — a drifted drawer included, unless `opts.refresh`
+/// sends it to [`refresh_one`]; otherwise writes via `memory_remember` with
+/// `force` set (the established
 /// mapping — these drawers are deliberate re-writes of curated content, not
 /// conversational capture). Note that `force` bypasses trusty-memory's own
 /// dedup along with the rest of its quality gates, so the check above is the
@@ -276,14 +308,20 @@ async fn import_one(socket: &Path, opts: &ImportOptions, path: &Path) -> FileRes
             return skipped(file, parsed, drawer_id, "already imported", opts.dry_run);
         }
         Ok(Existing::Drifted(drawer_id)) => {
-            return skipped(
-                file,
-                parsed,
-                drawer_id,
-                "already imported, but the stored drawer's text has drifted from \
-                 this file — left unchanged, never duplicated",
-                opts.dry_run,
-            );
+            // #5044: a snapshot import that later deletes its sources leaves
+            // the palace serving superseded text unless drift is repaired.
+            if !opts.refresh {
+                return skipped(
+                    file,
+                    parsed,
+                    drawer_id,
+                    "already imported, but the stored drawer's text has drifted from \
+                     this file — left unchanged, never duplicated; re-run with \
+                     `refresh` to replace it",
+                    opts.dry_run,
+                );
+            }
+            return refresh_one(socket, opts, file, parsed, &drawer_id).await;
         }
         Ok(Existing::Absent) => {}
         Err(e) => {
@@ -322,6 +360,50 @@ async fn import_one(socket: &Path, opts: &ImportOptions, path: &Path) -> FileRes
             format!("write failed: {e:#}"),
             parsed.tags,
         ),
+    }
+}
+
+/// Replace one drifted drawer, or report why the palace was left as it is.
+///
+/// Why (#5044): the refresh path has three outcomes and they are not
+/// interchangeable — replaced, aborted with the stale drawer intact, and the
+/// window where the old drawer is gone and the new one was never written. Only
+/// the first may report success, and the third has to be loud enough that
+/// nobody deletes the source file after reading the report.
+/// What: dry-runs report [`ImportStatus::WouldRefresh`] and touch nothing.
+/// Otherwise [`refresh::refresh_drawer`] does the forget-then-remember and
+/// either arm of [`refresh::RefreshError`] becomes a failed row carrying that
+/// error's own wording.
+/// Test: `refresh_replaces_a_drifted_drawer`,
+/// `refresh_aborts_with_the_stale_drawer_intact`,
+/// `refresh_reports_the_lost_replacement_loudly`.
+async fn refresh_one(
+    socket: &Path,
+    opts: &ImportOptions,
+    file: String,
+    parsed: ParsedMemory,
+    drawer_id: &str,
+) -> FileResult {
+    if opts.dry_run {
+        return FileResult {
+            file,
+            name: Some(parsed.name),
+            status: ImportStatus::WouldRefresh,
+            drawer_id: Some(drawer_id.to_string()),
+            tags: parsed.tags,
+            detail: Some("the stored drawer's text has drifted from this file".to_string()),
+        };
+    }
+    match refresh::refresh_drawer(socket, opts, &parsed, drawer_id).await {
+        Ok(new_id) => FileResult {
+            file,
+            name: Some(parsed.name),
+            status: ImportStatus::Refreshed,
+            drawer_id: Some(new_id),
+            tags: parsed.tags,
+            detail: Some(format!("replaced the drifted drawer {drawer_id}")),
+        },
+        Err(e) => failure(file, Some(parsed.name), e.to_string(), parsed.tags),
     }
 }
 

--- a/crates/trusty-mpm/src/core/memory_import/refresh.rs
+++ b/crates/trusty-mpm/src/core/memory_import/refresh.rs
@@ -1,0 +1,229 @@
+//! Replace-in-place for a drifted drawer, and the findability gate around it.
+//!
+//! Why (issue #5044): the #4834 migration took its import as a one-shot
+//! snapshot and deleted the source files later. A file edited between the two
+//! steps left the palace serving superseded text — three such drawers were
+//! found by direct comparison, two of them carrying claims a later edit had
+//! reversed. Detection already existed ([`super::Existing::Drifted`]); the
+//! action did not, so an operator's only route was to delete the drawer by hand
+//! and re-import.
+//!
+//! What: [`refresh_drawer`] is that action — `memory_forget` then
+//! `memory_remember`, because trusty-memory has no update-in-place tool by
+//! design. [`verify_findable`] is the gate: it asks `palace_verify_embedded`
+//! (PR #6328) whether the drawer a file now maps to is actually retrievable,
+//! and downgrades the row to [`ImportStatus::Failed`] when it is not. A
+//! deletion workflow reads the run's exit code, so a fresh-but-unfindable
+//! drawer must not report success.
+//!
+//! Both halves fail closed and say which of the two happened, because the
+//! sequence has a window with no copy of the file in the palace: if the forget
+//! lands and the write does not, the stale drawer is gone and nothing replaced
+//! it. That arm is [`RefreshError::ReplacementLost`], and it is the one case
+//! where re-running the import is mandatory rather than merely idempotent.
+//!
+//! Test: `refresh_replaces_a_drifted_drawer`,
+//! `refresh_reports_the_lost_replacement_loudly`,
+//! `refresh_aborts_with_the_stale_drawer_intact`,
+//! `verify_gate_fails_a_drawer_no_vector_search_returns`.
+
+use std::path::Path;
+
+use serde_json::{Value, json};
+
+use super::{FileResult, ImportOptions, ImportStatus, ParsedMemory, write_drawer};
+
+/// How a refresh failed, and — the part that matters — what it left behind.
+///
+/// Why: the two arms call for opposite operator responses. An abort changed
+/// nothing, so the run can simply be repeated. A lost replacement means the
+/// palace no longer holds this file at all, so its source must not be deleted
+/// and the import must be re-run before anything else reads the palace.
+/// What: each variant names the drawer id it concerns and carries the
+/// underlying RPC failure.
+/// Test: `refresh_aborts_with_the_stale_drawer_intact`,
+/// `refresh_reports_the_lost_replacement_loudly`.
+#[derive(Debug, thiserror::Error)]
+pub enum RefreshError {
+    /// The `memory_forget` failed; the stale drawer is still there.
+    #[error(
+        "refresh aborted with nothing changed — the stale drawer {drawer_id} is still in \
+         place: {source:#}"
+    )]
+    Aborted {
+        /// The drawer the refresh would have replaced.
+        drawer_id: String,
+        /// The `memory_forget` failure.
+        source: anyhow::Error,
+    },
+    /// The forget landed and the write did not: the file is now unrepresented.
+    #[error(
+        "DATA LOSS — the stale drawer {drawer_id} was removed and its replacement could not \
+         be written ({source:#}); this file is no longer in the palace, so do not delete its \
+         source, and re-run the import to restore it"
+    )]
+    ReplacementLost {
+        /// The drawer that was removed and not replaced.
+        drawer_id: String,
+        /// The `memory_remember` failure.
+        source: anyhow::Error,
+    },
+}
+
+/// Replace `drawer_id`'s contents with this file's current text.
+///
+/// Why: trusty-memory exposes no update-in-place tool, so "refresh" composes
+/// out of the two tools that do exist. Doing it here rather than at the call
+/// site keeps the ordering — forget first, so the slug tag can never name two
+/// drawers — in one place.
+/// What: `memory_forget` the stale drawer, then `memory_remember` the derived
+/// text through the same [`write_drawer`] path a first import uses. Returns the
+/// new drawer id.
+///
+/// # Errors
+///
+/// [`RefreshError::Aborted`] when the forget failed and nothing changed;
+/// [`RefreshError::ReplacementLost`] when the forget landed and the write did
+/// not. A forget that reports `not_found` is not an error: the drawer was
+/// already gone, and writing the file back is exactly the right next step.
+///
+/// Test: `refresh_replaces_a_drifted_drawer`,
+/// `refresh_aborts_with_the_stale_drawer_intact`,
+/// `refresh_reports_the_lost_replacement_loudly`.
+pub async fn refresh_drawer(
+    socket: &Path,
+    opts: &ImportOptions,
+    parsed: &ParsedMemory,
+    drawer_id: &str,
+) -> Result<String, RefreshError> {
+    // #5044: forget before remember, so the file's slug tag never names two
+    // drawers at once — the ambiguity `existing_drawer` refuses to guess at.
+    trusty_common::memory_rpc::call_memory_tool_at(
+        socket,
+        "memory_forget",
+        json!({ "palace": opts.palace, "drawer_id": drawer_id }),
+    )
+    .await
+    .map_err(|source| RefreshError::Aborted {
+        drawer_id: drawer_id.to_string(),
+        source,
+    })?;
+
+    write_drawer(socket, opts, parsed).await.map_err(|source| {
+        // The one arm that leaves the palace worse than it found it.
+        tracing::error!(
+            drawer_id = %drawer_id,
+            palace = %opts.palace,
+            "refresh removed a drawer and could not write its replacement: {source:#}"
+        );
+        RefreshError::ReplacementLost {
+            drawer_id: drawer_id.to_string(),
+            source,
+        }
+    })
+}
+
+/// Fail `result` unless the drawer it names is retrievable right now.
+///
+/// Why (#5044, gate from PR #6328): the reason to refresh a drawer is that
+/// something is about to delete the source file. "Written" is not the property
+/// that authorises the delete — "findable" is, and the two differ: a drawer can
+/// be stored, durable, and permanently absent from vector search.
+/// `memory_recall` cannot answer it either, because it can hit lexically on a
+/// drawer no vector search returns.
+/// What: asks `palace_verify_embedded` about this row's drawer id and reads its
+/// single `verified` boolean. Anything but `true` — a missing vector, an id the
+/// palace does not know, an alias-audited collision, or a gate that could not
+/// run at all — downgrades the row to [`ImportStatus::Failed`], which is what
+/// makes the run exit non-zero. Rows with no drawer id (a dry-run create, an
+/// index file) and rows already failed are left alone.
+/// Test: `verify_gate_fails_a_drawer_no_vector_search_returns`,
+/// `verify_gate_fails_closed_when_it_cannot_run`,
+/// `refresh_replaces_a_drifted_drawer`.
+pub async fn verify_findable(socket: &Path, palace: &str, result: &mut FileResult) {
+    let Some(drawer_id) = result.drawer_id.clone() else {
+        return;
+    };
+    if result.status == ImportStatus::Failed {
+        return;
+    }
+    let stored = stored_phrase(result.status);
+    match verdict(socket, palace, &drawer_id).await {
+        Ok(None) => {}
+        Ok(Some(reason)) => fail(result, format!("{stored}, but is not findable: {reason}")),
+        // #5044: a gate that could not run is never a pass — nothing is known
+        // about this drawer, which is a block for a deletion workflow.
+        Err(e) => fail(
+            result,
+            format!("{stored}, but the findability gate could not run: {e:#}"),
+        ),
+    }
+}
+
+/// What the row had achieved before the gate downgraded it to `Failed`.
+///
+/// Why: the row's own status is about to be overwritten, and "failed" alone
+/// would read as "nothing was written" — a drawer this run created and could
+/// not verify is still in the palace, and the operator has to know that.
+fn stored_phrase(status: ImportStatus) -> &'static str {
+    match status {
+        ImportStatus::Created => "the drawer was written",
+        ImportStatus::Refreshed => "the drifted drawer was replaced",
+        ImportStatus::Skipped => "the drawer was already in the palace",
+        _ => "the drawer is in the palace",
+    }
+}
+
+/// `Ok(None)` when the drawer is findable, `Ok(Some(reason))` when it is not.
+async fn verdict(socket: &Path, palace: &str, drawer_id: &str) -> anyhow::Result<Option<String>> {
+    let answer = trusty_common::memory_rpc::call_memory_tool_at(
+        socket,
+        "palace_verify_embedded",
+        json!({ "palace": palace, "drawer_ids": [drawer_id] }),
+    )
+    .await?;
+    if answer.get("verified").and_then(Value::as_bool) == Some(true) {
+        return Ok(None);
+    }
+    Ok(Some(unverified_reason(&answer)))
+}
+
+/// Turn a `verified: false` answer into the phrase an operator can act on.
+fn unverified_reason(answer: &Value) -> String {
+    let has = |key: &str| {
+        answer
+            .get(key)
+            .and_then(Value::as_array)
+            .is_some_and(|ids| !ids.is_empty())
+    };
+    if has("unknown") {
+        return "the palace holds no drawer with this id".to_string();
+    }
+    if has("missing") {
+        return "the drawer has no vector, so no vector search will return it — \
+                run palace_reembed"
+            .to_string();
+    }
+    match answer.get("alias_audit").and_then(Value::as_str) {
+        Some("clean") | None => {
+            "palace_verify_embedded declined to verify it and named no cause".to_string()
+        }
+        Some(state) => format!(
+            "the palace's vector-key audit is {state}{}",
+            answer
+                .get("alias_audit_error")
+                .and_then(Value::as_str)
+                .map(|e| format!(" ({e})"))
+                .unwrap_or_default()
+        ),
+    }
+}
+
+/// Downgrade a row to `Failed`, keeping any detail it already carried.
+fn fail(result: &mut FileResult, reason: String) {
+    result.status = ImportStatus::Failed;
+    result.detail = Some(match result.detail.take() {
+        Some(prior) => format!("{prior}; {reason}"),
+        None => reason,
+    });
+}

--- a/crates/trusty-mpm/src/core/memory_import/tests.rs
+++ b/crates/trusty-mpm/src/core/memory_import/tests.rs
@@ -5,13 +5,16 @@
 //! nothing, and a re-run duplicates nothing — are the whole reason the command
 //! can be pointed at a live palace.
 //! What: pure parser tests plus loop tests driven against a stub JSON-RPC
-//! daemon that implements just `memory_list` and `memory_remember`.
+//! daemon that implements `memory_list`, `memory_remember`, `memory_forget`
+//! and `palace_verify_embedded`, and can be told to refuse any of them.
 //! Test: this file.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 
 use serde_json::{Value, json};
+
+use crate::uds_mock::RpcError;
 
 use super::parse::{describe, parse_memory_file, split_frontmatter, wikilink_targets};
 use super::{DEDUP_CANDIDATE_LIMIT, ImportOptions, ImportStatus, has_headline_of, run_import};
@@ -249,17 +252,27 @@ struct StubState {
     writes: Vec<Value>,
     /// Every `memory_list` params object, in call order.
     lists: Vec<Value>,
+    /// Every `memory_forget` params object, in call order (#5044).
+    forgets: Vec<Value>,
     /// tag → drawer ids carrying it.
     by_tag: HashMap<String, Vec<String>>,
     /// drawer id → stored content.
     content: HashMap<String, String>,
+    /// Methods the daemon refuses, so a test can pick which half of the
+    /// forget-then-remember pair fails (#5044).
+    deny: HashSet<String>,
+    /// Drawer ids `palace_verify_embedded` reports as stored but unfindable.
+    unembedded: HashSet<String>,
 }
 
 type Stub = Arc<Mutex<StubState>>;
 
-fn rpc(state: &Stub, method: &str, params: Value) -> Value {
+fn rpc(state: &Stub, method: &str, params: Value) -> Result<Value, RpcError> {
     let mut st = state.lock().expect("stub lock");
-    match method {
+    if st.deny.contains(method) {
+        return Err(RpcError::internal(format!("{method} refused by the stub")));
+    }
+    Ok(match method {
         "memory_list" => {
             st.lists.push(params.clone());
             let tag = params.get("tag").and_then(Value::as_str).unwrap_or("");
@@ -302,8 +315,52 @@ fn rpc(state: &Stub, method: &str, params: Value) -> Value {
             }
             json!({ "drawer_id": id, "status": "stored" })
         }
+        "memory_forget" => {
+            st.forgets.push(params.clone());
+            let id = params
+                .get("drawer_id")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            let existed = st.content.remove(&id).is_some();
+            for ids in st.by_tag.values_mut() {
+                ids.retain(|held| held != &id);
+            }
+            let status = if existed { "deleted" } else { "not_found" };
+            json!({ "status": status, "drawer_id": id, "palace": "stub" })
+        }
+        "palace_verify_embedded" => {
+            let requested: Vec<String> = params
+                .get("drawer_ids")
+                .and_then(Value::as_array)
+                .map(|ids| {
+                    ids.iter()
+                        .filter_map(Value::as_str)
+                        .map(str::to_string)
+                        .collect()
+                })
+                .unwrap_or_default();
+            let (mut embedded, mut missing, mut unknown) = (Vec::new(), Vec::new(), Vec::new());
+            for id in requested {
+                if !st.content.contains_key(&id) {
+                    unknown.push(id);
+                } else if st.unembedded.contains(&id) {
+                    missing.push(id);
+                } else {
+                    embedded.push(id);
+                }
+            }
+            json!({
+                "palace": "stub",
+                "embedded": embedded,
+                "missing": missing,
+                "unknown": unknown,
+                "alias_audit": "clean",
+                "verified": missing.is_empty() && unknown.is_empty(),
+            })
+        }
         other => json!({ "error": format!("unexpected method {other}") }),
-    }
+    })
 }
 
 /// Start the stub on a temp Unix socket (#6286); returns the daemon + state.
@@ -313,7 +370,7 @@ async fn start_stub() -> (crate::uds_mock::MockMemoryDaemon, Stub) {
     let daemon = crate::uds_mock::spawn(move |method: &str, params: Value| {
         let state = Arc::clone(&served);
         let method = method.to_string();
-        Box::pin(async move { Ok(rpc(&state, &method, params)) })
+        Box::pin(async move { rpc(&state, &method, params) })
     })
     .await;
     (daemon, state)
@@ -324,9 +381,33 @@ fn opts(dir: &std::path::Path, socket: &std::path::Path, dry_run: bool) -> Impor
         dir: dir.to_path_buf(),
         palace: "stub".to_string(),
         dry_run,
+        refresh: false,
         allow_secret_like: true,
         memory_socket: Some(socket.to_path_buf()),
     }
+}
+
+/// The same options with `refresh` on (#5044).
+fn refresh_opts(dir: &std::path::Path, socket: &std::path::Path, dry_run: bool) -> ImportOptions {
+    ImportOptions {
+        refresh: true,
+        ..opts(dir, socket, dry_run)
+    }
+}
+
+/// Import `SAMPLE`, then rewrite its `description` so the stored drawer drifts.
+///
+/// Returns the drawer id the first import wrote — the one a refresh replaces.
+async fn import_then_drift(dir: &std::path::Path, socket: &std::path::Path) -> String {
+    let first = run_import(&opts(dir, socket, false)).await.unwrap();
+    assert_eq!(first.created, 1, "{:#?}", first.files);
+    let id = first.files[0].drawer_id.clone().expect("drawer id");
+    let drifted = SAMPLE.replace(
+        "description: Admin-merge bypasses bot-approval ONLY — never a red CI gate;",
+        "description: Admin-merge bypasses bot approval, never a red CI gate",
+    );
+    std::fs::write(dir.join("admin-merge-only-on-green.md"), &drifted).unwrap();
+    id
 }
 
 // ---------------------------------------------------------------------------
@@ -655,6 +736,7 @@ fn report_serialises_with_per_file_status_and_drawer_id() {
         total: 1,
         created: 1,
         skipped: 0,
+        refreshed: 0,
         failed: 0,
         files: vec![super::FileResult {
             file: "a.md".into(),
@@ -669,4 +751,237 @@ fn report_serialises_with_per_file_status_and_drawer_id() {
     assert_eq!(json["files"][0]["status"], "created");
     assert_eq!(json["files"][0]["drawer_id"], "uuid-1");
     assert!(json["files"][0].get("detail").is_none());
+}
+
+// ---------------------------------------------------------------------------
+// Refresh + findability gate (#5044)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn refresh_replaces_a_drifted_drawer() {
+    // The defect: the #4834 migration imported once and deleted its sources
+    // later, so a file edited in between left the palace serving superseded
+    // text. Drift was detected and reported; nothing repaired it.
+    let dir = write_dir(&[("admin-merge-only-on-green.md", SAMPLE)]);
+    let (daemon, state) = start_stub().await;
+    let stale_id = import_then_drift(dir.path(), daemon.socket()).await;
+
+    let second = run_import(&refresh_opts(dir.path(), daemon.socket(), false))
+        .await
+        .unwrap();
+
+    assert_eq!(second.failed, 0, "{:#?}", second.files);
+    assert_eq!(second.refreshed, 1, "{:#?}", second.files);
+    assert_eq!(second.files[0].status, ImportStatus::Refreshed);
+    let fresh_id = second.files[0].drawer_id.clone().expect("new drawer id");
+    assert_ne!(fresh_id, stale_id, "a refresh writes a new drawer");
+
+    let st = state.lock().unwrap();
+    assert_eq!(
+        st.forgets[0]["drawer_id"].as_str(),
+        Some(stale_id.as_str()),
+        "the stale drawer must be the one forgotten"
+    );
+    assert_eq!(
+        st.writes.len(),
+        2,
+        "one original write plus the replacement"
+    );
+    assert!(
+        !st.content.contains_key(&stale_id),
+        "the stale drawer must be gone, never left beside its replacement"
+    );
+    assert!(
+        st.content[&fresh_id]
+            .starts_with("Admin-merge bypasses bot approval, never a red CI gate."),
+        "{:?}",
+        st.content[&fresh_id]
+    );
+}
+
+#[tokio::test]
+async fn refresh_reports_the_lost_replacement_loudly() {
+    // Fail-open check: the forget lands, the write does not, and the palace
+    // now holds no copy of this file at all. Reporting that as anything but a
+    // failure would let a deletion workflow read a clean exit and drop the
+    // only surviving copy.
+    let dir = write_dir(&[("admin-merge-only-on-green.md", SAMPLE)]);
+    let (daemon, state) = start_stub().await;
+    let stale_id = import_then_drift(dir.path(), daemon.socket()).await;
+    state
+        .lock()
+        .unwrap()
+        .deny
+        .insert("memory_remember".to_string());
+
+    let second = run_import(&refresh_opts(dir.path(), daemon.socket(), false))
+        .await
+        .unwrap();
+
+    assert_eq!(second.refreshed, 0, "{:#?}", second.files);
+    assert_eq!(second.failed, 1, "{:#?}", second.files);
+    assert_eq!(second.files[0].status, ImportStatus::Failed);
+    let detail = second.files[0].detail.clone().unwrap_or_default();
+    assert!(detail.contains("DATA LOSS"), "{detail}");
+    assert!(detail.contains(&stale_id), "{detail}");
+    assert!(
+        detail.contains("do not delete its"),
+        "the report must say what not to do next: {detail}"
+    );
+
+    let st = state.lock().unwrap();
+    assert!(
+        !st.content.contains_key(&stale_id),
+        "the forget really did land — this is the state the row must report"
+    );
+}
+
+#[tokio::test]
+async fn refresh_aborts_with_the_stale_drawer_intact() {
+    // The other arm: the forget failed, so nothing changed and re-running is
+    // all the operator has to do. It must not read like the arm above.
+    let dir = write_dir(&[("admin-merge-only-on-green.md", SAMPLE)]);
+    let (daemon, state) = start_stub().await;
+    let stale_id = import_then_drift(dir.path(), daemon.socket()).await;
+    state
+        .lock()
+        .unwrap()
+        .deny
+        .insert("memory_forget".to_string());
+
+    let second = run_import(&refresh_opts(dir.path(), daemon.socket(), false))
+        .await
+        .unwrap();
+
+    assert_eq!(second.failed, 1, "{:#?}", second.files);
+    let detail = second.files[0].detail.clone().unwrap_or_default();
+    assert!(detail.contains("nothing changed"), "{detail}");
+    assert!(!detail.contains("DATA LOSS"), "{detail}");
+
+    let st = state.lock().unwrap();
+    assert!(
+        st.content.contains_key(&stale_id),
+        "the drawer must survive"
+    );
+    assert_eq!(st.writes.len(), 1, "an aborted refresh writes nothing");
+}
+
+#[tokio::test]
+async fn refresh_dry_run_touches_nothing() {
+    // `--dry-run --refresh` is the diff-check a deletion flow runs first: it
+    // must name every drawer it would replace without replacing any.
+    let dir = write_dir(&[("admin-merge-only-on-green.md", SAMPLE)]);
+    let (daemon, state) = start_stub().await;
+    let stale_id = import_then_drift(dir.path(), daemon.socket()).await;
+
+    let second = run_import(&refresh_opts(dir.path(), daemon.socket(), true))
+        .await
+        .unwrap();
+
+    assert_eq!(second.refreshed, 1, "{:#?}", second.files);
+    assert_eq!(second.files[0].status, ImportStatus::WouldRefresh);
+    assert_eq!(
+        second.files[0].drawer_id.as_deref(),
+        Some(stale_id.as_str())
+    );
+
+    let st = state.lock().unwrap();
+    assert!(st.forgets.is_empty(), "a dry run must forget nothing");
+    assert_eq!(st.writes.len(), 1, "a dry run must write nothing");
+}
+
+#[tokio::test]
+async fn verify_gate_fails_a_drawer_no_vector_search_returns() {
+    // A drawer can be stored, current, and permanently unfindable. Under
+    // `refresh` the run's exit code authorises deleting the source, so an
+    // unembedded drawer has to fail the file even when nothing drifted.
+    let dir = write_dir(&[("admin-merge-only-on-green.md", SAMPLE)]);
+    let (daemon, state) = start_stub().await;
+    let first = run_import(&refresh_opts(dir.path(), daemon.socket(), false))
+        .await
+        .unwrap();
+    assert_eq!(
+        first.failed, 0,
+        "a findable drawer passes: {:#?}",
+        first.files
+    );
+    let drawer_id = first.files[0].drawer_id.clone().expect("drawer id");
+    state.lock().unwrap().unembedded.insert(drawer_id);
+
+    let second = run_import(&refresh_opts(dir.path(), daemon.socket(), false))
+        .await
+        .unwrap();
+
+    assert_eq!(second.failed, 1, "{:#?}", second.files);
+    assert_eq!(second.files[0].status, ImportStatus::Failed);
+    let detail = second.files[0].detail.clone().unwrap_or_default();
+    assert!(detail.contains("not findable"), "{detail}");
+    assert!(detail.contains("no vector"), "{detail}");
+    // The skip reason it carried before the downgrade is still there.
+    assert!(detail.contains("already imported"), "{detail}");
+}
+
+#[tokio::test]
+async fn verify_gate_fails_closed_when_it_cannot_run() {
+    // An older daemon has no `palace_verify_embedded` at all. Nothing is known
+    // about the drawer, which is a block — not a pass.
+    let dir = write_dir(&[("admin-merge-only-on-green.md", SAMPLE)]);
+    let (daemon, state) = start_stub().await;
+    state
+        .lock()
+        .unwrap()
+        .deny
+        .insert("palace_verify_embedded".to_string());
+
+    let report = run_import(&refresh_opts(dir.path(), daemon.socket(), false))
+        .await
+        .unwrap();
+
+    assert_eq!(report.failed, 1, "{:#?}", report.files);
+    assert!(
+        report.files[0]
+            .detail
+            .as_deref()
+            .unwrap_or_default()
+            .contains("findability gate could not run"),
+        "{:#?}",
+        report.files[0]
+    );
+    assert!(
+        report.files[0]
+            .detail
+            .as_deref()
+            .unwrap_or_default()
+            .contains("the drawer was written"),
+        "an unverifiable row must still say the drawer is in the palace: {:#?}",
+        report.files[0]
+    );
+}
+
+#[tokio::test]
+async fn a_plain_run_never_calls_the_gate() {
+    // The gate costs one RPC per file. Without `refresh` it must not run at
+    // all, and drift must still be reported rather than repaired.
+    let dir = write_dir(&[("admin-merge-only-on-green.md", SAMPLE)]);
+    let (daemon, state) = start_stub().await;
+    let stale_id = import_then_drift(dir.path(), daemon.socket()).await;
+
+    let second = run_import(&opts(dir.path(), daemon.socket(), false))
+        .await
+        .unwrap();
+
+    assert_eq!(second.skipped, 1, "{:#?}", second.files);
+    assert_eq!(second.refreshed, 0);
+    assert!(
+        second.files[0]
+            .detail
+            .as_deref()
+            .unwrap_or_default()
+            .contains("drifted"),
+        "{:#?}",
+        second.files[0]
+    );
+    let st = state.lock().unwrap();
+    assert!(st.forgets.is_empty());
+    assert!(st.content.contains_key(&stale_id));
 }


### PR DESCRIPTION
Refs #5044

## What and why

The #4834 migration imported once and deleted its source files later, so a file edited in between left the palace serving superseded text. `tm memory import` already detected that drift and reported it; nothing repaired it, and the report's own advice was to delete the drawer by hand.

`--refresh` replaces a drifted drawer in place — `memory_forget` then `memory_remember`, since trusty-memory has no update-in-place tool by design. A plain run is unchanged and still refuses to touch a drifted drawer.

Writing is not the property that authorises deleting a source file; being findable is, and the two differ. Under `--refresh` every drawer the run names goes through `palace_verify_embedded` (#6328), and anything short of `verified: true` — no vector, an unknown id, an aliased or unreadable audit, or a gate that could not run at all — fails the file and the run's exit code with it. `--dry-run --refresh` reports the same verdicts and writes nothing, which is the diff-check the issue's Resolution asks for.

The sequence has a window with no copy of the file in the palace. If the forget lands and the write does not, the row reports `DATA LOSS`, names the removed drawer, and says not to delete the source. If the forget itself fails, the row says nothing changed. A row the gate downgrades still says what it left behind (`the drawer was written, but is not findable: …`), so `failed` is never read as "nothing was written".

Out of scope: the deletion step itself. This makes the exit code trustworthy for whatever runs it.

## Test ladder: rung 3 (trusty-mpm)

```
cargo fmt --check                                        # EXIT=0
cargo check -p trusty-mpm                                # EXIT=0
cargo clippy -p trusty-mpm --all-targets -- -D warnings  # EXIT=0
cargo test -p trusty-mpm --no-fail-fast                  # EXIT=0
```

`cargo test -p trusty-mpm --no-fail-fast`: 50 targets, 9382 passed, 0 failed, 18 ignored.

Repo gates: `check_line_cap.sh` (4208 files, 0 violations), `check_changelog_fragment.sh` (1 crate recorded), `check_test_pointers.sh` (26990 citations, 0 dangling), `check_sld.sh` (0 errors), `check-pr-version-bump.sh` (`[ OK ] trusty-mpm 1.5.6 — src changed, version not yet published`; main had already bumped to 1.5.6 and 1.5.5 is the live crates.io version, so no further bump).

## Failing before the fix

Seven new tests in `core::memory_import::tests`. With the two change sites reverted to their pre-#5044 behaviour (the `Drifted` arm ignoring `refresh`, and the `verify_findable` call removed) while the new API stays so the target compiles:

```
test result: FAILED. 29 passed; 6 failed; 0 ignored

failures:
    core::memory_import::tests::refresh_aborts_with_the_stale_drawer_intact
    core::memory_import::tests::refresh_dry_run_touches_nothing
    core::memory_import::tests::refresh_replaces_a_drifted_drawer
    core::memory_import::tests::refresh_reports_the_lost_replacement_loudly
    core::memory_import::tests::verify_gate_fails_a_drawer_no_vector_search_returns
    core::memory_import::tests::verify_gate_fails_closed_when_it_cannot_run
```

Reverting the production files wholesale instead (`git checkout origin/main -- crates/trusty-mpm/src/core/memory_import/`) fails to compile: `no field 'refresh' on ImportOptions`, `no variant 'Refreshed'`.

With the fix: `test result: ok. 35 passed; 0 failed`.

## Fail-open arm

`refresh_reports_the_lost_replacement_loudly` denies `memory_remember` on the refresh run, asserts the row is `Failed`, that its detail carries `DATA LOSS`, the removed drawer id and "do not delete its source", and that the stub really no longer holds the drawer — the state the row has to report. `refresh_aborts_with_the_stale_drawer_intact` is the mirror: the forget fails, the drawer survives, no write is issued, and the detail says "nothing changed" and never "DATA LOSS".

## Live smoke run

Against the running trusty-memory daemon (which predates #6328, so it has no `palace_verify_embedded`), into a throwaway palace deleted afterwards:

```
$ tm memory import <dir> --palace smoke-5044 --refresh --allow-secret-like
FAILED  agent-monitor-parking-pattern.md  83eb5712-b23b-48f2-9ae5-4c17fe1d759b
        replaced the drifted drawer 0e9a8b0f-b8c0-4a96-b9c7-c715ac10cb4d;
        the drifted drawer was replaced, but the findability gate could not run:
        palace_verify_embedded failed: Method not found: palace_verify_embedded (-32601)

2 file(s) in <dir>: 0 created, 0 refreshed, 0 skipped, 2 failed → palace smoke-5044
Error: 2 file(s) failed to import
```

`memory_list` on that palace afterwards returned exactly one drawer for the slug — the new id, carrying the edited text — so the live replace-in-place landed and left no duplicate. The gate then failed closed on a daemon that cannot answer it, with a non-zero exit.

## Baseline

`tests_behavior_b::compose_session_instructions_display_matches_live_prompt_with_override` failed once mid-session and passed in isolation and on the final full run. It compares two enumerations of the live `~/.claude` roster — the environmental flake #4937 documents for its sibling. Not touched by this change.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
