### PR TITLE
fix(trusty-common): remove dead /indexes/:id/communities client call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11503,6 +11503,7 @@ dependencies = [
  "unicode-normalization",
  "uuid",
  "walkdir",
+ "wiremock",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11425,7 +11425,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-common"
-version = "0.45.5"
+version = "0.45.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -310,6 +310,10 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 # postcard: used by `memory_palace` integration test to assert DrawerType
 # serialization indices are stable (issue #1722 backward-compat guarantee).
 postcard = { workspace = true }
+# wiremock: hermetic HTTP mock server for `search_client`'s `fetch_all`
+# regression test (#6382 — proves the dead `/communities` route is no longer
+# dialled).
+wiremock = { workspace = true }
 
 [features]
 default = []

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -35,7 +35,10 @@ name = "trusty-common"
 # (`ConsolidationProvider`, `resolve_consolidation_provider`, three consts) or a
 # default VALUE change on an existing field; no public item was removed or had
 # its type changed, so nothing here breaks a consumer at compile time.
-version = "0.45.5"
+# 0.45.6 (#6382): patch — `SearchClient::index_communities` and its
+# `CommunitiesWire` struct are removed, but both were private (no `pub`), so
+# no public item changed; nothing here breaks a consumer at compile time.
+version = "0.45.6"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/trusty-common/changelog.d/6382-remove-dead-communities-route.md
+++ b/crates/trusty-common/changelog.d/6382-remove-dead-communities-route.md
@@ -1,0 +1,9 @@
+Fixed
+
+- `SearchClient::fetch_all` (the monitor dashboard's trusty-search poller) no
+  longer GETs `/indexes/:id/communities` — trusty-search has never served that
+  route (the Louvain community-detection pipeline was retired server-side in
+  v0.10.0, issue #152), so every call 404'd. `index_communities` and its
+  `CommunitiesWire` wire struct are removed; `IndexRow.community_count` /
+  `.modularity` stay on the struct (existing TUI tests exercise them directly)
+  but nothing populates them from the daemon. (#6382)

--- a/crates/trusty-common/src/monitor/dashboard/types.rs
+++ b/crates/trusty-common/src/monitor/dashboard/types.rs
@@ -43,13 +43,13 @@ pub enum Focus {
 /// Why: the search panel lists every registered index with its chunk count so
 /// the operator can see corpus sizes at a glance; the TUI also uses
 /// `disk_bytes` and `last_indexed` to drive its sort / stats panels and the
-/// inferred project name (from `root_path`) to group rows. Graph stats and
-/// community info give the operator visibility into the symbol graph and
-/// detected community structure built by the daemon.
+/// inferred project name (from `root_path`) to group rows. Graph stats give
+/// the operator visibility into the symbol graph built by the daemon.
 /// What: the index id, its chunk count, indexed root path, optional on-disk
 /// size, optional last-indexed timestamp, plus knowledge-graph node/edge
-/// counts, per-edge-kind breakdown (sorted desc by count), and community
-/// count + modularity score from community detection.
+/// counts and per-edge-kind breakdown (sorted desc by count).
+/// `community_count` / `modularity` are vestigial (see their own docs) and
+/// carry no live data.
 /// Test: `test_search_panel_renders`, `test_index_row_project`,
 /// `test_stats_lines_graph_section`.
 #[derive(Debug, Clone, Default, PartialEq)]
@@ -82,16 +82,23 @@ pub struct IndexRow {
     /// What: vector of `(kind_name, count)` from `edge_kinds`.
     /// Test: `test_stats_lines_edge_kind_bars`.
     pub edge_kinds: Vec<(String, u64)>,
-    /// Number of communities detected by community detection.
+    /// Vestigial: always `0`. Community detection was retired server-side in
+    /// trusty-search v0.10.0 (issue #152); `GET /indexes/:id/communities`
+    /// never existed on the daemon this client talks to, so nothing ever
+    /// populated this field over the wire. `SearchClient` stopped dialling
+    /// the dead route in #6382; the field stays only because
+    /// `test_stats_lines_graph_section` sets it directly to assert the
+    /// stats panel does NOT render it.
     ///
-    /// Why: surfaces high-level cluster count in the STATISTICS panel.
-    /// What: `community_count` from `/indexes/:id/communities` (0 when none).
-    /// Test: `test_stats_lines_graph_section`.
+    /// Why: kept for the regression test above, not for live data.
+    /// What: always `0` in production; `render.rs` never reads it.
+    /// Test: `test_stats_lines_graph_section`, `test_stats_lines_no_graph_section`.
     pub community_count: u64,
-    /// Modularity score of the community partition (0.0 when unknown).
+    /// Vestigial: always `0.0`. See [`Self::community_count`] — same history,
+    /// same reason it is kept.
     ///
-    /// Why: a quality signal for the detected community structure.
-    /// What: `modularity` from `/indexes/:id/communities`.
+    /// Why: kept for the regression test above, not for live data.
+    /// What: always `0.0` in production; `render.rs` never reads it.
     /// Test: `test_stats_lines_graph_section`.
     pub modularity: f64,
 }

--- a/crates/trusty-common/src/monitor/search_client.rs
+++ b/crates/trusty-common/src/monitor/search_client.rs
@@ -107,20 +107,6 @@ struct GraphStatsWire {
     edge_kinds: std::collections::HashMap<String, u64>,
 }
 
-/// Wire shape of `GET /indexes/:id/communities` from the trusty-search daemon.
-///
-/// Why: the STATISTICS panel surfaces the community count and modularity
-/// score; the full `communities` array is intentionally ignored.
-/// What: top-level community count and modularity score.
-/// Test: deserialisation is exercised live by the trusty-search daemon suite.
-#[derive(Debug, Deserialize)]
-struct CommunitiesWire {
-    #[serde(default)]
-    community_count: u64,
-    #[serde(default)]
-    modularity: f64,
-}
-
 /// Wire shape of `GET /indexes/:id/status` from the trusty-search daemon.
 ///
 /// Why: the dashboard now surfaces last-indexed time and on-disk size in
@@ -242,8 +228,14 @@ impl SearchClient {
                     }
                 }
             };
-            // Graph stats and community info are best-effort: a failure leaves
-            // the corresponding counters at zero so the panel can still render.
+            // Graph stats are best-effort: a failure leaves the corresponding
+            // counters at zero so the panel can still render.
+            // #6382: no `communities` probe here — trusty-search never served
+            // `GET /indexes/:id/communities` (the Louvain pipeline was
+            // retired server-side in v0.10.0, issue #152); this crate kept
+            // dialling it anyway, so every call 404'd. `IndexRow.community_count`
+            // / `.modularity` stay on the struct (existing TUI tests exercise
+            // them directly) but nothing populates them from the daemon.
             match self.index_graph_stats(&id).await {
                 Ok(stats) => {
                     row.node_count = stats.node_count;
@@ -254,15 +246,6 @@ impl SearchClient {
                 }
                 Err(e) => {
                     tracing::debug!("graph stats probe failed for {id}: {e}");
-                }
-            }
-            match self.index_communities(&id).await {
-                Ok(c) => {
-                    row.community_count = c.community_count;
-                    row.modularity = c.modularity;
-                }
-                Err(e) => {
-                    tracing::debug!("communities probe failed for {id}: {e}");
                 }
             }
             indexes.push(row);
@@ -316,26 +299,6 @@ impl SearchClient {
             .json()
             .await?;
         Ok(stats)
-    }
-
-    /// Fetch the community-detection summary for an index from `/communities`.
-    ///
-    /// Why: the STATISTICS panel reports the top-level community count and
-    /// modularity score; the full `communities` array is ignored to keep
-    /// the wire payload small.
-    /// What: GETs `/indexes/:id/communities` and returns the parsed wire
-    /// struct.
-    /// Test: covered by the trusty-search daemon suite.
-    async fn index_communities(&self, id: &str) -> anyhow::Result<CommunitiesWire> {
-        let c: CommunitiesWire = self
-            .http
-            .get(format!("{}/indexes/{id}/communities", self.base))
-            .send()
-            .await?
-            .error_for_status()?
-            .json()
-            .await?;
-        Ok(c)
     }
 
     /// Fetch the N most-recent daemon log lines from `GET /logs/tail`.
@@ -715,6 +678,82 @@ mod tests {
         assert_eq!(
             url, "http://127.0.0.1:59321",
             "resolve_search_url must discover a registered non-default-port address"
+        );
+    }
+
+    /// Regression for #6382: `fetch_all` used to also GET
+    /// `/indexes/:id/communities` per index — a route trusty-search has never
+    /// served (the Louvain community-detection pipeline was retired
+    /// server-side in v0.10.0, issue #152), so every such call 404'd.
+    ///
+    /// Why safe: talks only to a local wiremock server, never a real daemon.
+    /// What: serves `/health`, `/indexes`, `/indexes/:id/status`, and
+    /// `/indexes/:id/graph/stats`, but registers no mock for `.../communities`
+    /// and asserts no request ever reached that path. Before the fix this
+    /// failed: `fetch_all` issued a GET to `/indexes/demo/communities` that
+    /// wiremock's request log would show.
+    /// Test: this function.
+    #[tokio::test]
+    async fn fetch_all_never_requests_communities_route() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/health"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "version": "0.1.0",
+                "uptime_secs": 5,
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/indexes"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "indexes": ["demo"],
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/indexes/demo/status"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "root_path": "/tmp/demo",
+                "chunk_count": 3,
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/indexes/demo/graph/stats"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "node_count": 1,
+                "edge_count": 0,
+                "edge_kinds": {},
+            })))
+            .mount(&server)
+            .await;
+
+        let client = SearchClient::new(server.uri());
+        let data = client
+            .fetch_all()
+            .await
+            .expect("fetch_all should succeed with no communities mock registered");
+        assert_eq!(data.indexes.len(), 1);
+        assert_eq!(data.indexes[0].id, "demo");
+
+        let received = server
+            .received_requests()
+            .await
+            .expect("wiremock request recording is on by default");
+        assert!(
+            !received
+                .iter()
+                .any(|req| req.url.path().ends_with("communities")),
+            "fetch_all must never request /indexes/:id/communities (#6382): got {:?}",
+            received.iter().map(|r| r.url.path()).collect::<Vec<_>>()
         );
     }
 


### PR DESCRIPTION
Refs #6382.

`SearchClient::fetch_all` GET'd `/indexes/:id/communities` on every dashboard
poll. trusty-search has never served that route — the Louvain
community-detection pipeline was retired server-side in v0.10.0 (issue #152),
and trusty-search's socket.rs migration doc (`service/socket.rs`) already
names this as a pre-existing client-side bug with its own ticket, not a gap
the new UDS RPC surface owes a method for. Every call silently 404'd (caught
and logged at debug, so `fetch_all` itself never failed on it).

Removes `index_communities` and its `CommunitiesWire` wire struct.
`IndexRow.community_count` / `.modularity` stay on the struct — the search
TUI's own tests (`test_stats_lines_graph_section`,
`test_stats_lines_no_graph_section`) set them directly to assert the stats
panel does NOT render "Communities" (that display was retired separately) —
but nothing populates them from the daemon anymore.

## Rung 4 (trusty-common is a shared library)

- `cargo fmt --check` — clean
- `cargo clippy -p trusty-common --features monitor-tui --all-targets -- -D warnings` — clean
- `cargo test -p trusty-common --features monitor-tui --no-fail-fast` — `664 passed; 0 failed; 6 ignored`
- `cargo check --workspace` — clean
- `cargo test -p trusty-search --no-fail-fast` (only real direct dependent of `monitor::search_client`/`IndexRow`) — `1909 passed; 1 failed` (pre-existing: `service::rpc::admin::tests::registry_orphans_over_the_socket_matches_the_http_body`, unrelated to this change — `git diff --name-only origin/main...HEAD -- crates/trusty-search/` is empty)

## Regression test

Added `fetch_all_never_requests_communities_route` (wiremock-based). Verified
it fails against the pre-fix code path with the exact request list including
`/indexes/demo/communities`, and passes against the fix.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools