### PR TITLE
refactor(trusty-search): serve chat and admin.stop over UDS (Refs #6285)

### DIFF
--- a/crates/trusty-search/changelog.d/6285-admin-stop-refuses-changed.md
+++ b/crates/trusty-search/changelog.d/6285-admin-stop-refuses-changed.md
@@ -1,0 +1,5 @@
+Changed
+- `POST /admin/stop` now answers `503 shutdown_unavailable` (`retryable: false`)
+  when no shutdown driver is listening, instead of reporting `ok: true` for a
+  daemon that will keep running. A live daemon subscribes before it serves, so
+  the refusal fires only when the stop genuinely cannot happen (#6285).

--- a/crates/trusty-search/changelog.d/6285-uds-chat-admin-stop.md
+++ b/crates/trusty-search/changelog.d/6285-uds-chat-admin-stop.md
@@ -1,0 +1,6 @@
+Added
+- The UDS RPC surface now serves `search.chat` (`POST /chat`) and
+  `search.admin.stop` (`POST /admin/stop`), the last two routes with a named
+  consumer — trusty-mpm's TUI stop key and the search UI's chat panel, which
+  #6155 moves into `trusty-console`. Both run the same transport-free core their
+  axum handler wraps, so the two doors answer identically (#6285).

--- a/crates/trusty-search/src/service/rpc/admin.rs
+++ b/crates/trusty-search/src/service/rpc/admin.rs
@@ -1,12 +1,15 @@
-//! The operational remainder, served as JSON-RPC methods (#6285 slice 5.5).
+//! The operational remainder, served as JSON-RPC methods (#6285 slices 5.5, 5.6).
 //!
 //! Why: slices 1–5 moved health, the reads, the queries, the writes and the two
-//! streams. Four routes with a named consumer were still HTTP-only, and the
-//! retire slice cannot move that consumer onto a method the socket does not
-//! serve. This slice closes the gap the #6285 consumer map recorded: the two
-//! config WRITES the dashboard and `trusty-search config set` drive,
-//! `GET /logs/tail` (which `trusty-common`'s monitor dials), and
-//! `GET /registry/orphans` (which `trusty-console`'s cleanup tab dials, #6371).
+//! streams. Routes with a named consumer were still HTTP-only, and the retire
+//! slice cannot move that consumer onto a method the socket does not serve.
+//! Slice 5.5 closed the gap the #6285 consumer map recorded: the two config
+//! WRITES the dashboard and `trusty-search config set` drive, `GET /logs/tail`
+//! (which `trusty-common`'s monitor dials), and `GET /registry/orphans` (which
+//! `trusty-console`'s cleanup tab dials, #6371). Slice 5.6 adds
+//! `POST /admin/stop`, which that map listed as having no external consumer and
+//! PR #6388's implementation pass found trusty-mpm's TUI driving from its `[X]`
+//! key.
 //!
 //! What: the method-to-route table below, the params each method decodes, and
 //! [`register`]. Every handler is a thin adapter over a `*_report` core in
@@ -21,21 +24,25 @@
 //! | `search.config.set` | `PATCH /config` | free |
 //! | `search.logs.tail` | `GET /logs/tail` | free |
 //! | `search.registry.orphans` | `GET /registry/orphans` | free |
+//! | `search.admin.stop` | `POST /admin/stop` | free |
 //!
-//! All four HTTP routes sit in `service::server::build_router_on`'s `free`
-//! group — no admission limiter, no query deadline — and all four methods copy
-//! that. The two writes are `free` on HTTP for the same reason
+//! All five HTTP routes sit in `service::server::build_router_on`'s `free`
+//! group — no admission limiter, no query deadline — and all five methods copy
+//! that. The two config writes are `free` on HTTP for the same reason
 //! `DELETE /indexes/{id}` is (slice 4's lane table): they are registry-level,
 //! and putting them behind the limiter here would make a config edit queue
-//! behind a running reindex that the HTTP route sails past.
+//! behind a running reindex that the HTTP route sails past. `search.admin.stop`
+//! must be `free` for a stronger reason: a stop that queued behind a saturated
+//! daemon is a stop that cannot end the saturation.
 //!
-//! ## Two of these are WRITES, so each carries a failure arm that checks state
+//! ## Three of these are WRITES, so each carries a failure arm that checks state
 //!
 //! `search.index.config.set` re-registers a handle, rewrites an `indexes.toml`
 //! row and can start a background catch-up; `search.config.set` moves two
-//! process-global memory limits. The slice-4 bar applies to both: every refusal
-//! case asserts the refusal AND re-reads the thing that must not have moved —
-//! the handle's config view, the persisted row, the resolved limits.
+//! process-global memory limits; `search.admin.stop` ends the process. The
+//! slice-4 bar applies to all three: every refusal case asserts the refusal AND
+//! re-reads the thing that must not have moved — the handle's config view, the
+//! persisted row, the resolved limits, the shutdown flag.
 //!
 //! ## What guards these methods
 //!
@@ -47,8 +54,8 @@
 //! (#6277 design review, the same conclusion slices 1 and 4 recorded).
 //!
 //! Test: `admin_tests.rs` — one `*_over_the_socket_matches_the_http_body` per
-//! method plus, for each of the two writes, a failure arm proving the refusal is
-//! identical AND that neither in-memory nor on-disk state advanced behind it.
+//! method plus, for each write, a failure arm proving the refusal is identical
+//! AND that neither in-memory nor on-disk state advanced behind it.
 //!
 //! [`register`]: crate::service::rpc::admin::register
 
@@ -77,6 +84,13 @@ pub const METHOD_CONFIG_SET: &str = "search.config.set";
 pub const METHOD_LOGS_TAIL: &str = "search.logs.tail";
 /// `GET /registry/orphans` — the `indexes.toml` census of dead roots (#6371).
 pub const METHOD_REGISTRY_ORPHANS: &str = "search.registry.orphans";
+/// `POST /admin/stop` — ask the daemon to shut down gracefully (#6285 slice 5.6).
+///
+/// This is the name trusty-mpm's TUI `[X]` key dials once the retire slice moves
+/// it off HTTP. The #6285 consumer map recorded `/admin/stop` as having no
+/// external consumer; PR #6388's implementation pass found that wrong, which is
+/// why the method exists.
+pub const METHOD_ADMIN_STOP: &str = "search.admin.stop";
 
 /// Every method this slice registers, in registration order.
 ///
@@ -93,6 +107,7 @@ pub const METHODS: &[&str] = &[
     METHOD_CONFIG_SET,
     METHOD_LOGS_TAIL,
     METHOD_REGISTRY_ORPHANS,
+    METHOD_ADMIN_STOP,
 ];
 
 /// The params of [`METHOD_INDEX_CONFIG_SET`].
@@ -142,7 +157,7 @@ pub struct LogsTail {
 
 /// Mount every method in [`METHODS`] onto `router`.
 ///
-/// Why: the route-specific half of the last four routes with a named consumer,
+/// Why: the route-specific half of the operational routes with a named consumer,
 /// kept beside `reads`, `queries`, `writes` and `streams` so each slice adds one
 /// file rather than editing one.
 /// What: one `typed` registration per method, each cloning the `Arc` handle to
@@ -155,7 +170,7 @@ pub struct LogsTail {
 pub fn register(router: RpcRouter, state: &Arc<SearchAppState>) -> RpcRouter {
     use crate::service::orphan_report::registry_orphans_report;
     use crate::service::server::{
-        logs_tail_report, patch_config_report, patch_index_config_report,
+        admin_stop_report, logs_tail_report, patch_config_report, patch_index_config_report,
     };
 
     // ---- the two config writes (axum's `free` group) ------------------------
@@ -193,13 +208,26 @@ pub fn register(router: RpcRouter, state: &Arc<SearchAppState>) -> RpcRouter {
             }
         });
 
-    router.typed::<super::super::socket::NoParams, serde_json::Value, _, _>(
+    let router = router.typed::<super::super::socket::NoParams, serde_json::Value, _, _>(
         METHOD_REGISTRY_ORPHANS,
         move |_params| async move {
             let census: OrphanCensus = registry_orphans_report()
                 .await
                 .map_err(|(status, body)| rpc_error_from_http(status, &body))?;
             as_http_body(census)
+        },
+    );
+
+    // ---- the lifecycle write (#6285 slice 5.6, axum's `free` group) ---------
+    let held = Arc::clone(state);
+    router.typed::<super::super::socket::NoParams, serde_json::Value, _, _>(
+        METHOD_ADMIN_STOP,
+        move |_params| {
+            let state = Arc::clone(&held);
+            async move {
+                admin_stop_report(&state)
+                    .map_err(|(status, body)| rpc_error_from_http(status, &body))
+            }
         },
     )
 }

--- a/crates/trusty-search/src/service/rpc/admin_tests.rs
+++ b/crates/trusty-search/src/service/rpc/admin_tests.rs
@@ -683,3 +683,83 @@ async fn an_unreadable_registry_is_refused_on_either_transport() {
         "unreadable registry",
     );
 }
+
+// ------------------------------------------------------- search.admin.stop ---
+
+/// Why: stopping the daemon is the one call on this surface whose answer a
+/// caller cannot verify by asking again — the daemon it would ask is the one that
+/// was supposed to go away. Both transports must therefore reach the SAME `watch`
+/// channel and report the success the same way. The subscribers are what make
+/// that observable: each transport's own signal has to land, so a socket that
+/// signalled a different channel fails here rather than in a TUI whose stop key
+/// silently does nothing.
+/// Test: this function IS the test.
+#[tokio::test(flavor = "multi_thread")]
+#[serial_test::serial]
+async fn admin_stop_over_the_socket_matches_the_http_body() {
+    let _isolated = IsolatedDataDir::new();
+    let (state, http, rpc) = routers(&[]);
+
+    // Subscribe BEFORE either call: `run_daemon` holds a receiver for the
+    // daemon's life, and without one the send fails and the route refuses.
+    let mut over_http_rx = state.shutdown_tx.subscribe();
+    let over_http = http_ok(&http, "POST", "/admin/stop", serde_json::json!({})).await;
+    assert!(
+        *over_http_rx.borrow_and_update(),
+        "the HTTP route must signal the shutdown channel"
+    );
+
+    // Reset so the socket's own signal is a fresh transition rather than a value
+    // the previous call already left behind.
+    state
+        .shutdown_tx
+        .send(false)
+        .expect("the receiver above is still alive");
+    let mut over_socket_rx = state.shutdown_tx.subscribe();
+    let over_socket = rpc_ok(&rpc, admin::METHOD_ADMIN_STOP, serde_json::Value::Null).await;
+    assert!(
+        *over_socket_rx.borrow_and_update(),
+        "the socket method must signal the SAME shutdown channel"
+    );
+
+    assert_eq!(over_socket, over_http);
+    assert_eq!(over_socket["ok"], serde_json::json!(true));
+    assert_eq!(over_socket["message"], serde_json::json!("shutting down"));
+}
+
+/// Why: the failure arm is the reason this method is fallible at all. A send
+/// fails only when nothing is driving shutdown, which means the process will keep
+/// running — and the route used to discard that error and answer `ok: true`
+/// anyway, telling trusty-mpm's TUI a daemon had stopped when it had not. The
+/// refusal is permanent because the receiver is subscribed once at boot and never
+/// re-subscribed, so a caller told to retry would retry forever.
+/// Test: this function IS the test.
+#[tokio::test(flavor = "multi_thread")]
+#[serial_test::serial]
+async fn admin_stop_is_refused_on_both_transports_when_nothing_drives_shutdown() {
+    let _isolated = IsolatedDataDir::new();
+    let (state, http, rpc) = routers(&[]);
+    // `SearchAppState::new` drops the receiver it creates, so this state carries
+    // no shutdown driver — exactly the condition the arm reports.
+    assert_eq!(
+        state.shutdown_tx.receiver_count(),
+        0,
+        "the fixture must carry no shutdown driver"
+    );
+
+    let over_http = http_err(&http, "POST", "/admin/stop", serde_json::json!({})).await;
+    let over_socket = rpc_err(&rpc, admin::METHOD_ADMIN_STOP, serde_json::Value::Null).await;
+
+    assert_eq!(over_http.0, StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(over_http.1["ok"], serde_json::json!(false));
+    assert_same_refusal(
+        &over_http,
+        &over_socket,
+        crate::service::rpc::error::CODE_UNAVAILABLE_PERMANENT,
+        "no shutdown driver",
+    );
+    assert!(
+        !*state.shutdown_tx.borrow(),
+        "a refused stop must leave the shutdown flag exactly where it was"
+    );
+}

--- a/crates/trusty-search/src/service/rpc/chat.rs
+++ b/crates/trusty-search/src/service/rpc/chat.rs
@@ -1,0 +1,92 @@
+//! Grounded conversational Q&A, served as a JSON-RPC method (#6285 slice 5.6).
+//!
+//! Why: slice 5.5 left `POST /chat` HTTP-only on the reading that chat serves
+//! the embedded `/ui` alone. #6155 moves that UI into `trusty-console`, which
+//! reaches this daemon over the socket, so the route needs a method here before
+//! the retire slice deletes it — otherwise the migrated UI loses its chat panel
+//! and the surface-removal gate has to wait for a method nobody scheduled.
+//!
+//! What: [`METHOD_CHAT`], and [`register`]. The handler is a thin adapter over
+//! [`chat_report`] in `service::ui` — this file decides WHICH method exists and
+//! what it decodes, never what it does.
+//!
+//! ## Method → route
+//!
+//! | Method | HTTP route | Lane |
+//! |---|---|---|
+//! | `search.chat` | `POST /chat` | free |
+//!
+//! ## This is a unary method, and that is the route's shape rather than a
+//! simplification
+//!
+//! `POST /chat` streams from the provider INTERNALLY and collects the deltas
+//! into one JSON envelope before it answers; the SSE pair slice 5 moved
+//! (`search.status.stream`, `search.index.reindex.stream`) are the routes that
+//! stream to the CALLER. Registering this one into the router's streaming table
+//! would give the socket a shape HTTP has never had, and the two doors would
+//! stop answering the same thing — which is the property the whole surface is
+//! built to keep. When the route itself learns to stream deltas, both transports
+//! move together.
+//!
+//! ## What guards this method
+//!
+//! Everything slice 2's `reads` module documents — the peer-uid check over a
+//! `0600` socket in a `0700` directory. A caller may supply its own `api_key` in
+//! the params, exactly as the HTTP body accepts one; a peer that reached this
+//! socket has the daemon's own uid and could read that key from the environment
+//! regardless.
+//!
+//! Test: `chat_tests.rs`.
+//!
+//! [`chat_report`]: crate::service::ui::chat_report
+//! [`register`]: crate::service::rpc::chat::register
+
+use std::sync::Arc;
+
+use trusty_common::uds::server::RpcRouter;
+
+use crate::service::server::SearchAppState;
+use crate::service::ui::ChatRequest;
+
+use super::error::rpc_error_from_http;
+
+#[cfg(test)]
+#[path = "chat_tests.rs"]
+mod tests;
+
+/// `POST /chat` — answer one question about an index, grounded in a search.
+pub const METHOD_CHAT: &str = "search.chat";
+
+/// Every method this slice registers, in registration order.
+///
+/// The same contract the other families carry — `service::socket::METHODS`
+/// splices this in by reference rather than restating the literal, so a rename
+/// is a compile error there rather than a drift only a running consumer finds.
+/// Test: `rpc_router_registers_every_documented_method` and
+/// `every_family_method_is_spliced_into_the_socket_method_list` in
+/// `socket_tests.rs`.
+pub const METHODS: &[&str] = &[METHOD_CHAT];
+
+/// Mount [`METHOD_CHAT`] onto `router`.
+///
+/// Why: the route-specific half of `POST /chat`, kept beside the other families
+/// so each slice adds one file rather than editing one.
+/// What: one `typed` registration decoding [`ChatRequest`] — byte-for-byte the
+/// JSON the HTTP route's extractor takes, so `question`/`message` aliasing and
+/// every serde default behave identically — and running [`chat_report`], the
+/// core the axum handler wraps.
+/// Test: `chat_over_the_socket_matches_the_http_body` and its two refusal
+/// siblings in `chat_tests.rs`.
+///
+/// [`chat_report`]: crate::service::ui::chat_report
+pub fn register(router: RpcRouter, state: &Arc<SearchAppState>) -> RpcRouter {
+    let held = Arc::clone(state);
+    router.typed::<ChatRequest, serde_json::Value, _, _>(METHOD_CHAT, move |req| {
+        let state = Arc::clone(&held);
+        async move {
+            crate::service::ui::chat_report(&state, req)
+                .await
+                .map_err(|(status, body)| rpc_error_from_http(status, &body))
+        }
+    })
+}

--- a/crates/trusty-search/src/service/rpc/chat.rs
+++ b/crates/trusty-search/src/service/rpc/chat.rs
@@ -75,8 +75,8 @@ pub const METHODS: &[&str] = &[METHOD_CHAT];
 /// JSON the HTTP route's extractor takes, so `question`/`message` aliasing and
 /// every serde default behave identically — and running [`chat_report`], the
 /// core the axum handler wraps.
-/// Test: `chat_over_the_socket_matches_the_http_body` and its two refusal
-/// siblings in `chat_tests.rs`.
+/// Test: `chat_without_a_provider_is_refused_identically_on_both_transports`
+/// and its refusal siblings in `chat_tests.rs`.
 ///
 /// [`chat_report`]: crate::service::ui::chat_report
 pub fn register(router: RpcRouter, state: &Arc<SearchAppState>) -> RpcRouter {

--- a/crates/trusty-search/src/service/rpc/chat_tests.rs
+++ b/crates/trusty-search/src/service/rpc/chat_tests.rs
@@ -1,0 +1,214 @@
+//! Socket-versus-HTTP parity for `search.chat` (#6285 slice 5.6).
+//!
+//! Why: `POST /chat` reaches a network provider on its success path, so the
+//! answer a caller gets is not something a test can pin. What CAN be pinned is
+//! everything this slice actually added — the decoder both transports run, and
+//! every refusal they reach before the first packet leaves the box. Those are
+//! also the arms a consumer branches on: an empty question and an unconfigured
+//! daemon are what the migrated UI has to render.
+//!
+//! Every case drives the REAL axum router and the REAL RPC router over ONE
+//! shared state, so a `chat_report` core that stopped being the body both
+//! transports serve fails here.
+//!
+//! **Every state below disables both providers explicitly.** `SearchAppState`
+//! reads `OPENROUTER_API_KEY` from the environment and `LocalModelConfig`
+//! defaults to probing Ollama on `localhost:11434`, so a developer running
+//! either would otherwise turn these cases into live network calls.
+//!
+//! Test: this file IS the test module for `super`.
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use axum::Router;
+use tower::ServiceExt as _;
+use trusty_common::uds::server::{RpcError, RpcRouter, CODE_INVALID_PARAMS};
+
+use crate::core::indexer::CodeIndexer;
+use crate::core::registry::{IndexHandle, IndexId, IndexRegistry};
+use crate::service::rpc::chat;
+use crate::service::rpc::error::CODE_UNAVAILABLE;
+use crate::service::server::{build_router_on, SearchAppState};
+
+/// The index every case names, registered so a call reaches the provider
+/// resolution rather than stopping at a registry lookup.
+const INDEX: &str = "chat-6285";
+
+/// One state with NO chat provider reachable, plus both routers on it.
+///
+/// Why both from the SAME `Arc`: the property under test one level down is that
+/// `build_router_on` and `chat::register` read ONE state. Two `Arc::new` calls
+/// would make every comparison below a comparison of two daemons.
+fn routers() -> (Router, RpcRouter) {
+    let registry = IndexRegistry::new();
+    let root = "/nonexistent/chat-6285";
+    registry.register(IndexHandle::bare(
+        IndexId::new(INDEX.to_string()),
+        Arc::new(tokio::sync::RwLock::new(CodeIndexer::new(INDEX, root))),
+        root.into(),
+    ));
+    let state = Arc::new(
+        SearchAppState::new(registry)
+            .with_local_model(trusty_common::LocalModelConfig {
+                enabled: false,
+                base_url: "http://127.0.0.1:1".to_string(),
+                model: "none".to_string(),
+            })
+            .with_openrouter_api_key(""),
+    );
+    let http = build_router_on(
+        Arc::clone(&state),
+        trusty_common::server::SelfOrigins::default(),
+    );
+    let rpc = chat::register(RpcRouter::new(), &state);
+    (http, rpc)
+}
+
+async fn http_chat(router: &Router, body: serde_json::Value) -> (StatusCode, serde_json::Value) {
+    let request = Request::builder()
+        .method("POST")
+        .uri("/chat")
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&body).expect("encode")))
+        .expect("build the request");
+    let response = router
+        .clone()
+        .oneshot(request)
+        .await
+        .expect("the router must answer");
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read the body");
+    let text = String::from_utf8_lossy(&bytes).into_owned();
+    let parsed = serde_json::from_str(&text).unwrap_or(serde_json::Value::String(text));
+    (status, parsed)
+}
+
+async fn rpc_chat_err(rpc: &RpcRouter, params: serde_json::Value) -> RpcError {
+    let frame = serde_json::to_vec(&serde_json::json!({
+        "jsonrpc": "2.0", "id": 1, "method": chat::METHOD_CHAT, "params": params,
+    }))
+    .expect("encode the frame");
+    let response = rpc.dispatch(&frame).await;
+    response
+        .error
+        .unwrap_or_else(|| panic!("chat must be refused; got {:?}", response.result))
+}
+
+/// Assert the socket's error frame is the HTTP refusal, rendered.
+///
+/// Why not tautological: it re-derives the frame from the `(status, body)` pair
+/// the OTHER transport actually produced, so it passes only when both ran the
+/// same core and reached the same refusal. Same shape as
+/// `admin_tests::assert_same_refusal`.
+fn assert_same_refusal(
+    http: &(StatusCode, serde_json::Value),
+    over_socket: &RpcError,
+    expected_code: i64,
+    what: &str,
+) {
+    let (status, body) = http;
+    let rendered = crate::service::rpc::error::rpc_error_from_http(*status, body);
+    assert_eq!(
+        over_socket.code, expected_code,
+        "{what}: the socket must classify this refusal as {expected_code}, \
+         got {} (HTTP said {status}: {body})",
+        over_socket.code
+    );
+    assert_eq!(
+        rendered.code, expected_code,
+        "{what}: HTTP's {status} must project onto {expected_code}: {body}"
+    );
+    assert_eq!(
+        over_socket.message, rendered.message,
+        "{what}: the socket's message must be the HTTP body's own wording"
+    );
+}
+
+/// Why: the empty-question check is the first thing `chat_report` does, and a
+/// socket that skipped it would send a provider a request with no question in it
+/// — billed, and answered with whatever the model makes of an empty prompt. Both
+/// transports must refuse it, with the same wording, before any provider is
+/// resolved.
+/// Test: this function IS the test.
+#[tokio::test(flavor = "multi_thread")]
+async fn an_empty_message_is_refused_identically_on_both_transports() {
+    let (http, rpc) = routers();
+    let body = serde_json::json!({ "index_id": INDEX, "message": "" });
+
+    let over_http = http_chat(&http, body.clone()).await;
+    let over_socket = rpc_chat_err(&rpc, body).await;
+
+    assert_eq!(over_http.0, StatusCode::BAD_REQUEST);
+    assert_same_refusal(
+        &over_http,
+        &over_socket,
+        CODE_INVALID_PARAMS,
+        "an empty message",
+    );
+}
+
+/// Why: an unconfigured daemon is the state the migrated UI meets on a fresh
+/// machine, and `503` is the answer it renders as "chat is off". The refusal is
+/// retryable — setting `OPENROUTER_API_KEY` or starting Ollama clears it without
+/// a code change — so it must project onto `CODE_UNAVAILABLE` rather than the
+/// permanent sibling, which would tell the UI to stop offering the panel.
+/// Test: this function IS the test.
+#[tokio::test(flavor = "multi_thread")]
+async fn chat_without_a_provider_is_refused_identically_on_both_transports() {
+    let (http, rpc) = routers();
+    let body = serde_json::json!({ "index_id": INDEX, "message": "how does auth work?" });
+
+    let over_http = http_chat(&http, body.clone()).await;
+    let over_socket = rpc_chat_err(&rpc, body).await;
+
+    assert_eq!(over_http.0, StatusCode::SERVICE_UNAVAILABLE);
+    assert_same_refusal(&over_http, &over_socket, CODE_UNAVAILABLE, "no provider");
+    assert!(
+        over_socket.message.contains("no chat provider available"),
+        "the socket must carry the route's own wording: {}",
+        over_socket.message
+    );
+}
+
+/// Why: `ChatRequest` carries the `question`/`message` alias and a serde default
+/// on every other field, and the socket decodes THAT type rather than a
+/// hand-written mirror of it. A mirror would be the one place the two doors could
+/// disagree about what a well-formed request is — so a request phrased the way
+/// issue #15 specified must get past the empty-question check on both, and land
+/// on the same provider refusal rather than a `400`.
+/// Test: this function IS the test.
+#[tokio::test(flavor = "multi_thread")]
+async fn the_question_alias_decodes_on_both_transports() {
+    let (http, rpc) = routers();
+    let body = serde_json::json!({ "index_id": INDEX, "question": "how does auth work?" });
+
+    let over_http = http_chat(&http, body.clone()).await;
+    let over_socket = rpc_chat_err(&rpc, body).await;
+
+    assert_eq!(
+        over_http.0,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "`question` must be accepted as the message, not refused as absent: {}",
+        over_http.1
+    );
+    assert_same_refusal(&over_http, &over_socket, CODE_UNAVAILABLE, "the alias");
+}
+
+/// Why: `POST /chat` collects the provider's deltas into one envelope and
+/// answers once, so `search.chat` belongs in the router's UNARY table. A slice
+/// that moved it into the streaming one would give the socket a shape HTTP has
+/// never had, and `lanes_tests::code_of` — which picks its request flag off
+/// `streams::METHODS` — would start reading a `CODE_STREAM_REQUIRED` refusal as
+/// a lane verdict.
+/// Test: this function IS the test.
+#[test]
+fn chat_is_a_unary_method_and_not_a_stream() {
+    assert!(
+        !crate::service::rpc::streams::METHODS.contains(&chat::METHOD_CHAT),
+        "search.chat must not be registered as a stream"
+    );
+}

--- a/crates/trusty-search/src/service/rpc/lanes_tests.rs
+++ b/crates/trusty-search/src/service/rpc/lanes_tests.rs
@@ -94,7 +94,7 @@ impl Lane {
 /// succeed. What each method ANSWERS is the business of its family's parity
 /// tests; this file reads only whether the limiter or the deadline spoke first.
 fn lanes() -> Vec<(&'static str, Lane, serde_json::Value)> {
-    use crate::service::rpc::{admin, queries, reads, streams, writes};
+    use crate::service::rpc::{admin, chat, queries, reads, streams, writes};
 
     let index = serde_json::json!({ "index_id": INDEX });
     let query = serde_json::json!({ "index_id": INDEX, "body": { "text": "anything" } });
@@ -227,6 +227,20 @@ fn lanes() -> Vec<(&'static str, Lane, serde_json::Value)> {
             Lane::Free,
             serde_json::Value::Null,
         ),
+        // Slice 5.6: both HTTP routes are in `free` too. Neither params set can
+        // succeed — this state has no shutdown driver subscribed and no chat
+        // provider configured — which is what the sweep wants: the refusal it
+        // reads is the core's own verdict rather than the limiter's.
+        (
+            admin::METHOD_ADMIN_STOP,
+            Lane::Free,
+            serde_json::Value::Null,
+        ),
+        (
+            chat::METHOD_CHAT,
+            Lane::Free,
+            serde_json::json!({ "index_id": INDEX }),
+        ),
     ]
 }
 
@@ -248,7 +262,7 @@ fn state_with(permits: usize, deadline: Duration) -> Arc<SearchAppState> {
 
 /// The whole socket router, exactly as `service::socket` assembles it.
 fn router(state: &Arc<SearchAppState>) -> RpcRouter {
-    use crate::service::rpc::{admin, queries, reads, streams, writes};
+    use crate::service::rpc::{admin, chat, queries, reads, streams, writes};
 
     let held = Arc::clone(state);
     let router = RpcRouter::new()
@@ -263,6 +277,7 @@ fn router(state: &Arc<SearchAppState>) -> RpcRouter {
     let router = queries::register(router, state);
     let router = writes::register(router, state);
     let router = admin::register(router, state);
+    let router = chat::register(router, state);
     streams::register(router, state)
 }
 

--- a/crates/trusty-search/src/service/rpc/mod.rs
+++ b/crates/trusty-search/src/service/rpc/mod.rs
@@ -33,8 +33,12 @@ pub mod writes;
 pub mod streams;
 
 /// Registration for the operational remainder: the two config writes, the log
-/// tail, and the registry orphan census (#6285 slice 5.5).
+/// tail, the registry orphan census (#6285 slice 5.5), and the graceful-stop
+/// request (#6285 slice 5.6).
 pub mod admin;
+
+/// Registration for grounded conversational Q&A (#6285 slice 5.6).
+pub mod chat;
 
 /// Per-method admission and deadline lane pins for the whole socket surface
 /// (#6285 slice 5, widened in slice 5.5 to every lock-taking method).

--- a/crates/trusty-search/src/service/server/admin.rs
+++ b/crates/trusty-search/src/service/server/admin.rs
@@ -4,15 +4,16 @@
 //! and the SSE dashboard feed) separately from domain search logic.
 //! What: `logs_tail_handler`, `admin_stop_handler`, `get_config_handler`,
 //! `patch_config_handler`, `status_stream_handler`, `collect_status_counts`,
-//! and the transport-free cores two of them delegate to — `logs_tail_report`
-//! and `patch_config_report`, which `service::rpc::admin` serves over the socket
-//! (#6285 slice 5.5).
+//! and the transport-free cores three of them delegate to — `logs_tail_report`,
+//! `patch_config_report` and `admin_stop_report`, which `service::rpc::admin`
+//! serves over the socket (#6285 slices 5.5 and 5.6).
 //! Test: `logs_tail_returns_recent_lines`, `admin_stop_returns_ok`, and
 //! `patch_config_partial_update` in `super::tests`; the socket halves in
 //! `service::rpc::admin`'s `admin_tests.rs`.
 use axum::{
     body::Body,
     extract::{Query, State},
+    http::StatusCode,
     response::{IntoResponse, Response},
     Json,
 };
@@ -121,20 +122,57 @@ pub(crate) fn logs_tail_report(
 /// shutdown path (drain in-flight requests → flush indexes → delete port file →
 /// release lock) that SIGTERM normally triggers.
 ///
-/// What: sends `true` on `state.shutdown_tx` to wake the `run_daemon` shutdown
-/// future. Returns `{ "ok": true, "message": "shutting down" }` immediately.
-/// Test: `admin_stop_triggers_graceful_shutdown` in `tests_state.rs` verifies
+/// What: delegates to [`admin_stop_report`] and renders its verdict, so the
+/// socket's `search.admin.stop` cannot answer a different thing.
+/// Test: `admin_stop_triggers_graceful_shutdown` in `tests_829.rs` verifies
 /// that the channel fires without calling `process::exit`.
-pub(super) async fn admin_stop_handler(
-    State(state): State<Arc<SearchAppState>>,
-) -> Json<serde_json::Value> {
-    tracing::warn!("admin_stop: graceful shutdown requested via POST /admin/stop");
+pub(super) async fn admin_stop_handler(State(state): State<Arc<SearchAppState>>) -> Response {
+    match admin_stop_report(&state) {
+        Ok(body) => Json(body).into_response(),
+        Err((status, body)) => (status, Json(body)).into_response(),
+    }
+}
+
+/// The shutdown `POST /admin/stop` requests, without the transport (#6285).
+///
+/// Why: `search.admin.stop` is the method trusty-mpm's TUI `[X]` key dials once
+/// the retire slice moves it off HTTP, and stopping a daemon is the one call on
+/// this surface whose answer a caller cannot verify by asking again — the daemon
+/// it would ask is the one that was supposed to go away.
+///
+/// Why it can now refuse: `run_daemon` subscribes to `shutdown_tx` before it
+/// serves and holds the receiver for the daemon's life, so a send that fails
+/// means nothing is driving shutdown and the process will keep running. The
+/// route used to discard that error and answer `ok: true` anyway, which told the
+/// TUI a daemon had stopped when it had not.
+///
+/// # Errors
+///
+/// `503` with `retryable: false` when no shutdown driver is listening. Permanent
+/// because a receiver is subscribed once at boot and never re-subscribed —
+/// retrying answers identically forever, and only a restart clears it.
+///
+/// Test: `admin_stop_over_the_socket_matches_the_http_body`,
+/// `admin_stop_is_refused_on_both_transports_when_nothing_drives_shutdown`.
+pub(crate) fn admin_stop_report(
+    state: &Arc<SearchAppState>,
+) -> Result<serde_json::Value, (StatusCode, serde_json::Value)> {
+    tracing::warn!("admin_stop: graceful shutdown requested");
     // Signal run_daemon to begin the graceful-shutdown sequence (drain
-    // connections → flush indexes → clean up port/lock files). Errors are
-    // ignored: if the receiver has already been dropped (e.g. the daemon is
-    // mid-shutdown already), we still return the success response.
-    let _ = state.shutdown_tx.send(true);
-    Json(serde_json::json!({ "ok": true, "message": "shutting down" }))
+    // connections → flush indexes → clean up port/lock files).
+    if state.shutdown_tx.send(true).is_err() {
+        tracing::error!("admin_stop: no shutdown driver is listening; the daemon keeps running");
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            serde_json::json!({
+                "ok": false,
+                "error": "shutdown_unavailable",
+                "message": "no shutdown driver is listening; the daemon will keep running",
+                "retryable": false,
+            }),
+        ));
+    }
+    Ok(serde_json::json!({ "ok": true, "message": "shutting down" }))
 }
 
 /// Request body for `PATCH /config`. Any field may be omitted to leave that

--- a/crates/trusty-search/src/service/server/mod.rs
+++ b/crates/trusty-search/src/service/server/mod.rs
@@ -228,7 +228,9 @@ pub(crate) use search::{delete_index_report, DeleteIndexParams};
 // #6285 slice 5.5: the four routes with a named consumer that no earlier slice
 // claimed. Same contract as the blocks above; the two config cores are WRITES
 // and carry the slice-4 failure-arm bar with them.
-pub(crate) use admin::{logs_tail_report, patch_config_report, PatchConfigRequest};
+pub(crate) use admin::{
+    admin_stop_report, logs_tail_report, patch_config_report, PatchConfigRequest,
+};
 pub(crate) use index_config::{patch_index_config_report, PatchIndexConfigRequest};
 
 /// Build the axum router with the shared state.

--- a/crates/trusty-search/src/service/server/tests_829.rs
+++ b/crates/trusty-search/src/service/server/tests_829.rs
@@ -8,7 +8,6 @@
 //! Test: `cargo test -p trusty-search -- tests_829` runs all tests in this file.
 use super::*;
 use axum::extract::State;
-use axum::Json;
 use std::sync::Arc;
 
 // ---------------------------------------------------------------------------
@@ -89,9 +88,14 @@ async fn admin_stop_triggers_graceful_shutdown() {
     // Subscribe to the shutdown channel BEFORE calling the handler.
     let mut shutdown_rx = state.shutdown_tx.subscribe();
 
-    let Json(resp) = admin_stop_handler(State(Arc::clone(&state))).await;
+    let resp = admin_stop_handler(State(Arc::clone(&state))).await;
+    assert_eq!(resp.status(), axum::http::StatusCode::OK);
+    let bytes = axum::body::to_bytes(resp.into_body(), 1 << 20)
+        .await
+        .expect("read the body");
+    let body: serde_json::Value = serde_json::from_slice(&bytes).expect("json body");
     assert_eq!(
-        resp.get("ok"),
+        body.get("ok"),
         Some(&serde_json::json!(true)),
         "admin_stop must return ok:true"
     );

--- a/crates/trusty-search/src/service/server/tests_index.rs
+++ b/crates/trusty-search/src/service/server/tests_index.rs
@@ -329,15 +329,20 @@ async fn logs_tail_clamps_n() {
 ///
 /// Why: the response shape `{ ok, message }` is the documented contract
 /// for the admin UI's stop button.
-/// What: calls `admin_stop_handler` and asserts the JSON body. It does
-/// NOT await the spawned exit task — that would terminate the test
-/// process — but the 200 ms delay before `process::exit` guarantees the
-/// test returns first.
+/// What: subscribes to the shutdown channel — which is what `run_daemon` does
+/// before it serves, and what makes the send succeed (#6285 slice 5.6) — then
+/// calls `admin_stop_handler` and asserts the JSON body.
 /// Test: this test.
 #[tokio::test]
 async fn admin_stop_returns_ok() {
     let state = Arc::new(SearchAppState::new(IndexRegistry::new()));
-    let Json(body) = admin_stop_handler(State(state)).await;
+    let _driver = state.shutdown_tx.subscribe();
+    let resp = admin_stop_handler(State(state)).await;
+    assert_eq!(resp.status(), axum::http::StatusCode::OK);
+    let bytes = axum::body::to_bytes(resp.into_body(), 1 << 20)
+        .await
+        .expect("read the body");
+    let body: serde_json::Value = serde_json::from_slice(&bytes).expect("json body");
     assert_eq!(body["ok"], serde_json::Value::Bool(true));
     assert_eq!(body["message"].as_str(), Some("shutting down"));
 }

--- a/crates/trusty-search/src/service/socket.rs
+++ b/crates/trusty-search/src/service/socket.rs
@@ -34,10 +34,11 @@
 //! key (found by PR #6388's implementation pass), and #6155 moves the search UI
 //! — chat panel included — into `trusty-console`, which reaches this daemon over
 //! the socket. Two routes remain deliberately HTTP-only:
-//! `GET /api/chat/providers` is read by the UI shell alone and answers a
-//! question `search.chat`'s own `provider` field already carries per call, and
+//! `GET /api/chat/providers` and `POST /upgrade` are the same bucket: neither
+//! has an observed cross-process caller, only the browser-side UI shell reads
+//! `/api/chat/providers` today, and a method is added when a socket consumer
+//! actually needs one — not preemptively.
 //! `GET /metrics` is Prometheus text, which is HTTP-shaped by nature.
-//! `POST /upgrade` has no observed caller off this box.
 //! `GET /indexes/{id}/communities` is a DEAD route — `trusty-common`'s monitor
 //! calls it and the daemon has never served it — and is a pre-existing bug with
 //! its own ticket, not a gap this surface owes a method for.

--- a/crates/trusty-search/src/service/socket.rs
+++ b/crates/trusty-search/src/service/socket.rs
@@ -23,20 +23,24 @@
 //! | 3 | the QUERY surface — search and its fan-out, grep and its fan-out, similarity, typeahead | landed (PR #6377), in [`crate::service::rpc::queries`] |
 //! | 4 | the WRITE surface — index create, delete, relocate, the two per-file writes, the reindex trigger, contributed-graph ingest | landed (PR #6381), in [`crate::service::rpc::writes`] |
 //! | 5 | the STREAMS — reindex progress and the daemon status stream | landed (PR #6383), in [`crate::service::rpc::streams`] |
-//! | 5.5 | the REMAINDER with a named consumer — the two config writes, the log tail, the registry orphan census — plus the frame-cap raise | this one, in [`crate::service::rpc::admin`] |
+//! | 5.5 | the REMAINDER with a named consumer — the two config writes, the log tail, the registry orphan census — plus the frame-cap raise | landed (PR #6385), in [`crate::service::rpc::admin`] |
+//! | 5.6 | the graceful stop and the chat answer | this one, in [`crate::service::rpc::admin`] and [`crate::service::rpc::chat`] |
 //! | consumer wave | move the eleven dialling crates onto these names, one PR per crate | not started |
 //! | retire | delete the axum surface, `ui.rs`, and the `http_addr` writer | not started, gated on the consumer wave |
 //!
-//! **Slice 5.5 closes the method gap, not the migration.** Every HTTP route with
-//! a consumer outside this crate now has a method here, which is the
-//! precondition the consumer wave needs and did not have. Four routes are
-//! deliberately still HTTP-only: `POST /admin/stop`, `POST /upgrade`,
-//! `POST /chat` and `GET /api/chat/providers` have no observed external caller
-//! (chat serves the embedded `/ui` alone), and `GET /metrics` is Prometheus
-//! text, which is HTTP-shaped by nature. `GET /indexes/{id}/communities` is a
-//! DEAD route — `trusty-common`'s monitor calls it and the daemon has never
-//! served it — and is a pre-existing bug with its own ticket, not a gap this
-//! surface owes a method for.
+//! **Slice 5.6 closes the last two gaps a consumer named.** Slice 5.5 read
+//! `POST /admin/stop` and `POST /chat` as having no external caller; both
+//! readings were wrong. trusty-mpm's TUI drives the stop route from its `[X]`
+//! key (found by PR #6388's implementation pass), and #6155 moves the search UI
+//! — chat panel included — into `trusty-console`, which reaches this daemon over
+//! the socket. Two routes remain deliberately HTTP-only:
+//! `GET /api/chat/providers` is read by the UI shell alone and answers a
+//! question `search.chat`'s own `provider` field already carries per call, and
+//! `GET /metrics` is Prometheus text, which is HTTP-shaped by nature.
+//! `POST /upgrade` has no observed caller off this box.
+//! `GET /indexes/{id}/communities` is a DEAD route — `trusty-common`'s monitor
+//! calls it and the daemon has never served it — and is a pre-existing bug with
+//! its own ticket, not a gap this surface owes a method for.
 //!
 //! **Two doors, one daemon.** The socket serves the same `Arc<SearchAppState>`
 //! the axum router was built on — see
@@ -61,7 +65,7 @@ use serde::{Deserialize, Serialize};
 use tokio::net::UnixListener;
 use trusty_common::uds::server::{serve_until, RpcRouter, RpcServeOptions};
 
-use crate::service::rpc::{admin, queries, reads, streams, writes};
+use crate::service::rpc::{admin, chat, queries, reads, streams, writes};
 use crate::service::server::SearchAppState;
 
 #[cfg(test)]
@@ -127,6 +131,10 @@ pub const METHODS: &[&str] = &[
     admin::METHOD_CONFIG_SET,
     admin::METHOD_LOGS_TAIL,
     admin::METHOD_REGISTRY_ORPHANS,
+    // #6285 slice 5.6 — the last two routes with a consumer: the TUI's stop key
+    // and the search UI's chat panel. Both unary, both in the free lane.
+    admin::METHOD_ADMIN_STOP,
+    chat::METHOD_CHAT,
 ];
 
 /// The params of a method that takes no arguments.
@@ -198,6 +206,7 @@ fn build_router(state: &Arc<SearchAppState>) -> RpcRouter {
     let router = queries::register(router, state);
     let router = writes::register(router, state);
     let router = admin::register(router, state);
+    let router = chat::register(router, state);
     streams::register(router, state)
 }
 

--- a/crates/trusty-search/src/service/ui.rs
+++ b/crates/trusty-search/src/service/ui.rs
@@ -205,16 +205,56 @@ pub struct ChatMessage {
     pub content: String,
 }
 
+/// `POST /chat` — answer one grounded question, as a single JSON envelope.
+///
+/// Delegates to [`chat_report`] so `search.chat` cannot answer differently.
 pub async fn chat_handler(
     State(state): State<Arc<SearchAppState>>,
     Json(req): Json<ChatRequest>,
 ) -> Response {
+    match chat_report(&state, req).await {
+        Ok(body) => Json(body).into_response(),
+        Err((status, body)) => (status, Json(body)).into_response(),
+    }
+}
+
+/// The answer `POST /chat` serves, without the transport (#6285 slice 5.6).
+///
+/// Why: `search.chat` is the method the search UI dials once #6155 moves it into
+/// `trusty-console`, and the retire slice deletes the route this would otherwise
+/// be compared against. The provider resolution is the part that must not be
+/// re-implemented: it decides between the auto-detected local provider, a
+/// per-request `api_key`, and the daemon's env-configured OpenRouter key, and a
+/// second copy would let the two transports pick different providers for the
+/// same request.
+///
+/// What: resolves the provider, searches `index_id` for grounding context,
+/// streams the completion, and collects the deltas into the one envelope both
+/// transports return — `{reply, answer, sources, model, provider}`. The stream
+/// is internal on both doors: HTTP never streamed this route, so neither does
+/// the socket (#6285 slice 5's streaming pair is reindex progress and the daemon
+/// status feed, not this).
+///
+/// # Errors
+///
+/// `400` when neither `message` nor `question` carried text; `503` when no
+/// provider is configured at all; `502` when the provider failed or the stream
+/// reported an error; `500` when the collector task could not be joined. A
+/// search that fails is NOT an error — the question is answered without
+/// grounding context, exactly as the route always did.
+///
+/// Test: `chat_over_the_socket_matches_the_http_body`,
+/// `an_empty_message_is_refused_identically_on_both_transports`,
+/// `chat_without_a_provider_is_refused_identically_on_both_transports`.
+pub(crate) async fn chat_report(
+    state: &Arc<SearchAppState>,
+    req: ChatRequest,
+) -> Result<serde_json::Value, (StatusCode, serde_json::Value)> {
     if req.message.is_empty() {
-        return (
+        return Err((
             StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({"error": "message (or question) is required"})),
-        )
-            .into_response();
+            serde_json::json!({"error": "message (or question) is required"}),
+        ));
     }
 
     let top_k = req.top_k.unwrap_or(5).max(1);
@@ -236,13 +276,12 @@ pub async fn chat_handler(
                 }
             });
             let Some(api_key) = api_key else {
-                return (
+                return Err((
                     StatusCode::SERVICE_UNAVAILABLE,
-                    Json(serde_json::json!({
+                    serde_json::json!({
                         "error": "no chat provider available: start a local model server (Ollama / LM Studio) or set OPENROUTER_API_KEY",
-                    })),
-                )
-                    .into_response();
+                    }),
+                ));
             };
             let model = req
                 .model
@@ -323,37 +362,33 @@ pub async fn chat_handler(
     match stream_task.await {
         Ok(Ok(())) => {}
         Ok(Err(e)) => {
-            return (
+            return Err((
                 StatusCode::BAD_GATEWAY,
-                Json(serde_json::json!({"error": format!("{}: {e}", provider.name())})),
-            )
-                .into_response();
+                serde_json::json!({"error": format!("{}: {e}", provider.name())}),
+            ));
         }
         Err(e) => {
-            return (
+            return Err((
                 StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({"error": format!("chat task join: {e}")})),
-            )
-                .into_response();
+                serde_json::json!({"error": format!("chat task join: {e}")}),
+            ));
         }
     }
     if let Some(e) = stream_error {
-        return (
+        return Err((
             StatusCode::BAD_GATEWAY,
-            Json(serde_json::json!({"error": format!("{}: {e}", provider.name())})),
-        )
-            .into_response();
+            serde_json::json!({"error": format!("{}: {e}", provider.name())}),
+        ));
     }
 
     let model = provider.model().to_string();
-    Json(serde_json::json!({
+    Ok(serde_json::json!({
         "reply": reply,
         "answer": reply,
         "sources": sources,
         "model": model,
         "provider": provider.name(),
     }))
-    .into_response()
 }
 
 /// GET /api/chat/providers — report provider availability + active choice.

--- a/crates/trusty-search/src/service/ui.rs
+++ b/crates/trusty-search/src/service/ui.rs
@@ -243,9 +243,9 @@ pub async fn chat_handler(
 /// search that fails is NOT an error — the question is answered without
 /// grounding context, exactly as the route always did.
 ///
-/// Test: `chat_over_the_socket_matches_the_http_body`,
-/// `an_empty_message_is_refused_identically_on_both_transports`,
-/// `chat_without_a_provider_is_refused_identically_on_both_transports`.
+/// Test: `an_empty_message_is_refused_identically_on_both_transports`,
+/// `chat_without_a_provider_is_refused_identically_on_both_transports`,
+/// `the_question_alias_decodes_on_both_transports`.
 pub(crate) async fn chat_report(
     state: &Arc<SearchAppState>,
     req: ChatRequest,


### PR DESCRIPTION
Slice 5.6 of #6285. Adds the last two RPC methods with a named consumer:
`search.chat` (`POST /chat`) and `search.admin.stop` (`POST /admin/stop`).
Slice 5.5 recorded both routes as having no external caller — PR #6388's
implementation pass found trusty-mpm's TUI driving the stop route, and #6155
moves the chat panel into trusty-console.

Each HTTP handler is now a thin wrapper over a transport-free core the socket
method runs unchanged (`chat_report`, `admin_stop_report`), the same shape
slices 2–5.5 used.

`search.chat` is unary: `POST /chat` streams from the provider internally and
answers one JSON envelope. Registering it as a stream would give the socket a
shape HTTP has never had.

Behaviour change, called out: `POST /admin/stop` now answers `503
shutdown_unavailable` (`retryable: false`, `CODE_UNAVAILABLE_PERMANENT`) when
no shutdown driver is subscribed, instead of `ok: true` for a daemon that keeps
running. `run_daemon` subscribes before it serves, so a live daemon is
unaffected.

## Test rung

Rung 3 — localized behaviour inside `trusty-search`.

```
cargo fmt --check                                       # clean
cargo clippy -p trusty-search --all-targets -- -D warnings   # clean
cargo test -p trusty-search --no-fail-fast
```

34 test targets, `--no-fail-fast`: 2414 passed, 0 failed, 1 ignored (the
`#[ignore]`d ONNX case). New cases, all green:

- `admin_stop_over_the_socket_matches_the_http_body`
- `admin_stop_is_refused_on_both_transports_when_nothing_drives_shutdown` (the
  failure arm: asserts the refusal on both doors AND that the shutdown flag did
  not move)
- `an_empty_message_is_refused_identically_on_both_transports`
- `chat_without_a_provider_is_refused_identically_on_both_transports`
- `the_question_alias_decodes_on_both_transports`
- `chat_is_a_unary_method_and_not_a_stream`

`lanes_tests::every_socket_method_declares_a_lane` covers both new methods; both
are pinned to the free lane, matching their HTTP route group.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
