### PR TITLE
fix(trusty-mpm): batch — squash-merge reclaim (#6507), dead-session worktree adoption (#6497)

### DIFF
--- a/crates/trusty-mpm/changelog.d/6497-adopt-dead-owners-worktree.md
+++ b/crates/trusty-mpm/changelog.d/6497-adopt-dead-owners-worktree.md
@@ -1,0 +1,10 @@
+Added
+
+- `tm session adopt-worktree <path> --as <session>` transfers a worktree whose
+  owning session or agent is provably dead to a live session, by rewriting the
+  ownership sentinel. The daemon refuses unless the current owner is positively
+  known to have ended and no live delegation is still working in the tree; an
+  owner the delegation registry has merely never heard of is undeterminable and
+  refuses too (ADR-0045). The verb is EXPLICIT rather than automatic — a design
+  choice this change makes, since a tree that changes hands on its own is
+  indistinguishable from one taken from a working agent (#6497).

--- a/crates/trusty-mpm/changelog.d/6497-reap-stales-dead-session-delegations.md
+++ b/crates/trusty-mpm/changelog.d/6497-reap-stales-dead-session-delegations.md
@@ -1,0 +1,9 @@
+Fixed
+
+- The session reaper now marks a dead session's live delegations `Stale` in the
+  same pass that buries the session. Their `SubagentStop` never arrives, so the
+  records read as live for six hours and reported the dead session's agents as
+  writing in the shared checkout — which refused a successor's serialized
+  dispatch with no verb to clear it. Staling records that the owner is gone, not
+  that the agent finished, so a late stop still resolves the record; a session
+  the reaper leaves alone keeps every delegation live (#6497).

--- a/crates/trusty-mpm/changelog.d/6507-squash-merge-reclaim.md
+++ b/crates/trusty-mpm/changelog.d/6507-squash-merge-reclaim.md
@@ -1,0 +1,11 @@
+Fixed
+
+- `tm session prune-worktrees --merged-prs` now reclaims worktrees whose pull
+  request was SQUASH-merged. A squash replays a branch as one new commit on
+  `main`, and `gh pr merge --squash --delete-branch` then removes the remote
+  branch, so every landed commit read as unpushed and the dirty-work gate
+  refused the tree — the flag reclaimed nothing on a repository that
+  squash-merges. The gate now discounts a commit only when `git cherry` proves
+  its patch is already on a remote landing branch; a commit that landed nowhere
+  is still refused, and an unanswerable comparison leaves the count untouched
+  (#6507).

--- a/crates/trusty-mpm/src/bin/tm/cli/actions/session.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli/actions/session.rs
@@ -563,4 +563,24 @@ pub(crate) enum SessionAction {
         #[arg(long)]
         json: bool,
     },
+    /// Take over a worktree whose owning session or agent is dead (#6497).
+    ///
+    /// Why: a session can die holding an agent's worktree that still contains
+    /// uncommitted work, and until this verb a successor had no compliant way
+    /// to finish it — every write route in was refused because the sentinel
+    /// still named the dead owner, and the recorded workaround rebuilt the
+    /// branch by hand in a new tree.
+    /// What: POSTs `/api/v1/sessions/managed/adopt-worktree`. The daemon
+    /// refuses unless the current owner is POSITIVELY known to have ended and
+    /// nothing live is still working in the tree; on success the ownership
+    /// sentinel names `--as` instead. It moves no files and commits nothing.
+    /// Test: `cli_parses_session_adopt_worktree`,
+    /// `cli_adopt_worktree_requires_the_adopting_session`.
+    AdoptWorktree {
+        /// The worktree directory whose ownership is being transferred.
+        path: std::path::PathBuf,
+        /// The managed session that becomes the new owner.
+        #[arg(long = "as")]
+        as_session: String,
+    },
 }

--- a/crates/trusty-mpm/src/bin/tm/commands/adopt_worktree.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/adopt_worktree.rs
@@ -1,0 +1,47 @@
+//! `tm session adopt-worktree` — transfer a dead owner's worktree to a live
+//! session (#6497).
+//!
+//! Why: `session.rs` is a dispatch table, and this verb needs a refusal path of
+//! its own: the daemon answers a refusal with 409 and the gate's own reason,
+//! which the operator has to read verbatim rather than as a generic HTTP error.
+//! What: one POST; the refusal reason is printed and the process exits
+//! non-zero, so a script cannot mistake a refusal for a transfer.
+//! Test: `cli_parses_session_adopt_worktree`,
+//! `cli_adopt_worktree_requires_the_adopting_session`.
+
+use std::path::Path;
+
+/// POST the adoption request and report what the daemon decided (#6497).
+///
+/// Why: the daemon owns the decision — it is the only process holding both the
+/// delegation map and the session-record store — so this function's whole job
+/// is to carry the answer back without softening it.
+/// What: 200 prints the new owner; 409 prints the refusal reason and returns an
+/// error so the exit status is non-zero; anything else surfaces as the HTTP
+/// error it is.
+/// Test: `cli_parses_session_adopt_worktree`.
+pub(crate) async fn session_adopt_worktree(
+    client: &reqwest::Client,
+    url: &str,
+    path: &Path,
+    as_session: &str,
+) -> anyhow::Result<()> {
+    let resp = client
+        .post(format!("{url}/api/v1/sessions/managed/adopt-worktree"))
+        .json(&serde_json::json!({ "path": path, "as_session": as_session }))
+        .send()
+        .await?;
+    let status = resp.status();
+    let body = resp.text().await.unwrap_or_default();
+    if status.as_u16() == 409 {
+        // The gate's own words. Paraphrasing them would hide which of the three
+        // refusal arms fired, which is the only thing that tells the operator
+        // what to do next.
+        anyhow::bail!("adoption refused: {body}");
+    }
+    if !status.is_success() {
+        anyhow::bail!("adopt-worktree failed ({status}): {body}");
+    }
+    println!("adopted {} as {as_session}", path.display());
+    Ok(())
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/mod.rs
@@ -14,6 +14,9 @@
 //! Test: each module has its own unit tests; integration coverage lives in
 //! `tests.rs`.
 
+// #6497: `tm session adopt-worktree` — the explicit ownership transfer for a
+// tree whose owning session or agent is provably dead.
+pub(crate) mod adopt_worktree;
 pub(crate) mod agent;
 pub(crate) mod auth;
 // #6274: `tm` in a plain directory initializes a repository there instead of

--- a/crates/trusty-mpm/src/bin/tm/commands/session.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session.rs
@@ -431,6 +431,13 @@ pub(crate) async fn session(
             crate::commands::reconcile_worktrees::session_reconcile_worktrees(client, url, json)
                 .await?
         }
+        // #6497: the transfer the reconcile report can only propose. Explicit
+        // by design — a tree that changes hands on its own is indistinguishable
+        // from one taken out from under a working agent.
+        SessionAction::AdoptWorktree { path, as_session } => {
+            crate::commands::adopt_worktree::session_adopt_worktree(client, url, &path, &as_session)
+                .await?
+        }
         // #2444: re-sync a live session's (or every syncable session's)
         // deployed assets against the current catalog. Fleet-wide store
         // operation like `Prune`/`DecommissionEphemeral` above — direct HTTP,

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_d_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_d_tests.rs
@@ -699,6 +699,45 @@ fn cli_reconcile_worktrees_takes_no_destructive_flag() {
     }
 }
 
+/// #6497: the adoption verb parses a path and the session taking it over.
+#[test]
+fn cli_parses_session_adopt_worktree() {
+    let cli = Cli::try_parse_from([
+        "trusty-mpm",
+        "session",
+        "adopt-worktree",
+        "/repo/.claude/worktrees/agent-abc",
+        "--as",
+        "11111111-2222-3333-4444-555555555555",
+    ])
+    .unwrap();
+    match cli.command.unwrap() {
+        Command::Session {
+            action: SessionAction::AdoptWorktree { path, as_session },
+        } => {
+            assert_eq!(
+                path,
+                std::path::PathBuf::from("/repo/.claude/worktrees/agent-abc")
+            );
+            assert_eq!(as_session, "11111111-2222-3333-4444-555555555555");
+        }
+        other => panic!("expected session adopt-worktree, got {other:?}"),
+    }
+}
+
+/// #6497: adoption names its new owner or does not run.
+///
+/// Why: a transfer with no stated recipient would have to invent one, and the
+/// invented answer — "whoever is running this command" — is exactly the
+/// implicit ownership change this verb exists to replace.
+#[test]
+fn cli_adopt_worktree_requires_the_adopting_session() {
+    assert!(
+        Cli::try_parse_from(["trusty-mpm", "session", "adopt-worktree", "/repo/tree"]).is_err(),
+        "`adopt-worktree` without `--as` must not parse"
+    );
+}
+
 #[test]
 fn cli_parses_sessions_sync_assets() {
     // #2444: `sync-assets <id>` re-syncs ONE session.

--- a/crates/trusty-mpm/src/daemon/managed_routes/adopt_worktree.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/adopt_worktree.rs
@@ -1,0 +1,151 @@
+//! POST /api/v1/sessions/managed/adopt-worktree — hand a dead owner's worktree
+//! to a live session (#6497).
+//!
+//! Why: the policy in
+//! [`crate::session_manager::worktree_adopt`] needs two liveness answers that
+//! live in two different registries — a dispatched agent's in the delegation
+//! map, a managed session's in the session-record store — and only the daemon
+//! holds both. Answering them here keeps the policy a pure function and keeps
+//! the CLI from having to re-derive liveness over several round trips and guess
+//! when one of them is silent.
+//!
+//! What: one POST carrying the worktree `path` and the `as_session` taking it
+//! over. The daemon reads the ownership sentinel, resolves the CURRENT owner's
+//! liveness through whichever registry owns it, collects the agents any live
+//! delegation still has working inside the tree, and runs
+//! [`evaluate_adoption`](crate::session_manager::worktree_adopt::evaluate_adoption).
+//! A refusal is a 409 carrying the policy's own reason; nothing is written.
+//!
+//! It changes ONE thing on disk: the sentinel. It moves no files, commits
+//! nothing, and creates and deletes no worktree.
+//! Test: `adopt_worktree_route_refuses_a_live_owner`,
+//! `adopt_worktree_route_transfers_a_dead_owners_tree`.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use axum::{Json, extract::State, response::IntoResponse};
+use serde::Deserialize;
+
+use crate::daemon::rpc::managed::outcome::RouteOutcome;
+use crate::daemon::services::agent_worktree_reap::delegation_state_for_agent;
+use crate::daemon::state::DaemonState;
+use crate::session_manager::record::ManagedSessionId;
+use crate::session_manager::worktree_adopt::{
+    AdoptionVerdict, OwnerLiveness, adopt_worktree, evaluate_adoption,
+};
+use crate::session_manager::worktree_ownership::{SentinelOwner, read_sentinel_owner};
+
+/// The request body: which tree, and which session takes it (#6497).
+#[derive(Debug, Deserialize)]
+pub struct AdoptWorktreeRequest {
+    /// The worktree whose ownership sentinel is being rewritten.
+    pub path: PathBuf,
+    /// The managed session that becomes the new owner.
+    pub as_session: ManagedSessionId,
+}
+
+/// POST /api/v1/sessions/managed/adopt-worktree (#6497).
+///
+/// Test: `adopt_worktree_route_refuses_a_live_owner`,
+/// `adopt_worktree_route_transfers_a_dead_owners_tree`.
+pub async fn adopt_worktree_route(
+    State(state): State<Arc<DaemonState>>,
+    Json(req): Json<AdoptWorktreeRequest>,
+) -> impl IntoResponse {
+    adopt_worktree_core(&state, req).await
+}
+
+/// The transport-neutral body of `POST .../managed/adopt-worktree` (#6497).
+///
+/// Why: mirrors [`super::reconcile::reconcile_worktrees_core`] so a socket
+/// transport can serve the same verb without a second copy of the policy call.
+/// What: resolves the owner's liveness, runs the pure gate, and writes the
+/// sentinel only on [`AdoptionVerdict::Adopt`]. A refusal is a 409 whose body
+/// is the gate's own reason, so the operator reads exactly what the guard read.
+/// Test: `adopt_worktree_route_refuses_a_live_owner`,
+/// `adopt_worktree_route_transfers_a_dead_owners_tree`.
+pub(crate) async fn adopt_worktree_core(
+    state: &Arc<DaemonState>,
+    req: AdoptWorktreeRequest,
+) -> RouteOutcome {
+    let owner = read_sentinel_owner(&req.path);
+    let liveness = owner_liveness(state, &owner).await;
+    let claimants = live_claimants_in(state, &req.path);
+    match evaluate_adoption(&req.path, &owner, liveness, &claimants) {
+        AdoptionVerdict::Refuse(reason) => {
+            tracing::info!(path = %req.path.display(), %reason, "adopt-worktree: refused (#6497)");
+            RouteOutcome::text(409, reason)
+        }
+        AdoptionVerdict::Adopt => match adopt_worktree(&req.path, req.as_session) {
+            Ok(()) => {
+                tracing::info!(
+                    path = %req.path.display(),
+                    owner = %req.as_session,
+                    "adopt-worktree: ownership transferred (#6497)"
+                );
+                RouteOutcome::ok(&serde_json::json!({
+                    "adopted": true,
+                    "path": req.path,
+                    "owner": req.as_session.to_string(),
+                }))
+            }
+            Err(e) => RouteOutcome::text(500, format!("sentinel rewrite failed: {e}")),
+        },
+    }
+}
+
+/// What the registry owning `owner` says about its liveness (#6497).
+///
+/// Why: the two owner shapes resolve through different registries, and only one
+/// of them can distinguish "ended" from "never heard of" — so the mapping is
+/// per-shape rather than one lookup with a fallback.
+/// What: a dispatched agent goes through the delegation map, which
+/// [`OwnerLiveness::from_agent_state`] reads with #5661's absent-vs-
+/// undeterminable split; a managed session goes through the session-record
+/// store's own terminal-state check, whose grace window already covers a
+/// sentinel written before its record was persisted. An unreadable sentinel is
+/// undeterminable and gate 1 refuses it before this answer matters.
+/// Test: `adopt_worktree_route_refuses_a_live_owner`.
+async fn owner_liveness(state: &Arc<DaemonState>, owner: &SentinelOwner) -> OwnerLiveness {
+    match owner {
+        SentinelOwner::Agent(agent, _) => {
+            OwnerLiveness::from_agent_state(delegation_state_for_agent(state, &agent.agent_id))
+        }
+        SentinelOwner::Known(session, created_at) => {
+            let mgr = state.session_manager().await;
+            if mgr
+                .resolve_ownerless_with_grace(*session, *created_at)
+                .await
+            {
+                OwnerLiveness::Dead
+            } else {
+                OwnerLiveness::Alive
+            }
+        }
+        SentinelOwner::Unknown => OwnerLiveness::Undeterminable,
+    }
+}
+
+/// The agents any LIVE delegation still has working inside `path` (#6497).
+///
+/// Why: the sentinel names who PROVISIONED the tree, never everyone who is in
+/// it. A successor dispatched into an adopted tree, or a sibling agent that was
+/// pointed at it, is a claim the sentinel cannot see — and taking the tree out
+/// from under one is the same harm as taking it from its owner.
+/// What: every live delegation whose recorded `cwd` is the tree or sits beneath
+/// it, by agent name. A delegation with no recorded `cwd` claims nothing here.
+/// Test: `adopt_worktree_route_refuses_a_live_owner` covers the empty case;
+/// the populated case is `adoption_refuses_a_tree_something_still_works_in`.
+fn live_claimants_in(state: &Arc<DaemonState>, path: &Path) -> Vec<String> {
+    state
+        .all_delegations()
+        .into_iter()
+        .filter(|d| d.status.is_live() && d.cwd.as_deref().is_some_and(|cwd| cwd.starts_with(path)))
+        .map(|d| d.agent)
+        .collect()
+}
+
+#[cfg(test)]
+#[path = "adopt_worktree_tests.rs"]
+mod adopt_worktree_tests;

--- a/crates/trusty-mpm/src/daemon/managed_routes/adopt_worktree.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/adopt_worktree.rs
@@ -63,8 +63,24 @@ pub async fn adopt_worktree_route(
 /// What: resolves the owner's liveness, runs the pure gate, and writes the
 /// sentinel only on [`AdoptionVerdict::Adopt`]. A refusal is a 409 whose body
 /// is the gate's own reason, so the operator reads exactly what the guard read.
+///
+/// **The claimant set is read TWICE, and the second read is what the write
+/// stands on.** `owner_liveness` awaits the session-manager store, so the first
+/// read can be milliseconds old by the time the sentinel is written, and a
+/// dispatch landing in that window records a `cwd` under the tree this call is
+/// about to hand away. Re-asking immediately before the write is the two-pass
+/// shape [`dirt_blocks_removal`](crate::session_manager::worktree_safety::dirt_blocks_removal)
+/// already uses on the reclaim path.
+///
+/// It NARROWS the window rather than closing it: nothing holds a lock across
+/// the check and the write, so a delegation recorded between the second read and
+/// the `std::fs::write` is still missed. Closing it needs a per-path lock the
+/// daemon does not have today, and the residual costs an adoption racing a
+/// dispatch into the same tree — an operator-typed verb racing a dispatch, not
+/// two automatic sweeps.
 /// Test: `adopt_worktree_route_refuses_a_live_owner`,
-/// `adopt_worktree_route_transfers_a_dead_owners_tree`.
+/// `adopt_worktree_route_transfers_a_dead_owners_tree`,
+/// `adopt_worktree_route_refuses_a_claimant_under_a_symlinked_spelling`.
 pub(crate) async fn adopt_worktree_core(
     state: &Arc<DaemonState>,
     req: AdoptWorktreeRequest,
@@ -77,20 +93,35 @@ pub(crate) async fn adopt_worktree_core(
             tracing::info!(path = %req.path.display(), %reason, "adopt-worktree: refused (#6497)");
             RouteOutcome::text(409, reason)
         }
-        AdoptionVerdict::Adopt => match adopt_worktree(&req.path, req.as_session) {
-            Ok(()) => {
-                tracing::info!(
-                    path = %req.path.display(),
-                    owner = %req.as_session,
-                    "adopt-worktree: ownership transferred (#6497)"
+        // #6497: re-ask who is in the tree, now, immediately before the write.
+        AdoptionVerdict::Adopt => match evaluate_adoption(
+            &req.path,
+            &owner,
+            liveness,
+            &live_claimants_in(state, &req.path),
+        ) {
+            AdoptionVerdict::Refuse(reason) => {
+                tracing::warn!(
+                    path = %req.path.display(), %reason,
+                    "adopt-worktree: re-check refused a claim that passed the first pass (#6497)"
                 );
-                RouteOutcome::ok(&serde_json::json!({
-                    "adopted": true,
-                    "path": req.path,
-                    "owner": req.as_session.to_string(),
-                }))
+                RouteOutcome::text(409, reason)
             }
-            Err(e) => RouteOutcome::text(500, format!("sentinel rewrite failed: {e}")),
+            AdoptionVerdict::Adopt => match adopt_worktree(&req.path, req.as_session) {
+                Ok(()) => {
+                    tracing::info!(
+                        path = %req.path.display(),
+                        owner = %req.as_session,
+                        "adopt-worktree: ownership transferred (#6497)"
+                    );
+                    RouteOutcome::ok(&serde_json::json!({
+                        "adopted": true,
+                        "path": req.path,
+                        "owner": req.as_session.to_string(),
+                    }))
+                }
+                Err(e) => RouteOutcome::text(500, format!("sentinel rewrite failed: {e}")),
+            },
         },
     }
 }
@@ -135,15 +166,57 @@ async fn owner_liveness(state: &Arc<DaemonState>, owner: &SentinelOwner) -> Owne
 /// from under one is the same harm as taking it from its owner.
 /// What: every live delegation whose recorded `cwd` is the tree or sits beneath
 /// it, by agent name. A delegation with no recorded `cwd` claims nothing here.
-/// Test: `adopt_worktree_route_refuses_a_live_owner` covers the empty case;
-/// the populated case is `adoption_refuses_a_tree_something_still_works_in`.
+///
+/// **Both sides are compared in BOTH spellings.** A raw `starts_with` is
+/// component-wise, so `/a/bc` never matches `/a/b` — but it is also purely
+/// lexical, and a delegation's `cwd` and the request's `path` routinely reach
+/// this function through different symlinks. On macOS every `TempDir` is under
+/// `/var`, which IS `/private/var`, so one side canonicalized and the other not
+/// is the ordinary case rather than the exotic one. A missed match here means
+/// adoption proceeds against a tree an agent is still writing in. So each side
+/// contributes its canonical form AND its raw form, and any pairing that matches
+/// refuses — the same both-spellings pattern
+/// [`is_live`](crate::session_manager::worktree_reclaim::is_live) uses, for the
+/// same reason: a failed canonicalization may only ever spare a tree.
+///
+/// The containment stays one-directional on purpose. `is_live` also counts a
+/// claimed path that CONTAINS the candidate, because a session standing in a
+/// parent still owns it. Here that would count every delegation recorded in the
+/// enclosing checkout — which is exactly the population #6497 is about — and
+/// refuse every adoption in the reported scenario.
+/// Test: `adopt_worktree_route_refuses_a_claimant_under_a_symlinked_spelling`,
+/// `adopt_worktree_route_refuses_a_claimant_under_a_trailing_slash_spelling`,
+/// `adopt_worktree_route_refuses_a_live_owner` covers the empty case.
 fn live_claimants_in(state: &Arc<DaemonState>, path: &Path) -> Vec<String> {
+    let tree_forms = both_spellings(path);
     state
         .all_delegations()
         .into_iter()
-        .filter(|d| d.status.is_live() && d.cwd.as_deref().is_some_and(|cwd| cwd.starts_with(path)))
+        .filter(|d| d.status.is_live())
+        .filter(|d| {
+            d.cwd.as_deref().is_some_and(|cwd| {
+                both_spellings(cwd)
+                    .iter()
+                    .any(|c| tree_forms.iter().any(|t| c.starts_with(t)))
+            })
+        })
         .map(|d| d.agent)
         .collect()
+}
+
+/// A path's canonical form and its raw form (#6497).
+///
+/// Why: canonicalization resolves symlinks and `..`, and fails outright for a
+/// path that no longer exists. Keeping the raw form alongside it means a failed
+/// resolution degrades to today's lexical comparison instead of dropping the
+/// path from the comparison entirely.
+/// What: `[canonical, raw]`, which may be the same path twice — the caller only
+/// ever asks whether ANY pairing matches, so a duplicate costs one comparison.
+fn both_spellings(path: &Path) -> [PathBuf; 2] {
+    [
+        std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf()),
+        path.to_path_buf(),
+    ]
 }
 
 #[cfg(test)]

--- a/crates/trusty-mpm/src/daemon/managed_routes/adopt_worktree_tests.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/adopt_worktree_tests.rs
@@ -13,6 +13,20 @@ use crate::core::session::SessionId;
 use crate::session_manager::decommission::WORKTREE_SENTINEL_FILE;
 use crate::session_manager::worktree_ownership::{AgentWorktreeOwner, WorktreeSentinel};
 
+/// Write an AGENT ownership sentinel naming `agent_id` into `dir`.
+fn write_agent_sentinel(dir: &std::path::Path, agent_id: &str, parent: SessionId) {
+    let payload = WorktreeSentinel::for_agent(AgentWorktreeOwner {
+        agent_id: agent_id.to_string(),
+        delegation_id: crate::core::agent::DelegationId::new(),
+        parent_session_id: parent,
+    });
+    std::fs::write(
+        dir.join(WORKTREE_SENTINEL_FILE),
+        serde_json::to_vec(&payload).expect("serialize sentinel"),
+    )
+    .expect("write sentinel");
+}
+
 /// A directory carrying an AGENT ownership sentinel naming `agent_id`.
 fn agent_owned_tree(agent_id: &str) -> (tempfile::TempDir, SessionId) {
     let dir = tempfile::tempdir().expect("tempdir");
@@ -93,5 +107,119 @@ async fn adopt_worktree_route_transfers_a_dead_owners_tree() {
     match read_sentinel_owner(tree.path()) {
         SentinelOwner::Known(id, _) => assert_eq!(id, successor),
         other => panic!("the sentinel must name the adopting session; got {other:?}"),
+    }
+}
+
+/// A tree that exists under two names — `<tmp>/real/tree` and, through a
+/// symlinked parent, `<tmp>/link/tree` — with an ENDED owner, so only the
+/// claimant gate can refuse.
+///
+/// Returns the tempdir, the real spelling, and the symlinked spelling.
+fn symlinked_tree(
+    state: &Arc<DaemonState>,
+    agent_id: &str,
+) -> (tempfile::TempDir, std::path::PathBuf, std::path::PathBuf) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = std::fs::canonicalize(tmp.path()).expect("canonicalize tempdir");
+    let real = root.join("real");
+    std::fs::create_dir_all(real.join("tree")).expect("mkdir real/tree");
+    std::os::unix::fs::symlink(&real, root.join("link")).expect("symlink");
+
+    let parent = SessionId::new();
+    write_agent_sentinel(&real.join("tree"), agent_id, parent);
+    state.upsert_delegation(delegation_for(
+        parent,
+        agent_id,
+        DelegationStatus::Completed,
+    ));
+    (tmp, real.join("tree"), root.join("link").join("tree"))
+}
+
+/// A live delegation working in the tree under a DIFFERENT-but-equivalent
+/// spelling still refuses adoption.
+///
+/// Why this is the gate's real failure mode rather than an exotic one: a raw
+/// `starts_with` is lexical, and the delegation's `cwd` and the request's path
+/// routinely reach the daemon through different symlinks. Missing the match
+/// hands away a tree an agent is writing in.
+#[tokio::test]
+async fn adopt_worktree_route_refuses_a_claimant_under_a_symlinked_spelling() {
+    let state = Arc::new(DaemonState::new());
+    let (_tmp, real, linked) = symlinked_tree(&state, "agent-ended-symlink");
+
+    // The claimant records the REAL spelling; the request asks under the
+    // SYMLINKED one. Lexically these share no prefix.
+    let mut claimant = delegation_for(SessionId::new(), "other-agent", DelegationStatus::Running);
+    claimant.agent = "rust-engineer".to_string();
+    claimant.cwd = Some(real.clone());
+    state.upsert_delegation(claimant);
+    assert!(
+        !linked.starts_with(&real),
+        "the fixture must present two spellings a lexical prefix test cannot relate"
+    );
+
+    let outcome = adopt_worktree_core(
+        &state,
+        AdoptWorktreeRequest {
+            path: linked.clone(),
+            as_session: ManagedSessionId::new(),
+        },
+    )
+    .await;
+
+    assert_eq!(
+        outcome.status, 409,
+        "a live claimant under an equivalent spelling must refuse; body was: {:?}",
+        outcome.body
+    );
+    // And the reverse direction: request the real path, claim the linked one.
+    let state = Arc::new(DaemonState::new());
+    let (_tmp2, real2, linked2) = symlinked_tree(&state, "agent-ended-symlink-2");
+    let mut claimant = delegation_for(SessionId::new(), "other-agent", DelegationStatus::Running);
+    claimant.agent = "rust-engineer".to_string();
+    claimant.cwd = Some(linked2);
+    state.upsert_delegation(claimant);
+    let outcome = adopt_worktree_core(
+        &state,
+        AdoptWorktreeRequest {
+            path: real2,
+            as_session: ManagedSessionId::new(),
+        },
+    )
+    .await;
+    assert_eq!(outcome.status, 409, "the mirror spelling must refuse too");
+}
+
+/// The same tree spelled with a trailing slash, and with a `..` hop through it,
+/// still refuses. Both are the ordinary shapes a recorded `cwd` arrives in.
+#[tokio::test]
+async fn adopt_worktree_route_refuses_a_claimant_under_a_trailing_slash_spelling() {
+    for spelling in ["trailing-slash", "dot-dot"] {
+        let state = Arc::new(DaemonState::new());
+        let (_tmp, real, _linked) = symlinked_tree(&state, "agent-ended-slash");
+        let cwd = match spelling {
+            "trailing-slash" => std::path::PathBuf::from(format!("{}/", real.display())),
+            _ => real.join("..").join("tree"),
+        };
+
+        let mut claimant =
+            delegation_for(SessionId::new(), "other-agent", DelegationStatus::Running);
+        claimant.agent = "rust-engineer".to_string();
+        claimant.cwd = Some(cwd);
+        state.upsert_delegation(claimant);
+
+        let outcome = adopt_worktree_core(
+            &state,
+            AdoptWorktreeRequest {
+                path: real,
+                as_session: ManagedSessionId::new(),
+            },
+        )
+        .await;
+        assert_eq!(
+            outcome.status, 409,
+            "the {spelling} spelling must refuse; body was: {:?}",
+            outcome.body
+        );
     }
 }

--- a/crates/trusty-mpm/src/daemon/managed_routes/adopt_worktree_tests.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/adopt_worktree_tests.rs
@@ -1,0 +1,97 @@
+//! Tests for the #6497 adopt-worktree route.
+//!
+//! Why: the route is where the two liveness registries meet the pure gate, so
+//! its tests must drive REAL registry state — a hand-built verdict would prove
+//! only that the gate was called.
+//! What: the refusal a live owner earns, and the transfer a dead one permits.
+//! Test: this file IS the test module.
+
+use super::*;
+
+use crate::core::agent::{Delegation, DelegationStatus, ModelTier};
+use crate::core::session::SessionId;
+use crate::session_manager::decommission::WORKTREE_SENTINEL_FILE;
+use crate::session_manager::worktree_ownership::{AgentWorktreeOwner, WorktreeSentinel};
+
+/// A directory carrying an AGENT ownership sentinel naming `agent_id`.
+fn agent_owned_tree(agent_id: &str) -> (tempfile::TempDir, SessionId) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let parent = SessionId::new();
+    let payload = WorktreeSentinel::for_agent(AgentWorktreeOwner {
+        agent_id: agent_id.to_string(),
+        delegation_id: crate::core::agent::DelegationId::new(),
+        parent_session_id: parent,
+    });
+    std::fs::write(
+        dir.path().join(WORKTREE_SENTINEL_FILE),
+        serde_json::to_vec(&payload).expect("serialize sentinel"),
+    )
+    .expect("write sentinel");
+    (dir, parent)
+}
+
+/// A delegation naming `agent_id`, in `status`.
+fn delegation_for(session: SessionId, agent_id: &str, status: DelegationStatus) -> Delegation {
+    let mut d = Delegation::new(session, None, "rust-engineer", ModelTier::Sonnet, "work");
+    d.agent_id = Some(agent_id.to_string());
+    d.status = status;
+    d
+}
+
+/// A live owner keeps its tree, and the sentinel is left exactly as it was.
+#[tokio::test]
+async fn adopt_worktree_route_refuses_a_live_owner() {
+    let (tree, parent) = agent_owned_tree("agent-alive");
+    let state = Arc::new(DaemonState::new());
+    state.upsert_delegation(delegation_for(
+        parent,
+        "agent-alive",
+        DelegationStatus::Running,
+    ));
+    let before = std::fs::read(tree.path().join(WORKTREE_SENTINEL_FILE)).expect("read sentinel");
+
+    let outcome = adopt_worktree_core(
+        &state,
+        AdoptWorktreeRequest {
+            path: tree.path().to_path_buf(),
+            as_session: ManagedSessionId::new(),
+        },
+    )
+    .await;
+
+    assert_eq!(outcome.status, 409, "a live owner's tree must be refused");
+    assert_eq!(
+        std::fs::read(tree.path().join(WORKTREE_SENTINEL_FILE)).expect("read sentinel"),
+        before,
+        "a refusal must write nothing"
+    );
+}
+
+/// The #6497 case: every delegation naming the owning agent has ended, nothing
+/// else claims the tree, and the sentinel is rewritten to the adopting session.
+#[tokio::test]
+async fn adopt_worktree_route_transfers_a_dead_owners_tree() {
+    let (tree, parent) = agent_owned_tree("agent-ended");
+    let state = Arc::new(DaemonState::new());
+    state.upsert_delegation(delegation_for(
+        parent,
+        "agent-ended",
+        DelegationStatus::Completed,
+    ));
+    let successor = ManagedSessionId::new();
+
+    let outcome = adopt_worktree_core(
+        &state,
+        AdoptWorktreeRequest {
+            path: tree.path().to_path_buf(),
+            as_session: successor,
+        },
+    )
+    .await;
+
+    assert_eq!(outcome.status, 200, "a dead owner's tree is adoptable");
+    match read_sentinel_owner(tree.path()) {
+        SentinelOwner::Known(id, _) => assert_eq!(id, successor),
+        other => panic!("the sentinel must name the adopting session; got {other:?}"),
+    }
+}

--- a/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
@@ -49,6 +49,8 @@ pub mod proxy;
 pub mod prune;
 pub mod reactivate;
 pub mod reconcile;
+// #6497: the explicit ownership transfer for a dead owner's worktree.
+pub mod adopt_worktree;
 pub mod rename;
 mod resume_error;
 pub(crate) mod route_outcome_http;

--- a/crates/trusty-mpm/src/daemon/managed_routes/reconcile.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/reconcile.rs
@@ -51,6 +51,11 @@ pub fn worktree_routes() -> Router<Arc<DaemonState>> {
             "/api/v1/sessions/managed/reconcile-worktrees",
             get(reconcile_worktrees_route),
         )
+        // #6497: the ownership transfer the reconcile report can only propose.
+        .route(
+            "/api/v1/sessions/managed/adopt-worktree",
+            post(super::adopt_worktree::adopt_worktree_route),
+        )
 }
 
 /// GET /api/v1/sessions/managed/reconcile-worktrees (#4288).

--- a/crates/trusty-mpm/src/daemon/state/sessions.rs
+++ b/crates/trusty-mpm/src/daemon/state/sessions.rs
@@ -381,14 +381,65 @@ impl DaemonState {
         }
         for id in &dead {
             self.remove_session(*id);
+            // #6497: the session's agents cannot outlive it, and their records
+            // block a successor's dispatch until they are reconciled.
+            self.stale_delegations_of_dead_session(*id);
         }
         for id in &stopped_ids {
             self.update_session(id, |s| s.status = SessionStatus::Stopped);
+            self.stale_delegations_of_dead_session(*id);
         }
         ReapResult {
             reaped: dead.len(),
             stopped: stopped_ids.len(),
         }
+    }
+
+    /// Mark every live delegation of a session the reaper just buried
+    /// [`DelegationStatus::Stale`] (#6497).
+    ///
+    /// Why: `SubagentStop` is the only signal that closes a `Running`
+    /// delegation, and a session that dies takes its agents down without any of
+    /// them sending one. The records then read as live for the six hours of
+    /// [`RUNNING_STALE_AFTER_SECS`], and
+    /// [`Self::live_shared_tree_writers`] reports the dead session's agents as
+    /// writing in the shared checkout — so a successor session dispatched to
+    /// finish that work is refused, with the guard's own error text telling it
+    /// to "say so rather than retrying" and naming no verb to say it with. That
+    /// is the second half of #6497.
+    ///
+    /// What: status only, exactly as [`Self::sweep_delegations_at`] writes it —
+    /// `Stale`, never `Completed`, and no `ended_at`. This records that the
+    /// OWNER is gone, not that the agent finished, so a late `SubagentStop` can
+    /// still resolve the record to the truth for the rest of its
+    /// [`STALE_RETENTION_SECS`] window.
+    ///
+    /// It is driven only by the reaper, which acts on POSITIVE evidence — the
+    /// tmux session is gone from `list-sessions`, or the tracked `claude`
+    /// process has exited. Absence from the registry is deliberately NOT a
+    /// trigger: a session the daemon never registered is undeterminable rather
+    /// than dead (ADR-0045), and treating it as dead would quietly disarm the
+    /// ADR-0048 shared-checkout guard for every unregistered session.
+    /// Test: `reap_stales_a_dead_sessions_delegations`,
+    /// `reap_leaves_a_live_sessions_delegations_alone`.
+    pub(crate) fn stale_delegations_of_dead_session(&self, session: SessionId) -> usize {
+        let mut staled = 0;
+        for mut entry in self.delegations.iter_mut() {
+            let d = entry.value_mut();
+            if d.session != session || !d.status.is_live() {
+                continue;
+            }
+            d.status = DelegationStatus::Stale;
+            staled += 1;
+        }
+        if staled > 0 {
+            tracing::info!(
+                session = ?session,
+                staled,
+                "delegation: owning session is gone — its live records are stale (#6497)"
+            );
+        }
+        staled
     }
 
     /// Gather the tmux names tracked by BOTH session registries.

--- a/crates/trusty-mpm/src/daemon/state/tests.rs
+++ b/crates/trusty-mpm/src/daemon/state/tests.rs
@@ -323,6 +323,91 @@ fn reap_marks_stopped_when_pid_dead() {
     assert_eq!(after.status, SessionStatus::Stopped);
 }
 
+/// A `Running` delegation belonging to `session`, standing in `cwd` with no
+/// worktree of its own — the shape `live_shared_tree_writers` reports (#6497).
+fn unisolated_running_delegation(
+    session: crate::core::session::SessionId,
+    cwd: &std::path::Path,
+) -> crate::core::agent::Delegation {
+    let mut d = crate::core::agent::Delegation::new(
+        session,
+        None,
+        "rust-engineer",
+        crate::core::agent::ModelTier::Sonnet,
+        "finish the work",
+    );
+    d.status = crate::core::agent::DelegationStatus::Running;
+    d.cwd = Some(cwd.to_path_buf());
+    d.isolation = None;
+    d
+}
+
+/// The #6497 regression. When the reaper buries a session, that session's agents
+/// went down with it — their `SubagentStop` never arrives, so their records
+/// stayed live for six hours and `live_shared_tree_writers` kept reporting them
+/// as writing in the shared checkout, refusing a successor's serialized
+/// dispatch.
+#[test]
+fn reap_stales_a_dead_sessions_delegations() {
+    let state = DaemonState::new();
+    let session = sample_session();
+    let id = session.id;
+    let cwd = std::path::PathBuf::from("/repo/main");
+    state.register_session(session);
+    state.upsert_delegation(unisolated_running_delegation(id, &cwd));
+
+    assert_eq!(
+        state.live_shared_tree_writers(&cwd, None).len(),
+        1,
+        "the record blocks a dispatch while its session is alive"
+    );
+
+    // The tmux session is gone from `list-sessions` — the reaper's positive
+    // evidence of death.
+    let result = state.reap_against(&std::collections::HashSet::new());
+    assert_eq!(result.reaped, 1);
+
+    assert!(
+        state.live_shared_tree_writers(&cwd, None).is_empty(),
+        "a dead session's records must stop blocking dispatch"
+    );
+    let after = state.all_delegations();
+    assert_eq!(after.len(), 1, "the record is staled, never dropped");
+    assert_eq!(
+        after[0].status,
+        crate::core::agent::DelegationStatus::Stale,
+        "Stale records that tracking gave up, and stays resolvable by a late stop"
+    );
+    assert!(
+        after[0].ended_at.is_none(),
+        "staling must not stamp ended_at — that field means `reached a terminal status`"
+    );
+}
+
+/// The control: a session the reaper leaves alone keeps every one of its
+/// delegations live, so the ADR-0048 shared-checkout guard is untouched for
+/// every session that is still running.
+#[test]
+fn reap_leaves_a_live_sessions_delegations_alone() {
+    let state = DaemonState::new();
+    let session = sample_session();
+    let id = session.id;
+    let tmux_name = session.tmux_name.clone();
+    let cwd = std::path::PathBuf::from("/repo/main");
+    state.register_session(session);
+    state.upsert_delegation(unisolated_running_delegation(id, &cwd));
+
+    let live: std::collections::HashSet<String> = [tmux_name].into_iter().collect();
+    let result = state.reap_against(&live);
+
+    assert_eq!(result.reaped, 0);
+    assert_eq!(
+        state.live_shared_tree_writers(&cwd, None).len(),
+        1,
+        "a live session's agent must still block a second writer in its checkout"
+    );
+}
+
 #[test]
 fn new_reads_default_when_optimizer_file_missing() {
     // With no framework installed (the optimizer.toml file absent), the

--- a/crates/trusty-mpm/src/session_manager/mod.rs
+++ b/crates/trusty-mpm/src/session_manager/mod.rs
@@ -45,6 +45,9 @@ pub mod store_health;
 pub mod store_integrity;
 pub mod task_inject;
 pub mod workspace_guard;
+// #6497: the explicit ownership transfer for a tree whose owner is provably
+// dead — the compliant alternative to rebuilding the branch by hand.
+pub(crate) mod worktree_adopt;
 // #4311: the OS-level "is a process standing in here?" gate — the one removal
 // check that does not read a registry trusty-mpm or git wrote.
 pub(crate) mod worktree_liveness;

--- a/crates/trusty-mpm/src/session_manager/worktree_adopt.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_adopt.rs
@@ -1,0 +1,211 @@
+//! Transfer a worktree's ownership away from a session or agent that is
+//! provably dead (#6497).
+//!
+//! Why: a session can die holding an agent's worktree that still contains
+//! uncommitted work, and until #6497 there was no compliant way for a successor
+//! to finish that work. Every write route into the tree is refused — the
+//! ownership sentinel still names the dead owner, so `worktree_reclaim`'s gate 4
+//! spares it and the write-boundary guard keeps a successor out — while the
+//! serialize-instead route is refused too, because the daemon's delegation
+//! records still name the dead session's agents as running in the shared
+//! checkout. The recorded workaround was to rebuild the branch by hand in a new
+//! tree, which loses the original tree's identity and leaves both stale claims
+//! in place.
+//!
+//! What: [`evaluate_adoption`] — the pure policy, which permits a transfer ONLY
+//! when the current owner is positively known to be gone — and
+//! [`adopt_worktree`], which rewrites the sentinel to name the adopting managed
+//! session. Adoption is an EXPLICIT operator verb
+//! (`tm session adopt-worktree <path> --as <session>`), never automatic: a tree
+//! that changes hands on its own is indistinguishable from one that was taken
+//! from a working agent.
+//!
+//! FAIL-CLOSED, in the same direction as every other worktree gate here: the
+//! only permitting arm requires positive evidence of death. An owner the
+//! registry has merely never heard of is UNDETERMINABLE, not absent (ADR-0045),
+//! and is refused — a delegation map is rebuilt empty at every daemon boot, so
+//! its silence proves nothing about an agent that is still working.
+//!
+//! What adoption does NOT do, stated rather than hidden: it changes the
+//! sentinel, so it changes what the reclaim and prune gates believe about the
+//! tree. It does not move the harness's own worktree isolation — a subagent
+//! confined to a different tree still cannot reach into this one — and it does
+//! not commit, push, or merge anything.
+//! Test: `worktree_adopt_tests`.
+
+use std::path::Path;
+
+use super::decommission::WORKTREE_SENTINEL_FILE;
+use super::record::ManagedSessionId;
+use super::worktree_ownership::{AgentDelegationState, SentinelOwner, sentinel_payload_bytes};
+
+/// What the caller was able to establish about the CURRENT owner's liveness
+/// (#6497).
+///
+/// Why: the policy must not go looking for this itself. The two owner shapes
+/// resolve through completely different registries — a managed session through
+/// the session-record store, a dispatched agent through the delegation map —
+/// and only the daemon holds both. Passing the answer in keeps the policy a
+/// pure function and forces every caller to say which of the three answers it
+/// actually has, rather than collapsing "not found" into "gone".
+/// What: [`Dead`](Self::Dead) — the owner is positively known to have ended;
+/// [`Alive`](Self::Alive) — positively known to be running;
+/// [`Undeterminable`](Self::Undeterminable) — the registry could not answer,
+/// which refuses.
+/// Test: `adoption_refuses_a_live_owner`, `adoption_takes_a_dead_owners_tree`,
+/// `adoption_refuses_an_owner_the_registry_never_heard_of`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum OwnerLiveness {
+    /// The owner has provably ended — its record is terminal or its session is
+    /// gone from the registry that tracked it.
+    Dead,
+    /// The owner is still running.
+    Alive,
+    /// The registry holds no usable answer.
+    Undeterminable,
+}
+
+impl OwnerLiveness {
+    /// Map the delegation registry's answer for an agent onto this axis
+    /// (#6497).
+    ///
+    /// Why: [`AgentDelegationState::Unknown`] and
+    /// [`AgentDelegationState::Ended`] are the same empty-looking answer read
+    /// two ways, and only one of them is evidence — the distinction #5661
+    /// established for the reclaim gate. Adoption is a weaker action than
+    /// deletion but it still takes a tree away from whoever holds it, so it
+    /// keeps the same reading.
+    /// Test: `adoption_refuses_an_owner_the_registry_never_heard_of`.
+    pub(crate) fn from_agent_state(state: AgentDelegationState) -> Self {
+        match state {
+            AgentDelegationState::Live => Self::Alive,
+            AgentDelegationState::Ended => Self::Dead,
+            AgentDelegationState::Unknown => Self::Undeterminable,
+        }
+    }
+}
+
+/// Whether a worktree may change hands, and if not, why not (#6497).
+///
+/// Test: every test in `worktree_adopt_tests`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum AdoptionVerdict {
+    /// The current owner is provably gone and nothing live claims the tree.
+    Adopt,
+    /// Refused — `reason` is the operator-facing explanation.
+    Refuse(String),
+}
+
+/// Decide whether `owner`'s claim on a worktree may be transferred (#6497).
+///
+/// Why: this is the whole safety argument for the verb, written so `Adopt` is
+/// reachable only by falling off the end. Both conditions the issue asks for are
+/// gates here, in this order, and each one `return`s.
+/// What: three gates.
+/// 1. **A readable claim.** [`SentinelOwner::Unknown`] means the sentinel is
+///    absent, empty or unparsable, so there is no claim to transfer and nothing
+///    to prove dead. Refused.
+/// 2. **The owner is provably gone.** Only [`OwnerLiveness::Dead`] proceeds;
+///    `Alive` refuses because taking a working owner's tree is the harm this
+///    verb must never cause, and `Undeterminable` refuses because an
+///    unanswerable liveness question is not an absent one (ADR-0045).
+/// 3. **Nothing references the tree since the claim.** `live_claimants` is the
+///    set of agents or sessions the caller found still working IN this
+///    directory. A non-empty set refuses whatever the sentinel says: the
+///    sentinel names who provisioned the tree, not everyone who is in it.
+///
+/// Test: `adoption_refuses_an_unreadable_claim`, `adoption_refuses_a_live_owner`,
+/// `adoption_refuses_an_owner_the_registry_never_heard_of`,
+/// `adoption_refuses_a_tree_something_still_works_in`,
+/// `adoption_takes_a_dead_owners_tree`.
+pub(crate) fn evaluate_adoption(
+    path: &Path,
+    owner: &SentinelOwner,
+    owner_liveness: OwnerLiveness,
+    live_claimants: &[String],
+) -> AdoptionVerdict {
+    // Gate 1 (#6497): no claim to transfer, and an unreadable claim could be
+    // hiding a live one.
+    if matches!(owner, SentinelOwner::Unknown) {
+        return AdoptionVerdict::Refuse(format!(
+            "{} carries no readable ownership sentinel — absent, empty or malformed. There is no \
+             claim to transfer, and an unreadable claim could be hiding a live one, so adoption \
+             cannot prove this tree is free (ADR-0045).",
+            path.display()
+        ));
+    }
+    // Gate 2 (#6497): the owner must be positively gone.
+    match owner_liveness {
+        OwnerLiveness::Dead => {}
+        OwnerLiveness::Alive => {
+            return AdoptionVerdict::Refuse(format!(
+                "{} is owned by {}, which is still running. Adoption transfers a tree away from \
+                 its owner and must never take one from a live session or agent — wait for it to \
+                 finish, or ask the PM to serialize behind it.",
+                path.display(),
+                describe_owner(owner)
+            ));
+        }
+        OwnerLiveness::Undeterminable => {
+            return AdoptionVerdict::Refuse(format!(
+                "{} is owned by {}, and the registry that tracks it holds no record either way. A \
+                 delegation map is rebuilt empty at every daemon boot, so its silence is \
+                 undeterminable rather than absent (ADR-0045) — adoption refuses rather than \
+                 guess.",
+                path.display(),
+                describe_owner(owner)
+            ));
+        }
+    }
+    // Gate 3 (#6497): the sentinel names who PROVISIONED the tree, never
+    // everyone who is working in it.
+    if !live_claimants.is_empty() {
+        return AdoptionVerdict::Refuse(format!(
+            "{} is still claimed by {} — something has referenced this tree since the owner's \
+             claim, so it is not free to transfer.",
+            path.display(),
+            live_claimants.join(", ")
+        ));
+    }
+    AdoptionVerdict::Adopt
+}
+
+/// Name the current owner for a refusal message.
+///
+/// Why: "owned by a dead session" without the id sends the reader to the wrong
+/// registry. One line each, because the whole message is already long.
+fn describe_owner(owner: &SentinelOwner) -> String {
+    match owner {
+        SentinelOwner::Agent(agent, _) => format!("dispatched agent {}", agent.agent_id),
+        SentinelOwner::Known(session, _) => format!("managed session {session}"),
+        SentinelOwner::Unknown => "an unreadable claim".to_string(),
+    }
+}
+
+/// Rewrite `path`'s ownership sentinel to name `new_owner` (#6497).
+///
+/// Why: the sentinel IS the ownership record every gate reads, so a transfer is
+/// exactly this write and nothing else — no new state, no second registry, and
+/// no new expiry to keep in step with the first. Writing the SESSION shape
+/// rather than a fresh agent claim is deliberate: a managed session's liveness
+/// resolves through the session-record store, which has a real terminal state, so
+/// the adopted tree re-enters the ordinary reclaim lifecycle instead of becoming
+/// permanently unreclaimable.
+/// What: `<path>/.trusty-mpm-worktree` replaced with a payload naming
+/// `new_owner`, timestamped now. Refuses when `path` is not a directory, because
+/// writing a sentinel into a path that is not a worktree would manufacture a
+/// claim on nothing.
+/// Test: `adopt_worktree_rewrites_the_sentinel`,
+/// `adopt_worktree_refuses_a_path_that_is_not_a_directory`.
+pub(crate) fn adopt_worktree(path: &Path, new_owner: ManagedSessionId) -> Result<(), String> {
+    if !path.is_dir() {
+        return Err(format!("{} is not a directory", path.display()));
+    }
+    let sentinel = path.join(WORKTREE_SENTINEL_FILE);
+    std::fs::write(&sentinel, sentinel_payload_bytes(new_owner))
+        .map_err(|e| format!("could not write {}: {e}", sentinel.display()))
+}
+
+#[cfg(test)]
+#[path = "worktree_adopt_tests.rs"]
+mod worktree_adopt_tests;

--- a/crates/trusty-mpm/src/session_manager/worktree_adopt_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_adopt_tests.rs
@@ -1,0 +1,162 @@
+//! Unit tests for the #6497 worktree-adoption gate.
+//!
+//! Why: the verb takes a directory away from whoever the sentinel says owns it,
+//! so the refusal arms carry the whole safety argument and each one must fail
+//! independently if its gate is deleted.
+//! What: one test per gate, plus the two write-path cases.
+//! Test: this file IS the test module.
+
+use super::*;
+use crate::core::agent::DelegationId;
+use crate::core::session::SessionId;
+use crate::session_manager::worktree_ownership::AgentWorktreeOwner;
+use chrono::Utc;
+
+/// An agent-owned sentinel value, as `read_sentinel_owner` would return it.
+fn agent_owner(agent_id: &str) -> SentinelOwner {
+    SentinelOwner::Agent(
+        AgentWorktreeOwner {
+            agent_id: agent_id.to_string(),
+            delegation_id: DelegationId::new(),
+            parent_session_id: SessionId::new(),
+        },
+        Utc::now(),
+    )
+}
+
+/// FAIL-OPEN CHECK, gate 2: a LIVE owner keeps its tree. This is the harm the
+/// verb must never cause — adoption is a transfer, and transferring a tree out
+/// from under a working agent is the same loss as deleting it.
+#[test]
+fn adoption_refuses_a_live_owner() {
+    let dir = tempfile::tempdir().unwrap();
+    let verdict = evaluate_adoption(
+        dir.path(),
+        &agent_owner("agent-still-working"),
+        OwnerLiveness::Alive,
+        &[],
+    );
+    let AdoptionVerdict::Refuse(reason) = verdict else {
+        panic!("a live owner's tree must never be adoptable");
+    };
+    assert!(reason.contains("agent-still-working"), "{reason}");
+    assert!(reason.contains("still running"), "{reason}");
+}
+
+/// Gate 2, the ADR-0045 half: an owner the registry has merely never heard of
+/// is undeterminable, not absent. The delegation map is rebuilt empty at every
+/// daemon boot, so its silence proves nothing.
+#[test]
+fn adoption_refuses_an_owner_the_registry_never_heard_of() {
+    let dir = tempfile::tempdir().unwrap();
+    assert_eq!(
+        OwnerLiveness::from_agent_state(AgentDelegationState::Unknown),
+        OwnerLiveness::Undeterminable,
+    );
+    let verdict = evaluate_adoption(
+        dir.path(),
+        &agent_owner("agent-unheard-of"),
+        OwnerLiveness::Undeterminable,
+        &[],
+    );
+    assert!(
+        !matches!(verdict, AdoptionVerdict::Adopt),
+        "an unanswerable claim must refuse"
+    );
+}
+
+/// Gate 1: no readable claim means nothing to transfer, and an unreadable
+/// sentinel could be hiding a live claim.
+#[test]
+fn adoption_refuses_an_unreadable_claim() {
+    let dir = tempfile::tempdir().unwrap();
+    let verdict = evaluate_adoption(
+        dir.path(),
+        &SentinelOwner::Unknown,
+        OwnerLiveness::Dead,
+        &[],
+    );
+    assert!(
+        !matches!(verdict, AdoptionVerdict::Adopt),
+        "an unreadable sentinel must refuse even when the caller says the owner is dead"
+    );
+}
+
+/// Gate 3: the sentinel names who PROVISIONED the tree, never everyone who is
+/// working in it. A live claimant refuses whatever the sentinel says.
+#[test]
+fn adoption_refuses_a_tree_something_still_works_in() {
+    let dir = tempfile::tempdir().unwrap();
+    let verdict = evaluate_adoption(
+        dir.path(),
+        &agent_owner("agent-that-ended"),
+        OwnerLiveness::Dead,
+        &["rust-engineer".to_string()],
+    );
+    let AdoptionVerdict::Refuse(reason) = verdict else {
+        panic!("a tree with a live claimant must not be adoptable");
+    };
+    assert!(reason.contains("rust-engineer"), "{reason}");
+}
+
+/// The permitting arm — the #6497 case. Every gate passed: the sentinel is
+/// readable, the owner is positively ended, and nothing else claims the tree.
+#[test]
+fn adoption_takes_a_dead_owners_tree() {
+    let dir = tempfile::tempdir().unwrap();
+    assert_eq!(
+        OwnerLiveness::from_agent_state(AgentDelegationState::Ended),
+        OwnerLiveness::Dead,
+    );
+    assert_eq!(
+        evaluate_adoption(
+            dir.path(),
+            &agent_owner("agent-that-ended"),
+            OwnerLiveness::Dead,
+            &[],
+        ),
+        AdoptionVerdict::Adopt,
+    );
+}
+
+/// A session-owned tree adopts by the same rule — the owner shape changes the
+/// registry that answers gate 2, never the gate itself.
+#[test]
+fn adoption_handles_a_session_owned_tree_by_the_same_rule() {
+    let dir = tempfile::tempdir().unwrap();
+    let owner = SentinelOwner::Known(ManagedSessionId::new(), Utc::now());
+    assert_eq!(
+        evaluate_adoption(dir.path(), &owner, OwnerLiveness::Dead, &[]),
+        AdoptionVerdict::Adopt
+    );
+    assert!(!matches!(
+        evaluate_adoption(dir.path(), &owner, OwnerLiveness::Alive, &[]),
+        AdoptionVerdict::Adopt
+    ));
+}
+
+/// The write: after adoption the sentinel names the ADOPTING session, so every
+/// gate that reads it now protects the tree for its new owner.
+#[test]
+fn adopt_worktree_rewrites_the_sentinel() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join(WORKTREE_SENTINEL_FILE), b"{}").unwrap();
+    let new_owner = ManagedSessionId::new();
+
+    adopt_worktree(dir.path(), new_owner).expect("adoption must write the sentinel");
+
+    match crate::session_manager::worktree_ownership::read_sentinel_owner(dir.path()) {
+        SentinelOwner::Known(id, _) => assert_eq!(id, new_owner),
+        other => panic!("the sentinel must name the adopting session; got {other:?}"),
+    }
+}
+
+/// A path that is not a directory gets no sentinel: writing one would
+/// manufacture a claim on a tree that does not exist.
+#[test]
+fn adopt_worktree_refuses_a_path_that_is_not_a_directory() {
+    let dir = tempfile::tempdir().unwrap();
+    let missing = dir.path().join("no-such-worktree");
+    assert!(adopt_worktree(&missing, ManagedSessionId::new()).is_err());
+    assert!(!missing.join(WORKTREE_SENTINEL_FILE).exists());
+}

--- a/crates/trusty-mpm/src/session_manager/worktree_git_fixture.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_git_fixture.rs
@@ -238,6 +238,46 @@ impl GitWorktreeFixture {
         git_ok(&self.repo, &["fetch", "--prune", "origin"]);
     }
 
+    /// Commit `file` in `wt`, PUSH that commit under `remote_branch`, and ALSO
+    /// squash-merge its patch onto `origin/main` (#6507).
+    ///
+    /// Why: this builds the one shape that separates a per-commit patch filter
+    /// from a naive count subtraction. The commit ends up reachable from a
+    /// remote ref, so `rev-list HEAD --not --remotes` never counts it — while
+    /// `git cherry origin/main HEAD` still marks it `-`, because its patch is on
+    /// `main` too. Subtracting the number of `-` lines from the candidate count
+    /// therefore discounts one commit too many, and the commit it eats is
+    /// whichever genuinely unpushed one the caller adds next.
+    /// What: commits `file`, pushes the branch to `origin/<remote_branch>`,
+    /// squash-merges it onto `main` in the owning checkout, pushes `main`, and
+    /// fetches so both remote refs exist locally. No upstream is configured, so
+    /// the dirty check still takes its no-upstream arm.
+    /// Test: `inspect_dirt_discounts_only_the_commits_the_query_counted`.
+    pub(crate) fn land_patch_and_keep_the_remote_branch(
+        &self,
+        wt: &Path,
+        file: &str,
+        remote_branch: &str,
+    ) {
+        let branch = git_stdout_ok(wt, &["rev-parse", "--abbrev-ref", "HEAD"]);
+        let branch = branch.trim().to_string();
+        std::fs::write(wt.join(file), "landed and pushed\n").expect("fixture: write file");
+        git_ok(wt, &["add", file]);
+        git_ok(wt, &["commit", "-m", "feat: landed under two refs"]);
+        git_ok(
+            wt,
+            &[
+                "push",
+                "origin",
+                &format!("HEAD:refs/heads/{remote_branch}"),
+            ],
+        );
+        git_ok(&self.repo, &["merge", "--squash", &branch]);
+        git_ok(&self.repo, &["commit", "-m", "feat: landed (#2)"]);
+        git_ok(&self.repo, &["push", "origin", "main"]);
+        git_ok(&self.repo, &["fetch", "origin"]);
+    }
+
     /// Test: `enumerate_finds_worktree_at_an_unwalked_location`,
     /// `registry_root_for_ignores_where_the_worktree_is_parked`.
     pub(crate) fn add_worktree_at(&self, parent: &Path, name: &str) -> PathBuf {

--- a/crates/trusty-mpm/src/session_manager/worktree_git_fixture.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_git_fixture.rs
@@ -65,6 +65,27 @@ fn git_ok(dir: &Path, args: &[&str]) {
     );
 }
 
+/// Run `git -C <dir> <args>` and return stdout, panicking on failure (#6507).
+///
+/// Why: [`git_ok`] discards stdout, and the squash fixture has to read the
+/// worktree's own branch name back before it can merge it.
+fn git_stdout_ok(dir: &Path, args: &[&str]) -> String {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        .output()
+        .unwrap_or_else(|e| panic!("fixture: `git {}` could not be run: {e}", args.join(" ")));
+    assert!(
+        out.status.success(),
+        "fixture: `git {}` failed in {}: {}",
+        args.join(" "),
+        dir.display(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
 /// Restores a path's permission bits when it drops, pass or panic (#4732).
 ///
 /// Why: the "git cannot read this" tests work by `chmod 000`-ing a real `.git`
@@ -193,6 +214,30 @@ impl GitWorktreeFixture {
     /// covers, or outside the repos root entirely.
     /// What: `git worktree add -b wt/<name> <parent>/<name>` off the current
     /// `HEAD`, creating `<parent>` if needed. Returns the worktree path.
+    /// Commit `file` in `wt`, then SQUASH-merge that branch to `origin/main`
+    /// and drop every remote ref that made the commit reachable (#6507).
+    ///
+    /// Why: this is the exact end state `gh pr merge --squash --delete-branch`
+    /// plus `git fetch --prune` leaves behind, and it is the state the reclaim
+    /// path misread as "holds unsaved work". Reproducing it needs a real squash
+    /// — the landed commit must be a DIFFERENT SHA carrying the SAME patch —
+    /// so nothing here can be faked with a fast-forward.
+    /// What: commits `file` on the worktree's own branch, squash-merges that
+    /// branch onto `main` in the owning checkout, pushes `main`, and fetches.
+    /// The branch is never pushed, so it has no upstream and no remote-tracking
+    /// ref — the pruned-upstream shape.
+    /// Test: `inspect_dirt_clears_a_squash_merged_branch_whose_upstream_was_pruned`.
+    pub(crate) fn squash_merge_to_origin(&self, wt: &Path, file: &str) {
+        let branch = git_stdout_ok(wt, &["rev-parse", "--abbrev-ref", "HEAD"]);
+        std::fs::write(wt.join(file), "landed content\n").expect("fixture: write file");
+        git_ok(wt, &["add", file]);
+        git_ok(wt, &["commit", "-m", "feat: work that later squash-merges"]);
+        git_ok(&self.repo, &["merge", "--squash", branch.trim()]);
+        git_ok(&self.repo, &["commit", "-m", "feat: work (#1)"]);
+        git_ok(&self.repo, &["push", "origin", "main"]);
+        git_ok(&self.repo, &["fetch", "--prune", "origin"]);
+    }
+
     /// Test: `enumerate_finds_worktree_at_an_unwalked_location`,
     /// `registry_root_for_ignores_where_the_worktree_is_parked`.
     pub(crate) fn add_worktree_at(&self, parent: &Path, name: &str) -> PathBuf {

--- a/crates/trusty-mpm/src/session_manager/worktree_safety.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_safety.rs
@@ -99,6 +99,7 @@
 //!
 //! Test: `worktree_safety_tests`.
 
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -570,8 +571,18 @@ fn is_worktree_root(path: &Path) -> Result<bool, String> {
 /// pushed under its own name but never had upstream tracking configured. In a
 /// repository with no remotes at all, `--remotes` expands to nothing and every
 /// commit counts as unpushed — the correct, conservative answer.
+/// Reachability alone is not the question a SQUASH-merge repository can answer
+/// (#6507). A squash merge replays the branch's changes as ONE NEW commit on
+/// `main`, so the branch tip is never an ancestor of it, and
+/// `gh pr merge --squash --delete-branch` then removes the remote branch that
+/// made those commits reachable. `rev-list --count HEAD --not --remotes` counts
+/// them all as unpushed, gate 6 of the merged-PR reclaim reports "holds unsaved
+/// work", and `prune-worktrees --merged-prs` reclaims nothing on a repository
+/// that squash-merges every PR. [`count_unlanded`] subtracts the commits whose
+/// PATCH is provably already on a remote landing branch.
 /// Test: `inspect_dirt_reports_unpushed_commit`,
-/// `inspect_dirt_clean_pushed_worktree_is_none`.
+/// `inspect_dirt_clean_pushed_worktree_is_none`,
+/// `inspect_dirt_clears_a_squash_merged_branch_whose_upstream_was_pruned`.
 fn count_unpushed(path: &Path) -> Result<usize, String> {
     let upstream = git_stdout(
         path,
@@ -586,15 +597,160 @@ fn count_unpushed(path: &Path) -> Result<usize, String> {
     .map(|s| s.trim().to_string())
     .filter(|s| !s.is_empty());
 
-    let raw = match upstream {
-        Some(up) => git_stdout(path, &["rev-list", "--count", &format!("{up}..HEAD")])?,
-        None => git_stdout(path, &["rev-list", "--count", "HEAD", "--not", "--remotes"])?,
+    // #6507: the count and the listing must be the SAME query — the listing is
+    // what the patch-equivalence filter runs over.
+    let range;
+    let (count_args, list_args): (Vec<&str>, Vec<&str>) = match &upstream {
+        Some(up) => {
+            range = format!("{up}..HEAD");
+            (
+                vec!["rev-list", "--count", &range],
+                vec!["rev-list", &range],
+            )
+        }
+        None => (
+            vec!["rev-list", "--count", "HEAD", "--not", "--remotes"],
+            vec!["rev-list", "HEAD", "--not", "--remotes"],
+        ),
     };
-    let head = raw
+    let head = count_unlanded(path, &count_args, &list_args, &["HEAD"])?;
+    Ok(head + count_session_branch_unpushed(path)?)
+}
+
+/// The most unpushed-looking commits this guard will patch-compare (#6507).
+///
+/// Why: the no-upstream arm of [`count_unpushed`] is
+/// `rev-list HEAD --not --remotes`, which in a repository with no remote refs
+/// at all expands to the WHOLE history — tens of thousands of commits here. The
+/// patch comparison is worth running over a branch's divergence and never over
+/// a history, so past this many candidates the raw count is returned unchanged.
+/// That is the fail-closed direction: more unpushed commits, never fewer.
+/// What: 200, comfortably above any real branch's divergence.
+/// Test: `inspect_dirt_clears_a_squash_merged_branch_whose_upstream_was_pruned`
+/// exercises the comparing path; the cap only ever restores today's behaviour.
+const LANDED_PROBE_MAX_CANDIDATES: usize = 200;
+
+/// Ref patterns naming a branch a merge can LAND on (#6507).
+///
+/// Why: `git cherry` takes exactly one upstream, so the comparison needs a
+/// concrete ref rather than `--remotes`. A squash merge lands on a remote's
+/// default branch, and these three patterns name it: `HEAD` when the remote's
+/// symbolic default is known locally (every `git clone` sets it), and the two
+/// conventional spellings for a repository built by `git init` + `git remote
+/// add`, which sets no `HEAD`. A pattern that matches nothing contributes
+/// nothing, so an unusual default branch simply leaves the raw count in place.
+/// Test: `inspect_dirt_clears_a_squash_merged_branch_whose_upstream_was_pruned`.
+const LANDING_BASE_PATTERNS: &[&str] = &[
+    "refs/remotes/*/HEAD",
+    "refs/remotes/*/main",
+    "refs/remotes/*/master",
+];
+
+/// How many distinct landing bases one call will compare against (#6507).
+///
+/// Why: each base costs one `git cherry` per tip, and a machine with several
+/// remotes would otherwise pay for all of them on every dirty check.
+const LANDING_BASE_LIMIT: usize = 4;
+
+/// Count the commits in one rev-list query that are NOT already on a remote,
+/// by patch rather than by reachability (#6507).
+///
+/// Why: see [`count_unpushed`]. The subtraction is per-COMMIT and never a
+/// difference of counts: `git cherry`'s output range is `<base>..<tip>`, which
+/// can hold commits this query never counted, so subtracting its `-` total
+/// would discount a genuinely unsaved commit against an unrelated match.
+/// What: runs `count_args` for the number and `list_args` for the same
+/// commits' SHAs, then drops those [`landed_on_a_remote`] proved equivalent to
+/// a commit already on a landing branch. Every failure arm keeps the raw count:
+/// an unanswerable patch comparison must never lower it.
+/// Test: `inspect_dirt_clears_a_squash_merged_branch_whose_upstream_was_pruned`,
+/// `inspect_dirt_still_reports_a_genuinely_unpushed_commit_beside_a_squashed_one`.
+fn count_unlanded(
+    path: &Path,
+    count_args: &[&str],
+    list_args: &[&str],
+    tips: &[&str],
+) -> Result<usize, String> {
+    let raw = git_stdout(path, count_args)?;
+    let counted = raw
         .trim()
         .parse::<usize>()
         .map_err(|e| format!("unparsable rev-list count `{}`: {e}", raw.trim()))?;
-    Ok(head + count_session_branch_unpushed(path)?)
+    if counted == 0 || counted > LANDED_PROBE_MAX_CANDIDATES {
+        return Ok(counted);
+    }
+    let listed = git_stdout(path, list_args)?;
+    let landed = landed_on_a_remote(path, tips);
+    Ok(listed
+        .split_whitespace()
+        .filter(|sha| !landed.contains(*sha))
+        .count())
+}
+
+/// The SHAs reachable from `tips` whose patch is already on a landing branch
+/// (#6507).
+///
+/// Why: this is the only evidence that turns "unreachable from every remote"
+/// into "already landed". `git cherry <base> <tip>` marks a commit `-` when its
+/// patch id matches one on `base` — which is exactly what a squash merge
+/// produces — and `+` otherwise.
+/// What: the `-` SHAs, unioned over every [`landing_bases`] base and every tip.
+/// An empty set on every failure path, which leaves the caller's count intact.
+///
+/// Residual, stated rather than hidden: an EMPTY commit has an empty patch id,
+/// so two unrelated empty commits read as equivalent and one could be
+/// discounted. An empty commit carries no file content, so nothing recoverable
+/// is at risk. `git cherry` also skips merge commits, which therefore never
+/// appear here and stay counted — the conservative direction.
+/// Test: `inspect_dirt_clears_a_squash_merged_branch_whose_upstream_was_pruned`.
+fn landed_on_a_remote(path: &Path, tips: &[&str]) -> HashSet<String> {
+    let mut landed = HashSet::new();
+    for base in landing_bases(path) {
+        for tip in tips {
+            let Ok(out) = git_stdout(path, &["cherry", &base, tip]) else {
+                continue;
+            };
+            for line in out.lines() {
+                if let Some(sha) = line.strip_prefix("- ") {
+                    landed.insert(sha.trim().to_string());
+                }
+            }
+        }
+    }
+    landed
+}
+
+/// Remote refs a squash merge could have landed on, deduplicated by commit
+/// (#6507).
+///
+/// Why: `refs/remotes/origin/HEAD` and `refs/remotes/origin/main` usually name
+/// the SAME commit, and comparing against both would double the subprocess cost
+/// for one answer.
+/// What: one `for-each-ref` over [`LANDING_BASE_PATTERNS`], keeping the first
+/// ref for each distinct object and at most [`LANDING_BASE_LIMIT`] of them. An
+/// empty vector when git cannot be asked, which discounts nothing.
+/// Test: `inspect_dirt_clears_a_squash_merged_branch_whose_upstream_was_pruned`.
+fn landing_bases(path: &Path) -> Vec<String> {
+    let mut args = vec!["for-each-ref", "--format=%(objectname) %(refname)"];
+    args.extend_from_slice(LANDING_BASE_PATTERNS);
+    let Ok(out) = git_stdout(path, &args) else {
+        return Vec::new();
+    };
+    let mut seen: HashSet<&str> = HashSet::new();
+    let mut bases = Vec::new();
+    for line in out.lines() {
+        let Some((object, refname)) = line.trim().split_once(' ') else {
+            continue;
+        };
+        if !seen.insert(object) {
+            continue;
+        }
+        bases.push(refname.to_string());
+        if bases.len() >= LANDING_BASE_LIMIT {
+            break;
+        }
+    }
+    bases
 }
 
 /// Count unpushed commits on the `session/<leaf>` branch `decommission` deletes.
@@ -652,13 +808,18 @@ fn count_session_branch_unpushed(path: &Path) -> Result<usize, String> {
     if present.is_empty() {
         return Ok(0);
     }
-    let mut args: Vec<&str> = vec!["rev-list", "--count"];
-    args.extend(present.iter().map(String::as_str));
-    args.extend(["--not", "--remotes", "HEAD"]);
-    let raw = git_stdout(path, &args)?;
-    raw.trim()
-        .parse::<usize>()
-        .map_err(|e| format!("unparsable rev-list count `{}`: {e}", raw.trim()))
+    let mut count_args: Vec<&str> = vec!["rev-list", "--count"];
+    count_args.extend(present.iter().map(String::as_str));
+    count_args.extend(["--not", "--remotes", "HEAD"]);
+    let mut list_args: Vec<&str> = vec!["rev-list"];
+    list_args.extend(present.iter().map(String::as_str));
+    list_args.extend(["--not", "--remotes", "HEAD"]);
+    // #6507: a session branch is squash-merged like any other, so the same
+    // patch-equivalence subtraction applies here. The tips are the branch refs
+    // themselves — `HEAD` is excluded from this query, so comparing against it
+    // would name commits this arm never counted.
+    let tips: Vec<&str> = present.iter().map(String::as_str).collect();
+    count_unlanded(path, &count_args, &list_args, &tips)
 }
 
 /// Run `git -C <dir> <args>` and return stdout, or an error string.

--- a/crates/trusty-mpm/src/session_manager/worktree_safety_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_safety_tests.rs
@@ -794,3 +794,102 @@ fn inspect_dirt_allows_empty_non_git_leftover() {
         inspect_dirt(&shell)
     );
 }
+
+// ── #6507: a squash-merged branch is not unsaved work ────────────────────────
+
+/// Run one git command in `dir`, asserting it succeeded (#6507 tests).
+fn git_must(dir: &Path, args: &[&str]) {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        .output()
+        .unwrap_or_else(|e| panic!("`git {}` could not be run: {e}", args.join(" ")));
+    assert!(
+        out.status.success(),
+        "`git {}` failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// The #6507 regression. A branch whose PR squash-merged, and whose remote
+/// branch was then deleted, holds no work a removal could destroy — its patch
+/// is on `origin/main` under a different SHA. Before this fix
+/// `rev-list --count HEAD --not --remotes` returned 1 for exactly that state,
+/// gate 6 of the merged-PR reclaim reported "holds unsaved work", and
+/// `tm session prune-worktrees --merged-prs --force` reclaimed 0 on a
+/// squash-merging repository.
+///
+/// FAIL-OPEN CHECK: reporting clean when work is unsaved is the one direction
+/// this module may not get wrong, so the discount is per-commit and
+/// evidence-based — `git cherry` marking that commit `-` against a remote
+/// landing branch. It is never "the upstream ref is gone, therefore fine": the
+/// sibling test below keeps a genuinely unpushed commit on the same fixture
+/// refused.
+#[test]
+fn inspect_dirt_clears_a_squash_merged_branch_whose_upstream_was_pruned() {
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree("squashed");
+    fx.squash_merge_to_origin(&wt, "landed.rs");
+
+    // The pre-fix state, pinned so a regression stays legible: the commit
+    // really is unreachable from every remote ref.
+    let reachability = git_stdout(&wt, &["rev-list", "--count", "HEAD", "--not", "--remotes"])
+        .expect("rev-list must run");
+    assert_eq!(
+        reachability.trim(),
+        "1",
+        "the fixture must reproduce the pruned-upstream shape this bug needs"
+    );
+
+    assert!(
+        inspect_dirt(&wt).is_none(),
+        "a squash-merged branch holds no unsaved work; got {:?}",
+        inspect_dirt(&wt)
+    );
+}
+
+/// The control the #6507 fix may never break: a commit that landed NOWHERE is
+/// still unsaved work, in the same worktree, beside one that did land.
+#[test]
+fn inspect_dirt_still_reports_a_genuinely_unpushed_commit_beside_a_squashed_one() {
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree("mixed");
+    fx.squash_merge_to_origin(&wt, "landed.rs");
+
+    std::fs::write(wt.join("never-landed.rs"), "work that exists only here\n").unwrap();
+    git_must(&wt, &["add", "never-landed.rs"]);
+    git_must(&wt, &["commit", "-m", "feat: never pushed anywhere"]);
+
+    let dirt = inspect_dirt(&wt).expect("an unlanded commit must still read as dirty");
+    assert_eq!(
+        dirt.unpushed_commits, 1,
+        "only the squash-merged commit may be discounted; reason was: {}",
+        dirt.reason
+    );
+}
+
+/// A repository with no remote landing branch discounts NOTHING — the patch
+/// comparison has no base, and an unanswerable comparison must leave the raw
+/// count exactly where it was.
+#[test]
+fn inspect_dirt_discounts_nothing_without_a_remote_landing_branch() {
+    let tmp = tempfile::tempdir().unwrap();
+    let repo = std::fs::canonicalize(tmp.path()).unwrap().join("solo");
+    std::fs::create_dir_all(&repo).unwrap();
+    git_must(&repo, &["init", "--initial-branch=main"]);
+    git_must(&repo, &["config", "user.email", "ci@test.invalid"]);
+    git_must(&repo, &["config", "user.name", "CI"]);
+    git_must(&repo, &["config", "commit.gpgsign", "false"]);
+    std::fs::write(repo.join("only.rs"), "local\n").unwrap();
+    git_must(&repo, &["add", "only.rs"]);
+    git_must(&repo, &["commit", "-m", "local only"]);
+
+    assert!(
+        landing_bases(&repo).is_empty(),
+        "a repository with no remotes offers no landing base"
+    );
+    let dirt = inspect_dirt(&repo).expect("a commit on no remote is unsaved work");
+    assert_eq!(dirt.unpushed_commits, 1, "reason was: {}", dirt.reason);
+}

--- a/crates/trusty-mpm/src/session_manager/worktree_safety_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_safety_tests.rs
@@ -870,6 +870,51 @@ fn inspect_dirt_still_reports_a_genuinely_unpushed_commit_beside_a_squashed_one(
     );
 }
 
+/// The discount is applied PER COMMIT, never as a difference of counts.
+///
+/// Why this needs its own fixture: `git cherry`'s output range is
+/// `<base>..<tip>`, which can hold commits the rev-list never counted. Here the
+/// first commit is reachable from `origin/landed-elsewhere`, so it is not a
+/// candidate — and its patch is also on `origin/main`, so cherry marks it `-`.
+/// A naive `candidates - landed.len()` therefore reports 1 - 1 = 0 and calls the
+/// worktree clean, discarding the SECOND commit, which exists nowhere but this
+/// directory. The other two #6507 tests pass under that naive form; this one
+/// does not.
+#[test]
+fn inspect_dirt_discounts_only_the_commits_the_query_counted() {
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree("two-refs");
+    fx.land_patch_and_keep_the_remote_branch(&wt, "landed.rs", "landed-elsewhere");
+
+    std::fs::write(wt.join("only-here.rs"), "exists nowhere else\n").unwrap();
+    git_must(&wt, &["add", "only-here.rs"]);
+    git_must(&wt, &["commit", "-m", "feat: exists nowhere else"]);
+
+    // The fixture's own precondition: exactly ONE candidate (the second
+    // commit), and a cherry range that also marks the first one landed.
+    let counted = git_stdout(&wt, &["rev-list", "--count", "HEAD", "--not", "--remotes"])
+        .expect("rev-list must run");
+    assert_eq!(
+        counted.trim(),
+        "1",
+        "the fixture must count only the commit that landed nowhere"
+    );
+    let cherry = git_stdout(&wt, &["cherry", "refs/remotes/origin/main", "HEAD"])
+        .expect("git cherry must run");
+    assert_eq!(
+        cherry.lines().filter(|l| l.starts_with("- ")).count(),
+        1,
+        "the cherry range must also hold a landed commit the rev-list never counted: {cherry}"
+    );
+
+    let dirt = inspect_dirt(&wt).expect("the second commit is unsaved work");
+    assert_eq!(
+        dirt.unpushed_commits, 1,
+        "a landed commit outside the counted set must not discount one inside it; reason was: {}",
+        dirt.reason
+    );
+}
+
 /// A repository with no remote landing branch discounts NOTHING — the patch
 /// comparison has no base, and an unanswerable comparison must leave the raw
 /// count exactly where it was.


### PR DESCRIPTION
Refs #6507, #6497

**#6507** — root cause reproduced: `count_unpushed` fell to `rev-list HEAD --not --remotes` once the pruned upstream was gone and counted a squash-merged commit; gate 6 refused. Fix: `count_unlanded` discounts a commit only when `git cherry <remote landing branch> <tip>` marks that SHA `-`; per-commit, fail-closed on every error arm, >200 candidates uncompared. The PR-index theory (PR_INDEX_LIMIT) ruled out — the reclaim path already falls back to `gh pr list --head`.

**#6497** — `tm session adopt-worktree <path> --as <session>` + `POST /api/v1/sessions/managed/adopt-worktree`; adoption only when the owner is `Dead` (`Alive`/`Undeterminable` refuse, ADR-0045), any live delegation whose canonical or raw `cwd` is under the tree refuses, second-pass claimant check before the sentinel write; the session reaper marks a dead session's delegations `Stale` on positive evidence only. Left out, stated: no RPC mirror/MCP tool; harness worktree confinement of an already-running agent is not lifted (that refusal is Claude Code's, not tm's).

Test ladder: rung 3 + critic round (write-boundary/destructive path). `cargo test -p trusty-mpm --no-fail-fast`: lib 5613 passed / 4 failed, bins 1891 / 4 each, integration all ok except `full_user_cycle` — the failures are the pre-existing nested-tmux family tracked in #6523, reproduced failing on origin/main; regression tests with fail-before shown: `inspect_dirt_clears_a_squash_merged_branch_whose_upstream_was_pruned`, `inspect_dirt_still_reports_a_genuinely_unpushed_commit_beside_a_squashed_one`, `inspect_dirt_discounts_only_the_commits_the_query_counted`, `adopt_worktree_route_refuses_a_claimant_under_a_symlinked_spelling`, `reap_stales_a_dead_sessions_delegations`. clippy `-D warnings` clean; line-cap and changelog gates clean (three fragments). No version bump (trusty-mpm 1.5.15 on main, unpublished).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools