### PR TITLE
fix(trusty-analyze): probe the winner's socket before the kills (Refs #6411)

### DIFF
--- a/crates/trusty-analyze/tests/on_demand.rs
+++ b/crates/trusty-analyze/tests/on_demand.rs
@@ -376,6 +376,13 @@ async fn two_racing_server_processes_leave_exactly_one() {
         tokio::time::sleep(Duration::from_millis(100)).await;
     };
 
+    // #6411: probe while the winner is still RUNNING. Asking after the kills
+    // below measures the kill, not the race — a SIGKILLed winner stops serving
+    // and leaves its path behind, so the old check passed only when the connect
+    // beat signal delivery and failed ~20% of the time on a loaded CI runner.
+    let winner_still_serving =
+        trusty_common::uds::socket_is_serving(&socket, Duration::from_secs(1)).await;
+
     let _ = first.kill();
     let _ = second.kill();
 
@@ -383,10 +390,14 @@ async fn two_racing_server_processes_leave_exactly_one() {
         alive, 1,
         "exactly one server may hold the socket; {alive} processes survived the race"
     );
+    // A bare "still serving" is what the property needs, and it is stricter than
+    // the tolerate-a-missing-path form this replaces: an unlinked socket with
+    // the winner still alive IS the defect under test, so accepting it as a pass
+    // let the one outcome this test exists to catch through.
     assert!(
-        !socket.exists()
-            || trusty_common::uds::socket_is_serving(&socket, Duration::from_secs(1)).await,
-        "the loser must not have unlinked the winner's socket"
+        winner_still_serving,
+        "the loser must not have unlinked the winner's socket: {} is no longer served",
+        socket.display()
     );
 }
 


### PR DESCRIPTION
Refs #6411.

The `two_racing_server_processes_leave_exactly_one` assertion probed the winner's socket after SIGKILLing both children, so it passed only when the probe's connect() beat kill delivery — the ~21% shard-2 red on main (14 runs, all this one assertion, flaky since its introduction in #6355). The product unlink path is sound: `bind_singleton_hardened` unlinks only on a kernel-proven NotServing verdict, and the loser gets EADDRINUSE.

Test-only fix: capture the probe before the kills and drop the vacuous `!socket.exists()` arm (an unlinked socket with the winner alive is exactly the defect under test). A 500ms kill-to-assert delay reproduced the failure deterministically pre-fix (5/5); 129/130 clean post-fix under load. Test ladder: rung 2 (test-only stabilization). `cargo test -p trusty-analyze --no-fail-fast` → 554 passed / 0 failed / 1 ignored across 8 targets. No version bump, no changelog fragment (test-only).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools