### PR TITLE
fix(trusty-common): wave-1 — bare test run can no longer pass vacuously; coverage feature-sets stated checkably

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,22 @@ cargo test -p trusty-common --features unconditional-only                 # only
 - `cargo build` / `cargo check -p trusty-common` are unaffected.
   `--all-features` is unavailable — the `embedder-*` ORT variants are mutually
   exclusive.
+- 🔴 **Naming a feature covers that feature and nothing else (#4474).** A run
+  that names one is a deliberate, visible choice, and the guard above lets it
+  through — but `--features inference-client` never compiled
+  `inference::bedrock`, which sits behind `bedrock-client`. What full coverage
+  means is stated in `[package.metadata.trusty-test-coverage]` in
+  `crates/trusty-common/Cargo.toml`: four lanes (`unconditional`, `core`,
+  `inference`, `symgraph`) plus exemptions that each say why no lane runs them.
+  `tests/feature_coverage.rs` fails when a declared feature is in neither, so
+  the statement cannot rot. Run every lane at a hardening boundary — it builds a
+  bundled ONNX Runtime, so it is not an inner-loop command:
+
+  ```bash
+  bash scripts/test_trusty_common_lanes.sh          # every lane
+  bash scripts/test_trusty_common_lanes.sh core     # one lane by name
+  ```
+
 - 🟡 Other crates hide the same trap: before trusting a crate-scoped green, check
   whether the module you edited sits behind a non-default feature.
 

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -49,6 +49,71 @@ keywords = ["mcp", "utilities", "cli", "openrouter"]
 categories = ["command-line-utilities"]
 homepage = "https://github.com/bobmatnyc/trusty-tools"
 
+# #4474: which feature sets constitute full test coverage of this crate, stated
+# where a machine can read it.
+#
+# Why: `default = []` and 47 opt-in features mean no single `cargo test -p
+# trusty-common` run covers the crate. Which combination does was tribal
+# knowledge, so a new feature could ship with tests nothing ever ran —
+# `inference-client` missed `inference::bedrock`, and `credentials`,
+# `session-naming` and `memory-core` each went unrun for a whole PR.
+# What: `lanes` are the feature sets that together cover every declared
+# feature; `exempt` names the features no lane can run, each with the reason.
+# `tests/feature_coverage.rs` resolves every lane's transitive feature closure
+# from the `[features]` table below and fails when the union plus `exempt` is
+# not exactly that table, so adding a feature without placing it fails a test.
+# `scripts/test_trusty_common_lanes.sh` reads these same rows and runs them, so
+# the runner cannot drift from the statement.
+# Test: `every_declared_feature_is_covered_by_a_lane_or_exempted`,
+# `lanes_and_exemptions_name_only_declared_features`,
+# `every_exemption_states_a_reason` (`tests/feature_coverage.rs`).
+[package.metadata.trusty-test-coverage]
+lanes = [
+    { name = "unconditional", features = [
+        "unconditional-only",
+    ] },
+    { name = "core", features = [
+        "memory-core",
+        "embedder-test-support",
+        "embedder-client",
+        "catchup",
+        "monitor-tui",
+        "search-index",
+        "uds-supervisor",
+        "webhook-relay",
+        "bm25",
+        "migrations",
+        "docgen",
+        "cli-help",
+        "crate-config",
+        "codex-config",
+        "console-metrics",
+        "update-check",
+        "bug-capture",
+        "session-naming",
+        "rpc",
+    ] },
+    { name = "inference", features = [
+        "bedrock-client",
+        "config-cli",
+        "tickets",
+        "intent-source",
+        "keyring-store",
+        "bedrock",
+        "axum-server",
+    ] },
+    { name = "symgraph", features = [
+        "symgraph-server",
+    ] },
+]
+exempt = [
+    { feature = "default", reason = "Empty by design, and `build.rs` fails the build if it stops being empty — it is the precondition the #4901 zero-feature guard rests on, not a module." },
+    { feature = "embedder-cuda", reason = "Links ORT against a CUDA host runtime. Mutually exclusive with `embedder-bundled-ort`, which the `core` lane runs, and unbuildable on this workspace's macOS and ubuntu runners." },
+    { feature = "embedder-load-dynamic", reason = "Selects ORT's load-dynamic linking for AL2023; gates no `cfg` site anywhere in `src/`, so it changes how `embedder` links and not what it does. `core` runs the embedder tests." },
+    { feature = "embedder-coreml", reason = "Documented no-op alias for `embedder`, kept for backward compatibility; gates no `cfg` site anywhere in `src/`." },
+    { feature = "embedder-candle", reason = "Every test it gates is `#[ignore]`d — they download ~90 MB from HuggingFace. Run them deliberately: `cargo test -p trusty-common --features embedder-candle -- --ignored`." },
+]
+
 [lib]
 crate-type = ["rlib"]
 

--- a/crates/trusty-common/build.rs
+++ b/crates/trusty-common/build.rs
@@ -11,10 +11,12 @@
 //! here. The alternative — a `#[cfg(not(any(feature = …)))]` list in `lib.rs` —
 //! would silently stop covering every feature added after it was written.
 //! What: emits `trusty_common_build_script_ran` unconditionally (so the guard's
-//! delivery mechanism is itself testable), and `trusty_common_no_features` when
-//! Cargo activated no feature at all. `lib.rs` turns the latter into a
-//! `compile_error!` for the `cfg(test)` build only, so a plain `cargo build` /
-//! `cargo check` and all 20 consumer crates are unaffected.
+//! delivery mechanism is itself testable), `trusty_common_no_features` when
+//! Cargo activated no feature at all, and `trusty_common_default_not_empty`
+//! when the manifest's `default` set stops being `[]` — the precondition that
+//! makes discounting `CARGO_FEATURE_DEFAULT` correct. `lib.rs` turns the latter
+//! two into `compile_error!`s for the `cfg(test)` build only, so a plain
+//! `cargo build` / `cargo check` and all 20 consumer crates are unaffected.
 //! Test: `src/lib.rs` refuses to compile at all when
 //! `trusty_common_build_script_ran` is absent, so this script ceasing to run is
 //! a build failure rather than a silent one. The guard's own behaviour is
@@ -26,6 +28,7 @@ fn main() {
     println!("cargo::rerun-if-changed=Cargo.toml");
     println!("cargo::rustc-check-cfg=cfg(trusty_common_build_script_ran)");
     println!("cargo::rustc-check-cfg=cfg(trusty_common_no_features)");
+    println!("cargo::rustc-check-cfg=cfg(trusty_common_default_not_empty)");
     println!("cargo::rustc-cfg=trusty_common_build_script_ran");
 
     // Cargo sets `CARGO_FEATURE_<NAME>` for each activated feature. `default`
@@ -40,4 +43,50 @@ fn main() {
     if !any_real_feature_enabled {
         println!("cargo::rustc-cfg=trusty_common_no_features");
     }
+
+    // #4901: the discount above is only correct while `default` is empty. Give
+    // a non-empty `default` its own cfg so the guard says it went inert rather
+    // than going quiet — `default = ["foo"]` sets `CARGO_FEATURE_FOO` on the
+    // bare run, `any_real_feature_enabled` becomes true, and the zero-feature
+    // guard stops firing with nothing turning red.
+    if !default_feature_set_is_empty() {
+        println!("cargo::rustc-cfg=trusty_common_default_not_empty");
+    }
+}
+
+/// Why (#4901): reads the one manifest fact the zero-feature guard depends on.
+/// What: scans `Cargo.toml` for the `default` key inside `[features]` and
+/// reports whether its value is the empty array. Fails CLOSED — an unreadable
+/// manifest, a missing `[features]` table, or a `default` spelled in a shape
+/// this scan does not recognise all report "not empty", which turns into a
+/// `cfg(test)`-scoped `compile_error!` rather than a silently inert guard.
+/// Text-scanned rather than parsed because a build script that pulled in a TOML
+/// parser would put a build-dependency on every consumer of this crate;
+/// `tests/feature_coverage.rs` does the real parse, where `toml` is already a
+/// dev-dependency.
+/// Test: `default_feature_set_is_empty` (`tests/feature_coverage.rs`) asserts
+/// the same fact through a real TOML parse, so the two disagree loudly if this
+/// scan ever reads the manifest wrong.
+fn default_feature_set_is_empty() -> bool {
+    let Ok(manifest) = std::fs::read_to_string("Cargo.toml") else {
+        return false;
+    };
+    let mut in_features = false;
+    for line in manifest.lines() {
+        let line = line.trim();
+        if line.starts_with('#') {
+            continue;
+        }
+        if line.starts_with('[') {
+            in_features = line == "[features]";
+            continue;
+        }
+        if in_features && line.starts_with("default") {
+            let Some((key, value)) = line.split_once('=') else {
+                return false;
+            };
+            return key.trim() == "default" && value.trim() == "[]";
+        }
+    }
+    false
 }

--- a/crates/trusty-common/changelog.d/wave1-feature-gates.md
+++ b/crates/trusty-common/changelog.d/wave1-feature-gates.md
@@ -1,0 +1,29 @@
+Fixed
+
+- **A non-empty `default` can no longer disarm the zero-feature test guard.**
+  The #4901 guard reads Cargo's `CARGO_FEATURE_*` env vars and discounts
+  `CARGO_FEATURE_DEFAULT`, because Cargo activates `default` on every build.
+  That discount is correct only while `default` is `[]` — setting
+  `default = ["docgen"]` made a bare `cargo test -p trusty-common` look like a
+  deliberate feature selection, and the run went green over 407 of the crate's
+  ~2062 tests with nothing red anywhere. `build.rs` now reads the manifest and
+  a non-empty `default` is a `cfg(test)` `compile_error!`, so the guard says it
+  went inert instead of going quiet. `cargo build` / `cargo check` and every
+  consumer crate are untouched ([#4901](https://github.com/bobmatnyc/trusty-tools/issues/4901))
+- **Which feature sets constitute full coverage is now a manifest fact a test
+  checks.** `default = []` and 47 opt-in features mean no single
+  `cargo test -p trusty-common` run covers the crate, and which combination
+  does was tribal knowledge: `--features inference-client` looked thorough
+  while never compiling `inference::bedrock`, and `credentials`,
+  `session-naming` and `memory-core` each shipped a PR whose prescribed gate
+  never ran their tests. `[package.metadata.trusty-test-coverage]` in
+  `Cargo.toml` now names four coverage lanes — `unconditional`, `core`,
+  `inference`, `symgraph` — plus five exemptions that each state why no lane
+  can run them. `tests/feature_coverage.rs` resolves every lane's transitive
+  feature closure from the `[features]` table and fails when the union plus the
+  exemptions is not exactly that table, so a feature added without a lane is a
+  test failure rather than a silent coverage hole. That test target declares no
+  `required-features`, so every invocation runs it — it cannot be gated out by
+  the mechanism it polices. `scripts/test_trusty_common_lanes.sh` reads the same
+  rows through `cargo metadata` and runs them, so the runner cannot drift from
+  the statement ([#4474](https://github.com/bobmatnyc/trusty-tools/issues/4474))

--- a/crates/trusty-common/src/lib.rs
+++ b/crates/trusty-common/src/lib.rs
@@ -66,6 +66,31 @@ compile_error!(
      `--features unconditional-only` to test just the always-compiled surface."
 );
 
+// #4901: the guard above discounts `CARGO_FEATURE_DEFAULT`, because Cargo
+// activates `default` on every build including the bare one. That discount is
+// correct only while `default` is `[]`.
+//
+// Why: give `default = ["foo"]` its own failure instead of letting it disarm
+// the guard. Cargo would set `CARGO_FEATURE_FOO` on a bare `cargo test -p
+// trusty-common`, `build.rs` would see a real feature enabled, and the
+// zero-feature guard would stop firing — restoring the vacuous green with
+// nothing red anywhere.
+// What: `build.rs` scans the manifest for `default = []` and sets
+// `trusty_common_default_not_empty` when it does not find exactly that,
+// including when it cannot read the manifest at all. Scoped to `cfg(test)`
+// like the guard it protects, so consumer builds are untouched.
+// Test: `default_feature_set_is_empty` (`tests/feature_coverage.rs`) asserts
+// the same fact through a real TOML parse.
+#[cfg(all(test, trusty_common_default_not_empty))]
+compile_error!(
+    "crates/trusty-common/Cargo.toml no longer declares `default = []`. The #4901 \
+     zero-feature test guard discounts `CARGO_FEATURE_DEFAULT` on the assumption \
+     that `default` enables nothing; a non-empty `default` makes every bare \
+     `cargo test -p trusty-common` look like a deliberate feature selection, and \
+     the guard silently stops firing. Either keep `default` empty, or rewrite the \
+     guard in build.rs to compare the enabled set against the default set."
+);
+
 // #4901: the guard above is only as live as the build script that feeds it.
 // Deleting or short-circuiting `build.rs` would restore the silent green with
 // nothing turning red, so the absence of its unconditional marker is itself a

--- a/crates/trusty-common/tests/feature_coverage.rs
+++ b/crates/trusty-common/tests/feature_coverage.rs
@@ -1,0 +1,267 @@
+//! Why (#4474): keeps the crate's statement of "what full test coverage is"
+//! true. `default = []` and 47 opt-in features mean no single `cargo test -p
+//! trusty-common` run covers this crate, so which combination does was tribal
+//! knowledge — and it went wrong repeatedly. `--features inference-client`
+//! looked thorough while never compiling `inference::bedrock`; `credentials`,
+//! `session-naming` and `memory-core` each shipped a PR whose prescribed gate
+//! never ran their tests. #4901 stopped the bare run from passing vacuously;
+//! this stops the runs that DO name features from doing it more quietly.
+//!
+//! What: reads the lanes and exemptions from `[package.metadata.
+//! trusty-test-coverage]`, resolves each lane's transitive feature closure from
+//! the `[features]` table, and fails when the union plus the exemptions is not
+//! exactly the declared feature set. Adding a feature without placing it in a
+//! lane or exempting it with a reason is therefore a test failure, not a silent
+//! coverage hole. `scripts/test_trusty_common_lanes.sh` runs the same rows, so
+//! the runner cannot drift from the statement it executes.
+//!
+//! This is an integration test target with no `required-features`, so it is
+//! compiled and run by EVERY invocation — including `--features
+//! unconditional-only`. That is the point: the check cannot itself be gated out
+//! by the mechanism it exists to police.
+//!
+//! Test: the four `#[test]` functions below.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use toml::Value;
+
+/// Why: every assertion here is about this crate's own manifest, so read it
+/// from the one path Cargo guarantees rather than a relative guess that depends
+/// on the test binary's working directory.
+/// What: parses `$CARGO_MANIFEST_DIR/Cargo.toml` into a `toml::Value`.
+/// Test: any parse failure fails all four tests below with the path in the
+/// message.
+fn manifest() -> Value {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
+    let text =
+        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    text.parse::<Value>()
+        .unwrap_or_else(|e| panic!("parse {}: {e}", path.display()))
+}
+
+/// Why: the feature graph is what a lane's closure is resolved against.
+/// What: returns `feature -> features it enables`, keeping only entries that
+/// name another feature of this crate. `dep:foo` (an optional dependency) and
+/// `crate/feat` (a dependency's own feature) are dropped — neither gates a
+/// module here, so neither is something a lane can cover.
+/// Test: `lanes_and_exemptions_name_only_declared_features` fails if this ever
+/// returns a name the manifest does not declare.
+fn feature_graph(manifest: &Value) -> BTreeMap<String, Vec<String>> {
+    let table = manifest
+        .get("features")
+        .and_then(Value::as_table)
+        .expect("[features] table");
+    table
+        .iter()
+        .map(|(name, enables)| {
+            let edges = enables
+                .as_array()
+                .unwrap_or_else(|| panic!("feature `{name}` must be an array"))
+                .iter()
+                .filter_map(Value::as_str)
+                .filter(|e| !e.starts_with("dep:") && !e.contains('/'))
+                .map(str::to_owned)
+                .collect();
+            (name.clone(), edges)
+        })
+        .collect()
+}
+
+/// Why: a lane names only its roots — `memory-core` already pulls in
+/// `credentials`, `embedder`, `embedder-bundled-ort` and `redb-open`, and
+/// listing those again would make the manifest a second place to keep the
+/// feature graph correct.
+/// What: walks `graph` from `seeds` and returns every feature reachable,
+/// `seeds` included.
+/// Test: `every_declared_feature_is_covered_by_a_lane_or_exempted`.
+fn closure(graph: &BTreeMap<String, Vec<String>>, seeds: &[String]) -> BTreeSet<String> {
+    let mut seen = BTreeSet::new();
+    let mut stack: Vec<String> = seeds.to_vec();
+    while let Some(feature) = stack.pop() {
+        if !seen.insert(feature.clone()) {
+            continue;
+        }
+        if let Some(edges) = graph.get(&feature) {
+            stack.extend(edges.iter().cloned());
+        }
+    }
+    seen
+}
+
+/// The `[package.metadata.trusty-test-coverage]` table, already validated to be
+/// present and well-shaped.
+struct Coverage {
+    /// Lane name → the features that lane names on the command line.
+    lanes: Vec<(String, Vec<String>)>,
+    /// Exempt feature → the reason no lane runs it.
+    exempt: Vec<(String, String)>,
+}
+
+/// Why: one shaped read, so a malformed row fails once with a useful message
+/// instead of four times with `Option::unwrap` panics.
+/// What: reads `lanes` and `exempt` out of the package metadata table.
+/// Test: all four tests below go through this.
+fn coverage(manifest: &Value) -> Coverage {
+    let table = manifest
+        .get("package")
+        .and_then(|p| p.get("metadata"))
+        .and_then(|m| m.get("trusty-test-coverage"))
+        .and_then(Value::as_table)
+        .expect("[package.metadata.trusty-test-coverage] table — see #4474");
+
+    let lanes = table
+        .get("lanes")
+        .and_then(Value::as_array)
+        .expect("`lanes` array")
+        .iter()
+        .map(|lane| {
+            let name = lane
+                .get("name")
+                .and_then(Value::as_str)
+                .expect("every lane needs a `name`")
+                .to_owned();
+            let features = lane
+                .get("features")
+                .and_then(Value::as_array)
+                .unwrap_or_else(|| panic!("lane `{name}` needs a `features` array"))
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::to_owned)
+                .collect();
+            (name, features)
+        })
+        .collect();
+
+    let exempt = table
+        .get("exempt")
+        .and_then(Value::as_array)
+        .expect("`exempt` array")
+        .iter()
+        .map(|row| {
+            let feature = row
+                .get("feature")
+                .and_then(Value::as_str)
+                .expect("every exemption needs a `feature`")
+                .to_owned();
+            let reason = row
+                .get("reason")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_owned();
+            (feature, reason)
+        })
+        .collect();
+
+    Coverage { lanes, exempt }
+}
+
+/// Why (#4474): this is the assertion the issue asks for. A feature added
+/// without a lane is a module whose tests nothing runs, and the only signal
+/// today is a test count nobody compares against anything.
+/// What: unions every lane's transitive closure with the exempt set and
+/// requires it to equal the declared feature set exactly.
+/// Test: this test. Demonstrated by adding a feature and watching it fail.
+#[test]
+fn every_declared_feature_is_covered_by_a_lane_or_exempted() {
+    let manifest = manifest();
+    let graph = feature_graph(&manifest);
+    let coverage = coverage(&manifest);
+
+    let mut covered = BTreeSet::new();
+    for (_, features) in &coverage.lanes {
+        covered.extend(closure(&graph, features));
+    }
+    covered.extend(coverage.exempt.iter().map(|(f, _)| f.clone()));
+
+    let declared: BTreeSet<String> = graph.keys().cloned().collect();
+    let uncovered: Vec<&String> = declared.difference(&covered).collect();
+
+    assert!(
+        uncovered.is_empty(),
+        "these trusty-common features are in no coverage lane and carry no exemption: {uncovered:?}\n\
+         No `cargo test -p trusty-common` invocation runs their tests, so they can regress green.\n\
+         Add each to a lane in [package.metadata.trusty-test-coverage] in crates/trusty-common/Cargo.toml,\n\
+         or add an `exempt` row saying why no lane can run it. See #4474."
+    );
+}
+
+/// Why: an exemption or a lane naming a feature that no longer exists is a
+/// coverage claim about nothing, and it hides the feature that replaced it.
+/// What: requires every name in `lanes` and `exempt` to be a declared feature.
+/// Test: this test.
+#[test]
+fn lanes_and_exemptions_name_only_declared_features() {
+    let manifest = manifest();
+    let declared: BTreeSet<String> = feature_graph(&manifest).keys().cloned().collect();
+    let coverage = coverage(&manifest);
+
+    let named = coverage
+        .lanes
+        .iter()
+        .flat_map(|(lane, features)| features.iter().map(move |f| (lane.as_str(), f)))
+        .chain(coverage.exempt.iter().map(|(f, _)| ("exempt", f)));
+
+    let stale: Vec<String> = named
+        .filter(|(_, feature)| !declared.contains(*feature))
+        .map(|(owner, feature)| format!("{owner}: {feature}"))
+        .collect();
+
+    assert!(
+        stale.is_empty(),
+        "coverage rows name features this crate no longer declares: {stale:?}\n\
+         Fix the names in [package.metadata.trusty-test-coverage] in crates/trusty-common/Cargo.toml."
+    );
+}
+
+/// Why: an exemption is a decision not to test something. Without a stated
+/// reason it is indistinguishable from an oversight, and the next reader has no
+/// basis for removing it.
+/// What: requires every `exempt` row to carry a non-empty `reason`.
+/// Test: this test.
+#[test]
+fn every_exemption_states_a_reason() {
+    let manifest = manifest();
+    let coverage = coverage(&manifest);
+    let unreasoned: Vec<&String> = coverage
+        .exempt
+        .iter()
+        .filter(|(_, reason)| reason.trim().is_empty())
+        .map(|(feature, _)| feature)
+        .collect();
+
+    assert!(
+        unreasoned.is_empty(),
+        "these coverage exemptions state no reason: {unreasoned:?}\n\
+         Say why no lane can run the feature, so the exemption can be removed when that stops being true."
+    );
+}
+
+/// Why (#4901): the zero-feature guard in `src/lib.rs` discounts
+/// `CARGO_FEATURE_DEFAULT` because Cargo activates `default` on every build.
+/// That is correct only while `default` is empty; a non-empty `default` would
+/// make a bare run indistinguishable from a deliberate feature selection and
+/// disarm the guard.
+/// What: asserts `default = []` through a real TOML parse. `build.rs` asserts
+/// the same fact by text scan and turns a mismatch into a `cfg(test)`
+/// `compile_error!`; this is the readable half, and the two disagreeing is
+/// itself the signal that the scan misread the manifest.
+/// Test: this test.
+#[test]
+fn default_feature_set_is_empty() {
+    let manifest = manifest();
+    let default = manifest
+        .get("features")
+        .and_then(|f| f.get("default"))
+        .and_then(Value::as_array)
+        .expect("[features] must declare `default`");
+
+    assert!(
+        default.is_empty(),
+        "trusty-common declares `default = {default:?}`, but the #4901 zero-feature guard \
+         in src/lib.rs assumes it is empty. A non-empty `default` sets CARGO_FEATURE_* on a \
+         bare `cargo test -p trusty-common`, which makes the guard stop firing and restores \
+         the vacuous green. Either keep `default` empty, or rewrite the guard in build.rs to \
+         compare the enabled feature set against the default set."
+    );
+}

--- a/scripts/test_trusty_common_lanes.sh
+++ b/scripts/test_trusty_common_lanes.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#
+# test_trusty_common_lanes.sh — run every trusty-common coverage lane (#4474).
+#
+# Why: `trusty-common` declares `default = []` and gates 25+ modules behind 47
+#   opt-in features, so no single `cargo test -p trusty-common` run covers the
+#   crate. #4901 made the bare, zero-feature run fail rather than pass over the
+#   modules it never compiled; that leaves the runs that DO name a feature, each
+#   of which still covers only what it named. `--features inference-client`
+#   never compiled `inference::bedrock`; `credentials`, `session-naming` and
+#   `memory-core` each shipped a PR whose prescribed gate never ran their tests.
+#   This script is the one command that means "the whole crate".
+#
+# What: reads the lanes from `[package.metadata.trusty-test-coverage]` in
+#   crates/trusty-common/Cargo.toml via `cargo metadata`, and runs
+#   `cargo test -p trusty-common --features <lane> --no-fail-fast` for each.
+#   The lane list is NOT duplicated here — `tests/feature_coverage.rs` proves
+#   those same rows cover every declared feature, so the statement this script
+#   executes and the statement CI checks cannot drift apart.
+#
+#   Exits non-zero if any lane fails, after running them all. Lane output goes
+#   to a per-lane file under a temp directory; a passing lane prints its counts
+#   only, a failing lane prints its full output.
+#
+# Usage:
+#   bash scripts/test_trusty_common_lanes.sh              # every lane
+#   bash scripts/test_trusty_common_lanes.sh core symgraph # named lanes only
+#   CARGO_TEST_ARGS="--release" bash scripts/test_trusty_common_lanes.sh
+#
+# This is a hardening/pre-publish gate, not an inner-loop command — the `core`
+# lane alone builds a bundled ONNX Runtime. For an ordinary change, run the
+# lane that covers what you touched.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MANIFEST="${REPO_ROOT}/crates/trusty-common/Cargo.toml"
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "[FAIL] jq is required to read the coverage lanes from cargo metadata." >&2
+    exit 2
+fi
+
+# `--no-deps` keeps this to the workspace's own packages; the lanes live in
+# trusty-common's package metadata, which cargo passes through verbatim.
+metadata="$(cargo metadata --format-version 1 --no-deps --manifest-path "${MANIFEST}" 2>/dev/null)"
+if [[ -z "${metadata}" ]]; then
+    echo "[FAIL] cargo metadata produced no output for ${MANIFEST}." >&2
+    exit 2
+fi
+
+# One "name<TAB>feat,feat,feat" row per lane.
+lanes="$(
+    printf '%s' "${metadata}" | jq -r '
+        .packages[]
+        | select(.name == "trusty-common")
+        | .metadata["trusty-test-coverage"].lanes[]
+        | "\(.name)\t\(.features | join(","))"
+    '
+)"
+
+if [[ -z "${lanes}" ]]; then
+    echo "[FAIL] no lanes in [package.metadata.trusty-test-coverage] — see #4474." >&2
+    exit 2
+fi
+
+requested=("$@")
+outdir="$(mktemp -d)"
+trap 'rm -rf "${outdir}"' EXIT
+
+failed=()
+ran=0
+
+while IFS=$'\t' read -r name features; do
+    [[ -z "${name}" ]] && continue
+
+    if [[ ${#requested[@]} -gt 0 ]]; then
+        wanted=0
+        for r in "${requested[@]}"; do
+            [[ "${r}" == "${name}" ]] && wanted=1
+        done
+        [[ ${wanted} -eq 0 ]] && continue
+    fi
+
+    log="${outdir}/${name}.txt"
+    echo "==> lane ${name}: --features ${features}"
+    # shellcheck disable=SC2086  # CARGO_TEST_ARGS is a deliberate word-split.
+    cargo test -p trusty-common --features "${features}" --no-fail-fast \
+        ${CARGO_TEST_ARGS:-} >"${log}" 2>&1
+    status=$?
+    ran=$((ran + 1))
+
+    if [[ ${status} -eq 0 ]]; then
+        grep -E '^test result:' "${log}" | sed 's/^/    /'
+        echo "    [PASS] lane ${name}"
+    else
+        echo "    [FAIL] lane ${name} (exit ${status})"
+        cat "${log}"
+        failed+=("${name}")
+    fi
+done <<<"${lanes}"
+
+if [[ ${ran} -eq 0 ]]; then
+    echo "[FAIL] no lane matched: ${requested[*]}" >&2
+    exit 2
+fi
+
+if [[ ${#failed[@]} -gt 0 ]]; then
+    echo "[FAIL] ${#failed[@]} of ${ran} lanes failed: ${failed[*]}" >&2
+    exit 1
+fi
+
+echo "[PASS] ${ran} lane(s) passed."


### PR DESCRIPTION
Two feature-gate defects in `trusty-common`, one PR. Rung 4.

- **Refs #4901** — the zero-feature guard discounts `CARGO_FEATURE_DEFAULT`, which is correct only while `default` is `[]`, and nothing checked that. `build.rs` now reads the manifest for that one fact and a non-empty `default` becomes a `cfg(test)` `compile_error!`. The bare run itself already failed on `origin/main`; this closes the way to silently disarm it.
- **Refs #4474** — `[package.metadata.trusty-test-coverage]` states the four feature-set lanes that together cover the crate, plus five exemptions that each say why no lane can run them. `tests/feature_coverage.rs` resolves each lane's transitive closure from the `[features]` table and fails when the union plus exemptions is not exactly that table. `scripts/test_trusty_common_lanes.sh` runs the same rows via `cargo metadata`.

`--all-features` stays unavailable — the `embedder-*` ORT variants are mutually exclusive, which is why `embedder-cuda` and `embedder-load-dynamic` are exemptions rather than lanes.

## Regression demonstration

Both were run against the pre-fix tree first.

**#4901** — `default = ["docgen"]`, then a bare `cargo test -p trusty-common --no-fail-fast`:

```
# pre-fix (origin/main)
EXIT=0
test result: ok. 407 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out

# post-fix
EXIT=101
error: crates/trusty-common/Cargo.toml no longer declares `default = []`. The #4901
zero-feature test guard discounts `CARGO_FEATURE_DEFAULT` on the assumption that
`default` enables nothing; a non-empty `default` makes every bare
`cargo test -p trusty-common` look like a deliberate feature selection, and the
guard silently stops firing. [...]
error: could not compile `trusty-common` (lib test) due to 1 previous error
```

407 of ~2062 tests, green, nothing red anywhere. That is the #4901 failure the guard was meant to prevent, reachable by a one-line manifest edit.

**#4474** — a feature declared with no lane:

```
test every_declared_feature_is_covered_by_a_lane_or_exempted ... FAILED
these trusty-common features are in no coverage lane and carry no exemption: ["demo-uncovered-feature"]
No `cargo test -p trusty-common` invocation runs their tests, so they can regress green.
test result: FAILED. 3 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out
```

Nothing on the pre-fix tree catches this; the test does not exist there.

## Gates

`cargo fmt --check` → clean. `cargo check -p trusty-common` → exit 0. `cargo clippy -p trusty-common --features memory-core,embedder-test-support --all-targets -- -D warnings` → exit 0. `cargo check --workspace` → exit 0.

```
cargo test -p trusty-common --features memory-core,embedder-test-support --no-fail-fast
test result: ok. 1182 passed; 0 failed; 13 ignored   (+ 8 further targets, 0 failed)

cargo test -p trusty-common --features unconditional-only --no-fail-fast
test result: ok. 388 passed; 0 failed; 6 ignored     (+ 7 further targets, 0 failed)

cargo test -p trusty-memory --no-fail-fast
test result: ok. 835 passed; 0 failed; 4 ignored     (+ 30 further targets, 0 failed)

cargo test -p trusty-search --no-fail-fast
test result: ok. 1935 passed; 0 failed; 1 ignored    (+ 32 further targets, 0 failed)

bash scripts/test_trusty_common_lanes.sh inference symgraph
[PASS] lane inference   886 passed; 0 failed; 15 ignored (+ 12 targets)
[PASS] lane symgraph    471 passed; 0 failed;  6 ignored (+ 7 targets)
```

Scripts: `check_test_pointers.sh` (27785 citations, 0 dangling), `check_line_cap.sh` (0 violations), `check_sld.sh` (0 errors), `check_changelog_fragment.sh` (7 paths scanned, fragment recorded) — all exit 0.

## Flake seen once

`trusty-search`'s `service::rpc::reads::tests::config_over_the_socket_matches_the_http_body` failed on the first run (`left: {index_memory_limit_mb: 8192, memory_limit_mb: 8192}` vs `right: {512, 4096}`) and passed on the rerun, and the same target passed on a clean `origin/main` tree. Both limits are process-global `AtomicU64` cells the test's own doc names, so a concurrent test moved them between the socket read and the HTTP read. Nothing in this PR is reachable from `trusty-search` at runtime — it adds a build-script manifest read, two `cfg(test)` `compile_error!`s, one integration test target, and a script.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
