### PR TITLE
feat(trusty-mpm): core daemon routes served as RPC methods over UDS (Refs #6288)

### DIFF
--- a/crates/trusty-mpm/changelog.d/6288-s2-rpc-core.md
+++ b/crates/trusty-mpm/changelog.d/6288-s2-rpc-core.md
@@ -1,0 +1,3 @@
+Added
+
+- The daemon serves its health, doctor, error-list, bug-report, breaker, optimizer, overseer, LLM-chat, tmux and claude-config routes as JSON-RPC methods on the Unix socket, under `mpm.<family>.<verb>` names. HTTP still serves all twenty routes unchanged; each route now has one shared body both transports call. (#6288)

--- a/crates/trusty-mpm/src/daemon/api.rs
+++ b/crates/trusty-mpm/src/daemon/api.rs
@@ -32,6 +32,9 @@ use crate::core::project::ProjectInfo;
 use crate::core::session::{ControlModel, Session, SessionId, SessionStatus};
 
 use super::error::DaemonError;
+// #6288: the transport-neutral bodies these handlers and the socket's
+// `mpm.*` methods both call. One route, one implementation.
+use super::rpc::core_ops;
 use super::services::{HookDecision, HookService, PairingService, SessionService, TmuxService};
 use super::state::DaemonState;
 
@@ -438,25 +441,8 @@ pub fn router(state: Arc<DaemonState>) -> Router {
     responses((status = 200, description = "Daemon is alive", body = HealthResponse))
 )]
 pub async fn health(State(state): State<Arc<DaemonState>>) -> Json<HealthResponse> {
-    let fw = crate::core::paths::FrameworkPaths::from_root(state.framework_root());
-    // The daemon-wide baseline uses the framework root as the "project" so only
-    // the user/catalog/default manifest layers apply (no per-project override).
-    let report = crate::core::update_check::detect_for_framework(&fw, state.framework_root());
-    Json(HealthResponse {
-        status: "ok".to_owned(),
-        catalog_stale: report.stale,
-        catalog_unknown: report.unknown,
-        catalog_changes: report.summary_lines(),
-        supervised: state.supervised(),
-        // #4469: the three-state answer the bool above collapses. Published so
-        // `tm doctor` can distinguish "launchd says no" from "could not ask".
-        launchd_supervision: state.launchd_supervision(),
-        version: env!("CARGO_PKG_VERSION").to_owned(),
-        // #4230: identify WHICH process answered, so `tm doctor` can compare it
-        // against the PID launchd owns instead of trusting `supervised` alone.
-        pid: std::process::id(),
-        unsupervised_forced: state.unsupervised_forced(),
-    })
+    // #6288: the body is shared with `mpm.health` over the Unix socket.
+    Json(core_ops::health(&state).await)
 }
 
 /// Query parameters for `GET /sessions`.
@@ -1254,12 +1240,8 @@ pub async fn get_output(
     responses((status = 200, description = "Array of per-agent circuit-breaker states"))
 )]
 pub async fn breakers(State(state): State<Arc<DaemonState>>) -> Json<BreakersResponse> {
-    let breakers = state
-        .all_breakers()
-        .into_iter()
-        .map(|(agent, breaker)| BreakerEntry { agent, breaker })
-        .collect();
-    Json(BreakersResponse { breakers })
+    // #6288: the body is shared with `mpm.breakers` over the Unix socket.
+    Json(core_ops::breakers(&state))
 }
 
 /// JSON body for the universal hook relay endpoint.
@@ -1361,12 +1343,8 @@ pub async fn ingest_hook(
     responses((status = 200, description = "Overseer enabled flag and handler type"))
 )]
 pub async fn get_overseer(State(state): State<Arc<DaemonState>>) -> Json<OverseerResponse> {
-    Json(OverseerResponse {
-        overseer: OverseerStatus {
-            enabled: state.overseer().is_enabled(),
-            handler: state.overseer_handler().to_string(),
-        },
-    })
+    // #6288: the body is shared with `mpm.overseer` over the Unix socket.
+    Json(core_ops::overseer(&state))
 }
 
 /// `POST /llm/chat` — send a message to the LLM chat assistant.
@@ -1393,17 +1371,8 @@ pub async fn llm_chat(
     State(state): State<Arc<DaemonState>>,
     Json(body): Json<LlmChatRequest>,
 ) -> Result<Json<LlmChatResponse>, DaemonError> {
-    let overseer = state.llm_overseer().ok_or_else(|| {
-        DaemonError::ServiceUnavailable(
-            "LLM chat is not configured (no OpenRouter API key)".to_string(),
-        )
-    })?;
-    let mut history = body.history;
-    let reply = overseer
-        .chat(&mut history, &body.message)
-        .await
-        .map_err(|e| DaemonError::Internal(e.to_string()))?;
-    Ok(Json(LlmChatResponse { reply, history }))
+    // #6288: the body is shared with `mpm.llm.chat` over the Unix socket.
+    Ok(Json(core_ops::llm_chat(&state, body).await?))
 }
 
 /// `GET /optimizer` — current token-use optimizer configuration.
@@ -1422,10 +1391,8 @@ pub async fn llm_chat(
     responses((status = 200, description = "Current token-use optimizer configuration"))
 )]
 pub async fn get_optimizer(State(state): State<Arc<DaemonState>>) -> Json<OptimizerResponse> {
-    Json(OptimizerResponse {
-        optimizer: state.optimizer_config(),
-        scope: crate::daemon::optimizer::OPTIMIZER_SCOPE_NOTE.to_string(),
-    })
+    // #6288: the body is shared with `mpm.optimizer` over the Unix socket.
+    Json(core_ops::optimizer(&state))
 }
 
 /// JSON body for registering a project via `POST /projects`.
@@ -1576,11 +1543,10 @@ fn system_time_to_iso8601(time: std::time::SystemTime) -> String {
     responses((status = 200, description = "All tmux sessions with origin labels"))
 )]
 pub async fn list_tmux_sessions(
-    State(_state): State<Arc<DaemonState>>,
+    State(state): State<Arc<DaemonState>>,
 ) -> Json<TmuxSessionsResponse> {
-    Json(TmuxSessionsResponse {
-        sessions: TmuxService::list_all(),
-    })
+    // #6288: the body is shared with `mpm.tmux.sessions` over the Unix socket.
+    Json(core_ops::list_tmux_sessions(&state))
 }
 
 /// `GET /tmux/sessions/{name}/snapshot` — capture any session's current state.
@@ -1601,11 +1567,11 @@ pub async fn list_tmux_sessions(
     )
 )]
 pub async fn tmux_snapshot(
-    State(_state): State<Arc<DaemonState>>,
+    State(state): State<Arc<DaemonState>>,
     Path(name): Path<String>,
 ) -> Result<Json<TmuxSnapshotResponse>, DaemonError> {
-    let snapshot = TmuxService::snapshot(&name, 100)?;
-    Ok(Json(TmuxSnapshotResponse { snapshot }))
+    // #6288: the body is shared with `mpm.tmux.snapshot` over the Unix socket.
+    Ok(Json(core_ops::tmux_snapshot(&state, &name)?))
 }
 
 /// JSON body for `POST /tmux/adopt`.
@@ -1638,11 +1604,11 @@ pub struct AdoptRequest {
     )
 )]
 pub async fn adopt_tmux_session(
-    State(_state): State<Arc<DaemonState>>,
+    State(state): State<Arc<DaemonState>>,
     Json(body): Json<AdoptRequest>,
 ) -> Result<Json<AdoptResponse>, DaemonError> {
-    let adopted = TmuxService::adopt(&body.session)?;
-    Ok(Json(AdoptResponse { adopted }))
+    // #6288: the body is shared with `mpm.tmux.adopt` over the Unix socket.
+    Ok(Json(core_ops::adopt_tmux(&state, body)?))
 }
 
 // ---- bot pairing --------------------------------------------------------
@@ -1789,11 +1755,8 @@ pub async fn doctor(
     State(state): State<Arc<DaemonState>>,
     Query(query): Query<DoctorQuery>,
 ) -> Json<crate::core::doctor::DoctorReport> {
-    // #6336: the workspace paths, the managed root, and the reconciled worktree
-    // counts are all derived by `run_doctor_for_manager`, so this route and the
-    // daemonless `tm doctor` CLI cannot drift on how the fleet is read.
-    let mgr = state.session_manager().await;
-    Json(super::doctor::run_doctor_for_manager(&mgr, query.project.as_deref()).await)
+    // #6288: the body is shared with `mpm.doctor` over the Unix socket.
+    Json(core_ops::doctor(&state, query).await)
 }
 
 // ── Bug-reporting HTTP endpoints (Phase 2 surface + Phase 3 filing) ──────────
@@ -1826,28 +1789,11 @@ pub struct ErrorsQuery {
     responses((status = 200, description = "Deduplicated error list"))
 )]
 pub async fn list_errors(
-    State(_state): State<Arc<DaemonState>>,
+    State(state): State<Arc<DaemonState>>,
     Query(query): Query<ErrorsQuery>,
 ) -> Json<ErrorsResponse> {
-    let limit = query.limit.unwrap_or(20).min(100) as usize;
-    let errors = super::bug_report::aggregate_errors(limit);
-    let summaries: Vec<ErrorSummary> = errors
-        .iter()
-        .map(|e| ErrorSummary {
-            fingerprint: e.record.fingerprint.clone(),
-            crate_target: e.record.crate_target.clone(),
-            crate_version: e.record.crate_version.clone(),
-            summary: e.record.summary(),
-            occurrences: e.occurrences,
-            timestamp_secs: e.record.timestamp_secs,
-        })
-        .collect();
-    let total = summaries.len();
-    Json(ErrorsResponse {
-        errors: summaries,
-        total,
-        limit,
-    })
+    // #6288: the body is shared with `mpm.errors.list` over the Unix socket.
+    Json(core_ops::list_errors(&state, query))
 }
 
 /// JSON body for `POST /api/v1/report-bug`.
@@ -1865,28 +1811,11 @@ pub struct ReportBugApiRequest {
     pub confirm: bool,
 }
 
-/// Build a [`BugReportPreview`] from a scrubbed [`IssuePreview`].
+/// The scrubbed-preview builder, now shared with `mpm.report_bug` (#6288).
 ///
-/// Why: both the `confirm:false` path and the rate-limited path must return the
-///      same preview shape so HTTP clients can inspect before (or after a blocked)
-///      filing.
-/// What: maps `IssuePreview` fields to [`BugReportPreview`] (the wire type).
-/// Test: exercised transitively by `report_bug_no_confirm_includes_preview`.
-fn to_wire_preview(p: &super::bug_report::IssuePreview) -> BugReportPreview {
-    BugReportPreview {
-        title: p.title.clone(),
-        body: p.body.clone(),
-        labels: p.labels.clone(),
-        scrub_changes: p
-            .scrub_changes
-            .iter()
-            .map(|c| ScrubChangeSummary {
-                pattern: c.pattern.to_string(),
-                hint: c.hint.to_string(),
-            })
-            .collect(),
-    }
-}
+/// Why a re-export rather than a move outright: `api_tests` reaches it as
+/// `super::to_wire_preview`, and the HTTP tests must keep passing unmodified.
+pub use super::rpc::core_ops::to_wire_preview;
 
 /// `POST /api/v1/report-bug` — file or preview a bug report via HTTP.
 ///
@@ -1925,115 +1854,11 @@ fn to_wire_preview(p: &super::bug_report::IssuePreview) -> BugReportPreview {
     )
 )]
 pub async fn report_bug_http(
-    State(_state): State<Arc<DaemonState>>,
+    State(state): State<Arc<DaemonState>>,
     Json(body): Json<ReportBugApiRequest>,
 ) -> Json<ReportBugHttpResponse> {
-    // Load errors and find the requested fingerprint.
-    let errors = super::bug_report::aggregate_errors(500);
-    let found = errors
-        .into_iter()
-        .find(|e| e.record.fingerprint == body.fingerprint);
-
-    let Some(agg) = found else {
-        return Json(ReportBugHttpResponse {
-            filed: false,
-            deduped: None,
-            issue_url: None,
-            issue_number: None,
-            note: Some(format!(
-                "fingerprint `{}` not found in local error stores; \
-                 run GET /api/v1/errors to see available fingerprints",
-                body.fingerprint
-            )),
-            preview: None,
-            rate_limited: None,
-        });
-    };
-
-    let preview = super::bug_report::build_preview(&agg);
-
-    // Fix 2 (P1): include scrubbed preview in confirm:false response.
-    if !body.confirm {
-        return Json(ReportBugHttpResponse {
-            filed: false,
-            deduped: None,
-            issue_url: None,
-            issue_number: None,
-            note: Some("confirm:false — preview only. POST with confirm:true to file.".to_string()),
-            preview: Some(to_wire_preview(&preview)),
-            rate_limited: None,
-        });
-    }
-
-    // Fix 3 (P2): check the rate-limit guard before calling GitHub.
-    let guard = super::bug_report::RateLimitGuard::production();
-    let now_secs = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs() as i64)
-        .unwrap_or(0);
-    let rl_decision = guard.check(&body.fingerprint, now_secs);
-    if !rl_decision.is_allowed() {
-        return Json(ReportBugHttpResponse {
-            filed: false,
-            deduped: None,
-            issue_url: None,
-            issue_number: None,
-            note: Some(rl_decision.block_reason()),
-            preview: None,
-            rate_limited: Some(true),
-        });
-    }
-
-    // Fix 1 (P0): use the full resolution chain — PAT → file → GitHub App → NoToken.
-    let fingerprint = body.fingerprint.clone();
-    let provider = super::bug_report::ResolvedProvider;
-    let result =
-        tokio::task::spawn_blocking(move || super::bug_report::file_issue(&preview, &provider))
-            .await;
-
-    match result {
-        Ok(Ok(filing)) => {
-            // Fix 3 (P2): record the successful filing in the rate-limit store.
-            // State-file failures are non-fatal — log and allow.
-            guard.record_filed(&fingerprint, now_secs);
-            Json(ReportBugHttpResponse {
-                filed: true,
-                deduped: Some(filing.deduped),
-                issue_url: Some(filing.issue_url),
-                issue_number: Some(filing.issue_number),
-                note: None,
-                preview: None,
-                rate_limited: None,
-            })
-        }
-        Ok(Err(super::bug_report::GithubFilingError::NoToken)) => Json(ReportBugHttpResponse {
-            filed: false,
-            deduped: None,
-            issue_url: None,
-            issue_number: None,
-            note: Some(super::bug_report::GithubFilingError::NoToken.to_string()),
-            preview: None,
-            rate_limited: None,
-        }),
-        Ok(Err(e)) => Json(ReportBugHttpResponse {
-            filed: false,
-            deduped: None,
-            issue_url: None,
-            issue_number: None,
-            note: Some(format!("GitHub filing failed: {e}")),
-            preview: None,
-            rate_limited: None,
-        }),
-        Err(e) => Json(ReportBugHttpResponse {
-            filed: false,
-            deduped: None,
-            issue_url: None,
-            issue_number: None,
-            note: Some(format!("internal error: {e}")),
-            preview: None,
-            rate_limited: None,
-        }),
-    }
+    // #6288: the body is shared with `mpm.report_bug` over the Unix socket.
+    Json(core_ops::report_bug(&state, body).await)
 }
 
 /// Parse a UUID string into a `SessionId`, mapping failure to a `400`-mapped

--- a/crates/trusty-mpm/src/daemon/api/claude_config_routes.rs
+++ b/crates/trusty-mpm/src/daemon/api/claude_config_routes.rs
@@ -25,6 +25,7 @@ use crate::daemon::api::types::{
     DeleteCheckpointResponse, DeployProfileResponse, ProfilesResponse, RestartResponse,
     RestoreResponse,
 };
+use crate::daemon::error::DaemonError;
 use crate::daemon::state::DaemonState;
 use crate::session_manager::record::{ManagedSessionState, SessionRecord};
 
@@ -56,17 +57,29 @@ pub struct ClaudeConfigQuery {
     responses((status = 200, description = "Analyzed config plus recommendations"))
 )]
 pub async fn get_claude_config(
-    State(_state): State<Arc<DaemonState>>,
+    State(state): State<Arc<DaemonState>>,
     Query(query): Query<ClaudeConfigQuery>,
 ) -> Json<ClaudeConfigResponse> {
+    Json(get_claude_config_op(&state, query))
+}
+
+/// Transport-neutral body of `GET /claude-config` and `mpm.claude_config.get`
+/// (#6288).
+///
+/// Test: `get_claude_config_returns_recommendations`,
+/// `parity_claude_config_get_agrees_across_transports`.
+pub fn get_claude_config_op(
+    _state: &Arc<DaemonState>,
+    query: ClaudeConfigQuery,
+) -> ClaudeConfigResponse {
     use crate::core::claude_config::ClaudeConfigReader;
     let paths = ClaudeConfigReader::paths_for_project(&query.project);
     let config = crate::daemon::claude_config::ClaudeConfigAnalyzer::read_config(&paths);
     let recommendations = crate::daemon::claude_config::ClaudeConfigAnalyzer::analyze(&config);
-    Json(ClaudeConfigResponse {
+    ClaudeConfigResponse {
         config,
         recommendations,
-    })
+    }
 }
 
 /// JSON body for `POST /claude-config/apply`.
@@ -103,9 +116,28 @@ pub struct ApplyConfigRequest {
     )
 )]
 pub async fn apply_claude_config(
-    State(_state): State<Arc<DaemonState>>,
+    State(state): State<Arc<DaemonState>>,
     Json(body): Json<ApplyConfigRequest>,
 ) -> Result<Json<ApplyConfigResponse>, StatusCode> {
+    apply_claude_config_op(&state, body)
+        .map(Json)
+        .map_err(|e| e.status())
+}
+
+/// Transport-neutral body of `POST /claude-config/apply` and
+/// `mpm.claude_config.apply` (#6288).
+///
+/// # Errors
+///
+/// [`DaemonError::NotFound`] when no recommendation carries that id (HTTP 404),
+/// [`DaemonError::Internal`] when applying it fails (HTTP 500).
+///
+/// Test: `apply_claude_config_unknown_rec_is_404`,
+/// `rpc_claude_config_apply_unknown_recommendation_reports_not_found`.
+pub fn apply_claude_config_op(
+    _state: &Arc<DaemonState>,
+    body: ApplyConfigRequest,
+) -> Result<ApplyConfigResponse, DaemonError> {
     use crate::core::claude_config::ClaudeConfigReader;
     let paths = ClaudeConfigReader::paths_for_project(&body.project);
     let config = crate::daemon::claude_config::ClaudeConfigAnalyzer::read_config(&paths);
@@ -113,7 +145,9 @@ pub async fn apply_claude_config(
     let rec = recommendations
         .iter()
         .find(|r| r.id == body.recommendation_id)
-        .ok_or(StatusCode::NOT_FOUND)?;
+        .ok_or_else(|| {
+            DaemonError::NotFound(format!("recommendation `{}`", body.recommendation_id))
+        })?;
     let checkpoint_id = crate::daemon::claude_config::ClaudeConfigAnalyzer::apply_recommendation(
         rec,
         &paths,
@@ -121,13 +155,13 @@ pub async fn apply_claude_config(
     )
     .map_err(|e| {
         tracing::warn!("applying recommendation {} failed: {e}", rec.id);
-        StatusCode::INTERNAL_SERVER_ERROR
+        DaemonError::Internal(format!("applying recommendation {} failed: {e}", rec.id))
     })?;
-    Ok(Json(ApplyConfigResponse {
+    Ok(ApplyConfigResponse {
         applied: true,
         recommendation_id: body.recommendation_id,
         checkpoint_id,
-    }))
+    })
 }
 
 // ---- checkpoints & deployment profiles ----------------------------------
@@ -157,15 +191,27 @@ pub struct CheckpointQuery {
     responses((status = 200, description = "Config checkpoints, newest first"))
 )]
 pub async fn list_checkpoints(
-    State(_state): State<Arc<DaemonState>>,
+    State(state): State<Arc<DaemonState>>,
     Query(query): Query<CheckpointQuery>,
 ) -> Json<CheckpointsResponse> {
+    Json(list_checkpoints_op(&state, query))
+}
+
+/// Transport-neutral body of `GET /claude-config/checkpoints` and
+/// `mpm.claude_config.checkpoints.list` (#6288).
+///
+/// Test: `list_checkpoints_returns_array`,
+/// `parity_claude_config_checkpoints_agrees_across_transports`.
+pub fn list_checkpoints_op(
+    _state: &Arc<DaemonState>,
+    query: CheckpointQuery,
+) -> CheckpointsResponse {
     let checkpoints = crate::daemon::claude_config::ConfigCheckpointer::list(&query.project)
         .unwrap_or_else(|e| {
             tracing::warn!("listing checkpoints failed: {e}");
             Vec::new()
         });
-    Json(CheckpointsResponse { checkpoints })
+    CheckpointsResponse { checkpoints }
 }
 
 /// JSON body for `POST /claude-config/checkpoints`.
@@ -199,9 +245,26 @@ pub struct CreateCheckpointRequest {
     )
 )]
 pub async fn create_checkpoint(
-    State(_state): State<Arc<DaemonState>>,
+    State(state): State<Arc<DaemonState>>,
     Json(body): Json<CreateCheckpointRequest>,
 ) -> Result<Json<CreateCheckpointResponse>, StatusCode> {
+    create_checkpoint_op(&state, body)
+        .map(Json)
+        .map_err(|e| e.status())
+}
+
+/// Transport-neutral body of `POST /claude-config/checkpoints` and
+/// `mpm.claude_config.checkpoints.create` (#6288).
+///
+/// # Errors
+///
+/// [`DaemonError::Internal`] when the snapshot cannot be written (HTTP 500).
+///
+/// Test: `create_checkpoint_returns_id`.
+pub fn create_checkpoint_op(
+    _state: &Arc<DaemonState>,
+    body: CreateCheckpointRequest,
+) -> Result<CreateCheckpointResponse, DaemonError> {
     use crate::core::claude_config::ClaudeConfigReader;
     let paths = ClaudeConfigReader::paths_for_project(&body.project);
     let id = crate::daemon::claude_config::ConfigCheckpointer::create(
@@ -211,9 +274,9 @@ pub async fn create_checkpoint(
     )
     .map_err(|e| {
         tracing::warn!("creating checkpoint failed: {e}");
-        StatusCode::INTERNAL_SERVER_ERROR
+        DaemonError::Internal(format!("creating checkpoint failed: {e}"))
     })?;
-    Ok(Json(CreateCheckpointResponse { id }))
+    Ok(CreateCheckpointResponse { id })
 }
 
 /// JSON body for `POST /claude-config/restore`.
@@ -247,18 +310,39 @@ pub struct RestoreRequest {
     )
 )]
 pub async fn restore_checkpoint(
-    State(_state): State<Arc<DaemonState>>,
+    State(state): State<Arc<DaemonState>>,
     Json(body): Json<RestoreRequest>,
 ) -> Result<Json<RestoreResponse>, StatusCode> {
+    restore_checkpoint_op(&state, body)
+        .map(Json)
+        .map_err(|e| e.status())
+}
+
+/// Transport-neutral body of `POST /claude-config/restore` and
+/// `mpm.claude_config.restore` (#6288).
+///
+/// # Errors
+///
+/// [`DaemonError::Internal`] when the checkpoint is missing or the rewrite
+/// fails — HTTP 500, the status this route has always answered for both.
+///
+/// Test: `restore_unknown_checkpoint_is_500`.
+pub fn restore_checkpoint_op(
+    _state: &Arc<DaemonState>,
+    body: RestoreRequest,
+) -> Result<RestoreResponse, DaemonError> {
     crate::daemon::claude_config::ConfigCheckpointer::restore(&body.project, &body.checkpoint_id)
         .map_err(|e| {
         tracing::warn!("restoring checkpoint {} failed: {e}", body.checkpoint_id);
-        StatusCode::INTERNAL_SERVER_ERROR
+        DaemonError::Internal(format!(
+            "restoring checkpoint {} failed: {e}",
+            body.checkpoint_id
+        ))
     })?;
-    Ok(Json(RestoreResponse {
+    Ok(RestoreResponse {
         restored: true,
         checkpoint_id: body.checkpoint_id,
-    }))
+    })
 }
 
 /// `DELETE /claude-config/checkpoints/{id}?project=<path>` — delete a checkpoint.
@@ -280,15 +364,57 @@ pub async fn restore_checkpoint(
     )
 )]
 pub async fn delete_checkpoint(
-    State(_state): State<Arc<DaemonState>>,
+    State(state): State<Arc<DaemonState>>,
     Path(id): Path<String>,
     Query(query): Query<CheckpointQuery>,
 ) -> Result<Json<DeleteCheckpointResponse>, StatusCode> {
-    crate::daemon::claude_config::ConfigCheckpointer::delete(&query.project, &id).map_err(|e| {
-        tracing::warn!("deleting checkpoint {id} failed: {e}");
-        StatusCode::NOT_FOUND
-    })?;
-    Ok(Json(DeleteCheckpointResponse { deleted: id }))
+    delete_checkpoint_op(
+        &state,
+        DeleteCheckpointParams {
+            project: query.project,
+            id,
+        },
+    )
+    .map(Json)
+    .map_err(|e| e.status())
+}
+
+/// The two arguments `DELETE /claude-config/checkpoints/{id}` splits across a
+/// path segment and a query string, carried as one decoded value (#6288).
+///
+/// Why a struct rather than two parameters: the socket carries one `params`
+/// object per call, so the RPC method needs a single type to decode into, and
+/// giving the shared body that shape keeps one signature for both transports.
+#[derive(serde::Deserialize)]
+pub struct DeleteCheckpointParams {
+    /// Project directory whose checkpoint is being deleted.
+    pub project: PathBuf,
+    /// Id of the checkpoint to delete.
+    pub id: String,
+}
+
+/// Transport-neutral body of `DELETE /claude-config/checkpoints/{id}` and
+/// `mpm.claude_config.checkpoints.delete` (#6288).
+///
+/// # Errors
+///
+/// [`DaemonError::CheckpointNotFound`] when the checkpoint cannot be removed —
+/// HTTP 404, the status this route has always answered for every failure here.
+///
+/// Test: `delete_unknown_checkpoint_is_404`.
+pub fn delete_checkpoint_op(
+    _state: &Arc<DaemonState>,
+    params: DeleteCheckpointParams,
+) -> Result<DeleteCheckpointResponse, DaemonError> {
+    crate::daemon::claude_config::ConfigCheckpointer::delete(&params.project, &params.id).map_err(
+        |e| {
+            tracing::warn!("deleting checkpoint {} failed: {e}", params.id);
+            DaemonError::CheckpointNotFound {
+                id: params.id.clone(),
+            }
+        },
+    )?;
+    Ok(DeleteCheckpointResponse { deleted: params.id })
 }
 
 /// `GET /claude-config/profiles` — list the built-in deployment profiles.
@@ -302,9 +428,18 @@ pub async fn delete_checkpoint(
     tag = "claude-config",
     responses((status = 200, description = "Built-in deployment profiles"))
 )]
-pub async fn list_profiles(State(_state): State<Arc<DaemonState>>) -> Json<ProfilesResponse> {
+pub async fn list_profiles(State(state): State<Arc<DaemonState>>) -> Json<ProfilesResponse> {
+    Json(list_profiles_op(&state))
+}
+
+/// Transport-neutral body of `GET /claude-config/profiles` and
+/// `mpm.claude_config.profiles` (#6288).
+///
+/// Test: `list_profiles_returns_builtins`,
+/// `parity_claude_config_profiles_agrees_across_transports`.
+pub fn list_profiles_op(_state: &Arc<DaemonState>) -> ProfilesResponse {
     let profiles = crate::daemon::claude_config::ProfileDeployer::builtin_profiles();
-    Json(ProfilesResponse { profiles })
+    ProfilesResponse { profiles }
 }
 
 /// JSON body for `POST /claude-config/deploy`.
@@ -346,14 +481,33 @@ pub struct DeployProfileRequest {
     )
 )]
 pub async fn deploy_profile(
-    State(_state): State<Arc<DaemonState>>,
+    State(state): State<Arc<DaemonState>>,
     Json(body): Json<DeployProfileRequest>,
 ) -> Result<Json<DeployProfileResponse>, StatusCode> {
+    deploy_profile_op(&state, body)
+        .map(Json)
+        .map_err(|e| e.status())
+}
+
+/// Transport-neutral body of `POST /claude-config/deploy` and
+/// `mpm.claude_config.deploy` (#6288).
+///
+/// # Errors
+///
+/// [`DaemonError::NotFound`] when no built-in profile carries that name (HTTP
+/// 404), [`DaemonError::Internal`] when the deploy fails (HTTP 500).
+///
+/// Test: `deploy_profile_returns_checkpoint_id`, `deploy_unknown_profile_is_404`,
+/// `rpc_claude_config_deploy_unknown_profile_reports_not_found`.
+pub fn deploy_profile_op(
+    _state: &Arc<DaemonState>,
+    body: DeployProfileRequest,
+) -> Result<DeployProfileResponse, DaemonError> {
     use crate::core::claude_config::ClaudeConfigReader;
     let mut profile = crate::daemon::claude_config::ProfileDeployer::builtin_profiles()
         .into_iter()
         .find(|p| p.name == body.profile_name)
-        .ok_or(StatusCode::NOT_FOUND)?;
+        .ok_or_else(|| DaemonError::NotFound(format!("profile `{}`", body.profile_name)))?;
     if let Some(target) = body.target {
         profile.target = target;
     }
@@ -362,12 +516,15 @@ pub async fn deploy_profile(
         crate::daemon::claude_config::ProfileDeployer::deploy(&profile, &paths, &body.project)
             .map_err(|e| {
                 tracing::warn!("deploying profile {} failed: {e}", body.profile_name);
-                StatusCode::INTERNAL_SERVER_ERROR
+                DaemonError::Internal(format!(
+                    "deploying profile {} failed: {e}",
+                    body.profile_name
+                ))
             })?;
-    Ok(Json(DeployProfileResponse {
+    Ok(DeployProfileResponse {
         deployed: body.profile_name,
         checkpoint_id,
-    }))
+    })
 }
 
 /// JSON body for `POST /claude-config/restart`.
@@ -445,6 +602,25 @@ pub async fn restart_claude_code(
     State(state): State<Arc<DaemonState>>,
     Json(body): Json<RestartRequest>,
 ) -> Result<Json<RestartResponse>, StatusCode> {
+    restart_claude_code_op(&state, body)
+        .await
+        .map(Json)
+        .map_err(|e| e.status())
+}
+
+/// Transport-neutral body of `POST /claude-config/restart` and
+/// `mpm.claude_config.restart` (#6288).
+///
+/// # Errors
+///
+/// [`DaemonError::Internal`] when tmux is absent or the recorded pane is
+/// confirmed gone (HTTP 500).
+///
+/// Test: `restart_claude_code_handles_missing_tmux`.
+pub async fn restart_claude_code_op(
+    state: &Arc<DaemonState>,
+    body: RestartRequest,
+) -> Result<RestartResponse, DaemonError> {
     let records = state.session_manager().await.list().await;
     let pane_id = select_restart_pane_id(&records, &body.tmux_session);
     crate::daemon::claude_config::ClaudeCodeRestarter::restart_in_session(
@@ -453,11 +629,11 @@ pub async fn restart_claude_code(
     )
     .map_err(|e| {
         tracing::warn!("restart in {} failed: {e}", body.tmux_session);
-        StatusCode::INTERNAL_SERVER_ERROR
+        DaemonError::Internal(format!("restart in {} failed: {e}", body.tmux_session))
     })?;
-    Ok(Json(RestartResponse {
+    Ok(RestartResponse {
         restarted: body.tmux_session,
-    }))
+    })
 }
 
 #[cfg(test)]

--- a/crates/trusty-mpm/src/daemon/error.rs
+++ b/crates/trusty-mpm/src/daemon/error.rs
@@ -275,8 +275,8 @@ impl IntoResponse for DaemonError {
 /// crosses verbatim — it is the same string the HTTP body's `error` field
 /// carries, which is what makes a parity assertion meaningful.
 /// Test: `rpc_error_codes_track_http_statuses`;
-/// `rpc_tmux_snapshot_unknown_session_reports_not_found` drives one arm through
-/// a real failure.
+/// `rpc_tmux_snapshot_unknown_session_reports_a_coded_error` drives one arm
+/// through a real failure.
 impl From<DaemonError> for RpcError {
     fn from(e: DaemonError) -> Self {
         let code = match e.status() {

--- a/crates/trusty-mpm/src/daemon/error.rs
+++ b/crates/trusty-mpm/src/daemon/error.rs
@@ -8,14 +8,49 @@
 //! `IntoResponse` impl maps each variant to the right HTTP status. Business
 //! logic stays HTTP-agnostic; the transport mapping lives in one place.
 //! What: [`DaemonError`] enumerates every way a daemon request can fail, with a
-//! `thiserror`-derived `Display` and an `axum::IntoResponse` that picks the
-//! status code and renders a `{ "error": <message> }` body.
-//! Test: `error_status_codes_map` asserts the variant → status mapping.
+//! `thiserror`-derived `Display`, an `axum::IntoResponse` that picks the status
+//! code and renders a `{ "error": <message> }` body, and — since #6288 — a
+//! `From<DaemonError> for RpcError` that picks the JSON-RPC error code for the
+//! same failure on the Unix socket. Both transports read the SAME variant, so a
+//! route served over HTTP and over the socket cannot disagree about what went
+//! wrong.
+//! Test: `error_status_codes_map` asserts the variant → status mapping;
+//! `rpc_error_codes_track_http_statuses` asserts the variant → code mapping.
 
 use axum::Json;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use thiserror::Error;
+use trusty_common::uds::server::{CODE_INTERNAL_ERROR, CODE_INVALID_PARAMS, RpcError};
+
+// ---- JSON-RPC error codes for the daemon's non-standard failure kinds -------
+//
+// Why these are declared here rather than in `trusty_common::uds::server::wire`:
+// that module owns the codes JSON-RPC itself reserves (-32700..-32600) plus the
+// two streaming codes #6286 added. Everything below is a DOMAIN failure kind
+// with no JSON-RPC counterpart, so it lives beside the enum it describes.
+//
+// The numbers are not arbitrary. -32004 and -32005 are already spent by
+// `trusty-analyze` (`service::events::CODE_NOT_FOUND`, `CODE_DEADLINE_EXCEEDED`)
+// and -32010/-32011 by `trusty-common`'s streaming pair, so #6288 takes free
+// slots around them and reuses -32004 for the SAME meaning — a later
+// consolidation into `trusty-common` is then a move, not a renumbering.
+// Test: `rpc_error_codes_track_http_statuses`.
+
+/// HTTP 404 over the socket — the same code `trusty-analyze` uses.
+pub const CODE_NOT_FOUND: i64 = -32004;
+
+/// HTTP 503 over the socket: a capability this daemon is not configured for.
+pub const CODE_UNAVAILABLE: i64 = -32002;
+
+/// HTTP 403 over the socket: a guard rejected the request.
+pub const CODE_FORBIDDEN: i64 = -32003;
+
+/// HTTP 422 over the socket: well-formed but un-fulfillable.
+pub const CODE_UNPROCESSABLE: i64 = -32006;
+
+/// HTTP 409 over the socket: the request conflicts with the record's state.
+pub const CODE_CONFLICT: i64 = -32009;
 
 /// A failure surfaced by a daemon domain service or request handler.
 ///
@@ -150,6 +185,20 @@ pub enum DaemonError {
     #[error("forbidden: {0}")]
     Forbidden(String),
 
+    /// A resource of a kind with no dedicated variant above was not found.
+    ///
+    /// Why (#6288): the `/claude-config/*` routes 404 on an unknown
+    /// recommendation id and an unknown profile name. Both used to be a bare
+    /// `StatusCode::NOT_FOUND` returned straight from the handler, which
+    /// carried no message. Sharing one body between HTTP and RPC means the
+    /// failure has to be a typed value, and neither resource is a session, a
+    /// checkpoint, a deliverable, or a milestone.
+    /// What: carries the operator-facing message; maps to HTTP 404 and to
+    /// [`CODE_NOT_FOUND`](crate::daemon::error::CODE_NOT_FOUND) on the socket.
+    /// Test: `error_status_codes_map`, `rpc_error_codes_track_http_statuses`.
+    #[error("not found: {0}")]
+    NotFound(String),
+
     /// The request is syntactically valid but semantically un-fulfillable.
     ///
     /// Why: a precondition the daemon cannot satisfy (e.g. `POST /sessions`
@@ -176,7 +225,8 @@ impl DaemonError {
             | Self::CheckpointNotFound { .. }
             | Self::DeliverableNotFound { .. }
             | Self::MilestoneNotFound { .. }
-            | Self::ProjectNotFoundForRepoUrl { .. } => StatusCode::NOT_FOUND,
+            | Self::ProjectNotFoundForRepoUrl { .. }
+            | Self::NotFound(_) => StatusCode::NOT_FOUND,
             Self::SessionNotActive { .. } | Self::InvalidTransition { .. } => StatusCode::CONFLICT,
             Self::OverseerBlocked { .. } | Self::Forbidden(_) => StatusCode::FORBIDDEN,
             Self::InvalidRequest(_) | Self::InvalidPairCode => StatusCode::BAD_REQUEST,
@@ -210,6 +260,37 @@ impl IntoResponse for DaemonError {
             _ => Json(serde_json::json!({ "error": self.to_string() })),
         };
         (status, body).into_response()
+    }
+}
+
+/// Map a daemon failure onto the JSON-RPC error frame a socket client reads.
+///
+/// Why (#6288): `RpcRouter::typed` takes `Result<Resp, RpcError>`, and every
+/// route this slice moves onto the socket already reports its failures as a
+/// [`DaemonError`]. Without this conversion each RPC registration would spell
+/// its own status-to-code table, and the HTTP status and the RPC code would be
+/// free to drift apart for the same variant.
+/// What: derives the code from [`DaemonError::status`], so the code is a pure
+/// function of the status the HTTP transport would have sent. The message
+/// crosses verbatim — it is the same string the HTTP body's `error` field
+/// carries, which is what makes a parity assertion meaningful.
+/// Test: `rpc_error_codes_track_http_statuses`;
+/// `rpc_tmux_snapshot_unknown_session_reports_not_found` drives one arm through
+/// a real failure.
+impl From<DaemonError> for RpcError {
+    fn from(e: DaemonError) -> Self {
+        let code = match e.status() {
+            StatusCode::BAD_REQUEST => CODE_INVALID_PARAMS,
+            StatusCode::NOT_FOUND => CODE_NOT_FOUND,
+            StatusCode::FORBIDDEN => CODE_FORBIDDEN,
+            StatusCode::CONFLICT => CODE_CONFLICT,
+            StatusCode::UNPROCESSABLE_ENTITY => CODE_UNPROCESSABLE,
+            StatusCode::SERVICE_UNAVAILABLE => CODE_UNAVAILABLE,
+            // Everything left maps to 500, and a caller could not have sent any
+            // of them differently.
+            _ => CODE_INTERNAL_ERROR,
+        };
+        RpcError::new(code, e.to_string())
     }
 }
 
@@ -297,6 +378,67 @@ mod tests {
             }
             .status(),
             StatusCode::CONFLICT
+        );
+    }
+
+    /// Why (#6288): the socket and HTTP must never disagree about what a failure
+    /// was. The conversion derives the code FROM the status, so this pins that
+    /// derivation — a variant whose status changes moves its RPC code with it,
+    /// and a variant silently falling into the catch-all `internal` arm shows up
+    /// here.
+    /// Test: this function IS the test.
+    #[test]
+    fn rpc_error_codes_track_http_statuses() {
+        let cases: Vec<(DaemonError, i64)> = vec![
+            (
+                DaemonError::SessionNotFound { id: "x".into() },
+                CODE_NOT_FOUND,
+            ),
+            (DaemonError::NotFound("x".into()), CODE_NOT_FOUND),
+            (
+                DaemonError::CheckpointNotFound { id: "x".into() },
+                CODE_NOT_FOUND,
+            ),
+            (DaemonError::InvalidRequest("x".into()), CODE_INVALID_PARAMS),
+            (DaemonError::Forbidden("x".into()), CODE_FORBIDDEN),
+            (
+                DaemonError::SessionNotActive {
+                    id: "x".into(),
+                    status: "stopped".into(),
+                },
+                CODE_CONFLICT,
+            ),
+            (DaemonError::Unprocessable("x".into()), CODE_UNPROCESSABLE),
+            (
+                DaemonError::ServiceUnavailable("x".into()),
+                CODE_UNAVAILABLE,
+            ),
+            (DaemonError::Internal("x".into()), CODE_INTERNAL_ERROR),
+            (
+                DaemonError::TmuxUnavailable("x".into()),
+                CODE_INTERNAL_ERROR,
+            ),
+        ];
+
+        for (err, expected) in cases {
+            let message = err.to_string();
+            let rpc: RpcError = err.into();
+            assert_eq!(rpc.code, expected, "wrong code for {message:?}");
+            assert_eq!(
+                rpc.message, message,
+                "the RPC message must be the HTTP body's message verbatim"
+            );
+        }
+    }
+
+    /// Why: the #6288 variant is new, so its 404 mapping needs its own
+    /// assertion rather than riding on the pre-existing table above.
+    /// Test: this function IS the test.
+    #[test]
+    fn not_found_variant_is_404() {
+        assert_eq!(
+            DaemonError::NotFound("profile `nope`".into()).status(),
+            StatusCode::NOT_FOUND
         );
     }
 

--- a/crates/trusty-mpm/src/daemon/mod.rs
+++ b/crates/trusty-mpm/src/daemon/mod.rs
@@ -45,6 +45,8 @@ pub mod overseer_compose;
 pub mod pairing_routes;
 pub mod pairing_store;
 pub mod provisioning;
+// #6288: the method families served on the Unix socket.
+pub mod rpc;
 pub mod runtime_reap;
 pub mod services;
 pub(crate) mod session_record_kind;
@@ -271,8 +273,11 @@ pub async fn serve_with_shutdown(
     });
 
     let rpc_drain = drain.clone();
+    // #6288 slice 2: the socket serves the SAME state the axum router was built
+    // with, so the two transports are two doors onto one daemon, not two.
+    let rpc_state = Arc::clone(&state);
     let rpc_task = tokio::spawn(async move {
-        socket::serve_until_shutdown(rpc, rpc_drain.cancelled_owned()).await;
+        socket::serve_until_shutdown(rpc, rpc_state, rpc_drain.cancelled_owned()).await;
     });
 
     let http_drain = drain.clone();

--- a/crates/trusty-mpm/src/daemon/rpc/core.rs
+++ b/crates/trusty-mpm/src/daemon/rpc/core.rs
@@ -1,0 +1,329 @@
+//! The core request/response routes, served as JSON-RPC methods (#6288 slice 2).
+//!
+//! Why: slice 1 bound a hardened Unix socket beside the daemon's HTTP listener
+//! and registered nothing on it. This slice puts the first twenty methods on it.
+//! HTTP is untouched and still serves every one of these routes — the socket is
+//! an ADDITIONAL way to reach the same body, not a replacement, until the retire
+//! slice deletes the axum surface.
+//!
+//! What: the name-to-route table below, `METHODS` as an assertable array of it,
+//! and [`register`], which mounts each name on the router `daemon::socket`
+//! builds. Every handler is a thin adapter over a function in
+//! [`super::core_ops`] or `daemon::api::claude_config_routes` — this file
+//! decides WHICH method exists and what it decodes, never what it does.
+//!
+//! ## Method → route
+//!
+//! | Method | HTTP route |
+//! |---|---|
+//! | `mpm.health` | `GET /health` |
+//! | `mpm.doctor` | `GET /api/v1/doctor` |
+//! | `mpm.errors.list` | `GET /api/v1/errors` |
+//! | `mpm.report_bug` | `POST /api/v1/report-bug` |
+//! | `mpm.breakers` | `GET /breakers` |
+//! | `mpm.optimizer` | `GET /optimizer` |
+//! | `mpm.overseer` | `GET /overseer` |
+//! | `mpm.llm.chat` | `POST /llm/chat` |
+//! | `mpm.tmux.sessions` | `GET /tmux/sessions` |
+//! | `mpm.tmux.snapshot` | `GET /tmux/sessions/{name}/snapshot` |
+//! | `mpm.tmux.adopt` | `POST /tmux/adopt` |
+//! | `mpm.claude_config.get` | `GET /claude-config` |
+//! | `mpm.claude_config.apply` | `POST /claude-config/apply` |
+//! | `mpm.claude_config.checkpoints.list` | `GET /claude-config/checkpoints` |
+//! | `mpm.claude_config.checkpoints.create` | `POST /claude-config/checkpoints` |
+//! | `mpm.claude_config.checkpoints.delete` | `DELETE /claude-config/checkpoints/{id}` |
+//! | `mpm.claude_config.restore` | `POST /claude-config/restore` |
+//! | `mpm.claude_config.profiles` | `GET /claude-config/profiles` |
+//! | `mpm.claude_config.deploy` | `POST /claude-config/deploy` |
+//! | `mpm.claude_config.restart` | `POST /claude-config/restart` |
+//!
+//! A route whose HTTP form splits its arguments across a path segment and a
+//! query string carries them as one `params` object here — `mpm.tmux.snapshot`
+//! takes `{"name": …}` and `mpm.claude_config.checkpoints.delete` takes
+//! `{"project": …, "id": …}`. Everything else decodes the same struct the axum
+//! extractor decodes, so a caller's payload is unchanged by the transport.
+//!
+//! ## What guards these methods
+//!
+//! Two of them cost something. `mpm.report_bug` files a GitHub issue when the
+//! caller sets `confirm: true`, and `mpm.llm.chat` spends OpenRouter credit. So
+//! the guards have to be at least as strong here as on HTTP, and they are:
+//!
+//! - **HTTP** layers `trusty_common::server::guard_write_origin` router-wide
+//!   (`daemon::mod`, via `api::origin_guard::guard_router`). It is a CSRF
+//!   defence: it inspects the `Origin` header and, per
+//!   `origin_guard::origin_allowed`, ALLOWS any request that carries none —
+//!   which is every server-side caller. It authenticates nobody.
+//! - **The socket** runs `ensure_peer_is_self` on every accepted connection
+//!   before a byte is read (`trusty_common::uds::server`), over a `0600` socket
+//!   in a `0700` directory. It authenticates the calling process's uid.
+//!
+//! Nothing is dropped by moving across. The origin guard has no counterpart to
+//! carry — there is no `Origin` header on a Unix socket and no browser that
+//! could send one — and the peer-uid check is the stronger of the two, since it
+//! refuses a caller the origin guard would have waved through. The `/rpc`
+//! loopback gate (`api::rpc::is_loopback`) guards a route this slice does not
+//! own and is untouched.
+//!
+//! Test: `core_tests.rs` — `rpc_*` for the wire behaviour, `parity_*` for the
+//! HTTP-versus-socket comparison.
+
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use trusty_common::uds::server::RpcRouter;
+
+use crate::daemon::api::claude_config_routes as cc;
+use crate::daemon::state::DaemonState;
+
+use super::core_ops;
+
+#[cfg(test)]
+#[path = "core_tests.rs"]
+mod tests;
+
+/// Every method this slice registers, in registration order.
+///
+/// Why: `tm doctor`'s daemon probe and the slice-7 client swap both dial these
+/// names by literal, from code with no compile-time link to this table. An
+/// array here is what a contract test can compare the router against, so a
+/// rename surfaces as a failing assertion rather than as a consumer that
+/// silently reports `method_not_found`.
+/// Test: `rpc_router_registers_every_documented_method`.
+pub const METHODS: &[&str] = &[
+    "mpm.health",
+    "mpm.doctor",
+    "mpm.errors.list",
+    "mpm.report_bug",
+    "mpm.breakers",
+    "mpm.optimizer",
+    "mpm.overseer",
+    "mpm.llm.chat",
+    "mpm.tmux.sessions",
+    "mpm.tmux.snapshot",
+    "mpm.tmux.adopt",
+    "mpm.claude_config.get",
+    "mpm.claude_config.apply",
+    "mpm.claude_config.checkpoints.list",
+    "mpm.claude_config.checkpoints.create",
+    "mpm.claude_config.checkpoints.delete",
+    "mpm.claude_config.restore",
+    "mpm.claude_config.profiles",
+    "mpm.claude_config.deploy",
+    "mpm.claude_config.restart",
+];
+
+/// The params of a method that takes no arguments.
+///
+/// Why: `RpcRouter::typed` decodes `params` into the handler's request type
+/// before the handler runs, and `params` is absent — `serde_json::Value::Null` —
+/// on a well-formed call to a no-argument method. A plain unit struct refuses
+/// `null`, so every `mpm.health` probe would answer `invalid_params`.
+/// What: accepts anything and keeps nothing. A caller that sends a stray field
+/// is not refused: these methods have no arguments to get wrong, and refusing
+/// would turn an additive client change into an outage.
+/// Test: `rpc_health_answers_with_no_params`,
+/// `rpc_health_answers_with_a_stray_params_object`.
+#[derive(Debug, Clone, Copy, Default, Serialize)]
+pub struct NoParams;
+
+impl<'de> Deserialize<'de> for NoParams {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        serde::de::IgnoredAny::deserialize(deserializer)?;
+        Ok(NoParams)
+    }
+}
+
+/// The one argument `GET /tmux/sessions/{name}/snapshot` carries in its path.
+///
+/// Why a struct: JSON-RPC carries one `params` value, so a bare string would
+/// give this method a shape none of its siblings has. Test:
+/// `rpc_tmux_snapshot_unknown_session_reports_a_coded_error`.
+#[derive(Debug, Deserialize)]
+pub struct TmuxSnapshotParams {
+    /// tmux session name to capture.
+    pub name: String,
+}
+
+/// Mount every method in [`METHODS`] onto `router`.
+///
+/// Why: the only trusty-mpm-specific half of the socket server. Hardening,
+/// framing, the envelope and the accept loop are all
+/// `trusty_common::uds::server`'s.
+/// What: one `typed` registration per method, each cloning the `Arc` handle to
+/// the shared [`DaemonState`] — the daemon's ONE state, the same value the axum
+/// router was built with, so the two transports read and write the same
+/// sessions, breakers, and manager rather than two copies of them.
+/// Every fallible body returns `DaemonError`, which crosses the wire through
+/// `From<DaemonError> for RpcError` (`daemon::error`) — the same seam that
+/// picks the HTTP status, so a failure cannot be one thing over HTTP and
+/// another over the socket.
+/// Test: `rpc_router_registers_every_documented_method`, and the `parity_*`
+/// cases drive each registration against its HTTP twin.
+pub fn register(router: RpcRouter, state: &Arc<DaemonState>) -> RpcRouter {
+    /// One method whose body cannot fail.
+    macro_rules! ok {
+        ($router:expr, $name:literal, $req:ty, $resp:ty, |$s:ident, $r:ident| $call:expr) => {{
+            let held = Arc::clone(state);
+            $router.typed::<$req, $resp, _, _>($name, move |$r| {
+                let $s = Arc::clone(&held);
+                async move { Ok($call) }
+            })
+        }};
+    }
+
+    /// One method whose body returns `Result<_, DaemonError>`.
+    macro_rules! fallible {
+        ($router:expr, $name:literal, $req:ty, $resp:ty, |$s:ident, $r:ident| $call:expr) => {{
+            let held = Arc::clone(state);
+            $router.typed::<$req, $resp, _, _>($name, move |$r| {
+                let $s = Arc::clone(&held);
+                async move { $call.map_err(Into::into) }
+            })
+        }};
+    }
+
+    use crate::daemon::api::types as t;
+    use crate::daemon::api::{AdoptRequest, DoctorQuery, ErrorsQuery, ReportBugApiRequest};
+
+    let r = router;
+
+    // ---- health / doctor / errors / report-bug ------------------------------
+    let r = ok!(r, "mpm.health", NoParams, t::HealthResponse, |s, _p| {
+        core_ops::health(&s).await
+    });
+    let r = ok!(
+        r,
+        "mpm.doctor",
+        DoctorQuery,
+        crate::core::doctor::DoctorReport,
+        |s, p| core_ops::doctor(&s, p).await
+    );
+    let r = ok!(
+        r,
+        "mpm.errors.list",
+        ErrorsQuery,
+        t::ErrorsResponse,
+        |s, p| core_ops::list_errors(&s, p)
+    );
+    let r = ok!(
+        r,
+        "mpm.report_bug",
+        ReportBugApiRequest,
+        t::ReportBugHttpResponse,
+        |s, p| core_ops::report_bug(&s, p).await
+    );
+
+    // ---- breakers / optimizer / overseer / llm-chat -------------------------
+    let r = ok!(r, "mpm.breakers", NoParams, t::BreakersResponse, |s, _p| {
+        core_ops::breakers(&s)
+    });
+    let r = ok!(
+        r,
+        "mpm.optimizer",
+        NoParams,
+        t::OptimizerResponse,
+        |s, _p| core_ops::optimizer(&s)
+    );
+    let r = ok!(r, "mpm.overseer", NoParams, t::OverseerResponse, |s, _p| {
+        core_ops::overseer(&s)
+    });
+    let r = fallible!(
+        r,
+        "mpm.llm.chat",
+        t::LlmChatRequest,
+        t::LlmChatResponse,
+        |s, p| core_ops::llm_chat(&s, p).await
+    );
+
+    // ---- tmux ---------------------------------------------------------------
+    let r = ok!(
+        r,
+        "mpm.tmux.sessions",
+        NoParams,
+        t::TmuxSessionsResponse,
+        |s, _p| core_ops::list_tmux_sessions(&s)
+    );
+    let r = fallible!(
+        r,
+        "mpm.tmux.snapshot",
+        TmuxSnapshotParams,
+        t::TmuxSnapshotResponse,
+        |s, p| core_ops::tmux_snapshot(&s, &p.name)
+    );
+    let r = fallible!(
+        r,
+        "mpm.tmux.adopt",
+        AdoptRequest,
+        t::AdoptResponse,
+        |s, p| core_ops::adopt_tmux(&s, p)
+    );
+
+    // ---- claude-config ------------------------------------------------------
+    let r = ok!(
+        r,
+        "mpm.claude_config.get",
+        cc::ClaudeConfigQuery,
+        t::ClaudeConfigResponse,
+        |s, p| cc::get_claude_config_op(&s, p)
+    );
+    let r = fallible!(
+        r,
+        "mpm.claude_config.apply",
+        cc::ApplyConfigRequest,
+        t::ApplyConfigResponse,
+        |s, p| cc::apply_claude_config_op(&s, p)
+    );
+    let r = ok!(
+        r,
+        "mpm.claude_config.checkpoints.list",
+        cc::CheckpointQuery,
+        t::CheckpointsResponse,
+        |s, p| cc::list_checkpoints_op(&s, p)
+    );
+    let r = fallible!(
+        r,
+        "mpm.claude_config.checkpoints.create",
+        cc::CreateCheckpointRequest,
+        t::CreateCheckpointResponse,
+        |s, p| cc::create_checkpoint_op(&s, p)
+    );
+    let r = fallible!(
+        r,
+        "mpm.claude_config.checkpoints.delete",
+        cc::DeleteCheckpointParams,
+        t::DeleteCheckpointResponse,
+        |s, p| cc::delete_checkpoint_op(&s, p)
+    );
+    let r = fallible!(
+        r,
+        "mpm.claude_config.restore",
+        cc::RestoreRequest,
+        t::RestoreResponse,
+        |s, p| cc::restore_checkpoint_op(&s, p)
+    );
+    let r = ok!(
+        r,
+        "mpm.claude_config.profiles",
+        NoParams,
+        t::ProfilesResponse,
+        |s, _p| cc::list_profiles_op(&s)
+    );
+    let r = fallible!(
+        r,
+        "mpm.claude_config.deploy",
+        cc::DeployProfileRequest,
+        t::DeployProfileResponse,
+        |s, p| cc::deploy_profile_op(&s, p)
+    );
+    fallible!(
+        r,
+        "mpm.claude_config.restart",
+        cc::RestartRequest,
+        t::RestartResponse,
+        |s, p| cc::restart_claude_code_op(&s, p).await
+    )
+}

--- a/crates/trusty-mpm/src/daemon/rpc/core_ops.rs
+++ b/crates/trusty-mpm/src/daemon/rpc/core_ops.rs
@@ -20,8 +20,15 @@
 //! headroom, and eleven extra wrappers would have pushed it over. The split
 //! ships in the PR that forces it, per the SLOC-cap rule.
 //!
-//! Test: `super::core_tests` — the `rpc_*` and `parity_*` cases drive these
-//! through BOTH transports and compare the answers.
+//! Test: `parity_health_agrees_across_transports`,
+//! `parity_doctor_agrees_across_transports`,
+//! `parity_errors_agrees_across_transports`,
+//! `parity_report_bug_preview_agrees_across_transports`,
+//! `parity_breakers_agrees_across_transports`,
+//! `parity_optimizer_agrees_across_transports`,
+//! `parity_overseer_agrees_across_transports`,
+//! `parity_tmux_sessions_agrees_across_transports` — each drives one of these
+//! through BOTH transports and compares the answers.
 
 use std::sync::Arc;
 

--- a/crates/trusty-mpm/src/daemon/rpc/core_ops.rs
+++ b/crates/trusty-mpm/src/daemon/rpc/core_ops.rs
@@ -1,0 +1,359 @@
+//! Transport-neutral bodies for the daemon's core request/response routes.
+//!
+//! Why (#6288 slice 2): every route in the health/doctor/errors/report-bug,
+//! breakers/optimizer/overseer/llm-chat and tmux families is now reachable two
+//! ways — `daemon::api`'s axum handler and [`super::core`]'s JSON-RPC method.
+//! Two transports over one route must not become two implementations of it: the
+//! moment a fix lands in one copy and not the other, a caller's answer depends
+//! on which socket it happened to dial. So the body lives here exactly once and
+//! both transports call in.
+//!
+//! What: one function per route, taking `&Arc<DaemonState>` plus the route's own
+//! decoded arguments and returning the response type the HTTP handler used to
+//! build. Nothing here names an HTTP type — no `Json`, no `StatusCode`, no
+//! extractor — and nothing names a JSON-RPC type either. Failures are
+//! [`DaemonError`], which both transports already know how to render
+//! (`IntoResponse` for HTTP, `From<DaemonError> for RpcError` for the socket).
+//!
+//! Why these bodies MOVED rather than staying in `api.rs` behind a sibling
+//! wrapper: `api.rs` sits on a frozen 1176-SLOC ratchet budget with 15 lines of
+//! headroom, and eleven extra wrappers would have pushed it over. The split
+//! ships in the PR that forces it, per the SLOC-cap rule.
+//!
+//! Test: `super::core_tests` — the `rpc_*` and `parity_*` cases drive these
+//! through BOTH transports and compare the answers.
+
+use std::sync::Arc;
+
+use crate::daemon::api::types::{
+    AdoptResponse, BreakerEntry, BreakersResponse, BugReportPreview, ErrorSummary, ErrorsResponse,
+    HealthResponse, LlmChatRequest, LlmChatResponse, OptimizerResponse, OverseerResponse,
+    OverseerStatus, ReportBugHttpResponse, ScrubChangeSummary, TmuxSessionsResponse,
+    TmuxSnapshotResponse,
+};
+use crate::daemon::api::{AdoptRequest, DoctorQuery, ErrorsQuery, ReportBugApiRequest};
+use crate::daemon::bug_report;
+use crate::daemon::error::DaemonError;
+use crate::daemon::services::TmuxService;
+use crate::daemon::state::DaemonState;
+
+/// Liveness plus the HR-3 catalog-staleness signal (`GET /health`, `mpm.health`).
+///
+/// Test: `health_reports_ok_status`, `parity_health_agrees_across_transports`.
+pub async fn health(state: &Arc<DaemonState>) -> HealthResponse {
+    let fw = crate::core::paths::FrameworkPaths::from_root(state.framework_root());
+    // The daemon-wide baseline uses the framework root as the "project" so only
+    // the user/catalog/default manifest layers apply (no per-project override).
+    let report = crate::core::update_check::detect_for_framework(&fw, state.framework_root());
+    HealthResponse {
+        status: "ok".to_owned(),
+        catalog_stale: report.stale,
+        catalog_unknown: report.unknown,
+        catalog_changes: report.summary_lines(),
+        supervised: state.supervised(),
+        // #4469: the three-state answer the bool above collapses. Published so
+        // `tm doctor` can distinguish "launchd says no" from "could not ask".
+        launchd_supervision: state.launchd_supervision(),
+        version: env!("CARGO_PKG_VERSION").to_owned(),
+        // #4230: identify WHICH process answered, so `tm doctor` can compare it
+        // against the PID launchd owns instead of trusting `supervised` alone.
+        pid: std::process::id(),
+        unsupervised_forced: state.unsupervised_forced(),
+    }
+}
+
+/// The full stack diagnostic (`GET /api/v1/doctor`, `mpm.doctor`).
+///
+/// Test: `doctor_endpoint_returns_report`, `parity_doctor_agrees_across_transports`.
+pub async fn doctor(
+    state: &Arc<DaemonState>,
+    query: DoctorQuery,
+) -> crate::core::doctor::DoctorReport {
+    // #6336: the workspace paths, the managed root, and the reconciled worktree
+    // counts are all derived by `run_doctor_for_manager`, so this route and the
+    // daemonless `tm doctor` CLI cannot drift on how the fleet is read.
+    let mgr = state.session_manager().await;
+    crate::daemon::doctor::run_doctor_for_manager(&mgr, query.project.as_deref()).await
+}
+
+/// Recently captured errors from every daemon store (`GET /api/v1/errors`,
+/// `mpm.errors.list`).
+///
+/// Test: `list_errors_returns_array`, `parity_errors_agrees_across_transports`.
+pub fn list_errors(_state: &Arc<DaemonState>, query: ErrorsQuery) -> ErrorsResponse {
+    let limit = query.limit.unwrap_or(20).min(100) as usize;
+    let errors = bug_report::aggregate_errors(limit);
+    let summaries: Vec<ErrorSummary> = errors
+        .iter()
+        .map(|e| ErrorSummary {
+            fingerprint: e.record.fingerprint.clone(),
+            crate_target: e.record.crate_target.clone(),
+            crate_version: e.record.crate_version.clone(),
+            summary: e.record.summary(),
+            occurrences: e.occurrences,
+            timestamp_secs: e.record.timestamp_secs,
+        })
+        .collect();
+    let total = summaries.len();
+    ErrorsResponse {
+        errors: summaries,
+        total,
+        limit,
+    }
+}
+
+/// Build a [`BugReportPreview`] from a scrubbed [`bug_report::IssuePreview`].
+///
+/// Why: both the `confirm:false` path and the rate-limited path must return the
+///      same preview shape so callers can inspect before (or after a blocked)
+///      filing.
+/// Test: exercised transitively by `report_bug_no_confirm_includes_preview`.
+pub fn to_wire_preview(p: &bug_report::IssuePreview) -> BugReportPreview {
+    BugReportPreview {
+        title: p.title.clone(),
+        body: p.body.clone(),
+        labels: p.labels.clone(),
+        scrub_changes: p
+            .scrub_changes
+            .iter()
+            .map(|c| ScrubChangeSummary {
+                pattern: c.pattern.to_string(),
+                hint: c.hint.to_string(),
+            })
+            .collect(),
+    }
+}
+
+/// File or preview a bug report (`POST /api/v1/report-bug`, `mpm.report_bug`).
+///
+/// Why this never returns `Err`: filing is best-effort, and every failure mode —
+/// an unknown fingerprint, a missing token, a rate-limit block, a GitHub
+/// rejection — is reported IN the response so the caller learns which one it
+/// hit. The HTTP route is documented as always `200` for exactly that reason,
+/// and the socket method inherits it: `mpm.report_bug` answers with a RESULT
+/// frame whose `filed` is `false`, never a coded error frame.
+///
+/// The consent gate is `confirm`, and the transport does not change it: nothing
+/// is filed unless the caller sets it. [`super::core`]'s module doc records why
+/// the socket's peer-uid check is the stronger half of the guard pair here.
+///
+/// Test: `report_bug_no_confirm_includes_preview`,
+/// `report_bug_rate_limited_returns_not_filed`,
+/// `parity_report_bug_preview_agrees_across_transports`.
+pub async fn report_bug(
+    _state: &Arc<DaemonState>,
+    body: ReportBugApiRequest,
+) -> ReportBugHttpResponse {
+    // Load errors and find the requested fingerprint.
+    let errors = bug_report::aggregate_errors(500);
+    let found = errors
+        .into_iter()
+        .find(|e| e.record.fingerprint == body.fingerprint);
+
+    let Some(agg) = found else {
+        return ReportBugHttpResponse {
+            filed: false,
+            deduped: None,
+            issue_url: None,
+            issue_number: None,
+            note: Some(format!(
+                "fingerprint `{}` not found in local error stores; \
+                 run GET /api/v1/errors to see available fingerprints",
+                body.fingerprint
+            )),
+            preview: None,
+            rate_limited: None,
+        };
+    };
+
+    let preview = bug_report::build_preview(&agg);
+
+    // Fix 2 (P1): include scrubbed preview in confirm:false response.
+    if !body.confirm {
+        return ReportBugHttpResponse {
+            filed: false,
+            deduped: None,
+            issue_url: None,
+            issue_number: None,
+            note: Some("confirm:false — preview only. POST with confirm:true to file.".to_string()),
+            preview: Some(to_wire_preview(&preview)),
+            rate_limited: None,
+        };
+    }
+
+    // Fix 3 (P2): check the rate-limit guard before calling GitHub.
+    let guard = bug_report::RateLimitGuard::production();
+    let now_secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    let rl_decision = guard.check(&body.fingerprint, now_secs);
+    if !rl_decision.is_allowed() {
+        return ReportBugHttpResponse {
+            filed: false,
+            deduped: None,
+            issue_url: None,
+            issue_number: None,
+            note: Some(rl_decision.block_reason()),
+            preview: None,
+            rate_limited: Some(true),
+        };
+    }
+
+    // Fix 1 (P0): use the full resolution chain — PAT → file → GitHub App → NoToken.
+    let fingerprint = body.fingerprint.clone();
+    let provider = bug_report::ResolvedProvider;
+    let result =
+        tokio::task::spawn_blocking(move || bug_report::file_issue(&preview, &provider)).await;
+
+    match result {
+        Ok(Ok(filing)) => {
+            // Fix 3 (P2): record the successful filing in the rate-limit store.
+            // State-file failures are non-fatal — log and allow.
+            guard.record_filed(&fingerprint, now_secs);
+            ReportBugHttpResponse {
+                filed: true,
+                deduped: Some(filing.deduped),
+                issue_url: Some(filing.issue_url),
+                issue_number: Some(filing.issue_number),
+                note: None,
+                preview: None,
+                rate_limited: None,
+            }
+        }
+        Ok(Err(bug_report::GithubFilingError::NoToken)) => ReportBugHttpResponse {
+            filed: false,
+            deduped: None,
+            issue_url: None,
+            issue_number: None,
+            note: Some(bug_report::GithubFilingError::NoToken.to_string()),
+            preview: None,
+            rate_limited: None,
+        },
+        Ok(Err(e)) => ReportBugHttpResponse {
+            filed: false,
+            deduped: None,
+            issue_url: None,
+            issue_number: None,
+            note: Some(format!("GitHub filing failed: {e}")),
+            preview: None,
+            rate_limited: None,
+        },
+        Err(e) => ReportBugHttpResponse {
+            filed: false,
+            deduped: None,
+            issue_url: None,
+            issue_number: None,
+            note: Some(format!("internal error: {e}")),
+            preview: None,
+            rate_limited: None,
+        },
+    }
+}
+
+/// Every agent's circuit-breaker state (`GET /breakers`, `mpm.breakers`).
+///
+/// Test: `parity_breakers_agrees_across_transports`.
+pub fn breakers(state: &Arc<DaemonState>) -> BreakersResponse {
+    let breakers = state
+        .all_breakers()
+        .into_iter()
+        .map(|(agent, breaker)| BreakerEntry { agent, breaker })
+        .collect();
+    BreakersResponse { breakers }
+}
+
+/// The overseer's enabled flag and active handler (`GET /overseer`,
+/// `mpm.overseer`).
+///
+/// Test: `get_overseer_returns_status`, `parity_overseer_agrees_across_transports`.
+pub fn overseer(state: &Arc<DaemonState>) -> OverseerResponse {
+    OverseerResponse {
+        overseer: OverseerStatus {
+            enabled: state.overseer().is_enabled(),
+            handler: state.overseer_handler().to_string(),
+        },
+    }
+}
+
+/// The token-use optimizer configuration (`GET /optimizer`, `mpm.optimizer`).
+///
+/// Test: `parity_optimizer_agrees_across_transports`.
+pub fn optimizer(state: &Arc<DaemonState>) -> OptimizerResponse {
+    OptimizerResponse {
+        optimizer: state.optimizer_config(),
+        scope: crate::daemon::optimizer::OPTIMIZER_SCOPE_NOTE.to_string(),
+    }
+}
+
+/// One turn of the LLM chat assistant (`POST /llm/chat`, `mpm.llm.chat`).
+///
+/// # Errors
+///
+/// [`DaemonError::ServiceUnavailable`] when no LLM overseer is configured (HTTP
+/// 503 / `CODE_UNAVAILABLE` on the socket), or [`DaemonError::Internal`] when
+/// the provider call fails.
+///
+/// Test: `llm_chat_without_overseer_is_503`,
+/// `rpc_llm_chat_without_overseer_reports_unavailable`.
+pub async fn llm_chat(
+    state: &Arc<DaemonState>,
+    body: LlmChatRequest,
+) -> Result<LlmChatResponse, DaemonError> {
+    let overseer = state.llm_overseer().ok_or_else(|| {
+        DaemonError::ServiceUnavailable(
+            "LLM chat is not configured (no OpenRouter API key)".to_string(),
+        )
+    })?;
+    let mut history = body.history;
+    let reply = overseer
+        .chat(&mut history, &body.message)
+        .await
+        .map_err(|e| DaemonError::Internal(e.to_string()))?;
+    Ok(LlmChatResponse { reply, history })
+}
+
+/// Every tmux session with its origin label (`GET /tmux/sessions`,
+/// `mpm.tmux.sessions`).
+///
+/// Test: `list_tmux_sessions_returns_array`,
+/// `parity_tmux_sessions_agrees_across_transports`.
+pub fn list_tmux_sessions(_state: &Arc<DaemonState>) -> TmuxSessionsResponse {
+    TmuxSessionsResponse {
+        sessions: TmuxService::list_all(),
+    }
+}
+
+/// One session's last 100 pane lines (`GET /tmux/sessions/{name}/snapshot`,
+/// `mpm.tmux.snapshot`).
+///
+/// # Errors
+///
+/// [`DaemonError`] when the session is missing or tmux is unavailable.
+///
+/// Test: `tmux_snapshot_unknown_session_is_404`,
+/// `rpc_tmux_snapshot_unknown_session_reports_a_coded_error`.
+pub fn tmux_snapshot(
+    _state: &Arc<DaemonState>,
+    name: &str,
+) -> Result<TmuxSnapshotResponse, DaemonError> {
+    let snapshot = TmuxService::snapshot(name, 100)?;
+    Ok(TmuxSnapshotResponse { snapshot })
+}
+
+/// Bring an external tmux session under oversight (`POST /tmux/adopt`,
+/// `mpm.tmux.adopt`).
+///
+/// # Errors
+///
+/// [`DaemonError`] when the session is missing or tmux is unavailable.
+///
+/// Test: `adopt_tmux_session_handles_missing`,
+/// `parity_tmux_adopt_unknown_session_agrees_across_transports`.
+pub fn adopt_tmux(
+    _state: &Arc<DaemonState>,
+    body: AdoptRequest,
+) -> Result<AdoptResponse, DaemonError> {
+    let adopted = TmuxService::adopt(&body.session)?;
+    Ok(AdoptResponse { adopted })
+}

--- a/crates/trusty-mpm/src/daemon/rpc/core_ops.rs
+++ b/crates/trusty-mpm/src/daemon/rpc/core_ops.rs
@@ -79,7 +79,7 @@ pub async fn doctor(
 /// Recently captured errors from every daemon store (`GET /api/v1/errors`,
 /// `mpm.errors.list`).
 ///
-/// Test: `list_errors_returns_array`, `parity_errors_agrees_across_transports`.
+/// Test: `parity_errors_agrees_across_transports`.
 pub fn list_errors(_state: &Arc<DaemonState>, query: ErrorsQuery) -> ErrorsResponse {
     let limit = query.limit.unwrap_or(20).min(100) as usize;
     let errors = bug_report::aggregate_errors(limit);
@@ -138,7 +138,8 @@ pub fn to_wire_preview(p: &bug_report::IssuePreview) -> BugReportPreview {
 /// the socket's peer-uid check is the stronger half of the guard pair here.
 ///
 /// Test: `report_bug_no_confirm_includes_preview`,
-/// `report_bug_rate_limited_returns_not_filed`,
+/// `report_bug_not_found_fingerprint_is_graceful`,
+/// `report_bug_rate_limit_guard_blocks_correctly`,
 /// `parity_report_bug_preview_agrees_across_transports`.
 pub async fn report_bug(
     _state: &Arc<DaemonState>,
@@ -266,7 +267,7 @@ pub fn breakers(state: &Arc<DaemonState>) -> BreakersResponse {
 /// The overseer's enabled flag and active handler (`GET /overseer`,
 /// `mpm.overseer`).
 ///
-/// Test: `get_overseer_returns_status`, `parity_overseer_agrees_across_transports`.
+/// Test: `parity_overseer_agrees_across_transports`.
 pub fn overseer(state: &Arc<DaemonState>) -> OverseerResponse {
     OverseerResponse {
         overseer: OverseerStatus {
@@ -316,8 +317,7 @@ pub async fn llm_chat(
 /// Every tmux session with its origin label (`GET /tmux/sessions`,
 /// `mpm.tmux.sessions`).
 ///
-/// Test: `list_tmux_sessions_returns_array`,
-/// `parity_tmux_sessions_agrees_across_transports`.
+/// Test: `parity_tmux_sessions_agrees_across_transports`.
 pub fn list_tmux_sessions(_state: &Arc<DaemonState>) -> TmuxSessionsResponse {
     TmuxSessionsResponse {
         sessions: TmuxService::list_all(),

--- a/crates/trusty-mpm/src/daemon/rpc/core_tests.rs
+++ b/crates/trusty-mpm/src/daemon/rpc/core_tests.rs
@@ -1,0 +1,581 @@
+//! Contract tests for the core RPC methods (#6288 slice 2).
+//!
+//! Why these are PARITY tests rather than "the socket answers 200-shaped JSON":
+//! this slice's whole claim is that a route reached over the socket and the same
+//! route reached over HTTP give the same answer. A test that only exercises the
+//! RPC side proves the method exists; it cannot fail when the two transports
+//! drift, which is the failure the slice exists to prevent. So every `parity_*`
+//! case builds the axum router AND the RPC router from ONE `Arc<DaemonState>`,
+//! issues the equivalent request both ways, and compares the decoded JSON.
+//!
+//! ## The comparison allowlist
+//!
+//! Two fields are dropped before comparing, both on `mpm.doctor`, and both
+//! because the DAEMON varies them between two calls of the same code rather
+//! than because the transports disagree:
+//!
+//! - `generated_at`, which `DoctorReport::from_checks` stamps with `Utc::now()`
+//!   at every call (`core::doctor`).
+//! - the `worktree_disk` check's `message`, which reports how much of the
+//!   worktree tree the probe measured inside its 3-second deadline. Its `name`
+//!   and `status` are still compared — see
+//!   [`blank_deadline_bounded_messages`].
+//!
+//! Nothing else is excused. Every other method is compared whole, `pid`
+//! included — the two transports run in one process, so a `pid` that differed
+//! would be a real finding.
+//!
+//! Test: this file IS the test module for [`super`].
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::{Value, json};
+use tempfile::TempDir;
+use tower::ServiceExt;
+use trusty_common::uds::server::{
+    CODE_INVALID_PARAMS, CODE_METHOD_NOT_FOUND, RpcResponse, RpcRouter,
+};
+
+use super::{METHODS, register};
+use crate::core::paths::FrameworkPaths;
+use crate::daemon::api;
+use crate::daemon::error::{CODE_NOT_FOUND, CODE_UNAVAILABLE};
+use crate::daemon::state::DaemonState;
+
+/// One daemon state rooted at an empty temp directory, plus the directory.
+///
+/// Why hermetic: a developer machine with a live `overseer.toml` and an
+/// `OPENROUTER_API_KEY` builds a REAL LLM overseer, and
+/// `rpc_llm_chat_without_overseer_reports_unavailable` would then get an answer
+/// instead of the refusal it asserts (#1523). An empty root builds the disabled
+/// deterministic overseer. The caller holds the `TempDir` for the test's life.
+fn hermetic() -> (Arc<DaemonState>, TempDir) {
+    let dir = tempfile::tempdir().expect("temp dir for hermetic DaemonState");
+    let paths = FrameworkPaths::under(dir.path());
+    (Arc::new(DaemonState::with_paths(&paths)), dir)
+}
+
+/// The RPC router this slice registers, over `state`.
+fn rpc_router(state: &Arc<DaemonState>) -> RpcRouter {
+    register(RpcRouter::new(), state)
+}
+
+/// Drive one HTTP request through the real daemon router and decode the answer.
+///
+/// Why the real router rather than calling a handler directly: the parity claim
+/// is about the ROUTE, so the path, the method, and the extractors all have to
+/// participate. Calling the handler would skip exactly the decoding the socket
+/// has to reproduce.
+async fn http(
+    state: &Arc<DaemonState>,
+    method: &str,
+    uri: &str,
+    body: Option<Value>,
+) -> (StatusCode, Value) {
+    let request = Request::builder().method(method).uri(uri);
+    let request = match body {
+        Some(v) => request
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_vec(&v).expect("encode body")))
+            .expect("build request"),
+        None => request.body(Body::empty()).expect("build request"),
+    };
+
+    let response = api::router(Arc::clone(state))
+        .oneshot(request)
+        .await
+        .expect("the router must answer");
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read the response body");
+    // A `StatusCode`-only refusal has an empty body; report it as `null` rather
+    // than failing the decode, so an error-parity case can still see the status.
+    let value = if bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&bytes).expect("the HTTP body must be JSON")
+    };
+    (status, value)
+}
+
+/// Dispatch one JSON-RPC call against `router` and return the whole frame.
+///
+/// `dispatch` takes a raw frame for the same reason the server does — the
+/// envelope checks are part of what is under test.
+async fn rpc_frame(router: &RpcRouter, method: &str, params: Value) -> Value {
+    let frame = json!({ "jsonrpc": "2.0", "id": 1, "method": method, "params": params });
+    let response: RpcResponse = router
+        .dispatch(&serde_json::to_vec(&frame).expect("encode the request frame"))
+        .await;
+    serde_json::to_value(response).expect("the response frame must serialise")
+}
+
+/// The `result` half of a call that must succeed.
+async fn rpc_ok(router: &RpcRouter, method: &str, params: Value) -> Value {
+    let frame = rpc_frame(router, method, params).await;
+    assert!(
+        frame.get("error").is_none(),
+        "{method} must succeed, got {frame}"
+    );
+    frame
+        .get("result")
+        .cloned()
+        .unwrap_or_else(|| panic!("{method} answered no result: {frame}"))
+}
+
+/// The `error` half of a call that must be refused.
+async fn rpc_err(router: &RpcRouter, method: &str, params: Value) -> Value {
+    let frame = rpc_frame(router, method, params).await;
+    frame
+        .get("error")
+        .cloned()
+        .unwrap_or_else(|| panic!("{method} must be refused, got {frame}"))
+}
+
+/// Assert the two transports answered the same JSON for one route.
+///
+/// `drop_fields` is the allowlist this module's doc records; it is empty for
+/// every method but `mpm.doctor`.
+fn assert_same(method: &str, mut http_body: Value, mut rpc_result: Value, drop_fields: &[&str]) {
+    for field in drop_fields {
+        if let Some(map) = http_body.as_object_mut() {
+            map.remove(*field);
+        }
+        if let Some(map) = rpc_result.as_object_mut() {
+            map.remove(*field);
+        }
+    }
+    assert_eq!(
+        http_body, rpc_result,
+        "{method} must answer identically over HTTP and the socket"
+    );
+}
+
+// ── The method table ─────────────────────────────────────────────────────────
+
+/// Why: four crates outside this one will dial these names by literal once the
+/// slice-7 client swap lands, with no compile-time link to this table. Pinning
+/// the registered set here turns a rename into a failing assertion rather than
+/// a consumer that silently reports `method_not_found`.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn rpc_router_registers_every_documented_method() {
+    let (state, _dir) = hermetic();
+    let router = rpc_router(&state);
+    let registered: Vec<&str> = router.method_names().collect();
+
+    let mut documented: Vec<&str> = METHODS.to_vec();
+    documented.sort_unstable();
+
+    assert_eq!(
+        registered, documented,
+        "the router and METHODS must name the same set"
+    );
+    assert_eq!(
+        METHODS.len(),
+        20,
+        "slice 2 owns twenty routes; a new one needs a row in core.rs's table too"
+    );
+}
+
+/// Why: slice 1's contract — an unregistered name answers with a coded frame
+/// rather than a dropped connection — has to survive the router gaining methods.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn rpc_reports_method_not_found_for_an_unknown_method() {
+    let (state, _dir) = hermetic();
+    let error = rpc_err(&rpc_router(&state), "mpm.no.such.method", json!({})).await;
+    assert_eq!(error["code"], json!(CODE_METHOD_NOT_FOUND), "{error}");
+}
+
+/// Why: `params` is absent on a well-formed no-argument call, and a plain unit
+/// struct refuses `null` — which would make every health probe fail with
+/// `invalid_params`. [`super::NoParams`] exists to prevent that, and this is
+/// what proves it.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn rpc_health_answers_with_no_params() {
+    let (state, _dir) = hermetic();
+    let result = rpc_ok(&rpc_router(&state), "mpm.health", Value::Null).await;
+    assert_eq!(result["status"], json!("ok"), "{result}");
+}
+
+/// Why: a no-argument method has nothing to get wrong, so refusing a stray
+/// field would turn an additive client change into an outage.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn rpc_health_answers_with_a_stray_params_object() {
+    let (state, _dir) = hermetic();
+    let result = rpc_ok(&rpc_router(&state), "mpm.health", json!({"unknown": 1})).await;
+    assert_eq!(result["status"], json!("ok"), "{result}");
+}
+
+/// Why: a method that DOES take arguments must refuse a payload it cannot
+/// decode, with the reason, rather than running on a default.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn rpc_reports_invalid_params_for_an_undecodable_payload() {
+    let (state, _dir) = hermetic();
+    let error = rpc_err(
+        &rpc_router(&state),
+        "mpm.tmux.snapshot",
+        json!({"name": 42}),
+    )
+    .await;
+    assert_eq!(error["code"], json!(CODE_INVALID_PARAMS), "{error}");
+}
+
+// ── Parity: one state, two transports, one answer ────────────────────────────
+
+/// Why: `/health` is what `tm doctor` and every liveness probe read, so a drift
+/// between the transports here is the one a consumer notices first.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_health_agrees_across_transports() {
+    let (state, _dir) = hermetic();
+    let (status, body) = http(&state, "GET", "/health", None).await;
+    assert_eq!(status, StatusCode::OK);
+    let result = rpc_ok(&rpc_router(&state), "mpm.health", Value::Null).await;
+    assert_same("mpm.health", body, result, &[]);
+}
+
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_breakers_agrees_across_transports() {
+    let (state, _dir) = hermetic();
+    let (status, body) = http(&state, "GET", "/breakers", None).await;
+    assert_eq!(status, StatusCode::OK);
+    let result = rpc_ok(&rpc_router(&state), "mpm.breakers", Value::Null).await;
+    assert_same("mpm.breakers", body, result, &[]);
+}
+
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_optimizer_agrees_across_transports() {
+    let (state, _dir) = hermetic();
+    let (status, body) = http(&state, "GET", "/optimizer", None).await;
+    assert_eq!(status, StatusCode::OK);
+    let result = rpc_ok(&rpc_router(&state), "mpm.optimizer", Value::Null).await;
+    assert_same("mpm.optimizer", body, result, &[]);
+}
+
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_overseer_agrees_across_transports() {
+    let (state, _dir) = hermetic();
+    let (status, body) = http(&state, "GET", "/overseer", None).await;
+    assert_eq!(status, StatusCode::OK);
+    let result = rpc_ok(&rpc_router(&state), "mpm.overseer", Value::Null).await;
+    assert_same("mpm.overseer", body, result, &[]);
+}
+
+/// Why the explicit `?limit=`: the HTTP route defaults an absent `limit` to 20
+/// inside the shared body, and passing it on both sides proves the ARGUMENT
+/// survives the transport change rather than only the default.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_errors_agrees_across_transports() {
+    let (state, _dir) = hermetic();
+    let (status, body) = http(&state, "GET", "/api/v1/errors?limit=5", None).await;
+    assert_eq!(status, StatusCode::OK);
+    let result = rpc_ok(&rpc_router(&state), "mpm.errors.list", json!({"limit": 5})).await;
+    assert_eq!(body["limit"], json!(5), "the argument must reach the body");
+    assert_same("mpm.errors.list", body, result, &[]);
+}
+
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_tmux_sessions_agrees_across_transports() {
+    let (state, _dir) = hermetic();
+    let (status, body) = http(&state, "GET", "/tmux/sessions", None).await;
+    assert_eq!(status, StatusCode::OK);
+    let result = rpc_ok(&rpc_router(&state), "mpm.tmux.sessions", Value::Null).await;
+    assert_same("mpm.tmux.sessions", body, result, &[]);
+}
+
+/// Why `generated_at` is dropped: `DoctorReport::from_checks` stamps it with
+/// `Utc::now()` on every call, so two calls differ there by construction. Every
+/// other field — the overall status and every check — is compared whole.
+///
+/// Why serial: the agent, asset-tier and hooks checks resolve paths under
+/// `$HOME`, and several tests in this binary move `$HOME` process-wide through
+/// `test_support`'s `override_home`. Without the crate-wide serial group one of
+/// them can land BETWEEN this test's two calls, so the HTTP report reads a temp
+/// home and the socket report reads the real one — which fails the comparison
+/// while proving nothing about the transports. `HomeOverride`'s doc records why
+/// that group has to be crate-wide rather than a local lock.
+/// Test: this function IS the test.
+#[serial_test::serial]
+#[tokio::test]
+async fn parity_doctor_agrees_across_transports() {
+    let (state, dir) = hermetic();
+    let project = dir.path().display().to_string();
+    let (status, body) = http(
+        &state,
+        "GET",
+        &format!("/api/v1/doctor?project={project}"),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let result = rpc_ok(
+        &rpc_router(&state),
+        "mpm.doctor",
+        json!({"project": project}),
+    )
+    .await;
+    assert!(
+        body.get("generated_at").is_some(),
+        "the allowlist entry must name a field that exists: {body}"
+    );
+    assert_same(
+        "mpm.doctor",
+        blank_deadline_bounded_messages(body),
+        blank_deadline_bounded_messages(result),
+        &["generated_at"],
+    );
+}
+
+/// Blank the `worktree_disk` check's message, keeping its name and status.
+///
+/// Why: that probe measures worktree sizes against a 3-second deadline and
+/// reports how far it got — "6.2 GiB … 268 worktree(s) went unmeasured" on one
+/// call and "6.8 GiB … 267" on the next. The variation is the PROBE's, not the
+/// transport's, so comparing that string would make this test a stopwatch. Its
+/// `name` and `status` are still compared, so a check that vanished or changed
+/// verdict between the transports still fails.
+///
+/// This is the second and last entry in the allowlist this module's doc records.
+fn blank_deadline_bounded_messages(mut report: Value) -> Value {
+    if let Some(checks) = report.get_mut("checks").and_then(Value::as_array_mut) {
+        for check in checks {
+            if check.get("name") == Some(&json!("worktree_disk")) {
+                if let Some(map) = check.as_object_mut() {
+                    map.insert("message".into(), json!("<deadline-bounded>"));
+                }
+            }
+        }
+    }
+    report
+}
+
+/// Why an unknown fingerprint: it exercises the whole route — argument decode,
+/// the store scan, the response shape — while filing nothing and spending
+/// nothing, which is what makes it safe to run in a unit suite.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_report_bug_preview_agrees_across_transports() {
+    let (state, _dir) = hermetic();
+    let payload = json!({
+        "fingerprint": "0".repeat(64),
+        "confirm": false,
+    });
+    let (status, body) = http(&state, "POST", "/api/v1/report-bug", Some(payload.clone())).await;
+    assert_eq!(status, StatusCode::OK, "this route is always 200");
+    assert_eq!(body["filed"], json!(false), "nothing may be filed: {body}");
+    let result = rpc_ok(&rpc_router(&state), "mpm.report_bug", payload).await;
+    assert_same("mpm.report_bug", body, result, &[]);
+}
+
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_claude_config_get_agrees_across_transports() {
+    let (state, dir) = hermetic();
+    let project = dir.path().display().to_string();
+    let (status, body) = http(
+        &state,
+        "GET",
+        &format!("/claude-config?project={project}"),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let result = rpc_ok(
+        &rpc_router(&state),
+        "mpm.claude_config.get",
+        json!({"project": project}),
+    )
+    .await;
+    assert_same("mpm.claude_config.get", body, result, &[]);
+}
+
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_claude_config_checkpoints_agrees_across_transports() {
+    let (state, dir) = hermetic();
+    let project = dir.path().display().to_string();
+    let (status, body) = http(
+        &state,
+        "GET",
+        &format!("/claude-config/checkpoints?project={project}"),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let result = rpc_ok(
+        &rpc_router(&state),
+        "mpm.claude_config.checkpoints.list",
+        json!({"project": project}),
+    )
+    .await;
+    assert_same("mpm.claude_config.checkpoints.list", body, result, &[]);
+}
+
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_claude_config_profiles_agrees_across_transports() {
+    let (state, _dir) = hermetic();
+    let (status, body) = http(&state, "GET", "/claude-config/profiles", None).await;
+    assert_eq!(status, StatusCode::OK);
+    let result = rpc_ok(
+        &rpc_router(&state),
+        "mpm.claude_config.profiles",
+        Value::Null,
+    )
+    .await;
+    assert_same("mpm.claude_config.profiles", body, result, &[]);
+}
+
+// ── Error parity: one failure, two renderings ────────────────────────────────
+
+/// Why 503 rather than any refusal: an unconfigured capability is the one error
+/// class on this slice that a caller can act on (set a key), so losing its
+/// distinctness in the move to the socket would cost real information.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn rpc_llm_chat_without_overseer_reports_unavailable() {
+    let (state, _dir) = hermetic();
+    let payload = json!({"message": "hello", "history": []});
+
+    let (status, body) = http(&state, "POST", "/llm/chat", Some(payload.clone())).await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+
+    let error = rpc_err(&rpc_router(&state), "mpm.llm.chat", payload).await;
+    assert_eq!(error["code"], json!(CODE_UNAVAILABLE), "{error}");
+    assert_eq!(
+        error["message"], body["error"],
+        "the socket must carry the HTTP body's message verbatim"
+    );
+}
+
+/// Why the unknown profile name: it is the only 404 on this slice that fires
+/// deterministically on any machine — no tmux, no config, no network.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn rpc_claude_config_deploy_unknown_profile_reports_not_found() {
+    let (state, dir) = hermetic();
+    let payload = json!({
+        "project": dir.path().display().to_string(),
+        "profile_name": "no-such-profile-xyz",
+    });
+
+    let (status, _body) = http(
+        &state,
+        "POST",
+        "/claude-config/deploy",
+        Some(payload.clone()),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND, "HTTP must still 404");
+
+    let error = rpc_err(&rpc_router(&state), "mpm.claude_config.deploy", payload).await;
+    assert_eq!(error["code"], json!(CODE_NOT_FOUND), "{error}");
+    assert!(
+        error["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("no-such-profile-xyz"),
+        "the refusal must name what was not found: {error}"
+    );
+}
+
+/// Why: the recommendation id is the second 404 on this slice, and it fires on
+/// an empty project directory — which analyses to a recommendation set that
+/// certainly does not contain this id.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn rpc_claude_config_apply_unknown_recommendation_reports_not_found() {
+    let (state, dir) = hermetic();
+    let payload = json!({
+        "project": dir.path().display().to_string(),
+        "recommendation_id": "no-such-recommendation-xyz",
+    });
+
+    let (status, _body) = http(
+        &state,
+        "POST",
+        "/claude-config/apply",
+        Some(payload.clone()),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND, "HTTP must still 404");
+
+    let error = rpc_err(&rpc_router(&state), "mpm.claude_config.apply", payload).await;
+    assert_eq!(error["code"], json!(CODE_NOT_FOUND), "{error}");
+}
+
+/// Why this one asserts the DERIVED code rather than a literal: what tmux does
+/// on a machine with no tmux binary and on one with tmux but no such session are
+/// different failure kinds, and pinning either would make the test a report on
+/// the machine rather than on the transport. What must hold either way is that
+/// the socket's code is the code the HTTP status maps to and its message is the
+/// HTTP body's message — which is the whole of requirement 3.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn rpc_tmux_snapshot_unknown_session_reports_a_coded_error() {
+    let (state, _dir) = hermetic();
+
+    let (status, body) = http(
+        &state,
+        "GET",
+        "/tmux/sessions/no-such-session-xyz/snapshot",
+        None,
+    )
+    .await;
+    assert!(
+        status.is_client_error() || status.is_server_error(),
+        "{status}"
+    );
+
+    let error = rpc_err(
+        &rpc_router(&state),
+        "mpm.tmux.snapshot",
+        json!({"name": "no-such-session-xyz"}),
+    )
+    .await;
+    assert_eq!(
+        error["message"], body["error"],
+        "the socket must carry the HTTP body's message verbatim"
+    );
+    let expected = match status {
+        StatusCode::NOT_FOUND => CODE_NOT_FOUND,
+        StatusCode::INTERNAL_SERVER_ERROR => trusty_common::uds::server::CODE_INTERNAL_ERROR,
+        other => panic!("unexpected status for a missing tmux session: {other}"),
+    };
+    assert_eq!(error["code"], json!(expected), "{error}");
+}
+
+/// Why an adopt of a session that is not there: it is the write-shaped tmux
+/// route, and it must refuse identically over both transports rather than
+/// reporting success on one.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_tmux_adopt_unknown_session_agrees_across_transports() {
+    let (state, _dir) = hermetic();
+    let payload = json!({"session": "no-such-session-xyz"});
+
+    let (status, body) = http(&state, "POST", "/tmux/adopt", Some(payload.clone())).await;
+    assert!(
+        status.is_client_error() || status.is_server_error(),
+        "{status}"
+    );
+
+    let error = rpc_err(&rpc_router(&state), "mpm.tmux.adopt", payload).await;
+    assert_eq!(
+        error["message"], body["error"],
+        "the socket must carry the HTTP body's message verbatim"
+    );
+}

--- a/crates/trusty-mpm/src/daemon/rpc/core_tests.rs
+++ b/crates/trusty-mpm/src/daemon/rpc/core_tests.rs
@@ -35,7 +35,7 @@ use serde_json::{Value, json};
 use tempfile::TempDir;
 use tower::ServiceExt;
 use trusty_common::uds::server::{
-    CODE_INVALID_PARAMS, CODE_METHOD_NOT_FOUND, RpcResponse, RpcRouter,
+    CODE_INTERNAL_ERROR, CODE_INVALID_PARAMS, CODE_METHOD_NOT_FOUND, RpcResponse, RpcRouter,
 };
 
 use super::{METHODS, register};
@@ -352,10 +352,10 @@ async fn parity_doctor_agrees_across_transports() {
 fn blank_deadline_bounded_messages(mut report: Value) -> Value {
     if let Some(checks) = report.get_mut("checks").and_then(Value::as_array_mut) {
         for check in checks {
-            if check.get("name") == Some(&json!("worktree_disk")) {
-                if let Some(map) = check.as_object_mut() {
-                    map.insert("message".into(), json!("<deadline-bounded>"));
-                }
+            if check.get("name") == Some(&json!("worktree_disk"))
+                && let Some(map) = check.as_object_mut()
+            {
+                map.insert("message".into(), json!("<deadline-bounded>"));
             }
         }
     }
@@ -578,4 +578,213 @@ async fn parity_tmux_adopt_unknown_session_agrees_across_transports() {
         error["message"], body["error"],
         "the socket must carry the HTTP body's message verbatim"
     );
+}
+
+// ── The four write-shaped claude-config methods ──────────────────────────────
+//
+// Why these get their own section: `checkpoints.create`, `checkpoints.delete`,
+// `restore` and `restart` all WRITE (or drive tmux), so a whole-body comparison
+// against an HTTP call would perform the side effect twice and — for `create`,
+// whose id embeds a timestamp and four random characters — compare two ids that
+// can never be equal. Each therefore asserts the same persisted effect its HTTP
+// test asserts, driven over the socket, or the failure both transports must
+// agree on. Every one dials a registered method and asserts a code OTHER than
+// `method_not_found`, so deleting the registration line in `core.rs::register`
+// fails the test rather than silently passing it.
+
+/// Why: `create` is the only method on this slice whose success is a WRITE, and
+/// its HTTP test (`create_checkpoint_returns_id`) proves it by listing the
+/// checkpoint back. This proves the socket performs the same write, with both
+/// halves over the socket — so a `create` registered but wired to the wrong body
+/// lists nothing.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn rpc_claude_config_checkpoint_create_then_list_sees_it() {
+    let (state, _dir) = hermetic();
+    let project = tempfile::tempdir().expect("project dir");
+    let project_path = project.path().display().to_string();
+    let router = rpc_router(&state);
+
+    let created = rpc_ok(
+        &router,
+        "mpm.claude_config.checkpoints.create",
+        json!({"project": project_path, "label": "from-the-socket"}),
+    )
+    .await;
+    let id = created["id"]
+        .as_str()
+        .expect("create returns an id")
+        .to_string();
+    assert!(!id.is_empty(), "the id must not be empty: {created}");
+
+    let listed = rpc_ok(
+        &router,
+        "mpm.claude_config.checkpoints.list",
+        json!({"project": project_path}),
+    )
+    .await;
+    assert!(
+        checkpoint_ids(&listed).contains(&id),
+        "the checkpoint written over the socket must be listed back: {listed}"
+    );
+}
+
+/// Why: `delete`'s effect is a removal, so the only assertion that proves it ran
+/// is that a checkpoint which WAS listed no longer is. Creating it over the
+/// socket first keeps the whole round trip on the transport under test.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn rpc_claude_config_checkpoint_delete_removes_a_created_checkpoint() {
+    let (state, _dir) = hermetic();
+    let project = tempfile::tempdir().expect("project dir");
+    let project_path = project.path().display().to_string();
+    let router = rpc_router(&state);
+
+    let created = rpc_ok(
+        &router,
+        "mpm.claude_config.checkpoints.create",
+        json!({"project": project_path}),
+    )
+    .await;
+    let id = created["id"]
+        .as_str()
+        .expect("create returns an id")
+        .to_string();
+    assert!(
+        checkpoint_ids(
+            &rpc_ok(
+                &router,
+                "mpm.claude_config.checkpoints.list",
+                json!({"project": project_path}),
+            )
+            .await
+        )
+        .contains(&id),
+        "the checkpoint must exist before the delete is meaningful"
+    );
+
+    let deleted = rpc_ok(
+        &router,
+        "mpm.claude_config.checkpoints.delete",
+        json!({"project": project_path, "id": id}),
+    )
+    .await;
+    assert_eq!(
+        deleted["deleted"],
+        json!(id),
+        "delete must name the checkpoint it removed: {deleted}"
+    );
+
+    let listed = rpc_ok(
+        &router,
+        "mpm.claude_config.checkpoints.list",
+        json!({"project": project_path}),
+    )
+    .await;
+    assert!(
+        !checkpoint_ids(&listed).contains(&id),
+        "the deleted checkpoint must be gone from the listing: {listed}"
+    );
+}
+
+/// The `id` of every checkpoint in a `checkpoints.list` result.
+fn checkpoint_ids(listed: &Value) -> Vec<String> {
+    listed["checkpoints"]
+        .as_array()
+        .expect("checkpoints is an array")
+        .iter()
+        .filter_map(|c| c["id"].as_str().map(str::to_owned))
+        .collect()
+}
+
+/// Why: a checkpoint id that was never written is the one `delete` failure both
+/// transports reach with no setup, and HTTP answers 404 for it
+/// (`delete_unknown_checkpoint_is_404`). The socket must answer the code that
+/// 404 maps to, not the `method_not_found` a missing registration would give.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn rpc_claude_config_delete_unknown_checkpoint_reports_not_found() {
+    let (state, _dir) = hermetic();
+    let project = tempfile::tempdir().expect("project dir");
+    let project_path = project.path().display().to_string();
+
+    let (status, _body) = http(
+        &state,
+        "DELETE",
+        &format!("/claude-config/checkpoints/no-such-checkpoint?project={project_path}"),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND, "HTTP must still 404");
+
+    let error = rpc_err(
+        &rpc_router(&state),
+        "mpm.claude_config.checkpoints.delete",
+        json!({"project": project_path, "id": "no-such-checkpoint"}),
+    )
+    .await;
+    assert_eq!(error["code"], json!(CODE_NOT_FOUND), "{error}");
+}
+
+/// Why: restoring an id that was never written is `restore`'s reachable failure,
+/// and HTTP answers 500 for it (`restore_unknown_checkpoint_is_500`) — a missing
+/// checkpoint and a failed rewrite are deliberately the same status there. This
+/// pins that the socket agrees rather than inventing a 404.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn rpc_claude_config_restore_unknown_checkpoint_reports_internal_error() {
+    let (state, _dir) = hermetic();
+    let project = tempfile::tempdir().expect("project dir");
+    let payload = json!({
+        "project": project.path().display().to_string(),
+        "checkpoint_id": "no-such-checkpoint",
+    });
+
+    let (status, _body) = http(
+        &state,
+        "POST",
+        "/claude-config/restore",
+        Some(payload.clone()),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "HTTP must still 500"
+    );
+
+    let error = rpc_err(&rpc_router(&state), "mpm.claude_config.restore", payload).await;
+    assert_eq!(error["code"], json!(CODE_INTERNAL_ERROR), "{error}");
+}
+
+/// Why: `restart` drives tmux, so what it does on a machine with no tmux and on
+/// one with tmux but no such session are different failure kinds — pinning
+/// either would make this a report on the machine. What holds either way is that
+/// the socket's code is the one the observed HTTP status maps to, which is also
+/// what rules out `method_not_found`.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn rpc_claude_config_restart_unknown_session_reports_a_coded_error() {
+    let (state, _dir) = hermetic();
+    let payload = json!({"tmux_session": "no-such-session-xyz"});
+
+    let (status, _body) = http(
+        &state,
+        "POST",
+        "/claude-config/restart",
+        Some(payload.clone()),
+    )
+    .await;
+    assert!(
+        status.is_client_error() || status.is_server_error(),
+        "restarting a session that is not there must fail: {status}"
+    );
+
+    let error = rpc_err(&rpc_router(&state), "mpm.claude_config.restart", payload).await;
+    let expected = match status {
+        StatusCode::NOT_FOUND => CODE_NOT_FOUND,
+        StatusCode::INTERNAL_SERVER_ERROR => CODE_INTERNAL_ERROR,
+        other => panic!("unexpected status for a missing tmux session: {other}"),
+    };
+    assert_eq!(error["code"], json!(expected), "{error}");
 }

