### PR TITLE
docs: resolve 13 rustdoc intra-doc links; bump trusty-installer to 0.13.2 (Refs #6285)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11611,7 +11611,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-installer"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-audit/changelog.d/6285-rustdoc-link-fix.md
+++ b/crates/trusty-audit/changelog.d/6285-rustdoc-link-fix.md
@@ -1,0 +1,5 @@
+Fixed
+
+- Resolved a broken rustdoc intra-doc link in `grounding::search_rpc` (a bare
+  `[`Display`]` now points at `std::fmt::Display`), unblocking the rustdoc
+  intra-doc-link publish gate. No behavior change (#6285).

--- a/crates/trusty-audit/src/grounding/search_rpc.rs
+++ b/crates/trusty-audit/src/grounding/search_rpc.rs
@@ -122,8 +122,8 @@ impl SearchRpcFailure {
     /// True when the daemon ANSWERED and refused, rather than not answering.
     ///
     /// Why: a future caller that must not act on silence needs this
-    /// distinction, and a string comparison against [`Display`] would be a
-    /// second contract. `root_matches` (see [`super::index`]) does not call
+    /// distinction, and a string comparison against [`std::fmt::Display`]
+    /// would be a second contract. `root_matches` (see [`super::index`]) does not call
     /// this — it discards the `Result` and stays fail-open on every variant
     /// by design, so today this is exercised only by its own tests.
     /// Test: `search_rpc_tests::a_dead_socket_is_unreachable_not_a_refusal`.

--- a/crates/trusty-installer/Cargo.toml
+++ b/crates/trusty-installer/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "trusty-installer"
-# 0.13.1 (#6285): patch — 0.13.0 is published and this PR edits `src/**`,
-# moving the trusty-search health probe onto `search.health` over UDS. Additive
-# on the public surface (`probe_http::dual_transport`); `fixed_port_for` and
-# `uds_socket_for` keep their signatures.
-version = "0.13.1"
+# 0.13.2 (#6285): patch — the `trusty-installer-v0.13.1` tag is stranded at a
+# commit that cannot pass the rustdoc intra-doc-link gate, and release tags
+# are immutable here, so 0.13.1 is spent. No code change; version bump only to
+# free a publishable tag.
+version = "0.13.2"
 edition = "2021"
 description = "Thin control plane for the claude-mpm stack: install, upgrade, restart, health, and config coordination across all trusty-* tools."
 readme = "README.md"

--- a/crates/trusty-installer/changelog.d/6285-version-0132.md
+++ b/crates/trusty-installer/changelog.d/6285-version-0132.md
@@ -1,0 +1,5 @@
+Changed
+
+- Bumped version to 0.13.2 to replace the stranded `trusty-installer-v0.13.1`
+  tag, which was cut at a commit that cannot pass the rustdoc intra-doc-link
+  publish gate. No code change (#6285).

--- a/crates/trusty-search/changelog.d/6285-rustdoc-link-fix.md
+++ b/crates/trusty-search/changelog.d/6285-rustdoc-link-fix.md
@@ -1,0 +1,8 @@
+Fixed
+
+- Resolved 12 broken rustdoc intra-doc links in `service::rpc`'s module-level
+  docs (`queries`, `writes`, `streams`, `chat`) — private helper names (`guarded`,
+  `bulk_guarded`, `unguarded`) are now plain code spans rather than dead links,
+  and public items (`register`, `IndexBody`, `SearchAppState`, `METHOD_CHAT`)
+  resolve through fully-qualified reference-style links — unblocking the
+  rustdoc intra-doc-link publish gate. No behavior change (#6285).

--- a/crates/trusty-search/src/service/rpc/chat.rs
+++ b/crates/trusty-search/src/service/rpc/chat.rs
@@ -40,6 +40,7 @@
 //!
 //! [`chat_report`]: crate::service::ui::chat_report
 //! [`register`]: crate::service::rpc::chat::register
+//! [`METHOD_CHAT`]: crate::service::rpc::chat::METHOD_CHAT
 
 use std::sync::Arc;
 

--- a/crates/trusty-search/src/service/rpc/queries.rs
+++ b/crates/trusty-search/src/service/rpc/queries.rs
@@ -7,7 +7,7 @@
 //! way to reach the same body until the retire slice.
 //!
 //! What: the method-to-route table below, the params each method decodes,
-//! [`guarded`], and [`register`].
+//! `guarded`, and [`register`].
 //!
 //! ## Method → route
 //!
@@ -43,7 +43,7 @@
 //! `interactive_limited` group: admission-limited (#2845) and bounded by the
 //! interactive query deadline (#907). Both live on [`SearchAppState`] so the
 //! socket gates on the SAME semaphore and the SAME deadline rather than a
-//! second copy of each — see [`guarded`].
+//! second copy of each — see `guarded`.
 //!
 //! ## One limit that does NOT match HTTP yet
 //!
@@ -59,6 +59,10 @@
 //! Test: `queries_tests.rs` — one `*_over_the_socket_matches_the_http_body` per
 //! family, driving the real axum router and the real RPC router against one
 //! shared state, over an index holding a real corpus.
+//!
+//! [`register`]: crate::service::rpc::queries::register
+//! [`IndexBody`]: crate::service::rpc::queries::IndexBody
+//! [`SearchAppState`]: crate::service::SearchAppState
 
 use std::sync::Arc;
 

--- a/crates/trusty-search/src/service/rpc/streams.rs
+++ b/crates/trusty-search/src/service/rpc/streams.rs
@@ -101,6 +101,8 @@
 //! is still parked.
 //!
 //! Test: `streams_tests.rs`.
+//!
+//! [`register`]: crate::service::rpc::streams::register
 
 use std::sync::Arc;
 

--- a/crates/trusty-search/src/service/rpc/writes.rs
+++ b/crates/trusty-search/src/service/rpc/writes.rs
@@ -8,7 +8,7 @@
 //! slice.
 //!
 //! What: the method-to-route table below, the params each method decodes, the
-//! two lane wrappers ([`bulk_guarded`] and [`unguarded`]), and [`register`].
+//! two lane wrappers (`bulk_guarded` and `unguarded`), and [`register`].
 //!
 //! ## Method → route
 //!
@@ -31,8 +31,8 @@
 //! seven land in two of them. The four per-index writes are `bulk_limited`:
 //! admission-limited on the SAME `SearchAppState` semaphore the query surface
 //! uses, and deliberately NOT deadline-bounded, because a reindex or an ingest
-//! can legitimately run for minutes ([`bulk_guarded`]). The three registry-level
-//! routes are in `free`: no limiter and no deadline at all ([`unguarded`]).
+//! can legitimately run for minutes (`bulk_guarded`). The three registry-level
+//! routes are in `free`: no limiter and no deadline at all (`unguarded`).
 //!
 //! That asymmetry is copied, not invented. Slice 3 put the whole query family
 //! behind one wrapper because axum puts the whole query family behind one
@@ -74,6 +74,8 @@
 //! Test: `writes_tests.rs` — one `*_over_the_socket_matches_the_http_body` per
 //! family plus, for every mutating core, a failure arm proving the refusal is
 //! identical AND that registry / on-disk state did not advance behind it.
+//!
+//! [`register`]: crate::service::rpc::writes::register
 
 use std::sync::Arc;
 


### PR DESCRIPTION
Refs #6285. Unblocks the trusty-tools publish train: main (65ecefc6b) fails the pre-publish gate's rustdoc intra-doc-link ratchet (Gate 1, `scripts/check_rustdoc_links.sh`) with 13 broken links against baseline 0.

## Fixes
- `crates/trusty-audit/src/grounding/search_rpc.rs:125` — qualified `[`Display`]` to `[`std::fmt::Display`]`.
- `crates/trusty-search/src/service/rpc/{queries,writes,streams,chat}.rs` — 12 links in module-level `//!` docs. Private helpers (`guarded`, `bulk_guarded`, `unguarded`) demoted to plain code spans (not part of the public doc surface). Public items (`register`, `IndexBody`, `SearchAppState`, `METHOD_CHAT`) fixed with fully-qualified reference-style link definitions (`[`x`]: crate::path::x`), matching the pattern already used in `admin.rs`/`chat.rs` — bare same-module names don't resolve from these merged outer+inner module docs, but absolute `crate::` paths do.
- `crates/trusty-installer/Cargo.toml` — version 0.13.1 → 0.13.2. The `trusty-installer-v0.13.1` tag is stranded at a commit that cannot pass this gate, and release tags are immutable here, so 0.13.1 is spent. No code change; `Cargo.lock` updated via `cargo update -p trusty-installer`.
- Changelog fragments added for all three crates.

No baseline rows added — all three crates now examine at 0 broken links.

## Verification
- `SKIP_UI_BUILD=1 bash scripts/check_rustdoc_links.sh`: `SUMMARY 26 crate(s) examined by rustdoc, 0 broken link(s), baseline 0, 0 diagnostic(s) examined` (exit 0)
- `cargo fmt --check`: exit 0
- `cargo check -p trusty-audit -p trusty-search -p trusty-installer`: exit 0
- `bash scripts/check_changelog_fragment.sh`: exit 0

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools