### PR TITLE
fix(tga): take the credential lookup as a parameter, not the process env (Refs #6405)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10262,7 +10262,7 @@ dependencies = [
 
 [[package]]
 name = "tga"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/crates/trusty-git-analytics/Cargo.toml
+++ b/crates/trusty-git-analytics/Cargo.toml
@@ -37,7 +37,12 @@ name = "tga"
 # after it, so `preflight-publish.sh` CHECK 6 (tag/publish commit parity) can
 # never be satisfied at that tag. 4.0.1 is a burned version number and the
 # release moves forward to a gate-clean commit.
-version = "5.0.0"
+#
+# 5.0.0 → 5.0.1 (#6405): the unsynchronized env-mutation family closes out. The
+# credential-lookup seam is additive — every existing `pub fn` keeps its
+# signature and delegates to a `pub(crate)` `_with_creds` variant — so nothing
+# in the public API breaks. PATCH.
+version = "5.0.1"
 publish = true
 edition = "2021"
 # Aligned with the workspace MSRV (1.94) per #254. Required for

--- a/crates/trusty-git-analytics/changelog.d/6405-env-mutation-family.md
+++ b/crates/trusty-git-analytics/changelog.d/6405-env-mutation-family.md
@@ -1,0 +1,17 @@
+Fixed
+
+- **Credentials resolve through a lookup the caller supplies, not the process
+  environment (#6405)** — 42 `set_var`/`remove_var` sites across ten files
+  mutated the environment while 50+ reader threads, plus reqwest and rustls,
+  called `getenv` under `cargo test -p tga`. `setenv` can reallocate the
+  environment array mid-`getenv`, the likely mechanism behind the #2613 SIGSEGV.
+  Every JIRA, GitHub Issues, Linear, Shortcut, Confluence and Datadog fetch
+  helper now has a `_with_creds` variant carrying a `CredentialSource`, and
+  `ExternalSourceResolver` threads one through `resolve` and `warm_cache`; the
+  LLM tier's `from_provider` and `from_llm_config` take one too. Every existing
+  public function keeps its signature and delegates with the environment-backed
+  lookup, so no caller changes. `marker_file_path` and `resolve_db_path` take
+  their variable's value as a parameter, retiring a module-local mutex and three
+  `#[serial]` attributes. One site remains, in `batch_reviewer_tests`, because
+  the env tier it exercises lives in `trusty_common` and takes no lookup — it
+  stays `#[serial]` with that reason recorded at the call site.

--- a/crates/trusty-git-analytics/src/classify/classifier.rs
+++ b/crates/trusty-git-analytics/src/classify/classifier.rs
@@ -18,6 +18,7 @@ use crate::classify::tiers::override_tier::OverrideTier;
 use crate::classify::tiers::regex_tier::RegexMatcher;
 use crate::classify::tiers::weighted_sum::WeightedSumClassifier;
 use crate::classify::tiers::ClassificationResult;
+use crate::core::creds::CredentialSource;
 use crate::core::models::ClassificationMethod;
 
 /// Runtime configuration for the [`ClassificationEngine`].
@@ -211,6 +212,62 @@ impl ClassificationEngine {
         jira_confidence: Option<f64>,
         override_conn: Option<Arc<Mutex<Connection>>>,
     ) -> Result<Self> {
+        Self::build(
+            ruleset,
+            config,
+            custom_taxonomy,
+            jira_project_mappings,
+            jira_confidence,
+            override_conn,
+            &CredentialSource::from_env(),
+        )
+    }
+
+    /// [`Self::new`] with the LLM tier's credential lookup supplied by the
+    /// caller.
+    ///
+    /// Why (#6405): the "LLM enabled but no key resolves" arm used to be
+    /// provable only by clearing `OPENAI_API_KEY` process-wide, racing every
+    /// other thread's `getenv`.
+    /// What: builds the same engine as [`Self::new`], with `creds` replacing
+    /// the process environment for the LLM tier's key resolution.
+    /// Test: `classify::tests::llm_has_api_key_signals_misconfiguration`.
+    ///
+    /// # Errors
+    ///
+    /// As [`Self::new`].
+    #[cfg(test)]
+    pub(crate) fn new_with_creds(
+        ruleset: RuleSet,
+        config: ClassificationEngineConfig,
+        creds: &CredentialSource,
+    ) -> Result<Self> {
+        Self::build(
+            ruleset,
+            config,
+            Vec::new(),
+            HashMap::new(),
+            None,
+            None,
+            creds,
+        )
+    }
+
+    /// The one place the engine is actually assembled.
+    ///
+    /// Why: every public constructor above is a defaulting wrapper; keeping the
+    /// assembly in one private function is what lets the credential lookup be a
+    /// parameter without adding it to four public signatures (#6405).
+    #[allow(clippy::too_many_arguments)]
+    fn build(
+        ruleset: RuleSet,
+        config: ClassificationEngineConfig,
+        custom_taxonomy: Vec<SubcategoryDef>,
+        jira_project_mappings: HashMap<String, String>,
+        jira_confidence: Option<f64>,
+        override_conn: Option<Arc<Mutex<Connection>>>,
+        creds: &CredentialSource,
+    ) -> Result<Self> {
         let exact = ExactMatcher::new(&ruleset.rules)?;
         let regex = RegexMatcher::new(&ruleset.rules)?;
         // Tier 2.5: weighted-sum classifier. Active regardless of
@@ -229,10 +286,11 @@ impl ClassificationEngine {
             None
         };
         let llm = if config.use_llm {
-            match LlmClassifier::from_provider(
+            match LlmClassifier::from_provider_with_creds(
                 &config.llm_provider,
                 &config.llm_model,
                 config.openrouter_api_key.clone(),
+                creds,
             ) {
                 Ok(c) => Some(c),
                 Err(e) => {

--- a/crates/trusty-git-analytics/src/classify/pipeline_tests.rs
+++ b/crates/trusty-git-analytics/src/classify/pipeline_tests.rs
@@ -514,8 +514,6 @@ async fn pipeline_external_sources_dedupe_and_apply() {
         .mount(&server)
         .await;
 
-    unsafe { std::env::set_var("JIRA_TOKEN_2719", "test-token") };
-
     let mut issue_type_map = HashMap::new();
     issue_type_map.insert("Bug".to_string(), "bug_fix".to_string());
     let jira = JiraSourceConfig {
@@ -530,8 +528,10 @@ async fn pipeline_external_sources_dedupe_and_apply() {
             components: HashMap::new(),
         },
     };
+    // #6405: the token is a parameter, not a process-wide `set_var`.
     let resolver = ExternalSourceResolver::new(&[SourceConfig::Jira(jira)])
-        .with_jira_base_url(0, server.uri());
+        .with_jira_base_url(0, server.uri())
+        .with_credentials([("JIRA_TOKEN_2719", "test-token")]);
 
     let mut db = Database::open_in_memory().expect("db");
     for sha in ["sha-a", "sha-b", "sha-c"] {
@@ -564,7 +564,6 @@ async fn pipeline_external_sources_dedupe_and_apply() {
         );
     }
 
-    unsafe { std::env::remove_var("JIRA_TOKEN_2719") };
     // Dropping the server asserts `.expect(1)` — exactly one JIRA fetch.
     drop(server);
 }
@@ -606,8 +605,6 @@ async fn pipeline_external_sources_dedupe_distinct_messages_same_ticket() {
         .mount(&server)
         .await;
 
-    unsafe { std::env::set_var("JIRA_TOKEN_2719_DISTINCT", "test-token") };
-
     let mut issue_type_map = HashMap::new();
     issue_type_map.insert("Bug".to_string(), "bug_fix".to_string());
     let jira = JiraSourceConfig {
@@ -622,8 +619,10 @@ async fn pipeline_external_sources_dedupe_distinct_messages_same_ticket() {
             components: HashMap::new(),
         },
     };
+    // #6405: the token is a parameter, not a process-wide `set_var`.
     let resolver = ExternalSourceResolver::new(&[SourceConfig::Jira(jira)])
-        .with_jira_base_url(0, server.uri());
+        .with_jira_base_url(0, server.uri())
+        .with_credentials([("JIRA_TOKEN_2719_DISTINCT", "test-token")]);
 
     let mut db = Database::open_in_memory().expect("db");
     // Three DIFFERENT messages, same ticket key.
@@ -656,7 +655,6 @@ async fn pipeline_external_sources_dedupe_distinct_messages_same_ticket() {
         );
     }
 
-    unsafe { std::env::remove_var("JIRA_TOKEN_2719_DISTINCT") };
     // Dropping the server asserts `.expect(1)` — exactly one JIRA fetch,
     // regardless of how many distinct messages referenced PROJ-100.
     drop(server);

--- a/crates/trusty-git-analytics/src/classify/sources/confluence.rs
+++ b/crates/trusty-git-analytics/src/classify/sources/confluence.rs
@@ -27,6 +27,7 @@ use serde::{Deserialize, Serialize};
 use tracing::warn;
 
 use super::{ConfluenceSourceConfig, ExternalSignal};
+use crate::core::creds::CredentialSource;
 
 /// Default confidence for Confluence label signals.
 ///
@@ -184,9 +185,33 @@ pub async fn fetch_page(
     id: u64,
     base_url_override: Option<&str>,
 ) -> Option<ConfluencePage> {
-    let token = match std::env::var(&config.token_env) {
-        Ok(t) if !t.is_empty() => t,
-        _ => {
+    fetch_page_with_creds(
+        client,
+        config,
+        id,
+        base_url_override,
+        &CredentialSource::from_env(),
+    )
+    .await
+}
+
+/// [`fetch_page`], with the credential lookup supplied by the caller.
+///
+/// Why (#6405): proving the authenticated path used to require `set_var` on
+/// the two credential variables, racing every other thread's `getenv`.
+/// What: identical to [`fetch_page`] except that `creds` replaces the
+/// `std::env::var` reads for `token_env` and `email_env`.
+/// Test: `tests::fetch_and_classify_via_wiremock`.
+pub(crate) async fn fetch_page_with_creds(
+    client: &reqwest::Client,
+    config: &ConfluenceSourceConfig,
+    id: u64,
+    base_url_override: Option<&str>,
+    creds: &CredentialSource,
+) -> Option<ConfluencePage> {
+    let token = match creds.get(&config.token_env) {
+        Some(t) => t,
+        None => {
             warn!(
                 token_env = %config.token_env,
                 "Confluence token env var `{}` is not set — skipping Confluence lookups",
@@ -196,9 +221,9 @@ pub async fn fetch_page(
         }
     };
 
-    let email = match std::env::var(&config.email_env) {
-        Ok(e) if !e.is_empty() => e,
-        _ => {
+    let email = match creds.get(&config.email_env) {
+        Some(e) => e,
+        None => {
             warn!(
                 email_env = %config.email_env,
                 "Confluence email env var `{}` is not set — skipping Confluence lookups",
@@ -254,13 +279,32 @@ pub async fn fetch_pages_batch(
     ids: &[u64],
     base_url_override: Option<&str>,
 ) -> HashMap<String, Option<ExternalSignal>> {
+    fetch_pages_batch_with_creds(
+        client,
+        config,
+        ids,
+        base_url_override,
+        &CredentialSource::from_env(),
+    )
+    .await
+}
+
+/// [`fetch_pages_batch`], with the credential lookup supplied by the caller
+/// (#6405).
+pub(crate) async fn fetch_pages_batch_with_creds(
+    client: &reqwest::Client,
+    config: &ConfluenceSourceConfig,
+    ids: &[u64],
+    base_url_override: Option<&str>,
+    creds: &CredentialSource,
+) -> HashMap<String, Option<ExternalSignal>> {
     let mut out = HashMap::new();
     for &id in ids {
         let key = id.to_string();
         if out.contains_key(&key) {
             continue;
         }
-        let page = fetch_page(client, config, id, base_url_override).await;
+        let page = fetch_page_with_creds(client, config, id, base_url_override, creds).await;
         let signal = page.and_then(|p| classify_page(&p, config));
         out.insert(key, signal);
     }
@@ -501,8 +545,12 @@ label_mappings: {}
             .mount(&server)
             .await;
 
-        unsafe { std::env::set_var("CONF_TOKEN_WT", "test-token") }; // pragma: allowlist secret
-        unsafe { std::env::set_var("CONF_EMAIL_WT", "test@example.com") };
+        // #6405: the credentials are a parameter, so this test proves the
+        // authenticated path without mutating the process environment.
+        let creds = CredentialSource::fixed([
+            ("CONF_TOKEN_WT", "test-token"), // pragma: allowlist secret
+            ("CONF_EMAIL_WT", "test@example.com"),
+        ]);
 
         use std::collections::HashMap;
         let config = ConfluenceSourceConfig {
@@ -517,15 +565,33 @@ label_mappings: {}
         };
 
         let client = reqwest::Client::new();
-        let page = fetch_page(&client, &config, 99, Some(&server.uri()))
+        let page = fetch_page_with_creds(&client, &config, 99, Some(&server.uri()), &creds)
             .await
             .expect("fetch should succeed");
 
         let signal = classify_page(&page, &config).expect("should classify");
         assert_eq!(signal.category, "devops");
         assert!((signal.confidence - CONFLUENCE_CONFIDENCE).abs() < f64::EPSILON);
+    }
 
-        unsafe { std::env::remove_var("CONF_TOKEN_WT") };
-        unsafe { std::env::remove_var("CONF_EMAIL_WT") };
+    /// Why: an unset token must skip the lookup rather than issue an
+    /// unauthenticated request — the branch that used to be provable only by
+    /// clearing the variable process-wide (#6405).
+    /// What: resolve with an empty credential source and assert `None`, with
+    /// no HTTP server standing at all.
+    /// Test: this test itself.
+    #[tokio::test]
+    async fn fetch_page_returns_none_when_token_unset() {
+        use std::collections::HashMap;
+        let config = ConfluenceSourceConfig {
+            base_url: "https://acme.atlassian.net".to_string(),
+            token_env: "CONF_TOKEN_UNSET".to_string(), // pragma: allowlist secret
+            email_env: "CONF_EMAIL_UNSET".to_string(),
+            label_mappings: HashMap::new(),
+        };
+        let client = reqwest::Client::new();
+        let page =
+            fetch_page_with_creds(&client, &config, 1, None, &CredentialSource::empty()).await;
+        assert!(page.is_none(), "unset token must skip the lookup");
     }
 }

--- a/crates/trusty-git-analytics/src/classify/sources/datadog.rs
+++ b/crates/trusty-git-analytics/src/classify/sources/datadog.rs
@@ -24,6 +24,7 @@ use serde::{Deserialize, Serialize};
 use tracing::{debug, warn};
 
 use super::{DatadogSourceConfig, ExternalSignal};
+use crate::core::creds::CredentialSource;
 
 /// Default confidence for Datadog deployment-event signals.
 ///
@@ -109,9 +110,33 @@ pub async fn has_deployment_event(
     sha: &str,
     api_base_override: Option<&str>,
 ) -> bool {
-    let api_key = match std::env::var(&config.api_key_env) {
-        Ok(k) if !k.is_empty() => k,
-        _ => {
+    has_deployment_event_with_creds(
+        client,
+        config,
+        sha,
+        api_base_override,
+        &CredentialSource::from_env(),
+    )
+    .await
+}
+
+/// [`has_deployment_event`], with the credential lookup supplied by the caller.
+///
+/// Why (#6405): proving the authenticated path used to require `set_var` on
+/// both Datadog key variables, racing every other thread's `getenv`.
+/// What: identical to [`has_deployment_event`] except that `creds` replaces
+/// the `std::env::var` reads for `api_key_env` and `app_key_env`.
+/// Test: `tests::fetch_and_classify_via_wiremock`.
+pub(crate) async fn has_deployment_event_with_creds(
+    client: &reqwest::Client,
+    config: &DatadogSourceConfig,
+    sha: &str,
+    api_base_override: Option<&str>,
+    creds: &CredentialSource,
+) -> bool {
+    let api_key = match creds.get(&config.api_key_env) {
+        Some(k) => k,
+        None => {
             warn!(
                 api_key_env = %config.api_key_env,
                 "Datadog API key env var `{}` is not set — skipping Datadog lookups",
@@ -121,9 +146,9 @@ pub async fn has_deployment_event(
         }
     };
 
-    let app_key = match std::env::var(&config.app_key_env) {
-        Ok(k) if !k.is_empty() => k,
-        _ => {
+    let app_key = match creds.get(&config.app_key_env) {
+        Some(k) => k,
+        None => {
             warn!(
                 app_key_env = %config.app_key_env,
                 "Datadog app key env var `{}` is not set — skipping Datadog lookups",
@@ -200,12 +225,32 @@ pub async fn check_shas_batch(
     shas: &[String],
     api_base_override: Option<&str>,
 ) -> HashMap<String, Option<ExternalSignal>> {
+    check_shas_batch_with_creds(
+        client,
+        config,
+        shas,
+        api_base_override,
+        &CredentialSource::from_env(),
+    )
+    .await
+}
+
+/// [`check_shas_batch`], with the credential lookup supplied by the caller
+/// (#6405).
+pub(crate) async fn check_shas_batch_with_creds(
+    client: &reqwest::Client,
+    config: &DatadogSourceConfig,
+    shas: &[String],
+    api_base_override: Option<&str>,
+    creds: &CredentialSource,
+) -> HashMap<String, Option<ExternalSignal>> {
     let mut out = HashMap::new();
     for sha in shas {
         if out.contains_key(sha) {
             continue;
         }
-        let found = has_deployment_event(client, config, sha, api_base_override).await;
+        let found =
+            has_deployment_event_with_creds(client, config, sha, api_base_override, creds).await;
         let signal = if found {
             let confidence = config.confidence.unwrap_or(DATADOG_DEFAULT_CONFIDENCE);
             Some(ExternalSignal {
@@ -345,8 +390,12 @@ unknown_field: oops
             .mount(&server)
             .await;
 
-        unsafe { std::env::set_var("DD_API_KEY_WT", "test-api-key") }; // pragma: allowlist secret
-        unsafe { std::env::set_var("DD_APP_KEY_WT", "test-app-key") }; // pragma: allowlist secret
+        // #6405: the credentials are a parameter, so this test proves the
+        // authenticated path without mutating the process environment.
+        let creds = CredentialSource::fixed([
+            ("DD_API_KEY_WT", "test-api-key"), // pragma: allowlist secret
+            ("DD_APP_KEY_WT", "test-app-key"), // pragma: allowlist secret
+        ]);
 
         let config = DatadogSourceConfig {
             api_key_env: "DD_API_KEY_WT".to_string(), // pragma: allowlist secret
@@ -358,15 +407,23 @@ unknown_field: oops
         };
 
         let client = reqwest::Client::new();
-        let found = has_deployment_event(&client, &config, "abc1234", Some(&server.uri())).await;
+        let found = has_deployment_event_with_creds(
+            &client,
+            &config,
+            "abc1234",
+            Some(&server.uri()),
+            &creds,
+        )
+        .await;
         assert!(found, "deployment event should be found");
 
         // Now verify the batch helper produces the right signal.
-        let map = check_shas_batch(
+        let map = check_shas_batch_with_creds(
             &client,
             &config,
             &["abc1234".to_string()],
             Some(&server.uri()),
+            &creds,
         )
         .await;
         let signal = map.get("abc1234").and_then(|s| s.as_ref()).expect("signal");
@@ -376,9 +433,36 @@ unknown_field: oops
             "confidence should be 0.95"
         );
         assert!(signal.source.contains("abc1234"));
+    }
 
-        unsafe { std::env::remove_var("DD_API_KEY_WT") };
-        unsafe { std::env::remove_var("DD_APP_KEY_WT") };
+    /// Why: an unset API key must skip the lookup rather than issue an
+    /// unauthenticated request — the branch that used to be provable only by
+    /// clearing the variable process-wide (#6405).
+    /// What: query with an empty credential source and assert `false`, with no
+    /// HTTP server standing at all.
+    /// Test: this test itself.
+    #[tokio::test]
+    async fn has_deployment_event_is_false_when_keys_unset() {
+        let config = DatadogSourceConfig {
+            api_key_env: "DD_API_KEY_UNSET".to_string(), // pragma: allowlist secret
+            app_key_env: "DD_APP_KEY_UNSET".to_string(), // pragma: allowlist secret
+            dd_site: None,
+            service: None,
+            default_category: "devops".to_string(),
+            confidence: None,
+        };
+        let client = reqwest::Client::new();
+        assert!(
+            !has_deployment_event_with_creds(
+                &client,
+                &config,
+                "abc1234",
+                None,
+                &CredentialSource::empty()
+            )
+            .await,
+            "unset keys must skip the lookup"
+        );
     }
 
     /// Why: when no deployment event is found the batch helper must return
@@ -399,8 +483,11 @@ unknown_field: oops
             .mount(&server)
             .await;
 
-        unsafe { std::env::set_var("DD_API_KEY_EMPTY", "test-api-key") }; // pragma: allowlist secret
-        unsafe { std::env::set_var("DD_APP_KEY_EMPTY", "test-app-key") }; // pragma: allowlist secret
+        // #6405: credentials as a parameter, never a process-wide `set_var`.
+        let creds = CredentialSource::fixed([
+            ("DD_API_KEY_EMPTY", "test-api-key"), // pragma: allowlist secret
+            ("DD_APP_KEY_EMPTY", "test-app-key"), // pragma: allowlist secret
+        ]);
 
         let config = DatadogSourceConfig {
             api_key_env: "DD_API_KEY_EMPTY".to_string(), // pragma: allowlist secret
@@ -412,11 +499,12 @@ unknown_field: oops
         };
 
         let client = reqwest::Client::new();
-        let map = check_shas_batch(
+        let map = check_shas_batch_with_creds(
             &client,
             &config,
             &["deadbeef".to_string()],
             Some(&server.uri()),
+            &creds,
         )
         .await;
         let signal = map.get("deadbeef").expect("key present");
@@ -424,8 +512,5 @@ unknown_field: oops
             signal.is_none(),
             "no events should yield None signal, got {signal:?}"
         );
-
-        unsafe { std::env::remove_var("DD_API_KEY_EMPTY") };
-        unsafe { std::env::remove_var("DD_APP_KEY_EMPTY") };
     }
 }

--- a/crates/trusty-git-analytics/src/classify/sources/github_issues.rs
+++ b/crates/trusty-git-analytics/src/classify/sources/github_issues.rs
@@ -23,6 +23,7 @@ use tracing::warn;
 use super::{ExternalSignal, GithubIssuesSourceConfig, EXTERNAL_SOURCE_CONFIDENCE};
 use crate::collect::github::budget::{FetchBudget, MAX_REFERENCE_LOOKUPS};
 use crate::collect::github::retry::retry_send;
+use crate::core::creds::CredentialSource;
 
 /// A parsed GitHub issue reference extracted from a commit message.
 ///
@@ -174,9 +175,34 @@ pub async fn fetch_issue(
     api_base_override: Option<&str>,
     budget: &FetchBudget,
 ) -> crate::collect::errors::Result<Option<GitHubIssue>> {
-    let token = std::env::var(&config.token_env)
-        .ok()
-        .filter(|t| !t.is_empty());
+    fetch_issue_with_creds(
+        client,
+        config,
+        owner_repo,
+        number,
+        api_base_override,
+        budget,
+        &CredentialSource::from_env(),
+    )
+    .await
+}
+
+/// [`fetch_issue`], with the credential lookup supplied by the caller (#6405).
+///
+/// # Errors
+///
+/// As [`fetch_issue`].
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn fetch_issue_with_creds(
+    client: &reqwest::Client,
+    config: &GithubIssuesSourceConfig,
+    owner_repo: &str,
+    number: u64,
+    api_base_override: Option<&str>,
+    budget: &FetchBudget,
+    creds: &CredentialSource,
+) -> crate::collect::errors::Result<Option<GitHubIssue>> {
+    let token = creds.get(&config.token_env);
 
     let base = api_base_override.unwrap_or("https://api.github.com");
     let url = format!("{base}/repos/{owner_repo}/issues/{number}");
@@ -242,6 +268,27 @@ pub async fn fetch_issues_batch(
     api_base_override: Option<&str>,
     budget: &FetchBudget,
 ) -> IssueBatch {
+    fetch_issues_batch_with_creds(
+        client,
+        config,
+        refs,
+        api_base_override,
+        budget,
+        &CredentialSource::from_env(),
+    )
+    .await
+}
+
+/// [`fetch_issues_batch`], with the credential lookup supplied by the caller
+/// (#6405).
+pub(crate) async fn fetch_issues_batch_with_creds(
+    client: &reqwest::Client,
+    config: &GithubIssuesSourceConfig,
+    refs: &[GitHubRef],
+    api_base_override: Option<&str>,
+    budget: &FetchBudget,
+    creds: &CredentialSource,
+) -> IssueBatch {
     let mut out = IssueBatch::default();
     let mut looked_up = 0usize;
 
@@ -263,13 +310,14 @@ pub async fn fetch_issues_batch(
         }
 
         looked_up += 1;
-        match fetch_issue(
+        match fetch_issue_with_creds(
             client,
             config,
             repo,
             gh_ref.number,
             api_base_override,
             budget,
+            creds,
         )
         .await
         {

--- a/crates/trusty-git-analytics/src/classify/sources/jira.rs
+++ b/crates/trusty-git-analytics/src/classify/sources/jira.rs
@@ -22,6 +22,7 @@ use serde::Deserialize;
 use tracing::warn;
 
 use super::{ExternalSignal, JiraSourceConfig, EXTERNAL_SOURCE_CONFIDENCE};
+use crate::core::creds::CredentialSource;
 
 /// Regex matching a JIRA-style ticket key (`PROJ-1234`).
 ///
@@ -210,9 +211,33 @@ pub async fn fetch_issue(
     key: &str,
     base_url_override: Option<&str>,
 ) -> Option<JiraIssue> {
-    let token = match std::env::var(&config.token_env) {
-        Ok(t) if !t.is_empty() => t,
-        _ => {
+    fetch_issue_with_creds(
+        client,
+        config,
+        key,
+        base_url_override,
+        &CredentialSource::from_env(),
+    )
+    .await
+}
+
+/// [`fetch_issue`], with the credential lookup supplied by the caller.
+///
+/// Why (#6405): proving the authenticated path used to require `set_var` on
+/// the token variable, racing every other thread's `getenv`.
+/// What: identical to [`fetch_issue`] except that `creds` replaces the
+/// `std::env::var` reads for `token_env` and `email_env`.
+/// Test: `resolver_tests::resolver_returns_jira_signal_for_bug_issue_type`.
+pub(crate) async fn fetch_issue_with_creds(
+    client: &reqwest::Client,
+    config: &JiraSourceConfig,
+    key: &str,
+    base_url_override: Option<&str>,
+    creds: &CredentialSource,
+) -> Option<JiraIssue> {
+    let token = match creds.get(&config.token_env) {
+        Some(t) => t,
+        None => {
             warn!(
                 token_env = %config.token_env,
                 "JIRA token env var `{}` is not set in the tga process environment — \
@@ -235,11 +260,11 @@ pub async fn fetch_issue(
     if let Some(username) = &config.username {
         req = req.basic_auth(username, Some(&token));
     } else if let Some(env_name) = &config.email_env {
-        match std::env::var(env_name) {
-            Ok(email) if !email.is_empty() => {
+        match creds.get(env_name) {
+            Some(email) => {
                 req = req.basic_auth(email, Some(&token));
             }
-            _ => {
+            None => {
                 warn!(
                     email_env = %env_name,
                     "JIRA email env var `{env_name}` is not set in the tga process \
@@ -296,12 +321,31 @@ pub async fn fetch_issues_batch(
     keys: &[String],
     base_url_override: Option<&str>,
 ) -> HashMap<String, Option<ExternalSignal>> {
+    fetch_issues_batch_with_creds(
+        client,
+        config,
+        keys,
+        base_url_override,
+        &CredentialSource::from_env(),
+    )
+    .await
+}
+
+/// [`fetch_issues_batch`], with the credential lookup supplied by the caller
+/// (#6405).
+pub(crate) async fn fetch_issues_batch_with_creds(
+    client: &reqwest::Client,
+    config: &JiraSourceConfig,
+    keys: &[String],
+    base_url_override: Option<&str>,
+    creds: &CredentialSource,
+) -> HashMap<String, Option<ExternalSignal>> {
     let mut out = HashMap::new();
     for key in keys {
         if out.contains_key(key) {
             continue;
         }
-        let issue = fetch_issue(client, config, key, base_url_override).await;
+        let issue = fetch_issue_with_creds(client, config, key, base_url_override, creds).await;
         let signal = issue.and_then(|iss| classify_issue(&iss, config));
         out.insert(key.clone(), signal);
     }

--- a/crates/trusty-git-analytics/src/classify/sources/linear.rs
+++ b/crates/trusty-git-analytics/src/classify/sources/linear.rs
@@ -21,6 +21,7 @@ use serde::{Deserialize, Serialize};
 use tracing::warn;
 
 use super::{ExternalSignal, LinearSourceConfig, EXTERNAL_SOURCE_CONFIDENCE};
+use crate::core::creds::CredentialSource;
 
 /// Linear-specific confidence — same as the global constant (issue type is
 /// very authoritative).
@@ -231,9 +232,33 @@ pub async fn fetch_issue(
     key: &str,
     base_url_override: Option<&str>,
 ) -> Option<LinearIssue> {
-    let token = match std::env::var(&config.api_key_env) {
-        Ok(t) if !t.is_empty() => t,
-        _ => {
+    fetch_issue_with_creds(
+        client,
+        config,
+        key,
+        base_url_override,
+        &CredentialSource::from_env(),
+    )
+    .await
+}
+
+/// [`fetch_issue`], with the credential lookup supplied by the caller.
+///
+/// Why (#6405): proving the authenticated path used to require `set_var` on
+/// the API-key variable, racing every other thread's `getenv`.
+/// What: identical to [`fetch_issue`] except that `creds` replaces the
+/// `std::env::var` read for `api_key_env`.
+/// Test: `tests::fetch_and_classify_via_wiremock`.
+pub(crate) async fn fetch_issue_with_creds(
+    client: &reqwest::Client,
+    config: &LinearSourceConfig,
+    key: &str,
+    base_url_override: Option<&str>,
+    creds: &CredentialSource,
+) -> Option<LinearIssue> {
+    let token = match creds.get(&config.api_key_env) {
+        Some(t) => t,
+        None => {
             warn!(
                 api_key_env = %config.api_key_env,
                 "Linear API key env var `{}` is not set — did you `export {}` before running tga?",
@@ -302,12 +327,31 @@ pub async fn fetch_issues_batch(
     keys: &[String],
     base_url_override: Option<&str>,
 ) -> HashMap<String, Option<ExternalSignal>> {
+    fetch_issues_batch_with_creds(
+        client,
+        config,
+        keys,
+        base_url_override,
+        &CredentialSource::from_env(),
+    )
+    .await
+}
+
+/// [`fetch_issues_batch`], with the credential lookup supplied by the caller
+/// (#6405).
+pub(crate) async fn fetch_issues_batch_with_creds(
+    client: &reqwest::Client,
+    config: &LinearSourceConfig,
+    keys: &[String],
+    base_url_override: Option<&str>,
+    creds: &CredentialSource,
+) -> HashMap<String, Option<ExternalSignal>> {
     let mut out = HashMap::new();
     for key in keys {
         if out.contains_key(key) {
             continue;
         }
-        let issue = fetch_issue(client, config, key, base_url_override).await;
+        let issue = fetch_issue_with_creds(client, config, key, base_url_override, creds).await;
         let signal = issue.and_then(|iss| classify_issue(&iss, config));
         out.insert(key.clone(), signal);
     }
@@ -574,7 +618,9 @@ field_mappings:
             .mount(&server)
             .await;
 
-        unsafe { std::env::set_var("LINEAR_API_TOKEN_WT", "test-token") }; // pragma: allowlist secret
+        // #6405: the credential is a parameter, so this test proves the
+        // authenticated path without mutating the process environment.
+        let creds = CredentialSource::fixed([("LINEAR_API_TOKEN_WT", "test-token")]); // pragma: allowlist secret
 
         use std::collections::HashMap;
         let config = LinearSourceConfig {
@@ -592,14 +638,37 @@ field_mappings:
         };
 
         let client = reqwest::Client::new();
-        let issue = fetch_issue(&client, &config, "ENG-99", Some(&server.uri()))
+        let issue = fetch_issue_with_creds(&client, &config, "ENG-99", Some(&server.uri()), &creds)
             .await
             .expect("fetch should succeed");
 
         let signal = classify_issue(&issue, &config).expect("should classify");
         assert_eq!(signal.category, "bug_fix");
         assert!(signal.source.contains("issue_type"));
+    }
 
-        unsafe { std::env::remove_var("LINEAR_API_TOKEN_WT") };
+    /// Why: an unset API key must skip the lookup rather than issue an
+    /// unauthenticated request — the branch that used to be provable only by
+    /// clearing the variable process-wide (#6405).
+    /// What: fetch with an empty credential source and assert `None`, with no
+    /// HTTP server standing at all.
+    /// Test: this test itself.
+    #[tokio::test]
+    async fn fetch_issue_returns_none_when_token_unset() {
+        use std::collections::HashMap;
+        let config = LinearSourceConfig {
+            api_key_env: "LINEAR_API_TOKEN_UNSET".to_string(), // pragma: allowlist secret
+            team_keys: vec![],
+            field_mappings: crate::classify::sources::LinearFieldMappings {
+                issue_type: HashMap::new(),
+                labels: HashMap::new(),
+                cycle: HashMap::new(),
+            },
+        };
+        let client = reqwest::Client::new();
+        let issue =
+            fetch_issue_with_creds(&client, &config, "ENG-1", None, &CredentialSource::empty())
+                .await;
+        assert!(issue.is_none(), "unset token must skip the lookup");
     }
 }

--- a/crates/trusty-git-analytics/src/classify/sources/resolver/mod.rs
+++ b/crates/trusty-git-analytics/src/classify/sources/resolver/mod.rs
@@ -29,6 +29,7 @@ use super::{
     github_issues::{self, GitHubRef},
     jira, linear, shortcut, ExternalSignal, SourceConfig,
 };
+use crate::core::creds::CredentialSource;
 
 mod warm;
 
@@ -95,6 +96,9 @@ pub struct ExternalSourceResolver {
     /// issues one lookup per unique `#N` in commit history, so the bound that
     /// matters spans calls rather than sitting inside any one of them.
     github_budget: crate::collect::github::budget::FetchBudget,
+    /// #6405: where every source's token comes from. The process environment
+    /// in production; a fixed table in tests, so no test has to `set_var`.
+    creds: CredentialSource,
 }
 
 impl ExternalSourceResolver {
@@ -146,12 +150,39 @@ impl ExternalSourceResolver {
             client,
             sources: states,
             github_budget: crate::collect::github::budget::FetchBudget::new(),
+            creds: CredentialSource::from_env(),
         }
     }
 
     /// The GitHub fetch budget this resolver's sources share (#6084).
     pub(crate) fn github_budget(&self) -> &crate::collect::github::budget::FetchBudget {
         &self.github_budget
+    }
+
+    /// The credential lookup this resolver's sources share (#6405).
+    pub(crate) fn creds(&self) -> &CredentialSource {
+        &self.creds
+    }
+
+    /// Resolve every source's token from a fixed `(name, value)` table
+    /// instead of the process environment.
+    ///
+    /// Why (#6405): a test that needs an authenticated source used to
+    /// `set_var` the token, which races every other thread's `getenv` and is
+    /// the likely mechanism behind the #2613 SIGSEGV. This is the same
+    /// injection seam as `with_jira_base_url`, applied to credentials.
+    /// What: replaces the resolver's [`CredentialSource`]; names not listed
+    /// read as unset.
+    /// Test: used by every credential-dependent resolver and pipeline test.
+    #[cfg(test)]
+    pub fn with_credentials<K, V, I>(mut self, pairs: I) -> Self
+    where
+        K: Into<String>,
+        V: Into<String>,
+        I: IntoIterator<Item = (K, V)>,
+    {
+        self.creds = CredentialSource::fixed(pairs);
+        self
     }
 
     /// Resolve a commit message against all configured sources.
@@ -222,11 +253,12 @@ impl ExternalSourceResolver {
                 }
 
                 // Fetch misses.
-                let fetched = jira::fetch_issues_batch(
+                let fetched = jira::fetch_issues_batch_with_creds(
                     &self.client,
                     config,
                     &misses.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
                     base_url_override.as_deref(),
+                    &self.creds,
                 )
                 .await;
 
@@ -271,12 +303,13 @@ impl ExternalSourceResolver {
                 }
 
                 // Fetch misses.
-                let fetched = github_issues::fetch_issues_batch(
+                let fetched = github_issues::fetch_issues_batch_with_creds(
                     &self.client,
                     config,
                     &refs,
                     api_base_override.as_deref(),
                     &self.github_budget,
+                    &self.creds,
                 )
                 .await;
 
@@ -336,11 +369,12 @@ impl ExternalSourceResolver {
                 }
 
                 // Fetch misses.
-                let fetched = linear::fetch_issues_batch(
+                let fetched = linear::fetch_issues_batch_with_creds(
                     &self.client,
                     config,
                     &filtered,
                     api_base_override.as_deref(),
+                    &self.creds,
                 )
                 .await;
 
@@ -382,11 +416,12 @@ impl ExternalSourceResolver {
                 }
 
                 // Fetch misses.
-                let fetched = shortcut::fetch_stories_batch(
+                let fetched = shortcut::fetch_stories_batch_with_creds(
                     &self.client,
                     config,
                     &ids,
                     api_base_override.as_deref(),
+                    &self.creds,
                 )
                 .await;
 
@@ -429,11 +464,12 @@ impl ExternalSourceResolver {
                 }
 
                 // Fetch misses.
-                let fetched = confluence::fetch_pages_batch(
+                let fetched = confluence::fetch_pages_batch_with_creds(
                     &self.client,
                     config,
                     &ids,
                     api_base_override.as_deref(),
+                    &self.creds,
                 )
                 .await;
 
@@ -475,11 +511,12 @@ impl ExternalSourceResolver {
                 }
 
                 // Fetch misses.
-                let fetched = datadog::check_shas_batch(
+                let fetched = datadog::check_shas_batch_with_creds(
                     &self.client,
                     config,
                     &shas,
                     api_base_override.as_deref(),
+                    &self.creds,
                 )
                 .await;
 

--- a/crates/trusty-git-analytics/src/classify/sources/resolver/warm.rs
+++ b/crates/trusty-git-analytics/src/classify/sources/resolver/warm.rs
@@ -36,6 +36,7 @@ use tracing::warn;
 use super::{confluence, datadog, github_issues, jira, linear, shortcut};
 use super::{Cache, ExternalSignal, ExternalSourceResolver, GitHubRef, SourceState};
 use crate::collect::github::budget::FetchBudget;
+use crate::core::creds::CredentialSource;
 
 impl ExternalSourceResolver {
     /// Pre-resolve every ticket key referenced across `messages`, for every
@@ -59,6 +60,7 @@ impl ExternalSourceResolver {
                 messages,
                 concurrency,
                 self.github_budget(),
+                self.creds(),
             )
             .await;
         }
@@ -80,6 +82,7 @@ async fn warm_source(
     messages: &[String],
     concurrency: usize,
     github_budget: &FetchBudget,
+    creds: &CredentialSource,
 ) {
     match state {
         SourceState::Jira {
@@ -107,11 +110,12 @@ async fn warm_source(
                 keys,
                 |k: &String| k.clone(),
                 |k: String| async move {
-                    let mut result = jira::fetch_issues_batch(
+                    let mut result = jira::fetch_issues_batch_with_creds(
                         client,
                         config,
                         std::slice::from_ref(&k),
                         base_url_override,
+                        creds,
                     )
                     .await;
                     result.remove(&k)
@@ -146,12 +150,13 @@ async fn warm_source(
                 |r: GitHubRef| async move {
                     let repo = r.repo.clone().unwrap_or_else(|| config.repo.clone());
                     let key = format!("{repo}#{}", r.number);
-                    let mut result = github_issues::fetch_issues_batch(
+                    let mut result = github_issues::fetch_issues_batch_with_creds(
                         client,
                         config,
                         std::slice::from_ref(&r),
                         api_base_override,
                         github_budget,
+                        creds,
                     )
                     .await;
                     if let Some(reason) = &result.stopped_early {
@@ -182,11 +187,12 @@ async fn warm_source(
                 keys,
                 |k: &String| k.clone(),
                 |k: String| async move {
-                    let mut result = linear::fetch_issues_batch(
+                    let mut result = linear::fetch_issues_batch_with_creds(
                         client,
                         config,
                         std::slice::from_ref(&k),
                         api_base_override,
+                        creds,
                     )
                     .await;
                     result.remove(&k)
@@ -214,11 +220,12 @@ async fn warm_source(
                 |id: &u64| id.to_string(),
                 |id: u64| async move {
                     let key = id.to_string();
-                    let mut result = shortcut::fetch_stories_batch(
+                    let mut result = shortcut::fetch_stories_batch_with_creds(
                         client,
                         config,
                         std::slice::from_ref(&id),
                         api_base_override,
+                        creds,
                     )
                     .await;
                     result.remove(&key)
@@ -246,11 +253,12 @@ async fn warm_source(
                 |id: &u64| id.to_string(),
                 |id: u64| async move {
                     let key = id.to_string();
-                    let mut result = confluence::fetch_pages_batch(
+                    let mut result = confluence::fetch_pages_batch_with_creds(
                         client,
                         config,
                         std::slice::from_ref(&id),
                         api_base_override,
+                        creds,
                     )
                     .await;
                     result.remove(&key)
@@ -277,11 +285,12 @@ async fn warm_source(
                 shas,
                 |s: &String| s.clone(),
                 |s: String| async move {
-                    let mut result = datadog::check_shas_batch(
+                    let mut result = datadog::check_shas_batch_with_creds(
                         client,
                         config,
                         std::slice::from_ref(&s),
                         api_base_override,
+                        creds,
                     )
                     .await;
                     result.remove(&s)

--- a/crates/trusty-git-analytics/src/classify/sources/resolver/warm_tests.rs
+++ b/crates/trusty-git-analytics/src/classify/sources/resolver/warm_tests.rs
@@ -34,8 +34,6 @@ async fn warm_cache_dedupes_ticket_key_across_distinct_messages() {
         .mount(&server)
         .await;
 
-    unsafe { std::env::set_var("JIRA_TOKEN_WARM_TEST", "test-token") };
-
     let mut issue_type_map = HashMap::new();
     issue_type_map.insert("Bug".to_string(), "bug_fix".to_string());
     let jira = JiraSourceConfig {
@@ -50,8 +48,10 @@ async fn warm_cache_dedupes_ticket_key_across_distinct_messages() {
             components: HashMap::new(),
         },
     };
+    // #6405: the token is a parameter, not a process-wide `set_var`.
     let resolver = ExternalSourceResolver::new(&[SourceConfig::Jira(jira)])
-        .with_jira_base_url(0, server.uri());
+        .with_jira_base_url(0, server.uri())
+        .with_credentials([("JIRA_TOKEN_WARM_TEST", "test-token")]);
 
     let messages = vec![
         "PROJ-7 fix the crash".to_string(),
@@ -65,7 +65,6 @@ async fn warm_cache_dedupes_ticket_key_across_distinct_messages() {
     assert_eq!(s1, s2);
     assert_eq!(s1.category, "bug_fix");
 
-    unsafe { std::env::remove_var("JIRA_TOKEN_WARM_TEST") };
     // Dropping the server asserts `.expect(1)`.
     drop(server);
 }

--- a/crates/trusty-git-analytics/src/classify/sources/resolver_tests.rs
+++ b/crates/trusty-git-analytics/src/classify/sources/resolver_tests.rs
@@ -62,9 +62,6 @@ async fn resolver_returns_jira_signal_for_bug_issue_type() {
         .mount(&server)
         .await;
 
-    // Set token env var for this test.
-    unsafe { std::env::set_var("JIRA_API_TOKEN_TEST_BUG", "test-token") };
-
     let mut issue_type_map = HashMap::new();
     issue_type_map.insert("Bug".to_string(), "bug_fix".to_string());
 
@@ -80,8 +77,10 @@ async fn resolver_returns_jira_signal_for_bug_issue_type() {
             components: HashMap::new(),
         },
     };
+    // #6405: the token is a parameter, not a process-wide `set_var`.
     let resolver = ExternalSourceResolver::new(&[SourceConfig::Jira(config)])
-        .with_jira_base_url(0, server.uri());
+        .with_jira_base_url(0, server.uri())
+        .with_credentials([("JIRA_API_TOKEN_TEST_BUG", "test-token")]);
 
     let signal = resolver
         .resolve("PROJ-1234 fix null pointer")
@@ -89,8 +88,6 @@ async fn resolver_returns_jira_signal_for_bug_issue_type() {
         .expect("should have signal");
     assert_eq!(signal.category, "bug_fix");
     assert!(signal.source.contains("issue_type"));
-
-    unsafe { std::env::remove_var("JIRA_API_TOKEN_TEST_BUG") };
 }
 
 /// Why: the cache must prevent duplicate HTTP calls for the same ticket
@@ -120,8 +117,6 @@ async fn resolver_caches_jira_result_across_calls() {
         .mount(&server)
         .await;
 
-    unsafe { std::env::set_var("JIRA_API_TOKEN_CACHE_TEST", "test-token") };
-
     let mut issue_type_map = HashMap::new();
     issue_type_map.insert("Story".to_string(), "new_feature".to_string());
 
@@ -137,8 +132,10 @@ async fn resolver_caches_jira_result_across_calls() {
             components: HashMap::new(),
         },
     };
+    // #6405: the token is a parameter, not a process-wide `set_var`.
     let resolver = ExternalSourceResolver::new(&[SourceConfig::Jira(config)])
-        .with_jira_base_url(0, server.uri());
+        .with_jira_base_url(0, server.uri())
+        .with_credentials([("JIRA_API_TOKEN_CACHE_TEST", "test-token")]);
 
     // First call — should fetch from mock.
     let s1 = resolver.resolve("PROJ-99 add widget").await;
@@ -148,8 +145,6 @@ async fn resolver_caches_jira_result_across_calls() {
     // second request).
     let s2 = resolver.resolve("PROJ-99 related commit").await;
     assert_eq!(s1, s2);
-
-    unsafe { std::env::remove_var("JIRA_API_TOKEN_CACHE_TEST") };
 }
 
 /// Why: when the JIRA token env var is unset the resolver must return
@@ -159,9 +154,6 @@ async fn resolver_caches_jira_result_across_calls() {
 /// Test: no HTTP expected (token check happens before fetch).
 #[tokio::test]
 async fn resolver_skips_jira_when_token_unset() {
-    // Guarantee the env var is absent for this test.
-    unsafe { std::env::remove_var("JIRA_TOKEN_DEFINITELY_NOT_SET_XYZ") };
-
     let config = JiraSourceConfig {
         base_url: "https://acme.atlassian.net".to_string(),
         token_env: "JIRA_TOKEN_DEFINITELY_NOT_SET_XYZ".to_string(),
@@ -170,7 +162,10 @@ async fn resolver_skips_jira_when_token_unset() {
         project_keys: vec![],
         field_mappings: JiraFieldMappings::default(),
     };
-    let resolver = ExternalSourceResolver::new(&[SourceConfig::Jira(config)]);
+    // #6405: an empty credential table proves "the variable is unset" without
+    // clearing anything process-wide.
+    let resolver = ExternalSourceResolver::new(&[SourceConfig::Jira(config)])
+        .with_credentials(Vec::<(String, String)>::new());
     let result = resolver.resolve("PROJ-1234 update").await;
     assert!(result.is_none(), "missing token must yield None, not panic");
 }
@@ -195,8 +190,6 @@ async fn resolver_returns_github_signal_for_bug_label() {
         .mount(&server)
         .await;
 
-    unsafe { std::env::set_var("GITHUB_TOKEN_TEST_BUG", "test-token") };
-
     let mut label_map = HashMap::new();
     label_map.insert("bug".to_string(), "bug_fix".to_string());
 
@@ -206,8 +199,10 @@ async fn resolver_returns_github_signal_for_bug_label() {
         label_mappings: label_map,
     };
 
+    // #6405: the token is a parameter, not a process-wide `set_var`.
     let resolver = ExternalSourceResolver::new(&[SourceConfig::GithubIssues(config)])
-        .with_github_api_base(0, server.uri());
+        .with_github_api_base(0, server.uri())
+        .with_credentials([("GITHUB_TOKEN_TEST_BUG", "test-token")]);
 
     let signal = resolver
         .resolve("fix: closes #42")
@@ -215,6 +210,4 @@ async fn resolver_returns_github_signal_for_bug_label() {
         .expect("should have signal");
     assert_eq!(signal.category, "bug_fix");
     assert!(signal.source.contains("bug"));
-
-    unsafe { std::env::remove_var("GITHUB_TOKEN_TEST_BUG") };
 }

--- a/crates/trusty-git-analytics/src/classify/sources/shortcut.rs
+++ b/crates/trusty-git-analytics/src/classify/sources/shortcut.rs
@@ -20,6 +20,7 @@ use serde::{Deserialize, Serialize};
 use tracing::warn;
 
 use super::{ExternalSignal, ShortcutSourceConfig, EXTERNAL_SOURCE_CONFIDENCE};
+use crate::core::creds::CredentialSource;
 
 /// Regex matching the `[ch1234]` bracket reference form.
 ///
@@ -170,9 +171,33 @@ pub async fn fetch_story(
     id: u64,
     base_url_override: Option<&str>,
 ) -> Option<ShortcutStory> {
-    let token = match std::env::var(&config.api_token_env) {
-        Ok(t) if !t.is_empty() => t,
-        _ => {
+    fetch_story_with_creds(
+        client,
+        config,
+        id,
+        base_url_override,
+        &CredentialSource::from_env(),
+    )
+    .await
+}
+
+/// [`fetch_story`], with the credential lookup supplied by the caller.
+///
+/// Why (#6405): proving the authenticated path used to require `set_var` on
+/// the API-token variable, racing every other thread's `getenv`.
+/// What: identical to [`fetch_story`] except that `creds` replaces the
+/// `std::env::var` read for `api_token_env`.
+/// Test: `tests::fetch_and_classify_via_wiremock`.
+pub(crate) async fn fetch_story_with_creds(
+    client: &reqwest::Client,
+    config: &ShortcutSourceConfig,
+    id: u64,
+    base_url_override: Option<&str>,
+    creds: &CredentialSource,
+) -> Option<ShortcutStory> {
+    let token = match creds.get(&config.api_token_env) {
+        Some(t) => t,
+        None => {
             warn!(
                 api_token_env = %config.api_token_env,
                 "Shortcut API token env var `{}` is not set — did you `export {}` before running tga?",
@@ -229,13 +254,32 @@ pub async fn fetch_stories_batch(
     ids: &[u64],
     base_url_override: Option<&str>,
 ) -> HashMap<String, Option<ExternalSignal>> {
+    fetch_stories_batch_with_creds(
+        client,
+        config,
+        ids,
+        base_url_override,
+        &CredentialSource::from_env(),
+    )
+    .await
+}
+
+/// [`fetch_stories_batch`], with the credential lookup supplied by the caller
+/// (#6405).
+pub(crate) async fn fetch_stories_batch_with_creds(
+    client: &reqwest::Client,
+    config: &ShortcutSourceConfig,
+    ids: &[u64],
+    base_url_override: Option<&str>,
+    creds: &CredentialSource,
+) -> HashMap<String, Option<ExternalSignal>> {
     let mut out = HashMap::new();
     for &id in ids {
         let key = id.to_string();
         if out.contains_key(&key) {
             continue;
         }
-        let story = fetch_story(client, config, id, base_url_override).await;
+        let story = fetch_story_with_creds(client, config, id, base_url_override, creds).await;
         let signal = story.and_then(|s| classify_story(&s, config));
         out.insert(key, signal);
     }
@@ -468,7 +512,9 @@ field_mappings:
             .mount(&server)
             .await;
 
-        unsafe { std::env::set_var("SHORTCUT_TOKEN_WT", "test-token") }; // pragma: allowlist secret
+        // #6405: the credential is a parameter, so this test proves the
+        // authenticated path without mutating the process environment.
+        let creds = CredentialSource::fixed([("SHORTCUT_TOKEN_WT", "test-token")]); // pragma: allowlist secret
 
         use std::collections::HashMap;
         let config = ShortcutSourceConfig {
@@ -486,14 +532,36 @@ field_mappings:
         };
 
         let client = reqwest::Client::new();
-        let story = fetch_story(&client, &config, 55, Some(&server.uri()))
+        let story = fetch_story_with_creds(&client, &config, 55, Some(&server.uri()), &creds)
             .await
             .expect("fetch should succeed");
 
         let signal = classify_story(&story, &config).expect("should classify");
         assert_eq!(signal.category, "bug_fix");
         assert!(signal.source.contains("story_type"));
+    }
 
-        unsafe { std::env::remove_var("SHORTCUT_TOKEN_WT") };
+    /// Why: an unset API token must skip the lookup rather than issue an
+    /// unauthenticated request — the branch that used to be provable only by
+    /// clearing the variable process-wide (#6405).
+    /// What: fetch with an empty credential source and assert `None`, with no
+    /// HTTP server standing at all.
+    /// Test: this test itself.
+    #[tokio::test]
+    async fn fetch_story_returns_none_when_token_unset() {
+        use std::collections::HashMap;
+        let config = ShortcutSourceConfig {
+            api_token_env: "SHORTCUT_TOKEN_UNSET".to_string(), // pragma: allowlist secret
+            workspace_id: "myco".to_string(),
+            field_mappings: crate::classify::sources::ShortcutFieldMappings {
+                story_type: HashMap::new(),
+                labels: HashMap::new(),
+                workflow_state: HashMap::new(),
+            },
+        };
+        let client = reqwest::Client::new();
+        let story =
+            fetch_story_with_creds(&client, &config, 55, None, &CredentialSource::empty()).await;
+        assert!(story.is_none(), "unset token must skip the lookup");
     }
 }

--- a/crates/trusty-git-analytics/src/classify/tests.rs
+++ b/crates/trusty-git-analytics/src/classify/tests.rs
@@ -836,50 +836,23 @@ async fn llm_classify_only_returns_none_when_disabled() {
     assert_eq!(engine.llm_has_api_key(), None);
 }
 
-/// Panic-safe env-var save/restore (mirrors the pattern in
-/// `core::config::validator::tests::EnvVarGuard`). Without this, a
-/// failing assertion between `remove_var` and the restore would leak
-/// the cleared state to other parallel tests in the same binary.
-struct EnvVarGuard {
-    name: &'static str,
-    original: Option<String>,
-}
-
-impl EnvVarGuard {
-    fn remove(name: &'static str) -> Self {
-        let original = std::env::var(name).ok();
-        // SAFETY: 2024-edition env mutation; cleanup guaranteed by Drop.
-        unsafe { std::env::remove_var(name) };
-        Self { name, original }
-    }
-}
-
-impl Drop for EnvVarGuard {
-    fn drop(&mut self) {
-        // SAFETY: see `EnvVarGuard::remove`.
-        unsafe {
-            match self.original.as_deref() {
-                Some(v) => std::env::set_var(self.name, v),
-                None => std::env::remove_var(self.name),
-            }
-        }
-    }
-}
-
 #[tokio::test]
 async fn llm_has_api_key_signals_misconfiguration() {
-    // Issue #99 follow-up: when use_llm is on but no env key is set,
-    // the engine should expose `Some(false)` so the pipeline can warn
-    // at startup instead of silently producing no LLM verdicts.
-    let _guard = EnvVarGuard::remove("OPENAI_API_KEY");
-
-    let engine = ClassificationEngine::new(
+    // Issue #99 follow-up: when use_llm is on but no key resolves, the engine
+    // should expose `Some(false)` so the pipeline can warn at startup instead
+    // of silently producing no LLM verdicts.
+    //
+    // #6405: an empty credential table is what makes "no key resolves" true
+    // here. The `EnvVarGuard` this test used to carry cleared
+    // `OPENAI_API_KEY` process-wide, racing every other thread's `getenv`.
+    let engine = ClassificationEngine::new_with_creds(
         rules::default_rules(),
         ClassificationEngineConfig {
             use_llm: true,
             llm_provider: "openai".to_string(),
             ..Default::default()
         },
+        &crate::core::creds::CredentialSource::empty(),
     )
     .expect("engine");
     assert_eq!(engine.llm_has_api_key(), Some(false));

--- a/crates/trusty-git-analytics/src/classify/tiers/llm.rs
+++ b/crates/trusty-git-analytics/src/classify/tiers/llm.rs
@@ -24,6 +24,7 @@ use tracing::{debug, info, warn};
 use crate::classify::tiers::bedrock::BedrockClassifier;
 use crate::classify::tiers::ClassificationResult;
 use crate::core::config::{LlmConfig, LlmSource};
+use crate::core::creds::CredentialSource;
 use crate::core::models::ClassificationMethod;
 
 /// OpenAI-compatible chat completion endpoint.
@@ -180,10 +181,37 @@ impl LlmClassifier {
         model: &str,
         openrouter_api_key: Option<String>,
     ) -> Result<Self, String> {
+        Self::from_provider_with_creds(
+            provider,
+            model,
+            openrouter_api_key,
+            &CredentialSource::from_env(),
+        )
+    }
+
+    /// [`Self::from_provider`], with the credential lookup supplied by the
+    /// caller.
+    ///
+    /// Why (#6405): proving the "provider is configured but no key resolves"
+    /// arm used to require clearing `OPENAI_API_KEY` process-wide, racing every
+    /// other thread's `getenv`.
+    /// What: identical to [`Self::from_provider`] except that `creds` replaces
+    /// the `std::env::var` reads.
+    /// Test: `classify::tests::llm_has_api_key_signals_misconfiguration`.
+    ///
+    /// # Errors
+    ///
+    /// As [`Self::from_provider`].
+    pub(crate) fn from_provider_with_creds(
+        provider: &str,
+        model: &str,
+        openrouter_api_key: Option<String>,
+        creds: &CredentialSource,
+    ) -> Result<Self, String> {
         let normalized = provider.trim().to_ascii_lowercase();
         match normalized.as_str() {
-            "openrouter" => Ok(Self::build_openrouter(model, openrouter_api_key)),
-            "openai" => Ok(Self::new(model, std::env::var("OPENAI_API_KEY").ok())),
+            "openrouter" => Ok(Self::build_openrouter(model, openrouter_api_key, creds)),
+            "openai" => Ok(Self::new(model, creds.get("OPENAI_API_KEY"))),
             "bedrock" => {
                 // Bedrock requires async SDK initialization. Direct sync
                 // callers get a clear error so they know to use
@@ -206,15 +234,14 @@ impl LlmClassifier {
                 }
             }
             "auto" | "" => {
-                let or_key = openrouter_api_key.or_else(|| {
-                    std::env::var(trusty_common::env_vars::ENV_OPENROUTER_API_KEY).ok()
-                });
+                let or_key = openrouter_api_key
+                    .or_else(|| creds.get(trusty_common::env_vars::ENV_OPENROUTER_API_KEY));
                 if or_key.is_some() {
                     info!("LLM provider auto-selected: openrouter");
-                    Ok(Self::build_openrouter(model, or_key))
+                    Ok(Self::build_openrouter(model, or_key, creds))
                 } else {
                     info!("LLM provider auto-selected: openai");
-                    Ok(Self::new(model, std::env::var("OPENAI_API_KEY").ok()))
+                    Ok(Self::new(model, creds.get("OPENAI_API_KEY")))
                 }
             }
             other => {
@@ -222,7 +249,7 @@ impl LlmClassifier {
                     provider = %other,
                     "unknown LLM provider; falling back to OpenAI endpoint"
                 );
-                Ok(Self::new(model, std::env::var("OPENAI_API_KEY").ok()))
+                Ok(Self::new(model, creds.get("OPENAI_API_KEY")))
             }
         }
     }
@@ -282,12 +309,33 @@ impl LlmClassifier {
     /// - Key-based source with unset / empty env var → error naming the
     ///   missing variable and how to set it.
     pub async fn from_llm_config(cfg: &LlmConfig, model: &str) -> Result<Self, String> {
+        Self::from_llm_config_with_creds(cfg, model, &CredentialSource::from_env()).await
+    }
+
+    /// [`Self::from_llm_config`], with the credential lookup supplied by the
+    /// caller.
+    ///
+    /// Why (#6405): proving that the key comes from the variable named by
+    /// `api_key_env` used to require `set_var` on that variable, racing every
+    /// other thread's `getenv`.
+    /// What: identical to [`Self::from_llm_config`] except that `creds`
+    /// replaces the `std::env::var` read.
+    /// Test: `llm_tests::from_llm_config_anthropic_api_reads_api_key_env`,
+    /// `llm_tests::from_llm_config_anthropic_api_missing_key_errors`,
+    /// `llm_tests::anthropic_default_model_used_when_none_configured`.
+    ///
+    /// # Errors
+    ///
+    /// As [`Self::from_llm_config`].
+    pub(crate) async fn from_llm_config_with_creds(
+        cfg: &LlmConfig,
+        model: &str,
+        creds: &CredentialSource,
+    ) -> Result<Self, String> {
         match &cfg.source {
             LlmSource::Openrouter => {
-                // Read key from the named env var; fail loudly if unset.
-                let key = std::env::var(&cfg.api_key_env)
-                    .ok()
-                    .filter(|k| !k.is_empty());
+                // Read key from the named variable; fail loudly if unset.
+                let key = creds.get(&cfg.api_key_env);
                 if key.is_none() {
                     return Err(format!(
                         "LLM source 'openrouter' requires an API key but the environment \
@@ -301,7 +349,7 @@ impl LlmClassifier {
                     api_key_env = %cfg.api_key_env,
                     "LLM provider: openrouter (from llm: config section)"
                 );
-                Ok(Self::build_openrouter(model, key))
+                Ok(Self::build_openrouter(model, key, creds))
             }
             LlmSource::Bedrock => {
                 info!(
@@ -321,10 +369,8 @@ impl LlmClassifier {
                 })
             }
             LlmSource::AnthropicApi => {
-                // Read key from the named env var; fail loudly if unset.
-                let key = std::env::var(&cfg.api_key_env)
-                    .ok()
-                    .filter(|k| !k.is_empty());
+                // Read key from the named variable; fail loudly if unset.
+                let key = creds.get(&cfg.api_key_env);
                 if key.is_none() {
                     return Err(format!(
                         "LLM source 'anthropic-api' requires an API key but the environment \
@@ -356,9 +402,10 @@ impl LlmClassifier {
 
     /// Internal helper: build an OpenRouter-configured classifier with
     /// attribution headers set.
-    fn build_openrouter(model: &str, api_key: Option<String>) -> Self {
-        let key =
-            api_key.or_else(|| std::env::var(trusty_common::env_vars::ENV_OPENROUTER_API_KEY).ok());
+    fn build_openrouter(model: &str, api_key: Option<String>, creds: &CredentialSource) -> Self {
+        // #6405: the fallback lookup is a parameter, so a test never has to set
+        // or clear `OPENROUTER_API_KEY` process-wide to reach either arm.
+        let key = api_key.or_else(|| creds.get(trusty_common::env_vars::ENV_OPENROUTER_API_KEY));
         let mut headers = HeaderMap::new();
         // These are static, valid ASCII strings — `from_static` cannot panic
         // on them at runtime.

--- a/crates/trusty-git-analytics/src/classify/tiers/llm_tests.rs
+++ b/crates/trusty-git-analytics/src/classify/tiers/llm_tests.rs
@@ -3,6 +3,7 @@ use crate::classify::tiers::llm::{
     SYSTEM_PROMPT,
 };
 use crate::core::config::LlmSource;
+use crate::core::creds::CredentialSource;
 use crate::core::models::ClassificationMethod;
 use wiremock::matchers::{header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -126,17 +127,18 @@ async fn anthropic_api_request_sets_correct_headers() {
     assert_eq!(r.category, "chore");
 }
 
-/// Why: `from_llm_config` must resolve the API key from the env var
+/// Why: `from_llm_config` must resolve the API key from the variable
 /// named by `api_key_env` for the `anthropic-api` source, not from
 /// a hardcoded var like `ANTHROPIC_API_KEY`.
-/// What: set a custom env var, build from a config with that var name,
-/// and assert the classifier has a key.
-/// Test: env-var manipulation + constructor check.
+/// What: build from a config naming a custom variable, with a credential
+/// source that answers only that name, and assert the classifier has a key.
+/// Test: this test itself.
 #[tokio::test]
 async fn from_llm_config_anthropic_api_reads_api_key_env() {
-    // Use a unique var name to avoid polluting parallel tests.
     let var_name = "TGA_TEST_ANTHROPIC_KEY_9f2e";
-    std::env::set_var(var_name, "sk-ant-from-env"); // pragma: allowlist secret
+    // #6405: the lookup is a parameter, so proving "the named variable is the
+    // one consulted" no longer means setting it process-wide.
+    let creds = CredentialSource::fixed([(var_name, "sk-ant-from-env")]); // pragma: allowlist secret
 
     let cfg = crate::core::config::LlmConfig {
         source: LlmSource::AnthropicApi,
@@ -144,23 +146,22 @@ async fn from_llm_config_anthropic_api_reads_api_key_env() {
         region: None,
         model: Some("claude-3-5-haiku-latest".to_string()),
     };
-    let result = LlmClassifier::from_llm_config(&cfg, "claude-3-5-haiku-latest").await;
-    std::env::remove_var(var_name);
+    let result =
+        LlmClassifier::from_llm_config_with_creds(&cfg, "claude-3-5-haiku-latest", &creds).await;
 
-    let llm = result.expect("should build from env var");
+    let llm = result.expect("should build from the named variable");
     assert!(llm.has_api_key());
     assert!(llm.use_anthropic_format);
 }
 
-/// Why: when the named env var is absent, from_llm_config must return
+/// Why: when the named variable is absent, from_llm_config must return
 /// an error naming the variable — no silent no-op allowed.
-/// What: call from_llm_config with an env var that does not exist and
-/// assert Err mentions the var name.
+/// What: call from_llm_config with an empty credential source and assert Err
+/// mentions the var name.
 /// Test: pure error-path check, no network.
 #[tokio::test]
 async fn from_llm_config_anthropic_api_missing_key_errors() {
     let var_name = "TGA_TEST_ANTHROPIC_MISSING_KEY_7c4b";
-    std::env::remove_var(var_name); // ensure absent
 
     let cfg = crate::core::config::LlmConfig {
         source: LlmSource::AnthropicApi,
@@ -168,7 +169,11 @@ async fn from_llm_config_anthropic_api_missing_key_errors() {
         region: None,
         model: None,
     };
-    let result = LlmClassifier::from_llm_config(&cfg, "gpt-4o-mini").await;
+    // #6405: an empty credential table is how "absent" is stated now — no
+    // `remove_var` racing the rest of the suite.
+    let result =
+        LlmClassifier::from_llm_config_with_creds(&cfg, "gpt-4o-mini", &CredentialSource::empty())
+            .await;
     assert!(result.is_err(), "missing env var must produce Err");
     let err = result.err().expect("just asserted is_err");
     assert!(
@@ -183,11 +188,12 @@ async fn from_llm_config_anthropic_api_missing_key_errors() {
 /// receives a valid model ID.
 /// What: call from_llm_config with `model: None` and `source: anthropic-api`
 /// and assert the classifier's model field equals ANTHROPIC_DEFAULT_MODEL.
-/// Test: env-var + constructor inspection.
+/// Test: constructor inspection.
 #[tokio::test]
 async fn anthropic_default_model_used_when_none_configured() {
     let var_name = "TGA_TEST_ANTHROPIC_DEFAULT_MODEL_3a8d";
-    std::env::set_var(var_name, "sk-ant-test-model"); // pragma: allowlist secret
+    // #6405: credential as a parameter, never a process-wide `set_var`.
+    let creds = CredentialSource::fixed([(var_name, "sk-ant-test-model")]); // pragma: allowlist secret
 
     let cfg = crate::core::config::LlmConfig {
         source: LlmSource::AnthropicApi,
@@ -196,10 +202,9 @@ async fn anthropic_default_model_used_when_none_configured() {
         model: None, // user did not set a model
     };
     // The pipeline passes "gpt-4o-mini" as the fallback when model is None.
-    let result = LlmClassifier::from_llm_config(&cfg, "gpt-4o-mini").await;
-    std::env::remove_var(var_name);
+    let result = LlmClassifier::from_llm_config_with_creds(&cfg, "gpt-4o-mini", &creds).await;
 
-    let llm = result.expect("build from env");
+    let llm = result.expect("build from the named variable");
     assert_eq!(
         llm.model, ANTHROPIC_DEFAULT_MODEL,
         "must substitute ANTHROPIC_DEFAULT_MODEL, not gpt-4o-mini"

--- a/crates/trusty-git-analytics/src/collect/ai_marker_config.rs
+++ b/crates/trusty-git-analytics/src/collect/ai_marker_config.rs
@@ -277,11 +277,25 @@ impl MarkerConfig {
 /// resolved, never required — an absent file is the normal case.
 /// Test: `tests::env_var_overrides_default_path`.
 pub fn marker_file_path() -> PathBuf {
-    let raw = match std::env::var(ENV_AI_MARKERS) {
-        Ok(v) if !v.trim().is_empty() => v,
-        _ => DEFAULT_MARKER_FILE.to_string(),
+    // #6405: read the process env here so the rule below stays pure.
+    marker_file_path_from(std::env::var(ENV_AI_MARKERS).ok().as_deref())
+}
+
+/// [`marker_file_path`], with the [`ENV_AI_MARKERS`] value supplied by the
+/// caller.
+///
+/// Why (#6405): proving the override and the blank-is-unset rule used to
+/// require `set_var`, which races every other thread's `getenv`. A
+/// caller-supplied value makes both provable with no global state.
+/// What: `raw` when present and not whitespace-only, else
+/// [`DEFAULT_MARKER_FILE`]; either way a leading `~` is expanded.
+/// Test: `tests::env_var_overrides_default_path`.
+pub(crate) fn marker_file_path_from(raw: Option<&str>) -> PathBuf {
+    let raw = match raw {
+        Some(v) if !v.trim().is_empty() => v,
+        _ => DEFAULT_MARKER_FILE,
     };
-    expand_path(Path::new(&raw))
+    expand_path(Path::new(raw))
 }
 
 #[cfg(test)]
@@ -411,37 +425,19 @@ mod tests {
     /// Why: the env var is the "without a code change" half of #5414; if it
     /// were ignored, only the fixed default path would be configurable.
     ///
-    /// Serialised against the other env-touching test in this module by a
-    /// module-local mutex, since env vars are process-global.
+    /// #6405: the value is a parameter now, so the module-local `env_lock` and
+    /// the `set_var` / restore dance it guarded are both gone.
     #[test]
     fn env_var_overrides_default_path() {
-        let _guard = env_lock();
-        let prev = std::env::var(ENV_AI_MARKERS).ok();
-
-        std::env::set_var(ENV_AI_MARKERS, "/tmp/tga-markers-5414.yaml");
         assert_eq!(
-            marker_file_path(),
+            marker_file_path_from(Some("/tmp/tga-markers-5414.yaml")),
             PathBuf::from("/tmp/tga-markers-5414.yaml")
         );
 
         // Blank is treated as unset, so an exported-but-empty var does not
         // point detection at "".
-        std::env::set_var(ENV_AI_MARKERS, "   ");
-        assert!(marker_file_path().ends_with(".config/tga/ai-markers.yaml"));
+        assert!(marker_file_path_from(Some("   ")).ends_with(".config/tga/ai-markers.yaml"));
 
-        std::env::remove_var(ENV_AI_MARKERS);
-        assert!(marker_file_path().ends_with(".config/tga/ai-markers.yaml"));
-
-        match prev {
-            Some(v) => std::env::set_var(ENV_AI_MARKERS, v),
-            None => std::env::remove_var(ENV_AI_MARKERS),
-        }
-    }
-
-    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
-        static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
-        LOCK.get_or_init(|| std::sync::Mutex::new(()))
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
+        assert!(marker_file_path_from(None).ends_with(".config/tga/ai-markers.yaml"));
     }
 }

--- a/crates/trusty-git-analytics/src/core/creds.rs
+++ b/crates/trusty-git-analytics/src/core/creds.rs
@@ -1,0 +1,141 @@
+//! Credential lookup as a parameter instead of a process-global read.
+//!
+//! Why (#6405): every source client used to read its token straight from
+//! `std::env::var`, so the only way to prove a token-dependent path was to
+//! `set_var` it. `setenv` can reallocate the environment array while another
+//! thread is inside `getenv`, and `cargo test -p tga` runs dozens of threads
+//! that call `getenv` through reqwest, rustls and tracing — the family behind
+//! the #2613 SIGSEGV. Passing the lookup in removes the mutation entirely.
+//!
+//! What: [`CredentialSource`] wraps a name → value function.
+//! [`CredentialSource::from_env`] is the production one; the test constructors
+//! answer from a fixed table.
+//!
+//! Test: `crate::core::creds::tests` here, plus every caller listed on
+//! [`CredentialSource::get`].
+
+use std::sync::Arc;
+
+/// The lookup a [`CredentialSource`] wraps: variable name → value.
+type Lookup = Arc<dyn Fn(&str) -> Option<String> + Send + Sync>;
+
+/// Resolves a credential environment-variable NAME to its value.
+///
+/// Why: see the module doc — this is the seam that lets a test prove a
+/// token-dependent branch without mutating the process environment.
+/// What: a cloneable, thread-safe wrapper around a `&str -> Option<String>`
+/// lookup, with the "an empty value means unset" rule applied once here rather
+/// than re-spelled at each of the eight call sites that used to own it.
+/// Test: `credential_source_*` in this module.
+#[derive(Clone)]
+pub(crate) struct CredentialSource {
+    lookup: Lookup,
+}
+
+impl CredentialSource {
+    /// The production lookup: the process environment.
+    pub(crate) fn from_env() -> Self {
+        Self {
+            lookup: Arc::new(|name| std::env::var(name).ok()),
+        }
+    }
+
+    /// A lookup that answers from a fixed `(name, value)` table and nothing
+    /// else.
+    ///
+    /// Why: replaces the `set_var` / `remove_var` pair that used to bracket
+    /// every credential-dependent test (#6405).
+    /// What: unlisted names resolve to `None`, so a test also proves the
+    /// "variable is unset" branch by simply not listing it.
+    /// Test: `credential_source_answers_only_listed_names`.
+    #[cfg(test)]
+    pub(crate) fn fixed<K, V, I>(pairs: I) -> Self
+    where
+        K: Into<String>,
+        V: Into<String>,
+        I: IntoIterator<Item = (K, V)>,
+    {
+        let table: std::collections::HashMap<String, String> = pairs
+            .into_iter()
+            .map(|(k, v)| (k.into(), v.into()))
+            .collect();
+        Self {
+            lookup: Arc::new(move |name| table.get(name).cloned()),
+        }
+    }
+
+    /// A lookup where every variable is unset.
+    #[cfg(test)]
+    pub(crate) fn empty() -> Self {
+        Self::fixed(Vec::<(String, String)>::new())
+    }
+
+    /// Resolve `name`, treating an empty value as unset.
+    ///
+    /// Why: an exported-but-empty credential var is a shell accident, never an
+    /// intentional empty key — every caller already applied this rule, and
+    /// applying it once here keeps them from drifting apart.
+    /// What: returns the lookup's value for `name` unless it is the empty
+    /// string.
+    /// Test: `credential_source_treats_empty_as_unset`.
+    pub(crate) fn get(&self, name: &str) -> Option<String> {
+        (self.lookup)(name).filter(|v| !v.is_empty())
+    }
+}
+
+impl Default for CredentialSource {
+    fn default() -> Self {
+        Self::from_env()
+    }
+}
+
+impl std::fmt::Debug for CredentialSource {
+    /// Never renders a value — a `Debug` of a credential source must not be a
+    /// way to leak one into a log.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("CredentialSource(..)")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn credential_source_answers_only_listed_names() {
+        let creds = CredentialSource::fixed([("TOKEN_A", "value-a")]);
+        assert_eq!(creds.get("TOKEN_A").as_deref(), Some("value-a"));
+        assert_eq!(creds.get("TOKEN_B"), None);
+    }
+
+    #[test]
+    fn credential_source_treats_empty_as_unset() {
+        let creds = CredentialSource::fixed([("TOKEN_A", "")]);
+        assert_eq!(
+            creds.get("TOKEN_A"),
+            None,
+            "an exported-but-empty value must read as unset"
+        );
+    }
+
+    #[test]
+    fn credential_source_empty_answers_nothing() {
+        assert_eq!(CredentialSource::empty().get("ANYTHING"), None);
+    }
+
+    #[test]
+    fn credential_source_from_env_reads_the_process_environment() {
+        // PATH is set in every environment this suite runs in, and this test
+        // only READS it — no mutation, which is the whole point of #6405.
+        let creds = CredentialSource::from_env();
+        assert_eq!(creds.get("PATH"), std::env::var("PATH").ok());
+    }
+
+    #[test]
+    fn credential_source_debug_hides_the_lookup() {
+        assert_eq!(
+            format!("{:?}", CredentialSource::fixed([("T", "secret")])),
+            "CredentialSource(..)"
+        );
+    }
+}

--- a/crates/trusty-git-analytics/src/core/mod.rs
+++ b/crates/trusty-git-analytics/src/core/mod.rs
@@ -6,6 +6,8 @@
 //! ## Submodules
 //!
 //! - [`config`] — YAML configuration loading and types
+//! - `creds` — credential lookup passed as a parameter instead of read from
+//!   the process environment (#6405)
 //! - [`db`] — SQLite database wrapper with WAL mode and versioned migrations
 //! - [`errors`] — crate-wide error enum and `Result` alias
 //! - [`models`] — domain structs for commits, authors, classifications, etc.
@@ -14,6 +16,7 @@
 //! - [`revert`] — shared commit-message revert detection
 
 pub mod config;
+pub(crate) mod creds;
 pub mod db;
 pub mod effort;
 pub mod effort_percentile;

--- a/crates/trusty-git-analytics/src/profile/batch_reviewer_tests.rs
+++ b/crates/trusty-git-analytics/src/profile/batch_reviewer_tests.rs
@@ -437,6 +437,11 @@ fn from_slug_with_store_builds_an_adapter_for_a_stored_credential() {
 #[test]
 #[serial]
 fn from_slug_with_store_errors_when_no_credential_resolves() {
+    // #6405: the LAST unsynchronized-env-mutation site in this crate. The env
+    // tier lives in `trusty_common::credentials::resolver::env_tier`, which
+    // takes no lookup parameter, so the seam cannot move from tga — every
+    // other site in the crate is parameterized instead. `#[serial]` is the
+    // fallback the issue allows here.
     let saved = std::env::var("OPENROUTER_API_KEY").ok();
     // SAFETY: `#[serial]` keeps every env-mutating test in this crate off other
     // threads for the duration, which is what `remove_var` requires.

--- a/crates/trusty-git-analytics/src/profile/selector.rs
+++ b/crates/trusty-git-analytics/src/profile/selector.rs
@@ -261,10 +261,32 @@ pub fn resolve_contributor(db_path: &Path, query: &str) -> Result<ResolvedIdenti
 /// Test: `resolve_db_path_uses_env_var`, `resolve_db_path_explicit_beats_env`,
 /// `resolve_db_path_blank_env_falls_through`.
 pub fn resolve_db_path(explicit_path: Option<&Path>) -> Result<PathBuf> {
+    // #6405: read the process env here so the precedence rule below stays pure.
+    resolve_db_path_from(explicit_path, std::env::var(ENV_TGA_DB).ok().as_deref())
+}
+
+/// [`resolve_db_path`], with the [`ENV_TGA_DB`] value supplied by the caller.
+///
+/// Why (#6405): proving the precedence used to require `set_var`, which races
+/// every other thread's `getenv`; the three `#[serial]` tests that guarded it
+/// serialized only against each other, never against a concurrent reader.
+/// What: same precedence as [`resolve_db_path`], with `env_value` standing in
+/// for the variable.
+///
+/// # Errors
+///
+/// As [`resolve_db_path`].
+///
+/// Test: `resolve_db_path_uses_env_var`, `resolve_db_path_explicit_beats_env`,
+/// `resolve_db_path_blank_env_falls_through`.
+pub(crate) fn resolve_db_path_from(
+    explicit_path: Option<&Path>,
+    env_value: Option<&str>,
+) -> Result<PathBuf> {
     if let Some(p) = explicit_path {
         return Ok(expand_path(p));
     }
-    if let Ok(val) = std::env::var(ENV_TGA_DB) {
+    if let Some(val) = env_value {
         let trimmed = val.trim();
         if !trimmed.is_empty() {
             return Ok(expand_path(Path::new(trimmed)));
@@ -282,7 +304,6 @@ pub fn resolve_db_path(explicit_path: Option<&Path>) -> Result<PathBuf> {
 mod tests {
     use super::*;
     use rusqlite::params;
-    use serial_test::serial;
 
     fn seed_author(db: &Database, name: &str, email: &str, aliases_json: &str) {
         db.connection()
@@ -363,58 +384,36 @@ mod tests {
     }
 
     /// Why: `resolve_db_path` must honour `TGA_DB` when no explicit path is given.
-    /// What: sets the variable, calls with `None`, asserts the path matches.
-    /// Test: this test itself. `#[serial]` because it mutates the environment.
+    /// What: passes the variable's value, calls with no explicit path, asserts
+    /// the path matches.
+    /// Test: this test itself. #6405: the value is a parameter, so the
+    /// `#[serial]` and the `set_var` it guarded are both gone.
     #[test]
-    #[serial]
     fn resolve_db_path_uses_env_var() {
         let expected = "/tmp/test-tga.db";
-        // SAFETY: `#[serial]` keeps every env-mutating test in this crate off
-        // other threads for the duration, which is what `set_var` requires.
-        unsafe {
-            std::env::set_var(ENV_TGA_DB, expected);
-        }
-        let path = resolve_db_path(None).expect("resolve path");
-        unsafe {
-            std::env::remove_var(ENV_TGA_DB);
-        }
+        let path = resolve_db_path_from(None, Some(expected)).expect("resolve path");
         assert_eq!(path, PathBuf::from(expected));
     }
 
     /// Why: an explicit path must beat the environment, or a `--db` flag would
     /// be silently ignored in a shell that exports `TGA_DB`.
-    /// What: sets the variable, passes an explicit path, asserts explicit wins.
-    /// Test: this test itself. `#[serial]` because it mutates the environment.
+    /// What: supplies both, asserts explicit wins.
+    /// Test: this test itself.
     #[test]
-    #[serial]
     fn resolve_db_path_explicit_beats_env() {
-        // SAFETY: see `resolve_db_path_uses_env_var`.
-        unsafe {
-            std::env::set_var(ENV_TGA_DB, "/tmp/env-tga.db");
-        }
         let explicit = Path::new("/tmp/explicit-tga.db");
-        let path = resolve_db_path(Some(explicit)).expect("resolve path");
-        unsafe {
-            std::env::remove_var(ENV_TGA_DB);
-        }
+        let path =
+            resolve_db_path_from(Some(explicit), Some("/tmp/env-tga.db")).expect("resolve path");
         assert_eq!(path, explicit.to_path_buf());
     }
 
     /// Why: an exported-but-empty `TGA_DB` is a common shell accident and must
     /// fall through to the convention default rather than resolving to `""`.
-    /// What: sets the variable to whitespace, asserts the result is not empty.
-    /// Test: this test itself. `#[serial]` because it mutates the environment.
+    /// What: supplies a whitespace-only value, asserts the convention default.
+    /// Test: this test itself.
     #[test]
-    #[serial]
     fn resolve_db_path_blank_env_falls_through() {
-        // SAFETY: see `resolve_db_path_uses_env_var`.
-        unsafe {
-            std::env::set_var(ENV_TGA_DB, "   ");
-        }
-        let path = resolve_db_path(None).expect("resolve path");
-        unsafe {
-            std::env::remove_var(ENV_TGA_DB);
-        }
+        let path = resolve_db_path_from(None, Some("   ")).expect("resolve path");
         assert!(
             path.ends_with("tga/tga.db"),
             "blank env must fall through to the convention default, got {}",

--- a/crates/trusty-git-analytics/tests/agentic_detection_corpus_configured.rs
+++ b/crates/trusty-git-analytics/tests/agentic_detection_corpus_configured.rs
@@ -68,6 +68,9 @@ fn a_configured_marker_raises_the_catch_rate() {
          \x20   pattern: '(?i)Bob\\s+Matsuoka'\n",
     )
     .expect("writes the marker file");
+    // #6405: this file is a one-test binary on purpose — the process has no
+    // other thread reading the environment, so this set_var races nothing.
+    // The lazily-cached marker load is what needs its own process.
     std::env::set_var("TGA_AI_MARKERS", &path);
 
     let Some(commits) = history() else {

--- a/crates/trusty-git-analytics/tests/ai_markers_bad_file.rs
+++ b/crates/trusty-git-analytics/tests/ai_markers_bad_file.rs
@@ -26,6 +26,9 @@ fn a_rejected_marker_file_does_not_break_detection() {
     )
     .expect("writes the marker file");
 
+    // #6405: this file is a one-test binary on purpose — the process has no
+    // other thread reading the environment, so this set_var races nothing.
+    // The lazily-cached marker load is what needs its own process.
     std::env::set_var("TGA_AI_MARKERS", &path);
 
     // The shipped markers are unaffected.

--- a/crates/trusty-git-analytics/tests/ai_markers_operator_file.rs
+++ b/crates/trusty-git-analytics/tests/ai_markers_operator_file.rs
@@ -36,6 +36,9 @@ fn a_house_footer_added_at_runtime_is_detected() {
     )
     .expect("writes the marker file");
 
+    // #6405: this file is a one-test binary on purpose — the process has no
+    // other thread reading the environment, so this set_var races nothing.
+    // The lazily-cached marker load is what needs its own process.
     std::env::set_var("TGA_AI_MARKERS", &path);
 
     // Nothing in BUILTIN knows this footer; before #5414 nothing could.


### PR DESCRIPTION
Refs #6405.

Closes the unsynchronized env-mutation family in tga: 42 `set_var`/`remove_var`
sites across ten files, racing 50+ reader threads plus reqwest and rustls under
`cargo test -p tga`. Two sites remain, both in the same `#[serial]` test.

Remedy is #5313's stated preference — take the override as a parameter. Every
source fetch helper gains a `_with_creds` variant carrying a
`core::creds::CredentialSource`; `ExternalSourceResolver` holds one and threads
it through `resolve` and `warm_cache`, injectable in tests via
`with_credentials`. Existing `pub fn` signatures are unchanged and delegate with
the environment-backed lookup, so no caller changes and the public API does not
break — hence the PATCH bump to 5.0.1.

`marker_file_path` and `resolve_db_path` take their variable's value directly,
retiring a module-local mutex and three `#[serial]` attributes.

The one remaining site exercises the env tier in
`trusty_common::credentials::resolver::env_tier`, which takes no lookup
parameter. Moving that seam is a cross-crate change, out of scope here; it keeps
`#[serial]` with the reason recorded at the call site.

Closure check:

```
git grep -n 'set_var\|remove_var' crates/trusty-git-analytics/src
```

returns only doc/comment references plus the two lines in
`profile/batch_reviewer_tests.rs`.

## Gates — rung 3

```
cargo fmt --check                                      EXIT=0
cargo clippy -p tga --all-targets -- -D warnings       EXIT=0
cargo test -p tga --no-fail-fast                       EXIT=0
  test result: ok. 1386 passed; 0 failed; 7 ignored    (lib)
  + 10 further targets, 24 passed; 0 failed
bash scripts/check-pr-version-bump.sh                  EXIT=0  (tga 5.0.0 -> 5.0.1)
bash scripts/check_changelog_fragment.sh               EXIT=0
bash scripts/check_line_cap.sh                         EXIT=0
bash scripts/check_sld.sh                              EXIT=0
```

High-parallelism stability pass — the lib binary, 10 runs at
`--test-threads=32`, all `test result: ok. 1386 passed; 0 failed; 7 ignored`.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
