### PR TITLE
fix: repair pre-publish gate — intra-doc links, contracts drift, common 0.45.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6519,7 +6519,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11425,7 +11425,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-common"
-version = "0.45.4"
+version = "0.45.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -35,7 +35,7 @@ name = "trusty-common"
 # (`ConsolidationProvider`, `resolve_consolidation_provider`, three consts) or a
 # default VALUE change on an existing field; no public item was removed or had
 # its type changed, so nothing here breaks a consumer at compile time.
-version = "0.45.4"
+version = "0.45.5"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/trusty-common/changelog.d/6290-retired-services-doc-link.md
+++ b/crates/trusty-common/changelog.d/6290-retired-services-doc-link.md
@@ -1,0 +1,8 @@
+Documentation
+
+- `launchd_labels`'s module header links `RETIRED_SERVICES` again. The header is
+  merged with the `///` doc on `pub mod launchd_labels;` in `lib.rs`, so rustdoc
+  resolves it in the crate root, where a bare `RETIRED_SERVICES` does not exist —
+  the link rendered as dead literal text and denied the crate's `cargo doc` build.
+  It now has the same `crate::`-rooted reference definition `SERVICES` and
+  `canonical_label` were given in #5753.

--- a/crates/trusty-common/src/launchd_labels.rs
+++ b/crates/trusty-common/src/launchd_labels.rs
@@ -66,6 +66,7 @@
 //!
 //! [`canonical_label`]: crate::launchd_labels::canonical_label
 //! [`SERVICES`]: crate::launchd_labels::SERVICES
+//! [`RETIRED_SERVICES`]: crate::launchd_labels::RETIRED_SERVICES
 
 /// Reverse-DNS domain prefix shared by every trusty-* LaunchAgent.
 ///

--- a/crates/trusty-mpm/changelog.d/6288-rpc-doc-links.md
+++ b/crates/trusty-mpm/changelog.d/6288-rpc-doc-links.md
@@ -1,0 +1,11 @@
+Documentation
+
+- The `daemon::rpc` module headers link their own items again. Each submodule
+  carries a `///` doc on its `pub mod` line, which merges with the module's `//!`
+  header and makes rustdoc resolve the whole doc in `daemon::rpc` — so `register`,
+  `METHODS`, `DaemonError` and every `super::` path written inside a header
+  rendered as dead literal text and denied `cargo doc`. Each header now ends with
+  `crate::`-rooted reference definitions. `api.rs`'s links to
+  `TmuxService::spawn_claude` and `PairingService::reset` are qualified the same
+  way; `daemon::socket`'s private `build_router` is a code span, since docs.rs
+  cannot link a private item.

--- a/crates/trusty-mpm/src/daemon/api.rs
+++ b/crates/trusty-mpm/src/daemon/api.rs
@@ -591,7 +591,8 @@ pub struct RegisterSession {
 /// is created — that behaviour is unchanged so the existing CLI and hook
 /// auto-registration paths keep working).
 /// What: builds the `Session` record and registers it in state. When `workdir`
-/// is present, additionally creates the tmux session via [`TmuxService::spawn_claude`]
+/// is present, additionally creates the tmux session via
+/// [`TmuxService::spawn_claude`](crate::daemon::services::TmuxService::spawn_claude)
 /// and starts `claude` in it; failures map to HTTP 422 (`claude` missing or
 /// tmux missing) or 500 (tmux command failed). On success the new session
 /// appears immediately in `GET /sessions`.
@@ -1467,7 +1468,9 @@ pub async fn pair_status(
 ///
 /// Why: an operator unpairing the bot must drop the binding both in memory and
 /// on disk so a daemon restart does not restore it from `pairing.json`.
-/// What: delegates to [`PairingService::reset`] and returns `{ "reset": true }`.
+/// What: delegates to
+/// [`PairingService::reset`](crate::daemon::services::PairingService::reset) and
+/// returns `{ "reset": true }`.
 /// Test: `pair_reset_clears_pairing` in `api_tests.rs`.
 #[utoipa::path(
     post,

--- a/crates/trusty-mpm/src/daemon/rpc/core.rs
+++ b/crates/trusty-mpm/src/daemon/rpc/core.rs
@@ -67,6 +67,9 @@
 //!
 //! Test: `core_tests.rs` — `rpc_*` for the wire behaviour, `parity_*` for the
 //! HTTP-versus-socket comparison.
+//!
+//! [`register`]: crate::daemon::rpc::core::register
+//! [`super::core_ops`]: crate::daemon::rpc::core_ops
 
 use std::sync::Arc;
 

--- a/crates/trusty-mpm/src/daemon/rpc/core_ops.rs
+++ b/crates/trusty-mpm/src/daemon/rpc/core_ops.rs
@@ -29,6 +29,9 @@
 //! `parity_overseer_agrees_across_transports`,
 //! `parity_tmux_sessions_agrees_across_transports` — each drives one of these
 //! through BOTH transports and compares the answers.
+//!
+//! [`super::core`]: crate::daemon::rpc::core
+//! [`DaemonError`]: crate::daemon::error::DaemonError
 
 use std::sync::Arc;
 

--- a/crates/trusty-mpm/src/daemon/rpc/managed.rs
+++ b/crates/trusty-mpm/src/daemon/rpc/managed.rs
@@ -67,6 +67,10 @@
 //! cannot reach `connect(2)` in the first place.
 //!
 //! Test: `managed_tests.rs`.
+//!
+//! [`register`]: crate::daemon::rpc::managed::register
+//! [`outcome::status_to_rpc_code`]: crate::daemon::rpc::managed::outcome::status_to_rpc_code
+//! [`control::CallerTrust`]: crate::daemon::rpc::managed::control::CallerTrust
 
 pub mod control;
 pub mod outcome;

--- a/crates/trusty-mpm/src/daemon/rpc/registry.rs
+++ b/crates/trusty-mpm/src/daemon/rpc/registry.rs
@@ -86,6 +86,12 @@
 //!
 //! [`DaemonError`]: crate::daemon::error::DaemonError
 //! [`BusError`]: crate::daemon::bus::BusError
+//!
+//! [`register`]: crate::daemon::rpc::registry::register
+//! [`METHODS`]: crate::daemon::rpc::registry::METHODS
+//! [`projects`]: crate::daemon::rpc::registry::projects
+//! [`pairing`]: crate::daemon::rpc::registry::pairing
+//! [`manager`]: crate::daemon::rpc::registry::manager
 
 use std::sync::Arc;
 

--- a/crates/trusty-mpm/src/daemon/rpc/sessions_legacy.rs
+++ b/crates/trusty-mpm/src/daemon/rpc/sessions_legacy.rs
@@ -82,6 +82,9 @@
 //!
 //! Test: `sessions_legacy_tests.rs` — `rpc_*` for the wire behaviour, `parity_*`
 //! for the HTTP-versus-socket comparison.
+//!
+//! [`register`]: crate::daemon::rpc::sessions_legacy::register
+//! [`super::sessions_legacy_ops`]: crate::daemon::rpc::sessions_legacy_ops
 
 use std::sync::Arc;
 

--- a/crates/trusty-mpm/src/daemon/rpc/sessions_legacy_ops.rs
+++ b/crates/trusty-mpm/src/daemon/rpc/sessions_legacy_ops.rs
@@ -40,6 +40,13 @@
 //! rest of the `parity_*` set in `sessions_legacy_tests.rs`, which drives every
 //! body here through BOTH transports and compares the answers and the state
 //! each left behind.
+//!
+//! [`super::sessions_legacy`]: crate::daemon::rpc::sessions_legacy
+//! [`super::core_ops`]: crate::daemon::rpc::core_ops
+//! [`DaemonError`]: crate::daemon::error::DaemonError
+//! [`remove_session`]: crate::daemon::rpc::sessions_legacy_ops::remove_session
+//! [`pause_session`]: crate::daemon::rpc::sessions_legacy_ops::pause_session
+//! [`send_command`]: crate::daemon::rpc::sessions_legacy_ops::send_command
 
 use std::sync::Arc;
 

--- a/crates/trusty-mpm/src/daemon/socket.rs
+++ b/crates/trusty-mpm/src/daemon/socket.rs
@@ -8,7 +8,7 @@
 //!
 //! What: the socket path (derived, never published to a discovery file), the
 //! bind, and the serve loop. Which METHODS are served is `daemon::rpc`'s —
-//! [`build_router`] names one `register` call per family, and slice 2 mounted
+//! `build_router` names one `register` call per family, and slice 2 mounted
 //! the first twenty. A name no family claims still answers `method_not_found`.
 //!
 //! The trust boundary is the socket, not the payload: `bind_singleton_hardened`

--- a/crates/trusty-search/changelog.d/6285-rpc-doc-links.md
+++ b/crates/trusty-search/changelog.d/6285-rpc-doc-links.md
@@ -1,0 +1,9 @@
+Documentation
+
+- The `service::rpc` module headers link their own items again. `error` and
+  `reads` each carry a `///` doc on their `pub mod` line, which merges with the
+  module's `//!` header and makes rustdoc resolve the whole doc in
+  `service::rpc` — so `rpc_error_from_http`, `RpcError`, `CODE_UNAVAILABLE`,
+  `CODE_UNAVAILABLE_PERMANENT` and `register` rendered as dead literal text and
+  denied `cargo doc`. Each header now ends with fully-qualified reference
+  definitions.

--- a/crates/trusty-search/src/service/rpc/error.rs
+++ b/crates/trusty-search/src/service/rpc/error.rs
@@ -25,6 +25,11 @@
 //! index.
 //!
 //! Test: `error_tests.rs`.
+//!
+//! [`rpc_error_from_http`]: crate::service::rpc::error::rpc_error_from_http
+//! [`CODE_UNAVAILABLE`]: crate::service::rpc::error::CODE_UNAVAILABLE
+//! [`CODE_UNAVAILABLE_PERMANENT`]: crate::service::rpc::error::CODE_UNAVAILABLE_PERMANENT
+//! [`RpcError`]: trusty_common::uds::server::RpcError
 
 use trusty_common::uds::server::{RpcError, CODE_INTERNAL_ERROR, CODE_INVALID_PARAMS};
 

--- a/crates/trusty-search/src/service/rpc/reads.rs
+++ b/crates/trusty-search/src/service/rpc/reads.rs
@@ -47,6 +47,8 @@
 //! Test: `reads_tests.rs` — one `*_over_the_socket_matches_the_http_body` per
 //! family, driving the real axum router and the real socket router against one
 //! shared state.
+//!
+//! [`register`]: crate::service::rpc::reads::register
 
 use std::sync::Arc;
 


### PR DESCRIPTION
Run [33203602288](https://github.com/bobmatnyc/trusty-tools/actions/runs/33203602288) left `Pre-publish gate` red at main tip 5fefc31bc, blocking the 7-crate publish wave. This makes it green.

**Gate 1 — 24 broken intra-doc links.** A module whose `pub mod` declaration carries an outer `///` doc has that doc merged with the module's own `//!` header, and rustdoc then resolves the whole thing in the PARENT module. A bare `register` or a `super::core_ops` written inside a header therefore resolves against `daemon::rpc`, not against the module that wrote it. `launchd_labels` already carries the fix for this class from #5753 — `crate::`-rooted reference definitions at the end of the header — so every link here gets one and no prose changes. `daemon::socket`'s `build_router` is private, so it becomes a code span beside `bind_singleton_hardened` and `serve_until` rather than a link docs.rs cannot render.

Five more of the same appeared in `trusty-search`'s `service::rpc` from #6368, which merged after that run was measured; they are fixed here too, since main tip would otherwise still be red.

**Gates 5-6 — same root cause, not a second defect.** `check_contracts.sh` builds trusty-common's rustdoc JSON across 45 features; `#![deny(rustdoc::broken_intra_doc_links)]` in `lib.rs` failed that build on the one `RETIRED_SERVICES` link, so the checker reported `NO VERDICT: the rustdoc JSON build failed`. It passes once the link resolves. Gate 6 then reaches its recorded no-baseline skip.

**trusty-common 0.45.5.** `trusty-common-v0.45.4` names 5fefc31bc, which can never pass the gate, and tags here are immutable (#6178) — the number is spent. The workspace requirement is `version = "0.45"`, so nothing else needed editing.

Refs #6288, #6290, #6285.

Gates, all raw output in the review thread: `check_rustdoc_links.sh` (26 crates examined, 0 broken, baseline 0), `check_contracts.sh --crate trusty-common` (15 contracts, artifact matches source), Gate 6 no-baseline skip (exit 3, expected reason), `cargo fmt --check`, `cargo check --workspace`, `check_semver.sh --crate trusty-common` (196 checks, 196 pass, no semver update required), `check_changelog_fragment.sh`. No test run: the only trusty-common source change is a doc comment.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