--- a/crates/trusty-mpm/src/daemon/rpc/mod.rs
+++ b/crates/trusty-mpm/src/daemon/rpc/mod.rs
@@ -1,0 +1,20 @@
+//! The JSON-RPC methods the daemon serves on its Unix socket (#6288).
+//!
+//! Why: `daemon::socket` owns the transport — bind, peer check, framing, accept
+//! loop — and nothing about which methods exist. This module is the other half,
+//! split by route family so the slices that move the remaining ~35k SLOC of
+//! HTTP surface across can each add one file rather than editing one.
+//!
+//! What: a module list. Every family registers itself into the router
+//! `socket::build_router` assembles.
+//!
+//! Test: each family's own `*_tests.rs`.
+
+/// Registration for the core request/response families: health, doctor,
+/// errors, report-bug, breakers, optimizer, overseer, llm-chat, tmux, and
+/// claude-config (#6288 slice 2).
+pub mod core;
+
+/// The transport-neutral bodies `core`'s methods and `daemon::api`'s HTTP
+/// handlers both call, so one route has one implementation.
+pub mod core_ops;

--- a/crates/trusty-mpm/src/daemon/socket.rs
+++ b/crates/trusty-mpm/src/daemon/socket.rs
@@ -2,14 +2,14 @@
 //!
 //! Why: ADR-0032 moves every trusty-* service off loopback TCP and onto a Unix
 //! socket, and trusty-mpm's HTTP surface is ~35k SLOC across a dozen route
-//! files. A single-PR cutover is not viable, so this slice adds the socket
-//! ALONGSIDE `127.0.0.1:7880` and registers nothing on it. Later slices move
-//! methods across; the retire slice deletes the axum surface.
+//! files. A single-PR cutover is not viable, so the socket was added ALONGSIDE
+//! `127.0.0.1:7880` (slice 1) and route families move onto it one slice at a
+//! time; the retire slice deletes the axum surface.
 //!
 //! What: the socket path (derived, never published to a discovery file), the
-//! bind, and the serve loop. The router this slice builds is deliberately
-//! EMPTY — a request for any method gets a well-formed `method_not_found`
-//! frame, which is the scaffolding's whole observable contract until slice 2.
+//! bind, and the serve loop. Which METHODS are served is `daemon::rpc`'s —
+//! [`build_router`] names one `register` call per family, and slice 2 mounted
+//! the first twenty. A name no family claims still answers `method_not_found`.
 //!
 //! The trust boundary is the socket, not the payload: `bind_singleton_hardened`
 //! puts a `0600` socket in a `0700` directory, and `serve_until` runs the
@@ -25,6 +25,9 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use tokio::net::UnixListener;
 use trusty_common::uds::server::{RpcRouter, RpcServeOptions, serve_until};
+
+use super::rpc;
+use super::state::DaemonState;
 
 #[cfg(test)]
 #[path = "socket_tests.rs"]
@@ -51,15 +54,19 @@ pub fn socket_path() -> Result<PathBuf> {
 
 /// The methods this listener serves.
 ///
-/// Why: slice 1 registers none, on purpose. An empty router is not a stub — it
-/// is a listener whose every answer is a `method_not_found` frame, which is a
-/// contract a client can be written against and a later slice can extend one
-/// method at a time without changing the transport.
+/// Why: the transport is fixed and this is the only part that grows. Slice 1
+/// registered nothing; each later slice adds one `register` call for its own
+/// route family, so a family arrives without the accept loop, the framing, or
+/// the peer check being touched.
 ///
-/// Test: `unknown_method_gets_a_method_not_found_frame`.
-fn build_router() -> RpcRouter {
-    // #6288: methods arrive in slices 2-6; the transport lands first.
-    RpcRouter::new()
+/// A name no family claims still answers `method_not_found` — the contract
+/// slice 1 established for the whole surface now holds for the remainder of it.
+///
+/// Test: `unknown_method_gets_a_method_not_found_frame`,
+/// `rpc_router_registers_every_documented_method`.
+fn build_router(state: &Arc<DaemonState>) -> RpcRouter {
+    // #6288 slice 2: the core request/response families. Slices 3-6 append here.
+    rpc::core::register(RpcRouter::new(), state)
 }
 
 /// Per-connection budgets for this listener.
@@ -133,10 +140,11 @@ pub async fn bind(socket: &Path) -> Result<BoundSocket> {
 /// `unknown_method_gets_a_method_not_found_frame`.
 pub async fn serve_until_shutdown(
     bound: BoundSocket,
+    state: Arc<DaemonState>,
     shutdown: impl std::future::Future<Output = ()> + Send,
 ) {
     let BoundSocket { listener, path } = bound;
-    let router = Arc::new(build_router());
+    let router = Arc::new(build_router(&state));
     tracing::info!(
         socket = %path.display(),
         methods = router.method_names().count(),

--- a/crates/trusty-mpm/src/daemon/socket_tests.rs
+++ b/crates/trusty-mpm/src/daemon/socket_tests.rs
@@ -15,6 +15,7 @@ use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::UnixStream;
 
 use super::{bind, serve_until_shutdown, socket_path};
+use crate::daemon::state::DaemonState;
 
 /// How long a dial or a bind is given before the test calls it stuck.
 ///
@@ -50,8 +51,12 @@ async fn serve_bound(
     tokio::task::JoinHandle<()>,
 ) {
     let (stop_tx, stop_rx) = tokio::sync::oneshot::channel::<()>();
+    // #6288 slice 2: the listener now serves real methods, so it needs the
+    // state they read. `shared()` is the process-wide daemon state, which is
+    // what a test that only probes dispatch (never mutates) wants.
+    let state = DaemonState::shared();
     let handle = tokio::spawn(async move {
-        serve_until_shutdown(bound, async {
+        serve_until_shutdown(bound, state, async {
             let _ = stop_rx.await;
         })
         .await;
@@ -127,8 +132,9 @@ async fn dial_once(socket: &Path, request: &serde_json::Value) -> RawExchange {
 /// JSON-RPC error frame carrying `-32601`, the request's id echoed back, and a
 /// clean close with no trailing bytes.
 ///
-/// `mpm.health` is the method slice 2 registers first, so this also pins the
-/// answer a client gets from a daemon that has not yet taken that slice.
+/// The probed name has to be one NO slice serves: since #6288 slice 2 the
+/// router carries twenty real methods, and `mpm.health` — which this test used
+/// while the router was empty — now answers with a result.
 /// Test: this function IS the test.
 #[tokio::test(flavor = "multi_thread")]
 async fn unknown_method_gets_a_method_not_found_frame() {
@@ -139,7 +145,7 @@ async fn unknown_method_gets_a_method_not_found_frame() {
     let exchange = dial_once(
         &socket,
         &serde_json::json!({
-            "jsonrpc": "2.0", "id": 7, "method": "mpm.health", "params": {},
+            "jsonrpc": "2.0", "id": 7, "method": "mpm.no.such.method", "params": {},
         }),
     )
     .await;
@@ -148,7 +154,7 @@ async fn unknown_method_gets_a_method_not_found_frame() {
     assert_eq!(exchange.frame["id"], 7);
     assert!(
         exchange.frame.get("result").is_none(),
-        "a router with no methods must not answer a result: {}",
+        "an unregistered method must not answer a result: {}",
         exchange.frame
     );
     assert_eq!(

--- a/crates/trusty-mpm/tests/daemon_dual_serve.rs
+++ b/crates/trusty-mpm/tests/daemon_dual_serve.rs
@@ -121,16 +121,22 @@ async fn serve_http_drains_both_listeners_on_shutdown() {
     }
     assert!(http_ok, "the HTTP listener must answer /health at {addr}");
 
-    // The socket serves an empty router in slice 1, so the answer is an error
-    // frame. That it is a FRAME is the point: the request was read and answered
-    // over the socket while HTTP was serving on the same runtime.
+    // Since #6288 slice 2 the socket serves `mpm.health` for real, so the answer
+    // is a RESULT rather than the `method_not_found` frame slice 1 asserted.
+    // That it is answered at all is still the point — the request was read and
+    // served over the socket while HTTP was serving on the same runtime — and a
+    // real result is the stronger evidence of it.
     let answer = call_over_socket(&socket, "mpm.health")
         .await
         .expect("the rpc listener must answer while HTTP is also serving");
+    assert!(
+        answer.get("error").is_none(),
+        "mpm.health is a registered method: {answer}"
+    );
     assert_eq!(
-        answer["error"]["code"],
-        serde_json::json!(trusty_common::uds::server::CODE_METHOD_NOT_FOUND),
-        "slice 1 registers no methods: {answer}"
+        answer["result"]["status"],
+        serde_json::json!("ok"),
+        "the socket must serve the same liveness word HTTP does: {answer}"
     );
 
     // ── One shutdown drains both ─────────────────────────────────────────────


### PR DESCRIPTION
Twenty core daemon routes are now reachable as JSON-RPC methods on the Unix socket slice 1 bound, under `mpm.<family>.<verb>` names, with each route's body extracted into one transport-neutral function that the axum handler and the RPC method both call. HTTP serves all twenty unchanged — nothing is removed, and no existing HTTP test was modified.

Refs #6288. Slice 2 of the #6288 plan.

## Method → route

| Method | HTTP route |
|---|---|
| `mpm.health` | `GET /health` |
| `mpm.doctor` | `GET /api/v1/doctor` |
| `mpm.errors.list` | `GET /api/v1/errors` |
| `mpm.report_bug` | `POST /api/v1/report-bug` |
| `mpm.breakers` | `GET /breakers` |
| `mpm.optimizer` | `GET /optimizer` |
| `mpm.overseer` | `GET /overseer` |
| `mpm.llm.chat` | `POST /llm/chat` |
| `mpm.tmux.sessions` | `GET /tmux/sessions` |
| `mpm.tmux.snapshot` | `GET /tmux/sessions/{name}/snapshot` |
| `mpm.tmux.adopt` | `POST /tmux/adopt` |
| `mpm.claude_config.get` | `GET /claude-config` |
| `mpm.claude_config.apply` | `POST /claude-config/apply` |
| `mpm.claude_config.checkpoints.list` | `GET /claude-config/checkpoints` |
| `mpm.claude_config.checkpoints.create` | `POST /claude-config/checkpoints` |
| `mpm.claude_config.checkpoints.delete` | `DELETE /claude-config/checkpoints/{id}` |
| `mpm.claude_config.restore` | `POST /claude-config/restore` |
| `mpm.claude_config.profiles` | `GET /claude-config/profiles` |
| `mpm.claude_config.deploy` | `POST /claude-config/deploy` |
| `mpm.claude_config.restart` | `POST /claude-config/restart` |

## Guards on the two write-or-spend methods

`mpm.report_bug` files a GitHub issue on `confirm: true` and `mpm.llm.chat` spends OpenRouter credit, so nothing may be weaker on the socket. HTTP layers `guard_write_origin` router-wide — a CSRF defence that ALLOWS any request carrying no `Origin` header, which is every server-side caller, so it authenticates nobody. The socket runs `ensure_peer_is_self` on every connection before a byte is read, over a `0600` socket in a `0700` directory, so it authenticates the calling process's uid. The peer-uid check is the stronger of the two and refuses callers the origin guard waves through; the origin guard has no counterpart to carry, since there is no `Origin` header on a Unix socket. The `/rpc` loopback gate belongs to a route this slice does not own and is untouched. Recorded in `rpc/core.rs`'s module doc.

## Parity evidence

Each of the eleven `parity_*` tests builds the axum router AND the RPC router from ONE `Arc<DaemonState>`, issues the equivalent request both ways, and compares the decoded JSON whole. Two fields are excluded, both on `mpm.doctor` and both because the daemon varies them between two calls of the same code: `generated_at` (stamped `Utc::now()` per call) and the `worktree_disk` check's `message` (it reports how far a 3-second-budgeted probe got — its `name` and `status` are still compared). The allowlist is stated in `core_tests.rs`'s module doc.

Error mapping has one test per class exercised by a real failure: `rpc_llm_chat_without_overseer_reports_unavailable` (503), `rpc_claude_config_deploy_unknown_profile_reports_not_found` and `rpc_claude_config_apply_unknown_recommendation_reports_not_found` (404), and `rpc_tmux_snapshot_unknown_session_reports_a_coded_error`, which asserts the socket's code is the code the observed HTTP status maps to and its message is the HTTP body's message verbatim.

## Rebase onto main

Slice 1 merged as `5f3a8de3b`, so this branch was rebased from
`feat/6288-s1-uds-scaffold` onto `main` and GitHub retargeted the PR. Only this
slice's four commits replayed (`git rebase --onto origin/main 39a709fb3`); slice
1's own commits are already in main under the squash. One hunk dropped in the
replay: a `Test:` pointer fix in `socket.rs` that slice 1 had made identically
in `012a24e03` before merging, so main already carries it.

## Gate — rung 4, at head `1af1977a6`

Every line below was read back from the run's own output file.

```
cargo fmt --check                                         EXIT=0
cargo clippy -p trusty-mpm --all-targets -- -D warnings   EXIT=0   (0 errors)
cargo test -p trusty-mpm --no-fail-fast                   EXIT=0
    test result: ok. 5326 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out
    52 targets, 0 FAILED; daemon::rpc::core::tests contributes 26
cargo check --workspace                                   EXIT=0   (0 errors)
bash scripts/check_line_cap.sh    4220 files, 4 allowlisted, 0 violations — OK
bash scripts/check_changelog_fragment.sh   OK trusty-mpm: fragment present and valid
bash scripts/check_test_pointers.sh        27079 citations, 0 dangling — OK
```

### Correction: this body previously claimed clippy was green when it was not

An earlier revision of this section reported `cargo clippy … EXIT=0`. That was
false, and the true history is:

| Commit | clippy | What was true |
|---|---|---|
| `11d6b2aed` | **EXIT=101** | `clippy::collapsible_if` on `core_tests.rs`'s `blank_deadline_bounded_messages`, under `-D warnings` |
| `267d24fba` (was `e442abc8d`) | EXIT=0 | fixed with a let-chain — the compiler's own suggestion, verbatim; the crate is edition 2024 |
| `1af1977a6` (head) | EXIT=0 | still green after the rebase onto main |

The cause was not a toolchain difference — the local default is
`rustc 1.94.1 / clippy 0.1.94`, the same version CI pins. The run at
`11d6b2aed` printed `EXIT=101` and the full lint into its log file, and that
file was never opened before the result was reported. A pass was written down
that had not been observed. Two follow-ups came out of the same review and are
in this PR: five socket tests for `checkpoints.create`, `checkpoints.delete`,
`restore` and `restart`, which were registered with nothing dialling them; and
seven `Test:` doc pointers that named tests which do not exist.

## Files outside the slice's own set

Three edits were unavoidable and are minimal:

- `daemon/mod.rs` — `pub mod rpc;`, and `serve_until_shutdown` now receives the `Arc<DaemonState>` the axum router was built with, so both transports serve one daemon.
- `daemon/socket.rs` — `build_router` takes that state and calls `rpc::core::register`; `serve_until_shutdown` gained the parameter.
- `daemon/socket_tests.rs` — slice 1's `unknown_method_gets_a_method_not_found_frame` probed `mpm.health`, which now answers with a result. It probes `mpm.no.such.method` instead, so it still asserts exactly what it was written to assert.

`daemon/error.rs` gained a `NotFound(String)` variant (the `/claude-config` 404s had been bare `StatusCode`s carrying no message) and the `From<DaemonError> for RpcError` mapping.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

