### PR TITLE
fix(trusty-embedderd-py): budget spawn attempts, not just the poll, in bounded venv rechecks (Refs #5328)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11568,7 +11568,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-embedderd-py"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "fs4 0.8.4",

--- a/crates/trusty-embedderd-py/Cargo.toml
+++ b/crates/trusty-embedderd-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-embedderd-py"
-version = "0.1.3"
+version = "0.1.4"  # bump for the #5328 spawn-retry fix release
 publish = true
 edition = "2021"
 license.workspace = true

--- a/crates/trusty-embedderd-py/changelog.d/5328-bounded-python-check-spawn-race.md
+++ b/crates/trusty-embedderd-py/changelog.d/5328-bounded-python-check-spawn-race.md
@@ -1,0 +1,5 @@
+Fixed
+- `run_bounded_python_check` no longer reports a venv recheck as `Failed`
+  when the spawn itself is starved by CI contention (EAGAIN/ENOMEM) — the
+  check budget now covers the spawn attempt, and a transient spawn error
+  retries within it instead of returning a false-negative failure (#5328).

--- a/crates/trusty-embedderd-py/src/bootstrap.rs
+++ b/crates/trusty-embedderd-py/src/bootstrap.rs
@@ -50,6 +50,8 @@ use fs4::FileExt;
 use include_dir::{include_dir, Dir};
 use sha2::{Digest, Sha256};
 
+use crate::spawn_retry::run_bounded_python_check;
+
 /// The Python project (pyproject + hashed uv.lock + `trusty_embed_sidecar`
 /// package + tests) embedded into the binary and materialized at bootstrap.
 static PY_PROJECT: Dir<'static> = include_dir!("$CARGO_MANIFEST_DIR/python");
@@ -509,67 +511,6 @@ fn recheck_with_one_retry(
             check(retry, "full-import-recheck (retry)")
         }
         decided => decided,
-    }
-}
-
-/// Shared bounded spawn-and-poll helper for [`verify_venv_alive`] and
-/// [`verify_full_import_smoke`]: run `python <args>` to completion, killing it
-/// if it outlives `timeout`. `label` only tags the log lines so the call sites
-/// stay distinguishable in output.
-///
-/// #4125: returns a three-state [`RecheckOutcome`] rather than a bool. A
-/// completed run maps to `Passed`/`Failed` by exit status; a spawn or poll
-/// error is `Failed` (the venv genuinely could not be exercised); running out
-/// of budget is `Indeterminate` and is deliberately NOT reported as a failed
-/// check — it says nothing about the venv, only about how much time it was
-/// given.
-fn run_bounded_python_check(
-    python: &Path,
-    args: &[&str],
-    timeout: Duration,
-    label: &str,
-) -> RecheckOutcome {
-    let mut cmd = Command::new(python);
-    cmd.args(args)
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null());
-
-    let mut child = match cmd.spawn() {
-        Ok(c) => c,
-        Err(e) => {
-            tracing::warn!("py-embedder: {label} failed to spawn venv python: {e}");
-            return RecheckOutcome::Failed;
-        }
-    };
-
-    let start = Instant::now();
-    loop {
-        match child.try_wait() {
-            Ok(Some(status)) => {
-                return if status.success() {
-                    RecheckOutcome::Passed
-                } else {
-                    RecheckOutcome::Failed
-                }
-            }
-            Ok(None) => {
-                if start.elapsed() >= timeout {
-                    let _ = child.kill();
-                    let _ = child.wait();
-                    tracing::debug!(
-                        "py-embedder: {label} did not finish within {}s — indeterminate, \
-                         not a failed check (#4125)",
-                        timeout.as_secs()
-                    );
-                    return RecheckOutcome::Indeterminate;
-                }
-                std::thread::sleep(Duration::from_millis(50));
-            }
-            Err(e) => {
-                tracing::warn!("py-embedder: {label} poll failed: {e}");
-                return RecheckOutcome::Failed;
-            }
-        }
     }
 }
 

--- a/crates/trusty-embedderd-py/src/bootstrap_tests.rs
+++ b/crates/trusty-embedderd-py/src/bootstrap_tests.rs
@@ -472,6 +472,11 @@ fn bounded_python_check_classifies_timeout_apart_from_failure() {
     );
 }
 
+// #5328: the transient-vs-permanent spawn classification and the
+// spawn-retry policy that consumes it moved to their own module
+// (`spawn_retry.rs`, tested in `spawn_retry_tests.rs`) so `bootstrap.rs`
+// stayed under the 500-SLOC production cap.
+
 /// Why (#4125): a single fixed budget under variable startup load is wrong
 /// again the moment the load changes, so an over-budget first attempt must buy
 /// a second, larger one rather than a verdict.

--- a/crates/trusty-embedderd-py/src/lib.rs
+++ b/crates/trusty-embedderd-py/src/lib.rs
@@ -29,6 +29,7 @@
 
 pub mod bootstrap;
 pub mod launcher;
+mod spawn_retry;
 
 pub use bootstrap::{ensure_venv, ensure_venv_eager, resolve_layout, VenvLayout};
 pub use launcher::{exec_sidecar, locate_launcher_binary};

--- a/crates/trusty-embedderd-py/src/spawn_retry.rs
+++ b/crates/trusty-embedderd-py/src/spawn_retry.rs
@@ -1,0 +1,158 @@
+//! Bounded, contention-tolerant subprocess spawn-and-poll for
+//! [`bootstrap`](crate::bootstrap)'s venv rechecks (#5328).
+//!
+//! Why: [`run_bounded_python_check`] used to try `Command::spawn()` exactly
+//! once and treat ANY error as evidence the venv was broken. Under CI
+//! contention `fork()` can transiently fail (EAGAIN / ENOMEM) even though the
+//! identical spawn would succeed moments later — split into its own module so
+//! the spawn-and-poll mechanics have a home separate from the recheck POLICY
+//! that consumes them (`bootstrap::verify_venv_alive`,
+//! `bootstrap::verify_full_import_smoke`), and so this addition didn't push
+//! `bootstrap.rs` back over the 500-SLOC production cap.
+
+use std::path::Path;
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+use crate::bootstrap::RecheckOutcome;
+
+/// Retry a fallible spawn attempt while its error is transient OS-level
+/// contention, bounded by `timeout` measured from `start` (#5328).
+///
+/// Why: `Command::spawn()`s fork() can transiently fail with EAGAIN (mapped
+/// by `std::io` to [`ErrorKind::WouldBlock`](std::io::ErrorKind::WouldBlock))
+/// or ENOMEM ([`ErrorKind::OutOfMemory`](std::io::ErrorKind::OutOfMemory))
+/// when a loaded CI box is near its process-table or memory limit, even
+/// though the identical spawn would succeed moments later once a slot frees
+/// up. The caller used to try `spawn()` exactly once and treat any error —
+/// transient or not — as proof the venv is broken. That is the same "slow is
+/// not broken" conflation issue #4125 fixed for the post-spawn poll loop, one
+/// step earlier: a fork that could not get a process slot in time says
+/// nothing about whether the venv itself is intact. The policy is injected as
+/// a closure — same shape as #4125's `recheck_with_one_retry` — so a test can
+/// assert it with synthetic errors instead of racing a real `fork()` for a
+/// genuine EAGAIN.
+/// What: calls `attempt()`. On success, returns `Ok`. On a transient error
+/// (see [`is_transient_spawn_error`]), sleeps briefly and retries as long as
+/// `start.elapsed() < timeout`; once the budget is exhausted with every
+/// attempt still transient, returns `Err(None)` — no evidence either way,
+/// same as a poll-loop timeout. A non-transient error returns `Err(Some(e))`
+/// immediately, without retrying — that IS evidence (e.g. the interpreter
+/// path genuinely does not exist).
+/// Test: `spawn_with_retry_succeeds_immediately_when_first_attempt_works`,
+/// `spawn_with_retry_retries_transient_errors_until_success`,
+/// `spawn_with_retry_gives_up_as_indeterminate_when_budget_runs_out`,
+/// `spawn_with_retry_short_circuits_on_a_permanent_error`.
+pub(crate) fn spawn_with_retry<T>(
+    start: Instant,
+    timeout: Duration,
+    mut attempt: impl FnMut() -> std::io::Result<T>,
+) -> Result<T, Option<std::io::Error>> {
+    loop {
+        match attempt() {
+            Ok(v) => return Ok(v),
+            Err(e) if is_transient_spawn_error(&e) => {
+                if start.elapsed() >= timeout {
+                    return Err(None);
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            Err(e) => return Err(Some(e)),
+        }
+    }
+}
+
+/// Whether a spawn error is transient OS-level contention rather than real
+/// evidence the venv is broken (#5328). See [`spawn_with_retry`] for why the
+/// distinction exists.
+/// What: `true` for `WouldBlock` (EAGAIN — fork() found no process slot) and
+/// `OutOfMemory` (ENOMEM); `false` for everything else, including
+/// `NotFound`/`PermissionDenied`, which stay real evidence.
+/// Test: `is_transient_spawn_error_classifies_would_block_and_out_of_memory`.
+fn is_transient_spawn_error(e: &std::io::Error) -> bool {
+    matches!(
+        e.kind(),
+        std::io::ErrorKind::WouldBlock | std::io::ErrorKind::OutOfMemory
+    )
+}
+
+/// Shared bounded spawn-and-poll helper for `bootstrap::verify_venv_alive`
+/// and `bootstrap::verify_full_import_smoke`: run `python <args>` to
+/// completion, killing it if it outlives `timeout`. `label` only tags the log
+/// lines so the call sites stay distinguishable in output.
+///
+/// #4125: returns a three-state [`RecheckOutcome`] rather than a bool. A
+/// completed run maps to `Passed`/`Failed` by exit status; a poll error is
+/// `Failed` (the venv genuinely could not be exercised); running out of
+/// budget is `Indeterminate` and is deliberately NOT reported as a failed
+/// check — it says nothing about the venv, only about how much time it was
+/// given.
+///
+/// #5328: `timeout` is measured from BEFORE the spawn attempt via
+/// [`spawn_with_retry`], not after it succeeds — the spawn itself shares the
+/// budget with the poll loop rather than sitting outside it, and a transient
+/// spawn error (see [`is_transient_spawn_error`]) retries within that budget
+/// instead of being reported as `Failed`.
+/// Test: `bootstrap::tests::bounded_python_check_classifies_timeout_apart_from_failure`.
+pub(crate) fn run_bounded_python_check(
+    python: &Path,
+    args: &[&str],
+    timeout: Duration,
+    label: &str,
+) -> RecheckOutcome {
+    let start = Instant::now();
+    let mut child = match spawn_with_retry(start, timeout, || {
+        Command::new(python)
+            .args(args)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+    }) {
+        Ok(c) => c,
+        Err(Some(e)) => {
+            tracing::warn!("py-embedder: {label} failed to spawn venv python: {e}");
+            return RecheckOutcome::Failed;
+        }
+        Err(None) => {
+            tracing::debug!(
+                "py-embedder: {label} could not spawn within {}s under contention — \
+                 indeterminate, not a failed check (#5328)",
+                timeout.as_secs()
+            );
+            return RecheckOutcome::Indeterminate;
+        }
+    };
+
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                return if status.success() {
+                    RecheckOutcome::Passed
+                } else {
+                    RecheckOutcome::Failed
+                }
+            }
+            Ok(None) => {
+                if start.elapsed() >= timeout {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    tracing::debug!(
+                        "py-embedder: {label} did not finish within {}s — indeterminate, \
+                         not a failed check (#4125)",
+                        timeout.as_secs()
+                    );
+                    return RecheckOutcome::Indeterminate;
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            Err(e) => {
+                tracing::warn!("py-embedder: {label} poll failed: {e}");
+                return RecheckOutcome::Failed;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "spawn_retry_tests.rs"]
+mod tests;

--- a/crates/trusty-embedderd-py/src/spawn_retry_tests.rs
+++ b/crates/trusty-embedderd-py/src/spawn_retry_tests.rs
@@ -1,0 +1,115 @@
+//! Unit tests for [`spawn_with_retry`](super::spawn_with_retry) and
+//! [`is_transient_spawn_error`](super) — no process, no clock races (#5328).
+
+use super::*;
+use std::cell::Cell;
+
+/// Why (#5328): `run_bounded_python_check` used to classify ANY
+/// `Command::spawn()` error — including a transient `WouldBlock`/`OutOfMemory`
+/// fork failure under CI contention — as a hard failure. This is the pure,
+/// deterministic half of the classification: no process, no clock.
+/// What: `WouldBlock` and `OutOfMemory` are transient; `NotFound` and
+/// `PermissionDenied` (real evidence the interpreter is missing/unusable) are
+/// not.
+/// Test: this test.
+#[test]
+fn is_transient_spawn_error_classifies_would_block_and_out_of_memory() {
+    use std::io::{Error, ErrorKind};
+
+    assert!(is_transient_spawn_error(&Error::from(
+        ErrorKind::WouldBlock
+    )));
+    assert!(is_transient_spawn_error(&Error::from(
+        ErrorKind::OutOfMemory
+    )));
+    assert!(!is_transient_spawn_error(&Error::from(ErrorKind::NotFound)));
+    assert!(!is_transient_spawn_error(&Error::from(
+        ErrorKind::PermissionDenied
+    )));
+}
+
+/// Why (#5328): the common case — nothing to retry — must not pay any extra
+/// cost or delay.
+/// What: `attempt()` succeeding on the first call returns `Ok` after exactly
+/// one call.
+/// Test: this test.
+#[test]
+fn spawn_with_retry_succeeds_immediately_when_first_attempt_works() {
+    let calls = Cell::new(0usize);
+    let result = spawn_with_retry(Instant::now(), Duration::from_secs(30), || {
+        calls.set(calls.get() + 1);
+        Ok::<_, std::io::Error>(42)
+    });
+    assert_eq!(result.ok(), Some(42));
+    assert_eq!(calls.get(), 1);
+}
+
+/// Why (#5328): this is the real production shape — a fork() that loses the
+/// race for a process slot twice under CI contention, then succeeds once a
+/// slot frees up. The venv must be exercised normally, not condemned for a
+/// spawn hiccup.
+/// What: two `WouldBlock` errors followed by success returns `Ok` after
+/// exactly three calls.
+/// Test: this test.
+#[test]
+fn spawn_with_retry_retries_transient_errors_until_success() {
+    let calls = Cell::new(0usize);
+    let result = spawn_with_retry(Instant::now(), Duration::from_secs(30), || {
+        calls.set(calls.get() + 1);
+        if calls.get() < 3 {
+            Err(std::io::Error::from(std::io::ErrorKind::WouldBlock))
+        } else {
+            Ok(7)
+        }
+    });
+    assert_eq!(result.ok(), Some(7));
+    assert_eq!(
+        calls.get(),
+        3,
+        "must retry exactly the two transient failures"
+    );
+}
+
+/// Why (#5328): a machine that stays saturated for the WHOLE budget still has
+/// said nothing about whether the venv is broken — same "no evidence" verdict
+/// as a post-spawn poll timeout (#4125's `Indeterminate`), not `Failed`.
+/// What: an `attempt` that is always `WouldBlock` returns `Err(None)` once
+/// `start.elapsed() >= timeout` — asserted with a small, deterministic
+/// `timeout` so the test itself stays fast without racing a real clock.
+/// Test: this test.
+#[test]
+fn spawn_with_retry_gives_up_as_indeterminate_when_budget_runs_out() {
+    let start = Instant::now();
+    let result = spawn_with_retry(start, Duration::from_millis(120), || {
+        Err::<(), _>(std::io::Error::from(std::io::ErrorKind::WouldBlock))
+    });
+    assert!(
+        result.is_err_and(|e| e.is_none()),
+        "budget exhausted while every attempt was transient must report \
+         no-evidence (None), not a failure"
+    );
+    assert!(
+        start.elapsed() >= Duration::from_millis(120),
+        "must not give up before the budget is spent"
+    );
+}
+
+/// Why (#5328): a genuinely broken interpreter path (missing binary, bad
+/// permissions) IS real evidence, and retrying it would only add latency to a
+/// verdict that will never change.
+/// What: a `NotFound` error returns `Err(Some(e))` after exactly one call —
+/// no retry.
+/// Test: this test.
+#[test]
+fn spawn_with_retry_short_circuits_on_a_permanent_error() {
+    let calls = Cell::new(0usize);
+    let result = spawn_with_retry(Instant::now(), Duration::from_secs(30), || {
+        calls.set(calls.get() + 1);
+        Err::<(), _>(std::io::Error::from(std::io::ErrorKind::NotFound))
+    });
+    assert!(
+        result.is_err_and(|e| e.is_some_and(|e| e.kind() == std::io::ErrorKind::NotFound)),
+        "a permanent spawn error must be returned as real evidence, not swallowed"
+    );
+    assert_eq!(calls.get(), 1, "a permanent error must not be retried");
+}


### PR DESCRIPTION
## Summary

`run_bounded_python_check` tried `Command::spawn()` exactly once and reported any spawn error as `RecheckOutcome::Failed`. Under CI contention `fork()` can transiently fail with EAGAIN/ENOMEM even though the identical spawn succeeds moments later, so a loaded CI box could read a slow-but-successful venv recheck as a hard failure — the mechanism in #5328.

Fix, same shape #4125 already established for the post-spawn poll loop:

- The check's timeout budget now starts **before** the spawn attempt, not after it succeeds.
- A transient spawn error (`WouldBlock`/`OutOfMemory`) retries within that shared budget instead of being reported as `Failed`. Budget exhausted while every attempt was transient reports `Indeterminate` (no evidence), never `Failed`.
- A genuine spawn error (`NotFound`, `PermissionDenied`, …) still short-circuits to `Failed` immediately — that stays real evidence.

New `spawn_retry` module (`spawn_with_retry` + `is_transient_spawn_error`) holds the retry policy and the moved `run_bounded_python_check`; this also kept `bootstrap.rs` under the 500-SLOC production cap after the addition.

## Rung / gates

Rung 2 (test-only stabilization, per the repo's rust test ladder):

- `cargo fmt --check` — clean
- `cargo clippy -p trusty-embedderd-py --all-targets -- -D warnings` — clean
- `cargo test -p trusty-embedderd-py --no-fail-fast` — `28 passed; 0 failed`
- `bash scripts/check_line_cap.sh` — `0 violations`
- Flake evidence: `bounded_python_check_classifies_timeout_apart_from_failure` and the four new `spawn_with_retry_*` tests each re-run 10/10 clean.

Refs #5328