### PR TITLE
fix(trusty-review): wave-1 batch — map-reduce chunking, verdict parity, health dry_run, e2e flake

### DIFF
--- a/crates/trusty-review/changelog.d/wave1-review-batch.md
+++ b/crates/trusty-review/changelog.d/wave1-review-batch.md
@@ -1,0 +1,22 @@
+Fixed
+
+- A finding claiming a file is "not present in diff" no longer blocks a PR that
+  contains that file. A map call sees one chunk, so it cannot see the chunk that
+  adds the file it calls missing; the claim is now checked against the whole
+  changeset and the finding dropped when the changeset refutes it (#1873).
+- Caller-supplied `referenced_code` is pinned to the map-reduce per-file prompts
+  by an end-to-end test, and the branch restores and logs at error level any
+  caller context that failed to reach it instead of reviewing without it
+  (#2654).
+- The verdict embedded in `review_body` is reconciled to the authoritative
+  top-level verdict, so a merge gate reading `BLOCK` can no longer disagree with
+  an `APPROVE` printed inside the review. On the map-reduce path both the grade
+  and verdict reconciles now run after the shallow-review cap (#1902).
+- `review_health` and `/health` report the `dry_run` a review invoked through
+  that surface actually executes with, plus a `dry_run_reason` naming the gate —
+  previously they reported the raw config flag while every review ran dry and
+  posted nothing (#4254).
+- `report_analyze_e2e::analyze_populates_complexity_and_findings` no longer
+  fails when the temp path happens to spell a dropped diagnostic's code; the
+  drop check reads the structured finding rather than the whole rendered page
+  (#4387).

--- a/crates/trusty-review/src/mcp/tools.rs
+++ b/crates/trusty-review/src/mcp/tools.rs
@@ -35,6 +35,22 @@ use crate::{
     },
 };
 
+// ─── Posting posture (#4254) ─────────────────────────────────────────────────
+
+/// The trigger every MCP review tool runs under.
+///
+/// Why: `review_health` used to report `state.config.dry_run` while
+/// `review_pr` ran with these two constants, so a daemon configured live
+/// answered `dry_run: false` and then posted nothing (#4254). Naming the
+/// posture once, and reading it from both the review path and the health path,
+/// is what stops the two answers from drifting again.
+/// Test: `review_health_reports_the_dry_run_the_review_path_executes`.
+const MCP_REVIEW_TRIGGER: TriggerDecision = TriggerDecision::ForceDryRun;
+
+/// Whether an MCP review tool may post to GitHub. It may not — see
+/// [`MCP_REVIEW_TRIGGER`].
+const MCP_REVIEW_ALLOW_POSTING: bool = false;
+
 // ─── Tool definitions ────────────────────────────────────────────────────────
 
 /// Return the `tools/list` payload — one descriptor per exposed tool.
@@ -218,9 +234,9 @@ async fn call_review_pr(args: &Value, state: &AppState) -> Result<Value, ToolErr
         reviewer_model: reviewer_model.clone(),
         write_log: false,
         print_result: false,
-        trigger: TriggerDecision::ForceDryRun,
+        trigger: MCP_REVIEW_TRIGGER,
         run_mode: mcp_run_mode(&state.config),
-        allow_posting: false,
+        allow_posting: MCP_REVIEW_ALLOW_POSTING,
         caller_context: crate::pipeline::runner::CallerContext::default(),
         // Search-unreachable semantics fix: the MCP tool surface can never post
         // to a real PR (`allow_posting: false` above), so a search outage
@@ -275,9 +291,9 @@ async fn call_review_diff(args: &Value, state: &AppState) -> Result<Value, ToolE
         reviewer_model: reviewer_model.clone(),
         write_log: false,
         print_result: false,
-        trigger: TriggerDecision::ForceDryRun,
+        trigger: MCP_REVIEW_TRIGGER,
         run_mode: mcp_run_mode(&state.config),
-        allow_posting: false,
+        allow_posting: MCP_REVIEW_ALLOW_POSTING,
         caller_context: crate::pipeline::runner::CallerContext::default(),
         // See the matching comment in `call_review_pr` — same rationale.
         surface: InvocationSurface::Interactive,
@@ -306,13 +322,22 @@ async fn call_review_diff(args: &Value, state: &AppState) -> Result<Value, ToolE
 /// #3658), and the inference endpoint (via the cached `InferenceProbe`);
 /// computes `status` via the shared `compute_status` helper so the HTTP and
 /// MCP paths are always consistent; returns a JSON health snapshot with
-/// `status` (`"ok"` or `"degraded"`), `inference`, `dry_run`,
+/// `status` (`"ok"` or `"degraded"`), `inference`, `dry_run`, `dry_run_reason`,
 /// `reviewer_model`, and a `deps` object with `reachable` and tri-state
 /// `state` (`"ok"`/`"unreachable"`/`"timeout"`) for each dep.  When inference
 /// is not `"ok"` OR a required dep is unreachable, `status` becomes
 /// `"degraded"`.
+///
+/// #4254: `dry_run` is the value a review invoked through THIS surface
+/// executes with — computed by `surface_dry_run` from the same
+/// [`MCP_REVIEW_TRIGGER`] / [`MCP_REVIEW_ALLOW_POSTING`] the review handlers
+/// pass — not the raw `config.dry_run` flag, which the review path overrides
+/// and which therefore told callers reviews were being posted when none were.
+/// `dry_run_reason` names the gate, so a caller reading `dry_run: true` on a
+/// live-configured daemon is told why rather than left to guess.
 /// Test: `review_health_inference_ok`, `review_health_inference_auth_error_degraded`,
-/// `review_health_required_dep_down_degraded`, `review_health_optional_dep_down_ok`.
+/// `review_health_required_dep_down_degraded`, `review_health_optional_dep_down_ok`,
+/// `review_health_reports_the_dry_run_the_review_path_executes`.
 async fn call_review_health(state: &AppState) -> Value {
     let reviewer_model = state.config.role_models.reviewer.model.clone();
 
@@ -328,10 +353,18 @@ async fn call_review_health(state: &AppState) -> Value {
     // #722: status is "degraded" when inference fails OR any required dep is down.
     let status = compute_status(inference, &deps);
 
+    // #4254: the dry_run the review path executes with, not the config flag.
+    let (dry_run, dry_run_reason) = crate::pipeline::surface_dry_run(
+        state.config.dry_run,
+        MCP_REVIEW_TRIGGER,
+        MCP_REVIEW_ALLOW_POSTING,
+    );
+
     let result = serde_json::json!({
         "status": status,
         "version": env!("CARGO_PKG_VERSION"),
-        "dry_run": state.config.dry_run,
+        "dry_run": dry_run,
+        "dry_run_reason": dry_run_reason.map(|r| r.as_str()),
         "reviewer_model": reviewer_model,
         "inference": inference,
         "deps": {

--- a/crates/trusty-review/src/mcp/tools_tests.rs
+++ b/crates/trusty-review/src/mcp/tools_tests.rs
@@ -620,3 +620,38 @@ fn mcp_run_mode_resolves_cli_strategy() {
         AuthStrategy::Cli
     );
 }
+
+/// REGRESSION (#4254): `review_health` reports the dry_run the MCP review path
+/// executes with, never the raw config flag.
+///
+/// Why: the reported defect — `review_health` answered `"dry_run": false` while
+/// `review_pr` on the same process returned `"dry_run": true, "posted": false`
+/// and posted nothing. A caller gating on health believed reviews were reaching
+/// GitHub.
+/// What: builds a state whose config says LIVE (`dry_run = false`) — the exact
+/// configuration that produced the false answer — and asserts health reports
+/// `dry_run: true` with a reason naming the gate. Pre-fix this asserted
+/// `false == true` and failed.
+/// Test: this test itself.
+#[tokio::test]
+async fn review_health_reports_the_dry_run_the_review_path_executes() {
+    let mut config = ReviewConfig::load(None);
+    config.dry_run = false;
+    let state = AppState::new(config, Arc::new(OkLlmTool), Arc::new(FakeSearchTool), None);
+
+    let result = call_review_health(&state).await;
+    let text = result["content"][0]["text"].as_str().expect("text field");
+    let health: Value = serde_json::from_str(text).expect("valid JSON");
+
+    assert_eq!(
+        health["dry_run"], true,
+        "the MCP review tools force dry-run, so health must say so: {health}"
+    );
+    assert!(
+        health["dry_run_reason"]
+            .as_str()
+            .expect("a reason accompanies a forced dry-run")
+            .contains("never posts"),
+        "the reason names the gate: {health}"
+    );
+}

--- a/crates/trusty-review/src/pipeline/absence_claim.rs
+++ b/crates/trusty-review/src/pipeline/absence_claim.rs
@@ -1,0 +1,217 @@
+//! Drop findings whose premise is "this file is not in the diff" when it is
+//! (#1873).
+//!
+//! Why: `review_pr` returned BLOCK / grade F on PR #1872 off a single finding
+//! claiming `crates/trusty-mpm/src/daemon/doctor_fs_checks.rs` was "not present
+//! in diff → possible compile break". The file was in the diff — 411
+//! insertions — the crate compiled, and the whole suite passed on that SHA. Two
+//! consecutive reviews produced the same false BLOCK and the merge stopped for
+//! a human.
+//!
+//! The map-reduce path is where this originates. Each map call sees ONE file's
+//! chunk, so a chunk that removes a function and imports it from a new sibling
+//! module has no way to see the chunk that ADDS that sibling. The reviewer
+//! reasons correctly from what it was shown and reaches a conclusion the whole
+//! changeset refutes.
+//!
+//! What: [`drop_refuted_absence_claims`] finds findings whose own text asserts
+//! a named path is absent from the diff, and drops any whose named path the
+//! changeset actually touches. The claim is not weak evidence to be demoted
+//! (`finding_hygiene::demote_diff_absent_speculation`) or an unverifiable one
+//! to be marked advisory (`evidence_admission`) — it is a statement of fact
+//! about the changeset that the changeset itself disproves, which is the same
+//! standard `citation_check` drops a confabulated citation under.
+//!
+//! A claim naming a path the changeset does NOT touch is left alone: this
+//! refutes, it never confirms.
+//!
+//! Test: `absence_claim_tests.rs`, plus
+//! `mapreduce_phantom_missing_file_finding_does_not_block` (`runner_mapreduce_tests.rs`).
+
+use tracing::warn;
+
+use crate::models::Finding;
+use crate::pipeline::citation_check::DiffContentIndex;
+
+/// Case-insensitive substrings asserting that something is not in the diff.
+///
+/// Why: taken from the shape #1873 reported ("not present in diff → possible
+/// compile break") plus the near spellings of the same assertion. Each is a
+/// claim ABOUT THE CHANGESET, which is the class this module can check; a
+/// claim about the repository at large ("this file does not exist") is not,
+/// and is deliberately absent.
+/// What: matched with `str::contains` over the lowercased finding text.
+/// Test: `matches_each_absence_marker`.
+const ABSENCE_MARKERS: &[&str] = &[
+    "not present in diff",
+    "not present in the diff",
+    "not in the diff",
+    "not included in the diff",
+    "not included in this diff",
+    "missing from the diff",
+    "missing from this diff",
+    "absent from the diff",
+    "does not appear in the diff",
+    "is not part of this diff",
+    "no such file in the diff",
+];
+
+/// Drop every finding whose diff-absence claim the changeset refutes.
+///
+/// Why: a false premise that survives to the verdict floor is worse than no
+/// finding — #1873's phantom drove a full BLOCK at 0.55 confidence and cost a
+/// merge. Dropping (not demoting) is what `citation_check` already does for a
+/// citation the diff disproves, and it keeps the false claim out of the
+/// rendered review as well as out of the floor.
+/// What: for each finding, scans its `kind`/`description`/`consequence` one
+/// sentence at a time; a sentence carrying an [`ABSENCE_MARKERS`] phrase is
+/// searched for path-like tokens, and the finding is dropped when any of those
+/// paths — or the finding's own `file`, when the marker sentence names none —
+/// resolves in `index`. Returns how many were dropped.
+///
+/// Scoping the path search to the marker's own sentence is what keeps a finding
+/// that names two files (one genuinely absent, one present) from being dropped
+/// on the wrong one.
+/// Test: `refutes_a_missing_file_claim_when_the_file_is_in_the_diff`,
+/// `keeps_a_missing_file_claim_for_a_file_the_diff_does_not_touch`,
+/// `keeps_an_ordinary_finding`,
+/// `refutes_using_the_findings_own_file_when_the_sentence_names_no_path`,
+/// `ignores_a_present_path_in_a_different_sentence`.
+pub fn drop_refuted_absence_claims(findings: &mut Vec<Finding>, index: &DiffContentIndex) -> usize {
+    let mut dropped = 0usize;
+    let mut kept = Vec::with_capacity(findings.len());
+    for f in std::mem::take(findings) {
+        match refuted_path(&f, index) {
+            Some(path) => {
+                warn!(
+                    file = %f.file,
+                    line = ?f.line,
+                    kind = %f.kind,
+                    claimed_missing = %path,
+                    "absence-claim: dropping a finding that calls a changed file \
+                     missing from the diff (#1873)"
+                );
+                dropped += 1;
+            }
+            None => kept.push(f),
+        }
+    }
+    *findings = kept;
+    dropped
+}
+
+/// The path a finding calls absent that the changeset actually touches.
+///
+/// Why: the drop decision and the log line both want the specific path, so the
+/// check returns it rather than a bare bool.
+/// What: walks the sentences of the finding's text; for a sentence containing
+/// an absence marker, returns the first path-like token in it that resolves in
+/// `index`, or the finding's own `file` when the sentence names no path at all
+/// and that file resolves. `None` when nothing is refuted.
+/// Test: see [`drop_refuted_absence_claims`].
+fn refuted_path(f: &Finding, index: &DiffContentIndex) -> Option<String> {
+    let haystack = format!("{} {} {}", f.kind, f.description, f.consequence);
+    for sentence in sentences(&haystack) {
+        let lowered = sentence.to_lowercase();
+        if !ABSENCE_MARKERS.iter().any(|m| lowered.contains(m)) {
+            continue;
+        }
+        let mut named_any = false;
+        for candidate in path_candidates(sentence) {
+            named_any = true;
+            if index.contains_path(candidate) {
+                return Some(candidate.to_string());
+            }
+        }
+        // "the module is not present in the diff" names no path in its own
+        // text; the finding's `file` is then what it is talking about.
+        if !named_any && !f.file.trim().is_empty() && index.contains_path(&f.file) {
+            return Some(f.file.clone());
+        }
+    }
+    None
+}
+
+/// Split text into sentence-ish spans.
+///
+/// Why: a finding can name a genuinely-absent file in one sentence and a
+/// present one in the next; matching the marker against the whole finding
+/// would drop it on the unrelated path.
+/// What: splits on `.`, `;`, `!`, `?` and newlines. A path's own dots do not
+/// split it, because a split point must be followed by whitespace or end of
+/// text.
+/// Test: `ignores_a_present_path_in_a_different_sentence`.
+fn sentences(text: &str) -> Vec<&str> {
+    let bytes = text.as_bytes();
+    let mut out = Vec::new();
+    let mut start = 0usize;
+    for (i, &b) in bytes.iter().enumerate() {
+        let terminator = matches!(b, b'.' | b';' | b'!' | b'?' | b'\n');
+        if !terminator {
+            continue;
+        }
+        let ends_span = b == b'\n'
+            || bytes
+                .get(i + 1)
+                .is_none_or(|next| next.is_ascii_whitespace());
+        if ends_span {
+            out.push(&text[start..i]);
+            start = i + 1;
+        }
+    }
+    if start < text.len() {
+        out.push(&text[start..]);
+    }
+    out
+}
+
+/// The path-like tokens in one sentence.
+///
+/// Why: the claim names its subject as a path, usually backticked
+/// (`` `crates/trusty-mpm/src/daemon/doctor_fs_checks.rs` ``), sometimes bare.
+/// What: splits on whitespace, trims the punctuation and quoting a path
+/// acquires in prose, and keeps tokens that look like a file path — they carry
+/// a `/` or a dotted extension, and nothing but path characters.
+/// Test: `path_candidates_finds_backticked_and_bare_paths`.
+fn path_candidates(sentence: &str) -> Vec<&str> {
+    sentence
+        .split_whitespace()
+        .map(|t| {
+            t.trim_matches(|c: char| {
+                !c.is_ascii_alphanumeric() && c != '/' && c != '.' && c != '_' && c != '-'
+            })
+        })
+        .filter(|t| looks_like_path(t))
+        .collect()
+}
+
+/// Whether a token reads as a file path rather than prose.
+///
+/// What: at least three characters, only path characters, and either a `/`
+/// separator or a dotted extension of 1–8 alphanumerics. The extension bound
+/// is what keeps an abbreviation or an ellipsis out.
+/// Test: `path_candidates_finds_backticked_and_bare_paths`.
+fn looks_like_path(token: &str) -> bool {
+    if token.len() < 3
+        || !token
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '/' | '.' | '_' | '-'))
+    {
+        return false;
+    }
+    if token.contains('/') {
+        return true;
+    }
+    match token.rsplit_once('.') {
+        Some((stem, ext)) => {
+            !stem.is_empty()
+                && (1..=8).contains(&ext.len())
+                && ext.chars().all(|c| c.is_ascii_alphanumeric())
+        }
+        None => false,
+    }
+}
+
+#[cfg(test)]
+#[path = "absence_claim_tests.rs"]
+mod tests;

--- a/crates/trusty-review/src/pipeline/absence_claim_tests.rs
+++ b/crates/trusty-review/src/pipeline/absence_claim_tests.rs
@@ -1,0 +1,190 @@
+//! Unit tests for the diff-absence claim check (#1873).
+//!
+//! Why: the reported harm is a full BLOCK driven by one finding whose premise
+//! the changeset disproves. These pin both directions — the refuted claim is
+//! dropped, and a claim about a file the diff really does not touch survives.
+//! What: drives `drop_refuted_absence_claims` against a two-file index built
+//! the way `citation_check_tests` builds one.
+//! Test: this file.
+
+use super::*;
+use crate::models::{Effort, Finding};
+use crate::pipeline::diff_analyzer::models::{
+    FileDisposition, FilteredDiff, FilteredFile, FilteredHunk,
+};
+use std::collections::HashMap;
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+fn kept_file(name: &str, lines: &[&str]) -> FilteredFile {
+    FilteredFile {
+        filename: name.to_string(),
+        status: "modified".to_string(),
+        disposition: FileDisposition::Kept,
+        hunks: vec![FilteredHunk {
+            header: "@@ -1,1 +1,2 @@".to_string(),
+            lines: lines.iter().map(|l| l.to_string()).collect(),
+            substantive_confidence: 1.0,
+            reason_kept: "test".to_string(),
+        }],
+        dropped_hunks: Vec::new(),
+        summary_line: None,
+    }
+}
+
+/// The #1873 changeset shape: a file that imports from a NEW sibling module,
+/// plus that sibling — the two chunks a map call never sees together.
+fn index_1873() -> DiffContentIndex {
+    DiffContentIndex::from_filtered(&FilteredDiff {
+        files: vec![
+            kept_file(
+                "crates/trusty-mpm/src/daemon/doctor.rs",
+                &[
+                    "+#[path = \"doctor_fs_checks.rs\"]",
+                    "+mod doctor_fs_checks;",
+                ],
+            ),
+            kept_file(
+                "crates/trusty-mpm/src/daemon/doctor_fs_checks.rs",
+                &["+pub fn check_fs() -> bool { true }"],
+            ),
+        ],
+        dropped_files: Vec::new(),
+        drop_hunk_counts: HashMap::new(),
+        original_byte_size: 0,
+        filtered_byte_size: 0,
+    })
+}
+
+fn finding(file: &str, description: &str) -> Finding {
+    Finding::new(
+        file,
+        "compile-break",
+        description,
+        "add the module",
+        0.55,
+        Effort::High,
+    )
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+/// REGRESSION (#1873): the verbatim phantom — a finding calling a file missing
+/// from the diff when the diff adds it — is dropped.
+#[test]
+fn refutes_a_missing_file_claim_when_the_file_is_in_the_diff() {
+    let index = index_1873();
+    let mut findings = vec![finding(
+        "crates/trusty-mpm/src/daemon/doctor.rs",
+        "doctor.rs declares `#[path = \"doctor_fs_checks.rs\"] mod doctor_fs_checks;` but \
+         `crates/trusty-mpm/src/daemon/doctor_fs_checks.rs` is not present in diff — \
+         possible compile break.",
+    )];
+
+    let dropped = drop_refuted_absence_claims(&mut findings, &index);
+
+    assert_eq!(
+        dropped, 1,
+        "the changeset adds the file the claim calls absent"
+    );
+    assert!(
+        findings.is_empty(),
+        "a finding resting on a refuted premise must not reach the verdict floor"
+    );
+}
+
+/// A claim about a file the changeset genuinely does not touch survives — this
+/// check refutes, it never confirms.
+#[test]
+fn keeps_a_missing_file_claim_for_a_file_the_diff_does_not_touch() {
+    let index = index_1873();
+    let mut findings = vec![finding(
+        "crates/trusty-mpm/src/daemon/doctor.rs",
+        "`crates/trusty-mpm/src/daemon/doctor_net_checks.rs` is not present in diff.",
+    )];
+
+    let dropped = drop_refuted_absence_claims(&mut findings, &index);
+
+    assert_eq!(dropped, 0, "nothing in the changeset refutes this claim");
+    assert_eq!(findings.len(), 1);
+}
+
+/// An ordinary finding with no absence claim is untouched.
+#[test]
+fn keeps_an_ordinary_finding() {
+    let index = index_1873();
+    let mut findings = vec![finding(
+        "crates/trusty-mpm/src/daemon/doctor.rs",
+        "check_fs() returns true unconditionally, so the doctor never reports a \
+         filesystem failure.",
+    )];
+
+    let dropped = drop_refuted_absence_claims(&mut findings, &index);
+
+    assert_eq!(dropped, 0);
+    assert_eq!(findings.len(), 1);
+}
+
+/// A claim naming no path is judged against the finding's own `file`.
+#[test]
+fn refutes_using_the_findings_own_file_when_the_sentence_names_no_path() {
+    let index = index_1873();
+    let mut findings = vec![finding(
+        "crates/trusty-mpm/src/daemon/doctor_fs_checks.rs",
+        "The referenced module is not present in the diff, so this will not compile.",
+    )];
+
+    let dropped = drop_refuted_absence_claims(&mut findings, &index);
+
+    assert_eq!(dropped, 1);
+    assert!(findings.is_empty());
+}
+
+/// A present path in a DIFFERENT sentence does not refute an absence claim
+/// about another file.
+#[test]
+fn ignores_a_present_path_in_a_different_sentence() {
+    let index = index_1873();
+    let mut findings = vec![finding(
+        "crates/trusty-mpm/src/daemon/doctor.rs",
+        "`crates/trusty-mpm/src/daemon/doctor.rs` grew a module declaration. \
+         `crates/trusty-mpm/src/daemon/doctor_net_checks.rs` is not present in diff.",
+    )];
+
+    let dropped = drop_refuted_absence_claims(&mut findings, &index);
+
+    assert_eq!(
+        dropped, 0,
+        "the present path is in a sentence that makes no absence claim"
+    );
+    assert_eq!(findings.len(), 1);
+}
+
+/// Every marker phrase is recognised, so a rewording of the same claim is not
+/// a way past the check.
+#[test]
+fn matches_each_absence_marker() {
+    let index = index_1873();
+    for marker in ABSENCE_MARKERS {
+        let mut findings = vec![finding(
+            "crates/trusty-mpm/src/daemon/doctor.rs",
+            &format!(
+                "`crates/trusty-mpm/src/daemon/doctor_fs_checks.rs` {marker} — compile break."
+            ),
+        )];
+        let dropped = drop_refuted_absence_claims(&mut findings, &index);
+        assert_eq!(dropped, 1, "marker not recognised: {marker:?}");
+    }
+}
+
+/// Path extraction reads a backticked path, a bare one, and one wearing
+/// trailing punctuation — and reads prose as prose.
+#[test]
+fn path_candidates_finds_backticked_and_bare_paths() {
+    let found = path_candidates("`src/a.rs` and src/b.rs, plus lib.rs — but not this.");
+    assert_eq!(found, vec!["src/a.rs", "src/b.rs", "lib.rs"]);
+    assert!(
+        path_candidates("the module is gone, i.e. removed").is_empty(),
+        "prose with a dotted abbreviation is not a path"
+    );
+}

--- a/crates/trusty-review/src/pipeline/citation_check.rs
+++ b/crates/trusty-review/src/pipeline/citation_check.rs
@@ -215,6 +215,19 @@ impl DiffContentIndex {
         }
         hit
     }
+
+    /// Whether `cited_path` names a file this changeset touches.
+    ///
+    /// Why: #1873 — a finding can assert a file is ABSENT from the diff, and
+    /// refuting that assertion needs the changeset's file list, not its
+    /// content. The index already holds every touched path (including Stage-A
+    /// exclusions), so the absence check reuses it rather than rebuilding one.
+    /// What: `true` when [`Self::lookup`] resolves the path, exactly (after
+    /// normalization) or by unique basename.
+    /// Test: `refutes_a_missing_file_claim_when_the_file_is_in_the_diff`.
+    pub fn contains_path(&self, cited_path: &str) -> bool {
+        self.lookup(cited_path).is_some()
+    }
 }
 
 // ─── Public entry point ─────────────────────────────────────────────────────────

--- a/crates/trusty-review/src/pipeline/grade_reconcile.rs
+++ b/crates/trusty-review/src/pipeline/grade_reconcile.rs
@@ -29,7 +29,15 @@
 //! quoted value, and replaces only the value.  Grade strings are ASCII with no
 //! embedded quotes, so the scan is byte-safe even amid multi-byte UTF-8 prose.
 //!
+//! #1902 generalises the same rewrite to the `"verdict"` key. The top-level
+//! `verdict` is authoritative for exactly the same reason the grade is — it is
+//! computed after the severity floor, the coverage floor, and the verification
+//! round — and `review_body` carried the model's raw pre-adjustment lean beside
+//! it. See [`reconcile_review_body_verdict`].
+//!
 //! Test: `grade_reconcile_tests.rs`.
+
+use crate::models::Verdict;
 
 /// The JSON key token whose string value is the embedded letter grade.
 ///
@@ -39,6 +47,15 @@
 /// What: the literal searched for in the body to locate each embedded grade value.
 /// Test: `reconcile_leaves_grade_justification_untouched`.
 const GRADE_KEY_TOKEN: &str = "\"grade\"";
+
+/// The JSON key token whose string value is the embedded verdict (#1902).
+///
+/// Why: the same fully-quoted-key rule as [`GRADE_KEY_TOKEN`] — matching
+/// `"verdict"` and not the bare word is what keeps `"verdict_justification"`
+/// untouched, since the byte after `verdict` there is `_`, not the closing `"`.
+/// What: the literal searched for in the body to locate each embedded verdict.
+/// Test: `reconcile_leaves_verdict_justification_untouched`.
+const VERDICT_KEY_TOKEN: &str = "\"verdict\"";
 
 /// Rewrite every JSON `"grade"` value in `review_body` to the final `grade`.
 ///
@@ -65,13 +82,55 @@ pub(crate) fn reconcile_review_body_grade(body: &str, final_grade: Option<&str>)
     let Some(new_grade) = final_grade else {
         return body.to_string();
     };
+    rewrite_json_string_values(body, GRADE_KEY_TOKEN, new_grade)
+}
 
-    let mut out = String::with_capacity(body.len() + new_grade.len());
+/// Rewrite every JSON `"verdict"` value in `review_body` to the final verdict.
+///
+/// Why: #1886 reconciled the embedded GRADE and stopped there, so the same
+/// staleness survived one field over (#1902). A `review_pr` on PR #1901
+/// returned a top-level `verdict: BLOCK` while the verdict inside `review_body`
+/// read `APPROVE`: the top-level value is the pipeline's, computed after the
+/// severity floor, the coverage floor, and the verification round, while the
+/// embedded one is the model's raw pre-adjustment lean. An automated merge gate
+/// reading the top-level `BLOCK` refused to proceed while the review a human
+/// read said APPROVE, and the disagreement cost a manual investigation.
+/// What: mirrors the authoritative verdict into the model's own JSON with the
+/// same conservative rewrite [`reconcile_review_body_grade`] uses — the key
+/// token `"verdict"` followed by a quoted value, value replaced, everything
+/// else byte-for-byte. A body with no JSON `"verdict"` key (the map-reduce
+/// prose summary) is returned unchanged; `"verdict_justification"` never
+/// matches. `UNKNOWN` is written like any other verdict: unlike a grade, it is
+/// a real assessed outcome, not the absence of one.
+/// Test: `reconcile_rewrites_direct_json_verdict`,
+/// `reconcile_rewrites_fenced_block_verdict`,
+/// `reconcile_leaves_verdict_justification_untouched`,
+/// `reconcile_verdict_prose_without_verdict_is_noop`,
+/// `reconcile_rewrites_all_verdict_occurrences`.
+pub(crate) fn reconcile_review_body_verdict(body: &str, final_verdict: &Verdict) -> String {
+    rewrite_json_string_values(body, VERDICT_KEY_TOKEN, &final_verdict.to_string())
+}
+
+/// Replace the quoted string value of every `key_token` occurrence in `body`.
+///
+/// Why: the grade (#1886) and verdict (#1902) reconciliations are one rewrite
+/// over two keys; a second copy of the scanner would drift the moment either
+/// one's edge cases changed.
+/// What: walks `body` for `key_token`, and for each occurrence whose value is a
+/// quoted string, emits everything up to the opening quote verbatim, then
+/// `new_value`, then resumes at the closing quote. An occurrence that is not
+/// followed by a quoted string value (`null`, a number, a truncated tail) is
+/// emitted untouched and the scan continues past it. The scan compares single
+/// ASCII bytes only, so it is byte-safe amid multi-byte UTF-8 prose.
+/// Test: the `reconcile_*` cases in `grade_reconcile_tests.rs`, which drive
+/// this through both public wrappers.
+fn rewrite_json_string_values(body: &str, key_token: &str, new_value: &str) -> String {
+    let mut out = String::with_capacity(body.len() + new_value.len());
     let mut cursor = 0usize;
 
-    while let Some(rel) = body[cursor..].find(GRADE_KEY_TOKEN) {
+    while let Some(rel) = body[cursor..].find(key_token) {
         let key_start = cursor + rel;
-        let key_end = key_start + GRADE_KEY_TOKEN.len();
+        let key_end = key_start + key_token.len();
 
         match string_value_span(body, key_end) {
             // `key_end..value_start` includes the `:`, any whitespace, and the
@@ -79,7 +138,7 @@ pub(crate) fn reconcile_review_body_grade(body: &str, final_grade: Option<&str>)
             // the closing quote so it (and everything after) is emitted next.
             Some((value_start, close_quote)) => {
                 out.push_str(&body[cursor..value_start]);
-                out.push_str(new_grade);
+                out.push_str(new_value);
                 cursor = close_quote;
             }
             // `"grade"` is present but not a quoted string value (e.g. `null`,
@@ -96,7 +155,7 @@ pub(crate) fn reconcile_review_body_grade(body: &str, final_grade: Option<&str>)
     out
 }
 
-/// Locate the quoted string value that follows a `"grade"` key.
+/// Locate the quoted string value that follows a rewritten key.
 ///
 /// Why: the rewrite must find exactly the value between the quotes so it can splice
 /// in the authoritative grade while preserving the key, colon, whitespace, and the

--- a/crates/trusty-review/src/pipeline/grade_reconcile_tests.rs
+++ b/crates/trusty-review/src/pipeline/grade_reconcile_tests.rs
@@ -7,7 +7,8 @@
 //! What: exercises `reconcile_review_body_grade` directly with hand-built bodies.
 //! Test: this file.
 
-use super::reconcile_review_body_grade;
+use super::{reconcile_review_body_grade, reconcile_review_body_verdict};
+use crate::models::Verdict;
 
 /// A direct-JSON body (structured-output path) has its `"grade"` value rewritten.
 ///
@@ -156,4 +157,67 @@ fn reconcile_unterminated_grade_value_is_noop() {
     let body = r#"{"grade":"B+"#; // no closing quote
     let out = reconcile_review_body_grade(body, Some("C"));
     assert_eq!(out, body);
+}
+
+// ── Verdict reconciliation (#1902) ───────────────────────────────────────────
+
+/// A direct-JSON body has its `"verdict"` value rewritten to the final verdict.
+///
+/// Why: the divergence #1902 reports — the model self-assessed APPROVE while the
+/// pipeline's floor settled on BLOCK, and both values were observable.
+/// What: asserts the embedded `"APPROVE"` becomes `"BLOCK"` and the grade,
+/// summary and findings are untouched.
+/// Test: this test.
+#[test]
+fn reconcile_rewrites_direct_json_verdict() {
+    let body = r#"{"verdict":"APPROVE","grade":"B+","summary":"LGTM","findings":[]}"#;
+    let out = reconcile_review_body_verdict(body, &Verdict::Block);
+    assert_eq!(
+        out,
+        r#"{"verdict":"BLOCK","grade":"B+","summary":"LGTM","findings":[]}"#
+    );
+}
+
+/// A fenced-block body keeps its prose and fences; only the verdict changes.
+#[test]
+fn reconcile_rewrites_fenced_block_verdict() {
+    let body = "Looks good.\n\n```json\n{\"verdict\":\"APPROVE\",\"grade\":\"A\"}\n```";
+    let out = reconcile_review_body_verdict(body, &Verdict::RequestChanges);
+    assert_eq!(
+        out,
+        "Looks good.\n\n```json\n{\"verdict\":\"REQUEST_CHANGES\",\"grade\":\"A\"}\n```"
+    );
+}
+
+/// `"verdict_justification"` is a different key and is never rewritten.
+///
+/// Why: the near-miss key is the one way a fixed-substring rewrite corrupts a
+/// body it should not touch — `"verdict"` matches only with its closing quote.
+/// What: asserts the justification prose survives while the real verdict moves.
+/// Test: this test.
+#[test]
+fn reconcile_leaves_verdict_justification_untouched() {
+    let body = r#"{"verdict":"APPROVE","verdict_justification":"APPROVE because nothing blocks"}"#;
+    let out = reconcile_review_body_verdict(body, &Verdict::Block);
+    assert_eq!(
+        out,
+        r#"{"verdict":"BLOCK","verdict_justification":"APPROVE because nothing blocks"}"#
+    );
+}
+
+/// A prose-only body (the map-reduce synthesis summary) is returned unchanged.
+#[test]
+fn reconcile_verdict_prose_without_verdict_is_noop() {
+    let body = "Map-reduce review: 3 file(s) reviewed across 4 unit(s).";
+    let out = reconcile_review_body_verdict(body, &Verdict::Block);
+    assert_eq!(out, body);
+}
+
+/// Every occurrence is rewritten — a body that repeats the field in a summary
+/// block and a JSON block cannot half-agree with the envelope.
+#[test]
+fn reconcile_rewrites_all_verdict_occurrences() {
+    let body = r#"{"verdict":"APPROVE"} … also {"verdict":"APPROVE*"}"#;
+    let out = reconcile_review_body_verdict(body, &Verdict::Unknown);
+    assert_eq!(out, r#"{"verdict":"UNKNOWN"} … also {"verdict":"UNKNOWN"}"#);
 }

--- a/crates/trusty-review/src/pipeline/mapreduce/mod.rs
+++ b/crates/trusty-review/src/pipeline/mapreduce/mod.rs
@@ -93,6 +93,10 @@ pub async fn run_map_reduce(
             let findings_before = findings.len();
             crate::pipeline::finding_hygiene::sanitize_findings(findings);
             crate::pipeline::citation_check::enforce_citation_integrity(findings, &cite_index);
+            // #1873: a map call sees ONE chunk, so it cannot see the chunk that
+            // ADDS the file it is about to call missing. The whole changeset
+            // can, and refutes the claim here before it reaches the floor.
+            crate::pipeline::absence_claim::drop_refuted_absence_claims(findings, &cite_index);
             // This chunk's own `verdict` field rested on the SAME findings we
             // may have just wiped out — relax it too so a wiped-out chunk
             // cannot poison `reduce`'s stricter-of-all-chunks seed (#4042,

--- a/crates/trusty-review/src/pipeline/mod.rs
+++ b/crates/trusty-review/src/pipeline/mod.rs
@@ -92,7 +92,9 @@ pub use letter_grade::{
 };
 pub use output::{log_json_path, print_review_result, write_review_log};
 pub use parser::{ParsedReview, parse_review_response};
-pub use post::{FinalizeAction, PostContext, decide_action, finalize_review};
+pub use post::{
+    DryRunReason, FinalizeAction, PostContext, decide_action, finalize_review, surface_dry_run,
+};
 pub use prompt::{
     ReviewContext, ReviewPrMeta, build_review_prompt, build_review_prompt_with_coverage,
     build_system_prompt, build_system_prompt_with_coverage, reviewer_system_prompt,

--- a/crates/trusty-review/src/pipeline/mod.rs
+++ b/crates/trusty-review/src/pipeline/mod.rs
@@ -24,6 +24,7 @@
 //!
 //! Test: each submodule carries its own unit tests.
 
+pub mod absence_claim;
 pub mod citation_check;
 // Why: the grounding guard for package-registry / version-existence claims
 // (#4081) — kept separate from `finding_hygiene` (self-admission markers) and

--- a/crates/trusty-review/src/pipeline/post.rs
+++ b/crates/trusty-review/src/pipeline/post.rs
@@ -168,6 +168,76 @@ pub fn decide_action(
     }
 }
 
+/// Why a surface's reviews run dry, when they cannot run live at all (#4254).
+///
+/// Why: a health endpoint that reports the raw `config.dry_run` answers a
+/// different question from the one the caller asked. `review_health` reported
+/// `dry_run: false` while every `review_pr` on the same process returned
+/// `dry_run: true` and posted nothing, because the MCP tools pass
+/// `allow_posting: false` and `TriggerDecision::ForceDryRun` — two gates the
+/// config flag never sees. A caller that trusts the config flag believes
+/// reviews reach GitHub when they cannot.
+/// What: the sentence a health payload carries beside an effective `dry_run` of
+/// `true`, naming which gate decided it. `None` when the surface would post.
+/// Test: `surface_dry_run_reason_names_the_deciding_gate`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DryRunReason {
+    /// The surface never posts: it hard-codes `allow_posting: false` and/or
+    /// `TriggerDecision::ForceDryRun`, regardless of configuration.
+    SurfaceNeverPosts,
+    /// The surface would post, but the operator configured dry-run
+    /// (`PR_INTELLIGENCE_DRY_RUN`).
+    ConfiguredDryRun,
+}
+
+impl DryRunReason {
+    /// The reason as the sentence a health payload renders.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::SurfaceNeverPosts => {
+                "this surface never posts to GitHub — its reviews always run dry \
+                 (allow_posting=false and/or force_dry_run), independent of \
+                 PR_INTELLIGENCE_DRY_RUN"
+            }
+            Self::ConfiguredDryRun => {
+                "PR_INTELLIGENCE_DRY_RUN is set — reviews run dry and post nothing"
+            }
+        }
+    }
+}
+
+/// The `dry_run` a review invoked through one surface actually executes with.
+///
+/// Why: #4254 — `review_health` read `config.dry_run` while the review path read
+/// [`decide_action`]. Two computations of one fact drift, and this one drifted
+/// silently: nothing errored, reviews simply stopped reaching GitHub while the
+/// health endpoint kept saying they did. Every health surface now derives its
+/// answer from the SAME function, passed the SAME posting posture constants its
+/// own review path passes.
+/// What: returns the effective dry-run plus, when it is `true`, which gate
+/// decided it. `is_github_source: true` is assumed — a health endpoint is asked
+/// about the surface, not about one diff's origin, and a local diff can only
+/// make a live surface drier, never the reverse.
+/// Test: `surface_dry_run_matches_decide_action`,
+/// `surface_dry_run_reason_names_the_deciding_gate`.
+pub fn surface_dry_run(
+    config_dry_run: bool,
+    trigger: TriggerDecision,
+    allow_posting: bool,
+) -> (bool, Option<DryRunReason>) {
+    if decide_action(config_dry_run, trigger, allow_posting, true) == FinalizeAction::Post {
+        return (false, None);
+    }
+    // A surface that would post with the config flag cleared is dry only because
+    // the operator asked for it; one that stays dry either way never posts.
+    let reason = if decide_action(false, trigger, allow_posting, true) == FinalizeAction::Post {
+        DryRunReason::ConfiguredDryRun
+    } else {
+        DryRunReason::SurfaceNeverPosts
+    };
+    (true, Some(reason))
+}
+
 /// Count the findings nothing rendered a judgment on (#4459).
 ///
 /// Why: both canonical exits — `finalize_review` here and `abort_dry` in
@@ -592,6 +662,51 @@ mod tests {
         assert_eq!(
             decide_action(false, TriggerDecision::ForceDryRun, true, true),
             FinalizeAction::LogOnly
+        );
+    }
+
+    /// #4254: the health answer and the review behaviour are the SAME
+    /// computation — `surface_dry_run` agrees with `decide_action` on every
+    /// combination of the three inputs.
+    #[test]
+    fn surface_dry_run_matches_decide_action() {
+        for config_dry in [false, true] {
+            for trigger in [
+                TriggerDecision::None,
+                TriggerDecision::ForceLive,
+                TriggerDecision::ForceDryRun,
+            ] {
+                for allow in [false, true] {
+                    let (dry, _) = surface_dry_run(config_dry, trigger, allow);
+                    let posts =
+                        decide_action(config_dry, trigger, allow, true) == FinalizeAction::Post;
+                    assert_eq!(
+                        dry, !posts,
+                        "config_dry={config_dry} trigger={trigger:?} allow={allow}"
+                    );
+                }
+            }
+        }
+    }
+
+    /// #4254: a caller told `dry_run: true` is told which gate decided it — the
+    /// surface's own hard-coded posture, or the operator's config flag.
+    #[test]
+    fn surface_dry_run_reason_names_the_deciding_gate() {
+        // The MCP / RPC review surfaces: never post, whatever the config says.
+        assert_eq!(
+            surface_dry_run(false, TriggerDecision::ForceDryRun, false),
+            (true, Some(DryRunReason::SurfaceNeverPosts))
+        );
+        // A posting surface the operator put in dry-run.
+        assert_eq!(
+            surface_dry_run(true, TriggerDecision::None, true),
+            (true, Some(DryRunReason::ConfiguredDryRun))
+        );
+        // A posting surface running live carries no reason.
+        assert_eq!(
+            surface_dry_run(false, TriggerDecision::None, true),
+            (false, None)
         );
     }
 

--- a/crates/trusty-review/src/pipeline/runner.rs
+++ b/crates/trusty-review/src/pipeline/runner.rs
@@ -654,6 +654,12 @@ pub async fn run_review(
     let cite_index = crate::pipeline::citation_check::DiffContentIndex::from_filtered(&filtered);
     crate::pipeline::citation_check::enforce_citation_integrity(&mut parsed.findings, &cite_index);
 
+    // ── Step 7-absent: refute "this file is not in the diff" claims (#1873) ─
+    // A render truncation can hide a file's content from this path's single
+    // prompt the way chunking hides it from a map call, so the claim is checked
+    // against the changeset here too.
+    crate::pipeline::absence_claim::drop_refuted_absence_claims(&mut parsed.findings, &cite_index);
+
     // ── Step 7-relax: the model's own raw verdict/grade rested on the SAME
     // findings we may have just wiped out entirely — relax it too (#4042,
     // #4044). See `finding_hygiene::relax_verdict_if_evidence_wiped` doc for

--- a/crates/trusty-review/src/pipeline/runner.rs
+++ b/crates/trusty-review/src/pipeline/runner.rs
@@ -18,7 +18,8 @@ use tracing::{debug, error, info, warn};
 use super::runner_coverage::load_coverage_contrib;
 use super::runner_helpers::{
     DedupClaim, abort_dry, apply_grade_and_floor, attach_inline_comments, build_author_rationale,
-    fetch_github_pr_meta, finalize_run, mark_no_head_sha_abort, resolve_diff_token,
+    fetch_github_pr_meta, finalize_run, ground_parsed_findings, mark_no_head_sha_abort,
+    resolve_diff_token,
 };
 use crate::{
     config::{
@@ -639,38 +640,11 @@ pub async fn run_review(
         result.error = Some(format!("review not parsed — {reason}"));
     }
 
-    // ── Step 7-hyg: drop self-negated / CoT-leaking findings (#4044) ───────
-    // A finding that withdraws itself in its own text, or leaks raw mid-
-    // reasoning deliberation, must never reach the rendered review or the
-    // verdict floor — see `finding_hygiene` module doc.
-    let findings_before_hygiene = parsed.findings.len();
-    crate::pipeline::finding_hygiene::sanitize_findings(&mut parsed.findings);
-
-    // ── Step 7-cite: enforce citation integrity BEFORE grading (#2881, #4042) ─
-    // Every finding's cited path (and, where quoted, content) must verifiably
-    // exist in the diff; a finding that fails is DROPPED (never downgraded-but-
-    // kept) so a fabrication can never fail-close a clean PR nor survive into
-    // the rendered review.
-    let cite_index = crate::pipeline::citation_check::DiffContentIndex::from_filtered(&filtered);
-    crate::pipeline::citation_check::enforce_citation_integrity(&mut parsed.findings, &cite_index);
-
-    // ── Step 7-absent: refute "this file is not in the diff" claims (#1873) ─
-    // A render truncation can hide a file's content from this path's single
-    // prompt the way chunking hides it from a map call, so the claim is checked
-    // against the changeset here too.
-    crate::pipeline::absence_claim::drop_refuted_absence_claims(&mut parsed.findings, &cite_index);
-
-    // ── Step 7-relax: the model's own raw verdict/grade rested on the SAME
-    // findings we may have just wiped out entirely — relax it too (#4042,
-    // #4044). See `finding_hygiene::relax_verdict_if_evidence_wiped` doc for
-    // why this is safe and does not touch `derive_verdict`'s shared floor
-    // semantics.
-    crate::pipeline::finding_hygiene::relax_verdict_if_evidence_wiped(
-        &mut parsed.verdict,
-        &mut parsed.grade,
-        findings_before_hygiene,
-        &parsed.findings,
-    );
+    // ── Step 7-hyg/cite/absent/relax: output hygiene + grounding ──────────
+    // Self-negated findings, ungrounded citations, refuted diff-absence claims,
+    // and a self-reported verdict left resting on findings this run removed —
+    // all four run before grading. See `ground_parsed_findings`.
+    ground_parsed_findings(&mut parsed, &filtered);
 
     // ── Step 7b–7e: grade derivation, coverage floor, verification, reconcile ─
     // `original_llm_grade` is the pre-floor LLM grade; it is held separately so

--- a/crates/trusty-review/src/pipeline/runner.rs
+++ b/crates/trusty-review/src/pipeline/runner.rs
@@ -806,6 +806,16 @@ pub async fn run_review(
         result.grade.as_deref(),
     );
 
+    // #1902: the verdict embedded in the same raw JSON is stale for the same
+    // reason the grade was — it is the model's pre-floor lean, not the value
+    // the severity floor, coverage floor, and verification round settled on.
+    // A merge gate reading the top-level BLOCK while a human read an embedded
+    // APPROVE is the reported harm.
+    result.review_body = crate::pipeline::grade_reconcile::reconcile_review_body_verdict(
+        &result.review_body,
+        &result.verdict,
+    );
+
     // 7e: build inline per-line comments from the RAW diff (#1414).  Using the
     // pre-filter `raw_diff` (not the noise-filtered `diff` sent to the LLM) means
     // anchors map to the actual PR diff lines GitHub will accept; findings that do

--- a/crates/trusty-review/src/pipeline/runner_helpers.rs
+++ b/crates/trusty-review/src/pipeline/runner_helpers.rs
@@ -387,6 +387,45 @@ pub(super) async fn finalize_run(
     .await
 }
 
+/// Run every output-hygiene and grounding pass over a freshly parsed review.
+///
+/// Why: four passes must all run BEFORE grading, in this order, and they moved
+/// here together when the #1873 pass pushed `runner.rs` over the 500-SLOC cap.
+/// Keeping them in one function is also what keeps the unified path's ordering
+/// visible beside the map-reduce path's, which runs the same four in
+/// `mapreduce/mod.rs`.
+/// What, in order:
+///   1. `finding_hygiene::sanitize_findings` — drop self-negated / CoT-leaking
+///      findings and demote the speculative ones (#4043, #4044, #4081, #5309).
+///   2. `citation_check::enforce_citation_integrity` — drop any finding whose
+///      cited path or quoted content the diff does not contain (#2881, #4042).
+///   3. `absence_claim::drop_refuted_absence_claims` — drop any finding whose
+///      premise is that a file is missing from a diff that contains it (#1873).
+///   4. `finding_hygiene::relax_verdict_if_evidence_wiped` — when 1–3 removed
+///      every finding, the model's own verdict rested on the same evidence and
+///      is relaxed with it (#4042, #4044).
+///
+/// Test: `run_review_outer_and_embedded_verdict_agree_after_severity_floor`,
+/// `unified_path_emits_no_finding_citing_a_path_outside_the_diff`.
+pub(super) fn ground_parsed_findings(
+    parsed: &mut crate::pipeline::parser::ParsedReview,
+    filtered: &crate::pipeline::diff_analyzer::models::FilteredDiff,
+) {
+    let findings_before = parsed.findings.len();
+    crate::pipeline::finding_hygiene::sanitize_findings(&mut parsed.findings);
+
+    let cite_index = crate::pipeline::citation_check::DiffContentIndex::from_filtered(filtered);
+    crate::pipeline::citation_check::enforce_citation_integrity(&mut parsed.findings, &cite_index);
+    crate::pipeline::absence_claim::drop_refuted_absence_claims(&mut parsed.findings, &cite_index);
+
+    crate::pipeline::finding_hygiene::relax_verdict_if_evidence_wiped(
+        &mut parsed.verdict,
+        &mut parsed.grade,
+        findings_before,
+        &parsed.findings,
+    );
+}
+
 // ─── Unit tests ───────────────────────────────────────────────────────────────
 // Split into a sibling file to keep this file under the 500-line cap.
 

--- a/crates/trusty-review/src/pipeline/runner_mapreduce.rs
+++ b/crates/trusty-review/src/pipeline/runner_mapreduce.rs
@@ -338,17 +338,6 @@ async fn fold_reduced_into_result(
     result.grade =
         original_llm_grade.map(|g| reconcile_grade_with_verdict(g, &result.verdict).to_string());
 
-    // Grade reconciliation (#1886 parity with the unified path): mirror the final
-    // top-level grade into any JSON `"grade"` embedded in `review_body` so the two
-    // observable copies can never disagree.  In this path `review_body` is the
-    // synthesis PROSE summary (no embedded JSON grade), so this is normally a no-op;
-    // it is applied unconditionally as defence-in-depth against a future summary
-    // format that embeds a grade.
-    result.review_body = crate::pipeline::grade_reconcile::reconcile_review_body_grade(
-        &result.review_body,
-        result.grade.as_deref(),
-    );
-
     // Inline per-line comments from the RAW diff (#1414 parity).
     attach_inline_comments(result, &run.raw_diff);
 
@@ -366,6 +355,27 @@ async fn fold_reduced_into_result(
     // path's rendered `diff.len()` — the char count actually sent to the reviewers,
     // which the aggregate token spend is proportional to.
     apply_shallow_review_flag(result, run.filtered.filtered_byte_size);
+
+    // Reconciliation (#1886 grade, #1902 verdict) — mirror both final top-level
+    // values into any JSON embedded in `review_body` so the two observable
+    // copies of each can never disagree. In this path `review_body` is normally
+    // the synthesis PROSE summary with no embedded JSON, making both a no-op;
+    // they run unconditionally as defence-in-depth against a summary format
+    // that embeds either field.
+    //
+    // #1902: this runs AFTER `apply_shallow_review_flag`, not before it. The
+    // shallow cap lowers `result.grade`, so reconciling ahead of it mirrored a
+    // grade the envelope no longer carried — the same staleness #1886 fixed,
+    // reintroduced by ordering. The unified path has always reconciled after
+    // its own shallow cap (`runner.rs` step 7d).
+    result.review_body = crate::pipeline::grade_reconcile::reconcile_review_body_grade(
+        &result.review_body,
+        result.grade.as_deref(),
+    );
+    result.review_body = crate::pipeline::grade_reconcile::reconcile_review_body_verdict(
+        &result.review_body,
+        &result.verdict,
+    );
 }
 
 /// Flag and grade-cap a suspiciously shallow clean review on the map-reduce path.

--- a/crates/trusty-review/src/pipeline/runner_mapreduce.rs
+++ b/crates/trusty-review/src/pipeline/runner_mapreduce.rs
@@ -19,7 +19,7 @@
 //! Test: `run_review_oversized_diff_mapreduce_reviews_tail_signature`,
 //! `run_review_mapreduce_chunk_request_changes_propagates` (runner_tests.rs).
 
-use tracing::{info, warn};
+use tracing::{error, info, warn};
 
 use crate::{
     config::{MapReduceConfig, ReviewConfig},
@@ -31,7 +31,7 @@ use crate::{
         mapreduce::{MapContext, ReducedReview, run_map_reduce},
         parser::ParsedReview,
         prompt::{ReviewContext, ReviewPrMeta},
-        runner::{ReviewDeps, ReviewInput},
+        runner::{CallerContext, ReviewDeps, ReviewInput},
         runner_helpers::{
             DedupClaim, abort_dry, apply_grade_and_floor, attach_inline_comments,
             build_author_rationale, finalize_run,
@@ -85,8 +85,20 @@ pub(super) async fn run_mapreduce_branch(
     deps: &ReviewDeps,
     mr_config: &MapReduceConfig,
     mut result: ReviewResult,
-    run: MapReduceRun,
+    mut run: MapReduceRun,
 ) -> ReviewResult {
+    // #2654: the caller's context reaches the per-file prompts only because
+    // `run_review` copied it into `context` several steps above this call. That
+    // coupling is invisible from here, so a drop would strip the context from
+    // exactly the largest PRs and say nothing.
+    for field in restore_caller_context(&mut run.context, &input.caller_context) {
+        error!(
+            field,
+            "map-reduce: caller-supplied context did not reach this branch — \
+             restored it, but the runner's threading is broken (#2654)"
+        );
+    }
+
     let voice_config = build_voice_config(config);
     let ctx = MapContext {
         owner: &result.owner,
@@ -233,6 +245,57 @@ pub(super) async fn run_mapreduce_branch(
     }
 
     finalize_run(result, config, input, deps.dedup.as_ref()).await
+}
+
+/// Put back any caller-supplied context field that did not reach this branch,
+/// and name what was put back (#2654).
+///
+/// Why: `referenced_code` is the caller's semantic context — a downstream
+/// consumer populates it with multi-repo code the diff depends on, and the
+/// largest PRs are exactly where a diff-only review is weakest. It reaches the
+/// per-file prompts through a field assignment in `run_review`, and losing that
+/// assignment would cost nothing observable: no error, no warning, just weaker
+/// reviews. This is the Fail-Open shape the issue names — the context would
+/// disappear while the review advanced and reported success.
+/// What: for each of the three [`CallerContext`] fields, restores the caller's
+/// value when the caller supplied a non-blank one and `context` carries none,
+/// and returns the names of the fields restored. An empty return is the healthy
+/// state, and the ONLY state a caller who supplied nothing can produce.
+/// Test: `restore_caller_context_reports_and_restores_a_dropped_field`,
+/// `restore_caller_context_is_silent_when_the_runner_threaded_it`.
+pub(super) fn restore_caller_context(
+    context: &mut ReviewContext,
+    caller: &CallerContext,
+) -> Vec<&'static str> {
+    let mut restored = Vec::new();
+    let fields: [(&'static str, &Option<String>, &mut Option<String>); 3] = [
+        (
+            "pr_description",
+            &caller.pr_description,
+            &mut context.pr_description,
+        ),
+        (
+            "pr_discussion",
+            &caller.pr_discussion,
+            &mut context.pr_discussion,
+        ),
+        (
+            "referenced_code",
+            &caller.referenced_code,
+            &mut context.referenced_code,
+        ),
+    ];
+    for (name, supplied, carried) in fields {
+        let Some(value) = supplied.as_ref().filter(|v| !v.trim().is_empty()) else {
+            continue;
+        };
+        if carried.as_ref().is_some_and(|v| !v.trim().is_empty()) {
+            continue;
+        }
+        *carried = Some(value.clone());
+        restored.push(name);
+    }
+    restored
 }
 
 /// Apply the post-LLM grade/verify/inline chain to a reduced parse.

--- a/crates/trusty-review/src/pipeline/runner_mapreduce_tests.rs
+++ b/crates/trusty-review/src/pipeline/runner_mapreduce_tests.rs
@@ -277,6 +277,104 @@ async fn run_review_oversized_diff_mapreduce_reviews_tail_signature() {
     );
 }
 
+/// REGRESSION (#2654): caller-supplied `referenced_code` reaches EVERY per-file
+/// map prompt, not just the unified single-shot prompt.
+///
+/// Why: a downstream consumer populates `referenced_code` with multi-repo
+/// semantic context so the verdict-deciding review is not diff-only. The
+/// map-reduce path is chosen for the largest, most complex PRs — where that
+/// context matters most — and a drop there produces no error, no warning, and a
+/// weaker review that still reports success.
+/// What: runs an over-cap diff through map-reduce with a sentinel in
+/// `caller_context.referenced_code` and asserts every recorded map prompt
+/// carries it under the `## Referenced Code` heading.
+/// Test: this test itself (no network).
+#[tokio::test]
+async fn mapreduce_prompts_carry_caller_supplied_referenced_code() {
+    const SENTINEL: &str = "fn cross_repo_helper() { /* REFERENCED_CODE_SENTINEL */ }";
+
+    let (diff, _tail) = oversized_multi_file_diff();
+    let (source, _tmp) = local_source(&diff);
+
+    let reviewer = Arc::new(RecordingReviewer::approving());
+    let llm: Arc<dyn LlmProvider> = reviewer.clone();
+    let mut review_input = input(source);
+    review_input.caller_context = CallerContext {
+        referenced_code: Some(SENTINEL.to_string()),
+        ..CallerContext::default()
+    };
+    let config = ReviewConfig::load(None);
+
+    let _ = run_review(&config, review_input, deps(llm)).await;
+
+    let prompts = reviewer.prompts();
+    assert!(!prompts.is_empty(), "map-reduce must issue per-file calls");
+    // The synthesis call is not a per-file review and carries findings, not
+    // code, so only the map prompts (those carrying the diff block) are held to
+    // this.
+    let map_prompts: Vec<&String> = prompts
+        .iter()
+        .filter(|p| p.contains("## Unified diff"))
+        .collect();
+    assert!(
+        !map_prompts.is_empty(),
+        "at least one prompt must be a per-file map call"
+    );
+    for p in map_prompts {
+        assert!(
+            p.contains("## Referenced Code") && p.contains(SENTINEL),
+            "every map prompt must carry the caller's referenced code (#2654)"
+        );
+    }
+}
+
+/// #2654: the branch says so, loudly, when caller context did not reach it —
+/// and reviews with the context rather than without it.
+///
+/// Why: the failure this guards is silent by construction. A restored field
+/// that logged nothing would leave the same defect undetectable.
+/// What: hands the guard a context stripped of `referenced_code` alongside a
+/// caller that supplied one; asserts the field is named and put back.
+/// Test: this test itself.
+#[test]
+fn restore_caller_context_reports_and_restores_a_dropped_field() {
+    let caller = CallerContext {
+        referenced_code: Some("fn helper() {}".to_string()),
+        pr_description: Some("why this change".to_string()),
+        pr_discussion: None,
+    };
+    let mut context = crate::pipeline::prompt::ReviewContext::default();
+
+    let restored = super::restore_caller_context(&mut context, &caller);
+
+    assert_eq!(restored, vec!["pr_description", "referenced_code"]);
+    assert_eq!(context.referenced_code.as_deref(), Some("fn helper() {}"));
+    assert_eq!(context.pr_description.as_deref(), Some("why this change"));
+}
+
+/// #2654: the guard is silent on the healthy path — the runner threaded the
+/// context, so there is nothing to restore and nothing to report.
+#[test]
+fn restore_caller_context_is_silent_when_the_runner_threaded_it() {
+    let caller = CallerContext {
+        referenced_code: Some("fn helper() {}".to_string()),
+        ..CallerContext::default()
+    };
+    let context = crate::pipeline::prompt::ReviewContext {
+        referenced_code: Some("fn helper() {}".to_string()),
+        ..crate::pipeline::prompt::ReviewContext::default()
+    };
+    let mut context = context;
+
+    assert!(
+        super::restore_caller_context(&mut context, &caller).is_empty(),
+        "a threaded context reports nothing"
+    );
+    // And a caller who supplied nothing can never trip it.
+    let mut empty = crate::pipeline::prompt::ReviewContext::default();
+    assert!(super::restore_caller_context(&mut empty, &CallerContext::default()).is_empty());
+}
+
 /// Returns the #1873 phantom — a BLOCK whose only finding calls a file that IS
 /// in the changeset "not present in diff" — for the chunk carrying `marker`,
 /// and APPROVEs everything else.

--- a/crates/trusty-review/src/pipeline/runner_mapreduce_tests.rs
+++ b/crates/trusty-review/src/pipeline/runner_mapreduce_tests.rs
@@ -277,6 +277,89 @@ async fn run_review_oversized_diff_mapreduce_reviews_tail_signature() {
     );
 }
 
+/// Returns the #1873 phantom — a BLOCK whose only finding calls a file that IS
+/// in the changeset "not present in diff" — for the chunk carrying `marker`,
+/// and APPROVEs everything else.
+///
+/// Why: reproduces the cross-chunk blindness verbatim. The map call reviewing
+/// `src/file0.rs` cannot see the chunk that adds `src/big.rs`, so it reasons
+/// correctly from its own chunk to a conclusion the whole changeset refutes.
+/// What: one prompt-substring match, one hard-coded finding.
+/// Test: `mapreduce_phantom_missing_file_finding_does_not_block`.
+struct PhantomMissingFileReviewer {
+    marker: String,
+}
+
+#[async_trait]
+impl LlmProvider for PhantomMissingFileReviewer {
+    fn name(&self) -> &str {
+        "phantom-missing-file"
+    }
+    async fn complete(&self, req: LlmRequest) -> Result<LlmResponse, LlmError> {
+        let body = req
+            .messages
+            .iter()
+            .map(|m| m.content.clone())
+            .collect::<Vec<_>>()
+            .join("\n");
+        let text = if body.contains(self.marker.as_str()) {
+            r#"{"verdict":"BLOCK","summary":"missing module","findings":[{"title":"module missing","body":"This file imports from src/file0.rs, which is not present in diff - possible compile break.","severity":"high","confidence":0.95,"file":"src/big.rs","line":1,"code_provable":true}]}"#
+        } else {
+            r#"{"verdict":"APPROVE","summary":"ok","findings":[]}"#
+        };
+        Ok(LlmResponse {
+            text: text.to_string(),
+            model: req.model.clone(),
+            input_tokens: 10,
+            output_tokens: 5,
+            latency_ms: 1,
+            cost_usd: 0.0,
+            finish_reason: Some("stop".to_string()),
+        })
+    }
+}
+
+/// REGRESSION (#1873): a chunk claiming a file is missing from the diff cannot
+/// BLOCK a changeset that contains that file.
+///
+/// Why: the reported harm — `review_pr` returned BLOCK / grade F on PR #1872
+/// off one 0.55-confidence finding calling `doctor_fs_checks.rs` "not present
+/// in diff", while the file was in the PR, the crate compiled, and the suite
+/// passed. It happened on two consecutive reviews and stopped the merge.
+/// What: runs an over-cap diff through map-reduce with a reviewer that emits
+/// that finding for one chunk; asserts the verdict stays APPROVE and the
+/// phantom reaches neither the findings nor the rendered review. Pre-fix the
+/// verdict was BLOCK.
+/// Test: this test itself (no network).
+#[tokio::test]
+async fn mapreduce_phantom_missing_file_finding_does_not_block() {
+    let (diff, tail_signature) = oversized_multi_file_diff();
+    let (source, _tmp) = local_source(&diff);
+
+    // Key on the tail file's distinctive signature — the one chunk marker
+    // `run_review_oversized_diff_mapreduce_reviews_tail_signature` already
+    // proves reaches exactly one map prompt.
+    let llm: Arc<dyn LlmProvider> = Arc::new(PhantomMissingFileReviewer {
+        marker: tail_signature.to_string(),
+    });
+    let config = ReviewConfig::load(None);
+
+    let result = run_review(&config, input(source), deps(llm)).await;
+
+    assert_eq!(
+        result.verdict,
+        Verdict::Approve,
+        "a claim the changeset itself refutes must not drive the verdict (#1873)"
+    );
+    assert!(
+        !result
+            .findings
+            .iter()
+            .any(|f| f.description.contains("not present in diff")),
+        "the refuted finding must not reach the rendered review (#1873)"
+    );
+}
+
 /// Selectively fails for prompts containing `fail_marker`, succeeds otherwise.
 /// Lets us inject exactly ONE LLM-error failure into a multi-chunk map-reduce
 /// run without failing every chunk.

--- a/crates/trusty-review/src/pipeline/runner_tests.rs
+++ b/crates/trusty-review/src/pipeline/runner_tests.rs
@@ -130,6 +130,28 @@ impl FakeLlm {
         }
     }
 
+    /// A self-assessed APPROVE carrying a High-severity finding on a file that
+    /// IS in the diff (#1902).
+    ///
+    /// Why: the severity floor escalates the pipeline's verdict well above the
+    /// model's own lean, which is exactly the divergence #1902 reports — a
+    /// top-level BLOCK beside an embedded APPROVE. Citing a real diff path
+    /// keeps the citation check from dropping the finding and relaxing the
+    /// verdict back down.
+    /// Test: `run_review_outer_and_embedded_verdict_agree_after_severity_floor`.
+    fn self_approves_with_blocking_finding() -> Self {
+        Self {
+            response: r#"Looks fine to me.
+
+```json
+{"verdict":"APPROVE","grade":"A","summary":"LGTM","findings":[{"title":"SQL injection","body":"the query is built by string interpolation","severity":"high","confidence":0.95,"file":"src/a.rs","line":1,"code_provable":true}]}
+```"#
+                .to_string(),
+            error: None,
+            output_tokens: None,
+        }
+    }
+
     fn errors(msg: impl Into<String>) -> Self {
         Self {
             response: String::new(),
@@ -605,6 +627,60 @@ async fn run_review_outer_and_embedded_grade_agree_after_shallow_cap() {
     assert_ne!(
         embedded, "A+",
         "the stale model self-grade must have been reconciled away (#1886)"
+    );
+}
+
+/// REGRESSION (#1902): the top-level `verdict` and the verdict embedded in
+/// `review_body` agree after the severity floor moves the top-level one.
+///
+/// Why: the reported harm — `review_pr` on PR #1901 returned a top-level
+/// `BLOCK` while `review_body` said `APPROVE`. An automated merge gate
+/// correctly refused on the `BLOCK`, and the human reading the review saw an
+/// approval. #1886 fixed this class for `grade` and left `verdict` behind.
+/// What: runs a review whose model self-assesses APPROVE while reporting a
+/// High-severity finding, so the floor escalates the top-level verdict; then
+/// re-parses `review_body` and asserts the embedded verdict equals the
+/// top-level one and is no longer the stale APPROVE.
+/// Test: this test itself (no network).
+#[tokio::test]
+async fn run_review_outer_and_embedded_verdict_agree_after_severity_floor() {
+    let (source, _tmp) = local_diff_source_for_file(
+        "src/a.rs",
+        "+fn bad_query(id: &str) { db.exec(format!(\"SELECT * FROM users WHERE id={id}\")) }",
+    );
+    let config = default_config();
+    let input = ReviewInput {
+        diff_source: source,
+        reviewer_model: "openai/gpt-5.4-mini-20260317".to_string(),
+        write_log: false,
+        print_result: false,
+        trigger: TriggerDecision::None,
+        run_mode: RunMode::Cli,
+        allow_posting: false,
+        caller_context: CallerContext::default(),
+        surface: InvocationSurface::default(),
+    };
+    let deps = ready_deps(
+        Arc::new(FakeLlm::self_approves_with_blocking_finding()),
+        None,
+    );
+
+    let result = run_review(&config, input, deps).await;
+
+    assert_ne!(
+        result.verdict,
+        Verdict::Approve,
+        "a High-severity finding must move the top-level verdict off the model's APPROVE"
+    );
+    let embedded = crate::pipeline::parser::parse_review_response(&result.review_body).verdict;
+    assert_eq!(
+        embedded, result.verdict,
+        "the verdict embedded in review_body must equal the authoritative one (#1902)"
+    );
+    assert_ne!(
+        embedded,
+        Verdict::Approve,
+        "the model's stale pre-floor APPROVE must have been reconciled away (#1902)"
     );
 }
 

--- a/crates/trusty-review/src/service/handlers.rs
+++ b/crates/trusty-review/src/service/handlers.rs
@@ -146,6 +146,21 @@ impl AppState {
     }
 }
 
+// ─── Posting posture (#4254) ─────────────────────────────────────────────────
+
+/// The trigger `handle_review` runs under — it never posts.
+///
+/// Why: `handle_health` reported `config.dry_run` while `handle_review` ran with
+/// these two constants, so a live-configured process answered `dry_run: false`
+/// and then posted nothing (#4254). Both paths read the constants now, so the
+/// health answer cannot drift from the review behaviour again.
+/// Test: `health_reports_the_dry_run_the_review_path_executes`.
+const REVIEW_TRIGGER: TriggerDecision = TriggerDecision::ForceDryRun;
+
+/// Whether `handle_review` may post to GitHub. It may not — see
+/// [`REVIEW_TRIGGER`].
+const REVIEW_ALLOW_POSTING: bool = false;
+
 // ─── Response shapes ──────────────────────────────────────────────────────────
 
 /// Response body for GET /health.
@@ -161,16 +176,28 @@ impl AppState {
 /// Test: `health_returns_ok_json`, `health_inference_ok_when_llm_ok`,
 /// `health_inference_auth_error_sets_degraded`,
 /// `health_required_dep_down_sets_degraded`,
-/// `health_optional_dep_down_stays_ok`.
+/// `health_optional_dep_down_stays_ok`,
+/// `health_reports_the_dry_run_the_review_path_executes`.
+///
+/// `#[non_exhaustive]`: #4254 added `dry_run_reason`, and this struct grows a
+/// field whenever the health contract does — see `HygieneCounts` for the same
+/// reasoning.
 #[derive(Debug, Serialize)]
+#[non_exhaustive]
 pub struct HealthResponse {
     /// `"ok"` when inference is healthy AND all required deps are reachable;
     /// `"degraded"` when inference is not `"ok"` OR a required dep is unreachable.
     pub status: &'static str,
     /// Pipeline version (e.g. `"tr-0.1"`).
     pub version: &'static str,
-    /// Whether the service is in dry-run mode.
+    /// Whether a review invoked through this surface runs dry (#4254).
+    ///
+    /// Not the raw `config.dry_run` flag: `handle_review` overrides it with
+    /// [`REVIEW_TRIGGER`] / [`REVIEW_ALLOW_POSTING`], so the flag reported
+    /// `false` while every review ran dry and posted nothing.
     pub dry_run: bool,
+    /// Which gate forced `dry_run`, or `None` when reviews would post (#4254).
+    pub dry_run_reason: Option<&'static str>,
     /// Configured reviewer model slug.
     pub reviewer_model: String,
     /// Inference-reachability probe result (#719).  One of: `"ok"`,
@@ -562,10 +589,19 @@ pub async fn handle_health(state: &AppState) -> HealthResponse {
     // #722: status is "degraded" when inference fails OR any required dep is down.
     let status = compute_status(inference, &deps);
 
+    // #4254: report the dry_run `handle_review` actually executes with, derived
+    // from the same posting-posture constants it passes.
+    let (dry_run, dry_run_reason) = crate::pipeline::surface_dry_run(
+        state.config.dry_run,
+        REVIEW_TRIGGER,
+        REVIEW_ALLOW_POSTING,
+    );
+
     HealthResponse {
         status,
         version: env!("CARGO_PKG_VERSION"),
-        dry_run: state.config.dry_run,
+        dry_run,
+        dry_run_reason: dry_run_reason.map(|r| r.as_str()),
         reviewer_model,
         inference,
         deps,
@@ -638,10 +674,12 @@ pub async fn handle_review(state: &AppState, req: ReviewRequest) -> Result<Revie
         write_log: false, // service callers don't write logs by default.
         print_result: false,
         // `review` never posts to GitHub — it always returns the result to
-        // the caller (push firewall + dry-run remain in force).
-        trigger: TriggerDecision::ForceDryRun,
+        // the caller (push firewall + dry-run remain in force). #4254: these
+        // two constants are what `handle_health` reads, so its `dry_run` is
+        // this path's, not the config flag's.
+        trigger: REVIEW_TRIGGER,
         run_mode: RunMode::Serve,
-        allow_posting: false,
+        allow_posting: REVIEW_ALLOW_POSTING,
         // Thread caller-supplied PR context (#1618) into the runner.  On the
         // local-diff path this is the only source of PR description / discussion /
         // referenced code (no GitHub fetch).

--- a/crates/trusty-review/src/service/handlers_tests.rs
+++ b/crates/trusty-review/src/service/handlers_tests.rs
@@ -583,6 +583,37 @@ async fn review_handler_decrements_in_flight_when_client_disconnects() {
     );
 }
 
+/// REGRESSION (#4254): `/health` reports the dry_run `handle_review` executes
+/// with, never the raw config flag.
+///
+/// Why: the same defect the MCP pair carried — a process configured live
+/// answered `dry_run: false` while every review it ran was dry and posted
+/// nothing. A caller that trusts health believed reviews reached GitHub.
+/// What: builds a state whose config says LIVE, calls `handle_health`, and
+/// asserts the reported `dry_run` is `true` with a reason naming the gate.
+/// Pre-fix this asserted `false == true` and failed.
+/// Test: this test itself.
+#[tokio::test]
+async fn health_reports_the_dry_run_the_review_path_executes() {
+    let mut config = crate::config::ReviewConfig::load(None);
+    config.dry_run = false;
+    let state = AppState::new(config, Arc::new(FakeLlm), Arc::new(FakeSearch), None);
+
+    let health = handle_health(&state).await;
+
+    assert!(
+        health.dry_run,
+        "handle_review forces dry-run, so /health must report dry_run: true"
+    );
+    let reason = health
+        .dry_run_reason
+        .expect("a forced dry-run names its gate");
+    assert!(
+        reason.contains("never posts"),
+        "the reason names the gate: {reason}"
+    );
+}
+
 // ── Inference-probe handler tests (#719) ──────────────────────────────────────
 
 /// /health includes `inference: "ok"` and `status: "ok"` when the LLM succeeds.

--- a/crates/trusty-review/tests/report_analyze_e2e.rs
+++ b/crates/trusty-review/tests/report_analyze_e2e.rs
@@ -218,11 +218,90 @@ async fn analyze_populates_complexity_and_findings() {
         md.contains("Extract method — a"),
         "AMBER refactor finding missing"
     );
-    // The GREEN-mapped hint diagnostic is NOT rendered.
+    assert_green_diagnostic_dropped(metrics, &md);
+}
+
+/// Assert the GREEN-mapped hint diagnostic reached neither the metrics nor the
+/// page.
+///
+/// Why: #4385/#4387 reported this check failing three times on unrelated PRs,
+/// and read it as a timing flake in the mock. It is not timing. The check was
+/// `!md.contains("H1")` over the WHOLE rendered report, and the report embeds
+/// the manifest's absolute path — `…/T/.tmpXYZabc/manifest.toml`, whose six
+/// random characters come from the full alphanumeric alphabet and land on the
+/// two-character sequence `H1` roughly once in eight hundred renders. Every
+/// sighting was that collision: a passing render and a failing one differed
+/// only in the name the OS handed the temp directory.
+/// What: checks the structured findings for the dropped code, then the two
+/// shapes the renderer would print it in — the risk-table row `H1 — meh` and
+/// the detail heading `**H1**`. Neither can appear in a filesystem path.
+/// Test: called by `analyze_populates_complexity_and_findings` and
+/// `green_diagnostic_stays_dropped_under_a_path_that_spells_its_code`.
+fn assert_green_diagnostic_dropped(metrics: &trusty_review::report::AnalyzeMetrics, md: &str) {
     assert!(
-        !md.contains("H1"),
-        "green-mapped diagnostic should be dropped"
+        !metrics.findings.iter().any(|f| f.title == "H1"),
+        "a hint diagnostic maps to GREEN and must never become a finding: {:?}",
+        metrics.findings
     );
+    assert!(
+        !md.contains("H1 — meh"),
+        "the dropped diagnostic must not reach the risk table"
+    );
+    assert!(
+        !md.contains("**H1**"),
+        "the dropped diagnostic must not reach the findings detail"
+    );
+}
+
+/// REGRESSION (#4387, recurrence of #4385): the drop check survives a workspace
+/// path that happens to spell the dropped diagnostic's code.
+///
+/// Why: this is the flake, made deterministic. Three CI failures on unrelated
+/// PRs were read as a race in the mock; the mock had already been rewritten
+/// from a raw `TcpListener` to a Unix socket (#6287) and the failures continued
+/// in the same shape, because the cause was never the transport. It was
+/// `md.contains("H1")` run over a document that embeds a random temp path. This
+/// test pins the workspace under a directory literally named `runH1x` — the
+/// collision the OS produced by chance — and asserts the check still holds.
+/// What: same fixture, mock, enrichment and render as
+/// `analyze_populates_complexity_and_findings`, rooted one directory deeper.
+/// Under the old whole-document substring check this fails every run.
+/// Test: this test itself.
+#[tokio::test]
+async fn green_diagnostic_stays_dropped_under_a_path_that_spells_its_code() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    // The name is the point: `H1` appears in the path the report prints.
+    let workspace = tmp.path().join("runH1x");
+    std::fs::create_dir_all(&workspace).expect("mkdir workspace");
+
+    let manifest_path = write_fixture(&workspace);
+    let index_id = trusty_review::report::derive_index_id(&workspace.join(REPO_DIR))
+        .expect("the fixture checkout has a final path component");
+    let socket = spawn_mock(index_id, &workspace);
+
+    let manifest = load_manifest(&manifest_path).expect("manifest loads");
+    let template = TemplateLoader::new()
+        .load("report-technical-dd")
+        .expect("template loads");
+    let mut model =
+        ReportModel::build(&manifest, &manifest_path, "report-technical-dd", None).expect("build");
+
+    let source = HttpAnalyzeMetricsSource::new(socket).expect("client");
+    enrich_with_analyze(&mut model, &source).await;
+
+    let metrics = model.repositories[0]
+        .metrics
+        .as_ref()
+        .expect("analyze filled metrics");
+    let reporter = Reporter::new(workspace.join("reports"));
+    let md = reporter.render(&model, &template);
+
+    assert!(
+        md.contains("runH1x"),
+        "the rendered report must embed the workspace path — otherwise this test \
+         proves nothing about the collision"
+    );
+    assert_green_diagnostic_dropped(metrics, &md);
 }
 
 /// Why: a fetch failure must fall through cleanly to scan-only output, never


### PR DESCRIPTION
Five bugs in `crates/trusty-review`, batched because four of them sit in the same
module family (the map-reduce path, the finding-hygiene chain, and the
`review_body` reconciliation) and would otherwise conflict on the same lines.

- A finding claiming a file is "not present in diff" no longer blocks a PR that
  contains that file — the claim is checked against the whole changeset, which a
  single map chunk cannot see. Refs #1873
- Caller-supplied `referenced_code` on the map-reduce path is pinned by an
  end-to-end test, and the branch now restores and logs any caller context that
  failed to reach it instead of reviewing without it. Refs #2654
- The verdict embedded in `review_body` is reconciled to the authoritative
  top-level verdict, generalising the #1886 grade fix; on the map-reduce path
  both reconciles moved after the shallow-review cap. Refs #1902
- `review_health` and `/health` report the `dry_run` a review invoked through
  that surface executes with, plus a `dry_run_reason` naming the gate, instead
  of the raw config flag. Refs #4254
- The analyze e2e drop check reads the structured finding rather than the whole
  rendered page, which embeds a random temp path — the actual cause of the
  flake. Refs #4387

## Test ladder

Rung 4 (public API: `HealthResponse` gains `dry_run_reason` and
`#[non_exhaustive]`; `pipeline` gains `surface_dry_run` and `absence_claim`).

```
cargo fmt --check                                          EXIT=0
cargo check -p trusty-review --all-targets                 EXIT=0
cargo clippy -p trusty-review --all-targets -- -D warnings EXIT=0
cargo test -p trusty-review --no-fail-fast                 ok. 2054 passed; 0 failed; 5 ignored
                                                           (+ 8 integration targets, all ok)
cargo check --workspace                                    EXIT=0
cargo test -p trusty-analyze --features review --no-fail-fast
                                                           ok. 512 + 24 + 7 + 5 + 3 + 2 + 2 passed; 0 failed
bash scripts/check_test_pointers.sh                        0 dangling pointers
bash scripts/check_line_cap.sh                             0 violations
bash scripts/check_sld.sh                                  0 errors, 0 warnings
CHANGELOG_BASE=origin/main bash scripts/check_changelog_fragment.sh   OK
```

`report_analyze_e2e` was re-run 10×: `test result: ok. 3 passed` in all ten.

## How each regression test was proven to fail first

Each fix was inverted in place and its test re-run.

- #4254 — health reading `state.config.dry_run` again: both tests FAILED,
  `left: false, right: true`.
- #1902 — verdict reconcile removed: FAILED, `left: Approve, right: Block`.
- #1873 — absence pass removed: FAILED with the phantom finding present and
  `verdict=Block`.
- #2654 — the runner's `context.referenced_code` assignment removed AND the
  guard disabled: FAILED, "every map prompt must carry the caller's referenced
  code". Restoring only the guard makes it pass, which is what proves the guard
  repairs the drop rather than merely reporting it.
- #4387 — the old `!md.contains("H1")` assertion restored: the new test FAILED
  every run, because its workspace directory is named `runH1x`. That is the
  flake made deterministic.

## Note on #2654

At HEAD the map prompts already carried `referenced_code`: `run_review` copies
it into the gathered `ReviewContext` before the map-reduce branch, and the map
prompt builder renders it. The issue's literal claim — that
`runner_mapreduce.rs` never references the field — is true and not the whole
picture. What this PR adds is the test that pins it and the guard that makes a
future drop loud, since the coupling is invisible from the branch itself.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
