### PR TITLE
chore(trusty-code-tui): publish the crate to unblock trusty-code (Refs #4713)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,8 @@ authors = ["Bob Matsuoka <bob@matsuoka.com>"]
 trusty-code = { path = "crates/trusty-code", version = "0.4.0" }
 # trusty-code-tui: engine-agnostic terminal-UI seam (`TuiEngine` trait + `ReplEvent`)
 # shared by trusty-code's `tcode tui` and trusty-agents' tagent REPL (DOC-50,
-# epic #3411). Not yet published (Slice 1, #3425).
+# epic #3411). Published as of #4713 so `trusty-code` can publish again; 0.1.0
+# is the first upload.
 trusty-code-tui = { path = "crates/trusty-code-tui", version = "0.1.0" }
 trusty-agents-common = { path = "crates/trusty-agents-common", version = "0.6.0" }
 trusty-common = { path = "crates/trusty-common", version = "0.45" }

--- a/crates/trusty-code-tui/Cargo.toml
+++ b/crates/trusty-code-tui/Cargo.toml
@@ -10,33 +10,18 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
-# NOT PUBLISHED, and deliberately so. This crate has never been uploaded to
-# crates.io and it is still Slice 1 scaffold, so claiming the permanent
-# `trusty-code-tui` name for a seam whose shape is still moving buys nothing and
-# cannot be undone — a crates.io name is never released back.
+readme = "README.md"
+# #4713: this crate is published. `trusty-code` depends on it from production
+# code (`src/cli/tui.rs`, `src/tui_client/`), and `cargo publish` refuses a
+# crate whose non-dev dependency is unpublishable — so the earlier
+# `publish = false` here is what held `trusty-code` at 0.2.0 on crates.io while
+# the tree moved to 0.4.0. The owner decided to publish rather than vendor the
+# seam or freeze the registry copy. 0.1.0 is the first upload; no
+# `trusty-code-tui-v*` tag exists yet.
 #
-# THE COST, STATED PLAINLY. `cargo publish` requires a `version` on every
-# non-dev dependency and refuses a crate that depends on an unpublishable one.
-# `trusty-code` depends on this crate from PRODUCTION code (`src/cli/tui.rs`
-# and the whole `src/tui_client/` adapter), not from tests, so this line is
-# what keeps `trusty-code` unpublishable. That is a disclosure, not a
-# regression: `trusty-code` 0.3.0 already cannot publish, because `trusty-code-tui`
-# 0.1.0 does not exist on crates.io for its `version = "0.1.0"` requirement to
-# resolve against. `trusty-code` 0.1.0 and 0.2.0 are live on crates.io and
-# stay live; neither declared this dependency.
-#
-# Publishing `trusty-code` again therefore needs a decision this line does not
-# make: publish `trusty-code-tui` after all, vendor the seam into `trusty-code`, or
-# leave `trusty-code` at 0.2.0 on the registry. Moving the dependency to
-# `[dev-dependencies]` is NOT among the options — dev-dependencies need no
-# version to publish, but the usage here is production.
-publish = false
-# Slice 1 (#3412, epic #3411, DOC-50 §3.1/§5 Slice 1): scaffold only — the
-# `TuiEngine` trait and `ReplEvent` enum that let one TUI drive both tagent
-# and tcode. Deliberately dependency-minimal: no ratatui/crossterm yet (that
-# terminal layer + the ratatui-0.30 decision are Slice 2, #3414). This crate
-# will grow the event loop, widgets, and layout in later slices per DOC-50
-# §3.1 and §5.
+# `trusty-code-tui` (#3412, epic #3411, DOC-50 §3.1/§5): the `TuiEngine` trait
+# and `ReplEvent` enum that let one TUI drive both tagent and tcode, plus the
+# terminal layer, event loop, widgets, and layout added in later slices.
 
 [dependencies]
 async-trait = { workspace = true }

--- a/crates/trusty-code-tui/LICENSE
+++ b/crates/trusty-code-tui/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Bob Matsuoka
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/trusty-code-tui/README.md
+++ b/crates/trusty-code-tui/README.md
@@ -1,0 +1,40 @@
+# trusty-code-tui
+
+The engine-agnostic terminal-UI seam shared by trusty-code's `tcode tui` and
+trusty-agents' tagent REPL.
+
+Both products need the same ratatui event loop, widgets, and line editing.
+Forking one for the other would duplicate that code and let the two drift, so
+it lives here once and each product supplies a thin `TuiEngine` adapter.
+
+## What's here
+
+| Module | Surface |
+|---|---|
+| `engine` | `TuiEngine` — the trait a product implements to drive the shared loop |
+| `event` | `ReplEvent` — the event vocabulary the engine and the loop speak; no terminal-library dependency |
+| `model` | `StatuslineSegment`, `PickerItem`/`PickerRequest`, `CommandDescriptor` — engine-supplied data, so no product constant is hardcoded here |
+| `terminal` | `TerminalGuard` — panic-safe raw-mode/alternate-screen entry and exit |
+| `run` | The render/event loop, generic over `TuiEngine` |
+| `keys` | `crossterm` → `KeyInput` translation |
+| `app`, `widgets`, `render`, `layout` | The reducer model, the widgets that draw it, markdown rendering, and frame composition |
+| `commands` | The slash-command parser: `/help`, `/clear`, `/quit`, `/exit` are client-side built-ins; every other command forwards verbatim to the engine |
+
+## Dependency direction
+
+`trusty-code` and `trusty-agents` depend on `trusty-code-tui`;
+`trusty-code-tui` depends on neither. Its public API never references a
+product-specific type.
+
+`ratatui` 0.30 / `crossterm` 0.29 are confined to `terminal`, `run`, and
+`keys`. They diverge from the rest of the workspace's 0.29/0.28 pin during the
+tagent migration window — see the comment in `Cargo.toml`.
+
+## Design
+
+DOC-50 (`docs/specs/DOC-50-tcode-tui-claude-code-clone.md`) §2.2 and §5, epic
+[#3411](https://github.com/bobmatnyc/trusty-tools/issues/3411).
+
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/crates/trusty-code-tui/changelog.d/4713-publish-the-crate.md
+++ b/crates/trusty-code-tui/changelog.d/4713-publish-the-crate.md
@@ -1,0 +1,11 @@
+Changed
+- The crate is now published to crates.io: `publish = false` is removed and
+  0.1.0 becomes the first upload (#4713). `trusty-code` depends on this crate
+  from production code, and `cargo publish` refuses a crate whose non-dev
+  dependency is unpublishable, so that line is what held `trusty-code` at 0.2.0
+  on the registry while the tree moved to 0.4.0. The owner decided to publish
+  rather than vendor the seam or freeze the registry copy.
+- Added a `README.md` (with `readme = "README.md"` in the manifest) and an
+  in-crate MIT `LICENSE`, matching how `trusty-code` and `trusty-mcp` ship.
+  The license declaration itself is unchanged — `license.workspace = true`,
+  which resolves to MIT.


### PR DESCRIPTION
Owner decision: publish `trusty-code-tui` rather than vendor the seam into `trusty-code` or leave `trusty-code` frozen at 0.2.0 on crates.io. `trusty-code` depends on this crate from production code, and `cargo publish` refuses a crate whose non-dev dependency is unpublishable, so `publish = false` is what held the registry at 0.2.0 while the tree moved to 0.4.0. See #4713.

Removes `publish = false`; adds `readme = "README.md"`, a `README.md`, and an in-crate MIT `LICENSE`. The license declaration is unchanged — `license.workspace = true` already resolved to MIT, matching `trusty-code`.

**Dependency closure:** `trusty-code-tui` has no workspace-internal dependencies. Its deps are async-trait, tokio, serde, serde_json, anyhow, tracing, ratatui 0.30, crossterm 0.29 — all live on crates.io. Nothing further is chained.

**Version:** 0.1.0, first upload. The `trusty-code-tui` name is free on crates.io and no `trusty-code-tui-v*` tag exists.

## Gates

```
cargo publish --dry-run -p trusty-code-tui        EXIT=0
    Packaged 35 files, 395.8KiB (112.1KiB compressed)
    Uploading trusty-code-tui v0.1.0
    warning: aborting upload due to dry run

cargo publish --dry-run -p trusty-code            EXIT=101 (expected)
    error: failed to prepare local package for uploading
    Caused by:
      no matching package named `trusty-code-tui` found
      location searched: crates.io index

cargo fmt --check                                 EXIT=0
cargo check -p trusty-code-tui -p trusty-code     EXIT=0
bash scripts/check_changelog_fragment.sh          EXIT=0
bash scripts/check_line_cap.sh                    EXIT=0
bash scripts/check_sld.sh                         EXIT=0
```

The `trusty-code` dry run fails on registry absence alone — the version spec resolves and no other dependency blocks it. It clears once `trusty-code-tui` 0.1.0 is uploaded.

Test ladder rung 1: manifest, README, LICENSE, and changelog fragment only; no `src/**` change.

Refs #4713

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools