### PR TITLE
docs(trusty-common): repoint the dead check_secret rustdoc link

### DIFF
--- a/crates/trusty-common/src/memory_core/retrieval/handle.rs
+++ b/crates/trusty-common/src/memory_core/retrieval/handle.rs
@@ -614,8 +614,9 @@ impl PalaceHandle {
     /// `RememberOptions::allow_secret_like` opt-in bypasses the secret gate.
     /// What: Applies the supplied `FilterConfig` (skipping it entirely when
     /// `force == true`), THEN — unless `allow_secret_like == true` — always
-    /// runs [`check_secret`] regardless of `force`, classifies the content,
-    /// sets the appropriate TTL when the result is a `SessionEvent`, then
+    /// runs [`crate::memory_core::filter::check_secret`] regardless of
+    /// `force`, classifies the content, sets the appropriate TTL when the
+    /// result is a `SessionEvent`, then
     /// runs the original embed/upsert/persist pipeline under the default
     /// write-pipeline ceiling.
     ///


### PR DESCRIPTION
Repoints the unresolved `[`check_secret`]` intra-doc link at `crates/trusty-common/src/memory_core/retrieval/handle.rs:617` to its fully-qualified path (`crate::memory_core::filter::check_secret`), matching the pattern already used at `types.rs:129`, so `check_rustdoc_links.sh` stops blocking the trusty-common publish gate.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools