### PR TITLE
fix(website): the trusty-memory fact card counts the two tools #6328 added

### DIFF
--- a/website/src/routes/tools/trusty-memory/+page.svelte
+++ b/website/src/routes/tools/trusty-memory/+page.svelte
@@ -7,7 +7,7 @@
 	const facts = [
 		{ label: 'Package', value: 'trusty-memory' },
 		{ label: 'Default port', value: '7070' },
-		{ label: 'MCP tools', value: '47' },
+		{ label: 'MCP tools', value: '49' },
 		{ label: 'Storage', value: 'usearch + redb, on disk' }
 	];
 </script>


### PR DESCRIPTION
## Summary
PR #6328 added `palace_verify_embedded` and `palace_embed_sweep` dispatch arms to `crates/trusty-memory/src/tools/mod.rs` (49 dispatch arms total), but the hand-authored fact card on `/tools/trusty-memory` still said `47`. Updates the card to `49`.

Refs #5000, surfaced as Vitest red on #6319/#6334/#6341

## Test plan
Test ladder: rung 1 (docs-only bucket, `website/**` only) — website `pnpm test` from `website/`:

```
Test Files  14 passed (14)
     Tests  268 passed (268)
```

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools