### PR TITLE
chore(sessions): commit the 2026-08-31 pause snapshot

### DIFF
--- a/.trusty-mpm/sessions/sessions-log.jsonl
+++ b/.trusty-mpm/sessions/sessions-log.jsonl
@@ -68,3 +68,4 @@
 {"session_id":"tm-dogfood-0-at0-20260830","event":"pause","snapshot":"tm-dogfood-0-at0-20260830/session-20260830-185702.md","timestamp":"2026-08-30T18:57:02.493922+00:00"}
 {"session_id":"tm-dogfood-0-at0-20260830","event":"pause","snapshot":"tm-dogfood-0-at0-20260830/session-20260831-001831.md","timestamp":"2026-08-31T00:18:31.782944+00:00"}
 {"session_id":"tm-dogfood-0-at0-20260831","event":"pause","snapshot":"tm-dogfood-0-at0-20260831/session-20260831-122741.md","timestamp":"2026-08-31T12:27:41.649425+00:00"}
+{"session_id":"tm-dogfood-0-at0-20260831","event":"pause","snapshot":"tm-dogfood-0-at0-20260831/session-20260831-170955.md","timestamp":"2026-08-31T17:09:55.446633+00:00"}

--- a/.trusty-mpm/sessions/tm-dogfood-0-at0-20260831/session-20260831-170955.md
+++ b/.trusty-mpm/sessions/tm-dogfood-0-at0-20260831/session-20260831-170955.md
@@ -1,0 +1,28 @@
+# Session Pause - 2026-08-31T17:09:55.446633+00:00
+
+## Summary
+Paused at the clean end of the 2026-08-31 bug drive + release + workflow-consolidation day (owner-ordered pause after #6483 landed and the close wave finished; ping obligation drawer 5306c43a discharged at pause). EVERYTHING IS LANDED OR ARMED-UNATTENDED; zero engineers/critics in flight. THE DAY: (1) Bug drive completed — 40 issues closed at status:tested with re-run-test + ancestry + installed-binary evidence (9 flake-class, 10 cheap-probed, 11 hard-set, 7 post-install fixes, #6478 gate crash, #2745 et al), plus #4180 closed already-fixed. status:merged residue now only: #6414 (needs independent re-measure), #4271 (closure tests superseded by #6464 redesign — owner call), #5161 (stale slack-mcp install; live probe touches real Slack — owner call), #6483 (TUI default, ships in 1.5.13, live-verify at next install). (2) Release train COMPLETE after one stop (burned tag trusty-common-v0.46.1, remedied by 0.46.2 + changelog assembly PR #6481): trusty-common 0.46.2, trusty-mpm 1.5.12, trusty-console 0.9.1 published (tags at 19c36c65c, 9/9 preflight, parity verified) and installed; trusty-memory rebuilt on common 0.46.2; tagent local build; all daemon restarts graceful with evidence. (3) Workflow changes live: .trusty-mpm/sessions/ tracked in git (#6473); status:in-progress lifecycle label protocol (CLAUDE.md + GitHub, exercised all day); ticketing+version-control consolidation with by-role main-checkout grant, ADR-0056, guard change (PR #6482 MERGED, ships as tm 1.5.13); tm TUI multipane dashboard default (#6483 fix, PR #6484 MERGED e3df26e02). (4) Gate defects found+fixed in flight: #6478 version-bump gate sed pipe crash (PR #6479), capabilities drift from #6475 (PR #6480), #5657 reopened (drift workflow lacks notify-main-failure). Worktrees: all cleaned; only the main checkout remains (the #6483 engineer tree auto-reclaims). tm 1.5.13 is UNPUBLISHED on main (consolidation + TUI default) — next session runs its publish+install when ordered, which also live-verifies #6483 and deploys the new agent assets.
+
+## Completed
+- Resume + drive close-out: 40 issues closed at status:tested today (evidence-based waves 1-4), #4180 closed already-fixed
+- Publish+install train: common 0.46.2 / mpm 1.5.12 / console 0.9.1 live + installed; memory rebuilt; daemons restarted gracefully (drawer c916fad9)
+- Workflow adjustments shipped: sessions-dir tracked (#6473), status:in-progress protocol live, ticketing+version-control consolidation (PR #6482, ADR-0056), TUI multipane default (#6484)
+- Gate fixes: #6478 sed-pipe crash (PR #6479), capabilities drift regen (PR #6480), release-prep 0.46.2 + changelogs (PR #6481)
+- Worktree cleanup: 8 trees + 10 branches removed after per-PR MERGED verification; inventory = main checkout only
+
+## In Progress
+- NOTHING in flight. PR #6482 and #6484 both MERGED; no armed auto-merges outstanding; no background agents (all reported).
+
+## Next Steps
+- Publish tm 1.5.13 (consolidation guard + agent assets + TUI multipane default) when the owner orders it; install live-verifies #6483 (tm tui/attach open the dashboard; --single-pane opts out) and advances it to status:tested
+- Owner decisions parked: #4271 close call (superseded closure tests), #5161 slack-mcp reinstall+live probe (touches real Slack), #6414 re-measure or accept, #4462 signed-install half, #3844 merge policy (with #3899), #4751 build-info feature, #6444 push/pull ruling, #5439 P1 scheduling, documentation-agent main-checkout grant (excluded from ADR-0056 per #5650)
+- Ready backlog: #4999 APEX-retrieval removal, #6439 console back-links, #6462 inbox idle reaper, #6470 memory inspection dashboard, epic #6284 UDS slices
+- On resume: verify PR states with gh before acting; snapshot commit of .trusty-mpm/sessions/ rides the next docs PR (sessions dir is tracked now)
+
+## Git Context
+Branch: main
+Last commit: 2d0155c36 refactor(tga): consume trusty-search over UDS (Refs #6285) (#6393)
+Uncommitted changes: 11 file(s) changed
+
+## Tmux Window
+tm-dogfood:0:@0


### PR DESCRIPTION
Session snapshots are tracked shared history (rule shipped in #6473). Docs-only, test ladder rung 1.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools