### PR TITLE
fix(website): format claude-mpm-migration page so Prettier + ESLint is green on main

### DIFF
--- a/website/src/routes/claude-mpm-migration/+page.svelte
+++ b/website/src/routes/claude-mpm-migration/+page.svelte
@@ -266,8 +266,8 @@ tm --version</pre>
 							<td><code class="whitespace-nowrap">127.0.0.1:7880</code></td>
 							<td class="text-foundry-secondary"
 								>Registered projects, the session roster, and the relayed hook feed. A separate
-								supervisor process watches sessions and publishes its fleet snapshot to a file
-								the daemon reads.</td
+								supervisor process watches sessions and publishes its fleet snapshot to a file the
+								daemon reads.</td
 							>
 						</tr>
 						<tr>


### PR DESCRIPTION
## Summary

`Prettier + ESLint` (website-tests.yml) is red on main as of run [33181583635](https://github.com/bobmatnyc/trusty-tools/actions/runs/33181583635/job/98883838954) (commit 627968f50, PR #6357), reporting `[warn] src/routes/claude-mpm-migration/+page.svelte` / `Code style issues found in the above file. Run Prettier with --write to fix.` ESLint itself has no findings on that file — this is a pure Prettier formatting gap.

Fixed by running `pnpm exec prettier --write` on that one file (touches only a paragraph's line-wrap inside a `<td>`, no other files changed, no config changed).

## Test plan

From inside `website/`, Node 22 / pnpm 9.15.9 (matches the workflow's pin):

- Before: `pnpm exec prettier --check .` → exit 1, `[warn] src/routes/claude-mpm-migration/+page.svelte`
- After: `pnpm run lint` (`prettier --check . && eslint .`) → exit 0, "All matched files use Prettier code style!"
- `pnpm run test` → `Test Files 14 passed (14)`, `Tests 268 passed (268)`

- [x] `pnpm run lint` passes
- [x] `pnpm run test` passes
- [x] Only the one target file changed; no config changes

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools