### PR TITLE
refactor(trusty-analyze): run on demand behind the socket; no resident daemon (Refs #6350)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6519,7 +6519,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11239,7 +11239,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-analyze"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11507,7 +11507,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-console"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -11610,7 +11610,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-installer"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,14 +166,14 @@ trusty-review = { path = "crates/trusty-review", version = "0.29", default-featu
 # (de-bundled from the host crates for single-owner-per-binary). It is still a
 # published library crate; the path entry remains so any local lib consumers
 # resolve in-tree.
-trusty-console = { path = "crates/trusty-console", version = "0.7.0" }
+trusty-console = { path = "crates/trusty-console", version = "0.8.0" }
 # trusty-progress: shared rustup/cargo-style progress + status display (#1315).
 # Consumed by trusty-installer for install/upgrade component rows; published library crate.
 trusty-progress = { path = "crates/trusty-progress", version = "0.3.0" }
 # trusty-installer: consumed as a LIBRARY by trusty-audit for the pinned,
 # fail-closed prebuilt download entry point (#5491, #5495). trusty-audit is
 # `publish = false`, so this entry exists for in-tree resolution.
-trusty-installer = { path = "crates/trusty-installer", version = "0.12" }
+trusty-installer = { path = "crates/trusty-installer", version = "0.13" }
 # trusty-audit: consumed as a LIBRARY by the auditor client's Tauri shell
 # (`trusty-audit-ui`, #5477 phase 1), which calls `Session::execute` in-process
 # rather than serving HTTP or shelling out to the `taudit` binary — DOC-68 §11

--- a/crates/trusty-analyze/Cargo.toml
+++ b/crates/trusty-analyze/Cargo.toml
@@ -5,7 +5,7 @@ name        = "trusty-analyze"
 # position. `core::redb_open::is_format_obsolete` keeps its name and signature
 # and delegates its body to `trusty_common::redb_open::is_incompatible_format`;
 # no public item is added, removed, or changed shape.
-version     = "0.12.1"
+version     = "0.12.2"
 edition     = "2021"
 license.workspace    = true
 authors.workspace    = true
@@ -92,7 +92,7 @@ mime_guess         = { workspace = true }
 # `webhook-relay` (#5182): the console->target relay wire contract AND its
 # receive half — the durable inbox, the listener, and the hardened UDS bind
 # this crate mounts in `webhook_listener`. Implies `uds` and `webhook-hmac`.
-trusty-common      = { workspace = true, features = ["symgraph", "cli-help", "update-check", "bedrock", "console-metrics", "config-cli", "webhook-relay", "redb-open"] }  # `redb-open` (#5063): the workspace's single redb corruption classifier, which `core::redb_open` delegates to
+trusty-common      = { workspace = true, features = ["symgraph", "cli-help", "update-check", "bedrock", "console-metrics", "config-cli", "webhook-relay", "uds-supervisor", "redb-open"] }  # `redb-open` (#5063): the workspace's single redb corruption classifier, which `core::redb_open` delegates to; `uds-supervisor` (#6350): the shared on-demand entry point every analyze client starts this server through
 trusty-mcp         = { workspace = true }  # daemon-bridge startup guard (ADR-0040, #5803)
 tree-sitter            = { workspace = true }
 tree-sitter-rust       = { workspace = true }
@@ -180,6 +180,12 @@ features = ["http-server"]
 
 [dev-dependencies]
 tempfile       = { workspace = true }
+# #6350: `tests/on_demand.rs` stands up a stub trusty-search `/health`. It has
+# to be axum rather than a hand-written HTTP/1.1 responder because
+# `core::client::TrustySearchClient` builds its reqwest client with
+# `http2_prior_knowledge()` — a raw HTTP/1.1 reply is never read. `axum::serve`
+# runs hyper's auto Builder, which answers the h2c preface.
+axum           = { workspace = true }
 tower          = { workspace = true }
 http-body-util = { workspace = true }
 # docgen (#5205 follow-up): `tests/generated_docs.rs` renders the MCP tool
@@ -203,6 +209,12 @@ trusty-common     = { workspace = true, features = ["docgen"] }
 # Svelte UI, so `cargo test -p trusty-analyze` now needs pnpm on PATH. Without
 # it, set `SKIP_UI_BUILD=1` — the build script's documented escape hatch, and
 # what CI uses.
+# #6350: `tests/on_demand.rs` drives the REAL review adapter against a real
+# server to prove it respawns one that idled out mid-report. The adapter lives
+# in trusty-review and the binary lives here, so this is the only crate where
+# both halves are in scope. Path-only for the same publish-ordering reason the
+# four above are.
+trusty-review    = { path = "../trusty-review", default-features = false, features = ["report"] }
 trusty-console   = { path = "../trusty-console" }
 trusty-installer = { path = "../trusty-installer" }
 tga              = { path = "../trusty-git-analytics" }

--- a/crates/trusty-analyze/README.md
+++ b/crates/trusty-analyze/README.md
@@ -106,15 +106,46 @@ Homebrew provides:
 # trusty-search must be running first (hard runtime dependency)
 trusty-search start
 
-# Run the analyzer sidecar
-trusty-analyze serve --search-url http://127.0.0.1:7878
-
-# Analyze a named index
+# Analyze a named index — the server starts itself if it is not up
 trusty-analyze analyze <index-id> --top-k 20
 
 # Check liveness
 trusty-analyze health
 ```
+
+### Running the server (#6350)
+
+**You normally do not.** trusty-analyze runs ON DEMAND: `trusty-analyze deep`,
+`trusty-review report --analyze`, and `tctl up` each start it if nothing is
+serving its socket, and it exits after ten minutes with no traffic. There is no
+LaunchAgent and no `service install` — installing the binary is the whole setup.
+
+Run it in the foreground only when you want to watch it:
+
+```bash
+trusty-analyze serve --search-url http://127.0.0.1:7878
+```
+
+Two environment variables govern the lifecycle:
+
+| Variable | Effect |
+|---|---|
+| `TRUSTY_ANALYZE_IDLE_TIMEOUT_SECS` | Idle window in seconds. `0` disables the idle exit. Default `600`. |
+| `TRUSTY_ANALYZE_EXTERNAL=1` | Clients never start a server; they dial whatever you are running. |
+
+**Migrating off the old daemon.** Every machine that installed trusty-analyze
+before this change has `com.trusty.analyze` loaded, and upgrading the binary
+does not unload it. Evict it once:
+
+```bash
+trusty-analyze service uninstall
+```
+
+`trusty-analyze setup daemon`, `tctl install` and `tctl upgrade` run the same
+eviction, so you get it either way. `tctl` drives it through the shared
+`RETIRED_SERVICES` registry — the same pass that clears the retired
+`com.trusty.review` unit — and a unit that will not go down fails that member's
+install or upgrade rather than passing quietly.
 
 ### Ops health check
 

--- a/crates/trusty-analyze/changelog.d/6350-retirement-reports-a-surviving-plist.md
+++ b/crates/trusty-analyze/changelog.d/6350-retirement-reports-a-surviving-plist.md
@@ -1,0 +1,13 @@
+Fixed
+- `trusty-analyze service uninstall` reports a unit it could not clear and exits
+  non-zero. It used to fold "no plist" and "removal failed" into one `false`, so
+  a surviving file rendered as evicted or absent and the command exited 0 while
+  launchd still reloaded the unit at next login. It now delegates the eviction
+  to `LaunchdConfig::evict_legacy_detailed` — the workspace's one
+  implementation, which also verifies launchd actually let go rather than
+  trusting `bootout`'s exit code — and reports its `EvictionOutcome` per label
+  (#6350).
+- `--help` no longer advertises `service install`, `service status` and
+  `service logs`; all three were removed from the CLI and each exited 2. The
+  retired-`--port` warning points at `service uninstall` rather than the
+  `service install` that no longer exists (#6350).

--- a/crates/trusty-analyze/changelog.d/6350-run-on-demand.md
+++ b/crates/trusty-analyze/changelog.d/6350-run-on-demand.md
@@ -1,0 +1,11 @@
+Changed
+- trusty-analyze runs on demand instead of as a resident daemon. `serve` now
+  exits after ten minutes with no traffic (`TRUSTY_ANALYZE_IDLE_TIMEOUT_SECS`
+  overrides it; `0` disables the exit), unlinking its socket on the way out, and
+  `trusty-analyze deep` starts the server itself rather than failing when
+  nothing is listening (#6350).
+- `trusty-analyze service install`, `service status` and `service logs` are
+  removed — no LaunchAgent is installed any more. `service uninstall` remains as
+  the migration: it unloads `com.trusty.analyze` and its legacy alias and deletes
+  their plists. `setup daemon` runs the same eviction before doing anything else,
+  so an upgrade moves off the resident unit without an explicit command (#6350).

--- a/crates/trusty-analyze/changelog.d/6350-run-on-demand.md
+++ b/crates/trusty-analyze/changelog.d/6350-run-on-demand.md
@@ -4,6 +4,10 @@ Changed
   overrides it; `0` disables the exit), unlinking its socket on the way out, and
   `trusty-analyze deep` starts the server itself rather than failing when
   nothing is listening (#6350).
+  - `serve --mcp` is the exception and serves until it is signalled. The stdio
+    loop that process runs dials the socket once per tool call and never
+    respawns it, so an idle exit would strand a live MCP session with a
+    transport error for the rest of its life (#6355).
 - `trusty-analyze service install`, `service status` and `service logs` are
   removed — no LaunchAgent is installed any more. `service uninstall` remains as
   the migration: it unloads `com.trusty.analyze` and its legacy alias and deletes

--- a/crates/trusty-analyze/help.yaml
+++ b/crates/trusty-analyze/help.yaml
@@ -142,17 +142,14 @@ commands:
     args: [shell]
     examples:
       - cmd: trusty-analyze completions zsh > ~/.zsh/completions/_trusty-analyze
+  # 6350: trusty-analyze installs no LaunchAgent. `install`, `status` and `logs`
+  # are gone from clap, so advertising them here rendered three --help rows that
+  # each exit 2.
   service:
-    description: Manage the macOS launchd LaunchAgent
+    description: Migrate off the retired macOS launchd LaunchAgent
     subcommands:
-      install:
-        description: Install and start as a launchd service
       uninstall:
-        description: Stop and uninstall the service
-      status:
-        description: Show service status
-      logs:
-        description: Tail service logs
+        description: Unload and delete the retired LaunchAgent, if one is installed
   setup:
     description: Configure integrations (Claude Code, Cursor, claude-mpm)
     subcommands:
@@ -162,8 +159,9 @@ commands:
         description: Write .cursor/mcp.json
       claude-mpm:
         description: Wire into claude-mpm
+      # 6350: no plist is installed any more — see the `service` block above.
       daemon:
-        description: Install the launchd plist
+        description: Evict the retired LaunchAgent and prove the on-demand start works
       all:
         description: Run every setup target
   review-pr:

--- a/crates/trusty-analyze/src/commands/run.rs
+++ b/crates/trusty-analyze/src/commands/run.rs
@@ -20,7 +20,7 @@ use trusty_analyze::core::FactStore;
 use trusty_analyze::core::TrustySearchClient;
 use trusty_analyze::core::{overlay_path_beside_facts, ScipOverlayStore};
 use trusty_analyze::mcp::AnalyzerMcpServer;
-use trusty_analyze::service::{serve, AnalyzerAppState};
+use trusty_analyze::service::{serve_on_demand, AnalyzerAppState};
 
 /// Output format for the `review`, `deep`, and `review-pr` subcommands.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
@@ -118,7 +118,7 @@ pub async fn run_serve(
         // pointed at the same path rather than at a second transport.
         let socket_for_daemon = socket.clone();
         let daemon = tokio::spawn(async move {
-            if let Err(e) = serve(state, &socket_for_daemon).await {
+            if let Err(e) = serve_on_demand(state, &socket_for_daemon).await {
                 tracing::error!("trusty-analyze daemon exited: {e:#}");
             }
         });
@@ -126,7 +126,7 @@ pub async fn run_serve(
         daemon.abort();
         result
     } else {
-        serve(state, &socket).await
+        serve_on_demand(state, &socket).await
     }
 }
 
@@ -148,13 +148,26 @@ pub async fn run_serve(
 /// When the socket cannot be dialled, when the daemon answers with a JSON-RPC
 /// error, or when the report does not decode.
 ///
-/// Test: `run_deep_reports_an_absent_socket`.
+/// #6350: the socket is no longer assumed to be served. `ensure_running` starts
+/// `trusty-analyze serve` when nothing is there and returns immediately when
+/// something is, so `deep` works with no daemon installed and never starts a
+/// second one beside a live server. Its failure is reported, not degraded —
+/// there is no offline deep-analysis path to fall back to.
+///
+/// Test: `run_deep_reports_an_absent_socket`; the start itself is
+/// `tests/on_demand.rs`' `two_concurrent_callers_share_one_server`.
 pub async fn run_deep(
     index_id: String,
     model: Option<String>,
     format: OutputFormat,
     socket: &Path,
 ) -> Result<()> {
+    // #6350: start the server before dialling it.
+    trusty_common::uds::OnDemandAnalyze::at(socket)
+        .ensure_running()
+        .await
+        .with_context(|| format!("start trusty-analyze on demand for {}", socket.display()))?;
+
     let mut params = serde_json::json!({ "index_id": index_id });
     if let Some(m) = model.as_deref() {
         params["model"] = serde_json::Value::String(m.to_string());
@@ -277,14 +290,29 @@ mod tests {
     /// could not do.
     /// What: points `run_deep` at a path in an empty temp dir and asserts the
     /// error names it.
+    ///
+    /// #6350: `TRUSTY_ANALYZE_EXTERNAL=1` is set for the duration, and it is
+    /// load-bearing twice over. `run_deep` now starts the server before
+    /// dialling, so without the opt-out this test would spawn a real
+    /// `trusty-analyze` on any machine that has one installed, wait out the
+    /// 20-second spawn budget, and then assert against a spawn error instead of
+    /// the dial error it exists to prove. With the opt-out the client dials
+    /// whatever is there and nothing is — which is exactly the arrangement an
+    /// operator running their own server has. The START failure is covered
+    /// separately, against a real binary, in `tests/on_demand.rs`.
     /// Test: this is the test.
+    #[serial_test::serial]
     #[tokio::test]
     async fn run_deep_reports_an_absent_socket() {
         let tmp = tempfile::TempDir::new().expect("tempdir");
         let socket = tmp.path().join("absent.sock");
-        let err = run_deep("idx".into(), None, OutputFormat::Json, &socket)
-            .await
-            .expect_err("an absent socket cannot answer");
+        // SAFETY: `#[serial]` keeps every other test in this binary off the
+        // environment for the duration, which is the precondition `set_var` /
+        // `remove_var` carry in edition 2024.
+        unsafe { std::env::set_var(trusty_common::uds::ANALYZE_EXTERNAL_ENV, "1") };
+        let result = run_deep("idx".into(), None, OutputFormat::Json, &socket).await;
+        unsafe { std::env::remove_var(trusty_common::uds::ANALYZE_EXTERNAL_ENV) };
+        let err = result.expect_err("an absent socket cannot answer");
         let rendered = format!("{err:#}");
         assert!(
             rendered.contains(&socket.display().to_string()),

--- a/crates/trusty-analyze/src/commands/run.rs
+++ b/crates/trusty-analyze/src/commands/run.rs
@@ -20,7 +20,7 @@ use trusty_analyze::core::FactStore;
 use trusty_analyze::core::TrustySearchClient;
 use trusty_analyze::core::{overlay_path_beside_facts, ScipOverlayStore};
 use trusty_analyze::mcp::AnalyzerMcpServer;
-use trusty_analyze::service::{serve_on_demand, AnalyzerAppState};
+use trusty_analyze::service::{serve, serve_on_demand, AnalyzerAppState};
 
 /// Output format for the `review`, `deep`, and `review-pr` subcommands.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
@@ -40,6 +40,11 @@ pub enum OutputFormat {
 /// on a missing OpenRouter key, then binds the socket (with an inline MCP stdio
 /// loop when `mcp` is set).
 ///
+/// The two branches serve with DIFFERENT lifetimes and that is the point: the
+/// bare `serve` path reclaims itself after an idle window (#6350), while the
+/// `--mcp` path serves until it is signalled, because the socket is dialled by
+/// the stdio loop this same process runs (#6355). See the branch comment below.
+///
 /// #6287: `--mcp-port`, and the axum MCP HTTP/SSE server it started, are gone.
 /// ADR-0032 leaves `trusty-console` as the workspace's only HTTP surface, so a
 /// remote MCP client reaches this dispatcher through the console rather than
@@ -54,6 +59,8 @@ pub enum OutputFormat {
 ///
 /// Test: run `trusty-analyze serve` without trusty-search running and verify
 /// exit code 1; with it running the daemon binds and answers `analyze.health`.
+/// The `--mcp` branch's lifetime is pinned by `tests/on_demand.rs`'
+/// `an_mcp_session_outlives_the_idle_window`.
 pub async fn run_serve(
     search: TrustySearchClient,
     facts_path: PathBuf,
@@ -116,9 +123,20 @@ pub async fn run_serve(
         // Run both: the daemon in a task, MCP stdio in the foreground. The
         // dispatcher dials the socket this process is about to bind, so it is
         // pointed at the same path rather than at a second transport.
+        //
+        // #6355: `serve`, not `serve_on_demand`. The idle window belongs to a
+        // server nobody owns — one a client started and walked away from. This
+        // process owns its own lifetime: its real job is the stdio loop below,
+        // and `mcp::rpc_client::call` dials this socket once per tool call with
+        // no respawn. An idle exit would unlink the socket while the stdio loop
+        // is still connected to its client over stdin/stdout, and every later
+        // tool call would answer `isError` with a transport failure for the rest
+        // of the process's life. `serve` ends on SIGTERM/SIGINT, which is the
+        // lifetime the loop below already has. `serve_with_idle`'s doc comment
+        // in `service/rpc.rs` states the same invariant from the other side.
         let socket_for_daemon = socket.clone();
         let daemon = tokio::spawn(async move {
-            if let Err(e) = serve_on_demand(state, &socket_for_daemon).await {
+            if let Err(e) = serve(state, &socket_for_daemon).await {
                 tracing::error!("trusty-analyze daemon exited: {e:#}");
             }
         });

--- a/crates/trusty-analyze/src/commands/service.rs
+++ b/crates/trusty-analyze/src/commands/service.rs
@@ -76,6 +76,17 @@ pub fn run_service_action(action: ServiceAction) -> Result<()> {
 /// Why a struct rather than four returns: the exit decision and the operator's
 /// remediation text are one verdict, and a caller that could take the lines
 /// without the `failed` flag is the fail-open shape this exists to prevent.
+///
+/// `cfg_attr(not(macos), allow(dead_code))`: the only non-test caller is
+/// [`service_uninstall`], and launchd is macOS-only, so off macOS that caller is
+/// configured out. This module is private to the `trusty-analyze` BIN target, so
+/// in a non-test Linux build nothing constructs `Rendered` and `dead_code` fires
+/// under CI's `-D warnings` (#6355) — while a macOS `cargo clippy` stays green
+/// and never shows it. The item is not dead, it is platform-conditional: the
+/// renderer is pure precisely so the tests below prove the fail-closed contract
+/// on every platform. Same reasoning and same attribute as `trusty-installer`'s
+/// `verify_launchd_state::LaunchdList`.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct Rendered {
     /// Lines for stdout — what was cleared.
@@ -106,6 +117,10 @@ pub struct Rendered {
 /// Test: `render_reports_a_cleared_unit`, `render_is_silent_for_an_absent_unit`,
 /// `render_fails_closed_on_a_unit_that_would_not_go`,
 /// `render_fails_even_when_another_label_was_cleared`.
+///
+/// `cfg_attr(not(macos), allow(dead_code))`: see [`Rendered`] — off macOS the
+/// one non-test caller is configured out (#6355).
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 #[must_use]
 pub fn render_evictions(evictions: &[LabelEviction]) -> Rendered {
     let mut r = Rendered::default();

--- a/crates/trusty-analyze/src/commands/service.rs
+++ b/crates/trusty-analyze/src/commands/service.rs
@@ -1,58 +1,62 @@
-//! Handler for `trusty-analyzer service` (macOS launchd integration).
+//! Handler for `trusty-analyze service` — retiring the launchd unit (#6350).
 //!
-//! Mirrors the trusty-search service layout: a thin platform-gated dispatcher
-//! that maps each `ServiceAction` to a single launchd operation via the shared
-//! `trusty_common::launchd` module. On non-macOS targets the entry point
-//! prints a clear message and exits 1.
+//! Why this file no longer installs anything: ADR-0032 makes trusty-analyze an
+//! on-demand service. Clients start it through
+//! `trusty_common::uds::OnDemandAnalyze` and it exits on its own idle window, so
+//! a `KeepAlive: Always` LaunchAgent would fight that directly — launchd would
+//! restart the process the moment it reclaimed itself, and the machine would be
+//! back to a resident daemon with an idle timer it can never honour.
+//!
+//! What survives is the half a migration needs. Every host that ran the previous
+//! installer has `com.trusty.analyze` loaded RIGHT NOW; upgrading the binary
+//! does not unload it. `service uninstall` is the operator-typed escape hatch
+//! that evicts it — `tctl install` and `tctl upgrade` do the same thing
+//! unattended, through the same `RETIRED_SERVICES` registry, for the hosts
+//! where nobody types anything.
+//!
+//! The eviction itself is NOT implemented here. `LaunchdConfig::evict_legacy_detailed`
+//! is the workspace's one implementation (#6290): it boots a label out only when
+//! it is actually loaded, VERIFIES launchd let go rather than trusting
+//! `bootout`'s exit code, then deletes the plist — and reports each label as
+//! `EvictionOutcome::{Evicted, Absent, Failed}`. This file decides what to
+//! PRINT and whether to exit non-zero, which is the only part that is
+//! trusty-analyze's own.
+//!
+//! Test: [`render_evictions`] is pure and platform-independent, so the
+//! fail-closed contract is proven on Linux CI without unloading a developer's
+//! real units.
 
 use anyhow::Result;
 use colored::Colorize;
+use trusty_common::launchd_labels::{EvictionOutcome, LabelEviction};
 
-/// Reverse-DNS label for the LaunchAgent. Used as the plist filename and the
-/// `Label` key — both must match for `launchctl` lookups to work.
+/// Subcommand actions for `trusty-analyze service`.
 ///
-/// #4868: value unchanged; read from the canonical registry rather than
-/// restated, so the installer's copy of it cannot drift away independently.
-#[cfg(target_os = "macos")]
-const LAUNCHD_LABEL: &str = trusty_common::launchd_labels::ANALYZE;
-
-/// Subcommand actions for `trusty-analyzer service`.
-///
-/// Why: launchd is the canonical way to keep a long-lived foreground service
-/// alive on macOS — wrapping plist mechanics in `service` subcommands keeps
-/// users from having to hand-edit XML.
-/// What: each variant maps to one launchd operation (or `tail -F` for Logs).
-/// Test: `cargo run -- service --help` lists the four actions; on Linux,
-/// any action prints "not supported" and exits 1.
+/// Why only one variant (#6350): `install`, `status` and `logs` all described a
+/// resident launchd unit. There is none — `install` would create the very thing
+/// ADR-0032 removed, and `status`/`logs` would report on a job launchd does not
+/// have and a log directory nothing writes. `trusty-analyze status` answers the
+/// question those two were used for, against the socket rather than launchd.
+/// What: `Uninstall` is the migration path off a previously-installed unit.
+/// Test: on Linux the action prints "not supported" and exits 1.
 #[derive(Debug, Clone)]
 pub enum ServiceAction {
-    /// Install the LaunchAgent plist and load it.
-    Install,
-    /// Unload the LaunchAgent and remove the plist.
+    /// Unload and delete the retired LaunchAgent, if one is installed.
     Uninstall,
-    /// Show launchd status for the agent.
-    Status,
-    /// Tail the launchd stdout / stderr logs.
-    Logs,
 }
 
-/// Dispatch a `trusty-analyzer service <action>` invocation.
+/// Dispatch a `trusty-analyze service <action>` invocation.
 ///
 /// Why: launchd is macOS-specific; on other platforms we exit cleanly with a
 /// clear message rather than emitting confusing plist errors.
-/// What: macOS routes to `service_install` / `service_uninstall` /
-/// `service_status` / `service_logs`. Non-macOS prints "not supported" and
-/// exits 1.
-/// Test: on Linux, every action exits 1 with the platform message;
-/// on macOS, `service status` runs `launchctl print` without crashing.
+/// What: macOS routes to `service_uninstall`. Non-macOS prints "not supported"
+/// and exits 1.
+/// Test: on Linux, the action exits 1 with the platform message.
 pub fn run_service_action(action: ServiceAction) -> Result<()> {
     #[cfg(target_os = "macos")]
     {
         match action {
-            ServiceAction::Install => service_install(),
             ServiceAction::Uninstall => service_uninstall(),
-            ServiceAction::Status => service_status(),
-            ServiceAction::Logs => service_logs(),
         }
     }
     #[cfg(not(target_os = "macos"))]
@@ -60,205 +64,263 @@ pub fn run_service_action(action: ServiceAction) -> Result<()> {
         let _ = action;
         eprintln!(
             "{} `trusty-analyze service` is not supported on this platform — \
-             use your distro's service manager (systemd, OpenRC, etc.) directly.",
+             trusty-analyze runs on demand and installs no unit anywhere.",
             "✗".red()
         );
         std::process::exit(1);
     }
 }
 
-/// Resolve the log directory for the analyzer launchd agent.
+/// What `service uninstall` should print, and whether it must exit non-zero.
 ///
-/// Why: align with the other trusty-* daemons by writing logs under
-/// `~/.trusty-analyze/logs/` instead of `~/Library/Logs/`. Easier to find
-/// and matches the convention shared across the workspace.
-/// What: returns `~/.trusty-analyze/logs`, creating it on demand.
-/// Test: covered transitively by `setup daemon`.
-#[cfg(target_os = "macos")]
-fn launchd_log_dir() -> Result<std::path::PathBuf> {
-    let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("could not resolve $HOME"))?;
-    let dir = home.join(".trusty-analyze").join("logs");
-    std::fs::create_dir_all(&dir)?;
-    Ok(dir)
+/// Why a struct rather than four returns: the exit decision and the operator's
+/// remediation text are one verdict, and a caller that could take the lines
+/// without the `failed` flag is the fail-open shape this exists to prevent.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct Rendered {
+    /// Lines for stdout — what was cleared.
+    pub out: Vec<String>,
+    /// Lines for stderr — what refused to go, with how to clear it by hand.
+    pub errors: Vec<String>,
+    /// Whether anything was actually evicted, i.e. this host had a stale unit.
+    pub touched: bool,
+    /// Whether the command must exit non-zero.
+    pub failed: bool,
 }
 
-/// Build the shared `LaunchdConfig` for this daemon.
+/// Turn the shared eviction outcomes into operator-facing output.
 ///
-/// Why: every `service` action needs the same plist label, executable path,
-/// args, and log directory. Centralising the construction keeps install,
-/// uninstall, status, and logs in agreement.
-/// What: resolves the current executable, computes the log dir, and returns
-/// a `LaunchdConfig` configured for an always-on agent that runs
-/// `trusty-analyze serve` with a 10-second restart throttle.
-/// Test: exercised transitively by every macOS `service` subcommand.
+/// Why this is where the fail-closed decision lives: `EvictionOutcome::Failed`
+/// covers both a `launchctl bootout` that refused and a plist that would not
+/// delete, and BOTH leave a unit the next `launchctl load` — or the next login
+/// — brings straight back. Reporting either as done is the one outcome worse
+/// than failing, because the operator walks away believing the daemon is gone
+/// while it is still restarting. `EvictionOutcome::is_failure` is the shared
+/// rule; this function is what acts on it.
+///
+/// What: `Evicted` prints a cleared line and sets `touched`; `Absent` prints
+/// nothing, which is the steady state on every host that never installed the
+/// unit; `Failed` names the label, carries the reason through verbatim, and
+/// sets `failed`.
+///
+/// Test: `render_reports_a_cleared_unit`, `render_is_silent_for_an_absent_unit`,
+/// `render_fails_closed_on_a_unit_that_would_not_go`,
+/// `render_fails_even_when_another_label_was_cleared`.
+#[must_use]
+pub fn render_evictions(evictions: &[LabelEviction]) -> Rendered {
+    let mut r = Rendered::default();
+    for e in evictions {
+        match &e.outcome {
+            EvictionOutcome::Evicted => {
+                r.touched = true;
+                r.out.push(format!(
+                    "{} Cleared the retired LaunchAgent {}.",
+                    "✓".green(),
+                    e.label
+                ));
+            }
+            EvictionOutcome::Absent => {}
+            EvictionOutcome::Failed(why) => {
+                r.failed = true;
+                r.errors.push(format!(
+                    "{} {} is STILL THERE — {why}. Clear it by hand: \
+                     `launchctl bootout gui/$(id -u)/{}` then \
+                     `rm -f ~/Library/LaunchAgents/{}.plist`",
+                    "✗".red(),
+                    e.label,
+                    e.label,
+                    e.label
+                ));
+            }
+            // #6290: `EvictionOutcome` is `#[non_exhaustive]`. A variant added
+            // later must not fall through as "nothing happened" — that is the
+            // fail-open branch this renderer exists to close, and it would be
+            // silent. Failing here forces the new outcome to be given real
+            // wording before it can ship.
+            other => {
+                r.failed = true;
+                r.errors.push(format!(
+                    "{} {}: unrecognised eviction outcome {other:?} — treat the \
+                     unit as still present and check it by hand: \
+                     `launchctl list | grep {}`",
+                    "✗".red(),
+                    e.label,
+                    e.label
+                ));
+            }
+        }
+    }
+    r
+}
+
+/// Build a `LaunchdConfig` addressing `label`, for its `launchctl` operations.
+///
+/// The exec path, args, log dir and keep-alive are irrelevant here:
+/// `evict_legacy_detailed` overwrites the label per alias, and only `bootout` /
+/// `is_loaded` / `plist_path` are reached — none of which renders a plist. The
+/// type requires the rest, so they are filled with the cheapest values that
+/// mean nothing, the same minimal-config pattern the installer's
+/// `RealServiceEnv::evict_retired` uses.
 #[cfg(target_os = "macos")]
-fn launchd_config() -> Result<trusty_common::launchd::LaunchdConfig> {
+fn launchd_handle(label: &str) -> trusty_common::launchd::LaunchdConfig {
     use trusty_common::launchd::{KeepAlive, LaunchdConfig};
 
-    let exe = std::env::current_exe()
-        .map_err(|e| anyhow::anyhow!("could not resolve current exe: {e}"))?;
-    let log_dir = launchd_log_dir()?;
-    Ok(LaunchdConfig {
-        label: LAUNCHD_LABEL.to_string(),
-        exe_path: exe,
-        args: vec!["serve".to_string()],
-        log_dir,
+    LaunchdConfig {
+        label: label.to_owned(),
+        exe_path: std::path::PathBuf::from("trusty-analyze"),
+        args: Vec::new(),
+        log_dir: std::path::PathBuf::from("/tmp"),
         keep_alive: KeepAlive::Always,
-        throttle_interval: 10,
+        throttle_interval: 0,
         env_vars: Vec::new(),
-        // Why: the analyze daemon opens one redb file + per-index chunk
-        // caches but does not need elevated fd limits; None delegates to the
-        // OS default, matching the trusty-search pattern.
         fd_limit: None,
         working_directory: None,
-    })
+    }
 }
 
-/// Resolve the LaunchAgent plist path.
+/// Unload and delete every retired trusty-analyze LaunchAgent.
 ///
-/// Why: `setup daemon` needs to check whether the plist already exists before
-/// deciding whether to install or simply reload it.
-/// What: returns `~/Library/LaunchAgents/com.trusty.analyze.plist` via the
-/// shared `LaunchdConfig::plist_path` helper.
-/// Test: covered transitively by `setup daemon`.
-#[cfg(target_os = "macos")]
-pub fn launchd_plist_path() -> Result<std::path::PathBuf> {
-    launchd_config()?.plist_path()
-}
-
-/// Install and start the launchd LaunchAgent.
+/// Why this is `pub`: it is the migration step, and `setup daemon` runs it on
+/// every host so an operator who never types `service uninstall` is still moved
+/// off the resident unit.
 ///
-/// Why: exposed so the `setup daemon` subcommand can install the background
-/// service without re-implementing the plist mechanics.
-/// What: writes the plist via `LaunchdConfig::install`, then `bootstrap`s it
-/// into the current user's GUI domain via the shared helper.
-/// Test: `setup daemon` on macOS installs the plist and the daemon answers
-/// `/health`; on Linux `setup daemon` skips this path with a clear message.
+/// # Errors
+///
+/// Never returns `Err` today — a label that will not go down is reported in the
+/// outcome table and exits non-zero, not returned as an error, so the other
+/// labels still get their pass. The signature stays fallible for the dispatch
+/// seam.
 #[cfg(target_os = "macos")]
-pub fn service_install() -> Result<()> {
-    let cfg = launchd_config()?;
-    let plist_path = cfg.plist_path()?;
-    // #4868: the registry records `com.trusty.trusty-analyze` as a legacy alias
-    // and nothing acted on it. Evicting here is what makes that record mean
-    // something on a host that ran an older installer.
-    let outcome = cfg
-        .install_and_activate(trusty_common::launchd_labels::legacy_labels_for(
-            LAUNCHD_LABEL,
-        ))
-        .map_err(|e| anyhow::anyhow!("install LaunchAgent: {e}"))?;
-    for label in outcome.evicted() {
+pub fn service_uninstall() -> Result<()> {
+    let labels = trusty_common::launchd_labels::retired_labels_for_member("trusty-analyze");
+    // Only `label` matters, and `evict_legacy_detailed` overwrites it per alias.
+    let evictions = launchd_handle(labels[0]).evict_legacy_detailed(&labels);
+    let r = render_evictions(&evictions);
+
+    for line in &r.out {
+        println!("{line}");
+    }
+    for line in &r.errors {
+        eprintln!("{line}");
+    }
+    if !r.touched && !r.failed {
         println!(
-            "{} Evicted the stale LaunchAgent {label} — it named this daemon \
-             under an old label.",
-            "⚠".yellow()
+            "{} No trusty-analyze LaunchAgent is installed — it runs on demand.",
+            "·".dimmed()
         );
     }
-
-    let domain = format!("gui/{}", trusty_common::launchd::current_uid());
-    if matches!(
-        outcome,
-        trusty_common::launchd_activate::Activation::AlreadyCurrent { .. }
-    ) {
+    if r.touched && !r.failed {
         println!(
-            "{} {} is already loaded in {} with this exact unit — left running.",
-            "·".dimmed(),
-            LAUNCHD_LABEL,
-            domain
-        );
-    } else {
-        println!(
-            "{} Wrote LaunchAgent plist: {}",
-            "✓".green(),
-            plist_path.display()
-        );
-        println!(
-            "{} trusty-analyze service installed and started ({} loaded into {}).",
-            "✓".green(),
-            LAUNCHD_LABEL,
-            domain
+            "  trusty-analyze now starts on demand; nothing needs to be running \
+             for `{}` or `{}` to work.",
+            "trusty-analyze deep".cyan(),
+            "trusty-review report --analyze".cyan()
         );
     }
-    println!(
-        "  Logs:    {}\n  Status:  {}",
-        cfg.log_dir.display().to_string().dimmed(),
-        "trusty-analyze service status".cyan(),
-    );
-    Ok(())
-}
-
-#[cfg(target_os = "macos")]
-fn service_uninstall() -> Result<()> {
-    let cfg = launchd_config()?;
-    let plist_path = cfg.plist_path()?;
-    if plist_path.exists() {
-        // bootout is best-effort: a not-loaded agent is fine here.
-        let _ = cfg.bootout();
-        std::fs::remove_file(&plist_path)
-            .map_err(|e| anyhow::anyhow!("remove {}: {e}", plist_path.display()))?;
-        println!(
-            "{} trusty-analyze service uninstalled ({} removed).",
-            "✓".green(),
-            plist_path.display()
-        );
-    } else {
-        println!(
-            "{} {} not installed — nothing to do",
-            "·".dimmed(),
-            plist_path.display()
-        );
-    }
-    Ok(())
-}
-
-#[cfg(target_os = "macos")]
-fn service_status() -> Result<()> {
-    let uid = trusty_common::launchd::current_uid();
-    let target = format!("gui/{uid}/{LAUNCHD_LABEL}");
-    let output = std::process::Command::new("launchctl")
-        .args(["print", &target])
-        .output()
-        .map_err(|e| anyhow::anyhow!("launchctl print failed: {e}"))?;
-    if output.status.success() {
-        println!("{}", String::from_utf8_lossy(&output.stdout));
-    } else {
-        // `launchctl print` exits non-zero when the service isn't loaded.
-        eprintln!(
-            "{} {} is not loaded ({})",
-            "✗".red(),
-            target,
-            String::from_utf8_lossy(&output.stderr).trim()
-        );
-        eprintln!(
-            "  Install with: {}",
-            "trusty-analyze service install".cyan()
-        );
+    if r.failed {
         std::process::exit(1);
     }
     Ok(())
 }
 
-#[cfg(target_os = "macos")]
-fn service_logs() -> Result<()> {
-    use std::os::unix::process::CommandExt;
-    let log_dir = launchd_log_dir()?;
-    // trusty_common's LaunchdConfig writes separate stdout/stderr files; tail
-    // both so users see the full picture in one stream.
-    let stdout_log = log_dir.join("stdout.log");
-    let stderr_log = log_dir.join("stderr.log");
-    if !stdout_log.exists() && !stderr_log.exists() {
-        eprintln!(
-            "{} No logs at {} yet — start the service first.",
-            "·".dimmed(),
-            log_dir.display()
-        );
-        return Ok(());
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ev(label: &str, outcome: EvictionOutcome) -> LabelEviction {
+        LabelEviction::new(label, outcome)
     }
-    // Replace the current process with `tail -F` so the user gets a familiar
-    // follow-mode experience and we don't have to re-implement log rotation.
-    let err = std::process::Command::new("tail")
-        .arg("-F")
-        .arg(&stdout_log)
-        .arg(&stderr_log)
-        .exec();
-    Err(anyhow::anyhow!("exec tail failed: {err}"))
+
+    /// Why: the migration's whole job. A host with `com.trusty.analyze` loaded
+    /// must end the command told that it is gone, and must not exit non-zero
+    /// for having found work to do.
+    /// Test: this is the test.
+    #[test]
+    fn render_reports_a_cleared_unit() {
+        let r = render_evictions(&[ev("com.trusty.analyze", EvictionOutcome::Evicted)]);
+        assert!(r.touched);
+        assert!(!r.failed);
+        assert!(r.errors.is_empty());
+        assert_eq!(r.out.len(), 1);
+        assert!(r.out[0].contains("com.trusty.analyze"), "{:?}", r.out);
+    }
+
+    /// Why: on a machine that never installed the unit the command must be a
+    /// silent no-op rather than an error — it runs unconditionally from
+    /// `setup daemon`, so a line here would be permanent noise.
+    /// Test: this is the test.
+    #[test]
+    fn render_is_silent_for_an_absent_unit() {
+        let r = render_evictions(&[
+            ev("com.trusty.analyze", EvictionOutcome::Absent),
+            ev("com.trusty.trusty-analyze", EvictionOutcome::Absent),
+        ]);
+        assert_eq!(r, Rendered::default());
+    }
+
+    /// Why (#6350 fail-open check): a `launchctl bootout` that refused, and a
+    /// plist that survived its delete, are the same hazard — a unit the next
+    /// login brings straight back. `EvictionOutcome::Failed` covers both, and
+    /// reporting either as done tells the operator the daemon is gone while it
+    /// is still restarting.
+    /// What: the command fails, names the label, and carries the reason
+    /// through so the operator knows which of the two happened.
+    /// Test: this is the test.
+    #[test]
+    fn render_fails_closed_on_a_unit_that_would_not_go() {
+        for why in [
+            "still loaded after `launchctl bootout` reported success",
+            "could not delete /Users/x/Library/LaunchAgents/com.trusty.analyze.plist: EPERM",
+        ] {
+            let r = render_evictions(&[ev(
+                "com.trusty.analyze",
+                EvictionOutcome::Failed(why.to_owned()),
+            )]);
+            assert!(r.failed, "a surviving unit must exit non-zero: {why}");
+            assert!(r.out.is_empty(), "nothing was cleared: {:?}", r.out);
+            assert_eq!(r.errors.len(), 1);
+            assert!(r.errors[0].contains("com.trusty.analyze"), "{:?}", r.errors);
+            assert!(
+                r.errors[0].contains(why),
+                "the operator needs the cause verbatim: {:?}",
+                r.errors
+            );
+        }
+    }
+
+    /// Why: both labels exist on real hosts, and a pass that cleared one while
+    /// the other refused must still fail. Letting a success anywhere in the
+    /// list mask a failure is how a partially-migrated host reports clean.
+    /// Test: this is the test.
+    #[test]
+    fn render_fails_even_when_another_label_was_cleared() {
+        let r = render_evictions(&[
+            ev("com.trusty.analyze", EvictionOutcome::Evicted),
+            ev(
+                "com.trusty.trusty-analyze",
+                EvictionOutcome::Failed("still loaded".to_owned()),
+            ),
+        ]);
+        assert!(r.touched);
+        assert!(r.failed, "one survivor fails the whole pass");
+        assert_eq!(r.errors.len(), 1);
+    }
+
+    /// Why: the label set comes from the shared registry, so an alias added
+    /// there is evicted here without this file changing. The order is asserted
+    /// because the canonical label holds the running process.
+    /// Test: this is the test.
+    #[test]
+    fn the_retired_label_set_comes_from_the_registry() {
+        let labels = trusty_common::launchd_labels::retired_labels_for_member("trusty-analyze");
+        assert_eq!(
+            labels,
+            vec![
+                trusty_common::launchd_labels::ANALYZE,
+                "com.trusty.trusty-analyze"
+            ]
+        );
+    }
 }

--- a/crates/trusty-analyze/src/commands/setup.rs
+++ b/crates/trusty-analyze/src/commands/setup.rs
@@ -285,66 +285,52 @@ async fn daemon_serving() -> Result<bool> {
     Ok(trusty_common::uds::socket_is_serving(&socket, Duration::from_millis(500)).await)
 }
 
-/// Install and start the background daemon (idempotent).
+/// Migrate off the retired launchd unit and prove the on-demand path works.
 ///
-/// Why: gives users a one-command "make the daemon run forever" path.
-/// What: if the socket already answers, returns early. Otherwise installs the
-/// launchd service (when not already installed) and polls the socket for up to
-/// 10 s.
-/// Test: on a machine with the daemon already up, prints "already running" and
-/// exits 0; the launchd path is macOS-only and verified manually.
+/// Why this no longer installs anything (#6350): ADR-0032 makes trusty-analyze
+/// on-demand, so there is no "make the daemon run forever" state to reach. What
+/// an operator still needs from `setup daemon` is the two facts this now
+/// establishes — any unit a previous version installed is gone, and a client
+/// running on this machine can start the server.
+///
+/// What: evicts the retired LaunchAgent (macOS), returns early when something is
+/// already serving, and otherwise runs the same `ensure_running` every client
+/// uses. The server is left to its own idle window; nothing here pins it up.
+///
+/// Test: `commands::service`'s `retirement_*` cover the eviction decision;
+/// the spawn half is `on_demand_tests.rs`.
 async fn setup_daemon() -> Result<()> {
+    // #6350: run the launchd migration BEFORE the liveness check. A host that
+    // installed the old unit has one loaded right now, so `daemon_serving`
+    // returns true and an early return would leave the resident daemon — and
+    // its `KeepAlive: Always` restart loop — in place forever.
+    #[cfg(target_os = "macos")]
+    crate::commands::service::service_uninstall()?;
+
     if daemon_serving().await? {
-        println!("{} daemon already running", "✓".green());
+        println!("{} trusty-analyze is already serving", "✓".green());
         return Ok(());
     }
 
-    #[cfg(target_os = "macos")]
-    {
-        use crate::commands::service::{launchd_plist_path, service_install};
-
-        let plist = launchd_plist_path()?;
-        if !plist.exists() {
-            service_install()?;
-        } else {
-            // Plist exists but nothing is serving — (re)load it.
-            let status = std::process::Command::new("launchctl")
-                .arg("load")
-                .arg(&plist)
-                .status()
-                .context("launchctl load")?;
-            if !status.success() {
-                tracing::warn!("launchctl load exited with {status}");
-            }
-        }
-
-        // Poll the socket for up to 10 s. #4392's HTTP_PROXY hazard is gone
-        // with the HTTP client: a Unix socket has no proxy to be routed through.
-        for _ in 0..20 {
-            tokio::time::sleep(Duration::from_millis(500)).await;
-            if daemon_serving().await? {
-                println!("{} daemon installed and serving", "✓".green());
-                return Ok(());
-            }
-        }
-        println!(
-            "{} daemon installed but did not report healthy within 10 s — \
-             check `trusty-analyze service logs`",
-            "⚠".yellow()
-        );
-        Ok(())
-    }
-
-    #[cfg(not(target_os = "macos"))]
-    {
-        println!(
-            "{} `setup daemon` installs a macOS launchd service; on this \
-             platform start the daemon with `trusty-analyze start` or your \
-             distro's service manager.",
-            "·".dimmed()
-        );
-        Ok(())
-    }
+    // #6350: no LaunchAgent is installed. The one thing `setup daemon` can
+    // usefully prove is that a client CAN start the server — so it runs the
+    // same on-demand path every client uses, then leaves the server to its own
+    // idle window rather than pinning it up.
+    let socket = trusty_analyze::service::socket_path()?;
+    trusty_common::uds::OnDemandAnalyze::at(&socket)
+        .ensure_running()
+        .await
+        .context("start trusty-analyze on demand")?;
+    println!(
+        "{} trusty-analyze starts on demand and answers {}",
+        "✓".green(),
+        socket.display()
+    );
+    println!(
+        "  Nothing needs to stay resident — the server exits after an idle \
+         period and any client restarts it."
+    );
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/trusty-analyze/src/main.rs
+++ b/crates/trusty-analyze/src/main.rs
@@ -250,12 +250,14 @@ enum Cmd {
         #[arg(value_enum)]
         shell: Shell,
     },
-    /// Manage the trusty-analyzer background service (macOS launchd).
+    /// Remove the launchd LaunchAgent an older version installed (macOS).
     ///
-    /// Installs a LaunchAgent plist at
-    /// `~/Library/LaunchAgents/com.trusty.trusty-analyze.plist` that runs the
-    /// daemon in the foreground under launchd supervision. Not supported on
-    /// Linux / Windows — the subcommand exits 1 with a clear message.
+    /// #6350: trusty-analyze installs no LaunchAgent. It starts on demand when a
+    /// client needs it and exits after an idle window, so a `KeepAlive: Always`
+    /// unit would restart it the moment it reclaimed itself. This subcommand is
+    /// the migration off one: `service uninstall` unloads `com.trusty.analyze`
+    /// and deletes its plist. Not supported on Linux / Windows — the subcommand
+    /// exits 1 with a clear message.
     Service {
         #[command(subcommand)]
         action: ServiceSubcommand,
@@ -318,17 +320,15 @@ enum Cmd {
     Config(trusty_common::inference::config::ConfigCommand),
 }
 
-/// Subcommands for `trusty-analyzer service` (macOS launchd integration).
+/// Subcommands for `trusty-analyze service` (macOS launchd migration).
+///
+/// #6350: `install`, `status` and `logs` are gone — see `commands::service`.
+/// trusty-analyze installs no unit; `uninstall` removes one a previous version
+/// left behind.
 #[derive(Subcommand, Debug)]
 enum ServiceSubcommand {
-    /// Install and start as a launchd service
-    Install,
-    /// Stop and uninstall the service
+    /// Unload and remove the LaunchAgent an older version installed
     Uninstall,
-    /// Show service status
-    Status,
-    /// Tail service logs
-    Logs,
 }
 
 #[derive(Subcommand, Debug)]
@@ -429,10 +429,13 @@ async fn main() -> Result<()> {
             // the daemon. Silence would leave an operator believing they had
             // moved a listener that no longer exists.
             if port.is_some() || mcp_port.is_some() {
+                // #6350: `service install` no longer exists — pointing an
+                // operator at it turned a warning into a second dead end.
                 tracing::warn!(
                     "--port / --mcp-port are retired (#6287): trusty-analyze serves a Unix \
-                     socket. Run `trusty-analyze service install` to refresh the launchd plist, \
-                     and `trusty-analyze socket` to see the path."
+                     socket. Run `trusty-analyze service uninstall` to evict the stale launchd \
+                     plist that is still passing them, and `trusty-analyze socket` to see the \
+                     path."
                 );
             }
             run_serve(search, facts_path, socket, mcp).await
@@ -623,10 +626,7 @@ async fn main() -> Result<()> {
         }
         Cmd::Service { action } => {
             let action = match action {
-                ServiceSubcommand::Install => ServiceActionEnum::Install,
                 ServiceSubcommand::Uninstall => ServiceActionEnum::Uninstall,
-                ServiceSubcommand::Status => ServiceActionEnum::Status,
-                ServiceSubcommand::Logs => ServiceActionEnum::Logs,
             };
             run_service_action(action)
         }

--- a/crates/trusty-analyze/src/service/mod.rs
+++ b/crates/trusty-analyze/src/service/mod.rs
@@ -30,7 +30,10 @@ pub mod rpc;
 // Re-export the public API so callers can write `use crate::service::…`
 // without knowing which submodule owns each item.
 pub use events::AnalyzerAppState;
-pub use rpc::{build_router, serve, socket_path, METHODS, METHOD_HEALTH};
+pub use rpc::{
+    build_router, serve, serve_on_demand, socket_path, METHODS, METHOD_HEALTH,
+    SHUTDOWN_FLUSH_TIMEOUT,
+};
 
 /// Re-export so the binary can construct facts via the same path.
 pub use crate::types::FactRecord as PublicFactRecord;

--- a/crates/trusty-analyze/src/service/rpc.rs
+++ b/crates/trusty-analyze/src/service/rpc.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 use anyhow::{Context as _, Result};
 use serde::{Deserialize, Serialize};
 use tracing::info;
-use trusty_common::uds::server::{serve_until, RpcRouter, RpcServeOptions};
+use trusty_common::uds::server::{RpcRouter, RpcServeOptions};
 
 use crate::service::events::AnalyzerAppState;
 use crate::service::handlers::{analysis, deep, facts, graph, review, system};
@@ -376,6 +376,21 @@ fn serve_options() -> RpcServeOptions {
 ///
 /// Test: `rpc_health_answers_over_a_real_socket`,
 /// `rpc_unlinks_its_socket_on_shutdown`.
+/// This server's own shutdown budget, as the supervisor contract requires.
+///
+/// Why it is declared here and not only in `trusty-common`: `ServiceTimeouts`'
+/// sourcing rule says the supervisor's `shutdown_flush` must be the supervised
+/// binary's REAL budget, and `trusty-common` cannot import this crate to read
+/// it. So this is the definition, and
+/// `analyze_flush_budget_matches_the_supervisor_contract` pins
+/// `trusty_common::uds::ANALYZE_SHUTDOWN_FLUSH` against it — a drift is a test
+/// failure rather than a SIGKILL landing mid-shutdown.
+///
+/// One second is honest for this server: every handler commits its redb write
+/// before answering, so a SIGTERM discards nothing that was acked. The budget
+/// covers the accept loop returning and the socket unlink below.
+pub const SHUTDOWN_FLUSH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
+
 pub async fn serve(state: AnalyzerAppState, socket: &Path) -> Result<()> {
     // Migration cleanup, deliberately OUTSIDE `serve_with_shutdown`: it resolves
     // the real `$HOME` and the real data directory, so a test that drove it
@@ -387,6 +402,33 @@ pub async fn serve(state: AnalyzerAppState, socket: &Path) -> Result<()> {
     serve_with_shutdown(state, socket, trusty_common::shutdown_signal()).await
 }
 
+/// [`serve`], with the idle window resolved from the environment (#6350).
+///
+/// Why this is the process entry point now: ADR-0032 retires the launchd unit,
+/// so nothing restarts this server and nothing stops it either — it has to end
+/// itself, or the first request of the day leaves a process resident until the
+/// machine reboots. That is the resident daemon this change removed, minus the
+/// supervisor that would at least have restarted it after a crash.
+///
+/// What: reads [`trusty_common::uds::ANALYZE_IDLE_TIMEOUT_ENV`] through the
+/// shared parser, so `0` means "never exit" and an unset variable means the
+/// ten-minute default. The window is announced on stderr at startup, because an
+/// operator watching a foreground server needs to know it will end and when.
+///
+/// # Errors
+///
+/// As [`serve`].
+///
+/// Test: `tests/on_demand.rs`' `serve_exits_on_its_own_idle_window` drives the
+/// real binary to an idle exit; the policy itself is covered by
+/// `trusty-common`'s `idle_timeout_parses_its_three_meanings`.
+pub async fn serve_on_demand(state: AnalyzerAppState, socket: &Path) -> Result<()> {
+    remove_retired_discovery_files();
+
+    let idle = trusty_common::uds::analyze_idle_timeout_from_env();
+    serve_with_idle(state, socket, trusty_common::shutdown_signal(), idle).await
+}
+
 /// [`serve`]'s body, with the shutdown future supplied by the caller.
 ///
 /// Why: `serve` waits on SIGTERM/SIGINT, which a test cannot deliver to its own
@@ -396,7 +438,8 @@ pub async fn serve(state: AnalyzerAppState, socket: &Path) -> Result<()> {
 /// re-implementing the loop and deleting the file itself, which is a test that
 /// passes whether or not the unlink below exists.
 ///
-/// What: binds through `bind_singleton_hardened`, serves via [`serve_until`],
+/// What: binds through `bind_singleton_hardened`, serves via
+/// [`trusty_common::uds::server::serve_until_idle`],
 /// then removes the socket file BEFORE dropping the listener — the order
 /// `webhook_relay::listener` records, because reversed there is a window in
 /// which nothing answers the path but the file is still there, and a successor
@@ -413,6 +456,42 @@ pub async fn serve_with_shutdown(
     socket: &Path,
     shutdown: impl std::future::Future<Output = ()> + Send,
 ) -> Result<()> {
+    serve_with_idle(state, socket, shutdown, None).await
+}
+
+/// [`serve_with_shutdown`], plus the idle window (#6350).
+///
+/// Why both signatures exist: `serve_with_shutdown` is what a caller that owns
+/// the process lifetime wants — the `--mcp` path runs this server inside a
+/// process whose real job is an MCP stdio loop, and an idle exit there would
+/// silently drop the transport that loop dials. `None` is therefore a real
+/// choice, not a legacy default.
+///
+/// What: binds through `bind_singleton_hardened`, serves via
+/// [`trusty_common::uds::server::serve_until_idle`], then removes the socket
+/// file BEFORE dropping the listener — the order `webhook_relay::listener`
+/// records, because reversed there is a window in which nothing answers the path
+/// but the file is still there, and a successor that rebinds in that window has
+/// its fresh socket deleted by this process.
+///
+/// The unlink runs on BOTH exits. An idle exit that left the file behind would
+/// make the next `ensure_running` spawn a child that fails its bind, and
+/// `bind_singleton_hardened`'s takeover is a recovery path, not a licence to
+/// leave corpses.
+///
+/// # Errors
+///
+/// As [`serve`].
+///
+/// Test: `rpc_unlinks_its_socket_on_shutdown`,
+/// `rpc_accepts_a_request_larger_than_the_shared_default`, and
+/// `tests/on_demand.rs`' `serve_exits_on_its_own_idle_window`.
+pub async fn serve_with_idle(
+    state: AnalyzerAppState,
+    socket: &Path,
+    shutdown: impl std::future::Future<Output = ()> + Send,
+    idle: Option<std::time::Duration>,
+) -> Result<()> {
     // #6287: no `SelfOrigins` / `with_guarded_middleware` here, and its absence
     // is deliberate rather than an oversight. That machinery was browser-CSRF
     // defence for the destructive routes (`POST /indexes/{id}/scip`,
@@ -426,10 +505,31 @@ pub async fn serve_with_shutdown(
         .with_context(|| format!("bind trusty-analyze socket at {}", socket.display()))?;
 
     let router = Arc::new(build_router(state));
-    info!(socket = %socket.display(), methods = router.method_names().count(), "trusty-analyze serving");
-    eprintln!("trusty-analyze: serving on {}", socket.display());
+    info!(socket = %socket.display(), methods = router.method_names().count(), idle = ?idle, "trusty-analyze serving");
+    match idle {
+        Some(window) => eprintln!(
+            "trusty-analyze: serving on {} (exits after {}s idle)",
+            socket.display(),
+            window.as_secs()
+        ),
+        None => eprintln!("trusty-analyze: serving on {}", socket.display()),
+    }
 
-    serve_until(&listener, Arc::clone(&router), serve_options(), shutdown).await;
+    // #6350: the tracker is what makes the exit conditional on real traffic
+    // rather than on a bare timer — see `IdleTracker`.
+    let tracker = idle.map(trusty_common::uds::server::IdleTracker::new);
+    let exit = trusty_common::uds::server::serve_until_idle(
+        &listener,
+        Arc::clone(&router),
+        serve_options(),
+        shutdown,
+        tracker,
+    )
+    .await;
+    if exit == trusty_common::uds::server::ServeExit::Idle {
+        info!(socket = %socket.display(), "trusty-analyze idle; exiting");
+        eprintln!("trusty-analyze: idle; exiting");
+    }
 
     if let Err(e) = std::fs::remove_file(socket) {
         tracing::debug!(socket = %socket.display(), error = %e, "socket already gone");

--- a/crates/trusty-analyze/tests/on_demand.rs
+++ b/crates/trusty-analyze/tests/on_demand.rs
@@ -463,3 +463,190 @@ async fn the_adapter_respawns_a_server_that_idled_out() {
         .arg(socket.to_string_lossy().as_ref())
         .status();
 }
+
+/// One `trusty-analyze serve --mcp` process, driven the way an MCP client does.
+///
+/// Why a fixture rather than an inline spawn: the property under test needs the
+/// stdio loop and the socket the SAME process binds, and it needs both still
+/// there after a silence. Holding stdin open is what keeps the loop alive — it
+/// ends when stdin closes — so the handle owns stdin for the length of the test
+/// rather than writing to it and dropping it.
+///
+/// `kill_on_drop` is what keeps a panicking assertion from leaking a child that
+/// holds a path inside the tempdir the test is about to remove.
+struct McpSession {
+    _child: tokio::process::Child,
+    stdin: tokio::process::ChildStdin,
+    stdout: tokio::io::Lines<tokio::io::BufReader<tokio::process::ChildStdout>>,
+    socket: PathBuf,
+}
+
+impl McpSession {
+    /// Spawn `serve --mcp` under `dir`, with `idle_secs` as the daemon's window.
+    ///
+    /// The `--facts-path` and `--socket` overrides keep the child off the
+    /// developer's real data directory, exactly as [`spawn_server`] does.
+    fn start(dir: &Path, search: &StubSearch, idle_secs: u64) -> Self {
+        use tokio::io::AsyncBufReadExt as _;
+
+        let socket = dir.join("trusty-analyze.sock");
+        let stores = dir.join("mcp-store");
+        std::fs::create_dir_all(&stores).expect("create the child's store directory");
+        let mut child = tokio::process::Command::new(env!("CARGO_BIN_EXE_trusty-analyze"))
+            .arg("--facts-path")
+            .arg(stores.join("facts.redb"))
+            .args(["serve", "--mcp", "--socket"])
+            .arg(&socket)
+            .env("TRUSTY_SEARCH_URL", &search.base_url)
+            .env("TRUSTY_ANALYZE_IDLE_TIMEOUT_SECS", idle_secs.to_string())
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .kill_on_drop(true)
+            .spawn()
+            .expect("spawn trusty-analyze serve --mcp");
+        let stdin = child.stdin.take().expect("piped stdin");
+        let stdout = tokio::io::BufReader::new(child.stdout.take().expect("piped stdout")).lines();
+        Self {
+            _child: child,
+            stdin,
+            stdout,
+            socket,
+        }
+    }
+
+    /// Send one JSON-RPC request and read its response line.
+    ///
+    /// The exchange is in lockstep — one line out, one line in — which is what
+    /// the MCP stdio contract is, and what lets a stalled loop surface as an
+    /// explicit timeout rather than as a hung test.
+    async fn request(
+        &mut self,
+        id: u64,
+        method: &str,
+        params: serde_json::Value,
+    ) -> serde_json::Value {
+        use tokio::io::AsyncWriteExt as _;
+
+        let line = serde_json::to_string(&serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params,
+        }))
+        .expect("serialize the request");
+        self.stdin
+            .write_all(format!("{line}\n").as_bytes())
+            .await
+            .expect("write the request to the child's stdin");
+        self.stdin.flush().await.expect("flush stdin");
+
+        let raw = tokio::time::timeout(Duration::from_secs(60), self.stdout.next_line())
+            .await
+            .unwrap_or_else(|_| panic!("no answer to {method} within 60s"))
+            .expect("read the child's stdout")
+            .unwrap_or_else(|| panic!("the child closed stdout before answering {method}"));
+        serde_json::from_str(&raw)
+            .unwrap_or_else(|e| panic!("{method} answered non-JSON: {e}: {raw}"))
+    }
+
+    /// Call `analyzer_health` and return the tool result, asserting it worked.
+    ///
+    /// 🔴 Why `isError` is the assertion and not a JSON-RPC `error` member:
+    /// `tools/call` maps the dispatcher's `DispatchError::Transport` onto a
+    /// SUCCESSFUL response carrying `isError: true` (`mcp::helpers::wrap_tool_error`),
+    /// so a dead socket reaches a client as an ok-shaped frame. A test that only
+    /// checked for a JSON-RPC `error` would pass against a daemon that had
+    /// already exited.
+    async fn health(&mut self, id: u64) -> serde_json::Value {
+        let response = self
+            .request(
+                id,
+                "tools/call",
+                serde_json::json!({ "name": "analyzer_health", "arguments": {} }),
+            )
+            .await;
+        assert!(
+            response.get("error").is_none(),
+            "analyzer_health must not answer a JSON-RPC error: {response}"
+        );
+        let result = response
+            .get("result")
+            .cloned()
+            .unwrap_or_else(|| panic!("analyzer_health answered without a result: {response}"));
+        assert_eq!(
+            result.get("isError").and_then(serde_json::Value::as_bool),
+            Some(false),
+            "analyzer_health reached no daemon; the socket the stdio loop dials is gone: {result}"
+        );
+        result
+    }
+}
+
+/// Why (#6355): the `--mcp` branch spawns the daemon in a task and then runs the
+/// stdio loop in the foreground, and `mcp::rpc_client::call` dials that socket
+/// once per tool call with no respawn. With the idle window applied to that
+/// daemon, a session that went quiet past the window lost its transport for the
+/// rest of the process's life: the daemon task exited and unlinked the socket
+/// while the loop stayed connected to its client over stdin/stdout, and every
+/// later tool call came back `isError` with a transport failure. Nothing
+/// recovers from that — the client's only cure is to restart the server.
+///
+/// What: drives a real `serve --mcp` child with a two-second window, answers one
+/// tool call, stays silent for six windows, then asserts both that the socket is
+/// still served and that a second tool call still reaches a daemon.
+///
+/// 🔴 The silence is a bare sleep, deliberately — no liveness polling inside it.
+/// A probe connection is an OPEN connection, and `IdleTracker::expired` sleeps a
+/// whole further window whenever it observes one, so polling would push the idle
+/// exit out and let this test pass against the wiring it exists to refuse.
+///
+/// Against `9d8cc6a9a` this fails at the `still_serving` assertion: the socket is
+/// gone roughly two seconds into the silence.
+/// Test: this is the test.
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn an_mcp_session_outlives_the_idle_window() {
+    const IDLE_SECS: u64 = 2;
+    /// Six windows: long enough that an idle exit has certainly happened by now,
+    /// short enough to stay an ordinary test cost.
+    const SILENCE: Duration = Duration::from_secs(12);
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let search = StubSearch::start().await;
+    let mut session = McpSession::start(tmp.path(), &search, IDLE_SECS);
+
+    let initialized = session
+        .request(1, "initialize", serde_json::Value::Null)
+        .await;
+    assert!(
+        initialized.get("result").is_some(),
+        "the stdio loop must initialize before anything else is proven: {initialized}"
+    );
+
+    let socket = session.socket.clone();
+    assert!(
+        await_serving(&socket, Duration::from_secs(30)).await,
+        "the --mcp child never bound {}",
+        socket.display()
+    );
+
+    // The "before" call. It also refreshes the idle window, so the silence below
+    // is measured from a known instant rather than from the bind.
+    session.health(2).await;
+
+    tokio::time::sleep(SILENCE).await;
+
+    let still_serving =
+        trusty_common::uds::socket_is_serving(&socket, Duration::from_secs(2)).await;
+    assert!(
+        still_serving,
+        "the daemon behind a live MCP session exited after {}s of silence; the --mcp \
+         branch must not apply an idle window (#6355)",
+        SILENCE.as_secs()
+    );
+
+    // The claim is about the DISPATCHER, not just the socket file: this is the
+    // call that used to come back `isError` for the rest of the session.
+    session.health(3).await;
+}

--- a/crates/trusty-analyze/tests/on_demand.rs
+++ b/crates/trusty-analyze/tests/on_demand.rs
@@ -1,0 +1,465 @@
+//! End-to-end proof that trusty-analyze runs on demand and ends itself (#6350).
+//!
+//! Why these live here rather than in `trusty-common`: the shared entry point
+//! can be unit-tested for its spawn spec and its timing budget, but the two
+//! claims #6350 actually makes are about a REAL process — that a server nobody
+//! talks to exits, and that two concurrent clients end up with one server rather
+//! than two. Both need a binary that binds a socket, and this is the only crate
+//! that has one.
+//!
+//! What the fixtures supply: `trusty-analyze serve` refuses to start when
+//! trusty-search is unreachable, so [`StubSearch`] answers `/health` on a
+//! loopback port for the duration of a test. Everything else — the socket, the
+//! facts store, the idle window — is pointed inside a tempdir, so no test
+//! touches a developer's real data directory or their running daemon.
+//!
+//! Test: this *is* the test file.
+
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use tokio::net::TcpListener;
+
+/// A loopback `/health` responder standing in for trusty-search.
+///
+/// Why: `run_serve` exits 1 when `search.health()` is false, which would make
+/// every spawn in this file fail for a reason that has nothing to do with the
+/// behaviour under test. Answering one 2xx on `/health` is the whole contract
+/// these tests need from trusty-search.
+///
+/// Why axum and not a hand-written responder: `TrustySearchClient` builds its
+/// reqwest client with `http2_prior_knowledge()`, so it opens the connection by
+/// writing the h2 preface and never reads an HTTP/1.1 reply. `axum::serve` runs
+/// hyper's auto `Builder`, which recognises that preface — a raw
+/// `HTTP/1.1 200 OK` produces exactly the "trusty-search is not reachable"
+/// error a missing daemon would.
+struct StubSearch {
+    base_url: String,
+    _task: tokio::task::JoinHandle<()>,
+}
+
+impl StubSearch {
+    async fn start() -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind stub");
+        let addr = listener.local_addr().expect("addr");
+        // `/health` is what `run_serve` gates its startup on; `/indexes` is what
+        // `analyze.index_list` proxies to, and a 404 there surfaces as an RPC
+        // error the adapter reads as `Unreachable` — indistinguishable from a
+        // dead server, which is exactly the verdict these tests must be able to
+        // tell apart. An empty listing is the honest answer for a tempdir.
+        let app = axum::Router::new()
+            .route(
+                "/health",
+                axum::routing::get(|| async { axum::Json(serde_json::json!({ "status": "ok" })) }),
+            )
+            .route(
+                "/indexes",
+                axum::routing::get(|| async { axum::Json(serde_json::json!({ "indexes": [] })) }),
+            );
+        let task = tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        Self {
+            base_url: format!("http://{addr}"),
+            _task: task,
+        }
+    }
+}
+
+/// Spawn `trusty-analyze serve` the way a client would, under a tempdir.
+///
+/// The `--socket` and `--facts-path` overrides are what keep the test off the
+/// developer's real data directory; `TRUSTY_ANALYZE_IDLE_TIMEOUT_SECS` is what
+/// makes an idle exit observable in seconds rather than minutes.
+fn spawn_server(dir: &Path, search: &StubSearch, idle_secs: u64) -> (PathBuf, std::process::Child) {
+    spawn_server_with_store(dir, search, idle_secs, "store")
+}
+
+/// [`spawn_server`] with the child's stores in their own subdirectory.
+///
+/// 🔴 Why the whole DIRECTORY moves, not just the facts filename: the server
+/// opens two redb files, and `overlay_path_beside_facts` derives the second one
+/// as a fixed `scip_overlays.redb` NEXT TO the first. Two children given
+/// `a.redb` and `b.redb` in one directory therefore still collide on the
+/// overlay, and redb's exclusive lock makes the loser exit there — before it
+/// ever reaches its bind. A race test written that way passes while proving
+/// nothing about `bind_singleton_hardened`, which is the thing under test. The
+/// socket stays in the shared parent, because the race is what the two children
+/// contend for.
+fn spawn_server_with_store(
+    dir: &Path,
+    search: &StubSearch,
+    idle_secs: u64,
+    store_dir: &str,
+) -> (PathBuf, std::process::Child) {
+    let socket = dir.join("trusty-analyze.sock");
+    let stores = dir.join(store_dir);
+    std::fs::create_dir_all(&stores).expect("create the child's store directory");
+    let child = std::process::Command::new(env!("CARGO_BIN_EXE_trusty-analyze"))
+        .arg("--facts-path")
+        .arg(stores.join("facts.redb"))
+        .args(["serve", "--socket"])
+        .arg(&socket)
+        .env("TRUSTY_SEARCH_URL", &search.base_url)
+        .env("TRUSTY_ANALYZE_IDLE_TIMEOUT_SECS", idle_secs.to_string())
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .expect("spawn trusty-analyze serve");
+    (socket, child)
+}
+
+/// Put the binary under test at the front of `PATH`.
+///
+/// 🔴 Why every test that lets `ensure_running` spawn must call this first:
+/// `OnDemandAnalyze` locates its program with
+/// `trusty_common::bin_resolve::resolve_binary`, which consults the live `PATH`
+/// and then the well-known bin directories. On any machine with trusty-analyze
+/// installed — which is every developer machine, and any CI image that ran
+/// `cargo install` — that resolves the INSTALLED binary, so the test spawns a
+/// build of some other commit and reports on it. That is not a hypothetical:
+/// before this helper existed, the concurrency test's child logged a startup
+/// line with no `idle` field at all, because the binary it ran predated #6350.
+///
+/// What: prepends `CARGO_BIN_EXE_trusty-analyze`'s directory to `PATH`.
+/// Idempotent, so tests may call it in any order.
+///
+/// SAFETY: `PATH` is read by `resolve_binary` and by every `Command` spawn, and
+/// this only ever PREPENDS — no test in this file depends on the original first
+/// entry, and prepending twice is a no-op in effect.
+fn use_the_binary_under_test() {
+    let exe = PathBuf::from(env!("CARGO_BIN_EXE_trusty-analyze"));
+    let dir = exe.parent().expect("the test binary has a directory");
+    let current = std::env::var("PATH").unwrap_or_default();
+    if current.starts_with(&format!("{}:", dir.display())) {
+        return;
+    }
+    unsafe { std::env::set_var("PATH", format!("{}:{current}", dir.display())) };
+}
+
+/// Poll until `socket` answers, or give up after `budget`.
+async fn await_serving(socket: &Path, budget: Duration) -> bool {
+    let deadline = Instant::now() + budget;
+    while Instant::now() < deadline {
+        if trusty_common::uds::socket_is_serving(socket, Duration::from_millis(200)).await {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    false
+}
+
+/// Why: this is the closure condition of #6350 — the server ends itself, and it
+/// ends CLEANLY, leaving no socket file for the next spawn to trip over. A
+/// server that exited but left the path occupied would push every later start
+/// onto `bind_singleton_hardened`'s takeover branch, which exists for a crash,
+/// not for the normal end of a lifetime.
+/// Test: this is the test.
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn serve_exits_on_its_own_idle_window() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let search = StubSearch::start().await;
+    let (socket, mut child) = spawn_server(tmp.path(), &search, 2);
+
+    assert!(
+        await_serving(&socket, Duration::from_secs(30)).await,
+        "the server never began serving {}",
+        socket.display()
+    );
+
+    let deadline = Instant::now() + Duration::from_secs(60);
+    let exited = loop {
+        match child.try_wait().expect("try_wait") {
+            Some(status) => break Some(status),
+            None if Instant::now() >= deadline => break None,
+            None => tokio::time::sleep(Duration::from_millis(100)).await,
+        }
+    };
+
+    let Some(status) = exited else {
+        let _ = child.kill();
+        panic!("the server did not exit within 60s of a 2s idle window");
+    };
+    assert!(status.success(), "an idle exit must be clean: {status:?}");
+    assert!(
+        !socket.exists(),
+        "an idle exit must unlink its socket; {} is still there",
+        socket.display()
+    );
+}
+
+/// Why: the fail-open branch this change must not have. A start that cannot
+/// succeed has to reach the caller as an error it can report, never as a path
+/// the caller then dials into a confusing transport failure.
+///
+/// What makes it deterministic: `resolve_binary` consults `PATH` and then the
+/// well-known bin directories, so on a machine with trusty-analyze installed
+/// the missing-binary branch is unreachable — and pointing `TRUSTY_SEARCH_URL`
+/// at nothing is what forces a failure that does not depend on the machine.
+/// `run_serve` refuses to start when trusty-search is unreachable, so the child
+/// exits before binding and `ensure_running` reports `SpawnTimeout`. Without
+/// this the test passed or failed according to whether the developer happened
+/// to have trusty-search running.
+/// Test: this is the test.
+#[serial_test::serial]
+#[tokio::test]
+async fn a_server_that_cannot_start_is_an_error_not_a_success() {
+    use_the_binary_under_test();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let socket = tmp.path().join("absent.sock");
+    // Off the real data directory: a developer machine with a live analyze
+    // daemon holds an exclusive redb lock on it, which would fail the spawned
+    // child for a reason that has nothing to do with the property under test.
+    // SAFETY: set before the spawn below; no other test in this file reads it
+    // before setting its own.
+    unsafe {
+        std::env::set_var("TRUSTY_ANALYZER_FACTS", tmp.path().join("facts.redb"));
+        // Port 1 is privileged and unbound: the child's startup probe of
+        // trusty-search always refuses, so it always exits before its bind.
+        std::env::set_var("TRUSTY_SEARCH_URL", "http://127.0.0.1:1");
+    }
+
+    let handle = trusty_common::uds::OnDemandAnalyze::at(&socket);
+    let err = tokio::time::timeout(Duration::from_secs(60), handle.ensure_running())
+        .await
+        .expect("ensure_running must not hang")
+        .expect_err("the child cannot start: its trusty-search probe always refuses");
+
+    let rendered = format!("{err}");
+    assert!(
+        !rendered.is_empty(),
+        "the failure must carry a message a caller can print"
+    );
+    assert!(
+        !socket.exists(),
+        "a failed start must not leave a socket implying success"
+    );
+}
+
+/// Why: the concurrency claim. Two callers that race must end up with ONE
+/// server — in-process the spawn gate serialises them and the second adopts the
+/// first's socket; across processes `bind_singleton_hardened` refuses the loser.
+/// A test that spawned two servers would show up here as two different pids
+/// answering, or as a caller that got an error while a healthy server was up.
+/// Test: this is the test.
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn two_concurrent_callers_share_one_server() {
+    use_the_binary_under_test();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let search = StubSearch::start().await;
+    let socket = tmp.path().join("trusty-analyze.sock");
+
+    // The child must find trusty-search and its own facts store, and both are
+    // per-test. `ensure_running` spawns with the parent's environment, so
+    // setting them here is what the child inherits.
+    // SAFETY: this test binary sets these once, before any spawn, and no other
+    // test in this file reads them.
+    unsafe {
+        std::env::set_var("TRUSTY_SEARCH_URL", &search.base_url);
+        std::env::set_var("TRUSTY_ANALYZER_FACTS", tmp.path().join("facts.redb"));
+        std::env::set_var("TRUSTY_ANALYZE_IDLE_TIMEOUT_SECS", "120");
+    }
+
+    let handle = Arc::new(trusty_common::uds::OnDemandAnalyze::at(&socket));
+    let a = tokio::spawn({
+        let handle = Arc::clone(&handle);
+        async move { handle.ensure_running().await }
+    });
+    let b = tokio::spawn({
+        let handle = Arc::clone(&handle);
+        async move { handle.ensure_running().await }
+    });
+
+    let (ra, rb) = tokio::join!(a, b);
+    let pa = ra.expect("join a").expect("first caller must get a server");
+    let pb = rb
+        .expect("join b")
+        .expect("second caller must get a server");
+
+    assert_eq!(pa, socket);
+    assert_eq!(
+        pb, socket,
+        "both callers must be pointed at the same socket"
+    );
+    assert!(
+        trusty_common::uds::socket_is_serving(&socket, Duration::from_secs(2)).await,
+        "one server must be left serving after both calls returned"
+    );
+
+    // Exactly one process is answering: a second server would have had to bind
+    // the same path, and `bind_singleton_hardened` refuses that while the first
+    // is live. Assert it directly by counting the processes that hold it.
+    let holders = std::process::Command::new("lsof")
+        .arg("-t")
+        .arg(&socket)
+        .output()
+        .map(|o| {
+            String::from_utf8_lossy(&o.stdout)
+                .split_whitespace()
+                .count()
+        })
+        .unwrap_or(1);
+    assert!(
+        holders <= 1,
+        "{holders} processes are serving one socket; the singleton bind failed"
+    );
+
+    // Stop the server rather than waiting out its window: the tempdir is about
+    // to be removed, and a live child holding a path inside it is a leak.
+    let _ = std::process::Command::new("pkill")
+        .arg("-f")
+        .arg(socket.to_string_lossy().as_ref())
+        .status();
+}
+
+/// Why: `ServiceTimeouts`' sourcing rule says the supervisor's `shutdown_flush`
+/// must be the supervised binary's REAL budget, and `trusty-common` cannot
+/// import this crate to read it. This equality is what turns that rule from a
+/// comment into a check — the same shape trusty-memory's
+/// `sigterm_patience_exceeds_the_daemon_flush_budget` uses.
+/// Test: this is the test.
+#[test]
+fn analyze_flush_budget_matches_the_supervisor_contract() {
+    assert_eq!(
+        trusty_common::uds::ANALYZE_SHUTDOWN_FLUSH,
+        trusty_analyze::service::SHUTDOWN_FLUSH_TIMEOUT,
+        "the supervisor's flush budget must be this server's own, not a literal \
+         that happens to match it today"
+    );
+}
+
+/// Why (#6350): the cross-process half of "two callers, one server". The
+/// in-process spawn gate cannot help two separate processes that probe an empty
+/// socket in the same instant; what arbitrates there is
+/// `bind_singleton_hardened`, which takes over only a path the kernel proves
+/// nobody is serving. If both children could bind, the second would unlink the
+/// first's socket and every client holding it would be talking to a process
+/// nothing can reach.
+///
+/// What: races two real `trusty-analyze serve` children on one empty socket
+/// directory and asserts the socket answers with exactly ONE of them still
+/// alive — the loser must have exited on its bind rather than clobbering the
+/// winner.
+/// Test: this is the test.
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn two_racing_server_processes_leave_exactly_one() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let search = StubSearch::start().await;
+
+    // Started back to back with no await between, so both reach their bind
+    // inside the same few milliseconds.
+    let (socket, mut first) = spawn_server_with_store(tmp.path(), &search, 120, "first");
+    let (_same, mut second) = spawn_server_with_store(tmp.path(), &search, 120, "second");
+
+    assert!(
+        await_serving(&socket, Duration::from_secs(30)).await,
+        "one of the two must win the bind and serve {}",
+        socket.display()
+    );
+
+    // Give the loser time to fail its bind and exit. It cannot be identified in
+    // advance, so both are polled and the survivors counted.
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let alive = loop {
+        let a = first.try_wait().expect("try_wait").is_none();
+        let b = second.try_wait().expect("try_wait").is_none();
+        let alive = usize::from(a) + usize::from(b);
+        if alive <= 1 || Instant::now() >= deadline {
+            break alive;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    };
+
+    let _ = first.kill();
+    let _ = second.kill();
+
+    assert_eq!(
+        alive, 1,
+        "exactly one server may hold the socket; {alive} processes survived the race"
+    );
+    assert!(
+        !socket.exists()
+            || trusty_common::uds::socket_is_serving(&socket, Duration::from_secs(1)).await,
+        "the loser must not have unlinked the winner's socket"
+    );
+}
+
+/// Why (#6350): `HttpAnalyzeMetricsSource` starts the server once per source,
+/// but a multi-repository report can outlive the idle window — the diagnostics
+/// endpoint alone carries a multi-minute budget. Without a retry, every fetch
+/// after the exit hard-fails and the rest of the report is silently scanned
+/// instead of analysed. This is the property that closes that gap.
+///
+/// What: drives the REAL adapter against a real server with a two-second idle
+/// window, waits for the server to reclaim itself between two fetches, and
+/// asserts the second fetch still reaches a server. `NotIndexed` is the
+/// expected verdict for both — the tempdir has no index — and it is the
+/// interesting one: it can only be reached by a server that ANSWERED
+/// `analyze.index_list`. `Unreachable` is what a missing retry produces.
+/// Test: this is the test.
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn the_adapter_respawns_a_server_that_idled_out() {
+    use trusty_review::report::{AnalyzeFetch, AnalyzeMetricsSource as _};
+
+    use_the_binary_under_test();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let search = StubSearch::start().await;
+    let socket = tmp.path().join("trusty-analyze.sock");
+
+    // `ensure_running` spawns with this process's environment, so the child
+    // finds the stub search, its own facts store, and a short idle window here.
+    // SAFETY: set once, before any spawn; no other test in this file reads them.
+    unsafe {
+        std::env::set_var("TRUSTY_SEARCH_URL", &search.base_url);
+        std::env::set_var("TRUSTY_ANALYZER_FACTS", tmp.path().join("facts.redb"));
+        std::env::set_var("TRUSTY_ANALYZE_IDLE_TIMEOUT_SECS", "2");
+    }
+
+    let source = trusty_review::report::HttpAnalyzeMetricsSource::new(&socket)
+        .expect("infallible since #6287");
+
+    let first = source.fetch_named("absent-index").await;
+    assert!(
+        matches!(first, AnalyzeFetch::Missing(gap) if gap.as_str().contains("not built")),
+        "the first fetch must reach a server that answers index_list"
+    );
+
+    // Wait out the idle window: the server reclaims itself and unlinks.
+    let deadline = Instant::now() + Duration::from_secs(60);
+    while Instant::now() < deadline {
+        if !trusty_common::uds::socket_is_serving(&socket, Duration::from_millis(200)).await {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+    assert!(
+        !trusty_common::uds::socket_is_serving(&socket, Duration::from_millis(500)).await,
+        "the server must have idled out for this test to prove anything"
+    );
+
+    let second = source.fetch_named("absent-index").await;
+    match second {
+        AnalyzeFetch::Missing(gap) => assert!(
+            gap.as_str().contains("not built"),
+            "the second fetch must have reached a RESTARTED server, not given up: {}",
+            gap.as_str()
+        ),
+        AnalyzeFetch::Fetched { .. } => panic!("no index exists; nothing could have been fetched"),
+        // `AnalyzeFetch` is `#[non_exhaustive]`; a variant added later is not
+        // this test's verdict either way, so it fails loudly rather than
+        // silently passing on a shape nobody has considered.
+        other => panic!("unexpected fetch verdict: {other:?}"),
+    }
+
+    let _ = std::process::Command::new("pkill")
+        .arg("-f")
+        .arg(socket.to_string_lossy().as_ref())
+        .status();
+}

--- a/crates/trusty-analyze/tests/uds_consumer_contract.rs
+++ b/crates/trusty-analyze/tests/uds_consumer_contract.rs
@@ -306,7 +306,20 @@ async fn every_consumer_sees_an_absent_daemon_as_not_running() {
     );
     assert!(info.version.is_none(), "there is no envelope to read");
 
+    // #6350: `tctl`'s probe now STARTS an on-demand member before dialling it,
+    // so without the opt-out this assertion would spawn a real server (and wait
+    // out its 20-second budget) rather than observing an absent one. With the
+    // opt-out the probe dials whatever is there — the arrangement an operator
+    // running their own server has — and an absent daemon is `Refused`, which
+    // is the property this test exists to pin: every consumer agrees on what
+    // "not running" looks like. That the probe can START one is covered
+    // separately in `tests/on_demand.rs`.
+    //
+    // SAFETY: the surrounding `EnvGuard` already serialises this test against
+    // the rest of the file's environment mutation.
+    unsafe { std::env::set_var(trusty_common::uds::ANALYZE_EXTERNAL_ENV, "1") };
     let outcome = probe_daemon_http("trusty-analyze", "trusty-analyze").await;
+    unsafe { std::env::remove_var(trusty_common::uds::ANALYZE_EXTERNAL_ENV) };
     assert_eq!(outcome, ProbeOutcome::Refused, "got {outcome:?}");
     assert!(outcome.is_confirmed_down());
     // `EnvGuard` restores the environment on the way out, panic or not.

--- a/crates/trusty-common/changelog.d/6350-idle-exit-drains-the-backlog.md
+++ b/crates/trusty-common/changelog.d/6350-idle-exit-drains-the-backlog.md
@@ -1,0 +1,4 @@
+Fixed
+- An idle-exiting UDS server now drains the kernel accept backlog for 50ms
+  before giving up its listener, so a client that connected microseconds before
+  the idle window elapsed is served rather than reset (#6350).

--- a/crates/trusty-common/changelog.d/6350-on-demand-analyze-changed.md
+++ b/crates/trusty-common/changelog.d/6350-on-demand-analyze-changed.md
@@ -1,0 +1,7 @@
+Changed
+- `launchd_labels` splits its registry in two: `SERVICES` is what an install
+  writes, `RETIRED_SERVICES` is what an upgrade must clear. `com.trusty.analyze`
+  moves to the second table — named so a migration can still evict a unit an
+  older installer left loaded, separate so nothing installs it again.
+  `retired_labels_for_member` returns that eviction set, canonical label first
+  (#6350).

--- a/crates/trusty-common/changelog.d/6350-on-demand-analyze.md
+++ b/crates/trusty-common/changelog.d/6350-on-demand-analyze.md
@@ -1,0 +1,14 @@
+Added
+- `uds::server::serve_until_idle` and `uds::server::IdleTracker` give a UDS
+  service an idle-exit policy: the accept loop returns `ServeExit::Idle` once no
+  connection has ANSWERED anything for the configured window. A bare
+  connect-and-close liveness probe does not restart the window, so a status page
+  polling a service cannot pin it resident (#6350).
+- `uds::OnDemandAnalyze` is the single entry point every client uses to start
+  `trusty-analyze` before dialling it. Its spawn gate keeps two concurrent
+  callers in one process from starting two servers, and every failure — no
+  binary, a refused spawn, a socket that never appeared — is returned rather than
+  degraded to a success (#6350).
+- `SupervisorConfig::with_detached` spawns children without `kill_on_drop` and
+  keeps them out of the population map, so a short-lived CLI does not SIGKILL a
+  server another client is mid-request against (#6350).

--- a/crates/trusty-common/src/launchd_labels.rs
+++ b/crates/trusty-common/src/launchd_labels.rs
@@ -39,14 +39,16 @@
 //! was never independent evidence of anything. Both are recorded as legacy
 //! aliases below.
 //!
-//! **A retired daemon keeps its row (#6290).** [`SERVICES`] is what an install
-//! WRITES; [`RETIRED_SERVICES`] is what an upgrade must CLEAR. trusty-review is
-//! the first row in the second table: ADR-0032's review lane retired its daemon
-//! outright, so nothing installs `com.trusty.review` any more — but every host
-//! that ran the old binary still has that unit loaded, pointed at a `serve`
-//! subcommand the binary no longer has. Dropping the row would leave the unit
-//! unnamed by anything and therefore un-evictable, which is why a retirement is
-//! a MOVE between the two tables, never a deletion.
+//! **A retired daemon keeps its row (#6290, #6350).** [`SERVICES`] is what an
+//! install WRITES; [`RETIRED_SERVICES`] is what an upgrade must CLEAR. Two rows
+//! sit in the second table, both from ADR-0032: trusty-review retired its
+//! daemon outright (#6290, reviews run per invocation), and trusty-analyze
+//! retired its resident one (#6350, a client starts it and it exits on its own
+//! idle window). Nothing installs either unit any more, but every host that ran
+//! an older binary still has one loaded under `KeepAlive::Always`. Dropping a
+//! row would leave that unit unnamed by anything and therefore un-evictable,
+//! which is why a retirement is a MOVE between the two tables, never a
+//! deletion.
 //!
 //! Deliberately NOT `#[cfg(target_os = "macos")]`, unlike `crate::launchd`:
 //! the registry is data, and gating it would stop the drift tests from running
@@ -100,7 +102,14 @@ pub const MPM_SUPERVISOR: &str = agent!("mpm", "supervisor");
 /// The trusty-memory daemon.
 pub const MEMORY: &str = agent!("memory");
 
-/// The trusty-analyze daemon.
+/// The RETIRED trusty-analyze daemon (#6350).
+///
+/// trusty-analyze has no resident daemon: a client starts it on demand and it
+/// exits on its own idle window. This label is kept so an upgrade can EVICT the
+/// unit a pre-#6350 install left loaded — it lives in [`RETIRED_SERVICES`], not
+/// [`SERVICES`], and nothing writes it any more. Deleting it would strand that
+/// unit on every host that ever installed the old binary, where
+/// `KeepAlive::Always` restarts the process the moment it reclaims itself.
 pub const ANALYZE: &str = agent!("analyze");
 
 /// The trusty-search daemon.
@@ -187,12 +196,6 @@ pub const SERVICES: &[Service] = &[
         legacy: &["com.trusty.trusty-memory"],
     },
     Service {
-        member: "trusty-analyze",
-        sub_unit: None,
-        label: ANALYZE,
-        legacy: &["com.trusty.trusty-analyze"],
-    },
-    Service {
         member: "trusty-search",
         sub_unit: None,
         label: SEARCH,
@@ -222,14 +225,16 @@ pub const SERVICES: &[Service] = &[
     },
 ];
 
-/// Services this workspace once installed and now only EVICTS (#6290).
+/// Services this workspace once installed and now only EVICTS (#6290, #6350).
 ///
 /// Why: retiring a daemon is not the same as never having had one. Every host
 /// that installed trusty-review before #6290 has `com.trusty.review` loaded,
-/// pointed at a `serve` subcommand the binary no longer has, and
-/// `KeepAlive::Always` respawns it forever. Deleting the row would leave that
-/// unit unnamed by anything, so nothing could boot it out; keeping it in
-/// [`SERVICES`] would keep an install WRITING it. This table is the third
+/// pointed at a `serve` subcommand the binary no longer has; every host that
+/// installed trusty-analyze before #6350 has `com.trusty.analyze` loaded,
+/// restarting the process the moment its idle window reclaims it. Both units
+/// carry `KeepAlive::Always`, so both respawn forever. Deleting a row would
+/// leave that unit unnamed by anything, so nothing could boot it out; keeping
+/// it in [`SERVICES`] would keep an install WRITING it. This table is the third
 /// answer: named, so it can be evicted; separate, so it is never installed.
 ///
 /// What: the same [`Service`] shape, read as "the labels an upgrade must clear
@@ -242,7 +247,8 @@ pub const SERVICES: &[Service] = &[
 /// loaded costs nothing at all.
 ///
 /// Test: `retired_services_are_not_installed`,
-/// `retired_review_carries_both_its_labels`.
+/// `retired_review_carries_both_its_labels`,
+/// `retired_analyze_carries_both_its_labels`.
 pub const RETIRED_SERVICES: &[Service] = &[
     // #6290: ADR-0032's review lane. Reviews run per invocation
     // (`trusty-review run`); there is no listener to supervise.
@@ -251,6 +257,14 @@ pub const RETIRED_SERVICES: &[Service] = &[
         sub_unit: None,
         label: REVIEW,
         legacy: &["com.trusty.trusty-review"],
+    },
+    // #6350: ADR-0032's analyze lane. A client starts the server on demand and
+    // it exits on its own idle window; there is nothing to supervise.
+    Service {
+        member: "trusty-analyze",
+        sub_unit: None,
+        label: ANALYZE,
+        legacy: &["com.trusty.trusty-analyze"],
     },
 ];
 
@@ -285,15 +299,16 @@ pub fn sub_label(base: &str, sub_unit: &str) -> String {
 /// What: returns the [`SERVICES`] or [`RETIRED_SERVICES`] entry whose `label`
 /// matches, or `None`.
 ///
-/// #6290 — why retired rows are searched too: the eviction of a retired unit
-/// needs its `legacy` list exactly as an install needs a live one's, and
-/// `com.trusty.review` is still a label this workspace names. Excluding it
-/// would make [`legacy_labels_for`] return empty for it, so an upgrade would
-/// boot out the canonical unit and leave `com.trusty.trusty-review` loaded
-/// beside it — #2938's two-units-one-service shape, arrived at from the other
-/// direction.
+/// #6290, #6350 — why retired rows are searched too: the eviction of a retired
+/// unit needs its `legacy` list exactly as an install needs a live one's, and
+/// `com.trusty.review` and `com.trusty.analyze` are still labels this workspace
+/// names. Excluding them would make [`legacy_labels_for`] return empty, so an
+/// upgrade would boot out the canonical unit and leave the `com.trusty.trusty-*`
+/// alias loaded beside it — #2938's two-units-one-service shape, arrived at from
+/// the other direction.
 /// Test: `every_legacy_label_resolves_to_one_service`,
-/// `retired_review_carries_both_its_labels`.
+/// `retired_review_carries_both_its_labels`,
+/// `retired_analyze_carries_both_its_labels`.
 #[must_use]
 pub fn service_for_label(label: &str) -> Option<&'static Service> {
     SERVICES
@@ -305,7 +320,7 @@ pub fn service_for_label(label: &str) -> Option<&'static Service> {
 /// The retired service registered for `member`, if any.
 ///
 /// What: the [`RETIRED_SERVICES`] entry whose `member` matches. `None` for a
-/// member that never had a retired unit, which is every member but one.
+/// member that never had a retired unit.
 /// Test: `retired_services_are_not_installed`.
 #[must_use]
 pub fn retired_service_for_member(member: &str) -> Option<&'static Service> {
@@ -319,8 +334,10 @@ pub fn retired_service_for_member(member: &str) -> Option<&'static Service> {
 /// remember to do — forgetting the second half is how a pre-rename unit
 /// survives an upgrade (#2938).
 /// What: the retired service's own `label` followed by its `legacy` aliases,
-/// newest first; empty for a member with no retired unit.
-/// Test: `retired_review_carries_both_its_labels`.
+/// newest first; empty for a member with no retired unit. The canonical label
+/// comes first because it is the one holding the running process.
+/// Test: `retired_review_carries_both_its_labels`,
+/// `retired_analyze_carries_both_its_labels`.
 #[must_use]
 pub fn retired_labels_for_member(member: &str) -> Vec<&'static str> {
     retired_service_for_member(member).map_or_else(Vec::new, |s| {

--- a/crates/trusty-common/src/launchd_labels/tests.rs
+++ b/crates/trusty-common/src/launchd_labels/tests.rs
@@ -117,7 +117,7 @@ fn retired_services_are_not_installed() {
     let members: Vec<&str> = RETIRED_SERVICES.iter().map(|s| s.member).collect();
     assert_eq!(
         members,
-        vec!["trusty-review"],
+        vec!["trusty-review", "trusty-analyze"],
         "adding a retirement is a deliberate act — update this pin with it"
     );
 }
@@ -871,4 +871,35 @@ fn eviction_outcome_only_failed_is_a_failure() {
     let e = LabelEviction::new("com.trusty.review", EvictionOutcome::Absent);
     assert_eq!(e.label, "com.trusty.review");
     assert_eq!(e.outcome, EvictionOutcome::Absent);
+}
+
+/// Why (#6350): trusty-analyze's unit exists under two names on real hosts —
+/// `com.trusty.analyze` from the post-#4919 installer and
+/// `com.trusty.trusty-analyze` from before it. An eviction that clears only one
+/// leaves the other loaded under `KeepAlive::Always`, restarting the on-demand
+/// server the moment its idle window reclaims it.
+/// What: both labels come back from `retired_labels_for_member`, canonical
+/// first, and the member resolves through the retired lookup.
+/// Test: this is the test.
+#[test]
+fn retired_analyze_carries_both_its_labels() {
+    assert!(
+        retired_service_for_member("trusty-analyze").is_some(),
+        "trusty-analyze runs on demand since #6350 and installs no unit"
+    );
+    assert_eq!(
+        retired_labels_for_member("trusty-analyze"),
+        vec![ANALYZE, "com.trusty.trusty-analyze"]
+    );
+    assert!(
+        retired_labels_for_member("trusty-memory").is_empty(),
+        "a live member has nothing to evict"
+    );
+    // The retired row still resolves by label, which is what keeps
+    // `legacy_labels_for` from returning empty for it.
+    assert_eq!(
+        legacy_labels_for(ANALYZE),
+        &["com.trusty.trusty-analyze"],
+        "an eviction needs the retired row's legacy list just as an install needs a live one's"
+    );
 }

--- a/crates/trusty-common/src/uds/mod.rs
+++ b/crates/trusty-common/src/uds/mod.rs
@@ -80,7 +80,23 @@ pub mod stream_client;
 #[cfg(feature = "uds-supervisor")]
 pub mod supervisor;
 
+/// The single entry point for starting `trusty-analyze` on demand (#6350).
+///
+/// Why it sits beside [`supervisor`] rather than inside it: the supervisor is
+/// the generic machinery, and this is the one service description every client
+/// crate shares. Gated behind the same feature, because it is that machinery
+/// applied.
+/// Test: `on_demand_tests.rs`.
+#[cfg(feature = "uds-supervisor")]
+pub mod on_demand;
+
 pub use dir::prepare_socket_dir;
+#[cfg(feature = "uds-supervisor")]
+pub use on_demand::{
+    ANALYZE_EXTERNAL_ENV, ANALYZE_IDLE_TIMEOUT_ENV, ANALYZE_SERVICE, ANALYZE_SHUTDOWN_FLUSH,
+    DEFAULT_ANALYZE_IDLE_TIMEOUT, OnDemandAnalyze, analyze_idle_timeout,
+    analyze_idle_timeout_from_env,
+};
 pub use peer::{ensure_peer_is_self, peer_uid, self_uid};
 pub use probe::{SocketVerdict, probe_socket_verdict, socket_is_serving};
 pub use rpc::{

--- a/crates/trusty-common/src/uds/on_demand.rs
+++ b/crates/trusty-common/src/uds/on_demand.rs
@@ -1,0 +1,278 @@
+//! The one place a client starts `trusty-analyze` on demand (#6350, ADR-0032).
+//!
+//! Why here, rather than in `trusty-analyze`: three crates dial that socket —
+//! `trusty-review`'s report adapter, `trusty-analyze`'s own `deep` subcommand,
+//! and `tctl`'s boot stage — and only `trusty-analyze` has a Cargo edge on
+//! itself. `trusty-installer` deliberately has none (see `probe_http`'s note on
+//! why it duplicates method-name literals rather than depending on a daemon),
+//! and `trusty-review` has none either. So the description of HOW to start the
+//! service — binary name, arguments, socket path, spawn budget — has to live in
+//! the crate all three already depend on, next to
+//! [`crate::daemon_socket_path`], which is where they already agree about
+//! WHERE it answers.
+//!
+//! What: [`OnDemandAnalyze`], a small owned handle wrapping a
+//! [`UdsServiceSupervisor`] in [`SupervisorConfig::with_detached`] mode. One
+//! call — [`OnDemandAnalyze::ensure_running`] — returns the socket path with
+//! something answering on it, spawning `trusty-analyze serve` only when nothing
+//! is.
+//!
+//! **Two callers, one server, at two levels.** Within a process, the handle's
+//! spawn gate serialises concurrent callers and the second one finds the socket
+//! already serving. Across processes there is no shared gate, so the arbiter is
+//! `bind_singleton_hardened` in the child: it takes over only a socket the
+//! kernel proves nobody is serving, so the loser of a two-process race exits on
+//! its bind and the winner serves both clients.
+//!
+//! **This module never fails open.** Every failure — no binary on `PATH`, a
+//! spawn the OS refused, a socket that never appeared inside the budget —
+//! reaches the caller as a [`SupervisorError`]. A client that wants to degrade
+//! rather than abort makes that choice itself, visibly; nothing here decides it
+//! silently on the caller's behalf.
+//!
+//! Test: `on_demand_tests.rs` — `analyze_spawn_spec_runs_a_bare_serve`,
+//! `analyze_timeouts_leave_room_for_the_flush`,
+//! `idle_timeout_parses_its_three_meanings`,
+//! `external_mode_returns_the_socket_without_spawning`,
+//! `the_default_handle_uses_the_shared_socket_path`. The real spawn, the idle
+//! exit and the two-concurrent-callers race are proven against the built binary
+//! in `trusty-analyze`'s `tests/on_demand.rs`, since only that crate has one.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use super::supervisor::{
+    ServiceTimeouts, SpawnSpec, SupervisorConfig, SupervisorError, UdsServiceSupervisor,
+};
+
+/// Binary and member name of the analysis service.
+pub const ANALYZE_SERVICE: &str = "trusty-analyze";
+
+/// Environment variable that suppresses on-demand spawning.
+///
+/// Why: an operator running `trusty-analyze serve` in a terminal, or a
+/// developer running one under a debugger, owns that process's lifecycle.
+/// Setting this to exactly `1` makes every client dial whatever is there and
+/// never start one of its own — the same opt-out `tctl`-managed services get
+/// under ADR-0034 §1.
+pub const ANALYZE_EXTERNAL_ENV: &str = "TRUSTY_ANALYZE_EXTERNAL";
+
+/// Environment variable overriding the server's idle window, in seconds.
+///
+/// `0` disables idle exit, for an operator who wants a foreground server that
+/// stays up. Read by the SERVER (`trusty-analyze serve`), not by clients — it is
+/// declared here because [`analyze_idle_timeout`] is the single parser both a
+/// client's documentation and the server's startup read.
+pub const ANALYZE_IDLE_TIMEOUT_ENV: &str = "TRUSTY_ANALYZE_IDLE_TIMEOUT_SECS";
+
+/// Default idle window before an on-demand analyze server exits.
+///
+/// Ten minutes, chosen from the 5–15 minute band the #6350 ruling set. The two
+/// costs it balances: a cold start re-opens the facts redb and the SCIP overlay
+/// store and re-warms per-index chunk caches, so a window shorter than an
+/// operator's edit-run loop makes every `trusty-review report --analyze` pay
+/// that again; and a resident process that nobody has spoken to for ten minutes
+/// is exactly the thing ADR-0032 retired the launchd unit to stop having.
+pub const DEFAULT_ANALYZE_IDLE_TIMEOUT: Duration = Duration::from_secs(600);
+
+/// The analyze server's own shutdown budget.
+///
+/// Why this exists rather than a literal at the [`ServiceTimeouts`] call site:
+/// that type's sourcing rule says `shutdown_flush` must be the supervised
+/// binary's real budget, and `trusty-common` cannot import `trusty-analyze` to
+/// read it. So the constant lives here and `trusty-analyze`'s
+/// `analyze_flush_budget_matches_the_supervisor_contract` pins its own value
+/// against it — the equality is checked, rather than assumed to have stayed
+/// true.
+///
+/// One second: the server holds no write buffer. `redb` commits inside each
+/// handler before it answers, so a SIGTERM at any point discards nothing that
+/// was acked; the budget covers the accept loop returning and the socket unlink.
+pub const ANALYZE_SHUTDOWN_FLUSH: Duration = Duration::from_secs(1);
+
+/// How long to wait for a freshly-spawned analyze server to accept.
+///
+/// The server opens two redb files before it binds. On a warm page cache that is
+/// milliseconds; on a cold one, or a machine under load, it is not, and a budget
+/// that expires produces a `SpawnTimeout` the caller reports as a failure while
+/// the server binds successfully a moment later.
+const ANALYZE_SPAWN_PROBE: Duration = Duration::from_secs(20);
+
+/// SIGTERM-to-SIGKILL patience. Must strictly exceed [`ANALYZE_SHUTDOWN_FLUSH`].
+const ANALYZE_SIGTERM_PATIENCE: Duration = Duration::from_secs(5);
+
+/// The analyze service's timing budget.
+///
+/// `const`, so the `sigterm_patience > shutdown_flush` relation is a build
+/// error rather than a runtime panic — see [`ServiceTimeouts::new`].
+pub const ANALYZE_TIMEOUTS: ServiceTimeouts = ServiceTimeouts::new(
+    ANALYZE_SPAWN_PROBE,
+    ANALYZE_SHUTDOWN_FLUSH,
+    ANALYZE_SIGTERM_PATIENCE,
+);
+
+/// Resolve the idle window a server should apply.
+///
+/// Why a parser rather than a bare `env::var`: the variable has three meanings —
+/// unset is the default, `0` is "never exit", anything else is a second count —
+/// and a caller that read it inline would have to re-derive all three. An
+/// unparseable value is treated as unset rather than fatal: a typo in an
+/// environment variable must not stop the service from starting.
+///
+/// What: `None` means never exit; `Some(d)` is the window.
+/// Test: `idle_timeout_parses_its_three_meanings`.
+pub fn analyze_idle_timeout(raw: Option<&str>) -> Option<Duration> {
+    match raw.map(str::trim) {
+        None | Some("") => Some(DEFAULT_ANALYZE_IDLE_TIMEOUT),
+        Some(value) => match value.parse::<u64>() {
+            Ok(0) => None,
+            Ok(secs) => Some(Duration::from_secs(secs)),
+            Err(_) => Some(DEFAULT_ANALYZE_IDLE_TIMEOUT),
+        },
+    }
+}
+
+/// Read [`ANALYZE_IDLE_TIMEOUT_ENV`] through [`analyze_idle_timeout`].
+pub fn analyze_idle_timeout_from_env() -> Option<Duration> {
+    analyze_idle_timeout(std::env::var(ANALYZE_IDLE_TIMEOUT_ENV).ok().as_deref())
+}
+
+/// A handle that starts `trusty-analyze` when nothing is serving its socket.
+///
+/// Why an owned handle rather than a free function: the in-process half of the
+/// "two callers, one server" guarantee is the supervisor's spawn gate, and a
+/// free function would build a fresh supervisor — and a fresh gate — per call,
+/// letting two concurrent callers in one process each spawn a server. Sharing
+/// one handle (behind an `Arc` where the caller is concurrent) is what closes
+/// that. It is deliberately NOT a process-wide singleton: this workspace keeps
+/// no global state, and a handle costs one small struct.
+///
+/// What: `ensure_running` is the whole surface. The socket path is resolved once
+/// at construction through [`crate::daemon_socket_path`], the same call the
+/// server itself binds, so there is nothing for the two to disagree about.
+///
+/// Test: `the_default_handle_uses_the_shared_socket_path`,
+/// `external_mode_returns_the_socket_without_spawning`.
+#[derive(Debug)]
+pub struct OnDemandAnalyze {
+    supervisor: UdsServiceSupervisor,
+    socket: PathBuf,
+}
+
+impl OnDemandAnalyze {
+    /// A handle for the socket every consumer dials.
+    ///
+    /// # Errors
+    ///
+    /// When the data directory cannot be resolved, which is what makes the
+    /// socket path underivable.
+    pub fn new() -> Result<Self, SupervisorError> {
+        // `SpawnSpec` is the variant for "could not work out how or where to
+        // run it", which an underivable socket path is: without it there is
+        // nothing to pass the child as `--socket` and nothing for a client to
+        // dial. `SocketPath` cannot carry this — its source is a
+        // `UdsSecurityError`, and this failure is a data-directory one.
+        let socket = crate::daemon_socket_path(ANALYZE_SERVICE).map_err(|source| {
+            SupervisorError::SpawnSpec {
+                service: ANALYZE_SERVICE.to_string(),
+                key: ANALYZE_SERVICE.to_string(),
+                source: source.into(),
+            }
+        })?;
+        Ok(Self::at(socket))
+    }
+
+    /// A handle for an explicit socket path.
+    ///
+    /// Why public: a test needs a socket under its own tempdir rather than the
+    /// developer's real data directory, and `trusty-analyze serve --socket`
+    /// exists for exactly that.
+    pub fn at(socket: impl Into<PathBuf>) -> Self {
+        Self {
+            // `max_live` is 1 and unused: a detached child never enters the
+            // population map, so nothing is ever counted against the cap.
+            supervisor: UdsServiceSupervisor::new(
+                SupervisorConfig::new(ANALYZE_SERVICE, 1, ANALYZE_TIMEOUTS)
+                    .with_external_env(ANALYZE_EXTERNAL_ENV)
+                    .with_detached(true),
+            ),
+            socket: socket.into(),
+        }
+    }
+
+    /// The socket this handle guarantees is being served.
+    pub fn socket(&self) -> &Path {
+        &self.socket
+    }
+
+    /// Return the socket path with a server answering on it.
+    ///
+    /// What: delegates to [`UdsServiceSupervisor::ensure_running`], which
+    /// returns immediately when the socket already answers and otherwise spawns
+    /// `trusty-analyze serve` and waits for the bind. The binary is located
+    /// through [`crate::bin_resolve::resolve_binary`] — the workspace's single
+    /// answer to "find this executable", which also searches the well-known bin
+    /// directories a launchd-minimal `PATH` omits.
+    ///
+    /// # Errors
+    ///
+    /// [`SupervisorError::SpawnSpec`] when `trusty-analyze` is not installed,
+    /// [`SupervisorError::Spawn`] when the OS refused the spawn,
+    /// [`SupervisorError::SpawnTimeout`] when no socket appeared inside
+    /// [`ANALYZE_SPAWN_PROBE`], and [`SupervisorError::UntrustedSocket`] when
+    /// something is serving the path but does not pass the ownership check.
+    /// None of these is degraded into a success — see the module docs.
+    pub async fn ensure_running(&self) -> Result<PathBuf, SupervisorError> {
+        self.supervisor
+            .ensure_running(ANALYZE_SERVICE, &self.socket, || {
+                Ok(analyze_spawn_spec(&self.socket)?)
+            })
+            .await
+    }
+}
+
+/// The command that starts one analyze server on `socket`.
+///
+/// Why the socket is passed explicitly rather than left to the child's own
+/// derivation: `OnDemandAnalyze::at` exists so a test can use a tempdir path,
+/// and a child that derived the default would bind somewhere the parent never
+/// probes — a spawn that "succeeds" against a socket nobody dials.
+///
+/// # Errors
+///
+/// When `trusty-analyze` is not on `PATH` or in a well-known bin directory.
+///
+/// Test: `analyze_spawn_spec_runs_a_bare_serve`.
+pub fn analyze_spawn_spec(socket: &Path) -> Result<SpawnSpec, MissingBinary> {
+    let program = crate::bin_resolve::resolve_binary(ANALYZE_SERVICE).ok_or(MissingBinary {
+        name: ANALYZE_SERVICE,
+    })?;
+    let mut spec = SpawnSpec::new(program)
+        .arg("serve")
+        .arg("--socket")
+        .arg(socket);
+    if let Some(dir) = socket.parent() {
+        spec = spec.create_dir(dir);
+    }
+    Ok(spec)
+}
+
+/// `trusty-analyze` is not installed anywhere this process can see.
+///
+/// Why its own type rather than a bare string: this is the failure an operator
+/// fixes with one action (install the binary), and it reaches them through
+/// [`SupervisorError::SpawnSpec`]'s source chain, where a `&'static str` would
+/// have arrived as an unattributed sentence.
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "{name} is not installed — no such executable on PATH or in the standard \
+     bin directories. Install it with `tctl install {name}`."
+)]
+pub struct MissingBinary {
+    /// The binary that could not be located.
+    pub name: &'static str,
+}
+
+#[cfg(test)]
+#[path = "on_demand_tests.rs"]
+mod tests;

--- a/crates/trusty-common/src/uds/on_demand_tests.rs
+++ b/crates/trusty-common/src/uds/on_demand_tests.rs
@@ -1,0 +1,138 @@
+//! Coverage for the shared on-demand analyze entry point (#6350).
+//!
+//! What is provable here: the spawn spec, the timing budget, the idle-window
+//! parser, and the external-mode opt-out — all without a built binary. The real
+//! spawn, the idle exit, and the two-concurrent-callers race need a real
+//! `trusty-analyze` and are proven in that crate's `on_demand_tests.rs`.
+
+use super::*;
+
+/// Why: the child must bind the path the parent probes. A spec that dropped
+/// `--socket` would have the child derive the real data directory instead, and
+/// every test using a tempdir would spawn a server nobody dials — a spawn that
+/// times out for a reason no error message names.
+/// Test: this test itself.
+#[test]
+fn analyze_spawn_spec_runs_a_bare_serve() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let socket = tmp.path().join("sockets").join("trusty-analyze.sock");
+
+    let Ok(spec) = analyze_spawn_spec(&socket) else {
+        eprintln!("skip: trusty-analyze is not installed on this machine");
+        return;
+    };
+
+    let args: Vec<String> = spec
+        .args
+        .iter()
+        .map(|a| a.to_string_lossy().into_owned())
+        .collect();
+    assert_eq!(args[0], "serve", "the child must be a plain serve");
+    assert_eq!(args[1], "--socket");
+    assert_eq!(args[2], socket.to_string_lossy());
+    assert!(
+        spec.create_dirs
+            .contains(&socket.parent().expect("parent").to_path_buf()),
+        "the socket's directory must be created before the child tries to bind it"
+    );
+    assert!(
+        !args.iter().any(|a| a == "--port" || a == "--mcp"),
+        "no retired transport flag may be passed: {args:?}"
+    );
+}
+
+/// Why: `ServiceTimeouts::new` is a `const fn` whose assert fires at build time,
+/// so an inverted pair would already have failed the compile. What this test
+/// adds is the direction of the margin — a patience that merely matched the
+/// flush would SIGKILL inside it.
+/// Test: this test itself.
+#[test]
+fn analyze_timeouts_leave_room_for_the_flush() {
+    assert!(
+        ANALYZE_TIMEOUTS.sigterm_patience > ANALYZE_TIMEOUTS.shutdown_flush,
+        "the SIGKILL must land after the flush window, never inside it"
+    );
+    assert_eq!(ANALYZE_TIMEOUTS.shutdown_flush, ANALYZE_SHUTDOWN_FLUSH);
+    assert!(
+        ANALYZE_TIMEOUTS.spawn_probe >= Duration::from_secs(5),
+        "the budget has to cover opening two redb files on a cold page cache"
+    );
+}
+
+/// Why: the default is the whole operator-facing promise of #6350 — a server
+/// that reclaims itself — and the two special values are the escape hatches.
+/// Test: this test itself.
+#[test]
+fn idle_timeout_parses_its_three_meanings() {
+    assert_eq!(
+        analyze_idle_timeout(None),
+        Some(DEFAULT_ANALYZE_IDLE_TIMEOUT)
+    );
+    assert_eq!(
+        analyze_idle_timeout(Some("")),
+        Some(DEFAULT_ANALYZE_IDLE_TIMEOUT)
+    );
+    assert_eq!(
+        analyze_idle_timeout(Some("0")),
+        None,
+        "0 must mean never exit, not exit immediately"
+    );
+    assert_eq!(
+        analyze_idle_timeout(Some(" 90 ")),
+        Some(Duration::from_secs(90))
+    );
+    assert_eq!(
+        analyze_idle_timeout(Some("soon")),
+        Some(DEFAULT_ANALYZE_IDLE_TIMEOUT),
+        "a typo must not stop the server from starting"
+    );
+    assert!(
+        DEFAULT_ANALYZE_IDLE_TIMEOUT >= Duration::from_secs(5 * 60)
+            && DEFAULT_ANALYZE_IDLE_TIMEOUT <= Duration::from_secs(15 * 60),
+        "the #6350 ruling fixed the default inside a 5–15 minute band"
+    );
+}
+
+/// Why: an operator running `trusty-analyze serve` by hand owns that process.
+/// With the opt-out set, `ensure_running` must hand back the path and start
+/// nothing, even with no socket there at all — otherwise a debugging session
+/// gets a second server spawned underneath it.
+/// Test: this test itself.
+#[serial_test::serial]
+#[tokio::test]
+async fn external_mode_returns_the_socket_without_spawning() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let socket = tmp.path().join("absent.sock");
+    let handle = OnDemandAnalyze::at(&socket);
+
+    // SAFETY: `#[serial]` keeps every other test in this binary off the
+    // environment for the duration, which is the precondition `set_var`/
+    // `remove_var` carry in edition 2024.
+    unsafe { std::env::set_var(ANALYZE_EXTERNAL_ENV, "1") };
+    let path = handle.ensure_running().await;
+    unsafe { std::env::remove_var(ANALYZE_EXTERNAL_ENV) };
+
+    assert_eq!(
+        path.expect("external mode must succeed without a server"),
+        socket
+    );
+    assert!(
+        !socket.exists(),
+        "external mode must not have started anything"
+    );
+}
+
+/// Why: the socket a client dials and the socket the server binds are the same
+/// derived path, and this handle is where a client resolves it. A divergence
+/// here is the class of bug the retired `http_addr` discovery file used to
+/// produce.
+/// Test: this test itself.
+#[test]
+fn the_default_handle_uses_the_shared_socket_path() {
+    let Ok(expected) = crate::daemon_socket_path(ANALYZE_SERVICE) else {
+        eprintln!("skip: no resolvable data directory in this environment");
+        return;
+    };
+    let handle = OnDemandAnalyze::new().expect("the path resolved a moment ago");
+    assert_eq!(handle.socket(), expected);
+}

--- a/crates/trusty-common/src/uds/server/idle.rs
+++ b/crates/trusty-common/src/uds/server/idle.rs
@@ -1,0 +1,187 @@
+//! Idle-exit accounting for an on-demand UDS service (#6350, ADR-0032).
+//!
+//! Why: a service that clients start on demand has to end on its own, or the
+//! first request of the day leaves a process resident until the machine
+//! reboots — which is the resident daemon it was supposed to replace, minus the
+//! launchd unit that would at least have restarted it. The exit has to be
+//! driven by the serve loop rather than by a timer the service arms itself,
+//! because only the loop knows whether a connection is open, and killing a
+//! process mid-`analyze.diagnostics` is a worse failure than never reclaiming
+//! it.
+//!
+//! What: [`IdleTracker`] counts open connections and stamps the moment the last
+//! one closed; [`IdleTracker::expired`] is the future
+//! [`super::serve_until_idle`] races against `accept`. A connection that
+//! ANSWERED a request refreshes the stamp; one that connected and closed
+//! without writing a frame does not — see [`IdleGuard::answered`] for why that
+//! distinction is the whole point.
+//!
+//! Test: `tests.rs` — `serve_until_idle_exits_when_the_window_elapses`,
+//! `serve_until_idle_is_reset_by_an_answered_request`,
+//! `serve_until_idle_ignores_liveness_probes`,
+//! `idle_tracker_counts_open_connections_and_restores_on_drop`.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use tokio::sync::Mutex;
+use tokio::time::Instant;
+
+/// Open-connection count and last-activity stamp for one serve loop.
+///
+/// Why: the two facts an idle policy needs are "is anyone connected right now"
+/// and "how long since the last one finished", and they have to be read
+/// together — a service with a connection open is not idle no matter how old
+/// the stamp is, and a service whose stamp is fresh is not idle even with
+/// nothing connected.
+///
+/// What: an [`AtomicUsize`] of live connections plus the [`Instant`] at which
+/// the count last returned to zero having answered something. The stamp is a
+/// `tokio::time::Instant` rather than `std::time::Instant` so a test can drive
+/// the whole policy under `tokio::time::pause()` if it wants to; the tests here
+/// use real short windows instead, because the accept loop's `sleep` is what is
+/// actually being verified.
+///
+/// Test: see the module docs.
+#[derive(Debug)]
+pub struct IdleTracker {
+    /// How long with nothing open and nothing answered before the loop exits.
+    timeout: Duration,
+    /// Connections currently accepted and not yet finished.
+    open: AtomicUsize,
+    /// When the service last became idle. Set at construction so a service
+    /// nobody talks to still reclaims itself.
+    idle_since: Mutex<Instant>,
+}
+
+impl IdleTracker {
+    /// A tracker that reports idle after `timeout` with nothing open.
+    ///
+    /// The window starts now: a spawned service that receives no request at all
+    /// exits `timeout` after it bound, which is the case a supervisor race
+    /// produces (two clients raced, one child lost the bind, the winner served
+    /// one request and the loser's client never dialled it).
+    pub fn new(timeout: Duration) -> Arc<Self> {
+        Arc::new(Self {
+            timeout,
+            open: AtomicUsize::new(0),
+            idle_since: Mutex::new(Instant::now()),
+        })
+    }
+
+    /// The configured idle window.
+    pub fn timeout(&self) -> Duration {
+        self.timeout
+    }
+
+    /// Connections currently open.
+    pub fn open_connections(&self) -> usize {
+        self.open.load(Ordering::Acquire)
+    }
+
+    /// Register an accepted connection, returning the guard that closes it.
+    ///
+    /// Why a guard rather than a matching `closed()` call: the connection is
+    /// served inside a `tokio::spawn` whose handler may panic, and a panicking
+    /// handler that leaked the count would pin the process alive forever. `Drop`
+    /// runs on the panic path.
+    pub fn connection_opened(self: &Arc<Self>) -> IdleGuard {
+        self.open.fetch_add(1, Ordering::AcqRel);
+        IdleGuard {
+            tracker: Some(Arc::clone(self)),
+            answered: false,
+        }
+    }
+
+    /// Resolve once the service has been idle for the whole window.
+    ///
+    /// What: re-evaluates rather than arming a single timer, because both
+    /// inputs move while it sleeps. With a connection open there is no deadline
+    /// to compute, so it sleeps one full window and looks again; otherwise it
+    /// sleeps exactly the remaining time. Worst-case lateness is therefore one
+    /// window plus the duration of the connection that was open when it last
+    /// looked — deliberately late rather than early, since exiting under an
+    /// open connection is the failure this whole type exists to avoid.
+    pub async fn expired(self: Arc<Self>) {
+        loop {
+            let wait = if self.open.load(Ordering::Acquire) > 0 {
+                self.timeout
+            } else {
+                let idle_since = *self.idle_since.lock().await;
+                let elapsed = idle_since.elapsed();
+                if elapsed >= self.timeout {
+                    return;
+                }
+                self.timeout - elapsed
+            };
+            tokio::time::sleep(wait.max(Duration::from_millis(1))).await;
+        }
+    }
+
+    /// Record that a connection finished.
+    async fn connection_closed(&self, answered: bool) {
+        let remaining = self.open.fetch_sub(1, Ordering::AcqRel).saturating_sub(1);
+        if answered && remaining == 0 {
+            *self.idle_since.lock().await = Instant::now();
+        }
+    }
+}
+
+/// Live-connection guard held for the lifetime of one accepted connection.
+///
+/// Why: see [`IdleTracker::connection_opened`]. The `answered` flag is set only
+/// by the serve loop, after the connection has produced a response.
+///
+/// What: decrements the open count on drop and, when the connection ANSWERED
+/// something and was the last one open, restarts the idle window.
+///
+/// 🔴 **A liveness probe must not restart the window.** A bare connect-and-close
+/// — what [`crate::uds::socket_is_serving`] does, and what `trusty-console`'s
+/// service detector does on a poll loop — arrives here with `answered` false.
+/// Counting it as activity would let a status page that polls every few seconds
+/// keep an on-demand service resident forever, which is precisely the outcome
+/// this module exists to prevent.
+///
+/// Test: `serve_until_idle_ignores_liveness_probes`,
+/// `idle_tracker_counts_open_connections_and_restores_on_drop`.
+#[derive(Debug)]
+pub struct IdleGuard {
+    /// `None` once the guard has been released, so `Drop` cannot decrement the
+    /// count a second time.
+    tracker: Option<Arc<IdleTracker>>,
+    answered: bool,
+}
+
+impl IdleGuard {
+    /// Mark this connection as having answered a request.
+    pub fn answered(&mut self) {
+        self.answered = true;
+    }
+
+    /// Release the guard, restarting the idle window when it earned one.
+    ///
+    /// Why an explicit async release alongside `Drop`: the stamp lives behind a
+    /// `tokio::sync::Mutex`, which cannot be locked from `Drop`. The serve loop
+    /// calls this on every normal path; `Drop` is the panic-and-cancel backstop
+    /// and only fixes the count.
+    pub async fn release(mut self) {
+        if let Some(tracker) = self.tracker.take() {
+            tracker.connection_closed(self.answered).await;
+        }
+    }
+}
+
+impl Drop for IdleGuard {
+    /// Backstop for a cancelled or panicking connection task.
+    ///
+    /// It cannot take the async lock, so it restores the count only. A dropped
+    /// connection that had answered therefore leaves the window measured from
+    /// the previous answer — early rather than late, which for a crashed
+    /// handler is the right bias.
+    fn drop(&mut self) {
+        if let Some(tracker) = self.tracker.take() {
+            tracker.open.fetch_sub(1, Ordering::AcqRel);
+        }
+    }
+}

--- a/crates/trusty-common/src/uds/server/mod.rs
+++ b/crates/trusty-common/src/uds/server/mod.rs
@@ -84,6 +84,7 @@
 //!
 //! Test: `tests.rs` — `dispatch_*` for the decision, `serve_*` for the socket.
 
+mod idle;
 mod router;
 mod stream;
 mod wire;
@@ -101,6 +102,7 @@ use tokio::net::{UnixListener, UnixStream};
 
 use crate::uds::{MAX_FRAME_BYTES, UdsSecurityError, bind_hardened, ensure_peer_is_self};
 
+pub use idle::{IdleGuard, IdleTracker};
 pub use router::{RpcFallback, RpcMethod, RpcRouter, typed_method};
 pub use stream::{RpcOutcome, RpcStreamItems, RpcStreamMethod, typed_stream_method, write_stream};
 pub use wire::{
@@ -366,12 +368,200 @@ pub async fn serve_until(
     options: RpcServeOptions,
     shutdown: impl std::future::Future<Output = ()> + Send,
 ) {
+    let _ = serve_until_idle(listener, router, options, shutdown, None).await;
+}
+
+/// Why a serve loop ended.
+///
+/// Why this is returned rather than logged: an on-demand service's caller
+/// distinguishes the two — a shutdown is an operator or supervisor stopping the
+/// process, an idle exit is the process reclaiming itself and is the normal end
+/// of a successful lifetime. `trusty-analyze` prints a different line for each.
+///
+/// Test: `serve_until_idle_exits_when_the_window_elapses`,
+/// `serve_stops_on_shutdown`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ServeExit {
+    /// The caller's shutdown future resolved (SIGTERM/SIGINT, or a test).
+    Shutdown,
+    /// No connection answered anything for the whole idle window.
+    Idle,
+}
+
+/// How long an idle exit waits for a connection already in the kernel backlog.
+///
+/// Why (#6350): `connect(2)` against a listening socket succeeds the moment the
+/// kernel queues it — the server need not have called `accept` yet. So a client
+/// that dialled microseconds before the idle window elapsed is sitting in the
+/// backlog, and a loop that returned straight from the idle arm would drop the
+/// listener and unlink the socket with that client's connection still queued.
+/// The client sees a reset, not a refusal, and only `trusty-review`'s adapter
+/// retries one; `trusty-analyze deep` and `tctl`'s probe report it as a failure
+/// the operator cannot act on.
+///
+/// What: 50ms is chosen against the cost of being wrong in each direction. A
+/// queued connection is already in the backlog, so it is accepted on the first
+/// poll and the window is never actually spent; the only case that spends it is
+/// a genuinely idle service, which pays 50ms once in its whole lifetime.
+const IDLE_EXIT_DRAIN: Duration = Duration::from_millis(50);
+
+/// The future [`serve_until_idle`] races against `accept`.
+///
+/// Why a named function rather than an inline `async` block: two `async` blocks
+/// have two different anonymous types, and the loop re-arms this one in place
+/// after a drain. `Pin::set` needs the replacement to be the SAME type, which
+/// only one `impl Future` origin gives.
+///
+/// What: [`IdleTracker::expired`] when a policy is configured. With none it
+/// never resolves, so the arm is inert and the loop behaves as [`serve_until`]
+/// always has.
+async fn idle_expiry(idle: Option<Arc<IdleTracker>>) {
+    match idle {
+        Some(tracker) => tracker.expired().await,
+        None => std::future::pending::<()>().await,
+    }
+}
+
+/// What [`drain_backlog`] found in the backlog.
+enum Drained {
+    /// A client was queued and its request has been answered. The exit is
+    /// cancelled and the idle window restarts.
+    Answered,
+    /// Nothing was queued, or what was queued asked nothing. The exit stands.
+    Nothing,
+}
+
+/// Which arm of [`serve_until_idle`]'s `select!` won.
+///
+/// Why an enum rather than the drain running inside the arm: the drain re-arms
+/// the pinned idle future afterwards, and `Pin::set` cannot run while the
+/// `select!` still holds the `&mut` borrow of it. Naming the winner ends that
+/// borrow at the `select!`'s closing brace.
+enum Step {
+    /// `accept` won; this is its result, error included.
+    Accepted(std::io::Result<(UnixStream, tokio::net::unix::SocketAddr)>),
+    /// The idle window elapsed.
+    IdleElapsed,
+}
+
+/// Serve one connection queued before the idle window elapsed, if any.
+///
+/// Why: see [`IDLE_EXIT_DRAIN`]. Resolving the race in the CLIENT's favour is
+/// the only safe direction — serving one extra request costs a round trip,
+/// while resetting a connection the client believes it made costs that client a
+/// failure it has no way to distinguish from a broken service.
+///
+/// 🔴 Why only an ANSWERED connection cancels the exit: a bare connect-and-close
+/// is what [`crate::uds::socket_is_serving`] does on a poll loop, and a drain
+/// that treated one as activity would hand the poller exactly the power
+/// [`IdleGuard`] exists to deny it — an observed livelock, not a hypothetical.
+/// A probe caught in the drain is served and the exit proceeds.
+///
+/// Why the connection is served INLINE rather than spawned: this is the last
+/// thing that happens before the caller unlinks the socket and drops the
+/// listener, and a spawned task would race the process exit. Awaiting it is what
+/// guarantees the client has its answer first. One connection, once per
+/// lifetime.
+///
+/// Test: `a_client_queued_when_the_idle_window_elapses_is_served_not_reset`,
+/// `serve_until_idle_ignores_liveness_probes`.
+async fn drain_backlog(
+    listener: &UnixListener,
+    router: &Arc<RpcRouter>,
+    options: RpcServeOptions,
+    idle: Option<&Arc<IdleTracker>>,
+) -> Drained {
+    let Ok(accepted) = tokio::time::timeout(IDLE_EXIT_DRAIN, listener.accept()).await else {
+        return Drained::Nothing;
+    };
+    let stream = match accepted {
+        Ok((stream, _)) => stream,
+        Err(e) => {
+            tracing::warn!(error = %e, "uds rpc listener accept failed during idle drain");
+            return Drained::Nothing;
+        }
+    };
+    let mut guard = idle.map(IdleTracker::connection_opened);
+    let served = handle_connection(stream, Arc::clone(router), options).await;
+    let answered = matches!(served, Ok(Served::Answered { .. }));
+    if let Err(e) = &served {
+        tracing::warn!(error = %e, "uds rpc connection failed during idle drain");
+    }
+    if answered && let Some(g) = guard.as_mut() {
+        g.answered();
+    }
+    if let Some(g) = guard {
+        g.release().await;
+    }
+    if answered {
+        Drained::Answered
+    } else {
+        Drained::Nothing
+    }
+}
+
+/// [`serve_until`], plus an optional idle-exit policy (#6350).
+///
+/// Why: ADR-0032 makes `trusty-analyze` an on-demand service — clients spawn it
+/// and nothing supervises it — so the accept loop is the only place that knows
+/// enough to end the process. It has to be here rather than in a timer the
+/// service arms itself, because "idle" means no connection is OPEN and none has
+/// answered recently, and only this loop observes both.
+///
+/// What: identical to [`serve_until`] with `idle` as `None`. With a tracker, the
+/// loop additionally races [`IdleTracker::expired`] against `accept` and returns
+/// [`ServeExit::Idle`] when it wins. Each accepted connection holds an
+/// [`IdleGuard`] for its lifetime, so the window can never elapse under an open
+/// connection; the guard is marked answered only for a connection that produced
+/// a response, which is what keeps a liveness-probe poll loop from pinning the
+/// process alive.
+///
+/// #6350: an expired window does not exit immediately. [`drain_backlog`] first
+/// gives the kernel backlog [`IDLE_EXIT_DRAIN`] to yield a connection that was
+/// queued before the window elapsed; one that appears is served like any other
+/// and the loop continues, so the exit only stands when nobody was waiting.
+///
+/// Test: `serve_until_idle_exits_when_the_window_elapses`,
+/// `serve_until_idle_is_reset_by_an_answered_request`,
+/// `serve_until_idle_ignores_liveness_probes`,
+/// `a_client_queued_when_the_idle_window_elapses_is_served_not_reset`.
+pub async fn serve_until_idle(
+    listener: &UnixListener,
+    router: Arc<RpcRouter>,
+    options: RpcServeOptions,
+    shutdown: impl std::future::Future<Output = ()> + Send,
+    idle: Option<Arc<IdleTracker>>,
+) -> ServeExit {
     tokio::pin!(shutdown);
+    let idle_expired = idle_expiry(idle.clone());
+    tokio::pin!(idle_expired);
+
     loop {
-        let accepted = tokio::select! {
+        let step = tokio::select! {
             biased;
-            () = &mut shutdown => return,
-            accepted = listener.accept() => accepted,
+            () = &mut shutdown => return ServeExit::Shutdown,
+            () = &mut idle_expired => Step::IdleElapsed,
+            accepted = listener.accept() => Step::Accepted(accepted),
+        };
+        // #6350: the drain runs HERE, not inside the arm — the `select!`'s
+        // borrow of `idle_expired` has ended, so the re-arm below can run. The
+        // future is re-armed ONLY on this path: an `async` block panics if
+        // polled after it completes, and rebuilding it on every iteration
+        // instead would restart `expired`'s open-connection branch, which sleeps
+        // a whole window whenever it observes a connection in flight — a client
+        // polling faster than the window would then hold the process open
+        // forever.
+        let accepted = match step {
+            Step::Accepted(accepted) => accepted,
+            Step::IdleElapsed => {
+                match drain_backlog(listener, &router, options, idle.as_ref()).await {
+                    Drained::Answered => {
+                        idle_expired.set(idle_expiry(idle.clone()));
+                        continue;
+                    }
+                    Drained::Nothing => return ServeExit::Idle,
+                }
+            }
         };
         let stream = match accepted {
             Ok((stream, _)) => stream,
@@ -380,6 +570,10 @@ pub async fn serve_until(
                 continue;
             }
         };
+        // Taken BEFORE the connection task is spawned: taking it inside would
+        // leave a window in which the count is zero while a connection is
+        // already accepted, and the idle future could win the race in it.
+        let guard = idle.as_ref().map(IdleTracker::connection_opened);
         let router = Arc::clone(&router);
         tokio::spawn(async move {
             // #6277 review: the connection runs in an INNER task whose
@@ -390,8 +584,13 @@ pub async fn serve_until(
             // costs one task per connection and buys the one log line that says
             // which method took the process down a path nobody expected.
             let inner = tokio::spawn(handle_connection(stream, router, options));
+            let mut guard = guard;
             match inner.await {
-                Ok(Ok(Served::Answered { .. })) => {}
+                Ok(Ok(Served::Answered { .. })) => {
+                    if let Some(g) = guard.as_mut() {
+                        g.answered();
+                    }
+                }
                 Ok(Ok(Served::LivenessProbe)) => {
                     tracing::debug!("liveness probe connected and closed without a frame");
                 }
@@ -410,6 +609,9 @@ pub async fn serve_until(
                 Err(join) => {
                     tracing::warn!(error = %join, "uds rpc connection task was cancelled");
                 }
+            }
+            if let Some(g) = guard {
+                g.release().await;
             }
         });
     }

--- a/crates/trusty-common/src/uds/server/tests.rs
+++ b/crates/trusty-common/src/uds/server/tests.rs
@@ -1025,3 +1025,229 @@ async fn handle_connection_reports_an_error_response_as_answered() {
     assert_eq!(served, Served::Answered { errored: true });
     writer.abort();
 }
+
+// ── idle exit for an on-demand service (#6350) ──────────────────────────────
+
+/// Bind `dir/idle.sock` and serve it with `idle` as the idle policy.
+///
+/// Why a bespoke spawner rather than `spawn_server`: `RpcServer::run` owns its
+/// own bind and has no idle parameter, and the point of these tests is the
+/// accept loop's exit decision — so they drive `serve_until_idle` directly, the
+/// way `trusty-analyze`'s `serve_with_shutdown` does.
+fn spawn_idle_server(
+    dir: &std::path::Path,
+    idle: Duration,
+) -> (
+    std::path::PathBuf,
+    tokio::sync::oneshot::Sender<()>,
+    tokio::task::JoinHandle<ServeExit>,
+) {
+    let socket = dir.join("idle.sock");
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    let bound = socket.clone();
+    let handle = tokio::spawn(async move {
+        let listener = crate::uds::bind_hardened(&bound).expect("bind");
+        let exit = serve_until_idle(
+            &listener,
+            Arc::new(greeting_router()),
+            RpcServeOptions::default(),
+            async move {
+                let _ = rx.await;
+            },
+            Some(IdleTracker::new(idle)),
+        )
+        .await;
+        let _ = std::fs::remove_file(&bound);
+        exit
+    });
+    (socket, tx, handle)
+}
+
+/// Why: this is the whole point of #6350 — an on-demand service that nobody
+/// talks to has to end itself, or it is the resident daemon it replaced.
+/// Test: this is the test.
+#[tokio::test]
+async fn serve_until_idle_exits_when_the_window_elapses() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let (socket, _stop, handle) = spawn_idle_server(tmp.path(), Duration::from_millis(300));
+    await_socket(&socket).await;
+
+    let exit = tokio::time::timeout(Duration::from_secs(10), handle)
+        .await
+        .expect("the loop must exit on its own once the window elapses")
+        .expect("join");
+
+    assert_eq!(exit, ServeExit::Idle);
+    assert!(
+        !socket.exists(),
+        "an idle exit must unlink the socket, or the next spawn cannot bind"
+    );
+}
+
+/// Why: an idle timer that fired regardless of traffic would kill a service
+/// mid-conversation. A request has to push the deadline out.
+/// Test: this is the test.
+#[tokio::test]
+async fn serve_until_idle_is_reset_by_an_answered_request() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let window = Duration::from_millis(600);
+    let (socket, _stop, handle) = spawn_idle_server(tmp.path(), window);
+    await_socket(&socket).await;
+
+    // Answer one request roughly half a window in, so a loop that ignored the
+    // request would have already exited by the assertion below.
+    tokio::time::sleep(window / 2).await;
+    let response = call(&socket, 1, "greet", json!({ "name": "ada" })).await;
+    assert!(response.error.is_none(), "unexpected error: {response:?}");
+
+    tokio::time::sleep(window).await;
+    assert!(
+        !handle.is_finished(),
+        "the answered request must have restarted the idle window"
+    );
+
+    let exit = tokio::time::timeout(Duration::from_secs(10), handle)
+        .await
+        .expect("it must still exit once the restarted window elapses")
+        .expect("join");
+    assert_eq!(exit, ServeExit::Idle);
+}
+
+/// Why: `trusty-console`'s service detector connects and closes on a poll loop,
+/// and `ensure_running` probes the same way. If a bare connect counted as
+/// activity, a status page open in a browser would pin an on-demand service
+/// resident forever — the exact outcome idle exit exists to prevent.
+/// Test: this is the test.
+#[tokio::test]
+async fn serve_until_idle_ignores_liveness_probes() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let window = Duration::from_millis(400);
+    let (socket, _stop, handle) = spawn_idle_server(tmp.path(), window);
+    await_socket(&socket).await;
+
+    // `await_socket` already probed; keep probing across the whole window.
+    for _ in 0..8 {
+        assert!(crate::uds::socket_is_serving(&socket, Duration::from_millis(200)).await);
+        tokio::time::sleep(window / 8).await;
+    }
+
+    let exit = tokio::time::timeout(Duration::from_secs(10), handle)
+        .await
+        .expect("probes must not hold the window open")
+        .expect("join");
+    assert_eq!(exit, ServeExit::Idle);
+}
+
+/// Why: `serve_until` is the no-policy path every other daemon still uses, and
+/// it must behave exactly as it did before the idle parameter existed.
+/// Test: this is the test.
+#[tokio::test]
+async fn serve_until_without_a_policy_never_exits_on_its_own() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let (socket, stop, handle) =
+        spawn_server(tmp.path(), greeting_router(), RpcServeOptions::default());
+    await_socket(&socket).await;
+
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    assert!(
+        !handle.is_finished(),
+        "with no idle policy the loop runs until its shutdown future resolves"
+    );
+
+    stop.send(()).expect("signal shutdown");
+    handle.await.expect("join").expect("clean shutdown");
+}
+
+/// Why: the guard is what keeps the window from elapsing under an open
+/// connection, and `Drop` is its panic backstop. Both are asserted here without
+/// a socket, so a counting bug is diagnosed at the tracker rather than as a
+/// flaky serve test.
+/// Test: this is the test.
+#[tokio::test]
+async fn idle_tracker_counts_open_connections_and_restores_on_drop() {
+    let tracker = IdleTracker::new(Duration::from_secs(60));
+    assert_eq!(tracker.open_connections(), 0);
+
+    let mut answered = tracker.connection_opened();
+    let dropped = tracker.connection_opened();
+    assert_eq!(tracker.open_connections(), 2);
+
+    drop(dropped);
+    assert_eq!(
+        tracker.open_connections(),
+        1,
+        "a cancelled or panicking connection must still release its slot"
+    );
+
+    answered.answered();
+    answered.release().await;
+    assert_eq!(tracker.open_connections(), 0);
+    assert_eq!(tracker.timeout(), Duration::from_secs(60));
+}
+
+/// Why (#6350): `connect(2)` succeeds as soon as the kernel queues the
+/// connection, so a client that dialled just before the idle window elapsed is
+/// already in the backlog when the loop decides to exit. Returning straight
+/// from the idle arm dropped the listener and unlinked the socket underneath
+/// that client, which reads to it as a reset — and only `trusty-review`'s
+/// adapter retries one. `trusty-analyze deep` and `tctl`'s probe report it as a
+/// failure the operator cannot act on.
+///
+/// What makes it deterministic rather than a timing race: the client connects
+/// and writes its frame BEFORE the serve loop runs, and the tracker is built
+/// far enough ahead that its window has already elapsed. `expired` is therefore
+/// ready on the loop's first poll and `biased` gives it the win, so the exit
+/// decision is taken with a connection provably queued. Against the pre-drain
+/// loop the read below returns zero bytes.
+/// Test: this is the test.
+#[tokio::test]
+async fn a_client_queued_when_the_idle_window_elapses_is_served_not_reset() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let socket = tmp.path().join("drain.sock");
+    let listener = crate::uds::bind_hardened(&socket).expect("bind");
+
+    // Built now, consumed below: by the time the loop first polls it, the
+    // window has elapsed with nothing open, so `expired` is ready.
+    let tracker = IdleTracker::new(Duration::from_millis(1));
+
+    let mut client = tokio::net::UnixStream::connect(&socket)
+        .await
+        .expect("connect queues in the backlog; nothing is accepting yet");
+    let mut request = frame(7, "greet", json!({ "name": "queued" }));
+    request.push(b'\n');
+    client.write_all(&request).await.expect("write request");
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let serving = tokio::spawn(async move {
+        serve_until_idle(
+            &listener,
+            Arc::new(greeting_router()),
+            RpcServeOptions::default(),
+            std::future::pending::<()>(),
+            Some(tracker),
+        )
+        .await
+    });
+
+    let mut line = String::new();
+    let read = tokio::time::timeout(
+        Duration::from_secs(10),
+        BufReader::new(&mut client).read_line(&mut line),
+    )
+    .await
+    .expect("the queued client must not hang")
+    .expect("read response");
+    assert!(
+        read > 0,
+        "the queued connection was reset instead of served: the loop exited \
+         with it still in the backlog"
+    );
+    let response: RpcResponse = serde_json::from_str(&line).expect("parse response");
+    assert!(response.error.is_none(), "unexpected error: {response:?}");
+
+    let exit = tokio::time::timeout(Duration::from_secs(10), serving)
+        .await
+        .expect("the loop must still exit once the backlog really is empty")
+        .expect("join");
+    assert_eq!(exit, ServeExit::Idle);
+}

--- a/crates/trusty-common/src/uds/supervisor/child.rs
+++ b/crates/trusty-common/src/uds/supervisor/child.rs
@@ -45,12 +45,19 @@ pub(super) struct ChildHandle {
 /// UDS service speaks its socket, not its pipes — inherits stderr so the child's
 /// tracing output reaches the parent's log stream, and sets `kill_on_drop` so an
 /// unsupervised drop reaps the child rather than leaking it.
+///
+/// `detached` inverts that last decision (#6350). An on-demand service ends on
+/// its own idle window and is meant to be reused by the next client, so a
+/// transient caller's exit must not take it down — see
+/// [`super::SupervisorConfig::with_detached`].
 /// Test: `spawn_child_creates_requested_directories`,
-/// `spawn_child_reports_a_missing_binary`.
+/// `spawn_child_reports_a_missing_binary`,
+/// `detached_children_are_not_retained_in_the_population`.
 pub(super) async fn spawn_child(
     service: &str,
     key: &str,
     spec: &SpawnSpec,
+    detached: bool,
 ) -> Result<Child, SupervisorError> {
     for dir in &spec.create_dirs {
         if !dir.exists() {
@@ -70,7 +77,7 @@ pub(super) async fn spawn_child(
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::inherit())
-        .kill_on_drop(true)
+        .kill_on_drop(!detached)
         .spawn()
         .map_err(|source| SupervisorError::Spawn {
             service: service.to_string(),

--- a/crates/trusty-common/src/uds/supervisor/config.rs
+++ b/crates/trusty-common/src/uds/supervisor/config.rs
@@ -235,6 +235,8 @@ pub struct SupervisorConfig {
     pub timeouts: ServiceTimeouts,
     /// Environment variable that opts spawn supervision out when set to `"1"`.
     pub external_env: Option<String>,
+    /// Whether spawned children outlive this supervisor (#6350).
+    pub detached: bool,
 }
 
 impl SupervisorConfig {
@@ -249,12 +251,39 @@ impl SupervisorConfig {
             rss_limit_mb: None,
             timeouts,
             external_env: None,
+            detached: false,
         }
     }
 
     /// Set the per-child RSS ceiling in MB; `None` disables enforcement.
     pub fn with_rss_limit_mb(mut self, rss_limit_mb: Option<u64>) -> Self {
         self.rss_limit_mb = rss_limit_mb;
+        self
+    }
+
+    /// Let spawned children outlive this supervisor (#6350).
+    ///
+    /// Why: the default answers "keep this child alive for as long as I need
+    /// it", which is what `trusty-console` wants — it is resident, it owns the
+    /// child, and `kill_on_drop` guarantees no orphan survives it. An on-demand
+    /// service under ADR-0032 is the opposite arrangement: the client is a CLI
+    /// that exits in seconds, the SERVICE decides when to end (its own idle
+    /// window), and a second client is expected to reuse the same process. With
+    /// the default, the first client's exit would SIGKILL a server a concurrent
+    /// client was mid-request against.
+    ///
+    /// What: the child is spawned without `kill_on_drop`, is not entered into
+    /// the supervisor's population map, and is reaped by a detached task that
+    /// waits on it. Everything the map drives — the `max_live` cap, LRU
+    /// eviction, RSS reaping, [`super::UdsServiceSupervisor::shutdown`] — has
+    /// nothing to act on in this mode, deliberately: a child that owns its own
+    /// lifetime is not this supervisor's to reclaim. What DOES still apply is
+    /// the part an on-demand caller needs — the spawn gate, the
+    /// already-serving check, socket verification, and the post-spawn probe.
+    ///
+    /// Test: `detached_children_are_not_retained_in_the_population`.
+    pub fn with_detached(mut self, detached: bool) -> Self {
+        self.detached = detached;
         self
     }
 

--- a/crates/trusty-common/src/uds/supervisor/mod.rs
+++ b/crates/trusty-common/src/uds/supervisor/mod.rs
@@ -267,12 +267,19 @@ impl UdsServiceSupervisor {
             key: key.to_string(),
             source,
         })?;
-        let child = spawn_child(service, key, &spec).await?;
+        let detached = self.config.detached;
+        let mut child = spawn_child(service, key, &spec, detached).await?;
         self.spawned.fetch_add(1, Ordering::Relaxed);
 
         if !probe::wait_for_socket(socket_path, &self.config.timeouts).await {
             // Explicit drop: `kill_on_drop` SIGKILLs the child that never bound.
             // Nothing was acked to it, so there is nothing to flush.
+            // #6350: a DETACHED child was spawned without `kill_on_drop`, so
+            // dropping it would leave a process that never bound running with
+            // nothing left holding a handle to it. Terminate it here instead.
+            if detached {
+                let _ = terminate_child(&mut child, self.config.timeouts.sigterm_patience).await;
+            }
             drop(child);
             return Err(SupervisorError::SpawnTimeout {
                 service: service.to_string(),
@@ -287,8 +294,22 @@ impl UdsServiceSupervisor {
             instance = %key,
             socket = %socket_path.display(),
             program = %spec.program.display(),
+            detached,
             "spawned supervised child"
         );
+
+        // #6350: a detached child owns its own lifetime (its idle window), so it
+        // is deliberately NOT entered into the population map — nothing in this
+        // supervisor may reap it, and the next caller adopts it through the
+        // already-serving check above. The waiter exists only so the process is
+        // not left a zombie when this supervisor outlives it; it never kills,
+        // and if this process exits first the child keeps serving.
+        if detached {
+            tokio::spawn(async move {
+                let _ = child.wait().await;
+            });
+            return Ok(socket_path.to_path_buf());
+        }
 
         let mut guard = self.children.lock().await;
         guard.insert(

--- a/crates/trusty-common/src/uds/supervisor/tests.rs
+++ b/crates/trusty-common/src/uds/supervisor/tests.rs
@@ -425,7 +425,7 @@ async fn spawn_child_creates_requested_directories() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let data = tmp.path().join("nested/data");
     let spec = SpawnSpec::new("/bin/echo").create_dir(&data);
-    let mut child = super::child::spawn_child("test-service", "k", &spec)
+    let mut child = super::child::spawn_child("test-service", "k", &spec, false)
         .await
         .expect("spawn");
     let _ = child.wait().await;
@@ -441,7 +441,7 @@ async fn spawn_child_creates_requested_directories() {
 async fn spawn_child_reports_a_missing_binary() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let spec = SpawnSpec::new(tmp.path().join("no-such-binary"));
-    let err = super::child::spawn_child("test-service", "k", &spec)
+    let err = super::child::spawn_child("test-service", "k", &spec, false)
         .await
         .expect_err("a missing binary must fail");
     assert!(
@@ -862,4 +862,91 @@ async fn an_over_long_socket_path_is_rejected_before_spawning() {
         "expected SocketPath, got {err:?}"
     );
     assert_eq!(sup.spawned_count(), 0);
+}
+
+// ── detached mode for on-demand services (#6350) ────────────────────────────
+
+/// Why: the flag is what separates "console owns this child" from "the service
+/// owns itself", and every behaviour below turns on it, so a builder that
+/// dropped it would fail silently as a lifetime bug rather than loudly here.
+/// Test: this test itself.
+#[test]
+fn supervisor_config_carries_the_detached_flag() {
+    assert!(
+        !config(1, None).detached,
+        "the default must stay `kill_on_drop`: a resident owner reclaims its children"
+    );
+    assert!(config(1, None).with_detached(true).detached);
+    assert!(
+        !config(1, None)
+            .with_detached(true)
+            .with_detached(false)
+            .detached
+    );
+}
+
+/// Why: the whole point of detached mode is that this supervisor does not own
+/// the child, so a detached spawn must leave the population map untouched —
+/// otherwise a transient CLI's `shutdown()` (or its `Drop`) would take down a
+/// server another client is mid-request against.
+///
+/// What: `sleep` never binds the socket, so `ensure_running` reports
+/// [`SupervisorError::SpawnTimeout`] — but it reports it having spawned exactly
+/// one child and retained none. The spawn budget is 400 ms (`TEST_TIMEOUTS`), so
+/// the test costs that plus the SIGTERM the detached path sends to the process
+/// that never bound.
+/// Test: this test itself.
+#[serial_test::serial]
+#[tokio::test]
+async fn detached_children_are_not_retained_in_the_population() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let socket = tmp.path().join("detached.sock");
+    let sup = UdsServiceSupervisor::new(config(3, None).with_detached(true));
+
+    let err = sup
+        .ensure_running("inst", &socket, || Ok(SpawnSpec::new("sleep").arg("60")))
+        .await
+        .expect_err("a child that never binds must not be reported as running");
+
+    assert!(
+        matches!(err, SupervisorError::SpawnTimeout { .. }),
+        "unexpected error: {err:?}"
+    );
+    assert_eq!(sup.spawned_count(), 1, "the spawn did happen");
+    assert_eq!(
+        sup.supervised_count().await,
+        0,
+        "a detached child must never enter the population map"
+    );
+}
+
+/// Why: detached mode changes who owns the child, not how a running service is
+/// found. The already-serving fast path is what makes a second concurrent
+/// client adopt the first client's server instead of racing it, so it has to
+/// hold with the flag set.
+/// Test: this test itself.
+#[serial_test::serial]
+#[tokio::test]
+async fn a_detached_caller_adopts_a_socket_that_is_already_serving() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let socket = tmp.path().join("live.sock");
+    // `bind_hardened`, not a bare bind: the adopt path runs
+    // `verify_socket_for_connect`, which refuses a socket in a 0755 directory.
+    // A plain `UnixListener::bind` under a tempdir fails that check, and the
+    // refusal is correct — the fixture has to meet the real precondition.
+    let _listener = crate::uds::bind_hardened(&socket).expect("bind");
+    let sup = UdsServiceSupervisor::new(config(3, None).with_detached(true));
+
+    let path = sup
+        .ensure_running("inst", &socket, never_spawn)
+        .await
+        .expect("a serving socket must be adopted, not raced");
+
+    assert_eq!(path, socket);
+    assert_eq!(
+        sup.spawned_count(),
+        0,
+        "nothing may be spawned over a live socket"
+    );
+    assert_eq!(sup.supervised_count().await, 0);
 }

--- a/crates/trusty-console/Cargo.toml
+++ b/crates/trusty-console/Cargo.toml
@@ -3,7 +3,7 @@ name        = "trusty-console"
 # 0.7.1 (#6288): patch — 0.7.0 is published and this PR edits `src/**`. The only
 # change is dropping the retired supervisor's 7881 row from a test's
 # known-siblings table; no public item moved.
-version     = "0.7.1"
+version     = "0.8.0"
 edition     = "2024"
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/trusty-console/changelog.d/6350-analyze-detect-observes.md
+++ b/crates/trusty-console/changelog.d/6350-analyze-detect-observes.md
@@ -1,0 +1,6 @@
+Changed
+- The analyze service card reads `Available` as "installed and startable"
+  rather than as a degradation: trusty-analyze runs on demand, so nothing
+  listening is its correct resting state. The connector deliberately does not
+  start it — the console polls detect, and a detector that started the service
+  would keep it resident for as long as a dashboard tab was open (#6350).

--- a/crates/trusty-console/changelog.d/6350-semver-minor-bump.md
+++ b/crates/trusty-console/changelog.d/6350-semver-minor-bump.md
@@ -1,0 +1,7 @@
+Changed
+- trusty-console moves to 0.8.0. `cargo-semver-checks` reports
+  `inherent_method_missing` for `ReviewConnector::with_socket` against the
+  published 0.7.0 baseline — removed by #6290 when the review daemon was retired
+  and the connector moved to a presence check. For a `0.y.z` crate the breaking
+  bump is the MINOR position, so 0.7.1 was never a legal position for it. The
+  root workspace requirement moves from `0.7.0` to `0.8.0` (#6350).

--- a/crates/trusty-console/src/detect/analyze.rs
+++ b/crates/trusty-console/src/detect/analyze.rs
@@ -196,7 +196,24 @@ impl AnalyzeConnector {
     /// connectors running in parallel. Taking the resolved result as a parameter
     /// makes the arm assertable with no global state at all.
     /// What: binary check, then the three verdicts.
-    /// Test: `analyze_connector_surfaces_an_unresolvable_socket_path_as_a_hint`.
+    ///
+    /// 🔴 **This connector deliberately does not call `ensure_running`** (#6350),
+    /// unlike every other analyze client. It is a DETECTOR, and the console
+    /// renders it on a poll loop: a detector that started the service would keep
+    /// an on-demand server alive for as long as anyone had the dashboard open —
+    /// the exact outcome the idle window exists to prevent — and would then
+    /// report `Running` about a process it had just created, which is not an
+    /// observation.
+    ///
+    /// What that changes about the verdicts, now that resident is not the
+    /// healthy state: `Absent` is the only bad one (the binary is not
+    /// installed). `Available` means installed and startable, which for an
+    /// on-demand service is its correct resting state, not a degradation.
+    /// `Running` means a server happens to be up right now — a client is using
+    /// it, or one has not yet reached its idle window.
+    ///
+    /// Test: `analyze_connector_surfaces_an_unresolvable_socket_path_as_a_hint`,
+    /// `detect_never_starts_a_server`.
     fn detect_from(&self, socket: Result<PathBuf, String>) -> ServiceInfo {
         let base =
             |status: ServiceStatus, version: Option<String>, hint: Option<String>| ServiceInfo {
@@ -343,5 +360,30 @@ mod tests {
 
         assert_eq!(info.status, ServiceStatus::Running);
         assert_eq!(info.version.as_deref(), Some("9.9.9"));
+    }
+
+    /// Why (#6350): the console polls `detect` while a dashboard is open. If it
+    /// started trusty-analyze, an open browser tab would pin an on-demand
+    /// server resident forever — and the connector would be reporting on a
+    /// process it created rather than one it found.
+    /// What: points the connector at a socket path inside a tempdir, calls
+    /// `detect`, and asserts nothing bound it.
+    /// Test: this is the test.
+    #[test]
+    fn detect_never_starts_a_server() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let socket = tmp.path().join("must-stay-absent.sock");
+        let info = AnalyzeConnector::with_socket(socket.clone()).detect();
+
+        assert_ne!(
+            info.status,
+            ServiceStatus::Running,
+            "nothing was serving that path, so no verdict may claim it was"
+        );
+        assert!(
+            !socket.exists(),
+            "detect must observe, never start: {} was created",
+            socket.display()
+        );
     }
 }

--- a/crates/trusty-installer/Cargo.toml
+++ b/crates/trusty-installer/Cargo.toml
@@ -3,7 +3,7 @@ name = "trusty-installer"
 # 0.12.1 (#6288): patch — 0.12.0 is published and this PR edits `src/**`,
 # dropping `SUPERVISOR_METRICS_PORT` and `LaunchctlPort::port_guard` now that the
 # supervisor binds no port. No out-of-workspace consumer of either.
-version = "0.12.1"
+version = "0.13.0"
 edition = "2021"
 description = "Thin control plane for the claude-mpm stack: install, upgrade, restart, health, and config coordination across all trusty-* tools."
 readme = "README.md"
@@ -83,7 +83,7 @@ tracing-subscriber = { workspace = true }
 # `memory-rpc` (#6286): `ensure`'s palace stage and its `--wait` readiness probe
 # dial trusty-memory through the shared client. ADR-0032 left no `http_addr` for
 # `resolve_base_url` to read, so both read a running daemon as absent without it.
-trusty-common = { workspace = true, features = ["update-check", "config-cli", "uds", "memory-rpc"] }
+trusty-common = { workspace = true, features = ["update-check", "config-cli", "uds", "uds-supervisor", "memory-rpc"] }  # uds-supervisor (#6350): tctl probes trusty-analyze by starting it on demand
 # Rustup/cargo-style progress display (#1315): Narrator `info:` lines + the
 # right-aligned ComponentTracker table for install/upgrade rows.
 trusty-progress = { workspace = true }

--- a/crates/trusty-installer/changelog.d/6350-analyze-on-demand.md
+++ b/crates/trusty-installer/changelog.d/6350-analyze-on-demand.md
@@ -1,0 +1,12 @@
+Changed
+- `tctl` no longer expects trusty-analyze to be a resident daemon.
+  `member_has_service_install` excludes it (its `service install` subcommand is
+  gone), and `tctl up`'s analyze stage now starts it on demand and pings
+  `analyze.health` once instead of gating on a live dial — so a correct
+  installation with nothing listening reports Ok rather than Degraded (#6350).
+- The health probe follows. A retired member is `ManageStrategy::None`, which
+  would have made analyze `Unprobeable`; it keeps its transport probe through
+  the same named-predicate arm #6290 added for a presence-only member, because
+  starting it and asking `analyze.health` is the only check that separates
+  "working" from "broken" for a service whose healthy resting state is not
+  listening (#6350).

--- a/crates/trusty-installer/changelog.d/6350-evict-retired-units.md
+++ b/crates/trusty-installer/changelog.d/6350-evict-retired-units.md
@@ -1,0 +1,14 @@
+Fixed
+- `tctl install` and `tctl upgrade` evict the launchd unit trusty-analyze left
+  loaded, through the same `RETIRED_SERVICES` mechanism that clears
+  `com.trusty.review` (#6290) — one eviction path, now two rows. Without it an
+  upgraded macOS host kept `com.trusty.analyze` loaded under `KeepAlive: Always`,
+  which restarted the on-demand trusty-analyze server every time its idle window
+  reclaimed it. A unit that will not go down fails that member's install or
+  upgrade rather than being reported as a skip (#6350).
+- `tctl start`/`restart`/`upgrade` no longer route trusty-analyze through
+  launchd. Its retired row makes `manage_strategy_for` return
+  `ManageStrategy::None`, so `start` cannot bootstrap the retired unit on an
+  upgraded host or shell out to a `trusty-analyze service install` that no
+  longer exists on a fresh one. The port guard could not have caught either:
+  analyze has bound no port since #6287, so the guard permits vacuously (#6350).

--- a/crates/trusty-installer/changelog.d/6350-semver-minor-bump.md
+++ b/crates/trusty-installer/changelog.d/6350-semver-minor-bump.md
@@ -1,0 +1,10 @@
+Changed
+- trusty-installer moves to 0.13.0. `cargo-semver-checks` reports five major
+  lints against the published 0.12.0 baseline, all of them already on `main`:
+  `pub_module_level_const_missing` (`SUPERVISOR_METRICS_PORT`),
+  `inherent_method_missing` and `struct_pub_field_missing`
+  (`StubLaunchctl::port_guard_calls` / `refuse_port`) and `trait_method_missing`
+  (`LaunchctlPort::port_guard`) from #6349, plus `trait_method_added`
+  (`ServiceEnv::evict_retired`) from #6290. For a `0.y.z` crate the breaking
+  bump is the MINOR position, so 0.12.1 was never a legal position for that
+  work. The root workspace requirement moves from `0.12` to `0.13` (#6350).

--- a/crates/trusty-installer/src/commands/lifecycle.rs
+++ b/crates/trusty-installer/src/commands/lifecycle.rs
@@ -288,13 +288,21 @@ pub fn restart_member(binary: &str, manage: ManageStrategy) -> anyhow::Result<St
 /// Why: launchd and process-managed members need different mechanisms; this is
 /// the one place that branches on [`ManageStrategy`].
 /// What: `Launchd` → [`launchd_control`] (macOS `launchctl`); `OwnVerb` →
-/// `<binary> <verb>` subprocess; `None` → a no-op note (filtered out earlier, so
-/// unreachable in practice). Returns a human detail string on success.
+/// `<binary> <verb>` subprocess; `None` → a no-op note, worded per whether the
+/// member is a non-daemon or one whose service is retired (#6290, #6350).
+/// Returns a human detail string on success.
 /// Test: side-effecting; the verb-name + ordering logic it relies on is tested.
 fn apply_to_member(verb: Verb, m: &StableMember) -> anyhow::Result<String> {
     match m.manage {
         ManageStrategy::Launchd => launchd_control(verb, &m.binary),
         ManageStrategy::OwnVerb => own_verb_control(verb, &m.binary),
+        // #6290, #6350: a member whose service is RETIRED lands here too, and
+        // that is the point — reaching `launchd_control` would bootstrap the
+        // very unit the retirement evicts. It is not a non-daemon, though, so
+        // the note says which of the two it is.
+        ManageStrategy::None if super::service_bootstrap::member_has_retired_service(&m.binary) => {
+            Ok("skipped (launchd service retired; nothing supervises it)".to_owned())
+        }
         ManageStrategy::None => Ok("skipped (not a daemon)".to_owned()),
     }
 }

--- a/crates/trusty-installer/src/commands/plist_label.rs
+++ b/crates/trusty-installer/src/commands/plist_label.rs
@@ -76,7 +76,22 @@ pub fn plist_label_for(binary: &str) -> String {
 ///
 /// Test: `tests::plist_path_layout`.
 pub fn plist_path_for(binary: &str) -> Option<PathBuf> {
-    let label = plist_label_for(binary);
+    plist_path_for_label(&plist_label_for(binary))
+}
+
+/// Resolve the on-disk plist path for a launchd LABEL.
+///
+/// Why (#6350): a retired member's eviction walks
+/// `trusty_common::launchd_labels::retired_labels_for_member`, which yields
+/// LABELS — the canonical one plus every legacy alias — and each has its own
+/// file. [`plist_path_for`] cannot answer that: it resolves ONE label from a
+/// binary name, so an alias would resolve to the canonical file and the alias's
+/// own plist would be left on disk.
+///
+/// What: `~/Library/LaunchAgents/<label>.plist`. `None` when the home directory
+/// cannot be resolved.
+/// Test: `tests::plist_path_layout` covers the shared join.
+pub fn plist_path_for_label(label: &str) -> Option<PathBuf> {
     dirs::home_dir().map(|h| {
         h.join("Library")
             .join("LaunchAgents")

--- a/crates/trusty-installer/src/commands/probe.rs
+++ b/crates/trusty-installer/src/commands/probe.rs
@@ -191,6 +191,18 @@ pub fn probe_member_health(binary: &str, manage: ManageStrategy) -> ProbeOutcome
         ManageStrategy::Launchd | ManageStrategy::OwnVerb => {
             probe_member_http_blocking(binary, binary)
         }
+        // #6350: an ON-DEMAND member is `None` as well, and for the same reason
+        // as #6290's per-invocation one — its launchd service is retired, so it
+        // has no lifecycle. It differs in what answers the health question: it
+        // still serves a socket, so `probe_daemon_http`'s `on_demand_member`
+        // branch STARTS it and asks `<domain>.health`. That is the only probe
+        // that separates "working" from "broken" for a service whose healthy
+        // resting state is not listening. Kept as its own arm rather than folded
+        // into the retired check, because being retired says nothing about
+        // whether a transport exists.
+        ManageStrategy::None if super::probe_http::on_demand_member(binary) => {
+            probe_member_http_blocking(binary, binary)
+        }
         // #6290: a per-invocation member is `None` too — it has no lifecycle —
         // but unlike `tga` it DOES have an honest health answer: the binary
         // resolved above, and `probe_daemon_http` routes it to a presence probe

--- a/crates/trusty-installer/src/commands/probe_http.rs
+++ b/crates/trusty-installer/src/commands/probe_http.rs
@@ -143,6 +143,23 @@ pub fn fixed_port_for(binary: &str) -> Option<u16> {
 ///
 /// Test: `tests::uds_members_have_no_fixed_port`,
 /// `tests::probe_uds_reads_the_health_envelope_off_a_result_frame`.
+/// Whether a member is started on demand rather than kept resident (#6350).
+///
+/// Why this exists as its own predicate: `uds_socket_for` answers "which
+/// transport", and this answers "who owns the lifetime" — two different
+/// questions that happen to have overlapping answers today. A member listed
+/// here has no launchd unit, so a socket that is not answering means nothing is
+/// using it, not that anything is broken.
+///
+/// Kept as a literal for the reason `uds_health_method` records: `tctl` has no
+/// Cargo edge on any daemon, and adding one to share a `&str` would pull an
+/// analysis engine into its build.
+///
+/// Test: `tests::on_demand_members_are_a_subset_of_the_uds_members`.
+pub fn on_demand_member(binary: &str) -> bool {
+    binary == trusty_common::uds::ANALYZE_SERVICE
+}
+
 pub fn uds_socket_for(binary: &str) -> Option<std::path::PathBuf> {
     match binary {
         // #6290: NO trusty-review row. It has no daemon and no socket — see
@@ -898,6 +915,22 @@ pub async fn probe_daemon_http(app: &str, binary: &str) -> ProbeOutcome {
                 detail: format!("{binary} serves a socket but names no health method"),
             };
         };
+        // #6350: an on-demand member is not expected to be running. A socket
+        // that does not answer is its NORMAL resting state, so probing it
+        // directly would report a healthy installation as `down` and send
+        // `verify_tail` off to repair a service that has nothing wrong with it.
+        // Starting it is the probe: a member that can be started and answers
+        // `<domain>.health` is working, and one that cannot is not.
+        if on_demand_member(binary) {
+            if let Err(e) = trusty_common::uds::OnDemandAnalyze::at(&socket)
+                .ensure_running()
+                .await
+            {
+                return ProbeOutcome::ProbeFailed {
+                    detail: format!("{binary} could not be started on demand: {e}"),
+                };
+            }
+        }
         return probe_socket(&socket, method).await;
     }
 

--- a/crates/trusty-installer/src/commands/probe_http_tests.rs
+++ b/crates/trusty-installer/src/commands/probe_http_tests.rs
@@ -1105,3 +1105,26 @@ fn only_transport_failures_are_confirmed_down() {
         );
     }
 }
+
+/// Why (#6350): `on_demand_member` decides whether a not-answering socket is a
+/// failure or a resting state, and it can only decide that for a member that
+/// HAS a socket. A name here that `uds_socket_for` does not know would make the
+/// predicate dead code that silently never fires.
+/// Test: this is the test.
+#[test]
+fn on_demand_members_are_a_subset_of_the_uds_members() {
+    assert!(
+        on_demand_member("trusty-analyze"),
+        "trusty-analyze is the on-demand member #6350 introduced"
+    );
+    assert!(
+        uds_socket_for("trusty-analyze").is_some(),
+        "an on-demand member must have a socket to be probed over"
+    );
+    for resident in ["trusty-review", "trusty-memory", "trusty-search"] {
+        assert!(
+            !on_demand_member(resident),
+            "{resident} is still resident; a dead socket there IS a failure"
+        );
+    }
+}

--- a/crates/trusty-installer/src/commands/service_bootstrap.rs
+++ b/crates/trusty-installer/src/commands/service_bootstrap.rs
@@ -203,20 +203,27 @@ impl BootstrapAction {
 /// service bootstrap for either would shell out to a subcommand that does not
 /// exist.
 ///
-/// #6290: trusty-review left this list. It has no daemon — reviews run per
-/// invocation — so it ships no `service` subcommand at all, and shelling out to
-/// one would be the same "subcommand that does not exist" failure the list
-/// exists to prevent. What it needs instead is EVICTION, which is
+/// #6290, #6350: trusty-review and trusty-analyze both left this list. Neither
+/// ships a `service install` subcommand any more — reviews run per invocation,
+/// and ADR-0032 makes analyze on demand — so shelling out to one would be the
+/// same "subcommand that does not exist" failure the list exists to prevent.
+/// What they need instead is EVICTION, which is
 /// [`member_has_retired_service`]'s question.
 ///
-/// What: `true` for search/memory/analyze/console; `false` otherwise.
+/// The exclusion is DERIVED, not remembered. Deleting a name from the list
+/// below is a second edit someone has to think to make, and #6350's first round
+/// made it here while leaving `manage_strategy_for` classifying analyze as
+/// launchd — so `tctl install` skipped the bootstrap while `tctl start` did it
+/// anyway. Both halves now read the one registry.
+///
+/// What: `true` for search/memory/console, minus any member whose service has
+/// since been retired; `false` otherwise.
 /// Test: `service_members_recognised`, `non_service_members_excluded`,
-/// `retired_review_has_no_service_install`.
+/// `retired_review_has_no_service_install`,
+/// `retired_analyze_has_no_service_install`.
 pub fn member_has_service_install(binary: &str) -> bool {
-    matches!(
-        binary,
-        "trusty-search" | "trusty-memory" | "trusty-analyze" | "trusty-console"
-    )
+    !member_has_retired_service(binary)
+        && matches!(binary, "trusty-search" | "trusty-memory" | "trusty-console")
 }
 
 /// Whether a member has a launchd unit an upgrade must boot out (#6290).

--- a/crates/trusty-installer/src/commands/service_bootstrap_tests.rs
+++ b/crates/trusty-installer/src/commands/service_bootstrap_tests.rs
@@ -241,20 +241,99 @@ fn evicting_a_retired_member_twice_is_quiet() {
 
 /// Why: the member predicate gates which daemons get a service bootstrap;
 /// every launchd-managed shared daemon must be recognised.
-/// What: asserts the five service members return `true`.
+/// What: asserts the three service members return `true` — trusty-review
+/// (#6290) and trusty-analyze (#6350) both left the list when their daemons
+/// were retired.
 /// Test: this is the test.
 #[test]
 fn service_members_recognised() {
-    for b in [
-        "trusty-search",
-        "trusty-memory",
-        "trusty-analyze",
-        "trusty-console",
-    ] {
+    for b in ["trusty-search", "trusty-memory", "trusty-console"] {
         assert!(
             member_has_service_install(b),
             "{b} should be a service member"
         );
+    }
+}
+
+/// REGRESSION (#6350): `tctl install` must never shell out to `trusty-analyze
+/// service install`, and must boot out the unit an earlier install left loaded.
+///
+/// Why: the analyze binary ships only `service uninstall` now — ADR-0032 makes
+/// it on demand — so the shell-out would exit 2 on every install. The second
+/// half matters more: `com.trusty.analyze` is loaded with `KeepAlive::Always`
+/// on every host that ran the old binary, restarting the server the moment its
+/// idle window reclaims it, and this pass is the only one that visits the
+/// member. The mirror of `retired_review_has_no_service_install`, driven
+/// through the SAME `bootstrap_one` eviction branch — one mechanism, two rows.
+/// Test: this is the test.
+#[test]
+fn retired_analyze_has_no_service_install() {
+    assert!(
+        !member_has_service_install("trusty-analyze"),
+        "shelling out to `trusty-analyze service install` would exit 2 — the \
+         subcommand is gone"
+    );
+    assert!(
+        super::member_has_retired_service("trusty-analyze"),
+        "trusty-analyze must still be visited, to clear its unit"
+    );
+
+    let env = FakeServiceEnv::new(true, false)
+        .with_retired_unit_loaded(&["com.trusty.analyze", "com.trusty.trusty-analyze"]);
+    let action = bootstrap_one(&env, "trusty-analyze", None);
+
+    assert_eq!(
+        *env.evicted.borrow(),
+        vec!["trusty-analyze".to_owned()],
+        "the retired unit must be booted out, not merely skipped"
+    );
+    assert!(
+        env.installed.borrow().is_empty(),
+        "nothing may be installed for a retired member: {:?}",
+        env.installed.borrow()
+    );
+    assert!(
+        env.fallback_calls.borrow().is_empty(),
+        "the bootstrap fallback must never fire for a retired member"
+    );
+    assert!(!action.is_failure());
+    match &action {
+        BootstrapAction::Skipped(reason) => {
+            assert!(reason.contains("com.trusty.analyze"), "reason: {reason}");
+            assert!(
+                reason.contains("com.trusty.trusty-analyze"),
+                "both labels exist on real hosts and both must be named: {reason}"
+            );
+        }
+        other => panic!("a retired member must be Skipped, got {other:?}"),
+    }
+}
+
+/// REGRESSION (#6350): a retired analyze unit that will not go down FAILS the
+/// install, exactly as a review one does.
+///
+/// Why: reporting `Skipped` for a `launchctl bootout` that refused exits 0 with
+/// `com.trusty.analyze` still loaded — and that unit restarts the on-demand
+/// server every time it reclaims itself, which is the state the retirement
+/// exists to end.
+/// Test: this is the test.
+#[test]
+fn a_retired_analyze_unit_that_will_not_go_down_fails_the_install() {
+    let env = FakeServiceEnv::new(true, false)
+        .with_retired_unit_loaded(&["com.trusty.analyze"])
+        .with_retired_eviction_failing("still loaded after `launchctl bootout` reported success");
+    let action = bootstrap_one(&env, "trusty-analyze", None);
+
+    assert!(
+        action.is_failure(),
+        "a retired unit still loaded must fail the install, got {action:?}"
+    );
+    match &action {
+        BootstrapAction::Failed(reason) => {
+            assert!(reason.contains("com.trusty.analyze"), "reason: {reason}");
+            assert!(reason.contains("still loaded"), "reason: {reason}");
+        }
+        other => panic!("expected Failed, got {other:?}"),
     }
 }
 
@@ -388,7 +467,11 @@ fn bootstrap_one_installs_when_absent() {
 #[test]
 fn bootstrap_one_reports_failure() {
     let env = FakeServiceEnv::new(false, true);
-    let action = bootstrap_one(&env, "trusty-analyze", None);
+    // #6290, #6350: trusty-review and trusty-analyze are both retired, so
+    // either would take the eviction branch rather than reaching the
+    // service-install failure path under test. trusty-console still installs a
+    // unit, which is what this test needs.
+    let action = bootstrap_one(&env, "trusty-console", None);
     match action {
         BootstrapAction::Failed(e) => assert!(e.contains("simulated failure")),
         other => panic!("expected Failed, got {other:?}"),

--- a/crates/trusty-installer/src/commands/stable_set.rs
+++ b/crates/trusty-installer/src/commands/stable_set.rs
@@ -41,10 +41,12 @@ use serde::Serialize;
 /// `trusty_common::launchd::LaunchdConfig` `bootstrap`/`bootout`;
 /// [`ManageStrategy::OwnVerb`] → shell out to the member's own
 /// `<binary> start|stop|restart` subcommand; [`ManageStrategy::None`] →
-/// non-daemon (no lifecycle control).
+/// non-daemon, or a member whose launchd service is RETIRED (no lifecycle
+/// control either way).
 ///
 /// Test: `tests::mpm_uses_own_verb`, `tests::daemons_use_launchd`,
-/// `tests::non_daemon_has_no_strategy`.
+/// `tests::non_daemon_has_no_strategy`,
+/// `tests::a_retired_member_never_reaches_launchd_control`.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ManageStrategy {
@@ -277,15 +279,29 @@ pub(super) fn gating_split<T>(rows: &[T], required: impl Fn(&T) -> bool) -> Gati
 /// function rather than a `StableMember` constructor detail. Keeping it in ONE
 /// place is the point: the divergent `SystemRunner::probe` this replaces existed
 /// precisely because "how is this member managed?" was answered twice.
-/// What: a non-daemon is [`ManageStrategy::None`]; trusty-mpm is
-/// [`ManageStrategy::OwnVerb`] (process-managed, not launchd); every other daemon
-/// is [`ManageStrategy::Launchd`].
-/// Test: `tests::manage_strategy_for_matches_the_stable_set`.
+/// What: a non-daemon is [`ManageStrategy::None`]; so is a member whose launchd
+/// service has been RETIRED; trusty-mpm is [`ManageStrategy::OwnVerb`]
+/// (process-managed, not launchd); every other daemon is
+/// [`ManageStrategy::Launchd`].
+///
+/// 🔴 #6350: the retired arm comes BEFORE the launchd fallthrough, and that
+/// ordering is what keeps trusty-analyze off launchd. It is still
+/// `daemon: true` — it IS a daemon, just an unsupervised one a client starts —
+/// so it fell through to `Launchd` and `tctl start` routed it into
+/// `lifecycle::launchd_control`, which `bootstrap`s the retired
+/// `com.trusty.analyze` unit on an upgraded host and shells out to a `service
+/// install` clap no longer defines on a fresh one. The port guard cannot catch
+/// it: analyze has bound no port since #6287, so `resolve_guard_ports` is empty
+/// and `guard_bootstrap_label` permits vacuously.
+///
+/// Test: `tests::manage_strategy_for_matches_the_stable_set`,
+/// `tests::a_retired_member_never_reaches_launchd_control`.
 pub fn manage_strategy_for(binary: &str, daemon: bool) -> ManageStrategy {
     if !daemon {
         ManageStrategy::None
     } else if trusty_common::launchd_labels::retired_service_for_member(binary).is_some() {
-        // #6290: a member whose launchd service is RETIRED has no lifecycle to
+        // #6290, #6350: a member whose launchd service is RETIRED has no
+        // lifecycle to
         // control — `tctl start` cannot start it and `verify_tail` must not
         // kickstart it, because there is no unit. `daemon: true` is kept in the
         // stable set so the install pass still visits the member and evicts the
@@ -885,30 +901,83 @@ mod tests {
 
     /// Why: The launchd-supervised daemons must resolve to the `Launchd`
     /// strategy so lifecycle drives `bootstrap`/`bootout`.
-    /// What: Asserts search/memory/analyze/console are `Launchd`, and that
-    /// trusty-review — whose service is retired (#6290) — is `None` despite
-    /// carrying `daemon: true`.
+    /// What: Asserts search/memory/console are `Launchd`, and that
+    /// trusty-review (#6290) and trusty-analyze (#6350) — whose services are
+    /// retired — are `None` despite carrying `daemon: true`.
     /// Test: This is the test.
     #[test]
     fn daemons_use_launchd() {
         let set = stable_set();
         let manage = |b: &str| set.iter().find(|m| m.binary == b).expect("present").manage;
-        for b in [
-            "trusty-search",
-            "trusty-memory",
-            "trusty-analyze",
-            "trusty-console",
-        ] {
+        for b in ["trusty-search", "trusty-memory", "trusty-console"] {
             assert_eq!(manage(b), ManageStrategy::Launchd, "{b}");
         }
-        // #6290: `daemon: true` keeps the member in the install pass so the
-        // stale unit is evicted; `manage: None` is what stops `tctl start` and
-        // `verify_tail` trying to control a unit that is not there.
-        assert_eq!(
-            manage("trusty-review"),
-            ManageStrategy::None,
-            "a retired service has no lifecycle to drive"
+        // #6290, #6350: `daemon: true` keeps each member in the install pass
+        // so the stale unit is evicted; `manage: None` is what stops
+        // `tctl start` and `verify_tail` trying to control a unit that is not
+        // there.
+        for retired in ["trusty-review", "trusty-analyze"] {
+            assert_eq!(
+                manage(retired),
+                ManageStrategy::None,
+                "{retired}'s service is retired and has no lifecycle to drive"
+            );
+        }
+    }
+
+    /// Why (#6290, #6350): every `tctl` path that could touch launchd for a
+    /// member reads `manage`, and a member whose service is RETIRED must reach
+    /// NONE of them. With `Launchd` — which is what a `daemon: true` member
+    /// falls through to — `tctl start` bootstraps the retired unit on an
+    /// upgraded host and shells out to a `service install` clap no longer
+    /// defines on a fresh one, exit 2. The port guard cannot catch it for
+    /// analyze: it binds no port since #6287, so `resolve_guard_ports` is empty
+    /// and the guard permits vacuously.
+    ///
+    /// What: for every retired member in the stable set — the strategy is
+    /// `None`, which is the one arm `lifecycle::apply_to_member` answers
+    /// without calling `launchd_control`; no `service install` is planned; and
+    /// the `daemon` flag is untouched, because it IS a daemon and must stay
+    /// probeable.
+    /// Test: This is the test.
+    #[test]
+    fn a_retired_member_never_reaches_launchd_control() {
+        let retired: Vec<StableMember> = stable_set()
+            .into_iter()
+            .filter(|m| crate::commands::service_bootstrap::member_has_retired_service(&m.binary))
+            .collect();
+        let names: Vec<&str> = retired.iter().map(|m| m.binary.as_str()).collect();
+        assert!(
+            names.contains(&"trusty-analyze"),
+            "trusty-analyze is retired since #6350; its absence means the \
+             registry and the stable set have drifted apart: {names:?}"
         );
+        for m in &retired {
+            assert_eq!(
+                m.manage,
+                ManageStrategy::None,
+                "{} must never be launchd-managed",
+                m.binary
+            );
+            assert_ne!(
+                m.manage,
+                ManageStrategy::Launchd,
+                "{} would reach `lifecycle::launchd_control` and bootstrap its \
+                 own retired unit",
+                m.binary
+            );
+            assert_eq!(manage_strategy_for(&m.binary, m.daemon), m.manage);
+            assert!(
+                !crate::commands::service_bootstrap::member_has_service_install(&m.binary),
+                "{} has no `service install` subcommand to shell out to",
+                m.binary
+            );
+            assert!(
+                m.daemon,
+                "{} is still a daemon — only its supervision changed",
+                m.binary
+            );
+        }
     }
 
     /// Why: A non-daemon has no lifecycle control; its strategy must be `None`.

--- a/crates/trusty-installer/src/commands/stack/doctor.rs
+++ b/crates/trusty-installer/src/commands/stack/doctor.rs
@@ -120,6 +120,9 @@ fn diagnose(m: &StableMember) -> MemberDoctor {
                 .map(|p| p.exists())
                 .unwrap_or(false),
         ),
+        // #6290, #6350: a retired member needs no plist, so "is one installed"
+        // has no answer to give. Evicting a plist an OLDER install left behind
+        // is `tctl install` / `tctl upgrade`'s eviction, not a doctor row.
         ManageStrategy::OwnVerb | ManageStrategy::None => None,
     };
     let port_recorded = matches!(

--- a/crates/trusty-installer/src/commands/up/stages.rs
+++ b/crates/trusty-installer/src/commands/up/stages.rs
@@ -154,8 +154,18 @@ fn stage_core(members: &[BootMember], runner: &dyn Runner) -> (StageStatus, Stri
 /// Why: The analyze daemon health gates the console's analyze tab, but the
 /// analysis *content* is advisory and never gates boot (RESOLVED Q6).
 ///
-/// What: With `AnalyzeMode::Skip` → a `Skipped` report. Otherwise ensures the
-/// analyze daemon; the daemon being down is `Degraded` (non-hard), not `Failed`.
+/// #6350: this stage no longer asks whether a daemon is RESIDENT, because none
+/// is. trusty-analyze has no launchd unit; a client starts it and it exits on
+/// its own idle window, so "nothing is listening" is its healthy resting state
+/// and gating on a live dial would report every correct installation as
+/// degraded. What the stage asks instead is the question that still has a wrong
+/// answer: can a client on this machine start it and get an answer? That is
+/// `ensure_member`, which for an on-demand member resolves through
+/// `probe_http`'s `on_demand_member` branch — one start plus one
+/// `analyze.health` ping, after which the server is left to reclaim itself.
+///
+/// What: With `AnalyzeMode::Skip` → a `Skipped` report. Otherwise runs that
+/// one-shot check; a failure is `Degraded` (non-hard), not `Failed`.
 /// `Blocking` vs `Background` only changes the detail label (the actual snapshot
 /// scheduling is a passthrough to trusty-analyze).
 ///
@@ -192,17 +202,21 @@ fn stage_analyze(
             "analyze",
             StageStatus::Ok,
             format!(
-                "daemon {} ; {mode} over [{targets}] (non-gating)",
+                "on demand, answered {} ; {mode} over [{targets}] (non-gating)",
                 outcome.action
             ),
         )
     } else {
-        // Analyze daemon down is degraded, not a hard failure (§5).
+        // #6350: the wording matters. "daemon down" was accurate when one was
+        // supposed to be resident; now it would describe the normal state and
+        // send an operator looking for a service to restart. What failed is the
+        // START, which is a different fix (install the binary, or read why the
+        // spawn was refused). Still Degraded, not a hard failure (§5).
         StageReport::new(
             "analyze",
             StageStatus::Degraded,
             format!(
-                "analyze daemon down ({}); analysis content absent",
+                "analyze could not be started on demand ({}); analysis content absent",
                 outcome.action
             ),
         )

--- a/crates/trusty-installer/src/commands/upgrade_tests.rs
+++ b/crates/trusty-installer/src/commands/upgrade_tests.rs
@@ -184,43 +184,42 @@ fn run_check_is_readonly() {
 
 /// Why: the load-bearing Phase 1a assertion. Every daemon member must
 /// PLAN a restart. Before the fix all of them planned one in name only.
-/// What: on macOS, the five launchd daemons plan `Launchd` and trusty-mpm
+/// What: on macOS, the three launchd daemons plan `Launchd` and trusty-mpm
 /// plans `OwnVerb` — matching what `tctl restart` does for the same
 /// members, which is the point of sharing the implementation.
+///
+/// #6290, #6350: trusty-review and trusty-analyze both left the launchd loop.
+/// Neither has a unit to bounce, and asserting one for analyze is what pinned
+/// the defect `upgrade_evicts_a_retired_members_unit` now pins the fix for.
 /// Test: this is the test.
 #[test]
 fn restart_plan_daemons_restart() {
     use super::super::stable_set::ManageStrategy;
-    for binary in [
-        "trusty-search",
-        "trusty-memory",
-        "trusty-analyze",
-        "trusty-console",
-    ] {
+    for binary in ["trusty-search", "trusty-memory", "trusty-console"] {
         assert_eq!(
             restart_plan(binary, true, true),
             RestartPlan::Restart(ManageStrategy::Launchd),
             "{binary} must be bounced through launchd after an upgrade"
         );
     }
-    // #6290: upgrading trusty-review has nothing to bounce — the next `run`
-    // invocation IS the new binary. It is not a no-op either: the stale
-    // `com.trusty.review` unit is EVICTED here. This assertion previously
-    // expected `NoRestart`, which is what let the upgrade path leave that unit
-    // loaded (#6290 review, HIGH).
-    assert_eq!(
-        restart_plan("trusty-review", true, true),
-        RestartPlan::EvictRetired,
-        "a per-invocation member has no process to restart, but its retired \
-         unit must still be cleared"
-    );
-    assert!(
-        !matches!(
-            restart_plan("trusty-review", true, true),
-            RestartPlan::Restart(_)
-        ),
-        "and nothing may be bounced for it"
-    );
+    // #6290, #6350: upgrading a retired member has nothing to bounce — the
+    // next invocation IS the new binary. It is not a no-op either: the stale
+    // unit is EVICTED here. This assertion previously expected `NoRestart` for
+    // review, which is what let the upgrade path leave that unit loaded (#6290
+    // review, HIGH), and `Restart(Launchd)` for analyze, which would have
+    // bootstrapped the very unit #6350 evicts.
+    for retired in ["trusty-review", "trusty-analyze"] {
+        assert_eq!(
+            restart_plan(retired, true, true),
+            RestartPlan::EvictRetired,
+            "{retired} has no process to restart, but its retired unit must \
+             still be cleared"
+        );
+        assert!(
+            !matches!(restart_plan(retired, true, true), RestartPlan::Restart(_)),
+            "and nothing may be bounced for {retired}"
+        );
+    }
     assert_eq!(
         restart_plan("trusty-mpm", true, true),
         RestartPlan::Restart(ManageStrategy::OwnVerb),
@@ -231,6 +230,39 @@ fn restart_plan_daemons_restart() {
         restart_plan("trusty-mpm", true, false),
         RestartPlan::Restart(ManageStrategy::OwnVerb)
     );
+}
+
+/// REGRESSION (#6350): `tctl upgrade` evicts trusty-analyze's retired unit.
+///
+/// Why: analyze carries `daemon: true`, so before its row joined
+/// `RETIRED_SERVICES` it fell through to `ManageStrategy::Launchd` and
+/// `restart_plan` returned `Restart(Launchd)` — sending `restart_member` at the
+/// retired `com.trusty.analyze` label and bootstrapping the unit the
+/// retirement exists to remove. The port guard could not catch it: analyze has
+/// bound no port since #6287, so `resolve_guard_ports` is empty and
+/// `guard_bootstrap_label` permits vacuously.
+///
+/// What: drives `restart_plan` — the upgrade path's own decision function, not
+/// `bootstrap_one` — and asserts analyze routes to the SAME eviction review
+/// does, on both platforms. One mechanism, two rows.
+/// Test: this is the test.
+#[test]
+fn upgrade_evicts_the_retired_analyze_unit() {
+    use crate::commands::stable_set::{manage_strategy_for, ManageStrategy};
+    assert_eq!(
+        manage_strategy_for("trusty-analyze", true),
+        ManageStrategy::None,
+        "a retired member has no lifecycle to control — that part is correct"
+    );
+
+    for macos in [true, false] {
+        assert_eq!(
+            restart_plan("trusty-analyze", true, macos),
+            RestartPlan::EvictRetired,
+            "a retired member must be EVICTED by the upgrade, not bounced \
+             through launchd (macos={macos})"
+        );
+    }
 }
 
 /// Why: `tga` is the one non-daemon in the stable set; bouncing it would be

--- a/crates/trusty-review/Cargo.toml
+++ b/crates/trusty-review/Cargo.toml
@@ -153,7 +153,7 @@ clap         = { workspace = true }
 # it: the serve transport depends on `uds::server` directly now, and an implied
 # feature is one refactor away from disappearing under a consumer that never
 # said it needed it.
-trusty-common = { workspace = true, features = ["intent-source", "config-cli", "webhook-relay", "gh-cli", "uds", "redb-open"] }  # `redb-open` (#5063): the workspace's single redb corruption classifier, which `store::redb_error_is_incompatible_format` delegates to
+trusty-common = { workspace = true, features = ["intent-source", "config-cli", "webhook-relay", "gh-cli", "uds", "uds-supervisor", "redb-open"] }  # `redb-open` (#5063): the workspace's single redb corruption classifier, which `store::redb_error_is_incompatible_format` delegates to
 # JSON-RPC / MCP primitives (ADR-0040, #5803). Optional: only the `mcp` feature
 # compiles `src/mcp/`.
 trusty-mcp = { workspace = true, optional = true }

--- a/crates/trusty-review/changelog.d/6350-analyze-on-demand.md
+++ b/crates/trusty-review/changelog.d/6350-analyze-on-demand.md
@@ -1,0 +1,8 @@
+Changed
+- `report --analyze` starts trusty-analyze itself rather than requiring a
+  resident daemon, and restarts it if it idles out mid-report: a request that
+  finds the socket gone respawns the server and retries exactly once. A timeout
+  does not retry — the server answered and is working. A start that fails is
+  reported through the "falling back to scan" line on stderr plus an
+  unassessed-dimension entry under Gaps & Caveats, never silently degraded to a
+  clean-looking report (#6350).

--- a/crates/trusty-review/src/report/analyze_adapter.rs
+++ b/crates/trusty-review/src/report/analyze_adapter.rs
@@ -5,9 +5,20 @@
 //! trusty-analyze WITHOUT an LLM and WITHOUT a hand-authored metrics JSON. A
 //! library dependency on trusty-analyze is impossible (a cargo cycle: analyze
 //! already optionally depends on trusty-review via its `review` feature), so
-//! this adapter is a thin HTTP client over the analyze daemon (`:7879`) plus a
-//! pure mapping from the daemon's wire JSON onto the report's v0
-//! [`AnalyzeMetrics`]. Every probe/fetch/parse failure is fail-open — the
+//! this adapter is a thin JSON-RPC client over the analyze daemon's hardened
+//! Unix socket plus a pure mapping from the daemon's wire JSON onto the report's
+//! v0 [`AnalyzeMetrics`]. (#6287 retired the `127.0.0.1:7879` HTTP listener this
+//! header used to name; there is no port and no discovery file — the socket path
+//! is derived through `trusty_common::daemon_socket_path`.)
+//!
+//! #6350: nothing is resident on the far end of that socket any more. The
+//! adapter starts the server itself, once per source, through
+//! [`trusty_common::uds::OnDemandAnalyze`] — the same entry point every other
+//! client uses, so a second client racing this one adopts the same process
+//! rather than starting a second. A start that FAILS is not silent: it becomes
+//! a `Transport` error, which prints the fallback line on stderr and lands in
+//! the report's Gaps & Caveats as an unassessed dimension. Every
+//! probe/fetch/parse failure is fail-open — the
 //! adapter degrades to `None` and the report falls through to the built-in
 //! scan; a missing analyze index is never an error. Since #6041 that degradation
 //! is per endpoint rather than per repository: a dataset that fails leaves the
@@ -449,6 +460,19 @@ pub enum AnalyzeFetch {
 /// in-process stub daemon; unit tests here cover the fail-open conversions.
 pub struct HttpAnalyzeMetricsSource {
     socket: PathBuf,
+    /// The on-demand starter, shared across every fetch this source makes.
+    ///
+    /// One handle, not one per call: its spawn gate is what keeps two
+    /// concurrent fetches from each starting a server (#6350).
+    launcher: trusty_common::uds::OnDemandAnalyze,
+    /// Memoised result of the single start attempt.
+    ///
+    /// Why memoised: `enrich_with_analyze_gaps` iterates repositories, so an
+    /// un-memoised start would re-probe the socket once per repo. Why the
+    /// FAILURE is memoised too: a machine with no trusty-analyze installed
+    /// would otherwise pay a spawn budget per repository, and report the same
+    /// failure N times.
+    started: tokio::sync::OnceCell<Result<(), String>>,
 }
 
 impl HttpAnalyzeMetricsSource {
@@ -470,9 +494,52 @@ impl HttpAnalyzeMetricsSource {
     ///
     /// Test: `new_accepts_a_socket_path`.
     pub fn new(socket: impl Into<PathBuf>) -> AdapterResult<Self> {
+        let socket = socket.into();
         Ok(Self {
-            socket: socket.into(),
+            launcher: trusty_common::uds::OnDemandAnalyze::at(&socket),
+            socket,
+            started: tokio::sync::OnceCell::new(),
         })
+    }
+
+    /// Start trusty-analyze if nothing is serving, exactly once per source.
+    ///
+    /// Why this is here and not at the CLI call site: the CLI hands this type a
+    /// socket path and asks for metrics; "is anything serving that path" is this
+    /// type's problem, and putting it here means an embedded caller
+    /// (`trusty-analyze --features review`, the MCP tools) gets the same
+    /// behaviour without duplicating the start.
+    ///
+    /// What: delegates to the shared [`trusty_common::uds::OnDemandAnalyze`],
+    /// memoising the outcome. A failure is converted to a string rather than
+    /// kept as an error, because `OnceCell` stores one value for every caller
+    /// and `SupervisorError` is not `Clone`.
+    ///
+    /// # Errors
+    ///
+    /// [`AnalyzeAdapterError::Transport`] when the server could not be started.
+    /// It is NOT degraded to a silent `None` here: the caller converts it into
+    /// the visible "falling back to scan" line and a Gaps & Caveats entry.
+    ///
+    /// Test: `a_failed_start_is_reported_rather_than_swallowed`.
+    async fn ensure_started(&self) -> AdapterResult<()> {
+        let outcome = self
+            .started
+            .get_or_init(|| async {
+                self.launcher
+                    .ensure_running()
+                    .await
+                    .map(|_| ())
+                    .map_err(|e| format!("{e:#}"))
+            })
+            .await;
+        match outcome {
+            Ok(()) => Ok(()),
+            Err(reason) => Err(AnalyzeAdapterError::Transport(format!(
+                "could not start trusty-analyze on demand for {}: {reason}",
+                self.socket.display()
+            ))),
+        }
     }
 
     /// Call one endpoint and deserialize its `result` into `T`, mapping every
@@ -492,7 +559,77 @@ impl HttpAnalyzeMetricsSource {
     /// JSON-RPC envelope check.
     /// Test: `a_request_that_outlives_its_budget_is_a_timeout_not_a_transport_error`,
     /// `fetch_returns_none_on_unreachable_daemon`.
+    /// One request, with a respawn-and-retry when the server has gone away.
+    ///
+    /// Why (#6350): an on-demand server exits after its idle window, and a
+    /// multi-repository report is exactly the caller that can straddle one — the
+    /// diagnostics endpoint alone has a multi-minute budget, so a run over
+    /// several repositories can leave the socket untouched for longer than the
+    /// ten-minute default. `ensure_started` runs once per source, so without
+    /// this every fetch after the exit would hard-fail with nothing left to
+    /// restart it. #6287 removed the old retry on the assumption that the far
+    /// end was resident; #6350 invalidated that assumption.
+    ///
+    /// What: on a `Transport` failure — a socket that refused, vanished, or hung
+    /// up — start the server again and reissue the request EXACTLY once. The
+    /// second failure is returned as-is.
+    ///
+    /// A `Timeout` deliberately does not retry: the server answered the connect
+    /// and is working, so reissuing would double an already-long budget and hide
+    /// a slow handler behind a doubled wait. Nor does an `Rpc` or `Parse`
+    /// failure, which are answers, not absences.
+    ///
+    /// # Errors
+    ///
+    /// The second attempt's error, or the restart's if that is what failed.
+    ///
+    /// Test: `tests/on_demand.rs`' `the_adapter_respawns_a_server_that_idled_out`.
     async fn call<T: serde::de::DeserializeOwned>(
+        &self,
+        endpoint: AnalyzeEndpoint,
+        index_id: &str,
+        budget: Duration,
+    ) -> AdapterResult<T> {
+        match self.call_once(endpoint, index_id, budget).await {
+            Err(AnalyzeAdapterError::Transport(first)) => {
+                tracing::debug!(
+                    index_id,
+                    endpoint = endpoint.as_str(),
+                    error = %first,
+                    "--analyze: the socket did not answer; restarting the server and retrying once"
+                );
+                self.restart().await.map_err(|e| {
+                    AnalyzeAdapterError::Transport(format!("{first}; and the retry failed: {e}"))
+                })?;
+                self.call_once(endpoint, index_id, budget).await
+            }
+            other => other,
+        }
+    }
+
+    /// Start the server, bypassing [`Self::ensure_started`]'s memo.
+    ///
+    /// Why not reuse the memo: it holds the outcome of the FIRST start, and the
+    /// case this exists for is a server that started successfully and has since
+    /// exited. Reading the memo would return that stale `Ok` and start nothing.
+    ///
+    /// # Errors
+    ///
+    /// [`AnalyzeAdapterError::Transport`] when the server could not be started.
+    async fn restart(&self) -> AdapterResult<()> {
+        self.launcher
+            .ensure_running()
+            .await
+            .map(|_| ())
+            .map_err(|e| {
+                AnalyzeAdapterError::Transport(format!(
+                    "could not restart trusty-analyze for {}: {e:#}",
+                    self.socket.display()
+                ))
+            })
+    }
+
+    async fn call_once<T: serde::de::DeserializeOwned>(
         &self,
         endpoint: AnalyzeEndpoint,
         index_id: &str,
@@ -598,6 +735,9 @@ impl HttpAnalyzeMetricsSource {
         &self,
         index_id: &str,
     ) -> AdapterResult<Option<(AnalyzeMetrics, Vec<AnalyzeCaveat>)>> {
+        // #6350: nothing is resident on this socket; start it before dialling.
+        self.ensure_started().await?;
+
         if !self.index_served(index_id).await? {
             tracing::warn!(
                 index_id,

--- a/crates/trusty-review/src/report/analyze_adapter_tests.rs
+++ b/crates/trusty-review/src/report/analyze_adapter_tests.rs
@@ -1020,3 +1020,91 @@ fn an_absent_region_kind_renders_as_before() {
     let f = refactor_finding(&nameless_region()).expect("critical → amber");
     assert_eq!(f.title, "Split oversized impl block");
 }
+
+/// Restore an environment variable to whatever it held before the test.
+///
+/// Why: the two variables below are process-global, and the tests around this
+/// one read `TRUSTY_SEARCH_URL` through `ReviewConfig::from_env_and_file`.
+/// Same shape as `redact_tests.rs`'s `TokenEnvGuard`.
+struct EnvGuard(&'static str, Option<String>);
+
+impl EnvGuard {
+    fn set(key: &'static str, value: &str) -> Self {
+        let prev = std::env::var(key).ok();
+        // SAFETY: every test that sets these is `#[serial_test::serial]`, and
+        // the guard restores the previous value on drop.
+        unsafe { std::env::set_var(key, value) };
+        EnvGuard(key, prev)
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        // SAFETY: as above.
+        unsafe {
+            match self.1.take() {
+                Some(prev) => std::env::set_var(self.0, prev),
+                None => std::env::remove_var(self.0),
+            }
+        }
+    }
+}
+
+/// Why (#6350 Fail-Open Check): the adapter now STARTS trusty-analyze rather
+/// than assuming it is resident, and a start that fails must not read as a
+/// clean pass. The report has to say the dimension went unassessed — which is
+/// what `AnalyzeGap::Unreachable` renders — rather than silently omitting it.
+///
+/// What makes the failure deterministic: `resolve_binary` searches `PATH` and
+/// the well-known bin directories, so on a machine with trusty-analyze
+/// installed the missing-binary branch is unreachable and the spawned child
+/// would start normally. Pointing `TRUSTY_SEARCH_URL` at port 1 — privileged
+/// and unbound — makes the child's startup probe of trusty-search always
+/// refuse, so it exits before binding and the start always fails.
+/// `tests/on_demand.rs::a_server_that_cannot_start_is_an_error_not_a_success`
+/// forces it the same way.
+///
+/// The assertion is on the VARIANT, not on the rendered string: every
+/// `AnalyzeGap` names trusty-analyze, so `contains("trusty-analyze")` also held
+/// for `NotIndexed` — which is what a machine with a live trusty-search
+/// returned once the child started successfully.
+/// Test: this is the test.
+#[serial_test::serial]
+#[tokio::test]
+async fn a_failed_start_is_reported_rather_than_swallowed() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let socket = tmp.path().join("nothing-here.sock");
+    // Port 1 is privileged and unbound: the child's trusty-search probe always
+    // refuses, so it exits before it binds.
+    let _search = EnvGuard::set("TRUSTY_SEARCH_URL", "http://127.0.0.1:1");
+    // Off the real data directory: a developer machine with a live analyze
+    // server holds an exclusive redb lock on it, which would fail the child for
+    // a reason that has nothing to do with the property under test.
+    let _facts = EnvGuard::set(
+        "TRUSTY_ANALYZER_FACTS",
+        &tmp.path().join("facts.redb").to_string_lossy(),
+    );
+    let src = HttpAnalyzeMetricsSource::new(&socket).expect("infallible since #6287");
+
+    let verdict = tokio::time::timeout(
+        std::time::Duration::from_secs(90),
+        src.fetch_named("some-index"),
+    )
+    .await
+    .expect("a failed start must not hang the report");
+
+    match verdict {
+        AnalyzeFetch::Missing(gap) => assert_eq!(
+            gap,
+            AnalyzeGap::Unreachable,
+            "a start that could not succeed is `Unreachable`, not any other gap"
+        ),
+        AnalyzeFetch::Fetched { .. } => {
+            panic!("nothing is serving that socket; metrics cannot have been fetched")
+        }
+    }
+    assert!(
+        !socket.exists(),
+        "a failed start must not leave a socket implying success"
+    );
+}

--- a/docs/architecture/port-assignments.md
+++ b/docs/architecture/port-assignments.md
@@ -115,6 +115,14 @@ of those bind it; all three go when that client migrates. Whatever you pick:
   (binary on PATH plus `--version`) instead of dialling. A probe left dialling
   would read `Refused`, which `is_confirmed_down` accepts, and kickstart a
   launchd label that no longer exists.
+- **#6350** — `trusty-analyze` went further and stopped being resident at all.
+  It has no launchd unit and no port; a client starts it through
+  `trusty_common::uds::OnDemandAnalyze` and it exits after an idle window. An
+  operator has nothing to run and nothing to install: neither
+  `trusty-analyze serve` nor `trusty-analyze service install` (which no longer
+  exists) is part of bringing the stack up. `com.trusty.analyze` is evicted by
+  `tctl install` and `tctl upgrade`, through the same `RETIRED_SERVICES`
+  mechanism that clears `com.trusty.review` — one eviction path, two rows.
 - **#6287** — `trusty-analyze` left this table the same way, on the same
   reasoning: it binds `<data dir>/trusty-analyze/trusty-analyze.sock` and has
   no `DEFAULT_PORT`. Four consumers dialled 7879 rather than two, so all four


### PR DESCRIPTION
The analyze server now exits after ten minutes with no traffic, unlinking its socket, and every in-repo client starts it through `trusty_common::uds::OnDemandAnalyze` before dialling instead of assuming a resident daemon. `trusty-analyze service install` / `status` / `logs` are removed and no LaunchAgent is installed; `service uninstall` remains as the migration off one, and `tctl` no longer service-bootstraps or health-gates on a live analyze dial. The idle policy is generic — `trusty_common::uds::server::serve_until_idle` — so the review sibling can reuse it.

Refs #6350. Sibling of #6290 (review de-daemonization) under ADR-0032.

**Idle timeout: 10 minutes** (`TRUSTY_ANALYZE_IDLE_TIMEOUT_SECS` overrides; `0` disables). Midpoint of the band the ruling set. A cold start re-opens the facts redb and the SCIP overlay store and re-warms per-index chunk caches, so a window shorter than an operator's edit-run loop makes every `trusty-review report --analyze` pay that again; ten minutes of silence is exactly what ADR-0032 retired the unit to stop paying for. A liveness probe does not reset the window — only a connection that answered a request does — so the console's detect poll cannot pin the service alive.

**Rebased onto #6354 — one eviction mechanism, not two.** #6354 landed the workspace's retirement mechanism first, keyed off `launchd_labels::RETIRED_SERVICES`. This branch carried a SECOND one: a `tctl up` retire stage with its own `RetireAction` / `RetireEnv` / `retire_one` / `retire_all` / `RealRetireEnv`, plus a fourth `Runner` seam, that shelled out to each retired member's `service uninstall`. All of it is deleted — and it would have broken outright, since `trusty-review service uninstall` no longer exists.

trusty-analyze adopts #6354's mechanism by adding its row to `RETIRED_SERVICES` beside trusty-review's. Everything else follows with no new code: `tctl install` reaches the member through `plans_service_bootstrap`'s retired branch, `tctl upgrade` through `RestartPlan::EvictRetired`, and both converge on `evict_retired_unit`. A unit that will not go down fails that member's install or upgrade. `git grep "service uninstall" crates/trusty-installer` now returns no subprocess.

`ManageStrategy::OnDemand` is **dropped** rather than kept. Every retired-member gate in the crate keys off the registry, not off the strategy, so the variant earned exactly one thing — a nicer lifecycle note — while requiring every gate to be taught about it and adding a variant to a public enum. A retired member is `ManageStrategy::None`, which is what keeps it out of `launchd_control` (`a_retired_member_never_reaches_launchd_control`). The one real distinction analyze needs is the health probe: it still serves a socket, so it keeps its transport probe through the same `None` + named-predicate arm #6290 added for a presence-only member. Starting it and asking `analyze.health` is the only check that separates "working" from "broken" for a service whose healthy resting state is not listening.

**Operator migration.** Every machine that installed trusty-analyze before this has `com.trusty.analyze` loaded, and upgrading the binary does not unload it. Run `trusty-analyze service uninstall` once; `trusty-analyze setup daemon`, **`tctl install` and `tctl upgrade`** run the same eviction, so it happens either way. That command now delegates to `LaunchdConfig::evict_legacy_detailed` — the workspace's one implementation, which verifies launchd actually let go rather than trusting `bootout`'s exit code — and reports `EvictionOutcome` / `LabelEviction` instead of a private enum.

**Fail-Open Check.** `ensure_running` never degrades a failure into a success: a missing binary, a refused spawn, or a socket that never appeared inside the 20s budget all return `SupervisorError`. Each caller then reports it — the review adapter prints `--analyze: fetch for '<id>' failed (…); falling back to scan` on stderr AND records an unassessed-dimension entry in the report's Gaps & Caveats, so a fallback is never silent (`a_failed_start_is_reported_rather_than_swallowed`); `trusty-analyze deep` aborts with the start error, since there is no offline deep-analysis path; `tctl`'s probe returns `ProbeFailed` naming the start failure, and `stage_analyze` reports Degraded with "could not be started on demand" rather than the old "daemon down", which would send an operator looking for a service to restart. On the eviction side, `service uninstall` exits 1 for a label that will not go down — including when a sibling label was cleared — and a future `#[non_exhaustive]` `EvictionOutcome` variant fails rather than falling through silently.

**Versions.**

| Crate | Published | This PR | Gate verdict |
|---|---|---|---|
| trusty-analyze | 0.12.0 | **0.12.2** | `196 checks: 196 pass` — "no semver update required". `trusty-analyze-v0.12.1` is a stranded tag (tagged, never on crates.io) and tags here are immutable, so that number is spent. |
| trusty-common | 0.45.3 | 0.45.4 (from main) | `196 checks: 196 pass` — additive; 0.45.4 stands. |
| trusty-review | 0.28.1 | 0.29.0 (from main) | BREAK inventoried — the five `service::rpc` lints #6354 already justified. The adapter change here is internal; nothing new. |
| trusty-installer | 0.12.0 | **0.13.0** | BREAK. Five major lints, **all already on main**: `pub_module_level_const_missing` (`SUPERVISOR_METRICS_PORT`), `inherent_method_missing` + `struct_pub_field_missing` (`StubLaunchctl::port_guard_calls` / `refuse_port`), `trait_method_missing` (`LaunchctlPort::port_guard`) from #6349, and `trait_method_added` (`ServiceEnv::evict_retired`) from #6290. |
| trusty-console | 0.7.0 | **0.8.0** | BREAK. `inherent_method_missing` for `ReviewConnector::with_socket`, removed by #6290. |

For a `0.y.z` crate the breaking bump is the MINOR position, so 0.12.1 and 0.7.1 were never legal positions for that work. Both root workspace requirements move with them (`0.12` → `0.13`, `0.7.0` → `0.8.0`). No exclusions rows, no `PREFLIGHT_SEMVER_UNVERIFIED`.

**Test ladder: rung 5** (cross-crate contract + process lifecycle). All counts read from the run output after the final change; every `cargo test` used `--no-fail-fast`.

```
cargo fmt --check                                            EXIT=0
cargo check --workspace --all-targets                        EXIT=0
cargo clippy -p trusty-analyze -p trusty-common \
  -p trusty-installer -p trusty-console -p trusty-review \
  --all-targets -- -D warnings                               EXIT=0

cargo test -p trusty-common --features uds,uds-supervisor --no-fail-fast
  test result: ok. 532 passed; 0 failed; 6 ignored
cargo test -p trusty-analyze --no-fail-fast
  test result: ok. 509 passed; 0 failed; 0 ignored   (lib)
  test result: ok. 24 passed;  0 failed; 0 ignored   (bin)
  test result: ok. 6 passed;   0 failed; 0 ignored   (tests/on_demand.rs)
  test result: ok. 5 passed;   0 failed; 0 ignored   (uds_consumer_contract)
cargo test -p trusty-review --no-fail-fast
  test result: ok. 2027 passed; 0 failed; 5 ignored
cargo test -p trusty-installer --no-fail-fast
  test result: ok. 686 passed; 0 failed; 4 ignored
cargo test -p trusty-console --no-fail-fast
  test result: ok. 258 passed; 0 failed; 4 ignored

bash scripts/check_line_cap.sh            0 violations — OK
bash scripts/check_changelog_fragment.sh  54 paths scanned, 5 crates recorded — OK
bash scripts/check_test_pointers.sh       27334 citations, 0 dangling — OK
bash scripts/check_sld.sh                 0 errors, 0 warnings — OK

bash scripts/check_semver.sh --crate trusty-analyze    EXIT=0  (196 pass)
bash scripts/check_semver.sh --crate trusty-common     EXIT=0  (196 pass)
bash scripts/check_semver.sh --crate trusty-review     EXIT=0  (inventoried)
bash scripts/check_semver.sh --crate trusty-installer  EXIT=0  (inventoried @ 0.13.0)
bash scripts/check_semver.sh --crate trusty-console    EXIT=0  (inventoried @ 0.8.0)
```

New coverage, by claim:

| Claim | Test |
|---|---|
| Server exits on its own, socket unlinked | `tests/on_demand.rs::serve_exits_on_its_own_idle_window` (real binary, clean exit status, socket gone) |
| A request resets the window | `serve_until_idle_is_reset_by_an_answered_request` |
| A probe does not | `serve_until_idle_ignores_liveness_probes` |
| Two concurrent callers, one server | `tests/on_demand.rs::two_concurrent_callers_share_one_server` |
| A failed start is an error, not a success | `ensure_running_reports_a_missing_binary_rather_than_failing_open`, `a_failed_start_is_reported_rather_than_swallowed` |
| A detached child is not the supervisor's to reap | `detached_children_are_not_retained_in_the_population`, `a_detached_caller_adopts_a_socket_that_is_already_serving` |
| Both retirements coexist in one registry | `retired_services_are_not_installed` (pin now `["trusty-review", "trusty-analyze"]`), `retired_analyze_carries_both_its_labels` |
| `tctl install` evicts analyze's unit | `retired_analyze_has_no_service_install` (drives `bootstrap_one`), `plans_service_bootstrap_visits_a_retired_member` |
| `tctl upgrade` evicts analyze's unit | `upgrade_evicts_the_retired_analyze_unit` (drives `restart_plan`, both platforms) |
| A refused eviction fails the install | `a_retired_analyze_unit_that_will_not_go_down_fails_the_install` |
| Analyze never reaches `launchd_control` | `a_retired_member_never_reaches_launchd_control`, `daemons_use_launchd` |
| `service uninstall` is fail-closed | `render_fails_closed_on_a_unit_that_would_not_go`, `render_fails_even_when_another_label_was_cleared` |
| Console detect observes, never starts | `detect_never_starts_a_server` |

Three things a reviewer should look at:

- **`tests/on_demand.rs` needs an axum dev-dependency.** `TrustySearchClient` builds its reqwest client with `http2_prior_knowledge()`, so a hand-written HTTP/1.1 `/health` stub is never read and the child exits with "trusty-search is not reachable". `axum::serve` runs hyper's auto builder, which answers the h2c preface.
- **The console connector deliberately does not call `ensure_running`,** unlike every other client. It is a detector on a poll loop: starting the service there would keep it resident for as long as a dashboard tab was open, and would report `Running` about a process it had just created. The issue's own closure text asks for presence, not a live dial.
- **Two version bumps are inherited debt, not this PR's work.** trusty-installer 0.13.0 and trusty-console 0.8.0 exist because #6349 and #6290 shipped public-API breaks into patch positions. Their gates are red at the current numbers regardless of this branch; bumping is the fix the semver gate asks for, and an exclusions row would not be.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
