### PR TITLE
fix(trusty-agents): stable build provenance in --version; invocation counter no longer masquerades as a build number

### DIFF
--- a/crates/trusty-agents/build.rs
+++ b/crates/trusty-agents/build.rs
@@ -9,10 +9,12 @@
 //! in `src/api/server.rs` always finds a directory to scan — without this,
 //! a missing `ui/dist/` (e.g. fresh clone with no pnpm installed) yields the
 //! 3 compile errors tracked in #112.
-//! What: Queries `git rev-parse --short HEAD` at build time and exposes it
-//! as the `GIT_COMMIT_HASH` environment variable to the compiled crate via
-//! `cargo:rustc-env`. Falls back to `"unknown"` when git isn't available or
-//! the directory isn't a git repo. Then attempts a real `pnpm build` of the
+//! What: Queries git at build time and exposes the results to the compiled
+//! crate via `cargo:rustc-env` — `GIT_COMMIT_HASH` (short SHA),
+//! `GIT_COMMIT_HASH_FULL`, `GIT_COMMIT_DATE` (strict ISO 8601 committer
+//! date), and `GIT_DIRTY` (`"1"` when the working tree had uncommitted or
+//! untracked changes at build time). Falls back to `"unknown"` when git isn't
+//! available or the directory isn't a git repo. Then attempts a real `pnpm build` of the
 //! Svelte UI; if pnpm is unavailable or `SKIP_UI_BUILD=1`, falls back to
 //! writing a placeholder `ui/dist/index.html` so `rust-embed` still compiles.
 //! Test: After `cargo build`, `build_info::GIT_HASH` should be non-empty and
@@ -39,8 +41,11 @@ fn main() {
     println!("cargo:rerun-if-changed=ui/package.json");
     println!("cargo:rerun-if-env-changed=SKIP_UI_BUILD");
 
+    // #4260: watch the index too so a `git add` refreshes the dirty flag.
+    println!("cargo:rerun-if-changed=.git/index");
+
     ensure_ui_dist();
-    emit_git_hash();
+    emit_git_provenance();
 }
 
 /// Run the Svelte UI build (or fall back to a placeholder `ui/dist/index.html`).
@@ -151,30 +156,50 @@ fn ensure_placeholder(ui_dist: &Path) {
     }
 }
 
-/// Capture the short git SHA at build time and expose it via `cargo:rustc-env`.
+/// Capture the git provenance of this build and expose it via `cargo:rustc-env`.
 ///
 /// Why: Bug reports and log lines need a deterministic identifier for the
 /// running binary — `CARGO_PKG_VERSION` alone collapses every commit on a
-/// dev branch into the same version string.
-/// What: Runs `git rev-parse --short HEAD`, exposes the result as
-/// `GIT_COMMIT_HASH`, or falls back to `"unknown"` if git is unavailable.
-/// Test: After `cargo build`, the compiled binary's startup banner should
-/// include either a 7-char hash or the literal `"unknown"`.
-fn emit_git_hash() {
-    let git_hash = Command::new("git")
-        .args(["rev-parse", "--short", "HEAD"])
-        .output()
-        .ok()
-        .and_then(|o| {
-            if o.status.success() {
-                String::from_utf8(o.stdout).ok()
-            } else {
-                None
-            }
-        })
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| "unknown".to_string());
+/// dev branch into the same version string, which is how a ~3.5h-stale
+/// `tagent` was reported as a code bug (#4260). The commit date answers "is
+/// this binary older than that merge?" directly, and the dirty flag says
+/// whether the SHA describes the whole binary or only most of it.
+/// What: Runs `git rev-parse --short HEAD`, `git rev-parse HEAD`,
+/// `git log -1 --format=%cI`, and `git status --porcelain`, exposing them as
+/// `GIT_COMMIT_HASH`, `GIT_COMMIT_HASH_FULL`, `GIT_COMMIT_DATE`, and
+/// `GIT_DIRTY` (`"1"`/`"0"`). Each git value falls back to `"unknown"` (dirty
+/// to `"0"`) when git is unavailable or this is not a repo. The dirty flag
+/// describes the tree as of the last build-script run: the
+/// `cargo:rerun-if-changed` paths above are repo-root-relative and so never
+/// exist next to this crate, which makes cargo re-run this script on every
+/// build and keeps the flag current.
+/// Test: `crates/trusty-agents/tests/version_provenance.rs` asserts the
+/// binary's `--version` carries `GIT_COMMIT_HASH`;
+/// `build_info::commit_mark_matches_the_dirty_flag` covers the rendering.
+fn emit_git_provenance() {
+    let short = git(&["rev-parse", "--short", "HEAD"]).unwrap_or_else(|| "unknown".to_string());
+    let full = git(&["rev-parse", "HEAD"]).unwrap_or_else(|| "unknown".to_string());
+    let date = git(&["log", "-1", "--format=%cI"]).unwrap_or_else(|| "unknown".to_string());
+    // #4260: `--porcelain` prints one line per changed or untracked path, so
+    // any output at all means the tree does not match the SHA above.
+    let dirty = match git(&["status", "--porcelain"]) {
+        Some(_) => "1",
+        None => "0",
+    };
 
-    println!("cargo:rustc-env=GIT_COMMIT_HASH={git_hash}");
+    println!("cargo:rustc-env=GIT_COMMIT_HASH={short}");
+    println!("cargo:rustc-env=GIT_COMMIT_HASH_FULL={full}");
+    println!("cargo:rustc-env=GIT_COMMIT_DATE={date}");
+    println!("cargo:rustc-env=GIT_DIRTY={dirty}");
+}
+
+/// Run `git` with `args`, returning trimmed stdout, or `None` when the command
+/// fails or produces no output.
+fn git(args: &[&str]) -> Option<String> {
+    let out = Command::new("git").args(args).output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8(out.stdout).ok()?.trim().to_string();
+    if s.is_empty() { None } else { Some(s) }
 }

--- a/crates/trusty-agents/changelog.d/4260-version-build-provenance.md
+++ b/crates/trusty-agents/changelog.d/4260-version-build-provenance.md
@@ -1,0 +1,8 @@
+Fixed
+
+- `tagent --version` now names the commit the binary was built from, and says the same thing every time ([#4260](https://github.com/bobmatnyc/trusty-tools/issues/4260))
+  - It used to print `trusty-agents v0.39.0 build #2435`, where the number came from `.trusty-agents/state/build.json` and was incremented by the `--version` path itself. The same installed binary answered `build #2435`, then `build #2440`, so the string could not be quoted as install evidence — and it read exactly like a build id, which is how a ~3.5h-stale binary was reported as a code bug on 2026-07-28.
+  - `--version` now prints `trusty-agents v0.39.0 (fa4b02a30, 2026-08-31T09:12:44-04:00)` — crate version, short commit SHA, and that commit's date, all baked in at compile time. It touches no disk and creates no state directory, so it is safe to run from a script or a read-only cwd.
+  - A build from a dirty working tree marks the SHA: `(fa4b02a30-dirty, …)`.
+  - `GET /api/health` gained `commit`, `commit_full`, `commit_date`, and `dirty`, so a running daemon is identifiable over HTTP rather than by comparing file mtimes. The Svelte header picks up `commit` with no UI change.
+  - The per-invocation counter is not gone — it still disambiguates concurrent runs in a merged log and stamps telemetry filenames — but the startup log line now labels it `run #N`, and it appears in neither `--version` nor the REPL's `/version`.

--- a/crates/trusty-agents/src/api/server/handlers.rs
+++ b/crates/trusty-agents/src/api/server/handlers.rs
@@ -124,6 +124,19 @@ pub(super) struct TaskSubmittedBody {
 pub(super) struct HealthBody {
     status: &'static str,
     version: &'static str,
+    /// Short commit SHA this daemon was built from, `-dirty`-suffixed when the
+    /// build tree was not clean.
+    ///
+    /// Why: #4260 — `version` alone cannot tell a stale daemon from a current
+    /// one, since both report the same semver between releases. The Svelte
+    /// header reads this field (`ui/src/lib/buildInfo.ts::parseHealthBody`).
+    commit: String,
+    /// Full commit SHA, for reports where a short SHA is ambiguous.
+    commit_full: &'static str,
+    /// Committer date of `commit_full`, strict ISO 8601.
+    commit_date: &'static str,
+    /// Whether the build tree carried uncommitted changes.
+    dirty: bool,
     /// This sidecar process's own pid.
     pid: u32,
     /// This sidecar's parent pid (`getppid`), or `None` off unix.
@@ -146,18 +159,24 @@ pub(super) fn projects_config_dir() -> std::path::PathBuf {
     std::path::PathBuf::from(".trusty-agents/projects")
 }
 
-/// `GET /api/health` — liveness + version + parentage probe.
+/// `GET /api/health` — liveness + build provenance + parentage probe.
 ///
 /// Why: Beyond liveness, a GUI sidecar caller uses `pid`/`ppid` to verify it is
 /// talking to the sidecar it spawned rather than a reparented orphan on the same
-/// fixed port (#3734 adoption race).
-/// What: Returns `status`/`version` plus this process's `pid` and, on unix, its
-/// `getppid()`.
-/// Test: `health_returns_ok_and_version` (asserts the pid field is present).
+/// fixed port (#3734 adoption race). #4260 adds the commit fields so a running
+/// daemon can be identified over HTTP — a stale build and a current one both
+/// report the same `version` between releases.
+/// What: Returns `status`/`version`/`commit`/`commit_full`/`commit_date`/`dirty`
+/// plus this process's `pid` and, on unix, its `getppid()`.
+/// Test: `health_returns_ok_and_version` (asserts pid and the commit fields).
 pub(super) async fn health() -> Json<HealthBody> {
     Json(HealthBody {
         status: "ok",
-        version: env!("CARGO_PKG_VERSION"),
+        version: crate::build_info::VERSION,
+        commit: crate::build_info::commit_mark(),
+        commit_full: crate::build_info::GIT_HASH_FULL,
+        commit_date: crate::build_info::GIT_COMMIT_DATE,
+        dirty: crate::build_info::is_dirty(),
         pid: std::process::id(),
         ppid: parent_pid(),
     })

--- a/crates/trusty-agents/src/api/server/tests/mod.rs
+++ b/crates/trusty-agents/src/api/server/tests/mod.rs
@@ -64,6 +64,16 @@ async fn health_returns_ok_and_version() {
         body.get("ppid").is_some(),
         "health must include a ppid field"
     );
+    // #4260: a running daemon must be identifiable by commit over HTTP —
+    // `version` alone repeats across every build between two releases.
+    assert_eq!(
+        body["commit"].as_str().map(str::to_string),
+        Some(crate::build_info::commit_mark()),
+        "health must report the build's short commit: {body}"
+    );
+    assert_eq!(body["commit_full"], crate::build_info::GIT_HASH_FULL);
+    assert_eq!(body["commit_date"], crate::build_info::GIT_COMMIT_DATE);
+    assert_eq!(body["dirty"], crate::build_info::is_dirty());
 }
 
 #[tokio::test]

--- a/crates/trusty-agents/src/build_info.rs
+++ b/crates/trusty-agents/src/build_info.rs
@@ -1,12 +1,16 @@
-//! Build and version tracking.
+//! Build provenance and per-run tracking — two different questions, kept
+//! apart.
 //!
-//! Why: We need a monotonic build counter that increments on every process
-//! start, independent of the semver version. The combined `vX.Y.Z build #N`
-//! string lets us correlate log lines and performance telemetry with the
-//! exact binary invocation that produced them. Keeping the counter on disk
-//! (rather than baked into the binary) lets a single `cargo build` produce
-//! many distinct "builds" across repeated `cargo run` invocations during
-//! development — which is exactly when we need the disambiguation.
+//! Why: "which SOURCE produced this binary" is answered by the compile-time
+//! constants below (version, git SHA, commit date, dirty flag) and never
+//! changes for a given artifact. "which RUN of that binary am I reading logs
+//! from" is answered by the on-disk counter in [`BuildInfo`], which increments
+//! on every process start. Conflating them is #4260: the counter used to
+//! render as `build #N` in `--version`, so the same installed binary reported
+//! `build #2435` then `build #2440` and could not be cited as install
+//! evidence. The counter now renders as `run #N` and appears only where a
+//! per-invocation discriminator is the point — the startup log line and
+//! performance telemetry filenames.
 //!
 //! What: Reads `<dir>/build.json` for a caller-resolved `dir` (always
 //! `<project>/.trusty-agents/state`, never a bare cwd — see
@@ -40,13 +44,65 @@ pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 /// Test: `version_string_contains_version` confirms both fields render.
 pub const GIT_HASH: &str = env!("GIT_COMMIT_HASH");
 
-/// Human-readable banner used by the CTRL REPL and `--version` output.
+/// Full 40-character git commit hash captured at build time by `build.rs`.
 ///
-/// Why: One canonical format keeps log grep and support reports consistent.
-/// What: Returns `trusty-agents vX.Y.Z (<git-hash>)`.
-/// Test: `version_string_contains_version` checks both substrings render.
+/// Why: Short SHAs collide across repositories, so a support report or a
+/// remote `/api/health` probe needs the unambiguous form (#4260).
+/// What: `git rev-parse HEAD`, or `"unknown"` when git is unavailable.
+/// Test: `provenance_constants_are_populated`.
+pub const GIT_HASH_FULL: &str = env!("GIT_COMMIT_HASH_FULL");
+
+/// Committer date of [`GIT_HASH`], in strict ISO 8601.
+///
+/// Why: Answers "is this binary older than that merge?" without a filesystem
+/// mtime comparison — the forensic exercise #4260 was filed over.
+/// What: `git log -1 --format=%cI`, or `"unknown"` when git is unavailable.
+/// Test: `provenance_constants_are_populated`.
+pub const GIT_COMMIT_DATE: &str = env!("GIT_COMMIT_DATE");
+
+/// Whether the working tree carried uncommitted or untracked changes when
+/// this binary was compiled.
+///
+/// Why: A SHA describes a dirty build only approximately; saying so out loud
+/// stops a local experiment from being mistaken for the merged commit.
+/// What: `"1"` when `git status --porcelain` printed anything at build time,
+/// `"0"` otherwise. Read it through [`is_dirty`].
+/// Test: `provenance_constants_are_populated`.
+pub const GIT_DIRTY: &str = env!("GIT_DIRTY");
+
+/// True when the working tree was dirty at build time.
+pub fn is_dirty() -> bool {
+    GIT_DIRTY == "1"
+}
+
+/// Human-readable banner used by the CTRL REPL, `--version`, and the startup
+/// log line.
+///
+/// Why: One canonical format keeps log grep and support reports consistent,
+/// and — since #4260 — every token in it is a property of the ARTIFACT, so
+/// two invocations of one binary print identical bytes.
+/// What: `trusty-agents vX.Y.Z (<short-sha>[-dirty], <commit-date>)`.
+/// Test: `version_string_contains_version`, `version_string_is_stable`,
+/// `commit_mark_matches_the_dirty_flag`.
 pub fn version_string() -> String {
-    format!("trusty-agents v{VERSION} ({GIT_HASH})")
+    format!(
+        "trusty-agents v{VERSION} ({}, {GIT_COMMIT_DATE})",
+        commit_mark()
+    )
+}
+
+/// The short SHA, suffixed with `-dirty` when the build tree was not clean.
+///
+/// Why: Callers that render provenance (banner, `/api/health`) must not each
+/// re-derive the dirty suffix — #4260 is a duplication-of-truth bug already.
+/// What: `<short-sha>` or `<short-sha>-dirty`.
+/// Test: `commit_mark_matches_the_dirty_flag`.
+pub fn commit_mark() -> String {
+    if is_dirty() {
+        format!("{GIT_HASH}-dirty")
+    } else {
+        GIT_HASH.to_string()
+    }
 }
 
 /// On-disk shape of `.trusty-agents/state/build.json`.
@@ -62,15 +118,15 @@ struct PersistedBuild {
     started_at: String,
 }
 
-/// Runtime build metadata surfaced to logs, the `--version` flag, and
-/// downstream instrumentation.
+/// Per-RUN metadata surfaced to the startup log line and downstream
+/// instrumentation. Not build identity — see the module docs.
 ///
-/// Why: Centralizes "which binary + which invocation" so later instrumentation
-/// (issue #47) can tag every telemetry event with the same build stamp the
-/// startup log line shows.
-/// What: Holds the compile-time semver, the incremented build counter, and
-/// the ISO8601 UTC start timestamp.
-/// Test: `display_string` returns `trusty-agents vX.Y.Z build #N`.
+/// Why: Lets instrumentation (issue #47) tag every telemetry event with the
+/// same run stamp the startup log line shows, so two concurrent processes of
+/// one binary stay distinguishable in a merged log.
+/// What: Holds the compile-time semver, the incremented run counter, and the
+/// ISO8601 UTC start timestamp.
+/// Test: `display_string` returns `<version-string> run #N`.
 #[derive(Debug, Clone)]
 pub struct BuildInfo {
     pub version: &'static str,
@@ -123,13 +179,16 @@ impl BuildInfo {
         })
     }
 
-    /// Human-readable banner used by the startup log line and `--version`.
+    /// Human-readable banner used by the startup log line.
     ///
     /// Why: Single canonical format so grep/tooling can match it uniformly.
-    /// What: `trusty-agents vX.Y.Z build #N`.
-    /// Test: Asserted directly in unit tests.
+    /// #4260: the counter is labelled `run #N`, never `build #N` — it names
+    /// this invocation, and calling it a build made a stale binary look
+    /// current.
+    /// What: `trusty-agents vX.Y.Z (<sha>, <date>) run #N`.
+    /// Test: `display_string_format`.
     pub fn display_string(&self) -> String {
-        format!("trusty-agents v{} build #{}", self.version, self.build)
+        format!("{} run #{}", version_string(), self.build)
     }
 }
 
@@ -282,6 +341,9 @@ mod tests {
         assert_eq!(info.build, 1, "corrupt file should be treated as build=0");
     }
 
+    /// Why: #4260 — the counter must be labelled as an invocation, and the
+    /// artifact provenance must lead. `build #N` must not reappear anywhere.
+    /// Test: itself.
     #[tokio::test]
     async fn display_string_format() {
         let info = BuildInfo {
@@ -289,7 +351,12 @@ mod tests {
             build: 42,
             started_at: "2026-04-22T17:31:30Z".to_string(),
         };
-        assert_eq!(info.display_string(), "trusty-agents v0.1.0 build #42");
+        let s = info.display_string();
+        assert_eq!(s, format!("{} run #42", version_string()));
+        assert!(
+            !s.contains("build #"),
+            "counter must not read as build: {s}"
+        );
     }
 
     #[test]
@@ -299,6 +366,43 @@ mod tests {
         assert!(s.contains(VERSION));
         // GIT_HASH is either a short hash or "unknown"; rendered in parens.
         assert!(s.contains(GIT_HASH));
+        assert!(s.contains(GIT_COMMIT_DATE));
+    }
+
+    /// Why: #4260 — the whole point is that repeated asks of one binary get
+    /// one answer. Nothing in `version_string` may read the clock, the disk,
+    /// or the environment.
+    /// Test: itself.
+    #[test]
+    fn version_string_is_stable() {
+        assert_eq!(version_string(), version_string());
+        assert_eq!(version_string(), version_string());
+    }
+
+    /// Why: the dirty suffix is the difference between "this SHA is the whole
+    /// binary" and "mostly"; it must track the flag `build.rs` recorded rather
+    /// than being decorative.
+    /// Test: itself.
+    #[test]
+    fn commit_mark_matches_the_dirty_flag() {
+        let mark = commit_mark();
+        assert!(mark.starts_with(GIT_HASH), "got: {mark}");
+        assert_eq!(
+            mark.ends_with("-dirty"),
+            is_dirty(),
+            "dirty suffix must follow GIT_DIRTY={GIT_DIRTY}: {mark}"
+        );
+    }
+
+    /// Why: an `env!` that `build.rs` forgot to emit is a compile error, but
+    /// one it emits empty is a silent hole in every provenance report.
+    /// Test: itself.
+    #[test]
+    fn provenance_constants_are_populated() {
+        assert!(!GIT_HASH.is_empty());
+        assert!(!GIT_HASH_FULL.is_empty());
+        assert!(!GIT_COMMIT_DATE.is_empty());
+        assert!(GIT_DIRTY == "0" || GIT_DIRTY == "1", "got: {GIT_DIRTY}");
     }
 
     #[tokio::test]

--- a/crates/trusty-agents/src/repl/commands/dispatch.rs
+++ b/crates/trusty-agents/src/repl/commands/dispatch.rs
@@ -180,28 +180,11 @@ impl TrustyAgentsRepl {
                 Ok(true)
             }
             "/version" => {
-                // #buildinfo-erofs: use the already-resolved `project_dir`
-                // (set via `detect_self_project`/`/connect`, never a bare
-                // `std::env::current_dir()`) so this never attempts to
-                // create `.trusty-agents/state` under an unwritable cwd —
-                // the REPL only reaches this path once interactive startup
-                // has already succeeded, but resolving through the same
-                // primitive as the CLI paths keeps the invariant obvious
-                // and removes the last caller of the raw-cwd
-                // `BuildInfo::load_and_increment()`.
-                let state_dir = self.project_dir.join(".trusty-agents").join("state");
-                match crate::build_info::BuildInfo::load_and_increment_in(&state_dir).await {
-                    Ok(info) => {
-                        let _ = writeln!(out, "{}", info.display_string());
-                    }
-                    Err(_) => {
-                        let _ = writeln!(
-                            out,
-                            "trusty-agents v{} (build info unavailable)",
-                            env!("CARGO_PKG_VERSION")
-                        );
-                    }
-                }
+                // #4260: report the artifact's own provenance. This used to
+                // bump the on-disk run counter (and so had to resolve a
+                // writable state dir), which made repeated `/version` calls
+                // in one session disagree about the "build" they named.
+                let _ = writeln!(out, "{}", crate::build_info::version_string());
                 Ok(true)
             }
             "/projects" => {

--- a/crates/trusty-agents/src/runtime/startup.rs
+++ b/crates/trusty-agents/src/runtime/startup.rs
@@ -81,24 +81,20 @@ use build_info::BuildInfo;
 pub(super) async fn run_startup_init(_args: &[String]) -> Result<bool> {
     // Handle --version / -V before anything else (no env/tracing/etc.).
     // Why: `--version` must be cheap and side-effect-free so it's safe to
-    // run in CI or scripts without an OPENROUTER_API_KEY. It still bumps
-    // the build counter so CI runs are disambiguated in logs.
+    // run in CI or scripts without an OPENROUTER_API_KEY.
+    //
+    // #4260: it prints ONLY compile-time provenance and touches no disk. It
+    // used to resolve a state dir and bump the per-run counter, so the same
+    // installed binary answered `build #2435` then `build #2440` — a number
+    // that changes per ask cannot be cited as install evidence.
     //
     // Note: We probe argv directly here (not via clap) so the version path
     // doesn't depend on clap successfully parsing every other flag. Clap's
     // own version-handling is disabled (`disable_version_flag = true` on
-    // `Cli`) so we control formatting + the build-counter bump.
+    // `Cli`) so we control the formatting.
     let raw_args: Vec<String> = std::env::args().collect();
     if raw_args.iter().any(|a| a == "--version" || a == "-V") {
-        // Resolve project dir so `.trusty-agents/state` lands in the project root
-        // even when invoked from a subdirectory.
-        let state_dir = ctrl::detect_self_project()
-            .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")))
-            .join(".trusty-agents")
-            .join("state");
-        tokio::fs::create_dir_all(&state_dir).await?;
-        let info = BuildInfo::load_and_increment_in(&state_dir).await?;
-        println!("{}", info.display_string());
+        println!("{}", build_info::version_string());
         return Ok(false);
     }
 

--- a/crates/trusty-agents/tests/version_provenance.rs
+++ b/crates/trusty-agents/tests/version_provenance.rs
@@ -1,0 +1,121 @@
+//! Integration test (#4260): `tagent --version` names the commit that built
+//! the binary, and says the same thing every time it is asked.
+//!
+//! Why: the version string used to end in `build #N`, a counter read from
+//! `.trusty-agents/state/build.json` and incremented by the `--version` path
+//! itself — so the SAME installed binary reported `build #2435` then
+//! `build #2440` across successive runs. A number that changes per invocation
+//! cannot identify a build, and it read exactly like one, so a stale binary
+//! sat unnoticed and was reported as a code bug. This drives the REAL built
+//! binary rather than calling `build_info::version_string()` in-process,
+//! because the defect lived in the CLI path (which counter it printed and the
+//! disk write it performed), not in the formatter.
+//! What: runs `--version` three times from an isolated `$HOME`/cwd and asserts
+//! the three stdouts are byte-identical, that the string carries the crate
+//! version and the compile-time short SHA, and that no `build #` counter
+//! survives anywhere in it.
+//! Test: this file IS the test.
+
+use std::path::Path;
+use std::process::Command;
+
+const BIN: &str = env!("CARGO_BIN_EXE_tagent");
+
+/// Short git SHA baked in by `build.rs` for THIS compilation of the crate.
+///
+/// Why: `cargo:rustc-env` reaches every target in the package, so the test
+/// binary and the `tagent` binary are stamped with the same value — the
+/// assertion compares the binary's claim against the build's own record
+/// instead of re-shelling out to git.
+const GIT_HASH: &str = env!("GIT_COMMIT_HASH");
+
+/// Run `tagent --version` in `dir` with an isolated `$HOME` and no ambient
+/// project hint (#4826), returning stdout.
+fn version_stdout(dir: &Path) -> String {
+    let out = Command::new(BIN)
+        .arg("--version")
+        .current_dir(dir)
+        .env("HOME", dir)
+        .env_remove("TAGENT_PROJECT_DIR")
+        .env_remove("OPEN_MPM_PROJECT_DIR")
+        .output()
+        .expect("spawn `tagent --version`");
+    assert!(
+        out.status.success(),
+        "`--version` should exit 0; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+/// Why: this is the #4260 defect itself — the same binary must not describe
+/// itself differently on the second and third ask.
+/// Test: itself.
+#[test]
+fn version_output_is_identical_across_invocations() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let first = version_stdout(tmp.path());
+    let second = version_stdout(tmp.path());
+    let third = version_stdout(tmp.path());
+
+    assert_eq!(
+        first, second,
+        "`--version` must be stable across invocations of the same binary"
+    );
+    assert_eq!(
+        second, third,
+        "`--version` must be stable across invocations of the same binary"
+    );
+}
+
+/// Why: stability alone is satisfied by printing nothing useful. The string
+/// must also identify WHICH source produced the binary — the question the
+/// 2026-07-28 stale-build incident could not answer without a `strings` dump.
+/// Test: itself.
+#[test]
+fn version_output_names_the_commit_that_built_it() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let out = version_stdout(tmp.path());
+
+    assert!(
+        out.contains(env!("CARGO_PKG_VERSION")),
+        "`--version` must carry the crate version: {out}"
+    );
+    assert!(
+        out.contains(GIT_HASH),
+        "`--version` must carry the build's short SHA ({GIT_HASH}): {out}"
+    );
+}
+
+/// Why: the counter is the misleading half of #4260 — a `build #N` token in
+/// `--version` is a build identity claim the number cannot honour.
+/// Test: itself.
+#[test]
+fn version_output_carries_no_per_invocation_counter() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let out = version_stdout(tmp.path());
+
+    assert!(
+        !out.contains("build #"),
+        "`--version` must not present a per-invocation counter: {out}"
+    );
+}
+
+/// Why: `--version` is run by scripts and CI; it has no business creating a
+/// state directory or mutating a counter file to answer a read-only question.
+/// Test: itself.
+#[test]
+fn version_output_writes_nothing_to_the_working_directory() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let _ = version_stdout(tmp.path());
+
+    let entries: Vec<_> = std::fs::read_dir(tmp.path())
+        .unwrap()
+        .filter_map(Result::ok)
+        .map(|e| e.file_name())
+        .collect();
+    assert!(
+        entries.is_empty(),
+        "`--version` must not write to the working directory, found: {entries:?}"
+    );
+}

--- a/docs/trusty-agents/developer/building.md
+++ b/docs/trusty-agents/developer/building.md
@@ -58,17 +58,22 @@ cd ui && pnpm dev
 # Vite proxies /api/* to http://localhost:7654
 ```
 
-## Build counter
+## Build provenance and the run counter
 
-`build.rs` runs at compile time, captures the git commit hash, and bakes
-it into the binary. At runtime, every invocation increments
-`.open-mpm/state/build.json` so each run has a unique build number you
-can correlate with `docs/performance/runs/*.json`.
+`build.rs` runs at compile time and bakes four values into the binary: the
+short and full git commit hashes, that commit's date, and whether the working
+tree was dirty. `--version` prints them and nothing else, so two invocations of
+one binary print identical bytes (#4260).
 
 ```bash
 cargo run -- --version
-# open-mpm v0.1.37 (abc1234) build #189
+# trusty-agents v0.39.0 (abc1234, 2026-08-31T09:12:44-04:00)
 ```
+
+Separately, each process start increments `.trusty-agents/state/build.json`.
+That counter names the RUN, not the build — it renders as `run #N` in the
+startup log line and lets you correlate a run with
+`docs/performance/runs/*.json`. It never appears in `--version`.
 
 ## Cross-compilation
 


### PR DESCRIPTION
Refs #4260.

tagent --version now prints compile-time provenance (v0.39.0 (fa4b02a30-dirty, <commit date>)), is identical across invocations, and writes nothing to disk (it previously bumped a per-invocation counter presented as "build #N"); /api/health gains commit/commit_full/commit_date/dirty fields; the REPL /version path matches. Cross-daemon provenance consolidation is out of scope, tracked by #4751.

Test ladder: rung 3 — cargo test -p trusty-agents --no-fail-fast, 14 targets, 3585 passed / 0 failed; 4 regression tests provably failed pre-fix; live double-invocation smoke identical. Changelog fragment included.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools