### PR TITLE
fix(trusty-channels): name the existing canvas on already-exists

### DIFF
--- a/crates/trusty-channels/README.md
+++ b/crates/trusty-channels/README.md
@@ -86,13 +86,13 @@ This installs the `slack-mcp` binary into `~/.cargo/bin`.
 | `slack_schedule_message`     | Schedule a message for future delivery | `chat:write` |
 | `slack_create_conversation`  | Create a new channel | `channels:manage` (public) / `groups:write` (private) |
 | `slack_list_channel_members` | List a channel's member IDs, cursor-paginated | `channels:read` (+ `groups:`/`im:`/`mpim:read`) |
-| `slack_create_canvas`        | Create a canvas, optionally tabbed into a channel | **`canvases:write`** |
+| `slack_create_canvas`        | Create a canvas, optionally tabbed into a channel | **`canvases:write`** (+ `channels:read`*) |
 | `slack_update_canvas`        | Replace a canvas's document content | **`canvases:write`** |
 | `slack_read_canvas`          | Read a canvas's exported content (HTML, not markdown — see below) | **`canvases:read`**, `files:read` |
 | `slack_read_file`            | Read a file's metadata and (text files only) content | `files:read` |
 | `slack_search_emojis`        | Search custom emoji by name (client-side filter — no `emoji.search`) | `emoji:read` |
 | `slack_search_users`         | Search users by name/real name/email (client-side filter — no non-admin `users.search`) | `users:read` |
-| `slack_canvas_create`        | Create a canvas seeded with markdown; with `channel_id` it becomes the channel's canvas and members inherit edit access | **`canvases:write`** |
+| `slack_canvas_create`        | Create a canvas seeded with markdown; with `channel_id` it becomes the channel's canvas and members inherit edit access | **`canvases:write`** (+ `channels:read`*) |
 | `slack_canvas_lookup_sections` | Look up section ids within a canvas, filtered by heading type and/or contained text; returns ids only, never content | **`canvases:read`** |
 | `slack_canvas_push`          | Translate CommonMark to canvas markdown and append it, or replace the canvas's header-delimited sections (non-atomic) | **`canvases:write`** (+ **`canvases:read`** for `replace_all`) |
 
@@ -100,6 +100,15 @@ This installs the `slack-mcp` binary into `~/.cargo/bin`.
 a Slack app that only had the original nine tools' scopes will need these
 added before `slack_create_canvas` / `slack_update_canvas` / `slack_read_canvas`
 will work; other tools reuse scopes the original nine already needed.
+
+**\* `channels:read` (issue #5161):** when a repeat `slack_create_canvas` /
+`slack_canvas_create` against a channel that already has one fails with
+`channel_canvas_already_exists`, the tool follows up with a
+`conversations.info` call to name the existing canvas's file id in the error
+(`channels:read` for a public channel; `groups:`/`im:`/`mpim:read` for a
+private channel/DM/group DM). This is a courtesy on the failure path, not a
+hard requirement — without the scope the lookup itself fails and the error
+degrades to the bare `channel_canvas_already_exists` slug, same as before.
 
 **Not implemented:** `slack_send_message_draft` — Slack has no public API to
 create an editable message draft (`chat.postMessage` sends immediately,

--- a/crates/trusty-channels/changelog.d/5161-canvas-exists.md
+++ b/crates/trusty-channels/changelog.d/5161-canvas-exists.md
@@ -1,0 +1,14 @@
+Fixed
+
+- `slack_create_canvas` / `slack_canvas_create` against a channel that already
+  has a channel canvas surfaced a bare `channel_canvas_already_exists` — the
+  caller knew a canvas existed but not which one, a dead end for the normal
+  usage pattern of repeat delivery to the same channel. The error now follows
+  up with a `conversations.info` lookup and names the existing canvas's file
+  id and the fix (`channel_canvas_already_exists (from
+  conversations.canvases.create) — channel C1 already has canvas F456; use
+  slack_canvas_push to update it`). The lookup is a courtesy, not a
+  requirement: if it fails (missing `channels:read`/`groups:`/`im:`/`mpim:read`,
+  a transport error, or no canvas on the response) the error degrades to the
+  original bare slug rather than masking it (Refs
+  [#5161](https://github.com/bobmatnyc/trusty-tools/issues/5161))

--- a/crates/trusty-channels/src/slack/handlers/canvas.rs
+++ b/crates/trusty-channels/src/slack/handlers/canvas.rs
@@ -34,6 +34,14 @@
 //! updated (see the PR description / README) — note this can require an app
 //! **reinstall**, not just an updated manifest, before newly-declared scopes
 //! carry through to the live token (issue #3744 research pass).
+//! Already-exists diagnostics (issue #5161): a channel holds at most one
+//! channel canvas, so a repeat [`create_canvas`]/[`canvas_create`] against a
+//! channel that already has one fails with `channel_canvas_already_exists`.
+//! [`post_create_canvas`] follows up that specific failure with a
+//! `conversations.info` lookup (needs `channels:read`, or its
+//! `groups:`/`im:`/`mpim:read` counterpart for non-public channels) to name
+//! the existing canvas's file id in the error, so the caller has something to
+//! act on instead of a dead end — see [`name_existing_canvas`].
 //! Canvas-read design note (issue #3612): as of this writing Slack has never
 //! shipped a public "read the full canvas markdown" method — `canvases.create`
 //! /`canvases.edit` are write-only, and `canvases.sections.lookup` returns only
@@ -77,6 +85,8 @@
 //! `::canvas_create_without_channel_uses_standalone_endpoint`,
 //! `::both_create_paths_return_the_same_structure`,
 //! `::canvas_create_channel_endpoint_error_names_the_endpoint`,
+//! `::channel_canvas_already_exists_names_the_existing_canvas`,
+//! `::channel_canvas_already_exists_degrades_when_lookup_fails`,
 //! `::update_canvas_replaces_content`,
 //! `::read_canvas_downloads_and_escapes_content`,
 //! `::read_canvas_without_download_url_returns_empty_content`,
@@ -92,7 +102,7 @@ use super::args::{opt_str, opt_str_array, require_str};
 use super::clean::field_str;
 use super::{
     CANVASES_CREATE, CANVASES_EDIT, CANVASES_SECTIONS_LOOKUP, CONVERSATIONS_CANVASES_CREATE,
-    FILES_INFO,
+    CONVERSATIONS_INFO, FILES_INFO,
 };
 use crate::slack::api::client::BaseClient;
 use crate::slack::api::error::SlackError;
@@ -105,6 +115,17 @@ fn document_content(markdown: &str) -> Value {
     json!({ "type": "markdown", "markdown": markdown })
 }
 
+/// Format a Slack API error slug together with the method that produced it.
+///
+/// Why: shared by [`with_endpoint`] and [`name_existing_canvas`] so the
+/// `"<slug> (from <method>)"` shape can't drift between the generic
+/// endpoint-naming path and the `channel_canvas_already_exists` path that
+/// appends further detail onto the same base string.
+/// What: `format!("{slug} (from {method})")`, no further shaping.
+fn slug_with_endpoint(method: &str, slug: &str) -> String {
+    format!("{slug} (from {method})")
+}
+
 /// Name the Slack method a canvas-create failure came from.
 ///
 /// Why: #5155 — the two create endpoints fail for different reasons
@@ -113,17 +134,74 @@ fn document_content(markdown: &str) -> Value {
 /// `team_tier_cannot_create_channel_canvases` only ever come from
 /// `conversations.canvases.create`). A bare slug forces the next person
 /// diagnosing this to read the source to work out which call ran.
-/// What: appends `(from <method>)` to a `SlackError::Api` slug, leaving the
-/// slug itself as the leading token and every other variant untouched.
+/// What: appends `(from <method>)` to a `SlackError::Api` slug via
+/// [`slug_with_endpoint`], leaving the slug itself as the leading token and
+/// every other variant untouched.
 /// Test: `tests/tools_http.rs::canvas_create_surfaces_slack_api_error`,
 /// `::canvas_create_channel_endpoint_error_names_the_endpoint`.
 fn with_endpoint(method: &str, err: SlackError) -> ToolCallError {
     match err {
         SlackError::Api(slug) => {
-            ToolCallError::from(SlackError::Api(format!("{slug} (from {method})")))
+            ToolCallError::from(SlackError::Api(slug_with_endpoint(method, &slug)))
         }
         other => ToolCallError::from(other),
     }
+}
+
+/// Look up the `file_id` of a channel's existing canvas via `conversations.info`.
+///
+/// Why: #5161 — `channel_canvas_already_exists` on its own is a dead end for a
+/// caller doing the normal thing here (repeat delivery to the same
+/// destination): they know a canvas exists but not which one, so they can't
+/// act on it. Slack's `conversations.info` returns the channel's canvas at
+/// `channel.properties.canvas.file_id` (see
+/// <https://api.slack.com/types/conversations>) — one extra read call turns
+/// that into something actionable.
+/// What: `None` on any failure to resolve an id — a transport error, an
+/// `ok:false` response, or a present-but-empty/absent `file_id` — so the
+/// caller can degrade to the bare slug rather than propagate a *second*
+/// failure in place of the original one.
+/// Test: `tests/tools_http.rs::channel_canvas_already_exists_names_the_existing_canvas`,
+/// `::channel_canvas_already_exists_degrades_when_lookup_fails`.
+async fn lookup_existing_canvas_id(client: &BaseClient, channel_id: &str) -> Option<String> {
+    let body = json!({ "channel": channel_id });
+    let resp = client.call_method(CONVERSATIONS_INFO, &body).await.ok()?;
+    let id = field_str(
+        resp.get("channel")?.get("properties")?.get("canvas")?,
+        "file_id",
+    );
+    (!id.is_empty()).then_some(id)
+}
+
+/// Build the `channel_canvas_already_exists` error, naming the existing
+/// canvas when [`lookup_existing_canvas_id`] can resolve one.
+///
+/// Why: isolates the one Slack error slug this module treats specially so
+/// [`post_create_canvas`]'s main path stays a plain `map_err`. Per issue
+/// #5161's acceptance criteria, the lookup is a courtesy on top of the
+/// original failure, never a replacement for it — a lookup failure must not
+/// mask `channel_canvas_already_exists` with some other, less actionable
+/// error.
+/// What: always includes [`slug_with_endpoint`]'s `"channel_canvas_already_exists
+/// (from conversations.canvases.create)"` base; when the lookup finds a
+/// `file_id`, appends `" — channel <channel_id> already has canvas <file_id>;
+/// use slack_canvas_push to update it"` naming the concrete next step.
+/// Test: `tests/tools_http.rs::channel_canvas_already_exists_names_the_existing_canvas`,
+/// `::channel_canvas_already_exists_degrades_when_lookup_fails`.
+async fn name_existing_canvas(
+    client: &BaseClient,
+    method: &str,
+    channel_id: &str,
+) -> ToolCallError {
+    let base = slug_with_endpoint(method, "channel_canvas_already_exists");
+    let message = match lookup_existing_canvas_id(client, channel_id).await {
+        Some(existing_id) => format!(
+            "{base} — channel {channel_id} already has canvas {existing_id}; \
+             use slack_canvas_push to update it"
+        ),
+        None => base,
+    };
+    ToolCallError::from(SlackError::Api(message))
 }
 
 /// POST a canvas-creation request and shape the response, choosing the
@@ -147,29 +225,40 @@ fn with_endpoint(method: &str, err: SlackError) -> ToolCallError {
 /// `canvas_id` key, and this is the single place that reads it, so callers get
 /// an identical `{ok, canvas_id}` either way and never learn which ran.
 /// Failures surface through [`SlackError::Api`] as before, with the attempted
-/// method named by [`with_endpoint`].
+/// method named by [`with_endpoint`] — except `channel_canvas_already_exists`
+/// (issue #5161), which additionally names the existing canvas via
+/// [`name_existing_canvas`] since a channel holds at most one channel canvas
+/// and a repeat `create` against it is this tool's normal usage pattern.
 /// Test: `tests/tools_http.rs::create_canvas_with_channel_and_markdown`,
 /// `::create_canvas_without_channel_uses_standalone_endpoint`,
 /// `::canvas_create_posts_document_content_and_channel`,
 /// `::canvas_create_without_channel_uses_standalone_endpoint`,
-/// `::both_create_paths_return_the_same_structure`.
+/// `::both_create_paths_return_the_same_structure`,
+/// `::channel_canvas_already_exists_names_the_existing_canvas`,
+/// `::channel_canvas_already_exists_degrades_when_lookup_fails`.
 async fn post_create_canvas(
     client: &BaseClient,
     mut body: Value,
     channel_id: Option<String>,
 ) -> Result<Value, ToolCallError> {
-    let method = match channel_id {
-        Some(channel_id) => {
-            body["channel_id"] = json!(channel_id);
+    let method = match &channel_id {
+        Some(id) => {
+            body["channel_id"] = json!(id);
             CONVERSATIONS_CANVASES_CREATE
         }
         None => CANVASES_CREATE,
     };
-    let resp = client
-        .call_method(method, &body)
-        .await
-        .map_err(|e| with_endpoint(method, e))?;
-    Ok(json!({ "ok": true, "canvas_id": field_str(&resp, "canvas_id") }))
+    match client.call_method(method, &body).await {
+        Ok(resp) => Ok(json!({ "ok": true, "canvas_id": field_str(&resp, "canvas_id") })),
+        // `channel_id` is always `Some` here: this slug is only ever raised by
+        // `conversations.canvases.create`, which `method` only selects when a
+        // channel was named.
+        Err(SlackError::Api(slug)) if slug == "channel_canvas_already_exists" => {
+            let channel_id = channel_id.unwrap_or_default();
+            Err(name_existing_canvas(client, method, &channel_id).await)
+        }
+        Err(e) => Err(with_endpoint(method, e)),
+    }
 }
 
 /// Create a canvas (requires `canvases:write`).

--- a/crates/trusty-channels/src/slack/handlers/mod.rs
+++ b/crates/trusty-channels/src/slack/handlers/mod.rs
@@ -90,6 +90,12 @@ pub(super) const CONVERSATIONS_REPLIES: &str = "conversations.replies";
 pub(super) const CONVERSATIONS_LIST: &str = "conversations.list";
 pub(super) const CONVERSATIONS_CREATE: &str = "conversations.create";
 pub(super) const CONVERSATIONS_MEMBERS: &str = "conversations.members";
+/// Bot-scope, requires `channels:read` (+ `groups:`/`im:`/`mpim:read` for
+/// non-public channel types): reads a single channel's metadata, including
+/// `properties.canvas.file_id` when the channel already has a channel canvas
+/// (issue #5161). Used only to name the existing canvas on a
+/// `channel_canvas_already_exists` collision — never on the create happy path.
+pub(super) const CONVERSATIONS_INFO: &str = "conversations.info";
 pub(super) const USERS_LIST: &str = "users.list";
 pub(super) const USERS_INFO: &str = "users.info";
 /// User-scope-only: reached through the client's **user** token.

--- a/crates/trusty-channels/tests/tools_http.rs
+++ b/crates/trusty-channels/tests/tools_http.rs
@@ -1281,6 +1281,91 @@ async fn canvas_create_channel_endpoint_error_names_the_endpoint() {
     }
 }
 
+// #5161: `channel_canvas_already_exists` on its own is a dead end for the
+// caller — a channel holds at most one channel canvas, and repeat delivery to
+// the same destination is this tool's normal pattern. The error must name the
+// canvas that already exists.
+#[tokio::test]
+async fn channel_canvas_already_exists_names_the_existing_canvas() {
+    let server = MockServer::start().await;
+    mount_ok(
+        &server,
+        "conversations.canvases.create",
+        json!({ "ok": false, "error": "channel_canvas_already_exists" }),
+    )
+    .await;
+    Mock::given(method("POST"))
+        .and(path("/conversations.info"))
+        .and(body_partial_json(json!({ "channel": "C1" })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "ok": true,
+            "channel": {
+                "id": "C1",
+                "properties": { "canvas": { "file_id": "F456" } },
+            },
+        })))
+        .mount(&server)
+        .await;
+
+    let client = client_for(&server);
+    let err = dispatch(
+        &client,
+        "slack_canvas_create",
+        json!({ "markdown": "# Runbook", "channel_id": "C1" }),
+    )
+    .await
+    .expect_err("channel_canvas_already_exists must still error");
+    match err {
+        ToolCallError::Slack(SlackError::Api(message)) => {
+            assert_eq!(
+                message,
+                "channel_canvas_already_exists (from conversations.canvases.create) \
+                 — channel C1 already has canvas F456; use slack_canvas_push to update it"
+            );
+        }
+        other => panic!("expected ToolCallError::Slack(SlackError::Api(_)), got {other:?}"),
+    }
+}
+
+// #5161: the `conversations.info` lookup is a courtesy on top of the original
+// failure, never a replacement — a lookup failure (or an absent `file_id`)
+// must degrade to the bare endpoint-named slug rather than masking
+// `channel_canvas_already_exists` with something less actionable.
+#[tokio::test]
+async fn channel_canvas_already_exists_degrades_when_lookup_fails() {
+    let server = MockServer::start().await;
+    mount_ok(
+        &server,
+        "conversations.canvases.create",
+        json!({ "ok": false, "error": "channel_canvas_already_exists" }),
+    )
+    .await;
+    mount_ok(
+        &server,
+        "conversations.info",
+        json!({ "ok": false, "error": "channel_not_found" }),
+    )
+    .await;
+
+    let client = client_for(&server);
+    let err = dispatch(
+        &client,
+        "slack_canvas_create",
+        json!({ "markdown": "# Runbook", "channel_id": "C1" }),
+    )
+    .await
+    .expect_err("channel_canvas_already_exists must still error");
+    match err {
+        ToolCallError::Slack(SlackError::Api(message)) => {
+            assert_eq!(
+                message,
+                "channel_canvas_already_exists (from conversations.canvases.create)"
+            );
+        }
+        other => panic!("expected ToolCallError::Slack(SlackError::Api(_)), got {other:?}"),
+    }
+}
+
 #[tokio::test]
 async fn canvas_create_surfaces_slack_api_error() {
     // Slack errors like `missing_scope` / `canvas_creation_failed` /


### PR DESCRIPTION
Refs #5161

## Part 1 — DM/IM verification: NOT VERIFIABLE from this session

No live slack-mcp credentials are available here: no `SLACK_BOT_TOKEN`/`SLACK_USER_TOKEN` in the environment, no `slack`/`slack-user` entry in the OS keychain (`security find-generic-password -s trusty-tools -a slack`), no entry in `~/.trusty-tools/credentials.toml`, and no `slack-mcp` MCP server registered in this session — so no live probe (real or via error response) could be made against `conversations.canvases.create`.

The issue's own re-opening comment (2026-08-29) already answers this empirically from a real Duetto-workspace reproduction: a DM-bound `slack_canvas_create` call **succeeded** (no rejection of the DM channel id), so `conversations.canvases.create` does accept an IM/DM id. What that reproduction also found is a separate problem out of this PR's scope: the created canvas — DM-bound or standalone — was not accessible to the human recipient until `canvases.access.set` was called manually. That access-grant gap is not something this PR addresses; it's a different mechanism (`canvases.access.set`) than the create-endpoint routing #5157 shipped.

**To verify independently:** a workspace with `canvases:write`/`canvases:read` scopes and a registered `slack-mcp` connector, calling `slack_canvas_create` with a DM `channel_id` and checking the response for `ok:true`/an error slug.

## Part 2 — fix

`channel_canvas_already_exists` (only ever from `conversations.canvases.create`) surfaced bare — a dead end for the normal usage pattern here (repeat delivery to the same channel). `post_create_canvas` in `crates/trusty-channels/src/slack/handlers/canvas.rs` now follows that specific failure with a `conversations.info` lookup and names the existing canvas's file id: `channel_canvas_already_exists (from conversations.canvases.create) — channel C1 already has canvas F456; use slack_canvas_push to update it`. The lookup is a courtesy on the failure path only — a lookup failure (missing scope, transport error, absent `file_id`) degrades to the original bare slug rather than masking it.

New constant `CONVERSATIONS_INFO` in `crates/trusty-channels/src/slack/handlers/mod.rs`. README scope table updated with the optional `channels:read` (+ `groups:`/`im:`/`mpim:read`) note.

trusty-channels is unpublished — no version bump gate.

## Gates (rung 3, `-p trusty-channels`)

- `cargo fmt --check` — clean
- `cargo clippy -p trusty-channels --all-targets -- -D warnings` — clean
- `cargo test -p trusty-channels --no-fail-fast` — 110+9+15+12+56 = 202 passed, 0 failed, across all targets
- Pre-fix regression check: reverted the two production files, re-ran `channel_canvas_already_exists_names_the_existing_canvas` — failed as expected (`left: bare slug` vs `right: slug + canvas name`); restored the fix and it passes.

## Test plan

- [x] `channel_canvas_already_exists_names_the_existing_canvas` — names the canvas on a successful lookup
- [x] `channel_canvas_already_exists_degrades_when_lookup_fails` — degrades to the bare slug when `conversations.info` itself fails
- [x] Full `trusty-channels` suite green

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools