### PR TITLE
fix(trusty-search): the complete frame's status agrees with the terminal status (Refs #6415)

### DIFF
--- a/crates/trusty-search/changelog.d/6415-complete-frame-status-agrees.md
+++ b/crates/trusty-search/changelog.d/6415-complete-frame-status-agrees.md
@@ -1,0 +1,14 @@
+Fixed
+
+- A reindex halted by the background memory poller reported `"status":
+  "complete"` and `"memory_limit_hit": false` on its terminal SSE frame, while
+  the daemon recorded the same run as `AbortedMemory`. The frame derived those
+  two fields from the batch loop's own `mem_limit_hit` flag, and the enum status
+  derived from `mem_limit_hit || mem_abort` — the poller sets `mem_abort` on its
+  own tick and the producer then halts at the next batch boundary, so a run can
+  end with `mem_abort` set and `mem_limit_hit` never set. A consumer reading the
+  wire string, which is what `trusty_common::monitor::search_client` does, saw a
+  memory-aborted reindex as a success and would retry straight into the same
+  ceiling. Both fields now come from the terminal status the frame already
+  carries, so the payload and the enum cannot disagree. `RunTotals::mem_limit_hit`
+  is gone with them. Refs #6415, #6386.

--- a/crates/trusty-search/src/service/reindex/completion.rs
+++ b/crates/trusty-search/src/service/reindex/completion.rs
@@ -52,7 +52,6 @@ pub(super) struct RunTotals {
     pub bm25_ms: u64,
     pub vector_upsert_ms: u64,
     pub vector_count: usize,
-    pub mem_limit_hit: bool,
     /// Issue #100: total chunks dropped by the per-index chunk cap across the
     /// whole reindex. Non-zero ⇒ the walk was truncated by the budget and the
     /// index is incomplete.
@@ -105,14 +104,15 @@ pub(super) async fn rebuild_symbol_graph_for_reindex(handle: &IndexHandle) -> Kg
 /// `terminal_status` — the status this run ends in. #6386: it is stored HERE,
 /// with the frame, rather than by the caller before it — `push_terminal` does
 /// both under one hold of the replay-buffer lock, so a stream opening now cannot
-/// read a terminal status from a buffer that lacks the terminal frame. The
-/// `status` FIELD in the payload keeps its own derivation from
-/// `totals.mem_limit_hit` and is unchanged.
+/// read a terminal status from a buffer that lacks the terminal frame. #6415: it
+/// is also the sole source of the payload's `status` and `memory_limit_hit`
+/// fields, so the wire frame and the stored enum cannot disagree.
 ///
 /// What: reads final counters from `progress`, builds the JSON event, and calls
 /// `progress.push_terminal`.
 /// Test: `complete` event shape verified in `reindex_walks_directory_and_emits_events`;
-/// the atomicity in `a_terminal_status_is_not_observable_before_its_event_is_in_the_replay`.
+/// the payload/enum agreement in `completion_tests.rs`; the atomicity in
+/// `a_terminal_status_is_not_observable_before_its_event_is_in_the_replay`.
 pub(super) async fn emit_complete_event(
     progress: &ReindexProgress,
     terminal_status: ReindexStatus,
@@ -139,7 +139,12 @@ pub(super) async fn emit_complete_event(
     let indexed_new = indexed_final.saturating_sub(skipped_final);
     // Issue #120: surface the terminal status string in the SSE payload so
     // external callers can distinguish a clean completion from a memory-abort.
-    let status_str = if totals.mem_limit_hit {
+    // #6415: derive it from the terminal status rather than from the batch
+    // loop's own `mem_limit_hit` flag — the background memory poller trips
+    // `mem_abort` without that flag, and the payload then read "complete" for a
+    // run the daemon recorded as `AbortedMemory`.
+    let aborted_memory = matches!(terminal_status, ReindexStatus::AbortedMemory);
+    let status_str = if aborted_memory {
         "aborted_memory"
     } else {
         "complete"
@@ -155,7 +160,8 @@ pub(super) async fn emit_complete_event(
         "elapsed_ms": elapsed_ms,
         "chunks_per_sec": chunks_per_sec,
         "peak_rss_mb": peak_rss_mb,
-        "memory_limit_hit": totals.mem_limit_hit,
+        // #6415: same derivation as `status` above — one flag, one meaning.
+        "memory_limit_hit": aborted_memory,
         // Issue #100: surface budget truncation.
         "walk_truncated_by_budget": totals.chunks_dropped_by_cap > 0,
         "chunks_dropped_by_cap": totals.chunks_dropped_by_cap,

--- a/crates/trusty-search/src/service/reindex/completion_tests.rs
+++ b/crates/trusty-search/src/service/reindex/completion_tests.rs
@@ -1,0 +1,110 @@
+//! #6415: the `complete` frame's `status` field must agree with the terminal
+//! status stored beside it.
+//!
+//! Why: the payload derived `status` from `RunTotals::mem_limit_hit` — the flag
+//! the batch loop sets from its own post-commit RSS sample — while the enum
+//! status derived from `mem_limit_hit || mem_abort`. The background memory
+//! poller (`spawn_memory_poller`) sets `mem_abort` on its own tick and the
+//! producer then halts at the next batch boundary, so a run can end with
+//! `mem_abort` set and `mem_limit_hit` never set. The daemon recorded that run as
+//! `AbortedMemory` while the frame on the wire said `"complete"` with
+//! `memory_limit_hit: false`, and
+//! `trusty_common::monitor::search_client::parse_reindex_event` reads the string,
+//! not the enum — a memory-aborted reindex reported success to its consumer.
+//!
+//! What: [`the_payload_status_agrees_with_the_terminal_status`] drives
+//! `emit_complete_event` on the divergent input (an `AbortedMemory` run whose
+//! `RunTotals` carry no batch-loop trip) and reads the frame back off the replay
+//! buffer. [`a_clean_run_still_reports_complete`] pins the other arm.
+//!
+//! Test: this file IS the test module.
+
+use std::time::Instant;
+
+use super::completion::{emit_complete_event, KgRebuildOutcome, RunTotals};
+use super::{ReindexProgress, ReindexStatus};
+
+/// Build totals with every accumulator at zero.
+///
+/// The memory verdict is deliberately absent from `RunTotals` since #6415 — the
+/// point of these tests is that the frame reads it off `terminal_status` alone.
+fn zeroed_totals() -> RunTotals {
+    RunTotals {
+        walk_ms: 0,
+        parse_ms: 0,
+        embed_ms: 0,
+        bm25_ms: 0,
+        vector_upsert_ms: 0,
+        vector_count: 0,
+        chunks_dropped_by_cap: 0,
+        stages: super::stage_timings::StageTimings::default(),
+        other_ms: 0,
+    }
+}
+
+/// A KG rebuild that installed a graph cleanly.
+fn clean_kg() -> KgRebuildOutcome {
+    KgRebuildOutcome {
+        symbol_count: 0,
+        edge_count: 0,
+        kg_ms: 0,
+        kg_skipped: false,
+        contrib_merge_error: None,
+    }
+}
+
+/// Emit one terminal frame and return it parsed, alongside the stored status.
+async fn emit_and_read(terminal: ReindexStatus) -> (serde_json::Value, ReindexStatus) {
+    let progress = ReindexProgress::new();
+    emit_complete_event(
+        &progress,
+        terminal,
+        Instant::now(),
+        0,
+        None,
+        &zeroed_totals(),
+        &clean_kg(),
+    )
+    .await;
+    let buf = progress.events.lock().await;
+    let line = buf
+        .last()
+        .expect("a terminal frame must be buffered")
+        .clone();
+    drop(buf);
+    let frame: serde_json::Value =
+        serde_json::from_str(&line).expect("the terminal frame must be valid JSON");
+    (frame, progress.status.load())
+}
+
+/// A `mem_abort`-only run must reach the wire as `aborted_memory`.
+///
+/// Pre-fix this frame read `"complete"` with `memory_limit_hit: false`, because
+/// the batch loop never set `mem_limit_hit` — exactly the run the memory poller
+/// halts on its own tick.
+#[tokio::test]
+async fn the_payload_status_agrees_with_the_terminal_status() {
+    let (frame, stored) = emit_and_read(ReindexStatus::AbortedMemory).await;
+    assert_eq!(
+        stored,
+        ReindexStatus::AbortedMemory,
+        "the stored enum must be the status passed in"
+    );
+    assert_eq!(
+        frame["status"], "aborted_memory",
+        "a run stored as AbortedMemory must not report `complete` on the wire"
+    );
+    assert_eq!(
+        frame["memory_limit_hit"], true,
+        "`memory_limit_hit` must carry the same verdict as `status`"
+    );
+}
+
+/// The clean arm is unchanged: no abort, no `aborted_memory` on the wire.
+#[tokio::test]
+async fn a_clean_run_still_reports_complete() {
+    let (frame, stored) = emit_and_read(ReindexStatus::Complete).await;
+    assert_eq!(stored, ReindexStatus::Complete);
+    assert_eq!(frame["status"], "complete");
+    assert_eq!(frame["memory_limit_hit"], false);
+}

--- a/crates/trusty-search/src/service/reindex/finish.rs
+++ b/crates/trusty-search/src/service/reindex/finish.rs
@@ -448,7 +448,9 @@ pub(super) async fn finish_reindex(
         total_chunks,
         elapsed_ms,
         peak_rss_mb,
-        mem_limit_hit,
+        // #6415: the same value the SSE payload carries, so the log and the
+        // wire frame do not disagree on a poller-only abort.
+        aborted_memory,
     );
     // #5024: the old `model_load_approx_ms` was `elapsed` minus the subsystem
     // accumulators, which lumped the hash-cache load, the carryover copy, the
@@ -493,7 +495,8 @@ pub(super) async fn finish_reindex(
         bm25_ms: total_bm25_ms,
         vector_upsert_ms: total_vector_upsert_ms,
         vector_count: total_vector_count,
-        mem_limit_hit,
+        // #6415: the payload's memory verdict now comes from `terminal_status`,
+        // which already folds in the poller's `mem_abort`.
         chunks_dropped_by_cap: total_chunks_dropped_by_cap,
         // #5024: same breakdown the log line above prints, so a client polling
         // the SSE stream sees it without scraping stderr.

--- a/crates/trusty-search/src/service/reindex/mod.rs
+++ b/crates/trusty-search/src/service/reindex/mod.rs
@@ -290,3 +290,8 @@ mod pollers_tests;
 // orchestration tests in `tests.rs`.
 #[cfg(test)]
 mod progress_race_tests;
+// #6415: the terminal frame's `status` field must agree with the terminal status
+// stored beside it. Its own file so the payload contract is not buried in the
+// orchestration tests.
+#[cfg(test)]
+mod completion_tests;


### PR DESCRIPTION
The terminal `complete` frame derived `status` and `memory_limit_hit` from the batch loop's `mem_limit_hit`; the enum status stored beside it derived from `mem_limit_hit || mem_abort`. `spawn_memory_poller` trips `mem_abort` on its own tick and the producer halts at the next batch boundary, so a run ends with `mem_abort` set and `mem_limit_hit` never set. The daemon recorded `AbortedMemory` while the wire frame said `"complete"` with `"memory_limit_hit": false`.

`trusty_common::monitor::search_client::parse_reindex_event` reads that string, not the enum, so a memory-aborted reindex reached its consumer as a success — the retry-cooldown case #120 added the field for.

Both fields now derive from `terminal_status`, which `emit_complete_event` already receives. `RunTotals::mem_limit_hit` had no other reader and is gone. The run's summary log line prints the same verdict.

Regression test: `service::reindex::completion_tests` (new file). `the_payload_status_agrees_with_the_terminal_status` drives `emit_complete_event` with `AbortedMemory` and totals carrying no batch-loop trip. Against the pre-fix derivation it fails:

```
assertion `left == right` failed: a run stored as AbortedMemory must not report `complete` on the wire
  left: String("complete")
 right: "aborted_memory"
test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 1930 filtered out
```

Test ladder: **rung 3** — localized behavior inside `trusty-search`. `RunTotals` is `pub(super)` to `service::reindex`, so nothing outside the crate sees the removed field.

```
cargo fmt --check                                          EXIT=0
cargo check -p trusty-search --all-targets                 EXIT=0
cargo clippy -p trusty-search --all-targets -- -D warnings EXIT=0
cargo test -p trusty-search --no-fail-fast                 EXIT=0
  34 targets: 2448 passed; 0 failed; 41 ignored
bash scripts/check_line_cap.sh                             EXIT=0
bash scripts/check_sld.sh                                  EXIT=0
bash scripts/check_changelog_fragment.sh                   EXIT=0
bash scripts/check-pr-version-bump.sh                      EXIT=0  (no bump demanded)
```

Refs #6415, #6386.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
