### PR TITLE
feat(trusty-mpm): legacy session and hook routes served as RPC methods over UDS (Refs #6288)

### DIFF
--- a/crates/trusty-mpm/changelog.d/6288-s3-rpc-sessions-added.md
+++ b/crates/trusty-mpm/changelog.d/6288-s3-rpc-sessions-added.md
@@ -1,0 +1,10 @@
+Added
+
+- Sixteen more JSON-RPC methods on the daemon's Unix socket: the legacy session
+  registry (`mpm.sessions.list` / `.register` / `.connect` / `.discover` /
+  `.reap` / `.get` / `.delete` / `.pause` / `.resume` / `.command` / `.output` /
+  `.pane` / `.set_pid` / `.events_poll`), the hook relay (`mpm.hooks.ingest`),
+  and the polled event feed (`mpm.events.poll`). The HTTP routes they mirror are
+  unchanged and still served; the socket is an additional way to reach the same
+  body. The SSE streams `/events` and `/sessions/{id}/events` stay HTTP-only for
+  now ([#6288](https://github.com/bobmatnyc/trusty-tools/issues/6288)).

--- a/crates/trusty-mpm/changelog.d/6288-s3-rpc-sessions-changed.md
+++ b/crates/trusty-mpm/changelog.d/6288-s3-rpc-sessions-changed.md
@@ -1,0 +1,10 @@
+Changed
+
+- The bodies of the legacy session, hook, and polled-event routes moved from
+  `daemon::api` into `daemon::rpc::sessions_legacy_ops`, and the axum handlers
+  now delegate to them, so one route has one implementation across both
+  transports. The handler signatures, paths, status codes, and response bodies
+  are unchanged ([#6288](https://github.com/bobmatnyc/trusty-tools/issues/6288)).
+- `daemon::api::session_start_correlation` and its two hook handlers are
+  `pub(crate)` rather than `pub(super)`, so the shared `ingest_hook` body can
+  reach them from `daemon::rpc`.

--- a/crates/trusty-mpm/src/daemon/api.rs
+++ b/crates/trusty-mpm/src/daemon/api.rs
@@ -29,13 +29,16 @@ use utoipa_swagger_ui::SwaggerUi;
 use crate::core::compress::CompressionLevel;
 use crate::core::hook::HookEvent;
 use crate::core::project::ProjectInfo;
-use crate::core::session::{ControlModel, Session, SessionId, SessionStatus};
+use crate::core::session::Session;
 
 use super::error::DaemonError;
 // #6288: the transport-neutral bodies these handlers and the socket's
 // `mpm.*` methods both call. One route, one implementation.
 use super::rpc::core_ops;
-use super::services::{HookDecision, HookService, PairingService, SessionService, TmuxService};
+// #6288 slice 3: the shared bodies for the legacy session, hook, and polled
+// event routes. Every handler below is a thin adapter over one of them.
+use super::rpc::sessions_legacy_ops as sessions_ops;
+use super::services::PairingService;
 use super::state::DaemonState;
 
 /// The SESSCTL control-plane routes (`/api/v1/control/sessions/*`, WI-2 #1593).
@@ -67,16 +70,21 @@ pub use claude_config_routes::*;
 /// (`.line-cap-allowlist.tsv`) could absorb. It is cohesive and
 /// self-contained — both hook handlers are called only from `ingest_hook`
 /// below — so it moves out, mirroring `control_routes`/`claude_config_routes`.
-/// Not `pub`: unlike those two, nothing outside `api.rs` calls these handlers
-/// directly (`ingest_hook` is the only public entry point), so a private
-/// `use` is enough to bring the names into `api.rs`'s own scope — and, via
-/// `api_tests.rs`'s `use super::*;`, into the test module too.
-mod session_start_correlation;
-use session_start_correlation::{correlate_session_start, handle_session_end};
+/// `pub(crate)` since #6288 slice 3: `ingest_hook`'s body now lives in
+/// `daemon::rpc::sessions_legacy_ops` so the socket and HTTP share it, and that
+/// module is outside `daemon::api`. Still not `pub` — nothing outside this
+/// crate calls these handlers.
+pub(crate) mod session_start_correlation;
 // Only `api_tests.rs` (via `use super::*;`) calls this directly — a plain
 // `use` would be flagged `unused_imports` on the non-test lib target.
 #[cfg(test)]
 use session_start_correlation::session_end_pane_still_live;
+// #6288 slice 3: `SessionId` left this file with the handler bodies that named
+// it. `api_tests.rs` still reaches it through `use super::*;` — and imports
+// `ControlModel`/`SessionStatus`/`TmuxService` itself — so this one name keeps
+// the same `cfg(test)` treatment as the import above.
+#[cfg(test)]
+use crate::core::session::SessionId;
 
 /// The cross-session coordinator routes (`/api/v1/sessions/context` + `/chat`).
 ///
@@ -469,11 +477,8 @@ pub async fn list_sessions(
     State(state): State<Arc<DaemonState>>,
     Query(query): Query<SessionQuery>,
 ) -> Json<SessionsResponse> {
-    let sessions = match query.project {
-        Some(path) => state.list_sessions_for_project(&path),
-        None => state.list_sessions(),
-    };
-    Json(SessionsResponse { sessions })
+    // #6288: the body is shared with `mpm.sessions.list` over the Unix socket.
+    Json(sessions_ops::list_sessions(&state, query))
 }
 
 /// `GET /events/poll` — JSON snapshot of recent hook events (legacy / fallback).
@@ -492,9 +497,8 @@ pub async fn list_sessions(
     responses((status = 200, description = "Recent hook events across all sessions"))
 )]
 pub async fn recent_events(State(state): State<Arc<DaemonState>>) -> Json<EventsResponse> {
-    Json(EventsResponse {
-        events: state.recent_hook_events(),
-    })
+    // #6288: the body is shared with `mpm.events.poll` over the Unix socket.
+    Json(sessions_ops::recent_events(&state))
 }
 
 /// `GET /events` — live SSE stream of every hook event.
@@ -612,53 +616,10 @@ pub async fn register_session(
     State(state): State<Arc<DaemonState>>,
     Json(body): Json<RegisterSession>,
 ) -> Result<Json<RegisterSessionResponse>, DaemonError> {
-    // Derive the tmux name from the project directory (`tm-<folder>`) so the
-    // registry name matches the folder-based session the CLI creates. A
-    // caller-supplied `name` always wins; otherwise fall back to the UUID name.
-    let project_dir = body.project_path.as_deref();
-    let mut session = Session::new(
-        SessionId::new(),
-        body.project.clone(),
-        ControlModel::Tmux,
-        project_dir,
-    );
-    session.project_path = body.project_path.clone();
-    if let Some(name) = body.name.as_deref().filter(|n| !n.is_empty()) {
-        session.tmux_name = name.to_string();
-    }
-    if let Some(workdir) = body.workdir.as_deref() {
-        // Mirror the workdir onto the session record so the dashboard and the
-        // reaper see the spawn directory, not the project label. The
-        // `Session::workdir` field is the per-session working directory; the
-        // `project` field is a label / association.
-        session.workdir = workdir.to_string_lossy().into_owned();
-    }
-
-    // Spawn mode: create the tmux host and start `claude` *before* the session
-    // is registered, so a 422 or 500 leaves the registry untouched. This
-    // matches the standard HTTP contract — a failed POST should not leave a
-    // half-created resource visible to subsequent GETs.
-    if let Some(workdir) = body.workdir.as_deref() {
-        TmuxService::spawn_claude(&session.tmux_name, workdir)?;
-        // The session is now actively running `claude`; mark it Active so the
-        // dashboard reflects reality rather than the default `Starting` state.
-        session.status = SessionStatus::Active;
-    }
-
-    let id = session.id;
-    let tmux_name = session.tmux_name.clone();
-    state.register_session(session);
-
-    // Discover the `claude` PID inside the registered tmux pane in the
-    // background so the reaper can monitor process liveness. This is the
-    // daemon-side counterpart of the CLI's post-launch PID capture; it does not
-    // block the response, and a failure is logged, never fatal.
-    super::services::session_service::spawn_pid_capture(Arc::clone(&state), id, tmux_name.clone());
-
-    Ok(Json(RegisterSessionResponse {
-        id,
-        name: tmux_name,
-    }))
+    // #6288: the body is shared with `mpm.sessions.register` over the Unix
+    // socket; `mpm.sessions.connect` mounts the same body under its own name,
+    // exactly as `POST /api/v1/sessions/connect` does here.
+    Ok(Json(sessions_ops::register_session(&state, body)?))
 }
 
 /// `POST /api/v1/sessions/connect` — register a session for a *connect* (no
@@ -711,11 +672,8 @@ pub async fn get_session(
     State(state): State<Arc<DaemonState>>,
     Path(id): Path<String>,
 ) -> Result<Json<Session>, DaemonError> {
-    let session_id = parse_id(&id)?;
-    state
-        .session(session_id)
-        .map(Json)
-        .ok_or(DaemonError::SessionNotFound { id })
+    // #6288: the body is shared with `mpm.sessions.get` over the Unix socket.
+    Ok(Json(sessions_ops::get_session(&state, &id)?))
 }
 
 /// `DELETE /sessions/:id` — deregister a session AND kill its tmux host.
@@ -748,55 +706,9 @@ pub async fn remove_session(
     State(state): State<Arc<DaemonState>>,
     Path(id): Path<String>,
 ) -> Result<Json<RemoveSessionResponse>, DaemonError> {
-    let session = parse_id(&id)?;
-    let removed = state
-        .remove_session(session)
-        .ok_or_else(|| DaemonError::SessionNotFound { id: id.clone() })?;
-
-    // Best-effort teardown: kill the owning tmux host so the session does not
-    // leak, then reconcile the SessionManager store for any record that shares
-    // the same tmux name. Neither step fails the response — the registry entry
-    // is already gone, which is the contract the DELETE promises.
-    let tmux_name = removed.tmux_name.clone();
-    TmuxService::kill_best_effort(&tmux_name);
-    reconcile_managed_store_on_delete(&state, &tmux_name).await;
-
-    Ok(Json(RemoveSessionResponse { removed: id }))
-}
-
-/// Decommission any SessionManager record that shares `tmux_name`, best-effort.
-///
-/// Why: the legacy `DaemonState` registry and the `SessionManager` store are two
-/// registries that can both track a session under the same tmux name. A DELETE
-/// against the legacy registry must not leave the managed store pointing at a
-/// now-dead tmux host, or the orphan-GC and `ls` would show a phantom (#1454).
-/// What: lists the managed store, finds records whose `tmux_name` matches and
-/// that are not already terminal (Stopped/Decommissioned), and decommissions
-/// each. Every step is best-effort: a store-read or decommission failure is
-/// logged to stderr via `tracing` and swallowed so the HTTP DELETE still
-/// succeeds. Idempotent — already-terminal records are skipped.
-/// Test: exercised by `full_user_cycle`; the managed-store decommission path
-/// itself is unit-tested in `session_manager::tests`.
-async fn reconcile_managed_store_on_delete(state: &Arc<DaemonState>, tmux_name: &str) {
-    let mgr = state.session_manager().await;
-    for record in mgr.list().await {
-        if record.tmux_name != tmux_name {
-            continue;
-        }
-        if matches!(
-            record.state,
-            crate::session_manager::ManagedSessionState::Stopped
-                | crate::session_manager::ManagedSessionState::Decommissioned
-        ) {
-            continue;
-        }
-        if let Err(e) = mgr.decommission(&record.id, None).await {
-            tracing::warn!(
-                name = %tmux_name,
-                "DELETE reconcile: decommission of managed record failed (may already be gone): {e}"
-            );
-        }
-    }
+    // #6288: the body — including the best-effort tmux kill and the managed-
+    // store reconcile — is shared with `mpm.sessions.delete` over the socket.
+    Ok(Json(sessions_ops::remove_session(&state, &id).await?))
 }
 
 /// `DELETE /sessions/dead` — reap registry entries with no live tmux session.
@@ -814,11 +726,8 @@ async fn reconcile_managed_store_on_delete(state: &Arc<DaemonState>, tmux_name: 
     responses((status = 200, description = "Dead sessions reaped; returns the removed count"))
 )]
 pub async fn reap_sessions(State(state): State<Arc<DaemonState>>) -> Json<ReapResponse> {
-    let result = SessionService::new(&state).reap();
-    Json(ReapResponse {
-        removed: result.reaped,
-        stopped: result.stopped,
-    })
+    // #6288: the body is shared with `mpm.sessions.reap` over the Unix socket.
+    Json(sessions_ops::reap_sessions(&state))
 }
 
 /// JSON body for `PATCH /sessions/{id}/pid`.
@@ -858,15 +767,8 @@ pub async fn set_session_pid(
     Path(id): Path<String>,
     Json(body): Json<SetPidRequest>,
 ) -> Result<Json<SetPidResponse>, DaemonError> {
-    let session = parse_id(&id)?;
-    if state.set_session_pid(session, body.pid) {
-        Ok(Json(SetPidResponse {
-            session_id: id,
-            pid: body.pid,
-        }))
-    } else {
-        Err(DaemonError::SessionNotFound { id })
-    }
+    // #6288: the body is shared with `mpm.sessions.set_pid` over the socket.
+    Ok(Json(sessions_ops::set_session_pid(&state, &id, body.pid)?))
 }
 
 /// `POST /sessions/discover` — auto-discover Claude Code sessions.
@@ -887,12 +789,8 @@ pub async fn set_session_pid(
     responses((status = 200, description = "tmux sessions running Claude Code, newly registered"))
 )]
 pub async fn discover_sessions(State(state): State<Arc<DaemonState>>) -> Json<DiscoverResponse> {
-    let result = super::discovery::discover_all(&state).await;
-    Json(DiscoverResponse {
-        discovered: result.adopted,
-        sessions: result.sessions,
-        skipped: result.skipped,
-    })
+    // #6288: the body is shared with `mpm.sessions.discover` over the socket.
+    Json(sessions_ops::discover_sessions(&state).await)
 }
 
 /// `GET /sessions/:id/events/poll` — JSON snapshot of one session's hook events.
@@ -918,10 +816,8 @@ pub async fn session_events(
     State(state): State<Arc<DaemonState>>,
     Path(id): Path<String>,
 ) -> Result<Json<EventsResponse>, DaemonError> {
-    let session = parse_id(&id)?;
-    Ok(Json(EventsResponse {
-        events: state.hook_events_for(session),
-    }))
+    // #6288: the body is shared with `mpm.sessions.events_poll` over the socket.
+    Ok(Json(sessions_ops::session_events(&state, &id)?))
 }
 
 /// `GET /sessions/{id}/events` — live SSE stream of one session's hook events.
@@ -958,65 +854,6 @@ pub async fn stream_session_events(
             .interval(Duration::from_secs(15))
             .text("ping"),
     )
-}
-
-/// Result of applying an optional compression level to captured output.
-///
-/// Why: the command and output endpoints share the same compress-then-return
-/// shape; bundling the text and stats lets one helper produce both.
-/// What: the (possibly compressed) text, the byte stats, and the level as a
-/// lowercase wire string (`None` when no compression was applied).
-/// Test: `apply_compression_off_is_passthrough`, `apply_compression_summarise`.
-struct CompressedOutput {
-    /// The output text after compression (or unchanged when off).
-    text: String,
-    /// Byte counts before and after compression.
-    stats: crate::core::compress::CompressionStats,
-    /// Lowercase wire name of the level applied, or `None` when uncompressed.
-    level_label: Option<String>,
-}
-
-/// Apply an optional compression level to captured pane output.
-///
-/// Why: `POST .../command` and `GET .../output` both accept an optional
-/// `?compress=` query param; doing the compress-or-passthrough decision once
-/// keeps the two handlers identical.
-/// What: when `level` is `Some`, runs [`compress_output`] and records the
-/// level's lowercase label; when `None`, returns the raw text with empty stats
-/// and no label.
-/// Test: `apply_compression_off_is_passthrough`, `apply_compression_summarise`.
-fn apply_compression(level: Option<CompressionLevel>, raw: &str) -> CompressedOutput {
-    match level {
-        Some(level) => {
-            let (text, stats) = crate::core::compress::compress_output(raw, level);
-            CompressedOutput {
-                text,
-                stats,
-                level_label: Some(compression_level_label(level)),
-            }
-        }
-        None => CompressedOutput {
-            text: raw.to_string(),
-            stats: crate::core::compress::CompressionStats::default(),
-            level_label: None,
-        },
-    }
-}
-
-/// Lowercase wire name for a [`CompressionLevel`].
-///
-/// Why: API responses report the applied level as a stable lowercase string,
-/// matching the `snake_case` serde representation of the enum.
-/// What: maps each variant to its `serde` wire name.
-/// Test: `compress_level_label_matches_serde`.
-fn compression_level_label(level: CompressionLevel) -> String {
-    match level {
-        CompressionLevel::Off => "off",
-        CompressionLevel::Trim => "trim",
-        CompressionLevel::Summarise => "summarise",
-        CompressionLevel::Caveman => "caveman",
-    }
-    .to_string()
 }
 
 /// JSON body for `POST /sessions/{id}/pause`.
@@ -1058,12 +895,12 @@ pub async fn pause_session(
     Path(id): Path<String>,
     Json(body): Json<PauseRequest>,
 ) -> Result<Json<PauseResponse>, DaemonError> {
-    let result = SessionService::new(&state).pause(&id, body.summary)?;
-    Ok(Json(PauseResponse {
-        paused: true,
-        session_id: result.session_id,
-        summary: result.summary,
-    }))
+    // #6288: the body is shared with `mpm.sessions.pause` over the Unix socket.
+    Ok(Json(sessions_ops::pause_session(
+        &state,
+        &id,
+        body.summary,
+    )?))
 }
 
 /// `POST /sessions/{id}/resume` — resume a previously-paused session.
@@ -1089,8 +926,8 @@ pub async fn resume_session(
     State(state): State<Arc<DaemonState>>,
     Path(id): Path<String>,
 ) -> Result<Json<ResumeResponse>, DaemonError> {
-    SessionService::new(&state).resume(&id)?;
-    Ok(Json(ResumeResponse { resumed: true }))
+    // #6288: the body is shared with `mpm.sessions.resume` over the socket.
+    Ok(Json(sessions_ops::resume_session(&state, &id)?))
 }
 
 /// JSON body for `POST /sessions/{id}/command`.
@@ -1151,21 +988,10 @@ pub async fn send_command(
     Query(query): Query<CommandQuery>,
     Json(body): Json<CommandRequest>,
 ) -> Result<Json<CommandResponse>, DaemonError> {
-    let session = SessionService::new(&state).command_target(&id)?;
-    TmuxService::send_command(&session, &body.command);
-
-    // Give the pane a moment to render the command's output before capturing.
-    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-    let raw = TmuxService::capture(&session, 100);
-    let compressed = apply_compression(query.compress, &raw);
-
-    Ok(Json(CommandResponse {
-        sent: true,
-        output: compressed.text,
-        original_bytes: compressed.stats.original_bytes,
-        compressed_bytes: compressed.stats.compressed_bytes,
-        compress_level: compressed.level_label,
-    }))
+    // #6288: the body is shared with `mpm.sessions.command` over the socket.
+    Ok(Json(
+        sessions_ops::send_command(&state, &id, &body.command, query.compress).await?,
+    ))
 }
 
 /// Query parameters for `GET /sessions/{id}/output`.
@@ -1184,11 +1010,6 @@ pub struct OutputQuery {
     /// Values: off, trim, summarise, caveman. Defaults to none (raw output).
     #[serde(default)]
     pub compress: Option<CompressionLevel>,
-}
-
-/// Default trailing-line count for `GET /sessions/{id}/output`.
-fn default_output_lines() -> u32 {
-    50
 }
 
 /// `GET /sessions/{id}/output` — capture the current tmux pane output.
@@ -1219,17 +1040,15 @@ pub async fn get_output(
     Path(id): Path<String>,
     Query(query): Query<OutputQuery>,
 ) -> Result<Json<OutputResponse>, DaemonError> {
-    let session = SessionService::new(&state).resolve(&id)?;
-    let lines = query.lines.unwrap_or_else(default_output_lines);
-    let raw = TmuxService::capture(&session, lines);
-    let compressed = apply_compression(query.compress, &raw);
-    Ok(Json(OutputResponse {
-        output: compressed.text,
-        lines,
-        original_bytes: compressed.stats.original_bytes,
-        compressed_bytes: compressed.stats.compressed_bytes,
-        compress_level: compressed.level_label,
-    }))
+    // #6288: the body is shared with `mpm.sessions.output` and its
+    // `mpm.sessions.pane` alias over the Unix socket, mirroring the two HTTP
+    // routes that already point here.
+    Ok(Json(sessions_ops::get_output(
+        &state,
+        &id,
+        query.lines,
+        query.compress,
+    )?))
 }
 
 /// `GET /breakers` — every agent's circuit-breaker state.
@@ -1294,39 +1113,9 @@ pub async fn ingest_hook(
     State(state): State<Arc<DaemonState>>,
     Json(post): Json<HookPost>,
 ) -> Result<Json<HookAcceptedResponse>, DaemonError> {
-    let session = parse_id(&post.session_id)?;
-
-    // Auto-register on SessionStart if not already known. This is how a claude
-    // session connects itself to the daemon: its first hook event registers it
-    // using the incoming UUID, so discovery and `POST /sessions` are not the
-    // only ways a session enters state. The workdir is left empty here and
-    // enriched later by a snapshot or subsequent events.
-    if post.event == HookEvent::SessionStart && state.session(session).is_none() {
-        let mut new_session = Session::new(session, String::new(), ControlModel::Tmux, None);
-        new_session.status = SessionStatus::Active;
-        state.register_session(new_session);
-        tracing::info!("auto-registered session on SessionStart: {session:?}");
-    }
-
-    // #1744: correlate Claude session id → managed session on SessionStart;
-    // immediately mark the managed session Stopped on SessionEnd.
-    if post.event == HookEvent::SessionStart {
-        correlate_session_start(&state, &post.session_id, &post.payload).await;
-    }
-    if post.event == HookEvent::SessionEnd {
-        handle_session_end(&state, &post.session_id).await;
-    }
-
-    // #2621 (code-critic MEDIUM): the idle-park surface+auto-nudge dispatch
-    // lives inside `HookService::process` (daemon/services/hook_service.rs),
-    // not here — this grandfathered handler is already at its line-cap budget,
-    // and `HookService` already has the same event/session/payload inputs.
-    match HookService::new(Arc::clone(&state)).process(session, post.event, post.payload) {
-        HookDecision::Block { reason } => Err(DaemonError::OverseerBlocked { reason }),
-        _ => Ok(Json(HookAcceptedResponse {
-            accepted: post.event,
-        })),
-    }
+    // #6288: the body — auto-registration, the #1744 correlation, and the
+    // overseer veto — is shared with `mpm.hooks.ingest` over the Unix socket.
+    Ok(Json(sessions_ops::ingest_hook(&state, post).await?))
 }
 
 /// `GET /overseer` — current session-overseer configuration and status.
@@ -1861,14 +1650,6 @@ pub async fn report_bug_http(
     Json(core_ops::report_bug(&state, body).await)
 }
 
-/// Parse a UUID string into a `SessionId`, mapping failure to a `400`-mapped
-/// [`DaemonError::InvalidRequest`].
-fn parse_id(raw: &str) -> Result<SessionId, DaemonError> {
-    uuid::Uuid::parse_str(raw)
-        .map(SessionId)
-        .map_err(|_| DaemonError::InvalidRequest(format!("malformed session id: {raw}")))
-}
-
 /// Handler unit tests.
 ///
 /// Why: the suite is large enough that keeping it in `api.rs` pushed the file
@@ -1876,6 +1657,14 @@ fn parse_id(raw: &str) -> Result<SessionId, DaemonError> {
 /// surface readable while the tests still see the private helpers via
 /// `super::*`.
 /// Test: this *is* the test module.
+// #6288 slice 3: `apply_compression` and its label helper moved to
+// `daemon::rpc::sessions_legacy_ops` with the two handler bodies that use them.
+// `api_tests.rs` reaches them through its `use super::*;`, so re-export the
+// names here rather than editing the cases. Test-only: nothing in the non-test
+// lib target references them any more.
+#[cfg(test)]
+pub(crate) use super::rpc::sessions_legacy_ops::{apply_compression, compression_level_label};
+
 #[cfg(test)]
 #[path = "api_tests.rs"]
 mod tests;

--- a/crates/trusty-mpm/src/daemon/api/session_start_correlation.rs
+++ b/crates/trusty-mpm/src/daemon/api/session_start_correlation.rs
@@ -68,7 +68,7 @@ use crate::daemon::state::DaemonState;
 /// `session_start_hook_still_refuses_a_live_subagent_id`,
 /// `session_start_hook_reasserting_same_id_is_a_noop`,
 /// `session_start_hook_re_correlates_a_stale_id` in `api_tests.rs`.
-pub(super) async fn correlate_session_start(
+pub(crate) async fn correlate_session_start(
     state: &Arc<DaemonState>,
     claude_session_id: &str,
     payload: &serde_json::Value,
@@ -273,7 +273,7 @@ pub(super) fn session_end_pane_still_live(
 /// the gate fails open); the gate's own decision logic is covered by the
 /// `session_end_pane_still_live_*` unit tests above;
 /// `session_end_hook_clears_claude_session_id` covers the #4337 clear.
-pub(super) async fn handle_session_end(state: &Arc<DaemonState>, claude_session_id: &str) {
+pub(crate) async fn handle_session_end(state: &Arc<DaemonState>, claude_session_id: &str) {
     let mgr = state.session_manager().await;
     let records = mgr.list().await;
     let matched = records.iter().find(|r| {

--- a/crates/trusty-mpm/src/daemon/rpc/mod.rs
+++ b/crates/trusty-mpm/src/daemon/rpc/mod.rs
@@ -19,6 +19,14 @@ pub mod core;
 /// handlers both call, so one route has one implementation.
 pub mod core_ops;
 
+/// Registration for the legacy session registry, hook ingestion, and the polled
+/// event feeds (#6288 slice 3). The SSE stream legs stay on HTTP until slice 6.
+pub mod sessions_legacy;
+
+/// The transport-neutral bodies `sessions_legacy`'s methods and `daemon::api`'s
+/// HTTP handlers both call, so one route has one implementation.
+pub mod sessions_legacy_ops;
+
 /// Registration for the managed-session lifecycle, the SESSCTL control plane,
 /// and the L2 proxy (#6288 slice 4).
 pub mod managed;

--- a/crates/trusty-mpm/src/daemon/rpc/sessions_legacy.rs
+++ b/crates/trusty-mpm/src/daemon/rpc/sessions_legacy.rs
@@ -1,0 +1,334 @@
+//! The legacy session registry, hook relay, and polled event feeds, served as
+//! JSON-RPC methods (#6288 slice 3).
+//!
+//! Why: slice 2 put the first twenty methods on the socket slice 1 bound. This
+//! slice adds the `/sessions*` registry family, the `/hooks` relay, and the two
+//! `/events/poll` legs. HTTP is untouched and still serves every one of these
+//! routes — the socket is an ADDITIONAL way to reach the same body, not a
+//! replacement, until the retire slice deletes the axum surface.
+//!
+//! What: the name-to-route table below, `METHODS` as an assertable array of it,
+//! and [`register`], which mounts each name on the router `daemon::socket`
+//! builds. Every handler is a thin adapter over a function in
+//! [`super::sessions_legacy_ops`] — this file decides WHICH method exists and
+//! what it decodes, never what it does.
+//!
+//! ## Method → route
+//!
+//! | Method | HTTP route |
+//! |---|---|
+//! | `mpm.sessions.list` | `GET /sessions` |
+//! | `mpm.sessions.register` | `POST /sessions` |
+//! | `mpm.sessions.connect` | `POST /api/v1/sessions/connect` |
+//! | `mpm.sessions.discover` | `POST /sessions/discover` |
+//! | `mpm.sessions.reap` | `DELETE /sessions/dead` |
+//! | `mpm.sessions.get` | `GET /sessions/{id}` |
+//! | `mpm.sessions.delete` | `DELETE /sessions/{id}` |
+//! | `mpm.sessions.pause` | `POST /sessions/{id}/pause` |
+//! | `mpm.sessions.resume` | `POST /sessions/{id}/resume` |
+//! | `mpm.sessions.command` | `POST /sessions/{id}/command` |
+//! | `mpm.sessions.output` | `GET /sessions/{id}/output` |
+//! | `mpm.sessions.pane` | `GET /sessions/{id}/pane` |
+//! | `mpm.sessions.set_pid` | `PATCH /sessions/{id}/pid` |
+//! | `mpm.sessions.events_poll` | `GET /sessions/{id}/events/poll` |
+//! | `mpm.events.poll` | `GET /events/poll` |
+//! | `mpm.hooks.ingest` | `POST /hooks` |
+//!
+//! Three naming notes, so a reader does not have to diff the table against
+//! `api::router` to find them:
+//!
+//! - `mpm.sessions.pane` and `mpm.sessions.output` are one body under two
+//!   names, mirroring `/sessions/{id}/pane` and `/sessions/{id}/output`, which
+//!   axum registers against one handler. The alias is carried rather than
+//!   dropped because a client that dials `pane` today must keep working.
+//! - `mpm.sessions.set_pid` is named for what it does, not for its path leaf
+//!   (`PATCH …/pid`), since a bare `pid` would read as a getter.
+//! - `mpm.sessions.reap` is `DELETE /sessions/dead`. The slice-3 brief listed
+//!   twelve `/sessions*` verbs and this was not among them; it is registered
+//!   here anyway because it is a `/sessions*` legacy-registry route that no
+//!   other slice owns, and leaving it out would strand it between slices.
+//!
+//! `mpm.sessions.list` takes every argument optionally, so it decodes an absent
+//! `params` as well as an object. A route whose HTTP form splits its arguments across a path segment, a query
+//! string, and a body carries them as one `params` object here —
+//! `mpm.sessions.command` takes `{"id": …, "command": …, "compress": …}`.
+//! Everything else decodes the same struct the axum extractor decodes, so a
+//! caller's payload is unchanged by the transport.
+//!
+//! ## What guards these methods
+//!
+//! Every write here costs something: `mpm.sessions.register` can spawn a tmux
+//! session running `claude`, `mpm.sessions.delete` kills one, and
+//! `mpm.hooks.ingest` mutates the registry and the event log. So the guards have
+//! to be at least as strong on the socket, and they are:
+//!
+//! - **HTTP** layers `trusty_common::server::guard_write_origin` router-wide
+//!   (`daemon::mod`, via `api::origin_guard::guard_router`). `/hooks` carries
+//!   nothing beyond it — no hook token, no shared secret, no per-route loopback
+//!   check (`git grep` over this crate finds no such credential, and the
+//!   forwarder shim posts a bare JSON body). That guard is CSRF defence: it
+//!   inspects the `Origin` header and ALLOWS any request that carries none,
+//!   which is every server-side caller. It authenticates nobody.
+//! - **The socket** runs `ensure_peer_is_self` on every accepted connection
+//!   before a byte is read (`trusty_common::uds::server`), over a `0600` socket
+//!   in a `0700` directory. It authenticates the calling process's uid.
+//!
+//! Nothing is dropped by moving across. The origin guard has no counterpart to
+//! carry — there is no `Origin` header on a Unix socket and no browser that
+//! could send one — and the peer-uid check is the stronger of the two, since it
+//! refuses a caller the origin guard would have waved through. The overseer veto
+//! on `mpm.hooks.ingest` is not a transport guard at all: it lives in the shared
+//! body and fires identically either way.
+//!
+//! Test: `sessions_legacy_tests.rs` — `rpc_*` for the wire behaviour, `parity_*`
+//! for the HTTP-versus-socket comparison.
+
+use std::sync::Arc;
+
+use serde::Deserialize;
+use trusty_common::uds::server::RpcRouter;
+
+use crate::core::compress::CompressionLevel;
+use crate::daemon::state::DaemonState;
+
+use super::core::NoParams;
+use super::sessions_legacy_ops as ops;
+
+#[cfg(test)]
+#[path = "sessions_legacy_tests.rs"]
+mod tests;
+
+/// Every method this slice registers, in registration order.
+///
+/// Why: the slice-7 client swap will dial these names by literal, from code with
+/// no compile-time link to this table. An array here is what a contract test can
+/// compare the router against, so a rename surfaces as a failing assertion
+/// rather than as a consumer that silently reports `method_not_found`.
+///
+/// Test: `rpc_router_registers_every_documented_method`.
+pub const METHODS: &[&str] = &[
+    "mpm.sessions.list",
+    "mpm.sessions.register",
+    "mpm.sessions.connect",
+    "mpm.sessions.discover",
+    "mpm.sessions.reap",
+    "mpm.sessions.get",
+    "mpm.sessions.delete",
+    "mpm.sessions.pause",
+    "mpm.sessions.resume",
+    "mpm.sessions.command",
+    "mpm.sessions.output",
+    "mpm.sessions.pane",
+    "mpm.sessions.set_pid",
+    "mpm.sessions.events_poll",
+    "mpm.events.poll",
+    "mpm.hooks.ingest",
+];
+
+/// The one path segment a session route takes: `GET`/`DELETE /sessions/{id}`,
+/// `POST …/resume`, `GET …/events/poll`.
+///
+/// `id` accepts a UUID everywhere, and additionally a friendly tmux name on the
+/// routes whose HTTP form does — the resolution rule is the body's, not this
+/// struct's.
+#[derive(Deserialize)]
+pub struct SessionIdParams {
+    /// Session UUID, or a friendly tmux name where the route resolves one.
+    pub id: String,
+}
+
+/// `POST /sessions/{id}/pause`'s path segment plus its optional body note.
+#[derive(Deserialize)]
+pub struct PauseParams {
+    /// Session UUID or friendly name.
+    pub id: String,
+    /// Optional note about where the session was left off.
+    #[serde(default)]
+    pub summary: Option<String>,
+}
+
+/// `PATCH /sessions/{id}/pid`'s path segment plus its body.
+#[derive(Deserialize)]
+pub struct SetPidParams {
+    /// Session UUID.
+    pub id: String,
+    /// OS-level `claude` process id discovered inside the session's tmux pane.
+    pub pid: u32,
+}
+
+/// `POST /sessions/{id}/command`'s path segment, query, and body as one object.
+#[derive(Deserialize)]
+pub struct CommandParams {
+    /// Session UUID or friendly name.
+    pub id: String,
+    /// The command line to send to the session's tmux pane.
+    pub command: String,
+    /// Compression level to apply to the captured output before returning.
+    #[serde(default)]
+    pub compress: Option<CompressionLevel>,
+}
+
+/// `GET /sessions/{id}/output` (and its `/pane` alias) as one object.
+#[derive(Deserialize)]
+pub struct OutputParams {
+    /// Session UUID or friendly name.
+    pub id: String,
+    /// Trailing pane lines to capture (default 50 when absent).
+    #[serde(default)]
+    pub lines: Option<u32>,
+    /// Compression level to apply to the captured output before returning.
+    #[serde(default)]
+    pub compress: Option<CompressionLevel>,
+}
+
+/// Mount every method in [`METHODS`] onto `router`.
+///
+/// Why a free function rather than a builder method: `daemon::socket` names one
+/// `register` call per family, so a family arrives without the accept loop, the
+/// framing, or the peer check being touched.
+///
+/// Test: `rpc_router_registers_every_documented_method`.
+pub fn register(router: RpcRouter, state: &Arc<DaemonState>) -> RpcRouter {
+    macro_rules! ok {
+        ($router:expr, $name:literal, $req:ty, $resp:ty, |$s:ident, $r:ident| $call:expr) => {{
+            let held = Arc::clone(state);
+            $router.typed::<$req, $resp, _, _>($name, move |$r| {
+                let $s = Arc::clone(&held);
+                async move { Ok($call) }
+            })
+        }};
+    }
+    macro_rules! fallible {
+        ($router:expr, $name:literal, $req:ty, $resp:ty, |$s:ident, $r:ident| $call:expr) => {{
+            let held = Arc::clone(state);
+            $router.typed::<$req, $resp, _, _>($name, move |$r| {
+                let $s = Arc::clone(&held);
+                async move { $call.map_err(Into::into) }
+            })
+        }};
+    }
+
+    use crate::daemon::api::types as t;
+    use crate::daemon::api::{HookPost, RegisterSession, SessionQuery};
+
+    let r = router;
+    // `Option<SessionQuery>` rather than `SessionQuery`: every argument this
+    // method takes is optional, so a caller may send no `params` at all, and
+    // serde's derive refuses `null` for a struct — the same trap `NoParams`
+    // exists for on the no-argument methods (#6288).
+    let r = ok!(
+        r,
+        "mpm.sessions.list",
+        Option<SessionQuery>,
+        t::SessionsResponse,
+        |s, p| ops::list_sessions(&s, p.unwrap_or_default())
+    );
+    let r = fallible!(
+        r,
+        "mpm.sessions.register",
+        RegisterSession,
+        t::RegisterSessionResponse,
+        |s, p| ops::register_session(&s, p)
+    );
+    // `connect` is a distinct name over the same body, exactly as
+    // `POST /api/v1/sessions/connect` is a distinct route over the same handler
+    // — the daemon does no deployment in either path (#6288).
+    let r = fallible!(
+        r,
+        "mpm.sessions.connect",
+        RegisterSession,
+        t::RegisterSessionResponse,
+        |s, p| ops::register_session(&s, p)
+    );
+    let r = ok!(
+        r,
+        "mpm.sessions.discover",
+        NoParams,
+        t::DiscoverResponse,
+        |s, _p| ops::discover_sessions(&s).await
+    );
+    let r = ok!(
+        r,
+        "mpm.sessions.reap",
+        NoParams,
+        t::ReapResponse,
+        |s, _p| ops::reap_sessions(&s)
+    );
+    let r = fallible!(
+        r,
+        "mpm.sessions.get",
+        SessionIdParams,
+        crate::core::session::Session,
+        |s, p| ops::get_session(&s, &p.id)
+    );
+    let r = fallible!(
+        r,
+        "mpm.sessions.delete",
+        SessionIdParams,
+        t::RemoveSessionResponse,
+        |s, p| ops::remove_session(&s, &p.id).await
+    );
+    let r = fallible!(
+        r,
+        "mpm.sessions.pause",
+        PauseParams,
+        t::PauseResponse,
+        |s, p| ops::pause_session(&s, &p.id, p.summary)
+    );
+    let r = fallible!(
+        r,
+        "mpm.sessions.resume",
+        SessionIdParams,
+        t::ResumeResponse,
+        |s, p| ops::resume_session(&s, &p.id)
+    );
+    let r = fallible!(
+        r,
+        "mpm.sessions.command",
+        CommandParams,
+        t::CommandResponse,
+        |s, p| ops::send_command(&s, &p.id, &p.command, p.compress).await
+    );
+    let r = fallible!(
+        r,
+        "mpm.sessions.output",
+        OutputParams,
+        t::OutputResponse,
+        |s, p| ops::get_output(&s, &p.id, p.lines, p.compress)
+    );
+    let r = fallible!(
+        r,
+        "mpm.sessions.pane",
+        OutputParams,
+        t::OutputResponse,
+        |s, p| ops::get_output(&s, &p.id, p.lines, p.compress)
+    );
+    let r = fallible!(
+        r,
+        "mpm.sessions.set_pid",
+        SetPidParams,
+        t::SetPidResponse,
+        |s, p| ops::set_session_pid(&s, &p.id, p.pid)
+    );
+    let r = fallible!(
+        r,
+        "mpm.sessions.events_poll",
+        SessionIdParams,
+        t::EventsResponse,
+        |s, p| ops::session_events(&s, &p.id)
+    );
+    let r = ok!(
+        r,
+        "mpm.events.poll",
+        NoParams,
+        t::EventsResponse,
+        |s, _p| ops::recent_events(&s)
+    );
+    fallible!(
+        r,
+        "mpm.hooks.ingest",
+        HookPost,
+        t::HookAcceptedResponse,
+        |s, p| ops::ingest_hook(&s, p).await
+    )
+}

--- a/crates/trusty-mpm/src/daemon/rpc/sessions_legacy_ops.rs
+++ b/crates/trusty-mpm/src/daemon/rpc/sessions_legacy_ops.rs
@@ -1,0 +1,541 @@
+//! Transport-neutral bodies for the legacy session registry, hook ingestion,
+//! and the polled event feeds.
+//!
+//! Why (#6288 slice 3): every route in the `/sessions*` registry family, the
+//! `/hooks` relay, and the two `/events/poll` legs is now reachable two ways —
+//! `daemon::api`'s axum handler and [`super::sessions_legacy`]'s JSON-RPC
+//! method. Two transports over one route must not become two implementations of
+//! it: the moment a fix lands in one copy and not the other, a caller's answer
+//! depends on which socket it happened to dial. So the body lives here exactly
+//! once and both transports call in. Slice 2's [`super::core_ops`] made the same
+//! move for the health/doctor/tmux families; this file copies that shape.
+//!
+//! What: one function per route, taking `&Arc<DaemonState>` plus the route's own
+//! decoded arguments and returning the response type the HTTP handler used to
+//! build. Nothing here names an HTTP type — no `Json`, no `StatusCode`, no
+//! extractor — and nothing names a JSON-RPC type either. Failures are
+//! [`DaemonError`], which both transports already know how to render
+//! (`IntoResponse` for HTTP, `From<DaemonError> for RpcError` for the socket).
+//!
+//! Why these bodies MOVED rather than staying in `api.rs` behind a sibling
+//! wrapper: `api.rs` sits on a frozen 1176-SLOC ratchet budget, and fourteen
+//! extra wrappers would have pushed it over. The split ships in the PR that
+//! forces it, per the SLOC-cap rule.
+//!
+//! ## Best-effort steps are best-effort on BOTH transports
+//!
+//! Three routes here do work that is deliberately allowed to fail without
+//! failing the call: the tmux kill and managed-store reconcile behind
+//! [`remove_session`], the pause-file write behind [`pause_session`], and the
+//! tmux `send-keys` behind [`send_command`]. Each is logged and swallowed
+//! exactly where it always was — inside this one body — so the socket inherits
+//! the HTTP contract rather than a second, laxer one. The failure branches that
+//! DO error (an unknown id, a stopped session, an overseer block) error on both
+//! transports for the same reason, because there is one `?` to hit.
+//!
+//! Test: `parity_sessions_list_agrees_across_transports`,
+//! `parity_sessions_delete_agrees_across_transports`,
+//! `parity_sessions_pause_leaves_the_same_state_on_both_transports`,
+//! `parity_hooks_ingest_leaves_the_same_event_log_on_both_transports` — and the
+//! rest of the `parity_*` set in `sessions_legacy_tests.rs`, which drives every
+//! body here through BOTH transports and compares the answers and the state
+//! each left behind.
+
+use std::sync::Arc;
+
+use crate::core::compress::CompressionLevel;
+use crate::core::hook::HookEvent;
+use crate::core::session::{ControlModel, Session, SessionId, SessionStatus};
+use crate::daemon::api::session_start_correlation::{correlate_session_start, handle_session_end};
+use crate::daemon::api::types::{
+    CommandResponse, DiscoverResponse, EventsResponse, HookAcceptedResponse, OutputResponse,
+    PauseResponse, ReapResponse, RegisterSessionResponse, RemoveSessionResponse, ResumeResponse,
+    SessionsResponse, SetPidResponse,
+};
+use crate::daemon::api::{HookPost, RegisterSession, SessionQuery};
+use crate::daemon::error::DaemonError;
+use crate::daemon::services::{HookDecision, HookService, SessionService, TmuxService};
+use crate::daemon::state::DaemonState;
+
+/// Parse a UUID string into a [`SessionId`].
+///
+/// Why here rather than in `api.rs`: every caller is a body in this file, and
+/// the refusal has to be identical on both transports — `InvalidRequest` renders
+/// as HTTP 400 and as `CODE_INVALID_PARAMS` on the socket.
+///
+/// # Errors
+///
+/// [`DaemonError::InvalidRequest`] when `raw` is not a UUID.
+///
+/// Test: `parity_get_session_malformed_id_agrees_across_transports`.
+pub fn parse_id(raw: &str) -> Result<SessionId, DaemonError> {
+    uuid::Uuid::parse_str(raw)
+        .map(SessionId)
+        .map_err(|_| DaemonError::InvalidRequest(format!("malformed session id: {raw}")))
+}
+
+/// Result of applying an optional compression level to captured output.
+///
+/// Why: the command and output endpoints share the same compress-then-return
+/// shape; bundling the text and stats lets one helper produce both.
+/// What: the (possibly compressed) text, the byte stats, and the level as a
+/// lowercase wire string (`None` when no compression was applied).
+/// Test: `apply_compression_off_is_passthrough`, `apply_compression_summarise`.
+pub struct CompressedOutput {
+    /// The output text after compression (or unchanged when off).
+    pub text: String,
+    /// Byte counts before and after compression.
+    pub stats: crate::core::compress::CompressionStats,
+    /// Lowercase wire name of the level applied, or `None` when uncompressed.
+    pub level_label: Option<String>,
+}
+
+/// Apply an optional compression level to captured pane output.
+///
+/// Why: [`send_command`] and [`get_output`] both accept an optional compression
+/// level; doing the compress-or-passthrough decision once keeps them identical.
+/// What: when `level` is `Some`, runs `compress_output` and records the level's
+/// lowercase label; when `None`, returns the raw text with empty stats and no
+/// label.
+/// Test: `apply_compression_off_is_passthrough`, `apply_compression_summarise`.
+pub fn apply_compression(level: Option<CompressionLevel>, raw: &str) -> CompressedOutput {
+    match level {
+        Some(level) => {
+            let (text, stats) = crate::core::compress::compress_output(raw, level);
+            CompressedOutput {
+                text,
+                stats,
+                level_label: Some(compression_level_label(level)),
+            }
+        }
+        None => CompressedOutput {
+            text: raw.to_string(),
+            stats: crate::core::compress::CompressionStats::default(),
+            level_label: None,
+        },
+    }
+}
+
+/// Lowercase wire name for a [`CompressionLevel`].
+///
+/// Why: API responses report the applied level as a stable lowercase string,
+/// matching the `snake_case` serde representation of the enum.
+/// Test: `compress_level_label_matches_serde`.
+pub fn compression_level_label(level: CompressionLevel) -> String {
+    match level {
+        CompressionLevel::Off => "off",
+        CompressionLevel::Trim => "trim",
+        CompressionLevel::Summarise => "summarise",
+        CompressionLevel::Caveman => "caveman",
+    }
+    .to_string()
+}
+
+/// Default trailing-line count for a pane capture.
+fn default_output_lines() -> u32 {
+    50
+}
+
+/// Snapshot of managed sessions, optionally project-scoped (`GET /sessions`,
+/// `mpm.sessions.list`).
+///
+/// Test: `parity_sessions_list_agrees_across_transports`.
+pub fn list_sessions(state: &Arc<DaemonState>, query: SessionQuery) -> SessionsResponse {
+    let sessions = match query.project {
+        Some(path) => state.list_sessions_for_project(&path),
+        None => state.list_sessions(),
+    };
+    SessionsResponse { sessions }
+}
+
+/// Register a managed session, optionally spawning it (`POST /sessions`,
+/// `mpm.sessions.register`; also `POST /api/v1/sessions/connect`,
+/// `mpm.sessions.connect`).
+///
+/// Why spawn happens BEFORE the registry write: a failed spawn must leave the
+/// registry untouched, so a refused call never leaves a half-created session
+/// visible to a later list. That ordering is the contract, and it is one
+/// ordering for both transports because there is one body.
+///
+/// # Errors
+///
+/// [`DaemonError`] when `workdir` was supplied and the tmux spawn failed —
+/// `claude` or tmux missing (HTTP 422 / `CODE_UNPROCESSABLE`), or the tmux
+/// command itself failing (HTTP 500 / `CODE_INTERNAL_ERROR`).
+///
+/// Test: `parity_sessions_register_agrees_across_transports`,
+/// `register_and_remove_session`.
+pub fn register_session(
+    state: &Arc<DaemonState>,
+    body: RegisterSession,
+) -> Result<RegisterSessionResponse, DaemonError> {
+    // Derive the tmux name from the project directory (`tm-<folder>`) so the
+    // registry name matches the folder-based session the CLI creates. A
+    // caller-supplied `name` always wins; otherwise fall back to the UUID name.
+    let project_dir = body.project_path.as_deref();
+    let mut session = Session::new(
+        SessionId::new(),
+        body.project.clone(),
+        ControlModel::Tmux,
+        project_dir,
+    );
+    session.project_path = body.project_path.clone();
+    if let Some(name) = body.name.as_deref().filter(|n| !n.is_empty()) {
+        session.tmux_name = name.to_string();
+    }
+    if let Some(workdir) = body.workdir.as_deref() {
+        // Mirror the workdir onto the session record so the dashboard and the
+        // reaper see the spawn directory, not the project label. The
+        // `Session::workdir` field is the per-session working directory; the
+        // `project` field is a label / association.
+        session.workdir = workdir.to_string_lossy().into_owned();
+    }
+
+    // Spawn mode: create the tmux host and start `claude` *before* the session
+    // is registered, so a refusal leaves the registry untouched.
+    if let Some(workdir) = body.workdir.as_deref() {
+        TmuxService::spawn_claude(&session.tmux_name, workdir)?;
+        // The session is now actively running `claude`; mark it Active so the
+        // dashboard reflects reality rather than the default `Starting` state.
+        session.status = SessionStatus::Active;
+    }
+
+    let id = session.id;
+    let tmux_name = session.tmux_name.clone();
+    state.register_session(session);
+
+    // Discover the `claude` PID inside the registered tmux pane in the
+    // background so the reaper can monitor process liveness. This is the
+    // daemon-side counterpart of the CLI's post-launch PID capture; it does not
+    // block the response, and a failure is logged, never fatal.
+    crate::daemon::services::session_service::spawn_pid_capture(
+        Arc::clone(state),
+        id,
+        tmux_name.clone(),
+    );
+
+    Ok(RegisterSessionResponse {
+        id,
+        name: tmux_name,
+    })
+}
+
+/// One session's detail (`GET /sessions/{id}`, `mpm.sessions.get`).
+///
+/// # Errors
+///
+/// [`DaemonError::InvalidRequest`] for a malformed id,
+/// [`DaemonError::SessionNotFound`] for an unknown one.
+///
+/// Test: `parity_get_session_agrees_across_transports`,
+/// `parity_get_session_unknown_id_agrees_across_transports`.
+pub fn get_session(state: &Arc<DaemonState>, id: &str) -> Result<Session, DaemonError> {
+    let session_id = parse_id(id)?;
+    state
+        .session(session_id)
+        .ok_or_else(|| DaemonError::SessionNotFound { id: id.to_string() })
+}
+
+/// Deregister a session AND kill its tmux host (`DELETE /sessions/{id}`,
+/// `mpm.sessions.delete`).
+///
+/// Why the teardown is best-effort: the registry removal having succeeded is the
+/// contract the caller relies on, and the tmux host may already be gone. The
+/// kill and the managed-store reconcile are logged and swallowed — on BOTH
+/// transports, because they are swallowed here rather than in either handler.
+///
+/// # Errors
+///
+/// [`DaemonError::InvalidRequest`] for a malformed id,
+/// [`DaemonError::SessionNotFound`] for an unknown one.
+///
+/// Test: `parity_sessions_delete_agrees_across_transports`, `full_user_cycle`.
+pub async fn remove_session(
+    state: &Arc<DaemonState>,
+    id: &str,
+) -> Result<RemoveSessionResponse, DaemonError> {
+    let session = parse_id(id)?;
+    let removed = state
+        .remove_session(session)
+        .ok_or_else(|| DaemonError::SessionNotFound { id: id.to_string() })?;
+
+    let tmux_name = removed.tmux_name.clone();
+    TmuxService::kill_best_effort(&tmux_name);
+    reconcile_managed_store_on_delete(state, &tmux_name).await;
+
+    Ok(RemoveSessionResponse {
+        removed: id.to_string(),
+    })
+}
+
+/// Decommission any SessionManager record that shares `tmux_name`, best-effort.
+///
+/// Why: the legacy `DaemonState` registry and the `SessionManager` store are two
+/// registries that can both track a session under the same tmux name. A delete
+/// against the legacy registry must not leave the managed store pointing at a
+/// now-dead tmux host, or the orphan-GC and `ls` would show a phantom (#1454).
+/// What: lists the managed store, finds records whose `tmux_name` matches and
+/// that are not already terminal (Stopped/Decommissioned), and decommissions
+/// each. Every step is best-effort: a store-read or decommission failure is
+/// logged to stderr via `tracing` and swallowed so the delete still succeeds.
+/// Idempotent — already-terminal records are skipped.
+/// Test: exercised by `full_user_cycle`; the managed-store decommission path
+/// itself is unit-tested in `session_manager::tests`.
+async fn reconcile_managed_store_on_delete(state: &Arc<DaemonState>, tmux_name: &str) {
+    let mgr = state.session_manager().await;
+    for record in mgr.list().await {
+        if record.tmux_name != tmux_name {
+            continue;
+        }
+        if matches!(
+            record.state,
+            crate::session_manager::ManagedSessionState::Stopped
+                | crate::session_manager::ManagedSessionState::Decommissioned
+        ) {
+            continue;
+        }
+        if let Err(e) = mgr.decommission(&record.id, None).await {
+            tracing::warn!(
+                name = %tmux_name,
+                "delete reconcile: decommission of managed record failed (may already be gone): {e}"
+            );
+        }
+    }
+}
+
+/// Reap registry entries with no live tmux session (`DELETE /sessions/dead`,
+/// `mpm.sessions.reap`).
+///
+/// Test: `parity_sessions_reap_agrees_across_transports`.
+pub fn reap_sessions(state: &Arc<DaemonState>) -> ReapResponse {
+    let result = SessionService::new(state).reap();
+    ReapResponse {
+        removed: result.reaped,
+        stopped: result.stopped,
+    }
+}
+
+/// Record the OS-level `claude` process PID (`PATCH /sessions/{id}/pid`,
+/// `mpm.sessions.set_pid`).
+///
+/// # Errors
+///
+/// [`DaemonError::InvalidRequest`] for a malformed id,
+/// [`DaemonError::SessionNotFound`] for an unknown one.
+///
+/// Test: `parity_sessions_set_pid_agrees_across_transports`,
+/// `parity_sessions_set_pid_unknown_agrees_across_transports`.
+pub fn set_session_pid(
+    state: &Arc<DaemonState>,
+    id: &str,
+    pid: u32,
+) -> Result<SetPidResponse, DaemonError> {
+    let session = parse_id(id)?;
+    if state.set_session_pid(session, pid) {
+        Ok(SetPidResponse {
+            session_id: id.to_string(),
+            pid,
+        })
+    } else {
+        Err(DaemonError::SessionNotFound { id: id.to_string() })
+    }
+}
+
+/// Auto-discover Claude Code sessions (`POST /sessions/discover`,
+/// `mpm.sessions.discover`).
+///
+/// Test: `parity_sessions_discover_agrees_across_transports`.
+pub async fn discover_sessions(state: &Arc<DaemonState>) -> DiscoverResponse {
+    let result = crate::daemon::discovery::discover_all(state).await;
+    DiscoverResponse {
+        discovered: result.adopted,
+        sessions: result.sessions,
+        skipped: result.skipped,
+    }
+}
+
+/// The bounded ring buffer of recent hook events (`GET /events/poll`,
+/// `mpm.events.poll`).
+///
+/// Test: `parity_events_poll_agrees_across_transports`.
+pub fn recent_events(state: &Arc<DaemonState>) -> EventsResponse {
+    EventsResponse {
+        events: state.recent_hook_events(),
+    }
+}
+
+/// One session's slice of the ring buffer (`GET /sessions/{id}/events/poll`,
+/// `mpm.sessions.events_poll`).
+///
+/// # Errors
+///
+/// [`DaemonError::InvalidRequest`] for a malformed id.
+///
+/// Test: `parity_session_events_poll_agrees_across_transports`.
+pub fn session_events(state: &Arc<DaemonState>, id: &str) -> Result<EventsResponse, DaemonError> {
+    let session = parse_id(id)?;
+    Ok(EventsResponse {
+        events: state.hook_events_for(session),
+    })
+}
+
+/// Pause a session, saving its state for resume (`POST /sessions/{id}/pause`,
+/// `mpm.sessions.pause`).
+///
+/// Why the pause-file write does not fail the call: the in-memory status flip is
+/// the contract, and a disk failure is logged inside `SessionService::pause`.
+/// Both transports inherit that single decision.
+///
+/// # Errors
+///
+/// [`DaemonError::SessionNotFound`] when neither the UUID nor the friendly name
+/// resolves.
+///
+/// Test: `parity_sessions_pause_leaves_the_same_state_on_both_transports`,
+/// `pause_then_resume_round_trips`.
+pub fn pause_session(
+    state: &Arc<DaemonState>,
+    id: &str,
+    summary: Option<String>,
+) -> Result<PauseResponse, DaemonError> {
+    let result = SessionService::new(state).pause(id, summary)?;
+    Ok(PauseResponse {
+        paused: true,
+        session_id: result.session_id,
+        summary: result.summary,
+    })
+}
+
+/// Resume a previously-paused session (`POST /sessions/{id}/resume`,
+/// `mpm.sessions.resume`).
+///
+/// # Errors
+///
+/// [`DaemonError::SessionNotFound`] for an unknown session,
+/// [`DaemonError::SessionNotActive`] when it is not paused (HTTP 409 /
+/// `CODE_CONFLICT`).
+///
+/// Test: `parity_sessions_resume_leaves_the_same_state_on_both_transports`,
+/// `parity_sessions_resume_unpaused_agrees_across_transports`.
+pub fn resume_session(state: &Arc<DaemonState>, id: &str) -> Result<ResumeResponse, DaemonError> {
+    SessionService::new(state).resume(id)?;
+    Ok(ResumeResponse { resumed: true })
+}
+
+/// Send a command into a session's tmux pane (`POST /sessions/{id}/command`,
+/// `mpm.sessions.command`).
+///
+/// Why the tmux write is best-effort but the state check is not: a `Stopped`
+/// session is refused before anything is sent (`SessionNotActive`, HTTP 409 /
+/// `CODE_CONFLICT`), while a tmux failure after that point is logged and the
+/// caller still gets whatever the pane held. One body, so one policy.
+///
+/// # Errors
+///
+/// [`DaemonError::SessionNotFound`] for an unknown session,
+/// [`DaemonError::SessionNotActive`] for a stopped one.
+///
+/// Test: `parity_sessions_command_leaves_the_same_state_on_both_transports`,
+/// `parity_sessions_command_stopped_agrees_across_transports`.
+pub async fn send_command(
+    state: &Arc<DaemonState>,
+    id: &str,
+    command: &str,
+    compress: Option<CompressionLevel>,
+) -> Result<CommandResponse, DaemonError> {
+    let session = SessionService::new(state).command_target(id)?;
+    TmuxService::send_command(&session, command);
+
+    // Give the pane a moment to render the command's output before capturing.
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    let raw = TmuxService::capture(&session, 100);
+    let compressed = apply_compression(compress, &raw);
+
+    Ok(CommandResponse {
+        sent: true,
+        output: compressed.text,
+        original_bytes: compressed.stats.original_bytes,
+        compressed_bytes: compressed.stats.compressed_bytes,
+        compress_level: compressed.level_label,
+    })
+}
+
+/// Capture the current tmux pane output (`GET /sessions/{id}/output` and its
+/// `/pane` alias; `mpm.sessions.output` and `mpm.sessions.pane`).
+///
+/// # Errors
+///
+/// [`DaemonError::SessionNotFound`] for an unknown session.
+///
+/// Test: `parity_sessions_output_agrees_across_transports`,
+/// `parity_sessions_pane_matches_output_on_both_transports`.
+pub fn get_output(
+    state: &Arc<DaemonState>,
+    id: &str,
+    lines: Option<u32>,
+    compress: Option<CompressionLevel>,
+) -> Result<OutputResponse, DaemonError> {
+    let session = SessionService::new(state).resolve(id)?;
+    let lines = lines.unwrap_or_else(default_output_lines);
+    let raw = TmuxService::capture(&session, lines);
+    let compressed = apply_compression(compress, &raw);
+    Ok(OutputResponse {
+        output: compressed.text,
+        lines,
+        original_bytes: compressed.stats.original_bytes,
+        compressed_bytes: compressed.stats.compressed_bytes,
+        compress_level: compressed.level_label,
+    })
+}
+
+/// Ingest one Claude Code hook event (`POST /hooks`, `mpm.hooks.ingest`).
+///
+/// Why this is the write that matters most: it is how a claude session announces
+/// itself (a `SessionStart` for an unknown id auto-registers it), how the
+/// managed store learns a session ended, and how the overseer gets its veto. All
+/// three effects land here, so both transports produce them or neither does.
+///
+/// # Errors
+///
+/// [`DaemonError::InvalidRequest`] for a malformed session id, and
+/// [`DaemonError::OverseerBlocked`] when the overseer vetoes the event (HTTP 403
+/// / `CODE_FORBIDDEN`) — a refusal, never a warning-and-continue.
+///
+/// Test: `parity_hooks_ingest_leaves_the_same_event_log_on_both_transports`,
+/// `parity_hooks_ingest_malformed_id_agrees_across_transports`.
+pub async fn ingest_hook(
+    state: &Arc<DaemonState>,
+    post: HookPost,
+) -> Result<HookAcceptedResponse, DaemonError> {
+    let session = parse_id(&post.session_id)?;
+
+    // Auto-register on SessionStart if not already known. This is how a claude
+    // session connects itself to the daemon: its first hook event registers it
+    // using the incoming UUID, so discovery and `POST /sessions` are not the
+    // only ways a session enters state. The workdir is left empty here and
+    // enriched later by a snapshot or subsequent events.
+    if post.event == HookEvent::SessionStart && state.session(session).is_none() {
+        let mut new_session = Session::new(session, String::new(), ControlModel::Tmux, None);
+        new_session.status = SessionStatus::Active;
+        state.register_session(new_session);
+        tracing::info!("auto-registered session on SessionStart: {session:?}");
+    }
+
+    // #1744: correlate Claude session id → managed session on SessionStart;
+    // immediately mark the managed session Stopped on SessionEnd.
+    if post.event == HookEvent::SessionStart {
+        correlate_session_start(state, &post.session_id, &post.payload).await;
+    }
+    if post.event == HookEvent::SessionEnd {
+        handle_session_end(state, &post.session_id).await;
+    }
+
+    // #2621 (code-critic MEDIUM): the idle-park surface+auto-nudge dispatch
+    // lives inside `HookService::process` (daemon/services/hook_service.rs).
+    match HookService::new(Arc::clone(state)).process(session, post.event, post.payload) {
+        HookDecision::Block { reason } => Err(DaemonError::OverseerBlocked { reason }),
+        _ => Ok(HookAcceptedResponse {
+            accepted: post.event,
+        }),
+    }
+}

--- a/crates/trusty-mpm/src/daemon/rpc/sessions_legacy_tests.rs
+++ b/crates/trusty-mpm/src/daemon/rpc/sessions_legacy_tests.rs
@@ -1,0 +1,1058 @@
+//! Contract tests for the legacy session, hook, and polled-event RPC methods
+//! (#6288 slice 3).
+//!
+//! Why these are PARITY tests rather than "the socket answers 200-shaped JSON":
+//! this slice's whole claim is that a route reached over the socket and the same
+//! route reached over HTTP give the same answer AND leave the same state behind.
+//! A test that only exercises the RPC side proves the method exists; it cannot
+//! fail when the two transports drift, which is the failure the slice exists to
+//! prevent. So every `parity_*` case builds the axum router AND the RPC router
+//! from ONE `Arc<DaemonState>`, issues the equivalent request both ways, and
+//! compares what came back — and, for a write, what the daemon then holds.
+//!
+//! ## Writes are compared by effect, not only by response
+//!
+//! Four routes here mutate. Each has a case that reads the state back:
+//!
+//! - `mpm.hooks.ingest` —
+//!   [`parity_hooks_ingest_leaves_the_same_event_log_on_both_transports`]
+//!   compares the two appended `HookEventRecord`s, and
+//!   [`parity_hooks_session_start_auto_registers_on_both_transports`] compares
+//!   the two auto-registered sessions.
+//! - `mpm.sessions.pause` / `.resume` —
+//!   [`parity_sessions_pause_leaves_the_same_state_on_both_transports`] pauses
+//!   over one transport, reads the session record, resumes, pauses over the
+//!   other, and compares the two records.
+//! - `mpm.sessions.command` —
+//!   [`parity_sessions_command_leaves_the_same_state_on_both_transports`]
+//!   compares the registry snapshot on either side of each call. The write this
+//!   route performs lands in tmux, not in daemon state, so the registry is what
+//!   a hermetic test can observe; the tmux `send-keys` itself is one call in one
+//!   shared body, reached identically from both transports.
+//! - `mpm.sessions.delete` —
+//!   [`parity_sessions_delete_agrees_across_transports`] deletes one of two
+//!   identically-built sessions over each transport and asserts each is gone.
+//! - `mpm.sessions.reap` —
+//!   [`parity_sessions_reap_removes_the_dead_and_spares_the_live_on_both_transports`]
+//!   gives reap one session it must remove and one it must leave, and compares
+//!   both the answer and the surviving registry.
+//!
+//! ## The comparison allowlist
+//!
+//! Fields dropped before a comparison, and why each varies for a reason that is
+//! not the transport:
+//!
+//! - `id` and `name` on `mpm.sessions.register` — a fresh UUID per call, and a
+//!   tmux name derived from it.
+//! - `session_id` on `mpm.sessions.pause` and `at` on an ingested hook record —
+//!   the id of whichever session the case built, and a `Utc::now()` stamp.
+//! - `paused_at` and `last_seen` on a compared `Session` — also
+//!   `SystemTime::now()`, stamped per call.
+//!
+//! Nothing else is excused. Both transports run in one process against one
+//! state, so any other difference would be a real finding.
+//!
+//! ## What is NOT here
+//!
+//! `mpm.sessions.discover` and `mpm.sessions.reap` both shell out to tmux, and
+//! `mpm.sessions.output` / `.pane` capture a pane. The seam every case here uses
+//! is the one the existing HTTP tests use: an empty hermetic registry, so
+//! `TmuxService` resolves no session of its own and returns its documented empty
+//! capture whether or not the host runs tmux. No case starts a tmux session.
+//!
+//! `mpm.sessions.discover` is the one route that still SEES the host's tmux, and
+//! adopts what it sees, so
+//! [`parity_sessions_discover_agrees_across_transports`] drains the host's
+//! sessions with a throwaway call before comparing the two transports on the
+//! drained state. That is what makes it deterministic on a developer machine
+//! running six tmux sessions and in CI running none.
+//!
+//! Test: this file IS the test module for [`super`].
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::{Value, json};
+use tempfile::TempDir;
+use tower::ServiceExt;
+use trusty_common::uds::server::{CODE_INVALID_PARAMS, RpcResponse, RpcRouter};
+
+use super::{METHODS, register};
+use crate::core::paths::FrameworkPaths;
+use crate::core::session::{ControlModel, Session, SessionId, SessionStatus};
+use crate::daemon::api;
+use crate::daemon::error::{CODE_CONFLICT, CODE_NOT_FOUND};
+use crate::daemon::state::DaemonState;
+
+/// One daemon state rooted at an empty temp directory, plus the directory.
+///
+/// Why hermetic: the pause path mirrors its record to disk under the framework
+/// root, and an empty temp root keeps that write off the developer's real
+/// `~/.trusty-mpm`. The caller holds the `TempDir` for the test's life.
+fn hermetic() -> (Arc<DaemonState>, TempDir) {
+    let dir = tempfile::tempdir().expect("temp dir for hermetic DaemonState");
+    let paths = FrameworkPaths::under(dir.path());
+    (Arc::new(DaemonState::with_paths(&paths)), dir)
+}
+
+/// A hermetic state carrying one registered, Active session.
+fn hermetic_with_session() -> (Arc<DaemonState>, SessionId, TempDir) {
+    let (state, dir) = hermetic();
+    let id = register_active(&state, "/tmp/p");
+    (state, id, dir)
+}
+
+/// Register one Active session and return its id.
+///
+/// `project_path` is assigned AFTER construction rather than passed to
+/// `Session::new`, and the distinction matters: the constructor derives
+/// `tmux_name` as `tm-<folder>` from a project directory, so passing `/tmp/p`
+/// would name every fixture session `tm-p` — which tmux prefix-matches to
+/// whatever the developer's host is running, and the pane capture then returns a
+/// real shell instead of the empty string a hermetic case expects. Leaving the
+/// argument `None` keeps the UUID-derived unique name, and the filter case still
+/// gets the `project_path` it needs, since `list_sessions_for_project` reads
+/// that field rather than the `project` label.
+fn register_active(state: &Arc<DaemonState>, project: &str) -> SessionId {
+    let id = SessionId::new();
+    let mut session = Session::new(id, project, ControlModel::Tmux, None);
+    session.project_path = Some(std::path::PathBuf::from(project));
+    session.status = SessionStatus::Active;
+    state.register_session(session);
+    id
+}
+
+/// The RPC router this slice registers, over `state`.
+fn rpc_router(state: &Arc<DaemonState>) -> RpcRouter {
+    register(RpcRouter::new(), state)
+}
+
+/// Drive one HTTP request through the real daemon router and decode the answer.
+///
+/// Why the real router rather than calling a handler directly: the parity claim
+/// is about the ROUTE, so the path, the method, and the extractors all have to
+/// participate. Calling the handler would skip exactly the decoding the socket
+/// has to reproduce.
+async fn http(
+    state: &Arc<DaemonState>,
+    method: &str,
+    uri: &str,
+    body: Option<Value>,
+) -> (StatusCode, Value) {
+    let request = Request::builder().method(method).uri(uri);
+    let request = match body {
+        Some(v) => request
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_vec(&v).expect("encode body")))
+            .expect("build request"),
+        None => request.body(Body::empty()).expect("build request"),
+    };
+
+    let response = api::router(Arc::clone(state))
+        .oneshot(request)
+        .await
+        .expect("the router must answer");
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read the response body");
+    // Not every refusal carries a JSON body: a `StatusCode`-only one is empty,
+    // and axum's own extractor rejection (an unknown `event` name on `/hooks`)
+    // is plain text. Report those as `null` and as a JSON string rather than
+    // failing the decode, so an error-parity case can still see the status.
+    let value = if bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&bytes)
+            .unwrap_or_else(|_| Value::String(String::from_utf8_lossy(&bytes).into_owned()))
+    };
+    (status, value)
+}
+
+/// Dispatch one JSON-RPC call against `router` and return the whole frame.
+async fn rpc_frame(router: &RpcRouter, method: &str, params: Value) -> Value {
+    let frame = json!({ "jsonrpc": "2.0", "id": 1, "method": method, "params": params });
+    let response: RpcResponse = router
+        .dispatch(&serde_json::to_vec(&frame).expect("encode the request frame"))
+        .await;
+    serde_json::to_value(response).expect("the response frame must serialise")
+}
+
+/// The `result` half of a call that must succeed.
+async fn rpc_ok(router: &RpcRouter, method: &str, params: Value) -> Value {
+    let frame = rpc_frame(router, method, params).await;
+    assert!(
+        frame.get("error").is_none(),
+        "{method} must succeed, got {frame}"
+    );
+    frame
+        .get("result")
+        .cloned()
+        .unwrap_or_else(|| panic!("{method} answered no result: {frame}"))
+}
+
+/// The `error` half of a call that must be refused.
+async fn rpc_err(router: &RpcRouter, method: &str, params: Value) -> Value {
+    let frame = rpc_frame(router, method, params).await;
+    frame
+        .get("error")
+        .cloned()
+        .unwrap_or_else(|| panic!("{method} must be refused, got {frame}"))
+}
+
+/// Assert the two transports answered the same JSON for one route.
+///
+/// `drop_fields` is the allowlist this module's doc records.
+fn assert_same(method: &str, mut http_body: Value, mut rpc_result: Value, drop_fields: &[&str]) {
+    for field in drop_fields {
+        if let Some(map) = http_body.as_object_mut() {
+            map.remove(*field);
+        }
+        if let Some(map) = rpc_result.as_object_mut() {
+            map.remove(*field);
+        }
+    }
+    assert_eq!(
+        http_body, rpc_result,
+        "{method} must answer identically over HTTP and the socket"
+    );
+}
+
+/// One session as JSON, with the fields the allowlist excuses removed.
+fn session_json(state: &Arc<DaemonState>, id: SessionId, drop_fields: &[&str]) -> Value {
+    let session = state.session(id).expect("the session must still exist");
+    let mut value = serde_json::to_value(session).expect("a Session must serialise");
+    if let Some(map) = value.as_object_mut() {
+        for field in drop_fields {
+            map.remove(*field);
+        }
+    }
+    value
+}
+
+// ── The method table ─────────────────────────────────────────────────────────
+
+/// Why: the slice-7 client swap will dial these names by literal, with no
+/// compile-time link to this table. Pinning the registered set here turns a
+/// rename into a failing assertion rather than a consumer that silently reports
+/// `method_not_found`.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn rpc_router_registers_every_documented_method() {
+    let (state, _dir) = hermetic();
+    let router = rpc_router(&state);
+    let registered: Vec<&str> = router.method_names().collect();
+
+    let mut documented: Vec<&str> = METHODS.to_vec();
+    documented.sort_unstable();
+
+    assert_eq!(
+        registered, documented,
+        "the router and METHODS must name the same set"
+    );
+    assert_eq!(
+        METHODS.len(),
+        16,
+        "slice 3 owns sixteen names; a new one needs a row in sessions_legacy.rs's table too"
+    );
+}
+
+/// Why: slice 2's twenty methods and slice 3's sixteen mount on ONE router, and
+/// a name collision would silently replace a registration rather than fail.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn slice_two_and_slice_three_methods_do_not_collide() {
+    let (state, _dir) = hermetic();
+    let combined = register(
+        super::super::core::register(RpcRouter::new(), &state),
+        &state,
+    );
+    assert_eq!(
+        combined.method_names().count(),
+        super::super::core::METHODS.len() + METHODS.len(),
+        "a collision would show as a shortfall here"
+    );
+}
+
+/// Why: a method that takes arguments must refuse a payload it cannot decode,
+/// with the reason, rather than running on a default.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn rpc_reports_invalid_params_for_an_undecodable_payload() {
+    let (state, _dir) = hermetic();
+    let error = rpc_err(&rpc_router(&state), "mpm.sessions.get", json!({"id": 42})).await;
+    assert_eq!(error["code"], json!(CODE_INVALID_PARAMS), "{error}");
+}
+
+/// Why: `mpm.sessions.list` decodes `Option<SessionQuery>` so an ABSENT params
+/// object works, and the risk that buys is a payload that is present but wrong
+/// silently collapsing to `None` — the caller would then get every session
+/// rather than an error, which is the worst possible answer to a typo. A wrong
+/// TYPE must still be `invalid_params`.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn rpc_sessions_list_reports_invalid_params_for_a_wrong_typed_filter() {
+    let (state, _dir) = hermetic();
+    register_active(&state, "/tmp/alpha");
+
+    let error = rpc_err(
+        &rpc_router(&state),
+        "mpm.sessions.list",
+        json!({"project": 42}),
+    )
+    .await;
+    assert_eq!(error["code"], json!(CODE_INVALID_PARAMS), "{error}");
+    assert!(
+        error["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("params do not decode"),
+        "the refusal must say what failed, not answer with a list: {error}"
+    );
+}
+
+/// Why: `params` is absent on a well-formed no-argument call, and the polled
+/// feed is the one a script reaches for first.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn rpc_events_poll_answers_with_no_params() {
+    let (state, _dir) = hermetic();
+    let result = rpc_ok(&rpc_router(&state), "mpm.events.poll", Value::Null).await;
+    assert_eq!(result["events"], json!([]), "{result}");
+}
+
+// ── Parity: reads ────────────────────────────────────────────────────────────
+
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_sessions_list_agrees_across_transports() {
+    let (state, _id, _dir) = hermetic_with_session();
+    let (status, body) = http(&state, "GET", "/sessions", None).await;
+    assert_eq!(status, StatusCode::OK);
+    let result = rpc_ok(&rpc_router(&state), "mpm.sessions.list", Value::Null).await;
+    assert_eq!(
+        body["sessions"].as_array().map(Vec::len),
+        Some(1),
+        "the fixture session must be visible: {body}"
+    );
+    assert_same("mpm.sessions.list", body, result, &[]);
+}
+
+/// Why the explicit `?project=`: passing the filter on both sides proves the
+/// ARGUMENT survives the transport change rather than only the default.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_sessions_list_project_filter_agrees_across_transports() {
+    let (state, _dir) = hermetic();
+    register_active(&state, "/tmp/alpha");
+    register_active(&state, "/tmp/beta");
+
+    let (status, body) = http(&state, "GET", "/sessions?project=/tmp/alpha", None).await;
+    assert_eq!(status, StatusCode::OK);
+    let result = rpc_ok(
+        &rpc_router(&state),
+        "mpm.sessions.list",
+        json!({"project": "/tmp/alpha"}),
+    )
+    .await;
+    assert_eq!(
+        body["sessions"].as_array().map(Vec::len),
+        Some(1),
+        "the filter must reach the body: {body}"
+    );
+    assert_same("mpm.sessions.list", body, result, &[]);
+}
+
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_get_session_agrees_across_transports() {
+    let (state, id, _dir) = hermetic_with_session();
+    let (status, body) = http(&state, "GET", &format!("/sessions/{}", id.0), None).await;
+    assert_eq!(status, StatusCode::OK);
+    let result = rpc_ok(
+        &rpc_router(&state),
+        "mpm.sessions.get",
+        json!({"id": id.0.to_string()}),
+    )
+    .await;
+    assert_same("mpm.sessions.get", body, result, &[]);
+}
+
+/// Why: an unknown id is the error class every consumer of this family hits
+/// first, so it must carry the same code and the same message either way
+/// (requirement 3).
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_get_session_unknown_id_agrees_across_transports() {
+    let (state, _dir) = hermetic();
+    let unknown = SessionId::new().0.to_string();
+
+    let (status, body) = http(&state, "GET", &format!("/sessions/{unknown}"), None).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+
+    let error = rpc_err(
+        &rpc_router(&state),
+        "mpm.sessions.get",
+        json!({"id": unknown}),
+    )
+    .await;
+    assert_eq!(error["code"], json!(CODE_NOT_FOUND), "{error}");
+    assert_eq!(
+        error["message"], body["error"],
+        "the socket must carry the HTTP body's message verbatim"
+    );
+}
+
+/// Why: a malformed id is a DIFFERENT class from an unknown one — 400 rather
+/// than 404 — and collapsing the two in the move to the socket would cost the
+/// caller the difference between "retry with a UUID" and "that session is gone".
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_get_session_malformed_id_agrees_across_transports() {
+    let (state, _dir) = hermetic();
+    let (status, body) = http(&state, "GET", "/sessions/not-a-uuid", None).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+
+    let error = rpc_err(
+        &rpc_router(&state),
+        "mpm.sessions.get",
+        json!({"id": "not-a-uuid"}),
+    )
+    .await;
+    assert_eq!(error["code"], json!(CODE_INVALID_PARAMS), "{error}");
+    assert_eq!(error["message"], body["error"], "{error}");
+}
+
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_events_poll_agrees_across_transports() {
+    let (state, _id, _dir) = hermetic_with_session();
+    let (status, body) = http(&state, "GET", "/events/poll", None).await;
+    assert_eq!(status, StatusCode::OK);
+    let result = rpc_ok(&rpc_router(&state), "mpm.events.poll", Value::Null).await;
+    assert_same("mpm.events.poll", body, result, &[]);
+}
+
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_session_events_poll_agrees_across_transports() {
+    let (state, id, _dir) = hermetic_with_session();
+    let (status, body) = http(
+        &state,
+        "GET",
+        &format!("/sessions/{}/events/poll", id.0),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let result = rpc_ok(
+        &rpc_router(&state),
+        "mpm.sessions.events_poll",
+        json!({"id": id.0.to_string()}),
+    )
+    .await;
+    assert_same("mpm.sessions.events_poll", body, result, &[]);
+}
+
+/// Why the explicit `?lines=`: it proves the query argument reaches the body,
+/// and the response echoes it, so a dropped argument fails loudly.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_sessions_output_agrees_across_transports() {
+    let (state, id, _dir) = hermetic_with_session();
+    let (status, body) = http(
+        &state,
+        "GET",
+        &format!("/sessions/{}/output?lines=7", id.0),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let result = rpc_ok(
+        &rpc_router(&state),
+        "mpm.sessions.output",
+        json!({"id": id.0.to_string(), "lines": 7}),
+    )
+    .await;
+    assert_eq!(body["lines"], json!(7), "the argument must reach the body");
+    assert_same("mpm.sessions.output", body, result, &[]);
+}
+
+/// Why: `/sessions/{id}/pane` and `/sessions/{id}/output` are one axum handler
+/// under two paths, and `mpm.sessions.pane` must stay the same alias rather than
+/// quietly becoming a second implementation.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_sessions_pane_matches_output_on_both_transports() {
+    let (state, id, _dir) = hermetic_with_session();
+    let (status, pane_body) = http(&state, "GET", &format!("/sessions/{}/pane", id.0), None).await;
+    assert_eq!(status, StatusCode::OK);
+    let (_, output_body) = http(&state, "GET", &format!("/sessions/{}/output", id.0), None).await;
+    assert_eq!(pane_body, output_body, "the two HTTP paths are one handler");
+
+    let router = rpc_router(&state);
+    let params = json!({"id": id.0.to_string()});
+    let pane = rpc_ok(&router, "mpm.sessions.pane", params.clone()).await;
+    let output = rpc_ok(&router, "mpm.sessions.output", params).await;
+    assert_eq!(pane, output, "the two method names are one body");
+    assert_same("mpm.sessions.pane", pane_body, pane, &[]);
+}
+
+/// Why: an unknown session on the read path must refuse identically, and it is
+/// the deterministic 404 on this route — no tmux involved, the resolve fails
+/// first.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_sessions_output_unknown_agrees_across_transports() {
+    let (state, _dir) = hermetic();
+    let unknown = SessionId::new().0.to_string();
+
+    let (status, body) = http(&state, "GET", &format!("/sessions/{unknown}/output"), None).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+
+    let error = rpc_err(
+        &rpc_router(&state),
+        "mpm.sessions.output",
+        json!({"id": unknown}),
+    )
+    .await;
+    assert_eq!(error["code"], json!(CODE_NOT_FOUND), "{error}");
+    assert_eq!(error["message"], body["error"], "{error}");
+}
+
+/// Why: `discover` and `reap` both shell out to tmux, so what they FIND varies
+/// with the host. What must not vary is that the two transports agree on the
+/// same host in the same process — which is exactly what comparing them here
+/// proves, whatever the machine has running.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_sessions_reap_agrees_across_transports() {
+    let (state, _dir) = hermetic();
+    let (status, body) = http(&state, "DELETE", "/sessions/dead", None).await;
+    assert_eq!(status, StatusCode::OK);
+    let result = rpc_ok(&rpc_router(&state), "mpm.sessions.reap", Value::Null).await;
+    assert_same("mpm.sessions.reap", body, result, &[]);
+}
+
+/// Why the first call is thrown away: discovery ADOPTS what it finds, so on a
+/// machine running tmux the first call reports every live session and the second
+/// reports none — comparing call one against call two would fail for a reason
+/// that is the route's idempotence, not the transport's. Draining first puts
+/// both transports on the same footing, and the comparison then holds on a
+/// machine with tmux and on one without.
+/// Why this is the reap case that matters: the empty-registry case above proves
+/// the two transports agree when there is nothing to do, which a broken
+/// registration would also pass. This one gives reap something to REMOVE and
+/// something it must LEAVE, then runs it once per transport and compares both
+/// the answer and the registry left behind.
+///
+/// The survivor is a `SessionHost::Native` session, not a live tmux one, and
+/// that choice is what keeps the case deterministic: `reap_against` skips every
+/// non-tmux session outright, so the survivor survives on a machine with tmux
+/// and on one without, and no test here has to start a tmux server. The victim
+/// is a tmux-origin session whose UUID-derived name no tmux server is hosting.
+///
+/// Whether the victim is actually removed depends on tmux being reachable —
+/// `SessionService::reap` reaps NOTHING when `TmuxDriver::discover` fails,
+/// deliberately, so that a missing tmux cannot wipe the registry. So the
+/// removal is asserted under that condition and the PARITY is asserted
+/// unconditionally: whatever this host let reap do, both transports did the
+/// same thing.
+///
+/// Why serial: `TmuxDriver::discover` consults the #5784 host-state gate, which
+/// other tests in this binary move process-wide by overriding `$HOME`. One
+/// landing between this test's two calls would let tmux be reachable for one
+/// transport and refused for the other — failing the comparison while proving
+/// nothing about either.
+/// Test: this function IS the test.
+#[serial_test::serial]
+#[tokio::test]
+async fn parity_sessions_reap_removes_the_dead_and_spares_the_live_on_both_transports() {
+    use crate::core::session::SessionHost;
+
+    let (state, _dir) = hermetic();
+    let tmux_reachable = crate::daemon::tmux::TmuxDriver::discover().is_ok();
+
+    // The survivor: native origin, so the tmux liveness rule skips it entirely.
+    let survivor = SessionId::new();
+    let mut native = Session::new(survivor, "/tmp/native", ControlModel::Tmux, None);
+    native.origin = SessionHost::Native;
+    native.status = SessionStatus::Active;
+    state.register_session(native);
+
+    // The victim over HTTP: tmux origin, a name no tmux server hosts.
+    let victim_http = register_active(&state, "/tmp/dead-http");
+    let (status, body) = http(&state, "DELETE", "/sessions/dead", None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        state.session(survivor).is_some(),
+        "a native session is never reaped, whatever tmux says"
+    );
+
+    // The victim over the socket: same shape, same starting registry.
+    let victim_rpc = register_active(&state, "/tmp/dead-rpc");
+    let result = rpc_ok(&rpc_router(&state), "mpm.sessions.reap", Value::Null).await;
+
+    assert_same("mpm.sessions.reap", body, result.clone(), &[]);
+    assert!(
+        state.session(survivor).is_some(),
+        "the socket must spare it too"
+    );
+    if tmux_reachable {
+        assert_eq!(
+            result["removed"],
+            json!(1),
+            "with tmux reachable each transport must reap exactly its own victim: {result}"
+        );
+        assert!(state.session(victim_http).is_none(), "HTTP must reap it");
+        assert!(state.session(victim_rpc).is_none(), "the socket must too");
+        assert_eq!(
+            state.list_sessions().len(),
+            1,
+            "only the native survivor may remain"
+        );
+    } else {
+        assert_eq!(
+            result["removed"],
+            json!(0),
+            "with tmux unreachable neither transport may reap anything: {result}"
+        );
+        assert!(
+            state.session(victim_http).is_some(),
+            "nothing may be reaped"
+        );
+        assert!(state.session(victim_rpc).is_some(), "nor over the socket");
+    }
+}
+
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_sessions_discover_agrees_across_transports() {
+    let (state, _dir) = hermetic();
+    let (drain_status, _drained) = http(&state, "POST", "/sessions/discover", None).await;
+    assert_eq!(drain_status, StatusCode::OK);
+
+    let result = rpc_ok(&rpc_router(&state), "mpm.sessions.discover", Value::Null).await;
+    let (status, body) = http(&state, "POST", "/sessions/discover", None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        result["discovered"],
+        json!(0),
+        "a drained registry must adopt nothing more: {result}"
+    );
+    assert_same("mpm.sessions.discover", body, result, &[]);
+}
+
+// ── Parity: writes, compared by the state they leave behind ──────────────────
+
+/// Why the dropped `id`/`name`: registration mints a fresh UUID per call, and
+/// the tmux name is derived from it. Everything else about the two records —
+/// project, workdir, status, the fact that a record exists at all — is compared.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_sessions_register_agrees_across_transports() {
+    let (state, _dir) = hermetic();
+    let payload = json!({"project": "/tmp/reg", "project_path": null, "name": null});
+
+    let (status, body) = http(&state, "POST", "/sessions", Some(payload.clone())).await;
+    assert_eq!(status, StatusCode::OK);
+    let http_id: SessionId = serde_json::from_value(body["id"].clone()).expect("an id");
+
+    let result = rpc_ok(&rpc_router(&state), "mpm.sessions.register", payload).await;
+    let rpc_id: SessionId = serde_json::from_value(result["id"].clone()).expect("an id");
+
+    assert_same("mpm.sessions.register", body, result, &["id", "name"]);
+    assert_eq!(state.list_sessions().len(), 2, "both writes must land");
+    // The two records must differ only where the allowlist says they may.
+    let drop = ["id", "tmux_name", "created_at", "last_seen"];
+    assert_eq!(
+        session_json(&state, http_id, &drop),
+        session_json(&state, rpc_id, &drop),
+        "the two transports must register the same session shape"
+    );
+}
+
+/// Why `connect` gets its own case: it is a SECOND name over the same body, and
+/// the thing that could break is the wiring, not the body — a `connect` that
+/// registered nothing would still return a plausible id.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_sessions_connect_agrees_across_transports() {
+    let (state, _dir) = hermetic();
+    let payload = json!({"project": "/tmp/conn"});
+
+    let (status, body) = http(
+        &state,
+        "POST",
+        "/api/v1/sessions/connect",
+        Some(payload.clone()),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let result = rpc_ok(&rpc_router(&state), "mpm.sessions.connect", payload).await;
+
+    assert_same("mpm.sessions.connect", body, result, &["id", "name"]);
+    assert_eq!(state.list_sessions().len(), 2, "both writes must land");
+}
+
+/// Why two sessions rather than one deleted twice: the second delete of one
+/// session would be a 404, which proves nothing about whether the FIRST removal
+/// happened the same way. Two identically-built sessions, one deleted per
+/// transport, compares the removal itself.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_sessions_delete_agrees_across_transports() {
+    let (state, _dir) = hermetic();
+    let over_http = register_active(&state, "/tmp/del");
+    let over_rpc = register_active(&state, "/tmp/del");
+
+    let (status, body) = http(
+        &state,
+        "DELETE",
+        &format!("/sessions/{}", over_http.0),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(state.session(over_http).is_none(), "HTTP must remove it");
+
+    let result = rpc_ok(
+        &rpc_router(&state),
+        "mpm.sessions.delete",
+        json!({"id": over_rpc.0.to_string()}),
+    )
+    .await;
+    assert!(state.session(over_rpc).is_none(), "the socket must too");
+    assert_eq!(state.list_sessions().len(), 0, "both removals must land");
+
+    // `removed` echoes the id that was asked for, so only the shape is shared.
+    assert_eq!(body["removed"], json!(over_http.0.to_string()), "{body}");
+    assert_eq!(result["removed"], json!(over_rpc.0.to_string()), "{result}");
+}
+
+/// Why pause-read-resume-pause rather than two sessions: pause derives its
+/// summary from the session it resolves, so running both transports against the
+/// SAME session is the comparison that has no confound. The resume in the middle
+/// puts the session back to where the first pause found it.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_sessions_pause_leaves_the_same_state_on_both_transports() {
+    let (state, id, _dir) = hermetic_with_session();
+    let uri = format!("/sessions/{}/pause", id.0);
+    let payload = json!({"summary": "mid-task"});
+    let drop = ["paused_at", "last_seen"];
+
+    let (status, body) = http(&state, "POST", &uri, Some(payload.clone())).await;
+    assert_eq!(status, StatusCode::OK);
+    let after_http = session_json(&state, id, &drop);
+    assert_eq!(
+        after_http["status"],
+        json!("Paused"),
+        "HTTP must actually pause it: {after_http}"
+    );
+
+    let router = rpc_router(&state);
+    rpc_ok(
+        &router,
+        "mpm.sessions.resume",
+        json!({"id": id.0.to_string()}),
+    )
+    .await;
+    let result = rpc_ok(
+        &router,
+        "mpm.sessions.pause",
+        json!({"id": id.0.to_string(), "summary": "mid-task"}),
+    )
+    .await;
+    let after_rpc = session_json(&state, id, &drop);
+
+    assert_same("mpm.sessions.pause", body, result, &["session_id"]);
+    assert_eq!(
+        after_http, after_rpc,
+        "both transports must leave the same paused session"
+    );
+}
+
+/// Why: resume is the state-clearing half, and a resume that answered `true`
+/// without clearing `pause_summary` would pass a response-only comparison.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_sessions_resume_leaves_the_same_state_on_both_transports() {
+    let (state, id, _dir) = hermetic_with_session();
+    let router = rpc_router(&state);
+    let params = json!({"id": id.0.to_string()});
+    let drop = ["paused_at", "last_seen"];
+
+    rpc_ok(&router, "mpm.sessions.pause", params.clone()).await;
+    let (status, body) = http(&state, "POST", &format!("/sessions/{}/resume", id.0), None).await;
+    assert_eq!(status, StatusCode::OK);
+    let after_http = session_json(&state, id, &drop);
+    assert_eq!(after_http["pause_summary"], json!(null), "{after_http}");
+
+    rpc_ok(&router, "mpm.sessions.pause", params.clone()).await;
+    let result = rpc_ok(&router, "mpm.sessions.resume", params).await;
+    let after_rpc = session_json(&state, id, &drop);
+
+    assert_same("mpm.sessions.resume", body, result, &[]);
+    assert_eq!(
+        after_http, after_rpc,
+        "both transports must leave the same resumed session"
+    );
+}
+
+/// Why: resuming a session that is not paused is the 409 on this family, and a
+/// transport that turned it into a success would silently clear state the
+/// caller never asked to clear.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_sessions_resume_unpaused_agrees_across_transports() {
+    let (state, id, _dir) = hermetic_with_session();
+    let (status, body) = http(&state, "POST", &format!("/sessions/{}/resume", id.0), None).await;
+    assert_eq!(status, StatusCode::CONFLICT);
+
+    let error = rpc_err(
+        &rpc_router(&state),
+        "mpm.sessions.resume",
+        json!({"id": id.0.to_string()}),
+    )
+    .await;
+    assert_eq!(error["code"], json!(CODE_CONFLICT), "{error}");
+    assert_eq!(error["message"], body["error"], "{error}");
+    assert_eq!(
+        state.session(id).expect("still there").status,
+        SessionStatus::Active,
+        "a refused resume must not mutate the session"
+    );
+}
+
+/// Why the registry snapshot rather than a tmux assertion: this route's write
+/// lands in tmux, which a hermetic test has none of. What IS observable is that
+/// neither transport disturbs the registry, and that both return the same
+/// capture — and the tmux `send-keys` they skip is one call in one shared body.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_sessions_command_leaves_the_same_state_on_both_transports() {
+    let (state, id, _dir) = hermetic_with_session();
+    let drop = ["last_seen"];
+    let before = session_json(&state, id, &drop);
+    let payload = json!({"command": "help"});
+
+    let (status, body) = http(
+        &state,
+        "POST",
+        &format!("/sessions/{}/command", id.0),
+        Some(payload),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let after_http = session_json(&state, id, &drop);
+
+    let result = rpc_ok(
+        &rpc_router(&state),
+        "mpm.sessions.command",
+        json!({"id": id.0.to_string(), "command": "help"}),
+    )
+    .await;
+    let after_rpc = session_json(&state, id, &drop);
+
+    assert_same("mpm.sessions.command", body, result, &[]);
+    assert_eq!(before, after_http, "HTTP must not disturb the registry");
+    assert_eq!(after_http, after_rpc, "nor may the socket");
+    assert_eq!(state.list_sessions().len(), 1, "no session may be added");
+}
+
+/// Why: a `Stopped` session is refused BEFORE anything is sent, and that refusal
+/// is the one failure branch on this route that must not become a
+/// warning-and-continue on either transport (the #6288 Fail-Open Check).
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_sessions_command_stopped_agrees_across_transports() {
+    let (state, _dir) = hermetic();
+    let id = SessionId::new();
+    let mut session = Session::new(id, "/tmp/p", ControlModel::Tmux, None);
+    session.status = SessionStatus::Stopped;
+    state.register_session(session);
+
+    let (status, body) = http(
+        &state,
+        "POST",
+        &format!("/sessions/{}/command", id.0),
+        Some(json!({"command": "help"})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT);
+
+    let error = rpc_err(
+        &rpc_router(&state),
+        "mpm.sessions.command",
+        json!({"id": id.0.to_string(), "command": "help"}),
+    )
+    .await;
+    assert_eq!(error["code"], json!(CODE_CONFLICT), "{error}");
+    assert_eq!(error["message"], body["error"], "{error}");
+}
+
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_sessions_set_pid_agrees_across_transports() {
+    let (state, id, _dir) = hermetic_with_session();
+    let uri = format!("/sessions/{}/pid", id.0);
+
+    let (status, body) = http(&state, "PATCH", &uri, Some(json!({"pid": 4242}))).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        state.session(id).expect("still there").pid,
+        Some(4242),
+        "HTTP must record the pid"
+    );
+
+    let result = rpc_ok(
+        &rpc_router(&state),
+        "mpm.sessions.set_pid",
+        json!({"id": id.0.to_string(), "pid": 5353}),
+    )
+    .await;
+    assert_eq!(
+        state.session(id).expect("still there").pid,
+        Some(5353),
+        "the socket must record it too"
+    );
+    assert_same("mpm.sessions.set_pid", body, result, &["pid"]);
+}
+
+/// Why: an unknown id on a WRITE must refuse rather than silently no-op, which
+/// is the failure mode a fail-open transport would introduce.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_sessions_set_pid_unknown_agrees_across_transports() {
+    let (state, _dir) = hermetic();
+    let unknown = SessionId::new().0.to_string();
+
+    let (status, body) = http(
+        &state,
+        "PATCH",
+        &format!("/sessions/{unknown}/pid"),
+        Some(json!({"pid": 1})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+
+    let error = rpc_err(
+        &rpc_router(&state),
+        "mpm.sessions.set_pid",
+        json!({"id": unknown, "pid": 1}),
+    )
+    .await;
+    assert_eq!(error["code"], json!(CODE_NOT_FOUND), "{error}");
+    assert_eq!(error["message"], body["error"], "{error}");
+}
+
+// ── Parity: hook ingestion, compared by the event log ────────────────────────
+
+/// Why the event log rather than the response: `mpm.hooks.ingest` answers with
+/// nothing but the event name it accepted, so a transport that decoded the frame
+/// and then dropped the record would pass a response-only comparison. The two
+/// appended records are what actually prove the write happened twice.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_hooks_ingest_leaves_the_same_event_log_on_both_transports() {
+    let (state, id, _dir) = hermetic_with_session();
+    let payload = json!({
+        "session_id": id.0.to_string(),
+        "event": "PostToolUse",
+        "payload": {"tool": "Edit"},
+    });
+
+    let (status, body) = http(&state, "POST", "/hooks", Some(payload.clone())).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(state.recent_hook_events().len(), 1, "HTTP must append one");
+
+    let result = rpc_ok(&rpc_router(&state), "mpm.hooks.ingest", payload).await;
+    let events = state.recent_hook_events();
+    assert_eq!(events.len(), 2, "the socket must append one too");
+
+    assert_same("mpm.hooks.ingest", body, result, &[]);
+    let mut first = serde_json::to_value(&events[0]).expect("a record must serialise");
+    let mut second = serde_json::to_value(&events[1]).expect("a record must serialise");
+    for value in [&mut first, &mut second] {
+        if let Some(map) = value.as_object_mut() {
+            map.remove("at");
+        }
+    }
+    assert_eq!(
+        first, second,
+        "both transports must append the same record modulo its timestamp"
+    );
+}
+
+/// Why: `SessionStart` for an unknown id AUTO-REGISTERS a session — the daemon's
+/// connection-driven registration path, and the largest side effect on this
+/// slice. A transport that ingested the event without registering would look
+/// identical on the wire.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_hooks_session_start_auto_registers_on_both_transports() {
+    let (state, _dir) = hermetic();
+    let over_http = SessionId::new();
+    let over_rpc = SessionId::new();
+    let event = |id: SessionId| json!({"session_id": id.0.to_string(), "event": "SessionStart", "payload": {}});
+
+    let (status, body) = http(&state, "POST", "/hooks", Some(event(over_http))).await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        state.session(over_http).is_some(),
+        "HTTP must auto-register the session"
+    );
+
+    let result = rpc_ok(&rpc_router(&state), "mpm.hooks.ingest", event(over_rpc)).await;
+    assert!(
+        state.session(over_rpc).is_some(),
+        "the socket must auto-register it too"
+    );
+
+    assert_same("mpm.hooks.ingest", body, result, &[]);
+    let drop = ["id", "tmux_name", "created_at", "last_seen"];
+    assert_eq!(
+        session_json(&state, over_http, &drop),
+        session_json(&state, over_rpc, &drop),
+        "both transports must register the same session shape"
+    );
+}
+
+/// Why: a malformed session id must be refused before anything is appended, on
+/// both transports — a fail-open socket would swallow the id error and leave a
+/// record attributed to nothing.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_hooks_ingest_malformed_id_agrees_across_transports() {
+    let (state, _dir) = hermetic();
+    let payload = json!({"session_id": "not-a-uuid", "event": "PostToolUse", "payload": {}});
+
+    let (status, body) = http(&state, "POST", "/hooks", Some(payload.clone())).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(state.recent_hook_events().len(), 0, "nothing may be logged");
+
+    let error = rpc_err(&rpc_router(&state), "mpm.hooks.ingest", payload).await;
+    assert_eq!(error["code"], json!(CODE_INVALID_PARAMS), "{error}");
+    assert_eq!(error["message"], body["error"], "{error}");
+    assert_eq!(state.recent_hook_events().len(), 0, "still nothing logged");
+}
+
+/// Why: an event name that is not a known `HookEvent` is refused by the DECODER,
+/// which is the one refusal that is genuinely per-transport — axum rejects the
+/// body, and the RPC router rejects the params. Both must still refuse, and
+/// neither may log.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn parity_hooks_ingest_unknown_event_is_refused_on_both_transports() {
+    let (state, id, _dir) = hermetic_with_session();
+    let payload = json!({"session_id": id.0.to_string(), "event": "NotAnEvent", "payload": {}});
+
+    let (status, _body) = http(&state, "POST", "/hooks", Some(payload.clone())).await;
+    assert!(status.is_client_error(), "HTTP must refuse it: {status}");
+
+    let error = rpc_err(&rpc_router(&state), "mpm.hooks.ingest", payload).await;
+    assert_eq!(error["code"], json!(CODE_INVALID_PARAMS), "{error}");
+    assert_eq!(state.recent_hook_events().len(), 0, "nothing may be logged");
+}

--- a/crates/trusty-mpm/src/daemon/socket.rs
+++ b/crates/trusty-mpm/src/daemon/socket.rs
@@ -66,8 +66,10 @@ pub fn socket_path() -> Result<PathBuf> {
 /// `rpc_router_registers_every_documented_method`,
 /// `every_scoped_route_has_a_method`.
 fn build_router(state: &Arc<DaemonState>) -> RpcRouter {
-    // #6288 slice 2: the core request/response families. Slices 3-6 append here.
+    // #6288 slice 2: the core request/response families. Slices 5-6 append here.
     let router = rpc::core::register(RpcRouter::new(), state);
+    // #6288 slice 3: the legacy session registry, hooks, and the polled feeds.
+    let router = rpc::sessions_legacy::register(router, state);
     // #6288 slice 4: managed sessions, the control plane, and the L2 proxy.
     rpc::managed::register(router, state)
 }


### PR DESCRIPTION
Sixteen JSON-RPC methods for the `/sessions*` legacy registry, the `/hooks` relay, and the two `/events/poll` legs, mounted on the Unix socket slice 1 bound. The route bodies move into `daemon::rpc::sessions_legacy_ops` and the axum handlers delegate to them, so one route has one implementation across both transports and the HTTP surface is unchanged.

Slice 3 of the #6288 plan, rebased onto `main` now that slice 2 (#6346) has merged. The SSE streams `/events` and `/sessions/{id}/events` stay HTTP-only; slice 6 owns them.

Refs #6288

## Method → route

| Method | HTTP route |
|---|---|
| `mpm.sessions.list` | `GET /sessions` |
| `mpm.sessions.register` | `POST /sessions` |
| `mpm.sessions.connect` | `POST /api/v1/sessions/connect` |
| `mpm.sessions.discover` | `POST /sessions/discover` |
| `mpm.sessions.reap` | `DELETE /sessions/dead` |
| `mpm.sessions.get` | `GET /sessions/{id}` |
| `mpm.sessions.delete` | `DELETE /sessions/{id}` |
| `mpm.sessions.pause` | `POST /sessions/{id}/pause` |
| `mpm.sessions.resume` | `POST /sessions/{id}/resume` |
| `mpm.sessions.command` | `POST /sessions/{id}/command` |
| `mpm.sessions.output` | `GET /sessions/{id}/output` |
| `mpm.sessions.pane` | `GET /sessions/{id}/pane` |
| `mpm.sessions.set_pid` | `PATCH /sessions/{id}/pid` |
| `mpm.sessions.events_poll` | `GET /sessions/{id}/events/poll` |
| `mpm.events.poll` | `GET /events/poll` |
| `mpm.hooks.ingest` | `POST /hooks` |

`mpm.sessions.reap` is one name beyond the twelve the slice brief enumerated. It is a `/sessions*` legacy-registry route that no other slice owns, so leaving it out would strand it between slices — flagged here rather than absorbed silently.

## Fail-Open Check

Every failure branch in the delta errors out the same way on both transports; none became a warning-and-continue. Each is asserted by a named test, and each asserts the socket's error code AND that its message is the HTTP body's message verbatim:

| Failure branch | Test |
|---|---|
| Hook write, malformed session id | `parity_hooks_ingest_malformed_id_agrees_across_transports` — also asserts the event log stayed empty on both paths |
| Hook write, unknown event name | `parity_hooks_ingest_unknown_event_is_refused_on_both_transports` |
| Registry mutation, unknown id (`set_pid`) | `parity_sessions_set_pid_unknown_agrees_across_transports` |
| Registry read, unknown id | `parity_get_session_unknown_id_agrees_across_transports` |
| Registry read, malformed id (400, not 404) | `parity_get_session_malformed_id_agrees_across_transports` |
| Resume of a session that is not paused (409) | `parity_sessions_resume_unpaused_agrees_across_transports` — also asserts a refused resume mutates nothing |
| Command to a stopped session (409) | `parity_sessions_command_stopped_agrees_across_transports` |
| Pane capture for an unknown session | `parity_sessions_output_unknown_agrees_across_transports` |
| A present-but-wrong-typed list filter (must not collapse to "return everything") | `rpc_sessions_list_reports_invalid_params_for_a_wrong_typed_filter` |

The three best-effort steps that are *deliberately* allowed to fail without failing the call — the tmux kill and managed-store reconcile behind `delete`, the pause-file write, and the tmux `send-keys` behind `command` — are swallowed inside the one shared body rather than in either handler, so neither transport can acquire a laxer policy than the other. `rpc/sessions_legacy_ops.rs`'s module doc records that explicitly.

## Write parity is by observed effect, not by response

Four routes mutate; each has a case that reads the daemon's state back rather than only comparing JSON:

- `mpm.hooks.ingest` — `parity_hooks_ingest_leaves_the_same_event_log_on_both_transports` compares the two appended `HookEventRecord`s (modulo `at`), and `parity_hooks_session_start_auto_registers_on_both_transports` compares the two auto-registered sessions.
- `mpm.sessions.pause` / `.resume` — `parity_sessions_pause_leaves_the_same_state_on_both_transports` and `..._resume_...` pause over one transport, read the record, reset, repeat over the other, and compare.
- `mpm.sessions.command` — `parity_sessions_command_leaves_the_same_state_on_both_transports` compares the registry snapshot on either side of each call. This route's write lands in tmux, not in daemon state, so the registry is what a hermetic test can observe.
- `mpm.sessions.delete` — `parity_sessions_delete_agrees_across_transports` deletes one of two identically-built sessions over each transport and asserts each is gone.
- `mpm.sessions.reap` — `parity_sessions_reap_removes_the_dead_and_spares_the_live_on_both_transports` gives reap one session it must remove and one it must leave, runs it once per transport, and compares both the answer and the surviving registry. The survivor is a `SessionHost::Native` session rather than a live tmux one: `reap_against` skips every non-tmux session outright, so it survives with or without tmux and no test has to start a tmux server. Whether the victim is actually removed depends on tmux being reachable — `SessionService::reap` deliberately reaps nothing when `TmuxDriver::discover` fails, so a missing tmux cannot wipe the registry — so the removal is asserted under that condition while the parity is asserted unconditionally.

## Guard parity for `/hooks`

`/hooks` carries no guard beyond the router-wide `guard_write_origin` layer — `git grep` over the crate finds no hook token, shared secret, or per-route loopback check, and the forwarder shim posts a bare JSON body. That guard is CSRF defence: it inspects the `Origin` header and allows any request carrying none, which is every server-side caller, so it authenticates nobody. The socket runs `ensure_peer_is_self` on every accepted connection before a byte is read, over a `0600` socket in a `0700` directory, which authenticates the calling process's uid. Nothing is dropped by moving across, and the peer-uid check refuses callers the origin guard would have waved through. The overseer veto is not a transport guard at all — it lives in the shared body and fires identically either way.

## No live-tmux dependency in tests

`mpm.sessions.discover` is the one route that sees the host's tmux and adopts what it sees, so its parity case drains with a throwaway call before comparing the two transports on the drained state. Every other case uses the seam the existing HTTP tests use — an empty hermetic registry with a UUID-derived tmux name, so `TmuxService` resolves nothing and returns its documented empty capture. Both points are recorded in the test module's doc, along with why the `register_active` fixture assigns `project_path` after construction rather than passing the project dir to `Session::new` (which would derive `tm-p` and let tmux prefix-match a live session on a developer machine).

## Rung 4 gates

Re-run in full after the rebase onto `main`:

```
cargo fmt --check                                       → exit 0
cargo check -p trusty-mpm --all-targets                 → exit 0
cargo clippy -p trusty-mpm --all-targets -- -D warnings → exit 0
cargo check --workspace                                 → exit 0
cargo test -p trusty-mpm --no-fail-fast                 → exit 0
  lib: test result: ok. 5358 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out
  52 targets total, every one `test result: ok`, 0 `test result: FAILED`
bash scripts/check_line_cap.sh        → 4223 files, 4 allowlisted, 0 violations — OK
bash scripts/check_changelog_fragment.sh → OK trusty-mpm
bash scripts/check_test_pointers.sh   → resolved 27109 Test: citation(s) (floor 5000) — 0 dangling pointers — OK
```

32 tests in `daemon::rpc::sessions_legacy::tests`. `api.rs` shrank by roughly 152 code lines and stays under its frozen 1176-SLOC ratchet budget.

The `PR version bump vs crates.io` check is expected RED until #6349 lands on `main` with the trusty-mpm 1.5.8 bump. No version is bumped here.

### Critic round (review 5051402721)

- HIGH — `set_session_pid` cited `set_session_pid_records_pid`, which the pointer lint grandfathers only for `api.rs`. It now cites `parity_sessions_set_pid_unknown_agrees_across_transports`. The unscoped run surfaced a second dangling pointer the review had not reached: `sessions_legacy_ops.rs`'s module doc cited `super::sessions_legacy_tests`, and the module is declared as `mod tests`. It now names four real `parity_*` tests, matching what slice 2 did to `core_ops.rs` in `1af1977a6`.
- MEDIUM — reap parity now has a live/dead case (above).
- MEDIUM — malformed `mpm.sessions.list` params now assert `-32602` (above).
- LOW (tmux prefix-match avoided by convention only) — tracked on #6348, no change here.

Seven of these tests failed on their first run and each fix was a real finding, not a loosened assertion: `SessionQuery` refuses a `null` params object (`mpm.sessions.list` now decodes `Option<SessionQuery>`); `list_sessions_for_project` filters on `project_path`, which the fixture was not setting; `SessionStatus` serialises capitalised; the per-call clock field is `last_seen`; discovery adopts what it finds so a second call reports nothing; and axum's own extractor rejection carries a plain-text body the test helper could not decode.

## Files outside the slice-3 set

`daemon/api/session_start_correlation.rs` — the module and its two hook handlers go from `pub(super)` to `pub(crate)` so the shared `ingest_hook` body can reach them from `daemon::rpc`. Visibility only, no logic change. It is a sub-file of `api.rs`, which this slice owns, and is claimed by no other in-flight branch.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
