### PR TITLE
refactor(trusty-search): complete the UDS RPC surface — gap methods, frame cap, stream fixes (Refs #6285)

### DIFF
--- a/crates/trusty-search/changelog.d/6285-uds-frame-budget.md
+++ b/crates/trusty-search/changelog.d/6285-uds-frame-budget.md
@@ -1,0 +1,7 @@
+Changed
+- The Unix socket accepts frames up to 64 MiB instead of the shared 8 MiB
+  control-plane default, matching the `DefaultBodyLimit` that
+  `POST /indexes/{id}/graph` already carried — which now names that constant
+  rather than restating the literal. A client reads its own responses under its
+  own budget, so a consumer dialling these names must use
+  `trusty_common::uds::send_framed_request_capped` with the same figure (#6285).

--- a/crates/trusty-search/changelog.d/6285-uds-surface-completion.md
+++ b/crates/trusty-search/changelog.d/6285-uds-surface-completion.md
@@ -1,0 +1,13 @@
+Added
+- The Unix-socket RPC surface serves the last four routes with a named consumer:
+  `search.index.config.set`, `search.config.set`, `search.logs.tail` and
+  `search.registry.orphans`. Each runs the same core its HTTP route runs, so a
+  caller moving onto the socket gets the same body and the same refusals (#6285).
+
+Changed
+- The socket accepts frames up to 64 MiB instead of the shared 8 MiB
+  control-plane default, matching the `DefaultBodyLimit` that
+  `POST /indexes/{id}/graph` already carried. `POST /indexes/{id}/graph` now
+  names that constant rather than restating the literal. A client reads its own
+  responses under its own budget, so a consumer dialling these names must use
+  `trusty_common::uds::send_framed_request_capped` with the same figure (#6285).

--- a/crates/trusty-search/changelog.d/6285-uds-surface-completion.md
+++ b/crates/trusty-search/changelog.d/6285-uds-surface-completion.md
@@ -3,11 +3,3 @@ Added
   `search.index.config.set`, `search.config.set`, `search.logs.tail` and
   `search.registry.orphans`. Each runs the same core its HTTP route runs, so a
   caller moving onto the socket gets the same body and the same refusals (#6285).
-
-Changed
-- The socket accepts frames up to 64 MiB instead of the shared 8 MiB
-  control-plane default, matching the `DefaultBodyLimit` that
-  `POST /indexes/{id}/graph` already carried. `POST /indexes/{id}/graph` now
-  names that constant rather than restating the literal. A client reads its own
-  responses under its own budget, so a consumer dialling these names must use
-  `trusty_common::uds::send_framed_request_capped` with the same figure (#6285).

--- a/crates/trusty-search/src/service/orphan_report.rs
+++ b/crates/trusty-search/src/service/orphan_report.rs
@@ -187,6 +187,34 @@ pub fn build_census(entries: &[PersistedIndex]) -> OrphanCensus {
 pub async fn registry_orphans_handler() -> axum::response::Response {
     use axum::response::IntoResponse as _;
 
+    match registry_orphans_report().await {
+        Ok(census) => axum::Json(census).into_response(),
+        Err((status, body)) => (status, axum::Json(body)).into_response(),
+    }
+}
+
+/// The census `GET /registry/orphans` serves, without the transport
+/// (#6285 slice 5.5).
+///
+/// Why: `search.registry.orphans` is what `trusty-console`'s cleanup tab dials
+/// once the retire slice moves it off HTTP, and it is the ONE method on this
+/// surface that reads the registry FILE rather than `SearchAppState` — which is
+/// why it takes no state. A second reader over the socket would be a second
+/// place deciding what `exists()` returning `false` means, and the whole point
+/// of #6371's three-valued classification is that the decision has one home.
+/// What: the blocking file read and the census, both off the runtime thread —
+/// a root on a network mount can make a `stat` slow enough to stall the reactor.
+///
+/// # Errors
+///
+/// `500` when the registry cannot be read, or when the blocking task itself
+/// failed. Never an empty census for either: "nothing to clean up" and "I could
+/// not look" are the two answers this route exists to keep apart.
+///
+/// Test: `registry_orphans_over_the_socket_matches_the_http_body`,
+/// `an_unreadable_registry_is_refused_on_either_transport`.
+pub async fn registry_orphans_report(
+) -> Result<OrphanCensus, (axum::http::StatusCode, serde_json::Value)> {
     let built = tokio::task::spawn_blocking(|| -> anyhow::Result<OrphanCensus> {
         let path = crate::service::persistence::indexes_toml_path()?;
         let entries = crate::service::persistence::load_index_registry_at(&path)?;
@@ -195,21 +223,19 @@ pub async fn registry_orphans_handler() -> axum::response::Response {
     .await;
 
     match built {
-        Ok(Ok(census)) => axum::Json(census).into_response(),
-        Ok(Err(e)) => (
+        Ok(Ok(census)) => Ok(census),
+        Ok(Err(e)) => Err((
             axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            axum::Json(serde_json::json!({
+            serde_json::json!({
                 "error": format!("could not read the index registry: {e:#}")
-            })),
-        )
-            .into_response(),
-        Err(e) => (
+            }),
+        )),
+        Err(e) => Err((
             axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            axum::Json(serde_json::json!({
+            serde_json::json!({
                 "error": format!("the registry census task failed: {e}")
-            })),
-        )
-            .into_response(),
+            }),
+        )),
     }
 }
 

--- a/crates/trusty-search/src/service/rpc/admin.rs
+++ b/crates/trusty-search/src/service/rpc/admin.rs
@@ -129,7 +129,8 @@ pub struct IndexConfigSet {
 /// `Option<LogsTail>` and reads `None` as the default — an absent `params` and an
 /// explicit `null` arrive here as the same `Value::Null` (#6285).
 /// Test: `logs_tail_over_the_socket_matches_the_http_body`,
-/// `logs_tail_clamps_n_on_the_socket_too`.
+/// `logs_tail_clamps_n_on_the_socket_too`,
+/// `a_malformed_n_is_refused_before_the_log_ring_is_read`.
 ///
 /// [`DEFAULT_LOGS_TAIL_N`]: crate::service::server::LogsTailParams
 #[derive(Debug, Default, Deserialize)]

--- a/crates/trusty-search/src/service/rpc/admin.rs
+++ b/crates/trusty-search/src/service/rpc/admin.rs
@@ -1,0 +1,196 @@
+//! The operational remainder, served as JSON-RPC methods (#6285 slice 5.5).
+//!
+//! Why: slices 1–5 moved health, the reads, the queries, the writes and the two
+//! streams. Four routes with a named consumer were still HTTP-only, and the
+//! retire slice cannot move that consumer onto a method the socket does not
+//! serve. This slice closes the gap the #6285 consumer map recorded: the two
+//! config WRITES the dashboard and `trusty-search config set` drive,
+//! `GET /logs/tail` (which `trusty-common`'s monitor dials), and
+//! `GET /registry/orphans` (which `trusty-console`'s cleanup tab dials, #6371).
+//!
+//! What: the method-to-route table below, the params each method decodes, and
+//! [`register`]. Every handler is a thin adapter over a `*_report` core in
+//! `service::server` or `service::orphan_report` — this file decides WHICH
+//! method exists and what it decodes, never what it does.
+//!
+//! ## Method → route
+//!
+//! | Method | HTTP route | Lane |
+//! |---|---|---|
+//! | `search.index.config.set` | `PATCH /indexes/{id}/config` | free |
+//! | `search.config.set` | `PATCH /config` | free |
+//! | `search.logs.tail` | `GET /logs/tail` | free |
+//! | `search.registry.orphans` | `GET /registry/orphans` | free |
+//!
+//! All four HTTP routes sit in `service::server::build_router_on`'s `free`
+//! group — no admission limiter, no query deadline — and all four methods copy
+//! that. The two writes are `free` on HTTP for the same reason
+//! `DELETE /indexes/{id}` is (slice 4's lane table): they are registry-level,
+//! and putting them behind the limiter here would make a config edit queue
+//! behind a running reindex that the HTTP route sails past.
+//!
+//! ## Two of these are WRITES, so each carries a failure arm that checks state
+//!
+//! `search.index.config.set` re-registers a handle, rewrites an `indexes.toml`
+//! row and can start a background catch-up; `search.config.set` moves two
+//! process-global memory limits. The slice-4 bar applies to both: every refusal
+//! case asserts the refusal AND re-reads the thing that must not have moved —
+//! the handle's config view, the persisted row, the resolved limits.
+//!
+//! ## What guards these methods
+//!
+//! Everything slice 2's `reads` module documents — the peer-uid check over a
+//! `0600` socket in a `0700` directory. `with_guarded_middleware`, the #3304
+//! same-origin write guard the axum router wraps the two PATCH routes in, does
+//! not carry over and does not need to: it is browser-CSRF defence for a
+//! listener a page can reach, and a Unix socket has no origin and no browser
+//! (#6277 design review, the same conclusion slices 1 and 4 recorded).
+//!
+//! Test: `admin_tests.rs` — one `*_over_the_socket_matches_the_http_body` per
+//! method plus, for each of the two writes, a failure arm proving the refusal is
+//! identical AND that neither in-memory nor on-disk state advanced behind it.
+//!
+//! [`register`]: crate::service::rpc::admin::register
+
+use std::sync::Arc;
+
+use serde::Deserialize;
+use trusty_common::uds::server::RpcRouter;
+
+use crate::service::orphan_report::OrphanCensus;
+use crate::service::server::{
+    ConfigResponse, LogsTailParams, PatchConfigRequest, PatchIndexConfigRequest, SearchAppState,
+};
+
+use super::as_http_body;
+use super::error::rpc_error_from_http;
+
+#[cfg(test)]
+#[path = "admin_tests.rs"]
+mod tests;
+
+/// `PATCH /indexes/{id}/config` — update one index's hygiene and component config.
+pub const METHOD_INDEX_CONFIG_SET: &str = "search.index.config.set";
+/// `PATCH /config` — retune the daemon's two memory limits without a restart.
+pub const METHOD_CONFIG_SET: &str = "search.config.set";
+/// `GET /logs/tail` — the most recent N lines from the in-memory log ring.
+pub const METHOD_LOGS_TAIL: &str = "search.logs.tail";
+/// `GET /registry/orphans` — the `indexes.toml` census of dead roots (#6371).
+pub const METHOD_REGISTRY_ORPHANS: &str = "search.registry.orphans";
+
+/// Every method this slice registers, in registration order.
+///
+/// Why: the same contract `reads::METHODS`, `queries::METHODS`,
+/// `writes::METHODS` and `streams::METHODS` carry — `service::socket::METHODS`
+/// splices these in by reference rather than restating the literals, so a rename
+/// is a compile error there rather than a drift only a running consumer would
+/// find.
+/// Test: `rpc_router_registers_every_documented_method` and
+/// `every_family_method_is_spliced_into_the_socket_method_list` in
+/// `socket_tests.rs`.
+pub const METHODS: &[&str] = &[
+    METHOD_INDEX_CONFIG_SET,
+    METHOD_CONFIG_SET,
+    METHOD_LOGS_TAIL,
+    METHOD_REGISTRY_ORPHANS,
+];
+
+/// The params of [`METHOD_INDEX_CONFIG_SET`].
+///
+/// Why nested rather than flattened: the same reason `writes::IndexBody` is —
+/// the body is one JSON document on HTTP and stays one here, so
+/// [`PatchIndexConfigRequest`]'s own `Deserialize` runs unmodified and cannot
+/// decode differently because a field now shares a namespace with `index_id`.
+/// That matters more here than anywhere else on the surface: every field of that
+/// body is `Option`, so a field silently shadowed by the wrapper would read as
+/// "leave it alone" rather than as an error.
+/// What: `{"index_id": "x", "body": { … }}`, where `body` is byte-for-byte the
+/// JSON a caller would PATCH.
+/// Test: `index_config_set_over_the_socket_matches_the_http_body`.
+#[derive(Debug, Deserialize)]
+pub struct IndexConfigSet {
+    /// The index the call is about — the `{id}` path segment on HTTP.
+    pub index_id: String,
+    /// The request body, exactly as the HTTP route's JSON extractor takes it.
+    pub body: PatchIndexConfigRequest,
+}
+
+/// The params of [`METHOD_LOGS_TAIL`].
+///
+/// Why its own type rather than decoding [`LogsTailParams`] directly: `n` is a
+/// query parameter with a serde default on HTTP, and a JSON-RPC call to a method
+/// with no arguments carries `params: null` — which `LogsTailParams` refuses
+/// outright, so every default-shaped tail would answer `invalid_params`. This
+/// wrapper carries the same default and accepts an absent `params`.
+/// What: `{}` or an absent `params` means [`DEFAULT_LOGS_TAIL_N`] lines;
+/// `{"n": 500}` is the same request `?n=500` makes. The clamp lives in the core,
+/// not here, so both transports refuse an over-large `n` identically.
+/// Test: `logs_tail_over_the_socket_matches_the_http_body`,
+/// `logs_tail_clamps_n_on_the_socket_too`.
+///
+/// [`DEFAULT_LOGS_TAIL_N`]: crate::service::server::LogsTailParams
+#[derive(Debug, Default, Deserialize)]
+pub struct LogsTail {
+    /// How many lines to return. Absent means the route's own default.
+    #[serde(default)]
+    pub n: Option<usize>,
+}
+
+/// Mount every method in [`METHODS`] onto `router`.
+///
+/// Why: the route-specific half of the last four routes with a named consumer,
+/// kept beside `reads`, `queries`, `writes` and `streams` so each slice adds one
+/// file rather than editing one.
+/// What: one `typed` registration per method, each cloning the `Arc` handle to
+/// the shared [`SearchAppState`] and running the SAME `*_report` core its axum
+/// handler wraps. [`METHOD_REGISTRY_ORPHANS`] takes no state at all — it reads
+/// the registry file, which is the entire reason #6371 added the route.
+/// Test: `rpc_router_registers_every_documented_method` in `socket_tests.rs`;
+/// the `*_over_the_socket_matches_the_http_body` cases and their failure-arm
+/// siblings drive each registration against its HTTP twin.
+pub fn register(router: RpcRouter, state: &Arc<SearchAppState>) -> RpcRouter {
+    use crate::service::orphan_report::registry_orphans_report;
+    use crate::service::server::{logs_tail_report, patch_config_report, patch_index_config_report};
+
+    // ---- the two config writes (axum's `free` group) ------------------------
+    let held = Arc::clone(state);
+    let router = router.typed::<IndexConfigSet, serde_json::Value, _, _>(
+        METHOD_INDEX_CONFIG_SET,
+        move |p| {
+            let state = Arc::clone(&held);
+            async move {
+                patch_index_config_report(&state, &p.index_id, p.body)
+                    .await
+                    .map_err(|(status, body)| rpc_error_from_http(status, &body))
+            }
+        },
+    );
+
+    let router = router.typed::<PatchConfigRequest, ConfigResponse, _, _>(
+        METHOD_CONFIG_SET,
+        move |req| async move { Ok(patch_config_report(req)) },
+    );
+
+    // ---- the two operational reads ------------------------------------------
+    let held = Arc::clone(state);
+    let router = router.typed::<LogsTail, serde_json::Value, _, _>(METHOD_LOGS_TAIL, move |p| {
+        let state = Arc::clone(&held);
+        async move {
+            let params = match p.n {
+                Some(n) => LogsTailParams { n },
+                None => LogsTailParams::default(),
+            };
+            Ok(logs_tail_report(&state, &params))
+        }
+    });
+
+    router.typed::<super::super::socket::NoParams, serde_json::Value, _, _>(
+        METHOD_REGISTRY_ORPHANS,
+        move |_params| async move {
+            let census: OrphanCensus = registry_orphans_report()
+                .await
+                .map_err(|(status, body)| rpc_error_from_http(status, &body))?;
+            as_http_body(census)
+        },
+    )
+}

--- a/crates/trusty-search/src/service/rpc/admin.rs
+++ b/crates/trusty-search/src/service/rpc/admin.rs
@@ -120,11 +120,14 @@ pub struct IndexConfigSet {
 /// Why its own type rather than decoding [`LogsTailParams`] directly: `n` is a
 /// query parameter with a serde default on HTTP, and a JSON-RPC call to a method
 /// with no arguments carries `params: null` — which `LogsTailParams` refuses
-/// outright, so every default-shaped tail would answer `invalid_params`. This
-/// wrapper carries the same default and accepts an absent `params`.
-/// What: `{}` or an absent `params` means [`DEFAULT_LOGS_TAIL_N`] lines;
-/// `{"n": 500}` is the same request `?n=500` makes. The clamp lives in the core,
-/// not here, so both transports refuse an over-large `n` identically.
+/// outright, so every default-shaped tail would answer `invalid_params`.
+/// What: `{}` means [`DEFAULT_LOGS_TAIL_N`] lines; `{"n": 500}` is the same
+/// request `?n=500` makes. The clamp lives in the core, not here, so both
+/// transports refuse an over-large `n` identically.
+///
+/// A derived `Deserialize` still refuses `null`, so [`register`] decodes this as
+/// `Option<LogsTail>` and reads `None` as the default — an absent `params` and an
+/// explicit `null` arrive here as the same `Value::Null` (#6285).
 /// Test: `logs_tail_over_the_socket_matches_the_http_body`,
 /// `logs_tail_clamps_n_on_the_socket_too`.
 ///
@@ -150,7 +153,9 @@ pub struct LogsTail {
 /// siblings drive each registration against its HTTP twin.
 pub fn register(router: RpcRouter, state: &Arc<SearchAppState>) -> RpcRouter {
     use crate::service::orphan_report::registry_orphans_report;
-    use crate::service::server::{logs_tail_report, patch_config_report, patch_index_config_report};
+    use crate::service::server::{
+        logs_tail_report, patch_config_report, patch_index_config_report,
+    };
 
     // ---- the two config writes (axum's `free` group) ------------------------
     let held = Arc::clone(state);
@@ -173,16 +178,19 @@ pub fn register(router: RpcRouter, state: &Arc<SearchAppState>) -> RpcRouter {
 
     // ---- the two operational reads ------------------------------------------
     let held = Arc::clone(state);
-    let router = router.typed::<LogsTail, serde_json::Value, _, _>(METHOD_LOGS_TAIL, move |p| {
-        let state = Arc::clone(&held);
-        async move {
-            let params = match p.n {
-                Some(n) => LogsTailParams { n },
-                None => LogsTailParams::default(),
-            };
-            Ok(logs_tail_report(&state, &params))
-        }
-    });
+    // #6285: `Option<LogsTail>` so a call with no arguments decodes — the router
+    // hands a handler `Value::Null` for both an absent and an explicit `params`.
+    let router =
+        router.typed::<Option<LogsTail>, serde_json::Value, _, _>(METHOD_LOGS_TAIL, move |p| {
+            let state = Arc::clone(&held);
+            async move {
+                let params = match p.and_then(|p| p.n) {
+                    Some(n) => LogsTailParams { n },
+                    None => LogsTailParams::default(),
+                };
+                Ok(logs_tail_report(&state, &params))
+            }
+        });
 
     router.typed::<super::super::socket::NoParams, serde_json::Value, _, _>(
         METHOD_REGISTRY_ORPHANS,

--- a/crates/trusty-search/src/service/rpc/admin_tests.rs
+++ b/crates/trusty-search/src/service/rpc/admin_tests.rs
@@ -526,6 +526,60 @@ async fn logs_tail_clamps_n_on_the_socket_too() {
     );
 }
 
+/// Why: `n` is the one field this method decodes, and the clamp only runs once a
+/// NUMBER has been parsed — a caller who sends a string or an object reaches no
+/// clamp and no route, so the refusal has to come from the decoder. The sibling
+/// `a_malformed_config_set_applies_neither_field_on_either_transport` pins that
+/// for the write; this pins it for the read, where the analogue of "no field
+/// moved" is that the ring still serves its page afterwards rather than being
+/// consumed or disturbed by the refusal (#6285).
+/// Test: this function IS the test.
+#[tokio::test(flavor = "multi_thread")]
+#[serial_test::serial]
+async fn a_malformed_n_is_refused_before_the_log_ring_is_read() {
+    let (state, http, rpc) = routers(&[]);
+    for i in 0..3 {
+        state.log_buffer.push(format!("line {i}"));
+    }
+
+    // Both transports refuse a non-numeric `n` — axum's `Query` extractor on one
+    // side, the router's decoder on the other. The two STATUSES are deliberately
+    // not compared: each is its own transport's layer answering, not a decision
+    // either core made. Same reasoning as the config.set sibling.
+    let (status, body) = http_raw(
+        &http,
+        Request::builder()
+            .method("GET")
+            .uri("/logs/tail?n=lots")
+            .body(Body::empty())
+            .expect("build the request"),
+    )
+    .await;
+    assert!(
+        status.is_client_error(),
+        "HTTP must refuse a non-numeric n, got {status}: {body}"
+    );
+
+    for malformed in [
+        serde_json::json!({ "n": "lots" }),
+        serde_json::json!({ "n": { "count": 5 } }),
+        serde_json::json!({ "n": -1 }),
+    ] {
+        let refused = rpc_err(&rpc, admin::METHOD_LOGS_TAIL, malformed.clone()).await;
+        assert_eq!(
+            refused.code, CODE_INVALID_PARAMS,
+            "{malformed} carries no decodable n, so it is the caller's fault: {refused:?}"
+        );
+    }
+
+    // The refusals stopped at the decoder: a well-formed call still serves the
+    // same page the HTTP route serves for the same request.
+    assert_eq!(
+        rpc_ok(&rpc, admin::METHOD_LOGS_TAIL, serde_json::json!({ "n": 3 })).await,
+        http_get(&http, "/logs/tail?n=3").await,
+    );
+}
+
 // ------------------------------------------------- search.registry.orphans ---
 
 /// Plant an `indexes.toml` row for `id` at `root` in the isolated data dir.

--- a/crates/trusty-search/src/service/rpc/admin_tests.rs
+++ b/crates/trusty-search/src/service/rpc/admin_tests.rs
@@ -140,7 +140,11 @@ async fn http_get(router: &Router, uri: &str) -> serde_json::Value {
         .body(Body::empty())
         .expect("build the request");
     let (status, body) = http_raw(router, request).await;
-    assert_eq!(status, StatusCode::OK, "GET {uri} answered {status}: {body}");
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "GET {uri} answered {status}: {body}"
+    );
     body
 }
 
@@ -400,15 +404,37 @@ async fn config_set_over_the_socket_matches_the_http_body() {
     assert_eq!(memory_limit_mb(), Some(2048));
     assert_eq!(index_memory_limit_mb(), Some(512));
 
-    // An explicit null disables, and must do so identically.
+    // An explicit null disables the per-index cap, and must do so identically on
+    // both transports. What comes BACK is the RESOLVED figure, not the raw cell:
+    // `core::memguard::index_memory_limit_mb` falls back to the global limit when
+    // the per-index one is disabled, so both bodies report the global 4096 rather
+    // than `null`. #6285: a socket that answered the raw cell would disagree with
+    // the route about the same request.
+    set_memory_limit_mb(Some(4096));
+    set_index_memory_limit_mb(Some(512));
+    let disabled_over_http = http_ok(
+        &http,
+        "PATCH",
+        "/config",
+        serde_json::json!({ "index_memory_limit_mb": null }),
+    )
+    .await;
+
+    set_memory_limit_mb(Some(4096));
+    set_index_memory_limit_mb(Some(512));
     let disabled = rpc_ok(
         &rpc,
         admin::METHOD_CONFIG_SET,
         serde_json::json!({ "index_memory_limit_mb": null }),
     )
     .await;
-    assert_eq!(disabled["index_memory_limit_mb"], serde_json::Value::Null);
-    assert_eq!(index_memory_limit_mb(), None);
+    assert_eq!(disabled, disabled_over_http);
+    assert_eq!(
+        disabled["index_memory_limit_mb"],
+        serde_json::json!(4096),
+        "a disabled per-index cap resolves to the global limit on both transports"
+    );
+    assert_eq!(index_memory_limit_mb(), Some(4096));
 }
 
 /// Why: this write's only refusal is a malformed field, and the failure that
@@ -463,12 +489,7 @@ async fn logs_tail_over_the_socket_matches_the_http_body() {
     }
 
     let over_http = http_get(&http, "/logs/tail?n=3").await;
-    let over_socket = rpc_ok(
-        &rpc,
-        admin::METHOD_LOGS_TAIL,
-        serde_json::json!({ "n": 3 }),
-    )
-    .await;
+    let over_socket = rpc_ok(&rpc, admin::METHOD_LOGS_TAIL, serde_json::json!({ "n": 3 })).await;
 
     assert_eq!(
         over_socket["lines"].as_array().map(Vec::len),
@@ -608,4 +629,3 @@ async fn an_unreadable_registry_is_refused_on_either_transport() {
         "unreadable registry",
     );
 }
-

--- a/crates/trusty-search/src/service/rpc/admin_tests.rs
+++ b/crates/trusty-search/src/service/rpc/admin_tests.rs
@@ -1,0 +1,611 @@
+//! Socket-versus-HTTP parity for the operational remainder (#6285 slice 5.5).
+//!
+//! Why: two of these four methods are WRITES, and the slice-4 bar applies to
+//! both — a refusal case asserts the refusal AND re-reads the thing that must
+//! not have moved. The other two are reads whose whole value is that they answer
+//! the same document HTTP answers: `search.logs.tail` replaces the monitor's
+//! `GET /logs/tail`, and `search.registry.orphans` replaces the console cleanup
+//! tab's `GET /registry/orphans`. A socket that answered either differently
+//! would be discovered in a consumer, after the retire slice deleted the route
+//! it could have been compared against.
+//!
+//! Every case drives the REAL axum router and the REAL RPC router over ONE
+//! shared state, so a `*_report` core that stopped being the body both
+//! transports serve fails here.
+//!
+//! **The two config writes touch process-global state, so every case is
+//! `#[serial]` and runs under an isolated `TRUSTY_DATA_DIR`.** The memory limits
+//! are `AtomicU64` cells shared by the whole test binary, and the config PATCH
+//! rewrites `indexes.toml`.
+//!
+//! Test: this file IS the test module for `super`.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use axum::Router;
+use tower::ServiceExt as _;
+use trusty_common::uds::server::{RpcError, RpcRouter, CODE_INVALID_PARAMS};
+
+use crate::core::indexer::CodeIndexer;
+use crate::core::memguard::{
+    index_memory_limit_mb, memory_limit_mb, set_index_memory_limit_mb, set_memory_limit_mb,
+};
+use crate::core::registry::{IndexHandle, IndexId, IndexRegistry};
+use crate::service::persistence::{self, PersistedIndex};
+use crate::service::rpc::admin;
+use crate::service::rpc::error::CODE_NOT_FOUND;
+use crate::service::server::tests_components::IsolatedDataDir;
+use crate::service::server::{build_router_on, SearchAppState};
+
+// ---------------------------------------------------------------- fixtures ---
+
+/// One state carrying `ids` as registered indexes, plus both routers on it.
+///
+/// Why both from the SAME `Arc`: the property under test one level down is that
+/// `build_router_on` and `admin::register` read ONE registry. Two `Arc::new`
+/// calls would make every comparison below a comparison of two daemons.
+fn routers(ids: &[&str]) -> (Arc<SearchAppState>, Router, RpcRouter) {
+    let registry = IndexRegistry::new();
+    for id in ids {
+        let root = format!("/nonexistent/admin-{id}");
+        registry.register(IndexHandle::bare(
+            IndexId::new((*id).to_string()),
+            Arc::new(tokio::sync::RwLock::new(CodeIndexer::new(*id, &root))),
+            root.into(),
+        ));
+    }
+    let state = Arc::new(SearchAppState::new(registry));
+    let http = build_router_on(
+        Arc::clone(&state),
+        trusty_common::server::SelfOrigins::default(),
+    );
+    let rpc = admin::register(RpcRouter::new(), &state);
+    (state, http, rpc)
+}
+
+/// Restore both memory limits when a config-write case ends.
+///
+/// Why a guard rather than a trailing statement: an assertion that fails leaves
+/// the process-global cells wherever the case put them, and the next test in the
+/// binary would read them as its baseline.
+struct RestoreLimits {
+    memory_limit_mb: Option<u64>,
+    index_memory_limit_mb: Option<u64>,
+}
+
+impl RestoreLimits {
+    fn capture() -> Self {
+        Self {
+            memory_limit_mb: memory_limit_mb(),
+            index_memory_limit_mb: index_memory_limit_mb(),
+        }
+    }
+}
+
+impl Drop for RestoreLimits {
+    fn drop(&mut self) {
+        set_memory_limit_mb(self.memory_limit_mb);
+        set_index_memory_limit_mb(self.index_memory_limit_mb);
+    }
+}
+
+// ------------------------------------------------------------- transports ---
+
+async fn http_raw(router: &Router, request: Request<Body>) -> (StatusCode, serde_json::Value) {
+    let response = router
+        .clone()
+        .oneshot(request)
+        .await
+        .expect("the router must answer");
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read the body");
+    let text = String::from_utf8_lossy(&bytes).into_owned();
+    let body = serde_json::from_str(&text).unwrap_or(serde_json::Value::String(text));
+    (status, body)
+}
+
+fn json_request(method: &str, uri: &str, body: serde_json::Value) -> Request<Body> {
+    Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&body).expect("encode")))
+        .expect("build the request")
+}
+
+async fn http_ok(
+    router: &Router,
+    method: &str,
+    uri: &str,
+    body: serde_json::Value,
+) -> serde_json::Value {
+    let (status, body) = http_raw(router, json_request(method, uri, body)).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "{method} {uri} answered {status}: {body}"
+    );
+    body
+}
+
+async fn http_get(router: &Router, uri: &str) -> serde_json::Value {
+    let request = Request::builder()
+        .method("GET")
+        .uri(uri)
+        .body(Body::empty())
+        .expect("build the request");
+    let (status, body) = http_raw(router, request).await;
+    assert_eq!(status, StatusCode::OK, "GET {uri} answered {status}: {body}");
+    body
+}
+
+async fn http_err(
+    router: &Router,
+    method: &str,
+    uri: &str,
+    body: serde_json::Value,
+) -> (StatusCode, serde_json::Value) {
+    let (status, body) = http_raw(router, json_request(method, uri, body)).await;
+    assert!(
+        status.is_client_error() || status.is_server_error(),
+        "{method} {uri} must be refused, got {status}: {body}"
+    );
+    (status, body)
+}
+
+async fn dispatch(
+    rpc: &RpcRouter,
+    method: &str,
+    params: serde_json::Value,
+) -> trusty_common::uds::server::RpcResponse {
+    let frame = serde_json::to_vec(&serde_json::json!({
+        "jsonrpc": "2.0", "id": 1, "method": method, "params": params,
+    }))
+    .expect("encode the frame");
+    rpc.dispatch(&frame).await
+}
+
+async fn rpc_ok(rpc: &RpcRouter, method: &str, params: serde_json::Value) -> serde_json::Value {
+    let response = dispatch(rpc, method, params).await;
+    assert!(
+        response.error.is_none(),
+        "{method} must answer a result: {:?}",
+        response.error
+    );
+    response.result.expect("a non-error frame carries a result")
+}
+
+async fn rpc_err(rpc: &RpcRouter, method: &str, params: serde_json::Value) -> RpcError {
+    let response = dispatch(rpc, method, params).await;
+    response
+        .error
+        .unwrap_or_else(|| panic!("{method} must be refused; got {:?}", response.result))
+}
+
+/// Assert the socket's error frame is the HTTP refusal, rendered.
+///
+/// Why not tautological: it re-derives the frame from the `(status, body)` pair
+/// the OTHER transport actually produced, so it passes only when both ran the
+/// same core and reached the same refusal. The expected code is asserted
+/// separately so a mis-classification is caught outright rather than agreed on
+/// by both sides. Same shape as `writes_tests::assert_same_refusal`.
+fn assert_same_refusal(
+    http: &(StatusCode, serde_json::Value),
+    over_socket: &RpcError,
+    expected_code: i64,
+    what: &str,
+) {
+    let (status, body) = http;
+    let rendered = crate::service::rpc::error::rpc_error_from_http(*status, body);
+    assert_eq!(
+        over_socket.code, expected_code,
+        "{what}: the socket must classify this refusal as {expected_code}, \
+         got {} (HTTP said {status}: {body})",
+        over_socket.code
+    );
+    assert_eq!(
+        rendered.code, expected_code,
+        "{what}: HTTP's {status} must project onto {expected_code}: {body}"
+    );
+    assert_eq!(
+        over_socket.message, rendered.message,
+        "{what}: the socket's message must be the HTTP body's own wording"
+    );
+}
+
+/// Overwrite the id-shaped fields, which name the SUBJECT rather than the answer.
+fn without_subject(mut body: serde_json::Value, fields: &[&str]) -> serde_json::Value {
+    if let Some(obj) = body.as_object_mut() {
+        for field in fields {
+            if obj.contains_key(*field) {
+                obj[*field] = serde_json::Value::String("<subject>".into());
+            }
+        }
+    }
+    body
+}
+
+/// The persisted hygiene row for `id`, or `None` when it has none.
+fn persisted_row(id: &str) -> Option<PersistedIndex> {
+    persistence::load_index_registry()
+        .expect("load registry")
+        .into_iter()
+        .find(|e| e.id == id)
+}
+
+/// The live config view for `id`, read through the GET core both transports use.
+fn live_config(state: &Arc<SearchAppState>, id: &str) -> serde_json::Value {
+    serde_json::to_value(
+        crate::service::server::index_config_report(state, id).expect("the index is registered"),
+    )
+    .expect("the view serialises")
+}
+
+// ------------------------------------------------- search.index.config.set ---
+
+/// Why: `PATCH /indexes/{id}/config` is the widest write on this surface — it
+/// re-registers the handle, rewrites the `indexes.toml` row, and can start a
+/// background component catch-up. A socket that reached those through a second
+/// implementation would bypass the zero-cap validation, the per-index
+/// mutual-exclusion permit (#2984 Phase 1) and the #3049 teardown guard at once.
+/// Test: this function IS the test.
+#[tokio::test(flavor = "multi_thread")]
+#[serial_test::serial]
+async fn index_config_set_over_the_socket_matches_the_http_body() {
+    let _isolated = IsolatedDataDir::new();
+    let (state, http, rpc) = routers(&["cfg-http", "cfg-socket"]);
+
+    let patch = serde_json::json!({ "include_docs": false, "extra_skip_dirs": ["vendor"] });
+    let over_http = http_ok(&http, "PATCH", "/indexes/cfg-http/config", patch.clone()).await;
+    let over_socket = rpc_ok(
+        &rpc,
+        admin::METHOD_INDEX_CONFIG_SET,
+        serde_json::json!({ "index_id": "cfg-socket", "body": patch }),
+    )
+    .await;
+
+    assert_eq!(over_socket["persisted"], serde_json::json!(true));
+    assert_eq!(over_socket["reindex_required"], serde_json::json!(true));
+    assert_eq!(
+        without_subject(over_socket, &["id"]),
+        without_subject(over_http, &["id"]),
+    );
+
+    // The edit is the point, not the body: both handles and both rows moved.
+    for id in ["cfg-http", "cfg-socket"] {
+        assert_eq!(
+            live_config(&state, id)["include_docs"],
+            serde_json::json!(false),
+            "{id}: the live handle must carry the edit"
+        );
+        let row = persisted_row(id).unwrap_or_else(|| panic!("{id} must have a persisted row"));
+        assert_eq!(
+            row.extra_skip_dirs,
+            vec!["vendor".to_string()],
+            "{id}: the edit must reach indexes.toml"
+        );
+    }
+}
+
+/// Why: `data_file_max_bytes: 0` would prune every data file, and the route
+/// rejects it BEFORE it touches the handle. A socket that validated after
+/// mutating — or not at all — would leave an index with a cap its HTTP twin
+/// refuses to set. Both transports are pointed at ONE subject, which a refusal
+/// permits, so this is a parity assertion rather than two separate checks.
+/// Test: this function IS the test.
+#[tokio::test(flavor = "multi_thread")]
+#[serial_test::serial]
+async fn a_zero_data_cap_is_refused_and_changes_no_config_on_either_transport() {
+    let _isolated = IsolatedDataDir::new();
+    let (state, http, rpc) = routers(&["cfg-zero"]);
+    let before = live_config(&state, "cfg-zero");
+
+    let patch = serde_json::json!({ "data_file_max_bytes": 0 });
+    let over_http = http_err(&http, "PATCH", "/indexes/cfg-zero/config", patch.clone()).await;
+    let over_socket = rpc_err(
+        &rpc,
+        admin::METHOD_INDEX_CONFIG_SET,
+        serde_json::json!({ "index_id": "cfg-zero", "body": patch }),
+    )
+    .await;
+
+    assert_eq!(over_http.0, StatusCode::BAD_REQUEST);
+    assert_same_refusal(&over_http, &over_socket, CODE_INVALID_PARAMS, "zero cap");
+    assert_eq!(
+        live_config(&state, "cfg-zero"),
+        before,
+        "a refused cap must leave the live config exactly where it was"
+    );
+    assert!(
+        persisted_row("cfg-zero").is_none(),
+        "a refused cap must not write a registry row"
+    );
+}
+
+/// Why: #4715 made an index-scoped 404 mean "no such index ANYWHERE". A config
+/// set against an unknown id must be that same refusal on both transports and
+/// must not seed a row — the persist path SEEDS a minimal entry when the
+/// registry has none, so a socket that reached it would register an index the
+/// HTTP route refuses to.
+/// Test: this function IS the test.
+#[tokio::test(flavor = "multi_thread")]
+#[serial_test::serial]
+async fn a_config_set_against_an_unknown_index_is_refused_and_registers_nothing() {
+    let _isolated = IsolatedDataDir::new();
+    let (_state, http, rpc) = routers(&[]);
+
+    let patch = serde_json::json!({ "include_docs": false });
+    let over_http = http_err(&http, "PATCH", "/indexes/cfg-ghost/config", patch.clone()).await;
+    let over_socket = rpc_err(
+        &rpc,
+        admin::METHOD_INDEX_CONFIG_SET,
+        serde_json::json!({ "index_id": "cfg-ghost", "body": patch }),
+    )
+    .await;
+
+    assert_eq!(over_http.0, StatusCode::NOT_FOUND);
+    assert_same_refusal(&over_http, &over_socket, CODE_NOT_FOUND, "unknown index");
+    assert!(
+        persisted_row("cfg-ghost").is_none(),
+        "a refused config set must not seed an indexes.toml row"
+    );
+}
+
+// ------------------------------------------------------- search.config.set ---
+
+/// Why: `PATCH /config` retunes two process-global memory limits without a
+/// restart, and its whole contract is the three-state field encoding — absent
+/// leaves the limit alone, a number sets it, an explicit `null` disables it. A
+/// socket that decoded `Option<u64>` instead of `Option<Option<u64>>` would
+/// collapse the first and third into one and silently disable a limit a caller
+/// meant to leave alone. This drives all three arms across both transports.
+/// Test: this function IS the test.
+#[tokio::test(flavor = "multi_thread")]
+#[serial_test::serial]
+async fn config_set_over_the_socket_matches_the_http_body() {
+    let _restore = RestoreLimits::capture();
+    let (_state, http, rpc) = routers(&[]);
+
+    set_memory_limit_mb(Some(4096));
+    set_index_memory_limit_mb(Some(512));
+    let over_http = http_ok(
+        &http,
+        "PATCH",
+        "/config",
+        serde_json::json!({ "memory_limit_mb": 2048 }),
+    )
+    .await;
+    assert_eq!(over_http["memory_limit_mb"], serde_json::json!(2048));
+    assert_eq!(
+        over_http["index_memory_limit_mb"],
+        serde_json::json!(512),
+        "an absent field must leave its limit alone"
+    );
+
+    // The same request, from the same starting point, over the socket.
+    set_memory_limit_mb(Some(4096));
+    set_index_memory_limit_mb(Some(512));
+    let over_socket = rpc_ok(
+        &rpc,
+        admin::METHOD_CONFIG_SET,
+        serde_json::json!({ "memory_limit_mb": 2048 }),
+    )
+    .await;
+    assert_eq!(over_socket, over_http);
+    assert_eq!(memory_limit_mb(), Some(2048));
+    assert_eq!(index_memory_limit_mb(), Some(512));
+
+    // An explicit null disables, and must do so identically.
+    let disabled = rpc_ok(
+        &rpc,
+        admin::METHOD_CONFIG_SET,
+        serde_json::json!({ "index_memory_limit_mb": null }),
+    )
+    .await;
+    assert_eq!(disabled["index_memory_limit_mb"], serde_json::Value::Null);
+    assert_eq!(index_memory_limit_mb(), None);
+}
+
+/// Why: this write's only refusal is a malformed field, and the failure that
+/// matters is a partial apply — a body whose second field is unparseable must
+/// not leave the first one applied. The decoder runs before the core on both
+/// transports, so neither limit may move. The two REFUSALS are deliberately not
+/// compared frame-for-frame: axum reports a JSON decode failure as `422` and the
+/// router reports it as `invalid_params`, which is the transport's own layer
+/// answering rather than a decision either core made.
+/// Test: this function IS the test.
+#[tokio::test(flavor = "multi_thread")]
+#[serial_test::serial]
+async fn a_malformed_config_set_applies_neither_field_on_either_transport() {
+    let _restore = RestoreLimits::capture();
+    let (_state, http, rpc) = routers(&[]);
+
+    set_memory_limit_mb(Some(4096));
+    set_index_memory_limit_mb(Some(512));
+    let malformed = serde_json::json!({ "memory_limit_mb": 1024, "index_memory_limit_mb": "lots" });
+
+    let (status, body) = http_err(&http, "PATCH", "/config", malformed.clone()).await;
+    assert_eq!(
+        (memory_limit_mb(), index_memory_limit_mb()),
+        (Some(4096), Some(512)),
+        "HTTP refused with {status} ({body}) but a limit moved anyway"
+    );
+
+    let over_socket = rpc_err(&rpc, admin::METHOD_CONFIG_SET, malformed).await;
+    assert_eq!(
+        over_socket.code, CODE_INVALID_PARAMS,
+        "a body that does not decode is the caller's fault: {over_socket:?}"
+    );
+    assert_eq!(
+        (memory_limit_mb(), index_memory_limit_mb()),
+        (Some(4096), Some(512)),
+        "the socket refused but a limit moved anyway"
+    );
+}
+
+// -------------------------------------------------------- search.logs.tail ---
+
+/// Why: this is the method `trusty-common`'s monitor dials once the retire slice
+/// moves it off `GET /logs/tail`, and the monitor renders the `total` beside the
+/// lines to tell whether the ring has wrapped. Both fields are compared whole.
+/// Test: this function IS the test.
+#[tokio::test(flavor = "multi_thread")]
+#[serial_test::serial]
+async fn logs_tail_over_the_socket_matches_the_http_body() {
+    let (state, http, rpc) = routers(&[]);
+    for i in 0..5 {
+        state.log_buffer.push(format!("line {i}"));
+    }
+
+    let over_http = http_get(&http, "/logs/tail?n=3").await;
+    let over_socket = rpc_ok(
+        &rpc,
+        admin::METHOD_LOGS_TAIL,
+        serde_json::json!({ "n": 3 }),
+    )
+    .await;
+
+    assert_eq!(
+        over_socket["lines"].as_array().map(Vec::len),
+        Some(3),
+        "n must bound the page: {over_socket}"
+    );
+    assert_eq!(over_socket, over_http);
+}
+
+/// Why: the clamp lives in the core precisely so it cannot be skipped by
+/// dialling the socket — an unclamped `n` would let a caller ask for more lines
+/// than the ring holds and read a different page than the HTTP route serves for
+/// the same request. This drives both ends of the clamp and the defaulted call.
+/// Test: this function IS the test.
+#[tokio::test(flavor = "multi_thread")]
+#[serial_test::serial]
+async fn logs_tail_clamps_n_on_the_socket_too() {
+    let (state, http, rpc) = routers(&[]);
+    for i in 0..3 {
+        state.log_buffer.push(format!("line {i}"));
+    }
+
+    // Over the ceiling: both transports answer the whole buffer, not an error.
+    let huge = serde_json::json!({ "n": 10_000_000 });
+    assert_eq!(
+        rpc_ok(&rpc, admin::METHOD_LOGS_TAIL, huge).await,
+        http_get(&http, "/logs/tail?n=10000000").await,
+    );
+
+    // Absent: the socket must reach the route's own default, not `usize`'s zero.
+    assert_eq!(
+        rpc_ok(&rpc, admin::METHOD_LOGS_TAIL, serde_json::Value::Null).await,
+        http_get(&http, "/logs/tail").await,
+    );
+}
+
+// ------------------------------------------------- search.registry.orphans ---
+
+/// Plant an `indexes.toml` row for `id` at `root` in the isolated data dir.
+fn plant_row(id: &str, root: impl Into<std::path::PathBuf>) {
+    persistence::upsert_index_registry_entry(PersistedIndex::new(id.to_string(), root.into()))
+        .expect("write the registry row");
+}
+
+/// Why (#6371): this is the census `trusty-console`'s cleanup tab reads before
+/// offering rows for deletion, and its whole contract is that `orphans` and
+/// `indeterminate` do not mix. A socket that flattened them — or that re-derived
+/// the classification instead of reading the same census — would hand the
+/// console an unmounted volume's roster as deletion candidates.
+/// Test: this function IS the test.
+#[tokio::test(flavor = "multi_thread")]
+#[serial_test::serial]
+async fn registry_orphans_over_the_socket_matches_the_http_body() {
+    let _isolated = IsolatedDataDir::new();
+    let live = tempfile::tempdir().expect("tempdir");
+    plant_row("orphans-live", live.path());
+    plant_row("orphans-wiped", live.path().join("wiped-root"));
+    plant_row("orphans-unplugged", Path::new("/Volumes/Kemono/project"));
+
+    let (_state, http, rpc) = routers(&[]);
+    let over_http = http_get(&http, "/registry/orphans").await;
+    let over_socket = rpc_ok(
+        &rpc,
+        admin::METHOD_REGISTRY_ORPHANS,
+        serde_json::Value::Null,
+    )
+    .await;
+
+    assert_eq!(over_socket, over_http);
+    assert_eq!(over_socket["total"], serde_json::json!(3));
+    assert_eq!(over_socket["live_count"], serde_json::json!(1));
+    assert_eq!(
+        over_socket["orphans"]
+            .as_array()
+            .expect("orphans is an array")
+            .iter()
+            .map(|o| o["id"].as_str().unwrap_or_default())
+            .collect::<Vec<_>>(),
+        vec!["orphans-wiped"],
+        "only the deleted root is a deletion candidate: {over_socket}"
+    );
+    assert_eq!(
+        over_socket["indeterminate"]
+            .as_array()
+            .expect("indeterminate is an array")
+            .iter()
+            .map(|u| u["id"].as_str().unwrap_or_default())
+            .collect::<Vec<_>>(),
+        vec!["orphans-unplugged"],
+        "the external volume must be reported, not offered: {over_socket}"
+    );
+}
+
+/// The Fail-Open Check.
+///
+/// Why: an unreadable registry answered as an empty census reads to the console
+/// as "nothing to clean up", which is the one wrong answer this route must never
+/// give. Both transports must refuse. What makes the file unreadable is a
+/// DIRECTORY at `indexes.toml` — a missing file is legitimately an empty
+/// registry, so it would prove nothing.
+/// Test: this function IS the test.
+#[tokio::test(flavor = "multi_thread")]
+#[serial_test::serial]
+async fn an_unreadable_registry_is_refused_on_either_transport() {
+    let _isolated = IsolatedDataDir::new();
+    let path = persistence::indexes_toml_path().expect("resolve the registry path");
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("create the data dir");
+    }
+    let _ = std::fs::remove_file(&path);
+    std::fs::create_dir_all(&path).expect("make indexes.toml unreadable as a file");
+
+    let (_state, http, rpc) = routers(&[]);
+    let request = Request::builder()
+        .method("GET")
+        .uri("/registry/orphans")
+        .body(Body::empty())
+        .expect("build the request");
+    let over_http = http_raw(&http, request).await;
+    assert_eq!(
+        over_http.0,
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "an unreadable registry is an error, never an empty census: {}",
+        over_http.1
+    );
+
+    let over_socket = rpc_err(
+        &rpc,
+        admin::METHOD_REGISTRY_ORPHANS,
+        serde_json::Value::Null,
+    )
+    .await;
+    assert_same_refusal(
+        &over_http,
+        &over_socket,
+        trusty_common::uds::server::CODE_INTERNAL_ERROR,
+        "unreadable registry",
+    );
+}
+

--- a/crates/trusty-search/src/service/rpc/lanes_tests.rs
+++ b/crates/trusty-search/src/service/rpc/lanes_tests.rs
@@ -43,6 +43,13 @@
 //! must still be running — which is what a method wrongly moved INTO the
 //! interactive lane would stop doing.
 //!
+//! That control set can only hold methods that take the lock, which is four of
+//! the roughly nineteen non-interactive ones. The remainder are covered
+//! structurally instead:
+//! `the_query_deadline_has_exactly_one_call_site_on_the_rpc_surface` fails if a
+//! second call to the deadline wrapper is added anywhere outside
+//! `queries::guarded` (#6285 slice 5.5 review).
+//!
 //! Test: this file IS the test module for `super`.
 
 use std::sync::Arc;
@@ -87,7 +94,7 @@ impl Lane {
 /// succeed. What each method ANSWERS is the business of its family's parity
 /// tests; this file reads only whether the limiter or the deadline spoke first.
 fn lanes() -> Vec<(&'static str, Lane, serde_json::Value)> {
-    use crate::service::rpc::{queries, reads, streams, writes};
+    use crate::service::rpc::{admin, queries, reads, streams, writes};
 
     let index = serde_json::json!({ "index_id": INDEX });
     let query = serde_json::json!({ "index_id": INDEX, "body": { "text": "anything" } });
@@ -204,6 +211,22 @@ fn lanes() -> Vec<(&'static str, Lane, serde_json::Value)> {
             Lane::Free,
             index.clone(),
         ),
+        // Slice 5.5's operational remainder: every HTTP route is in `free`.
+        // `search.config.set` names no field and `search.index.config.set`
+        // carries an empty body, so neither moves anything the sweep would then
+        // have to restore — the lane is what is under test, not the update.
+        (
+            admin::METHOD_INDEX_CONFIG_SET,
+            Lane::Free,
+            serde_json::json!({ "index_id": INDEX, "body": {} }),
+        ),
+        (admin::METHOD_CONFIG_SET, Lane::Free, serde_json::json!({})),
+        (admin::METHOD_LOGS_TAIL, Lane::Free, serde_json::Value::Null),
+        (
+            admin::METHOD_REGISTRY_ORPHANS,
+            Lane::Free,
+            serde_json::Value::Null,
+        ),
     ]
 }
 
@@ -225,7 +248,7 @@ fn state_with(permits: usize, deadline: Duration) -> Arc<SearchAppState> {
 
 /// The whole socket router, exactly as `service::socket` assembles it.
 fn router(state: &Arc<SearchAppState>) -> RpcRouter {
-    use crate::service::rpc::{queries, reads, streams, writes};
+    use crate::service::rpc::{admin, queries, reads, streams, writes};
 
     let held = Arc::clone(state);
     let router = RpcRouter::new()
@@ -239,6 +262,7 @@ fn router(state: &Arc<SearchAppState>) -> RpcRouter {
     let router = reads::register(router, state);
     let router = queries::register(router, state);
     let router = writes::register(router, state);
+    let router = admin::register(router, state);
     streams::register(router, state)
 }
 
@@ -295,6 +319,10 @@ fn every_socket_method_declares_a_lane() {
 #[tokio::test(flavor = "multi_thread")]
 #[serial_test::serial]
 async fn every_socket_method_takes_the_admission_lane_its_http_route_takes() {
+    // #6285: the sweep now calls `search.registry.orphans`, which reads the
+    // registry FILE, and three write methods that persist rows into it. Point
+    // the data dir at a tempdir so neither reads nor writes the developer's own.
+    let _isolated = crate::service::server::tests_components::IsolatedDataDir::new();
     let state = state_with(1, Duration::from_secs(30));
     let rpc = router(&state);
 
@@ -383,4 +411,60 @@ async fn only_the_interactive_lane_is_deadline_bounded() {
              not cut by a deadline it does not have: answered {outcome:?}"
         );
     }
+}
+
+/// Why: the control set above can only stall methods that take the indexer's
+/// write lock, so it samples four of the roughly nineteen non-interactive
+/// methods. The rest — `search.index.create`, `search.config.get`,
+/// `search.status.stream` and their neighbours — have no equivalent stall point,
+/// and their "not deadline-bounded" status rests on a structural fact rather
+/// than on any running assertion: the deadline wrapper has exactly one call site
+/// on this surface, in `queries::guarded`. A second call added elsewhere would
+/// make a method deadline-bounded with nothing in this file noticing.
+///
+/// What: reads the production sources under `service/rpc/` and counts calls to
+/// the wrapper, ignoring comment lines and the `*_tests.rs` files. Exactly one
+/// call, in `queries.rs`. A source scan rather than a type-level guard because
+/// the wrapper is also called by the axum middleware in `service::query_timeout`,
+/// so it cannot be made private to `queries` (#6285 slice 5.5 review).
+/// Test: this function IS the test.
+#[test]
+fn the_query_deadline_has_exactly_one_call_site_on_the_rpc_surface() {
+    // Split so this file's own mentions of the name are not what it counts.
+    let needle = format!("with_query{}(", "_deadline");
+    let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/service/rpc");
+
+    let mut call_sites = Vec::new();
+    for entry in std::fs::read_dir(&dir).expect("the rpc module directory must be readable") {
+        let path = entry.expect("a readable directory entry").path();
+        let name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or_default()
+            .to_string();
+        if !name.ends_with(".rs") || name.ends_with("_tests.rs") {
+            continue;
+        }
+        let source = std::fs::read_to_string(&path).expect("a readable source file");
+        for (i, line) in source.lines().enumerate() {
+            let trimmed = line.trim_start();
+            if trimmed.starts_with("//") || trimmed.starts_with("*") {
+                continue;
+            }
+            if line.contains(&needle) {
+                call_sites.push(format!("{name}:{}", i + 1));
+            }
+        }
+    }
+
+    assert_eq!(
+        call_sites.len(),
+        1,
+        "the query deadline must have exactly one call site on this surface; found {call_sites:?}"
+    );
+    assert!(
+        call_sites[0].starts_with("queries.rs:"),
+        "the one call site must be `queries::guarded`; found {}",
+        call_sites[0]
+    );
 }

--- a/crates/trusty-search/src/service/rpc/mod.rs
+++ b/crates/trusty-search/src/service/rpc/mod.rs
@@ -32,8 +32,12 @@ pub mod writes;
 /// index's reindex progress stream (#6285 slice 5).
 pub mod streams;
 
+/// Registration for the operational remainder: the two config writes, the log
+/// tail, and the registry orphan census (#6285 slice 5.5).
+pub mod admin;
+
 /// Per-method admission and deadline lane pins for the whole socket surface
-/// (#6285 slice 5, discharging the slice-4 review's deferred MEDIUM).
+/// (#6285 slice 5, widened in slice 5.5 to every lock-taking method).
 #[cfg(test)]
 #[path = "lanes_tests.rs"]
 mod lanes_tests;

--- a/crates/trusty-search/src/service/rpc/streams.rs
+++ b/crates/trusty-search/src/service/rpc/streams.rs
@@ -77,14 +77,28 @@
 //!   `broadcast::recv()` ends as soon as the receiver goes rather than one event
 //!   later. Without it a disconnect would cost two events to clear instead of
 //!   one.
-//! - one event still has to arrive. Neither surface can wait long for it: the
-//!   daemon's status ticker emits every ~2 s, a running reindex emits per batch,
-//!   and a FINISHED reindex ends its stream outright rather than subscribing.
-//!   `a_client_that_drops_mid_stream_leaves_no_producer_subscribed` pins the
-//!   whole sequence over a real socket.
+//! - one event still has to arrive, and how long that takes differs per stream.
+//!   `search.status.stream` is bounded: the daemon's status ticker emits every
+//!   ~2 s whatever else is happening, so an abandoned producer clears within a
+//!   tick. `search.index.reindex.stream` is bounded only while the reindex is
+//!   PROGRESSING — it emits per batch, and a run that stalls between batches
+//!   emits nothing, so its abandoned producer stays parked for the stall's
+//!   duration. A finished reindex never parks at all; that arm returns after the
+//!   replay rather than subscribing. A run that COMPLETES while a producer is
+//!   parked ends it when the progress record is garbage-collected — 60 s after
+//!   the terminal event (`service::reindex::stages`'s `REINDEX_PROGRESS_TTL_SECS`)
+//!   — because dropping the record drops the sender the producer is waiting on.
+//!   `a_client_that_drops_mid_stream_leaves_no_producer_subscribed` pins that
+//!   sequence over a real socket for the status stream; the stalled-reindex case
+//!   is documented rather than tested, since forcing a stall needs a seam the
+//!   reindex runner does not have.
 //!
-//! Neither stream holds an admission permit for its lifetime, so an abandoned
-//! one costs the semaphore nothing even while its task is still parked.
+//! The pre-existing HTTP SSE route parks on the same broadcast with the same
+//! characteristic: its 20 s heartbeat keeps the TCP connection alive but does not
+//! unstick a stalled reindex either. So a parked producer costs one task and one
+//! broadcast subscriber slot. Neither stream holds an admission permit for its
+//! lifetime, so an abandoned one costs the semaphore nothing even while its task
+//! is still parked.
 //!
 //! Test: `streams_tests.rs`.
 
@@ -205,9 +219,23 @@ fn status_stream(state: &Arc<SearchAppState>) -> RpcStreamItems {
 ///
 /// What, in the order `reindex_stream_handler` does it: look the index's
 /// progress up and refuse when there is none, snapshot the replay buffer, read
-/// the status, then subscribe. Snapshot-before-subscribe is copied deliberately
-/// — it can duplicate an event that arrives between the two, and the reverse
-/// order can LOSE the `start` event a late subscriber connected to see.
+/// the status, then subscribe.
+///
+/// That ordering is copied from the SSE handler deliberately, and it is not
+/// race-free in either place. `ReindexProgress::push` writes the replay buffer
+/// under its lock and THEN broadcasts, while this clones the buffer under the
+/// same lock and THEN subscribes, so an event whose two halves straddle the open
+/// can be delivered TWICE (buffered before the snapshot, broadcast after the
+/// subscribe) or NOT AT ALL (buffered after the snapshot, broadcast before the
+/// subscribe). Both transports inherit it identically, which is why parity holds
+/// and why this slice copies rather than corrects it: subscribing before
+/// snapshotting would close the loss arm, but it changes the shipped SSE route's
+/// behaviour and belongs to its own change. See #6285 (slice 5.5 review).
+///
+/// The window itself is not drivable from a test — there is no await point
+/// between the snapshot and the subscribe, so it is only reachable from another
+/// thread at an instant nothing exposes. What IS pinned is the composition
+/// either side of it.
 ///
 /// A progress record whose status is no longer `Running` yields its replay and
 /// ends. Without that arm the stream would deliver the buffered `complete` event
@@ -223,6 +251,7 @@ fn status_stream(state: &Arc<SearchAppState>) -> RpcStreamItems {
 ///
 /// Test: `reindex_progress_events_match_the_sse_body_frame_for_frame`,
 /// `a_live_reindex_stream_delivers_events_in_order_as_they_are_emitted`,
+/// `an_event_either_side_of_the_stream_opening_is_delivered_exactly_once`,
 /// `an_unknown_index_is_refused_before_the_reindex_stream_opens`.
 async fn reindex_stream(
     state: &Arc<SearchAppState>,

--- a/crates/trusty-search/src/service/rpc/streams_tests.rs
+++ b/crates/trusty-search/src/service/rpc/streams_tests.rs
@@ -314,6 +314,57 @@ async fn a_live_reindex_stream_delivers_events_in_order_as_they_are_emitted() {
     );
 }
 
+/// Why: `reindex_stream` snapshots the replay buffer and THEN subscribes, and
+/// `ReindexProgress::push` buffers under the same lock and THEN broadcasts — so
+/// an event whose two halves straddle the open can be delivered twice or lost.
+/// That instant is not drivable: `reindex_stream` has no await point between the
+/// snapshot and the subscribe, so the window is only reachable from another
+/// thread with no seam to stop at.
+///
+/// What this pins is the composition either side of it — the two orderings that
+/// ARE deterministic. An event pushed strictly BEFORE the open arrives once, from
+/// the replay; one pushed strictly AFTER arrives once, live. A rewrite that
+/// subscribed before snapshotting, replayed twice, or dropped the replay changes
+/// one of those two counts, so it fails here even though the race itself is not
+/// reproducible. The window is inherited from the SSE handler and accepted, not
+/// introduced by this slice (#6285).
+/// Test: this function IS the test.
+#[tokio::test(flavor = "multi_thread")]
+async fn an_event_either_side_of_the_stream_opening_is_delivered_exactly_once() {
+    let (state, _http, rpc) = routers(&["rs"]).await;
+    let before = serde_json::json!({ "event": "start", "total_files": 2 });
+    let progress = plant_progress(
+        &state,
+        "rs",
+        ReindexStatus::Running,
+        std::slice::from_ref(&before),
+    )
+    .await;
+
+    let mut items = open_stream(
+        &rpc,
+        streams::METHOD_INDEX_REINDEX_STREAM,
+        serde_json::json!({ "index_id": "rs" }),
+    )
+    .await;
+
+    let after = serde_json::json!({ "event": "progress", "indexed": 1, "total": 2 });
+    progress.push(after.clone()).await;
+
+    // Two items, in that order: a third would mean the replayed event was also
+    // delivered live, and a first item of `after` would mean the replay was lost.
+    assert_eq!(
+        take_items(&mut items, 2).await,
+        vec![before, after],
+        "each event either side of the open must arrive exactly once, in order"
+    );
+
+    // The next item is the next event and nothing left over from the open.
+    let latest = serde_json::json!({ "event": "complete", "indexed": 2, "elapsed_ms": 3 });
+    progress.push(latest.clone()).await;
+    assert_eq!(take_items(&mut items, 1).await, vec![latest]);
+}
+
 /// Why: the SSE route answers `404` for an index with no recorded reindex, and a
 /// stream that opened and then ended empty would read to a consumer as "the
 /// reindex produced nothing" rather than "there is no reindex". This pins the

--- a/crates/trusty-search/src/service/server/admin.rs
+++ b/crates/trusty-search/src/service/server/admin.rs
@@ -3,9 +3,13 @@
 //! Why: Groups operational endpoints (log tailing, live config, graceful stop,
 //! and the SSE dashboard feed) separately from domain search logic.
 //! What: `logs_tail_handler`, `admin_stop_handler`, `get_config_handler`,
-//! `patch_config_handler`, `status_stream_handler`, `collect_status_counts`.
+//! `patch_config_handler`, `status_stream_handler`, `collect_status_counts`,
+//! and the transport-free cores two of them delegate to — `logs_tail_report`
+//! and `patch_config_report`, which `service::rpc::admin` serves over the socket
+//! (#6285 slice 5.5).
 //! Test: `logs_tail_returns_recent_lines`, `admin_stop_returns_ok`, and
-//! `patch_config_partial_update` in `super::tests`.
+//! `patch_config_partial_update` in `super::tests`; the socket halves in
+//! `service::rpc::admin`'s `admin_tests.rs`.
 use axum::{
     body::Body,
     extract::{Query, State},
@@ -45,6 +49,21 @@ fn default_logs_tail_n() -> usize {
     DEFAULT_LOGS_TAIL_N
 }
 
+impl Default for LogsTailParams {
+    /// [`DEFAULT_LOGS_TAIL_N`], the same figure the serde default supplies.
+    ///
+    /// Why it exists (#6285 slice 5.5): `search.logs.tail` accepts an absent
+    /// `n`, and a derived `Default` would give `0` — which the clamp turns into
+    /// one line rather than the route's hundred. Routing both transports through
+    /// one constant is what keeps a defaulted socket call and a bare
+    /// `GET /logs/tail` the same request.
+    fn default() -> Self {
+        Self {
+            n: DEFAULT_LOGS_TAIL_N,
+        }
+    }
+}
+
 /// `GET /logs/tail?n=200` — return the most recent N tracing log lines.
 ///
 /// Why (issue #35): operators debugging a running daemon want recent logs
@@ -60,12 +79,30 @@ pub(super) async fn logs_tail_handler(
     State(state): State<Arc<SearchAppState>>,
     Query(params): Query<LogsTailParams>,
 ) -> Json<serde_json::Value> {
+    Json(logs_tail_report(&state, &params))
+}
+
+/// The page `GET /logs/tail` serves, without the transport (#6285 slice 5.5).
+///
+/// Why: `search.logs.tail` reads the same ring buffer over the socket — it is
+/// the one gap `trusty-common`'s monitor still dials over HTTP. The clamp is the
+/// part that must not be re-implemented: a socket that skipped it would let a
+/// caller ask for more lines than the buffer holds and read a different `total`
+/// than the HTTP route reports for the same request.
+/// What: clamps `n` to `[1, MAX_LOGS_TAIL_N]` and returns the same
+/// `{lines, total}` document the handler wraps in `Json`.
+/// Test: `logs_tail_over_the_socket_matches_the_http_body`,
+/// `logs_tail_clamps_n_on_the_socket_too`.
+pub(crate) fn logs_tail_report(
+    state: &Arc<SearchAppState>,
+    params: &LogsTailParams,
+) -> serde_json::Value {
     let n = params.n.clamp(1, MAX_LOGS_TAIL_N);
     let lines = state.log_buffer.tail(n);
-    Json(serde_json::json!({
+    serde_json::json!({
         "lines": lines,
         "total": state.log_buffer.len(),
-    }))
+    })
 }
 
 /// `POST /admin/stop` — request a graceful shutdown of the daemon.
@@ -115,7 +152,7 @@ pub(super) async fn admin_stop_handler(
 /// `Option<Option<u64>>`.
 /// Test: `tests::patch_config_partial_update` exercises both arms.
 #[derive(Debug, Deserialize, Default)]
-pub(super) struct PatchConfigRequest {
+pub(crate) struct PatchConfigRequest {
     #[serde(default, deserialize_with = "deserialize_optional_option_u64")]
     memory_limit_mb: Option<Option<u64>>,
     #[serde(default, deserialize_with = "deserialize_optional_option_u64")]
@@ -198,6 +235,25 @@ pub(super) async fn patch_config_handler(
     State(_state): State<Arc<SearchAppState>>,
     Json(req): Json<PatchConfigRequest>,
 ) -> Json<ConfigResponse> {
+    Json(patch_config_report(req))
+}
+
+/// The update `PATCH /config` applies, without the transport (#6285 slice 5.5).
+///
+/// Why: `search.config.set` is the first WRITE this daemon serves that changes
+/// nothing an index owns — both limits are process-global `AtomicU64` cells in
+/// `core::memguard`. A second implementation over the socket would be a second
+/// place that decides what an absent field means against what an explicit `null`
+/// means, and the two transports would disagree about which limits a partial
+/// patch left alone.
+/// What: applies whichever of the two fields the request carried, logs each
+/// change at `INFO` exactly as the route already did, and answers the resolved
+/// post-update values — so a caller can print "before → after" without a
+/// follow-up read. Infallible: an unparseable field is refused by the decoder
+/// ahead of this, and a resolvable one always applies.
+/// Test: `config_set_over_the_socket_matches_the_http_body`,
+/// `a_config_set_that_names_no_field_changes_nothing_on_either_transport`.
+pub(crate) fn patch_config_report(req: PatchConfigRequest) -> ConfigResponse {
     use crate::core::memguard::{
         index_memory_limit_mb, memory_limit_mb, set_index_memory_limit_mb, set_memory_limit_mb,
     };
@@ -228,10 +284,10 @@ pub(super) async fn patch_config_handler(
         );
     }
 
-    Json(ConfigResponse {
+    ConfigResponse {
         memory_limit_mb: memory_limit_mb(),
         index_memory_limit_mb: index_memory_limit_mb(),
-    })
+    }
 }
 
 /// Snapshot used by both `/health` (one-shot) and `/status/stream` (SSE tick).

--- a/crates/trusty-search/src/service/server/admin.rs
+++ b/crates/trusty-search/src/service/server/admin.rs
@@ -252,7 +252,7 @@ pub(super) async fn patch_config_handler(
 /// follow-up read. Infallible: an unparseable field is refused by the decoder
 /// ahead of this, and a resolvable one always applies.
 /// Test: `config_set_over_the_socket_matches_the_http_body`,
-/// `a_config_set_that_names_no_field_changes_nothing_on_either_transport`.
+/// `a_malformed_config_set_applies_neither_field_on_either_transport`.
 pub(crate) fn patch_config_report(req: PatchConfigRequest) -> ConfigResponse {
     use crate::core::memguard::{
         index_memory_limit_mb, memory_limit_mb, set_index_memory_limit_mb, set_memory_limit_mb,

--- a/crates/trusty-search/src/service/server/index_config.rs
+++ b/crates/trusty-search/src/service/server/index_config.rs
@@ -16,11 +16,15 @@
 //! background catch-up job (issue #2984 Phase 1, see `super::components`).
 //!
 //! What: `index_config_handler` (GET), `patch_index_config_handler` (PATCH),
-//! and the serde request/response types. The component-toggle decision logic
-//! and catch-up spawn live in the sibling `components` module to keep this
-//! file under the 500-SLOC production cap.
+//! their transport-free cores `index_config_report` / `patch_index_config_report`
+//! — which `service::rpc` serves as `search.index.config.get` and
+//! `search.index.config.set` (#6285 slices 2 and 5.5) — and the serde
+//! request/response types. The component-toggle decision logic and catch-up
+//! spawn live in the sibling `components` module to keep this file under the
+//! 500-SLOC production cap.
 //!
-//! Test: `service::server::tests_index_config`, `service::server::tests_components`.
+//! Test: `service::server::tests_index_config`, `service::server::tests_components`;
+//! the socket halves in `service::rpc::admin`'s `admin_tests.rs`.
 
 use axum::{
     extract::{Path, State},
@@ -204,25 +208,56 @@ pub(super) async fn patch_index_config_handler(
     Path(id): Path<String>,
     Json(req): Json<PatchIndexConfigRequest>,
 ) -> Response {
+    match patch_index_config_report(&state, &id, req).await {
+        Ok(body) => Json(body).into_response(),
+        Err((status, body)) => (status, Json(body)).into_response(),
+    }
+}
+
+/// The update `PATCH /indexes/{id}/config` applies, without the transport
+/// (#6285 slice 5.5).
+///
+/// Why: `search.index.config.set` is the socket's most consequential write —
+/// it re-registers the handle, rewrites the `indexes.toml` row, and can start a
+/// background component catch-up. Every one of those steps has a guard that a
+/// second implementation would have to restate: the zero-cap rejection, the
+/// per-index mutual-exclusion permit taken BEFORE any mutation (#2984 Phase 1
+/// CRITICAL finding 2), the #3049 teardown read-guard, and the 500 that refuses
+/// to claim success when the persist failed. This is the one body both
+/// transports run, so none of them can be skipped by dialling the socket.
+///
+/// # Errors
+///
+/// `400` for a zero `data_file_max_bytes`, `404` for an unknown index, `409`
+/// when this index already has a reindex or catch-up running, and `500` when the
+/// change applied in memory but could not be persisted — the same four the route
+/// answered before this extraction, with the same bodies.
+///
+/// Test: `index_config_set_over_the_socket_matches_the_http_body`,
+/// `a_zero_data_cap_is_refused_and_changes_no_config_on_either_transport`,
+/// `a_config_set_against_an_unknown_index_is_refused_and_registers_nothing`.
+pub(crate) async fn patch_index_config_report(
+    state: &Arc<SearchAppState>,
+    id: &str,
+    req: PatchIndexConfigRequest,
+) -> Result<serde_json::Value, (StatusCode, serde_json::Value)> {
     let index_id = IndexId::new(id);
 
     // Validate: a zero (or absurd) data cap would prune every data file.
     if matches!(req.data_file_max_bytes, Some(0)) {
-        return (
+        return Err((
             StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({
+            serde_json::json!({
                 "error": "data_file_max_bytes must be greater than zero"
-            })),
-        )
-            .into_response();
+            }),
+        ));
     }
 
     let Some(existing) = state.registry.get(&index_id) else {
-        return (
+        return Err((
             StatusCode::NOT_FOUND,
-            Json(serde_json::json!({ "error": format!("unknown index '{}'", index_id.0) })),
-        )
-            .into_response();
+            serde_json::json!({ "error": format!("unknown index '{}'", index_id.0) }),
+        ));
     };
 
     // #3049 round 3: hold this id's teardown-lock SHARED side across the whole
@@ -254,18 +289,17 @@ pub(super) async fn patch_index_config_handler(
         match crate::service::reindex::index_semaphore(&index_id).try_acquire_owned() {
             Ok(p) => Some(p),
             Err(_) => {
-                return (
+                return Err((
                     StatusCode::CONFLICT,
-                    Json(serde_json::json!({
+                    serde_json::json!({
                         "error": format!(
                             "a reindex or component catch-up is already in progress for \
                              index '{}' — retry once it completes",
                             index_id.0,
                         ),
                         "index_id": index_id.0,
-                    })),
-                )
-                    .into_response();
+                    }),
+                ));
             }
         }
     } else {
@@ -364,18 +398,17 @@ pub(super) async fn patch_index_config_handler(
         state.emit(DaemonEvent::IndexRegistered {
             id: index_id.0.clone(),
         });
-        return (
+        return Err((
             StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({
+            serde_json::json!({
                 "error": format!(
                     "config applied in memory but could not be persisted to indexes.toml: {e}. \
                      The change will be lost on the next daemon restart."
                 ),
                 "config": view,
                 "persisted": false,
-            })),
-        )
-            .into_response();
+            }),
+        ));
     }
 
     // Issue #2984 Phase 1: spawn the background catch-up now that the new
@@ -392,7 +425,7 @@ pub(super) async fn patch_index_config_handler(
         id: index_id.0.clone(),
     });
 
-    Json(serde_json::json!({
+    Ok(serde_json::json!({
         "id": index_id.0,
         "config": view,
         "reindex_required": true,
@@ -403,7 +436,6 @@ pub(super) async fn patch_index_config_handler(
             "catch_up_started": catch_up_started,
         },
     }))
-    .into_response()
 }
 
 /// Trim empties from a directory / glob list and drop blank entries.

--- a/crates/trusty-search/src/service/server/mod.rs
+++ b/crates/trusty-search/src/service/server/mod.rs
@@ -225,6 +225,12 @@ pub(crate) use indexes_relocate::{relocate_index_report, RelocateIndexRequest};
 pub(crate) use reindex_handlers::reindex_report;
 pub(crate) use search::{delete_index_report, DeleteIndexParams};
 
+// #6285 slice 5.5: the four routes with a named consumer that no earlier slice
+// claimed. Same contract as the blocks above; the two config cores are WRITES
+// and carry the slice-4 failure-arm bar with them.
+pub(crate) use admin::{logs_tail_report, patch_config_report, PatchConfigRequest};
+pub(crate) use index_config::{patch_index_config_report, PatchIndexConfigRequest};
+
 /// Build the axum router with the shared state.
 ///
 /// Why: Wraps `state` in an `Arc` so every handler clones the pointer cheaply.
@@ -344,10 +350,15 @@ pub fn build_router_on(
         // bounding the per-request RAM/DoS surface (PR #1129 review,
         // finding 2); revisit with a streaming ingest path if producers
         // outgrow it.
+        //
+        // #6285 slice 5.5: the figure is the socket listener's frame budget,
+        // named rather than restated. The two doors must accept the same
+        // payload, and two literals is how they stop doing so.
         .route(
             "/indexes/{id}/graph",
-            post(ingest_graph_handler)
-                .layer(axum::extract::DefaultBodyLimit::max(64 * 1024 * 1024)),
+            post(ingest_graph_handler).layer(axum::extract::DefaultBodyLimit::max(
+                crate::service::socket::MAX_FRAME_BYTES as usize,
+            )),
         )
         .route_layer(axum::middleware::from_fn(
             crate::service::concurrency::apply_limiter,

--- a/crates/trusty-search/src/service/server/reindex_handlers.rs
+++ b/crates/trusty-search/src/service/server/reindex_handlers.rs
@@ -436,10 +436,15 @@ pub(super) async fn reindex_stream_handler(
         .map(|r| Arc::clone(r.value()))
         .ok_or(StatusCode::NOT_FOUND)?;
 
-    // Snapshot the replay buffer first so we don't miss the `start` event,
-    // then subscribe for live updates. New events that arrive between the
-    // snapshot and subscription will appear in both — duplicates are harmless
-    // for SSE consumers and rare in practice.
+    // Snapshot the replay buffer first so we don't miss the `start` event, then
+    // subscribe for live updates.
+    //
+    // #6285: an event that straddles the two can be delivered twice OR lost —
+    // `ReindexProgress::push` buffers under its lock and then broadcasts, so an
+    // event broadcast between this snapshot and the subscribe below reaches
+    // neither path. The earlier claim here that the race only duplicates was
+    // wrong. `service::rpc::streams::reindex_stream` copies this ordering, so both
+    // transports behave identically; correcting it is its own change.
     let replay = progress.events.lock().await.clone();
     let initial_status = progress.status.load();
     let rx = progress.sender.subscribe();

--- a/crates/trusty-search/src/service/socket.rs
+++ b/crates/trusty-search/src/service/socket.rs
@@ -22,8 +22,21 @@
 //! | 2 | the READ surface — indexes, status, config, chunks, graph, call chain | landed (PR #6368), in [`crate::service::rpc::reads`] |
 //! | 3 | the QUERY surface — search and its fan-out, grep and its fan-out, similarity, typeahead | landed (PR #6377), in [`crate::service::rpc::queries`] |
 //! | 4 | the WRITE surface — index create, delete, relocate, the two per-file writes, the reindex trigger, contributed-graph ingest | landed (PR #6381), in [`crate::service::rpc::writes`] |
-//! | 5 | the STREAMS — reindex progress and the daemon status stream | this one, in [`crate::service::rpc::streams`] |
-//! | retire | delete the axum surface and move the eleven dialling crates | not started |
+//! | 5 | the STREAMS — reindex progress and the daemon status stream | landed (PR #6383), in [`crate::service::rpc::streams`] |
+//! | 5.5 | the REMAINDER with a named consumer — the two config writes, the log tail, the registry orphan census — plus the frame-cap raise | this one, in [`crate::service::rpc::admin`] |
+//! | consumer wave | move the eleven dialling crates onto these names, one PR per crate | not started |
+//! | retire | delete the axum surface, `ui.rs`, and the `http_addr` writer | not started, gated on the consumer wave |
+//!
+//! **Slice 5.5 closes the method gap, not the migration.** Every HTTP route with
+//! a consumer outside this crate now has a method here, which is the
+//! precondition the consumer wave needs and did not have. Four routes are
+//! deliberately still HTTP-only: `POST /admin/stop`, `POST /upgrade`,
+//! `POST /chat` and `GET /api/chat/providers` have no observed external caller
+//! (chat serves the embedded `/ui` alone), and `GET /metrics` is Prometheus
+//! text, which is HTTP-shaped by nature. `GET /indexes/{id}/communities` is a
+//! DEAD route — `trusty-common`'s monitor calls it and the daemon has never
+//! served it — and is a pre-existing bug with its own ticket, not a gap this
+//! surface owes a method for.
 //!
 //! **Two doors, one daemon.** The socket serves the same `Arc<SearchAppState>`
 //! the axum router was built on — see
@@ -48,7 +61,7 @@ use serde::{Deserialize, Serialize};
 use tokio::net::UnixListener;
 use trusty_common::uds::server::{serve_until, RpcRouter, RpcServeOptions};
 
-use crate::service::rpc::{queries, reads, streams, writes};
+use crate::service::rpc::{admin, queries, reads, streams, writes};
 use crate::service::server::SearchAppState;
 
 #[cfg(test)]
@@ -108,6 +121,12 @@ pub const METHODS: &[&str] = &[
     // against the union of the two.
     streams::METHOD_STATUS_STREAM,
     streams::METHOD_INDEX_REINDEX_STREAM,
+    // #6285 slice 5.5 — the operational remainder. Back in the unary table with
+    // the twenty-three above.
+    admin::METHOD_INDEX_CONFIG_SET,
+    admin::METHOD_CONFIG_SET,
+    admin::METHOD_LOGS_TAIL,
+    admin::METHOD_REGISTRY_ORPHANS,
 ];
 
 /// The params of a method that takes no arguments.
@@ -178,31 +197,60 @@ fn build_router(state: &Arc<SearchAppState>) -> RpcRouter {
     let router = reads::register(router, state);
     let router = queries::register(router, state);
     let router = writes::register(router, state);
+    let router = admin::register(router, state);
     streams::register(router, state)
 }
 
+/// The frame budget this listener accepts, in bytes (#6285 slice 5.5).
+///
+/// Why 64 MiB and not a figure of this surface's own: it is exactly the
+/// `DefaultBodyLimit` `POST /indexes/{id}/graph` carries
+/// (`service::server::build_router_on`), which is what makes the two doors take
+/// the same payload rather than nearly the same one. A contributed graph is the
+/// largest thing either transport moves — PR #1129 recorded ~20 MB maxima from
+/// large pilot corpora and sized the HTTP limit at ~3× that — and a slice-3
+/// query response can also pass 8 MiB when a caller asks for full content at a
+/// large `top_k`. Both were refused here and accepted there until this slice.
+///
+/// A caller must raise its own budget to match with
+/// [`trusty_common::uds::send_framed_request_capped`]; see [`serve_options`].
+pub const MAX_FRAME_BYTES: u64 = 64 * 1024 * 1024;
+
 /// Per-connection budgets for this listener.
 ///
-/// The shared defaults: a 30-second bound on delivering a REQUEST frame, and
-/// the 8 MiB shared frame budget. Neither bounds a handler; slice 3's query
-/// methods are bounded by the interactive query deadline instead, which they
-/// share with their HTTP routes (see [`queries::register`]).
+/// The read bound is the shared default — 30 seconds to deliver a REQUEST
+/// frame. It bounds no handler; slice 3's query methods are bounded by the
+/// interactive query deadline instead, which they share with their HTTP routes
+/// (see [`queries::register`]). It is not a stream's idle budget either: neither
+/// end applies a deadline between two frames of a response (#6286).
 ///
-/// Two surfaces will outgrow the 8 MiB budget, and both are raised on the
-/// listener and the client TOGETHER — raising it here alone only moves which
-/// end refuses. `POST /indexes/{id}/graph` carries a 64 MiB axum body limit
-/// today, and a slice-3 query response can exceed 8 MiB when a caller asks for
-/// full content at a large `top_k` or a grep at a large `max_results`. Both
-/// wait for the retire slice, which is when a consumer first dials these names.
+/// **The frame budget is [`MAX_FRAME_BYTES`], and the two ends now match.** The
+/// shared 8 MiB default is a control-plane figure, and this surface is not one:
+/// `search.graph.ingest` carries a document HTTP accepts up to 64 MiB, so until
+/// this slice a producer whose graph exceeded 8 MiB was refused on the socket
+/// and served on HTTP. Raising the listener alone would only have moved which
+/// end refuses — [`trusty_common::uds::send_framed_request`] applies the 8 MiB
+/// default to the RESPONSE it reads — so a consumer moving onto the query or
+/// ingest names dials through
+/// [`trusty_common::uds::send_framed_request_capped`] with this same figure
+/// rather than the plain helper. Anything smaller on the client turns a request
+/// this listener accepted into a `FrameTooLarge` on the way back.
 ///
-/// Slice 5's streams are NOT a third such surface. The budget bounds each
-/// streamed frame separately rather than their sum, and one progress event or
-/// one `DaemonEvent` is a few hundred bytes — a stream reaches the cap only if a
-/// single event does. The read bound is not a stream's idle budget either: it
-/// bounds delivery of the REQUEST frame, and neither end applies a deadline
-/// between two frames of a response (#6286).
+/// The raise costs no memory at rest. It is a ceiling on how far a single
+/// unterminated frame may grow before the read is refused, not an allocation:
+/// an ordinary `search.health` frame is a few hundred bytes either way.
+///
+/// Slice 5's streams are unaffected. The budget bounds each streamed frame
+/// separately rather than their sum, and one progress event or one `DaemonEvent`
+/// is a few hundred bytes — a stream reaches the cap only if a single event
+/// does.
+///
+/// Test: `serve_options_matches_the_http_graph_ingest_body_limit`.
 fn serve_options() -> RpcServeOptions {
-    RpcServeOptions::default()
+    RpcServeOptions {
+        max_frame_bytes: MAX_FRAME_BYTES,
+        ..RpcServeOptions::default()
+    }
 }
 
 /// A bound RPC socket, with the path it occupies.

--- a/crates/trusty-search/src/service/socket.rs
+++ b/crates/trusty-search/src/service/socket.rs
@@ -214,6 +214,9 @@ fn build_router(state: &Arc<SearchAppState>) -> RpcRouter {
 ///
 /// A caller must raise its own budget to match with
 /// [`trusty_common::uds::send_framed_request_capped`]; see [`serve_options`].
+///
+/// Test: `serve_options_carries_the_raised_frame_budget`,
+/// `a_request_frame_over_the_shared_default_is_accepted_and_refused_at_the_default`.
 pub const MAX_FRAME_BYTES: u64 = 64 * 1024 * 1024;
 
 /// Per-connection budgets for this listener.
@@ -245,7 +248,13 @@ pub const MAX_FRAME_BYTES: u64 = 64 * 1024 * 1024;
 /// is a few hundred bytes — a stream reaches the cap only if a single event
 /// does.
 ///
-/// Test: `serve_options_matches_the_http_graph_ingest_body_limit`.
+/// The HTTP half of the pairing is a compile-time link rather than a test:
+/// `build_router_on` names [`MAX_FRAME_BYTES`] in its `DefaultBodyLimit` instead
+/// of restating the literal, so the two doors cannot drift apart.
+///
+/// Test: `serve_options_carries_the_raised_frame_budget`,
+/// `a_request_frame_over_the_shared_default_is_accepted_and_refused_at_the_default`,
+/// `a_client_budget_below_this_listeners_refuses_a_response_it_serves`.
 fn serve_options() -> RpcServeOptions {
     RpcServeOptions {
         max_frame_bytes: MAX_FRAME_BYTES,

--- a/crates/trusty-search/src/service/socket_tests.rs
+++ b/crates/trusty-search/src/service/socket_tests.rs
@@ -15,7 +15,9 @@ use tempfile::TempDir;
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::UnixStream;
 
-use super::{bind, serve_until_shutdown, socket_path, BoundSocket, METHODS, METHOD_HEALTH};
+use super::{
+    bind, serve_until_shutdown, socket_path, BoundSocket, MAX_FRAME_BYTES, METHODS, METHOD_HEALTH,
+};
 use crate::core::indexer::CodeIndexer;
 use crate::core::registry::{IndexHandle, IndexId, IndexRegistry};
 use crate::service::server::SearchAppState;
@@ -527,4 +529,154 @@ fn socket_path_is_the_product_named_socket_under_the_data_dir() {
          launchd): {}",
         path.display()
     );
+}
+
+// ------------------------------------------------ the frame budget (5.5) ---
+
+/// Why: [`MAX_FRAME_BYTES`] is only a constant until [`serve_options`] carries
+/// it, and the raise exists precisely because the shared control-plane default
+/// is too small for this surface. Asserting both halves — the listener takes the
+/// figure, and the figure is above the shared default — is what makes the two
+/// tests below meaningful rather than tautological.
+/// Test: this function IS the test.
+#[test]
+fn serve_options_carries_the_raised_frame_budget() {
+    assert_eq!(
+        super::serve_options().max_frame_bytes,
+        MAX_FRAME_BYTES,
+        "the listener must serve with this surface's budget, not the default"
+    );
+    const {
+        assert!(
+            MAX_FRAME_BYTES > trusty_common::uds::MAX_FRAME_BYTES,
+            "a budget at or below the shared default would be a no-op raise"
+        );
+    }
+}
+
+/// Why: `search.graph.ingest` carries a document `POST /indexes/{id}/graph`
+/// accepts up to 64 MiB, and until this slice the socket refused at 8 MiB — the
+/// same request served on one door and refused on the other. This drives a
+/// REQUEST frame over the shared default through a real listener, and pins the
+/// control beside it: the identical frame against a listener serving
+/// `RpcServeOptions::default()` is refused, so the raise is what carries it
+/// rather than the frame having been small enough all along.
+///
+/// `search.health` is the method because `NoParams` ignores its payload, so the
+/// filler is carried by the framing without a decode step of its own.
+/// Test: this function IS the test.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_request_frame_over_the_shared_default_is_accepted_and_refused_at_the_default() {
+    let dir = TempDir::new().expect("tempdir");
+    let raised = dir.path().join("raised.sock");
+    let (stop, handle) = spawn_listener(&raised, state_with_indexes(1)).await;
+
+    // One mebibyte past the shared default: over it, and far under this one.
+    let filler = "x".repeat(trusty_common::uds::MAX_FRAME_BYTES as usize + 1024 * 1024);
+    let request = serde_json::json!({
+        "jsonrpc": "2.0", "id": 1, "method": METHOD_HEALTH, "params": { "filler": filler },
+    });
+
+    let answered = dial_once(&raised, &request).await;
+    assert!(
+        answered.frame.get("result").is_some(),
+        "a frame under this listener's budget must be served: {}",
+        answered.frame
+    );
+
+    let _ = stop.send(());
+    handle.await.expect("the serve task must not panic");
+
+    // The control: the same frame, a listener serving the shared default.
+    let defaulted = dir.path().join("defaulted.sock");
+    let bound = bind(&defaulted).await.expect("bind the control socket");
+    let router = Arc::new(super::build_router(&state_with_indexes(1)));
+    let (stop_tx, stop_rx) = tokio::sync::oneshot::channel::<()>();
+    let control = tokio::spawn(async move {
+        trusty_common::uds::server::serve_until(
+            &bound.listener,
+            router,
+            trusty_common::uds::server::RpcServeOptions::default(),
+            async {
+                let _ = stop_rx.await;
+            },
+        )
+        .await;
+    });
+    for _ in 0..200 {
+        if trusty_common::uds::socket_is_serving(&defaulted, Duration::from_millis(50)).await {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    let refused: Result<serde_json::Value, _> =
+        trusty_common::uds::send_framed_request(&defaulted, &request, GENEROUS).await;
+    assert!(
+        refused.is_err(),
+        "the shared default must refuse the frame this surface accepts: {refused:?}"
+    );
+
+    let _ = stop_tx.send(());
+    control
+        .await
+        .expect("the control serve task must not panic");
+}
+
+/// Why: raising the LISTENER alone only moves which end refuses — the client
+/// applies its own budget to the response frame it reads, and
+/// [`trusty_common::uds::send_framed_request`] applies the 8 MiB shared default.
+/// A consumer moving onto these names therefore dials through
+/// `send_framed_request_capped` with [`MAX_FRAME_BYTES`], and this pins that:
+/// the same response is delivered under this surface's budget and refused as
+/// `FrameTooLarge` under the shared one.
+///
+/// `search.logs.tail` is the method because the log ring is the one surface a
+/// test can fill to a known size without indexing anything.
+/// Test: this function IS the test.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_client_budget_below_this_listeners_refuses_a_response_it_serves() {
+    let dir = TempDir::new().expect("tempdir");
+    let socket = dir.path().join("tail.sock");
+    let state = state_with_indexes(0);
+
+    // 1000 lines is the ring's capacity; 9 KiB each puts the response frame past
+    // the shared 8 MiB default and well under this surface's 64 MiB.
+    let line = "y".repeat(9 * 1024);
+    for _ in 0..trusty_common::log_buffer::DEFAULT_LOG_CAPACITY {
+        state.log_buffer.push(line.clone());
+    }
+    let (stop, handle) = spawn_listener(&socket, Arc::clone(&state)).await;
+
+    let request = serde_json::json!({
+        "jsonrpc": "2.0", "id": 1, "method": "search.logs.tail", "params": { "n": 1000 },
+    });
+
+    let served: serde_json::Value = trusty_common::uds::send_framed_request_capped(
+        &socket,
+        &request,
+        GENEROUS,
+        MAX_FRAME_BYTES,
+    )
+    .await
+    .expect("this surface's budget must carry the response");
+    assert_eq!(
+        served["result"]["lines"].as_array().map(Vec::len),
+        Some(trusty_common::log_buffer::DEFAULT_LOG_CAPACITY),
+        "the whole ring must come back: {served}"
+    );
+
+    let refused: Result<serde_json::Value, _> =
+        trusty_common::uds::send_framed_request(&socket, &request, GENEROUS).await;
+    match refused {
+        Err(trusty_common::uds::UdsRpcError::FrameTooLarge { limit, .. }) => assert_eq!(
+            limit,
+            trusty_common::uds::MAX_FRAME_BYTES,
+            "the refusal must name the CLIENT's budget, not the listener's"
+        ),
+        other => panic!("the shared default must refuse this response: {other:?}"),
+    }
+
+    let _ = stop.send(());
+    handle.await.expect("the serve task must not panic");
 }


### PR DESCRIPTION
Slice 5.5 of #6285: the last four HTTP routes with a named consumer get a socket
method, the frame budget matches on both ends, and the three MEDIUM findings from
review 5055473387 on PR #6383 are discharged.

Built on a WIP checkpoint (`aa03a9c25`) recovered from a paused session; three of
its tests were failing.

## Gap methods

`search.index.config.set`, `search.config.set`, `search.logs.tail`,
`search.registry.orphans` — each a thin adapter over the same `*_report` core its
axum handler runs, with a parity test per method and a state-checking failure arm
per write.

Two checkpoint defects fixed. `search.logs.tail` refused every default-shaped
call, because a derived `Deserialize` rejects the `params: null` the router hands
a handler for an absent `params`; it is registered as `Option<LogsTail>` now.
`config_set_over_the_socket_matches_the_http_body` expected a disabled per-index
cap to read back as `null` — `core::memguard::index_memory_limit_mb` resolves the
fallback to the global limit, and both transports answer the resolved figure, so
the test compares the two transports instead of pinning a value neither answers.

## Frame cap

The listener serves at 64 MiB, and `POST /indexes/{id}/graph` names that constant
rather than restating the literal. Raising the listener alone only moves which
end refuses, so the client end is pinned too: the same response is delivered under
`send_framed_request_capped(…, MAX_FRAME_BYTES)` and refused as `FrameTooLarge`
under the plain helper's 8 MiB default.

## Review findings

1. The orphan-window claim was true only for the status stream. The doc now
   separates the two streams and names the completed-reindex bound
   (`REINDEX_PROGRESS_TTL_SECS`, 60 s).
2. Added `the_query_deadline_has_exactly_one_call_site_on_the_rpc_surface`, which
   covers the non-interactive methods the deadline test's control set cannot
   stall.
3. Added `an_event_either_side_of_the_stream_opening_is_delivered_exactly_once`,
   and corrected both snapshot-then-subscribe comments: the race LOSES an event,
   it does not duplicate it. `ReindexProgress::push` buffers under its lock and
   then broadcasts, so an event broadcast between the snapshot and the subscribe
   reaches neither path. Both transports carry the defect identically, so parity
   holds; closing it changes a shipped SSE route and needs its own change — see
   "Follow-up" below.

## Test ladder — rung 3 (localized behavior inside one crate)

```
cargo fmt --check                                        # exit 0
cargo check -p trusty-search --all-targets               # exit 0
cargo clippy -p trusty-search --all-targets -- -D warnings  # exit 0
cargo test -p trusty-search --no-fail-fast               # 1902 passed; 1 failed; 1 ignored
cargo check --workspace                                  # exit 0
bash scripts/check_line_cap.sh                           # 0 violations
```

`cargo check --workspace` because `MAX_FRAME_BYTES` is now public API a consumer
must read.

The one failure is `core::indexer::tests::eviction_kg_paths::test_kg_refine_query_none_preserves_all_neighbours`,
a pre-existing flake in `core/`, which this branch does not touch:

```
$ git diff --name-only origin/main...HEAD -- crates/trusty-search/src/core/
$ cargo test -p trusty-search --lib eviction_kg_paths -- --test-threads=1
test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 1890 filtered out
```

New-and-changed targets, all green:

```
$ cargo test -p trusty-search --lib service::rpc:: --no-fail-fast
test result: ok. 72 passed; 0 failed; 0 ignored; 0 measured; 1832 filtered out

$ cargo test -p trusty-search --lib service::socket::tests --no-fail-fast
test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 1888 filtered out
```

## Follow-up, not in this PR

The replay/subscribe ordering can lose an event on both transports. Subscribing
before snapshotting would close the loss arm and can only duplicate, which is the
safe direction — but it changes the shipped SSE route's behaviour and the window
is not reproducible from a test, so it wants its own ticket rather than a rider
here.

Refs #6285

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
