### PR TITLE
feat(trusty-agents): bundled-template provider policy comes from configuration

### DIFF
--- a/crates/trusty-agents/assets/config/default-config.toml
+++ b/crates/trusty-agents/assets/config/default-config.toml
@@ -1,6 +1,25 @@
 # trusty-agents global configuration
 # ~/.trusty-agents/config.toml
 
+# Issue #3766: which inference provider serves the bundled agent templates.
+#
+# Every bundled template ships a bare model slug (e.g. `claude-sonnet-4-6`)
+# and no `[agent].provider_id`. Left unset, such a template runs on whichever
+# ambient credential is found first, so the same template can land on a
+# different provider on two machines. Set this key to decide it once, here.
+#
+# Applies ONLY to agents that declare neither `[agent].provider_id` nor a
+# provider in their model slug — an explicit pin and a provider-named template
+# (`bedrock/…`, `openai/…`) both win over this default.
+#
+# Accepted values: openrouter, anthropic, bedrock, fireworks, atlascloud,
+# local. The provider must have a working credential or agent loads fail with
+# a message naming the missing environment variable — this never falls back
+# silently. Unset (the default, below) keeps the ambient behaviour unchanged.
+#
+# [providers]
+# default_provider_id = "anthropic"
+
 [mcp]
 # Agent roles that receive MCP tool descriptions in their system prompt
 inject_for_roles = ["ctrl", "pm", "research", "observe"]

--- a/crates/trusty-agents/changelog.d/3766-provider-policy-config.md
+++ b/crates/trusty-agents/changelog.d/3766-provider-policy-config.md
@@ -16,3 +16,5 @@ Added
   message naming the config key — and it lives in the operator config rather
   than in the template files, so refreshing a bundled template cannot revert
   it. Leaving the key unset keeps the previous ambient behaviour exactly.
+  `[providers]` is a typed section of `GlobalConfig`, so `/local on|off` and
+  the `mcp_*` tools preserve it when they rewrite the file.

