### PR TITLE
feat(trusty-mpm): managed-session and control-plane routes served as RPC methods over UDS (Refs #6288)

### DIFF
--- a/crates/trusty-mpm/changelog.d/6288-s4-rpc-managed.md
+++ b/crates/trusty-mpm/changelog.d/6288-s4-rpc-managed.md
@@ -1,0 +1,5 @@
+Added
+
+- The daemon's managed-session lifecycle, SESSCTL control-plane, and L2 proxy routes are now also served as JSON-RPC methods on the Unix socket (`mpm.managed.*`, `mpm.control.*`, `mpm.proxy.*`). HTTP is unchanged and every route still answers on it; each method and its HTTP route share one implementation, so the two transports cannot drift.
+- The #6197 input validation and caller check moved into that shared implementation, so neither transport can reach a control-plane spawn without them. The socket's own peer-uid check is stricter than the loopback guard it stands in for.
+- `mpm.control.connect` answers as a frame stream, carrying the same session events the SSE route's `data:` lines carry.

--- a/crates/trusty-mpm/src/daemon/api/control_routes.rs
+++ b/crates/trusty-mpm/src/daemon/api/control_routes.rs
@@ -29,6 +29,8 @@ use tokio_stream::wrappers::BroadcastStream;
 
 use crate::control::event::BackendKind;
 use crate::control::{ActorCommand, ControlSessionId, RunParams};
+use crate::daemon::rpc::managed::control::CallerTrust;
+use crate::daemon::rpc::managed::outcome::RouteOutcome;
 use crate::daemon::state::DaemonState;
 
 // ── RAII write-lock guard ─────────────────────────────────────────────────────
@@ -260,16 +262,13 @@ fn parse_backend(s: Option<&str>) -> BackendKind {
 /// address, `Ok(())` otherwise. Reuses [`super::rpc::is_loopback`] rather than
 /// re-implementing the check (single entry point).
 /// Test: `ctl_run_session_rejects_non_loopback_peer`.
-fn loopback_guard(peer: &SocketAddr) -> Result<(), (StatusCode, String)> {
-    if super::rpc::is_loopback(peer) {
-        Ok(())
-    } else {
+fn loopback_guard(peer: &SocketAddr) -> CallerTrust {
+    let is_loopback = super::rpc::is_loopback(peer);
+    if !is_loopback {
         tracing::warn!(%peer, "rejected non-loopback control-plane session request (#6197)");
-        Err((
-            StatusCode::FORBIDDEN,
-            "control-plane session routes are loopback-only; remote access is forbidden".to_owned(),
-        ))
     }
+    // #6288: the verdict has no literal — the constructor is the only way in.
+    CallerTrust::from_loopback_check(is_loopback)
 }
 
 /// True when every character of `s` is in the conservative command charset.
@@ -301,16 +300,15 @@ fn is_safe_cmd_charset(s: &str) -> bool {
 /// Test: `ctl_run_session_rejects_claude_cmd_outside_allowlist`,
 /// `ctl_run_session_accepts_default_claude_cmd`,
 /// `validate_claude_cmd_allows_default_refuses_paths`.
-fn validate_claude_cmd(cmd: Option<&str>) -> Result<(), (StatusCode, String)> {
+pub(crate) fn validate_claude_cmd(cmd: Option<&str>) -> Result<(), RouteOutcome> {
     match cmd {
         None => Ok(()),
         Some("claude") => Ok(()),
         Some(other) => {
             tracing::warn!(cmd = %other, "rejected claude_cmd outside the allowed set (#6197)");
-            Err((
-                StatusCode::BAD_REQUEST,
-                "claude_cmd override is not permitted over HTTP; omit it to use the default `claude`"
-                    .to_owned(),
+            Err(RouteOutcome::text(
+                400,
+                "claude_cmd override is not permitted over HTTP; omit it to use the default `claude`",
             ))
         }
     }
@@ -334,7 +332,7 @@ fn validate_claude_cmd(cmd: Option<&str>) -> Result<(), (StatusCode, String)> {
 /// only names which prompt file `claude` reads. See #6197.
 /// Test: `ctl_run_session_rejects_prompt_file_injection`,
 /// `validate_prompt_file_requires_absolute_existing_regular_file`.
-fn validate_prompt_file(prompt_file: Option<&str>) -> Result<(), (StatusCode, String)> {
+pub(crate) fn validate_prompt_file(prompt_file: Option<&str>) -> Result<(), RouteOutcome> {
     let Some(pf) = prompt_file else { return Ok(()) };
     let path = std::path::Path::new(pf);
     let traversal = path
@@ -344,10 +342,9 @@ fn validate_prompt_file(prompt_file: Option<&str>) -> Result<(), (StatusCode, St
         Ok(())
     } else {
         tracing::warn!(prompt_file = %pf, "rejected invalid prompt_file (#6197)");
-        Err((
-            StatusCode::BAD_REQUEST,
-            "prompt_file must be an absolute path (no `..`, no shell metacharacters) to an existing file"
-                .to_owned(),
+        Err(RouteOutcome::text(
+            400,
+            "prompt_file must be an absolute path (no `..`, no shell metacharacters) to an existing file",
         ))
     }
 }
@@ -371,7 +368,7 @@ fn validate_prompt_file(prompt_file: Option<&str>) -> Result<(), (StatusCode, St
 /// not offer. Tracked, not fixed here. See #6197.
 /// Test: `ctl_run_session_rejects_relative_workdir`,
 /// `ctl_run_session_rejects_workdir_traversal`.
-fn validate_workdir(workdir: &std::path::Path) -> Result<(), (StatusCode, String)> {
+pub(crate) fn validate_workdir(workdir: &std::path::Path) -> Result<(), RouteOutcome> {
     let traversal = workdir
         .components()
         .any(|c| matches!(c, std::path::Component::ParentDir));
@@ -379,9 +376,9 @@ fn validate_workdir(workdir: &std::path::Path) -> Result<(), (StatusCode, String
         Ok(())
     } else {
         tracing::warn!(workdir = %workdir.display(), "rejected invalid control-plane workdir (#6197)");
-        Err((
-            StatusCode::BAD_REQUEST,
-            "workdir must be an absolute path (no `..`) to an existing directory".to_owned(),
+        Err(RouteOutcome::text(
+            400,
+            "workdir must be an absolute path (no `..`) to an existing directory",
         ))
     }
 }
@@ -408,14 +405,49 @@ pub async fn ctl_run_session(
     State(state): State<Arc<DaemonState>>,
     ConnectInfo(peer): ConnectInfo<SocketAddr>,
     Json(req): Json<CtlRunRequest>,
-) -> Result<Json<CtlRunResponse>, (StatusCode, String)> {
-    // #6197: this handler spawns a caller-named executable, so it enforces the
-    // same loopback boundary as `/rpc` and validates the two spawn inputs before
-    // anything is spawned.
-    loopback_guard(&peer)?;
-    validate_claude_cmd(req.claude_cmd.as_deref())?;
-    validate_prompt_file(req.prompt_file.as_deref())?;
-    validate_workdir(std::path::Path::new(&req.workdir))?;
+) -> impl axum::response::IntoResponse {
+    ctl_run_core(&state, loopback_guard(&peer), req).await // #6288
+}
+
+/// The transport-neutral body of `POST /api/v1/control/sessions/run` (#6288),
+/// served over the socket as `mpm.control.run`.
+///
+/// Why: this is the spawn route, and the four #6197 checks are what stand
+/// between a caller-supplied request and `Command::spawn`. Putting them in the
+/// shared body — ahead of every other statement, in the order PR #6205 wrote
+/// them — is what makes "the guard travels" a structural fact rather than a
+/// claim about two copies staying in step.
+/// What: refuses a caller no transport vouched for, with the same 403 the
+/// HTTP loopback guard answered, then runs `validate_claude_cmd`,
+/// `validate_prompt_file`, and `validate_workdir` before constructing
+/// [`RunParams`]. Only then is `run_session` reached.
+/// Test: `ctl_run_session_rejects_non_loopback_peer`,
+/// `ctl_run_session_rejects_claude_cmd_outside_allowlist`,
+/// `ctl_run_session_rejects_prompt_file_injection`,
+/// `ctl_run_session_rejects_relative_workdir`,
+/// `ctl_run_session_rejects_workdir_traversal`,
+/// `ctl_run_session_accepts_default_claude_cmd`, and each one's
+/// `rpc_ctl_run_*` twin in `daemon::rpc::managed_tests`.
+pub(crate) async fn ctl_run_core(
+    state: &Arc<DaemonState>,
+    trust: CallerTrust,
+    req: CtlRunRequest,
+) -> RouteOutcome {
+    // #6197: this route spawns a caller-named executable, so it enforces the
+    // caller boundary and validates every spawn input before anything is
+    // spawned. #6288: the checks live here so both transports run them.
+    if let Err(refusal) = trust.ensure_local() {
+        return refusal;
+    }
+    if let Err(refusal) = validate_claude_cmd(req.claude_cmd.as_deref()) {
+        return refusal;
+    }
+    if let Err(refusal) = validate_prompt_file(req.prompt_file.as_deref()) {
+        return refusal;
+    }
+    if let Err(refusal) = validate_workdir(std::path::Path::new(&req.workdir)) {
+        return refusal;
+    }
     let backend = parse_backend(req.backend.as_deref());
     let params = RunParams {
         project_id: req.project_id,
@@ -425,10 +457,10 @@ pub async fn ctl_run_session(
         claude_cmd: req.claude_cmd,
     };
     match state.session_registry.run_session(params).await {
-        Ok(id) => Ok(Json(CtlRunResponse {
+        Ok(id) => RouteOutcome::ok(&CtlRunResponse {
             session_id: id.to_string(),
-        })),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, e.to_string())),
+        }),
+        Err(e) => RouteOutcome::text(500, e.to_string()),
     }
 }
 
@@ -453,7 +485,10 @@ pub async fn ctl_connect_session(
     ConnectInfo(peer): ConnectInfo<SocketAddr>,
     Path(id_str): Path<String>,
 ) -> Result<Sse<impl Stream<Item = Result<Event, Infallible>>>, (StatusCode, String)> {
-    loopback_guard(&peer)?; // #6197
+    // #6197 + #6288: the same caller check, expressed through the shared token.
+    if !loopback_guard(&peer).is_local() {
+        return Err((StatusCode::FORBIDDEN, CallerTrust::REFUSAL.to_owned()));
+    }
     let id = parse_id(&id_str);
     let handle = state
         .session_registry
@@ -500,31 +535,48 @@ pub async fn ctl_stop_session(
     ConnectInfo(peer): ConnectInfo<SocketAddr>,
     Path(id_str): Path<String>,
     Query(query): Query<CtlStopQuery>,
-) -> Result<Json<CtlStopResponse>, (StatusCode, String)> {
-    loopback_guard(&peer)?; // #6197
-    let id = parse_id(&id_str);
-    let handle = state
-        .session_registry
-        .get(&id)
-        .await
-        .ok_or_else(|| (StatusCode::NOT_FOUND, format!("session {id_str} not found")))?;
+) -> impl axum::response::IntoResponse {
+    ctl_stop_core(
+        &state,
+        loopback_guard(&peer),
+        &id_str,
+        query.force.unwrap_or(false),
+    )
+    .await // #6288
+}
 
-    let force = query.force.unwrap_or(false);
+/// The transport-neutral body of `POST .../control/sessions/{id}/stop` (#6288),
+/// served over the socket as `mpm.control.stop`.
+///
+/// Test: `ctl_stop_session_sends_stop_command`, `ctl_stop_session_not_found`,
+/// and `rpc_ctl_stop_parity` in `daemon::rpc::managed_tests`.
+pub(crate) async fn ctl_stop_core(
+    state: &Arc<DaemonState>,
+    trust: CallerTrust,
+    id_str: &str,
+    force: bool,
+) -> RouteOutcome {
+    if let Err(refusal) = trust.ensure_local() {
+        return refusal; // #6197
+    }
+    let id = parse_id(id_str);
+    let Some(handle) = state.session_registry.get(&id).await else {
+        return RouteOutcome::text(404, format!("session {id_str} not found"));
+    };
+
     let cmd = if force {
         ActorCommand::ForceStop
     } else {
         ActorCommand::Stop
     };
-    handle
-        .command_tx
-        .send(cmd)
-        .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    if let Err(e) = handle.command_tx.send(cmd).await {
+        return RouteOutcome::text(500, e.to_string());
+    }
 
-    Ok(Json(CtlStopResponse {
-        session_id: id_str,
+    RouteOutcome::ok(&CtlStopResponse {
+        session_id: id_str.to_owned(),
         force,
-    }))
+    })
 }
 
 /// Return the auth state for a session.
@@ -538,23 +590,36 @@ pub async fn ctl_auth_session(
     State(state): State<Arc<DaemonState>>,
     ConnectInfo(peer): ConnectInfo<SocketAddr>,
     Path(id_str): Path<String>,
-) -> Result<Json<CtlAuthResponse>, (StatusCode, String)> {
-    loopback_guard(&peer)?; // #6197
-    let id = parse_id(&id_str);
-    let handle = state
-        .session_registry
-        .get(&id)
-        .await
-        .ok_or_else(|| (StatusCode::NOT_FOUND, format!("session {id_str} not found")))?;
+) -> impl axum::response::IntoResponse {
+    ctl_auth_core(&state, loopback_guard(&peer), &id_str).await // #6288
+}
+
+/// The transport-neutral body of `GET .../control/sessions/{id}/auth` (#6288),
+/// served over the socket as `mpm.control.auth`.
+///
+/// Test: `ctl_auth_session_returns_state`, `ctl_auth_session_not_found`, and
+/// `rpc_ctl_auth_parity` in `daemon::rpc::managed_tests`.
+pub(crate) async fn ctl_auth_core(
+    state: &Arc<DaemonState>,
+    trust: CallerTrust,
+    id_str: &str,
+) -> RouteOutcome {
+    if let Err(refusal) = trust.ensure_local() {
+        return refusal; // #6197
+    }
+    let id = parse_id(id_str);
+    let Some(handle) = state.session_registry.get(&id).await else {
+        return RouteOutcome::text(404, format!("session {id_str} not found"));
+    };
 
     let meta = handle.metadata.read().await;
     let state_label = meta.state.label().to_owned();
     let awaiting_auth = state_label == "awaiting-auth";
-    Ok(Json(CtlAuthResponse {
-        session_id: id_str,
+    RouteOutcome::ok(&CtlAuthResponse {
+        session_id: id_str.to_owned(),
         state: state_label,
         awaiting_auth,
-    }))
+    })
 }
 
 /// List all live SESSCTL sessions, optionally filtered by project.
@@ -571,8 +636,23 @@ pub async fn ctl_list_sessions(
     State(state): State<Arc<DaemonState>>,
     ConnectInfo(peer): ConnectInfo<SocketAddr>,
     Query(query): Query<CtlListQuery>,
-) -> Result<Json<CtlListResponse>, (StatusCode, String)> {
-    loopback_guard(&peer)?; // #6197
+) -> impl axum::response::IntoResponse {
+    ctl_list_core(&state, loopback_guard(&peer), query).await // #6288
+}
+
+/// The transport-neutral body of `GET /api/v1/control/sessions` (#6288), served
+/// over the socket as `mpm.control.list`.
+///
+/// Test: `ctl_list_sessions_returns_empty`, `ctl_list_sessions_full_schema`, and
+/// `rpc_ctl_list_parity` in `daemon::rpc::managed_tests`.
+pub(crate) async fn ctl_list_core(
+    state: &Arc<DaemonState>,
+    trust: CallerTrust,
+    query: CtlListQuery,
+) -> RouteOutcome {
+    if let Err(refusal) = trust.ensure_local() {
+        return refusal; // #6197
+    }
     let ids = state.session_registry.list_ids().await;
     let mut sessions = Vec::with_capacity(ids.len());
     for id in ids {
@@ -604,7 +684,7 @@ pub async fn ctl_list_sessions(
             });
         }
     }
-    Ok(Json(CtlListResponse { sessions }))
+    RouteOutcome::ok(&CtlListResponse { sessions })
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -1247,10 +1327,14 @@ mod tests {
     /// The loopback guard predicate accepts local and refuses remote peers (#6197).
     #[test]
     fn loopback_guard_accepts_loopback_refuses_remote() {
-        assert!(loopback_guard(&loopback_peer()).is_ok());
+        assert!(loopback_guard(&loopback_peer()).is_local());
         let remote = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 5)), 1234);
-        let err = loopback_guard(&remote).expect_err("remote must be refused");
-        assert_eq!(err.0, StatusCode::FORBIDDEN);
+        assert!(!loopback_guard(&remote).is_local());
+        // #6288: the refusal is the shared one both transports answer with.
+        let refusal = loopback_guard(&remote)
+            .ensure_local()
+            .expect_err("remote must be refused");
+        assert_eq!(refusal.status, 403);
     }
 
     /// `validate_claude_cmd` allows only the default and refuses every path or
@@ -1274,7 +1358,7 @@ mod tests {
             "",
         ] {
             let err = validate_claude_cmd(Some(bad)).expect_err("must refuse");
-            assert_eq!(err.0, StatusCode::BAD_REQUEST, "bad claude_cmd: {bad:?}");
+            assert_eq!(err.status, 400, "bad claude_cmd: {bad:?}");
         }
     }
 

--- a/crates/trusty-mpm/src/daemon/error.rs
+++ b/crates/trusty-mpm/src/daemon/error.rs
@@ -52,6 +52,48 @@ pub const CODE_UNPROCESSABLE: i64 = -32006;
 /// HTTP 409 over the socket: the request conflicts with the record's state.
 pub const CODE_CONFLICT: i64 = -32009;
 
+/// A resume refused because the workspace directory is gone (#6288 slice 4).
+///
+/// Why its own code rather than plain [`CODE_UNPROCESSABLE`]: on HTTP the two
+/// 422 resume classes are told apart by an `x-trusty-resume-reason` header, and
+/// they need DIFFERENT operator remedies — a vanished workspace is safe to
+/// `tm session delete --force`, a vanished pane is not, because a live sibling
+/// tmux window may still hold work. The socket has no headers, so the
+/// discriminant becomes the code rather than being dropped or smuggled into the
+/// message. See `managed_routes::resume_error`.
+pub const CODE_WORKSPACE_GONE: i64 = -32023;
+
+/// A resume refused because the recorded tmux pane is gone (#6288 slice 4). See
+/// [`CODE_WORKSPACE_GONE`] for why the two 422 classes carry distinct codes.
+pub const CODE_PANE_GONE: i64 = -32024;
+
+/// The JSON-RPC code an HTTP status projects onto (#6288).
+///
+/// Why: slice 2 wrote this table inside `From<DaemonError> for RpcError`, and
+/// slice 4's route bodies — which report a status without ever building a
+/// [`DaemonError`] — needed the identical mapping. Two copies of it would let
+/// the same status answer two different codes depending on which family served
+/// the route, which is the exact drift the shared-body rule exists to prevent.
+/// Extracting it leaves ONE table with two callers.
+/// What: takes a raw `u16` rather than a `StatusCode` so callers under
+/// `daemon::rpc` can use it without importing an HTTP type — the acceptance bar
+/// for slice 4 is that no HTTP type appears there.
+/// Test: `rpc_error_codes_track_http_statuses`,
+/// `status_to_rpc_code_maps_each_refusal_class`.
+pub fn rpc_code_for_status(status: u16) -> i64 {
+    match status {
+        400 => CODE_INVALID_PARAMS,
+        403 => CODE_FORBIDDEN,
+        404 => CODE_NOT_FOUND,
+        409 => CODE_CONFLICT,
+        422 => CODE_UNPROCESSABLE,
+        503 => CODE_UNAVAILABLE,
+        // Everything left maps to 500, and a caller could not have sent any of
+        // them differently.
+        _ => CODE_INTERNAL_ERROR,
+    }
+}
+
 /// A failure surfaced by a daemon domain service or request handler.
 ///
 /// Why: domain services must report *why* an operation failed without knowing
@@ -279,18 +321,9 @@ impl IntoResponse for DaemonError {
 /// through a real failure.
 impl From<DaemonError> for RpcError {
     fn from(e: DaemonError) -> Self {
-        let code = match e.status() {
-            StatusCode::BAD_REQUEST => CODE_INVALID_PARAMS,
-            StatusCode::NOT_FOUND => CODE_NOT_FOUND,
-            StatusCode::FORBIDDEN => CODE_FORBIDDEN,
-            StatusCode::CONFLICT => CODE_CONFLICT,
-            StatusCode::UNPROCESSABLE_ENTITY => CODE_UNPROCESSABLE,
-            StatusCode::SERVICE_UNAVAILABLE => CODE_UNAVAILABLE,
-            // Everything left maps to 500, and a caller could not have sent any
-            // of them differently.
-            _ => CODE_INTERNAL_ERROR,
-        };
-        RpcError::new(code, e.to_string())
+        // #6288 slice 4: the table moved to `rpc_code_for_status` so the route
+        // bodies that report a status without building a `DaemonError` share it.
+        RpcError::new(rpc_code_for_status(e.status().as_u16()), e.to_string())
     }
 }
 

--- a/crates/trusty-mpm/src/daemon/managed_routes/activity.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/activity.rs
@@ -10,14 +10,13 @@
 use std::sync::Arc;
 
 use axum::{
-    Json,
     extract::{Path as AxumPath, State},
-    http::StatusCode,
     response::IntoResponse,
 };
 use serde::Serialize;
 use tracing::warn;
 
+use crate::daemon::rpc::managed::outcome::RouteOutcome;
 use crate::daemon::state::DaemonState;
 
 use super::parse_id;
@@ -110,16 +109,22 @@ pub async fn get_session_activity(
     State(state): State<Arc<DaemonState>>,
     AxumPath(id_str): AxumPath<String>,
 ) -> impl IntoResponse {
-    let id = match parse_id(&id_str) {
+    activity_core(&state, &id_str).await // #6288
+}
+
+/// The transport-neutral body of `GET .../{id}/activity` (#6288), served over
+/// the socket as `mpm.managed.activity`.
+///
+/// Test: `managed_activity_parity` in `daemon::rpc::managed_tests`.
+pub(crate) async fn activity_core(state: &Arc<DaemonState>, id_str: &str) -> RouteOutcome {
+    let id = match parse_id(id_str) {
         Ok(id) => id,
-        Err((code, msg)) => return (code, msg).into_response(),
+        Err((code, msg)) => return RouteOutcome::text(code.as_u16(), msg),
     };
     let mgr = state.session_manager().await;
     let record = match mgr.get(&id).await {
         Ok(r) => r,
-        Err(_) => {
-            return (StatusCode::NOT_FOUND, format!("session {id_str} not found")).into_response();
-        }
+        Err(_) => return RouteOutcome::text(404, format!("session {id_str} not found")),
     };
 
     // Capture the last 60 pane lines — always available, no LLM key required.
@@ -165,15 +170,11 @@ pub async fn get_session_activity(
     // `MissingApiKey` to an `Unknown` verdict non-erroring — the raw pane is
     // always available regardless of whether a key is configured.
     let monitor = state.activity_monitor();
-    let result = match monitor.check(&id_str, &raw_pane).await {
+    let result = match monitor.check(id_str, &raw_pane).await {
         Ok(r) => r,
         Err(e) => {
             warn!(session = %id_str, "activity check error (non-key): {e}");
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("activity check failed: {e}"),
-            )
-                .into_response();
+            return RouteOutcome::text(500, format!("activity check failed: {e}"));
         }
     };
 
@@ -184,7 +185,7 @@ pub async fn get_session_activity(
         None
     };
 
-    Json(ActivityResponse {
+    RouteOutcome::ok(&ActivityResponse {
         raw_pane,
         runtime_active,
         pane_stale,
@@ -201,5 +202,4 @@ pub async fn get_session_activity(
         pending_decision: record.pending_decision,
         proposed_default: record.proposed_default,
     })
-    .into_response()
 }

--- a/crates/trusty-mpm/src/daemon/managed_routes/cores.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/cores.rs
@@ -403,8 +403,8 @@ pub(crate) async fn decommission_core(
 /// What: maps [`CODE_WORKSPACE_GONE`] → `workspace_missing` and
 /// [`CODE_PANE_GONE`] → `pane_gone`; every other outcome passes through
 /// untouched.
-/// Test: `resume_http_still_tags_the_reason_header` in
-/// `daemon::rpc::managed_tests`.
+/// Test: `resume_http_response_restores_the_reason_header_from_the_rpc_code`
+/// in this module's `cores_tests`.
 pub(crate) fn resume_http_response(outcome: RouteOutcome) -> axum::response::Response {
     let reason = match outcome.rpc_code {
         Some(CODE_WORKSPACE_GONE) => Some("workspace_missing"),

--- a/crates/trusty-mpm/src/daemon/managed_routes/cores.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/cores.rs
@@ -1,0 +1,466 @@
+//! The transport-neutral bodies of the managed-session routes (#6288 slice 4).
+//!
+//! Why: each of these routes is served over BOTH axum and the daemon's Unix
+//! socket, and the bar is one implementation rather than two that drift. The
+//! bodies moved here verbatim from `mod.rs`'s handlers; what stayed there is a
+//! wrapper that supplies the axum extractors. Moving them also kept `mod.rs`
+//! under its 500-SLOC cap, which it was six lines away from.
+//!
+//! What: one `*_core` per route, each returning a [`RouteOutcome`]. Behaviour is
+//! unchanged from the pre-slice handlers — the same branches, the same statuses,
+//! the same message strings.
+//!
+//! Test: every pre-existing handler test in `tests/session_manager_mvp.rs` and
+//! `managed_routes::tests` now runs through these bodies; the socket half is
+//! `daemon::rpc::managed_tests`.
+
+use std::sync::Arc;
+
+use tracing::warn;
+
+use super::route_outcome_http::outcome_from_response;
+use super::*;
+use crate::daemon::rpc::managed::outcome::{CODE_PANE_GONE, CODE_WORKSPACE_GONE, RouteOutcome};
+
+/// Parse a managed-session id, or the 400 the HTTP route answers with.
+fn parse_id_neutral(id_str: &str) -> Result<ManagedSessionId, RouteOutcome> {
+    parse_id(id_str).map_err(|(code, msg)| RouteOutcome::text(code.as_u16(), msg))
+}
+
+/// The 404 body every id-addressed route in this module shares.
+fn not_found(id_str: &str) -> RouteOutcome {
+    RouteOutcome::text(404, format!("session {id_str} not found"))
+}
+
+/// `POST /api/v1/sessions/managed` — see [`super::spawn_session`].
+pub(crate) async fn spawn_core(state: &Arc<DaemonState>, req: SpawnRequest) -> RouteOutcome {
+    // Reject an invalid runtime selector up front with a 400 (the shared
+    // `spawn_managed` helper also rejects it, but doing it here keeps the
+    // 400-vs-500 distinction existing clients rely on).
+    if let Some(raw) = req.runtime.as_deref()
+        && let Err(e) = raw.parse::<RuntimeKind>()
+    {
+        warn!("spawn_session: invalid runtime selector: {e}");
+        return RouteOutcome::text(400, e.to_string());
+    }
+
+    // Deliverable linkage (DOC-35 §10.6, #2379): validate BEFORE any
+    // provisioning side effect, mirroring the runtime-selector pre-check
+    // above — an invalid `--deliverable` must never mint infrastructure for a
+    // link that was never going to be recorded.
+    if let Some(deliverable_id) = req.deliverable_id.as_deref()
+        && let Err(resp) =
+            deliverable_link::validate_deliverable_scope(state, &req.repo_url, deliverable_id).await
+    {
+        return outcome_from_response(resp).await;
+    }
+
+    let params = SpawnParams {
+        repo_url: req.repo_url,
+        git_ref: req.git_ref,
+        task: req.task,
+        name_hint: req.name_hint,
+        runtime: req.runtime,
+        ephemeral: req.ephemeral,
+        // A client call (`tm launch`/`tm ticket`) — never subject to the MCP
+        // spawn gate (#1836/#1837).
+        mcp_initiated: false,
+        // Turnkey by default (#1903/#1299); a client sets `inject_task: false`
+        // to opt into the legacy metadata-only behavior (`--no-inject`).
+        inject_task: req.inject_task,
+        deliverable_id: req.deliverable_id,
+        // Force-new opt-out (#2450): a client (the picker's "launch new
+        // session", `tm session new`) sets `force_new: true` to skip the
+        // in-project reconnect pre-flight and always spawn fresh.
+        force_new: req.force_new,
+        // #5274: the explicit "give this session its own worktree" request.
+        worktree: req.worktree,
+    };
+
+    // Async path (#2605): provision on a detached task and return the job id
+    // immediately, so a large-repo clone never outlasts the client's timeout
+    // and the blocking provision runs OFF the request path.
+    if req.background {
+        return provision_status::accept_async_spawn(Arc::clone(state), params);
+    }
+
+    match spawn_managed(state, ManagedSessionId::new(), params).await {
+        Ok(final_record) => {
+            let resp = SpawnResponse {
+                id: final_record.id.to_string(),
+                name: final_record.tmux_name.clone(),
+                workspace_path: final_record
+                    .workspace_path
+                    .as_ref()
+                    .map(|p| p.to_string_lossy().to_string()),
+                repo_url: final_record.repo_url.clone(),
+                branch: final_record.branch.clone(),
+                state: final_record.state.to_string(),
+                created_at: final_record.created_at.to_rfc3339(),
+                attach_cmd: attach_cmd_for(&final_record.tmux_name),
+                runtime: final_record.runtime.as_str().to_owned(),
+                deliverable_id: final_record.deliverable_id.map(|id| id.to_string()),
+            };
+            RouteOutcome::created(&resp)
+        }
+        Err(e) => RouteOutcome::text(500, e),
+    }
+}
+
+/// `POST /api/v1/sessions/managed/adopt` — see [`super::adopt_existing_session`].
+pub(crate) async fn adopt_core(
+    state: &Arc<DaemonState>,
+    req: AdoptExistingRequest,
+) -> RouteOutcome {
+    // Resolve the runtime selector up front so a typo is a 400, not a 500.
+    let runtime = match req.runtime.as_deref() {
+        None => RuntimeKind::default(),
+        Some(raw) => match raw.parse::<RuntimeKind>() {
+            Ok(rk) => rk,
+            Err(e) => {
+                warn!("adopt_existing: invalid runtime selector: {e}");
+                return RouteOutcome::text(400, e.to_string());
+            }
+        },
+    };
+
+    let task = req.task.unwrap_or_default();
+    let cwd = std::path::PathBuf::from(&req.cwd);
+
+    let mgr = state.session_manager().await;
+    match mgr
+        .adopt_existing(
+            &req.tmux_name,
+            cwd,
+            task,
+            runtime,
+            req.ephemeral.unwrap_or(false),
+        )
+        .await
+    {
+        Ok(record) => RouteOutcome::created(&AdoptExistingResponse {
+            id: record.id.to_string(),
+            name: record.tmux_name.clone(),
+            state: record.state.to_string(),
+            cwd: record.cwd.to_string_lossy().to_string(),
+            runtime: record.runtime.as_str().to_owned(),
+            attach_cmd: attach_cmd_for(&record.tmux_name),
+        }),
+        Err(crate::session_manager::ManagedError::TmuxSessionMissing(msg)) => {
+            RouteOutcome::text(404, msg)
+        }
+        Err(crate::session_manager::ManagedError::AlreadyAdopted(msg)) => {
+            RouteOutcome::text(409, msg)
+        }
+        Err(e) => RouteOutcome::text(500, e.to_string()),
+    }
+}
+
+/// `GET /api/v1/sessions/managed` — see [`super::list_managed_sessions`].
+pub(crate) async fn list_core(
+    state: &Arc<DaemonState>,
+    source_id: Option<&str>,
+    slim: bool,
+) -> RouteOutcome {
+    let mgr = state.session_manager().await;
+    // #3034: numbering is observed against the FULL, unfiltered record set
+    // BEFORE the `source_id` filter is applied — otherwise a session outside
+    // the current filter would go unobserved and receive a fresh number the
+    // next time it IS listed.
+    let all_records = mgr.list().await;
+    let numbered = mgr.numbered_snapshot(&all_records).await;
+    let sessions = numbered_summaries(numbered, mgr.tmux.as_ref(), source_id, !slim).await;
+    // #5007: if `mgr.list()` just served its last-known in-memory set because
+    // the store could not be read, say so in the same response.
+    let store_health = mgr.store_health().await.map(|d| StoreHealthPayload {
+        message: d.message,
+        corrupt: d.corrupt,
+        observed_at: d.observed_at.to_rfc3339(),
+    });
+    RouteOutcome::ok(&ListSessionsResponse {
+        sessions,
+        store_health,
+    })
+}
+
+/// `GET /api/v1/sessions/managed/{id}` — see [`super::get_managed_session`].
+pub(crate) async fn get_core(state: &Arc<DaemonState>, id_str: &str) -> RouteOutcome {
+    let id = match parse_id_neutral(id_str) {
+        Ok(id) => id,
+        Err(refusal) => return refusal,
+    };
+    let mgr = state.session_manager().await;
+    match mgr.get(&id).await {
+        Ok(record) => {
+            // Reconcile against live tmux like the list body — this is the
+            // record `tm session resume <id>` reads, and its resume decision
+            // keys off `state`; serving a stale `stopped` for a live session
+            // would let resume destructively recreate the pane.
+            let mut summary = record_to_summary_checked(&record).await;
+            reconcile_against_tmux(
+                mgr.tmux.as_ref(),
+                std::slice::from_mut(&mut summary),
+                std::slice::from_ref(&record),
+            );
+            RouteOutcome::ok(&summary)
+        }
+        Err(_) => not_found(id_str),
+    }
+}
+
+/// `POST /api/v1/sessions/managed/{id}/send` — see [`super::send_to_session`].
+pub(crate) async fn send_core(
+    state: &Arc<DaemonState>,
+    id_str: &str,
+    req: SendInputRequest,
+) -> RouteOutcome {
+    let id = match parse_id_neutral(id_str) {
+        Ok(id) => id,
+        Err(refusal) => return refusal,
+    };
+    let mgr = state.session_manager().await;
+    let tmux_name = match mgr.get(&id).await {
+        Ok(r) => r.tmux_name,
+        Err(_) => return not_found(id_str),
+    };
+    match mgr.send_input(&id, &req.text).await {
+        Ok(()) => RouteOutcome::ok(&SendInputResponse {
+            sent: true,
+            tmux_name,
+        }),
+        Err(e) => RouteOutcome::text(500, e.to_string()),
+    }
+}
+
+/// `POST /api/v1/sessions/managed/{id}/answer` — see
+/// [`super::answer_session_decision`].
+pub(crate) async fn answer_core(
+    state: &Arc<DaemonState>,
+    id_str: &str,
+    req: AnswerRequest,
+) -> RouteOutcome {
+    let id = match parse_id_neutral(id_str) {
+        Ok(id) => id,
+        Err(refusal) => return refusal,
+    };
+    let mgr = state.session_manager().await;
+    let record = match mgr.get(&id).await {
+        Ok(r) => r,
+        Err(_) => return not_found(id_str),
+    };
+    let tmux_name = record.tmux_name.clone();
+
+    // FRONT-gate (#1360) path: a session escalated *before* spawn sits in
+    // `Provisioning` with a `pending_decision` and NO running harness.
+    // Answering it must clear the decision AND launch the withheld runtime
+    // (AC-15) — not inject the answer into a bare pane.
+    let is_front_gate_escalation = record.state
+        == crate::session_manager::ManagedSessionState::Provisioning
+        && record.pending_decision.is_some();
+
+    if is_front_gate_escalation {
+        if let Err(e) = mgr.clear_pending_decision(&id).await {
+            return RouteOutcome::text(500, e.to_string());
+        }
+        // Re-fetch AFTER clearing: `clear_pending_decision` upserts a new
+        // record version, so the `record` captured above is now stale.
+        let fresh = match mgr.get(&id).await {
+            Ok(r) => r,
+            Err(_) => return not_found(id_str),
+        };
+        match spawn_runtime_for(state, &fresh).await {
+            Ok(()) => RouteOutcome::ok(&AnswerResponse {
+                injected: true,
+                tmux_name,
+            }),
+            Err(e) => RouteOutcome::text(500, e),
+        }
+    } else {
+        match mgr.answer_decision(&id, &req.answer).await {
+            Ok(()) => RouteOutcome::ok(&AnswerResponse {
+                injected: true,
+                tmux_name,
+            }),
+            Err(e) => RouteOutcome::text(500, e.to_string()),
+        }
+    }
+}
+
+/// `GET /api/v1/sessions/managed/{id}/attach-cmd` — see
+/// [`super::get_attach_cmd`].
+pub(crate) async fn attach_cmd_core(state: &Arc<DaemonState>, id_str: &str) -> RouteOutcome {
+    let id = match parse_id_neutral(id_str) {
+        Ok(id) => id,
+        Err(refusal) => return refusal,
+    };
+    let mgr = state.session_manager().await;
+    match mgr.get(&id).await {
+        Ok(record) => RouteOutcome::ok(&AttachCmdResponse {
+            attach_cmd: attach_cmd_for(&record.tmux_name),
+        }),
+        Err(_) => not_found(id_str),
+    }
+}
+
+/// `POST /api/v1/sessions/managed/{id}/runtime-stop` — see
+/// [`super::stop_managed_session_runtime`].
+pub(crate) async fn runtime_stop_core(state: &Arc<DaemonState>, id_str: &str) -> RouteOutcome {
+    let id = match parse_id_neutral(id_str) {
+        Ok(id) => id,
+        Err(refusal) => return refusal,
+    };
+    let mgr = state.session_manager().await;
+    match mgr.stop(&id).await {
+        Ok(record) => RouteOutcome::ok(&record_to_summary(&record)),
+        Err(_) => not_found(id_str),
+    }
+}
+
+/// `POST /api/v1/sessions/managed/{id}/resume` — see
+/// [`super::resume_managed_session`].
+///
+/// The two 422 refusals ([`ResumeManagedError::WorkspaceGone`],
+/// [`ResumeManagedError::PaneGone`]) carry a distinct RPC code each, because on
+/// HTTP they are told apart by the `x-trusty-resume-reason` header and the
+/// socket has no headers (#6288). The HTTP wrapper re-attaches that header from
+/// the same code, so neither transport loses the discriminant.
+pub(crate) async fn resume_core(state: &Arc<DaemonState>, id_str: &str) -> RouteOutcome {
+    let id = match parse_id_neutral(id_str) {
+        Ok(id) => id,
+        Err(refusal) => return refusal,
+    };
+    // Single round-trip: `resume_managed` performs the existence + state check
+    // inside `SessionManager::resume` and re-spawns the runtime. No pre-flight
+    // `get` (which introduced a TOCTOU race) and no `Display`-substring match.
+    match resume_managed(state, &id).await {
+        Ok(final_record) => RouteOutcome::ok(&record_to_summary(&final_record)),
+        Err(ResumeManagedError::NotFound(id)) => {
+            RouteOutcome::text(404, format!("session {id} not found"))
+        }
+        Err(ResumeManagedError::InvalidState(reason)) => RouteOutcome::text(409, reason),
+        Err(ResumeManagedError::WorkspaceGone(msg)) => {
+            RouteOutcome::text(422, msg).with_rpc_code(CODE_WORKSPACE_GONE)
+        }
+        Err(ResumeManagedError::PaneGone(msg)) => {
+            RouteOutcome::text(422, msg).with_rpc_code(CODE_PANE_GONE)
+        }
+        Err(ResumeManagedError::Other(msg)) => RouteOutcome::text(500, msg),
+    }
+}
+
+/// `POST /api/v1/sessions/managed/{id}/decommission` — see
+/// [`super::decommission_managed_session`].
+pub(crate) async fn decommission_core(
+    state: &Arc<DaemonState>,
+    id_str: &str,
+    record_only: bool,
+) -> RouteOutcome {
+    let id = match parse_id_neutral(id_str) {
+        Ok(id) => id,
+        Err(refusal) => return refusal,
+    };
+    let mgr = state.session_manager().await;
+    // Pre-fetch the record to obtain the workspace_path BEFORE the tombstone
+    // clears it. `decommission` returns `workspace_removed` directly;
+    // `workspace_path_was` for the CLI's `git worktree prune` hint must still
+    // be captured here since the tombstone nulls it out.
+    let pre = mgr.get(&id).await.ok();
+    let pre_owned = pre.as_ref().map(|r| r.workspace_owned).unwrap_or(false);
+    let pre_ws = pre.and_then(|r| r.workspace_path);
+    let outcome = if record_only {
+        mgr.decommission_record_only(&id).await
+    } else {
+        mgr.decommission(&id, None).await
+    };
+    match outcome {
+        Ok((record, workspace_removed)) => {
+            // workspace_path_was: only meaningful for owned sessions.
+            let workspace_path_was = if pre_owned {
+                pre_ws.map(|p| p.to_string_lossy().into_owned())
+            } else {
+                None
+            };
+            RouteOutcome::ok(&DecommissionResponse {
+                summary: record_to_summary(&record),
+                workspace_removed,
+                workspace_path_was,
+            })
+        }
+        Err(crate::session_manager::ManagedError::SessionNotFound(_)) => not_found(id_str),
+        Err(e) => RouteOutcome::text(500, e.to_string()),
+    }
+}
+
+/// Re-attach the `x-trusty-resume-reason` header a 422 resume refusal carries
+/// on HTTP (#6288).
+///
+/// Why: the header is the CLI's machine-readable discriminant between "the
+/// workspace is gone" (safe to `tm session delete --force`) and "the pane is
+/// gone" (a live sibling window may still exist, so teardown is dangerous).
+/// [`resume_core`] records that same distinction as an RPC code, which is what
+/// the socket carries; this reads the code back and restores the header, so the
+/// HTTP contract is byte-identical to what it was before the extraction.
+/// What: maps [`CODE_WORKSPACE_GONE`] → `workspace_missing` and
+/// [`CODE_PANE_GONE`] → `pane_gone`; every other outcome passes through
+/// untouched.
+/// Test: `resume_http_still_tags_the_reason_header` in
+/// `daemon::rpc::managed_tests`.
+pub(crate) fn resume_http_response(outcome: RouteOutcome) -> axum::response::Response {
+    let reason = match outcome.rpc_code {
+        Some(CODE_WORKSPACE_GONE) => Some("workspace_missing"),
+        Some(CODE_PANE_GONE) => Some("pane_gone"),
+        _ => None,
+    };
+    let mut resp = axum::response::IntoResponse::into_response(outcome);
+    if let Some(reason) = reason {
+        resp.headers_mut().insert(
+            axum::http::HeaderName::from_static("x-trusty-resume-reason"),
+            axum::http::HeaderValue::from_static(reason),
+        );
+    }
+    resp
+}
+
+#[cfg(test)]
+mod cores_tests {
+    use super::*;
+    use crate::daemon::rpc::managed::outcome::status_to_rpc_code;
+
+    /// A 422 resume refusal keeps BOTH discriminants: the RPC code the socket
+    /// reads, and the HTTP header the CLI reads (#6288, #2577).
+    #[test]
+    fn resume_http_response_restores_the_reason_header_from_the_rpc_code() {
+        for (code, expected) in [
+            (CODE_WORKSPACE_GONE, "workspace_missing"),
+            (CODE_PANE_GONE, "pane_gone"),
+        ] {
+            let resp = resume_http_response(RouteOutcome::text(422, "gone").with_rpc_code(code));
+            assert_eq!(resp.status().as_u16(), 422);
+            assert_eq!(
+                resp.headers()
+                    .get("x-trusty-resume-reason")
+                    .and_then(|v| v.to_str().ok()),
+                Some(expected)
+            );
+        }
+    }
+
+    /// Every other resume outcome is header-free, exactly as before.
+    #[test]
+    fn resume_http_response_adds_no_header_to_an_ordinary_refusal() {
+        let resp = resume_http_response(RouteOutcome::text(404, "session x not found"));
+        assert_eq!(resp.status().as_u16(), 404);
+        assert!(resp.headers().get("x-trusty-resume-reason").is_none());
+    }
+
+    /// The neutral id parser answers the SAME 400 the HTTP route answered.
+    #[test]
+    fn an_unparseable_id_is_a_400_on_both_transports() {
+        let refusal = parse_id_neutral("not-a-uuid").expect_err("must refuse");
+        assert_eq!(refusal.status, 400);
+        assert_eq!(
+            status_to_rpc_code(refusal.status),
+            trusty_common::uds::server::CODE_INVALID_PARAMS
+        );
+    }
+}

--- a/crates/trusty-mpm/src/daemon/managed_routes/delete.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/delete.rs
@@ -15,15 +15,14 @@
 use std::sync::Arc;
 
 use axum::{
-    Json,
     extract::{Path as AxumPath, State},
-    http::StatusCode,
     response::IntoResponse,
 };
 
 use super::{
     DeleteQuery, DeleteResponse, parse_id, record_to_summary, stop_managed_session_runtime,
 };
+use crate::daemon::rpc::managed::outcome::RouteOutcome;
 use crate::daemon::state::DaemonState;
 
 /// POST /api/v1/sessions/managed/{id}/delete — soft-delete the RECORD, mark `--deleted--` (#2012).
@@ -47,24 +46,39 @@ pub async fn delete_managed_session(
     AxumPath(id_str): AxumPath<String>,
     axum::extract::Query(q): axum::extract::Query<DeleteQuery>,
 ) -> impl IntoResponse {
-    let id = match parse_id(&id_str) {
+    delete_core(&state, &id_str, q.force).await // #6288
+}
+
+/// The transport-neutral body of `POST .../{id}/delete` (#6288), served over
+/// the socket as `mpm.managed.delete`.
+///
+/// Test: `managed_delete_parity` (the missing-id refusal),
+/// `managed_delete_refuses_a_running_session_without_force` and
+/// `managed_delete_force_bypasses_the_running_guard_on_both_transports` (the
+/// `force` flag, decoded from a real JSON-RPC frame) — all in
+/// `daemon::rpc::managed_tests`.
+pub(crate) async fn delete_core(
+    state: &Arc<DaemonState>,
+    id_str: &str,
+    force: bool,
+) -> RouteOutcome {
+    let id = match parse_id(id_str) {
         Ok(id) => id,
-        Err((code, msg)) => return (code, msg).into_response(),
+        Err((code, msg)) => return RouteOutcome::text(code.as_u16(), msg),
     };
     let mgr = state.session_manager().await;
-    match mgr.delete_record(&id, q.force).await {
-        Ok(record) => Json(DeleteResponse {
+    match mgr.delete_record(&id, force).await {
+        Ok(record) => RouteOutcome::ok(&DeleteResponse {
             summary: record_to_summary(&record),
             deleted: true,
-        })
-        .into_response(),
+        }),
         Err(crate::session_manager::ManagedError::SessionNotFound(_)) => {
-            (StatusCode::NOT_FOUND, format!("session {id_str} not found")).into_response()
+            RouteOutcome::text(404, format!("session {id_str} not found"))
         }
         Err(crate::session_manager::ManagedError::InvalidState(_, reason)) => {
-            (StatusCode::CONFLICT, reason).into_response()
+            RouteOutcome::text(409, reason)
         }
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+        Err(e) => RouteOutcome::text(500, e.to_string()),
     }
 }
 

--- a/crates/trusty-mpm/src/daemon/managed_routes/fleet.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/fleet.rs
@@ -9,10 +9,11 @@
 
 use std::sync::Arc;
 
-use axum::{Json, extract::State, response::IntoResponse};
+use axum::{extract::State, response::IntoResponse};
 use serde::Serialize;
 use tracing::warn;
 
+use crate::daemon::rpc::managed::outcome::RouteOutcome;
 use crate::daemon::state::DaemonState;
 use crate::session_manager::SessionRecord;
 
@@ -63,6 +64,14 @@ pub struct FleetByProjectResponse {
 /// Test: `fleet_route_groups_by_project` in `tests/session_manager_mvp.rs`;
 /// `fleet_route_marks_dead_session_unresumable` in the same file (#2595).
 pub async fn fleet_by_project_route(State(state): State<Arc<DaemonState>>) -> impl IntoResponse {
+    fleet_core(&state).await // #6288
+}
+
+/// The transport-neutral body of `GET .../managed/fleet` (#6288), served over
+/// the socket as `mpm.managed.fleet`.
+///
+/// Test: `managed_fleet_parity` in `daemon::rpc::managed_tests`.
+pub(crate) async fn fleet_core(state: &Arc<DaemonState>) -> RouteOutcome {
     let mgr = state.session_manager().await;
     let registry = state.project_registry().await;
 
@@ -94,7 +103,7 @@ pub async fn fleet_by_project_route(State(state): State<Arc<DaemonState>>) -> im
         });
     }
 
-    Json(FleetByProjectResponse {
+    RouteOutcome::ok(&FleetByProjectResponse {
         projects: project_groups,
     })
 }

--- a/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
@@ -16,21 +16,20 @@ use std::sync::Arc;
 use axum::{
     Json,
     extract::{Path as AxumPath, State},
-    http::StatusCode,
     response::IntoResponse,
 };
 use serde::{Deserialize, Serialize};
-use tracing::warn;
 
 use crate::daemon::state::DaemonState;
 use crate::runtime::RuntimeKind;
 use crate::session_manager::ManagedSessionId;
 
 pub mod activity;
-mod delete;
+pub(crate) mod cores;
+pub mod delete;
 mod deliverable_link;
 mod deployment_check;
-mod fleet;
+pub mod fleet;
 mod foreign_harness;
 pub mod front_gate;
 pub mod inproject;
@@ -46,10 +45,11 @@ mod project_status;
 pub mod provision_status;
 pub mod proxy;
 pub mod prune;
-mod reactivate;
+pub mod reactivate;
 pub mod reconcile;
 pub mod rename;
 mod resume_error;
+pub(crate) mod route_outcome_http;
 mod session_prep;
 mod session_summary;
 mod summary;
@@ -81,7 +81,7 @@ pub use prune::{
     EphemeralQuery, PruneRequest, decommission_ephemeral_route, prune_managed_route,
     prune_worktrees_route,
 };
-pub use reactivate::reactivate_managed_session;
+pub use reactivate::{ReactivateQuery, reactivate_managed_session};
 pub use rename::{RenameRequest, rename_managed_session};
 pub use resume_error::ResumeManagedError;
 pub use session_summary::SessionSummary;
@@ -461,82 +461,8 @@ pub async fn spawn_session(
     State(state): State<Arc<DaemonState>>,
     Json(req): Json<SpawnRequest>,
 ) -> impl IntoResponse {
-    // Reject an invalid runtime selector up front with a 400 (the shared
-    // `spawn_managed` helper also rejects it, but doing it here lets us keep the
-    // HTTP-specific 400-vs-500 status distinction that existing clients rely on).
-    if let Some(raw) = req.runtime.as_deref()
-        && let Err(e) = raw.parse::<RuntimeKind>()
-    {
-        warn!("spawn_session: invalid runtime selector: {e}");
-        return (StatusCode::BAD_REQUEST, e.to_string()).into_response();
-    }
-
-    // Deliverable linkage (DOC-35 §10.6, #2379): validate BEFORE any
-    // provisioning side effect, mirroring the runtime-selector pre-check
-    // above — an invalid `--deliverable` must never mint infrastructure for a
-    // link that was never going to be recorded.
-    if let Some(deliverable_id) = req.deliverable_id.as_deref()
-        && let Err(resp) =
-            deliverable_link::validate_deliverable_scope(&state, &req.repo_url, deliverable_id)
-                .await
-    {
-        return resp;
-    }
-
-    let params = SpawnParams {
-        repo_url: req.repo_url,
-        git_ref: req.git_ref,
-        task: req.task,
-        name_hint: req.name_hint,
-        runtime: req.runtime,
-        ephemeral: req.ephemeral,
-        // HTTP route == CLI-origin (`tm launch`/`tm ticket` client calls) —
-        // never subject to the MCP spawn gate (#1836/#1837).
-        mcp_initiated: false,
-        // Turnkey by default (#1903/#1299); a client sets `inject_task: false`
-        // to opt into the legacy metadata-only behavior (`--no-inject`).
-        inject_task: req.inject_task,
-        deliverable_id: req.deliverable_id,
-        // Force-new opt-out (#2450): a client (the picker's "launch new
-        // session", `tm session new`) sets `force_new: true` to skip the
-        // in-project reconnect pre-flight and always spawn fresh.
-        force_new: req.force_new,
-        // #5274: the explicit "give this session its own worktree" request. Only
-        // a human-driven surface sets it (`tm launch --worktree`); absent, the
-        // session runs in the project's main checkout.
-        worktree: req.worktree,
-    };
-
-    // Async path (#2605): provision on a detached task and return the job id
-    // immediately, so a large-repo clone never outlasts the client's HTTP
-    // timeout and the blocking provision runs OFF the request path. The runtime
-    // and deliverable validations above already ran synchronously, so an
-    // invalid request is still a fast 400/404 (never a deferred failure).
-    if req.background {
-        return provision_status::accept_async_spawn(state.clone(), params);
-    }
-
-    match spawn_managed(&state, ManagedSessionId::new(), params).await {
-        Ok(final_record) => {
-            let resp = SpawnResponse {
-                id: final_record.id.to_string(),
-                name: final_record.tmux_name.clone(),
-                workspace_path: final_record
-                    .workspace_path
-                    .as_ref()
-                    .map(|p| p.to_string_lossy().to_string()),
-                repo_url: final_record.repo_url.clone(),
-                branch: final_record.branch.clone(),
-                state: final_record.state.to_string(),
-                created_at: final_record.created_at.to_rfc3339(),
-                attach_cmd: attach_cmd_for(&final_record.tmux_name),
-                runtime: final_record.runtime.as_str().to_owned(),
-                deliverable_id: final_record.deliverable_id.map(|id| id.to_string()),
-            };
-            (StatusCode::CREATED, Json(resp)).into_response()
-        }
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e).into_response(),
-    }
+    // #6288: the body lives in `cores::spawn_core` so the socket serves it too.
+    cores::spawn_core(&state, req).await
 }
 
 /// POST /api/v1/sessions/managed/adopt — adopt an EXISTING tmux session (#1433).
@@ -558,51 +484,7 @@ pub async fn adopt_existing_session(
     State(state): State<Arc<DaemonState>>,
     Json(req): Json<AdoptExistingRequest>,
 ) -> impl IntoResponse {
-    // Resolve the runtime selector up front so a typo is a 400, not a 500.
-    let runtime = match req.runtime.as_deref() {
-        None => RuntimeKind::default(),
-        Some(raw) => match raw.parse::<RuntimeKind>() {
-            Ok(rk) => rk,
-            Err(e) => {
-                warn!("adopt_existing: invalid runtime selector: {e}");
-                return (StatusCode::BAD_REQUEST, e.to_string()).into_response();
-            }
-        },
-    };
-
-    let task = req.task.unwrap_or_default();
-    let cwd = std::path::PathBuf::from(&req.cwd);
-
-    let mgr = state.session_manager().await;
-    match mgr
-        .adopt_existing(
-            &req.tmux_name,
-            cwd,
-            task,
-            runtime,
-            req.ephemeral.unwrap_or(false),
-        )
-        .await
-    {
-        Ok(record) => {
-            let resp = AdoptExistingResponse {
-                id: record.id.to_string(),
-                name: record.tmux_name.clone(),
-                state: record.state.to_string(),
-                cwd: record.cwd.to_string_lossy().to_string(),
-                runtime: record.runtime.as_str().to_owned(),
-                attach_cmd: attach_cmd_for(&record.tmux_name),
-            };
-            (StatusCode::CREATED, Json(resp)).into_response()
-        }
-        Err(crate::session_manager::ManagedError::TmuxSessionMissing(msg)) => {
-            (StatusCode::NOT_FOUND, msg).into_response()
-        }
-        Err(crate::session_manager::ManagedError::AlreadyAdopted(msg)) => {
-            (StatusCode::CONFLICT, msg).into_response()
-        }
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
-    }
+    cores::adopt_core(&state, req).await // #6288
 }
 
 /// GET /api/v1/sessions/managed — list all managed sessions.
@@ -645,35 +527,11 @@ pub async fn list_managed_sessions(
     State(state): State<Arc<DaemonState>>,
     axum::extract::Query(q): axum::extract::Query<std::collections::HashMap<String, String>>,
 ) -> impl IntoResponse {
-    let mgr = state.session_manager().await;
-    let sid_filter = q.get("source_id").map(String::as_str);
-    // #3034: numbering is observed against the FULL, unfiltered record set
-    // BEFORE the `source_id` filter is applied — otherwise a session outside
-    // the current filter would go unobserved and receive a fresh number the
-    // next time it IS listed. `numbered_summaries` applies the `source_id`
-    // filter, the async unresumable/stale-assets probes, AND the live-tmux
-    // `state`/`attached` reconciliation (#3302/#3531 — a running/attached
-    // session must never read `(stopped)`) to the surviving rows, fail-closed
-    // on a tmux probe error (see `reconcile_against_tmux`).
     // #4335: `?slim=true` opts OUT of the expensive per-session `stale_assets`
-    // probe for callers that never read the flag (the nested-session guard).
-    // Absent/malformed → the full probe, so no existing client changes shape.
+    // probe. Absent/malformed keeps the full probe, so no existing client
+    // changes shape. #6288: the body itself lives in `cores::list_core`.
     let slim = q.get("slim").is_some_and(|v| v == "true" || v == "1");
-    let all_records = mgr.list().await;
-    let numbered = mgr.numbered_snapshot(&all_records).await;
-    let sessions = numbered_summaries(numbered, mgr.tmux.as_ref(), sid_filter, !slim).await;
-    // #5007: if `mgr.list()` just served its last-known in-memory set because
-    // the store could not be read, say so in the same response. Absent on a
-    // healthy store, so the wire shape is unchanged for every normal listing.
-    let store_health = mgr.store_health().await.map(|d| StoreHealthPayload {
-        message: d.message,
-        corrupt: d.corrupt,
-        observed_at: d.observed_at.to_rfc3339(),
-    });
-    Json(ListSessionsResponse {
-        sessions,
-        store_health,
-    })
+    cores::list_core(&state, q.get("source_id").map(String::as_str), slim).await
 }
 
 /// GET /api/v1/sessions/managed/{id} — get one session record.
@@ -689,27 +547,7 @@ pub async fn get_managed_session(
     State(state): State<Arc<DaemonState>>,
     AxumPath(id_str): AxumPath<String>,
 ) -> impl IntoResponse {
-    let id = match parse_id(&id_str) {
-        Ok(id) => id,
-        Err((code, msg)) => return (code, msg).into_response(),
-    };
-    let mgr = state.session_manager().await;
-    match mgr.get(&id).await {
-        Ok(record) => {
-            // Reconcile against live tmux like the list handler — this is the
-            // record `tm session resume <id>` reads, and its resume decision keys
-            // off `state`; serving a stale `stopped` for a live session would let
-            // resume destructively recreate the pane (code-critic HIGH).
-            let mut summary = record_to_summary_checked(&record).await;
-            reconcile_against_tmux(
-                mgr.tmux.as_ref(),
-                std::slice::from_mut(&mut summary),
-                std::slice::from_ref(&record),
-            );
-            Json(summary).into_response()
-        }
-        Err(_) => (StatusCode::NOT_FOUND, format!("session {id_str} not found")).into_response(),
-    }
+    cores::get_core(&state, &id_str).await // #6288
 }
 
 /// POST /api/v1/sessions/managed/{id}/send — inject text into pane.
@@ -723,25 +561,7 @@ pub async fn send_to_session(
     AxumPath(id_str): AxumPath<String>,
     Json(req): Json<SendInputRequest>,
 ) -> impl IntoResponse {
-    let id = match parse_id(&id_str) {
-        Ok(id) => id,
-        Err((code, msg)) => return (code, msg).into_response(),
-    };
-    let mgr = state.session_manager().await;
-    let tmux_name = match mgr.get(&id).await {
-        Ok(r) => r.tmux_name,
-        Err(_) => {
-            return (StatusCode::NOT_FOUND, format!("session {id_str} not found")).into_response();
-        }
-    };
-    match mgr.send_input(&id, &req.text).await {
-        Ok(()) => Json(SendInputResponse {
-            sent: true,
-            tmux_name,
-        })
-        .into_response(),
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
-    }
+    cores::send_core(&state, &id_str, req).await // #6288
 }
 
 /// POST /api/v1/sessions/managed/{id}/answer — inject answer to pending decision.
@@ -755,61 +575,7 @@ pub async fn answer_session_decision(
     AxumPath(id_str): AxumPath<String>,
     Json(req): Json<AnswerRequest>,
 ) -> impl IntoResponse {
-    let id = match parse_id(&id_str) {
-        Ok(id) => id,
-        Err((code, msg)) => return (code, msg).into_response(),
-    };
-    let mgr = state.session_manager().await;
-    let record = match mgr.get(&id).await {
-        Ok(r) => r,
-        Err(_) => {
-            return (StatusCode::NOT_FOUND, format!("session {id_str} not found")).into_response();
-        }
-    };
-    let tmux_name = record.tmux_name.clone();
-
-    // FRONT-gate (#1360) path: a session escalated *before* spawn sits in
-    // `Provisioning` with a `pending_decision` and NO running harness. Answering
-    // it must clear the decision AND launch the withheld runtime (AC-15) — not
-    // inject the answer into a bare pane. Any other state is the ordinary
-    // harness-question path (`answer_decision`, which injects into the live pane).
-    let is_front_gate_escalation = record.state
-        == crate::session_manager::ManagedSessionState::Provisioning
-        && record.pending_decision.is_some();
-
-    if is_front_gate_escalation {
-        if let Err(e) = mgr.clear_pending_decision(&id).await {
-            return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
-        }
-        // Re-fetch AFTER clearing: `clear_pending_decision` upserts a new record
-        // version, so the `record` captured above is now stale (it still carries
-        // the pending decision). Spawn the runtime from the fresh snapshot so the
-        // withheld harness launches against the post-clear state (#1360 review).
-        let fresh = match mgr.get(&id).await {
-            Ok(r) => r,
-            Err(_) => {
-                return (StatusCode::NOT_FOUND, format!("session {id_str} not found"))
-                    .into_response();
-            }
-        };
-        match spawn_runtime_for(&state, &fresh).await {
-            Ok(()) => Json(AnswerResponse {
-                injected: true,
-                tmux_name,
-            })
-            .into_response(),
-            Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e).into_response(),
-        }
-    } else {
-        match mgr.answer_decision(&id, &req.answer).await {
-            Ok(()) => Json(AnswerResponse {
-                injected: true,
-                tmux_name,
-            })
-            .into_response(),
-            Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
-        }
-    }
+    cores::answer_core(&state, &id_str, req).await // #6288
 }
 
 /// GET /api/v1/sessions/managed/{id}/attach-cmd — return tmux attach command.
@@ -822,18 +588,7 @@ pub async fn get_attach_cmd(
     State(state): State<Arc<DaemonState>>,
     AxumPath(id_str): AxumPath<String>,
 ) -> impl IntoResponse {
-    let id = match parse_id(&id_str) {
-        Ok(id) => id,
-        Err((code, msg)) => return (code, msg).into_response(),
-    };
-    let mgr = state.session_manager().await;
-    match mgr.get(&id).await {
-        Ok(record) => {
-            let attach_cmd = attach_cmd_for(&record.tmux_name);
-            Json(AttachCmdResponse { attach_cmd }).into_response()
-        }
-        Err(_) => (StatusCode::NOT_FOUND, format!("session {id_str} not found")).into_response(),
-    }
+    cores::attach_cmd_core(&state, &id_str).await // #6288
 }
 
 /// POST /api/v1/sessions/managed/{id}/runtime-stop — stop the runtime only (keep workspace).
@@ -847,15 +602,7 @@ pub async fn stop_managed_session_runtime(
     State(state): State<Arc<DaemonState>>,
     AxumPath(id_str): AxumPath<String>,
 ) -> impl IntoResponse {
-    let id = match parse_id(&id_str) {
-        Ok(id) => id,
-        Err((code, msg)) => return (code, msg).into_response(),
-    };
-    let mgr = state.session_manager().await;
-    match mgr.stop(&id).await {
-        Ok(record) => Json(record_to_summary(&record)).into_response(),
-        Err(_) => (StatusCode::NOT_FOUND, format!("session {id_str} not found")).into_response(),
-    }
+    cores::runtime_stop_core(&state, &id_str).await // #6288
 }
 
 /// POST /api/v1/sessions/managed/{id}/resume — re-spawn the runtime in the existing workspace.
@@ -871,23 +618,10 @@ pub async fn resume_managed_session(
     State(state): State<Arc<DaemonState>>,
     AxumPath(id_str): AxumPath<String>,
 ) -> impl IntoResponse {
-    let id = match parse_id(&id_str) {
-        Ok(id) => id,
-        Err((code, msg)) => return (code, msg).into_response(),
-    };
-
-    // Single round-trip: the shared `resume_managed` helper performs the
-    // existence + state check inside `SessionManager::resume` and re-spawns the
-    // runtime. The TYPED error picks its own HTTP status/headers via its
-    // `IntoResponse` impl (`resume_error.rs`) — no pre-flight `get` (which
-    // introduced a TOCTOU race where the session could be decommissioned
-    // between the probe and the resume, yielding 500 instead of 404) and no
-    // `Display`-substring matching (which silently fell through to 500 whenever
-    // the error wording changed).
-    match resume_managed(&state, &id).await {
-        Ok(final_record) => Json(record_to_summary(&final_record)).into_response(),
-        Err(e) => e.into_response(),
-    }
+    // #6288: `resume_http_response` re-attaches the `x-trusty-resume-reason`
+    // header the 422 refusals carry; the socket reads the same distinction off
+    // the outcome's rpc code.
+    cores::resume_http_response(cores::resume_core(&state, &id_str).await)
 }
 
 /// Query parameters for POST /api/v1/sessions/managed/{id}/decommission
@@ -929,44 +663,7 @@ pub async fn decommission_managed_session(
     AxumPath(id_str): AxumPath<String>,
     axum::extract::Query(q): axum::extract::Query<DecommissionQuery>,
 ) -> impl IntoResponse {
-    let id = match parse_id(&id_str) {
-        Ok(id) => id,
-        Err((code, msg)) => return (code, msg).into_response(),
-    };
-    let mgr = state.session_manager().await;
-    // Pre-fetch the record to obtain the workspace_path BEFORE the tombstone clears
-    // it. `decommission` now returns `workspace_removed` directly (no TOCTOU
-    // filesystem re-check); `workspace_path_was` for the CLI's `git worktree prune`
-    // hint must still be captured here since the tombstone nulls it out.
-    let pre = mgr.get(&id).await.ok();
-    let pre_owned = pre.as_ref().map(|r| r.workspace_owned).unwrap_or(false);
-    let pre_ws = pre.and_then(|r| r.workspace_path);
-    let outcome = if q.record_only {
-        mgr.decommission_record_only(&id).await
-    } else {
-        mgr.decommission(&id, None).await
-    };
-    match outcome {
-        Ok((record, workspace_removed)) => {
-            // workspace_path_was: only meaningful for owned sessions (those where
-            // `decommission_with_root` might have removed the directory).
-            let workspace_path_was = if pre_owned {
-                pre_ws.map(|p| p.to_string_lossy().into_owned())
-            } else {
-                None
-            };
-            Json(DecommissionResponse {
-                summary: record_to_summary(&record),
-                workspace_removed,
-                workspace_path_was,
-            })
-            .into_response()
-        }
-        Err(crate::session_manager::ManagedError::SessionNotFound(_)) => {
-            (StatusCode::NOT_FOUND, format!("session {id_str} not found")).into_response()
-        }
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
-    }
+    cores::decommission_core(&state, &id_str, q.record_only).await // #6288
 }
 
 #[cfg(test)]

--- a/crates/trusty-mpm/src/daemon/managed_routes/provision_status.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/provision_status.rs
@@ -20,10 +20,9 @@
 use std::sync::Arc;
 
 use axum::{
-    Json, Router,
+    Router,
     extract::{Path as AxumPath, State},
-    http::StatusCode,
-    response::{IntoResponse, Response},
+    response::IntoResponse,
     routing::get,
 };
 use serde::Serialize;
@@ -34,6 +33,7 @@ use super::lifecycle::{SpawnParams, spawn_managed};
 use super::summary::parse_id;
 use crate::core::provisioning_stage::ProvisioningStage;
 use crate::daemon::provisioning::{ProvisioningLifecycle, ProvisioningProgress};
+use crate::daemon::rpc::managed::outcome::RouteOutcome;
 use crate::daemon::state::DaemonState;
 use crate::session_manager::ManagedSessionId;
 
@@ -249,18 +249,19 @@ pub fn router() -> Router<Arc<DaemonState>> {
 /// `202` with `{ id, state: "provisioning" }`.
 /// Test: `spawn_background_registers_and_polls_ready` covers the registry
 /// begin + poll; the `202` shape is covered by the integration tests.
-pub fn accept_async_spawn(state: Arc<DaemonState>, params: SpawnParams) -> Response {
+pub fn accept_async_spawn(state: Arc<DaemonState>, params: SpawnParams) -> RouteOutcome {
     let session_id = ManagedSessionId::new();
     let id = session_id.to_string();
     spawn_background(state, session_id, params);
-    (
-        StatusCode::ACCEPTED,
-        Json(AsyncSpawnResponse {
+    // #6288: 202 as a transport-neutral outcome, so the socket serves the same
+    // async-spawn ack the HTTP route does.
+    RouteOutcome::json(
+        202,
+        &AsyncSpawnResponse {
             id,
             state: "provisioning".to_string(),
-        }),
+        },
     )
-        .into_response()
 }
 
 /// GET /api/v1/sessions/managed/{id}/provision-status — poll async spawn progress.
@@ -280,34 +281,38 @@ pub async fn get_provision_status(
     State(state): State<Arc<DaemonState>>,
     AxumPath(id_str): AxumPath<String>,
 ) -> impl IntoResponse {
-    if let Some(progress) = state.provisioning.get(&id_str) {
-        return Json(ProvisionStatusResponse::from_progress(&progress)).into_response();
+    provision_status_core(&state, &id_str).await // #6288
+}
+
+/// The transport-neutral body of `GET .../{id}/provision-status` (#6288),
+/// served over the socket as `mpm.managed.provision_status`.
+///
+/// Test: `managed_provision_status_parity` in `daemon::rpc::managed_tests`.
+pub(crate) async fn provision_status_core(state: &Arc<DaemonState>, id_str: &str) -> RouteOutcome {
+    if let Some(progress) = state.provisioning.get(id_str) {
+        return RouteOutcome::ok(&ProvisionStatusResponse::from_progress(&progress));
     }
 
     // Not (or no longer) a tracked job — parse the id and fall back to the live
     // session store so a pruned/sync session still answers `ready`.
-    let id = match parse_id(&id_str) {
+    let id = match parse_id(id_str) {
         Ok(id) => id,
-        Err((code, msg)) => return (code, msg).into_response(),
+        Err((code, msg)) => return RouteOutcome::text(code.as_u16(), msg),
     };
     let mgr = state.session_manager().await;
     match mgr.get(&id).await {
-        Ok(record) => Json(ProvisionStatusResponse::ready_from_record(
+        Ok(record) => RouteOutcome::ok(&ProvisionStatusResponse::ready_from_record(
             &record.id.to_string(),
             &record.tmux_name,
-        ))
-        .into_response(),
-        Err(_) => (
-            StatusCode::NOT_FOUND,
-            format!("no provisioning job or session for {id_str}"),
-        )
-            .into_response(),
+        )),
+        Err(_) => RouteOutcome::text(404, format!("no provisioning job or session for {id_str}")),
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::http::StatusCode;
 
     fn stage_frame(session: &str, stage: &str, detail: Option<&str>) -> Value {
         let mut v = serde_json::json!({

--- a/crates/trusty-mpm/src/daemon/managed_routes/proxy/mod.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/proxy/mod.rs
@@ -42,6 +42,7 @@ use serde::{Deserialize, Serialize};
 use crate::client::proxy::{
     FocusOutcome, FocusTarget, InjectOutcome, ManagedBackend, SessionProxy, SummarizeOutcome,
 };
+use crate::daemon::rpc::managed::outcome::RouteOutcome;
 use crate::daemon::state::DaemonState;
 
 mod backend;
@@ -291,9 +292,19 @@ pub async fn proxy_focus(
     State(state): State<Arc<DaemonState>>,
     Json(req): Json<ProxyFocusRequest>,
 ) -> impl IntoResponse {
-    let proxy = local_proxy(&state);
+    // #6288: the body lives in `focus_core` so the socket serves this same route.
+    focus_core(&state, req).await
+}
+
+/// The transport-neutral body of `POST /api/v1/sessions/proxy/focus` (#6288).
+///
+/// Served over HTTP by [`proxy_focus`] and over the socket as
+/// `mpm.proxy.focus`; there is one implementation, not two.
+/// Test: `proxy_focus_parity` in `daemon::rpc::managed_tests`.
+pub(crate) async fn focus_core(state: &Arc<DaemonState>, req: ProxyFocusRequest) -> RouteOutcome {
+    let proxy = local_proxy(state);
     let outcome = proxy.focus(&req.conversation_key, &req.session_id).await;
-    Json(ProxyFocusResponse::from(outcome)).into_response()
+    RouteOutcome::ok(&ProxyFocusResponse::from(outcome))
 }
 
 /// `GET /api/v1/sessions/proxy/focus/{conversation_key}` — query the current
@@ -308,9 +319,20 @@ pub async fn proxy_get_focus(
     State(state): State<Arc<DaemonState>>,
     AxumPath(conversation_key): AxumPath<String>,
 ) -> impl IntoResponse {
-    let proxy = local_proxy(&state);
-    let outcome = proxy.focus(&conversation_key, "").await;
-    Json(ProxyFocusResponse::from(outcome)).into_response()
+    get_focus_core(&state, &conversation_key).await // #6288
+}
+
+/// The transport-neutral body of `GET .../proxy/focus/{conversation_key}`
+/// (#6288), served over the socket as `mpm.proxy.get_focus`.
+///
+/// Test: `proxy_get_focus_parity` in `daemon::rpc::managed_tests`.
+pub(crate) async fn get_focus_core(
+    state: &Arc<DaemonState>,
+    conversation_key: &str,
+) -> RouteOutcome {
+    let proxy = local_proxy(state);
+    let outcome = proxy.focus(conversation_key, "").await;
+    RouteOutcome::ok(&ProxyFocusResponse::from(outcome))
 }
 
 /// `POST /api/v1/sessions/proxy/unfocus` — clear a conversation's focus.
@@ -324,9 +346,20 @@ pub async fn proxy_unfocus(
     State(state): State<Arc<DaemonState>>,
     Json(req): Json<ProxyUnfocusRequest>,
 ) -> impl IntoResponse {
-    let proxy = local_proxy(&state);
-    let cleared = proxy.unfocus(&req.conversation_key).map(Into::into);
-    Json(ProxyUnfocusResponse { cleared }).into_response()
+    unfocus_core(&state, req).await // #6288
+}
+
+/// The transport-neutral body of `POST /api/v1/sessions/proxy/unfocus` (#6288),
+/// served over the socket as `mpm.proxy.unfocus`.
+///
+/// Test: `proxy_unfocus_parity` in `daemon::rpc::managed_tests`.
+pub(crate) async fn unfocus_core(
+    state: &Arc<DaemonState>,
+    req: ProxyUnfocusRequest,
+) -> RouteOutcome {
+    let proxy = local_proxy(state);
+    let cleared: Option<ProxyTargetWire> = proxy.unfocus(&req.conversation_key).map(Into::into);
+    RouteOutcome::ok(&ProxyUnfocusResponse { cleared })
 }
 
 /// `POST /api/v1/sessions/proxy/message` — route free text exactly like a
@@ -346,9 +379,20 @@ pub async fn proxy_message(
     State(state): State<Arc<DaemonState>>,
     Json(req): Json<ProxyMessageRequest>,
 ) -> impl IntoResponse {
-    let proxy = local_proxy(&state);
+    message_core(&state, req).await // #6288
+}
+
+/// The transport-neutral body of `POST /api/v1/sessions/proxy/message` (#6288),
+/// served over the socket as `mpm.proxy.message`.
+///
+/// Test: `proxy_message_parity` in `daemon::rpc::managed_tests`.
+pub(crate) async fn message_core(
+    state: &Arc<DaemonState>,
+    req: ProxyMessageRequest,
+) -> RouteOutcome {
+    let proxy = local_proxy(state);
     let outcome = proxy.inject(&req.conversation_key, &req.text).await;
-    Json(ProxyMessageResponse::from(outcome)).into_response()
+    RouteOutcome::ok(&ProxyMessageResponse::from(outcome))
 }
 
 /// `GET /api/v1/sessions/proxy/summary/{conversation_key}` — digest the focused
@@ -362,9 +406,17 @@ pub async fn proxy_summary(
     State(state): State<Arc<DaemonState>>,
     AxumPath(conversation_key): AxumPath<String>,
 ) -> impl IntoResponse {
-    let proxy = local_proxy(&state);
-    let outcome = proxy.summarize(&conversation_key).await;
-    Json(ProxySummaryResponse::from(outcome)).into_response()
+    summary_core(&state, &conversation_key).await // #6288
+}
+
+/// The transport-neutral body of `GET .../proxy/summary/{conversation_key}`
+/// (#6288), served over the socket as `mpm.proxy.summary`.
+///
+/// Test: `proxy_summary_parity` in `daemon::rpc::managed_tests`.
+pub(crate) async fn summary_core(state: &Arc<DaemonState>, conversation_key: &str) -> RouteOutcome {
+    let proxy = local_proxy(state);
+    let outcome = proxy.summarize(conversation_key).await;
+    RouteOutcome::ok(&ProxySummaryResponse::from(outcome))
 }
 
 /// Build the sub-router for the local session-manager PROXY surface.

--- a/crates/trusty-mpm/src/daemon/managed_routes/prune.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/prune.rs
@@ -188,7 +188,8 @@ pub async fn prune_worktrees_route(
 /// The transport-neutral body of `POST .../managed/prune-worktrees` (#6288),
 /// served over the socket as `mpm.managed.prune_worktrees`.
 ///
-/// Test: `managed_prune_worktrees_parity` in `daemon::rpc::managed_tests`.
+/// Test: `managed_prune_worktrees_parity_defaults_to_a_preview` in
+/// `daemon::rpc::managed_tests`.
 pub(crate) async fn prune_worktrees_core(
     state: &Arc<DaemonState>,
     req: PruneWorktreesRequest,

--- a/crates/trusty-mpm/src/daemon/managed_routes/prune.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/prune.rs
@@ -13,10 +13,11 @@
 
 use std::sync::Arc;
 
-use axum::{Json, extract::State, http::StatusCode, response::IntoResponse};
+use axum::{Json, extract::State, response::IntoResponse};
 use serde::Deserialize;
 use tracing::warn;
 
+use crate::daemon::rpc::managed::outcome::RouteOutcome;
 use crate::daemon::state::DaemonState;
 use crate::session_manager::worktree_reclaim::ReclaimMode;
 use crate::session_manager::worktree_reclaim_sweep::reclaim_merged_pr_worktrees;
@@ -102,14 +103,25 @@ pub async fn decommission_ephemeral_route(
     State(state): State<Arc<DaemonState>>,
     axum::extract::Query(q): axum::extract::Query<EphemeralQuery>,
 ) -> impl IntoResponse {
+    decommission_ephemeral_core(&state, q.dry_run).await // #6288
+}
+
+/// The transport-neutral body of `POST .../managed/decommission-ephemeral`
+/// (#6288), served over the socket as `mpm.managed.decommission_ephemeral`.
+///
+/// Test: `managed_decommission_ephemeral_parity` in
+/// `daemon::rpc::managed_tests`.
+pub(crate) async fn decommission_ephemeral_core(
+    state: &Arc<DaemonState>,
+    dry_run: bool,
+) -> RouteOutcome {
     let mgr = state.session_manager().await;
-    match mgr.sweep_all_ephemeral(q.dry_run).await {
-        Ok(outcome) => Json(serde_json::json!({
+    match mgr.sweep_all_ephemeral(dry_run).await {
+        Ok(outcome) => RouteOutcome::ok(&serde_json::json!({
             "decommissioned": outcome.count(),
-            "dry_run": q.dry_run,
-        }))
-        .into_response(),
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+            "dry_run": dry_run,
+        })),
+        Err(e) => RouteOutcome::text(500, e.to_string()),
     }
 }
 
@@ -170,6 +182,17 @@ pub async fn prune_worktrees_route(
     State(state): State<Arc<DaemonState>>,
     Json(req): Json<PruneWorktreesRequest>,
 ) -> impl IntoResponse {
+    prune_worktrees_core(&state, req).await // #6288
+}
+
+/// The transport-neutral body of `POST .../managed/prune-worktrees` (#6288),
+/// served over the socket as `mpm.managed.prune_worktrees`.
+///
+/// Test: `managed_prune_worktrees_parity` in `daemon::rpc::managed_tests`.
+pub(crate) async fn prune_worktrees_core(
+    state: &Arc<DaemonState>,
+    req: PruneWorktreesRequest,
+) -> RouteOutcome {
     let mgr = state.session_manager().await;
     let records = mgr.list().await;
     // #4288 (item 4 of #4207): DELIBERATELY UNFILTERED. Do NOT "tidy this up"
@@ -263,7 +286,7 @@ pub async fn prune_worktrees_route(
                 // only place an agent's liveness is resolved from real
                 // `SubagentStop` signals, so it is read here and handed to the
                 // classifier as a probe rather than as a captured list.
-                let state_for_agents = Arc::clone(&state);
+                let state_for_agents = Arc::clone(state);
                 match tokio::task::spawn_blocking(move || {
                     let in_use_now = move || -> Option<Vec<std::path::PathBuf>> {
                         // `None` means "could not be determined", which REFUSES
@@ -322,7 +345,7 @@ pub async fn prune_worktrees_route(
             } else {
                 serde_json::Value::Null
             };
-            Json(serde_json::json!({
+            RouteOutcome::ok(&serde_json::json!({
                 "dry_run": req.dry_run,
                 "paths": paths,
                 "owner_unknown_paths": owner_unknown_paths,
@@ -330,15 +353,10 @@ pub async fn prune_worktrees_route(
                 "skipped_dirty": outcome.skipped_dirty,
                 "merged_prs": merged,
             }))
-            .into_response()
         }
         Err(e) => {
             warn!("prune-worktrees route: orphan scan failed: {e}");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("orphan worktree scan failed: {e}"),
-            )
-                .into_response()
+            RouteOutcome::text(500, format!("orphan worktree scan failed: {e}"))
         }
     }
 }
@@ -364,11 +382,24 @@ pub async fn prune_managed_route(
     State(state): State<Arc<DaemonState>>,
     Json(req): Json<PruneRequest>,
 ) -> impl IntoResponse {
+    prune_managed_core(&state, req).await // #6288
+}
+
+/// The transport-neutral body of `POST .../managed/prune` (#6288), served over
+/// the socket as `mpm.managed.prune`.
+///
+/// Test: `managed_prune_parity`,
+/// `managed_prune_rejects_an_unparseable_invoking_session` in
+/// `daemon::rpc::managed_tests`.
+pub(crate) async fn prune_managed_core(
+    state: &Arc<DaemonState>,
+    req: PruneRequest,
+) -> RouteOutcome {
     let filter = match PruneFilter::parse(&req.state) {
         Ok(f) => f,
         Err(e) => {
             warn!("prune route: {e}");
-            return (StatusCode::BAD_REQUEST, e).into_response();
+            return RouteOutcome::text(400, e);
         }
     };
     let invoker = match req
@@ -383,7 +414,7 @@ pub async fn prune_managed_route(
                        running it without the requested self-exclusion (#6118)"
                 .to_string();
             warn!("prune route: {msg}");
-            return (StatusCode::BAD_REQUEST, msg).into_response();
+            return RouteOutcome::text(400, msg);
         }
     };
     let mgr = state.session_manager().await;
@@ -393,14 +424,15 @@ pub async fn prune_managed_route(
         .prune_managed(filter, req.dry_run, req.include_active, None, invoker)
         .await
     {
-        Ok(outcome) => Json(outcome).into_response(),
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+        Ok(outcome) => RouteOutcome::ok(&outcome),
+        Err(e) => RouteOutcome::text(500, e.to_string()),
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::http::StatusCode;
 
     /// #4091: a request body that says nothing about dirty worktrees must
     /// deserialize to the SAFE behaviour. An omitted field is the overwhelming

--- a/crates/trusty-mpm/src/daemon/managed_routes/reactivate.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/reactivate.rs
@@ -15,14 +15,13 @@
 use std::sync::Arc;
 
 use axum::{
-    Json,
     extract::{Path as AxumPath, Query, State},
-    http::StatusCode,
     response::IntoResponse,
 };
 use serde::Deserialize;
 
 use crate::daemon::orphan_gc::{ChildLivenessProbe, PaneInfo, ProcessTreeProbe};
+use crate::daemon::rpc::managed::outcome::RouteOutcome;
 use crate::daemon::runtime_reap::{find_runtime_exited, session_has_live_pane};
 use crate::daemon::state::DaemonState;
 use crate::session_manager::{
@@ -111,15 +110,27 @@ pub async fn reactivate_managed_session(
     AxumPath(id_str): AxumPath<String>,
     Query(params): Query<ReactivateQuery>,
 ) -> impl IntoResponse {
-    let id = match parse_id(&id_str) {
+    reactivate_core(&state, &id_str, &params).await // #6288
+}
+
+/// The transport-neutral body of `POST .../{id}/reactivate` (#6288), served
+/// over the socket as `mpm.managed.reactivate`.
+///
+/// Test: `managed_reactivate_parity` in `daemon::rpc::managed_tests`.
+pub(crate) async fn reactivate_core(
+    state: &Arc<DaemonState>,
+    id_str: &str,
+    params: &ReactivateQuery,
+) -> RouteOutcome {
+    let id = match parse_id(id_str) {
         Ok(id) => id,
-        Err((code, msg)) => return (code, msg).into_response(),
+        Err((code, msg)) => return RouteOutcome::text(code.as_u16(), msg),
     };
     let mgr = state.session_manager().await;
     match mgr.mark_reactivated(&id).await {
-        Ok(record) => Json(record_to_summary(&record)).into_response(),
+        Ok(record) => RouteOutcome::ok(&record_to_summary(&record)),
         Err(ManagedError::SessionNotFound(_)) => {
-            (StatusCode::NOT_FOUND, format!("session {id_str} not found")).into_response()
+            RouteOutcome::text(404, format!("session {id_str} not found"))
         }
         Err(ManagedError::InvalidState(_, reason)) => match reconcile_stale_active_then_reactivate(
             &mgr,
@@ -129,10 +140,10 @@ pub async fn reactivate_managed_session(
         )
         .await
         {
-            Some(record) => Json(record_to_summary(&record)).into_response(),
-            None => (StatusCode::CONFLICT, reason).into_response(),
+            Some(record) => RouteOutcome::ok(&record_to_summary(&record)),
+            None => RouteOutcome::text(409, reason),
         },
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+        Err(e) => RouteOutcome::text(500, e.to_string()),
     }
 }
 

--- a/crates/trusty-mpm/src/daemon/managed_routes/reconcile.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/reconcile.rs
@@ -18,14 +18,14 @@
 use std::sync::Arc;
 
 use axum::{
-    Json, Router,
+    Router,
     extract::State,
-    http::StatusCode,
     response::IntoResponse,
     routing::{get, post},
 };
 use tracing::warn;
 
+use crate::daemon::rpc::managed::outcome::RouteOutcome;
 use crate::daemon::state::DaemonState;
 
 /// The two worktree routes as one sub-router (#4288).
@@ -67,18 +67,22 @@ pub fn worktree_routes() -> Router<Arc<DaemonState>> {
 /// lie for this surface.
 /// Test: `reconcile_worktrees_route_reports_without_mutating`.
 pub async fn reconcile_worktrees_route(State(state): State<Arc<DaemonState>>) -> impl IntoResponse {
+    reconcile_worktrees_core(&state).await // #6288
+}
+
+/// The transport-neutral body of `GET .../managed/reconcile-worktrees` (#6288),
+/// served over the socket as `mpm.managed.reconcile_worktrees`.
+///
+/// Test: `managed_reconcile_worktrees_parity` in `daemon::rpc::managed_tests`.
+pub(crate) async fn reconcile_worktrees_core(state: &Arc<DaemonState>) -> RouteOutcome {
     let mgr = state.session_manager().await;
     let config = crate::core::trusty_tools_config::TrustyToolsConfig::load();
     let repos_root = crate::core::trusty_tools_config::workspace_root(&config);
     match mgr.reconcile_worktree_inventory(&repos_root).await {
-        Ok(report) => Json(report).into_response(),
+        Ok(report) => RouteOutcome::ok(&report),
         Err(e) => {
             warn!("reconcile-worktrees route: inventory scan failed: {e}");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("worktree reconciliation failed: {e}"),
-            )
-                .into_response()
+            RouteOutcome::text(500, format!("worktree reconciliation failed: {e}"))
         }
     }
 }

--- a/crates/trusty-mpm/src/daemon/managed_routes/reconcile_tests.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/reconcile_tests.rs
@@ -8,6 +8,7 @@
 //! Test: this file IS the test module.
 
 use super::*;
+use axum::http::StatusCode;
 
 use crate::daemon::state::DaemonState;
 use crate::session_manager::worktree_git_fixture::GitWorktreeFixture;

--- a/crates/trusty-mpm/src/daemon/managed_routes/rename.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/rename.rs
@@ -17,13 +17,13 @@ use std::sync::Arc;
 use axum::{
     Json,
     extract::{Path as AxumPath, State},
-    http::StatusCode,
     response::IntoResponse,
 };
 use serde::Deserialize;
 use tracing::warn;
 
 use super::{parse_id, record_to_summary};
+use crate::daemon::rpc::managed::outcome::RouteOutcome;
 use crate::daemon::state::DaemonState;
 use crate::session_manager::ManagedError;
 
@@ -60,29 +60,37 @@ pub async fn rename_managed_session(
     AxumPath(id_str): AxumPath<String>,
     Json(body): Json<RenameRequest>,
 ) -> impl IntoResponse {
-    let id = match parse_id(&id_str) {
+    rename_core(&state, &id_str, body).await // #6288
+}
+
+/// The transport-neutral body of `PATCH .../managed/{id}` (#6288), served over
+/// the socket as `mpm.managed.rename`.
+///
+/// Test: `managed_rename_parity` in `daemon::rpc::managed_tests`.
+pub(crate) async fn rename_core(
+    state: &Arc<DaemonState>,
+    id_str: &str,
+    body: RenameRequest,
+) -> RouteOutcome {
+    let id = match parse_id(id_str) {
         Ok(id) => id,
-        Err((code, msg)) => return (code, msg).into_response(),
+        Err((code, msg)) => return RouteOutcome::text(code.as_u16(), msg),
     };
     let mgr = state.session_manager().await;
     match mgr.rename(&id, &body.name).await {
-        Ok(record) => Json(record_to_summary(&record)).into_response(),
+        Ok(record) => RouteOutcome::ok(&record_to_summary(&record)),
         Err(ManagedError::SessionNotFound(_)) => {
-            (StatusCode::NOT_FOUND, format!("session {id_str} not found")).into_response()
+            RouteOutcome::text(404, format!("session {id_str} not found"))
         }
-        Err(e @ ManagedError::NameCollision(_)) => {
-            (StatusCode::CONFLICT, e.to_string()).into_response()
-        }
-        Err(ManagedError::InvalidState(_, reason)) => {
-            (StatusCode::BAD_REQUEST, reason).into_response()
-        }
+        Err(e @ ManagedError::NameCollision(_)) => RouteOutcome::text(409, e.to_string()),
+        Err(ManagedError::InvalidState(_, reason)) => RouteOutcome::text(400, reason),
         Err(e) => {
             // #5001: the body already carried this message, but nothing logged
             // it — a 500 here left NO daemon-side trace, so diagnosing one meant
             // correlating unrelated log spam. The unmapped remainder is by
             // definition the case nobody anticipated; log it where it happens.
             warn!(id = %id_str, error = %e, "rename failed with an unmapped error");
-            (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response()
+            RouteOutcome::text(500, e.to_string())
         }
     }
 }

--- a/crates/trusty-mpm/src/daemon/managed_routes/route_outcome_http.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/route_outcome_http.rs
@@ -1,0 +1,118 @@
+//! The axum half of the transport-neutral [`RouteOutcome`] (#6288 slice 4).
+//!
+//! Why: the route bodies this slice shares between axum and the Unix socket
+//! return a [`RouteOutcome`], which knows nothing about HTTP. Something still
+//! has to turn one into a `Response` for the HTTP surface, and that something
+//! must not live under `daemon::rpc` — the acceptance bar for slice 4 is that
+//! no HTTP type appears in the RPC modules, so the axum dependency is pinned
+//! here instead, next to the handlers that need it.
+//!
+//! What: one `IntoResponse` impl. A `Json` body becomes an
+//! `application/json` response at the outcome's status; a `Text` body becomes a
+//! bare string at that status — byte for byte the two shapes the pre-slice
+//! handlers produced with `Json(..).into_response()` and
+//! `(StatusCode::X, msg).into_response()`.
+//!
+//! Test: `route_outcome_http_tests` below; every pre-existing HTTP handler test
+//! is the real regression net, since each now reaches axum through this impl.
+
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+
+use crate::daemon::rpc::managed::outcome::{RouteBody, RouteOutcome};
+
+impl IntoResponse for RouteOutcome {
+    fn into_response(self) -> Response {
+        // A status this daemon does not produce would be a programmer error, so
+        // it degrades to 500 rather than panicking inside a live request.
+        let status = StatusCode::from_u16(self.status).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+        match self.body {
+            RouteBody::Json(v) => (status, axum::Json(v)).into_response(),
+            RouteBody::Text(s) => (status, s).into_response(),
+        }
+    }
+}
+
+/// Read an already-built axum `Response` back into a [`RouteOutcome`] (#6288).
+///
+/// Why: three refusals in this slice's scope are produced by error types that
+/// predate it and implement `IntoResponse` themselves — `DaemonError` and the
+/// deliverable-scope errors. Re-deriving their status and wording in a neutral
+/// form would create the second implementation this slice exists to prevent.
+/// Reading the response back preserves both verbatim, so the socket reports
+/// exactly what HTTP reports.
+/// What: takes the status, and the body as JSON when it parses as JSON and as
+/// text otherwise. A body that cannot be read at all becomes a 500 naming the
+/// read failure.
+/// Test: `a_json_error_response_round_trips_into_an_outcome`.
+pub(crate) async fn outcome_from_response(resp: Response) -> RouteOutcome {
+    let status = resp.status().as_u16();
+    let bytes = match axum::body::to_bytes(resp.into_body(), usize::MAX).await {
+        Ok(b) => b,
+        Err(e) => return RouteOutcome::text(500, format!("read response body: {e}")),
+    };
+    match serde_json::from_slice::<serde_json::Value>(&bytes) {
+        Ok(v) => RouteOutcome::json(status, &v),
+        Err(_) => RouteOutcome::text(status, String::from_utf8_lossy(&bytes).into_owned()),
+    }
+}
+
+#[cfg(test)]
+mod route_outcome_http_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn a_json_outcome_becomes_a_json_response_at_its_status() {
+        let resp = RouteOutcome::created(&serde_json::json!({"id": "s1"})).into_response();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        assert_eq!(
+            resp.headers()
+                .get("content-type")
+                .and_then(|v| v.to_str().ok()),
+            Some("application/json")
+        );
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .expect("body");
+        assert_eq!(&bytes[..], br#"{"id":"s1"}"#);
+    }
+
+    #[tokio::test]
+    async fn a_text_outcome_becomes_a_bare_string_at_its_status() {
+        let resp = RouteOutcome::text(404, "session zzz not found").into_response();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .expect("body");
+        assert_eq!(&bytes[..], b"session zzz not found");
+    }
+
+    #[test]
+    fn an_impossible_status_degrades_to_500_rather_than_panicking() {
+        let resp = RouteOutcome::text(9999, "nonsense").into_response();
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[tokio::test]
+    async fn a_json_error_response_round_trips_into_an_outcome() {
+        let resp = (
+            StatusCode::NOT_FOUND,
+            axum::Json(serde_json::json!({"error": "no project"})),
+        )
+            .into_response();
+        let outcome = outcome_from_response(resp).await;
+        assert_eq!(outcome.status, 404);
+        assert_eq!(
+            outcome.body,
+            RouteBody::Json(serde_json::json!({"error": "no project"}))
+        );
+    }
+
+    #[tokio::test]
+    async fn a_text_error_response_round_trips_as_text() {
+        let resp = (StatusCode::CONFLICT, "already adopted").into_response();
+        let outcome = outcome_from_response(resp).await;
+        assert_eq!(outcome.status, 409);
+        assert_eq!(outcome.body, RouteBody::Text("already adopted".to_owned()));
+    }
+}

--- a/crates/trusty-mpm/src/daemon/managed_routes/sync_assets.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/sync_assets.rs
@@ -25,9 +25,8 @@
 use std::sync::Arc;
 
 use axum::{
-    Json, Router,
+    Router,
     extract::{Path as AxumPath, State},
-    http::StatusCode,
     response::IntoResponse,
     routing::post,
 };
@@ -35,6 +34,7 @@ use serde::Serialize;
 
 use super::summary::parse_id;
 use crate::core::paths::FrameworkPaths;
+use crate::daemon::rpc::managed::outcome::RouteOutcome;
 use crate::daemon::state::DaemonState;
 use crate::session_manager::{ManagedSessionState, SessionRecord};
 
@@ -193,32 +193,40 @@ pub async fn sync_session_assets_route(
     State(state): State<Arc<DaemonState>>,
     AxumPath(id_str): AxumPath<String>,
 ) -> impl IntoResponse {
-    let id = match parse_id(&id_str) {
+    sync_session_assets_core(&state, &id_str).await // #6288
+}
+
+/// The transport-neutral body of `POST .../{id}/sync-assets` (#6288), served
+/// over the socket as `mpm.managed.sync_assets`.
+///
+/// Test: `managed_sync_assets_parity` in `daemon::rpc::managed_tests`.
+pub(crate) async fn sync_session_assets_core(
+    state: &Arc<DaemonState>,
+    id_str: &str,
+) -> RouteOutcome {
+    let id = match parse_id(id_str) {
         Ok(id) => id,
-        Err((code, msg)) => return (code, msg).into_response(),
+        Err((code, msg)) => return RouteOutcome::text(code.as_u16(), msg),
     };
     let mgr = state.session_manager().await;
     let record = match mgr.get(&id).await {
         Ok(r) => r,
-        Err(_) => {
-            return (StatusCode::NOT_FOUND, format!("session {id_str} not found")).into_response();
-        }
+        Err(_) => return RouteOutcome::text(404, format!("session {id_str} not found")),
     };
     if !syncable(&record.state) {
-        return (
-            StatusCode::CONFLICT,
+        return RouteOutcome::text(
+            409,
             format!(
                 "session {id_str} is {} — sync-assets only applies to active/stopped/errored \
                  sessions (a provisioning session has not deployed yet; a decommissioned \
                  session's workspace is gone and must never be recreated)",
                 record.state
             ),
-        )
-            .into_response();
+        );
     }
     match sync_one(record).await {
-        Ok(resp) => Json(resp).into_response(),
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e).into_response(),
+        Ok(resp) => RouteOutcome::ok(&resp),
+        Err(e) => RouteOutcome::text(500, e),
     }
 }
 
@@ -240,6 +248,14 @@ pub async fn sync_session_assets_route(
 pub async fn sync_all_session_assets_route(
     State(state): State<Arc<DaemonState>>,
 ) -> impl IntoResponse {
+    sync_all_session_assets_core(&state).await // #6288
+}
+
+/// The transport-neutral body of `POST .../managed/sync-assets` (#6288), served
+/// over the socket as `mpm.managed.sync_assets_all`.
+///
+/// Test: `managed_sync_assets_all_parity` in `daemon::rpc::managed_tests`.
+pub(crate) async fn sync_all_session_assets_core(state: &Arc<DaemonState>) -> RouteOutcome {
     let mgr = state.session_manager().await;
     let records = mgr.list().await;
 
@@ -258,7 +274,7 @@ pub async fn sync_all_session_assets_route(
         }
     }
 
-    Json(SyncAllAssetsResponse {
+    RouteOutcome::ok(&SyncAllAssetsResponse {
         synced,
         skipped,
         errors,

--- a/crates/trusty-mpm/src/daemon/rpc/managed.rs
+++ b/crates/trusty-mpm/src/daemon/rpc/managed.rs
@@ -1,0 +1,96 @@
+//! Managed sessions, the SESSCTL control plane, and the L2 proxy, served as
+//! JSON-RPC methods on the daemon's Unix socket (#6288 slice 4).
+//!
+//! Why: these three families are the daemon's lifecycle surface — they spawn
+//! processes, tear down workspaces, and inject text into live panes — so they
+//! are the families whose transport migration carries real risk. ADR-0032 moves
+//! them onto the socket; this slice does that while HTTP keeps serving every
+//! route unchanged. The bar is one implementation per route: each method calls
+//! the SAME `*_core` body the axum handler calls, so the two transports cannot
+//! drift.
+//!
+//! What: [`register`] mounts every method below. Requests are plain JSON
+//! objects — a socket request has no URL, so what the HTTP route reads from a
+//! path segment or a query string becomes a field. Responses are the HTTP
+//! JSON body verbatim. A refusal becomes an [`RpcError`] whose message is the
+//! HTTP body verbatim and whose code is
+//! [`outcome::status_to_rpc_code`] of the HTTP status.
+//!
+//! [`RpcError`]: trusty_common::uds::server::RpcError
+//!
+//! ## Transport-only differences
+//!
+//! The parity tests compare the two transports' JSON bodies and allow exactly
+//! these differences, which are properties of the transport and not of the
+//! route:
+//!
+//!   - **The status number.** HTTP carries it in the status line; RPC carries
+//!     its projection in `error.code`, and a 2xx carries nothing at all.
+//!   - **`Content-Type`, and every other HTTP header.** The socket has no
+//!     headers.
+//!   - **The refusal envelope.** HTTP answers a refusal with a bare string
+//!     body; RPC answers with `{"error":{"code":…,"message":…}}` carrying that
+//!     same string. The MESSAGE is compared verbatim; the envelope is not.
+//!   - **201 versus 200.** Both are `Ok` on the socket, which has no
+//!     created-versus-ok distinction.
+//!
+//! Nothing else is allowed to differ, and no route in this slice returns a
+//! different BODY on the two transports.
+//!
+//! ## The #6197 guard, and why it is stronger here
+//!
+//! `ctl_run_session` and its four siblings carry the input validation and the
+//! caller check that PR #6205 (`a2c9d0f2e`) added for #6197. All four checks
+//! travel:
+//!
+//! | #6197 check | Where it runs now | RPC regression test |
+//! |---|---|---|
+//! | caller must be local | [`control::CallerTrust`] | `rpc_ctl_run_refuses_an_untrusted_caller` |
+//! | `claude_cmd` allowlist | `control_routes::validate_claude_cmd` | `rpc_ctl_run_rejects_claude_cmd_outside_allowlist` |
+//! | `prompt_file` validation | `control_routes::validate_prompt_file` | `rpc_ctl_run_rejects_prompt_file_injection` |
+//! | `workdir` validation | `control_routes::validate_workdir` | `rpc_ctl_run_rejects_relative_workdir`, `rpc_ctl_run_rejects_workdir_traversal` |
+//!
+//! The three validators are transport-independent and now run inside the shared
+//! `ctl_run_core`, so neither transport can reach a spawn without them.
+//!
+//! The caller check is the one that changes shape. On HTTP it is
+//! `loopback_guard`, which asks whether the peer address is loopback — that is,
+//! whether the caller is on this HOST. On the socket the equivalent check is
+//! `trusty_common::uds::ensure_peer_is_self`, which `serve_until` runs on every
+//! accepted connection before a byte is read, and which asks whether the peer's
+//! uid is THIS USER'S. Same-uid is a strict subset of same-host: every caller
+//! the socket admits would also pass `loopback_guard`, and callers
+//! `loopback_guard` admits (any other local user, any process in another
+//! account on this machine) the socket refuses. The socket guard is therefore
+//! strictly stronger, and nothing weaker is carried across. The socket path
+//! additionally sits at `0600` inside a `0700` directory, so a foreign uid
+//! cannot reach `connect(2)` in the first place.
+//!
+//! Test: `managed_tests.rs`.
+
+pub mod control;
+pub mod outcome;
+pub mod proxy;
+pub mod sessions;
+
+#[cfg(test)]
+#[path = "managed_tests.rs"]
+mod managed_tests;
+
+use std::sync::Arc;
+
+use trusty_common::uds::server::RpcRouter;
+
+use crate::daemon::state::DaemonState;
+
+/// Mount every managed-session, control-plane, and proxy method on `router`.
+///
+/// Why: `socket.rs::build_router` composes the families with one call each, so
+/// a slice adds exactly one line there and owns everything below it.
+/// What: delegates to the three family modules in turn.
+/// Test: `every_scoped_route_has_a_method`.
+pub fn register(router: RpcRouter, state: &Arc<DaemonState>) -> RpcRouter {
+    let router = sessions::register(router, state);
+    let router = control::register(router, state);
+    proxy::register(router, state)
+}

--- a/crates/trusty-mpm/src/daemon/rpc/managed/control.rs
+++ b/crates/trusty-mpm/src/daemon/rpc/managed/control.rs
@@ -1,0 +1,313 @@
+//! The SESSCTL control-plane routes as JSON-RPC methods, and the caller-trust
+//! token the #6197 guard travels on (#6288 slice 4).
+//!
+//! Why: `ctl_run_session` spawns a caller-named executable from a
+//! caller-supplied request. #6197 was that it did so with no validation and no
+//! proof the caller was local; PR #6205 (`a2c9d0f2e`) closed it with a caller
+//! check and three input validators, all written as HTTP-extractor code. Moving
+//! this family onto a second transport is exactly the change that could leave
+//! those checks behind, so they were moved INTO the shared body first
+//! (`control_routes::ctl_run_core`) and the caller check was given a type.
+//!
+//! What: [`CallerTrust`] is that type — an opaque newtype over a PRIVATE enum,
+//! so a trusted verdict has no literal any caller can write. Its only two
+//! constructors are `pub(crate)` and each belongs to one transport's guard:
+//! `from_loopback_check` for `control_routes::loopback_guard`, and
+//! `from_peer_checked_socket` for the socket's accept-time peer-uid check. The
+//! `compile_fail` doctests on the type prove an outside caller cannot reach
+//! either, nor name a variant, nor build one by hand.
+//!
+//! | Method | Route |
+//! |---|---|
+//! | `mpm.control.list` | `GET /api/v1/control/sessions` |
+//! | `mpm.control.run` | `POST /api/v1/control/sessions/run` |
+//! | `mpm.control.connect` | `POST /api/v1/control/sessions/{id}/connect` (SSE → stream) |
+//! | `mpm.control.stop` | `POST /api/v1/control/sessions/{id}/stop` |
+//! | `mpm.control.auth` | `GET /api/v1/control/sessions/{id}/auth` |
+//!
+//! `mpm.control.connect` is the one route whose HTTP form is an SSE stream. It
+//! is registered with [`RpcRouter::typed_stream`], so a caller sends
+//! `"stream": true` and reads one frame per `SessionEvent` — the same events,
+//! in the same order, that the SSE `data:` lines carry.
+//!
+//! Test: `rpc_ctl_*` in `daemon::rpc::managed_tests`.
+
+use std::sync::Arc;
+
+use serde::Deserialize;
+use tokio::sync::mpsc;
+use tokio_stream::StreamExt;
+use tokio_stream::wrappers::BroadcastStream;
+use trusty_common::uds::server::{RpcError, RpcRouter, RpcStreamItems};
+
+use super::outcome::{CODE_NOT_FOUND, RouteOutcome};
+use crate::control::ControlSessionId;
+use crate::daemon::api::control_routes::{
+    CtlListQuery, CtlRunRequest, ctl_auth_core, ctl_list_core, ctl_run_core, ctl_stop_core,
+};
+use crate::daemon::state::DaemonState;
+
+/// Whether the transport proved the caller is entitled to the control plane
+/// (#6197, carried across transports by #6288).
+///
+/// Why: the check is a property of the CONNECTION, not of the request body, so
+/// it cannot live inside a route body that both transports share — but its
+/// RESULT must, or the body has no way to refuse. This enum is that result, and
+/// making it a parameter means a new caller of a control-plane body has to say
+/// which transport vouched for it. There is no `Default`, deliberately.
+///
+/// **The socket's proof is strictly stronger than HTTP's.** `loopback_guard`
+/// asks whether the peer address is loopback — whether the caller is on this
+/// HOST. `trusty_common::uds::ensure_peer_is_self`, which `serve_until` runs on
+/// every accepted connection before a byte is read, asks whether the peer's uid
+/// is THIS USER'S. Same-uid is a strict subset of same-host, so every caller the
+/// socket admits would also have passed `loopback_guard`, while a different
+/// local user — admitted by `loopback_guard` — is refused by the socket. The
+/// socket path is additionally `0600` inside a `0700` directory, so a foreign
+/// uid cannot reach `connect(2)` at all. Nothing weaker is carried across.
+///
+/// Test: `caller_trust_refusal_matches_the_http_403`,
+/// `rpc_ctl_run_refuses_an_untrusted_caller`.
+/// The three `compile_fail` blocks below are the proof, and this one is what
+/// keeps them honest: a `compile_fail` test passes for ANY compile error, a
+/// mistyped import path included, so one block that MUST compile pins the path
+/// they all use. If `CallerTrust` ever stops being reachable at this path, this
+/// block fails and the three below stop proving anything silently.
+///
+/// ```
+/// use trusty_mpm::daemon::rpc::managed::control::CallerTrust;
+/// assert!(CallerTrust::REFUSAL.contains("loopback-only"));
+/// ```
+///
+/// ```compile_fail
+/// // #6288: the verdict has no public variant, so a caller cannot name one.
+/// use trusty_mpm::daemon::rpc::managed::control::CallerTrust;
+/// let _trusted = CallerTrust::LocalVerified;
+/// ```
+///
+/// ```compile_fail
+/// // #6288: nor build one by hand — the inner verdict is private.
+/// use trusty_mpm::daemon::rpc::managed::control::CallerTrust;
+/// let _trusted = CallerTrust(());
+/// ```
+///
+/// ```compile_fail
+/// // #6288: nor call a constructor — both are crate-internal.
+/// use trusty_mpm::daemon::rpc::managed::control::CallerTrust;
+/// let _trusted = CallerTrust::from_peer_checked_socket();
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CallerTrust(Verdict);
+
+/// The verdict [`CallerTrust`] wraps.
+///
+/// Private on purpose, and the whole mechanism behind the type's guarantee: a
+/// newtype over a private type has no expressible literal outside this module,
+/// so `CallerTrust`'s only constructors are the two below. Making this `pub`
+/// would restore exactly the hole #6347's review found.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Verdict {
+    /// The transport proved the caller local. On HTTP: a loopback peer address.
+    /// On the socket: a peer uid equal to this process's.
+    LocalVerified,
+    /// The transport did not. Every control-plane body refuses.
+    Unverified,
+}
+
+impl CallerTrust {
+    /// The refusal body, byte-identical on both transports (#6197).
+    pub const REFUSAL: &'static str =
+        "control-plane session routes are loopback-only; remote access is forbidden";
+
+    /// The trust a request arriving on the peer-checked socket carries.
+    ///
+    /// Why a named constructor rather than a variant: this is the ONE place the
+    /// socket's claim is made, so the invariant behind it has one place to be
+    /// written down and one place to be reviewed. The claim is that
+    /// `serve_until` ran `ensure_peer_is_self` on this connection before any
+    /// byte of the request was read — see `daemon::socket`, which is the only
+    /// module that mounts this router.
+    pub(crate) fn from_peer_checked_socket() -> Self {
+        Self(Verdict::LocalVerified)
+    }
+
+    /// The trust an HTTP request carries, given whether its peer is loopback.
+    ///
+    /// Why it takes a `bool` rather than a `SocketAddr`: the address check is
+    /// `control_routes::loopback_guard`'s, which owns the logging and the
+    /// `is_loopback` predicate. This is only the verdict's constructor, and
+    /// keeping it address-free is what lets `daemon::rpc` stay free of HTTP
+    /// types (#6288).
+    /// Test: `loopback_guard_accepts_loopback_refuses_remote`.
+    pub(crate) fn from_loopback_check(peer_is_loopback: bool) -> Self {
+        if peer_is_loopback {
+            Self(Verdict::LocalVerified)
+        } else {
+            Self(Verdict::Unverified)
+        }
+    }
+
+    /// A caller no transport vouched for. Refused by every control-plane body.
+    ///
+    /// Test-only: both production paths mint their verdict from a real check
+    /// (`from_loopback_check`, `from_peer_checked_socket`), so nothing outside a
+    /// test needs to name a refusal directly. Gated rather than left dead so a
+    /// future production caller has to justify itself in review.
+    #[cfg(test)]
+    pub(crate) fn unverified() -> Self {
+        Self(Verdict::Unverified)
+    }
+
+    /// Whether a transport vouched for this caller.
+    ///
+    /// Test: `loopback_guard_accepts_loopback_refuses_remote`.
+    pub fn is_local(self) -> bool {
+        self.0 == Verdict::LocalVerified
+    }
+
+    /// `Ok(())` when the caller is entitled; otherwise the shared 403.
+    ///
+    /// # Errors
+    ///
+    /// An unverified caller — as a 403 [`RouteOutcome`] carrying
+    /// [`Self::REFUSAL`], which projects onto
+    /// [`super::outcome::CODE_FORBIDDEN`] on the socket.
+    ///
+    /// Test: `caller_trust_refusal_matches_the_http_403`,
+    /// `rpc_ctl_run_refuses_an_untrusted_caller`.
+    pub fn ensure_local(self) -> Result<(), RouteOutcome> {
+        match self.0 {
+            Verdict::LocalVerified => Ok(()),
+            Verdict::Unverified => Err(RouteOutcome::text(403, Self::REFUSAL)),
+        }
+    }
+}
+
+/// A control-plane request naming a session by id.
+#[derive(Debug, Deserialize)]
+pub struct CtlSessionParams {
+    /// The control-plane session id the HTTP route reads from its path.
+    pub id: String,
+}
+
+/// `mpm.control.stop` parameters: the id, plus the `?force=` query flag.
+#[derive(Debug, Deserialize)]
+pub struct CtlStopParams {
+    /// The control-plane session id.
+    pub id: String,
+    /// When true, send `ForceStop` rather than `Stop`. Absent means false, as
+    /// an absent `?force=` does.
+    #[serde(default)]
+    pub force: bool,
+}
+
+/// Register the five control-plane methods on `router`.
+pub fn register(router: RpcRouter, state: &Arc<DaemonState>) -> RpcRouter {
+    let list_state = Arc::clone(state);
+    let run_state = Arc::clone(state);
+    let stop_state = Arc::clone(state);
+    let auth_state = Arc::clone(state);
+    let connect_state = Arc::clone(state);
+
+    router
+        .typed("mpm.control.list", move |query: CtlListQuery| {
+            let state = Arc::clone(&list_state);
+            async move {
+                ctl_list_core(&state, CallerTrust::from_peer_checked_socket(), query)
+                    .await
+                    .into_rpc()
+            }
+        })
+        .typed("mpm.control.run", move |req: CtlRunRequest| {
+            let state = Arc::clone(&run_state);
+            async move {
+                ctl_run_core(&state, CallerTrust::from_peer_checked_socket(), req)
+                    .await
+                    .into_rpc()
+            }
+        })
+        .typed("mpm.control.stop", move |req: CtlStopParams| {
+            let state = Arc::clone(&stop_state);
+            async move {
+                ctl_stop_core(
+                    &state,
+                    CallerTrust::from_peer_checked_socket(),
+                    &req.id,
+                    req.force,
+                )
+                .await
+                .into_rpc()
+            }
+        })
+        .typed("mpm.control.auth", move |req: CtlSessionParams| {
+            let state = Arc::clone(&auth_state);
+            async move {
+                ctl_auth_core(&state, CallerTrust::from_peer_checked_socket(), &req.id)
+                    .await
+                    .into_rpc()
+            }
+        })
+        .typed_stream("mpm.control.connect", move |req: CtlSessionParams| {
+            let state = Arc::clone(&connect_state);
+            async move { connect_stream(&state, req.id).await }
+        })
+}
+
+/// `mpm.control.connect` — the SSE route's socket form (#6288).
+///
+/// Why a stream and not a unary method: the HTTP route answers with an
+/// open-ended `text/event-stream`, one `data:` line per `SessionEvent`. A unary
+/// method could only return a snapshot, which is a different route, so this one
+/// is registered with `typed_stream` and answers in many frames.
+///
+/// What: refuses an untrusted caller and an unknown id up front — before any
+/// frame is written — then forwards each broadcast event as one stream item.
+/// The write-lock CAS the HTTP route performs is NOT done here: the HTTP
+/// handler's `WriteLockGuard` is owned by the SSE stream and released when that
+/// stream drops, and this slice has no equivalent drop point on the socket. A
+/// socket connect is therefore an OBSERVER, and `writer` is reported false.
+/// That is a deliberate narrowing, not a parity gap to paper over — an RPC
+/// caller that acquired the lock with no drop path would leak it permanently.
+///
+/// # Errors
+///
+/// [`CODE_NOT_FOUND`] for an unknown session; the shared 403 code for an
+/// untrusted caller.
+///
+/// Test: `rpc_ctl_connect_streams_events`,
+/// `rpc_ctl_connect_unknown_session_refuses_before_any_frame`.
+async fn connect_stream(
+    state: &Arc<DaemonState>,
+    id_str: String,
+) -> Result<RpcStreamItems, RpcError> {
+    if let Err(refusal) = CallerTrust::from_peer_checked_socket().ensure_local() {
+        return Err(refusal.into_rpc().expect_err("a 403 is always an error"));
+    }
+    let id = ControlSessionId(id_str.clone());
+    let Some(handle) = state.session_registry.get(&id).await else {
+        return Err(RpcError::new(
+            CODE_NOT_FOUND,
+            format!("session {id_str} not found"),
+        ));
+    };
+
+    let rx = handle.event_tx.subscribe();
+    let (tx, items) = mpsc::channel(64);
+    tokio::spawn(async move {
+        let mut stream = BroadcastStream::new(rx);
+        while let Some(item) = stream.next().await {
+            // A lag or a closed channel ends the stream, exactly as the SSE
+            // `filter_map` ends it on `Err(_)`.
+            let Ok(event) = item else { break };
+            let frame = match serde_json::to_value(&event) {
+                Ok(v) => Ok(v),
+                Err(e) => Err(RpcError::internal(format!("serialize session event: {e}"))),
+            };
+            let failed = frame.is_err();
+            if tx.send(frame).await.is_err() || failed {
+                break;
+            }
+        }
+    });
+    Ok(items)
+}

--- a/crates/trusty-mpm/src/daemon/rpc/managed/outcome.rs
+++ b/crates/trusty-mpm/src/daemon/rpc/managed/outcome.rs
@@ -1,0 +1,220 @@
+//! The transport-neutral result of a route body, and its JSON-RPC projection
+//! (#6288 slice 4).
+//!
+//! Why: slice 4 serves the managed-session, control-plane, and L2 proxy routes
+//! over BOTH axum and the Unix socket, and the acceptance bar is one
+//! implementation per route rather than two that drift. A handler body that
+//! builds an `axum::response::Response` cannot be called from the socket, and
+//! one that builds an `RpcResponse` cannot be called from axum. This type is
+//! what both bodies return instead: a status plus a payload, with no transport
+//! in it.
+//!
+//! What: [`RouteOutcome`] carries an HTTP-shaped status number and a
+//! [`RouteBody`]. The socket side projects it through [`RouteOutcome::into_rpc`];
+//! the axum side projects it through the `IntoResponse` impl that lives beside
+//! the HTTP handlers, in `crate::daemon::managed_routes::route_outcome_http` —
+//! deliberately NOT here, so nothing under `daemon::rpc` imports axum at all.
+//!
+//! The status number is not a transport leak. It is the routes' own refusal
+//! vocabulary — "not found", "conflict", "forbidden" — which predates this
+//! slice and is what the two projections have to agree on.
+//! [`status_to_rpc_code`] is the single place that agreement is written down.
+//!
+//! Test: `outcome_tests` below, and the per-route parity tests in
+//! `daemon::rpc::managed_tests`.
+
+use serde::Serialize;
+use trusty_common::uds::server::RpcError;
+
+// #6288: the domain codes live in `daemon::error`, beside slice 2's
+// `From<DaemonError> for RpcError` — one declaration per code, re-exported here
+// so a route body reads them without reaching across families.
+pub use crate::daemon::error::{
+    CODE_CONFLICT, CODE_FORBIDDEN, CODE_NOT_FOUND, CODE_PANE_GONE, CODE_UNPROCESSABLE,
+    CODE_WORKSPACE_GONE,
+};
+
+/// A route's payload, before any transport has been chosen.
+///
+/// `Json` is what every success arm produces; `Text` is what the refusal arms
+/// produce, because the HTTP handlers answer a refusal with a bare string body
+/// rather than a JSON envelope. Keeping both means each projection preserves
+/// what the route actually returns instead of inventing a wrapper on one side.
+#[derive(Debug, Clone, PartialEq)]
+pub enum RouteBody {
+    /// A JSON document — the shape every 2xx arm returns.
+    Json(serde_json::Value),
+    /// A bare string — the shape every 4xx/5xx arm returns.
+    Text(String),
+}
+
+/// One route's answer: a status plus a body, with no transport attached.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RouteOutcome {
+    /// The status the HTTP surface reports, and the input to
+    /// [`status_to_rpc_code`] on the socket surface.
+    pub status: u16,
+    /// The payload.
+    pub body: RouteBody,
+    /// A code the socket must use INSTEAD of [`status_to_rpc_code`]`(status)`.
+    ///
+    /// Why: exactly one route family — resume — distinguishes two refusals that
+    /// share HTTP 422 using a response header, and the socket has no headers.
+    /// Set by [`RouteOutcome::with_rpc_code`] so the discriminant survives as
+    /// the RPC code instead of being dropped. Ignored by the HTTP projection.
+    pub rpc_code: Option<i64>,
+}
+
+impl RouteOutcome {
+    /// 200 with `value` serialized as the body.
+    pub fn ok(value: &impl Serialize) -> Self {
+        Self::json(200, value)
+    }
+
+    /// 201 with `value` serialized as the body.
+    pub fn created(value: &impl Serialize) -> Self {
+        Self::json(201, value)
+    }
+
+    /// `status` with `value` serialized as the body.
+    ///
+    /// A body that will not serialize becomes a 500 carrying the serde message
+    /// on both transports, never a panic — these bodies run inside a daemon
+    /// that must outlive one bad response.
+    pub fn json(status: u16, value: &impl Serialize) -> Self {
+        match serde_json::to_value(value) {
+            Ok(v) => Self {
+                status,
+                body: RouteBody::Json(v),
+                rpc_code: None,
+            },
+            Err(e) => Self::text(500, format!("serialize response: {e}")),
+        }
+    }
+
+    /// `status` with `message` as a bare string body — the refusal shape.
+    pub fn text(status: u16, message: impl Into<String>) -> Self {
+        Self {
+            status,
+            body: RouteBody::Text(message.into()),
+            rpc_code: None,
+        }
+    }
+
+    /// Override the RPC code this refusal projects onto. See [`Self::rpc_code`].
+    pub fn with_rpc_code(mut self, code: i64) -> Self {
+        self.rpc_code = Some(code);
+        self
+    }
+
+    /// True when the status is 2xx.
+    pub fn is_success(&self) -> bool {
+        (200..300).contains(&self.status)
+    }
+
+    /// Project onto the result/error pair the socket writes.
+    ///
+    /// Why: `RpcError` has no status field, so a refusal's identity survives as
+    /// a CODE plus the SAME message the HTTP body carries. A caller comparing
+    /// the two transports reads identical message text; only the numeric label
+    /// differs, and [`status_to_rpc_code`] is that mapping.
+    /// What: a 2xx becomes `Ok(value)` — the JSON body verbatim, a text body as
+    /// a JSON string. Anything else becomes `Err(RpcError)` whose message is the
+    /// text body verbatim.
+    /// Test: `success_projects_the_body_verbatim`,
+    /// `refusal_keeps_the_http_message_and_maps_the_status`.
+    pub fn into_rpc(self) -> Result<serde_json::Value, RpcError> {
+        let success = self.is_success();
+        let code = self
+            .rpc_code
+            .unwrap_or_else(|| status_to_rpc_code(self.status));
+        match (success, self.body) {
+            (true, RouteBody::Json(v)) => Ok(v),
+            (true, RouteBody::Text(s)) => Ok(serde_json::Value::String(s)),
+            (false, RouteBody::Text(s)) => Err(RpcError::new(code, s)),
+            (false, RouteBody::Json(v)) => Err(RpcError::new(code, v.to_string())),
+        }
+    }
+}
+
+/// The JSON-RPC error code a refusal status maps to.
+///
+/// The mapping itself is `rpc_code_for_status` in `daemon::error`, shared with
+/// slice 2's `From<DaemonError> for RpcError` so one status cannot answer two
+/// codes depending on which family served the route. This alias is the name the
+/// route bodies and the parity tests read.
+pub use crate::daemon::error::rpc_code_for_status as status_to_rpc_code;
+
+#[cfg(test)]
+mod outcome_tests {
+    use trusty_common::uds::server::{CODE_INTERNAL_ERROR, CODE_INVALID_PARAMS};
+
+    use super::*;
+
+    #[test]
+    fn success_projects_the_body_verbatim() {
+        let outcome = RouteOutcome::ok(&serde_json::json!({"id": "abc", "n": 3}));
+        let value = outcome.into_rpc().expect("2xx is Ok");
+        assert_eq!(value, serde_json::json!({"id": "abc", "n": 3}));
+    }
+
+    #[test]
+    fn created_is_a_success_like_ok() {
+        let outcome = RouteOutcome::created(&serde_json::json!({"id": "abc"}));
+        assert!(outcome.is_success());
+        assert!(outcome.into_rpc().is_ok());
+    }
+
+    #[test]
+    fn refusal_keeps_the_http_message_and_maps_the_status() {
+        let outcome = RouteOutcome::text(404, "session zzz not found");
+        let err = outcome.into_rpc().expect_err("4xx is Err");
+        assert_eq!(err.code, CODE_NOT_FOUND);
+        assert_eq!(
+            err.message, "session zzz not found",
+            "the socket must carry the HTTP body verbatim, not a paraphrase"
+        );
+    }
+
+    #[test]
+    fn status_to_rpc_code_maps_each_refusal_class() {
+        assert_eq!(status_to_rpc_code(400), CODE_INVALID_PARAMS);
+        assert_eq!(status_to_rpc_code(403), CODE_FORBIDDEN);
+        assert_eq!(status_to_rpc_code(404), CODE_NOT_FOUND);
+        assert_eq!(status_to_rpc_code(409), CODE_CONFLICT);
+        assert_eq!(status_to_rpc_code(422), CODE_UNPROCESSABLE);
+        assert_eq!(status_to_rpc_code(500), CODE_INTERNAL_ERROR);
+        assert_eq!(status_to_rpc_code(502), CODE_INTERNAL_ERROR);
+    }
+
+    /// The two 422 resume refusals keep distinct codes, since the socket has no
+    /// place for the `x-trusty-resume-reason` header that separates them on
+    /// HTTP (#6288).
+    #[test]
+    fn an_rpc_code_override_replaces_the_status_projection() {
+        let err = RouteOutcome::text(422, "workspace /gone no longer exists")
+            .with_rpc_code(CODE_WORKSPACE_GONE)
+            .into_rpc()
+            .expect_err("422 is Err");
+        assert_eq!(err.code, CODE_WORKSPACE_GONE);
+        assert_eq!(err.message, "workspace /gone no longer exists");
+
+        let pane = RouteOutcome::text(422, "pane %42 no longer exists")
+            .with_rpc_code(CODE_PANE_GONE)
+            .into_rpc()
+            .expect_err("422 is Err");
+        assert_ne!(
+            pane.code, err.code,
+            "the two 422 classes must stay distinguishable without a header"
+        );
+    }
+
+    #[test]
+    fn an_unserializable_body_is_a_500_not_a_panic() {
+        let bad: std::collections::HashMap<(u8, u8), u8> =
+            std::collections::HashMap::from([((1, 2), 3)]);
+        let outcome = RouteOutcome::ok(&bad);
+        assert_eq!(outcome.status, 500);
+        assert!(outcome.into_rpc().is_err());
+    }
+}

--- a/crates/trusty-mpm/src/daemon/rpc/managed/proxy.rs
+++ b/crates/trusty-mpm/src/daemon/rpc/managed/proxy.rs
@@ -1,0 +1,79 @@
+//! The L2 session-proxy routes as JSON-RPC methods (#6288 slice 4).
+//!
+//! Why: `managed_routes::proxy` is the focus/inject/summarize state machine
+//! every channel binds to, and ADR-0032 moves its transport onto the socket.
+//! Nothing here re-implements it — each method calls the same `*_core` body the
+//! axum handler calls.
+//!
+//! What: five methods. The two GET routes carry their path segment as a
+//! `conversation_key` field instead, since a socket request has no path.
+//!
+//! | Method | Route |
+//! |---|---|
+//! | `mpm.proxy.focus` | `POST /api/v1/sessions/proxy/focus` |
+//! | `mpm.proxy.get_focus` | `GET /api/v1/sessions/proxy/focus/{conversation_key}` |
+//! | `mpm.proxy.unfocus` | `POST /api/v1/sessions/proxy/unfocus` |
+//! | `mpm.proxy.message` | `POST /api/v1/sessions/proxy/message` |
+//! | `mpm.proxy.summary` | `GET /api/v1/sessions/proxy/summary/{conversation_key}` |
+//!
+//! Test: `proxy_*_parity` in `daemon::rpc::managed_tests`.
+
+use std::sync::Arc;
+
+use serde::Deserialize;
+use trusty_common::uds::server::RpcRouter;
+
+use crate::daemon::managed_routes::proxy;
+use crate::daemon::state::DaemonState;
+
+/// A path-only request: the conversation key the HTTP route reads from its URL.
+#[derive(Debug, Deserialize)]
+pub struct ConversationKeyParams {
+    /// The conversation whose focus (or summary) is being read.
+    pub conversation_key: String,
+}
+
+/// Register the five proxy methods on `router`.
+pub fn register(router: RpcRouter, state: &Arc<DaemonState>) -> RpcRouter {
+    let focus_state = Arc::clone(state);
+    let get_focus_state = Arc::clone(state);
+    let unfocus_state = Arc::clone(state);
+    let message_state = Arc::clone(state);
+    let summary_state = Arc::clone(state);
+
+    router
+        .typed("mpm.proxy.focus", move |req: proxy::ProxyFocusRequest| {
+            let state = Arc::clone(&focus_state);
+            async move { proxy::focus_core(&state, req).await.into_rpc() }
+        })
+        .typed("mpm.proxy.get_focus", move |req: ConversationKeyParams| {
+            let state = Arc::clone(&get_focus_state);
+            async move {
+                proxy::get_focus_core(&state, &req.conversation_key)
+                    .await
+                    .into_rpc()
+            }
+        })
+        .typed(
+            "mpm.proxy.unfocus",
+            move |req: proxy::ProxyUnfocusRequest| {
+                let state = Arc::clone(&unfocus_state);
+                async move { proxy::unfocus_core(&state, req).await.into_rpc() }
+            },
+        )
+        .typed(
+            "mpm.proxy.message",
+            move |req: proxy::ProxyMessageRequest| {
+                let state = Arc::clone(&message_state);
+                async move { proxy::message_core(&state, req).await.into_rpc() }
+            },
+        )
+        .typed("mpm.proxy.summary", move |req: ConversationKeyParams| {
+            let state = Arc::clone(&summary_state);
+            async move {
+                proxy::summary_core(&state, &req.conversation_key)
+                    .await
+                    .into_rpc()
+            }
+        })
+}

--- a/crates/trusty-mpm/src/daemon/rpc/managed/sessions.rs
+++ b/crates/trusty-mpm/src/daemon/rpc/managed/sessions.rs
@@ -1,0 +1,334 @@
+//! The managed-session lifecycle routes as JSON-RPC methods (#6288 slice 4).
+//!
+//! Why: `/api/v1/sessions/managed*` is what `tm launch`, the picker, the TUI,
+//! Telegram, and Slack all drive. ADR-0032 moves its transport onto the socket;
+//! nothing here re-implements a route — every method calls the same `*_core`
+//! body the axum handler calls.
+//!
+//! What: what an HTTP route reads from a path segment or a query string becomes
+//! a field of the request object, since a socket request has no URL.
+//!
+//! | Method | Route |
+//! |---|---|
+//! | `mpm.managed.spawn` | `POST /api/v1/sessions/managed` |
+//! | `mpm.managed.list` | `GET /api/v1/sessions/managed` |
+//! | `mpm.managed.adopt` | `POST /api/v1/sessions/managed/adopt` |
+//! | `mpm.managed.prune` | `POST /api/v1/sessions/managed/prune` |
+//! | `mpm.managed.decommission_ephemeral` | `POST /api/v1/sessions/managed/decommission-ephemeral` |
+//! | `mpm.managed.prune_worktrees` | `POST /api/v1/sessions/managed/prune-worktrees` |
+//! | `mpm.managed.reconcile_worktrees` | `GET /api/v1/sessions/managed/reconcile-worktrees` |
+//! | `mpm.managed.fleet` | `GET /api/v1/sessions/managed/fleet` |
+//! | `mpm.managed.get` | `GET /api/v1/sessions/managed/{id}` |
+//! | `mpm.managed.stop` | `DELETE /api/v1/sessions/managed/{id}` |
+//! | `mpm.managed.rename` | `PATCH /api/v1/sessions/managed/{id}` |
+//! | `mpm.managed.send` | `POST /api/v1/sessions/managed/{id}/send` |
+//! | `mpm.managed.provision_status` | `GET /api/v1/sessions/managed/{id}/provision-status` |
+//! | `mpm.managed.sync_assets` | `POST /api/v1/sessions/managed/{id}/sync-assets` |
+//! | `mpm.managed.sync_assets_all` | `POST /api/v1/sessions/managed/sync-assets` |
+//! | `mpm.managed.answer` | `POST /api/v1/sessions/managed/{id}/answer` |
+//! | `mpm.managed.attach_cmd` | `GET /api/v1/sessions/managed/{id}/attach-cmd` |
+//! | `mpm.managed.activity` | `GET /api/v1/sessions/managed/{id}/activity` |
+//! | `mpm.managed.runtime_stop` | `POST /api/v1/sessions/managed/{id}/runtime-stop` |
+//! | `mpm.managed.resume` | `POST /api/v1/sessions/managed/{id}/resume` |
+//! | `mpm.managed.reactivate` | `POST /api/v1/sessions/managed/{id}/reactivate` |
+//! | `mpm.managed.decommission` | `POST /api/v1/sessions/managed/{id}/decommission` |
+//! | `mpm.managed.delete` | `POST /api/v1/sessions/managed/{id}/delete` |
+//!
+//! `mpm.managed.stop` and `mpm.managed.runtime_stop` name the same body, because
+//! the `DELETE` route is a legacy alias that delegates to runtime-stop. Both
+//! names are registered so a caller porting either HTTP route finds its verb.
+//!
+//! Test: `managed_*_parity` in `daemon::rpc::managed_tests`.
+
+use std::sync::Arc;
+
+use serde::Deserialize;
+use trusty_common::uds::server::RpcRouter;
+
+use crate::daemon::managed_routes::prune::{PruneRequest, PruneWorktreesRequest};
+use crate::daemon::managed_routes::{
+    AdoptExistingRequest, AnswerRequest, ReactivateQuery, RenameRequest, SendInputRequest,
+    SpawnRequest, activity, cores, delete, fleet, provision_status, prune, reactivate, reconcile,
+    rename, sync_assets,
+};
+use crate::daemon::state::DaemonState;
+
+/// A request naming a managed session by id, with nothing else.
+#[derive(Debug, Deserialize)]
+pub struct SessionParams {
+    /// The managed-session id the HTTP route reads from its path.
+    pub id: String,
+}
+
+/// `mpm.managed.list` parameters — the HTTP route's two query flags.
+#[derive(Debug, Deserialize, Default)]
+#[serde(default)]
+pub struct ListParams {
+    /// Return only rows whose last-known `source_id` matches exactly.
+    pub source_id: Option<String>,
+    /// Skip the per-session `stale_assets` probe (#4335). Only a caller that
+    /// never reads that flag may pass it — every `stale_assets` then reports
+    /// its `false` default, meaning "not computed".
+    pub slim: bool,
+}
+
+/// `mpm.managed.send` parameters: the id plus the HTTP body.
+#[derive(Debug, Deserialize)]
+pub struct SendParams {
+    /// The managed-session id.
+    pub id: String,
+    /// The text to inject.
+    pub text: String,
+}
+
+/// `mpm.managed.answer` parameters: the id plus the HTTP body.
+#[derive(Debug, Deserialize)]
+pub struct AnswerParams {
+    /// The managed-session id.
+    pub id: String,
+    /// The answer to the pending decision.
+    pub answer: String,
+}
+
+/// `mpm.managed.rename` parameters: the id plus the HTTP body.
+#[derive(Debug, Deserialize)]
+pub struct RenameParams {
+    /// The managed-session id.
+    pub id: String,
+    /// The new session name.
+    pub name: String,
+}
+
+/// `mpm.managed.decommission` parameters: the id plus `?record_only=`.
+#[derive(Debug, Deserialize)]
+pub struct DecommissionParams {
+    /// The managed-session id.
+    pub id: String,
+    /// Tear down the RECORD only, never the filesystem. Absent means false, as
+    /// an absent query parameter does.
+    #[serde(default)]
+    pub record_only: bool,
+}
+
+/// `mpm.managed.delete` parameters: the id plus `?force=`.
+#[derive(Debug, Deserialize)]
+pub struct DeleteParams {
+    /// The managed-session id.
+    pub id: String,
+    /// Bypass the running-session guard. Absent means false.
+    #[serde(default)]
+    pub force: bool,
+}
+
+/// `mpm.managed.decommission_ephemeral` parameters: `?dry_run=`.
+#[derive(Debug, Deserialize, Default)]
+#[serde(default)]
+pub struct EphemeralParams {
+    /// Report what would be torn down without tearing it down.
+    pub dry_run: bool,
+}
+
+/// `mpm.managed.reactivate` parameters: the id plus the two query flags.
+#[derive(Debug, Deserialize)]
+pub struct ReactivateParams {
+    /// The managed-session id.
+    pub id: String,
+    /// The caller's own pane, excluded from the liveness probe (#2789).
+    #[serde(default)]
+    pub caller_pane_id: Option<String>,
+    /// The caller's self-asserted claim that it watched the agent exit (#2453).
+    #[serde(default)]
+    pub pane_confirmed_dead: bool,
+}
+
+/// A request carrying nothing — the socket form of a GET with no path or query.
+#[derive(Debug, Deserialize, Default)]
+#[serde(default)]
+pub struct NoParams {}
+
+/// Register every managed-session method on `router`.
+///
+/// Why one function rather than several: the SLOC cost is in the closures, not
+/// the structure, and splitting it would separate a method name from the body
+/// it names without making either easier to read.
+pub fn register(router: RpcRouter, state: &Arc<DaemonState>) -> RpcRouter {
+    let router = register_fleet_wide(router, state);
+    register_per_session(router, state)
+}
+
+/// The methods that address the fleet rather than one session.
+fn register_fleet_wide(router: RpcRouter, state: &Arc<DaemonState>) -> RpcRouter {
+    macro_rules! st {
+        () => {
+            Arc::clone(state)
+        };
+    }
+    let (spawn_s, list_s, adopt_s, prune_s, eph_s) = (st!(), st!(), st!(), st!(), st!());
+    let (pw_s, rw_s, fleet_s, sa_s) = (st!(), st!(), st!(), st!());
+
+    router
+        .typed("mpm.managed.spawn", move |req: SpawnRequest| {
+            let state = Arc::clone(&spawn_s);
+            async move { cores::spawn_core(&state, req).await.into_rpc() }
+        })
+        .typed("mpm.managed.list", move |req: ListParams| {
+            let state = Arc::clone(&list_s);
+            async move {
+                cores::list_core(&state, req.source_id.as_deref(), req.slim)
+                    .await
+                    .into_rpc()
+            }
+        })
+        .typed("mpm.managed.adopt", move |req: AdoptExistingRequest| {
+            let state = Arc::clone(&adopt_s);
+            async move { cores::adopt_core(&state, req).await.into_rpc() }
+        })
+        .typed("mpm.managed.prune", move |req: PruneRequest| {
+            let state = Arc::clone(&prune_s);
+            async move { prune::prune_managed_core(&state, req).await.into_rpc() }
+        })
+        .typed(
+            "mpm.managed.decommission_ephemeral",
+            move |req: EphemeralParams| {
+                let state = Arc::clone(&eph_s);
+                async move {
+                    prune::decommission_ephemeral_core(&state, req.dry_run)
+                        .await
+                        .into_rpc()
+                }
+            },
+        )
+        .typed(
+            "mpm.managed.prune_worktrees",
+            move |req: PruneWorktreesRequest| {
+                let state = Arc::clone(&pw_s);
+                async move { prune::prune_worktrees_core(&state, req).await.into_rpc() }
+            },
+        )
+        .typed("mpm.managed.reconcile_worktrees", move |_: NoParams| {
+            let state = Arc::clone(&rw_s);
+            async move { reconcile::reconcile_worktrees_core(&state).await.into_rpc() }
+        })
+        .typed("mpm.managed.fleet", move |_: NoParams| {
+            let state = Arc::clone(&fleet_s);
+            async move { fleet::fleet_core(&state).await.into_rpc() }
+        })
+        .typed("mpm.managed.sync_assets_all", move |_: NoParams| {
+            let state = Arc::clone(&sa_s);
+            async move {
+                sync_assets::sync_all_session_assets_core(&state)
+                    .await
+                    .into_rpc()
+            }
+        })
+}
+
+/// The methods that address one session by id.
+fn register_per_session(router: RpcRouter, state: &Arc<DaemonState>) -> RpcRouter {
+    macro_rules! st {
+        () => {
+            Arc::clone(state)
+        };
+    }
+    let (get_s, stop_s, rstop_s, rename_s, send_s) = (st!(), st!(), st!(), st!(), st!());
+    let (ps_s, sa_s, ans_s, ac_s, act_s) = (st!(), st!(), st!(), st!(), st!());
+    let (res_s, react_s, dec_s, del_s) = (st!(), st!(), st!(), st!());
+
+    router
+        .typed("mpm.managed.get", move |req: SessionParams| {
+            let state = Arc::clone(&get_s);
+            async move { cores::get_core(&state, &req.id).await.into_rpc() }
+        })
+        // The DELETE alias and runtime-stop are ONE body; both names resolve to
+        // it so a caller porting either HTTP route finds its verb.
+        .typed("mpm.managed.stop", move |req: SessionParams| {
+            let state = Arc::clone(&stop_s);
+            async move { cores::runtime_stop_core(&state, &req.id).await.into_rpc() }
+        })
+        .typed("mpm.managed.runtime_stop", move |req: SessionParams| {
+            let state = Arc::clone(&rstop_s);
+            async move { cores::runtime_stop_core(&state, &req.id).await.into_rpc() }
+        })
+        .typed("mpm.managed.rename", move |req: RenameParams| {
+            let state = Arc::clone(&rename_s);
+            async move {
+                rename::rename_core(&state, &req.id, RenameRequest { name: req.name })
+                    .await
+                    .into_rpc()
+            }
+        })
+        .typed("mpm.managed.send", move |req: SendParams| {
+            let state = Arc::clone(&send_s);
+            async move {
+                cores::send_core(&state, &req.id, SendInputRequest { text: req.text })
+                    .await
+                    .into_rpc()
+            }
+        })
+        .typed("mpm.managed.provision_status", move |req: SessionParams| {
+            let state = Arc::clone(&ps_s);
+            async move {
+                provision_status::provision_status_core(&state, &req.id)
+                    .await
+                    .into_rpc()
+            }
+        })
+        .typed("mpm.managed.sync_assets", move |req: SessionParams| {
+            let state = Arc::clone(&sa_s);
+            async move {
+                sync_assets::sync_session_assets_core(&state, &req.id)
+                    .await
+                    .into_rpc()
+            }
+        })
+        .typed("mpm.managed.answer", move |req: AnswerParams| {
+            let state = Arc::clone(&ans_s);
+            async move {
+                cores::answer_core(&state, &req.id, AnswerRequest { answer: req.answer })
+                    .await
+                    .into_rpc()
+            }
+        })
+        .typed("mpm.managed.attach_cmd", move |req: SessionParams| {
+            let state = Arc::clone(&ac_s);
+            async move { cores::attach_cmd_core(&state, &req.id).await.into_rpc() }
+        })
+        .typed("mpm.managed.activity", move |req: SessionParams| {
+            let state = Arc::clone(&act_s);
+            async move { activity::activity_core(&state, &req.id).await.into_rpc() }
+        })
+        .typed("mpm.managed.resume", move |req: SessionParams| {
+            let state = Arc::clone(&res_s);
+            async move { cores::resume_core(&state, &req.id).await.into_rpc() }
+        })
+        .typed("mpm.managed.reactivate", move |req: ReactivateParams| {
+            let state = Arc::clone(&react_s);
+            async move {
+                let query = ReactivateQuery {
+                    caller_pane_id: req.caller_pane_id,
+                    pane_confirmed_dead: req.pane_confirmed_dead,
+                };
+                let outcome = reactivate::reactivate_core(&state, &req.id, &query).await;
+                outcome.into_rpc()
+            }
+        })
+        .typed(
+            "mpm.managed.decommission",
+            move |req: DecommissionParams| {
+                let state = Arc::clone(&dec_s);
+                async move {
+                    cores::decommission_core(&state, &req.id, req.record_only)
+                        .await
+                        .into_rpc()
+                }
+            },
+        )
+        .typed("mpm.managed.delete", move |req: DeleteParams| {
+            let state = Arc::clone(&del_s);
+            async move {
+                delete::delete_core(&state, &req.id, req.force)
+                    .await
+                    .into_rpc()
+            }
+        })
+}

--- a/crates/trusty-mpm/src/daemon/rpc/managed_tests.rs
+++ b/crates/trusty-mpm/src/daemon/rpc/managed_tests.rs
@@ -1,0 +1,1454 @@
+//! Parity tests for the managed-session, control-plane, and L2 proxy methods
+//! (#6288 slice 4).
+//!
+//! Why: the acceptance bar for this slice is that the socket and HTTP answer the
+//! same thing, and that the #6197 guard did not stay behind on HTTP. Both are
+//! claims about two transports agreeing, so every test here drives BOTH — the
+//! real axum router built by `daemon::api::router`, and the real RPC router
+//! built by [`super::managed::register`] — against the same `DaemonState`, and
+//! compares what comes back.
+//!
+//! What: [`assert_parity`] holds the comparison rule in one place, including the
+//! transport-only allowlist documented in `super::managed`'s module header. A
+//! test that only asserted the RPC side would pass on a route that answers
+//! something different from HTTP, which is the exact failure this slice can
+//! produce.
+//!
+//! Nothing here spawns a real process. The per-session routes are driven with a
+//! session id that does not exist, which reaches the same body and the same
+//! refusal on both transports; the control-plane spawn route uses the cap-0
+//! state `control_routes`'s own #6197 tests use, so the spawn path is REACHED
+//! and rejected at admission rather than launching `claude`.
+
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+
+use axum::Router;
+use axum::body::Body;
+use axum::extract::connect_info::MockConnectInfo;
+use axum::http::{Method, Request};
+use serde_json::{Value, json};
+use tower::ServiceExt;
+use trusty_common::uds::server::{
+    CODE_INVALID_PARAMS, CODE_METHOD_NOT_FOUND, RpcResponse, RpcRouter,
+};
+
+use super::control::CallerTrust;
+use super::outcome::{CODE_FORBIDDEN, CODE_NOT_FOUND, status_to_rpc_code};
+use crate::daemon::api;
+use crate::daemon::rpc::managed;
+use crate::daemon::state::DaemonState;
+use crate::session_manager::ManagedError;
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+/// A `DaemonState` rooted in a fresh temp dir, with its managed-session store
+/// pre-seeded so nothing here can reach the operator's live fleet.
+///
+/// Why `with_root_isolated_managed` and not `with_paths`: `session_manager()`
+/// lazily calls `RealTmuxDriver::discover()` and then `reconcile_on_boot`, which
+/// ADOPTS the machine's live tmux sessions into whatever store it was given —
+/// carrying their real `workspace_path`s with them. A fleet-wide route driven
+/// against that state is then operating on the operator's real worktrees, and
+/// `sync-assets` in particular WRITES into them. `with_root_isolated_managed`
+/// pre-seeds the `OnceCell` with a `FakeNoopTmuxDriver`-backed manager, so the
+/// cell is full before the first request and discovery never runs. This is the
+/// same hazard `#1790` records, and the same remedy.
+async fn test_state() -> (Arc<DaemonState>, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let state = DaemonState::with_root_isolated_managed(dir.path().to_path_buf()).await;
+    (Arc::new(state), dir)
+}
+
+/// A `DaemonState` whose control-plane concurrency cap is `0`.
+///
+/// Why: the #6197 tests must never spawn a real backend. With the cap at 0,
+/// `run_session` rejects at admission and returns an error BEFORE any spawn — so
+/// a request that PASSES every guard still cannot launch a process, while a
+/// request that a guard refuses returns 400/403 instead. The two are
+/// distinguishable, which is what makes "the guard fired" provable rather than
+/// assumed. Lifted verbatim from `control_routes`'s `test_state_no_spawn`.
+async fn test_state_no_spawn() -> (Arc<DaemonState>, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("temp dir");
+    // `with_root` reads `[control_plane]` from the root it is handed, so the cap
+    // goes directly there rather than under a `FrameworkPaths` layout.
+    std::fs::write(
+        dir.path().join("config.toml"),
+        "[control_plane]\nmax_concurrent_sessions = 0\n",
+    )
+    .expect("write config");
+    let state = DaemonState::with_root_isolated_managed(dir.path().to_path_buf()).await;
+    (Arc::new(state), dir)
+}
+
+/// The daemon's real HTTP router, with a loopback peer injected.
+///
+/// The `MockConnectInfo` layer is what the control routes' `ConnectInfo`
+/// extractor reads; without it those routes 500 before reaching their body.
+fn http_router(state: Arc<DaemonState>) -> Router {
+    api::router(state).layer(MockConnectInfo(SocketAddr::new(
+        IpAddr::V4(Ipv4Addr::LOCALHOST),
+        0,
+    )))
+}
+
+/// The daemon's real RPC router for this state.
+fn rpc_router(state: &Arc<DaemonState>) -> RpcRouter {
+    managed::register(RpcRouter::new(), state)
+}
+
+/// One HTTP answer, kept in the two shapes the comparison needs.
+struct HttpAnswer {
+    status: u16,
+    text: String,
+    json: Option<Value>,
+}
+
+/// Drive `router` and read the whole answer.
+async fn http_call(router: Router, method: Method, uri: &str, body: Option<Value>) -> HttpAnswer {
+    let mut builder = Request::builder().method(method).uri(uri);
+    let request = match body {
+        Some(v) => {
+            builder = builder.header("content-type", "application/json");
+            builder.body(Body::from(v.to_string()))
+        }
+        None => builder.body(Body::empty()),
+    }
+    .expect("build request");
+    let response = router.oneshot(request).await.expect("http call");
+    let status = response.status().as_u16();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read body");
+    let text = String::from_utf8_lossy(&bytes).into_owned();
+    let json = serde_json::from_slice::<Value>(&bytes).ok();
+    HttpAnswer { status, text, json }
+}
+
+/// Dispatch one unary RPC request against `router`.
+async fn rpc_call(router: &RpcRouter, method: &str, params: Value) -> RpcResponse {
+    let frame = json!({"jsonrpc": "2.0", "id": 1, "method": method, "params": params});
+    router.dispatch(frame.to_string().as_bytes()).await
+}
+
+/// Assert that the two transports answered the same route the same way.
+///
+/// Why: the allowlist in `super::managed`'s header is a claim about what may
+/// differ; putting the comparison in one function is what keeps every test
+/// bound to the same claim instead of each test choosing its own leniency.
+/// What: a 2xx HTTP answer must have an RPC `result` equal to its JSON body; a
+/// refusal must have an RPC `error` whose message is the HTTP body verbatim and
+/// whose code is `status_to_rpc_code(status)`. The one route that overrides that
+/// projection — resume's two 422 classes, which HTTP separates with a header the
+/// socket has no place for — is covered directly by
+/// `managed_routes::cores::cores_tests`.
+fn assert_parity(label: &str, http: &HttpAnswer, rpc: &RpcResponse) {
+    if (200..300).contains(&http.status) {
+        let expected = http.json.as_ref().unwrap_or_else(|| {
+            panic!("{label}: a 2xx HTTP body must be JSON, got {:?}", http.text)
+        });
+        let got = rpc.result.as_ref().unwrap_or_else(|| {
+            panic!("{label}: rpc refused a route HTTP answered {}", http.status)
+        });
+        assert_eq!(got, expected, "{label}: response bodies must be identical");
+        return;
+    }
+    let error = rpc
+        .error
+        .as_ref()
+        .unwrap_or_else(|| panic!("{label}: rpc succeeded where HTTP answered {}", http.status));
+    assert_eq!(
+        error.message, http.text,
+        "{label}: the refusal message must be the HTTP body verbatim"
+    );
+    assert_eq!(
+        error.code,
+        status_to_rpc_code(http.status),
+        "{label}: the refusal code must be the documented projection of HTTP {}",
+        http.status
+    );
+}
+
+/// An id no session will ever have — the hermetic way to reach a route body.
+const MISSING_ID: &str = "11111111-2222-3333-4444-555555555555";
+
+// ── Registration ─────────────────────────────────────────────────────────────
+
+/// Every route this slice owns is reachable under its documented method name.
+///
+/// Why: the slice's first acceptance criterion is coverage, and a method that
+/// was never registered fails silently — a caller gets `method_not_found`, which
+/// reads like a client typo. This pins the whole list.
+/// Test: this test.
+#[tokio::test]
+async fn every_scoped_route_has_a_method() {
+    let (state, _dir) = test_state().await;
+    let router = rpc_router(&state);
+    let registered: Vec<&str> = router.method_names().chain(router.stream_names()).collect();
+
+    for expected in [
+        "mpm.managed.spawn",
+        "mpm.managed.list",
+        "mpm.managed.adopt",
+        "mpm.managed.prune",
+        "mpm.managed.decommission_ephemeral",
+        "mpm.managed.prune_worktrees",
+        "mpm.managed.reconcile_worktrees",
+        "mpm.managed.fleet",
+        "mpm.managed.get",
+        "mpm.managed.stop",
+        "mpm.managed.runtime_stop",
+        "mpm.managed.rename",
+        "mpm.managed.send",
+        "mpm.managed.provision_status",
+        "mpm.managed.sync_assets",
+        "mpm.managed.sync_assets_all",
+        "mpm.managed.answer",
+        "mpm.managed.attach_cmd",
+        "mpm.managed.activity",
+        "mpm.managed.resume",
+        "mpm.managed.reactivate",
+        "mpm.managed.decommission",
+        "mpm.managed.delete",
+        "mpm.control.list",
+        "mpm.control.run",
+        "mpm.control.connect",
+        "mpm.control.stop",
+        "mpm.control.auth",
+        "mpm.proxy.focus",
+        "mpm.proxy.get_focus",
+        "mpm.proxy.unfocus",
+        "mpm.proxy.message",
+        "mpm.proxy.summary",
+    ] {
+        assert!(
+            registered.contains(&expected),
+            "{expected} is not registered; the listener serves {registered:?}"
+        );
+    }
+}
+
+/// An unregistered name still refuses in the shape slice 1 established.
+#[tokio::test]
+async fn an_unknown_method_is_still_method_not_found() {
+    let (state, _dir) = test_state().await;
+    let response = rpc_call(&rpc_router(&state), "mpm.managed.nope", json!({})).await;
+    assert_eq!(
+        response.error.expect("unknown method refuses").code,
+        CODE_METHOD_NOT_FOUND
+    );
+}
+
+/// Params that do not decode are an invalid-params refusal, not a panic.
+#[tokio::test]
+async fn malformed_params_are_invalid_params() {
+    let (state, _dir) = test_state().await;
+    // `mpm.managed.get` requires an `id`; an empty object cannot decode.
+    let response = rpc_call(&rpc_router(&state), "mpm.managed.get", json!({})).await;
+    assert_eq!(
+        response.error.expect("must refuse").code,
+        CODE_INVALID_PARAMS
+    );
+}
+
+// ── #6197 parity: the guard travels ──────────────────────────────────────────
+
+/// The caller-trust refusal is byte-identical to the HTTP 403 the loopback
+/// guard answers (#6197, #6288).
+///
+/// Why: `loopback_guard` and the socket's peer-uid check are different
+/// mechanisms, so the only thing that can be identical between them is the
+/// REFUSAL. This pins that, which is what lets the RPC-side tests below assert
+/// against a known string rather than against whatever the body happened to say.
+/// Test: this test.
+#[tokio::test]
+async fn caller_trust_refusal_matches_the_http_403() {
+    let (state, _dir) = test_state_no_spawn().await;
+    let peer = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 50)), 40000);
+    let mut request = Request::builder()
+        .method(Method::POST)
+        .uri("/api/v1/control/sessions/run")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({"project_id": "p", "workdir": "/tmp", "backend": "stream-json"}).to_string(),
+        ))
+        .expect("build");
+    request
+        .extensions_mut()
+        .insert(axum::extract::ConnectInfo(peer));
+    // No `MockConnectInfo` layer here — it would overwrite the remote peer.
+    let response = api::router(Arc::clone(&state))
+        .oneshot(request)
+        .await
+        .expect("http call");
+    assert_eq!(response.status().as_u16(), 403);
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body");
+    assert_eq!(
+        String::from_utf8_lossy(&bytes),
+        CallerTrust::REFUSAL,
+        "the shared refusal string must be what HTTP actually sends"
+    );
+
+    let refusal = CallerTrust::unverified()
+        .ensure_local()
+        .expect_err("an unverified caller must be refused")
+        .into_rpc()
+        .expect_err("a 403 is always an error");
+    assert_eq!(refusal.code, CODE_FORBIDDEN);
+    assert_eq!(refusal.message, CallerTrust::REFUSAL);
+}
+
+/// An untrusted caller is refused by the SHARED body, before any spawn (#6197).
+///
+/// Why (Fail-Open Check): the socket's own peer check is stronger than
+/// `loopback_guard`, so a socket request always carries
+/// a verified verdict — which is exactly the argument that could hide
+/// a body that never checks at all. This drives the same body the RPC method
+/// drives, with the trust value the RPC method would carry if the socket had NOT
+/// vouched for the caller, and asserts the 403. Under the cap-0 state a request
+/// that reached `run_session` answers 500, so a 403 proves the guard returned
+/// first.
+/// Test: this test.
+#[tokio::test]
+async fn rpc_ctl_run_refuses_an_untrusted_caller() {
+    let (state, _dir) = test_state_no_spawn().await;
+    let dir = tempfile::tempdir().expect("temp dir");
+    let outcome = crate::daemon::api::control_routes::ctl_run_core(
+        &state,
+        CallerTrust::unverified(),
+        serde_json::from_value(json!({
+            "project_id": "p",
+            "workdir": dir.path().to_string_lossy(),
+            "backend": "stream-json",
+        }))
+        .expect("decode"),
+    )
+    .await;
+    assert_eq!(
+        outcome.status, 403,
+        "an unverified caller must be refused before any spawn"
+    );
+    let error = outcome.into_rpc().expect_err("403 is an error");
+    assert_eq!(error.code, CODE_FORBIDDEN);
+    assert_eq!(error.message, CallerTrust::REFUSAL);
+}
+
+/// A `claude_cmd` outside the allowed set is rejected over the SOCKET (#6197).
+///
+/// Why (Fail-Open Check): the pre-#6205 handler passed `claude_cmd` into the
+/// spawn path unvalidated — arbitrary process execution. This sends `"sh"` over
+/// the RPC router with a valid workdir, so nothing else can refuse first. Under
+/// the cap-0 state an unguarded request reaches `run_session` and answers 500,
+/// which is neither the asserted code nor the asserted message — so a pass here
+/// cannot come from the request failing for some other reason.
+/// Test: this test.
+#[tokio::test]
+async fn rpc_ctl_run_rejects_claude_cmd_outside_allowlist() {
+    let (state, _dir) = test_state_no_spawn().await;
+    let dir = tempfile::tempdir().expect("temp dir");
+    let response = rpc_call(
+        &rpc_router(&state),
+        "mpm.control.run",
+        json!({
+            "project_id": "p",
+            "workdir": dir.path().to_string_lossy(),
+            "backend": "tmux",
+            "claude_cmd": "sh",
+        }),
+    )
+    .await;
+    let error = response.error.expect("must refuse");
+    assert_eq!(
+        error.code, CODE_INVALID_PARAMS,
+        "a 400 projects onto -32602"
+    );
+    assert_eq!(
+        error.message,
+        "claude_cmd override is not permitted over HTTP; omit it to use the default `claude`",
+        "the refusal must come from validate_claude_cmd, not from somewhere else"
+    );
+}
+
+/// A `prompt_file` carrying shell metacharacters is rejected over the SOCKET
+/// (#6197).
+///
+/// Why: `prompt_file` reaches the tmux command line, so
+/// `"/tmp/x; touch /tmp/PWNED; #"` was command injection. The asserted message
+/// is `validate_prompt_file`'s and nothing else's.
+/// Test: this test.
+#[tokio::test]
+async fn rpc_ctl_run_rejects_prompt_file_injection() {
+    let (state, _dir) = test_state_no_spawn().await;
+    let dir = tempfile::tempdir().expect("temp dir");
+    let response = rpc_call(
+        &rpc_router(&state),
+        "mpm.control.run",
+        json!({
+            "project_id": "p",
+            "workdir": dir.path().to_string_lossy(),
+            "backend": "tmux",
+            "prompt_file": "/tmp/x; touch /tmp/PWNED; #",
+        }),
+    )
+    .await;
+    let error = response.error.expect("must refuse");
+    assert_eq!(error.code, CODE_INVALID_PARAMS);
+    assert_eq!(
+        error.message,
+        "prompt_file must be an absolute path (no `..`, no shell metacharacters) to an existing file"
+    );
+    assert!(
+        !std::path::Path::new("/tmp/PWNED").exists(),
+        "the injected command must never have run"
+    );
+}
+
+/// A relative `workdir` is rejected over the SOCKET (#6197).
+#[tokio::test]
+async fn rpc_ctl_run_rejects_relative_workdir() {
+    let (state, _dir) = test_state_no_spawn().await;
+    let response = rpc_call(
+        &rpc_router(&state),
+        "mpm.control.run",
+        json!({"project_id": "p", "workdir": "relative/dir", "backend": "stream-json"}),
+    )
+    .await;
+    let error = response.error.expect("must refuse");
+    assert_eq!(error.code, CODE_INVALID_PARAMS);
+    assert_eq!(
+        error.message,
+        "workdir must be an absolute path (no `..`) to an existing directory"
+    );
+}
+
+/// A `workdir` containing `..` is rejected over the SOCKET (#6197).
+#[tokio::test]
+async fn rpc_ctl_run_rejects_workdir_traversal() {
+    let (state, _dir) = test_state_no_spawn().await;
+    let response = rpc_call(
+        &rpc_router(&state),
+        "mpm.control.run",
+        json!({"project_id": "p", "workdir": "/tmp/../etc", "backend": "stream-json"}),
+    )
+    .await;
+    let error = response.error.expect("must refuse");
+    assert_eq!(error.code, CODE_INVALID_PARAMS);
+    assert_eq!(
+        error.message,
+        "workdir must be an absolute path (no `..`) to an existing directory"
+    );
+}
+
+/// A legitimate request passes every guard and reaches the capped spawn path
+/// (#6197).
+///
+/// Why: without this, every test above could pass on a body that refuses
+/// everything. Under the cap-0 state the advanced request is rejected by
+/// admission — an internal error, which is neither a validator's 400 nor the
+/// caller check's 403 — so reaching it proves all four guards let a valid
+/// request through.
+/// Test: this test.
+#[tokio::test]
+async fn rpc_ctl_run_accepts_a_default_request_and_reaches_the_spawn_path() {
+    let (state, _dir) = test_state_no_spawn().await;
+    let dir = tempfile::tempdir().expect("temp dir");
+    let response = rpc_call(
+        &rpc_router(&state),
+        "mpm.control.run",
+        json!({
+            "project_id": "p",
+            "workdir": dir.path().to_string_lossy(),
+            "backend": "stream-json",
+        }),
+    )
+    .await;
+    let error = response
+        .error
+        .expect("the cap-0 state refuses at admission");
+    assert_eq!(
+        error.code,
+        trusty_common::uds::server::CODE_INTERNAL_ERROR,
+        "a valid request must reach run_session, not a guard: {}",
+        error.message
+    );
+    assert_ne!(error.message, CallerTrust::REFUSAL);
+}
+
+// ── Control-plane parity ─────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn rpc_ctl_list_parity() {
+    let (state, _dir) = test_state().await;
+    let http = http_call(
+        http_router(Arc::clone(&state)),
+        Method::GET,
+        "/api/v1/control/sessions",
+        None,
+    )
+    .await;
+    let rpc = rpc_call(&rpc_router(&state), "mpm.control.list", json!({})).await;
+    assert_parity("mpm.control.list", &http, &rpc);
+}
+
+#[tokio::test]
+async fn rpc_ctl_stop_parity() {
+    let (state, _dir) = test_state().await;
+    let http = http_call(
+        http_router(Arc::clone(&state)),
+        Method::POST,
+        "/api/v1/control/sessions/ghost/stop",
+        None,
+    )
+    .await;
+    let rpc = rpc_call(
+        &rpc_router(&state),
+        "mpm.control.stop",
+        json!({"id": "ghost"}),
+    )
+    .await;
+    assert_eq!(http.status, 404);
+    assert_parity("mpm.control.stop", &http, &rpc);
+}
+
+#[tokio::test]
+async fn rpc_ctl_auth_parity() {
+    let (state, _dir) = test_state().await;
+    let http = http_call(
+        http_router(Arc::clone(&state)),
+        Method::GET,
+        "/api/v1/control/sessions/ghost/auth",
+        None,
+    )
+    .await;
+    let rpc = rpc_call(
+        &rpc_router(&state),
+        "mpm.control.auth",
+        json!({"id": "ghost"}),
+    )
+    .await;
+    assert_eq!(http.status, 404);
+    assert_parity("mpm.control.auth", &http, &rpc);
+}
+
+/// `mpm.control.connect` refuses an unknown session before writing any frame.
+///
+/// Why: the SSE route 404s an unknown id; the stream form must not open a stream
+/// and then report the failure inside it, because a caller reading frames would
+/// have to distinguish "no events yet" from "no such session".
+/// Test: this test.
+#[tokio::test]
+async fn rpc_ctl_connect_unknown_session_refuses_before_any_frame() {
+    let (state, _dir) = test_state().await;
+    let router = rpc_router(&state);
+    let frame = json!({
+        "jsonrpc": "2.0", "id": 1, "stream": true,
+        "method": "mpm.control.connect", "params": {"id": "ghost"},
+    });
+    let outcome = router
+        .dispatch_streaming(frame.to_string().as_bytes())
+        .await;
+    let trusty_common::uds::server::RpcOutcome::Stream { mut items, .. } = outcome else {
+        panic!("a streaming request must produce a stream outcome");
+    };
+    let first = items.recv().await.expect("one terminal frame");
+    let error = first.expect_err("an unknown session must refuse");
+    assert_eq!(error.code, CODE_NOT_FOUND);
+    assert_eq!(error.message, "session ghost not found");
+    assert!(
+        items.recv().await.is_none(),
+        "a refusal carries exactly one frame"
+    );
+}
+
+/// A unary request for the streaming connect method is refused, not silently
+/// answered with a snapshot.
+#[tokio::test]
+async fn rpc_ctl_connect_refuses_a_unary_request() {
+    let (state, _dir) = test_state().await;
+    let response = rpc_call(
+        &rpc_router(&state),
+        "mpm.control.connect",
+        json!({"id": "x"}),
+    )
+    .await;
+    assert_eq!(
+        response.error.expect("must refuse").code,
+        trusty_common::uds::server::CODE_STREAM_REQUIRED
+    );
+}
+
+/// `mpm.control.connect` carries the session's events as stream frames — the
+/// same events, in order, that the SSE route's `data:` lines carry (#6288).
+///
+/// Why: the refusal test above proves only that the method exists. Without this,
+/// a handler that opened a stream and never forwarded anything would pass every
+/// other test here, and a caller would read an idle stream as a quiet session.
+/// Test: this test.
+#[tokio::test]
+async fn rpc_ctl_connect_streams_events() {
+    use crate::control::id::ControlSessionId;
+    use crate::control::state::SessionMetadata;
+
+    let (state, _dir) = test_state().await;
+    let id = ControlSessionId::new("stream-proj", 0);
+    let (command_tx, _command_rx) = tokio::sync::mpsc::channel(4);
+    let (event_tx, _) = tokio::sync::broadcast::channel(16);
+    let handle = crate::control::actor::SessionActorHandle {
+        command_tx,
+        event_tx: event_tx.clone(),
+        write_lock_held: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        metadata: Arc::new(tokio::sync::RwLock::new(SessionMetadata::new(
+            id.clone(),
+            "stream-proj".into(),
+            crate::control::event::BackendKind::StreamJson,
+        ))),
+    };
+    state.session_registry.register(id.clone(), handle).await;
+
+    let router = rpc_router(&state);
+    let frame = json!({
+        "jsonrpc": "2.0", "id": 1, "stream": true,
+        "method": "mpm.control.connect", "params": {"id": id.to_string()},
+    });
+    let outcome = router
+        .dispatch_streaming(frame.to_string().as_bytes())
+        .await;
+    let trusty_common::uds::server::RpcOutcome::Stream { mut items, .. } = outcome else {
+        panic!("a streaming request must produce a stream outcome");
+    };
+
+    let event = crate::control::event::SessionEvent::ObserverLagged {
+        session_id: id.clone(),
+        dropped: 7,
+    };
+    let expected = serde_json::to_value(&event).expect("serialize");
+    event_tx.send(event).expect("the subscriber is live");
+
+    let first = items.recv().await.expect("one item").expect("not an error");
+    assert_eq!(
+        first, expected,
+        "a stream frame must carry the SessionEvent verbatim"
+    );
+}
+
+// ── Managed-session parity ───────────────────────────────────────────────────
+
+/// Drive one id-addressed route both ways against a session that does not
+/// exist, and assert the two answers match.
+async fn assert_missing_session_parity(
+    label: &str,
+    http_method: Method,
+    http_uri: &str,
+    rpc_method: &str,
+    rpc_params: Value,
+) {
+    let (state, _dir) = test_state().await;
+    let body = if http_method == Method::GET || http_method == Method::DELETE {
+        None
+    } else {
+        Some(json!({"text": "x", "answer": "x", "name": "x"}))
+    };
+    let http = http_call(http_router(Arc::clone(&state)), http_method, http_uri, body).await;
+    let rpc = rpc_call(&rpc_router(&state), rpc_method, rpc_params).await;
+    assert!(
+        http.status >= 400,
+        "{label}: an absent session must refuse, got {}",
+        http.status
+    );
+    assert_parity(label, &http, &rpc);
+}
+
+#[tokio::test]
+async fn managed_get_parity() {
+    assert_missing_session_parity(
+        "mpm.managed.get",
+        Method::GET,
+        &format!("/api/v1/sessions/managed/{MISSING_ID}"),
+        "mpm.managed.get",
+        json!({"id": MISSING_ID}),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn managed_runtime_stop_parity() {
+    assert_missing_session_parity(
+        "mpm.managed.runtime_stop",
+        Method::POST,
+        &format!("/api/v1/sessions/managed/{MISSING_ID}/runtime-stop"),
+        "mpm.managed.runtime_stop",
+        json!({"id": MISSING_ID}),
+    )
+    .await;
+}
+
+/// The `DELETE` alias and `mpm.managed.stop` are the same body.
+#[tokio::test]
+async fn managed_stop_alias_parity() {
+    assert_missing_session_parity(
+        "mpm.managed.stop",
+        Method::DELETE,
+        &format!("/api/v1/sessions/managed/{MISSING_ID}"),
+        "mpm.managed.stop",
+        json!({"id": MISSING_ID}),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn managed_send_parity() {
+    assert_missing_session_parity(
+        "mpm.managed.send",
+        Method::POST,
+        &format!("/api/v1/sessions/managed/{MISSING_ID}/send"),
+        "mpm.managed.send",
+        json!({"id": MISSING_ID, "text": "x"}),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn managed_answer_parity() {
+    assert_missing_session_parity(
+        "mpm.managed.answer",
+        Method::POST,
+        &format!("/api/v1/sessions/managed/{MISSING_ID}/answer"),
+        "mpm.managed.answer",
+        json!({"id": MISSING_ID, "answer": "x"}),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn managed_attach_cmd_parity() {
+    assert_missing_session_parity(
+        "mpm.managed.attach_cmd",
+        Method::GET,
+        &format!("/api/v1/sessions/managed/{MISSING_ID}/attach-cmd"),
+        "mpm.managed.attach_cmd",
+        json!({"id": MISSING_ID}),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn managed_activity_parity() {
+    assert_missing_session_parity(
+        "mpm.managed.activity",
+        Method::GET,
+        &format!("/api/v1/sessions/managed/{MISSING_ID}/activity"),
+        "mpm.managed.activity",
+        json!({"id": MISSING_ID}),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn managed_rename_parity() {
+    assert_missing_session_parity(
+        "mpm.managed.rename",
+        Method::PATCH,
+        &format!("/api/v1/sessions/managed/{MISSING_ID}"),
+        "mpm.managed.rename",
+        json!({"id": MISSING_ID, "name": "x"}),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn managed_resume_parity() {
+    assert_missing_session_parity(
+        "mpm.managed.resume",
+        Method::POST,
+        &format!("/api/v1/sessions/managed/{MISSING_ID}/resume"),
+        "mpm.managed.resume",
+        json!({"id": MISSING_ID}),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn managed_reactivate_parity() {
+    assert_missing_session_parity(
+        "mpm.managed.reactivate",
+        Method::POST,
+        &format!("/api/v1/sessions/managed/{MISSING_ID}/reactivate"),
+        "mpm.managed.reactivate",
+        json!({"id": MISSING_ID}),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn managed_decommission_parity() {
+    assert_missing_session_parity(
+        "mpm.managed.decommission",
+        Method::POST,
+        &format!("/api/v1/sessions/managed/{MISSING_ID}/decommission"),
+        "mpm.managed.decommission",
+        json!({"id": MISSING_ID}),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn managed_delete_parity() {
+    assert_missing_session_parity(
+        "mpm.managed.delete",
+        Method::POST,
+        &format!("/api/v1/sessions/managed/{MISSING_ID}/delete"),
+        "mpm.managed.delete",
+        json!({"id": MISSING_ID}),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn managed_provision_status_parity() {
+    assert_missing_session_parity(
+        "mpm.managed.provision_status",
+        Method::GET,
+        &format!("/api/v1/sessions/managed/{MISSING_ID}/provision-status"),
+        "mpm.managed.provision_status",
+        json!({"id": MISSING_ID}),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn managed_sync_assets_parity() {
+    assert_missing_session_parity(
+        "mpm.managed.sync_assets",
+        Method::POST,
+        &format!("/api/v1/sessions/managed/{MISSING_ID}/sync-assets"),
+        "mpm.managed.sync_assets",
+        json!({"id": MISSING_ID}),
+    )
+    .await;
+}
+
+/// An unparseable id is the SAME 400 on both transports (#6288).
+#[tokio::test]
+async fn managed_unparseable_id_parity() {
+    let (state, _dir) = test_state().await;
+    let http = http_call(
+        http_router(Arc::clone(&state)),
+        Method::GET,
+        "/api/v1/sessions/managed/not-a-uuid",
+        None,
+    )
+    .await;
+    let rpc = rpc_call(
+        &rpc_router(&state),
+        "mpm.managed.get",
+        json!({"id": "not-a-uuid"}),
+    )
+    .await;
+    assert_eq!(http.status, 400);
+    assert_parity("mpm.managed.get (bad id)", &http, &rpc);
+}
+
+#[tokio::test]
+async fn managed_list_parity() {
+    let (state, _dir) = test_state().await;
+    let http = http_call(
+        http_router(Arc::clone(&state)),
+        Method::GET,
+        "/api/v1/sessions/managed",
+        None,
+    )
+    .await;
+    let rpc = rpc_call(&rpc_router(&state), "mpm.managed.list", json!({})).await;
+    assert_eq!(http.status, 200);
+    assert_parity("mpm.managed.list", &http, &rpc);
+}
+
+#[tokio::test]
+async fn managed_fleet_parity() {
+    let (state, _dir) = test_state().await;
+    let http = http_call(
+        http_router(Arc::clone(&state)),
+        Method::GET,
+        "/api/v1/sessions/managed/fleet",
+        None,
+    )
+    .await;
+    let rpc = rpc_call(&rpc_router(&state), "mpm.managed.fleet", json!({})).await;
+    assert_eq!(http.status, 200);
+    assert_parity("mpm.managed.fleet", &http, &rpc);
+}
+
+#[tokio::test]
+async fn managed_sync_assets_all_parity() {
+    let (state, _dir) = test_state().await;
+    let http = http_call(
+        http_router(Arc::clone(&state)),
+        Method::POST,
+        "/api/v1/sessions/managed/sync-assets",
+        None,
+    )
+    .await;
+    let rpc = rpc_call(
+        &rpc_router(&state),
+        "mpm.managed.sync_assets_all",
+        json!({}),
+    )
+    .await;
+    assert_eq!(http.status, 200);
+    assert_parity("mpm.managed.sync_assets_all", &http, &rpc);
+}
+
+#[tokio::test]
+async fn managed_decommission_ephemeral_parity() {
+    let (state, _dir) = test_state().await;
+    let http = http_call(
+        http_router(Arc::clone(&state)),
+        Method::POST,
+        "/api/v1/sessions/managed/decommission-ephemeral?dry_run=true",
+        None,
+    )
+    .await;
+    let rpc = rpc_call(
+        &rpc_router(&state),
+        "mpm.managed.decommission_ephemeral",
+        json!({"dry_run": true}),
+    )
+    .await;
+    assert_eq!(http.status, 200);
+    assert_parity("mpm.managed.decommission_ephemeral", &http, &rpc);
+}
+
+#[tokio::test]
+async fn managed_prune_parity() {
+    let (state, _dir) = test_state().await;
+    let body = json!({"state": "stopped", "dry_run": true, "include_active": false});
+    let http = http_call(
+        http_router(Arc::clone(&state)),
+        Method::POST,
+        "/api/v1/sessions/managed/prune",
+        Some(body.clone()),
+    )
+    .await;
+    let rpc = rpc_call(&rpc_router(&state), "mpm.managed.prune", body).await;
+    assert_eq!(http.status, 200);
+    assert_parity("mpm.managed.prune", &http, &rpc);
+}
+
+/// #6118's refusal travels: an unparseable `invoking_session` is a 400 on the
+/// socket too, rather than a prune run without the requested self-exclusion.
+#[tokio::test]
+async fn managed_prune_rejects_an_unparseable_invoking_session() {
+    let (state, _dir) = test_state().await;
+    let body = json!({
+        "state": "stopped", "dry_run": true, "include_active": false,
+        "invoking_session": "not-a-uuid",
+    });
+    let http = http_call(
+        http_router(Arc::clone(&state)),
+        Method::POST,
+        "/api/v1/sessions/managed/prune",
+        Some(body.clone()),
+    )
+    .await;
+    let rpc = rpc_call(&rpc_router(&state), "mpm.managed.prune", body).await;
+    assert_eq!(http.status, 400);
+    assert!(
+        http.text.contains("#6118"),
+        "the refusal must be #6118's, got {:?}",
+        http.text
+    );
+    assert_parity("mpm.managed.prune (bad invoker)", &http, &rpc);
+}
+
+/// The safe defaults survive the transport: an RPC `prune-worktrees` with no
+/// flags previews rather than deleting, exactly as an empty HTTP body does
+/// (#4091, #2919).
+#[tokio::test]
+async fn managed_prune_worktrees_parity_defaults_to_a_preview() {
+    let (state, _dir) = test_state().await;
+    let http = http_call(
+        http_router(Arc::clone(&state)),
+        Method::POST,
+        "/api/v1/sessions/managed/prune-worktrees",
+        Some(json!({})),
+    )
+    .await;
+    let rpc = rpc_call(
+        &rpc_router(&state),
+        "mpm.managed.prune_worktrees",
+        json!({}),
+    )
+    .await;
+    assert_eq!(http.status, 200);
+    assert_eq!(
+        http.json.as_ref().and_then(|v| v["dry_run"].as_bool()),
+        Some(true),
+        "an unspecified prune must preview, not delete"
+    );
+    assert_parity("mpm.managed.prune_worktrees", &http, &rpc);
+}
+
+#[tokio::test]
+async fn managed_reconcile_worktrees_parity() {
+    let (state, _dir) = test_state().await;
+    let http = http_call(
+        http_router(Arc::clone(&state)),
+        Method::GET,
+        "/api/v1/sessions/managed/reconcile-worktrees",
+        None,
+    )
+    .await;
+    let rpc = rpc_call(
+        &rpc_router(&state),
+        "mpm.managed.reconcile_worktrees",
+        json!({}),
+    )
+    .await;
+    assert_parity("mpm.managed.reconcile_worktrees", &http, &rpc);
+}
+
+/// An invalid runtime selector is the same 400 on both transports, and neither
+/// provisions anything (#6288).
+#[tokio::test]
+async fn managed_spawn_rejects_an_invalid_runtime_on_both_transports() {
+    let (state, _dir) = test_state().await;
+    let body = json!({
+        "repo_url": "https://example.com/x.git",
+        "ref": "main",
+        "task": "t",
+        "runtime": "nonsense-runtime",
+    });
+    let http = http_call(
+        http_router(Arc::clone(&state)),
+        Method::POST,
+        "/api/v1/sessions/managed",
+        Some(body.clone()),
+    )
+    .await;
+    let rpc = rpc_call(&rpc_router(&state), "mpm.managed.spawn", body).await;
+    assert_eq!(
+        http.status, 400,
+        "an invalid runtime must be refused before any provisioning side effect"
+    );
+    assert_parity("mpm.managed.spawn (bad runtime)", &http, &rpc);
+}
+
+/// An adopt of a tmux session that does not exist refuses identically, without
+/// registering anything (#1433).
+#[tokio::test]
+async fn managed_adopt_rejects_an_invalid_runtime_on_both_transports() {
+    let (state, _dir) = test_state().await;
+    let body = json!({"tmux_name": "no-such-pane", "cwd": "/tmp", "runtime": "nonsense-runtime"});
+    let http = http_call(
+        http_router(Arc::clone(&state)),
+        Method::POST,
+        "/api/v1/sessions/managed/adopt",
+        Some(body.clone()),
+    )
+    .await;
+    let rpc = rpc_call(&rpc_router(&state), "mpm.managed.adopt", body).await;
+    assert_eq!(http.status, 400);
+    assert_parity("mpm.managed.adopt (bad runtime)", &http, &rpc);
+}
+
+/// A tmux double that reports the sessions it was asked to create as LIVE.
+///
+/// Why: `delete_record`'s running-session guard is a tmux PROBE
+/// (`session_exists_checked`), not a record-state check, so under the default
+/// `FakeNoopTmuxDriver` — whose `list_sessions` is always empty — nothing is
+/// ever running and `force` is never consulted. That is precisely how the flag
+/// went untested. This driver makes a seeded session observably live so the
+/// guard fires, without a real tmux server.
+/// What: records every `create_session` name and serves them from
+/// `list_sessions`, which is what the trait's default `session_exists_checked`
+/// reads; `kill_session` removes one. Every other method is the no-op
+/// `FakeNoopTmuxDriver` provides.
+/// Test: `managed_delete_refuses_a_running_session_without_force`.
+#[derive(Debug, Default)]
+struct LiveTrackingTmux {
+    live: std::sync::Mutex<Vec<String>>,
+}
+
+impl crate::session_manager::ManagedTmuxDriver for LiveTrackingTmux {
+    fn create_session(&self, name: &str, _workdir: &str) -> Result<(), ManagedError> {
+        self.live
+            .lock()
+            .expect("not poisoned")
+            .push(name.to_owned());
+        Ok(())
+    }
+
+    fn kill_session(&self, name: &str) -> Result<(), ManagedError> {
+        self.live
+            .lock()
+            .expect("not poisoned")
+            .retain(|n| n != name);
+        Ok(())
+    }
+
+    fn send_line(&self, _name: &str, _text: &str) -> Result<(), ManagedError> {
+        Ok(())
+    }
+
+    fn send_keys_literal(&self, _name: &str, _text: &str) -> Result<(), ManagedError> {
+        Ok(())
+    }
+
+    fn send_interrupt(&self, _name: &str) -> Result<(), ManagedError> {
+        Ok(())
+    }
+
+    fn capture(&self, _name: &str, _lines: usize) -> Result<String, ManagedError> {
+        Ok(String::new())
+    }
+
+    fn list_sessions(&self) -> Result<Vec<String>, ManagedError> {
+        Ok(self.live.lock().expect("not poisoned").clone())
+    }
+}
+
+/// A `test_state` whose seeded sessions read as live, for the `force` tests.
+async fn test_state_live_tmux() -> (Arc<DaemonState>, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let driver: Arc<dyn crate::session_manager::ManagedTmuxDriver> =
+        Arc::new(LiveTrackingTmux::default());
+    let state =
+        DaemonState::with_root_isolated_managed_and_driver(dir.path().to_path_buf(), driver).await;
+    (Arc::new(state), dir)
+}
+
+// ── The `force` flag, decoded from a real frame ──────────────────────────────
+
+/// Seed one `Active` managed session in `state`, and return its id.
+///
+/// Why: every other managed test here drives a session id that does not exist,
+/// which reaches the route body but refuses before any flag is read. The two
+/// `force` tests below need a record whose state the guard actually refuses.
+async fn seed_running_session(
+    state: &Arc<DaemonState>,
+    root: &std::path::Path,
+) -> crate::session_manager::ManagedSessionId {
+    let mgr = state.session_manager().await;
+    let id = crate::session_manager::ManagedSessionId::new();
+    let workspace = root.join(format!("{id}-force-test"));
+    mgr.create_with_id(
+        id,
+        "force-flag test".to_string(),
+        Some(workspace.clone()),
+        None,
+        Some(workspace),
+        Some("https://example.com/r.git".to_string()),
+        Some("main".to_string()),
+        crate::runtime::RuntimeKind::default(),
+        false,
+        false,
+    )
+    .await
+    .expect("seed session");
+    id
+}
+
+/// `force: false` refuses a running session identically on both transports
+/// (#2012, #6288).
+///
+/// Why: `mpm.managed.delete`'s `force` field is decoded from the request frame,
+/// and until this test nothing decoded it — the other delete tests drive a
+/// missing id, which refuses before `force` is read. A field that is never
+/// decoded is a field whose `#[serde(default)]` could flip to `true` unnoticed,
+/// which would turn the running-session guard off for every socket caller.
+/// What: seeds an `Active` record, then drives `?force=false` over HTTP and
+/// `{"force": false}` over the socket, asserting the same 409 and the same
+/// message. The record is re-read afterwards to prove neither call deleted it.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn managed_delete_refuses_a_running_session_without_force() {
+    let (state, dir) = test_state_live_tmux().await;
+    let session = seed_running_session(&state, dir.path()).await;
+    let id = session.to_string();
+
+    let http = http_call(
+        http_router(Arc::clone(&state)),
+        Method::POST,
+        &format!("/api/v1/sessions/managed/{id}/delete?force=false"),
+        None,
+    )
+    .await;
+    let rpc = rpc_call(
+        &rpc_router(&state),
+        "mpm.managed.delete",
+        json!({"id": id, "force": false}),
+    )
+    .await;
+
+    assert_eq!(
+        http.status, 409,
+        "a running session must be refused without force, body={:?}",
+        http.text
+    );
+    assert_parity("mpm.managed.delete (running, no force)", &http, &rpc);
+
+    let mgr = state.session_manager().await;
+    let record = mgr.get(&session).await.expect("record must survive");
+    assert_ne!(
+        record.state,
+        crate::session_manager::ManagedSessionState::Deleted,
+        "a refused delete must not have deleted the record"
+    );
+}
+
+/// `force: true` reaches the destructive path on both transports (#2012, #6288).
+///
+/// Why: the mirror of the test above — proving the flag is not merely decoded
+/// but honoured, on the socket as on HTTP. Without it, a socket caller's
+/// `force: true` could be silently dropped and the operator would read a 409
+/// they did not ask for.
+/// What: seeds TWO `Active` records and deletes one over each transport, since
+/// the verb is destructive and a single record cannot be deleted twice. The
+/// bodies are compared with the two identity fields that necessarily differ
+/// (`id`, `name`) blanked; everything else, `deleted` and the record's new
+/// state included, must match.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn managed_delete_force_bypasses_the_running_guard_on_both_transports() {
+    let (state, dir) = test_state_live_tmux().await;
+    let over_http = seed_running_session(&state, dir.path()).await;
+    let over_rpc = seed_running_session(&state, dir.path()).await;
+
+    let http = http_call(
+        http_router(Arc::clone(&state)),
+        Method::POST,
+        &format!("/api/v1/sessions/managed/{over_http}/delete?force=true"),
+        None,
+    )
+    .await;
+    let rpc = rpc_call(
+        &rpc_router(&state),
+        "mpm.managed.delete",
+        json!({"id": over_rpc.to_string(), "force": true}),
+    )
+    .await;
+
+    assert_eq!(
+        http.status, 200,
+        "force=true must bypass the running guard, body={:?}",
+        http.text
+    );
+    let http_body = http.json.clone().expect("a 200 delete answers JSON");
+    let rpc_body = rpc.result.clone().expect("the socket must not refuse");
+    assert_eq!(
+        http_body["deleted"],
+        json!(true),
+        "HTTP must report the record deleted"
+    );
+    assert_eq!(
+        rpc_body["deleted"],
+        json!(true),
+        "the socket must report the record deleted"
+    );
+    assert_eq!(
+        blank_identity(&http_body),
+        blank_identity(&rpc_body),
+        "the two transports must answer the same body once the per-record \
+         identity fields are set aside"
+    );
+
+    let mgr = state.session_manager().await;
+    for id in [&over_http, &over_rpc] {
+        let record = mgr
+            .get(id)
+            .await
+            .expect("a deleted record is kept, not removed");
+        assert_eq!(
+            record.state,
+            crate::session_manager::ManagedSessionState::Deleted,
+            "session {id} must be marked deleted on both transports"
+        );
+    }
+}
+
+/// Blank the two fields that identify WHICH record a delete answered for.
+///
+/// Why: the `force: true` test deletes a different record per transport, so the
+/// fields naming WHICH record answered differ by construction. Blanking exactly
+/// those — rather than comparing a hand-picked subset — keeps every other field
+/// under the equality assertion, so a divergence anywhere else still fails.
+fn blank_identity(body: &Value) -> Value {
+    let mut body = body.clone();
+    if let Some(map) = body.as_object_mut() {
+        // `DeleteResponse` flattens the summary, so these sit at the top level.
+        for field in [
+            "id",
+            "name",
+            "tmux_name",
+            "cwd",
+            "workspace_path",
+            "created_at",
+        ] {
+            if map.contains_key(field) {
+                map.insert(field.to_owned(), Value::Null);
+            }
+        }
+    }
+    body
+}
+
+/// `mpm.control.stop` decodes `force` off the frame and sends the matching
+/// command (#6288).
+///
+/// Why: `rpc_ctl_stop_parity` drives a session that does not exist, so it
+/// refuses before `force` is read — the field's wire decoding was untested. The
+/// difference between `Stop` and `ForceStop` is the difference between a
+/// graceful shutdown and a kill, so a dropped flag is not cosmetic.
+/// What: registers a real actor handle, sends `force: true` and then an omitted
+/// `force`, and asserts BOTH the echoed field and the `ActorCommand` the actor
+/// actually received on its channel — the response alone could echo a flag the
+/// registry never acted on.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn rpc_ctl_stop_decodes_the_force_flag() {
+    use crate::control::ActorCommand;
+
+    let (state, _dir) = test_state().await;
+    let id = crate::control::ControlSessionId::new("force-proj", 0);
+    let (command_tx, mut commands) = tokio::sync::mpsc::channel(4);
+    let (event_tx, _) = tokio::sync::broadcast::channel(4);
+    let handle = crate::control::actor::SessionActorHandle {
+        command_tx,
+        event_tx,
+        write_lock_held: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        metadata: Arc::new(tokio::sync::RwLock::new(
+            crate::control::state::SessionMetadata::new(
+                id.clone(),
+                "force-proj".into(),
+                crate::control::event::BackendKind::StreamJson,
+            ),
+        )),
+    };
+    state.session_registry.register(id.clone(), handle).await;
+    let router = rpc_router(&state);
+
+    let forced = rpc_call(
+        &router,
+        "mpm.control.stop",
+        json!({"id": id.to_string(), "force": true}),
+    )
+    .await;
+    assert_eq!(
+        forced.result.expect("stop must succeed")["force"],
+        json!(true),
+        "the response must echo the flag it acted on"
+    );
+    assert!(
+        matches!(
+            commands.recv().await.expect("a command must be sent"),
+            ActorCommand::ForceStop
+        ),
+        "force: true must reach the actor as ForceStop, not Stop"
+    );
+
+    // An omitted `force` is the graceful stop, exactly as an absent `?force=` is.
+    let graceful = rpc_call(&router, "mpm.control.stop", json!({"id": id.to_string()})).await;
+    assert_eq!(
+        graceful.result.expect("stop must succeed")["force"],
+        json!(false)
+    );
+    assert!(
+        matches!(
+            commands.recv().await.expect("a command must be sent"),
+            ActorCommand::Stop
+        ),
+        "an omitted force must reach the actor as Stop"
+    );
+}
+
+// ── L2 proxy parity ──────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn proxy_focus_parity() {
+    let (state, _dir) = test_state().await;
+    let body = json!({"conversation_key": "c1", "session_id": ""});
+    let http = http_call(
+        http_router(Arc::clone(&state)),
+        Method::POST,
+        "/api/v1/sessions/proxy/focus",
+        Some(body.clone()),
+    )
+    .await;
+    let rpc = rpc_call(&rpc_router(&state), "mpm.proxy.focus", body).await;
+    assert_eq!(http.status, 200);
+    assert_parity("mpm.proxy.focus", &http, &rpc);
+}
+
+#[tokio::test]
+async fn proxy_get_focus_parity() {
+    let (state, _dir) = test_state().await;
+    let http = http_call(
+        http_router(Arc::clone(&state)),
+        Method::GET,
+        "/api/v1/sessions/proxy/focus/c1",
+        None,
+    )
+    .await;
+    let rpc = rpc_call(
+        &rpc_router(&state),
+        "mpm.proxy.get_focus",
+        json!({"conversation_key": "c1"}),
+    )
+    .await;
+    assert_eq!(http.status, 200);
+    assert_parity("mpm.proxy.get_focus", &http, &rpc);
+}
+
+#[tokio::test]
+async fn proxy_unfocus_parity() {
+    let (state, _dir) = test_state().await;
+    let body = json!({"conversation_key": "c1"});
+    let http = http_call(
+        http_router(Arc::clone(&state)),
+        Method::POST,
+        "/api/v1/sessions/proxy/unfocus",
+        Some(body.clone()),
+    )
+    .await;
+    let rpc = rpc_call(&rpc_router(&state), "mpm.proxy.unfocus", body).await;
+    assert_eq!(http.status, 200);
+    assert_parity("mpm.proxy.unfocus", &http, &rpc);
+}
+
+#[tokio::test]
+async fn proxy_message_parity() {
+    let (state, _dir) = test_state().await;
+    let body = json!({"conversation_key": "c1", "text": "hello"});
+    let http = http_call(
+        http_router(Arc::clone(&state)),
+        Method::POST,
+        "/api/v1/sessions/proxy/message",
+        Some(body.clone()),
+    )
+    .await;
+    let rpc = rpc_call(&rpc_router(&state), "mpm.proxy.message", body).await;
+    assert_eq!(http.status, 200);
+    assert_parity("mpm.proxy.message", &http, &rpc);
+}
+
+#[tokio::test]
+async fn proxy_summary_parity() {
+    let (state, _dir) = test_state().await;
+    let http = http_call(
+        http_router(Arc::clone(&state)),
+        Method::GET,
+        "/api/v1/sessions/proxy/summary/c1",
+        None,
+    )
+    .await;
+    let rpc = rpc_call(
+        &rpc_router(&state),
+        "mpm.proxy.summary",
+        json!({"conversation_key": "c1"}),
+    )
+    .await;
+    assert_eq!(http.status, 200);
+    assert_parity("mpm.proxy.summary", &http, &rpc);
+}

--- a/crates/trusty-mpm/src/daemon/rpc/mod.rs
+++ b/crates/trusty-mpm/src/daemon/rpc/mod.rs
@@ -18,3 +18,7 @@ pub mod core;
 /// The transport-neutral bodies `core`'s methods and `daemon::api`'s HTTP
 /// handlers both call, so one route has one implementation.
 pub mod core_ops;
+
+/// Registration for the managed-session lifecycle, the SESSCTL control plane,
+/// and the L2 proxy (#6288 slice 4).
+pub mod managed;

--- a/crates/trusty-mpm/src/daemon/socket.rs
+++ b/crates/trusty-mpm/src/daemon/socket.rs
@@ -63,10 +63,13 @@ pub fn socket_path() -> Result<PathBuf> {
 /// slice 1 established for the whole surface now holds for the remainder of it.
 ///
 /// Test: `unknown_method_gets_a_method_not_found_frame`,
-/// `rpc_router_registers_every_documented_method`.
+/// `rpc_router_registers_every_documented_method`,
+/// `every_scoped_route_has_a_method`.
 fn build_router(state: &Arc<DaemonState>) -> RpcRouter {
     // #6288 slice 2: the core request/response families. Slices 3-6 append here.
-    rpc::core::register(RpcRouter::new(), state)
+    let router = rpc::core::register(RpcRouter::new(), state);
+    // #6288 slice 4: managed sessions, the control plane, and the L2 proxy.
+    rpc::managed::register(router, state)
 }
 
 /// Per-connection budgets for this listener.


### PR DESCRIPTION
The managed-session lifecycle, the SESSCTL control plane, and the L2 proxy are now reachable on the daemon's Unix socket as `mpm.managed.*`, `mpm.control.*`, and `mpm.proxy.*`, while HTTP keeps serving every one of them unchanged. Each route body moved into a transport-neutral function that both the axum handler and the RPC method call, so there is one implementation per route rather than two that drift.

Slice 4 of the #6288 plan. Stacked on #6346 (slice 2), which is itself on slice 1; retarget to `main` after those merge.

Refs #6288

## Method → route

| Method | Route |
|---|---|
| `mpm.managed.spawn` | `POST /api/v1/sessions/managed` |
| `mpm.managed.list` | `GET /api/v1/sessions/managed` |
| `mpm.managed.adopt` | `POST /api/v1/sessions/managed/adopt` |
| `mpm.managed.prune` | `POST /api/v1/sessions/managed/prune` |
| `mpm.managed.decommission_ephemeral` | `POST /api/v1/sessions/managed/decommission-ephemeral` |
| `mpm.managed.prune_worktrees` | `POST /api/v1/sessions/managed/prune-worktrees` |
| `mpm.managed.reconcile_worktrees` | `GET /api/v1/sessions/managed/reconcile-worktrees` |
| `mpm.managed.fleet` | `GET /api/v1/sessions/managed/fleet` |
| `mpm.managed.get` | `GET /api/v1/sessions/managed/{id}` |
| `mpm.managed.stop` | `DELETE /api/v1/sessions/managed/{id}` |
| `mpm.managed.rename` | `PATCH /api/v1/sessions/managed/{id}` |
| `mpm.managed.send` | `POST /api/v1/sessions/managed/{id}/send` |
| `mpm.managed.provision_status` | `GET /api/v1/sessions/managed/{id}/provision-status` |
| `mpm.managed.sync_assets` | `POST /api/v1/sessions/managed/{id}/sync-assets` |
| `mpm.managed.sync_assets_all` | `POST /api/v1/sessions/managed/sync-assets` |
| `mpm.managed.answer` | `POST /api/v1/sessions/managed/{id}/answer` |
| `mpm.managed.attach_cmd` | `GET /api/v1/sessions/managed/{id}/attach-cmd` |
| `mpm.managed.activity` | `GET /api/v1/sessions/managed/{id}/activity` |
| `mpm.managed.runtime_stop` | `POST /api/v1/sessions/managed/{id}/runtime-stop` |
| `mpm.managed.resume` | `POST /api/v1/sessions/managed/{id}/resume` |
| `mpm.managed.reactivate` | `POST /api/v1/sessions/managed/{id}/reactivate` |
| `mpm.managed.decommission` | `POST /api/v1/sessions/managed/{id}/decommission` |
| `mpm.managed.delete` | `POST /api/v1/sessions/managed/{id}/delete` |
| `mpm.control.list` | `GET /api/v1/control/sessions` |
| `mpm.control.run` | `POST /api/v1/control/sessions/run` |
| `mpm.control.connect` | `POST /api/v1/control/sessions/{id}/connect` (SSE → frame stream) |
| `mpm.control.stop` | `POST /api/v1/control/sessions/{id}/stop` |
| `mpm.control.auth` | `GET /api/v1/control/sessions/{id}/auth` |
| `mpm.proxy.focus` | `POST /api/v1/sessions/proxy/focus` |
| `mpm.proxy.get_focus` | `GET /api/v1/sessions/proxy/focus/{conversation_key}` |
| `mpm.proxy.unfocus` | `POST /api/v1/sessions/proxy/unfocus` |
| `mpm.proxy.message` | `POST /api/v1/sessions/proxy/message` |
| `mpm.proxy.summary` | `GET /api/v1/sessions/proxy/summary/{conversation_key}` |

`mpm.managed.stop` and `mpm.managed.runtime_stop` name the same body — the `DELETE` route is a legacy alias for runtime-stop, and both names are registered so a caller porting either HTTP route finds its verb. `every_scoped_route_has_a_method` pins the whole list.

## #6197 parity

The four checks PR #6205 (`a2c9d0f2e`) added now live in the shared `ctl_run_core`, ahead of every other statement. Each has a regression test that sends the malicious or invalid input over the RPC router and asserts the same rejection the HTTP test asserts — same message text, and the documented code projection of the same status.

| #6197 check | RPC regression test |
|---|---|
| caller must be local | `rpc_ctl_run_refuses_an_untrusted_caller` |
| `claude_cmd` allowlist | `rpc_ctl_run_rejects_claude_cmd_outside_allowlist` |
| `prompt_file` validation | `rpc_ctl_run_rejects_prompt_file_injection` |
| `workdir` absolute | `rpc_ctl_run_rejects_relative_workdir` |
| `workdir` no `..` | `rpc_ctl_run_rejects_workdir_traversal` |
| the guards do not reject valid input | `rpc_ctl_run_accepts_a_default_request_and_reaches_the_spawn_path` |
| the refusal string is the one HTTP sends | `caller_trust_refusal_matches_the_http_403` |

**These tests fail when the guard is removed.** Deleting the three validators from `ctl_run_core` and re-running:

```
test rpc_ctl_run_rejects_relative_workdir ... FAILED
test rpc_ctl_run_rejects_workdir_traversal ... FAILED
test rpc_ctl_run_rejects_claude_cmd_outside_allowlist ... FAILED
test rpc_ctl_run_rejects_prompt_file_injection ... FAILED
test rpc_ctl_run_rejects_claude_cmd_outside_allowlist ... FAILED
test rpc_ctl_run_rejects_relative_workdir ... FAILED
test rpc_ctl_run_refuses_an_untrusted_caller ... FAILED
test rpc_ctl_run_rejects_workdir_traversal ... FAILED
test rpc_ctl_run_rejects_prompt_file_injection ... FAILED
test result: FAILED. 1 passed; 5 failed; 0 ignored; 0 measured; 5379 filtered out

assertion `left == right` failed: a 400 projects onto -32602
  left: -32603
 right: -32602

assertion `left == right` failed: an unverified caller must be refused before any spawn
  left: 500
 right: 403
```

`-32603` / `500` is the cap-0 test state's admission refusal: without the guards the request reaches `run_session`. So the five tests pass because the guard fires, not because the request failed for some other reason. The sixth — `rpc_ctl_run_accepts_a_default_request_and_reaches_the_spawn_path` — still passes with the guards gone, which is what it is for: it asserts a valid request is NOT refused. The guards were restored before the commit and `git status` was clean.

## Peer check: the socket's guard is stronger

`loopback_guard` asks whether the peer address is loopback — whether the caller is on this HOST. `ensure_peer_is_self`, which `serve_until` runs on every accepted connection before a byte is read, asks whether the peer's uid is THIS USER'S. Same-uid is a strict subset of same-host: every caller the socket admits would also pass `loopback_guard`, and a different local user that `loopback_guard` admits the socket refuses. The socket path is additionally `0600` inside a `0700` directory, so a foreign uid cannot reach `connect(2)`. No HTTP-side guard on these routes is stronger than the socket's, so nothing extra is carried across. There is no token or header guard on this family — the origin guard `api::router` wraps is browser-CSRF defence for a listener a page can reach, and guards nothing on a socket.

## Transport-only differences

`assert_parity` compares the two transports' JSON bodies and allows exactly these, all properties of the transport rather than of the route: the status number (HTTP's status line versus RPC's `error.code`), HTTP headers, the refusal envelope (a bare string body versus `{"error":{"code","message"}}` carrying that same string verbatim), and 201-versus-200 (both `Ok` on a socket). No route in this slice returns a different body on the two transports.

One route overrides the status→code projection: resume's two 422 refusals are told apart on HTTP by an `x-trusty-resume-reason` header, and the socket has no headers, so the discriminant becomes a distinct RPC code per class (`CODE_WORKSPACE_GONE`, `CODE_PANE_GONE`) and the HTTP wrapper re-attaches the header from that same code. Covered by `resume_http_response_restores_the_reason_header_from_the_rpc_code`.

`mpm.control.connect` is an observer-only connect. The SSE handler's write-lock CAS is not performed on the socket: its `WriteLockGuard` is released when the SSE stream drops, and this slice has no equivalent drop point, so an RPC caller that acquired the lock would leak it permanently. Deliberate narrowing, recorded in the module doc.

## Rebase onto slice 2

Slice 2 had already landed the shared plumbing this branch hand-rolled from the same slice-1 base. Every conflict was resolved by adopting slice 2's version outright:

| File | Resolution |
|---|---|
| `daemon/mod.rs` | slice 2's, both hunks — its `pub mod rpc;` comment and its `serve_until_shutdown(rpc, state, drain)` call on slice 1's `BoundSocket` |
| `daemon/socket_tests.rs` | slice 2's — `DaemonState::shared()` and the `BoundSocket` argument |
| `daemon/rpc/mod.rs` | slice 2's header and module list, plus one added `pub mod managed;` |
| `daemon/socket.rs` (imports, `serve_until_shutdown`) | slice 2's — `super::rpc`, and the `BoundSocket` destructuring signature |
| `daemon/socket.rs` (`build_router`) | the only hunk that kept both sides: slice 2's `rpc::core::register` line, then slice 4's `rpc::managed::register` line |

Bind-before-serve is untouched — `serve_http` still takes the socket pre-bound.

### One error mapping, not two

Slice 2's `daemon/error.rs` and slice 4's `rpc/managed/outcome.rs` had each written a status-to-code table. They agreed on 403/404/409 and disagreed on 422 (`-32006` vs `-32022`). Converged on slice 2's: the match moved out of `From<DaemonError> for RpcError` into a shared `error::rpc_code_for_status(u16) -> i64` that both callers use, and slice 4's constants are now re-exports of slice 2's. It takes a `u16` rather than a `StatusCode` so `daemon::rpc` still imports no HTTP type.

**Added to slice 2's table:** `CODE_WORKSPACE_GONE` (-32023) and `CODE_PANE_GONE` (-32024), for the two 422 resume classes HTTP separates with a header. Nothing else changed value.

## Gate — rung 5

```
cargo fmt --check                                      EXIT=0
cargo check -p trusty-mpm --all-targets                EXIT=0
cargo clippy -p trusty-mpm --all-targets -- -D warnings EXIT=101  <- see below
cargo test -p trusty-mpm --no-fail-fast                EXIT=0
    52 targets; 9493 passed, 0 failed, 18 ignored
cargo check --workspace                                EXIT=0
bash scripts/check_line_cap.sh
    measured 4228 tracked .rs file(s) (floor 500); 4 allowlisted, 0 violations — OK
bash scripts/check_changelog_fragment.sh
    OK trusty-mpm: changelog.d fragment present and valid
bash scripts/check_sld.sh
    scanned 61 spec doc(s) + 3436 code file(s); 0 error(s), 0 warning(s)
```

**Clippy is blocked by one pre-existing lint in slice 2's file**, not by this change:

```
error: this `if` statement can be collapsed
   --> crates/trusty-mpm/src/daemon/rpc/core_tests.rs:355:13
```

`git diff --name-only origin/feat/6288-s2-rpc-core...HEAD -- crates/trusty-mpm/src/daemon/rpc/core_tests.rs` is empty, and that file's last commit is slice 2's `11d6b2aed`. The lint reads only lines 355-359 of that file, which this branch does not touch. Left for slice 2 rather than edited here. Nothing else in the clippy run is red.

`managed_routes/mod.rs` went from 494 SLOC to 259 — the extracted bodies live in the new `managed_routes/cores.rs` (305 SLOC). `control_routes.rs` is 297 SLOC, unchanged in order of magnitude.

New tests beyond the #6197 set: one parity test per route (`managed_*_parity`, `rpc_ctl_*_parity`, `proxy_*_parity`), one per error class (`managed_unparseable_id_parity` for 400, the missing-session tests for 404, `managed_prune_rejects_an_unparseable_invoking_session` for #6118's 400, `an_unknown_method_is_still_method_not_found`, `malformed_params_are_invalid_params`), and three for the stream method (`rpc_ctl_connect_streams_events`, `rpc_ctl_connect_unknown_session_refuses_before_any_frame`, `rpc_ctl_connect_refuses_a_unary_request`).

## A test-isolation defect the rebase surfaced

The rebase run failed `managed_sync_assets_all_parity` and `managed_prune_worktrees_parity_defaults_to_a_preview`. Not flakes — the fixture was not isolating the managed-session store, and `sync-assets` writes files.

`test_state()` built its state with `DaemonState::with_paths(FrameworkPaths::under(tempdir))`, which points the store at a temp dir but leaves the `managed_sessions` `OnceCell` empty. The first request then triggers the lazy `session_manager()`, which calls `RealTmuxDriver::discover()` and `reconcile_on_boot` — and that ADOPTS the machine's live tmux sessions into the temp store, carrying their real `workspace_path`s. `sync_assets_all` then deployed skills into 14 real agent worktrees on this machine. The two transports disagreed because the HTTP call did the deploy and the RPC call found everything already current.

Fixed by building the fixture with `DaemonState::with_root_isolated_managed`, which pre-seeds the `OnceCell` with a `FakeNoopTmuxDriver`-backed manager so discovery never runs. That constructor exists for exactly this hazard — its doc records it as #1790.

**Separate finding, not fixed here.** `#5784`'s host-state gate is meant to stop precisely this: its module doc says a scratch daemon "refreshed `.claude/skills/` inside two real project checkouts", and that "holding a `TmuxDriver` is itself proof the gate passed". But `daemon::state::core::session_manager()` reaches `crate::session_manager::RealTmuxDriver::discover()`, a second tmux-backed constructor that does not consult the gate. Any caller of `session_manager()` under a scratch `$HOME` still adopts the operator's live panes. That is a gap in #5784's coverage, in a file this slice does not own — worth a ticket.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
