### PR TITLE
fix(scripts): the changelog assembler becomes a publish gate

### DIFF
--- a/scripts/check-changelog-assembled-selftest.sh
+++ b/scripts/check-changelog-assembled-selftest.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+#
+# check-changelog-assembled-selftest.sh — failing-case fixtures for
+# scripts/check-changelog-assembled.sh.
+#
+# Why: a check whose FAILING branches were never exercised is exactly the gap
+#   #6406 is about — eight `preflight-publish.sh` checks existed and none of
+#   them read `changelog.d/` or `CHANGELOG.md`, so the six trusty-audit
+#   releases that bypassed the assembler sailed through every one of them.
+#   Asserting only "the gate ran and exited 0" against a clean fixture would
+#   repeat that shape at one remove: a gate that always passes looks
+#   identical to one that checks something.
+#
+# What: builds synthetic `crates/<dir>/` fixtures under a scratch directory and
+#   runs the gate against each with `--repo`, asserting both the exit status
+#   and the finding code on stdout/stderr. Case 5 runs the gate against the
+#   REAL, currently-checked-out trusty-audit crate — the one #6400 repaired —
+#   to prove the live repo passes with no fixture standing in for it.
+#
+# Test: this IS the test. Run directly:
+#   bash scripts/check-changelog-assembled-selftest.sh
+#
+# Portability: POSIX tools only, bash 3.2 (macOS) and bash 5 (Linux CI).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+GATE="${SCRIPT_DIR}/check-changelog-assembled.sh"
+
+PASSED=0
+FAILED=0
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/changelog-assembled-selftest.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+pass_case() { echo "  ok  $1"; PASSED=$((PASSED + 1)); }
+fail_case() {
+  echo "SELF-TEST FAIL: $1" >&2
+  shift
+  printf '%s\n' "$@" | sed 's/^/       /' >&2
+  FAILED=$((FAILED + 1))
+}
+
+# mkrepo <name> <crate-dir> <package-name> <version> -> prints the repo path.
+# A minimal workspace shape: just enough for the gate's own resolve_crate_dir
+# (a crates/<dir>/Cargo.toml with a name/version) to find it. The gate never
+# invokes git when --repo is passed, so no git history is needed here.
+mkrepo() {
+  local name="$1" dir="$2" pkg="$3" version="$4"
+  local repo="${WORK}/${name}"
+  mkdir -p "${repo}/crates/${dir}"
+  cat > "${repo}/crates/${dir}/Cargo.toml" <<TOML
+[package]
+name = "${pkg}"
+version = "${version}"
+edition = "2021"
+TOML
+  echo "$repo"
+}
+
+# run_case <label> <expect-exit> <expect-substring|-> <repo> [gate args...]
+run_case() {
+  local label="$1" want_exit="$2" want_sub="$3" repo="$4"
+  shift 4
+  local out rc=0
+  out="$(bash "$GATE" --repo "$repo" "$@" 2>&1)" || rc=$?
+  if [ "$rc" -ne "$want_exit" ]; then
+    fail_case "${label}: expected exit ${want_exit}, got ${rc}" "$out"
+    return
+  fi
+  if [ "$want_sub" != "-" ] && ! grep -qF -- "$want_sub" <<< "$out"; then
+    fail_case "${label}: exit ${rc} but output never said '${want_sub}'" "$out"
+    return
+  fi
+  if [ "$want_sub" = "-" ]; then
+    pass_case "${label} -> exit ${rc} (clean)"
+  else
+    pass_case "${label} -> exit ${rc}, reported ${want_sub}"
+  fi
+}
+
+# ===========================================================================
+# 1. Correctly assembled — a section exists for the version, changelog.d/
+#    holds only the README.md placeholder. This is what a real
+#    scripts/assemble-changelog.sh run leaves behind. Exit 0.
+# ===========================================================================
+repo="$(mkrepo clean clean-crate clean-crate 1.0.0)"
+mkdir -p "${repo}/crates/clean-crate/changelog.d"
+echo "placeholder" > "${repo}/crates/clean-crate/changelog.d/README.md"
+cat > "${repo}/crates/clean-crate/CHANGELOG.md" <<'EOF'
+# Changelog — clean-crate
+
+---
+
+## [1.0.0] — 2026-01-01
+
+### Fixed
+
+- an assembled fix
+EOF
+run_case "clean assembled state" 0 "-" "$repo" clean-crate
+
+# ===========================================================================
+# 2. THE REGRESSION TEST — the #5919/#6406 shape. Cargo.toml was hand-bumped,
+#    the assembler never ran: changelog.d/ still holds a real fragment and
+#    CHANGELOG.md has no section for the new version. Both findings, exit 1.
+# ===========================================================================
+repo="$(mkrepo stranded stranded-crate stranded-crate 0.9.0)"
+mkdir -p "${repo}/crates/stranded-crate/changelog.d"
+echo "placeholder" > "${repo}/crates/stranded-crate/changelog.d/README.md"
+cat > "${repo}/crates/stranded-crate/changelog.d/6406-stranded.md" <<'EOF'
+Fixed
+
+- a fix nobody ever folded into CHANGELOG.md
+EOF
+cat > "${repo}/crates/stranded-crate/CHANGELOG.md" <<'EOF'
+# Changelog — stranded-crate
+
+---
+
+## [0.8.0] — 2026-01-01
+
+### Fixed
+
+- an older, already-released fix
+EOF
+run_case "hand-edited bump: stranded fragment" 1 "STRANDED-FRAGMENTS" "$repo" stranded-crate
+run_case "hand-edited bump: no section (same fixture)" 1 "NO-SECTION" "$repo" stranded-crate
+
+# ===========================================================================
+# 3. Section exists, but a fragment survives anyway (a partial/aborted
+#    assemble, or a fragment added by hand after the fact). One finding only.
+# ===========================================================================
+repo="$(mkrepo partial partial-crate partial-crate 2.0.0)"
+mkdir -p "${repo}/crates/partial-crate/changelog.d"
+echo "placeholder" > "${repo}/crates/partial-crate/changelog.d/README.md"
+cat > "${repo}/crates/partial-crate/changelog.d/9999-leftover.md" <<'EOF'
+Added
+
+- something that should have been consumed
+EOF
+cat > "${repo}/crates/partial-crate/CHANGELOG.md" <<'EOF'
+# Changelog — partial-crate
+
+---
+
+## [2.0.0] — 2026-01-01
+
+### Added
+
+- the real assembled entry
+EOF
+run_case "section present, fragment still stranded" 1 "STRANDED-FRAGMENTS" "$repo" partial-crate
+out="$(bash "$GATE" --repo "$repo" partial-crate 2>&1)" || true
+if grep -qF "NO-SECTION" <<< "$out"; then
+  fail_case "section present, fragment still stranded: falsely also reported NO-SECTION" "$out"
+else
+  pass_case "section present, fragment still stranded -> only STRANDED-FRAGMENTS reported"
+fi
+
+# ===========================================================================
+# 4. No changelog.d/ directory at all (never created, or already cleaned up)
+#    but the section IS present — a legitimate clean state. Exit 0.
+# ===========================================================================
+repo="$(mkrepo nodir nodir-crate nodir-crate 3.1.0)"
+cat > "${repo}/crates/nodir-crate/CHANGELOG.md" <<'EOF'
+# Changelog — nodir-crate
+
+---
+
+## [3.1.0] — 2026-01-01
+
+### Changed
+
+- entry with no changelog.d/ directory left behind
+EOF
+run_case "no changelog.d/ directory, section present" 0 "-" "$repo" nodir-crate
+
+# ===========================================================================
+# 5. THE LIVE REPO. trusty-audit was the crate #5919/#6400 repaired — this
+#    proves the check passes against the real, current checkout rather than
+#    only a fixture built to make it pass.
+# ===========================================================================
+if [ -f "${REPO_ROOT}/crates/trusty-audit/Cargo.toml" ]; then
+  run_case "live repo: trusty-audit (post-#6400 repair)" 0 "-" "$REPO_ROOT" trusty-audit
+else
+  echo "  skip live-repo case: crates/trusty-audit not found at ${REPO_ROOT}"
+fi
+
+echo
+echo "check-changelog-assembled-selftest: ${PASSED} passed, ${FAILED} failed."
+[ "$FAILED" -eq 0 ]

--- a/scripts/check-changelog-assembled.sh
+++ b/scripts/check-changelog-assembled.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+#
+# check-changelog-assembled.sh — the changelog assembler becomes a publish gate
+# (#6406).
+#
+# Why: six `trusty-audit` tags (0.8.0 -> 0.12.0) were cut by hand-editing
+#   `Cargo.toml` directly, skipping `scripts/bump-version.sh` and therefore
+#   `scripts/assemble-changelog.sh` — the ONLY thing that ever writes a
+#   `## [<version>]` section or deletes a consumed fragment (#5919, repaired in
+#   PR #6400). Fragments sat unconsumed across all six releases and
+#   `CHANGELOG.md` never gained a section for any of them. Nothing mechanical
+#   noticed, because nothing asked: `preflight-publish.sh`'s eight checks cover
+#   identity, tree cleanliness, tag/commit parity, public-API SemVer and the
+#   UI bundle, but none of them reads `changelog.d/` or `CHANGELOG.md` at all.
+#
+# What: given a crate and the version about to ship, asserts the two facts
+#   that are only both true when the assembler actually ran for THIS version:
+#
+#   STRANDED-FRAGMENTS   `crates/<crate>/changelog.d/` holds a fragment file
+#                        (anything but the tracked `README.md` placeholder).
+#                        A successful assemble run always deletes every
+#                        fragment it consumes in the same operation — see
+#                        `delete_consumed_fragments()` in
+#                        `scripts/assemble-changelog.sh` — so any survivor
+#                        means either the assembler never ran, or it ran and
+#                        failed partway (which itself prints a loud error and
+#                        refuses to report success). Either way, publishing
+#                        now ships a release with unrecorded changes still
+#                        sitting in the working tree.
+#
+#   NO-SECTION           `crates/<crate>/CHANGELOG.md` has no
+#                        `## [<version>]` heading for the exact version being
+#                        published. The assembler is the only writer of that
+#                        heading; its absence means either it never ran for
+#                        this version, or the version in `Cargo.toml` was
+#                        bumped by hand after the last real assemble run.
+#
+#   Both findings are checked unconditionally and reported together — a
+#   half-bypassed release (say, a hand-added section with fragments still
+#   left behind, or vice versa) is exactly the state a partial workaround
+#   would produce, and naming only one finding would leave the other
+#   invisible.
+#
+#   NOT what this checks: whether `changelog.d/` is empty in general. An
+#   empty `changelog.d/` (or one holding only `README.md`) between releases is
+#   the STEADY state — see `scripts/assemble-changelog.sh`'s own note on this —
+#   and a NON-empty one is completely normal for a crate whose next release
+#   has not been cut yet (trusty-mpm's `changelog.d/` holds dozens of pending
+#   fragments at any given time). This check only makes sense asked AT THE
+#   MOMENT a specific version is about to be tagged or published — which is
+#   exactly when `scripts/preflight-publish.sh` calls it, immediately before
+#   `cargo publish`, as its own CHECK 9.
+#
+# Usage:
+#   scripts/check-changelog-assembled.sh [--repo <dir>] <crate-name-or-dir> [version]
+#
+#   <crate-name-or-dir>  the crates.io package name (e.g. `tga`) or the
+#                        crates/ directory name (e.g. `trusty-git-analytics`),
+#                        resolved the same way preflight-publish.sh does.
+#   [version]            defaults to the first `version = "X.Y.Z"` line in
+#                        that crate's Cargo.toml — the version `cargo publish`
+#                        will actually ship.
+#   --repo <dir>         operate on a different repo root (self-test only).
+#
+# Exit codes: 0 = the assembler ran for this version — safe on this axis.
+#   1 = at least one finding (STRANDED-FRAGMENTS and/or NO-SECTION) — do NOT
+#   tag or publish. 2 = usage error.
+#
+# Test: scripts/check-changelog-assembled-selftest.sh builds synthetic repos
+#   for a stranded-fragment crate, a crate missing its version section, and a
+#   correctly-assembled crate, and asserts both the exit status and the
+#   finding code for each. It also runs this script against the REAL
+#   trusty-audit crate at its current (post-#6400-repair) state to prove the
+#   live repo passes.
+#
+# Portability: POSIX tools only, bash 3.2 (macOS) and bash 5 (Linux CI).
+
+set -euo pipefail
+
+for arg in "$@"; do
+  case "$arg" in
+    -h|--help)
+      grep '^#' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+  esac
+done
+
+usage() {
+  echo "usage: scripts/check-changelog-assembled.sh [--repo <dir>] <crate-name-or-dir> [version]" >&2
+  exit 2
+}
+
+REPO_ARG=""
+POSITIONAL=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --repo)
+      [ "$#" -ge 2 ] || usage
+      REPO_ARG="$2"
+      shift 2
+      ;;
+    -*)
+      echo "check-changelog-assembled: unknown argument: $1" >&2
+      usage
+      ;;
+    *)
+      POSITIONAL="${POSITIONAL}${POSITIONAL:+ }$1"
+      shift
+      ;;
+  esac
+done
+
+# shellcheck disable=SC2086
+set -- $POSITIONAL
+[ "$#" -ge 1 ] && [ "$#" -le 2 ] || usage
+CRATE_INPUT="$1"
+VERSION_ARG="${2:-}"
+
+if [ -n "$REPO_ARG" ]; then
+  REPO_ROOT="$(cd "$REPO_ARG" && pwd)"
+else
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+fi
+cd "$REPO_ROOT"
+
+# resolve_crate_dir: accept either the crates.io package name or the crates/
+# directory name. A deliberate standalone copy of preflight-publish.sh's and
+# check-tag-publish-parity.sh's resolver — each of these scripts must run
+# independently from any cwd with no sourcing contract between them, and the
+# logic is two lines over a manifest glob.
+resolve_crate_dir() {
+  local input="$1" manifest dir
+  if [ -f "${REPO_ROOT}/crates/${input}/Cargo.toml" ]; then
+    echo "$input"
+    return 0
+  fi
+  for manifest in "${REPO_ROOT}"/crates/*/Cargo.toml; do
+    [ -f "$manifest" ] || continue
+    if grep -qE "^name[[:space:]]*=[[:space:]]*\"${input}\"" "$manifest"; then
+      dir="$(basename "$(dirname "$manifest")")"
+      echo "$dir"
+      return 0
+    fi
+  done
+  return 1
+}
+
+CRATE_DIR=""
+if ! CRATE_DIR="$(resolve_crate_dir "$CRATE_INPUT")"; then
+  echo "check-changelog-assembled: ERROR: no crate found matching '${CRATE_INPUT}'" >&2
+  exit 2
+fi
+CRATE_PATH="${REPO_ROOT}/crates/${CRATE_DIR}"
+MANIFEST="${CRATE_PATH}/Cargo.toml"
+
+PKG_NAME="$(grep -m1 -E '^name[[:space:]]*=[[:space:]]*"' "$MANIFEST" \
+  | sed -E 's/^name[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/')"
+if [ -z "$PKG_NAME" ]; then
+  echo "check-changelog-assembled: ERROR: could not read 'name' from ${MANIFEST}" >&2
+  exit 2
+fi
+
+if [ -n "$VERSION_ARG" ]; then
+  VERSION="$VERSION_ARG"
+else
+  VERSION="$(grep -m1 -E '^version[[:space:]]*=[[:space:]]*"[0-9]+\.[0-9]+\.[0-9]+"' "$MANIFEST" \
+    | sed -E 's/^version[[:space:]]*=[[:space:]]*"([0-9]+\.[0-9]+\.[0-9]+)".*/\1/')"
+  if [ -z "$VERSION" ]; then
+    echo "check-changelog-assembled: ERROR: could not find version = \"X.Y.Z\" in ${MANIFEST}" >&2
+    exit 2
+  fi
+fi
+
+echo "check-changelog-assembled: crate=${CRATE_DIR} package=${PKG_NAME} version=${VERSION}" >&2
+
+FINDINGS=0
+
+# ---------------------------------------------------------------------------
+# STRANDED-FRAGMENTS: changelog.d/ holds anything but the README.md
+# placeholder. Mirrors the fragment-collection glob in
+# scripts/assemble-changelog.sh's main() exactly, so this check and the
+# assembler can never disagree about what counts as a fragment.
+# ---------------------------------------------------------------------------
+FRAG_DIR="${CRATE_PATH}/changelog.d"
+if [ -d "$FRAG_DIR" ]; then
+  STRANDED="$(find "$FRAG_DIR" -maxdepth 1 -type f -name '*.md' ! -name 'README.md' | LC_ALL=C sort || true)"
+else
+  STRANDED=""
+fi
+
+if [ -n "$STRANDED" ]; then
+  FINDINGS=$((FINDINGS + 1))
+  echo "FAIL: STRANDED-FRAGMENTS — crates/${CRATE_DIR}/changelog.d/ still holds" >&2
+  echo "      fragment(s) that ${PKG_NAME} ${VERSION} was supposed to consume:" >&2
+  printf '%s\n' "$STRANDED" | sed "s#^${CRATE_PATH}/#         #" >&2
+  echo "      A successful 'scripts/assemble-changelog.sh ${CRATE_DIR} <version>' run" >&2
+  echo "      deletes every fragment it folds into CHANGELOG.md in the same" >&2
+  echo "      operation, so a survivor means the assembler either never ran for" >&2
+  echo "      this release or was bypassed by hand-editing ${MANIFEST#"${REPO_ROOT}"/}." >&2
+  echo "      This is exactly the #5919 shape: six trusty-audit tags shipped with" >&2
+  echo "      changelog.d/ fragments nobody ever folded in." >&2
+  echo "      Fix: run the real bump path, which calls the assembler for you:" >&2
+  echo "        scripts/bump-version.sh ${CRATE_DIR} <major|minor|patch>" >&2
+  echo "      Already at the version you intend to ship? Assemble directly:" >&2
+  echo "        scripts/assemble-changelog.sh ${CRATE_DIR} ${VERSION}" >&2
+else
+  echo "PASS: no stranded fragments in crates/${CRATE_DIR}/changelog.d/." >&2
+fi
+
+# ---------------------------------------------------------------------------
+# NO-SECTION: CHANGELOG.md has no '## [<version>]' heading. Same anchor and
+# escaping as scripts/assemble-changelog.sh uses to detect an EXISTING
+# section, so "the assembler would consider this version already cut" and
+# "this check finds the section" can never disagree.
+# ---------------------------------------------------------------------------
+CHANGELOG="${CRATE_PATH}/CHANGELOG.md"
+if [ ! -f "$CHANGELOG" ]; then
+  FINDINGS=$((FINDINGS + 1))
+  echo "FAIL: NO-SECTION — crates/${CRATE_DIR}/CHANGELOG.md does not exist." >&2
+  echo "      There is nowhere a '## [${VERSION}]' section could have been written." >&2
+elif ! grep -qE "^## \[${VERSION//./\\.}\]" "$CHANGELOG"; then
+  FINDINGS=$((FINDINGS + 1))
+  echo "FAIL: NO-SECTION — crates/${CRATE_DIR}/CHANGELOG.md has no '## [${VERSION}]'" >&2
+  echo "      heading. The assembler is the only writer of that heading" >&2
+  echo "      (scripts/assemble-changelog.sh); its absence means either it never" >&2
+  echo "      ran for this version, or Cargo.toml's version was hand-edited after" >&2
+  echo "      the last real assemble run." >&2
+  echo "      Fix: run the real bump path, which writes the section for you:" >&2
+  echo "        scripts/bump-version.sh ${CRATE_DIR} <major|minor|patch>" >&2
+  echo "      Already at the version you intend to ship? Assemble directly:" >&2
+  echo "        scripts/assemble-changelog.sh ${CRATE_DIR} ${VERSION}" >&2
+else
+  echo "PASS: crates/${CRATE_DIR}/CHANGELOG.md has a '## [${VERSION}]' section." >&2
+fi
+
+if [ "$FINDINGS" -gt 0 ]; then
+  echo "check-changelog-assembled: FAILED (${FINDINGS} finding(s)) for ${PKG_NAME} ${VERSION}." >&2
+  exit 1
+fi
+
+echo "check-changelog-assembled: OK — ${PKG_NAME} ${VERSION} was assembled by the real tooling." >&2
+exit 0

--- a/scripts/check-pr-changelog-assembled.sh
+++ b/scripts/check-pr-changelog-assembled.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+#
+# check-pr-changelog-assembled.sh — merge-time half of the changelog-assembler
+# gate (#6406). Companion to scripts/check-changelog-assembled.sh, which is the
+# publish-time half wired into scripts/preflight-publish.sh CHECK 9.
+#
+# Why: the publish-time gate stops a bypass at the last possible moment, right
+#   before `cargo publish`. This one catches the SAME shape earlier — while the
+#   PR that wrote a hand-authored `## [<version>]` section is still open — so a
+#   bypass never reaches main at all. #5919's six trusty-audit releases each
+#   landed a PR that (by hand-editing Cargo.toml and never running
+#   `scripts/assemble-changelog.sh`) either wrote no section at all, or could
+#   have written one by hand while leaving the fragments it should have
+#   consumed sitting untouched. This gate targets the second shape specifically
+#   — the first is unreachable at PR time, because a version bump alone is not
+#   evidence a release section exists yet (see the scope note below).
+#
+# What: for every crate whose `crates/<crate>/CHANGELOG.md` gains a NEW
+#   `## [<version>]` heading in this PR (present in the diff's added lines,
+#   absent from the merge base entirely), runs
+#   `scripts/check-changelog-assembled.sh <crate> <version>` and fails if it
+#   reports STRANDED-FRAGMENTS. A NEW heading is precisely what
+#   `scripts/assemble-changelog.sh` writes when it runs for real — so a PR that
+#   adds one is asserting "I cut a release", and this gate holds that PR to the
+#   one guarantee a real assemble run always keeps: every fragment it folded in
+#   is gone in the same commit.
+#
+# SCOPE, DELIBERATELY NARROW. This does NOT fire merely because a crate's
+#   `Cargo.toml` version changed. `scripts/bump-version.sh --no-changelog`
+#   bumps the manifest and deliberately leaves `changelog.d/` fragments pending
+#   for the release cut to consume LATER — see that script's own header note,
+#   "FRAGMENT CONSUMPTION IS THE RELEASE CUT'S JOB, AND ONLY ITS JOB (#5674)".
+#   A gate that flagged every version bump without a same-PR CHANGELOG.md
+#   section would break that supported workflow and teach people to bypass
+#   this gate instead of the one it exists to catch. Requiring a NEW version
+#   heading as the trigger keeps this gate silent on every in-flight bump and
+#   loud only when a PR claims, in its own diff, to have assembled a release.
+#
+#   This narrowness means a hand-edited `Cargo.toml` version with NO CHANGELOG
+#   section at all (the actual #5919 shape at the PR that introduced it) is NOT
+#   caught here — nothing distinguishes that PR from a legitimate
+#   `--no-changelog` bump at merge time. `scripts/check-changelog-assembled.sh`
+#   run as CHECK 9 of `scripts/preflight-publish.sh` is what catches that shape,
+#   at the point a version is actually tagged or published, when the ambiguity
+#   is gone.
+#
+# Usage:
+#   bash scripts/check-pr-changelog-assembled.sh                  # base: origin/main
+#   bash scripts/check-pr-changelog-assembled.sh --base <ref>     # explicit base
+#   PR_CHANGELOG_ASSEMBLED_BASE=<ref> bash scripts/check-pr-changelog-assembled.sh
+#
+# Exit: 0 when no crate has a new version section with stranded fragments (or
+#   no crate's CHANGELOG.md changed at all); 1 when at least one does; 2 usage.
+#
+# Test: scripts/check-pr-changelog-assembled-selftest.sh builds synthetic
+#   repos with a real assemble commit (clean) and a hand-authored section that
+#   left a fragment behind (stranded), and asserts both outcomes.
+#
+# Portability: POSIX tools only, bash 3.2 (macOS) and bash 5 (Linux CI).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+BASE="${PR_CHANGELOG_ASSEMBLED_BASE:-origin/main}"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base)
+      [[ $# -lt 2 ]] && {
+        echo "ERROR: --base needs a ref" >&2
+        exit 2
+      }
+      BASE="$2"
+      shift 2
+      ;;
+    -h|--help)
+      grep '^#' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown argument '$1'" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if ! MERGE_BASE="$(git merge-base "${BASE}" HEAD 2>/dev/null)"; then
+  echo "ERROR: cannot find a merge base between '${BASE}' and HEAD." >&2
+  echo "       Fetch the base ref first (CI must check out with fetch-depth: 0):" >&2
+  echo "         git fetch origin main" >&2
+  exit 1
+fi
+
+CHANGED="$(git diff --name-only --no-renames "${MERGE_BASE}" HEAD -- 'crates/*/CHANGELOG.md')"
+
+if [[ -z "${CHANGED//[$'\n' ]/}" ]]; then
+  echo "check-pr-changelog-assembled: no crates/*/CHANGELOG.md changed — OK."
+  exit 0
+fi
+
+FAIL=0
+while IFS= read -r path; do
+  [[ -z "$path" ]] && continue
+  crate="$(printf '%s' "$path" | sed -E 's#^crates/([^/]+)/CHANGELOG\.md$#\1#')"
+  [[ "$crate" == "$path" ]] && continue
+
+  # New headings only: lines the diff ADDS that are absent from the WHOLE
+  # merge-base file. A heading that already existed at the merge base (a
+  # --merge run folding fragments into a stale section, #5298) is not "new"
+  # even if the diff happens to touch nearby lines.
+  new_headings="$(
+    git diff --unified=0 --no-renames "${MERGE_BASE}" HEAD -- "$path" \
+      | grep -E '^\+## \[' \
+      | sed -E 's/^\+## \[([^]]+)\].*/\1/' \
+      | LC_ALL=C sort -u
+  )"
+  [[ -z "$new_headings" ]] && continue
+
+  base_headings="$(git show "${MERGE_BASE}:${path}" 2>/dev/null \
+    | grep -oE '^## \[[^]]+\]' | sed -E 's/^## \[([^]]+)\].*/\1/' || true)"
+
+  while IFS= read -r version; do
+    [[ -z "$version" ]] && continue
+    if printf '%s\n' "$base_headings" | grep -qxF "$version"; then
+      continue # already existed at the merge base — not a new section
+    fi
+
+    echo "check-pr-changelog-assembled: ${crate} gained a new '## [${version}]'" \
+      "section in this PR — verifying it was assembled, not hand-written."
+    out=""
+    rc=0
+    out="$(bash "${REPO_ROOT}/scripts/check-changelog-assembled.sh" "${crate}" "${version}" 2>&1)" || rc=$?
+    if [[ "$rc" -ne 0 ]] && printf '%s' "$out" | grep -q 'STRANDED-FRAGMENTS'; then
+      echo "FAIL ${crate} ${version}: new CHANGELOG.md section, but changelog.d/ still" >&2
+      echo "     holds fragment(s) it should have consumed:" >&2
+      printf '%s\n' "$out" | sed 's/^/       /' >&2
+      FAIL=1
+    elif [[ "$rc" -ne 0 ]]; then
+      # NO-SECTION cannot fire here (the section is exactly what triggered this
+      # scan), so any other nonzero exit is unexpected tool trouble, not a
+      # finding this gate is designed to make. Report it rather than swallow it.
+      echo "FAIL ${crate} ${version}: check-changelog-assembled.sh reported an" >&2
+      echo "     unexpected failure:" >&2
+      printf '%s\n' "$out" | sed 's/^/       /' >&2
+      FAIL=1
+    else
+      echo "OK   ${crate} ${version}: assembled cleanly, no stranded fragments."
+    fi
+  done <<<"$new_headings"
+done <<<"$CHANGED"
+
+if [[ "$FAIL" -ne 0 ]]; then
+  cat >&2 <<'EOF'
+
+A new '## [<version>]' section in CHANGELOG.md must come from the real
+assembler, never a hand-written edit:
+
+  scripts/assemble-changelog.sh <crate-dir> <version>
+
+which deletes every fragment it folds in as part of the SAME operation. If
+fragments still exist after adding the section, either run the assembler for
+real or delete the section and let the actual release cut write it (#6406).
+EOF
+  exit 1
+fi
+
+echo "check-pr-changelog-assembled: OK — every new CHANGELOG.md section in this PR was assembled cleanly."
+exit 0

--- a/scripts/preflight-publish.sh
+++ b/scripts/preflight-publish.sh
@@ -17,7 +17,7 @@
 #   absolute stop.
 #
 # What: given a crate (by package name or crates/ directory name) and,
-#   optionally, an explicit version, runs EIGHT independent checks and exits
+#   optionally, an explicit version, runs NINE independent checks and exits
 #   nonzero if any of them fail:
 #
 #   CHECK 1 (merged-main): after `git fetch origin main`, current HEAD's
@@ -212,6 +212,27 @@
 #     that a publish bypassed the gate without recording why, and why is the
 #     whole content of the disclosure.
 #
+#   CHECK 9 (the changelog assembler actually ran, #6406): delegates to
+#     `scripts/check-changelog-assembled.sh <pkg> <version>`, which fails when
+#     `crates/<crate>/changelog.d/` still holds a fragment (STRANDED-FRAGMENTS)
+#     or `crates/<crate>/CHANGELOG.md` has no `## [<version>]` heading for the
+#     version about to ship (NO-SECTION).
+#
+#     WHY THIS IS NOT ALREADY COVERED: none of checks 1-8 reads `changelog.d/`
+#     or `CHANGELOG.md` at all. Six `trusty-audit` tags (0.8.0 -> 0.12.0) were
+#     cut by hand-editing `Cargo.toml` directly — skipping
+#     `scripts/bump-version.sh` and therefore `scripts/assemble-changelog.sh`,
+#     the only thing that ever writes a release section or deletes a consumed
+#     fragment. Fragments sat unconsumed across all six releases and every
+#     other check here — identity, clean tree, tag/commit parity, public-API
+#     SemVer, the UI bundle, the pre-publish gate — stayed green throughout
+#     (#5919, repaired by hand in PR #6400).
+#
+#     No override flag. The remedy is always the same: run the real bump path
+#     (`scripts/bump-version.sh <crate-dir> <major|minor|patch>`), which calls
+#     the assembler for you, or assemble directly at the version you intend to
+#     ship (`scripts/assemble-changelog.sh <crate-dir> <version>`).
+#
 # Crate + version resolution: accepts EITHER
 #     scripts/preflight-publish.sh <crate-name-or-dir> [version]
 #   or, when [version] is omitted, reads the version from that crate's
@@ -226,7 +247,7 @@
 #   check-publish-ready.sh does, to avoid a second, divergent lookup
 #   convention in this workspace.
 #
-#   --check-only     run all 8 checks unconditionally (never short-circuits)
+#   --check-only     run all 9 checks unconditionally (never short-circuits)
 #                     and print one [PASS]/[FAIL] line per check, then a
 #                     one-line summary. Useful to preview status without
 #                     assuming you are mid-publish. Exit code is still
@@ -287,6 +308,12 @@
 #         Case 18 runs against the real fc7f396f — the commit trusty-search
 #         0.37.0 was published from — and names #3509's commit 972171e8 as the
 #         source change the bundle never picked up.
+#     (h) BOTH modes for check 9 (#6406), via
+#         scripts/check-changelog-assembled-selftest.sh: synthetic fixtures for
+#         a stranded fragment with no section (the #5919 shape), a section
+#         written with a fragment still left behind, and a correctly-assembled
+#         crate. Plus an end-to-end run of THIS script against the real,
+#         post-#6400-repair `trusty-audit`, where check 9 reports OK.
 #   See the PR description for this script for the full raw terminal output.
 
 set -euo pipefail
@@ -1401,6 +1428,27 @@ gate_unverified() {
   return 1
 }
 
+# ===========================================================================
+# CHECK 9 — the changelog assembler actually ran for this version (#6406)
+# ===========================================================================
+# Delegated rather than inlined so the comparison has somewhere to be tested:
+# scripts/check-changelog-assembled-selftest.sh drives every finding against
+# synthetic fixtures. No override — see the header comment for why.
+check9_changelog_assembled() {
+  local log="${TMP_CHANGELOG}" rc=0
+
+  bash "${REPO_ROOT}/scripts/check-changelog-assembled.sh" "$PKG_NAME" "$VERSION" > "$log" 2>&1 || rc=$?
+
+  if [ "$rc" -eq 0 ]; then
+    echo "[PASS] changelog-assembled: $(tail -1 "$log")" >&2
+    return 0
+  fi
+
+  echo "[FAIL] changelog-assembled: the changelog assembler was bypassed for ${PKG_NAME} ${VERSION}:" >&2
+  sed 's/^/       /' "$log" >&2
+  return 1
+}
+
 # ---------------------------------------------------------------------------
 # Scratch temp file for check 4's curl response body. Created once up front
 # and cleaned up via a script-scoped EXIT trap (matches check_line_cap.sh's
@@ -1410,22 +1458,24 @@ TMP_BODY="$(mktemp "${TMPDIR:-/tmp}/preflight-publish.body.XXXXXX")"
 TMP_SEMVER="$(mktemp "${TMPDIR:-/tmp}/preflight-publish.semver.XXXXXX")"
 TMP_PARITY="$(mktemp "${TMPDIR:-/tmp}/preflight-publish.parity.XXXXXX")"
 TMP_UIBUNDLE="$(mktemp "${TMPDIR:-/tmp}/preflight-publish.uibundle.XXXXXX")"
-trap 'rm -f "$TMP_BODY" "$TMP_SEMVER" "$TMP_PARITY" "$TMP_UIBUNDLE"' EXIT
+TMP_CHANGELOG="$(mktemp "${TMPDIR:-/tmp}/preflight-publish.changelog.XXXXXX")"
+trap 'rm -f "$TMP_BODY" "$TMP_SEMVER" "$TMP_PARITY" "$TMP_UIBUNDLE" "$TMP_CHANGELOG"' EXIT
 
 # ---------------------------------------------------------------------------
-# Run all 8 checks. Always run every check (rather than short-circuiting) so
+# Run all 9 checks. Always run every check (rather than short-circuiting) so
 # --check-only and normal mode share one code path and a single run always
 # reports the full picture — a partial preflight is how gaps get missed.
 # ---------------------------------------------------------------------------
 set +e
-check1_merged_main;      [ $? -eq 0 ] || FAILURES=$((FAILURES + 1))
-check2_identity;         [ $? -eq 0 ] || FAILURES=$((FAILURES + 1))
-check3_clean_tree;       [ $? -eq 0 ] || FAILURES=$((FAILURES + 1))
-check4_version_not_live; [ $? -eq 0 ] || FAILURES=$((FAILURES + 1))
-check5_semver;           [ $? -eq 0 ] || FAILURES=$((FAILURES + 1))
-check6_tag_parity;       [ $? -eq 0 ] || FAILURES=$((FAILURES + 1))
-check7_ui_bundle;        [ $? -eq 0 ] || FAILURES=$((FAILURES + 1))
-check8_prepublish_gate;  [ $? -eq 0 ] || FAILURES=$((FAILURES + 1))
+check1_merged_main;         [ $? -eq 0 ] || FAILURES=$((FAILURES + 1))
+check2_identity;            [ $? -eq 0 ] || FAILURES=$((FAILURES + 1))
+check3_clean_tree;          [ $? -eq 0 ] || FAILURES=$((FAILURES + 1))
+check4_version_not_live;    [ $? -eq 0 ] || FAILURES=$((FAILURES + 1))
+check5_semver;              [ $? -eq 0 ] || FAILURES=$((FAILURES + 1))
+check6_tag_parity;          [ $? -eq 0 ] || FAILURES=$((FAILURES + 1))
+check7_ui_bundle;           [ $? -eq 0 ] || FAILURES=$((FAILURES + 1))
+check8_prepublish_gate;     [ $? -eq 0 ] || FAILURES=$((FAILURES + 1))
+check9_changelog_assembled; [ $? -eq 0 ] || FAILURES=$((FAILURES + 1))
 set -e
 
 if [ "$FAILURES" -gt 0 ]; then
@@ -1437,18 +1487,18 @@ if [ -n "${SEMVER_NOT_VERIFIED:-}" ]; then
   # #5620: "passed all 7 checks" must not absorb a check-5 outcome that verified
   # nothing. The same distinction the check line draws, drawn again at the line
   # an operator is most likely to read on its own.
-  echo "preflight-publish: OK — ${PKG_NAME} ${VERSION} passed all 8 checks, but the" >&2
+  echo "preflight-publish: OK — ${PKG_NAME} ${VERSION} passed all 9 checks, but the" >&2
   echo "  public API was NOT VERIFIED: ${SEMVER_NOT_VERIFIED}. See the check 5 line above." >&2
 elif [ -n "${SEMVER_TYPES_ADVISORY:-}" ]; then
   # The type differ blocks nothing, so without this the summary would say
   # "safe to publish" over a listed set of type changes nobody has confirmed.
-  echo "preflight-publish: OK — ${PKG_NAME} ${VERSION} passed all 8 checks." >&2
+  echo "preflight-publish: OK — ${PKG_NAME} ${VERSION} passed all 9 checks." >&2
   echo "  ADVISORY, not blocking: ${SEMVER_TYPES_ADVISORY}. See the semver-types line above." >&2
 else
-  echo "preflight-publish: OK — ${PKG_NAME} ${VERSION} passed all 8 checks. Safe to publish." >&2
+  echo "preflight-publish: OK — ${PKG_NAME} ${VERSION} passed all 9 checks. Safe to publish." >&2
 fi
 if [ -n "${GATE_NOT_VERIFIED:-}" ]; then
-  # Same reasoning as the SEMVER_NOT_VERIFIED line above: "passed all 8 checks"
+  # Same reasoning as the SEMVER_NOT_VERIFIED line above: "passed all 9 checks"
   # must not absorb a check-8 outcome that read nothing.
   echo "preflight-publish: NOTE — ${GATE_NOT_VERIFIED}. See the check 8 line above." >&2
 fi


### PR DESCRIPTION
## Summary

Refs #6406. Six `trusty-audit` tags (0.8.0 -> 0.12.0) were cut by hand-editing `Cargo.toml`, skipping `scripts/bump-version.sh` and therefore `scripts/assemble-changelog.sh` — fragments sat unconsumed across all six releases with every `preflight-publish.sh` check staying green (#5919, repaired by hand in PR #6400).

- `scripts/check-changelog-assembled.sh` (new): given a crate + version, fails on STRANDED-FRAGMENTS (`changelog.d/` still holds a fragment) or NO-SECTION (`CHANGELOG.md` has no `## [<version>]` heading for that version).
- Wired into `scripts/preflight-publish.sh` as CHECK 9 — an absolute stop before `cargo publish`, no override (matches the other unconditional checks).
- `scripts/check-changelog-assembled-selftest.sh` (new): synthetic fixtures for both findings plus a clean/assembled state, and an end-to-end run against the real, post-#6400 `trusty-audit`.
- `scripts/check-pr-changelog-assembled.sh` (new, merge-time companion): fails a PR whose diff adds a NEW `## [<version>]` CHANGELOG.md section while leaving a fragment behind — narrowly scoped to a brand-new section so a legitimate `bump-version.sh --no-changelog` in-flight bump never trips it.

## Test plan

- [x] `bash -n` on all four changed/added scripts
- [x] `bash scripts/check-changelog-assembled.sh trusty-audit` against the live repo — PASS (post-#6400 repaired state)
- [x] `bash scripts/check-changelog-assembled.sh --repo <contrived-fixture> fake-crate` — FAILS with both STRANDED-FRAGMENTS and NO-SECTION
- [x] `bash scripts/check-changelog-assembled-selftest.sh` — 7/7 cases pass, including the live-trusty-audit case
- [x] `bash scripts/check-pr-changelog-assembled.sh` against this branch — OK (no CHANGELOG.md changed)
- Docs-only/CI-only script change — no crate `src/**` touched, so no changelog fragment (per CLAUDE.md's exemption) and no version bump.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools