### PR TITLE
fix(trusty-installer): wave-1 — unknown health is loud; vmtest release-skew

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11612,7 +11612,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-installer"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-installer/Cargo.toml
+++ b/crates/trusty-installer/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "trusty-installer"
-# 0.13.2 (#6285): patch — the `trusty-installer-v0.13.1` tag is stranded at a
-# commit that cannot pass the rustdoc intra-doc-link gate, and release tags
-# are immutable here, so 0.13.1 is spent. No code change; version bump only to
-# free a publishable tag.
-version = "0.13.2"
+# 0.13.3 (#4847, #4917): patch — 0.13.2 is published and this PR edits
+# `src/**`. `stack doctor`/`stack health` gain an `undetermined` verdict and
+# exit 4, and `MemberDoctor::ok` narrows (an `unknown` member no longer passes);
+# `MemberDoctor::failed`/`undetermined` are additive. No signature changes.
+version = "0.13.3"
 edition = "2021"
 description = "Thin control plane for the claude-mpm stack: install, upgrade, restart, health, and config coordination across all trusty-* tools."
 readme = "README.md"

--- a/crates/trusty-installer/changelog.d/wave1-installer-batch.md
+++ b/crates/trusty-installer/changelog.d/wave1-installer-batch.md
@@ -1,0 +1,13 @@
+Fixed
+- `tctl stack doctor` and `tctl stack health` no longer report a member whose
+  health is `unknown` as passing. Both gained a third verdict, `undetermined`,
+  with its own exit code 4 — exit 2 still means a member is genuinely broken and
+  exit 0 now means every member was determined healthy. A harness gating on
+  these exit codes could previously go green over a stack that was not up
+  (#4847).
+- A `service install` that fails because the installed binary has no `service`
+  subcommand is reported as release skew instead of forwarding clap's
+  `unrecognized subcommand 'service'`. `tctl start trusty-console` against the
+  published 0.4.0 now names the installed version, says the member has no
+  supervised unit as a result, and gives the remedy, with the raw error appended
+  (#4917).

--- a/crates/trusty-installer/src/commands/service_bootstrap.rs
+++ b/crates/trusty-installer/src/commands/service_bootstrap.rs
@@ -61,6 +61,15 @@
 //! [`BootstrapAction::RefusedForeignPort`], with nothing attempted and nothing
 //! changed.
 //!
+//! 🔴 (#4917) A `service install` that fails because the installed binary has
+//! no `service` subcommand is REWRITTEN before it reaches the operator. That
+//! failure is release skew — `tctl install` fetches a component's latest
+//! PUBLISHED release, so a member whose `service install` shipped later than
+//! that release cannot bootstrap itself — and clap's `unrecognized subcommand`
+//! text describes it as a bad argument instead. [`release_skew_message`] names
+//! the installed version and the remedy; the raw error is appended, not
+//! replaced.
+//!
 //! Testability: every side effect is behind the [`ServiceEnv`] seam so the
 //! decision logic is unit-tested against an in-memory fake — the tests NEVER
 //! touch `~/Library/LaunchAgents` or invoke `launchctl` against the live
@@ -616,7 +625,20 @@ impl ServiceEnv for RealServiceEnv {
         let target = service_install_target(binary, exe_path)?;
         let mut cmd = std::process::Command::new(&target);
         cmd.args(["service", "install"]);
-        run_captured(cmd, &format!("`{} service install`", target.display()))
+        run_captured(cmd, &format!("`{} service install`", target.display())).map_err(|e| {
+            // #4917: an argument-parser rejection here is release skew, not a
+            // broken service install. Name that, and only then pay for the
+            // `--version` spawn that puts a number on it.
+            let raw = e.to_string();
+            if !names_missing_service_subcommand(&raw) {
+                return e;
+            }
+            let installed = super::update_engine::installed_version(binary);
+            anyhow::anyhow!(
+                "{}",
+                release_skew_message(binary, installed.as_deref(), &raw)
+            )
+        })
     }
 
     fn is_loaded(&self, binary: &str) -> bool {
@@ -704,6 +726,63 @@ impl ServiceEnv for RealServiceEnv {
             anyhow::bail!("launchd is macOS-only")
         }
     }
+}
+
+/// Whether a failed `service install` is the binary rejecting the subcommand.
+///
+/// Why (#4917): `tctl start trusty-console` on a machine running the published
+/// trusty-console reported `exited with exit status: 2: error: unrecognized
+/// subcommand 'service'` — clap's parser output, forwarded verbatim. That text
+/// says the argument was wrong; the actual fact is that the installed release
+/// predates the subcommand, which is a different problem with a different fix.
+/// Classifying it here is what lets [`release_skew_message`] say so.
+///
+/// What: `true` when the captured text carries an argument-parser
+/// "no such subcommand" rejection AND names `service`. Both halves are
+/// required: a `service install` that fails for its own reasons (a plist it
+/// cannot write, a port it cannot bind) must keep its own error text. Matching
+/// is case-insensitive and covers clap 4's `unrecognized subcommand` and
+/// clap 3's `wasn't expected` spellings, since the failing binary is a
+/// PUBLISHED release whose clap version the installer does not choose.
+///
+/// Test: `missing_service_subcommand_detects_clap_rejections`,
+/// `missing_service_subcommand_ignores_other_failures`.
+fn names_missing_service_subcommand(err: &str) -> bool {
+    let lower = err.to_lowercase();
+    let rejected = lower.contains("unrecognized subcommand")
+        || lower.contains("unknown subcommand")
+        || lower.contains("wasn't expected");
+    rejected && lower.contains("'service'")
+}
+
+/// The operator-facing explanation for a release-skew `service install` (#4917).
+///
+/// Why: the raw parser error tells an operator their argument was wrong, which
+/// sends them looking at `tctl`. The fact they need is that this member's
+/// installed binary is too old to install its own launchd unit, so the member
+/// has no supervised service and `tctl start` cannot bring it up until a newer
+/// release lands. `vmtest run released` hit exactly this against
+/// trusty-console 0.4.0 while the working tree carried the 0.5.0 that added
+/// `service` (#2557).
+///
+/// What: names the binary, the installed version when `--version` yielded one,
+/// what the skew costs (no plist, so no supervised start), and the remedy —
+/// then appends the underlying error rather than discarding it.
+///
+/// Test: `release_skew_message_names_version_and_remedy`,
+/// `release_skew_message_without_a_version`.
+fn release_skew_message(binary: &str, installed: Option<&str>, err: &str) -> String {
+    let version = match installed {
+        Some(v) => format!(" {v}"),
+        None => String::new(),
+    };
+    format!(
+        "the installed {binary}{version} has no `service` subcommand, so it \
+         cannot install its own launchd plist — this release predates the \
+         subcommand (release skew, #4917). Without a plist the member has no \
+         supervised unit and `tctl start` cannot bring it up. Install a \
+         {binary} new enough to ship `service install`. Underlying error: {err}"
+    )
 }
 
 /// Which executable a `service install` should actually spawn.

--- a/crates/trusty-installer/src/commands/service_bootstrap_tests.rs
+++ b/crates/trusty-installer/src/commands/service_bootstrap_tests.rs
@@ -964,3 +964,85 @@ fn retired_unit_already_absent_is_not_a_failure() {
         "the eviction must still be ATTEMPTED, even on a clean host"
     );
 }
+
+/// REGRESSION (#4917): the clap rejection that release skew produces is
+/// recognised as such.
+///
+/// Why: `vmtest run released` surfaced `exit status: 2: error: unrecognized
+/// subcommand 'service'` from trusty-console 0.4.0 — the parser's words, which
+/// point an operator at their own command line rather than at the installed
+/// release. Nothing classified that text before, so nothing could rewrite it.
+/// What: asserts the clap 4 and clap 3 spellings both match, including the full
+/// captured line `run_captured` builds.
+#[test]
+fn missing_service_subcommand_detects_clap_rejections() {
+    assert!(names_missing_service_subcommand(
+        "`trusty-console service install` exited with exit status: 2: \
+         error: unrecognized subcommand 'service'\n\n  tip: a similar \
+         subcommand exists: 'serve'"
+    ));
+    assert!(names_missing_service_subcommand(
+        "error: Found argument 'service' which wasn't expected, or isn't valid \
+         in this context"
+    ));
+    assert!(names_missing_service_subcommand(
+        "error: unknown subcommand 'service'"
+    ));
+}
+
+/// Why: the rewrite must not swallow a `service install` that failed on its own
+/// terms — a plist it could not write, a port already held. Those errors carry
+/// the only diagnosis there is, and a skew message pasted over one would send
+/// the operator after a version bump that fixes nothing.
+/// What: asserts each non-skew failure text is left unclassified, including a
+/// parser rejection naming a DIFFERENT subcommand.
+#[test]
+fn missing_service_subcommand_ignores_other_failures() {
+    assert!(!names_missing_service_subcommand(
+        "`trusty-search service install` exited with exit status: 1: \
+         error: could not write ~/Library/LaunchAgents/com.trusty.search.plist: \
+         Permission denied"
+    ));
+    assert!(!names_missing_service_subcommand(
+        "error: unrecognized subcommand 'serve'"
+    ));
+    assert!(!names_missing_service_subcommand(
+        "spawn `trusty-console service install`: No such file or directory"
+    ));
+}
+
+/// Why (#4917): the operator needs four facts the parser error gives none of —
+/// which binary, which version they are running, what the skew costs, and what
+/// to do — and needs the raw error kept so nothing is lost in the rewrite.
+/// What: asserts all four plus the underlying text appear in the message.
+#[test]
+fn release_skew_message_names_version_and_remedy() {
+    let msg = release_skew_message(
+        "trusty-console",
+        Some("0.4.0"),
+        "error: unrecognized subcommand 'service'",
+    );
+    assert!(msg.contains("trusty-console 0.4.0"), "{msg}");
+    assert!(msg.contains("release skew, #4917"), "{msg}");
+    assert!(msg.contains("`tctl start` cannot bring it up"), "{msg}");
+    assert!(msg.contains("Install a trusty-console new enough"), "{msg}");
+    assert!(
+        msg.contains("Underlying error: error: unrecognized subcommand 'service'"),
+        "{msg}"
+    );
+}
+
+/// Why: `installed_version` returns `None` whenever `<binary> --version` does
+/// not answer, and a missing version must not turn the explanation into a
+/// malformed sentence or block it entirely.
+/// What: asserts the message still reads correctly with no version, naming the
+/// binary without a stray double space.
+#[test]
+fn release_skew_message_without_a_version() {
+    let msg = release_skew_message("trusty-console", None, "error: unrecognized subcommand");
+    assert!(msg.contains("the installed trusty-console has no"), "{msg}");
+    assert!(
+        !msg.contains("  "),
+        "no doubled space where the version went: {msg}"
+    );
+}

--- a/crates/trusty-installer/src/commands/stack/doctor.rs
+++ b/crates/trusty-installer/src/commands/stack/doctor.rs
@@ -8,11 +8,16 @@
 //! What: for each in-scope daemon member, runs the strategy-aware health probe
 //! and the four diagnostic checks, builds a [`DoctorReport`], and renders a human
 //! drill-down or `--json` envelope. Returns exit 0 when every member is OK
-//! (binary present + not `down`), 2 otherwise.
+//! (binary present + a determined, not-`down` health), 4 when the worst member
+//! is merely undetermined, 2 otherwise.
 //!
 //! Test: `tests` covers the per-member check aggregation (`MemberDoctor::ok`),
 //! the report verdict, and the unknown-member error path; the filesystem/PATH
 //! probes are side-effecting.
+//!
+//! #4847: a member whose health is `unknown` no longer counts as OK. It is
+//! neither a pass nor a failure, so it has its own verdict (`undetermined`) and
+//! its own exit code (4), leaving exit 2 to mean a member is genuinely broken.
 
 use serde::Serialize;
 
@@ -46,15 +51,40 @@ pub struct MemberDoctor {
 }
 
 impl MemberDoctor {
+    /// Whether this member's diagnostics FAILED.
+    ///
+    /// Why: the report verdict + exit code reduce over this and
+    /// [`MemberDoctor::undetermined`].
+    /// What: failed iff the binary is missing from PATH OR its health is `down`.
+    /// Absent plist / unrecorded port are reported but not fatal (a member may
+    /// be stopped intentionally).
+    /// Test: `tests::member_ok_requires_path_and_not_down`.
+    pub fn failed(&self) -> bool {
+        !self.on_path || self.health == health_str::DOWN
+    }
+
+    /// Whether this member's health could not be determined (#4847).
+    ///
+    /// Why: `unknown` means the probe could not tell, which is neither a pass
+    /// nor a failure. Folding it into either one throws away the only fact the
+    /// row carries.
+    /// What: undetermined iff the member did not fail AND its health is
+    /// `unknown` — a member off PATH is already a failure and stays one.
+    /// Test: `tests::member_unknown_is_undetermined_not_ok`.
+    pub fn undetermined(&self) -> bool {
+        !self.failed() && self.health == health_str::UNKNOWN
+    }
+
     /// Whether this member passed its diagnostics.
     ///
-    /// Why: the report verdict + exit code reduce over this.
-    /// What: OK iff the binary is on PATH AND its health is not `down`. Absent
-    /// plist / unrecorded port are reported but not fatal (a member may be
-    /// stopped intentionally); a missing binary or a `down` daemon is the failure.
-    /// Test: `tests::member_ok_requires_path_and_not_down`.
+    /// Why: the human row and the verdict both need "passed" to mean passed —
+    /// before #4847 it also meant "we could not tell", which is what made the
+    /// green verdict unfalsifiable for an `unknown` member.
+    /// What: OK iff the member neither failed nor is undetermined.
+    /// Test: `tests::member_ok_requires_path_and_not_down`,
+    /// `tests::member_unknown_is_undetermined_not_ok`.
     pub fn ok(&self) -> bool {
-        self.on_path && self.health != health_str::DOWN
+        !self.failed() && !self.undetermined()
     }
 }
 
@@ -69,7 +99,7 @@ pub struct DoctorReport {
     pub command: &'static str,
     /// Per-member diagnostics in stable-set order.
     pub members: Vec<MemberDoctor>,
-    /// Overall verdict: `ok` | `degraded`.
+    /// Overall verdict: `ok` | `undetermined` | `degraded`.
     pub verdict: &'static str,
 }
 
@@ -77,13 +107,18 @@ impl DoctorReport {
     /// Build the report and derive the verdict.
     ///
     /// Why: one place derives the verdict so JSON + exit code agree.
-    /// What: `degraded` when any member is not `ok`, else `ok`.
-    /// Test: `tests::report_verdict_degraded`.
+    /// What: worst-wins over the per-member states — `degraded` when any member
+    /// failed, else `undetermined` when any member's health could not be
+    /// determined (#4847), else `ok`.
+    /// Test: `tests::report_verdict_degraded`,
+    /// `tests::report_verdict_undetermined`.
     fn build(members: Vec<MemberDoctor>) -> Self {
-        let verdict = if members.iter().all(MemberDoctor::ok) {
-            "ok"
-        } else {
+        let verdict = if members.iter().any(MemberDoctor::failed) {
             "degraded"
+        } else if members.iter().any(MemberDoctor::undetermined) {
+            "undetermined"
+        } else {
+            "ok"
         };
         Self {
             command: "stack doctor",
@@ -92,16 +127,19 @@ impl DoctorReport {
         }
     }
 
-    /// Process exit code: 0 ok, 2 degraded.
+    /// Process exit code: 0 ok, 2 degraded, 4 undetermined.
     ///
-    /// Why: triage scripts branch on this.
-    /// What: `2` when `degraded`, else `0`.
-    /// Test: `tests::report_verdict_degraded`.
+    /// Why: triage scripts branch on this, and the sweep that determined nothing
+    /// must not hand them a 0 (#4847). Giving `undetermined` its own code keeps
+    /// exit 2 meaning a member is actually broken.
+    /// What: `2` when `degraded`, `4` when `undetermined`, else `0`.
+    /// Test: `tests::report_verdict_degraded`,
+    /// `tests::report_verdict_undetermined`.
     fn exit_code(&self) -> i32 {
-        if self.verdict == "degraded" {
-            2
-        } else {
-            0
+        match self.verdict {
+            "degraded" => 2,
+            "undetermined" => 4,
+            _ => 0,
         }
     }
 }
@@ -237,8 +275,28 @@ mod tests {
         assert!(md("a", "healthy", true).ok());
         assert!(!md("a", "healthy", false).ok()); // not on PATH
         assert!(!md("a", "down", true).ok()); // down
-                                              // unknown health (mpm) with binary present is OK.
-        assert!(md("trusty-mpm", "unknown", true).ok());
+        assert!(md("a", "healthy", false).failed());
+        assert!(md("a", "down", true).failed());
+        assert!(!md("a", "healthy", true).failed());
+    }
+
+    /// Why: #4847 — `unknown` health used to satisfy `ok`, so a member the probe
+    /// could not read at all advanced a green verdict. It must now be its own
+    /// state: not a pass, not a failure.
+    /// What: an on-PATH member with `unknown` health is neither `ok` nor
+    /// `failed`, and IS `undetermined`. A member that is off PATH stays a
+    /// failure whatever its health word says, so it is never undetermined.
+    /// Test: This is the test.
+    #[test]
+    fn member_unknown_is_undetermined_not_ok() {
+        let m = md("trusty-mpm", "unknown", true);
+        assert!(!m.ok());
+        assert!(!m.failed());
+        assert!(m.undetermined());
+
+        let absent = md("trusty-mpm", "unknown", false);
+        assert!(absent.failed());
+        assert!(!absent.undetermined());
     }
 
     /// Why: the JSON envelope is a contract; pin its shape.
@@ -289,9 +347,33 @@ mod tests {
     fn report_verdict_ok() {
         let r = DoctorReport::build(vec![
             md("trusty-search", "healthy", true),
-            md("trusty-mpm", "unknown", true),
+            md("trusty-mpm", "healthy", true),
         ]);
         assert_eq!(r.verdict, "ok");
         assert_eq!(r.exit_code(), 0);
+    }
+
+    /// Why: #4847 — this exact sweep (every member healthy except one reporting
+    /// `unknown`) is what the issue observed exiting 0 with verdict `ok`. It
+    /// must now be visibly not-green, and it must not claim `degraded` either,
+    /// which would report a broken daemon that nobody observed.
+    /// What: healthy + unknown → `undetermined`, exit 4. Adding a `down` member
+    /// takes it to `degraded`/exit 2, so a real failure still outranks it.
+    /// Test: This is the test.
+    #[test]
+    fn report_verdict_undetermined() {
+        let r = DoctorReport::build(vec![
+            md("trusty-search", "healthy", true),
+            md("trusty-mpm", "unknown", true),
+        ]);
+        assert_eq!(r.verdict, "undetermined");
+        assert_eq!(r.exit_code(), 4);
+
+        let worse = DoctorReport::build(vec![
+            md("trusty-search", "down", true),
+            md("trusty-mpm", "unknown", true),
+        ]);
+        assert_eq!(worse.verdict, "degraded");
+        assert_eq!(worse.exit_code(), 2);
     }
 }

--- a/crates/trusty-installer/src/commands/stack/health.rs
+++ b/crates/trusty-installer/src/commands/stack/health.rs
@@ -7,7 +7,8 @@
 //! What: probes each daemon member via `probe::probe_member_health` (an HTTP
 //! `GET /health` probe since #4246, not a `health --json` subprocess), builds a
 //! [`HealthReport`], renders a human matrix or `--json` envelope, and returns an
-//! exit code (0 ready, 2 when any daemon is `down`).
+//! exit code (0 ready, 2 when any daemon is `down`, 4 when a daemon's health is
+//! only `unknown` — #4847: an undetermined health never reports as ready).
 //!
 //! Test: `tests` covers the report shaping + verdict derivation; the probe is
 //! side-effecting (covered in `probe`).
@@ -42,7 +43,7 @@ pub struct HealthReport {
     pub command: &'static str,
     /// Per-member rows in stable-set order.
     pub members: Vec<HealthRow>,
-    /// Overall verdict: `ready` | `degraded`.
+    /// Overall verdict: `ready` | `undetermined` | `degraded`.
     pub verdict: &'static str,
 }
 
@@ -50,24 +51,37 @@ impl HealthReport {
     /// Build a report and compute the verdict.
     ///
     /// Why: one place derives the verdict so the exit code + JSON agree.
-    /// What: degrade policy — both `down` AND `not_installed` degrade the verdict
-    /// to `degraded`. A `down` daemon is the running-but-broken failure signal; a
-    /// `not_installed` member is a real gap in the resolved stable set (an
-    /// operator after a failed install must NOT see green). Only a genuinely
-    /// `unknown` member does NOT degrade — its health is undetermined, not
-    /// absent. `stale` also stays non-degrading (running, just below the version
-    /// floor). (#4925: trusty-mpm used to be this policy's one live example; it is
-    /// probed over HTTP now, so a stopped mpm degrades the verdict like any other
-    /// daemon. Whether an undetermined health should advance a green verdict at
-    /// all is #4847's open question and is untouched here.)
+    /// What: three verdicts, worst-wins. `down` or `not_installed` on any member
+    /// is `degraded` — a `down` daemon is the running-but-broken failure signal,
+    /// and a `not_installed` member is a real gap in the resolved stable set (an
+    /// operator after a failed install must NOT see green). Otherwise an
+    /// `unknown` member makes the verdict `undetermined`: the probe could not
+    /// tell, which is a different claim from `ready`. `stale` stays
+    /// non-degrading (running, just below the version floor), so an
+    /// all-healthy-or-stale sweep is `ready`.
+    ///
+    /// #4847: `unknown` used to fold into `ready`, so a sweep that determined
+    /// nothing about a member still exited 0 and a harness gating on that exit
+    /// code went green over a stack that was not up. `unknown` now carries its
+    /// own verdict and its own non-zero exit instead of counting as failure, so
+    /// a broken daemon (exit 2) stays distinguishable from one that could not be
+    /// probed (exit 4).
     /// Test: `tests::verdict_down_is_degraded`,
     /// `tests::verdict_not_installed_is_degraded`,
-    /// `tests::verdict_unknown_is_ready`.
+    /// `tests::verdict_unknown_is_undetermined`,
+    /// `tests::verdict_down_outranks_unknown`.
     fn build(members: Vec<HealthRow>) -> Self {
         let degrades = members
             .iter()
             .any(|m| m.health == health_str::DOWN || m.health == health_str::NOT_INSTALLED);
-        let verdict = if degrades { "degraded" } else { "ready" };
+        let undetermined = members.iter().any(|m| m.health == health_str::UNKNOWN);
+        let verdict = if degrades {
+            "degraded"
+        } else if undetermined {
+            "undetermined"
+        } else {
+            "ready"
+        };
         Self {
             command: "stack health",
             members,
@@ -75,16 +89,19 @@ impl HealthReport {
         }
     }
 
-    /// Process exit code: 0 ready, 2 degraded.
+    /// Process exit code: 0 ready, 2 degraded, 4 undetermined.
     ///
-    /// Why: monitoring scripts branch on this.
-    /// What: `2` when `degraded`, else `0`.
+    /// Why: monitoring scripts branch on this, so three verdicts need three
+    /// codes. A script that treats any non-zero as "not ready" is then right
+    /// about `undetermined` too, and one that discriminates can still separate a
+    /// broken daemon (2) from an unprobeable one (4) (#4847).
+    /// What: `2` when `degraded`, `4` when `undetermined`, else `0`.
     /// Test: `tests::exit_code_reflects_verdict`.
     fn exit_code(&self) -> i32 {
-        if self.verdict == "degraded" {
-            2
-        } else {
-            0
+        match self.verdict {
+            "degraded" => 2,
+            "undetermined" => 4,
+            _ => 0,
         }
     }
 }
@@ -168,29 +185,53 @@ mod tests {
         assert_eq!(r.exit_code(), 2);
     }
 
-    /// Why: an `unknown` member must NOT degrade the verdict — its health is
-    /// merely undetermined, not absent. (#4925: the `trusty-mpm` name is now just
-    /// a label on a hand-written row; mpm itself is probed and no longer reports
-    /// `unknown`. The POLICY under test is unchanged and still live.)
-    /// What: one unknown member → `ready`, exit 0. A mix of unknown + healthy
-    /// also stays ready, proving unknown never falsely degrades.
+    /// Why: #4847 — an `unknown` member must not report as `ready`. The probe
+    /// determined nothing about it, and a harness that gates on this exit code
+    /// passed a stack that was not up. `unknown` is not `degraded` either: it is
+    /// its own verdict with its own non-zero exit.
+    /// What: one unknown member → `undetermined`, exit 4. Mixing unknown with a
+    /// healthy member keeps it `undetermined`, so one determined member cannot
+    /// carry the sweep back to green.
     /// Test: This is the test.
     #[test]
-    fn verdict_unknown_is_ready() {
+    fn verdict_unknown_is_undetermined() {
         let r = HealthReport::build(vec![row("trusty-mpm", "unknown")]);
-        assert_eq!(r.verdict, "ready");
-        assert_eq!(r.exit_code(), 0);
+        assert_eq!(r.verdict, "undetermined");
+        assert_eq!(r.exit_code(), 4);
 
         let mixed = HealthReport::build(vec![
             row("trusty-search", "healthy"),
             row("trusty-mpm", "unknown"),
         ]);
-        assert_eq!(mixed.verdict, "ready");
-        assert_eq!(mixed.exit_code(), 0);
+        assert_eq!(mixed.verdict, "undetermined");
+        assert_eq!(mixed.exit_code(), 4);
+    }
+
+    /// Why: the two non-green verdicts must not mask each other. A broken daemon
+    /// is the actionable signal, so `degraded` outranks `undetermined` when both
+    /// are present (#4847).
+    /// What: down + unknown → `degraded`, exit 2. `stale` alongside unknown does
+    /// not degrade, so that mix stays `undetermined`.
+    /// Test: This is the test.
+    #[test]
+    fn verdict_down_outranks_unknown() {
+        let both = HealthReport::build(vec![
+            row("trusty-search", "down"),
+            row("trusty-mpm", "unknown"),
+        ]);
+        assert_eq!(both.verdict, "degraded");
+        assert_eq!(both.exit_code(), 2);
+
+        let stale_and_unknown = HealthReport::build(vec![
+            row("trusty-search", "stale"),
+            row("trusty-mpm", "unknown"),
+        ]);
+        assert_eq!(stale_and_unknown.verdict, "undetermined");
+        assert_eq!(stale_and_unknown.exit_code(), 4);
     }
 
     /// Why: the exit code must track the verdict.
-    /// What: asserts 0 for ready, 2 for degraded.
+    /// What: asserts 0 for ready, 2 for degraded, 4 for undetermined (#4847).
     /// Test: This is the test.
     #[test]
     fn exit_code_reflects_verdict() {
@@ -198,5 +239,7 @@ mod tests {
         assert_eq!(ready.exit_code(), 0);
         let degraded = HealthReport::build(vec![row("trusty-search", "down")]);
         assert_eq!(degraded.exit_code(), 2);
+        let undetermined = HealthReport::build(vec![row("trusty-search", "unknown")]);
+        assert_eq!(undetermined.exit_code(), 4);
     }
 }

--- a/crates/trusty-installer/src/commands/verify_tail.rs
+++ b/crates/trusty-installer/src/commands/verify_tail.rs
@@ -192,9 +192,12 @@ impl VerifyTailReport {
     /// What: `verified = ensure_ok AND no REQUIRED member is
     /// `down`/`not_installed`` (an OPTIONAL member's health never fails this
     /// — demo-critical fix). A `stale` or `unknown` member does NOT fail
-    /// verification — mirrors `stack::health::HealthReport`'s degrade policy
+    /// verification — mirrors `stack::health::HealthReport`'s DEGRADE policy
     /// exactly (an under-the-version-floor daemon is still up; a member with no
-    /// probeable transport is not a verified gap).
+    /// probeable transport is not a verified gap). #4847 gave `stack health` a
+    /// third `undetermined` verdict ABOVE that degrade policy; this verdict is
+    /// binary, so it mirrors the degrade half only and still tolerates
+    /// `unknown`.
     ///
     /// #4925: trusty-mpm is no longer an example of the `unknown` tolerance. It
     /// is probed over HTTP now, so a stopped mpm arrives here as `down` and — it


### PR DESCRIPTION
- `tctl stack doctor` / `tctl stack health` gained a third verdict, `undetermined` (exit 4), so an `unknown` member no longer folds into the passing verdict and exit 0 — `degraded` (exit 2) still outranks it. Refs #4847
- A `service install` rejected by the binary's own argument parser is reported as release skew — installed version, what it costs, the remedy, raw error appended — instead of forwarding clap's `unrecognized subcommand 'service'`. Refs #4917

Rung 3 (localized behavior in one crate). `cargo fmt --check`, `cargo check -p trusty-installer --all-targets`, `cargo clippy -p trusty-installer --all-targets -- -D warnings` clean; `cargo test -p trusty-installer --no-fail-fast` → 696 passed, 0 failed, 4 ignored (lib) plus 3 + 3 in the two integration targets. `check_test_pointers.sh`, `check_line_cap.sh`, `check_sld.sh`, `check_changelog_fragment.sh` all pass.

The five #4847 regression assertions were run against the pre-fix verdict logic first and failed there (`verdict "ok" != "undetermined"`, `exit 0 != 4`, `assert!(!m.ok())`).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools