### PR TITLE
fix(trusty-common): resolve 7 broken intra-doc links from the daemon-token surface (repairs red pre-publish gate)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11427,7 +11427,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-common"
-version = "0.46.4"
+version = "0.46.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -47,7 +47,7 @@ name = "trusty-common"
 # position, so 0.46.0 is where they ship.
 # 0.46.3 (#5439): patch — new public `daemon_token` module and
 # `server::bearer_auth` are additive; cargo-semver-checks reports no break.
-version = "0.46.4"
+version = "0.46.5"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/trusty-common/changelog.d/5439-doc-link-fix.md
+++ b/crates/trusty-common/changelog.d/5439-doc-link-fix.md
@@ -1,0 +1,3 @@
+Fixed
+
+- Resolved 7 broken intra-doc links on the `daemon_token` / `server::bearer_auth` surface (#5439) so the pre-publish rustdoc-link gate is green again.

--- a/crates/trusty-common/src/daemon_token.rs
+++ b/crates/trusty-common/src/daemon_token.rs
@@ -24,12 +24,13 @@
 //! not a stronger token. Do not describe this module as providing more than
 //! it does.
 //!
-//! What: [`token_path`] resolves `{resolve_data_dir(app)}/auth_token`;
-//! [`ensure_token`] is the SERVER side (read the existing token, or mint and
-//! persist one at `0600`); [`read_token`] is the CLIENT side (best-effort —
-//! `None` means "no credential available", never a hard error);
-//! [`credentials_match`] is the constant-time comparison every verifier must
-//! use instead of `==`.
+//! What: [`crate::daemon_token::token_path`] resolves
+//! `{resolve_data_dir(app)}/auth_token`; [`crate::daemon_token::ensure_token`]
+//! is the SERVER side (read the existing token, or mint and persist one at
+//! `0600`); [`crate::daemon_token::read_token`] is the CLIENT side (best-effort
+//! — `None` means "no credential available", never a hard error);
+//! [`crate::daemon_token::credentials_match`] is the constant-time comparison
+//! every verifier must use instead of `==`.
 //!
 //! Test: `daemon_token_tests::*` — mint strength, round trip, `0600` mode,
 //! rotation on a too-weak stored value, constant-time equality.

--- a/crates/trusty-common/src/server/bearer_auth.rs
+++ b/crates/trusty-common/src/server/bearer_auth.rs
@@ -1,7 +1,7 @@
 //! Router-wide bearer authentication for a loopback daemon's HTTP/SSE
 //! surface (#5439).
 //!
-//! Why: [`super::origin_guard`] stops a browser page on a foreign origin from
+//! Why: [`crate::server::origin_guard`] stops a browser page on a foreign origin from
 //! issuing a WRITE and (with `same_origin_cors`) from READING a response, but
 //! it is deliberately not authentication: it passes every request that sends
 //! no `Origin` at all — `curl`, a reverse proxy, any local process. That is
@@ -28,7 +28,7 @@
 //! opening `GET /sessions/{id}/events` has no way to attach `Authorization`,
 //! and putting the durable token in the query string would write it into every
 //! access log and tracing span. [`DaemonAuth::issue_ticket`] mints a
-//! single-use value that expires in [`TICKET_TTL`], obtained over the
+//! single-use value that expires in [`crate::server::bearer_auth::TICKET_TTL`], obtained over the
 //! header-authenticated surface; a ticket in a log is spent and stale.
 //!
 //! **A public path passes unmarked, not authenticated.** A handler that serves
@@ -236,7 +236,7 @@ impl DaemonAuth {
 /// surface and one hole.
 /// What: valid `Authorization: Bearer` → mark [`Authenticated`], continue;
 /// else valid `?ticket=` → mark [`Authenticated`], continue; else a path in
-/// [`DaemonAuth::with_public_paths`] → continue UNMARKED; else `401` with an
+/// [`DaemonAuth::new`]'s `public_paths` → continue UNMARKED; else `401` with an
 /// empty body and a bare `WWW-Authenticate: Bearer`, disclosing nothing about
 /// whether the path exists, why the credential failed, or what the daemon is.
 /// Test: `bearer_auth_tests::*`.


### PR DESCRIPTION
Refs #5439

Lines: 7 intra-doc links from the #5439 daemon-token/bearer_auth surface resolved in crate-root-scoped module docs (crate-qualified paths, matching the file's existing style; `DaemonAuth::with_public_paths` corrected to the real `DaemonAuth::new` public_paths); this is the exact defect main's Pre-publish rustdoc-links gate is red on, so it repairs main and unblocks the trusty-common publish; doc-comment-only, semver `no semver update required`, version bumped 0.46.4→0.46.5 (0.46.4 goes unpublished, root pin `"0.46"` unchanged). Test: `scripts/check_rustdoc_links.sh` GATE_EXIT=0, 0 broken; fmt/check/clippy -p trusty-common (features catchup,daemon-token,axum-server) clean.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools