### PR TITLE
fix(cargo-publish): make preflight --check-only usable before tagging so a gate failure cannot strand a tag

### DIFF
--- a/.claude/skills/cargo-publish/SKILL.md
+++ b/.claude/skills/cargo-publish/SKILL.md
@@ -22,9 +22,14 @@ Every publish follows this exact sequence:
 0. scripts/check-publish-ready.sh <crate>   — MANDATORY, MUST PASS
 1. Pre-flight checks (fmt, clippy, tests)
 2. cargo publish --dry-run
+2b. scripts/preflight-publish.sh --check-only <crate>  — MANDATORY, MUST PASS
+    BEFORE TAGGING (#6508): decides whether tagging is allowed. Tags here are
+    immutable (#6178), so a failure found only AFTER tagging strands the
+    version — this is what trusty-common 0.46.1 and 0.46.3 both burned this
+    week.
 3. git tag <crate-name>-v<version>
 4. git push origin <crate-name>-v<version>
-5. scripts/preflight-publish.sh <crate>     — MANDATORY, MUST PASS (run again, immediately before step 6)
+5. scripts/preflight-publish.sh <crate>     — MANDATORY, MUST PASS (run again, immediately before step 6; this run also binds the tag to the commit via CHECK 6, which step 2b cannot do — no tag exists yet at that point)
 6. cargo publish
 6b. scripts/check-tag-publish-parity.sh --vcs-info auto <crate>  — confirm the
     tag names the commit cargo actually recorded
@@ -34,7 +39,8 @@ Every publish follows this exact sequence:
 10. Verify <binary> --version
 ```
 
-**Critical**: Never skip dry-run. Never publish from the main checkout.
+**Critical**: Never skip dry-run. Never publish from the main checkout. Never
+tag before step 2b passes.
 
 ## Step 0: Publish-Only-From-Merged-Main Guard (MANDATORY, issue #2227)
 
@@ -82,6 +88,34 @@ the entire pipeline (build/release/homebrew-bump AND the publish-dry-run job
 below) is skipped — this is a second, independent enforcement point, not a
 replacement for running `check-publish-ready.sh` yourself before `cargo
 publish`.
+
+## Step 2b: Pre-Tag Gate (MANDATORY, issue #6508)
+
+🔴 **Run `scripts/preflight-publish.sh --check-only <crate>` BEFORE `git tag`
+— it is the gate that decides whether tagging is allowed.** Tags on this repo
+are immutable (#6178); a preflight failure discovered only after the tag is
+already pushed cannot be fixed by moving or deleting the tag, so it burns the
+version number. trusty-common 0.46.1 and 0.46.3 both burned a version this
+week this way — the canonical workflow tagged and pushed BEFORE running
+preflight, so CHECK 5 (semver) failing there stranded an already-pushed tag.
+
+```bash
+scripts/preflight-publish.sh --check-only trusty-mpm
+```
+
+This runs every check unconditionally, including the checks that don't need a
+tag yet (semver, identity, clean-tree, version-not-live, UI bundle freshness,
+the pre-publish gate, the changelog assembler). CHECK 6 (tag/publish-commit
+parity, Step 5 below) is the one exception: a `TAG-MISSING` finding here is
+the expected pre-tag state, not a failure — `--check-only` reports it as
+`[SKIP]` and does not block on it. Only tag once this run passes clean.
+
+The full (non-`--check-only`) run in Step 5 below is the POST-TAG gate and
+mechanically enforces this ordering: it refuses to certify a run — failing
+the same way any other check does, printing the exact `--check-only` command
+above — when no candidate tag for the target version exists locally yet.
+This does not replace the procedural rule; it catches the case where someone
+reaches for the full run as a substitute for the pre-tag one.
 
 ## Step 5: Identity + Clean-Tree + Version-Not-Live Guard (MANDATORY, closes the 2026-07-08 collision)
 
@@ -160,12 +194,13 @@ version instead). Runs six checks and fails loud on any of them:
    Full rationale, the four finding codes, and the residual gap:
    [docs/reference/release-workflow.md](../../../docs/reference/release-workflow.md#tagpublish-commit-parity-guard).
 
-`scripts/preflight-publish.sh --check-only <crate>` runs all six checks
-unconditionally and prints a `[PASS]`/`[FAIL]` line per check without
-assuming you're mid-publish — use it to preview status. `--help` documents
-the rare, logged `PREFLIGHT_ALLOW_DETACHED=1` override for check 1 (validated
-release worktrees only — misuse of it is exactly how the incident happened).
-No override exists for the identity check.
+`scripts/preflight-publish.sh --check-only <crate>` runs all checks
+unconditionally and prints a `[PASS]`/`[FAIL]`/`[SKIP]` line per check without
+assuming you're mid-publish — this is the Step 2b pre-tag gate above, MANDATORY
+before `git tag`, not just a status preview. `--help` documents the rare,
+logged `PREFLIGHT_ALLOW_DETACHED=1` override for check 1 (validated release
+worktrees only — misuse of it is exactly how the incident happened). No
+override exists for the identity check.
 
 ## Step 6: Version-Parity Guard (MANDATORY, issue #3366)
 
@@ -619,11 +654,20 @@ SKIP_UI_BUILD=1 cargo publish --dry-run -p <crate>
 #    - Wait 100s
 #    - Retry this crate's dry-run
 
+# 8b. Pre-tag gate (MANDATORY, #6508) — MUST PASS before tagging. Tags here
+#     are immutable (#6178); a failure found only after tagging strands the
+#     version, which is what burned trusty-common 0.46.1 and 0.46.3 this week.
+scripts/preflight-publish.sh --check-only <crate>
+
 # 9. Tag
 git tag <crate>-v<version>
 
 # 10. Push tag to origin
 git push -u origin <crate>-v<version>
+
+# 10b. Full preflight gate (MANDATORY, Step 5 above) — run again now that the
+#      tag exists; this run is what binds the tag to the commit (CHECK 6).
+scripts/preflight-publish.sh <crate>
 
 # 11. Publish to crates.io (same SKIP_UI_BUILD=1 requirement as step 7, for
 #     the same reason)
@@ -649,10 +693,15 @@ depends on it. Both need to publish.
 # === STEP 1: PUBLISH trusty-common 0.8.0 ===
 cd .claude/worktrees/publish-trusty-common
 
-# Edit, test, commit, tag
+# Edit, test, commit
 vim crates/trusty-common/Cargo.toml  # 0.7.0 → 0.8.0
 cargo test -p trusty-common
 git commit -m "chore: bump trusty-common to v0.8.0"
+
+# Pre-tag gate (MANDATORY, #6508) — must pass BEFORE tagging
+scripts/preflight-publish.sh --check-only trusty-common
+
+# Tag
 git tag trusty-common-v0.8.0
 git push origin trusty-common-v0.8.0
 
@@ -672,10 +721,15 @@ curl -s https://crates.io/api/v1/crates/trusty-common/0.8.0 | head -c 200
 # === STEP 2: PUBLISH trusty-search 0.13.1 ===
 cd .claude/worktrees/publish-trusty-search
 
-# Edit, test, commit, tag
+# Edit, test, commit
 vim crates/trusty-search/Cargo.toml  # 0.13.0 → 0.13.1
 cargo test -p trusty-search
 git commit -m "chore: bump trusty-search to v0.13.1"
+
+# Pre-tag gate (MANDATORY, #6508) — must pass BEFORE tagging
+scripts/preflight-publish.sh --check-only trusty-search
+
+# Tag
 git tag trusty-search-v0.13.1
 git push origin trusty-search-v0.13.1
 
@@ -754,8 +808,13 @@ Before declaring a publish complete:
 - [ ] `scripts/check-publish-ready.sh <crate>` (or `make publish-check CRATE=<crate>`) passed
 - [ ] Pre-flight checks passed (fmt, clippy, tests, check)
 - [ ] Dry-run succeeded
+- [ ] `scripts/preflight-publish.sh --check-only <crate>` passed — MANDATORY
+      before tagging (#6508); tags are immutable, so this is what catches a
+      semver/changelog/gate failure before it can strand one
 - [ ] Tag created with correct name pattern
 - [ ] Tag pushed to origin
+- [ ] `scripts/preflight-publish.sh <crate>` (full run) passed again, now that
+      the tag exists — this is what binds the tag to the commit (CHECK 6)
 - [ ] `cargo publish` succeeded (status 200 OK)
 - [ ] Waited 100s and verified on crates.io API
 - [ ] Binary installed with `cargo install --path … --locked` (if applicable)

--- a/docs/reference/release-workflow.md
+++ b/docs/reference/release-workflow.md
@@ -63,6 +63,15 @@ e.g. `trusty-mcp-core-v0.2.0`. The version comes from the crate's `Cargo.toml`.
 > is intentionally deferred and not yet implemented.
 3. Run `cargo test -p <name>` and `cargo clippy --workspace -- -D warnings`.
 4. Commit the version bump.
+4b. Run `scripts/preflight-publish.sh --check-only <crate-name>` — MANDATORY,
+   must pass BEFORE tagging (issue #6508). This is the gate that decides
+   whether tagging is allowed: tags here are immutable (see
+   [Release Tags Are Immutable](#release-tags-are-immutable) below), so a
+   preflight failure discovered only after the tag is already pushed burns the
+   version rather than being fixable in place — this is what happened to
+   trusty-common 0.46.1 and 0.46.3 in one week. Full rationale and the
+   `--check-only`/full-mode split:
+   [`.claude/skills/cargo-publish/SKILL.md`, "Step 2b"](../../.claude/skills/cargo-publish/SKILL.md#step-2b-pre-tag-gate-mandatory-issue-6508).
 5. Create the tag: `git tag <crate-name>-v<version>`.
 6. Push the tag: `git push origin <crate-name>-v<version>`.
 7. Run `scripts/check-publish-ready.sh <crate-name>` (or
@@ -71,9 +80,10 @@ e.g. `trusty-mcp-core-v0.2.0`. The version comes from the crate's `Cargo.toml`.
    Also runs automatically post-merge: `make version-parity-check` (or wait
    for `.github/workflows/version-parity.yml` on the merge commit) — see
    [Version-Parity Guard](#version-parity-guard-issue-3366) below.
-7b. Run `scripts/preflight-publish.sh <crate-name>` immediately before step 8.
-   Its CHECK 6 is the one that catches a tag left behind by a fast-forward —
-   see [Tag/Publish-Commit Parity Guard](#tagpublish-commit-parity-guard) below.
+7b. Run `scripts/preflight-publish.sh <crate-name>` immediately before step 8 —
+   the post-tag counterpart of step 4b, now that the tag exists. Its CHECK 6
+   is the one that catches a tag left behind by a fast-forward — see
+   [Tag/Publish-Commit Parity Guard](#tagpublish-commit-parity-guard) below.
    🔴 If main moved between steps 5 and 7 and you fast-forwarded this checkout
    to satisfy the merged-main check, the tag from step 5 is now stale. Reset the
    checkout back to the tag (`git reset --hard <crate-name>-v<version>`) and
@@ -154,7 +164,10 @@ publish-dry-run job below — is skipped rather than silently proceeding.
 
 🔴 **The release tag must name the commit `cargo publish` actually ships.**
 `scripts/check-tag-publish-parity.sh <crate> [version]` enforces it, and
-`scripts/preflight-publish.sh` runs it as CHECK 6 with no override.
+`scripts/preflight-publish.sh` runs it as CHECK 6 with no override — except
+that a `TAG-MISSING` finding under `--check-only` is a pass-through `[SKIP]`,
+not a failure: no tag is expected to exist yet at the pre-tag gate (issue
+#6508). See [`.claude/skills/cargo-publish/SKILL.md`, "Step 2b"](../../.claude/skills/cargo-publish/SKILL.md#step-2b-pre-tag-gate-mandatory-issue-6508).
 
 **The defect it closes.** Nothing bound the tag to the upload. Step 5 tags,
 step 8 publishes, and the two gates in between check different things:

--- a/scripts/preflight-check6-tag-gate-selftest.sh
+++ b/scripts/preflight-check6-tag-gate-selftest.sh
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+#
+# preflight-check6-tag-gate-selftest.sh — the pre-tag guard around preflight
+# CHECK 6 (#6508).
+#
+# Why: the canonical workflow tags and pushes BEFORE preflight-publish.sh's
+#   full run, so a CHECK 5 (semver) failure discovered there strands an
+#   already-pushed tag — tags on this repo are IMMUTABLE (#6178).
+#   trusty-common 0.46.1 and 0.46.3 both burned a version this week exactly
+#   this way. The fix is procedural: `scripts/preflight-publish.sh
+#   --check-only <crate>` is now the MANDATORY gate before `git tag` (see
+#   .claude/skills/cargo-publish and docs/reference/release-workflow.md).
+#   Two decisions in preflight-publish.sh make that hold together:
+#
+#     tagparity_decide()      CHECK 6 itself. --check-only must be able to
+#                              PASS before a tag exists — a TAG-MISSING
+#                              finding there is the expected pre-tag state,
+#                              not a failure. Before this fix, --check-only
+#                              always failed pre-tag (CHECK 6 always found no
+#                              tag), which made the new mandatory gate
+#                              impossible to satisfy honestly.
+#
+#     full_mode_requires_tag() the new guard. FULL mode (no --check-only)
+#                              must still refuse to certify a run with no
+#                              tag — it is the post-tag gate, and a missing
+#                              tag there means the canonical sequence was not
+#                              followed.
+#
+# What: drives both functions directly — tagparity_decide over canned
+#   rc/log content (no shell-out, no network), full_mode_requires_tag against
+#   a real scratch git repo (it calls `git rev-parse --verify refs/tags/...`
+#   directly, so a real repo is cheaper than mocking git). Both are lifted out
+#   of preflight-publish.sh BY PATTERN (the same awk-extraction
+#   preflight-check5-selftest.sh and preflight-check8-selftest.sh use), so
+#   this exercises the shipped definitions rather than a copy that can drift.
+#
+#   Cases:
+#     1.  tag-parity clean            rc=0. [PASS] in either mode.
+#     2.  TAG-MISSING, --check-only   the expected pre-tag state. [SKIP],
+#                                     and the overall decision still permits
+#                                     (return 0) — this is the case that used
+#                                     to make --check-only unsatisfiable
+#                                     pre-tag.
+#     3.  TAG-MISSING, full mode      [FAIL] — full mode never treats a
+#                                     missing tag as expected.
+#     4.  TAG-SPLIT, --check-only     a tag DOES exist and disagrees with its
+#                                     alias. Must still [FAIL] even in
+#                                     --check-only — this is not the
+#                                     expected-pre-tag shape the SKIP exists
+#                                     for.
+#     5.  TAG-DRIFT, --check-only     same reasoning: a real tag naming the
+#                                     wrong commit is a real problem, not a
+#                                     pre-tag preview artifact.
+#     6.  tag exists locally          full_mode_requires_tag passes once the
+#                                     candidate tag is present.
+#     7.  tag missing locally         full_mode_requires_tag fails, and names
+#                                     the exact --check-only remedy.
+#     8.  --check-only is a no-op     full_mode_requires_tag always passes in
+#                                     --check-only mode, tag or no tag — it
+#                                     exists to gate FULL mode only.
+#     9.  package-name alias          a tga-style crate (PKG_NAME != CRATE_DIR)
+#                                     passes on either candidate tag name.
+#
+# Usage:  bash scripts/preflight-check6-tag-gate-selftest.sh
+# Exit:   0 when every case behaves; 1 (naming the case) when one does not.
+#
+# Portability: bash 3.2 (macOS system bash) and bash 5 (Linux CI). No cargo,
+# no network.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_TOP="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+UNDER_TEST="${PREFLIGHT_SELFTEST_SCRIPT:-${REPO_TOP}/scripts/preflight-publish.sh}"
+
+if [ ! -r "$UNDER_TEST" ]; then
+  echo "preflight-check6-tag-gate-selftest: cannot read ${UNDER_TEST}" >&2
+  exit 1
+fi
+
+PASSED=0
+FAILED=0
+
+fail_case() {
+  echo "SELF-TEST FAIL: $1" >&2
+  shift
+  printf '%s\n' "$@" | sed 's/^/       /' >&2
+  FAILED=$((FAILED + 1))
+}
+
+pass_case() {
+  echo "  ok  $1"
+  PASSED=$((PASSED + 1))
+}
+
+# ---------------------------------------------------------------------------
+# run_tagparity_decide <rc> <log-content> <check-only> -> "<exit>|<stderr>"
+# ---------------------------------------------------------------------------
+run_tagparity_decide() {
+  local rc="$1" content="$2" check_only="$3" log out xrc
+  log="$(mktemp "${TMPDIR:-/tmp}/preflight-check6-gate.XXXXXX")"
+  printf '%s\n' "$content" > "$log"
+  out="$(
+    set +e
+    PKG_NAME="trusty-selftest"
+    VERSION="9.9.9"
+    CHECK_ONLY="$check_only"
+    eval "$(awk '/^tagparity_decide\(\) \{/,/^\}/' "$UNDER_TEST")"
+    tagparity_decide "$rc" "$log" 2>&1 >/dev/null
+    printf '\nEXIT=%s' "$?"
+  )"
+  rm -f "$log"
+  xrc="$(printf '%s' "$out" | sed -n 's/^EXIT=//p' | tail -n1)"
+  out="$(printf '%s' "$out" | grep -v '^EXIT=' | tr '\n' ' ' | tr -s ' ')"
+  printf '%s|%s' "${xrc:-?}" "$out"
+}
+
+status_of() { printf '%s' "$1" | cut -d'|' -f1; }
+text_of() { printf '%s' "$1" | cut -d'|' -f2-; }
+
+echo "tagparity_decide:"
+
+# --- 1. clean --------------------------------------------------------------
+raw="$(run_tagparity_decide 0 "PASS: trusty-common-v9.9.9 names abc123, which is the commit this publish ships." 1)"
+if [ "$(status_of "$raw")" = "0" ] && case "$(text_of "$raw")" in *"[PASS]"*) true ;; *) false ;; esac; then
+  pass_case "1 clean: PASS"
+else
+  fail_case "1 clean: PASS" "$raw"
+fi
+
+# --- 2. TAG-MISSING, --check-only: SKIP and permit --------------------------
+raw="$(run_tagparity_decide 1 "FAIL: TAG-MISSING — no release tag resolves for trusty-selftest 9.9.9." 1)"
+if [ "$(status_of "$raw")" = "0" ] && case "$(text_of "$raw")" in *"[SKIP]"*) true ;; *) false ;; esac; then
+  pass_case "2 TAG-MISSING + check-only: SKIP, permits"
+else
+  fail_case "2 TAG-MISSING + check-only: SKIP, permits" "$raw"
+fi
+
+# --- 3. TAG-MISSING, full mode: FAIL ----------------------------------------
+raw="$(run_tagparity_decide 1 "FAIL: TAG-MISSING — no release tag resolves for trusty-selftest 9.9.9." 0)"
+if [ "$(status_of "$raw")" = "1" ] && case "$(text_of "$raw")" in *"[FAIL]"*) true ;; *) false ;; esac; then
+  pass_case "3 TAG-MISSING + full mode: FAIL"
+else
+  fail_case "3 TAG-MISSING + full mode: FAIL" "$raw"
+fi
+
+# --- 4. TAG-SPLIT, --check-only: still FAIL ---------------------------------
+raw="$(run_tagparity_decide 1 "FAIL: TAG-SPLIT — the accepted alias tags name DIFFERENT commits." 1)"
+if [ "$(status_of "$raw")" = "1" ] && case "$(text_of "$raw")" in *"[FAIL]"*) true ;; *) false ;; esac; then
+  pass_case "4 TAG-SPLIT + check-only: still FAIL"
+else
+  fail_case "4 TAG-SPLIT + check-only: still FAIL" "$raw"
+fi
+
+# --- 5. TAG-DRIFT, --check-only: still FAIL ---------------------------------
+raw="$(run_tagparity_decide 1 "FAIL: TAG-DRIFT — the tag names a commit other than HEAD." 1)"
+if [ "$(status_of "$raw")" = "1" ] && case "$(text_of "$raw")" in *"[FAIL]"*) true ;; *) false ;; esac; then
+  pass_case "5 TAG-DRIFT + check-only: still FAIL"
+else
+  fail_case "5 TAG-DRIFT + check-only: still FAIL" "$raw"
+fi
+
+echo "full_mode_requires_tag:"
+
+# ---------------------------------------------------------------------------
+# run_full_mode_requires_tag <crate-dir> <pkg-name> <version> <check-only> \
+#   <make-tag: 0|1> -> "<exit>|<stderr>"
+#
+# Builds a real scratch git repo (the function shells out to `git
+# rev-parse`), optionally creates the candidate tag, then drives the
+# extracted function inside it.
+# ---------------------------------------------------------------------------
+# shellcheck disable=SC2034  # CRATE_DIR/PKG_NAME/VERSION/CRATE_INPUT/CHECK_ONLY
+# are read by full_mode_requires_tag, eval'd below, which shellcheck cannot see into.
+run_full_mode_requires_tag() {
+  local crate_dir="$1" pkg_name="$2" version="$3" check_only="$4" make_tag="$5"
+  local repo out xrc
+  repo="$(mktemp -d "${TMPDIR:-/tmp}/preflight-check6-gate-repo.XXXXXX")"
+  (
+    cd "$repo" || exit 1
+    git init -q .
+    git config user.email "selftest@example.com"
+    git config user.name "selftest"
+    printf 'x\n' > file.txt
+    git add file.txt
+    git commit -q -m init
+    if [ "$make_tag" -eq 1 ]; then
+      if [ "$pkg_name" != "$crate_dir" ]; then
+        git tag "${pkg_name}-v${version}"
+      else
+        git tag "${crate_dir}-v${version}"
+      fi
+    fi
+  ) >/dev/null 2>&1
+  out="$(
+    cd "$repo" || exit 1
+    set +e
+    CRATE_DIR="$crate_dir"
+    PKG_NAME="$pkg_name"
+    VERSION="$version"
+    CRATE_INPUT="$crate_dir"
+    CHECK_ONLY="$check_only"
+    eval "$(awk '/^full_mode_requires_tag\(\) \{/,/^\}/' "$UNDER_TEST")"
+    full_mode_requires_tag 2>&1 >/dev/null
+    printf '\nEXIT=%s' "$?"
+  )"
+  rm -rf "$repo"
+  xrc="$(printf '%s' "$out" | sed -n 's/^EXIT=//p' | tail -n1)"
+  out="$(printf '%s' "$out" | grep -v '^EXIT=' | tr '\n' ' ' | tr -s ' ')"
+  printf '%s|%s' "${xrc:-?}" "$out"
+}
+
+# --- 6. tag exists locally: passes -------------------------------------------
+raw="$(run_full_mode_requires_tag trusty-selftest trusty-selftest 9.9.9 0 1)"
+if [ "$(status_of "$raw")" = "0" ]; then
+  pass_case "6 tag exists: passes"
+else
+  fail_case "6 tag exists: passes" "$raw"
+fi
+
+# --- 7. tag missing locally: fails, names the --check-only remedy ------------
+raw="$(run_full_mode_requires_tag trusty-selftest trusty-selftest 9.9.9 0 0)"
+if [ "$(status_of "$raw")" = "1" ] && case "$(text_of "$raw")" in *"--check-only trusty-selftest"*) true ;; *) false ;; esac; then
+  pass_case "7 tag missing: fails, names remedy"
+else
+  fail_case "7 tag missing: fails, names remedy" "$raw"
+fi
+
+# --- 8. --check-only is always a no-op, tag or no tag ------------------------
+raw="$(run_full_mode_requires_tag trusty-selftest trusty-selftest 9.9.9 1 0)"
+if [ "$(status_of "$raw")" = "0" ]; then
+  pass_case "8 check-only, no tag: no-op, passes"
+else
+  fail_case "8 check-only, no tag: no-op, passes" "$raw"
+fi
+
+# --- 9. package-name alias (tga-style): passes on the pkg-name candidate -----
+raw="$(run_full_mode_requires_tag trusty-git-analytics tga 2.19.0 0 1)"
+if [ "$(status_of "$raw")" = "0" ]; then
+  pass_case "9 alias tag (tga-v...): passes"
+else
+  fail_case "9 alias tag (tga-v...): passes" "$raw"
+fi
+
+echo
+if [ "$FAILED" -eq 0 ]; then
+  echo "preflight-check6-tag-gate-selftest: ${PASSED} case(s) passed."
+  exit 0
+fi
+echo "preflight-check6-tag-gate-selftest: ${FAILED} of $((PASSED + FAILED)) case(s) FAILED." >&2
+exit 1

--- a/scripts/preflight-publish.sh
+++ b/scripts/preflight-publish.sh
@@ -970,26 +970,89 @@ semver_decide() {
 }
 
 # ===========================================================================
+# Pre-tag guard (#6508) — FULL mode refuses to certify a run without a tag
+# ===========================================================================
+# Why: the canonical workflow tags and pushes BEFORE this script's full run
+#   (`scripts/preflight-publish.sh <crate>`, no --check-only), so a CHECK 5
+#   (semver) failure discovered here strands an already-pushed tag — tags on
+#   this repo are IMMUTABLE (#6178). trusty-common 0.46.1 and 0.46.3 both
+#   burned a version this week exactly this way. `--check-only` runs every
+#   check, tag-parity included (see tagparity_decide below), and is the
+#   MANDATORY gate before `git tag` — see .claude/skills/cargo-publish and
+#   docs/reference/release-workflow.md.
+#
+#   This guard makes full mode refuse to double as that pre-tag check. It
+#   does NOT short-circuit the run — every other check still executes, per
+#   this file's existing "always run every check" design (below: "a partial
+#   preflight is how gaps get missed") — it only ensures a missing tag costs
+#   full mode a [FAIL] and the exact remedy, the same as any other check. A
+#   no-op in --check-only mode, and a no-op once the tag has actually been
+#   created — the corrected sequence never trips it.
+full_mode_requires_tag() {
+  [ "$CHECK_ONLY" -eq 1 ] && return 0
+  local candidates="${CRATE_DIR}-v${VERSION}" tag
+  if [ "$PKG_NAME" != "$CRATE_DIR" ]; then
+    candidates="${candidates} ${PKG_NAME}-v${VERSION}"
+  fi
+  for tag in $candidates; do
+    if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null 2>&1; then
+      return 0
+    fi
+  done
+  echo "[FAIL] tag-exists: no local tag (${candidates}) for ${PKG_NAME} ${VERSION} yet." >&2
+  echo "       Full-mode preflight-publish.sh is the POST-TAG gate — CHECK 6 binds" >&2
+  echo "       the tag to the commit about to publish, which is undefined before" >&2
+  echo "       one exists. Run the pre-tag gate first, and only tag once it passes" >&2
+  echo "       clean (#6508 — this is what keeps a preflight failure from ever" >&2
+  echo "       stranding an already-pushed, immutable tag):" >&2
+  echo "         scripts/preflight-publish.sh --check-only ${CRATE_INPUT}" >&2
+  return 1
+}
+
+# ===========================================================================
 # CHECK 6 — the release tag names the commit this publish ships
 # ===========================================================================
 # Delegated rather than inlined so the comparison has somewhere to be tested:
 # scripts/check-tag-publish-parity-selftest.sh drives every failure branch
 # against synthetic repos, which is not something this script's network- and
 # identity-bound checks can be wrapped in.
-check6_tag_parity() {
-  local log="${TMP_PARITY}" rc=0
-
-  bash "${REPO_ROOT}/scripts/check-tag-publish-parity.sh" \
-    "$PKG_NAME" "$VERSION" > "$log" 2>&1 || rc=$?
+#
+# tagparity_decide is split out (rather than inlined in check6_tag_parity) so
+# it can be extracted and driven over canned log content the same way
+# semver_decide (CHECK 5) and gate_decide (CHECK 8) are — see
+# preflight-check6-tag-gate-selftest.sh. In --check-only mode (#6508), a
+# TAG-MISSING finding is the expected pre-tag state, not a failure: the whole
+# point of --check-only is previewing the OTHER checks before the tag exists.
+# TAG-SPLIT, TAG-DRIFT and VCS-INFO-MISMATCH all still fail in either mode —
+# those mean a tag DOES exist and is wrong, never "as expected, not yet."
+tagparity_decide() {
+  local rc="$1" log="$2"
 
   if [ "$rc" -eq 0 ]; then
     echo "[PASS] tag-parity: $(grep '^PASS:' "$log" | head -1)" >&2
     return 0
   fi
 
+  if [ "$CHECK_ONLY" -eq 1 ] && grep -q '^FAIL: TAG-MISSING' "$log"; then
+    echo "[SKIP] tag-parity: no release tag exists yet for ${PKG_NAME} ${VERSION} —" >&2
+    echo "       expected before tagging. --check-only previews the checks that" >&2
+    echo "       do not depend on a tag; tag/publish-commit parity is verified for" >&2
+    echo "       real by the full, post-tag preflight run once the tag exists." >&2
+    return 0
+  fi
+
   echo "[FAIL] tag-parity: the release tag does not name the commit about to be published:" >&2
   sed 's/^/       /' "$log" >&2
   return 1
+}
+
+check6_tag_parity() {
+  local log="${TMP_PARITY}" rc=0
+
+  bash "${REPO_ROOT}/scripts/check-tag-publish-parity.sh" \
+    "$PKG_NAME" "$VERSION" > "$log" 2>&1 || rc=$?
+
+  tagparity_decide "$rc" "$log"
 }
 
 # ===========================================================================
@@ -1472,6 +1535,7 @@ check2_identity;            [ $? -eq 0 ] || FAILURES=$((FAILURES + 1))
 check3_clean_tree;          [ $? -eq 0 ] || FAILURES=$((FAILURES + 1))
 check4_version_not_live;    [ $? -eq 0 ] || FAILURES=$((FAILURES + 1))
 check5_semver;              [ $? -eq 0 ] || FAILURES=$((FAILURES + 1))
+full_mode_requires_tag;     [ $? -eq 0 ] || FAILURES=$((FAILURES + 1))
 check6_tag_parity;          [ $? -eq 0 ] || FAILURES=$((FAILURES + 1))
 check7_ui_bundle;           [ $? -eq 0 ] || FAILURES=$((FAILURES + 1))
 check8_prepublish_gate;     [ $? -eq 0 ] || FAILURES=$((FAILURES + 1))


### PR DESCRIPTION
Refs #6508

Tagging before preflight burned trusty-common 0.46.1 and 0.46.3 this week (a semver failure after the tag push stranded an immutable tag, #6178). --check-only now SKIPs the expected pre-tag TAG-MISSING case (it hard-failed before, making a pre-tag check impossible), and full mode gains a stricter requirement that a tag must exist. TAG-SPLIT/TAG-DRIFT/VCS-INFO-MISMATCH still hard-fail in both modes. New 9-case selftest proven to fail against the old script. SKILL.md + release-workflow.md sequence updated to run --check-only before git tag. Guard-weakening scan: no publish guard loosened.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools