### PR TITLE
feat(trusty-mpm): project, manager, bus and pairing routes served as RPC methods over UDS (Refs #6288)

### DIFF
--- a/crates/trusty-mpm/changelog.d/6288-s5-rpc-registry.md
+++ b/crates/trusty-mpm/changelog.d/6288-s5-rpc-registry.md
@@ -1,0 +1,3 @@
+Added
+- The daemon serves its registry-B project, deliverable/milestone, L3 manager, peer-bus, pairing and delegation-query routes as JSON-RPC methods on the Unix socket, alongside the unchanged HTTP surface (33 methods, `mpm.projects.*` through `mpm.delegation.*`).
+- The peer bus's SSE `subscribe` leg is deliberately not among them — it needs the streaming seam a later slice adds, and its HTTP handler is untouched.

--- a/crates/trusty-mpm/src/daemon/api.rs
+++ b/crates/trusty-mpm/src/daemon/api.rs
@@ -38,7 +38,6 @@ use super::rpc::core_ops;
 // #6288 slice 3: the shared bodies for the legacy session, hook, and polled
 // event routes. Every handler below is a thin adapter over one of them.
 use super::rpc::sessions_legacy_ops as sessions_ops;
-use super::services::PairingService;
 use super::state::DaemonState;
 
 /// The SESSCTL control-plane routes (`/api/v1/control/sessions/*`, WI-2 #1593).
@@ -1215,7 +1214,10 @@ pub async fn register_project(
     State(state): State<Arc<DaemonState>>,
     Json(body): Json<RegisterProject>,
 ) -> Json<ProjectInfo> {
-    Json(state.register_project(body.path))
+    // #6288: the body is shared with `mpm.projects.register`.
+    Json(crate::daemon::rpc::registry::projects::register_project_op(
+        &state, body.path,
+    ))
 }
 
 /// `GET /projects` — snapshot of every registered project.
@@ -1226,9 +1228,10 @@ pub async fn register_project(
     responses((status = 200, description = "Array of registered projects", body = [ProjectInfo]))
 )]
 pub async fn list_projects(State(state): State<Arc<DaemonState>>) -> Json<ProjectsResponse> {
-    Json(ProjectsResponse {
-        projects: state.list_projects(),
-    })
+    // #6288: the body is shared with `mpm.projects.list`.
+    Json(crate::daemon::rpc::registry::projects::list_projects_op(
+        &state,
+    ))
 }
 
 /// Query parameters for `GET /projects/current`.
@@ -1264,12 +1267,10 @@ pub async fn current_project(
     State(state): State<Arc<DaemonState>>,
     Query(query): Query<CurrentProjectQuery>,
 ) -> Result<Json<ProjectInfo>, DaemonError> {
-    match state.project(&query.path) {
-        Some(info) => Ok(Json(info)),
-        None => Err(DaemonError::SessionNotFound {
-            id: query.path.display().to_string(),
-        }),
-    }
+    // #6288: the body is shared with `mpm.projects.current`.
+    Ok(Json(
+        crate::daemon::rpc::registry::projects::current_project_op(&state, &query.path)?,
+    ))
 }
 
 /// `GET /projects/discover` — projects mined from `~/.claude/projects/`.
@@ -1291,27 +1292,8 @@ pub async fn current_project(
 pub async fn discover_projects(
     State(_state): State<Arc<DaemonState>>,
 ) -> Json<DiscoverProjectsResponse> {
-    let projects = crate::core::project_discovery::ProjectDiscovery::discover()
-        .into_iter()
-        .map(|p| DiscoveredProjectInfo {
-            path: p.path.display().to_string(),
-            session_count: p.session_count,
-            last_session: p.last_session.map(system_time_to_iso8601),
-        })
-        .collect();
-    Json(DiscoverProjectsResponse { projects })
-}
-
-/// Render a `SystemTime` as an ISO-8601 / RFC3339 UTC string.
-///
-/// Why: the discovery endpoint reports session times as human- and
-/// machine-readable strings; `SystemTime` has no wire-stable serde form.
-/// What: converts via `chrono::DateTime<Utc>`, falling back to the Unix epoch
-/// for the (unreachable in practice) pre-1970 case.
-/// Test: covered by `discover_projects_returns_array`.
-fn system_time_to_iso8601(time: std::time::SystemTime) -> String {
-    let datetime: chrono::DateTime<chrono::Utc> = time.into();
-    datetime.to_rfc3339()
+    // #6288: the body is shared with `mpm.projects.discover`.
+    Json(crate::daemon::rpc::registry::projects::discover_projects_op())
 }
 
 // ---- universal tmux session management ---------------------------------
@@ -1419,7 +1401,8 @@ pub async fn adopt_tmux_session(
 pub async fn pair_request(
     State(state): State<Arc<DaemonState>>,
 ) -> Json<super::services::PairCode> {
-    Json(PairingService::new(&state).request_code())
+    // #6288: the body is shared with `mpm.pair.request`.
+    Json(crate::daemon::rpc::registry::pairing::request_op(&state))
 }
 
 /// JSON body for `POST /pair/confirm`.
@@ -1455,18 +1438,10 @@ pub async fn pair_confirm(
     State(state): State<Arc<DaemonState>>,
     Json(body): Json<PairConfirmRequest>,
 ) -> Json<PairConfirmResponse> {
-    match PairingService::new(&state).confirm(&body.code, body.chat_id) {
-        Ok(()) => Json(PairConfirmResponse {
-            success: true,
-            chat_id: Some(body.chat_id),
-            error: None,
-        }),
-        Err(_) => Json(PairConfirmResponse {
-            success: false,
-            chat_id: None,
-            error: Some("invalid or expired code".to_string()),
-        }),
-    }
+    // #6288: the body is shared with `mpm.pair.confirm`.
+    Json(crate::daemon::rpc::registry::pairing::confirm_op(
+        &state, &body,
+    ))
 }
 
 /// `GET /pair/status` — report whether a Telegram chat is paired.
@@ -1484,7 +1459,8 @@ pub async fn pair_confirm(
 pub async fn pair_status(
     State(state): State<Arc<DaemonState>>,
 ) -> Json<super::services::PairStatus> {
-    Json(PairingService::new(&state).status())
+    // #6288: the body is shared with `mpm.pair.status`.
+    Json(crate::daemon::rpc::registry::pairing::status_op(&state))
 }
 
 /// `POST /pair/reset` — clear the Telegram pairing.
@@ -1500,8 +1476,8 @@ pub async fn pair_status(
     responses((status = 200, description = "Pairing cleared"))
 )]
 pub async fn pair_reset(State(state): State<Arc<DaemonState>>) -> Json<PairResetResponse> {
-    PairingService::new(&state).reset();
-    Json(PairResetResponse { reset: true })
+    // #6288: the body is shared with `mpm.pair.reset`.
+    Json(crate::daemon::rpc::registry::pairing::reset_op(&state))
 }
 
 // ---- diagnostics --------------------------------------------------------

--- a/crates/trusty-mpm/src/daemon/api/deliverable_routes.rs
+++ b/crates/trusty-mpm/src/daemon/api/deliverable_routes.rs
@@ -262,7 +262,28 @@ pub async fn create_deliverable(
     Path(project): Path<String>,
     body_in: Result<Json<CreateDeliverable>, JsonRejection>,
 ) -> Result<(StatusCode, Json<Deliverable>), DaemonError> {
+    // #6288: the body is shared with `mpm.deliverables.create`.
     let req = body(body_in)?;
+    Ok((
+        StatusCode::CREATED,
+        Json(create_deliverable_op(&state, project, req).await?),
+    ))
+}
+
+/// [`create_deliverable`]'s body, with no transport in it (#6288 slice 5).
+///
+/// # Errors
+///
+/// [`DaemonError::InvalidRequest`] on a blank name; [`DaemonError::Internal`]
+/// when the store write fails.
+///
+/// Test: `parity_deliverable_create_agrees_across_transports`,
+/// `rpc_deliverable_create_rejects_a_blank_name`.
+pub async fn create_deliverable_op(
+    state: &Arc<DaemonState>,
+    project: String,
+    req: CreateDeliverable,
+) -> Result<Deliverable, DaemonError> {
     if req.name.trim().is_empty() {
         return Err(DaemonError::InvalidRequest(
             "deliverable name must not be empty".into(),
@@ -285,7 +306,7 @@ pub async fn create_deliverable(
     mgr.upsert_deliverable(deliverable.clone())
         .await
         .map_err(store_internal)?;
-    Ok((StatusCode::CREATED, Json(deliverable)))
+    Ok(deliverable)
 }
 
 /// `GET /api/v1/projects/{name}/deliverables` — list a project's Deliverables.
@@ -299,15 +320,31 @@ pub async fn list_deliverables(
     Path(project): Path<String>,
     Query(query): Query<DeliverableListQuery>,
 ) -> Result<Json<DeliverablesResponse>, DaemonError> {
+    // #6288: the body is shared with `mpm.deliverables.list`.
+    Ok(Json(list_deliverables_op(&state, &project, query).await?))
+}
+
+/// [`list_deliverables`]'s body, with no transport in it (#6288 slice 5).
+///
+/// # Errors
+///
+/// [`DaemonError::Internal`] when the store read fails.
+///
+/// Test: `parity_deliverable_list_agrees_across_transports`.
+pub async fn list_deliverables_op(
+    state: &Arc<DaemonState>,
+    project: &str,
+    query: DeliverableListQuery,
+) -> Result<DeliverablesResponse, DaemonError> {
     let mgr = state.deliverable_manager().await;
     let mut deliverables = mgr
-        .deliverables_by_project(&project)
+        .deliverables_by_project(project)
         .await
         .map_err(store_internal)?;
     if let Some(status) = query.status {
         deliverables.retain(|d| d.status == status);
     }
-    Ok(Json(DeliverablesResponse { deliverables }))
+    Ok(DeliverablesResponse { deliverables })
 }
 
 /// Fetch a Deliverable and confirm it belongs to `project` (404 otherwise).
@@ -348,8 +385,9 @@ pub async fn get_deliverable(
     State(state): State<Arc<DaemonState>>,
     Path((project, id)): Path<(String, String)>,
 ) -> Result<Json<Deliverable>, DaemonError> {
-    let d = fetch_scoped(&state, &project, &id).await?;
-    Ok(Json(d))
+    // #6288: `fetch_scoped` IS the transport-neutral body — `mpm.deliverables.get`
+    // calls it directly rather than through a second one-line wrapper.
+    Ok(Json(fetch_scoped(&state, &project, &id).await?))
 }
 
 /// `PATCH /api/v1/projects/{name}/deliverables/{id}` — update a Deliverable.
@@ -378,12 +416,40 @@ pub async fn patch_deliverable(
     Path((project, id)): Path<(String, String)>,
     body_in: Result<Json<PatchDeliverable>, JsonRejection>,
 ) -> Result<Json<Deliverable>, DaemonError> {
+    // #6288: the body is shared with `mpm.deliverables.patch`.
     let patch = body(body_in)?;
+    Ok(Json(
+        patch_deliverable_op(&state, &project, &id, patch).await?,
+    ))
+}
+
+/// [`patch_deliverable`]'s body, with no transport in it (#6288 slice 5).
+///
+/// Why the §10.3 state machine did not move with it: the transition check runs
+/// inside the SAME closure `update_deliverable_with` holds its single write
+/// lock across, so relocating the call site changed neither when it runs nor
+/// what it sees. A rejected transition still leaves the record untouched, and
+/// it does so identically on both transports.
+///
+/// # Errors
+///
+/// [`DaemonError::InvalidRequest`] on a blank name;
+/// [`DaemonError::DeliverableNotFound`] when the id does not resolve inside
+/// `project`; [`DaemonError::InvalidTransition`] on an illegal status change.
+///
+/// Test: `parity_deliverable_patch_agrees_across_transports`,
+/// `rpc_deliverable_patch_rejects_an_illegal_transition`.
+pub async fn patch_deliverable_op(
+    state: &Arc<DaemonState>,
+    project: &str,
+    id: &str,
+    patch: PatchDeliverable,
+) -> Result<Deliverable, DaemonError> {
     reject_blank_patch_name(&patch.name, "deliverable")?;
 
     let mgr = state.deliverable_manager().await;
     let updated = mgr
-        .update_deliverable_with(&id, &project, move |mut d| {
+        .update_deliverable_with(id, project, move |mut d| {
             // #2380: enforce the status state machine BEFORE any other mutation,
             // so a rejected transition leaves the record untouched. Validated
             // against `d.status`, which was fetched and will be persisted under
@@ -419,8 +485,8 @@ pub async fn patch_deliverable(
             Ok(d)
         })
         .await
-        .map_err(|e| update_err(e, &id))?;
-    Ok(Json(updated))
+        .map_err(|e| update_err(e, id))?;
+    Ok(updated)
 }
 
 // ───────────────────────── Milestone DTOs ────────────────────────────
@@ -500,7 +566,27 @@ pub async fn create_milestone(
     Path(project): Path<String>,
     body_in: Result<Json<CreateMilestone>, JsonRejection>,
 ) -> Result<(StatusCode, Json<Milestone>), DaemonError> {
+    // #6288: the body is shared with `mpm.milestones.create`.
     let req = body(body_in)?;
+    Ok((
+        StatusCode::CREATED,
+        Json(create_milestone_op(&state, project, req).await?),
+    ))
+}
+
+/// [`create_milestone`]'s body, with no transport in it (#6288 slice 5).
+///
+/// # Errors
+///
+/// [`DaemonError::InvalidRequest`] on a blank name; [`DaemonError::Internal`]
+/// when the store write fails.
+///
+/// Test: `parity_milestone_create_agrees_across_transports`.
+pub async fn create_milestone_op(
+    state: &Arc<DaemonState>,
+    project: String,
+    req: CreateMilestone,
+) -> Result<Milestone, DaemonError> {
     if req.name.trim().is_empty() {
         return Err(DaemonError::InvalidRequest(
             "milestone name must not be empty".into(),
@@ -520,7 +606,7 @@ pub async fn create_milestone(
     mgr.upsert_milestone(milestone.clone())
         .await
         .map_err(store_internal)?;
-    Ok((StatusCode::CREATED, Json(milestone)))
+    Ok(milestone)
 }
 
 /// `GET /api/v1/projects/{name}/milestones` — list a project's Milestones.
@@ -528,16 +614,31 @@ pub async fn list_milestones(
     State(state): State<Arc<DaemonState>>,
     Path(project): Path<String>,
 ) -> Result<Json<MilestonesResponse>, DaemonError> {
+    // #6288: the body is shared with `mpm.milestones.list`.
+    Ok(Json(list_milestones_op(&state, &project).await?))
+}
+
+/// [`list_milestones`]'s body, with no transport in it (#6288 slice 5).
+///
+/// # Errors
+///
+/// [`DaemonError::Internal`] when the store read fails.
+///
+/// Test: `parity_milestone_list_agrees_across_transports`.
+pub async fn list_milestones_op(
+    state: &Arc<DaemonState>,
+    project: &str,
+) -> Result<MilestonesResponse, DaemonError> {
     let mgr = state.deliverable_manager().await;
     let milestones = mgr
-        .milestones_by_project(&project)
+        .milestones_by_project(project)
         .await
         .map_err(store_internal)?;
-    Ok(Json(MilestonesResponse { milestones }))
+    Ok(MilestonesResponse { milestones })
 }
 
 /// Fetch a Milestone and confirm it belongs to `project` (404 otherwise).
-async fn fetch_scoped_milestone(
+pub(crate) async fn fetch_scoped_milestone(
     state: &Arc<DaemonState>,
     project: &str,
     id: &str,
@@ -558,8 +659,10 @@ pub async fn get_milestone(
     State(state): State<Arc<DaemonState>>,
     Path((project, id)): Path<(String, String)>,
 ) -> Result<Json<Milestone>, DaemonError> {
-    let m = fetch_scoped_milestone(&state, &project, &id).await?;
-    Ok(Json(m))
+    // #6288: `fetch_scoped_milestone` IS the transport-neutral body — it is
+    // `pub(crate)` so `mpm.milestones.get` calls it rather than a second
+    // one-line wrapper.
+    Ok(Json(fetch_scoped_milestone(&state, &project, &id).await?))
 }
 
 /// `PATCH /api/v1/projects/{name}/milestones/{id}` — update a Milestone.
@@ -579,12 +682,33 @@ pub async fn patch_milestone(
     Path((project, id)): Path<(String, String)>,
     body_in: Result<Json<PatchMilestone>, JsonRejection>,
 ) -> Result<Json<Milestone>, DaemonError> {
+    // #6288: the body is shared with `mpm.milestones.patch`.
     let patch = body(body_in)?;
+    Ok(Json(
+        patch_milestone_op(&state, &project, &id, patch).await?,
+    ))
+}
+
+/// [`patch_milestone`]'s body, with no transport in it (#6288 slice 5).
+///
+/// # Errors
+///
+/// [`DaemonError::InvalidRequest`] on a blank name;
+/// [`DaemonError::MilestoneNotFound`] when the id does not resolve inside
+/// `project`.
+///
+/// Test: `parity_milestone_patch_agrees_across_transports`.
+pub async fn patch_milestone_op(
+    state: &Arc<DaemonState>,
+    project: &str,
+    id: &str,
+    patch: PatchMilestone,
+) -> Result<Milestone, DaemonError> {
     reject_blank_patch_name(&patch.name, "milestone")?;
 
     let mgr = state.deliverable_manager().await;
     let updated = mgr
-        .update_milestone_with(&id, &project, move |mut m| {
+        .update_milestone_with(id, project, move |mut m| {
             if let Some(name) = patch.name {
                 m.name = name;
             }
@@ -603,6 +727,6 @@ pub async fn patch_milestone(
             m
         })
         .await
-        .map_err(|e| milestone_lookup_err(e, &id))?;
-    Ok(Json(updated))
+        .map_err(|e| milestone_lookup_err(e, id))?;
+    Ok(updated)
 }

--- a/crates/trusty-mpm/src/daemon/bus/error.rs
+++ b/crates/trusty-mpm/src/daemon/bus/error.rs
@@ -14,6 +14,9 @@ use axum::Json;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use thiserror::Error;
+use trusty_common::uds::server::{CODE_INTERNAL_ERROR, CODE_INVALID_PARAMS, RpcError};
+
+use crate::daemon::error::{CODE_CONFLICT, CODE_FORBIDDEN, CODE_GONE, CODE_NOT_FOUND};
 
 /// A peer-bus publish, addressing, or registration failure.
 ///
@@ -149,6 +152,36 @@ impl BusError {
             | Self::InvalidCaller(_)
             | Self::CallerKindNotPermitted { .. } => StatusCode::BAD_REQUEST,
         }
+    }
+}
+
+/// Map a bus failure onto the JSON-RPC error frame a socket client reads.
+///
+/// Why (#6288 slice 5): the bus's four request/response verbs are served over
+/// the Unix socket as well as over HTTP, and DOC-60 §4's whole point is that a
+/// sender can tell WHICH failure it hit from the status alone. A socket caller
+/// gets the same discrimination only if the code is derived from the same
+/// [`BusError::status`] table the HTTP transport reads — a second hand-written
+/// table here would let the two drift, and the drift would be silent.
+/// What: derives the code from the status, so `403` sender-unverified, `404`
+/// no-live-instance, `410` instance-gone, `409` no-subscriber, and `400`
+/// malformed each stay distinguishable. The message crosses verbatim, so it is
+/// the same string the HTTP body's `error` field carries.
+/// Test: `bus_error_rpc_codes_track_http_statuses`.
+impl From<BusError> for RpcError {
+    fn from(e: BusError) -> Self {
+        let code = match e.status() {
+            StatusCode::BAD_REQUEST => CODE_INVALID_PARAMS,
+            StatusCode::FORBIDDEN => CODE_FORBIDDEN,
+            StatusCode::NOT_FOUND => CODE_NOT_FOUND,
+            StatusCode::CONFLICT => CODE_CONFLICT,
+            StatusCode::GONE => CODE_GONE,
+            // Unreachable while `status` stays total over the variants above;
+            // a new variant that forgets a row lands here rather than silently
+            // borrowing another failure's code.
+            _ => CODE_INTERNAL_ERROR,
+        };
+        RpcError::new(code, e.to_string())
     }
 }
 

--- a/crates/trusty-mpm/src/daemon/bus/routes.rs
+++ b/crates/trusty-mpm/src/daemon/bus/routes.rs
@@ -7,9 +7,17 @@
 //! explicit that this surface should mirror the existing patterns rather than
 //! invent a new one.
 //! What: five handlers — register/deregister/list an instance, publish a peer
-//! message, and subscribe to one instance's inbound stream.
+//! message, and subscribe to one instance's inbound stream. Since #6288 slice
+//! 5 the four request/response verbs are ALSO JSON-RPC methods on the daemon's
+//! Unix socket: each handler is now a delegator over a transport-neutral
+//! `*_op` body ([`register_op`], [`deregister_op`], [`list_op`], [`publish_op`])
+//! that both transports call, so one route keeps one implementation.
+//! [`subscribe_instance`] is deliberately NOT among them — it is SSE, and it
+//! needs the `RpcStreamMethod` seam slice 6 owns. No RPC method is registered
+//! for it, and its handler is untouched here.
 //! Test: `bus::tests` — `route_register_returns_instance_id`,
-//! `route_publish_to_dead_instance_is_410`, `route_list_instances`.
+//! `route_publish_to_dead_instance_is_410`, `route_list_instances`; the
+//! transport-parity cases live in `daemon::rpc::registry::tests`.
 
 use std::convert::Infallible;
 use std::sync::Arc;
@@ -26,6 +34,7 @@ use serde::{Deserialize, Serialize};
 use tokio_stream::StreamExt;
 use tokio_stream::wrappers::BroadcastStream;
 
+use crate::daemon::error::DaemonError;
 use crate::daemon::state::DaemonState;
 
 use super::envelope::{BusEnvelope, BusPayload, CallerIdentity};
@@ -156,11 +165,21 @@ pub async fn register_instance(
     State(state): State<Arc<DaemonState>>,
     Json(req): Json<RegisterInstanceRequest>,
 ) -> Result<(StatusCode, Json<InstanceMeta>), BusError> {
-    let meta = state
+    // #6288: the body is shared with `mpm.bus.register` over the Unix socket.
+    Ok((StatusCode::CREATED, Json(register_op(&state, req)?)))
+}
+
+/// [`register_instance`]'s body, with no transport in it (#6288 slice 5).
+///
+/// Test: `parity_bus_register_agrees_across_transports`.
+pub fn register_op(
+    state: &Arc<DaemonState>,
+    req: RegisterInstanceRequest,
+) -> Result<InstanceMeta, BusError> {
+    state
         .bus()
         .registry()
-        .register(&req.definition_id, req.project)?;
-    Ok((StatusCode::CREATED, Json(meta)))
+        .register(&req.definition_id, req.project)
 }
 
 /// `DELETE /api/v1/bus/instances/{instance_id}` — deregister on exit.
@@ -173,10 +192,53 @@ pub async fn deregister_instance(
     State(state): State<Arc<DaemonState>>,
     Path(instance_id): Path<String>,
 ) -> StatusCode {
-    if state.bus().registry().deregister(&instance_id) {
-        StatusCode::NO_CONTENT
+    // #6288: the body is shared with `mpm.bus.deregister` over the Unix socket.
+    // The status pair is preserved exactly — this route has never had a body.
+    match deregister_op(&state, &instance_id) {
+        Ok(_) => StatusCode::NO_CONTENT,
+        Err(_) => StatusCode::NOT_FOUND,
+    }
+}
+
+/// The acknowledgement `mpm.bus.deregister` answers with.
+///
+/// Why: the HTTP route says "removed" with a bodyless `204`, which a JSON-RPC
+/// result cannot express — a result is a JSON value or it is an error. Rather
+/// than inventing a null result, the socket answers a one-field record, and
+/// the miss stays an ERROR on both transports (`404` / `CODE_NOT_FOUND`) so a
+/// caller still cannot mistake "there was nothing to remove" for a removal.
+/// Test: `parity_bus_deregister_agrees_across_transports`,
+/// `rpc_bus_deregister_unknown_instance_reports_not_found`.
+#[derive(Debug, Serialize)]
+pub struct DeregisterAck {
+    /// Always `true` — a failure is an error frame, never `false` here.
+    pub deregistered: bool,
+}
+
+/// [`deregister_instance`]'s body, with no transport in it (#6288 slice 5).
+///
+/// Why the error is a [`DaemonError`] rather than a [`BusError`]: `BusError` has
+/// no "was not registered" variant, and the two candidates both say the wrong
+/// thing — `InstanceGone` is `410` (this route has always answered `404`) and
+/// `NoLiveInstance` is about a DEFINITION that resolved to nothing. Inventing a
+/// bus variant to serve one route would put a fifth addressing failure into an
+/// enum DOC-60 §4 keeps deliberately narrow.
+///
+/// # Errors
+///
+/// [`DaemonError::NotFound`] when `instance_id` was not a live registration.
+///
+/// Test: `parity_bus_deregister_agrees_across_transports`.
+pub fn deregister_op(
+    state: &Arc<DaemonState>,
+    instance_id: &str,
+) -> Result<DeregisterAck, DaemonError> {
+    if state.bus().registry().deregister(instance_id) {
+        Ok(DeregisterAck { deregistered: true })
     } else {
-        StatusCode::NOT_FOUND
+        Err(DaemonError::NotFound(format!(
+            "bus instance '{instance_id}' is not registered"
+        )))
     }
 }
 
@@ -187,9 +249,17 @@ pub async fn deregister_instance(
 /// What: every live [`InstanceMeta`], ordered by registration sequence.
 /// Test: `route_list_instances`.
 pub async fn list_instances(State(state): State<Arc<DaemonState>>) -> Json<ListInstancesResponse> {
-    Json(ListInstancesResponse {
+    // #6288: the body is shared with `mpm.bus.list` over the Unix socket.
+    Json(list_op(&state))
+}
+
+/// [`list_instances`]'s body, with no transport in it (#6288 slice 5).
+///
+/// Test: `parity_bus_list_agrees_across_transports`.
+pub fn list_op(state: &Arc<DaemonState>) -> ListInstancesResponse {
+    ListInstancesResponse {
         instances: state.bus().registry().live(),
-    })
+    }
 }
 
 /// `POST /api/v1/bus/publish` — send one peer message.
@@ -212,11 +282,39 @@ pub async fn publish_message(
     State(state): State<Arc<DaemonState>>,
     Json(req): Json<PublishRequest>,
 ) -> Result<(StatusCode, Json<BusEnvelope>), BusError> {
+    // #6288: the body is shared with `mpm.bus.publish` over the Unix socket.
+    Ok((StatusCode::ACCEPTED, Json(publish_op(&state, req)?)))
+}
+
+/// [`publish_message`]'s body, with no transport in it (#6288 slice 5).
+///
+/// Why this is a call-signature move and nothing more: DOC-60 §4's fail-closed
+/// sequencing lives inside
+/// [`PeerBus::publish`](crate::daemon::bus::PeerBus::publish) — structural
+/// validation of the caller identity, then the `assistant_instance` edge check,
+/// then sender verification against the registry, then target resolution, then
+/// the delivery attempt, with the durable record written to state what actually
+/// happened. None of that moved, and none of it is re-derived here, so the
+/// socket path rejects at exactly the same four points the HTTP path does.
+/// Every rejection reaches the caller as a [`BusError`], which both transports
+/// render from the same `status` table.
+///
+/// # Errors
+///
+/// Every [`BusError`] `PeerBus::publish` can raise, plus
+/// [`BusError::InvalidTarget`] when the request names neither addressing mode.
+///
+/// Test: `parity_bus_publish_agrees_across_transports`,
+/// `rpc_bus_publish_rejects_a_forged_user_kind`,
+/// `rpc_bus_publish_rejects_an_unregistered_sender`,
+/// `rpc_bus_publish_to_a_dead_instance_is_gone`,
+/// `rpc_bus_publish_without_a_subscriber_is_conflict`,
+/// `rpc_bus_publish_without_a_target_is_invalid`.
+pub fn publish_op(state: &Arc<DaemonState>, req: PublishRequest) -> Result<BusEnvelope, BusError> {
     let target = req.to.to_peer_target()?;
-    let envelope = state
+    state
         .bus()
-        .publish(req.from, &target, req.payload, req.in_reply_to)?;
-    Ok((StatusCode::ACCEPTED, Json(envelope)))
+        .publish(req.from, &target, req.payload, req.in_reply_to)
 }
 
 /// `GET /api/v1/bus/subscribe/{instance_id}` — an instance's inbound stream.

--- a/crates/trusty-mpm/src/daemon/delegation_routes.rs
+++ b/crates/trusty-mpm/src/daemon/delegation_routes.rs
@@ -184,13 +184,29 @@ pub async fn granted_worktree_route(
     Path(id): Path<String>,
     Json(req): Json<SharedTreeDispatchRequest>,
 ) -> Result<Json<SharedTreeWritersResponse>, DaemonError> {
-    let session = uuid::Uuid::parse_str(&id)
+    // #6288: the body is shared with `mpm.delegation.granted_worktree`.
+    Ok(Json(granted_worktree_op(&state, &id, req)?))
+}
+
+/// [`granted_worktree_route`]'s body, with no transport in it (#6288 slice 5).
+///
+/// # Errors
+///
+/// [`DaemonError::InvalidRequest`] when `id` is not a UUID.
+///
+/// Test: `parity_delegation_granted_worktree_agrees_across_transports`.
+pub fn granted_worktree_op(
+    state: &Arc<DaemonState>,
+    id: &str,
+    req: SharedTreeDispatchRequest,
+) -> Result<SharedTreeWritersResponse, DaemonError> {
+    let session = uuid::Uuid::parse_str(id)
         .map(SessionId)
         .map_err(|_| DaemonError::InvalidRequest(format!("malformed session id: {id}")))?;
 
     let payload = &req.payload;
     let Some(cwd) = str_field(payload, "cwd").map(PathBuf::from) else {
-        return Ok(Json(SharedTreeWritersResponse::default()));
+        return Ok(SharedTreeWritersResponse::default());
     };
     let exclude = str_field(payload, "tool_use_id");
     let input = payload.get("input");
@@ -201,7 +217,7 @@ pub async fn granted_worktree_route(
     let (names, claimed) = state.claim_shared_tree_dispatch(&cwd, exclude, eligible, |s| {
         crate::daemon::services::delegation_tracker::record_granted_isolation(s, session, payload);
     });
-    Ok(Json(writers_response(&names, claimed)))
+    Ok(writers_response(&names, claimed))
 }
 
 /// `POST /api/v1/sessions/{id}/delegations/shared-tree-dispatch` (#4480, #5324).
@@ -231,13 +247,31 @@ pub async fn shared_tree_dispatch_route(
     Path(id): Path<String>,
     Json(req): Json<SharedTreeDispatchRequest>,
 ) -> Result<Json<SharedTreeWritersResponse>, DaemonError> {
-    let session = uuid::Uuid::parse_str(&id)
+    // #6288: the body is shared with `mpm.delegation.shared_tree_dispatch`.
+    Ok(Json(shared_tree_dispatch_op(&state, &id, req)?))
+}
+
+/// [`shared_tree_dispatch_route`]'s body, with no transport in it (#6288
+/// slice 5).
+///
+/// # Errors
+///
+/// [`DaemonError::InvalidRequest`] when `id` is not a UUID.
+///
+/// Test: `parity_delegation_shared_tree_dispatch_agrees_across_transports`,
+/// `rpc_delegation_rejects_a_malformed_session_id`.
+pub fn shared_tree_dispatch_op(
+    state: &Arc<DaemonState>,
+    id: &str,
+    req: SharedTreeDispatchRequest,
+) -> Result<SharedTreeWritersResponse, DaemonError> {
+    let session = uuid::Uuid::parse_str(id)
         .map(SessionId)
         .map_err(|_| DaemonError::InvalidRequest(format!("malformed session id: {id}")))?;
 
     let payload = &req.payload;
     let Some(cwd) = str_field(payload, "cwd").map(PathBuf::from) else {
-        return Ok(Json(SharedTreeWritersResponse::default()));
+        return Ok(SharedTreeWritersResponse::default());
     };
     let exclude = str_field(payload, "tool_use_id");
     let input = payload.get("input");
@@ -257,7 +291,7 @@ pub async fn shared_tree_dispatch_route(
         );
     });
 
-    Ok(Json(writers_response(&names, claimed)))
+    Ok(writers_response(&names, claimed))
 }
 
 /// Fold a list of live writer names into the wire response.

--- a/crates/trusty-mpm/src/daemon/error.rs
+++ b/crates/trusty-mpm/src/daemon/error.rs
@@ -52,6 +52,23 @@ pub const CODE_UNPROCESSABLE: i64 = -32006;
 /// HTTP 409 over the socket: the request conflicts with the record's state.
 pub const CODE_CONFLICT: i64 = -32009;
 
+/// HTTP 502 over the socket: an upstream this daemon called answered badly.
+///
+/// #6288: distinct from [`CODE_UNAVAILABLE`], which says the daemon has no
+/// provider configured at all. This one says a configured provider was called
+/// and the call failed, so the caller's retry advice differs.
+pub const CODE_UPSTREAM_FAILED: i64 = -32007;
+
+/// HTTP 410 over the socket: the addressed resource existed and is now gone.
+///
+/// #6288: the peer bus's instance-bypass failure ([`BusError::InstanceGone`])
+/// is the only route in this daemon that distinguishes "gone" from "never
+/// existed", and DOC-60 §4 requires the sender to be able to tell them apart
+/// without parsing a message — so the distinction has to survive the socket.
+///
+/// [`BusError::InstanceGone`]: crate::daemon::bus::BusError::InstanceGone
+pub const CODE_GONE: i64 = -32008;
+
 /// A resume refused because the workspace directory is gone (#6288 slice 4).
 ///
 /// Why its own code rather than plain [`CODE_UNPROCESSABLE`]: on HTTP the two
@@ -87,6 +104,10 @@ pub fn rpc_code_for_status(status: u16) -> i64 {
         404 => CODE_NOT_FOUND,
         409 => CODE_CONFLICT,
         422 => CODE_UNPROCESSABLE,
+        // #6288 slice 5: the manager surface is the first to report "a
+        // configured provider answered badly", so 502 stops falling through to
+        // 500. See `DaemonError::UpstreamFailed`.
+        502 => CODE_UPSTREAM_FAILED,
         503 => CODE_UNAVAILABLE,
         // Everything left maps to 500, and a caller could not have sent any of
         // them differently.
@@ -252,6 +273,23 @@ pub enum DaemonError {
     /// Test: `error_status_codes_map`, `spawn_session_without_claude_returns_422`.
     #[error("unprocessable: {0}")]
     Unprocessable(String),
+
+    /// An upstream service this daemon called answered badly.
+    ///
+    /// Why (#6288 slice 5): the L3 manager's digest, chat, and route-task
+    /// routes call a configured inference provider and return HTTP 502 when
+    /// that call errors or returns an empty body. That is a different fact
+    /// from [`ServiceUnavailable`](Self::ServiceUnavailable) (503, "no provider
+    /// is configured"), and a caller's correct reaction differs: retry a 502,
+    /// configure a provider for a 503. Before this variant the distinction
+    /// lived only in the handlers' own `StatusCode` literals, which a shared
+    /// transport-neutral body cannot carry — so serving those routes over the
+    /// socket needed the class to become a value.
+    /// What: carries the operator-facing reason; maps to HTTP 502 and to
+    /// [`CODE_UPSTREAM_FAILED`] on the socket.
+    /// Test: `error_status_codes_map`, `rpc_error_codes_track_http_statuses`.
+    #[error("upstream failed: {0}")]
+    UpstreamFailed(String),
 }
 
 impl DaemonError {
@@ -275,6 +313,33 @@ impl DaemonError {
             Self::TmuxUnavailable(_) | Self::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
             Self::ServiceUnavailable(_) => StatusCode::SERVICE_UNAVAILABLE,
             Self::Unprocessable(_) => StatusCode::UNPROCESSABLE_ENTITY,
+            Self::UpstreamFailed(_) => StatusCode::BAD_GATEWAY,
+        }
+    }
+
+    /// The message WITHOUT the variant's `Display` prefix.
+    ///
+    /// Why (#6288 slice 5): several routes moving onto the socket answer HTTP
+    /// with a bare plain-text body — `project foo not found`, not
+    /// `{"error":"not found: project foo not found"}`. Their bodies now live in
+    /// a shared `*_op` that reports a [`DaemonError`], and the HTTP delegator
+    /// has to reproduce the old body byte for byte, which `Display` cannot do:
+    /// it prepends the variant label. This returns just the payload, so a
+    /// delegator can render `(status, detail)` and leave the wire unchanged.
+    /// What: the carried string for the single-field variants; `to_string()`
+    /// for the structured ones, which have no single payload to return.
+    /// Test: `detail_drops_the_display_prefix`.
+    pub fn detail(&self) -> String {
+        match self {
+            Self::TmuxUnavailable(m)
+            | Self::InvalidRequest(m)
+            | Self::Internal(m)
+            | Self::ServiceUnavailable(m)
+            | Self::Forbidden(m)
+            | Self::NotFound(m)
+            | Self::Unprocessable(m)
+            | Self::UpstreamFailed(m) => m.clone(),
+            other => other.to_string(),
         }
     }
 }
@@ -388,6 +453,12 @@ mod tests {
             DaemonError::Unprocessable("x".into()).status(),
             StatusCode::UNPROCESSABLE_ENTITY
         );
+        // #6288: 502 is the manager surface's "a configured provider answered
+        // badly", distinct from the 503 no-provider case above it.
+        assert_eq!(
+            DaemonError::UpstreamFailed("x".into()).status(),
+            StatusCode::BAD_GATEWAY
+        );
         assert_eq!(
             DaemonError::DeliverableNotFound { id: "x".into() }.status(),
             StatusCode::NOT_FOUND
@@ -443,6 +514,10 @@ mod tests {
             ),
             (DaemonError::Unprocessable("x".into()), CODE_UNPROCESSABLE),
             (
+                DaemonError::UpstreamFailed("x".into()),
+                CODE_UPSTREAM_FAILED,
+            ),
+            (
                 DaemonError::ServiceUnavailable("x".into()),
                 CODE_UNAVAILABLE,
             ),
@@ -488,6 +563,21 @@ mod tests {
         assert!(msg.contains("proposed"), "{msg}");
         assert!(msg.contains("complete"), "{msg}");
         assert!(msg.contains("in-progress"), "{msg}");
+    }
+
+    /// Why (#6288): a plain-text route's HTTP body is reproduced from
+    /// `detail`, so a prefix leaking back in silently changes that wire.
+    /// Test: this function IS the test.
+    #[test]
+    fn detail_drops_the_display_prefix() {
+        let e = DaemonError::NotFound("project foo not found".into());
+        assert_eq!(e.to_string(), "not found: project foo not found");
+        assert_eq!(e.detail(), "project foo not found");
+
+        // A structured variant has no single payload, so it falls back to
+        // `Display` rather than losing its fields.
+        let e = DaemonError::SessionNotFound { id: "abc".into() };
+        assert_eq!(e.detail(), e.to_string());
     }
 
     #[test]

--- a/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
@@ -40,8 +40,10 @@ mod launch_on_main;
 mod lifecycle;
 pub mod managed_checkout;
 mod mcp_spawn_gate;
-mod project_registry_routes;
-mod project_status;
+// #6288: `pub` so `rpc::registry::projects` can call the shared `*_op` bodies.
+pub mod project_registry_routes;
+// #6288: `pub` so `rpc::registry::projects` can call `project_status_op`.
+pub mod project_status;
 pub mod provision_status;
 pub mod proxy;
 pub mod prune;

--- a/crates/trusty-mpm/src/daemon/managed_routes/project_registry_routes.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/project_registry_routes.rs
@@ -37,6 +37,7 @@ use tracing::warn;
 
 use crate::core::gh_account::{GH_DOCTOR_TIMEOUT, GhAuthProbe, probe_gh_auth};
 use crate::core::trusty_tools_config::GithubConfig;
+use crate::daemon::error::DaemonError;
 use crate::daemon::state::DaemonState;
 use crate::project::{Project, ProjectStoreError};
 
@@ -114,19 +115,46 @@ pub struct ProjectsListResponse {
 pub async fn list_projects_registry_route(
     State(state): State<Arc<DaemonState>>,
 ) -> impl IntoResponse {
+    // #6288: the body is shared with `mpm.projects.registry.list`.
+    match list_projects_registry_op(&state).await {
+        Ok(body) => Json(body).into_response(),
+        Err(e) => plain(e),
+    }
+}
+
+/// Render a registry-B failure in this surface's historical plain-text body.
+///
+/// Why (#6288 slice 5): these four routes have always answered a bare
+/// `text/plain` body — `project foo not found`, not a JSON `{ "error": … }`
+/// object. Their bodies now report a [`DaemonError`] so the socket transport can
+/// carry the same failure class, and this renders that value back onto the exact
+/// wire the routes had before. [`DaemonError::detail`] is what drops the
+/// variant's `Display` prefix.
+fn plain(e: DaemonError) -> Response {
+    (e.status(), e.detail()).into_response()
+}
+
+/// [`list_projects_registry_route`]'s body, with no transport in it (#6288).
+///
+/// # Errors
+///
+/// [`DaemonError::Internal`] when the registry read fails.
+///
+/// Test: `parity_projects_registry_list_agrees_across_transports`.
+pub async fn list_projects_registry_op(
+    state: &Arc<DaemonState>,
+) -> Result<ProjectsListResponse, DaemonError> {
     let registry = state.project_registry().await;
     match registry.list().await {
         Ok(projects) => {
             let count = projects.len();
-            Json(ProjectsListResponse { projects, count }).into_response()
+            Ok(ProjectsListResponse { projects, count })
         }
         Err(e) => {
             warn!(error = %e, "list_projects_registry_route: registry read failed");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
+            Err(DaemonError::Internal(
                 "project registry read failed".to_string(),
-            )
-                .into_response()
+            ))
         }
     }
 }
@@ -169,11 +197,35 @@ pub async fn register_project_registry_route(
     State(state): State<Arc<DaemonState>>,
     Json(body): Json<RegisterProjectBody>,
 ) -> impl IntoResponse {
+    // #6288: the body is shared with `mpm.projects.registry.register`.
+    match register_project_registry_op(&state, body).await {
+        Ok(project) => (StatusCode::CREATED, Json(project)).into_response(),
+        Err(e) => plain(e),
+    }
+}
+
+/// [`register_project_registry_route`]'s body, with no transport in it (#6288).
+///
+/// # Errors
+///
+/// [`DaemonError::InvalidRequest`] on a blank `name` or `repo_url`;
+/// [`DaemonError::Internal`] when the registry write fails.
+///
+/// Test: `parity_projects_registry_register_agrees_across_transports`,
+/// `rpc_projects_registry_register_rejects_a_blank_name`.
+pub async fn register_project_registry_op(
+    state: &Arc<DaemonState>,
+    body: RegisterProjectBody,
+) -> Result<Project, DaemonError> {
     if body.name.trim().is_empty() {
-        return (StatusCode::BAD_REQUEST, "project name must not be empty").into_response();
+        return Err(DaemonError::InvalidRequest(
+            "project name must not be empty".to_string(),
+        ));
     }
     if body.repo_url.trim().is_empty() {
-        return (StatusCode::BAD_REQUEST, "repo_url must not be empty").into_response();
+        return Err(DaemonError::InvalidRequest(
+            "repo_url must not be empty".to_string(),
+        ));
     }
 
     let registry = state.project_registry().await;
@@ -219,13 +271,11 @@ pub async fn register_project_registry_route(
     };
     if let Err(e) = registry.register(project.clone()).await {
         warn!(error = %e, project = %project.name, "register_project_registry_route: register failed");
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
+        return Err(DaemonError::Internal(
             "project registry write failed".to_string(),
-        )
-            .into_response();
+        ));
     }
-    (StatusCode::CREATED, Json(project)).into_response()
+    Ok(project)
 }
 
 /// Fold a register-time `--gh-config-dir` into a project's `github` binding
@@ -281,19 +331,37 @@ pub async fn get_project_registry_route(
     State(state): State<Arc<DaemonState>>,
     AxumPath(name): AxumPath<String>,
 ) -> impl IntoResponse {
-    let registry = state.project_registry().await;
-    match registry.get(&name).await {
+    // #6288: the body is shared with `mpm.projects.registry.get`.
+    match get_project_registry_op(&state, &name).await {
         Ok(project) => Json(project).into_response(),
+        Err(e) => plain(e),
+    }
+}
+
+/// [`get_project_registry_route`]'s body, with no transport in it (#6288).
+///
+/// # Errors
+///
+/// [`DaemonError::NotFound`] when `name` is not registered;
+/// [`DaemonError::Internal`] on any other store read failure.
+///
+/// Test: `parity_projects_registry_get_agrees_across_transports`,
+/// `rpc_projects_registry_get_unknown_project_is_not_found`.
+pub async fn get_project_registry_op(
+    state: &Arc<DaemonState>,
+    name: &str,
+) -> Result<Project, DaemonError> {
+    let registry = state.project_registry().await;
+    match registry.get(name).await {
+        Ok(project) => Ok(project),
         Err(ProjectStoreError::NotFound(_)) => {
-            (StatusCode::NOT_FOUND, format!("project {name} not found")).into_response()
+            Err(DaemonError::NotFound(format!("project {name} not found")))
         }
         Err(e) => {
             warn!(error = %e, project = %name, "get_project_registry_route: registry read failed");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
+            Err(DaemonError::Internal(
                 "project registry read failed".to_string(),
-            )
-                .into_response()
+            ))
         }
     }
 }
@@ -442,10 +510,39 @@ pub async fn patch_project_registry_route(
     AxumPath(name): AxumPath<String>,
     Json(body): Json<PatchProjectBody>,
 ) -> impl IntoResponse {
-    // #2121: only a request that actually SETS `gh_user` pays for the `gh auth
-    // status` subprocess — absent and `null` (clear) never run it. The probe
-    // blocks its thread for up to GH_DOCTOR_TIMEOUT, so it runs off the async
-    // executor.
+    // #6288: the body is shared with `mpm.projects.registry.patch`, and the
+    // #2121 conditional `gh auth status` probe moved inside it so both
+    // transports pay for it on exactly the same condition.
+    match patch_project_registry_op(&state, &name, body).await {
+        Ok(project) => Json(project).into_response(),
+        Err(e) => plain(e),
+    }
+}
+
+/// [`patch_project_registry_route`]'s body, with no transport in it (#6288).
+///
+/// Why it takes the probe rather than running it: `mpm.projects.registry.patch`
+/// must pay the same `gh auth status` cost on the same condition the HTTP route
+/// does — only when the request actually SETS `gh_user`. Sharing the probe
+/// decision as well as the validation keeps the two transports from differing on
+/// when a subprocess is spawned.
+///
+/// # Errors
+///
+/// [`DaemonError::InvalidRequest`] on a name change, a blank required field, a
+/// blank tag, or a `gh_user` `gh` does not report as logged in;
+/// [`DaemonError::ServiceUnavailable`] when `gh` could not be asked;
+/// [`DaemonError::NotFound`] when `name` is not registered;
+/// [`DaemonError::Internal`] when the registry write fails.
+///
+/// Test: `parity_projects_registry_patch_agrees_across_transports`,
+/// `rpc_projects_registry_patch_rejects_a_blank_required_field`.
+pub async fn patch_project_registry_op(
+    state: &Arc<DaemonState>,
+    name: &str,
+    body: PatchProjectBody,
+) -> Result<Project, DaemonError> {
+    // #6288: the same conditional probe the HTTP route runs, in the shared body.
     let probe = match body.gh_user.as_ref().and_then(|v| v.as_deref()) {
         Some(login) if !login.trim().is_empty() => Some(
             tokio::task::spawn_blocking(|| probe_gh_auth(GH_DOCTOR_TIMEOUT))
@@ -456,7 +553,7 @@ pub async fn patch_project_registry_route(
         ),
         _ => None,
     };
-    patch_project_registry_with_probe(state, name, body, probe).await
+    patch_project_registry_with_probe(Arc::clone(state), name.to_string(), body, probe).await
 }
 
 /// [`patch_project_registry_route`]'s body, with the `gh auth status` answer
@@ -477,25 +574,27 @@ pub(crate) async fn patch_project_registry_with_probe(
     name: String,
     body: PatchProjectBody,
     probe: Option<GhAuthProbe>,
-) -> Response {
+) -> Result<Project, DaemonError> {
     if let Some(new_name) = &body.name
         && new_name.trim() != name
     {
-        return (
-            StatusCode::BAD_REQUEST,
-            "project name is the identity key and cannot be changed via PATCH",
-        )
-            .into_response();
+        return Err(DaemonError::InvalidRequest(
+            "project name is the identity key and cannot be changed via PATCH".to_string(),
+        ));
     }
     if let Some(repo_url) = &body.repo_url
         && repo_url.trim().is_empty()
     {
-        return (StatusCode::BAD_REQUEST, "repo_url must not be empty").into_response();
+        return Err(DaemonError::InvalidRequest(
+            "repo_url must not be empty".to_string(),
+        ));
     }
     if let Some(default_branch) = &body.default_branch
         && default_branch.trim().is_empty()
     {
-        return (StatusCode::BAD_REQUEST, "default_branch must not be empty").into_response();
+        return Err(DaemonError::InvalidRequest(
+            "default_branch must not be empty".to_string(),
+        ));
     }
 
     let tags_add = match body
@@ -503,7 +602,7 @@ pub(crate) async fn patch_project_registry_with_probe(
         .map(|tags| trim_and_reject_blank_tags(tags, "tags_add"))
     {
         Some(Ok(tags)) => Some(tags),
-        Some(Err(msg)) => return (StatusCode::BAD_REQUEST, msg).into_response(),
+        Some(Err(msg)) => return Err(DaemonError::InvalidRequest(msg)),
         None => None,
     };
     let tags_remove = match body
@@ -511,16 +610,13 @@ pub(crate) async fn patch_project_registry_with_probe(
         .map(|tags| trim_and_reject_blank_tags(tags, "tags_remove"))
     {
         Some(Ok(tags)) => Some(tags),
-        Some(Err(msg)) => return (StatusCode::BAD_REQUEST, msg).into_response(),
+        Some(Err(msg)) => return Err(DaemonError::InvalidRequest(msg)),
         None => None,
     };
     // #2121: verify a `gh_user` SET before anything touches the store; absent
     // and `null` (clear) pass straight through.
     let gh_user = match body.gh_user {
-        Some(Some(login)) => match validate_gh_user_login(&login, probe.as_ref()) {
-            Ok(canonical) => Some(Some(canonical)),
-            Err((status, message)) => return (status, message).into_response(),
-        },
+        Some(Some(login)) => Some(Some(validate_gh_user_login(&login, probe.as_ref())?)),
         other => other,
     };
 
@@ -570,17 +666,15 @@ pub(crate) async fn patch_project_registry_with_probe(
         .await;
 
     match result {
-        Ok(project) => Json(project).into_response(),
+        Ok(project) => Ok(project),
         Err(ProjectStoreError::NotFound(_)) => {
-            (StatusCode::NOT_FOUND, format!("project {name} not found")).into_response()
+            Err(DaemonError::NotFound(format!("project {name} not found")))
         }
         Err(e) => {
             warn!(error = %e, project = %name, "patch_project_registry_route: registry write failed");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
+            Err(DaemonError::Internal(
                 "project registry write failed".to_string(),
-            )
-                .into_response()
+            ))
         }
     }
 }
@@ -609,47 +703,33 @@ pub(crate) async fn patch_project_registry_with_probe(
 /// `validate_gh_user_rejects_a_blank_login`,
 /// `validate_gh_user_rejects_a_host_with_no_accounts`,
 /// `validate_gh_user_is_503_when_gh_could_not_answer`.
-fn validate_gh_user_login(
-    login: &str,
-    probe: Option<&GhAuthProbe>,
-) -> Result<String, (StatusCode, String)> {
+fn validate_gh_user_login(login: &str, probe: Option<&GhAuthProbe>) -> Result<String, DaemonError> {
     let login = login.trim();
     if login.is_empty() {
-        return Err((
-            StatusCode::BAD_REQUEST,
+        return Err(DaemonError::InvalidRequest(
             "gh_user must not be blank — send null to clear it".to_string(),
         ));
     }
     match probe {
         Some(GhAuthProbe::Answered(status)) => match status.canonical_logged_in_login(login) {
             Some(canonical) => Ok(canonical),
-            None if status.logged_in.is_empty() => Err((
-                StatusCode::BAD_REQUEST,
-                format!(
-                    "gh_user must name an account `gh auth status` reports as logged in, but it \
-                     reports none — run `gh auth login` before setting gh_user to '{login}'"
-                ),
-            )),
-            None => Err((
-                StatusCode::BAD_REQUEST,
-                format!(
-                    "gh_user must name an account `gh auth status` reports as logged in; \
-                     '{login}' is not one of: {}",
-                    status.logged_in.join(", ")
-                ),
-            )),
+            None if status.logged_in.is_empty() => Err(DaemonError::InvalidRequest(format!(
+                "gh_user must name an account `gh auth status` reports as logged in, but it \
+                 reports none — run `gh auth login` before setting gh_user to '{login}'"
+            ))),
+            None => Err(DaemonError::InvalidRequest(format!(
+                "gh_user must name an account `gh auth status` reports as logged in; \
+                 '{login}' is not one of: {}",
+                status.logged_in.join(", ")
+            ))),
         },
-        Some(GhAuthProbe::Inconclusive(why)) => Err((
-            StatusCode::SERVICE_UNAVAILABLE,
-            format!("gh_user '{login}' could not be verified against `gh auth status`: {why}"),
-        )),
-        None => Err((
-            StatusCode::SERVICE_UNAVAILABLE,
-            format!(
-                "gh_user '{login}' could not be verified: no `gh auth status` answer was \
-                 available for this request"
-            ),
-        )),
+        Some(GhAuthProbe::Inconclusive(why)) => Err(DaemonError::ServiceUnavailable(format!(
+            "gh_user '{login}' could not be verified against `gh auth status`: {why}"
+        ))),
+        None => Err(DaemonError::ServiceUnavailable(format!(
+            "gh_user '{login}' could not be verified: no `gh auth status` answer was \
+             available for this request"
+        ))),
     }
 }
 
@@ -719,8 +799,10 @@ mod tests {
     /// Test: itself.
     #[test]
     fn validate_gh_user_rejects_an_unknown_login() {
-        let (status, message) =
-            validate_gh_user_login("typo-bot", Some(&two_accounts())).unwrap_err();
+        // #6288: the helper reports a `DaemonError` now; the status and the
+        // operator-facing text are unchanged and still what is asserted.
+        let error = validate_gh_user_login("typo-bot", Some(&two_accounts())).unwrap_err();
+        let (status, message) = (error.status(), error.detail());
         assert_eq!(status, StatusCode::BAD_REQUEST);
         assert!(message.contains("gh_user"), "{message}");
         assert!(message.contains("typo-bot"), "{message}");
@@ -733,8 +815,8 @@ mod tests {
     #[test]
     fn validate_gh_user_rejects_a_blank_login() {
         for blank in ["", "   "] {
-            let (status, message) =
-                validate_gh_user_login(blank, Some(&two_accounts())).unwrap_err();
+            let error = validate_gh_user_login(blank, Some(&two_accounts())).unwrap_err();
+            let (status, message) = (error.status(), error.detail());
             assert_eq!(status, StatusCode::BAD_REQUEST);
             assert!(message.contains("null"), "{message}");
         }
@@ -746,7 +828,8 @@ mod tests {
     #[test]
     fn validate_gh_user_rejects_a_host_with_no_accounts() {
         let probe = GhAuthProbe::Answered(GhAccountStatus::default());
-        let (status, message) = validate_gh_user_login("bobmatnyc", Some(&probe)).unwrap_err();
+        let error = validate_gh_user_login("bobmatnyc", Some(&probe)).unwrap_err();
+        let (status, message) = (error.status(), error.detail());
         assert_eq!(status, StatusCode::BAD_REQUEST);
         assert!(message.contains("gh auth login"), "{message}");
     }
@@ -758,12 +841,13 @@ mod tests {
     #[test]
     fn validate_gh_user_is_503_when_gh_could_not_answer() {
         let probe = GhAuthProbe::Inconclusive("`gh` could not be run".to_string());
-        let (status, message) = validate_gh_user_login("bobmatnyc", Some(&probe)).unwrap_err();
+        let error = validate_gh_user_login("bobmatnyc", Some(&probe)).unwrap_err();
+        let (status, message) = (error.status(), error.detail());
         assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
         assert!(message.contains("could not be verified"), "{message}");
 
-        let (status, _) = validate_gh_user_login("bobmatnyc", None).unwrap_err();
-        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        let error = validate_gh_user_login("bobmatnyc", None).unwrap_err();
+        assert_eq!(error.status(), StatusCode::SERVICE_UNAVAILABLE);
     }
 
     /// Seed an isolated daemon holding one registered project.
@@ -808,7 +892,8 @@ mod tests {
             Some(two_accounts()),
         )
         .await;
-        assert_eq!(resp.status(), StatusCode::OK);
+        // #6288: the seam answers `Result<Project, DaemonError>` now.
+        assert!(resp.is_ok(), "{:?}", resp.err().map(|e| e.to_string()));
 
         let stored = state
             .project_registry()
@@ -846,7 +931,12 @@ mod tests {
             Some(two_accounts()),
         )
         .await;
-        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        // #6288: the seam answers `Result<Project, DaemonError>` now; the
+        // status the HTTP delegator would render is still what is asserted.
+        assert_eq!(
+            resp.expect_err("the request must be refused").status(),
+            StatusCode::BAD_REQUEST
+        );
 
         let after = state
             .project_registry()
@@ -874,7 +964,8 @@ mod tests {
             None,
         )
         .await;
-        assert_eq!(resp.status(), StatusCode::OK);
+        // #6288: the seam answers `Result<Project, DaemonError>` now.
+        assert!(resp.is_ok(), "{:?}", resp.err().map(|e| e.to_string()));
         assert_eq!(
             state
                 .project_registry()

--- a/crates/trusty-mpm/src/daemon/managed_routes/project_status/mod.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/project_status/mod.rs
@@ -32,13 +32,13 @@ use std::sync::Arc;
 use axum::{
     Json,
     extract::{Path as AxumPath, State},
-    http::StatusCode,
     response::IntoResponse,
 };
 use chrono::{DateTime, Utc};
 use serde::Serialize;
 use tracing::warn;
 
+use crate::daemon::error::DaemonError;
 use crate::daemon::state::DaemonState;
 use crate::deliverable::{
     Deliverable, DeliverableId, DeliverableStatus, Milestone, MilestoneStatus,
@@ -399,11 +399,33 @@ pub async fn project_status_route(
     State(state): State<Arc<DaemonState>>,
     AxumPath(name): AxumPath<String>,
 ) -> impl IntoResponse {
+    // #6288: the body is shared with `mpm.projects.status`. The plain-text
+    // error bodies are preserved via `DaemonError::detail`.
+    match project_status_op(&state, &name).await {
+        Ok(rollup) => Json(rollup).into_response(),
+        Err(e) => (e.status(), e.detail()).into_response(),
+    }
+}
+
+/// [`project_status_route`]'s body, with no transport in it (#6288 slice 5).
+///
+/// # Errors
+///
+/// [`DaemonError::NotFound`] when `name` is not registered;
+/// [`DaemonError::Internal`] when the project, deliverable, or milestone store
+/// read fails.
+///
+/// Test: `parity_project_status_agrees_across_transports`,
+/// `rpc_project_status_unknown_project_is_not_found`.
+pub async fn project_status_op(
+    state: &Arc<DaemonState>,
+    name: &str,
+) -> Result<ProjectStatusResponse, DaemonError> {
     let registry = state.project_registry().await;
-    let project = match registry.get(&name).await {
+    let project = match registry.get(name).await {
         Ok(project) => project,
         Err(ProjectStoreError::NotFound(_)) => {
-            return (StatusCode::NOT_FOUND, format!("project {name} not found")).into_response();
+            return Err(DaemonError::NotFound(format!("project {name} not found")));
         }
         Err(e) => {
             warn!(
@@ -411,11 +433,9 @@ pub async fn project_status_route(
                 project = %name,
                 "project_status_route: project registry read failed"
             );
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
+            return Err(DaemonError::Internal(
                 "project registry read failed".to_string(),
-            )
-                .into_response();
+            ));
         }
     };
 
@@ -431,11 +451,9 @@ pub async fn project_status_route(
                 project = %name,
                 "project_status_route: deliverable store read failed"
             );
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
+            return Err(DaemonError::Internal(
                 "deliverable store read failed".to_string(),
-            )
-                .into_response();
+            ));
         }
     };
     let milestones = match deliverable_mgr.all_milestones().await {
@@ -446,21 +464,18 @@ pub async fn project_status_route(
                 project = %name,
                 "project_status_route: milestone store read failed"
             );
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
+            return Err(DaemonError::Internal(
                 "milestone store read failed".to_string(),
-            )
-                .into_response();
+            ));
         }
     };
 
-    Json(aggregate_project_status(
+    Ok(aggregate_project_status(
         &project,
         &sessions,
         &deliverables,
         &milestones,
     ))
-    .into_response()
 }
 
 #[cfg(test)]

--- a/crates/trusty-mpm/src/daemon/manager/act.rs
+++ b/crates/trusty-mpm/src/daemon/manager/act.rs
@@ -23,12 +23,12 @@ use std::sync::Arc;
 
 use axum::Json;
 use axum::extract::State;
-use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use super::actuator::{InjectOutcome, ManagerActuator, SummarizeOutcome, resolve_actuator};
+use crate::daemon::error::DaemonError;
 use crate::daemon::state::DaemonState;
 
 /// The action a caller proposes (and, on confirm, the manager executes).
@@ -308,39 +308,67 @@ pub async fn manager_act_route(
     State(state): State<Arc<DaemonState>>,
     Json(body): Json<ActRequest>,
 ) -> impl IntoResponse {
-    let conversation_key = body.conversation_key.trim().to_string();
-    if conversation_key.is_empty() {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(json!({ "error": "invalid_request",
-                         "message": "conversation_key must not be empty" })),
-        )
-            .into_response();
-    }
-
-    // Propose-only: return what confirming would do; execute NOTHING.
-    if !body.confirm {
-        return Json(ActResponse::Proposed {
-            proposal: propose_message(&body.action),
-            action: body.action,
-        })
-        .into_response();
-    }
-
-    // Confirmed: resolve the execution seam (test override, else production) and
-    // execute through the SAME dispatch the chat confirm turn uses.
-    let actuator = resolve_actuator(&state);
-    match execute_action(&actuator, &conversation_key, body.action).await {
+    // #6288: the body is shared with `mpm.manager.act`.
+    match act_op(&state, body).await {
         Ok(response) => Json(response).into_response(),
-        Err(error) => {
-            tracing::warn!("manager act: action execution failed: {error}");
+        Err(e) => {
+            let code = match &e {
+                DaemonError::InvalidRequest(_) => "invalid_request",
+                _ => "launch_failed",
+            };
             (
-                StatusCode::BAD_GATEWAY,
-                Json(json!({ "error": "launch_failed", "message": error })),
+                e.status(),
+                Json(json!({ "error": code, "message": e.detail() })),
             )
                 .into_response()
         }
     }
+}
+
+/// [`manager_act_route`]'s body, with no transport in it (#6288 slice 5).
+///
+/// Why the propose→confirm gate is unchanged: `confirm == false` still returns
+/// [`ActResponse::Proposed`] and executes nothing, and the confirmed path still
+/// runs through the one [`execute_action`] seam the chat confirm turn drives.
+/// Moving the call site changed neither, so the socket cannot mutate a session
+/// on a call an HTTP caller could not have mutated one with.
+///
+/// # Errors
+///
+/// [`DaemonError::InvalidRequest`] on a blank conversation key;
+/// [`DaemonError::UpstreamFailed`] when a confirmed launch fails to spawn.
+/// Inject and summarize outcomes are advisory `Ok` values, never errors.
+///
+/// Test: `parity_manager_act_propose_agrees_across_transports`,
+/// `rpc_manager_act_rejects_a_blank_conversation_key`.
+pub async fn act_op(
+    state: &Arc<DaemonState>,
+    body: ActRequest,
+) -> Result<ActResponse, DaemonError> {
+    let conversation_key = body.conversation_key.trim().to_string();
+    if conversation_key.is_empty() {
+        return Err(DaemonError::InvalidRequest(
+            "conversation_key must not be empty".to_string(),
+        ));
+    }
+
+    // Propose-only: return what confirming would do; execute NOTHING.
+    if !body.confirm {
+        return Ok(ActResponse::Proposed {
+            proposal: propose_message(&body.action),
+            action: body.action,
+        });
+    }
+
+    // Confirmed: resolve the execution seam (test override, else production) and
+    // execute through the SAME dispatch the chat confirm turn uses.
+    let actuator = resolve_actuator(state);
+    execute_action(&actuator, &conversation_key, body.action)
+        .await
+        .map_err(|error| {
+            tracing::warn!("manager act: action execution failed: {error}");
+            DaemonError::UpstreamFailed(error)
+        })
 }
 
 #[cfg(test)]

--- a/crates/trusty-mpm/src/daemon/manager/chat.rs
+++ b/crates/trusty-mpm/src/daemon/manager/chat.rs
@@ -49,6 +49,7 @@ use super::chat_store::{ChatTurn, TurnRole};
 use super::inference::{MANAGER_MAX_TOKENS, MANAGER_TEMPERATURE};
 use super::proposal::{extract_proposed_action, is_confirmation};
 use super::status::{PortfolioStatusResponse, load_portfolio_status};
+use crate::daemon::error::DaemonError;
 use crate::daemon::state::DaemonState;
 
 /// Request body for `POST /api/v1/manager/chat`.
@@ -224,20 +225,69 @@ pub async fn manager_chat_route(
     State(state): State<Arc<DaemonState>>,
     Json(body): Json<ChatRequestBody>,
 ) -> impl IntoResponse {
+    // #6288: the body is shared with `mpm.manager.chat`.
+    match chat_op(&state, body).await {
+        Ok(reply) => Json(reply).into_response(),
+        Err(e) => render_chat_error(e),
+    }
+}
+
+/// Render a chat failure in this route's historical body shape (#6288).
+///
+/// Why: three of the four failure classes have always answered a typed
+/// `{ error, message }` JSON object, and the fourth — a store read failure
+/// reaching here from [`load_portfolio_status`] — has always answered plain
+/// text. Both wires are preserved exactly; only where the failure is DECIDED
+/// moved, from the handler into [`chat_op`].
+fn render_chat_error(e: DaemonError) -> axum::response::Response {
+    match &e {
+        DaemonError::InvalidRequest(m) => {
+            chat_error(StatusCode::BAD_REQUEST, "invalid_request", m.clone())
+        }
+        DaemonError::ServiceUnavailable(m) => chat_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "inference_unavailable",
+            m.clone(),
+        ),
+        DaemonError::UpstreamFailed(m) => {
+            chat_error(StatusCode::BAD_GATEWAY, "inference_failed", m.clone())
+        }
+        other => (other.status(), other.detail()).into_response(),
+    }
+}
+
+/// [`manager_chat_route`]'s body, with no transport in it (#6288 slice 5).
+///
+/// Why nothing about the propose→confirm flow moved: the pending-proposal store
+/// is consulted, and unconditionally consumed, before any inference call — that
+/// ordering is what makes the confirm turn deterministic and zero-LLM, and it is
+/// preserved verbatim here. A socket caller therefore gets the same next-turn
+/// TTL semantics as an HTTP one.
+///
+/// # Errors
+///
+/// [`DaemonError::InvalidRequest`] on a blank conversation key or message;
+/// [`DaemonError::Internal`] when a store read fails;
+/// [`DaemonError::ServiceUnavailable`] when no provider is configured;
+/// [`DaemonError::UpstreamFailed`] when the provider call fails or returns
+/// nothing.
+///
+/// Test: `parity_manager_chat_agrees_across_transports`,
+/// `rpc_manager_chat_rejects_a_blank_conversation_key`.
+pub async fn chat_op(
+    state: &Arc<DaemonState>,
+    body: ChatRequestBody,
+) -> Result<ChatReplyBody, DaemonError> {
     let conversation_key = body.conversation_key.trim().to_string();
     if conversation_key.is_empty() {
-        return chat_error(
-            StatusCode::BAD_REQUEST,
-            "invalid_request",
+        return Err(DaemonError::InvalidRequest(
             "conversation_key must not be empty".to_string(),
-        );
+        ));
     }
     if body.message.trim().is_empty() {
-        return chat_error(
-            StatusCode::BAD_REQUEST,
-            "invalid_request",
+        return Err(DaemonError::InvalidRequest(
             "message must not be empty".to_string(),
-        );
+        ));
     }
 
     let manager = state.manager_state();
@@ -250,7 +300,7 @@ pub async fn manager_chat_route(
     if let Some(pending) = manager.proposals().take(&conversation_key)
         && is_confirmation(&body.message)
     {
-        let actuator = resolve_actuator(&state);
+        let actuator = resolve_actuator(state);
         let action_result = match execute_action(&actuator, &conversation_key, pending).await {
             Ok(response) => response,
             Err(error) => {
@@ -271,31 +321,21 @@ pub async fn manager_chat_route(
             .palace()
             .record_chat_turn(&conversation_key, &body.message, &reply)
             .await;
-        return Json(ChatReplyBody {
+        return Ok(ChatReplyBody {
             conversation_key,
             reply,
             model,
             turn_count,
             action_result: Some(action_result),
-        })
-        .into_response();
+        });
     }
 
-    let status = match load_portfolio_status(&state).await {
-        Ok(status) => status,
-        Err((code, msg)) => return (code, msg).into_response(),
-    };
+    let status = load_portfolio_status(state).await?;
 
-    let (model, adapter) = match manager.inference().resolve() {
-        Ok(pair) => pair,
-        Err(unavailable) => {
-            return chat_error(
-                StatusCode::SERVICE_UNAVAILABLE,
-                "inference_unavailable",
-                unavailable.to_string(),
-            );
-        }
-    };
+    let (model, adapter) = manager
+        .inference()
+        .resolve()
+        .map_err(|unavailable| DaemonError::ServiceUnavailable(unavailable.to_string()))?;
 
     let history = manager.conversations().history(&conversation_key);
     // No tool-calling surface: NO `tools` are attached, so the model has no API
@@ -313,20 +353,16 @@ pub async fn manager_chat_route(
         Ok(response) => match response.first_text().filter(|t| !t.trim().is_empty()) {
             Some(text) => text,
             None => {
-                return chat_error(
-                    StatusCode::BAD_GATEWAY,
-                    "inference_failed",
+                return Err(DaemonError::UpstreamFailed(
                     "provider returned an empty reply".to_string(),
-                );
+                ));
             }
         },
         Err(e) => {
             tracing::warn!("manager chat inference call failed: {e}");
-            return chat_error(
-                StatusCode::BAD_GATEWAY,
-                "inference_failed",
+            return Err(DaemonError::UpstreamFailed(
                 "inference call failed".to_string(),
-            );
+            ));
         }
     };
 
@@ -359,14 +395,13 @@ pub async fn manager_chat_route(
         .record_chat_turn(&conversation_key, &body.message, &reply)
         .await;
 
-    Json(ChatReplyBody {
+    Ok(ChatReplyBody {
         conversation_key,
         reply,
         model,
         turn_count,
         action_result,
     })
-    .into_response()
 }
 
 #[cfg(test)]

--- a/crates/trusty-mpm/src/daemon/manager/digest.rs
+++ b/crates/trusty-mpm/src/daemon/manager/digest.rs
@@ -29,6 +29,7 @@ use trusty_common::inference::{ChatMessage, ChatRequest};
 
 use super::inference::{MANAGER_MAX_TOKENS, MANAGER_TEMPERATURE};
 use super::status::{PortfolioStatusResponse, load_portfolio_status, rollup_of};
+use crate::daemon::error::DaemonError;
 use crate::daemon::state::DaemonState;
 
 /// `generated_by` marker for a genuine LLM-authored narrative.
@@ -218,15 +219,76 @@ pub async fn manager_digest_route(
     State(state): State<Arc<DaemonState>>,
     Query(query): Query<DigestQuery>,
 ) -> impl IntoResponse {
-    let scope = match parse_scope(query.scope.as_deref()) {
-        Ok(scope) => scope,
-        Err(msg) => return (StatusCode::BAD_REQUEST, msg).into_response(),
-    };
+    // #6288: the body is shared with `mpm.manager.digest`. The status this
+    // route renders comes from the outcome, so 200/503/502 are unchanged.
+    match digest_op(&state, query).await {
+        Ok(outcome) => (outcome.http_status(), Json(outcome.into_body())).into_response(),
+        // These three have always been plain-text bodies; `detail` keeps them so.
+        Err(e) => (e.status(), e.detail()).into_response(),
+    }
+}
 
-    let full = match load_portfolio_status(&state).await {
-        Ok(full) => full,
-        Err((code, msg)) => return (code, msg).into_response(),
-    };
+/// What one digest call produced, and how the two transports render it.
+///
+/// Why this is an OUTCOME rather than three `Result` arms: the 503 and 502 legs
+/// are not empty refusals — each carries a complete [`DigestResponse`] with the
+/// deterministic narrative and the full rollup, which is the entire point of
+/// DOC-16 D1's degrade contract. A JSON-RPC error frame is `{code, message}`
+/// and cannot carry a body, so turning those two into RPC errors would DROP the
+/// numbers the caller asked for. Over the socket all three are results, and the
+/// `error` field already on [`DigestResponse`] (`None` /
+/// `"inference_unavailable"` / `"inference_failed"`) is what distinguishes
+/// them — the same field an HTTP caller reads. Only the three genuinely empty
+/// refusals (bad scope, unknown project, store read failed) are errors, and
+/// those are [`DaemonError`]s on both transports.
+/// Test: `parity_manager_digest_agrees_across_transports` drives the
+/// no-provider leg through both transports and compares the whole body.
+#[derive(Debug)]
+pub enum DigestOutcome {
+    /// A provider answered; `generated_by` is the LLM (HTTP 200).
+    Generated(DigestResponse),
+    /// No provider is configured; the deterministic fallback (HTTP 503).
+    Unavailable(DigestResponse),
+    /// A configured provider was called and failed; the fallback (HTTP 502).
+    Failed(DigestResponse),
+}
+
+impl DigestOutcome {
+    /// The status the HTTP route answers with, unchanged from before #6288.
+    fn http_status(&self) -> StatusCode {
+        match self {
+            Self::Generated(_) => StatusCode::OK,
+            Self::Unavailable(_) => StatusCode::SERVICE_UNAVAILABLE,
+            Self::Failed(_) => StatusCode::BAD_GATEWAY,
+        }
+    }
+
+    /// The body, which is identical on both transports.
+    pub fn into_body(self) -> DigestResponse {
+        match self {
+            Self::Generated(b) | Self::Unavailable(b) | Self::Failed(b) => b,
+        }
+    }
+}
+
+/// [`manager_digest_route`]'s body, with no transport in it (#6288 slice 5).
+///
+/// # Errors
+///
+/// [`DaemonError::InvalidRequest`] on a malformed `scope`;
+/// [`DaemonError::NotFound`] when a project scope names no registered project;
+/// [`DaemonError::Internal`] when a store read fails.
+///
+/// Test: `parity_manager_digest_agrees_across_transports`,
+/// `rpc_manager_digest_rejects_a_malformed_scope`,
+/// `rpc_manager_digest_unknown_project_is_not_found`.
+pub async fn digest_op(
+    state: &Arc<DaemonState>,
+    query: DigestQuery,
+) -> Result<DigestOutcome, DaemonError> {
+    let scope = parse_scope(query.scope.as_deref()).map_err(DaemonError::InvalidRequest)?;
+
+    let full = load_portfolio_status(state).await?;
 
     // Narrow to scope, reusing the per-project rollups verbatim (never re-derived).
     let scoped = match &scope {
@@ -235,11 +297,9 @@ pub async fn manager_digest_route(
             match full.projects.iter().find(|p| &p.project_name == name) {
                 Some(p) => rollup_of(vec![p.clone()]),
                 None => {
-                    return (
-                        StatusCode::NOT_FOUND,
-                        format!("project '{name}' is not registered"),
-                    )
-                        .into_response();
+                    return Err(DaemonError::NotFound(format!(
+                        "project '{name}' is not registered"
+                    )));
                 }
             }
         }
@@ -251,19 +311,15 @@ pub async fn manager_digest_route(
     let (model, adapter) = match state.manager_state().inference().resolve() {
         Ok(pair) => pair,
         Err(unavailable) => {
-            return (
-                StatusCode::SERVICE_UNAVAILABLE,
-                Json(DigestResponse {
-                    scope: scope_label.clone(),
-                    generated_by: GENERATED_BY_FALLBACK,
-                    model: None,
-                    narrative: deterministic_narrative(&scope_label, &scoped),
-                    status: scoped,
-                    error: Some("inference_unavailable".to_string()),
-                    message: Some(unavailable.to_string()),
-                }),
-            )
-                .into_response();
+            return Ok(DigestOutcome::Unavailable(DigestResponse {
+                scope: scope_label.clone(),
+                generated_by: GENERATED_BY_FALLBACK,
+                model: None,
+                narrative: deterministic_narrative(&scope_label, &scoped),
+                status: scoped,
+                error: Some("inference_unavailable".to_string()),
+                message: Some(unavailable.to_string()),
+            }));
         }
     };
 
@@ -274,7 +330,7 @@ pub async fn manager_digest_route(
 
     match adapter.chat(&request).await {
         Ok(response) => match response.first_text().filter(|t| !t.trim().is_empty()) {
-            Some(narrative) => Json(DigestResponse {
+            Some(narrative) => Ok(DigestOutcome::Generated(DigestResponse {
                 scope: scope_label,
                 generated_by: GENERATED_BY_LLM,
                 model: Some(model),
@@ -282,13 +338,20 @@ pub async fn manager_digest_route(
                 status: scoped,
                 error: None,
                 message: None,
-            })
-            .into_response(),
-            None => digest_call_failed(scope_label, scoped, "provider returned an empty narrative"),
+            })),
+            None => Ok(digest_call_failed(
+                scope_label,
+                scoped,
+                "provider returned an empty narrative",
+            )),
         },
         Err(e) => {
             tracing::warn!("manager digest inference call failed: {e}");
-            digest_call_failed(scope_label, scoped, "inference call failed")
+            Ok(digest_call_failed(
+                scope_label,
+                scoped,
+                "inference call failed",
+            ))
         }
     }
 }
@@ -300,28 +363,26 @@ pub async fn manager_digest_route(
 /// and a clearly-marked deterministic narrative, distinct (502) from the
 /// no-provider 503 case.
 /// What: renders a [`DigestResponse`] with the fallback narrative + an
-/// `inference_failed` error code as a `502`.
+/// `inference_failed` error code, as [`DigestOutcome::Failed`] — which the HTTP
+/// route still answers with `502` (#6288 moved the status out of this function
+/// and onto the outcome; the body is byte-identical).
 /// Test: HTTP coverage in `tests/manager_inference.rs`.
 fn digest_call_failed(
     scope_label: String,
     status: PortfolioStatusResponse,
     reason: &str,
-) -> axum::response::Response {
-    (
-        StatusCode::BAD_GATEWAY,
-        Json(DigestResponse {
-            scope: scope_label.clone(),
-            generated_by: GENERATED_BY_FALLBACK,
-            model: None,
-            narrative: deterministic_narrative(&scope_label, &status),
-            status,
-            error: Some("inference_failed".to_string()),
-            message: Some(format!(
-                "{reason}; returning the deterministic rollup — see GET /api/v1/manager/status"
-            )),
-        }),
-    )
-        .into_response()
+) -> DigestOutcome {
+    DigestOutcome::Failed(DigestResponse {
+        scope: scope_label.clone(),
+        generated_by: GENERATED_BY_FALLBACK,
+        model: None,
+        narrative: deterministic_narrative(&scope_label, &status),
+        status,
+        error: Some("inference_failed".to_string()),
+        message: Some(format!(
+            "{reason}; returning the deterministic rollup — see GET /api/v1/manager/status"
+        )),
+    })
 }
 
 #[cfg(test)]

--- a/crates/trusty-mpm/src/daemon/manager/route_task.rs
+++ b/crates/trusty-mpm/src/daemon/manager/route_task.rs
@@ -28,13 +28,13 @@ use std::sync::Arc;
 
 use axum::Json;
 use axum::extract::State;
-use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use trusty_common::inference::{ChatMessage, ChatRequest};
 
 use super::inference::{MANAGER_MAX_TOKENS, MANAGER_TEMPERATURE};
+use crate::daemon::error::DaemonError;
 use crate::daemon::state::DaemonState;
 use crate::project::resolver::{ProjectMatch, ProjectResolution, ResolverError, resolve_project};
 
@@ -230,46 +230,73 @@ pub async fn manager_route_task_route(
     State(state): State<Arc<DaemonState>>,
     Json(body): Json<RouteTaskRequest>,
 ) -> impl IntoResponse {
+    // #6288: the body is shared with `mpm.manager.route_task`.
+    match route_task_op(&state, body).await {
+        Ok(reply) => Json(reply).into_response(),
+        Err(e) => render_route_task_error(e),
+    }
+}
+
+/// Render a route-task failure in this route's historical body shape (#6288).
+///
+/// Why: both failure classes have always answered a typed `{ error, message }`
+/// JSON object, with different `error` codes. Only where the failure is
+/// DECIDED moved.
+fn render_route_task_error(e: DaemonError) -> axum::response::Response {
+    let code = match &e {
+        DaemonError::InvalidRequest(_) => "invalid_request",
+        _ => "registry_read_failed",
+    };
+    (
+        e.status(),
+        Json(json!({ "error": code, "message": e.detail() })),
+    )
+        .into_response()
+}
+
+/// [`manager_route_task_route`]'s body, with no transport in it (#6288 slice 5).
+///
+/// # Errors
+///
+/// [`DaemonError::InvalidRequest`] on blank `text`; [`DaemonError::Internal`]
+/// when the project registry read fails. Every other outcome — including
+/// no-match and an inconclusive disambiguation — is an advisory `Ok`, exactly
+/// as it was over HTTP.
+///
+/// Test: `parity_manager_route_task_agrees_across_transports`,
+/// `rpc_manager_route_task_rejects_blank_text`.
+pub async fn route_task_op(
+    state: &Arc<DaemonState>,
+    body: RouteTaskRequest,
+) -> Result<RouteTaskResponse, DaemonError> {
     let text = body.text.trim().to_string();
     if text.is_empty() {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(json!({ "error": "invalid_request", "message": "text must not be empty" })),
-        )
-            .into_response();
+        return Err(DaemonError::InvalidRequest(
+            "text must not be empty".to_string(),
+        ));
     }
 
     let registry = state.project_registry().await;
-    let projects = match registry.list().await {
-        Ok(projects) => projects,
-        Err(e) => {
-            tracing::warn!(error = %e, "route-task: project registry read failed");
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({ "error": "registry_read_failed",
-                             "message": "project registry read failed" })),
-            )
-                .into_response();
-        }
-    };
+    let projects = registry.list().await.map_err(|e| {
+        tracing::warn!(error = %e, "route-task: project registry read failed");
+        DaemonError::Internal("project registry read failed".to_string())
+    })?;
 
     let resolution = match resolve_project(&text, &projects) {
         Ok(resolution) => resolution,
         Err(ResolverError::EmptyRegistry) => {
-            return Json(no_match_response(
+            return Ok(no_match_response(
                 "no projects are registered; register one with `tm projects register`",
-            ))
-            .into_response();
+            ));
         }
         Err(ResolverError::NoMatch { .. }) => {
-            return Json(no_match_response("no registered project matched the task"))
-                .into_response();
+            return Ok(no_match_response("no registered project matched the task"));
         }
     };
 
     // Unambiguous: reuse the deterministic pick verbatim — no inference.
     if !resolution.needs_disambiguation() {
-        return Json(resolver_response(&resolution, None)).into_response();
+        return Ok(resolver_response(&resolution, None));
     }
 
     // Tie/low-confidence: #2109 owns the judgment. Escalate to ONE LLM call.
@@ -278,14 +305,13 @@ pub async fn manager_route_task_route(
         Err(_) => {
             // No provider — degrade to the deterministic top candidate rather
             // than fail; advisory output must never panic (§4 degrade bar).
-            return Json(resolver_response(
+            return Ok(resolver_response(
                 &resolution,
                 Some(
                     "multiple candidates tied and no inference provider was available to \
                       disambiguate, so the highest-confidence candidate was chosen",
                 ),
-            ))
-            .into_response();
+            ));
         }
     };
 
@@ -308,7 +334,7 @@ pub async fn manager_route_task_route(
     };
 
     match picked {
-        Some(m) => Json(RouteTaskResponse {
+        Some(m) => Ok(RouteTaskResponse {
             project: Some(m.project.name.clone()),
             confidence: m.confidence,
             rationale: format!(
@@ -320,15 +346,13 @@ pub async fn manager_route_task_route(
                 m.reason.label(),
             ),
             resolved_by: ResolvedBy::Disambiguation,
-        })
-        .into_response(),
+        }),
         // The call failed or named an unlisted project — fall back to the
         // deterministic top candidate.
-        None => Json(resolver_response(
+        None => Ok(resolver_response(
             &resolution,
             Some("disambiguation was inconclusive, so the highest-confidence candidate was chosen"),
-        ))
-        .into_response(),
+        )),
     }
 }
 

--- a/crates/trusty-mpm/src/daemon/manager/status.rs
+++ b/crates/trusty-mpm/src/daemon/manager/status.rs
@@ -21,11 +21,12 @@
 
 use std::sync::Arc;
 
-use axum::{Json, extract::State, http::StatusCode, response::IntoResponse};
+use axum::{Json, extract::State, response::IntoResponse};
 use chrono::{DateTime, Utc};
 use serde::Serialize;
 use tracing::warn;
 
+use crate::daemon::error::DaemonError;
 use crate::daemon::managed_routes::{
     DeliverableStatusCounts, MilestoneStatusCounts, ProjectStatusResponse, SessionStateCounts,
     aggregate_project_status,
@@ -218,21 +219,26 @@ fn fold_totals(per_project: &[ProjectStatusResponse]) -> PortfolioTotals {
 /// What: lists every registered project plus all session/Deliverable/Milestone
 /// records ONCE, folds them via [`aggregate_portfolio_status`], and returns the
 /// [`PortfolioStatusResponse`]. Any store read error becomes a
-/// `(500, message)` pair the caller renders — the library never `unwrap`s a store
-/// result. Read-only: it never mutates a record (§2.1 boundary).
+/// [`DaemonError::Internal`] the caller renders — the library never `unwrap`s a
+/// store result. #6288 changed that error from an HTTP `(StatusCode, String)`
+/// pair to the typed value, so the socket transport can carry the SAME failure
+/// without re-deriving a status; the plain-text HTTP body is reproduced from
+/// [`DaemonError::detail`]. Read-only: it never mutates a record (§2.1).
+///
+/// # Errors
+///
+/// [`DaemonError::Internal`] when the project, deliverable, or milestone store
+/// read fails.
 /// Test: `manager_status_route_rolls_up_all_projects`,
 /// `manager_status_route_empty_portfolio` in `tests/manager_routes.rs`; the digest
 /// and chat coverage in `tests/manager_inference.rs` exercise it via those routes.
 pub(crate) async fn load_portfolio_status(
     state: &DaemonState,
-) -> Result<PortfolioStatusResponse, (StatusCode, String)> {
+) -> Result<PortfolioStatusResponse, DaemonError> {
     let registry = state.project_registry().await;
     let projects = registry.list().await.map_err(|e| {
         warn!(error = %e, "manager status: project registry read failed");
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "project registry read failed".to_string(),
-        )
+        DaemonError::Internal("project registry read failed".to_string())
     })?;
 
     let sessions = state.session_manager().await.list().await;
@@ -240,17 +246,11 @@ pub(crate) async fn load_portfolio_status(
     let deliverable_mgr = state.deliverable_manager().await;
     let deliverables = deliverable_mgr.all_deliverables().await.map_err(|e| {
         warn!(error = %e, "manager status: deliverable store read failed");
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "deliverable store read failed".to_string(),
-        )
+        DaemonError::Internal("deliverable store read failed".to_string())
     })?;
     let milestones = deliverable_mgr.all_milestones().await.map_err(|e| {
         warn!(error = %e, "manager status: milestone store read failed");
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "milestone store read failed".to_string(),
-        )
+        DaemonError::Internal("milestone store read failed".to_string())
     })?;
 
     Ok(aggregate_portfolio_status(
@@ -269,14 +269,17 @@ pub(crate) async fn load_portfolio_status(
 /// The handler is a thin, read-only composition over the same registry / session
 /// / Deliverable stores the per-project endpoint reads — it adds no persistence,
 /// no reasoning, and never mutates a record (§2.1 boundary).
-/// What: delegates to [`load_portfolio_status`] and renders the rollup as JSON, or
-/// the store-read error as its `(500, message)` pair.
+/// What: delegates to [`load_portfolio_status`] — which IS the transport-neutral
+/// body `mpm.manager.status` calls (#6288) — and renders the rollup as JSON, or
+/// the store-read error as the same `(500, plain text)` pair it always was.
 /// Test: `manager_status_route_rolls_up_all_projects`,
-/// `manager_status_route_empty_portfolio` in `tests/manager_routes.rs`.
+/// `manager_status_route_empty_portfolio` in `tests/manager_routes.rs`;
+/// `parity_manager_status_agrees_across_transports`.
 pub async fn manager_status_route(State(state): State<Arc<DaemonState>>) -> impl IntoResponse {
     match load_portfolio_status(&state).await {
         Ok(rollup) => Json(rollup).into_response(),
-        Err((code, msg)) => (code, msg).into_response(),
+        // #6288: `detail` keeps the body plain text, exactly as before.
+        Err(e) => (e.status(), e.detail()).into_response(),
     }
 }
 

--- a/crates/trusty-mpm/src/daemon/manager/version.rs
+++ b/crates/trusty-mpm/src/daemon/manager/version.rs
@@ -161,9 +161,17 @@ fn advertised_endpoints() -> Vec<ManagerEndpoint> {
 /// /verb-set data with the live palace availability. Read-only; never mutates.
 /// Test: `manager_version_route_reports_capabilities` in `tests/manager_routes.rs`.
 pub async fn manager_version_route(State(state): State<Arc<DaemonState>>) -> impl IntoResponse {
+    // #6288: the body is shared with `mpm.manager.version`.
+    Json(version_op(&state))
+}
+
+/// [`manager_version_route`]'s body, with no transport in it (#6288 slice 5).
+///
+/// Test: `parity_manager_version_agrees_across_transports`.
+pub fn version_op(state: &Arc<DaemonState>) -> ManagerVersionResponse {
     let manager = state.manager_state();
     let palace = manager.palace();
-    Json(ManagerVersionResponse {
+    ManagerVersionResponse {
         manager_api_version: MANAGER_API_VERSION,
         crate_version: env!("CARGO_PKG_VERSION"),
         phase: MANAGER_PHASE,
@@ -173,5 +181,5 @@ pub async fn manager_version_route(State(state): State<Arc<DaemonState>>) -> imp
             available: palace.is_available(),
             reason: palace.unavailable_reason().map(str::to_string),
         },
-    })
+    }
 }

--- a/crates/trusty-mpm/src/daemon/rpc/managed/outcome.rs
+++ b/crates/trusty-mpm/src/daemon/rpc/managed/outcome.rs
@@ -149,6 +149,8 @@ pub use crate::daemon::error::rpc_code_for_status as status_to_rpc_code;
 mod outcome_tests {
     use trusty_common::uds::server::{CODE_INTERNAL_ERROR, CODE_INVALID_PARAMS};
 
+    use crate::daemon::error::CODE_UPSTREAM_FAILED;
+
     use super::*;
 
     #[test]
@@ -184,7 +186,9 @@ mod outcome_tests {
         assert_eq!(status_to_rpc_code(409), CODE_CONFLICT);
         assert_eq!(status_to_rpc_code(422), CODE_UNPROCESSABLE);
         assert_eq!(status_to_rpc_code(500), CODE_INTERNAL_ERROR);
-        assert_eq!(status_to_rpc_code(502), CODE_INTERNAL_ERROR);
+        // #6288 slice 5: 502 gained its own code once the manager surface began
+        // reporting "a configured provider answered badly".
+        assert_eq!(status_to_rpc_code(502), CODE_UPSTREAM_FAILED);
     }
 
     /// The two 422 resume refusals keep distinct codes, since the socket has no

--- a/crates/trusty-mpm/src/daemon/rpc/mod.rs
+++ b/crates/trusty-mpm/src/daemon/rpc/mod.rs
@@ -30,3 +30,8 @@ pub mod sessions_legacy_ops;
 /// Registration for the managed-session lifecycle, the SESSCTL control plane,
 /// and the L2 proxy (#6288 slice 4).
 pub mod managed;
+
+/// Registration for the record-keeping families: registry-B projects,
+/// deliverables/milestones, the L3 manager, the peer bus, pairing, and the
+/// delegation query (#6288 slice 5).
+pub mod registry;

--- a/crates/trusty-mpm/src/daemon/rpc/registry.rs
+++ b/crates/trusty-mpm/src/daemon/rpc/registry.rs
@@ -1,0 +1,181 @@
+//! The registry, deliverable, manager, bus, pairing and delegation RPC methods
+//! (#6288 slice 5).
+//!
+//! Why one module for six families: they are the daemon's RECORD-KEEPING
+//! surface — projects and their deliverables, the L3 rollup over both, the peer
+//! roster, the bot binding, and the delegation ledger. They share one property
+//! that matters here: every one of them is a plain request/response route over
+//! daemon-owned state, so all of them move onto the socket by the same
+//! mechanism and none of them needs the streaming seam. Splitting them across
+//! six top-level modules would put six `register` lines in `socket.rs` for one
+//! slice.
+//!
+//! What: [`register`] mounts all of them, and [`METHODS`] pins the names. The
+//! per-family registrations live in the submodules, and the transport-neutral
+//! bodies live beside their HTTP handlers — except where the handler's file sits
+//! on a frozen SLOC budget, which is why the legacy `/projects*` and `/pair/*`
+//! bodies live in [`projects`] and [`pairing`] instead of in `api.rs`.
+//!
+//! Nothing in this module or its submodules names an HTTP type. The two error
+//! enums that cross both transports — [`DaemonError`] and [`BusError`] — each
+//! own their own `From<…> for RpcError`, derived from the same status table the
+//! HTTP transport reads, so a code and a status cannot drift apart.
+//!
+//! ## Method → route
+//!
+//! | Method | Route |
+//! |---|---|
+//! | `mpm.projects.list` | `GET /projects` |
+//! | `mpm.projects.register` | `POST /projects` |
+//! | `mpm.projects.current` | `GET /projects/current?path=` |
+//! | `mpm.projects.discover` | `GET /projects/discover` |
+//! | `mpm.projects.registry.list` | `GET /api/v1/projects` |
+//! | `mpm.projects.registry.register` | `POST /api/v1/projects` |
+//! | `mpm.projects.registry.get` | `GET /api/v1/projects/{name}` |
+//! | `mpm.projects.registry.patch` | `PATCH /api/v1/projects/{name}` |
+//! | `mpm.projects.status` | `GET /api/v1/projects/{name}/status` |
+//! | `mpm.deliverables.create` | `POST /api/v1/projects/{name}/deliverables` |
+//! | `mpm.deliverables.list` | `GET /api/v1/projects/{name}/deliverables` |
+//! | `mpm.deliverables.get` | `GET /api/v1/projects/{name}/deliverables/{id}` |
+//! | `mpm.deliverables.patch` | `PATCH /api/v1/projects/{name}/deliverables/{id}` |
+//! | `mpm.milestones.create` | `POST /api/v1/projects/{name}/milestones` |
+//! | `mpm.milestones.list` | `GET /api/v1/projects/{name}/milestones` |
+//! | `mpm.milestones.get` | `GET /api/v1/projects/{name}/milestones/{id}` |
+//! | `mpm.milestones.patch` | `PATCH /api/v1/projects/{name}/milestones/{id}` |
+//! | `mpm.manager.version` | `GET /api/v1/manager/version` |
+//! | `mpm.manager.status` | `GET /api/v1/manager/status` |
+//! | `mpm.manager.digest` | `GET /api/v1/manager/digest?scope=` |
+//! | `mpm.manager.chat` | `POST /api/v1/manager/chat` |
+//! | `mpm.manager.route_task` | `POST /api/v1/manager/route-task` |
+//! | `mpm.manager.act` | `POST /api/v1/manager/act` |
+//! | `mpm.bus.register` | `POST /api/v1/bus/instances` |
+//! | `mpm.bus.deregister` | `DELETE /api/v1/bus/instances/{instance_id}` |
+//! | `mpm.bus.list` | `GET /api/v1/bus/instances` |
+//! | `mpm.bus.publish` | `POST /api/v1/bus/publish` |
+//! | `mpm.pair.request` | `POST /pair/request` |
+//! | `mpm.pair.confirm` | `POST /pair/confirm` |
+//! | `mpm.pair.status` | `GET /pair/status` |
+//! | `mpm.pair.reset` | `POST /pair/reset` |
+//! | `mpm.delegation.shared_tree_dispatch` | `POST /api/v1/sessions/{id}/delegations/shared-tree-dispatch` |
+//! | `mpm.delegation.granted_worktree` | `POST /api/v1/sessions/{id}/delegations/granted-worktree` |
+//!
+//! **`mpm.manager.digest` reports failure in its RESULT, not an error frame.**
+//! Where HTTP answers `503` (no inference provider) or `502` (the provider call
+//! failed), the socket answers a normal result carrying the same complete
+//! `DigestResponse` — deterministic narrative plus the full rollup — with
+//! `error: Some("inference_unavailable")` or `Some("inference_failed")`. A
+//! caller that reads only the narrative will silently treat a degraded digest as
+//! an LLM-authored one, so **check `error` before trusting `narrative`**;
+//! `generated_by` says the same thing a second way. The three genuinely empty
+//! refusals — malformed scope, unknown project, store read failed — ARE error
+//! frames. See [`manager`]'s module doc for why the degrade legs cannot be.
+//!
+//! **Pending slice 6:** `GET /api/v1/bus/subscribe/{instance_id}` is SSE and has
+//! no RPC method here. It needs the `RpcStreamMethod` seam slice 6 owns; its
+//! HTTP handler is untouched by this slice.
+//!
+//! ## Path and query parameters become named fields
+//!
+//! A JSON-RPC call has no path and no query string, so `{name}`, `{id}`,
+//! `{instance_id}` and `?status=` / `?scope=` / `?path=` all arrive as named
+//! parameter fields. Where a route takes a path segment AND a body, the params
+//! struct `#[serde(flatten)]`s the body around the segment field, so the wire is
+//! the HTTP body plus one key rather than a nested object.
+//!
+//! Test: `registry/tests.rs` — one parity case per route.
+//!
+//! [`DaemonError`]: crate::daemon::error::DaemonError
+//! [`BusError`]: crate::daemon::bus::BusError
+
+use std::sync::Arc;
+
+use serde::Deserialize;
+use trusty_common::uds::server::RpcRouter;
+
+use crate::daemon::state::DaemonState;
+
+pub mod bus;
+pub mod delegation;
+pub mod deliverables;
+pub mod manager;
+pub mod pairing;
+pub mod projects;
+
+#[cfg(test)]
+mod tests;
+
+/// Every method name this module registers, sorted.
+///
+/// Why pinned here: the slice-7 client swap and trusty-console will dial these
+/// names by literal, with no compile-time link to the registrations. A rename
+/// then becomes a failing assertion rather than a consumer that silently
+/// reports `method_not_found`.
+/// Test: `rpc_router_registers_every_documented_method`.
+pub const METHODS: &[&str] = &[
+    "mpm.bus.deregister",
+    "mpm.bus.list",
+    "mpm.bus.publish",
+    "mpm.bus.register",
+    "mpm.delegation.granted_worktree",
+    "mpm.delegation.shared_tree_dispatch",
+    "mpm.deliverables.create",
+    "mpm.deliverables.get",
+    "mpm.deliverables.list",
+    "mpm.deliverables.patch",
+    "mpm.manager.act",
+    "mpm.manager.chat",
+    "mpm.manager.digest",
+    "mpm.manager.route_task",
+    "mpm.manager.status",
+    "mpm.manager.version",
+    "mpm.milestones.create",
+    "mpm.milestones.get",
+    "mpm.milestones.list",
+    "mpm.milestones.patch",
+    "mpm.pair.confirm",
+    "mpm.pair.request",
+    "mpm.pair.reset",
+    "mpm.pair.status",
+    "mpm.projects.current",
+    "mpm.projects.discover",
+    "mpm.projects.list",
+    "mpm.projects.register",
+    "mpm.projects.registry.get",
+    "mpm.projects.registry.list",
+    "mpm.projects.registry.patch",
+    "mpm.projects.registry.register",
+    "mpm.projects.status",
+];
+
+/// A method that takes no arguments, tolerating `null` and a stray object.
+///
+/// Why a local copy rather than a re-export of [`crate::daemon::rpc::core`]'s:
+/// that one is `pub`, so this could import it — but importing a sibling FAMILY's
+/// type would make slice 2's file a dependency of slice 5's for a six-line
+/// struct, and the two slices are meant to be independently reviewable. The
+/// consolidation belongs in `trusty-common` alongside `RpcRouter`, where every
+/// daemon's no-argument methods can share one.
+/// Test: `rpc_projects_list_answers_with_no_params`.
+pub struct NoParams;
+
+impl<'de> Deserialize<'de> for NoParams {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        serde::de::IgnoredAny::deserialize(deserializer)?;
+        Ok(NoParams)
+    }
+}
+
+/// Mount every method in this module's table onto `router`.
+///
+/// Test: `rpc_router_registers_every_documented_method`.
+pub fn register(router: RpcRouter, state: &Arc<DaemonState>) -> RpcRouter {
+    let r = projects::register(router, state);
+    let r = deliverables::register(r, state);
+    let r = manager::register(r, state);
+    let r = bus::register(r, state);
+    let r = pairing::register(r, state);
+    delegation::register(r, state)
+}

--- a/crates/trusty-mpm/src/daemon/rpc/registry/bus.rs
+++ b/crates/trusty-mpm/src/daemon/rpc/registry/bus.rs
@@ -1,0 +1,77 @@
+//! The peer bus's four request/response verbs as RPC methods (#6288 slice 5).
+//!
+//! Why the caller is trusty-console and not a peer: the 2026-08-28 owner ruling
+//! on #6288 is that cross-instance peers reach this daemon ONLY through
+//! trusty-console (ADR-0032). The bus therefore stays on the mpm socket with
+//! console as its one caller; console's own slice-9 work gains the public,
+//! authenticated route. No peer ever dials this daemon directly.
+//!
+//! Why `subscribe` is absent: `GET /api/v1/bus/subscribe/{instance_id}` is SSE
+//! and needs the `RpcStreamMethod` seam slice 6 owns. It is a named in-slice
+//! dependency, not an oversight — its HTTP handler is untouched, and no RPC
+//! method is registered for it here.
+//!
+//! What the fail-closed contract looks like over the socket: DOC-60 §4's
+//! sequence — structural validation of the caller identity, the
+//! `assistant_instance` edge check, sender verification against the registry,
+//! target resolution, then the delivery attempt with the durable record written
+//! to state what actually happened — all lives inside `PeerBus::publish`, which
+//! this slice did not touch. Every rejection reaches a socket caller as a
+//! [`BusError`] carrying the same discrimination the HTTP status gave it, via
+//! the `From<BusError> for RpcError` mapping in `bus::error`.
+//!
+//! Test: the `parity_bus_*` and `rpc_bus_*` cases in `super::tests`.
+//!
+//! [`BusError`]: crate::daemon::bus::BusError
+
+use std::sync::Arc;
+
+use serde::Deserialize;
+use trusty_common::uds::server::RpcRouter;
+
+use crate::daemon::bus::envelope::BusEnvelope;
+use crate::daemon::bus::registry::InstanceMeta;
+use crate::daemon::bus::routes as bus;
+use crate::daemon::state::DaemonState;
+
+use super::NoParams;
+
+/// `mpm.bus.deregister` parameters — the instance id from the URL path.
+#[derive(Debug, Deserialize)]
+pub struct InstanceParams {
+    /// The instance id to remove.
+    pub instance_id: String,
+}
+
+/// Mount the four bus methods. `subscribe` is slice 6's; see the module doc.
+///
+/// Test: `rpc_router_registers_every_documented_method`,
+/// `rpc_bus_does_not_register_subscribe`.
+pub fn register(router: RpcRouter, state: &Arc<DaemonState>) -> RpcRouter {
+    let held = Arc::clone(state);
+    let r = router.typed::<bus::RegisterInstanceRequest, InstanceMeta, _, _>(
+        "mpm.bus.register",
+        move |p| {
+            let s = Arc::clone(&held);
+            async move { bus::register_op(&s, p).map_err(Into::into) }
+        },
+    );
+
+    let held = Arc::clone(state);
+    let r = r.typed::<InstanceParams, bus::DeregisterAck, _, _>("mpm.bus.deregister", move |p| {
+        let s = Arc::clone(&held);
+        async move { bus::deregister_op(&s, &p.instance_id).map_err(Into::into) }
+    });
+
+    let held = Arc::clone(state);
+    let r = r.typed::<NoParams, bus::ListInstancesResponse, _, _>("mpm.bus.list", move |_| {
+        let s = Arc::clone(&held);
+        async move { Ok(bus::list_op(&s)) }
+    });
+
+    let held = Arc::clone(state);
+    r.typed::<bus::PublishRequest, BusEnvelope, _, _>("mpm.bus.publish", move |p| {
+        let s = Arc::clone(&held);
+        async move { bus::publish_op(&s, p).map_err(Into::into) }
+    })
+}

--- a/crates/trusty-mpm/src/daemon/rpc/registry/delegation.rs
+++ b/crates/trusty-mpm/src/daemon/rpc/registry/delegation.rs
@@ -1,0 +1,68 @@
+//! The two delegation-query verbs as RPC methods (#6288 slice 5).
+//!
+//! Why registration only: `delegation_routes` had SLOC headroom, so its two
+//! `*_op` bodies stayed beside their handlers.
+//!
+//! What does NOT change: both routes answer and CLAIM in one critical section
+//! (`DaemonState::claim_shared_tree_dispatch` holds one mutex across both
+//! halves, #5324), and both re-derive eligibility from the payload rather than
+//! trusting the caller. Neither moved, so a socket caller cannot occupy a
+//! directory an HTTP caller could not have.
+//!
+//! Test: the `parity_delegation_*` cases in `super::tests`.
+
+use std::sync::Arc;
+
+use serde::Deserialize;
+use serde_json::Value;
+use trusty_common::uds::server::RpcRouter;
+
+use crate::daemon::delegation_routes as dg;
+use crate::daemon::state::DaemonState;
+
+/// Parameters for both delegation methods: the session id the HTTP route
+/// carries in its path, plus the forwarded hook payload.
+#[derive(Debug, Deserialize)]
+pub struct DispatchParams {
+    /// The session id from the URL path.
+    pub id: String,
+    /// The `PreToolUse` hook payload, in the daemon's own forwarded shape.
+    pub payload: Value,
+}
+
+/// Mount the two delegation methods.
+///
+/// Test: `rpc_router_registers_every_documented_method`.
+pub fn register(router: RpcRouter, state: &Arc<DaemonState>) -> RpcRouter {
+    let held = Arc::clone(state);
+    let r = router.typed::<DispatchParams, dg::SharedTreeWritersResponse, _, _>(
+        "mpm.delegation.shared_tree_dispatch",
+        move |p| {
+            let s = Arc::clone(&held);
+            async move {
+                dg::shared_tree_dispatch_op(
+                    &s,
+                    &p.id,
+                    dg::SharedTreeDispatchRequest { payload: p.payload },
+                )
+                .map_err(Into::into)
+            }
+        },
+    );
+
+    let held = Arc::clone(state);
+    r.typed::<DispatchParams, dg::SharedTreeWritersResponse, _, _>(
+        "mpm.delegation.granted_worktree",
+        move |p| {
+            let s = Arc::clone(&held);
+            async move {
+                dg::granted_worktree_op(
+                    &s,
+                    &p.id,
+                    dg::SharedTreeDispatchRequest { payload: p.payload },
+                )
+                .map_err(Into::into)
+            }
+        },
+    )
+}

--- a/crates/trusty-mpm/src/daemon/rpc/registry/deliverables.rs
+++ b/crates/trusty-mpm/src/daemon/rpc/registry/deliverables.rs
@@ -1,0 +1,189 @@
+//! Deliverable and Milestone CRUD as RPC methods (#6288 slice 5).
+//!
+//! Why registration only, with no bodies: `api::deliverable_routes` had SLOC
+//! headroom, so its `*_op` functions stayed beside the handlers that share them
+//! — which is the preferred shape. A body moves out of its route file only when
+//! the file cannot hold it.
+//!
+//! What: eight methods over the four Deliverable and four Milestone verbs. The
+//! `{name}`/`{id}` path segments become named parameter fields, since a JSON-RPC
+//! call has no path to carry them in.
+//!
+//! Test: the `parity_deliverable_*` and `parity_milestone_*` cases in
+//! `super::tests`.
+
+use std::sync::Arc;
+
+use serde::Deserialize;
+use trusty_common::uds::server::RpcRouter;
+
+use crate::daemon::api::deliverable_routes as dl;
+use crate::daemon::state::DaemonState;
+use crate::deliverable::{Deliverable, DeliverableStatus, Milestone};
+
+/// The project scope every one of these routes nests under.
+#[derive(Debug, Deserialize)]
+pub struct ProjectParams {
+    /// The project name from the URL path.
+    pub project: String,
+}
+
+/// A project scope plus the optional `?status=` filter.
+#[derive(Debug, Deserialize)]
+pub struct ListDeliverablesParams {
+    /// The project name from the URL path.
+    pub project: String,
+    /// Optional status filter, matching the HTTP query parameter.
+    #[serde(default)]
+    pub status: Option<DeliverableStatus>,
+}
+
+/// A project scope plus a record id.
+#[derive(Debug, Deserialize)]
+pub struct RecordParams {
+    /// The project name from the URL path.
+    pub project: String,
+    /// The Deliverable or Milestone id from the URL path.
+    pub id: String,
+}
+
+/// A project scope plus a create body.
+#[derive(Debug, Deserialize)]
+pub struct CreateDeliverableParams {
+    /// The project name from the URL path.
+    pub project: String,
+    /// The create body, verbatim.
+    #[serde(flatten)]
+    pub body: dl::CreateDeliverable,
+}
+
+/// A project scope plus a Milestone create body.
+#[derive(Debug, Deserialize)]
+pub struct CreateMilestoneParams {
+    /// The project name from the URL path.
+    pub project: String,
+    /// The create body, verbatim.
+    #[serde(flatten)]
+    pub body: dl::CreateMilestone,
+}
+
+/// A project scope, a record id, and a Deliverable patch body.
+#[derive(Debug, Deserialize)]
+pub struct PatchDeliverableParams {
+    /// The project name from the URL path.
+    pub project: String,
+    /// The Deliverable id from the URL path.
+    pub id: String,
+    /// The patch body, verbatim.
+    #[serde(flatten)]
+    pub body: dl::PatchDeliverable,
+}
+
+/// A project scope, a record id, and a Milestone patch body.
+#[derive(Debug, Deserialize)]
+pub struct PatchMilestoneParams {
+    /// The project name from the URL path.
+    pub project: String,
+    /// The Milestone id from the URL path.
+    pub id: String,
+    /// The patch body, verbatim.
+    #[serde(flatten)]
+    pub body: dl::PatchMilestone,
+}
+
+/// Mount the eight Deliverable/Milestone methods.
+///
+/// Test: `rpc_router_registers_every_documented_method`.
+pub fn register(router: RpcRouter, state: &Arc<DaemonState>) -> RpcRouter {
+    let held = Arc::clone(state);
+    let r = router.typed::<CreateDeliverableParams, Deliverable, _, _>(
+        "mpm.deliverables.create",
+        move |p| {
+            let s = Arc::clone(&held);
+            async move {
+                dl::create_deliverable_op(&s, p.project, p.body)
+                    .await
+                    .map_err(Into::into)
+            }
+        },
+    );
+
+    let held = Arc::clone(state);
+    let r = r.typed::<ListDeliverablesParams, dl::DeliverablesResponse, _, _>(
+        "mpm.deliverables.list",
+        move |p| {
+            let s = Arc::clone(&held);
+            async move {
+                dl::list_deliverables_op(
+                    &s,
+                    &p.project,
+                    dl::DeliverableListQuery { status: p.status },
+                )
+                .await
+                .map_err(Into::into)
+            }
+        },
+    );
+
+    let held = Arc::clone(state);
+    let r = r.typed::<RecordParams, Deliverable, _, _>("mpm.deliverables.get", move |p| {
+        let s = Arc::clone(&held);
+        async move {
+            dl::fetch_scoped(&s, &p.project, &p.id)
+                .await
+                .map_err(Into::into)
+        }
+    });
+
+    let held = Arc::clone(state);
+    let r =
+        r.typed::<PatchDeliverableParams, Deliverable, _, _>("mpm.deliverables.patch", move |p| {
+            let s = Arc::clone(&held);
+            async move {
+                dl::patch_deliverable_op(&s, &p.project, &p.id, p.body)
+                    .await
+                    .map_err(Into::into)
+            }
+        });
+
+    let held = Arc::clone(state);
+    let r = r.typed::<CreateMilestoneParams, Milestone, _, _>("mpm.milestones.create", move |p| {
+        let s = Arc::clone(&held);
+        async move {
+            dl::create_milestone_op(&s, p.project, p.body)
+                .await
+                .map_err(Into::into)
+        }
+    });
+
+    let held = Arc::clone(state);
+    let r =
+        r.typed::<ProjectParams, dl::MilestonesResponse, _, _>("mpm.milestones.list", move |p| {
+            let s = Arc::clone(&held);
+            async move {
+                dl::list_milestones_op(&s, &p.project)
+                    .await
+                    .map_err(Into::into)
+            }
+        });
+
+    let held = Arc::clone(state);
+    let r = r.typed::<RecordParams, Milestone, _, _>("mpm.milestones.get", move |p| {
+        let s = Arc::clone(&held);
+        async move {
+            dl::fetch_scoped_milestone(&s, &p.project, &p.id)
+                .await
+                .map_err(Into::into)
+        }
+    });
+
+    let held = Arc::clone(state);
+    r.typed::<PatchMilestoneParams, Milestone, _, _>("mpm.milestones.patch", move |p| {
+        let s = Arc::clone(&held);
+        async move {
+            dl::patch_milestone_op(&s, &p.project, &p.id, p.body)
+                .await
+                .map_err(Into::into)
+        }
+    })
+}

--- a/crates/trusty-mpm/src/daemon/rpc/registry/manager.rs
+++ b/crates/trusty-mpm/src/daemon/rpc/registry/manager.rs
@@ -1,0 +1,113 @@
+//! The L3 portfolio-manager surface as RPC methods (#6288 slice 5).
+//!
+//! Why registration only: every `manager/*` submodule had SLOC headroom, so the
+//! `*_op` bodies stayed beside their handlers.
+//!
+//! ## What `mpm.manager.digest` answers, and why it is not three error frames
+//!
+//! `GET /api/v1/manager/digest` answers `503` and `502` with a COMPLETE body —
+//! the deterministic fallback narrative plus the full rollup — because DOC-16
+//! D1 requires the numbers to survive an inference failure. A JSON-RPC error
+//! frame is `{code, message}` and can carry neither. So `digest_op` reports
+//! those two as `Ok` values ([`DigestOutcome`]), the socket returns the body,
+//! and the caller reads the `error` field that is already on it
+//! (`"inference_unavailable"` / `"inference_failed"`) — the same field an HTTP
+//! caller reads. Only the three empty refusals (bad scope, unknown project,
+//! store read failed) are RPC errors.
+//!
+//! ## Guard parity
+//!
+//! No `/api/v1/manager/*` route carries an HTTP-side guard: `origin_allowed` is
+//! referenced from one call site in the crate, the action-capable coordinator
+//! chat endpoint, and none of these six routes is layered with it. There is
+//! therefore no guard stronger than the socket's peer-uid check to carry over.
+//! The mutating verb, `mpm.manager.act`, keeps its own gate — it executes only
+//! on `confirm: true`, decided inside the shared body, not by a transport.
+//!
+//! Test: the `parity_manager_*` cases in `super::tests`.
+//!
+//! [`DigestOutcome`]: crate::daemon::manager::digest::DigestOutcome
+
+use std::sync::Arc;
+
+use serde::Deserialize;
+use trusty_common::uds::server::RpcRouter;
+
+use crate::daemon::manager::{
+    ActRequest, ActResponse, ChatReplyBody, ChatRequestBody, ManagerVersionResponse,
+    PortfolioStatusResponse, RouteTaskRequest, RouteTaskResponse, act, chat, digest, route_task,
+    status, version,
+};
+use crate::daemon::state::DaemonState;
+
+use super::NoParams;
+
+/// `mpm.manager.digest` parameters — the same optional `scope` selector the
+/// HTTP query string carries.
+///
+/// Why the registration wraps this in `Option`: every field is optional, so
+/// `GET /api/v1/manager/digest` with no query string is the ordinary call — and
+/// its socket counterpart sends no `params` at all, which arrives as `null`.
+/// Serde refuses `null` for a struct even when every field defaults, so a bare
+/// `DigestParams` would make the most common digest call fail with
+/// `invalid_params`. `Option<DigestParams>` accepts `null` and an object alike.
+/// Test: `parity_manager_digest_agrees_across_transports` calls it with no
+/// params; `rpc_manager_digest_rejects_a_malformed_scope` calls it with some.
+#[derive(Debug, Default, Deserialize)]
+pub struct DigestParams {
+    /// `portfolio` | `project:<name>`; absent means portfolio.
+    #[serde(default)]
+    pub scope: Option<String>,
+}
+
+/// Mount the six manager methods.
+///
+/// Test: `rpc_router_registers_every_documented_method`.
+pub fn register(router: RpcRouter, state: &Arc<DaemonState>) -> RpcRouter {
+    let held = Arc::clone(state);
+    let r =
+        router.typed::<NoParams, ManagerVersionResponse, _, _>("mpm.manager.version", move |_| {
+            let s = Arc::clone(&held);
+            async move { Ok(version::version_op(&s)) }
+        });
+
+    let held = Arc::clone(state);
+    let r = r.typed::<NoParams, PortfolioStatusResponse, _, _>("mpm.manager.status", move |_| {
+        let s = Arc::clone(&held);
+        async move { status::load_portfolio_status(&s).await.map_err(Into::into) }
+    });
+
+    let held = Arc::clone(state);
+    let r = r.typed::<Option<DigestParams>, digest::DigestResponse, _, _>(
+        "mpm.manager.digest",
+        move |p| {
+            let s = Arc::clone(&held);
+            async move {
+                let scope = p.unwrap_or_default().scope;
+                digest::digest_op(&s, digest::DigestQuery { scope })
+                    .await
+                    .map(digest::DigestOutcome::into_body)
+                    .map_err(Into::into)
+            }
+        },
+    );
+
+    let held = Arc::clone(state);
+    let r = r.typed::<ChatRequestBody, ChatReplyBody, _, _>("mpm.manager.chat", move |p| {
+        let s = Arc::clone(&held);
+        async move { chat::chat_op(&s, p).await.map_err(Into::into) }
+    });
+
+    let held = Arc::clone(state);
+    let r =
+        r.typed::<RouteTaskRequest, RouteTaskResponse, _, _>("mpm.manager.route_task", move |p| {
+            let s = Arc::clone(&held);
+            async move { route_task::route_task_op(&s, p).await.map_err(Into::into) }
+        });
+
+    let held = Arc::clone(state);
+    r.typed::<ActRequest, ActResponse, _, _>("mpm.manager.act", move |p| {
+        let s = Arc::clone(&held);
+        async move { act::act_op(&s, p).await.map_err(Into::into) }
+    })
+}

--- a/crates/trusty-mpm/src/daemon/rpc/registry/pairing.rs
+++ b/crates/trusty-mpm/src/daemon/rpc/registry/pairing.rs
@@ -1,0 +1,134 @@
+//! The four `/pair/*` verbs as RPC methods, plus their shared bodies (#6288
+//! slice 5).
+//!
+//! Why the bodies are here: the handlers live in `api.rs`, which sits on a
+//! frozen SLOC ratchet budget, so four `*_op` functions could not be added
+//! there. Each is a single call into [`PairingService`], which is where the
+//! code, its five-minute TTL, and the on-disk `pairing.json` all already live —
+//! so "the body" is genuinely one line and both transports share it.
+//!
+//! ## Guard parity
+//!
+//! The HTTP `/pair/*` routes carry NO guard beyond the daemon's loopback bind:
+//! `api::origin_guard::origin_allowed` is referenced from exactly one call site
+//! in the whole crate (`api/coordinator_routes.rs:193`, the action-capable chat
+//! endpoint), and no `/pair/*` route is layered with it. So there is nothing
+//! stronger than the socket's own peer-uid check to carry across, and the RPC
+//! path is not weaker than the HTTP one it mirrors — it is strictly narrower,
+//! since the socket is `0600` in a `0700` directory and a browser cannot reach
+//! it at all. The same comparison holds for every `/api/v1/manager/*` route.
+//!
+//! What matters for `pair/confirm` specifically: the code check itself is
+//! [`PairingService::confirm`]'s, not a transport's, and it is unchanged. A
+//! wrong or expired code answers `success: false` on both transports.
+//!
+//! Test: the `parity_pair_*` cases in `super::tests`.
+//!
+//! [`PairingService`]: crate::daemon::services::PairingService
+//! [`PairingService::confirm`]: crate::daemon::services::PairingService::confirm
+
+use std::sync::Arc;
+
+use serde::Deserialize;
+use trusty_common::uds::server::RpcRouter;
+
+use crate::daemon::api::PairConfirmRequest;
+use crate::daemon::api::types::{PairConfirmResponse, PairResetResponse};
+use crate::daemon::services::{PairCode, PairStatus, PairingService};
+use crate::daemon::state::DaemonState;
+
+use super::NoParams;
+
+/// `POST /pair/request`, `mpm.pair.request` — mint a one-time pairing code.
+///
+/// Test: `parity_pair_request_agrees_across_transports`.
+pub fn request_op(state: &Arc<DaemonState>) -> PairCode {
+    PairingService::new(state).request_code()
+}
+
+/// `POST /pair/confirm`, `mpm.pair.confirm` — validate a code and bind a chat.
+///
+/// Why this answers `200`-shaped on both transports even when the code is
+/// wrong: the route has always reported a rejection INSIDE the body
+/// (`success: false`, `error: "invalid or expired code"`) rather than as a
+/// status, because a bot polling this endpoint needs to distinguish "your code
+/// was wrong" from "the daemon is unreachable". Turning the rejection into an
+/// RPC error frame on the socket would erase that distinction for a socket
+/// caller, so the body stays the body. The check itself is unchanged.
+/// Test: `parity_pair_confirm_agrees_across_transports`,
+/// `rpc_pair_confirm_rejects_a_bad_code_in_the_body`.
+pub fn confirm_op(state: &Arc<DaemonState>, req: &PairConfirmRequest) -> PairConfirmResponse {
+    match PairingService::new(state).confirm(&req.code, req.chat_id) {
+        Ok(()) => PairConfirmResponse {
+            success: true,
+            chat_id: Some(req.chat_id),
+            error: None,
+        },
+        Err(_) => PairConfirmResponse {
+            success: false,
+            chat_id: None,
+            error: Some("invalid or expired code".to_string()),
+        },
+    }
+}
+
+/// `GET /pair/status`, `mpm.pair.status` — is a chat paired?
+///
+/// Test: `parity_pair_status_agrees_across_transports`.
+pub fn status_op(state: &Arc<DaemonState>) -> PairStatus {
+    PairingService::new(state).status()
+}
+
+/// `POST /pair/reset`, `mpm.pair.reset` — drop the binding, memory and disk.
+///
+/// Test: `parity_pair_reset_agrees_across_transports`.
+pub fn reset_op(state: &Arc<DaemonState>) -> PairResetResponse {
+    PairingService::new(state).reset();
+    PairResetResponse { reset: true }
+}
+
+/// `mpm.pair.confirm` parameters — the same two fields the HTTP body carries.
+#[derive(Debug, Deserialize)]
+pub struct ConfirmParams {
+    /// The one-time pairing code.
+    pub code: String,
+    /// The Telegram chat id to bind.
+    pub chat_id: i64,
+}
+
+/// Mount the four pairing methods.
+///
+/// Test: `rpc_router_registers_every_documented_method`.
+pub fn register(router: RpcRouter, state: &Arc<DaemonState>) -> RpcRouter {
+    let held = Arc::clone(state);
+    let r = router.typed::<NoParams, PairCode, _, _>("mpm.pair.request", move |_| {
+        let s = Arc::clone(&held);
+        async move { Ok(request_op(&s)) }
+    });
+
+    let held = Arc::clone(state);
+    let r = r.typed::<ConfirmParams, PairConfirmResponse, _, _>("mpm.pair.confirm", move |p| {
+        let s = Arc::clone(&held);
+        async move {
+            Ok(confirm_op(
+                &s,
+                &PairConfirmRequest {
+                    code: p.code,
+                    chat_id: p.chat_id,
+                },
+            ))
+        }
+    });
+
+    let held = Arc::clone(state);
+    let r = r.typed::<NoParams, PairStatus, _, _>("mpm.pair.status", move |_| {
+        let s = Arc::clone(&held);
+        async move { Ok(status_op(&s)) }
+    });
+
+    let held = Arc::clone(state);
+    r.typed::<NoParams, PairResetResponse, _, _>("mpm.pair.reset", move |_| {
+        let s = Arc::clone(&held);
+        async move { Ok(reset_op(&s)) }
+    })
+}

--- a/crates/trusty-mpm/src/daemon/rpc/registry/projects.rs
+++ b/crates/trusty-mpm/src/daemon/rpc/registry/projects.rs
@@ -1,0 +1,210 @@
+//! The project-family RPC methods, and the transport-neutral bodies the four
+//! legacy `/projects*` routes could not keep in `api.rs` (#6288 slice 5).
+//!
+//! Why those four bodies live HERE rather than beside their handlers: `api.rs`
+//! sits on a frozen SLOC ratchet budget, so four extra `*_op` functions there
+//! would push the file toward a cap it may not cross. The same reasoning put
+//! slice 2's core bodies in [`crate::daemon::rpc::core_ops`]. The registry-B
+//! bodies did NOT need to move — `managed_routes::project_registry_routes` and
+//! `managed_routes::project_status` both had headroom, so their `*_op`
+//! functions stayed next to the handlers that share them.
+//!
+//! What: [`register`] mounts nine methods — the four legacy `/projects*` verbs,
+//! the four registry-B `/api/v1/projects*` verbs, and the `/status` rollup.
+//! Nothing here names an HTTP type.
+//!
+//! Test: the `parity_projects_*` and `parity_project_status_*` cases in
+//! `super::tests`.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use serde::Deserialize;
+use trusty_common::uds::server::RpcRouter;
+
+use crate::core::project::ProjectInfo;
+use crate::daemon::api::types::{
+    DiscoverProjectsResponse, DiscoveredProjectInfo, ProjectsResponse,
+};
+use crate::daemon::error::DaemonError;
+use crate::daemon::managed_routes::ProjectStatusResponse;
+use crate::daemon::managed_routes::project_registry_routes as reg;
+use crate::daemon::managed_routes::project_status;
+use crate::daemon::state::DaemonState;
+use crate::project::Project;
+
+use super::NoParams;
+
+/// A project name carried as an RPC parameter.
+///
+/// Why: `GET /api/v1/projects/{name}` puts the identity key in the path, which
+/// a JSON-RPC call has nowhere to put — so it becomes a named field.
+/// Test: `parity_projects_registry_get_agrees_across_transports`.
+#[derive(Debug, Deserialize)]
+pub struct NameParams {
+    /// The registry key.
+    pub name: String,
+}
+
+/// `mpm.projects.registry.patch` parameters: the path key plus the PATCH body.
+///
+/// Why flattened rather than nested: the body's double-`Option` fields carry
+/// "absent means unchanged" semantics that a nesting level would not change but
+/// would obscure. Flattening keeps the wire identical to the HTTP body with one
+/// extra key.
+/// Test: `parity_projects_registry_patch_agrees_across_transports`.
+#[derive(Debug, Deserialize)]
+pub struct PatchProjectParams {
+    /// The registry key, from the HTTP route's path segment.
+    pub name: String,
+    /// The PATCH body, verbatim.
+    #[serde(flatten)]
+    pub body: reg::PatchProjectBody,
+}
+
+/// `mpm.projects.current` parameters.
+///
+/// Test: `parity_projects_current_agrees_across_transports`.
+#[derive(Debug, Deserialize)]
+pub struct PathParams {
+    /// Directory whose registered project to resolve, or to announce.
+    pub path: PathBuf,
+}
+
+/// `POST /projects`, `mpm.projects.register` — announce a working directory.
+///
+/// Test: `parity_projects_register_agrees_across_transports`.
+pub fn register_project_op(state: &Arc<DaemonState>, path: PathBuf) -> ProjectInfo {
+    state.register_project(path)
+}
+
+/// `GET /projects`, `mpm.projects.list` — every announced directory.
+///
+/// Test: `parity_projects_list_agrees_across_transports`.
+pub fn list_projects_op(state: &Arc<DaemonState>) -> ProjectsResponse {
+    ProjectsResponse {
+        projects: state.list_projects(),
+    }
+}
+
+/// `GET /projects/current`, `mpm.projects.current` — resolve one directory.
+///
+/// # Errors
+///
+/// [`DaemonError::SessionNotFound`] when `path` is not a registered project —
+/// the variant this route has always used, so its `404` is unchanged.
+///
+/// Test: `parity_projects_current_agrees_across_transports`,
+/// `rpc_projects_current_unregistered_path_is_not_found`.
+pub fn current_project_op(
+    state: &Arc<DaemonState>,
+    path: &Path,
+) -> Result<ProjectInfo, DaemonError> {
+    state
+        .project(path)
+        .ok_or_else(|| DaemonError::SessionNotFound {
+            id: path.display().to_string(),
+        })
+}
+
+/// `GET /projects/discover`, `mpm.projects.discover` — the projects Claude Code
+/// already knows about.
+///
+/// Test: `parity_projects_discover_agrees_across_transports`.
+pub fn discover_projects_op() -> DiscoverProjectsResponse {
+    let projects = crate::core::project_discovery::ProjectDiscovery::discover()
+        .into_iter()
+        .map(|p| DiscoveredProjectInfo {
+            path: p.path.display().to_string(),
+            session_count: p.session_count,
+            last_session: p.last_session.map(system_time_to_iso8601),
+        })
+        .collect();
+    DiscoverProjectsResponse { projects }
+}
+
+/// Render a `SystemTime` as an ISO-8601 / RFC3339 UTC string.
+fn system_time_to_iso8601(time: std::time::SystemTime) -> String {
+    let datetime: chrono::DateTime<chrono::Utc> = time.into();
+    datetime.to_rfc3339()
+}
+
+/// Mount the nine project methods.
+///
+/// Test: `rpc_router_registers_every_documented_method`.
+pub fn register(router: RpcRouter, state: &Arc<DaemonState>) -> RpcRouter {
+    let held = Arc::clone(state);
+    let r = router.typed::<NoParams, ProjectsResponse, _, _>("mpm.projects.list", move |_| {
+        let s = Arc::clone(&held);
+        async move { Ok(list_projects_op(&s)) }
+    });
+
+    let held = Arc::clone(state);
+    let r = r.typed::<PathParams, ProjectInfo, _, _>("mpm.projects.register", move |p| {
+        let s = Arc::clone(&held);
+        async move { Ok(register_project_op(&s, p.path)) }
+    });
+
+    let held = Arc::clone(state);
+    let r = r.typed::<PathParams, ProjectInfo, _, _>("mpm.projects.current", move |p| {
+        let s = Arc::clone(&held);
+        async move { current_project_op(&s, &p.path).map_err(Into::into) }
+    });
+
+    let r = r.typed::<NoParams, DiscoverProjectsResponse, _, _>(
+        "mpm.projects.discover",
+        move |_| async move { Ok(discover_projects_op()) },
+    );
+
+    let held = Arc::clone(state);
+    let r = r.typed::<NoParams, reg::ProjectsListResponse, _, _>(
+        "mpm.projects.registry.list",
+        move |_| {
+            let s = Arc::clone(&held);
+            async move { reg::list_projects_registry_op(&s).await.map_err(Into::into) }
+        },
+    );
+
+    let held = Arc::clone(state);
+    let r = r.typed::<reg::RegisterProjectBody, Project, _, _>(
+        "mpm.projects.registry.register",
+        move |p| {
+            let s = Arc::clone(&held);
+            async move {
+                reg::register_project_registry_op(&s, p)
+                    .await
+                    .map_err(Into::into)
+            }
+        },
+    );
+
+    let held = Arc::clone(state);
+    let r = r.typed::<NameParams, Project, _, _>("mpm.projects.registry.get", move |p| {
+        let s = Arc::clone(&held);
+        async move {
+            reg::get_project_registry_op(&s, &p.name)
+                .await
+                .map_err(Into::into)
+        }
+    });
+
+    let held = Arc::clone(state);
+    let r = r.typed::<PatchProjectParams, Project, _, _>("mpm.projects.registry.patch", move |p| {
+        let s = Arc::clone(&held);
+        async move {
+            reg::patch_project_registry_op(&s, &p.name, p.body)
+                .await
+                .map_err(Into::into)
+        }
+    });
+
+    let held = Arc::clone(state);
+    r.typed::<NameParams, ProjectStatusResponse, _, _>("mpm.projects.status", move |p| {
+        let s = Arc::clone(&held);
+        async move {
+            project_status::project_status_op(&s, &p.name)
+                .await
+                .map_err(Into::into)
+        }
+    })
+}

--- a/crates/trusty-mpm/src/daemon/rpc/registry/tests.rs
+++ b/crates/trusty-mpm/src/daemon/rpc/registry/tests.rs
@@ -1,0 +1,1955 @@
+//! Transport-parity contract tests for the registry RPC methods (#6288 slice 5).
+//!
+//! Why these are PARITY tests and not "the socket answers JSON": the slice's
+//! claim is that a route reached over the socket and the same route reached over
+//! HTTP give the same answer AND leave the same state behind. A test that only
+//! drives the RPC side proves the method exists; it cannot fail when the two
+//! transports drift, which is the failure this slice exists to prevent. So every
+//! `parity_*` case builds the axum router AND the RPC router from ONE
+//! `Arc<DaemonState>` and compares.
+//!
+//! For a WRITE route that is not enough: two calls that return equal JSON could
+//! still have persisted different things, or one could have persisted nothing.
+//! So each write route's case reads the store back afterwards and asserts BOTH
+//! records are there — see `assert_same_after_write`'s callers.
+//!
+//! ## The comparison allowlist
+//!
+//! Server-assigned identity fields are normalised before comparing, because two
+//! calls of the same code differ there by construction, not because the
+//! transports disagree: `id` and `created_at` on a Deliverable/Milestone, and
+//! `code`/`expires_in_seconds` on a freshly minted pairing code. Nothing else is
+//! excused.
+//!
+//! Test: this file IS the test module for [`super`].
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::{Value, json};
+use tempfile::TempDir;
+use tower::ServiceExt;
+use trusty_common::uds::server::{CODE_INVALID_PARAMS, RpcError, RpcResponse, RpcRouter};
+
+use super::{METHODS, register};
+use crate::core::paths::FrameworkPaths;
+use crate::daemon::api;
+use crate::daemon::bus::BusError;
+use crate::daemon::error::{
+    CODE_CONFLICT, CODE_FORBIDDEN, CODE_GONE, CODE_NOT_FOUND, CODE_UNAVAILABLE,
+    CODE_UPSTREAM_FAILED, DaemonError,
+};
+use crate::daemon::state::DaemonState;
+
+/// One daemon state rooted at an empty temp directory, plus the directory.
+///
+/// Why hermetic: a developer machine with a live `overseer.toml` or a real
+/// project registry would let a store read return records this suite never
+/// wrote. The caller holds the `TempDir` for the test's life.
+fn hermetic() -> (Arc<DaemonState>, TempDir) {
+    let dir = tempfile::tempdir().expect("temp dir for hermetic DaemonState");
+    let paths = FrameworkPaths::under(dir.path());
+    (Arc::new(DaemonState::with_paths(&paths)), dir)
+}
+
+/// The RPC router this slice registers, over `state`.
+fn rpc_router(state: &Arc<DaemonState>) -> RpcRouter {
+    register(RpcRouter::new(), state)
+}
+
+/// Force the manager's inference seam into "no provider configured".
+///
+/// Why (#1523): a hermetic ROOT is not a hermetic ENVIRONMENT.
+/// `ManagerInference` resolves a provider from ambient env, so a machine with
+/// `OPENROUTER_API_KEY` set builds a REAL adapter, and the digest and chat cases
+/// would call a live model instead of taking the degrade path they assert.
+/// `set_unconfigured` is the seam that exists for exactly this, and it makes
+/// both transports take the SAME leg — which is what a parity case needs.
+fn without_a_provider(state: &Arc<DaemonState>) {
+    state.manager_state().inference().set_unconfigured();
+}
+
+/// Drive one HTTP request through the real daemon router and decode the answer.
+///
+/// Why the real router rather than calling a handler directly: the parity claim
+/// is about the ROUTE, so the path, the method, and the extractors all have to
+/// participate — that decoding is exactly what the socket has to reproduce.
+async fn http(
+    state: &Arc<DaemonState>,
+    method: &str,
+    uri: &str,
+    body: Option<Value>,
+) -> (StatusCode, Value) {
+    let request = Request::builder().method(method).uri(uri);
+    let request = match body {
+        Some(v) => request
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_vec(&v).expect("encode body")))
+            .expect("build request"),
+        None => request.body(Body::empty()).expect("build request"),
+    };
+
+    let response = api::router(Arc::clone(state))
+        .oneshot(request)
+        .await
+        .expect("the router must answer");
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read the response body");
+    // A plain-text or bodyless refusal is not JSON; report it as a string (or
+    // null) rather than failing the decode, so an error-parity case can still
+    // compare the status.
+    let value = if bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&bytes)
+            .unwrap_or_else(|_| Value::String(String::from_utf8_lossy(&bytes).into_owned()))
+    };
+    (status, value)
+}
+
+/// Dispatch one JSON-RPC call against `router` and return the whole frame.
+async fn rpc_frame(router: &RpcRouter, method: &str, params: Value) -> Value {
+    let frame = json!({ "jsonrpc": "2.0", "id": 1, "method": method, "params": params });
+    let response: RpcResponse = router
+        .dispatch(&serde_json::to_vec(&frame).expect("encode the request frame"))
+        .await;
+    serde_json::to_value(response).expect("the response frame must serialise")
+}
+
+/// The `result` half of a call that must succeed.
+async fn rpc_ok(router: &RpcRouter, method: &str, params: Value) -> Value {
+    let frame = rpc_frame(router, method, params).await;
+    assert!(
+        frame.get("error").is_none(),
+        "{method} must succeed, got {frame}"
+    );
+    frame
+        .get("result")
+        .cloned()
+        .unwrap_or_else(|| panic!("{method} answered no result: {frame}"))
+}
+
+/// The `error` half of a call that must be refused.
+async fn rpc_err(router: &RpcRouter, method: &str, params: Value) -> Value {
+    let frame = rpc_frame(router, method, params).await;
+    frame
+        .get("error")
+        .cloned()
+        .unwrap_or_else(|| panic!("{method} must be refused, got {frame}"))
+}
+
+/// Assert the two transports answered the same JSON for one route.
+fn assert_same(method: &str, mut http_body: Value, mut rpc_result: Value, drop_fields: &[&str]) {
+    for field in drop_fields {
+        if let Some(map) = http_body.as_object_mut() {
+            map.remove(*field);
+        }
+        if let Some(map) = rpc_result.as_object_mut() {
+            map.remove(*field);
+        }
+    }
+    assert_eq!(
+        http_body, rpc_result,
+        "{method} must answer identically over HTTP and the socket"
+    );
+}
+
+// ── The method table ─────────────────────────────────────────────────────────
+
+/// Why: the slice-7 client swap and trusty-console will dial these names by
+/// literal, with no compile-time link to the registrations. Pinning the set here
+/// turns a rename into a failing assertion rather than a consumer that silently
+/// reports `method_not_found`.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn rpc_router_registers_every_documented_method() {
+    let (state, _dir) = hermetic();
+    let router = rpc_router(&state);
+    let registered: Vec<&str> = router.method_names().collect();
+
+    let mut documented: Vec<&str> = METHODS.to_vec();
+    documented.sort_unstable();
+
+    assert_eq!(
+        registered, documented,
+        "the router and METHODS must name the same set"
+    );
+    assert_eq!(
+        METHODS.len(),
+        33,
+        "slice 5 owns thirty-three routes; a new one needs a row in registry.rs's table too"
+    );
+}
+
+/// Why: `GET /api/v1/bus/subscribe/{instance_id}` is SSE and belongs to slice 6.
+/// Registering it here as a plain request/response method would answer once and
+/// close, which is worse than not serving it — so its absence is asserted rather
+/// than left to a reviewer to notice.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn rpc_bus_does_not_register_subscribe() {
+    let (state, _dir) = hermetic();
+    let router = rpc_router(&state);
+    assert!(
+        !router.method_names().any(|m| m.contains("subscribe")),
+        "bus subscribe is slice 6's streaming work; it must not be a plain method"
+    );
+    assert!(
+        router.stream_names().next().is_none(),
+        "slice 5 registers no stream methods"
+    );
+}
+
+/// Why: `params` is absent on a well-formed no-argument call, and a plain unit
+/// struct refuses `null` — which would make every listing fail with
+/// `invalid_params`. [`super::NoParams`] exists to prevent that.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn rpc_projects_list_answers_with_no_params() {
+    let (state, _dir) = hermetic();
+    let result = rpc_ok(&rpc_router(&state), "mpm.projects.list", Value::Null).await;
+    assert!(result["projects"].is_array(), "{result}");
+}
+
+// ── Legacy `/projects*` ──────────────────────────────────────────────────────
+
+/// Why the register calls come first: an empty registry would make the two
+/// listings trivially equal, which proves nothing about the data crossing.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_projects_list_agrees_across_transports() {
+    let (state, dir) = hermetic();
+    let a = dir.path().join("alpha");
+    std::fs::create_dir_all(&a).expect("mkdir");
+    state.register_project(a);
+
+    let (status, body) = http(&state, "GET", "/projects", None).await;
+    assert_eq!(status, StatusCode::OK);
+    let result = rpc_ok(&rpc_router(&state), "mpm.projects.list", Value::Null).await;
+    assert_eq!(
+        body["projects"].as_array().map(Vec::len),
+        Some(1),
+        "the registration must reach the listing: {body}"
+    );
+    assert_same("mpm.projects.list", body, result, &[]);
+}
+
+/// Why this asserts the STORE and not just the two answers: register is a write,
+/// and two equal responses could both have persisted nothing.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_projects_register_agrees_across_transports() {
+    let (state, dir) = hermetic();
+    let over_http = dir.path().join("via-http");
+    let over_rpc = dir.path().join("via-rpc");
+    std::fs::create_dir_all(&over_http).expect("mkdir");
+    std::fs::create_dir_all(&over_rpc).expect("mkdir");
+
+    let (status, body) = http(
+        &state,
+        "POST",
+        "/projects",
+        Some(json!({ "path": over_http })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let result = rpc_ok(
+        &rpc_router(&state),
+        "mpm.projects.register",
+        json!({ "path": over_rpc }),
+    )
+    .await;
+
+    // The two answers differ only in the path each announced, so compare the
+    // shape by key set and then prove BOTH writes landed.
+    assert_eq!(
+        body.as_object().map(|m| m.keys().collect::<Vec<_>>()),
+        result.as_object().map(|m| m.keys().collect::<Vec<_>>()),
+        "both transports must answer the same ProjectInfo shape"
+    );
+    assert!(
+        state.project(&over_http).is_some(),
+        "the HTTP register must have persisted"
+    );
+    assert!(
+        state.project(&over_rpc).is_some(),
+        "the RPC register must have persisted the same way"
+    );
+}
+
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_projects_current_agrees_across_transports() {
+    let (state, dir) = hermetic();
+    let path = dir.path().join("alpha");
+    std::fs::create_dir_all(&path).expect("mkdir");
+    state.register_project(path.clone());
+
+    let uri = format!("/projects/current?path={}", path.display());
+    let (status, body) = http(&state, "GET", &uri, None).await;
+    assert_eq!(status, StatusCode::OK);
+    let result = rpc_ok(
+        &rpc_router(&state),
+        "mpm.projects.current",
+        json!({ "path": path }),
+    )
+    .await;
+    assert_same("mpm.projects.current", body, result, &[]);
+}
+
+/// Why: an unregistered path is this route's only failure, and the two
+/// transports must agree it is a not-found rather than an empty answer.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn rpc_projects_current_unregistered_path_is_not_found() {
+    let (state, dir) = hermetic();
+    let path = dir.path().join("never-registered");
+
+    let uri = format!("/projects/current?path={}", path.display());
+    let (status, _) = http(&state, "GET", &uri, None).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+
+    let error = rpc_err(
+        &rpc_router(&state),
+        "mpm.projects.current",
+        json!({ "path": path }),
+    )
+    .await;
+    assert_eq!(error["code"], json!(CODE_NOT_FOUND), "{error}");
+}
+
+/// Why serial: discovery reads `~/.claude/projects/`, and other tests in this
+/// binary move `$HOME` process-wide. One landing between the two calls would
+/// make the HTTP answer read a temp home and the socket answer the real one,
+/// failing the comparison while proving nothing about the transports.
+/// Test: this function IS the test.
+#[serial_test::serial]
+#[tokio::test]
+async fn parity_projects_discover_agrees_across_transports() {
+    let (state, _dir) = hermetic();
+    let (status, body) = http(&state, "GET", "/projects/discover", None).await;
+    assert_eq!(status, StatusCode::OK);
+    let result = rpc_ok(&rpc_router(&state), "mpm.projects.discover", Value::Null).await;
+    assert_same("mpm.projects.discover", body, result, &[]);
+}
+
+// ── Registry-B `/api/v1/projects*` ───────────────────────────────────────────
+
+/// Register one registry-B project directly through the store.
+async fn seed_project(state: &Arc<DaemonState>, name: &str) {
+    let registry = state.project_registry().await;
+    registry
+        .register(crate::project::Project {
+            name: name.to_string(),
+            repo_url: format!("https://example.invalid/{name}"),
+            default_branch: "main".to_string(),
+            stack_hint: None,
+            tags: Vec::new(),
+            description: None,
+            gh_user: None,
+            gh_account: None,
+            github: None,
+            commit_name: None,
+            commit_email: None,
+            worktree: None,
+        })
+        .await
+        .expect("seed the project registry");
+}
+
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_projects_registry_list_agrees_across_transports() {
+    let (state, _dir) = hermetic();
+    seed_project(&state, "alpha").await;
+
+    let (status, body) = http(&state, "GET", "/api/v1/projects", None).await;
+    assert_eq!(status, StatusCode::OK);
+    let result = rpc_ok(
+        &rpc_router(&state),
+        "mpm.projects.registry.list",
+        Value::Null,
+    )
+    .await;
+    assert_eq!(body["count"], json!(1), "the seed must reach the listing");
+    assert_same("mpm.projects.registry.list", body, result, &[]);
+}
+
+/// Why the store read at the end: register is a write, and this is the file the
+/// registry-B surface persists to. Two equal `201` bodies would not prove either
+/// call reached it.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_projects_registry_register_agrees_across_transports() {
+    let (state, _dir) = hermetic();
+
+    let body_for = |name: &str| {
+        json!({
+            "name": name,
+            "repo_url": "https://example.invalid/repo",
+            "description": "seeded by the parity suite",
+        })
+    };
+
+    let (status, http_body) = http(
+        &state,
+        "POST",
+        "/api/v1/projects",
+        Some(body_for("via-http")),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    let rpc_body = rpc_ok(
+        &rpc_router(&state),
+        "mpm.projects.registry.register",
+        body_for("via-rpc"),
+    )
+    .await;
+
+    // Same record shape, differing only in the name each call chose.
+    assert_same(
+        "mpm.projects.registry.register",
+        http_body,
+        rpc_body,
+        &["name"],
+    );
+
+    // Both writes must be in the ONE registry file.
+    let registry = state.project_registry().await;
+    let mut names: Vec<String> = registry
+        .list()
+        .await
+        .expect("list the registry")
+        .into_iter()
+        .map(|p| p.name)
+        .collect();
+    names.sort();
+    assert_eq!(
+        names,
+        vec!["via-http".to_string(), "via-rpc".to_string()],
+        "both transports must have persisted into the same registry"
+    );
+}
+
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_projects_registry_get_agrees_across_transports() {
+    let (state, _dir) = hermetic();
+    seed_project(&state, "alpha").await;
+
+    let (status, body) = http(&state, "GET", "/api/v1/projects/alpha", None).await;
+    assert_eq!(status, StatusCode::OK);
+    let result = rpc_ok(
+        &rpc_router(&state),
+        "mpm.projects.registry.get",
+        json!({ "name": "alpha" }),
+    )
+    .await;
+    assert_same("mpm.projects.registry.get", body, result, &[]);
+}
+
+/// Why: an unknown project is a `404` with a plain-text body over HTTP, which
+/// has no JSON-RPC counterpart — the code has to carry the whole distinction.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn rpc_projects_registry_get_unknown_project_is_not_found() {
+    let (state, _dir) = hermetic();
+
+    let (status, body) = http(&state, "GET", "/api/v1/projects/nope", None).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(
+        body,
+        json!("project nope not found"),
+        "the plain-text HTTP body must be unchanged by the extraction"
+    );
+
+    let error = rpc_err(
+        &rpc_router(&state),
+        "mpm.projects.registry.get",
+        json!({ "name": "nope" }),
+    )
+    .await;
+    assert_eq!(error["code"], json!(CODE_NOT_FOUND), "{error}");
+}
+
+/// Why two different fields: a PATCH that set the same field twice could pass
+/// while one transport silently no-opped. Each call edits its own project and
+/// the store is read back for both.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_projects_registry_patch_agrees_across_transports() {
+    let (state, _dir) = hermetic();
+    seed_project(&state, "via-http").await;
+    seed_project(&state, "via-rpc").await;
+
+    let (status, http_body) = http(
+        &state,
+        "PATCH",
+        "/api/v1/projects/via-http",
+        Some(json!({ "description": "patched" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let rpc_body = rpc_ok(
+        &rpc_router(&state),
+        "mpm.projects.registry.patch",
+        json!({ "name": "via-rpc", "description": "patched" }),
+    )
+    .await;
+    assert_same(
+        "mpm.projects.registry.patch",
+        http_body,
+        rpc_body,
+        &["name", "repo_url"],
+    );
+
+    let registry = state.project_registry().await;
+    for name in ["via-http", "via-rpc"] {
+        let stored = registry.get(name).await.expect("the project must persist");
+        assert_eq!(
+            stored.description.as_deref(),
+            Some("patched"),
+            "{name}: the patch must be in the store, not only in the answer"
+        );
+    }
+}
+
+/// Why the RPC half asserts a BLANK `repo_url` and not the rename: over HTTP a
+/// rename is a body `name` disagreeing with the path `name`, and the params
+/// struct flattens the body around ONE `name` field — so the two can never
+/// disagree on the socket, and the rename rejection is unreachable there by
+/// construction rather than by a check. That is strictly stronger than the HTTP
+/// guard, not weaker. What both transports CAN express is a blank required
+/// field, which runs through the same validation, before the store is touched.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn rpc_projects_registry_patch_rejects_a_blank_required_field() {
+    let (state, _dir) = hermetic();
+    seed_project(&state, "alpha").await;
+
+    // The HTTP-only rename guard still holds.
+    let (status, _) = http(
+        &state,
+        "PATCH",
+        "/api/v1/projects/alpha",
+        Some(json!({ "name": "renamed" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+
+    let (status, _) = http(
+        &state,
+        "PATCH",
+        "/api/v1/projects/alpha",
+        Some(json!({ "repo_url": "  " })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+
+    let error = rpc_err(
+        &rpc_router(&state),
+        "mpm.projects.registry.patch",
+        json!({ "name": "alpha", "repo_url": "  " }),
+    )
+    .await;
+    assert_eq!(error["code"], json!(CODE_INVALID_PARAMS), "{error}");
+
+    let registry = state.project_registry().await;
+    let stored = registry.get("alpha").await.expect("still registered");
+    assert_eq!(
+        stored.repo_url, "https://example.invalid/alpha",
+        "a rejected patch must leave the record untouched on both paths"
+    );
+}
+
+/// Why: a blank name is rejected before the store is touched on both paths.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn rpc_projects_registry_register_rejects_a_blank_name() {
+    let (state, _dir) = hermetic();
+    let payload = json!({ "name": "   ", "repo_url": "https://example.invalid/r" });
+
+    let (status, _) = http(&state, "POST", "/api/v1/projects", Some(payload.clone())).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+
+    let error = rpc_err(
+        &rpc_router(&state),
+        "mpm.projects.registry.register",
+        payload,
+    )
+    .await;
+    assert_eq!(error["code"], json!(CODE_INVALID_PARAMS), "{error}");
+
+    let registry = state.project_registry().await;
+    assert!(
+        registry.list().await.expect("list").is_empty(),
+        "a rejected register must leave the registry untouched on both paths"
+    );
+}
+
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_project_status_agrees_across_transports() {
+    let (state, _dir) = hermetic();
+    seed_project(&state, "alpha").await;
+
+    let (status, body) = http(&state, "GET", "/api/v1/projects/alpha/status", None).await;
+    assert_eq!(status, StatusCode::OK);
+    let result = rpc_ok(
+        &rpc_router(&state),
+        "mpm.projects.status",
+        json!({ "name": "alpha" }),
+    )
+    .await;
+    assert_same("mpm.projects.status", body, result, &[]);
+}
+
+/// Test: this function IS the test.
+#[tokio::test]
+async fn rpc_project_status_unknown_project_is_not_found() {
+    let (state, _dir) = hermetic();
+
+    let (status, _) = http(&state, "GET", "/api/v1/projects/nope/status", None).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+
+    let error = rpc_err(
+        &rpc_router(&state),
+        "mpm.projects.status",
+        json!({ "name": "nope" }),
+    )
+    .await;
+    assert_eq!(error["code"], json!(CODE_NOT_FOUND), "{error}");
+}
+
+// ── Deliverables and Milestones ──────────────────────────────────────────────
+
+/// The two fields the server assigns per record, which two calls of the same
+/// code differ on by construction.
+const RECORD_IDENTITY: &[&str] = &["id", "created_at"];
+
+/// A minimal create body for a Deliverable.
+fn deliverable_body(name: &str) -> Value {
+    json!({ "name": name, "kind": "feature", "estimated_effort": "M" })
+}
+
+/// A minimal create body for a Milestone.
+fn milestone_body(name: &str) -> Value {
+    json!({ "name": name, "target_date": "2030-01-01T00:00:00Z" })
+}
+
+/// Why the store read: create is a write into the deliverable store, and two
+/// equal `201` bodies would not prove either call reached it.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_deliverable_create_agrees_across_transports() {
+    let (state, _dir) = hermetic();
+
+    let (status, http_body) = http(
+        &state,
+        "POST",
+        "/api/v1/projects/alpha/deliverables",
+        Some(deliverable_body("shared")),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    let rpc_body = rpc_ok(
+        &rpc_router(&state),
+        "mpm.deliverables.create",
+        json!({ "project": "alpha", "name": "shared", "kind": "feature",
+                "estimated_effort": "M" }),
+    )
+    .await;
+    assert_same(
+        "mpm.deliverables.create",
+        http_body,
+        rpc_body,
+        RECORD_IDENTITY,
+    );
+
+    let mgr = state.deliverable_manager().await;
+    let stored = mgr
+        .deliverables_by_project("alpha")
+        .await
+        .expect("read the deliverable store");
+    assert_eq!(
+        stored.len(),
+        2,
+        "both transports must have persisted into the same store"
+    );
+}
+
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_deliverable_list_agrees_across_transports() {
+    let (state, _dir) = hermetic();
+    http(
+        &state,
+        "POST",
+        "/api/v1/projects/alpha/deliverables",
+        Some(deliverable_body("seeded")),
+    )
+    .await;
+
+    let (status, body) = http(&state, "GET", "/api/v1/projects/alpha/deliverables", None).await;
+    assert_eq!(status, StatusCode::OK);
+    let result = rpc_ok(
+        &rpc_router(&state),
+        "mpm.deliverables.list",
+        json!({ "project": "alpha" }),
+    )
+    .await;
+    assert_eq!(
+        body["deliverables"].as_array().map(Vec::len),
+        Some(1),
+        "the seed must reach the listing: {body}"
+    );
+    assert_same("mpm.deliverables.list", body, result, &[]);
+}
+
+/// Why the filter is passed explicitly: it proves the ARGUMENT survives the
+/// transport change, not only the unfiltered default.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_deliverable_list_status_filter_agrees_across_transports() {
+    let (state, _dir) = hermetic();
+    http(
+        &state,
+        "POST",
+        "/api/v1/projects/alpha/deliverables",
+        Some(deliverable_body("seeded")),
+    )
+    .await;
+
+    let (status, body) = http(
+        &state,
+        "GET",
+        "/api/v1/projects/alpha/deliverables?status=blocked",
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        body["deliverables"].as_array().map(Vec::len),
+        Some(0),
+        "the filter must exclude the proposed record: {body}"
+    );
+    let result = rpc_ok(
+        &rpc_router(&state),
+        "mpm.deliverables.list",
+        json!({ "project": "alpha", "status": "blocked" }),
+    )
+    .await;
+    assert_same("mpm.deliverables.list", body, result, &[]);
+}
+
+/// Create one Deliverable over HTTP and return its id.
+async fn seed_deliverable(state: &Arc<DaemonState>, project: &str, name: &str) -> String {
+    let (_, body) = http(
+        state,
+        "POST",
+        &format!("/api/v1/projects/{project}/deliverables"),
+        Some(deliverable_body(name)),
+    )
+    .await;
+    body["id"].as_str().expect("a created id").to_string()
+}
+
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_deliverable_get_agrees_across_transports() {
+    let (state, _dir) = hermetic();
+    let id = seed_deliverable(&state, "alpha", "seeded").await;
+
+    let (status, body) = http(
+        &state,
+        "GET",
+        &format!("/api/v1/projects/alpha/deliverables/{id}"),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let result = rpc_ok(
+        &rpc_router(&state),
+        "mpm.deliverables.get",
+        json!({ "project": "alpha", "id": id }),
+    )
+    .await;
+    assert_same("mpm.deliverables.get", body, result, &[]);
+}
+
+/// Why two records: a patch is a write, so each transport edits its own and the
+/// store is read back for both.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_deliverable_patch_agrees_across_transports() {
+    let (state, _dir) = hermetic();
+    let via_http = seed_deliverable(&state, "alpha", "via-http").await;
+    let via_rpc = seed_deliverable(&state, "alpha", "via-rpc").await;
+
+    let (status, http_body) = http(
+        &state,
+        "PATCH",
+        &format!("/api/v1/projects/alpha/deliverables/{via_http}"),
+        Some(json!({ "status": "in-progress" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let rpc_body = rpc_ok(
+        &rpc_router(&state),
+        "mpm.deliverables.patch",
+        json!({ "project": "alpha", "id": via_rpc, "status": "in-progress" }),
+    )
+    .await;
+    assert_same(
+        "mpm.deliverables.patch",
+        http_body,
+        rpc_body,
+        &["id", "created_at", "name"],
+    );
+
+    let mgr = state.deliverable_manager().await;
+    for id in [&via_http, &via_rpc] {
+        let stored = mgr.get_deliverable(id).await.expect("the record persists");
+        assert_eq!(
+            stored.status,
+            crate::deliverable::DeliverableStatus::InProgress,
+            "{id}: the transition must be in the store, not only in the answer"
+        );
+    }
+}
+
+/// Why: §10.3 rejects `proposed → complete`, and that rejection runs inside the
+/// same write-locked closure on both transports. It is the sharpest available
+/// proof that the state machine did not move.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn rpc_deliverable_patch_rejects_an_illegal_transition() {
+    let (state, _dir) = hermetic();
+    let id = seed_deliverable(&state, "alpha", "seeded").await;
+
+    let error = rpc_err(
+        &rpc_router(&state),
+        "mpm.deliverables.patch",
+        json!({ "project": "alpha", "id": id, "status": "complete" }),
+    )
+    .await;
+    assert_eq!(error["code"], json!(CODE_CONFLICT), "{error}");
+
+    let mgr = state.deliverable_manager().await;
+    let stored = mgr.get_deliverable(&id).await.expect("the record persists");
+    assert_eq!(
+        stored.status,
+        crate::deliverable::DeliverableStatus::Proposed,
+        "a rejected transition must leave the record untouched over the socket too"
+    );
+}
+
+/// Test: this function IS the test.
+#[tokio::test]
+async fn rpc_deliverable_create_rejects_a_blank_name() {
+    let (state, _dir) = hermetic();
+
+    let (status, _) = http(
+        &state,
+        "POST",
+        "/api/v1/projects/alpha/deliverables",
+        Some(deliverable_body("   ")),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+
+    let error = rpc_err(
+        &rpc_router(&state),
+        "mpm.deliverables.create",
+        json!({ "project": "alpha", "name": "   ", "kind": "feature",
+                "estimated_effort": "M" }),
+    )
+    .await;
+    assert_eq!(error["code"], json!(CODE_INVALID_PARAMS), "{error}");
+
+    let mgr = state.deliverable_manager().await;
+    assert!(
+        mgr.deliverables_by_project("alpha")
+            .await
+            .expect("read")
+            .is_empty(),
+        "a rejected create must persist nothing on either path"
+    );
+}
+
+/// Test: this function IS the test.
+#[tokio::test]
+async fn rpc_deliverable_get_wrong_project_is_not_found() {
+    let (state, _dir) = hermetic();
+    let id = seed_deliverable(&state, "alpha", "seeded").await;
+
+    let (status, _) = http(
+        &state,
+        "GET",
+        &format!("/api/v1/projects/beta/deliverables/{id}"),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+
+    let error = rpc_err(
+        &rpc_router(&state),
+        "mpm.deliverables.get",
+        json!({ "project": "beta", "id": id }),
+    )
+    .await;
+    assert_eq!(error["code"], json!(CODE_NOT_FOUND), "{error}");
+}
+
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_milestone_create_agrees_across_transports() {
+    let (state, _dir) = hermetic();
+
+    let (status, http_body) = http(
+        &state,
+        "POST",
+        "/api/v1/projects/alpha/milestones",
+        Some(milestone_body("shared")),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    let rpc_body = rpc_ok(
+        &rpc_router(&state),
+        "mpm.milestones.create",
+        json!({ "project": "alpha", "name": "shared",
+                "target_date": "2030-01-01T00:00:00Z" }),
+    )
+    .await;
+    assert_same(
+        "mpm.milestones.create",
+        http_body,
+        rpc_body,
+        RECORD_IDENTITY,
+    );
+
+    let mgr = state.deliverable_manager().await;
+    assert_eq!(
+        mgr.milestones_by_project("alpha")
+            .await
+            .expect("read the milestone store")
+            .len(),
+        2,
+        "both transports must have persisted into the same store"
+    );
+}
+
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_milestone_list_agrees_across_transports() {
+    let (state, _dir) = hermetic();
+    http(
+        &state,
+        "POST",
+        "/api/v1/projects/alpha/milestones",
+        Some(milestone_body("seeded")),
+    )
+    .await;
+
+    let (status, body) = http(&state, "GET", "/api/v1/projects/alpha/milestones", None).await;
+    assert_eq!(status, StatusCode::OK);
+    let result = rpc_ok(
+        &rpc_router(&state),
+        "mpm.milestones.list",
+        json!({ "project": "alpha" }),
+    )
+    .await;
+    assert_eq!(
+        body["milestones"].as_array().map(Vec::len),
+        Some(1),
+        "{body}"
+    );
+    assert_same("mpm.milestones.list", body, result, &[]);
+}
+
+/// Create one Milestone over HTTP and return its id.
+async fn seed_milestone(state: &Arc<DaemonState>, project: &str, name: &str) -> String {
+    let (_, body) = http(
+        state,
+        "POST",
+        &format!("/api/v1/projects/{project}/milestones"),
+        Some(milestone_body(name)),
+    )
+    .await;
+    body["id"].as_str().expect("a created id").to_string()
+}
+
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_milestone_get_agrees_across_transports() {
+    let (state, _dir) = hermetic();
+    let id = seed_milestone(&state, "alpha", "seeded").await;
+
+    let (status, body) = http(
+        &state,
+        "GET",
+        &format!("/api/v1/projects/alpha/milestones/{id}"),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let result = rpc_ok(
+        &rpc_router(&state),
+        "mpm.milestones.get",
+        json!({ "project": "alpha", "id": id }),
+    )
+    .await;
+    assert_same("mpm.milestones.get", body, result, &[]);
+}
+
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_milestone_patch_agrees_across_transports() {
+    let (state, _dir) = hermetic();
+    let via_http = seed_milestone(&state, "alpha", "via-http").await;
+    let via_rpc = seed_milestone(&state, "alpha", "via-rpc").await;
+
+    let (status, http_body) = http(
+        &state,
+        "PATCH",
+        &format!("/api/v1/projects/alpha/milestones/{via_http}"),
+        Some(json!({ "description": "patched" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let rpc_body = rpc_ok(
+        &rpc_router(&state),
+        "mpm.milestones.patch",
+        json!({ "project": "alpha", "id": via_rpc, "description": "patched" }),
+    )
+    .await;
+    assert_same(
+        "mpm.milestones.patch",
+        http_body,
+        rpc_body,
+        &["id", "created_at", "name"],
+    );
+
+    let mgr = state.deliverable_manager().await;
+    for id in [&via_http, &via_rpc] {
+        let stored = mgr.get_milestone(id).await.expect("the record persists");
+        assert_eq!(
+            stored.description, "patched",
+            "{id}: the patch must be in the store, not only in the answer"
+        );
+    }
+}
+
+// ── L3 manager ───────────────────────────────────────────────────────────────
+
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_manager_version_agrees_across_transports() {
+    let (state, _dir) = hermetic();
+    let (status, body) = http(&state, "GET", "/api/v1/manager/version", None).await;
+    assert_eq!(status, StatusCode::OK);
+    let result = rpc_ok(&rpc_router(&state), "mpm.manager.version", Value::Null).await;
+    assert_same("mpm.manager.version", body, result, &[]);
+}
+
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_manager_status_agrees_across_transports() {
+    let (state, _dir) = hermetic();
+    seed_project(&state, "alpha").await;
+
+    let (status, body) = http(&state, "GET", "/api/v1/manager/status", None).await;
+    assert_eq!(status, StatusCode::OK);
+    let result = rpc_ok(&rpc_router(&state), "mpm.manager.status", Value::Null).await;
+    assert_eq!(body["project_count"], json!(1), "{body}");
+    assert_same("mpm.manager.status", body, result, &[]);
+}
+
+/// Why the HTTP status is 503 and the RPC call still succeeds: the degrade leg
+/// carries a COMPLETE body — the deterministic narrative plus the rollup — which
+/// a JSON-RPC error frame cannot hold. Over the socket the body is the result,
+/// and the `error` field already on it carries the distinction. This asserts
+/// both halves of that claim at once.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_manager_digest_agrees_across_transports() {
+    let (state, _dir) = hermetic();
+    without_a_provider(&state);
+
+    let (status, body) = http(&state, "GET", "/api/v1/manager/digest", None).await;
+    assert_eq!(
+        status,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "with the provider forced off, this is the degrade leg"
+    );
+    let result = rpc_ok(&rpc_router(&state), "mpm.manager.digest", Value::Null).await;
+    assert_eq!(
+        result["error"],
+        json!("inference_unavailable"),
+        "the body must carry the distinction the status carried: {result}"
+    );
+    assert_same("mpm.manager.digest", body, result, &[]);
+}
+
+/// Test: this function IS the test.
+#[tokio::test]
+async fn rpc_manager_digest_rejects_a_malformed_scope() {
+    let (state, _dir) = hermetic();
+
+    let (status, _) = http(&state, "GET", "/api/v1/manager/digest?scope=nonsense", None).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+
+    let error = rpc_err(
+        &rpc_router(&state),
+        "mpm.manager.digest",
+        json!({ "scope": "nonsense" }),
+    )
+    .await;
+    assert_eq!(error["code"], json!(CODE_INVALID_PARAMS), "{error}");
+}
+
+/// Test: this function IS the test.
+#[tokio::test]
+async fn rpc_manager_digest_unknown_project_is_not_found() {
+    let (state, _dir) = hermetic();
+
+    let (status, _) = http(
+        &state,
+        "GET",
+        "/api/v1/manager/digest?scope=project:nope",
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+
+    let error = rpc_err(
+        &rpc_router(&state),
+        "mpm.manager.digest",
+        json!({ "scope": "project:nope" }),
+    )
+    .await;
+    assert_eq!(error["code"], json!(CODE_NOT_FOUND), "{error}");
+}
+
+/// Why the no-provider leg is the comparable one: with the seam forced off both
+/// transports take the same 503 path, and no live model is called from a unit
+/// suite.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_manager_chat_agrees_across_transports() {
+    let (state, _dir) = hermetic();
+    without_a_provider(&state);
+    let payload = json!({ "conversation_key": "k", "message": "hello" });
+
+    let (status, body) = http(
+        &state,
+        "POST",
+        "/api/v1/manager/chat",
+        Some(payload.clone()),
+    )
+    .await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(body["error"], json!("inference_unavailable"), "{body}");
+
+    let error = rpc_err(&rpc_router(&state), "mpm.manager.chat", payload).await;
+    assert_eq!(
+        error["code"],
+        json!(CODE_UNAVAILABLE),
+        "the socket must report the same class the 503 did: {error}"
+    );
+}
+
+/// Test: this function IS the test.
+#[tokio::test]
+async fn rpc_manager_chat_rejects_a_blank_conversation_key() {
+    let (state, _dir) = hermetic();
+    let payload = json!({ "conversation_key": "  ", "message": "hello" });
+
+    let (status, body) = http(
+        &state,
+        "POST",
+        "/api/v1/manager/chat",
+        Some(payload.clone()),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        body["error"],
+        json!("invalid_request"),
+        "the typed HTTP error body must be unchanged by the extraction: {body}"
+    );
+
+    let error = rpc_err(&rpc_router(&state), "mpm.manager.chat", payload).await;
+    assert_eq!(error["code"], json!(CODE_INVALID_PARAMS), "{error}");
+}
+
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_manager_route_task_agrees_across_transports() {
+    let (state, _dir) = hermetic();
+    let payload = json!({ "text": "fix the parser" });
+
+    let (status, body) = http(
+        &state,
+        "POST",
+        "/api/v1/manager/route-task",
+        Some(payload.clone()),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "an empty registry is an advisory 200"
+    );
+    let result = rpc_ok(&rpc_router(&state), "mpm.manager.route_task", payload).await;
+    assert_same("mpm.manager.route_task", body, result, &[]);
+}
+
+/// Test: this function IS the test.
+#[tokio::test]
+async fn rpc_manager_route_task_rejects_blank_text() {
+    let (state, _dir) = hermetic();
+    let payload = json!({ "text": "   " });
+
+    let (status, body) = http(
+        &state,
+        "POST",
+        "/api/v1/manager/route-task",
+        Some(payload.clone()),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(body["error"], json!("invalid_request"), "{body}");
+
+    let error = rpc_err(&rpc_router(&state), "mpm.manager.route_task", payload).await;
+    assert_eq!(error["code"], json!(CODE_INVALID_PARAMS), "{error}");
+}
+
+/// Why the propose leg and not the confirm leg: `confirm: false` is the arm that
+/// must execute NOTHING, and proving both transports take it is what shows the
+/// mutation gate did not move into a handler.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_manager_act_propose_agrees_across_transports() {
+    let (state, _dir) = hermetic();
+    let payload = json!({
+        "conversation_key": "k",
+        "action": { "type": "summarize", "session": "s" },
+    });
+
+    let (status, body) = http(&state, "POST", "/api/v1/manager/act", Some(payload.clone())).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["status"], json!("proposed"), "{body}");
+    let result = rpc_ok(&rpc_router(&state), "mpm.manager.act", payload).await;
+    assert_same("mpm.manager.act", body, result, &[]);
+}
+
+/// Test: this function IS the test.
+#[tokio::test]
+async fn rpc_manager_act_rejects_a_blank_conversation_key() {
+    let (state, _dir) = hermetic();
+    let payload = json!({
+        "conversation_key": "  ",
+        "action": { "type": "summarize", "session": "s" },
+    });
+
+    let (status, body) = http(&state, "POST", "/api/v1/manager/act", Some(payload.clone())).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(body["error"], json!("invalid_request"), "{body}");
+
+    let error = rpc_err(&rpc_router(&state), "mpm.manager.act", payload).await;
+    assert_eq!(error["code"], json!(CODE_INVALID_PARAMS), "{error}");
+}
+
+// ── Peer bus ─────────────────────────────────────────────────────────────────
+
+/// A well-formed publish request from `sender_instance` to a definition.
+fn publish_payload(sender_instance: &str, to_definition: &str) -> Value {
+    json!({
+        "from": { "kind": "assistant_instance",
+                  "instance_id": sender_instance,
+                  "definition_id": "izzie" },
+        "to": { "definition_id": to_definition },
+        "payload": { "type": "peer_request", "text": "review please" }
+    })
+}
+
+/// Why the registry read: registration is what makes an instance addressable,
+/// so a register that answered without recording would leave every later
+/// publish unroutable.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_bus_register_agrees_across_transports() {
+    let (state, _dir) = hermetic();
+
+    let (status, http_body) = http(
+        &state,
+        "POST",
+        "/api/v1/bus/instances",
+        Some(json!({ "definition_id": "izzie" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    let rpc_body = rpc_ok(
+        &rpc_router(&state),
+        "mpm.bus.register",
+        json!({ "definition_id": "izzie" }),
+    )
+    .await;
+
+    // `instance_id` and the registration sequence are minted per call.
+    assert_eq!(
+        http_body["definition_id"], rpc_body["definition_id"],
+        "both transports must record the same definition"
+    );
+    assert_eq!(
+        state.bus().registry().live().len(),
+        2,
+        "both registrations must be in the one registry"
+    );
+}
+
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_bus_list_agrees_across_transports() {
+    let (state, _dir) = hermetic();
+    state
+        .bus()
+        .registry()
+        .register("izzie", None)
+        .expect("seed a registration");
+
+    let (status, body) = http(&state, "GET", "/api/v1/bus/instances", None).await;
+    assert_eq!(status, StatusCode::OK);
+    let result = rpc_ok(&rpc_router(&state), "mpm.bus.list", Value::Null).await;
+    assert_eq!(
+        body["instances"].as_array().map(Vec::len),
+        Some(1),
+        "{body}"
+    );
+    assert_same("mpm.bus.list", body, result, &[]);
+}
+
+/// Why the HTTP leg has no body to compare: `DELETE` answers `204`, which is
+/// why the socket answers a one-field acknowledgement instead. What both must
+/// agree on is the EFFECT — the registration is gone — and that is what is
+/// asserted.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_bus_deregister_agrees_across_transports() {
+    let (state, _dir) = hermetic();
+    let a = state
+        .bus()
+        .registry()
+        .register("izzie", None)
+        .expect("seed");
+    let b = state
+        .bus()
+        .registry()
+        .register("izzie", None)
+        .expect("seed");
+
+    let (status, _) = http(
+        &state,
+        "DELETE",
+        &format!("/api/v1/bus/instances/{}", a.instance_id),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NO_CONTENT);
+
+    let result = rpc_ok(
+        &rpc_router(&state),
+        "mpm.bus.deregister",
+        json!({ "instance_id": b.instance_id }),
+    )
+    .await;
+    assert_eq!(result["deregistered"], json!(true), "{result}");
+    assert!(
+        state.bus().registry().live().is_empty(),
+        "both transports must have removed their registration"
+    );
+}
+
+/// Why this is not a quiet no-op: a deregister that reported success for an id
+/// it never held would let a caller believe it had cleaned up.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn rpc_bus_deregister_unknown_instance_reports_not_found() {
+    let (state, _dir) = hermetic();
+
+    let (status, _) = http(&state, "DELETE", "/api/v1/bus/instances/ghost", None).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+
+    let error = rpc_err(
+        &rpc_router(&state),
+        "mpm.bus.deregister",
+        json!({ "instance_id": "ghost" }),
+    )
+    .await;
+    assert_eq!(error["code"], json!(CODE_NOT_FOUND), "{error}");
+}
+
+/// Why the subscriber is drained twice: publish DELIVERS, and a single receive
+/// would pass even if only one of the two transports had sent anything.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_bus_publish_agrees_across_transports() {
+    let (state, _dir) = hermetic();
+    let target = state
+        .bus()
+        .registry()
+        .register("cto-assistant", None)
+        .expect("seed the target");
+    let mut rx = state
+        .bus()
+        .subscribe(&target.instance_id)
+        .expect("attach a subscriber");
+    let sender = state
+        .bus()
+        .registry()
+        .register("izzie", None)
+        .expect("seed the sender");
+
+    let (status, http_body) = http(
+        &state,
+        "POST",
+        "/api/v1/bus/publish",
+        Some(publish_payload(&sender.instance_id, "cto-assistant")),
+    )
+    .await;
+    assert_eq!(status, StatusCode::ACCEPTED);
+    assert!(rx.try_recv().is_ok(), "the HTTP publish must deliver");
+
+    let rpc_body = rpc_ok(
+        &rpc_router(&state),
+        "mpm.bus.publish",
+        publish_payload(&sender.instance_id, "cto-assistant"),
+    )
+    .await;
+    assert!(rx.try_recv().is_ok(), "the RPC publish must deliver too");
+
+    // `message_id` and `ts` are minted per envelope; everything else must match.
+    assert_same(
+        "mpm.bus.publish",
+        http_body,
+        rpc_body,
+        &["message_id", "ts"],
+    );
+}
+
+// ── Fail-Open Check: every bus rejection path, driven over the socket ────────
+//
+// DOC-60 §4 requires the bus to fail CLOSED — an undeliverable message is an
+// explicit error, never a silent drop. `PeerBus::publish` enforces that in one
+// sequence (structural validation of the caller identity, then the
+// assistant_instance edge check, then sender verification against the registry,
+// then target resolution, then the delivery attempt), and slice 5 moved only the
+// call site. The six cases below drive each rejection point through the SOCKET,
+// so a downgrade to warning-and-continue on the RPC path fails a test rather
+// than reaching production.
+
+/// Why: a `user`-kind caller on the peer path would let one assistant hand
+/// another a message the recipient reads as a user instruction — the exact
+/// delegation ADR-0024 closed.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn rpc_bus_publish_rejects_a_forged_user_kind() {
+    let (state, _dir) = hermetic();
+    let error = rpc_err(
+        &rpc_router(&state),
+        "mpm.bus.publish",
+        json!({
+            "from": { "kind": "user" },
+            "to": { "definition_id": "cto-assistant" },
+            "payload": { "type": "peer_request", "text": "do this" }
+        }),
+    )
+    .await;
+    assert_eq!(error["code"], json!(CODE_INVALID_PARAMS), "{error}");
+}
+
+/// Why: an unverifiable SENDER is a `403`, and the socket must keep that
+/// distinct from the `404`/`410` failures about the RECIPIENT — the caller's
+/// recovery differs (register yourself vs re-address).
+/// Test: this function IS the test.
+#[tokio::test]
+async fn rpc_bus_publish_rejects_an_unregistered_sender() {
+    let (state, _dir) = hermetic();
+    state
+        .bus()
+        .registry()
+        .register("cto-assistant", None)
+        .expect("seed the target");
+
+    let error = rpc_err(
+        &rpc_router(&state),
+        "mpm.bus.publish",
+        publish_payload("izzie~never-registered", "cto-assistant"),
+    )
+    .await;
+    assert_eq!(error["code"], json!(CODE_FORBIDDEN), "{error}");
+}
+
+/// Why: bypass mode exists to tell the sender its SPECIFIC target died rather
+/// than silently redirecting to another instance of the same definition.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn rpc_bus_publish_to_a_dead_instance_is_gone() {
+    let (state, _dir) = hermetic();
+    let sender = state
+        .bus()
+        .registry()
+        .register("izzie", None)
+        .expect("seed the sender");
+
+    let error = rpc_err(
+        &rpc_router(&state),
+        "mpm.bus.publish",
+        json!({
+            "from": { "kind": "assistant_instance",
+                      "instance_id": sender.instance_id,
+                      "definition_id": "izzie" },
+            "to": { "instance_id": "cto-assistant~dead" },
+            "payload": { "type": "peer_request", "text": "hello" }
+        }),
+    )
+    .await;
+    assert_eq!(error["code"], json!(CODE_GONE), "{error}");
+}
+
+/// Why: a registered-but-unattached target would drop the envelope on the
+/// floor. §4 says the sender is told; the socket must tell it too.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn rpc_bus_publish_without_a_subscriber_is_conflict() {
+    let (state, _dir) = hermetic();
+    state
+        .bus()
+        .registry()
+        .register("cto-assistant", None)
+        .expect("seed the target with NO subscriber");
+    let sender = state
+        .bus()
+        .registry()
+        .register("izzie", None)
+        .expect("seed the sender");
+
+    let error = rpc_err(
+        &rpc_router(&state),
+        "mpm.bus.publish",
+        publish_payload(&sender.instance_id, "cto-assistant"),
+    )
+    .await;
+    assert_eq!(error["code"], json!(CODE_CONFLICT), "{error}");
+}
+
+/// Why: a request naming neither addressing mode has nothing to resolve, and
+/// guessing one is the only way this path could deliver to the wrong peer.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn rpc_bus_publish_without_a_target_is_invalid() {
+    let (state, _dir) = hermetic();
+    let sender = state
+        .bus()
+        .registry()
+        .register("izzie", None)
+        .expect("seed the sender");
+
+    let error = rpc_err(
+        &rpc_router(&state),
+        "mpm.bus.publish",
+        json!({
+            "from": { "kind": "assistant_instance",
+                      "instance_id": sender.instance_id,
+                      "definition_id": "izzie" },
+            "to": {},
+            "payload": { "type": "peer_request", "text": "hello" }
+        }),
+    )
+    .await;
+    assert_eq!(error["code"], json!(CODE_INVALID_PARAMS), "{error}");
+}
+
+/// Why: definition-addressed delivery with nothing running is `404`, distinct
+/// from the `410` an id-addressed call to a dead instance gets. Collapsing them
+/// would leave a client unable to tell "start one" from "re-resolve".
+/// Test: this function IS the test.
+#[tokio::test]
+async fn rpc_bus_publish_to_an_unrun_definition_is_not_found() {
+    let (state, _dir) = hermetic();
+    let sender = state
+        .bus()
+        .registry()
+        .register("izzie", None)
+        .expect("seed the sender");
+
+    let error = rpc_err(
+        &rpc_router(&state),
+        "mpm.bus.publish",
+        publish_payload(&sender.instance_id, "nobody-home"),
+    )
+    .await;
+    assert_eq!(error["code"], json!(CODE_NOT_FOUND), "{error}");
+}
+
+// ── Pairing ──────────────────────────────────────────────────────────────────
+
+/// Why `code` and `expires_in_seconds` are dropped: each call mints a fresh
+/// six-character code, and the TTL is measured from the mint. The SHAPE is what
+/// the two transports must agree on.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_pair_request_agrees_across_transports() {
+    let (state, _dir) = hermetic();
+
+    let (status, body) = http(&state, "POST", "/pair/request", None).await;
+    assert_eq!(status, StatusCode::OK);
+    let result = rpc_ok(&rpc_router(&state), "mpm.pair.request", Value::Null).await;
+    assert!(
+        body["code"].as_str().is_some_and(|c| !c.is_empty()),
+        "the HTTP call must mint a code: {body}"
+    );
+    assert!(
+        result["code"].as_str().is_some_and(|c| !c.is_empty()),
+        "the RPC call must mint one too: {result}"
+    );
+    assert_same("mpm.pair.request", body, result, &["code"]);
+}
+
+/// Why the code is minted first and used twice: the second confirm must fail —
+/// a pairing code is one-time — so this proves the socket call really consumed
+/// the same single-use code the HTTP call would have.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_pair_confirm_agrees_across_transports() {
+    let (state, _dir) = hermetic();
+
+    let (_, minted) = http(&state, "POST", "/pair/request", None).await;
+    let code = minted["code"].as_str().expect("a minted code").to_string();
+
+    let result = rpc_ok(
+        &rpc_router(&state),
+        "mpm.pair.confirm",
+        json!({ "code": code, "chat_id": 4242 }),
+    )
+    .await;
+    assert_eq!(result["success"], json!(true), "{result}");
+    assert_eq!(result["chat_id"], json!(4242), "{result}");
+
+    // The store, not just the answer.
+    let (_, status_body) = http(&state, "GET", "/pair/status", None).await;
+    assert_eq!(status_body["paired"], json!(true), "{status_body}");
+    assert_eq!(status_body["chat_id"], json!(4242), "{status_body}");
+
+    // The same code a second time is refused, over HTTP, in the same body shape.
+    let (status, second) = http(
+        &state,
+        "POST",
+        "/pair/confirm",
+        Some(json!({ "code": code, "chat_id": 9 })),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "the refusal is in the body, not the status"
+    );
+    assert_eq!(second["success"], json!(false), "{second}");
+}
+
+/// Why the refusal is asserted as a BODY and not an error frame: the route has
+/// always reported a bad code inside a `200`, so a bot can tell "your code was
+/// wrong" from "the daemon is unreachable". Turning it into an RPC error would
+/// erase that distinction for a socket caller.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn rpc_pair_confirm_rejects_a_bad_code_in_the_body() {
+    let (state, _dir) = hermetic();
+
+    let (status, body) = http(
+        &state,
+        "POST",
+        "/pair/confirm",
+        Some(json!({ "code": "ZZZZZZ", "chat_id": 1 })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let result = rpc_ok(
+        &rpc_router(&state),
+        "mpm.pair.confirm",
+        json!({ "code": "ZZZZZZ", "chat_id": 1 }),
+    )
+    .await;
+    assert_eq!(result["success"], json!(false), "{result}");
+    assert_eq!(
+        result["error"],
+        json!("invalid or expired code"),
+        "the reason must cross the socket verbatim: {result}"
+    );
+    assert_same("mpm.pair.confirm", body, result, &[]);
+}
+
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_pair_status_agrees_across_transports() {
+    let (state, _dir) = hermetic();
+
+    let (status, body) = http(&state, "GET", "/pair/status", None).await;
+    assert_eq!(status, StatusCode::OK);
+    let result = rpc_ok(&rpc_router(&state), "mpm.pair.status", Value::Null).await;
+    assert_eq!(body["paired"], json!(false), "{body}");
+    assert_same("mpm.pair.status", body, result, &[]);
+}
+
+/// Why the pairing is established first: a reset against an unpaired daemon
+/// would answer `{ reset: true }` either way, proving nothing.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_pair_reset_agrees_across_transports() {
+    let (state, _dir) = hermetic();
+    let (_, minted) = http(&state, "POST", "/pair/request", None).await;
+    let code = minted["code"].as_str().expect("a minted code").to_string();
+    http(
+        &state,
+        "POST",
+        "/pair/confirm",
+        Some(json!({ "code": code, "chat_id": 7 })),
+    )
+    .await;
+
+    let result = rpc_ok(&rpc_router(&state), "mpm.pair.reset", Value::Null).await;
+    assert_eq!(result, json!({ "reset": true }), "{result}");
+
+    let (_, after) = http(&state, "GET", "/pair/status", None).await;
+    assert_eq!(
+        after["paired"],
+        json!(false),
+        "the reset must clear the binding, not only answer: {after}"
+    );
+
+    // And the HTTP verb answers identically against an already-clear daemon.
+    let (status, body) = http(&state, "POST", "/pair/reset", None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_same("mpm.pair.reset", body, result, &[]);
+}
+
+// ── Delegation query ─────────────────────────────────────────────────────────
+
+/// A dispatch payload the guard would send for an unisolated subagent.
+fn dispatch_payload(cwd: &std::path::Path, tool_use_id: &str) -> Value {
+    json!({
+        "cwd": cwd.display().to_string(),
+        "tool": "Task",
+        "tool_use_id": tool_use_id,
+        "input": { "subagent_type": "rust-engineer" }
+    })
+}
+
+/// Why two different session ids and two different `tool_use_id`s: the route
+/// answers AND claims in one critical section, so reusing either would let the
+/// second call see the first's own claim and change the answer for reasons that
+/// have nothing to do with the transport.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_delegation_shared_tree_dispatch_agrees_across_transports() {
+    let (state, dir) = hermetic();
+    let a = uuid::Uuid::new_v4().to_string();
+    let b = uuid::Uuid::new_v4().to_string();
+    let tree_http = dir.path().join("tree-http");
+    let tree_rpc = dir.path().join("tree-rpc");
+
+    let (status, body) = http(
+        &state,
+        "POST",
+        &format!("/api/v1/sessions/{a}/delegations/shared-tree-dispatch"),
+        Some(json!({ "payload": dispatch_payload(&tree_http, "tu-http") })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let mut params = json!({ "id": b });
+    params["payload"] = dispatch_payload(&tree_rpc, "tu-rpc");
+    let result = rpc_ok(
+        &rpc_router(&state),
+        "mpm.delegation.shared_tree_dispatch",
+        params,
+    )
+    .await;
+
+    assert_eq!(
+        body["claimed"],
+        json!(true),
+        "an empty tree must be claimed over HTTP: {body}"
+    );
+    assert_same("mpm.delegation.shared_tree_dispatch", body, result, &[]);
+}
+
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_delegation_granted_worktree_agrees_across_transports() {
+    let (state, dir) = hermetic();
+    let a = uuid::Uuid::new_v4().to_string();
+    let b = uuid::Uuid::new_v4().to_string();
+    let tree_http = dir.path().join("granted-http");
+    let tree_rpc = dir.path().join("granted-rpc");
+
+    let mut http_payload = dispatch_payload(&tree_http, "tu-http");
+    http_payload["input"]["isolation"] = json!("worktree");
+    let mut rpc_payload = dispatch_payload(&tree_rpc, "tu-rpc");
+    rpc_payload["input"]["isolation"] = json!("worktree");
+
+    let (status, body) = http(
+        &state,
+        "POST",
+        &format!("/api/v1/sessions/{a}/delegations/granted-worktree"),
+        Some(json!({ "payload": http_payload })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let mut params = json!({ "id": b });
+    params["payload"] = rpc_payload;
+    let result = rpc_ok(
+        &rpc_router(&state),
+        "mpm.delegation.granted_worktree",
+        params,
+    )
+    .await;
+    assert_same("mpm.delegation.granted_worktree", body, result, &[]);
+}
+
+/// Why: a malformed session id is a `400` over HTTP, and the guard reads a
+/// coded refusal differently from an empty answer — the two must not collapse.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn rpc_delegation_rejects_a_malformed_session_id() {
+    let (state, dir) = hermetic();
+
+    let (status, _) = http(
+        &state,
+        "POST",
+        "/api/v1/sessions/not-a-uuid/delegations/shared-tree-dispatch",
+        Some(json!({ "payload": dispatch_payload(dir.path(), "tu") })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+
+    let mut params = json!({ "id": "not-a-uuid" });
+    params["payload"] = dispatch_payload(dir.path(), "tu");
+    let error = rpc_err(
+        &rpc_router(&state),
+        "mpm.delegation.shared_tree_dispatch",
+        params,
+    )
+    .await;
+    assert_eq!(error["code"], json!(CODE_INVALID_PARAMS), "{error}");
+}
+
+// ── Error mapping, both ways ─────────────────────────────────────────────────
+
+/// Why this pins the two enums together rather than testing one route: a code
+/// derived from a status is only trustworthy while the derivation stays total.
+/// A new [`DaemonError`] or [`BusError`] variant that forgets its row lands on
+/// the catch-all, and the catch-all is what this asserts against.
+/// Test: this function IS the test.
+#[test]
+fn rpc_error_codes_track_http_statuses_for_this_slice() {
+    // The `DaemonError` classes this slice's routes actually raise.
+    for (error, expected) in [
+        (
+            DaemonError::InvalidRequest("bad".into()),
+            CODE_INVALID_PARAMS,
+        ),
+        (DaemonError::NotFound("gone".into()), CODE_NOT_FOUND),
+        (
+            DaemonError::ServiceUnavailable("no provider".into()),
+            CODE_UNAVAILABLE,
+        ),
+        (
+            DaemonError::UpstreamFailed("provider erred".into()),
+            CODE_UPSTREAM_FAILED,
+        ),
+        (
+            DaemonError::InvalidTransition {
+                from: "proposed".into(),
+                to: "complete".into(),
+                allowed: vec!["in-progress".into()],
+            },
+            CODE_CONFLICT,
+        ),
+        (
+            DaemonError::DeliverableNotFound { id: "d".into() },
+            CODE_NOT_FOUND,
+        ),
+        (
+            DaemonError::MilestoneNotFound { id: "m".into() },
+            CODE_NOT_FOUND,
+        ),
+    ] {
+        let message = error.to_string();
+        let rpc: RpcError = error.into();
+        assert_eq!(rpc.code, expected, "{message}");
+        assert_eq!(
+            rpc.message, message,
+            "the message must cross verbatim so a parity assertion means something"
+        );
+    }
+}
+
+/// Why every variant and not a sample: [`BusError`] is the enum whose whole
+/// purpose is that a sender can tell the five failures apart. A variant sharing
+/// another's code would silently undo that over the socket.
+/// Test: this function IS the test.
+#[test]
+fn bus_error_rpc_codes_track_http_statuses() {
+    for (error, expected) in [
+        (
+            BusError::UnregisteredSender {
+                instance_id: "i".into(),
+            },
+            CODE_FORBIDDEN,
+        ),
+        (
+            BusError::NoLiveInstance {
+                definition_id: "d".into(),
+            },
+            CODE_NOT_FOUND,
+        ),
+        (
+            BusError::InstanceGone {
+                instance_id: "i".into(),
+            },
+            CODE_GONE,
+        ),
+        (
+            BusError::NoSubscriber {
+                instance_id: "i".into(),
+            },
+            CODE_CONFLICT,
+        ),
+        (
+            BusError::InvalidTarget("neither id".into()),
+            CODE_INVALID_PARAMS,
+        ),
+        (
+            BusError::InvalidCaller("inconsistent".into()),
+            CODE_INVALID_PARAMS,
+        ),
+        (
+            BusError::InvalidDefinitionId {
+                definition_id: "d".into(),
+                reason: "r".into(),
+            },
+            CODE_INVALID_PARAMS,
+        ),
+    ] {
+        let message = error.to_string();
+        let rpc: RpcError = error.into();
+        assert_eq!(rpc.code, expected, "{message}");
+        assert_eq!(rpc.message, message);
+    }
+}

--- a/crates/trusty-mpm/src/daemon/socket.rs
+++ b/crates/trusty-mpm/src/daemon/socket.rs
@@ -66,12 +66,15 @@ pub fn socket_path() -> Result<PathBuf> {
 /// `rpc_router_registers_every_documented_method`,
 /// `every_scoped_route_has_a_method`.
 fn build_router(state: &Arc<DaemonState>) -> RpcRouter {
-    // #6288 slice 2: the core request/response families. Slices 5-6 append here.
+    // #6288 slice 2: the core request/response families. Slice 6 appends here.
     let router = rpc::core::register(RpcRouter::new(), state);
     // #6288 slice 3: the legacy session registry, hooks, and the polled feeds.
     let router = rpc::sessions_legacy::register(router, state);
     // #6288 slice 4: managed sessions, the control plane, and the L2 proxy.
-    rpc::managed::register(router, state)
+    let router = rpc::managed::register(router, state);
+    // #6288 slice 5: projects, deliverables/milestones, manager, bus, pairing,
+    // delegation.
+    rpc::registry::register(router, state)
 }
 
 /// Per-connection budgets for this listener.


### PR DESCRIPTION
Thirty-three registry-B project, deliverable/milestone, L3 manager, peer-bus, pairing and delegation-query routes are now reachable as JSON-RPC methods on the daemon's Unix socket, each handler body having moved into a transport-neutral `*_op` that both transports call. HTTP is unchanged — same paths, same statuses, and the same plain-text and typed-JSON error bodies these routes have always sent.

Refs #6288. Slice 5 of the #6288 plan. Stacked on `feat/6288-s2-rpc-core` (slice 2), whose `RpcRouter`, `*_op` pattern and `From<DaemonError> for RpcError` this reuses.

## Gate — rung 4

| Command | Result |
|---|---|
| `cargo fmt --check` | exit 0 |
| `cargo check -p trusty-mpm` | exit 0 |
| `cargo clippy -p trusty-mpm --all-targets -- -D warnings` | exit 0 |
| `cargo test -p trusty-mpm --no-fail-fast` | **9500 passed; 0 failed**, 52 targets |
| `cargo check --workspace` | exit 0 |
| `bash scripts/check_line_cap.sh` | 4228 files, 4 allowlisted, 0 violations |
| `bash scripts/check_changelog_fragment.sh` | OK — fragment present and valid |

The 139 tests scoped to this slice (`cargo test -p trusty-mpm --lib registry::`) are all new: one parity case per route, plus the rejection cases below.

## Method → route

| Method | Route |
|---|---|
| `mpm.projects.list` | `GET /projects` |
| `mpm.projects.register` | `POST /projects` |
| `mpm.projects.current` | `GET /projects/current?path=` |
| `mpm.projects.discover` | `GET /projects/discover` |
| `mpm.projects.registry.list` | `GET /api/v1/projects` |
| `mpm.projects.registry.register` | `POST /api/v1/projects` |
| `mpm.projects.registry.get` | `GET /api/v1/projects/{name}` |
| `mpm.projects.registry.patch` | `PATCH /api/v1/projects/{name}` |
| `mpm.projects.status` | `GET /api/v1/projects/{name}/status` |
| `mpm.deliverables.create` | `POST /api/v1/projects/{name}/deliverables` |
| `mpm.deliverables.list` | `GET /api/v1/projects/{name}/deliverables` |
| `mpm.deliverables.get` | `GET /api/v1/projects/{name}/deliverables/{id}` |
| `mpm.deliverables.patch` | `PATCH /api/v1/projects/{name}/deliverables/{id}` |
| `mpm.milestones.create` | `POST /api/v1/projects/{name}/milestones` |
| `mpm.milestones.list` | `GET /api/v1/projects/{name}/milestones` |
| `mpm.milestones.get` | `GET /api/v1/projects/{name}/milestones/{id}` |
| `mpm.milestones.patch` | `PATCH /api/v1/projects/{name}/milestones/{id}` |
| `mpm.manager.version` | `GET /api/v1/manager/version` |
| `mpm.manager.status` | `GET /api/v1/manager/status` |
| `mpm.manager.digest` | `GET /api/v1/manager/digest?scope=` |
| `mpm.manager.chat` | `POST /api/v1/manager/chat` |
| `mpm.manager.route_task` | `POST /api/v1/manager/route-task` |
| `mpm.manager.act` | `POST /api/v1/manager/act` |
| `mpm.bus.register` | `POST /api/v1/bus/instances` |
| `mpm.bus.deregister` | `DELETE /api/v1/bus/instances/{instance_id}` |
| `mpm.bus.list` | `GET /api/v1/bus/instances` |
| `mpm.bus.publish` | `POST /api/v1/bus/publish` |
| `mpm.pair.request` | `POST /pair/request` |
| `mpm.pair.confirm` | `POST /pair/confirm` |
| `mpm.pair.status` | `GET /pair/status` |
| `mpm.pair.reset` | `POST /pair/reset` |
| `mpm.delegation.shared_tree_dispatch` | `POST /api/v1/sessions/{id}/delegations/shared-tree-dispatch` |
| `mpm.delegation.granted_worktree` | `POST /api/v1/sessions/{id}/delegations/granted-worktree` |

## Bus `subscribe` deferral

`GET /api/v1/bus/subscribe/{instance_id}` is SSE and gets no RPC method here — it needs the `RpcStreamMethod` seam slice 6 owns. Its HTTP handler is untouched, the deferral is recorded in `bus/routes.rs` and `rpc/registry.rs`, and `rpc_bus_does_not_register_subscribe` asserts the router registers no stream method at all, so a later slice cannot mount it here by accident.

Per the 2026-08-28 owner ruling, peers reach the daemon only through trusty-console, so these bus methods' caller is console over UDS. `PeerBus::publish` is unchanged beyond the call signature.

## Fail-Open Check

No failure branch was downgraded to warning-and-continue. Every rejection reaches the caller as a coded error frame, and each is driven over the socket by its own test.

- **Bus, DOC-60 §4 fail-closed.** The structural-validation → sender-verification → resolve → deliver sequence all lives inside `PeerBus::publish`, which this slice did not touch; only the call site moved. Six rejection tests: forged `user` kind (`invalid_params`), unregistered sender (`403`-class), dead instance (`410`-class `CODE_GONE`), registered-but-unattached (`409`-class), no addressing mode (`invalid_params`), and a definition with nothing running (`404`-class — kept distinct from `410`).
- **Registry persistence.** A blank `name` on register and a blank `repo_url` on patch are refused before the store is touched, and the tests read the registry back to prove nothing was written.
- **Deliverable writes.** The §10.3 transition check still runs inside the same write-locked closure; `rpc_deliverable_patch_rejects_an_illegal_transition` proves a refused `proposed → complete` leaves the record at `proposed` over the socket too.
- **Pairing confirm.** A wrong or expired code still answers `success: false` in the BODY rather than an error frame, on both transports — a bot has to be able to tell "your code was wrong" from "the daemon is unreachable".
- **Write parity.** Every write route's test asserts the persisted state after each transport, not just equal responses: the projects registry file, the deliverable and milestone stores, and the bus registry.

## Guard parity

`origin_guard::origin_allowed` has exactly one call site in the crate — `api/coordinator_routes.rs:193`, the action-capable chat endpoint. No `/pair/*` or `/api/v1/manager/*` route is layered with it, so there is no HTTP-side guard stronger than `ensure_peer_is_self` to carry over; the socket's `0600`-in-`0700` peer-uid check is strictly narrower than the loopback HTTP listener. The mutating manager verb keeps its own gate: `mpm.manager.act` executes only on `confirm: true`, decided inside the shared body.

One guard is structurally stronger over RPC than over HTTP: a rename via `PATCH /api/v1/projects/{name}` is a body `name` disagreeing with the path `name`, and `PatchProjectParams` flattens the body around one `name` field — so the two cannot disagree on the socket at all.

## Notes for review

- `DaemonError` gains one variant, `UpstreamFailed` → HTTP 502 / `CODE_UPSTREAM_FAILED`, and one `CODE_GONE` constant. The 502 class is real and previously unrepresented: the manager's digest, chat and route-task routes distinguish "a configured provider failed" from `ServiceUnavailable`'s "no provider is configured", and that distinction lived only in handler `StatusCode` literals a shared body cannot carry. `DaemonError::detail()` is added so a delegator can reproduce a plain-text body byte for byte.
- `mpm.manager.digest` returns its 503 and 502 legs as RESULTS, not error frames: both carry a complete `DigestResponse` with the deterministic narrative and the full rollup, which a `{code, message}` frame cannot hold. The `error` field already on that body (`inference_unavailable` / `inference_failed`) carries the distinction, and the HTTP statuses are unchanged.
- `managed_routes/{project_registry_routes,project_status}` are `pub` now so `rpc::registry::projects` can call their shared bodies. Those two files are registry-B project routes, not managed-session routes, so they sit outside slice 4's named scope despite the directory.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
