### PR TITLE
fix(trusty-memory): forward palace_verify_embedded and palace_embed_sweep over raw RPC (Refs #5044)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11673,7 +11673,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-memory"
-version = "0.25.3"
+version = "0.25.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-memory/Cargo.toml
+++ b/crates/trusty-memory/Cargo.toml
@@ -15,7 +15,10 @@ name = "trusty-memory"
 # disk rather than only the cache-resident ones, and carries room counts.
 # Additive payload fields and metrics_schema_version 3. No public item was
 # removed or changed.
-version = "0.25.3"
+# 0.25.4 (#5044): patch — TOOL_METHODS allowlist forwards
+# palace_verify_embedded and palace_embed_sweep over raw RPC. No public item
+# was removed or changed.
+version = "0.25.4"
 edition = "2021"
 description = "MCP server (stdio + Unix socket) for trusty-memory"
 license.workspace = true

--- a/crates/trusty-memory/changelog.d/5044-tool-methods-allowlist.md
+++ b/crates/trusty-memory/changelog.d/5044-tool-methods-allowlist.md
@@ -1,0 +1,2 @@
+Fixed
+- Raw JSON-RPC callers can reach `palace_verify_embedded` and `palace_embed_sweep` again. Both were registered in `tools/list` but missing from the `TOOL_METHODS` allowlist, so a bare-method call — the path `tm memory import --refresh` takes — answered `Method not found (-32601)` while `tools/call` served the same tool. A new test partitions every registered tool across the allowlist and an explicit unforwarded list, so the next added tool cannot drift the same way (#5044).

--- a/crates/trusty-memory/src/transport/rpc.rs
+++ b/crates/trusty-memory/src/transport/rpc.rs
@@ -185,7 +185,9 @@ impl JsonRpcResponse {
 /// What: a sorted, exhaustive list of every method name routed through
 /// `dispatch_tool`. Adding a tool requires extending this constant.
 /// Test: `dispatch_palace_list_returns_empty_array_initially` confirms
-/// the forwarding works end-to-end.
+/// the forwarding works end-to-end;
+/// `every_registered_tool_is_forwarded_or_listed_unforwarded` holds this
+/// constant exhaustive over the tool registry.
 const TOOL_METHODS: &[&str] = &[
     "add_alias",
     "console_metrics",
@@ -206,10 +208,14 @@ const TOOL_METHODS: &[&str] = &[
     "memory_send_message",
     "palace_compact",
     "palace_create",
+    // #5044: `tm memory import --refresh` calls `palace_verify_embedded` by raw
+    // name and got -32601 — #6328 registered both tools but not here.
+    "palace_embed_sweep",
     "palace_info",
     "palace_list",
     "palace_reembed",
     "palace_unalias",
+    "palace_verify_embedded",
     "remove_prompt_fact",
 ];
 
@@ -515,6 +521,133 @@ mod tests {
             PROTOCOL_METHODS.len() + TOOL_METHODS.len(),
             "every protocol arm and every tool method, and nothing twice"
         );
+    }
+
+    /// Registry tools the raw-JSON-RPC path does not forward.
+    ///
+    /// Why: `TOOL_METHODS` is an allowlist, so a tool added to the registry and
+    /// nowhere else is unreachable by raw name with nothing saying so — #5044,
+    /// where `tm memory import --refresh` got -32601 for
+    /// `palace_verify_embedded` while `tools/call` reached the same tool. Paired
+    /// with `TOOL_METHODS` this list is exhaustive over the registry, so a new
+    /// tool has to be entered in one of the two.
+    /// What: names `tools/list` publishes and `TOOL_METHODS` omits. A row
+    /// records that the omission was seen; it is not a claim that the tool
+    /// should stay off the raw path. `chat_*` is the one omission with a
+    /// documented reason — see `uds_consumer_contract.rs`.
+    /// Test: `every_registered_tool_is_forwarded_or_listed_unforwarded`.
+    const UNFORWARDED_TOOLS: &[&str] = &[
+        "chat_session_add_turn",
+        "chat_session_create",
+        "chat_session_delete",
+        "chat_session_get",
+        "chat_session_list",
+        "chat_session_recall",
+        "chat_turn_append",
+        "dream_consolidate_room",
+        "kg_list_subjects",
+        "kg_retract_triple",
+        "palace_delete",
+        "palace_dream",
+        "palace_update",
+        "room_create",
+        "room_list",
+        "room_rename",
+        "task_add",
+        "task_complete",
+        "task_list",
+        "upgrade",
+        "wing_create",
+        "wing_list",
+        "wing_rename",
+    ];
+
+    /// Why: #5044. #6328 registered `palace_verify_embedded` and
+    /// `palace_embed_sweep` in `tools/list` but left `TOOL_METHODS` alone, so
+    /// every raw-name caller of either got `Method not found (-32601)` from a
+    /// daemon whose `tools/call` path served them fine. Nothing compared the two
+    /// surfaces, so the drift only showed up in a live run. This compares them.
+    /// What: partitions every name `tool_definitions` publishes across
+    /// `TOOL_METHODS` and `UNFORWARDED_TOOLS`, and fails on a name in neither,
+    /// a name in both, or a row in either naming a tool the registry no longer
+    /// has.
+    /// Test: this is the test.
+    #[test]
+    fn every_registered_tool_is_forwarded_or_listed_unforwarded() {
+        let defs = crate::tools::tool_definitions();
+        let registered: Vec<&str> = defs["tools"]
+            .as_array()
+            .expect("tools/list payload carries a `tools` array")
+            .iter()
+            .map(|tool| tool["name"].as_str().expect("every tool has a name"))
+            .collect();
+        assert!(
+            !registered.is_empty(),
+            "an empty registry would make this test vacuous"
+        );
+
+        let unclassified: Vec<&&str> = registered
+            .iter()
+            .filter(|name| !TOOL_METHODS.contains(*name) && !UNFORWARDED_TOOLS.contains(*name))
+            .collect();
+        assert!(
+            unclassified.is_empty(),
+            "registered but in neither list, so raw-name callers get -32601 with \
+             nothing saying so (#5044): {unclassified:?} — add each to TOOL_METHODS \
+             to forward it, or to UNFORWARDED_TOOLS to record that it is not"
+        );
+
+        let both: Vec<&&str> = TOOL_METHODS
+            .iter()
+            .filter(|name| UNFORWARDED_TOOLS.contains(*name))
+            .collect();
+        assert!(
+            both.is_empty(),
+            "listed as forwarded and unforwarded: {both:?}"
+        );
+
+        let stale: Vec<&&str> = TOOL_METHODS
+            .iter()
+            .chain(UNFORWARDED_TOOLS)
+            .filter(|name| !registered.contains(*name))
+            .collect();
+        assert!(
+            stale.is_empty(),
+            "named here but absent from the registry, so the row can no longer \
+             be dispatched: {stale:?}"
+        );
+    }
+
+    /// Why: #5044's live symptom, at the seam that produced it —
+    /// `trusty_common::memory_rpc::call_memory_tool_at` sends the bare tool name
+    /// as the JSON-RPC method, which is the path `tm memory import --refresh`
+    /// takes. `every_registered_tool_is_forwarded_or_listed_unforwarded` guards
+    /// the constant; this proves the two names actually reach `dispatch_tool`.
+    /// What: dispatches both by raw name against a fresh state and asserts
+    /// neither answers `METHOD_NOT_FOUND`. An argument-level error still proves
+    /// the routing, exactly as in `method_names_covers_every_dispatched_arm`.
+    /// Test: this is the test.
+    #[tokio::test]
+    async fn dispatch_forwards_the_embed_audit_tools_by_raw_name() {
+        let state = test_state();
+        for method in ["palace_verify_embedded", "palace_embed_sweep"] {
+            let req = JsonRpcRequest {
+                jsonrpc: Some("2.0".to_string()),
+                id: Some(json!(1)),
+                method: method.to_string(),
+                params: Some(json!({})),
+            };
+            let resp = dispatch(&state, req).await;
+            if let Some(error) = resp.error {
+                assert_ne!(
+                    error.code,
+                    error_codes::METHOD_NOT_FOUND,
+                    "{method} is registered in tools/list but the raw-name path \
+                     refuses it: {}",
+                    error.message
+                );
+            }
+        }
     }
 
     /// Why: spec compliance — unknown methods must return -32601.


### PR DESCRIPTION
`TOOL_METHODS` in `crates/trusty-memory/src/transport/rpc.rs` is the allowlist the raw-JSON-RPC dispatch fallback forwards. #6328 added `palace_verify_embedded` and `palace_embed_sweep` to the tool registry but not to it.

Live repro on installed trusty-memory 0.25.3 — `tm memory import --refresh` calls `palace_verify_embedded` by raw name through `trusty_common::memory_rpc::call_memory_tool_at`:

```
Method not found: palace_verify_embedded (-32601)
```

The same tool answered fine through the MCP `tools/call` envelope, which is why nothing caught it before a live run.

Both names are added. `every_registered_tool_is_forwarded_or_listed_unforwarded` now partitions every name `tool_definitions` publishes across `TOOL_METHODS` and a new `UNFORWARDED_TOOLS` list, so the next added tool has to be entered in one of the two. Against the pre-fix constant it fails with `["palace_verify_embedded", "palace_embed_sweep"]`, and `dispatch_forwards_the_embed_audit_tools_by_raw_name` fails with the -32601 above.

Rung 3 — localized behavior inside one crate.

```
cargo fmt --check                                       # EXIT=0
cargo clippy -p trusty-memory --all-targets -- -D warnings   # EXIT=0
cargo test -p trusty-memory --no-fail-fast              # EXIT=0
```

31 targets, 942 passed, 0 failed, 14 ignored.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
