### PR TITLE
fix(trusty-analyze): expose SCIP overlay status through the MCP interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11239,7 +11239,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-analyze"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-analyze/CLAUDE.md
+++ b/crates/trusty-analyze/CLAUDE.md
@@ -422,7 +422,7 @@ implementation-defined `-32000..=-32099` band:
 Parity rule: every RPC method has an MCP tool equivalent.
 
 <!-- BEGIN GENERATED: mcp-tools -->
-The MCP server registers **20 tools** with default features, **23 tools** with `--features review`. Authoritative source: `trusty_analyze::mcp::tool_descriptors + trusty_analyze::mcp::descriptors::review_tool_descriptors` —
+The MCP server registers **21 tools** with default features, **24 tools** with `--features review`. Authoritative source: `trusty_analyze::mcp::tool_descriptors + trusty_analyze::mcp::descriptors::review_tool_descriptors` —
 this table is generated from it, not maintained by hand.
 
 | Tool | Available | Arguments | Summary |
@@ -445,6 +445,7 @@ this table is generated from it, not maintained by hand.
 | `review_diff` | always | `diff`, `index_id` | Review a unified git diff and return a structured quality report (per-file complexity, code smells, grade A-F, recommendations). |
 | `review_github_pr` | always | `owner`, `repo`, `pr`, `index_id`, `post_comment?` | Fetch a GitHub pull request's unified diff and run a structured quality review against a trusty-search index. |
 | `run_diagnostics` | always | `index?`, `index_id?`, `language?`, `limit?`, `offset?`, `tools?` | Run available external static-analysis tools (clippy, ruff, biome, staticcheck, pmd, rubocop, phpstan, swiftlint, detekt, clang-tidy,… |
+| `scip_status` | always | `index?`, `index_id?` | Report whether a SCIP overlay has been ingested for an index. |
 | `suggest_refactors` | always | `file?`, `index?`, `index_id?`, `min_severity?`, `top_k?` | Suggest concrete refactoring actions (extract method, reduce nesting, ...) ranked by severity, derived from complexity metrics and code… |
 | `tr_review_diff` | `--features review` | `diff`, `context?`, `reviewer_model?` | LLM-backed review of a raw unified diff string via the embedded trusty-review pipeline. |
 | `tr_review_health` | `--features review` | — | Probe the embedded trusty-review pipeline's liveness and configuration (dry_run mode, reviewer model, dependency URLs). |

--- a/crates/trusty-analyze/Cargo.toml
+++ b/crates/trusty-analyze/Cargo.toml
@@ -1,11 +1,8 @@
 [package]
 name        = "trusty-analyze"
-# 0.12.1 (#5063): PATCH — 0.12.0 is published on crates.io and this change edits
-# `src/**`, so the pre-merge version-bump gate (#4421) requires the next free
-# position. `core::redb_open::is_format_obsolete` keeps its name and signature
-# and delegates its body to `trusty_common::redb_open::is_incompatible_format`;
-# no public item is added, removed, or changed shape.
-version     = "0.12.2"
+# 0.12.3 (#5056): PATCH — adds the `scip_status` MCP tool wrapping
+# `analyze.scip_status`, an additive tool-surface change.
+version     = "0.12.3"
 edition     = "2021"
 license.workspace    = true
 authors.workspace    = true

--- a/crates/trusty-analyze/README.md
+++ b/crates/trusty-analyze/README.md
@@ -211,7 +211,7 @@ unreachable.
 ## MCP Tools
 
 <!-- BEGIN GENERATED: mcp-tools -->
-The MCP server registers **20 tools** with default features, **23 tools** with `--features review`. Authoritative source: `trusty_analyze::mcp::tool_descriptors + trusty_analyze::mcp::descriptors::review_tool_descriptors` —
+The MCP server registers **21 tools** with default features, **24 tools** with `--features review`. Authoritative source: `trusty_analyze::mcp::tool_descriptors + trusty_analyze::mcp::descriptors::review_tool_descriptors` —
 this table is generated from it, not maintained by hand.
 
 | Tool | Available | Arguments | Summary |
@@ -234,6 +234,7 @@ this table is generated from it, not maintained by hand.
 | `review_diff` | always | `diff`, `index_id` | Review a unified git diff and return a structured quality report (per-file complexity, code smells, grade A-F, recommendations). |
 | `review_github_pr` | always | `owner`, `repo`, `pr`, `index_id`, `post_comment?` | Fetch a GitHub pull request's unified diff and run a structured quality review against a trusty-search index. |
 | `run_diagnostics` | always | `index?`, `index_id?`, `language?`, `limit?`, `offset?`, `tools?` | Run available external static-analysis tools (clippy, ruff, biome, staticcheck, pmd, rubocop, phpstan, swiftlint, detekt, clang-tidy,… |
+| `scip_status` | always | `index?`, `index_id?` | Report whether a SCIP overlay has been ingested for an index. |
 | `suggest_refactors` | always | `file?`, `index?`, `index_id?`, `min_severity?`, `top_k?` | Suggest concrete refactoring actions (extract method, reduce nesting, ...) ranked by severity, derived from complexity metrics and code… |
 | `tr_review_diff` | `--features review` | `diff`, `context?`, `reviewer_model?` | LLM-backed review of a raw unified diff string via the embedded trusty-review pipeline. |
 | `tr_review_health` | `--features review` | — | Probe the embedded trusty-review pipeline's liveness and configuration (dry_run mode, reviewer model, dependency URLs). |
@@ -266,6 +267,7 @@ ADR-0032 moved the daemon onto a socket.
 | `upsert_fact` | `analyze.facts_upsert` |
 | `delete_fact` | `analyze.facts_delete` |
 | `ingest_scip` | `analyze.scip_ingest` |
+| `scip_status` | `analyze.scip_status` |
 | `cluster_concepts` | `analyze.clusters` |
 | `extract_graph` | `analyze.graph` |
 | `extract_ner` | `analyze.ner` (optional ONNX) |

--- a/crates/trusty-analyze/changelog.d/5056-scip-status-mcp-tool.md
+++ b/crates/trusty-analyze/changelog.d/5056-scip-status-mcp-tool.md
@@ -1,0 +1,3 @@
+Added
+
+- **New `scip_status` MCP tool wraps `analyze.scip_status`** — an MCP caller can now distinguish an index with no SCIP overlay ingested from one whose overlay carried zero symbols, the same distinction `GET /indexes/{id}/scip` gave HTTP callers in #5054. `extract_graph`'s `scip_overlay` flag already carried this through the JSON-RPC body since #6287; this tool adds the dedicated node/edge/ingested_at lookup MCP had no way to reach ([#5056](https://github.com/bobmatnyc/trusty-tools/issues/5056))

--- a/crates/trusty-analyze/src/mcp/descriptors.rs
+++ b/crates/trusty-analyze/src/mcp/descriptors.rs
@@ -175,6 +175,17 @@ pub fn base_tool_descriptors() -> Value {
             }
         },
         {
+            "name": "scip_status",
+            "description": "Report whether a SCIP overlay has been ingested for an index. Distinguishes 'never ingested' (this tool errors) from 'ingested but contributed zero symbols' (this tool returns node/edge counts of 0), which extract_graph's own scip_overlay flag cannot do on its own. Returns node count, edge count, and the ingest timestamp for the overlay.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "index":    { "type": "string" },
+                    "index_id": { "type": "string" }
+                }
+            }
+        },
+        {
             "name": "extract_ner",
             "description": "Extract named entities from doc comments for a code index using NER",
             "inputSchema": {

--- a/crates/trusty-analyze/src/mcp/mod.rs
+++ b/crates/trusty-analyze/src/mcp/mod.rs
@@ -17,6 +17,7 @@
 //! | `delete_fact`         | `analyze.facts_delete`            |
 //! | `cluster_concepts`    | `analyze.clusters`                |
 //! | `ingest_scip`         | `analyze.scip_ingest`             |
+//! | `scip_status`         | `analyze.scip_status`             |
 //! | `analyzer_health`     | `analyze.health`                  |
 //!
 //! #6287 removed the `sse` submodule along with the `POST /mcp` + `GET /mcp/sse`
@@ -335,6 +336,7 @@ impl AnalyzerMcpServer {
             "upsert_fact" => self.handle_upsert_fact(args).await,
             "delete_fact" => self.handle_delete_fact(args).await,
             "extract_graph" => self.handle_extract_graph(args).await,
+            "scip_status" => self.handle_scip_status(args).await,
             "list_entities" => self.handle_list_entities(args).await,
             "cluster_concepts" => self.handle_cluster_concepts(args).await,
             // Why (#1104 rework): proxies the index list for the console
@@ -450,6 +452,24 @@ impl AnalyzerMcpServer {
             with_index(args, optional_params(args, &["language"])),
         )
         .await
+    }
+
+    /// Handle the `scip_status` tool: forward to `analyze.scip_status`.
+    ///
+    /// #5056: `extract_graph`'s `scip_overlay` boolean says a SCIP overlay
+    /// exists but not what it contains. This tool is the MCP counterpart of
+    /// the daemon's dedicated overlay-status method — it answers `-32004
+    /// not_found` (surfaced here as a `Transport` error naming the method,
+    /// same as every other daemon error) when no overlay was ever ingested,
+    /// or the overlay's node/edge counts and ingest timestamp when one was.
+    /// That is the distinction an MCP caller could not previously make: an
+    /// index with no overlay and an index whose overlay carried zero symbols
+    /// both produce an empty `extract_graph` body, but only the latter
+    /// answers this tool with a result.
+    /// Test: `tools_list_includes_scip_status`,
+    /// `handle_scip_status_calls_the_scip_status_method`.
+    async fn handle_scip_status(&self, args: &Value) -> Result<Value, DispatchError> {
+        self.call("analyze.scip_status", index_params(args)).await
     }
 
     async fn handle_list_entities(&self, args: &Value) -> Result<Value, DispatchError> {

--- a/crates/trusty-analyze/src/mcp/tests.rs
+++ b/crates/trusty-analyze/src/mcp/tests.rs
@@ -216,6 +216,44 @@ async fn deep_analysis_calls_the_daemon_method() {
     }
 }
 
+// ── #5056: MCP counterpart of `analyze.scip_status` ──────────────────────
+
+#[tokio::test]
+async fn tools_list_includes_scip_status() {
+    let server = AnalyzerMcpServer::new("http://127.0.0.1:1");
+    let resp = server.dispatch(req("tools/list", Value::Null)).await;
+    let result = resp.result.expect("expected result");
+    let tools = result
+        .get("tools")
+        .and_then(Value::as_array)
+        .expect("array");
+    let names: Vec<&str> = tools
+        .iter()
+        .filter_map(|t| t.get("name").and_then(Value::as_str))
+        .collect();
+    assert!(names.contains(&"scip_status"), "got {names:?}");
+}
+
+#[tokio::test]
+async fn handle_scip_status_calls_the_scip_status_method() {
+    // Daemon unreachable — a Transport error naming `analyze.scip_status`
+    // proves the handler picked the dedicated overlay-status method rather
+    // than reusing `analyze.graph`, which is the #5056 regression: before
+    // this tool existed, an MCP caller had no way to reach
+    // `analyze.scip_status` at all.
+    let server = AnalyzerMcpServer::new("/nonexistent/trusty-analyze.sock");
+    let err = server
+        .handle_scip_status(&serde_json::json!({ "index_id": "my-idx" }))
+        .await
+        .expect_err("daemon unreachable");
+    match err {
+        DispatchError::Transport(msg) => {
+            assert!(msg.contains("analyze.scip_status"), "got {msg}");
+        }
+        other => panic!("expected Transport, got {other:?}"),
+    }
+}
+
 #[tokio::test]
 async fn resources_list_returns_envelope() {
     // Daemon unreachable → GET /indexes fails → empty resource list, but


### PR DESCRIPTION
Refs #5056

extract_graph's `scip_overlay` flag (added by #5054, moved into the JSON-RPC body by #6287) already reaches MCP callers unchanged, since the dispatcher forwards the whole `analyze.graph` result. The gap was `analyze.scip_status` — the UDS counterpart of the old `GET /indexes/{id}/scip` — having no MCP tool at all, so a caller had no way to reach the node/edge counts and ingest timestamp, or the not-found signal for "never ingested".

Adds a `scip_status` MCP tool forwarding to `analyze.scip_status`, following the existing index/index_id-with-default convention. Regenerates the CLAUDE.md/README.md MCP-tool tables and adds the row to the hand-maintained RPC-equivalents table.

Rung 3 (localized behavior inside trusty-analyze).

- `cargo fmt --check`: clean
- `cargo clippy -p trusty-analyze --all-targets -- -D warnings`: clean
- `cargo test -p trusty-analyze --no-fail-fast`: `test result: ok. 511 passed; 0 failed` (lib) plus every other target green, including the two new tests (`tools_list_includes_scip_status`, `handle_scip_status_calls_the_scip_status_method`) and the regenerated-docs assertions
- `bash scripts/check-pr-version-bump.sh`: `[ OK ] trusty-analyze — version bumped 0.12.2 -> 0.12.3`
- `bash scripts/check_changelog_fragment.sh`: OK

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools