### PR TITLE
refactor(trusty-audit): consume trusty-search over UDS (Refs #6285)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11304,7 +11304,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-audit"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11304,7 +11304,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-audit"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/trusty-analyze/tests/uds_consumer_contract.rs
+++ b/crates/trusty-analyze/tests/uds_consumer_contract.rs
@@ -263,7 +263,11 @@ async fn every_consumer_sees_a_live_uds_daemon_as_healthy() {
         PathBuf::from("trusty-search"),
         PathBuf::from("trusty-analyze"),
     );
-    tools.search_url = search_base.clone();
+    // #6285: trusty-audit reaches trusty-search over a socket now, and this
+    // case exercises its ANALYZE guard alone. Point the search half at a path
+    // nothing binds, so a future edit that made ensure_analyze dial it fails
+    // here rather than reaching whatever daemon the machine happens to run.
+    tools.search_socket = tmp.path().join("absent-search.sock");
     assert_eq!(
         tools.analyze_socket, socket,
         "trusty-audit must derive the same path"

--- a/crates/trusty-audit/Cargo.toml
+++ b/crates/trusty-audit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-audit"
-version = "0.11.2"
+version = "0.12.0"
 description = "Auditor client — installs its pinned audit tooling and drives an audit engagement on the recipient's own codebases."
 readme = "README.md"
 homepage = "https://github.com/bobmatnyc/trusty-tools"

--- a/crates/trusty-audit/Cargo.toml
+++ b/crates/trusty-audit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-audit"
-version = "0.11.1"
+version = "0.11.2"
 description = "Auditor client — installs its pinned audit tooling and drives an audit engagement on the recipient's own codebases."
 readme = "README.md"
 homepage = "https://github.com/bobmatnyc/trusty-tools"

--- a/crates/trusty-audit/changelog.d/6285-search-over-uds-breaking.md
+++ b/crates/trusty-audit/changelog.d/6285-search-over-uds-breaking.md
@@ -1,0 +1,4 @@
+Breaking
+- `grounding::Tools::search_url: String` is now `grounding::Tools::search_socket: PathBuf` — the trusty-search half of the pair names a Unix socket rather than a base URL.
+- `grounding::evidence::HttpSearch` is now `grounding::evidence::SocketSearch`, and its constructor takes a socket path and is infallible: there is no HTTP client left to fail to build.
+- `grounding::daemons::search_base_url` is removed. `grounding::daemons::search_socket` replaces it, forwarding to the new `grounding::search_rpc::search_socket`.

--- a/crates/trusty-audit/changelog.d/6285-search-over-uds.md
+++ b/crates/trusty-audit/changelog.d/6285-search-over-uds.md
@@ -1,4 +1,3 @@
 Changed
 - The three legs that reach `trusty-search` — the readiness probe, the index-root backstop, and the per-dimension evidence queries — now speak framed JSON-RPC over the daemon's Unix socket instead of loopback HTTP (`search.health`, `search.index.status`, `search.query`). The socket path is derived from `trusty_common::daemon_socket_path("trusty-search")`, the same call the daemon binds, so there is no address to discover and no `http_addr` file for a stale write to contradict. `TRUSTY_SEARCH_SOCKET` pins it explicitly for a rig that started its own daemon.
-- `Tools::search_url` is now `Tools::search_socket`, a path rather than a base URL.
 - A daemon that answers and refuses stays distinguishable from a daemon that is not there. Both remain fail-open at every leg, as before, but an error frame can no longer read as an empty result — a refused query is reported with the daemon's own code and message rather than as "no evidence found".

--- a/crates/trusty-audit/changelog.d/6285-search-over-uds.md
+++ b/crates/trusty-audit/changelog.d/6285-search-over-uds.md
@@ -1,0 +1,4 @@
+Changed
+- The three legs that reach `trusty-search` — the readiness probe, the index-root backstop, and the per-dimension evidence queries — now speak framed JSON-RPC over the daemon's Unix socket instead of loopback HTTP (`search.health`, `search.index.status`, `search.query`). The socket path is derived from `trusty_common::daemon_socket_path("trusty-search")`, the same call the daemon binds, so there is no address to discover and no `http_addr` file for a stale write to contradict. `TRUSTY_SEARCH_SOCKET` pins it explicitly for a rig that started its own daemon.
+- `Tools::search_url` is now `Tools::search_socket`, a path rather than a base URL.
+- A daemon that answers and refuses stays distinguishable from a daemon that is not there. Both remain fail-open at every leg, as before, but an error frame can no longer read as an empty result — a refused query is reported with the daemon's own code and message rather than as "no evidence found".

--- a/crates/trusty-audit/src/grounding.rs
+++ b/crates/trusty-audit/src/grounding.rs
@@ -61,6 +61,7 @@ pub mod hotspots;
 pub mod index;
 pub mod priority;
 pub mod quality;
+pub mod search_rpc;
 pub mod topology;
 
 #[cfg(test)]
@@ -68,25 +69,25 @@ mod grounding_tests;
 
 /// The two daemons this module drives: where they are, and what starts them.
 ///
-/// Why: every address and binary is a VALUE rather than something the functions
+/// Why: every socket and binary is a VALUE rather than something the functions
 /// read from the environment themselves. That is what lets the failure arms be
-/// tested against a dead port and a stub executable without any test touching
+/// tested against a dead socket and a stub executable without any test touching
 /// `std::env::set_var`, which is `unsafe` in edition 2024 and unsound under the
 /// parallel harness — the same split `tga::audit::AnalyzeGuard` takes.
-/// What: a binary and a base URL per daemon, plus the shared readiness budget.
+/// What: a binary and a socket per daemon, plus the shared readiness budget.
 /// Test: `super::grounding_tests`, which constructs one directly for every arm.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct Tools {
     /// The `trusty-search` binary to run — indexing, and starting the daemon.
     pub search: PathBuf,
-    /// Base address of the trusty-search daemon, e.g. `http://127.0.0.1:7878`.
-    pub search_url: String,
+    /// The trusty-search daemon's Unix socket (#6285, ADR-0032).
+    pub search_socket: PathBuf,
     /// The `trusty-analyze` binary to spawn when its daemon is absent.
     pub analyze: PathBuf,
     /// The trusty-analyze daemon's Unix socket (#6287, ADR-0032).
     pub analyze_socket: PathBuf,
-    /// Wall-clock budget for a freshly-spawned daemon to bind its port or socket.
+    /// Wall-clock budget for a freshly-spawned daemon to bind its socket.
     pub bind_timeout: Duration,
     /// Wall-clock budget for a listening daemon to report itself healthy.
     pub startup_timeout: Duration,
@@ -101,16 +102,16 @@ impl Tools {
     /// them in keeps the daemon this starts and the binary the sweep checked
     /// from ever being two different installs — the same reason
     /// `tga::audit::SearchGuard` resolves its binary once at the entry point.
-    /// What: the two paths as given, with the search URL resolved by
-    /// [`daemons::search_base_url`] and the analyze socket by
-    /// [`daemons::analyze_socket`] — #6287 retired the analyze daemon's HTTP
-    /// base URL, so that half of the pair is a Unix socket path now.
+    /// What: the two paths as given, with each daemon's socket resolved by
+    /// [`daemons::search_socket`] and [`daemons::analyze_socket`] — #6287
+    /// retired the analyze daemon's HTTP base URL and #6285 retired
+    /// trusty-search's, so both halves of the pair are socket paths now.
     /// Test: `super::grounding_tests::pinned_tools_keep_the_paths_they_were_given`.
     #[must_use]
     pub fn pinned(search: PathBuf, analyze: PathBuf) -> Self {
         Self {
             search,
-            search_url: daemons::search_base_url(),
+            search_socket: daemons::search_socket(),
             analyze,
             analyze_socket: daemons::analyze_socket(),
             bind_timeout: daemons::BIND_TIMEOUT,
@@ -254,7 +255,7 @@ pub async fn ground(
     // #6082: an index id is a checkout basename, so a same-named checkout
     // elsewhere on this machine is served under it. Both legs below read that
     // index, so a wrong root poisons the evidence AND the measurements.
-    if let Err(cause) = index::root_matches(&tools.search_url, &index_id, checkout).await {
+    if let Err(cause) = index::root_matches(&tools.search_socket, &index_id, checkout).await {
         return Grounding {
             index_id: Some(index_id),
             priorities: Vec::new(),
@@ -270,13 +271,8 @@ pub async fn ground(
     // #6082: the discovery leg. It asks the index where each DD dimension's
     // evidence is, so a selected file arrives already attributed to what it is
     // evidence FOR.
-    let discovery = match evidence::HttpSearch::new(&tools.search_url, &index_id, checkout) {
-        Ok(client) => evidence::discover(&client, instructions, caps).await,
-        Err(cause) => evidence::Discovery {
-            dimensions: Vec::new(),
-            failures: vec![cause],
-        },
-    };
+    let client = evidence::SocketSearch::new(&tools.search_socket, &index_id, checkout);
+    let discovery = evidence::discover(&client, instructions, caps).await;
     // #6082: judged BEFORE the manifest backfill below, because that backfill
     // finds `Cargo.toml` in every Rust repository and would therefore create a
     // dimension on a run where search answered nothing at all. Reading the

--- a/crates/trusty-audit/src/grounding/daemons.rs
+++ b/crates/trusty-audit/src/grounding/daemons.rs
@@ -14,10 +14,17 @@
 //!
 //! ## Nothing here is implemented twice
 //!
-//! Probing, detaching a child, and polling to readiness are
-//! [`trusty_common::daemon_guard`]'s, which is where they were promoted for
-//! exactly this kind of caller (#5670, #985). This module contributes the two
-//! addresses, the two argument vectors, and the failure text — nothing else.
+//! Detaching a child is [`trusty_common::daemon_guard`]'s, which is where it
+//! was promoted for exactly this kind of caller (#5670, #985). Dialling either
+//! daemon is [`super::search_rpc`] for one and [`analyze_is_healthy`] for the
+//! other. This module contributes the two socket paths, the two argument
+//! vectors, the readiness rule, and the failure text — nothing else.
+//!
+//! #6285: both daemons speak framed JSON-RPC over a Unix socket now, so the
+//! probe and the two-phase readiness wait are ONE implementation shared by
+//! both — see [`wait_socket_ready`]. The TCP half that trusty-search needed
+//! until this change (`probe_once`, an `accepting` connect, a base URL parsed
+//! for its authority) is gone with the listener it probed.
 //!
 //! Test: `daemon_tests`, and `super::grounding_tests` for the live arms.
 
@@ -26,9 +33,10 @@ use std::time::Duration;
 
 use std::time::Instant;
 
-use trusty_common::daemon_guard::{DaemonAddrLayout, probe_once, spawn_detached};
+use trusty_common::daemon_guard::spawn_detached;
 
 use super::Tools;
+use super::search_rpc;
 
 /// Environment variable naming the `trusty-search` binary.
 ///
@@ -56,6 +64,13 @@ pub const ENV_ANALYZE_BIN: &str = "TRUSTY_ANALYZE_BIN";
 /// configured.
 pub const ENV_ANALYZE_SOCKET: &str = "TRUSTY_ANALYZE_SOCKET";
 
+/// Environment variable overriding the trusty-search daemon's socket.
+///
+/// Re-exported from [`super::search_rpc`], which owns the whole trusty-search
+/// dial, so a caller reading this module finds both daemons' overrides in one
+/// place. See [`search_rpc::ENV_SEARCH_SOCKET`] for why the variable exists.
+pub use super::search_rpc::ENV_SEARCH_SOCKET;
+
 /// The method `trusty-analyze` answers a health probe on.
 ///
 /// Copied for the same reason [`ENV_ANALYZE_SOCKET`] is.
@@ -64,35 +79,38 @@ pub const ENV_ANALYZE_SOCKET: &str = "TRUSTY_ANALYZE_SOCKET";
 /// driving [`ensure_analyze`] against a live router rather than a stub.
 const ANALYZE_HEALTH_METHOD: &str = "analyze.health";
 
-/// Wall-clock budget for a freshly-spawned daemon to answer `/health`.
+/// Wall-clock budget for a freshly-spawned daemon to report itself healthy.
 ///
-/// Why 60s rather than `daemon_guard::DEFAULT_STARTUP_TIMEOUT`'s 30s: the HTTP
-/// port binds in about a second, but a first run on a recipient's machine with
-/// no model cache spends 15–30s in ONNX load before trusty-search answers, and
+/// Why 60s rather than `daemon_guard::DEFAULT_STARTUP_TIMEOUT`'s 30s: the socket
+/// binds in about a second, but a first run on a recipient's machine with no
+/// model cache spends 15–30s in ONNX load before trusty-search answers, and
 /// giving up at 30s would turn a slow cold start into an unassessed engagement.
 /// Matches `trusty-search`'s own guard and `tga::audit::SEARCH_STARTUP_TIMEOUT`.
 pub const STARTUP_TIMEOUT: Duration = Duration::from_secs(60);
 
-/// How long a freshly-spawned daemon has to BIND its port before it is given up
-/// on. See [`wait_ready`] for why this is separate from [`STARTUP_TIMEOUT`].
+/// How long a freshly-spawned daemon has to BIND its socket before it is given
+/// up on. See [`wait_socket_ready`] for why this is separate from
+/// [`STARTUP_TIMEOUT`].
 pub const BIND_TIMEOUT: Duration = Duration::from_secs(3);
 
-/// How long a single TCP connection attempt may take.
+/// How long a single socket connection attempt may take.
 ///
-/// Loopback, so a reachable port answers in microseconds and an unreachable one
-/// is refused immediately. This bounds the third case — a host that silently
-/// drops packets — rather than the two that matter.
+/// A reachable socket answers in microseconds and an absent one is refused
+/// immediately. This bounds the third case — a daemon that accepts and then
+/// stops reading — rather than the two that matter.
 const CONNECT_TIMEOUT: Duration = Duration::from_millis(200);
 
-/// The trusty-search daemon's address, as every client of it resolves one.
+/// The trusty-search daemon's socket, as every client of it resolves one.
 ///
-/// Why: trusty-search binds an OS-assigned port and records it in its own
-/// discovery files, so a hard-coded `127.0.0.1:7878` would miss an auto-ported
-/// daemon and every `TRUSTY_DATA_DIR`-isolated one. [`DaemonAddrLayout`] is that
-/// resolution, promoted into `trusty-common` for sibling callers (#5670).
+/// #6285: the discovery files this used to read described a TCP listener that
+/// no longer exists. Both the daemon and this caller now DERIVE the path from
+/// [`trusty_common::daemon_socket_path`], so there is nothing published between
+/// them for a stale write to contradict. A thin forward to
+/// [`search_rpc::search_socket`], kept named here because `Tools::pinned` and
+/// the tests read better against a per-daemon resolver.
 #[must_use]
-pub fn search_base_url() -> String {
-    DaemonAddrLayout::TRUSTY_SEARCH.resolve_base_url()
+pub fn search_socket() -> PathBuf {
+    search_rpc::search_socket()
 }
 
 /// The trusty-analyze daemon's socket: [`ENV_ANALYZE_SOCKET`], else the derived
@@ -153,9 +171,31 @@ async fn analyze_is_healthy(socket: &Path, timeout: Duration) -> bool {
         == Some("ok")
 }
 
-/// The health endpoint for a base address, tolerating a trailing slash.
-fn health_url(base: &str) -> String {
-    format!("{}/health", base.trim_end_matches('/'))
+/// Is the trusty-search daemon at `socket` answering?
+///
+/// Why any result frame counts: `GET /health` on trusty-search answered 200
+/// unconditionally — `health_handler` returns a bare `Json<HealthResponse>`
+/// with no status code of its own — so `probe_once` treated a degraded daemon
+/// as reachable. Reading `status` here would newly respawn a daemon that is up
+/// and warning about one index, which is a behaviour change #6285 does not owe.
+/// The analyze probe reads `status` because its HTTP route really did answer
+/// 503 (see [`analyze_is_healthy`]).
+///
+/// What: one `search.health` frame; `true` only for a result frame. A dial
+/// failure and an error frame are both `false`, so an RPC error can never
+/// read as a healthy daemon.
+/// Test: `super::grounding_tests::{a_search_daemon_that_will_not_start_is_a_named_gap,
+/// a_reachable_search_daemon_is_not_restarted,
+/// a_search_daemon_that_refuses_health_is_not_healthy}`.
+async fn search_is_healthy(socket: &Path, timeout: Duration) -> bool {
+    search_rpc::call(
+        socket,
+        search_rpc::METHOD_HEALTH,
+        serde_json::Value::Null,
+        timeout,
+    )
+    .await
+    .is_ok()
 }
 
 /// The argument vector `trusty-search` is started with.
@@ -184,23 +224,25 @@ fn analyze_serve_args() -> [&'static str; 1] {
 ///
 /// # Errors
 ///
-/// One line, safe to show the recipient, naming the address and the binary, when
+/// One line, safe to show the recipient, naming the socket and the binary, when
 /// the binary will not spawn or the daemon never becomes ready. The caller turns
 /// it into a gap; nothing here fails a run.
 ///
 /// Test: `super::grounding_tests::{a_search_daemon_that_will_not_start_is_a_named_gap,
-/// a_reachable_search_daemon_is_not_restarted}`.
+/// a_reachable_search_daemon_is_not_restarted,
+/// a_daemon_that_binds_but_never_answers_is_a_named_gap}`.
 pub async fn ensure_search(tools: &Tools) -> Result<(), String> {
-    let health = health_url(&tools.search_url);
-    if probe_once(&health).await {
+    let socket = &tools.search_socket;
+    let at = socket.display().to_string();
+    if search_is_healthy(socket, CONNECT_TIMEOUT).await {
         return Ok(());
     }
     let binary = tools.search.display().to_string();
     spawn_detached(&tools.search, &search_start_args())
-        .map_err(|e| refusal("trusty-search", &tools.search_url, &binary, &e.to_string()))?;
-    wait_ready(&health, &tools.search_url, tools)
+        .map_err(|e| refusal("trusty-search", &at, &binary, &e.to_string()))?;
+    wait_socket_ready(socket, tools, || search_is_healthy(socket, CONNECT_TIMEOUT))
         .await
-        .map_err(|cause| refusal("trusty-search", &tools.search_url, &binary, &cause))
+        .map_err(|cause| refusal("trusty-search", &at, &binary, &cause))
 }
 
 /// Ensure the trusty-analyze daemon answers, starting it if it does not.
@@ -211,12 +253,8 @@ pub async fn ensure_search(tools: &Tools) -> Result<(), String> {
 /// reports `status: "degraded"`, so it is reported here rather than surfacing
 /// later as an empty hotspot list — see [`analyze_is_healthy`].
 ///
-/// #6287: the two-phase wait [`wait_ready`] performs for trusty-search does not
-/// apply here. Its first phase separates "the process is not there" from "the
-/// process is there and still warming up" by asking whether anything ACCEPTS a
-/// TCP connection, which is a weaker question than a health probe. A Unix socket
-/// answers that same question through `socket_is_serving`, so the two phases are
-/// kept — one budget for the bind, then the full startup budget for health.
+/// The readiness wait is [`wait_socket_ready`], shared with [`ensure_search`]
+/// since #6285.
 ///
 /// Test: `super::grounding_tests::an_analyze_daemon_that_will_not_start_is_a_named_gap`.
 pub async fn ensure_analyze(tools: &Tools) -> Result<(), String> {
@@ -227,26 +265,47 @@ pub async fn ensure_analyze(tools: &Tools) -> Result<(), String> {
     let binary = tools.analyze.display().to_string();
     spawn_detached(&tools.analyze, &analyze_serve_args())
         .map_err(|e| refusal("trusty-analyze", &at, &binary, &e.to_string()))?;
-    wait_analyze_ready(tools)
-        .await
-        .map_err(|cause| refusal("trusty-analyze", &at, &binary, &cause))
+    wait_socket_ready(&tools.analyze_socket, tools, || {
+        analyze_is_healthy(&tools.analyze_socket, CONNECT_TIMEOUT)
+    })
+    .await
+    .map_err(|cause| refusal("trusty-analyze", &at, &binary, &cause))
 }
 
-/// [`wait_ready`]'s UDS counterpart, with the same two budgets (#6287).
+/// Wait for a daemon this call just spawned, in two phases.
 ///
-/// Why the phases survive the transport change: a binary that dies immediately —
-/// which is what `trusty-analyze serve` does when trusty-search is unreachable —
-/// must cost the short bind budget, not the full 60-second startup one. In an
-/// unattended engagement that difference is a minute per repository spent
-/// waiting for a process that is already gone.
+/// Why not `trusty_common::daemon_guard::spin_until_ready`: it applies ONE
+/// budget to both of the things that can be slow, and they are slow for
+/// unrelated reasons. Binding the socket takes about a second whatever the
+/// machine; answering a health call afterwards can take 15-30s on a first run
+/// that has to load ONNX weights. Under one budget a binary that dies
+/// immediately — which is exactly what `trusty-analyze serve` does when
+/// trusty-search is unreachable — costs the FULL startup budget before anything
+/// is reported. In an unattended engagement that is 60 seconds per repository
+/// spent waiting for a process that is already gone.
 ///
-/// What: the socket must accept a connection within [`Tools::bind_timeout`], and
-/// only then does the health verdict get the full [`Tools::startup_timeout`].
-async fn wait_analyze_ready(tools: &Tools) -> Result<(), String> {
-    let socket = &tools.analyze_socket;
+/// #6285: one loop for both daemons. Until this change trusty-search took the
+/// TCP form of it (a `connect` for phase one, `probe_once` for phase two) and
+/// trusty-analyze the UDS form, and the two drifted apart by construction.
+/// Both dial a socket now, so the phases are a single implementation and
+/// `healthy` is the only thing that varies.
+///
+/// What: the socket must accept a connection within [`Tools::bind_timeout`],
+/// and only then does `healthy` get the full [`Tools::startup_timeout`].
+/// `spin_until_ready`'s spinner is dropped with it, which this crate wants
+/// anyway — it writes to the same stderr the sweep's progress relay is reading.
+///
+/// Test: `super::grounding_tests::{a_search_daemon_that_will_not_start_is_a_named_gap,
+/// a_daemon_that_binds_but_never_answers_is_a_named_gap,
+/// an_analyze_daemon_that_will_not_start_is_a_named_gap}`.
+async fn wait_socket_ready<F, Fut>(socket: &Path, tools: &Tools, healthy: F) -> Result<(), String>
+where
+    F: Fn() -> Fut,
+    Fut: std::future::Future<Output = bool>,
+{
     let bound_by = Instant::now() + tools.bind_timeout;
     loop {
-        if analyze_is_healthy(socket, CONNECT_TIMEOUT).await {
+        if healthy().await {
             return Ok(());
         }
         if trusty_common::uds::socket_is_serving(socket, CONNECT_TIMEOUT).await {
@@ -263,7 +322,7 @@ async fn wait_analyze_ready(tools: &Tools) -> Result<(), String> {
     let ready_by = Instant::now() + tools.startup_timeout;
     loop {
         tokio::time::sleep(tools.poll_interval).await;
-        if analyze_is_healthy(socket, CONNECT_TIMEOUT).await {
+        if healthy().await {
             return Ok(());
         }
         if Instant::now() >= ready_by {
@@ -275,92 +334,13 @@ async fn wait_analyze_ready(tools: &Tools) -> Result<(), String> {
     }
 }
 
-/// Wait for a daemon this call just spawned, in two phases.
-///
-/// Why not `trusty_common::daemon_guard::spin_until_ready`: it applies ONE
-/// budget to both of the things that can be slow, and they are slow for
-/// unrelated reasons. Binding the port takes about a second whatever the
-/// machine; answering `/health` afterwards can take 15–30s on a first run that
-/// has to load ONNX weights. Under one budget a binary that dies immediately —
-/// which is exactly what `trusty-analyze serve` does when trusty-search is
-/// unreachable — costs the FULL startup budget before anything is reported. In
-/// an unattended engagement that is 60 seconds per repository spent waiting for
-/// a process that is already gone.
-///
-/// What: the port must accept a TCP connection within
-/// [`Tools::bind_timeout`], and only then does `/health` get the full
-/// [`Tools::startup_timeout`]. `spin_until_ready`'s spinner is dropped with it,
-/// which this crate wants anyway — it writes to the same stderr the sweep's
-/// progress relay is reading.
-/// Test: `super::grounding_tests::{a_search_daemon_that_will_not_start_is_a_named_gap,
-/// a_daemon_that_binds_but_never_answers_is_a_named_gap}`.
-async fn wait_ready(health: &str, url: &str, tools: &Tools) -> Result<(), String> {
-    let bound_by = Instant::now() + tools.bind_timeout;
-    loop {
-        if probe_once(health).await {
-            return Ok(());
-        }
-        if accepting(url).await {
-            break;
-        }
-        if Instant::now() >= bound_by {
-            return Err(format!(
-                "nothing was listening there {}s after it was started",
-                tools.bind_timeout.as_secs_f32()
-            ));
-        }
-        tokio::time::sleep(tools.poll_interval).await;
-    }
-    let ready_by = Instant::now() + tools.startup_timeout;
-    loop {
-        tokio::time::sleep(tools.poll_interval).await;
-        if probe_once(health).await {
-            return Ok(());
-        }
-        if Instant::now() >= ready_by {
-            return Err(format!(
-                "it is listening but did not answer /health within {}s",
-                tools.startup_timeout.as_secs_f32()
-            ));
-        }
-    }
-}
-
-/// Whether anything accepts a TCP connection at this address.
-///
-/// Deliberately weaker than a health probe: it separates "the process is not
-/// there" from "the process is there and still warming up", which is the
-/// distinction [`wait_ready`]'s two budgets rest on.
-async fn accepting(url: &str) -> bool {
-    let Some(authority) = authority_of(url) else {
-        return false;
-    };
-    matches!(
-        tokio::time::timeout(
-            CONNECT_TIMEOUT,
-            tokio::net::TcpStream::connect(authority.as_str()),
-        )
-        .await,
-        Ok(Ok(_))
-    )
-}
-
-/// The `host:port` of a base URL, or `None` when it names no host.
-fn authority_of(url: &str) -> Option<String> {
-    let rest = url
-        .trim_start_matches("http://")
-        .trim_start_matches("https://");
-    let authority = rest.split('/').next().unwrap_or_default();
-    (!authority.is_empty() && authority.contains(':')).then(|| authority.to_owned())
-}
-
 /// One unavailable daemon, rendered as one line the recipient can act on.
 ///
 /// Why the cause is quoted rather than replaced: the remedies differ — a binary
 /// that is not installed needs an install, a daemon that will not stay up needs
 /// its own log — and only the spawn or the readiness poll knows which fired.
-fn refusal(service: &str, url: &str, binary: &str, cause: &str) -> String {
-    format!("{service} is not reachable at {url} and `{binary}` could not start it ({cause})")
+fn refusal(service: &str, at: &str, binary: &str, cause: &str) -> String {
+    format!("{service} is not reachable at {at} and `{binary}` could not start it ({cause})")
 }
 
 #[cfg(test)]
@@ -396,10 +376,18 @@ mod daemon_tests {
         );
     }
 
+    /// #6285: the search leg's half of the same contract. The daemon derives
+    /// its socket from `daemon_socket_path("trusty-search")`
+    /// (`trusty_search::service::socket::socket_path`), so a resolver that
+    /// disagreed would dial a path nothing binds.
     #[test]
-    fn health_is_one_slash_whatever_the_base_looks_like() {
-        assert_eq!(health_url("http://x:1"), "http://x:1/health");
-        assert_eq!(health_url("http://x:1/"), "http://x:1/health");
+    fn the_search_socket_is_the_path_the_daemon_binds() {
+        assert_eq!(search_rpc::ENV_SEARCH_SOCKET, "TRUSTY_SEARCH_SOCKET");
+        assert_eq!(
+            search_socket(),
+            trusty_common::daemon_socket_path("trusty-search").unwrap_or_default(),
+            "the default must be the same path the daemon binds"
+        );
     }
 
     /// `--foreground` is the flag that keeps the spawned process and the daemon
@@ -421,12 +409,12 @@ mod daemon_tests {
     fn a_refusal_names_the_service_the_address_the_binary_and_the_cause() {
         let line = refusal(
             "trusty-analyze",
-            "http://127.0.0.1:7879",
+            "/w/sockets/trusty-analyze.sock",
             "/w/tools/trusty-analyze",
             "no such file",
         );
         assert!(line.contains("trusty-analyze"), "{line}");
-        assert!(line.contains("http://127.0.0.1:7879"), "{line}");
+        assert!(line.contains("/w/sockets/trusty-analyze.sock"), "{line}");
         assert!(line.contains("/w/tools/trusty-analyze"), "{line}");
         assert!(line.contains("no such file"), "{line}");
         assert_eq!(line.lines().count(), 1, "must stay one line: {line}");

--- a/crates/trusty-audit/src/grounding/daemons.rs
+++ b/crates/trusty-audit/src/grounding/daemons.rs
@@ -186,7 +186,7 @@ async fn analyze_is_healthy(socket: &Path, timeout: Duration) -> bool {
 /// read as a healthy daemon.
 /// Test: `super::grounding_tests::{a_search_daemon_that_will_not_start_is_a_named_gap,
 /// a_reachable_search_daemon_is_not_restarted,
-/// a_search_daemon_that_refuses_health_is_not_healthy}`.
+/// a_daemon_that_binds_but_never_answers_is_a_named_gap}`.
 async fn search_is_healthy(socket: &Path, timeout: Duration) -> bool {
     search_rpc::call(
         socket,

--- a/crates/trusty-audit/src/grounding/evidence.rs
+++ b/crates/trusty-audit/src/grounding/evidence.rs
@@ -12,11 +12,12 @@
 //! handling" instead of guessed at.
 //!
 //! What: one query set per DD dimension (plus queries derived from the
-//! analyst's own instructions), each run against `POST
-//! /indexes/{id}/search`, each hit collapsed to a repo-relative file that
-//! remembers WHICH query found it. [`blend`] then interleaves the dimensions
-//! round-robin with the complexity ranking, so the budget is spent across the
-//! dimensions rather than down one of them.
+//! analyst's own instructions), each run against `search.query` on the
+//! daemon's socket (#6285 — the method `POST /indexes/{id}/search` became),
+//! each hit collapsed to a repo-relative file that remembers WHICH query found
+//! it. [`blend`] then interleaves the dimensions round-robin with the
+//! complexity ranking, so the budget is spent across the dimensions rather than
+//! down one of them.
 //!
 //! The dimension names are trusty-review's, spelled identically
 //! (`report::investigate::select::DIMENSIONS`). That is what lets the rendered
@@ -30,7 +31,7 @@
 //! Test: `super::evidence_tests`.
 
 use std::future::Future;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use serde::Deserialize;
@@ -38,6 +39,7 @@ use serde::Deserialize;
 use super::hotspots::RankedFile;
 use super::priority::Priority;
 use super::quality;
+use super::search_rpc;
 
 /// Chunk hits requested per query at [`MIN_FILES_PER_DIMENSION`].
 const MIN_TOP_K: usize = 12;
@@ -269,7 +271,7 @@ pub struct FileEvidence {
 /// an `Err` is a reason string, never a panic, because every caller here is
 /// fail-open. The request size is a PARAMETER rather than a constant so it
 /// scales with [`Caps`] — a per-dimension cap of 17 files starves on a top-12.
-/// Test: `super::evidence_tests` drives `StubSearch`; [`HttpSearch`] is the
+/// Test: `super::evidence_tests` drives `StubSearch`; [`SocketSearch`] is the
 /// production implementation.
 pub trait SearchClient {
     /// Run one query, returning its chunk hits (possibly none).
@@ -280,66 +282,78 @@ pub trait SearchClient {
     ) -> impl Future<Output = Result<Vec<Hit>, String>> + Send;
 }
 
-/// The trusty-search daemon, over its loopback HTTP surface.
+/// The trusty-search daemon, over its hardened Unix socket (#6285).
+///
+/// Why it holds a path rather than a client: the socket is dialled per call by
+/// [`search_rpc::call_capped`], so there is no connection pool to build once and
+/// no fallible constructor — a discovery pass that could not reach the daemon
+/// now reports that per query, where the reason names the query that lost its
+/// evidence.
+/// What: the socket, the index the queries run against, and the checkout root
+/// hits are made relative to.
+/// Test: `super::evidence_tests::{the_query_names_the_index_and_pins_graph_expansion,
+/// a_dead_daemon_is_a_reason_not_a_panic, a_refused_query_is_a_reason}`.
 #[derive(Debug, Clone)]
-pub struct HttpSearch {
-    client: reqwest::Client,
-    url: String,
+pub struct SocketSearch {
+    socket: PathBuf,
+    index_id: String,
     root: String,
 }
 
-impl HttpSearch {
+impl SocketSearch {
     /// A client for one index, resolving hits against `checkout`.
-    ///
-    /// The HTTP client is built ONCE here rather than per query: a discovery
-    /// pass runs a dozen-plus queries, and each build allocates a fresh
-    /// connection pool that the next query then throws away.
-    ///
-    /// # Errors
-    ///
-    /// One line when no HTTP client can be built, which the caller turns into a
-    /// gap — the discovery leg is fail-open like every other.
-    pub fn new(base: &str, index_id: &str, checkout: &Path) -> Result<Self, String> {
-        let base = base.trim_end_matches('/');
-        let client = trusty_common::http_client::loopback_client_builder()
-            .timeout(REQUEST_BUDGET)
-            .build()
-            .map_err(|e| format!("no HTTP client could be built for {base} ({e})"))?;
-        Ok(Self {
-            client,
-            url: format!("{base}/indexes/{index_id}/search"),
+    #[must_use]
+    pub fn new(socket: &Path, index_id: &str, checkout: &Path) -> Self {
+        Self {
+            socket: socket.to_path_buf(),
+            index_id: index_id.to_owned(),
             root: checkout.to_string_lossy().replace('\\', "/"),
+        }
+    }
+
+    /// The `params` one query sends, split out so a test can read it without a
+    /// daemon.
+    ///
+    /// `body` is byte-for-byte the JSON the HTTP route took, which is what the
+    /// socket's `IndexBody` shape preserves — so a refusal the daemon spells
+    /// for a malformed query is the same refusal on either transport.
+    fn params(&self, query: &str, top_k: usize) -> serde_json::Value {
+        serde_json::json!({
+            "index_id": self.index_id,
+            "body": {
+                "text": query,
+                "top_k": top_k,
+                "compact": true,
+                // #6082: `expand_graph` already defaults true on the daemon, so
+                // this pins the behaviour the evidence leg DEPENDS on rather
+                // than inheriting it — a future default flip would otherwise
+                // silently drop relationship evidence from every audit.
+                "expand_graph": true,
+            },
         })
     }
 }
 
-impl SearchClient for HttpSearch {
+impl SearchClient for SocketSearch {
     async fn hits(&self, query: &str, top_k: usize) -> Result<Vec<Hit>, String> {
-        let url = &self.url;
-        let response = self
-            .client
-            .post(url)
-            // #6082: `expand_graph` already defaults true on the daemon, so this
-            // pins the behaviour the evidence leg DEPENDS on rather than
-            // inheriting it — a future default flip would otherwise silently
-            // drop relationship evidence from every audit.
-            .json(&serde_json::json!({
-                "text": query,
-                "top_k": top_k,
-                "compact": true,
-                "expand_graph": true,
-            }))
-            .send()
-            .await
-            .map_err(|e| format!("trusty-search did not answer {url} ({e})"))?;
-        let status = response.status();
-        if !status.is_success() {
-            return Err(format!("trusty-search answered {status} for {url}"));
-        }
-        let envelope: SearchEnvelope = response
-            .json()
-            .await
-            .map_err(|e| format!("trusty-search answered {url} with an unreadable body ({e})"))?;
+        // #6285: the raised budget, because a query response is the one bulk
+        // payload this crate moves — see `search_rpc::QUERY_MAX_FRAME_BYTES`.
+        let result = search_rpc::call_capped(
+            &self.socket,
+            search_rpc::METHOD_QUERY,
+            self.params(query, top_k),
+            REQUEST_BUDGET,
+            search_rpc::QUERY_MAX_FRAME_BYTES,
+        )
+        .await
+        .map_err(|e| e.to_string())?;
+        let envelope: SearchEnvelope = serde_json::from_value(result).map_err(|e| {
+            format!(
+                "trusty-search answered {} on {} with an unreadable body ({e})",
+                search_rpc::METHOD_QUERY,
+                self.socket.display()
+            )
+        })?;
         Ok(envelope.into_hits(&self.root))
     }
 }

--- a/crates/trusty-audit/src/grounding/evidence_tests.rs
+++ b/crates/trusty-audit/src/grounding/evidence_tests.rs
@@ -543,22 +543,31 @@ fn the_daemons_search_envelope_parses_to_relative_paths() {
     assert_eq!(hits[0].start_line, 12);
 }
 
-/// The endpoint names the index the repository was indexed under.
+/// #6285: the params name the index the repository was indexed under, and the
+/// query half stays byte-for-byte the JSON the HTTP route took — which is what
+/// keeps a malformed-query refusal identical on either transport.
 #[test]
-fn the_query_url_names_the_index() {
-    let client = HttpSearch::new(
-        "http://127.0.0.1:7878/",
+fn the_query_names_the_index_and_pins_graph_expansion() {
+    let client = SocketSearch::new(
+        std::path::Path::new("/w/sockets/trusty-search.sock"),
         "acme-api",
         std::path::Path::new("/w/repos/acme-api"),
-    )
-    .expect("a client is built");
-    assert_eq!(client.url, "http://127.0.0.1:7878/indexes/acme-api/search");
+    );
+    let params = client.params("credential handling", 12);
+    assert_eq!(params["index_id"], "acme-api");
+    assert_eq!(params["body"]["text"], "credential handling");
+    assert_eq!(params["body"]["top_k"], 12);
+    assert_eq!(params["body"]["compact"], true);
+    assert_eq!(
+        params["body"]["expand_graph"], true,
+        "#6082: a default flip must not silently drop relationship evidence"
+    );
 }
 
 /// #6082: the whole discovery pass, against the score scale the daemon really
 /// answers on.
 ///
-/// Why this is the regression: `POST /indexes/{id}/search` fuses its lanes with
+/// Why this is the regression: `search.query` fuses its lanes with
 /// Reciprocal Rank Fusion, so a hit's score is `Σ weight / (60 + rank)` and can
 /// never exceed `1/61 ≈ 0.0164`. The floor this replaced was an absolute `0.15`,
 /// which no hit of any query could ever clear — so `discover` returned an empty
@@ -614,13 +623,50 @@ fn rrf_scored_hits_still_become_evidence() {
 /// A daemon that is not listening is a reason, never a panic.
 #[test]
 fn a_dead_daemon_is_a_reason_not_a_panic() {
-    // Port 1 is never a trusty-search daemon.
-    let client = HttpSearch::new(
-        "http://127.0.0.1:1",
+    let dir = tempfile::tempdir().expect("tempdir");
+    // Nothing has ever bound this socket.
+    let client = SocketSearch::new(
+        &dir.path().join("absent.sock"),
         "acme-api",
         std::path::Path::new("/w/repos/acme-api"),
-    )
-    .expect("a client is built");
+    );
     let err = block_on(client.hits("credential handling", MIN_TOP_K)).expect_err("must fail");
     assert!(err.contains("trusty-search did not answer"), "{err}");
+}
+
+/// #6285: the fail-open arm that matters most here. A daemon that ANSWERS and
+/// refuses must reach the caller as a failure carrying the daemon's own words —
+/// an error frame read as an empty result would report "no evidence found" for
+/// a query the daemon never ran.
+#[tokio::test]
+async fn a_refused_query_is_a_reason() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let socket = dir.path().join("refusing.sock");
+    let listener = trusty_common::uds::bind_hardened(&socket).expect("bind the stub socket");
+    tokio::spawn(async move {
+        while let Ok((mut conn, _)) = listener.accept().await {
+            use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+            let mut sink = Vec::new();
+            let _ = conn.read_to_end(&mut sink).await;
+            let _ = conn
+                .write_all(
+                    br#"{"jsonrpc":"2.0","id":1,"error":{"code":-32004,"message":"no such index"}}"#,
+                )
+                .await;
+            let _ = conn.write_all(b"\n").await;
+            let _ = conn.flush().await;
+        }
+    });
+
+    let client = SocketSearch::new(
+        &socket,
+        "acme-api",
+        std::path::Path::new("/w/repos/acme-api"),
+    );
+    let err = client
+        .hits("credential handling", MIN_TOP_K)
+        .await
+        .expect_err("a refusal is never an empty result");
+    assert!(err.contains("refused"), "{err}");
+    assert!(err.contains("no such index"), "{err}");
 }

--- a/crates/trusty-audit/src/grounding/grounding_tests.rs
+++ b/crates/trusty-audit/src/grounding/grounding_tests.rs
@@ -7,11 +7,10 @@
 //! survives into the caller's gap list — the shape a bare `Ok(())` return would
 //! hide.
 //!
-//! Nothing here reaches a real daemon or a real binary: every address is a
-//! stub server bound to an ephemeral port or a port with nothing on it, and
-//! every binary is a shell script. Nothing reads or writes the process
-//! environment either, which is what lets these run in parallel with the rest
-//! of the suite.
+//! Nothing here reaches a real daemon or a real binary: every daemon is a stub
+//! socket under a temp directory, or a path nothing has ever bound, and every
+//! binary is a shell script. Nothing reads or writes the process environment
+//! either, which is what lets these run in parallel with the rest of the suite.
 
 use std::io::Write as _;
 use std::path::{Path, PathBuf};
@@ -19,100 +18,91 @@ use std::time::Duration;
 
 use super::*;
 
-/// A one-connection-at-a-time HTTP stub standing in for a trusty-* daemon.
+/// A stand-in `trusty-search` socket (#6285).
 ///
-/// Answers 200 to anything whose path contains `health`, and `hotspots` (when
-/// given) to anything containing `complexity_hotspots`. `None` answers 500 —
-/// the reachable-but-broken daemon, which is a different failure from an
-/// unreachable one and gets its own test.
-async fn stub_daemon(hotspots: Option<&'static str>) -> String {
-    stub_daemon_with(hotspots, None).await
+/// Why a socket and not an HTTP listener: the search leg dials
+/// `trusty_common::daemon_socket_path("trusty-search")` now, exactly as the
+/// analyze leg has since #6287, so one stub shape serves both daemons.
+///
+/// What: binds a hardened socket under `dir` and answers two methods.
+/// `search.health` always reports `ok` — the daemon's own `GET /health`
+/// answered 200 unconditionally, and `search_is_healthy` keeps that. Queries
+/// answer `hits` as their result, or the refusal a daemon spells for an index
+/// it does not hold when `hits` is `None`, which is what the pre-#6285 stub's
+/// HTTP 404 meant.
+fn stub_search_socket(dir: &Path, hits: Option<&'static str>) -> PathBuf {
+    answering_socket(dir, "trusty-search", move |request| {
+        if request.contains("search.health") {
+            r#"{"jsonrpc":"2.0","id":1,"result":{"status":"ok","version":"0.0.0","indexes":1}}"#
+                .to_owned()
+        } else if request.contains("search.query") {
+            match hits {
+                // Compacted, not interpolated raw: the fixtures are
+                // pretty-printed and a frame is newline-terminated, so
+                // embedding one verbatim would end the frame at its first
+                // line break.
+                Some(json) => {
+                    let value: serde_json::Value =
+                        serde_json::from_str(json).expect("a valid search fixture");
+                    format!(r#"{{"jsonrpc":"2.0","id":1,"result":{value}}}"#)
+                }
+                None => {
+                    r#"{"jsonrpc":"2.0","id":1,"error":{"code":-32004,"message":"no such index"}}"#
+                        .to_owned()
+                }
+            }
+        } else {
+            r#"{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"no such method"}}"#
+                .to_owned()
+        }
+    })
 }
 
-/// [`stub_daemon`], plus an answer for #6082's `/indexes/{id}/search` queries.
+/// A socket that accepts connections and refuses every health call.
 ///
-/// Why a second constructor rather than a parameter on the first: the discovery
-/// leg asks a dozen-plus queries per repository, and most tests here drive a
-/// DIFFERENT leg to failure — they want the search leg to answer quietly,
-/// without restating that at every call site.
-async fn stub_daemon_with(hotspots: Option<&'static str>, search: Option<&'static str>) -> String {
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-        .await
-        .expect("bind an ephemeral port");
-    let addr = listener.local_addr().expect("local addr");
+/// The middle case `daemons::wait_socket_ready`'s two budgets exist to
+/// separate: the socket IS bound, so this is a daemon that is starting rather
+/// than absent.
+fn unhealthy_search_socket(dir: &Path) -> PathBuf {
+    answering_socket(dir, "warming-search", |_| {
+        r#"{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"warming up"}}"#.to_owned()
+    })
+}
+
+/// A socket path nothing has ever bound — the search equivalent of
+/// [`dead_socket`].
+fn dead_search_socket(dir: &Path) -> PathBuf {
+    dir.join("absent-search.sock")
+}
+
+/// Bind one hardened socket under `dir` and answer every frame with `reply`.
+///
+/// A distinct filename per stub: one test builds its `Tools` twice from the
+/// same temp dir, and a socket path can only be bound once.
+fn answering_socket<F>(dir: &Path, name: &str, reply: F) -> PathBuf
+where
+    F: Fn(&str) -> String + Send + Sync + 'static,
+{
+    static NEXT: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+    let n = NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let socket = dir.join("sockets").join(format!("{name}-{n}.sock"));
+    let listener = trusty_common::uds::bind_hardened(&socket).expect("bind the stub socket");
+    let reply = std::sync::Arc::new(reply);
     tokio::spawn(async move {
-        loop {
-            let Ok((mut socket, _)) = listener.accept().await else {
-                return;
-            };
-            let mut buffer = [0u8; 2048];
-            let read = {
-                use tokio::io::AsyncReadExt as _;
-                socket.read(&mut buffer).await.unwrap_or(0)
-            };
-            let request = String::from_utf8_lossy(&buffer[..read]).into_owned();
-            let response = if request.contains("health") {
-                body(200, "text/plain", "ok")
-            } else if request.contains("complexity_hotspots") {
-                match hotspots {
-                    Some(json) => body(200, "application/json", json),
-                    None => body(500, "text/plain", "index is not loaded"),
-                }
-            } else if request.contains("/search") {
-                match search {
-                    Some(json) => body(200, "application/json", json),
-                    None => body(404, "text/plain", "no such index"),
-                }
-            } else {
-                body(404, "text/plain", "no")
-            };
-            use tokio::io::AsyncWriteExt as _;
-            let _ = socket.write_all(response.as_bytes()).await;
-            let _ = socket.shutdown().await;
+        while let Ok((mut conn, _)) = listener.accept().await {
+            let reply = std::sync::Arc::clone(&reply);
+            tokio::spawn(async move {
+                use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+                let mut sink = Vec::new();
+                let _ = conn.read_to_end(&mut sink).await;
+                let request = String::from_utf8_lossy(&sink).into_owned();
+                let _ = conn.write_all(reply(&request).as_bytes()).await;
+                let _ = conn.write_all(b"\n").await;
+                let _ = conn.flush().await;
+            });
         }
     });
-    format!("http://{addr}")
-}
-
-fn body(status: u16, content_type: &str, payload: &str) -> String {
-    format!(
-        "HTTP/1.1 {status} X\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{payload}",
-        payload.len()
-    )
-}
-
-/// A listener that accepts connections and refuses every request.
-///
-/// The middle case `daemons::wait_ready`'s two budgets exist to separate: the
-/// port IS bound, so this is a daemon that is starting rather than absent.
-async fn listening_but_unhealthy() -> String {
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-        .await
-        .expect("bind an ephemeral port");
-    let addr = listener.local_addr().expect("local addr");
-    tokio::spawn(async move {
-        loop {
-            let Ok((mut socket, _)) = listener.accept().await else {
-                return;
-            };
-            use tokio::io::AsyncWriteExt as _;
-            let _ = socket
-                .write_all(body(503, "text/plain", "warming up").as_bytes())
-                .await;
-            let _ = socket.shutdown().await;
-        }
-    });
-    format!("http://{addr}")
-}
-
-/// An address with nothing listening on it: bound, read back, then released.
-async fn dead_url() -> String {
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-        .await
-        .expect("bind an ephemeral port");
-    let addr = listener.local_addr().expect("local addr");
-    drop(listener);
-    format!("http://{addr}")
+    socket
 }
 
 /// A `trusty-search` that approves and indexes whatever it is asked to.
@@ -133,10 +123,15 @@ fn stub_binary(at: &Path, name: &str, script: &str) -> PathBuf {
 }
 
 /// Tools whose budgets are short enough that no failing test waits on one.
-fn tools(search: PathBuf, search_url: String, analyze: PathBuf, analyze_socket: PathBuf) -> Tools {
+fn tools(
+    search: PathBuf,
+    search_socket: PathBuf,
+    analyze: PathBuf,
+    analyze_socket: PathBuf,
+) -> Tools {
     Tools {
         search,
-        search_url,
+        search_socket,
         analyze,
         analyze_socket,
         bind_timeout: Duration::from_millis(60),
@@ -146,10 +141,6 @@ fn tools(search: PathBuf, search_url: String, analyze: PathBuf, analyze_socket: 
 }
 
 /// A stand-in `trusty-analyze` socket (#6287).
-///
-/// Why: the analyze leg dials a Unix socket now, so [`stub_daemon`] — one HTTP
-/// listener that answered for both daemons — can no longer stand in for it. The
-/// search half stays HTTP, which is why both stubs still exist.
 ///
 /// What: binds a hardened socket under `dir` and answers two methods.
 /// `analyze.health` always reports `ok`; `analyze.complexity_hotspots` returns
@@ -215,7 +206,7 @@ const HOTSPOTS: &str = r#"{"index_id":"acme-api","top_n":60,"hotspots":[
 
 const EMPTY_HOTSPOTS: &str = r#"{"index_id":"acme-api","top_n":60,"hotspots":[]}"#;
 
-/// What #6082's `/indexes/{id}/search` answers with. The stub cannot vary its
+/// What #6082's `search.query` answers with. The stub cannot vary its
 /// answer per query, so every dimension finds the same two files — enough to
 /// assert attribution and that the leg survives a dead trusty-analyze.
 const SEARCH_HITS: &str = r#"{"results":[
@@ -245,11 +236,10 @@ fn manifest_naming(dir: &Path, checkout: &Path) -> PathBuf {
 /// it — the first leg refuses before anything is spawned or probed.
 #[tokio::test]
 async fn a_checkout_with_no_basename_never_reaches_a_daemon() {
-    let dead = dead_url().await;
     let tmp = tempfile::tempdir().expect("tempdir");
     let t = tools(
         PathBuf::from("/nonexistent/trusty-search"),
-        dead,
+        dead_search_socket(tmp.path()),
         PathBuf::from("/nonexistent/trusty-analyze"),
         dead_socket(tmp.path()),
     );
@@ -276,11 +266,10 @@ async fn a_checkout_with_no_basename_never_reaches_a_daemon() {
 /// must produce a line rather than an empty code-analysis section.
 #[tokio::test]
 async fn a_search_daemon_that_will_not_start_is_a_named_gap() {
-    let dead = dead_url().await;
     let tmp = tempfile::tempdir().expect("tempdir");
     let t = tools(
         PathBuf::from("/nonexistent/trusty-search"),
-        dead,
+        dead_search_socket(tmp.path()),
         PathBuf::from("/nonexistent/trusty-analyze"),
         dead_socket(tmp.path()),
     );
@@ -305,11 +294,11 @@ async fn a_search_daemon_that_will_not_start_is_a_named_gap() {
 #[tokio::test]
 async fn a_reachable_search_daemon_is_not_restarted() {
     let tmp = tempfile::tempdir().expect("tempdir");
-    let search_url = stub_daemon(None).await;
+    let search_socket = stub_search_socket(tmp.path(), None);
     // The binary does not exist: reaching the spawn at all would fail the leg.
     let t = tools(
         PathBuf::from("/nonexistent/trusty-search"),
-        search_url,
+        search_socket,
         PathBuf::from("/nonexistent/trusty-analyze"),
         dead_socket(tmp.path()),
     );
@@ -332,7 +321,7 @@ async fn an_unindexable_checkout_is_a_named_gap() {
     );
     let t = tools(
         search,
-        stub_daemon(None).await,
+        stub_search_socket(tmp.path(), None),
         PathBuf::from("/nonexistent/trusty-analyze"),
         dead_socket(tmp.path()),
     );
@@ -365,7 +354,7 @@ async fn an_analyze_daemon_that_will_not_start_is_a_named_gap() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let t = tools(
         approving_search(tmp.path()),
-        stub_daemon_with(None, Some(SEARCH_HITS)).await,
+        stub_search_socket(tmp.path(), Some(SEARCH_HITS)),
         PathBuf::from("/nonexistent/trusty-analyze"),
         dead_socket(tmp.path()),
     );
@@ -393,7 +382,7 @@ async fn an_analyze_daemon_that_will_not_start_is_a_named_gap() {
     );
 }
 
-/// Reachable but broken: the daemon answers `/health` and then 500s the query.
+/// Reachable but broken: the daemon reports healthy and then refuses the query.
 /// That is a different failure from an unreachable daemon and gets its own line.
 #[cfg(unix)]
 #[tokio::test]
@@ -401,7 +390,7 @@ async fn an_unreachable_hotspots_endpoint_is_a_named_gap() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let t = tools(
         approving_search(tmp.path()),
-        stub_daemon_with(None, Some(SEARCH_HITS)).await,
+        stub_search_socket(tmp.path(), Some(SEARCH_HITS)),
         PathBuf::from("/nonexistent/trusty-analyze"),
         stub_analyze_socket(tmp.path(), None),
     );
@@ -438,7 +427,7 @@ async fn an_empty_hotspot_list_is_a_named_gap() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let t = tools(
         approving_search(tmp.path()),
-        stub_daemon_with(None, Some(SEARCH_HITS)).await,
+        stub_search_socket(tmp.path(), Some(SEARCH_HITS)),
         PathBuf::from("/nonexistent/trusty-analyze"),
         stub_analyze_socket(tmp.path(), Some(EMPTY_HOTSPOTS)),
     );
@@ -467,7 +456,7 @@ async fn a_search_that_answers_nothing_is_a_named_gap() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let t = tools(
         approving_search(tmp.path()),
-        stub_daemon_with(None, Some(r#"{"results":[]}"#)).await,
+        stub_search_socket(tmp.path(), Some(r#"{"results":[]}"#)),
         PathBuf::from("/nonexistent/trusty-analyze"),
         stub_analyze_socket(tmp.path(), Some(EMPTY_HOTSPOTS)),
     );
@@ -502,7 +491,7 @@ async fn failing_evidence_queries_are_named_once_with_their_count() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let t = tools(
         approving_search(tmp.path()),
-        stub_daemon(None).await, // answers /health, 404s every query
+        stub_search_socket(tmp.path(), None), // healthy; refuses every query
         PathBuf::from("/nonexistent/trusty-analyze"),
         stub_analyze_socket(tmp.path(), Some(EMPTY_HOTSPOTS)),
     );
@@ -520,18 +509,21 @@ async fn failing_evidence_queries_are_named_once_with_their_count() {
         .filter(|g| g.contains("evidence queries failed"))
         .collect();
     assert_eq!(failures.len(), 1, "{:?}", out.gaps);
-    assert!(failures[0].contains("404"), "{failures:?}");
+    // #6285: the refusal is a JSON-RPC error frame now, and the gap must still
+    // carry the daemon's own words rather than a generic failure.
+    assert!(failures[0].contains("no such index"), "{failures:?}");
 }
 
-/// A daemon that binds its port and never becomes healthy gets the full
-/// readiness budget and then a line — the second of `wait_ready`'s two phases.
+/// A daemon that binds its socket and never becomes healthy gets the full
+/// readiness budget and then a line — the second of `wait_socket_ready`'s two
+/// phases.
 #[cfg(unix)]
 #[tokio::test]
 async fn a_daemon_that_binds_but_never_answers_is_a_named_gap() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let t = tools(
         approving_search(tmp.path()),
-        listening_but_unhealthy().await,
+        unhealthy_search_socket(tmp.path()),
         PathBuf::from("/nonexistent/trusty-analyze"),
         dead_socket(tmp.path()),
     );
@@ -546,7 +538,7 @@ async fn a_daemon_that_binds_but_never_answers_is_a_named_gap() {
     assert!(out.priorities.is_empty());
     assert_eq!(out.gaps.len(), 1, "{:?}", out.gaps);
     assert!(
-        out.gaps[0].contains("did not answer /health"),
+        out.gaps[0].contains("did not report healthy"),
         "{:?}",
         out.gaps
     );
@@ -572,7 +564,7 @@ async fn hotspots_and_search_hits_become_ranked_inspect_priority_in_the_manifest
 
     let t = tools(
         approving_search(tmp.path()),
-        stub_daemon_with(None, Some(SEARCH_HITS)).await,
+        stub_search_socket(tmp.path(), Some(SEARCH_HITS)),
         PathBuf::from("/nonexistent/trusty-analyze"),
         stub_analyze_socket(tmp.path(), Some(payload)),
     );
@@ -672,7 +664,7 @@ async fn a_search_that_found_nothing_is_a_gap_even_when_a_manifest_backfills_it(
 
     let t = tools(
         approving_search(tmp.path()),
-        stub_daemon_with(None, Some(r#"{"results":[]}"#)).await,
+        stub_search_socket(tmp.path(), Some(r#"{"results":[]}"#)),
         PathBuf::from("/nonexistent/trusty-analyze"),
         stub_analyze_socket(tmp.path(), Some(EMPTY_HOTSPOTS)),
     );
@@ -727,7 +719,7 @@ async fn a_ranking_that_lands_after_the_render_says_so() {
     let stubs = || async {
         tools(
             approving_search(tmp.path()),
-            stub_daemon_with(None, Some(SEARCH_HITS)).await,
+            stub_search_socket(tmp.path(), Some(SEARCH_HITS)),
             PathBuf::from("/nonexistent/trusty-analyze"),
             stub_analyze_socket(tmp.path(), Some(payload)),
         )
@@ -819,11 +811,10 @@ async fn a_gap_is_recorded_in_the_manifest_the_renderer_reads() {
     let checkout = tmp.path().join("repos").join("acme-api");
     std::fs::create_dir_all(&checkout).expect("mkdir checkout");
     let manifest = manifest_naming(tmp.path(), &checkout);
-    let dead = dead_url().await;
     let tmp = tempfile::tempdir().expect("tempdir");
     let t = tools(
         PathBuf::from("/nonexistent/trusty-search"),
-        dead,
+        dead_search_socket(tmp.path()),
         PathBuf::from("/nonexistent/trusty-analyze"),
         dead_socket(tmp.path()),
     );
@@ -869,7 +860,7 @@ async fn a_manifest_that_cannot_be_written_is_a_named_gap() {
 
     let t = tools(
         approving_search(tmp.path()),
-        stub_daemon_with(None, Some(SEARCH_HITS)).await,
+        stub_search_socket(tmp.path(), Some(SEARCH_HITS)),
         PathBuf::from("/nonexistent/trusty-analyze"),
         stub_analyze_socket(tmp.path(), Some(payload)),
     );

--- a/crates/trusty-audit/src/grounding/index.rs
+++ b/crates/trusty-audit/src/grounding/index.rs
@@ -33,6 +33,7 @@ use std::ffi::OsString;
 use std::path::Path;
 use std::process::{Command, Output};
 
+use super::search_rpc;
 use crate::run::approve::approve_for_indexing;
 
 /// What became of one repository's index.
@@ -79,12 +80,15 @@ const ROOT_PROBE_BUDGET: std::time::Duration = std::time::Duration::from_secs(10
 /// and commit, and every complexity hotspot the report stamped "measured" was
 /// measured against code that was never audited.
 ///
-/// What: reads `root_path` off `GET /indexes/{id}/status` and compares it to
-/// `checkout`, canonicalising both so a symlinked or `..`-laden path still
-/// matches. A daemon that will not answer, or a response with no `root_path`,
-/// is `Ok` — this guard exists to catch a WRONG root, and every other failure
-/// already has a gap of its own; failing closed here would turn one unreadable
-/// field into a repository with no code analysis at all.
+/// What: reads `root_path` off `search.index.status` — the socket method
+/// `GET /indexes/{id}/status` became in #6285 — and compares it to `checkout`,
+/// canonicalising both so a symlinked or `..`-laden path still matches. A
+/// daemon that will not answer, a daemon that refuses, and a response with no
+/// `root_path` are all `Ok` — this guard exists to catch a WRONG root, and every
+/// other failure already has a gap of its own; failing closed here would turn
+/// one unreadable field into a repository with no code analysis at all. That
+/// fail-open arm is exactly why [`search_rpc`] keeps "unreachable" and
+/// "refused" apart: neither may ever arrive here as a root that matched.
 ///
 /// # Errors
 ///
@@ -95,25 +99,18 @@ const ROOT_PROBE_BUDGET: std::time::Duration = std::time::Duration::from_secs(10
 /// Never panics.
 ///
 /// Test: `index_tests::{same_tree_resolves_before_it_compares,
-/// an_unreachable_daemon_is_not_a_refusal}`.
-pub async fn root_matches(base_url: &str, index_id: &str, checkout: &Path) -> Result<(), String> {
-    let url = format!(
-        "{}/indexes/{index_id}/status",
-        base_url.trim_end_matches('/')
-    );
-    let Ok(client) = trusty_common::http_client::loopback_client_builder()
-        .timeout(ROOT_PROBE_BUDGET)
-        .build()
+/// an_unreachable_daemon_is_not_a_refusal, a_refused_status_is_not_a_refusal,
+/// a_mismatched_root_is_refused_over_the_socket}`.
+pub async fn root_matches(socket: &Path, index_id: &str, checkout: &Path) -> Result<(), String> {
+    // #6285: any failure to READ the root is Ok — see the doc comment.
+    let Ok(body) = search_rpc::call(
+        socket,
+        search_rpc::METHOD_INDEX_STATUS,
+        serde_json::json!({ "index_id": index_id }),
+        ROOT_PROBE_BUDGET,
+    )
+    .await
     else {
-        return Ok(());
-    };
-    let Ok(response) = client.get(&url).send().await else {
-        return Ok(());
-    };
-    if !response.status().is_success() {
-        return Ok(());
-    }
-    let Ok(body) = response.json::<serde_json::Value>().await else {
         return Ok(());
     };
     let Some(served) = body.get("root_path").and_then(|v| v.as_str()) else {
@@ -428,8 +425,67 @@ mod index_tests {
     /// whole code-analysis leg over one unreadable field.
     #[tokio::test]
     async fn an_unreachable_daemon_is_not_a_refusal() {
-        // Port 1 is never a trusty-search daemon.
-        let out = root_matches("http://127.0.0.1:1", "acme-api", Path::new("/w/a")).await;
+        let dir = tempfile::tempdir().expect("tempdir");
+        // Nothing has ever bound this socket.
+        let out = root_matches(
+            &dir.path().join("absent.sock"),
+            "acme-api",
+            Path::new("/w/a"),
+        )
+        .await;
         assert!(out.is_ok(), "{out:?}");
+    }
+
+    /// #6285: the other half of that arm. A daemon that ANSWERS and refuses —
+    /// `search.index.status` for an id it does not hold — must also be `Ok`,
+    /// because an index the daemon never heard of has no root to disagree with.
+    #[tokio::test]
+    async fn a_refused_status_is_not_a_refusal() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let socket = stub_status(
+            dir.path(),
+            r#"{"jsonrpc":"2.0","id":1,"error":{"code":-32004,"message":"no such index"}}"#,
+        );
+        let out = root_matches(&socket, "acme-api", Path::new("/w/a")).await;
+        assert!(out.is_ok(), "a refusal carries no root to compare: {out:?}");
+    }
+
+    /// The backstop itself, end to end over the socket: a served root that names
+    /// a different tree is the one case that must NOT be `Ok`.
+    #[tokio::test]
+    async fn a_mismatched_root_is_refused_over_the_socket() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let socket = stub_status(
+            dir.path(),
+            r#"{"jsonrpc":"2.0","id":1,"result":{"root_path":"/Users/masa/Projects/trusty-tools"}}"#,
+        );
+        let reason = root_matches(&socket, "trusty-tools", Path::new("/w/repos/trusty-tools"))
+            .await
+            .expect_err("a foreign root is the collision this guard exists for");
+        assert!(
+            reason.contains("/Users/masa/Projects/trusty-tools"),
+            "{reason}"
+        );
+        assert!(reason.contains("/w/repos/trusty-tools"), "{reason}");
+        assert_eq!(reason.lines().count(), 1, "must stay one line: {reason}");
+    }
+
+    /// A socket that answers `reply` to every frame, standing in for the daemon.
+    fn stub_status(dir: &Path, reply: &'static str) -> std::path::PathBuf {
+        static NEXT: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+        let n = NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let socket = dir.join(format!("status-{n}.sock"));
+        let listener = trusty_common::uds::bind_hardened(&socket).expect("bind the stub socket");
+        tokio::spawn(async move {
+            while let Ok((mut conn, _)) = listener.accept().await {
+                use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+                let mut sink = Vec::new();
+                let _ = conn.read_to_end(&mut sink).await;
+                let _ = conn.write_all(reply.as_bytes()).await;
+                let _ = conn.write_all(b"\n").await;
+                let _ = conn.flush().await;
+            }
+        });
+        socket
     }
 }

--- a/crates/trusty-audit/src/grounding/quality.rs
+++ b/crates/trusty-audit/src/grounding/quality.rs
@@ -36,7 +36,7 @@ use super::evidence::FileEvidence;
 /// Why RELATIVE rather than absolute (#6082): the floor shipped as an absolute
 /// `0.15`, calibrated against a run whose filler scored 0.02 and whose signal
 /// scored 0.6–0.9. The endpoint the discovery leg actually calls does not
-/// produce scores on that scale. `POST /indexes/{id}/search` fuses its lanes
+/// produce scores on that scale. `search.query` fuses its lanes
 /// with Reciprocal Rank Fusion — `Σ weight / (60 + rank)` over lane weights that
 /// sum to one — so the highest score any hit can carry is `1/61 ≈ 0.0164`, an
 /// order of magnitude BELOW the floor. Every hit of every query failed it, on

--- a/crates/trusty-audit/src/grounding/quality_tests.rs
+++ b/crates/trusty-audit/src/grounding/quality_tests.rs
@@ -25,7 +25,7 @@ fn a_filler_row_beside_a_real_hit_is_dropped() {
 
 /// #6082: the floor tracks the scale the daemon actually answers on.
 ///
-/// `POST /indexes/{id}/search` fuses its lanes with RRF, so no hit can score
+/// `search.query` fuses its lanes with RRF, so no hit can score
 /// above `1/61 ≈ 0.0164`. Against the absolute `0.15` this replaced, every
 /// assertion below fails: the whole result set is rejected and the discovery leg
 /// returns nothing however good the index is.

--- a/crates/trusty-audit/src/grounding/search_rpc.rs
+++ b/crates/trusty-audit/src/grounding/search_rpc.rs
@@ -121,9 +121,11 @@ pub enum SearchRpcFailure {
 impl SearchRpcFailure {
     /// True when the daemon ANSWERED and refused, rather than not answering.
     ///
-    /// Why: a caller that must not act on silence — the index-root backstop is
-    /// the one here — needs the distinction the module docs describe, and a
-    /// string comparison against [`Display`] would be a second contract.
+    /// Why: a future caller that must not act on silence needs this
+    /// distinction, and a string comparison against [`Display`] would be a
+    /// second contract. `root_matches` (see [`super::index`]) does not call
+    /// this — it discards the `Result` and stays fail-open on every variant
+    /// by design, so today this is exercised only by its own tests.
     /// Test: `search_rpc_tests::a_dead_socket_is_unreachable_not_a_refusal`.
     #[must_use]
     pub fn is_refusal(&self) -> bool {

--- a/crates/trusty-audit/src/grounding/search_rpc.rs
+++ b/crates/trusty-audit/src/grounding/search_rpc.rs
@@ -1,0 +1,377 @@
+//! The one way this crate calls the running `trusty-search` daemon (#6285).
+//!
+//! Why: three legs of grounding reached trusty-search over loopback HTTP — the
+//! readiness probe in [`super::daemons`], the index-root backstop in
+//! [`super::index`], and the per-dimension evidence queries in
+//! [`super::evidence`]. ADR-0032 retires that listener: trusty-search binds one
+//! hardened Unix socket at the path [`trusty_common::daemon_socket_path`]
+//! derives, and speaks the framed JSON-RPC envelope [`trusty_common::uds`]
+//! defines. There is no address to discover, no port to fall back to, and
+//! nothing for a stale `http_addr` left by an older daemon to disagree with.
+//!
+//! What: [`search_socket`] derives the path both ends compute, and [`call`]
+//! writes one frame and reads one back. Every trusty-search call in this crate
+//! goes through here — a second dial or a second path resolver would be two
+//! answers to one question.
+//!
+//! ## The three outcomes stay apart
+//!
+//! Every leg above is fail-open, and fail-open only works when "the daemon is
+//! gone" is distinguishable from "the daemon answered, and the answer was no".
+//! [`SearchRpcFailure`] keeps them apart: [`SearchRpcFailure::Unreachable`] is
+//! an absence of information, [`SearchRpcFailure::Refused`] is a verdict the
+//! daemon reached, and [`SearchRpcFailure::Malformed`] is a daemon that
+//! answered something this crate cannot read. None of the three is ever a
+//! success — an error frame that read as one would let a dead index render as a
+//! clean bill of health.
+//!
+//! ## The method names are literals, deliberately
+//!
+//! trusty-audit has no Cargo edge on trusty-search, so the names cannot be
+//! imported; they are pinned by `trusty_search::service::socket::METHODS`,
+//! which the daemon's own `rpc_router_registers_every_documented_method`
+//! compares its router against. A name that drifted answers `method_not_found`,
+//! which arrives here as a [`SearchRpcFailure::Refused`] and reaches the
+//! operator as a named gap.
+//!
+//! Test: `search_rpc_tests`.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use serde_json::Value;
+
+/// Environment variable that pins the daemon's socket path explicitly.
+///
+/// Why: it replaces `TRUSTY_DATA_DIR` as the way a rig points this crate at a
+/// daemon it started, without redirecting every other trusty-* client in the
+/// same process. Same shape as [`super::daemons::ENV_ANALYZE_SOCKET`] and
+/// trusty-mpm's `TRUSTY_SEARCH_SOCKET` — the same variable name, so an operator
+/// pins one daemon for both crates with one export.
+pub const ENV_SEARCH_SOCKET: &str = "TRUSTY_SEARCH_SOCKET";
+
+/// Liveness, index count and the daemon's version.
+pub const METHOD_HEALTH: &str = "search.health";
+
+/// One index's stages, capabilities and footprint — `GET /indexes/{id}/status`.
+pub const METHOD_INDEX_STATUS: &str = "search.index.status";
+
+/// Hybrid search within one index — `POST /indexes/{id}/search`.
+pub const METHOD_QUERY: &str = "search.query";
+
+/// Response-frame budget for a query, in bytes.
+///
+/// Why not the shared [`trusty_common::uds::rpc::MAX_FRAME_BYTES`] default of
+/// 8 MiB: a discovery pass asks for up to 64 chunks per query, and the HTTP
+/// route it replaces had no response limit at all. Slice 5.5 raised the
+/// daemon's own accept budget to 64 MiB (`trusty_search::service::socket::
+/// MAX_FRAME_BYTES`) precisely so both ends could carry a bulk payload; a
+/// client left at the control-plane default would refuse a frame the daemon was
+/// willing to send, and the evidence leg would degrade for a reason that is not
+/// the daemon's.
+///
+/// Test: `search_rpc_tests::the_query_budget_matches_the_daemons_accept_budget`.
+pub const QUERY_MAX_FRAME_BYTES: u64 = 64 * 1024 * 1024;
+
+/// Why one call to the daemon produced no result.
+///
+/// Why a typed error rather than a formatted string: see the module docs — the
+/// three cases are three different facts and each leg here reports them
+/// differently.
+/// What: `Display` renders one line, safe to show the recipient, in each case.
+/// Test: `search_rpc_tests::each_failure_renders_one_line`.
+#[derive(Debug, Clone, thiserror::Error)]
+#[non_exhaustive]
+pub enum SearchRpcFailure {
+    /// The socket could not be dialled, or the exchange failed. An absence of
+    /// information, never a verdict.
+    #[error("trusty-search did not answer {method} on {at} ({cause})")]
+    Unreachable {
+        /// The method that was attempted.
+        method: String,
+        /// The socket that was dialled.
+        at: String,
+        /// What the transport reported.
+        cause: String,
+    },
+    /// The daemon answered, and the answer was an error frame.
+    #[error("trusty-search refused {method} on {at} ({code}: {message})")]
+    Refused {
+        /// The method that was called.
+        method: String,
+        /// The socket that was dialled.
+        at: String,
+        /// The daemon's own JSON-RPC error code.
+        code: i64,
+        /// The daemon's own message.
+        message: String,
+    },
+    /// The daemon answered something this crate cannot read.
+    #[error("trusty-search answered {method} on {at} with an unreadable body ({cause})")]
+    Malformed {
+        /// The method that was called.
+        method: String,
+        /// The socket that was dialled.
+        at: String,
+        /// What could not be read.
+        cause: String,
+    },
+}
+
+impl SearchRpcFailure {
+    /// True when the daemon ANSWERED and refused, rather than not answering.
+    ///
+    /// Why: a caller that must not act on silence — the index-root backstop is
+    /// the one here — needs the distinction the module docs describe, and a
+    /// string comparison against [`Display`] would be a second contract.
+    /// Test: `search_rpc_tests::a_dead_socket_is_unreachable_not_a_refusal`.
+    #[must_use]
+    pub fn is_refusal(&self) -> bool {
+        matches!(self, Self::Refused { .. })
+    }
+}
+
+/// The socket the trusty-search daemon binds: [`ENV_SEARCH_SOCKET`], else the
+/// derived default.
+///
+/// Why derived rather than read from a discovery file: the daemon computes the
+/// same path from the same call (`trusty_search::service::socket::socket_path`),
+/// so there is nothing published between them for a stale write to contradict.
+/// A resolution failure yields an empty path, which every caller then reports as
+/// unreachable — the same outcome a wrong path would produce, without the guess.
+/// This mirrors [`super::daemons::analyze_socket`] exactly.
+/// Test: `search_rpc_tests::an_absent_or_empty_override_falls_back_to_the_default_socket`.
+#[must_use]
+pub fn search_socket() -> PathBuf {
+    socket_from_override(std::env::var(ENV_SEARCH_SOCKET).ok().as_deref())
+}
+
+/// The override rule itself: a non-empty value wins, everything else defaults.
+///
+/// Split out so the rule is asserted without any test reading or writing the
+/// process environment — `set_var` is `unsafe` in edition 2024 and unsound under
+/// the parallel harness.
+fn socket_from_override(value: Option<&str>) -> PathBuf {
+    match value.filter(|s| !s.is_empty()) {
+        Some(p) => PathBuf::from(p),
+        None => trusty_common::daemon_socket_path("trusty-search").unwrap_or_default(),
+    }
+}
+
+/// Call one method on the daemon at `socket` and return its `result`.
+///
+/// # Errors
+///
+/// [`SearchRpcFailure`], one variant per outcome that is not a result frame.
+///
+/// Test: `search_rpc_tests::a_dead_socket_is_unreachable_not_a_refusal`.
+pub async fn call(
+    socket: &Path,
+    method: &str,
+    params: Value,
+    timeout: Duration,
+) -> Result<Value, SearchRpcFailure> {
+    call_capped(
+        socket,
+        method,
+        params,
+        timeout,
+        trusty_common::uds::rpc::MAX_FRAME_BYTES,
+    )
+    .await
+}
+
+/// [`call`] with an explicit response-frame budget — see [`QUERY_MAX_FRAME_BYTES`].
+///
+/// # Errors
+///
+/// The same set [`call`] returns; a response over `max_frame_bytes` arrives as
+/// [`SearchRpcFailure::Unreachable`], because a refused frame is a transport
+/// outcome rather than a verdict the daemon reached.
+///
+/// Test: `search_rpc_tests::an_error_frame_is_a_refusal_carrying_the_daemons_code`.
+pub async fn call_capped(
+    socket: &Path,
+    method: &str,
+    params: Value,
+    timeout: Duration,
+    max_frame_bytes: u64,
+) -> Result<Value, SearchRpcFailure> {
+    let at = socket.display().to_string();
+    let request = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": method,
+        "params": params,
+    });
+    let response: trusty_common::uds::server::RpcResponse =
+        trusty_common::uds::send_framed_request_capped(socket, &request, timeout, max_frame_bytes)
+            .await
+            .map_err(|e| SearchRpcFailure::Unreachable {
+                method: method.to_owned(),
+                at: at.clone(),
+                cause: e.to_string(),
+            })?;
+    if let Some(error) = response.error {
+        return Err(SearchRpcFailure::Refused {
+            method: method.to_owned(),
+            at,
+            code: error.code,
+            message: error.message,
+        });
+    }
+    response.result.ok_or(SearchRpcFailure::Malformed {
+        method: method.to_owned(),
+        at,
+        cause: "neither a result nor an error".to_owned(),
+    })
+}
+
+#[cfg(test)]
+mod search_rpc_tests {
+    use super::*;
+
+    /// #6285: the names this crate cannot import. A drift here answers
+    /// `method_not_found` against a daemon that is perfectly healthy.
+    #[test]
+    fn the_method_names_match_the_daemons_registered_spelling() {
+        assert_eq!(METHOD_HEALTH, "search.health");
+        assert_eq!(METHOD_INDEX_STATUS, "search.index.status");
+        assert_eq!(METHOD_QUERY, "search.query");
+        assert_eq!(ENV_SEARCH_SOCKET, "TRUSTY_SEARCH_SOCKET");
+    }
+
+    /// The query budget is the daemon's accept budget, not the shared default —
+    /// a smaller one would refuse a frame the daemon was willing to send.
+    #[test]
+    fn the_query_budget_matches_the_daemons_accept_budget() {
+        assert_eq!(QUERY_MAX_FRAME_BYTES, 64 * 1024 * 1024);
+        const { assert!(QUERY_MAX_FRAME_BYTES > trusty_common::uds::rpc::MAX_FRAME_BYTES) };
+    }
+
+    #[test]
+    fn an_absent_or_empty_override_falls_back_to_the_default_socket() {
+        let derived = trusty_common::daemon_socket_path("trusty-search").unwrap_or_default();
+        assert_eq!(socket_from_override(None), derived);
+        assert_eq!(socket_from_override(Some("")), derived);
+        assert_eq!(
+            socket_from_override(Some("/tmp/pinned-search.sock")),
+            PathBuf::from("/tmp/pinned-search.sock")
+        );
+    }
+
+    /// The fail-open distinction the module exists for: nothing listening is an
+    /// absence of information, never a verdict a caller may act on.
+    #[tokio::test]
+    async fn a_dead_socket_is_unreachable_not_a_refusal() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let socket = dir.path().join("absent.sock");
+        let err = call(
+            &socket,
+            METHOD_HEALTH,
+            serde_json::json!({}),
+            Duration::from_secs(2),
+        )
+        .await
+        .expect_err("nothing is listening");
+        assert!(!err.is_refusal(), "{err}");
+        assert!(matches!(err, SearchRpcFailure::Unreachable { .. }), "{err}");
+    }
+
+    /// The other side of it: a daemon that answers an error frame reached a
+    /// verdict, and that must never read as a result.
+    #[tokio::test]
+    async fn an_error_frame_is_a_refusal_carrying_the_daemons_code() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let socket = dir.path().join("refusing.sock");
+        let listener = trusty_common::uds::bind_hardened(&socket).expect("bind");
+        tokio::spawn(async move {
+            while let Ok((mut conn, _)) = listener.accept().await {
+                use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+                let mut sink = Vec::new();
+                let _ = conn.read_to_end(&mut sink).await;
+                let _ = conn
+                    .write_all(
+                        br#"{"jsonrpc":"2.0","id":1,"error":{"code":-32004,"message":"no such index"}}"#,
+                    )
+                    .await;
+                let _ = conn.write_all(b"\n").await;
+                let _ = conn.flush().await;
+            }
+        });
+
+        let err = call(
+            &socket,
+            METHOD_INDEX_STATUS,
+            serde_json::json!({"index_id": "acme-api"}),
+            Duration::from_secs(5),
+        )
+        .await
+        .expect_err("the daemon refused");
+        assert!(err.is_refusal(), "{err}");
+        let SearchRpcFailure::Refused { code, message, .. } = &err else {
+            panic!("{err}");
+        };
+        assert_eq!(*code, -32004);
+        assert_eq!(message, "no such index");
+    }
+
+    /// A result frame is the ONLY success, and it comes back verbatim.
+    #[tokio::test]
+    async fn a_result_frame_comes_back_as_the_result() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let socket = dir.path().join("answering.sock");
+        let listener = trusty_common::uds::bind_hardened(&socket).expect("bind");
+        tokio::spawn(async move {
+            while let Ok((mut conn, _)) = listener.accept().await {
+                use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+                let mut sink = Vec::new();
+                let _ = conn.read_to_end(&mut sink).await;
+                let _ = conn
+                    .write_all(br#"{"jsonrpc":"2.0","id":1,"result":{"status":"ok","indexes":3}}"#)
+                    .await;
+                let _ = conn.write_all(b"\n").await;
+                let _ = conn.flush().await;
+            }
+        });
+
+        let result = call(
+            &socket,
+            METHOD_HEALTH,
+            serde_json::json!({}),
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("the daemon answered");
+        assert_eq!(result["status"], "ok");
+        assert_eq!(result["indexes"], 3);
+    }
+
+    /// Every rendering stays one line: these reach the recipient's report.
+    #[test]
+    fn each_failure_renders_one_line() {
+        for failure in [
+            SearchRpcFailure::Unreachable {
+                method: METHOD_HEALTH.to_owned(),
+                at: "/tmp/s.sock".to_owned(),
+                cause: "connection refused".to_owned(),
+            },
+            SearchRpcFailure::Refused {
+                method: METHOD_QUERY.to_owned(),
+                at: "/tmp/s.sock".to_owned(),
+                code: -32601,
+                message: "no such method".to_owned(),
+            },
+            SearchRpcFailure::Malformed {
+                method: METHOD_INDEX_STATUS.to_owned(),
+                at: "/tmp/s.sock".to_owned(),
+                cause: "neither a result nor an error".to_owned(),
+            },
+        ] {
+            let line = failure.to_string();
+            assert_eq!(line.lines().count(), 1, "must stay one line: {line}");
+            assert!(line.contains("trusty-search"), "{line}");
+            assert!(line.contains("/tmp/s.sock"), "{line}");
+        }
+    }
+}

--- a/crates/trusty-audit/src/rerender.rs
+++ b/crates/trusty-audit/src/rerender.rs
@@ -1759,13 +1759,13 @@ mod rerender_tests {
         (manifest, checkout)
     }
 
-    /// Addresses with nothing listening, and binaries that do not exist, so no
+    /// Sockets nothing has ever bound, and binaries that do not exist, so no
     /// test reaches a real daemon or a real install.
     fn unreachable_tools() -> grounding::Tools {
         grounding::Tools {
             search: PathBuf::from("/nonexistent/trusty-search"),
-            // Port 1 is privileged: a connect there is refused immediately.
-            search_url: "http://127.0.0.1:1".to_owned(),
+            // #6285: a path nothing has ever bound — refused immediately.
+            search_socket: PathBuf::from("/nonexistent/trusty-search.sock"),
             analyze: PathBuf::from("/nonexistent/trusty-analyze"),
             // #6287: a path nothing has ever bound — the socket equivalent of
             // port 1, refused immediately.


### PR DESCRIPTION
Moves trusty-audit's trusty-search consumption from loopback HTTP to the UDS RPC surface, per the #6285 consumer-move wave.

## Call sites moved

The consumer map (comment 5458166173) lists one row for this crate — the `GET /health` probe. A grep of the crate found three, and all three have a method on main:

| File | Was | Now |
|---|---|---|
| `grounding/daemons.rs` `ensure_search` | `GET /health` + a TCP connect probe | `search.health` + `socket_is_serving` |
| `grounding/index.rs` `root_matches` | `GET /indexes/{id}/status` | `search.index.status` |
| `grounding/evidence.rs` `HttpSearch` | `POST /indexes/{id}/search` | `search.query` (now `SocketSearch`) |

No call site was left behind: `grep -rn "search_url\|7878\|HttpSearch\|loopback_client_builder"` over the crate returns only historical prose naming the HTTP twin.

## One client per crate

`grounding/search_rpc.rs` is the crate's single trusty-search dial — socket resolution (`daemon_socket_path("trusty-search")`, overridable by `TRUSTY_SEARCH_SOCKET`), the framed exchange, and the method-name literals pinned against `trusty_search::service::socket::METHODS`. It mirrors what `daemons.rs` already did for trusty-analyze in #6287. Query responses use the raised 64 MiB budget slice 5.5 gave the daemon, since a query is the one bulk payload this crate moves.

## Fail-open check

Every leg was fail-open and stays fail-open, but the three outcomes are now distinct types rather than one `return Ok(())`:

- `SearchRpcFailure::Unreachable` — nothing answered. An absence of information.
- `SearchRpcFailure::Refused` — the daemon answered an error frame. A verdict.
- `SearchRpcFailure::Malformed` — neither a result nor an error.

`root_matches` treats all three as `Ok` (an index the daemon does not hold has no root to disagree with), but a refusal can no longer be confused with a root that matched. `SocketSearch::hits` turns a refusal into a reason carrying the daemon's own code and message — an error frame read as an empty result would report "no evidence found" for a query that never ran. `search_is_healthy` is `true` only for a result frame; `GET /health` answered 200 unconditionally, so any-result-frame is the faithful translation and not a behaviour change.

Error-arm tests: `a_dead_socket_is_unreachable_not_a_refusal`, `an_error_frame_is_a_refusal_carrying_the_daemons_code`, `a_refused_status_is_not_a_refusal`, `a_mismatched_root_is_refused_over_the_socket`, `a_refused_query_is_a_reason`, `a_dead_daemon_is_a_reason_not_a_panic`.

## Deleted with the listener

`wait_ready`, `accepting` and `authority_of` are gone. trusty-search now shares `wait_socket_ready`, the two-phase wait trusty-analyze already used — one loop instead of a TCP form and a UDS form that could drift.

## Test ladder

**Rung 4** — cross-crate: the transport contract with trusty-search changes, and `Tools::search_url` becomes `Tools::search_socket` on a public struct.

```
cargo fmt --check                                          -> clean
cargo check -p trusty-audit --all-targets                  -> EXIT=0
cargo clippy -p trusty-audit --all-targets -- -D warnings  -> EXIT=0
cargo test -p trusty-audit --no-fail-fast
  test result: ok. 758 passed; 0 failed; 5 ignored; 0 measured; 0 filtered out
  integration targets: 3 / 5 / 4 / 4 (2 ignored) / 8 / 9 passed; 0 failed
cargo check --workspace                                    -> EXIT=0
bash scripts/check_test_pointers.sh
  test-pointers: resolved 27536 Test: citation(s) - 0 dangling pointers - OK.
bash scripts/check_changelog_fragment.sh
  OK   trusty-audit: changelog.d fragment present and valid
bash scripts/check_line_cap.sh
  line-cap: measured 4242 tracked .rs file(s); 0 violations - OK.
bash scripts/check_sld.sh
  sld-lint: 0 error(s), 0 warning(s)
```

Version: trusty-audit 0.11.1 -> **0.12.0**. Three public-API changes are breaking — `Tools::search_url` -> `search_socket`, `HttpSearch` -> `SocketSearch`, and the removal of `daemons::search_base_url` — so a 0.x crate needs the MINOR position. `bash scripts/check_semver.sh --crate trusty-audit` exits 0 and inventories all three.

Changelog fragments: `6285-search-over-uds-breaking.md` (the renames) and `6285-search-over-uds.md` (transport and fail-open behaviour).

## Two things the crate-scoped gates missed, caught by CI

- **Workspace Clippy.** `crates/trusty-analyze/tests/uds_consumer_contract.rs` is a cross-crate consumer of `Tools` that `cargo check -p trusty-audit --all-targets` never compiles. It set `search_url` to an HTTP stub while exercising the ANALYZE guard alone; it now points the search half at a path nothing binds, so a future edit that made `ensure_analyze` dial it fails there. `cargo check --workspace --all-targets` is clean, and `cargo test -p trusty-analyze --test uds_consumer_contract` reports `ok. 3 passed; 0 failed`.
- **The semver gate**, as above.

Refs #6285

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
