### PR TITLE
test(trusty-mpm): tmux fixture diagnosis and full_user_cycle HOME isolation (Refs #6523)

### DIFF
--- a/crates/trusty-mpm/changelog.d/6523-tmux-fixture-diagnosis-and-home-isolation.md
+++ b/crates/trusty-mpm/changelog.d/6523-tmux-fixture-diagnosis-and-home-isolation.md
@@ -1,0 +1,14 @@
+Fixed
+
+- The `full_user_cycle` lifecycle test no longer writes a real
+  `~/.trusty-mpm/sessions/<uuid>/pause.json` into the operator's home on every
+  run. It redirects `$HOME` to a scratch directory, and takes
+  `host_state_gate`'s `TRUSTY_MPM_ALLOW_HOST_STATE` opt-in so the scratch
+  `$HOME` does not silently void its real-tmux assertion (#6523).
+- A failed `ScratchTmuxSession::spawn` now quotes tmux's own stderr in the
+  panic. The exit status alone did not distinguish a duplicate session name
+  from a host that has run out of pseudo-terminals, so both read
+  `exit status: 1` (#6523).
+- `drop_kills_the_session_even_when_the_body_panics` no longer passes
+  vacuously when the fixture cannot create a tmux session: the spawn moved out
+  of the `catch_unwind` that was swallowing its failure (#6523).

--- a/crates/trusty-mpm/src/test_tmux_session.rs
+++ b/crates/trusty-mpm/src/test_tmux_session.rs
@@ -190,19 +190,33 @@ impl ScratchTmuxSession {
     /// name is one such non-zero exit, which is the behaviour that keeps the
     /// ownership claim honest: the caller gets no guard, so nothing later kills
     /// a session someone else created.
+    ///
+    /// The panic quotes tmux's own stderr, because the exit status alone does
+    /// not distinguish the cases (#6523). `create window failed: fork failed:
+    /// Device not configured` means the HOST is out of pseudo-terminals — on
+    /// macOS the pool is capped by `kern.tty.ptmx_max` (511) and a machine with
+    /// hundreds of leaked panes exhausts it — so every tmux spawn on that
+    /// machine fails until the panes are reaped. That is a machine fault, not a
+    /// fixture one; no test-side change creates a pty.
     pub(crate) fn spawn(tmux_bin: &str, name: &str, pane_command: &str) -> Self {
         // #6116: reap what an earlier hard-killed run leaked, before adding to
         // the namespace. Once per process, mirroring `test_support`'s
         // `sweep_stale_test_dirs`.
         SWEEP_ONCE.call_once(|| sweep_stale_reserved_sessions(tmux_bin));
-        let status = Command::new(tmux_bin)
+        // #6523: capture tmux's stderr instead of letting it through. `.status()`
+        // sent the real cause to the test binary's stderr, unattached to the
+        // panic, so five simultaneous failures each read only `exit status: 1`
+        // and got misattributed to nested tmux.
+        let out = Command::new(tmux_bin)
             .args(["new-session", "-d", "-s", name, pane_command])
-            .status()
+            .output()
             .unwrap_or_else(|e| panic!("spawn `{tmux_bin} new-session -s {name}`: {e}"));
         assert!(
-            status.success(),
-            "`{tmux_bin} new-session -d -s {name}` failed with {status}; the session was NOT \
-             created, so no guard may claim it"
+            out.status.success(),
+            "`{tmux_bin} new-session -d -s {name}` failed with {}; the session was NOT \
+             created, so no guard may claim it. tmux said: {}",
+            out.status,
+            String::from_utf8_lossy(&out.stderr).trim()
         );
         Self {
             tmux_bin: tmux_bin.to_string(),
@@ -323,6 +337,14 @@ not-an-epoch tm-xtest-garbage-01
     ///
     /// The panic message reaching stderr during this run is expected output,
     /// not a failure.
+    ///
+    /// #6523: the spawn and the precondition sit OUTSIDE the `catch_unwind`. In
+    /// the earlier shape both were inside it, so a spawn that FAILED was caught
+    /// by the same handler that the deliberate panic was meant to trip:
+    /// `outcome.is_err()` held for the wrong reason, and `!exists` then held
+    /// trivially because nothing had been created. The test reported `ok` on a
+    /// machine that could not spawn a tmux session at all, while its two
+    /// siblings failed — a false green that hid a third of the evidence.
     #[test]
     fn drop_kills_the_session_even_when_the_body_panics() {
         if !ScratchTmuxSession::tmux_available(TMUX) {
@@ -330,12 +352,15 @@ not-an-epoch tm-xtest-garbage-01
             return;
         }
         let name = scratch_name("panic");
-        let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            let session = ScratchTmuxSession::spawn(TMUX, &name, "sh");
-            assert!(
-                ScratchTmuxSession::exists(TMUX, session.name()),
-                "fixture precondition: the session must be live before the panic"
-            );
+        let session = ScratchTmuxSession::spawn(TMUX, &name, "sh");
+        assert!(
+            ScratchTmuxSession::exists(TMUX, session.name()),
+            "fixture precondition: the session must be live before the panic"
+        );
+        let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+            // Moved in, so the guard drops during THIS unwind — the property
+            // under test.
+            let _owned = session;
             panic!("simulated mid-test failure while the guard is alive");
         }));
         assert!(

--- a/crates/trusty-mpm/tests/test_session_lifecycle.rs
+++ b/crates/trusty-mpm/tests/test_session_lifecycle.rs
@@ -13,8 +13,42 @@ use std::net::SocketAddr;
 use std::time::{Duration, Instant};
 
 use serde_json::{Value, json};
+use trusty_mpm::core::host_state_gate::ALLOW_HOST_STATE_ENV;
 use trusty_mpm::daemon::state::DaemonState;
 use trusty_mpm::daemon::tmux::TmuxDriver;
+
+/// RAII override of one environment variable, restored on drop.
+///
+/// Why: `$HOME` is process-global, and an assertion failure between the set and
+/// a manual restore would leak the scratch value into the harness's own
+/// teardown. Same shape as `scratch_home_tmux_gate.rs`'s guard — this binary
+/// holds exactly ONE test (`full_user_cycle`), which is what makes a plain
+/// process-global override safe here without `#[serial_test::file_serial]`:
+/// under both `cargo test` and `cargo nextest` no other test shares the process.
+struct EnvOverride {
+    key: &'static str,
+    prev: Option<std::ffi::OsString>,
+}
+
+impl EnvOverride {
+    fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+        let prev = std::env::var_os(key);
+        // SAFETY: single-test binary — no other thread reads or writes the
+        // environment while this runs.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, prev }
+    }
+}
+
+impl Drop for EnvOverride {
+    fn drop(&mut self) {
+        // SAFETY: as in `set` — single-test binary.
+        match self.prev.take() {
+            Some(v) => unsafe { std::env::set_var(self.key, v) },
+            None => unsafe { std::env::remove_var(self.key) },
+        }
+    }
+}
 
 /// True when a tmux session named `name` is live on this host.
 ///
@@ -107,8 +141,25 @@ async fn wait_for_health(base: &str) {
 /// Note: tmux send/capture are not exercised (tmux may not be installed in CI);
 /// the command and output endpoints are called but the underlying driver ops
 /// are best-effort and errors are logged rather than propagated to the test.
+/// `$HOME` is redirected to a scratch directory for the whole run (#6523), so
+/// the pause step writes its `pause.json` there rather than into the operator's
+/// real `~/.trusty-mpm/sessions/`.
 #[tokio::test]
 async fn full_user_cycle() {
+    // #6523: `$HOME` is both the daemon's data root (`~/.trusty-mpm`) and the
+    // base `core::session_store::pause_path` resolves, so step 5's pause wrote a
+    // real `~/.trusty-mpm/sessions/<uuid>/pause.json` into the operator's home
+    // on every run and nothing removed it. Set before `TestServer::spawn`, which
+    // resolves `FrameworkPaths::default()` at construction.
+    let scratch_home = tempfile::tempdir().expect("scratch home");
+    let _home = EnvOverride::set("HOME", scratch_home.path());
+    // #6523: a scratch `$HOME` is precisely what `host_state_gate` refuses tmux
+    // under (#5784), and step 11's #1454 assertion needs a REAL tmux host to
+    // mean anything — without the opt-in `tmux_available` reads false and the
+    // whole tmux arm silently vanishes. This is the hatch that gate documents
+    // for a test that deliberately wants an isolated `$HOME` AND real tmux.
+    let _allow_host_state = EnvOverride::set(ALLOW_HOST_STATE_ENV, "1");
+
     let server = TestServer::spawn().await;
     let client = reqwest::Client::new();
 


### PR DESCRIPTION
Refs #6523

Root cause of the five failures is NOT nested tmux: the host's pty pool is exhausted by ~465 leaked idle `tm-<uuid>` zsh sessions (separate bug being filed); this PR makes the failure legible and removes two test defects it exposed.

What lands: `ScratchTmuxSession::spawn` uses `.output()` and quotes tmux's stderr in the panic (before: only `exit status: 1`); `drop_kills_the_session_even_when_the_body_panics` had a vacuous pass (spawn inside its own `catch_unwind`) — spawn moved out, so the lib target now reports 3 failures on this host instead of 2, a false green removed; `full_user_cycle` redirects `$HOME` to a scratch dir via a drop-restoring `EnvOverride` and takes the documented `TRUSTY_MPM_ALLOW_HOST_STATE` opt-in so the #1454 real-tmux arm still runs — `~/.trusty-mpm/sessions/` 2969 entries before and after. No production code changed.

Test ladder: rung 2. On this host the tmux family stays red (ENXIO from `openpty`, 0/10 in and out of tmux — machine state, not code); `cargo fmt --check`, `cargo clippy -p trusty-mpm --all-targets -- -D warnings`, `check_line_cap.sh`, `check_sld.sh`, `check_changelog_fragment.sh` all clean. CI (Linux runners) is the green proof for the fixture change.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools