### PR TITLE
fix(trusty-mpm): wave-3 batch — pm_guard classification, doctor identity, tracing subscriber, suffix collision

### DIFF
--- a/crates/trusty-mpm/changelog.d/wave3-mpm-batch.md
+++ b/crates/trusty-mpm/changelog.d/wave3-mpm-batch.md
@@ -1,0 +1,34 @@
+Fixed
+
+- `tm hook --pm-guard` now classifies process-substitution bodies. `<(…)` and
+  `>(…)` join `$(…)` and backticks as one class of substitution the guard
+  decomposes, so `diff <(sed -i s/a/b/ f) x` — which bash executes, and which
+  the guard allowed — is refused, and `>(…)` is denied by its body rather than
+  incidentally by the `>` redirection scan. An unbalanced opener fails closed,
+  matching the `$(`/backtick shape; a quoted `<(…)` in a commit message stays
+  literal text. (Refs #2745)
+- `tm doctor` gained a `base_clone` check. A linked worktree keeps every source
+  file when the clone behind it loses its git internals, and then every git
+  command there fails with `fatal: not a git repository` — the 2026-07-21 state
+  that went unnoticed for over half an hour across 70 worktrees while both
+  worktree probes stayed green. The check reads each live session workspace's
+  `.git` pointer and Fails naming the base path, what is missing, and how many
+  live worktrees hang off it. Detection only: it never repairs, moves, or
+  deletes, and its remediation text keeps the existing quarantine-never-delete
+  discipline. (Refs #3605)
+- Deploy diagnostics now reach the operator on every in-process CLI path. Bare
+  `tm` (including the in-place relaunch), `tm doctor --fix-skills`, and
+  `tm catalog apply` each run a deploy that legitimately declines files — a
+  checksum-frozen skill, an unreadable ledger, a raced merge — and each decline
+  was written to a `tracing` subscriber that was never registered, so the file
+  stayed stale forever with no signal. All three now install the same
+  stderr-only subscriber `tm sessions instructions` uses, at the `warn` default
+  so a clean run stays quiet. Registration is `try_init`, so a second
+  installation returns an error instead of aborting the process. (Refs #4878)
+- Peer-bus registration no longer overwrites a live instance on an instance-id
+  suffix collision. `DashMap::insert` replaced the existing entry, after which
+  every lookup of the first instance resolved to the second — instance-addressed
+  delivery reaching an instance the sender did not name. Registration now claims
+  the key through `entry`, re-minting up to eight times and logging each
+  collision, and returns the new `BusError::InstanceIdCollision` (HTTP 409)
+  rather than displacing a registered instance. (Refs #4276)

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/mod.rs
@@ -5,14 +5,15 @@
 //! can edit a file with `sed -i`, write one with `echo … > f.rs`, apply a diff
 //! with `git apply`, or run the suite with `pytest`, all of which side-step the
 //! P1–P5 prohibitions. Worse, shell *composition* (`&&`, `||`, `;`, `|`, a bare
-//! `&`, a newline) and command *substitution* (`$(…)`, backticks) are
-//! themselves bypasses: a benign leading verb can hide a forbidden one further
-//! down the line or inside a substitution. This module is the quote-unaware,
+//! `&`, a newline) and *substitution* — command (`$(…)`, backticks) and
+//! process (`<(…)`, `>(…)`, #2745) alike — are themselves bypasses: a benign
+//! leading verb can hide a forbidden one further down the line or inside a
+//! substitution body. This module is the quote-unaware,
 //! conservatively-over-blocking classifier that closes those seams; it is
 //! factored out of `pm_guard.rs` so that file stays under the 500-SLOC cap.
 //! What: [`evaluate_bash_command`] splits a command on every composition
 //! separator, classifies each segment (first-token verb, two-token
-//! `git apply` / `npm test`, and recursively any command substitution), and
+//! `git apply` / `npm test`, and recursively every substitution body), and
 //! applies a whole-command file-write redirection check. A missed deny is the
 //! dangerous direction, so ambiguous forms (unbalanced substitutions,
 //! over-deep nesting) deny. `sed`/`awk`-family verbs are classified by the
@@ -246,7 +247,38 @@ fn classify_bash_segment(segment: &str, depth: usize) -> Option<&'static str> {
     classify_command_substitutions(trimmed, depth)
 }
 
-/// Inspect `$(…)` / backtick command substitutions for hidden forbidden verbs.
+/// Whether a paren-delimited substitution opens at byte `i`, and whether it is
+/// live there given the segment's quote map.
+///
+/// Why (#2745): `$(…)`, `<(…)` and `>(…)` are one CLASS — bash executes the
+/// body of each, so each must be decomposed and classified. Naming them in one
+/// place is what makes that true by construction: a spelling added here is
+/// scanned by [`classify_command_substitutions`] with no other edit, and the
+/// gap that let `diff <(sed -i …) x` through cannot reopen one form at a time.
+/// The two forms differ in ONE respect, which is why this returns liveness
+/// rather than a bare bool: double quotes suppress process substitution
+/// (`echo "<(x)"` is literal text) but NOT command substitution
+/// (`echo "$(sed -i …)"` still runs `sed`).
+/// What: `Some(true)` when a substitution opens at `i` and is live shell
+/// syntax there, `Some(false)` when one opens but is quoted into literal text,
+/// `None` when no substitution opens at `i`. On unbalanced quotes the map is
+/// untrustworthy, so every opener reads as live — the conservative direction.
+/// Test: `evaluate_bash_command_denies_process_substitution_edit`,
+/// `evaluate_bash_command_allows_quoted_process_substitution_prose`,
+/// `evaluate_bash_command_allows_quoted_substitution_prose`.
+fn paren_substitution_live_at(scan: &QuoteScan, bytes: &[u8], i: usize) -> Option<bool> {
+    if bytes.get(i + 1).copied() != Some(b'(') {
+        return None;
+    }
+    match bytes[i] {
+        b'$' => Some(!scan.balanced || scan.allows_substitution(i)),
+        b'<' | b'>' => Some(!scan.balanced || scan.is_unquoted(i)),
+        _ => None,
+    }
+}
+
+/// Inspect every substitution in a segment — `$(…)`, `<(…)`, `>(…)`, and
+/// backticks — for hidden forbidden verbs.
 ///
 /// Why: first-token classification sees the *outer* command only, so
 /// `echo "$(sed -i s/a/b/ f)"` would pass on `echo` while the substitution
@@ -255,24 +287,31 @@ fn classify_bash_segment(segment: &str, depth: usize) -> Option<&'static str> {
 /// substitution (which would break trivial, ubiquitous forms like
 /// `echo "$(date)"`), it recursively classifies the *body* of each with
 /// [`evaluate_bash_command_inner`] — benign body allows, forbidden one denies.
-/// Unbalanced substitutions (an opening `$(` / backtick with no matching close)
-/// deny conservatively, and so does over-deep nesting: an adversarial
-/// `$($($(…` chain is bounded by [`MAX_SUBSTITUTION_DEPTH`] so it can never
-/// exhaust the stack and crash the guard process (a deny is the safe outcome).
+/// Unbalanced substitutions (an opening `$(`/`<(`/`>(`/backtick with no
+/// matching close) deny conservatively, and so does over-deep nesting: an
+/// adversarial `$($($(…` chain is bounded by [`MAX_SUBSTITUTION_DEPTH`] so it
+/// can never exhaust the stack and crash the guard process (a deny is the safe
+/// outcome).
+///
+/// #2745: process substitution used to be invisible here, so
+/// `diff <(sed -i s/a/b/ f) x` was ALLOWED while bash ran the `sed -i`, and
+/// `>(…)` denied only incidentally — its leading `>` tripped
+/// [`has_file_write_redirection`], never its body. Both now classify like every
+/// other substitution, via [`paren_substitution_live_at`].
 /// What: past the depth cap, returns [`SHELL_EDIT_REASON`] immediately.
-/// Otherwise byte-scans for `$(` (matching `)` with paren-depth tracking) and
-/// backtick pairs, recursively evaluates each balanced body at `depth + 1`, and
-/// propagates a deny; unbalanced substitutions return [`SHELL_EDIT_REASON`].
-/// Quote-aware (#2734): a `$(`/backtick inside SINGLE quotes is literal text
-/// (`git commit -m 'costs $(x)'`) and is skipped — but double quotes do NOT
-/// suppress substitution (`echo "$(sed -i …)"` still runs `sed`), so those stay
-/// scanned. On unbalanced quotes the map is untrustworthy and every position is
-/// scanned (the original conservative behaviour).
+/// Otherwise byte-scans for each paren-delimited opener (matching `)` with
+/// paren-depth tracking) and for backtick pairs, recursively evaluates each
+/// balanced body at `depth + 1`, and propagates a deny; an unbalanced
+/// substitution returns [`SHELL_EDIT_REASON`].
 /// Test: `evaluate_bash_command_denies_hidden_substitution_verb`,
 /// `evaluate_bash_command_allows_benign_substitution`,
 /// `evaluate_bash_command_denies_unbalanced_substitution`,
 /// `evaluate_bash_command_bounds_deep_substitution_nesting`,
-/// `evaluate_bash_command_allows_quoted_substitution_prose`.
+/// `evaluate_bash_command_allows_quoted_substitution_prose`,
+/// `evaluate_bash_command_denies_process_substitution_edit`,
+/// `evaluate_bash_command_denies_output_process_substitution_by_classification`,
+/// `evaluate_bash_command_allows_readonly_process_substitution`,
+/// `evaluate_bash_command_denies_unbalanced_process_substitution`.
 fn classify_command_substitutions(segment: &str, depth: usize) -> Option<&'static str> {
     if depth >= MAX_SUBSTITUTION_DEPTH {
         // Too deeply nested to safely decompose — deny conservatively rather
@@ -280,15 +319,15 @@ fn classify_command_substitutions(segment: &str, depth: usize) -> Option<&'stati
         return Some(SHELL_EDIT_REASON);
     }
     let scan = QuoteScan::new(segment);
-    let live = |i: usize| !scan.balanced || scan.allows_substitution(i);
+    let backtick_live = |i: usize| !scan.balanced || scan.allows_substitution(i);
     let bytes = segment.as_bytes();
     let mut i = 0;
     while i < bytes.len() {
-        if !live(i) {
-            i += 1;
-            continue;
-        }
-        if bytes[i] == b'$' && i + 1 < bytes.len() && bytes[i + 1] == b'(' {
+        if let Some(live) = paren_substitution_live_at(&scan, bytes, i) {
+            if !live {
+                i += 1;
+                continue;
+            }
             let mut paren = 1usize;
             let mut j = i + 2;
             while j < bytes.len() && paren > 0 {
@@ -300,7 +339,7 @@ fn classify_command_substitutions(segment: &str, depth: usize) -> Option<&'stati
                 j += 1;
             }
             if paren != 0 {
-                // Unbalanced `$(` — cannot decompose; deny conservatively.
+                // Unbalanced opener — cannot decompose; deny conservatively.
                 return Some(SHELL_EDIT_REASON);
             }
             if let Some(reason) = evaluate_bash_command_inner(&segment[i + 2..j - 1], depth + 1) {
@@ -309,7 +348,7 @@ fn classify_command_substitutions(segment: &str, depth: usize) -> Option<&'stati
             i = j;
             continue;
         }
-        if bytes[i] == b'`' {
+        if bytes[i] == b'`' && backtick_live(i) {
             let mut j = i + 1;
             while j < bytes.len() && bytes[j] != b'`' {
                 j += 1;

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/tests.rs
@@ -1282,3 +1282,79 @@ fn evaluate_bash_command_never_denies_tm_wait() {
         );
     }
 }
+
+#[test]
+fn evaluate_bash_command_denies_process_substitution_edit() {
+    // #2745: bash executes the body of `<(…)`, so a `sed -i` there edits a file
+    // exactly as a bare `sed -i` would. Before the fix the guard inspected only
+    // `$(…)` and backticks, so every spelling below was ALLOWED.
+    for cmd in [
+        "diff <(sed -i s/a/b/ f) x",
+        "diff x <(sed -i s/a/b/ f)",
+        "cat <(patch -p1 f.diff)",
+        "wc -l <(git apply my.patch)",
+    ] {
+        assert_eq!(
+            evaluate_bash_command(cmd),
+            Some(SHELL_EDIT_REASON),
+            "process-substitution body must be classified: {cmd:?}"
+        );
+    }
+}
+
+#[test]
+fn evaluate_bash_command_denies_output_process_substitution_by_classification() {
+    // #2745: `>(…)` was denied only incidentally, because its leading `>` trips
+    // the redirection scan. The body is now classified, so the deny is by
+    // design — and a non-shell-edit body reports ITS OWN reason rather than the
+    // redirection one.
+    assert_eq!(
+        evaluate_bash_command("tee >(sed -i s/a/b/ f)"),
+        Some(SHELL_EDIT_REASON)
+    );
+    assert_eq!(
+        evaluate_bash_command("tee >(curl http://example.com)"),
+        Some(NETWORK_REASON),
+        "the body's own classification decides, not the `>` scan"
+    );
+}
+
+#[test]
+fn evaluate_bash_command_allows_readonly_process_substitution() {
+    // #2745 must close the bypass without blanket-denying the read-only form.
+    for cmd in [
+        "diff <(sort a.txt) <(sort b.txt)",
+        "comm -12 <(git ls-files) <(cat manifest.txt)",
+    ] {
+        assert_eq!(
+            evaluate_bash_command(cmd),
+            None,
+            "read-only process substitution must still pass: {cmd:?}"
+        );
+    }
+}
+
+#[test]
+fn evaluate_bash_command_denies_unbalanced_process_substitution() {
+    // An unclassifiable segment fails CLOSED, matching the `$(`/backtick shape.
+    assert_eq!(
+        evaluate_bash_command("diff <(sed -i s/a/b/ f x"),
+        Some(SHELL_EDIT_REASON)
+    );
+}
+
+#[test]
+fn evaluate_bash_command_allows_quoted_process_substitution_prose() {
+    // Unlike `$(…)`, process substitution is suppressed by BOTH quote styles,
+    // so a `<(…)` in a commit message is literal text in either.
+    for cmd in [
+        r#"git commit -m 'use diff <(sed -i x) y'"#,
+        r#"git commit -m "use diff <(sed -i x) y""#,
+    ] {
+        assert_eq!(
+            evaluate_bash_command(cmd),
+            None,
+            "quoted process-substitution prose is not shell syntax: {cmd:?}"
+        );
+    }
+}

--- a/crates/trusty-mpm/src/bin/tm/generate/doctor.rs
+++ b/crates/trusty-mpm/src/bin/tm/generate/doctor.rs
@@ -121,6 +121,11 @@ pub(crate) const DOCTOR_CHECKS: &[(&str, &str)] = &[
          pull requests with no unsaved work (issue #2919).",
     ),
     (
+        "base_clone",
+        "The base clone each live worktree resolves through still has its git identity — \
+         fails naming the base path and how many worktrees hang off it (issue #3605).",
+    ),
+    (
         "gh_account",
         "Active `gh` CLI identity is unambiguous — warns on multi-account ambiguity.",
     ),

--- a/crates/trusty-mpm/src/bin/tm/tracing_setup.rs
+++ b/crates/trusty-mpm/src/bin/tm/tracing_setup.rs
@@ -24,24 +24,43 @@
 //!
 //! Test: `tests/tm_sessions_instructions_diagnostics.rs`.
 
-use crate::cli::{Command, SessionAction};
+use crate::cli::{CatalogAction, Command, SessionAction};
 
 /// Whether this invocation is a CLI command whose value is its diagnostics.
 ///
 /// Why: kept as a predicate over the parsed command rather than a flag threaded
 /// from the handler, because the subscriber must exist BEFORE the handler runs —
 /// the events fire inside `resolve_pm_prompt`, which the handler calls.
-/// What: true for `tm sessions instructions` and its deprecated singular alias
-/// `tm session instructions`.
-/// Test: `instructions_emits_override_diagnostics_on_stderr`.
+///
+/// #4878 widened it past `tm sessions instructions` to every in-process path
+/// that runs a DEPLOY. Deployment legitimately declines a file — a
+/// checksum-frozen skill, an unreadable ledger, a raced merge — and each
+/// decline is a `warn!`/`error!` written to end silent staleness (#4840, and
+/// PRs #4848 / #4876 / #4908). With no subscriber those events went nowhere, so
+/// the file stayed stale forever with no signal on the four paths an operator
+/// runs by hand.
+/// What: true for `tm sessions instructions` and its deprecated singular alias;
+/// for bare `tm` (`None`), which deploys in-process on both the launch and the
+/// in-place relaunch path; for `tm doctor`, whose `--fix-skills` redeploys; and
+/// for `tm catalog apply`, which redeploys the manifest-selected roster.
+/// Test: `wants_cli_diagnostics_covers_every_in_process_deploy_path`,
+/// `wants_cli_diagnostics_skips_paths_that_own_stdout`,
+/// `instructions_emits_override_diagnostics_on_stderr`.
 fn wants_cli_diagnostics(command: &Option<Command>) -> bool {
     matches!(
         command,
-        Some(Command::Sessions {
-            action: SessionAction::Instructions { .. }
-        }) | Some(Command::Session {
-            action: SessionAction::Instructions { .. }
-        })
+        // Bare `tm`: `commands::launch` and the in-place relaunch path both
+        // deploy in-process before handing off to Claude Code.
+        None | Some(Command::Doctor { .. })
+            | Some(Command::Catalog {
+                action: CatalogAction::Apply { .. }
+            })
+            | Some(Command::Sessions {
+                action: SessionAction::Instructions { .. }
+            })
+            | Some(Command::Session {
+                action: SessionAction::Instructions { .. }
+            })
     )
 }
 
@@ -58,9 +77,9 @@ fn wants_cli_diagnostics(command: &Option<Command>) -> bool {
 /// stdout, and this binary's daemon and MCP modes require stdout stay free for
 /// JSON-RPC framing. The `with_writer` call is load-bearing.
 ///
-/// Called at most once per process, before dispatch. `init` would panic on a
-/// second global-subscriber registration, which is why the caller gates this
-/// against the daemon/supervisor branch rather than running both.
+/// Called at most once per process, before dispatch; the caller still gates
+/// this against the daemon/supervisor branch so those keep their file-rotating
+/// subscriber.
 /// Test: `instructions_emits_override_diagnostics_on_stderr`,
 /// `declined_overrides_are_reported_without_rust_log_set`,
 /// `a_clean_project_produces_no_override_diagnostics`.
@@ -78,17 +97,85 @@ pub(crate) fn init_cli_diagnostics_if_wanted(command: &Option<Command>) {
 /// daemon and MCP modes need it free for JSON-RPC framing. The `with_writer`
 /// call is the load-bearing line in this function, not decoration.
 ///
-/// Panics on a second call: `init` registers the global subscriber. Both callers
-/// are mutually exclusive branches of `main`, which is what keeps that true.
-/// Test: `a_clean_project_produces_no_override_diagnostics` (the writer choice is
+/// Idempotent: `try_init` returns an error instead of panicking when a global
+/// subscriber is already registered, and that error is discarded. #4878 widened
+/// [`wants_cli_diagnostics`] to cover bare `tm`, so a path that also installs
+/// its own subscriber would otherwise abort the process rather than log — and
+/// the project convention is `try_init` for exactly this reason.
+/// Test: `init_stderr_only_is_idempotent`,
+/// `a_clean_project_produces_no_override_diagnostics` (the writer choice is
 /// asserted by piping the two streams apart).
 pub(crate) fn init_stderr_only(default: &str) {
-    tracing_subscriber::fmt()
+    let _ = tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| default.into()),
         )
         .with_writer(std::io::stderr)
         .with_target(false)
-        .init();
+        .try_init();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    use crate::cli::Cli;
+
+    /// Parse a real argv the way `main` does, so the predicate is asserted
+    /// against the command clap actually produces.
+    fn command_for(argv: &[&str]) -> Option<crate::cli::Command> {
+        Cli::try_parse_from(argv)
+            .unwrap_or_else(|e| panic!("argv {argv:?} must parse: {e}"))
+            .command
+    }
+
+    #[test]
+    fn wants_cli_diagnostics_covers_every_in_process_deploy_path() {
+        // #4878: each of these runs a deploy in-process and emits its declines
+        // as `tracing` events. Before the fix only `sessions instructions`
+        // registered a subscriber, so every warning here went nowhere.
+        for argv in [
+            vec!["tm"],
+            vec!["tm", "doctor"],
+            vec!["tm", "doctor", "--fix-skills"],
+            vec!["tm", "catalog", "apply"],
+            vec!["tm", "catalog", "apply", "--force", "--prune"],
+            vec!["tm", "sessions", "instructions"],
+            vec!["tm", "session", "instructions"],
+        ] {
+            assert!(
+                wants_cli_diagnostics(&command_for(&argv)),
+                "{argv:?} runs an in-process deploy and must get a subscriber"
+            );
+        }
+    }
+
+    #[test]
+    fn wants_cli_diagnostics_skips_paths_that_own_stdout() {
+        // The daemon/supervisor branch installs its own file-rotating
+        // subscriber, and `tm serve --stdio` needs stdout for JSON-RPC framing.
+        // Neither deploys in-process, so neither is widened here.
+        for argv in [
+            vec!["tm", "serve", "--stdio"],
+            vec!["tm", "status"],
+            vec!["tm", "catalog", "ls"],
+        ] {
+            assert!(
+                !wants_cli_diagnostics(&command_for(&argv)),
+                "{argv:?} must not register the CLI diagnostics subscriber"
+            );
+        }
+    }
+
+    #[test]
+    fn init_stderr_only_is_idempotent() {
+        // `try_init`, not `init`: a second registration must return an error
+        // that is discarded, never abort the process. Other tests in this
+        // binary may already have installed a subscriber, so this asserts the
+        // no-panic property in either order.
+        init_stderr_only("warn");
+        init_stderr_only("warn");
+    }
 }

--- a/crates/trusty-mpm/src/daemon/api_tests.rs
+++ b/crates/trusty-mpm/src/daemon/api_tests.rs
@@ -1226,6 +1226,8 @@ async fn doctor_endpoint_returns_report() {
         "search_index_pin",
         "worktrees",
         "worktree_disk",
+        // #3605: the base clone a live worktree resolves through.
+        "base_clone",
         "gh_account",
         "oauth_token",
         "hooks_contamination",

--- a/crates/trusty-mpm/src/daemon/bus/error.rs
+++ b/crates/trusty-mpm/src/daemon/bus/error.rs
@@ -25,7 +25,8 @@ use crate::daemon::error::{CODE_CONFLICT, CODE_FORBIDDEN, CODE_GONE, CODE_NOT_FO
 /// instance it named is gone, or the instance is registered but has no
 /// attached subscriber — because the correct client reaction differs for each
 /// (start one / re-resolve the definition / retry).
-/// What: four addressing/delivery variants plus two request-validation ones.
+/// What: five addressing/delivery/registration variants plus two
+/// request-validation ones.
 /// Test: `bus_error_status_codes_map`, `instance_gone_is_410`.
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum BusError {
@@ -108,6 +109,27 @@ pub enum BusError {
         kind: super::envelope::CallerKind,
     },
 
+    /// Registration could not mint an instance id that was not already live.
+    ///
+    /// Why this is an error and not a silent overwrite (#4276): the alternative
+    /// is [`super::registry::InstanceRegistry`] replacing a live instance's
+    /// entry with the newcomer's, after which every lookup of the FIRST
+    /// instance resolves to the second. That is misrouting dressed as success —
+    /// the same failure the no-fallback rule exists to prevent, reached by
+    /// registration rather than by resolution. Refusing to register is
+    /// recoverable; the caller retries and sees why.
+    #[error(
+        "could not mint a free instance id for definition '{definition_id}' \
+         after {attempts} attempts; registration refused rather than \
+         overwriting a live instance"
+    )]
+    InstanceIdCollision {
+        /// The definition whose registration was refused.
+        definition_id: String,
+        /// How many suffixes were minted and found occupied.
+        attempts: usize,
+    },
+
     /// A definition id failed validation.
     #[error("invalid definition id '{definition_id}': {reason}")]
     InvalidDefinitionId {
@@ -138,7 +160,10 @@ impl BusError {
     /// [`BusError::UnregisteredSender`] — the one failure about the caller's
     /// own identity rather than the target's.
     /// What: `403` sender unverified, `404` not-found, `410` gone, `409`
-    /// conflict, `400` bad request.
+    /// conflict, `400` bad request. [`BusError::InstanceIdCollision`] joins the
+    /// `409` row (#4276): the request was well-formed and the state of the
+    /// registry is what refused it, which is what `409 Conflict` names — and a
+    /// retry is the correct client reaction, as it is for the other `409`.
     /// Test: `bus_error_status_codes_map`, `instance_gone_is_410`,
     /// `unregistered_sender_is_403`.
     pub fn status(&self) -> StatusCode {
@@ -146,7 +171,7 @@ impl BusError {
             Self::UnregisteredSender { .. } => StatusCode::FORBIDDEN,
             Self::NoLiveInstance { .. } => StatusCode::NOT_FOUND,
             Self::InstanceGone { .. } => StatusCode::GONE,
-            Self::NoSubscriber { .. } => StatusCode::CONFLICT,
+            Self::NoSubscriber { .. } | Self::InstanceIdCollision { .. } => StatusCode::CONFLICT,
             Self::InvalidDefinitionId { .. }
             | Self::InvalidTarget(_)
             | Self::InvalidCaller(_)

--- a/crates/trusty-mpm/src/daemon/bus/registry.rs
+++ b/crates/trusty-mpm/src/daemon/bus/registry.rs
@@ -54,6 +54,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use dashmap::DashMap;
+use dashmap::mapref::entry::Entry;
 use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast;
 
@@ -81,6 +82,24 @@ const INSTANCE_CHANNEL_CAPACITY: usize = 64;
 /// RFC 3986 *unreserved* separator that is safe in a path, a query, and a
 /// fragment alike.
 pub const INSTANCE_ID_SEPARATOR: char = '~';
+
+/// How many suffixes [`InstanceRegistry::register`] mints before refusing.
+///
+/// Why (#4276): a bounded retry is what turns a collision into a re-mint
+/// instead of an overwrite, and the bound is what stops a pathological suffix
+/// source from spinning forever inside a registration. Eight is generous
+/// against a 32-bit space — reaching it means the source is not random, which
+/// is a condition to report, not to retry through.
+const MAX_INSTANCE_ID_MINT_ATTEMPTS: usize = 8;
+
+/// One random 8-hex-character instance-id suffix.
+///
+/// Why a named function rather than an inline expression: it is the production
+/// argument [`InstanceRegistry::register_with_minter`] takes, so the seam a
+/// test substitutes has exactly one real implementation.
+fn mint_instance_suffix() -> String {
+    uuid::Uuid::new_v4().simple().to_string()[..8].to_string()
+}
 
 /// The publicly observable facts about one live instance.
 ///
@@ -188,30 +207,83 @@ impl InstanceRegistry {
     /// `<definition_id>~<8 hex>` ([`INSTANCE_ID_SEPARATOR`]), creates the
     /// instance's delivery channel, and inserts it.
     /// Test: `register_mints_prefixed_id`, `register_rejects_bad_definition`,
-    /// `instance_id_is_url_path_safe`.
+    /// `instance_id_is_url_path_safe`,
+    /// `register_re_mints_on_a_suffix_collision`,
+    /// `register_fails_loudly_when_every_mint_collides`.
     pub fn register(
         &self,
         definition_id: &str,
         project: Option<String>,
     ) -> Result<InstanceMeta, BusError> {
+        self.register_with_minter(definition_id, project, mint_instance_suffix)
+    }
+
+    /// [`register`](Self::register) against an explicit suffix source.
+    ///
+    /// Why (#4276): registration used to `insert` unconditionally, and
+    /// `DashMap::insert` REPLACES on a duplicate key. Two instances that drew
+    /// the same 32-bit suffix would therefore collapse into one entry, and
+    /// every later lookup of the first instance would resolve to the second —
+    /// the one way instance-addressed delivery could reach an instance the
+    /// sender did not name, defeating the no-fallback guarantee this module is
+    /// built around by a route the module doc does not cover. The suffix source
+    /// is a parameter because a collision cannot be provoked through
+    /// `Uuid::new_v4`, so the guard would otherwise be untestable.
+    /// What: mints, then claims the key through `entry` — a VACANT entry
+    /// inserts and returns, an OCCUPIED one logs and re-mints, up to
+    /// [`MAX_INSTANCE_ID_MINT_ATTEMPTS`]. Exhausting those returns
+    /// [`BusError::InstanceIdCollision`] rather than overwriting a live
+    /// instance: refusing to register is recoverable, silently stealing another
+    /// instance's id is not. `seq` is drawn once per call, so a re-mint does
+    /// not perturb the registration ordering
+    /// [`resolve_definition`](Self::resolve_definition) tie-breaks on.
+    /// Test: `register_re_mints_on_a_suffix_collision`,
+    /// `register_fails_loudly_when_every_mint_collides`.
+    pub(super) fn register_with_minter(
+        &self,
+        definition_id: &str,
+        project: Option<String>,
+        mut mint: impl FnMut() -> String,
+    ) -> Result<InstanceMeta, BusError> {
         validate_definition_id(definition_id)?;
-        let short = uuid::Uuid::new_v4().simple().to_string()[..8].to_string();
-        let meta = InstanceMeta {
-            instance_id: format!("{definition_id}{INSTANCE_ID_SEPARATOR}{short}"),
-            definition_id: definition_id.to_string(),
-            project,
-            registered_at: chrono::Utc::now().to_rfc3339(),
-            seq: self.next_seq.fetch_add(1, Ordering::SeqCst),
-        };
-        let (tx, _) = broadcast::channel(INSTANCE_CHANNEL_CAPACITY);
-        self.instances.insert(
-            meta.instance_id.clone(),
-            LiveInstance {
-                meta: meta.clone(),
-                tx,
-            },
+        let seq = self.next_seq.fetch_add(1, Ordering::SeqCst);
+        for attempt in 1..=MAX_INSTANCE_ID_MINT_ATTEMPTS {
+            let instance_id = format!("{definition_id}{INSTANCE_ID_SEPARATOR}{}", mint());
+            match self.instances.entry(instance_id.clone()) {
+                Entry::Occupied(_) => {
+                    tracing::warn!(
+                        %instance_id,
+                        attempt,
+                        "bus: minted instance id already live — re-minting rather than \
+                         overwriting the registered instance"
+                    );
+                }
+                Entry::Vacant(vacant) => {
+                    let meta = InstanceMeta {
+                        instance_id,
+                        definition_id: definition_id.to_string(),
+                        project,
+                        registered_at: chrono::Utc::now().to_rfc3339(),
+                        seq,
+                    };
+                    let (tx, _) = broadcast::channel(INSTANCE_CHANNEL_CAPACITY);
+                    vacant.insert(LiveInstance {
+                        meta: meta.clone(),
+                        tx,
+                    });
+                    return Ok(meta);
+                }
+            }
+        }
+        tracing::error!(
+            definition_id,
+            attempts = MAX_INSTANCE_ID_MINT_ATTEMPTS,
+            "bus: could not mint a free instance id — registration refused"
         );
-        Ok(meta)
+        Err(BusError::InstanceIdCollision {
+            definition_id: definition_id.to_string(),
+            attempts: MAX_INSTANCE_ID_MINT_ATTEMPTS,
+        })
     }
 
     /// Remove an instance, making it no longer addressable.

--- a/crates/trusty-mpm/src/daemon/bus/tests.rs
+++ b/crates/trusty-mpm/src/daemon/bus/tests.rs
@@ -220,6 +220,75 @@ fn register_mints_prefixed_id() {
     assert_eq!(reg.len(), 2);
 }
 
+/// A minter that hands back `suffixes` in order, then repeats the last one.
+///
+/// Why: `Uuid::new_v4` cannot be made to collide, so the collision path is
+/// reachable only through the injected suffix source. Repeating the last value
+/// is what lets one helper drive both the recover-on-retry case and the
+/// every-attempt-collides case.
+fn scripted_minter(suffixes: &[&str]) -> impl FnMut() -> String + use<> {
+    let scripted: Vec<String> = suffixes.iter().map(|s| (*s).to_string()).collect();
+    let mut next = 0usize;
+    move || {
+        let out = scripted[next.min(scripted.len() - 1)].clone();
+        next += 1;
+        out
+    }
+}
+
+#[test]
+fn register_re_mints_on_a_suffix_collision() {
+    // #4276: pre-fix this was a bare `DashMap::insert`, so the second
+    // registration REPLACED the first — `len()` stayed 1 and resolving the
+    // first instance's id reached the second instance's channel.
+    let reg = InstanceRegistry::default();
+    let first = reg
+        .register_with_minter("izzie", None, scripted_minter(&["aaaaaaaa"]))
+        .expect("first registration");
+    let second = reg
+        .register_with_minter("izzie", None, scripted_minter(&["aaaaaaaa", "bbbbbbbb"]))
+        .expect("collision must re-mint, not overwrite");
+
+    assert_eq!(first.instance_id, "izzie~aaaaaaaa");
+    assert_eq!(second.instance_id, "izzie~bbbbbbbb");
+    assert_eq!(reg.len(), 2, "the first instance must still be registered");
+    // The decisive assertion: the first id still resolves to the FIRST
+    // instance, not to the one that collided with it.
+    let resolved = reg
+        .resolve_instance(&first.instance_id)
+        .expect("still live");
+    assert_eq!(resolved.meta.seq, first.seq);
+    assert!(second.seq > first.seq, "re-minting must not reorder seq");
+}
+
+#[test]
+fn register_fails_loudly_when_every_mint_collides() {
+    // A suffix source that never yields a free id must refuse the registration
+    // rather than overwrite the live instance holding that id.
+    let reg = InstanceRegistry::default();
+    let first = reg
+        .register_with_minter("izzie", None, scripted_minter(&["aaaaaaaa"]))
+        .expect("first registration");
+
+    let err = reg
+        .register_with_minter("izzie", None, scripted_minter(&["aaaaaaaa"]))
+        .expect_err("an exhausted mint must error, not overwrite");
+    assert!(
+        matches!(err, BusError::InstanceIdCollision { .. }),
+        "expected InstanceIdCollision, got {err:?}"
+    );
+    assert_eq!(err.status(), StatusCode::CONFLICT);
+    assert_eq!(reg.len(), 1);
+    assert_eq!(
+        reg.resolve_instance(&first.instance_id)
+            .expect("survivor")
+            .meta
+            .seq,
+        first.seq,
+        "the live instance must be untouched by the refused registration"
+    );
+}
+
 #[test]
 fn register_rejects_bad_definition() {
     let reg = InstanceRegistry::default();

--- a/crates/trusty-mpm/src/daemon/doctor.rs
+++ b/crates/trusty-mpm/src/daemon/doctor.rs
@@ -29,6 +29,13 @@ use doctor_worktrees::check_worktrees;
 pub(crate) use doctor_worktrees::gather_worktree_counts;
 pub use doctor_worktrees::{WORKTREE_REMEDIATION_COMMAND, WorktreeOrphanCounts};
 
+// #3605: `check_worktrees` above counts orphaned worktree DIRECTORIES. This is
+// the opposite condition — a live worktree whose base clone stopped resolving,
+// which the 2026-07-21 incident left undetected for over half an hour.
+#[path = "doctor_base_clone.rs"]
+mod doctor_base_clone;
+use doctor_base_clone::check_base_clones;
+
 use super::search_rpc;
 
 // Split out to keep this file under the 500-SLOC production cap (DOC-28 R4(a)).
@@ -396,6 +403,10 @@ pub async fn run_doctor(
     // byte, so it read identically whether the worktree store held 4 GiB or the
     // 1.1 TiB measured on 2026-07-21. This is the disk half.
     checks.push(check_worktree_disk(repos_root, active_workspace_paths).await);
+    // #3605: and this is the identity half — a live worktree keeps its files
+    // when the base clone behind it loses its git internals, so every git
+    // command there fails while both probes above stay green.
+    checks.push(check_base_clones(active_workspace_paths));
     checks.push(check_gh_account().await);
     checks.push(check_oauth_token_config());
     let (hooks_contamination, hooks_foreign_conflict) =

--- a/crates/trusty-mpm/src/daemon/doctor_base_clone.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_base_clone.rs
@@ -1,0 +1,225 @@
+//! `tm doctor`'s `base_clone` probe — the git identity of the clone a live
+//! session's worktree hangs off (issue #3605).
+//!
+//! Why: a linked worktree stores no object database of its own. Its `.git` is a
+//! one-line FILE pointing at admin data inside the base clone, and every git
+//! command run inside it reads through that pointer. When the base clone loses
+//! its git internals the worktree keeps every source file it had and stops
+//! being a git repository, which surfaces to whoever is working in it as
+//! `fatal: not a git repository: (null)` — and, second-hand, as test failures
+//! that have nothing to do with the code under test. On 2026-07-21 that state
+//! went unnoticed for over half an hour across 70 worktrees, discovered only
+//! when two agents died in it. Nothing in doctor looked at the base clone:
+//! `doctor_worktrees` counts orphaned worktree DIRECTORIES, which is the
+//! opposite condition (a directory nothing owns, rather than an owner that has
+//! stopped resolving).
+//!
+//! What: [`check_base_clones`] reads each live session workspace's `.git`
+//! pointer, resolves the base clone behind it, and Fails when that clone can no
+//! longer answer for the worktree — naming the base path and how many live
+//! worktrees hang off it, so the blast radius is in the report rather than
+//! inferred later.
+//!
+//! DETECTION ONLY. It reads; it never repairs, moves, or deletes.
+//! `provisioner::workspace::base_lock::stale_base_dir_error` already settles
+//! the repair side by refusing to touch a directory that may hold live
+//! worktrees, and this probe's remediation text points at the same quarantine
+//! discipline rather than inventing a second answer.
+//! Test: `base_clone_ok_with_no_live_workspaces`,
+//! `base_clone_ok_for_a_healthy_worktree`,
+//! `base_clone_fails_when_the_admin_dir_is_gone`,
+//! `base_clone_fails_when_the_object_database_is_gone`,
+//! `base_clone_counts_every_worktree_behind_one_base`,
+//! `base_clone_ignores_a_plain_checkout` (all in `doctor_base_clone_tests.rs`).
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use crate::core::doctor::{CheckStatus, DoctorCheck};
+
+/// What a live workspace's `.git` pointer established about its base clone.
+///
+/// Why: "no base clone" and "a base clone that stopped resolving" must not
+/// collapse into one value — the first is the normal state of a plain checkout
+/// and the second is the incident. Making them separate variants is what keeps
+/// [`check_base_clones`] from reporting a project that simply is not a linked
+/// worktree.
+/// What: `NotLinked` for a workspace whose `.git` is a directory or absent;
+/// `Healthy` carries the base clone root; `Severed` carries the root plus the
+/// reason it no longer answers.
+#[derive(Debug, PartialEq, Eq)]
+enum BaseCloneState {
+    /// The workspace is not a linked worktree — it has no base clone.
+    NotLinked,
+    /// The base clone at this path still answers for the workspace.
+    Healthy(PathBuf),
+    /// The base clone at this path can no longer answer for the workspace.
+    Severed {
+        /// The base clone's root directory.
+        base: PathBuf,
+        /// What is missing, in one clause, for the report.
+        reason: &'static str,
+    },
+}
+
+/// The admin directory a linked worktree's `.git` file points at.
+///
+/// Why: `git worktree add` writes `gitdir: <path>` into the worktree's `.git`
+/// FILE, and that pointer is the whole of the worktree's git identity. Reading
+/// it directly — rather than shelling out to `git` — is what lets this probe
+/// report the severed state at all: once the target is gone every `git` command
+/// run there fails with the same opaque error and tells us nothing about which
+/// path it was reaching for.
+/// What: reads `<workspace>/.git` as a file, returns the `gitdir:` value
+/// resolved against `workspace` when relative. `None` when `.git` is a
+/// directory (a plain clone), absent, unreadable, or carries no `gitdir:` line.
+fn worktree_gitdir(workspace: &Path) -> Option<PathBuf> {
+    let dot_git = workspace.join(".git");
+    if dot_git.is_dir() {
+        return None;
+    }
+    let contents = std::fs::read_to_string(&dot_git).ok()?;
+    let target = contents
+        .lines()
+        .find_map(|line| line.trim().strip_prefix("gitdir:"))?
+        .trim();
+    if target.is_empty() {
+        return None;
+    }
+    let path = Path::new(target);
+    Some(if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        workspace.join(path)
+    })
+}
+
+/// The base clone root, and its common git directory, for a worktree admin
+/// path.
+///
+/// Why: git writes the admin path as `<common>/worktrees/<name>`, where
+/// `<common>` is `<base>/.git` for an ordinary clone and `<base>` itself for
+/// the legacy bare shape #4270 retired. Both spellings still exist on disk on
+/// any machine that ran an older build, so the report must name the right base
+/// for either.
+/// What: pops `<name>` and `worktrees`, yielding the common dir; the base root
+/// is that with a trailing `.git` popped when present. `None` when the path is
+/// not shaped like a worktree admin directory.
+fn base_and_common_dir(gitdir: &Path) -> Option<(PathBuf, PathBuf)> {
+    let worktrees_dir = gitdir.parent()?;
+    if worktrees_dir.file_name()? != "worktrees" {
+        return None;
+    }
+    let common = worktrees_dir.parent()?.to_path_buf();
+    let base = match common.file_name() {
+        Some(name) if name == ".git" => common.parent()?.to_path_buf(),
+        _ => common.clone(),
+    };
+    Some((base, common))
+}
+
+/// Classify one live workspace's base clone.
+///
+/// What: resolves the `.git` pointer, then asks three questions of what it
+/// found — does the worktree's own admin directory still exist, does the common
+/// git directory still hold a `HEAD`, and does it still hold an object
+/// database. Any "no" is the severed state; a partial deletion that spares
+/// `worktrees/` is caught by the second and third.
+/// Test: `base_clone_fails_when_the_admin_dir_is_gone`,
+/// `base_clone_fails_when_the_object_database_is_gone`,
+/// `base_clone_ignores_a_plain_checkout`.
+fn classify(workspace: &Path) -> BaseCloneState {
+    let Some(gitdir) = worktree_gitdir(workspace) else {
+        return BaseCloneState::NotLinked;
+    };
+    let Some((base, common)) = base_and_common_dir(&gitdir) else {
+        return BaseCloneState::NotLinked;
+    };
+    if !gitdir.is_dir() {
+        return BaseCloneState::Severed {
+            base,
+            reason: "its per-worktree admin directory is gone",
+        };
+    }
+    if !common.join("HEAD").is_file() {
+        return BaseCloneState::Severed {
+            base,
+            reason: "it has no HEAD",
+        };
+    }
+    if !common.join("objects").is_dir() {
+        return BaseCloneState::Severed {
+            base,
+            reason: "it has no object database",
+        };
+    }
+    BaseCloneState::Healthy(base)
+}
+
+/// Probe every live session workspace for a base clone that stopped resolving.
+///
+/// Why: see the module doc — this is the detection half of #3605, and it is a
+/// hard `Fail` rather than a `Warn` deliberately. The condition is not degraded
+/// service: every git operation in every affected worktree is already failing,
+/// and unpushed commits that lived only in that clone are already unreachable.
+/// A quiet row is what made the original incident expensive.
+/// What: classifies each path in `active_workspace_paths`, groups the severed
+/// ones by base clone, and reports `Ok` when none is severed (naming how many
+/// linked worktrees were examined) or `Fail` naming each broken base, the
+/// reason, and how many live worktrees hang off it. Reads only.
+/// Test: `base_clone_ok_with_no_live_workspaces`,
+/// `base_clone_ok_for_a_healthy_worktree`,
+/// `base_clone_fails_when_the_admin_dir_is_gone`,
+/// `base_clone_counts_every_worktree_behind_one_base`.
+pub(super) fn check_base_clones(active_workspace_paths: &[PathBuf]) -> DoctorCheck {
+    let mut linked = 0usize;
+    // BTreeMap so a multi-base failure reports in a stable order.
+    let mut severed: BTreeMap<PathBuf, (&'static str, usize)> = BTreeMap::new();
+    for workspace in active_workspace_paths {
+        match classify(workspace) {
+            BaseCloneState::NotLinked => {}
+            BaseCloneState::Healthy(_) => linked += 1,
+            BaseCloneState::Severed { base, reason } => {
+                linked += 1;
+                let entry = severed.entry(base).or_insert((reason, 0));
+                entry.1 += 1;
+            }
+        }
+    }
+
+    if severed.is_empty() {
+        return DoctorCheck::new(
+            "base_clone",
+            CheckStatus::Ok,
+            format!(
+                "{linked} live worktree(s) resolve through their base clone \
+                 ({} session workspace(s) examined)",
+                active_workspace_paths.len()
+            ),
+        );
+    }
+
+    let detail = severed
+        .iter()
+        .map(|(base, (reason, count))| {
+            format!("{} — {reason} ({count} live worktree(s))", base.display())
+        })
+        .collect::<Vec<_>>()
+        .join("; ");
+    DoctorCheck::new(
+        "base_clone",
+        CheckStatus::Fail,
+        format!(
+            "base clone lost its git identity while live worktrees still point at it: \
+             {detail}. Every git command in those worktrees fails with `fatal: not a \
+             git repository`, and commits that lived only in that clone are \
+             unreachable. Do NOT recursively delete the base — quarantine it (`mv` it \
+             aside) and re-clone, so an orphaned worktree can still be repointed at \
+             the copy (issue #3605)."
+        ),
+    )
+}
+
+#[cfg(test)]
+#[path = "doctor_base_clone_tests.rs"]
+mod tests;

--- a/crates/trusty-mpm/src/daemon/doctor_base_clone_tests.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_base_clone_tests.rs
@@ -1,0 +1,173 @@
+//! Unit tests for the `base_clone` doctor probe (issue #3605).
+//!
+//! Why: the condition being detected is a directory layout, so every case is
+//! built on disk rather than mocked — a fixture that only *described* a severed
+//! base would not prove the probe reads the same bytes git does.
+//! What: builds the real `<base>/.git/worktrees/<name>` shape a `git worktree
+//! add` produces, then deletes exactly what the 2026-07-21 incident deleted.
+//! Test: this module IS the test module.
+
+use super::*;
+
+/// Build a base clone plus `count` linked worktrees, the way git lays them out.
+///
+/// Returns the base root and the worktree workspace paths.
+fn base_with_worktrees(root: &Path, name: &str, count: usize) -> (PathBuf, Vec<PathBuf>) {
+    let base = root.join(name);
+    let common = base.join(".git");
+    std::fs::create_dir_all(common.join("objects")).unwrap();
+    std::fs::write(common.join("HEAD"), "ref: refs/heads/main\n").unwrap();
+    let mut workspaces = Vec::new();
+    for i in 0..count {
+        let id = format!("wt-{i}");
+        let admin = common.join("worktrees").join(&id);
+        std::fs::create_dir_all(&admin).unwrap();
+        std::fs::write(admin.join("HEAD"), "ref: refs/heads/main\n").unwrap();
+        let workspace = root.join(&id);
+        std::fs::create_dir_all(&workspace).unwrap();
+        std::fs::write(
+            workspace.join(".git"),
+            format!("gitdir: {}\n", admin.display()),
+        )
+        .unwrap();
+        workspaces.push(workspace);
+    }
+    (base, workspaces)
+}
+
+#[test]
+fn base_clone_ok_with_no_live_workspaces() {
+    let check = check_base_clones(&[]);
+    assert_eq!(check.status, CheckStatus::Ok);
+}
+
+#[test]
+fn base_clone_ok_for_a_healthy_worktree() {
+    let dir = tempfile::tempdir().unwrap();
+    let (_base, workspaces) = base_with_worktrees(dir.path(), "proj", 2);
+    let check = check_base_clones(&workspaces);
+    assert_eq!(check.status, CheckStatus::Ok, "{}", check.message);
+    assert!(
+        check.message.contains("2 live worktree(s)"),
+        "{}",
+        check.message
+    );
+}
+
+#[test]
+fn base_clone_ignores_a_plain_checkout() {
+    // A workspace whose `.git` is a DIRECTORY is its own clone — it has no base
+    // clone to lose, and must never be counted or reported.
+    let dir = tempfile::tempdir().unwrap();
+    let plain = dir.path().join("plain");
+    std::fs::create_dir_all(plain.join(".git").join("objects")).unwrap();
+    let check = check_base_clones(&[plain]);
+    assert_eq!(check.status, CheckStatus::Ok);
+    assert!(
+        check.message.contains("0 live worktree(s)"),
+        "{}",
+        check.message
+    );
+}
+
+#[test]
+fn base_clone_fails_when_the_admin_dir_is_gone() {
+    // The 2026-07-21 signature: the base clone's git internals are deleted
+    // while the worktrees still point at them.
+    let dir = tempfile::tempdir().unwrap();
+    let (base, workspaces) = base_with_worktrees(dir.path(), "proj", 1);
+    std::fs::remove_dir_all(base.join(".git").join("worktrees")).unwrap();
+
+    let check = check_base_clones(&workspaces);
+    assert_eq!(check.status, CheckStatus::Fail, "{}", check.message);
+    assert!(
+        check.message.contains(&base.display().to_string()),
+        "the failing base must be named: {}",
+        check.message
+    );
+    assert!(
+        check.message.contains("1 live worktree(s)"),
+        "the blast radius must be reported: {}",
+        check.message
+    );
+    assert!(
+        check.message.contains("Do NOT recursively delete"),
+        "remediation must preserve the quarantine discipline: {}",
+        check.message
+    );
+}
+
+#[test]
+fn base_clone_fails_when_the_object_database_is_gone() {
+    // A partial deletion that spares `worktrees/` still leaves every git
+    // command in the worktree failing, so the admin-dir probe alone is not
+    // enough.
+    let dir = tempfile::tempdir().unwrap();
+    let (base, workspaces) = base_with_worktrees(dir.path(), "proj", 1);
+    std::fs::remove_dir_all(base.join(".git").join("objects")).unwrap();
+
+    let check = check_base_clones(&workspaces);
+    assert_eq!(check.status, CheckStatus::Fail, "{}", check.message);
+    assert!(
+        check.message.contains("no object database"),
+        "{}",
+        check.message
+    );
+}
+
+#[test]
+fn base_clone_counts_every_worktree_behind_one_base() {
+    // The count is what turns "a base is broken" into "and this much work is
+    // sitting behind it" — the number the original incident had to be
+    // reconstructed by hand.
+    let dir = tempfile::tempdir().unwrap();
+    let (base, workspaces) = base_with_worktrees(dir.path(), "proj", 5);
+    std::fs::remove_dir_all(base.join(".git")).unwrap();
+
+    let check = check_base_clones(&workspaces);
+    assert_eq!(check.status, CheckStatus::Fail);
+    assert!(
+        check.message.contains("5 live worktree(s)"),
+        "{}",
+        check.message
+    );
+}
+
+#[test]
+fn base_clone_reports_the_legacy_bare_layout_too() {
+    // #4270 moved the base clone off the bare `.base` shape, but a machine that
+    // ran an older build still has `<base>/worktrees/<id>` on disk, and that
+    // layout is what the incident actually hit.
+    let dir = tempfile::tempdir().unwrap();
+    let base = dir.path().join(".base");
+    let admin = base.join("worktrees").join("wt-0");
+    std::fs::create_dir_all(&admin).unwrap();
+    std::fs::create_dir_all(base.join("objects")).unwrap();
+    std::fs::write(base.join("HEAD"), "ref: refs/heads/main\n").unwrap();
+    let workspace = dir.path().join("wt-0");
+    std::fs::create_dir_all(&workspace).unwrap();
+    std::fs::write(
+        workspace.join(".git"),
+        format!("gitdir: {}\n", admin.display()),
+    )
+    .unwrap();
+
+    assert_eq!(
+        check_base_clones(std::slice::from_ref(&workspace)).status,
+        CheckStatus::Ok
+    );
+
+    // Now delete the bare clone's non-dot internals, exactly as the incident's
+    // `rm -rf .base/*` did.
+    std::fs::remove_dir_all(base.join("worktrees")).unwrap();
+    std::fs::remove_dir_all(base.join("objects")).unwrap();
+    std::fs::remove_file(base.join("HEAD")).unwrap();
+
+    let check = check_base_clones(&[workspace]);
+    assert_eq!(check.status, CheckStatus::Fail, "{}", check.message);
+    assert!(
+        check.message.contains(&base.display().to_string()),
+        "{}",
+        check.message
+    );
+}

--- a/crates/trusty-mpm/src/daemon/doctor_tests.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_tests.rs
@@ -443,7 +443,7 @@ async fn run_doctor_produces_thirty_two_checks() {
     // twenty-seven); issue #4033 adds `binary_provenance` (twenty-seven →
     // twenty-eight); issue #5045 adds `search_index_pin` (twenty-nine →
     // thirty); the stray-`.mcp.json` probe adds `stray_mcp_json` (thirty →
-    // thirty-one).
+    // thirty-one); issue #3605 adds `base_clone` (thirty-one → thirty-two).
     // #1905's stale-skill cleanup is deliberately NOT a `run_doctor` probe
     // — see the `run_doctor` doc.
     let report = run_doctor(None, None, &[], None).await;
@@ -471,6 +471,8 @@ async fn run_doctor_produces_thirty_two_checks() {
         "search_index_pin",
         "worktrees",
         "worktree_disk",
+        // #3605: the base clone a live worktree resolves through.
+        "base_clone",
         "gh_account",
         "oauth_token",
         "hooks_contamination",


### PR DESCRIPTION
Four independent `trusty-mpm` defects, one PR. Each carries a regression test that was run against the pre-fix shape and observed to fail.

- **Refs #2745** — `tm hook --pm-guard` never classified process-substitution bodies, so `diff <(sed -i s/a/b/ f) x` was ALLOWED while bash ran the `sed -i`. `<(`, `>(`, `$(` and backticks are now one class the classifier decomposes: `paren_substitution_live_at` names the openers in one place, each body recurses through `evaluate_bash_command_inner`, and an unbalanced opener fails closed. `>(…)` now denies by its body's own reason rather than incidentally via the `>` redirection scan. Process substitution is suppressed by BOTH quote styles, so a `<(…)` in a commit message stays literal text. Pre-fix run: `evaluate_bash_command("diff <(sed -i s/a/b/ f) x")` returned `None`.
- **Refs #3605** — nothing in `tm doctor` detected a live session's base clone losing its git identity; the 2026-07-21 incident surfaced only when two agents died in it 30+ minutes later. The new `base_clone` check reads each live workspace's `.git` pointer, resolves the base clone behind it, and Fails naming the base path, what is missing (admin dir / HEAD / object database), and how many live worktrees hang off it. Handles both the current `<base>/.git/worktrees/<id>` layout and the legacy bare `<base>/worktrees/<id>` one #4270 retired. Detection only — it never repairs, moves, or deletes, and its remediation text keeps `stale_base_dir_error`'s quarantine-never-delete discipline. Pre-fix run: with the probe neutered to the pre-fix "no signal" state, all six behaviour tests fail.
- **Refs #4878** — bare `tm`, `tm doctor --fix-skills`, and `tm catalog apply` each run a deploy in-process and each decline was a `tracing` event with no subscriber registered, so a checksum-frozen skill or an unreadable ledger stayed stale forever with no signal. All three now install the same stderr-only subscriber `tm sessions instructions` uses, at the `warn` default so a clean run stays quiet, stderr so MCP JSON-RPC framing is untouched. `init_stderr_only` switched from `init` to `try_init` per the project's idempotency convention. Pre-fix run: `wants_cli_diagnostics` returned false for bare `tm`.
- **Refs #4276** — `InstanceRegistry::register` used a bare `DashMap::insert`, which REPLACES on a duplicate key, so two instances drawing the same 32-bit suffix collapsed into one entry and every later lookup of the first resolved to the second. Registration now claims the key through `entry`, re-minting up to eight times and logging each collision, and returns the new `BusError::InstanceIdCollision` (409) rather than displacing a live instance. The suffix source is a parameter because `Uuid::new_v4` cannot be made to collide. Pre-fix run: the second registration's id came back as the first's, and `len()` stayed 1.

Test ladder rung 3 (localized behaviour inside one crate), plus the doctor check-name tables in `daemon/doctor_tests.rs`, `daemon/api_tests.rs`, and `bin/tm/generate/doctor.rs`.

```
cargo fmt --check                                     EXIT=0
cargo check -p trusty-mpm --all-targets               EXIT=0
cargo clippy -p trusty-mpm --all-targets -D warnings  EXIT=0
cargo test -p trusty-mpm --no-fail-fast               EXIT=0  9681 passed; 0 failed; 18 ignored (54 targets)
bash scripts/check_test_pointers.sh                   EXIT=0  27860 citations, 0 dangling
bash scripts/check_line_cap.sh                        EXIT=0  4296 files, 0 violations
bash scripts/check_sld.sh                             EXIT=0  0 errors, 0 warnings
CHANGELOG_BASE=origin/main check_changelog_fragment.sh EXIT=0
```

An earlier full-suite run reddened `core::session_assets::tests::session_plan_under_matches_session_plan_at_home` (two `TMPDIR`-derived roots differing) and `daemon::rpc::core::tests::rpc_tmux_snapshot_unknown_session_reports_a_coded_error` (the `$HOME`/host-state gate answering instead of the session lookup). Both are in files this branch does not touch — `git diff --name-only origin/main...HEAD -- crates/trusty-mpm/src/core/ crates/trusty-mpm/src/daemon/rpc/ crates/trusty-mpm/src/daemon/tmux.rs` is empty — and both passed on the rerun above. They are the flake class PR #6453 (`fix/wave1-mpm-flakes`) is fixing.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
