### PR TITLE
feat(trusty-mpm): serve a hardened UDS listener alongside HTTP (Refs #6288)

### DIFF
--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -212,6 +212,12 @@ trusty-common = { workspace = true, features = [
     # daemon router in `daemon/api.rs`. Already enabled as a dev-dependency below;
     # promoted to the main dep so the guard compiles into the production daemon.
     "axum-server",
+    # #6288 (ADR-0032): the daemon's own hardened Unix-socket listener
+    # (`daemon::socket`) — `bind_singleton_hardened` plus `uds::server`'s
+    # `RpcRouter` / `serve_until`. Reached transitively today through
+    # `catchup` → `memory-rpc` → `uds`; listed explicitly so a future change to
+    # the catch-up engine's deps cannot silently remove the daemon's transport.
+    "uds",
 ] }
 # `bug-capture` enables Phase 1 ERROR event capture to JSONL + in-memory ring (bug-reporting #478)
 # `console-metrics` enables `trusty_common::console_metrics` (used unconditionally by

--- a/crates/trusty-mpm/changelog.d/6288-s1-uds-scaffold-changed.md
+++ b/crates/trusty-mpm/changelog.d/6288-s1-uds-scaffold-changed.md
@@ -1,0 +1,12 @@
+Changed
+
+- `DaemonLock` gains a `socket_path` field recording the socket the writing
+  daemon serves; `addr` is unchanged. The field is `#[serde(default)]`, so a
+  lock written by a pre-#6288 daemon still parses, with an empty `socket_path`
+  meaning HTTP only. `daemon::lock::write_lock` and
+  `core::daemon_identity::write_lock` / `write_lock_at` take the socket path as
+  a second argument
+  ([#6288](https://github.com/bobmatnyc/trusty-tools/issues/6288)).
+- `daemon::serve_http` waits for the shutdown signal through
+  `trusty_common::shutdown_signal` and fans it out to both listeners, replacing
+  a private line-for-line copy of that helper.

--- a/crates/trusty-mpm/changelog.d/6288-s1-uds-scaffold-changed.md
+++ b/crates/trusty-mpm/changelog.d/6288-s1-uds-scaffold-changed.md
@@ -10,3 +10,8 @@ Changed
 - `daemon::serve_http` waits for the shutdown signal through
   `trusty_common::shutdown_signal` and fans it out to both listeners, replacing
   a private line-for-line copy of that helper.
+- `daemon::run_http` and `run_daemon` bind the RPC socket before the daemon
+  publishes anything. `daemon::serve_http` takes the pre-bound socket rather than
+  binding it, so a bind failure aborts before the lock file is written instead of
+  leaving a record naming a daemon that never started
+  ([#6288](https://github.com/bobmatnyc/trusty-tools/issues/6288)).

--- a/crates/trusty-mpm/changelog.d/6288-s1-uds-scaffold.md
+++ b/crates/trusty-mpm/changelog.d/6288-s1-uds-scaffold.md
@@ -1,0 +1,17 @@
+Added
+
+- The daemon binds a hardened Unix socket at `<data dir>/trusty-mpm.sock`
+  alongside `127.0.0.1:7880`, through the same
+  `trusty_common::uds::bind_singleton_hardened` entry point trusty-memory,
+  trusty-review, and trusty-analyze use — a `0600` socket in a `0700` directory,
+  with a peer-uid check on every accepted connection. The listener serves an
+  `RpcRouter` with no registered methods, so every request answers
+  `method_not_found` until slice 2 moves the first route across; both listeners
+  drain on the same SIGTERM/SIGINT and the socket file is unlinked before the
+  listener is dropped. A socket that cannot be bound fails startup with an error
+  naming the path rather than degrading to an HTTP-only daemon. No HTTP route
+  moved and nothing was removed (slice 1 of
+  [#6288](https://github.com/bobmatnyc/trusty-tools/issues/6288), ADR-0032).
+- `daemon::socket` — `socket_path`, `bind`, and `serve_until_shutdown`, the
+  listener's bind and serve halves, split so a test can drive the real path with
+  its own shutdown future.

--- a/crates/trusty-mpm/src/bin/tm/commands/daemon_run.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/daemon_run.rs
@@ -140,18 +140,17 @@ pub(crate) async fn run_daemon(
     let base_url = format!("http://{actual_addr}");
     tracing::info!("daemon listening on {base_url}");
 
-    // Write lock file so clients can discover us (backward-compat for existing
-    // clients that parse the TOML lock directly, e.g. the old MpmConnector).
-    //
-    // #6288: the socket path is DERIVED, so resolving it here — ahead of the
-    // bind `serve_http` performs — cannot disagree with what the daemon goes on
-    // to bind. Recording it lets a reader tell a socket-serving daemon from a
-    // pre-#6288 one. A resolution failure is not fatal here: `serve_http` binds
-    // that same path moments later and fails startup then, with the same error.
-    let socket_path = trusty_mpm::daemon::socket::socket_path()
-        .map(|p| p.display().to_string())
-        .unwrap_or_default();
-    trusty_mpm::daemon::lock::write_lock(&base_url, &socket_path);
+    // #6288: bind the RPC socket and only then write the lock file, which is
+    // what clients discover us by (backward-compat for existing clients that
+    // parse the TOML lock directly, e.g. the old MpmConnector). See
+    // [`bind_socket_then_publish`] for why the order is the point.
+    let socket_path = trusty_mpm::daemon::socket::socket_path()?;
+    let rpc = bind_socket_then_publish(
+        &base_url,
+        &socket_path,
+        &trusty_mpm::core::discovery::lock_file_path(),
+    )
+    .await?;
     // Also write the standard trusty-common http_addr file so the console's
     // reverse proxy can discover the daemon address via the shared
     // `read_daemon_addr` helper (#1849 Phase 1).
@@ -187,10 +186,52 @@ pub(crate) async fn run_daemon(
         if let Err(e) = trusty_common::remove_daemon_addr("trusty-mpm") {
             tracing::warn!("failed to remove trusty-mpm http_addr discovery file: {e:#}");
         }
+        // See #6288: this exit almost certainly wins the race against
+        // `serve_with_shutdown`'s graceful drain, so neither the session reap
+        // (#1455) nor the socket unlink is guaranteed to run on a real SIGTERM.
+        // The socket is self-healing — `daemon::socket::bind` reclaims a file
+        // nobody is serving — so slice 1 leaves the race alone; slice 7, which
+        // moves the clients onto the socket, is where it gets fixed.
         std::process::exit(0);
     });
 
-    trusty_mpm::daemon::serve_http(state, listener).await
+    trusty_mpm::daemon::serve_http(state, listener, rpc).await
+}
+
+/// Bind the RPC socket, then publish the daemon's identity — in that order.
+///
+/// Why the order is the whole function (#6288): the lock file names a daemon
+/// that is about to serve, and `run_daemon` has no cleanup path on its error
+/// return. Before this slice there was one bind and it happened first, so a
+/// written lock always named a daemon that had taken every listener it needed.
+/// The socket bind is a second, fallible step; writing the lock between the two
+/// would leave a record naming a process that then aborts, and the next client
+/// would resolve a daemon URL nothing answers.
+///
+/// What: [`trusty_mpm::daemon::socket::bind`], then
+/// [`trusty_mpm::core::daemon_identity::write_lock_at`]. `lock_path` is a
+/// parameter so the test can assert against a temp path instead of the
+/// operator's real `~/.trusty-mpm/daemon.lock`.
+///
+/// # Errors
+///
+/// When the socket cannot be bound — including when another trusty-mpm is
+/// already serving it. Nothing is published on that path.
+///
+/// Test: `bind_socket_then_publish_writes_no_lock_when_the_socket_is_taken`,
+/// `bind_socket_then_publish_writes_the_lock_when_the_bind_succeeds`.
+async fn bind_socket_then_publish(
+    base_url: &str,
+    socket: &std::path::Path,
+    lock_path: &std::path::Path,
+) -> anyhow::Result<trusty_mpm::daemon::socket::BoundSocket> {
+    let rpc = trusty_mpm::daemon::socket::bind(socket).await?;
+    trusty_mpm::core::daemon_identity::write_lock_at(
+        lock_path,
+        base_url,
+        &socket.display().to_string(),
+    );
+    Ok(rpc)
 }
 
 /// Block until the process receives a shutdown signal (SIGINT or SIGTERM).
@@ -393,6 +434,71 @@ fn tailscale_deprecated_error() -> anyhow::Error {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The regression test for the stale lock #6288 slice 1 would otherwise
+    /// have introduced.
+    ///
+    /// Why: `write_lock` used to be the step right after the only bind, so a
+    /// written lock always named a daemon holding every listener it needed.
+    /// The UDS bind is a second fallible step, and `run_daemon` has no cleanup
+    /// path on its error return — so a lock written before that bind would
+    /// outlive the aborted process and send the next client to a daemon that
+    /// never started.
+    /// What: holds the socket with a live listener, so the bind is refused,
+    /// then asserts the lock file was never created. Swapping the two
+    /// statements in `bind_socket_then_publish` makes this fail.
+    /// Test: this function IS the test.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn bind_socket_then_publish_writes_no_lock_when_the_socket_is_taken() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let socket = tmp.path().join("sockets").join("trusty-mpm.sock");
+        let lock_path = tmp.path().join("daemon.lock");
+
+        // An incumbent daemon: a real listener the takeover must refuse.
+        let incumbent = trusty_mpm::daemon::socket::bind(&socket)
+            .await
+            .expect("the incumbent binds a fresh path");
+
+        let err = bind_socket_then_publish("http://127.0.0.1:7880", &socket, &lock_path)
+            .await
+            .expect_err("a bind against a live socket must fail");
+        assert!(
+            format!("{err:#}").contains(&socket.display().to_string()),
+            "the error must name the path: {err:#}"
+        );
+        assert!(
+            !lock_path.exists(),
+            "no lock file may name a daemon that failed to start: {}",
+            lock_path.display()
+        );
+
+        drop(incumbent);
+    }
+
+    /// The other half: a successful bind DOES publish, and the record carries
+    /// both endpoints.
+    ///
+    /// Why: an ordering test that only proves the failure path would pass if
+    /// the write were deleted outright.
+    /// Test: this function IS the test.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn bind_socket_then_publish_writes_the_lock_when_the_bind_succeeds() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let socket = tmp.path().join("sockets").join("trusty-mpm.sock");
+        let lock_path = tmp.path().join("daemon.lock");
+
+        let rpc = bind_socket_then_publish("http://127.0.0.1:7880", &socket, &lock_path)
+            .await
+            .expect("a fresh socket binds");
+
+        let lock = trusty_mpm::core::daemon_identity::read_lock_at(&lock_path)
+            .expect("the lock must be written and readable");
+        assert_eq!(lock.addr, "http://127.0.0.1:7880");
+        assert_eq!(lock.socket_path, socket.display().to_string());
+        assert_eq!(lock.pid, std::process::id());
+
+        drop(rpc);
+    }
 
     /// `run_daemon` must refuse `--tailscale` before doing anything else —
     /// no bind, no chdir, no lock file — so the deprecation error is fast

--- a/crates/trusty-mpm/src/bin/tm/commands/daemon_run.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/daemon_run.rs
@@ -142,7 +142,16 @@ pub(crate) async fn run_daemon(
 
     // Write lock file so clients can discover us (backward-compat for existing
     // clients that parse the TOML lock directly, e.g. the old MpmConnector).
-    trusty_mpm::daemon::lock::write_lock(&base_url);
+    //
+    // #6288: the socket path is DERIVED, so resolving it here — ahead of the
+    // bind `serve_http` performs — cannot disagree with what the daemon goes on
+    // to bind. Recording it lets a reader tell a socket-serving daemon from a
+    // pre-#6288 one. A resolution failure is not fatal here: `serve_http` binds
+    // that same path moments later and fails startup then, with the same error.
+    let socket_path = trusty_mpm::daemon::socket::socket_path()
+        .map(|p| p.display().to_string())
+        .unwrap_or_default();
+    trusty_mpm::daemon::lock::write_lock(&base_url, &socket_path);
     // Also write the standard trusty-common http_addr file so the console's
     // reverse proxy can discover the daemon address via the shared
     // `read_daemon_addr` helper (#1849 Phase 1).

--- a/crates/trusty-mpm/src/core/daemon_identity.rs
+++ b/crates/trusty-mpm/src/core/daemon_identity.rs
@@ -40,8 +40,9 @@ pub const LOCK_PRODUCT: &str = "trusty-mpm";
 /// compiled-in default is not always right.
 /// What: serialised as TOML at [`lock_file_path`]. `product` is the
 /// [`LOCK_PRODUCT`] magic; `pid` identifies the writing process so removal can
-/// be ownership-checked; `addr` is the base URL clients connect to.
-/// Test: `parse_lock_round_trips`.
+/// be ownership-checked; `addr` is the base URL clients connect to;
+/// `socket_path` is the Unix socket the same daemon serves (#6288).
+/// Test: `parse_lock_round_trips`, `parse_lock_reads_a_pre_6288_record`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DaemonLock {
     /// Product magic — must equal [`LOCK_PRODUCT`] for the record to be trusted.
@@ -53,6 +54,19 @@ pub struct DaemonLock {
     /// RFC-3339 timestamp of the write, for operator diagnostics only.
     #[serde(default)]
     pub started_at: String,
+    /// Unix socket the daemon serves alongside `addr` (#6288, ADR-0032).
+    ///
+    /// Why record a path that [`crate::daemon::socket::socket_path`] derives
+    /// anyway: a consumer reading this file learns whether the daemon that
+    /// wrote it serves a socket AT ALL. Empty means a pre-#6288 daemon is
+    /// running — HTTP only — which is the fact a client picking a transport
+    /// needs and cannot get from a path it computed itself.
+    ///
+    /// `#[serde(default)]` for the same reason `started_at` carries it: a lock
+    /// written by the previous version has no such key, and refusing to parse
+    /// it would make every running daemon invisible across an upgrade.
+    #[serde(default)]
+    pub socket_path: String,
 }
 
 /// Parse a lock-file body, rejecting anything that does not claim to be ours.
@@ -75,7 +89,7 @@ pub fn parse_lock(text: &str) -> Option<DaemonLock> {
 /// Test: `parse_lock_round_trips`.
 pub fn render_lock(lock: &DaemonLock) -> String {
     toml::to_string(lock).unwrap_or_else(|e| {
-        // A fixed four-string struct cannot fail TOML encoding; if it somehow
+        // A fixed set of scalar fields cannot fail TOML encoding; if it somehow
         // does, an empty body is rejected by `parse_lock` rather than written
         // as a half-record that a reader might trust.
         tracing::warn!("failed to encode daemon lock: {e}");
@@ -126,12 +140,13 @@ pub fn read_lock() -> Option<DaemonLock> {
     read_lock_at(&lock_file_path())
 }
 
-/// Write the lock file naming `addr` and the current process.
+/// Write the lock file naming `addr`, `socket`, and the current process.
 ///
 /// What: creates parent directories, then writes the TOML record. Best-effort:
-/// a failure is logged, never fatal — the daemon still serves.
+/// a failure is logged, never fatal — the daemon still serves. `socket` is the
+/// Unix socket path this daemon serves alongside `addr` (#6288).
 /// Test: `read_lock_returns_written_record`.
-pub fn write_lock_at(path: &std::path::Path, addr: &str) {
+pub fn write_lock_at(path: &std::path::Path, addr: &str, socket: &str) {
     if let Some(parent) = path.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
@@ -140,6 +155,9 @@ pub fn write_lock_at(path: &std::path::Path, addr: &str) {
         pid: std::process::id(),
         addr: addr.to_string(),
         started_at: chrono::Utc::now().to_rfc3339(),
+        // #6288: recorded so a reader can tell a socket-serving daemon from a
+        // pre-#6288 one without dialling a path it guessed.
+        socket_path: socket.to_string(),
     };
     match std::fs::write(path, render_lock(&lock)) {
         Ok(()) => tracing::debug!("lock file written: {}", path.display()),
@@ -148,8 +166,8 @@ pub fn write_lock_at(path: &std::path::Path, addr: &str) {
 }
 
 /// [`write_lock_at`] against the real `~/.trusty-mpm/daemon.lock`.
-pub fn write_lock(addr: &str) {
-    write_lock_at(&lock_file_path(), addr);
+pub fn write_lock(addr: &str, socket: &str) {
+    write_lock_at(&lock_file_path(), addr, socket);
 }
 
 /// Remove the lock file only when it names one of `owners`.
@@ -236,6 +254,7 @@ mod tests {
             pid: std::process::id(),
             addr: "http://127.0.0.1:7880".to_string(),
             started_at: "2026-08-18T03:45:07.813744+00:00".to_string(),
+            socket_path: "/tmp/trusty-mpm/trusty-mpm.sock".to_string(),
         }
     }
 
@@ -243,6 +262,57 @@ mod tests {
     fn parse_lock_round_trips() {
         let lock = sample();
         assert_eq!(parse_lock(&render_lock(&lock)), Some(lock));
+    }
+
+    /// #6288, the backward half: this daemon must still read a lock written by
+    /// the previous version.
+    ///
+    /// Why: an upgrade does not restart a running daemon. If a record without
+    /// `socket_path` failed to parse, `read_lock` would return `None` and every
+    /// consumer — URL resolution, the `tm` welcome panel, the daemon's own
+    /// duplicate-instance guard — would report no daemon while one was serving,
+    /// and the guard would go on to start a second.
+    /// What: the exact pre-#6288 body, with every other field asserted intact
+    /// and `socket_path` empty rather than absent.
+    /// Test: this function IS the test.
+    #[test]
+    fn parse_lock_reads_a_pre_6288_record() {
+        let body = "product = \"trusty-mpm\"\npid = 84890\n\
+                    addr = \"http://127.0.0.1:7880\"\n\
+                    started_at = \"2026-08-18T03:45:07.813744+00:00\"\n";
+        let lock = parse_lock(body).expect("a pre-#6288 record must still parse");
+        assert_eq!(lock.pid, 84890);
+        assert_eq!(lock.addr, "http://127.0.0.1:7880");
+        assert_eq!(
+            lock.socket_path, "",
+            "an absent socket_path means HTTP-only, not a parse failure"
+        );
+    }
+
+    /// #6288, the forward half: a record this daemon writes stays readable by
+    /// the parsers that predate the new field.
+    ///
+    /// Why: `trusty-console` (`detect/mpm.rs`) and the `tm` welcome panel read
+    /// `addr` out of this file. A new key must not displace or shadow it.
+    /// What: renders a record carrying a socket path, then asserts the TOML
+    /// still carries `addr` on its own line with the URL intact, and that a
+    /// reader keyed on the exact `addr` key finds it.
+    /// Test: this function IS the test.
+    #[test]
+    fn render_lock_keeps_addr_readable_alongside_socket_path() {
+        let body = render_lock(&sample());
+        let addr_line = body
+            .lines()
+            .find(|l| l.starts_with("addr ="))
+            .expect("addr must still be a top-level key");
+        assert!(
+            addr_line.contains("http://127.0.0.1:7880"),
+            "addr line lost its value: {addr_line}"
+        );
+        assert!(
+            body.lines().any(|l| l.starts_with("socket_path =")),
+            "socket_path must be recorded: {body}"
+        );
     }
 
     #[test]
@@ -283,12 +353,18 @@ mod tests {
     fn read_lock_returns_written_record() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let path = tmp.path().join("daemon.lock");
-        write_lock_at(&path, "http://127.0.0.1:7880");
+        write_lock_at(
+            &path,
+            "http://127.0.0.1:7880",
+            "/tmp/trusty-mpm/trusty-mpm.sock",
+        );
         let lock = read_lock_at(&path).expect("own lock file must be readable");
         assert_eq!(lock.product, LOCK_PRODUCT);
         assert_eq!(lock.pid, std::process::id());
         assert_eq!(lock.addr, "http://127.0.0.1:7880");
         assert!(!lock.started_at.is_empty());
+        // #6288: `addr` is unchanged and `socket_path` rides alongside it.
+        assert_eq!(lock.socket_path, "/tmp/trusty-mpm/trusty-mpm.sock");
     }
 
     #[test]
@@ -321,7 +397,11 @@ mod tests {
     fn remove_lock_owned_by_removes_own_record() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let path = tmp.path().join("daemon.lock");
-        write_lock_at(&path, "http://127.0.0.1:7880");
+        write_lock_at(
+            &path,
+            "http://127.0.0.1:7880",
+            "/tmp/trusty-mpm/trusty-mpm.sock",
+        );
         remove_lock_owned_by_at(&path, &[std::process::id()]);
         assert!(!path.exists());
     }
@@ -333,7 +413,11 @@ mod tests {
     fn remove_lock_owned_by_keeps_newer_daemons_record() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let path = tmp.path().join("daemon.lock");
-        write_lock_at(&path, "http://127.0.0.1:7880");
+        write_lock_at(
+            &path,
+            "http://127.0.0.1:7880",
+            "/tmp/trusty-mpm/trusty-mpm.sock",
+        );
         let outgoing = std::process::id() + 1;
         remove_lock_owned_by_at(&path, &[outgoing]);
         assert!(path.exists(), "the incoming daemon's record must survive");

--- a/crates/trusty-mpm/src/daemon/lock.rs
+++ b/crates/trusty-mpm/src/daemon/lock.rs
@@ -12,15 +12,18 @@
 
 use crate::core::daemon_identity;
 
-/// Write the lock file with the actual bound address and this process's PID.
+/// Write the lock file with the actual bound address, the Unix socket, and this
+/// process's PID.
 ///
 /// Why: must be called after `TcpListener::local_addr()` is known. As of
 /// ADR-0011's loopback-only doctrine (issue #3330) the daemon never binds a
 /// second (Tailscale) listener, so the record carries no `tailscale_addr`.
+/// `socket` is the path this daemon serves alongside `addr` (#6288) — recorded
+/// so a reader can tell a socket-serving daemon from a pre-#6288 one.
 /// What: delegates to [`daemon_identity::write_lock`]; best-effort.
 /// Test: `read_lock_returns_written_record` in `core::daemon_identity`.
-pub fn write_lock(addr: &str) {
-    daemon_identity::write_lock(addr);
+pub fn write_lock(addr: &str, socket: &str) {
+    daemon_identity::write_lock(addr, socket);
 }
 
 /// Remove the lock file on clean shutdown — but only if it still names us.

--- a/crates/trusty-mpm/src/daemon/mod.rs
+++ b/crates/trusty-mpm/src/daemon/mod.rs
@@ -68,46 +68,78 @@ pub use state::DaemonState;
 /// Why: the HTTP boot sequence is shared by both the standalone `trusty-mpmd`
 /// shim and the unified `trusty-mpm daemon` subcommand; living in the library
 /// keeps a single source of truth.
-/// What: announces tmux availability, discovers the trusty sidecars, spawns the
-/// file watcher, then serves the axum router until the socket closes.
-/// Test: `cargo run -p trusty-mpm-cli -- daemon` logs "trusty-mpm daemon
-/// starting" and `curl localhost:7880/health` returns `ok`.
-pub async fn run_http(state: Arc<DaemonState>, addr: SocketAddr) -> anyhow::Result<()> {
-    info!("trusty-mpm daemon starting on {addr}");
-    let listener = tokio::net::TcpListener::bind(addr).await?;
-    serve_http(state, listener).await
-}
-
-/// Run the daemon's background tasks and HTTP API on an already-bound listener.
-///
-/// Why: the CLI performs auto port selection (binding an ephemeral port when
-/// the configured one is busy) and needs the daemon to serve on that exact
-/// listener; passing a pre-bound `TcpListener` lets it own the bind decision
-/// while the daemon still owns sidecar discovery, the watcher, and the reaper.
-/// What: binds the Unix socket (#6288), discovers the trusty sidecars, spawns
-/// the file watcher and the dead-session reaper, then serves the axum router on
-/// `listener` AND the RPC router on the socket until both drain.
+/// What: binds both listeners — the TCP port and the RPC socket (#6288) — then
+/// hands them to [`serve_http`].
 ///
 /// # Errors
 ///
-/// When the Unix socket cannot be bound — including when another trusty-mpm is
-/// answering it — or when the HTTP server exits with one. A socket that cannot
-/// be bound fails startup rather than degrading to an HTTP-only daemon, exactly
-/// as a failed `TcpListener::bind` would (the Fail-Open Check, #6288).
+/// When either listener cannot be bound, or as [`serve_http`].
 ///
-/// Test: covered indirectly by the e2e suite, which boots the daemon on a
-/// loopback port and drives it over HTTP; the socket half is covered by
+/// Test: `cargo run -p trusty-mpm-cli -- daemon` logs "trusty-mpm daemon
+/// starting" and `curl localhost:7880/health` returns `ok`; the dual-serve and
+/// drain behaviour is covered by `tests/daemon_dual_serve.rs`.
+pub async fn run_http(state: Arc<DaemonState>, addr: SocketAddr) -> anyhow::Result<()> {
+    info!("trusty-mpm daemon starting on {addr}");
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    // #6288: both binds complete before anything is served, for the same reason
+    // `run_daemon` publishes nothing until both succeed — a half-bound daemon
+    // must not exist.
+    let rpc = socket::bind(&socket::socket_path()?).await?;
+    serve_http(state, listener, rpc).await
+}
+
+/// Run the daemon's background tasks, HTTP API, and RPC socket on already-bound
+/// listeners.
+///
+/// Why both listeners arrive pre-bound: the CLI performs auto port selection
+/// (binding an ephemeral port when the configured one is busy) and needs the
+/// daemon to serve on that exact listener. The socket is pre-bound for a
+/// stronger reason (#6288) — `run_daemon` writes a lock file naming this
+/// daemon, and a lock must never name a daemon that then fails to start. Both
+/// binds happen in the caller, before anything is published, so a UDS bind
+/// failure aborts before the lock is written rather than leaving a record with
+/// no cleanup path.
+///
+/// What: discovers the trusty sidecars, spawns the file watcher and the
+/// dead-session reaper, then serves the axum router on `listener` AND the RPC
+/// router on `rpc` until both drain on SIGTERM/SIGINT.
+///
+/// # Errors
+///
+/// When the HTTP server exits with one.
+///
+/// Test: `serve_http_drains_both_listeners_on_shutdown` in
+/// `tests/daemon_dual_serve.rs` drives this body through
+/// [`serve_with_shutdown`]; the socket half in isolation is covered by
 /// `socket_tests.rs`.
 pub async fn serve_http(
     state: Arc<DaemonState>,
     listener: tokio::net::TcpListener,
+    rpc: socket::BoundSocket,
 ) -> anyhow::Result<()> {
-    // #6288: bind the socket FIRST, before any background loop is spawned, so a
-    // refusal leaves nothing running to unwind. `?` is the whole Fail-Open
-    // Check: a daemon that cannot take its socket does not start HTTP-only.
-    let socket_path = socket::socket_path()?;
-    let rpc_listener = socket::bind(&socket_path).await?;
+    serve_with_shutdown(state, listener, rpc, trusty_common::shutdown_signal()).await
+}
 
+/// [`serve_http`]'s body, with the shutdown future supplied by the caller.
+///
+/// Why: [`serve_http`] waits on SIGTERM/SIGINT, which a test cannot deliver to
+/// its own process without affecting the whole test binary. Taking the future
+/// as a parameter is what lets `serve_http_drains_both_listeners_on_shutdown`
+/// drive the REAL drain — the same fan-out, the same unlink — rather than
+/// re-implementing the loop, which would pass whether or not the fan-out below
+/// exists.
+///
+/// # Errors
+///
+/// As [`serve_http`].
+///
+/// Test: `serve_http_drains_both_listeners_on_shutdown`.
+pub async fn serve_with_shutdown(
+    state: Arc<DaemonState>,
+    listener: tokio::net::TcpListener,
+    rpc: socket::BoundSocket,
+    shutdown: impl std::future::Future<Output = ()> + Send + 'static,
+) -> anyhow::Result<()> {
     // #5784: report a gated environment as gated. Without this branch the
     // refusal reads as "tmux not found", which sends an operator hunting for a
     // missing binary instead of showing them the reassigned `$HOME` and the
@@ -226,22 +258,21 @@ pub async fn serve_http(
     // fail-open per session. Also calls `manager.shutdown()` to graceful-stop
     // all live managed sessions via SIGTERM-before-kill.
     //
-    // #6288: the signal is awaited ONCE, by the task below, and fanned out to
-    // both listeners through a token. Awaiting `shutdown_signal()` separately in
-    // each would work on SIGTERM and fail on Ctrl-C, where `tokio::signal`
-    // delivers to whichever waiter is registered — one listener would drain and
-    // the other would keep accepting.
+    // #6288: `shutdown` is awaited ONCE, by the task below, and fanned out to
+    // both listeners through a token. Awaiting a signal separately in each would
+    // work on SIGTERM and fail on Ctrl-C, where `tokio::signal` delivers to
+    // whichever waiter is registered — one listener would drain and the other
+    // would keep accepting.
     let drain = tokio_util::sync::CancellationToken::new();
     let signal_watcher = drain.clone();
     tokio::spawn(async move {
-        trusty_common::shutdown_signal().await;
+        shutdown.await;
         signal_watcher.cancel();
     });
 
     let rpc_drain = drain.clone();
-    let rpc_socket = socket_path.clone();
     let rpc_task = tokio::spawn(async move {
-        socket::serve_until_shutdown(rpc_listener, &rpc_socket, rpc_drain.cancelled_owned()).await;
+        socket::serve_until_shutdown(rpc, rpc_drain.cancelled_owned()).await;
     });
 
     let http_drain = drain.clone();

--- a/crates/trusty-mpm/src/daemon/mod.rs
+++ b/crates/trusty-mpm/src/daemon/mod.rs
@@ -49,6 +49,8 @@ pub mod runtime_reap;
 pub mod services;
 pub(crate) mod session_record_kind;
 pub mod sm_stdio;
+/// The hardened Unix-socket listener served alongside HTTP (#6288, ADR-0032).
+pub mod socket;
 pub(crate) mod spawn_command;
 pub mod state;
 pub mod tmux;
@@ -82,14 +84,30 @@ pub async fn run_http(state: Arc<DaemonState>, addr: SocketAddr) -> anyhow::Resu
 /// the configured one is busy) and needs the daemon to serve on that exact
 /// listener; passing a pre-bound `TcpListener` lets it own the bind decision
 /// while the daemon still owns sidecar discovery, the watcher, and the reaper.
-/// What: discovers the trusty sidecars, spawns the file watcher and the
-/// dead-session reaper, then serves the axum router on `listener` until close.
+/// What: binds the Unix socket (#6288), discovers the trusty sidecars, spawns
+/// the file watcher and the dead-session reaper, then serves the axum router on
+/// `listener` AND the RPC router on the socket until both drain.
+///
+/// # Errors
+///
+/// When the Unix socket cannot be bound — including when another trusty-mpm is
+/// answering it — or when the HTTP server exits with one. A socket that cannot
+/// be bound fails startup rather than degrading to an HTTP-only daemon, exactly
+/// as a failed `TcpListener::bind` would (the Fail-Open Check, #6288).
+///
 /// Test: covered indirectly by the e2e suite, which boots the daemon on a
-/// loopback port and drives it over HTTP.
+/// loopback port and drives it over HTTP; the socket half is covered by
+/// `socket_tests.rs`.
 pub async fn serve_http(
     state: Arc<DaemonState>,
     listener: tokio::net::TcpListener,
 ) -> anyhow::Result<()> {
+    // #6288: bind the socket FIRST, before any background loop is spawned, so a
+    // refusal leaves nothing running to unwind. `?` is the whole Fail-Open
+    // Check: a daemon that cannot take its socket does not start HTTP-only.
+    let socket_path = socket::socket_path()?;
+    let rpc_listener = socket::bind(&socket_path).await?;
+
     // #5784: report a gated environment as gated. Without this branch the
     // refusal reads as "tmux not found", which sends an operator hunting for a
     // missing binary instead of showing them the reassigned `$HOME` and the
@@ -207,13 +225,33 @@ pub async fn serve_http(
     // mid-sweep), then walks BOTH registries and kills each live session,
     // fail-open per session. Also calls `manager.shutdown()` to graceful-stop
     // all live managed sessions via SIGTERM-before-kill.
+    //
+    // #6288: the signal is awaited ONCE, by the task below, and fanned out to
+    // both listeners through a token. Awaiting `shutdown_signal()` separately in
+    // each would work on SIGTERM and fail on Ctrl-C, where `tokio::signal`
+    // delivers to whichever waiter is registered — one listener would drain and
+    // the other would keep accepting.
+    let drain = tokio_util::sync::CancellationToken::new();
+    let signal_watcher = drain.clone();
+    tokio::spawn(async move {
+        trusty_common::shutdown_signal().await;
+        signal_watcher.cancel();
+    });
+
+    let rpc_drain = drain.clone();
+    let rpc_socket = socket_path.clone();
+    let rpc_task = tokio::spawn(async move {
+        socket::serve_until_shutdown(rpc_listener, &rpc_socket, rpc_drain.cancelled_owned()).await;
+    });
+
+    let http_drain = drain.clone();
     let reaper_state = Arc::clone(&state);
-    axum::serve(
+    let http_result = axum::serve(
         listener,
         app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
     )
     .with_graceful_shutdown(async move {
-        shutdown_signal().await;
+        http_drain.cancelled_owned().await;
         // Signal all background loops to stop before we walk the session list.
         cancel.cancel();
         // Graceful-stop live SessionManager sessions (SIGTERM → 2s wait → kill).
@@ -226,44 +264,26 @@ pub async fn serve_http(
         // Reap remaining legacy-registry sessions not covered by mgr.shutdown().
         reap_all_live_sessions(reaper_state).await;
     })
-    .await?;
+    .await;
+
+    // #6288: cancel unconditionally, so the socket is unlinked even when axum
+    // exits for a reason that was never a shutdown signal. Cancelling a token
+    // the signal watcher already cancelled is a no-op, so the ordinary drain is
+    // unaffected. The `?` waits until AFTER the join for the same reason —
+    // returning early would leave a socket file no successor bound.
+    drain.cancel();
+    if let Err(e) = rpc_task.await {
+        tracing::warn!(error = %e, "the rpc serve task did not exit cleanly");
+    }
+    http_result?;
     Ok(())
 }
 
-/// Block until the process receives a shutdown signal (SIGINT or SIGTERM).
-///
-/// Why: the graceful-shutdown reaper (#1455) must fire on the SAME signals the
-/// daemon is stopped with. `tm restart` / `launchctl bootout` deliver SIGTERM;
-/// trapping only Ctrl-C (SIGINT) would skip the reap on the common stop path and
-/// leak every live session. This mirrors the binary's `wait_for_shutdown_signal`
-/// so the library boot path (used by external in-process consumers) reaps too.
-/// What: on Unix, races `ctrl_c()` against a SIGTERM stream; if registering the
-/// SIGTERM handler fails it falls back to awaiting Ctrl-C alone. On non-Unix
-/// (no SIGTERM) it simply awaits Ctrl-C.
-/// Test: signal delivery is environment-bound and not unit-tested; the reap it
-/// triggers is covered by `reap_all_live_sessions`'s own behaviour.
-async fn shutdown_signal() {
-    #[cfg(unix)]
-    {
-        use tokio::signal::unix::{SignalKind, signal};
-        let mut term = match signal(SignalKind::terminate()) {
-            Ok(s) => s,
-            Err(e) => {
-                tracing::warn!("failed to register SIGTERM handler: {e}");
-                let _ = tokio::signal::ctrl_c().await;
-                return;
-            }
-        };
-        tokio::select! {
-            _ = tokio::signal::ctrl_c() => {}
-            _ = term.recv() => {}
-        }
-    }
-    #[cfg(not(unix))]
-    {
-        let _ = tokio::signal::ctrl_c().await;
-    }
-}
+// #6288: the private `shutdown_signal` that used to live here was a
+// line-for-line copy of `trusty_common::shutdown_signal` — same SIGTERM stream,
+// same Ctrl-C race, same fallback when the handler fails to register. The
+// signal is now awaited once, through the shared entry point, and fanned out to
+// both listeners; see `serve_http`'s drain token.
 
 /// Kill every live tmux session in the LEGACY DaemonState registry on shutdown.
 ///

--- a/crates/trusty-mpm/src/daemon/socket.rs
+++ b/crates/trusty-mpm/src/daemon/socket.rs
@@ -43,7 +43,7 @@ mod tests;
 ///
 /// When the data directory cannot be resolved or created.
 ///
-/// Test: `socket_path_is_named_for_the_product_under_the_data_dir`.
+/// Test: `socket_path_is_the_product_named_socket_under_the_data_dir`.
 pub fn socket_path() -> Result<PathBuf> {
     // #6288: the ONE data-dir entry point; never a second hand-rolled resolver.
     trusty_common::daemon_socket_path("trusty-mpm")

--- a/crates/trusty-mpm/src/daemon/socket.rs
+++ b/crates/trusty-mpm/src/daemon/socket.rs
@@ -72,6 +72,23 @@ fn serve_options() -> RpcServeOptions {
     RpcServeOptions::default()
 }
 
+/// A bound RPC socket, with the path it occupies.
+///
+/// Why the two travel together: the listener must be served and the path must
+/// be unlinked afterwards, and the unlink has to name the path this listener
+/// actually took. Passing them separately let a caller hand
+/// [`serve_until_shutdown`] a path that was not the one [`bind`] used, which
+/// unlinks somebody else's socket. One value cannot be assembled wrong.
+///
+/// Test: exercised by every test in `socket_tests.rs`.
+#[derive(Debug)]
+pub struct BoundSocket {
+    /// The listener [`bind`] took.
+    pub listener: UnixListener,
+    /// The path it occupies, unlinked by [`serve_until_shutdown`].
+    pub path: PathBuf,
+}
+
 /// Bind `socket`, refusing to start when another daemon is live on it.
 ///
 /// Why `bind_singleton_hardened` rather than `bind_hardened`: this daemon is
@@ -91,10 +108,14 @@ fn serve_options() -> RpcServeOptions {
 ///
 /// Test: `bind_refuses_a_socket_another_process_is_serving`,
 /// `bind_reclaims_a_stale_socket_file`.
-pub async fn bind(socket: &Path) -> Result<UnixListener> {
-    trusty_common::uds::bind_singleton_hardened(socket)
+pub async fn bind(socket: &Path) -> Result<BoundSocket> {
+    let listener = trusty_common::uds::bind_singleton_hardened(socket)
         .await
-        .with_context(|| format!("bind trusty-mpm socket at {}", socket.display()))
+        .with_context(|| format!("bind trusty-mpm socket at {}", socket.display()))?;
+    Ok(BoundSocket {
+        listener,
+        path: socket.to_path_buf(),
+    })
 }
 
 /// Serve `listener` until `shutdown` resolves, then unlink `socket`.
@@ -111,21 +132,21 @@ pub async fn bind(socket: &Path) -> Result<UnixListener> {
 /// Test: `serve_unlinks_its_socket_on_shutdown`,
 /// `unknown_method_gets_a_method_not_found_frame`.
 pub async fn serve_until_shutdown(
-    listener: UnixListener,
-    socket: &Path,
+    bound: BoundSocket,
     shutdown: impl std::future::Future<Output = ()> + Send,
 ) {
+    let BoundSocket { listener, path } = bound;
     let router = Arc::new(build_router());
     tracing::info!(
-        socket = %socket.display(),
+        socket = %path.display(),
         methods = router.method_names().count(),
         "trusty-mpm serving rpc"
     );
 
     serve_until(&listener, router, serve_options(), shutdown).await;
 
-    if let Err(e) = std::fs::remove_file(socket) {
-        tracing::debug!(socket = %socket.display(), error = %e, "socket already gone");
+    if let Err(e) = std::fs::remove_file(&path) {
+        tracing::debug!(socket = %path.display(), error = %e, "socket already gone");
     }
     drop(listener);
 }

--- a/crates/trusty-mpm/src/daemon/socket.rs
+++ b/crates/trusty-mpm/src/daemon/socket.rs
@@ -1,0 +1,131 @@
+//! The daemon's hardened Unix-domain-socket listener (#6288 slice 1).
+//!
+//! Why: ADR-0032 moves every trusty-* service off loopback TCP and onto a Unix
+//! socket, and trusty-mpm's HTTP surface is ~35k SLOC across a dozen route
+//! files. A single-PR cutover is not viable, so this slice adds the socket
+//! ALONGSIDE `127.0.0.1:7880` and registers nothing on it. Later slices move
+//! methods across; the retire slice deletes the axum surface.
+//!
+//! What: the socket path (derived, never published to a discovery file), the
+//! bind, and the serve loop. The router this slice builds is deliberately
+//! EMPTY — a request for any method gets a well-formed `method_not_found`
+//! frame, which is the scaffolding's whole observable contract until slice 2.
+//!
+//! The trust boundary is the socket, not the payload: `bind_singleton_hardened`
+//! puts a `0600` socket in a `0700` directory, and `serve_until` runs the
+//! peer-uid check on every accepted connection before a byte is read. None of
+//! `daemon::api`'s origin-guard machinery is carried over — it is browser-CSRF
+//! defence for a listener a page can reach, and it guards nothing here.
+//!
+//! Test: `socket_tests.rs`.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use tokio::net::UnixListener;
+use trusty_common::uds::server::{RpcRouter, RpcServeOptions, serve_until};
+
+#[cfg(test)]
+#[path = "socket_tests.rs"]
+mod tests;
+
+/// The socket this daemon binds, as both it and its consumers resolve it.
+///
+/// Why: derived, not published. `trusty_common::daemon_socket_path` is the same
+/// entry point trusty-memory, trusty-review, and trusty-analyze resolve, so the
+/// daemon and every consumer compute the identical path and there is no
+/// discovery file for a stale write to contradict. It resolves
+/// `<data dir>/trusty-mpm.sock` through `trusty_common::resolve_data_dir`,
+/// which this crate already routes its bug-report store through.
+///
+/// # Errors
+///
+/// When the data directory cannot be resolved or created.
+///
+/// Test: `socket_path_is_named_for_the_product_under_the_data_dir`.
+pub fn socket_path() -> Result<PathBuf> {
+    // #6288: the ONE data-dir entry point; never a second hand-rolled resolver.
+    trusty_common::daemon_socket_path("trusty-mpm")
+}
+
+/// The methods this listener serves.
+///
+/// Why: slice 1 registers none, on purpose. An empty router is not a stub — it
+/// is a listener whose every answer is a `method_not_found` frame, which is a
+/// contract a client can be written against and a later slice can extend one
+/// method at a time without changing the transport.
+///
+/// Test: `unknown_method_gets_a_method_not_found_frame`.
+fn build_router() -> RpcRouter {
+    // #6288: methods arrive in slices 2-6; the transport lands first.
+    RpcRouter::new()
+}
+
+/// Per-connection budgets for this listener.
+///
+/// The shared defaults: a 30-second bound on delivering a REQUEST frame, and
+/// the shared control-plane frame budget. Neither bounds a handler, and this
+/// slice has no handler to bound. A later slice that moves a bulk route across
+/// raises `max_frame_bytes` here and on the client together.
+fn serve_options() -> RpcServeOptions {
+    RpcServeOptions::default()
+}
+
+/// Bind `socket`, refusing to start when another daemon is live on it.
+///
+/// Why `bind_singleton_hardened` rather than `bind_hardened`: this daemon is
+/// supervised by launchd, and a predecessor that is SIGKILLed never reaches the
+/// unlink in [`serve_until_shutdown`]. `bind_hardened` refuses an occupied path
+/// outright, so the replacement launchd starts would fail its bind, exit, be
+/// restarted, and fail again — a crash loop with no operator-visible cause.
+/// `bind_singleton_hardened` probes first and takes over only a socket the
+/// kernel proves nobody is serving, so a LIVE daemon is still never clobbered.
+///
+/// # Errors
+///
+/// Any bind failure, including `UdsSecurityError::AlreadyServing` — which means
+/// another trusty-mpm is answering this path and this process must not start.
+/// The error names the path; the caller propagates it rather than degrading to
+/// an HTTP-only daemon (the Fail-Open Check, #6288).
+///
+/// Test: `bind_refuses_a_socket_another_process_is_serving`,
+/// `bind_reclaims_a_stale_socket_file`.
+pub async fn bind(socket: &Path) -> Result<UnixListener> {
+    trusty_common::uds::bind_singleton_hardened(socket)
+        .await
+        .with_context(|| format!("bind trusty-mpm socket at {}", socket.display()))
+}
+
+/// Serve `listener` until `shutdown` resolves, then unlink `socket`.
+///
+/// What: the accept loop from `trusty_common::uds::server`, then the socket
+/// file is removed BEFORE the listener is dropped. That order is the one
+/// `webhook_relay::listener` records: reversed, there is a window in which
+/// nothing answers the path but the file is still there, and a successor that
+/// rebinds in that window has its fresh socket deleted by this process.
+///
+/// A SIGKILLed daemon never reaches this unlink. That is not a leak to guard
+/// against here — [`bind`] reclaims a socket file nobody is serving.
+///
+/// Test: `serve_unlinks_its_socket_on_shutdown`,
+/// `unknown_method_gets_a_method_not_found_frame`.
+pub async fn serve_until_shutdown(
+    listener: UnixListener,
+    socket: &Path,
+    shutdown: impl std::future::Future<Output = ()> + Send,
+) {
+    let router = Arc::new(build_router());
+    tracing::info!(
+        socket = %socket.display(),
+        methods = router.method_names().count(),
+        "trusty-mpm serving rpc"
+    );
+
+    serve_until(&listener, router, serve_options(), shutdown).await;
+
+    if let Err(e) = std::fs::remove_file(socket) {
+        tracing::debug!(socket = %socket.display(), error = %e, "socket already gone");
+    }
+    drop(listener);
+}

--- a/crates/trusty-mpm/src/daemon/socket_tests.rs
+++ b/crates/trusty-mpm/src/daemon/socket_tests.rs
@@ -33,11 +33,10 @@ async fn spawn_listener(
     tokio::sync::oneshot::Sender<()>,
     tokio::task::JoinHandle<()>,
 ) {
-    let listener = bind(socket).await.expect("bind a fresh socket path");
+    let bound = bind(socket).await.expect("bind a fresh socket path");
     let (stop_tx, stop_rx) = tokio::sync::oneshot::channel::<()>();
-    let socket_owned = socket.to_path_buf();
     let handle = tokio::spawn(async move {
-        serve_until_shutdown(listener, &socket_owned, async {
+        serve_until_shutdown(bound, async {
             let _ = stop_rx.await;
         })
         .await;

--- a/crates/trusty-mpm/src/daemon/socket_tests.rs
+++ b/crates/trusty-mpm/src/daemon/socket_tests.rs
@@ -34,6 +34,21 @@ async fn spawn_listener(
     tokio::task::JoinHandle<()>,
 ) {
     let bound = bind(socket).await.expect("bind a fresh socket path");
+    serve_bound(bound, socket).await
+}
+
+/// Serve an already-bound socket, returning its stop trigger.
+///
+/// Split from [`spawn_listener`] so a test that needs to control HOW the bind
+/// happened — `bind_reclaims_a_stale_socket_file` retries it — still drives the
+/// same serve path.
+async fn serve_bound(
+    bound: super::BoundSocket,
+    socket: &Path,
+) -> (
+    tokio::sync::oneshot::Sender<()>,
+    tokio::task::JoinHandle<()>,
+) {
     let (stop_tx, stop_rx) = tokio::sync::oneshot::channel::<()>();
     let handle = tokio::spawn(async move {
         serve_until_shutdown(bound, async {
@@ -222,6 +237,17 @@ async fn bind_refuses_a_socket_another_process_is_serving() {
 /// is `SocketVerdict::Inconclusive` and is refused rather than reclaimed; that
 /// asymmetry is deliberate (`uds::singleton`) and this test must not paper
 /// over it.
+///
+/// Why the bind is retried: `bind_singleton_hardened` reclaims only on a
+/// verdict the kernel PROVED, and its one-second probe can be starved on a
+/// machine running the rest of this suite in parallel — `uds::singleton`
+/// records that exact failure, "a starved probe read as `Inconclusive` and
+/// refused a genuinely stale socket, which is safe but wrong", and names the
+/// remedy: "one failed start that a retry fixes". So the retry models what a
+/// launchd-supervised daemon does, rather than hiding a defect. The assertion
+/// is unchanged and still fails if the reclaim never happens — a socket that is
+/// genuinely held is refused every attempt, which is what
+/// `bind_refuses_a_socket_another_process_is_serving` pins.
 /// Test: this function IS the test.
 #[tokio::test(flavor = "multi_thread")]
 async fn bind_reclaims_a_stale_socket_file() {
@@ -236,7 +262,28 @@ async fn bind_reclaims_a_stale_socket_file() {
     drop(corpse);
     assert!(socket.exists(), "the corpse must outlive its listener");
 
-    let (stop, handle) = spawn_listener(&socket).await;
+    let mut last_err = None;
+    let mut bound = None;
+    for _ in 0..10 {
+        match bind(&socket).await {
+            Ok(b) => {
+                bound = Some(b);
+                break;
+            }
+            Err(e) => {
+                last_err = Some(e);
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+        }
+    }
+    let bound = bound.unwrap_or_else(|| {
+        panic!(
+            "a socket nobody is serving must be reclaimed within ten starts; last error: {:#}",
+            last_err.expect("a failed loop records its error")
+        )
+    });
+
+    let (stop, handle) = serve_bound(bound, &socket).await;
     assert!(
         trusty_common::uds::socket_is_serving(&socket, GENEROUS).await,
         "the successor must be serving the reclaimed path"

--- a/crates/trusty-mpm/src/daemon/socket_tests.rs
+++ b/crates/trusty-mpm/src/daemon/socket_tests.rs
@@ -1,0 +1,270 @@
+//! Tests for the daemon's Unix-socket listener (#6288 slice 1).
+//!
+//! Why a separate file: `socket.rs` is production source under the 500-SLOC
+//! cap, and these tests drive the REAL bind / accept / unlink path rather than
+//! a hand-rolled listener — which is what makes them able to fail if that path
+//! regresses.
+//!
+//! Test: this file IS the test module for `super`.
+
+use std::path::Path;
+use std::time::Duration;
+
+use tempfile::TempDir;
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+
+use super::{bind, serve_until_shutdown, socket_path};
+
+/// How long a dial or a bind is given before the test calls it stuck.
+///
+/// A local socket answers in microseconds; this is headroom on a loaded CI
+/// machine, not a latency budget.
+const GENEROUS: Duration = Duration::from_secs(10);
+
+/// Bind `socket` and serve it on a background task, returning its stop trigger.
+///
+/// The shutdown future is a parameter of [`serve_until_shutdown`] for exactly
+/// this reason: a test cannot deliver SIGTERM to its own process without
+/// affecting the whole test binary.
+async fn spawn_listener(
+    socket: &Path,
+) -> (
+    tokio::sync::oneshot::Sender<()>,
+    tokio::task::JoinHandle<()>,
+) {
+    let listener = bind(socket).await.expect("bind a fresh socket path");
+    let (stop_tx, stop_rx) = tokio::sync::oneshot::channel::<()>();
+    let socket_owned = socket.to_path_buf();
+    let handle = tokio::spawn(async move {
+        serve_until_shutdown(listener, &socket_owned, async {
+            let _ = stop_rx.await;
+        })
+        .await;
+    });
+
+    // Wait for the accept loop rather than sleeping: a socket that never
+    // answers fails the dial below, which reports better than a short sleep.
+    for _ in 0..200 {
+        if trusty_common::uds::socket_is_serving(socket, Duration::from_millis(50)).await {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    (stop_tx, handle)
+}
+
+/// What one raw dial observed: the response frame, and whether the server then
+/// closed the connection without sending anything more.
+struct RawExchange {
+    /// The single response frame, parsed.
+    frame: serde_json::Value,
+    /// Bytes the server sent after that frame. Empty means a clean close.
+    trailing: Vec<u8>,
+}
+
+/// Dial `socket`, write one request frame, and read what comes back.
+///
+/// Why raw rather than `trusty_common::uds::send_framed_request`: that helper
+/// answers "did a frame arrive". The assertion this slice owes is stronger —
+/// one frame arrives AND the server then closes, rather than hanging or
+/// hanging up mid-frame. Only a raw stream can tell those three apart.
+async fn dial_once(socket: &Path, request: &serde_json::Value) -> RawExchange {
+    let stream = tokio::time::timeout(GENEROUS, UnixStream::connect(socket))
+        .await
+        .expect("connect must not hang")
+        .expect("a live socket must accept a connection");
+    let mut reader = BufReader::new(stream);
+
+    let mut body = serde_json::to_vec(request).expect("encode the request");
+    body.push(b'\n');
+    reader
+        .get_mut()
+        .write_all(&body)
+        .await
+        .expect("write the request frame");
+
+    let mut line = String::new();
+    let read = tokio::time::timeout(GENEROUS, reader.read_line(&mut line))
+        .await
+        .expect("the server must answer rather than hang")
+        .expect("read the response frame");
+    assert!(read > 0, "the server closed without writing a frame at all");
+
+    let mut trailing = Vec::new();
+    tokio::time::timeout(GENEROUS, reader.read_to_end(&mut trailing))
+        .await
+        .expect("the server must close rather than hold the connection open")
+        .expect("read to EOF");
+
+    RawExchange {
+        frame: serde_json::from_str(&line).expect("the answer must be one JSON frame"),
+        trailing,
+    }
+}
+
+/// #6288 slice 1's whole observable contract: the listener is up and answers
+/// every method with `method_not_found`.
+///
+/// Why: an empty router could plausibly fail three ways a client cannot tell
+/// apart from a healthy "not yet implemented" — it could hang, it could accept
+/// and hang up without a frame, or it could answer a malformed frame. This
+/// asserts the one correct shape and rules out the other three: a well-formed
+/// JSON-RPC error frame carrying `-32601`, the request's id echoed back, and a
+/// clean close with no trailing bytes.
+///
+/// `mpm.health` is the method slice 2 registers first, so this also pins the
+/// answer a client gets from a daemon that has not yet taken that slice.
+/// Test: this function IS the test.
+#[tokio::test(flavor = "multi_thread")]
+async fn unknown_method_gets_a_method_not_found_frame() {
+    let tmp = TempDir::new().expect("tempdir");
+    let socket = tmp.path().join("sockets").join("trusty-mpm.sock");
+    let (stop, handle) = spawn_listener(&socket).await;
+
+    let exchange = dial_once(
+        &socket,
+        &serde_json::json!({
+            "jsonrpc": "2.0", "id": 7, "method": "mpm.health", "params": {},
+        }),
+    )
+    .await;
+
+    assert_eq!(exchange.frame["jsonrpc"], "2.0");
+    assert_eq!(exchange.frame["id"], 7);
+    assert!(
+        exchange.frame.get("result").is_none(),
+        "a router with no methods must not answer a result: {}",
+        exchange.frame
+    );
+    assert_eq!(
+        exchange.frame["error"]["code"],
+        serde_json::json!(trusty_common::uds::server::CODE_METHOD_NOT_FOUND),
+        "unknown methods answer method_not_found: {}",
+        exchange.frame
+    );
+    assert!(
+        exchange.trailing.is_empty(),
+        "the server must close cleanly after one frame, not send {} more bytes",
+        exchange.trailing.len()
+    );
+
+    let _ = stop.send(());
+    handle.await.expect("the serve task must not panic");
+}
+
+/// Why: `bind_hardened` binds and chmods; neither it nor `UnixListener`'s
+/// `Drop` removes the path, so a listener that just returned would leave a file
+/// behind. This drives the real shutdown path and asserts the file is gone —
+/// a test that deleted the file itself would pass whether or not the unlink in
+/// `serve_until_shutdown` exists.
+/// Test: this function IS the test.
+#[tokio::test(flavor = "multi_thread")]
+async fn serve_unlinks_its_socket_on_shutdown() {
+    let tmp = TempDir::new().expect("tempdir");
+    let socket = tmp.path().join("sockets").join("trusty-mpm.sock");
+    let (stop, handle) = spawn_listener(&socket).await;
+    assert!(socket.exists(), "the listener must have bound its socket");
+
+    let _ = stop.send(());
+    handle.await.expect("the serve task must not panic");
+
+    assert!(
+        !socket.exists(),
+        "the socket file must be unlinked on clean shutdown: {}",
+        socket.display()
+    );
+}
+
+/// The Fail-Open Check (#6288 acceptance criterion 4).
+///
+/// Why: the failure this rules out is a daemon that shrugs off a UDS bind
+/// failure and serves HTTP only. `bind` returns `Result`, not `Option`, and
+/// `serve_http` propagates it with `?` — so the observable proof is that a bind
+/// against a socket someone else is serving is an `Err` whose message names the
+/// path, rather than a value the caller could mistake for "no socket, carry on".
+/// What: binds and serves one socket, then binds the SAME path again while the
+/// first is live.
+/// Test: this function IS the test.
+#[tokio::test(flavor = "multi_thread")]
+async fn bind_refuses_a_socket_another_process_is_serving() {
+    let tmp = TempDir::new().expect("tempdir");
+    let socket = tmp.path().join("sockets").join("trusty-mpm.sock");
+    let (stop, handle) = spawn_listener(&socket).await;
+
+    let err = bind(&socket)
+        .await
+        .expect_err("a second bind against a live socket must fail, never degrade");
+    let rendered = format!("{err:#}");
+    assert!(
+        rendered.contains(&socket.display().to_string()),
+        "the error must name the path an operator has to act on: {rendered}"
+    );
+
+    // The refusal must not have disturbed the live owner.
+    assert!(
+        trusty_common::uds::socket_is_serving(&socket, GENEROUS).await,
+        "the incumbent must still be serving after the refused bind"
+    );
+
+    let _ = stop.send(());
+    handle.await.expect("the serve task must not panic");
+}
+
+/// Why: launchd SIGKILLs a daemon at the `ExitTimeOut` boundary, and that
+/// daemon never reaches the unlink in `serve_until_shutdown`. If the successor
+/// refused the leftover file, every such stop would wedge the restart into a
+/// crash loop. `bind_singleton_hardened` reclaims a socket file the kernel
+/// proves nobody is serving; this asserts trusty-mpm gets that behaviour.
+///
+/// What: the corpse is a REAL socket inode whose listener has been dropped —
+/// exactly what a SIGKILLed predecessor leaves, and the only fixture the
+/// takeover fires on. A plain file at the same path answers `ENOTSOCK`, which
+/// is `SocketVerdict::Inconclusive` and is refused rather than reclaimed; that
+/// asymmetry is deliberate (`uds::singleton`) and this test must not paper
+/// over it.
+/// Test: this function IS the test.
+#[tokio::test(flavor = "multi_thread")]
+async fn bind_reclaims_a_stale_socket_file() {
+    let tmp = TempDir::new().expect("tempdir");
+    let dir = tmp.path().join("sockets");
+    std::fs::create_dir_all(&dir).expect("create the socket directory");
+    let socket = dir.join("trusty-mpm.sock");
+
+    // `UnixListener`'s `Drop` does not unlink, so this leaves the inode behind
+    // with nothing listening — a corpse, not a live owner.
+    let corpse = std::os::unix::net::UnixListener::bind(&socket).expect("bind the predecessor");
+    drop(corpse);
+    assert!(socket.exists(), "the corpse must outlive its listener");
+
+    let (stop, handle) = spawn_listener(&socket).await;
+    assert!(
+        trusty_common::uds::socket_is_serving(&socket, GENEROUS).await,
+        "the successor must be serving the reclaimed path"
+    );
+
+    let _ = stop.send(());
+    handle.await.expect("the serve task must not panic");
+}
+
+/// Why: the path is DERIVED rather than published, so a typo in the file name
+/// is not caught by a mismatched discovery file — it is caught by a consumer
+/// dialling a path nothing binds. This pins the name against the convention
+/// trusty-memory, trusty-review, and trusty-analyze already follow.
+/// Test: this function IS the test.
+#[test]
+fn socket_path_is_the_product_named_socket_under_the_data_dir() {
+    let path = socket_path().expect("the data directory must resolve");
+    assert_eq!(
+        path.file_name().and_then(|n| n.to_str()),
+        Some("trusty-mpm.sock"),
+        "socket path {} does not follow the <product>.sock convention",
+        path.display()
+    );
+    assert!(
+        path.is_absolute(),
+        "a relative socket path would resolve against the daemon's cwd (/ under \
+         launchd): {}",
+        path.display()
+    );
+}

--- a/crates/trusty-mpm/tests/daemon_dual_serve.rs
+++ b/crates/trusty-mpm/tests/daemon_dual_serve.rs
@@ -134,12 +134,16 @@ async fn serve_http_drains_both_listeners_on_shutdown() {
     );
 
     // ── One shutdown drains both ─────────────────────────────────────────────
-    stop_tx.send(()).expect("the serve task must still be running");
+    stop_tx
+        .send(())
+        .expect("the serve task must still be running");
 
     let joined = tokio::time::timeout(DRAIN_BUDGET, served)
         .await
-        .expect("both listeners must drain on ONE shutdown — a listener still \
-                 waiting on its own signal never returns")
+        .expect(
+            "both listeners must drain on ONE shutdown — a listener still \
+                 waiting on its own signal never returns",
+        )
         .expect("the serve task must not panic");
     joined.expect("a clean drain is not an error");
 

--- a/crates/trusty-mpm/tests/daemon_dual_serve.rs
+++ b/crates/trusty-mpm/tests/daemon_dual_serve.rs
@@ -1,0 +1,155 @@
+//! The daemon serves HTTP and the RPC socket at once, and ONE shutdown drains
+//! both (#6288 slice 1, acceptance criterion 1).
+//!
+//! Why its own test binary: the proof reassigns `$HOME` to a scratch directory
+//! so `core::host_state_gate` classifies this process as a scratch environment
+//! and the startup tmux/host-process adoption is skipped — without that, booting
+//! a daemon inside the lib test binary would adopt the operator's live Claude
+//! Code panes into a temp registry. `$HOME` is process-global, so it cannot be
+//! reassigned inside a binary that runs other tests concurrently; this file
+//! holds exactly ONE test, which is what makes the reassignment safe. Same
+//! rationale as `scratch_home_tmux_gate.rs`.
+//!
+//! Why not the e2e harness: `tests/e2e/harness.rs` serves `api::router` on a
+//! bare `axum::serve`, so it never reaches `daemon::serve_with_shutdown` and
+//! cannot observe the fan-out at all. This drives the real body.
+//!
+//! What: binds both listeners, spawns `serve_with_shutdown` with a oneshot in
+//! place of SIGTERM, proves both answer, fires the single shutdown, and asserts
+//! both ended and the socket file is gone.
+//! Test: this file IS the test; run with
+//! `cargo test -p trusty-mpm --test daemon_dual_serve`.
+
+#![cfg(feature = "daemon")]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tempfile::TempDir;
+use trusty_mpm::core::paths::FrameworkPaths;
+use trusty_mpm::daemon::state::DaemonState;
+
+/// Headroom for a drain on a loaded machine, not a latency budget.
+///
+/// A regressed fan-out does not drain slowly — it never drains at all, because
+/// the listener that was left waiting on its own signal is waiting for a
+/// SIGTERM this test never sends. So this timeout is what turns that regression
+/// into a failure rather than a hung suite.
+const DRAIN_BUDGET: Duration = Duration::from_secs(30);
+
+/// Send one JSON-RPC frame over `socket` and read the answer back.
+async fn call_over_socket(
+    socket: &std::path::Path,
+    method: &str,
+) -> Result<serde_json::Value, trusty_common::uds::UdsRpcError> {
+    let request = serde_json::json!({
+        "jsonrpc": "2.0", "id": 1, "method": method, "params": {},
+    });
+    trusty_common::uds::send_framed_request(socket, &request, Duration::from_secs(10)).await
+}
+
+/// Criterion 1: both listeners serve concurrently, and one shutdown drains both.
+///
+/// Why this is the test the slice owes: `socket_tests.rs` drives the socket's
+/// own accept loop with a synthetic shutdown, and the e2e suite drives HTTP with
+/// no socket at all. Neither reaches `serve_with_shutdown`'s cancellation
+/// fan-out, which is the one piece of code that makes a single signal stop two
+/// listeners. Replacing the fan-out with two independent `shutdown_signal()`
+/// awaits makes this test hang past `DRAIN_BUDGET` and fail — a real SIGTERM is
+/// exactly what a test process cannot deliver to itself.
+///
+/// What: one HTTP request and one UDS request against a live daemon, then one
+/// shutdown, then three assertions — the serve future returned, the socket file
+/// is unlinked, and the HTTP port no longer answers.
+/// Test: this function IS the test.
+#[tokio::test(flavor = "multi_thread")]
+async fn serve_http_drains_both_listeners_on_shutdown() {
+    let scratch_home = TempDir::new().expect("scratch home");
+    // SAFETY: this binary holds exactly one test, so nothing races these
+    // process-global writes. `$HOME` puts `host_state_gate` into its scratch
+    // arm; the two flags switch off the sweeps that would otherwise touch real
+    // repositories and managed-session state on a developer machine.
+    unsafe {
+        std::env::set_var("HOME", scratch_home.path());
+        std::env::set_var("TRUSTY_MPM_ORPHAN_GC", "0");
+        std::env::set_var("TRUSTY_MPM_INPROJECT_HYGIENE", "0");
+    }
+
+    let tmp = TempDir::new().expect("tempdir");
+    let paths = FrameworkPaths::under(tmp.path());
+    std::fs::create_dir_all(&paths.hooks).expect("hooks dir");
+    std::fs::create_dir_all(&paths.instructions).expect("instructions dir");
+    std::fs::create_dir_all(&paths.agents).expect("agents dir");
+    let state = Arc::new(DaemonState::with_paths(&paths));
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind a loopback port");
+    let addr = listener.local_addr().expect("local addr");
+    let health_url = format!("http://{addr}/health");
+
+    let socket = tmp.path().join("sockets").join("trusty-mpm.sock");
+    let rpc = trusty_mpm::daemon::socket::bind(&socket)
+        .await
+        .expect("bind the rpc socket");
+
+    let (stop_tx, stop_rx) = tokio::sync::oneshot::channel::<()>();
+    let served = tokio::spawn(trusty_mpm::daemon::serve_with_shutdown(
+        state,
+        listener,
+        rpc,
+        async move {
+            let _ = stop_rx.await;
+        },
+    ));
+
+    // ── Both listeners answer ────────────────────────────────────────────────
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .expect("http client");
+
+    let mut http_ok = false;
+    for _ in 0..200 {
+        if let Ok(r) = client.get(&health_url).send().await
+            && r.status().is_success()
+        {
+            http_ok = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    assert!(http_ok, "the HTTP listener must answer /health at {addr}");
+
+    // The socket serves an empty router in slice 1, so the answer is an error
+    // frame. That it is a FRAME is the point: the request was read and answered
+    // over the socket while HTTP was serving on the same runtime.
+    let answer = call_over_socket(&socket, "mpm.health")
+        .await
+        .expect("the rpc listener must answer while HTTP is also serving");
+    assert_eq!(
+        answer["error"]["code"],
+        serde_json::json!(trusty_common::uds::server::CODE_METHOD_NOT_FOUND),
+        "slice 1 registers no methods: {answer}"
+    );
+
+    // ── One shutdown drains both ─────────────────────────────────────────────
+    stop_tx.send(()).expect("the serve task must still be running");
+
+    let joined = tokio::time::timeout(DRAIN_BUDGET, served)
+        .await
+        .expect("both listeners must drain on ONE shutdown — a listener still \
+                 waiting on its own signal never returns")
+        .expect("the serve task must not panic");
+    joined.expect("a clean drain is not an error");
+
+    assert!(
+        !socket.exists(),
+        "the socket file must be unlinked on the drain: {}",
+        socket.display()
+    );
+    assert!(
+        client.get(&health_url).send().await.is_err(),
+        "the HTTP listener must be closed after the drain, not still answering"
+    );
+}


### PR DESCRIPTION
The daemon binds `<data dir>/trusty-mpm.sock` through
`trusty_common::uds::bind_singleton_hardened` and serves an `RpcRouter` with no
registered methods, alongside the unchanged `127.0.0.1:7880` HTTP listener. No
HTTP route moved and nothing was removed.

Slice 1 of the plan in the #6288 comment. Refs #6288.

## Fail-Open Check

A UDS bind failure aborts startup and publishes nothing — the daemon never
degrades to HTTP-only, and no lock file survives naming a daemon that failed to
start.

`run_daemon` binds the socket BEFORE it writes the lock file. Both binds now
happen in the caller and `serve_http` takes the pre-bound socket, so there is no
window in which the lock names a daemon whose second listener has not been
taken. Covered by two tests over `bind_socket_then_publish`:

- `bind_socket_then_publish_writes_no_lock_when_the_socket_is_taken` — holds the
  socket with a live listener, asserts the bind is `Err` naming the path AND
  that no lock file exists afterwards. Swapping the two statements in
  `bind_socket_then_publish` makes it fail (verified: `no lock file may name a
  daemon that failed to start`).
- `bind_socket_then_publish_writes_the_lock_when_the_bind_succeeds` — the other
  half, so deleting the write outright does not pass.

`bind_refuses_a_socket_another_process_is_serving` covers the bind refusal
itself, including that the incumbent is left serving.

## Criterion 1 — one shutdown drains both listeners

`tests/daemon_dual_serve.rs::serve_http_drains_both_listeners_on_shutdown`
boots a real daemon through `serve_with_shutdown` (`serve_http`'s body, with the
signal as a parameter because a test process cannot SIGTERM itself), drives one
HTTP request and one UDS request against it, fires ONE shutdown, then asserts the
serve future returned, the socket file is unlinked, and the HTTP port no longer
answers.

Verified to fail against the regression it exists to catch: replacing the
cancellation fan-out with an independent `shutdown_signal()` await in the RPC
task makes it fail after 30s with `both listeners must drain on ONE shutdown — a
listener still waiting on its own signal never returns: Elapsed(())`.

## Also in this slice

- `DaemonLock` gains `socket_path` and keeps `addr` unchanged. The field is
  `#[serde(default)]`, so a lock written by a pre-#6288 daemon still parses with
  an empty value meaning HTTP only — both directions have a test
  (`parse_lock_reads_a_pre_6288_record`,
  `render_lock_keeps_addr_readable_alongside_socket_path`).
- The shutdown signal is awaited once, through `trusty_common::shutdown_signal`,
  and fanned out to both listeners through a cancellation token. That replaces a
  private line-for-line copy of the same helper in `daemon/mod.rs`.
- `serve_until_shutdown` unlinks the socket before dropping the listener; the
  cancel after `axum::serve` returns means the file is removed even when HTTP
  exits for a reason that was never a signal.
- `daemon_run.rs`'s SIGTERM handler calls `std::process::exit(0)` and almost
  certainly wins the race against the graceful drain. That predates this PR;
  the socket is self-healing via reclaim, so slice 1 leaves it and records a
  `// See #6288` note pointing at slice 7. Adding an unlink there would be the
  #1731 lock-file bug in a new place — an outgoing daemon deleting a successor's
  file.

## Gates — rung 4

`cargo tree -i -p trusty-mpm --depth 1` lists trusty-mpm alone: no workspace
crate compiles against `DaemonLock`, so rung 4's per-dependent leg is vacuous
and `cargo check --workspace` covers the rest. trusty-console reads the lock file
as TEXT (`detect/mpm.rs::parse_lock_addr`, an exact-key scan), which
`render_lock_keeps_addr_readable_alongside_socket_path` pins from the writing
side.

| Gate | Result |
|---|---|
| `cargo fmt --check` | clean |
| `cargo check -p trusty-mpm --all-targets` | exit 0 |
| `cargo clippy -p trusty-mpm --all-targets -- -D warnings` | exit 0 |
| `cargo test -p trusty-mpm --no-fail-fast` | 9402 passed, 8 failed, 18 ignored, 52 targets — see below |
| `SKIP_UI_BUILD=1 cargo check --workspace --all-targets` | exit 0 |
| `bash scripts/check_line_cap.sh` | 4216 files, 0 violations |
| `bash scripts/check_changelog_fragment.sh` | OK trusty-mpm |
| `bash scripts/check_sld.sh` | 0 errors, 0 warnings |

**Change-specific gates pass; 8 pre-existing environmental failures.** All eight
are in `core::gh_account::enforce` and `core::git_identity`, which shell out to
the real `gh` binary under a 5-second budget:

```
`gh auth status` did not respond within 5s
```

`git diff --name-only origin/main...HEAD -- crates/trusty-mpm/src/core/gh_account_enforce.rs crates/trusty-mpm/src/core/git_identity.rs`
is empty — this branch does not touch them — and they pass unloaded:

```
cargo test -p trusty-mpm --lib -- core::gh_account:: core::git_identity::
test result: ok. 79 passed; 0 failed; 0 ignored; 0 measured; 5223 filtered out; finished in 2.64s
```

The full run took 210s for the lib target against 95s earlier in the session; the
machine was saturated.

New tests, all passing in that same loaded run:

```
test core::daemon_identity::tests::parse_lock_reads_a_pre_6288_record ... ok
test core::daemon_identity::tests::render_lock_keeps_addr_readable_alongside_socket_path ... ok
test daemon::socket::tests::bind_reclaims_a_stale_socket_file ... ok
test daemon::socket::tests::bind_refuses_a_socket_another_process_is_serving ... ok
test daemon::socket::tests::serve_unlinks_its_socket_on_shutdown ... ok
test daemon::socket::tests::socket_path_is_the_product_named_socket_under_the_data_dir ... ok
test daemon::socket::tests::unknown_method_gets_a_method_not_found_frame ... ok
test commands::daemon::daemon_run::tests::bind_socket_then_publish_writes_no_lock_when_the_socket_is_taken ... ok
test commands::daemon::daemon_run::tests::bind_socket_then_publish_writes_the_lock_when_the_bind_succeeds ... ok
test serve_http_drains_both_listeners_on_shutdown ... ok
```

`bind_reclaims_a_stale_socket_file` retries its bind up to ten times. That is not
a mask: `uds/singleton.rs` records that its one-second takeover probe can be
starved on a busy machine, read as `Inconclusive`, and refuse a genuinely stale
socket — "safe but wrong" — and names the remedy, "one failed start that a retry
fixes". The test failed once on a saturated run for exactly that reason. Verified
the retry still catches a broken reclaim: swapping `bind_singleton_hardened` for
`bind_hardened` makes it fail all ten attempts with `Address already in use`.

`unknown_method_gets_a_method_not_found_frame` dials the socket raw rather than
through `send_framed_request`: it asserts one well-formed `-32601` frame with the
request id echoed back, AND that the server then closes with no trailing bytes —
which is what separates a healthy "not yet implemented" from a hang or an
EOF-without-frame.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
