### PR TITLE
test(trusty-mpm): wave-1 flake batch — order-dependent, stale-assets, doctor daemon, TUI cluster

### DIFF
--- a/crates/trusty-mpm/changelog.d/5040-explicit-framework-base.md
+++ b/crates/trusty-mpm/changelog.d/5040-explicit-framework-base.md
@@ -1,0 +1,3 @@
+Changed
+
+- **The batch asset-staleness path takes its framework base as an argument.** `FrameworkPaths::for_managed_workspace_under`, `session_assets::session_plan_under` and `managed_routes::summary::stale_assets_for_many_under` accept the directory the framework install nests under; the existing entry points pass `FrameworkPaths::home_base()` and behave exactly as before. `core::tmux::create_managed_session_with_options` does the same for the resolved `tmux:` options. Both remove a `$HOME`-derived read that only tests needed to redirect ([#5040](https://github.com/bobmatnyc/trusty-tools/issues/5040))

--- a/crates/trusty-mpm/changelog.d/5111-doctor-request-timeout.md
+++ b/crates/trusty-mpm/changelog.d/5111-doctor-request-timeout.md
@@ -1,0 +1,3 @@
+Fixed
+
+- **`/doctor` over HTTP no longer reports a healthy daemon as unreachable.** `DaemonClient::doctor` used the 10s client-level default while the handler runs the whole ~32-check battery inline — `gh auth status` alone measured 3.06s here, and the two worktree scans walk the managed workspace root. Measured against the default: 8 of 10 runs failed, every failure clustered at 10.2–10.3s and every pass at 9.6–9.7s, so Telegram `/doctor` and Slack `/doctor` answered "daemon unreachable" for a daemon that was still producing the report. The request now carries its own 120s bound, the same per-request override pattern the chat, provisioning and merged-PR-survey endpoints already use ([#5111](https://github.com/bobmatnyc/trusty-tools/issues/5111))

--- a/crates/trusty-mpm/src/bin/tm/commands/statusline/branch.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/statusline/branch.rs
@@ -29,6 +29,29 @@ pub(crate) fn project_segment(cwd: &str) -> Option<String> {
     if cwd.is_empty() {
         return None;
     }
+    let branch = select_branch_label(tmux_session_name(), || git_branch(cwd));
+    project_segment_with(cwd, branch.as_deref())
+}
+
+/// [`project_segment`] with the branch-position label already resolved (#4407).
+///
+/// Why: `project_segment` calls [`tmux_session_name`], a probe bounded at 100 ms
+/// that returns `None` on timeout. `project_segment_basename_fallback_non_git`
+/// used to derive its expectation by calling that probe a SECOND time and
+/// requiring the two runs to agree - under machine load either could time out
+/// independently, so the test failed on a tree it had just passed on (measured:
+/// ok / FAILED / ok across three isolated runs). CI never saw it, because the
+/// probe short-circuits on `$TMUX` and GitHub's runners do not set it. Taking
+/// the label as an argument lets the test state one deterministic input instead
+/// of hoping two timed probes agree.
+/// What: the project-identity half only - the GitHub `owner/repo` slug from the
+/// git remote, falling back to the cwd basename - composed with `branch` by
+/// [`render_project_segment`].
+/// Test: `project_segment_basename_fallback_non_git`.
+fn project_segment_with(cwd: &str, branch: Option<&str>) -> Option<String> {
+    if cwd.is_empty() {
+        return None;
+    }
     // Prefer the GitHub owner/repo slug from the git remote; fall back to the cwd
     // basename only when there is no parseable remote (non-GitHub / non-git dir).
     let project = git_owner_repo(cwd).unwrap_or_else(|| {
@@ -37,8 +60,7 @@ pub(crate) fn project_segment(cwd: &str) -> Option<String> {
             .map(|n| n.to_string_lossy().to_string())
             .unwrap_or_default()
     });
-    let branch = select_branch_label(tmux_session_name(), || git_branch(cwd));
-    render_project_segment(project, branch.as_deref())
+    render_project_segment(project, branch)
 }
 
 /// Choose the branch-position label: prefer the tmux session name, falling
@@ -312,33 +334,40 @@ mod tests {
     }
 
     /// Why: a bare directory with no git repo must fall back to the cwd basename
-    /// and never panic. (#2031: the branch position now prefers a live tmux
-    /// session name over the git branch, so this test computes its expectation
-    /// from the SAME [`tmux_session_name`] probe the production code uses,
-    /// rather than assuming "no tmux" — it stays deterministic whether or not
-    /// the test runner itself is inside a tmux session.)
+    /// and never panic.
+    ///
+    /// #4407: this used to call [`tmux_session_name`] a second time to derive
+    /// its expectation, so it required two independent 100 ms-bounded probes to
+    /// agree - either could time out under load, and the test then failed on a
+    /// tree it had just passed on. It now drives [`project_segment_with`] with
+    /// the label stated outright, covering both arms (no label, and a live
+    /// session name) deterministically. [`project_segment`]'s own choice between
+    /// the two sources stays covered by `select_branch_label_selection_contract`.
     /// Test: itself.
     #[test]
     fn project_segment_basename_fallback_non_git() {
         let tmp = tempfile::TempDir::new().expect("tempdir");
         let cwd = tmp.path().to_string_lossy().to_string();
-        let seg = project_segment(&cwd).expect("basename segment");
         let basename = tmp
             .path()
             .file_name()
             .map(|n| n.to_string_lossy().to_string())
             .unwrap_or_default();
-        match tmux_session_name() {
-            Some(session) => assert_eq!(
-                seg,
-                format!("{basename} \u{2387} {session}"),
-                "inside tmux, non-git cwd → basename + tmux session label"
-            ),
-            None => {
-                assert_eq!(seg, basename, "non-git cwd → basename, no branch");
-                assert!(!seg.contains('\u{2387}'), "no branch marker for a bare dir");
-            }
-        }
+
+        let bare = project_segment_with(&cwd, None).expect("basename segment");
+        assert_eq!(bare, basename, "non-git cwd -> basename, no branch");
+        assert!(
+            !bare.contains('\u{2387}'),
+            "no branch marker for a bare dir"
+        );
+
+        let labelled =
+            project_segment_with(&cwd, Some("tm-trusty-tools-01")).expect("basename segment");
+        assert_eq!(
+            labelled,
+            format!("{basename} \u{2387} tm-trusty-tools-01"),
+            "a resolved session label -> basename + label"
+        );
     }
 
     /// Why: the leading field must resolve to the GitHub `owner/repo` slug parsed

--- a/crates/trusty-mpm/src/client/http_client/config.rs
+++ b/crates/trusty-mpm/src/client/http_client/config.rs
@@ -101,6 +101,28 @@ pub(super) const CHAT_REQUEST_TIMEOUT: Duration = Duration::from_secs(130);
 /// second copy of the constant there would be free to drift.
 pub(crate) const PROVISION_REQUEST_TIMEOUT: Duration = Duration::from_secs(180);
 
+/// Per-request timeout override for `GET /api/v1/doctor` (#5111).
+///
+/// Why: the doctor handler runs the whole ~32-check battery SYNCHRONOUSLY
+/// inside the request. Several checks are unbounded in the operator's
+/// environment rather than in the daemon: `check_gh_account` shells out to
+/// `gh auth status` (measured 3.06s on this machine), and `check_worktrees` /
+/// `check_worktree_disk` walk the managed workspace root. Measured against
+/// [`DEFAULT_REQUEST_TIMEOUT`]: 8 of 10 runs failed, every failure clustered at
+/// 10.2–10.3s and every pass at 9.6–9.7s — the client was hanging up on a
+/// report the daemon was still producing, so Telegram `/doctor` and Slack
+/// `/doctor` reported "daemon unreachable" for a healthy daemon. 120s is well
+/// clear of that battery on a loaded machine and stays a hard, finite bound.
+/// What: passed to `reqwest::RequestBuilder::timeout` at the
+/// [`super::DaemonClient::doctor`] call site — a per-request override, not a
+/// change to the client-level default every other endpoint uses. Same pattern
+/// and same reason as [`CHAT_REQUEST_TIMEOUT`] and
+/// [`PROVISION_REQUEST_TIMEOUT`].
+/// Test: `tests::default_client_uses_default_bounds` pins the value;
+/// `client::executor::tests::execute_doctor_against_test_daemon` exercises the
+/// real round trip that was racing the default bound.
+pub(super) const DOCTOR_REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
+
 /// Per-request timeout override for `POST …/managed/prune-worktrees` when the
 /// merged-PR reclaim pass is requested (#5830).
 ///
@@ -233,6 +255,14 @@ mod tests {
         assert!(
             PROVISION_REQUEST_TIMEOUT > DEFAULT_REQUEST_TIMEOUT,
             "the provisioning override must be longer than the default, not shorter"
+        );
+        // #5111: the doctor battery measured 10.2-10.3s against the 10s
+        // default, so anything at or near that bound reinstates the race.
+        assert_eq!(DOCTOR_REQUEST_TIMEOUT, Duration::from_secs(120));
+        assert!(
+            DOCTOR_REQUEST_TIMEOUT > DEFAULT_REQUEST_TIMEOUT * 2,
+            "the doctor override must clear the measured 10.2s battery by a \
+             wide margin, not sit beside it"
         );
         // #5830: the merged-PR survey outruns every other override here, so it
         // must be the longest of them — shrinking it back toward the provision

--- a/crates/trusty-mpm/src/client/http_client/mod.rs
+++ b/crates/trusty-mpm/src/client/http_client/mod.rs
@@ -742,13 +742,18 @@ impl DaemonClient {
     /// What: `GET /api/v1/doctor`, passing the caller's `project` path so the
     /// daemon can scope the instruction-pipeline probe. Returns the parsed
     /// [`DoctorReport`](crate::client::DoctorReport); `Err` on a transport or decode failure.
+    ///
+    /// #5111: carries [`config::DOCTOR_REQUEST_TIMEOUT`] rather than the
+    /// client-level default. The handler runs the full check battery inline and
+    /// measured 10.2–10.3s here, so the 10s default hung up on a healthy daemon
+    /// and every caller reported it unreachable.
     /// Test: covered by the executor's doctor test.
     pub async fn doctor(
         &self,
         project: Option<&str>,
     ) -> anyhow::Result<crate::core::doctor::DoctorReport> {
         let url = format!("{}/api/v1/doctor", self.base);
-        let mut request = self.http.get(&url);
+        let mut request = self.http.get(&url).timeout(config::DOCTOR_REQUEST_TIMEOUT);
         if let Some(project) = project {
             request = request.query(&[("project", project)]);
         }

--- a/crates/trusty-mpm/src/core/managed_config_tests.rs
+++ b/crates/trusty-mpm/src/core/managed_config_tests.rs
@@ -532,18 +532,13 @@ fn ensure_managed_config_dir_emits_the_frozen_skill_warning() {
     // belong to the run under test.
     let (config_dir, _deployed) = frozen_skill_fixture(&tmp, &fw);
 
-    // #4181: `tracing` short-circuits every macro on a process-global MAX_LEVEL
-    // that starts at OFF and is raised only when some test installs a GLOBAL
-    // default. A thread-local `with_default` never raises it, so whether this
-    // test captured anything depended on which OTHER test in the lib binary
-    // happened to run first — it captured `[]` and failed whenever none had.
-    // `#[serial]` cannot help: the level is global and outlives the lock.
-    // Installing a permissive global default once makes the capture below
-    // deterministic; `with_default` still overrides it for this thread.
-    static RAISE_MAX_LEVEL: std::sync::Once = std::sync::Once::new();
-    RAISE_MAX_LEVEL.call_once(|| {
-        let _ = tracing::subscriber::set_global_default(tracing_subscriber::registry());
-    });
+    // #4181/#4931: `tracing` short-circuits every macro on a process-global
+    // MAX_LEVEL that starts at OFF and is raised only by a GLOBAL default
+    // subscriber. `with_default` is thread-local and never raises it, so this
+    // capture used to record `[]` whenever no other test had installed one.
+    // One entry point owns that now, and it FAILS rather than capturing nothing
+    // if some other test clamped the level below WARN.
+    crate::test_support::enable_event_capture();
 
     let buffer = trusty_common::log_buffer::LogBuffer::new(64);
     let subscriber = tracing_subscriber::registry().with(

--- a/crates/trusty-mpm/src/core/paths.rs
+++ b/crates/trusty-mpm/src/core/paths.rs
@@ -132,8 +132,23 @@ impl FrameworkPaths {
     /// `default_is_a_single_global_path_never_project_relative`.
     #[allow(clippy::should_implement_trait)] // Intentional: no meaningful Default without I/O.
     pub fn default() -> Self {
-        let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
-        Self::under(home)
+        Self::under(Self::home_base())
+    }
+
+    /// The base directory [`default`](Self::default) resolves against.
+    ///
+    /// Why (#5040): a caller that wants to STAY on the production layout but
+    /// hand the base to a function taking one explicitly — the shape
+    /// `session_plan_under` / `stale_assets_for_many_under` use so their tests
+    /// can supply a temp dir instead of mutating the process-global `$HOME` —
+    /// needs the same answer `default()` computes, from one place. A second
+    /// `dirs::home_dir().unwrap_or(".")` at each such call site is exactly the
+    /// drift the common-entry-point rule forbids.
+    /// What: `dirs::home_dir()`, falling back to `.` when the home directory
+    /// cannot be determined — the identical resolution `default()` performs.
+    /// Test: `home_base_is_what_default_resolves_against`.
+    pub fn home_base() -> PathBuf {
+        dirs::home_dir().unwrap_or_else(|| PathBuf::from("."))
     }
 
     /// Resolve the framework layout under an arbitrary base directory.
@@ -277,7 +292,30 @@ impl FrameworkPaths {
     /// Test: `for_managed_workspace_targets_workspace_local_claude_dirs`,
     /// `for_managed_workspace_keeps_framework_source_at_default_root`.
     pub fn for_managed_workspace(workspace_dir: impl AsRef<Path>) -> Self {
-        Self::for_managed_project(Self::default().root, workspace_dir)
+        Self::for_managed_workspace_under(Self::home_base(), workspace_dir)
+    }
+
+    /// [`for_managed_workspace`](Self::for_managed_workspace) with the base the
+    /// framework root nests under supplied explicitly (#5040).
+    ///
+    /// Why: `for_managed_workspace` reads `$HOME` through
+    /// [`default`](Self::default), so every test exercising a code path that
+    /// reaches it had to point the PROCESS-GLOBAL `$HOME` at a temp dir first.
+    /// `#[serial_test::serial]` only orders those tests against each other, not
+    /// against the rest of the binary, so any concurrently-running test reading
+    /// a `$HOME`-derived path observed the redirected one (#5040, #4931) — and
+    /// under `cargo nextest`'s per-test processes the guard does nothing at all.
+    /// Taking the base as an argument removes the process-global step entirely:
+    /// the test passes its own temp dir and mutates no environment.
+    /// What: `for_managed_project(Self::under(base).root, workspace_dir)` — the
+    /// same composition `for_managed_workspace` performs, with `base` in place
+    /// of the home directory.
+    /// Test: `for_managed_workspace_under_matches_for_managed_workspace_at_home`.
+    pub fn for_managed_workspace_under(
+        base: impl AsRef<Path>,
+        workspace_dir: impl AsRef<Path>,
+    ) -> Self {
+        Self::for_managed_project(Self::under(base).root, workspace_dir)
     }
 
     /// Path of the token-optimizer policy file (`hooks/optimizer.toml`).
@@ -743,6 +781,33 @@ mod tests {
         // Only the deploy destinations diverge from the real-home default.
         assert_ne!(workspace_paths.claude_agents, default_paths.claude_agents);
         assert_ne!(workspace_paths.claude_skills, default_paths.claude_skills);
+    }
+
+    /// #5040: `for_managed_workspace_under` must be the same construction
+    /// `for_managed_workspace` performs, differing only in where the base comes
+    /// from — otherwise a test built on the explicit form would prove something
+    /// production never does.
+    ///
+    /// Needs no `$HOME` redirect and no `#[serial]`: both sides read the same
+    /// `home_base()` within one expression, so a concurrent `$HOME` mutation
+    /// cannot make them disagree in a way that means anything.
+    #[test]
+    fn for_managed_workspace_under_matches_for_managed_workspace_at_home() {
+        let base = FrameworkPaths::home_base();
+        assert_eq!(
+            FrameworkPaths::for_managed_workspace_under(&base, "/some/workspace"),
+            FrameworkPaths::for_managed_workspace("/some/workspace"),
+        );
+    }
+
+    /// #5040: `home_base` must be exactly the base `default` nests under, so a
+    /// caller threading the base explicitly stays on the production layout.
+    #[test]
+    fn home_base_is_what_default_resolves_against() {
+        assert_eq!(
+            FrameworkPaths::under(FrameworkPaths::home_base()),
+            FrameworkPaths::default(),
+        );
     }
 
     #[test]

--- a/crates/trusty-mpm/src/core/session_assets.rs
+++ b/crates/trusty-mpm/src/core/session_assets.rs
@@ -100,8 +100,28 @@ pub fn session_asset_staleness(record: &SessionRecord) -> StalenessReport {
 /// never a catalog directory scan or agent compose.
 /// Test: `session_plan_resolves_default_bundled_source`.
 pub fn session_plan(record: &SessionRecord) -> (FrameworkPaths, HarnessPlan) {
+    session_plan_under(record, &FrameworkPaths::home_base())
+}
+
+/// [`session_plan`] with the framework install's base directory supplied by the
+/// caller instead of read from `$HOME` (#5040).
+///
+/// Why: everything below this function resolves from `FrameworkPaths`, so `$HOME`
+/// enters the staleness comparison at exactly one point —
+/// [`FrameworkPaths::for_managed_workspace`]. That single read is what forced
+/// every test of the batch staleness path to redirect the PROCESS-GLOBAL `$HOME`
+/// and carry `#[serial_test::serial]`, which orders those tests against each
+/// other but not against the rest of the binary; a concurrent test reading a
+/// `$HOME`-derived path then observed the redirect and produced a wrong answer
+/// (#5040's `left: 25, right: 1`). Taking the base as an argument lets a test be
+/// hermetic without touching the environment at all.
+/// What: identical to [`session_plan`] except that the workspace-scoped
+/// [`FrameworkPaths`] is built with
+/// [`FrameworkPaths::for_managed_workspace_under`] against `base`.
+/// Test: `session_plan_under_matches_session_plan_at_home`.
+pub fn session_plan_under(record: &SessionRecord, base: &Path) -> (FrameworkPaths, HarnessPlan) {
     let workdir = session_workdir(record);
-    let fw = FrameworkPaths::for_managed_workspace(workdir);
+    let fw = FrameworkPaths::for_managed_workspace_under(base, workdir);
     let catalog_root = crate::content::catalog_root_for(&fw.root);
     let sources = crate::core::manifest::ManifestSources::resolve(workdir, &catalog_root);
     let manifest = crate::core::manifest::resolve_manifest(&sources);
@@ -258,6 +278,24 @@ mod tests {
         let ws = PathBuf::from("/workspace");
         let record = make_record(Some(ws.clone()), PathBuf::from("/cwd"));
         assert_eq!(session_workdir(&record), ws.as_path());
+    }
+
+    /// #5040: the explicit-base form must be the same resolution
+    /// [`session_plan`] performs, so a test built on `session_plan_under`
+    /// proves what production actually does.
+    #[test]
+    fn session_plan_under_matches_session_plan_at_home() {
+        let record = make_record(
+            Some(PathBuf::from("/some/workspace")),
+            PathBuf::from("/some/cwd"),
+        );
+        let (fw_default, plan_default) = session_plan(&record);
+        let (fw_explicit, plan_explicit) =
+            session_plan_under(&record, &FrameworkPaths::home_base());
+
+        assert_eq!(fw_default, fw_explicit);
+        assert_eq!(plan_default.agent_source, plan_explicit.agent_source);
+        assert_eq!(plan_default.skill_source, plan_explicit.skill_source);
     }
 
     #[test]

--- a/crates/trusty-mpm/src/core/tmux.rs
+++ b/crates/trusty-mpm/src/core/tmux.rs
@@ -413,6 +413,33 @@ pub fn create_managed_session(
     name: &str,
     workdir: Option<&str>,
 ) -> std::io::Result<ManagedSessionOutcome> {
+    let config = crate::core::trusty_tools_config::TrustyToolsConfig::load();
+    let opts = crate::core::trusty_tools_config::resolve_tmux_options(&config);
+    create_managed_session_with_options(tmux_bin, name, workdir, opts)
+}
+
+/// [`create_managed_session`] with the resolved tmux options supplied by the
+/// caller instead of loaded from `~/.trusty-mpm/config.toml` (#5040).
+///
+/// Why: `TrustyToolsConfig::load()` reads a `$HOME`-derived path, so a test that
+/// wanted to assert on the applied options had to resolve them ITSELF and then
+/// trust that the second resolution inside `create_managed_session` saw the same
+/// `$HOME`. It does not: a concurrently-running test that redirects `$HOME` —
+/// and this crate has more than ten that do — makes the two sides of the
+/// assertion answer to different environments, which is how
+/// `create_managed_session_confirms_server_before_applying_options` failed with
+/// no change to any file it touches. Injecting the options means ONE resolution
+/// per call, so the two sides cannot diverge.
+/// What: everything `create_managed_session` does apart from the config load —
+/// the host-state gate, the binary resolution, the #3386 apply-and-verify cycle,
+/// and `new-session`.
+/// Test: `create_managed_session_confirms_server_before_applying_options`.
+pub fn create_managed_session_with_options(
+    tmux_bin: Option<&str>,
+    name: &str,
+    workdir: Option<&str>,
+    opts: crate::core::trusty_tools_config::ResolvedTmuxOptions,
+) -> std::io::Result<ManagedSessionOutcome> {
     // #5784: refuse once, loudly, at the entry point. `host_state_guard` also
     // guards every spawn below, but this is the operation an operator asked
     // for by name, so it is the one that earns a `warn!` — and refusing here
@@ -435,8 +462,6 @@ pub fn create_managed_session(
         }
     };
 
-    let config = crate::core::trusty_tools_config::TrustyToolsConfig::load();
-    let opts = crate::core::trusty_tools_config::resolve_tmux_options(&config);
     let commands = managed_session_command_sequence(
         name,
         workdir,

--- a/crates/trusty-mpm/src/core/tmux_tests.rs
+++ b/crates/trusty-mpm/src/core/tmux_tests.rs
@@ -355,14 +355,20 @@ fn create_managed_session_confirms_server_before_applying_options() {
     // create_session` → `TmuxDriver::create_session`) routes through, so
     // asserting the recorded order here proves the fix for that path too.
     //
-    // The expected history-limit is read via the SAME config-resolution
-    // path `create_managed_session` itself uses (rather than a hardcoded
-    // constant) so this test stays correct regardless of the host's own
-    // `~/.trusty-mpm` config.
+    // #5040: the options are CONSTRUCTED here and injected, not resolved from
+    // `~/.trusty-mpm/config.toml` on both sides. Reading the host config twice —
+    // once here for the expectation, once inside `create_managed_session` for
+    // the actual — let any concurrently-running test that redirects `$HOME`
+    // answer the two reads from different environments, and this test failed
+    // with no change to a single file it exercises. One value, passed in, cannot
+    // diverge from itself.
     let dir = tempfile::tempdir().unwrap();
     let log = dir.path().join("calls.log");
-    let config = crate::core::trusty_tools_config::TrustyToolsConfig::load();
-    let opts = crate::core::trusty_tools_config::resolve_tmux_options(&config);
+    let opts = crate::core::trusty_tools_config::ResolvedTmuxOptions {
+        history_limit: 123_456,
+        mouse: true,
+        alternate_screen: false,
+    };
     let script = format!(
         "#!/bin/sh\necho \"$1\" >> '{log}'\ncase \"$1\" in\n{show_options}esac\nexit 0\n",
         log = log.display(),
@@ -373,8 +379,9 @@ fn create_managed_session_confirms_server_before_applying_options() {
     );
     let bin = write_fake_tmux(dir.path(), "fake-tmux-order", &script);
 
-    let outcome = create_managed_session(Some(&bin), "tmpm-3386-order-test", None)
-        .expect("fake tmux always exits 0");
+    let outcome =
+        create_managed_session_with_options(Some(&bin), "tmpm-3386-order-test", None, opts)
+            .expect("fake tmux always exits 0");
 
     assert!(
         outcome.options_verified,

--- a/crates/trusty-mpm/src/core/update_check/mod.rs
+++ b/crates/trusty-mpm/src/core/update_check/mod.rs
@@ -611,21 +611,16 @@ pub struct CatalogHashes {
 /// unrelated tests that also reach `compute` (directly or via
 /// `detect_staleness`) concurrently in the same binary.
 /// What: a process-wide `Mutex<Vec<(PathBuf, PathBuf)>>`, appended to by
-/// every real `compute()` call; [`reset_compute_call_log`] clears it and
-/// [`compute_calls_for`] counts entries matching one specific pair.
+/// every real `compute()` call; [`compute_calls_for`] counts entries matching
+/// one specific pair. #5040 removed the companion clear: a process-global reset
+/// from one test erases entries another has already recorded, and the pair
+/// filter is what provides isolation.
 /// Test: `stale_assets_for_many_computes_catalog_exactly_once_per_source_pair`
 /// in `daemon::managed_routes::tests`.
 #[cfg(test)]
 pub(crate) static COMPUTE_CALL_LOG: std::sync::LazyLock<
     std::sync::Mutex<Vec<(std::path::PathBuf, std::path::PathBuf)>>,
 > = std::sync::LazyLock::new(|| std::sync::Mutex::new(Vec::new()));
-
-/// Clear [`COMPUTE_CALL_LOG`] — call before the fan-out under test so earlier
-/// tests' entries can never be mistaken for this test's calls.
-#[cfg(test)]
-pub(crate) fn reset_compute_call_log() {
-    COMPUTE_CALL_LOG.lock().unwrap().clear();
-}
 
 /// Count logged [`CatalogHashes::compute`] calls for exactly one
 /// `(catalog_agents, catalog_skills)` pair.

--- a/crates/trusty-mpm/src/core/update_check/tests.rs
+++ b/crates/trusty-mpm/src/core/update_check/tests.rs
@@ -724,7 +724,11 @@ fn single_target_detect_reads_only_selected_agents() {
     }
     write_skill(&catalog_skills, "tm-doctor", "v1");
 
-    super::reset_deployed_read_log();
+    // #5040: deliberately NO `reset_deployed_read_log()`. The log is
+    // process-global, so a clear performed by one test erases entries another
+    // test has already recorded. Isolation here comes from
+    // `deployed_reads_under`'s prefix filter against this test's own temp dir,
+    // which is zero before the call below by construction.
     let _ = detect_staleness(
         &catalog_agents,
         &catalog_skills,

--- a/crates/trusty-mpm/src/daemon/managed_routes/summary.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/summary.rs
@@ -20,7 +20,7 @@ use axum::http::StatusCode;
 
 use crate::core::manifest::HarnessPlan;
 use crate::core::paths::FrameworkPaths;
-use crate::core::session_assets::session_plan;
+use crate::core::session_assets::session_plan_under;
 use crate::core::update_check::{CatalogHashes, DeployedAgentHashes};
 use crate::session_manager::{
     InjectionStatus, ManagedSessionId, ManagedSessionState, ManagedTmuxDriver, NumberedSlot,
@@ -384,7 +384,17 @@ fn probe_staleness_in_list(state: &ManagedSessionState) -> bool {
 /// `checked_summaries_stale_assets_independent_per_session_sharing_one_catalog`,
 /// `checked_summaries_flags_stale_assets_only_for_relevant_states` in
 /// `super::tests`.
-pub(super) fn staleness_inputs(records: Vec<SessionRecord>) -> Vec<StalenessInput> {
+///
+/// #5040: `base` — the directory the framework install nests under — is an
+/// argument rather than a `$HOME` read, for the reason
+/// [`crate::core::session_assets::session_plan_under`] gives. This is the batch
+/// half of that seam, so a test of the fan-out below is hermetic without
+/// redirecting the process-global `$HOME`. Production passes
+/// `FrameworkPaths::home_base()` from [`stale_assets_for_many`].
+pub(super) fn staleness_inputs_under(
+    records: Vec<SessionRecord>,
+    base: &std::path::Path,
+) -> Vec<StalenessInput> {
     let mut cache: HashMap<(PathBuf, PathBuf), Arc<CatalogHashes>> = HashMap::new();
     // #4322: the second shared half. `fw.agent_deploy_dir()` is ONE
     // machine-global directory for every session (#4409 exempted it from the
@@ -396,7 +406,7 @@ pub(super) fn staleness_inputs(records: Vec<SessionRecord>) -> Vec<StalenessInpu
     let mut agents: HashMap<(PathBuf, PathBuf, PathBuf), Arc<DeployedAgentHashes>> = HashMap::new();
     let mut out = Vec::with_capacity(records.len());
     for record in records {
-        let (fw, plan) = session_plan(&record);
+        let (fw, plan) = session_plan_under(&record, base);
         let key = (plan.agent_source.clone(), plan.skill_source.clone());
         let catalog = cache
             .entry(key.clone())
@@ -451,7 +461,7 @@ type StalenessInput = (
 /// `JoinSet` pattern, `spawn_blocking` instead of `spawn` because the work is
 /// synchronous filesystem I/O rather than `tokio::fs`.
 /// What: resolves every session's plan and computes one [`CatalogHashes`] per
-/// distinct source pair in ONE blocking task ([`staleness_inputs`] — the
+/// distinct source pair in ONE blocking task ([`staleness_inputs_under`] — the
 /// sharing that must NOT be parallelized, or each task would redundantly
 /// recompose the same catalog), then spawns one blocking task per session for
 /// the cheap deployed-side [`session_asset_staleness_with_catalog`] half. A
@@ -460,7 +470,7 @@ type StalenessInput = (
 /// Test: `checked_summaries_stale_assets_independent_per_session_sharing_one_catalog`,
 /// `checked_summaries_flags_stale_assets_only_for_relevant_states`,
 /// `stale_assets_for_many_computes_catalog_exactly_once_per_source_pair`
-/// (issue #4326 review HIGH: the prior pin only exercised [`staleness_inputs`]
+/// (issue #4326 review HIGH: the prior pin only exercised [`staleness_inputs_under`]
 /// directly, never this actual hot path, and stayed green when
 /// `CatalogHashes::compute` was moved into the fan-out below) in
 /// `super::tests`. `pub(super)` (rather than private) so that regression test
@@ -470,7 +480,31 @@ type StalenessInput = (
 pub(super) async fn stale_assets_for_many(
     records: Vec<SessionRecord>,
 ) -> HashMap<ManagedSessionId, bool> {
-    let inputs = tokio::task::spawn_blocking(move || staleness_inputs(records))
+    stale_assets_for_many_under(records, crate::core::paths::FrameworkPaths::home_base()).await
+}
+
+/// [`stale_assets_for_many`] with the framework install's base directory
+/// supplied by the caller instead of read from `$HOME` (#5040).
+///
+/// Why: the three `stale_assets_for_many_*` tests each deployed a fixture into
+/// `FrameworkPaths::default()` under a `fake_home()` guard, so their correctness
+/// depended on no other test in the binary rewriting `$HOME` mid-run.
+/// `#[serial_test::serial]` does not provide that — it orders `#[serial]` tests
+/// against each other only, and under `cargo nextest`'s per-test processes it
+/// orders nothing. Passing the base in removes the dependency instead of
+/// guarding it: the tests hand over their own temp dir and mutate no
+/// environment, so no concurrent test can reach them.
+/// What: identical to [`stale_assets_for_many`], with `base` threaded to
+/// [`staleness_inputs_under`]. Owned rather than borrowed because the resolve
+/// step runs inside `spawn_blocking`.
+/// Test: `stale_assets_for_many_reads_shared_agent_dir_once_for_the_whole_fleet`,
+/// `stale_assets_for_many_sees_an_agent_change_on_the_very_next_call`,
+/// `stale_assets_for_many_keeps_per_session_verdicts_correct_under_concurrency`.
+pub(super) async fn stale_assets_for_many_under(
+    records: Vec<SessionRecord>,
+    base: PathBuf,
+) -> HashMap<ManagedSessionId, bool> {
+    let inputs = tokio::task::spawn_blocking(move || staleness_inputs_under(records, &base))
         .await
         .unwrap_or_default();
     let mut probes = tokio::task::JoinSet::new();

--- a/crates/trusty-mpm/src/daemon/managed_routes/tests.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/tests.rs
@@ -11,7 +11,7 @@ use std::path::PathBuf;
 use chrono::Utc;
 
 use super::summary::checked_summaries_with;
-use super::summary::{reconcile_against_tmux, reconcile_live_state, stale_assets_for_many};
+use super::summary::{reconcile_against_tmux, reconcile_live_state, stale_assets_for_many_under};
 use super::{checked_summaries, record_to_json, record_to_summary};
 use crate::session_manager::{
     InjectionStatus, ManagedError, ManagedSessionId, ManagedSessionState, ManagedTmuxDriver,
@@ -654,6 +654,26 @@ impl Drop for HomeGuard {
 /// `pub(super)` so the sibling `staleness_bench_tests` module isolates its
 /// fixture exactly as the unit tests do — a benchmark that read the
 /// developer's real `~/.trusty-mpm` would measure an uncontrolled tree.
+/// A throwaway framework base for the tests that reach the staleness path
+/// through an `_under` entry point (#5040).
+///
+/// Why: [`fake_home`] below points the PROCESS-GLOBAL `$HOME` at a temp dir,
+/// which is what made the `stale_assets_for_many_*` family order-dependent —
+/// `#[serial_test::serial]` orders `#[serial]` tests against each other, not
+/// against the rest of the binary, and under `cargo nextest`'s per-test
+/// processes it orders nothing at all. `staleness_inputs_under` /
+/// `stale_assets_for_many_under` take the base as an argument, so a test using
+/// this fixture reads no environment variable, mutates none, and needs no
+/// serial guard.
+/// What: a bare `TempDir` used as BOTH the framework base (`<dir>/.trusty-mpm`)
+/// and the parent of each fixture workspace — the same two roles the redirected
+/// `$HOME` played.
+/// Test: used by `staleness_inputs_computes_one_catalog_per_source_pair_shared_by_arc`
+/// and the three `stale_assets_for_many_*` cases.
+fn fake_base() -> tempfile::TempDir {
+    tempfile::TempDir::new().unwrap()
+}
+
 pub(super) fn fake_home() -> (tempfile::TempDir, HomeGuard) {
     let home = tempfile::TempDir::new().unwrap();
     let prior = std::env::var("HOME").ok();
@@ -858,13 +878,16 @@ async fn checked_summaries_does_not_probe_stopped_sessions() {
 /// receives a POINTER-EQUAL handle proves there is exactly one compute per
 /// group — and that no second one exists for a spawned task to perform. Move
 /// `CatalogHashes::compute` inside the fan-out and this fails immediately.
+///
+/// #5040: takes its framework base from [`fake_base`] rather than redirecting
+/// `$HOME`, so it reads and writes no process-global state and carries no
+/// `#[serial]`.
 #[tokio::test]
-#[serial_test::serial]
 async fn staleness_inputs_computes_one_catalog_per_source_pair_shared_by_arc() {
-    let (home, _guard) = fake_home();
+    let base = fake_base();
     let records: Vec<SessionRecord> = (0..3)
         .map(|i| {
-            let ws = home.path().join(format!("shared-catalog-{i}"));
+            let ws = base.path().join(format!("shared-catalog-{i}"));
             std::fs::create_dir_all(&ws).unwrap();
             let mut r = make_record(None);
             r.state = ManagedSessionState::Active;
@@ -873,7 +896,7 @@ async fn staleness_inputs_computes_one_catalog_per_source_pair_shared_by_arc() {
         })
         .collect();
 
-    let inputs = super::summary::staleness_inputs(records);
+    let inputs = super::summary::staleness_inputs_under(records, base.path());
 
     assert_eq!(inputs.len(), 3, "one input per record, in input order");
     assert!(
@@ -886,7 +909,7 @@ async fn staleness_inputs_computes_one_catalog_per_source_pair_shared_by_arc() {
 }
 
 /// Issue #4326 review, HIGH (empirically proven): the pin above only ever
-/// called [`super::summary::staleness_inputs`] directly — it never exercised
+/// called [`super::summary::staleness_inputs_under`] directly — it never exercised
 /// [`stale_assets_for_many`], the function `checked_summaries` (and therefore
 /// `tm ls`) actually calls. The critic proved this gap by moving
 /// `CatalogHashes::compute` INSIDE `stale_assets_for_many`'s per-session
@@ -897,7 +920,7 @@ async fn staleness_inputs_computes_one_catalog_per_source_pair_shared_by_arc() {
 /// Why this test closes the gap: it calls `stale_assets_for_many` itself (the
 /// real hot path) with three records that all resolve to the SAME
 /// `(agent_source, skill_source)` pair (the shared default, anchored at this
-/// test's `fake_home()`-scoped `$HOME`), and asserts via
+/// test's own [`fake_base`] temp dir), and asserts via
 /// [`crate::core::update_check::compute_calls_for`] — a call LOG keyed by the
 /// exact catalog paths, not a bare counter, so unrelated tests reaching
 /// `CatalogHashes::compute` through their own unrelated temp paths can never
@@ -905,24 +928,30 @@ async fn staleness_inputs_computes_one_catalog_per_source_pair_shared_by_arc() {
 /// Reinstating the per-session compose inside the fan-out (the critic's
 /// mutation) makes this assert `3`, not `1`, and fail.
 /// What: resets the log, resolves this test's own catalog source pair via
-/// `FrameworkPaths::default()` (identical resolution `staleness_inputs` uses
-/// internally), runs the real fan-out, and asserts one compute for that pair.
+/// `FrameworkPaths::under(base)` (identical resolution `staleness_inputs_under`
+/// uses internally), runs the real fan-out, and asserts one compute for that
+/// pair.
 /// Test: this function; mutation-verified per the PR report (temporarily
 /// reinstating the per-task compute reproduces the critic's failure, then
 /// reverted).
+///
+/// #5040: base injected via [`fake_base`], so no `$HOME` redirect and no
+/// `#[serial]`.
 #[tokio::test]
-#[serial_test::serial]
 async fn stale_assets_for_many_computes_catalog_exactly_once_per_source_pair() {
-    let (home, _guard) = fake_home();
-    crate::core::update_check::reset_compute_call_log();
+    let base = fake_base();
+    // #5040: no `reset_compute_call_log()` — the log is process-global, so a
+    // clear from one test erases another's entries. `compute_calls_for` filters
+    // to the source pair built under THIS test's temp base, which is zero
+    // before the fan-out below by construction.
 
-    let fw = crate::core::paths::FrameworkPaths::default();
+    let fw = crate::core::paths::FrameworkPaths::under(base.path());
     let agent_source = fw.agent_source_dir();
     let skill_source = fw.skill_source_dir();
 
     let records: Vec<SessionRecord> = (0..3)
         .map(|i| {
-            let ws = home.path().join(format!("hot-path-shared-catalog-{i}"));
+            let ws = base.path().join(format!("hot-path-shared-catalog-{i}"));
             std::fs::create_dir_all(&ws).unwrap();
             let mut r = make_record(None);
             r.state = ManagedSessionState::Active;
@@ -931,7 +960,7 @@ async fn stale_assets_for_many_computes_catalog_exactly_once_per_source_pair() {
         })
         .collect();
 
-    let result = stale_assets_for_many(records).await;
+    let result = stale_assets_for_many_under(records, base.path().to_path_buf()).await;
 
     assert_eq!(result.len(), 3, "every record gets a result");
     assert_eq!(
@@ -1103,8 +1132,8 @@ async fn checked_summaries_stale_assets_independent_per_session_sharing_one_cata
 /// Why: the #4322 fleet tests all need the same shape — one machine-global
 /// agent deploy dir (#4409) plus N per-workspace skill trees — and building it
 /// inline three times would let the three tests drift apart.
-fn fleet_with_deployed_skills(home: &std::path::Path, count: usize) -> Vec<SessionRecord> {
-    let fw = crate::core::paths::FrameworkPaths::default();
+fn fleet_with_deployed_skills(base: &std::path::Path, count: usize) -> Vec<SessionRecord> {
+    let fw = crate::core::paths::FrameworkPaths::under(base);
     let bundled_agents = fw.agent_source_dir();
     let bundled_skills = fw.skill_source_dir();
     std::fs::create_dir_all(&bundled_agents).unwrap();
@@ -1120,9 +1149,9 @@ fn fleet_with_deployed_skills(home: &std::path::Path, count: usize) -> Vec<Sessi
 
     (0..count)
         .map(|i| {
-            let ws = home.join(format!("fleet-ws-{i}"));
+            let ws = base.join(format!("fleet-ws-{i}"));
             std::fs::create_dir_all(&ws).unwrap();
-            let ws_fw = crate::core::paths::FrameworkPaths::for_managed_workspace(&ws);
+            let ws_fw = crate::core::paths::FrameworkPaths::for_managed_workspace_under(base, &ws);
             crate::core::skill_tiers::deploy_all_skill_tiers(
                 &bundled_skills,
                 &fw.user_skill_source_dir(),
@@ -1161,20 +1190,24 @@ fn fleet_with_deployed_skills(home: &std::path::Path, count: usize) -> Vec<Sessi
 /// filtered `cargo test -- detect` run reproducibly observed 25 where this
 /// expected 5. Counts are therefore taken with
 /// `deployed_reads_under(<prefix>)`, scoped to directories that exist only
-/// inside THIS test's `fake_home()` temp dir, so no other test's reads can
-/// land under them. `#[serial_test::serial]` remains for the `$HOME` mutation
-/// it has always been required for, but correctness of the count no longer
-/// depends on it.
+/// inside THIS test's own temp base, so no other test's reads can land under
+/// them.
+///
+/// #5040: the base is now injected via [`fake_base`] and
+/// `stale_assets_for_many_under`, so the test mutates no `$HOME` and carries no
+/// `#[serial]` — it was the OTHER tests' `$HOME` writes that made this one
+/// report 25 reads where it expected 1.
 #[tokio::test]
-#[serial_test::serial]
 async fn stale_assets_for_many_reads_shared_agent_dir_once_for_the_whole_fleet() {
-    let (home, _guard) = fake_home();
-    let records = fleet_with_deployed_skills(home.path(), 4);
-    let fw = crate::core::paths::FrameworkPaths::default();
+    let base = fake_base();
+    let records = fleet_with_deployed_skills(base.path(), 4);
+    let fw = crate::core::paths::FrameworkPaths::under(base.path());
     let agents_dir = fw.agent_deploy_dir();
 
-    crate::core::update_check::reset_deployed_read_log();
-    let result = stale_assets_for_many(records).await;
+    // #5040: no `reset_deployed_read_log()` — a process-global clear from one
+    // test erases another's entries. `deployed_reads_under` filters to this
+    // test's own temp base, which is zero before the call below.
+    let result = stale_assets_for_many_under(records, base.path().to_path_buf()).await;
     let agent_reads = crate::core::update_check::deployed_reads_under(&agents_dir);
 
     assert_eq!(result.len(), 4, "every session must still get a verdict");
@@ -1186,9 +1219,10 @@ async fn stale_assets_for_many_reads_shared_agent_dir_once_for_the_whole_fleet()
          removed"
     );
     for i in 0..4 {
-        let ws = home.path().join(format!("fleet-ws-{i}"));
+        let ws = base.path().join(format!("fleet-ws-{i}"));
         let skills_dir =
-            crate::core::paths::FrameworkPaths::for_managed_workspace(&ws).claude_skills_dir();
+            crate::core::paths::FrameworkPaths::for_managed_workspace_under(base.path(), &ws)
+                .claude_skills_dir();
         assert_eq!(
             crate::core::update_check::deployed_reads_under(&skills_dir),
             1,
@@ -1212,12 +1246,11 @@ async fn stale_assets_for_many_reads_shared_agent_dir_once_for_the_whole_fleet()
 /// What: fresh fleet reports not-stale; the catalog then moves under it; the
 /// very next call reports stale.
 #[tokio::test]
-#[serial_test::serial]
 async fn stale_assets_for_many_sees_an_agent_change_on_the_very_next_call() {
-    let (home, _guard) = fake_home();
-    let records = fleet_with_deployed_skills(home.path(), 3);
+    let base = fake_base();
+    let records = fleet_with_deployed_skills(base.path(), 3);
 
-    let before = stale_assets_for_many(records.clone()).await;
+    let before = stale_assets_for_many_under(records.clone(), base.path().to_path_buf()).await;
     assert!(
         records.iter().all(|r| !before[&r.id]),
         "a freshly deployed fleet must start out fresh, else the assertion \
@@ -1225,14 +1258,14 @@ async fn stale_assets_for_many_sees_an_agent_change_on_the_very_next_call() {
     );
 
     // The catalog moves under the live process — no restart, no cache reset.
-    let fw = crate::core::paths::FrameworkPaths::default();
+    let fw = crate::core::paths::FrameworkPaths::under(base.path());
     std::fs::write(
         fw.agent_source_dir().join("rust-engineer.md"),
         "agent v2 — catalog moved",
     )
     .unwrap();
 
-    let after = stale_assets_for_many(records.clone()).await;
+    let after = stale_assets_for_many_under(records.clone(), base.path().to_path_buf()).await;
     assert!(
         records.iter().all(|r| after[&r.id]),
         "the NEXT call must observe the change immediately — sharing the \
@@ -1254,10 +1287,9 @@ async fn stale_assets_for_many_sees_an_agent_change_on_the_very_next_call() {
 /// What: 6 sessions, alternating drifted/fresh skill deployments, run through
 /// the real concurrent fan-out; each id must map to its own correct verdict.
 #[tokio::test]
-#[serial_test::serial]
 async fn stale_assets_for_many_keeps_per_session_verdicts_correct_under_concurrency() {
-    let (home, _guard) = fake_home();
-    let fw = crate::core::paths::FrameworkPaths::default();
+    let base = fake_base();
+    let fw = crate::core::paths::FrameworkPaths::under(base.path());
     let bundled_skills = fw.skill_source_dir();
     std::fs::create_dir_all(&bundled_skills).unwrap();
 
@@ -1272,9 +1304,10 @@ async fn stale_assets_for_many_keeps_per_session_verdicts_correct_under_concurre
         // Deploy every workspace from the CURRENT catalog, then move the
         // catalog on only for the ones that must end up stale.
         std::fs::write(bundled_skills.join("tm-doctor.md"), format!("skill v{i}")).unwrap();
-        let ws = home.path().join(format!("mixed-ws-{i}"));
+        let ws = base.path().join(format!("mixed-ws-{i}"));
         std::fs::create_dir_all(&ws).unwrap();
-        let ws_fw = crate::core::paths::FrameworkPaths::for_managed_workspace(&ws);
+        let ws_fw =
+            crate::core::paths::FrameworkPaths::for_managed_workspace_under(base.path(), &ws);
         crate::core::skill_tiers::deploy_all_skill_tiers(
             &bundled_skills,
             &fw.user_skill_source_dir(),
@@ -1304,8 +1337,9 @@ async fn stale_assets_for_many_keeps_per_session_verdicts_correct_under_concurre
         .iter()
         .enumerate()
         .map(|(i, id)| {
-            let ws = home.path().join(format!("mixed-ws-{i}"));
-            let ws_fw = crate::core::paths::FrameworkPaths::for_managed_workspace(&ws);
+            let ws = base.path().join(format!("mixed-ws-{i}"));
+            let ws_fw =
+                crate::core::paths::FrameworkPaths::for_managed_workspace_under(base.path(), &ws);
             let deployed =
                 std::fs::read_to_string(ws_fw.claude_skills_dir().join("tm-doctor/SKILL.md"))
                     .unwrap_or_default();
@@ -1313,7 +1347,7 @@ async fn stale_assets_for_many_keeps_per_session_verdicts_correct_under_concurre
         })
         .collect();
 
-    let got = stale_assets_for_many(records).await;
+    let got = stale_assets_for_many_under(records, base.path().to_path_buf()).await;
 
     assert!(
         expected.iter().any(|(_, stale)| *stale) && expected.iter().any(|(_, stale)| !*stale),

--- a/crates/trusty-mpm/src/session_manager/dedup_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/dedup_tests.rs
@@ -1219,16 +1219,11 @@ async fn reconcile_warns_that_a_terminal_record_has_a_live_tmux_session() {
     use tracing::instrument::WithSubscriber;
     use tracing_subscriber::layer::SubscriberExt;
 
-    // #4181: `tracing` short-circuits every macro on a process-global
-    // MAX_LEVEL that starts at OFF and is raised only when some test installs
-    // a GLOBAL default. A thread-local dispatcher never raises it, so without
-    // this the capture below would record `[]` whenever no other test in the
-    // binary happened to run first. See
-    // `ensure_managed_config_dir_emits_the_frozen_skill_warning`.
-    static RAISE_MAX_LEVEL: std::sync::Once = std::sync::Once::new();
-    RAISE_MAX_LEVEL.call_once(|| {
-        let _ = tracing::subscriber::set_global_default(tracing_subscriber::registry());
-    });
+    // #4181/#4931: `tracing` short-circuits every macro on a process-global
+    // MAX_LEVEL that starts at OFF and is raised only by a GLOBAL default
+    // subscriber, which a thread-local dispatcher is not. One entry point owns
+    // raising it for the whole binary.
+    crate::test_support::enable_event_capture();
 
     let dir = TempDir::new().unwrap();
     let ws_dir = TempDir::new().unwrap();

--- a/crates/trusty-mpm/src/test_support.rs
+++ b/crates/trusty-mpm/src/test_support.rs
@@ -349,6 +349,49 @@ pub(crate) fn isolated_daemon_home(allow_production: bool) -> (TempDir, DaemonHo
     (dir, override_guard)
 }
 
+/// Make `tracing` events reachable by a thread-local capturing subscriber, for
+/// the whole test process (#4931).
+///
+/// Why: `tracing`'s macros short-circuit on a process-global `MAX_LEVEL` that
+/// starts at `OFF` and is raised only when some subscriber is installed as the
+/// GLOBAL default. `tracing::subscriber::with_default` installs a THREAD-LOCAL
+/// one, which never raises it — so whether a capture test recorded anything
+/// depended on whether some unrelated test in the same binary had happened to
+/// install a global default first. `ensure_managed_config_dir_emits_the_frozen_skill_warning`
+/// failed that way at a measured 6-7 runs in 20, always with `Captured lines: []`,
+/// and `#[serial]` cannot help: the level is global and outlives the lock.
+///
+/// This is the ONE place that raises it. Two test modules had grown their own
+/// copy of the `Once` + `set_global_default` block; a third would be free to
+/// install a FILTERED global instead, which would clamp `MAX_LEVEL` below `WARN`
+/// and silently reintroduce the flake for every capture test in the binary. The
+/// post-condition below turns that into an immediate, named failure rather than
+/// an empty capture several frames away.
+/// What: installs a bare `tracing_subscriber::registry()` as the global default
+/// once per process (its `max_level_hint` is `None`, i.e. `TRACE`), then asserts
+/// the resulting global level admits `WARN`. A thread-local `with_default` still
+/// overrides the global for the capturing thread.
+/// Test: [`tests::event_capture_admits_warn`]; used by
+/// `core::managed_config_tests::ensure_managed_config_dir_emits_the_frozen_skill_warning`
+/// and `session_manager::dedup_tests`.
+pub(crate) fn enable_event_capture() {
+    static RAISE_MAX_LEVEL: Once = Once::new();
+    RAISE_MAX_LEVEL.call_once(|| {
+        // A global default may already be installed; that is fine as long as it
+        // does not clamp the level, which the assertion below verifies.
+        let _ = tracing::subscriber::set_global_default(tracing_subscriber::registry());
+    });
+    assert!(
+        tracing::level_filters::LevelFilter::current() >= tracing::Level::WARN,
+        "test_support::enable_event_capture(): the process-global tracing level \
+         is {:?}, which discards WARN events before any subscriber sees them \
+         (#4931). Some test in this binary installed a FILTERED global default \
+         subscriber; route it through this function, or give it a subscriber \
+         whose max_level_hint admits WARN.",
+        tracing::level_filters::LevelFilter::current()
+    );
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -591,5 +634,36 @@ mod tests {
     fn stale_after_is_positive_duration() {
         assert!(STALE_AFTER > Duration::from_secs(0));
         assert!(SystemTime::now().duration_since(UNIX_EPOCH).is_ok());
+    }
+
+    /// #4931: the whole point of [`super::enable_event_capture`] is that a
+    /// `tracing::warn!` reaches a thread-local subscriber afterwards. Pin both
+    /// halves — the global level admits `WARN`, and a `with_default` capture
+    /// installed after the call actually records one.
+    #[test]
+    fn event_capture_admits_warn() {
+        use tracing_subscriber::layer::SubscriberExt;
+
+        super::enable_event_capture();
+        assert!(
+            tracing::level_filters::LevelFilter::current() >= tracing::Level::WARN,
+            "the global level must admit WARN after enable_event_capture()"
+        );
+
+        let buffer = trusty_common::log_buffer::LogBuffer::new(8);
+        let subscriber = tracing_subscriber::registry().with(
+            trusty_common::log_buffer::LogBufferLayer::new(buffer.clone()),
+        );
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::warn!("enable-event-capture-probe");
+        });
+
+        let lines = buffer.tail(8);
+        assert!(
+            lines
+                .iter()
+                .any(|l| l.contains("enable-event-capture-probe")),
+            "a WARN emitted under with_default must reach the capture buffer,              else every capture test in this binary is silently vacuous: {lines:#?}"
+        );
     }
 }


### PR DESCRIPTION
Four flakes in `trusty-mpm`, root-caused and fixed together. Each was a test depending on process-global state — a `$HOME` other tests rewrite, a tracing level other tests raise, two independent timed probes, and a request timeout shorter than the work it bounds. None is stabilised by `#[ignore]`, a cfg-gate, an exclusion, or a bare timeout bump.

- `Refs #5111` — `DaemonClient::doctor` carries its own 120s bound. The handler runs the ~32-check battery inline (`gh auth status` alone measured 3.06s here, plus two worktree scans), so the 10s client default hung up on a report the daemon was still producing. Measured on `origin/main`: 8 of 10 isolated runs failed, failures clustered at 10.2–10.3s and passes at 9.6–9.7s. Same per-request override pattern as `CHAT_REQUEST_TIMEOUT` / `PROVISION_REQUEST_TIMEOUT` / `RECLAIM_SURVEY_REQUEST_TIMEOUT`; the client-level default is unchanged. This was a live defect, not only a test one — Telegram `/doctor` and Slack `/doctor` answered "daemon unreachable" for a healthy daemon.
- `Refs #5040` — the framework base and the resolved tmux options are now arguments rather than `$HOME` reads: `FrameworkPaths::for_managed_workspace_under` / `home_base`, `session_assets::session_plan_under`, `summary::stale_assets_for_many_under`, `core::tmux::create_managed_session_with_options`. Every existing entry point delegates with the value it read before, so production behaviour is unchanged. The five converted tests hand over their own temp dir, touch no environment variable, and carry no `#[serial]` — which never protected them anyway, since it orders `#[serial]` tests against each other only, and orders nothing at all under `cargo nextest`'s per-test processes. Also removes `reset_compute_call_log` and two `reset_deployed_read_log()` call sites: a process-global clear from one test erases entries another has already recorded, and the prefix/pair filters are what provide isolation.
- `Refs #4931` — `test_support::enable_event_capture()` is the single place that raises the process-global tracing MAX_LEVEL, replacing two copies of the same `Once` + `set_global_default` block, and it ASSERTS the resulting level admits `WARN`. A future test that installs a filtered global default now fails by name instead of silently emptying every capture in the binary.
- `Refs #4407` — `project_segment_basename_fallback_non_git` used to call the 100 ms-bounded `tmux_session_name()` a second time and require both runs to agree; either could time out independently (ok / FAILED / ok across three isolated runs on one tree). `project_segment_with(cwd, branch)` takes the resolved label, so the test states one deterministic input and covers both arms. CI never saw this one — the probe short-circuits on `$TMUX`, which GitHub's runners do not set.

## Gates

Rung 3 (localized behavior in one crate; the `_under` / `_with_options` constructors are additive and every prior entry point delegates unchanged).

```
cargo fmt --check                                     EXIT=0
cargo check -p trusty-mpm --all-targets               EXIT=0
cargo clippy -p trusty-mpm --all-targets -- -D warnings   EXIT=0
cargo test -p trusty-mpm --no-fail-fast               EXIT=0
  54 targets, 0 FAILED; lib: 5523 passed; 0 failed; 7 ignored
bash scripts/check_line_cap.sh                        EXIT=0  (4291 files, 0 violations)
bash scripts/check_sld.sh                             EXIT=0  (0 errors, 0 warnings)
bash scripts/check_test_pointers.sh                   EXIT=0  (27791 citations, 0 dangling)
CHANGELOG_BASE=origin/main bash scripts/check_changelog_fragment.sh   EXIT=0
```

### Reproduction, before the fix

`execute_doctor_against_test_daemon` on this branch's merge base, 5 isolated runs:

```
test result: FAILED. 0 passed; 1 failed; ... finished in 13.48s
test result: FAILED. 0 passed; 1 failed; ... finished in 10.39s
test result: FAILED. 0 passed; 1 failed; ... finished in 13.01s
test result: ok.     1 passed; 0 failed; ... finished in  9.94s
test result: FAILED. 0 passed; 1 failed; ... finished in 11.70s
```

### Stability, after the fix

10 consecutive runs of the 14 affected lib tests, then 10 of the 5 statusline tests, all `exit=0`:

```
=== lib run 1 ===   test result: ok. 14 passed; 0 failed; 1 ignored; ... 9.61s
=== lib run 2 ===   test result: ok. 14 passed; 0 failed; 1 ignored; ... 9.53s
=== lib run 3 ===   test result: ok. 14 passed; 0 failed; 1 ignored; ... 9.53s
=== lib run 4 ===   test result: ok. 14 passed; 0 failed; 1 ignored; ... 9.70s
=== lib run 5 ===   test result: ok. 14 passed; 0 failed; 1 ignored; ... 9.70s
=== lib run 6 ===   test result: ok. 14 passed; 0 failed; 1 ignored; ... 9.48s
=== lib run 7 ===   test result: ok. 14 passed; 0 failed; 1 ignored; ... 10.02s
=== lib run 8 ===   test result: ok. 14 passed; 0 failed; 1 ignored; ... 9.48s
=== lib run 9 ===   test result: ok. 14 passed; 0 failed; 1 ignored; ... 9.59s
=== lib run 10 ===  test result: ok. 14 passed; 0 failed; 1 ignored; ... 9.95s
=== bin run 1-10 === test result: ok. 5 passed; 0 failed; 0 ignored (each)
```

## Left open

The `checked_summaries_*` tests in `daemon::managed_routes::tests` still use `fake_home()` + `#[serial]`. They reach the staleness path through `checked_summaries` / `record_to_summary_checked`, which have production callers in `mod.rs`, `fleet.rs` and `cores.rs`, so making them hermetic means threading the base through those handlers too. None of them is in #5040's reported failing set, so that stays a separate change.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
