### PR TITLE
fix(trusty-agents): batch — hermetic credential status, bundled-asset allowlist, one HOME lock, trace_flow identity (Refs #5678, #5226, #6089, #6232)

### DIFF
--- a/.test-pointer-allowlist.tsv
+++ b/.test-pointer-allowlist.tsv
@@ -144,7 +144,6 @@ crates/trusty-agents/src/ticketing/mod.rs	build_client_force_gh_cli_falls_back_t
 crates/trusty-agents/src/ticketing/mod.rs	from_env_reads_github_token
 crates/trusty-agents/src/tm/commands/mod.rs	dispatch_help
 crates/trusty-agents/src/tm/commands/mod.rs	dispatch_unknown
-crates/trusty-agents/src/tools/analysis/trace_flow.rs	trace_flow_outgoing_smoke
 crates/trusty-agents/src/tools/mcp_service_tools.rs	formats_text_content
 crates/trusty-agents/src/tools/mcp_service_tools.rs	mcp_service_tool_executors_returns_tools_for_enabled_services
 crates/trusty-agents/src/tools/mcp_service_tools.rs	surfaces_call_errors

--- a/crates/trusty-agents/changelog.d/5226-bundled-asset-allowlist.md
+++ b/crates/trusty-agents/changelog.d/5226-bundled-asset-allowlist.md
@@ -1,0 +1,9 @@
+Fixed
+
+- The `BundledAgents` and `BundledWorkflows` embed trees now carry an explicit
+  allowlist, so a stray local file — a `.env`, an editor backup, one of
+  `atomic_write`'s `.lock` sidecars — can no longer ship inside the `tagent`
+  binary or be written into a user's `~/.trusty-agents/` (#5226). The filter is
+  applied twice: `#[include]` globs at build time, and `is_bundled_asset` at
+  deploy time, so a binary built before the globs existed still cannot
+  materialise a stray file. The bundle stamp hashes the same filtered set.

--- a/crates/trusty-agents/changelog.d/5678-hermetic-credential-status.md
+++ b/crates/trusty-agents/changelog.d/5678-hermetic-credential-status.md
@@ -1,0 +1,7 @@
+Fixed
+
+- `system_status`'s credential listing no longer reads the developer's own
+  `.env.local` when a caller supplies its own source. `list_status_from` takes
+  a `&dyn EnvLocalSource` alongside the existing `&dyn KeyStore`, so
+  `credential_status_never_leaks_a_value` reports the store tier regardless of
+  what an ancestor `.env.local` binds (#5678). Tier precedence is unchanged.

--- a/crates/trusty-agents/changelog.d/6089-one-home-lock-discipline.md
+++ b/crates/trusty-agents/changelog.d/6089-one-home-lock-discipline.md
@@ -1,0 +1,10 @@
+Fixed
+
+- `assistants::tests::home_tests` guarded its `$HOME` mutations with
+  `#[serial]` while the rest of the crate guards the same global with
+  `test_env::HOME_LOCK` — two disjoint locks, so the two groups interleaved and
+  `okg_store_path_matches_the_owners_spelling` compared paths under two
+  different tempdirs (#6089). Those tests now take `HOME_LOCK` as well, and a
+  new `home_lock_discipline` test fails any source file that mutates `$HOME`
+  without acquiring it, so the point fix cannot silently lapse again as #3952's
+  did.

--- a/crates/trusty-agents/changelog.d/6232-trace-flow-node-identity.md
+++ b/crates/trusty-agents/changelog.d/6232-trace-flow-node-identity.md
@@ -1,0 +1,12 @@
+Fixed
+
+- `trace_execution_flow` no longer mixes two same-named definitions in one
+  trace (#6232). It anchored on the first node in insertion order and then
+  re-queried callees by bare name, which resolves to the most-connected
+  definition — so the reported root file and line could describe one function
+  while the listed callees came from another. It now anchors through
+  `SymbolGraph::resolve_symbol` and traverses by each node's `<file>::<symbol>`
+  key.
+- `trace_execution_flow` accepts a `<path>::<symbol>` entry point, which
+  previously found nothing, and reports the other candidates under
+  `ambiguous_with` when a bare name matches several definitions.

--- a/crates/trusty-agents/src/agents/bundled/mod.rs
+++ b/crates/trusty-agents/src/agents/bundled/mod.rs
@@ -88,8 +88,14 @@ mod stamp;
 /// persona set (`assistant`, `ctrl`, `pm`, `cto-assistant`, `izzie`) and the
 /// specialist roster (`python-engineer`, `qa-agent`, …) — into the compiled
 /// binary at build time.
+/// #5226: an allowlist, so a stray local file cannot ship inside the binary.
+/// See [`is_bundled_asset`] for why the filter is an allowlist and not a
+/// denylist, and for the second layer that repeats it at deploy time.
 #[derive(rust_embed::RustEmbed)]
 #[folder = ".trusty-agents/agents/"]
+#[include = "*.toml"]
+#[include = "*.md"]
+#[include = "*.json"]
 struct BundledAgents;
 
 /// Embeds this crate's own `.trusty-agents/workflows/` tree — the prescriptive
@@ -103,9 +109,77 @@ struct BundledAgents;
 /// What: same `rust-embed` mechanism as [`BundledAgents`], deployed by
 /// [`ensure_bundled_workflows_deployed`] through the SAME stamp/lock/refresh
 /// path — see [`reprovision_embedded_locked`].
+/// #5226: same allowlist as [`BundledAgents`] — see [`is_bundled_asset`].
 #[derive(rust_embed::RustEmbed)]
 #[folder = ".trusty-agents/workflows/"]
+#[include = "*.toml"]
+#[include = "*.md"]
+#[include = "*.json"]
 struct BundledWorkflows;
+
+/// Is `rel` a file the bundle is allowed to ship and deploy? (#5226)
+///
+/// Why: `rust-embed` embeds whatever physically sits in the folder at build
+/// time and ignores `.gitignore`, so a stray local file left in
+/// `.trusty-agents/agents/` before a release build ships inside the
+/// distributed `tagent` binary and — because that tree is deployed to
+/// `~/.trusty-agents/agents/` — gets written into every user's home. A `.env`
+/// is the worst case; `state_writer::atomic_write` leaves a `<file>.lock`
+/// sidecar beside every file it writes, so a `.lock` reaching a source asset
+/// directory is realistic rather than hypothetical. This is an ALLOWLIST, not
+/// a denylist, so a stray file of a kind nobody anticipated is excluded by
+/// default: a bundled file that fails to ship is loud (the agent does not
+/// resolve), a secret that ships is silent.
+/// What: accepts a path whose extension is one of the three the bundle
+/// actually uses — `toml`, `md`, `json` — and whose every path component is
+/// dotless. It repeats, at deploy time, what the `#[include]` globs on
+/// [`BundledAgents`] and [`BundledWorkflows`] already do at build time; a
+/// binary built before that filter existed still cannot write a stray file
+/// into a user's home.
+/// Test: `bundled_asset_predicate_fails_closed`,
+/// `stray_files_in_the_asset_tree_are_never_deployed`,
+/// `embedded_trees_carry_only_bundled_assets` (tests.rs).
+fn is_bundled_asset(rel: &str) -> bool {
+    let mut components = rel.split('/').peekable();
+    let mut last = "";
+    for component in components.by_ref() {
+        if component.is_empty() || component.starts_with('.') {
+            return false;
+        }
+        last = component;
+    }
+    matches!(
+        last.rsplit_once('.').map(|(_, ext)| ext),
+        Some("toml") | Some("md") | Some("json")
+    )
+}
+
+/// Every `(path, bytes)` pair the bundle `E` actually contributes (#5226).
+///
+/// Why: the stamp and the write loop both have to agree on what "the bundle"
+/// is — a stray file that changed the stamp but was never written would make
+/// every startup see a stale stamp and refresh forever. One filtered read
+/// keeps them from drifting.
+/// What: walks `E::iter()`, drops anything [`is_bundled_asset`] rejects with a
+/// `warn` naming it, and returns the rest.
+/// Test: `stray_files_in_the_asset_tree_are_never_deployed`,
+/// `stray_files_do_not_move_the_bundle_stamp` (tests.rs).
+fn bundled_assets<E: rust_embed::RustEmbed>() -> Result<Vec<(String, Vec<u8>)>> {
+    let mut out = Vec::new();
+    for rel in E::iter() {
+        if !is_bundled_asset(rel.as_ref()) {
+            tracing::warn!(
+                asset = %rel,
+                "ignoring a file in the embedded asset tree that is not a bundled asset"
+            );
+            continue;
+        }
+        let file =
+            E::get(&rel).with_context(|| format!("embedded bundled asset vanished: {rel}"))?;
+        out.push((rel.to_string(), file.data.into_owned()));
+    }
+    Ok(out)
+}
 
 /// Outcome of one (re)provision pass over the bundled agent set (#3556).
 ///
@@ -223,10 +297,9 @@ fn reprovision_embedded_locked<E: rust_embed::RustEmbed>(
     refresh_stale: bool,
 ) -> Result<ReprovisionReport> {
     let mut report = ReprovisionReport::default();
-    for rel in E::iter() {
-        let dest = target_dir.join(rel.as_ref());
-        let file =
-            E::get(&rel).with_context(|| format!("embedded bundled asset vanished: {rel}"))?;
+    // #5226: a path the bundle does not own is never materialised here.
+    for (rel, bytes) in bundled_assets::<E>()? {
+        let dest = target_dir.join(&rel);
 
         if dest.exists() {
             if !refresh_stale {
@@ -234,7 +307,7 @@ fn reprovision_embedded_locked<E: rust_embed::RustEmbed>(
             }
             let current = std::fs::read(&dest)
                 .with_context(|| format!("failed to read existing {}", dest.display()))?;
-            if current == file.data.as_ref() {
+            if current == bytes {
                 continue;
             }
             // #4461: the backup name carries the digest of the bytes being
@@ -256,13 +329,13 @@ fn reprovision_embedded_locked<E: rust_embed::RustEmbed>(
                 );
                 report.backed_up += 1;
             }
-            crate::state_writer::atomic_write(&dest, file.data.as_ref())
+            crate::state_writer::atomic_write(&dest, &bytes)
                 .with_context(|| format!("failed to refresh {}", dest.display()))?;
             report.refreshed += 1;
             continue;
         }
 
-        crate::state_writer::atomic_write(&dest, file.data.as_ref())
+        crate::state_writer::atomic_write(&dest, &bytes)
             .with_context(|| format!("failed to write {}", dest.display()))?;
         report.written += 1;
     }
@@ -322,13 +395,9 @@ fn stale_backup_path(dest: &Path, content: &[u8]) -> PathBuf {
 /// Test: `stamp_changes_when_content_changes`,
 /// `stamp_stable_regardless_of_input_order` (`stamp`'s own tests).
 fn current_bundle_stamp<E: rust_embed::RustEmbed>() -> Result<String> {
-    let mut entries: Vec<(String, Vec<u8>)> = Vec::new();
-    for rel in E::iter() {
-        let file =
-            E::get(&rel).with_context(|| format!("embedded bundled asset vanished: {rel}"))?;
-        entries.push((rel.to_string(), file.data.into_owned()));
-    }
-    Ok(stamp::compute(entries))
+    // #5226: the same filtered view the write loop uses, so a stray file can
+    // never make the stamp disagree with what actually gets deployed.
+    Ok(stamp::compute(bundled_assets::<E>()?))
 }
 
 /// Hermetic core of [`ensure_bundled_agents_deployed`] — takes `target_dir`

--- a/crates/trusty-agents/src/agents/bundled/tests.rs
+++ b/crates/trusty-agents/src/agents/bundled/tests.rs
@@ -946,3 +946,135 @@ fn stray_files_do_not_move_the_bundle_stamp() {
         "the stamp must hash the bundled file set, not the raw embed tree"
     );
 }
+
+/// Every entry under `dir` — files AND directories — as a `/`-joined path
+/// relative to `dir`, paired with its own `symlink_metadata` (#5226).
+///
+/// Why: [`source_tree_paths`] answers "which files are here" and follows
+/// symlinks to do it, so a link is indistinguishable from the file it names.
+/// The two tests below need the opposite: the link ITSELF, unresolved.
+/// What: reads each directory entry, stats it with `symlink_metadata` (which
+/// never traverses the final component), and descends only into a real
+/// directory — so a symlinked directory is reported once and never walked.
+/// Test: `no_symlink_reaches_the_embedded_asset_trees`,
+/// `every_source_file_is_a_bundled_asset_or_known_junk`.
+fn source_tree_entries(
+    dir: &Path,
+    prefix: &str,
+    out: &mut Vec<(String, std::fs::Metadata)>,
+) -> std::io::Result<()> {
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let name = entry.file_name().to_string_lossy().to_string();
+        let rel = if prefix.is_empty() {
+            name
+        } else {
+            format!("{prefix}/{name}")
+        };
+        let meta = std::fs::symlink_metadata(entry.path())?;
+        let descend = !meta.is_symlink() && meta.is_dir();
+        out.push((rel.clone(), meta));
+        if descend {
+            source_tree_entries(&entry.path(), &rel, out)?;
+        }
+    }
+    Ok(())
+}
+
+/// The two embedded source trees, as `(name, absolute path)` (#5226).
+fn embedded_source_trees() -> [(&'static str, PathBuf); 2] {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join(".trusty-agents");
+    [
+        ("agents", root.join("agents")),
+        ("workflows", root.join("workflows")),
+    ]
+}
+
+/// Why (#5226): [`is_bundled_asset`] and the `#[include]` globs both match on
+/// the NAME, and `rust-embed-utils` walks the folder with `.follow_links(true)`
+/// (8.11.0, `lib.rs:18`). A symlink named `persona.md` planted in
+/// `.trusty-agents/agents/` before a release build therefore passes both
+/// filters and embeds its TARGET's bytes into the shipped binary — which is
+/// then written into every user's `~/.trusty-agents/`. A link to `~/.ssh/id_rsa`
+/// is the worst case, and the allowlist cannot see it: only the file type can.
+/// What: walks both source trees without resolving links and fails naming every
+/// entry that is itself a symlink, file and directory alike. A symlinked
+/// directory would embed its whole target subtree, so it is caught the same way.
+/// Test: itself.
+#[test]
+fn no_symlink_reaches_the_embedded_asset_trees() {
+    let mut offenders: Vec<String> = Vec::new();
+    for (tree, dir) in embedded_source_trees() {
+        let mut entries = Vec::new();
+        source_tree_entries(&dir, "", &mut entries)
+            .unwrap_or_else(|e| panic!("{tree}: cannot walk {}: {e}", dir.display()));
+        assert!(!entries.is_empty(), "{tree}: no source entries found");
+        for (rel, meta) in entries {
+            if meta.is_symlink() {
+                offenders.push(format!("{tree}/{rel}"));
+            }
+        }
+    }
+    offenders.sort();
+
+    assert!(
+        offenders.is_empty(),
+        "these entries in the embedded asset trees are symlinks, so a release \
+         build would embed their targets' bytes and write them into every \
+         user's home — replace each with a real file (#5226): {offenders:?}"
+    );
+}
+
+/// Names a stray file is allowed to carry without failing the tripwire below.
+///
+/// Why (#5226): the strays that actually reach these trees are editor and tool
+/// droppings, and they must not be mistaken for a new asset kind nobody wired
+/// up. Everything else — including `.DS_Store` and any dotfile — is either a
+/// bundled asset or a mistake.
+/// What: dotfiles (which covers `.env`, `.gitignore`, `.DS_Store`), `*.bak`
+/// editor backups, and the `*.lock` sidecars `state_writer::atomic_write` drops.
+/// Test: `every_source_file_is_a_bundled_asset_or_known_junk`.
+fn is_known_junk(rel: &str) -> bool {
+    let name = rel.rsplit('/').next().unwrap_or(rel);
+    name.starts_with('.') || name.ends_with(".bak") || name.ends_with(".lock")
+}
+
+/// Why (#5226): `embedded_trees_carry_only_bundled_assets` filters BOTH of its
+/// comparands through [`is_bundled_asset`], so a real new asset kind — a
+/// `roster.yaml`, say — is subtracted from the embedded set and from the
+/// expected set alike, and that test stays green while the asset silently never
+/// ships. Filtering both sides can only prove the two filters agree; it can
+/// never notice a file neither side was asked about.
+/// What: walks both source trees UNFILTERED and requires every file to be
+/// either accepted by [`is_bundled_asset`] or matched by [`is_known_junk`]. An
+/// unrecognised real extension fails here, at the point where a human can
+/// decide whether to add it to the allowlist and the `#[include]` globs or to
+/// delete it.
+/// Test: itself.
+#[test]
+fn every_source_file_is_a_bundled_asset_or_known_junk() {
+    let mut unrecognised: Vec<String> = Vec::new();
+    for (tree, dir) in embedded_source_trees() {
+        let mut entries = Vec::new();
+        source_tree_entries(&dir, "", &mut entries)
+            .unwrap_or_else(|e| panic!("{tree}: cannot walk {}: {e}", dir.display()));
+        assert!(!entries.is_empty(), "{tree}: no source entries found");
+        for (rel, meta) in entries {
+            if meta.is_dir() {
+                continue;
+            }
+            if !is_bundled_asset(&rel) && !is_known_junk(&rel) {
+                unrecognised.push(format!("{tree}/{rel}"));
+            }
+        }
+    }
+    unrecognised.sort();
+
+    assert!(
+        unrecognised.is_empty(),
+        "these source files are neither bundled assets nor recognised strays, \
+         so they are silently absent from the shipped binary — extend \
+         `is_bundled_asset` and the `#[include]` globs if they belong in the \
+         bundle, or delete them (#5226): {unrecognised:?}"
+    );
+}

--- a/crates/trusty-agents/src/agents/bundled/tests.rs
+++ b/crates/trusty-agents/src/agents/bundled/tests.rs
@@ -758,3 +758,191 @@ fn agent_and_workflow_bundles_hash_differently() {
         current_bundle_stamp::<BundledWorkflows>().unwrap()
     );
 }
+
+/// A synthetic embed tree standing in for a source asset directory that
+/// picked up stray local files before a build (#5226).
+///
+/// Why: `RustEmbed` embeds whatever physically sits in the folder at build
+/// time and ignores `.gitignore`, so a `.env`, an editor backup, or one of
+/// `state_writer::atomic_write`'s `<file>.lock` sidecars left in
+/// `.trusty-agents/agents/` ships inside the distributed `tagent` binary and
+/// is then written into every user's home. A committed fixture directory
+/// cannot express that — `.env*` and `*.bak` are gitignored — so the file set
+/// is stated in code instead.
+/// What: a hand-written `RustEmbed` impl (no derive, no folder) over four
+/// paths: one legitimate bundled agent and three strays.
+/// Test: `stray_files_in_the_asset_tree_are_never_deployed`.
+struct StrayAssetTree;
+
+/// `(path, bytes)` pairs [`StrayAssetTree`] serves.
+const STRAY_TREE: &[(&str, &[u8])] = &[
+    ("assistant/agent.toml", b"[agent]\nname = \"assistant\"\n"),
+    (".env", b"OPENROUTER_API_KEY=sk-or-should-never-ship\n"),
+    // Deliberately NOT `assistant/agent.toml.lock`: `atomic_write` leaves its
+    // own sidecar at exactly that path when it writes the bundled file, so the
+    // stray has to name a file this fixture never deploys.
+    ("ctrl.toml.lock", b"lock-sidecar\n"),
+    ("assistant/persona.md.bak", b"editor backup\n"),
+];
+
+impl rust_embed::RustEmbed for StrayAssetTree {
+    fn get(file_path: &str) -> Option<rust_embed::EmbeddedFile> {
+        STRAY_TREE
+            .iter()
+            .find(|(path, _)| *path == file_path)
+            .map(|(_, bytes)| rust_embed::EmbeddedFile {
+                data: std::borrow::Cow::Borrowed(bytes),
+                // `Metadata` has no public constructor; this doc-hidden one is
+                // what the derive macro itself emits.
+                metadata: rust_embed::Metadata::__rust_embed_new([0u8; 32], None, None),
+            })
+    }
+
+    fn iter() -> impl Iterator<Item = std::borrow::Cow<'static, str>> + 'static {
+        STRAY_TREE
+            .iter()
+            .map(|(path, _)| std::borrow::Cow::Borrowed(*path))
+    }
+}
+
+/// Why (#5226): the deploy loop wrote every path the embed tree offered, so a
+/// stray file that reached the build reached the user's `$HOME` too — a `.env`
+/// among them. The filter is what stops a non-bundled path from ever being
+/// materialised.
+/// What: deploys [`StrayAssetTree`] into a tempdir and asserts the legitimate
+/// agent file landed while none of the three strays did, and that the report
+/// counts only the file actually written.
+/// Test: itself.
+#[test]
+fn stray_files_in_the_asset_tree_are_never_deployed() {
+    let tmp = tempfile::tempdir().unwrap();
+    let guard = lock::acquire(tmp.path()).unwrap();
+    let report = reprovision_embedded_locked::<StrayAssetTree>(&guard, tmp.path(), false).unwrap();
+
+    assert!(
+        tmp.path().join("assistant/agent.toml").is_file(),
+        "the legitimate bundled agent must still deploy"
+    );
+    for stray in [".env", "ctrl.toml.lock", "assistant/persona.md.bak"] {
+        assert!(
+            !tmp.path().join(stray).exists(),
+            "{stray} must never be materialised under the deploy target"
+        );
+    }
+    assert_eq!(report.written, 1, "only the bundled file counts as written");
+}
+
+/// Why (#5226): the allowlist is the whole defence, so its edges are pinned
+/// directly — a dotfile, a lock sidecar, an editor backup and a dotted
+/// directory component must all be rejected, and the three extensions the
+/// bundle actually uses must all be accepted at any depth.
+/// Test: itself.
+#[test]
+fn bundled_asset_predicate_fails_closed() {
+    for accepted in [
+        "pm.toml",
+        "assistant/agent.toml",
+        "assistant/persona.md",
+        "izzie/events/gmail.md",
+        "prescriptive.json",
+    ] {
+        assert!(is_bundled_asset(accepted), "{accepted} must be bundled");
+    }
+    for rejected in [
+        ".env",
+        ".env.local",
+        "assistant/.env",
+        "assistant/agent.toml.lock",
+        "assistant/persona.md.bak",
+        ".DS_Store",
+        ".gitignore",
+        "assistant/agent.toml.stale.abc123.bak",
+        "notes",
+        "script.sh",
+    ] {
+        assert!(!is_bundled_asset(rejected), "{rejected} must be rejected");
+    }
+}
+
+/// Every file under `dir`, as a `/`-joined path relative to it.
+fn source_tree_paths(dir: &Path) -> Vec<String> {
+    fn walk(dir: &Path, prefix: &str, out: &mut Vec<String>) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let name = entry.file_name().to_string_lossy().to_string();
+            let rel = if prefix.is_empty() {
+                name
+            } else {
+                format!("{prefix}/{name}")
+            };
+            if entry.path().is_dir() {
+                walk(&entry.path(), &rel, out);
+            } else {
+                out.push(rel);
+            }
+        }
+    }
+    let mut out = Vec::new();
+    walk(dir, "", &mut out);
+    out.sort();
+    out
+}
+
+/// Why (#5226): the `#[include]` globs are the build-time half of the filter.
+/// Nothing that fails [`is_bundled_asset`] may reach the embedded set — and the
+/// globs must not have quietly dropped part of the real roster while excluding
+/// strays, which an anchor-file spot check would miss.
+/// What: compares each embedded set against the source tree it is built from,
+/// filtered by the same predicate — so the assertion states the whole expected
+/// file list without hard-coding one that rots on the next roster change. A
+/// stray file a developer happens to have locally is filtered out of BOTH
+/// sides, so it cannot fail this test spuriously.
+/// Test: itself.
+#[test]
+fn embedded_trees_carry_only_bundled_assets() {
+    let source_root = Path::new(env!("CARGO_MANIFEST_DIR")).join(".trusty-agents");
+
+    for (tree, embedded) in [
+        ("agents", {
+            let mut v: Vec<String> = BundledAgents::iter().map(|r| r.to_string()).collect();
+            v.sort();
+            v
+        }),
+        ("workflows", {
+            let mut v: Vec<String> = BundledWorkflows::iter().map(|r| r.to_string()).collect();
+            v.sort();
+            v
+        }),
+    ] {
+        let expected: Vec<String> = source_tree_paths(&source_root.join(tree))
+            .into_iter()
+            .filter(|rel| is_bundled_asset(rel))
+            .collect();
+        assert!(!expected.is_empty(), "{tree}: no source assets found");
+        assert_eq!(
+            embedded, expected,
+            "{tree}: the embedded set does not match the bundled source files"
+        );
+    }
+}
+
+/// Why (#5226): the stamp and the write loop must read the SAME bundle. A
+/// stray file that moved the stamp but was never written would leave every
+/// startup seeing a stale stamp and refreshing forever.
+/// What: hashes the stray tree and asserts the digest equals the one its single
+/// bundled file alone produces.
+/// Test: itself.
+#[test]
+fn stray_files_do_not_move_the_bundle_stamp() {
+    let bundled_only = stamp::compute(vec![(
+        "assistant/agent.toml".to_string(),
+        b"[agent]\nname = \"assistant\"\n".to_vec(),
+    )]);
+    assert_eq!(
+        current_bundle_stamp::<StrayAssetTree>().unwrap(),
+        bundled_only,
+        "the stamp must hash the bundled file set, not the raw embed tree"
+    );
+}

--- a/crates/trusty-agents/src/assistants/tests/home_tests.rs
+++ b/crates/trusty-agents/src/assistants/tests/home_tests.rs
@@ -24,6 +24,11 @@ use crate::assistants::{
 ///
 /// Mirrors the crate's established `#[serial]` + guard convention (see
 /// `workflow::engine::executor::tests::checkpoint_resume`).
+///
+/// #6089: `#[serial]` alone is NOT enough when the variable is `HOME` — the
+/// crate's ~30 other `$HOME` mutators serialize on `test_env::HOME_LOCK`, a
+/// different mutex, so every test here that touches `HOME` takes that lock too.
+/// `tests::home_lock_discipline` is what keeps that true.
 pub(super) struct EnvVarGuard {
     key: &'static str,
     prev: Option<String>,
@@ -32,7 +37,8 @@ pub(super) struct EnvVarGuard {
 impl EnvVarGuard {
     pub(super) fn set(key: &'static str, value: &Path) -> Self {
         let prev = std::env::var(key).ok();
-        // SAFETY: serialized against other env-mutating tests by `#[serial]`.
+        // SAFETY: serialized by `#[serial]`, and for `HOME` by the caller's
+        // `test_env::HOME_LOCK` guard as well (#6089).
         unsafe { std::env::set_var(key, value) };
         Self { key, prev }
     }
@@ -115,6 +121,10 @@ fn for_instance_validates_the_id() {
 #[test]
 #[serial]
 fn default_root_is_dotless_under_the_user_home() {
+    // #6089: declared first so it outlives the guards that restore $HOME.
+    let _home_lock = crate::test_env::HOME_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
     let tmp = tempfile::tempdir().unwrap();
     let _no_override = EnvVarGuard::clear(ASSISTANTS_DIR_ENV);
     let _home = EnvVarGuard::set("HOME", tmp.path());
@@ -134,6 +144,12 @@ fn default_root_is_dotless_under_the_user_home() {
 #[test]
 #[serial]
 fn okg_store_path_matches_the_owners_spelling() {
+    // #6089: this is the test that flaked — it compared paths under two
+    // different tempdirs because a HOME_LOCK holder ran between its set and
+    // its read.
+    let _home_lock = crate::test_env::HOME_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
     let tmp = tempfile::tempdir().unwrap();
     let _no_override = EnvVarGuard::clear(ASSISTANTS_DIR_ENV);
     let _home = EnvVarGuard::set("HOME", tmp.path());
@@ -159,6 +175,10 @@ fn okg_store_path_matches_the_owners_spelling() {
 #[test]
 #[serial]
 fn env_override_wins_over_the_user_home() {
+    // #6089: same lock discipline as its two siblings above.
+    let _home_lock = crate::test_env::HOME_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
     let tmp = tempfile::tempdir().unwrap();
     let elsewhere = tmp.path().join("elsewhere");
     let _home = EnvVarGuard::set("HOME", tmp.path());

--- a/crates/trusty-agents/src/system_status/credentials.rs
+++ b/crates/trusty-agents/src/system_status/credentials.rs
@@ -8,8 +8,9 @@
 //! tier-classification logic (`classify_tier`) to build a structured
 //! `Vec<CredentialStatus>` — the same decision, a machine-readable shape.
 //! What: [`CredentialStatus`] + [`list_status`], parameterised over a
-//! `&dyn KeyStore` so tests can inject a sandboxed `FileKeyStore` instead of
-//! touching the real OS keychain / secure store.
+//! `&dyn KeyStore` AND a `&dyn EnvLocalSource` so tests can inject a sandboxed
+//! `FileKeyStore` and a fixed `.env.local` table instead of touching the real
+//! OS keychain / secure store or the real filesystem.
 //! Test: `super::tests::credential_status_never_leaks_a_value`.
 
 use serde::Serialize;
@@ -22,6 +23,35 @@ use trusty_common::inference::registry::all;
 pub struct CredentialStatus {
     pub provider: String,
     pub status: String,
+}
+
+/// The `.env.local` tier signal, injectable exactly like `store: &dyn KeyStore`.
+///
+/// Why: [`list_status`] read that signal straight from
+/// `trusty_common::credentials::env_local_value`, which searches upward from the
+/// real `std::env::current_dir()` for a real `.env.local`. A developer's own
+/// `.env.local` — the file this crate's CLAUDE.md tells everyone to create —
+/// therefore decided what the tests observed, so
+/// `credential_status_never_leaks_a_value` failed on any machine whose ancestor
+/// `.env.local` bound `OPENROUTER_API_KEY` (#5678). The precedence
+/// `classify_tier` applies is correct and stays untouched; only where the signal
+/// comes from becomes injectable.
+/// What: one method answering the same question `env_local_value` answers.
+/// Production passes [`WorkspaceEnvLocal`]; tests pass a fixed table and read no
+/// file at all.
+/// Test: `super::tests::env_local_tier_comes_from_the_injected_source`.
+pub trait EnvLocalSource {
+    /// The value `.env.local` binds to `var`, or `None` when it binds nothing.
+    fn value(&self, var: &str) -> Option<String>;
+}
+
+/// Production [`EnvLocalSource`] — the cwd-upward `.env.local` search.
+pub struct WorkspaceEnvLocal;
+
+impl EnvLocalSource for WorkspaceEnvLocal {
+    fn value(&self, var: &str) -> Option<String> {
+        env_local_value(var)
+    }
 }
 
 /// List every known provider's key status (names/tiers only).
@@ -37,6 +67,23 @@ pub struct CredentialStatus {
 /// Test: `super::tests::credential_status_never_leaks_a_value`,
 /// `super::tests::unconfigured_provider_reports_not_configured`.
 pub fn list_status(store: &dyn KeyStore) -> Vec<CredentialStatus> {
+    // #5678: production reads the real `.env.local`; tests inject a table.
+    list_status_from(store, &WorkspaceEnvLocal)
+}
+
+/// [`list_status`] with the `.env.local` tier signal supplied by the caller.
+///
+/// Why: the seam #5678 asked for — the same shape as the existing `store`
+/// injection, so a test can state every one of `classify_tier`'s three signals
+/// instead of inheriting one from whatever machine it runs on.
+/// What: identical to [`list_status`], reading the `.env.local` signal from
+/// `env_local` rather than the filesystem.
+/// Test: `super::tests::credential_status_never_leaks_a_value`,
+/// `super::tests::env_local_tier_comes_from_the_injected_source`.
+pub fn list_status_from(
+    store: &dyn KeyStore,
+    env_local: &dyn EnvLocalSource,
+) -> Vec<CredentialStatus> {
     all()
         .iter()
         .map(|caps| {
@@ -48,9 +95,9 @@ pub fn list_status(store: &dyn KeyStore) -> Vec<CredentialStatus> {
                         .ok()
                         .filter(|v| !v.is_empty())
                         .is_some();
-                    let env_local = env_local_value(env_var).is_some();
+                    let has_env_local = env_local.value(env_var).is_some();
                     let stored = store.get(&provider).is_some();
-                    match classify_tier(env, env_local, stored) {
+                    match classify_tier(env, has_env_local, stored) {
                         Some(tier) => format!("configured via {}", tier.label()),
                         None => "not configured".to_string(),
                     }
@@ -66,13 +113,36 @@ mod tests {
     use super::*;
     use trusty_common::credentials::FileKeyStore;
 
+    /// A `.env.local` that binds nothing — the hermetic default (#5678).
+    struct NoEnvLocal;
+
+    impl EnvLocalSource for NoEnvLocal {
+        fn value(&self, _var: &str) -> Option<String> {
+            None
+        }
+    }
+
+    /// A `.env.local` binding exactly one variable (#5678).
+    struct OneVarEnvLocal(&'static str);
+
+    impl EnvLocalSource for OneVarEnvLocal {
+        fn value(&self, var: &str) -> Option<String> {
+            (var == self.0).then(|| "value-that-must-never-be-reported".to_string())
+        }
+    }
+
     /// Why: the never-echo-a-value mandate is the single most security
     /// critical property of this whole tool — a seeded sentinel key must
     /// never appear anywhere in the structured status output, only the
     /// provider name and tier label.
     /// What: seeds a `FileKeyStore` under a tempdir with a fake sentinel
-    /// value for `openrouter`, calls `list_status`, and asserts the
-    /// sentinel string is absent from every field of every entry.
+    /// value for `openrouter`, calls `list_status_from` with a `.env.local`
+    /// that binds nothing, and asserts the sentinel string is absent from
+    /// every field of every entry.
+    ///
+    /// #5678: the store-tier assertion below is what an ancestor `.env.local`
+    /// binding `OPENROUTER_API_KEY` used to break — the injected source is
+    /// what makes it hermetic.
     /// Test: itself.
     #[test]
     fn credential_status_never_leaks_a_value() {
@@ -94,7 +164,7 @@ mod tests {
         let store = FileKeyStore::at(tmp.path());
         KeyStore::set(&store, "openrouter", SENTINEL).expect("seed store");
 
-        let statuses = list_status(&store);
+        let statuses = list_status_from(&store, &NoEnvLocal);
 
         // SAFETY: lock still held.
         unsafe {
@@ -142,7 +212,9 @@ mod tests {
 
         let tmp = tempfile::TempDir::new().unwrap();
         let store = FileKeyStore::at(tmp.path());
-        let statuses = list_status(&store);
+        // #5678: same hermeticity fix — a real ancestor `.env.local` binding
+        // TOGETHER_API_KEY would otherwise report a tier here.
+        let statuses = list_status_from(&store, &NoEnvLocal);
 
         // SAFETY: lock still held.
         unsafe {
@@ -156,5 +228,60 @@ mod tests {
             .find(|s| s.provider == "together")
             .expect("together is a known provider");
         assert_eq!(together.status, "not configured");
+    }
+
+    /// Why: the seam is only worth having if the reported tier actually
+    /// follows the injected source — a source that binds the variable must
+    /// produce the `.env.local` tier even with a seeded store present, and one
+    /// that binds nothing must fall through to the store (#5678).
+    /// What: runs both directions over the same seeded `FileKeyStore`, with
+    /// the process env var cleared so `classify_tier`'s highest tier is out of
+    /// play.
+    /// Test: itself.
+    #[test]
+    fn env_local_tier_comes_from_the_injected_source() {
+        let _env_guard = crate::test_env::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+
+        let prev = std::env::var_os("OPENROUTER_API_KEY");
+        // SAFETY: ENV_LOCK held for the whole test body.
+        unsafe {
+            std::env::remove_var("OPENROUTER_API_KEY");
+        }
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let store = FileKeyStore::at(tmp.path());
+        KeyStore::set(&store, "openrouter", "sk-or-FAKE-injected-source") // pragma: allowlist secret
+            .expect("seed store");
+
+        let with_env_local = list_status_from(&store, &OneVarEnvLocal("OPENROUTER_API_KEY"));
+        let without_env_local = list_status_from(&store, &NoEnvLocal);
+
+        // SAFETY: lock still held.
+        unsafe {
+            if let Some(v) = prev {
+                std::env::set_var("OPENROUTER_API_KEY", v);
+            }
+        }
+
+        let tier_of = |statuses: &[CredentialStatus]| {
+            statuses
+                .iter()
+                .find(|s| s.provider == "openrouter")
+                .expect("openrouter is a known provider")
+                .status
+                .clone()
+        };
+        assert!(
+            tier_of(&with_env_local).contains(".env.local"),
+            "a binding source must report the .env.local tier, got: {}",
+            tier_of(&with_env_local)
+        );
+        assert!(
+            tier_of(&without_env_local).contains("secure store"),
+            "an empty source must fall through to the store, got: {}",
+            tier_of(&without_env_local)
+        );
     }
 }

--- a/crates/trusty-agents/src/tools/analysis/trace_flow.rs
+++ b/crates/trusty-agents/src/tools/analysis/trace_flow.rs
@@ -5,7 +5,21 @@
 //! What: Builds a `SymbolGraph` (from the pre-indexed registry if present,
 //! else falls back to walking the project root), then BFSes
 //! callers/callees up to `max_depth`.
-//! Test: `trace_flow_outgoing_smoke`.
+//!
+//! Why the anchor is `resolve_symbol` (#6232): this tool used to anchor with
+//! `nodes().find(|n| n.name == entry)` — first in insertion order — and then
+//! re-query `callees_of`/`callers_of` by BARE name at every step. Two
+//! definitions sharing a name meant the reported root file/line could describe
+//! one of them while the listed callees came from the other, and a
+//! `<path>::<symbol>` entry point missed outright. It now anchors through
+//! `SymbolGraph::resolve_symbol` (which #6229 taught to answer `Unique` for a
+//! path-qualified spelling), reports the alternatives when a name is
+//! ambiguous, and traverses by each node's `<file>::<symbol>` key rather than
+//! its bare name.
+//! Test: `trace_flow_missing_entry_errors`,
+//! `same_named_definitions_do_not_mix_in_one_trace`,
+//! `path_qualified_entry_point_anchors_on_the_file_it_names`,
+//! `an_ambiguous_bare_entry_reports_its_alternatives`.
 
 use std::collections::HashSet;
 use std::path::PathBuf;
@@ -16,7 +30,7 @@ use serde_json::{Value, json};
 use super::analyze_project::collect_source_files;
 use crate::tools::traits::{ToolExecutor, ToolResult};
 
-use trusty_common::symgraph::graph::{SymbolGraph, SymbolNode};
+use trusty_common::symgraph::graph::{SymbolGraph, SymbolMatch, SymbolNode};
 use trusty_common::symgraph::registry::SymbolRegistry;
 
 pub struct TraceExecutionFlowTool;
@@ -35,7 +49,7 @@ impl ToolExecutor for TraceExecutionFlowTool {
                 "parameters": {
                     "type": "object",
                     "properties": {
-                        "entry_point": {"type": "string", "description": "Bare function name to start from."},
+                        "entry_point": {"type": "string", "description": "Function to start from — a bare name, or '<path>::<name>' to pick one of several definitions sharing a name."},
                         "direction": {"type": "string", "description": "'outgoing' | 'incoming' | 'both'. Default 'outgoing'."},
                         "max_depth": {"type": "integer", "description": "Maximum BFS depth. Default 5."}
                     },
@@ -57,26 +71,85 @@ impl ToolExecutor for TraceExecutionFlowTool {
         let max_depth = args.get("max_depth").and_then(Value::as_u64).unwrap_or(5) as usize;
 
         let graph = build_graph();
+        match trace(&graph, entry, &direction, max_depth) {
+            Ok(out) => ToolResult::ok(out.to_string()),
+            Err(message) => ToolResult::err(message),
+        }
+    }
+}
 
-        // Find entry node.
-        let entry_node = graph.nodes().into_iter().find(|n| n.name == entry).cloned();
-        let Some(root_node) = entry_node else {
-            return ToolResult::err(format!(
+/// One definition, as the tool reports it.
+fn describe(node: &SymbolNode) -> Value {
+    json!({
+        "name": node.name,
+        "file": node.file.display().to_string(),
+        "line": node.start_line,
+    })
+}
+
+/// The `<file>::<symbol>` spelling that names ONE definition (#6232).
+///
+/// Why: `callees_of`/`callers_of` take a name, and a bare name is answered by
+/// every definition that shares it — which is how a trace mixed two same-named
+/// functions from different files. `resolve_symbol` accepts a `<path>::<symbol>`
+/// key and narrows to the definitions in that file, so keying the traversal on
+/// it keeps each hop inside the definition it descended from.
+/// What: joins the node's own file and name. A node with no assigned file
+/// produces `::<name>`, which the resolver falls back to answering by bare name
+/// — the pre-#6232 behaviour, and the best available for a node whose file the
+/// registry never recorded.
+/// Test: `same_named_definitions_do_not_mix_in_one_trace`.
+fn node_key(node: &SymbolNode) -> String {
+    format!("{}::{}", node.file.display(), node.name)
+}
+
+/// Anchor `entry` in `graph` and BFS from it (#6232).
+///
+/// Why: split out of `execute` so the anchoring and traversal rules can be
+/// tested against a hand-built graph holding two same-named definitions — the
+/// case the tool got wrong — instead of only against whatever the pre-indexed
+/// registry happens to hold.
+/// What: resolves `entry` through `SymbolGraph::resolve_symbol`. `NotFound` is
+/// the one error. `Ambiguous` is NOT an error: the most-connected definition
+/// leads, and every alternative is reported under `ambiguous_with` so the
+/// caller can re-ask with a `<path>::<symbol>` spelling. `ambiguous_with` is
+/// always present, empty when the name resolved uniquely.
+/// Test: `same_named_definitions_do_not_mix_in_one_trace`,
+/// `path_qualified_entry_point_anchors_on_the_file_it_names`,
+/// `an_ambiguous_bare_entry_reports_its_alternatives`.
+fn trace(
+    graph: &SymbolGraph,
+    entry: &str,
+    direction: &str,
+    max_depth: usize,
+) -> Result<Value, String> {
+    let (root, alternatives) = match graph.resolve_symbol(entry) {
+        SymbolMatch::NotFound => {
+            return Err(format!(
                 "trace_execution_flow: '{entry}' not found in symbol graph"
             ));
-        };
+        }
+        SymbolMatch::Unique(node) => (node.clone(), Vec::new()),
+        SymbolMatch::Ambiguous {
+            chosen,
+            alternatives,
+        } => (
+            chosen.clone(),
+            alternatives.iter().map(|n| describe(n)).collect(),
+        ),
+    };
 
-        let mut total = 0usize;
-        let tree = bfs(&graph, &root_node, &direction, max_depth, &mut total);
+    let mut total = 0usize;
+    let tree = bfs(graph, &root, direction, max_depth, &mut total);
 
-        let out = json!({
-            "entry": entry,
-            "direction": direction,
-            "call_tree": tree,
-            "total_nodes": total
-        });
-        ToolResult::ok(out.to_string())
-    }
+    Ok(json!({
+        "entry": entry,
+        "direction": direction,
+        "resolved_to": describe(&root),
+        "ambiguous_with": alternatives,
+        "call_tree": tree,
+        "total_nodes": total,
+    }))
 }
 
 /// Build a `SymbolGraph` from the pre-indexed registry if available;
@@ -110,8 +183,10 @@ fn bfs(
     max_depth: usize,
     total: &mut usize,
 ) -> Value {
+    // #6232: keyed on node identity, not bare name — two same-named
+    // definitions are two nodes and must not collapse into one visit.
     let mut visited: HashSet<String> = HashSet::new();
-    visited.insert(root.name.clone());
+    visited.insert(node_key(root));
     *total += 1;
 
     // We materialize children level by level so we can return a tree directly.
@@ -126,17 +201,20 @@ fn bfs(
     ) -> Value {
         let mut children: Vec<&SymbolNode> = Vec::new();
         if depth < max_depth {
+            // #6232: query by this node's own qualified key, so the hop stays
+            // inside the definition it descended from.
+            let key = node_key(node);
             if direction == "outgoing" || direction == "both" {
-                for c in graph.callees_of(&node.name) {
-                    if visited.insert(c.name.clone()) {
+                for c in graph.callees_of(&key) {
+                    if visited.insert(node_key(c)) {
                         children.push(c);
                         *total += 1;
                     }
                 }
             }
             if direction == "incoming" || direction == "both" {
-                for c in graph.callers_of(&node.name) {
-                    if visited.insert(c.name.clone()) {
+                for c in graph.callers_of(&key) {
+                    if visited.insert(node_key(c)) {
                         children.push(c);
                         *total += 1;
                     }
@@ -161,6 +239,138 @@ fn bfs(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use trusty_common::symgraph::registry::{SymbolEntry, SymbolId, SymbolKind};
+
+    /// One function definition in module `module`, in `file`, calling `calls`.
+    ///
+    /// The module path matters: `SymbolRegistry` is keyed by id, so two
+    /// definitions sharing a bare name need distinct module paths or the second
+    /// silently replaces the first.
+    fn entry(module: &str, file: &str, name: &str, calls: &[&str]) -> SymbolEntry {
+        let mut e = SymbolEntry::new(
+            SymbolId::new(module, name),
+            SymbolKind::Function,
+            format!("fn {name}() {{}}"),
+            "rust",
+        );
+        e.assigned_file = Some(PathBuf::from(file));
+        for callee in calls {
+            e.dependencies.insert(SymbolId::new(module, callee));
+        }
+        e
+    }
+
+    /// Two files each defining `helper`, each calling a distinct callee — the
+    /// shape #6232 describes.
+    ///
+    /// `a.rs`'s `helper` is registered FIRST but `b.rs`'s is more connected, so
+    /// insertion order and node degree disagree. That disagreement is the
+    /// defect: the anchor took the first, the traversal took the most
+    /// connected, and the two were different definitions.
+    fn two_same_named_helpers() -> SymbolGraph {
+        let mut reg = SymbolRegistry::new(PathBuf::from("/proj"));
+        reg.insert(entry("a", "/proj/a.rs", "helper", &["only_in_a"]));
+        reg.insert(entry("a", "/proj/a.rs", "only_in_a", &[]));
+        reg.insert(entry(
+            "b",
+            "/proj/b.rs",
+            "helper",
+            &["only_in_b", "also_in_b"],
+        ));
+        reg.insert(entry("b", "/proj/b.rs", "only_in_b", &[]));
+        reg.insert(entry("b", "/proj/b.rs", "also_in_b", &[]));
+        reg.insert(entry("b", "/proj/b.rs", "caller_of_b", &["helper"]));
+        SymbolGraph::build_from_registry(&reg)
+    }
+
+    /// One field of every node in a `call_tree`, root first.
+    fn tree_field(tree: &Value, field: &str) -> Vec<String> {
+        let mut out = vec![tree[field].as_str().unwrap_or_default().to_string()];
+        for child in tree["callees"].as_array().into_iter().flatten() {
+            out.extend(tree_field(child, field));
+        }
+        out
+    }
+
+    /// Why (#6232): the reported root belonged to one definition while the
+    /// listed callees came from a same-named one elsewhere. A trace anchored on
+    /// `a.rs`'s `helper` must never list `b.rs`'s callee.
+    /// Test: itself.
+    #[test]
+    fn same_named_definitions_do_not_mix_in_one_trace() {
+        let graph = two_same_named_helpers();
+        let out = trace(&graph, "/proj/a.rs::helper", "outgoing", 3).expect("entry resolves");
+
+        assert_eq!(out["resolved_to"]["file"], "/proj/a.rs");
+        let names = tree_field(&out["call_tree"], "name");
+        assert!(
+            names.contains(&"only_in_a".to_string()),
+            "a.rs's own callee is missing: {names:?}"
+        );
+        assert!(
+            !names.contains(&"only_in_b".to_string()),
+            "b.rs's callee leaked into a.rs's trace: {names:?}"
+        );
+
+        // A BARE name must produce one definition's trace end to end too. The
+        // anchor used to take insertion order and the traversal node degree, so
+        // the root and its callees could come from different files.
+        let bare = trace(&graph, "helper", "outgoing", 3).expect("entry resolves");
+        let root_file = bare["resolved_to"]["file"].as_str().unwrap_or_default();
+        for file in tree_field(&bare["call_tree"], "file") {
+            assert_eq!(
+                file, root_file,
+                "one trace spanned two files: {}",
+                bare["call_tree"]
+            );
+        }
+    }
+
+    /// Why (#6232): a `<path>::<symbol>` entry point used to miss outright,
+    /// because the anchor compared the whole string against a bare node name.
+    /// Test: itself.
+    #[test]
+    fn path_qualified_entry_point_anchors_on_the_file_it_names() {
+        let graph = two_same_named_helpers();
+        let out = trace(&graph, "/proj/b.rs::helper", "outgoing", 3).expect("entry resolves");
+
+        assert_eq!(out["resolved_to"]["file"], "/proj/b.rs");
+        assert_eq!(
+            out["ambiguous_with"].as_array().map(Vec::len),
+            Some(0),
+            "a path-qualified spelling names one definition"
+        );
+    }
+
+    /// Why (#6232): a bare name several definitions answer to must say so
+    /// rather than silently taking one — that silence is what made the wrong
+    /// trace look authoritative.
+    /// Test: itself.
+    #[test]
+    fn an_ambiguous_bare_entry_reports_its_alternatives() {
+        let graph = two_same_named_helpers();
+        let out = trace(&graph, "helper", "outgoing", 3).expect("entry resolves");
+
+        let alternatives = out["ambiguous_with"]
+            .as_array()
+            .expect("ambiguous_with is always present");
+        assert_eq!(
+            alternatives.len(),
+            1,
+            "the other definition must be reported: {out}"
+        );
+        let chosen = out["resolved_to"]["file"].as_str().unwrap_or_default();
+        let other = alternatives[0]["file"].as_str().unwrap_or_default();
+        assert_ne!(chosen, other, "an alternative must be a different file");
+    }
+
+    /// Why: an unknown name is the one condition that is still an error.
+    /// Test: itself.
+    #[test]
+    fn trace_reports_an_unknown_entry_as_an_error() {
+        let graph = two_same_named_helpers();
+        assert!(trace(&graph, "no_such_symbol_xyz", "outgoing", 3).is_err());
+    }
 
     #[tokio::test]
     async fn trace_flow_missing_entry_errors() {

--- a/crates/trusty-agents/tests/home_lock_discipline.rs
+++ b/crates/trusty-agents/tests/home_lock_discipline.rs
@@ -23,6 +23,10 @@
 use std::path::{Path, PathBuf};
 
 /// Text that mutates the process-global `$HOME`.
+///
+/// Blind spot: these are literal substrings, so a mutation routed through a
+/// generic helper that takes the variable NAME as a parameter is not seen
+/// (#6089).
 const HOME_MUTATIONS: &[&str] = &[
     "set_var(\"HOME\"",
     "remove_var(\"HOME\"",

--- a/crates/trusty-agents/tests/home_lock_discipline.rs
+++ b/crates/trusty-agents/tests/home_lock_discipline.rs
@@ -1,0 +1,94 @@
+//! One lock discipline for the process-global `$HOME` (#6089).
+//!
+//! Why: `$HOME` is a process-global, and `cargo test` runs unit tests on a
+//! multi-threaded executor, so two tests that redirect it stomp on each other.
+//! This crate's convention is a single process-wide mutex, `test_env::HOME_LOCK`
+//! — but `#[serial_test::serial]` is a SECOND, disjoint lock over the same
+//! global, and a test guarded only by that one interleaves freely with every
+//! HOME_LOCK holder. `assistants::tests::home_tests` did exactly that and
+//! `okg_store_path_matches_the_owners_spelling` failed once in four full-suite
+//! runs, comparing paths under two different tempdirs (#6089). The same
+//! mechanism was fixed once for `llm::http::tests` (#3952) and came back here,
+//! because that fix was a point repair and nothing checked the rest of the
+//! crate. `python_skill`'s `hold_home_for_uv` states the crate-wide property in
+//! prose — every HOME mutation sits under HOME_LOCK — and relies on it for
+//! hermeticity; this file is what makes that statement checkable instead of
+//! hopeful.
+//! What: scans this crate's own `src/` for files that mutate `$HOME` and
+//! asserts each also acquires `HOME_LOCK`. File granularity, deliberately: it
+//! needs no Rust parser, and it is the granularity at which the convention has
+//! actually been violated.
+//! Test: this file IS the test.
+
+use std::path::{Path, PathBuf};
+
+/// Text that mutates the process-global `$HOME`.
+const HOME_MUTATIONS: &[&str] = &[
+    "set_var(\"HOME\"",
+    "remove_var(\"HOME\"",
+    "EnvVarGuard::set(\"HOME\"",
+    "EnvVarGuard::clear(\"HOME\"",
+];
+
+/// Text that acquires the crate's one `$HOME` lock.
+const HOME_LOCK_ACQUISITIONS: &[&str] = &["HOME_LOCK", "lock_home"];
+
+/// Every `.rs` file under `dir`.
+fn rust_sources(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            rust_sources(&path, out);
+        } else if path.extension().is_some_and(|e| e == "rs") {
+            out.push(path);
+        }
+    }
+}
+
+/// Why: the two disjoint locks are invisible at any single call site — a test
+/// author reads `#[serial]` on the test above theirs and copies it, which is
+/// how #3952 came back as #6089. The invariant has to be asserted somewhere
+/// that sees the whole crate.
+/// What: fails naming every file that mutates `$HOME` without acquiring
+/// `HOME_LOCK`. `#[serial]` is not an accepted substitute: it is a different
+/// mutex, so it excludes only other `#[serial]` tests and none of the ~30 files
+/// that hold `HOME_LOCK`. A `#[serial]` test may keep that attribute for a
+/// second global it also guards — it just has to take `HOME_LOCK` too.
+#[test]
+fn every_home_mutating_source_file_takes_the_home_lock() {
+    let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut files = Vec::new();
+    rust_sources(&src, &mut files);
+    assert!(
+        !files.is_empty(),
+        "no sources found under {}",
+        src.display()
+    );
+
+    let mut offenders: Vec<String> = Vec::new();
+    for file in &files {
+        let Ok(text) = std::fs::read_to_string(file) else {
+            continue;
+        };
+        let mutates = HOME_MUTATIONS.iter().any(|pat| text.contains(pat));
+        let locks = HOME_LOCK_ACQUISITIONS.iter().any(|pat| text.contains(pat));
+        if mutates && !locks {
+            offenders.push(
+                file.strip_prefix(&src)
+                    .unwrap_or(file)
+                    .display()
+                    .to_string(),
+            );
+        }
+    }
+    offenders.sort();
+
+    assert!(
+        offenders.is_empty(),
+        "these files mutate $HOME without acquiring test_env::HOME_LOCK, so they \
+         race every test that does hold it (#6089): {offenders:?}"
+    );
+}


### PR DESCRIPTION
Refs #5678, #5226, #6089, #6232. Four-fix batch per the one-PR-per-crate bugfix-batching rule: (1) credential status reads .env.local through an injected EnvLocalSource — hermetic tests, production precedence unchanged; (2) SECURITY #5226: RustEmbed `#[include]` allowlist + deploy-time `is_bundled_asset` re-filter + single `bundled_assets` view for write loop and stamp, plus symlink-rejection and unfiltered-tree tripwire tests from the critic round; (3) the three $HOME-mutating tests take test_env::HOME_LOCK, with a mechanical lock-discipline scanner test; (4) trace_flow anchors via resolve_symbol and traverses by file::symbol keys — ambiguous bare names rank and list ambiguous_with.

Test ladder rung 5 (security): cargo test -p trusty-agents --no-fail-fast — 13 targets, 3578 passed, 0 failed; clippy --all-targets -D warnings, fmt --check, line-cap, changelog fragments clean. Each fix has a regression test with a verified pre-fix failure; the critic independently reverted the #5226 runtime filter and reproduced the failure. code-critic verdict: WARN — HIGH/MEDIUM findings fixed in 335313d51 (symlink test proven against a planted symlink). No version bump: trusty-agents 0.39.0 is not yet published.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools