### PR TITLE
chore(release): assemble the trusty-mpm 1.5.13 changelog

### DIFF
--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -6,6 +6,31 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.5.13] — 2026-08-31
+
+### Changed
+
+- `tm-ticketing` now carries the full issue lifecycle — `status:in-progress`
+  claimed at dispatch with a dated session comment, event-driven advances to
+  `status:coded` / `status:merged` / `status:tested`, and a close bar that
+  requires live verification evidence. `tm-workflow` and
+  `tm-delegation-patterns` record the matching `version-control` ownership: the
+  merge, the post-merge verification against the exact head SHA, the merged-
+  worktree reclaim, and the label advance it must flag rather than make.
+- `tm hook --pm-guard` no longer diverts a `version-control` dispatch into an
+  isolation worktree, and no longer denies one beside another writer. Its
+  writes are the merge into main, the branch delete, and the merged-worktree
+  reclaim, none of which can be done from inside a worktree. It still counts as
+  an occupant, so an engineer dispatched into the same directory beside it is
+  denied exactly as before, and engineer source-write confinement is unchanged.
+  (ADR-0056; narrows #4480 and #5650 for one agent name)
+- `tm tui` and `tm attach <target>` now open the multipane project control
+  dashboard (projects / sessions / activity / action bar) instead of the
+  single-pane coordinator chat. `tm attach` selects the resolved session's
+  owning project and row on the first frame.
+  - The coordinator chat stays reachable with the new `--single-pane` flag on
+    both commands, and `tm sessions tui` is unchanged.
+
 ## [1.5.12] — 2026-08-31
 
 ### Added

--- a/crates/trusty-mpm/changelog.d/0056-ticketing-and-workflow-skills.md
+++ b/crates/trusty-mpm/changelog.d/0056-ticketing-and-workflow-skills.md
@@ -1,9 +1,0 @@
-Changed
-
-- `tm-ticketing` now carries the full issue lifecycle — `status:in-progress`
-  claimed at dispatch with a dated session comment, event-driven advances to
-  `status:coded` / `status:merged` / `status:tested`, and a close bar that
-  requires live verification evidence. `tm-workflow` and
-  `tm-delegation-patterns` record the matching `version-control` ownership: the
-  merge, the post-merge verification against the exact head SHA, the merged-
-  worktree reclaim, and the label advance it must flag rather than make.

--- a/crates/trusty-mpm/changelog.d/0056-version-control-keeps-its-checkout.md
+++ b/crates/trusty-mpm/changelog.d/0056-version-control-keeps-its-checkout.md
@@ -1,9 +1,0 @@
-Changed
-
-- `tm hook --pm-guard` no longer diverts a `version-control` dispatch into an
-  isolation worktree, and no longer denies one beside another writer. Its
-  writes are the merge into main, the branch delete, and the merged-worktree
-  reclaim, none of which can be done from inside a worktree. It still counts as
-  an occupant, so an engineer dispatched into the same directory beside it is
-  denied exactly as before, and engineer source-write confinement is unchanged.
-  (ADR-0056; narrows #4480 and #5650 for one agent name)

--- a/crates/trusty-mpm/changelog.d/6483-tui-multipane-default.md
+++ b/crates/trusty-mpm/changelog.d/6483-tui-multipane-default.md
@@ -1,8 +1,0 @@
-Changed
-
-- `tm tui` and `tm attach <target>` now open the multipane project control
-  dashboard (projects / sessions / activity / action bar) instead of the
-  single-pane coordinator chat. `tm attach` selects the resolved session's
-  owning project and row on the first frame.
-  - The coordinator chat stays reachable with the new `--single-pane` flag on
-    both commands, and `tm sessions tui` is unchanged.


### PR DESCRIPTION
`crates/trusty-mpm/Cargo.toml` already reads `1.5.13`, but the three
`changelog.d/` fragments for that version were never folded in. The publish
gate `scripts/check-changelog-assembled.sh` (preflight CHECK 9) reported both
STRANDED-FRAGMENTS and NO-SECTION, which blocks `cargo publish` for 1.5.13.

This runs the real tooling — `scripts/assemble-changelog.sh trusty-mpm 1.5.13`
— which writes the `## [1.5.13]` section and deletes the three consumed
fragments in the same operation.

## Gates

Rung 1 (docs only — `CHANGELOG.md` plus fragment deletions; no `src/**` change).

- `bash scripts/assemble-changelog.sh trusty-mpm 1.5.13 --check` — exit 0
- `bash scripts/check-changelog-assembled.sh trusty-mpm` — `OK — trusty-mpm 1.5.13 was assembled by the real tooling`

Refs #6483

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools