### PR TITLE
fix(trusty-code): prune dangling workstream session_ids on daemon boot (Refs #4579)

### DIFF
--- a/crates/trusty-code/changelog.d/4579-prune-dangling-session-ids.md
+++ b/crates/trusty-code/changelog.d/4579-prune-dangling-session-ids.md
@@ -1,0 +1,12 @@
+Fixed
+
+- **Boot reconciliation prunes dangling workstream `session_ids` (issue
+  #4579).** `WorkstreamStore` persists each workstream's `session_ids`, but
+  `SessionRegistry` is in-memory only, so after a daemon restart every
+  persisted id referenced a session that no longer exists and was never cleaned
+  up. `reconcile_on_boot` now takes the live session-id set and drops, from
+  every record, any id absent from it — a live id is always kept, and no
+  workstream record is ever removed (AC-6.1 unchanged). At the real boot site
+  the registry is empty, so all stale references are pruned; the change is
+  persisted only when something actually changed, and never touches a record's
+  `updated_at`.

--- a/crates/trusty-code/src/serve/mod.rs
+++ b/crates/trusty-code/src/serve/mod.rs
@@ -188,8 +188,15 @@ async fn build_router_at(
     let mut workstream_store = WorkstreamStore::load_for_binding(data_dir, &binding)
         .await
         .context("loading workstream store")?;
+    // #4579: the registry is in-memory, so at boot it is empty and every
+    // persisted session_id is dangling — reconciliation prunes them against
+    // the live set. Deriving the set from `sessions` (rather than passing an
+    // empty one) keeps this correct if a future boot path pre-populates the
+    // registry before reconciling.
+    let live_session_ids: std::collections::HashSet<String> =
+        sessions.list().into_iter().map(|s| s.id).collect();
     workstream_store
-        .reconcile_on_boot()
+        .reconcile_on_boot(&live_session_ids)
         .await
         .context("reconciling workstream store on boot")?;
     let workstreams = Arc::new(Mutex::new(workstream_store));

--- a/crates/trusty-code/src/workstreams/store.rs
+++ b/crates/trusty-code/src/workstreams/store.rs
@@ -17,6 +17,7 @@
 //! the active pointer or clears it if the target vanished).
 //! Test: `store_tests`.
 
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
@@ -117,15 +118,20 @@ struct FileSig {
 /// Why: the daemon boot path needs to log/report what reconciliation found
 /// without re-deriving it from before/after store snapshots.
 /// What: how many workstream records were loaded, the active id restored (if
-/// any), and whether a stale pointer (referencing a now-nonexistent
-/// workstream) was cleared.
+/// any), whether a stale pointer (referencing a now-nonexistent workstream)
+/// was cleared, and how many dangling `session_ids` were pruned across all
+/// records (#4579).
 /// Test: `store_tests::reconcile_restores_active_pointer`,
-/// `store_tests::reconcile_clears_active_when_target_missing`.
+/// `store_tests::reconcile_clears_active_when_target_missing`,
+/// `store_tests::reconcile_prunes_dangling_session_ids`.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ReconcileOutcome {
     pub workstream_count: usize,
     pub active_restored: Option<WorkstreamId>,
     pub active_cleared: bool,
+    /// #4579: total count of `session_ids` entries dropped on boot because no
+    /// matching session is present in the (in-memory) `SessionRegistry`.
+    pub sessions_pruned: usize,
 }
 
 /// Async, file-backed store for [`Workstream`] records (DOC-48 §3).
@@ -494,27 +500,47 @@ impl WorkstreamStore {
         Ok(())
     }
 
-    /// Boot-time reconciliation (DOC-48 §3.3, AC-1.4, AC-6.1, AC-6.2).
+    /// Boot-time reconciliation (DOC-48 §3.3, AC-1.4, AC-6.1, AC-6.2; #4579).
     ///
     /// Why: a daemon restart must never silently change which workstream is
     /// active (§3.2), and must never delete a workstream record (§3.3,
-    /// AC-6.1) — session liveness plays NO part in this (§3.3: "does NOT
-    /// determine active/idle state").
-    /// What: reloads from disk, then: if the persisted active pointer still
-    /// references an existing workstream, leaves it untouched (restored);
-    /// if it references a workstream that no longer exists, clears it to
-    /// `None` and persists that single change; if there was no pointer,
-    /// does nothing. Every workstream record is preserved either way — this
-    /// method never removes an entry from `workstreams`.
+    /// AC-6.1) — session liveness plays NO part in the active/idle STATE a
+    /// record reports (§3.3: "does NOT determine active/idle state"). #4579:
+    /// but the `SessionRegistry` is in-memory only, so after a restart every
+    /// persisted `session_id` names a session that no longer exists. Left in
+    /// place those references dangle forever — the workstream event
+    /// aggregation layer (§3, "fan-outs over the workstream's bound
+    /// `session_ids`") would keep resolving them against an empty registry.
+    /// Per owner ruling (2026-08-31, PRUNE ON BOOT), reconciliation drops each
+    /// `session_id` absent from the live registry. This prunes stale entries
+    /// from a record's list; it never removes a record, and never changes the
+    /// active/idle state a record reports — so it is still non-destructive in
+    /// the sense §3.3/AC-6.1 require. It is the one exception to §2.1's
+    /// append-only `session_ids`, scoped to boot only.
+    /// What: reloads from disk, then (1) if the persisted active pointer still
+    /// references an existing workstream, leaves it untouched (restored); if
+    /// it references a workstream that no longer exists, clears it to `None`;
+    /// if there was no pointer, does nothing. (2) Retains, in every record's
+    /// `session_ids`, only ids present in `live_session_ids`; a live id is
+    /// always kept. Persists once iff anything changed. Every workstream
+    /// record is preserved either way — this method never removes an entry
+    /// from `workstreams`. `updated_at` is deliberately NOT touched by a
+    /// prune, so a restart does not silently reorder records by recency.
     /// Test: `store_tests::reconcile_restores_active_pointer`,
     /// `store_tests::reconcile_clears_active_when_target_missing`,
-    /// `store_tests::reconcile_is_noop_with_no_active_pointer`.
-    pub async fn reconcile_on_boot(&mut self) -> Result<ReconcileOutcome, StoreError> {
+    /// `store_tests::reconcile_is_noop_with_no_active_pointer`,
+    /// `store_tests::reconcile_prunes_dangling_session_ids`,
+    /// `store_tests::reconcile_keeps_live_session_ids`.
+    pub async fn reconcile_on_boot(
+        &mut self,
+        live_session_ids: &HashSet<String>,
+    ) -> Result<ReconcileOutcome, StoreError> {
         self.reload_if_changed().await?;
         let mut outcome = ReconcileOutcome {
             workstream_count: self.data.workstreams.len(),
             ..Default::default()
         };
+        let mut changed = false;
         match self.data.active_workstream_id {
             Some(id) if self.data.workstreams.iter().any(|w| w.id == id) => {
                 outcome.active_restored = Some(id);
@@ -522,9 +548,22 @@ impl WorkstreamStore {
             Some(_) => {
                 self.data.active_workstream_id = None;
                 outcome.active_cleared = true;
-                self.save().await?;
+                changed = true;
             }
             None => {}
+        }
+        // #4579: prune session_ids whose session is gone from the in-memory
+        // registry, keeping every live one.
+        for ws in &mut self.data.workstreams {
+            let before = ws.session_ids.len();
+            ws.session_ids.retain(|sid| live_session_ids.contains(sid));
+            outcome.sessions_pruned += before - ws.session_ids.len();
+        }
+        if outcome.sessions_pruned > 0 {
+            changed = true;
+        }
+        if changed {
+            self.save().await?;
         }
         Ok(outcome)
     }

--- a/crates/trusty-code/src/workstreams/store_tests.rs
+++ b/crates/trusty-code/src/workstreams/store_tests.rs
@@ -1,10 +1,17 @@
 //! Tests for `workstreams::store` (DOC-48 §3, AC-1.2, AC-1.4, AC-6.1, AC-6.2).
 
 use super::*;
+use std::collections::HashSet;
 use tempfile::TempDir;
 
 fn store_file(dir: &TempDir) -> PathBuf {
     dir.path().join("workstreams-test.json")
+}
+
+/// #4579: the live-session set a fresh daemon boot presents — empty, because
+/// the `SessionRegistry` is in-memory and holds nothing across a restart.
+fn no_live_sessions() -> HashSet<String> {
+    HashSet::new()
 }
 
 #[tokio::test]
@@ -110,7 +117,10 @@ async fn reconcile_restores_active_pointer() {
 
     // A fresh store handle stands in for the daemon reloading after restart.
     let mut restarted = WorkstreamStore::load(&path).await.expect("load restarted");
-    let outcome = restarted.reconcile_on_boot().await.expect("reconcile");
+    let outcome = restarted
+        .reconcile_on_boot(&no_live_sessions())
+        .await
+        .expect("reconcile");
     assert_eq!(outcome.workstream_count, 1);
     assert_eq!(outcome.active_restored, Some(id));
     assert!(!outcome.active_cleared);
@@ -147,7 +157,10 @@ async fn reconcile_clears_active_when_target_missing() {
         "precondition: dangling pointer is present before reconciliation"
     );
 
-    let outcome = store.reconcile_on_boot().await.expect("reconcile");
+    let outcome = store
+        .reconcile_on_boot(&no_live_sessions())
+        .await
+        .expect("reconcile");
     assert!(outcome.active_cleared);
     assert_eq!(outcome.active_restored, None);
     assert_eq!(store.active_workstream_id().await.expect("active"), None);
@@ -167,7 +180,10 @@ async fn reconcile_is_noop_with_no_active_pointer() {
     let mut store = WorkstreamStore::load(store_file(&dir)).await.expect("load");
     store.create("A").await.expect("create");
 
-    let outcome = store.reconcile_on_boot().await.expect("reconcile");
+    let outcome = store
+        .reconcile_on_boot(&no_live_sessions())
+        .await
+        .expect("reconcile");
     assert_eq!(outcome.workstream_count, 1);
     assert_eq!(outcome.active_restored, None);
     assert!(!outcome.active_cleared);
@@ -186,7 +202,10 @@ async fn reconcile_preserves_every_workstream_record() {
     drop(store);
 
     let mut restarted = WorkstreamStore::load(&path).await.expect("reload");
-    restarted.reconcile_on_boot().await.expect("reconcile");
+    restarted
+        .reconcile_on_boot(&no_live_sessions())
+        .await
+        .expect("reconcile");
     let all = restarted.list().await.expect("list");
     assert_eq!(
         all.len(),
@@ -195,6 +214,84 @@ async fn reconcile_preserves_every_workstream_record() {
     );
     assert!(all.iter().any(|w| w.id == a));
     assert!(all.iter().any(|w| w.id == b));
+}
+
+/// #4579: a `session_id` bound before a restart, whose session is absent from
+/// the (in-memory) registry after the restart, must be pruned on boot — the
+/// persisted reference cannot be left dangling. The workstream RECORD survives.
+#[tokio::test]
+async fn reconcile_prunes_dangling_session_ids() {
+    let dir = TempDir::new().expect("tempdir");
+    let path = store_file(&dir);
+
+    // Before restart: a workstream with a bound session.
+    let mut writer = WorkstreamStore::load(&path).await.expect("load writer");
+    let ws = writer.create("A").await.expect("create");
+    writer
+        .bind_session(ws, "sess-gone")
+        .await
+        .expect("bind session");
+    assert_eq!(
+        writer.get(ws).await.expect("get").session_ids,
+        vec!["sess-gone".to_string()],
+        "precondition: the session_id is persisted before the restart"
+    );
+    drop(writer);
+
+    // After restart: the registry is empty, so `sess-gone` is not live.
+    let mut restarted = WorkstreamStore::load(&path).await.expect("load restarted");
+    let outcome = restarted
+        .reconcile_on_boot(&no_live_sessions())
+        .await
+        .expect("reconcile");
+    assert_eq!(outcome.sessions_pruned, 1, "the dangling id must be pruned");
+    assert_eq!(
+        restarted.list().await.expect("list").len(),
+        1,
+        "the workstream record itself must survive (AC-6.1)"
+    );
+    assert!(
+        restarted.get(ws).await.expect("get").session_ids.is_empty(),
+        "no workstream may retain a session_id absent from the live registry"
+    );
+
+    // Persisted, not just in-memory.
+    let mut reloaded = WorkstreamStore::load(&path).await.expect("reload");
+    assert!(
+        reloaded.get(ws).await.expect("get").session_ids.is_empty(),
+        "the prune must be written to disk"
+    );
+}
+
+/// #4579: reconciliation must NOT over-prune — a `session_id` present in the
+/// live registry is kept, while a dangling sibling in the same record is
+/// dropped.
+#[tokio::test]
+async fn reconcile_keeps_live_session_ids() {
+    let dir = TempDir::new().expect("tempdir");
+    let path = store_file(&dir);
+
+    let mut store = WorkstreamStore::load(&path).await.expect("load");
+    let ws = store.create("A").await.expect("create");
+    store
+        .bind_session(ws, "sess-live")
+        .await
+        .expect("bind live");
+    store
+        .bind_session(ws, "sess-gone")
+        .await
+        .expect("bind gone");
+
+    let mut live = HashSet::new();
+    live.insert("sess-live".to_string());
+
+    let outcome = store.reconcile_on_boot(&live).await.expect("reconcile");
+    assert_eq!(outcome.sessions_pruned, 1, "only the dangling id is pruned");
+    assert_eq!(
+        store.get(ws).await.expect("get").session_ids,
+        vec!["sess-live".to_string()],
+        "a live session_id must be kept"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Refs #4579

reconcile_on_boot now takes the live session-id set (derived from sessions.list() at the boot site) and retains only live ids in each workstream's session_ids, so a persisted workstream can no longer reference a session that vanished across a restart; records are never removed (only stale id entries), persisted once iff something changed, updated_at untouched.

Note: #3696 was batched with this but is ALREADY FIXED on main (per-turn narrative emit path exists via merged slices) and was dispositioned separately — this PR is #4579 only.

Rung 3: cargo test -p trusty-code --no-fail-fast, 1671 lib passed / 0 failed; 2 regression tests (reconcile_prunes_dangling_session_ids, reconcile_keeps_live_session_ids) provably fail pre-fix. Changelog fragment included.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools