### PR TITLE
fix(trusty-mpm): tm tui and tm attach default to the multipane project_ctl dashboard (Refs #6483)

### DIFF
--- a/crates/trusty-mpm/changelog.d/6483-tui-multipane-default.md
+++ b/crates/trusty-mpm/changelog.d/6483-tui-multipane-default.md
@@ -1,0 +1,8 @@
+Changed
+
+- `tm tui` and `tm attach <target>` now open the multipane project control
+  dashboard (projects / sessions / activity / action bar) instead of the
+  single-pane coordinator chat. `tm attach` selects the resolved session's
+  owning project and row on the first frame.
+  - The coordinator chat stays reachable with the new `--single-pane` flag on
+    both commands, and `tm sessions tui` is unchanged.

--- a/crates/trusty-mpm/src/assets/skills/tm-capabilities/references/cli.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-capabilities/references/cli.md
@@ -7,7 +7,7 @@ Generated from `Cli::command()` (clap's command-tree introspection) — every `t
 - `agent` — Inspect the deployed agent roster's declared skills (DOC-42, issue #2889)
   - `list` — List every deployed agent with its declared skills
   - `show` — Show one agent's metadata and per-skill resolution
-- `attach` — Attach to an existing session by ID, name prefix, or project path. Opens the TUI focused on the matched session
+- `attach` — Attach to an existing session by ID, name prefix, or project path. Opens the multipane TUI focused on the matched session (#6483)
 - `auth` — Manage the tm-managed `CLAUDE_CODE_OAUTH_TOKEN` store (issue #2246)
   - `clear-token` — Remove the stored token, if present
   - `set-token` — Store a `CLAUDE_CODE_OAUTH_TOKEN` for managed sessions to use
@@ -202,7 +202,7 @@ Generated from `Cli::command()` (clap's command-tree introspection) — every `t
   - `status` — Show Telegram bot pairing status
   - `stop` — Stop the Telegram bot process if running
 - `ticket` — One-shot issue → branch → PR → close workflow (#1237)
-- `tui` — Launch the ratatui multi-session TUI dashboard
+- `tui` — Launch the ratatui multipane TUI dashboard (projects / sessions / activity / actions)
 - `update` — Refresh a loaded alias — pull latest and re-deploy managed config (DOC-24)
 - `validate` — Validate a workspace's deployed `.claude/{agents,skills}` payload and `settings.json` against the canonical bundled roster (issue #2158)
 - `wait` — Wait for a condition, in-turn, without blocking past the harness ceiling

--- a/crates/trusty-mpm/src/bin/tm/cli/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli/mod.rs
@@ -352,7 +352,14 @@ pub(crate) enum Command {
     },
     /// Report daemon health: reachability, catalog freshness, and a fleet summary.
     Health,
-    /// Launch the ratatui multi-session TUI dashboard.
+    /// Launch the ratatui multipane TUI dashboard (projects / sessions /
+    /// activity / actions).
+    ///
+    /// Why: #6483 — this used to open the single-pane coordinator chat, which
+    /// is now behind `--single-pane`. The multipane `project_ctl` dashboard is
+    /// the default surface.
+    /// What: routes through `trusty_mpm::tui::initial_view`.
+    /// Test: `cli_parses_tui_defaults`, `cli_parses_tui_single_pane_opt_in`.
     Tui {
         /// Base URL of the trusty-mpm daemon. `Option<String>`, no
         /// `default_value` (#2487) — resolved via `resolve_daemon_url`, which
@@ -362,6 +369,10 @@ pub(crate) enum Command {
         /// Poll interval in milliseconds.
         #[arg(long, default_value_t = 1000)]
         interval_ms: u64,
+        /// Open the single-pane coordinator chat instead of the multipane
+        /// dashboard (#6483 opt-in).
+        #[arg(long)]
+        single_pane: bool,
     },
     /// Launch the Tauri desktop GUI (or open the web build in the browser
     /// when Tauri is unavailable).
@@ -645,7 +656,7 @@ pub(crate) enum Command {
         dir: Option<String>,
     },
     /// Attach to an existing session by ID, name prefix, or project path.
-    /// Opens the TUI focused on the matched session.
+    /// Opens the multipane TUI focused on the matched session (#6483).
     Attach {
         /// Session ID, name prefix, or project directory path.
         target: String,
@@ -653,6 +664,11 @@ pub(crate) enum Command {
         /// Print session JSON and exit (no TUI).
         #[arg(long)]
         json: bool,
+
+        /// Open the single-pane coordinator chat instead of the multipane
+        /// dashboard (#6483 opt-in).
+        #[arg(long)]
+        single_pane: bool,
     },
     /// Inspect or configure the token-use optimizer.
     Optimizer {

--- a/crates/trusty-mpm/src/bin/tm/commands/gui.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/gui.rs
@@ -1,0 +1,75 @@
+//! `tm gui` — launch the separately installed Tauri desktop binary.
+//!
+//! Why: split out of `main.rs` (#6483) — adding the `--single-pane` TUI
+//! routing pushed that file past the 500-SLOC cap, and these three helpers are
+//! a self-contained subcommand handler that never belonged in the bootstrap.
+//! What: [`launch_gui`] resolves and spawns `trusty-mpm-gui`; the two helpers
+//! it calls stay here with it.
+//! Test: `tests.rs::gui_not_found_error_has_install_hint`,
+//! `tests.rs::gui_binary_resolution_falls_back_to_bare_name`.
+
+/// Launch the Tauri desktop GUI by shelling out to the `trusty-mpm-gui` binary.
+///
+/// Why: the GUI lives in the separate, publish=false `trusty-mpm-gui` crate
+/// (it owns Tauri's `build.rs` + `tauri.conf.json`, which cannot be published
+/// cleanly to crates.io). Declaring it as an optional Cargo dependency blocks
+/// `cargo publish` for trusty-mpm, so `tm gui` instead launches a separately
+/// installed `trusty-mpm-gui` binary — matching the Single-Install convention.
+/// What: resolves the `trusty-mpm-gui` executable next to the running `tm`
+/// binary (via `current_exe().parent()`), falling back to a bare `trusty-mpm-gui`
+/// name so the OS resolves it on `PATH`. Spawns it and waits for it to exit,
+/// returning an actionable error if the binary is not installed.
+/// Test: the not-found → install-hint mapping is covered by `tests.rs`
+/// (`gui_not_found_error_has_install_hint`), which exercises `gui_status_to_result`
+/// directly with a synthetic `NotFound` error.
+pub(crate) fn launch_gui() -> anyhow::Result<()> {
+    let program = resolve_gui_binary();
+    gui_status_to_result(std::process::Command::new(&program).status())
+}
+
+/// Map the outcome of spawning `trusty-mpm-gui` to a CLI-friendly result.
+///
+/// Why: factoring the result mapping out of `launch_gui` keeps the actionable
+/// "not installed" hint unit-testable without actually spawning a GUI process.
+/// What: success → `Ok`; non-zero exit → error with the status; `NotFound`
+/// spawn error → the install hint; any other spawn error → a context error.
+/// Test: `tests.rs::gui_not_found_error_has_install_hint`.
+pub(crate) fn gui_status_to_result(
+    status: std::io::Result<std::process::ExitStatus>,
+) -> anyhow::Result<()> {
+    match status {
+        Ok(status) if status.success() => Ok(()),
+        Ok(status) => anyhow::bail!("trusty-mpm-gui exited with status: {status}"),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => anyhow::bail!(
+            "trusty-mpm-gui is not installed.\n\
+             Install it with: cargo install trusty-mpm-gui\n\
+             (the desktop GUI ships as a separate Tauri crate; `tm gui` launches it)"
+        ),
+        Err(err) => Err(anyhow::Error::new(err).context("failed to launch trusty-mpm-gui")),
+    }
+}
+
+/// Resolve the path to the `trusty-mpm-gui` executable.
+///
+/// Why: a `cargo install`-based deployment lands every trusty-* binary in the
+/// same directory (`~/.cargo/bin`), so the sibling-of-`tm` lookup is the most
+/// reliable. We fall back to the bare binary name so a `PATH`-installed GUI is
+/// still found when `current_exe()` is unavailable or the sibling is missing.
+/// What: returns `<dir-of-current-exe>/trusty-mpm-gui` when that file exists,
+/// otherwise the bare `trusty-mpm-gui` name (resolved by the OS via `PATH`).
+/// Test: indirectly exercised by `launch_gui`'s missing-binary test; the
+/// sibling-exists branch is environment-dependent and not unit-tested.
+pub(crate) fn resolve_gui_binary() -> std::path::PathBuf {
+    const GUI_BIN: &str = "trusty-mpm-gui";
+    if let Ok(exe) = std::env::current_exe()
+        && let Some(dir) = exe.parent()
+    {
+        // Include the platform executable suffix (`.exe` on Windows; "" on
+        // macOS/Linux) so the sibling lookup finds the GUI binary on every OS.
+        let sibling = dir.join(format!("{GUI_BIN}{}", std::env::consts::EXE_SUFFIX));
+        if sibling.is_file() {
+            return sibling;
+        }
+    }
+    std::path::PathBuf::from(GUI_BIN)
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/misc.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/misc.rs
@@ -712,13 +712,17 @@ pub(crate) async fn optimizer(
 /// operators type a short name or path rather than a full UUID.
 /// What: Fetches `/sessions`, resolves via `resolve_target`, then either
 /// serialises to JSON (`--json`) or launches the TUI pre-focused on the match.
-/// Test: Resolution logic is tested in `trusty-mpm-core::connect`; here we
-/// test CLI flag parsing only (see unit tests).
+/// #6483: that TUI is the multipane `project_ctl` dashboard by default;
+/// `--single-pane` (threaded in as `single_pane`) opts back into the
+/// coordinator chat.
+/// Test: Resolution logic is tested in `trusty-mpm-core::connect`;
+/// `cli_parses_attach_single_pane_opt_in` covers the flag.
 pub(crate) async fn attach_cmd(
     client: &reqwest::Client,
     url: &str,
     target: &str,
     json: bool,
+    single_pane: bool,
 ) -> anyhow::Result<()> {
     use trusty_mpm::core::{ResolveResult, SessionSummary, resolve_target};
 
@@ -758,9 +762,10 @@ pub(crate) async fn attach_cmd(
                 }
                 return Ok(());
             }
-            // Launch the TUI focused on this session.
+            // Launch the TUI focused on this session. #6483: the multipane
+            // dashboard is the default; the single-pane chat is opt-in.
             let resolved_url = trusty_mpm::core::resolve_daemon_url(Some(url));
-            trusty_mpm::tui::run_focused(resolved_url, 1000, Some(id)).await
+            trusty_mpm::tui::run_initial_view(resolved_url, 1000, Some(id), single_pane).await
         }
         ResolveResult::Ambiguous(ids) => {
             eprintln!(

--- a/crates/trusty-mpm/src/bin/tm/commands/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/mod.rs
@@ -36,6 +36,9 @@ pub(crate) mod doctor_repair;
 pub(crate) mod doctor_stale;
 pub(crate) mod first_run;
 pub(crate) mod generate;
+// #6483: `tm gui` — split out of main.rs when the TUI view routing pushed that
+// file past the 500-SLOC cap.
+pub(crate) mod gui;
 pub(crate) mod guided;
 pub(crate) mod guided_autostart;
 pub(crate) mod guided_inplace;

--- a/crates/trusty-mpm/src/bin/tm/main.rs
+++ b/crates/trusty-mpm/src/bin/tm/main.rs
@@ -461,11 +461,13 @@ async fn main() -> anyhow::Result<()> {
         Some(Command::Tui {
             url: tui_url,
             interval_ms,
+            single_pane,
         }) => {
             let resolved = trusty_mpm::core::resolve_daemon_url(tui_url.as_deref());
-            trusty_mpm::tui::run(resolved, interval_ms).await
+            // #6483: multipane by default; `--single-pane` opts into the chat.
+            trusty_mpm::tui::run_initial_view(resolved, interval_ms, None, single_pane).await
         }
-        Some(Command::Gui) => launch_gui(),
+        Some(Command::Gui) => commands::gui::launch_gui(),
         Some(Command::Telegram { cmd }) => telegram(&url, cmd).await,
         Some(Command::Slack { cmd }) => slack(cmd).await,
         Some(Command::Install {
@@ -514,7 +516,11 @@ async fn main() -> anyhow::Result<()> {
             // placement: ADR-0037's rule applies here and only here (#5836).
         }) => launch(&client, &url, dir, style, worktree, LaunchDir::OperatorCwd).await,
         Some(Command::Connect { dir }) => connect(&client, &url, dir).await,
-        Some(Command::Attach { target, json }) => attach_cmd(&client, &url, &target, json).await,
+        Some(Command::Attach {
+            target,
+            json,
+            single_pane,
+        }) => attach_cmd(&client, &url, &target, json, single_pane).await,
         Some(Command::Optimizer { action }) => optimizer(&client, &url, action).await,
         Some(Command::Overseer { action }) => overseer(&client, &url, action).await,
         Some(Command::Coordinator { message, action }) => {
@@ -758,68 +764,4 @@ async fn dispatch_watch(
             .await
         }
     }
-}
-
-/// Launch the Tauri desktop GUI by shelling out to the `trusty-mpm-gui` binary.
-///
-/// Why: the GUI lives in the separate, publish=false `trusty-mpm-gui` crate
-/// (it owns Tauri's `build.rs` + `tauri.conf.json`, which cannot be published
-/// cleanly to crates.io). Declaring it as an optional Cargo dependency blocks
-/// `cargo publish` for trusty-mpm, so `tm gui` instead launches a separately
-/// installed `trusty-mpm-gui` binary — matching the Single-Install convention.
-/// What: resolves the `trusty-mpm-gui` executable next to the running `tm`
-/// binary (via `current_exe().parent()`), falling back to a bare `trusty-mpm-gui`
-/// name so the OS resolves it on `PATH`. Spawns it and waits for it to exit,
-/// returning an actionable error if the binary is not installed.
-/// Test: the not-found → install-hint mapping is covered by `tests.rs`
-/// (`gui_not_found_error_has_install_hint`), which exercises `gui_status_to_result`
-/// directly with a synthetic `NotFound` error.
-fn launch_gui() -> anyhow::Result<()> {
-    let program = resolve_gui_binary();
-    gui_status_to_result(std::process::Command::new(&program).status())
-}
-
-/// Map the outcome of spawning `trusty-mpm-gui` to a CLI-friendly result.
-///
-/// Why: factoring the result mapping out of `launch_gui` keeps the actionable
-/// "not installed" hint unit-testable without actually spawning a GUI process.
-/// What: success → `Ok`; non-zero exit → error with the status; `NotFound`
-/// spawn error → the install hint; any other spawn error → a context error.
-/// Test: `tests.rs::gui_not_found_error_has_install_hint`.
-fn gui_status_to_result(status: std::io::Result<std::process::ExitStatus>) -> anyhow::Result<()> {
-    match status {
-        Ok(status) if status.success() => Ok(()),
-        Ok(status) => anyhow::bail!("trusty-mpm-gui exited with status: {status}"),
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => anyhow::bail!(
-            "trusty-mpm-gui is not installed.\n\
-             Install it with: cargo install trusty-mpm-gui\n\
-             (the desktop GUI ships as a separate Tauri crate; `tm gui` launches it)"
-        ),
-        Err(err) => Err(anyhow::Error::new(err).context("failed to launch trusty-mpm-gui")),
-    }
-}
-
-/// Resolve the path to the `trusty-mpm-gui` executable.
-///
-/// Why: a `cargo install`-based deployment lands every trusty-* binary in the
-/// same directory (`~/.cargo/bin`), so the sibling-of-`tm` lookup is the most
-/// reliable. We fall back to the bare binary name so a `PATH`-installed GUI is
-/// still found when `current_exe()` is unavailable or the sibling is missing.
-/// What: returns `<dir-of-current-exe>/trusty-mpm-gui` when that file exists,
-/// otherwise the bare `trusty-mpm-gui` name (resolved by the OS via `PATH`).
-/// Test: indirectly exercised by `launch_gui`'s missing-binary test; the
-/// sibling-exists branch is environment-dependent and not unit-tested.
-fn resolve_gui_binary() -> std::path::PathBuf {
-    const GUI_BIN: &str = "trusty-mpm-gui";
-    if let Ok(exe) = std::env::current_exe()
-        && let Some(dir) = exe.parent()
-    {
-        // Include the platform executable suffix (`.exe` on Windows; "" on
-        // macOS/Linux) so the sibling lookup finds the GUI binary on every OS.
-        let sibling = dir.join(format!("{GUI_BIN}{}", std::env::consts::EXE_SUFFIX));
-        if sibling.is_file() {
-            return sibling;
-        }
-    }
-    std::path::PathBuf::from(GUI_BIN)
 }

--- a/crates/trusty-mpm/src/bin/tm/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests.rs
@@ -997,9 +997,36 @@ fn cli_parses_tui_defaults() {
     // `interval_ms` has no env binding, so its default is asserted bare.
     let cli = Cli::try_parse_from(["trusty-mpm", "tui", "--url", DEFAULT_URL]).unwrap();
     match cli.command.unwrap() {
-        Command::Tui { url, interval_ms } => {
+        Command::Tui {
+            url,
+            interval_ms,
+            single_pane,
+        } => {
             assert_eq!(url.as_deref(), Some(DEFAULT_URL));
             assert_eq!(interval_ms, 1000);
+            // #6483: bare `tm tui` opts into nothing — the multipane
+            // project_ctl dashboard is what `initial_view(false)` resolves to.
+            assert!(!single_pane);
+            assert_eq!(
+                trusty_mpm::tui::initial_view(single_pane),
+                trusty_mpm::tui::TuiView::Multipane
+            );
+        }
+        other => panic!("expected Tui, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_tui_single_pane_opt_in() {
+    // #6483: the single-pane coordinator chat is still reachable, explicitly.
+    let cli = Cli::try_parse_from(["trusty-mpm", "tui", "--single-pane"]).unwrap();
+    match cli.command.unwrap() {
+        Command::Tui { single_pane, .. } => {
+            assert!(single_pane);
+            assert_eq!(
+                trusty_mpm::tui::initial_view(single_pane),
+                trusty_mpm::tui::TuiView::SinglePane
+            );
         }
         other => panic!("expected Tui, got {other:?}"),
     }
@@ -1774,7 +1801,7 @@ fn gui_not_found_error_has_install_hint() {
     // What: feeds a synthetic `NotFound` spawn error into the result mapper and
     // asserts the error string carries the `cargo install trusty-mpm-gui` hint.
     let not_found = std::io::Error::new(std::io::ErrorKind::NotFound, "no such file");
-    let err = crate::gui_status_to_result(Err(not_found))
+    let err = crate::commands::gui::gui_status_to_result(Err(not_found))
         .expect_err("NotFound spawn error must map to an Err");
     let msg = err.to_string();
     assert!(
@@ -1793,7 +1820,7 @@ fn gui_binary_resolution_falls_back_to_bare_name() {
     // the resolver must fall back to the bare name so the OS resolves it on PATH
     // (Single-Install convention). The test binary's dir has no such sibling.
     // What: asserts the resolved path's file name is exactly `trusty-mpm-gui`.
-    let resolved = crate::resolve_gui_binary();
+    let resolved = crate::commands::gui::resolve_gui_binary();
     assert_eq!(
         resolved.file_name().and_then(|n| n.to_str()),
         Some("trusty-mpm-gui"),

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_b_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_b_tests.rs
@@ -21,9 +21,15 @@ use crate::commands::session::{
 fn cli_parses_attach() {
     let cli = Cli::try_parse_from(["trusty-mpm", "attach", "frontend"]).unwrap();
     match cli.command.unwrap() {
-        Command::Attach { target, json } => {
+        Command::Attach {
+            target,
+            json,
+            single_pane,
+        } => {
             assert_eq!(target, "frontend");
             assert!(!json);
+            // #6483: no flag means the multipane dashboard.
+            assert!(!single_pane);
         }
         other => panic!("expected Attach, got {other:?}"),
     }
@@ -33,10 +39,21 @@ fn cli_parses_attach() {
 fn cli_parses_attach_with_json() {
     let cli = Cli::try_parse_from(["trusty-mpm", "attach", "abc-123", "--json"]).unwrap();
     match cli.command.unwrap() {
-        Command::Attach { target, json } => {
+        Command::Attach { target, json, .. } => {
             assert_eq!(target, "abc-123");
             assert!(json);
         }
+        other => panic!("expected Attach, got {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parses_attach_single_pane_opt_in() {
+    // #6483: the pre-existing single-pane coordinator chat stays reachable
+    // through an explicit opt-in flag.
+    let cli = Cli::try_parse_from(["trusty-mpm", "attach", "frontend", "--single-pane"]).unwrap();
+    match cli.command.unwrap() {
+        Command::Attach { single_pane, .. } => assert!(single_pane),
         other => panic!("expected Attach, got {other:?}"),
     }
 }

--- a/crates/trusty-mpm/src/tui/mod.rs
+++ b/crates/trusty-mpm/src/tui/mod.rs
@@ -58,6 +58,69 @@ pub enum Screen {
     Health,
 }
 
+/// Which top-level TUI surface a `tm tui` / `tm attach` invocation opens.
+///
+/// Why: both entry points used to call [`run`]/[`run_focused`] directly, which
+/// hard-wires the single-pane coordinator chat; the multipane `project_ctl`
+/// dashboard was reachable ONLY from a bare `tm projects` on a TTY. Opening or
+/// attaching a session through the tm TUI therefore always landed in the
+/// single-pane view. #6483 makes the multipane dashboard the default and
+/// demotes the chat surface to an explicit `--single-pane` opt-in. A typed
+/// enum plus [`initial_view`] keeps that routing decision pure and testable
+/// instead of an inline `if` duplicated at two call sites.
+/// What: `Multipane` is the default — [`project_ctl::run_focused`];
+/// `SinglePane` is the coordinator chat dashboard — [`run_focused`].
+/// Test: `initial_view_defaults_to_multipane`,
+/// `initial_view_honours_single_pane_opt_in`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TuiView {
+    /// The multipane `project_ctl` dashboard (projects / sessions / activity
+    /// / action bar) — the default since #6483.
+    #[default]
+    Multipane,
+    /// The single-pane coordinator chat dashboard — `--single-pane` opt-in.
+    SinglePane,
+}
+
+/// Resolve which surface to open from the `--single-pane` opt-in flag.
+///
+/// Why: the ONE place the default lives, so flipping it is a one-line change
+/// and the regression test has a pure seam to assert against.
+/// What: returns [`TuiView::SinglePane`] only when the operator explicitly
+/// asked for it; otherwise [`TuiView::default`] — the multipane dashboard.
+/// Test: `initial_view_defaults_to_multipane`,
+/// `initial_view_honours_single_pane_opt_in`.
+pub fn initial_view(single_pane: bool) -> TuiView {
+    // #6483: multipane is the default view; single-pane is opt-in only.
+    if single_pane {
+        TuiView::SinglePane
+    } else {
+        TuiView::default()
+    }
+}
+
+/// Open whichever surface [`initial_view`] resolves to, optionally focused.
+///
+/// Why: `tm tui` and `tm attach` make the identical routing decision; one
+/// helper keeps it single-sourced and keeps `main.rs` a thin bootstrap.
+/// What: [`project_ctl::run_focused`] for [`TuiView::Multipane`],
+/// [`run_focused`] for [`TuiView::SinglePane`]. `focus_id` is the session the
+/// surface should open on (`None` for a plain `tm tui`).
+/// Test: the routing decision is unit-tested through [`initial_view`]
+/// (`initial_view_defaults_to_multipane`); this await glue is exercised by
+/// launching the TUI.
+pub async fn run_initial_view(
+    url: String,
+    interval_ms: u64,
+    focus_id: Option<String>,
+    single_pane: bool,
+) -> anyhow::Result<()> {
+    match initial_view(single_pane) {
+        TuiView::Multipane => project_ctl::run_focused(url, interval_ms, focus_id).await,
+        TuiView::SinglePane => run_focused(url, interval_ms, focus_id).await,
+    }
+}
+
 /// Status-bar hint listing the screen-switch and global keys.
 ///
 /// Why: the health screen's footer must always show how to switch screens and

--- a/crates/trusty-mpm/src/tui/project_ctl/mod.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/mod.rs
@@ -79,9 +79,41 @@ const KEY_POLL: Duration = Duration::from_millis(50);
 /// Test: terminal glue is exercised by launching the TUI; the loop's pure
 /// pieces are unit-tested in their own modules.
 pub async fn run(url: String, interval_ms: u64) -> anyhow::Result<()> {
+    run_focused(url, interval_ms, None).await
+}
+
+/// Launch the multipane dashboard, optionally pre-selecting one session.
+///
+/// Why (#6483): `tm tui` and `tm attach <target>` now open THIS surface by
+/// default instead of the single-pane coordinator chat. `tm attach` resolves a
+/// session id first and expects the TUI to open on that session, so the entry
+/// point needs the same `focus_id` seam `tui::run_focused` already had.
+/// What: same client/prime/terminal-guard sequence as [`run`]; after the
+/// priming poll it calls [`ProjectCtlState::focus_session`], which selects the
+/// owning project and session row (and is a no-op for an id the fleet does not
+/// know). A missed focus sets a notice rather than failing the launch — the
+/// session may simply not have been polled yet.
+/// Test: the focus selection itself is unit-tested
+/// (`focus_session_selects_owning_project_and_row`); this terminal glue is
+/// exercised by launching the TUI.
+pub async fn run_focused(
+    url: String,
+    interval_ms: u64,
+    focus_id: Option<String>,
+) -> anyhow::Result<()> {
     let mut client = DaemonClient::new(url);
     let mut state = ProjectCtlState::default();
     project_ctl_poll_daemon(&mut state, &mut client).await;
+    if let Some(id) = focus_id.as_deref() {
+        // #6483: a `tm attach` target that the priming poll has not surfaced
+        // yet leaves the selection alone and says so, rather than silently
+        // opening on an unrelated project.
+        if state.focus_session(id) {
+            state.set_notice(format!("attached to {id}"));
+        } else {
+            state.set_notice(format!("session {id} not in the polled fleet yet"));
+        }
+    }
 
     enable_raw_mode()?;
     let mut stdout = std::io::stdout();

--- a/crates/trusty-mpm/src/tui/project_ctl/state/mod.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/state/mod.rs
@@ -545,6 +545,48 @@ impl ProjectCtlState {
         self.focus = Pane::Sessions;
     }
 
+    /// Select the project and session row owning `session_id`, focusing Sessions.
+    ///
+    /// Why: #6483 routes `tm attach <target>` at this multipane dashboard
+    /// instead of the single-pane chat. That command resolves a session id and
+    /// expects the TUI to open ON that session; without this the operator
+    /// would land on whichever project happens to sort first and have to hunt
+    /// for the session they just named.
+    /// What: scans `projects` in registry order for the first project whose
+    /// `sessions_by_project` entry contains `session_id`, syncs and points both
+    /// navs at it, and moves keyboard focus to [`Pane::Sessions`]. Returns
+    /// `false` (leaving every selection untouched) when the id is unknown —
+    /// the fleet may not have polled it yet, and a silent no-op is better than
+    /// a misleading selection.
+    /// Test: `focus_session_selects_owning_project_and_row`,
+    /// `focus_session_is_a_noop_for_an_unknown_id`.
+    pub fn focus_session(&mut self, session_id: &str) -> bool {
+        let Some((project_idx, session_idx)) = self.locate_session(session_id) else {
+            return false;
+        };
+        self.projects_nav.sync_len(self.projects.len());
+        self.projects_nav.select(project_idx);
+        self.sessions_nav.sync_len(self.current_sessions().len());
+        self.sessions_nav.select(session_idx);
+        self.focus = Pane::Sessions;
+        true
+    }
+
+    /// Locate `session_id` as a `(project index, session index)` pair.
+    ///
+    /// Why: keeps [`Self::focus_session`]'s search separate from its mutation
+    /// so the borrow of `self` ends before the navs are written.
+    /// What: the first match scanning `projects` in order; `None` when no
+    /// project's session list holds the id.
+    /// Test: covered through `focus_session_*`.
+    fn locate_session(&self, session_id: &str) -> Option<(usize, usize)> {
+        self.projects.iter().enumerate().find_map(|(pi, project)| {
+            let sessions = self.sessions_by_project.get(&project.name)?;
+            let si = sessions.iter().position(|s| s.id == session_id)?;
+            Some((pi, si))
+        })
+    }
+
     /// Set the transient action-bar notice.
     pub fn set_notice(&mut self, msg: impl Into<String>) {
         self.notice = Some(msg.into());
@@ -870,5 +912,44 @@ mod tests {
             DeliverableLinkState::Dangling,
             "a Some(list) that does not contain the id is a CONFIRMED dangling ref"
         );
+    }
+
+    #[test]
+    fn focus_session_selects_owning_project_and_row() {
+        // #6483: `tm attach <target>` opens THIS dashboard, so the resolved
+        // session id must select its owning project AND its row, with keyboard
+        // focus on the Sessions pane.
+        let mut state = ProjectCtlState {
+            projects: vec![row("a"), row("b")],
+            ..Default::default()
+        };
+        state
+            .sessions_by_project
+            .insert("a".to_string(), vec![session("aaaaaaaa1111")]);
+        state.sessions_by_project.insert(
+            "b".to_string(),
+            vec![session("bbbbbbbb1111"), session("bbbbbbbb2222")],
+        );
+
+        assert!(state.focus_session("bbbbbbbb2222"));
+        assert_eq!(state.selected_project().unwrap().name, "b");
+        assert_eq!(state.selected_session().unwrap().id, "bbbbbbbb2222");
+        assert_eq!(state.focus, Pane::Sessions);
+    }
+
+    #[test]
+    fn focus_session_is_a_noop_for_an_unknown_id() {
+        // An id the fleet has not polled yet leaves every selection alone.
+        let mut state = ProjectCtlState {
+            projects: vec![row("a"), row("b")],
+            ..Default::default()
+        };
+        state
+            .sessions_by_project
+            .insert("a".to_string(), vec![session("aaaaaaaa1111")]);
+
+        assert!(!state.focus_session("cccccccc9999"));
+        assert_eq!(state.selected_project().unwrap().name, "a");
+        assert_eq!(state.focus, Pane::Projects);
     }
 }

--- a/crates/trusty-mpm/src/tui/tests.rs
+++ b/crates/trusty-mpm/src/tui/tests.rs
@@ -135,3 +135,21 @@ async fn coordinator_send_without_daemon_reports_error() {
         state.chat_history[1].content
     );
 }
+
+// #6483: the initial-view routing for a new/attached session. The multipane
+// project_ctl dashboard is the DEFAULT; the single-pane coordinator chat is
+// reachable only through the explicit `--single-pane` opt-in.
+
+#[test]
+fn initial_view_defaults_to_multipane() {
+    // No opt-in flag: `tm tui` / `tm attach` must resolve to the multipane
+    // project_ctl dashboard, not the single-pane chat.
+    assert_eq!(initial_view(false), TuiView::Multipane);
+    assert_eq!(TuiView::default(), TuiView::Multipane);
+}
+
+#[test]
+fn initial_view_honours_single_pane_opt_in() {
+    // The pre-#6483 surface stays reachable — explicitly.
+    assert_eq!(initial_view(true), TuiView::SinglePane);
+}


### PR DESCRIPTION
Refs #6483. `tm tui`/`tm attach` were hard-wired to the coordinator-chat surface — the multipane project_ctl dashboard was reachable only via bare `tm projects`. New TuiView routing defaults both commands to the dashboard (attach focuses the resolved session's row); `--single-pane` on both is the opt-in back to the chat surface; `tm sessions tui` untouched; no tmux split-window provisioning (explicit non-goal per the issue). gui.rs split out of main.rs for the 500-SLOC cap. CLI reference regenerated.

Test ladder rung 3: cargo test -p trusty-mpm --no-fail-fast — 54 targets, 9729 passed, 0 failed; clippy -D warnings, fmt, line-cap, test-pointers, changelog fragment, capabilities all green. Regression test initial_view_defaults_to_multipane verified failing pre-fix. Live check at next install: `tm tui` / `tm attach <s>` open the four-region dashboard; `tm tui --single-pane` opens chat. Ships in 1.5.13.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools