### PR TITLE
fix(docs): resolve ten broken intra-doc links; trusty-common 0.45.3 supersedes the stranded 0.45.2 tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11425,7 +11425,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-common"
-version = "0.45.2"
+version = "0.45.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -35,7 +35,7 @@ name = "trusty-common"
 # (`ConsolidationProvider`, `resolve_consolidation_provider`, three consts) or a
 # default VALUE change on an existing field; no public item was removed or had
 # its type changed, so nothing here breaks a consumer at compile time.
-version = "0.45.2"
+version = "0.45.3"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/trusty-common/changelog.d/6345-rustdoc-links-changed.md
+++ b/crates/trusty-common/changelog.d/6345-rustdoc-links-changed.md
@@ -1,0 +1,5 @@
+Changed
+
+- Version 0.45.3. The `trusty-common-v0.45.2` tag is stranded at `e8a74389f`,
+  the commit these links are broken on, and release tags here are immutable
+  (#6178), so 0.45.2 is spent and 0.45.3 supersedes it.

--- a/crates/trusty-common/changelog.d/6345-rustdoc-links-fixed.md
+++ b/crates/trusty-common/changelog.d/6345-rustdoc-links-fixed.md
@@ -1,0 +1,15 @@
+Fixed
+
+- Seven broken intra-doc links that failed the pre-publish rustdoc gate
+  (`scripts/check_rustdoc_links.sh`) and, because `lib.rs` carries
+  `#![deny(rustdoc::broken_intra_doc_links)]`, failed `cargo doc -p
+  trusty-common` outright — which also took down the pre-publish contract gate,
+  since it reads rustdoc JSON from the same build. `gui_mcp_client` and
+  `redb_open` each carry an outer `///` doc on their `pub mod` line in `lib.rs`
+  and an inner `//!` block in their own file; rustdoc resolves the whole
+  combined doc in the outer attribute's scope, so the inner block's bare
+  `[\`running_binary_path\`]`, `[\`build_entry\`]`, `[\`configure\`]`,
+  `[\`is_incompatible_format\`]`, `[\`INCOMPATIBLE_SUFFIX\`]`,
+  `[\`incompatible_backup_path\`]` and `[\`backup_incompatible_file\`]` were
+  looked up at the crate root and found nothing. All seven are now
+  `crate::`-qualified, which resolves from either scope.

--- a/crates/trusty-common/src/gui_mcp_client.rs
+++ b/crates/trusty-common/src/gui_mcp_client.rs
@@ -15,9 +15,11 @@
 //! The owner's ruling is that the user never types a cargo path: the installed
 //! binary writes its own, read from [`std::env::current_exe`].
 //!
-//! What: [`running_binary_path`] resolves and canonicalizes the running
-//! executable, [`build_entry`] validates a `{command, args, cwd}` registration
-//! (absolute command, existing working directory) and [`configure`] either
+//! What: [`crate::gui_mcp_client::running_binary_path`] resolves and
+//! canonicalizes the running executable,
+//! [`crate::gui_mcp_client::build_entry`] validates a `{command, args, cwd}`
+//! registration (absolute command, existing working directory) and
+//! [`crate::gui_mcp_client::configure`] either
 //! writes it to the client's own config file or hands it back for the operator
 //! to paste when the client keeps no file we can write. The JSON body is built
 //! by [`crate::claude_config::mcp_server_entry`] and written by

--- a/crates/trusty-common/src/redb_open.rs
+++ b/crates/trusty-common/src/redb_open.rs
@@ -9,10 +9,12 @@
 //! is the defect #5063 records: the classification is one decision, and a
 //! second independent copy of it is drift waiting to happen.
 //!
-//! What: [`is_incompatible_format`] is that decision, and nothing else.
-//! [`INCOMPATIBLE_SUFFIX`], [`incompatible_backup_path`] and
-//! [`backup_incompatible_file`] are the quarantine-path mechanics two of those
-//! crates also duplicated verbatim, including the numbered anti-clobber rule.
+//! What: [`crate::redb_open::is_incompatible_format`] is that decision, and
+//! nothing else. [`crate::redb_open::INCOMPATIBLE_SUFFIX`],
+//! [`crate::redb_open::incompatible_backup_path`] and
+//! [`crate::redb_open::backup_incompatible_file`] are the quarantine-path
+//! mechanics two of those crates also duplicated verbatim, including the
+//! numbered anti-clobber rule.
 //!
 //! What this module deliberately does NOT own: the recovery POLICY. What a
 //! store does once the classifier says "unopenable" diverges for recorded

--- a/crates/trusty-memory/changelog.d/6345-rustdoc-links.md
+++ b/crates/trusty-memory/changelog.d/6345-rustdoc-links.md
@@ -1,0 +1,9 @@
+Documentation
+
+- Two broken intra-doc links in the `tools::embed_audit` module doc, which
+  failed the pre-publish rustdoc gate (`scripts/check_rustdoc_links.sh`).
+  `EmbedHealth` is not imported here, so the link now names its full path,
+  `trusty_common::memory_core::retrieval::EmbedHealth::missing_vector_ids`. The
+  reference to `MAX_PALACES_IN_REPORT` is now plain code text and the link
+  points at `console_metrics` instead: the constant is private to that module,
+  so no link to it can resolve from public documentation.

--- a/crates/trusty-memory/src/tools/embed_audit.rs
+++ b/crates/trusty-memory/src/tools/embed_audit.rs
@@ -1,7 +1,7 @@
 //! Answer "is this findable?" directly, per id and per estate (#5000, #4786).
 //!
 //! Why: `palace_reembed` reports one palace's whole missing set, and
-//! `console_metrics` reports at most [`MAX_PALACES_IN_REPORT`] of them from
+//! [`crate::console_metrics`] reports at most `MAX_PALACES_IN_REPORT` of them from
 //! cache. Neither answers the two questions that actually get asked.
 //!
 //! A deletion-bearing workflow asks about ITS OWN ids — #4834 deleted 72 source
@@ -25,7 +25,8 @@
 //! that gap in both directions: palace `trusty-tools` read a gap of 4 with 0
 //! drawers missing (id aliasing, nothing absent), and orphan vectors can mask a
 //! real hole the other way. What is reported instead is
-//! [`EmbedHealth::missing_vector_ids`] plus the alias audit's `key_rows` versus
+//! [`trusty_common::memory_core::retrieval::EmbedHealth::missing_vector_ids`]
+//! plus the alias audit's `key_rows` versus
 //! `distinct_vector_ids` — the pair that catches both classes. An audit that
 //! could not RUN is never a pass: it reports `unavailable`, and a caller gating
 //! a deletion on it must treat that as a block.

--- a/crates/trusty-mpm/changelog.d/6345-rustdoc-links.md
+++ b/crates/trusty-mpm/changelog.d/6345-rustdoc-links.md
@@ -1,0 +1,6 @@
+Documentation
+
+- One broken intra-doc link on `daemon::doctor::run_doctor_for_manager`, which
+  failed the pre-publish rustdoc gate (`scripts/check_rustdoc_links.sh`).
+  `SessionManager` is referred to by its full path in the signature and never
+  imported, so the doc link now says `crate::session_manager::SessionManager`.

--- a/crates/trusty-mpm/src/daemon/doctor.rs
+++ b/crates/trusty-mpm/src/daemon/doctor.rs
@@ -436,7 +436,8 @@ pub async fn run_doctor(
     DoctorReport::from_checks(checks)
 }
 
-/// Run the full check battery against one [`SessionManager`]'s view of the fleet.
+/// Run the full check battery against one
+/// [`crate::session_manager::SessionManager`]'s view of the fleet.
 ///
 /// Why (#6336): [`run_doctor`] takes its fleet inputs as plain values, so the
 /// daemon's `GET /api/v1/doctor` handler and the standalone `tm doctor` CLI


### PR DESCRIPTION
The `Pre-publish gate` is red on `main` at `e8a74389f`: `scripts/check_rustdoc_links.sh` reports ten unresolved intra-doc links, and because `crates/trusty-common/src/lib.rs` carries `#![deny(rustdoc::broken_intra_doc_links)]`, `cargo doc -p trusty-common` fails outright, which fails Gate 5 too since it reads rustdoc JSON from the same build. All ten links now resolve — seven of them share one cause, that `gui_mcp_client` and `redb_open` each carry an outer `///` doc on their `pub mod` line in `lib.rs` plus an inner `//!` block in their own file, and rustdoc resolves the combined doc in the outer attribute's scope, so the inner block's bare links were looked up at the crate root. `trusty-common-v0.45.2` is tagged at `e8a74389f` and release tags here are immutable (#6178), so that version number is spent and this bumps trusty-common to 0.45.3.

## Each link, and how it was fixed

| Crate | Site | Link | Fix |
|---|---|---|---|
| trusty-common | `src/gui_mcp_client.rs:18` (reported at `lib.rs:174`) | `running_binary_path` | `crate::gui_mcp_client::running_binary_path` |
| trusty-common | `src/gui_mcp_client.rs:19` | `build_entry` | `crate::gui_mcp_client::build_entry` |
| trusty-common | `src/gui_mcp_client.rs:20` | `configure` | `crate::gui_mcp_client::configure` |
| trusty-common | `src/redb_open.rs:12` (reported at `lib.rs:582`) | `is_incompatible_format` | `crate::redb_open::is_incompatible_format` |
| trusty-common | `src/redb_open.rs:13` | `INCOMPATIBLE_SUFFIX` | `crate::redb_open::INCOMPATIBLE_SUFFIX` |
| trusty-common | `src/redb_open.rs:13` | `incompatible_backup_path` | `crate::redb_open::incompatible_backup_path` |
| trusty-common | `src/redb_open.rs:14` | `backup_incompatible_file` | `crate::redb_open::backup_incompatible_file` |
| trusty-memory | `src/tools/embed_audit.rs:4` | `MAX_PALACES_IN_REPORT` | Plain code text; the link now points at `crate::console_metrics`. The constant is `const MAX_PALACES_IN_REPORT` (`console_metrics.rs:32`) with no `pub`, so no link from public documentation can resolve to it. |
| trusty-memory | `src/tools/embed_audit.rs:28` | `EmbedHealth::missing_vector_ids` | `trusty_common::memory_core::retrieval::EmbedHealth::missing_vector_ids` — the type is not imported here, and `embed_repair` is private, so the re-export path is the reachable one |
| trusty-mpm | `src/daemon/doctor.rs:439` | `SessionManager` | `crate::session_manager::SessionManager` — the signature names it by full path and never imports it |

No baseline row was added; `scripts/rustdoc-link-baseline.tsv` is unchanged and still has zero rows.

## Version bump

`crates/trusty-common/Cargo.toml` 0.45.2 → 0.45.3. `Cargo.lock` changed on one line, the `trusty-common` package version — no `cargo update`, so no transitive-dependency churn that could move the MSRV 1.94 job. The root `[workspace.dependencies]` entry is `version = "0.45"` and every dependent declares `version = "0.45"`, all of which 0.45.3 already satisfies, so no requirement needed widening. No other crate's version changed.

Test ladder rung 3: doc comments and a version field, no logic changed.

## Gates

`bash scripts/check_rustdoc_links.sh`

```
SUMMARY	26 crate(s) examined by rustdoc, 0 broken link(s), baseline 0, 0 diagnostic(s) examined
EXIT=0
```

That script is verbatim what the `Pre-publish gate` Gate 1 step runs; it invokes `cargo doc --workspace --no-deps --locked --keep-going` under `RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links"` with the three GUI crates excluded.

```
+ cargo fmt --check
=== fmt OK ===
+ cargo doc --no-deps --locked -p trusty-common -p trusty-memory -p trusty-mpm
=== doc OK ===
+ cargo check --workspace --locked
=== check OK ===
+ cargo test -p trusty-common --features unconditional-only
running 390 tests
test result: ok. 384 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 3.18s
EXIT=0
```

`--locked` held on both the doc and the workspace check, which is the evidence that the hand-edited lockfile is complete and no other entry moved.

`bash scripts/check_changelog_fragment.sh`

```
OK   trusty-common: changelog.d fragment present and valid
OK   trusty-memory: changelog.d fragment present and valid
OK   trusty-mpm: changelog.d fragment present and valid
changelog-fragment gate: scanned 10 changed path(s); attributed 4 crate-source path(s); all 3 crate(s) with source changes are recorded.
```

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
