### PR TITLE
fix(ci): version-bump gate helpers read manifests in one process (Refs #6478)

### DIFF
--- a/scripts/check-ci-helpers-selftest.sh
+++ b/scripts/check-ci-helpers-selftest.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # check-ci-helpers-selftest.sh — regression fixtures for the CI helper scripts
-# (issues #4179, #4468, #4421, #4688, #5407).
+# (issues #4179, #4468, #4421, #4688, #5407, #6478).
 #
 # Why: the three helpers this covers each encode a decision that is invisible
 #   until it is WRONG in production — a cancelled run reported as green, a
@@ -18,7 +18,9 @@
 #                        the #4688 attribution pair — one tree run twice, once
 #                        from a frozen stale base (misattributes) and once from
 #                        the live base branch (does not) — and the workflow
-#                        wiring that decides which of the two CI gets.
+#                        wiring that decides which of the two CI gets, plus the
+#                        #6478 oversized-[package] pair, whose manifests are
+#                        large enough to break a sed-into-grep pipe.
 #   ci.yml `changes` job: that every gate verdict comes from a diff, never from
 #                        the PR activity type, and that the push path's
 #                        no-before-SHA arms still fail closed (#5407).
@@ -254,7 +256,7 @@ chmod +x "${STUB_DIR}/published.sh" "${STUB_DIR}/notpublished.sh" \
 
 # Build a throwaway repo so the gate sees a real merge base and a real diff.
 make_fixture_repo() {
-  local dir="$1" version_at_head="$2" publish_line="$3"
+  local dir="$1" version_at_head="$2" publish_line="$3" pad_lines="${4:-0}"
   rm -rf "${dir}"
   mkdir -p "${dir}/crates/pinned-crate/src"
   git -C "${dir}" init -q
@@ -266,6 +268,16 @@ name = "pinned-crate"
 version = "1.0.0"
 ${publish_line}
 EOF
+  # #6478: filler INSIDE the [package] block. The readers this gate used to
+  # carry piped sed into an early-exiting grep, and the pipe only broke once
+  # the block outgrew the buffer between the two processes — so a fixture that
+  # bites has to exceed it. GNU sed flushes at 4 KiB; the pipe buffer itself is
+  # 64 KiB on both Linux and macOS, which is what BSD sed needs to fail too.
+  if [ "${pad_lines}" -gt 0 ]; then
+    awk -v n="${pad_lines}" \
+      'BEGIN { for (i = 0; i < n; i++) print "# release-note filler that grows the [package] block" }' \
+      >>"${dir}/crates/pinned-crate/Cargo.toml"
+  fi
   echo "// base" >"${dir}/crates/pinned-crate/src/lib.rs"
   git -C "${dir}" add -A
   git -C "${dir}" commit -qm base
@@ -317,6 +329,54 @@ assert_eq "publish = false -> skipped, pass" "0" \
 make_fixture_repo "${STUB_DIR}/offline" "1.0.0" ""
 assert_eq "registry unreachable -> warn, pass" "0" \
   "$(run_gate "${STUB_DIR}/offline" "${STUB_DIR}/unreachable.sh")"
+
+# --- Oversized [package] block (#6478) ----------------------------------------
+# The gate read manifests through `sed -n '/^\[package\]/,/^\[[^p]/p' | grep`.
+# grep exits on its first match, sed's remaining writes hit the closed pipe, and
+# `set -o pipefail` promotes that to a failed pipeline — exit 4 from GNU sed,
+# 141 from BSD sed. The gate died mid-run, before any verdict, once a crate's
+# [package] block outgrew the buffer between the two: trusty-common's hit 6755
+# bytes and took PR #6474's required check down twice. Exit code alone is not
+# the assertion — a gate can exit 0 having printed nothing — so each case also
+# demands the verdict line the crate has earned.
+#
+# 4000 filler lines is ~216 KiB, past the 64 KiB pipe buffer, so these bite on
+# BSD sed as well as GNU sed rather than passing on a developer's Mac.
+PAD_LINES=4000
+
+# gate_output <dir> <stub> — the gate's combined output for one fixture repo.
+gate_output() {
+  local dir="$1" stub="$2"
+  mkdir -p "${dir}/scripts/lib"
+  cp scripts/check-pr-version-bump.sh "${dir}/scripts/check-pr-version-bump.sh"
+  cp scripts/lib/source_class.sh "${dir}/scripts/lib/source_class.sh"
+  (
+    cd "${dir}" &&
+      PR_VERSION_BUMP_BASE=base-ref \
+        PR_VERSION_BUMP_REGISTRY_STUB="${stub}" \
+        bash scripts/check-pr-version-bump.sh 2>&1
+  )
+}
+
+make_fixture_repo "${STUB_DIR}/oversized" "1.0.1" "" "${PAD_LINES}"
+assert_eq "oversized [package] block -> pass, not exit 4" "0" \
+  "$(run_gate "${STUB_DIR}/oversized" "${STUB_DIR}/published.sh")"
+assert_eq "oversized [package] block -> bump verdict printed" "1" \
+  "$(gate_output "${STUB_DIR}/oversized" "${STUB_DIR}/published.sh" |
+    grep -c 'version bumped 1.0.0 -> 1.0.1' || true)"
+
+make_fixture_repo "${STUB_DIR}/oversized-private" "1.0.0" "publish = false" "${PAD_LINES}"
+assert_eq "oversized [package] block, publish = false -> skip verdict" "1" \
+  "$(gate_output "${STUB_DIR}/oversized-private" "${STUB_DIR}/published.sh" |
+    grep -c 'SKIP.*publish = false' || true)"
+
+# Closure condition 1 of #6478, asserted on the shape as well as the behavior:
+# no manifest read may reintroduce the sed-into-grep pipe at a size that happens
+# to fit the buffer. Comment lines are stripped first — the gate's own header
+# quotes the retired sed range to explain why it went.
+assert_eq "no sed-into-grep manifest read remains" "0" \
+  "$(grep -vE '^[[:space:]]*#' scripts/check-pr-version-bump.sh |
+    grep -cF 'package\]/,/' || true)"
 
 # --- Attribution (#4688) ------------------------------------------------------
 # The shape that failed docs-only PR #4666: the base branch itself changes a

--- a/scripts/check-pr-version-bump.sh
+++ b/scripts/check-pr-version-bump.sh
@@ -99,17 +99,63 @@ cd "${REPO_ROOT}"
 
 BASE="${PR_VERSION_BUMP_BASE:-origin/main}"
 
-# manifest_field <file> <field> — first literal `field = "value"` in [package].
+# PACKAGE_FIELD_AWK — read one [package] field of a Cargo manifest in ONE
+# process. Every manifest read in this file goes through it.
+#
+# Why: the three readers this replaced each piped
+#   `sed -n '/^\[package\]/,/^\[[^p]/p'` into a `grep` that exits early. grep
+#   leaves on its first match, sed's remaining writes land on a closed pipe, and
+#   `set -o pipefail` (line 93) turns that into a failed pipeline: GNU sed
+#   reports the failed flush as exit 4, BSD sed dies on SIGPIPE (141). The gate
+#   then aborted mid-run, before printing any verdict, as soon as a crate's
+#   `[package]` block outgrew the buffer between the two processes —
+#   trusty-common's reached 6755 bytes and did exactly that (#6478). awk opens
+#   the manifest itself, so there is no pipe to break.
+# What: prints the value of the first `<field> = <value>` line inside
+#   `[package]`, then stops. The block ends at the first following table whose
+#   name does not start with `p`, which is the range the sed form matched — so
+#   `[package.metadata]` still counts as inside. A double-quoted value is
+#   unquoted; a bare value (`publish = false`) has its trailing comment and
+#   whitespace trimmed. Absent field: no output, exit 0.
+# Test: scripts/check-ci-helpers-selftest.sh, the two
+#   `check-pr-version-bump: oversized [package] block ...` cases, whose fixture
+#   manifests are large enough to have tripped the old pipe.
+PACKAGE_FIELD_AWK='
+  /^\[package\]/ { in_pkg = 1; next }
+  in_pkg && /^\[[^p]/ { exit }
+  in_pkg && $0 ~ "^" field "[ \t]*=" {
+    sub("^" field "[ \t]*=[ \t]*", "")
+    if (substr($0, 1, 1) == "\"") { sub(/^"/, ""); sub(/".*/, "") }
+    else { sub(/[ \t]*#.*$/, ""); sub(/[ \t]+$/, "") }
+    print
+    exit
+  }
+'
+
+# manifest_field <file> <field> — first `field = value` in [package], or empty.
 manifest_field() {
-  sed -n '/^\[package\]/,/^\[[^p]/p' "$1" 2>/dev/null |
-    grep -m1 -E "^${2}[[:space:]]*=[[:space:]]*\"" |
-    sed -E 's/^[^"]*"([^"]*)".*/\1/'
+  [ -r "$1" ] || return 0
+  awk -v field="$2" "${PACKAGE_FIELD_AWK}" "$1"
+}
+
+# manifest_field_of_text <field> — the same scan over manifest text on stdin.
+# Feed it a here-string, never a pipe: the `exit` above would close a pipe on
+# the writer exactly the way the sed form was closed on (#6478).
+manifest_field_of_text() {
+  awk -v field="$1" "${PACKAGE_FIELD_AWK}"
 }
 
 # manifest_is_unpublishable <file> — true when [package] carries publish = false.
+#
+# #6478: fails CLOSED — an unreadable manifest reports unpublishable, because
+# the other arm asserts "publishable" about a file this function never read.
+# The stderr line keeps the resulting [SKIP] from being silent.
 manifest_is_unpublishable() {
-  sed -n '/^\[package\]/,/^\[[^p]/p' "$1" 2>/dev/null |
-    grep -qE '^publish[[:space:]]*=[[:space:]]*false'
+  if [ ! -r "$1" ]; then
+    echo "check-pr-version-bump: cannot read $1 — treating it as publish = false" >&2
+    return 0
+  fi
+  [ "$(manifest_field "$1" publish)" = "false" ]
 }
 
 # sparse_index_path <crate-name> — crates.io sparse-index route for a name.
@@ -203,7 +249,7 @@ main() {
     return 0
   fi
 
-  local failures=0 warnings=0 crate manifest name version base_version
+  local failures=0 warnings=0 crate manifest name version base_manifest base_version
   while IFS= read -r crate; do
     [ -n "${crate}" ] || continue
     manifest="crates/${crate}/Cargo.toml"
@@ -225,12 +271,10 @@ main() {
       continue
     fi
 
-    base_version="$(
-      git show "${merge_base}:${manifest}" 2>/dev/null |
-        sed -n '/^\[package\]/,/^\[[^p]/p' |
-        grep -m1 -E '^version[[:space:]]*=[[:space:]]*"' |
-        sed -E 's/^[^"]*"([^"]*)".*/\1/'
-    )" || true
+    # #6478: same one-process read as manifest_field, via a here-string rather
+    # than a pipe. Missing at the merge base means a new crate, handled below.
+    base_manifest="$(git show "${merge_base}:${manifest}" 2>/dev/null || true)"
+    base_version="$(manifest_field_of_text version <<<"${base_manifest}")"
 
     if [ -z "${base_version}" ]; then
       echo "[ OK ] ${name} — new crate on this branch, nothing published to drift from"


### PR DESCRIPTION
Refs #6478. Under `set -euo pipefail`, three manifest reads in scripts/check-pr-version-bump.sh piped sed into grep; grep's early exit broke the pipe and GNU sed's failed flush surfaced as a bare exit 4 before any verdict (BSD sed: SIGPIPE/141), silenced by 2>/dev/null. All three now go through one awk program; `manifest_is_unpublishable` additionally fails CLOSED on an unreadable manifest. Selftest fixture sized at ~216KiB after measuring BSD sed's 64KiB pipe-buffer threshold — 4 new cases fail against the old script (revert-proven).

Scripts-only (no fragment owed). Gates: check-ci-helpers-selftest 194/194, check_version_bump_verdict_selftest 11/11, check_scan_floor_selftest 12/12, check_sld clean; live gate runs verified on both the real bump path and publish=false. Currently blocking PR #6474.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools