### PR TITLE
docs: setup-doc review edits — tctl doctor cheat-sheet rows, default local URLs, btop GPU tip

### DIFF
--- a/crates/trusty-search/README.md
+++ b/crates/trusty-search/README.md
@@ -728,6 +728,10 @@ Run `trusty-search doctor` for a 6-check diagnostic. Common causes:
 - Stale PID lockfile: `trusty-search doctor --fix` removes it automatically
 - Less than 16 GB RAM: the daemon performs a hard RAM check and exits with an actionable error. Set `TRUSTY_SKIP_RAM_CHECK=1` in the daemon environment to bypass for small workloads; not recommended on large corpora (risk of OOM during indexing)
 
+**High GPU load during indexing**
+
+During an initial index or reindex, embedding is the GPU-heavy stage — `btop` (or Activity Monitor → GPU) shows the load, and the search dashboard's per-collection panel can pause embedding.
+
 **Embedder stuck on "initializing"**
 
 The ONNX Runtime initializes the model on first start and may take 30–60 seconds on slower machines. If it hangs indefinitely, increase the timeout:

--- a/docs/getting-started/install-and-run-tm.md
+++ b/docs/getting-started/install-and-run-tm.md
@@ -363,7 +363,8 @@ See [claude-mpm vs trusty-mpm — Differences & Install](./claude-mpm-vs-trusty-
 | `tctl upgrade [members]` | Upgrade to BOM-pinned versions. |
 | `tctl updates` | List available updates + changelog. |
 | `tctl status` | One-line stack summary. |
-| `tctl doctor` | Full system health check. |
+| `tctl stack doctor [member]` | Deep diagnostic sweep — tools×scope matrix, drill-down, remediation. |
+| `tctl doctor --self-check <member>` | Per-member DOC-1 conformance self-check (contract envelope, `verbs[]`, secret redaction). |
 | `tctl config` | Print effective configuration. |
 | `tctl version` | Print versions: installer + stack members. |
 | `tctl start [members]` | Start daemon(s). |

--- a/docs/reference/running-mcp-servers.md
+++ b/docs/reference/running-mcp-servers.md
@@ -48,6 +48,14 @@ cargo build --release -p trusty-search
 ./target/release/trusty-search start
 ```
 
+## Default local URLs
+
+| Service | Default URL |
+|---|---|
+| trusty-console | `http://127.0.0.1:7788` |
+| trusty-search | `http://127.0.0.1:7878` |
+| trusty-memory | `http://127.0.0.1:7070` |
+
 To wire a locally-built binary into Claude Code, update your project's
 `.mcp.json` or `~/.claude/mcp.json` to point `command` at the absolute path
 of the built binary (e.g. `target/release/trusty-search`).


### PR DESCRIPTION
## What

Three docs edits surfaced by the Duetto setup-doc review:

- `docs/getting-started/install-and-run-tm.md`: replaces incorrect `tctl doctor` "full health check" row with `tctl stack doctor [member]` (deep sweep) and `tctl doctor --self-check <member>` (DOC-1 conformance), verified against `crates/trusty-installer/src/cli.rs`
- `docs/reference/running-mcp-servers.md`: adds "Default local URLs" table (console 7788, search 7878, memory 7070)
- `crates/trusty-search/README.md`: adds "High GPU load during indexing" troubleshooting note

## Test ladder

Rung 1 (docs only). Gates run:
- `check_sld.sh`: 0 errors, 0 warnings
- `check_public_docs.sh`: 27 pages OK
- `check_doc_numbers.sh`: 0 violations
- `check_line_cap.sh`: 0 violations
- `check_changelog_fragment.sh`: no crate source changed — OK

Both edited docs are already in `docs/public-manifest.tsv`; no manifest change.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools