### PR TITLE
refactor(trusty-installer): consume trusty-search over UDS (Refs #6285)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11610,7 +11610,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-installer"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-installer/Cargo.toml
+++ b/crates/trusty-installer/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "trusty-installer"
-# 0.12.1 (#6288): patch — 0.12.0 is published and this PR edits `src/**`,
-# dropping `SUPERVISOR_METRICS_PORT` and `LaunchctlPort::port_guard` now that the
-# supervisor binds no port. No out-of-workspace consumer of either.
-version = "0.13.0"
+# 0.13.1 (#6285): patch — 0.13.0 is published and this PR edits `src/**`,
+# moving the trusty-search health probe onto `search.health` over UDS. Additive
+# on the public surface (`probe_http::dual_transport`); `fixed_port_for` and
+# `uds_socket_for` keep their signatures.
+version = "0.13.1"
 edition = "2021"
 description = "Thin control plane for the claude-mpm stack: install, upgrade, restart, health, and config coordination across all trusty-* tools."
 readme = "README.md"

--- a/crates/trusty-installer/changelog.d/6285-uds-consumer.md
+++ b/crates/trusty-installer/changelog.d/6285-uds-consumer.md
@@ -1,0 +1,10 @@
+Changed
+
+- `tctl`'s health probe now asks trusty-search for `search.health` on its Unix
+  socket, the transport #6285 is moving the daemon onto, instead of reading
+  `GET /health` alone. Both legs are read while trusty-search serves both: no
+  published trusty-search binds a socket yet, so a socket-only probe would
+  report every installed daemon as `Refused` — the verdict that arms `launchctl
+  kickstart -k` — and hard-restart a healthy search mid-index-flush on every
+  `tctl install`. `probe_http::dual_transport` marks that window, and its arm is
+  deleted when the axum surface is (#6285)

--- a/crates/trusty-installer/src/commands/probe_http.rs
+++ b/crates/trusty-installer/src/commands/probe_http.rs
@@ -19,6 +19,8 @@
 //! trusty-analyze and trusty-memory serve a hardened Unix socket and are probed
 //! through [`uds_socket_for`] / [`classify_rpc_response`]; trusty-review has no
 //! transport at all since #6290 and is probed by presence ([`presence_only`]);
+//! trusty-search serves BOTH transports while #6285 retires its axum surface
+//! and is probed over both at once ([`dual_transport`]);
 //! everything else still answers `GET /health` over loopback. Three properties are load-bearing and each has a
 //! named regression test — remove any one of them and #4246 comes straight
 //! back:
@@ -110,6 +112,10 @@ const DEGRADED: &str = "degraded";
 pub fn fixed_port_for(binary: &str) -> Option<u16> {
     match binary {
         "trusty-console" => Some(7788),
+        // #6285: trusty-search now answers `search.health` on a socket too, but
+        // this row STAYS until the axum surface is deleted. It is what
+        // [`dual_transport`] reads to know a second leg exists, and an
+        // installed daemon older than the listener answers on nothing else.
         "trusty-search" => Some(7878),
         "trusty-mpm" => Some(7880),
         // #6277 / #6287 / #6286: NO trusty-review, trusty-analyze or
@@ -133,16 +139,18 @@ pub fn fixed_port_for(binary: &str) -> Option<u16> {
 ///
 /// What: the path from `trusty_common::daemon_socket_path`, the same call the
 /// daemon binds through, for members that serve UDS; `None` for every member
-/// still on HTTP. A member with a socket is probed ONLY over it — there is no
-/// second leg to reconcile, because there is no second transport, and no
-/// discovery file that could disagree with a derived path.
+/// still on HTTP. A member that has RETIRED HTTP is probed ONLY over the
+/// socket — there is no second leg to reconcile, because there is no second
+/// transport, and no discovery file that could disagree with a derived path.
+/// [`dual_transport`] is the exception, and states its own case.
 ///
 /// ADR-0035's console-side aggregator routing is deliberately NOT done here:
 /// its own open questions are unresolved, so this is a transport swap and
 /// nothing more.
 ///
 /// Test: `tests::uds_members_have_no_fixed_port`,
-/// `tests::probe_uds_reads_the_health_envelope_off_a_result_frame`.
+/// `tests::probe_uds_reads_the_health_envelope_off_a_result_frame`,
+/// `tests::uds_socket_for_matches_the_shared_entry_point`.
 /// Whether a member is started on demand rather than kept resident (#6350).
 ///
 /// Why this exists as its own predicate: `uds_socket_for` answers "which
@@ -164,9 +172,45 @@ pub fn uds_socket_for(binary: &str) -> Option<std::path::PathBuf> {
     match binary {
         // #6290: NO trusty-review row. It has no daemon and no socket — see
         // [`presence_only`].
-        "trusty-analyze" | "trusty-memory" => trusty_common::daemon_socket_path(binary).ok(),
+        // #6285: trusty-search binds this same path from
+        // `trusty_search::service::socket::socket_path`, which is
+        // `daemon_socket_path` under another name. It is the one member here
+        // that still serves HTTP as well — see [`dual_transport`].
+        "trusty-analyze" | "trusty-memory" | "trusty-search" => {
+            trusty_common::daemon_socket_path(binary).ok()
+        }
         _ => None,
     }
+}
+
+/// Whether a member answers on a socket AND on HTTP, so both legs must be read.
+///
+/// Why (#6285): every earlier migration deleted the daemon's axum surface in
+/// the PR that added its socket, so "has a socket" and "has no port" were the
+/// same fact. trusty-search breaks that pairing: its listener went up beside
+/// the axum server in #6367 and the HTTP surface is deleted several slices
+/// later. Probing only the socket in that window reads every INSTALLED
+/// trusty-search older than the listener as `Refused` — no published version
+/// binds one — and `Refused` is one of the two variants
+/// [`ProbeOutcome::is_confirmed_down`] accepts, so `verify_tail` would
+/// `launchctl kickstart -k` a healthy daemon on every `tctl install`. That is
+/// #4246, and on this member it lands as a SIGKILL mid-index-flush.
+///
+/// Probing only HTTP would be safe today and wrong tomorrow: it is the surface
+/// being retired, and the row that carries it disappears with it.
+///
+/// What: `true` for `trusty-search` only. Such a member's socket answer and its
+/// HTTP legs are reconciled through [`reconcile`], which already ranks an
+/// answer above a refusal — so whichever transport the installed binary serves
+/// is the one that decides the verdict. Deleting this arm is the LAST step of
+/// the retire program, once no daemon on the axum surface can still be
+/// installed; deleting it early re-ships #4246.
+///
+/// Test: `tests::search_is_probed_over_both_transports`,
+/// `tests::a_pre_socket_search_is_healthy_over_http_alone`,
+/// `tests::dual_transport_members_keep_a_fixed_port`.
+pub fn dual_transport(binary: &str) -> bool {
+    binary == "trusty-search"
 }
 
 /// Whether this member's health is a PRESENCE question, not a liveness one.
@@ -258,9 +302,10 @@ fn parse_version_line(stdout: &str) -> Option<String> {
 /// Duplicated as literals rather than imported: `trusty-installer` has no Cargo
 /// edge on either daemon, and adding one to share a `&str` would pull an
 /// LLM-pipeline crate and an analysis engine into `tctl`'s build.
-/// `trusty_review::service::METHOD_HEALTH` and
-/// `trusty_analyze::service::METHOD_HEALTH` are the definitions; each crate's
-/// `uds_consumer_contract` test is what keeps them equal.
+/// `trusty_analyze::service::METHOD_HEALTH`,
+/// `trusty_memory::transport::uds::METHOD_HEALTH` and
+/// `trusty_search::service::socket::METHOD_HEALTH` are the definitions; each
+/// daemon crate's `uds_consumer_contract` test is what keeps them equal.
 ///
 /// # Panics
 ///
@@ -274,6 +319,10 @@ fn uds_health_method(binary: &str) -> Option<&'static str> {
         // #6286: `trusty_memory::transport::uds::METHOD_HEALTH`. It is the only
         // folded method `tctl` needs, and the one trusty-console dials too.
         "trusty-memory" => Some("memory.health"),
+        // #6285: `trusty_search::service::socket::METHOD_HEALTH`. It reads the
+        // same `health_report()` the axum route does, so the two legs of a
+        // dual-transport probe cannot answer differently about the same daemon.
+        "trusty-search" => Some("search.health"),
         _ => None,
     }
 }
@@ -890,12 +939,18 @@ pub async fn probe_bases(
 /// probes them.
 /// #6277: a member with a Unix socket ([`uds_socket_for`]) is probed over it
 /// INSTEAD, and the HTTP legs are not attempted at all. There is nothing to
-/// reconcile: a UDS member has one transport, one derived path, and no
+/// reconcile: a retired-HTTP member has one transport, one derived path, and no
 /// discovery file, so a second leg could only contribute a false refusal.
+/// #6285: a [`dual_transport`] member is the one exception — its socket leg and
+/// its HTTP legs run concurrently and go through [`reconcile`], because during
+/// the retire window either transport may be the only one its installed binary
+/// serves.
 ///
 /// Test: `tests::probe_uses_http_addr_when_fixed_port_unknown`,
 /// `tests::probe_no_address_when_nothing_resolves`,
-/// `tests::probe_uds_reads_the_health_envelope_off_a_result_frame`.
+/// `tests::probe_uds_reads_the_health_envelope_off_a_result_frame`,
+/// `tests::search_is_probed_over_both_transports`,
+/// `tests::a_pre_socket_search_is_healthy_over_http_alone`.
 pub async fn probe_daemon_http(app: &str, binary: &str) -> ProbeOutcome {
     // #6290: checked FIRST. A per-invocation member has neither a socket nor an
     // address, so falling through would reach `NoAddress` — which renders
@@ -931,7 +986,28 @@ pub async fn probe_daemon_http(app: &str, binary: &str) -> ProbeOutcome {
                 };
             }
         }
-        return probe_socket(&socket, method).await;
+        // #6285: a member that has retired HTTP has exactly one transport and
+        // stops here. trusty-search has not retired it yet, so its socket
+        // answer is RECONCILED with the HTTP legs instead of replacing them —
+        // an installed daemon older than the listener answers only on 7878.
+        if !dual_transport(binary) {
+            return probe_socket(&socket, method).await;
+        }
+        let client = match build_probe_client() {
+            Ok(c) => c,
+            // A client that could not be built is a LOCAL failure and says
+            // nothing about the daemon, so the socket leg alone is still the
+            // honest answer — never a `ProbeFailed` that discards it.
+            Err(_) => return probe_socket(&socket, method).await,
+        };
+        let (recorded, fixed) = resolve_probe_bases(app, binary);
+        // Concurrently: a refusing leg costs a connect, but a wedged one costs
+        // REQUEST_TIMEOUT, and `verify_tail` polls every member repeatedly.
+        let (uds, http) = tokio::join!(
+            probe_socket(&socket, method),
+            probe_bases(&client, recorded, fixed)
+        );
+        return reconcile(vec![uds, http]);
     }
 
     let client = match build_probe_client() {

--- a/crates/trusty-installer/src/commands/probe_http_tests.rs
+++ b/crates/trusty-installer/src/commands/probe_http_tests.rs
@@ -528,6 +528,9 @@ async fn probe_ignores_http_proxy_env() {
 #[test]
 fn fixed_ports_match_port_assignments_doc() {
     assert_eq!(fixed_port_for("trusty-console"), Some(7788));
+    // #6285: trusty-search answers `search.health` on a socket now AND still
+    // serves 7878. The row goes when the axum surface does, not before — see
+    // `dual_transport_members_keep_a_fixed_port`.
     assert_eq!(fixed_port_for("trusty-search"), Some(7878));
     assert_eq!(fixed_port_for("trusty-mpm"), Some(7880));
     // Never guess: `tga` is not a daemon, and `trusty-installer` binds nothing.
@@ -633,12 +636,20 @@ fn version_line_parses_the_clap_shape() {
 /// confirmed-down into `launchctl kickstart -k` — so every `tctl install` would
 /// hard-restart a healthy daemon. That is #4246 verbatim, and it is why a
 /// transport swap and its consumers have to land together.
-/// What: asserts the two resolvers are mutually exclusive for each UDS member
-/// and that an HTTP member resolves no socket.
+/// What: asserts the two resolvers are mutually exclusive for each member that
+/// has RETIRED HTTP, and that a member still on HTTP alone resolves no socket.
+/// #6285 narrows the claim from "has a socket" to "has retired HTTP": those
+/// were the same fact until trusty-search served both, and
+/// `dual_transport_members_keep_a_fixed_port` owns that member.
 /// Test: This is the test.
 #[test]
 fn uds_members_have_no_fixed_port() {
     for binary in ["trusty-analyze", "trusty-memory"] {
+        assert!(
+            !super::dual_transport(binary),
+            "{binary} retired HTTP; if that changed, this test is asserting the \
+             wrong thing about it"
+        );
         assert_eq!(
             fixed_port_for(binary),
             None,
@@ -651,9 +662,53 @@ fn uds_members_have_no_fixed_port() {
         );
     }
     assert!(
-        uds_socket_for("trusty-search").is_none(),
-        "an HTTP member must not resolve a socket"
+        uds_socket_for("trusty-console").is_none(),
+        "an HTTP-only member must not resolve a socket"
     );
+}
+
+/// REGRESSION (#6285): trusty-search must resolve BOTH transports.
+///
+/// Why: this is the inverse of `uds_members_have_no_fixed_port`, and it is what
+/// keeps a healthy daemon from being hard-restarted during the retire window.
+/// No published trusty-search binds a socket — the listener landed in an
+/// unpublished version — so an installed daemon answers on 7878 and nowhere
+/// else. Dropping the port row the moment the socket arrived would read every
+/// one of them as `Refused`, and `Refused` authorises `launchctl kickstart -k`,
+/// which on this member is a SIGKILL mid-index-flush.
+/// What: asserts the port row, the socket, the health method and the
+/// `dual_transport` predicate all answer for trusty-search at once.
+/// Test: This is the test.
+#[test]
+fn dual_transport_members_keep_a_fixed_port() {
+    assert!(super::dual_transport("trusty-search"));
+    assert_eq!(
+        fixed_port_for("trusty-search"),
+        Some(7878),
+        "the HTTP leg must survive until the axum surface is deleted"
+    );
+    assert!(
+        uds_socket_for("trusty-search").is_some(),
+        "the socket leg is the transport this migration moves to"
+    );
+    assert_eq!(
+        super::uds_health_method("trusty-search"),
+        Some("search.health")
+    );
+    // Nothing else is dual: every earlier migration deleted its axum surface in
+    // the same PR that added its socket.
+    for single in [
+        "trusty-analyze",
+        "trusty-memory",
+        "trusty-console",
+        "trusty-mpm",
+    ] {
+        assert!(
+            !super::dual_transport(single),
+            "{single} serves one transport; a second leg could only contribute a \
+             false refusal"
+        );
+    }
 }
 
 /// REGRESSION (#6287): every member with a socket must also name a health
@@ -670,7 +725,7 @@ fn uds_members_have_no_fixed_port() {
 /// Test: This is the test.
 #[test]
 fn every_uds_member_has_a_health_method() {
-    for binary in ["trusty-analyze", "trusty-memory"] {
+    for binary in ["trusty-analyze", "trusty-memory", "trusty-search"] {
         let method = super::uds_health_method(binary)
             .unwrap_or_else(|| panic!("{binary} serves a socket but names no health method"));
         let domain = binary.trim_start_matches("trusty-");
@@ -681,9 +736,9 @@ fn every_uds_member_has_a_health_method() {
         );
     }
     assert_eq!(
-        super::uds_health_method("trusty-search"),
+        super::uds_health_method("trusty-console"),
         None,
-        "an HTTP member must not name a UDS method"
+        "an HTTP-only member must not name a UDS method"
     );
 }
 
@@ -695,7 +750,12 @@ fn every_uds_member_has_a_health_method() {
 /// Test: This is the test.
 #[test]
 fn uds_socket_for_matches_the_shared_entry_point() {
-    for binary in ["trusty-analyze", "trusty-memory"] {
+    // Both sides read `TRUSTY_DATA_DIR_OVERRIDE`, which a sibling test sets and
+    // clears. Without the lock the two calls straddle that window and disagree
+    // about a path neither side got wrong — a pre-existing flake (~1 run in 8
+    // on main) that the socket-binding tests below make more likely.
+    let _guard = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    for binary in ["trusty-analyze", "trusty-memory", "trusty-search"] {
         assert_eq!(
             uds_socket_for(binary),
             trusty_common::daemon_socket_path(binary).ok(),
@@ -821,6 +881,115 @@ async fn probe_uds_reports_refused_for_an_absent_socket() {
     assert!(
         outcome.is_confirmed_down(),
         "nothing accepted the connection, which IS the evidence a repair needs"
+    );
+}
+
+/// A short-path data dir for a test that has to BIND the derived socket.
+///
+/// Why not `test_support::stub_data_dir`: a `sun_path` is 104 bytes on macOS,
+/// and that helper's name carries the app, the pid and a nanosecond timestamp
+/// under `/var/folders/...`, which overruns the budget before
+/// `trusty-search/trusty-search.sock` is appended. `bind_hardened` would fail
+/// on the path length rather than on anything this test is about.
+///
+/// # Preconditions
+/// The caller MUST be holding [`ENV_TEST_LOCK`] — the override is process-global.
+/// # Postconditions
+/// Returns the created directory; teardown is `clear_data_dir_override`.
+/// Test: used by `search_is_probed_over_both_transports`.
+fn short_data_dir(tag: &str) -> std::path::PathBuf {
+    let dir = std::path::PathBuf::from(format!("/tmp/tctl-{tag}-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("create short data dir");
+    unsafe {
+        // SAFETY: serialised by ENV_TEST_LOCK; no concurrent env access in this crate's tests.
+        std::env::set_var(trusty_common::DATA_DIR_OVERRIDE_ENV, &dir);
+    }
+    dir
+}
+
+/// REGRESSION (#6285): a trusty-search that predates the socket must stay
+/// healthy.
+///
+/// Why: THE acceptance test for this migration. No published trusty-search
+/// binds a socket — the listener landed in an unpublished version — so on every
+/// machine that installs from crates.io today the socket leg answers `Refused`.
+/// `Refused` is one of the two variants `is_confirmed_down` accepts, and
+/// `verify_tail::needs_kickstart` turns a confirmed-down into `launchctl
+/// kickstart -k`, so a socket-only probe would hard-restart a healthy search on
+/// every `tctl install` — SIGKILL mid-index-flush, the harm CLAUDE.md names.
+/// What: no socket bound, a live stub on the recorded `http_addr`; asserts the
+/// reconciled verdict is `Serving`, renders `healthy`, and is NOT
+/// confirmed-down.
+/// Test: This is the test.
+#[tokio::test]
+#[allow(clippy::await_holding_lock)]
+async fn a_pre_socket_search_is_healthy_over_http_alone() {
+    let _guard = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let recorded = stub_once(OK_LINE, REAL_SEARCH).await;
+    let dir = crate::commands::test_support::stub_data_dir("trusty-search", &recorded);
+
+    let outcome = probe_daemon_http("trusty-search", "trusty-search").await;
+    crate::commands::test_support::clear_data_dir_override(&dir);
+
+    assert!(
+        matches!(outcome, ProbeOutcome::Serving { .. }),
+        "a search daemon serving only HTTP must be Serving; got {outcome:?}"
+    );
+    assert_eq!(outcome.health_string(), "healthy");
+    assert!(
+        !outcome.is_confirmed_down(),
+        "an unbound socket must NEVER feed needs_kickstart while the HTTP leg \
+         is Serving — that is #4246 on a daemon whose restart is a SIGKILL \
+         mid-index-flush"
+    );
+}
+
+/// REGRESSION (#6285): a trusty-search that serves the socket is read off it.
+///
+/// Why: the other half of the window. Once the listener ships, the socket is
+/// the transport this migration moves to, and a dead HTTP leg beside it must
+/// not drag the verdict down — the same precedence rule
+/// `probe_port_walked_daemon_is_healthy` pins for two HTTP legs, now applied
+/// across two transports.
+/// What: binds the derived socket, answers one `search.health` frame, and
+/// points `http_addr` at an address nothing listens on. Asserts `Serving` and
+/// not confirmed-down. On a machine with a real trusty-search on 7878 that leg
+/// answers too — the assertion is the safety property, which must hold either
+/// way.
+/// Test: This is the test.
+#[tokio::test]
+#[allow(clippy::await_holding_lock)]
+async fn search_is_probed_over_both_transports() {
+    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+    let _guard = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = short_data_dir("6285");
+    trusty_common::write_daemon_addr("trusty-search", &dead_addr()).expect("plant http_addr");
+    let socket = uds_socket_for("trusty-search").expect("search resolves a socket");
+    let _ = std::fs::remove_file(&socket);
+    let listener = trusty_common::uds::bind_hardened(&socket).expect("bind");
+
+    tokio::spawn(async move {
+        let Ok((mut conn, _)) = listener.accept().await else {
+            return;
+        };
+        let mut sink = Vec::new();
+        let _ = conn.read_to_end(&mut sink).await;
+        let reply = format!("{{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{REAL_SEARCH}}}\n");
+        let _ = conn.write_all(reply.as_bytes()).await;
+        let _ = conn.flush().await;
+    });
+
+    let outcome = probe_daemon_http("trusty-search", "trusty-search").await;
+    crate::commands::test_support::clear_data_dir_override(&dir);
+
+    assert!(
+        matches!(outcome, ProbeOutcome::Serving { .. }),
+        "a search daemon answering search.health must be Serving; got {outcome:?}"
+    );
+    assert!(
+        !outcome.is_confirmed_down(),
+        "a refused HTTP leg must not outrank a socket that answered"
     );
 }
 


### PR DESCRIPTION
Refs #6285. First PR of the consumer-move wave, per the consumer map in
https://github.com/bobmatnyc/trusty-tools/issues/6285#issuecomment-5458166173.

## What moved

The map's single trusty-installer row — `commands/probe_http.rs:113`, the fixed
7878 leg. `tctl`'s health probe now asks trusty-search for `search.health` on
the socket `trusty_common::daemon_socket_path` derives, through the same
`probe_socket` / `classify_rpc_response` path trusty-analyze and trusty-memory
already use. No new connect or resolve code: `uds_socket_for` gains a match arm,
`uds_health_method` gains the method name.

## Deviation from the map, and why

The map says move the row. This keeps the HTTP legs alongside the socket while
trusty-search serves both, and reconciles them.

Every earlier migration deleted the daemon's axum surface in the PR that added
its socket, so "has a socket" and "has no port" were the same fact. trusty-search
breaks that pairing: the listener went up beside the axum server in #6367 and
the surface is deleted several slices later. Published trusty-search is 0.49.5;
the listener landed in unpublished 0.49.6, so **no installed trusty-search binds
a socket today**. A socket-only probe reads every one of them as `Refused`,
`Refused` is one of the two variants `ProbeOutcome::is_confirmed_down` accepts,
and `verify_tail::needs_kickstart` turns that into `launchctl kickstart -k` — on
this member a SIGKILL mid-index-flush, on every `tctl install`. That is #4246,
the bug this module exists to fix.

`dual_transport(binary)` marks the window. Both legs run concurrently and go
through the existing `reconcile`, which already ranks an answer above a refusal,
so whichever transport the installed binary serves decides the verdict. The
`fixed_port_for` row for 7878 stays until the axum surface is deleted; that
deletion removes the `dual_transport` arm with it, and both are named in each
other's doc comments so neither is dropped alone.

Nothing else changes: a member that has retired HTTP still has one transport and
returns before the reconcile.

## Not in this PR

- **No `uds_consumer_contract` test for trusty-search.** Its #6287 shape is a
  combined-PR proof living in the *daemon* crate, dev-depending on every
  consumer. trusty-search's consumers land across ~8 PRs, and the crate is
  off-limits here (other slices in flight). It belongs to the surface-removal
  slice, which the map already lists it as the gate for.
- **No `docs/architecture/port-assignments.md` edit.** 7878 is still served; the
  map assigns that row to the surface-removal slice.

## Rung 4 (consumer of a shared surface)

```
cargo fmt --check                                              EXIT=0
cargo check -p trusty-installer                                EXIT=0
cargo clippy -p trusty-installer --all-targets -- -D warnings  EXIT=0
cargo test -p trusty-installer --no-fail-fast                  EXIT=0
cargo check --workspace                                        EXIT=0
```

`cargo test -p trusty-installer --no-fail-fast` — every target, `--no-fail-fast`
so one red target cannot hide the rest:

```
test result: ok. 689 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

Direct dependents of the touched public surface (`probe_daemon_http`,
`ProbeOutcome`), both of which drive it from their own contract tests:

```
cargo test -p trusty-analyze --test uds_consumer_contract --no-fail-fast
  test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
cargo test -p trusty-memory  --test uds_consumer_contract --no-fail-fast
  test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

`bash scripts/check_line_cap.sh` — `4261 tracked .rs file(s); 0 violations`.

### The regression test provably fails without the fix

With the `dual_transport` arm disabled, on an otherwise unchanged tree:

```
thread 'commands::probe_http::tests::a_pre_socket_search_is_healthy_over_http_alone'
panicked at crates/trusty-installer/src/commands/probe_http_tests.rs:929:5:
a search daemon serving only HTTP must be Serving; got Refused
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 692 filtered out
```

## Pre-existing flake fixed here

`uds_socket_for_matches_the_shared_entry_point` took no `ENV_TEST_LOCK` while
both of its calls read `TRUSTY_DATA_DIR_OVERRIDE`, so a sibling test setting and
clearing that variable made them disagree about a path neither side got wrong.
Reproduced on unmodified `origin/main` with this PR's changes stashed — 1 failure
in 8 runs:

```
test commands::probe_http::tests::uds_socket_for_matches_the_shared_entry_point ... FAILED
assertion `left == right` failed: trusty-analyze's probe must dial exactly what its daemon binds
  left: Some(".../tctl-test-empty-probe-noaddr-1701-.../trusty-analyze/trusty-analyze.sock")
 right: Some("/Users/…/Library/Application Support/trusty-analyze/trusty-analyze.sock")
```

Fixed by taking the lock; 10/10 green after. Reported separately for a ticketing
disposition rather than assumed to need one.

## Version

`trusty-installer` 0.13.0 → 0.13.1. 0.13.0 is published and this edits `src/**`.
Additive on the public surface (`probe_http::dual_transport`); `fixed_port_for`
and `uds_socket_for` keep their signatures.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
