### PR TITLE
refactor(trusty-console): reach trusty-search over UDS (Refs #6285)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6519,7 +6519,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11507,7 +11507,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-console"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/trusty-console/Cargo.toml
+++ b/crates/trusty-console/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name        = "trusty-console"
-# 0.8.1 (#6371): patch — 0.8.0 was published while this PR was open and it edits
-# `src/**`. The public surface only GAINS items: the two cleanup handlers and
-# their request body. `DeleteVerdict` becoming `ActionVerdict` moves nothing
-# public — it was `pub(crate)`, as is everything else the routes refactor
-# touched.
-version     = "0.8.1"
+# 0.8.2 (#6285): patch — trusty-search moves from loopback HTTP to its Unix
+# socket. Nothing public changes shape: `AppState` GAINS `with_search_socket`
+# and the two `search_uds::routes` handlers, and the routes that changed
+# transport (`delete_index_on_socket`, `prune_indexes_on_socket`) were
+# `pub(crate)`.
+version     = "0.8.2"
 edition     = "2024"
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/trusty-console/changelog.d/6285-search-endpoints-without-a-method.md
+++ b/crates/trusty-console/changelog.d/6285-search-endpoints-without-a-method.md
@@ -1,0 +1,7 @@
+Fixed
+- A console request to a trusty-search endpoint with no socket method answers
+  `501` naming the endpoint, and a daemon that is not listening answers `502`
+  with the reason. Neither reaches the dashboard as an empty success, so "the
+  daemon is down" stays distinguishable from "the daemon has nothing to show".
+  `POST /chat` and `POST /admin/stop` are the two endpoints the search dashboard
+  calls that have no socket method yet (#6285).

--- a/crates/trusty-console/changelog.d/6285-search-over-uds.md
+++ b/crates/trusty-console/changelog.d/6285-search-over-uds.md
@@ -1,0 +1,11 @@
+Changed
+- The console reaches trusty-search over its Unix socket instead of loopback
+  HTTP (ADR-0032). The service card dials `search.health`, the index-delete and
+  batch-prune routes dial `search.index.delete`, and `/api/search/*` — the prefix
+  the console-served search dashboard calls — is translated into RPC calls rather
+  than reverse-proxied. The two Server-Sent Event streams the dashboard opens,
+  `/status/stream` and `/indexes/{id}/reindex/stream`, are bridged from the
+  daemon's RPC streams frame for frame, keep-alive comment included. Nothing now
+  reads trusty-search's `http_addr` discovery file, so a stale one left by a
+  pre-migration daemon can no longer forward the dashboard to whatever holds
+  7878 (#6285).

--- a/crates/trusty-console/changelog.d/6285-stream-open-is-bounded.md
+++ b/crates/trusty-console/changelog.d/6285-stream-open-is-bounded.md
@@ -1,10 +1,12 @@
 Fixed
 - Opening one of the dashboard's Server-Sent Event streams is now bounded at 60
-  seconds. A trusty-search daemon that accepts the connection and then answers
-  nothing — a full listener backlog — used to leave the browser waiting out the
-  24-hour per-frame budget for a response head; it now answers `502` with the
-  reason. An established stream keeps the long per-frame budget, so a reindex
-  that emits nothing for minutes is still not cut off. The bridge also stops
-  reading from the socket the moment the browser disconnects, rather than at the
-  next frame, which releases the daemon's producer on a stream that is quiet
-  (#6285).
+  seconds total. A trusty-search daemon that accepts the connection and then
+  answers nothing — a full listener backlog — used to leave the browser waiting
+  out the 24-hour per-frame budget for a response head; it now answers `502`
+  with the reason. The dial, the request write and the first frame read share
+  one deadline, so a slow-but-successful open leaves the first read what is left
+  of the 60 seconds rather than a fresh 60 of its own. An established stream
+  keeps the long per-frame budget, so a reindex that emits nothing for minutes
+  is still not cut off. The bridge also stops reading from the socket the moment
+  the browser disconnects, rather than at the next frame, which releases the
+  daemon's producer on a stream that is quiet (#6285).

--- a/crates/trusty-console/changelog.d/6285-stream-open-is-bounded.md
+++ b/crates/trusty-console/changelog.d/6285-stream-open-is-bounded.md
@@ -1,0 +1,10 @@
+Fixed
+- Opening one of the dashboard's Server-Sent Event streams is now bounded at 60
+  seconds. A trusty-search daemon that accepts the connection and then answers
+  nothing — a full listener backlog — used to leave the browser waiting out the
+  24-hour per-frame budget for a response head; it now answers `502` with the
+  reason. An established stream keeps the long per-frame budget, so a reindex
+  that emits nothing for minutes is still not cut off. The bridge also stops
+  reading from the socket the moment the browser disconnects, rather than at the
+  next frame, which releases the daemon's producer on a stream that is quiet
+  (#6285).

--- a/crates/trusty-console/src/console_ui.rs
+++ b/crates/trusty-console/src/console_ui.rs
@@ -1,0 +1,95 @@
+//! The console's own Svelte SPA, served from the binary at `/` and `/ui/`.
+//!
+//! Why: lifted out of `server/mod.rs` (#6285) when that file passed the 500-SLOC
+//! production cap. It is a self-contained concern — an embedded asset set and
+//! the three routes that serve it — and it now sits beside `tools_ui`, which
+//! does the same job for the trusty-search dashboard.
+//! What: the `rust_embed` asset set, the two handlers `server::build_router`
+//! mounts, and the shared asset lookup with its SPA fallback.
+//! Test: `test_spa_root_returns_html` in `server::tests` drives these through
+//! the real router.
+
+use axum::{
+    body::Body,
+    extract::Path,
+    http::{Response, StatusCode, header},
+    response::IntoResponse,
+};
+use rust_embed::RustEmbed;
+
+/// Embedded Svelte SPA assets compiled by `build.rs`.
+///
+/// Why: Shipping the UI inside the binary eliminates external file dependencies
+/// and matches the pattern used by trusty-search, trusty-memory, and
+/// trusty-analyze.
+/// What: rust-embed embeds every file under `ui/dist/` at compile time.
+/// Test: The server tests assert that `GET /` returns 200.
+#[derive(RustEmbed)]
+#[folder = "ui/dist/"]
+struct UiAssets;
+
+/// `GET /` — serve the SPA index.html.
+///
+/// Why: The root path must return the SPA shell so the browser bootstraps.
+/// What: Reads `index.html` from the embedded asset set.
+/// Test: `test_spa_root_returns_html` below.
+pub async fn spa_index_handler() -> impl IntoResponse {
+    serve_asset("index.html")
+}
+
+/// `GET /ui/*path` — serve SPA static assets.
+///
+/// Why: Vite emits JS/CSS/assets under hashed filenames; all are embedded and
+/// served from the `/ui/*` prefix.
+/// What: Strips the leading `/ui/` from `path` and serves the matching asset.
+/// Test: Indirectly covered by `test_spa_root_returns_html`.
+pub async fn spa_asset_handler(Path(path): Path<String>) -> impl IntoResponse {
+    let path = path.trim_start_matches('/');
+    serve_asset(path)
+}
+
+/// Serve one asset from the embedded `UiAssets`.
+///
+/// Why: Centralises asset serving so both the index and asset routes share the
+/// same content-type detection and 404 handling.
+/// What: Looks up the path in `UiAssets`, infers the MIME type via
+/// `mime_guess`, returns the bytes with the appropriate `Content-Type` header.
+/// On a 404 serves `index.html` (SPA client-side routing).
+/// Test: `test_spa_root_returns_html`.
+fn serve_asset(path: &str) -> Response<Body> {
+    match UiAssets::get(path) {
+        Some(content) => {
+            let mime = mime_guess::from_path(path).first_or_octet_stream();
+            Response::builder()
+                .status(StatusCode::OK)
+                .header(header::CONTENT_TYPE, mime.as_ref())
+                .body(Body::from(content.data.to_vec()))
+                .unwrap_or_else(|_| {
+                    Response::builder()
+                        .status(StatusCode::INTERNAL_SERVER_ERROR)
+                        .body(Body::empty())
+                        .expect("static response")
+                })
+        }
+        None => {
+            // SPA fallback: serve index.html for unknown paths so client-side
+            // routing works when the user navigates directly to a subpath.
+            match UiAssets::get("index.html") {
+                Some(content) => Response::builder()
+                    .status(StatusCode::OK)
+                    .header(header::CONTENT_TYPE, "text/html")
+                    .body(Body::from(content.data.to_vec()))
+                    .unwrap_or_else(|_| {
+                        Response::builder()
+                            .status(StatusCode::INTERNAL_SERVER_ERROR)
+                            .body(Body::empty())
+                            .expect("static response")
+                    }),
+                None => Response::builder()
+                    .status(StatusCode::NOT_FOUND)
+                    .body(Body::from("not found"))
+                    .expect("static 404"),
+            }
+        }
+    }
+}

--- a/crates/trusty-console/src/detect/search.rs
+++ b/crates/trusty-console/src/detect/search.rs
@@ -1,63 +1,88 @@
 //! `ServiceConnector` implementation for `trusty-search`.
 //!
-//! Why: trusty-search writes its bound address to `~/.trusty-search/http_addr`
-//! on successful bind. This connector reads that file and probes the TCP port.
-//! What: `SearchConnector` implements `ServiceConnector::detect()` using
-//! `~/.trusty-search/http_addr` as the discovery file and `trusty-search` as
-//! the binary name.
-//! Test: `test_search_connector_*` in the module below. Run with
-//! `cargo test -p trusty-console`.
+//! Why: trusty-search served TCP loopback HTTP and published its bound address
+//! in `~/.trusty-search/http_addr`; this connector read that file and probed the
+//! port. #6285 (ADR-0032) moves the daemon onto a hardened Unix socket, so both
+//! are gone — there is no port and no discovery file, and the file that is still
+//! on disk from before the migration names 7878, which any process can now hold.
+//! The socket path is derived, and the daemon and this connector resolve it
+//! through the same `trusty_common::daemon_socket_path` call.
+//!
+//! What: `SearchConnector::detect()` dials `search.health` over the socket and
+//! reads `version` off the answer.
+//! Test: `search_connector_reports_available_when_nothing_is_serving`,
+//! `search_connector_reads_the_version_off_a_live_socket`,
+//! `search_connector_surfaces_an_unresolvable_socket_path_as_a_hint`,
+//! `search_connector_reports_an_error_frame_as_not_running`.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
-use crate::connector::{ServiceConnector, ServiceInfo};
+use crate::connector::{ServiceConnector, ServiceInfo, ServiceStatus};
+use crate::search_uds::{HEALTH_TIMEOUT, METHOD_HEALTH, SEARCH_SERVICE};
 
-use super::helpers::detect_service;
+use super::helpers::binary_on_path;
+
+/// The `result` half of a `search.health` response, as far as the console reads
+/// it.
+///
+/// Only `version` is consumed — the card renders it. `status` is deserialised
+/// too so a body carrying neither is refused as not-a-health-envelope rather
+/// than silently rendering a versionless Running card.
+#[derive(Debug, serde::Deserialize)]
+struct HealthEnvelope {
+    /// `"ok"` or `"degraded"`. Presence is what makes this a health answer.
+    #[allow(dead_code)]
+    status: String,
+    /// The daemon's own version, rendered on the service card.
+    version: Option<String>,
+}
 
 /// ServiceConnector for `trusty-search`.
 ///
-/// Why: trusty-search writes its bound address to `~/.trusty-search/http_addr`
-/// on successful bind. This connector reads that file and probes the TCP port.
-/// What: Implements `detect()` using `~/.trusty-search/http_addr` as the
-/// discovery file and `trusty-search` as the binary name.
-/// Test: `test_search_connector_with_stale_addr_file` and
-/// `test_search_connector_no_addr_file` below.
+/// Why: the dashboard needs to know whether the search daemon is running, and
+/// since #6285 that question is answered by dialling its socket.
+/// What: implements `detect()` — binary on PATH, then one `search.health` call.
+/// Test: see the module docs.
 pub struct SearchConnector {
-    /// Override for the home directory (used in tests).
-    home_dir: Option<PathBuf>,
+    /// Override for the socket path (used in tests).
+    ///
+    /// Before #6285 this was a HOME override, because the discovery file lived
+    /// under `~`. The socket path comes from the data directory now, which
+    /// `TRUSTY_DATA_DIR_OVERRIDE` already redirects — but that variable is
+    /// process-global and this connector runs beside five others in one poll,
+    /// so a path override keeps a test from redirecting its siblings too.
+    socket: Option<PathBuf>,
 }
 
 impl SearchConnector {
     /// Create a new `SearchConnector`.
-    ///
-    /// Why: Production callers use `new()`; tests use `with_home()`.
-    /// What: Stores no state except the optional home override.
-    /// Test: Created in `all_connectors()` and in unit tests.
     pub fn new() -> Self {
-        Self { home_dir: None }
+        Self { socket: None }
     }
 
-    /// Create a connector that uses `home_dir` instead of the real home.
+    /// Create a connector that dials `socket` instead of the resolved path.
     ///
-    /// Why: Unit tests must not read or write the real user's `~/.trusty-*`
-    /// directories. Injecting a temp dir keeps tests hermetic.
-    /// What: Stores `home_dir` for use in `addr_file_path()`.
-    /// Test: `test_search_connector_with_stale_addr_file`,
-    /// `test_search_connector_no_addr_file`.
-    #[cfg(test)]
-    pub fn with_home(home_dir: PathBuf) -> Self {
+    /// Why: unit tests must not dial the real user's running daemon.
+    /// Test: `search_connector_reports_available_when_nothing_is_serving`.
+    pub fn with_socket(socket: PathBuf) -> Self {
         Self {
-            home_dir: Some(home_dir),
+            socket: Some(socket),
         }
     }
 
-    fn addr_file_path(&self) -> PathBuf {
-        let home = self
-            .home_dir
-            .clone()
-            .or_else(dirs::home_dir)
-            .unwrap_or_else(|| PathBuf::from("/tmp"));
-        home.join(".trusty-search").join("http_addr")
+    /// The socket this connector dials, or why it could not be resolved.
+    ///
+    /// Why the error is carried rather than discarded: a data directory that
+    /// cannot be resolved or created is operator-fixable (permissions, a
+    /// `TRUSTY_DATA_DIR_OVERRIDE` pointing somewhere unusable), and it is
+    /// indistinguishable on the dashboard from a daemon that is simply not
+    /// running. `detect()` still reports `Available` — nothing was observed, so
+    /// claiming otherwise would be a guess — but puts the reason in `hint`.
+    fn socket_path(&self) -> Result<PathBuf, String> {
+        match &self.socket {
+            Some(p) => Ok(p.clone()),
+            None => crate::search_uds::socket_path(),
+        }
     }
 }
 
@@ -67,9 +92,50 @@ impl Default for SearchConnector {
     }
 }
 
+/// Dial `search.health` and return the envelope, or `None` if nothing answered.
+///
+/// Why a dedicated thread: `ServiceConnector::detect` is synchronous — the
+/// poller calls it inside `spawn_blocking` — and the shared UDS client is async.
+/// The exchange runs on its own current-thread runtime rather than through
+/// `Handle::block_on`, for the reason `trusty-installer`'s
+/// `probe_member_http_blocking` records: building a runtime and blocking on it
+/// from inside another runtime's worker panics, and this way the call is safe
+/// from any caller regardless of what it is running on. The same shape
+/// `detect::AnalyzeConnector` uses.
+///
+/// What: one [`crate::search_uds::call`] bounded by [`HEALTH_TIMEOUT`]. A
+/// response carrying an `error` is `None`: the daemon answered, but not with
+/// health, and the console has nothing to render.
+///
+/// Test: `search_connector_reports_an_error_frame_as_not_running`.
+fn probe_health(socket: &Path) -> Option<HealthEnvelope> {
+    let socket = socket.to_path_buf();
+    let handle = std::thread::Builder::new()
+        .name("console-search-probe".to_owned())
+        .spawn(move || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .ok()?;
+            rt.block_on(async {
+                let result = crate::search_uds::call(
+                    &socket,
+                    METHOD_HEALTH,
+                    serde_json::json!({}),
+                    HEALTH_TIMEOUT,
+                )
+                .await
+                .ok()?;
+                serde_json::from_value::<HealthEnvelope>(result).ok()
+            })
+        })
+        .ok()?;
+    handle.join().ok()?
+}
+
 impl ServiceConnector for SearchConnector {
     fn id(&self) -> &'static str {
-        "trusty-search"
+        SEARCH_SERVICE
     }
 
     fn display_name(&self) -> &'static str {
@@ -78,18 +144,57 @@ impl ServiceConnector for SearchConnector {
 
     /// Detect trusty-search status.
     ///
-    /// Why: Reads `~/.trusty-search/http_addr` — the file the daemon writes
-    /// immediately after successfully binding its port.
-    /// What: Three-step sequence: binary check → addr file + TCP probe → status.
-    /// Test: `test_search_connector_with_stale_addr_file`,
-    /// `test_search_connector_no_addr_file`.
+    /// Why: the dashboard needs to know whether the daemon is up, and `tctl`'s
+    /// probe asks the same question — so the two must agree, which they do by
+    /// dialling the same method on the same derived path (#6285).
+    /// What: binary check → `search.health` over the socket → status. `url` is
+    /// deliberately `None`: a UDS daemon has no URL, and ADR-0032 makes
+    /// trusty-console the only HTTP surface in the workspace, so a synthesised
+    /// `http://` address would be a link that cannot work. The dashboard reaches
+    /// the daemon's own UI at `/tools/search/` instead (#6155).
+    /// Test: see the module docs.
     fn detect(&self) -> ServiceInfo {
-        detect_service(
-            self.id(),
-            self.display_name(),
-            "trusty-search",
-            self.addr_file_path(),
-        )
+        self.detect_from(self.socket_path())
+    }
+}
+
+impl SearchConnector {
+    /// [`ServiceConnector::detect`]'s body, over an already-resolved path.
+    ///
+    /// Why separate: the unresolvable-path arm is only reachable when
+    /// `trusty_common::daemon_socket_path` fails, and the only way to make it
+    /// fail from a test is to set `TRUSTY_DATA_DIR_OVERRIDE` — which is
+    /// process-global and, in this crate's test binary, is read by five sibling
+    /// connectors running in parallel. Taking the resolved result as a parameter
+    /// makes the arm assertable with no global state at all.
+    /// What: binary check, then the three verdicts. `Absent` means the binary is
+    /// not installed; `Available` means installed with nothing answering on the
+    /// socket; `Running` means the daemon answered `search.health`.
+    /// Test: `search_connector_surfaces_an_unresolvable_socket_path_as_a_hint`.
+    fn detect_from(&self, socket: Result<PathBuf, String>) -> ServiceInfo {
+        let base =
+            |status: ServiceStatus, version: Option<String>, hint: Option<String>| ServiceInfo {
+                id: self.id().to_string(),
+                display_name: self.display_name().to_string(),
+                status,
+                version,
+                url: None,
+                hint,
+            };
+
+        if !binary_on_path(SEARCH_SERVICE) {
+            return base(ServiceStatus::Absent, None, None);
+        }
+
+        let socket = match socket {
+            Ok(p) => p,
+            Err(reason) => return base(ServiceStatus::Available, None, Some(reason)),
+        };
+
+        match probe_health(&socket) {
+            Some(health) => base(ServiceStatus::Running, health.version, None),
+            None => base(ServiceStatus::Available, None, None),
+        }
     }
 }
 
@@ -98,55 +203,136 @@ impl ServiceConnector for SearchConnector {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::connector::ServiceStatus;
-    use std::fs;
-    use tempfile::TempDir;
+    use std::path::PathBuf;
 
-    fn make_home_with_addr(rel_path: &str, content: &str) -> TempDir {
-        let tmp = TempDir::new().expect("tempdir");
-        let path = tmp.path().join(rel_path);
-        fs::create_dir_all(path.parent().expect("parent")).expect("mkdir");
-        fs::write(&path, content).expect("write addr file");
-        tmp
+    fn installed() -> ServiceStatus {
+        if which::which(SEARCH_SERVICE).is_ok() {
+            ServiceStatus::Available
+        } else {
+            ServiceStatus::Absent
+        }
     }
 
-    /// Why: when http_addr contains a valid but unreachable address, the
-    /// connector must return Available (binary present, file present, TCP failed).
-    /// This test requires `trusty-search` to NOT be on PATH — it short-circuits
-    /// to Absent if it is, which is the correct behaviour in that environment.
-    /// What: creates a fake HOME with `.trusty-search/http_addr = 127.0.0.1:14998`
-    /// and calls detect(); expects either Absent (binary not on PATH in CI) or
-    /// Available (binary on PATH, TCP fails on 14998).
-    /// Test: this test itself.
+    /// Bind a socket that answers exactly one framed request with `reply`.
+    ///
+    /// Must be called from inside a tokio runtime — `bind_hardened` registers
+    /// the listener with the reactor. `detect()` itself is blocking and runs its
+    /// dial on its own thread, so it is safe to call from a `#[tokio::test]`.
+    fn stub_daemon(dir: &Path, reply: impl Into<String>) -> PathBuf {
+        let socket = dir.join("sockets").join("search.sock");
+        let reply = reply.into();
+        let listener = trusty_common::uds::bind_hardened(&socket).expect("bind");
+        tokio::spawn(async move {
+            use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+            let Ok((mut conn, _)) = listener.accept().await else {
+                return;
+            };
+            let mut sink = Vec::new();
+            let _ = conn.read_to_end(&mut sink).await;
+            let _ = conn.write_all(reply.as_bytes()).await;
+            let _ = conn.write_all(b"\n").await;
+            let _ = conn.flush().await;
+        });
+        socket
+    }
+
+    /// Run `detect()` off the runtime's worker so the blocking probe inside it
+    /// cannot stall the stub task that has to answer it.
+    async fn detect_against(socket: PathBuf) -> ServiceInfo {
+        tokio::task::spawn_blocking(move || SearchConnector::with_socket(socket).detect())
+            .await
+            .expect("detect")
+    }
+
+    /// Why (#6285): the pre-migration connector read `~/.trusty-search/http_addr`
+    /// and probed the port it named, so once the daemon stops writing that file
+    /// any process holding 7878 would make this report a trusty-search that is
+    /// not there. The file path is gone, and this is what keeps it gone: an
+    /// absent socket is `Available`, never `Running`, whatever else is listening
+    /// on the machine.
+    /// Test: this is the test.
     #[test]
-    fn test_search_connector_with_stale_addr_file() {
-        let tmp = make_home_with_addr(".trusty-search/http_addr", "127.0.0.1:14998");
-        let connector = SearchConnector::with_home(tmp.path().to_path_buf());
+    fn search_connector_reports_available_when_nothing_is_serving() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let connector = SearchConnector::with_socket(tmp.path().join("absent.sock"));
         let info = connector.detect();
-        // Either Absent (no binary) or Available (binary present, TCP stale).
-        assert!(
-            info.status == ServiceStatus::Absent || info.status == ServiceStatus::Available,
-            "expected Absent or Available, got {:?}",
-            info.status
-        );
-        assert_eq!(info.id, "trusty-search");
+
+        assert_eq!(info.status, installed());
+        assert_eq!(info.id, SEARCH_SERVICE);
         assert_eq!(info.display_name, "Trusty Search");
+        assert!(
+            info.url.is_none(),
+            "a UDS daemon has no URL to link to: {info:?}"
+        );
     }
 
-    /// Why: when no http_addr file exists, detect() must return Absent or
-    /// Available depending on whether the binary is on PATH.
-    /// What: temp HOME with no trusty-search dir.
-    /// Test: this test itself.
-    #[test]
-    fn test_search_connector_no_addr_file() {
-        let tmp = TempDir::new().expect("tempdir");
-        let connector = SearchConnector::with_home(tmp.path().to_path_buf());
-        let info = connector.detect();
-        assert!(
-            info.status == ServiceStatus::Absent || info.status == ServiceStatus::Available,
-            "expected Absent or Available, got {:?}",
-            info.status
+    /// Why: the service card renders the daemon's version, so a live socket has
+    /// to produce `Running` with that version rather than a bare liveness bit.
+    /// Test: this is the test.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn search_connector_reads_the_version_off_a_live_socket() {
+        if which::which(SEARCH_SERVICE).is_err() {
+            // The binary check short-circuits to Absent before any dial, so
+            // there is nothing to assert on a machine without it installed.
+            return;
+        }
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let socket = stub_daemon(
+            tmp.path(),
+            r#"{"jsonrpc":"2.0","id":1,"result":{"status":"ok","version":"0.49.6","indexes":3}}"#,
         );
-        assert!(info.url.is_none());
+        let info = detect_against(socket).await;
+        assert_eq!(info.status, ServiceStatus::Running);
+        assert_eq!(info.version.as_deref(), Some("0.49.6"));
+    }
+
+    /// Why: the fail-open arm. A daemon that answers a JSON-RPC `error` has told
+    /// us nothing about its health, and rendering `Running` off the fact that
+    /// SOMETHING replied is exactly the false-healthy card #6285 must not
+    /// introduce.
+    /// Test: this is the test.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn search_connector_reports_an_error_frame_as_not_running() {
+        if which::which(SEARCH_SERVICE).is_err() {
+            return;
+        }
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let socket = stub_daemon(
+            tmp.path(),
+            r#"{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"method not found"}}"#,
+        );
+        let info = detect_against(socket).await;
+        assert_eq!(info.status, ServiceStatus::Available);
+        assert!(info.version.is_none(), "{info:?}");
+    }
+
+    /// Why: an answer that is not a health envelope must not render a
+    /// versionless Running card — the daemon replied, but not with health.
+    /// Test: this is the test.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn search_connector_reports_a_non_health_answer_as_not_running() {
+        if which::which(SEARCH_SERVICE).is_err() {
+            return;
+        }
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let socket = stub_daemon(tmp.path(), r#"{"jsonrpc":"2.0","id":1,"result":{"hi":1}}"#);
+        let info = detect_against(socket).await;
+        assert_eq!(info.status, ServiceStatus::Available);
+    }
+
+    /// Why: an unusable data directory is operator-fixable and looks identical
+    /// on the dashboard to a daemon that is not running, so the reason has to
+    /// reach the card rather than being swallowed.
+    /// Test: this is the test.
+    #[test]
+    fn search_connector_surfaces_an_unresolvable_socket_path_as_a_hint() {
+        let connector = SearchConnector::new();
+        let info = connector.detect_from(Err("no data directory".to_string()));
+        if info.status == ServiceStatus::Absent {
+            // No binary on PATH: the check short-circuits before the path arm.
+            return;
+        }
+        assert_eq!(info.status, ServiceStatus::Available);
+        assert_eq!(info.hint.as_deref(), Some("no data directory"));
     }
 }

--- a/crates/trusty-console/src/lib.rs
+++ b/crates/trusty-console/src/lib.rs
@@ -46,13 +46,17 @@ pub const DEFAULT_HTTP: &str = "127.0.0.1:7788";
 pub const DEFAULT_PORT: u16 = 7788;
 
 pub mod bind;
+// #6285: the console's own SPA, split out of `server` at the 500-SLOC cap.
 pub mod connector;
+pub mod console_ui;
 pub mod detect;
 pub mod mcp_handle;
 pub mod metrics_poller;
 pub mod poller;
 pub mod proxy;
 pub mod routes;
+// #6285: the console's client to trusty-search, which no longer serves HTTP.
+pub mod search_uds;
 pub mod server;
 pub mod service;
 // #6155: the trusty-search SPA, mounted under /tools/search/.

--- a/crates/trusty-console/src/proxy/routes.rs
+++ b/crates/trusty-console/src/proxy/routes.rs
@@ -59,7 +59,15 @@ static HOP_BY_HOP: &[&str] = &[
 /// Test: `test_service_key_mapping` below.
 fn full_id(service_key: &str) -> Option<&'static str> {
     match service_key {
-        "search" => Some("trusty-search"),
+        // #6285: NO `search` row. trusty-search moved to UDS (ADR-0032) and
+        // stopped writing the `http_addr` file this proxy resolves a base URL
+        // from — the same reason the memory and analyze rows below are gone,
+        // with the same hazard: that file predates the migration on every
+        // existing machine, so a kept row would forward `/api/search/*` to
+        // whatever now holds 7878. `/api/search/{*path}` is served by
+        // `crate::search_uds::routes` instead, which translates each request
+        // into an RPC call on the socket.
+        //
         // #6286: NO `memory` row. trusty-memory moved to UDS (ADR-0032) and
         // this proxy resolves a target's base URL from its `http_addr` file,
         // which the daemon no longer writes — and which is still on disk from
@@ -644,7 +652,11 @@ mod tests {
     /// Test: this test itself.
     #[test]
     fn test_service_key_mapping() {
-        assert_eq!(full_id("search"), Some("trusty-search"));
+        // #6285: `search` is no longer allowlisted. trusty-search serves UDS
+        // and writes no `http_addr`, so an allowlisted key could only resolve a
+        // stale one and forward `/api/search/*` to whatever now holds 7878.
+        // `crate::search_uds::routes` owns that prefix instead.
+        assert_eq!(full_id("search"), None);
         assert_eq!(
             full_id("memory"),
             None,

--- a/crates/trusty-console/src/routes/cleanup.rs
+++ b/crates/trusty-console/src/routes/cleanup.rs
@@ -12,13 +12,13 @@
 //! What: two routes.
 //!   - `POST /api/console/search/prune-indexes` takes the ids an operator
 //!     CONFIRMED and deletes them one at a time through
-//!     [`crate::routes::deletes::delete_index_on_daemon`] — the same
-//!     `DELETE /indexes/{id}` a single-row delete uses, which since #6365
+//!     [`crate::routes::deletes::delete_index_on_socket`] — the same
+//!     `search.index.delete` a single-row delete uses, which since #6365
 //!     also removes a registration the warm-boot allowlist excluded. This
 //!     route discovers nothing and selects nothing: the candidate list comes
-//!     from the daemon's own `GET /registry/orphans` census, which the UI
-//!     reaches through the console's reverse proxy so there is no second answer
-//!     to "which registrations are stale".
+//!     from the daemon's own `search.registry.orphans` census, which the UI
+//!     reaches through `/api/search/registry/orphans` (#6285) so there is no
+//!     second answer to "which registrations are stale".
 //!   - `POST /api/console/memory/palaces/{id}/compact` calls trusty-memory's
 //!     `palace_compact` over its socket.
 //!
@@ -39,7 +39,7 @@ use axum::response::{IntoResponse, Response};
 use serde::Deserialize;
 use serde_json::{Value, json};
 
-use crate::routes::deletes::delete_index_on_daemon;
+use crate::routes::deletes::delete_index_on_socket;
 use crate::routes::memory_rpc;
 use crate::routes::verdict::{ActionVerdict, validate_id};
 use crate::routes::{MEMORY_SERVICE, SEARCH_SERVICE_ID};
@@ -111,7 +111,7 @@ impl PruneOutcome {
 ///
 /// Why: this is the whole prune. It holds no idea of what "stale" means — the
 /// daemon's census decides that and the operator confirms it — and it adds no
-/// deletion path, calling the same [`delete_index_on_daemon`] a single-row
+/// deletion path, calling the same [`delete_index_on_socket`] a single-row
 /// delete uses. Its one job is to not lose a per-id outcome.
 /// What: walks `ids` in order. Past `deadline` an id is not attempted and says
 /// so. Every id produces exactly one row carrying `ok` and, when it failed, the
@@ -119,9 +119,8 @@ impl PruneOutcome {
 /// Test: `prune_reports_per_item_outcomes_for_a_partial_batch`,
 /// `prune_reports_an_expired_budget_as_unattempted`,
 /// `prune_of_a_clean_batch_reports_every_id_removed`.
-pub(crate) async fn prune_indexes_on_daemon(
-    client: &reqwest::Client,
-    base_url: &str,
+pub(crate) async fn prune_indexes_on_socket(
+    socket: &Path,
     ids: &[String],
     delete_data: bool,
     deadline: Instant,
@@ -146,7 +145,7 @@ pub(crate) async fn prune_indexes_on_daemon(
             continue;
         }
 
-        let verdict = delete_index_on_daemon(client, base_url, id, delete_data).await;
+        let verdict = delete_index_on_socket(socket, id, delete_data).await;
         if verdict.succeeded() {
             outcome.removed += 1;
             outcome.rows.push(json!({ "id": verdict.id(), "ok": true }));
@@ -189,14 +188,14 @@ pub struct PruneRequest {
 /// is unusable in — dozens of dead registrations at once.
 /// What: refuses an empty or oversized list and any id outside the console's id
 /// allowlist BEFORE dialling anything, so a malformed batch never partially
-/// executes. Then resolves trusty-search's loopback address from the same
-/// poller cache the single delete uses and prunes under [`PRUNE_BUDGET`].
-/// Refreshes the search metrics cache when anything was removed, so the roster
-/// the UI re-fetches reflects the prune.
+/// executes. Then resolves trusty-search's socket the same way the single
+/// delete does (#6285) and prunes under [`PRUNE_BUDGET`]. Refreshes the search
+/// metrics cache when anything was removed, so the roster the UI re-fetches
+/// reflects the prune.
 /// Test: `prune_route_rejects_an_empty_batch`,
 /// `prune_route_rejects_a_bad_id_without_dialling`,
 /// `prune_route_rejects_an_oversized_batch`,
-/// `prune_route_reports_an_unresolved_daemon_as_unreachable`.
+/// `prune_route_reports_a_dead_daemon_on_every_row`.
 pub async fn prune_indexes_handler(
     State(state): State<AppState>,
     axum::Json(req): axum::Json<PruneRequest>,
@@ -221,27 +220,19 @@ pub async fn prune_indexes_handler(
         }
     }
 
-    let base_url = match state.poller_cache().snapshot().await {
-        Some(snap) => snap.url_map().get(SEARCH_SERVICE_ID).cloned(),
-        None => None,
-    };
-    let Some(base_url) = base_url else {
-        return (
-            StatusCode::SERVICE_UNAVAILABLE,
-            axum::Json(json!({
-                "ok": false,
-                "error": format!(
-                    "{SEARCH_SERVICE_ID} is not reachable: the console has no live address for it"
-                ),
-            })),
-        )
-            .into_response();
+    let socket: PathBuf = match state.search_socket_path() {
+        Ok(p) => p,
+        Err(reason) => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                axum::Json(json!({ "ok": false, "error": reason })),
+            )
+                .into_response();
+        }
     };
 
-    let client = state.http_client();
-    let outcome = prune_indexes_on_daemon(
-        &client,
-        &base_url,
+    let outcome = prune_indexes_on_socket(
+        &socket,
         &req.ids,
         req.delete_data,
         Instant::now() + PRUNE_BUDGET,
@@ -400,49 +391,46 @@ mod tests {
         .to_string()
     }
 
-    /// Start a stub trusty-search whose `DELETE /indexes/{id}` answer depends on
-    /// the id: `doomed-*` is removed, anything else is a skipped no-op.
+    /// Bind a stub trusty-search socket whose `search.index.delete` answer
+    /// depends on the id: `doomed-*` is removed, anything else is a skipped
+    /// no-op.
     ///
     /// Why per-id: a batch's whole contract is that one id's failure does not
     /// change another id's row, and a stub that answers every id identically
     /// cannot show that.
-    async fn stub_search_daemon_removing_only_doomed() -> String {
-        let app = axum::Router::new().route(
-            "/indexes/{id}",
-            axum::routing::delete(
-                |axum::extract::Path(id): axum::extract::Path<String>| async move {
-                    let removed = id.starts_with("doomed-");
-                    let body = json!({
-                        "id": id,
-                        "removed": removed,
-                        "data_deleted": false,
-                        "quiesced": true,
-                    });
-                    (StatusCode::OK, axum::Json(body))
+    /// What: reuses `deletes::tests::stub_search_socket` so there is one stub
+    /// answering for trusty-search's socket in this crate, not two.
+    fn stub_search_socket_removing_only_doomed(dir: &Path) -> PathBuf {
+        crate::routes::deletes::tests::stub_search_socket(dir, |request: &Value| {
+            let id = request["params"]["index_id"].as_str().unwrap_or_default();
+            let removed = id.starts_with("doomed-");
+            json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": {
+                    "id": id,
+                    "removed": removed,
+                    "data_deleted": false,
+                    "quiesced": true,
                 },
-            ),
-        );
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-            .await
-            .expect("bind");
-        let addr = listener.local_addr().expect("addr");
-        tokio::spawn(async move {
-            let _ = axum::serve(listener, app).await;
-        });
-        format!("http://{addr}")
-    }
-
-    /// The client the routes actually use.
-    fn client() -> reqwest::Client {
-        (*AppState::new(vec![]).http_client()).clone()
+            })
+        })
     }
 
     fn ids(list: &[&str]) -> Vec<String> {
         list.iter().map(|s| s.to_string()).collect()
     }
 
+    /// Drive the real router with trusty-search pointed at a socket nothing is
+    /// bound to.
+    ///
+    /// Why the override (#6285): without it these tests resolve the REAL
+    /// trusty-search socket, and on a machine with the daemon running a route
+    /// test would prune live indexes.
     async fn post_through_router(uri: &str, body: Value) -> (StatusCode, Value) {
-        let router = build_router(AppState::new(vec![]));
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let router =
+            build_router(AppState::new(vec![]).with_search_socket(tmp.path().join("absent.sock")));
         let req = Request::builder()
             .method("POST")
             .uri(uri)
@@ -465,10 +453,10 @@ mod tests {
     /// Test: this is the test.
     #[tokio::test(flavor = "multi_thread")]
     async fn prune_reports_per_item_outcomes_for_a_partial_batch() {
-        let base = stub_search_daemon_removing_only_doomed().await;
-        let outcome = prune_indexes_on_daemon(
-            &client(),
-            &base,
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let socket = stub_search_socket_removing_only_doomed(tmp.path());
+        let outcome = prune_indexes_on_socket(
+            &socket,
             &ids(&["doomed-a", "survivor", "doomed-b"]),
             false,
             Instant::now() + PRUNE_BUDGET,
@@ -508,10 +496,10 @@ mod tests {
     /// Test: this is the test.
     #[tokio::test(flavor = "multi_thread")]
     async fn prune_of_a_clean_batch_reports_every_id_removed() {
-        let base = stub_search_daemon_removing_only_doomed().await;
-        let outcome = prune_indexes_on_daemon(
-            &client(),
-            &base,
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let socket = stub_search_socket_removing_only_doomed(tmp.path());
+        let outcome = prune_indexes_on_socket(
+            &socket,
             &ids(&["doomed-a", "doomed-b"]),
             false,
             Instant::now() + PRUNE_BUDGET,
@@ -529,15 +517,9 @@ mod tests {
     /// Test: this is the test.
     #[tokio::test(flavor = "multi_thread")]
     async fn prune_reports_a_dead_daemon_as_a_failure_on_every_id() {
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-            .await
-            .expect("bind");
-        let addr = listener.local_addr().expect("addr");
-        drop(listener);
-
-        let outcome = prune_indexes_on_daemon(
-            &client(),
-            &format!("http://{addr}"),
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let outcome = prune_indexes_on_socket(
+            &tmp.path().join("absent.sock"),
             &ids(&["a", "b"]),
             false,
             Instant::now() + PRUNE_BUDGET,
@@ -562,10 +544,10 @@ mod tests {
     /// starts, so no id is attempted.
     #[tokio::test(flavor = "multi_thread")]
     async fn prune_reports_an_expired_budget_as_unattempted() {
-        let base = stub_search_daemon_removing_only_doomed().await;
-        let outcome = prune_indexes_on_daemon(
-            &client(),
-            &base,
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let socket = stub_search_socket_removing_only_doomed(tmp.path());
+        let outcome = prune_indexes_on_socket(
+            &socket,
             &ids(&["doomed-a", "doomed-b"]),
             false,
             Instant::now(),
@@ -594,10 +576,10 @@ mod tests {
     /// the underlying delete refuses only when the data was actually asked for.
     #[tokio::test(flavor = "multi_thread")]
     async fn prune_forwards_the_delete_data_choice() {
-        let base = stub_search_daemon_removing_only_doomed().await;
-        let without = prune_indexes_on_daemon(
-            &client(),
-            &base,
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let socket = stub_search_socket_removing_only_doomed(tmp.path());
+        let without = prune_indexes_on_socket(
+            &socket,
             &ids(&["doomed-a"]),
             false,
             Instant::now() + PRUNE_BUDGET,
@@ -605,9 +587,8 @@ mod tests {
         .await;
         assert_eq!(without.removed, 1, "a deregister-only prune succeeds");
 
-        let with = prune_indexes_on_daemon(
-            &client(),
-            &base,
+        let with = prune_indexes_on_socket(
+            &socket,
             &ids(&["doomed-a"]),
             true,
             Instant::now() + PRUNE_BUDGET,
@@ -662,25 +643,34 @@ mod tests {
         assert_eq!(status, StatusCode::BAD_REQUEST, "body: {body}");
     }
 
-    /// Why: with no poller snapshot the route must say trusty-search is
-    /// unreachable rather than claim a prune.
+    /// Why (#6285): with nothing bound to the socket the route must fail every
+    /// row and say why, rather than answer `ok: true` for a prune that removed
+    /// nothing. Before the migration this arm was "the poller cache has no
+    /// address"; a socket path always resolves, so the daemon being down is now
+    /// observed at the dial instead.
     /// Test: this is the test.
     #[tokio::test]
-    async fn prune_route_reports_an_unresolved_daemon_as_unreachable() {
+    async fn prune_route_reports_a_dead_daemon_on_every_row() {
         let (status, body) = post_through_router(
             "/api/console/search/prune-indexes",
-            json!({ "ids": ["scratch"] }),
+            json!({ "ids": ["scratch", "other"] }),
         )
         .await;
-        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE, "body: {body}");
+        assert_eq!(status, StatusCode::CONFLICT, "body: {body}");
         assert_eq!(body["ok"], json!(false));
-        assert!(
-            body["error"]
-                .as_str()
-                .unwrap_or_default()
-                .contains("trusty-search"),
-            "the error must name the daemon: {body}"
-        );
+        assert_eq!(body["removed"], json!(0));
+        let rows = body["results"].as_array().expect("rows");
+        assert_eq!(rows.len(), 2, "one row per requested id: {body}");
+        for row in rows {
+            assert_eq!(row["ok"], json!(false), "{body}");
+            assert!(
+                row["error"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .contains("trusty-search"),
+                "every failed row must name the daemon: {body}"
+            );
+        }
     }
 
     // ── compact ──────────────────────────────────────────────────────────────

--- a/crates/trusty-console/src/routes/deletes.rs
+++ b/crates/trusty-console/src/routes/deletes.rs
@@ -13,17 +13,18 @@
 //!     on trusty-memory's Unix socket — the same transport
 //!     [`crate::detect::MemoryConnector`] already uses, so this opens no second
 //!     door to that daemon (#6286, ADR-0032).
-//!   - `/api/console/search/indexes/{id}` sends `DELETE /indexes/{id}` to the
-//!     live trusty-search daemon over the loopback HTTP address the poller cache
-//!     already resolves, through the crate's one shared `reqwest::Client`.
+//!   - `/api/console/search/indexes/{id}` dials `search.index.delete` on
+//!     trusty-search's Unix socket — since #6285 the same transport
+//!     [`crate::detect::SearchConnector`] and the `/api/search/*` bridge use, so
+//!     this opens no second door to that daemon either (ADR-0032).
 //!
 //! Neither route reports success it did not observe. A daemon that refuses, a
 //! daemon that answers a JSON-RPC error, and a daemon that skips the work and
 //! answers `removed: false` all become a NON-success verdict carrying the
 //! daemon's own words — see [`ActionVerdict`]. That last case is the one worth
-//! naming: `DELETE /indexes/{id}` answers `200 OK` with `removed: false` for an
-//! index it never had, so status code alone would report a delete that never
-//! happened as a success.
+//! naming: the delete answers successfully with `removed: false` for an index it
+//! never had, so a transport-level success alone would report a delete that
+//! never happened as one that worked.
 //!
 //! Test: `palace_delete_*`, `index_delete_*` and `validate_id_*` in the `tests`
 //! module below drive both transports against stub daemons.
@@ -96,23 +97,26 @@ pub(crate) async fn delete_palace_on_socket(socket: &Path, id: &str, force: bool
     }
 }
 
-// ─── trusty-search: DELETE /indexes/{id} on the loopback daemon ──────────────
+// ─── trusty-search: search.index.delete over the daemon socket ───────────────
 
-/// Delete a search index by calling the daemon's `DELETE /indexes/{id}`.
+/// Delete a search index by calling `search.index.delete` on the socket.
 ///
-/// Why: that route is trusty-search's own deregistration path — the same
+/// Why: that method is trusty-search's own deregistration path — it runs the
+/// same `delete_index_report` core `DELETE /indexes/{id}` wrapped, which is the
 /// `unregister_index` the `delete_index` MCP tool and the orphan reaper drive.
-/// The console sends it through the crate's single shared `reqwest::Client` so
-/// no second HTTP client exists here.
+/// #6285 moves the transport off HTTP (ADR-0032); the console dials the socket
+/// through [`crate::search_uds`] so there is one client to trusty-search here,
+/// not a second one for deletes.
 ///
-/// What: `DELETE {base_url}/indexes/{id}?delete_data={delete_data}`. Since
+/// What: one `search.index.delete` call with `{index_id, delete_data}`. Since
 /// #4123 a bare delete deregisters and PRESERVES the on-disk corpus, so
 /// `delete_data` is passed explicitly rather than left to a default either side
 /// might change. The answer is read for what it says the daemon DID:
-///   - a non-2xx status is [`ActionVerdict::Refused`] carrying the body;
-///   - `removed: false` is `Refused` even on `200` — that is the no-op an
-///     unregistered id produces, and it is the failure mode this route exists to
-///     not paper over;
+///   - a JSON-RPC `error` frame is [`ActionVerdict::Refused`] carrying the
+///     daemon's words;
+///   - `removed: false` is `Refused` even on a successful exchange — that is the
+///     no-op an unregistered id produces, and it is the failure mode this route
+///     exists to not paper over;
 ///   - `delete_data` requested but `data_deleted: false` is `Refused`, because
 ///     the registration went but the bytes stayed and reporting "deleted" would
 ///     record a corpus as reclaimed while every byte of it is still on disk
@@ -121,12 +125,11 @@ pub(crate) async fn delete_palace_on_socket(socket: &Path, id: &str, force: bool
 /// Test: `index_delete_confirms_a_real_delete`,
 /// `index_delete_reports_a_skipped_delete_as_a_failure`,
 /// `index_delete_rejects_a_confirmation_for_another_id`,
-/// `index_delete_reports_a_daemon_error_status_as_a_failure`,
+/// `index_delete_reports_a_daemon_error_frame_as_a_failure`,
 /// `index_delete_reports_undeleted_data_as_a_failure`,
 /// `index_delete_reports_a_dead_daemon_as_unreachable`.
-pub(crate) async fn delete_index_on_daemon(
-    client: &reqwest::Client,
-    base_url: &str,
+pub(crate) async fn delete_index_on_socket(
+    socket: &Path,
     id: &str,
     delete_data: bool,
 ) -> ActionVerdict {
@@ -137,50 +140,39 @@ pub(crate) async fn delete_index_on_daemon(
         };
     }
 
-    let base = crate::proxy::routes::normalize_base_url(base_url);
-    // SSRF guard, identical to the proxy's: the console is loopback-only
-    // (ADR-0018), so a non-local upstream in the cache is a bug and must not be
-    // dialled. Reusing the proxy's predicate keeps one definition of "local".
-    if !crate::proxy::routes::is_local_upstream(&base) {
-        return ActionVerdict::Unreachable {
-            id: id.to_string(),
-            reason: format!("the resolved {SEARCH_SERVICE_ID} address '{base}' is not loopback"),
-        };
-    }
-
-    // `id` is restricted to `[A-Za-z0-9._-]` by `validate_id`, so it carries no
-    // path or query metacharacter and needs no escaping here.
-    let url = format!(
-        "{}/indexes/{id}?delete_data={delete_data}",
-        base.trim_end_matches('/')
-    );
-
-    let sent = client.delete(&url).timeout(ACTION_TIMEOUT).send().await;
-    let response = match sent {
-        Ok(r) => r,
+    // #6285: no SSRF guard here any more, and none is needed. The pre-migration
+    // path dialled a base URL read off disk, which could name a non-loopback
+    // address; a socket path is derived from the data directory and dials no
+    // network at all.
+    let parsed = match crate::search_uds::call(
+        socket,
+        crate::search_uds::METHOD_INDEX_DELETE,
+        json!({ "index_id": id, "delete_data": delete_data }),
+        ACTION_TIMEOUT,
+    )
+    .await
+    {
+        Ok(result) => result,
+        Err(crate::search_uds::SearchRpcError::Refused { code, message }) => {
+            return ActionVerdict::Refused {
+                id: id.to_string(),
+                reason: format!(
+                    "{SEARCH_SERVICE_ID} refused the delete (code {code}): {}",
+                    first_line(&message)
+                ),
+                detail: json!({ "code": code }),
+            };
+        }
         Err(e) => {
             return ActionVerdict::Unreachable {
                 id: id.to_string(),
-                reason: format!("{SEARCH_SERVICE_ID} did not answer the delete: {e}"),
+                reason: format!(
+                    "{SEARCH_SERVICE_ID} did not answer the delete: {}",
+                    e.message()
+                ),
             };
         }
     };
-
-    let status = response.status();
-    let body = response.text().await.unwrap_or_default();
-    let parsed: Value = serde_json::from_str(&body).unwrap_or(Value::Null);
-
-    if !status.is_success() {
-        return ActionVerdict::Refused {
-            id: id.to_string(),
-            reason: format!(
-                "{SEARCH_SERVICE_ID} refused the delete with HTTP {}: {}",
-                status.as_u16(),
-                first_line(&body)
-            ),
-            detail: parsed,
-        };
-    }
 
     if parsed.get("removed").and_then(Value::as_bool) != Some(true) {
         let quiesced = parsed.get("quiesced").and_then(Value::as_bool);
@@ -302,14 +294,13 @@ pub struct IndexDeleteParams {
 ///
 /// Why: the counterpart to [`delete_palace_handler`] for the Search tab's index
 /// roster.
-/// What: validates the id, then resolves trusty-search's loopback base URL from
-/// the health-poll cache —
-/// the same resolution the reverse proxy uses, so there is one answer to "where
-/// is trusty-search" — then calls [`delete_index_on_daemon`] with the crate's
-/// shared HTTP client. Refreshes the search metrics cache after a confirmed
-/// delete.
+/// What: validates the id, then resolves trusty-search's socket the way
+/// [`crate::detect::SearchConnector`] does — through `AppState`, which defers to
+/// `trusty_common::daemon_socket_path`, so there is one answer to "where is
+/// trusty-search" — then calls [`delete_index_on_socket`]. Refreshes the search
+/// metrics cache after a confirmed delete.
 /// Test: `index_route_rejects_a_bad_id`,
-/// `index_route_reports_an_unresolved_daemon_as_unreachable`.
+/// `index_route_reports_a_dead_daemon_as_unreachable`.
 pub async fn delete_index_handler(
     State(state): State<AppState>,
     AxumPath(id): AxumPath<String>,
@@ -323,22 +314,12 @@ pub async fn delete_index_handler(
         return ActionVerdict::Invalid { id, reason }.into_response();
     }
 
-    let base_url = match state.poller_cache().snapshot().await {
-        Some(snap) => snap.url_map().get(SEARCH_SERVICE_ID).cloned(),
-        None => None,
-    };
-    let Some(base_url) = base_url else {
-        return ActionVerdict::Unreachable {
-            id,
-            reason: format!(
-                "{SEARCH_SERVICE_ID} is not reachable: the console has no live address for it"
-            ),
-        }
-        .into_response();
+    let socket: PathBuf = match state.search_socket_path() {
+        Ok(p) => p,
+        Err(reason) => return ActionVerdict::Unreachable { id, reason }.into_response(),
     };
 
-    let client = state.http_client();
-    let verdict = delete_index_on_daemon(&client, &base_url, &id, params.delete_data).await;
+    let verdict = delete_index_on_socket(&socket, &id, params.delete_data).await;
     if matches!(verdict, ActionVerdict::Succeeded { .. }) {
         refresh_metrics(&state, SEARCH_SERVICE_ID, state.search_metrics_cache()).await;
     }
@@ -375,7 +356,9 @@ pub(crate) async fn refresh_metrics(
 // ─── tests ───────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
-mod tests {
+// `pub(crate)` (#6285): `routes::cleanup`'s tests reuse `stub_search_socket`
+// from here rather than minting a second stub for the same socket.
+pub(crate) mod tests {
     use super::*;
     use crate::routes::verdict::MAX_ID_LEN;
     use axum::body::Body;
@@ -420,33 +403,53 @@ mod tests {
         .to_string()
     }
 
-    /// Start a stub trusty-search on loopback that answers every `DELETE
-    /// /indexes/{id}` with `status` and `body`. Returns its base URL.
-    async fn stub_search_daemon(status: StatusCode, body: Value) -> String {
-        let app = axum::Router::new().route(
-            "/indexes/{id}",
-            axum::routing::delete(move || {
-                let body = body.clone();
-                async move { (status, axum::Json(body)) }
-            }),
-        );
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-            .await
-            .expect("bind");
-        let addr = listener.local_addr().expect("addr");
+    /// Bind a stub trusty-search socket that answers each framed request with
+    /// whatever `respond` returns for it.
+    ///
+    /// Why a loop rather than the one-shot memory stub above: a prune batch
+    /// sends one request per id, and a stub that answered once would report
+    /// every id after the first as unreachable.
+    /// `pub(crate)` so `routes::cleanup`'s tests drive the same stub rather than
+    /// minting a second answer to what trusty-search's socket says.
+    pub(crate) fn stub_search_socket<F>(dir: &std::path::Path, respond: F) -> PathBuf
+    where
+        F: Fn(&Value) -> Value + Send + Sync + 'static,
+    {
+        let socket = dir.join("sockets").join("search.sock");
+        let listener = trusty_common::uds::bind_hardened(&socket).expect("bind");
+        let respond = std::sync::Arc::new(respond);
         tokio::spawn(async move {
-            let _ = axum::serve(listener, app).await;
+            loop {
+                let Ok((mut conn, _)) = listener.accept().await else {
+                    return;
+                };
+                let respond = std::sync::Arc::clone(&respond);
+                tokio::spawn(async move {
+                    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+                    let mut raw = Vec::new();
+                    let _ = conn.read_to_end(&mut raw).await;
+                    let request: Value = serde_json::from_slice(&raw).unwrap_or(Value::Null);
+                    let reply = respond(&request).to_string();
+                    let _ = conn.write_all(reply.as_bytes()).await;
+                    let _ = conn.write_all(b"\n").await;
+                    let _ = conn.flush().await;
+                });
+            }
         });
-        format!("http://{addr}")
+        socket
     }
 
-    /// The client the routes actually use.
-    ///
-    /// Built through `AppState` rather than by a second builder here: the
-    /// redirect assertion in `index_delete_does_not_follow_a_redirect` is only
-    /// worth anything if it exercises the production policy.
-    fn client() -> reqwest::Client {
-        (*AppState::new(vec![]).http_client()).clone()
+    /// A stub that answers every request with the same `result`.
+    pub(crate) fn always_result(result: Value) -> impl Fn(&Value) -> Value + Send + Sync + 'static {
+        move |_| json!({ "jsonrpc": "2.0", "id": 1, "result": result.clone() })
+    }
+
+    /// A stub that answers every request with the same JSON-RPC `error`.
+    fn always_error(
+        code: i64,
+        message: &'static str,
+    ) -> impl Fn(&Value) -> Value + Send + Sync + 'static {
+        move |_| json!({ "jsonrpc": "2.0", "id": 1, "error": { "code": code, "message": message } })
     }
 
     /// Assert a verdict is not a success and say what it carried when it is.
@@ -649,31 +652,66 @@ mod tests {
     /// Test: this is the test.
     #[tokio::test(flavor = "multi_thread")]
     async fn index_delete_confirms_a_real_delete() {
-        let base = stub_search_daemon(
-            StatusCode::OK,
-            json!({"id":"scratch","removed":true,"data_deleted":false,"quiesced":true}),
-        )
-        .await;
-        let verdict = delete_index_on_daemon(&client(), &base, "scratch", false).await;
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let socket = stub_search_socket(
+            tmp.path(),
+            always_result(
+                json!({"id":"scratch","removed":true,"data_deleted":false,"quiesced":true}),
+            ),
+        );
+        let verdict = delete_index_on_socket(&socket, "scratch", false).await;
         assert!(
             matches!(&verdict, ActionVerdict::Succeeded { id, .. } if id == "scratch"),
             "a confirmed delete must read as success: {verdict:?}"
         );
     }
 
-    /// Why (#6360, acceptance 2): `DELETE /indexes/{id}` answers `200 OK` with
-    /// `removed: false` for an id it never had. Status code alone would render
-    /// that skipped delete as a success — this is the exact recorded no-op the
-    /// route must not paper over.
+    /// Why (#6285): the request the daemon receives has to carry the id in
+    /// `index_id` and the choice in `delete_data`. Over HTTP those were a path
+    /// segment and a query parameter, and getting either wrong on the socket
+    /// deletes nothing — or deletes the corpus when the operator did not ask.
+    /// Test: this is the test.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn index_delete_sends_the_id_and_the_data_choice_as_params() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let socket = stub_search_socket(tmp.path(), |request: &Value| {
+            let params = &request["params"];
+            let ok = params["index_id"] == json!("scratch") && params["delete_data"] == json!(true);
+            json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": {
+                    "id": "scratch",
+                    "removed": ok,
+                    "data_deleted": ok,
+                    "quiesced": true,
+                    "method": request["method"].clone(),
+                },
+            })
+        });
+        let verdict = delete_index_on_socket(&socket, "scratch", true).await;
+        assert!(
+            matches!(&verdict, ActionVerdict::Succeeded { detail, .. }
+                if detail["method"] == json!("search.index.delete")),
+            "the params and the method name must both reach the daemon: {verdict:?}"
+        );
+    }
+
+    /// Why (#6360, acceptance 2): the delete answers successfully with
+    /// `removed: false` for an id it never had. A transport-level success alone
+    /// would render that skipped delete as a real one — this is the exact
+    /// recorded no-op the route must not paper over.
     /// Test: this is the test.
     #[tokio::test(flavor = "multi_thread")]
     async fn index_delete_reports_a_skipped_delete_as_a_failure() {
-        let base = stub_search_daemon(
-            StatusCode::OK,
-            json!({"id":"scratch","removed":false,"data_deleted":false,"quiesced":true}),
-        )
-        .await;
-        let verdict = delete_index_on_daemon(&client(), &base, "scratch", false).await;
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let socket = stub_search_socket(
+            tmp.path(),
+            always_result(
+                json!({"id":"scratch","removed":false,"data_deleted":false,"quiesced":true}),
+            ),
+        );
+        let verdict = delete_index_on_socket(&socket, "scratch", false).await;
         assert_failure(&verdict, "skipped the delete");
 
         // The rendered body must say `ok: false` — the field the UI reads.
@@ -693,15 +731,16 @@ mod tests {
         );
     }
 
-    /// Why (#6360): a `200` whose body carries no `removed` field at all is the
-    /// same class of answer as `removed: false` — the daemon did not say it
-    /// removed anything. Reading a missing field as success is how a protocol
-    /// change or a proxy that swallowed the body turns into a phantom delete.
+    /// Why (#6360): a result carrying no `removed` field at all is the same
+    /// class of answer as `removed: false` — the daemon did not say it removed
+    /// anything. Reading a missing field as success is how a protocol change
+    /// turns into a phantom delete.
     /// Test: this is the test.
     #[tokio::test(flavor = "multi_thread")]
     async fn index_delete_reports_an_empty_body_as_a_failure() {
-        let base = stub_search_daemon(StatusCode::OK, json!({})).await;
-        let verdict = delete_index_on_daemon(&client(), &base, "scratch", false).await;
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let socket = stub_search_socket(tmp.path(), always_result(json!({})));
+        let verdict = delete_index_on_socket(&socket, "scratch", false).await;
         assert_failure(&verdict, "skipped the delete");
     }
 
@@ -710,12 +749,14 @@ mod tests {
     /// Test: this is the test.
     #[tokio::test(flavor = "multi_thread")]
     async fn index_delete_rejects_a_confirmation_for_another_id() {
-        let base = stub_search_daemon(
-            StatusCode::OK,
-            json!({"id":"someone-else","removed":true,"data_deleted":false,"quiesced":true}),
-        )
-        .await;
-        let verdict = delete_index_on_daemon(&client(), &base, "scratch", false).await;
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let socket = stub_search_socket(
+            tmp.path(),
+            always_result(
+                json!({"id":"someone-else","removed":true,"data_deleted":false,"quiesced":true}),
+            ),
+        );
+        let verdict = delete_index_on_socket(&socket, "scratch", false).await;
         assert_failure(&verdict, "not for 'scratch'");
     }
 
@@ -725,26 +766,29 @@ mod tests {
     /// Test: this is the test.
     #[tokio::test(flavor = "multi_thread")]
     async fn index_delete_names_an_abandoned_teardown() {
-        let base = stub_search_daemon(
-            StatusCode::OK,
-            json!({"id":"scratch","removed":false,"data_deleted":false,"quiesced":false}),
-        )
-        .await;
-        let verdict = delete_index_on_daemon(&client(), &base, "scratch", false).await;
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let socket = stub_search_socket(
+            tmp.path(),
+            always_result(
+                json!({"id":"scratch","removed":false,"data_deleted":false,"quiesced":false}),
+            ),
+        );
+        let verdict = delete_index_on_socket(&socket, "scratch", false).await;
         assert_failure(&verdict, "never quiesced");
     }
 
-    /// Why (#6360, acceptance 2): a 4xx/5xx from the daemon must carry the
-    /// daemon's own body, not a console-invented message.
+    /// Why (#6360, acceptance 2, carried onto the socket by #6285): a refusal
+    /// must carry the daemon's own words, not a console-invented message. Over
+    /// HTTP that was a 4xx body; here it is the JSON-RPC `error` frame.
     /// Test: this is the test.
     #[tokio::test(flavor = "multi_thread")]
-    async fn index_delete_reports_a_daemon_error_status_as_a_failure() {
-        let base = stub_search_daemon(
-            StatusCode::BAD_REQUEST,
-            json!({"error":"delete_data must be a boolean"}),
-        )
-        .await;
-        let verdict = delete_index_on_daemon(&client(), &base, "scratch", false).await;
+    async fn index_delete_reports_a_daemon_error_frame_as_a_failure() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let socket = stub_search_socket(
+            tmp.path(),
+            always_error(-32602, "delete_data must be a boolean"),
+        );
+        let verdict = delete_index_on_socket(&socket, "scratch", false).await;
         assert_failure(&verdict, "delete_data must be a boolean");
     }
 
@@ -755,84 +799,45 @@ mod tests {
     /// Test: this is the test.
     #[tokio::test(flavor = "multi_thread")]
     async fn index_delete_reports_undeleted_data_as_a_failure() {
-        let base = stub_search_daemon(
-            StatusCode::OK,
-            json!({"id":"scratch","removed":true,"data_deleted":false,"quiesced":true}),
-        )
-        .await;
-        let verdict = delete_index_on_daemon(&client(), &base, "scratch", true).await;
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let socket = stub_search_socket(
+            tmp.path(),
+            always_result(
+                json!({"id":"scratch","removed":true,"data_deleted":false,"quiesced":true}),
+            ),
+        );
+        let verdict = delete_index_on_socket(&socket, "scratch", true).await;
         assert_failure(&verdict, "did not delete its on-disk data");
     }
 
-    /// Why: nothing listening must read as unreachable, distinct from a refusal.
+    /// Why: nothing listening must read as unreachable, distinct from a refusal
+    /// — the dashboard renders the two differently and an operator acts on them
+    /// differently.
     /// Test: this is the test.
     #[tokio::test(flavor = "multi_thread")]
     async fn index_delete_reports_a_dead_daemon_as_unreachable() {
-        // Bind and immediately drop, so the port is almost certainly free.
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-            .await
-            .expect("bind");
-        let addr = listener.local_addr().expect("addr");
-        drop(listener);
-
+        let tmp = tempfile::TempDir::new().expect("tempdir");
         let verdict =
-            delete_index_on_daemon(&client(), &format!("http://{addr}"), "scratch", false).await;
+            delete_index_on_socket(&tmp.path().join("absent.sock"), "scratch", false).await;
         assert!(
             matches!(verdict, ActionVerdict::Unreachable { .. }),
             "a dead daemon must read as unreachable: {verdict:?}"
         );
     }
 
-    /// Why (#6360): every loopback check in this crate validates the URL it was
-    /// handed and nothing else. A followed 3xx would re-issue the DELETE, method
-    /// and all, at whatever host the `Location` names — past the guard that just
-    /// ran. The stub redirects to a public address; if the policy ever went back
-    /// to `limited(10)`, this would leave loopback.
-    /// Test: this is the test.
-    #[tokio::test(flavor = "multi_thread")]
-    async fn index_delete_does_not_follow_a_redirect() {
-        let app = axum::Router::new().route(
-            "/indexes/{id}",
-            axum::routing::delete(|| async {
-                (
-                    StatusCode::TEMPORARY_REDIRECT,
-                    [(
-                        axum::http::header::LOCATION,
-                        "http://169.254.169.254/indexes/scratch",
-                    )],
-                )
-            }),
-        );
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-            .await
-            .expect("bind");
-        let addr = listener.local_addr().expect("addr");
-        tokio::spawn(async move {
-            let _ = axum::serve(listener, app).await;
-        });
-
-        let verdict =
-            delete_index_on_daemon(&client(), &format!("http://{addr}"), "scratch", false).await;
-        assert_failure(&verdict, "HTTP 307");
-    }
-
-    /// Why (ADR-0018): a non-loopback upstream in the cache is a bug or a
-    /// compromise; the delete must not be sent to it.
-    /// Test: this is the test.
-    #[tokio::test(flavor = "multi_thread")]
-    async fn index_delete_refuses_a_non_loopback_upstream() {
-        let verdict =
-            delete_index_on_daemon(&client(), "http://10.0.0.9:7878", "scratch", false).await;
-        assert!(
-            matches!(&verdict, ActionVerdict::Unreachable { reason, .. } if reason.contains("not loopback")),
-            "a remote upstream must be refused: {verdict:?}"
-        );
-    }
-
     // ── route wiring ─────────────────────────────────────────────────────────
 
+    /// Drive the real router with trusty-search pointed at a socket nothing is
+    /// bound to.
+    ///
+    /// Why the override (#6285): without it these tests resolve the REAL
+    /// trusty-search socket, and on a developer machine with the daemon running
+    /// a route test would delete a live index. The override is also what makes
+    /// the unreachable arm deterministic on a machine where the daemon IS up.
     async fn delete_through_router(uri: &str) -> (StatusCode, Value) {
-        let router = build_router(AppState::new(vec![]));
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let router =
+            build_router(AppState::new(vec![]).with_search_socket(tmp.path().join("absent.sock")));
         let req = Request::builder()
             .method("DELETE")
             .uri(uri)
@@ -855,11 +860,12 @@ mod tests {
         assert_eq!(body["ok"], json!(false));
     }
 
-    /// Why: the index route must be mounted, and with no poller snapshot yet it
-    /// must say trusty-search is unreachable rather than 500 or claim a delete.
+    /// Why: the index route must be mounted, and with nothing bound to the
+    /// socket it must say trusty-search is unreachable rather than 500 or claim
+    /// a delete.
     /// Test: this is the test.
     #[tokio::test]
-    async fn index_route_reports_an_unresolved_daemon_as_unreachable() {
+    async fn index_route_reports_a_dead_daemon_as_unreachable() {
         let (status, body) = delete_through_router("/api/console/search/indexes/scratch").await;
         assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE, "body: {body}");
         assert_eq!(body["ok"], json!(false));

--- a/crates/trusty-console/src/search_uds/map.rs
+++ b/crates/trusty-console/src/search_uds/map.rs
@@ -1,0 +1,454 @@
+//! Which trusty-search RPC method one `/api/search/…` request becomes (#6285).
+//!
+//! Why: the console served this prefix with a generic reverse proxy — any
+//! method, any path, forwarded verbatim to a base URL. A socket has no paths, so
+//! the translation has to be written down, and writing it down is what makes the
+//! mapped surface reviewable: a request this table does not name is refused with
+//! `501` rather than forwarded somewhere approximate.
+//!
+//! What: [`map_request`] turns a method, a path and a query string into one
+//! [`Call`]. The table covers every endpoint the two SPAs served from this
+//! binary actually call — the trusty-search dashboard at `/tools/search/`
+//! (`crates/trusty-search/ui/src/lib/api.js` plus the two `EventSource`s) and
+//! the console's own cleanup flow (`ui/src/cleanupFlow.js`).
+//!
+//! ## Two endpoints the SPA calls have no method to map to
+//!
+//! `POST /chat` and `POST /admin/stop` are HTTP-only on trusty-search: slice 5.5
+//! left them out on the grounds that "chat serves the embedded `/ui` alone", and
+//! #6384 moved that `/ui` here — so the console-served SPA IS the consumer that
+//! reasoning said did not exist. Both answer `501` naming the gap. The same
+//! finding the #6285 consumer-map correction recorded for trusty-mpm's TUI stop
+//! key: the retire slice needs an owner decision on `admin.stop`, and the chat
+//! lane needs one too.
+//!
+//! ## Query values are coerced, and that is visible when it is wrong
+//!
+//! A query string is all text; the RPC params are typed. `details=true` has to
+//! become `true` and `n=200` has to become `200`, or every call answers
+//! `invalid_params`. [`query_json`] coerces the two literals and any integer and
+//! leaves everything else a string. A string-valued parameter whose value is
+//! literally `true` or a bare integer would be coerced wrongly — and would then
+//! be REFUSED by the daemon's own deserialiser rather than silently mis-read,
+//! which is why the coercion is safe to make blind.
+//!
+//! Test: `maps_every_endpoint_the_spa_calls`, `refuses_an_unmapped_path`,
+//! `query_json_coerces_bools_and_integers`, `body_json_reads_an_empty_body_as_absent`.
+
+use axum::http::Method;
+use serde_json::{Map, Value, json};
+
+use super::{
+    METHOD_CONFIG_GET, METHOD_CONFIG_SET, METHOD_HEALTH, METHOD_INDEX_CONFIG_GET,
+    METHOD_INDEX_CONFIG_SET, METHOD_INDEX_CREATE, METHOD_INDEX_DELETE, METHOD_INDEX_REINDEX,
+    METHOD_INDEX_REINDEX_STREAM, METHOD_INDEX_STATUS, METHOD_INDEXES_LIST, METHOD_LOGS_TAIL,
+    METHOD_QUERY, METHOD_QUERY_ALL, METHOD_REGISTRY_ORPHANS, METHOD_STATUS_STREAM,
+};
+
+/// What one mapped request asks the daemon for.
+///
+/// Why the two are separate types rather than a flag: a method is streaming or
+/// unary and never both (`trusty_common::uds::server` registers them in
+/// different tables), and the HTTP side answers them differently — one JSON body
+/// against a `text/event-stream` that stays open. Deciding which from the PATH
+/// rather than from the caller's `Accept` header is also strictly stronger than
+/// what #6155 could do over HTTP: there, `Accept: text/event-stream` was a claim
+/// the proxy had to re-check against the upstream's `Content-Type` before
+/// granting a deadline-free read. Here the transport is fixed by this table, so
+/// no caller can talk its way into an open-ended connection.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum Call {
+    /// One request, one answer.
+    Unary {
+        /// The RPC method name.
+        method: &'static str,
+        /// The `params` object.
+        params: Value,
+    },
+    /// One request, many frames, bridged to Server-Sent Events.
+    Stream {
+        /// The RPC method name.
+        method: &'static str,
+        /// The `params` object.
+        params: Value,
+    },
+}
+
+/// Turn one `/api/search/…` request into the call it stands for.
+///
+/// Why the `Err` is a sentence rather than a code: it is rendered into the `501`
+/// body an operator reads, and "no socket method serves POST /chat" is what
+/// makes the gap actionable.
+///
+/// What: `path` is the sub-path with no leading slash — what axum's `{*path}`
+/// captures. `body` is the raw request body, parsed as JSON only for the methods
+/// that carry one.
+///
+/// # Errors
+///
+/// A path and method pair this table does not name, or a body that is not JSON.
+///
+/// Test: `maps_every_endpoint_the_spa_calls`, `refuses_an_unmapped_path`,
+/// `refuses_a_body_that_is_not_json`.
+pub(crate) fn map_request(
+    method: &Method,
+    path: &str,
+    query: Option<&str>,
+    body: &[u8],
+) -> Result<Call, String> {
+    let segments: Vec<&str> = path.trim_matches('/').split('/').collect();
+    let q = query_json(query);
+
+    // Every `params` here is an OBJECT, never `null`, even for a method that
+    // takes no arguments: trusty-search decodes `params` into a struct whose
+    // fields all have serde defaults, and a derived `Deserialize` refuses
+    // `null` outright — so a no-argument call sent as `null` answers
+    // `invalid_params`. `NoParams` accepts either; `{}` is what works for both.
+    let unary = |method: &'static str, params: Value| Ok(Call::Unary { method, params });
+    let stream = |method: &'static str, params: Value| Ok(Call::Stream { method, params });
+
+    match (method, segments.as_slice()) {
+        (&Method::GET, ["health"]) => unary(METHOD_HEALTH, json!({})),
+
+        // ---- the index roster -----------------------------------------------
+        (&Method::GET, ["indexes"]) => unary(METHOD_INDEXES_LIST, q),
+        (&Method::POST, ["indexes"]) => unary(METHOD_INDEX_CREATE, body_json(body)?),
+        (&Method::DELETE, ["indexes", id]) => unary(METHOD_INDEX_DELETE, with_index(id, q)),
+
+        // ---- one index -------------------------------------------------------
+        (&Method::GET, ["indexes", id, "status"]) => {
+            unary(METHOD_INDEX_STATUS, json!({ "index_id": id }))
+        }
+        (&Method::GET, ["indexes", id, "config"]) => {
+            unary(METHOD_INDEX_CONFIG_GET, json!({ "index_id": id }))
+        }
+        (&Method::PATCH, ["indexes", id, "config"]) => unary(
+            METHOD_INDEX_CONFIG_SET,
+            json!({ "index_id": id, "body": body_json(body)? }),
+        ),
+        (&Method::POST, ["indexes", id, "search"]) => unary(
+            METHOD_QUERY,
+            json!({ "index_id": id, "body": body_json(body)? }),
+        ),
+        // `ReindexParams::body` is `Option`, so an absent body maps to `null`
+        // rather than to `{}` — the same "no overrides" the HTTP route reads
+        // from an empty request body.
+        (&Method::POST, ["indexes", id, "reindex"]) => unary(
+            METHOD_INDEX_REINDEX,
+            json!({ "index_id": id, "body": body_json(body)? }),
+        ),
+        (&Method::GET, ["indexes", id, "reindex", "stream"]) => {
+            stream(METHOD_INDEX_REINDEX_STREAM, json!({ "index_id": id }))
+        }
+
+        // ---- registry-wide ---------------------------------------------------
+        (&Method::POST, ["search"]) => unary(METHOD_QUERY_ALL, body_json(body)?),
+        (&Method::GET, ["config"]) => unary(METHOD_CONFIG_GET, json!({})),
+        (&Method::PATCH, ["config"]) => unary(METHOD_CONFIG_SET, body_json(body)?),
+        (&Method::GET, ["logs", "tail"]) => unary(METHOD_LOGS_TAIL, q),
+        (&Method::GET, ["registry", "orphans"]) => unary(METHOD_REGISTRY_ORPHANS, json!({})),
+        (&Method::GET, ["status", "stream"]) => stream(METHOD_STATUS_STREAM, json!({})),
+
+        _ => Err(format!(
+            "no trusty-search socket method serves {method} /{}. The console reaches \
+             trusty-search over its Unix socket (ADR-0032, #6285); only the endpoints the \
+             dashboard uses are mapped. `POST /chat` and `POST /admin/stop` have no socket \
+             method at all and are pending an owner decision on #6285.",
+            path.trim_matches('/')
+        )),
+    }
+}
+
+/// Merge an index id into the query-derived params object.
+///
+/// Why: `DELETE /indexes/{id}?delete_data=true` carries half its arguments in
+/// the path and half in the query, and the RPC method takes one flat object.
+/// Test: `maps_every_endpoint_the_spa_calls`.
+fn with_index(id: &str, mut params: Value) -> Value {
+    if let Some(obj) = params.as_object_mut() {
+        obj.insert("index_id".to_string(), Value::String(id.to_string()));
+    }
+    params
+}
+
+/// Parse a request body as JSON, reading an empty body as absent.
+///
+/// Why `Null` and not `{}` for an empty body: the only methods that take one are
+/// the ones whose params wrap it, and `ReindexParams::body` is an `Option` that
+/// must read an empty POST as "no overrides". A method whose body is required
+/// refuses `null` itself, which is the correct refusal to inherit.
+///
+/// # Errors
+///
+/// A non-empty body that is not JSON.
+///
+/// Test: `body_json_reads_an_empty_body_as_absent`,
+/// `refuses_a_body_that_is_not_json`.
+fn body_json(body: &[u8]) -> Result<Value, String> {
+    if body.iter().all(u8::is_ascii_whitespace) {
+        return Ok(Value::Null);
+    }
+    serde_json::from_slice(body).map_err(|e| format!("request body is not JSON: {e}"))
+}
+
+/// Turn a query string into the typed JSON object the RPC params expect.
+///
+/// Why coercion rather than passing strings through: see the module docs — the
+/// daemon's params are typed and a query string is not. Why it is safe to do
+/// blind: a wrongly-coerced value is refused by the daemon's own deserialiser
+/// with `invalid_params`, which this bridge surfaces as `400`. Nothing is read
+/// as a different valid value.
+/// What: `true`/`false` become booleans, anything parsing as an `i64` becomes a
+/// number, everything else stays a string. A repeated key keeps its LAST value,
+/// matching what `serde_urlencoded` does for a non-sequence field.
+/// Test: `query_json_coerces_bools_and_integers`,
+/// `query_json_is_an_empty_object_for_no_query`.
+fn query_json(query: Option<&str>) -> Value {
+    let mut out = Map::new();
+    let Some(raw) = query.filter(|q| !q.is_empty()) else {
+        return Value::Object(out);
+    };
+    // Parsing through `Url` rather than splitting by hand: percent-decoding and
+    // `+`-as-space are its job, and the crate already depends on it.
+    let Ok(url) = reqwest::Url::parse(&format!("http://console/?{raw}")) else {
+        return Value::Object(out);
+    };
+    for (key, value) in url.query_pairs() {
+        let coerced = match value.as_ref() {
+            "true" => Value::Bool(true),
+            "false" => Value::Bool(false),
+            other => match other.parse::<i64>() {
+                Ok(n) => Value::from(n),
+                Err(_) => Value::String(other.to_string()),
+            },
+        };
+        out.insert(key.into_owned(), coerced);
+    }
+    Value::Object(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn unary(method: &Method, path: &str, query: Option<&str>, body: &str) -> Call {
+        map_request(method, path, query, body.as_bytes()).expect("mapped")
+    }
+
+    /// Why: this table is the whole contract between the SPA and the socket. If
+    /// one row is wrong the dashboard loses a feature silently — the SPA renders
+    /// an error toast, not a crash — so every endpoint the bundle calls is
+    /// asserted here against the method it must reach.
+    /// What: one case per `api.js` entry plus the two `EventSource`s and the
+    /// console's own orphan census.
+    /// Test: this is the test.
+    #[test]
+    fn maps_every_endpoint_the_spa_calls() {
+        assert_eq!(
+            unary(&Method::GET, "health", None, ""),
+            Call::Unary {
+                method: METHOD_HEALTH,
+                params: json!({})
+            }
+        );
+        assert_eq!(
+            unary(&Method::GET, "indexes", Some("details=true"), ""),
+            Call::Unary {
+                method: METHOD_INDEXES_LIST,
+                params: json!({ "details": true })
+            }
+        );
+        assert_eq!(
+            unary(
+                &Method::POST,
+                "indexes",
+                None,
+                r#"{"id":"a","root_path":"/r"}"#
+            ),
+            Call::Unary {
+                method: METHOD_INDEX_CREATE,
+                params: json!({ "id": "a", "root_path": "/r" })
+            }
+        );
+        assert_eq!(
+            unary(&Method::DELETE, "indexes/a", Some("delete_data=true"), ""),
+            Call::Unary {
+                method: METHOD_INDEX_DELETE,
+                params: json!({ "index_id": "a", "delete_data": true })
+            }
+        );
+        assert_eq!(
+            unary(&Method::GET, "indexes/a/status", None, ""),
+            Call::Unary {
+                method: METHOD_INDEX_STATUS,
+                params: json!({ "index_id": "a" })
+            }
+        );
+        assert_eq!(
+            unary(&Method::GET, "indexes/a/config", None, ""),
+            Call::Unary {
+                method: METHOD_INDEX_CONFIG_GET,
+                params: json!({ "index_id": "a" })
+            }
+        );
+        assert_eq!(
+            unary(
+                &Method::PATCH,
+                "indexes/a/config",
+                None,
+                r#"{"include_docs":false}"#
+            ),
+            Call::Unary {
+                method: METHOD_INDEX_CONFIG_SET,
+                params: json!({ "index_id": "a", "body": { "include_docs": false } })
+            }
+        );
+        assert_eq!(
+            unary(
+                &Method::POST,
+                "indexes/a/search",
+                None,
+                r#"{"text":"q","top_k":10}"#
+            ),
+            Call::Unary {
+                method: METHOD_QUERY,
+                params: json!({ "index_id": "a", "body": { "text": "q", "top_k": 10 } })
+            }
+        );
+        assert_eq!(
+            unary(&Method::POST, "indexes/a/reindex", None, "{}"),
+            Call::Unary {
+                method: METHOD_INDEX_REINDEX,
+                params: json!({ "index_id": "a", "body": {} })
+            }
+        );
+        assert_eq!(
+            unary(&Method::POST, "search", None, r#"{"query":"q","top_k":5}"#),
+            Call::Unary {
+                method: METHOD_QUERY_ALL,
+                params: json!({ "query": "q", "top_k": 5 })
+            }
+        );
+        assert_eq!(
+            unary(&Method::GET, "config", None, ""),
+            Call::Unary {
+                method: METHOD_CONFIG_GET,
+                params: json!({})
+            }
+        );
+        assert_eq!(
+            unary(&Method::PATCH, "config", None, r#"{"max_rss_mb":100}"#),
+            Call::Unary {
+                method: METHOD_CONFIG_SET,
+                params: json!({ "max_rss_mb": 100 })
+            }
+        );
+        assert_eq!(
+            unary(&Method::GET, "logs/tail", Some("n=200"), ""),
+            Call::Unary {
+                method: METHOD_LOGS_TAIL,
+                params: json!({ "n": 200 })
+            }
+        );
+        assert_eq!(
+            unary(&Method::GET, "registry/orphans", None, ""),
+            Call::Unary {
+                method: METHOD_REGISTRY_ORPHANS,
+                params: json!({})
+            }
+        );
+        assert_eq!(
+            unary(&Method::GET, "status/stream", None, ""),
+            Call::Stream {
+                method: METHOD_STATUS_STREAM,
+                params: json!({})
+            }
+        );
+        assert_eq!(
+            unary(&Method::GET, "indexes/a/reindex/stream", None, ""),
+            Call::Stream {
+                method: METHOD_INDEX_REINDEX_STREAM,
+                params: json!({ "index_id": "a" })
+            }
+        );
+    }
+
+    /// Why: an unmapped request must be refused with a sentence an operator can
+    /// act on, never forwarded on a guess. `POST /chat` is the live instance —
+    /// the SPA calls it and no socket method serves it.
+    /// Test: this is the test.
+    #[test]
+    fn refuses_an_unmapped_path() {
+        for (method, path) in [
+            (Method::POST, "chat"),
+            (Method::POST, "admin/stop"),
+            (Method::POST, "upgrade"),
+            (Method::GET, "metrics"),
+            (Method::GET, "indexes/a/communities"),
+        ] {
+            let err = map_request(&method, path, None, b"").expect_err("unmapped");
+            assert!(err.contains(path), "the refusal must name the path: {err}");
+        }
+    }
+
+    /// Why: a leading slash on the captured path must not change the mapping —
+    /// axum's `{*path}` has produced both shapes across versions.
+    /// Test: this is the test.
+    #[test]
+    fn maps_the_same_with_or_without_a_leading_slash() {
+        assert_eq!(
+            unary(&Method::GET, "/health", None, ""),
+            unary(&Method::GET, "health", None, "")
+        );
+    }
+
+    /// Why: an empty POST body is "no overrides", not a malformed request — the
+    /// SPA's reindex call sends `{}` but a hand-rolled `curl -X POST` sends
+    /// nothing, and both must reach the daemon.
+    /// Test: this is the test.
+    #[test]
+    fn body_json_reads_an_empty_body_as_absent() {
+        assert_eq!(body_json(b"").expect("empty"), Value::Null);
+        assert_eq!(body_json(b"  \n").expect("whitespace"), Value::Null);
+        assert_eq!(
+            unary(&Method::POST, "indexes/a/reindex", None, ""),
+            Call::Unary {
+                method: METHOD_INDEX_REINDEX,
+                params: json!({ "index_id": "a", "body": null })
+            }
+        );
+    }
+
+    /// Why: a body that is not JSON must be refused HERE, with the parse error,
+    /// rather than sent on to answer an opaque `invalid_params`.
+    /// Test: this is the test.
+    #[test]
+    fn refuses_a_body_that_is_not_json() {
+        let err = map_request(&Method::POST, "search", None, b"not json").expect_err("refused");
+        assert!(err.contains("not JSON"), "{err}");
+    }
+
+    /// Why: `details=true` reaching the daemon as the STRING `"true"` answers
+    /// `invalid_params`, which is how every index listing would fail.
+    /// Test: this is the test.
+    #[test]
+    fn query_json_coerces_bools_and_integers() {
+        let v = query_json(Some(
+            "details=true&force=false&n=200&format=json&repo=own%2Frepo",
+        ));
+        assert_eq!(v["details"], json!(true));
+        assert_eq!(v["force"], json!(false));
+        assert_eq!(v["n"], json!(200));
+        assert_eq!(v["format"], json!("json"));
+        assert_eq!(v["repo"], json!("own/repo"));
+    }
+
+    /// Why: a method whose params struct has all-default fields still refuses
+    /// `null`, so "no query" has to be `{}`.
+    /// Test: this is the test.
+    #[test]
+    fn query_json_is_an_empty_object_for_no_query() {
+        assert_eq!(query_json(None), json!({}));
+        assert_eq!(query_json(Some("")), json!({}));
+    }
+}

--- a/crates/trusty-console/src/search_uds/mod.rs
+++ b/crates/trusty-console/src/search_uds/mod.rs
@@ -1,0 +1,568 @@
+//! trusty-console's one client to trusty-search, over the daemon's Unix socket
+//! (#6285).
+//!
+//! Why: ADR-0032 leaves trusty-console as the workspace's only HTTP surface, and
+//! #6285 deletes trusty-search's own. Until this module existed the console
+//! reached trusty-search three ways — the reverse proxy resolved a base URL from
+//! the `http_addr` discovery file, `detect::SearchConnector` read that same file
+//! and probed the port, and `routes::deletes` dialled `DELETE /indexes/{id}` on
+//! it. All three stop resolving the moment the daemon stops writing that file,
+//! and a stale file left by a pre-migration daemon is worse than none: it names
+//! a port that whatever now holds 7878 will answer. #6286 and #6287 deleted the
+//! memory and analyze rows from the proxy for exactly that reason; this module
+//! is what lets the search row go the same way without taking the SPA with it.
+//!
+//! What: the method names this crate dials, the socket-path resolution every
+//! caller shares, one unary exchange, one stream open, and the mapping from a
+//! JSON-RPC refusal back to the HTTP status the same refusal used to carry.
+//!
+//! **There is no HTTP fallback.** trusty-memory and trusty-analyze migrated with
+//! none, and the reason is the stale discovery file above — a fallback that
+//! resolves `127.0.0.1:7878` is not a safety net, it is a way to report an
+//! unrelated process as a healthy trusty-search. A daemon with no socket reads
+//! as unreachable, which is what it is.
+//!
+//! Test: `error_status_maps_every_documented_code`,
+//! `call_reports_a_dead_socket_as_unreachable`,
+//! `call_reports_a_jsonrpc_error_with_the_http_status_it_came_from`,
+//! `call_reports_an_empty_answer_as_malformed`.
+
+pub(crate) mod map;
+pub(crate) mod routes;
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use axum::body::Body;
+use axum::http::{StatusCode, header};
+use axum::response::{IntoResponse, Response};
+use serde_json::{Value, json};
+use trusty_common::uds::server::{
+    CODE_INTERNAL_ERROR, CODE_INVALID_PARAMS, CODE_INVALID_REQUEST, CODE_METHOD_NOT_FOUND,
+    CODE_PARSE_ERROR, RpcResponse,
+};
+use trusty_common::uds::stream_client::FramedStream;
+
+/// The daemon this module dials, as `trusty_common::daemon_socket_path` names it.
+pub(crate) const SEARCH_SERVICE: &str = "trusty-search";
+
+// ─── the method names ────────────────────────────────────────────────────────
+//
+// Duplicated as literals rather than imported: trusty-console has no Cargo edge
+// on trusty-search and adding one would pull a whole search engine into the
+// console's build. `trusty_search::service::socket::METHODS` is the definition;
+// these are the client's copy, and the contract test the retire slice adds to
+// trusty-search is what keeps them equal — the same arrangement
+// `detect::AnalyzeConnector` records for `analyze.health`.
+
+/// Liveness, index count and the daemon's version.
+pub(crate) const METHOD_HEALTH: &str = "search.health";
+/// The index roster — `GET /indexes`.
+pub(crate) const METHOD_INDEXES_LIST: &str = "search.indexes.list";
+/// Register an index — `POST /indexes`.
+pub(crate) const METHOD_INDEX_CREATE: &str = "search.index.create";
+/// Deregister an index — `DELETE /indexes/{id}`.
+pub(crate) const METHOD_INDEX_DELETE: &str = "search.index.delete";
+/// One index's status — `GET /indexes/{id}/status`.
+pub(crate) const METHOD_INDEX_STATUS: &str = "search.index.status";
+/// One index's hygiene config — `GET /indexes/{id}/config`.
+pub(crate) const METHOD_INDEX_CONFIG_GET: &str = "search.index.config.get";
+/// Patch one index's hygiene config — `PATCH /indexes/{id}/config`.
+pub(crate) const METHOD_INDEX_CONFIG_SET: &str = "search.index.config.set";
+/// Per-index hybrid search — `POST /indexes/{id}/search`.
+pub(crate) const METHOD_QUERY: &str = "search.query";
+/// Cross-index fan-out search — `POST /search`.
+pub(crate) const METHOD_QUERY_ALL: &str = "search.query.all";
+/// Trigger a reindex — `POST /indexes/{id}/reindex`.
+pub(crate) const METHOD_INDEX_REINDEX: &str = "search.index.reindex";
+/// Daemon memory-limit config — `GET /config`.
+pub(crate) const METHOD_CONFIG_GET: &str = "search.config.get";
+/// Patch the daemon config — `PATCH /config`.
+pub(crate) const METHOD_CONFIG_SET: &str = "search.config.set";
+/// The in-memory log ring — `GET /logs/tail`.
+pub(crate) const METHOD_LOGS_TAIL: &str = "search.logs.tail";
+/// The stale-registration census — `GET /registry/orphans`.
+pub(crate) const METHOD_REGISTRY_ORPHANS: &str = "search.registry.orphans";
+/// Live daemon events — `GET /status/stream`, as a stream.
+pub(crate) const METHOD_STATUS_STREAM: &str = "search.status.stream";
+/// One index's reindex progress — `GET /indexes/{id}/reindex/stream`, as a stream.
+pub(crate) const METHOD_INDEX_REINDEX_STREAM: &str = "search.index.reindex.stream";
+
+/// How long one unary exchange may take, end to end.
+///
+/// Matches `routes::ACTION_TIMEOUT`: a delete waits for in-flight writers to
+/// quiesce and a fan-out query walks every registered corpus, so this is bounded
+/// by disk work rather than by a round trip.
+pub(crate) const CALL_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// How long the health probe may take.
+///
+/// Shorter than [`CALL_TIMEOUT`] and for a different reason: the console's
+/// detection pass runs six connectors, and one wedged daemon must not stall the
+/// dashboard. Matches the figure `detect::AnalyzeConnector` uses.
+pub(crate) const HEALTH_TIMEOUT: Duration = Duration::from_secs(3);
+
+/// The per-frame budget on an open stream — effectively none.
+///
+/// Why so large: `send_framed_stream_request` applies this to EACH frame read,
+/// and `search.index.reindex.stream` emits per batch. A reindex whose embedder
+/// sidecar stalls emits nothing for the length of the stall, and the SPA reads a
+/// closed stream as "the reindex finished"
+/// (`crates/trusty-search/ui/src/lib/views/Indexes.svelte`) — so a budget short
+/// enough to cut a stall would report a still-running reindex as complete. That
+/// is the same trade #6155 recorded when it gave the proxy's stream client a
+/// silence bound rather than a total one.
+/// What: a day. Not `Duration::MAX`, which overflows tokio's timer when it is
+/// added to `Instant::now()`.
+///
+/// The same value also bounds the dial and the request write, which is the one
+/// place it is looser than it should be — the API takes one figure for both. A
+/// socket that is absent fails the dial immediately with `ENOENT` rather than
+/// waiting, so what is left unbounded is a socket whose backlog is full.
+pub(crate) const STREAM_FRAME_TIMEOUT: Duration = Duration::from_secs(24 * 60 * 60);
+
+/// The frame budget this client applies, matching the listener's.
+///
+/// Why not the shared 8 MiB default: `trusty_search::service::socket`'s
+/// `MAX_FRAME_BYTES` is 64 MiB — the figure `POST /indexes/{id}/graph` carries
+/// as its `DefaultBodyLimit` — and slice 5.5 states that a consumer must raise
+/// its own budget to match or a request the listener ACCEPTED comes back as
+/// `FrameTooLarge`, because the default applies to the response read too. The
+/// console proxies `search.query.all`, which can pass 8 MiB whenever a caller
+/// asks for full content at a large `top_k`, so the plain helper would fail that
+/// call after the daemon had already done the work.
+/// Test: `a_response_over_the_shared_default_is_read`.
+pub(crate) const MAX_FRAME_BYTES: u64 = 64 * 1024 * 1024;
+
+// ─── the codes trusty-search's refusals carry ────────────────────────────────
+//
+// `crates/trusty-search/src/service/rpc/error.rs` projects an HTTP status onto
+// one of these; [`SearchRpcError::status`] projects it back, so a refusal the
+// SPA used to read as `404 Not Found` still reads as one through this bridge.
+
+/// HTTP 404 — `rpc::error::CODE_NOT_FOUND`.
+const CODE_NOT_FOUND: i64 = -32004;
+/// HTTP 503, retryable — `rpc::error::CODE_UNAVAILABLE`.
+const CODE_UNAVAILABLE: i64 = -32002;
+/// HTTP 503, permanent — `rpc::error::CODE_UNAVAILABLE_PERMANENT`.
+const CODE_UNAVAILABLE_PERMANENT: i64 = -32012;
+/// HTTP 408 — `rpc::error::CODE_DEADLINE_EXCEEDED`.
+const CODE_DEADLINE_EXCEEDED: i64 = -32005;
+/// HTTP 403 — `rpc::error::CODE_FORBIDDEN`.
+const CODE_FORBIDDEN: i64 = -32003;
+/// HTTP 409 — `rpc::error::CODE_CONFLICT`.
+const CODE_CONFLICT: i64 = -32009;
+/// HTTP 429 — `rpc::error::CODE_TOO_MANY_REQUESTS`.
+const CODE_TOO_MANY_REQUESTS: i64 = -32013;
+
+/// Why one exchange with trusty-search did not produce an answer.
+///
+/// Why the three arms are separate: the dashboard must not render "the daemon
+/// is not running" and "the daemon said no" the same way, and neither may render
+/// as an empty success. That is the fail-open branch this whole module exists to
+/// close — see [`call`].
+/// Test: `error_status_maps_every_documented_code`, and the `call_reports_*`
+/// tests below.
+#[derive(Debug)]
+pub(crate) enum SearchRpcError {
+    /// The socket path itself could not be resolved — an unusable data
+    /// directory, not a daemon that is down.
+    Unresolved(String),
+    /// Nothing answered on the socket, or the exchange failed in transport.
+    Unreachable(String),
+    /// The daemon answered with a JSON-RPC `error` frame.
+    Refused { code: i64, message: String },
+    /// The daemon answered, but with neither a result nor an error.
+    Malformed(String),
+}
+
+impl SearchRpcError {
+    /// The HTTP status this failure surfaces as.
+    ///
+    /// Why: the SPA branches on status (`api.js`'s `ApiError`), so a refusal has
+    /// to arrive as the status the HTTP route sent for the same condition. An
+    /// unmapped code is `500` rather than `200` with an error body — no failure
+    /// arm here may reach the browser as a success.
+    /// What: the inverse of `trusty-search`'s `rpc_error_from_http` table, plus
+    /// `502` for the two arms that are the console's own observation.
+    /// Test: `error_status_maps_every_documented_code`.
+    pub(crate) fn status(&self) -> StatusCode {
+        match self {
+            Self::Unresolved(_) | Self::Unreachable(_) | Self::Malformed(_) => {
+                StatusCode::BAD_GATEWAY
+            }
+            Self::Refused { code, .. } => match *code {
+                CODE_NOT_FOUND => StatusCode::NOT_FOUND,
+                CODE_UNAVAILABLE | CODE_UNAVAILABLE_PERMANENT => StatusCode::SERVICE_UNAVAILABLE,
+                CODE_DEADLINE_EXCEEDED => StatusCode::REQUEST_TIMEOUT,
+                CODE_FORBIDDEN => StatusCode::FORBIDDEN,
+                CODE_CONFLICT => StatusCode::CONFLICT,
+                CODE_TOO_MANY_REQUESTS => StatusCode::TOO_MANY_REQUESTS,
+                CODE_INVALID_PARAMS | CODE_INVALID_REQUEST => StatusCode::BAD_REQUEST,
+                CODE_METHOD_NOT_FOUND => StatusCode::NOT_IMPLEMENTED,
+                CODE_PARSE_ERROR | CODE_INTERNAL_ERROR => StatusCode::INTERNAL_SERVER_ERROR,
+                _ => StatusCode::INTERNAL_SERVER_ERROR,
+            },
+        }
+    }
+
+    /// The daemon's own words, or the console's account of why it heard none.
+    pub(crate) fn message(&self) -> &str {
+        match self {
+            Self::Unresolved(m) | Self::Unreachable(m) | Self::Malformed(m) => m,
+            Self::Refused { message, .. } => message,
+        }
+    }
+}
+
+impl IntoResponse for SearchRpcError {
+    /// Render the failure as the JSON body the SPA reads.
+    ///
+    /// `api.js` reads a non-2xx body as text and puts it in the thrown
+    /// `ApiError`'s message, so the daemon's wording reaches the operator
+    /// whatever the status was.
+    /// Test: `a_dead_socket_is_a_bad_gateway_not_an_empty_success` in
+    /// `tests/search_uds_bridge.rs`.
+    fn into_response(self) -> Response {
+        let status = self.status();
+        let body = json!({
+            "error": self.message(),
+            "service": SEARCH_SERVICE,
+        });
+        (status, axum::Json(body)).into_response()
+    }
+}
+
+/// Where trusty-search's socket is, or why the console could not work it out.
+///
+/// Why the error is carried rather than discarded: an unresolvable data
+/// directory is operator-fixable (permissions, a `TRUSTY_DATA_DIR_OVERRIDE`
+/// pointing somewhere unusable) and is indistinguishable on the dashboard from a
+/// daemon that is simply not running. The reason has to survive to the caller —
+/// the same argument `detect::AnalyzeConnector::socket_path` records.
+/// What: `trusty_common::daemon_socket_path`, the ONE resolver the daemon itself
+/// calls (`trusty_search::service::socket::socket_path`), so there is no second
+/// answer to where the socket is.
+/// Test: `socket_path_matches_the_daemon_resolver`.
+pub(crate) fn socket_path() -> Result<PathBuf, String> {
+    trusty_common::daemon_socket_path(SEARCH_SERVICE)
+        .map_err(|e| format!("could not resolve the {SEARCH_SERVICE} socket path: {e:#}"))
+}
+
+/// One unary JSON-RPC exchange with trusty-search.
+///
+/// Why here rather than at each call site: the envelope, the framing, the
+/// timeout and the two ways an exchange fails before a handler runs are
+/// identical for every method, and a second copy of them is how one caller
+/// starts reading an `error` frame as a success while another does not — the
+/// argument `routes::memory_rpc` records for the trusty-memory side.
+///
+/// What: one framed request, then the envelope check. A response carrying
+/// `error` is [`SearchRpcError::Refused`] with the daemon's code and message; a
+/// response carrying neither half is [`SearchRpcError::Malformed`], never an
+/// empty success.
+///
+/// # Errors
+///
+/// Every arm of [`SearchRpcError`].
+///
+/// Test: `call_reports_a_dead_socket_as_unreachable`,
+/// `call_reports_a_jsonrpc_error_with_the_http_status_it_came_from`,
+/// `call_reports_an_empty_answer_as_malformed`,
+/// `call_returns_the_daemon_result`.
+pub(crate) async fn call(
+    socket: &Path,
+    method: &str,
+    params: Value,
+    timeout: Duration,
+) -> Result<Value, SearchRpcError> {
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": method,
+        "params": params,
+    });
+
+    let response: RpcResponse =
+        trusty_common::uds::send_framed_request_capped(socket, &request, timeout, MAX_FRAME_BYTES)
+            .await
+            .map_err(|e| {
+                SearchRpcError::Unreachable(format!(
+                    "{SEARCH_SERVICE} did not answer {method}: {e}"
+                ))
+            })?;
+
+    if let Some(error) = response.error {
+        return Err(SearchRpcError::Refused {
+            code: error.code,
+            message: error.message,
+        });
+    }
+
+    response.result.ok_or_else(|| {
+        SearchRpcError::Malformed(format!(
+            "{SEARCH_SERVICE} answered {method} with neither a result nor an error"
+        ))
+    })
+}
+
+/// Open one streaming JSON-RPC exchange with trusty-search.
+///
+/// Why `"stream": true` is set here: the server negotiates on that field
+/// (`trusty_common::uds::server`'s wire contract) and a streaming method called
+/// without it answers `CODE_STREAM_REQUIRED`. Setting it at the one place that
+/// opens a stream is what keeps a caller from having to know that.
+///
+/// What: dials and writes the request frame, then hands back the reader. Nothing
+/// has been read yet — the first frame may still be the server's refusal, which
+/// is why [`routes`] reads it before choosing an HTTP status.
+///
+/// # Errors
+///
+/// [`SearchRpcError::Unreachable`] for a dial or write failure.
+///
+/// Test: `open_stream_reports_a_dead_socket_as_unreachable`.
+pub(crate) async fn open_stream(
+    socket: &Path,
+    method: &str,
+    params: Value,
+) -> Result<FramedStream<Value>, SearchRpcError> {
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": method,
+        "params": params,
+        "stream": true,
+    });
+
+    trusty_common::uds::stream_client::send_framed_stream_request_capped(
+        socket,
+        &request,
+        STREAM_FRAME_TIMEOUT,
+        MAX_FRAME_BYTES,
+    )
+    .await
+    .map_err(|e| {
+        SearchRpcError::Unreachable(format!("{SEARCH_SERVICE} did not open {method}: {e}"))
+    })
+}
+
+/// Render a `serde_json::Value` as the JSON body an HTTP route would have sent.
+///
+/// Why not `axum::Json`: the daemon's cores already answer the exact document
+/// the axum handler serialised, so re-encoding through a typed wrapper would be
+/// a second chance to differ from it.
+/// Test: `unary_route_returns_the_daemon_body_verbatim` in
+/// `tests/search_uds_bridge.rs`.
+pub(crate) fn json_response(value: &Value) -> Response {
+    match serde_json::to_vec(value) {
+        Ok(bytes) => Response::builder()
+            .status(StatusCode::OK)
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(bytes))
+            .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response()),
+        Err(e) => SearchRpcError::Malformed(format!(
+            "{SEARCH_SERVICE} answered a body the console could not re-encode: {e}"
+        ))
+        .into_response(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Bind a socket that answers exactly one framed request with `reply`.
+    ///
+    /// The same stub shape `routes::memory_rpc`'s tests use, so the two clients
+    /// are exercised against the same kind of daemon.
+    pub(crate) fn stub_daemon(dir: &Path, reply: impl Into<String>) -> PathBuf {
+        let socket = dir.join("sockets").join("search.sock");
+        let reply = reply.into();
+        let listener = trusty_common::uds::bind_hardened(&socket).expect("bind");
+        tokio::spawn(async move {
+            use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+            let Ok((mut conn, _)) = listener.accept().await else {
+                return;
+            };
+            let mut sink = Vec::new();
+            let _ = conn.read_to_end(&mut sink).await;
+            let _ = conn.write_all(reply.as_bytes()).await;
+            let _ = conn.write_all(b"\n").await;
+            let _ = conn.flush().await;
+        });
+        socket
+    }
+
+    /// Why: the SPA branches on HTTP status, so every code trusty-search's
+    /// `rpc_error_from_http` can produce has to come back out as the status it
+    /// went in as. An unmapped code must be a 5xx, never a success.
+    /// Test: this is the test.
+    #[test]
+    fn error_status_maps_every_documented_code() {
+        let cases = [
+            (CODE_NOT_FOUND, StatusCode::NOT_FOUND),
+            (CODE_UNAVAILABLE, StatusCode::SERVICE_UNAVAILABLE),
+            (CODE_UNAVAILABLE_PERMANENT, StatusCode::SERVICE_UNAVAILABLE),
+            (CODE_DEADLINE_EXCEEDED, StatusCode::REQUEST_TIMEOUT),
+            (CODE_FORBIDDEN, StatusCode::FORBIDDEN),
+            (CODE_CONFLICT, StatusCode::CONFLICT),
+            (CODE_TOO_MANY_REQUESTS, StatusCode::TOO_MANY_REQUESTS),
+            (CODE_INVALID_PARAMS, StatusCode::BAD_REQUEST),
+            (CODE_INVALID_REQUEST, StatusCode::BAD_REQUEST),
+            (CODE_METHOD_NOT_FOUND, StatusCode::NOT_IMPLEMENTED),
+            (CODE_INTERNAL_ERROR, StatusCode::INTERNAL_SERVER_ERROR),
+            (CODE_PARSE_ERROR, StatusCode::INTERNAL_SERVER_ERROR),
+            (-31999, StatusCode::INTERNAL_SERVER_ERROR),
+        ];
+        for (code, expected) in cases {
+            let err = SearchRpcError::Refused {
+                code,
+                message: "refused".to_string(),
+            };
+            assert_eq!(err.status(), expected, "code {code}");
+        }
+    }
+
+    /// Why: a daemon that is not running must never be reported as one that
+    /// answered.
+    /// Test: this is the test.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn call_reports_a_dead_socket_as_unreachable() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let err = call(
+            &tmp.path().join("absent.sock"),
+            METHOD_HEALTH,
+            json!({}),
+            Duration::from_secs(2),
+        )
+        .await
+        .expect_err("a dead socket is not a success");
+        assert!(matches!(err, SearchRpcError::Unreachable(_)), "{err:?}");
+        assert_eq!(err.status(), StatusCode::BAD_GATEWAY);
+    }
+
+    /// Why: the fail-open branch this module closes. A JSON-RPC `error` is the
+    /// daemon refusing, and it must reach the caller as the HTTP status the same
+    /// refusal carried over HTTP — carrying the daemon's own wording.
+    /// Test: this is the test.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn call_reports_a_jsonrpc_error_with_the_http_status_it_came_from() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let socket = stub_daemon(
+            tmp.path(),
+            r#"{"jsonrpc":"2.0","id":1,"error":{"code":-32004,"message":"no index 'ghost'"}}"#,
+        );
+        let err = call(
+            &socket,
+            METHOD_INDEX_STATUS,
+            json!({ "index_id": "ghost" }),
+            Duration::from_secs(5),
+        )
+        .await
+        .expect_err("an error frame is not a success");
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+        assert!(err.message().contains("no index 'ghost'"), "{err:?}");
+    }
+
+    /// Why: a frame with neither half is a broken contract, and reading it as an
+    /// empty success would render a healthy-but-empty dashboard for a daemon
+    /// that told us nothing.
+    /// Test: this is the test.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn call_reports_an_empty_answer_as_malformed() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let socket = stub_daemon(tmp.path(), r#"{"jsonrpc":"2.0","id":1}"#);
+        let err = call(&socket, METHOD_HEALTH, json!({}), Duration::from_secs(5))
+            .await
+            .expect_err("an empty answer is not a success");
+        assert!(matches!(err, SearchRpcError::Malformed(_)), "{err:?}");
+        assert_eq!(err.status(), StatusCode::BAD_GATEWAY);
+    }
+
+    /// Why: the success path has to hand back the daemon's own document, since
+    /// the SPA reads fields the console does not model.
+    /// Test: this is the test.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn call_returns_the_daemon_result() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let socket = stub_daemon(
+            tmp.path(),
+            r#"{"jsonrpc":"2.0","id":1,"result":{"status":"ok","version":"9.9.9"}}"#,
+        );
+        let result = call(&socket, METHOD_HEALTH, json!({}), Duration::from_secs(5))
+            .await
+            .expect("the exchange succeeds");
+        assert_eq!(result["version"], json!("9.9.9"));
+    }
+
+    /// Why: `search.query.all` with full content at a large `top_k` passes the
+    /// shared 8 MiB default, and the default applies to the RESPONSE read — so
+    /// under the plain helper that call would fail AFTER the daemon had done the
+    /// work. This asserts the raised budget is actually in force.
+    /// What: answers a result whose payload is over 8 MiB and reads it back.
+    /// Test: this is the test.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_response_over_the_shared_default_is_read() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let big = "x".repeat(9 * 1024 * 1024);
+        let reply = json!({ "jsonrpc": "2.0", "id": 1, "result": { "blob": big } }).to_string();
+        assert!(
+            reply.len() as u64 > trusty_common::uds::MAX_FRAME_BYTES,
+            "the fixture must exceed the shared default to prove anything"
+        );
+        let socket = stub_daemon(tmp.path(), reply);
+        let result = call(
+            &socket,
+            METHOD_QUERY_ALL,
+            json!({}),
+            Duration::from_secs(20),
+        )
+        .await
+        .expect("an oversized-but-permitted response is read");
+        assert_eq!(result["blob"].as_str().map(str::len), Some(9 * 1024 * 1024));
+    }
+
+    /// Why: a stream that cannot be opened must not read as an empty stream —
+    /// the SPA treats a closed reindex stream as a completed reindex.
+    /// Test: this is the test.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn open_stream_reports_a_dead_socket_as_unreachable() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let err = open_stream(
+            &tmp.path().join("absent.sock"),
+            METHOD_STATUS_STREAM,
+            json!({}),
+        )
+        .await
+        .expect_err("a dead socket cannot open a stream");
+        assert!(matches!(err, SearchRpcError::Unreachable(_)), "{err:?}");
+    }
+
+    /// Why: the console and the daemon must compute the SAME path, or the
+    /// console dials a socket nothing is bound to and reports a running daemon
+    /// as down. `trusty_search::service::socket::socket_path` is
+    /// `daemon_socket_path("trusty-search")` and so is this.
+    /// What: points `resolve_data_dir` at a tempdir — under the shared
+    /// `detect::ENV_LOCK`, because that env var is process-global and the
+    /// connector tests read it too — and asserts the whole resolved path.
+    /// Test: this is the test.
+    #[test]
+    fn socket_path_matches_the_daemon_resolver() {
+        let _guard = crate::detect::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        unsafe {
+            std::env::set_var(trusty_common::DATA_DIR_OVERRIDE_ENV, tmp.path());
+        }
+        let resolved = socket_path();
+        unsafe {
+            std::env::remove_var(trusty_common::DATA_DIR_OVERRIDE_ENV);
+        }
+        assert_eq!(
+            resolved.expect("the override resolves"),
+            tmp.path().join(SEARCH_SERVICE).join("trusty-search.sock")
+        );
+    }
+}

--- a/crates/trusty-console/src/search_uds/mod.rs
+++ b/crates/trusty-console/src/search_uds/mod.rs
@@ -115,13 +115,29 @@ pub(crate) const HEALTH_TIMEOUT: Duration = Duration::from_secs(3);
 /// What: a day. Not `Duration::MAX`, which overflows tokio's timer when it is
 /// added to `Instant::now()`.
 ///
-/// The same value also bounds the dial and the request write, which is the one
-/// place it is looser than it should be — the API takes one figure for both. A
-/// socket that is absent fails the dial immediately with `ENOENT` rather than
-/// waiting, so what is left unbounded is a socket whose backlog is full.
+/// The same value also bounds the dial and the request write inside the shared
+/// helper, which takes one figure for both. [`STREAM_OPEN_TIMEOUT`] is what
+/// bounds the open, wrapped around the call rather than passed into it.
 pub(crate) const STREAM_FRAME_TIMEOUT: Duration = Duration::from_secs(24 * 60 * 60);
 
-/// The frame budget this client applies, matching the listener's.
+/// How long opening a stream may take before the console gives up on it.
+///
+/// Why separate from [`STREAM_FRAME_TIMEOUT`]: that budget is a day, and
+/// `send_framed_stream_request_capped` applies its ONE figure to the dial, the
+/// request write, and every frame read alike. A socket whose backlog is full
+/// accepts the connect and then never reads, so the dial and the write both
+/// park — and with only the day-long figure in play the browser's reindex
+/// request would hang for a day rather than being told the daemon is
+/// unreachable. An ABSENT socket is not this case; it fails immediately with
+/// `ENOENT`.
+/// What: 60 s, wrapped around the whole open — the dial, the write, and the
+/// first frame read, which is the last step before a response head exists. Once
+/// the head is written the long per-frame budget takes over, because a reindex
+/// legitimately emits nothing for minutes.
+/// Test: `a_socket_that_never_answers_is_a_prompt_bad_gateway` in [`routes`].
+pub(crate) const STREAM_OPEN_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// The frame budget this client applies — at least the listener's.
 ///
 /// Why not the shared 8 MiB default: `trusty_search::service::socket`'s
 /// `MAX_FRAME_BYTES` is 64 MiB — the figure `POST /indexes/{id}/graph` carries
@@ -131,7 +147,16 @@ pub(crate) const STREAM_FRAME_TIMEOUT: Duration = Duration::from_secs(24 * 60 * 
 /// console proxies `search.query.all`, which can pass 8 MiB whenever a caller
 /// asks for full content at a large `top_k`, so the plain helper would fail that
 /// call after the daemon had already done the work.
-/// Test: `a_response_over_the_shared_default_is_read`.
+///
+/// The invariant is a FLOOR, not an equality: this figure must be at least the
+/// listener's. Smaller breaks a response the daemon has already produced;
+/// larger has no failure mode, because the listener refuses an oversized REQUEST
+/// on its own terms and never sends a frame past its own budget.
+///
+/// The same figure bounds the HTTP request body [`routes`] will carry, so the
+/// bridge refuses a body over the frame budget before copying 64 MiB of it.
+/// Test: `a_response_over_the_shared_default_is_read` and
+/// `the_frame_budget_is_at_least_the_listeners`.
 pub(crate) const MAX_FRAME_BYTES: u64 = 64 * 1024 * 1024;
 
 // ─── the codes trusty-search's refusals carry ────────────────────────────────
@@ -317,15 +342,24 @@ pub(crate) async fn call(
 /// has been read yet — the first frame may still be the server's refusal, which
 /// is why [`routes`] reads it before choosing an HTTP status.
 ///
+/// Why `open_timeout` wraps the helper instead of being passed to it: the helper
+/// takes ONE figure for the dial, the request write, and each frame read, and
+/// the frame read needs [`STREAM_FRAME_TIMEOUT`]'s day. Wrapping bounds only the
+/// open — a wedged listener answers in a minute — while the established stream
+/// keeps the long per-frame budget.
+///
 /// # Errors
 ///
-/// [`SearchRpcError::Unreachable`] for a dial or write failure.
+/// [`SearchRpcError::Unreachable`] for a dial or write failure, and for an open
+/// that outlasts `open_timeout`.
 ///
-/// Test: `open_stream_reports_a_dead_socket_as_unreachable`.
+/// Test: `open_stream_reports_a_dead_socket_as_unreachable`, and
+/// `a_socket_that_never_answers_is_a_prompt_bad_gateway` in [`routes`].
 pub(crate) async fn open_stream(
     socket: &Path,
     method: &str,
     params: Value,
+    open_timeout: Duration,
 ) -> Result<FramedStream<Value>, SearchRpcError> {
     let request = json!({
         "jsonrpc": "2.0",
@@ -335,14 +369,24 @@ pub(crate) async fn open_stream(
         "stream": true,
     });
 
-    trusty_common::uds::stream_client::send_framed_stream_request_capped(
-        socket,
-        &request,
-        STREAM_FRAME_TIMEOUT,
-        MAX_FRAME_BYTES,
+    let opened = tokio::time::timeout(
+        open_timeout,
+        trusty_common::uds::stream_client::send_framed_stream_request_capped(
+            socket,
+            &request,
+            STREAM_FRAME_TIMEOUT,
+            MAX_FRAME_BYTES,
+        ),
     )
     .await
-    .map_err(|e| {
+    .map_err(|_| {
+        SearchRpcError::Unreachable(format!(
+            "{SEARCH_SERVICE} did not open {method} within {}s",
+            open_timeout.as_secs_f32()
+        ))
+    })?;
+
+    opened.map_err(|e| {
         SearchRpcError::Unreachable(format!("{SEARCH_SERVICE} did not open {method}: {e}"))
     })
 }
@@ -533,10 +577,63 @@ mod tests {
             &tmp.path().join("absent.sock"),
             METHOD_STATUS_STREAM,
             json!({}),
+            STREAM_OPEN_TIMEOUT,
         )
         .await
         .expect_err("a dead socket cannot open a stream");
         assert!(matches!(err, SearchRpcError::Unreachable(_)), "{err:?}");
+    }
+
+    /// Why: [`MAX_FRAME_BYTES`] is a floor under the listener's own figure, and
+    /// nothing in a `cargo check` couples the two — trusty-console does not
+    /// depend on trusty-search, and adding a dev-dependency to compare the
+    /// constants would build tantivy, tree-sitter and ORT into this crate's test
+    /// run. Reading the declaration out of the listener's source keeps the two
+    /// coupled at the cost of one file read.
+    /// What: parses `pub const MAX_FRAME_BYTES` out of
+    /// `crates/trusty-search/src/service/socket.rs` and asserts the direction.
+    /// Fails when the declaration moves rather than passing on a missed match,
+    /// which is what makes the check worth having.
+    /// Test: this is the test.
+    #[test]
+    fn the_frame_budget_is_at_least_the_listeners() {
+        let socket_rs = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../trusty-search/src/service/socket.rs");
+        let source = std::fs::read_to_string(&socket_rs)
+            .unwrap_or_else(|e| panic!("read {}: {e}", socket_rs.display()));
+
+        let decl = source
+            .lines()
+            .find_map(|line| {
+                line.trim()
+                    .strip_prefix("pub const MAX_FRAME_BYTES: u64 = ")?
+                    .strip_suffix(';')
+                    .map(str::to_owned)
+            })
+            .unwrap_or_else(|| {
+                panic!(
+                    "no `pub const MAX_FRAME_BYTES: u64 = …;` in {} — the listener's budget moved, \
+                     so this floor is unverified",
+                    socket_rs.display()
+                )
+            });
+
+        // `64 * 1024 * 1024` — the only shape the declaration has ever taken.
+        let listener: u64 = decl
+            .split('*')
+            .map(|factor| {
+                factor
+                    .trim()
+                    .parse::<u64>()
+                    .unwrap_or_else(|e| panic!("parse `{decl}`: {e}"))
+            })
+            .product();
+
+        assert!(
+            MAX_FRAME_BYTES >= listener,
+            "this client's frame budget ({MAX_FRAME_BYTES}) is under the listener's ({listener}); \
+             a response trusty-search already produced would come back as FrameTooLarge"
+        );
     }
 
     /// Why: the console and the daemon must compute the SAME path, or the

--- a/crates/trusty-console/src/search_uds/mod.rs
+++ b/crates/trusty-console/src/search_uds/mod.rs
@@ -130,11 +130,15 @@ pub(crate) const STREAM_FRAME_TIMEOUT: Duration = Duration::from_secs(24 * 60 * 
 /// request would hang for a day rather than being told the daemon is
 /// unreachable. An ABSENT socket is not this case; it fails immediately with
 /// `ENOENT`.
-/// What: 60 s, wrapped around the whole open — the dial, the write, and the
-/// first frame read, which is the last step before a response head exists. Once
-/// the head is written the long per-frame budget takes over, because a reindex
-/// legitimately emits nothing for minutes.
-/// Test: `a_socket_that_never_answers_is_a_prompt_bad_gateway` in [`routes`].
+/// What: 60 s for the whole open — the dial, the write, and the first frame
+/// read, which is the last step before a response head exists. `routes`'
+/// `stream_response` takes ONE deadline before dialling and reuses it for the
+/// first-frame read, so the figure here is the total rather than a per-step
+/// budget two steps could each spend in full. Once the head is written the long
+/// per-frame budget takes over, because a reindex legitimately emits nothing for
+/// minutes.
+/// Test: `a_socket_that_never_answers_is_a_prompt_bad_gateway` and
+/// `a_slow_open_and_a_silent_first_frame_share_one_budget` in [`routes`].
 pub(crate) const STREAM_OPEN_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// The frame budget this client applies — at least the listener's.
@@ -347,6 +351,12 @@ pub(crate) async fn call(
 /// the frame read needs [`STREAM_FRAME_TIMEOUT`]'s day. Wrapping bounds only the
 /// open — a wedged listener answers in a minute — while the established stream
 /// keeps the long per-frame budget.
+///
+/// `open_timeout` bounds the dial and the write only. The caller owns the rest
+/// of the open: `routes::stream_response` computes one deadline before calling
+/// this and bounds the first frame read against the same deadline, so a slow but
+/// successful open leaves the peek less than the full figure rather than a
+/// second copy of it.
 ///
 /// # Errors
 ///

--- a/crates/trusty-console/src/search_uds/routes.rs
+++ b/crates/trusty-console/src/search_uds/routes.rs
@@ -1,0 +1,376 @@
+//! `/api/search/{*path}` — the HTTP face of trusty-search's socket (#6285).
+//!
+//! Why: the console-served dashboard at `/tools/search/` (#6155, PR #6384) is
+//! plain browser JavaScript. It speaks HTTP and Server-Sent Events and nothing
+//! else, while trusty-search now speaks framed JSON-RPC over a Unix socket. This
+//! module is the whole of the translation, so the SPA needs no fork and
+//! trusty-search needs no HTTP.
+//!
+//! What: one handler. It maps the request through [`super::map::map_request`],
+//! dials the socket, and answers either a JSON body or an open
+//! `text/event-stream`.
+//!
+//! ## The SSE bridge, frame for frame
+//!
+//! `trusty_search::service::rpc::streams` states the contract this side has to
+//! honour: one stream ITEM is exactly the JSON document one SSE `data:` line
+//! carried, parsed rather than prefixed. So the bridge re-prefixes it and adds
+//! nothing — the `{"type":"connected"}` opener, every `DaemonEvent`, every
+//! reindex progress event and the `{"type":"lag","skipped":N}` frame reach the
+//! browser byte-identical to what the daemon's own SSE route wrote.
+//!
+//! Two things the daemon's SSE route emitted that its RPC stream deliberately
+//! does not, and what happens to them here:
+//!
+//! - the `: heartbeat\n\n` comment every 20 s. It exists so an idle TCP body is
+//!   not torn down, and the browser hop is still TCP — so this module emits it,
+//!   on the same interval, rather than changing what the browser receives.
+//! - the terminal `data:` framing of a failure. A mid-stream failure becomes one
+//!   `{"type":"error","message":…}` event before the body closes, because the
+//!   SPA reads a closed reindex stream as a COMPLETED reindex
+//!   (`crates/trusty-search/ui/src/lib/views/Indexes.svelte`) and a silent close
+//!   would report a broken reindex as a finished one.
+//!
+//! A refusal that arrives BEFORE the first item — the reindex stream's "no
+//! progress record for this index" — becomes an HTTP status, not a `200`
+//! carrying an error event, which is what `GET /indexes/{id}/reindex/stream`
+//! answered over HTTP. That is why the first frame is read before the response
+//! head is built.
+//!
+//! Test: `tests` below, plus `tests/search_uds_bridge.rs`, which drives the
+//! whole router against a stub daemon socket.
+
+use std::path::{Path, PathBuf};
+
+use axum::body::{Body, Bytes};
+use axum::extract::{Path as AxumPath, Request, State};
+use axum::http::{StatusCode, header};
+use axum::response::{IntoResponse, Response};
+use futures_util::StreamExt as _;
+use serde_json::{Value, json};
+use tokio::sync::mpsc;
+use tracing::{debug, warn};
+use trusty_common::uds::UdsRpcError;
+use trusty_common::uds::stream_client::FramedStream;
+
+use super::map::{Call, map_request};
+use super::{CALL_TIMEOUT, SearchRpcError, call, json_response, open_stream};
+use crate::server::AppState;
+
+/// How large a request body this bridge will carry.
+///
+/// Matches `trusty_search::service::socket::MAX_FRAME_BYTES`, which is itself
+/// the `DefaultBodyLimit` the daemon's largest HTTP route carried. A body over
+/// this is refused here rather than after a 64 MiB copy has been made.
+const BODY_LIMIT: usize = 64 * 1024 * 1024;
+
+/// How often an open stream emits an SSE keep-alive comment.
+///
+/// The same 20 s `trusty_search::service::server::reindex_handlers` used, so an
+/// idle browser connection sees the byte sequence it saw before the migration.
+const SSE_HEARTBEAT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(20);
+
+/// How many stream items may buffer between the socket reader and the browser.
+///
+/// Matches the daemon-side producer buffer (`streams::STREAM_BUFFER`), so
+/// neither side is the first to accumulate behind a slow reader.
+const SSE_BUFFER: usize = 64;
+
+/// `ANY /api/search/{*path}` — reach trusty-search over its socket.
+///
+/// Why a dedicated handler rather than a row in `proxy::routes::full_id`: that
+/// proxy forwards bytes to a base URL resolved from an `http_addr` discovery
+/// file, and trusty-search stops writing one (#6285, ADR-0032). #6286 and #6287
+/// deleted the memory and analyze rows for the same reason; the search row would
+/// have been deleted too, taking the dashboard with it.
+///
+/// What: map the request, resolve the socket, then either one unary exchange
+/// rendered as JSON or one stream bridged to Server-Sent Events. An unmapped
+/// path is `501` naming itself; an unresolvable or unreachable socket is `502`;
+/// a refusal is the status the same refusal carried over HTTP.
+///
+/// Test: `an_unmapped_path_is_not_implemented_and_names_itself` and
+/// `a_dead_socket_is_a_bad_gateway_not_an_empty_success`, plus every other
+/// case in `tests/search_uds_bridge.rs`.
+pub async fn search_api_handler(
+    State(state): State<AppState>,
+    AxumPath(path): AxumPath<String>,
+    req: Request,
+) -> Response {
+    let (parts, body) = req.into_parts();
+    let query = parts.uri.query().map(str::to_owned);
+
+    let body_bytes: Bytes = match axum::body::to_bytes(body, BODY_LIMIT).await {
+        Ok(b) => b,
+        Err(e) => {
+            warn!("search_uds: could not read the request body: {e}");
+            return (
+                StatusCode::PAYLOAD_TOO_LARGE,
+                "request body exceeds the 64 MiB frame budget",
+            )
+                .into_response();
+        }
+    };
+
+    let mapped = match map_request(&parts.method, &path, query.as_deref(), &body_bytes) {
+        Ok(call) => call,
+        Err(reason) => {
+            warn!(
+                "search_uds: {} /{path} is not mapped: {reason}",
+                parts.method
+            );
+            return (
+                StatusCode::NOT_IMPLEMENTED,
+                axum::Json(json!({ "error": reason, "service": super::SEARCH_SERVICE })),
+            )
+                .into_response();
+        }
+    };
+
+    let socket = match state.search_socket_path() {
+        Ok(p) => p,
+        Err(reason) => return SearchRpcError::Unresolved(reason).into_response(),
+    };
+
+    match mapped {
+        Call::Unary { method, params } => {
+            debug!("search_uds: {} /{path} → {method}", parts.method);
+            match call(&socket, method, params, CALL_TIMEOUT).await {
+                Ok(result) => json_response(&result),
+                Err(e) => e.into_response(),
+            }
+        }
+        Call::Stream { method, params } => {
+            debug!("search_uds: {} /{path} → {method} (stream)", parts.method);
+            stream_response(&socket, method, params).await
+        }
+    }
+}
+
+/// `ANY /proxy/search/{*path}` — the deprecated alias, kept working (#1849).
+///
+/// Why kept: the trusty-search SPA's own `base.js` documents `/proxy/search/` as
+/// a supported mount, so callers exist that predate the `/api/` rename. They
+/// would otherwise get `400 unknown daemon` once the search row leaves
+/// `proxy::routes::full_id`.
+/// Test: `deprecated_alias_reaches_the_same_handler` in
+/// `tests/search_uds_bridge.rs`.
+pub async fn deprecated_search_api_handler(
+    state: State<AppState>,
+    path: AxumPath<String>,
+    req: Request,
+) -> Response {
+    tracing::trace!("search_uds: DEPRECATED /proxy/search/… — use /api/search/… instead (#1849)");
+    search_api_handler(state, path, req).await
+}
+
+/// Open one stream and answer it as Server-Sent Events.
+///
+/// Why the first frame is read before the head is built: a streaming method can
+/// refuse — `search.index.reindex.stream` answers `404` for an index with no
+/// progress record — and that refusal arrives as the stream's FIRST frame, after
+/// the dial has already succeeded. Committing to `200 text/event-stream` before
+/// reading it would turn every such refusal into an empty stream, which the SPA
+/// reads as a finished reindex.
+/// What: peek, then either the refusal's own status or a `200` whose body starts
+/// with the peeked item.
+/// Test: `tests/search_uds_bridge.rs`'s
+/// `a_stream_refusal_before_the_first_item_is_an_http_status`.
+async fn stream_response(socket: &Path, method: &'static str, params: Value) -> Response {
+    let mut stream = match open_stream(socket, method, params).await {
+        Ok(s) => s,
+        Err(e) => return e.into_response(),
+    };
+
+    let first = match stream.next_frame().await {
+        Some(Ok(item)) => Some(item),
+        Some(Err(e)) => return stream_error(method, e).into_response(),
+        // A stream that ended with no items at all is still a well-formed empty
+        // answer; the browser gets an immediately-closed event stream, which is
+        // what the HTTP route did for a completed reindex with an empty replay.
+        None => None,
+    };
+
+    let head = futures_util::stream::iter(
+        first
+            .into_iter()
+            .map(|item| Ok::<Bytes, std::convert::Infallible>(sse_data(&item))),
+    );
+
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, "text/event-stream")
+        .header(header::CACHE_CONTROL, "no-cache")
+        // The same header the daemon's SSE routes set, so a reverse proxy in
+        // front of the console does not buffer the stream into uselessness.
+        .header("X-Accel-Buffering", "no")
+        .body(Body::from_stream(head.chain(sse_tail(stream, method))))
+        .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response())
+}
+
+/// The rest of an open stream, as SSE frames plus keep-alive comments.
+///
+/// Why the reader runs in its own task rather than inside the `select!`:
+/// `FramedStream::next_frame` reads a line off a `BufReader`, and cancelling
+/// that mid-line — which a heartbeat tick would do — discards the bytes already
+/// read. Moving the read behind an `mpsc` makes both arms of the select
+/// cancel-safe, since `Receiver::recv` and `Interval::tick` both are.
+///
+/// The task also carries the disconnect signal: when the browser goes, axum
+/// drops this body, the receiver drops, the next `send` fails, and the task
+/// returns — dropping the `FramedStream` and closing the socket, which is what
+/// ends the daemon's producer (`streams`'s "a dropped client stops the
+/// producer").
+///
+/// Test: `tests/search_uds_bridge.rs`'s `a_stream_reaches_the_browser_frame_for_frame`
+/// and `a_mid_stream_failure_becomes_an_error_event`.
+fn sse_tail(
+    mut stream: FramedStream<Value>,
+    method: &'static str,
+) -> impl futures_util::Stream<Item = Result<Bytes, std::convert::Infallible>> {
+    let (tx, rx) = mpsc::channel::<Result<Value, UdsRpcError>>(SSE_BUFFER);
+    tokio::spawn(async move {
+        while let Some(item) = stream.next_frame().await {
+            let terminal = item.is_err();
+            if tx.send(item).await.is_err() || terminal {
+                return;
+            }
+        }
+    });
+
+    let heartbeat = tokio::time::interval_at(
+        tokio::time::Instant::now() + SSE_HEARTBEAT_INTERVAL,
+        SSE_HEARTBEAT_INTERVAL,
+    );
+
+    futures_util::stream::unfold(Some((rx, heartbeat)), move |state| async move {
+        let (mut rx, mut heartbeat) = state?;
+        tokio::select! {
+            biased;
+            item = rx.recv() => match item {
+                Some(Ok(value)) => Some((Ok(sse_data(&value)), Some((rx, heartbeat)))),
+                Some(Err(e)) => {
+                    // #6285: never a silent close. See the module docs.
+                    warn!("search_uds: {method} failed mid-stream: {e}");
+                    let event = json!({ "type": "error", "message": e.to_string() });
+                    Some((Ok(sse_data(&event)), None))
+                }
+                None => None,
+            },
+            _ = heartbeat.tick() => Some((
+                Ok(Bytes::from_static(b": heartbeat\n\n")),
+                Some((rx, heartbeat)),
+            )),
+        }
+    })
+}
+
+/// Encode one stream item as an SSE `data:` frame.
+///
+/// Why `to_string` on a `Value` rather than passing the raw line through: the
+/// stream carries parsed JSON, and re-serialising is what puts it back on one
+/// line — an embedded newline would split one event into two.
+/// Test: `sse_data_is_one_line_per_event`.
+fn sse_data(value: &Value) -> Bytes {
+    Bytes::from(format!("data: {value}\n\n"))
+}
+
+/// Turn a stream failure into the console's verdict about it.
+///
+/// Why: `UdsRpcError::Stream` is the daemon's own terminal error frame and
+/// carries its code, so it maps to the HTTP status that refusal had. Every other
+/// variant is a transport problem the console observed, which is a `502`.
+/// Test: `stream_error_carries_the_daemon_code`.
+fn stream_error(method: &str, e: UdsRpcError) -> SearchRpcError {
+    match e {
+        UdsRpcError::Stream { error, .. } => SearchRpcError::Refused {
+            code: error.code,
+            message: error.message,
+        },
+        other => SearchRpcError::Unreachable(format!(
+            "{} did not stream {method}: {other}",
+            super::SEARCH_SERVICE
+        )),
+    }
+}
+
+/// Resolve trusty-search's socket for the routes and the connector alike.
+///
+/// Why on `AppState` rather than a free call: the integration tests bind their
+/// own stub socket and need the router to dial it, and the alternative —
+/// `TRUSTY_DATA_DIR_OVERRIDE` — is process-global in a test binary that runs
+/// six connectors in parallel. The same argument `detect::AnalyzeConnector`
+/// records for taking a socket override.
+/// Test: `tests/search_uds_bridge.rs` drives every case through it.
+impl AppState {
+    /// The socket this console dials for trusty-search.
+    ///
+    /// # Errors
+    ///
+    /// When the data directory cannot be resolved or created.
+    pub(crate) fn search_socket_path(&self) -> Result<PathBuf, String> {
+        match &self.search_socket {
+            Some(p) => Ok(p.as_ref().clone()),
+            None => super::socket_path(),
+        }
+    }
+
+    /// Dial `socket` for trusty-search instead of the resolved path.
+    ///
+    /// Why: see the `AppState::search_socket` field doc — the alternative is a
+    /// process-global env var this crate's test binary cannot use safely.
+    /// Test: `tests/search_uds_bridge.rs` sets it on every case.
+    #[must_use]
+    pub fn with_search_socket(mut self, socket: PathBuf) -> Self {
+        self.search_socket = Some(std::sync::Arc::new(socket));
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use trusty_common::uds::server::RpcError;
+
+    /// Why: an event carrying a newline inside a string would split into two SSE
+    /// events and the SPA would parse neither.
+    /// Test: this is the test.
+    #[test]
+    fn sse_data_is_one_line_per_event() {
+        let framed = sse_data(&json!({ "message": "a\nb" }));
+        let text = String::from_utf8(framed.to_vec()).expect("utf-8");
+        assert_eq!(text, "data: {\"message\":\"a\\nb\"}\n\n");
+        assert_eq!(text.matches("\n\n").count(), 1);
+    }
+
+    /// Why: the daemon's terminal error frame is a refusal with a code, and it
+    /// must reach the browser as the status that code stands for — not as a
+    /// generic gateway failure that hides which index was missing.
+    /// Test: this is the test.
+    #[test]
+    fn stream_error_carries_the_daemon_code() {
+        let err = stream_error(
+            "search.index.reindex.stream",
+            UdsRpcError::Stream {
+                path: PathBuf::from("/tmp/x.sock"),
+                error: RpcError::new(-32004, "no reindex in progress for 'ghost'"),
+            },
+        );
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+        assert!(err.message().contains("ghost"), "{err:?}");
+    }
+
+    /// Why: everything that is not the daemon's own refusal is the console
+    /// failing to reach it, and must not be dressed up as a daemon verdict.
+    /// Test: this is the test.
+    #[test]
+    fn stream_error_reports_a_transport_failure_as_unreachable() {
+        let err = stream_error(
+            "search.status.stream",
+            UdsRpcError::NoResponse {
+                path: PathBuf::from("/tmp/x.sock"),
+            },
+        );
+        assert_eq!(err.status(), StatusCode::BAD_GATEWAY);
+    }
+}

--- a/crates/trusty-console/src/search_uds/routes.rs
+++ b/crates/trusty-console/src/search_uds/routes.rs
@@ -175,27 +175,34 @@ pub async fn deprecated_search_api_handler(
 /// with the peeked item.
 ///
 /// `open_timeout` bounds everything up to that peek — the dial, the request
-/// write, and the first frame read. A listener whose backlog is full accepts the
-/// connection and then reads nothing, and without this bound the browser waits
-/// out [`super::STREAM_FRAME_TIMEOUT`]'s day for a response head. Abandoning the
-/// read is safe: the whole `FramedStream` is dropped on the timeout path, so no
+/// write, and the first frame read, which share ONE deadline computed here. A
+/// listener whose backlog is full accepts the connection and then reads nothing,
+/// and without this bound the browser waits out
+/// [`super::STREAM_FRAME_TIMEOUT`]'s day for a response head. Abandoning the read
+/// is safe: the whole `FramedStream` is dropped on the timeout path, so no
 /// half-read line is left for anyone to resume. The parameter exists so a test
 /// need not wait the production minute.
 /// Test: `tests/search_uds_bridge.rs`'s
-/// `a_stream_refusal_before_the_first_item_is_an_http_status`, and
-/// `a_socket_that_never_answers_is_a_prompt_bad_gateway` below.
+/// `a_stream_refusal_before_the_first_item_is_an_http_status`, plus
+/// `a_socket_that_never_answers_is_a_prompt_bad_gateway` and
+/// `a_slow_open_and_a_silent_first_frame_share_one_budget` below.
 async fn stream_response(
     socket: &Path,
     method: &'static str,
     params: Value,
     open_timeout: std::time::Duration,
 ) -> Response {
+    // #6285: one deadline, taken before the dial and reused for the first-frame
+    // read. Giving each step its own `open_timeout` let the two together run to
+    // twice the figure the constant names.
+    let deadline = tokio::time::Instant::now() + open_timeout;
+
     let mut stream = match open_stream(socket, method, params, open_timeout).await {
         Ok(s) => s,
         Err(e) => return e.into_response(),
     };
 
-    let peeked = match tokio::time::timeout(open_timeout, stream.next_frame()).await {
+    let peeked = match tokio::time::timeout_at(deadline, stream.next_frame()).await {
         Ok(frame) => frame,
         Err(_) => {
             return SearchRpcError::Unreachable(format!(
@@ -251,8 +258,9 @@ async fn stream_response(
 /// dropping the `FramedStream` and closing the socket, which is what ends the
 /// producer (`streams`'s "a dropped client stops the producer").
 ///
-/// Test: `tests/search_uds_bridge.rs`'s `a_stream_reaches_the_browser_frame_for_frame`
-/// and `a_mid_stream_failure_becomes_an_error_event`.
+/// Test: `tests/search_uds_bridge.rs`'s `a_stream_reaches_the_browser_frame_for_frame`,
+/// `a_mid_stream_failure_becomes_an_error_event`, and
+/// `a_browser_disconnect_releases_the_daemon_socket` for the disconnect arm.
 fn sse_tail(
     mut stream: FramedStream<Value>,
     method: &'static str,
@@ -436,6 +444,93 @@ mod tests {
             started.elapsed() < std::time::Duration::from_secs(5),
             "the open must be bounded, not left to the per-frame budget: {:?}",
             started.elapsed()
+        );
+    }
+
+    /// Bind a listener that accepts, stalls `drain_after`, then drains the
+    /// request and answers nothing at all.
+    ///
+    /// The stall is what makes the OPEN slow rather than instant: the request
+    /// frame is larger than any plausible UNIX-socket send buffer, so the
+    /// client's `write_all` cannot finish until this end starts reading.
+    fn stalls_then_drains(socket: PathBuf, drain_after: std::time::Duration) -> PathBuf {
+        let listener = trusty_common::uds::bind_hardened(&socket).expect("bind");
+        tokio::spawn(async move {
+            let Ok((mut conn, _)) = listener.accept().await else {
+                return;
+            };
+            tokio::time::sleep(drain_after).await;
+            let mut sink = Vec::new();
+            let _ = tokio::io::AsyncReadExt::read_to_end(&mut conn, &mut sink).await;
+            std::future::pending::<()>().await;
+        });
+        socket
+    }
+
+    /// A request frame past any plausible socket send buffer.
+    fn bulky_params() -> Value {
+        json!({ "blob": "x".repeat(512 * 1024) })
+    }
+
+    /// Why: the open has two waiting steps — the dial-and-write inside
+    /// [`open_stream`] and the first frame read here — and giving each its own
+    /// full `open_timeout` made the real ceiling twice the figure
+    /// [`STREAM_OPEN_TIMEOUT`], its doc comment and the changelog all name. A
+    /// browser waiting two minutes for a bound documented as one is the defect.
+    /// What: two phases against the same stub shape, because the ceiling alone
+    /// would pass vacuously if the open happened to be fast. Phase one proves
+    /// the open both SUCCEEDS and takes about `DRAIN_AFTER`. Phase two runs the
+    /// same shape through `stream_response`, whose first-frame read then waits
+    /// for a frame that never comes: one shared deadline returns at about
+    /// `BUDGET`, two separate ones would run to `DRAIN_AFTER + BUDGET`.
+    /// Test: this is the test.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_slow_open_and_a_silent_first_frame_share_one_budget() {
+        const BUDGET: std::time::Duration = std::time::Duration::from_millis(1000);
+        const DRAIN_AFTER: std::time::Duration = std::time::Duration::from_millis(600);
+        // Above `BUDGET`, so one shared deadline clears it; below
+        // `DRAIN_AFTER + BUDGET`, so two separate deadlines cannot.
+        const CEILING: std::time::Duration = std::time::Duration::from_millis(1300);
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+
+        let slow = stalls_then_drains(tmp.path().join("slow-open.sock"), DRAIN_AFTER);
+        let started = std::time::Instant::now();
+        let opened = open_stream(
+            &slow,
+            super::super::METHOD_STATUS_STREAM,
+            bulky_params(),
+            BUDGET,
+        )
+        .await;
+        let open_took = started.elapsed();
+        assert!(opened.is_ok(), "the open must succeed, slowly: {opened:?}");
+        assert!(
+            open_took >= DRAIN_AFTER,
+            "the write must park until the peer drains, or this test proves nothing: {open_took:?}"
+        );
+        drop(opened);
+
+        let silent = stalls_then_drains(tmp.path().join("silent-frame.sock"), DRAIN_AFTER);
+        let started = std::time::Instant::now();
+        let response = stream_response(
+            &silent,
+            super::super::METHOD_STATUS_STREAM,
+            bulky_params(),
+            BUDGET,
+        )
+        .await;
+        let elapsed = started.elapsed();
+
+        assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+        assert!(
+            elapsed >= BUDGET,
+            "a shared deadline still spends the whole budget: {elapsed:?}"
+        );
+        assert!(
+            elapsed < CEILING,
+            "the dial, the write and the first frame read must share ONE {BUDGET:?} deadline, \
+             not take one each: {elapsed:?}"
         );
     }
 

--- a/crates/trusty-console/src/search_uds/routes.rs
+++ b/crates/trusty-console/src/search_uds/routes.rs
@@ -54,15 +54,11 @@ use trusty_common::uds::UdsRpcError;
 use trusty_common::uds::stream_client::FramedStream;
 
 use super::map::{Call, map_request};
-use super::{CALL_TIMEOUT, SearchRpcError, call, json_response, open_stream};
+use super::{
+    CALL_TIMEOUT, MAX_FRAME_BYTES, STREAM_OPEN_TIMEOUT, SearchRpcError, call, json_response,
+    open_stream,
+};
 use crate::server::AppState;
-
-/// How large a request body this bridge will carry.
-///
-/// Matches `trusty_search::service::socket::MAX_FRAME_BYTES`, which is itself
-/// the `DefaultBodyLimit` the daemon's largest HTTP route carried. A body over
-/// this is refused here rather than after a 64 MiB copy has been made.
-const BODY_LIMIT: usize = 64 * 1024 * 1024;
 
 /// How often an open stream emits an SSE keep-alive comment.
 ///
@@ -100,13 +96,16 @@ pub async fn search_api_handler(
     let (parts, body) = req.into_parts();
     let query = parts.uri.query().map(str::to_owned);
 
-    let body_bytes: Bytes = match axum::body::to_bytes(body, BODY_LIMIT).await {
+    // #6285: the body becomes one request FRAME, so the frame budget is the body
+    // limit — one constant, not a second literal that can drift from it.
+    let body_limit = usize::try_from(MAX_FRAME_BYTES).unwrap_or(usize::MAX);
+    let body_bytes: Bytes = match axum::body::to_bytes(body, body_limit).await {
         Ok(b) => b,
         Err(e) => {
             warn!("search_uds: could not read the request body: {e}");
             return (
                 StatusCode::PAYLOAD_TOO_LARGE,
-                "request body exceeds the 64 MiB frame budget",
+                format!("request body exceeds the {MAX_FRAME_BYTES}-byte frame budget"),
             )
                 .into_response();
         }
@@ -142,7 +141,7 @@ pub async fn search_api_handler(
         }
         Call::Stream { method, params } => {
             debug!("search_uds: {} /{path} → {method} (stream)", parts.method);
-            stream_response(&socket, method, params).await
+            stream_response(&socket, method, params, STREAM_OPEN_TIMEOUT).await
         }
     }
 }
@@ -174,15 +173,41 @@ pub async fn deprecated_search_api_handler(
 /// reads as a finished reindex.
 /// What: peek, then either the refusal's own status or a `200` whose body starts
 /// with the peeked item.
+///
+/// `open_timeout` bounds everything up to that peek — the dial, the request
+/// write, and the first frame read. A listener whose backlog is full accepts the
+/// connection and then reads nothing, and without this bound the browser waits
+/// out [`super::STREAM_FRAME_TIMEOUT`]'s day for a response head. Abandoning the
+/// read is safe: the whole `FramedStream` is dropped on the timeout path, so no
+/// half-read line is left for anyone to resume. The parameter exists so a test
+/// need not wait the production minute.
 /// Test: `tests/search_uds_bridge.rs`'s
-/// `a_stream_refusal_before_the_first_item_is_an_http_status`.
-async fn stream_response(socket: &Path, method: &'static str, params: Value) -> Response {
-    let mut stream = match open_stream(socket, method, params).await {
+/// `a_stream_refusal_before_the_first_item_is_an_http_status`, and
+/// `a_socket_that_never_answers_is_a_prompt_bad_gateway` below.
+async fn stream_response(
+    socket: &Path,
+    method: &'static str,
+    params: Value,
+    open_timeout: std::time::Duration,
+) -> Response {
+    let mut stream = match open_stream(socket, method, params, open_timeout).await {
         Ok(s) => s,
         Err(e) => return e.into_response(),
     };
 
-    let first = match stream.next_frame().await {
+    let peeked = match tokio::time::timeout(open_timeout, stream.next_frame()).await {
+        Ok(frame) => frame,
+        Err(_) => {
+            return SearchRpcError::Unreachable(format!(
+                "{} did not answer {method} within {}s",
+                super::SEARCH_SERVICE,
+                open_timeout.as_secs_f32()
+            ))
+            .into_response();
+        }
+    };
+
+    let first = match peeked {
         Some(Ok(item)) => Some(item),
         Some(Err(e)) => return stream_error(method, e).into_response(),
         // A stream that ended with no items at all is still a well-formed empty
@@ -217,10 +242,14 @@ async fn stream_response(socket: &Path, method: &'static str, params: Value) -> 
 /// cancel-safe, since `Receiver::recv` and `Interval::tick` both are.
 ///
 /// The task also carries the disconnect signal: when the browser goes, axum
-/// drops this body, the receiver drops, the next `send` fails, and the task
-/// returns — dropping the `FramedStream` and closing the socket, which is what
-/// ends the daemon's producer (`streams`'s "a dropped client stops the
-/// producer").
+/// drops this body and the receiver drops. The read itself selects on
+/// `Sender::closed()` so the task notices immediately rather than at the next
+/// frame — a status stream can be silent for minutes, and waiting for a frame
+/// that will never come would hold the socket, and the daemon's producer behind
+/// it, open for exactly that long. The same shape the daemon's own producer uses
+/// (`trusty_search::service::rpc::streams`). Either way the task returns,
+/// dropping the `FramedStream` and closing the socket, which is what ends the
+/// producer (`streams`'s "a dropped client stops the producer").
 ///
 /// Test: `tests/search_uds_bridge.rs`'s `a_stream_reaches_the_browser_frame_for_frame`
 /// and `a_mid_stream_failure_becomes_an_error_event`.
@@ -230,7 +259,16 @@ fn sse_tail(
 ) -> impl futures_util::Stream<Item = Result<Bytes, std::convert::Infallible>> {
     let (tx, rx) = mpsc::channel::<Result<Value, UdsRpcError>>(SSE_BUFFER);
     tokio::spawn(async move {
-        while let Some(item) = stream.next_frame().await {
+        loop {
+            // Cancelling `next_frame` mid-line discards the bytes already read,
+            // which only matters to a reader that resumes. This arm never
+            // resumes: it returns, and the `FramedStream` is dropped with it.
+            let item = tokio::select! {
+                biased;
+                () = tx.closed() => return,
+                item = stream.next_frame() => item,
+            };
+            let Some(item) = item else { return };
             let terminal = item.is_err();
             if tx.send(item).await.is_err() || terminal {
                 return;
@@ -358,6 +396,47 @@ mod tests {
         );
         assert_eq!(err.status(), StatusCode::NOT_FOUND);
         assert!(err.message().contains("ghost"), "{err:?}");
+    }
+
+    /// Why: a listener that accepts and then never answers is the case the
+    /// per-frame budget cannot cover — that budget is a day, deliberately, so a
+    /// stalled reindex is not cut off. Without a separate bound on the OPEN, the
+    /// browser waits a day for a response head it will never get.
+    /// What: binds a socket that accepts, reads the request, and writes nothing,
+    /// then asks for a stream with a 300 ms open budget. The production budget
+    /// is [`STREAM_OPEN_TIMEOUT`]; the parameter is what lets this assert in
+    /// milliseconds.
+    /// Test: this is the test.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_socket_that_never_answers_is_a_prompt_bad_gateway() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let socket = tmp.path().join("silent.sock");
+        let listener = trusty_common::uds::bind_hardened(&socket).expect("bind");
+        let _accepting = tokio::spawn(async move {
+            let Ok((mut conn, _)) = listener.accept().await else {
+                return;
+            };
+            let mut sink = Vec::new();
+            // Read the request and answer nothing — the wedged-listener case.
+            let _ = tokio::io::AsyncReadExt::read_to_end(&mut conn, &mut sink).await;
+            std::future::pending::<()>().await;
+        });
+
+        let started = std::time::Instant::now();
+        let response = stream_response(
+            &socket,
+            super::super::METHOD_STATUS_STREAM,
+            json!({}),
+            std::time::Duration::from_millis(300),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(5),
+            "the open must be bounded, not left to the per-frame budget: {:?}",
+            started.elapsed()
+        );
     }
 
     /// Why: everything that is not the daemon's own refusal is the console

--- a/crates/trusty-console/src/server/mod.rs
+++ b/crates/trusty-console/src/server/mod.rs
@@ -15,16 +15,19 @@
 //!   - `DELETE /api/console/memory/palaces/{id}` — delete one palace via
 //!     trusty-memory's `palace_delete` on its socket (#6360).
 //!   - `DELETE /api/console/search/indexes/{id}` — delete one index via
-//!     trusty-search's own `DELETE /indexes/{id}` (#6360).
+//!     trusty-search's own `search.index.delete` on its socket (#6360, #6285).
 //!   - `GET /api/console/metrics/analyze/indexes` — analyze index list via stdio MCP.
 //!   - `GET /api/console/metrics/analyze/visualize?index=<id>` — graph+entities+clusters.
 //!   - `…/api/console/sessions/*` — the single HTTP front door for the trusty-mpm
 //!     session manager (#1222); handlers live in `crate::routes::sessions`.
+//!   - `ANY /api/search/{*path}` — translate the request into a trusty-search
+//!     RPC call on its socket (#6285); see `crate::search_uds`.
 //!   - `ANY /api/{service}/{*path}` — reverse-proxy to live daemon via clean path
-//!     (#1849 Phase 2); `{service}` ∈ {search, memory, analyze, review, mpm}.
+//!     (#1849 Phase 2); `{service}` ∈ {review, mpm, agents}.
 //!   - `ANY /proxy/{daemon}/{*path}` — DEPRECATED alias; routes to the same
 //!     handler with a trace-level deprecation note.
-//!   - `GET /` and `GET /ui/*path` — serve the embedded Svelte SPA.
+//!   - `GET /` and `GET /ui/*path` — serve the embedded Svelte SPA; the
+//!     handlers live in `crate::console_ui` (#6285, 500-SLOC split).
 //!   - `GET /tools/search/*path` — serve the embedded trusty-search SPA
 //!     (#6155); see `crate::tools_ui`.
 //!
@@ -33,18 +36,17 @@
 //! Test: The `tests` module starts the router in a real axum test client.
 
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
 use axum::{
     Router,
-    body::Body,
-    extract::{Path, Query, State},
-    http::{Response, StatusCode, header},
+    extract::{Query, State},
+    http::StatusCode,
     response::IntoResponse,
     routing::{any, get, post},
 };
-use rust_embed::RustEmbed;
 use serde::Deserialize;
 use serde_json::json;
 use tower_http::cors::CorsLayer;
@@ -54,19 +56,6 @@ use crate::connector::{ServiceConnector, ServiceInfo, ServiceStatus};
 use crate::mcp_handle::{McpHandleError, McpServiceHandle};
 use crate::metrics_poller::MetricsCache;
 use crate::poller::PollerCache;
-
-// ─── embedded UI ─────────────────────────────────────────────────────────────
-
-/// Embedded Svelte SPA assets compiled by `build.rs`.
-///
-/// Why: Shipping the UI inside the binary eliminates external file dependencies
-/// and matches the pattern used by trusty-search, trusty-memory, and
-/// trusty-analyze.
-/// What: rust-embed embeds every file under `ui/dist/` at compile time.
-/// Test: The server tests assert that `GET /` returns 200.
-#[derive(RustEmbed)]
-#[folder = "ui/dist/"]
-struct UiAssets;
 
 // ─── app state ───────────────────────────────────────────────────────────────
 
@@ -132,6 +121,17 @@ pub struct AppState {
     /// for every future service.
     /// What: Populated by `AppState::new`; read by `apply_handle_overrides`.
     mcp_handles: Arc<HashMap<String, Arc<McpServiceHandle>>>,
+    /// Override for the trusty-search socket path (#6285).
+    ///
+    /// Why: `search_uds` and `detect::SearchConnector` resolve that path through
+    /// `trusty_common::daemon_socket_path`, which reads the process-global
+    /// `TRUSTY_DATA_DIR_OVERRIDE`. A test that redirected it would redirect five
+    /// sibling connectors running in the same binary at the same time, so the
+    /// override is carried here instead — the same argument
+    /// `detect::AnalyzeConnector::with_socket` records.
+    /// What: `None` in production, which resolves the real path.
+    /// Test: `tests/search_uds_bridge.rs` sets it on every case.
+    pub(crate) search_socket: Option<Arc<PathBuf>>,
 }
 
 impl AppState {
@@ -228,6 +228,7 @@ impl AppState {
             stream_client: Arc::new(stream_client),
             analyze_handle,
             mcp_handles: Arc::new(handles),
+            search_socket: None,
         }
     }
 
@@ -495,8 +496,22 @@ fn build_router_inner(
             "/api/console/metrics/analyze/visualize",
             get(analyze_visualize_handler),
         )
+        // #6285: `search` is NOT a reverse-proxy row any more. trusty-search
+        // moved onto a Unix socket (ADR-0032) and stopped writing the
+        // `http_addr` file the proxy resolves a base URL from, so this literal
+        // route takes the prefix and translates each request into an RPC call.
+        // matchit prefers the static `search` segment over the `{service}`
+        // capture below, so the two cannot collide.
+        .route(
+            "/api/search/{*path}",
+            any(crate::search_uds::routes::search_api_handler),
+        )
+        .route(
+            "/proxy/search/{*path}",
+            any(crate::search_uds::routes::deprecated_search_api_handler),
+        )
         // Primary reverse-proxy: /api/{service}/{*path} (#1849 Phase 2).
-        // {service} ∈ {search, memory, analyze, review, mpm}.
+        // {service} ∈ {review, mpm, agents}.
         // No collision with /api/console/*: axum (matchit 0.8) routes literal
         // segments before wildcard captures, so /api/console/* always wins.
         // The proxy handler also rejects service_key == "console" explicitly as // pragma: allowlist secret
@@ -518,10 +533,10 @@ fn build_router_inner(
             "/tools/search/{*path}",
             get(crate::tools_ui::search_ui_asset),
         )
-        .route("/", get(spa_index_handler))
-        .route("/ui", get(spa_index_handler))
-        .route("/ui/", get(spa_index_handler))
-        .route("/ui/{*path}", get(spa_asset_handler))
+        .route("/", get(crate::console_ui::spa_index_handler))
+        .route("/ui", get(crate::console_ui::spa_index_handler))
+        .route("/ui/", get(crate::console_ui::spa_index_handler))
+        .route("/ui/{*path}", get(crate::console_ui::spa_asset_handler))
         .with_state(state);
 
     // Webhook ingress (#5089 step 3, ADR-0034). Merged as its own state-typed
@@ -941,72 +956,6 @@ async fn analyze_visualize_handler(
         "clusters": clusters_res.unwrap_or(serde_json::Value::Null),
     });
     axum::Json(combined).into_response()
-}
-
-/// `GET /` — serve the SPA index.html.
-///
-/// Why: The root path must return the SPA shell so the browser bootstraps.
-/// What: Reads `index.html` from the embedded asset set.
-/// Test: `test_spa_root_returns_html` below.
-async fn spa_index_handler() -> impl IntoResponse {
-    serve_asset("index.html")
-}
-
-/// `GET /ui/*path` — serve SPA static assets.
-///
-/// Why: Vite emits JS/CSS/assets under hashed filenames; all are embedded and
-/// served from the `/ui/*` prefix.
-/// What: Strips the leading `/ui/` from `path` and serves the matching asset.
-/// Test: Indirectly covered by `test_spa_root_returns_html`.
-async fn spa_asset_handler(Path(path): Path<String>) -> impl IntoResponse {
-    let path = path.trim_start_matches('/');
-    serve_asset(path)
-}
-
-/// Serve one asset from the embedded `UiAssets`.
-///
-/// Why: Centralises asset serving so both the index and asset routes share the
-/// same content-type detection and 404 handling.
-/// What: Looks up the path in `UiAssets`, infers the MIME type via
-/// `mime_guess`, returns the bytes with the appropriate `Content-Type` header.
-/// On a 404 serves `index.html` (SPA client-side routing).
-/// Test: `test_spa_root_returns_html`.
-fn serve_asset(path: &str) -> Response<Body> {
-    match UiAssets::get(path) {
-        Some(content) => {
-            let mime = mime_guess::from_path(path).first_or_octet_stream();
-            Response::builder()
-                .status(StatusCode::OK)
-                .header(header::CONTENT_TYPE, mime.as_ref())
-                .body(Body::from(content.data.to_vec()))
-                .unwrap_or_else(|_| {
-                    Response::builder()
-                        .status(StatusCode::INTERNAL_SERVER_ERROR)
-                        .body(Body::empty())
-                        .expect("static response")
-                })
-        }
-        None => {
-            // SPA fallback: serve index.html for unknown paths so client-side
-            // routing works when the user navigates directly to a subpath.
-            match UiAssets::get("index.html") {
-                Some(content) => Response::builder()
-                    .status(StatusCode::OK)
-                    .header(header::CONTENT_TYPE, "text/html")
-                    .body(Body::from(content.data.to_vec()))
-                    .unwrap_or_else(|_| {
-                        Response::builder()
-                            .status(StatusCode::INTERNAL_SERVER_ERROR)
-                            .body(Body::empty())
-                            .expect("static response")
-                    }),
-                None => Response::builder()
-                    .status(StatusCode::NOT_FOUND)
-                    .body(Body::from("not found"))
-                    .expect("static 404"),
-            }
-        }
-    }
 }
 
 // ─── tests ───────────────────────────────────────────────────────────────────

--- a/crates/trusty-console/src/server/tests.rs
+++ b/crates/trusty-console/src/server/tests.rs
@@ -11,6 +11,8 @@
 //! Test: this module IS the test suite for `server/mod.rs`.
 
 use super::*;
+// #6285: `body::Body` left `server/mod.rs` with the SPA handlers.
+use axum::body::Body;
 use axum::http::header::CONTENT_TYPE;
 use axum::http::{Request, StatusCode};
 use http_body_util::BodyExt;
@@ -313,15 +315,17 @@ async fn test_api_proxy_unknown_service_returns_400() {
 
 /// Why: the `/api/{service}/*` route for a known service that is not running
 /// must return 503 (cache cold) — proves the route reaches the proxy handler.
-/// What: issues GET /api/search/health on a fresh state (no poll),
-/// asserts 503 SERVICE_UNAVAILABLE.
+/// What: issues GET /api/review/health on a fresh state (no poll), asserts 503
+/// SERVICE_UNAVAILABLE. `review` rather than `search` since #6285: search left
+/// the proxy allowlist for its own socket-backed route, so it can no longer
+/// exercise the cold-cache arm.
 /// Test: this test itself (#1849 Phase 2 primary path).
 #[tokio::test]
 async fn test_api_proxy_known_service_cold_cache_returns_503() {
     let router = build_router(make_test_state());
 
     let req = Request::builder()
-        .uri("/api/search/health")
+        .uri("/api/review/health")
         .body(Body::empty())
         .expect("request");
     let resp = router.oneshot(req).await.expect("response");
@@ -351,22 +355,25 @@ async fn test_api_proxy_mpm_is_in_allowlist_cold_cache_returns_503() {
 
 /// Why: the deprecated `/proxy/{daemon}/*` alias must still route to the
 /// proxy handler; removing it would break external callers mid-migration.
-/// What: issues GET /proxy/search/health on the deprecated path, asserts 503
-/// (cache cold, not 404 route-miss or 400 key-rejected).
+/// What: issues GET /proxy/review/health on the deprecated path, asserts 503
+/// (cache cold, not 404 route-miss or 400 key-rejected). `review` rather than
+/// `search` since #6285 — `/proxy/search/*` now has its own literal route to
+/// the socket bridge, covered by `deprecated_alias_reaches_the_same_handler` in
+/// `tests/search_uds_bridge.rs`.
 /// Test: this test itself (backward-compat guard for #1849 Phase 2).
 #[tokio::test]
 async fn test_deprecated_proxy_alias_still_routes() {
     let router = build_router(make_test_state());
 
     let req = Request::builder()
-        .uri("/proxy/search/health")
+        .uri("/proxy/review/health")
         .body(Body::empty())
         .expect("request");
     let resp = router.oneshot(req).await.expect("response");
     assert_eq!(
         resp.status(),
         StatusCode::SERVICE_UNAVAILABLE,
-        "/proxy/search/health must return 503 via deprecated alias, not 404"
+        "/proxy/review/health must return 503 via deprecated alias, not 404"
     );
 }
 

--- a/crates/trusty-console/tests/search_uds_bridge.rs
+++ b/crates/trusty-console/tests/search_uds_bridge.rs
@@ -393,6 +393,89 @@ async fn a_truncated_stream_becomes_an_error_event() {
     );
 }
 
+/// Why: a status stream can be silent for minutes, and the reader used to
+/// notice a departed browser only when the next frame arrived. Until then it
+/// held the socket open, and the daemon's producer behind it — so closing a
+/// quiet dashboard tab leaked a producer for as long as the stream stayed quiet.
+/// The reader now selects on the sender's closure, so the socket goes with the
+/// body.
+/// What: opens the real stream route against a stub that answers ONE item and
+/// then stays silent, reads that item to prove the stream is live, drops the
+/// response body, and waits for the stub to observe the socket closing.
+///
+/// The stub detects the close by writing, not reading: the RPC client
+/// half-closes its write side once the request frame is out, so this end is
+/// already at EOF and a read proves nothing. Each probe is a single space rather
+/// than a frame — a reader still sitting there parks on the unterminated line
+/// instead of being woken by it, which is what makes a bridge without the
+/// disconnect arm hang here rather than pass.
+/// Test: this is the test.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_browser_disconnect_releases_the_daemon_socket() {
+    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let socket = tmp.path().join("sockets").join("quiet-stream.sock");
+    let listener = trusty_common::uds::bind_hardened(&socket).expect("bind");
+    let (closed_tx, closed_rx) = tokio::sync::oneshot::channel::<()>();
+
+    let _serving = tokio::spawn(async move {
+        let Ok((mut conn, _)) = listener.accept().await else {
+            return;
+        };
+        let mut raw = Vec::new();
+        let _ = conn.read_to_end(&mut raw).await;
+
+        let opener = format!("{}\n", item_frame(json!({ "type": "connected" })));
+        if conn.write_all(opener.as_bytes()).await.is_err() {
+            return;
+        }
+        let _ = conn.flush().await;
+
+        loop {
+            if conn.write_all(b" ").await.is_err() {
+                let _ = closed_tx.send(());
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+    });
+
+    let router = build_router(AppState::new(vec![]).with_search_socket(socket));
+    let request = Request::builder()
+        .method("GET")
+        .uri("/api/search/status/stream")
+        .body(Body::empty())
+        .expect("request");
+    let response = router.oneshot(request).await.expect("response");
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let mut body = response.into_body();
+    let first = body
+        .frame()
+        .await
+        .expect("the stream carries its opener")
+        .expect("a first chunk");
+    let data = first.into_data().expect("a data frame");
+    assert!(
+        String::from_utf8_lossy(&data).contains("connected"),
+        "the opener proves the stream is live before the disconnect"
+    );
+
+    let dropped_at = std::time::Instant::now();
+    drop(body);
+
+    tokio::time::timeout(std::time::Duration::from_secs(2), closed_rx)
+        .await
+        .expect("the daemon side must see the socket close, not wait for a frame that never comes")
+        .expect("the stub reports the close");
+    assert!(
+        dropped_at.elapsed() < std::time::Duration::from_secs(2),
+        "the socket must be released on disconnect: {:?}",
+        dropped_at.elapsed()
+    );
+}
+
 /// Why: nothing bound to the socket must fail the stream open with a status,
 /// not with an empty `200` event stream.
 /// Test: this is the test.

--- a/crates/trusty-console/tests/search_uds_bridge.rs
+++ b/crates/trusty-console/tests/search_uds_bridge.rs
@@ -1,0 +1,411 @@
+//! `/api/search/*` reaches trusty-search over its Unix socket (#6285).
+//!
+//! Why: #6384 moved the trusty-search dashboard into this binary, and its every
+//! API call resolves to `/api/search/…`. #6285 takes trusty-search's HTTP
+//! surface away, so that prefix has to reach the daemon over a socket instead —
+//! and the SPA must not be able to tell. These cases drive the REAL router
+//! against a stub daemon socket, which is the only way to prove the whole path:
+//! route, mapping table, RPC exchange, and the SSE bridge.
+//!
+//! What: one stub socket per case, a `build_router` pointed at it through
+//! `AppState::with_search_socket`, and one assertion per behaviour the dashboard
+//! depends on.
+//! Test: this file IS the test.
+
+use std::path::{Path, PathBuf};
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::{Value, json};
+use tower::ServiceExt;
+use trusty_console::server::{AppState, build_router};
+
+// ─── the stub daemon ─────────────────────────────────────────────────────────
+
+/// Bind a socket that answers each framed request with `respond`'s frames.
+///
+/// `respond` returns the LINES to write back, so one case can answer a single
+/// response frame and another a whole stream — the two shapes the bridge has to
+/// tell apart.
+fn stub_daemon<F>(dir: &Path, respond: F) -> PathBuf
+where
+    F: Fn(&Value) -> Vec<String> + Send + Sync + 'static,
+{
+    let socket = dir.join("sockets").join("search.sock");
+    let listener = trusty_common::uds::bind_hardened(&socket).expect("bind");
+    let respond = std::sync::Arc::new(respond);
+    tokio::spawn(async move {
+        loop {
+            let Ok((mut conn, _)) = listener.accept().await else {
+                return;
+            };
+            let respond = std::sync::Arc::clone(&respond);
+            tokio::spawn(async move {
+                use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+                let mut raw = Vec::new();
+                let _ = conn.read_to_end(&mut raw).await;
+                let request: Value = serde_json::from_slice(&raw).unwrap_or(Value::Null);
+                for line in respond(&request) {
+                    if conn.write_all(line.as_bytes()).await.is_err() {
+                        return;
+                    }
+                    let _ = conn.write_all(b"\n").await;
+                    let _ = conn.flush().await;
+                }
+            });
+        }
+    });
+    socket
+}
+
+/// One ordinary response frame carrying `result`.
+fn result_frame(result: Value) -> String {
+    json!({ "jsonrpc": "2.0", "id": 1, "result": result }).to_string()
+}
+
+/// One ordinary response frame carrying a JSON-RPC `error`.
+fn error_frame(code: i64, message: &str) -> String {
+    json!({ "jsonrpc": "2.0", "id": 1, "error": { "code": code, "message": message } }).to_string()
+}
+
+/// One `"stream":"item"` frame.
+fn item_frame(result: Value) -> String {
+    json!({ "jsonrpc": "2.0", "id": 1, "stream": "item", "result": result }).to_string()
+}
+
+/// The terminal `"stream":"end"` frame.
+fn end_frame() -> String {
+    json!({ "jsonrpc": "2.0", "id": 1, "stream": "end" }).to_string()
+}
+
+/// The terminal `"stream":"error"` frame.
+fn stream_error_frame(code: i64, message: &str) -> String {
+    json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "stream": "error",
+        "error": { "code": code, "message": message },
+    })
+    .to_string()
+}
+
+// ─── driving the router ──────────────────────────────────────────────────────
+
+/// Send one request through the real router with search pointed at `socket`.
+async fn through_router(
+    socket: PathBuf,
+    method: &str,
+    uri: &str,
+    body: &str,
+) -> (StatusCode, String, String) {
+    let router = build_router(AppState::new(vec![]).with_search_socket(socket));
+    let request = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(Body::from(body.to_string()))
+        .expect("request");
+    let resp = router.oneshot(request).await.expect("response");
+    let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get(axum::http::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default()
+        .to_string();
+    let bytes = resp.into_body().collect().await.expect("body").to_bytes();
+    (
+        status,
+        content_type,
+        String::from_utf8_lossy(&bytes).into_owned(),
+    )
+}
+
+// ─── unary ───────────────────────────────────────────────────────────────────
+
+/// Why: this is the whole dashboard. `GET /api/search/health` used to be
+/// forwarded verbatim to the daemon's HTTP `/health`; it now has to become one
+/// `search.health` call whose result reaches the browser unchanged, or the SPA
+/// renders an offline badge against a running daemon.
+/// Test: this is the test.
+#[tokio::test(flavor = "multi_thread")]
+async fn unary_route_returns_the_daemon_body_verbatim() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let socket = stub_daemon(tmp.path(), |request| {
+        vec![result_frame(json!({
+            "status": "ok",
+            "version": "0.49.6",
+            "method_seen": request["method"].clone(),
+        }))]
+    });
+
+    let (status, content_type, body) =
+        through_router(socket, "GET", "/api/search/health", "").await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert!(content_type.contains("application/json"), "{content_type}");
+    let parsed: Value = serde_json::from_str(&body).expect("json");
+    assert_eq!(parsed["version"], json!("0.49.6"));
+    assert_eq!(parsed["method_seen"], json!("search.health"));
+}
+
+/// Why: the index roster carries `?details=true`, and a query string is text
+/// while the RPC params are typed. A `"true"` string there answers
+/// `invalid_params` and the roster renders empty.
+/// Test: this is the test.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_query_parameter_reaches_the_daemon_as_its_own_type() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let socket = stub_daemon(tmp.path(), |request| {
+        vec![result_frame(json!({
+            "details": request["params"]["details"].clone(),
+            "method_seen": request["method"].clone(),
+        }))]
+    });
+
+    let (status, _, body) =
+        through_router(socket, "GET", "/api/search/indexes?details=true", "").await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    let parsed: Value = serde_json::from_str(&body).expect("json");
+    assert_eq!(parsed["details"], json!(true), "must arrive as a bool");
+    assert_eq!(parsed["method_seen"], json!("search.indexes.list"));
+}
+
+/// Why: a POST body has to arrive nested under the key the RPC params expect,
+/// or every search from the dashboard is refused.
+/// Test: this is the test.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_post_body_reaches_the_daemon_under_the_params_it_expects() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let socket = stub_daemon(tmp.path(), |request| {
+        vec![result_frame(json!({
+            "params": request["params"].clone(),
+            "method_seen": request["method"].clone(),
+        }))]
+    });
+
+    let (status, _, body) = through_router(
+        socket,
+        "POST",
+        "/api/search/indexes/scratch/search",
+        r#"{"text":"hello","top_k":5}"#,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    let parsed: Value = serde_json::from_str(&body).expect("json");
+    assert_eq!(parsed["method_seen"], json!("search.query"));
+    assert_eq!(parsed["params"]["index_id"], json!("scratch"));
+    assert_eq!(parsed["params"]["body"]["text"], json!("hello"));
+}
+
+/// Why: the fail-open branch. A daemon that refuses must not reach the browser
+/// as a `200` carrying an error-shaped body — the SPA branches on status, so a
+/// refusal read as a success renders an empty index rather than an error.
+/// Test: this is the test.
+#[tokio::test(flavor = "multi_thread")]
+async fn an_rpc_error_frame_becomes_the_http_status_it_stands_for() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let socket = stub_daemon(tmp.path(), |_| {
+        vec![error_frame(-32004, "no index 'ghost'")]
+    });
+
+    let (status, _, body) =
+        through_router(socket, "GET", "/api/search/indexes/ghost/status", "").await;
+    assert_eq!(status, StatusCode::NOT_FOUND, "{body}");
+    assert!(
+        body.contains("no index 'ghost'"),
+        "the daemon's words must reach the caller: {body}"
+    );
+}
+
+/// Why (#6285, the fail-open check): a daemon that is not running must be
+/// distinguishable from a healthy one with nothing to show. `502` with a reason
+/// is that distinction; a `200` with an empty body would not be.
+/// Test: this is the test.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_dead_socket_is_a_bad_gateway_not_an_empty_success() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let (status, _, body) = through_router(
+        tmp.path().join("absent.sock"),
+        "GET",
+        "/api/search/indexes",
+        "",
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_GATEWAY, "{body}");
+    assert!(
+        body.contains("trusty-search"),
+        "the failure must name the daemon: {body}"
+    );
+}
+
+/// Why: `POST /chat` and `POST /admin/stop` are called by the SPA and have no
+/// socket method. They must refuse loudly and name the gap, not answer an
+/// approximate `502` that reads as "the daemon is down".
+/// Test: this is the test.
+#[tokio::test(flavor = "multi_thread")]
+async fn an_unmapped_path_is_not_implemented_and_names_itself() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let socket = stub_daemon(tmp.path(), |_| vec![result_frame(json!({}))]);
+
+    let (status, _, body) = through_router(socket, "POST", "/api/search/chat", "{}").await;
+    assert_eq!(status, StatusCode::NOT_IMPLEMENTED, "{body}");
+    assert!(body.contains("chat"), "{body}");
+}
+
+/// Why: the SPA's own `base.js` documents `/proxy/search/` as a supported mount,
+/// so callers predating the `/api/` rename exist. Removing the search row from
+/// the generic proxy would have answered them `400 unknown daemon`.
+/// Test: this is the test.
+#[tokio::test(flavor = "multi_thread")]
+async fn deprecated_alias_reaches_the_same_handler() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let socket = stub_daemon(tmp.path(), |_| {
+        vec![result_frame(json!({ "status": "ok" }))]
+    });
+
+    let (status, _, body) = through_router(socket, "GET", "/proxy/search/health", "").await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+}
+
+// ─── streams ─────────────────────────────────────────────────────────────────
+
+/// Why: the reindex view reads `/reindex/stream` as Server-Sent Events, and the
+/// socket answers the same event sequence as typed frames. One item must become
+/// exactly one `data:` line carrying the same document — that is the parity
+/// `trusty_search::service::rpc::streams` pins on its side, and this is the
+/// other half of it.
+/// Test: this is the test.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_stream_reaches_the_browser_frame_for_frame() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let socket = stub_daemon(tmp.path(), |request| {
+        assert_eq!(request["method"], json!("search.status.stream"));
+        assert_eq!(
+            request["stream"],
+            json!(true),
+            "a streaming method needs the negotiation field"
+        );
+        vec![
+            item_frame(json!({ "type": "connected" })),
+            item_frame(json!({ "type": "stats", "indexes": 3 })),
+            item_frame(json!({ "type": "lag", "skipped": 7 })),
+            end_frame(),
+        ]
+    });
+
+    let (status, content_type, body) =
+        through_router(socket, "GET", "/api/search/status/stream", "").await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(content_type, "text/event-stream");
+    assert_eq!(
+        body,
+        "data: {\"type\":\"connected\"}\n\n\
+         data: {\"indexes\":3,\"type\":\"stats\"}\n\n\
+         data: {\"skipped\":7,\"type\":\"lag\"}\n\n",
+        "each item must be exactly one SSE data line"
+    );
+}
+
+/// Why: `GET /indexes/{id}/reindex/stream` answered `404` over HTTP for an index
+/// with no progress record, and on the socket that refusal is the stream's FIRST
+/// frame. Committing to `200 text/event-stream` before reading it would turn
+/// every such refusal into an empty stream — which the SPA reads as a finished
+/// reindex.
+/// Test: this is the test.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_stream_refusal_before_the_first_item_is_an_http_status() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let socket = stub_daemon(tmp.path(), |_| {
+        vec![stream_error_frame(
+            -32004,
+            "no reindex in progress for 'ghost'",
+        )]
+    });
+
+    let (status, content_type, body) = through_router(
+        socket,
+        "GET",
+        "/api/search/indexes/ghost/reindex/stream",
+        "",
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND, "{body}");
+    assert!(
+        !content_type.contains("event-stream"),
+        "a refusal must not open a stream: {content_type}"
+    );
+    assert!(body.contains("no reindex in progress"), "{body}");
+}
+
+/// Why: once the stream is open the status is already sent, so a failure can
+/// only be reported in the body. A silent close is what the SPA reads as a
+/// COMPLETED reindex, so the failure has to arrive as an event.
+/// Test: this is the test.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_mid_stream_failure_becomes_an_error_event() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let socket = stub_daemon(tmp.path(), |_| {
+        vec![
+            item_frame(json!({ "type": "progress", "files": 1 })),
+            stream_error_frame(-32603, "the reindex worker died"),
+        ]
+    });
+
+    let (status, content_type, body) = through_router(
+        socket,
+        "GET",
+        "/api/search/indexes/scratch/reindex/stream",
+        "",
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(content_type, "text/event-stream");
+    assert!(body.starts_with("data: {"), "{body}");
+    assert!(
+        body.contains("the reindex worker died"),
+        "a broken stream must say so rather than closing quietly: {body}"
+    );
+    assert!(body.contains("\"type\":\"error\""), "{body}");
+}
+
+/// Why: a truncated stream — the socket closing with no terminal frame — is the
+/// same hazard as a mid-stream failure and must not read as a clean end.
+/// Test: this is the test.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_truncated_stream_becomes_an_error_event() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let socket = stub_daemon(tmp.path(), |_| {
+        vec![item_frame(json!({ "type": "progress", "files": 1 }))]
+    });
+
+    let (status, _, body) = through_router(
+        socket,
+        "GET",
+        "/api/search/indexes/scratch/reindex/stream",
+        "",
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert!(
+        body.contains("\"type\":\"error\""),
+        "an unterminated stream must not read as complete: {body}"
+    );
+}
+
+/// Why: nothing bound to the socket must fail the stream open with a status,
+/// not with an empty `200` event stream.
+/// Test: this is the test.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_stream_against_a_dead_socket_is_a_bad_gateway() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let (status, content_type, body) = through_router(
+        tmp.path().join("absent.sock"),
+        "GET",
+        "/api/search/status/stream",
+        "",
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_GATEWAY, "{body}");
+    assert!(!content_type.contains("event-stream"), "{content_type}");
+}


### PR DESCRIPTION
The trusty-console leg of the #6285 consumer wave, and the one PR #6384 named as
required before trusty-search's HTTP surface can go: the console reached
trusty-search three ways, and all three resolved a base URL from the `http_addr`
discovery file the daemon is about to stop writing.

## What moves

| Site | Before | Now |
|---|---|---|
| `detect/search.rs` | `http_addr` + TCP probe | `search.health` on the socket |
| `proxy/routes.rs` | a `search` row in the reverse-proxy allowlist | row deleted; `/api/search/{*path}` is its own route |
| `routes/deletes.rs` | `DELETE /indexes/{id}` over reqwest | `search.index.delete` |
| `routes/cleanup.rs` | the same, per id in a batch | the same, over the socket |

`search_uds` is the one client — method names, socket resolution, one unary
exchange, one stream open, and the JSON-RPC-code to HTTP-status map that keeps a
refusal the status it was over HTTP. It dials with the 64 MiB frame budget the
listener raised in slice 5.5, since the shared 8 MiB default applies to the
response read and `search.query.all` with full content passes it.

## The two streams

`/api/search/status/stream` and `/api/search/indexes/{id}/reindex/stream` are SSE
toward the browser and RPC streams on the socket. `streams.rs` states the parity
contract — one stream item is exactly the JSON document one `data:` line carried
— so the bridge re-prefixes and adds nothing. Three details:

- The daemon's 20 s `: heartbeat` comment has no RPC counterpart, so the console
  emits it on the same interval; the browser hop is still TCP and the byte
  sequence it sees is unchanged.
- A refusal arrives as the stream's FIRST frame, after the dial has succeeded.
  The first frame is read before the response head is built, so
  `reindex/stream` on an index with no progress record is still `404` and not a
  `200` carrying an empty stream — which the SPA reads as a finished reindex.
- A mid-stream failure or a truncated stream becomes one
  `{"type":"error","message":…}` event before the body closes, for the same
  reason.

Choosing streaming from the PATH rather than from `Accept` also closes the hazard
#6384 had to guard against: no caller can claim `Accept: text/event-stream` on an
ordinary route to get a deadline-free connection, because the transport is fixed
by the mapping table.

## Transition behaviour: no HTTP fallback, honest degradation

trusty-memory (#6286) and trusty-analyze (#6287) migrated with no transitional
form and the consumer map assigns this crate the same shape. The reason is the
stale discovery file: it names 7878 on every machine that ran a pre-migration
daemon, so a fallback would forward the dashboard to whatever holds that port
rather than protect it. So during the window where an installed trusty-search is
HTTP-only:

- the service card reads **available**, never **running** — it observed nothing;
- every `/api/search/*` call answers **502** carrying the dial failure;
- an endpoint with no socket method answers **501** naming it;
- the index-delete route answers **503 unreachable**, never a phantom delete.

Live evidence below, against a real HTTP-only daemon.

## Two endpoints the dashboard calls have no socket method — owner call needed

`POST /chat` and `POST /admin/stop` are HTTP-only on trusty-search. Slice 5.5
left them out on the grounds that chat "serves the embedded `/ui` alone", and
#6384 moved that `/ui` into this binary — so the console-served SPA IS the
consumer that reasoning said did not exist. Both answer `501` naming the gap
rather than a `502` that would read as "the daemon is down". This is the same
finding the consumer-map correction (comment 5460292495) recorded for
trusty-mpm's TUI stop key: the retire slice needs a decision on `admin.stop`, and
the chat lane needs one too.

## Coverage removed, and why

`index_delete_does_not_follow_a_redirect` and
`index_delete_refuses_a_non_loopback_upstream` are deleted rather than ported:
both guard a URL the delete path no longer has. `search_uds` dials a socket path
derived from the data directory, so there is no redirect to follow and no
upstream address to be non-loopback. The `Test:` pointers that cited them are
gone with them.

`server/mod.rs` passed the 500-SLOC cap once the two new routes landed, so the
console's own embedded SPA moved to `console_ui`, beside `tools_ui`. No behaviour
change; the routes point at the new module.

## Gates — rung 6 (UI / API surface)

Every command below was run in this worktree at the pushed head.

```
cargo fmt --check                                          → exit 0
cargo check -p trusty-console --all-targets                → exit 0
cargo clippy -p trusty-console --all-targets -- -D warnings → exit 0
cargo check --workspace                                    → exit 0
```

`cargo test -p trusty-console --no-fail-fast` — every target ran:

```
test result: ok. 313 passed; 0 failed; 4 ignored   (lib)
test result: ok.   2 passed; 0 failed; 0 ignored   (tests/config_mount.rs)
test result: ok.  12 passed; 0 failed; 0 ignored   (tests/search_uds_bridge.rs)
test result: ok.   5 passed; 0 failed; 0 ignored   (tests/search_ui_mount.rs)
```

`tests/search_uds_bridge.rs` is new and drives the real router against a stub
daemon socket: the unary path, query-parameter typing, POST body nesting, an RPC
error frame becoming its HTTP status, a dead socket as `502`, an unmapped path as
`501`, the deprecated `/proxy/search/*` alias, and five stream cases — frame-for-
frame parity, a refusal before the first item, a mid-stream failure, a truncated
stream, and a dead socket.

UI package (`crates/trusty-console/ui`, `node --test src/*.test.js`):

```
# tests 55
# pass 55
# fail 0
```

Repo gates:

```
bash scripts/check_line_cap.sh            → exit 0  (4270 files, 0 violations)
bash scripts/check_changelog_fragment.sh  → exit 0  (16 paths, 1 crate recorded)
bash scripts/check_sld.sh                 → exit 0  (0 errors, 0 warnings)
```

`scripts/check_test_pointers.sh` had not finished a full-repo pass in this
worktree when this was written — it ran over an hour without producing output.
Every `Test:` citation in the twelve `.rs` files this PR touches was checked
against the workspace's real test names instead; the only unresolved citations
are five that already stand on `origin/main` (`Cli::parse_from` in `lib.rs`,
four in `server/mod.rs`), which the gate's ratchet already carries. CI runs the
gate on this head.

## Live smoke — console on a scratch port, real HTTP-only daemon

`trusty-search 0.49.5` running and answering `GET http://127.0.0.1:7878/health`
with `200`; no socket at
`~/Library/Application Support/trusty-search/trusty-search.sock`.

```
$ ./target/debug/trusty-console serve --http 127.0.0.1:17788

$ curl -s $B/api/console/services | jq '[.[] | select(.id=="trusty-search")]'
[{"id":"trusty-search","display_name":"Trusty Search","status":"available","version":"0.49.5"}]

$ curl -s -w '\nHTTP %{http_code}\n' $B/api/search/health
{"error":"trusty-search did not answer search.health: dial …/trusty-search.sock: refusing to connect …","service":"trusty-search"}
HTTP 502

$ curl -s -w '\nHTTP %{http_code}\n' "$B/api/search/indexes?details=true"
{"error":"trusty-search did not answer search.indexes.list: dial …","service":"trusty-search"}
HTTP 502

$ curl -s -w '\nHTTP %{http_code}\n' $B/api/search/registry/orphans
{"error":"trusty-search did not answer search.registry.orphans: dial …","service":"trusty-search"}
HTTP 502

$ curl -s -D - -o /dev/null $B/api/search/status/stream
HTTP/1.1 502 Bad Gateway
content-type: application/json
{"error":"trusty-search did not open search.status.stream: dial …","service":"trusty-search"}

$ curl -s -X POST -d '{}' -w '\nHTTP %{http_code}\n' $B/api/search/chat
{"error":"no trusty-search socket method serves POST /chat. … `POST /chat` and `POST /admin/stop` have no socket method at all and are pending an owner decision on #6285.","service":"trusty-search"}
HTTP 501

$ curl -s -X DELETE -H "Origin: $B" -w '\nHTTP %{http_code}\n' $B/api/console/search/indexes/no-such-index
{"error":"trusty-search did not answer the delete: trusty-search did not answer search.index.delete: dial …","id":"no-such-index","ok":false}
HTTP 503

$ curl -s $B/tools/search/ | grep __SEARCH_BASE__
window.__SEARCH_BASE__ = new URL("/api/search/", document.baseURI).href;
HTTP 200

$ grep -c 7878 console.log
0
```

The last line is the fallback check: with a live HTTP daemon on 7878 and the
`http_addr` file present, the console never resolved either. The card reads
`available` rather than `running`, every call carries the dial failure, and the
`501` is distinguishable from the `502`. Process killed after the run.

The happy path is proven by `tests/search_uds_bridge.rs` against a stub socket
rather than live: the installed daemon has no socket, and building the
socket-serving trusty-search from this worktree is not something this PR needs.

## Code-critic round 1 — three fixes (a3f4a6ecb)

- **Stream open is bounded (HIGH).** `send_framed_stream_request_capped` applies
  one timeout to the dial, the request write, and each frame read alike, and that
  figure is `STREAM_FRAME_TIMEOUT`'s day. A listener with a full backlog accepts
  and then reads nothing, so the browser waited a day for a response head.
  `open_stream` and `stream_response` take an `open_timeout`; the whole open —
  the helper call plus the first `next_frame` — is wrapped in it, at
  `STREAM_OPEN_TIMEOUT` = 60 s. An established stream keeps the long per-frame
  budget. Test: `a_socket_that_never_answers_is_a_prompt_bad_gateway`
  (`src/search_uds/routes.rs`), which passes 300 ms so it asserts in
  milliseconds. It is a unit test because `stream_response` is private.
- **The SSE reader releases on disconnect (MEDIUM).** The reader task now selects
  on `Sender::closed()` beside `next_frame`, the shape the daemon-side producer
  in `crates/trusty-search/src/service/rpc/streams.rs` uses. A browser leaving a
  quiet status stream previously went unnoticed until the next frame.
- **One frame-budget constant (MEDIUM) — deliberate deviation from the suggested
  remedy.** `routes::BODY_LIMIT` was a second 64 MiB literal for the figure
  `search_uds::MAX_FRAME_BYTES` already holds; it is gone. The invariant is
  restated as a FLOOR: this client's budget must be at least the listener's,
  because smaller breaks a response the daemon already produced while larger has
  no failure mode. The critic suggested a dev-dependency on trusty-search so the
  two constants could be compared directly — not taken, because it would build
  tantivy, tree-sitter and ORT into `cargo test -p trusty-console`. Instead
  `the_frame_budget_is_at_least_the_listeners` reads the
  `pub const MAX_FRAME_BYTES` declaration out of
  `crates/trusty-search/src/service/socket.rs` source text and asserts the
  direction, failing closed when the declaration moves. A critic ruling on that
  trade is welcome.

Rung 3 gates on the fix commit:

```
$ cargo fmt --check                                          # clean
$ cargo clippy -p trusty-console --all-targets -- -D warnings # clean
$ cargo test -p trusty-console --no-fail-fast
test result: ok. 315 passed; 0 failed; 4 ignored   (lib)
test result: ok. 2 passed; 0 failed; 0 ignored     (search_uds_bridge)
test result: ok. 12 passed; 0 failed; 0 ignored
test result: ok. 5 passed; 0 failed; 0 ignored
```

Refs #6285

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

