### PR TITLE
feat(trusty-mpm): DOC-60 §7 durable per-client inbox (Refs #6462)

### DIFF
--- a/crates/trusty-mpm/changelog.d/6462-durable-inbox.md
+++ b/crates/trusty-mpm/changelog.d/6462-durable-inbox.md
@@ -1,0 +1,32 @@
+Changed
+
+- The peer bus's delivery boundary moved from the instance to the client
+  ([#6462](https://github.com/bobmatnyc/trusty-tools/issues/6462), DOC-60 §7).
+  Every subscriber of one instance used to share a single 64-slot broadcast
+  ring, which is why #4271's fix had to refuse the publish to stay truthful: one
+  client that stopped reading made `POST /api/v1/bus/publish` (and
+  `mpm.bus.publish`) answer `503` for every publisher and every healthy
+  co-subscriber, until that client drained, disconnected, or the instance was
+  deregistered. **That instance-wide wedge is gone.** Each subscription now has
+  its own 64-envelope inbox, so a stalled client falls behind alone: publishes
+  are accepted, co-subscribers keep receiving, and the stalled client's own
+  inbox displaces its oldest unread envelope to make room.
+- `BusError::SubscriberLagged` and the `503` / `CODE_UNAVAILABLE` answer are
+  retired from the publish path — a slow subscriber is no longer a publish
+  failure, so there is nothing for a sender to retry. The `400` / `403` / `404`
+  / `409` / `410` statuses are unchanged.
+- Every eviction is recorded. The DOC-60 §9 durable stream now carries a second
+  record shape alongside the envelope records — `{"record":"inbox_eviction",…}`,
+  naming the displaced `message_id`, the `instance_id`, the `subscription_id`
+  that lost it, and that subscription's running loss count. Readers of
+  `logs/bus/*.jsonl` must tolerate it: an envelope line has no `record` key, an
+  eviction line always does. Nothing recorded `delivered` is lost without a
+  matching eviction record.
+- `GET /api/v1/bus/subscribe/{instance_id}`'s `event: lagged` frame now also
+  carries `subscription_id`, which is the key to find that client's eviction
+  records in the durable log. Recovery is unchanged: re-read the log named in
+  the frame from your last known `message_id`.
+- A dropped subscription detaches itself, so a client that disconnects stops
+  being fanned out to and stops holding envelopes nobody will read. A client
+  that never polls costs its instance one bounded buffer and nothing else, which
+  is what bounds the wedge without a daemon-side timer.

--- a/crates/trusty-mpm/changelog.d/6462-durable-inbox.md
+++ b/crates/trusty-mpm/changelog.d/6462-durable-inbox.md
@@ -19,14 +19,19 @@ Changed
 - Every loss is recorded. The DOC-60 §9 durable stream now carries a second
   record shape alongside the envelope records — `{"record":"inbox_miss",…}`,
   naming the lost `message_id`, the `instance_id`, the `subscription_id` that
-  lost it, a `reason` (`displaced` when a full inbox dropped its oldest,
-  `subscription_closed` when a deregistration raced an in-flight publish), and
-  that subscription's running loss count. Readers of `logs/bus/*.jsonl` must
-  tolerate it: an envelope line has no `record` key, a miss line always does.
-  Nothing recorded `delivered` is lost without a matching miss record.
+  lost it, and that subscription's running loss count. Readers of
+  `logs/bus/*.jsonl` must tolerate it: an envelope line has no `record` key, a
+  miss line always does. Nothing recorded `delivered` is lost without a matching
+  miss record.
 - A publish that no inbox accepted is recorded `dropped` and answered `409`,
   never `delivered`. This is reachable when a deregistration closes every
   subscription while a publisher is mid-flight.
+- A subscription that attaches after its instance was deregistered ends
+  immediately instead of hanging. `subscribe` resolves the instance and then
+  attaches, so an attach could land after the deregistration had already closed
+  every inbox present — leaving one that nothing would ever close, whose SSE
+  stream stayed open on keep-alives forever. An instance's inbox set is now
+  terminal once closed, under the same lock the attach takes.
 - When a miss record cannot be written — the durable sink is failing, and §9's
   logger swallows that by design — the delivery's own record carries
   `losses_unrecorded: true` and an `error!` is emitted, so no line claims a

--- a/crates/trusty-mpm/changelog.d/6462-durable-inbox.md
+++ b/crates/trusty-mpm/changelog.d/6462-durable-inbox.md
@@ -14,19 +14,32 @@ Changed
 - `BusError::SubscriberLagged` and the `503` / `CODE_UNAVAILABLE` answer are
   retired from the publish path — a slow subscriber is no longer a publish
   failure, so there is nothing for a sender to retry. The `400` / `403` / `404`
-  / `409` / `410` statuses are unchanged.
-- Every eviction is recorded. The DOC-60 §9 durable stream now carries a second
-  record shape alongside the envelope records — `{"record":"inbox_eviction",…}`,
-  naming the displaced `message_id`, the `instance_id`, the `subscription_id`
-  that lost it, and that subscription's running loss count. Readers of
-  `logs/bus/*.jsonl` must tolerate it: an envelope line has no `record` key, an
-  eviction line always does. Nothing recorded `delivered` is lost without a
-  matching eviction record.
+  / `409` / `410` statuses are unchanged, and `BusError` is now
+  `#[non_exhaustive]`.
+- Every loss is recorded. The DOC-60 §9 durable stream now carries a second
+  record shape alongside the envelope records — `{"record":"inbox_miss",…}`,
+  naming the lost `message_id`, the `instance_id`, the `subscription_id` that
+  lost it, a `reason` (`displaced` when a full inbox dropped its oldest,
+  `subscription_closed` when a deregistration raced an in-flight publish), and
+  that subscription's running loss count. Readers of `logs/bus/*.jsonl` must
+  tolerate it: an envelope line has no `record` key, a miss line always does.
+  Nothing recorded `delivered` is lost without a matching miss record.
+- A publish that no inbox accepted is recorded `dropped` and answered `409`,
+  never `delivered`. This is reachable when a deregistration closes every
+  subscription while a publisher is mid-flight.
+- When a miss record cannot be written — the durable sink is failing, and §9's
+  logger swallows that by design — the delivery's own record carries
+  `losses_unrecorded: true` and an `error!` is emitted, so no line claims a
+  clean delivery the stream cannot back. The field is absent in every other
+  case, so an ordinary record is byte-identical to what it was.
 - `GET /api/v1/bus/subscribe/{instance_id}`'s `event: lagged` frame now also
-  carries `subscription_id`, which is the key to find that client's eviction
+  carries `subscription_id`, which is the key to find that client's miss
   records in the durable log. Recovery is unchanged: re-read the log named in
   the frame from your last known `message_id`.
 - A dropped subscription detaches itself, so a client that disconnects stops
   being fanned out to and stops holding envelopes nobody will read. A client
-  that never polls costs its instance one bounded buffer and nothing else, which
-  is what bounds the wedge without a daemon-side timer.
+  that stays attached and never reads — a TCP-wedged SSE body, where the
+  subscription is never dropped — costs its instance a bounded buffer plus one
+  miss record and one `warn!` per subsequent publish, for as long as it stays
+  attached. No publisher or co-subscriber pays for it; the operator's lever is
+  deregistering the instance, and the `warn!` names which one.

--- a/crates/trusty-mpm/src/daemon/audit.rs
+++ b/crates/trusty-mpm/src/daemon/audit.rs
@@ -170,6 +170,23 @@ impl AuditLogger {
         }
     }
 
+    /// [`log_record`](Self::log_record), but the caller sees the IO failure.
+    ///
+    /// Why (#6462): the peer bus's "nothing is lost without a record"
+    /// guarantee rests on a loss record reaching this stream. `log_record`
+    /// swallows an IO error by §9's deliberate never-fail-the-hot-path
+    /// discipline, which is right for a record whose absence costs only
+    /// observability — and wrong for one whose absence would leave a later
+    /// `delivered` record claiming more than the stream can back. A caller
+    /// that must not over-claim needs to know the write did not land.
+    /// What: exactly [`log_record`](Self::log_record)'s write, with the
+    /// `Result` returned instead of logged. The hot path is still the caller's
+    /// to protect — this returns an error, it does not propagate one for you.
+    /// Test: `bus::tests` — `an_unwritable_log_never_reports_a_clean_delivery`.
+    pub fn try_log_record<T: Serialize>(&self, record: &T) -> std::io::Result<()> {
+        self.try_log(record)
+    }
+
     /// Fallible core of [`log_record`](Self::log_record), separated for testability.
     ///
     /// #4271: the record and its newline go out in ONE `write_all` on an

--- a/crates/trusty-mpm/src/daemon/audit.rs
+++ b/crates/trusty-mpm/src/daemon/audit.rs
@@ -179,7 +179,9 @@ impl AuditLogger {
     /// could parse. Two concurrent bus publishes are an ordinary event, so the
     /// stream this daemon relies on to answer "sent, or never read?" has to
     /// survive them.
-    /// Test: `concurrent_publishers_never_evict_a_delivered_envelope`.
+    /// Test: `concurrent_publishers_lose_nothing_without_a_record` — it parses
+    /// every line the concurrent publishes produced, so an interleaved one
+    /// fails it before its accounting runs.
     fn try_log<T: Serialize>(&self, entry: &T) -> std::io::Result<()> {
         if let Some(parent) = self.path.parent() {
             std::fs::create_dir_all(parent)?;

--- a/crates/trusty-mpm/src/daemon/bus/error.rs
+++ b/crates/trusty-mpm/src/daemon/bus/error.rs
@@ -36,7 +36,15 @@ use crate::daemon::error::{CODE_CONFLICT, CODE_FORBIDDEN, CODE_GONE, CODE_NOT_FO
 /// What: five addressing/delivery/registration variants plus the
 /// sender-verification and request-validation ones.
 /// Test: `bus_error_status_codes_map`, `instance_gone_is_410`.
+///
+/// `#[non_exhaustive]` since #6462: this change removes a variant from an enum
+/// that is public through `pub mod daemon` -> `pub mod bus`, and the next
+/// delivery failure DOC-60 grows will add one. Marking it now means a
+/// downstream `match` cannot be broken by either, and `preflight-publish.sh`
+/// CHECK 5 has one fewer break to weigh at every future release. In-crate
+/// matches are unaffected, so `status` stays exhaustive.
 #[derive(Debug, Error, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum BusError {
     /// Definition-addressed delivery found no live instance (DOC-60 §5.3).
     ///

--- a/crates/trusty-mpm/src/daemon/bus/error.rs
+++ b/crates/trusty-mpm/src/daemon/bus/error.rs
@@ -16,22 +16,26 @@ use axum::response::{IntoResponse, Response};
 use thiserror::Error;
 use trusty_common::uds::server::{CODE_INTERNAL_ERROR, CODE_INVALID_PARAMS, RpcError};
 
-use crate::daemon::error::{
-    CODE_CONFLICT, CODE_FORBIDDEN, CODE_GONE, CODE_NOT_FOUND, CODE_UNAVAILABLE,
-};
+use crate::daemon::error::{CODE_CONFLICT, CODE_FORBIDDEN, CODE_GONE, CODE_NOT_FOUND};
 
 /// A peer-bus publish, addressing, or registration failure.
 ///
 /// Why: the sender must be able to tell *which* distinguishable bad outcome it
 /// hit — the definition has nothing running, the specific instance it named is
-/// gone, the instance is registered but has no attached subscriber, or it is
-/// attached but too far behind to take another envelope without discarding one
-/// — because the correct client reaction differs for each (start one /
-/// re-resolve the definition / stop sending / retry once it drains).
-/// What: six addressing/delivery/registration variants plus the
+/// gone, or the instance is registered but has no attached subscriber —
+/// because the correct client reaction differs for each (start one /
+/// re-resolve the definition / stop sending).
+///
+/// A slow subscriber is no longer among them (#6462). It was, as
+/// `SubscriberLagged` / `503`, for as long as every subscriber of an instance
+/// shared one ring: refusing the publish was the only way to keep the §9 log
+/// truthful, and it made one stalled client refuse delivery for the whole
+/// instance. Per-client inboxes ([`super::inbox`]) charge that backlog to the
+/// client that caused it, so there is nothing left for the sender to be told
+/// and no status to branch on.
+/// What: five addressing/delivery/registration variants plus the
 /// sender-verification and request-validation ones.
-/// Test: `bus_error_status_codes_map`, `instance_gone_is_410`,
-/// `subscriber_lagged_is_503`.
+/// Test: `bus_error_status_codes_map`, `instance_gone_is_410`.
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum BusError {
     /// Definition-addressed delivery found no live instance (DOC-60 §5.3).
@@ -74,37 +78,6 @@ pub enum BusError {
     )]
     NoSubscriber {
         /// The registered-but-unattached instance id.
-        instance_id: String,
-    },
-
-    /// The recipient is attached but its channel is full of unread envelopes.
-    ///
-    /// Why this is an error and not a `delivered` record (#4271): the send
-    /// would have succeeded — `broadcast::Sender::send` answers `Ok` for a
-    /// lagging receiver — while overwriting an envelope the recipient had never
-    /// read. The §9 log would then hold a `delivered` record for a message that
-    /// reached no one, which is the exact "sent, or just never read?" ambiguity
-    /// ADR-0019 and DOC-60 §4 exist to eliminate. Refusing the NEW message
-    /// instead keeps that log truthful: nothing it calls delivered has been
-    /// evicted unread.
-    ///
-    /// The backlog is deliberately NOT carried: it can only ever equal
-    /// [`INSTANCE_CHANNEL_CAPACITY`](super::INSTANCE_CHANNEL_CAPACITY), since
-    /// `Sender::len` caps at the ring length and the refusal fires at exactly
-    /// that value — a constant dressed as a measurement tells a client nothing.
-    ///
-    /// Why `503` and not [`BusError::NoSubscriber`]'s `409`: the two need
-    /// different client recoveries. `409` says nobody is listening, and the
-    /// sender's move is to stop sending. This says someone IS listening but is
-    /// behind, and the sender's move is to retry once the recipient drains —
-    /// DOC-60 §4's `BusUnavailable`-shaped answer.
-    #[error(
-        "instance '{instance_id}' cannot take another envelope without \
-         discarding one its subscriber has not read; the message was NOT \
-         delivered — retry once the recipient drains"
-    )]
-    SubscriberLagged {
-        /// The instance whose delivery channel is full of unread envelopes.
         instance_id: String,
     },
 
@@ -195,20 +168,20 @@ impl BusError {
     /// [`BusError::UnregisteredSender`] — the one failure about the caller's
     /// own identity rather than the target's.
     /// What: `403` sender unverified, `404` not-found, `410` gone, `409`
-    /// conflict, `503` recipient too far behind to take more, `400` bad
-    /// request. [`BusError::InstanceIdCollision`] joins the `409` row (#4276):
+    /// conflict, `400` bad request. There is no `503` row since #6462 — see
+    /// the enum's own doc for why a slow subscriber stopped being a publish
+    /// failure. [`BusError::InstanceIdCollision`] joins the `409` row (#4276):
     /// the request was well-formed and the state of the registry is what
     /// refused it, which is what `409 Conflict` names — and a retry is the
     /// correct client reaction, as it is for the other `409`.
     /// Test: `bus_error_status_codes_map`, `instance_gone_is_410`,
-    /// `unregistered_sender_is_403`, `subscriber_lagged_is_503`.
+    /// `unregistered_sender_is_403`.
     pub fn status(&self) -> StatusCode {
         match self {
             Self::UnregisteredSender { .. } => StatusCode::FORBIDDEN,
             Self::NoLiveInstance { .. } => StatusCode::NOT_FOUND,
             Self::InstanceGone { .. } => StatusCode::GONE,
             Self::NoSubscriber { .. } | Self::InstanceIdCollision { .. } => StatusCode::CONFLICT,
-            Self::SubscriberLagged { .. } => StatusCode::SERVICE_UNAVAILABLE,
             Self::InvalidDefinitionId { .. }
             | Self::InvalidTarget(_)
             | Self::InvalidCaller(_)
@@ -226,8 +199,8 @@ impl BusError {
 /// [`BusError::status`] table the HTTP transport reads — a second hand-written
 /// table here would let the two drift, and the drift would be silent.
 /// What: derives the code from the status, so `403` sender-unverified, `404`
-/// no-live-instance, `410` instance-gone, `409` no-subscriber, `503`
-/// subscriber-lagged, and `400` malformed each stay distinguishable. The message crosses verbatim, so it is
+/// no-live-instance, `410` instance-gone, `409` no-subscriber, and `400`
+/// malformed each stay distinguishable. The message crosses verbatim, so it is
 /// the same string the HTTP body's `error` field carries.
 /// Test: `bus_error_rpc_codes_track_http_statuses`.
 impl From<BusError> for RpcError {
@@ -238,7 +211,6 @@ impl From<BusError> for RpcError {
             StatusCode::NOT_FOUND => CODE_NOT_FOUND,
             StatusCode::CONFLICT => CODE_CONFLICT,
             StatusCode::GONE => CODE_GONE,
-            StatusCode::SERVICE_UNAVAILABLE => CODE_UNAVAILABLE,
             // Unreachable while `status` stays total over the variants above;
             // a new variant that forgets a row lands here rather than silently
             // borrowing another failure's code.

--- a/crates/trusty-mpm/src/daemon/bus/inbox.rs
+++ b/crates/trusty-mpm/src/daemon/bus/inbox.rs
@@ -34,7 +34,7 @@
 //!    budget.
 //! 2. **The OLDEST unread envelope loses, and the loss is recorded.** #4271's
 //!    defect was never the eviction; it was the lie — the log said `delivered`
-//!    and nobody was told. Every eviction here writes an [`InboxEviction`] to
+//!    and nobody was told. Every eviction here writes an [`InboxMiss`] to
 //!    the §9 stream naming the displaced `message_id` and the subscription that
 //!    lost it, and the reader gets an [`InboxItem::Lagged`] at the point of
 //!    loss. Refusing the NEWEST envelope instead would leave a recovering
@@ -119,32 +119,8 @@ pub enum InboxItem {
     /// One addressed envelope, in publish order.
     Envelope(Box<BusEnvelope>),
     /// This inbox displaced `missed` unread envelopes to make room. Each one
-    /// has an [`InboxEviction`] record in the §9 stream.
+    /// has an [`InboxMiss`] record in the §9 stream.
     Lagged(u64),
-}
-
-/// Why one subscription did not end up holding an envelope.
-///
-/// Why two reasons and not one: they have different operator meanings and
-/// different recoveries. A displacement says the client is behind and should
-/// re-read the log; a closed subscription says its instance was deregistered
-/// out from under an in-flight publish, and there is nothing for that client to
-/// come back to. Collapsing them would put "you are behind" and "you are gone"
-/// under one word.
-/// What: the two ways an inbox can fail to end up holding an envelope.
-/// Test: `eviction_is_recorded_per_client_in_the_durable_log`,
-/// `a_publish_racing_deregistration_records_the_closed_subscriptions_miss`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum MissReason {
-    /// The inbox was full, so its OLDEST unread envelope was displaced to make
-    /// room for this one. The record's `message_id` names the DISPLACED
-    /// envelope, not the one that arrived.
-    Displaced,
-    /// The subscription was closed by a deregistration before this envelope
-    /// reached it, so it took nothing. The record's `message_id` names the
-    /// envelope that arrived.
-    SubscriptionClosed,
 }
 
 /// One envelope one subscription will never read, with its §9 record's facts.
@@ -164,8 +140,6 @@ pub struct MissedEnvelope {
     /// How many envelopes that subscription has lost in total, this one
     /// included.
     pub missed_total: u64,
-    /// Why it was lost.
-    pub reason: MissReason,
     /// The envelope itself — the §9 log records this publish as `delivered`,
     /// and this is what says that record is not the whole truth for this one
     /// client.
@@ -184,7 +158,6 @@ impl MissedEnvelope {
             subscription_id: self.subscription_id,
             message_id: self.envelope.message_id.clone(),
             message_ts: self.envelope.ts.clone(),
-            reason: self.reason,
             missed_total: self.missed_total,
         }
     }
@@ -198,9 +171,17 @@ impl MissedEnvelope {
 /// delivery failure (co-subscribers may well have read it), so it is not a
 /// second `delivery_state` on the envelope; it is a separate fact about one
 /// subscription, and it is recorded as one.
-/// What: the lost `message_id`, the subscription that lost it, why, and that
+/// What: the lost `message_id`, the subscription that lost it, and that
 /// subscription's running loss count — enough to reconstruct exactly what any
 /// one client did and did not see by replaying the stream.
+///
+/// Displacement is the only thing that produces one. A subscription closed by a
+/// deregistration also loses envelopes, but never alongside a client that took
+/// them: [`InboxSet`]'s terminal flag makes a set all-open or all-closed, so a
+/// fan-out into a closed set accepts nothing, and `publish` records THAT
+/// envelope `dropped` — which already says it reached no one. The record is
+/// named for the fact (one client will not read this) rather than the mechanism,
+/// so a second cause would not need a second shape.
 /// Test: `eviction_is_recorded_per_client_in_the_durable_log`,
 /// `miss_records_are_distinguishable_from_envelopes`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -217,8 +198,6 @@ pub struct InboxMiss {
     pub message_id: String,
     /// That envelope's own timestamp, so a replay can seek to it.
     pub message_ts: String,
-    /// Displaced by a full inbox, or lost to a closed subscription.
-    pub reason: MissReason,
     /// How many envelopes this subscription has lost in total.
     pub missed_total: u64,
 }
@@ -304,26 +283,27 @@ impl ClientInbox {
     /// What: [`InboxAccept::Refused`] when the subscription is closed, taking
     /// nothing; [`InboxAccept::Displaced`] when the queue already holds
     /// [`CLIENT_INBOX_CAPACITY`], having popped the front to make room; else
-    /// [`InboxAccept::Took`]. A refusal and a displacement both count toward
-    /// this subscription's loss total and both wake the reader, so a client
-    /// learns of either through [`InboxItem::Lagged`].
+    /// [`InboxAccept::Took`].
+    ///
+    /// Why a refusal touches no counters (#6462 review): a closed subscription
+    /// is one whose instance was deregistered, so the whole set is closed
+    /// ([`SetState`]) and this envelope reaches nobody — `publish` records it
+    /// `dropped`, which already says so. Raising `pending_lag` would be worse
+    /// than useless: [`try_recv`](Self::try_recv) yields lag BEFORE the queue,
+    /// which is right for a displacement (the lost envelope came off the front,
+    /// where the reader is) and wrong for a refusal (the lost envelope is the
+    /// newest) — a client acting on a notice hoisted ahead of envelopes it has
+    /// not read yet would re-read the durable log from the wrong point in its
+    /// own stream.
     /// Test: `eviction_is_recorded_per_client_in_the_durable_log`,
-    /// `a_publish_racing_deregistration_is_not_recorded_delivered`.
+    /// `a_publish_racing_deregistration_is_not_recorded_delivered`,
+    /// `a_closed_subscription_reads_its_queue_without_a_hoisted_lag_notice`.
     fn deliver(&self, envelope: BusEnvelope) -> InboxAccept {
         let mut state = self.state();
         if state.closed {
-            state.evicted_total += 1;
-            state.pending_lag += 1;
-            let miss = MissedEnvelope {
-                instance_id: self.instance_id.clone(),
-                subscription_id: self.subscription_id,
-                missed_total: state.evicted_total,
-                reason: MissReason::SubscriptionClosed,
-                envelope,
-            };
-            drop(state);
-            self.signal.notify_one();
-            return InboxAccept::Refused(Box::new(miss));
+            // No notify: nothing became readable, and `close` already woke the
+            // reader.
+            return InboxAccept::Refused;
         }
         let displaced = if state.queue.len() >= CLIENT_INBOX_CAPACITY {
             let popped = state.queue.pop_front();
@@ -333,7 +313,6 @@ impl ClientInbox {
                 instance_id: self.instance_id.clone(),
                 subscription_id: self.subscription_id,
                 missed_total: state.evicted_total,
-                reason: MissReason::Displaced,
                 envelope: lost,
             })
         } else {
@@ -362,10 +341,13 @@ impl ClientInbox {
 
     /// Take the next item if one is ready, without waiting.
     ///
-    /// Why lag first: the eviction removed envelopes from the FRONT, which is
+    /// Why lag first: a DISPLACEMENT removed envelopes from the FRONT, which is
     /// where the reader is, so the gap belongs before everything still queued.
     /// That is the same ordering `broadcast` gave and what the SSE contract
-    /// (#4271) already documents.
+    /// (#4271) already documents. Only displacements reach `pending_lag` — a
+    /// closed subscription's refusal deliberately does not, because its lost
+    /// envelope is the newest and a notice here would sit in the wrong place.
+    /// See [`deliver`](Self::deliver).
     /// Test: `a_stalled_subscriber_reads_its_lag_before_the_surviving_envelopes`.
     fn try_recv(&self) -> Option<InboxItem> {
         let mut state = self.state();
@@ -393,16 +375,40 @@ impl ClientInbox {
 /// interleave and hand two clients the same two envelopes in opposite orders.
 /// That is the ordering guarantee the retired broadcast ring gave for free and
 /// that `two_subscribers_one_lagging_account_exactly` pins.
-/// What: the attached inboxes plus the subscription-id source. Attach, detach,
-/// and fan-out all take the same lock; a reader takes only its own inbox's.
+/// What: the attached inboxes, the set's own terminal flag, and the
+/// subscription-id source. Attach, detach, close, and fan-out all take the same
+/// lock; a reader takes only its own inbox's.
 /// Test: `two_subscribers_one_lagging_account_exactly`,
-/// `concurrent_publishers_lose_nothing_without_a_record`.
+/// `concurrent_publishers_lose_nothing_without_a_record`,
+/// `a_subscription_attached_after_deregistration_ends_rather_than_parking`.
 #[derive(Debug, Default)]
 pub struct InboxSet {
-    /// Attached inboxes, in attachment order.
-    inboxes: Mutex<Vec<Arc<ClientInbox>>>,
+    /// Everything the fan-out lock guards.
+    state: Mutex<SetState>,
     /// Source of subscription ids, unique within this instance.
     next_subscription: AtomicU64,
+}
+
+/// The fan-out lock's contents.
+///
+/// Why `closed` lives HERE rather than beside the inboxes as a separate atomic
+/// (#6462 review): [`InboxSet::attach`] and [`InboxSet::close_all`] must not
+/// interleave. `close_all` closes the inboxes present when it takes the lock;
+/// an `attach` landing a moment later used to push a fresh OPEN inbox into a
+/// set nothing would ever close again — its instance is already out of the
+/// registry, so no publisher can reach it and no second deregister can fire.
+/// The reader then parked forever and its SSE stream never ended, which the
+/// retired `broadcast` did not do (the last `Sender` dropped and the stream
+/// yielded `None`). Putting the flag under the same guard as the vector makes
+/// the race unrepresentable rather than unlikely.
+/// What: the attached inboxes plus whether this set has been terminated.
+/// Test: `a_subscription_attached_after_deregistration_ends_rather_than_parking`.
+#[derive(Debug, Default)]
+struct SetState {
+    /// Attached inboxes, in attachment order.
+    inboxes: Vec<Arc<ClientInbox>>,
+    /// Set by [`InboxSet::close_all`]; every later attach is born closed.
+    closed: bool,
 }
 
 /// What one fan-out actually did.
@@ -436,9 +442,9 @@ pub enum DeliveryOutcome {
 /// distinction between "took it" and "took nothing" is the one #6462's review
 /// found missing, and an `Option` cannot carry it.
 /// What: took it cleanly, took it by displacing its oldest, or refused it
-/// because the subscription is closed. The payload is boxed because
-/// [`MissedEnvelope`] carries a whole envelope and the common variant carries
-/// nothing.
+/// because the subscription is closed. The displacement payload is boxed
+/// because [`MissedEnvelope`] carries a whole envelope and the other two
+/// variants carry nothing.
 /// Test: `a_publish_racing_deregistration_is_not_recorded_delivered`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum InboxAccept {
@@ -446,30 +452,46 @@ enum InboxAccept {
     Took,
     /// Queued, displacing the oldest unread envelope.
     Displaced(Box<MissedEnvelope>),
-    /// Not queued — the subscription is closed.
-    Refused(Box<MissedEnvelope>),
+    /// Not queued — the subscription is closed. Carries nothing: the whole set
+    /// is closed whenever this happens, so `publish` records the envelope
+    /// `dropped` and no per-client record is owed. See [`ClientInbox::deliver`].
+    Refused,
 }
 
 impl InboxSet {
     /// Recover a poisoned lock rather than fail a publish — see
     /// [`ClientInbox::state`] for why that is safe here.
-    fn inboxes(&self) -> std::sync::MutexGuard<'_, Vec<Arc<ClientInbox>>> {
-        self.inboxes
+    fn locked(&self) -> std::sync::MutexGuard<'_, SetState> {
+        self.state
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 
     /// Attach a new subscription and hand back its reader.
     ///
-    /// Test: `a_detached_subscription_stops_costing_the_instance`.
+    /// Why the terminal flag is read under the SAME guard the push takes: see
+    /// [`SetState`]. An attach that raced [`close_all`](Self::close_all) used
+    /// to produce an inbox nothing would ever close, whose reader parked
+    /// forever.
+    /// What: mints a subscription id, builds its inbox already CLOSED when the
+    /// set has been terminated, and pushes it. A subscription born closed
+    /// drains nothing and ends on its first `recv`, which is what a client
+    /// connecting to an instance that just went away should see.
+    /// Test: `a_detached_subscription_stops_costing_the_instance`,
+    /// `a_subscription_attached_after_deregistration_ends_rather_than_parking`.
     pub(super) fn attach(self: &Arc<Self>, instance_id: &str) -> InboxSubscription {
+        let mut set = self.locked();
         let inbox = Arc::new(ClientInbox {
             subscription_id: self.next_subscription.fetch_add(1, Ordering::SeqCst),
             instance_id: instance_id.to_string(),
-            state: Mutex::new(InboxState::default()),
+            state: Mutex::new(InboxState {
+                closed: set.closed,
+                ..InboxState::default()
+            }),
             signal: Notify::new(),
         });
-        self.inboxes().push(Arc::clone(&inbox));
+        set.inboxes.push(Arc::clone(&inbox));
+        drop(set);
         InboxSubscription {
             set: Arc::clone(self),
             inbox,
@@ -480,7 +502,8 @@ impl InboxSet {
     ///
     /// Test: `a_detached_subscription_stops_costing_the_instance`.
     fn detach(&self, subscription_id: u64) {
-        self.inboxes()
+        self.locked()
+            .inboxes
             .retain(|inbox| inbox.subscription_id != subscription_id);
     }
 
@@ -502,43 +525,52 @@ impl InboxSet {
     /// What: [`DeliveryOutcome::NoSubscriber`] when nothing is attached OR
     /// nothing accepted, so the §9 record for that publish reads `dropped` and
     /// the sender gets `409`. Otherwise [`DeliveryOutcome::Delivered`] carrying
-    /// every miss the fan-out caused — displacements, and any closed
-    /// subscription that missed it — so each is recorded against the client
-    /// that lost it. The envelope is cloned per inbox because each client owns
-    /// its copy from here on.
+    /// every displacement the fan-out caused, so each is recorded against the
+    /// client that lost it. The envelope is cloned per inbox because each client
+    /// owns its copy from here on.
     /// Test: `two_subscribers_one_lagging_account_exactly`,
     /// `concurrent_publishers_lose_nothing_without_a_record`,
-    /// `a_publish_racing_deregistration_is_not_recorded_delivered`,
-    /// `a_publish_racing_deregistration_records_the_closed_subscriptions_miss`.
+    /// `a_publish_racing_deregistration_is_not_recorded_delivered`.
     pub(super) fn fan_out(&self, envelope: BusEnvelope) -> DeliveryOutcome {
-        let inboxes = self.inboxes();
+        let set = self.locked();
         let mut accepted = 0usize;
         let mut missed = Vec::new();
-        for inbox in inboxes.iter() {
+        for inbox in set.inboxes.iter() {
             match inbox.deliver(envelope.clone()) {
                 InboxAccept::Took => accepted += 1,
                 InboxAccept::Displaced(miss) => {
                     accepted += 1;
                     missed.push(*miss);
                 }
-                InboxAccept::Refused(miss) => missed.push(*miss),
+                InboxAccept::Refused => {}
             }
         }
         if accepted == 0 {
             // Nothing holds it, so nothing may say it was delivered. The
             // envelope's own `dropped` record already states that it reached
             // no one; a per-client miss record on top would double-count the
-            // same loss.
+            // same loss. Every refusal lands here, because a set is all-open or
+            // all-closed — see `SetState`.
             return DeliveryOutcome::NoSubscriber;
         }
         DeliveryOutcome::Delivered { missed }
     }
 
-    /// End every attached subscription once it has drained.
+    /// End every attached subscription once it has drained, and every later
+    /// one on arrival.
     ///
-    /// Test: `deregister_ends_a_subscription_after_it_drains`.
+    /// Why the flag as well as the loop: an [`attach`](Self::attach) racing
+    /// this loop would otherwise land an inbox nobody closes. Both take this
+    /// one lock, so whichever runs second sees the other's effect.
+    /// What: marks the set terminal, then closes each attached inbox. Neither
+    /// step discards a queued envelope — a reader drains what it holds and only
+    /// then ends.
+    /// Test: `deregister_ends_a_subscription_after_it_drains`,
+    /// `a_subscription_attached_after_deregistration_ends_rather_than_parking`.
     pub(super) fn close_all(&self) {
-        for inbox in self.inboxes().iter() {
+        let mut set = self.locked();
+        set.closed = true;
+        for inbox in set.inboxes.iter() {
             inbox.close();
         }
     }
@@ -547,14 +579,14 @@ impl InboxSet {
     ///
     /// Test: `a_detached_subscription_stops_costing_the_instance`.
     pub fn len(&self) -> usize {
-        self.inboxes().len()
+        self.locked().inboxes.len()
     }
 
     /// Whether nothing is subscribed.
     ///
     /// Test: `a_detached_subscription_stops_costing_the_instance`.
     pub fn is_empty(&self) -> bool {
-        self.inboxes().is_empty()
+        self.locked().inboxes.is_empty()
     }
 }
 
@@ -579,7 +611,7 @@ pub struct InboxSubscription {
 }
 
 impl InboxSubscription {
-    /// This subscription's id — the key its [`InboxEviction`] records carry.
+    /// This subscription's id — the key its [`InboxMiss`] records carry.
     ///
     /// Test: `a_stalled_subscriber_reads_its_lag_before_the_surviving_envelopes`.
     pub fn subscription_id(&self) -> u64 {

--- a/crates/trusty-mpm/src/daemon/bus/inbox.rs
+++ b/crates/trusty-mpm/src/daemon/bus/inbox.rs
@@ -8,12 +8,13 @@
 //! included, for as long as it stayed attached. Owner ruling on #6462: bound
 //! that. Giving each subscription its own buffer moves the delivery boundary
 //! from the instance to the client, so a stalled client's backlog is its own
-//! problem and costs the instance a fixed [`CLIENT_INBOX_CAPACITY`] envelopes
-//! of memory rather than its availability.
+//! problem and costs the instance memory rather than its availability. What it
+//! costs exactly is stated below — bounded in the availability sense that
+//! matters, but neither zero nor always self-limiting.
 //! What: [`ClientInbox`], one bounded queue per subscription; [`InboxSet`],
 //! the per-instance fan-out that owns them; [`InboxSubscription`], the reader
-//! handle that detaches on drop; and [`InboxEviction`], the §9 record that
-//! keeps an eviction from becoming a silent loss.
+//! handle that detaches on drop; and [`InboxMiss`], the §9 record that keeps a
+//! loss from being a silent one.
 //! Test: `bus::tests` — `a_wedged_client_does_not_refuse_publishes_for_a_healthy_co_subscriber`,
 //! `eviction_is_recorded_per_client_in_the_durable_log`,
 //! `concurrent_publishers_lose_nothing_without_a_record`,
@@ -43,8 +44,34 @@
 //! Recovery is unchanged from #6461 and is what makes eviction survivable: the
 //! §9 JSONL stream holds every envelope, so a client that sees a `lagged` frame
 //! re-reads the log from its last known `message_id`. The frame names the log's
-//! path and the subscription id, which is the key its [`InboxEviction`] records
-//! are written under.
+//! path and the subscription id, which is the key its [`InboxMiss`] records are
+//! written under.
+//!
+//! ## What a permanently wedged client actually costs
+//!
+//! A client that stops reading and then goes away costs nothing:
+//! [`InboxSubscription::drop`] detaches its inbox and frees what it never read.
+//!
+//! A client that stops reading and STAYS is the case #6462 was opened for, and
+//! its cost is ongoing. When an SSE peer's TCP window fills, hyper stops
+//! polling the response body but does not drop the future, so the subscription
+//! is never dropped and `Drop` never runs. From then on the instance carries
+//! that client's [`CLIENT_INBOX_CAPACITY`]-envelope buffer AND pays, on every
+//! subsequent publish to that instance, one [`InboxMiss`] line in the durable
+//! §9 stream plus one `warn!` — durable-log growth and log volume proportional
+//! to publish rate, for as long as the wedged client stays attached. That is
+//! deliberate: the alternative levers (a reaper, an idle timer, a cap on
+//! subscriptions) are the policy call #6462's review promoted to the owner,
+//! not decisions this change makes.
+//!
+//! **The operator's lever is deregistering the instance**
+//! (`DELETE /api/v1/bus/instances/{instance_id}`), which closes every
+//! subscription and stops the fan-out. The `warn!` names the instance and the
+//! subscription on every miss, so a wedged client is identifiable from the
+//! daemon log without a new diagnostic.
+//!
+//! What is gone either way is the AVAILABILITY cost: no publisher is refused
+//! and no co-subscriber is slowed, however long the wedge lasts.
 
 use std::collections::VecDeque;
 use std::sync::Arc;
@@ -69,14 +96,14 @@ use super::envelope::BusEnvelope;
 /// Test: `eviction_is_recorded_per_client_in_the_durable_log`.
 pub const CLIENT_INBOX_CAPACITY: usize = 64;
 
-/// The `record` discriminator on an [`InboxEviction`] line in the §9 stream.
+/// The `record` discriminator on an [`InboxMiss`] line in the §9 stream.
 ///
 /// Why: the durable stream now carries two record shapes. A reader that
 /// deserializes every line as a [`BusEnvelope`] must be able to tell them apart
 /// without guessing, and an envelope record has no `record` field at all — so
 /// presence of this key IS the discriminator.
-/// Test: `eviction_records_are_distinguishable_from_envelopes`.
-pub const INBOX_EVICTION_RECORD: &str = "inbox_eviction";
+/// Test: `miss_records_are_distinguishable_from_envelopes`.
+pub const INBOX_MISS_RECORD: &str = "inbox_miss";
 
 /// What one read from an inbox yields.
 ///
@@ -96,17 +123,40 @@ pub enum InboxItem {
     Lagged(u64),
 }
 
-/// One envelope displaced unread, with everything its §9 record needs.
+/// Why one subscription did not end up holding an envelope.
 ///
-/// Why: the eviction happens inside the fan-out, under the instance's lock,
-/// but the durable write belongs to
-/// [`PeerBus::publish`](super::PeerBus::publish) — which owns the logger and
-/// the ordering. Handing the facts out as a value keeps the IO out of the
-/// guarded section without losing what was lost.
-/// What: the displaced envelope plus the subscription it was displaced from.
+/// Why two reasons and not one: they have different operator meanings and
+/// different recoveries. A displacement says the client is behind and should
+/// re-read the log; a closed subscription says its instance was deregistered
+/// out from under an in-flight publish, and there is nothing for that client to
+/// come back to. Collapsing them would put "you are behind" and "you are gone"
+/// under one word.
+/// What: the two ways an inbox can fail to end up holding an envelope.
+/// Test: `eviction_is_recorded_per_client_in_the_durable_log`,
+/// `a_publish_racing_deregistration_records_the_closed_subscriptions_miss`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MissReason {
+    /// The inbox was full, so its OLDEST unread envelope was displaced to make
+    /// room for this one. The record's `message_id` names the DISPLACED
+    /// envelope, not the one that arrived.
+    Displaced,
+    /// The subscription was closed by a deregistration before this envelope
+    /// reached it, so it took nothing. The record's `message_id` names the
+    /// envelope that arrived.
+    SubscriptionClosed,
+}
+
+/// One envelope one subscription will never read, with its §9 record's facts.
+///
+/// Why: the miss happens inside the fan-out, under the instance's lock, but the
+/// durable write belongs to [`PeerBus::publish`](super::PeerBus::publish) —
+/// which owns the logger and the ordering. Handing the facts out as a value
+/// keeps the IO out of the guarded section without losing what was lost.
+/// What: the lost envelope, the subscription that lost it, and why.
 /// Test: `eviction_is_recorded_per_client_in_the_durable_log`.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct EvictedEnvelope {
+pub struct MissedEnvelope {
     /// The instance whose subscriber lost it.
     pub instance_id: String,
     /// Which of that instance's subscriptions lost it.
@@ -114,55 +164,61 @@ pub struct EvictedEnvelope {
     /// How many envelopes that subscription has lost in total, this one
     /// included.
     pub missed_total: u64,
-    /// The envelope itself — the §9 log already holds it as `delivered`, and
-    /// this is what says that record is no longer the whole truth.
+    /// Why it was lost.
+    pub reason: MissReason,
+    /// The envelope itself — the §9 log records this publish as `delivered`,
+    /// and this is what says that record is not the whole truth for this one
+    /// client.
     pub envelope: BusEnvelope,
 }
 
-impl EvictedEnvelope {
-    /// The §9 record for this eviction.
+impl MissedEnvelope {
+    /// The §9 record for this miss.
     ///
     /// Test: `eviction_is_recorded_per_client_in_the_durable_log`.
-    pub fn record(&self) -> InboxEviction {
-        InboxEviction {
-            record: INBOX_EVICTION_RECORD.to_string(),
+    pub fn record(&self) -> InboxMiss {
+        InboxMiss {
+            record: INBOX_MISS_RECORD.to_string(),
             ts: chrono::Utc::now().to_rfc3339(),
             instance_id: self.instance_id.clone(),
             subscription_id: self.subscription_id,
             message_id: self.envelope.message_id.clone(),
             message_ts: self.envelope.ts.clone(),
+            reason: self.reason,
             missed_total: self.missed_total,
         }
     }
 }
 
-/// The §9 record written when one client's inbox displaces an unread envelope.
+/// The §9 record written when one client will never read an envelope.
 ///
 /// Why: DOC-60 §4 forbids an outcome the sender and the operator cannot
 /// distinguish, and #4271 is what that looks like when it is violated — a
-/// `delivered` record for an envelope its recipient never saw. An eviction is
-/// not a delivery failure (co-subscribers may well have read it), so it is not
-/// a second `delivery_state` on the envelope; it is a separate fact about one
+/// `delivered` record for an envelope its recipient never saw. A miss is not a
+/// delivery failure (co-subscribers may well have read it), so it is not a
+/// second `delivery_state` on the envelope; it is a separate fact about one
 /// subscription, and it is recorded as one.
-/// What: the displaced `message_id`, the subscription that lost it, and that
+/// What: the lost `message_id`, the subscription that lost it, why, and that
 /// subscription's running loss count — enough to reconstruct exactly what any
 /// one client did and did not see by replaying the stream.
 /// Test: `eviction_is_recorded_per_client_in_the_durable_log`,
-/// `eviction_records_are_distinguishable_from_envelopes`.
+/// `miss_records_are_distinguishable_from_envelopes`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct InboxEviction {
-    /// Always [`INBOX_EVICTION_RECORD`].
+pub struct InboxMiss {
+    /// Always [`INBOX_MISS_RECORD`].
     pub record: String,
-    /// RFC3339 time of the eviction.
+    /// RFC3339 time of the miss.
     pub ts: String,
     /// The instance whose subscriber lost the envelope.
     pub instance_id: String,
     /// The subscription that lost it.
     pub subscription_id: u64,
-    /// The `message_id` of the envelope displaced unread.
+    /// The `message_id` of the envelope this subscription will not read.
     pub message_id: String,
     /// That envelope's own timestamp, so a replay can seek to it.
     pub message_ts: String,
+    /// Displaced by a full inbox, or lost to a closed subscription.
+    pub reason: MissReason,
     /// How many envelopes this subscription has lost in total.
     pub missed_total: u64,
 }
@@ -233,26 +289,52 @@ impl ClientInbox {
 
     /// Take one envelope, displacing this inbox's oldest when it is full.
     ///
-    /// Why the oldest and not the newest: see the module doc's point 2.
-    /// What: pushes; when the queue already holds [`CLIENT_INBOX_CAPACITY`],
-    /// pops the front first and returns it so the caller can record the loss.
-    /// A closed inbox takes nothing — its reader is on its way out and an
-    /// envelope pushed into it would be recorded delivered and then never read.
-    /// Test: `eviction_is_recorded_per_client_in_the_durable_log`.
-    fn deliver(&self, envelope: BusEnvelope) -> Option<EvictedEnvelope> {
+    /// Why the return type is three-state and not `Option` (#6462 review): a
+    /// closed inbox and a healthy one that displaced nothing both used to
+    /// answer `None`, so [`InboxSet::fan_out`] could not tell "took it" from
+    /// "took nothing". Once a deregistration closed every subscription, a
+    /// publisher holding a stale [`LiveInstance`](super::LiveInstance) clone
+    /// saw a non-empty set, got `None` from every inbox, and reported a clean
+    /// delivery for an envelope no inbox held — #4271's shape through a new
+    /// door. Whether an inbox ACCEPTED an envelope is the fact the caller needs,
+    /// so it is the fact this returns.
+    ///
+    /// Why the oldest and not the newest, when it is full: see the module doc's
+    /// point 2.
+    /// What: [`InboxAccept::Refused`] when the subscription is closed, taking
+    /// nothing; [`InboxAccept::Displaced`] when the queue already holds
+    /// [`CLIENT_INBOX_CAPACITY`], having popped the front to make room; else
+    /// [`InboxAccept::Took`]. A refusal and a displacement both count toward
+    /// this subscription's loss total and both wake the reader, so a client
+    /// learns of either through [`InboxItem::Lagged`].
+    /// Test: `eviction_is_recorded_per_client_in_the_durable_log`,
+    /// `a_publish_racing_deregistration_is_not_recorded_delivered`.
+    fn deliver(&self, envelope: BusEnvelope) -> InboxAccept {
         let mut state = self.state();
         if state.closed {
-            return None;
-        }
-        let evicted = if state.queue.len() >= CLIENT_INBOX_CAPACITY {
-            let displaced = state.queue.pop_front();
             state.evicted_total += 1;
             state.pending_lag += 1;
-            displaced.map(|envelope| EvictedEnvelope {
+            let miss = MissedEnvelope {
                 instance_id: self.instance_id.clone(),
                 subscription_id: self.subscription_id,
                 missed_total: state.evicted_total,
+                reason: MissReason::SubscriptionClosed,
                 envelope,
+            };
+            drop(state);
+            self.signal.notify_one();
+            return InboxAccept::Refused(Box::new(miss));
+        }
+        let displaced = if state.queue.len() >= CLIENT_INBOX_CAPACITY {
+            let popped = state.queue.pop_front();
+            state.evicted_total += 1;
+            state.pending_lag += 1;
+            popped.map(|lost| MissedEnvelope {
+                instance_id: self.instance_id.clone(),
+                subscription_id: self.subscription_id,
+                missed_total: state.evicted_total,
+                reason: MissReason::Displaced,
+                envelope: lost,
             })
         } else {
             None
@@ -260,7 +342,10 @@ impl ClientInbox {
         state.queue.push_back(envelope);
         drop(state);
         self.signal.notify_one();
-        evicted
+        match displaced {
+            Some(miss) => InboxAccept::Displaced(Box::new(miss)),
+            None => InboxAccept::Took,
+        }
     }
 
     /// Stop the reader once it has drained what it already holds.
@@ -333,14 +418,36 @@ pub struct InboxSet {
 /// `eviction_is_recorded_per_client_in_the_durable_log`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DeliveryOutcome {
-    /// Every attached inbox holds the envelope. `evicted` names what each one
-    /// displaced unread to make room — empty in the ordinary case.
+    /// At least one attached inbox holds the envelope. `missed` names every
+    /// subscription that will not read it and why — empty in the ordinary case.
     Delivered {
-        /// The envelopes displaced by this delivery, one entry per loss.
-        evicted: Vec<EvictedEnvelope>,
+        /// One entry per loss: an envelope displaced to make room, or this
+        /// envelope lost to a subscription that was already closed.
+        missed: Vec<MissedEnvelope>,
     },
-    /// The instance is registered but nothing is subscribed.
+    /// The instance is registered but nothing subscribed took the envelope —
+    /// nothing is attached, or every attached subscription is closed.
     NoSubscriber,
+}
+
+/// What one inbox did with one envelope.
+///
+/// Why it is not `Option<MissedEnvelope>`: see [`ClientInbox::deliver`]. The
+/// distinction between "took it" and "took nothing" is the one #6462's review
+/// found missing, and an `Option` cannot carry it.
+/// What: took it cleanly, took it by displacing its oldest, or refused it
+/// because the subscription is closed. The payload is boxed because
+/// [`MissedEnvelope`] carries a whole envelope and the common variant carries
+/// nothing.
+/// Test: `a_publish_racing_deregistration_is_not_recorded_delivered`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum InboxAccept {
+    /// Queued, nothing displaced.
+    Took,
+    /// Queued, displacing the oldest unread envelope.
+    Displaced(Box<MissedEnvelope>),
+    /// Not queued — the subscription is closed.
+    Refused(Box<MissedEnvelope>),
 }
 
 impl InboxSet {
@@ -383,22 +490,48 @@ impl InboxSet {
     /// makes concurrent publishers agree on an order. The guarded section is a
     /// handful of `VecDeque` pushes with no IO and no await, which is what
     /// [`CLIENT_INBOX_CAPACITY`]'s low-volume rationale already assumes.
-    /// What: [`DeliveryOutcome::NoSubscriber`] when nothing is attached, else
-    /// [`DeliveryOutcome::Delivered`] carrying every eviction the fan-out
-    /// caused. The envelope is cloned per inbox because each client owns its
-    /// copy from here on.
+    ///
+    /// Why acceptances are COUNTED rather than inferred from the set being
+    /// non-empty (#6462 review): [`ClientInbox::close`] marks a subscription
+    /// closed but leaves it in the set — only
+    /// [`InboxSubscription::drop`] removes it — so a non-empty set does not
+    /// mean anything took the envelope. Deciding on the count instead makes the
+    /// answer track what actually happened, which is what
+    /// [`PeerBus::publish`](super::PeerBus::publish) records.
+    ///
+    /// What: [`DeliveryOutcome::NoSubscriber`] when nothing is attached OR
+    /// nothing accepted, so the §9 record for that publish reads `dropped` and
+    /// the sender gets `409`. Otherwise [`DeliveryOutcome::Delivered`] carrying
+    /// every miss the fan-out caused — displacements, and any closed
+    /// subscription that missed it — so each is recorded against the client
+    /// that lost it. The envelope is cloned per inbox because each client owns
+    /// its copy from here on.
     /// Test: `two_subscribers_one_lagging_account_exactly`,
-    /// `concurrent_publishers_lose_nothing_without_a_record`.
+    /// `concurrent_publishers_lose_nothing_without_a_record`,
+    /// `a_publish_racing_deregistration_is_not_recorded_delivered`,
+    /// `a_publish_racing_deregistration_records_the_closed_subscriptions_miss`.
     pub(super) fn fan_out(&self, envelope: BusEnvelope) -> DeliveryOutcome {
         let inboxes = self.inboxes();
-        if inboxes.is_empty() {
+        let mut accepted = 0usize;
+        let mut missed = Vec::new();
+        for inbox in inboxes.iter() {
+            match inbox.deliver(envelope.clone()) {
+                InboxAccept::Took => accepted += 1,
+                InboxAccept::Displaced(miss) => {
+                    accepted += 1;
+                    missed.push(*miss);
+                }
+                InboxAccept::Refused(miss) => missed.push(*miss),
+            }
+        }
+        if accepted == 0 {
+            // Nothing holds it, so nothing may say it was delivered. The
+            // envelope's own `dropped` record already states that it reached
+            // no one; a per-client miss record on top would double-count the
+            // same loss.
             return DeliveryOutcome::NoSubscriber;
         }
-        let evicted = inboxes
-            .iter()
-            .filter_map(|inbox| inbox.deliver(envelope.clone()))
-            .collect();
-        DeliveryOutcome::Delivered { evicted }
+        DeliveryOutcome::Delivered { missed }
     }
 
     /// End every attached subscription once it has drained.

--- a/crates/trusty-mpm/src/daemon/bus/inbox.rs
+++ b/crates/trusty-mpm/src/daemon/bus/inbox.rs
@@ -1,0 +1,495 @@
+//! Per-client durable inbox — the bus's delivery boundary (DOC-60 §7, #6462).
+//!
+//! Why: until #6462 every subscriber of one instance shared a single 64-slot
+//! `tokio::sync::broadcast` ring. `broadcast` measures backlog across ALL
+//! attached receivers and cannot send to a subset, so #6461 could keep the §9
+//! log truthful only by refusing the publish — which made one client that
+//! stops reading refuse every publish to that instance, healthy co-subscribers
+//! included, for as long as it stayed attached. Owner ruling on #6462: bound
+//! that. Giving each subscription its own buffer moves the delivery boundary
+//! from the instance to the client, so a stalled client's backlog is its own
+//! problem and costs the instance a fixed [`CLIENT_INBOX_CAPACITY`] envelopes
+//! of memory rather than its availability.
+//! What: [`ClientInbox`], one bounded queue per subscription; [`InboxSet`],
+//! the per-instance fan-out that owns them; [`InboxSubscription`], the reader
+//! handle that detaches on drop; and [`InboxEviction`], the §9 record that
+//! keeps an eviction from becoming a silent loss.
+//! Test: `bus::tests` — `a_wedged_client_does_not_refuse_publishes_for_a_healthy_co_subscriber`,
+//! `eviction_is_recorded_per_client_in_the_durable_log`,
+//! `concurrent_publishers_lose_nothing_without_a_record`,
+//! `a_detached_subscription_stops_costing_the_instance`.
+//!
+//! ## Eviction policy, and the two points DOC-60 §7 does not settle
+//!
+//! §7 specifies a durable inbox and its replay-on-connect recovery. It does
+//! not state a per-client buffer depth, nor which envelope loses when a live
+//! client's buffer is full. Both are settled here in the direction that keeps
+//! the §9 log answerable, which is §4's actual requirement:
+//!
+//! 1. **Depth is [`CLIENT_INBOX_CAPACITY`], per subscription.** It carries the
+//!    retired shared ring's depth forward unchanged, so an instance's worst
+//!    case grows with the number of attached clients rather than staying fixed
+//!    — which is the point: a wedged client can no longer spend anyone else's
+//!    budget.
+//! 2. **The OLDEST unread envelope loses, and the loss is recorded.** #4271's
+//!    defect was never the eviction; it was the lie — the log said `delivered`
+//!    and nobody was told. Every eviction here writes an [`InboxEviction`] to
+//!    the §9 stream naming the displaced `message_id` and the subscription that
+//!    lost it, and the reader gets an [`InboxItem::Lagged`] at the point of
+//!    loss. Refusing the NEWEST envelope instead would leave a recovering
+//!    client reading stale traffic forever with no way to catch up, and would
+//!    put the refusal back on the publisher — the wedge #6462 exists to remove.
+//!
+//! Recovery is unchanged from #6461 and is what makes eviction survivable: the
+//! §9 JSONL stream holds every envelope, so a client that sees a `lagged` frame
+//! re-reads the log from its last known `message_id`. The frame names the log's
+//! path and the subscription id, which is the key its [`InboxEviction`] records
+//! are written under.
+
+use std::collections::VecDeque;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use serde::{Deserialize, Serialize};
+use tokio::sync::Notify;
+
+use super::envelope::BusEnvelope;
+
+/// How many envelopes ONE subscription buffers before it displaces its oldest.
+///
+/// Why: peer messages are low-volume by construction — DOC-60 §3 keeps
+/// streaming token deltas on the existing per-crate buses — so a shallow
+/// buffer is right, and it is what bounds a never-polling client's cost. This
+/// is the depth the retired shared ring had, now applied per client so one
+/// client's backlog is charged to that client.
+///
+/// Public because it is part of the delivery contract a subscriber reasons
+/// about: fall this far behind and the next envelope displaces your oldest.
+/// Test: `eviction_is_recorded_per_client_in_the_durable_log`.
+pub const CLIENT_INBOX_CAPACITY: usize = 64;
+
+/// The `record` discriminator on an [`InboxEviction`] line in the §9 stream.
+///
+/// Why: the durable stream now carries two record shapes. A reader that
+/// deserializes every line as a [`BusEnvelope`] must be able to tell them apart
+/// without guessing, and an envelope record has no `record` field at all — so
+/// presence of this key IS the discriminator.
+/// Test: `eviction_records_are_distinguishable_from_envelopes`.
+pub const INBOX_EVICTION_RECORD: &str = "inbox_eviction";
+
+/// What one read from an inbox yields.
+///
+/// Why: a subscriber needs to learn about a gap AT the gap, not after the
+/// fact — that is the whole content of #4271's SSE half. Making the gap a
+/// value in the same stream as the envelopes puts it in order by construction.
+/// What: an envelope, or the count this subscription lost since its last read.
+/// The envelope is boxed because it is an order of magnitude larger than the
+/// counter and the enum would otherwise be sized by its rare variant.
+/// Test: `a_stalled_subscriber_reads_its_lag_before_the_surviving_envelopes`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InboxItem {
+    /// One addressed envelope, in publish order.
+    Envelope(Box<BusEnvelope>),
+    /// This inbox displaced `missed` unread envelopes to make room. Each one
+    /// has an [`InboxEviction`] record in the §9 stream.
+    Lagged(u64),
+}
+
+/// One envelope displaced unread, with everything its §9 record needs.
+///
+/// Why: the eviction happens inside the fan-out, under the instance's lock,
+/// but the durable write belongs to
+/// [`PeerBus::publish`](super::PeerBus::publish) — which owns the logger and
+/// the ordering. Handing the facts out as a value keeps the IO out of the
+/// guarded section without losing what was lost.
+/// What: the displaced envelope plus the subscription it was displaced from.
+/// Test: `eviction_is_recorded_per_client_in_the_durable_log`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EvictedEnvelope {
+    /// The instance whose subscriber lost it.
+    pub instance_id: String,
+    /// Which of that instance's subscriptions lost it.
+    pub subscription_id: u64,
+    /// How many envelopes that subscription has lost in total, this one
+    /// included.
+    pub missed_total: u64,
+    /// The envelope itself — the §9 log already holds it as `delivered`, and
+    /// this is what says that record is no longer the whole truth.
+    pub envelope: BusEnvelope,
+}
+
+impl EvictedEnvelope {
+    /// The §9 record for this eviction.
+    ///
+    /// Test: `eviction_is_recorded_per_client_in_the_durable_log`.
+    pub fn record(&self) -> InboxEviction {
+        InboxEviction {
+            record: INBOX_EVICTION_RECORD.to_string(),
+            ts: chrono::Utc::now().to_rfc3339(),
+            instance_id: self.instance_id.clone(),
+            subscription_id: self.subscription_id,
+            message_id: self.envelope.message_id.clone(),
+            message_ts: self.envelope.ts.clone(),
+            missed_total: self.missed_total,
+        }
+    }
+}
+
+/// The §9 record written when one client's inbox displaces an unread envelope.
+///
+/// Why: DOC-60 §4 forbids an outcome the sender and the operator cannot
+/// distinguish, and #4271 is what that looks like when it is violated — a
+/// `delivered` record for an envelope its recipient never saw. An eviction is
+/// not a delivery failure (co-subscribers may well have read it), so it is not
+/// a second `delivery_state` on the envelope; it is a separate fact about one
+/// subscription, and it is recorded as one.
+/// What: the displaced `message_id`, the subscription that lost it, and that
+/// subscription's running loss count — enough to reconstruct exactly what any
+/// one client did and did not see by replaying the stream.
+/// Test: `eviction_is_recorded_per_client_in_the_durable_log`,
+/// `eviction_records_are_distinguishable_from_envelopes`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InboxEviction {
+    /// Always [`INBOX_EVICTION_RECORD`].
+    pub record: String,
+    /// RFC3339 time of the eviction.
+    pub ts: String,
+    /// The instance whose subscriber lost the envelope.
+    pub instance_id: String,
+    /// The subscription that lost it.
+    pub subscription_id: u64,
+    /// The `message_id` of the envelope displaced unread.
+    pub message_id: String,
+    /// That envelope's own timestamp, so a replay can seek to it.
+    pub message_ts: String,
+    /// How many envelopes this subscription has lost in total.
+    pub missed_total: u64,
+}
+
+/// The mutable half of one inbox.
+#[derive(Debug, Default)]
+struct InboxState {
+    /// Envelopes this subscription has not read, oldest first.
+    queue: VecDeque<BusEnvelope>,
+    /// Evictions the reader has not yet been told about.
+    pending_lag: u64,
+    /// Evictions over this subscription's whole life.
+    evicted_total: u64,
+    /// Set when the instance is deregistered; the reader drains, then ends.
+    closed: bool,
+}
+
+/// One subscription's bounded, per-client buffer.
+///
+/// Why: see the module doc — this is what moves the delivery boundary off the
+/// instance. Each inbox is written by publishers under [`InboxSet`]'s lock and
+/// read by exactly one reader, the [`InboxSubscription`] that owns it.
+/// What: a bounded [`VecDeque`] plus the lag counters, behind one mutex, with a
+/// [`Notify`] the single reader parks on.
+/// Test: `eviction_is_recorded_per_client_in_the_durable_log`,
+/// `a_stalled_subscriber_reads_its_lag_before_the_surviving_envelopes`.
+#[derive(Debug)]
+pub struct ClientInbox {
+    /// Which subscription this is — unique within its instance.
+    subscription_id: u64,
+    /// The instance this inbox belongs to, carried so an eviction record can
+    /// name it without a registry lookup.
+    instance_id: String,
+    /// Queue and counters.
+    state: Mutex<InboxState>,
+    /// Wakes the single reader. `notify_one` stores a permit when no reader is
+    /// parked, so a delivery between the reader's queue check and its `await`
+    /// cannot be lost.
+    signal: Notify,
+}
+
+impl ClientInbox {
+    /// Recover a poisoned lock rather than fail a publish.
+    ///
+    /// Why: the guarded section pushes and pops a `VecDeque` and increments two
+    /// counters. It calls no user code and holds no invariant across a panic,
+    /// so a poisoned lock carries no corrupted state — refusing delivery on it
+    /// would turn an unrelated panic elsewhere into a permanent dead inbox.
+    fn state(&self) -> std::sync::MutexGuard<'_, InboxState> {
+        self.state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    /// Which subscription this inbox serves.
+    ///
+    /// Test: `a_stalled_subscriber_reads_its_lag_before_the_surviving_envelopes`.
+    pub fn subscription_id(&self) -> u64 {
+        self.subscription_id
+    }
+
+    /// How many envelopes this subscription has lost to eviction.
+    ///
+    /// Test: `eviction_is_recorded_per_client_in_the_durable_log`.
+    pub fn evicted_total(&self) -> u64 {
+        self.state().evicted_total
+    }
+
+    /// Take one envelope, displacing this inbox's oldest when it is full.
+    ///
+    /// Why the oldest and not the newest: see the module doc's point 2.
+    /// What: pushes; when the queue already holds [`CLIENT_INBOX_CAPACITY`],
+    /// pops the front first and returns it so the caller can record the loss.
+    /// A closed inbox takes nothing — its reader is on its way out and an
+    /// envelope pushed into it would be recorded delivered and then never read.
+    /// Test: `eviction_is_recorded_per_client_in_the_durable_log`.
+    fn deliver(&self, envelope: BusEnvelope) -> Option<EvictedEnvelope> {
+        let mut state = self.state();
+        if state.closed {
+            return None;
+        }
+        let evicted = if state.queue.len() >= CLIENT_INBOX_CAPACITY {
+            let displaced = state.queue.pop_front();
+            state.evicted_total += 1;
+            state.pending_lag += 1;
+            displaced.map(|envelope| EvictedEnvelope {
+                instance_id: self.instance_id.clone(),
+                subscription_id: self.subscription_id,
+                missed_total: state.evicted_total,
+                envelope,
+            })
+        } else {
+            None
+        };
+        state.queue.push_back(envelope);
+        drop(state);
+        self.signal.notify_one();
+        evicted
+    }
+
+    /// Stop the reader once it has drained what it already holds.
+    ///
+    /// Why: deregistration used to end a subscriber's stream by dropping the
+    /// broadcast `Sender`. With per-client queues the end has to be stated,
+    /// and it has to come AFTER the queue rather than instead of it — envelopes
+    /// the log recorded delivered are still readable.
+    /// Test: `deregister_ends_a_subscription_after_it_drains`.
+    fn close(&self) {
+        self.state().closed = true;
+        self.signal.notify_one();
+    }
+
+    /// Take the next item if one is ready, without waiting.
+    ///
+    /// Why lag first: the eviction removed envelopes from the FRONT, which is
+    /// where the reader is, so the gap belongs before everything still queued.
+    /// That is the same ordering `broadcast` gave and what the SSE contract
+    /// (#4271) already documents.
+    /// Test: `a_stalled_subscriber_reads_its_lag_before_the_surviving_envelopes`.
+    fn try_recv(&self) -> Option<InboxItem> {
+        let mut state = self.state();
+        if state.pending_lag > 0 {
+            return Some(InboxItem::Lagged(std::mem::take(&mut state.pending_lag)));
+        }
+        state
+            .queue
+            .pop_front()
+            .map(|e| InboxItem::Envelope(Box::new(e)))
+    }
+
+    /// Whether the queue is drained and no further envelope can arrive.
+    fn is_finished(&self) -> bool {
+        let state = self.state();
+        state.closed && state.pending_lag == 0 && state.queue.is_empty()
+    }
+}
+
+/// Every inbox attached to one instance, and the fan-out over them.
+///
+/// Why: the instance-level lock survives the move to per-client buffers, but
+/// its job changes. It no longer gates delivery on the slowest reader — it
+/// makes ONE publish's fan-out indivisible, so two concurrent publishers cannot
+/// interleave and hand two clients the same two envelopes in opposite orders.
+/// That is the ordering guarantee the retired broadcast ring gave for free and
+/// that `two_subscribers_one_lagging_account_exactly` pins.
+/// What: the attached inboxes plus the subscription-id source. Attach, detach,
+/// and fan-out all take the same lock; a reader takes only its own inbox's.
+/// Test: `two_subscribers_one_lagging_account_exactly`,
+/// `concurrent_publishers_lose_nothing_without_a_record`.
+#[derive(Debug, Default)]
+pub struct InboxSet {
+    /// Attached inboxes, in attachment order.
+    inboxes: Mutex<Vec<Arc<ClientInbox>>>,
+    /// Source of subscription ids, unique within this instance.
+    next_subscription: AtomicU64,
+}
+
+/// What one fan-out actually did.
+///
+/// Why: the publisher must write a durable record stating what happened, and
+/// the two outcomes carry different records and different answers to the
+/// sender. Since #6462 a slow subscriber is no longer one of them: it cannot
+/// refuse a publish, so the `Saturated` arm — and the `503` it produced — is
+/// gone.
+/// What: delivered to every attached inbox (naming whatever each displaced), or
+/// nothing attached at all.
+/// Test: `publish_without_subscriber_errors`,
+/// `eviction_is_recorded_per_client_in_the_durable_log`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DeliveryOutcome {
+    /// Every attached inbox holds the envelope. `evicted` names what each one
+    /// displaced unread to make room — empty in the ordinary case.
+    Delivered {
+        /// The envelopes displaced by this delivery, one entry per loss.
+        evicted: Vec<EvictedEnvelope>,
+    },
+    /// The instance is registered but nothing is subscribed.
+    NoSubscriber,
+}
+
+impl InboxSet {
+    /// Recover a poisoned lock rather than fail a publish — see
+    /// [`ClientInbox::state`] for why that is safe here.
+    fn inboxes(&self) -> std::sync::MutexGuard<'_, Vec<Arc<ClientInbox>>> {
+        self.inboxes
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    /// Attach a new subscription and hand back its reader.
+    ///
+    /// Test: `a_detached_subscription_stops_costing_the_instance`.
+    pub(super) fn attach(self: &Arc<Self>, instance_id: &str) -> InboxSubscription {
+        let inbox = Arc::new(ClientInbox {
+            subscription_id: self.next_subscription.fetch_add(1, Ordering::SeqCst),
+            instance_id: instance_id.to_string(),
+            state: Mutex::new(InboxState::default()),
+            signal: Notify::new(),
+        });
+        self.inboxes().push(Arc::clone(&inbox));
+        InboxSubscription {
+            set: Arc::clone(self),
+            inbox,
+        }
+    }
+
+    /// Remove one subscription's inbox, freeing whatever it never read.
+    ///
+    /// Test: `a_detached_subscription_stops_costing_the_instance`.
+    fn detach(&self, subscription_id: u64) {
+        self.inboxes()
+            .retain(|inbox| inbox.subscription_id != subscription_id);
+    }
+
+    /// Deliver one envelope to every attached inbox.
+    ///
+    /// Why the whole fan-out is under one lock: see the type doc — it is what
+    /// makes concurrent publishers agree on an order. The guarded section is a
+    /// handful of `VecDeque` pushes with no IO and no await, which is what
+    /// [`CLIENT_INBOX_CAPACITY`]'s low-volume rationale already assumes.
+    /// What: [`DeliveryOutcome::NoSubscriber`] when nothing is attached, else
+    /// [`DeliveryOutcome::Delivered`] carrying every eviction the fan-out
+    /// caused. The envelope is cloned per inbox because each client owns its
+    /// copy from here on.
+    /// Test: `two_subscribers_one_lagging_account_exactly`,
+    /// `concurrent_publishers_lose_nothing_without_a_record`.
+    pub(super) fn fan_out(&self, envelope: BusEnvelope) -> DeliveryOutcome {
+        let inboxes = self.inboxes();
+        if inboxes.is_empty() {
+            return DeliveryOutcome::NoSubscriber;
+        }
+        let evicted = inboxes
+            .iter()
+            .filter_map(|inbox| inbox.deliver(envelope.clone()))
+            .collect();
+        DeliveryOutcome::Delivered { evicted }
+    }
+
+    /// End every attached subscription once it has drained.
+    ///
+    /// Test: `deregister_ends_a_subscription_after_it_drains`.
+    pub(super) fn close_all(&self) {
+        for inbox in self.inboxes().iter() {
+            inbox.close();
+        }
+    }
+
+    /// How many subscriptions are attached.
+    ///
+    /// Test: `a_detached_subscription_stops_costing_the_instance`.
+    pub fn len(&self) -> usize {
+        self.inboxes().len()
+    }
+
+    /// Whether nothing is subscribed.
+    ///
+    /// Test: `a_detached_subscription_stops_costing_the_instance`.
+    pub fn is_empty(&self) -> bool {
+        self.inboxes().is_empty()
+    }
+}
+
+/// One client's read handle on its inbox.
+///
+/// Why it owns the detach: a subscriber that goes away — an SSE body dropped
+/// when the client disconnects — must stop being fanned out to and must stop
+/// holding envelopes nobody will read. Tying that to `Drop` means no code path
+/// can forget it, which is what keeps a disconnected client's cost at zero
+/// rather than at [`CLIENT_INBOX_CAPACITY`] envelopes forever.
+/// What: the inbox plus its set, with `recv`/`try_recv` over the former.
+/// Exactly one of these exists per inbox, which is why the inbox's `Notify`
+/// only ever needs to wake one reader.
+/// Test: `a_detached_subscription_stops_costing_the_instance`,
+/// `deregister_ends_a_subscription_after_it_drains`.
+#[derive(Debug)]
+pub struct InboxSubscription {
+    /// The instance's fan-out set, so `Drop` can detach.
+    set: Arc<InboxSet>,
+    /// This subscription's own buffer.
+    inbox: Arc<ClientInbox>,
+}
+
+impl InboxSubscription {
+    /// This subscription's id — the key its [`InboxEviction`] records carry.
+    ///
+    /// Test: `a_stalled_subscriber_reads_its_lag_before_the_surviving_envelopes`.
+    pub fn subscription_id(&self) -> u64 {
+        self.inbox.subscription_id()
+    }
+
+    /// How many envelopes this subscription has lost to eviction.
+    ///
+    /// Test: `eviction_is_recorded_per_client_in_the_durable_log`.
+    pub fn evicted_total(&self) -> u64 {
+        self.inbox.evicted_total()
+    }
+
+    /// The next item if one is ready, without waiting.
+    ///
+    /// Test: `a_stalled_subscriber_reads_its_lag_before_the_surviving_envelopes`.
+    pub fn try_recv(&self) -> Option<InboxItem> {
+        self.inbox.try_recv()
+    }
+
+    /// Wait for the next item; `None` once the instance is gone and the inbox
+    /// is drained.
+    ///
+    /// Why the loop: the wake is advisory. A `notify_one` permit can outlive
+    /// the item that caused it (the reader drained it on the previous pass), so
+    /// the queue is re-checked on every wake rather than trusted.
+    /// Test: `deregister_ends_a_subscription_after_it_drains`,
+    /// `two_subscribers_one_lagging_account_exactly`.
+    pub async fn recv(&self) -> Option<InboxItem> {
+        loop {
+            if let Some(item) = self.inbox.try_recv() {
+                return Some(item);
+            }
+            if self.inbox.is_finished() {
+                return None;
+            }
+            self.inbox.signal.notified().await;
+        }
+    }
+}
+
+impl Drop for InboxSubscription {
+    fn drop(&mut self) {
+        self.set.detach(self.inbox.subscription_id);
+    }
+}

--- a/crates/trusty-mpm/src/daemon/bus/mod.rs
+++ b/crates/trusty-mpm/src/daemon/bus/mod.rs
@@ -6,20 +6,23 @@
 //! assistants are virtual twins that may communicate but never delegate — but
 //! it left trusty-agents personas with *no* agent-to-agent path of any kind.
 //! DOC-60 §5.3 is the specified replacement; this module is its daemon side.
-//! What: [`PeerBus`], holding the §6b instance registry, the per-instance
-//! delivery channels, and the DOC-60 §9 durable JSONL stream (written through
+//! What: [`PeerBus`], holding the §6b instance registry, the per-client
+//! durable inboxes, and the DOC-60 §9 durable JSONL stream (written through
 //! the EXISTING [`AuditLogger`](crate::daemon::audit::AuditLogger), not a
 //! second writer). Submodules: [`envelope`] is the §11 schema, [`registry`]
-//! resolves both addressing modes, [`error`] is the §4 fail-closed contract,
-//! and [`routes`] is the HTTP surface.
+//! resolves both addressing modes, [`inbox`] is §7's per-client delivery
+//! boundary, [`error`] is the §4 fail-closed contract, and [`routes`] is the
+//! HTTP surface.
 //! Test: `tests` — the module's suite covers publish, both addressing modes,
-//! the bypass failure mode, the durable record, and the #4271 lag contract.
+//! the bypass failure mode, the durable record, and the #4271/#6462 delivery
+//! contract.
 //!
 //! ## Scope: step 1 of DOC-60 §5.3, and what it deliberately excludes
 //!
-//! - **Targets a RUNNING instance only.** DOC-60 §7's durable inbox and
-//!   queue-not-spawn behavior are NOT built here; a message to a definition
-//!   with nothing running fails closed per §4 rather than queueing.
+//! - **Targets a RUNNING instance only.** #6462 built DOC-60 §7's durable
+//!   inbox for a live client's SUBSCRIPTION. §7's other half —
+//!   queue-not-spawn for a definition with nothing running — is NOT built
+//!   here; such a message fails closed per §4 rather than queueing.
 //! - **Cross-project addressing** (§12 Q4), **retention policy** (§12 Q1), and
 //!   **version-skew negotiation** (§12 Q2/Q5) are all deferred to the owner.
 //! - **Streaming token deltas stay off this bus.** High-volume telemetry
@@ -33,18 +36,18 @@
 //! [`PeerBus`]: crate::daemon::bus::PeerBus
 //! [`envelope`]: crate::daemon::bus::envelope
 //! [`registry`]: crate::daemon::bus::registry
+//! [`inbox`]: crate::daemon::bus::inbox
 //! [`error`]: crate::daemon::bus::error
 //! [`routes`]: crate::daemon::bus::routes
 
 use std::path::Path;
 use std::sync::Arc;
 
-use tokio::sync::broadcast;
-
 use crate::daemon::audit::{AuditLogger, BUS_STREAM};
 
 pub mod envelope;
 pub mod error;
+pub mod inbox;
 pub mod registry;
 pub mod routes;
 
@@ -56,15 +59,16 @@ pub use envelope::{
     Recipient,
 };
 pub use error::BusError;
-pub use registry::{
-    DeliveryOutcome, INSTANCE_CHANNEL_CAPACITY, InstanceMeta, InstanceRegistry, LiveInstance,
-    PeerTarget,
+pub use inbox::{
+    CLIENT_INBOX_CAPACITY, ClientInbox, DeliveryOutcome, EvictedEnvelope, INBOX_EVICTION_RECORD,
+    InboxEviction, InboxItem, InboxSet, InboxSubscription,
 };
+pub use registry::{InstanceMeta, InstanceRegistry, LiveInstance, PeerTarget};
 
 /// The daemon's peer message bus.
 ///
-/// Why: DOC-60 §4 makes `tm` the bus host, so the registry, the delivery
-/// channels, and the durable log must live behind one handle the daemon state
+/// Why: DOC-60 §4 makes `tm` the bus host, so the registry, the per-client
+/// inboxes, and the durable log must live behind one handle the daemon state
 /// can hold and the HTTP routes can borrow. Bundling them also keeps the
 /// publish path atomic in the way that matters: an envelope is stamped,
 /// logged, and delivered (or logged as dropped) without an interleaving caller
@@ -114,17 +118,18 @@ impl PeerBus {
     ///
     /// Why: delivery is per-instance, not broadcast-then-filter — see
     /// [`registry::LiveInstance`] for why that distinction is the point of
-    /// this bus. A subscriber therefore attaches to a specific instance's
-    /// channel, and attaching to a dead one is an error rather than a silently
-    /// empty stream.
-    /// What: resolves `instance_id` and returns a receiver on its channel.
+    /// this bus. A subscriber therefore attaches to a specific instance, and
+    /// attaching to a dead one is an error rather than a silently empty stream.
+    /// Since #6462 each subscription gets its OWN bounded buffer rather than a
+    /// share of one ring, so how far this subscriber falls behind is its own
+    /// business — see [`inbox`]'s module doc.
+    /// What: resolves `instance_id` and attaches an [`InboxSubscription`],
+    /// which detaches when it is dropped.
     /// Test: `publish_reaches_only_target_instance`,
-    /// `subscribe_to_dead_instance_errors`.
-    pub fn subscribe(
-        &self,
-        instance_id: &str,
-    ) -> Result<broadcast::Receiver<BusEnvelope>, BusError> {
-        Ok(self.registry.resolve_instance(instance_id)?.tx.subscribe())
+    /// `subscribe_to_dead_instance_errors`,
+    /// `a_detached_subscription_stops_costing_the_instance`.
+    pub fn subscribe(&self, instance_id: &str) -> Result<InboxSubscription, BusError> {
+        Ok(self.registry.resolve_instance(instance_id)?.subscribe())
     }
 
     /// Verify a claimed sender identity against the live registry.
@@ -179,51 +184,50 @@ impl PeerBus {
     ///    addressing modes (see [`registry`]'s module doc);
     /// 5. on resolution failure, stamps a [`DeliveryState::Dropped`] envelope,
     ///    logs it, and returns the error to the sender;
-    /// 6. on success, stamps a [`DeliveryState::Delivered`] envelope, sends it
-    ///    to that instance's channel, and logs what actually happened. A
-    ///    registered instance with no attached subscriber yields
+    /// 6. on success, stamps a [`DeliveryState::Delivered`] envelope, fans it
+    ///    out into every attached client's inbox, and logs what actually
+    ///    happened. A registered instance with no attached subscriber yields
     ///    [`BusError::NoSubscriber`] and a `Dropped` record rather than a
-    ///    silent drop — DOC-60 §7's durable inbox is what will make that case
-    ///    queue instead, and it is deferred.
+    ///    silent drop — §7's OTHER half, queueing to a definition with nothing
+    ///    running, is what will make that case queue instead, and it is
+    ///    deferred.
     ///
-    /// **The delivery guarantee, and the backpressure that buys it (#4271).**
-    /// An envelope this method records as `Delivered` stays readable by every
-    /// attached subscriber until that subscriber reads it. No later publish
-    /// through this method evicts it. Step 6 delegates to
-    /// [`LiveInstance::deliver`], which holds the instance's delivery gate
-    /// across both the measurement and the send: when the recipient's channel
-    /// already holds [`INSTANCE_CHANNEL_CAPACITY`] envelopes its slowest
-    /// subscriber has not read, the next send could only be taken by
-    /// overwriting the oldest of them, so the NEW envelope is refused with
-    /// [`BusError::SubscriberLagged`] (503) and recorded `Dropped`. The gate is
-    /// what makes the guarantee hold under concurrent publishers rather than
-    /// only under one — see `deliver` for why an unguarded check is stale by
-    /// the time the send runs.
+    /// **The delivery guarantee (#4271, re-cut per client by #6462).** An
+    /// envelope this method records as `Delivered` is readable by every
+    /// attached subscription until that subscription reads it, UNLESS this
+    /// method also wrote an [`InboxEviction`] naming that envelope and the one
+    /// subscription that lost it. Nothing is lost without a record. Step 6
+    /// delegates to [`LiveInstance::deliver`], which fans the envelope into one
+    /// bounded buffer per subscription under a single per-instance lock, so
+    /// concurrent publishers cannot hand two clients the same two envelopes in
+    /// opposite orders.
     ///
-    /// Before #4271 the send was made anyway. `broadcast::Sender::send` answers
-    /// `Ok` for a lagging receiver, so the log recorded `Delivered` for the
-    /// envelope that displaced an unread one, the sender got `202 Accepted`,
-    /// and the recipient was never told — a `delivered` record for a message
-    /// that reached no one. Refusing the newest message rather than silently
-    /// discarding the oldest keeps the §9 log answerable, which is the whole
-    /// reason DOC-60 §4 forbids a silent drop. A healthy subscriber never
-    /// reaches saturation and is unaffected.
+    /// Before #4271 an eviction was invisible: `broadcast::Sender::send`
+    /// answers `Ok` for a lagging receiver, so the log recorded `Delivered` for
+    /// the envelope that displaced an unread one, the sender got
+    /// `202 Accepted`, and the recipient was never told. #4271 closed that by
+    /// refusing the publish instead. The eviction is back, and the LIE is what
+    /// stays closed: an eviction now costs one `warn!` and one durable record
+    /// per lost envelope, plus an [`InboxItem::Lagged`] to the affected reader
+    /// at the point of loss.
     ///
-    /// **What the refusal costs, and why nothing here bounds it.** Saturation
-    /// is measured across every attached receiver, and `broadcast` cannot send
-    /// to a subset, so ONE subscriber that stops draining makes this instance
-    /// refuse every publish to it — including on behalf of healthy
-    /// co-subscribers. That wedge clears when the stalled subscriber drains,
-    /// when it drops (a client that exits closes its SSE connection, and
-    /// `Receiver::drop` drains the backlog it never read), or when an operator
-    /// deregisters the instance. Nothing puts a timer on it, deliberately: the
-    /// only sender-side lever `broadcast` offers is dropping the channel, which
-    /// would discard envelopes this log has already recorded `Delivered` and so
-    /// re-create #4271 by another route. A per-subscriber buffer that could
-    /// evict one client without touching the others is DOC-60 §7's durable
-    /// inbox, deferred to the owner. Until then the failure is loud — a `warn!`
-    /// and a 503 naming the instance on every refused publish — rather than
-    /// bounded.
+    /// **Why publish no longer refuses (#6462).** The refusal was measured
+    /// across every attached receiver of one shared ring, so ONE subscriber
+    /// that stopped draining made this instance refuse every publish to it,
+    /// healthy co-subscribers included, unboundedly. Per-client inboxes remove
+    /// the shared quantity that made that possible: a stalled client falls
+    /// behind alone, its cost to the instance is a fixed
+    /// [`CLIENT_INBOX_CAPACITY`] envelopes of memory, and it stops costing even
+    /// that when its subscription drops. No timer is needed and none is added.
+    /// The recovery for a client that fell behind is unchanged from #4271:
+    /// re-read the §9 durable log, whose path the `lagged` SSE frame carries.
+    ///
+    /// **Eviction records are written BEFORE the delivery record.** The
+    /// eviction has already happened in memory by the time either write runs,
+    /// so the ordering only decides which way a crash between them lies. This
+    /// way it under-claims — the loss is on record and the delivery that caused
+    /// it is not — where the other way round would leave a `delivered` record
+    /// with nothing explaining the gap, which is #4271 exactly.
     ///
     /// **What the durable §9 log does and does not contain.** Once a sender is
     /// verified (step 3), EVERY outcome is recorded — delivered or dropped —
@@ -242,9 +246,10 @@ impl PeerBus {
     /// `bypass_publish_stamps_both_ids`, `failed_publish_logs_dropped_envelope`,
     /// `publish_without_subscriber_errors`, `publish_rejects_forged_user_kind`,
     /// `rejected_publish_writes_no_durable_record`,
-    /// `delivered_records_match_what_a_stalled_subscriber_receives`,
-    /// `saturated_publish_is_dropped_in_the_durable_log`,
-    /// `concurrent_publishers_never_evict_a_delivered_envelope`.
+    /// `delivered_records_account_for_everything_a_stalled_subscriber_lost`,
+    /// `eviction_is_recorded_per_client_in_the_durable_log`,
+    /// `a_wedged_client_does_not_refuse_publishes_for_a_healthy_co_subscriber`,
+    /// `concurrent_publishers_lose_nothing_without_a_record`.
     pub fn publish(
         &self,
         from: CallerIdentity,
@@ -302,23 +307,23 @@ impl PeerBus {
         // that is supposed to settle "sent or not" — #4271 is what that lie
         // looked like in practice.
         match live.deliver(envelope.clone()) {
-            DeliveryOutcome::Delivered => {
+            DeliveryOutcome::Delivered { evicted } => {
+                // Losses first, so a crash between the two writes leaves the
+                // log under-claiming rather than repeating #4271.
+                for loss in &evicted {
+                    self.audit.log_record(&loss.record());
+                    tracing::warn!(
+                        instance_id = %loss.instance_id,
+                        subscription_id = loss.subscription_id,
+                        capacity = CLIENT_INBOX_CAPACITY,
+                        message_id = %loss.envelope.message_id,
+                        missed_total = loss.missed_total,
+                        "peer bus inbox displaced an unread envelope: this client \
+                         is behind and must re-read the durable log (#6462)"
+                    );
+                }
                 self.audit.log_record(&envelope);
                 Ok(envelope)
-            }
-            DeliveryOutcome::Saturated => {
-                envelope.delivery_state = DeliveryState::Dropped;
-                self.audit.log_record(&envelope);
-                tracing::warn!(
-                    instance_id = %live.meta.instance_id,
-                    capacity = INSTANCE_CHANNEL_CAPACITY,
-                    message_id = %envelope.message_id,
-                    "peer bus refused a publish: the recipient's channel is full \
-                     of unread envelopes (#4271)"
-                );
-                Err(BusError::SubscriberLagged {
-                    instance_id: live.meta.instance_id,
-                })
             }
             DeliveryOutcome::NoSubscriber => {
                 envelope.delivery_state = DeliveryState::Dropped;

--- a/crates/trusty-mpm/src/daemon/bus/mod.rs
+++ b/crates/trusty-mpm/src/daemon/bus/mod.rs
@@ -61,7 +61,7 @@ pub use envelope::{
 pub use error::BusError;
 pub use inbox::{
     CLIENT_INBOX_CAPACITY, ClientInbox, DeliveryOutcome, INBOX_MISS_RECORD, InboxItem, InboxMiss,
-    InboxSet, InboxSubscription, MissReason, MissedEnvelope,
+    InboxSet, InboxSubscription, MissedEnvelope,
 };
 pub use registry::{InstanceMeta, InstanceRegistry, LiveInstance, PeerTarget};
 
@@ -202,7 +202,6 @@ impl PeerBus {
                 subscription_id = loss.subscription_id,
                 capacity = CLIENT_INBOX_CAPACITY,
                 message_id = %loss.envelope.message_id,
-                reason = ?loss.reason,
                 missed_total = loss.missed_total,
                 "peer bus inbox lost an envelope for one client: it must re-read \
                  the durable log (#6462)"
@@ -383,8 +382,14 @@ impl PeerBus {
         // looked like in practice.
         match live.deliver(envelope.clone()) {
             DeliveryOutcome::Delivered { missed } => {
+                // These two statements are ordered, not incidental: the loss
+                // records go out FIRST so an interruption under-claims. Keep
+                // them as separate statements — folding the call into the
+                // argument list buries the invariant in operand evaluation
+                // order, where a later refactor can invert it silently.
+                let losses_unrecorded = self.record_losses(&missed);
                 self.audit
-                    .log_record(&EnvelopeRecord::new(&envelope, self.record_losses(&missed)));
+                    .log_record(&EnvelopeRecord::new(&envelope, losses_unrecorded));
                 Ok(envelope)
             }
             DeliveryOutcome::NoSubscriber => {

--- a/crates/trusty-mpm/src/daemon/bus/mod.rs
+++ b/crates/trusty-mpm/src/daemon/bus/mod.rs
@@ -60,8 +60,8 @@ pub use envelope::{
 };
 pub use error::BusError;
 pub use inbox::{
-    CLIENT_INBOX_CAPACITY, ClientInbox, DeliveryOutcome, EvictedEnvelope, INBOX_EVICTION_RECORD,
-    InboxEviction, InboxItem, InboxSet, InboxSubscription,
+    CLIENT_INBOX_CAPACITY, ClientInbox, DeliveryOutcome, INBOX_MISS_RECORD, InboxItem, InboxMiss,
+    InboxSet, InboxSubscription, MissReason, MissedEnvelope,
 };
 pub use registry::{InstanceMeta, InstanceRegistry, LiveInstance, PeerTarget};
 
@@ -168,6 +168,49 @@ impl PeerBus {
         Ok(from)
     }
 
+    /// Write one §9 record per client that lost this envelope.
+    ///
+    /// Why it returns a bool rather than swallowing (#6462 review): the
+    /// "nothing is lost without a record" guarantee is only as strong as these
+    /// writes landing, and `log_record` is designed to swallow the failure that
+    /// would break it. Reporting the failure up lets the envelope's own record
+    /// carry the caveat instead of quietly overstating what the stream holds.
+    /// What: writes each [`InboxMiss`] with
+    /// [`AuditLogger::try_log_record`](crate::daemon::audit::AuditLogger::try_log_record)
+    /// and emits one `warn!` per loss naming the client, returning `true` when
+    /// ANY write failed. A failure also gets its own `error!`, because a
+    /// durable-log write failing is an operator-visible condition and not just
+    /// a caveat on one line.
+    /// Test: `eviction_is_recorded_per_client_in_the_durable_log`,
+    /// `an_unwritable_log_never_reports_a_clean_delivery`.
+    fn record_losses(&self, missed: &[MissedEnvelope]) -> bool {
+        let mut unrecorded = false;
+        for loss in missed {
+            if let Err(e) = self.audit.try_log_record(&loss.record()) {
+                unrecorded = true;
+                tracing::error!(
+                    instance_id = %loss.instance_id,
+                    subscription_id = loss.subscription_id,
+                    message_id = %loss.envelope.message_id,
+                    error = %e,
+                    "peer bus could not record an inbox miss; the delivery record \
+                     will be marked losses_unrecorded (#6462)"
+                );
+            }
+            tracing::warn!(
+                instance_id = %loss.instance_id,
+                subscription_id = loss.subscription_id,
+                capacity = CLIENT_INBOX_CAPACITY,
+                message_id = %loss.envelope.message_id,
+                reason = ?loss.reason,
+                missed_total = loss.missed_total,
+                "peer bus inbox lost an envelope for one client: it must re-read \
+                 the durable log (#6462)"
+            );
+        }
+        unrecorded
+    }
+
     /// Publish one peer message, fail-closed.
     ///
     /// Why: this is the §5.3 delivery path and the §4 fail-closed contract in
@@ -195,12 +238,17 @@ impl PeerBus {
     /// **The delivery guarantee (#4271, re-cut per client by #6462).** An
     /// envelope this method records as `Delivered` is readable by every
     /// attached subscription until that subscription reads it, UNLESS this
-    /// method also wrote an [`InboxEviction`] naming that envelope and the one
-    /// subscription that lost it. Nothing is lost without a record. Step 6
-    /// delegates to [`LiveInstance::deliver`], which fans the envelope into one
-    /// bounded buffer per subscription under a single per-instance lock, so
-    /// concurrent publishers cannot hand two clients the same two envelopes in
-    /// opposite orders.
+    /// method also wrote an [`InboxMiss`] naming that envelope and the one
+    /// subscription that lost it — or marked the delivery record
+    /// `losses_unrecorded` because it could not. Nothing is lost without a
+    /// record, and no record is silently absent. Step 6 delegates to
+    /// [`LiveInstance::deliver`], which fans the envelope into one bounded
+    /// buffer per subscription under a single per-instance lock, so concurrent
+    /// publishers cannot hand two clients the same two envelopes in opposite
+    /// orders. A fan-out that NO inbox accepted — every attached subscription
+    /// closed by a deregistration that raced this publish — is
+    /// [`DeliveryOutcome::NoSubscriber`], recorded `Dropped` and answered
+    /// `409`, never `Delivered`.
     ///
     /// Before #4271 an eviction was invisible: `broadcast::Sender::send`
     /// answers `Ok` for a lagging receiver, so the log recorded `Delivered` for
@@ -216,18 +264,43 @@ impl PeerBus {
     /// that stopped draining made this instance refuse every publish to it,
     /// healthy co-subscribers included, unboundedly. Per-client inboxes remove
     /// the shared quantity that made that possible: a stalled client falls
-    /// behind alone, its cost to the instance is a fixed
-    /// [`CLIENT_INBOX_CAPACITY`] envelopes of memory, and it stops costing even
-    /// that when its subscription drops. No timer is needed and none is added.
-    /// The recovery for a client that fell behind is unchanged from #4271:
-    /// re-read the §9 durable log, whose path the `lagged` SSE frame carries.
+    /// behind alone, and no publisher or co-subscriber pays for it at all. The
+    /// recovery for a client that fell behind is unchanged from #4271: re-read
+    /// the §9 durable log, whose path the `lagged` SSE frame carries.
     ///
-    /// **Eviction records are written BEFORE the delivery record.** The
-    /// eviction has already happened in memory by the time either write runs,
-    /// so the ordering only decides which way a crash between them lies. This
-    /// way it under-claims — the loss is on record and the delivery that caused
-    /// it is not — where the other way round would leave a `delivered` record
-    /// with nothing explaining the gap, which is #4271 exactly.
+    /// **What a wedged client still costs, stated exactly.** A client that
+    /// disconnects costs nothing — its subscription drops and detaches. A
+    /// client that stays attached and never reads — a TCP-wedged SSE body,
+    /// where hyper stops polling the response body without dropping the future,
+    /// so `Drop` never runs — costs its instance a bounded
+    /// [`CLIENT_INBOX_CAPACITY`]-envelope buffer PLUS one [`InboxMiss`] line in
+    /// the durable log and one `warn!` per subsequent publish, for as long as
+    /// it stays attached. No timer bounds that, deliberately; the operator's
+    /// lever is deregistering the instance, and the `warn!` names which
+    /// instance and subscription. See [`inbox`]'s module doc.
+    ///
+    /// **Loss records are written BEFORE the delivery record, and their
+    /// failures are observed.** The loss has already happened in memory by the
+    /// time either write runs, so the ordering only decides which way an
+    /// interruption lies. This way it under-claims — the loss is on record and
+    /// the delivery that caused it is not — where the other way round would
+    /// leave a `delivered` record with nothing explaining the gap, which is
+    /// #4271 exactly.
+    ///
+    /// Ordering alone is not enough, because
+    /// [`AuditLogger::log_record`](crate::daemon::audit::AuditLogger::log_record)
+    /// swallows IO errors by §9's deliberate never-fail-the-hot-path design: a
+    /// loss record that failed to write, followed by an envelope record that
+    /// succeeded, would produce exactly the clean unexplained `delivered` line
+    /// this ordering exists to prevent. Loss records therefore go through
+    /// [`AuditLogger::try_log_record`](crate::daemon::audit::AuditLogger::try_log_record),
+    /// and if ANY of them fails the envelope's own record is written with
+    /// `losses_unrecorded: true` and an `error!` is emitted. A reader that sees
+    /// that flag knows this delivery lost envelopes the stream cannot
+    /// enumerate; a reader that does not see it knows the loss records for that
+    /// `message_id` are complete. The hot path is still never failed — the
+    /// sender gets its `202` either way, because the envelope did reach the
+    /// clients that took it.
     ///
     /// **What the durable §9 log does and does not contain.** Once a sender is
     /// verified (step 3), EVERY outcome is recorded — delivered or dropped —
@@ -249,6 +322,8 @@ impl PeerBus {
     /// `delivered_records_account_for_everything_a_stalled_subscriber_lost`,
     /// `eviction_is_recorded_per_client_in_the_durable_log`,
     /// `a_wedged_client_does_not_refuse_publishes_for_a_healthy_co_subscriber`,
+    /// `a_publish_racing_deregistration_is_not_recorded_delivered`,
+    /// `an_unwritable_log_never_reports_a_clean_delivery`,
     /// `concurrent_publishers_lose_nothing_without_a_record`.
     pub fn publish(
         &self,
@@ -307,22 +382,9 @@ impl PeerBus {
         // that is supposed to settle "sent or not" — #4271 is what that lie
         // looked like in practice.
         match live.deliver(envelope.clone()) {
-            DeliveryOutcome::Delivered { evicted } => {
-                // Losses first, so a crash between the two writes leaves the
-                // log under-claiming rather than repeating #4271.
-                for loss in &evicted {
-                    self.audit.log_record(&loss.record());
-                    tracing::warn!(
-                        instance_id = %loss.instance_id,
-                        subscription_id = loss.subscription_id,
-                        capacity = CLIENT_INBOX_CAPACITY,
-                        message_id = %loss.envelope.message_id,
-                        missed_total = loss.missed_total,
-                        "peer bus inbox displaced an unread envelope: this client \
-                         is behind and must re-read the durable log (#6462)"
-                    );
-                }
-                self.audit.log_record(&envelope);
+            DeliveryOutcome::Delivered { missed } => {
+                self.audit
+                    .log_record(&EnvelopeRecord::new(&envelope, self.record_losses(&missed)));
                 Ok(envelope)
             }
             DeliveryOutcome::NoSubscriber => {
@@ -332,6 +394,41 @@ impl PeerBus {
                     instance_id: live.meta.instance_id,
                 })
             }
+        }
+    }
+}
+
+/// The §9 line written for one published envelope.
+///
+/// Why a wrapper rather than a field on [`BusEnvelope`]: the envelope is
+/// DOC-60 §11's schema and travels back to the sender over HTTP; whether this
+/// daemon managed to write its companion loss records is a fact about the log,
+/// not about the message. `serde(flatten)` means a delivery whose losses were
+/// all recorded serializes byte-identically to the bare envelope, so §11
+/// fidelity and every existing reader are unaffected — the extra key appears
+/// only in the case it describes.
+/// What: the envelope's own fields, plus `losses_unrecorded: true` when a
+/// companion [`InboxMiss`] could not be written. See
+/// [`PeerBus::record_losses`].
+/// Test: `an_unwritable_log_never_reports_a_clean_delivery`,
+/// `a_fully_recorded_delivery_serializes_as_a_bare_envelope`.
+#[derive(Debug, serde::Serialize)]
+pub struct EnvelopeRecord<'a> {
+    /// The envelope, inlined so the line keeps §11's shape.
+    #[serde(flatten)]
+    pub envelope: &'a BusEnvelope,
+    /// Present only when true: this delivery lost envelopes for one or more
+    /// clients and at least one of those losses could not be written.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub losses_unrecorded: bool,
+}
+
+impl<'a> EnvelopeRecord<'a> {
+    /// Wrap `envelope` for the §9 stream.
+    pub fn new(envelope: &'a BusEnvelope, losses_unrecorded: bool) -> Self {
+        Self {
+            envelope,
+            losses_unrecorded,
         }
     }
 }

--- a/crates/trusty-mpm/src/daemon/bus/registry.rs
+++ b/crates/trusty-mpm/src/daemon/bus/registry.rs
@@ -8,8 +8,9 @@
 //! and instance-bypass validates against it.
 //! What: [`InstanceRegistry`], keyed by instance id, holding one
 //! [`LiveInstance`] per running assistant — its public [`InstanceMeta`] plus
-//! the per-instance delivery channel. Registration mints the id; resolution
-//! is fail-closed in both modes.
+//! the [`InboxSet`] holding one bounded buffer per attached subscription
+//! (`super::inbox`, #6462). Registration mints the id; resolution is
+//! fail-closed in both modes.
 //! Test: `bus::tests` — `register_mints_prefixed_id`,
 //! `resolve_definition_picks_most_recent`, `resolve_definition_missing_errors`,
 //! `bypass_to_dead_instance_errors_not_falls_back`,
@@ -50,35 +51,16 @@
 //! Gone` vs `404 Not Found`), so a client can implement the re-address
 //! recovery without parsing a message string.
 
+use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
 
 use dashmap::DashMap;
 use dashmap::mapref::entry::Entry;
 use serde::{Deserialize, Serialize};
-use tokio::sync::broadcast;
 
 use super::BusError;
 use super::envelope::BusEnvelope;
-
-/// How many envelopes a single instance's channel buffers before lagging.
-///
-/// Why: a subscriber that stalls must not block the publisher. A small buffer
-/// is right for peer messages, which are low-volume by construction —
-/// streaming token deltas stay on the existing per-crate buses and never reach
-/// this one.
-///
-/// Public since #4271: it is the depth at which [`LiveInstance::deliver`]
-/// answers [`DeliveryOutcome::Saturated`] instead of sending, so it is part of
-/// the delivery contract a sender reasons about, not an implementation detail.
-/// Test: `saturated_publish_is_dropped_in_the_durable_log`.
-pub const INSTANCE_CHANNEL_CAPACITY: usize = 64;
-
-// #4271: tokio rounds a broadcast capacity UP to a power of two, so a
-// non-rounded value would give a ring deeper than this constant and `deliver`
-// would refuse a publish before an eviction was actually imminent. Keeping it
-// already-rounded makes the two exactly equal.
-const _: () = assert!(INSTANCE_CHANNEL_CAPACITY.is_power_of_two());
+use super::inbox::{DeliveryOutcome, InboxSet, InboxSubscription};
 
 /// Separator between the definition id and the random suffix in an instance id.
 ///
@@ -159,104 +141,85 @@ pub struct InstanceMeta {
 /// recipient; consumers filter client-side after the fact"), so giving each
 /// instance its own channel is what makes this bus genuinely addressed rather
 /// than a sixth unaddressed broadcast.
-/// What: [`InstanceMeta`], the sender half of that instance's channel, and the
-/// gate [`LiveInstance::deliver`] holds to keep its saturation check and its
-/// send indivisible. Every clone of a `LiveInstance` shares that gate, so two
-/// publishers that each resolved the instance separately still serialize.
+/// What: [`InstanceMeta`] plus the [`InboxSet`] holding one bounded buffer per
+/// attached subscription. Every clone of a `LiveInstance` shares that set, so
+/// two publishers that each resolved the instance separately still fan out
+/// through the same lock and agree on an order.
 /// Test: `publish_reaches_only_target_instance`,
-/// `concurrent_publishers_never_evict_a_delivered_envelope`.
+/// `concurrent_publishers_lose_nothing_without_a_record`.
 #[derive(Debug, Clone)]
 pub struct LiveInstance {
     /// The instance's public metadata.
     pub meta: InstanceMeta,
-    /// Sender half of this instance's own delivery channel.
+    /// One [`ClientInbox`](super::inbox::ClientInbox) per attached
+    /// subscription.
     ///
-    /// Crate-internal since #4271: a send made directly on this opts out of
-    /// [`LiveInstance::deliver`]'s check, and the "no envelope recorded
-    /// `delivered` is ever evicted unread" guarantee is only as good as the
-    /// absence of such a send. Subscribing goes through
-    /// [`PeerBus::subscribe`](super::PeerBus::subscribe); publishing goes
-    /// through [`PeerBus::publish`](super::PeerBus::publish). The bus's own
-    /// tests reach for it to stage a lag the publish path now refuses to
-    /// create.
-    pub(super) tx: broadcast::Sender<BusEnvelope>,
-    /// Serializes [`LiveInstance::deliver`]'s check with the send it guards.
-    delivery_gate: Arc<Mutex<()>>,
-}
-
-/// What one delivery attempt actually did (#4271).
-///
-/// Why: the publisher must write a durable record stating what happened, and
-/// the three outcomes carry different records and different errors. Returning
-/// them as one value keeps the decision with the code that holds the gate —
-/// a caller cannot re-derive "was it saturated?" afterwards, because by then
-/// the answer has changed.
-/// What: the three terminal states of a send into an instance's channel.
-/// Test: `delivered_records_match_what_a_stalled_subscriber_receives`,
-/// `publish_without_subscriber_errors`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum DeliveryOutcome {
-    /// The envelope is in the channel and no unread envelope was displaced.
-    Delivered,
-    /// The channel is full of envelopes no subscriber has read; nothing sent.
-    Saturated,
-    /// The instance is registered but has no attached receiver.
-    NoSubscriber,
+    /// Private, and reachable only through [`LiveInstance::subscribe`] and
+    /// [`LiveInstance::deliver`]: #4271's defect was a send that bypassed the
+    /// delivery bookkeeping, and the "nothing is lost without a record"
+    /// guarantee is only as good as the absence of such a send. Subscribing
+    /// goes through [`PeerBus::subscribe`](super::PeerBus::subscribe);
+    /// publishing goes through [`PeerBus::publish`](super::PeerBus::publish).
+    inboxes: Arc<InboxSet>,
 }
 
 impl LiveInstance {
-    /// Send one envelope, refusing rather than displacing an unread one.
+    /// Attach a new subscription to this instance.
     ///
-    /// Why (#4271): `broadcast::Sender::send` answers `Ok` for a LAGGING
-    /// receiver — one still attached, whose oldest unread slot the send is
-    /// about to overwrite. A publisher reading only that `Ok` cannot tell
-    /// delivery from eviction, so it recorded `delivered` for envelopes the
-    /// recipient never saw. The channel must therefore be measured BEFORE the
-    /// send, which is the only point at which the difference is still
-    /// observable: afterwards the evicted envelope is gone and nothing in the
-    /// channel remembers it existed.
+    /// Why per subscription rather than per instance (#6462): the buffer IS the
+    /// delivery boundary, so giving each client its own is what stops one
+    /// stalled client from spending another's budget. See
+    /// [`super::inbox`]'s module doc.
+    /// What: mints a subscription id and returns its reader handle, which
+    /// detaches on drop.
+    /// Test: `publish_reaches_only_target_instance`,
+    /// `a_detached_subscription_stops_costing_the_instance`.
+    pub(super) fn subscribe(&self) -> InboxSubscription {
+        self.inboxes.attach(&self.meta.instance_id)
+    }
+
+    /// Deliver one envelope into every attached client's inbox.
     ///
-    /// Why the gate: `Sender::len` and `Sender::send` each take and release the
-    /// channel's tail lock, so a measurement outside a lock of our own is stale
-    /// by the time the send retakes it. Two publishers that both observed
-    /// `capacity - 1` would both send, and the second would evict — the same
-    /// fail-open narrowed to a window rather than closed. Holding
-    /// `delivery_gate` across both makes the pair indivisible. The cost is
-    /// serializing publishes to ONE instance, which is what
-    /// [`INSTANCE_CHANNEL_CAPACITY`]'s own rationale already assumes: peer
-    /// messages are low-volume by construction, and the guarded section is a
-    /// length read plus a memcpy into a ring — no IO, no await.
+    /// Why this can no longer refuse (#6462): the shared 64-slot broadcast ring
+    /// it replaced measured backlog across every attached receiver and could
+    /// not send to a subset, so keeping the §9 log truthful meant refusing the
+    /// publish — and one client that stopped reading refused every publish to
+    /// the instance. Each client now has its own buffer, so a stalled client
+    /// falls behind alone: its inbox displaces its own oldest unread envelope
+    /// and the loss is returned here to be recorded, rather than charged to the
+    /// publisher or to a healthy co-subscriber.
     ///
-    /// The guarantee is scoped to this method: an envelope sent through
-    /// `deliver` never displaces an unread one. A caller that reaches for
-    /// [`LiveInstance::tx`] directly opts out of it, which only the tests do.
+    /// The guarantee is scoped to this method and its logging caller: an
+    /// envelope recorded `delivered` is readable by every attached subscription
+    /// until that subscription reads it, UNLESS the §9 stream also carries an
+    /// [`InboxEviction`](super::inbox::InboxEviction) naming that envelope and
+    /// the subscription that lost it. Nothing else writes into an inbox.
     ///
-    /// What: locks the gate, then reports [`DeliveryOutcome::Saturated`] when
-    /// the channel already holds [`INSTANCE_CHANNEL_CAPACITY`] envelopes some
-    /// attached receiver has not read, [`DeliveryOutcome::NoSubscriber`] when
-    /// nothing is attached, and [`DeliveryOutcome::Delivered`] otherwise.
-    /// `Sender::len` counts slots no attached receiver has consumed, so
-    /// saturation is driven by the SLOWEST subscriber — a fast peer draining
-    /// alongside a stalled one does not mask the lag.
-    /// Test: `delivered_records_match_what_a_stalled_subscriber_receives`,
-    /// `two_subscribers_one_lagging_account_exactly`,
-    /// `concurrent_publishers_never_evict_a_delivered_envelope`.
+    /// What: delegates to [`InboxSet::fan_out`], which holds the instance's one
+    /// lock across the whole fan-out so concurrent publishers cannot hand two
+    /// clients the same two envelopes in opposite orders.
+    /// Test: `two_subscribers_one_lagging_account_exactly`,
+    /// `eviction_is_recorded_per_client_in_the_durable_log`,
+    /// `concurrent_publishers_lose_nothing_without_a_record`.
     pub fn deliver(&self, envelope: BusEnvelope) -> DeliveryOutcome {
-        // A panic cannot leave shared state inconsistent here — the gate guards
-        // a unit value, and the guarded section neither allocates a lock-owned
-        // invariant nor calls user code — so poisoning is recovered rather than
-        // turned into a publish failure.
-        let _gate = self
-            .delivery_gate
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if self.tx.len() >= INSTANCE_CHANNEL_CAPACITY {
-            return DeliveryOutcome::Saturated;
-        }
-        match self.tx.send(envelope) {
-            Ok(_) => DeliveryOutcome::Delivered,
-            Err(_) => DeliveryOutcome::NoSubscriber,
-        }
+        self.inboxes.fan_out(envelope)
+    }
+
+    /// How many subscriptions are attached.
+    ///
+    /// Test: `a_detached_subscription_stops_costing_the_instance`.
+    pub fn subscriber_count(&self) -> usize {
+        self.inboxes.len()
+    }
+
+    /// End every attached subscription once it has drained what it holds.
+    ///
+    /// Why: dropping the broadcast `Sender` used to do this implicitly. With
+    /// per-client queues the end has to be stated, and it must not discard what
+    /// the §9 log already recorded delivered — so the reader drains first.
+    /// Test: `deregister_ends_a_subscription_after_it_drains`.
+    fn close_subscribers(&self) {
+        self.inboxes.close_all();
     }
 }
 
@@ -368,11 +331,9 @@ impl InstanceRegistry {
                         registered_at: chrono::Utc::now().to_rfc3339(),
                         seq,
                     };
-                    let (tx, _) = broadcast::channel(INSTANCE_CHANNEL_CAPACITY);
                     vacant.insert(LiveInstance {
                         meta: meta.clone(),
-                        tx,
-                        delivery_gate: Arc::new(Mutex::new(())),
+                        inboxes: Arc::new(InboxSet::default()),
                     });
                     return Ok(meta);
                 }
@@ -394,10 +355,20 @@ impl InstanceRegistry {
     /// Why: an instance that exited must stop resolving, or definition-
     /// addressed delivery would route to a dead channel and bypass would
     /// silently succeed against a corpse.
-    /// What: removes the entry; returns whether one was present.
-    /// Test: `deregister_makes_instance_gone`.
+    /// What: removes the entry and ends its subscriptions once they have
+    /// drained ([`LiveInstance::close_subscribers`]); returns whether one was
+    /// present. The close is explicit since #6462 — a per-client inbox has no
+    /// `Sender` whose drop would end the stream for it.
+    /// Test: `deregister_makes_instance_gone`,
+    /// `deregister_ends_a_subscription_after_it_drains`.
     pub fn deregister(&self, instance_id: &str) -> bool {
-        self.instances.remove(instance_id).is_some()
+        match self.instances.remove(instance_id) {
+            Some((_, live)) => {
+                live.close_subscribers();
+                true
+            }
+            None => false,
+        }
     }
 
     /// Resolve a definition to its most-recently-registered live instance.
@@ -409,7 +380,10 @@ impl InstanceRegistry {
     /// therefore testable.
     /// What: scans live instances for `definition_id`, returning the highest
     /// [`InstanceMeta::seq`]; fails closed with [`BusError::NoLiveInstance`]
-    /// when none matches — queueing to a durable inbox is DOC-60 §7, deferred.
+    /// when none matches. #6462 built §7's inbox for a LIVE client's
+    /// subscription; §7's other half — queueing to a definition with no running
+    /// instance, without spawning one — is still deferred, so a definition that
+    /// resolves to nothing still fails rather than queues.
     /// Test: `resolve_definition_picks_most_recent`,
     /// `resolve_definition_missing_errors`.
     pub fn resolve_definition(&self, definition_id: &str) -> Result<LiveInstance, BusError> {

--- a/crates/trusty-mpm/src/daemon/bus/registry.rs
+++ b/crates/trusty-mpm/src/daemon/bus/registry.rs
@@ -192,8 +192,8 @@ impl LiveInstance {
     /// The guarantee is scoped to this method and its logging caller: an
     /// envelope recorded `delivered` is readable by every attached subscription
     /// until that subscription reads it, UNLESS the §9 stream also carries an
-    /// [`InboxEviction`](super::inbox::InboxEviction) naming that envelope and
-    /// the subscription that lost it. Nothing else writes into an inbox.
+    /// [`InboxMiss`](super::inbox::InboxMiss) naming that envelope and the
+    /// subscription that lost it. Nothing else writes into an inbox.
     ///
     /// What: delegates to [`InboxSet::fan_out`], which holds the instance's one
     /// lock across the whole fan-out so concurrent publishers cannot hand two

--- a/crates/trusty-mpm/src/daemon/bus/routes.rs
+++ b/crates/trusty-mpm/src/daemon/bus/routes.rs
@@ -31,15 +31,13 @@ use axum::{
 };
 use futures::Stream;
 use serde::{Deserialize, Serialize};
-use tokio_stream::StreamExt;
-use tokio_stream::wrappers::BroadcastStream;
-use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
 
 use crate::daemon::error::DaemonError;
 use crate::daemon::state::DaemonState;
 
 use super::envelope::{BusEnvelope, BusPayload, CallerIdentity};
 use super::error::BusError;
+use super::inbox::InboxItem;
 use super::registry::{InstanceMeta, PeerTarget};
 
 /// The peer bus's self-contained sub-router, merged into the daemon router.
@@ -269,19 +267,18 @@ pub fn list_op(state: &Arc<DaemonState>) -> ListInstancesResponse {
 /// status (`400` malformed request or a caller kind this path does not carry,
 /// `403` the claimed sender is not a live registration, `404` no live
 /// instance, `410` the named instance is gone, `409` registered but
-/// unattached, `503` attached but its channel is full of unread envelopes) per
-/// §4's fail-closed rule.
+/// unattached) per §4's fail-closed rule.
 ///
-/// **`503` is terminal for this attempt, and a retry is the recovery (#4271).**
-/// The message was not delivered and not queued — DOC-60 §7's durable inbox is
-/// deferred — so a sender that wants it delivered must send it again once the
-/// recipient drains. Two consequences a client author has to plan for: the
-/// refusal is per-INSTANCE and one stalled subscriber makes every publish to
-/// that instance answer `503`, healthy co-subscribers included; and the
-/// condition persists until that subscriber drains, drops, or the instance is
-/// deregistered, so retry with backoff rather than in a tight loop. See
-/// [`PeerBus::publish`](crate::daemon::bus::PeerBus::publish) for why nothing
-/// bounds it here.
+/// **A slow recipient no longer refuses the publish (#6462).** Between #4271
+/// and #6462 this endpoint answered `503` when the recipient's shared channel
+/// was full of unread envelopes, and one stalled subscriber made every publish
+/// to that instance answer `503` — healthy co-subscribers included, until it
+/// drained, dropped, or the instance was deregistered. Each subscription now
+/// has its own buffer, so a stalled client falls behind alone and this endpoint
+/// answers `202` while that client's inbox displaces its own oldest unread
+/// envelope. The loss is recorded in the DOC-60 §9 durable log and announced to
+/// the affected client as a [`LAGGED_EVENT`] frame; the sender is not involved
+/// and has nothing to retry. `503` is no longer a status this endpoint returns.
 /// What: resolves the target, publishes, and returns the stamped envelope with
 /// `202 Accepted` so the sender holds the `message_id` for threading. The
 /// `from` field is a CLAIM: [`PeerBus::publish`](crate::daemon::bus::PeerBus::publish)
@@ -290,7 +287,8 @@ pub fn list_op(state: &Arc<DaemonState>) -> ListInstancesResponse {
 /// Test: `route_publish_to_dead_instance_is_410`,
 /// `route_publish_delivers_and_returns_envelope`,
 /// `route_publish_forged_user_kind_is_400`,
-/// `route_publish_unregistered_sender_is_403`.
+/// `route_publish_unregistered_sender_is_403`,
+/// `route_publish_past_a_stalled_subscriber_is_accepted`.
 pub async fn publish_message(
     State(state): State<Arc<DaemonState>>,
     Json(req): Json<PublishRequest>,
@@ -314,10 +312,10 @@ pub async fn publish_message(
 ///
 /// # Errors
 ///
-/// Every [`BusError`] `PeerBus::publish` can raise — including
-/// [`BusError::SubscriberLagged`] (`503` / `CODE_UNAVAILABLE`) when the
-/// recipient's channel is full of unread envelopes — plus
+/// Every [`BusError`] `PeerBus::publish` can raise, plus
 /// [`BusError::InvalidTarget`] when the request names neither addressing mode.
+/// A recipient whose subscriber has stopped reading is NOT among them since
+/// #6462 — see [`publish_message`]'s doc.
 ///
 /// Test: `parity_bus_publish_agrees_across_transports`,
 /// `rpc_bus_publish_rejects_a_forged_user_kind`,
@@ -325,7 +323,7 @@ pub async fn publish_message(
 /// `rpc_bus_publish_to_a_dead_instance_is_gone`,
 /// `rpc_bus_publish_without_a_subscriber_is_conflict`,
 /// `rpc_bus_publish_without_a_target_is_invalid`,
-/// `route_publish_to_a_saturated_instance_is_503`.
+/// `route_publish_past_a_stalled_subscriber_is_accepted`.
 pub fn publish_op(state: &Arc<DaemonState>, req: PublishRequest) -> Result<BusEnvelope, BusError> {
     let target = req.to.to_peer_target()?;
     state
@@ -344,18 +342,23 @@ pub const LAGGED_EVENT: &str = "lagged";
 
 /// What a `lagged` SSE frame carries.
 ///
-/// Why: a subscriber that fell behind needs three things to recover — that it
-/// happened, how many envelopes it missed, and where to read them. The durable
-/// §9 JSONL stream holds every envelope the bus recorded as delivered, so
-/// naming its path makes the recovery a file read rather than a lost message.
-/// What: the instance whose stream lagged, the count the channel reports, and
-/// the durable log's resolved path.
+/// Why: a subscriber that fell behind needs four things to recover — that it
+/// happened, how many envelopes it missed, where to read them, and under which
+/// key. The durable §9 JSONL stream holds every envelope the bus recorded as
+/// delivered plus, since #6462, one
+/// [`InboxEviction`](crate::daemon::bus::InboxEviction) per envelope this
+/// subscription lost, keyed by `subscription_id` — so naming the path and the
+/// id makes the recovery a file read rather than a lost message.
+/// What: the instance, the subscription, the count its inbox displaced, and the
+/// durable log's resolved path.
 /// Test: `subscribe_stream_reports_lag_instead_of_swallowing_it`.
 #[derive(Debug, Serialize)]
 pub struct LagNotice {
     /// The instance whose subscription fell behind.
     pub instance_id: String,
-    /// How many envelopes the channel dropped for this subscriber.
+    /// Which subscription fell behind — the key its eviction records carry.
+    pub subscription_id: u64,
+    /// How many envelopes this subscription's inbox displaced unread.
     pub missed: u64,
     /// Path to the DOC-60 §9 durable stream to re-read them from.
     pub durable_log: String,
@@ -375,37 +378,57 @@ pub struct LagNotice {
 /// Here the skipped frames were addressed messages the durable log had already
 /// recorded as delivered, so the recipient lost them and was told nothing. A
 /// lag now arrives as a [`LAGGED_EVENT`] frame carrying a [`LagNotice`], plus a
-/// `warn!`. [`PeerBus::publish`](crate::daemon::bus::PeerBus::publish) refuses a
-/// saturated channel, so a lag reaching here means concurrent publishes raced
-/// past that check — rare, and exactly the case worth announcing.
+/// `warn!`. Since #6462 this stream reads THIS subscription's own inbox, so a
+/// lag here means this client fell
+/// [`CLIENT_INBOX_CAPACITY`](super::inbox::CLIENT_INBOX_CAPACITY) behind —
+/// nobody else's backlog can produce one, and no other client is slowed by it.
+///
+/// **The subscription ends when its body is dropped or the instance is
+/// deregistered.** Dropping the body detaches the inbox, which is what keeps a
+/// disconnected client from holding envelopes nobody will read; deregistration
+/// lets the reader drain what it already holds and then ends the stream.
 /// Test: `subscribe_to_dead_instance_errors`,
 /// `publish_reaches_only_target_instance`,
-/// `subscribe_stream_reports_lag_instead_of_swallowing_it`.
+/// `subscribe_stream_reports_lag_instead_of_swallowing_it`,
+/// `deregister_ends_a_subscription_after_it_drains`.
 pub async fn subscribe_instance(
     State(state): State<Arc<DaemonState>>,
     Path(instance_id): Path<String>,
 ) -> Result<Sse<impl Stream<Item = Result<Event, Infallible>>>, BusError> {
-    let rx = state.bus().subscribe(&instance_id)?;
+    let subscription = state.bus().subscribe(&instance_id)?;
     let durable_log = state.bus().log_path().display().to_string();
-    let stream = BroadcastStream::new(rx).filter_map(move |msg| match msg {
-        Ok(envelope) => match Event::default().json_data(&envelope) {
-            Ok(event) => Some(Ok(event)),
-            Err(e) => {
-                tracing::error!(
-                    message_id = %envelope.message_id,
-                    error = %e,
-                    "peer bus envelope could not be serialized onto the SSE stream"
-                );
-                None
+    let stream = futures::stream::unfold(subscription, move |subscription| {
+        let instance_id = instance_id.clone();
+        let durable_log = durable_log.clone();
+        async move {
+            loop {
+                match subscription.recv().await? {
+                    InboxItem::Envelope(envelope) => match Event::default().json_data(&*envelope) {
+                        Ok(event) => return Some((Ok(event), subscription)),
+                        Err(e) => {
+                            // The envelope is already consumed, so this arm
+                            // advances the reader rather than stalling it.
+                            tracing::error!(
+                                message_id = %envelope.message_id,
+                                error = %e,
+                                "peer bus envelope could not be serialized onto the SSE stream"
+                            );
+                        }
+                    },
+                    InboxItem::Lagged(missed) => {
+                        let subscription_id = subscription.subscription_id();
+                        tracing::warn!(
+                            instance_id = %instance_id,
+                            subscription_id,
+                            missed,
+                            "peer bus subscriber lagged; its inbox displaced unread \
+                             envelopes (#6462)"
+                        );
+                        let frame = lag_frame(&instance_id, subscription_id, missed, &durable_log);
+                        return Some((Ok(frame), subscription));
+                    }
+                }
             }
-        },
-        Err(BroadcastStreamRecvError::Lagged(missed)) => {
-            tracing::warn!(
-                instance_id = %instance_id,
-                missed,
-                "peer bus subscriber lagged; envelopes were evicted unread (#4271)"
-            );
-            Some(Ok(lag_frame(&instance_id, missed, &durable_log)))
         }
     });
     Ok(Sse::new(stream).keep_alive(KeepAlive::default()))
@@ -413,13 +436,14 @@ pub async fn subscribe_instance(
 
 /// Build the [`LAGGED_EVENT`] frame, keeping the count reachable either way.
 ///
-/// Why the fallback: serializing three owned scalars cannot fail, but mapping a
+/// Why the fallback: serializing four owned scalars cannot fail, but mapping a
 /// hypothetical failure to `None` would reinstate the silent skip this whole
 /// change removes. The plain-text form still carries the number that matters.
 /// Test: `subscribe_stream_reports_lag_instead_of_swallowing_it`.
-fn lag_frame(instance_id: &str, missed: u64, durable_log: &str) -> Event {
+fn lag_frame(instance_id: &str, subscription_id: u64, missed: u64, durable_log: &str) -> Event {
     let notice = LagNotice {
         instance_id: instance_id.to_string(),
+        subscription_id,
         missed,
         durable_log: durable_log.to_string(),
     };

--- a/crates/trusty-mpm/src/daemon/bus/routes.rs
+++ b/crates/trusty-mpm/src/daemon/bus/routes.rs
@@ -346,9 +346,9 @@ pub const LAGGED_EVENT: &str = "lagged";
 /// happened, how many envelopes it missed, where to read them, and under which
 /// key. The durable §9 JSONL stream holds every envelope the bus recorded as
 /// delivered plus, since #6462, one
-/// [`InboxEviction`](crate::daemon::bus::InboxEviction) per envelope this
-/// subscription lost, keyed by `subscription_id` — so naming the path and the
-/// id makes the recovery a file read rather than a lost message.
+/// [`InboxMiss`](crate::daemon::bus::InboxMiss) per envelope this subscription
+/// lost, keyed by `subscription_id` — so naming the path and the id makes the
+/// recovery a file read rather than a lost message.
 /// What: the instance, the subscription, the count its inbox displaced, and the
 /// durable log's resolved path.
 /// Test: `subscribe_stream_reports_lag_instead_of_swallowing_it`.

--- a/crates/trusty-mpm/src/daemon/bus/tests.rs
+++ b/crates/trusty-mpm/src/daemon/bus/tests.rs
@@ -887,12 +887,6 @@ fn eviction_is_recorded_per_client_in_the_durable_log() {
         assert_eq!(miss.instance_id, target.instance_id);
         assert_eq!(miss.subscription_id, stalled.subscription_id());
         assert_eq!(
-            miss.reason,
-            MissReason::Displaced,
-            "a full inbox displaces; that is not the same loss as a closed \
-             subscription"
-        );
-        assert_eq!(
             miss.missed_total,
             n as u64 + 1,
             "the running loss count must let a reader tell how far behind this \
@@ -934,11 +928,6 @@ fn miss_records_are_distinguishable_from_envelopes() {
         lines.iter().filter(|v| v.get("record").is_some()).collect();
     assert_eq!(tagged.len(), 1);
     assert_eq!(tagged[0]["record"], INBOX_MISS_RECORD);
-    assert_eq!(
-        tagged[0]["reason"], "displaced",
-        "a miss line must say WHY, so a reader can tell a slow client from a \
-         deregistered one"
-    );
     assert!(
         lines
             .iter()
@@ -1373,43 +1362,135 @@ fn a_publish_racing_deregistration_is_not_recorded_delivered() {
     );
 }
 
-#[test]
-fn a_publish_racing_deregistration_records_the_closed_subscriptions_miss() {
-    // The partial case the same defect produces more quietly: one subscription
-    // closed, one open. The open one takes the envelope, so the publish IS a
-    // delivery — but the closed one loses it, and that loss needs a record with
-    // its own reason, or the `delivered` line over-claims for that client.
+#[tokio::test]
+async fn a_subscription_attached_after_deregistration_ends_rather_than_parking() {
+    // #6462 review round 2, HIGH. `PeerBus::subscribe` resolves the instance
+    // and THEN attaches, so an attach can land after `close_all` has already
+    // walked the set. Before the fix that produced an inbox with `closed:
+    // false` that nothing would ever close — the instance is out of the
+    // registry, so no publisher can reach it and no second deregister can fire.
+    // `recv` parked forever (`try_recv` None, `is_finished` false, no waker
+    // left alive) and the SSE handler held the stream open with keep-alives
+    // indefinitely. The retired `broadcast` ended that stream immediately, so
+    // this was a regression, and it contradicted `subscribe_instance`'s own
+    // doc.
+    //
+    // The `timeout` is the assertion: a parked `recv` never resolves, so a
+    // pending future IS the failure. Against the pre-fix source this test hung
+    // here and reported the elapsed-timeout panic below.
     let (_dir, bus) = bus();
     let target = bus.registry().register("cto-assistant", None).unwrap();
-    let sender = registered_sender(&bus, "izzie");
-    let closing = bus.subscribe(&target.instance_id).unwrap();
     let stale = bus
         .registry()
         .resolve_instance(&target.instance_id)
         .unwrap();
     assert!(bus.registry().deregister(&target.instance_id));
-    // A second subscription attached through the same stale clone: open, in the
-    // same set as the closed one. Only an in-crate holder of a stale clone can
-    // reach this state, which is exactly what makes it worth pinning.
-    let open = stale.subscribe();
 
-    let envelope = envelope_for(sender, &target, "one takes it, one cannot");
-    let message_id = envelope.message_id.clone();
-    let DeliveryOutcome::Delivered { missed } = stale.deliver(envelope) else {
-        panic!("the open subscription took it, so this is a delivery");
-    };
-
-    assert_eq!(missed.len(), 1, "exactly the closed subscription lost it");
-    assert_eq!(missed[0].subscription_id, closing.subscription_id());
-    assert_eq!(missed[0].reason, MissReason::SubscriptionClosed);
+    let late = stale.subscribe();
+    let ended = tokio::time::timeout(std::time::Duration::from_secs(5), late.recv())
+        .await
+        .expect("a subscription attached after deregistration must not park forever");
     assert_eq!(
-        missed[0].envelope.message_id, message_id,
-        "a closed subscription loses THIS envelope, not a displaced older one"
+        ended, None,
+        "it has nothing to drain and its instance is gone, so it ends at once"
     );
+}
+
+#[test]
+fn a_closed_subscription_reads_its_queue_without_a_hoisted_lag_notice() {
+    // #6462 review round 2, LOW. `try_recv` yields lag before the queue, which
+    // is right for a displacement — the lost envelope came off the front, where
+    // the reader is — and wrong for a refusal, where the lost envelope is the
+    // newest. A refusal therefore does not touch `pending_lag`: a client acting
+    // on a notice hoisted ahead of envelopes it has not read yet would re-read
+    // the durable log from the wrong point in its own stream. The loss is still
+    // counted and still recorded.
+    let (_dir, bus) = bus();
+    let target = bus.registry().register("cto-assistant", None).unwrap();
+    let sender = registered_sender(&bus, "izzie");
+    let subscription = bus.subscribe(&target.instance_id).unwrap();
+    let held = bus
+        .publish(
+            sender.clone(),
+            &PeerTarget::Instance(target.instance_id.clone()),
+            chat("queued before the shutdown"),
+            None,
+        )
+        .unwrap();
+
+    let stale = bus
+        .registry()
+        .resolve_instance(&target.instance_id)
+        .unwrap();
+    assert!(bus.registry().deregister(&target.instance_id));
+    // A publish through the stale clone: refused by the now-closed inbox.
+    let outcome = stale.deliver(envelope_for(sender, &target, "too late"));
+    assert_eq!(outcome, DeliveryOutcome::NoSubscriber);
+
+    assert_eq!(
+        subscription.evicted_total(),
+        0,
+        "a refusal raises no gap for this client to act on — the envelope \
+         reached nobody and is recorded dropped"
+    );
+    match subscription.try_recv() {
+        Some(InboxItem::Envelope(envelope)) => assert_eq!(envelope.message_id, held.message_id),
+        other => panic!("the queued envelope must come first, not a lag notice: {other:?}"),
+    }
+    assert_eq!(
+        subscription.try_recv(),
+        None,
+        "and nothing else — a refusal raises no in-band gap notice"
+    );
+}
+
+#[test]
+fn record_losses_reports_a_durable_write_it_could_not_make() {
+    // #6462 review round 2, MEDIUM. `an_unwritable_log_never_reports_a_clean_delivery`
+    // passes against the pre-fix head too — it proves the hot path survives an
+    // unwritable sink, not that the failure is OBSERVED. `record_losses` is the
+    // link that changed, so its contract is pinned directly: `true` when a loss
+    // record could not be written, `false` when every one landed. The first
+    // assertion cannot compile against `47615f13`, where the method did not
+    // exist and evictions went through the swallowing `log_record`.
+    let writable_dir = tempfile::tempdir().unwrap();
+    let writable = PeerBus::new(writable_dir.path());
     assert!(
-        matches!(next_envelope(&open), Some(e) if e.message_id == message_id),
-        "and the open subscription holds it"
+        !writable.record_losses(&[a_miss()]),
+        "a loss record that lands is not an unrecorded loss"
     );
+    assert_eq!(read_misses(&writable).len(), 1);
+
+    // A FILE where the stream's directory belongs: every write fails.
+    let broken_dir = tempfile::tempdir().unwrap();
+    std::fs::write(broken_dir.path().join("bus"), b"not a directory").unwrap();
+    let broken = PeerBus::new(broken_dir.path());
+    assert!(
+        broken.record_losses(&[a_miss()]),
+        "a loss record that could not be written must be reported, or the \
+         delivery record silently over-claims"
+    );
+    assert!(read_lines(&broken).is_empty());
+}
+
+/// One loss, for the tests that drive `record_losses` directly.
+fn a_miss() -> MissedEnvelope {
+    MissedEnvelope {
+        instance_id: "cto-assistant~b1".into(),
+        subscription_id: 0,
+        missed_total: 1,
+        envelope: BusEnvelope::new(
+            BusEdge::AssistantAssistant,
+            peer_caller("izzie~a1", "izzie"),
+            Recipient {
+                instance_id: Some("cto-assistant~b1".into()),
+                definition_id: Some("cto-assistant".into()),
+            },
+            chat("displaced"),
+            None,
+            DeliveryState::Delivered,
+        ),
+    }
 }
 
 // ── fan-out ordering (#6462 review, MEDIUM) ──────────────────────────────────
@@ -2265,8 +2346,7 @@ async fn route_publish_past_a_stalled_subscriber_is_accepted() {
     assert_eq!(misses.len(), overflow);
     assert!(
         misses.iter().all(|m| m.instance_id == target.instance_id
-            && m.subscription_id == stalled.subscription_id()
-            && m.reason == MissReason::Displaced),
+            && m.subscription_id == stalled.subscription_id()),
         "every miss record must name the client that lost the envelope"
     );
 }

--- a/crates/trusty-mpm/src/daemon/bus/tests.rs
+++ b/crates/trusty-mpm/src/daemon/bus/tests.rs
@@ -80,18 +80,16 @@ fn read_log(bus: &PeerBus) -> Vec<BusEnvelope> {
     read_lines(bus)
         .into_iter()
         .filter(|v| v.get("record").is_none())
-        .map(|v| {
-            serde_json::from_value(v).expect("every non-eviction line must parse as an envelope")
-        })
+        .map(|v| serde_json::from_value(v).expect("every non-miss line must parse as an envelope"))
         .collect()
 }
 
-/// Read every per-client eviction record (#6462) from the same stream.
-fn read_evictions(bus: &PeerBus) -> Vec<InboxEviction> {
+/// Read every per-client miss record (#6462) from the same stream.
+fn read_misses(bus: &PeerBus) -> Vec<InboxMiss> {
     read_lines(bus)
         .into_iter()
-        .filter(|v| v.get("record").and_then(|r| r.as_str()) == Some(INBOX_EVICTION_RECORD))
-        .map(|v| serde_json::from_value(v).expect("an eviction line must parse as one"))
+        .filter(|v| v.get("record").and_then(|r| r.as_str()) == Some(INBOX_MISS_RECORD))
+        .map(|v| serde_json::from_value(v).expect("a miss line must parse as one"))
         .collect()
 }
 
@@ -781,8 +779,8 @@ fn delivered_ids(bus: &PeerBus) -> Vec<String> {
 }
 
 /// Every `message_id` the log records as evicted from `subscription_id`.
-fn evicted_ids(bus: &PeerBus, subscription_id: u64) -> Vec<String> {
-    read_evictions(bus)
+fn missed_ids(bus: &PeerBus, subscription_id: u64) -> Vec<String> {
+    read_misses(bus)
         .into_iter()
         .filter(|e| e.subscription_id == subscription_id)
         .map(|e| e.message_id)
@@ -833,11 +831,11 @@ fn delivered_records_account_for_everything_a_stalled_subscriber_lost() {
         "the reader must be told about every envelope its inbox displaced"
     );
 
-    let mut accounted = evicted_ids(&bus, stalled.subscription_id());
+    let mut accounted = missed_ids(&bus, stalled.subscription_id());
     assert_eq!(
         accounted.len(),
         overflow,
-        "the durable log must carry one eviction record per displaced envelope"
+        "the durable log must carry one miss record per displaced envelope"
     );
     accounted.extend(received);
     accounted.sort();
@@ -852,7 +850,7 @@ fn delivered_records_account_for_everything_a_stalled_subscriber_lost() {
 
 #[test]
 fn eviction_is_recorded_per_client_in_the_durable_log() {
-    // The other half of the contract: an eviction is a fact about ONE
+    // The other half of the contract: a miss is a fact about ONE
     // subscription, not a delivery failure, so it is recorded as its own record
     // naming that subscription rather than as a second `delivery_state` on an
     // envelope other clients may well have read.
@@ -882,20 +880,26 @@ fn eviction_is_recorded_per_client_in_the_durable_log() {
         "no publish is refused by a slow subscriber any more (#6462)"
     );
 
-    let evictions = read_evictions(&bus);
-    assert_eq!(evictions.len(), overflow);
+    let misses = read_misses(&bus);
+    assert_eq!(misses.len(), overflow);
     assert_eq!(stalled.evicted_total(), overflow as u64);
-    for (n, eviction) in evictions.iter().enumerate() {
-        assert_eq!(eviction.instance_id, target.instance_id);
-        assert_eq!(eviction.subscription_id, stalled.subscription_id());
+    for (n, miss) in misses.iter().enumerate() {
+        assert_eq!(miss.instance_id, target.instance_id);
+        assert_eq!(miss.subscription_id, stalled.subscription_id());
         assert_eq!(
-            eviction.missed_total,
+            miss.reason,
+            MissReason::Displaced,
+            "a full inbox displaces; that is not the same loss as a closed \
+             subscription"
+        );
+        assert_eq!(
+            miss.missed_total,
             n as u64 + 1,
             "the running loss count must let a reader tell how far behind this \
              client was at each point"
         );
     }
-    let displaced: Vec<&String> = evictions.iter().map(|e| &e.message_id).collect();
+    let displaced: Vec<&String> = misses.iter().map(|m| &m.message_id).collect();
     let oldest: Vec<&String> = envelopes
         .iter()
         .take(overflow)
@@ -909,9 +913,9 @@ fn eviction_is_recorded_per_client_in_the_durable_log() {
 }
 
 #[test]
-fn eviction_records_are_distinguishable_from_envelopes() {
+fn miss_records_are_distinguishable_from_envelopes() {
     // A §9 reader must be able to tell the two record shapes apart from the
-    // line alone. An envelope has no `record` key; an eviction always does.
+    // line alone. An envelope has no `record` key; a miss line always does.
     let (_dir, bus) = bus();
     let target = bus.registry().register("cto-assistant", None).unwrap();
     let _stalled = bus.subscribe(&target.instance_id).unwrap();
@@ -929,7 +933,12 @@ fn eviction_records_are_distinguishable_from_envelopes() {
     let tagged: Vec<&serde_json::Value> =
         lines.iter().filter(|v| v.get("record").is_some()).collect();
     assert_eq!(tagged.len(), 1);
-    assert_eq!(tagged[0]["record"], INBOX_EVICTION_RECORD);
+    assert_eq!(tagged[0]["record"], INBOX_MISS_RECORD);
+    assert_eq!(
+        tagged[0]["reason"], "displaced",
+        "a miss line must say WHY, so a reader can tell a slow client from a \
+         deregistered one"
+    );
     assert!(
         lines
             .iter()
@@ -1057,7 +1066,7 @@ async fn a_wedged_client_does_not_refuse_publishes_for_a_healthy_co_subscriber()
     let (late, missed) = drain(&wedged);
     assert_eq!(late.len(), CLIENT_INBOX_CAPACITY);
     assert_eq!(missed, (ROUNDS - CLIENT_INBOX_CAPACITY) as u64);
-    let mut accounted = evicted_ids(&bus, wedged.subscription_id());
+    let mut accounted = missed_ids(&bus, wedged.subscription_id());
     accounted.extend(late);
     accounted.sort();
     let mut delivered = delivered_ids(&bus);
@@ -1149,7 +1158,7 @@ async fn two_subscribers_one_lagging_account_exactly() {
         "and it keeps the most recent traffic, in order"
     );
     assert_eq!(
-        evicted_ids(&bus, lagging.subscription_id()),
+        missed_ids(&bus, lagging.subscription_id()),
         accepted[..ROUNDS - CLIENT_INBOX_CAPACITY].to_vec(),
         "the log names exactly the envelopes it lost, oldest first"
     );
@@ -1169,7 +1178,7 @@ fn concurrent_publishers_lose_nothing_without_a_record() {
     // now — so the invariant is restated where it still bites: whatever order
     // the publishers won the fan-out lock in, a stalled client's reads plus its
     // recorded losses must equal the delivered set exactly. One unrecorded
-    // eviction breaks it, and so does one eviction record for an envelope that
+    // unrecorded loss breaks it, and so does one miss record for an envelope that
     // was never displaced.
     //
     // Threads rather than tasks, and far more publishes than one inbox can
@@ -1226,7 +1235,7 @@ fn concurrent_publishers_lose_nothing_without_a_record() {
         "the reader must be told the exact size of its own gap"
     );
 
-    let mut accounted = evicted_ids(&bus, stalled.subscription_id());
+    let mut accounted = missed_ids(&bus, stalled.subscription_id());
     accounted.extend(received);
     accounted.sort();
     let mut delivered = delivered_ids(&bus);
@@ -1308,6 +1317,240 @@ async fn deregister_ends_a_subscription_after_it_drains() {
     assert!(
         subscription.recv().await.is_none(),
         "and then the stream ends rather than hanging"
+    );
+}
+
+// ── the closed-subscription fail-open (#6462 review, CRITICAL) ───────────────
+
+/// Build one envelope addressed at `target`, for tests that drive
+/// [`LiveInstance::deliver`] directly.
+///
+/// Why direct rather than through `publish`: the race under test is INSIDE
+/// `publish` — it resolves the instance, the instance is deregistered, then it
+/// delivers through the clone it already holds. Driving `deliver` on that clone
+/// reproduces the interleaving deterministically, where a threaded version
+/// would only hit it sometimes.
+fn envelope_for(from: CallerIdentity, target: &InstanceMeta, text: &str) -> BusEnvelope {
+    BusEnvelope::new(
+        BusEdge::AssistantAssistant,
+        from,
+        Recipient {
+            instance_id: Some(target.instance_id.clone()),
+            definition_id: Some(target.definition_id.clone()),
+        },
+        chat(text),
+        None,
+        DeliveryState::Delivered,
+    )
+}
+
+#[test]
+fn a_publish_racing_deregistration_is_not_recorded_delivered() {
+    // #6462 review, CRITICAL. `close` marks a subscription closed but leaves
+    // its inbox in the set — only `InboxSubscription::drop` removes it — so a
+    // publisher holding a `LiveInstance` clone resolved a moment before the
+    // deregister saw a non-empty set and a "nothing displaced" answer from
+    // every closed inbox. The outcome was `Delivered { evicted: [] }`, so the
+    // §9 log got a `delivered` record and the sender a `202` for an envelope
+    // NO inbox held, with no record naming the loss: #4271's exact shape
+    // through a new door, reachable by an ordinary publish racing an agent
+    // shutdown. Against the pre-fix source this asserted
+    // `left: Delivered { evicted: [] }, right: NoSubscriber`.
+    let (_dir, bus) = bus();
+    let target = bus.registry().register("cto-assistant", None).unwrap();
+    let sender = registered_sender(&bus, "izzie");
+    let _subscription = bus.subscribe(&target.instance_id).unwrap();
+    let stale = bus
+        .registry()
+        .resolve_instance(&target.instance_id)
+        .unwrap();
+    assert!(bus.registry().deregister(&target.instance_id));
+
+    assert_eq!(
+        stale.deliver(envelope_for(sender, &target, "racing the shutdown")),
+        DeliveryOutcome::NoSubscriber,
+        "no inbox took the envelope, so nothing may report a delivery"
+    );
+}
+
+#[test]
+fn a_publish_racing_deregistration_records_the_closed_subscriptions_miss() {
+    // The partial case the same defect produces more quietly: one subscription
+    // closed, one open. The open one takes the envelope, so the publish IS a
+    // delivery — but the closed one loses it, and that loss needs a record with
+    // its own reason, or the `delivered` line over-claims for that client.
+    let (_dir, bus) = bus();
+    let target = bus.registry().register("cto-assistant", None).unwrap();
+    let sender = registered_sender(&bus, "izzie");
+    let closing = bus.subscribe(&target.instance_id).unwrap();
+    let stale = bus
+        .registry()
+        .resolve_instance(&target.instance_id)
+        .unwrap();
+    assert!(bus.registry().deregister(&target.instance_id));
+    // A second subscription attached through the same stale clone: open, in the
+    // same set as the closed one. Only an in-crate holder of a stale clone can
+    // reach this state, which is exactly what makes it worth pinning.
+    let open = stale.subscribe();
+
+    let envelope = envelope_for(sender, &target, "one takes it, one cannot");
+    let message_id = envelope.message_id.clone();
+    let DeliveryOutcome::Delivered { missed } = stale.deliver(envelope) else {
+        panic!("the open subscription took it, so this is a delivery");
+    };
+
+    assert_eq!(missed.len(), 1, "exactly the closed subscription lost it");
+    assert_eq!(missed[0].subscription_id, closing.subscription_id());
+    assert_eq!(missed[0].reason, MissReason::SubscriptionClosed);
+    assert_eq!(
+        missed[0].envelope.message_id, message_id,
+        "a closed subscription loses THIS envelope, not a displaced older one"
+    );
+    assert!(
+        matches!(next_envelope(&open), Some(e) if e.message_id == message_id),
+        "and the open subscription holds it"
+    );
+}
+
+// ── fan-out ordering (#6462 review, MEDIUM) ──────────────────────────────────
+
+#[test]
+fn concurrent_publishers_deliver_one_order_to_every_client() {
+    // The fan-out lock's documented purpose, made falsifiable. Every doc that
+    // cites it says the lock is what stops two publishers handing two clients
+    // the same two envelopes in opposite orders — but the accounting tests
+    // either sort before comparing or use one publisher, so releasing the lock
+    // between inboxes failed none of them.
+    //
+    // Here both clients are drained only at the end and neither can lag
+    // (CLIENT_INBOX_CAPACITY is not reached), so each holds the complete
+    // sequence in fan-out order. If the fan-out were not atomic across inboxes,
+    // publisher A could reach client 1 between publisher B's two inbox writes
+    // and the two sequences would diverge. Unsorted, deliberately: sorting is
+    // what blinded the other tests to this.
+    const PUBLISHERS: usize = 4;
+    const PER_PUBLISHER: usize = CLIENT_INBOX_CAPACITY / 8;
+
+    let (_dir, bus) = bus();
+    let bus = Arc::new(bus);
+    let target = bus.registry().register("cto-assistant", None).unwrap();
+    let first = bus.subscribe(&target.instance_id).unwrap();
+    let second = bus.subscribe(&target.instance_id).unwrap();
+
+    std::thread::scope(|scope| {
+        for p in 0..PUBLISHERS {
+            let bus = Arc::clone(&bus);
+            let instance_id = target.instance_id.clone();
+            scope.spawn(move || {
+                let sender = registered_sender(&bus, &format!("izzie{p}"));
+                for i in 0..PER_PUBLISHER {
+                    bus.publish(
+                        sender.clone(),
+                        &PeerTarget::Instance(instance_id.clone()),
+                        chat(&format!("p{p} n{i}")),
+                        None,
+                    )
+                    .expect("no publish may be refused");
+                }
+            });
+        }
+    });
+
+    let (first_seen, first_missed) = drain(&first);
+    let (second_seen, second_missed) = drain(&second);
+    assert_eq!(first_missed, 0, "neither client may lag in this test");
+    assert_eq!(second_missed, 0);
+    assert_eq!(first_seen.len(), PUBLISHERS * PER_PUBLISHER);
+    assert_eq!(
+        first_seen, second_seen,
+        "both clients must observe ONE order; a divergence means the fan-out \
+         was interleaved and the lock is not doing what its doc claims"
+    );
+}
+
+// ── the durable write can fail, and the log must not over-claim ──────────────
+
+#[test]
+fn a_fully_recorded_delivery_serializes_as_a_bare_envelope() {
+    // The `losses_unrecorded` marker must cost nothing when it does not apply:
+    // a delivery whose losses were all recorded has to serialize byte-identical
+    // to the envelope itself, or every existing §9 reader and DOC-60 §11's
+    // field list would change for a case that never happened.
+    let envelope = BusEnvelope::new(
+        BusEdge::AssistantAssistant,
+        peer_caller("izzie~a1", "izzie"),
+        Recipient {
+            instance_id: Some("cto-assistant~b1".into()),
+            definition_id: Some("cto-assistant".into()),
+        },
+        chat("hi"),
+        None,
+        DeliveryState::Delivered,
+    );
+    assert_eq!(
+        serde_json::to_string(&EnvelopeRecord::new(&envelope, false)).unwrap(),
+        serde_json::to_string(&envelope).unwrap(),
+        "the marker must be absent unless a loss record failed to write"
+    );
+
+    let marked = serde_json::to_value(EnvelopeRecord::new(&envelope, true)).unwrap();
+    assert_eq!(marked["losses_unrecorded"], true);
+    assert_eq!(
+        marked["message_id"], envelope.message_id,
+        "and the marked form is still a readable envelope"
+    );
+}
+
+#[test]
+fn an_unwritable_log_never_reports_a_clean_delivery() {
+    // #6462 review, HIGH: "nothing is lost without a record" rested on
+    // `log_record`, which swallows every IO error by DOC-60 §9's
+    // never-fail-the-hot-path design. A loss record that failed to write, then
+    // an envelope record that succeeded, would leave a clean `delivered` line
+    // with nothing explaining the gap — #4271 produced by an IO failure rather
+    // than a logic bug.
+    //
+    // The sink is made unwritable by putting a FILE where the stream's
+    // directory belongs, so `create_dir_all` fails on every write. Two things
+    // must hold: the hot path still succeeds (the envelope really did reach the
+    // clients that took it), and nothing over-claims — here by writing nothing
+    // at all, which under-claims and is the safe direction.
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("bus"), b"not a directory").unwrap();
+    let bus = PeerBus::new(dir.path());
+
+    let target = bus.registry().register("cto-assistant", None).unwrap();
+    let sender = registered_sender(&bus, "izzie");
+    let stalled = bus.subscribe(&target.instance_id).unwrap();
+
+    // Past the inbox's depth, so every publish after the first
+    // CLIENT_INBOX_CAPACITY produces a loss record that cannot be written.
+    for i in 0..(CLIENT_INBOX_CAPACITY + 4) {
+        bus.publish(
+            sender.clone(),
+            &PeerTarget::Instance(target.instance_id.clone()),
+            chat(&format!("burst {i}")),
+            None,
+        )
+        .expect("a failed durability write must never fail the publish");
+    }
+
+    assert_eq!(
+        stalled.evicted_total(),
+        4,
+        "the losses happened whether or not they could be recorded"
+    );
+    assert!(
+        read_lines(&bus).is_empty(),
+        "an unwritable stream holds no records at all — it must never hold a \
+         `delivered` line whose losses it could not enumerate"
+    );
+
+    // And `try_log_record` is what makes that observable to the publisher,
+    // where `log_record` would have hidden it.
+    assert!(
+        bus.log_path().parent().is_some_and(|p| p.is_file()),
+        "the sink really is unwritable in this test"
     );
 }
 
@@ -1907,7 +2150,7 @@ async fn route_subscribe_to_dead_instance_is_410() {
 async fn subscribe_stream_reports_lag_instead_of_swallowing_it() {
     // #4271, the SSE half: a lagged subscriber used to be mapped to `None` —
     // the frames vanished and the recipient was told nothing. It gets a named
-    // `lagged` frame carrying the count, the subscription id its eviction
+    // `lagged` frame carrying the count, the subscription id its miss
     // records are keyed under, and where to re-read from.
     //
     // Since #6462 the lag is produced by the ordinary publish path: the SSE
@@ -1967,7 +2210,7 @@ async fn subscribe_stream_reports_lag_instead_of_swallowing_it() {
     );
     assert!(
         text.contains("\"subscription_id\":"),
-        "the notice must name the subscription its eviction records are keyed \
+        "the notice must name the subscription its miss records are keyed \
          under, got: {text}"
     );
     assert!(
@@ -1982,7 +2225,7 @@ async fn route_publish_past_a_stalled_subscriber_is_accepted() {
     // `route_publish_to_a_saturated_instance_is_503`. That test filled the
     // shared ring through a stalled subscriber and asserted the endpoint then
     // answered `503` to everyone. The endpoint now answers `202` well past the
-    // stalled client's depth, and the §9 log carries one eviction record per
+    // stalled client's depth, and the §9 log carries one miss record per
     // envelope that client lost — the same evidence, moved off the publisher.
     let (_dir, state) = test_state();
     let target = state
@@ -2018,11 +2261,12 @@ async fn route_publish_past_a_stalled_subscriber_is_accepted() {
         overflow as u64,
         "the stalled client absorbs its own backlog"
     );
-    let evictions = read_evictions(state.bus());
-    assert_eq!(evictions.len(), overflow);
+    let misses = read_misses(state.bus());
+    assert_eq!(misses.len(), overflow);
     assert!(
-        evictions.iter().all(|e| e.instance_id == target.instance_id
-            && e.subscription_id == stalled.subscription_id()),
-        "every eviction record must name the client that lost the envelope"
+        misses.iter().all(|m| m.instance_id == target.instance_id
+            && m.subscription_id == stalled.subscription_id()
+            && m.reason == MissReason::Displaced),
+        "every miss record must name the client that lost the envelope"
     );
 }

--- a/crates/trusty-mpm/src/daemon/bus/tests.rs
+++ b/crates/trusty-mpm/src/daemon/bus/tests.rs
@@ -14,7 +14,6 @@ use std::sync::Arc;
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use http_body_util::BodyExt;
-use tokio::sync::broadcast;
 use tower::ServiceExt;
 
 use super::routes::LAGGED_EVENT;
@@ -64,13 +63,49 @@ fn chat(text: &str) -> BusPayload {
     BusPayload::ChatText { text: text.into() }
 }
 
-/// Read every envelope written to the bus's durable JSONL stream.
-fn read_log(bus: &PeerBus) -> Vec<BusEnvelope> {
+/// Every line of the bus's durable JSONL stream, unparsed.
+///
+/// Why raw values: since #6462 the stream carries two record shapes, and which
+/// one a line is has to be decided from its own content rather than assumed.
+fn read_lines(bus: &PeerBus) -> Vec<serde_json::Value> {
     let contents = std::fs::read_to_string(bus.log_path()).unwrap_or_default();
     contents
         .lines()
-        .map(|l| serde_json::from_str(l).expect("every bus log line must parse as an envelope"))
+        .map(|l| serde_json::from_str(l).expect("every bus log line must be valid JSON"))
         .collect()
+}
+
+/// Read every envelope record written to the bus's durable JSONL stream.
+fn read_log(bus: &PeerBus) -> Vec<BusEnvelope> {
+    read_lines(bus)
+        .into_iter()
+        .filter(|v| v.get("record").is_none())
+        .map(|v| {
+            serde_json::from_value(v).expect("every non-eviction line must parse as an envelope")
+        })
+        .collect()
+}
+
+/// Read every per-client eviction record (#6462) from the same stream.
+fn read_evictions(bus: &PeerBus) -> Vec<InboxEviction> {
+    read_lines(bus)
+        .into_iter()
+        .filter(|v| v.get("record").and_then(|r| r.as_str()) == Some(INBOX_EVICTION_RECORD))
+        .map(|v| serde_json::from_value(v).expect("an eviction line must parse as one"))
+        .collect()
+}
+
+/// The next envelope a subscription holds, if it holds one.
+///
+/// Why it panics on a lag rather than skipping it: a test that asked for an
+/// envelope and silently swallowed a gap would assert the opposite of what
+/// #4271 is about.
+fn next_envelope(sub: &InboxSubscription) -> Option<BusEnvelope> {
+    match sub.try_recv() {
+        Some(InboxItem::Envelope(envelope)) => Some(*envelope),
+        Some(InboxItem::Lagged(missed)) => panic!("expected an envelope, got a lag of {missed}"),
+        None => None,
+    }
 }
 
 // ── envelope schema (DOC-60 §11) ──────────────────────────────────────────────
@@ -453,7 +488,7 @@ fn publish_bypass_to_dead_instance_does_not_deliver_to_sibling() {
     let dead = bus.registry().register("izzie", None).unwrap();
     bus.registry().deregister(&dead.instance_id);
     let sibling = bus.registry().register("izzie", None).unwrap();
-    let mut sibling_rx = bus.subscribe(&sibling.instance_id).unwrap();
+    let sibling_rx = bus.subscribe(&sibling.instance_id).unwrap();
 
     let err = bus
         .publish(
@@ -465,7 +500,7 @@ fn publish_bypass_to_dead_instance_does_not_deliver_to_sibling() {
         .unwrap_err();
     assert!(matches!(err, BusError::InstanceGone { .. }));
     assert!(
-        sibling_rx.try_recv().is_err(),
+        next_envelope(&sibling_rx).is_none(),
         "a live sibling must NOT receive a message addressed to a dead instance"
     );
 }
@@ -476,7 +511,7 @@ fn publish_bypass_to_dead_instance_does_not_deliver_to_sibling() {
 fn publish_delivers_to_definition_addressed_instance() {
     let (_dir, bus) = bus();
     let target = bus.registry().register("cto-assistant", None).unwrap();
-    let mut rx = bus.subscribe(&target.instance_id).unwrap();
+    let rx = bus.subscribe(&target.instance_id).unwrap();
 
     let sent = bus
         .publish(
@@ -487,7 +522,7 @@ fn publish_delivers_to_definition_addressed_instance() {
         )
         .unwrap();
 
-    let got = rx.try_recv().unwrap();
+    let got = next_envelope(&rx).expect("the target must hold the envelope");
     assert_eq!(got, sent);
     assert_eq!(got.delivery_state, DeliveryState::Delivered);
     assert_eq!(
@@ -526,8 +561,8 @@ fn publish_reaches_only_target_instance() {
     let (_dir, bus) = bus();
     let a = bus.registry().register("izzie", None).unwrap();
     let b = bus.registry().register("cto-assistant", None).unwrap();
-    let mut rx_a = bus.subscribe(&a.instance_id).unwrap();
-    let mut rx_b = bus.subscribe(&b.instance_id).unwrap();
+    let rx_a = bus.subscribe(&a.instance_id).unwrap();
+    let rx_b = bus.subscribe(&b.instance_id).unwrap();
 
     bus.publish(
         registered_sender(&bus, "izzie"),
@@ -537,9 +572,9 @@ fn publish_reaches_only_target_instance() {
     )
     .unwrap();
 
-    assert!(rx_b.try_recv().is_ok());
+    assert!(next_envelope(&rx_b).is_some());
     assert!(
-        rx_a.try_recv().is_err(),
+        next_envelope(&rx_a).is_none(),
         "a non-target must receive nothing"
     );
 }
@@ -717,24 +752,23 @@ fn no_subscriber_is_logged_as_dropped_not_delivered() {
     assert_eq!(log[0].delivery_state, DeliveryState::Dropped);
 }
 
-// ── subscriber lag (#4271) ────────────────────────────────────────────────────
+// ── per-client inbox delivery (#4271, re-cut per client by #6462) ────────────
 
-/// Drain every envelope a receiver can still produce, plus how much it lagged.
+/// Drain everything a subscription can still produce, plus how much it lost.
 ///
-/// Why: the two lag tests below both need "what did this subscriber ACTUALLY
-/// end up holding", and a `try_recv` loop that stops at the first `Lagged` would
-/// answer the wrong question — `Lagged` is not the end of the stream, it is a
-/// gap in the middle of one.
-fn drain(rx: &mut broadcast::Receiver<BusEnvelope>) -> (Vec<String>, u64) {
+/// Why: the tests below all need "what did this client ACTUALLY end up
+/// holding", and a loop that stopped at the first `Lagged` would answer the
+/// wrong question — a lag is a gap in the middle of a stream, not its end.
+fn drain(sub: &InboxSubscription) -> (Vec<String>, u64) {
     let mut ids = Vec::new();
     let mut missed = 0;
-    loop {
-        match rx.try_recv() {
-            Ok(envelope) => ids.push(envelope.message_id),
-            Err(broadcast::error::TryRecvError::Lagged(n)) => missed += n,
-            Err(_) => return (ids, missed),
+    while let Some(item) = sub.try_recv() {
+        match item {
+            InboxItem::Envelope(envelope) => ids.push(envelope.message_id),
+            InboxItem::Lagged(n) => missed += n,
         }
     }
+    (ids, missed)
 }
 
 /// Every `message_id` the durable log calls delivered, in write order.
@@ -746,12 +780,20 @@ fn delivered_ids(bus: &PeerBus) -> Vec<String> {
         .collect()
 }
 
+/// Every `message_id` the log records as evicted from `subscription_id`.
+fn evicted_ids(bus: &PeerBus, subscription_id: u64) -> Vec<String> {
+    read_evictions(bus)
+        .into_iter()
+        .filter(|e| e.subscription_id == subscription_id)
+        .map(|e| e.message_id)
+        .collect()
+}
+
 /// Publish `count` envelopes at one instance, ignoring refusals.
 fn burst(bus: &PeerBus, sender: &CallerIdentity, instance_id: &str, count: usize) {
     for i in 0..count {
-        // A refused publish's own record is asserted by
-        // `saturated_publish_is_dropped_in_the_durable_log`; the callers here
-        // care only about what the log and the subscriber end up agreeing on.
+        // Refusals are asserted by the tests that are about them; the callers
+        // here care only about what the log and the client end up agreeing on.
         let _ = bus.publish(
             sender.clone(),
             &PeerTarget::Instance(instance_id.to_string()),
@@ -762,49 +804,19 @@ fn burst(bus: &PeerBus, sender: &CallerIdentity, instance_id: &str, count: usize
 }
 
 #[test]
-fn delivered_records_match_what_a_stalled_subscriber_receives() {
-    // #4271, the defect itself: `broadcast::Sender::send` answers Ok for a
-    // LAGGING receiver, so a publish into a full ring evicted an envelope the
-    // recipient had never read while the §9 log recorded that envelope as
-    // `delivered`. The sender saw 202, the log said delivered, and the
-    // recipient was never told.
+fn delivered_records_account_for_everything_a_stalled_subscriber_lost() {
+    // #4271, the defect itself: an eviction the log did not record. The
+    // envelopes the log calls delivered used to include ones the recipient
+    // never saw, and nothing said which.
     //
-    // The invariant asserted here is the whole contract: the envelopes the log
-    // calls delivered are EXACTLY the envelopes the subscriber receives.
+    // The invariant asserted here is the whole contract, and it is the
+    // per-client form of it: what this client received, plus what the log says
+    // this client's inbox displaced, is EXACTLY what the log calls delivered.
+    // Nothing is lost without a record, and no record invents a loss.
     let (_dir, bus) = bus();
     let target = bus.registry().register("cto-assistant", None).unwrap();
     // Attached but stalled — the `cto-assistant~b1` inside a long LLM turn.
-    let mut stalled = bus.subscribe(&target.instance_id).unwrap();
-    let sender = registered_sender(&bus, "izzie");
-
-    burst(
-        &bus,
-        &sender,
-        &target.instance_id,
-        INSTANCE_CHANNEL_CAPACITY + 6,
-    );
-
-    let (received, missed) = drain(&mut stalled);
-    assert_eq!(
-        received,
-        delivered_ids(&bus),
-        "every envelope the durable log records as delivered must actually \
-         reach the subscriber, and no other"
-    );
-    assert_eq!(
-        missed, 0,
-        "a subscriber must not silently lose envelopes the log calls delivered"
-    );
-}
-
-#[test]
-fn saturated_publish_is_dropped_in_the_durable_log() {
-    // The other half of the contract: a refused publish is still RECORDED, as
-    // `dropped`. A log holding only successes cannot answer "was it sent, or
-    // just never read?" (DOC-60 §4).
-    let (_dir, bus) = bus();
-    let target = bus.registry().register("cto-assistant", None).unwrap();
-    let _stalled = bus.subscribe(&target.instance_id).unwrap();
+    let stalled = bus.subscribe(&target.instance_id).unwrap();
     let sender = registered_sender(&bus, "izzie");
     let overflow = 6;
 
@@ -812,55 +824,192 @@ fn saturated_publish_is_dropped_in_the_durable_log() {
         &bus,
         &sender,
         &target.instance_id,
-        INSTANCE_CHANNEL_CAPACITY + overflow,
+        CLIENT_INBOX_CAPACITY + overflow,
     );
 
-    let log = read_log(&bus);
+    let (received, missed) = drain(&stalled);
     assert_eq!(
-        log.len(),
-        INSTANCE_CHANNEL_CAPACITY + overflow,
-        "every publish past sender verification is recorded, delivered or not"
+        missed, overflow as u64,
+        "the reader must be told about every envelope its inbox displaced"
     );
-    let dropped = log
-        .iter()
-        .filter(|e| e.delivery_state == DeliveryState::Dropped)
-        .count();
+
+    let mut accounted = evicted_ids(&bus, stalled.subscription_id());
     assert_eq!(
-        dropped, overflow,
-        "the publishes the full channel could not take must be recorded dropped"
+        accounted.len(),
+        overflow,
+        "the durable log must carry one eviction record per displaced envelope"
+    );
+    accounted.extend(received);
+    accounted.sort();
+    let mut delivered = delivered_ids(&bus);
+    delivered.sort();
+    assert_eq!(
+        accounted, delivered,
+        "what the client read plus what the log says it lost must equal what \
+         the log calls delivered — no silent loss, no invented one"
     );
 }
 
+#[test]
+fn eviction_is_recorded_per_client_in_the_durable_log() {
+    // The other half of the contract: an eviction is a fact about ONE
+    // subscription, not a delivery failure, so it is recorded as its own record
+    // naming that subscription rather than as a second `delivery_state` on an
+    // envelope other clients may well have read.
+    let (_dir, bus) = bus();
+    let target = bus.registry().register("cto-assistant", None).unwrap();
+    let stalled = bus.subscribe(&target.instance_id).unwrap();
+    let sender = registered_sender(&bus, "izzie");
+    let overflow = 6;
+
+    burst(
+        &bus,
+        &sender,
+        &target.instance_id,
+        CLIENT_INBOX_CAPACITY + overflow,
+    );
+
+    let envelopes = read_log(&bus);
+    assert_eq!(
+        envelopes.len(),
+        CLIENT_INBOX_CAPACITY + overflow,
+        "every publish past sender verification is recorded"
+    );
+    assert!(
+        envelopes
+            .iter()
+            .all(|e| e.delivery_state == DeliveryState::Delivered),
+        "no publish is refused by a slow subscriber any more (#6462)"
+    );
+
+    let evictions = read_evictions(&bus);
+    assert_eq!(evictions.len(), overflow);
+    assert_eq!(stalled.evicted_total(), overflow as u64);
+    for (n, eviction) in evictions.iter().enumerate() {
+        assert_eq!(eviction.instance_id, target.instance_id);
+        assert_eq!(eviction.subscription_id, stalled.subscription_id());
+        assert_eq!(
+            eviction.missed_total,
+            n as u64 + 1,
+            "the running loss count must let a reader tell how far behind this \
+             client was at each point"
+        );
+    }
+    let displaced: Vec<&String> = evictions.iter().map(|e| &e.message_id).collect();
+    let oldest: Vec<&String> = envelopes
+        .iter()
+        .take(overflow)
+        .map(|e| &e.message_id)
+        .collect();
+    assert_eq!(
+        displaced, oldest,
+        "the OLDEST unread envelopes lose, in order — a recovering client must \
+         be able to keep reading the most recent traffic"
+    );
+}
+
+#[test]
+fn eviction_records_are_distinguishable_from_envelopes() {
+    // A §9 reader must be able to tell the two record shapes apart from the
+    // line alone. An envelope has no `record` key; an eviction always does.
+    let (_dir, bus) = bus();
+    let target = bus.registry().register("cto-assistant", None).unwrap();
+    let _stalled = bus.subscribe(&target.instance_id).unwrap();
+    let sender = registered_sender(&bus, "izzie");
+
+    burst(
+        &bus,
+        &sender,
+        &target.instance_id,
+        CLIENT_INBOX_CAPACITY + 1,
+    );
+
+    let lines = read_lines(&bus);
+    assert_eq!(lines.len(), CLIENT_INBOX_CAPACITY + 2);
+    let tagged: Vec<&serde_json::Value> =
+        lines.iter().filter(|v| v.get("record").is_some()).collect();
+    assert_eq!(tagged.len(), 1);
+    assert_eq!(tagged[0]["record"], INBOX_EVICTION_RECORD);
+    assert!(
+        lines
+            .iter()
+            .filter(|v| v.get("record").is_none())
+            .all(|v| v.get("delivery_state").is_some()),
+        "every untagged line must still be a readable envelope"
+    );
+}
+
+#[test]
+fn a_stalled_subscriber_reads_its_lag_before_the_surviving_envelopes() {
+    // The gap belongs where it happened. The eviction took envelopes from the
+    // FRONT of the queue, which is where the reader is, so the notice has to
+    // arrive before everything still queued — otherwise a client would read
+    // past its own gap and only learn of it afterwards.
+    let (_dir, bus) = bus();
+    let target = bus.registry().register("cto-assistant", None).unwrap();
+    let stalled = bus.subscribe(&target.instance_id).unwrap();
+    let sender = registered_sender(&bus, "izzie");
+
+    burst(
+        &bus,
+        &sender,
+        &target.instance_id,
+        CLIENT_INBOX_CAPACITY + 3,
+    );
+
+    assert_eq!(
+        stalled.try_recv(),
+        Some(InboxItem::Lagged(3)),
+        "the lag must be the first thing the reader sees"
+    );
+    let next = next_envelope(&stalled).expect("the surviving envelopes follow the notice");
+    assert_eq!(
+        next.message_id,
+        delivered_ids(&bus)[3],
+        "the reader resumes at the oldest envelope that was NOT displaced"
+    );
+    assert!(stalled.subscription_id() < u64::MAX);
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn two_subscribers_one_lagging_account_exactly() {
-    // Condition-based, never sleep-based: the drainer parks on the channel's
-    // own waker, and the accounting proceeds the instant the counter reaches
-    // its target. The deadline exists only so a hang reports a failure.
-    const ROUNDS: usize = INSTANCE_CHANNEL_CAPACITY + 36;
+async fn a_wedged_client_does_not_refuse_publishes_for_a_healthy_co_subscriber() {
+    // #6462, the defect this change closes. Before it, one client that never
+    // polled held the instance's single shared ring full, and `publish` refused
+    // every message to that instance with `503` — for every publisher and every
+    // healthy co-subscriber, unboundedly. Against the pre-fix source this
+    // asserted `refused: left: 36, right: 0`.
+    //
+    // Condition-based, never sleep-based: the drainer parks on its inbox's own
+    // waker and the accounting proceeds the instant the count is reached. The
+    // deadline exists only so a hang reports a failure.
+    const ROUNDS: usize = CLIENT_INBOX_CAPACITY + 36;
 
     let (_dir, bus) = bus();
     let bus = Arc::new(bus);
     let target = bus.registry().register("cto-assistant", None).unwrap();
-    let mut fast = bus.subscribe(&target.instance_id).unwrap();
-    // Registered, attached, and never polled until the accounting at the end —
-    // the lagging peer. It is what holds the ring full.
-    let mut lagging = bus.subscribe(&target.instance_id).unwrap();
+    let healthy = Arc::new(bus.subscribe(&target.instance_id).unwrap());
+    // Attached and never polled until the accounting at the end.
+    let wedged = bus.subscribe(&target.instance_id).unwrap();
     let sender = registered_sender(&bus, "izzie");
 
     let seen = Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
     let drainer = tokio::spawn({
         let seen = Arc::clone(&seen);
+        let healthy = Arc::clone(&healthy);
         async move {
-            while let Ok(envelope) = fast.recv().await {
-                seen.lock().unwrap().push(envelope.message_id);
+            while let Some(item) = healthy.recv().await {
+                match item {
+                    InboxItem::Envelope(envelope) => seen.lock().unwrap().push(envelope.message_id),
+                    InboxItem::Lagged(n) => panic!("the healthy client must never lag: {n}"),
+                }
             }
         }
     });
 
-    let publisher = tokio::spawn({
+    let (accepted, refused) = tokio::task::spawn_blocking({
         let bus = Arc::clone(&bus);
         let instance_id = target.instance_id.clone();
-        async move {
+        move || {
             let mut accepted = Vec::new();
             let mut refused = 0usize;
             for i in 0..ROUNDS {
@@ -876,17 +1025,99 @@ async fn two_subscribers_one_lagging_account_exactly() {
             }
             (accepted, refused)
         }
-    });
-    let (accepted, refused) = publisher.await.unwrap();
+    })
+    .await
+    .unwrap();
 
-    // A fast peer's progress does not rescue the channel: the ring is gated by
-    // the SLOWEST attached subscriber, so acceptance stops at its depth exactly.
     assert_eq!(
-        accepted.len(),
-        INSTANCE_CHANNEL_CAPACITY,
-        "the lagging subscriber must gate acceptance at the ring's depth"
+        refused, 0,
+        "a wedged client must not make the instance refuse a publish"
     );
-    assert_eq!(refused, ROUNDS - INSTANCE_CHANNEL_CAPACITY);
+    assert_eq!(accepted.len(), ROUNDS);
+
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+    while seen.lock().unwrap().len() < ROUNDS {
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "the healthy co-subscriber never caught up: {} of {ROUNDS}",
+            seen.lock().unwrap().len()
+        );
+        tokio::task::yield_now().await;
+    }
+    drainer.abort();
+
+    assert_eq!(
+        *seen.lock().unwrap(),
+        accepted,
+        "the healthy co-subscriber must receive every envelope, in order, \
+         however far behind its neighbour fell"
+    );
+
+    // And the wedged client's own loss is fully accounted for.
+    let (late, missed) = drain(&wedged);
+    assert_eq!(late.len(), CLIENT_INBOX_CAPACITY);
+    assert_eq!(missed, (ROUNDS - CLIENT_INBOX_CAPACITY) as u64);
+    let mut accounted = evicted_ids(&bus, wedged.subscription_id());
+    accounted.extend(late);
+    accounted.sort();
+    let mut delivered = delivered_ids(&bus);
+    delivered.sort();
+    assert_eq!(
+        accounted, delivered,
+        "the wedged client's reads plus its recorded losses must still equal \
+         the delivered set"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn two_subscribers_one_lagging_account_exactly() {
+    // The same accounting across two clients at once: the fast one loses
+    // nothing, the lagging one loses only what the log names, and both agree on
+    // the ORDER — which is what the per-instance fan-out lock buys now that the
+    // shared ring that used to guarantee it is gone.
+    const ROUNDS: usize = CLIENT_INBOX_CAPACITY + 36;
+
+    let (_dir, bus) = bus();
+    let bus = Arc::new(bus);
+    let target = bus.registry().register("cto-assistant", None).unwrap();
+    let fast = Arc::new(bus.subscribe(&target.instance_id).unwrap());
+    let lagging = bus.subscribe(&target.instance_id).unwrap();
+    let sender = registered_sender(&bus, "izzie");
+
+    let seen = Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+    let drainer = tokio::spawn({
+        let seen = Arc::clone(&seen);
+        let fast = Arc::clone(&fast);
+        async move {
+            while let Some(item) = fast.recv().await {
+                if let InboxItem::Envelope(envelope) = item {
+                    seen.lock().unwrap().push(envelope.message_id);
+                }
+            }
+        }
+    });
+
+    let accepted = tokio::task::spawn_blocking({
+        let bus = Arc::clone(&bus);
+        let instance_id = target.instance_id.clone();
+        move || {
+            let mut accepted = Vec::new();
+            for i in 0..ROUNDS {
+                let envelope = bus
+                    .publish(
+                        sender.clone(),
+                        &PeerTarget::Instance(instance_id.clone()),
+                        chat(&format!("round {i}")),
+                        None,
+                    )
+                    .expect("no publish may be refused by a lagging co-subscriber");
+                accepted.push(envelope.message_id);
+            }
+            accepted
+        }
+    })
+    .await
+    .unwrap();
 
     let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
     while seen.lock().unwrap().len() < accepted.len() {
@@ -905,40 +1136,53 @@ async fn two_subscribers_one_lagging_account_exactly() {
         accepted,
         "the fast subscriber must receive every accepted envelope, in order"
     );
-    let (late, missed) = drain(&mut lagging);
+
+    let (late, missed) = drain(&lagging);
     assert_eq!(
-        late, accepted,
-        "the lagging subscriber must still receive every accepted envelope once \
-         it drains — lag delays delivery here, it never discards it"
+        missed,
+        (ROUNDS - CLIENT_INBOX_CAPACITY) as u64,
+        "the lagging subscriber loses exactly what its own buffer could not hold"
     );
-    assert_eq!(missed, 0, "nothing may be evicted unread");
+    assert_eq!(
+        late,
+        accepted[ROUNDS - CLIENT_INBOX_CAPACITY..].to_vec(),
+        "and it keeps the most recent traffic, in order"
+    );
+    assert_eq!(
+        evicted_ids(&bus, lagging.subscription_id()),
+        accepted[..ROUNDS - CLIENT_INBOX_CAPACITY].to_vec(),
+        "the log names exactly the envelopes it lost, oldest first"
+    );
     assert_eq!(
         delivered_ids(&bus),
         accepted,
-        "the durable log's delivered set must equal what both subscribers got"
+        "the durable log's delivered set is every accepted envelope"
     );
 }
 
 #[test]
-fn concurrent_publishers_never_evict_a_delivered_envelope() {
-    // #4271, the concurrent arm: measuring the channel and sending into it are
-    // two separate acquisitions of the broadcast tail lock, so a check made
-    // outside a lock of our own is stale by the time the send runs. Two
-    // publishers that both observed `capacity - 1` would both send, and the
-    // second would evict an unread envelope the first had already recorded
-    // `delivered` — the same fail-open, narrowed to a window.
+fn concurrent_publishers_lose_nothing_without_a_record() {
+    // The per-client successor to #6461's
+    // `concurrent_publishers_never_evict_a_delivered_envelope`, which asserted
+    // that concurrent publishers could not push acceptance past the shared
+    // ring's depth. That ceiling is gone by design — every publish is accepted
+    // now — so the invariant is restated where it still bites: whatever order
+    // the publishers won the fan-out lock in, a stalled client's reads plus its
+    // recorded losses must equal the delivered set exactly. One unrecorded
+    // eviction breaks it, and so does one eviction record for an envelope that
+    // was never displaced.
     //
-    // Threads rather than tasks, and far more publishes than the ring can hold,
-    // so the interleaving is hit repeatedly within one run.
+    // Threads rather than tasks, and far more publishes than one inbox can
+    // hold, so the interleaving is hit repeatedly within one run.
     const PUBLISHERS: usize = 8;
     const PER_PUBLISHER: usize = 32;
 
     let (_dir, bus) = bus();
     let bus = Arc::new(bus);
     let target = bus.registry().register("cto-assistant", None).unwrap();
-    // Attached and never draining: it is what holds the ring full, so every
-    // publisher past the first `INSTANCE_CHANNEL_CAPACITY` races at the edge.
-    let mut stalled = bus.subscribe(&target.instance_id).unwrap();
+    // Attached and never draining: every publish past the first
+    // CLIENT_INBOX_CAPACITY evicts, so the eviction path races too.
+    let stalled = bus.subscribe(&target.instance_id).unwrap();
 
     let accepted = std::thread::scope(|scope| {
         let handles: Vec<_> = (0..PUBLISHERS)
@@ -968,26 +1212,102 @@ fn concurrent_publishers_never_evict_a_delivered_envelope() {
             .fold(0usize, |n, ids| n + ids.len())
     });
 
-    // Exact accounting: the ring's depth is the ceiling no interleaving may
-    // exceed. One extra acceptance is one evicted envelope.
     assert_eq!(
-        accepted, INSTANCE_CHANNEL_CAPACITY,
-        "concurrent publishers must not accept more than the ring can hold"
+        accepted,
+        PUBLISHERS * PER_PUBLISHER,
+        "no publish may be refused, however the publishers interleaved"
     );
 
-    let (received, missed) = drain(&mut stalled);
+    let (received, missed) = drain(&stalled);
+    assert_eq!(received.len(), CLIENT_INBOX_CAPACITY);
     assert_eq!(
-        missed, 0,
-        "no envelope may be evicted unread, however the publishes interleaved"
+        missed,
+        (PUBLISHERS * PER_PUBLISHER - CLIENT_INBOX_CAPACITY) as u64,
+        "the reader must be told the exact size of its own gap"
     );
+
+    let mut accounted = evicted_ids(&bus, stalled.subscription_id());
+    accounted.extend(received);
+    accounted.sort();
     let mut delivered = delivered_ids(&bus);
-    let mut got = received;
     delivered.sort();
-    got.sort();
     assert_eq!(
-        got, delivered,
-        "the log's delivered set must equal what the subscriber received, \
-         whichever order the publishers won the gate in"
+        accounted, delivered,
+        "reads plus recorded losses must equal the log's delivered set"
+    );
+}
+
+#[tokio::test]
+async fn a_detached_subscription_stops_costing_the_instance() {
+    // The wedge's bound: a client that never polls costs the instance one
+    // buffer, and costs it nothing at all once its subscription drops. That is
+    // what makes eviction rather than refusal safe — there is no unbounded
+    // resource for a stalled client to consume, and no cleanup an operator has
+    // to perform.
+    let (_dir, bus) = bus();
+    let target = bus.registry().register("cto-assistant", None).unwrap();
+    let sender = registered_sender(&bus, "izzie");
+    let live = bus
+        .registry()
+        .resolve_instance(&target.instance_id)
+        .unwrap();
+
+    let wedged = bus.subscribe(&target.instance_id).unwrap();
+    assert_eq!(live.subscriber_count(), 1);
+    burst(
+        &bus,
+        &sender,
+        &target.instance_id,
+        CLIENT_INBOX_CAPACITY + 4,
+    );
+    assert_eq!(wedged.evicted_total(), 4);
+
+    drop(wedged);
+    assert_eq!(
+        live.subscriber_count(),
+        0,
+        "a dropped subscription must detach itself"
+    );
+    assert!(matches!(
+        bus.publish(
+            sender.clone(),
+            &PeerTarget::Instance(target.instance_id.clone()),
+            chat("after the client left"),
+            None,
+        ),
+        Err(BusError::NoSubscriber { .. })
+    ));
+}
+
+#[tokio::test]
+async fn deregister_ends_a_subscription_after_it_drains() {
+    // Deregistration used to end a stream by dropping the broadcast `Sender`.
+    // With per-client queues the end is stated explicitly, and it must not
+    // discard what the §9 log already recorded delivered — so the reader drains
+    // first and only then sees the end.
+    let (_dir, bus) = bus();
+    let target = bus.registry().register("cto-assistant", None).unwrap();
+    let sender = registered_sender(&bus, "izzie");
+    let subscription = bus.subscribe(&target.instance_id).unwrap();
+
+    let held = bus
+        .publish(
+            sender,
+            &PeerTarget::Instance(target.instance_id.clone()),
+            chat("read me before you go"),
+            None,
+        )
+        .unwrap();
+
+    assert!(bus.registry().deregister(&target.instance_id));
+
+    match subscription.recv().await {
+        Some(InboxItem::Envelope(envelope)) => assert_eq!(envelope.message_id, held.message_id),
+        other => panic!("a queued envelope must survive deregistration, got {other:?}"),
+    }
+    assert!(
+        subscription.recv().await.is_none(),
+        "and then the stream ends rather than hanging"
     );
 }
 
@@ -1038,7 +1358,7 @@ fn published_envelope_edge_is_derived() {
 fn publish_rejects_forged_user_kind() {
     let (_dir, bus) = bus();
     let target = bus.registry().register("cto-assistant", None).unwrap();
-    let mut rx = bus.subscribe(&target.instance_id).unwrap();
+    let rx = bus.subscribe(&target.instance_id).unwrap();
     let forged = CallerIdentity {
         kind: CallerKind::User,
         instance_id: None,
@@ -1057,14 +1377,14 @@ fn publish_rejects_forged_user_kind() {
             kind: CallerKind::User
         }
     );
-    assert!(rx.try_recv().is_err());
+    assert!(next_envelope(&rx).is_none());
 }
 
 #[test]
 fn publish_rejects_unregistered_sender() {
     let (_dir, bus) = bus();
     let target = bus.registry().register("cto-assistant", None).unwrap();
-    let mut rx = bus.subscribe(&target.instance_id).unwrap();
+    let rx = bus.subscribe(&target.instance_id).unwrap();
     assert_eq!(
         bus.publish(
             peer_caller("izzie~deadbeef", "izzie"),
@@ -1077,7 +1397,7 @@ fn publish_rejects_unregistered_sender() {
             instance_id: "izzie~deadbeef".into()
         }
     );
-    assert!(rx.try_recv().is_err());
+    assert!(next_envelope(&rx).is_none());
 }
 
 #[test]
@@ -1273,29 +1593,6 @@ fn bus_error_status_codes_map() {
 }
 
 #[test]
-fn subscriber_lagged_is_503() {
-    // #4271: distinct from `NoSubscriber`'s 409 because the recoveries differ —
-    // 409 means stop sending, 503 means retry once the recipient drains.
-    assert_eq!(
-        BusError::SubscriberLagged {
-            instance_id: "izzie~b1".into(),
-        }
-        .status(),
-        StatusCode::SERVICE_UNAVAILABLE
-    );
-    assert_ne!(
-        BusError::SubscriberLagged {
-            instance_id: "izzie~b1".into(),
-        }
-        .status(),
-        BusError::NoSubscriber {
-            instance_id: "izzie~b1".into()
-        }
-        .status()
-    );
-}
-
-#[test]
 fn instance_gone_is_410() {
     assert_eq!(
         BusError::InstanceGone {
@@ -1419,7 +1716,7 @@ async fn route_publish_delivers_and_returns_envelope() {
         .registry()
         .register("cto-assistant", None)
         .unwrap();
-    let mut rx = state.bus().subscribe(&target.instance_id).unwrap();
+    let rx = state.bus().subscribe(&target.instance_id).unwrap();
     let sender = state.bus().registry().register("izzie", None).unwrap();
 
     let (status, body) = call(
@@ -1439,7 +1736,7 @@ async fn route_publish_delivers_and_returns_envelope() {
     assert_eq!(status, StatusCode::ACCEPTED);
     assert_eq!(body["delivery_state"], "delivered");
     assert!(body["message_id"].as_str().is_some());
-    assert!(rx.try_recv().is_ok());
+    assert!(next_envelope(&rx).is_some());
 }
 
 #[tokio::test]
@@ -1450,7 +1747,7 @@ async fn route_publish_to_dead_instance_is_410() {
     let dead = state.bus().registry().register("izzie", None).unwrap();
     state.bus().registry().deregister(&dead.instance_id);
     let sibling = state.bus().registry().register("izzie", None).unwrap();
-    let mut sibling_rx = state.bus().subscribe(&sibling.instance_id).unwrap();
+    let sibling_rx = state.bus().subscribe(&sibling.instance_id).unwrap();
     let sender = state
         .bus()
         .registry()
@@ -1474,7 +1771,7 @@ async fn route_publish_to_dead_instance_is_410() {
     assert_eq!(status, StatusCode::GONE);
     assert!(body["error"].as_str().unwrap().contains("no longer live"));
     assert!(
-        sibling_rx.try_recv().is_err(),
+        next_envelope(&sibling_rx).is_none(),
         "supplying definition_id alongside a dead instance_id must NOT fall back"
     );
 }
@@ -1515,7 +1812,7 @@ async fn route_publish_forged_user_kind_is_400() {
         .registry()
         .register("cto-assistant", None)
         .unwrap();
-    let mut rx = state.bus().subscribe(&target.instance_id).unwrap();
+    let rx = state.bus().subscribe(&target.instance_id).unwrap();
 
     let (status, body) = call(
         &state,
@@ -1532,7 +1829,7 @@ async fn route_publish_forged_user_kind_is_400() {
     assert_eq!(status, StatusCode::BAD_REQUEST);
     assert!(body["error"].as_str().unwrap().contains("may not publish"));
     assert!(
-        rx.try_recv().is_err(),
+        next_envelope(&rx).is_none(),
         "a forged user-kind message must never reach the recipient"
     );
 }
@@ -1548,7 +1845,7 @@ async fn route_publish_unregistered_sender_is_403() {
         .registry()
         .register("cto-assistant", None)
         .unwrap();
-    let mut rx = state.bus().subscribe(&target.instance_id).unwrap();
+    let rx = state.bus().subscribe(&target.instance_id).unwrap();
 
     let (status, body) = call(
         &state,
@@ -1571,7 +1868,7 @@ async fn route_publish_unregistered_sender_is_403() {
             .unwrap()
             .contains("not a live registration")
     );
-    assert!(rx.try_recv().is_err());
+    assert!(next_envelope(&rx).is_none());
 }
 
 #[tokio::test]
@@ -1609,13 +1906,13 @@ async fn route_subscribe_to_dead_instance_is_410() {
 #[tokio::test]
 async fn subscribe_stream_reports_lag_instead_of_swallowing_it() {
     // #4271, the SSE half: a lagged subscriber used to be mapped to `None` —
-    // the frames vanished and the recipient was told nothing. It now gets a
-    // named `lagged` frame carrying the count and where to re-read from.
+    // the frames vanished and the recipient was told nothing. It gets a named
+    // `lagged` frame carrying the count, the subscription id its eviction
+    // records are keyed under, and where to re-read from.
     //
-    // The lag is induced by sending straight on the instance's channel rather
-    // than through `publish`, because `publish` now refuses a saturated
-    // channel: this arm survives only for a concurrent-publish race, and the
-    // direct send is what reproduces that state deterministically.
+    // Since #6462 the lag is produced by the ordinary publish path: the SSE
+    // body is never polled, so its own inbox fills and displaces. Nothing has
+    // to reach past the public API to stage it.
     let (_dir, state) = test_state();
     let meta = state
         .bus()
@@ -1634,25 +1931,23 @@ async fn subscribe_stream_reports_lag_instead_of_swallowing_it() {
     assert_eq!(resp.status(), StatusCode::OK);
 
     let overflow = 36;
-    let live = state
-        .bus()
-        .registry()
-        .resolve_instance(&meta.instance_id)
-        .unwrap();
-    for i in 0..(INSTANCE_CHANNEL_CAPACITY + overflow) {
-        live.tx
-            .send(BusEnvelope::new(
-                BusEdge::AssistantAssistant,
-                peer_caller("izzie~a1", "izzie"),
-                Recipient {
-                    instance_id: Some(meta.instance_id.clone()),
-                    definition_id: Some(meta.definition_id.clone()),
-                },
-                chat(&format!("burst {i}")),
-                None,
-                DeliveryState::Delivered,
-            ))
-            .unwrap();
+    let sender = state.bus().registry().register("izzie", None).unwrap();
+    let body = serde_json::json!({
+        "from": {
+            "kind": "assistant_instance",
+            "instance_id": sender.instance_id,
+            "definition_id": sender.definition_id,
+        },
+        "to": { "instance_id": meta.instance_id },
+        "payload": { "type": "chat_text", "text": "burst" }
+    });
+    for _ in 0..(CLIENT_INBOX_CAPACITY + overflow) {
+        let (status, _) = call(&state, post("/api/v1/bus/publish", body.clone())).await;
+        assert_eq!(
+            status,
+            StatusCode::ACCEPTED,
+            "a subscriber that never reads must not make the endpoint refuse"
+        );
     }
 
     let mut body = resp.into_body();
@@ -1671,16 +1966,24 @@ async fn subscribe_stream_reports_lag_instead_of_swallowing_it() {
         "the notice must carry how many envelopes were missed, got: {text}"
     );
     assert!(
+        text.contains("\"subscription_id\":"),
+        "the notice must name the subscription its eviction records are keyed \
+         under, got: {text}"
+    );
+    assert!(
         text.contains(state.bus().log_path().to_str().unwrap()),
         "the notice must name the durable log to re-read from, got: {text}"
     );
 }
 
 #[tokio::test]
-async fn route_publish_to_a_saturated_instance_is_503() {
-    // #4271: the refusal has to reach a real client, not just `BusError`'s
-    // status table. `subscriber_lagged_is_503` pins the mapping; this pins that
-    // `POST /api/v1/bus/publish` actually answers it.
+async fn route_publish_past_a_stalled_subscriber_is_accepted() {
+    // #6462 over the real transport, replacing
+    // `route_publish_to_a_saturated_instance_is_503`. That test filled the
+    // shared ring through a stalled subscriber and asserted the endpoint then
+    // answered `503` to everyone. The endpoint now answers `202` well past the
+    // stalled client's depth, and the §9 log carries one eviction record per
+    // envelope that client lost — the same evidence, moved off the publisher.
     let (_dir, state) = test_state();
     let target = state
         .bus()
@@ -1688,8 +1991,8 @@ async fn route_publish_to_a_saturated_instance_is_503() {
         .register("cto-assistant", None)
         .unwrap();
     let sender = state.bus().registry().register("izzie", None).unwrap();
-    // Attached and stalled: the receiver is held and never read.
-    let _stalled = state.bus().subscribe(&target.instance_id).unwrap();
+    // Attached and stalled: the subscription is held and never read.
+    let stalled = state.bus().subscribe(&target.instance_id).unwrap();
 
     let body = serde_json::json!({
         "from": {
@@ -1700,22 +2003,26 @@ async fn route_publish_to_a_saturated_instance_is_503() {
         "to": { "instance_id": target.instance_id },
         "payload": { "type": "chat_text", "text": "burst" }
     });
-    for _ in 0..INSTANCE_CHANNEL_CAPACITY {
+    let overflow = 5;
+    for _ in 0..(CLIENT_INBOX_CAPACITY + overflow) {
         let (status, _) = call(&state, post("/api/v1/bus/publish", body.clone())).await;
-        assert_eq!(status, StatusCode::ACCEPTED);
+        assert_eq!(
+            status,
+            StatusCode::ACCEPTED,
+            "a stalled subscriber must not refuse a publish over HTTP"
+        );
     }
 
-    let (status, answer) = call(&state, post("/api/v1/bus/publish", body)).await;
     assert_eq!(
-        status,
-        StatusCode::SERVICE_UNAVAILABLE,
-        "a full recipient channel must refuse over HTTP, not report 202"
+        stalled.evicted_total(),
+        overflow as u64,
+        "the stalled client absorbs its own backlog"
     );
+    let evictions = read_evictions(state.bus());
+    assert_eq!(evictions.len(), overflow);
     assert!(
-        answer["error"]
-            .as_str()
-            .unwrap_or_default()
-            .contains(&target.instance_id),
-        "the refusal must name the instance that is behind, got: {answer}"
+        evictions.iter().all(|e| e.instance_id == target.instance_id
+            && e.subscription_id == stalled.subscription_id()),
+        "every eviction record must name the client that lost the envelope"
     );
 }

--- a/crates/trusty-mpm/src/daemon/rpc/registry/tests.rs
+++ b/crates/trusty-mpm/src/daemon/rpc/registry/tests.rs
@@ -1404,7 +1404,7 @@ async fn parity_bus_publish_agrees_across_transports() {
         .registry()
         .register("cto-assistant", None)
         .expect("seed the target");
-    let mut rx = state
+    let rx = state
         .bus()
         .subscribe(&target.instance_id)
         .expect("attach a subscriber");
@@ -1422,7 +1422,7 @@ async fn parity_bus_publish_agrees_across_transports() {
     )
     .await;
     assert_eq!(status, StatusCode::ACCEPTED);
-    assert!(rx.try_recv().is_ok(), "the HTTP publish must deliver");
+    assert!(rx.try_recv().is_some(), "the HTTP publish must deliver");
 
     let rpc_body = rpc_ok(
         &rpc_router(&state),
@@ -1430,7 +1430,7 @@ async fn parity_bus_publish_agrees_across_transports() {
         publish_payload(&sender.instance_id, "cto-assistant"),
     )
     .await;
-    assert!(rx.try_recv().is_ok(), "the RPC publish must deliver too");
+    assert!(rx.try_recv().is_some(), "the RPC publish must deliver too");
 
     // `message_id` and `ts` are minted per envelope; everything else must match.
     assert_same(
@@ -1901,8 +1901,10 @@ fn rpc_error_codes_track_http_statuses_for_this_slice() {
 }
 
 /// Why every variant and not a sample: [`BusError`] is the enum whose whole
-/// purpose is that a sender can tell the five failures apart. A variant sharing
-/// another's code would silently undo that over the socket.
+/// purpose is that a sender can tell the failures apart. A variant sharing
+/// another's code would silently undo that over the socket. `SubscriberLagged`
+/// / `CODE_UNAVAILABLE` left the enum with #6462 — a slow subscriber is no
+/// longer a publish failure.
 /// Test: this function IS the test.
 #[test]
 fn bus_error_rpc_codes_track_http_statuses() {
@@ -1930,12 +1932,6 @@ fn bus_error_rpc_codes_track_http_statuses() {
                 instance_id: "i".into(),
             },
             CODE_CONFLICT,
-        ),
-        (
-            BusError::SubscriberLagged {
-                instance_id: "i".into(),
-            },
-            CODE_UNAVAILABLE,
         ),
         (
             BusError::InvalidTarget("neither id".into()),


### PR DESCRIPTION
Every subscriber of one bus instance shared a single 64-slot `broadcast` ring, and `broadcast` measures backlog across all attached receivers and cannot send to a subset — so #4271's fix could keep the DOC-60 §9 log truthful only by refusing the publish. One client with a full TCP window whose SSE body was never polled therefore made `POST /api/v1/bus/publish` answer `503` for every publisher and every healthy co-subscriber, unboundedly, until it drained, disconnected, or the instance was deregistered.

The delivery boundary moves from the instance to the client. Each subscription owns a bounded 64-envelope inbox (`bus/inbox.rs`), and one publish fans out into all of them under a single per-instance lock, so a stalled client falls behind alone: publishes are accepted, co-subscribers keep receiving in order, and the stalled inbox displaces its own oldest unread envelope. `BusError::SubscriberLagged` and the `503` / `CODE_UNAVAILABLE` answer retire with the wedge — a slow subscriber is no longer a publish failure, so there is nothing for a sender to retry.

Eviction policy: the oldest unread envelope in that one client's inbox loses, and every loss writes an `inbox_miss` record to the §9 stream naming the `message_id`, the `instance_id`, the `subscription_id` that lost it and the `reason`, plus an `InboxItem::Lagged` to that reader at the point of loss.

## Review round 1 — BLOCK closed

All four required changes are in `9e51095`. The promoted finding is left for the owner.

**1. CRITICAL — a closed inbox could report a delivery.** `ClientInbox::close` marks a subscription closed but leaves it in the set (only `InboxSubscription::drop` removes it), and `deliver` answered `None` for both "closed, took nothing" and "took it, displaced nothing". A publisher holding a `LiveInstance` clone resolved just before a deregister therefore got `Delivered { evicted: [] }`, wrote a `delivered` §9 record, and answered `202` for an envelope no inbox held.

`deliver` now returns a three-state `InboxAccept` (`Took` / `Displaced` / `Refused`), `fan_out` counts acceptances, and a fan-out nothing accepted is `DeliveryOutcome::NoSubscriber` — recorded `dropped`, answered `409`. For the partial case (one closed, one open) the closed subscription's loss is recorded with `reason: subscription_closed`; the critic offered "record it or narrow the postcondition", and recording it keeps the log answerable per client, which is the stronger of the two.

**2. HIGH — the guarantee rested on a silently-swallowed write.** `AuditLogger::log_record` swallows IO errors by §9's never-fail-the-hot-path design, so a failed loss record followed by a successful envelope record would produce a clean unexplained `delivered` line. Loss records now go through a new fallible `AuditLogger::try_log_record` (same single-`write_all` discipline), and if any fails, the envelope's own record is written with `losses_unrecorded: true` plus an `error!`. `serde(flatten)` on a small `EnvelopeRecord` wrapper means an ordinary record is byte-identical to the bare envelope, so §11 fidelity and existing readers are untouched — the key appears only in the case it describes. The hot path still never fails: the sender gets its `202`, because the envelope did reach the clients that took it.

**3. MEDIUM — the fan-out lock's ordering purpose is now falsifiable.** `concurrent_publishers_deliver_one_order_to_every_client`: 4 concurrent publisher threads, 2 clients, neither lagging, both drained at the end, sequences compared **unsorted**.

**4. MEDIUM — the wedged-client cost is stated accurately.** Both `PeerBus::publish` and `inbox`'s module doc previously implied the cost ends when the subscription drops. A TCP-wedged SSE body is never dropped (hyper stops polling the body without dropping the future), so the ongoing cost is now stated: a bounded buffer **plus one `inbox_miss` line and one `warn!` per subsequent publish, for as long as it stays attached**, with deregistering the instance as the operator's lever and the `warn!` naming which one. What is gone either way is the availability cost.

**5. Promoted, not fixed here.** Nothing caps subscriptions per instance. A cap value and its refusal status are a policy call, and no one-line version is natural, so nothing was added — `inbox.rs`'s module doc names it as the owner's call alongside a reaper and an idle timer.

**Also in this round:** the record is renamed `inbox_eviction` → `inbox_miss` with a `reason` field (`displaced` / `subscription_closed`), because a closed subscription's loss is not an eviction and one word for both would hide the difference. `BusError` gains `#[non_exhaustive]` per the FYI.

### Both regressions, demonstrated failing pre-fix

`a_publish_racing_deregistration_is_not_recorded_delivered` against the previous head `47615f13`:

```
thread '...a_publish_racing_deregistration_is_not_recorded_delivered' panicked at
crates/trusty-mpm/src/daemon/bus/tests.rs:2055:5:
assertion `left == right` failed: no inbox took the envelope, so nothing may report a delivery
  left: Delivered { evicted: [] }
 right: NoSubscriber

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 5553 filtered out
```

`concurrent_publishers_deliver_one_order_to_every_client` with the fan-out lock released between inboxes (`let inboxes = self.inboxes().clone();` + a `yield_now`), which is exactly the mutation the critic said failed nothing before:

```
assertion `left == right` failed: both clients must observe ONE order; a divergence
means the fan-out was interleaved and the lock is not doing what its doc claims
  left:  [4702c4f0…, e1c4e5ab…, 5f484141…, ecd5c10a…, 3f635bd7…, …]
 right:  [4702c4f0…, ecd5c10a…, e1c4e5ab…, 5f484141…, 3f635bd7…, …]

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 5557 filtered out
```

The two clients diverge at index 1 — one publisher reached client 1 between the other's two inbox writes.

## Review round 2 — WARN closed

All five findings are in `c2f3e5a`.

**1. HIGH — `subscribe` racing `deregister` left a subscription that never ended.** `PeerBus::subscribe` resolves the instance and then attaches, so an attach could land after `close_all` had already walked the set, producing an inbox with `closed: false` that nothing would ever close — the instance is out of the registry, so no publisher can reach it and no second deregister can fire. `recv` parked forever and the SSE handler held the stream open on keep-alives, a regression against the `broadcast` it replaced and a contradiction of `subscribe_instance`'s own doc.

`InboxSet` now holds its inboxes and a terminal flag in one `Mutex<SetState>`, so `attach` and `close_all` cannot interleave: `close_all` marks the set terminal, and an attach that sees a terminal set builds its `ClientInbox` already closed. Such a subscription drains nothing and ends on its first `recv`.

**2. MEDIUM — `record_losses` is now pinned directly.** `record_losses_reports_a_durable_write_it_could_not_make` asserts `false` against a writable bus (and that the record landed) and `true` against one whose stream directory is a file. The first assertion cannot compile at `47615f13`, where the method did not exist.

**3. MEDIUM — three dead `[`InboxEviction`]` doc links repaired.** `bash scripts/check_rustdoc_links.sh` on this head: `trusty-mpm` contributes **zero** rows. One row remains, in a crate this PR does not touch — see "Pre-existing, out of scope" below.

**4. LOW — write ordering is explicit.** `let losses_unrecorded = self.record_losses(&missed);` on its own line, with a comment saying the two statements are ordered and why folding them back would bury the invariant.

**5. LOW — a refusal no longer raises a lag notice.** Taken as "stop bumping" rather than "document why": `try_recv` yields lag before the queue, which is right for a displacement and wrong for a refusal, where the lost envelope is the newest.

### The consequence I followed through rather than papering over

The terminal flag makes an inbox set **all-open or all-closed** — a mix is now unrepresentable. So a `Refused` can never coexist with an acceptance in one fan-out, which means `MissReason::SubscriptionClosed` became **unreachable**: every refusal lands on the `accepted == 0` path, where `publish` records the envelope `dropped` and owes no per-client record (the reasoning round 2 verified as "Not a finding").

Rather than leave an unreachable variant and a serialized `reason` field that can only ever hold one value — a constant dressed as a measurement — `MissReason` is removed, `InboxAccept::Refused` becomes a unit variant, and `a_publish_racing_deregistration_records_the_closed_subscriptions_miss` is deleted because the state it built is no longer constructible. `InboxMiss` keeps its name: it describes the fact (one client will not read this envelope), not the mechanism, so a second cause later would not need a second shape. The `inbox_miss` record loses only its `reason` key; the changelog says so.

### The HIGH regression, demonstrated pre-fix

`a_subscription_attached_after_deregistration_ends_rather_than_parking` against the previous head `9e51095`. The `timeout` is the assertion — a parked `recv` never resolves, so the future stays pending for the full five seconds:

```
thread '...a_subscription_attached_after_deregistration_ends_rather_than_parking' panicked at
crates/trusty-mpm/src/daemon/bus/tests.rs:2287:10:
a subscription attached after deregistration must not park forever: Elapsed(())

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 5558 filtered out; finished in 5.02s
```

### Pre-existing, out of scope

`check_rustdoc_links.sh` reports one broken link on this branch, in a crate this PR does not touch:

```
LINK	trusty-common	crates/trusty-common/src/memory_core/retrieval/handle.rs:617	unresolved link to `check_secret`
FAIL	UNBASELINED	trusty-common has 1 broken link(s) and no baseline row
```

`git diff --name-only origin/main...HEAD -- crates/trusty-common/` is empty, so it is pre-existing on `main`. Left alone under this PR's bus-module-only scope; it will block a `trusty-common` tag, not this merge.

## What §7 settles, and what it does not

DOC-60 §7 is "Wake semantics". It specifies a **durable inbox with replay on connect** and is the section #6461's own `PeerBus::publish` doc and the owner ruling on #6462 both name for this work. It does **not** state a per-client buffer depth, nor which envelope loses when a live client's buffer is full, nor whether publish stays always-accept. Those three are decided here, in the direction that keeps the §9 log answerable, and the reasoning is in `bus/inbox.rs`'s module doc:

1. **Depth** carries the retired shared ring's 64 forward, now charged per client.
2. **Oldest loses.** #4271's defect was never the eviction — it was the lie. Refusing the newest instead would leave a recovering client reading stale traffic with no way to catch up, and would put the refusal back on the publisher, which is the wedge this closes.
3. **Publish is always-accept** for a slow subscriber, so the `503` arm retires with its docs updated. It is NOT always-accept when nothing took the envelope: that is `409`.

§7's **other** half — queueing to a definition with no running instance, without spawning one — is untouched and still deferred; that case still fails closed with `NoLiveInstance`.

**Readers of `logs/bus/*.jsonl` must tolerate a second record shape.** An envelope line has no `record` key; a miss line always carries `"record":"inbox_miss"` and a `reason`.

## Contract tests: kept, or superseded by a stronger per-client form

`concurrent_publishers_never_evict_a_delivered_envelope` is **replaced**, not weakened. It asserted that concurrent publishers could not push acceptance past the shared ring's depth — a ceiling that is gone by design. Its successor `concurrent_publishers_lose_nothing_without_a_record` (8 threads × 32 publishes against a stalled client) asserts the invariant where it still bites and per client: **reads ∪ recorded losses == the log's delivered set, exactly**. One unrecorded loss breaks it, and so does one miss record for an envelope that was never lost. It is also still the audit-interleaving test — it parses every line the concurrent publishes wrote.

| #6461 test | Disposition |
|---|---|
| `delivered_records_match_what_a_stalled_subscriber_receives` | → `delivered_records_account_for_everything_a_stalled_subscriber_lost` (per-client: reads ∪ recorded losses == delivered set) |
| `saturated_publish_is_dropped_in_the_durable_log` | → `eviction_is_recorded_per_client_in_the_durable_log` (no publish refused, one record per loss, oldest-first, reason asserted) |
| `two_subscribers_one_lagging_account_exactly` | kept, contract inverted: the fast client now receives **everything** and no publish is refused |
| `concurrent_publishers_never_evict_a_delivered_envelope` | → `concurrent_publishers_lose_nothing_without_a_record` (above) |
| `subscriber_lagged_is_503`, `route_publish_to_a_saturated_instance_is_503` | retired with the variant; the route case → `route_publish_past_a_stalled_subscriber_is_accepted` |
| `subscribe_stream_reports_lag_instead_of_swallowing_it` | kept; the lag is now staged through the ordinary publish path instead of reaching past the public API |

New this round: `a_publish_racing_deregistration_is_not_recorded_delivered`, `a_publish_racing_deregistration_records_the_closed_subscriptions_miss`, `concurrent_publishers_deliver_one_order_to_every_client`, `an_unwritable_log_never_reports_a_clean_delivery`, `a_fully_recorded_delivery_serializes_as_a_bare_envelope`. From round 1: `a_wedged_client_does_not_refuse_publishes_for_a_healthy_co_subscriber`, `miss_records_are_distinguishable_from_envelopes`, `a_stalled_subscriber_reads_its_lag_before_the_surviving_envelopes`, `a_detached_subscription_stops_costing_the_instance`, `deregister_ends_a_subscription_after_it_drains`.

### The original wedge, demonstrated pre-fix

`a_wedged_client_does_not_refuse_publishes_for_a_healthy_co_subscriber` written against unmodified `origin/main` (`a5e6812`) — one wedged client, one healthy drainer, 100 publishes:

```
assertion `left == right` failed: a wedged client must not make the instance refuse publishes
  left: 36
 right: 0
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 5549 filtered out
```

## Test ladder

Rung 5 (persistence + delivery contract), re-run in full on `c2f3e5a`.

- `cargo fmt --check` — `EXIT=0`
- `cargo check -p trusty-mpm --all-targets` — `EXIT=0`
- `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — `EXIT=0`
- `cargo test -p trusty-mpm --no-fail-fast` — `EXIT=0`; lib `test result: ok. 5553 passed; 0 failed; 7 ignored`, 54 targets all `ok`, none failed
- Concurrency/flake check, 10 consecutive runs of `cargo test -p trusty-mpm --lib --no-fail-fast -- daemon::bus::tests`: `failures=0`, each `test result: ok. 72 passed; 0 failed`
- `check_test_pointers.sh` (27952 citations, 0 dangling), `check_line_cap.sh` (0 violations), `check_sld.sh` (0 errors), `check_capabilities.sh` (up to date, no route or tool changed), `CHANGELOG_BASE=origin/main check_changelog_fragment.sh` — all pass
- `check_rustdoc_links.sh` — `trusty-mpm` contributes zero broken links; the one remaining row is pre-existing in `trusty-common` (above)

Tests updated this round: the record shape drops its `reason` key, and the partial-fan-out test is deleted as unconstructible. Everything else in the table above is unchanged.

Refs #6462
Refs #4271

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
