### PR TITLE
chore(release): assemble trusty-common 0.46.5 changelog

### DIFF
--- a/crates/trusty-common/CHANGELOG.md
+++ b/crates/trusty-common/CHANGELOG.md
@@ -6,6 +6,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.46.5] — 2026-09-01
+
+### Fixed
+
+- Resolved 7 broken intra-doc links on the `daemon_token` / `server::bearer_auth` surface (#5439) so the pre-publish rustdoc-link gate is green again.
+
 ## [0.46.4] — 2026-09-01
 
 ### Fixed

--- a/crates/trusty-common/changelog.d/5439-doc-link-fix.md
+++ b/crates/trusty-common/changelog.d/5439-doc-link-fix.md
@@ -1,3 +1,0 @@
-Fixed
-
-- Resolved 7 broken intra-doc links on the `daemon_token` / `server::bearer_auth` surface (#5439) so the pre-publish rustdoc-link gate is green again.


### PR DESCRIPTION
Standalone changelog assemble for trusty-common 0.46.5 (separate from the tag/publish commit per #6508/#5674). Docs-only, rung 1.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
