### PR TITLE
fix(ci): central red-main notifier covers every push-to-main sibling workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,6 +221,13 @@ jobs:
       - name: CI helper selftests (#4179, #4468, #4421)
         run: bash scripts/check-ci-helpers-selftest.sh
 
+      # #5657: this job's notifier below cannot see a sibling workflow, so every
+      # push-to-main workflow must be watched by red-main-notify.yml instead. A
+      # PR that adds one fails HERE, naming the file, rather than going unwatched
+      # until a human notices main has been red for a day.
+      - name: Red-main notifier coverage (#5657)
+        run: bash scripts/check-red-main-coverage.sh
+
       # Refresh the base branch ref (same fix as #4688 in version-parity.yml's
       # pr-version-bump job). `github.event.pull_request.base.sha` is a
       # SNAPSHOT taken when the triggering event was delivered, but

--- a/.github/workflows/red-main-notify.yml
+++ b/.github/workflows/red-main-notify.yml
@@ -1,0 +1,205 @@
+# Red-main notifier for every SIBLING workflow (issue #5657).
+#
+# Why: `ci.yml`'s `notify-main-failure` job is the repo's red-main detector, and
+#   a `needs:` list cannot name a job in another workflow file. Every workflow
+#   with its own `push: branches: [main]` trigger is therefore structurally
+#   invisible to it — the notifier reports green while a sibling is red. That is
+#   not a theory and not a one-off:
+#     - `test-pointers.yml` sat red on main for over 24 hours (runs 31587713536
+#       to 31688534235, 2026-08-12/13). No `ci-red-main` issue was ever filed; a
+#       human found it by hand and opened #5520.
+#     - `capabilities-drift.yml` went red on main on 2026-08-31 (run 33395306170,
+#       commit 3c43a9e6d). It sat untracked for over an hour and surfaced only
+#       when unrelated PR #6474 inherited the drift through `update-branch`.
+#   The first recurrence was patched by copying a notify job into the one
+#   workflow that had broken. The second proves that shape does not generalise:
+#   nobody adds the job to the NEXT workflow, and the hand-maintained audit table
+#   in #5657 was already missing four push-to-main workflows when it was written.
+#
+# What: one workflow, triggered by `workflow_run` on the COMPLETION of every
+#   push-to-main sibling, that files or comments on the same `ci-red-main`
+#   tracking issue `ci.yml` uses, through the same `scripts/classify-ci-results.sh`
+#   verdict mapping. `workflow_run` crosses workflow files, which is the one
+#   mechanism `needs:` cannot provide.
+#
+# ONE MECHANISM PER WORKFLOW, never two racing. Two workflows are deliberately
+#   absent from the list below because they notify themselves, and adding them
+#   here would file twice for one failure:
+#     - `ci.yml` — its `notify-main-failure` classifies the SHARD matrix results
+#       directly, so a shard cancelled by concurrency reads `inconclusive`
+#       instead of red (#5998). A `workflow_run` trigger sees only the run's
+#       single aggregate conclusion and cannot make that distinction.
+#     - `version-parity.yml` — its `notify-main-drift` (#4688) files a different
+#       label (`version-drift-main`) with drift-specific remediation, and also
+#       fires on the schedule trigger, where drift appears with no new commit.
+#   `scripts/check-red-main-coverage.sh` holds that split in place: it fails when
+#   a push-to-main workflow is neither listed here nor one of those two, when a
+#   listed name matches no workflow file (a rename silently drops coverage,
+#   because `workflow_run` matches on NAME), and when a self-notifying workflow
+#   loses its own notify job. It runs in `ci.yml`'s `changes` job, so a PR adding
+#   a new sibling cannot merge until that sibling is covered.
+#
+# HOW A NEW SIBLING GETS COVERED: add its `name:` to the `workflows:` list below.
+#   Until you do, the coverage gate fails on your PR and names the file.
+#
+# LIMITS, stated so nobody assumes otherwise:
+#   - `workflow_run` fires only for a workflow file that is on the DEFAULT
+#     branch, so this notifier does nothing until it is merged to `main`. Its
+#     first real exercise is post-merge, not on this PR.
+#   - A workflow that never STARTS produces no `workflow_run` event. A skipped
+#     path filter is correct (nothing ran, nothing failed); a workflow whose YAML
+#     fails to parse is not, and stays invisible here.
+#   - This notifier does not watch itself. It cannot: `workflow_run` on your own
+#     completion recurses (GitHub caps the chain at three levels).
+#   - Every watched completion creates a run of this workflow, green or not. The
+#     job is skipped on a green one and consumes no runner, but the Actions list
+#     shows the entry. That noise buys a signal for all 18 siblings at once.
+name: Red main notifier
+
+on:
+  workflow_run:
+    # Sorted by workflow FILE name. Every entry is a workflow `name:`, which is
+    # what `workflow_run` matches on — see the rename hazard above.
+    workflows:
+      - "Agent assets" # agent-assets.yml
+      - "AL2023 load-dynamic build gate" # al2023-build.yml
+      - "build.rs sync" # buildrs-sync.yml
+      - "Capabilities drift" # capabilities-drift.yml
+      - "Doc numbers" # doc-numbers.yml
+      - "Generation artifact lint" # generation-artifact-lint.yml
+      - "Homebrew formula" # homebrew-formula.yml
+      - "Line cap" # line-cap.yml
+      - "SLD lint" # sld-lint.yml
+      - "Tag/publish parity" # tag-publish-parity.yml
+      - "Teardown guard" # teardown-guard.yml
+      - "Test count" # test-count.yml
+      - "Test pointers" # test-pointers.yml
+      - "Token drift" # token-drift.yml
+      - "trusty-audit installer" # trusty-audit-install.yml
+      - "UI bundle freshness" # ui-bundle-freshness.yml
+      - "vmtest harness" # vmtest-harness.yml
+      - "Website tests" # website-tests.yml
+    types: [completed]
+
+# Read-only by default; the one job that needs to write issues asks for it.
+permissions: {}
+
+# Keyed to the WATCHED run, so two siblings failing on the same commit each get
+# their own notification instead of one cancelling the other. Never
+# cancel-in-progress: a cancelled notifier is silence, which is the bug.
+concurrency:
+  group: red-main-notify-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+jobs:
+  notify:
+    name: Notify on red main (sibling workflow)
+    # Push-to-main only, matching `ci.yml`'s notifier. A red PR run is already
+    # visible on the PR; a red `workflow_dispatch` run is somebody watching it.
+    # `conclusion != 'success'` covers failure, cancelled, timed_out, skipped and
+    # every future value — not-success is never treated as success (#4179).
+    if: >-
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main' &&
+      github.event.workflow_run.conclusion != 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      issues: write
+    steps:
+      # Checks out the default branch (that is what `workflow_run` gives), which
+      # is where the classifier lives. The failing commit is read from the event
+      # payload below, never from this checkout.
+      - uses: actions/checkout@v5
+
+      # The same mapping `ci.yml` and `version-parity.yml` use, fed the watched
+      # run's own conclusion: `failure`/`timed_out` are red, `cancelled`/
+      # `skipped`/anything-else are inconclusive, only `success` is green.
+      # The classifier's key is space-separated, and workflow names contain
+      # spaces, so the workflow FILE stem is the key.
+      - name: Classify the watched run's conclusion
+        id: verdict
+        env:
+          WORKFLOW_PATH: ${{ github.event.workflow_run.path }}
+          RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+        run: |
+          key="$(basename "${WORKFLOW_PATH}" .yml)"
+          CI_JOB_RESULTS="${key}=${RUN_CONCLUSION}" \
+            bash scripts/classify-ci-results.sh > /dev/null
+
+      - name: File or update tracking issue
+        if: steps.verdict.outputs.verdict != 'green'
+        uses: actions/github-script@v7
+        env:
+          CI_VERDICT: ${{ steps.verdict.outputs.verdict }}
+          CI_SUMMARY: ${{ steps.verdict.outputs.summary }}
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+          WORKFLOW_PATH: ${{ github.event.workflow_run.path }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        with:
+          script: |
+            const label = 'ci-red-main';
+            const title = 'CI red on main';
+            const verdict = process.env.CI_VERDICT;
+            const workflow = process.env.WORKFLOW_NAME;
+            const path = process.env.WORKFLOW_PATH;
+            const sha = process.env.HEAD_SHA;
+            const body = [
+              verdict === 'red'
+                ? `\`${workflow}\` FAILED on a push to \`main\` at ${sha}.`
+                : `\`${workflow}\` did NOT conclude successfully on a push to \`main\` at ${sha} (verdict: ${verdict}).`,
+              '',
+              `Workflow: \`${path}\``,
+              `Run conclusion: ${process.env.CI_SUMMARY}`,
+              '',
+              `Run: ${process.env.RUN_URL}`,
+              '',
+              verdict === 'red'
+                ? 'Anyone branching off `main` right now inherits this breakage. The failing step in the run above names the gate and its remediation.'
+                : 'This commit has NO verdict from that gate. Cancelled and skipped runs prove nothing; re-run the workflow before treating `main` as green.',
+              '',
+              'Reported by `.github/workflows/red-main-notify.yml`, which watches every',
+              'push-to-main sibling workflow that `ci.yml`\'s `needs:` list cannot reach',
+              '(issue #5657).',
+            ].join('\n');
+
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: label,
+            });
+
+            if (existing.data.length > 0) {
+              const issue = existing.data[0];
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body,
+              });
+              core.notice(`Updated existing tracking issue #${issue.number}`);
+            } else {
+              const created = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: [label],
+              });
+              core.notice(`Filed new tracking issue #${created.data.number}`);
+            }
+
+      # This run's own conclusion must match what it just reported, the same rule
+      # `ci.yml`'s notifier enforces — a green notifier over a red sibling is the
+      # exact false all-clear this workflow exists to end.
+      - name: Fail this job on any non-green verdict
+        if: steps.verdict.outputs.verdict != 'green'
+        env:
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+          CI_VERDICT: ${{ steps.verdict.outputs.verdict }}
+          CI_SUMMARY: ${{ steps.verdict.outputs.summary }}
+        run: |
+          echo "::error::${WORKFLOW_NAME} verdict on main: ${CI_VERDICT} — ${CI_SUMMARY}"
+          exit 1

--- a/.github/workflows/test-pointers.yml
+++ b/.github/workflows/test-pointers.yml
@@ -10,11 +10,12 @@
 # Pure text scanning — no Rust toolchain or build needed, so this runs as
 # its own lightweight job (matches ci.yml / line-cap.yml's checkout style).
 #
-# On a push to main the `notify-main-failure` job at the bottom files or
-# comments on the `ci-red-main` tracking issue when the lint does not come out
-# green. `ci.yml`'s notifier cannot do that for this workflow — a `needs:` list
-# cannot cross workflow files — and for 24 hours in August 2026 that meant a red
-# lint on main with no alarm at all (#5657).
+# On a push to main a non-green result files or comments on the `ci-red-main`
+# tracking issue. That reporting used to live in a `notify-main-failure` job at
+# the bottom of this file; it now comes from `.github/workflows/red-main-notify.yml`,
+# which watches this workflow — and every other push-to-main sibling — over
+# `workflow_run`. `ci.yml`'s notifier still cannot see any of them, because a
+# `needs:` list cannot cross workflow files (#5657).
 name: Test pointers
 
 # `push` stays path-filtered to the lint's actual inputs.
@@ -144,111 +145,3 @@ jobs:
           echo "the gate scripts, or this workflow), so scripts/check_test_pointers.sh"
           echo "would report exactly what it reported on the base branch."
           echo "Reporting success rather than not reporting at all — see #5311."
-
-  # Loudness on main (#5657). `ci.yml`'s `notify-main-failure` is the repo's
-  # only red-main detector, and a `needs:` list cannot name a job in another
-  # workflow file — so this workflow's result was structurally invisible to it.
-  # That is not a theory: this lint was red on `main` continuously from run
-  # 31587713536 (2026-08-12 10:30) to 31688534235 (2026-08-13 09:52), over 24
-  # hours spanning every PR opened in that window, and no `ci-red-main` issue
-  # was ever filed. A human eventually found it by hand and opened #5520.
-  #
-  # WHY ITS OWN NOTIFY JOB rather than folding the lint into `ci.yml`. The two
-  # workflows disagree on every structural choice this job depends on: this one
-  # keeps a `paths:` filter on `push` (`ci.yml` has none, so the lint would run
-  # on every merge), carries its own per-commit concurrency group, and its job
-  # name is the REQUIRED branch-protection context "Doc-comment pointer lint
-  # (Why/What/Test)" — a move would have to preserve that string exactly while
-  # inheriting a trigger set built for a different question. `version-parity.yml`
-  # already answered this the other way with `notify-main-drift` (#4688), so
-  # copying that shape is the change the existing structure supports, and it
-  # generalises: the other 13 push-to-main workflows can each take this job.
-  #
-  # It files on the SAME `ci-red-main` label `ci.yml` uses, so a red lint lands
-  # on the one tracking issue a reader already watches instead of a second one.
-  # `always()` so a cancelled or skipped lint still reports — a non-green
-  # verdict is never silence.
-  notify-main-failure:
-    name: Notify on red main
-    if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: [test-pointers]
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      issues: write
-    steps:
-      - uses: actions/checkout@v5
-
-      # Same classifier `ci.yml` uses, fed this workflow's own job conclusion:
-      # `failure`/`timed_out` are red, `cancelled`/`skipped` are inconclusive,
-      # and only `success` is green (#4179).
-      - name: Classify the lint's conclusion
-        id: verdict
-        env:
-          CI_JOB_RESULTS: test-pointers=${{ needs['test-pointers'].result }}
-        run: bash scripts/classify-ci-results.sh > /dev/null
-
-      - name: File or update tracking issue
-        if: steps.verdict.outputs.verdict != 'green'
-        uses: actions/github-script@v7
-        env:
-          CI_VERDICT: ${{ steps.verdict.outputs.verdict }}
-          CI_SUMMARY: ${{ steps.verdict.outputs.summary }}
-        with:
-          script: |
-            const label = 'ci-red-main';
-            const title = 'CI red on main';
-            const verdict = process.env.CI_VERDICT;
-            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const body = [
-              verdict === 'red'
-                ? `The doc-comment pointer lint FAILED on a push to \`main\` at ${context.sha}.`
-                : `The doc-comment pointer lint did NOT conclude successfully on a push to \`main\` at ${context.sha} (verdict: ${verdict}).`,
-              '',
-              `Job conclusions: ${process.env.CI_SUMMARY}`,
-              '',
-              `Run: ${runUrl}`,
-              '',
-              'A `Test:` doc-comment pointer cites a test that does not exist in the',
-              'citing file’s crate, or an allowlisted pointer is no longer dangling.',
-              'Run `bash scripts/check_test_pointers.sh` locally for the exact lines.',
-              '',
-              'This lint runs in its own workflow, so `ci.yml`’s notifier cannot see it',
-              'and reports green regardless (issue #5657).',
-            ].join('\n');
-
-            const existing = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              labels: label,
-            });
-
-            if (existing.data.length > 0) {
-              const issue = existing.data[0];
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issue.number,
-                body,
-              });
-              core.notice(`Updated existing tracking issue #${issue.number}`);
-            } else {
-              const created = await github.rest.issues.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                title,
-                body,
-                labels: [label],
-              });
-              core.notice(`Filed new tracking issue #${created.data.number}`);
-            }
-
-      # The run's own conclusion must match what the lint actually did, the same
-      # rule `ci.yml`'s notifier enforces: without this a cancelled lint still
-      # ends the run green and `gh run view` reports a verified commit.
-      - name: Fail this job on any non-green verdict
-        if: steps.verdict.outputs.verdict != 'green'
-        run: |
-          echo "::error::pointer lint verdict on main: ${{ steps.verdict.outputs.verdict }}"
-          exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,8 +133,13 @@ change's blast radius. Risk labels map onto the rungs (1–2 Low, 3–4 Normal,
 - 🟡 A PR proves every test target COMPILES; test EXECUTION defers to `main`, so
   run the ladder rung your change earns before merging. Full suite on a branch:
   Actions → CI → "Run workflow".
-- 🟡 **A red `main` files an issue** — `notify-main-failure` opens or comments on
-  the `ci-red-main`-labelled tracking issue, then fails the run.
+- 🟡 **A red `main` files an issue** — `ci.yml`'s `notify-main-failure` opens or
+  comments on the `ci-red-main`-labelled tracking issue, then fails the run. A
+  `needs:` list cannot cross workflow files, so every OTHER push-to-main
+  workflow is watched by `red-main-notify.yml` over `workflow_run` instead
+  (#5657). Adding a push-to-main workflow means adding its `name:` to that
+  list — `scripts/check-red-main-coverage.sh` fails the `changes` job until you
+  do.
 - 🟡 **A `BEHIND` branch merges fine** — use `gh pr merge --squash
   --delete-branch --auto`
   ([#5958](https://github.com/bobmatnyc/trusty-tools/pull/5958)). What blocks is

--- a/docs/reference/test-ladder-baseline.md
+++ b/docs/reference/test-ladder-baseline.md
@@ -189,7 +189,9 @@ published is always a tree the shards have run against.
 **A failing check still blocks at every stage.** Deferring *when* the workspace
 suite runs changes nothing about what a red one means. On `main` a failure opens
 or updates the `ci-red-main` tracking issue via `ci.yml`'s `notify-main-failure`
-job and fails the run.
+job and fails the run. A sibling workflow's failure does the same through
+`.github/workflows/red-main-notify.yml`, which watches every other push-to-main
+workflow over `workflow_run` — `needs:` cannot cross workflow files (#5657).
 
 🔴 **Scoping down by stage is a claim you must be able to prove**, exactly as
 scoping down by rung is. It is never licence to make a red gate green by

--- a/scripts/check-ci-helpers-selftest.sh
+++ b/scripts/check-ci-helpers-selftest.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # check-ci-helpers-selftest.sh — regression fixtures for the CI helper scripts
-# (issues #4179, #4468, #4421, #4688, #5407, #6478).
+# (issues #4179, #4468, #4421, #4688, #5407, #5657, #6478).
 #
 # Why: the three helpers this covers each encode a decision that is invisible
 #   until it is WRONG in production — a cancelled run reported as green, a
@@ -24,6 +24,10 @@
 #   ci.yml `changes` job: that every gate verdict comes from a diff, never from
 #                        the PR activity type, and that the push path's
 #                        no-before-SHA arms still fail closed (#5407).
+#   check-red-main-coverage: which trigger shapes count as push-to-main, the
+#                        fail-closed answer for a trigger block it cannot parse,
+#                        and that the live repo leaves no push-to-main workflow
+#                        unwatched by a red-main notifier (#5657).
 #
 # Usage: bash scripts/check-ci-helpers-selftest.sh
 # Exit: 0 when every case matches; 1 on the first mismatch, printing both sides.
@@ -117,30 +121,142 @@ assert_eq "a cancelled shard is not laundered into red (#5998)" "1" \
   "$(grep -cF "needs['test-shard'].result == 'cancelled'" <<<"${notify_job}" || true)"
 
 # #5657: `notify-main-failure`'s `needs:` cannot name a job in another workflow
-# file, so `test-pointers.yml` was invisible to it — the doc-pointer lint sat red
-# on main for over 24 hours (runs 31587713536 to 31688534235) and no
-# `ci-red-main` issue was ever filed. That workflow now carries its own notifier,
-# on the same label and through the same classifier. Asserted by grep for the
-# same reason the ci.yml wiring above is: the script being correct proves
-# nothing while no workflow calls it.
-pointers_notify="$(sed -n '/^  notify-main-failure:/,$p' .github/workflows/test-pointers.yml)"
-assert_eq "test-pointers.yml has its own notifier (#5657)" "1" \
-  "$(grep -c '^  notify-main-failure:$' .github/workflows/test-pointers.yml || true)"
-assert_eq "it waits on the lint job itself" "1" \
-  "$(grep -cF "needs: [test-pointers]" <<<"${pointers_notify}" || true)"
+# file, so every sibling with its own `push: branches: [main]` trigger is
+# invisible to it. `test-pointers.yml` sat red on main for over 24 hours (runs
+# 31587713536 to 31688534235) with no `ci-red-main` issue; `capabilities-drift.yml`
+# repeated it on 2026-08-31 (run 33395306170). One notifier now watches all of
+# them over `workflow_run`, which is the one trigger that crosses workflow files.
+# Asserted by grep for the same reason the ci.yml wiring above is: the script
+# being correct proves nothing while no workflow calls it.
+red_main_notify=".github/workflows/red-main-notify.yml"
+assert_eq "the sibling notifier exists (#5657)" "1" \
+  "$([ -f "${red_main_notify}" ] && echo 1 || echo 0)"
+assert_eq "it triggers on workflow_run, the only cross-file trigger" "1" \
+  "$(grep -c '^  workflow_run:$' "${red_main_notify}" || true)"
+assert_eq "on completion, so a failure is seen at all" "1" \
+  "$(grep -cF 'types: [completed]' "${red_main_notify}" || true)"
 assert_eq "it classifies through classify-ci-results.sh" "1" \
-  "$(grep -c 'bash scripts/classify-ci-results\.sh' <<<"${pointers_notify}" || true)"
-assert_eq "it feeds the lint's own conclusion, unlaundered" "1" \
-  "$(grep -cF "test-pointers=\${{ needs['test-pointers'].result }}" <<<"${pointers_notify}" || true)"
+  "$(grep -c 'bash scripts/classify-ci-results\.sh' "${red_main_notify}" || true)"
 assert_eq "it files on the same ci-red-main label" "1" \
-  "$(grep -cF "const label = 'ci-red-main';" <<<"${pointers_notify}" || true)"
-# `always()` or the notifier itself is skipped by the very failure it reports.
-assert_eq "it runs even when the lint did not succeed" "1" \
-  "$(grep -c "if: always() && github.event_name == 'push'" <<<"${pointers_notify}" || true)"
+  "$(grep -cF "const label = 'ci-red-main';" "${red_main_notify}" || true)"
+# Not-success is not success: the job must fire on cancelled and skipped too,
+# never on an equality test against 'failure' alone (#4179).
+assert_eq "it fires on any non-success conclusion" "1" \
+  "$(grep -cF "github.event.workflow_run.conclusion != 'success'" "${red_main_notify}" || true)"
+assert_eq "it scopes to push-to-main runs" "1" \
+  "$(grep -cF "github.event.workflow_run.head_branch == 'main'" "${red_main_notify}" || true)"
 # And the run's own conclusion must follow the verdict, the same rule ci.yml's
-# notifier enforces — otherwise a cancelled lint still ends the run green.
+# notifier enforces — otherwise a notifier that just reported a red sibling ends
+# green itself.
 assert_eq "it fails the run on a non-green verdict" "1" \
-  "$(grep -c 'Fail this job on any non-green verdict' <<<"${pointers_notify}" || true)"
+  "$(grep -c 'Fail this job on any non-green verdict' "${red_main_notify}" || true)"
+# The two workflows deliberately absent from its list notify themselves. Both
+# must still carry the job that earns the exemption, or the coverage gate below
+# is asserting a hole.
+assert_eq "ci.yml still notifies itself" "1" \
+  "$(grep -c '^  notify-main-failure:$' .github/workflows/ci.yml || true)"
+assert_eq "version-parity.yml still notifies itself" "1" \
+  "$(grep -c '^  notify-main-drift:$' .github/workflows/version-parity.yml || true)"
+# test-pointers.yml's own notifier is GONE, and must stay gone: it is watched
+# centrally now, and keeping both would file twice for one red lint.
+assert_eq "test-pointers.yml no longer notifies separately" "0" \
+  "$(grep -c '^  notify-main-failure:$' .github/workflows/test-pointers.yml || true)"
+# The gate that keeps the list honest has to actually run somewhere.
+assert_eq "ci.yml runs the coverage gate on every PR" "1" \
+  "$(grep -c 'bash scripts/check-red-main-coverage\.sh' .github/workflows/ci.yml || true)"
+
+# ---------------------------------------------------------------------------
+# check-red-main-coverage.sh
+#
+# The `--detect` half, over fixtures. The audit's whole verdict rests on which
+# workflows it calls push-to-main, and that decision is a line-based parser, so
+# it is exercised against the shapes this repo actually contains plus the
+# malformed ones it must refuse to wave through.
+# ---------------------------------------------------------------------------
+echo
+echo "check-red-main-coverage:"
+
+# No EXIT trap here: STUB_DIR further down sets one, and a second `trap ... EXIT`
+# replaces the first rather than adding to it. This section removes its own
+# fixtures at the end instead.
+RMC_TMP="$(mktemp -d)"
+
+detect_field() {
+  bash scripts/check-red-main-coverage.sh --detect "$1" 2>/dev/null |
+    sed -n "s/^$2=//p"
+}
+
+printf 'name: Bare push\non:\n  push:\njobs: {}\n' >"${RMC_TMP}/bare.yml"
+printf 'name: Branches main\non:\n  push:\n    branches: [main]\njobs: {}\n' >"${RMC_TMP}/inline-main.yml"
+printf 'name: Branches list\non:\n  push:\n    branches:\n      - main\n      - release\njobs: {}\n' >"${RMC_TMP}/list-main.yml"
+printf 'name: Other branch\non:\n  push:\n    branches: [release]\njobs: {}\n' >"${RMC_TMP}/other-branch.yml"
+printf 'name: Tags only\non:\n  push:\n    tags:\n      - "*-v*"\njobs: {}\n' >"${RMC_TMP}/tags.yml"
+printf 'name: PR only\non:\n  pull_request:\n    branches: [main]\njobs: {}\n' >"${RMC_TMP}/pr.yml"
+printf 'name: Paths under main\non:\n  push:\n    branches: [main]\n    paths:\n      - "src/**"\n  pull_request:\n    branches: [main]\njobs: {}\n' >"${RMC_TMP}/paths.yml"
+printf 'name: Inline on\non: [push, pull_request]\njobs: {}\n' >"${RMC_TMP}/inline-on.yml"
+printf 'name: No triggers\njobs: {}\n' >"${RMC_TMP}/no-on.yml"
+printf 'name: Ignore list\non:\n  push:\n    branches-ignore: [gh-pages]\njobs: {}\n' >"${RMC_TMP}/ignore.yml"
+printf 'name: "Quoted name"\non:\n  push:\n    branches: [main]\njobs: {}\n' >"${RMC_TMP}/quoted.yml"
+
+assert_eq "bare push: covers main"            "true"  "$(detect_field "${RMC_TMP}/bare.yml" push_main)"
+assert_eq "branches: [main]"                  "true"  "$(detect_field "${RMC_TMP}/inline-main.yml" push_main)"
+assert_eq "multi-line branch list with main"  "true"  "$(detect_field "${RMC_TMP}/list-main.yml" push_main)"
+assert_eq "another branch only"               "false" "$(detect_field "${RMC_TMP}/other-branch.yml" push_main)"
+assert_eq "tags-only push is not push-to-main" "false" "$(detect_field "${RMC_TMP}/tags.yml" push_main)"
+assert_eq "pull_request only"                 "false" "$(detect_field "${RMC_TMP}/pr.yml" push_main)"
+assert_eq "paths filter does not hide main"   "true"  "$(detect_field "${RMC_TMP}/paths.yml" push_main)"
+# Fail closed. An unreadable trigger block is a parse failure, and a parse
+# failure that answered `false` is exactly the silence #5657 is about.
+assert_eq "inline on: form (fail closed)"     "true"  "$(detect_field "${RMC_TMP}/inline-on.yml" push_main)"
+assert_eq "no on: block at all (fail closed)" "true"  "$(detect_field "${RMC_TMP}/no-on.yml" push_main)"
+assert_eq "branches-ignore (fail closed)"     "true"  "$(detect_field "${RMC_TMP}/ignore.yml" push_main)"
+# workflow_run matches on the NAME, so the name has to come out exactly.
+assert_eq "name is read verbatim"             "Branches main" "$(detect_field "${RMC_TMP}/inline-main.yml" name)"
+assert_eq "a quoted name is unquoted"         "Quoted name"   "$(detect_field "${RMC_TMP}/quoted.yml" name)"
+
+# The audit itself, against the real workflow directory. This is the assertion
+# that catches a new sibling: it fails the moment one is added unwatched.
+bash scripts/check-red-main-coverage.sh >/dev/null 2>&1
+assert_eq "the live repo has no uncovered push-to-main workflow" "0" "$?"
+
+# MUTATION CASES. A gate that cannot fail makes its own green meaningless —
+# same rule as the scan-floor selftest test-pointers.yml runs before its lint.
+# Each mutation copies the real workflow directory and breaks exactly one thing.
+audit_exit() {
+  RED_MAIN_WORKFLOWS_DIR="$1" bash scripts/check-red-main-coverage.sh >/dev/null 2>&1
+  echo "$?"
+}
+
+RMC_COPY="${RMC_TMP}/wf"
+cp -R .github/workflows "${RMC_COPY}"
+assert_eq "an unmodified copy still passes" "0" "$(audit_exit "${RMC_COPY}")"
+
+# 1. The #5657 bug itself, recurring: a new sibling nobody watches.
+cp -R .github/workflows "${RMC_TMP}/new-sibling"
+printf 'name: Brand new gate\non:\n  push:\n    branches: [main]\njobs: {}\n' \
+  >"${RMC_TMP}/new-sibling/brand-new-gate.yml"
+assert_eq "a new unwatched push-to-main workflow fails the gate" "1" \
+  "$(audit_exit "${RMC_TMP}/new-sibling")"
+
+# 2. A rename. `workflow_run` matches on name, so renaming a watched workflow
+#    drops its coverage silently — the gate has to say so.
+cp -R .github/workflows "${RMC_TMP}/renamed"
+sed -i.bak 's/^name: Line cap$/name: Line cap v2/' "${RMC_TMP}/renamed/line-cap.yml"
+rm -f "${RMC_TMP}/renamed/line-cap.yml.bak"
+assert_eq "renaming a watched workflow fails the gate" "1" \
+  "$(audit_exit "${RMC_TMP}/renamed")"
+
+# 3. A self-notifying workflow that loses its own notify job. It is exempt from
+#    the watch list only because it reports for itself; without that job it is
+#    unwatched by anything.
+cp -R .github/workflows "${RMC_TMP}/no-self-notify"
+sed -i.bak 's/^  notify-main-failure:$/  notify-something-else:/' \
+  "${RMC_TMP}/no-self-notify/ci.yml"
+rm -f "${RMC_TMP}/no-self-notify/ci.yml.bak"
+assert_eq "ci.yml losing its own notifier fails the gate" "1" \
+  "$(audit_exit "${RMC_TMP}/no-self-notify")"
+
+rm -rf "${RMC_TMP}"
 
 # ---------------------------------------------------------------------------
 # detect-docs-only.sh
@@ -926,10 +1042,11 @@ for entry in "test-pointers.yml test-pointers" "semver-checks.yml semver-checks"
     "$(grep -cE "^      - name: No .* — nothing to (lint|compare)$" <<<"${gate}" || true)"
 done
 
-# The other half of that scoping: every job-level `if:` left in
-# test-pointers.yml belongs to the notifier, so the ban above cannot be evaded
-# by moving a condition onto a new job.
-assert_eq "test-pointers.yml: only the notifier carries a job-level if:" "1" \
+# The other half of that scoping: the ban above cannot be evaded by moving the
+# condition onto a new job. The count was 1 while the file carried its own
+# notifier; that job moved to red-main-notify.yml (#5657), so no job-level `if:`
+# belongs in this file at all any more.
+assert_eq "test-pointers.yml: no job-level if: anywhere" "0" \
   "$(grep -cE '^    if:' .github/workflows/test-pointers.yml || true)"
 
 assert_eq "semver-checks runs on pull requests at all" "1" \

--- a/scripts/check-red-main-coverage.sh
+++ b/scripts/check-red-main-coverage.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+#
+# check-red-main-coverage.sh — every push-to-main workflow must have a red-main
+# notifier watching it (issue #5657).
+#
+# Why: `ci.yml`'s `notify-main-failure` cannot see a job in another workflow
+#   file, so a sibling with its own `push: branches: [main]` trigger goes red on
+#   main and nothing files or comments on the `ci-red-main` tracking issue.
+#   `test-pointers.yml` did that for 24 hours; `capabilities-drift.yml` did it
+#   again on 2026-08-31. Both were patched one file at a time, and the audit
+#   table written to catch the rest was already missing four workflows the day
+#   it was written. A hand-maintained list is the failure mode, not the fix, so
+#   the list is machine-checked here instead.
+#
+# What: reads every `.github/workflows/*.yml`, decides which ones trigger on a
+#   push to `main`, and asserts each of those is covered exactly once — either
+#   listed in `red-main-notify.yml`'s `workflow_run.workflows:` list, or one of
+#   the two workflows that notify themselves (`ci.yml`, `version-parity.yml`)
+#   for reasons `red-main-notify.yml`'s header states. Three ways to fail:
+#     1. a push-to-main workflow nobody watches (the #5657 bug, recurring);
+#     2. a listed name that matches no workflow file — `workflow_run` matches on
+#        NAME, so renaming a workflow silently drops its coverage;
+#     3. a self-notifying workflow that lost its own notify job.
+#   Fails CLOSED: an `on:` block it cannot parse counts as push-to-main and must
+#   be covered, because a false alarm is noise and a false pass is the bug.
+#
+#   `--detect <file>` prints the two facts it derives from one workflow file
+#   (`name=` and `push_main=`) and exits. That mode exists so the decision is
+#   fixture-testable without a repo full of real workflows.
+#
+# Usage:
+#   bash scripts/check-red-main-coverage.sh            # audit the whole repo
+#   bash scripts/check-red-main-coverage.sh --detect .github/workflows/ci.yml
+#
+# Env: RED_MAIN_WORKFLOWS_DIR overrides the directory scanned (fixtures only).
+#
+# Exit: 0 when every push-to-main workflow is covered; 1 on the first gap, with
+#   the offending file and the exact edit that closes it.
+#
+# Test: scripts/check-ci-helpers-selftest.sh (`check-red-main-coverage:` cases)
+#   drives `--detect` over fixture workflows — bare push, `branches: [main]`,
+#   tags-only, pull-request-only, a multi-line branch list, an unparseable `on:`
+#   block — and asserts the live repo audit passes.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKFLOWS_DIR="${RED_MAIN_WORKFLOWS_DIR:-${REPO_ROOT}/.github/workflows}"
+NOTIFIER="${WORKFLOWS_DIR}/red-main-notify.yml"
+
+# Workflows that carry their own red-main notifier and are therefore NOT listed
+# in red-main-notify.yml — listing them would file twice for one failure.
+# `<file>|<job key that must still be present>|<why>`.
+SELF_NOTIFIED=(
+  "ci.yml|notify-main-failure:|classifies the shard matrix directly (#5998), which an aggregate run conclusion cannot"
+  "version-parity.yml|notify-main-drift:|files the version-drift-main label and also fires on the schedule trigger (#4688)"
+)
+
+# ---------------------------------------------------------------------------
+# workflow_name <file> — the workflow's `name:` value, unquoted. Empty when the
+# file declares none (GitHub then falls back to the path, which `workflow_run`
+# cannot match reliably, so the audit treats that as uncoverable).
+# ---------------------------------------------------------------------------
+workflow_name() {
+  sed -n 's/^name:[[:space:]]*//p' "$1" | head -1 |
+    sed -e 's/[[:space:]]*$//' -e 's/^"\(.*\)"$/\1/' -e "s/^'\(.*\)'$/\1/"
+}
+
+# ---------------------------------------------------------------------------
+# push_main <file> — `true` when a push to `main` triggers this workflow.
+#
+# A `push:` block covers main when it names `main` (or a wildcard) under
+# `branches:`, or when it constrains nothing at all. A `tags:`-only push block
+# fires on tag refs and never on a branch, so it is not push-to-main — that is
+# how release.yml, pre-publish.yml and semver-checks.yml stay out of the audit
+# without an exclusion list.
+# ---------------------------------------------------------------------------
+push_main() {
+  awk '
+    # Top-level "on:" opens the trigger block; the next top-level key closes it.
+    # Anything after the colon is the inline form (`on: [push]`), which this
+    # parser does not read — it is reported as push-to-main so the audit forces
+    # a human answer rather than assuming a safe one.
+    /^on:/ {
+      saw_on = 1
+      rest = $0
+      sub(/^on:[[:space:]]*/, "", rest)
+      if (rest != "" && rest !~ /^#/) inline = 1
+      in_on = 1
+      next
+    }
+    in_on && /^[^ \t#]/ { in_on = 0 }
+    !in_on            { next }
+
+    # Two-space keys inside "on:". Only "push:" matters.
+    /^  push:/        { in_push = 1; saw_push = 1; next }
+    in_push && /^  [^ \t]/ { in_push = 0 }
+    !in_push          { next }
+
+    # Four-space keys inside "push:".
+    /^    branches:/  { saw_branches = 1; in_list = "branches"; rest = $0; sub(/^[^:]*:/, "", rest); if (rest ~ /main|\*/) hit = 1; next }
+    /^    tags:/      { saw_tags = 1; in_list = "tags"; next }
+    /^    [^ \t]/     { in_list = ""; next }
+
+    # Deeper lines belong to whichever list is open.
+    in_list == "branches" && /^ *- / { if ($0 ~ /main|\*/) hit = 1 }
+
+    END {
+      # No "on:" block, or one this parser cannot read, is a parse failure, not
+      # evidence of no push trigger — fail closed.
+      if (!saw_on || inline) { print "true"; exit }
+      if (!saw_push)      { print "false"; exit }
+      if (saw_branches)   { print (hit ? "true" : "false"); exit }
+      if (saw_tags)       { print "false"; exit }
+      # A bare "push:" constrains nothing, so it includes main. So does anything
+      # else this parser did not recognise — `branches-ignore:` included.
+      print "true"
+    }
+  ' "$1"
+}
+
+# ---------------------------------------------------------------------------
+# --detect <file>: print the two derived facts and stop.
+# ---------------------------------------------------------------------------
+if [ "${1:-}" = "--detect" ]; then
+  file="${2:-}"
+  if [ ! -f "${file}" ]; then
+    echo "check-red-main-coverage: no such workflow file: ${file}" >&2
+    exit 1
+  fi
+  echo "name=$(workflow_name "${file}")"
+  echo "push_main=$(push_main "${file}")"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Full audit.
+# ---------------------------------------------------------------------------
+FAILURES=0
+
+fail() {
+  FAILURES=$((FAILURES + 1))
+  echo "  FAIL: $*" >&2
+}
+
+if [ ! -f "${NOTIFIER}" ]; then
+  echo "check-red-main-coverage: notifier missing: ${NOTIFIER}" >&2
+  echo "  Every push-to-main workflow depends on it (#5657). Restore it." >&2
+  exit 1
+fi
+
+# The names red-main-notify.yml watches: the block-list entries under
+# `workflows:`, up to the next key at the same indent (`types:`).
+WATCHED="$(awk '
+  /^    workflows:/ { in_list = 1; next }
+  in_list && /^    [^ \t]/ { in_list = 0 }
+  in_list && /^ *- / {
+    line = $0
+    sub(/^ *- /, "", line)
+    sub(/[[:space:]]*#.*$/, "", line)
+    sub(/[[:space:]]*$/, "", line)
+    gsub(/^"|"$/, "", line)
+    gsub(/^'"'"'|'"'"'$/, "", line)
+    print line
+  }
+' "${NOTIFIER}")"
+
+if [ -z "${WATCHED}" ]; then
+  echo "check-red-main-coverage: ${NOTIFIER} watches nothing — parse failed or the list is empty." >&2
+  exit 1
+fi
+
+echo "check-red-main-coverage: scanning ${WORKFLOWS_DIR}"
+
+# --- 1. Every push-to-main workflow is covered. ----------------------------
+covered=0
+for wf in "${WORKFLOWS_DIR}"/*.yml; do
+  [ -f "${wf}" ] || continue
+  base="$(basename "${wf}")"
+  [ "${base}" = "red-main-notify.yml" ] && continue
+
+  [ "$(push_main "${wf}")" = "true" ] || continue
+
+  self_notified=""
+  for entry in "${SELF_NOTIFIED[@]}"; do
+    [ "${entry%%|*}" = "${base}" ] && self_notified="${entry}"
+  done
+
+  if [ -n "${self_notified}" ]; then
+    marker="$(echo "${self_notified}" | cut -d'|' -f2)"
+    if grep -q "^  ${marker}$" "${wf}"; then
+      echo "  ok   ${base} — self-notified (${marker%:})"
+      covered=$((covered + 1))
+    else
+      fail "${base} is registered as self-notifying but has no '${marker%:}' job."
+      echo "       Either restore that job or add its name to ${NOTIFIER}." >&2
+    fi
+    continue
+  fi
+
+  name="$(workflow_name "${wf}")"
+  if [ -z "${name}" ]; then
+    fail "${base} triggers on push to main but declares no 'name:'."
+    echo "       workflow_run matches on name, so it cannot be watched without one." >&2
+    continue
+  fi
+
+  if grep -Fxq "${name}" <<<"${WATCHED}"; then
+    echo "  ok   ${base} — watched as \"${name}\""
+    covered=$((covered + 1))
+  else
+    fail "${base} triggers on push to main and NOTHING watches it (#5657)."
+    echo "       Add \"${name}\" to the workflows: list in ${NOTIFIER}." >&2
+  fi
+done
+
+# --- 2. Every watched name still resolves to a push-to-main workflow. ------
+while IFS= read -r name; do
+  [ -n "${name}" ] || continue
+  match=""
+  for wf in "${WORKFLOWS_DIR}"/*.yml; do
+    [ -f "${wf}" ] || continue
+    [ "$(workflow_name "${wf}")" = "${name}" ] && match="${wf}"
+  done
+  if [ -z "${match}" ]; then
+    fail "${NOTIFIER} watches \"${name}\", which no workflow declares."
+    echo "       A renamed workflow silently loses coverage — update the list." >&2
+  elif [ "$(push_main "${match}")" != "true" ]; then
+    fail "${NOTIFIER} watches \"${name}\" ($(basename "${match}")), which no longer triggers on push to main."
+    echo "       Drop it from the list, or restore its push: branches: [main] trigger." >&2
+  fi
+done <<<"${WATCHED}"
+
+echo
+if [ "${FAILURES}" -gt 0 ]; then
+  echo "check-red-main-coverage: ${FAILURES} coverage gap(s) — a red main would go unreported." >&2
+  exit 1
+fi
+echo "check-red-main-coverage: ${covered} push-to-main workflow(s), all covered"


### PR DESCRIPTION
Refs #5657

New `red-main-notify.yml` watches 18 sibling workflows via `workflow_run` and files/comments the `ci-red-main` issue through the existing classifier; `test-pointers.yml`'s own notify job removed (watched centrally now); a new coverage lint in the `changes` job blocks merging any future push-to-main workflow nobody watches; ci.yml and version-parity.yml stay self-notifying (shard matrix / drift label).

The notifier only becomes live once this lands on main (`workflow_run` reads the default branch, so this PR cannot demonstrate a fired alarm — verification is the coverage gate, 216 selftest cases, actionlint, and a PyYAML cross-check of the parser). Every watched workflow completion adds a skipped-when-green "Red main notifier" entry in the Actions list, costing no runner minutes.

CI-only change: rung 1, no changelog fragment owed.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools