### PR TITLE
feat(trusty-console): native macOS TrustyConsole.saver bundle wrapping the screensaver route (#6520)

### DIFF
--- a/crates/trusty-console/changelog.d/6520-macos-saver-bundle.md
+++ b/crates/trusty-console/changelog.d/6520-macos-saver-bundle.md
@@ -1,0 +1,13 @@
+Added
+
+- A native macOS screen saver, `TrustyConsole.saver`, that displays the console
+  dashboard: one `ScreenSaverView` hosting a `WKWebView` on
+  `http://127.0.0.1:7788/ui/screensaver`. When the console is unreachable it
+  paints a native Foundry-dark fallback and retries every 15s; the System
+  Settings thumbnail renders the wordmark rather than spinning up a web view; and
+  it reloads hourly for long-run memory hygiene. Port and route are overridable
+  via `defaults -currentHost write com.trusty.console.saver ConsolePort <port>`.
+  Source in `crates/trusty-console/macos/saver/`, built and installed by
+  `scripts/build-console-saver.sh` and `scripts/install-console-saver.sh` —
+  ad-hoc signed by default, Developer ID with `CODESIGN_IDENTITY` set. macOS-only
+  (#6520).

--- a/crates/trusty-console/macos/saver/Info.plist
+++ b/crates/trusty-console/macos/saver/Info.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Template for TrustyConsole.saver/Contents/Info.plist (#6520).
+
+  scripts/build-console-saver.sh copies this file into the bundle and replaces
+  __CONSOLE_VERSION__ with the trusty-console crate version read from
+  crates/trusty-console/Cargo.toml. Edit this template, never the copy under
+  target/.
+
+  NSPrincipalClass must stay module-qualified (`<Module>.<Class>`): the Swift
+  class carries no @objc rename, so its runtime name is the mangled Swift name
+  that NSClassFromString only resolves from this form.
+
+  No NSAppTransportSecurity key by design — ATS reads the HOST application's
+  plist, not a plug-in's, and 127.0.0.1 is exempt from ATS regardless.
+-->
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>TrustyConsoleSaver</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.trusty.console.saver</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>TrustyConsole</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>__CONSOLE_VERSION__</string>
+	<key>CFBundleVersion</key>
+	<string>__CONSOLE_VERSION__</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>13.0</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>MIT — https://github.com/bobmatnyc/trusty-tools</string>
+	<key>NSPrincipalClass</key>
+	<string>TrustyConsoleSaver.TrustyConsoleSaverView</string>
+</dict>
+</plist>

--- a/crates/trusty-console/macos/saver/LoadHarness.swift
+++ b/crates/trusty-console/macos/saver/LoadHarness.swift
@@ -1,0 +1,123 @@
+// LoadHarness — bundle-load smoke test for TrustyConsole.saver (#6520).
+//
+// Why: the two ways a `.saver` bundle silently fails are (a) `NSPrincipalClass`
+//   not resolving to the Swift class, and (b) the WKWebView never reaching the
+//   console. Both are invisible in a normal screen-saver run — the screen just
+//   stays dark. This harness makes each one an exit code.
+// What: loads the bundle at `argv[1]`, resolves its principal class, instantiates
+//   it offscreen, calls `startAnimation()`, and waits for a `didFinish` os_log
+//   entry by polling the view's live/offline state through its web view.
+// Test: it IS the test. `scripts/build-console-saver.sh` builds the bundle it
+//   consumes; README.md, "Smoke test", has the invocation.
+//
+// It runs UNSANDBOXED, so a pass here proves the bundle and the URL are sound but
+// says nothing about the sandboxed `legacyScreenSaver.appex` host. The in-host run
+// stays manual.
+
+import AppKit
+import ScreenSaver
+import WebKit
+
+let args = CommandLine.arguments
+let bundlePath = args.count > 1
+    ? args[1]
+    : NSHomeDirectory() + "/Library/Screen Savers/TrustyConsole.saver"
+// Optional second argument: the console URL to point the view at, e.g.
+// http://127.0.0.1:7788/ui while #6519's /ui/screensaver route is unmerged.
+let overrideURL: URL? = args.count > 2 ? URL(string: args[2]) : nil
+
+func note(_ message: String) {
+    FileHandle.standardError.write("HARNESS: \(message)\n".data(using: .utf8)!)
+}
+
+// MARK: - Optional defaults override (restored before exit)
+
+let defaultsDomain = "com.trusty.console.saver"
+let portKey = "ConsolePort"
+let pathKey = "ConsolePath"
+let defaults = ScreenSaverDefaults(forModuleWithName: defaultsDomain)
+let priorPort = defaults?.object(forKey: portKey)
+let priorPath = defaults?.object(forKey: pathKey)
+
+func restoreDefaults() {
+    guard let defaults else { return }
+    if let priorPort { defaults.set(priorPort, forKey: portKey) } else { defaults.removeObject(forKey: portKey) }
+    if let priorPath { defaults.set(priorPath, forKey: pathKey) } else { defaults.removeObject(forKey: pathKey) }
+    defaults.synchronize()
+}
+
+func finish(_ code: Int32) -> Never {
+    restoreDefaults()
+    exit(code)
+}
+
+if let overrideURL {
+    guard let defaults, let port = overrideURL.port else {
+        note("override URL needs an explicit port: \(overrideURL.absoluteString)")
+        finish(6)
+    }
+    defaults.set(port, forKey: portKey)
+    defaults.set(overrideURL.path.isEmpty ? "/" : overrideURL.path, forKey: pathKey)
+    defaults.synchronize()
+    note("override applied: \(portKey)=\(port) \(pathKey)=\(overrideURL.path)")
+}
+
+// MARK: - Bundle load
+
+guard let bundle = Bundle(path: bundlePath) else {
+    note("Bundle(path:) returned nil for \(bundlePath)")
+    finish(2)
+}
+note("bundle=\(bundlePath) loaded=\(bundle.load())")
+
+guard let principal = bundle.principalClass else {
+    note("principalClass is nil — NSPrincipalClass did not resolve")
+    finish(3)
+}
+note("principalClass=\(principal)")
+
+guard let saverClass = principal as? ScreenSaverView.Type else {
+    note("principalClass is not a ScreenSaverView subclass")
+    finish(4)
+}
+
+// MARK: - Instantiate and animate offscreen
+
+let app = NSApplication.shared
+app.setActivationPolicy(.accessory)
+
+let frame = NSRect(x: 0, y: 0, width: 1280, height: 800)
+guard let view = saverClass.init(frame: frame, isPreview: false) else {
+    note("init(frame:isPreview:) returned nil")
+    finish(5)
+}
+
+let window = NSWindow(contentRect: frame, styleMask: [.borderless], backing: .buffered, defer: false)
+window.contentView = view
+window.orderFrontRegardless()
+window.setFrameOrigin(NSPoint(x: -5000, y: -5000)) // offscreen: do not disturb the operator
+view.startAnimation()
+note("startAnimation called; waiting up to 20s for the web view to finish loading")
+
+// The saver hides its web view until `didFinish` fires, so `isHidden == false` is
+// the observable form of "the console loaded".
+let deadline = Date().addingTimeInterval(20)
+var loaded = false
+while Date() < deadline && !loaded {
+    RunLoop.current.run(until: Date().addingTimeInterval(0.25))
+    if let web = view.subviews.compactMap({ $0 as? WKWebView }).first {
+        loaded = !web.isHidden
+    }
+}
+
+if let web = view.subviews.compactMap({ $0 as? WKWebView }).first {
+    note("web view url=\(web.url?.absoluteString ?? "<nil>") title=\(web.title ?? "<nil>")")
+}
+view.stopAnimation()
+
+if loaded {
+    note("PASS — web view visible, console load finished")
+    finish(0)
+}
+note("FAIL — web view never finished loading (console down, or the route 404s)")
+finish(7)

--- a/crates/trusty-console/macos/saver/README.md
+++ b/crates/trusty-console/macos/saver/README.md
@@ -1,0 +1,176 @@
+# TrustyConsole.saver — macOS screen saver
+
+A native macOS `.saver` bundle that displays the trusty-console dashboard as a
+screen saver. It is a thin wrapper: one `ScreenSaverView` hosting one
+`WKWebView` pointed at `http://127.0.0.1:7788/ui/screensaver`. Every pixel of the
+live view comes from the console SPA, so dashboard changes ship without
+rebuilding the bundle.
+
+Phase 4 of #6516 (issue #6520). macOS-only by construction — nothing here builds
+or runs on Linux, and no CI job covers it (see "Not covered" below).
+
+## Layout
+
+| File | Role |
+|---|---|
+| `TrustyConsoleSaver.swift` | The `ScreenSaverView` subclass. The whole implementation. |
+| `Info.plist` | Bundle plist template. `__CONSOLE_VERSION__` is replaced at build time. |
+| `LoadHarness.swift` | Bundle-load smoke test — resolves the principal class and asserts the page loads. |
+
+The bundle is assembled by `scripts/build-console-saver.sh` and copied into place
+by `scripts/install-console-saver.sh`, both at the repo root.
+
+## Build
+
+```bash
+bash scripts/build-console-saver.sh
+```
+
+Produces `target/console-saver/TrustyConsole.saver` and a `ditto` zip beside it.
+The build reads the crate version from `crates/trusty-console/Cargo.toml` and
+injects it as `CFBundleShortVersionString`, so the bundle and the crate never
+disagree. Every run rebuilds in place.
+
+Two environment variables:
+
+```bash
+SAVER_ARCHS="arm64 x86_64" bash scripts/build-console-saver.sh   # universal via lipo
+CODESIGN_IDENTITY="Developer ID Application: … (TEAMID)" bash scripts/build-console-saver.sh
+```
+
+`SAVER_ARCHS` defaults to `uname -m`. With `CODESIGN_IDENTITY` set the bundle is
+signed Developer ID with `--options runtime --timestamp`; without it, ad-hoc
+(`--sign -`). Either way the identifier is pinned to `com.trusty.console.saver`,
+matching the workspace's stable-identifier convention
+(`crates/trusty-installer/src/commands/macos_signing/mod.rs`,
+`codesign_identifier()`). That table covers flat binaries on `PATH`; a directory
+bundle is a different codesign shape and is signed by this script instead.
+
+**Ad-hoc is enough to run it locally.** Developer ID and notarization matter only
+for distribution past Gatekeeper — see "What the spike proved".
+
+## Install
+
+```bash
+bash scripts/install-console-saver.sh                    # build, then install
+bash scripts/install-console-saver.sh --from <bundle>    # install a prebuilt bundle
+bash scripts/install-console-saver.sh --dry-run          # print every step, touch nothing
+bash scripts/install-console-saver.sh --uninstall
+```
+
+It installs to `~/Library/Screen Savers/TrustyConsole.saver` with `cp -R`.
+
+**Why `cp` here and not `cargo install`.** CLAUDE.md bans `cp` for installing
+release *binaries* on macOS: a `cp` over an on-`PATH` executable leaves a stale
+kernel cdhash cache and the next exec is SIGKILL'd as an invalid signature. A
+`.saver` is a directory bundle in a location that holds no `PATH` executables,
+`cargo install` cannot produce one, and copying is Apple's own documented install
+for the format. The rule does not reach this artifact.
+
+## Verify
+
+```bash
+codesign --verify --deep --strict --verbose=2 ~/Library/Screen\ Savers/TrustyConsole.saver
+```
+
+### Smoke test (automated)
+
+```bash
+swiftc -swift-version 5 -o target/console-saver/harness/loadharness \
+  crates/trusty-console/macos/saver/LoadHarness.swift
+
+curl -s http://127.0.0.1:7788/health                    # console must be up
+./target/console-saver/harness/loadharness \
+  target/console-saver/TrustyConsole.saver \
+  http://127.0.0.1:7788/ui                              # optional URL override
+```
+
+Exit 0 means the principal class resolved and the page finished loading. Exit
+2–5 are bundle-load failures, 7 is "the page never loaded" (console down, or the
+route 404s). The optional second argument writes `ConsolePort`/`ConsolePath` into
+the module's own defaults domain and restores the previous values before exiting.
+
+The harness runs **unsandboxed**, so a pass proves the bundle, the class name and
+the URL — not that the sandboxed screen-saver host can reach the console.
+
+### Manual verification (still owed)
+
+The in-host run cannot be scripted. One operator step remains:
+
+> System Settings → Screen Saver → select **TrustyConsole** → Preview.
+
+Watch it decide, live:
+
+```bash
+log stream --predicate 'subsystem == "com.trusty.console.saver"'
+```
+
+Expect `init`, `loading`, then `didFinish`. An `offline` line instead means the
+sandboxed `legacyScreenSaver.appex` host could not reach 127.0.0.1 — the one
+thing the spike could not settle from outside the host.
+
+## Port and route override
+
+Both keys live in the module's per-host defaults domain:
+
+```bash
+defaults -currentHost write com.trusty.console.saver ConsolePort 7790
+defaults -currentHost write com.trusty.console.saver ConsolePath /ui   # pre-#6519 consoles
+defaults -currentHost delete com.trusty.console.saver                  # back to defaults
+```
+
+Defaults are port `7788` and path `/ui/screensaver`. An out-of-range port or a
+path not starting with `/` is ignored rather than trusted. There is no
+configuration sheet this phase (`hasConfigureSheet` is `false`).
+
+## Behaviour
+
+- **Live** — full-bounds `WKWebView` on the console route. `startAnimation()`
+  loads it; `stopAnimation()` navigates to `about:blank`, which tears down the
+  SPA and stops its metrics polling; the web view is released in `deinit`.
+- **Offline** — on `didFailProvisionalNavigation` / `didFail` / a dead WebContent
+  process, the web view is hidden and the view paints a native fallback: the
+  Foundry dark background (`#201612`) with monospace `TRUSTY CONSOLE · offline`.
+  It retries the load every 15 s while animating.
+- **Preview** — the System Settings thumbnail (`isPreview == true`) never
+  constructs a web view; it paints the wordmark in Foundry accent (`#d97742`).
+- **Hourly reload** while animating, for long-run memory hygiene. The SPA polls
+  its own data, so this is not a freshness mechanism.
+- **Multi-display** — the framework instantiates one view per screen, so each
+  display gets its own web view and timers. No coordination is attempted.
+
+Colours are copied from `docs/design/UI/design-system/tokens.css`
+(`[data-theme='dark']`); the fallback is drawn natively and cannot pick up the
+console's stylesheet.
+
+## What the spike proved
+
+A feasibility spike ran before this implementation. Four findings bind the code
+and must not be "cleaned up":
+
+1. **The principal class must be `public` and carry no `@objc(Name)` rename.** An
+   explicit ObjC name changes the runtime class name, and the module-qualified
+   `NSPrincipalClass` value then fails to resolve.
+2. **`NSPrincipalClass` is `TrustyConsoleSaver.TrustyConsoleSaverView`** — the
+   `<Module>.<Class>` form, which is what `NSClassFromString` resolves for a
+   mangled Swift name.
+3. **`swiftc -emit-library` output (an `MH_DYLIB`) loads fine as a bundle
+   executable.** No Xcode project, no `.xcodeproj`, no bundle-loader dance.
+4. **Ad-hoc signing loads inside the real host**, which carries
+   `com.apple.security.cs.disable-library-validation`. Developer ID and
+   notarization are a Gatekeeper-distribution concern, not a local-run one.
+
+And one thing deliberately absent: **no `NSAppTransportSecurity` key.** ATS reads
+the *host* application's plist, not a plug-in's, so the key is inert here — and
+127.0.0.1 is exempt from ATS regardless.
+
+Reference host for the spike: macOS 26.5.2 arm64, `LSMinimumSystemVersion 13.0`.
+
+## Not covered
+
+- **No CI job.** Every required check runs on Linux; a `.saver` needs a macOS
+  runner. Adding one is a follow-up, not part of #6520.
+- **No notarization step.** `scripts/build-console-saver.sh` stops at a signed,
+  zipped bundle. Stapling is a distribution concern and nothing distributes this
+  yet — see `docs/reference/release-workflow.md` for the workspace's Developer ID
+  setup.

--- a/crates/trusty-console/macos/saver/TrustyConsoleSaver.swift
+++ b/crates/trusty-console/macos/saver/TrustyConsoleSaver.swift
@@ -1,0 +1,294 @@
+// TrustyConsoleSaver — the macOS screen-saver bundle for trusty-console (#6520,
+// Phase 4 of epic #6516).
+//
+// Why: the console already renders a full machine-status dashboard at
+//   `/ui/screensaver` (#6519). macOS has no way to run a web page as a screen
+//   saver, so the route needs a native `.saver` bundle around it. This file is
+//   that wrapper and nothing more — every pixel of the live view comes from the
+//   console SPA, so dashboard changes ship without rebuilding the bundle.
+// What: a `ScreenSaverView` subclass hosting one full-bounds `WKWebView` pointed
+//   at `http://127.0.0.1:<port><path>`, with a native offline fallback, a 15 s
+//   retry while the console is down, and an hourly reload for long-run memory
+//   hygiene.
+// Test: `LoadHarness.swift` in this directory resolves the principal class,
+//   instantiates the view outside the screen-saver host and asserts `didFinish`
+//   fires. The in-host run is manual — see README.md, "Manual verification".
+//
+// Two constraints below are load-tested spike findings, not preference:
+//   * the class is `public` and carries NO `@objc(Name)` rename, so the runtime
+//     name stays the mangled Swift one that `NSPrincipalClass` resolves from its
+//     module-qualified `TrustyConsoleSaver.TrustyConsoleSaverView` form;
+//   * no `NSAppTransportSecurity` key is shipped in Info.plist — ATS reads the
+//     HOST's plist, not the plug-in's, and 127.0.0.1 is exempt from ATS anyway.
+
+import AppKit
+import Foundation
+import ScreenSaver
+import WebKit
+import os.log
+
+private let saverLog = OSLog(subsystem: "com.trusty.console.saver", category: "saver")
+
+/// Why: the offline and preview states are drawn natively, so they cannot pick up
+///   the console's stylesheet. Hardcoding the Foundry dark-theme values keeps the
+///   fallback visually continuous with the live dashboard.
+/// What: the four `[data-theme='dark']` tokens this view paints with, copied from
+///   `docs/design/UI/design-system/tokens.css`.
+/// Test: visual — the fallback matches the console's dark background.
+private enum Foundry {
+    /// `--trusty-content-bg: #201612`
+    static let background = NSColor(srgbRed: 0x20 / 255.0, green: 0x16 / 255.0, blue: 0x12 / 255.0, alpha: 1)
+    /// `--trusty-text-primary: #f0e7d8`
+    static let textPrimary = NSColor(srgbRed: 0xf0 / 255.0, green: 0xe7 / 255.0, blue: 0xd8 / 255.0, alpha: 1)
+    /// `--trusty-text-muted: #a58a6b`
+    static let textMuted = NSColor(srgbRed: 0xa5 / 255.0, green: 0x8a / 255.0, blue: 0x6b / 255.0, alpha: 1)
+    /// `--trusty-accent: #d97742`
+    static let accent = NSColor(srgbRed: 0xd9 / 255.0, green: 0x77 / 255.0, blue: 0x42 / 255.0, alpha: 1)
+}
+
+/// Why: the console's port is site-local — an operator who moved it off 7788 must
+///   be able to retarget the saver without a rebuild, and while #6519 is unmerged
+///   the route path itself has to be steerable at `/ui`.
+/// What: reads `ConsolePort` (integer) and `ConsolePath` (string) from the
+///   per-host screen-saver defaults domain `com.trusty.console.saver`, falling
+///   back to 7788 and `/ui/screensaver`. An out-of-range port or a path that does
+///   not start with `/` is ignored rather than trusted.
+/// Test: `LoadHarness.swift` writes both keys before instantiating the view and
+///   restores them afterwards, so a harness run exercises this resolution.
+struct SaverConfig {
+    static let defaultsDomain = "com.trusty.console.saver"
+    static let portKey = "ConsolePort"
+    static let pathKey = "ConsolePath"
+    static let defaultPort = 7788
+    static let defaultPath = "/ui/screensaver"
+
+    let port: Int
+    let path: String
+
+    var url: URL {
+        // 127.0.0.1 rather than localhost: no DNS, and it is the address the
+        // console binds by default (crates/trusty-console/src/bind.rs).
+        URL(string: "http://127.0.0.1:\(port)\(path)") ?? URL(fileURLWithPath: "/")
+    }
+
+    static func current() -> SaverConfig {
+        let defaults = ScreenSaverDefaults(forModuleWithName: defaultsDomain)
+        let storedPort = defaults?.integer(forKey: portKey) ?? 0
+        let port = (1...65535).contains(storedPort) ? storedPort : defaultPort
+
+        let storedPath = defaults?.string(forKey: pathKey) ?? ""
+        let path = storedPath.hasPrefix("/") ? storedPath : defaultPath
+
+        return SaverConfig(port: port, path: path)
+    }
+}
+
+/// Why: the principal class System Settings and `ScreenSaverEngine` instantiate.
+/// What: hosts the console dashboard in a `WKWebView`, or paints a native
+///   wordmark when the console is unreachable or macOS is only asking for the
+///   System Settings thumbnail.
+/// Test: `LoadHarness.swift`; in-host verification is manual (README.md).
+public final class TrustyConsoleSaverView: ScreenSaverView, WKNavigationDelegate {
+
+    /// What the view is currently showing. Only `.live` puts the web view on screen.
+    private enum DisplayState {
+        case live
+        case offline
+        case preview
+    }
+
+    /// Retry cadence while the console is unreachable.
+    private static let retryInterval: TimeInterval = 15
+    /// Full reload cadence while animating — long-run memory hygiene, not freshness
+    /// (the SPA polls its own data).
+    private static let reloadInterval: TimeInterval = 3600
+
+    private var webView: WKWebView?
+    private var retryTimer: Timer?
+    private var reloadTimer: Timer?
+    private var state: DisplayState
+    private let config = SaverConfig.current()
+
+    // The ScreenSaver framework instantiates ONE view per attached screen, so a
+    // multi-display machine runs N independent views, each with its own web view
+    // and timers. That is the framework default and needs no coordination here.
+    public override init?(frame: NSRect, isPreview: Bool) {
+        state = isPreview ? .preview : .offline
+        super.init(frame: frame, isPreview: isPreview)
+
+        animationTimeInterval = 1.0
+        autoresizingMask = [.width, .height]
+
+        os_log("init isPreview=%{public}@ url=%{public}@",
+               log: saverLog, type: .info,
+               String(describing: isPreview), config.url.absoluteString)
+
+        // The System Settings thumbnail is a few hundred pixels of a dashboard
+        // nobody can read, and spinning up a WebContent XPC child for it is pure
+        // cost. Preview draws the wordmark natively instead.
+        guard !isPreview else { return }
+
+        let web = WKWebView(frame: bounds, configuration: WKWebViewConfiguration())
+        web.autoresizingMask = [.width, .height]
+        web.navigationDelegate = self
+        web.setValue(false, forKey: "drawsBackground")
+        web.isHidden = true
+        addSubview(web)
+        webView = web
+    }
+
+    @available(*, unavailable)
+    public required init?(coder: NSCoder) {
+        fatalError("init(coder:) is not used by the screen-saver host")
+    }
+
+    deinit {
+        retryTimer?.invalidate()
+        reloadTimer?.invalidate()
+        webView?.navigationDelegate = nil
+        webView?.removeFromSuperview()
+        webView = nil
+    }
+
+    // MARK: - ScreenSaverView
+
+    public override func startAnimation() {
+        super.startAnimation()
+        guard state != .preview else { return }
+        loadConsole()
+        scheduleReloadTimer()
+    }
+
+    public override func stopAnimation() {
+        super.stopAnimation()
+        retryTimer?.invalidate()
+        retryTimer = nil
+        reloadTimer?.invalidate()
+        reloadTimer = nil
+        guard state != .preview else { return }
+        // about:blank tears down the SPA, which stops its metrics polling. Without
+        // this the console keeps being polled by an off-screen saver.
+        if let blank = URL(string: "about:blank") {
+            webView?.load(URLRequest(url: blank))
+        }
+        webView?.isHidden = true
+        state = .offline
+        os_log("stopAnimation — navigated away", log: saverLog, type: .info)
+    }
+
+    /// Why: the fallback has to render even when no web view exists (preview) or the
+    ///   web view is hidden (offline), and a transparent screen saver is
+    ///   indistinguishable from a crashed one.
+    /// What: fills the Foundry dark background, then centres the wordmark unless the
+    ///   live dashboard is on screen.
+    public override func draw(_ rect: NSRect) {
+        Foundry.background.setFill()
+        rect.fill()
+        guard state != .live else { return }
+        drawWordmark()
+    }
+
+    public override var hasConfigureSheet: Bool { false }
+    public override var configureSheet: NSWindow? { nil }
+
+    // MARK: - Loading
+
+    private func loadConsole() {
+        guard let webView else { return }
+        os_log("loading %{public}@", log: saverLog, type: .info, config.url.absoluteString)
+        var request = URLRequest(url: config.url)
+        request.cachePolicy = .reloadIgnoringLocalCacheData
+        webView.load(request)
+    }
+
+    private func scheduleReloadTimer() {
+        reloadTimer?.invalidate()
+        reloadTimer = Timer.scheduledTimer(withTimeInterval: Self.reloadInterval, repeats: true) { [weak self] _ in
+            guard let self, self.state == .live else { return }
+            os_log("hourly reload", log: saverLog, type: .info)
+            self.loadConsole()
+        }
+    }
+
+    private func scheduleRetryTimer() {
+        guard retryTimer == nil else { return }
+        retryTimer = Timer.scheduledTimer(withTimeInterval: Self.retryInterval, repeats: true) { [weak self] _ in
+            guard let self, self.state == .offline else { return }
+            self.loadConsole()
+        }
+    }
+
+    private func enterOffline(_ reason: String) {
+        state = .offline
+        webView?.isHidden = true
+        needsDisplay = true
+        os_log("offline — %{public}@", log: saverLog, type: .error, reason)
+        scheduleRetryTimer()
+    }
+
+    // MARK: - Native fallback
+
+    private func drawWordmark() {
+        let size = max(14, bounds.height * 0.035)
+        let font = NSFont.monospacedSystemFont(ofSize: size, weight: .medium)
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.alignment = .center
+
+        let text = NSMutableAttributedString(
+            string: "TRUSTY CONSOLE",
+            attributes: [
+                .font: font,
+                .foregroundColor: state == .preview ? Foundry.accent : Foundry.textPrimary,
+                .kern: size * 0.18,
+                .paragraphStyle: paragraph,
+            ])
+        if state == .offline {
+            text.append(NSAttributedString(
+                string: " · offline",
+                attributes: [
+                    .font: font,
+                    .foregroundColor: Foundry.textMuted,
+                    .kern: size * 0.18,
+                    .paragraphStyle: paragraph,
+                ]))
+        }
+
+        let drawn = text.size()
+        let origin = NSPoint(x: bounds.midX - drawn.width / 2, y: bounds.midY - drawn.height / 2)
+        text.draw(at: origin)
+    }
+
+    // MARK: - WKNavigationDelegate
+
+    public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        // stopAnimation()'s teardown navigation also lands here; treating it as a
+        // successful console load would put a blank page on screen.
+        guard webView.url?.absoluteString != "about:blank" else { return }
+        state = .live
+        retryTimer?.invalidate()
+        retryTimer = nil
+        webView.isHidden = false
+        needsDisplay = true
+        os_log("didFinish url=%{public}@ title=%{public}@",
+               log: saverLog, type: .info,
+               webView.url?.absoluteString ?? "<nil>", webView.title ?? "<nil>")
+    }
+
+    public func webView(_ webView: WKWebView,
+                        didFailProvisionalNavigation navigation: WKNavigation!,
+                        withError error: Error) {
+        enterOffline("didFailProvisionalNavigation " + Self.describe(error as NSError))
+    }
+
+    public func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        enterOffline("didFail " + Self.describe(error as NSError))
+    }
+
+    public func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
+        enterOffline("WebContent process terminated")
+    }
+
+    private static func describe(_ error: NSError) -> String {
+        "domain=\(error.domain) code=\(error.code) desc=\(error.localizedDescription)"
+    }
+}

--- a/scripts/build-console-saver.sh
+++ b/scripts/build-console-saver.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# scripts/build-console-saver.sh
+#
+# Why: trusty-console's screensaver route (#6519) needs a native macOS `.saver`
+# bundle to run as an actual screen saver (#6520, epic #6516). No existing
+# pipeline in this workspace produces a bundle — `tctl sign` and the
+# `install-trusty-*-signed.sh` scripts sign flat Mach-O binaries on PATH, which
+# is a different codesign shape. This is that missing pipeline.
+#
+# What: compiles crates/trusty-console/macos/saver/TrustyConsoleSaver.swift to a
+# dylib with swiftc, assembles target/console-saver/TrustyConsole.saver from it
+# plus the Info.plist template (injecting the trusty-console crate version),
+# lints the plist, codesigns the bundle, verifies the signature, and zips the
+# result with ditto.
+#
+# Signing: `CODESIGN_IDENTITY` set → Developer ID with `--options runtime
+# --timestamp` (Gatekeeper/notarization path). Unset → ad-hoc (`--sign -`), which
+# the real host still loads: `legacyScreenSaver.appex` carries
+# `com.apple.security.cs.disable-library-validation`, so an ad-hoc bundle is
+# loadable locally and only distribution needs the certificate.
+#
+# Usage:
+#   bash scripts/build-console-saver.sh                  # host arch
+#   SAVER_ARCHS="arm64 x86_64" bash scripts/build-console-saver.sh   # universal
+#   CODESIGN_IDENTITY="Developer ID Application: …" bash scripts/build-console-saver.sh
+#
+# Test: run it, then `crates/trusty-console/macos/saver/LoadHarness.swift`
+# against the bundle it produces — see that crate directory's README.md.
+#
+# Idempotent: every run removes and rebuilds the bundle and the zip in place.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SRC_DIR="$REPO_ROOT/crates/trusty-console/macos/saver"
+OUT_DIR="$REPO_ROOT/target/console-saver"
+OBJ_DIR="$OUT_DIR/obj"
+BUNDLE="$OUT_DIR/TrustyConsole.saver"
+ZIP="$OUT_DIR/TrustyConsole.saver.zip"
+CARGO_TOML="$REPO_ROOT/crates/trusty-console/Cargo.toml"
+
+MODULE_NAME="TrustyConsoleSaver"
+BUNDLE_ID="com.trusty.console.saver"
+DEPLOYMENT_TARGET="13.0"
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "ERROR: a .saver bundle is macOS-only; this host is $(uname -s)." >&2
+  exit 1
+fi
+
+for tool in swiftc codesign plutil ditto; do
+  command -v "$tool" >/dev/null 2>&1 || { echo "ERROR: $tool not found on PATH." >&2; exit 1; }
+done
+
+# The first top-level `version = "…"` in the crate manifest. Every line above it
+# is a `#` comment, so a first-match read is unambiguous.
+VERSION="$(awk -F'"' '/^version[[:space:]]*=/ { print $2; exit }' "$CARGO_TOML")"
+if [[ -z "$VERSION" ]]; then
+  echo "ERROR: could not read a version from $CARGO_TOML" >&2
+  exit 1
+fi
+
+ARCHS="${SAVER_ARCHS:-$(uname -m)}"
+
+echo "==> trusty-console $VERSION → $BUNDLE"
+echo "    archs: $ARCHS"
+
+rm -rf "$BUNDLE" "$OBJ_DIR"
+rm -f "$ZIP"
+mkdir -p "$OBJ_DIR" "$BUNDLE/Contents/MacOS"
+
+# --- compile ---------------------------------------------------------------
+SLICES=()
+for arch in $ARCHS; do
+  slice="$OBJ_DIR/$MODULE_NAME-$arch"
+  echo "==> swiftc $arch"
+  swiftc \
+    -emit-library \
+    -O \
+    -swift-version 5 \
+    -module-name "$MODULE_NAME" \
+    -framework ScreenSaver \
+    -framework WebKit \
+    -target "${arch}-apple-macosx${DEPLOYMENT_TARGET}" \
+    -o "$slice" \
+    "$SRC_DIR/TrustyConsoleSaver.swift"
+  SLICES+=("$slice")
+done
+
+EXECUTABLE="$BUNDLE/Contents/MacOS/$MODULE_NAME"
+if [[ "${#SLICES[@]}" -gt 1 ]]; then
+  echo "==> lipo ${#SLICES[@]} slices"
+  lipo -create "${SLICES[@]}" -output "$EXECUTABLE"
+else
+  cp "${SLICES[0]}" "$EXECUTABLE"
+fi
+chmod 755 "$EXECUTABLE"
+
+# --- assemble --------------------------------------------------------------
+cp "$SRC_DIR/Info.plist" "$BUNDLE/Contents/Info.plist"
+plutil -replace CFBundleShortVersionString -string "$VERSION" "$BUNDLE/Contents/Info.plist"
+plutil -replace CFBundleVersion -string "$VERSION" "$BUNDLE/Contents/Info.plist"
+plutil -lint "$BUNDLE/Contents/Info.plist"
+
+# --- sign ------------------------------------------------------------------
+if [[ -n "${CODESIGN_IDENTITY:-}" ]]; then
+  echo "==> codesign (Developer ID): $CODESIGN_IDENTITY"
+  codesign --force \
+    --sign "$CODESIGN_IDENTITY" \
+    --options runtime \
+    --timestamp \
+    --identifier "$BUNDLE_ID" \
+    "$BUNDLE"
+else
+  echo "==> codesign (ad-hoc; set CODESIGN_IDENTITY for a distributable bundle)"
+  codesign --force --sign - --identifier "$BUNDLE_ID" "$BUNDLE"
+fi
+
+codesign --verify --deep --strict --verbose=2 "$BUNDLE"
+codesign -dv "$BUNDLE"
+
+# --- package ---------------------------------------------------------------
+# ditto, not `zip`: it preserves the bundle structure and extended attributes
+# that notarization submission expects.
+ditto -c -k --sequesterRsrc --keepParent "$BUNDLE" "$ZIP"
+
+echo
+echo "bundle: $BUNDLE"
+echo "zip:    $ZIP"
+echo "install with: bash scripts/install-console-saver.sh --from \"$BUNDLE\""

--- a/scripts/install-console-saver.sh
+++ b/scripts/install-console-saver.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# scripts/install-console-saver.sh
+#
+# Why: `TrustyConsole.saver` is a directory bundle, not a binary on PATH, so the
+# workspace's "never `cp`, always `cargo install`" rule does not reach it — that
+# rule exists because a `cp` over an on-PATH executable strands the kernel's
+# cdhash cache and the next exec is SIGKILL'd. `~/Library/Screen Savers/` holds
+# no executables on PATH; macOS's own documented install for a `.saver` IS a copy
+# (#6520).
+#
+# What: builds the bundle (or takes a prebuilt one via `--from`), removes any
+# installed copy, `cp -R`s the new one into `~/Library/Screen Savers/`, prints the
+# installed path and its codesign verdict, and prints the one manual step that
+# cannot be automated. `--uninstall` removes it.
+#
+# Usage:
+#   bash scripts/install-console-saver.sh
+#   bash scripts/install-console-saver.sh --from target/console-saver/TrustyConsole.saver
+#   bash scripts/install-console-saver.sh --dry-run
+#   bash scripts/install-console-saver.sh --uninstall
+#
+# Test: `--dry-run` prints every rm/cp without touching the filesystem, so the
+# path resolution and both branches are exercisable without installing.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEST_DIR="$HOME/Library/Screen Savers"
+DEST="$DEST_DIR/TrustyConsole.saver"
+DEFAULT_SOURCE="$REPO_ROOT/target/console-saver/TrustyConsole.saver"
+
+SOURCE=""
+DRY_RUN=0
+UNINSTALL=0
+
+# Prints the header comment block — every `#` line after the shebang, stopping at
+# the first line that is not a comment. Kept range-free so an edit to the header
+# cannot silently spill `set -euo pipefail` into --help.
+usage() {
+  awk 'NR == 1 { next } /^#/ { sub(/^# ?/, ""); print; next } { exit }' "${BASH_SOURCE[0]}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --from)      SOURCE="${2:-}"; shift 2 ;;
+    --dry-run)   DRY_RUN=1; shift ;;
+    --uninstall) UNINSTALL=1; shift ;;
+    -h|--help)   usage; exit 0 ;;
+    *)           echo "ERROR: unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "ERROR: a .saver bundle is macOS-only; this host is $(uname -s)." >&2
+  exit 1
+fi
+
+run() {
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    printf 'DRY-RUN:'; printf ' %q' "$@"; printf '\n'
+    return 0
+  fi
+  "$@"
+}
+
+# --- uninstall -------------------------------------------------------------
+if [[ "$UNINSTALL" -eq 1 ]]; then
+  if [[ -d "$DEST" ]]; then
+    run rm -rf "$DEST"
+    echo "removed: $DEST"
+  else
+    echo "not installed: $DEST"
+  fi
+  echo
+  echo "System Settings caches the screen-saver list; it repopulates on reopen."
+  exit 0
+fi
+
+# --- build or adopt --------------------------------------------------------
+if [[ -z "$SOURCE" ]]; then
+  echo "==> building (no --from given)"
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "DRY-RUN: bash $REPO_ROOT/scripts/build-console-saver.sh"
+  else
+    bash "$REPO_ROOT/scripts/build-console-saver.sh"
+  fi
+  SOURCE="$DEFAULT_SOURCE"
+fi
+
+if [[ ! -d "$SOURCE" && "$DRY_RUN" -eq 0 ]]; then
+  echo "ERROR: no bundle at $SOURCE" >&2
+  exit 1
+fi
+
+# --- install ---------------------------------------------------------------
+run mkdir -p "$DEST_DIR"
+if [[ -d "$DEST" ]]; then
+  echo "==> replacing existing install"
+  run rm -rf "$DEST"
+fi
+run cp -R "$SOURCE" "$DEST"
+
+echo
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  echo "DRY-RUN: nothing was installed; the target would be $DEST"
+else
+  echo "installed: $DEST"
+  codesign --verify --deep --strict --verbose=2 "$DEST"
+  codesign -dv "$DEST"
+fi
+
+cat <<'EOF'
+
+MANUAL STEP — this cannot be scripted:
+  System Settings → Screen Saver → select "TrustyConsole", then Preview.
+
+  The console must be running and reachable at http://127.0.0.1:7788 (or the
+  port set with: defaults -currentHost write com.trusty.console.saver ConsolePort <port>).
+  Watch it live with:
+    log stream --predicate 'subsystem == "com.trusty.console.saver"'
+EOF


### PR DESCRIPTION
Phase 4 of epic #6516. `Refs #6520` (never `Closes`).

**What lands:** Swift `ScreenSaverView` + WKWebView under `crates/trusty-console/macos/saver/` (bundle id `com.trusty.console.saver`; `ConsolePort`/`ConsolePath` via `ScreenSaverDefaults`, default `127.0.0.1:7788/ui/screensaver`; offline native fallback with 15 s retry; hourly reload; `about:blank` on stop; preview renders the native view); `scripts/build-console-saver.sh` (swiftc, universal via `SAVER_ARCHS`, plist lint, `CODESIGN_IDENTITY` or ad-hoc, verify, zip); `scripts/install-console-saver.sh` (`--from/--dry-run/--uninstall`); README. Not a workspace crate; no version bump; separate release artifact.

**Evidence:** build EXIT 0 arm64 and universal, `codesign --verify --deep --strict` valid; LoadHarness against the built bundle with the live console → `principalClass=TrustyConsoleSaverView`, `title=Trusty Console`, PASS; dead-port run → `NSURLErrorDomain -1004`, retry at 15 s; `shellcheck` clean on both scripts; line-cap / sld / public-docs / doc-numbers / changelog gates clean.

**Spike record on the issue:** sandboxed loopback networking under the `legacyScreenSaver.appex` entitlement mirror is REACHABLE. Still owed, manual: System Settings → Screen Saver → select "TrustyConsole" → Preview (the sandboxed appex host itself). Not covered: a macOS CI job, notarization.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
