### PR TITLE
fix(trusty-mpm): probe the tmux listing, not the binary, before asserting a reap (Refs #6411)

### DIFF
--- a/crates/trusty-mpm/changelog.d/6411-reap-tmux-visibility-probe.md
+++ b/crates/trusty-mpm/changelog.d/6411-reap-tmux-visibility-probe.md
@@ -1,0 +1,17 @@
+Fixed
+
+- The tmux reap-parity test no longer predicts reap's behaviour from whether the
+  `tmux` binary resolves
+  (refs [#6411](https://github.com/bobmatnyc/trusty-tools/issues/6411)).
+  `DaemonState::reap_dead_sessions` reaps nothing when `list-sessions` fails, and
+  on a host where no tmux server has ever run that listing fails with
+  `error connecting to <socket> (No such file or directory)` — a string
+  `TmuxDriver::list_sessions` deliberately does not classify as an empty server,
+  so a registry is never wiped by an unreachable tmux. `TmuxDriver::discover()`
+  succeeds on that same host, because the binary is installed, so gating on it
+  expected a removal that could not happen and turned `main` red. The probe now
+  runs the listing itself.
+- The `no server running` / `no sessions` stderr classification is one named
+  function, `stderr_means_empty_server`, instead of the same pair of `contains`
+  calls at three listing sites, so the boundary between an empty server and an
+  unreachable one cannot drift between them.

--- a/crates/trusty-mpm/src/daemon/rpc/sessions_legacy_tests.rs
+++ b/crates/trusty-mpm/src/daemon/rpc/sessions_legacy_tests.rs
@@ -553,10 +553,17 @@ async fn parity_sessions_reap_agrees_across_transports() {
 /// and on one without, and no test here has to start a tmux server. The victim
 /// is a tmux-origin session whose UUID-derived name no tmux server is hosting.
 ///
-/// Whether the victim is actually removed depends on tmux being reachable —
-/// `SessionService::reap` reaps NOTHING when `TmuxDriver::discover` fails,
-/// deliberately, so that a missing tmux cannot wipe the registry. So the
-/// removal is asserted under that condition and the PARITY is asserted
+/// Whether the victim is actually removed depends on what reap can SEE of
+/// tmux, and the precondition has to be the same question reap asks.
+/// `DaemonState::reap_dead_sessions` reaps nothing when `driver.list_sessions`
+/// fails, deliberately, so that an unreachable tmux cannot wipe the registry —
+/// and on a host where no tmux server has ever run that listing DOES fail,
+/// with `error connecting to <socket> (No such file or directory)`, which
+/// `TmuxDriver::list_sessions` does not classify as an empty server. A CI
+/// runner is exactly that host. Probing `TmuxDriver::discover().is_ok()`
+/// instead asks only whether the tmux BINARY resolves, which is true there and
+/// made `main` red (#6411). So the probe below runs the listing itself.
+/// The removal is asserted under that condition and the PARITY is asserted
 /// unconditionally: whatever this host let reap do, both transports did the
 /// same thing.
 ///
@@ -572,7 +579,11 @@ async fn parity_sessions_reap_removes_the_dead_and_spares_the_live_on_both_trans
     use crate::core::session::SessionHost;
 
     let (state, _dir) = hermetic();
-    let tmux_reachable = crate::daemon::tmux::TmuxDriver::discover().is_ok();
+    // #6411: ask the question reap asks — can it LIST the live set? — not the
+    // weaker "does the tmux binary resolve".
+    let reap_sees_tmux = crate::daemon::tmux::TmuxDriver::discover()
+        .and_then(|driver| driver.list_sessions())
+        .is_ok();
 
     // The survivor: native origin, so the tmux liveness rule skips it entirely.
     let survivor = SessionId::new();
@@ -599,11 +610,11 @@ async fn parity_sessions_reap_removes_the_dead_and_spares_the_live_on_both_trans
         state.session(survivor).is_some(),
         "the socket must spare it too"
     );
-    if tmux_reachable {
+    if reap_sees_tmux {
         assert_eq!(
             result["removed"],
             json!(1),
-            "with tmux reachable each transport must reap exactly its own victim: {result}"
+            "with the tmux listing readable each transport must reap exactly its own victim: {result}"
         );
         assert!(state.session(victim_http).is_none(), "HTTP must reap it");
         assert!(state.session(victim_rpc).is_none(), "the socket must too");
@@ -616,7 +627,7 @@ async fn parity_sessions_reap_removes_the_dead_and_spares_the_live_on_both_trans
         assert_eq!(
             result["removed"],
             json!(0),
-            "with tmux unreachable neither transport may reap anything: {result}"
+            "with the tmux listing unreadable neither transport may reap anything: {result}"
         );
         assert!(
             state.session(victim_http).is_some(),

--- a/crates/trusty-mpm/src/daemon/tmux.rs
+++ b/crates/trusty-mpm/src/daemon/tmux.rs
@@ -171,6 +171,30 @@ impl SessionInfo {
     }
 }
 
+/// True when a non-zero `tmux` listing means "the server is up but empty".
+///
+/// Why: `list-sessions` and `list-panes -a` both exit non-zero on a quiet host,
+/// and three call sites classified that stderr independently. Naming the rule
+/// once keeps them from drifting, and the name matters because the rule is
+/// NARROW on purpose. A host where no tmux server has ever run does not print
+/// `no server running`; it prints
+/// `error connecting to <socket> (No such file or directory)`, which this
+/// refuses, so the caller gets an `Err` and
+/// [`DaemonState::reap_dead_sessions`](crate::daemon::state::DaemonState::reap_dead_sessions)
+/// reaps nothing rather than mistaking an unreachable server for an empty one
+/// and deleting every registered session.
+///
+/// The consequence for callers is the one that made `main` red in #6411:
+/// `TmuxDriver::discover().is_ok()` says the BINARY resolves, which is a
+/// strictly weaker claim than "a listing will succeed". Never use the former to
+/// predict the latter.
+/// What: matches the two tmux spellings for an empty server, and nothing else.
+/// Test: `empty_server_stderr_is_an_empty_list`,
+/// `unreachable_socket_stderr_is_not_an_empty_list`.
+fn stderr_means_empty_server(stderr: &str) -> bool {
+    stderr.contains("no server running") || stderr.contains("no sessions")
+}
+
 /// Drives the `tmux` binary on behalf of the daemon's session manager.
 ///
 /// Why: hosting Claude Code inside tmux is the primary control model; the
@@ -407,7 +431,7 @@ impl TmuxDriver {
         let output = Command::new(&self.tmux_path).args(&argv).output()?;
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            if stderr.contains("no server running") || stderr.contains("no sessions") {
+            if stderr_means_empty_server(&stderr) {
                 return Ok(Vec::new());
             }
             return Err(Error::Protocol(format!("tmux list-sessions: {stderr}")));
@@ -527,7 +551,7 @@ impl TmuxDriver {
             .output()?;
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            if stderr.contains("no server running") || stderr.contains("no sessions") {
+            if stderr_means_empty_server(&stderr) {
                 return Ok(String::new());
             }
             return Err(Error::Protocol(format!("tmux list-panes -a: {stderr}")));
@@ -563,7 +587,7 @@ impl TmuxDriver {
             .output()?;
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            if stderr.contains("no server running") || stderr.contains("no sessions") {
+            if stderr_means_empty_server(&stderr) {
                 return Ok(Vec::new());
             }
             return Err(Error::Protocol(format!("tmux list-panes -a: {stderr}")));

--- a/crates/trusty-mpm/src/daemon/tmux_tests.rs
+++ b/crates/trusty-mpm/src/daemon/tmux_tests.rs
@@ -333,3 +333,53 @@ fn ensure_server_up_fails_loudly_when_the_server_never_comes_up() {
         "must surface as a Protocol error: {err:?}"
     );
 }
+
+// ── #6411: the empty-server stderr classification boundary ──────────────
+
+#[test]
+fn empty_server_stderr_is_an_empty_list() {
+    // The two spellings real tmux emits when the SERVER is up and holds
+    // nothing. Both mean "there is nothing to list", so every listing maps
+    // them to an empty collection rather than an error.
+    assert!(stderr_means_empty_server(
+        "no server running on /tmp/tmux-501/default\n"
+    ));
+    assert!(stderr_means_empty_server("no sessions\n"));
+}
+
+#[test]
+fn unreachable_socket_stderr_is_not_an_empty_list() {
+    // What real tmux prints on a host where no server has EVER run: the
+    // socket path does not exist yet. That is not an empty server, and
+    // classifying it as one would let `reap_dead_sessions` see an empty live
+    // set and delete every registered tmux session, so it must stay an Err.
+    //
+    // This is the gap that made `main` red: `TmuxDriver::discover()` succeeds
+    // on such a host (the BINARY resolves) while every listing fails, so
+    // `discover().is_ok()` must never be used to predict a reap outcome.
+    assert!(!stderr_means_empty_server(
+        "error connecting to /tmp/tmux-501/default (No such file or directory)"
+    ));
+    assert!(!stderr_means_empty_server("lost server"));
+}
+
+#[test]
+fn list_sessions_errors_on_a_host_whose_tmux_server_never_ran() {
+    // The end-to-end shape of the gap, through the real method: a tmux that
+    // resolves fine but cannot reach a server. `list_sessions` must return
+    // Err, because `reap_dead_sessions` turns an Err into "reap nothing" and
+    // an Ok(empty) into "every registered tmux session is dead". A caller
+    // that gated on binary resolution alone would predict the wrong one.
+    let dir = tempfile::tempdir().unwrap();
+    let script = "#!/bin/sh\necho 'error connecting to /tmp/tmux-501/default (No such file or directory)' >&2\nexit 1\n";
+    let bin = write_fake_tmux(dir.path(), "fake-tmux-no-server", script);
+    let driver = TmuxDriver { tmux_path: bin };
+
+    let err = driver
+        .list_sessions()
+        .expect_err("an unreachable tmux server must not read as an empty session list");
+    assert!(
+        matches!(err, Error::Protocol(_)),
+        "must surface as a Protocol error: {err:?}"
+    );
+}


### PR DESCRIPTION
The reap-parity test gated its removal assertion on `TmuxDriver::discover().is_ok()`, which only says the tmux binary resolves, while `reap_dead_sessions` branches on `driver.list_sessions()` succeeding — and on a runner where no tmux server has ever run the binary resolves but the listing fails with `error connecting to <socket> (No such file or directory)`, which `list_sessions` deliberately does not read as an empty server. The probe now runs the listing itself, and the `no server running` / `no sessions` classification moves into one named function so the three listing sites cannot drift apart on that boundary.

Rung 3. `cargo fmt --check`, `cargo check -p trusty-mpm`, `cargo clippy -p trusty-mpm --all-targets -- -D warnings` all clean; `cargo test -p trusty-mpm --no-fail-fast` gives `5521 passed; 1 failed` where the one failure is `parity_doctor_agrees_across_transports`, a live-daemon flake outside this diff that passes in isolation (`1 passed; 0 failed`). Reproduced deterministically by putting a `tmux` that resolves but cannot reach a server first on PATH: pre-fix the test panics at `sessions_legacy_tests.rs:603` with `{"removed":0,"stopped":0}`, byte-for-byte the CI failure; post-fix it passes.

Refs #6411

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools