### PR TITLE
docs(trusty-mpm): bugfix batching is the default for same-module bug clusters

### DIFF
--- a/crates/trusty-mpm/changelog.d/bugfix-batching-workflow.md
+++ b/crates/trusty-mpm/changelog.d/bugfix-batching-workflow.md
@@ -1,0 +1,3 @@
+Documentation
+
+- **Bugfix batching is now the default for same-module bug clusters.** The `tm-workflow` skill's "One Outcome, One PR" section states that several open bugs constrained to the same file, module, or tightly-coupled area go in one PR — one engineer, one worktree, one review, one CI pass — instead of one PR per issue, with each issue keeping its own regression test and `Refs #N`. `tm-delegation-patterns` adds the matching anti-pattern row: one PR per issue for same-module bugs is the anti-pattern; the fix is one batched dispatch/PR per file-cluster.

--- a/crates/trusty-mpm/src/assets/skills/tm-delegation-patterns.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-delegation-patterns.md
@@ -147,6 +147,7 @@ context reloaded by each). These are the specific splits to collapse:
 | Implement then commit (2) | Include "commit when done" in the task (1) |
 | Sequential fixes to the same agent (N) | One delegation with full scope (1) |
 | A separate docs agent for a per-task README | Include the README in the engineer delegation |
+| One PR per issue for same-module bugs | One batched dispatch/PR per file-cluster; each issue keeps its own regression test and `Refs #N` line |
 
 ## Retry Protocol (delegated work came back failing)
 

--- a/crates/trusty-mpm/src/assets/skills/tm-workflow.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-workflow.md
@@ -88,6 +88,15 @@ documentation/API updates, the changelog fragment, and in-scope review fixes.
 - Split only when the outcomes can be reviewed, deployed, or reverted
   independently, or when risk or size makes a stack materially safer to review.
 
+**Bugfix batching is the default, not an exception.** Several open bugs
+constrained to the same file, module, or tightly-coupled area go in ONE PR —
+one engineer, one worktree, one review, one CI pass — not one PR per issue.
+Each issue keeps its own regression test and its own `Refs #N` in the PR body.
+One changelog fragment per crate may cover the whole batch, naming each issue.
+Unrelated bugs in different modules still get separate PRs. This is what "no
+two in-flight PRs share a module" means for a bug cluster: same module now
+means same PR, not a serialized queue of small ones.
+
 ## The 5-Phase Model and Its Dispatch Briefs
 
 The instruction package's CORE phase table is canonical for **whether** a phase


### PR DESCRIPTION
Bugfix batching is now the default for a same-file or same-module bug cluster: several open bugs constrained to one file, module, or tightly-coupled area ship in one PR — one engineer, one worktree, one review, one CI pass — instead of one PR per issue. Each issue keeps its own regression test and its own `Refs #N` in the PR body; one changelog fragment per crate may cover the batch, naming each issue. Unrelated bugs in different modules still get separate PRs, and this composes with the existing "no two in-flight PRs share a module" doctrine — same module now means same PR, not a serialized queue.

Adds a short clause to the `tm-workflow` skill's "One Outcome, One PR" section and one anti-pattern row to `tm-delegation-patterns`'s batching table. Files: `crates/trusty-mpm/src/assets/skills/tm-workflow.md`, `crates/trusty-mpm/src/assets/skills/tm-delegation-patterns.md`.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
