### PR TITLE
chore: refresh yanked chacha20/spin pins in Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1554,9 +1554,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -9315,9 +9315,9 @@ checksum = "e990cc6cb89a82d70fe722cd7811dbce48a72bbfaebd623e58f142b6db28428f"
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]


### PR DESCRIPTION
## Summary

- `chacha20 0.10.1` and `spin 0.9.8` are yanked on crates.io (sparse-index confirmed).
- Targeted `cargo update -p chacha20 -p spin` → `chacha20 0.10.2`, `spin 0.9.9`. No other packages moved.
- Neither is a direct dependency of any workspace crate — transitive only, so rung 2, no test run owed.

## Test plan

- [x] `cargo check --workspace` — clean
- [x] `cargo build` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo audit` — no new vulnerabilities/errors from this change
- [x] `bash scripts/check_changelog_fragment.sh` — OK, lock-only, no fragment owed

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools