### PR TITLE
fix(trusty-mpm): decide a stale pane path on the first probe (Refs #6414)

### DIFF
--- a/crates/trusty-mpm/changelog.d/6414-stale-pane-path-no-retry.md
+++ b/crates/trusty-mpm/changelog.d/6414-stale-pane-path-no-retry.md
@@ -1,0 +1,13 @@
+Fixed
+
+- Boot reconciliation no longer sleeps through a retry that cannot change its
+  answer. A live tmux pane whose recorded working directory has been deleted — a
+  reaped agent worktree — was probed three times with the full 200 ms backoff
+  before being declined, even though tmux keeps reporting the same recorded path
+  on every probe. On a host with 276 such panes that was 55 s of sleep inside
+  `reconcile_on_boot`, which `DaemonState::session_manager()` awaits before it
+  hands the manager to its first caller; the SessionEnd worktree sweep is often
+  that caller and reached its first gate a minute late. The retry still runs in
+  full when tmux returns no answer at all, which is the transient failure it was
+  added for (#6118), and no pane's verdict changes — measured on 294 live
+  sessions, 60.65 s to 2.12 s (#6414).

--- a/crates/trusty-mpm/src/session_manager/adopt.rs
+++ b/crates/trusty-mpm/src/session_manager/adopt.rs
@@ -17,7 +17,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use chrono::Utc;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use super::driver::ManagedTmuxDriver;
 use super::manager::{ManagedError, SessionManager};
@@ -49,27 +49,59 @@ const CWD_PROBE_BACKOFF: [Duration; 2] = [Duration::from_millis(50), Duration::f
 ///
 /// What: asks `get_pane_cwd` up to `CWD_PROBE_BACKOFF.len() + 1` times, sleeping
 /// the matching backoff between attempts, and returns the first answer that
-/// names an existing directory. A pane that is genuinely unresolvable costs the
-/// full backoff once, at boot only.
+/// names an existing directory. Only a probe that returns NO answer is retried.
+///
+/// # A stale path is an answer, not a flake (#6414)
+///
+/// `.filter(|p| p.is_dir())` used to fold both negatives into the retry, so a
+/// pane whose `pane_current_path` names a directory that has since been deleted
+/// — a reaped agent worktree — cost the full 200 ms backoff before being
+/// declined. tmux keeps reporting that recorded path, so the second and third
+/// probes read the same bytes and reach the same verdict; the sleep between
+/// them buys nothing. On a host with 276 such panes that was 55 s of pure sleep
+/// inside `reconcile_on_boot`, which `DaemonState::session_manager()` awaits
+/// before it hands the manager to its first caller — and the first caller is
+/// often the SessionEnd worktree sweep, which then reached its first gate a
+/// minute late (#6391 raised its budget to 300 s as containment).
+///
+/// The #6118 protection is unchanged in the case it was written for: `None`
+/// means tmux did not answer at all (spawn failure, non-zero exit, empty
+/// output), which a retry genuinely can turn into an answer, and that arm still
+/// gets every attempt. No pane's verdict changes — only how long a determinate
+/// negative takes to reach.
 /// Test: `flaky_cwd_probe_still_adopts_within_one_reconcile`,
-/// `unresolvable_cwd_probe_is_retried_a_bounded_number_of_times` in
-/// `naming_tests.rs`.
+/// `unresolvable_cwd_probe_is_retried_a_bounded_number_of_times`,
+/// `a_stale_pane_path_is_declined_on_the_first_probe` in `naming_tests.rs`.
 pub(super) async fn resolve_adoptable_cwd(
     tmux: &dyn ManagedTmuxDriver,
     name: &str,
 ) -> Option<PathBuf> {
     for attempt in 0..=CWD_PROBE_BACKOFF.len() {
-        if let Some(cwd) = tmux.get_pane_cwd(name).filter(|p| p.is_dir()) {
-            if attempt > 0 {
-                warn!(
-                    name = %name,
-                    attempt = attempt + 1,
-                    "reconcile: pane working directory resolved only on retry — the first probe \
-                     was a transient failure, and declining on it would have exposed a live pane \
-                     to the orphan-GC (#6118)"
-                );
+        match tmux.get_pane_cwd(name) {
+            Some(cwd) if cwd.is_dir() => {
+                if attempt > 0 {
+                    warn!(
+                        name = %name,
+                        attempt = attempt + 1,
+                        "reconcile: pane working directory resolved only on retry — the first \
+                         probe was a transient failure, and declining on it would have exposed a \
+                         live pane to the orphan-GC (#6118)"
+                    );
+                }
+                return Some(cwd);
             }
-            return Some(cwd);
+            // #6414: tmux answered; the answer just names a directory that is
+            // gone. Re-reading it returns the same path, so decide now.
+            Some(stale) => {
+                debug!(
+                    name = %name,
+                    path = %stale.display(),
+                    "reconcile: pane working directory no longer exists — declining without \
+                     retry, which cannot change a path tmux keeps reporting (#6414)"
+                );
+                return None;
+            }
+            None => {}
         }
         if let Some(backoff) = CWD_PROBE_BACKOFF.get(attempt) {
             tokio::time::sleep(*backoff).await;

--- a/crates/trusty-mpm/src/session_manager/naming_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/naming_tests.rs
@@ -456,6 +456,57 @@ async fn unresolvable_cwd_probe_is_retried_a_bounded_number_of_times() {
     );
 }
 
+/// #6414 REGRESSION: a pane whose recorded path is GONE is declined on the
+/// first probe, not after the full backoff.
+///
+/// Why: `resolve_adoptable_cwd` folded "tmux did not answer" and "tmux named a
+/// directory that no longer exists" into one retry. Only the first is a flake.
+/// tmux keeps reporting the path it recorded, so probes two and three read the
+/// same bytes and reach the same verdict — and on a host with 276 panes left
+/// over from reaped agent worktrees, that identical verdict cost 55 s of sleep
+/// inside `reconcile_on_boot`, which every `DaemonState::session_manager()`
+/// caller awaits (#6391 raised the SessionEnd sweep's budget to 300 s to
+/// contain it).
+///
+/// What: one live pane whose `get_pane_cwd` always answers with a path that
+/// does not exist. Asserts the probe ran EXACTLY once — against the pre-fix
+/// body it runs 3 times and this fails — and that the verdict is byte-for-byte
+/// the one the retry produced: declined, no record, nothing adopted. The count
+/// is the assertion because it is the cause; wall-clock is not asserted.
+/// Test: this function IS the test.
+#[tokio::test]
+#[serial_test::serial]
+async fn a_stale_pane_path_is_declined_on_the_first_probe() {
+    let dir = TempDir::new().unwrap();
+    let _home = set_home(dir.path());
+    // A path under the temp dir that was never created — the shape a reaped
+    // agent worktree leaves behind in a still-live pane.
+    let reaped = dir.path().join("reaped-worktree");
+    assert!(!reaped.exists(), "the fixture path must not exist");
+
+    let fake = std::sync::Arc::new(FlakyPaneCwdTmux {
+        alive: vec!["tm-stale-01".into()],
+        pane_cwd: Some(reaped),
+        flaky_for: 0,
+        calls: std::sync::atomic::AtomicUsize::new(0),
+        pane_id: None,
+    });
+
+    let mgr = SessionManager::new(dir.path(), fake.clone()).await.unwrap();
+    let report = mgr.reconcile_on_boot(false).await.expect("reconcile");
+
+    assert_eq!(
+        fake.calls.load(std::sync::atomic::Ordering::SeqCst),
+        1,
+        "a path tmux keeps reporting cannot become a directory by being read again"
+    );
+    // The verdict is unchanged — the point of the fix is that it costs less,
+    // not that it decides differently.
+    assert_eq!(report.adoption_declined, vec!["tm-stale-01".to_string()]);
+    assert!(report.external_adopted.is_empty());
+    assert_eq!(mgr.list().await.len(), 0);
+}
+
 /// #6118: a live pane whose cwd will not resolve is NOT adopted.
 ///
 /// Why: #2158 adopted it as an `Active` record with a `/unknown` cwd and an

--- a/crates/trusty-mpm/src/session_manager/reconcile.rs
+++ b/crates/trusty-mpm/src/session_manager/reconcile.rs
@@ -348,16 +348,18 @@ impl SessionManager {
             // shell with no live child is KILLED after two 60-second sweeps
             // (a pane running an agent is kept and warned about instead). The
             // probe therefore decides a pane's life, which is why
-            // `resolve_adoptable_cwd` retries a failed one — see its doc.
+            // `resolve_adoptable_cwd` retries an UNANSWERED one — see its doc.
             let Some(resolved_cwd) = super::adopt::resolve_adoptable_cwd(&*self.tmux, name).await
             else {
+                // #6414: "on any attempt" over-claimed — a pane whose recorded
+                // path is simply gone is now decided on the first probe.
                 warn!(
                     name = %name,
                     "reconcile: declining external-adopt — the pane's working directory did not \
-                     resolve on any attempt, so there is nothing to track, resume or attach to \
-                     (#6118). The pane is left to the orphan-GC, which kills it only if it is an \
-                     idle shell with no live child on two consecutive sweeps; `tmux attach -t \
-                     <name>` still reaches it until then"
+                     resolve to a directory that exists, so there is nothing to track, resume or \
+                     attach to (#6118). The pane is left to the orphan-GC, which kills it only if \
+                     it is an idle shell with no live child on two consecutive sweeps; `tmux \
+                     attach -t <name>` still reaches it until then"
                 );
                 report.adoption_declined.push(name.clone());
                 continue;


### PR DESCRIPTION
`resolve_adoptable_cwd` retried a probe that cannot change its answer.

`.filter(|p| p.is_dir())` folded two different negatives into one retry: tmux
did not answer, and tmux answered with a directory that has since been deleted.
Only the first is a flake. tmux keeps reporting the `pane_current_path` it
recorded, so probes two and three read the same bytes and reach the same
verdict, having slept 50 ms + 150 ms to get there.

On this host that is 276 of 294 live panes — reaped agent worktrees whose panes
outlived them — so 55 s of pure sleep inside `reconcile_on_boot`.
`DaemonState::session_manager()` awaits that before it hands the manager to its
first caller, and the SessionEnd worktree sweep is often that caller. That is
the 53 s #6414 measured and what PR #6413 contained by raising `await_gone`'s
budget to 300 s.

The #6118 protection is unchanged where it applies. `None` means tmux did not
answer at all (spawn failure, non-zero exit, empty output), a retry can
genuinely turn that into an answer, and that arm still gets every attempt. No
pane's verdict changes — only how long a determinate negative takes to reach.

## #6426 altered the premise but did not moot it

#6426's host-state gate installs `NoopTmuxDriver` on a scratch framework root,
which removes this cost from the hermetic tests: the issue's named reproducer
is 0.01 s on current `main`. The production path is untouched by that gate —
the daemon runs against the operator's real root, resolves a real tmux driver,
and pays the full backoff. Both measurements below therefore run with
`TRUSTY_MPM_ALLOW_HOST_STATE=1`, which lifts the gate so the real driver
resolves against the host's 294 live sessions.

## Measurement

Same binary, same host, same 294 live tmux sessions
(`paths_in_use_protects_a_terminal_delegations_worktree`, which does nothing but
build the state and call `paths_in_use`):

```
before:  test result: ok. 1 passed; ... finished in 59.77s
         test result: ok. 1 passed; ... finished in 60.65s
after:   test result: ok. 1 passed; ... finished in 3.55s
         test result: ok. 1 passed; ... finished in 2.12s
```

The predicted cost matches the measured one: 276 unresolvable panes x 200 ms =
55.2 s.

## Regression test

`a_stale_pane_path_is_declined_on_the_first_probe` asserts the probe COUNT, not
wall-clock, and asserts the verdict is unchanged. Against the pre-fix body:

```
assertion `left == right` failed: a path tmux keeps reporting cannot become a
directory by being read again
  left: 3
 right: 1
```

`unresolvable_cwd_probe_is_retried_a_bounded_number_of_times` (the `None` arm,
3 probes) and `flaky_cwd_probe_still_adopts_within_one_reconcile` are unchanged
and still pass.

## Gates — rung 3 (localized behavior inside one crate)

`resolve_adoptable_cwd` is `pub(super)`; no cross-crate surface changes.

- `cargo fmt --check` — clean
- `cargo check -p trusty-mpm --all-targets` — clean
- `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — clean
- `cargo test -p trusty-mpm --no-fail-fast` — 54 targets, 9638 passed, 0 failed,
  18 ignored
- `check_line_cap.sh`, `check_sld.sh`, `check_changelog_fragment.sh`,
  `check-pr-version-bump.sh` — all clean; no version bump demanded

## Follow-up, not in scope here

The residual ~2 s is 588 serial tmux subprocess spawns (`get_pane_cwd` +
`get_pane_id`, one pair per pane). `daemon::tmux` already batches this shape
with `list-panes -a`; doing the same here would need a driver-trait addition and
is a separate change.

Refs #6414, #6391, #6413.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
