### PR TITLE
test(trusty-mpm): make the session-lock stale-clear test condition-based

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_budget/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_budget/mod.rs
@@ -428,6 +428,28 @@ impl Drop for SessionLock {
 /// `with_session_lock_clears_a_stale_lock`,
 /// `with_session_lock_concurrent_stale_clear_is_race_free`.
 fn with_session_lock(lock_path: &Path) -> Option<SessionLock> {
+    with_session_lock_with_stale_threshold(lock_path, STALE_LOCK_SECS)
+}
+
+/// Why (test-only seam, #6339): the concurrent-race test threads its own
+/// staleness threshold through here instead of calling [`with_session_lock`]
+/// directly. That test cannot let its assertion depend on both racer threads
+/// finishing inside the production `STALE_LOCK_SECS` (5s) window — under real
+/// scheduler load a descheduled racer can legitimately outlive 5s, at which
+/// point the winner's own fresh lock is ALSO genuinely stale and a correct
+/// clear-and-reacquire looks like a second winner (#6339). The atomic-rename
+/// claim in [`try_clear_if_stale`] is what the test verifies, not the literal
+/// 5-second window, so the test instead calls this with a threshold no
+/// realistic scheduling delay will reach (`tests.rs::RACE_TEST_STALE_SECS`),
+/// while every production caller keeps going through [`with_session_lock`]
+/// unaffected.
+/// What: identical acquisition loop to [`with_session_lock`], parameterized on
+/// the staleness threshold instead of hardcoding [`STALE_LOCK_SECS`].
+/// Test: `with_session_lock_concurrent_stale_clear_is_race_free`.
+fn with_session_lock_with_stale_threshold(
+    lock_path: &Path,
+    stale_secs: u64,
+) -> Option<SessionLock> {
     if let Some(parent) = lock_path.parent() {
         std::fs::create_dir_all(parent).ok()?;
     }
@@ -444,7 +466,7 @@ fn with_session_lock(lock_path: &Path) -> Option<SessionLock> {
                 });
             }
             Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
-                try_clear_if_stale(lock_path);
+                try_clear_if_stale(lock_path, stale_secs);
             }
             Err(_) => return None,
         }
@@ -489,7 +511,11 @@ fn with_session_lock(lock_path: &Path) -> Option<SessionLock> {
 /// caller's normal retry loop takes over.
 /// Test: `with_session_lock_clears_a_stale_lock`,
 /// `with_session_lock_concurrent_stale_clear_is_race_free`.
-fn try_clear_if_stale(lock_path: &Path) {
+///
+/// `stale_secs` is [`STALE_LOCK_SECS`] for every production caller; the
+/// concurrent-race test overrides it (#6339) — see
+/// [`with_session_lock_with_stale_threshold`] for why.
+fn try_clear_if_stale(lock_path: &Path, stale_secs: u64) {
     let Ok(metadata) = std::fs::metadata(lock_path) else {
         return;
     };
@@ -499,7 +525,7 @@ fn try_clear_if_stale(lock_path: &Path) {
     let age = SystemTime::now()
         .duration_since(modified)
         .unwrap_or(Duration::ZERO);
-    if age < Duration::from_secs(STALE_LOCK_SECS) {
+    if age < Duration::from_secs(stale_secs) {
         return;
     }
     let claim_path = unique_claim_path(lock_path);

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_budget/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_budget/tests.rs
@@ -310,6 +310,26 @@ fn with_session_lock_clears_a_stale_lock() {
     );
 }
 
+/// Staleness threshold used only by
+/// `with_session_lock_concurrent_stale_clear_is_race_free`, in place of the
+/// production [`STALE_LOCK_SECS`] (5s).
+///
+/// Why (#6339): the test races two threads against a pre-staled lock to prove
+/// the atomic-rename claim in `try_clear_if_stale` lets at most one racer win.
+/// That race normally settles in low single-digit milliseconds, but nothing
+/// bounds how long the OS scheduler can preempt a racer mid-call — under real
+/// load one was observed landing past the production 5s window. When that
+/// happens the "loser" clearing the lock is not a bug: by then the winner's
+/// own fresh lock genuinely IS more than 5s old, so reclaiming it is correct
+/// per [`STALE_LOCK_SECS`]'s design. The test was asserting a stronger
+/// property ("exactly one winner") than a 5s threshold can promise once a
+/// descheduling delay is allowed to approach that same 5s. Widening the
+/// threshold to one hour keeps the exact same atomic-rename logic under test
+/// while making a false failure require a racer thread to be starved of CPU
+/// for a full hour — not a real machine-load scenario, so the assertion no
+/// longer depends on a tight wall-clock window holding under load.
+const RACE_TEST_STALE_SECS: u64 = 3600;
+
 #[test]
 fn with_session_lock_concurrent_stale_clear_is_race_free() {
     // Reproduces the TOCTOU race code-critic flagged (PR #2928 MEDIUM, round
@@ -322,10 +342,10 @@ fn with_session_lock_concurrent_stale_clear_is_race_free() {
     let dir = crate::test_support::hermetic_temp_dir();
     let lock_path = std::sync::Arc::new(dir.path().join("sess.lock"));
 
-    // Pre-stale the lock: simulate an abandoned lock left by a crashed/killed
-    // `tm hook --pm-guard` process.
+    // Pre-stale the lock relative to `RACE_TEST_STALE_SECS`, not the
+    // production `STALE_LOCK_SECS` — see that constant's doc comment (#6339).
     let file = std::fs::File::create(lock_path.as_path()).expect("create lock");
-    let stale_time = SystemTime::now() - Duration::from_secs(STALE_LOCK_SECS + 1);
+    let stale_time = SystemTime::now() - Duration::from_secs(RACE_TEST_STALE_SECS + 1);
     file.set_modified(stale_time).expect("set_modified");
     drop(file);
 
@@ -336,7 +356,7 @@ fn with_session_lock_concurrent_stale_clear_is_race_free() {
             let barrier = std::sync::Arc::clone(&barrier);
             std::thread::spawn(move || {
                 barrier.wait();
-                with_session_lock(&lock_path)
+                with_session_lock_with_stale_threshold(&lock_path, RACE_TEST_STALE_SECS)
             })
         })
         .collect();


### PR DESCRIPTION
Refs #6339.

## Root cause (confirmed against code, not just the issue text)

`with_session_lock_concurrent_stale_clear_is_race_free` pre-stales a lock
file past the production `STALE_LOCK_SECS` (5s) and races two threads
against `with_session_lock`, asserting exactly one wins the clear +
reacquire. Under real scheduler load a racer thread can be descheduled past
that same 5s window; by the time it re-checks, the winner's own freshly
created lock is *itself* legitimately more than 5s old, so the atomic-rename
claim in `try_clear_if_stale` correctly treats it as abandoned and clears
it too — a second, correct winner. The product code (`mod.rs`'s
rename-based TOCTOU guard from PR #2928 round 2) is doing exactly what it's
designed to do; the test's failure mode is a 5-second wall-clock margin
that assumes the whole race settles well inside that window.

## Fix

Threaded the staleness threshold through as a parameter instead of hardcoding
`STALE_LOCK_SECS`:

- `with_session_lock` → delegates to new `with_session_lock_with_stale_threshold(path, stale_secs)`
- `try_clear_if_stale` now takes `stale_secs: u64`

The race test calls `with_session_lock_with_stale_threshold` with a
`RACE_TEST_STALE_SECS = 3600` (1 hour) threshold instead of the production
5s one, and pre-stales the lock relative to that. Same atomic-rename logic
under test; a false failure now needs a racer starved of CPU for a full
hour, not 5 seconds. Every production call site is unaffected —
`with_session_lock` still calls through with `STALE_LOCK_SECS`.

Regression coverage confirmed by reverting the atomic-rename claim locally
to the pre-#2928-round-2 metadata-check + unconditional `remove_file` and
observing the test reliably fail with "got 2 winners" — reverted before
committing.

## Rung 2 (test-only stabilization)

```
cargo fmt --check                                          # PASS
cargo clippy -p trusty-mpm --all-targets -- -D warnings     # PASS
cargo test -p trusty-mpm --no-fail-fast                     # 5498 passed; 0 failed; 7 ignored
```

- `with_session_lock_concurrent_stale_clear_is_race_free` run standalone
  10/10, and again while a full `cargo test -p trusty-mpm` ran concurrently
  in the background — no flake in either.
- A second clean full-suite run hit an unrelated flake
  (`daemon::rpc::managed::managed_tests::managed_reconcile_worktrees_parity`,
  outside this PR's diff), which passed standalone — consistent with this
  machine's heavy concurrent-worktree load, not this change.

Test-only change; no changelog fragment (per CLAUDE.md's docs/CI/test-only
exception). mpm stays at 1.5.11, unpublished.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools