### PR TITLE
fix(trusty-agents): wave-B batch — loud cto-db fallback, policy-driven max_turns, serial home test, stale calendar declaration

### DIFF
--- a/crates/trusty-agents/.trusty-agents/agents/cto-assistant.toml
+++ b/crates/trusty-agents/.trusty-agents/agents/cto-assistant.toml
@@ -117,12 +117,13 @@ scopes = ["memory.read", "memory.write", "search.read", "google.gmail.*", "googl
 # #256: Skill files live in `.trusty-agents/skills/<name>.md` and are resolved
 # by name at agent load time. The org/APEX/voice skills give the model
 # durable Duetto-specific knowledge without bloating this prompt file.
+# #4844: `gworkspace-calendar` dropped — no such skill file exists anywhere on
+# disk, so it never resolved (owner ruling: drop it, don't write it).
 skills = [
     "cto-duetto-org",
     "cto-apex-framework",
     "cto-bob-voice",
     "izzie-metro-north",
-    "gworkspace-calendar",
 ]
 content = """
 You are the CTO Assistant for Duetto Research, a private AI assistant available to Robert Matsuoka (CTO, goes by Masa) and Andrea Kovac (Engineering Operations Coordinator).

--- a/crates/trusty-agents/.trusty-agents/skills/cto-db/SKILL.md
+++ b/crates/trusty-agents/.trusty-agents/skills/cto-db/SKILL.md
@@ -29,15 +29,18 @@ Exact input schemas live in `manifest.json`, which
 one `ToolExecutor` per tool and register them (via `AgentPlugin` +
 `install_plugins`) against the `cto-assistant` persona declared above.
 
-## Data source — FIXTURE by default, read this before trusting a number
+## Data source — read this before trusting a number
 
-By default this skill queries a **fixture** SQLite database
-(`python/fixtures/cto_fixture.db`) containing invented sample data. The
-real database (`~/Duetto/cto/data/cto.db`, a Duetto-internal file on Bob's
-machine) is not reachable from this environment. Set `CTO_DB_PATH` to the
-real file's path to use it instead — see `python/README.md` for details.
-Every response should be treated as fixture output until that swap is made
-and verified.
+This skill refuses to answer unless a database is configured (#4860). Set
+`CTO_DB_PATH` to the real database (`~/Duetto/cto/data/cto.db`, a
+Duetto-internal file on Bob's machine, not reachable from this environment).
+Setting `CTO_DB_USE_FIXTURE=1` instead serves a bundled **fixture**
+(`python/fixtures/cto_fixture.db`) of invented sample data — useful for tests
+and local development, never a source of real figures. With neither set, all
+four tools return a JSON error rather than a fabricated answer.
+
+Every successful response carries `db_path` and `is_fixture`, so fixture
+output stays identifiable. See `python/README.md` for details.
 
 ## Invocation contract
 

--- a/crates/trusty-agents/.trusty-agents/skills/cto-db/python/README.md
+++ b/crates/trusty-agents/.trusty-agents/skills/cto-db/python/README.md
@@ -5,11 +5,10 @@ Python skill package backing cto-assistant's four `[tools].allow` entries:
 
 ## IMPORTANT: fixture data, not the real Duetto database
 
-**The database this skill queries by default (`fixtures/cto_fixture.db`) is
-invented sample data, checked in for structural completeness and
-testability only.** It is not a copy, sample, or export of any real Duetto
-system. Names, teams, and numbers are all placeholders (e.g. "Ada Fixture",
-"GTM Sample Team").
+**The bundled database (`fixtures/cto_fixture.db`) is invented sample data,
+checked in for structural completeness and testability only.** It is not a
+copy, sample, or export of any real Duetto system. Names, teams, and numbers
+are all placeholders (e.g. "Ada Fixture", "GTM Sample Team").
 
 The real source this skill is meant to eventually query is
 `~/Duetto/cto/data/cto.db` — a SQLite file that lives on Bob's machine. This
@@ -24,8 +23,18 @@ To use the real database once it's reachable:
 export CTO_DB_PATH=~/Duetto/cto/data/cto.db
 ```
 
-With `CTO_DB_PATH` unset, `db.resolve_db_path()` falls back to the bundled
-fixture. See `db.py`'s module docstring for the exact resolution order.
+### Resolution order (#4860)
+
+1. `CTO_DB_PATH` set and non-empty → that file.
+2. Else `CTO_DB_USE_FIXTURE` set to anything but `0`/`false`/`no`/`off` →
+   the bundled fixture.
+3. Else `db.resolve_db_path()` raises `UnconfiguredDatabaseError`, and
+   `cli.py` turns that into `{"error": ...}` with exit 1.
+
+The fixture used to be the silent default, so an unconfigured skill answered
+"how many people do we have?" with five invented names while the real
+database held 421. Every successful response now also carries `db_path` and
+`is_fixture`, so fixture output stays identifiable downstream.
 
 ## Why this schema
 
@@ -70,8 +79,16 @@ uv pip install -e ".[dev]"
 uv run pytest
 ```
 
+The suite sets `CTO_DB_USE_FIXTURE=1` itself and drops any inherited
+`CTO_DB_PATH`, so it queries the committed fixture rather than a developer's
+real database.
+
 ## Manual smoke test
 
 ```bash
-echo '{"filter_by": "team"}' | uv run python -m cto_db_skill.cli query_headcount
+echo '{"filter_by": "team"}' | CTO_DB_USE_FIXTURE=1 \
+  uv run python -m cto_db_skill.cli query_headcount
 ```
+
+Without `CTO_DB_PATH` or `CTO_DB_USE_FIXTURE`, that command prints a JSON
+error and exits 1 — the intended behaviour, not a misconfiguration.

--- a/crates/trusty-agents/.trusty-agents/skills/cto-db/python/src/cto_db_skill/cli.py
+++ b/crates/trusty-agents/.trusty-agents/skills/cto-db/python/src/cto_db_skill/cli.py
@@ -9,12 +9,14 @@ query logic (that's `db.py`), only argv/stdin/stdout plumbing and exit codes.
 
 What: `main()` reads `sys.argv[1]` as the tool name, parses stdin as JSON
 (treating empty stdin as `{}`), calls `db.dispatch`, and prints the result as
-a single JSON line to stdout. On any exception it prints
-`{"error": "<message>"}` to stdout and exits 1 — never a raw Python
-traceback, which would not parse as the JSON the Rust side expects.
+a single JSON line to stdout, stamped with the `db_path` it queried and an
+`is_fixture` flag (#4860). On any exception — including an unconfigured
+database — it prints `{"error": "<message>"}` to stdout and exits 1, never a
+raw Python traceback, which would not parse as the JSON the Rust side expects.
 
 Test: `tests/test_cli.py` drives this via `subprocess.run` end-to-end,
-including the fixture DB, an unknown tool, and an unknown filter value.
+including the fixture DB, an unknown tool, an unknown filter value, and the
+unconfigured-database refusal.
 """
 
 from __future__ import annotations
@@ -43,7 +45,14 @@ def main(argv: list[str] | None = None) -> int:
         print(json.dumps({"error": f"invalid JSON on stdin: {exc}"}))
         return 1
 
-    db_path = db.resolve_db_path()
+    # #4860: an unconfigured skill refuses here instead of quietly answering
+    # from the bundled fixture.
+    try:
+        db_path = db.resolve_db_path()
+    except db.UnconfiguredDatabaseError as exc:
+        print(json.dumps({"error": str(exc)}))
+        return 1
+
     try:
         conn = db.open_readonly(db_path)
     except Exception as exc:  # noqa: BLE001 - surfaced to the LLM, never a crash
@@ -64,6 +73,10 @@ def main(argv: list[str] | None = None) -> int:
     finally:
         conn.close()
 
+    # #4860: stamp the resolved source so fixture output stays identifiable
+    # downstream rather than reading as a real Duetto figure.
+    result["db_path"] = str(db_path)
+    result["is_fixture"] = db.is_fixture_path(db_path)
     print(json.dumps(result))
     return 0
 

--- a/crates/trusty-agents/.trusty-agents/skills/cto-db/python/src/cto_db_skill/db.py
+++ b/crates/trusty-agents/.trusty-agents/skills/cto-db/python/src/cto_db_skill/db.py
@@ -18,7 +18,8 @@ What: Four functions — `query_headcount`, `query_budget`, `query_risks`,
 optional filters and returning a JSON-serialisable `dict`. `resolve_db_path`
 / `open_readonly` centralise path resolution and read-only connection
 opening so `cli.py` (the subprocess entrypoint) and the test suite share one
-code path.
+code path. #4860: `resolve_db_path` refuses when nothing is configured — the
+bundled fixture is served only when `$CTO_DB_USE_FIXTURE` asks for it.
 
 Test: `tests/test_db.py` seeds an in-memory SQLite database with the same
 shape as `fixtures/build_fixture.py` and exercises every function's filters,
@@ -40,32 +41,77 @@ from typing import Any
 # module's README/comments.
 ENV_CTO_DB_PATH = "CTO_DB_PATH"
 
-# The bundled fixture, shipped alongside this package. This is what gets
-# used with NO configuration — see this directory's README.md for the loud
-# "this is fixture data, not the real Duetto CTO ops DB" disclosure.
+# Opt-in to the bundled fixture. #4860: the fixture used to be the silent
+# default, so an unconfigured skill answered "how many people do we have?"
+# with invented sample data and no way for the caller to tell. Serving it now
+# requires asking for it by name.
+ENV_CTO_DB_USE_FIXTURE = "CTO_DB_USE_FIXTURE"
+
+# The bundled fixture, shipped alongside this package. Reachable only via
+# `$CTO_DB_USE_FIXTURE` — see this directory's README.md for the loud "this is
+# fixture data, not the real Duetto CTO ops DB" disclosure.
 _SKILL_ROOT = Path(__file__).resolve().parent.parent.parent
 DEFAULT_FIXTURE_DB_PATH = _SKILL_ROOT / "fixtures" / "cto_fixture.db"
+
+# Spellings that turn the fixture opt-in OFF. Anything else non-empty turns it
+# on, so `CTO_DB_USE_FIXTURE=1` and `=true` both work.
+_FIXTURE_OPT_OUT_VALUES = frozenset({"", "0", "false", "no", "off"})
 
 
 class UnknownFilterError(ValueError):
     """Raised when a caller passes a filter value outside the documented enum."""
 
 
-def resolve_db_path() -> Path:
-    """Resolve which SQLite file to open.
+class UnconfiguredDatabaseError(RuntimeError):
+    """Raised when no database is configured and the fixture was not opted into.
 
-    Why: Local dev/CI/production all need to work without code changes —
-    honour an explicit override first, then fall back to the bundled
-    fixture so the skill is usable out of the box.
-    What: Returns `$CTO_DB_PATH` if set and non-empty, else
-    `DEFAULT_FIXTURE_DB_PATH`.
+    Why: #4860 — a confident wrong answer is worse than an error. The caller
+    must see a refusal it can surface, not sample data dressed as a real
+    headcount.
+    """
+
+
+def _fixture_opt_in() -> bool:
+    value = os.environ.get(ENV_CTO_DB_USE_FIXTURE, "").strip().lower()
+    return value not in _FIXTURE_OPT_OUT_VALUES
+
+
+def resolve_db_path() -> Path:
+    """Resolve which SQLite file to open, or refuse.
+
+    Why: #4860 — falling back to the bundled fixture with nothing configured
+    let the four query tools return well-formed answers built from invented
+    data, indistinguishable from a real one. The fixture stays reachable for
+    tests and local development, but only when asked for explicitly.
+    What: Returns `$CTO_DB_PATH` if set and non-empty; else
+    `DEFAULT_FIXTURE_DB_PATH` when `$CTO_DB_USE_FIXTURE` opts in; else raises
+    `UnconfiguredDatabaseError`.
     Test: `test_resolve_db_path_honours_env_override`,
-    `test_resolve_db_path_defaults_to_fixture`.
+    `test_resolve_db_path_refuses_when_unconfigured`,
+    `test_resolve_db_path_serves_fixture_only_on_explicit_opt_in`,
+    `test_fixture_opt_in_rejects_falsey_values`,
+    `test_real_path_wins_over_the_fixture_opt_in`.
     """
     override = os.environ.get(ENV_CTO_DB_PATH, "").strip()
     if override:
         return Path(override)
-    return DEFAULT_FIXTURE_DB_PATH
+    if _fixture_opt_in():
+        return DEFAULT_FIXTURE_DB_PATH
+    raise UnconfiguredDatabaseError(
+        f"no CTO database configured: set {ENV_CTO_DB_PATH} to the real "
+        f"database, or {ENV_CTO_DB_USE_FIXTURE}=1 to query the bundled "
+        "fixture (invented sample data, not real Duetto figures)"
+    )
+
+
+def is_fixture_path(path: Path) -> bool:
+    """Whether `path` is the bundled fixture rather than a real database.
+
+    Why: #4860 — every response carries this so fixture output stays
+    identifiable downstream, even once someone opts in.
+    Test: `test_is_fixture_path_labels_the_bundled_fixture`.
+    """
+    return Path(path) == DEFAULT_FIXTURE_DB_PATH
 
 
 def open_readonly(path: Path) -> sqlite3.Connection:

--- a/crates/trusty-agents/.trusty-agents/skills/cto-db/python/tests/test_cli.py
+++ b/crates/trusty-agents/.trusty-agents/skills/cto-db/python/tests/test_cli.py
@@ -23,6 +23,11 @@ def _run(tool_name: str, args: dict, env_overrides: dict | None = None) -> subpr
 
     env = os.environ.copy()
     env["PYTHONPATH"] = str(PYTHON_DIR / "src") + os.pathsep + env.get("PYTHONPATH", "")
+    # #4860: the fixture is opt-in, so these fixture-backed cases must ask for
+    # it by name. A developer's real `CTO_DB_PATH` is dropped so the suite
+    # queries the committed fixture rather than whatever is on their machine.
+    env.pop("CTO_DB_PATH", None)
+    env["CTO_DB_USE_FIXTURE"] = "1"
     if env_overrides:
         env.update(env_overrides)
     return subprocess.run(
@@ -43,6 +48,38 @@ def test_cli_query_headcount_against_fixture() -> None:
     assert payload["filter_by"] == "team"
     assert isinstance(payload["groups"], list)
     assert len(payload["groups"]) > 0
+
+
+# #4860: fixture output must be identifiable downstream, not indistinguishable
+# from a real answer.
+def test_cli_stamps_the_resolved_source_on_every_response() -> None:
+    proc = _run("query_headcount", {"filter_by": "team"})
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout)
+    assert payload["db_path"] == str(FIXTURE_DB)
+    assert payload["is_fixture"] is True
+
+
+def test_cli_refuses_when_no_database_is_configured() -> None:
+    import os
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(PYTHON_DIR / "src") + os.pathsep + env.get("PYTHONPATH", "")
+    env.pop("CTO_DB_PATH", None)
+    env.pop("CTO_DB_USE_FIXTURE", None)
+    proc = subprocess.run(
+        [sys.executable, "-m", "cto_db_skill.cli", "query_headcount"],
+        input=json.dumps({"filter_by": "team"}),
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=10,
+        check=False,
+    )
+    assert proc.returncode == 1
+    payload = json.loads(proc.stdout)
+    assert "CTO_DB_PATH" in payload["error"]
+    assert "groups" not in payload
 
 
 def test_cli_query_budget_no_args() -> None:

--- a/crates/trusty-agents/.trusty-agents/skills/cto-db/python/tests/test_db.py
+++ b/crates/trusty-agents/.trusty-agents/skills/cto-db/python/tests/test_db.py
@@ -9,6 +9,7 @@ sample rows drifting over time.
 from __future__ import annotations
 
 import sqlite3
+from pathlib import Path
 
 import pytest
 
@@ -195,9 +196,45 @@ def test_resolve_db_path_honours_env_override(monkeypatch: pytest.MonkeyPatch) -
     assert str(db.resolve_db_path()) == "/tmp/custom-cto.db"
 
 
-def test_resolve_db_path_defaults_to_fixture(monkeypatch: pytest.MonkeyPatch) -> None:
+# #4860: the fixture must never be the silent default — an unconfigured skill
+# refuses rather than answering a headcount question from invented sample data.
+def test_resolve_db_path_refuses_when_unconfigured(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv(db.ENV_CTO_DB_PATH, raising=False)
+    monkeypatch.delenv(db.ENV_CTO_DB_USE_FIXTURE, raising=False)
+    with pytest.raises(db.UnconfiguredDatabaseError) as excinfo:
+        db.resolve_db_path()
+    message = str(excinfo.value)
+    assert db.ENV_CTO_DB_PATH in message
+    assert db.ENV_CTO_DB_USE_FIXTURE in message
+
+
+def test_resolve_db_path_serves_fixture_only_on_explicit_opt_in(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(db.ENV_CTO_DB_PATH, raising=False)
+    monkeypatch.setenv(db.ENV_CTO_DB_USE_FIXTURE, "1")
     assert db.resolve_db_path() == db.DEFAULT_FIXTURE_DB_PATH
+
+
+@pytest.mark.parametrize("value", ["", "0", "false", "no", "off", "  FALSE  "])
+def test_fixture_opt_in_rejects_falsey_values(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    monkeypatch.delenv(db.ENV_CTO_DB_PATH, raising=False)
+    monkeypatch.setenv(db.ENV_CTO_DB_USE_FIXTURE, value)
+    with pytest.raises(db.UnconfiguredDatabaseError):
+        db.resolve_db_path()
+
+
+def test_real_path_wins_over_the_fixture_opt_in(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(db.ENV_CTO_DB_PATH, "/tmp/custom-cto.db")
+    monkeypatch.setenv(db.ENV_CTO_DB_USE_FIXTURE, "1")
+    assert str(db.resolve_db_path()) == "/tmp/custom-cto.db"
+
+
+def test_is_fixture_path_labels_the_bundled_fixture() -> None:
+    assert db.is_fixture_path(db.DEFAULT_FIXTURE_DB_PATH) is True
+    assert db.is_fixture_path(Path("/tmp/custom-cto.db")) is False
 
 
 def test_open_readonly_rejects_missing_file(tmp_path) -> None:

--- a/crates/trusty-agents/changelog.d/wave-b-4844-changed.md
+++ b/crates/trusty-agents/changelog.d/wave-b-4844-changed.md
@@ -1,0 +1,6 @@
+Changed
+
+- The bundled flat `cto-assistant.toml` no longer declares the
+  `gworkspace-calendar` skill
+  ([#4844](https://github.com/bobmatnyc/trusty-tools/issues/4844)). No such
+  skill file exists on disk, so the declaration never resolved.

--- a/crates/trusty-agents/changelog.d/wave-b-4860-3835-4611.md
+++ b/crates/trusty-agents/changelog.d/wave-b-4860-3835-4611.md
@@ -1,0 +1,20 @@
+Fixed
+
+- The `cto-db` skill refuses to answer when no database is configured, instead
+  of quietly querying its bundled fixture
+  ([#4860](https://github.com/bobmatnyc/trusty-tools/issues/4860)). With
+  `CTO_DB_PATH` unset, `resolve_db_path()` returned `DEFAULT_FIXTURE_DB_PATH`
+  and the four tools answered a headcount question with five invented names
+  while the real database held 421 — a well-formed answer the caller could not
+  tell from a real one. The fixture now needs `CTO_DB_USE_FIXTURE` to opt in;
+  with neither variable set, `cli.py` prints a JSON error naming both and exits
+  1. Every successful response also carries `db_path` and `is_fixture`, so
+  fixture output stays identifiable downstream.
+- `run_pm_task_with_history`'s tool-armed delegation call reads
+  `[llm].persona_max_turns` instead of a hardcoded `max_turns = 4`
+  ([#3835](https://github.com/bobmatnyc/trusty-tools/issues/3835)). This is the
+  literal #3806 already replaced on the persona path, left behind on the path
+  that backs Slack, Telegram and the API — a request needing two sequential
+  tool calls plus a summary exhausted the budget and failed with
+  `chat_with_tools exceeded max_turns`. The default is now 8, and an operator
+  can retune it per agent without a rebuild.

--- a/crates/trusty-agents/src/agents/params.rs
+++ b/crates/trusty-agents/src/agents/params.rs
@@ -294,10 +294,12 @@ pub struct LlmParams {
     /// routinely exhausted the 4-turn budget and failed with
     /// `chat_with_tools exceeded max_turns`. This field lets an operator raise
     /// the tool-using-persona ceiling per agent without a rebuild.
-    /// What: Only consulted by `dispatch::persona::persona_max_turns` for the
+    /// What: Consulted by `dispatch::persona_gate::persona_max_turns` for the
     /// tool-using branch; the no-tools branch is unaffected (stays 2). When
     /// `None` (default), that branch uses 8 turns — raised from the prior
-    /// hardcoded 4.
+    /// hardcoded 4. #3835: `dispatch::history::delegation_max_turns` reads it
+    /// through the same function for the ctrl/Slack/Telegram/API delegation
+    /// turn, which carried its own hardcoded 4 until then.
     /// Test: `llm_params_persona_max_turns_defaults_to_none`,
     /// `llm_params_persona_max_turns_parses_override` (`tests.rs`);
     /// `persona_max_turns_with_tools_defaults_to_eight`,

--- a/crates/trusty-agents/src/assistants/tests/home_tests.rs
+++ b/crates/trusty-agents/src/assistants/tests/home_tests.rs
@@ -106,7 +106,11 @@ fn two_instances_get_separate_homes() {
     assert_eq!(cto.okg_dir(), root.join("cto-assistant").join(OKG_DIR));
 }
 
+// #4611: `EnvVarGuard`'s own safety comment assumes this serialization. A
+// sibling clearing `ASSISTANTS_DIR_ENV` mid-body sent `for_instance` to the
+// real `$HOME` root — 5 failures in 40 parallel runs before this line.
 #[test]
+#[serial]
 fn for_instance_validates_the_id() {
     let tmp = tempfile::tempdir().unwrap();
     let _guard = EnvVarGuard::set(ASSISTANTS_DIR_ENV, tmp.path());

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/history.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/history.rs
@@ -544,7 +544,9 @@ pub async fn run_pm_task_with_history(
         allowed_tools,
         pm_cfg.llm.temperature,
         pm_cfg.llm.max_tokens,
-        4,
+        // #3835: was a hardcoded `4` — the literal #3806 already replaced on
+        // the persona path.
+        delegation_max_turns(&pm_cfg.llm),
         false,
         None,
         false,
@@ -646,6 +648,24 @@ fn ctrl_delegate_posture(
         .map(|s| s.to_string())
         .collect();
     (Some(taint), Some(roles), declared_tier)
+}
+
+/// Effective `max_turns` ceiling for `run_pm_task_with_history`'s tool-armed
+/// delegation call.
+///
+/// Why: #3835 — this call site hardcoded `4`, the same literal #3806 replaced
+/// on the persona path after a turn doing two sequential tool calls plus a
+/// summary exhausted the budget and failed with `chat_with_tools exceeded
+/// max_turns`. This path backs Slack/Telegram/API delegation, where multi-tool
+/// asks are routine, so it reads the same config field rather than its own
+/// literal.
+/// What: Defers to `persona_gate::persona_max_turns` with `has_tools = true` —
+/// the registry at this call site is always tool-armed. Honours
+/// `[llm].persona_max_turns` when declared, else 8.
+/// Test: `delegation_max_turns_defaults_to_eight_not_four`,
+/// `delegation_max_turns_honors_config_override`.
+fn delegation_max_turns(llm: &crate::agents::LlmParams) -> u32 {
+    super::persona_gate::persona_max_turns(true, llm)
 }
 
 /// Compute `chat_with_tools_gated`'s `allowed_tools` argument from an

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/history_tests.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/history_tests.rs
@@ -360,3 +360,52 @@ fn ctrl_delegate_posture_assistant_role_always_gates_target_roles() {
         "controller must NOT be a directly delegatable role, got: {roles:?}"
     );
 }
+
+// --- #3835: the tool-armed delegation turn budget ------------------------
+
+/// Builds a minimal parsed `LlmParams`, optionally declaring
+/// `persona_max_turns`, for the `delegation_max_turns` tests below.
+fn llm_params(persona_max_turns: Option<u32>) -> crate::agents::LlmParams {
+    let override_line = persona_max_turns
+        .map(|v| format!("persona_max_turns = {v}"))
+        .unwrap_or_default();
+    let toml_str = format!(
+        r#"
+[agent]
+name = "ctrl"
+role = "controller"
+model = "x"
+description = "x"
+
+[llm]
+temperature = 0.0
+max_tokens = 1024
+{override_line}
+
+[system_prompt]
+content = "base"
+"#
+    );
+    let cfg: crate::agents::AgentConfig = toml::from_str(&toml_str).expect("parses");
+    cfg.llm
+}
+
+/// #3835: the delegation call site hardcoded `4`, so a Slack/Telegram ask
+/// needing two sequential tool calls plus a summary died on
+/// `chat_with_tools exceeded max_turns`. It now inherits the same budget
+/// #3806 gave the persona path.
+#[test]
+fn delegation_max_turns_defaults_to_eight_not_four() {
+    let llm = llm_params(None);
+    let turns = super::delegation_max_turns(&llm);
+    assert_ne!(turns, 4, "the pre-#3835 hardcoded ceiling must be gone");
+    assert_eq!(turns, 8);
+}
+
+/// An operator can retune the ceiling via `[llm].persona_max_turns` without a
+/// rebuild — the whole point of sourcing it from config.
+#[test]
+fn delegation_max_turns_honors_config_override() {
+    assert_eq!(super::delegation_max_turns(&llm_params(Some(12))), 12);
+    assert_eq!(super::delegation_max_turns(&llm_params(Some(3))), 3);
+}

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona_gate.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona_gate.rs
@@ -184,6 +184,9 @@ pub(super) const DEFAULT_PERSONA_TOOL_MAX_TURNS: u32 = 8;
 /// Test: `persona_max_turns_no_tools_is_two`,
 /// `persona_max_turns_with_tools_defaults_to_eight`,
 /// `persona_max_turns_with_tools_honors_config_override`.
+///
+/// #3835: `history::delegation_max_turns` is the second caller — the
+/// ctrl/Slack/Telegram/API delegation turn, always `has_tools = true`.
 pub(super) fn persona_max_turns(has_tools: bool, llm: &crate::agents::LlmParams) -> u32 {
     if !has_tools {
         return 2;

--- a/crates/trusty-agents/src/tools/python_skill.rs
+++ b/crates/trusty-agents/src/tools/python_skill.rs
@@ -36,10 +36,12 @@
 //!       is the pre-existing behaviour, not a crash).
 //! Test: `manifest_parses_cto_db_shape`, `build_plugin_reads_four_tools`,
 //!       `execute_dispatches_to_python_and_parses_json` (spawns the real
-//!       `cto-db` skill's `uv run` command against its bundled fixture DB;
-//!       skipped with a loud stderr note if `uv` is not on `PATH`, matching
-//!       this workspace's fail-open convention for optional external
-//!       tooling), `execute_maps_python_error_key_to_recoverable_result`,
+//!       `cto-db` skill's `uv run` command against its bundled fixture DB,
+//!       opted into via `CtoDbEnvGuard` since #4860; skipped with a loud
+//!       stderr note if `uv` is not on `PATH`, matching this workspace's
+//!       fail-open convention for optional external tooling),
+//!       `execute_without_a_configured_db_surfaces_the_refusal`,
+//!       `execute_maps_python_error_key_to_recoverable_result`,
 //!       `install_discovered_skill_plugins_is_noop_on_missing_dir`.
 
 use std::path::{Path, PathBuf};
@@ -370,11 +372,77 @@ mod tests {
     /// use. Plain `HOME_LOCK` rather than `test_env::lock_home()` because these
     /// tests exercise no production path guarded by
     /// `home_lock_held_by_this_thread` (only `listeners::store::events_dir` is).
-    /// Test: [`execute_dispatches_to_python_and_parses_json`] and
-    /// [`execute_maps_python_error_key_to_recoverable_result`] — the two tests
+    /// Test: [`execute_dispatches_to_python_and_parses_json`],
+    /// [`execute_maps_python_error_key_to_recoverable_result`], and
+    /// [`execute_without_a_configured_db_surfaces_the_refusal`] — the tests
     /// that spawn `uv`. [`execute_reports_spawn_failure_as_recoverable`]
     /// deliberately does not: it spawns a nonexistent binary and never reads
     /// `HOME`.
+    const CTO_DB_PATH_ENV: &str = "CTO_DB_PATH";
+    const CTO_DB_USE_FIXTURE_ENV: &str = "CTO_DB_USE_FIXTURE";
+
+    /// Pin the cto-db skill's data source for one test body (#4860).
+    ///
+    /// Why: the skill refuses to answer unless a database is configured, so a
+    /// test wanting the bundled fixture must opt in by name, and a test proving
+    /// the refusal must ensure neither variable is set. A developer's real
+    /// `CTO_DB_PATH` is dropped either way so the suite never queries it.
+    /// What: RAII over both variables, restoring their prior values on drop.
+    /// Every caller also holds [`hold_home_for_uv`]'s `HOME_LOCK`, the mutex
+    /// this crate's env-mutating tests serialize on.
+    /// Test: used by [`execute_dispatches_to_python_and_parses_json`],
+    /// [`execute_maps_python_error_key_to_recoverable_result`], and
+    /// [`execute_without_a_configured_db_surfaces_the_refusal`].
+    struct CtoDbEnvGuard {
+        prev_path: Option<String>,
+        prev_fixture: Option<String>,
+    }
+
+    impl CtoDbEnvGuard {
+        fn new(use_fixture: bool) -> Self {
+            let guard = Self {
+                prev_path: std::env::var(CTO_DB_PATH_ENV).ok(),
+                prev_fixture: std::env::var(CTO_DB_USE_FIXTURE_ENV).ok(),
+            };
+            // SAFETY: serialized by the caller's `HOME_LOCK` guard, the same
+            // convention this module's `$HOME` mutation already relies on.
+            unsafe {
+                std::env::remove_var(CTO_DB_PATH_ENV);
+                if use_fixture {
+                    std::env::set_var(CTO_DB_USE_FIXTURE_ENV, "1");
+                } else {
+                    std::env::remove_var(CTO_DB_USE_FIXTURE_ENV);
+                }
+            }
+            guard
+        }
+
+        fn fixture() -> Self {
+            Self::new(true)
+        }
+
+        fn unconfigured() -> Self {
+            Self::new(false)
+        }
+    }
+
+    impl Drop for CtoDbEnvGuard {
+        fn drop(&mut self) {
+            // SAFETY: as above.
+            unsafe {
+                for (key, prev) in [
+                    (CTO_DB_PATH_ENV, self.prev_path.take()),
+                    (CTO_DB_USE_FIXTURE_ENV, self.prev_fixture.take()),
+                ] {
+                    match prev {
+                        Some(v) => std::env::set_var(key, v),
+                        None => std::env::remove_var(key),
+                    }
+                }
+            }
+        }
+    }
+
     fn hold_home_for_uv() -> std::sync::MutexGuard<'static, ()> {
         crate::test_env::HOME_LOCK
             .lock()
@@ -444,6 +512,8 @@ mod tests {
         }
         // #4414: pin $HOME for the whole body — see `hold_home_for_uv`.
         let _home = hold_home_for_uv();
+        // #4860: the fixture is opt-in now, so ask for it by name.
+        let _db = CtoDbEnvGuard::fixture();
         let plugin = build_plugin(&cto_db_skill_dir()).expect("plugin should build");
         let tool = plugin
             .tools
@@ -460,6 +530,53 @@ mod tests {
         let parsed: Value = serde_json::from_str(result.content()).expect("content must be JSON");
         assert_eq!(parsed["filter_by"], "team");
         assert!(parsed["groups"].as_array().is_some_and(|g| !g.is_empty()));
+        // #4860: fixture output must be labelled, not indistinguishable from a
+        // real answer.
+        assert_eq!(parsed["is_fixture"], true);
+        assert!(
+            parsed["db_path"]
+                .as_str()
+                .is_some_and(|p| p.ends_with("cto_fixture.db"))
+        );
+    }
+
+    /// #4860: with no database configured the bridge must surface a refusal,
+    /// not five invented names presented as a real headcount.
+    #[allow(
+        clippy::await_holding_lock,
+        reason = "#4414: holding HOME_LOCK across the uv subprocess IS the fix"
+    )]
+    #[tokio::test]
+    async fn execute_without_a_configured_db_surfaces_the_refusal() {
+        if !uv_available() {
+            eprintln!("SKIP: `uv` not on PATH — cannot exercise the real cto-db skill subprocess");
+            return;
+        }
+        let _home = hold_home_for_uv();
+        let _db = CtoDbEnvGuard::unconfigured();
+        let plugin = build_plugin(&cto_db_skill_dir()).expect("plugin should build");
+        let tool = plugin
+            .tools
+            .iter()
+            .find(|t| t.name() == "query_headcount")
+            .expect("query_headcount present");
+
+        let result = tool.execute(json!({ "filter_by": "team" })).await;
+        assert!(result.is_error(), "an unconfigured skill must not answer");
+        assert!(
+            !result.is_fatal(),
+            "python skill errors must be recoverable"
+        );
+        assert!(
+            result.content().contains("CTO_DB_PATH"),
+            "the refusal must name the variable that fixes it, got: {}",
+            result.content()
+        );
+        assert!(
+            !result.content().contains("groups"),
+            "no fixture rows may leak into the refusal, got: {}",
+            result.content()
+        );
     }
 
     // #4414: holds the guard across `.await` deliberately — the whole point is
@@ -478,6 +595,9 @@ mod tests {
         }
         // #4414: pin $HOME for the whole body — see `hold_home_for_uv`.
         let _home = hold_home_for_uv();
+        // #4860: opt into the fixture so this reaches the unknown-filter path
+        // rather than stopping at the unconfigured-database refusal.
+        let _db = CtoDbEnvGuard::fixture();
         let plugin = build_plugin(&cto_db_skill_dir()).expect("plugin should build");
         let tool = plugin
             .tools


### PR DESCRIPTION
Refs #4860, Refs #3835, Refs #4611, Refs #4844

- cto-db refuses instead of silently serving the fixture (opt-in via CTO_DB_USE_FIXTURE)
- delegation max_turns defers to persona_max_turns policy (default 8, config-overridable) instead of a hardcoded 4
- #[serial] on for_instance_validates_the_id (5/40 parallel failures pre-fix, 0/40 post)
- gworkspace-calendar declaration dropped from cto-assistant flat TOML per owner ruling

Test rung 3: cargo test -p trusty-agents --no-fail-fast
- 14 targets, lib 3569 passed, 0 failed; Python suite 39 passed
- Per-issue pre-fix failure proof shown in the work record

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools