### PR TITLE
chore(trusty-mpm): regenerate tm-capabilities catalog for adopt-worktree (Refs #6497)

### DIFF
--- a/crates/trusty-mpm/src/assets/skills/tm-capabilities/references/cli.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-capabilities/references/cli.md
@@ -123,6 +123,7 @@ Generated from `Cli::command()` (clap's command-tree introspection) — every `t
   - `stop` — Stop a session (graceful by default, --force for immediate)
 - `session` — \[DEPRECATED\] Alias of `sessions` (#2116) — use `tm sessions <verb>`
   - `activity` — Show recent activity for a managed session
+  - `adopt-worktree` — Take over a worktree whose owning session or agent is dead (#6497)
   - `answer` — Answer a managed session's pending decision
   - `attach` — Print the tmux attach command for a managed session
   - `breakers` — Show every agent's circuit-breaker state
@@ -156,6 +157,7 @@ Generated from `Cli::command()` (clap's command-tree introspection) — every `t
   - `tui` — Launch the coordinator TUI: an input box over a live session list (#1272)
 - `sessions` — Define and manage Claude Code sessions within a project
   - `activity` — Show recent activity for a managed session
+  - `adopt-worktree` — Take over a worktree whose owning session or agent is dead (#6497)
   - `answer` — Answer a managed session's pending decision
   - `attach` — Print the tmux attach command for a managed session
   - `breakers` — Show every agent's circuit-breaker state


### PR DESCRIPTION
Refs #6497. Follow-up to [#6528](https://github.com/bobmatnyc/trusty-tools/pull/6528): the new `tm session adopt-worktree` verb left `tm-capabilities/references/cli.md` stale and the (non-required) drift check red on main. Regenerated with `tm generate capabilities`; `scripts/check_capabilities.sh` → `up to date (7 generated files)`. One generated file, +2 lines. Docs-only.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools