### PR TITLE
fix(trusty-mpm): mark a peer-bus envelope delivered only when it is (Refs #4271)

### DIFF
--- a/crates/trusty-mpm/changelog.d/4271-bus-delivery-truth.md
+++ b/crates/trusty-mpm/changelog.d/4271-bus-delivery-truth.md
@@ -16,3 +16,7 @@ Fixed
   session SSE handlers that carry load-sheddable telemetry — which DOC-60 §3
   keeps off this bus. It now emits an `event: lagged` frame carrying the missed
   count and the durable log's path to re-read from, plus a `warn!`.
+- The bus's durable JSONL stream no longer interleaves two records into an
+  unparseable line when two publishes land at once. `AuditLogger::try_log` wrote
+  the record and its newline as separate unbuffered writes; it now appends both
+  in one `write_all`.

--- a/crates/trusty-mpm/changelog.d/4271-bus-delivery-truth.md
+++ b/crates/trusty-mpm/changelog.d/4271-bus-delivery-truth.md
@@ -1,0 +1,18 @@
+Fixed
+
+- The peer bus no longer records an envelope as `delivered` when a lagging
+  subscriber never saw it
+  ([#4271](https://github.com/bobmatnyc/trusty-tools/issues/4271)).
+  `broadcast::Sender::send` answers `Ok` for a receiver that is attached but
+  behind, so publishing into a full 64-deep instance channel overwrote an unread
+  envelope while the DOC-60 §9 durable log wrote `delivery_state: "delivered"`
+  for the one that displaced it — the sender saw `202 Accepted` and the
+  recipient was never told. `PeerBus::publish` now checks the channel before
+  sending and refuses the new message with `SubscriberLagged` (`503`, or
+  `CODE_UNAVAILABLE` over the socket), recording it `dropped`. What the log
+  calls delivered is now exactly what the subscriber receives.
+- `GET /api/v1/bus/subscribe/{instance_id}` reports a lag instead of swallowing
+  it. The handler mapped `Lagged(n)` to `None`, borrowing an idiom from the
+  session SSE handlers that carry load-sheddable telemetry — which DOC-60 §3
+  keeps off this bus. It now emits an `event: lagged` frame carrying the missed
+  count and the durable log's path to re-read from, plus a `warn!`.

--- a/crates/trusty-mpm/changelog.d/4271-bus-delivery-truth.md
+++ b/crates/trusty-mpm/changelog.d/4271-bus-delivery-truth.md
@@ -11,6 +11,16 @@ Fixed
   sending and refuses the new message with `SubscriberLagged` (`503`, or
   `CODE_UNAVAILABLE` over the socket), recording it `dropped`. What the log
   calls delivered is now exactly what the subscriber receives.
+
+  Operationally this trades a silent loss for a visible refusal, and the
+  refusal is per-instance: a subscriber that stops draining makes every publish
+  to its instance answer `503` — healthy co-subscribers included — until it
+  drains, disconnects, or the instance is deregistered. `broadcast` offers no
+  way to evict one subscriber without dropping the channel, and dropping it
+  would discard envelopes the log has already recorded delivered; the
+  per-subscriber buffer that would bound this is DOC-60 §7's durable inbox,
+  deferred. Senders should retry with backoff, and an operator seeing repeated
+  `503`s should look at the recipient, which the `warn!` names.
 - `GET /api/v1/bus/subscribe/{instance_id}` reports a lag instead of swallowing
   it. The handler mapped `Lagged(n)` to `None`, borrowing an idiom from the
   session SSE handlers that carry load-sheddable telemetry — which DOC-60 §3

--- a/crates/trusty-mpm/src/daemon/audit.rs
+++ b/crates/trusty-mpm/src/daemon/audit.rs
@@ -171,17 +171,27 @@ impl AuditLogger {
     }
 
     /// Fallible core of [`log_record`](Self::log_record), separated for testability.
+    ///
+    /// #4271: the record and its newline go out in ONE `write_all` on an
+    /// append-only descriptor. `writeln!` issued them as separate writes — a
+    /// `File` is unbuffered, so `write_fmt` calls through once per fragment —
+    /// and two threads appending at once interleaved into a line no reader
+    /// could parse. Two concurrent bus publishes are an ordinary event, so the
+    /// stream this daemon relies on to answer "sent, or never read?" has to
+    /// survive them.
+    /// Test: `concurrent_publishers_never_evict_a_delivered_envelope`.
     fn try_log<T: Serialize>(&self, entry: &T) -> std::io::Result<()> {
         if let Some(parent) = self.path.parent() {
             std::fs::create_dir_all(parent)?;
         }
-        let line = serde_json::to_string(entry)
+        let mut line = serde_json::to_string(entry)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+        line.push('\n');
         let mut file = OpenOptions::new()
             .create(true)
             .append(true)
             .open(&self.path)?;
-        writeln!(file, "{line}")
+        file.write_all(line.as_bytes())
     }
 }
 

--- a/crates/trusty-mpm/src/daemon/bus/error.rs
+++ b/crates/trusty-mpm/src/daemon/bus/error.rs
@@ -16,18 +16,22 @@ use axum::response::{IntoResponse, Response};
 use thiserror::Error;
 use trusty_common::uds::server::{CODE_INTERNAL_ERROR, CODE_INVALID_PARAMS, RpcError};
 
-use crate::daemon::error::{CODE_CONFLICT, CODE_FORBIDDEN, CODE_GONE, CODE_NOT_FOUND};
+use crate::daemon::error::{
+    CODE_CONFLICT, CODE_FORBIDDEN, CODE_GONE, CODE_NOT_FOUND, CODE_UNAVAILABLE,
+};
 
 /// A peer-bus publish, addressing, or registration failure.
 ///
-/// Why: the sender must be able to tell *which* of the three distinguishable
-/// bad outcomes it hit — the definition has nothing running, the specific
-/// instance it named is gone, or the instance is registered but has no
-/// attached subscriber — because the correct client reaction differs for each
-/// (start one / re-resolve the definition / retry).
-/// What: five addressing/delivery/registration variants plus two
-/// request-validation ones.
-/// Test: `bus_error_status_codes_map`, `instance_gone_is_410`.
+/// Why: the sender must be able to tell *which* distinguishable bad outcome it
+/// hit — the definition has nothing running, the specific instance it named is
+/// gone, the instance is registered but has no attached subscriber, or it is
+/// attached but too far behind to take another envelope without discarding one
+/// — because the correct client reaction differs for each (start one /
+/// re-resolve the definition / stop sending / retry once it drains).
+/// What: six addressing/delivery/registration variants plus the
+/// sender-verification and request-validation ones.
+/// Test: `bus_error_status_codes_map`, `instance_gone_is_410`,
+/// `subscriber_lagged_is_503`.
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum BusError {
     /// Definition-addressed delivery found no live instance (DOC-60 §5.3).
@@ -71,6 +75,34 @@ pub enum BusError {
     NoSubscriber {
         /// The registered-but-unattached instance id.
         instance_id: String,
+    },
+
+    /// The recipient is attached but its channel is full of unread envelopes.
+    ///
+    /// Why this is an error and not a `delivered` record (#4271): the send
+    /// would have succeeded — `broadcast::Sender::send` answers `Ok` for a
+    /// lagging receiver — while overwriting an envelope the recipient had never
+    /// read. The §9 log would then hold a `delivered` record for a message that
+    /// reached no one, which is the exact "sent, or just never read?" ambiguity
+    /// ADR-0019 and DOC-60 §4 exist to eliminate. Refusing the NEW message
+    /// instead keeps that log truthful: nothing it calls delivered has been
+    /// evicted unread.
+    ///
+    /// Why `503` and not [`BusError::NoSubscriber`]'s `409`: the two need
+    /// different client recoveries. `409` says nobody is listening, and the
+    /// sender's move is to stop sending. This says someone IS listening but is
+    /// behind, and the sender's move is to retry once the recipient drains —
+    /// DOC-60 §4's `BusUnavailable`-shaped answer.
+    #[error(
+        "instance '{instance_id}' has {backlog} unread envelopes queued and \
+         cannot take another without discarding one; the message was NOT \
+         delivered — retry once the recipient drains"
+    )]
+    SubscriberLagged {
+        /// The instance whose channel is saturated.
+        instance_id: String,
+        /// How many envelopes it has queued and unread.
+        backlog: usize,
     },
 
     /// The sender claimed an `instance_id` that is not a live registration.
@@ -160,18 +192,20 @@ impl BusError {
     /// [`BusError::UnregisteredSender`] — the one failure about the caller's
     /// own identity rather than the target's.
     /// What: `403` sender unverified, `404` not-found, `410` gone, `409`
-    /// conflict, `400` bad request. [`BusError::InstanceIdCollision`] joins the
-    /// `409` row (#4276): the request was well-formed and the state of the
-    /// registry is what refused it, which is what `409 Conflict` names — and a
-    /// retry is the correct client reaction, as it is for the other `409`.
+    /// conflict, `503` recipient too far behind to take more, `400` bad
+    /// request. [`BusError::InstanceIdCollision`] joins the `409` row (#4276):
+    /// the request was well-formed and the state of the registry is what
+    /// refused it, which is what `409 Conflict` names — and a retry is the
+    /// correct client reaction, as it is for the other `409`.
     /// Test: `bus_error_status_codes_map`, `instance_gone_is_410`,
-    /// `unregistered_sender_is_403`.
+    /// `unregistered_sender_is_403`, `subscriber_lagged_is_503`.
     pub fn status(&self) -> StatusCode {
         match self {
             Self::UnregisteredSender { .. } => StatusCode::FORBIDDEN,
             Self::NoLiveInstance { .. } => StatusCode::NOT_FOUND,
             Self::InstanceGone { .. } => StatusCode::GONE,
             Self::NoSubscriber { .. } | Self::InstanceIdCollision { .. } => StatusCode::CONFLICT,
+            Self::SubscriberLagged { .. } => StatusCode::SERVICE_UNAVAILABLE,
             Self::InvalidDefinitionId { .. }
             | Self::InvalidTarget(_)
             | Self::InvalidCaller(_)
@@ -189,8 +223,8 @@ impl BusError {
 /// [`BusError::status`] table the HTTP transport reads — a second hand-written
 /// table here would let the two drift, and the drift would be silent.
 /// What: derives the code from the status, so `403` sender-unverified, `404`
-/// no-live-instance, `410` instance-gone, `409` no-subscriber, and `400`
-/// malformed each stay distinguishable. The message crosses verbatim, so it is
+/// no-live-instance, `410` instance-gone, `409` no-subscriber, `503`
+/// subscriber-lagged, and `400` malformed each stay distinguishable. The message crosses verbatim, so it is
 /// the same string the HTTP body's `error` field carries.
 /// Test: `bus_error_rpc_codes_track_http_statuses`.
 impl From<BusError> for RpcError {
@@ -201,6 +235,7 @@ impl From<BusError> for RpcError {
             StatusCode::NOT_FOUND => CODE_NOT_FOUND,
             StatusCode::CONFLICT => CODE_CONFLICT,
             StatusCode::GONE => CODE_GONE,
+            StatusCode::SERVICE_UNAVAILABLE => CODE_UNAVAILABLE,
             // Unreachable while `status` stays total over the variants above;
             // a new variant that forgets a row lands here rather than silently
             // borrowing another failure's code.

--- a/crates/trusty-mpm/src/daemon/bus/error.rs
+++ b/crates/trusty-mpm/src/daemon/bus/error.rs
@@ -88,21 +88,24 @@ pub enum BusError {
     /// instead keeps that log truthful: nothing it calls delivered has been
     /// evicted unread.
     ///
+    /// The backlog is deliberately NOT carried: it can only ever equal
+    /// [`INSTANCE_CHANNEL_CAPACITY`](super::INSTANCE_CHANNEL_CAPACITY), since
+    /// `Sender::len` caps at the ring length and the refusal fires at exactly
+    /// that value — a constant dressed as a measurement tells a client nothing.
+    ///
     /// Why `503` and not [`BusError::NoSubscriber`]'s `409`: the two need
     /// different client recoveries. `409` says nobody is listening, and the
     /// sender's move is to stop sending. This says someone IS listening but is
     /// behind, and the sender's move is to retry once the recipient drains —
     /// DOC-60 §4's `BusUnavailable`-shaped answer.
     #[error(
-        "instance '{instance_id}' has {backlog} unread envelopes queued and \
-         cannot take another without discarding one; the message was NOT \
+        "instance '{instance_id}' cannot take another envelope without \
+         discarding one its subscriber has not read; the message was NOT \
          delivered — retry once the recipient drains"
     )]
     SubscriberLagged {
-        /// The instance whose channel is saturated.
+        /// The instance whose delivery channel is full of unread envelopes.
         instance_id: String,
-        /// How many envelopes it has queued and unread.
-        backlog: usize,
     },
 
     /// The sender claimed an `instance_id` that is not a live registration.

--- a/crates/trusty-mpm/src/daemon/bus/mod.rs
+++ b/crates/trusty-mpm/src/daemon/bus/mod.rs
@@ -13,7 +13,7 @@
 //! resolves both addressing modes, [`error`] is the §4 fail-closed contract,
 //! and [`routes`] is the HTTP surface.
 //! Test: `tests` — the module's suite covers publish, both addressing modes,
-//! the bypass failure mode, and the durable record.
+//! the bypass failure mode, the durable record, and the #4271 lag contract.
 //!
 //! ## Scope: step 1 of DOC-60 §5.3, and what it deliberately excludes
 //!
@@ -56,7 +56,9 @@ pub use envelope::{
     Recipient,
 };
 pub use error::BusError;
-pub use registry::{InstanceMeta, InstanceRegistry, LiveInstance, PeerTarget};
+pub use registry::{
+    INSTANCE_CHANNEL_CAPACITY, InstanceMeta, InstanceRegistry, LiveInstance, PeerTarget,
+};
 
 /// The daemon's peer message bus.
 ///
@@ -183,6 +185,25 @@ impl PeerBus {
     ///    silent drop — DOC-60 §7's durable inbox is what will make that case
     ///    queue instead, and it is deferred.
     ///
+    /// **The delivery guarantee, and the backpressure that buys it (#4271).**
+    /// An envelope this method records as `Delivered` stays readable by every
+    /// attached subscriber until that subscriber reads it. Nothing evicts it.
+    /// The guarantee holds because step 6 asks
+    /// [`LiveInstance::saturated_backlog`] first: when the recipient's channel
+    /// already holds [`INSTANCE_CHANNEL_CAPACITY`] envelopes its slowest
+    /// subscriber has not read, the next send could only be taken by
+    /// overwriting the oldest of them, so the NEW envelope is refused with
+    /// [`BusError::SubscriberLagged`] (503) and recorded `Dropped`.
+    ///
+    /// Before #4271 the send was made anyway. `broadcast::Sender::send` answers
+    /// `Ok` for a lagging receiver, so the log recorded `Delivered` for the
+    /// envelope that displaced an unread one, the sender got `202 Accepted`,
+    /// and the recipient was never told — a `delivered` record for a message
+    /// that reached no one. Refusing the newest message rather than silently
+    /// discarding the oldest keeps the §9 log answerable, which is the whole
+    /// reason DOC-60 §4 forbids a silent drop. A healthy subscriber never
+    /// reaches saturation and is unaffected.
+    ///
     /// **What the durable §9 log does and does not contain.** Once a sender is
     /// verified (step 3), EVERY outcome is recorded — delivered or dropped —
     /// because a log holding only successes cannot answer the question
@@ -199,7 +220,9 @@ impl PeerBus {
     /// Test: `publish_delivers_to_definition_addressed_instance`,
     /// `bypass_publish_stamps_both_ids`, `failed_publish_logs_dropped_envelope`,
     /// `publish_without_subscriber_errors`, `publish_rejects_forged_user_kind`,
-    /// `rejected_publish_writes_no_durable_record`.
+    /// `rejected_publish_writes_no_durable_record`,
+    /// `delivered_records_match_what_a_stalled_subscriber_receives`,
+    /// `saturated_publish_is_dropped_in_the_durable_log`.
     pub fn publish(
         &self,
         from: CallerIdentity,
@@ -250,6 +273,26 @@ impl PeerBus {
             in_reply_to,
             DeliveryState::Delivered,
         );
+
+        // #4271: refuse BEFORE the send when the channel can only take this
+        // envelope by discarding an unread one. `send` would answer `Ok` here —
+        // a lagging receiver is still an attached receiver — and the eviction
+        // is unobservable once it has happened.
+        if let Some(backlog) = live.saturated_backlog() {
+            envelope.delivery_state = DeliveryState::Dropped;
+            self.audit.log_record(&envelope);
+            tracing::warn!(
+                instance_id = %live.meta.instance_id,
+                backlog,
+                message_id = %envelope.message_id,
+                "peer bus refused a publish: the recipient's channel is full of \
+                 unread envelopes (#4271)"
+            );
+            return Err(BusError::SubscriberLagged {
+                instance_id: live.meta.instance_id,
+                backlog,
+            });
+        }
 
         // The durable record is written AFTER the send attempt so it states
         // what actually happened. Logging `Delivered` before knowing whether a

--- a/crates/trusty-mpm/src/daemon/bus/mod.rs
+++ b/crates/trusty-mpm/src/daemon/bus/mod.rs
@@ -213,10 +213,10 @@ impl PeerBus {
     /// is measured across every attached receiver, and `broadcast` cannot send
     /// to a subset, so ONE subscriber that stops draining makes this instance
     /// refuse every publish to it — including on behalf of healthy
-    /// co-subscribers. That wedge clears when the stalled receiver drops
-    /// (a client that exits closes its SSE connection, and `Receiver::drop`
-    /// drains the backlog it never read) or when an operator deregisters the
-    /// instance. Nothing in this daemon puts a timer on it, deliberately: the
+    /// co-subscribers. That wedge clears when the stalled subscriber drains,
+    /// when it drops (a client that exits closes its SSE connection, and
+    /// `Receiver::drop` drains the backlog it never read), or when an operator
+    /// deregisters the instance. Nothing puts a timer on it, deliberately: the
     /// only sender-side lever `broadcast` offers is dropping the channel, which
     /// would discard envelopes this log has already recorded `Delivered` and so
     /// re-create #4271 by another route. A per-subscriber buffer that could

--- a/crates/trusty-mpm/src/daemon/bus/mod.rs
+++ b/crates/trusty-mpm/src/daemon/bus/mod.rs
@@ -57,7 +57,8 @@ pub use envelope::{
 };
 pub use error::BusError;
 pub use registry::{
-    INSTANCE_CHANNEL_CAPACITY, InstanceMeta, InstanceRegistry, LiveInstance, PeerTarget,
+    DeliveryOutcome, INSTANCE_CHANNEL_CAPACITY, InstanceMeta, InstanceRegistry, LiveInstance,
+    PeerTarget,
 };
 
 /// The daemon's peer message bus.
@@ -187,13 +188,17 @@ impl PeerBus {
     ///
     /// **The delivery guarantee, and the backpressure that buys it (#4271).**
     /// An envelope this method records as `Delivered` stays readable by every
-    /// attached subscriber until that subscriber reads it. Nothing evicts it.
-    /// The guarantee holds because step 6 asks
-    /// [`LiveInstance::saturated_backlog`] first: when the recipient's channel
+    /// attached subscriber until that subscriber reads it. No later publish
+    /// through this method evicts it. Step 6 delegates to
+    /// [`LiveInstance::deliver`], which holds the instance's delivery gate
+    /// across both the measurement and the send: when the recipient's channel
     /// already holds [`INSTANCE_CHANNEL_CAPACITY`] envelopes its slowest
     /// subscriber has not read, the next send could only be taken by
     /// overwriting the oldest of them, so the NEW envelope is refused with
-    /// [`BusError::SubscriberLagged`] (503) and recorded `Dropped`.
+    /// [`BusError::SubscriberLagged`] (503) and recorded `Dropped`. The gate is
+    /// what makes the guarantee hold under concurrent publishers rather than
+    /// only under one — see `deliver` for why an unguarded check is stale by
+    /// the time the send runs.
     ///
     /// Before #4271 the send was made anyway. `broadcast::Sender::send` answers
     /// `Ok` for a lagging receiver, so the log recorded `Delivered` for the
@@ -203,6 +208,22 @@ impl PeerBus {
     /// discarding the oldest keeps the §9 log answerable, which is the whole
     /// reason DOC-60 §4 forbids a silent drop. A healthy subscriber never
     /// reaches saturation and is unaffected.
+    ///
+    /// **What the refusal costs, and why nothing here bounds it.** Saturation
+    /// is measured across every attached receiver, and `broadcast` cannot send
+    /// to a subset, so ONE subscriber that stops draining makes this instance
+    /// refuse every publish to it — including on behalf of healthy
+    /// co-subscribers. That wedge clears when the stalled receiver drops
+    /// (a client that exits closes its SSE connection, and `Receiver::drop`
+    /// drains the backlog it never read) or when an operator deregisters the
+    /// instance. Nothing in this daemon puts a timer on it, deliberately: the
+    /// only sender-side lever `broadcast` offers is dropping the channel, which
+    /// would discard envelopes this log has already recorded `Delivered` and so
+    /// re-create #4271 by another route. A per-subscriber buffer that could
+    /// evict one client without touching the others is DOC-60 §7's durable
+    /// inbox, deferred to the owner. Until then the failure is loud — a `warn!`
+    /// and a 503 naming the instance on every refused publish — rather than
+    /// bounded.
     ///
     /// **What the durable §9 log does and does not contain.** Once a sender is
     /// verified (step 3), EVERY outcome is recorded — delivered or dropped —
@@ -222,7 +243,8 @@ impl PeerBus {
     /// `publish_without_subscriber_errors`, `publish_rejects_forged_user_kind`,
     /// `rejected_publish_writes_no_durable_record`,
     /// `delivered_records_match_what_a_stalled_subscriber_receives`,
-    /// `saturated_publish_is_dropped_in_the_durable_log`.
+    /// `saturated_publish_is_dropped_in_the_durable_log`,
+    /// `concurrent_publishers_never_evict_a_delivered_envelope`.
     pub fn publish(
         &self,
         from: CallerIdentity,
@@ -274,39 +296,38 @@ impl PeerBus {
             DeliveryState::Delivered,
         );
 
-        // #4271: refuse BEFORE the send when the channel can only take this
-        // envelope by discarding an unread one. `send` would answer `Ok` here —
-        // a lagging receiver is still an attached receiver — and the eviction
-        // is unobservable once it has happened.
-        if let Some(backlog) = live.saturated_backlog() {
-            envelope.delivery_state = DeliveryState::Dropped;
-            self.audit.log_record(&envelope);
-            tracing::warn!(
-                instance_id = %live.meta.instance_id,
-                backlog,
-                message_id = %envelope.message_id,
-                "peer bus refused a publish: the recipient's channel is full of \
-                 unread envelopes (#4271)"
-            );
-            return Err(BusError::SubscriberLagged {
-                instance_id: live.meta.instance_id,
-                backlog,
-            });
+        // The durable record is written AFTER the delivery attempt so it states
+        // what actually happened. Logging `Delivered` before knowing whether
+        // the channel could take the envelope would put a lie in the one log
+        // that is supposed to settle "sent or not" — #4271 is what that lie
+        // looked like in practice.
+        match live.deliver(envelope.clone()) {
+            DeliveryOutcome::Delivered => {
+                self.audit.log_record(&envelope);
+                Ok(envelope)
+            }
+            DeliveryOutcome::Saturated => {
+                envelope.delivery_state = DeliveryState::Dropped;
+                self.audit.log_record(&envelope);
+                tracing::warn!(
+                    instance_id = %live.meta.instance_id,
+                    capacity = INSTANCE_CHANNEL_CAPACITY,
+                    message_id = %envelope.message_id,
+                    "peer bus refused a publish: the recipient's channel is full \
+                     of unread envelopes (#4271)"
+                );
+                Err(BusError::SubscriberLagged {
+                    instance_id: live.meta.instance_id,
+                })
+            }
+            DeliveryOutcome::NoSubscriber => {
+                envelope.delivery_state = DeliveryState::Dropped;
+                self.audit.log_record(&envelope);
+                Err(BusError::NoSubscriber {
+                    instance_id: live.meta.instance_id,
+                })
+            }
         }
-
-        // The durable record is written AFTER the send attempt so it states
-        // what actually happened. Logging `Delivered` before knowing whether a
-        // subscriber existed would put a lie in the one log that is supposed
-        // to settle "sent or not".
-        if live.tx.send(envelope.clone()).is_err() {
-            envelope.delivery_state = DeliveryState::Dropped;
-            self.audit.log_record(&envelope);
-            return Err(BusError::NoSubscriber {
-                instance_id: live.meta.instance_id,
-            });
-        }
-        self.audit.log_record(&envelope);
-        Ok(envelope)
     }
 }
 

--- a/crates/trusty-mpm/src/daemon/bus/registry.rs
+++ b/crates/trusty-mpm/src/daemon/bus/registry.rs
@@ -67,7 +67,18 @@ use super::envelope::BusEnvelope;
 /// is right for peer messages, which are low-volume by construction —
 /// streaming token deltas stay on the existing per-crate buses and never reach
 /// this one.
-const INSTANCE_CHANNEL_CAPACITY: usize = 64;
+///
+/// Public since #4271: it is the depth at which
+/// [`LiveInstance::saturated_backlog`] refuses a publish, so it is part of the
+/// delivery contract a sender reasons about, not an implementation detail.
+/// Test: `saturated_publish_is_dropped_in_the_durable_log`.
+pub const INSTANCE_CHANNEL_CAPACITY: usize = 64;
+
+// #4271: tokio rounds a broadcast capacity UP to a power of two, so a
+// non-rounded value would give a ring deeper than this constant and
+// `saturated_backlog` would refuse a publish before an eviction was actually
+// imminent. Keeping it already-rounded makes the two exactly equal.
+const _: () = assert!(INSTANCE_CHANNEL_CAPACITY.is_power_of_two());
 
 /// Separator between the definition id and the random suffix in an instance id.
 ///
@@ -156,6 +167,31 @@ pub struct LiveInstance {
     pub meta: InstanceMeta,
     /// Sender half of this instance's own delivery channel.
     pub tx: broadcast::Sender<BusEnvelope>,
+}
+
+impl LiveInstance {
+    /// The unread backlog when one more envelope cannot be taken without loss.
+    ///
+    /// Why (#4271): `broadcast::Sender::send` answers `Ok` for a LAGGING
+    /// receiver — one still attached, whose oldest unread slot the send is
+    /// about to overwrite. A publisher reading only that `Ok` therefore cannot
+    /// tell delivery from eviction, and recorded `delivered` for envelopes the
+    /// recipient never saw. Asking BEFORE the send is the only point at which
+    /// the difference is still observable: afterwards the evicted envelope is
+    /// gone and nothing in the channel remembers it existed.
+    /// What: `Some(backlog)` when the channel holds
+    /// [`INSTANCE_CHANNEL_CAPACITY`] envelopes that some attached receiver has
+    /// not read — the state in which the next send overwrites the oldest of
+    /// them — and `None` otherwise. `broadcast::Sender::len` counts slots no
+    /// attached receiver has consumed, so the answer is driven by the SLOWEST
+    /// subscriber, which is exactly the one at risk; a fast peer draining
+    /// alongside it does not mask the lag.
+    /// Test: `delivered_records_match_what_a_stalled_subscriber_receives`,
+    /// `two_subscribers_one_lagging_account_exactly`.
+    pub fn saturated_backlog(&self) -> Option<usize> {
+        let backlog = self.tx.len();
+        (backlog >= INSTANCE_CHANNEL_CAPACITY).then_some(backlog)
+    }
 }
 
 /// The daemon's registry of live agent instances (DOC-60 §6b).

--- a/crates/trusty-mpm/src/daemon/bus/registry.rs
+++ b/crates/trusty-mpm/src/daemon/bus/registry.rs
@@ -50,8 +50,8 @@
 //! Gone` vs `404 Not Found`), so a client can implement the re-address
 //! recovery without parsing a message string.
 
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 
 use dashmap::DashMap;
 use dashmap::mapref::entry::Entry;
@@ -159,38 +159,95 @@ pub struct InstanceMeta {
 /// recipient; consumers filter client-side after the fact"), so giving each
 /// instance its own channel is what makes this bus genuinely addressed rather
 /// than a sixth unaddressed broadcast.
-/// What: [`InstanceMeta`] plus the sender half of that instance's channel.
-/// Test: `publish_reaches_only_target_instance`.
+/// What: [`InstanceMeta`], the sender half of that instance's channel, and the
+/// gate [`LiveInstance::deliver`] holds to keep its saturation check and its
+/// send indivisible. Every clone of a `LiveInstance` shares that gate, so two
+/// publishers that each resolved the instance separately still serialize.
+/// Test: `publish_reaches_only_target_instance`,
+/// `concurrent_publishers_never_evict_a_delivered_envelope`.
 #[derive(Debug, Clone)]
 pub struct LiveInstance {
     /// The instance's public metadata.
     pub meta: InstanceMeta,
     /// Sender half of this instance's own delivery channel.
     pub tx: broadcast::Sender<BusEnvelope>,
+    /// Serializes [`LiveInstance::deliver`]'s check with the send it guards.
+    delivery_gate: Arc<Mutex<()>>,
+}
+
+/// What one delivery attempt actually did (#4271).
+///
+/// Why: the publisher must write a durable record stating what happened, and
+/// the three outcomes carry different records and different errors. Returning
+/// them as one value keeps the decision with the code that holds the gate —
+/// a caller cannot re-derive "was it saturated?" afterwards, because by then
+/// the answer has changed.
+/// What: the three terminal states of a send into an instance's channel.
+/// Test: `delivered_records_match_what_a_stalled_subscriber_receives`,
+/// `publish_without_subscriber_errors`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeliveryOutcome {
+    /// The envelope is in the channel and no unread envelope was displaced.
+    Delivered,
+    /// The channel is full of envelopes no subscriber has read; nothing sent.
+    Saturated,
+    /// The instance is registered but has no attached receiver.
+    NoSubscriber,
 }
 
 impl LiveInstance {
-    /// The unread backlog when one more envelope cannot be taken without loss.
+    /// Send one envelope, refusing rather than displacing an unread one.
     ///
     /// Why (#4271): `broadcast::Sender::send` answers `Ok` for a LAGGING
     /// receiver — one still attached, whose oldest unread slot the send is
-    /// about to overwrite. A publisher reading only that `Ok` therefore cannot
-    /// tell delivery from eviction, and recorded `delivered` for envelopes the
-    /// recipient never saw. Asking BEFORE the send is the only point at which
-    /// the difference is still observable: afterwards the evicted envelope is
-    /// gone and nothing in the channel remembers it existed.
-    /// What: `Some(backlog)` when the channel holds
-    /// [`INSTANCE_CHANNEL_CAPACITY`] envelopes that some attached receiver has
-    /// not read — the state in which the next send overwrites the oldest of
-    /// them — and `None` otherwise. `broadcast::Sender::len` counts slots no
-    /// attached receiver has consumed, so the answer is driven by the SLOWEST
-    /// subscriber, which is exactly the one at risk; a fast peer draining
-    /// alongside it does not mask the lag.
+    /// about to overwrite. A publisher reading only that `Ok` cannot tell
+    /// delivery from eviction, so it recorded `delivered` for envelopes the
+    /// recipient never saw. The channel must therefore be measured BEFORE the
+    /// send, which is the only point at which the difference is still
+    /// observable: afterwards the evicted envelope is gone and nothing in the
+    /// channel remembers it existed.
+    ///
+    /// Why the gate: `Sender::len` and `Sender::send` each take and release the
+    /// channel's tail lock, so a measurement outside a lock of our own is stale
+    /// by the time the send retakes it. Two publishers that both observed
+    /// `capacity - 1` would both send, and the second would evict — the same
+    /// fail-open narrowed to a window rather than closed. Holding
+    /// `delivery_gate` across both makes the pair indivisible. The cost is
+    /// serializing publishes to ONE instance, which is what
+    /// [`INSTANCE_CHANNEL_CAPACITY`]'s own rationale already assumes: peer
+    /// messages are low-volume by construction, and the guarded section is a
+    /// length read plus a memcpy into a ring — no IO, no await.
+    ///
+    /// The guarantee is scoped to this method: an envelope sent through
+    /// `deliver` never displaces an unread one. A caller that reaches for
+    /// [`LiveInstance::tx`] directly opts out of it, which only the tests do.
+    ///
+    /// What: locks the gate, then reports [`DeliveryOutcome::Saturated`] when
+    /// the channel already holds [`INSTANCE_CHANNEL_CAPACITY`] envelopes some
+    /// attached receiver has not read, [`DeliveryOutcome::NoSubscriber`] when
+    /// nothing is attached, and [`DeliveryOutcome::Delivered`] otherwise.
+    /// `Sender::len` counts slots no attached receiver has consumed, so
+    /// saturation is driven by the SLOWEST subscriber — a fast peer draining
+    /// alongside a stalled one does not mask the lag.
     /// Test: `delivered_records_match_what_a_stalled_subscriber_receives`,
-    /// `two_subscribers_one_lagging_account_exactly`.
-    pub fn saturated_backlog(&self) -> Option<usize> {
-        let backlog = self.tx.len();
-        (backlog >= INSTANCE_CHANNEL_CAPACITY).then_some(backlog)
+    /// `two_subscribers_one_lagging_account_exactly`,
+    /// `concurrent_publishers_never_evict_a_delivered_envelope`.
+    pub fn deliver(&self, envelope: BusEnvelope) -> DeliveryOutcome {
+        // A panic cannot leave shared state inconsistent here — the gate guards
+        // a unit value, and the guarded section neither allocates a lock-owned
+        // invariant nor calls user code — so poisoning is recovered rather than
+        // turned into a publish failure.
+        let _gate = self
+            .delivery_gate
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if self.tx.len() >= INSTANCE_CHANNEL_CAPACITY {
+            return DeliveryOutcome::Saturated;
+        }
+        match self.tx.send(envelope) {
+            Ok(_) => DeliveryOutcome::Delivered,
+            Err(_) => DeliveryOutcome::NoSubscriber,
+        }
     }
 }
 
@@ -306,6 +363,7 @@ impl InstanceRegistry {
                     vacant.insert(LiveInstance {
                         meta: meta.clone(),
                         tx,
+                        delivery_gate: Arc::new(Mutex::new(())),
                     });
                     return Ok(meta);
                 }

--- a/crates/trusty-mpm/src/daemon/bus/registry.rs
+++ b/crates/trusty-mpm/src/daemon/bus/registry.rs
@@ -68,16 +68,16 @@ use super::envelope::BusEnvelope;
 /// streaming token deltas stay on the existing per-crate buses and never reach
 /// this one.
 ///
-/// Public since #4271: it is the depth at which
-/// [`LiveInstance::saturated_backlog`] refuses a publish, so it is part of the
-/// delivery contract a sender reasons about, not an implementation detail.
+/// Public since #4271: it is the depth at which [`LiveInstance::deliver`]
+/// answers [`DeliveryOutcome::Saturated`] instead of sending, so it is part of
+/// the delivery contract a sender reasons about, not an implementation detail.
 /// Test: `saturated_publish_is_dropped_in_the_durable_log`.
 pub const INSTANCE_CHANNEL_CAPACITY: usize = 64;
 
 // #4271: tokio rounds a broadcast capacity UP to a power of two, so a
-// non-rounded value would give a ring deeper than this constant and
-// `saturated_backlog` would refuse a publish before an eviction was actually
-// imminent. Keeping it already-rounded makes the two exactly equal.
+// non-rounded value would give a ring deeper than this constant and `deliver`
+// would refuse a publish before an eviction was actually imminent. Keeping it
+// already-rounded makes the two exactly equal.
 const _: () = assert!(INSTANCE_CHANNEL_CAPACITY.is_power_of_two());
 
 /// Separator between the definition id and the random suffix in an instance id.
@@ -170,7 +170,16 @@ pub struct LiveInstance {
     /// The instance's public metadata.
     pub meta: InstanceMeta,
     /// Sender half of this instance's own delivery channel.
-    pub tx: broadcast::Sender<BusEnvelope>,
+    ///
+    /// Crate-internal since #4271: a send made directly on this opts out of
+    /// [`LiveInstance::deliver`]'s check, and the "no envelope recorded
+    /// `delivered` is ever evicted unread" guarantee is only as good as the
+    /// absence of such a send. Subscribing goes through
+    /// [`PeerBus::subscribe`](super::PeerBus::subscribe); publishing goes
+    /// through [`PeerBus::publish`](super::PeerBus::publish). The bus's own
+    /// tests reach for it to stage a lag the publish path now refuses to
+    /// create.
+    pub(super) tx: broadcast::Sender<BusEnvelope>,
     /// Serializes [`LiveInstance::deliver`]'s check with the send it guards.
     delivery_gate: Arc<Mutex<()>>,
 }

--- a/crates/trusty-mpm/src/daemon/bus/routes.rs
+++ b/crates/trusty-mpm/src/daemon/bus/routes.rs
@@ -33,6 +33,7 @@ use futures::Stream;
 use serde::{Deserialize, Serialize};
 use tokio_stream::StreamExt;
 use tokio_stream::wrappers::BroadcastStream;
+use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
 
 use crate::daemon::error::DaemonError;
 use crate::daemon::state::DaemonState;
@@ -317,6 +318,34 @@ pub fn publish_op(state: &Arc<DaemonState>, req: PublishRequest) -> Result<BusEn
         .publish(req.from, &target, req.payload, req.in_reply_to)
 }
 
+/// The SSE event name a lag notice arrives under (#4271).
+///
+/// Why its own name rather than another default `message` frame: a client
+/// deserializing every frame as a [`BusEnvelope`] must not have to guess. A
+/// named event is ignored by a client that does not know it, and dispatched by
+/// one that does.
+/// Test: `subscribe_stream_reports_lag_instead_of_swallowing_it`.
+pub const LAGGED_EVENT: &str = "lagged";
+
+/// What a `lagged` SSE frame carries.
+///
+/// Why: a subscriber that fell behind needs three things to recover — that it
+/// happened, how many envelopes it missed, and where to read them. The durable
+/// §9 JSONL stream holds every envelope the bus recorded as delivered, so
+/// naming its path makes the recovery a file read rather than a lost message.
+/// What: the instance whose stream lagged, the count the channel reports, and
+/// the durable log's resolved path.
+/// Test: `subscribe_stream_reports_lag_instead_of_swallowing_it`.
+#[derive(Debug, Serialize)]
+pub struct LagNotice {
+    /// The instance whose subscription fell behind.
+    pub instance_id: String,
+    /// How many envelopes the channel dropped for this subscriber.
+    pub missed: u64,
+    /// Path to the DOC-60 §9 durable stream to re-read them from.
+    pub durable_log: String,
+}
+
 /// `GET /api/v1/bus/subscribe/{instance_id}` — an instance's inbound stream.
 ///
 /// Why: delivery is per-instance, so a subscriber attaches to one instance's
@@ -324,18 +353,65 @@ pub fn publish_op(state: &Arc<DaemonState>, req: PublishRequest) -> Result<BusEn
 /// identifies in the existing `/sessions/{id}/events` path.
 /// What: SSE of [`BusEnvelope`] JSON; `410 Gone` when the instance is not
 /// registered, so a client cannot sit on a stream that will never produce.
+///
+/// **Lag is reported, never swallowed (#4271).** This handler used to map
+/// `Lagged(n)` to `None`, borrowing the session SSE handlers' idiom — but those
+/// streams carry load-sheddable telemetry, which DOC-60 §3 keeps OFF this bus.
+/// Here the skipped frames were addressed messages the durable log had already
+/// recorded as delivered, so the recipient lost them and was told nothing. A
+/// lag now arrives as a [`LAGGED_EVENT`] frame carrying a [`LagNotice`], plus a
+/// `warn!`. [`PeerBus::publish`](crate::daemon::bus::PeerBus::publish) refuses a
+/// saturated channel, so a lag reaching here means concurrent publishes raced
+/// past that check — rare, and exactly the case worth announcing.
 /// Test: `subscribe_to_dead_instance_errors`,
-/// `publish_reaches_only_target_instance`.
+/// `publish_reaches_only_target_instance`,
+/// `subscribe_stream_reports_lag_instead_of_swallowing_it`.
 pub async fn subscribe_instance(
     State(state): State<Arc<DaemonState>>,
     Path(instance_id): Path<String>,
 ) -> Result<Sse<impl Stream<Item = Result<Event, Infallible>>>, BusError> {
     let rx = state.bus().subscribe(&instance_id)?;
-    let stream = BroadcastStream::new(rx).filter_map(|msg| match msg {
-        Ok(envelope) => Event::default().json_data(envelope).ok().map(Ok),
-        // A lagged subscriber missed envelopes; skip rather than tear the
-        // stream down, matching the existing session SSE handlers.
-        Err(_) => None,
+    let durable_log = state.bus().log_path().display().to_string();
+    let stream = BroadcastStream::new(rx).filter_map(move |msg| match msg {
+        Ok(envelope) => match Event::default().json_data(&envelope) {
+            Ok(event) => Some(Ok(event)),
+            Err(e) => {
+                tracing::error!(
+                    message_id = %envelope.message_id,
+                    error = %e,
+                    "peer bus envelope could not be serialized onto the SSE stream"
+                );
+                None
+            }
+        },
+        Err(BroadcastStreamRecvError::Lagged(missed)) => {
+            tracing::warn!(
+                instance_id = %instance_id,
+                missed,
+                "peer bus subscriber lagged; envelopes were evicted unread (#4271)"
+            );
+            Some(Ok(lag_frame(&instance_id, missed, &durable_log)))
+        }
     });
     Ok(Sse::new(stream).keep_alive(KeepAlive::default()))
+}
+
+/// Build the [`LAGGED_EVENT`] frame, keeping the count reachable either way.
+///
+/// Why the fallback: serializing three owned scalars cannot fail, but mapping a
+/// hypothetical failure to `None` would reinstate the silent skip this whole
+/// change removes. The plain-text form still carries the number that matters.
+/// Test: `subscribe_stream_reports_lag_instead_of_swallowing_it`.
+fn lag_frame(instance_id: &str, missed: u64, durable_log: &str) -> Event {
+    let notice = LagNotice {
+        instance_id: instance_id.to_string(),
+        missed,
+        durable_log: durable_log.to_string(),
+    };
+    match Event::default().event(LAGGED_EVENT).json_data(&notice) {
+        Ok(event) => event,
+        Err(_) => Event::default()
+            .event(LAGGED_EVENT)
+            .data(missed.to_string()),
+    }
 }

--- a/crates/trusty-mpm/src/daemon/bus/routes.rs
+++ b/crates/trusty-mpm/src/daemon/bus/routes.rs
@@ -269,7 +269,19 @@ pub fn list_op(state: &Arc<DaemonState>) -> ListInstancesResponse {
 /// status (`400` malformed request or a caller kind this path does not carry,
 /// `403` the claimed sender is not a live registration, `404` no live
 /// instance, `410` the named instance is gone, `409` registered but
-/// unattached) per §4's fail-closed rule.
+/// unattached, `503` attached but its channel is full of unread envelopes) per
+/// §4's fail-closed rule.
+///
+/// **`503` is terminal for this attempt, and a retry is the recovery (#4271).**
+/// The message was not delivered and not queued — DOC-60 §7's durable inbox is
+/// deferred — so a sender that wants it delivered must send it again once the
+/// recipient drains. Two consequences a client author has to plan for: the
+/// refusal is per-INSTANCE and one stalled subscriber makes every publish to
+/// that instance answer `503`, healthy co-subscribers included; and the
+/// condition persists until that subscriber drains, drops, or the instance is
+/// deregistered, so retry with backoff rather than in a tight loop. See
+/// [`PeerBus::publish`](crate::daemon::bus::PeerBus::publish) for why nothing
+/// bounds it here.
 /// What: resolves the target, publishes, and returns the stamped envelope with
 /// `202 Accepted` so the sender holds the `message_id` for threading. The
 /// `from` field is a CLAIM: [`PeerBus::publish`](crate::daemon::bus::PeerBus::publish)
@@ -302,7 +314,9 @@ pub async fn publish_message(
 ///
 /// # Errors
 ///
-/// Every [`BusError`] `PeerBus::publish` can raise, plus
+/// Every [`BusError`] `PeerBus::publish` can raise — including
+/// [`BusError::SubscriberLagged`] (`503` / `CODE_UNAVAILABLE`) when the
+/// recipient's channel is full of unread envelopes — plus
 /// [`BusError::InvalidTarget`] when the request names neither addressing mode.
 ///
 /// Test: `parity_bus_publish_agrees_across_transports`,
@@ -310,7 +324,8 @@ pub async fn publish_message(
 /// `rpc_bus_publish_rejects_an_unregistered_sender`,
 /// `rpc_bus_publish_to_a_dead_instance_is_gone`,
 /// `rpc_bus_publish_without_a_subscriber_is_conflict`,
-/// `rpc_bus_publish_without_a_target_is_invalid`.
+/// `rpc_bus_publish_without_a_target_is_invalid`,
+/// `route_publish_to_a_saturated_instance_is_503`.
 pub fn publish_op(state: &Arc<DaemonState>, req: PublishRequest) -> Result<BusEnvelope, BusError> {
     let target = req.to.to_peer_target()?;
     state

--- a/crates/trusty-mpm/src/daemon/bus/tests.rs
+++ b/crates/trusty-mpm/src/daemon/bus/tests.rs
@@ -13,8 +13,11 @@ use std::sync::Arc;
 
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use tokio::sync::broadcast;
 use tower::ServiceExt;
 
+use super::routes::LAGGED_EVENT;
 use super::*;
 use crate::daemon::api::router;
 use crate::daemon::state::DaemonState;
@@ -714,6 +717,208 @@ fn no_subscriber_is_logged_as_dropped_not_delivered() {
     assert_eq!(log[0].delivery_state, DeliveryState::Dropped);
 }
 
+// ── subscriber lag (#4271) ────────────────────────────────────────────────────
+
+/// Drain every envelope a receiver can still produce, plus how much it lagged.
+///
+/// Why: the two lag tests below both need "what did this subscriber ACTUALLY
+/// end up holding", and a `try_recv` loop that stops at the first `Lagged` would
+/// answer the wrong question — `Lagged` is not the end of the stream, it is a
+/// gap in the middle of one.
+fn drain(rx: &mut broadcast::Receiver<BusEnvelope>) -> (Vec<String>, u64) {
+    let mut ids = Vec::new();
+    let mut missed = 0;
+    loop {
+        match rx.try_recv() {
+            Ok(envelope) => ids.push(envelope.message_id),
+            Err(broadcast::error::TryRecvError::Lagged(n)) => missed += n,
+            Err(_) => return (ids, missed),
+        }
+    }
+}
+
+/// Every `message_id` the durable log calls delivered, in write order.
+fn delivered_ids(bus: &PeerBus) -> Vec<String> {
+    read_log(bus)
+        .into_iter()
+        .filter(|e| e.delivery_state == DeliveryState::Delivered)
+        .map(|e| e.message_id)
+        .collect()
+}
+
+/// Publish `count` envelopes at one instance, ignoring refusals.
+fn burst(bus: &PeerBus, sender: &CallerIdentity, instance_id: &str, count: usize) {
+    for i in 0..count {
+        // A refused publish's own record is asserted by
+        // `saturated_publish_is_dropped_in_the_durable_log`; the callers here
+        // care only about what the log and the subscriber end up agreeing on.
+        let _ = bus.publish(
+            sender.clone(),
+            &PeerTarget::Instance(instance_id.to_string()),
+            chat(&format!("burst {i}")),
+            None,
+        );
+    }
+}
+
+#[test]
+fn delivered_records_match_what_a_stalled_subscriber_receives() {
+    // #4271, the defect itself: `broadcast::Sender::send` answers Ok for a
+    // LAGGING receiver, so a publish into a full ring evicted an envelope the
+    // recipient had never read while the §9 log recorded that envelope as
+    // `delivered`. The sender saw 202, the log said delivered, and the
+    // recipient was never told.
+    //
+    // The invariant asserted here is the whole contract: the envelopes the log
+    // calls delivered are EXACTLY the envelopes the subscriber receives.
+    let (_dir, bus) = bus();
+    let target = bus.registry().register("cto-assistant", None).unwrap();
+    // Attached but stalled — the `cto-assistant~b1` inside a long LLM turn.
+    let mut stalled = bus.subscribe(&target.instance_id).unwrap();
+    let sender = registered_sender(&bus, "izzie");
+
+    burst(
+        &bus,
+        &sender,
+        &target.instance_id,
+        INSTANCE_CHANNEL_CAPACITY + 6,
+    );
+
+    let (received, missed) = drain(&mut stalled);
+    assert_eq!(
+        received,
+        delivered_ids(&bus),
+        "every envelope the durable log records as delivered must actually \
+         reach the subscriber, and no other"
+    );
+    assert_eq!(
+        missed, 0,
+        "a subscriber must not silently lose envelopes the log calls delivered"
+    );
+}
+
+#[test]
+fn saturated_publish_is_dropped_in_the_durable_log() {
+    // The other half of the contract: a refused publish is still RECORDED, as
+    // `dropped`. A log holding only successes cannot answer "was it sent, or
+    // just never read?" (DOC-60 §4).
+    let (_dir, bus) = bus();
+    let target = bus.registry().register("cto-assistant", None).unwrap();
+    let _stalled = bus.subscribe(&target.instance_id).unwrap();
+    let sender = registered_sender(&bus, "izzie");
+    let overflow = 6;
+
+    burst(
+        &bus,
+        &sender,
+        &target.instance_id,
+        INSTANCE_CHANNEL_CAPACITY + overflow,
+    );
+
+    let log = read_log(&bus);
+    assert_eq!(
+        log.len(),
+        INSTANCE_CHANNEL_CAPACITY + overflow,
+        "every publish past sender verification is recorded, delivered or not"
+    );
+    let dropped = log
+        .iter()
+        .filter(|e| e.delivery_state == DeliveryState::Dropped)
+        .count();
+    assert_eq!(
+        dropped, overflow,
+        "the publishes the full channel could not take must be recorded dropped"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn two_subscribers_one_lagging_account_exactly() {
+    // Condition-based, never sleep-based: the drainer parks on the channel's
+    // own waker, and the accounting proceeds the instant the counter reaches
+    // its target. The deadline exists only so a hang reports a failure.
+    const ROUNDS: usize = INSTANCE_CHANNEL_CAPACITY + 36;
+
+    let (_dir, bus) = bus();
+    let bus = Arc::new(bus);
+    let target = bus.registry().register("cto-assistant", None).unwrap();
+    let mut fast = bus.subscribe(&target.instance_id).unwrap();
+    // Registered, attached, and never polled until the accounting at the end —
+    // the lagging peer. It is what holds the ring full.
+    let mut lagging = bus.subscribe(&target.instance_id).unwrap();
+    let sender = registered_sender(&bus, "izzie");
+
+    let seen = Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+    let drainer = tokio::spawn({
+        let seen = Arc::clone(&seen);
+        async move {
+            while let Ok(envelope) = fast.recv().await {
+                seen.lock().unwrap().push(envelope.message_id);
+            }
+        }
+    });
+
+    let publisher = tokio::spawn({
+        let bus = Arc::clone(&bus);
+        let instance_id = target.instance_id.clone();
+        async move {
+            let mut accepted = Vec::new();
+            let mut refused = 0usize;
+            for i in 0..ROUNDS {
+                match bus.publish(
+                    sender.clone(),
+                    &PeerTarget::Instance(instance_id.clone()),
+                    chat(&format!("round {i}")),
+                    None,
+                ) {
+                    Ok(envelope) => accepted.push(envelope.message_id),
+                    Err(_) => refused += 1,
+                }
+            }
+            (accepted, refused)
+        }
+    });
+    let (accepted, refused) = publisher.await.unwrap();
+
+    // A fast peer's progress does not rescue the channel: the ring is gated by
+    // the SLOWEST attached subscriber, so acceptance stops at its depth exactly.
+    assert_eq!(
+        accepted.len(),
+        INSTANCE_CHANNEL_CAPACITY,
+        "the lagging subscriber must gate acceptance at the ring's depth"
+    );
+    assert_eq!(refused, ROUNDS - INSTANCE_CHANNEL_CAPACITY);
+
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+    while seen.lock().unwrap().len() < accepted.len() {
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "the fast subscriber never caught up: {} of {}",
+            seen.lock().unwrap().len(),
+            accepted.len()
+        );
+        tokio::task::yield_now().await;
+    }
+    drainer.abort();
+
+    assert_eq!(
+        *seen.lock().unwrap(),
+        accepted,
+        "the fast subscriber must receive every accepted envelope, in order"
+    );
+    let (late, missed) = drain(&mut lagging);
+    assert_eq!(
+        late, accepted,
+        "the lagging subscriber must still receive every accepted envelope once \
+         it drains — lag delays delivery here, it never discards it"
+    );
+    assert_eq!(missed, 0, "nothing may be evicted unread");
+    assert_eq!(
+        delivered_ids(&bus),
+        accepted,
+        "the durable log's delivered set must equal what both subscribers got"
+    );
+}
+
 // ── caller verification + edge derivation (review findings #2 and #3) ─────────
 
 #[test]
@@ -992,6 +1197,31 @@ fn bus_error_status_codes_map() {
         }
         .status(),
         StatusCode::BAD_REQUEST
+    );
+}
+
+#[test]
+fn subscriber_lagged_is_503() {
+    // #4271: distinct from `NoSubscriber`'s 409 because the recoveries differ —
+    // 409 means stop sending, 503 means retry once the recipient drains.
+    assert_eq!(
+        BusError::SubscriberLagged {
+            instance_id: "izzie~b1".into(),
+            backlog: INSTANCE_CHANNEL_CAPACITY,
+        }
+        .status(),
+        StatusCode::SERVICE_UNAVAILABLE
+    );
+    assert_ne!(
+        BusError::SubscriberLagged {
+            instance_id: "izzie~b1".into(),
+            backlog: INSTANCE_CHANNEL_CAPACITY,
+        }
+        .status(),
+        BusError::NoSubscriber {
+            instance_id: "izzie~b1".into()
+        }
+        .status()
     );
 }
 
@@ -1304,4 +1534,74 @@ async fn route_subscribe_to_dead_instance_is_410() {
     )
     .await;
     assert_eq!(status, StatusCode::GONE);
+}
+
+#[tokio::test]
+async fn subscribe_stream_reports_lag_instead_of_swallowing_it() {
+    // #4271, the SSE half: a lagged subscriber used to be mapped to `None` —
+    // the frames vanished and the recipient was told nothing. It now gets a
+    // named `lagged` frame carrying the count and where to re-read from.
+    //
+    // The lag is induced by sending straight on the instance's channel rather
+    // than through `publish`, because `publish` now refuses a saturated
+    // channel: this arm survives only for a concurrent-publish race, and the
+    // direct send is what reproduces that state deterministically.
+    let (_dir, state) = test_state();
+    let meta = state
+        .bus()
+        .registry()
+        .register("cto-assistant", None)
+        .unwrap();
+    let resp = router(Arc::clone(&state))
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/v1/bus/subscribe/{}", meta.instance_id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let overflow = 36;
+    let live = state
+        .bus()
+        .registry()
+        .resolve_instance(&meta.instance_id)
+        .unwrap();
+    for i in 0..(INSTANCE_CHANNEL_CAPACITY + overflow) {
+        live.tx
+            .send(BusEnvelope::new(
+                BusEdge::AssistantAssistant,
+                peer_caller("izzie~a1", "izzie"),
+                Recipient {
+                    instance_id: Some(meta.instance_id.clone()),
+                    definition_id: Some(meta.definition_id.clone()),
+                },
+                chat(&format!("burst {i}")),
+                None,
+                DeliveryState::Delivered,
+            ))
+            .unwrap();
+    }
+
+    let mut body = resp.into_body();
+    let frame = tokio::time::timeout(std::time::Duration::from_secs(5), body.frame())
+        .await
+        .expect("the lag notice must arrive without waiting on a keep-alive")
+        .expect("the stream must yield a frame")
+        .unwrap();
+    let text = String::from_utf8(frame.into_data().unwrap().to_vec()).unwrap();
+    assert!(
+        text.contains(&format!("event: {LAGGED_EVENT}")),
+        "a lag must arrive under its own event name, got: {text}"
+    );
+    assert!(
+        text.contains(&format!("\"missed\":{overflow}")),
+        "the notice must carry how many envelopes were missed, got: {text}"
+    );
+    assert!(
+        text.contains(state.bus().log_path().to_str().unwrap()),
+        "the notice must name the durable log to re-read from, got: {text}"
+    );
 }

--- a/crates/trusty-mpm/src/daemon/bus/tests.rs
+++ b/crates/trusty-mpm/src/daemon/bus/tests.rs
@@ -919,6 +919,78 @@ async fn two_subscribers_one_lagging_account_exactly() {
     );
 }
 
+#[test]
+fn concurrent_publishers_never_evict_a_delivered_envelope() {
+    // #4271, the concurrent arm: measuring the channel and sending into it are
+    // two separate acquisitions of the broadcast tail lock, so a check made
+    // outside a lock of our own is stale by the time the send runs. Two
+    // publishers that both observed `capacity - 1` would both send, and the
+    // second would evict an unread envelope the first had already recorded
+    // `delivered` — the same fail-open, narrowed to a window.
+    //
+    // Threads rather than tasks, and far more publishes than the ring can hold,
+    // so the interleaving is hit repeatedly within one run.
+    const PUBLISHERS: usize = 8;
+    const PER_PUBLISHER: usize = 32;
+
+    let (_dir, bus) = bus();
+    let bus = Arc::new(bus);
+    let target = bus.registry().register("cto-assistant", None).unwrap();
+    // Attached and never draining: it is what holds the ring full, so every
+    // publisher past the first `INSTANCE_CHANNEL_CAPACITY` races at the edge.
+    let mut stalled = bus.subscribe(&target.instance_id).unwrap();
+
+    let accepted = std::thread::scope(|scope| {
+        let handles: Vec<_> = (0..PUBLISHERS)
+            .map(|p| {
+                let bus = Arc::clone(&bus);
+                let instance_id = target.instance_id.clone();
+                scope.spawn(move || {
+                    let sender = registered_sender(&bus, &format!("izzie{p}"));
+                    let mut mine = Vec::new();
+                    for i in 0..PER_PUBLISHER {
+                        if let Ok(envelope) = bus.publish(
+                            sender.clone(),
+                            &PeerTarget::Instance(instance_id.clone()),
+                            chat(&format!("p{p} n{i}")),
+                            None,
+                        ) {
+                            mine.push(envelope.message_id);
+                        }
+                    }
+                    mine
+                })
+            })
+            .collect();
+        handles
+            .into_iter()
+            .map(|h| h.join().expect("no publisher thread may panic"))
+            .fold(0usize, |n, ids| n + ids.len())
+    });
+
+    // Exact accounting: the ring's depth is the ceiling no interleaving may
+    // exceed. One extra acceptance is one evicted envelope.
+    assert_eq!(
+        accepted, INSTANCE_CHANNEL_CAPACITY,
+        "concurrent publishers must not accept more than the ring can hold"
+    );
+
+    let (received, missed) = drain(&mut stalled);
+    assert_eq!(
+        missed, 0,
+        "no envelope may be evicted unread, however the publishes interleaved"
+    );
+    let mut delivered = delivered_ids(&bus);
+    let mut got = received;
+    delivered.sort();
+    got.sort();
+    assert_eq!(
+        got, delivered,
+        "the log's delivered set must equal what the subscriber received, \
+         whichever order the publishers won the gate in"
+    );
+}
+
 // ── caller verification + edge derivation (review findings #2 and #3) ─────────
 
 #[test]
@@ -1207,7 +1279,6 @@ fn subscriber_lagged_is_503() {
     assert_eq!(
         BusError::SubscriberLagged {
             instance_id: "izzie~b1".into(),
-            backlog: INSTANCE_CHANNEL_CAPACITY,
         }
         .status(),
         StatusCode::SERVICE_UNAVAILABLE
@@ -1215,7 +1286,6 @@ fn subscriber_lagged_is_503() {
     assert_ne!(
         BusError::SubscriberLagged {
             instance_id: "izzie~b1".into(),
-            backlog: INSTANCE_CHANNEL_CAPACITY,
         }
         .status(),
         BusError::NoSubscriber {
@@ -1603,5 +1673,49 @@ async fn subscribe_stream_reports_lag_instead_of_swallowing_it() {
     assert!(
         text.contains(state.bus().log_path().to_str().unwrap()),
         "the notice must name the durable log to re-read from, got: {text}"
+    );
+}
+
+#[tokio::test]
+async fn route_publish_to_a_saturated_instance_is_503() {
+    // #4271: the refusal has to reach a real client, not just `BusError`'s
+    // status table. `subscriber_lagged_is_503` pins the mapping; this pins that
+    // `POST /api/v1/bus/publish` actually answers it.
+    let (_dir, state) = test_state();
+    let target = state
+        .bus()
+        .registry()
+        .register("cto-assistant", None)
+        .unwrap();
+    let sender = state.bus().registry().register("izzie", None).unwrap();
+    // Attached and stalled: the receiver is held and never read.
+    let _stalled = state.bus().subscribe(&target.instance_id).unwrap();
+
+    let body = serde_json::json!({
+        "from": {
+            "kind": "assistant_instance",
+            "instance_id": sender.instance_id,
+            "definition_id": sender.definition_id,
+        },
+        "to": { "instance_id": target.instance_id },
+        "payload": { "type": "chat_text", "text": "burst" }
+    });
+    for _ in 0..INSTANCE_CHANNEL_CAPACITY {
+        let (status, _) = call(&state, post("/api/v1/bus/publish", body.clone())).await;
+        assert_eq!(status, StatusCode::ACCEPTED);
+    }
+
+    let (status, answer) = call(&state, post("/api/v1/bus/publish", body)).await;
+    assert_eq!(
+        status,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "a full recipient channel must refuse over HTTP, not report 202"
+    );
+    assert!(
+        answer["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains(&target.instance_id),
+        "the refusal must name the instance that is behind, got: {answer}"
     );
 }

--- a/crates/trusty-mpm/src/daemon/rpc/registry/tests.rs
+++ b/crates/trusty-mpm/src/daemon/rpc/registry/tests.rs
@@ -1932,6 +1932,13 @@ fn bus_error_rpc_codes_track_http_statuses() {
             CODE_CONFLICT,
         ),
         (
+            BusError::SubscriberLagged {
+                instance_id: "i".into(),
+                backlog: 64,
+            },
+            CODE_UNAVAILABLE,
+        ),
+        (
             BusError::InvalidTarget("neither id".into()),
             CODE_INVALID_PARAMS,
         ),

--- a/crates/trusty-mpm/src/daemon/rpc/registry/tests.rs
+++ b/crates/trusty-mpm/src/daemon/rpc/registry/tests.rs
@@ -1934,7 +1934,6 @@ fn bus_error_rpc_codes_track_http_statuses() {
         (
             BusError::SubscriberLagged {
                 instance_id: "i".into(),
-                backlog: 64,
             },
             CODE_UNAVAILABLE,
         ),


### PR DESCRIPTION
`broadcast::Sender::send` answers `Ok` for a receiver that is attached but behind, so a publish into a full 64-deep instance channel overwrote an unread envelope while the DOC-60 §9 durable log recorded `delivery_state: "delivered"` for the one that displaced it — the sender got `202 Accepted` and the recipient neither saw the message nor learned it was gone. The SSE handler compounded it by mapping `Lagged(n)` to `None`, so the subscriber that lost the frames was not told either.

New contract: an envelope this bus records as `delivered` stays readable until every attached subscriber has read it. `LiveInstance::deliver` holds a per-instance gate across the saturation measurement and the send it guards, and refuses a saturated channel with `SubscriberLagged` (503 / `CODE_UNAVAILABLE`), recording the refused envelope `dropped` — rather than taking the message by discarding an older unread one.

`GET /api/v1/bus/subscribe/{instance_id}` now emits an `event: lagged` frame carrying the missed count and the durable log's path, so a subscriber that loses its place can recover what it missed.

## Review findings (round 1)

1. **HIGH, check/send TOCTOU — closed.** `Sender::len()` and `Sender::send()` each take and release the channel's tail lock, so a measurement outside a lock of our own was stale by the time the send ran. `LiveInstance` now carries a `delivery_gate` held across both, shared by every clone, so two publishers that resolved the instance separately still serialize. The guarded section is a length read and a memcpy into a ring — no IO, no await — which is what `INSTANCE_CHANNEL_CAPACITY`'s own low-volume rationale already assumes.
2. **HIGH, availability inversion — documented, not bounded. This is the one decision for the owner.** One subscriber that stops draining makes its instance refuse every publish, healthy co-subscribers included. It clears when that receiver drops (a client that exits closes its SSE connection, and `Receiver::drop` drains the backlog it never read) or when an operator deregisters the instance. No daemon-side timer is added, deliberately: `broadcast` offers no per-receiver eviction, and the only sender-side lever — dropping the channel — would discard envelopes the log has already recorded `delivered`, re-creating #4271 by another route. The per-subscriber buffer that would let one client be evicted without touching the others is DOC-60 §7's durable inbox, explicitly deferred to the owner. The trade-off is stated in `PeerBus::publish`'s doc and in `publish_message`'s status contract; until §7 lands the failure is loud (a `warn!` and a 503 naming the instance on every refusal) rather than bounded.
3. **MEDIUM, endpoint contract — fixed.** `publish_message` enumerates the `503` with its retry semantics and its per-instance availability consequence; `publish_op`'s `# Errors` names `SubscriberLagged`.
4. **MEDIUM, no transport-level coverage — fixed.** `route_publish_to_a_saturated_instance_is_503` fills the channel through a stalled subscriber over HTTP and asserts the refusal.
5. **LOW, constant `backlog` — dropped.** It could only ever equal the ring depth.

Found while closing (1): `AuditLogger::try_log` wrote the record and its newline as two unbuffered writes, so two concurrent publishes interleaved into a line no reader could parse — the new concurrency test hit it immediately. Both now go out in one `write_all`.

## Test ladder

Rung 5 (persistence + cross-component contract), re-run in full on the rebased tree (merge-base `7c0df4075`, after #6457's collision-retry rebase; the conflict in `bus/error.rs` was three doc/match hunks and resolved by combining both sides).

- `cargo fmt --check` — `EXIT=0`
- `cargo check -p trusty-mpm --all-targets` — `EXIT=0`
- `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — `EXIT=0`
- `cargo test -p trusty-mpm --no-fail-fast` — `EXIT=0`; lib `test result: ok. 5542 passed; 0 failed; 7 ignored`, 54 targets all `ok`, none failed
- `check_test_pointers.sh` (27902 citations, 0 dangling), `check_line_cap.sh` (0 violations), `check_sld.sh` (0 errors), `CHANGELOG_BASE=origin/main check_changelog_fragment.sh` — all pass

### The concurrent interleaving, demonstrated

With the gate removed from `deliver` (check-then-send, the shape review flagged), looping `concurrent_publishers_never_evict_a_delivered_envelope`:

```
=== failed on attempt 53 ===
assertion `left == right` failed: concurrent publishers must not accept more than the ring can hold
  left: 65
 right: 64
```

65 acceptances against a 64-deep ring is one envelope recorded `Delivered` that displaced an unread one. Ungated: 1 failure in 40 runs, then 1 in 53 — the window is narrow, which is why it survived round 1. With the gate restored: 0 failures in 40 runs.

The three round-1 tests each failed against the unfixed source (evidence unchanged from the previous body): the log listed 70 `delivered` ids against 64 received; `dropped` count `left: 0, right: 6`; accepted publishes `left: 100, right: 64`.

Refs #4271

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
