### PR TITLE
refactor(trusty-mpm): search GC and delete guard consume trusty-search over UDS (Refs #6285)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11713,7 +11713,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-mpm"
-version = "1.5.9"
+version = "1.5.10"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -13,7 +13,7 @@ name = "trusty-mpm"
 # 1.5.8 (#6288): patch — 1.5.7 is published and this PR edits `src/**`. Patch
 # because the removed items (`supervisor::http`, `SupervisorConfig::metrics_addr`)
 # have no out-of-workspace consumer, and every in-workspace caller moved with them.
-version = "1.5.9"
+version = "1.5.10"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/trusty-mpm/changelog.d/6285-search-gc-fail-safe-fixed.md
+++ b/crates/trusty-mpm/changelog.d/6285-search-gc-fail-safe-fixed.md
@@ -1,0 +1,14 @@
+Fixed
+
+- The orphan-index sweep no longer reads a failed status probe as an empty
+  index. It substituted `chunk_count: 0` for a refusal or an unanswered call, and
+  `0` is exactly the reading that makes an aged, unclaimed `.worktrees` index
+  collectable — so a wedged or restarting daemon could license a delete on
+  evidence that was never gathered. A candidate whose chunk count cannot be read
+  is now skipped, and a listing that goes unanswered ends the sweep with nothing
+  collected rather than erroring.
+- A destructive index delete is reported as removed only when the daemon says the
+  registration is gone. Any success answer used to count, including the #3049
+  body that reports `removed: false` because an in-flight writer never quiesced —
+  so the sweep recorded an index as reclaimed while it was still registered and
+  still on disk.

--- a/crates/trusty-mpm/changelog.d/6285-search-gc-uds-changed.md
+++ b/crates/trusty-mpm/changelog.d/6285-search-gc-uds-changed.md
@@ -1,0 +1,13 @@
+Changed
+
+- The managed-session search-index GC and the destructive index-delete capability
+  call the trusty-search daemon over its Unix socket (#6285, ADR-0032) —
+  `search.indexes.list`, `search.index.status` and `search.index.delete` in place
+  of `GET /indexes?details=true`, `GET /indexes/{id}/status` and
+  `DELETE /indexes/{id}?delete_data=true`. Both route through
+  `daemon::search_rpc`, this crate's one trusty-search client, so there is no
+  second address resolver and no second HTTP client to keep in step.
+- `DestructiveIndexDelete` refuses to hand out the capability when no daemon
+  socket is bound, which replaces the old "no `http_addr` discovery file" refusal
+  at the same point — before any request is built, and still after the #4743
+  test-process refusal that is checked first.

--- a/crates/trusty-mpm/src/daemon/search_rpc.rs
+++ b/crates/trusty-mpm/src/daemon/search_rpc.rs
@@ -23,7 +23,10 @@
 //!
 //! Test: `search_socket_honours_the_env_override`,
 //! `call_at_reports_a_dead_socket_rather_than_hanging`, and end-to-end through
-//! `doctor_tests::search_*` / `doctor_search_pin_tests::pinned_but_missing_index_is_fail`.
+//! `doctor_tests::search_*` / `doctor_search_pin_tests::pinned_but_missing_index_is_fail`;
+//! the session-manager consumers through
+//! `search_gc_guard_tests::sweep_skips_a_candidate_whose_status_probe_failed` and
+//! `index_delete_guard::tests::delete_over_a_stale_socket_is_a_transport_failure`.
 
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -61,6 +64,14 @@ pub const METHOD_INDEXES_LIST: &str = "search.indexes.list";
 /// One index's stages, capabilities and footprint. Answers
 /// [`crate::daemon::error::CODE_NOT_FOUND`] for an id the daemon does not hold.
 pub const METHOD_INDEX_STATUS: &str = "search.index.status";
+
+/// Deregister one index, and — with `delete_data: true` — destroy its on-disk
+/// data directory.
+///
+/// The only destructive method this crate names. It is reachable exclusively
+/// through `session_manager::index_delete_guard::DestructiveIndexDelete`, which
+/// holds the crate's one copy of the `delete_data` opt-in (#4743).
+pub const METHOD_INDEX_DELETE: &str = "search.index.delete";
 
 /// The daemon answered, and what it answered was an error.
 ///

--- a/crates/trusty-mpm/src/session_manager/index_delete_guard.rs
+++ b/crates/trusty-mpm/src/session_manager/index_delete_guard.rs
@@ -1,72 +1,97 @@
-//! The one door a destructive trusty-search index DELETE may pass through (#4743).
+//! The one door a destructive trusty-search index delete may pass through (#4743).
 //!
 //! Why: `search_gc` had two independent sites that formatted
 //! `DELETE /indexes/{id}?delete_data=true` — the decommission-time removal and
-//! the orphan sweep's delete loop. `?delete_data=true` destroys the index's
-//! on-disk data directory (trusty-search's own
-//! `delete_index_with_delete_data_true_destroys_data` asserts exactly that;
-//! its orphan reaper deliberately passes `delete_data=false`). The daemon those
-//! requests reach is whichever one `resolve_daemon_base_url` discovers, and
-//! under `cargo test` that is the OPERATOR'S live daemon: the address comes from
-//! `~/Library/Application Support/trusty-search/http_addr`, which a test process
-//! reads exactly like production does. Fixture workspaces derive their index id
-//! from a bare `file_name()` — `full`, `sess`, `live` — so a real index sharing
-//! that basename is destroyed by a test run, silently.
+//! the orphan sweep's delete loop. Destroying the data is opt-in (#4123), and
+//! the daemon those requests reached was whichever one discovery found. Under
+//! `cargo test` that is the OPERATOR'S live daemon: a test process resolves it
+//! exactly like production does. Fixture workspaces derive their index id from
+//! a bare `file_name()` — `full`, `sess`, `live` — so a real index sharing that
+//! basename is destroyed by a test run, silently.
 //!
 //! Why a capability type rather than an `if` at each site: two review rounds on
 //! PR #4725 each found a different destructive effect that a caller had failed
 //! to gate, and the response there was the same one taken here — stop relying on
 //! every call site remembering, and make the ungated shape unrepresentable. A
-//! caller cannot build the URL, because [`DestructiveIndexDelete`] holds the
-//! only copy of the `?delete_data=true` literal and exposes no constructor that
-//! takes a base URL. The only way to obtain one is [`DestructiveIndexDelete::acquire`],
-//! which decides for itself whether the process may destroy data. A new
-//! destructive site added later inherits the refusal by construction: it has to
-//! call `acquire` to get anything it can delete with.
+//! caller cannot build the request, because [`DestructiveIndexDelete`] holds the
+//! only copy of the `delete_data` opt-in and exposes no constructor that takes a
+//! daemon address. The only way to obtain one is
+//! [`DestructiveIndexDelete::acquire`], which decides for itself whether the
+//! process may destroy data. A new destructive site added later inherits the
+//! refusal by construction: it has to call `acquire` to get anything it can
+//! delete with.
 //!
 //! Why the refusal is a RUNTIME check: the delete lands in a DIFFERENT PROCESS.
 //! Issue #4094's `cfg(test)` arm in trusty-search's `default_data_dir` isolates
 //! that daemon's own data-dir resolution, and #4255/PR #4864 extended isolation
 //! to registry writes — but neither can help here. No compile-time guard in
-//! trusty-search governs what a trusty-mpm test binary puts on the wire, and no
-//! data-dir seam moves a request that is already addressed to port 7878.
+//! trusty-search governs what a trusty-mpm test binary puts on the wire.
 //! `trusty_common::running_under_test_harness` is the process-level answer, and
 //! reusing it keeps this crate from growing a second, drifting copy of the same
 //! detection.
 //!
+//! What #6285 changed: the transport, and nothing else. The call is
+//! `search.index.delete` over the daemon's Unix socket (ADR-0032) rather than
+//! `DELETE /indexes/{id}`, sent through [`crate::daemon::search_rpc`] — this
+//! crate's one trusty-search client. Who may acquire the capability did not
+//! move: the test-harness refusal is still the first thing `acquire` evaluates,
+//! still ahead of any resolution, and the `delete_data` opt-in still exists in
+//! exactly one place.
+//!
 //! Test: `acquire_is_refused_under_a_test_harness`,
+//! `acquire_refuses_when_no_daemon_socket_is_bound`,
 //! `acquire_succeeds_when_production_state_is_explicitly_allowed`,
-//! `delete_url_opts_into_data_deletion`; end-to-end,
+//! `delete_params_opt_into_data_deletion`,
+//! `delete_over_a_stale_socket_is_a_transport_failure`,
+//! `a_refusal_is_never_reported_as_removed`,
+//! `a_result_that_did_not_remove_is_not_reported_as_removed`; end-to-end,
 //! `decommission_issues_no_request_to_a_live_daemon_under_test` in
 //! `search_gc_guard_tests`.
 
+use std::path::PathBuf;
 use std::time::Duration;
 
+use serde_json::Value;
 use tracing::{debug, warn};
 
-/// Per-request timeout for the index DELETE.
+use crate::daemon::search_rpc::{self, SearchRpcError};
+
+/// Per-request timeout for the index delete.
 ///
 /// Why: the destructive call runs off the interactive request path
 /// (decommission, periodic GC) but must still never hang the daemon
 /// indefinitely if trusty-search is wedged.
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// Connect timeout, tighter than the overall request timeout so an unreachable
-/// host fails fast.
-const CONNECT_TIMEOUT: Duration = Duration::from_millis(750);
-
-/// What a destructive index DELETE did, for the caller to log in its own voice.
+/// What a destructive index delete did, for the caller to log in its own voice.
 ///
-/// Why: the two call sites want different log messages for the same three
-/// outcomes, and threading `reqwest` types back to them would leak the
-/// transport this module exists to own.
+/// Why: the two call sites want different log messages for the same outcomes,
+/// and threading the RPC types back to them would leak the transport this
+/// module exists to own.
+///
+/// Why four variants rather than worked / did not work: only [`Self::Removed`]
+/// licenses a caller to record an index as gone. The other three are distinct
+/// evidence — the daemon refused, the daemon answered but kept the index, or
+/// nothing answered at all — and collapsing them lets an unanswered call read
+/// as a completed one.
 #[derive(Debug)]
 pub(super) enum DeleteOutcome {
-    /// The daemon reported the index removed.
+    /// The daemon answered, and its answer says the registration is gone.
     Removed,
-    /// The daemon answered, but not with a 2xx.
-    Rejected(reqwest::StatusCode),
-    /// The request never got an answer.
+    /// The daemon answered, and its answer says the index is still registered.
+    ///
+    /// Reachable when an in-flight writer never released the teardown lock
+    /// (#3049): with `delete_data` requested, trusty-search abandons the delete
+    /// rather than destroying data underneath a running write.
+    NotRemoved(String),
+    /// The daemon answered with an error frame — its own code and wording.
+    Refused {
+        /// The daemon's JSON-RPC error code.
+        code: i64,
+        /// The daemon's own message.
+        message: String,
+    },
+    /// The call never got an answer.
     Transport(String),
 }
 
@@ -74,15 +99,14 @@ pub(super) enum DeleteOutcome {
 ///
 /// Why: see the module doc — holding one of these is the proof that this
 /// process is allowed to delete real data, and it is the only thing in the
-/// crate that can produce a `?delete_data=true` request.
-/// What: an acquired daemon base URL plus the short-timeout client to reach it.
-/// Both fields are private and there is no constructor other than
-/// [`Self::acquire`], so the capability cannot be forged from a base URL a
-/// caller happens to have.
+/// crate that can produce a `delete_data` request.
+/// What: the socket of a trusty-search daemon that was bound when the capability
+/// was acquired. The field is private and there is no constructor other than
+/// [`Self::acquire`], so the capability cannot be forged from a path a caller
+/// happens to have.
 /// Test: see the module doc.
 pub(super) struct DestructiveIndexDelete {
-    base: String,
-    client: reqwest::Client,
+    socket: PathBuf,
 }
 
 impl DestructiveIndexDelete {
@@ -94,153 +118,133 @@ impl DestructiveIndexDelete {
     /// call site away from being forgotten, which is precisely how the second
     /// destructive site in `search_gc` came to have no guard at all.
     /// What: `None` when (a) `trusty_common::running_under_test_harness()` says
-    /// this is a `cargo test` process, (b) no trusty-search daemon is
-    /// discoverable, or (c) the HTTP client cannot be built. `Some` otherwise.
-    /// The test refusal is checked FIRST so a test run never even resolves the
-    /// operator's daemon address.
+    /// this is a `cargo test` process, (b) the socket path cannot be resolved,
+    /// or (c) nothing is bound at it. `Some` otherwise. The test refusal is
+    /// checked FIRST so a test run never even resolves where the operator's
+    /// daemon lives.
+    ///
+    /// #6285: (c) replaces the old "no `http_addr` discovery file" arm. A bound
+    /// socket is what a running daemon leaves behind, so its absence carries the
+    /// same "there is nothing to talk to" signal, evaluated at the same point —
+    /// before any request is built. A socket file that outlived its daemon still
+    /// passes here and fails at [`Self::delete`], which reports it as
+    /// [`DeleteOutcome::Transport`] and deletes nothing.
     ///
     /// A test that genuinely needs to drive a real daemon sets
     /// `TRUSTY_ALLOW_PRODUCTION_STATE=1` (`trusty_common::test_harness::ALLOW_PRODUCTION_ENV`),
     /// which makes that intent explicit and greppable instead of ambient.
     /// Test: `acquire_is_refused_under_a_test_harness`,
+    /// `acquire_refuses_when_no_daemon_socket_is_bound`,
     /// `acquire_succeeds_when_production_state_is_explicitly_allowed`.
     pub(super) fn acquire() -> Option<Self> {
         // #4743: a `cargo test` process may not destroy index data. Checked
-        // before discovery so a test run does not even look up where the
+        // before resolution so a test run does not even look up where the
         // operator's daemon lives.
         if trusty_common::running_under_test_harness() {
             warn!(
-                "refusing a destructive trusty-search index DELETE: this is a test process \
+                "refusing a destructive trusty-search index delete: this is a test process \
                  (#4743). Set {} to override.",
                 trusty_common::test_harness::ALLOW_PRODUCTION_ENV
             );
             return None;
         }
-        let Some(base) = trusty_common::resolve_daemon_base_url("trusty-search") else {
-            debug!("trusty-search daemon not discoverable; skipping index removal (#2033)");
-            return None;
-        };
-        match reqwest::Client::builder()
-            .timeout(REQUEST_TIMEOUT)
-            .connect_timeout(CONNECT_TIMEOUT)
-            .build()
-        {
-            Ok(client) => Some(Self { base, client }),
+        let socket = match search_rpc::search_socket() {
+            Ok(socket) => socket,
             Err(e) => {
-                warn!("trusty-search index-delete client build failed: {e}");
-                None
+                warn!("cannot resolve the trusty-search socket; skipping index removal: {e:#}");
+                return None;
             }
+        };
+        // #6285: nothing bound means no daemon to ask — the no-op the old
+        // `resolve_daemon_base_url` miss produced.
+        if !socket.exists() {
+            debug!(
+                socket = %socket.display(),
+                "no trusty-search daemon socket; skipping index removal (#2033)"
+            );
+            return None;
         }
+        Some(Self { socket })
     }
 
-    /// The destructive URL for `index_id` — the crate's only `?delete_data=true`.
+    /// The destructive params for `index_id` — the crate's only `delete_data`
+    /// opt-in.
     ///
-    /// Why (#4123): trusty-search's `DELETE /indexes/:id` preserves on-disk data
-    /// unless `delete_data=true` is passed. Both callers opt in deliberately:
-    /// the workspace each index describes is a disposable worktree that is
-    /// being (or has been) deleted, so preserved index data would be
-    /// unreachable garbage on disk forever.
-    /// What: `{base}/indexes/{index_id}?delete_data=true`. Private, and
-    /// reachable only through an acquired capability.
-    /// Test: `delete_url_opts_into_data_deletion`.
-    fn delete_url(&self, index_id: &str) -> String {
-        format!("{}/indexes/{index_id}?delete_data=true", self.base)
+    /// Why (#4123): trusty-search's `search.index.delete` preserves on-disk data
+    /// unless `delete_data` is `true`. Both callers opt in deliberately: the
+    /// workspace each index describes is a disposable worktree that is being (or
+    /// has been) deleted, so preserved index data would be unreachable garbage
+    /// on disk forever.
+    /// What: `{"index_id": …, "delete_data": true}`. A method rather than a free
+    /// function so it cannot be called without a capability in hand.
+    /// Test: `delete_params_opt_into_data_deletion`.
+    fn delete_params(&self, index_id: &str) -> Value {
+        serde_json::json!({ "index_id": index_id, "delete_data": true })
     }
 
-    /// Issue the DELETE and classify the result.
+    /// Issue the delete and classify the result.
     ///
-    /// What: never returns an error — every failure mode maps to a
+    /// Why: never returns an error — every failure mode maps to a
     /// [`DeleteOutcome`] variant so both callers stay fail-soft (an unreachable
     /// or erroring search daemon must not block session teardown).
-    /// Test: covered end-to-end by
+    /// What: one [`REQUEST_TIMEOUT`]-bounded `search.index.delete`. A refusal
+    /// carries the daemon's own code, an unanswered call is
+    /// [`DeleteOutcome::Transport`], and a result is believed only as far as its
+    /// own `removed` field — see [`classify_delete_result`]. No arm but a
+    /// daemon-confirmed removal produces [`DeleteOutcome::Removed`].
+    /// Test: `delete_over_a_stale_socket_is_a_transport_failure`,
+    /// `a_refusal_is_never_reported_as_removed`,
+    /// `a_result_that_did_not_remove_is_not_reported_as_removed`; end-to-end by
     /// `decommission_issues_no_request_to_a_live_daemon_under_test`, which
     /// asserts this never runs under a test harness.
     pub(super) async fn delete(&self, index_id: &str) -> DeleteOutcome {
-        match self.client.delete(self.delete_url(index_id)).send().await {
-            Ok(resp) if resp.status().is_success() => DeleteOutcome::Removed,
-            Ok(resp) => DeleteOutcome::Rejected(resp.status()),
-            Err(e) => DeleteOutcome::Transport(e.to_string()),
+        let params = self.delete_params(index_id);
+        match search_rpc::call_at(
+            &self.socket,
+            search_rpc::METHOD_INDEX_DELETE,
+            params,
+            REQUEST_TIMEOUT,
+        )
+        .await
+        {
+            Ok(body) => classify_delete_result(&body),
+            Err(e) => match e.downcast_ref::<SearchRpcError>() {
+                Some(rpc) => DeleteOutcome::Refused {
+                    code: rpc.code,
+                    message: rpc.message.clone(),
+                },
+                None => DeleteOutcome::Transport(format!("{e:#}")),
+            },
         }
     }
+}
+
+/// Read a delete result as the daemon's own verdict, not as "it answered".
+///
+/// Why: `search.index.delete` answers a RESULT — not an error — for a delete it
+/// abandoned because an in-flight writer never quiesced (#3049). Over HTTP that
+/// was a `200`, and treating any 2xx as success recorded an index as reclaimed
+/// while it was still registered and still on disk. The daemon states the
+/// outcome in the body; this reads it.
+/// What: [`DeleteOutcome::Removed`] only when the body's `removed` is `true`. A
+/// body that says otherwise — or that omits the field, which is unverifiable
+/// rather than affirmative — is [`DeleteOutcome::NotRemoved`] carrying the
+/// daemon's `quiesced` flag, the field that explains the abandonment.
+/// Test: `a_result_that_did_not_remove_is_not_reported_as_removed`,
+/// `a_result_reporting_removal_is_removed`.
+fn classify_delete_result(body: &Value) -> DeleteOutcome {
+    if body.get("removed").and_then(Value::as_bool) == Some(true) {
+        return DeleteOutcome::Removed;
+    }
+    let quiesced = match body.get("quiesced").and_then(Value::as_bool) {
+        Some(v) => v.to_string(),
+        None => "unreported".to_string(),
+    };
+    DeleteOutcome::NotRemoved(format!(
+        "the daemon did not remove the index (quiesced: {quiesced})"
+    ))
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// The load-bearing assertion, made from inside the very thing it detects:
-    /// this test IS a `cargo test` process, so `acquire` must refuse it.
-    ///
-    /// Why no injection: a decision table with fabricated inputs would prove
-    /// the precedence rules (`trusty-common` already tests those) but not the
-    /// only fact that matters here — that a real trusty-mpm test binary is
-    /// classified as one. Reverting the `running_under_test_harness` branch in
-    /// `acquire` fails this on any machine with a running trusty-search daemon.
-    /// Test: this function IS the test.
-    #[test]
-    fn acquire_is_refused_under_a_test_harness() {
-        assert!(
-            DestructiveIndexDelete::acquire().is_none(),
-            "a cargo test process must never acquire the destructive-delete capability (#4743)"
-        );
-    }
-
-    /// The escape hatch works, and the guard is not over-applied into a
-    /// permanent disablement of the orphan GC.
-    ///
-    /// Why: a refusal that could never be lifted would be indistinguishable
-    /// from having deleted the feature, and nothing would notice if `acquire`
-    /// started returning `None` unconditionally.
-    /// What: with `TRUSTY_ALLOW_PRODUCTION_STATE=1` and a discoverable daemon
-    /// address written into an ISOLATED data dir, `acquire` yields a capability
-    /// pointed at that isolated address. Deliberately never calls `delete` — the
-    /// address belongs to nothing, and issuing a request is not what is under
-    /// test.
-    /// Test: this function IS the test.
-    #[serial_test::serial]
-    #[test]
-    fn acquire_succeeds_when_production_state_is_explicitly_allowed() {
-        let dir = crate::test_support::hermetic_temp_dir();
-        std::fs::create_dir_all(dir.path().join("trusty-search")).unwrap();
-        std::fs::write(
-            dir.path().join("trusty-search").join("http_addr"),
-            "127.0.0.1:59999",
-        )
-        .unwrap();
-
-        // SAFETY: `#[serial]` — no other test thread races this set/restore.
-        unsafe {
-            std::env::set_var(trusty_common::DATA_DIR_OVERRIDE_ENV, dir.path());
-            std::env::set_var(trusty_common::test_harness::ALLOW_PRODUCTION_ENV, "1");
-        }
-        let acquired = DestructiveIndexDelete::acquire();
-        let url = acquired.as_ref().map(|d| d.delete_url("some-index"));
-        unsafe {
-            std::env::remove_var(trusty_common::test_harness::ALLOW_PRODUCTION_ENV);
-            std::env::remove_var(trusty_common::DATA_DIR_OVERRIDE_ENV);
-        }
-
-        assert_eq!(
-            url.as_deref(),
-            Some("http://127.0.0.1:59999/indexes/some-index?delete_data=true"),
-            "the explicit production opt-in must still yield a working capability"
-        );
-    }
-
-    /// The opt-in that makes the call destructive must survive refactoring —
-    /// a URL that lost `?delete_data=true` would silently leak index data
-    /// forever (#4123), the failure this whole module is downstream of.
-    /// Test: this function IS the test.
-    #[serial_test::serial]
-    #[test]
-    fn delete_url_opts_into_data_deletion() {
-        let cap = DestructiveIndexDelete {
-            base: "http://127.0.0.1:7878".into(),
-            client: reqwest::Client::new(),
-        };
-        assert_eq!(
-            cap.delete_url("my-index"),
-            "http://127.0.0.1:7878/indexes/my-index?delete_data=true"
-        );
-    }
-}
+#[path = "index_delete_guard_tests.rs"]
+mod tests;

--- a/crates/trusty-mpm/src/session_manager/index_delete_guard_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/index_delete_guard_tests.rs
@@ -1,0 +1,265 @@
+//! Who may acquire the destructive-delete capability, and what it reports when
+//! the daemon does not confirm a removal (#4743, #6285).
+//!
+//! Why these two things together: #4743's guarantee is that a `cargo test`
+//! process never reaches a daemon on this path, and #6285 moved the path onto a
+//! Unix socket. A transport move is exactly where a guard silently stops
+//! applying, and exactly where a failure arm silently starts reading as success
+//! — so the acquisition rules and the outcome classification are pinned in one
+//! place.
+//!
+//! Why a real mock daemon rather than a dead path for most of these: a dead path
+//! makes "the guard refused" and "nothing was listening" indistinguishable. The
+//! daemon here WOULD answer, so a refusal is evidence about this crate's
+//! behaviour rather than about the machine.
+//!
+//! Test: the eight functions below.
+
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use serde_json::{Value, json};
+
+use super::*;
+use crate::test_support::isolated_daemon_home;
+use crate::uds_mock::{self, MockFuture, RpcError};
+
+/// The socket production resolution derives under the active override — the
+/// path `acquire` will look at and a mock daemon must bind.
+fn resolved_socket() -> PathBuf {
+    trusty_common::daemon_socket_path("trusty-search").expect("derive the trusty-search socket")
+}
+
+/// Every `(method, params)` one mock daemon was asked for.
+type Recorder = Arc<Mutex<Vec<(String, Value)>>>;
+
+/// A handler that records what it was called with and answers `result`.
+fn recording(seen: Recorder, result: Value) -> impl Fn(&str, Value) -> MockFuture + Send + Sync {
+    move |method, params| {
+        seen.lock()
+            .expect("recorder lock")
+            .push((method.to_string(), params));
+        let result = result.clone();
+        Box::pin(async move { Ok(result) })
+    }
+}
+
+/// A handler that refuses every call with `code`.
+fn refusing(code: i64, message: &str) -> impl Fn(&str, Value) -> MockFuture + Send + Sync {
+    let message = message.to_string();
+    move |_method, _params| {
+        let error = RpcError::new(code, message.clone());
+        Box::pin(async move { Err(error) })
+    }
+}
+
+// ---- acquisition ---------------------------------------------------------
+
+/// The load-bearing assertion, made from inside the very thing it detects:
+/// this test IS a `cargo test` process, so `acquire` must refuse it.
+///
+/// Why no injection: a decision table with fabricated inputs would prove the
+/// precedence rules (`trusty-common` already tests those) but not the only fact
+/// that matters here — that a real trusty-mpm test binary is classified as one.
+/// Reverting the `running_under_test_harness` branch in `acquire` fails this on
+/// any machine with a running trusty-search daemon.
+/// Test: this function IS the test.
+#[test]
+fn acquire_is_refused_under_a_test_harness() {
+    assert!(
+        DestructiveIndexDelete::acquire().is_none(),
+        "a cargo test process must never acquire the destructive-delete capability (#4743)"
+    );
+}
+
+/// #6285's replacement for the "no `http_addr` discovery file" refusal: with the
+/// harness check lifted and nothing bound, there is no daemon to destroy
+/// anything with.
+///
+/// Why it matters: the socket path resolves whether or not a daemon exists —
+/// unlike the old discovery file, whose absence WAS the answer. Without this
+/// arm the capability would be handed out on every machine, and the first thing
+/// that noticed would be a failed request.
+/// Test: this function IS the test.
+#[serial_test::serial]
+#[test]
+fn acquire_refuses_when_no_daemon_socket_is_bound() {
+    let (_dir, _scope) = isolated_daemon_home(true);
+    assert!(
+        DestructiveIndexDelete::acquire().is_none(),
+        "no bound socket means no daemon to delete through"
+    );
+}
+
+/// The escape hatch works, and the guard is not over-applied into a permanent
+/// disablement of the orphan GC.
+///
+/// Why: a refusal that could never be lifted would be indistinguishable from
+/// having deleted the feature, and nothing would notice if `acquire` started
+/// returning `None` unconditionally.
+/// What: with `TRUSTY_ALLOW_PRODUCTION_STATE=1` and a mock daemon bound where
+/// production resolution looks, `acquire` yields a capability pointed at THAT
+/// socket — the isolated one, never the operator's.
+/// Test: this function IS the test.
+#[serial_test::serial]
+#[tokio::test]
+async fn acquire_succeeds_when_production_state_is_explicitly_allowed() {
+    let (_dir, _scope) = isolated_daemon_home(true);
+    let socket = resolved_socket();
+    let _daemon = uds_mock::spawn_at(socket.clone(), uds_mock::always(json!({}))).await;
+
+    let acquired = DestructiveIndexDelete::acquire().expect("the explicit opt-in must yield one");
+    assert_eq!(
+        acquired.socket, socket,
+        "the capability must point at the resolved socket"
+    );
+}
+
+// ---- what goes on the wire -----------------------------------------------
+
+/// The opt-in that makes the call destructive must survive refactoring — a
+/// request that lost `delete_data` would silently leak index data forever
+/// (#4123), the failure this whole module is downstream of.
+///
+/// Why at the wire rather than on the params function: the method NAME is the
+/// other half. trusty-mpm has no Cargo edge on trusty-search, so a drifted name
+/// answers `method_not_found` and nothing local catches it.
+/// Test: this function IS the test.
+#[serial_test::serial]
+#[tokio::test]
+async fn delete_params_opt_into_data_deletion() {
+    let (_dir, _scope) = isolated_daemon_home(true);
+    let seen: Recorder = Arc::new(Mutex::new(Vec::new()));
+    let _daemon = uds_mock::spawn_at(
+        resolved_socket(),
+        recording(Arc::clone(&seen), json!({ "removed": true })),
+    )
+    .await;
+
+    let cap = DestructiveIndexDelete::acquire().expect("capability");
+    cap.delete("my-index").await;
+
+    let calls = seen.lock().expect("recorder lock").clone();
+    assert_eq!(
+        calls,
+        vec![(
+            "search.index.delete".to_string(),
+            json!({ "index_id": "my-index", "delete_data": true })
+        )],
+        "the destructive call must name trusty-search's own method and carry the opt-in"
+    );
+}
+
+// ---- failure arms: nothing unconfirmed may read as a removal --------------
+
+/// A socket file that outlived its daemon is a transport failure, never a
+/// removal.
+///
+/// Why this shape: `acquire`'s existence check passes on a stale socket, so the
+/// last thing standing between a crashed daemon and a falsely-recorded delete is
+/// how `delete` classifies a dial failure. A plain file at the socket path
+/// reproduces that exactly — resolution succeeds, connection does not.
+/// Test: this function IS the test.
+#[serial_test::serial]
+#[tokio::test]
+async fn delete_over_a_stale_socket_is_a_transport_failure() {
+    let (_dir, _scope) = isolated_daemon_home(true);
+    let socket = resolved_socket();
+    std::fs::create_dir_all(socket.parent().expect("socket parent"))
+        .expect("create the daemon dir");
+    std::fs::write(&socket, b"").expect("leave a stale socket file");
+
+    let cap = DestructiveIndexDelete::acquire().expect("a stale socket still resolves");
+    let outcome = cap.delete("my-index").await;
+
+    assert!(
+        matches!(outcome, DeleteOutcome::Transport(_)),
+        "an unanswered delete must report the transport failure, never a removal: {outcome:?}"
+    );
+}
+
+/// A daemon that refuses reports its own code, and reports nothing removed.
+///
+/// Why: `search.index.delete` answers not-found for an index the daemon does not
+/// hold (#6363). Reading that as "gone, then" would let the sweep record a
+/// removal it never performed.
+/// Test: this function IS the test.
+#[serial_test::serial]
+#[tokio::test]
+async fn a_refusal_is_never_reported_as_removed() {
+    let (_dir, _scope) = isolated_daemon_home(true);
+    let _daemon = uds_mock::spawn_at(
+        resolved_socket(),
+        refusing(
+            crate::daemon::error::CODE_NOT_FOUND,
+            "unknown index: my-index",
+        ),
+    )
+    .await;
+
+    let cap = DestructiveIndexDelete::acquire().expect("capability");
+    let outcome = cap.delete("my-index").await;
+
+    match outcome {
+        DeleteOutcome::Refused { code, ref message } => {
+            assert_eq!(code, crate::daemon::error::CODE_NOT_FOUND);
+            assert!(message.contains("unknown index"), "message: {message}");
+        }
+        other => panic!("a refusal must carry the daemon's own code: {other:?}"),
+    }
+}
+
+/// The #3049 arm: the daemon ANSWERED, and its answer says the index is still
+/// there.
+///
+/// Why: with `delete_data` requested and an in-flight writer that never
+/// quiesced, trusty-search abandons the delete and reports `removed: false` in a
+/// SUCCESS body. Over HTTP that was a 200, and any-2xx-is-success recorded the
+/// index as reclaimed while every byte of it was still on disk. Preserving that
+/// bug across the transport move is what this pins against.
+/// Test: this function IS the test.
+#[serial_test::serial]
+#[tokio::test]
+async fn a_result_that_did_not_remove_is_not_reported_as_removed() {
+    let (_dir, _scope) = isolated_daemon_home(true);
+    let _daemon = uds_mock::spawn_at(
+        resolved_socket(),
+        uds_mock::always(json!({ "ok": true, "removed": false, "quiesced": false })),
+    )
+    .await;
+
+    let cap = DestructiveIndexDelete::acquire().expect("capability");
+    let outcome = cap.delete("my-index").await;
+
+    match outcome {
+        DeleteOutcome::NotRemoved(ref detail) => {
+            assert!(detail.contains("quiesced: false"), "detail: {detail}");
+        }
+        other => panic!("an abandoned delete must not read as a removal: {other:?}"),
+    }
+}
+
+/// The fixture premise for the two arms above: a daemon that DOES remove the
+/// index is reported as a removal.
+///
+/// Why: without it, `classify_delete_result` returning `NotRemoved`
+/// unconditionally would pass every other test in this file.
+/// Test: this function IS the test.
+#[serial_test::serial]
+#[tokio::test]
+async fn a_result_reporting_removal_is_removed() {
+    let (_dir, _scope) = isolated_daemon_home(true);
+    let _daemon = uds_mock::spawn_at(
+        resolved_socket(),
+        uds_mock::always(json!({ "ok": true, "removed": true, "data_deleted": true })),
+    )
+    .await;
+
+    let cap = DestructiveIndexDelete::acquire().expect("capability");
+    let outcome = cap.delete("my-index").await;
+
+    assert!(
+        matches!(outcome, DeleteOutcome::Removed),
+        "a confirmed removal must read as one: {outcome:?}"
+    );
+}

--- a/crates/trusty-mpm/src/session_manager/search_gc.rs
+++ b/crates/trusty-mpm/src/session_manager/search_gc.rs
@@ -16,10 +16,10 @@
 //! production cap) rather than growing either file — this module's `impl
 //! SessionManager` block is additive, exactly like `adopt.rs`/`prune.rs`.
 //! Test: `disposable_index_id_*`, `is_orphan_index_*` in `tests` below (pure,
-//! no live daemon required); the live-HTTP paths are best-effort/fail-soft by
-//! design and are exercised the same way the shared
-//! `trusty_common::search_index` register path's daemon-down path is
-//! (integration-only).
+//! no live daemon required); the daemon-facing paths by
+//! `sweep_orphaned_search_indexes_noop_when_daemon_unreachable`,
+//! `sweep_skips_a_candidate_whose_status_probe_failed` and
+//! `sweep_makes_no_request_under_a_test_harness` in `search_gc_guard_tests`.
 
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
@@ -31,18 +31,16 @@ use tracing::{debug, info, warn};
 use super::decommission::is_session_worktree;
 use super::index_delete_guard::{DeleteOutcome, DestructiveIndexDelete};
 use super::manager::SessionManager;
+use crate::daemon::search_rpc::{self, SearchRpcError};
 
 /// Per-request timeout for the READ-ONLY trusty-search calls in this module
 /// (the sweep's index listing and status probes).
 ///
 /// Why: these calls run off the interactive request path (decommission,
 /// periodic GC) but must still never hang the daemon indefinitely if
-/// trusty-search is wedged. The destructive DELETE carries its own timeouts
+/// trusty-search is wedged. The destructive delete carries its own timeout
 /// inside [`DestructiveIndexDelete`] (#4743).
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
-/// Connect timeout, tighter than the overall request timeout so an
-/// unreachable host fails fast.
-const CONNECT_TIMEOUT: Duration = Duration::from_millis(750);
 
 /// How old a `.worktrees` root must be before a 0-chunk index rooted at it is
 /// eligible for deletion (#5065 review).
@@ -100,8 +98,8 @@ pub(super) fn disposable_workspace_index_id(
     if id.trim().is_empty() { None } else { Some(id) }
 }
 
-/// Best-effort `DELETE {base}/indexes/{index_id}` against the discovered
-/// trusty-search daemon (#2033).
+/// Best-effort `search.index.delete` against the running trusty-search daemon
+/// (#2033).
 ///
 /// Why: decommissioning a disposable managed-session workspace removes its
 /// directory from disk; leaving its trusty-search index registered is exactly
@@ -110,15 +108,15 @@ pub(super) fn disposable_workspace_index_id(
 /// teardown, so every outcome is logged and swallowed here — the caller
 /// (`decommission_with_root`) invokes this unconditionally.
 /// What: acquires the [`DestructiveIndexDelete`] capability and, when granted,
-/// issues the DELETE and logs the outcome (removed / non-2xx / transport error)
-/// at info/warn. A refused capability — daemon never started, or this is a test
-/// process (#4743) — is a no-op, logged by `acquire` itself.
+/// issues the delete and logs which of the four outcomes it got. A refused
+/// capability — no daemon socket bound, or this is a test process (#4743) — is a
+/// no-op, logged by `acquire` itself.
 /// Test: exercised via the live-daemon decommission integration path;
 /// `decommission_issues_no_request_to_a_live_daemon_under_test` pins that a
 /// test process reaches the daemon zero times.
 pub(super) async fn delete_search_index_best_effort(index_id: &str) {
-    // #4743: no base URL, no client, no `?delete_data=true` without this. A
-    // test process cannot acquire it, so the request is never built at all.
+    // #4743: no socket, no request, no `delete_data` opt-in without this. A
+    // test process cannot acquire it, so the call is never built at all.
     let Some(deleter) = DestructiveIndexDelete::acquire() else {
         return;
     };
@@ -129,11 +127,16 @@ pub(super) async fn delete_search_index_best_effort(index_id: &str) {
                 "decommission: removed trusty-search index (#2033)"
             );
         }
-        DeleteOutcome::Rejected(status) => {
+        DeleteOutcome::NotRemoved(detail) => {
             warn!(
                 index_id,
-                %status,
-                "decommission: trusty-search index delete returned non-2xx"
+                "decommission: trusty-search kept the index: {detail}"
+            );
+        }
+        DeleteOutcome::Refused { code, message } => {
+            warn!(
+                index_id,
+                code, "decommission: trusty-search index delete refused: {message}"
             );
         }
         DeleteOutcome::Transport(e) => {
@@ -145,34 +148,18 @@ pub(super) async fn delete_search_index_best_effort(index_id: &str) {
     }
 }
 
-/// Build the short-timeout `reqwest::Client` shared by the READ-ONLY
-/// search-index calls in this module.
-fn build_client() -> reqwest::Result<reqwest::Client> {
-    reqwest::Client::builder()
-        .timeout(REQUEST_TIMEOUT)
-        .connect_timeout(CONNECT_TIMEOUT)
-        .build()
-}
-
-/// Wire shape of one row of `GET /indexes?details=true`.
+/// Wire shape of one row of `search.indexes.list` with `details`.
 #[derive(Debug, Deserialize)]
 struct IndexDetailRow {
     id: String,
     root_path: Option<String>,
 }
 
-/// Wire shape of `GET /indexes?details=true`.
+/// Wire shape of `search.indexes.list` with `details`.
 #[derive(Debug, Deserialize, Default)]
 struct IndexDetailsResponse {
     #[serde(default)]
     indexes: Vec<IndexDetailRow>,
-}
-
-/// Wire shape of the fields we need from `GET /indexes/:id/status`.
-#[derive(Debug, Deserialize, Default)]
-struct IndexStatusRow {
-    #[serde(default)]
-    chunk_count: u64,
 }
 
 /// A minimal snapshot of one registered trusty-search index, enough to decide
@@ -254,12 +241,26 @@ fn root_is_within_grace(root: &Path, grace: Duration) -> bool {
 }
 
 /// Fetch `(id, root_path)` for every index registered with the daemon.
-async fn fetch_index_details(
-    client: &reqwest::Client,
-    base: &str,
-) -> anyhow::Result<Vec<(String, PathBuf)>> {
-    let url = format!("{base}/indexes?details=true");
-    let body: IndexDetailsResponse = client.get(&url).send().await?.json().await?;
+///
+/// # Errors
+///
+/// When the daemon cannot be reached, refuses the call, or answers a body this
+/// cannot decode. The caller decides what each means — see
+/// [`SessionManager::sweep_orphaned_search_indexes`], which treats an
+/// unanswered listing as "no daemon, nothing to sweep" and a refusal as a fault
+/// worth reporting.
+/// Test: `sweep_skips_a_candidate_whose_status_probe_failed` drives the success
+/// path; `sweep_orphaned_search_indexes_noop_when_daemon_unreachable` the
+/// transport failure.
+async fn fetch_index_details(socket: &Path) -> anyhow::Result<Vec<(String, PathBuf)>> {
+    let value = search_rpc::call_at(
+        socket,
+        search_rpc::METHOD_INDEXES_LIST,
+        serde_json::json!({ "details": true }),
+        REQUEST_TIMEOUT,
+    )
+    .await?;
+    let body: IndexDetailsResponse = serde_json::from_value(value)?;
     Ok(body
         .indexes
         .into_iter()
@@ -267,21 +268,33 @@ async fn fetch_index_details(
         .collect())
 }
 
-/// Fetch `chunk_count` for one index. A non-2xx or transport error is treated
-/// as `0` (fail-open toward "looks empty, worth reconsidering") since the
-/// caller's [`is_orphan_index`] check ALSO requires the index to be
-/// `.worktrees`-scoped and unclaimed by any live session before this value
-/// can result in deletion — a genuinely populated, still-claimed index is
-/// never at risk from a flaky status probe.
-async fn fetch_chunk_count(client: &reqwest::Client, base: &str, id: &str) -> u64 {
-    let url = format!("{base}/indexes/{id}/status");
-    match client.get(&url).send().await {
-        Ok(resp) if resp.status().is_success() => resp
-            .json::<IndexStatusRow>()
-            .await
-            .map(|s| s.chunk_count)
-            .unwrap_or(0),
-        _ => 0,
+/// Read `chunk_count` for one index, or `None` when the daemon did not tell us.
+///
+/// Why `Option` (#6285): this used to answer `0` for a failed probe, on the
+/// reasoning that [`is_orphan_index`]'s other conditions would catch anything
+/// important. They do not. `0` is the value that makes an aged, unclaimed
+/// `.worktrees` index collectable, so a wedged daemon, a timed-out call or a
+/// one-off refusal read as "this index is empty" and licensed a delete on
+/// evidence that was never gathered. An unreachable daemon must never read as an
+/// absent index.
+/// What: `Some(n)` only when the daemon answered with a `chunk_count`; `None` for
+/// a refusal, a transport failure, or a result that omits the field. The caller
+/// skips a `None` candidate entirely rather than substituting a value for it.
+/// Test: `sweep_skips_a_candidate_whose_status_probe_failed`.
+async fn probe_chunk_count(socket: &Path, id: &str) -> Option<u64> {
+    match search_rpc::call_at(
+        socket,
+        search_rpc::METHOD_INDEX_STATUS,
+        serde_json::json!({ "index_id": id }),
+        REQUEST_TIMEOUT,
+    )
+    .await
+    {
+        Ok(body) => body.get("chunk_count").and_then(serde_json::Value::as_u64),
+        Err(e) => {
+            debug!(index_id = %id, "search-index-gc: status probe failed: {e:#}");
+            None
+        }
     }
 }
 
@@ -315,24 +328,31 @@ impl SessionManager {
     /// flagged hundreds of these). This is the periodic backstop, mirroring
     /// `prune::prune_orphaned_worktrees`'s "orphan == not claimed by any live
     /// session" shape.
-    /// What: lists every registered index (`GET /indexes?details=true`),
-    /// keeps only `.worktrees`-scoped candidates ([`is_session_worktree`]) not
-    /// claimed by `active_workspace_path_set`, fetches each candidate's
-    /// `chunk_count`, and applies [`is_orphan_index`]. Under `dry_run` the
-    /// matching ids are logged and returned without deleting anything
-    /// (mirrors `PruneWorktreesRequest`'s dry-run-by-default convention);
-    /// otherwise each is removed via the [`DestructiveIndexDelete`] capability,
-    /// logged individually (no silent truncation), and returned. Returns
-    /// `Ok(vec![])` without error when the daemon is undiscoverable — the sweep
-    /// is best-effort, like the rest of the orphan-GC loop.
+    /// What: lists every registered index (`search.indexes.list` with
+    /// `details`), keeps only `.worktrees`-scoped candidates
+    /// ([`is_session_worktree`]) not claimed by `active_workspace_path_set`,
+    /// reads each candidate's `chunk_count`, and applies [`is_orphan_index`].
+    /// Under `dry_run` the matching ids are logged and returned without deleting
+    /// anything (mirrors `PruneWorktreesRequest`'s dry-run-by-default
+    /// convention); otherwise each is removed via the
+    /// [`DestructiveIndexDelete`] capability, logged individually (no silent
+    /// truncation), and returned. Returns `Ok(vec![])` without error when no
+    /// daemon answers — the sweep is best-effort, like the rest of the
+    /// orphan-GC loop.
+    ///
+    /// #6285: an unreachable daemon and an absent index are held apart at both
+    /// steps. A listing that goes unanswered ends the sweep with nothing
+    /// collected; a candidate whose status probe goes unanswered is skipped
+    /// rather than assumed empty. Neither can produce a delete.
     ///
     /// #4743: a non-dry-run sweep acquires the destructive capability BEFORE
     /// listing anything, so a test process returns `Ok(vec![])` having made no
     /// request at all rather than enumerating the operator's real indexes.
     /// Test: `is_orphan_index_*` cover the pure decision; this async
-    /// orchestration is exercised via the daemon-unreachable no-op path in
-    /// `sweep_orphaned_search_indexes_noop_when_daemon_unreachable`, and the
-    /// test-process refusal by `sweep_makes_no_request_under_a_test_harness`.
+    /// orchestration is exercised by
+    /// `sweep_orphaned_search_indexes_noop_when_daemon_unreachable`,
+    /// `sweep_skips_a_candidate_whose_status_probe_failed`, and the test-process
+    /// refusal by `sweep_makes_no_request_under_a_test_harness`.
     pub async fn sweep_orphaned_search_indexes(
         &self,
         dry_run: bool,
@@ -351,13 +371,28 @@ impl SessionManager {
             }
         };
 
-        let Some(base) = trusty_common::resolve_daemon_base_url("trusty-search") else {
-            debug!("trusty-search daemon not discoverable; skipping index orphan sweep (#2033)");
-            return Ok(Vec::new());
+        let socket = match search_rpc::search_socket() {
+            Ok(socket) => socket,
+            Err(e) => {
+                debug!(
+                    "cannot resolve the trusty-search socket; skipping index orphan sweep: {e:#}"
+                );
+                return Ok(Vec::new());
+            }
         };
-        let client = build_client()?;
 
-        let details = fetch_index_details(&client, &base).await?;
+        let details = match fetch_index_details(&socket).await {
+            Ok(details) => details,
+            // #6285: an unanswered listing is "no daemon", the no-op this sweep
+            // has always been on a machine without one. A REFUSAL is different —
+            // a daemon that answered and said no is a fault the GC loop should
+            // report, not a quiet skip.
+            Err(e) if e.downcast_ref::<SearchRpcError>().is_none() => {
+                debug!("trusty-search daemon unreachable; skipping index orphan sweep: {e:#}");
+                return Ok(Vec::new());
+            }
+            Err(e) => return Err(e),
+        };
         let active_workspace_paths = self.active_workspace_path_set().await;
 
         let mut candidates = Vec::new();
@@ -367,7 +402,12 @@ impl SessionManager {
             if !is_session_worktree(&root_path) {
                 continue;
             }
-            let chunk_count = fetch_chunk_count(&client, &base, &id).await;
+            // #6285: no chunk count, no verdict. Substituting a value here is
+            // what let an unreachable daemon read as an empty index — see
+            // `probe_chunk_count`.
+            let Some(chunk_count) = probe_chunk_count(&socket, &id).await else {
+                continue;
+            };
             let snapshot = IndexSnapshot {
                 id: id.clone(),
                 root_path,
@@ -389,23 +429,25 @@ impl SessionManager {
 
         let mut removed = Vec::new();
         for id in candidates {
-            // #4743: the `?delete_data=true` opt-in that used to be formatted
-            // inline here now lives inside the capability, so this loop and the
+            // #4743: the `delete_data` opt-in that used to be formatted inline
+            // here lives inside the capability, so this loop and the
             // decommission-time delete share one destructive door instead of
             // two independently-guarded ones. Its #4123 rationale is unchanged:
             // every candidate is a worktree-scoped index with no live session,
-            // so its data is unreachable garbage a bare DELETE would leak.
+            // so its data is unreachable garbage a bare delete would leak.
             match deleter.delete(&id).await {
                 DeleteOutcome::Removed => {
                     info!(index_id = %id, "search-index-gc: removed orphaned/0-chunk index");
                     removed.push(id);
                 }
-                DeleteOutcome::Rejected(status) => {
-                    warn!(
-                        index_id = %id,
-                        %status,
-                        "search-index-gc: delete returned non-2xx"
-                    );
+                // Every arm below leaves `id` OUT of `removed`: the sweep
+                // reports what the daemon confirmed it removed, never what it
+                // was asked to remove.
+                DeleteOutcome::NotRemoved(detail) => {
+                    warn!(index_id = %id, "search-index-gc: trusty-search kept the index: {detail}");
+                }
+                DeleteOutcome::Refused { code, message } => {
+                    warn!(index_id = %id, code, "search-index-gc: delete refused: {message}");
                 }
                 DeleteOutcome::Transport(e) => {
                     warn!(index_id = %id, "search-index-gc: delete failed: {e}");

--- a/crates/trusty-mpm/src/session_manager/search_gc_guard_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/search_gc_guard_tests.rs
@@ -1,14 +1,12 @@
-//! The standing guard on #4743: a test process reaches no trusty-search daemon
-//! on any destructive path.
+//! The standing guard on #4743 — a test process reaches no trusty-search daemon
+//! on any destructive path — and the sweep's fail-safe reads (#6285).
 //!
-//! Why a real, live, accepting listener rather than a dead port: a dead port
+//! Why a real, live, accepting daemon rather than a dead socket: a dead socket
 //! makes the guarded and the unguarded code look identical — both end with "no
 //! index was deleted", one because the request was refused at the source and one
-//! because nothing was there to answer it. The listener here is a daemon that
-//! WOULD have accepted the DELETE and answered 200, so the connection counter
-//! staying at zero is evidence about trusty-mpm's behaviour rather than about
-//! the machine's port allocation. This mirrors the shape PR #4864 used for the
-//! registry-write guard, and the reason is the same.
+//! because nothing was there to answer it. The daemon here WOULD have accepted
+//! the delete and answered success, so the call counter staying at zero is
+//! evidence about trusty-mpm's behaviour rather than about the machine.
 //!
 //! Why these fixtures reproduce the reported hazard exactly: the issue names
 //! `decommission_full_still_terminates_the_runtime`, whose workspace basename is
@@ -19,116 +17,100 @@
 //! written. Nothing about the fixture names is fixed here — the point of the fix
 //! is that the id no longer matters, because the request is never issued.
 //!
-//! Test: the two functions below.
+//! Why the sweep's READ path is pinned in the same file: #6285 moved these calls
+//! onto the socket, and the sweep's decision to delete rests on what those reads
+//! return. A read that fails must not resolve to a value that licenses a delete.
+//!
+//! Test: the four functions below.
 
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
 
-use tempfile::TempDir;
+use serde_json::{Value, json};
 
 use super::record::{ManagedSessionId, ManagedSessionState};
 use super::tests::make_manager;
+use crate::daemon::search_rpc;
+use crate::test_support::isolated_daemon_home;
+use crate::uds_mock::{self, MockFuture, MockUdsDaemon, RpcError};
 
-/// A loopback stand-in for the operator's trusty-search daemon that accepts
-/// every connection, answers a success body, and counts what it saw.
+/// Generous next to the client's own 5 s budget — this only has to outlast a
+/// loopback round-trip on a loaded machine.
+const PROBE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// A stand-in for the operator's trusty-search daemon that answers every method
+/// with a successful delete body and counts what it was asked.
+///
+/// Why it binds where production resolution looks, rather than taking
+/// `TRUSTY_SEARCH_SOCKET`: the hazard #4743 describes is the daemon a process
+/// finds on its own. `daemon_socket_path` under an overridden data directory is
+/// that lookup, run against a socket that is not the operator's.
 struct CountingDaemon {
-    connections: Arc<AtomicUsize>,
-    /// Data dir whose `trusty-search/http_addr` points at this listener, for
-    /// `TRUSTY_DATA_DIR_OVERRIDE`.
-    data_dir: TempDir,
+    calls: Arc<AtomicUsize>,
+    daemon: MockUdsDaemon,
 }
 
 impl CountingDaemon {
-    /// Bind, start accepting, and write the discovery file the production
-    /// resolver reads.
+    /// Bind at the path `search_rpc::search_socket` derives under the active
+    /// [`isolated_daemon_home`] override.
     async fn start() -> Self {
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        let connections = Arc::new(AtomicUsize::new(0));
-
-        let counter = Arc::clone(&connections);
-        tokio::spawn(async move {
-            use tokio::io::{AsyncReadExt, AsyncWriteExt};
-            while let Ok((mut sock, _)) = listener.accept().await {
-                counter.fetch_add(1, Ordering::SeqCst);
-                let mut buf = [0u8; 2048];
-                let _ = sock.read(&mut buf).await;
-                let _ = sock
-                    .write_all(
-                        b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\
-                          Content-Length: 36\r\n\r\n{\"removed\":true,\"data_deleted\":true}",
-                    )
-                    .await;
-                let _ = sock.shutdown().await;
-            }
-        });
-
-        let data_dir = crate::test_support::hermetic_temp_dir();
-        std::fs::create_dir_all(data_dir.path().join("trusty-search")).unwrap();
-        std::fs::write(
-            data_dir.path().join("trusty-search").join("http_addr"),
-            addr.to_string(),
-        )
-        .unwrap();
-
-        Self {
-            connections,
-            data_dir,
-        }
+        let calls = Arc::new(AtomicUsize::new(0));
+        let counter = Arc::clone(&calls);
+        let socket = search_rpc::search_socket().expect("derive the trusty-search socket");
+        let daemon = uds_mock::spawn_at(socket, move |_method, _params| {
+            counter.fetch_add(1, Ordering::SeqCst);
+            Box::pin(
+                async move { Ok(json!({ "ok": true, "removed": true, "data_deleted": true })) },
+            )
+        })
+        .await;
+        Self { calls, daemon }
     }
 
-    /// Confirm the fixture's own premise: this listener really does accept and
-    /// answer. Without it, a zero count could mean the listener was broken.
+    /// Confirm the fixture's own premise: this daemon really does accept and
+    /// answer. Without it, a zero count could mean the daemon was broken.
     async fn self_check(&self) {
-        let body = reqwest::Client::new()
-            .get(format!(
-                "http://{}/health",
-                std::fs::read_to_string(
-                    self.data_dir.path().join("trusty-search").join("http_addr")
-                )
-                .unwrap()
-            ))
-            .send()
-            .await
-            .expect("the stand-in daemon must answer — the fixture's premise")
-            .text()
-            .await
-            .unwrap();
-        assert!(body.contains("removed"), "unexpected body: {body}");
-        // The self-check's own connection does not count against the assertion.
-        self.connections.store(0, Ordering::SeqCst);
+        search_rpc::call_at(
+            self.daemon.socket(),
+            search_rpc::METHOD_HEALTH,
+            json!({}),
+            PROBE_TIMEOUT,
+        )
+        .await
+        .expect("the stand-in daemon must answer — the fixture's premise");
+        // The self-check's own call does not count against the assertion.
+        self.calls.store(0, Ordering::SeqCst);
     }
 
     fn seen(&self) -> usize {
-        self.connections.load(Ordering::SeqCst)
+        self.calls.load(Ordering::SeqCst)
     }
 }
 
 /// The regression test for #4743: a full decommission from a test process must
 /// put nothing on the wire, even though a daemon is discoverable and willing.
 ///
-/// Why serial: `TRUSTY_DATA_DIR_OVERRIDE` is process-global.
+/// Why serial: the daemon-home override is process-global.
 /// What: reproduces the issue's own fixture — an SM-owned workspace whose
 /// basename is `full`, so `disposable_workspace_index_id` yields the index id
 /// `full` and `decommission_with_root` reaches its effect-4 index delete. Points
-/// daemon discovery at a listener that would accept the DELETE, decommissions
-/// for real, and asserts the listener saw zero connections. Reverting
+/// daemon resolution at a daemon that would accept the delete, decommissions for
+/// real, and asserts it was called zero times. Reverting
 /// `DestructiveIndexDelete::acquire`'s `running_under_test_harness` branch makes
 /// this fail with a count of 1.
 /// Test: this function IS the test.
 #[serial_test::serial]
 #[tokio::test]
 async fn decommission_issues_no_request_to_a_live_daemon_under_test() {
-    let daemon = CountingDaemon::start().await;
-    daemon.self_check().await;
-
     let dir = crate::test_support::hermetic_temp_dir();
     let (mgr, _fake) = make_manager(&dir).await;
 
     let managed_root = crate::test_support::hermetic_temp_dir();
     // The issue's own fixture name. A bare `file_name()` becomes the index id.
     let workspace_path = managed_root.path().join("owner").join("repo").join("full");
-    std::fs::create_dir_all(&workspace_path).unwrap();
+    std::fs::create_dir_all(&workspace_path).expect("create the fixture workspace");
 
     let record = mgr
         .create_with_id(
@@ -146,16 +128,13 @@ async fn decommission_issues_no_request_to_a_live_daemon_under_test() {
         .await
         .expect("create");
 
-    // SAFETY: `#[serial]` — no other test thread races this set/restore.
-    unsafe {
-        std::env::set_var(trusty_common::DATA_DIR_OVERRIDE_ENV, daemon.data_dir.path());
-    }
+    let (_home, _override) = isolated_daemon_home(false);
+    let daemon = CountingDaemon::start().await;
+    daemon.self_check().await;
+
     let outcome = mgr
         .decommission_with_root(&record.id, managed_root.path(), None)
         .await;
-    unsafe {
-        std::env::remove_var(trusty_common::DATA_DIR_OVERRIDE_ENV);
-    }
 
     let (tombstone, _removed) = outcome.expect("full decommission");
     assert_eq!(
@@ -166,40 +145,33 @@ async fn decommission_issues_no_request_to_a_live_daemon_under_test() {
     assert_eq!(
         daemon.seen(),
         0,
-        "a test process must reach the trusty-search daemon zero times — a DELETE here \
-         carries ?delete_data=true and destroys a real index named `full` (#4743)"
+        "a test process must reach the trusty-search daemon zero times — this delete \
+         carries the delete_data opt-in and destroys a real index named `full` (#4743)"
     );
 }
 
 /// The same guarantee for the second destructive site, which before #4743 had
 /// no guard of its own at all.
 ///
-/// Why separate: `sweep_orphaned_search_indexes` formatted its own
-/// `?delete_data=true` URL in a loop rather than calling the decommission-time
-/// helper, so a guard placed only on that helper would have left this path
-/// fully exposed. Asserting on the sweep directly is what keeps the two from
-/// diverging again.
-/// What: with a willing daemon discoverable, a non-dry-run sweep must return
-/// empty having made no request — not even the index listing, which the
-/// capability is acquired ahead of.
+/// Why separate: `sweep_orphaned_search_indexes` built its own destructive
+/// request in a loop rather than calling the decommission-time helper, so a
+/// guard placed only on that helper would have left this path fully exposed.
+/// Asserting on the sweep directly is what keeps the two from diverging again.
+/// What: with a willing daemon resolvable, a non-dry-run sweep must return empty
+/// having made no call — not even the index listing, which the capability is
+/// acquired ahead of.
 /// Test: this function IS the test.
 #[serial_test::serial]
 #[tokio::test]
 async fn sweep_makes_no_request_under_a_test_harness() {
-    let daemon = CountingDaemon::start().await;
-    daemon.self_check().await;
-
     let dir = crate::test_support::hermetic_temp_dir();
     let (mgr, _fake) = make_manager(&dir).await;
 
-    // SAFETY: `#[serial]` — no other test thread races this set/restore.
-    unsafe {
-        std::env::set_var(trusty_common::DATA_DIR_OVERRIDE_ENV, daemon.data_dir.path());
-    }
+    let (_home, _override) = isolated_daemon_home(false);
+    let daemon = CountingDaemon::start().await;
+    daemon.self_check().await;
+
     let swept = mgr.sweep_orphaned_search_indexes(false).await;
-    unsafe {
-        std::env::remove_var(trusty_common::DATA_DIR_OVERRIDE_ENV);
-    }
 
     assert_eq!(
         swept.expect("sweep must not error").len(),
@@ -210,5 +182,123 @@ async fn sweep_makes_no_request_under_a_test_harness() {
         daemon.seen(),
         0,
         "the orphan sweep must not even LIST indexes from a test process (#4743)"
+    );
+}
+
+/// No daemon is a no-op, not a failure and not a sweep of nothing.
+///
+/// Why: the orphan-GC loop calls this every 60 s on every machine, including
+/// ones with no trusty-search installed. Before #6285 the absent discovery file
+/// answered that question; now the resolver returns a path whether or not
+/// anything is bound to it, so the no-op has to come from the unanswered call.
+/// What: dry-run, so no capability is needed and the read path really runs, with
+/// resolution pointed at a data directory holding no socket.
+/// Test: this function IS the test.
+#[serial_test::serial]
+#[tokio::test]
+async fn sweep_orphaned_search_indexes_noop_when_daemon_unreachable() {
+    let dir = crate::test_support::hermetic_temp_dir();
+    let (mgr, _fake) = make_manager(&dir).await;
+
+    let (_home, _override) = isolated_daemon_home(false);
+    let swept = mgr
+        .sweep_orphaned_search_indexes(true)
+        .await
+        .expect("an unreachable daemon is a no-op, never an error");
+
+    assert!(
+        swept.is_empty(),
+        "nothing is collectable when nothing answered: {swept:?}"
+    );
+}
+
+/// The index id both halves of the status-probe test use.
+const ORPHAN_ID: &str = "gone-session";
+
+/// A daemon that lists exactly one `.worktrees`-rooted index and answers
+/// `status` for it — or refuses the status call when `status` is `None`.
+fn one_index_daemon(
+    root: PathBuf,
+    status: Option<Value>,
+) -> impl Fn(&str, Value) -> MockFuture + Send + Sync {
+    move |method, _params| {
+        let answer = if method == search_rpc::METHOD_INDEXES_LIST {
+            Ok(json!({
+                "indexes": [{ "id": ORPHAN_ID, "root_path": root.to_string_lossy() }]
+            }))
+        } else if method == search_rpc::METHOD_INDEX_STATUS {
+            match &status {
+                Some(body) => Ok(body.clone()),
+                None => Err(RpcError::new(
+                    crate::daemon::error::CODE_UNAVAILABLE,
+                    "index status unavailable",
+                )),
+            }
+        } else {
+            Err(RpcError::new(
+                -32601,
+                format!("unexpected method: {method}"),
+            ))
+        };
+        Box::pin(async move { answer })
+    }
+}
+
+/// Run one dry-run sweep against a daemon that lists `ORPHAN_ID` rooted at
+/// `root` and answers `status` for it.
+///
+/// Why a fresh [`isolated_daemon_home`] per call: the socket path is derived
+/// from the override, and a bound socket file outlives the daemon that bound it
+/// — two daemons in one home would collide on the second bind.
+async fn dry_sweep_against(
+    mgr: &super::manager::SessionManager,
+    root: PathBuf,
+    status: Option<Value>,
+) -> Vec<String> {
+    let (_home, _override) = isolated_daemon_home(false);
+    let socket = search_rpc::search_socket().expect("derive the trusty-search socket");
+    let _daemon = uds_mock::spawn_at(socket, one_index_daemon(root, status)).await;
+    mgr.sweep_orphaned_search_indexes(true)
+        .await
+        .expect("a dry-run sweep against an answering daemon must not error")
+}
+
+/// A status probe that failed must not resolve to a collectable index (#6285).
+///
+/// Why: `probe_chunk_count` used to answer `0` for a failed probe, and `0` is
+/// precisely the reading that makes an unclaimed `.worktrees` index collectable.
+/// A wedged daemon, a timed-out call, or a one-off refusal therefore looked
+/// exactly like "this index is empty" — the sweep deleted on evidence it never
+/// gathered. An unreachable daemon must never read as an absent index.
+/// What: one fixture, driven twice against the SAME candidate — a `.worktrees`
+/// root that no longer exists on disk, which `is_orphan_index` reclaims at any
+/// chunk count. With the status probe refused the sweep must report nothing;
+/// with it answered the sweep must report the id. The second half is what proves
+/// the first is the probe failing rather than the fixture never qualifying.
+/// Dry-run throughout: the decision is what is under test, and a test process
+/// could not acquire the delete capability anyway (#4743).
+/// Test: this function IS the test.
+#[serial_test::serial]
+#[tokio::test]
+async fn sweep_skips_a_candidate_whose_status_probe_failed() {
+    let dir = crate::test_support::hermetic_temp_dir();
+    let (mgr, _fake) = make_manager(&dir).await;
+
+    // Never existed on disk: an unclaimed worktree index whose root is gone is
+    // an orphan at any chunk count, so only the probe's outcome can change the
+    // verdict between the two halves below.
+    let vanished_root = PathBuf::from("/nonexistent/owner/repo/.worktrees/gone-session");
+
+    let skipped = dry_sweep_against(&mgr, vanished_root.clone(), None).await;
+    assert!(
+        skipped.is_empty(),
+        "an index whose chunk count could not be read must not be collectable: {skipped:?}"
+    );
+
+    let collected = dry_sweep_against(&mgr, vanished_root, Some(json!({ "chunk_count": 0 }))).await;
+    assert_eq!(
+        collected,
+        vec![ORPHAN_ID.to_string()],
+        "fixture premise: the same candidate IS collectable once the daemon answers"
     );
 }

--- a/crates/trusty-mpm/src/test_support.rs
+++ b/crates/trusty-mpm/src/test_support.rs
@@ -291,6 +291,64 @@ fn sweep_stale_test_dirs() {
     }
 }
 
+/// Point every trusty-* daemon lookup at a scratch data directory for the body
+/// of one `#[serial_test::serial]` test, and restore the environment on drop.
+///
+/// Why here: two suites need it — `session_manager::search_gc_guard_tests` and
+/// `session_manager::index_delete_guard::tests` — and both are asserting that a
+/// test process does NOT reach the operator's real trusty-search daemon (#4743).
+/// A per-suite copy of a guard whose whole job is to keep production state out
+/// of a test run is the wrong thing to have two of.
+///
+/// Why a guard rather than the set / call / `remove_var` sequence written inline
+/// elsewhere in this crate: a panicking assertion between the set and the remove
+/// leaks process-global state into every later test in the binary. `Drop` runs
+/// on the unwind.
+///
+/// Callers MUST be tagged `#[serial_test::serial]` — the variables are
+/// process-global, so two tests holding one of these at once see each other's
+/// values.
+/// Test: `session_manager::index_delete_guard::tests::acquire_refuses_when_no_daemon_socket_is_bound`
+/// and the other users listed above.
+pub(crate) struct DaemonHomeOverride {
+    allow_production: bool,
+}
+
+impl DaemonHomeOverride {
+    /// Resolve daemon data under `data_dir`. With `allow_production`, also lift
+    /// the #4743 refusal that stops a test process destroying real index data.
+    pub(crate) fn new(data_dir: &Path, allow_production: bool) -> Self {
+        // SAFETY: callers are `#[serial]` — no other test thread races this.
+        unsafe {
+            std::env::set_var(trusty_common::DATA_DIR_OVERRIDE_ENV, data_dir);
+            if allow_production {
+                std::env::set_var(trusty_common::test_harness::ALLOW_PRODUCTION_ENV, "1");
+            }
+        }
+        Self { allow_production }
+    }
+}
+
+impl Drop for DaemonHomeOverride {
+    fn drop(&mut self) {
+        // SAFETY: `#[serial]` — see `DaemonHomeOverride::new`.
+        unsafe {
+            std::env::remove_var(trusty_common::DATA_DIR_OVERRIDE_ENV);
+            if self.allow_production {
+                std::env::remove_var(trusty_common::test_harness::ALLOW_PRODUCTION_ENV);
+            }
+        }
+    }
+}
+
+/// An isolated daemon data directory plus the override pointing resolution at
+/// it. Both must stay alive for the test's duration.
+pub(crate) fn isolated_daemon_home(allow_production: bool) -> (TempDir, DaemonHomeOverride) {
+    let dir = hermetic_temp_dir();
+    let override_guard = DaemonHomeOverride::new(dir.path(), allow_production);
+    (dir, override_guard)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/trusty-mpm/src/uds_mock.rs
+++ b/crates/trusty-mpm/src/uds_mock.rs
@@ -13,6 +13,8 @@
 //! What: [`spawn`] binds a socket under a `TempDir`, mounts `handler` as the
 //! router's catch-all through the same [`trusty_common::uds::server`] pieces the
 //! real daemon uses, and serves until the returned [`MockUdsDaemon`] drops.
+//! [`spawn_at`] does the same at a path the caller chose, for a rig that has to
+//! bind where production discovery will look.
 //! The handler answers a `result` value directly — a rig that needs the
 //! `tools/call` envelope wraps it itself, the same way it did over HTTP.
 //!
@@ -20,7 +22,9 @@
 //!
 //! Test: every caller — `core::memory_import::tests`,
 //! `tui::coordinator::tests`, `provisioner::identity_seed::tests`,
-//! `daemon::doctor_tests`, `daemon::doctor_search_pin_tests`.
+//! `daemon::doctor_tests`, `daemon::doctor_search_pin_tests`,
+//! `session_manager::search_gc_guard_tests`,
+//! `session_manager::index_delete_guard::tests`.
 
 use std::future::Future;
 use std::path::{Path, PathBuf};
@@ -45,7 +49,9 @@ pub type MockFuture = Pin<Box<dyn Future<Output = Result<Value, RpcError>> + Sen
 /// socket with its temp directory.
 pub struct MockUdsDaemon {
     socket: PathBuf,
-    _dir: TempDir,
+    /// Held only when [`spawn`] minted the directory. [`spawn_at`] binds inside
+    /// a directory the caller owns and keeps alive.
+    _dir: Option<TempDir>,
     shutdown: Option<tokio::sync::oneshot::Sender<()>>,
 }
 
@@ -90,6 +96,28 @@ where
 {
     let dir = TempDir::new().expect("tempdir for the mock socket");
     let socket = dir.path().join("daemon.sock");
+    let mut daemon = spawn_at(socket, handler).await;
+    daemon._dir = Some(dir);
+    daemon
+}
+
+/// Start a mock daemon at a socket path the CALLER chose.
+///
+/// Why: a rig that exercises production socket DISCOVERY cannot take whatever
+/// path [`spawn`] minted — it has to bind where `daemon_socket_path` will look,
+/// under a `TRUSTY_DATA_DIR_OVERRIDE` the test controls. `search_gc_guard_tests`
+/// and `index_delete_guard_tests` both need that, and a second accept loop for
+/// them is the duplication this module exists to prevent (#6285).
+/// What: as [`spawn`], except the temp directory keeping the socket alive is the
+/// caller's. `bind_hardened` creates and hardens the parent directory itself.
+///
+/// # Panics
+///
+/// When the socket cannot be bound — a test-only failure with no recovery.
+pub async fn spawn_at<F>(socket: PathBuf, handler: F) -> MockUdsDaemon
+where
+    F: Fn(&str, Value) -> MockFuture + Send + Sync + 'static,
+{
     let listener = trusty_common::uds::bind_hardened(&socket).expect("bind the mock socket");
 
     let router = Arc::new(RpcRouter::new().fallback(MockFallback { handler }));
@@ -103,7 +131,7 @@ where
 
     MockUdsDaemon {
         socket,
-        _dir: dir,
+        _dir: None,
         shutdown: Some(tx),
     }
 }


### PR DESCRIPTION
The second consumer-move slice of the #6285 program. PR #6388 established
`crates/trusty-mpm/src/daemon/search_rpc.rs` and moved doctor's two probes; this
moves the two remaining migratable call sites in the crate onto the same client.

- `session_manager/search_gc.rs:354` — `GET /indexes?details=true` and
  `GET /indexes/{id}/status` become `search.indexes.list` (with `details`) and
  `search.index.status`.
- `session_manager/index_delete_guard.rs:119` — `DELETE /indexes/{id}?delete_data=true`
  becomes `search.index.delete` with `delete_data: true`.

`resolve_daemon_base_url` and both `reqwest::Client::builder()` calls are gone
from these files. Method names are literals pinned by
`trusty_search::service::socket::METHODS`, which the daemon's own
`rpc_router_registers_every_documented_method` compares its router against; a
new `METHOD_INDEX_DELETE` const joins the two already in `search_rpc`.

The two TUI sites (`tui/health/probes.rs`, `tui/coordinator/banner.rs`) are
untouched — still HTTP, still blocked on slice 5.5 plus the `admin.stop`
decision.

## How the #4743 capability path is preserved

The destructive delete is still reachable only by holding a
`DestructiveIndexDelete`, and nothing about who can hold one changed:

- `acquire()` evaluates `trusty_common::running_under_test_harness()` **first**,
  ahead of any resolution — so a `cargo test` process still never learns where
  the operator's daemon is, let alone calls it.
- The capability still has no constructor but `acquire`, still holds no public
  field, and still holds the crate's **only** `delete_data` opt-in. A caller
  cannot assemble the request from a socket path it happens to have.
- The "no daemon discoverable" refusal did not disappear, it changed medium: an
  absent `http_addr` file becomes an unbound socket, checked at the same point in
  `acquire`, before any request is built. A socket file that outlived its daemon
  passes that check and then fails at the call, which reports
  `DeleteOutcome::Transport` and deletes nothing.
- `TRUSTY_ALLOW_PRODUCTION_STATE` remains the single, greppable escape hatch.

Nothing was widened: there is no new caller, no new entry point, and no path to a
delete that skips `acquire`.

## Fail-safe error arms

Both fail-open reads on this path are closed, each with a test that fails if the
arm is reverted.

**The GC sweep no longer confuses an unreachable daemon with an absent index.**
`fetch_chunk_count` answered `0` for a refusal or an unanswered call, and `0` is
exactly the reading that makes an aged, unclaimed `.worktrees` index collectable
— so a wedged or restarting daemon licensed a delete on evidence that was never
gathered. It now returns `Option<u64>` and the sweep skips a `None` candidate
outright. A listing that goes unanswered ends the sweep with `Ok(vec![])`; a
listing the daemon *refuses* still propagates, so daemon-down and daemon-said-no
stay distinguishable.

**A delete is reported as removed only when the daemon says the registration is
gone.** Any 2xx used to count, including the #3049 body that reports
`removed: false` because an in-flight writer never quiesced — the sweep recorded
an index as reclaimed while it was still registered and still on disk.
`DeleteOutcome` gains `NotRemoved` and `Refused { code, message }` beside
`Removed` and `Transport`; only `Removed` puts an id in the sweep's return value.

New tests, all driving the `MockUdsDaemon` rig:

- `sweep_skips_a_candidate_whose_status_probe_failed` — one candidate, driven
  twice: refused status probe reports nothing, answered status probe reports the
  id. The second half is what proves the first is the probe failing rather than
  the fixture never qualifying.
- `sweep_orphaned_search_indexes_noop_when_daemon_unreachable` — a `Test:`
  pointer that named no test before this PR; now it names one.
- `delete_over_a_stale_socket_is_a_transport_failure`,
  `a_refusal_is_never_reported_as_removed`,
  `a_result_that_did_not_remove_is_not_reported_as_removed`, and
  `a_result_reporting_removal_is_removed` as its fixture premise.

The #4743 guard tests moved with the transport: `CountingDaemon` is now a mock
UDS daemon bound where `daemon_socket_path` looks under an overridden data
directory, so both `decommission_issues_no_request_to_a_live_daemon_under_test`
and `sweep_makes_no_request_under_a_test_harness` still assert against a daemon
that *would* have answered. `uds_mock::spawn_at` is the one new rig affordance —
`spawn` now delegates to it, rather than a second accept loop existing.

## Gates — rung 4

| Gate | Result |
|---|---|
| `cargo fmt --check` | clean |
| `cargo check -p trusty-mpm --all-targets` | `EXIT=0` |
| `cargo clippy -p trusty-mpm --all-targets -- -D warnings` | `EXIT=0` |
| `cargo test -p trusty-mpm --no-fail-fast` | `5491 passed; 5 failed; 7 ignored` (lib) + `1880`, `1880`, `4`, `3`, `2`, `3`, `1` passed, 0 failed across the other seven targets — see below |
| `cargo check --workspace` | `EXIT=0` |
| `bash scripts/check_test_pointers.sh` | `resolved 27532 Test: citation(s) — 0 dangling pointers — OK` |
| `bash scripts/check_changelog_fragment.sh` | `all 1 crate(s) with source changes are recorded` |
| `bash scripts/check_line_cap.sh` | `measured 4264 tracked .rs file(s); 0 violations — OK` |
| `bash scripts/check_sld.sh` | `0 error(s), 0 warning(s)` |

All 12 tests in the touched modules pass, including every new one.

### The 5 lib failures are pre-existing

Two of them are an environment race and pass on their own:

```
cargo test -p trusty-mpm --lib --no-fail-fast worktrees_parity   →  EXIT=0
```

`managed_prune_worktrees_parity_defaults_to_a_preview` and
`managed_reconcile_worktrees_parity` compare two response bodies enumerating the
operator's **live** worktrees under other projects
(`~/trusty-mpm-projects/bobmatnyc/ai-power-rankings`, `.../trusty-things`), which
other agents were creating and removing during the run.

The other three fail deterministically, so they were reproduced against
`origin/main` with this crate's source fully reverted
(`git checkout origin/main -- crates/trusty-mpm/{src,Cargo.toml,changelog.d}`):

```
test result: FAILED. 20 passed; 3 failed; 0 ignored; 5473 filtered out; finished in 293.73s
/private/var/folders/.../repos/owner/repo/.claude/worktrees/agent-abandoned was never removed
/private/var/folders/.../repos/owner/repo/.claude/worktrees/agent-one was never removed
/private/var/folders/.../repos/owner/repo/.claude/worktrees/agent-resumable was never removed
```

Identical failures, identical count, with none of this PR's code present:
`session_end_reaps_a_worktree_whose_agent_never_stopped`,
`session_end_reaps_every_agent_of_the_ending_session`,
`subagent_stop_does_not_reap_a_resumable_worktree` — all three a real
`git worktree remove` that does not take effect on this machine. Change-specific
gates pass; these three are a pre-existing red on `main` with no tracking issue
that a search by test name and by the panic text turns up.

Refs #6285

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
