### PR TITLE
fix(trusty-search): open a reindex stream exactly-once (Refs #6386)

### DIFF
--- a/crates/trusty-search/changelog.d/6386-reindex-stream-open-exactly-once.md
+++ b/crates/trusty-search/changelog.d/6386-reindex-stream-open-exactly-once.md
@@ -10,8 +10,20 @@ Fixed
   twice, with no error anywhere. `push` now broadcasts while still holding the
   lock, and both transports open through one new
   `ReindexProgress::subscribe_with_replay`, which takes the replay buffer, the
-  status, and the subscription under that same lock. Every event now lands on
-  exactly one path. Refs #6386.
+  status, and the subscription under that same lock. Every event emitted through
+  `push` or `push_terminal` now lands on exactly one path. Refs #6386.
+- A stream opened while a reindex was FINISHING could end without its terminal
+  frame. The six terminal transitions in the reindex runner stored the status and
+  pushed the terminal event as two separate unlocked steps, and on the `Complete`
+  path an RSS poll, a git subprocess, a marker-file write and two `RwLock` writes
+  sat between them. A stream opening in that window read a terminal status while
+  the replay buffer still lacked the terminal event, and both transports stop
+  reading the live channel once the status is terminal — so the stream ended
+  silently and the client waited on a completion that had already happened. A new
+  `ReindexProgress::push_terminal` stores the status and emits the event under one
+  hold of the replay-buffer lock, and every terminal transition routes through it.
+  `ReindexTerminationGuard::drop` remains the one emission outside that rule,
+  because `Drop` cannot await the lock. Refs #6386.
 - `GET /indexes/{id}/reindex/stream` (SSE) and `search.index.reindex.stream`
   (Unix socket) shared the bug because each had its own copy of the two-step
   open. Both now call the one method, so the two transports cannot drift apart

--- a/crates/trusty-search/changelog.d/6386-reindex-stream-open-exactly-once.md
+++ b/crates/trusty-search/changelog.d/6386-reindex-stream-open-exactly-once.md
@@ -1,0 +1,19 @@
+Fixed
+
+- A reindex progress stream opened while a reindex was running could lose an
+  event or deliver one twice. `ReindexProgress::push` appended to the replay
+  buffer under a lock and broadcast after releasing it, while a stream opened by
+  snapshotting the buffer under that lock and subscribing after releasing it — so
+  an event appended after the snapshot and broadcast before the subscribe reached
+  neither path, and one appended before the snapshot but broadcast after the
+  subscribe reached both. A dashboard silently skipped a batch, or showed one
+  twice, with no error anywhere. `push` now broadcasts while still holding the
+  lock, and both transports open through one new
+  `ReindexProgress::subscribe_with_replay`, which takes the replay buffer, the
+  status, and the subscription under that same lock. Every event now lands on
+  exactly one path. Refs #6386.
+- `GET /indexes/{id}/reindex/stream` (SSE) and `search.index.reindex.stream`
+  (Unix socket) shared the bug because each had its own copy of the two-step
+  open. Both now call the one method, so the two transports cannot drift apart
+  again. Neither route's observable frame sequence changes for a client that was
+  not hitting the race. Refs #6386.

--- a/crates/trusty-search/src/service/reindex/completion.rs
+++ b/crates/trusty-search/src/service/reindex/completion.rs
@@ -9,14 +9,15 @@
 //! - `KgRebuildOutcome` — timing / count snapshot from the KG rebuild.
 //! - `RunTotals` — per-phase timing accumulators for the entire reindex run.
 //! - `rebuild_symbol_graph_for_reindex` — synchronous KG rebuild after batches.
-//! - `emit_complete_event` — build and push the terminal `complete` SSE event.
+//! - `emit_complete_event` — build the terminal `complete` SSE event and emit it
+//!   with the run's terminal status, as one step (#6386).
 //!
 //! Test: the `complete` event shape is asserted in `reindex_walks_directory_and_emits_events`.
 
 use crate::core::registry::IndexHandle;
 use std::time::Instant;
 
-use super::progress::ReindexProgress;
+use super::progress::{ReindexProgress, ReindexStatus};
 
 /// Result of the final symbol-graph rebuild.
 ///
@@ -101,11 +102,20 @@ pub(super) async fn rebuild_symbol_graph_for_reindex(handle: &IndexHandle) -> Kg
 /// reindex run (issue #282). `None` when the sidecar was not running or
 /// sampling failed for every poll tick.
 ///
-/// What: reads final counters from `progress`, builds the JSON event, and
-/// calls `progress.push`.
-/// Test: `complete` event shape verified in `reindex_walks_directory_and_emits_events`.
+/// `terminal_status` — the status this run ends in. #6386: it is stored HERE,
+/// with the frame, rather than by the caller before it — `push_terminal` does
+/// both under one hold of the replay-buffer lock, so a stream opening now cannot
+/// read a terminal status from a buffer that lacks the terminal frame. The
+/// `status` FIELD in the payload keeps its own derivation from
+/// `totals.mem_limit_hit` and is unchanged.
+///
+/// What: reads final counters from `progress`, builds the JSON event, and calls
+/// `progress.push_terminal`.
+/// Test: `complete` event shape verified in `reindex_walks_directory_and_emits_events`;
+/// the atomicity in `a_terminal_status_is_not_observable_before_its_event_is_in_the_replay`.
 pub(super) async fn emit_complete_event(
     progress: &ReindexProgress,
+    terminal_status: ReindexStatus,
     started: Instant,
     peak_rss_mb: u64,
     embedderd_peak_rss_mb: Option<u64>,
@@ -183,5 +193,5 @@ pub(super) async fn emit_complete_event(
     if let Some(n) = embedderd_peak_rss_mb {
         event["embedderd_peak_rss_mb"] = serde_json::Value::Number(n.into());
     }
-    progress.push(event).await;
+    progress.push_terminal(terminal_status, event).await;
 }

--- a/crates/trusty-search/src/service/reindex/finish.rs
+++ b/crates/trusty-search/src/service/reindex/finish.rs
@@ -304,17 +304,20 @@ pub(super) async fn finish_reindex(
             embed_failure_count,
         );
         mark_reindex_failed(&handle, reason).await;
-        progress.status.store(ReindexStatus::Failed);
+        // #6386: status and frame in one hold — see `push_terminal`.
         progress
-            .push(serde_json::json!({
-                "event": "error",
-                "index_id": index_id.0,
-                "message": reason,
-                "embed_failure_count": embed_failure_count,
-                "walked_files": total,
-                "vector_count": total_vector_count,
-                "fatal": true,
-            }))
+            .push_terminal(
+                ReindexStatus::Failed,
+                serde_json::json!({
+                    "event": "error",
+                    "index_id": index_id.0,
+                    "message": reason,
+                    "embed_failure_count": embed_failure_count,
+                    "walked_files": total,
+                    "vector_count": total_vector_count,
+                    "fatal": true,
+                }),
+            )
             .await;
         term_guard.disarm();
         stop_pollers(
@@ -398,13 +401,19 @@ pub(super) async fn finish_reindex(
 
     // Issue #120: distinguish memory-abort from clean completion.
     let aborted_memory = mem_limit_hit || mem_abort.load(AtomicOrdering::Acquire);
-    if aborted_memory {
-        progress.status.store(ReindexStatus::AbortedMemory);
+    // #6386: decide the terminal status here but do not STORE it — the store
+    // rides with the terminal frame in `emit_complete_event` below, under one
+    // hold of the replay-buffer lock. Everything this run must record therefore
+    // completes before any subscriber can observe the run as finished, which is
+    // the stronger order: the git call, the marker write and both handle stamps
+    // used to sit AFTER the status flip, so a `GET /indexes/:id/status` in that
+    // window read `Complete` beside a stale `last_indexed_at`.
+    let terminal_status = if aborted_memory {
         if let Some(map) = aborted_map.as_ref() {
             map.insert(index_id.clone(), Instant::now());
         }
+        ReindexStatus::AbortedMemory
     } else {
-        progress.status.store(ReindexStatus::Complete);
         // Issue #75: refresh the captured HEAD SHA.
         let new_sha = crate::core::git::head_sha(&handle.root_path);
         // #4391: the in-memory stamp dies with the handle — persist it so the
@@ -413,7 +422,8 @@ pub(super) async fn finish_reindex(
         *handle.indexed_head_sha.write().await = new_sha;
         // Issue #878: stamp the authoritative last-indexed timestamp.
         *handle.last_indexed_at.write().await = Some(now_rfc3339());
-    }
+        ReindexStatus::Complete
+    };
 
     // Final synchronous RSS poll so the peak reflects post-KG memory.
     if let Some(rss) = current_rss_mb() {
@@ -492,6 +502,7 @@ pub(super) async fn finish_reindex(
     };
     emit_complete_event(
         &progress,
+        terminal_status,
         started,
         peak_rss_mb,
         embedderd_peak_rss_mb,

--- a/crates/trusty-search/src/service/reindex/mod.rs
+++ b/crates/trusty-search/src/service/reindex/mod.rs
@@ -285,3 +285,8 @@ mod contrib_survival_tests;
 // #5047: poller shutdown latency — teardown must not wait out the current tick.
 #[cfg(test)]
 mod pollers_tests;
+// #6386: the stream open must be exactly-once against a live reindex. Its own
+// file because the regression is a race loop, not a case that belongs beside the
+// orchestration tests in `tests.rs`.
+#[cfg(test)]
+mod progress_race_tests;

--- a/crates/trusty-search/src/service/reindex/progress.rs
+++ b/crates/trusty-search/src/service/reindex/progress.rs
@@ -94,12 +94,14 @@ impl ReindexProgress {
     /// Caps the replay buffer at `MAX_REPLAY_EVENTS` to bound memory under
     /// pathological reindexes (e.g. one error event per file).
     ///
-    /// Why: central event emission point — all SSE events funnel through here
-    /// so the replay buffer and live broadcast channel stay in sync. The buffer
-    /// append and the broadcast happen under ONE hold of the `events` lock, which
-    /// is what makes an emission atomic with respect to
+    /// Why: central emission point for every non-terminal event — the replay
+    /// buffer and the live broadcast channel stay in sync because the append and
+    /// the broadcast happen under ONE hold of the `events` lock, which is what
+    /// makes an emission atomic with respect to
     /// [`subscribe_with_replay`](Self::subscribe_with_replay) — see #6386 and the
-    /// exactly-once argument on that method.
+    /// exactly-once argument on that method. A TERMINAL event goes through
+    /// [`push_terminal`](Self::push_terminal) instead, which stores the status
+    /// under that same hold.
     /// What: appends to the in-memory replay buffer (dropping the oldest event
     /// when over-cap) and sends on the broadcast channel (errors are benign —
     /// replay buffer retains the event for late subscribers).
@@ -109,14 +111,53 @@ impl ReindexProgress {
     pub async fn push(&self, event: serde_json::Value) {
         let line = event.to_string();
         let mut buf = self.events.lock().await;
+        self.emit_locked(&mut buf, line);
+    }
+
+    /// Store the terminal status and emit its event as ONE atomic step.
+    ///
+    /// Why: a terminal transition used to be two unlocked steps — `status.store`
+    /// followed by [`push`](Self::push) — and on the `Complete` path an RSS poll,
+    /// a git subprocess, a marker-file write and two `RwLock` writes sat between
+    /// them. A [`subscribe_with_replay`](Self::subscribe_with_replay) landing in
+    /// that window read a terminal status while the replay buffer still lacked
+    /// the terminal event. Both transports stop reading the live channel once the
+    /// status is terminal, so that subscriber's stream ended with no terminal
+    /// frame at all and its client waited on one that would never come. See
+    /// #6386.
+    /// What: takes the `events` lock once and, under that single hold, stores the
+    /// status, appends the event to the replay buffer, and broadcasts it — so no
+    /// open can observe the status and the buffer disagreeing. Identical to
+    /// `push` in every respect but the status store.
+    /// Test: `a_terminal_status_is_not_observable_before_its_event_is_in_the_replay`
+    /// and `a_stream_opened_across_the_terminal_transition_always_gets_the_terminal_frame`
+    /// in `progress_race_tests.rs`.
+    pub async fn push_terminal(&self, status: ReindexStatus, event: serde_json::Value) {
+        let line = event.to_string();
+        let mut buf = self.events.lock().await;
+        // #6386: inside the hold, so an open either predates the whole
+        // transition or sees both halves of it.
+        self.status.store(status);
+        self.emit_locked(&mut buf, line);
+    }
+
+    /// Append to the replay buffer and broadcast, under a lock the caller holds.
+    ///
+    /// Why: `push` and `push_terminal` differ only in whether they also store the
+    /// terminal status, and both must append and broadcast under ONE hold of the
+    /// `events` lock (#6386). Sharing the body keeps the two emission paths from
+    /// drifting apart.
+    /// What: evicts the oldest entry once at `MAX_REPLAY_EVENTS`, appends, then
+    /// sends on the broadcast channel. `broadcast::Sender::send` is synchronous
+    /// and never blocks on a receiver, so the caller's critical section stays
+    /// short and cannot deadlock.
+    /// Test: every test that calls `push` or `push_terminal` exercises it.
+    fn emit_locked(&self, buf: &mut Vec<String>, line: String) {
         if buf.len() >= MAX_REPLAY_EVENTS {
             // Drop the oldest event. `remove(0)` is O(n) but n ≤ 500.
             buf.remove(0);
         }
         buf.push(line.clone());
-        // #6386: broadcast while still holding the guard. `broadcast::Sender::send`
-        // is synchronous and never blocks on a receiver, so the critical section
-        // stays short and cannot deadlock.
         // Broadcast errors (no receivers) are fine — replay buffer still has it.
         let _ = self.sender.send(line);
     }
@@ -134,20 +175,29 @@ impl ReindexProgress {
     /// status, and subscribes to the broadcast channel, releasing the lock only
     /// once all three are in hand.
     ///
-    /// The exactly-once argument, given that `push` appends AND broadcasts under
-    /// the same lock: the two critical sections are ordered, so for any event
-    /// either `push` ran first — its line is in the returned buffer, and its
-    /// broadcast preceded the subscription, so the receiver never sees it — or
-    /// this ran first, and the line is absent from the buffer while the
-    /// subscription predates the broadcast. Every event lands in exactly one of
-    /// the two paths. Before #6386 the broadcast sat outside `push`'s lock and the
-    /// subscribe outside the snapshot's, so an event could land in both (a
-    /// duplicate) or in neither (a LOST event).
+    /// The exactly-once argument, for any event emitted through
+    /// [`push`](Self::push) or [`push_terminal`](Self::push_terminal), each of
+    /// which appends AND broadcasts under this same lock: the two critical
+    /// sections are ordered, so for any event either the emission ran first — its
+    /// line is in the returned buffer, and its broadcast preceded the
+    /// subscription, so the receiver never sees it — or this ran first, and the
+    /// line is absent from the buffer while the subscription predates the
+    /// broadcast. Every such event lands in exactly one of the two paths. Before
+    /// #6386 the broadcast sat outside `push`'s lock and the subscribe outside the
+    /// snapshot's, so an event could land in both (a duplicate) or in neither (a
+    /// LOST event).
     ///
-    /// The terminal frame `ReindexTerminationGuard::drop` emits is the one
-    /// emission that does NOT route through `push` — `Drop` cannot await the lock,
-    /// so it broadcasts only. A subscriber that opens after that frame reads the
-    /// `Failed` status rather than the frame; that predates #6386 and is unchanged.
+    /// A terminal event carries the status with it, so the same argument covers
+    /// the `status` returned beside the buffer: an open never reads a terminal
+    /// status from a buffer that does not yet hold the terminal frame. That
+    /// mattered because both transports stop reading the live channel on a
+    /// terminal status, so such an open ended its stream with no terminal frame.
+    ///
+    /// The terminal frame `ReindexTerminationGuard::drop` emits is the sole
+    /// remaining exception — `Drop` cannot await the lock, so it broadcasts and
+    /// stores the status without one. A subscriber that opens after that frame
+    /// reads the `Failed` status rather than the frame; that predates #6386 and is
+    /// unchanged.
     ///
     /// Test: `no_event_is_lost_or_duplicated_when_a_stream_opens_against_live_pushes`
     /// and `an_event_pushed_either_side_of_an_open_arrives_on_exactly_one_path` in

--- a/crates/trusty-search/src/service/reindex/progress.rs
+++ b/crates/trusty-search/src/service/reindex/progress.rs
@@ -95,23 +95,74 @@ impl ReindexProgress {
     /// pathological reindexes (e.g. one error event per file).
     ///
     /// Why: central event emission point — all SSE events funnel through here
-    /// so the replay buffer and live broadcast channel stay in sync.
+    /// so the replay buffer and live broadcast channel stay in sync. The buffer
+    /// append and the broadcast happen under ONE hold of the `events` lock, which
+    /// is what makes an emission atomic with respect to
+    /// [`subscribe_with_replay`](Self::subscribe_with_replay) — see #6386 and the
+    /// exactly-once argument on that method.
     /// What: appends to the in-memory replay buffer (dropping the oldest event
     /// when over-cap) and sends on the broadcast channel (errors are benign —
     /// replay buffer retains the event for late subscribers).
-    /// Test: covered by `reindex_walks_directory_and_emits_events`.
+    /// Test: `reindex_walks_directory_and_emits_events`;
+    /// `no_event_is_lost_or_duplicated_when_a_stream_opens_against_live_pushes`
+    /// in `progress_race_tests.rs` for the atomicity this ordering buys.
     pub async fn push(&self, event: serde_json::Value) {
         let line = event.to_string();
-        {
-            let mut buf = self.events.lock().await;
-            if buf.len() >= MAX_REPLAY_EVENTS {
-                // Drop the oldest event. `remove(0)` is O(n) but n ≤ 500.
-                buf.remove(0);
-            }
-            buf.push(line.clone());
+        let mut buf = self.events.lock().await;
+        if buf.len() >= MAX_REPLAY_EVENTS {
+            // Drop the oldest event. `remove(0)` is O(n) but n ≤ 500.
+            buf.remove(0);
         }
+        buf.push(line.clone());
+        // #6386: broadcast while still holding the guard. `broadcast::Sender::send`
+        // is synchronous and never blocks on a receiver, so the critical section
+        // stays short and cannot deadlock.
         // Broadcast errors (no receivers) are fine — replay buffer still has it.
         let _ = self.sender.send(line);
+    }
+
+    /// Open a stream: the replay buffer, the status, and a live subscription,
+    /// taken as one atomic step.
+    ///
+    /// Why: this is the ONE place a reindex stream may open, and it exists so the
+    /// snapshot and the subscription cannot straddle a [`push`](Self::push).
+    /// Both transports — the `GET /indexes/{id}/reindex/stream` SSE route and the
+    /// `search.index.reindex.stream` socket method — call it, so neither can
+    /// re-introduce the #6386 race by hand-ordering the two steps again.
+    ///
+    /// What: acquires the `events` lock, clones the replay buffer, reads the
+    /// status, and subscribes to the broadcast channel, releasing the lock only
+    /// once all three are in hand.
+    ///
+    /// The exactly-once argument, given that `push` appends AND broadcasts under
+    /// the same lock: the two critical sections are ordered, so for any event
+    /// either `push` ran first — its line is in the returned buffer, and its
+    /// broadcast preceded the subscription, so the receiver never sees it — or
+    /// this ran first, and the line is absent from the buffer while the
+    /// subscription predates the broadcast. Every event lands in exactly one of
+    /// the two paths. Before #6386 the broadcast sat outside `push`'s lock and the
+    /// subscribe outside the snapshot's, so an event could land in both (a
+    /// duplicate) or in neither (a LOST event).
+    ///
+    /// The terminal frame `ReindexTerminationGuard::drop` emits is the one
+    /// emission that does NOT route through `push` — `Drop` cannot await the lock,
+    /// so it broadcasts only. A subscriber that opens after that frame reads the
+    /// `Failed` status rather than the frame; that predates #6386 and is unchanged.
+    ///
+    /// Test: `no_event_is_lost_or_duplicated_when_a_stream_opens_against_live_pushes`
+    /// and `an_event_pushed_either_side_of_an_open_arrives_on_exactly_one_path` in
+    /// `progress_race_tests.rs`;
+    /// `an_event_either_side_of_the_stream_opening_is_delivered_exactly_once` in
+    /// `service::rpc::streams_tests` drives it end to end over both transports.
+    pub async fn subscribe_with_replay(
+        &self,
+    ) -> (Vec<String>, ReindexStatus, broadcast::Receiver<String>) {
+        let buffered = self.events.lock().await;
+        (
+            buffered.as_slice().to_vec(),
+            self.status.load(),
+            self.sender.subscribe(),
+        )
     }
 
     /// Load the current `indexed` counter with `Acquire` ordering.

--- a/crates/trusty-search/src/service/reindex/progress_race_tests.rs
+++ b/crates/trusty-search/src/service/reindex/progress_race_tests.rs
@@ -19,6 +19,16 @@
 //! deterministic composition either side of an open plus the two overflow paths
 //! the single lock hold must not have changed.
 //!
+//! A terminal event has a second, wider window of its own.
+//! [`a_terminal_status_is_not_observable_before_its_event_is_in_the_replay`] and
+//! [`a_stream_opened_across_the_terminal_transition_always_gets_the_terminal_frame`]
+//! cover it: the terminal transition used to store the status and push its frame
+//! as two unlocked steps, and on the `Complete` path an RSS poll, a git
+//! subprocess, a marker write and two `RwLock` writes sat between them. Both
+//! producers stop reading the live channel once the status is terminal, so an
+//! open in that window ended its stream with no terminal frame at all —
+//! `ReindexProgress::push_terminal` now does both under one lock hold.
+//!
 //! The race is only reachable across threads — before #6386 the window between
 //! the snapshot and the subscribe had no await point in it, so a single-threaded
 //! runtime could never schedule a push into it. That is why the regression test
@@ -52,6 +62,34 @@ const RACE_OPENERS: usize = 4;
 /// Events per trial. Deliberately below both channel bounds so a lagged
 /// subscriber or a truncated replay is a broken fixture rather than a finding.
 const RACE_EVENTS: usize = 200;
+
+/// Open-versus-terminal-transition races to run.
+const TERMINAL_RACE_TRIALS: usize = 512;
+/// Concurrent openers per terminal-transition trial, spawned either side of the
+/// emitter so some are always still opening when the transition lands.
+const TERMINAL_RACE_OPENERS: usize = 8;
+/// The `seq` the planted terminal frame carries. Far above any ordinary one so
+/// an assertion message names it unambiguously.
+const TERMINAL_SEQ: usize = 9_999;
+/// How long the lock-holding test watches for a leaked terminal status before
+/// concluding there is none. Proving an absence needs a bound; the watch returns
+/// the instant a leak appears, so only the healthy path pays this in full. A bare
+/// yield loop is NOT enough — it finishes before the emitter's worker is
+/// scheduled at all and passes vacuously, which is how this test was first
+/// written and why it went green against a reverted fix.
+const STATUS_LEAK_WATCH: std::time::Duration = std::time::Duration::from_millis(250);
+/// Gap between reads inside that watch — a real park, not a spin.
+const STATUS_LEAK_POLL: std::time::Duration = std::time::Duration::from_millis(1);
+
+/// The frame a terminal transition plants, shaped like the real `complete` event.
+fn terminal_event() -> serde_json::Value {
+    serde_json::json!({ "event": "complete", "seq": TERMINAL_SEQ })
+}
+
+/// Whether a replayed or broadcast line is the planted terminal frame.
+fn is_terminal(line: &str) -> bool {
+    seq_of(line) == TERMINAL_SEQ
+}
 
 /// The `seq` an event line carries.
 fn seq_of(line: &str) -> usize {
@@ -276,6 +314,149 @@ async fn the_replay_buffer_still_drops_its_oldest_at_the_cap() {
         MAX_REPLAY_EVENTS + overshoot - 1,
         "the newest event survives"
     );
+}
+
+/// Why: both stream producers stop reading the live channel the moment the
+/// status they opened with is terminal, so for such a subscriber the replay is
+/// the ONLY path the terminal frame can arrive on. A terminal transition used to
+/// store the status and push its frame as two unlocked steps, with an RSS poll, a
+/// git subprocess, a marker write and two `RwLock` writes between them on the
+/// `Complete` path. An open in that window read `Complete`, refused to read live,
+/// and got a replay with no terminal frame — its stream ended silently and its
+/// client waited for a completion that had already happened.
+///
+/// What: holds the replay-buffer lock, starts a real `push_terminal` against it,
+/// and checks the terminal status never becomes visible while that lock is held —
+/// which is what makes the store and the frame one step. Releasing the lock then
+/// proves the emission really did run, so the check above was not vacuous.
+/// Reverting `push_terminal` to `status.store` followed by `push` fails this
+/// immediately.
+///
+/// Test: this function IS the test.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_terminal_status_is_not_observable_before_its_event_is_in_the_replay() {
+    let progress = Arc::new(ReindexProgress::new());
+    progress.push(serde_json::json!({ "seq": 0 })).await;
+
+    // Hold the replay-buffer lock: every emission and every open must wait on it.
+    let held = progress.events.lock().await;
+
+    let (at_call_tx, at_call_rx) = tokio::sync::oneshot::channel();
+    let emitter = {
+        let progress = Arc::clone(&progress);
+        tokio::spawn(async move {
+            at_call_tx
+                .send(())
+                .expect("the test outlives its emitter task");
+            progress
+                .push_terminal(ReindexStatus::Complete, terminal_event())
+                .await;
+        })
+    };
+    at_call_rx
+        .await
+        .expect("the emitter must reach its terminal emission");
+
+    // The emitter is inside `push_terminal`, waiting on the lock this test holds.
+    // Watch the status for a bounded window: a leaked store is visible as soon as
+    // the emitter's worker runs, so this returns immediately when the invariant
+    // breaks and only waits out the budget on the healthy path.
+    let leaked = tokio::time::timeout(STATUS_LEAK_WATCH, async {
+        loop {
+            let seen = progress.status.load();
+            if seen != ReindexStatus::Running {
+                return seen;
+            }
+            tokio::time::sleep(STATUS_LEAK_POLL).await;
+        }
+    })
+    .await;
+    assert!(
+        leaked.is_err(),
+        "the terminal status became visible ({:?}) while the replay buffer was \
+         still locked, so an open in this window reads a terminal status, stops \
+         reading the live channel, and never sees the terminal frame (#6386)",
+        leaked.unwrap_or(ReindexStatus::Running),
+    );
+
+    drop(held);
+    emitter.await.expect("the terminal emission must not panic");
+
+    let (replay, status, _live) = progress.subscribe_with_replay().await;
+    assert_eq!(
+        status,
+        ReindexStatus::Complete,
+        "releasing the lock must let the transition through — otherwise the \
+         assertion above proved nothing"
+    );
+    assert!(
+        replay.iter().any(|line| is_terminal(line)),
+        "the terminal status and its frame must become visible together"
+    );
+}
+
+/// Why: the production interleaving of the case above — real opens racing a real
+/// terminal transition, on the multi-threaded runtime the daemon runs on. Each
+/// opener is judged by the rule its own transport applies: an open reporting
+/// `Running` reads the live channel, one reporting a terminal status reads only
+/// the replay. Either way the terminal frame must reach it exactly once.
+///
+/// What: races `TERMINAL_RACE_OPENERS` opens against one `push_terminal` over
+/// `TERMINAL_RACE_TRIALS` trials, half the openers spawned before the emitter and
+/// half after.
+///
+/// Test: this function IS the test.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_stream_opened_across_the_terminal_transition_always_gets_the_terminal_frame() {
+    for trial in 0..TERMINAL_RACE_TRIALS {
+        let progress = Arc::new(ReindexProgress::new());
+        progress.push(serde_json::json!({ "seq": 0 })).await;
+
+        let open = || {
+            let progress = Arc::clone(&progress);
+            tokio::spawn(async move { progress.subscribe_with_replay().await })
+        };
+
+        let mut openers: Vec<_> = (0..TERMINAL_RACE_OPENERS / 2).map(|_| open()).collect();
+        let emitter = {
+            let progress = Arc::clone(&progress);
+            tokio::spawn(async move {
+                progress
+                    .push_terminal(ReindexStatus::Complete, terminal_event())
+                    .await;
+            })
+        };
+        openers.extend((0..TERMINAL_RACE_OPENERS / 2).map(|_| open()));
+
+        emitter.await.expect("the emitter must not panic");
+
+        for (opener_n, opener) in openers.into_iter().enumerate() {
+            let (replay, status, mut live) = opener.await.expect("no opener may panic");
+            let in_replay = replay.iter().any(|line| is_terminal(line));
+
+            if status != ReindexStatus::Running {
+                assert!(
+                    in_replay,
+                    "trial {trial} opener {opener_n}: the open read status {status:?} but its \
+                     {replay_len}-event replay held no terminal frame — both producers stop \
+                     reading the live channel on a terminal status, so this stream ends \
+                     without one (#6386)",
+                    replay_len = replay.len(),
+                );
+            }
+
+            let seen = delivered(&replay, &mut live);
+            let arrivals = seen.iter().filter(|seq| **seq == TERMINAL_SEQ).count();
+            assert_eq!(
+                arrivals,
+                1,
+                "trial {trial} opener {opener_n}: the terminal frame arrived {arrivals} times \
+                 across the replay and the live channel, not once (status was {status:?}, \
+                 replay held {replay_len})",
+                replay_len = replay.len(),
+            );
+        }
+    }
 }
 
 /// Why: the status decides whether a producer subscribes at all — a stream that

--- a/crates/trusty-search/src/service/reindex/progress_race_tests.rs
+++ b/crates/trusty-search/src/service/reindex/progress_race_tests.rs
@@ -1,0 +1,299 @@
+//! #6386: opening a reindex stream against a running reindex must deliver every
+//! event exactly once.
+//!
+//! Why: a reindex stream opens by taking the replay buffer and then subscribing
+//! to the live broadcast. Until #6386 those were two separate steps, and
+//! `ReindexProgress::push` was two separate steps as well — it appended under the
+//! `events` lock and broadcast after releasing it. An event whose append landed
+//! after the snapshot and whose broadcast landed before the subscribe reached
+//! NEITHER path, so a dashboard silently missed a progress event; the mirror
+//! interleaving delivered one twice. Both arms are invisible to a consumer: a
+//! reindex that emits 100 events and streams 99 looks exactly like a reindex that
+//! emitted 99.
+//!
+//! What: [`no_event_is_lost_or_duplicated_when_a_stream_opens_against_live_pushes`]
+//! is the regression test — it races real opens against real pushes on a
+//! multi-threaded runtime and checks the one invariant the fix buys: the replay
+//! an open returns, unioned with everything its subscription then delivers, is
+//! every pushed event, each appearing once. The remaining cases pin the
+//! deterministic composition either side of an open plus the two overflow paths
+//! the single lock hold must not have changed.
+//!
+//! The race is only reachable across threads — before #6386 the window between
+//! the snapshot and the subscribe had no await point in it, so a single-threaded
+//! runtime could never schedule a push into it. That is why the regression test
+//! is a multi-threaded race rather than a barrier-sequenced pair, and why it
+//! carries enough trials to make the pre-fix loss reproducible.
+//!
+//! Test: this file IS the test module.
+
+use std::collections::BTreeSet;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use tokio::sync::broadcast::error::TryRecvError;
+
+use super::progress::{BROADCAST_CAPACITY, MAX_REPLAY_EVENTS};
+use super::{ReindexProgress, ReindexStatus};
+
+/// How many independent open-versus-push races to run.
+///
+/// Why this many: one trial is one scheduling coincidence, and the pre-fix window
+/// was a few instructions wide. At 4 openers per trial this is ~2 000 chances for
+/// a push to land inside an open. 128 trials reproduced the pre-fix defect on
+/// only about half of isolated runs; this count failed every reverted run
+/// measured, and the whole loop still finishes in well under a second because it
+/// touches nothing but memory.
+const RACE_TRIALS: usize = 512;
+/// Concurrent writers per trial — enough that some are always mid-emission.
+const RACE_PUSHERS: usize = 8;
+/// Concurrent readers per trial, each checked independently.
+const RACE_OPENERS: usize = 4;
+/// Events per trial. Deliberately below both channel bounds so a lagged
+/// subscriber or a truncated replay is a broken fixture rather than a finding.
+const RACE_EVENTS: usize = 200;
+
+/// The `seq` an event line carries.
+fn seq_of(line: &str) -> usize {
+    let event: serde_json::Value =
+        serde_json::from_str(line).expect("every planted event is one JSON document");
+    usize::try_from(
+        event["seq"]
+            .as_u64()
+            .expect("every planted event carries a numeric seq"),
+    )
+    .expect("seq fits a usize")
+}
+
+/// Every `seq` on the replay, then every `seq` the subscription still holds.
+///
+/// The order is the order a stream producer would emit them: replay first, live
+/// after. Duplicates are preserved rather than folded, because a repeat is one of
+/// the two failures under test.
+fn delivered(replay: &[String], live: &mut tokio::sync::broadcast::Receiver<String>) -> Vec<usize> {
+    let mut seen: Vec<usize> = replay.iter().map(|line| seq_of(line)).collect();
+    loop {
+        match live.try_recv() {
+            Ok(line) => seen.push(seq_of(&line)),
+            Err(TryRecvError::Empty | TryRecvError::Closed) => return seen,
+            Err(TryRecvError::Lagged(skipped)) => panic!(
+                "the subscriber lagged by {skipped}: this fixture pushes {RACE_EVENTS} events \
+                 into a {BROADCAST_CAPACITY}-slot channel, so a lag means the fixture broke, \
+                 not that the open lost anything"
+            ),
+        }
+    }
+}
+
+/// Why: this is the #6386 regression. Before the fix, an event pushed while a
+/// stream was opening could be appended after the open's snapshot and broadcast
+/// before its subscribe, reaching neither path — a progress event silently
+/// missing from a dashboard, with no error anywhere. The mirror interleaving
+/// delivered one twice.
+///
+/// What: races `RACE_OPENERS` real opens against `RACE_PUSHERS` real writers over
+/// `RACE_TRIALS` trials on a multi-threaded runtime. Each opener is then checked
+/// alone: its replay plus everything its subscription delivered must be the full
+/// pushed set, with no repeats. Reverting either half of the fix — the broadcast
+/// back outside `push`'s lock, or the subscribe back outside the snapshot's —
+/// fails this within a few trials.
+///
+/// Test: this function IS the test.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn no_event_is_lost_or_duplicated_when_a_stream_opens_against_live_pushes() {
+    // The fixture must not be able to lag or truncate on its own: a lag or a
+    // dropped replay entry would read as a lost event and accuse the code wrongly.
+    const { assert!(RACE_EVENTS < BROADCAST_CAPACITY && RACE_EVENTS <= MAX_REPLAY_EVENTS) };
+    let expected: BTreeSet<usize> = (0..RACE_EVENTS).collect();
+
+    for trial in 0..RACE_TRIALS {
+        let progress = Arc::new(ReindexProgress::new());
+        let next = Arc::new(AtomicUsize::new(0));
+
+        let pushers: Vec<_> = (0..RACE_PUSHERS)
+            .map(|_| {
+                let progress = Arc::clone(&progress);
+                let next = Arc::clone(&next);
+                tokio::spawn(async move {
+                    loop {
+                        let seq = next.fetch_add(1, Ordering::Relaxed);
+                        if seq >= RACE_EVENTS {
+                            return;
+                        }
+                        progress.push(serde_json::json!({ "seq": seq })).await;
+                    }
+                })
+            })
+            .collect();
+
+        // Spawned without yielding first: the writers are already running, so an
+        // open lands mid-emission rather than after the last one.
+        let openers: Vec<_> = (0..RACE_OPENERS)
+            .map(|_| {
+                let progress = Arc::clone(&progress);
+                tokio::spawn(async move { progress.subscribe_with_replay().await })
+            })
+            .collect();
+
+        for pusher in pushers {
+            pusher.await.expect("no writer may panic");
+        }
+
+        for (opener_n, opener) in openers.into_iter().enumerate() {
+            let (replay, _status, mut live) = opener.await.expect("no opener may panic");
+            let seen = delivered(&replay, &mut live);
+            let unique: BTreeSet<usize> = seen.iter().copied().collect();
+
+            assert_eq!(
+                seen.len(),
+                unique.len(),
+                "trial {trial} opener {opener_n}: an event was delivered twice — \
+                 it was in the {replay_len}-event replay AND arrived live",
+                replay_len = replay.len(),
+            );
+            let lost: Vec<usize> = expected.difference(&unique).copied().collect();
+            assert!(
+                lost.is_empty(),
+                "trial {trial} opener {opener_n}: {count} event(s) reached neither the replay \
+                 nor the live subscription — seq {lost:?} (replay held {replay_len})",
+                count = lost.len(),
+                replay_len = replay.len(),
+            );
+        }
+    }
+}
+
+/// Why: the two orderings either side of an open are what a consumer actually
+/// depends on — an event emitted before it connected must arrive from the replay
+/// and not again live, and one emitted after must arrive live and not already sit
+/// in the replay. A rewrite that replayed twice, subscribed before snapshotting,
+/// or dropped the replay changes one of these counts.
+///
+/// What: pushes one event, opens, then pushes a second, checking each path's
+/// contents at every step; then re-opens to prove the buffer itself still holds
+/// each event once.
+///
+/// Test: this function IS the test.
+#[tokio::test]
+async fn an_event_pushed_either_side_of_an_open_arrives_on_exactly_one_path() {
+    let progress = ReindexProgress::new();
+    progress.push(serde_json::json!({ "seq": 0 })).await;
+
+    let (replay, status, mut live) = progress.subscribe_with_replay().await;
+    assert_eq!(
+        replay.iter().map(|line| seq_of(line)).collect::<Vec<_>>(),
+        vec![0],
+        "the event pushed before the open must be replayed"
+    );
+    assert_eq!(
+        status,
+        ReindexStatus::Running,
+        "the open reports the status it read under the same lock"
+    );
+    assert!(
+        matches!(live.try_recv(), Err(TryRecvError::Empty)),
+        "the replayed event must not also arrive live"
+    );
+
+    progress.push(serde_json::json!({ "seq": 1 })).await;
+    let live_line = live
+        .try_recv()
+        .expect("the event pushed after the open must arrive live");
+    assert_eq!(seq_of(&live_line), 1);
+    assert!(
+        matches!(live.try_recv(), Err(TryRecvError::Empty)),
+        "nothing beyond that one event may arrive"
+    );
+
+    let (replay, _status, _live) = progress.subscribe_with_replay().await;
+    assert_eq!(
+        replay.iter().map(|line| seq_of(line)).collect::<Vec<_>>(),
+        vec![0, 1],
+        "a later open replays both events, once each"
+    );
+}
+
+/// Why: a subscriber that falls behind must still be TOLD, because both stream
+/// producers turn `Lagged` into the `{"type":"lag","skipped":N}` frame a consumer
+/// reads as "you missed some". Broadcasting under `push`'s lock must not have
+/// turned an overrun into silence or into an end-of-stream.
+///
+/// What: opens, pushes past the channel's capacity without reading, and checks
+/// the overrun is reported and that reception then resumes at the oldest event
+/// the channel still holds.
+///
+/// Test: this function IS the test.
+#[tokio::test]
+async fn a_subscriber_that_outruns_the_channel_still_reports_its_lag() {
+    let progress = ReindexProgress::new();
+    let (_replay, _status, mut live) = progress.subscribe_with_replay().await;
+
+    for seq in 0..BROADCAST_CAPACITY + 16 {
+        progress.push(serde_json::json!({ "seq": seq })).await;
+    }
+
+    let skipped = match live.try_recv() {
+        Err(TryRecvError::Lagged(skipped)) => skipped,
+        other => panic!("an overrun subscriber must report Lagged, got {other:?}"),
+    };
+    assert!(skipped > 0, "a reported lag must name a non-zero count");
+
+    let resumed = live
+        .try_recv()
+        .expect("a lagged subscriber resumes rather than ending");
+    assert_eq!(
+        u64::try_from(seq_of(&resumed)).expect("seq fits a u64"),
+        skipped,
+        "reception resumes at the oldest event the channel still holds"
+    );
+}
+
+/// Why: `push` now holds the `events` lock across the broadcast, and the
+/// over-cap eviction sits inside that same hold. A subscriber that opens after a
+/// pathological reindex must still get the most recent `MAX_REPLAY_EVENTS` and
+/// not an unbounded buffer.
+///
+/// What: pushes past the cap and checks the replay's length and both ends.
+///
+/// Test: this function IS the test.
+#[tokio::test]
+async fn the_replay_buffer_still_drops_its_oldest_at_the_cap() {
+    let progress = ReindexProgress::new();
+    let overshoot = 5;
+    for seq in 0..MAX_REPLAY_EVENTS + overshoot {
+        progress.push(serde_json::json!({ "seq": seq })).await;
+    }
+
+    let (replay, _status, _live) = progress.subscribe_with_replay().await;
+    assert_eq!(replay.len(), MAX_REPLAY_EVENTS, "the cap still bounds it");
+    assert_eq!(
+        seq_of(&replay[0]),
+        overshoot,
+        "the oldest {overshoot} events were evicted"
+    );
+    assert_eq!(
+        seq_of(replay.last().expect("a capped buffer is never empty")),
+        MAX_REPLAY_EVENTS + overshoot - 1,
+        "the newest event survives"
+    );
+}
+
+/// Why: the status decides whether a producer subscribes at all — a stream that
+/// read `Running` for a finished reindex would park on a broadcast nothing will
+/// send to again. Reading it inside the open's lock hold is what keeps it
+/// consistent with the replay handed back beside it.
+///
+/// What: pushes a terminal event, flips the status, and checks the open reports
+/// both together.
+///
+/// Test: this function IS the test.
+#[tokio::test]
+async fn an_open_reports_the_status_beside_the_replay_it_snapshotted() {
+    let progress = ReindexProgress::new();
+    progress.push(serde_json::json!({ "seq": 0 })).await;
+    progress.status.store(ReindexStatus::Complete);
+
+    let (replay, status, _live) = progress.subscribe_with_replay().await;
+    assert_eq!(status, ReindexStatus::Complete);
+    assert_eq!(replay.len(), 1, "the terminal event is in the replay");
+}

--- a/crates/trusty-search/src/service/reindex/runner.rs
+++ b/crates/trusty-search/src/service/reindex/runner.rs
@@ -152,15 +152,14 @@ pub(super) async fn run_reindex(
             // tree the corpus was never relativized against.
             root_gate::restore_indexer_root_after_refusal(&handle, &refusal).await;
             mark_reindex_failed(&handle, &refusal.reason).await;
-            progress.status.store(ReindexStatus::Failed);
-            progress
-                .push(serde_json::json!({
-                    "event": "error",
-                    "index_id": index_id.0,
-                    "message": refusal.reason,
-                    "fatal": true,
-                }))
-                .await;
+            // #6386: status and frame in one hold — see `push_terminal`.
+            let frame = serde_json::json!({
+                "event": "error",
+                "index_id": index_id.0,
+                "message": refusal.reason,
+                "fatal": true,
+            });
+            progress.push_terminal(ReindexStatus::Failed, frame).await;
             // term_guard drops here → broadcasts error event via Drop (mirrors
             // the carryover-copy-failure abort path below).
             drop(term_guard);
@@ -260,17 +259,17 @@ pub(super) async fn run_reindex(
         // at the `InProgress` that `reset_stages_for_reindex` just set would
         // strand the index mid-walk with no reindex in flight.
         super::stages::mark_reindex_failed_before_lexical(&handle, &reason).await;
-        progress.status.store(ReindexStatus::Failed);
-        progress
-            .push(serde_json::json!({
-                "event": "error",
-                "index_id": index_id.0,
-                "message": reason,
-                "fatal": true,
-            }))
-            .await;
+        // #6386: status and frame in one hold — see `push_terminal`.
+        let frame = serde_json::json!({
+            "event": "error",
+            "index_id": index_id.0,
+            "message": reason,
+            "fatal": true,
+        });
+        progress.push_terminal(ReindexStatus::Failed, frame).await;
         // #4356 (review): the frame above is this run's ONE terminal event, and
-        // `push` also wrote it to the replay buffer, which `Drop` cannot reach.
+        // `push_terminal` also wrote it to the replay buffer, which `Drop` cannot
+        // reach.
         // Leaving the guard armed broadcasts a SECOND `fatal` frame reading
         // "exited unexpectedly (panic or cancellation)" — the CLI prints every
         // error frame it receives (`commands::reindex_engine::events`), so an
@@ -448,18 +447,17 @@ pub(super) async fn run_reindex(
                     );
                     mark_reindex_failed(&handle, "carryover copy failed — live corpus intact")
                         .await;
-                    progress.status.store(ReindexStatus::Failed);
-                    progress
-                        .push(serde_json::json!({
-                            "event": "error",
-                            "index_id": index_id.0,
-                            "message": format!(
-                                "incremental reindex aborted: failed to copy live corpus \
-                                 into staging store ({e}) — live corpus is intact"
-                            ),
-                            "fatal": true,
-                        }))
-                        .await;
+                    // #6386: status and frame in one hold — see `push_terminal`.
+                    let frame = serde_json::json!({
+                        "event": "error",
+                        "index_id": index_id.0,
+                        "message": format!(
+                            "incremental reindex aborted: failed to copy live corpus \
+                             into staging store ({e}) — live corpus is intact"
+                        ),
+                        "fatal": true,
+                    });
+                    progress.push_terminal(ReindexStatus::Failed, frame).await;
                     // term_guard drops here → broadcasts error event via Drop.
                     drop(term_guard);
                     schedule_progress_cleanup(cleanup_map, cleanup_id);

--- a/crates/trusty-search/src/service/rpc/streams.rs
+++ b/crates/trusty-search/src/service/rpc/streams.rs
@@ -219,25 +219,16 @@ fn status_stream(state: &Arc<SearchAppState>) -> RpcStreamItems {
 /// `search.index.reindex.stream` — the item sequence
 /// `GET /indexes/{id}/reindex/stream` writes.
 ///
-/// What, in the order `reindex_stream_handler` does it: look the index's
-/// progress up and refuse when there is none, snapshot the replay buffer, read
-/// the status, then subscribe.
+/// What: look the index's progress up and refuse when there is none, then open
+/// the stream through [`ReindexProgress::subscribe_with_replay`], which hands
+/// back the replay buffer, the status, and the live subscription together.
 ///
-/// That ordering is copied from the SSE handler deliberately, and it is not
-/// race-free in either place. `ReindexProgress::push` writes the replay buffer
-/// under its lock and THEN broadcasts, while this clones the buffer under the
-/// same lock and THEN subscribes, so an event whose two halves straddle the open
-/// can be delivered TWICE (buffered before the snapshot, broadcast after the
-/// subscribe) or NOT AT ALL (buffered after the snapshot, broadcast before the
-/// subscribe). Both transports inherit it identically, which is why parity holds
-/// and why this slice copies rather than corrects it: subscribing before
-/// snapshotting would close the loss arm, but it changes the shipped SSE route's
-/// behaviour and belongs to its own change. See #6285 (slice 5.5 review).
-///
-/// The window itself is not drivable from a test — there is no await point
-/// between the snapshot and the subscribe, so it is only reachable from another
-/// thread at an instant nothing exposes. What IS pinned is the composition
-/// either side of it.
+/// #6386: that ONE call is what makes the open exactly-once. It used to be three
+/// statements here — snapshot, read status, subscribe — copied by hand from the
+/// SSE handler, and an event whose buffer write and broadcast straddled them
+/// could arrive twice or not at all. The SSE route now opens through the same
+/// method, so parity holds by construction rather than by two hand-kept copies;
+/// the argument for why nothing can straddle it is on that method.
 ///
 /// A progress record whose status is no longer `Running` yields its replay and
 /// ends. Without that arm the stream would deliver the buffered `complete` event
@@ -254,6 +245,7 @@ fn status_stream(state: &Arc<SearchAppState>) -> RpcStreamItems {
 /// Test: `reindex_progress_events_match_the_sse_body_frame_for_frame`,
 /// `a_live_reindex_stream_delivers_events_in_order_as_they_are_emitted`,
 /// `an_event_either_side_of_the_stream_opening_is_delivered_exactly_once`,
+/// `a_stream_opening_against_live_pushes_loses_and_repeats_nothing`,
 /// `an_unknown_index_is_refused_before_the_reindex_stream_opens`.
 async fn reindex_stream(
     state: &Arc<SearchAppState>,
@@ -273,9 +265,9 @@ async fn reindex_stream(
             )
         })?;
 
-    let replay = progress.events.lock().await.clone();
-    let live = progress.status.load() == ReindexStatus::Running;
-    let mut events = progress.sender.subscribe();
+    // #6386: one atomic open — no event can straddle the snapshot and the subscribe.
+    let (replay, status, mut events) = progress.subscribe_with_replay().await;
+    let live = status == ReindexStatus::Running;
 
     let (tx, items) = mpsc::channel(STREAM_BUFFER);
     tokio::spawn(async move {

--- a/crates/trusty-search/src/service/rpc/streams_tests.rs
+++ b/crates/trusty-search/src/service/rpc/streams_tests.rs
@@ -314,20 +314,16 @@ async fn a_live_reindex_stream_delivers_events_in_order_as_they_are_emitted() {
     );
 }
 
-/// Why: `reindex_stream` snapshots the replay buffer and THEN subscribes, and
-/// `ReindexProgress::push` buffers under the same lock and THEN broadcasts — so
-/// an event whose two halves straddle the open can be delivered twice or lost.
-/// That instant is not drivable: `reindex_stream` has no await point between the
-/// snapshot and the subscribe, so the window is only reachable from another
-/// thread with no seam to stop at.
+/// Why: `reindex_stream` opens through `ReindexProgress::subscribe_with_replay`,
+/// which takes the replay buffer and the live subscription under one lock hold
+/// that `push` also takes across its append and its broadcast — so no event can
+/// straddle an open (#6386). This pins the two orderings a consumer depends on:
+/// an event pushed strictly BEFORE the open arrives once, from the replay; one
+/// pushed strictly AFTER arrives once, live. A rewrite that replayed twice or
+/// dropped the replay changes one of those two counts.
 ///
-/// What this pins is the composition either side of it — the two orderings that
-/// ARE deterministic. An event pushed strictly BEFORE the open arrives once, from
-/// the replay; one pushed strictly AFTER arrives once, live. A rewrite that
-/// subscribed before snapshotting, replayed twice, or dropped the replay changes
-/// one of those two counts, so it fails here even though the race itself is not
-/// reproducible. The window is inherited from the SSE handler and accepted, not
-/// introduced by this slice (#6285).
+/// The concurrent case — an event pushed WHILE the stream opens — is
+/// `a_stream_opening_against_live_pushes_loses_and_repeats_nothing` below.
 /// Test: this function IS the test.
 #[tokio::test(flavor = "multi_thread")]
 async fn an_event_either_side_of_the_stream_opening_is_delivered_exactly_once() {
@@ -363,6 +359,77 @@ async fn an_event_either_side_of_the_stream_opening_is_delivered_exactly_once() 
     let latest = serde_json::json!({ "event": "complete", "indexed": 2, "elapsed_ms": 3 });
     progress.push(latest.clone()).await;
     assert_eq!(take_items(&mut items, 1).await, vec![latest]);
+}
+
+/// Why: #6386 end to end, on the transport a dashboard actually reads. The unit
+/// coverage in `reindex::progress_race_tests` proves `subscribe_with_replay` is
+/// exactly-once; this proves the socket producer built on it delivers that
+/// sequence whole — replay first, live after, nothing dropped between them — while
+/// a reindex is emitting. Before the fix an event pushed inside the open reached
+/// neither path, and a dashboard's progress simply skipped a batch with no error
+/// anywhere.
+///
+/// What: opens the real stream while eight writers push a known set through the
+/// real `ReindexProgress::push`, then reads exactly as many items as were pushed
+/// and checks the delivered `seq` values are that set — a lost event shows up as a
+/// missing one, a repeated event as a missing one plus a duplicate.
+/// Test: this function IS the test.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_stream_opening_against_live_pushes_loses_and_repeats_nothing() {
+    /// Below the 256-slot broadcast channel and the 500-event replay cap, so a
+    /// lag or a truncation here would be a broken fixture rather than a finding.
+    const EVENTS: usize = 120;
+    const WRITERS: usize = 8;
+
+    let (state, _http, rpc) = routers(&["rs"]).await;
+    let progress = plant_progress(&state, "rs", ReindexStatus::Running, &[]).await;
+    let next = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+    let writers: Vec<_> = (0..WRITERS)
+        .map(|_| {
+            let progress = Arc::clone(&progress);
+            let next = Arc::clone(&next);
+            tokio::spawn(async move {
+                loop {
+                    let seq = next.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    if seq >= EVENTS {
+                        return;
+                    }
+                    progress.push(serde_json::json!({ "seq": seq })).await;
+                }
+            })
+        })
+        .collect();
+
+    // Opened while the writers are mid-run, which is the whole point.
+    let mut items = open_stream(
+        &rpc,
+        streams::METHOD_INDEX_REINDEX_STREAM,
+        serde_json::json!({ "index_id": "rs" }),
+    )
+    .await;
+
+    let delivered = take_items(&mut items, EVENTS).await;
+    for writer in writers {
+        writer.await.expect("no writer may panic");
+    }
+
+    let seen: std::collections::BTreeSet<u64> = delivered
+        .iter()
+        .map(|item| {
+            item["seq"]
+                .as_u64()
+                .unwrap_or_else(|| panic!("every item must be a planted event, got {item}"))
+        })
+        .collect();
+    let expected: std::collections::BTreeSet<u64> = (0..EVENTS as u64).collect();
+    let missing: Vec<u64> = expected.difference(&seen).copied().collect();
+    assert!(
+        missing.is_empty(),
+        "{count} of the first {EVENTS} items were not the {EVENTS} pushed events — seq \
+         {missing:?} never arrived, so the open either lost them or repeated something else",
+        count = missing.len(),
+    );
 }
 
 /// Why: the SSE route answers `404` for an index with no recorded reindex, and a

--- a/crates/trusty-search/src/service/server/reindex_handlers.rs
+++ b/crates/trusty-search/src/service/server/reindex_handlers.rs
@@ -423,8 +423,12 @@ const SSE_HEARTBEAT_FRAME: &str = ": heartbeat\n\n";
 /// in `Body::from_stream` and returned as `text/event-stream`.
 ///
 /// Test: `reindex_stream_handler` is exercised by the full-reindex integration
-/// path. The heartbeat interval fires independently of real events so it
-/// cannot be blocked by a stalled sidecar.
+/// path and by `reindex_progress_events_match_the_sse_body_frame_for_frame` in
+/// `service::rpc::streams_tests`, which compares it frame for frame against the
+/// socket stream that opens the same way. The heartbeat interval fires
+/// independently of real events so it cannot be blocked by a stalled sidecar.
+/// `service::reindex::progress_race_tests` covers the #6386 exactly-once open
+/// both surfaces now share.
 pub(super) async fn reindex_stream_handler(
     State(state): State<Arc<SearchAppState>>,
     Path(id): Path<String>,
@@ -436,18 +440,12 @@ pub(super) async fn reindex_stream_handler(
         .map(|r| Arc::clone(r.value()))
         .ok_or(StatusCode::NOT_FOUND)?;
 
-    // Snapshot the replay buffer first so we don't miss the `start` event, then
-    // subscribe for live updates.
-    //
-    // #6285: an event that straddles the two can be delivered twice OR lost —
-    // `ReindexProgress::push` buffers under its lock and then broadcasts, so an
-    // event broadcast between this snapshot and the subscribe below reaches
-    // neither path. The earlier claim here that the race only duplicates was
-    // wrong. `service::rpc::streams::reindex_stream` copies this ordering, so both
-    // transports behave identically; correcting it is its own change.
-    let replay = progress.events.lock().await.clone();
-    let initial_status = progress.status.load();
-    let rx = progress.sender.subscribe();
+    // #6386: take the replay buffer, the status, and the live subscription as ONE
+    // atomic step, so no event can be buffered after the snapshot and broadcast
+    // before the subscribe (which lost it) or land in both (which repeated it).
+    // `service::rpc::streams::reindex_stream` opens through the same method, so
+    // the two transports cannot drift.
+    let (replay, initial_status, rx) = progress.subscribe_with_replay().await;
 
     fn frame(line: String) -> Result<axum::body::Bytes, std::io::Error> {
         Ok(axum::body::Bytes::from(format!("data: {line}\n\n")))


### PR DESCRIPTION
Refs #6386.

## What changed

`ReindexProgress::push` now broadcasts while still holding the `events` lock,
and both reindex-stream transports open through one new
`ReindexProgress::subscribe_with_replay`, which takes the replay buffer, the
status, and the live subscription under that same lock. The two critical
sections are ordered, so every event lands on exactly one path — replay or
live, never both, never neither.

`GET /indexes/{id}/reindex/stream` (SSE) and `search.index.reindex.stream`
(socket) each carried their own copy of the two-step open. Both now call the
one method. No frame sequence changes for a client that was not hitting the
race.

## Rung

Rung 5 (concurrency / cross-transport contract).

## Gates

```
cargo fmt --check                                        EXIT=0
cargo clippy -p trusty-search --all-targets -- -D warnings   EXIT=0
cargo test -p trusty-search --no-fail-fast -- --test-threads=1   EXIT=0
  lib: 1916 passed; 0 failed; 1 ignored
  integration targets: all ok (437 passed on the largest)
bash scripts/check_line_cap.sh          0 violations
bash scripts/check_sld.sh               0 errors, 0 warnings
bash scripts/check_changelog_fragment.sh  OK trusty-search
```

Two parallel-run flakes appeared in the unserialized run, a different one each
time — `service::rpc::admin::tests::registry_orphans_over_the_socket_matches_the_http_body`
and `core::indexer::tests::path_filter_search::test_path_prefix_filter_recovers_bm25_match_beyond_want`.
Both pass alone, and the whole crate is green under `--test-threads=1`
(protocol step 3). Neither is reachable from anything this branch changed.

## Regression evidence

`no_event_is_lost_or_duplicated_when_a_stream_opens_against_live_pushes` races
4 opens against 8 writers over 512 trials and checks that each opener's replay
plus everything its subscription delivered is the full pushed set, once each.
Reverting both halves of the fix failed it on 8 of 8 runs, on both arms:

```
trial 36 opener 3: 2 event(s) reached neither the replay nor the live
subscription — seq [44, 59] (replay held 57)

trial 71 opener 0: an event was delivered twice — it was in the 15-event
replay AND arrived live
  left: 201
 right: 200
```

Post-fix, 10 consecutive runs of the new module and 10 of the end-to-end case:

```
test result: ok. 5 passed; 0 failed; 0 ignored  (×10, 0.62–0.77s)
test result: ok. 1 passed; 0 failed; 0 ignored  (×10, 0.02s)
```

## Coverage added

- `progress_race_tests.rs` — the race above, the deterministic either-side
  composition, plus the two overflow paths the single lock hold must not have
  changed (lagged subscriber still reports its skip count; the replay buffer
  still evicts at `MAX_REPLAY_EVENTS`).
- `a_stream_opening_against_live_pushes_loses_and_repeats_nothing` in
  `streams_tests.rs` — the same race through the real socket producer.

## Not covered

`ReindexTerminationGuard::drop` broadcasts without appending to the replay
buffer, because `Drop` cannot await the lock. That predates #6386 and is
unchanged; it is documented on `subscribe_with_replay`.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
