### PR TITLE
fix(tga): wave-1 batch — misattribution, keyword mapping, vacuous filter guard, Linear API key

### DIFF
--- a/.github/workflows/test-count.yml
+++ b/.github/workflows/test-count.yml
@@ -1,0 +1,73 @@
+# Zero-tests-ran gate for the trusty-tools workspace (issue #4307).
+#
+# `cargo test` with a filter that matches zero tests exits 0 and prints `ok`.
+# Where a test module's file path differs from its module path via `#[path]`,
+# the natural filter — the one derived from the file name — silently matches
+# nothing and the run reports green having proved nothing.
+# `scripts/check_test_count.sh` wraps a test invocation and refuses an aggregate
+# of zero.
+#
+# This job does not merely run the guard's fixtures. It runs the guard around
+# two REAL cargo invocations — the mistyped filter and the correct one from the
+# issue — and asserts each verdict, so the gate is proven against live cargo
+# output every run rather than against a captured string that can go stale.
+#
+# Not a required branch-protection context: adding one wedges every open PR that
+# predates it (#5962). Promote it deliberately, not as a side effect.
+name: Test count
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    # Explicit activity types (#4179). `edited` is NOT in GitHub's default set
+    # (opened/synchronize/reopened) and is the event a base-branch RETARGET
+    # fires, so without it a stacked PR retargeted onto main never re-triggers
+    # and can merge with zero checks — PR #3838 did exactly that.
+    # `ready_for_review` covers a draft being marked ready. Matches ci.yml.
+    types: [opened, synchronize, reopened, ready_for_review, edited]
+    branches: [main]
+
+# Per-COMMIT concurrency group on push so a merge never cancels the previous
+# merge's verification (#4179); per-ref group on pull_request so a new push
+# still supersedes the superseded run. Matches ci.yml.
+concurrency:
+  group: test-count-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action != 'edited' }}
+
+jobs:
+  test-count:
+    name: Refuse a test run that ran nothing
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: dtolnay/rust-toolchain@1.94
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: test-count
+
+      # Fixtures first. A guard whose refusing branch is never exercised is
+      # untested code — and this guard exists precisely because "green" was
+      # printed by something that did nothing.
+      - name: Guard selftest (fixtures, no toolchain)
+        run: bash scripts/check_test_count_selftest.sh
+
+      # `trusty-progress` is the smallest crate in the workspace (two
+      # dependencies), so both live cases below compile once and run in seconds.
+      - name: A real zero-match filter must be refused (exit 3)
+        run: |
+          set +e
+          bash scripts/check_test_count.sh -- \
+            cargo test -p trusty-progress --lib no_such_test_name_4307
+          status=$?
+          set -e
+          if [ "$status" -ne 3 ]; then
+            echo "::error::the guard let a zero-match filter through (exit $status)"
+            exit 1
+          fi
+
+      - name: A real matching run must pass (exit 0)
+        run: bash scripts/check_test_count.sh -- cargo test -p trusty-progress --lib

--- a/crates/trusty-git-analytics/Cargo.toml
+++ b/crates/trusty-git-analytics/Cargo.toml
@@ -87,7 +87,11 @@ path = "src/main.rs"
 # edge to trusty-review. `config-cli` already implied it transitively; naming it
 # here makes the dependency the profile transport relies on explicit rather than
 # a side effect of the `config` subcommand staying mounted.
-trusty-common = { workspace = true, features = ["cli-help", "update-check", "config-cli", "inference-client", "monitor-tui", "uds"] }
+# `credentials` (#5983) is the same shape: `collect::linear::client` resolves its
+# API key through `trusty_common::credentials::resolve_key` and scrubs error
+# bodies with `scrub_secrets`, both of which sit behind that feature and both of
+# which arrived here transitively until now.
+trusty-common = { workspace = true, features = ["cli-help", "update-check", "config-cli", "credentials", "inference-client", "monitor-tui", "uds"] }
 # Async runtime
 tokio = { workspace = true }
 # IANA timezone database: JQL date literals are evaluated in the JIRA

--- a/crates/trusty-git-analytics/changelog.d/wave1-tga-batch.md
+++ b/crates/trusty-git-analytics/changelog.d/wave1-tga-batch.md
@@ -1,0 +1,32 @@
+Fixed
+
+- **A short security keyword no longer matches inside a longer word (#4331)** —
+  the Tier-1 exact matcher is an Aho-Corasick substring search, so
+  `kw-security`'s three-letter `rce` keyword fired inside `source`, `resource`,
+  `commerce`, and `enforce`. Any commit carrying one of those words classified
+  as `security` at priority 80 and confidence 0.9, outranking the rule that
+  should have won — measured on `feat(pegasus): S3 SignalStore schema for source
+  events`, which returned `("security", ExactRule, 0.9)`. A match now has to sit
+  on a word boundary, and which of a keyword's two edges are checked comes from
+  the keyword's own spelling, so `cve-` still matches `CVE-2024-1234`.
+- **Linear collection reads its API key through the shared credential resolver
+  (#5983)** — `LinearClient::new` consulted `linear.api_key` and nothing else,
+  so an operator holding the key where the rest of the workspace looks for it
+  (`LINEAR_API_KEY` in the environment, `.env.local`, the OS keychain) could not
+  collect until they hand-edited YAML. Config stays the first tier; when it is
+  silent or expands to empty, resolution falls through to
+  `trusty_common::credentials::resolve_key("linear")`. No CLI is involved on
+  this path, and the error now names every place the key may live.
+- **A test invocation that ran nothing is refused (#4307)** — `cargo test` with
+  a filter matching zero tests exits 0 and prints `ok`, so a filter derived from
+  a `#[path]` module's FILE name reports green having proved nothing.
+  `scripts/check_test_count.sh` wraps a test invocation, sums its
+  `running N tests` lines, and fails when the aggregate across the invocation is
+  zero, passing the command's own exit status through otherwise.
+  `.github/workflows/test-count.yml` runs it against two real cargo invocations
+  each build, alongside `scripts/check_test_count_selftest.sh`'s fixtures.
+- **#4251 needed no change** — the Tier-3/4 fuzzy-fallback gate it asks for
+  landed in PR #4291 (`IdentityResolver::fuzzy_fallback`, the
+  `fuzzy_identity_fallback` config key, and the `ISSUE_4251_MISATTRIBUTIONS`
+  reproduction in `resolver_tests`). Recorded here because the issue was in this
+  batch; the code is unchanged.

--- a/crates/trusty-git-analytics/src/classify/tests.rs
+++ b/crates/trusty-git-analytics/src/classify/tests.rs
@@ -411,6 +411,33 @@ fn security_prose_classifies_to_security() {
     assert_eq!(classify_sync("Address CVE-2023-0001").category, "security");
 }
 
+/// #4331: `kw-security` carries the bare keyword `rce`, and Tier 1 matched it
+/// as an unanchored substring. Every commit whose message contained `source`,
+/// `resource`, `commerce`, or `enforce` therefore classified as security at
+/// priority 80 and confidence 0.9, outranking the rule that should have won.
+/// Measured on the pre-fix tier: `feat(pegasus): S3 SignalStore schema for
+/// source events` returned `("security", ExactRule, 0.9)`.
+#[test]
+fn security_keywords_do_not_fire_inside_a_longer_word() {
+    for msg in [
+        "feat(pegasus): S3 SignalStore schema for source events",
+        "refactor: extract the shared resource pool",
+        "chore: bump the e-commerce sdk",
+        "feat: enforce the per-tenant rate limit",
+    ] {
+        assert_ne!(classify_sync(msg).category, "security", "{msg}");
+    }
+    // The same keywords still classify when they stand alone as words.
+    assert_eq!(
+        classify_sync("Mitigate the RCE the pentest reported").category,
+        "security"
+    );
+    assert_eq!(
+        classify_sync("Patch CVE-2024-1234 in the upload handler").category,
+        "security"
+    );
+}
+
 #[test]
 fn performance_prose_classifies_to_performance() {
     assert_eq!(

--- a/crates/trusty-git-analytics/src/classify/tiers/exact.rs
+++ b/crates/trusty-git-analytics/src/classify/tiers/exact.rs
@@ -4,11 +4,78 @@
 //! Aho-Corasick automaton. On match, the pattern id is mapped back to the
 //! originating rule. If multiple rules match, the one with the highest
 //! [`crate::classify::rules::Rule::priority`] wins.
+//!
+//! A match must sit on a word boundary to count (#4331). Aho-Corasick is a
+//! substring search, so before that rule the three-letter `kw-security`
+//! keyword `rce` fired inside `source`, `resource`, and `commerce`, and every
+//! commit carrying one of those words classified as security at priority 80.
+//! See [`boundaries_for`] for which of a keyword's two edges are checked.
 
 use aho_corasick::{AhoCorasick, AhoCorasickBuilder, MatchKind};
 
 use crate::classify::errors::{ClassifyError, Result};
 use crate::classify::rules::Rule;
+
+/// Which edges of a keyword must land on a word boundary to count as a match.
+///
+/// Why: a keyword's own spelling decides this. `cve-` ends in a hyphen, so
+/// demanding a word boundary after it would reject `CVE-2024-1234`, the exact
+/// text it exists to catch. `rce` ends in a letter, so not demanding one lets
+/// it match inside `source`.
+/// What: `left`/`right` are true when the keyword's first/last character is a
+/// word character, and are the only edges [`match_is_bounded`] checks.
+/// Test: `tests::boundaries_follow_the_keywords_own_edges`.
+#[derive(Clone, Copy)]
+struct Boundaries {
+    /// The character before the match must not be a word character.
+    left: bool,
+    /// The character after the match must not be a word character.
+    right: bool,
+}
+
+/// Word characters for boundary purposes: alphanumerics and `_`.
+fn is_word_char(c: char) -> bool {
+    c.is_alphanumeric() || c == '_'
+}
+
+/// Derive [`Boundaries`] from a keyword's own first and last characters.
+fn boundaries_for(keyword: &str) -> Boundaries {
+    let mut chars = keyword.chars();
+    let first = chars.next();
+    let last = chars.next_back().or(first);
+    Boundaries {
+        left: first.is_some_and(is_word_char),
+        right: last.is_some_and(is_word_char),
+    }
+}
+
+/// Whether a match spanning `start..end` of `haystack` sits on the boundaries
+/// its keyword requires.
+///
+/// Why: this is the whole of the #4331 fix — every other line in this module
+/// is unchanged plumbing.
+/// What: reads the character immediately before `start` and immediately after
+/// `end` and rejects the match when a required edge abuts a word character.
+/// Text that runs off either end of the string is a boundary. Both lookups go
+/// through `str::get`, so a byte offset that is not a character boundary
+/// yields `None` rather than panicking.
+/// Test: `tests::a_short_keyword_does_not_match_inside_a_longer_word`,
+/// `tests::a_keyword_ending_in_punctuation_still_matches_a_following_word`.
+fn match_is_bounded(haystack: &str, start: usize, end: usize, edges: Boundaries) -> bool {
+    if edges.left {
+        let before = haystack.get(..start).and_then(|s| s.chars().next_back());
+        if before.is_some_and(is_word_char) {
+            return false;
+        }
+    }
+    if edges.right {
+        let after = haystack.get(end..).and_then(|s| s.chars().next());
+        if after.is_some_and(is_word_char) {
+            return false;
+        }
+    }
+    true
+}
 
 /// Tier-1 exact matcher.
 pub struct ExactMatcher {
@@ -16,6 +83,8 @@ pub struct ExactMatcher {
     automaton: Option<AhoCorasick>,
     /// For each pattern id, the index of its rule in `rules`.
     pattern_rule_idx: Vec<usize>,
+    /// For each pattern id, the word boundaries that pattern requires (#4331).
+    pattern_boundaries: Vec<Boundaries>,
     /// Owned copy of the input rules.
     rules: Vec<Rule>,
 }
@@ -29,12 +98,14 @@ impl ExactMatcher {
     pub fn new(rules: &[Rule]) -> Result<Self> {
         let mut patterns: Vec<String> = Vec::new();
         let mut pattern_rule_idx: Vec<usize> = Vec::new();
+        let mut pattern_boundaries: Vec<Boundaries> = Vec::new();
 
         for (idx, rule) in rules.iter().enumerate() {
             for kw in &rule.keywords {
                 if kw.is_empty() {
                     continue;
                 }
+                pattern_boundaries.push(boundaries_for(kw));
                 patterns.push(kw.clone());
                 pattern_rule_idx.push(idx);
             }
@@ -54,18 +125,26 @@ impl ExactMatcher {
         Ok(Self {
             automaton,
             pattern_rule_idx,
+            pattern_boundaries,
             rules: rules.to_vec(),
         })
     }
 
     /// Classify `message` using exact keyword matching.
     ///
-    /// Returns the highest-priority matching rule, or `None` if no keyword matches.
+    /// Returns the highest-priority matching rule, or `None` if no keyword
+    /// matches on a word boundary. A match that lands inside a longer word is
+    /// discarded (#4331) — see [`match_is_bounded`].
     pub fn classify(&self, message: &str) -> Option<&Rule> {
         let ac = self.automaton.as_ref()?;
         let mut best: Option<&Rule> = None;
         for m in ac.find_iter(message) {
-            let rule_idx = self.pattern_rule_idx[m.pattern().as_usize()];
+            let pattern = m.pattern().as_usize();
+            let edges = self.pattern_boundaries[pattern];
+            if !match_is_bounded(message, m.start(), m.end(), edges) {
+                continue;
+            }
+            let rule_idx = self.pattern_rule_idx[pattern];
             let rule = &self.rules[rule_idx];
             best = match best {
                 Some(prev) if prev.priority >= rule.priority => Some(prev),
@@ -73,5 +152,76 @@ impl ExactMatcher {
             };
         }
         best
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A rule carrying exactly `keywords`, so a test names its own inputs.
+    fn rule(id: &str, keywords: &[&str]) -> Rule {
+        Rule {
+            id: id.into(),
+            category: id.into(),
+            subcategory: None,
+            keywords: keywords.iter().map(|k| (*k).to_string()).collect(),
+            patterns: vec![],
+            priority: 50,
+            confidence: 0.9,
+        }
+    }
+
+    #[test]
+    fn boundaries_follow_the_keywords_own_edges() {
+        let word = boundaries_for("rce");
+        assert!(word.left && word.right);
+        let trailing_punct = boundaries_for("cve-");
+        assert!(trailing_punct.left && !trailing_punct.right);
+        let leading_punct = boundaries_for("#fix");
+        assert!(!leading_punct.left && leading_punct.right);
+        // A one-character keyword reads the same character for both edges.
+        let single = boundaries_for("v");
+        assert!(single.left && single.right);
+    }
+
+    /// #4331: the defect, at the tier that produced it. Every one of these
+    /// matched before the boundary check and classified as `security`.
+    #[test]
+    fn a_short_keyword_does_not_match_inside_a_longer_word() {
+        let m = ExactMatcher::new(&[rule("security", &["rce"])]).expect("build");
+        for msg in [
+            "SignalStore schema for source events",
+            "extract shared resource pool",
+            "bump the e-commerce sdk",
+            "enforce the rate limit",
+        ] {
+            assert!(m.classify(msg).is_none(), "{msg}");
+        }
+        assert!(m.classify("mitigate the RCE the pentest found").is_some());
+    }
+
+    #[test]
+    fn a_keyword_ending_in_punctuation_still_matches_a_following_word() {
+        let m = ExactMatcher::new(&[rule("security", &["cve-"])]).expect("build");
+        assert!(m.classify("patch CVE-2024-1234").is_some());
+        // The leading edge is still a letter, so it stays boundary-checked.
+        assert!(m.classify("recve-2024-1234").is_none());
+    }
+
+    #[test]
+    fn multi_word_keywords_are_unaffected() {
+        let m = ExactMatcher::new(&[rule("bugfix", &["fix bug", "closes #"])]).expect("build");
+        assert!(m.classify("fix bug in the parser").is_some());
+        assert!(m.classify("closes #4331").is_some());
+        assert!(m.classify("prefix bug").is_none());
+    }
+
+    /// A non-ASCII haystack must not panic the byte-offset boundary lookup.
+    #[test]
+    fn a_multibyte_haystack_is_scored_without_panicking() {
+        let m = ExactMatcher::new(&[rule("security", &["rce"])]).expect("build");
+        assert!(m.classify("refactor — drop the résumé parser").is_none());
+        assert!(m.classify("— RCE —").is_some());
     }
 }

--- a/crates/trusty-git-analytics/src/collect/linear/client.rs
+++ b/crates/trusty-git-analytics/src/collect/linear/client.rs
@@ -2,6 +2,9 @@
 //!
 //! Uses the Linear GraphQL API (<https://api.linear.app/graphql>).
 //! Authentication: `Authorization: <api_key>` header (no "Bearer" prefix).
+//! The key comes from `linear.api_key` in config, or — when config is silent —
+//! from `trusty_common::credentials::resolve_key` (#5983). There is no Linear
+//! CLI on this path.
 //!
 //! Issue identifiers are matched against commit messages with the pattern
 //! `[A-Z][A-Z0-9]{0,9}-\d+` (e.g. `ENG-123`, `FE-456`).
@@ -95,18 +98,16 @@ impl std::fmt::Debug for LinearClient {
 impl LinearClient {
     /// Create a new Linear client from config.
     ///
-    /// Resolves `${LINEAR_API_KEY}` env var substitution in the `api_key` field.
+    /// Resolves the API key through [`resolve_api_key`]: `linear.api_key` from
+    /// config first (with `${LINEAR_API_KEY}` expansion), then the shared
+    /// credential resolver (#5983).
     ///
     /// # Errors
     ///
-    /// - [`CollectError::Config`] if `api_key` is missing or resolves to empty.
+    /// - [`CollectError::Config`] if no tier yields a non-empty key.
     /// - [`CollectError::Http`] if the HTTP client cannot be built.
     pub fn new(config: &LinearConfig) -> Result<Self> {
-        let raw_key = config.api_key.as_deref().unwrap_or("");
-        let api_key = expand_env_var(raw_key);
-        if api_key.is_empty() {
-            return Err(CollectError::Config("Linear api_key is required".into()));
-        }
+        let api_key = resolve_api_key(config)?;
         let client = Client::builder()
             .user_agent(USER_AGENT_VALUE)
             .timeout(std::time::Duration::from_secs(30))
@@ -408,6 +409,68 @@ fn expand_env_var(raw: &str) -> String {
     crate::collect::env_expand::expand_env_var(raw)
 }
 
+/// Provider key this client resolves its credential under.
+///
+/// The workspace registry maps it to `LINEAR_API_KEY`
+/// (`trusty_common::credentials::registry`).
+const LINEAR_CREDENTIAL_PROVIDER: &str = "linear";
+
+/// The Linear API key this client will authenticate with.
+///
+/// Why: #5983. Collection used to read `linear.api_key` and nothing else, so an
+/// operator holding the credential anywhere the rest of the workspace looks —
+/// `LINEAR_API_KEY` in the environment, `.env.local`, the OS keychain — still
+/// could not collect until they hand-edited YAML to say `${LINEAR_API_KEY}`.
+/// Config stays the first tier; the shared resolver is what answers when config
+/// is silent, which is the one entry point this repo permits for reading a
+/// secret across crates.
+/// What: delegates to [`resolve_api_key_with`] with
+/// [`trusty_common::credentials::resolve_key`] as the fallback.
+///
+/// # Errors
+///
+/// [`CollectError::Config`] when neither tier yields a non-empty key.
+fn resolve_api_key(config: &LinearConfig) -> Result<String> {
+    resolve_api_key_with(config, || {
+        trusty_common::credentials::resolve_key(LINEAR_CREDENTIAL_PROVIDER)
+    })
+}
+
+/// [`resolve_api_key`] with the fallback tier supplied by the caller.
+///
+/// Why: the production fallback reads the process environment, `.env.local`,
+/// and an OS keychain, none of which a test may depend on. A caller-supplied
+/// lookup makes both tiers and the failure provable with no global state — the
+/// same seam `collect::env_expand::expand_env_var_with` uses for #5313.
+/// What: returns the expanded `config.api_key` when it is non-empty; otherwise
+/// `fallback()`, ignoring an empty answer the same way; otherwise an error
+/// naming every place the operator may put the key.
+/// Test: `tests::config_api_key_wins_over_the_resolver`,
+/// `tests::an_absent_config_key_falls_back_to_the_resolver`,
+/// `tests::an_empty_resolver_answer_is_not_a_key`,
+/// `tests::new_rejects_missing_api_key`.
+///
+/// # Errors
+///
+/// [`CollectError::Config`] when neither tier yields a non-empty key.
+fn resolve_api_key_with(
+    config: &LinearConfig,
+    fallback: impl FnOnce() -> Option<String>,
+) -> Result<String> {
+    let configured = expand_env_var(config.api_key.as_deref().unwrap_or(""));
+    if !configured.is_empty() {
+        return Ok(configured);
+    }
+    fallback().filter(|k| !k.is_empty()).ok_or_else(|| {
+        CollectError::Config(
+            "Linear api_key is required — set `linear.api_key` in the config (a \
+             `${LINEAR_API_KEY}` reference is expanded), or provide LINEAR_API_KEY \
+             in the environment, in .env.local, or in the credential store"
+                .into(),
+        )
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -435,12 +498,61 @@ mod tests {
         assert!(ids.is_empty());
     }
 
+    /// #5983: asserted against [`resolve_api_key_with`], not `LinearClient::new`.
+    /// `new` now consults the shared credential resolver, which reads the real
+    /// environment, `.env.local`, and the OS keychain — so on a developer
+    /// machine that exports `LINEAR_API_KEY` this test would have started
+    /// passing the resolution it exists to prove fails.
     #[test]
     fn new_rejects_missing_api_key() {
         let cfg = LinearConfig::default();
-        let err = LinearClient::new(&cfg).expect_err("should reject empty key");
+        let err = resolve_api_key_with(&cfg, || None).expect_err("should reject empty key");
         match err {
             CollectError::Config(msg) => assert!(msg.contains("api_key")),
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    /// #5983: config is the first tier, so a key on disk is never overridden by
+    /// whatever the environment or keychain happens to hold.
+    #[test]
+    fn config_api_key_wins_over_the_resolver() {
+        let cfg = LinearConfig {
+            api_key: Some("lin_api_from_config".into()),
+            ..LinearConfig::default()
+        };
+        let key = resolve_api_key_with(&cfg, || Some("lin_api_from_store".into())).expect("key");
+        assert_eq!(key, "lin_api_from_config");
+    }
+
+    /// #5983 (primary reproduction): before the fix this path returned
+    /// `CollectError::Config`, so an operator whose key lived in the
+    /// environment, `.env.local`, or the keychain could not collect at all.
+    #[test]
+    fn an_absent_config_key_falls_back_to_the_resolver() {
+        let cfg = LinearConfig::default();
+        let key = resolve_api_key_with(&cfg, || Some("lin_api_from_store".into())).expect("key");
+        assert_eq!(key, "lin_api_from_store");
+        // An unresolvable `${VAR}` placeholder expands to empty, which is the
+        // same "config said nothing" state and must reach the same tier.
+        let placeholder = LinearConfig {
+            api_key: Some("${TGA_LINEAR_KEY_THAT_IS_NEVER_SET}".into()),
+            ..LinearConfig::default()
+        };
+        let key =
+            resolve_api_key_with(&placeholder, || Some("lin_api_from_store".into())).expect("key");
+        assert_eq!(key, "lin_api_from_store");
+    }
+
+    /// An empty answer from the resolver is absence, not a key — otherwise the
+    /// client would send `Authorization: ` and read Linear's 401 as a defect.
+    #[test]
+    fn an_empty_resolver_answer_is_not_a_key() {
+        let cfg = LinearConfig::default();
+        let err = resolve_api_key_with(&cfg, || Some(String::new()))
+            .expect_err("empty is not a credential");
+        match err {
+            CollectError::Config(msg) => assert!(msg.contains("LINEAR_API_KEY"), "{msg}"),
             other => panic!("unexpected: {other:?}"),
         }
     }

--- a/scripts/check_test_count.sh
+++ b/scripts/check_test_count.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+#
+# check_test_count.sh — refuse a test invocation that ran nothing (issue #4307).
+#
+# Why: `cargo test` with a filter that matches zero tests exits 0 and prints
+#   `test result: ok. 0 passed; 775 filtered out`. Where a test module's file
+#   path differs from its module path via `#[path]`, the natural filter — the
+#   one derived from the file name — silently matches nothing, and the run
+#   reports green having proved nothing. On origin/main at the time of filing,
+#   231 of 319 `#[path]`-attached test modules across 13 crates had a file stem
+#   that does not resolve as a filter. This is the same silent-vacuous-pass
+#   family as #5354 (a failing target hides the ones behind it) and #4901 (a
+#   non-default feature compiles a module out).
+#
+# What: wraps a test invocation, captures its output, sums the `running N tests`
+#   lines it emitted, and fails when the AGGREGATE across the whole invocation is
+#   zero. Aggregate, not per-binary: `cargo test` prints one `running N tests`
+#   line per test target, and a legitimately empty target is normal when a crate
+#   has tests in only some of them.
+#
+#   The wrapped command's own exit status is preserved. This gate only ADDS a
+#   failure mode; it never turns a red run green.
+#
+# Usage:
+#   scripts/check_test_count.sh -- cargo test -p tga --lib collect::identity::resolver::
+#   scripts/check_test_count.sh --from-file <captured output>   # self-test seam
+#
+# Exit codes:
+#   0  the command succeeded and ran at least one test
+#   1  the command itself failed (its status is passed through)
+#   3  VACUOUS: the command succeeded but ran zero tests
+#   2  usage error
+#
+# Test: scripts/check_test_count_selftest.sh, and the real wrapped runs in
+#   .github/workflows/test-count.yml.
+
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+usage: scripts/check_test_count.sh -- <test command...>
+       scripts/check_test_count.sh --from-file <path>
+
+  --                 everything after this is the command to run
+  --from-file <path> score already-captured output instead of running anything
+USAGE
+  exit 2
+}
+
+FROM_FILE=""
+case "${1:-}" in
+  --from-file)
+    [ $# -eq 2 ] || usage
+    FROM_FILE="$2"
+    ;;
+  --)
+    shift
+    [ $# -ge 1 ] || usage
+    ;;
+  *)
+    usage
+    ;;
+esac
+
+# Sum every `running N tests` line. Also recognises `cargo nextest`'s
+# `Starting N tests across M binaries`, so wrapping either runner is scored
+# rather than reported as a false vacuum.
+#
+# The awk program reads a FILE, never a pipe from the live command — a pipeline
+# would hand back awk's exit status instead of the command's.
+count_tests() {
+  awk '
+    /^running [0-9]+ tests?$/            { total += $2; seen = 1 }
+    /Starting [0-9]+ tests? across/      { for (i = 1; i <= NF; i++) if ($i == "Starting") { total += $(i + 1); seen = 1 } }
+    END { print (seen ? total : 0) }
+  ' "$1"
+}
+
+if [ -n "$FROM_FILE" ]; then
+  if [ ! -f "$FROM_FILE" ]; then
+    echo "check_test_count: no such file: $FROM_FILE" >&2
+    exit 2
+  fi
+  OUTPUT="$FROM_FILE"
+  STATUS=0
+  LABEL="(captured) $FROM_FILE"
+else
+  OUTPUT="$(mktemp -t check_test_count.XXXXXX)"
+  # shellcheck disable=SC2064 # expand OUTPUT now, not at trap time
+  trap "rm -f '$OUTPUT'" EXIT
+  LABEL="$*"
+  STATUS=0
+  "$@" > "$OUTPUT" 2>&1 || STATUS=$?
+  cat "$OUTPUT"
+fi
+
+RAN="$(count_tests "$OUTPUT")"
+
+if [ "$STATUS" -ne 0 ]; then
+  echo "check_test_count: FAIL — the command exited $STATUS (ran $RAN test(s)): $LABEL" >&2
+  exit "$STATUS"
+fi
+
+if [ "$RAN" -eq 0 ]; then
+  cat >&2 <<EOF
+check_test_count: VACUOUS — the command exited 0 having run 0 tests.
+
+  command: $LABEL
+
+A zero-match filter reports \`ok\`, so this run proved nothing. Check the filter
+against the MODULE path, not the file name: a \`#[path = "foo_tests.rs"] mod
+tests;\` module is filtered as \`…::foo::tests\`, never \`…::foo_tests\` (#4307).
+EOF
+  exit 3
+fi
+
+echo "check_test_count: OK — $RAN test(s) ran: $LABEL"

--- a/scripts/check_test_count_selftest.sh
+++ b/scripts/check_test_count_selftest.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+#
+# check_test_count_selftest.sh — prove scripts/check_test_count.sh can fail.
+#
+# Why: the gate's whole value is the branch that refuses a zero-count run. A
+#   guard whose failing branch is never exercised is untested code, and #4307 is
+#   precisely a case of "green" being printed by something that did nothing —
+#   the gate must not repeat the defect it exists to catch.
+#
+# What: drives the gate over captured `cargo test` output fixtures (the real
+#   shapes from the issue's reproduction) plus live commands, and asserts the
+#   exit code for each: 0 for a run with tests, 3 for a vacuous one, and the
+#   command's own status when the command fails.
+#
+# Exit codes: 0 = every case behaved; 1 = a case did not.
+#
+# Test: this IS the test; .github/workflows/test-count.yml runs it.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GATE="${SCRIPT_DIR}/check_test_count.sh"
+WORK="$(mktemp -d -t check_test_count_selftest.XXXXXX)"
+trap 'rm -rf "$WORK"' EXIT
+
+FAILURES=0
+
+# Assert that running the gate the given way exits with $1.
+expect_exit() {
+  local want="$1" name="$2"
+  shift 2
+  local got=0
+  "$@" > "${WORK}/out.txt" 2>&1 || got=$?
+  if [ "$got" -eq "$want" ]; then
+    echo "  ok    $name (exit $got)"
+  else
+    echo "  FAIL  $name — wanted exit $want, got $got" >&2
+    sed 's/^/        /' "${WORK}/out.txt" >&2
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+echo "check_test_count selftest"
+
+# ── Fixtures: the two runs from #4307, captured verbatim in shape ──
+
+# The mistyped filter. `resolver_tests` is the FILE stem; the module is
+# `collect::identity::resolver::tests`, so this matches nothing and cargo
+# still prints `ok`.
+cat > "${WORK}/vacuous.txt" <<'EOF'
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.09s
+     Running unittests src/lib.rs (target/debug/deps/tga-1f0e3dad99908345)
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 775 filtered out; finished in 0.00s
+EOF
+
+# The correct filter.
+cat > "${WORK}/real.txt" <<'EOF'
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.09s
+     Running unittests src/lib.rs (target/debug/deps/tga-1f0e3dad99908345)
+
+running 33 tests
+
+test result: ok. 33 passed; 0 failed; 0 ignored; 0 measured; 742 filtered out; finished in 0.02s
+EOF
+
+# Several targets, only some of which carry tests — the aggregate is what counts.
+cat > "${WORK}/multi.txt" <<'EOF'
+     Running unittests src/lib.rs (target/debug/deps/tga-aaa)
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 12 filtered out; finished in 0.00s
+
+     Running tests/audit_sweep.rs (target/debug/deps/audit_sweep-bbb)
+
+running 4 tests
+
+test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.10s
+EOF
+
+# Every target empty — an aggregate of zero, which is the failure.
+cat > "${WORK}/multi_empty.txt" <<'EOF'
+     Running unittests src/lib.rs (target/debug/deps/tga-aaa)
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 12 filtered out; finished in 0.00s
+
+     Running tests/audit_sweep.rs (target/debug/deps/audit_sweep-bbb)
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 3 filtered out; finished in 0.00s
+EOF
+
+# cargo nextest's own shape.
+cat > "${WORK}/nextest.txt" <<'EOF'
+    Starting 27 tests across 9 binaries (441 skipped)
+        PASS [   0.005s] tga collect::identity::resolver::tests::alias_wins
+     Summary [   0.041s] 27 tests run: 27 passed, 441 skipped
+EOF
+
+expect_exit 3 "the mistyped filter from #4307 is refused" \
+  bash "$GATE" --from-file "${WORK}/vacuous.txt"
+expect_exit 0 "the correct filter passes" \
+  bash "$GATE" --from-file "${WORK}/real.txt"
+expect_exit 0 "an empty target alongside a non-empty one passes" \
+  bash "$GATE" --from-file "${WORK}/multi.txt"
+expect_exit 3 "every target empty is refused" \
+  bash "$GATE" --from-file "${WORK}/multi_empty.txt"
+expect_exit 0 "cargo nextest output is scored, not read as a vacuum" \
+  bash "$GATE" --from-file "${WORK}/nextest.txt"
+
+# ── Live commands: the wrapper must not swallow a real failure ──
+
+expect_exit 3 "a live command that prints a zero-count run is refused" \
+  bash "$GATE" -- printf 'running 0 tests\ntest result: ok. 0 passed; 12 filtered out\n'
+expect_exit 0 "a live command that prints a real count passes" \
+  bash "$GATE" -- printf 'running 7 tests\ntest result: ok. 7 passed; 0 filtered out\n'
+expect_exit 1 "a failing command keeps its own exit status" \
+  bash "$GATE" -- sh -c 'echo "running 3 tests"; echo "test result: FAILED. 2 passed; 1 failed"; exit 1'
+expect_exit 101 "a cargo-shaped exit 101 is passed through, not rewritten" \
+  bash "$GATE" -- sh -c 'echo "error: could not compile"; exit 101'
+
+# ── Usage errors ──
+
+expect_exit 2 "no arguments is a usage error" bash "$GATE"
+expect_exit 2 "--from-file on a missing path is a usage error" \
+  bash "$GATE" --from-file "${WORK}/does-not-exist.txt"
+
+if [ "$FAILURES" -ne 0 ]; then
+  echo "check_test_count selftest: $FAILURES case(s) failed" >&2
+  exit 1
+fi
+
+echo "check_test_count selftest: all cases passed"


### PR DESCRIPTION
Wave-1 batch over `tga`. Four issues, three of which needed code.

- `Refs #4331` — Tier 1 is an Aho-Corasick substring search, so `kw-security`'s three-letter `rce` keyword matched inside `source`, `resource`, `commerce`, and `enforce`, classifying those commits as security at priority 80. A match now has to sit on a word boundary, with each keyword's own first and last character deciding which edges are checked, so `cve-` still matches `CVE-2024-1234`. The issue's second finding (a built-in ticket-key map sending `PROP-*` to security) has no mechanism in this crate — `jira_project_mappings` is operator config with no built-in entries, and the reported `method='exact_rule'` / `subcategory=NULL` evidence points at `kw-security`, the rule this fixes.
- `Refs #5983` — `LinearClient::new` read `linear.api_key` and nothing else, so an operator holding the key in the environment, `.env.local`, or the keychain could not collect. Config stays the first tier; when it is silent, resolution falls through to `trusty_common::credentials::resolve_key("linear")`. Per the 2026-08-19 owner ruling, which superseded the CLI direction in the issue title. No trusty-common change was needed.
- `Refs #4307` — `scripts/check_test_count.sh` wraps a test invocation, sums its `running N tests` lines, and fails when the aggregate is zero, passing the command's own exit status through otherwise. `.github/workflows/test-count.yml` runs it against two real cargo invocations each build; `scripts/check_test_count_selftest.sh` covers the fixtures and the pass-through. Not a required context — see #5962.
- `Refs #4251` — no code change. PR #4291 already landed the Tier-3/4 fuzzy-fallback gate this asks for: `IdentityResolver::fuzzy_fallback`, the `fuzzy_identity_fallback` config key, and the `ISSUE_4251_MISATTRIBUTIONS` reproduction in `resolver_tests`. The issue is open on lifecycle only.

## Test ladder

Rung 3, localized behaviour in one crate. Each fix carries a regression test proven to fail on the pre-fix code by inverting the fix and re-running.

- #4331 inverted (boundary check skipped): `security_keywords_do_not_fire_inside_a_longer_word`, `a_short_keyword_does_not_match_inside_a_longer_word`, `a_keyword_ending_in_punctuation_still_matches_a_following_word`, and `multi_word_keywords_are_unaffected` all FAILED — `test result: FAILED. 1391 passed; 4 failed`.
- #5983 inverted (fallback tier dropped): `an_absent_config_key_falls_back_to_the_resolver` FAILED.

## Gates

```
cargo fmt --check                                      EXIT=0
cargo check -p tga                                     EXIT=0
cargo clippy -p tga --all-targets -- -D warnings       EXIT=0
cargo test -p tga --no-fail-fast                       EXIT=0
  test result: ok. 1395 passed; 0 failed; 7 ignored    (lib, 1402 targets)
  10 further targets, all ok
bash scripts/check_test_pointers.sh                    27789 citations, 0 dangling
bash scripts/check_line_cap.sh                         4291 files, 0 violations
bash scripts/check_sld.sh                              0 errors, 0 warnings
CHANGELOG_BASE=origin/main scripts/check_changelog_fragment.sh   OK
bash scripts/check_test_count_selftest.sh              11/11 cases
```

#4307's own acceptance, both against live cargo:

```
$ scripts/check_test_count.sh -- cargo test -p tga --lib collect::identity::resolver_tests
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1402 filtered out
check_test_count: VACUOUS — the command exited 0 having run 0 tests.
exit 3

$ scripts/check_test_count.sh -- cargo test -p tga --lib collect::identity::resolver::
test result: ok. 33 passed; 0 failed; 0 ignored; 0 measured; 1369 filtered out
check_test_count: OK — 33 test(s) ran
exit 0
```

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