--- a/crates/trusty-agents/changelog.d/3766-provider-policy-config.md
+++ b/crates/trusty-agents/changelog.d/3766-provider-policy-config.md
@@ -1,0 +1,18 @@
+Added
+
+- `[providers] default_provider_id` in `~/.trusty-agents/config.toml` decides
+  which inference provider serves the bundled agent templates
+  ([#3766](https://github.com/bobmatnyc/trusty-tools/issues/3766)). Seven
+  bundled templates ship a bare model slug (`claude-sonnet-4-6`) and no
+  `[agent].provider_id`, so until now the provider was whichever ambient
+  credential the harness found first — the same template ran on
+  Anthropic-direct on one machine and OpenRouter on the next, and could change
+  provider when an unrelated environment variable appeared. Set the key once
+  and every such template resolves that provider deterministically.
+  The setting applies only to agents that declare neither a pin nor a provider
+  in their model slug: an explicit `[agent].provider_id` and a provider-named
+  template (`bedrock/…`, `openai/…`) both win over it. It fails closed like a
+  pin — a provider with no resolvable credential aborts the agent load with a
+  message naming the config key — and it lives in the operator config rather
+  than in the template files, so refreshing a bundled template cannot revert
+  it. Leaving the key unset keeps the previous ambient behaviour exactly.

--- a/crates/trusty-agents/src/agents/loader.rs
+++ b/crates/trusty-agents/src/agents/loader.rs
@@ -324,13 +324,84 @@ impl AgentConfig {
     /// other provider can no longer be hijacked by an ambient
     /// `ANTHROPIC_API_KEY`, and a pin TO Anthropic no longer depends on one
     /// being noticed.
+    ///
+    /// #3766 added one step in front: an agent that declares NEITHER a pin nor
+    /// a provider in its model slug adopts the operator's configured default
+    /// ([`crate::llm::provider_policy`]) as its `provider_id` before any of the
+    /// above runs. With no policy configured that step is a no-op and this
+    /// function behaves exactly as it did.
     /// Test: `agent_config_honours_a_provider_pin`,
     /// `agent_config_pin_beats_the_model_slug_prefix`,
     /// `agent_config_without_a_pin_is_unchanged`,
-    /// `agent_config_rejects_a_pin_with_no_credential`.
+    /// `agent_config_rejects_a_pin_with_no_credential`; and, for the policy
+    /// step, `agents::tests::provider_policy`.
     pub(crate) fn apply_provider_pin(&mut self) -> Result<()> {
-        let Some(pin) =
-            crate::llm::provider_pin::resolve(&self.agent.name, self.agent.provider_id.as_deref())?
+        // #3766: read the operator config only for an agent the policy could
+        // govern, so a pinned or provider-named agent costs no file I/O.
+        let policy = if crate::llm::provider_policy::applies_to(
+            self.agent.provider_id.as_deref(),
+            &self.agent.model,
+        ) {
+            crate::llm::provider_policy::configured_default()
+        } else {
+            None
+        };
+        self.apply_provider_pin_with_policy(policy.as_deref())
+    }
+
+    /// [`Self::apply_provider_pin`] against an explicitly supplied policy
+    /// (#3766) — the injectable half, so the policy's effect is testable
+    /// without mutating the process-global `$HOME`.
+    ///
+    /// Why: adopting the policy as this config's `provider_id` — rather than
+    /// carrying it as a second, parallel notion of "which provider" — is what
+    /// makes every #3765 consumer honour it for free: the slug rewrite here,
+    /// the ambient-routing skip in `ctrl::config::apply_credential_routing`,
+    /// and the re-pin on a post-load model override. A parallel field would
+    /// have to be threaded through each of those, and the first one missed
+    /// would be a silent ambient fallback — the exact defect being fixed.
+    /// What: when `policy` names a provider and
+    /// [`crate::llm::provider_policy::applies_to`] says this agent is
+    /// unpinned and provider-agnostic, writes it into `agent.provider_id`;
+    /// then runs the ordinary pin path. A policy naming an unusable provider
+    /// fails the load closed like any pin, with context naming the config key
+    /// so the operator knows which of the two sources to fix. Nothing is
+    /// written back to the agent's TOML — the policy is applied in memory on
+    /// every load, which is why a bundled-template reprovision cannot regress
+    /// it.
+    /// Test: `agents::tests::provider_policy`.
+    pub(crate) fn apply_provider_pin_with_policy(&mut self, policy: Option<&str>) -> Result<()> {
+        let mut from_policy = false;
+        if let Some(configured) = policy.map(str::trim).filter(|v| !v.is_empty())
+            && crate::llm::provider_policy::applies_to(
+                self.agent.provider_id.as_deref(),
+                &self.agent.model,
+            )
+        {
+            tracing::debug!(
+                agent = %self.agent.name,
+                provider = %configured,
+                "adopting the configured default provider for an unpinned agent"
+            );
+            self.agent.provider_id = Some(configured.to_string());
+            from_policy = true;
+        }
+
+        let resolved =
+            crate::llm::provider_pin::resolve(&self.agent.name, self.agent.provider_id.as_deref());
+        let Some(pin) = resolved.map_err(|e| {
+            if from_policy {
+                anyhow::Error::new(e).context(format!(
+                    "[{}] {} in ~/.trusty-agents/config.toml selected this provider for \
+                     unpinned agent '{}'; change that key or pin the agent explicitly",
+                    crate::llm::provider_policy::CONFIG_TABLE,
+                    crate::llm::provider_policy::CONFIG_KEY,
+                    self.agent.name
+                ))
+            } else {
+                anyhow::Error::new(e)
+            }
+        })?
         else {
             return Ok(());
         };

--- a/crates/trusty-agents/src/agents/tests/mod.rs
+++ b/crates/trusty-agents/src/agents/tests/mod.rs
@@ -9,6 +9,8 @@
 
 pub(crate) mod loading;
 mod params;
+// #3766: the configured bundled-template provider policy, end to end.
+mod provider_policy;
 
 use crate::agents::{AgentConfig, AgentInfo, ToolsConfig};
 

--- a/crates/trusty-agents/src/agents/tests/provider_policy.rs
+++ b/crates/trusty-agents/src/agents/tests/provider_policy.rs
@@ -1,0 +1,409 @@
+//! End-to-end coverage for the configured bundled-template provider policy
+//! (#3766).
+//!
+//! Why: `llm::provider_policy`'s own tests pin the predicate and the config
+//! parse. What they cannot show is the property the ticket is actually about —
+//! that a bundled template's provider stops depending on the ambient
+//! environment, covers EVERY unpinned template rather than a hand-picked few,
+//! survives a template reprovision, and changes nothing at all while the
+//! policy is unset. Each test below asserts one of those, and each carries its
+//! own control: the `policy = None` arm IS the pre-#3766 code path, so a test
+//! that shows `None` behaving differently from `Some(provider)` is
+//! demonstrating the defect and the fix in one run.
+//! What: drives `AgentConfig::apply_provider_pin_with_policy` over the real
+//! bundled templates read from this crate's `.trusty-agents/agents/` tree —
+//! the same bytes `agents::bundled` embeds — rather than over fixtures, so a
+//! template added later is covered automatically.
+//! Test: this module IS the test surface.
+
+use std::path::{Path, PathBuf};
+
+use crate::agents::AgentConfig;
+
+/// The policy provider these tests configure.
+///
+/// Why: Bedrock's `credential_name()` is `None`, so pinning to it needs no
+/// API key present. Every other pinnable provider would make these tests pass
+/// or fail on whether the developer's shell happens to export a key.
+const TEST_POLICY: &str = "bedrock";
+
+/// The bundled templates #3766 names as resolving their provider ambiently.
+///
+/// Why: acceptance criterion 4 is that the mechanism covers ALL of them, not a
+/// subset. Listing them here means dropping one from the covered set fails a
+/// test rather than passing quietly.
+const CITED_UNPINNED_TEMPLATES: [&str; 7] = [
+    "assistant/agent.toml",
+    "izzie/agent.toml",
+    "izzie.toml",
+    "personal-assistant.toml",
+    "ctrl.toml",
+    "ctrl/agent.toml",
+    "cto-assistant/agent.toml",
+];
+
+/// This crate's bundled agent-template directory.
+fn templates_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join(".trusty-agents")
+        .join("agents")
+}
+
+/// Every bundled template as `(path relative to the agents dir, TOML body)`.
+///
+/// Why: reading the tree rather than naming files keeps the sweep tests honest
+/// as the roster changes.
+/// What: flat `<name>.toml` plus one level of directory packages
+/// (`<name>/agent.toml`), skipping `.bak` archives.
+fn bundled_templates() -> Vec<(String, String)> {
+    fn collect(dir: &Path, prefix: &str, out: &mut Vec<(String, String)>) {
+        let entries = std::fs::read_dir(dir).expect("read the bundled agents dir");
+        for entry in entries {
+            let entry = entry.expect("dir entry");
+            let path = entry.path();
+            let name = entry.file_name().to_string_lossy().to_string();
+            if path.is_dir() {
+                collect(&path, &format!("{prefix}{name}/"), out);
+            } else if name.ends_with(".toml") && !name.contains(".bak") {
+                let body = std::fs::read_to_string(&path).expect("read template");
+                out.push((format!("{prefix}{name}"), body));
+            }
+        }
+    }
+
+    let mut out = Vec::new();
+    collect(&templates_dir(), "", &mut out);
+    out.sort();
+    assert!(
+        out.len() >= CITED_UNPINNED_TEMPLATES.len(),
+        "expected the bundled roster to be non-trivial, found {}",
+        out.len()
+    );
+    out
+}
+
+/// Parse `body` into an `AgentConfig` without running the loader's ambient
+/// steps.
+///
+/// Why: `AgentConfig::load` resolves `TAGENT_MODEL_*` overrides and reads the
+/// operator config from the real `$HOME`, either of which would make these
+/// assertions depend on the developer's environment. Parsing directly leaves
+/// `[agent].model` exactly as the template declares it, which is what the
+/// byte-level comparisons below need.
+/// What: parses to a `toml::Value` and fills in `system_prompt.content` only
+/// when the template omits it — the directory-package form
+/// (`assistant/agent.toml`, `ctrl/agent.toml`) keeps its prompt in a sibling
+/// file. `[agent]` and `[llm]` are never touched, so every field under test
+/// stays byte-exact.
+fn parse_template(rel: &str, body: &str) -> AgentConfig {
+    let mut value: toml::Value = body
+        .parse()
+        .unwrap_or_else(|e| panic!("parse bundled template {rel}: {e}"));
+    let table = value
+        .as_table_mut()
+        .unwrap_or_else(|| panic!("{rel} is not a TOML table"));
+    let prompt = table
+        .entry("system_prompt")
+        .or_insert_with(|| toml::Value::Table(toml::map::Map::new()));
+    if let Some(prompt) = prompt.as_table_mut()
+        && !prompt.contains_key("content")
+    {
+        prompt.insert(
+            "content".to_string(),
+            toml::Value::String("placeholder".to_string()),
+        );
+    }
+    value
+        .try_into()
+        .unwrap_or_else(|e| panic!("deserialize bundled template {rel}: {e}"))
+}
+
+/// Acceptance criterion 5 — with no policy configured, loading a bundled
+/// template resolves exactly what it resolved before #3766.
+///
+/// Why: the feature is only safe to ship if "unset" is a true no-op. This is
+/// the byte-level form of that claim: `apply_provider_pin_with_policy` writes
+/// exactly three fields (`agent.model`, `agent.provider_id`,
+/// `llm.use_anthropic_direct`), so asserting all three are unchanged over
+/// every bundled template IS the assertion that nothing resolved differently.
+/// Test: itself.
+#[test]
+fn an_unset_policy_leaves_every_bundled_template_unchanged() {
+    for (rel, body) in bundled_templates() {
+        let mut cfg = parse_template(&rel, &body);
+        let model_before = cfg.agent.model.clone();
+        let provider_before = cfg.agent.provider_id.clone();
+        let direct_before = cfg.llm.use_anthropic_direct;
+
+        cfg.apply_provider_pin_with_policy(None)
+            .unwrap_or_else(|e| panic!("{rel} must load with no policy configured: {e:#}"));
+
+        assert_eq!(cfg.agent.model, model_before, "{rel}: model");
+        assert_eq!(cfg.agent.provider_id, provider_before, "{rel}: provider_id");
+        assert_eq!(
+            cfg.llm.use_anthropic_direct, direct_before,
+            "{rel}: use_anthropic_direct"
+        );
+    }
+}
+
+/// Acceptance criterion 4 — the policy reaches EVERY unpinned template, and
+/// only those.
+///
+/// Why: a mechanism that covered five of the seven cited templates would leave
+/// the other two resolving ambiently and look fixed. Sweeping the whole tree
+/// and asserting the cited seven are among the templates the policy moved is
+/// what makes a partial fix fail.
+/// What: for each template, `applies_to` decides the expectation — an unpinned
+/// template with a bare slug must come out carrying the policy provider's
+/// routing marker; a template that pins a provider or names one in its slug
+/// must come out untouched.
+/// Test: itself.
+#[test]
+fn the_policy_covers_every_unpinned_bundled_template() {
+    let mut moved = Vec::new();
+
+    for (rel, body) in bundled_templates() {
+        let mut cfg = parse_template(&rel, &body);
+        let model_before = cfg.agent.model.clone();
+        let governed = crate::llm::provider_policy::applies_to(
+            cfg.agent.provider_id.as_deref(),
+            &cfg.agent.model,
+        );
+
+        cfg.apply_provider_pin_with_policy(Some(TEST_POLICY))
+            .unwrap_or_else(|e| panic!("{rel} must load under the policy: {e:#}"));
+
+        if governed {
+            assert_eq!(
+                cfg.agent.model,
+                format!("{TEST_POLICY}/{model_before}"),
+                "{rel}: an unpinned template must adopt the configured provider"
+            );
+            assert_eq!(cfg.agent.provider_id.as_deref(), Some(TEST_POLICY), "{rel}");
+            moved.push(rel);
+        } else {
+            assert_eq!(
+                cfg.agent.model, model_before,
+                "{rel}: a template that names its own provider must be left alone"
+            );
+        }
+    }
+
+    for cited in CITED_UNPINNED_TEMPLATES {
+        assert!(
+            moved.iter().any(|m| m == cited),
+            "#3766 names {cited} as resolving its provider ambiently, but the policy \
+             did not reach it; covered: {moved:?}"
+        );
+    }
+}
+
+/// Acceptance criterion 3 — with the policy set, the SAME template resolves
+/// the SAME provider under different ambient credentials.
+///
+/// Why: this is the defect. The `None` arm below is the pre-#3766 path and it
+/// FAILS the equality this test demands — an ambient `ANTHROPIC_API_KEY`
+/// flips `use_anthropic_direct`, an ambient OpenRouter key rewrites the slug,
+/// and the template silently runs somewhere else. The `Some` arm shows the
+/// configured policy making both credential environments resolve identically,
+/// via the same `provider_id` skip `ctrl::config::apply_credential_routing`
+/// already had from #3765.
+/// What: routes `ctrl.toml` — one of the seven templates #3766 cites —
+/// through `apply_credential_routing` under `AnthropicDirect` and under
+/// `OpenRouter`, and compares the resulting `(model, use_anthropic_direct)`.
+/// Test: itself.
+#[test]
+fn a_configured_policy_survives_differing_ambient_credentials() {
+    use crate::llm::credentials::LlmCredentials;
+
+    let body = std::fs::read_to_string(templates_dir().join("ctrl.toml")).expect("read ctrl.toml");
+
+    let resolve = |policy: Option<&str>, creds: &LlmCredentials| {
+        let mut cfg = parse_template("ctrl.toml", &body);
+        cfg.apply_provider_pin_with_policy(policy)
+            .expect("ctrl.toml loads");
+        crate::ctrl::config::apply_credential_routing(&mut cfg, creds);
+        (cfg.agent.model.clone(), cfg.llm.use_anthropic_direct)
+    };
+
+    // Control — the pre-#3766 behaviour, still reachable with no policy set:
+    // the ambient credential decides, so the two environments disagree.
+    let ambient_anthropic = resolve(None, &LlmCredentials::AnthropicDirect);
+    let ambient_openrouter = resolve(None, &LlmCredentials::OpenRouter);
+    assert_ne!(
+        ambient_anthropic, ambient_openrouter,
+        "without a policy the ambient credential is expected to decide — if this ever \
+         holds, the test below has stopped proving anything"
+    );
+
+    let pinned_anthropic = resolve(Some(TEST_POLICY), &LlmCredentials::AnthropicDirect);
+    let pinned_openrouter = resolve(Some(TEST_POLICY), &LlmCredentials::OpenRouter);
+    assert_eq!(
+        pinned_anthropic, pinned_openrouter,
+        "the configured policy must decide, not the ambient credential"
+    );
+    assert_eq!(
+        pinned_anthropic.0,
+        format!("{TEST_POLICY}/claude-sonnet-4-6")
+    );
+    assert!(
+        !pinned_anthropic.1,
+        "use_anthropic_direct must follow the policy"
+    );
+}
+
+/// Acceptance criterion 1 — a bundled-template refresh cannot regress a
+/// policy-resolved provider.
+///
+/// Why: `agents::bundled` rewrites a deployed template whenever its bytes
+/// differ from the embedded bundle, and it never re-applies a live edit. Had
+/// #3766 been implemented by writing a provider into the template files, every
+/// reprovision would have silently reverted it. Keeping the policy in the
+/// operator config and applying it at LOAD is what makes this test pass, so
+/// this is the test that would fail an in-template implementation.
+/// What: deploys the bundle into a tempdir, records the policy-resolved
+/// provider for `ctrl.toml`, forces a genuine stamp-mismatch refresh (an
+/// on-disk edit plus a stale `.bundled-stamp`), and re-resolves.
+/// Test: itself.
+#[test]
+fn a_reprovision_cannot_regress_the_policy_resolved_provider() {
+    let target = tempfile::tempdir().expect("tempdir");
+    let target = target.path();
+    crate::agents::bundled::ensure_bundled_agents_deployed_in(target).expect("initial deploy");
+
+    let deployed = target.join("ctrl.toml");
+    let resolve = || {
+        let body = std::fs::read_to_string(&deployed).expect("read the deployed template");
+        let mut cfg = parse_template("ctrl.toml", &body);
+        cfg.apply_provider_pin_with_policy(Some(TEST_POLICY))
+            .expect("deployed ctrl.toml loads under the policy");
+        (cfg.agent.model.clone(), cfg.agent.provider_id.clone())
+    };
+
+    let before = resolve();
+    assert_eq!(before.1.as_deref(), Some(TEST_POLICY));
+
+    // A hand-edit plus a stale stamp is exactly the state
+    // `ensure_bundled_agents_deployed_in` refreshes from.
+    let edited = format!(
+        "{}\n# local edit\n",
+        std::fs::read_to_string(&deployed).expect("read deployed")
+    );
+    std::fs::write(&deployed, edited).expect("write the edited template");
+    std::fs::write(target.join(".bundled-stamp"), "stale-stamp").expect("write a stale stamp");
+
+    let report =
+        crate::agents::bundled::ensure_bundled_agents_deployed_in(target).expect("refresh pass");
+    assert!(
+        report.refreshed >= 1,
+        "the stale stamp must have driven a real refresh: {report:?}"
+    );
+
+    assert_eq!(
+        resolve(),
+        before,
+        "a template refresh must not change the policy-resolved provider"
+    );
+}
+
+/// Acceptance criterion 2 — no bundled template defaults to the
+/// unauthenticated local endpoint.
+///
+/// Why: `ollama/…` routes to an unauthenticated localhost server, so a
+/// template defaulting to it degrades silently to whatever model that host
+/// happens to serve — the failure mode #3556 already recorded for `ctrl`.
+/// Nothing about #3766 should reintroduce one, and the policy is the obvious
+/// place a `local` default could leak in.
+/// What: asserts no bundled template names the local provider, either in its
+/// model slug (`ollama/…`, `local/…`) or in an explicit `provider_id`.
+/// Test: itself.
+#[test]
+fn no_bundled_template_defaults_to_the_local_provider() {
+    use trusty_common::inference::registry::ProviderId;
+
+    for (rel, body) in bundled_templates() {
+        let cfg = parse_template(&rel, &body);
+        assert_ne!(
+            ProviderId::from_slug_prefix(&cfg.agent.model),
+            Some(ProviderId::Local),
+            "{rel}: model '{}' defaults to the unauthenticated local endpoint",
+            cfg.agent.model
+        );
+        if let Some(pin) = cfg.agent.provider_id.as_deref() {
+            assert_ne!(
+                trusty_common::inference::registry::capabilities_for(pin).map(|c| c.id),
+                Some(ProviderId::Local),
+                "{rel}: provider_id '{pin}' defaults to the unauthenticated local endpoint"
+            );
+        }
+    }
+}
+
+/// An explicit `[agent].provider_id` outranks the operator default.
+///
+/// Why: the policy is a DEFAULT. If it overwrote a pin, #3766 would have
+/// broken #3765 — an operator who pinned one agent to a specific provider
+/// would find it silently retargeted by a machine-wide setting.
+/// Test: itself.
+#[test]
+fn an_explicit_pin_outranks_the_configured_policy() {
+    let mut cfg = parse_template(
+        "<inline>",
+        r#"
+[agent]
+name = "pinned"
+role = "engineer"
+model = "claude-sonnet-4-6"
+description = "x"
+provider_id = "bedrock"
+
+[llm]
+temperature = 0.0
+max_tokens = 1024
+"#,
+    );
+
+    // A policy naming a DIFFERENT provider must not be adopted. `atlascloud`
+    // is used only as the policy value here — it is never resolved, because
+    // the explicit pin short-circuits the adoption step.
+    cfg.apply_provider_pin_with_policy(Some("atlascloud"))
+        .expect("an explicitly pinned agent loads");
+
+    assert_eq!(cfg.agent.provider_id.as_deref(), Some("bedrock"));
+    assert_eq!(cfg.agent.model, "bedrock/claude-sonnet-4-6");
+}
+
+/// A policy naming an unusable provider fails the load closed, naming the
+/// config key that set it.
+///
+/// Why: the whole point of routing the policy through
+/// `llm::provider_pin::resolve` is that it inherits #3765's fail-closed
+/// contract instead of falling back to an ambient credential. The operator
+/// then needs to know WHICH of the two sources to fix — the agent's TOML or
+/// their `config.toml` — which the raw pin error cannot tell them.
+/// Test: itself.
+#[test]
+fn an_unusable_policy_fails_closed_and_names_the_config_key() {
+    let mut cfg = parse_template(
+        "<inline>",
+        r#"
+[agent]
+name = "unpinned"
+role = "engineer"
+model = "claude-sonnet-4-6"
+description = "x"
+
+[llm]
+temperature = 0.0
+max_tokens = 1024
+"#,
+    );
+
+    let err = cfg
+        .apply_provider_pin_with_policy(Some("not-a-provider"))
+        .expect_err("an unknown provider must fail the load, not fall back");
+    let msg = format!("{err:#}");
+    assert!(msg.contains("default_provider_id"), "{msg}");
+    assert!(msg.contains("not-a-provider"), "{msg}");
+}

--- a/crates/trusty-agents/src/ctrl/config.rs
+++ b/crates/trusty-agents/src/ctrl/config.rs
@@ -106,10 +106,14 @@ pub(crate) fn resolve_overridden_credentials(
     if let (Some(pinned), Some(requested)) = (cfg.agent.provider_id.as_deref(), provider_override)
         && !pinned.eq_ignore_ascii_case(requested)
     {
+        // #3766: the pin may come from the agent's own TOML or from the
+        // operator's `[providers] default_provider_id`, so name both.
         anyhow::bail!(
-            "agent '{}' pins [agent].provider_id = '{}'; a session provider \
-             override to '{}' contradicts it and is refused. Change the pin in \
-             the agent's TOML, or clear it to allow per-session provider \
+            "agent '{}' is pinned to provider '{}'; a session provider \
+             override to '{}' contradicts it and is refused. Change \
+             [agent].provider_id in the agent's TOML — or, if the agent \
+             declares none, [providers].default_provider_id in \
+             ~/.trusty-agents/config.toml — to allow per-session provider \
              switching.",
             cfg.agent.name,
             pinned,
@@ -524,6 +528,9 @@ pub(crate) fn apply_credential_routing(
     // exactly the silent-fallback the pin exists to prevent — e.g. an agent
     // pinned to `atlascloud` would be flipped to Anthropic-direct merely
     // because an `ANTHROPIC_API_KEY` happens to be present.
+    // #3766: the loader also sets `provider_id` from `[providers]
+    // .default_provider_id` for an agent that declares no pin, so this same
+    // skip is what makes the configured policy survive ambient probing.
     if cfg.agent.provider_id.is_some() {
         tracing::debug!(
             agent = %cfg.agent.name,

--- a/crates/trusty-agents/src/llm/mod.rs
+++ b/crates/trusty-agents/src/llm/mod.rs
@@ -27,6 +27,7 @@ mod http;
 pub mod inference_bridge;
 pub mod inference_client;
 pub mod provider_pin;
+pub mod provider_policy;
 mod single_turn;
 pub mod stream;
 pub mod thinking_classifier;

--- a/crates/trusty-agents/src/llm/provider_policy.rs
+++ b/crates/trusty-agents/src/llm/provider_policy.rs
@@ -1,0 +1,233 @@
+//! Operator-configured default inference provider for unpinned agents (#3766).
+//!
+//! Why: every bundled agent template ships a BARE model slug
+//! (`model = "claude-sonnet-4-6"`, seven templates as of this change) and no
+//! `[agent].provider_id`. Which provider actually serves such a template was
+//! therefore decided by whichever ambient credential
+//! `llm::credentials::pick_credentials` happened to find, so the same template
+//! ran on Anthropic-direct on one machine and OpenRouter on the next, and the
+//! provider changed under a template when an unrelated environment variable
+//! appeared. The owner's ruling on #3766 is that this belongs in
+//! CONFIGURATION — one operator-settable policy the templates defer to — not
+//! hardcoded per template, which would have to be re-decided in seven files
+//! and re-applied after every reprovision.
+//! What: the `[providers] default_provider_id` key of the crate's existing
+//! operator config (`~/.trusty-agents/config.toml`). UNSET is the default and
+//! means "keep today's ambient behaviour, byte for byte". When set, it is
+//! adopted as the `provider_id` of every agent that declares neither a pin nor
+//! a provider in its model slug ([`applies_to`]), which routes it through the
+//! #3765 pin machinery — validation, slug rewrite, and the ambient-routing
+//! skip in `ctrl::config::apply_credential_routing` — rather than a second,
+//! parallel mechanism. The policy lives OUTSIDE the template files, so a
+//! bundled-template reprovision (`agents::bundled`) cannot regress it.
+//! Test: the `tests` module below, plus `agents::tests::provider_policy` for
+//! the end-to-end loader behaviour.
+
+use std::path::Path;
+
+use trusty_common::inference::registry::ProviderId;
+
+/// The `~/.trusty-agents/config.toml` table this policy is read from.
+pub const CONFIG_TABLE: &str = "providers";
+
+/// The key inside [`CONFIG_TABLE`] naming the default provider.
+pub const CONFIG_KEY: &str = "default_provider_id";
+
+/// Whether the operator's default-provider policy governs this agent.
+///
+/// Why: the policy is a DEFAULT, so it must lose to anything more specific.
+/// Two things are more specific: an explicit `[agent].provider_id` (the
+/// operator already answered this question for that agent, #3765) and a model
+/// slug that names its own provider (`bedrock/…`, `openai/…`, `ollama/…` —
+/// the provider-named templates, which exist precisely to pin a provider).
+/// Applying the policy to either would silently overrule a statement the
+/// config already makes, which is the same defect #3766 is fixing in the other
+/// direction.
+/// What: `true` only when `declared_provider_id` is absent or blank AND
+/// `model` carries no provider prefix [`ProviderId::from_slug_prefix`]
+/// recognises. Blank is treated as absent because that is what clearing the
+/// field in the GUI leaves behind (the reading
+/// [`crate::llm::provider_pin::resolve`] already uses).
+/// Test: `policy_governs_a_bare_slug_with_no_pin`,
+/// `policy_defers_to_an_explicit_pin`,
+/// `policy_defers_to_a_provider_named_slug`.
+pub fn applies_to(declared_provider_id: Option<&str>, model: &str) -> bool {
+    declared_provider_id
+        .map(str::trim)
+        .is_none_or(str::is_empty)
+        && ProviderId::from_slug_prefix(model).is_none()
+}
+
+/// Extract `[providers] default_provider_id` from an operator config body.
+///
+/// Why: the parse is separated from the file read so the policy's meaning can
+/// be tested without touching `$HOME` — a process-global mutation that would
+/// leak a policy into every other test loading an agent concurrently.
+/// What: returns the trimmed value, or `None` for an absent table, an absent
+/// key, a blank value, or a body that does not parse. Failing SOFT here is
+/// deliberate and is not a hole: an unreadable config yields "no policy", i.e.
+/// today's ambient behaviour, whereas a policy that IS read but names an
+/// unusable provider still fails closed at
+/// [`crate::llm::provider_pin::resolve`]. Unknown keys are ignored so this
+/// composes with the rest of `config.toml`, matching every other section
+/// loader in this crate.
+/// Test: `parse_reads_the_configured_provider`, `parse_ignores_other_tables`,
+/// `parse_treats_a_blank_value_as_unset`, `parse_tolerates_a_malformed_body`.
+pub fn parse(config_toml: &str) -> Option<String> {
+    #[derive(serde::Deserialize, Default)]
+    struct Providers {
+        #[serde(default)]
+        default_provider_id: Option<String>,
+    }
+    #[derive(serde::Deserialize, Default)]
+    struct Wrapper {
+        #[serde(default)]
+        providers: Providers,
+    }
+
+    toml::from_str::<Wrapper>(config_toml)
+        .ok()?
+        .providers
+        .default_provider_id
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+}
+
+/// Read the policy from `<home>/.trusty-agents/config.toml`.
+///
+/// Why: takes `home` as an argument rather than resolving it, so a test can
+/// point it at a tempdir without redirecting the process-global `$HOME` — the
+/// mutation `tests/home_lock_discipline.rs` exists to keep under one lock.
+/// What: reads the file and delegates to [`parse`]; a missing or unreadable
+/// file is `None`.
+/// Test: `read_from_home_finds_the_configured_provider`,
+/// `read_from_home_is_none_without_a_config_file`.
+pub fn read_from_home(home: &Path) -> Option<String> {
+    let path = home.join(".trusty-agents").join("config.toml");
+    let text = std::fs::read_to_string(path).ok()?;
+    parse(&text)
+}
+
+/// The policy in effect for this process, or `None` when unset.
+///
+/// Why: the single ambient entry point the agent loader calls. Kept a thin
+/// `$HOME`-resolving wrapper over [`read_from_home`] — the same shape
+/// `agents::bundled::ensure_bundled_agents_deployed` uses — so all the
+/// behaviour is in the hermetically testable half.
+/// Test: [`read_from_home`]'s tests cover the body; this wrapper is exercised
+/// by real `tagent` invocations.
+pub fn configured_default() -> Option<String> {
+    read_from_home(&dirs::home_dir()?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why: the case the policy exists for — a bundled template with a bare
+    /// `claude-*` slug and no pin.
+    /// Test: itself.
+    #[test]
+    fn policy_governs_a_bare_slug_with_no_pin() {
+        assert!(applies_to(None, "claude-sonnet-4-6"));
+        assert!(applies_to(Some(""), "claude-sonnet-4-6"));
+        assert!(applies_to(Some("  "), "claude-sonnet-4-6"));
+    }
+
+    /// Why: #3765's explicit per-agent pin is more specific than a default and
+    /// must win; the policy filling it in would silently retarget the agent.
+    /// Test: itself.
+    #[test]
+    fn policy_defers_to_an_explicit_pin() {
+        assert!(!applies_to(Some("atlascloud"), "claude-sonnet-4-6"));
+    }
+
+    /// Why: the provider-named templates (`bedrock-engineer`,
+    /// `gpt5-codex-engineer`, `gpt-engineer`) declare their provider IN the
+    /// slug. A policy that overwrote those would break the exact templates
+    /// whose whole purpose is to name a provider.
+    /// Test: itself.
+    #[test]
+    fn policy_defers_to_a_provider_named_slug() {
+        for model in [
+            "bedrock/us.anthropic.claude-3-5-haiku-20241022-v1:0",
+            "openai/gpt-5.1-codex",
+            "anthropic/claude-sonnet-4-6",
+            "ollama/qwen3:8b",
+            "atlascloud/openai/gpt-5.6-sol",
+        ] {
+            assert!(!applies_to(None, model), "{model}");
+        }
+    }
+
+    /// Why: the key is the operator's whole interface to this feature.
+    /// Test: itself.
+    #[test]
+    fn parse_reads_the_configured_provider() {
+        let body = format!("[{CONFIG_TABLE}]\n{CONFIG_KEY} = \"bedrock\"\n");
+        assert_eq!(parse(&body).as_deref(), Some("bedrock"));
+        assert_eq!(
+            parse("[providers]\ndefault_provider_id = \"  anthropic  \"\n").as_deref(),
+            Some("anthropic")
+        );
+    }
+
+    /// Why: `config.toml` is shared with `[mcp]`, `[okg]`, `[search]` and the
+    /// tool registry; reading it must not depend on what else is in it.
+    /// Test: itself.
+    #[test]
+    fn parse_ignores_other_tables() {
+        let body = "[mcp]\ninject_for_roles = [\"ctrl\"]\n\n\
+                    [providers]\ndefault_provider_id = \"bedrock\"\n\n\
+                    [search]\ncool_after_minutes = 15\n";
+        assert_eq!(parse(body).as_deref(), Some("bedrock"));
+        assert_eq!(parse("[mcp]\ninject_for_roles = []\n"), None);
+        assert_eq!(parse(""), None);
+    }
+
+    /// Why: clearing the field in an editor leaves `""`, which must read as
+    /// "unset" — not as a provider named the empty string, which would fail
+    /// every agent load.
+    /// Test: itself.
+    #[test]
+    fn parse_treats_a_blank_value_as_unset() {
+        assert_eq!(parse("[providers]\ndefault_provider_id = \"\"\n"), None);
+        assert_eq!(parse("[providers]\ndefault_provider_id = \"   \"\n"), None);
+        assert_eq!(parse("[providers]\n"), None);
+    }
+
+    /// Why: a half-edited `config.toml` must degrade to today's ambient
+    /// behaviour, never brick every agent load in the harness.
+    /// Test: itself.
+    #[test]
+    fn parse_tolerates_a_malformed_body() {
+        assert_eq!(parse("[providers\ndefault_provider_id = "), None);
+        assert_eq!(parse("[providers]\ndefault_provider_id = 7\n"), None);
+    }
+
+    /// Why: proves the documented path — `<home>/.trusty-agents/config.toml` —
+    /// is the file actually read.
+    /// Test: itself.
+    #[test]
+    fn read_from_home_finds_the_configured_provider() {
+        let home = tempfile::tempdir().expect("tempdir");
+        let dir = home.path().join(".trusty-agents");
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        std::fs::write(
+            dir.join("config.toml"),
+            "[providers]\ndefault_provider_id = \"bedrock\"\n",
+        )
+        .expect("write config");
+
+        assert_eq!(read_from_home(home.path()).as_deref(), Some("bedrock"));
+    }
+
+    /// Why: no config file is the state of every existing install, and it must
+    /// mean "unset", not an error.
+    /// Test: itself.
+    #[test]
+    fn read_from_home_is_none_without_a_config_file() {
+        let home = tempfile::tempdir().expect("tempdir");
+        assert_eq!(read_from_home(home.path()), None);
+    }
+}

--- a/crates/trusty-agents/src/llm/provider_policy.rs
+++ b/crates/trusty-agents/src/llm/provider_policy.rs
@@ -12,7 +12,10 @@
 //! hardcoded per template, which would have to be re-decided in seven files
 //! and re-applied after every reprovision.
 //! What: the `[providers] default_provider_id` key of the crate's existing
-//! operator config (`~/.trusty-agents/config.toml`). UNSET is the default and
+//! operator config (`~/.trusty-agents/config.toml`), modelled as a typed
+//! section on [`crate::mcp::GlobalConfig`] alongside `[mcp]`, `[git]` and the
+//! rest — never parsed independently, because `GlobalConfig::save()` drops
+//! whatever it does not declare. UNSET is the default and
 //! means "keep today's ambient behaviour, byte for byte". When set, it is
 //! adopted as the `provider_id` of every agent that declares neither a pin nor
 //! a provider in its model slug ([`applies_to`]), which routes it through the
@@ -60,32 +63,27 @@ pub fn applies_to(declared_provider_id: Option<&str>, model: &str) -> bool {
 
 /// Extract `[providers] default_provider_id` from an operator config body.
 ///
-/// Why: the parse is separated from the file read so the policy's meaning can
-/// be tested without touching `$HOME` — a process-global mutation that would
-/// leak a policy into every other test loading an agent concurrently.
+/// Why: reads through [`GlobalConfig`] — the crate's one modelled schema for
+/// this file — rather than a private struct of its own. A second parser would
+/// work for reading and silently lose the key on every write:
+/// `GlobalConfig::save()` re-serializes only its declared fields, so any
+/// unrelated mutator (`/local on`, `mcp_add`) would drop an unmodelled
+/// `[providers]` table from disk. Keeping the function itself pure over a
+/// string also lets the policy's meaning be tested without redirecting the
+/// process-global `$HOME`, which would leak a policy into every other test
+/// loading an agent concurrently.
 /// What: returns the trimmed value, or `None` for an absent table, an absent
-/// key, a blank value, or a body that does not parse. Failing SOFT here is
+/// key, a blank value, or a body that does not parse. Failing SOFT is
 /// deliberate and is not a hole: an unreadable config yields "no policy", i.e.
 /// today's ambient behaviour, whereas a policy that IS read but names an
 /// unusable provider still fails closed at
-/// [`crate::llm::provider_pin::resolve`]. Unknown keys are ignored so this
-/// composes with the rest of `config.toml`, matching every other section
-/// loader in this crate.
+/// [`crate::llm::provider_pin::resolve`].
 /// Test: `parse_reads_the_configured_provider`, `parse_ignores_other_tables`,
 /// `parse_treats_a_blank_value_as_unset`, `parse_tolerates_a_malformed_body`.
+///
+/// [`GlobalConfig`]: crate::mcp::GlobalConfig
 pub fn parse(config_toml: &str) -> Option<String> {
-    #[derive(serde::Deserialize, Default)]
-    struct Providers {
-        #[serde(default)]
-        default_provider_id: Option<String>,
-    }
-    #[derive(serde::Deserialize, Default)]
-    struct Wrapper {
-        #[serde(default)]
-        providers: Providers,
-    }
-
-    toml::from_str::<Wrapper>(config_toml)
+    crate::mcp::GlobalConfig::from_toml_str(config_toml)
         .ok()?
         .providers
         .default_provider_id

--- a/crates/trusty-agents/src/mcp/config/mod.rs
+++ b/crates/trusty-agents/src/mcp/config/mod.rs
@@ -38,7 +38,9 @@ use serde::{Deserialize, Serialize};
 
 use defaults::DEFAULT_CONFIG_TOML;
 
-pub use types::{GitConfig, LocalInferenceConfig, McpSection, McpService, McpTool};
+pub use types::{
+    GitConfig, LocalInferenceConfig, McpSection, McpService, McpTool, ProvidersSection,
+};
 
 /// Roots of the global config tree (`~/.trusty-agents/config.toml`).
 const CONFIG_DIR_NAME: &str = ".trusty-agents";
@@ -110,6 +112,21 @@ pub struct GlobalConfig {
     /// `crate::tools::registry::tests::builder_with_no_endpoints_returns_empty`.
     #[serde(default)]
     pub tool_registry: Option<crate::tools::registry::config::ToolRegistryConfig>,
+
+    /// `[providers]` section (#3766) — the default inference provider for
+    /// agents that declare no pin of their own.
+    ///
+    /// Why: this section MUST be modelled here, not parsed independently.
+    /// `save()` re-serializes only the fields declared on this struct, so a
+    /// `[providers]` table it does not know about is dropped from disk by any
+    /// unrelated write — `/local on` and the four `mcp_*` mutators all
+    /// load-mutate-save.
+    /// What: see [`ProvidersSection`]. Absent means unset, which is today's
+    /// ambient behaviour.
+    /// Test: `providers_section_survives_an_unrelated_save`,
+    /// `providers_section_defaults_to_unset`.
+    #[serde(default)]
+    pub providers: ProvidersSection,
 
     /// `[[listeners]]` — harness-level eventstream listener definitions
     /// (#3820, DOC-54 SPEC-AGENTS-06 §7.5), stage-one (ingestion) filter.

--- a/crates/trusty-agents/src/mcp/config/tests/mod.rs
+++ b/crates/trusty-agents/src/mcp/config/tests/mod.rs
@@ -243,6 +243,85 @@ async fn save_and_reload_roundtrip() {
     assert!(reloaded.mcp.services[0].enabled);
 }
 
+/// #3766: `[providers] default_provider_id` must survive a save driven by an
+/// unrelated setting.
+///
+/// Why: `save()` re-serializes only the fields declared on `GlobalConfig`, so
+/// a `[providers]` table parsed by some OTHER reader would be silently erased
+/// the next time anything wrote this file. That is not hypothetical — the
+/// ordinary `/local on` / `/local off` commands
+/// (`repl::commands::routing::handle_local_command_into`) and the four `mcp_*`
+/// mutators all load, mutate one field, and save. This test drives that exact
+/// sequence, so it fails if the section is ever demoted back out of the
+/// modelled schema.
+/// Test: itself.
+#[tokio::test]
+async fn providers_section_survives_an_unrelated_save() {
+    let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let home = tempdir();
+    unsafe {
+        std::env::set_var("HOME", &home);
+    }
+
+    // An operator sets the policy by hand.
+    let dir = home.join(".trusty-agents");
+    std::fs::create_dir_all(&dir).expect("create config dir");
+    std::fs::write(
+        dir.join("config.toml"),
+        "[providers]\ndefault_provider_id = \"bedrock\"\n",
+    )
+    .expect("write config");
+
+    let mut cfg = GlobalConfig::load_or_create().await.expect("load config");
+    assert_eq!(
+        cfg.providers.default_provider_id.as_deref(),
+        Some("bedrock"),
+        "the hand-written policy must be read back"
+    );
+
+    // What `/local on` does: mutate one unrelated field, then save.
+    cfg.local_inference.enabled = !cfg.local_inference.enabled;
+    cfg.save().await.expect("save should succeed");
+
+    let reloaded = GlobalConfig::load().await;
+    assert_eq!(
+        reloaded.providers.default_provider_id.as_deref(),
+        Some("bedrock"),
+        "an unrelated save must not erase the operator's provider policy"
+    );
+    // The on-disk text is what the next process parses, so assert it directly.
+    let on_disk = std::fs::read_to_string(dir.join("config.toml")).expect("read saved config");
+    assert!(
+        on_disk.contains("default_provider_id"),
+        "the saved file dropped [providers]:\n{on_disk}"
+    );
+}
+
+/// #3766: an absent `[providers]` table is unset, not an error.
+///
+/// Why: every existing `config.toml` predates the section, and the shipped
+/// default leaves it commented out. Absent must round-trip as "no policy".
+/// Test: itself.
+#[tokio::test]
+async fn providers_section_defaults_to_unset() {
+    let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let home = tempdir();
+    unsafe {
+        std::env::set_var("HOME", &home);
+    }
+
+    let cfg = GlobalConfig::load_or_create()
+        .await
+        .expect("create default");
+    assert_eq!(cfg.providers.default_provider_id, None);
+
+    cfg.save().await.expect("save should succeed");
+    assert_eq!(
+        GlobalConfig::load().await.providers.default_provider_id,
+        None
+    );
+}
+
 #[tokio::test]
 async fn save_publishes_by_rename_leaving_the_old_file_intact() {
     // audit 2026-08-19: `save()` documented an atomic write but ran a plain

--- a/crates/trusty-agents/src/mcp/config/types.rs
+++ b/crates/trusty-agents/src/mcp/config/types.rs
@@ -209,3 +209,29 @@ pub struct McpTool {
     pub name: String,
     pub description: String,
 }
+
+/// `[providers]` section (#3766) — the default inference provider for agents
+/// that pin none of their own.
+///
+/// Why: the bundled agent templates ship bare model slugs
+/// (`model = "claude-sonnet-4-6"`) and no `[agent].provider_id`, so which
+/// provider served them was decided by whichever ambient credential the
+/// harness happened to find first. The owner's ruling on #3766 puts that
+/// choice in configuration. It is a field on [`super::GlobalConfig`] rather
+/// than a second parser over the same file because `GlobalConfig::save()`
+/// re-serializes only its declared fields: an unmodelled `[providers]` table
+/// would be erased from disk by any unrelated write — `/local on`
+/// (`repl::commands::routing`) and the four `mcp_*` mutators all
+/// load-mutate-save.
+/// What: `default_provider_id` names a provider from
+/// `trusty_common::inference::registry`. Absent (the default) means UNSET and
+/// preserves the ambient behaviour exactly. The precedence rules live in
+/// [`crate::llm::provider_policy`], which reads this field.
+/// Test: `providers_section_survives_an_unrelated_save`,
+/// `providers_section_defaults_to_unset`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize)]
+pub struct ProvidersSection {
+    /// The provider that unpinned, provider-agnostic agents default to.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_provider_id: Option<String>,
+}


### PR DESCRIPTION
Provider selection for bundled/unpinned templates reads `[providers] default_provider_id` from the operator config, adopted as the template's provider_id through the existing #3765 pin path — explicit pins and provider-named slugs always win; unset means byte-identical ambient behavior. `[providers]` is a typed section on GlobalConfig so no save path can drop it (round-trip regression test included).

Behavior note: with a policy set, a session /provider override contradicting it is refused (existing #3765 fail-closed rule now reaching policy-defaulted agents).

Refs #3766

**Test rung 3:** `cargo test -p trusty-agents --no-fail-fast` — 14 targets, lib 3584 passed, 0 failed; 4 acceptance tests proven red under a neutering mutation.

No version bump (trusty-agents unpublished).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools