### PR TITLE
chore(trusty-mpm): bump to 1.5.7 (1.5.6 tag stranded)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11713,7 +11713,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-mpm"
-version = "1.5.6"
+version = "1.5.7"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -10,7 +10,7 @@ name = "trusty-mpm"
 # #5949 rides the same 1.5.6: the worktree registry repair it adds to
 # `session_manager::decommission` is `pub(super)`, so no public item changed
 # signature.
-version = "1.5.6"
+version = "1.5.7"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/trusty-mpm/changelog.d/6288-tm-1.5.7-bump.md
+++ b/crates/trusty-mpm/changelog.d/6288-tm-1.5.7-bump.md
@@ -1,0 +1,4 @@
+Changed
+
+- 1.5.7 supersedes the stranded 1.5.6 tag; ships #6343 (statusline console link)
+  and #6288 slice 1 (UDS listener alongside HTTP).


### PR DESCRIPTION
The `trusty-mpm-v1.5.6` tag was pushed at aebd176e8, then #6343 and #6344 merged and both changed trusty-mpm source, so `preflight-publish.sh` CHECK 6 refused to publish that tag. Release tags in this repo are immutable (#6178), so 1.5.6 is spent and trusty-mpm ships as 1.5.7 instead. This bumps `crates/trusty-mpm/Cargo.toml`, the one matching `Cargo.lock` line, and adds a changelog fragment — no source changes.

Refs #6288

Gates (rung 1 — no crate source touched):
- `cargo fmt --check` — EXIT=0
- `cargo check -p trusty-mpm --locked` — EXIT=0 (lock accepted as-is; `git diff --stat Cargo.lock` = 1 line)
- `bash scripts/check_changelog_fragment.sh` — EXIT=0, `scanned 3 changed path(s) … no crate source changed — OK`
- `PR_VERSION_BUMP_BASE=origin/main bash scripts/check-pr-version-bump.sh` — EXIT=0, `[ OK ] 3 changed path(s) examined; none under crates/<crate>/src/**`
- `bash scripts/check_version_bump_verdict_selftest.sh` — EXIT=0, 11/11 cases passed

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools