### PR TITLE
feat(trusty-common): log_drain core — destination adapters, URI parsing, manifest, collector with scrub (Refs #6534)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1987,6 +1987,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc-fast"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
+dependencies = [
+ "digest 0.10.7",
+ "spin 0.10.1",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4379,7 +4389,7 @@ dependencies = [
  "hash32",
  "rustc_version",
  "serde",
- "spin",
+ "spin 0.9.9",
  "stable_deref_trait",
 ]
 
@@ -4615,6 +4625,12 @@ checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
 dependencies = [
  "libm",
 ]
+
+[[package]]
+name = "humantime"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
 
 [[package]]
 name = "hybrid-array"
@@ -5177,6 +5193,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5249,6 +5274,36 @@ dependencies = [
  "thiserror 1.0.69",
  "walkdir",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5730,7 +5785,7 @@ dependencies = [
  "indexmap 2.14.0",
  "itoa",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "nom 8.0.0",
  "rand 0.10.2",
  "rangemap",
@@ -5900,6 +5955,16 @@ checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -6264,6 +6329,18 @@ name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags 2.13.1",
  "cfg-if",
@@ -6752,6 +6829,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "object_store"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d354792e39fa5f0009e47623cf8b15b099bf9a652fa55c6f817fe28ac84fea50"
+dependencies = [
+ "async-trait",
+ "aws-lc-rs",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "crc-fast",
+ "form_urlencoded",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body-util",
+ "humantime",
+ "hyper 1.9.0",
+ "itertools 0.15.0",
+ "md-5 0.11.0",
+ "nix 0.31.3",
+ "parking_lot",
+ "percent-encoding",
+ "quick-xml",
+ "rand 0.10.2",
+ "reqwest 0.13.3",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
+ "wasm-bindgen-futures",
+ "web-time",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7629,6 +7748,7 @@ checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "encoding_rs",
  "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -7657,6 +7777,7 @@ version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.4.2",
  "lru-slab",
@@ -8304,19 +8425,26 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
+ "h2 0.4.14",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.9.0",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper 1.0.2",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -8561,6 +8689,33 @@ dependencies = [
  "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni 0.22.4",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework 3.7.0",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -9168,6 +9323,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
 name = "simd_helpers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9175,6 +9340,12 @@ checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
 dependencies = [
  "quote",
 ]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "similar"
@@ -9321,6 +9492,12 @@ checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]
+
+[[package]]
+name = "spin"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 
 [[package]]
 name = "spm_precompiled"
@@ -9713,7 +9890,7 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "ndk",
@@ -9781,7 +9958,7 @@ dependencies = [
  "heck 0.5.0",
  "http 1.4.0",
  "image",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "mime",
@@ -9945,7 +10122,7 @@ dependencies = [
  "dpi",
  "gtk",
  "http 1.4.0",
- "jni",
+ "jni 0.21.1",
  "objc2",
  "objc2-ui-kit",
  "objc2-web-kit",
@@ -9968,7 +10145,7 @@ checksum = "b83849ee63ecb27a8e8d0fe51915ca215076914aca43f96db1179f0f415f6cd9"
 dependencies = [
  "gtk",
  "http 1.4.0",
- "jni",
+ "jni 0.21.1",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -11432,11 +11609,13 @@ dependencies = [
  "anyhow",
  "async-trait",
  "aws-config",
+ "aws-credential-types",
  "aws-sdk-bedrockruntime",
  "aws-smithy-types",
  "aws-types",
  "axum",
  "base64 0.22.1",
+ "bytes",
  "candle-core 0.8.4",
  "candle-nn 0.8.4",
  "candle-transformers",
@@ -11449,10 +11628,12 @@ dependencies = [
  "dotenvy",
  "fastembed",
  "fd-lock",
+ "flate2",
  "futures",
  "futures-util",
  "genco",
  "git2",
+ "globset",
  "hex",
  "hf-hub 0.3.2",
  "hmac 0.12.1",
@@ -11461,6 +11642,7 @@ dependencies = [
  "keyring",
  "libc",
  "lru 0.16.4",
+ "object_store",
  "ort",
  "parking_lot",
  "petgraph 0.8.3",
@@ -13657,7 +13839,7 @@ dependencies = [
  "gtk",
  "http 1.4.0",
  "javascriptcore-rs",
- "jni",
+ "jni 0.21.1",
  "libc",
  "ndk",
  "objc2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -391,6 +391,31 @@ aws-config             = { version = "1.8", features = ["behavior-version-latest
 aws-sdk-bedrockruntime = { version = "1.131", default-features = false, features = ["default-https-client", "rt-tokio"] }
 aws-types              = { version = "1" }
 aws-smithy-types       = { version = "1.4" }
+# #6533: the log drain's S3 adapter bridges the AWS default credential chain
+# into `object_store`'s own `CredentialProvider`, which means calling
+# `ProvideCredentials::provide_credentials`. `aws-types` re-exports the
+# `SharedCredentialsProvider` HANDLE but not the TRAIT, so the trait has to come
+# from its own crate. Already resolved in `Cargo.lock` as a transitive dep of
+# `aws-config`, so declaring it direct adds no new crate to the graph.
+aws-credential-types   = { version = "1.2" }
+
+# ── Object storage (optional; used by trusty-common's `log-drain` feature) ──
+# #6533: the log drain's destination adapters. `aws` is the ONLY backend feature
+# enabled — it brings `AmazonS3Builder` for `s3://` URIs. `LocalFileSystem`
+# (`file://`, the hermetic-test destination) is in the crate core and needs no
+# feature. `gs://` and `az://` are deliberately NOT enabled: the URI parser
+# reserves those schemes and rejects them with `DrainError::UnsupportedScheme`,
+# so turning on `gcp`/`azure` here would compile two backends nothing reaches.
+# `default-features = false` keeps the generic `http` (WebDAV) backend and its
+# extra TLS stack out of the graph — the drain only ever talks S3 or local disk.
+# `fs` is re-enabled explicitly because dropping the defaults also drops
+# `LocalFileSystem`, which the `file://` destination and every hermetic test need.
+object_store = { version = "0.14", default-features = false, features = ["aws", "fs"] }
+# Cheaply-cloneable reference-counted byte buffer. `object_store` already
+# resolves it (its `PutPayload` is built from `Bytes`), so declaring it direct
+# adds no new crate to the lockfile — it only lets `LogDestination::put` name
+# the type in its own signature rather than leaking `object_store`'s re-export.
+bytes = "1"
 
 # ── trusty-analyze additional deps ────────────────────────────────────────
 clap_complete = "4"

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -101,6 +101,11 @@ lanes = [
         # `console_metrics::machine_status` module (which needs BOTH) is compiled
         # and tested by the core lane, not silently skipped.
         "host-metrics",
+        # #6533: log-drain implies `credentials`, which this lane does not
+        # otherwise carry. It sits here rather than in `inference` so the
+        # collector's `scrub_secrets` path is exercised by the lane that already
+        # owns the crate's filesystem-facing modules.
+        "log-drain",
         "update-check",
         "bug-capture",
         "session-naming",
@@ -338,6 +343,20 @@ aws-config = { workspace = true, optional = true }
 aws-sdk-bedrockruntime = { workspace = true, optional = true }
 aws-types = { workspace = true, optional = true }
 aws-smithy-types = { workspace = true, optional = true }
+
+# Optional: enabled by the `log-drain` feature (#6533). `object_store` supplies
+# both destination adapters — `AmazonS3Builder` for `s3://` and
+# `LocalFileSystem` for `file://`. `bytes` names the payload type in
+# `LogDestination::put`'s own signature. `flate2` gzips each body on the wire,
+# `sha2` produces the manifest's plaintext digest, `globset` compiles a
+# `LogSource`'s include patterns, and `walkdir` enumerates its root. Every one
+# of these is already an optional workspace dep pulled in by some other feature;
+# only `object_store` and `bytes` are new to the lockfile.
+object_store = { workspace = true, optional = true }
+bytes = { workspace = true, optional = true }
+aws-credential-types = { workspace = true, optional = true }
+flate2 = { workspace = true, optional = true }
+globset = { workspace = true, optional = true }
 
 # Optional: enabled by the `catchup` feature (DOC-28 cutover bridge, #1762).
 # rusqlite is used only by the `mpm_registry` submodule to read the
@@ -798,6 +817,35 @@ console-metrics = ["stdio-mcp-client"]
 # consumer's build. Adds no new crate to the lockfile — only two extra sysinfo
 # features, and only for a consumer that opts in.
 host-metrics = ["sysinfo/disk", "sysinfo/network"]
+
+# Enables the `log_drain` module (#6533, epic phase 1+2): the `LogDestination`
+# trait, its `s3://` and `file://` adapters, the `DestinationUri` parser, the
+# key layout, the idempotency manifest, the collector, and `run_once`. Phase 1+2
+# is the drain CORE only — no scheduler, and no consumer wired up yet.
+#
+# Why gated: `object_store` with the `aws` backend pulls the AWS SDK transport
+# stack, which the 20-plus consumers that never drain a log must not compile.
+# `credentials` is a hard implication rather than an optional extra — the
+# collector runs every body through `credentials::redact::scrub_secrets` before
+# it reaches a destination, so a build with the drain but without the scrubber
+# would upload log text nothing had cleaned. Making it a feature implication is
+# what stops that combination existing.
+# `dep:aws-config`/`dep:aws-types` supply the S3 adapter's credential chain —
+# the same providers the `bedrock` features use, reused rather than duplicated
+# per the common-entry-point rule.
+log-drain = [
+    "credentials",
+    "dep:object_store",
+    "dep:bytes",
+    "dep:flate2",
+    "dep:globset",
+    "dep:walkdir",
+    "dep:sha2",
+    "dep:futures",
+    "dep:aws-config",
+    "dep:aws-types",
+    "dep:aws-credential-types",
+]
 
 # Enables the top-level `credentials` module (issue #2401, epic #2400 Wave 1;
 # promoted out of `inference::` by #4564): the `KeyStore` trait,

--- a/crates/trusty-common/changelog.d/6533-log-drain-core.md
+++ b/crates/trusty-common/changelog.d/6533-log-drain-core.md
@@ -1,0 +1,16 @@
+Added
+
+- `log_drain` module (behind the new `log-drain` feature): uploads trusty-* log
+  files to object storage. Ships the `LogDestination` trait with `s3://` and
+  `file://` adapters over `object_store`, a closed-scheme `DestinationUri` parser
+  (`gs://`/`az://` are reserved and refused), the
+  `<prefix>/<github_id>/<session_id>/logs/<crate>/<file>` key layout, a
+  size+mtime+SHA-256 manifest that makes a re-run skip unchanged files, and a
+  collector that level-filters `tracing` output, scrubs secrets via
+  `credentials::scrub_secrets`, and gzips each body before `run_once` uploads it
+  (#6533). S3 credentials come from the AWS default provider chain already used
+  by the Bedrock adapters; no bucket or region is hardcoded. This is the drain
+  core only — no scheduler, no consumers, and no GitHub-identity resolution: the
+  caller supplies a `DrainTarget`, and an empty `github_id` or `session_id` is
+  refused rather than defaulted. The `log-drain` feature implies `credentials`
+  so the scrub cannot be compiled out from under the collector.

--- a/crates/trusty-common/src/lib.rs
+++ b/crates/trusty-common/src/lib.rs
@@ -517,6 +517,24 @@ pub mod stdio_mcp_client;
 #[cfg(feature = "host-metrics")]
 pub mod host_metrics;
 
+/// Upload trusty-* log files to object storage (#6533).
+///
+/// Why: every trusty daemon writes logs to a local path that nothing prunes and
+/// nothing collects, so diagnosing a failure on another machine means asking a
+/// human to find and send a file. The drain lives here rather than in any one
+/// daemon because five crates produce logs and the common-entry rule gives that
+/// capability exactly one implementation.
+/// What: gated behind the `log-drain` feature, which implies `credentials` so
+/// the collector's [`credentials::scrub_secrets`] pass cannot be
+/// compiled out from under it. Exposes the [`log_drain::LogDestination`] trait
+/// with `s3://` and `file://` adapters, [`log_drain::DestinationUri`],
+/// [`log_drain::DrainManifest`], [`log_drain::collect`], and
+/// [`log_drain::run_once`]. This is the drain CORE — no scheduler, and no
+/// GitHub-identity resolution; the caller supplies a [`log_drain::DrainTarget`].
+/// Test: `cargo test -p trusty-common --features log-drain --no-fail-fast`.
+#[cfg(feature = "log-drain")]
+pub mod log_drain;
+
 /// Throttled crates.io update-notification helper.
 ///
 /// Why: User-facing CLIs should nudge operators when a newer release is

--- a/crates/trusty-common/src/log_drain/collector.rs
+++ b/crates/trusty-common/src/log_drain/collector.rs
@@ -1,0 +1,355 @@
+//! Reading log files and preparing them for upload (#6533).
+//!
+//! Why: everything that must happen to a log line before it leaves the machine
+//! happens here, in one order, once. Splitting the level filter, the secret
+//! scrub, and the compression across call sites is how a body eventually
+//! reaches a bucket having skipped one of them.
+//! What: [`collect`] walks each [`LogSource`]'s root, matches its globs, and
+//! for every file: filters by level, scrubs secrets, gzips, and yields a
+//! [`CollectedFile`]. The SHA-256 it reports is over the PLAINTEXT bytes as
+//! read, before filtering — so the manifest's identity tracks the source file,
+//! not the drain's own processing, and a change to the filter never invalidates
+//! every recorded digest.
+//! Test: `super::tests::collect_filters_below_info`,
+//! `super::tests::collect_passes_through_non_tracing`,
+//! `super::tests::collect_scrubs_secrets_before_they_reach_the_destination`, `super::tests::collect_skips_oversize`.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use bytes::Bytes;
+use globset::{Glob, GlobSetBuilder};
+use sha2::{Digest, Sha256};
+
+use super::error::DrainError;
+
+/// Default ceiling on a single source file, in bytes.
+///
+/// 64 MiB is well above the trusty daemons' daily rolled logs and well below
+/// anything that would embarrass a machine holding one plaintext copy, one
+/// scrubbed copy, and one gzip buffer at once.
+pub const DEFAULT_MAX_FILE_BYTES: u64 = 64 * 1024 * 1024;
+
+/// Log levels the drain can filter on, ordered least to most severe.
+///
+/// Deliberately not `tracing::Level`: the drain reads level names out of
+/// already-written TEXT, and coupling that string parsing to `tracing`'s type
+/// would make the drain depend on the crate that produced the file rather than
+/// on the file format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[non_exhaustive]
+pub enum Level {
+    /// `TRACE`
+    Trace,
+    /// `DEBUG`
+    Debug,
+    /// `INFO`
+    Info,
+    /// `WARN`
+    Warn,
+    /// `ERROR`
+    Error,
+}
+
+impl Level {
+    /// Map a bare level token to its variant.
+    fn parse(token: &str) -> Option<Self> {
+        match token {
+            "TRACE" => Some(Self::Trace),
+            "DEBUG" => Some(Self::Debug),
+            "INFO" => Some(Self::Info),
+            "WARN" | "WARNING" => Some(Self::Warn),
+            "ERROR" => Some(Self::Error),
+            _ => None,
+        }
+    }
+}
+
+/// One directory of log files to drain, and how to read them.
+///
+/// Why: each producing crate writes a different shape into a different place.
+/// Naming the crate here is what puts its files under their own key segment, so
+/// two crates' `daemon.log` never collide.
+/// What: `root` is walked, `include` globs are matched against each path
+/// RELATIVE to `root`, and `level_filter` — when set — drops lines below that
+/// level in files the drain recognises as `tracing_subscriber::fmt` output.
+/// Test: `super::tests::collect_filters_below_info`.
+#[derive(Debug, Clone)]
+pub struct LogSource {
+    /// Producing crate, e.g. `trusty-mpm`. Becomes a key segment.
+    pub crate_name: String,
+    /// Directory to walk.
+    pub root: PathBuf,
+    /// Glob patterns, matched against paths relative to `root`.
+    pub include: Vec<String>,
+    /// Drop lines below this level. `None` uploads every line.
+    pub level_filter: Option<Level>,
+}
+
+/// One file, read and ready to upload.
+#[derive(Debug, Clone)]
+pub struct CollectedFile {
+    /// `<crate>/<relative path>` — the key suffix beneath the target's `logs/`.
+    pub relative_key: String,
+    /// Gzipped, scrubbed, level-filtered body.
+    pub body: Bytes,
+    /// Hex SHA-256 of the PLAINTEXT source bytes as read from disk.
+    pub sha256_plaintext: String,
+    /// Size in bytes of the plaintext source file.
+    pub plaintext_len: u64,
+    /// Source file's modification time, Unix seconds.
+    pub mtime_unix: i64,
+    /// Where it was read from, for error reporting.
+    pub source_path: PathBuf,
+}
+
+/// A source file the collector declined to read.
+#[derive(Debug, Clone)]
+pub struct OversizeFile {
+    /// The path that was skipped.
+    pub path: PathBuf,
+    /// Its size in bytes.
+    pub size: u64,
+}
+
+/// What one [`collect`] pass found.
+#[derive(Debug, Default)]
+pub struct Collected {
+    /// Files read and ready to upload.
+    pub files: Vec<CollectedFile>,
+    /// Files skipped for exceeding `max_file_bytes`.
+    pub oversize: Vec<OversizeFile>,
+    /// Per-file failures. A failure here never aborts the pass.
+    pub errors: Vec<(PathBuf, String)>,
+}
+
+/// Enumerate, read, filter, scrub, and compress every matching log file.
+///
+/// Why: see the module docs — one ordered pipeline, so no body can reach a
+/// destination having skipped the scrub.
+/// What: for each source, compiles its globs once, walks `root`, and processes
+/// each matching file. Files larger than `max_file_bytes` are SKIPPED with a
+/// `warn!` and an [`OversizeFile`] entry rather than streamed in chunks: the
+/// scrub has to see a whole body to catch a secret that straddles a chunk
+/// boundary, so a chunked path could only ever upload partially-scrubbed text.
+/// Refusing to upload is the safe half of that trade, and the report says so
+/// out loud rather than silently truncating.
+/// `secrets` is passed straight to [`crate::credentials::scrub_secrets`],
+/// which ignores needles under its own minimum length.
+/// Test: `super::tests::collect_skips_oversize`, `super::tests::collect_scrubs_secrets_before_they_reach_the_destination`.
+///
+/// # Errors
+/// Returns [`DrainError::Uri`] only for a malformed glob pattern, which is a
+/// caller bug rather than a runtime condition. Per-file IO failures land in
+/// [`Collected::errors`] and do not stop the pass.
+pub fn collect(
+    sources: &[LogSource],
+    secrets: &[String],
+    max_file_bytes: u64,
+) -> Result<Collected, DrainError> {
+    let mut out = Collected::default();
+
+    for source in sources {
+        let mut builder = GlobSetBuilder::new();
+        for pattern in &source.include {
+            let glob = Glob::new(pattern).map_err(|e| DrainError::Uri {
+                uri: pattern.clone(),
+                reason: format!("invalid include glob: {e}"),
+            })?;
+            builder.add(glob);
+        }
+        let globs = builder.build().map_err(|e| DrainError::Uri {
+            uri: source.include.join(","),
+            reason: format!("could not compile include globs: {e}"),
+        })?;
+
+        for entry in walkdir::WalkDir::new(&source.root)
+            .follow_links(false)
+            .into_iter()
+            .filter_map(Result::ok)
+        {
+            if !entry.file_type().is_file() {
+                continue;
+            }
+            let path = entry.path();
+            let Ok(relative) = path.strip_prefix(&source.root) else {
+                continue;
+            };
+            if !globs.is_match(relative) {
+                continue;
+            }
+            process_file(source, path, relative, secrets, max_file_bytes, &mut out);
+        }
+    }
+
+    Ok(out)
+}
+
+/// Read one matched file into `out`, recording an error rather than failing.
+fn process_file(
+    source: &LogSource,
+    path: &Path,
+    relative: &Path,
+    secrets: &[String],
+    max_file_bytes: u64,
+    out: &mut Collected,
+) {
+    let metadata = match std::fs::metadata(path) {
+        Ok(m) => m,
+        Err(e) => {
+            out.errors.push((path.to_path_buf(), e.to_string()));
+            return;
+        }
+    };
+
+    let size = metadata.len();
+    if size > max_file_bytes {
+        // #6533: skip, never truncate — see `collect`'s docs for why a chunked
+        // path cannot scrub a secret that straddles a boundary.
+        tracing::warn!(
+            path = %path.display(),
+            size,
+            max_file_bytes,
+            "log-drain skipping oversize file; it will not be uploaded"
+        );
+        out.oversize.push(OversizeFile {
+            path: path.to_path_buf(),
+            size,
+        });
+        return;
+    }
+
+    let plaintext = match std::fs::read(path) {
+        Ok(b) => b,
+        Err(e) => {
+            out.errors.push((path.to_path_buf(), e.to_string()));
+            return;
+        }
+    };
+
+    let sha256_plaintext = hex_digest(&plaintext);
+    let mtime_unix = mtime_seconds(&metadata);
+
+    // Order is load-bearing: decode, then filter, then scrub, then compress.
+    let text = String::from_utf8_lossy(&plaintext);
+    let filtered = match source.level_filter {
+        Some(min) => filter_by_level(&text, min),
+        None => text.into_owned(),
+    };
+    let scrubbed = crate::credentials::scrub_secrets(&filtered, secrets);
+
+    let body = match gzip(scrubbed.as_bytes()) {
+        Ok(b) => b,
+        Err(e) => {
+            out.errors.push((path.to_path_buf(), e.to_string()));
+            return;
+        }
+    };
+
+    out.files.push(CollectedFile {
+        relative_key: format!("{}/{}", source.crate_name, relative.to_string_lossy()),
+        body: Bytes::from(body),
+        sha256_plaintext,
+        plaintext_len: size,
+        mtime_unix,
+        source_path: path.to_path_buf(),
+    });
+}
+
+/// Drop lines below `min`, leaving non-tracing files untouched.
+///
+/// Why: a daemon's DEBUG output is the bulk of its log bytes and almost never
+/// the reason anyone reads it later. Dropping it before compression is where
+/// the drain's egress saving actually comes from.
+/// What: recognises the `tracing_subscriber::fmt` default line shape —
+/// `<timestamp> <LEVEL> <target>: <message>` — and keeps a line when its level
+/// is at or above `min`. A line carrying no recognisable level is a
+/// CONTINUATION (a wrapped message, a backtrace frame) and inherits the
+/// disposition of the line above it. If the file contains no recognisable
+/// level line at all, it is not tracing output and is returned VERBATIM rather
+/// than filtered to nothing.
+/// Test: `super::tests::collect_filters_below_info`,
+/// `super::tests::collect_passes_through_non_tracing`.
+fn filter_by_level(text: &str, min: Level) -> String {
+    let mut saw_any_level = false;
+    let mut keeping = true;
+    let mut kept = String::with_capacity(text.len());
+
+    for line in text.split_inclusive('\n') {
+        // No level token means a continuation line, which keeps whatever
+        // disposition the line above it had — hence no `else` branch.
+        if let Some(level) = line_level(line) {
+            saw_any_level = true;
+            keeping = level >= min;
+        }
+        if keeping {
+            kept.push_str(line);
+        }
+    }
+
+    if saw_any_level {
+        kept
+    } else {
+        text.to_string()
+    }
+}
+
+/// Extract the level from a `tracing_subscriber::fmt` line, if it has one.
+///
+/// Scans the first few whitespace-separated tokens with ANSI escapes stripped,
+/// so a colourised log (`fmt` with `with_ansi(true)`, which the console layer
+/// uses) is recognised the same as a plain file appender's output.
+fn line_level(line: &str) -> Option<Level> {
+    let plain = strip_ansi(line);
+    // The level is the second token in the default format; allow a little slack
+    // for a prefixed thread name or span without scanning the whole message.
+    plain
+        .split_whitespace()
+        .take(4)
+        .find_map(|token| Level::parse(token.trim_matches(|c: char| !c.is_ascii_alphabetic())))
+}
+
+/// Remove ANSI CSI escape sequences so level detection survives colour output.
+fn strip_ansi(line: &str) -> String {
+    let mut out = String::with_capacity(line.len());
+    let mut chars = line.chars();
+    while let Some(c) = chars.next() {
+        if c != '\u{1b}' {
+            out.push(c);
+            continue;
+        }
+        // ESC [ … <final byte in @-~>. Consume through the terminator.
+        if chars.next() != Some('[') {
+            continue;
+        }
+        for tail in chars.by_ref() {
+            if ('\u{40}'..='\u{7e}').contains(&tail) {
+                break;
+            }
+        }
+    }
+    out
+}
+
+/// Gzip a body at the default compression level.
+fn gzip(body: &[u8]) -> std::io::Result<Vec<u8>> {
+    let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+    encoder.write_all(body)?;
+    encoder.finish()
+}
+
+/// Hex SHA-256 of a byte slice.
+fn hex_digest(body: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(body);
+    format!("{:x}", hasher.finalize())
+}
+
+/// Modification time in Unix seconds, or `0` when the platform withholds it.
+fn mtime_seconds(metadata: &std::fs::Metadata) -> i64 {
+    metadata
+        .modified()
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map_or(0, |d| d.as_secs() as i64)
+}

--- a/crates/trusty-common/src/log_drain/destination.rs
+++ b/crates/trusty-common/src/log_drain/destination.rs
@@ -1,0 +1,424 @@
+//! Where drained logs go, and the two adapters that get them there (#6533).
+//!
+//! Why: `run_once` must be testable without a network, and the drain must not
+//! grow a second upload path when a later phase adds a backend. One
+//! object-safe trait gives both — the tests drive a real `file://` store
+//! through the same code the `s3://` destination uses, so a hermetic pass is
+//! evidence about the production path rather than about a mock.
+//! What: [`LogDestination`], the three-method async trait, and
+//! [`ObjectStoreDestination`], the one implementation. It wraps
+//! `object_store`'s `LocalFileSystem` for `file://` and `AmazonS3` for `s3://`,
+//! selected by [`ObjectStoreDestination::connect`] from a [`DestinationUri`].
+//! S3 credentials come from the AWS default provider chain — the same chain
+//! `inference::bedrock` uses — bridged into `object_store`'s own
+//! `CredentialProvider` by [`AwsChainCredentials`].
+//! Test: `super::tests::destination_roundtrip`, `super::tests::destination_roundtrip`,
+//! `super::tests::destination_list_is_bounded_and_prefix_scoped`, `super::tests::s3_smoke` (gated).
+
+use std::fmt;
+use std::sync::Arc;
+
+use bytes::Bytes;
+use futures::StreamExt;
+use object_store::aws::{AmazonS3Builder, AwsCredential};
+use object_store::local::LocalFileSystem;
+use object_store::path::Path as StorePath;
+use object_store::{
+    Attribute, AttributeValue, Attributes, CredentialProvider, ObjectStore, ObjectStoreExt,
+    PutOptions, PutPayload,
+};
+
+use super::error::DrainError;
+use super::uri::DestinationUri;
+
+/// Ceiling on how many entries [`LogDestination::list`] will return.
+///
+/// Why: `list` exists to reconcile a prefix against the manifest, not to
+/// enumerate a bucket. An unbounded listing over a years-old prefix would pull
+/// an arbitrary number of entries into memory for a comparison that only ever
+/// looks at one session's worth. The cap is the "bounded" in the trait's
+/// contract; a caller that hits it is asking the wrong question.
+pub const LIST_LIMIT: usize = 10_000;
+
+/// Metadata attached to an object as it is written.
+///
+/// Why: the drain gzips every body, and an S3 object served without
+/// `Content-Encoding: gzip` downloads as bytes no browser or `aws s3 cp` will
+/// transparently decompress. Carrying it here keeps the collector (which knows
+/// the body is gzipped) and the destination (which writes the header) from
+/// having to agree implicitly.
+/// What: two optional headers. `#[non_exhaustive]` plus [`Default`] so a later
+/// phase can add a field without breaking construction. A destination that has
+/// no headers to carry drops them — see
+/// [`ObjectStoreDestination`]'s `supports_attributes`.
+/// Test: `super::tests::destination_roundtrip` (the body survives the round
+/// trip on a local store, which is where attributes are dropped);
+/// `super::tests::s3_smoke` is the only path that sends them.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct PutMeta {
+    /// `Content-Type`, e.g. `text/plain`.
+    pub content_type: Option<String>,
+    /// `Content-Encoding`, `gzip` for every body the collector produces.
+    pub content_encoding: Option<String>,
+}
+
+impl PutMeta {
+    /// The metadata every collected log body is written with: gzipped plain text.
+    pub fn gzipped_text() -> Self {
+        Self {
+            content_type: Some("text/plain".to_string()),
+            content_encoding: Some("gzip".to_string()),
+        }
+    }
+}
+
+/// What the destination knows about an object that already exists.
+///
+/// Deliberately narrower than `object_store::ObjectMeta`: the drain compares
+/// sizes and timestamps and never reads an ETag, so exposing one would invite a
+/// caller to depend on a field whose semantics differ per backend.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ObjectMeta {
+    /// Full object key, including the destination prefix.
+    pub key: String,
+    /// Size in bytes of the stored (gzipped) body.
+    pub size: u64,
+    /// Last-modified time as a Unix timestamp in seconds.
+    pub last_modified_unix: i64,
+}
+
+/// A place drained logs can be written.
+///
+/// Why: see the module docs — one trait is what lets the hermetic tests
+/// exercise the production upload path.
+/// What: object-safe (via `#[async_trait]`), so `run_once` takes
+/// `&dyn LogDestination` and a later phase can add a backend without touching
+/// the drain core. Implementors are `Send + Sync` because the scheduler Phase 3
+/// adds will hold one across await points on a multi-threaded runtime.
+/// Test: exercised end-to-end through [`ObjectStoreDestination`] in
+/// `super::tests::run_once_end_to_end`.
+#[async_trait::async_trait]
+pub trait LogDestination: Send + Sync + fmt::Debug {
+    /// Write `body` at `key`, overwriting whatever was there.
+    ///
+    /// Overwrite rather than create-if-absent is deliberate: a re-upload only
+    /// happens when the manifest says the source changed, and in that case the
+    /// newer body is the one that should win.
+    async fn put(&self, key: &str, body: Bytes, meta: PutMeta) -> Result<(), DrainError>;
+
+    /// Look up one object, or `Ok(None)` when it does not exist.
+    ///
+    /// A missing object is `Ok(None)`, never an error — "not uploaded yet" is
+    /// the normal case on a first run, not a failure.
+    async fn head(&self, key: &str) -> Result<Option<ObjectMeta>, DrainError>;
+
+    /// Read one object whole, or `Ok(None)` when it does not exist.
+    ///
+    /// Why this exists alongside `head`: the manifest's "remote copy wins"
+    /// rule (see [`super::manifest::DrainManifest::load`]) needs the remote
+    /// document's CONTENT, not merely its existence — `head` can say a
+    /// manifest is there but not what it records, which would leave the
+    /// authoritative copy unreadable and the rule dead.
+    ///
+    /// Intended for the manifest only. It buffers the whole object, so it must
+    /// not be pointed at a drained log body; `run_once` never does.
+    async fn get(&self, key: &str) -> Result<Option<Bytes>, DrainError>;
+
+    /// List objects under `prefix`, capped at [`LIST_LIMIT`] entries.
+    async fn list(&self, prefix: &str) -> Result<Vec<ObjectMeta>, DrainError>;
+}
+
+/// The `object_store`-backed destination: `s3://` and `file://`.
+///
+/// Why: both schemes are the same three operations over a different transport,
+/// and `object_store` already abstracts exactly that. Writing two adapters
+/// would duplicate the key joining, the error mapping, and the list cap.
+/// What: holds an `Arc<dyn ObjectStore>` plus the URI's key prefix. Every
+/// method joins the prefix onto the caller's key, so callers pass drain-relative
+/// keys and never have to know whether a prefix is in play.
+/// Test: `super::tests::destination_roundtrip` and the `run_once` tests drive
+/// the `file://` form; `super::tests::s3_smoke` drives the `s3://` form when
+/// `TRUSTY_LOG_DRAIN_S3_SMOKE_URI` is set.
+pub struct ObjectStoreDestination {
+    store: Arc<dyn ObjectStore>,
+    prefix: String,
+    label: String,
+    /// Whether the backing store accepts `PutOptions::attributes`.
+    ///
+    /// `LocalFileSystem` REJECTS a put carrying attributes outright — it errors
+    /// with `NotImplemented` rather than ignoring them — because a file on disk
+    /// has nowhere to keep an HTTP header. So the flag is false for `file://`
+    /// and true for S3, and [`LogDestination::put`] drops the attributes rather
+    /// than failing. Nothing is lost: `Content-Encoding` exists to tell an HTTP
+    /// client the body is gzipped, and a local destination has no HTTP client.
+    supports_attributes: bool,
+}
+
+impl fmt::Debug for ObjectStoreDestination {
+    /// Prints the destination label, never the store — an `AmazonS3`'s Debug
+    /// carries its credential provider.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ObjectStoreDestination")
+            .field("destination", &self.label)
+            .finish()
+    }
+}
+
+impl ObjectStoreDestination {
+    /// Build a destination from a parsed URI.
+    ///
+    /// Why: connecting is fallible and async (the S3 path resolves credentials
+    /// through the AWS chain, which may reach IMDS or SSO), so it cannot be a
+    /// `From` impl.
+    /// What: `file://` creates the directory if absent and wraps a
+    /// `LocalFileSystem` rooted there. `s3://` loads the AWS default provider
+    /// chain, bridges it into `object_store`'s `CredentialProvider`, and builds
+    /// an `AmazonS3` for the bucket. The region comes from the URI's
+    /// `?region=` override when present and from the chain otherwise — no
+    /// bucket or region is ever hardcoded.
+    /// Test: `super::tests::destination_roundtrip` (file),
+    /// `super::tests::s3_smoke` (S3, gated on an env var).
+    ///
+    /// # Errors
+    /// - [`DrainError::Io`] when a `file://` root cannot be created or opened.
+    /// - [`DrainError::Credentials`] when the AWS chain yields no region.
+    /// - [`DrainError::Transport`] when the S3 client cannot be constructed.
+    pub async fn connect(uri: &DestinationUri) -> Result<Self, DrainError> {
+        match uri {
+            DestinationUri::File { path } => {
+                std::fs::create_dir_all(path).map_err(|source| DrainError::Io {
+                    path: path.clone(),
+                    source,
+                })?;
+                let store = LocalFileSystem::new_with_prefix(path).map_err(|e| DrainError::Io {
+                    path: path.clone(),
+                    source: std::io::Error::other(e),
+                })?;
+                Ok(Self {
+                    store: Arc::new(store),
+                    prefix: String::new(),
+                    label: format!("file://{}", path.display()),
+                    supports_attributes: false,
+                })
+            }
+            DestinationUri::S3 {
+                bucket,
+                prefix,
+                region,
+            } => Self::connect_s3(bucket, prefix, region.as_deref()).await,
+        }
+    }
+
+    /// Build the S3 store: resolve credentials and region, then hand both to
+    /// `AmazonS3Builder`.
+    async fn connect_s3(
+        bucket: &str,
+        prefix: &str,
+        region_override: Option<&str>,
+    ) -> Result<Self, DrainError> {
+        let label = format!("s3://{bucket}/{prefix}");
+
+        // #6533: the same default provider chain `inference::bedrock` loads —
+        // env vars, `~/.aws/credentials`, SSO, IMDS — reused rather than
+        // reimplemented, per the common-entry-point rule.
+        let sdk_config = aws_config::defaults(aws_config::BehaviorVersion::latest())
+            .load()
+            .await;
+
+        let region = region_override
+            .map(str::to_string)
+            .or_else(|| sdk_config.region().map(|r| r.as_ref().to_string()))
+            .ok_or_else(|| DrainError::Credentials {
+                uri: label.clone(),
+                source: "no AWS region: none in the URI's `?region=`, none from the \
+                         credential chain (set AWS_REGION or add `?region=` to the URI)"
+                    .into(),
+            })?;
+
+        let provider =
+            sdk_config
+                .credentials_provider()
+                .ok_or_else(|| DrainError::Credentials {
+                    uri: label.clone(),
+                    source: "the AWS default provider chain supplied no credentials provider"
+                        .into(),
+                })?;
+
+        let store = AmazonS3Builder::new()
+            .with_bucket_name(bucket)
+            .with_region(&region)
+            .with_credentials(Arc::new(AwsChainCredentials { inner: provider }))
+            .build()
+            .map_err(|source| DrainError::Transport {
+                op: "connect",
+                key: label.clone(),
+                source,
+            })?;
+
+        Ok(Self {
+            store: Arc::new(store),
+            prefix: prefix.to_string(),
+            label,
+            supports_attributes: true,
+        })
+    }
+
+    /// Join the destination prefix onto a drain-relative key.
+    fn absolute(&self, key: &str) -> String {
+        if self.prefix.is_empty() {
+            key.to_string()
+        } else {
+            format!("{}/{}", self.prefix, key)
+        }
+    }
+
+    /// Convert an `object_store::ObjectMeta` into the drain's narrower shape.
+    fn convert(meta: object_store::ObjectMeta) -> ObjectMeta {
+        ObjectMeta {
+            key: meta.location.as_ref().to_string(),
+            size: meta.size,
+            last_modified_unix: meta.last_modified.timestamp(),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl LogDestination for ObjectStoreDestination {
+    async fn put(&self, key: &str, body: Bytes, meta: PutMeta) -> Result<(), DrainError> {
+        let absolute = self.absolute(key);
+        let path = StorePath::from(absolute.as_str());
+
+        let mut attributes = Attributes::new();
+        // See `supports_attributes`: a local store errors on any attribute at
+        // all, so they are dropped rather than sent.
+        if self.supports_attributes {
+            if let Some(ct) = meta.content_type {
+                attributes.insert(Attribute::ContentType, AttributeValue::from(ct));
+            }
+            if let Some(ce) = meta.content_encoding {
+                attributes.insert(Attribute::ContentEncoding, AttributeValue::from(ce));
+            }
+        }
+
+        let options = PutOptions {
+            attributes,
+            ..PutOptions::default()
+        };
+
+        self.store
+            .put_opts(&path, PutPayload::from_bytes(body), options)
+            .await
+            .map_err(|source| DrainError::Transport {
+                op: "put",
+                key: absolute,
+                source,
+            })?;
+        Ok(())
+    }
+
+    async fn head(&self, key: &str) -> Result<Option<ObjectMeta>, DrainError> {
+        let absolute = self.absolute(key);
+        let path = StorePath::from(absolute.as_str());
+        match self.store.head(&path).await {
+            Ok(meta) => Ok(Some(Self::convert(meta))),
+            // Absent is the normal first-run case, not a failure.
+            Err(object_store::Error::NotFound { .. }) => Ok(None),
+            Err(source) => Err(DrainError::Transport {
+                op: "head",
+                key: absolute,
+                source,
+            }),
+        }
+    }
+
+    async fn get(&self, key: &str) -> Result<Option<Bytes>, DrainError> {
+        let absolute = self.absolute(key);
+        let path = StorePath::from(absolute.as_str());
+        let result = match self.store.get(&path).await {
+            Ok(result) => result,
+            Err(object_store::Error::NotFound { .. }) => return Ok(None),
+            Err(source) => {
+                return Err(DrainError::Transport {
+                    op: "get",
+                    key: absolute,
+                    source,
+                });
+            }
+        };
+        let bytes = result
+            .bytes()
+            .await
+            .map_err(|source| DrainError::Transport {
+                op: "get",
+                key: absolute,
+                source,
+            })?;
+        Ok(Some(bytes))
+    }
+
+    async fn list(&self, prefix: &str) -> Result<Vec<ObjectMeta>, DrainError> {
+        let absolute = self.absolute(prefix);
+        let path = StorePath::from(absolute.as_str());
+        let mut stream = self.store.list(Some(&path));
+        let mut out = Vec::new();
+        while let Some(next) = stream.next().await {
+            let meta = next.map_err(|source| DrainError::Transport {
+                op: "list",
+                key: absolute.clone(),
+                source,
+            })?;
+            out.push(Self::convert(meta));
+            if out.len() >= LIST_LIMIT {
+                tracing::warn!(
+                    prefix = %absolute,
+                    limit = LIST_LIMIT,
+                    "log-drain list hit its entry cap; results truncated"
+                );
+                break;
+            }
+        }
+        Ok(out)
+    }
+}
+
+/// Bridges the AWS default credential chain into `object_store`'s provider trait.
+///
+/// Why: `object_store` signs its own S3 requests and wants an
+/// `AwsCredentialProvider`; `aws-config` owns the chain that knows about env
+/// vars, profiles, SSO, and IMDS. Reimplementing that chain to satisfy
+/// `object_store` would be a second credential resolver in a workspace that
+/// already has one, which the common-entry-point rule forbids.
+/// What: holds a `SharedCredentialsProvider` and re-fetches on every
+/// `get_credential` call, so a rotated or refreshed session token is picked up
+/// without rebuilding the store. `object_store` caches the result for the
+/// credential's lifetime, so this is not a per-request round trip.
+/// Test: `super::tests::s3_smoke` (gated) is the only path that exercises it —
+/// there is no way to prove a credential bridge against a local filesystem.
+#[derive(Debug)]
+struct AwsChainCredentials {
+    inner: aws_types::sdk_config::SharedCredentialsProvider,
+}
+
+#[async_trait::async_trait]
+impl CredentialProvider for AwsChainCredentials {
+    type Credential = AwsCredential;
+
+    async fn get_credential(&self) -> object_store::Result<Arc<AwsCredential>> {
+        use aws_credential_types::provider::ProvideCredentials;
+
+        let creds = self.inner.provide_credentials().await.map_err(|e| {
+            object_store::Error::Unauthenticated {
+                path: "aws-credential-chain".to_string(),
+                source: Box::new(e),
+            }
+        })?;
+
+        Ok(Arc::new(AwsCredential {
+            key_id: creds.access_key_id().to_string(),
+            secret_key: creds.secret_access_key().to_string(),
+            token: creds.session_token().map(str::to_string),
+        }))
+    }
+}

--- a/crates/trusty-common/src/log_drain/error.rs
+++ b/crates/trusty-common/src/log_drain/error.rs
@@ -1,0 +1,118 @@
+//! The log drain's error contract (#6533).
+//!
+//! Why: the drain fails in six materially different ways and the caller acts
+//! differently on each. A malformed URI is an operator typo fixed in config; a
+//! credential failure is an environment problem that will not resolve on
+//! retry; a transport failure is transient and the next scheduled run may
+//! succeed; a missing identity is a REFUSAL, not a failure, and must never be
+//! retried into an upload. Collapsing those into one opaque string would make
+//! the scheduler Phase 3 adds unable to tell "stop asking" from "try later".
+//! What: [`DrainError`], a `thiserror` enum. `#[non_exhaustive]` so a later
+//! phase can add a variant without a breaking change on a `0.x` crate.
+//! Test: `super::tests::uri_*` (the URI and scheme variants),
+//! `super::tests::run_once_refuses_empty_github_id` and
+//! `super::tests::run_once_refuses_empty_session_id` (identity refusal).
+
+use std::path::PathBuf;
+
+/// Every way the log drain can fail or refuse.
+///
+/// Why: see the module docs — the caller's response differs per variant, so
+/// the variants are the contract, not decoration.
+/// What: seven variants covering scheme rejection, URI syntax, credential
+/// resolution, object-store transport, local IO, manifest decoding, and the
+/// fail-closed identity refusal.
+/// Test: `super::tests::uri_table_rejects`, `super::tests::uri_reserved_schemes`,
+/// `super::tests::run_once_refuses_empty_github_id`.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum DrainError {
+    /// A URI naming a scheme the drain deliberately does not implement.
+    ///
+    /// `gs://` and `az://` reach this variant on purpose: the parser reserves
+    /// them so a config pointing at Google or Azure storage fails with a clear
+    /// message instead of the generic "malformed URI" a bare rejection gives.
+    #[error(
+        "unsupported destination scheme `{scheme}://` in `{uri}` — \
+         the log drain supports `s3://` and `file://` only"
+    )]
+    UnsupportedScheme {
+        /// The scheme as written, without the `://`.
+        scheme: String,
+        /// The full URI the operator supplied.
+        uri: String,
+    },
+
+    /// A URI whose syntax the parser could not make sense of.
+    #[error("malformed destination URI `{uri}`: {reason}")]
+    Uri {
+        /// The full URI the operator supplied.
+        uri: String,
+        /// What specifically was wrong, in operator-facing terms.
+        reason: String,
+    },
+
+    /// The AWS credential chain produced no usable credentials.
+    ///
+    /// Distinct from [`DrainError::Transport`] because retrying does not help:
+    /// the environment has no credentials, and the next scheduled run will fail
+    /// identically until an operator fixes it.
+    #[error("AWS credentials unavailable for `{uri}`: {source}")]
+    Credentials {
+        /// The destination whose credentials could not be resolved.
+        uri: String,
+        /// The underlying provider-chain error.
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    /// The object store rejected or could not complete a request.
+    #[error("object-store {op} failed for `{key}`: {source}")]
+    Transport {
+        /// Which operation failed — `put`, `head`, or `list`.
+        op: &'static str,
+        /// The full object key (or prefix, for `list`).
+        key: String,
+        /// The underlying `object_store` error.
+        #[source]
+        source: object_store::Error,
+    },
+
+    /// A local filesystem operation failed.
+    #[error("io error at `{}`: {source}", path.display())]
+    Io {
+        /// The path being read, written, or created.
+        path: PathBuf,
+        /// The underlying IO error.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// A manifest object exists but could not be decoded.
+    ///
+    /// Never fatal to a run: [`super::run_once`] treats an undecodable manifest
+    /// as an absent one and re-uploads, because uploading a file twice is
+    /// strictly safer than skipping one that was never uploaded.
+    #[error("drain manifest at `{key}` is unreadable: {reason}")]
+    Manifest {
+        /// The manifest's object key.
+        key: String,
+        /// Why it could not be decoded.
+        reason: String,
+    },
+
+    /// The caller supplied an empty identity component.
+    ///
+    /// Why this is an error and not a default: the key layout puts every
+    /// uploaded byte under `<github_id>/<session_id>`. An empty component
+    /// collapses one user's logs into a shared, unattributable prefix, so the
+    /// drain fails closed rather than uploading under an unknown id.
+    #[error(
+        "refusing to upload: `{field}` is empty — \
+         the log drain never writes under an unknown identity"
+    )]
+    MissingIdentity {
+        /// Which component was empty: `github_id` or `session_id`.
+        field: &'static str,
+    },
+}

--- a/crates/trusty-common/src/log_drain/manifest.rs
+++ b/crates/trusty-common/src/log_drain/manifest.rs
@@ -1,0 +1,273 @@
+//! The idempotency record that makes a re-run cheap (#6533).
+//!
+//! Why: the drain runs on a schedule over directories that mostly do not
+//! change. Without a record of what was already uploaded, every run re-uploads
+//! every log file — unbounded egress for zero new information. The manifest is
+//! what turns the second run into a stat-only pass.
+//! What: [`DrainManifest`], a per-target JSON document stored both remotely (at
+//! [`MANIFEST_FILENAME`] under the target's `logs/` prefix, where it is
+//! authoritative) and locally under the caller's `state_dir` (a cache, so an
+//! unchanged run needs no network read at all). [`DrainManifest::decide`]
+//! answers upload-or-skip for one source file.
+//! Test: `super::tests::manifest_stat_fast_path_and_sha_tiebreak`,
+//! `super::tests::run_once_reuploads_a_mutated_file`,
+//! `super::tests::run_once_sha_beats_a_moved_mtime`,
+//! `super::tests::manifest_remote_wins_over_local_cache`.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use super::destination::LogDestination;
+use super::error::DrainError;
+
+/// Object name the per-target manifest is written under, inside `logs/`.
+pub const MANIFEST_FILENAME: &str = ".drain-manifest.json";
+
+/// Schema version of the manifest document.
+///
+/// A manifest carrying an unrecognised version is treated as absent rather than
+/// as an error: re-uploading is always safe, mis-reading a schema is not.
+pub const MANIFEST_VERSION: u32 = 1;
+
+/// One uploaded source file, as the manifest remembers it.
+///
+/// Why: the four recorded facts are exactly what [`DrainManifest::decide`]
+/// needs — `size` and `mtime_unix` for the cheap stat-only comparison,
+/// `sha256` for the authoritative content comparison, and `uploaded_at` for an
+/// operator reading the manifest by hand.
+/// What: `relative_file` is the key suffix beneath the target's `logs/` prefix,
+/// i.e. `<crate>/<relative_file>`. It is the entry's identity.
+/// Test: `super::tests::manifest_roundtrip`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ManifestEntry {
+    /// `<crate>/<relative path>` — the portion of the object key below `logs/`.
+    pub relative_file: String,
+    /// Size in bytes of the PLAINTEXT source file, not the gzipped body.
+    pub size: u64,
+    /// Source file's modification time, Unix seconds.
+    pub mtime_unix: i64,
+    /// Hex SHA-256 of the PLAINTEXT source bytes, before scrubbing and gzip.
+    pub sha256: String,
+    /// When this entry was written, RFC 3339.
+    pub uploaded_at: String,
+}
+
+/// The per-target upload record.
+///
+/// Why: see the module docs.
+/// What: a versioned list of [`ManifestEntry`]. Stored as a list rather than a
+/// map so the on-disk document is a stable, diffable, order-independent
+/// artifact an operator can read; the lookup index is built on demand.
+/// Test: `super::tests::manifest_roundtrip`, `super::tests::manifest_stat_fast_path_and_sha_tiebreak`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DrainManifest {
+    /// Schema version — [`MANIFEST_VERSION`] for anything this code writes.
+    pub version: u32,
+    /// One entry per successfully uploaded source file, sorted by `relative_file`.
+    pub entries: Vec<ManifestEntry>,
+}
+
+impl Default for DrainManifest {
+    fn default() -> Self {
+        Self {
+            version: MANIFEST_VERSION,
+            entries: Vec::new(),
+        }
+    }
+}
+
+/// What [`DrainManifest::decide`] concluded about one source file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StatDecision {
+    /// Size AND mtime match the recorded entry — skip without opening the file.
+    SkipUnchanged,
+    /// No entry, or the stat differs. The file must be read and hashed.
+    NeedsHash,
+}
+
+impl DrainManifest {
+    /// Build a `relative_file` → entry index for repeated lookups.
+    fn index(&self) -> HashMap<&str, &ManifestEntry> {
+        self.entries
+            .iter()
+            .map(|e| (e.relative_file.as_str(), e))
+            .collect()
+    }
+
+    /// The cheap first-pass decision, from `stat` alone.
+    ///
+    /// Why: an unchanged run must not read gigabytes of log text to conclude
+    /// nothing changed. Size plus mtime is what a filesystem can answer without
+    /// opening the file, and it is correct for the overwhelmingly common case
+    /// (an append-only log either grew or did not).
+    /// What: returns [`StatDecision::SkipUnchanged`] only when an entry exists
+    /// AND both size and mtime match it. Everything else needs the hash.
+    /// Test: `super::tests::manifest_stat_fast_path_and_sha_tiebreak`.
+    pub fn decide(&self, relative_file: &str, size: u64, mtime_unix: i64) -> StatDecision {
+        match self.index().get(relative_file) {
+            Some(entry) if entry.size == size && entry.mtime_unix == mtime_unix => {
+                StatDecision::SkipUnchanged
+            }
+            _ => StatDecision::NeedsHash,
+        }
+    }
+
+    /// Does the recorded entry's digest match `sha256`?
+    ///
+    /// Why: this is where SHA-256 WINS over mtime. A file whose mtime moved but
+    /// whose bytes are identical — a `touch`, a log rotated back into place, a
+    /// checkout that rewrote timestamps — is NOT re-uploaded. Content identity
+    /// is the thing the drain actually cares about; mtime is only ever an
+    /// optimisation for avoiding the read.
+    /// What: `true` when an entry exists and its `sha256` equals the argument.
+    /// The caller then refreshes the entry's size and mtime via
+    /// [`DrainManifest::record`] so the NEXT run hits the stat-only fast path.
+    /// Test: `super::tests::run_once_sha_beats_a_moved_mtime`.
+    pub fn digest_matches(&self, relative_file: &str, sha256: &str) -> bool {
+        self.index()
+            .get(relative_file)
+            .is_some_and(|entry| entry.sha256 == sha256)
+    }
+
+    /// Insert or replace the entry for one source file.
+    pub fn record(&mut self, entry: ManifestEntry) {
+        match self
+            .entries
+            .iter_mut()
+            .find(|e| e.relative_file == entry.relative_file)
+        {
+            Some(existing) => *existing = entry,
+            None => self.entries.push(entry),
+        }
+        self.entries
+            .sort_by(|a, b| a.relative_file.cmp(&b.relative_file));
+    }
+
+    /// Load the manifest for a target, preferring the remote copy.
+    ///
+    /// Why: the local cache exists so an unchanged run costs no network read,
+    /// but it can be stale or simply absent — a fresh machine, a cleared state
+    /// directory, or an upload that another host performed. When both exist and
+    /// disagree, the REMOTE copy wins, because it is the only one that
+    /// describes what is actually in the bucket. A stale local cache that won
+    /// would make the drain skip files that were never uploaded.
+    /// What: reads the remote object first; on success, refreshes the local
+    /// cache from it and returns it. On absence or an undecodable document,
+    /// falls back to the local cache, and to an empty manifest if that is
+    /// missing too. An undecodable manifest is never fatal — re-uploading is
+    /// strictly safer than skipping something that was never written.
+    /// Test: `super::tests::manifest_remote_wins_over_local_cache`,
+    /// `super::tests::manifest_corrupt_remote_falls_back_to_cache`.
+    ///
+    /// # Errors
+    /// [`DrainError::Transport`] only when the destination itself failed —
+    /// a missing or corrupt manifest is handled, not raised.
+    pub async fn load(
+        dest: &dyn LogDestination,
+        state_dir: &Path,
+        remote_key: &str,
+        cache_key: &str,
+    ) -> Result<Self, DrainError> {
+        let cache_path = cache_file(state_dir, cache_key);
+
+        if let Some(raw) = dest.get(remote_key).await? {
+            match Self::decode(&raw) {
+                Ok(remote) => {
+                    // Remote is authoritative: overwrite whatever the cache held.
+                    write_cache(&cache_path, &remote);
+                    return Ok(remote);
+                }
+                Err(reason) => {
+                    tracing::warn!(
+                        key = %remote_key,
+                        %reason,
+                        "log-drain manifest is undecodable; treating as absent and re-uploading"
+                    );
+                }
+            }
+        }
+
+        Ok(read_cache(&cache_path).unwrap_or_default())
+    }
+
+    /// Write the manifest to the destination and refresh the local cache.
+    ///
+    /// Called after each successful batch so a run interrupted partway still
+    /// leaves the next run able to skip what did land.
+    pub async fn save(
+        &self,
+        dest: &dyn LogDestination,
+        state_dir: &Path,
+        remote_key: &str,
+        cache_key: &str,
+    ) -> Result<(), DrainError> {
+        let body = serde_json::to_vec_pretty(self).map_err(|e| DrainError::Manifest {
+            key: remote_key.to_string(),
+            reason: format!("could not serialise: {e}"),
+        })?;
+
+        dest.put(
+            remote_key,
+            bytes::Bytes::from(body),
+            super::destination::PutMeta {
+                content_type: Some("application/json".to_string()),
+                content_encoding: None,
+            },
+        )
+        .await?;
+
+        write_cache(&cache_file(state_dir, cache_key), self);
+        Ok(())
+    }
+
+    /// Decode a manifest document, rejecting an unrecognised schema version.
+    fn decode(raw: &[u8]) -> Result<Self, String> {
+        let parsed: Self = serde_json::from_slice(raw).map_err(|e| e.to_string())?;
+        if parsed.version != MANIFEST_VERSION {
+            return Err(format!(
+                "schema version {} is not the supported {MANIFEST_VERSION}",
+                parsed.version
+            ));
+        }
+        Ok(parsed)
+    }
+}
+
+/// Where the local cache copy of a target's manifest lives.
+fn cache_file(state_dir: &Path, cache_key: &str) -> PathBuf {
+    state_dir
+        .join("log-drain")
+        .join(cache_key)
+        .join("manifest.json")
+}
+
+/// Read the cache, returning `None` for anything unreadable or undecodable.
+///
+/// A cache miss is ordinary; a corrupt cache is a re-upload, never an error.
+fn read_cache(path: &Path) -> Option<DrainManifest> {
+    let raw = std::fs::read(path).ok()?;
+    DrainManifest::decode(&raw).ok()
+}
+
+/// Best-effort cache write.
+///
+/// A failure here costs the NEXT run one extra remote read and nothing else, so
+/// it is logged and swallowed rather than failing an otherwise-successful
+/// upload.
+fn write_cache(path: &Path, manifest: &DrainManifest) {
+    let Some(parent) = path.parent() else { return };
+    if let Err(e) = std::fs::create_dir_all(parent) {
+        tracing::warn!(path = %parent.display(), error = %e, "log-drain cache dir unwritable");
+        return;
+    }
+    match serde_json::to_vec_pretty(manifest) {
+        Ok(body) => {
+            if let Err(e) = std::fs::write(path, body) {
+                tracing::warn!(path = %path.display(), error = %e, "log-drain cache write failed");
+            }
+        }
+        Err(e) => tracing::warn!(error = %e, "log-drain cache serialisation failed"),
+    }
+}

--- a/crates/trusty-common/src/log_drain/mod.rs
+++ b/crates/trusty-common/src/log_drain/mod.rs
@@ -1,0 +1,298 @@
+//! Upload trusty-* log files to object storage (#6533, epic phase 1+2).
+//!
+//! Why: every trusty daemon writes logs to a local path that nothing prunes and
+//! nothing collects. Diagnosing a failure on someone else's machine means
+//! asking them to find and send a file. This module is the piece that gets
+//! those bytes somewhere durable, scrubbed of credentials, without re-uploading
+//! what has not changed.
+//!
+//! What: the drain CORE — a [`LogDestination`] trait with `s3://` and `file://`
+//! adapters, a [`DestinationUri`] parser, the key layout, an idempotency
+//! [`DrainManifest`], the [`collect`] pipeline, and [`run_once`]. Phase 1+2 is
+//! the core ONLY: there is no scheduler, no config plumbing, and no consumer
+//! wired up. Phase 3 adds those, plus GitHub-identity resolution — this module
+//! deliberately does not resolve an identity, it demands one.
+//!
+//! Test: `tests` (sibling module). Run it with
+//! `cargo test -p trusty-common --features log-drain --no-fail-fast`.
+//!
+//! # Key layout
+//!
+//! ```text
+//! <destination prefix>/<github_id>/<session_id>/logs/<crate>/<relative file>
+//! ```
+//!
+//! The destination prefix comes from the URI (`s3://bucket/PREFIX`); everything
+//! after it is built by [`DrainTarget::logs_prefix`]. Per-target reference
+//! documentation: `docs/reference/log-drain.md`.
+//!
+//! # What the caller owns
+//!
+//! - **Identity.** [`DrainTarget`] is supplied, never resolved here. An empty
+//!   `github_id` or `session_id` is refused with
+//!   [`DrainError::MissingIdentity`] rather than defaulted.
+//! - **Single-flight.** [`run_once`] is exactly what its name says: one pass,
+//!   no locking. Two concurrent runs against one target will both upload and
+//!   both rewrite the manifest, and the loser's entries are lost. The scheduler
+//!   Phase 3 adds owns that mutual exclusion.
+//! - **The secret list.** [`crate::credentials::scrub_secrets`] removes
+//!   values it is GIVEN; it does not detect secret-shaped strings. A caller that
+//!   passes an empty list gets no scrubbing.
+
+mod collector;
+mod destination;
+mod error;
+mod manifest;
+mod uri;
+
+#[cfg(test)]
+mod tests;
+
+use std::path::PathBuf;
+
+pub use collector::{
+    Collected, CollectedFile, DEFAULT_MAX_FILE_BYTES, Level, LogSource, OversizeFile, collect,
+};
+pub use destination::{LIST_LIMIT, LogDestination, ObjectMeta, ObjectStoreDestination, PutMeta};
+pub use error::DrainError;
+pub use manifest::{
+    DrainManifest, MANIFEST_FILENAME, MANIFEST_VERSION, ManifestEntry, StatDecision,
+};
+pub use uri::{DestinationScheme, DestinationUri};
+
+/// Who and what a drain run is uploading for.
+///
+/// Why: the two components are the whole key namespace below the destination
+/// prefix, and getting either wrong mixes one user's logs into another's. They
+/// are the caller's to supply because the core has no business shelling out to
+/// `gh` — Phase 3 owns identity resolution and passes the answer in.
+/// What: [`DrainTarget::validate`] refuses an empty component, so no code path
+/// can produce a key containing `//` or an anonymous segment.
+/// Test: `tests::run_once_refuses_empty_github_id`,
+/// `tests::run_once_refuses_empty_session_id`, `tests::key_layout_shape`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DrainTarget {
+    /// GitHub login the logs belong to. Never resolved here.
+    pub github_id: String,
+    /// The consumer's own session id. Opaque to the drain.
+    pub session_id: String,
+}
+
+impl DrainTarget {
+    /// Refuse an empty identity component.
+    ///
+    /// Fail-closed by design: see [`DrainError::MissingIdentity`].
+    ///
+    /// # Errors
+    /// [`DrainError::MissingIdentity`] naming the empty field.
+    pub fn validate(&self) -> Result<(), DrainError> {
+        if self.github_id.trim().is_empty() {
+            return Err(DrainError::MissingIdentity { field: "github_id" });
+        }
+        if self.session_id.trim().is_empty() {
+            return Err(DrainError::MissingIdentity {
+                field: "session_id",
+            });
+        }
+        Ok(())
+    }
+
+    /// The `logs/` prefix every object for this target sits beneath.
+    ///
+    /// Destination-relative: the adapter joins the URI's own prefix on top.
+    /// Test: `tests::key_layout_shape`.
+    pub fn logs_prefix(&self) -> String {
+        format!("{}/{}/logs", self.github_id, self.session_id)
+    }
+
+    /// Full key for one collected file's `relative_key`.
+    pub fn object_key(&self, relative_key: &str) -> String {
+        format!("{}/{}", self.logs_prefix(), relative_key)
+    }
+
+    /// Key of this target's manifest object.
+    pub fn manifest_key(&self) -> String {
+        format!("{}/{}", self.logs_prefix(), MANIFEST_FILENAME)
+    }
+
+    /// Path segment identifying this target inside the local state directory.
+    fn cache_key(&self) -> String {
+        format!("{}/{}", self.github_id, self.session_id)
+    }
+}
+
+/// Everything a run needs that is not the destination, target, or sources.
+///
+/// `#[non_exhaustive]` so Phase 3 can add scheduling knobs without a breaking
+/// change; construct it with [`DrainConfig::new`].
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct DrainConfig {
+    /// Where the local manifest cache lives.
+    pub state_dir: PathBuf,
+    /// Values [`collect`] removes from every body before upload.
+    pub secrets: Vec<String>,
+    /// Files larger than this are skipped, never truncated.
+    pub max_file_bytes: u64,
+}
+
+impl DrainConfig {
+    /// A config with [`DEFAULT_MAX_FILE_BYTES`] and no secrets.
+    ///
+    /// A caller that leaves `secrets` empty gets no scrubbing — see the module
+    /// docs.
+    pub fn new(state_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            state_dir: state_dir.into(),
+            secrets: Vec::new(),
+            max_file_bytes: DEFAULT_MAX_FILE_BYTES,
+        }
+    }
+
+    /// Set the values to scrub from every uploaded body.
+    #[must_use]
+    pub fn with_secrets(mut self, secrets: Vec<String>) -> Self {
+        self.secrets = secrets;
+        self
+    }
+
+    /// Set the per-file size ceiling.
+    #[must_use]
+    pub fn with_max_file_bytes(mut self, max: u64) -> Self {
+        self.max_file_bytes = max;
+        self
+    }
+}
+
+/// What one [`run_once`] pass did.
+///
+/// Why: the scheduler Phase 3 adds decides whether to back off from these
+/// counts, and an operator reading a doctor check needs to tell "nothing
+/// changed" from "everything failed". Both are zero uploads.
+/// What: four counters, two byte totals, and the per-file errors that did not
+/// abort the batch.
+/// Test: `tests::run_once_end_to_end`, `tests::run_once_collects_per_file_errors_without_aborting`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct DrainReport {
+    /// Files uploaded this pass.
+    pub uploaded: usize,
+    /// Files skipped because the manifest already had them.
+    pub skipped_unchanged: usize,
+    /// Files skipped for exceeding `max_file_bytes`.
+    pub skipped_too_large: usize,
+    /// Total plaintext bytes of everything uploaded.
+    pub bytes_plain: u64,
+    /// Total gzipped bytes actually written to the destination.
+    pub bytes_wire: u64,
+    /// Per-file failures, as `(key or path, message)`. Never aborts the batch.
+    pub errors: Vec<(String, String)>,
+}
+
+/// Run the drain once: collect, compare against the manifest, upload what changed.
+///
+/// Why: one entry point means the ordering — validate identity, load manifest,
+/// collect, filter by manifest, upload, rewrite manifest — is fixed rather than
+/// reassembled per caller.
+///
+/// What: validates `target` FIRST, so a bad identity costs no filesystem walk
+/// and can never reach a `put`. Loads the manifest (remote authoritative, local
+/// cache as fallback). Collects every matching file. For each: the stat-only
+/// fast path skips unchanged files without comparing digests; a file whose stat
+/// moved but whose SHA-256 matches is still skipped, with its manifest entry
+/// refreshed so the next run takes the fast path. Everything else is uploaded.
+/// A per-file failure is recorded in [`DrainReport::errors`] and the batch
+/// CONTINUES — one unreadable file must not strand every other log on the
+/// machine. The manifest is rewritten once at the end, reflecting only what
+/// actually landed.
+///
+/// Single-flight is the CALLER's responsibility; see the module docs.
+///
+/// Test: `tests::run_once_end_to_end`, `tests::run_once_is_idempotent`,
+/// `tests::run_once_reuploads_a_mutated_file`, `tests::run_once_refuses_empty_github_id`.
+///
+/// # Errors
+/// - [`DrainError::MissingIdentity`] when `target` has an empty component.
+/// - [`DrainError::Uri`] for a malformed include glob.
+/// - [`DrainError::Transport`] when the manifest itself could not be read or
+///   written. A per-FILE transport failure is collected, not raised.
+pub async fn run_once(
+    cfg: &DrainConfig,
+    dest: &dyn LogDestination,
+    target: &DrainTarget,
+    sources: &[LogSource],
+) -> Result<DrainReport, DrainError> {
+    // #6533: fail closed before anything touches the filesystem or the network.
+    target.validate()?;
+
+    let manifest_key = target.manifest_key();
+    let cache_key = target.cache_key();
+    let mut manifest = DrainManifest::load(dest, &cfg.state_dir, &manifest_key, &cache_key).await?;
+
+    let collected = collect(sources, &cfg.secrets, cfg.max_file_bytes)?;
+
+    let mut report = DrainReport {
+        skipped_too_large: collected.oversize.len(),
+        ..DrainReport::default()
+    };
+    for (path, message) in collected.errors {
+        report.errors.push((path.display().to_string(), message));
+    }
+
+    let now = chrono::Utc::now().to_rfc3339();
+    let mut manifest_dirty = false;
+
+    for file in collected.files {
+        // Fast path: stat alone says nothing changed, so never compare digests.
+        if manifest.decide(&file.relative_key, file.plaintext_len, file.mtime_unix)
+            == StatDecision::SkipUnchanged
+        {
+            report.skipped_unchanged += 1;
+            continue;
+        }
+
+        // Slow path: the stat moved. SHA-256 decides, and it wins over mtime —
+        // identical bytes are never re-uploaded just because a timestamp moved.
+        if manifest.digest_matches(&file.relative_key, &file.sha256_plaintext) {
+            report.skipped_unchanged += 1;
+            manifest.record(entry_for(&file, &now));
+            manifest_dirty = true;
+            continue;
+        }
+
+        let key = target.object_key(&file.relative_key);
+        let wire_len = file.body.len() as u64;
+        match dest
+            .put(&key, file.body.clone(), PutMeta::gzipped_text())
+            .await
+        {
+            Ok(()) => {
+                report.uploaded += 1;
+                report.bytes_plain += file.plaintext_len;
+                report.bytes_wire += wire_len;
+                manifest.record(entry_for(&file, &now));
+                manifest_dirty = true;
+            }
+            Err(e) => report.errors.push((key, e.to_string())),
+        }
+    }
+
+    if manifest_dirty {
+        manifest
+            .save(dest, &cfg.state_dir, &manifest_key, &cache_key)
+            .await?;
+    }
+
+    Ok(report)
+}
+
+/// Build the manifest entry recording one collected file.
+fn entry_for(file: &CollectedFile, uploaded_at: &str) -> ManifestEntry {
+    ManifestEntry {
+        relative_file: file.relative_key.clone(),
+        size: file.plaintext_len,
+        mtime_unix: file.mtime_unix,
+        sha256: file.sha256_plaintext.clone(),
+        uploaded_at: uploaded_at.to_string(),
+    }
+}

--- a/crates/trusty-common/src/log_drain/tests.rs
+++ b/crates/trusty-common/src/log_drain/tests.rs
@@ -1,0 +1,987 @@
+//! Coverage for the log-drain core (#6533).
+//!
+//! Every test that needs a destination uses a REAL `file://`
+//! [`ObjectStoreDestination`] over a `tempfile::TempDir`, not a mock. A pass
+//! here is therefore evidence about the same `put`/`get`/`head`/`list` code the
+//! `s3://` destination runs, differing only in transport.
+//!
+//! `TRUSTY_LOG_DRAIN_S3_SMOKE_URI` opts into one real-S3 round trip; unset, that
+//! test prints why it is skipping and passes.
+
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use super::*;
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+/// A `file://` destination rooted in a fresh temp dir.
+async fn file_dest(root: &Path) -> ObjectStoreDestination {
+    let uri = DestinationUri::parse(&format!("file://{}", root.display()))
+        .expect("temp dir path parses as a file:// URI");
+    ObjectStoreDestination::connect(&uri)
+        .await
+        .expect("local destination connects")
+}
+
+fn target() -> DrainTarget {
+    DrainTarget {
+        github_id: "bobmatnyc".to_string(),
+        session_id: "sess-01".to_string(),
+    }
+}
+
+/// One source rooted at `root`, matching every `.log` file.
+fn source(root: &Path, level_filter: Option<Level>) -> LogSource {
+    LogSource {
+        crate_name: "trusty-mpm".to_string(),
+        root: root.to_path_buf(),
+        include: vec!["**/*.log".to_string()],
+        level_filter,
+    }
+}
+
+fn write(path: &Path, body: &str) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("fixture dir");
+    }
+    std::fs::write(path, body).expect("fixture write");
+}
+
+/// Read an object back through the destination and gunzip it.
+async fn read_gunzipped(dest: &dyn LogDestination, key: &str) -> String {
+    let raw = dest
+        .get(key)
+        .await
+        .expect("get succeeds")
+        .unwrap_or_else(|| panic!("object `{key}` is absent"));
+    let mut decoder = flate2::read::GzDecoder::new(&raw[..]);
+    let mut text = String::new();
+    decoder
+        .read_to_string(&mut text)
+        .expect("body is valid gzip");
+    text
+}
+
+/// Force a file's mtime forward without changing its bytes.
+fn touch_forward(path: &Path) {
+    let body = std::fs::read(path).expect("read for touch");
+    // A rewrite of identical bytes moves mtime while leaving content identical —
+    // exactly the case `manifest_sha_beats_mtime` is about.
+    std::thread::sleep(std::time::Duration::from_millis(1100));
+    std::fs::write(path, body).expect("rewrite for touch");
+}
+
+// ── DestinationUri: the table ───────────────────────────────────────────────
+
+#[test]
+fn uri_table_accepts() {
+    let cases: &[(&str, DestinationUri)] = &[
+        (
+            "s3://my-bucket",
+            DestinationUri::S3 {
+                bucket: "my-bucket".into(),
+                prefix: String::new(),
+                region: None,
+            },
+        ),
+        (
+            "s3://my-bucket/",
+            DestinationUri::S3 {
+                bucket: "my-bucket".into(),
+                prefix: String::new(),
+                region: None,
+            },
+        ),
+        (
+            "s3://my-bucket/logs",
+            DestinationUri::S3 {
+                bucket: "my-bucket".into(),
+                prefix: "logs".into(),
+                region: None,
+            },
+        ),
+        (
+            "s3://my-bucket/logs/nested/",
+            DestinationUri::S3 {
+                bucket: "my-bucket".into(),
+                prefix: "logs/nested".into(),
+                region: None,
+            },
+        ),
+        (
+            "  s3://my-bucket/logs  ",
+            DestinationUri::S3 {
+                bucket: "my-bucket".into(),
+                prefix: "logs".into(),
+                region: None,
+            },
+        ),
+        (
+            "S3://my-bucket/logs",
+            DestinationUri::S3 {
+                bucket: "my-bucket".into(),
+                prefix: "logs".into(),
+                region: None,
+            },
+        ),
+        (
+            "file:///var/log/trusty",
+            DestinationUri::File {
+                path: PathBuf::from("/var/log/trusty"),
+            },
+        ),
+        (
+            "file:///var/log/trusty/",
+            DestinationUri::File {
+                path: PathBuf::from("/var/log/trusty"),
+            },
+        ),
+    ];
+
+    for (input, expected) in cases {
+        let parsed = DestinationUri::parse(input)
+            .unwrap_or_else(|e| panic!("`{input}` should parse, got {e}"));
+        assert_eq!(&parsed, expected, "parsing `{input}`");
+    }
+}
+
+#[test]
+fn uri_region_override() {
+    let parsed = DestinationUri::parse("s3://bucket/logs?region=us-west-2").expect("parses");
+    assert_eq!(
+        parsed,
+        DestinationUri::S3 {
+            bucket: "bucket".into(),
+            prefix: "logs".into(),
+            region: Some("us-west-2".into()),
+        }
+    );
+}
+
+#[test]
+fn uri_table_rejects() {
+    // Each case must fail with DrainError::Uri, not a scheme error.
+    let cases = [
+        ("s3:/bucket", "no `://` separator"),
+        ("bucket/logs", "no `://` separator"),
+        ("", "no `://` separator"),
+        ("s3:///logs", "empty bucket"),
+        ("file://relative/path", "non-absolute file path"),
+        ("file:///", "filesystem root"),
+        ("file:///tmp/x?region=eu", "query on file://"),
+        ("s3://bucket/logs?", "empty query"),
+        ("s3://bucket/logs?region=", "empty region value"),
+        ("s3://bucket/logs?reigon=eu-west-1", "misspelled parameter"),
+        ("s3://bucket/logs?region", "parameter with no `=`"),
+    ];
+
+    for (input, why) in cases {
+        match DestinationUri::parse(input) {
+            Err(DrainError::Uri { .. }) => {}
+            other => panic!("`{input}` ({why}) should be DrainError::Uri, got {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn uri_reserved_schemes() {
+    // gs:// and az:// are RECOGNISED and then refused, so the message names
+    // what is supported instead of reading as a syntax error.
+    for input in ["gs://bucket/logs", "az://container/logs", "https://example"] {
+        match DestinationUri::parse(input) {
+            Err(DrainError::UnsupportedScheme { .. }) => {}
+            other => panic!("`{input}` should be UnsupportedScheme, got {other:?}"),
+        }
+    }
+
+    let message = DestinationUri::parse("gs://bucket/logs")
+        .expect_err("gs:// is refused")
+        .to_string();
+    assert!(
+        message.contains("s3://") && message.contains("file://"),
+        "the refusal must name what IS supported, got: {message}"
+    );
+}
+
+// ── key layout ──────────────────────────────────────────────────────────────
+
+#[test]
+fn key_layout_shape() {
+    let t = target();
+    assert_eq!(t.logs_prefix(), "bobmatnyc/sess-01/logs");
+    assert_eq!(
+        t.object_key("trusty-mpm/daemon.log"),
+        "bobmatnyc/sess-01/logs/trusty-mpm/daemon.log"
+    );
+    assert_eq!(
+        t.manifest_key(),
+        "bobmatnyc/sess-01/logs/.drain-manifest.json"
+    );
+}
+
+#[test]
+fn identity_refusal_is_fail_closed() {
+    for (github_id, session_id, field) in [
+        ("", "sess", "github_id"),
+        ("   ", "sess", "github_id"),
+        ("bob", "", "session_id"),
+        ("bob", "  ", "session_id"),
+    ] {
+        let t = DrainTarget {
+            github_id: github_id.to_string(),
+            session_id: session_id.to_string(),
+        };
+        match t.validate() {
+            Err(DrainError::MissingIdentity { field: got }) => assert_eq!(got, field),
+            other => panic!("`{github_id}`/`{session_id}` should refuse, got {other:?}"),
+        }
+    }
+}
+
+// ── destination round trip ──────────────────────────────────────────────────
+
+#[tokio::test]
+async fn destination_roundtrip() {
+    let root = tempfile::tempdir().expect("tempdir");
+    let dest = file_dest(root.path()).await;
+
+    assert!(
+        dest.head("absent/key")
+            .await
+            .expect("head succeeds")
+            .is_none(),
+        "a missing object must be Ok(None), never an error"
+    );
+    assert!(
+        dest.get("absent/key")
+            .await
+            .expect("get succeeds")
+            .is_none()
+    );
+
+    let body = bytes::Bytes::from_static(b"hello drain");
+    dest.put("a/b.txt", body.clone(), PutMeta::gzipped_text())
+        .await
+        .expect("put succeeds");
+
+    let meta = dest
+        .head("a/b.txt")
+        .await
+        .expect("head succeeds")
+        .expect("object is present after put");
+    assert_eq!(meta.size, body.len() as u64);
+    assert_eq!(meta.key, "a/b.txt");
+
+    assert_eq!(
+        dest.get("a/b.txt").await.expect("get succeeds").as_deref(),
+        Some(&body[..])
+    );
+}
+
+#[tokio::test]
+async fn destination_list_is_bounded_and_prefix_scoped() {
+    let root = tempfile::tempdir().expect("tempdir");
+    let dest = file_dest(root.path()).await;
+
+    for i in 0..5 {
+        dest.put(
+            &format!("keep/{i}.txt"),
+            bytes::Bytes::from_static(b"x"),
+            PutMeta::default(),
+        )
+        .await
+        .expect("put");
+    }
+    dest.put(
+        "other/z.txt",
+        bytes::Bytes::from_static(b"x"),
+        PutMeta::default(),
+    )
+    .await
+    .expect("put");
+
+    let listed = dest.list("keep").await.expect("list succeeds");
+    assert_eq!(listed.len(), 5, "list is scoped to its prefix");
+    assert!(listed.iter().all(|m| m.key.starts_with("keep/")));
+    assert!(
+        listed.len() <= LIST_LIMIT,
+        "list must never exceed its documented cap"
+    );
+}
+
+// ── collector: level filtering ──────────────────────────────────────────────
+
+/// A fixture in `tracing_subscriber::fmt`'s default line shape.
+const TRACING_FIXTURE: &str = concat!(
+    "2026-09-01T14:12:32.273982Z DEBUG tm::commands: dropped debug detail\n",
+    "2026-09-01T14:12:32.283982Z  INFO tm::daemon: daemon started\n",
+    "2026-09-01T14:12:32.293982Z TRACE tm::inner: dropped trace detail\n",
+    "2026-09-01T14:12:32.303982Z  WARN tm::daemon: port already bound\n",
+    "2026-09-01T14:12:32.313982Z ERROR tm::daemon: bind failed\n",
+    "    caused by: address in use\n",
+);
+
+#[test]
+fn collect_filters_below_info() {
+    let root = tempfile::tempdir().expect("tempdir");
+    write(&root.path().join("daemon.log"), TRACING_FIXTURE);
+
+    let collected = collect(
+        &[source(root.path(), Some(Level::Info))],
+        &[],
+        DEFAULT_MAX_FILE_BYTES,
+    )
+    .expect("collect succeeds");
+
+    assert_eq!(collected.files.len(), 1);
+    let mut decoder = flate2::read::GzDecoder::new(&collected.files[0].body[..]);
+    let mut text = String::new();
+    decoder.read_to_string(&mut text).expect("gunzip");
+
+    assert!(
+        !text.contains("dropped debug detail"),
+        "DEBUG must be dropped"
+    );
+    assert!(
+        !text.contains("dropped trace detail"),
+        "TRACE must be dropped"
+    );
+    assert!(text.contains("daemon started"), "INFO must be kept");
+    assert!(text.contains("port already bound"), "WARN must be kept");
+    assert!(text.contains("bind failed"), "ERROR must be kept");
+    assert!(
+        text.contains("address in use"),
+        "a continuation line inherits its parent's disposition"
+    );
+}
+
+#[test]
+fn collect_drops_continuation_of_a_dropped_line() {
+    let root = tempfile::tempdir().expect("tempdir");
+    write(
+        &root.path().join("daemon.log"),
+        "2026-09-01T14:12:32.2Z DEBUG tm: noisy\n        continuation of noise\n\
+         2026-09-01T14:12:32.3Z  INFO tm: kept\n",
+    );
+
+    let collected = collect(
+        &[source(root.path(), Some(Level::Info))],
+        &[],
+        DEFAULT_MAX_FILE_BYTES,
+    )
+    .expect("collect");
+    let mut decoder = flate2::read::GzDecoder::new(&collected.files[0].body[..]);
+    let mut text = String::new();
+    decoder.read_to_string(&mut text).expect("gunzip");
+
+    assert!(!text.contains("continuation of noise"));
+    assert!(text.contains("kept"));
+}
+
+#[test]
+fn collect_passes_through_non_tracing() {
+    let root = tempfile::tempdir().expect("tempdir");
+    let plain = "just a line\nand another\nno levels here at all\n";
+    write(&root.path().join("plain.log"), plain);
+
+    let collected = collect(
+        &[source(root.path(), Some(Level::Info))],
+        &[],
+        DEFAULT_MAX_FILE_BYTES,
+    )
+    .expect("collect");
+
+    let mut decoder = flate2::read::GzDecoder::new(&collected.files[0].body[..]);
+    let mut text = String::new();
+    decoder.read_to_string(&mut text).expect("gunzip");
+
+    assert_eq!(
+        text, plain,
+        "a file with no recognisable level line is not tracing output and must \
+         pass through verbatim rather than filter to nothing"
+    );
+}
+
+#[test]
+fn collect_recognises_ansi_coloured_levels() {
+    let root = tempfile::tempdir().expect("tempdir");
+    write(
+        &root.path().join("colour.log"),
+        "\u{1b}[2m2026-09-01T14:12:32.2Z\u{1b}[0m \u{1b}[34mDEBUG\u{1b}[0m tm: noise\n\
+         \u{1b}[2m2026-09-01T14:12:32.3Z\u{1b}[0m \u{1b}[32m INFO\u{1b}[0m tm: kept\n",
+    );
+
+    let collected = collect(
+        &[source(root.path(), Some(Level::Info))],
+        &[],
+        DEFAULT_MAX_FILE_BYTES,
+    )
+    .expect("collect");
+    let mut decoder = flate2::read::GzDecoder::new(&collected.files[0].body[..]);
+    let mut text = String::new();
+    decoder.read_to_string(&mut text).expect("gunzip");
+
+    assert!(
+        !text.contains("noise"),
+        "a colourised DEBUG line is still DEBUG"
+    );
+    assert!(text.contains("kept"));
+}
+
+// ── collector: size ceiling ─────────────────────────────────────────────────
+
+#[test]
+fn collect_skips_oversize() {
+    let root = tempfile::tempdir().expect("tempdir");
+    write(&root.path().join("big.log"), &"x".repeat(4096));
+    write(&root.path().join("small.log"), "tiny\n");
+
+    let collected = collect(&[source(root.path(), None)], &[], 1024).expect("collect");
+
+    assert_eq!(collected.files.len(), 1, "only the small file is collected");
+    assert_eq!(collected.files[0].relative_key, "trusty-mpm/small.log");
+    assert_eq!(collected.oversize.len(), 1);
+    assert_eq!(collected.oversize[0].size, 4096);
+    assert!(collected.oversize[0].path.ends_with("big.log"));
+}
+
+// ── collector: the scrub ────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn collect_scrubs_secrets_before_they_reach_the_destination() {
+    let root = tempfile::tempdir().expect("tempdir");
+    let dest_root = tempfile::tempdir().expect("tempdir");
+    let state = tempfile::tempdir().expect("tempdir");
+
+    // Well over `scrub_secrets`' minimum needle length, so it is actually scrubbed.
+    let secret = "sk-planted-secret-value-0123456789";
+    write(
+        &root.path().join("daemon.log"),
+        &format!("2026-09-01T14:12:32.2Z  INFO tm: token={secret} ok\n"),
+    );
+
+    let dest = file_dest(dest_root.path()).await;
+    let cfg = DrainConfig::new(state.path()).with_secrets(vec![secret.to_string()]);
+    let t = target();
+
+    let report = run_once(&cfg, &dest, &t, &[source(root.path(), Some(Level::Info))])
+        .await
+        .expect("run_once succeeds");
+    assert_eq!(report.uploaded, 1);
+
+    let key = t.object_key("trusty-mpm/daemon.log");
+    let text = read_gunzipped(&dest, &key).await;
+
+    assert!(
+        !text.contains(secret),
+        "the planted secret reached the destination: {text}"
+    );
+    assert!(
+        text.contains("[REDACTED]"),
+        "the scrub must leave its marker"
+    );
+    assert!(text.contains("token="), "surrounding text must survive");
+
+    // Belt and braces: the secret must not be in the raw bytes on disk either.
+    let on_disk = std::fs::read(dest_root.path().join(&key)).expect("object file exists");
+    assert!(
+        !String::from_utf8_lossy(&on_disk).contains(secret),
+        "the secret survived in the stored bytes"
+    );
+}
+
+// ── manifest ────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn manifest_roundtrip() {
+    let dest_root = tempfile::tempdir().expect("tempdir");
+    let state = tempfile::tempdir().expect("tempdir");
+    let dest = file_dest(dest_root.path()).await;
+
+    let mut manifest = DrainManifest::default();
+    assert_eq!(manifest.version, MANIFEST_VERSION);
+    manifest.record(ManifestEntry {
+        relative_file: "trusty-mpm/a.log".into(),
+        size: 10,
+        mtime_unix: 1_700_000_000,
+        sha256: "abc".into(),
+        uploaded_at: "2026-09-01T00:00:00Z".into(),
+    });
+
+    manifest
+        .save(&dest, state.path(), "k/manifest.json", "bob/sess")
+        .await
+        .expect("save");
+
+    let loaded = DrainManifest::load(&dest, state.path(), "k/manifest.json", "bob/sess")
+        .await
+        .expect("load");
+    assert_eq!(loaded.entries, manifest.entries);
+}
+
+#[tokio::test]
+async fn manifest_remote_wins_over_local_cache() {
+    let dest_root = tempfile::tempdir().expect("tempdir");
+    let state = tempfile::tempdir().expect("tempdir");
+    let dest = file_dest(dest_root.path()).await;
+
+    // Local cache claims a file was uploaded; the remote manifest says otherwise.
+    let mut stale = DrainManifest::default();
+    stale.record(ManifestEntry {
+        relative_file: "trusty-mpm/ghost.log".into(),
+        size: 1,
+        mtime_unix: 1,
+        sha256: "stale".into(),
+        uploaded_at: "2026-01-01T00:00:00Z".into(),
+    });
+    let cache_path = state
+        .path()
+        .join("log-drain")
+        .join("bob/sess")
+        .join("manifest.json");
+    std::fs::create_dir_all(cache_path.parent().expect("parent")).expect("cache dir");
+    std::fs::write(&cache_path, serde_json::to_vec(&stale).expect("encode")).expect("cache write");
+
+    let remote = DrainManifest::default();
+    remote
+        .save(&dest, state.path(), "k/manifest.json", "unrelated")
+        .await
+        .expect("save remote");
+
+    let loaded = DrainManifest::load(&dest, state.path(), "k/manifest.json", "bob/sess")
+        .await
+        .expect("load");
+    assert!(
+        loaded.entries.is_empty(),
+        "the remote copy is authoritative; the stale cache entry must not survive"
+    );
+
+    let refreshed: DrainManifest =
+        serde_json::from_slice(&std::fs::read(&cache_path).expect("cache")).expect("decode");
+    assert!(
+        refreshed.entries.is_empty(),
+        "loading must rewrite the cache from the authoritative remote copy"
+    );
+}
+
+#[tokio::test]
+async fn manifest_corrupt_remote_falls_back_to_cache() {
+    let dest_root = tempfile::tempdir().expect("tempdir");
+    let state = tempfile::tempdir().expect("tempdir");
+    let dest = file_dest(dest_root.path()).await;
+
+    dest.put(
+        "k/manifest.json",
+        bytes::Bytes::from_static(b"{ not json"),
+        PutMeta::default(),
+    )
+    .await
+    .expect("put corrupt manifest");
+
+    // An undecodable remote manifest is treated as ABSENT, never as an error —
+    // re-uploading is safer than skipping something that was never written.
+    let loaded = DrainManifest::load(&dest, state.path(), "k/manifest.json", "bob/sess")
+        .await
+        .expect("a corrupt manifest must not fail the load");
+    assert!(loaded.entries.is_empty());
+}
+
+#[test]
+fn manifest_stat_fast_path_and_sha_tiebreak() {
+    let mut manifest = DrainManifest::default();
+    manifest.record(ManifestEntry {
+        relative_file: "c/a.log".into(),
+        size: 100,
+        mtime_unix: 42,
+        sha256: "deadbeef".into(),
+        uploaded_at: "2026-09-01T00:00:00Z".into(),
+    });
+
+    assert_eq!(
+        manifest.decide("c/a.log", 100, 42),
+        StatDecision::SkipUnchanged
+    );
+    assert_eq!(manifest.decide("c/a.log", 101, 42), StatDecision::NeedsHash);
+    assert_eq!(manifest.decide("c/a.log", 100, 43), StatDecision::NeedsHash);
+    assert_eq!(
+        manifest.decide("c/absent.log", 100, 42),
+        StatDecision::NeedsHash
+    );
+
+    assert!(manifest.digest_matches("c/a.log", "deadbeef"));
+    assert!(!manifest.digest_matches("c/a.log", "cafe"));
+    assert!(!manifest.digest_matches("c/absent.log", "deadbeef"));
+}
+
+// ── run_once ────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn run_once_end_to_end() {
+    let logs = tempfile::tempdir().expect("tempdir");
+    let dest_root = tempfile::tempdir().expect("tempdir");
+    let state = tempfile::tempdir().expect("tempdir");
+
+    write(&logs.path().join("daemon.log"), TRACING_FIXTURE);
+    write(&logs.path().join("nested/worker.log"), TRACING_FIXTURE);
+    write(&logs.path().join("ignored.txt"), "not a .log file\n");
+
+    let dest = file_dest(dest_root.path()).await;
+    let cfg = DrainConfig::new(state.path());
+    let t = target();
+
+    let report = run_once(&cfg, &dest, &t, &[source(logs.path(), Some(Level::Info))])
+        .await
+        .expect("run_once");
+
+    assert_eq!(report.uploaded, 2, "both .log files, not the .txt");
+    assert_eq!(report.skipped_unchanged, 0);
+    assert_eq!(report.skipped_too_large, 0);
+    assert!(
+        report.errors.is_empty(),
+        "unexpected errors: {:?}",
+        report.errors
+    );
+    assert!(report.bytes_plain > 0);
+    assert!(report.bytes_wire > 0);
+
+    // The objects landed under the documented key layout.
+    for relative in ["trusty-mpm/daemon.log", "trusty-mpm/nested/worker.log"] {
+        let key = t.object_key(relative);
+        assert!(
+            dest.head(&key).await.expect("head").is_some(),
+            "expected an object at `{key}`"
+        );
+    }
+    // And so did the manifest.
+    assert!(
+        dest.head(&t.manifest_key()).await.expect("head").is_some(),
+        "the manifest must be rewritten after a successful batch"
+    );
+}
+
+#[tokio::test]
+async fn run_once_is_idempotent() {
+    let logs = tempfile::tempdir().expect("tempdir");
+    let dest_root = tempfile::tempdir().expect("tempdir");
+    let state = tempfile::tempdir().expect("tempdir");
+    write(&logs.path().join("daemon.log"), TRACING_FIXTURE);
+
+    let dest = file_dest(dest_root.path()).await;
+    let cfg = DrainConfig::new(state.path());
+    let t = target();
+    let sources = [source(logs.path(), Some(Level::Info))];
+
+    let first = run_once(&cfg, &dest, &t, &sources)
+        .await
+        .expect("first run");
+    assert_eq!(first.uploaded, 1);
+
+    let second = run_once(&cfg, &dest, &t, &sources)
+        .await
+        .expect("second run");
+    assert_eq!(second.uploaded, 0, "nothing changed, so nothing re-uploads");
+    assert_eq!(second.skipped_unchanged, 1);
+    assert_eq!(second.bytes_wire, 0);
+}
+
+#[tokio::test]
+async fn run_once_reuploads_a_mutated_file() {
+    let logs = tempfile::tempdir().expect("tempdir");
+    let dest_root = tempfile::tempdir().expect("tempdir");
+    let state = tempfile::tempdir().expect("tempdir");
+    let log = logs.path().join("daemon.log");
+    write(&log, TRACING_FIXTURE);
+
+    let dest = file_dest(dest_root.path()).await;
+    let cfg = DrainConfig::new(state.path());
+    let t = target();
+    let sources = [source(logs.path(), Some(Level::Info))];
+
+    run_once(&cfg, &dest, &t, &sources)
+        .await
+        .expect("first run");
+
+    write(
+        &log,
+        &format!("{TRACING_FIXTURE}2026-09-01T15:00:00.0Z  INFO tm: a new line\n"),
+    );
+
+    let second = run_once(&cfg, &dest, &t, &sources)
+        .await
+        .expect("second run");
+    assert_eq!(second.uploaded, 1, "changed bytes must re-upload");
+    assert_eq!(second.skipped_unchanged, 0);
+
+    let text = read_gunzipped(&dest, &t.object_key("trusty-mpm/daemon.log")).await;
+    assert!(
+        text.contains("a new line"),
+        "the destination holds the new body"
+    );
+}
+
+#[tokio::test]
+async fn run_once_sha_beats_a_moved_mtime() {
+    let logs = tempfile::tempdir().expect("tempdir");
+    let dest_root = tempfile::tempdir().expect("tempdir");
+    let state = tempfile::tempdir().expect("tempdir");
+    let log = logs.path().join("daemon.log");
+    write(&log, TRACING_FIXTURE);
+
+    let dest = file_dest(dest_root.path()).await;
+    let cfg = DrainConfig::new(state.path());
+    let t = target();
+    let sources = [source(logs.path(), Some(Level::Info))];
+
+    run_once(&cfg, &dest, &t, &sources)
+        .await
+        .expect("first run");
+    let recorded_before = manifest_mtime(&dest, &t).await;
+
+    // Same bytes, later mtime. SHA-256 wins: no re-upload.
+    touch_forward(&log);
+
+    // Guard against a vacuous pass: if the rewrite did not actually move the
+    // mtime, `decide` would take the stat-only fast path and the sha tiebreak
+    // below would never run.
+    let on_disk_mtime = std::fs::metadata(&log)
+        .expect("stat")
+        .modified()
+        .expect("mtime")
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("epoch")
+        .as_secs() as i64;
+    assert!(
+        on_disk_mtime > recorded_before,
+        "fixture is broken: mtime did not move ({on_disk_mtime} vs {recorded_before}), \
+         so this test would pass without exercising the sha tiebreak"
+    );
+
+    let second = run_once(&cfg, &dest, &t, &sources)
+        .await
+        .expect("second run");
+    assert_eq!(
+        second.uploaded, 0,
+        "identical bytes must not re-upload just because mtime moved"
+    );
+    assert_eq!(second.skipped_unchanged, 1);
+
+    // The sha tiebreak refreshed the entry's mtime — that refresh is what makes
+    // the NEXT run cheap, and it only happens on the sha path.
+    let recorded_after = manifest_mtime(&dest, &t).await;
+    assert_eq!(
+        recorded_after, on_disk_mtime,
+        "the sha tiebreak must refresh the recorded mtime so the next run takes \
+         the stat-only fast path"
+    );
+
+    let third = run_once(&cfg, &dest, &t, &sources)
+        .await
+        .expect("third run");
+    assert_eq!(third.uploaded, 0);
+    assert_eq!(third.skipped_unchanged, 1);
+}
+
+/// The mtime the destination's manifest currently records for `daemon.log`.
+async fn manifest_mtime(dest: &dyn LogDestination, t: &DrainTarget) -> i64 {
+    let raw = dest
+        .get(&t.manifest_key())
+        .await
+        .expect("get manifest")
+        .expect("manifest exists");
+    let manifest: DrainManifest = serde_json::from_slice(&raw).expect("decode manifest");
+    manifest
+        .entries
+        .iter()
+        .find(|e| e.relative_file == "trusty-mpm/daemon.log")
+        .expect("entry for the drained file")
+        .mtime_unix
+}
+
+#[tokio::test]
+async fn run_once_counts_oversize_without_uploading() {
+    let logs = tempfile::tempdir().expect("tempdir");
+    let dest_root = tempfile::tempdir().expect("tempdir");
+    let state = tempfile::tempdir().expect("tempdir");
+    write(&logs.path().join("big.log"), &"x".repeat(4096));
+    write(&logs.path().join("small.log"), "small\n");
+
+    let dest = file_dest(dest_root.path()).await;
+    let cfg = DrainConfig::new(state.path()).with_max_file_bytes(1024);
+    let t = target();
+
+    let report = run_once(&cfg, &dest, &t, &[source(logs.path(), None)])
+        .await
+        .expect("run_once");
+
+    assert_eq!(report.uploaded, 1);
+    assert_eq!(report.skipped_too_large, 1);
+    assert!(
+        dest.head(&t.object_key("trusty-mpm/big.log"))
+            .await
+            .expect("head")
+            .is_none(),
+        "an oversize file must never be uploaded, not even truncated"
+    );
+}
+
+#[tokio::test]
+async fn run_once_refuses_empty_github_id() {
+    let dest_root = tempfile::tempdir().expect("tempdir");
+    let state = tempfile::tempdir().expect("tempdir");
+    let dest = file_dest(dest_root.path()).await;
+
+    let t = DrainTarget {
+        github_id: String::new(),
+        session_id: "sess-01".to_string(),
+    };
+    let err = run_once(&DrainConfig::new(state.path()), &dest, &t, &[])
+        .await
+        .expect_err("an empty github_id must be refused");
+    assert!(matches!(
+        err,
+        DrainError::MissingIdentity { field: "github_id" }
+    ));
+
+    // Fail-closed means NOTHING was written, not even a manifest.
+    assert_eq!(
+        std::fs::read_dir(dest_root.path())
+            .expect("read dest root")
+            .count(),
+        0,
+        "a refused run must leave the destination untouched"
+    );
+}
+
+#[tokio::test]
+async fn run_once_refuses_empty_session_id() {
+    let dest_root = tempfile::tempdir().expect("tempdir");
+    let state = tempfile::tempdir().expect("tempdir");
+    let dest = file_dest(dest_root.path()).await;
+
+    let t = DrainTarget {
+        github_id: "bobmatnyc".to_string(),
+        session_id: "   ".to_string(),
+    };
+    let err = run_once(&DrainConfig::new(state.path()), &dest, &t, &[])
+        .await
+        .expect_err("an empty session_id must be refused");
+    assert!(matches!(
+        err,
+        DrainError::MissingIdentity {
+            field: "session_id"
+        }
+    ));
+}
+
+#[tokio::test]
+async fn run_once_collects_per_file_errors_without_aborting() {
+    let logs = tempfile::tempdir().expect("tempdir");
+    let dest_root = tempfile::tempdir().expect("tempdir");
+    let state = tempfile::tempdir().expect("tempdir");
+    write(&logs.path().join("a.log"), "one\n");
+    write(&logs.path().join("b.log"), "two\n");
+
+    let dest = FailingDestination {
+        inner: file_dest(dest_root.path()).await,
+        fail_on: "trusty-mpm/a.log".to_string(),
+    };
+    let cfg = DrainConfig::new(state.path());
+    let t = target();
+
+    let report = run_once(&cfg, &dest, &t, &[source(logs.path(), None)])
+        .await
+        .expect("a per-file failure must not fail the run");
+
+    assert_eq!(report.uploaded, 1, "the healthy file still uploads");
+    assert_eq!(
+        report.errors.len(),
+        1,
+        "the failure is reported, not raised"
+    );
+    assert!(report.errors[0].0.ends_with("trusty-mpm/a.log"));
+}
+
+/// A destination that fails `put` for one key and delegates everything else.
+///
+/// Proves [`run_once`] collects a per-file error and CONTINUES the batch —
+/// the behaviour that stops one unreadable file stranding every other log.
+#[derive(Debug)]
+struct FailingDestination {
+    inner: ObjectStoreDestination,
+    fail_on: String,
+}
+
+#[async_trait::async_trait]
+impl LogDestination for FailingDestination {
+    async fn put(&self, key: &str, body: bytes::Bytes, meta: PutMeta) -> Result<(), DrainError> {
+        if key.ends_with(&self.fail_on) {
+            return Err(DrainError::Manifest {
+                key: key.to_string(),
+                reason: "injected failure".to_string(),
+            });
+        }
+        self.inner.put(key, body, meta).await
+    }
+
+    async fn head(&self, key: &str) -> Result<Option<ObjectMeta>, DrainError> {
+        self.inner.head(key).await
+    }
+
+    async fn get(&self, key: &str) -> Result<Option<bytes::Bytes>, DrainError> {
+        self.inner.get(key).await
+    }
+
+    async fn list(&self, prefix: &str) -> Result<Vec<ObjectMeta>, DrainError> {
+        self.inner.list(prefix).await
+    }
+}
+
+// ── gated real-S3 smoke ─────────────────────────────────────────────────────
+
+/// Env var that opts this run into one real S3 round trip.
+const S3_SMOKE_ENV: &str = "TRUSTY_LOG_DRAIN_S3_SMOKE_URI";
+
+/// One real `s3://` upload, read back and verified.
+///
+/// Why an explicit skip rather than `#[ignore]`: an `#[ignore]`d test is
+/// invisible in a normal run, so nobody learns the S3 path exists or how to
+/// exercise it. This prints the exact env var to set and passes.
+///
+/// Set `TRUSTY_LOG_DRAIN_S3_SMOKE_URI=s3://<bucket>/<prefix>` (optionally with
+/// `?region=`) and provide AWS credentials the usual way.
+#[tokio::test]
+async fn s3_smoke() {
+    let Ok(uri_str) = std::env::var(S3_SMOKE_ENV) else {
+        eprintln!(
+            "SKIP s3_smoke: {S3_SMOKE_ENV} is unset. \
+             Set it to `s3://<bucket>/<prefix>` with AWS credentials available \
+             to exercise the real S3 destination."
+        );
+        return;
+    };
+
+    let uri = DestinationUri::parse(&uri_str).expect("smoke URI parses");
+    let dest = ObjectStoreDestination::connect(&uri)
+        .await
+        .expect("S3 destination connects");
+
+    let logs = tempfile::tempdir().expect("tempdir");
+    let state = tempfile::tempdir().expect("tempdir");
+    write(&logs.path().join("smoke.log"), TRACING_FIXTURE);
+
+    let t = DrainTarget {
+        github_id: "log-drain-smoke".to_string(),
+        session_id: format!("run-{}", chrono::Utc::now().timestamp()),
+    };
+    let cfg = DrainConfig::new(state.path());
+
+    let report = run_once(&cfg, &dest, &t, &[source(logs.path(), Some(Level::Info))])
+        .await
+        .expect("run_once against S3");
+    assert_eq!(report.uploaded, 1);
+
+    let text = read_gunzipped(&dest, &t.object_key("trusty-mpm/smoke.log")).await;
+    assert!(text.contains("daemon started"));
+    assert!(!text.contains("dropped debug detail"));
+}

--- a/crates/trusty-common/src/log_drain/uri.rs
+++ b/crates/trusty-common/src/log_drain/uri.rs
@@ -1,0 +1,253 @@
+//! Destination-URI parsing for the log drain (#6533).
+//!
+//! Why: the drain accepts exactly two destinations and reserves two more. A
+//! general URI crate would accept every scheme and push the "is this one of
+//! ours" question into the caller, where each call site would answer it
+//! slightly differently. A closed scheme enum answers it once, and makes
+//! `gs://` and `az://` produce a message naming what IS supported rather than
+//! a parse failure.
+//! What: [`DestinationUri`], a parsed destination, and [`DestinationScheme`],
+//! the closed set of schemes the parser recognises. Parsing is hand-rolled
+//! over `str` — split on `://`, dispatch on the scheme, then parse the
+//! remainder per-scheme. No generic URI crate is involved.
+//! Test: `super::tests::uri_table_accepts`, `super::tests::uri_table_rejects`,
+//! `super::tests::uri_reserved_schemes`, `super::tests::uri_region_override`.
+
+use std::path::PathBuf;
+
+use super::error::DrainError;
+
+/// The scheme half of a destination URI.
+///
+/// Why: naming the reserved schemes in the same enum as the supported ones is
+/// what lets the parser answer `gs://` with [`DrainError::UnsupportedScheme`]
+/// instead of a generic syntax error.
+/// What: two supported variants and two reserved ones. `Gs` and `Az` are
+/// recognised by [`DestinationScheme::parse`] and then rejected — no backend
+/// exists behind them, and `object_store`'s `gcp`/`azure` features are
+/// deliberately off in the workspace manifest.
+/// Test: `super::tests::uri_reserved_schemes`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum DestinationScheme {
+    /// `s3://bucket/prefix` — Amazon S3, credentials from the AWS chain.
+    S3,
+    /// `file:///abs/path` — a local directory, used by the hermetic tests.
+    File,
+    /// `gs://…` — recognised and rejected. Reserved for a later phase.
+    Gs,
+    /// `az://…` — recognised and rejected. Reserved for a later phase.
+    Az,
+}
+
+impl DestinationScheme {
+    /// Map a scheme string to its variant, or `None` if it is not one of the four.
+    fn parse(scheme: &str) -> Option<Self> {
+        match scheme {
+            "s3" => Some(Self::S3),
+            "file" => Some(Self::File),
+            "gs" => Some(Self::Gs),
+            "az" => Some(Self::Az),
+            _ => None,
+        }
+    }
+}
+
+/// A parsed, validated log-drain destination.
+///
+/// Why: the two supported schemes carry different data — S3 needs a bucket and
+/// an optional region, a local directory needs a path — so a single struct with
+/// nullable fields would let an impossible combination compile. The enum makes
+/// the adapter's `match` total.
+/// What: [`DestinationUri::parse`] is the only constructor. The `prefix` on the
+/// S3 variant is the key prefix every drained object is written beneath; it is
+/// normalised to carry no leading or trailing `/`, and is empty for a
+/// bucket-root destination.
+/// Test: `super::tests::uri_table_accepts` covers every accepted form,
+/// `super::tests::uri_table_rejects` every rejected one.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum DestinationUri {
+    /// An S3 bucket, optionally rooted at a key prefix.
+    S3 {
+        /// Bucket name. Never empty — the parser rejects `s3:///prefix`.
+        bucket: String,
+        /// Key prefix, `/`-normalised and possibly empty.
+        prefix: String,
+        /// Region override from `?region=…`. `None` defers to the AWS chain.
+        region: Option<String>,
+    },
+    /// A local directory. Used by the hermetic tests and by any operator who
+    /// wants the drain's output on disk before pointing it at a bucket.
+    File {
+        /// Absolute path to the directory that becomes the destination root.
+        path: PathBuf,
+    },
+}
+
+impl DestinationUri {
+    /// Parse a destination URI.
+    ///
+    /// Why: every entry point that accepts a destination string routes through
+    /// this one function, so the accepted grammar cannot drift between the
+    /// config reader, the CLI, and the tests.
+    /// What: splits at the first `://`, resolves the scheme through
+    /// [`DestinationScheme::parse`], then parses the remainder per scheme.
+    /// `s3://bucket/prefix?region=us-west-2` overrides the region the AWS chain
+    /// would otherwise supply; no other query parameter is accepted.
+    /// Test: `super::tests::uri_table_accepts`, `super::tests::uri_table_rejects`,
+    /// `super::tests::uri_reserved_schemes`, `super::tests::uri_region_override`.
+    ///
+    /// # Errors
+    /// - [`DrainError::UnsupportedScheme`] for `gs://` and `az://`, and for any
+    ///   scheme outside the four this parser knows.
+    /// - [`DrainError::Uri`] for a missing `://`, an empty bucket, a
+    ///   non-absolute `file://` path, or an unrecognised query parameter.
+    pub fn parse(uri: &str) -> Result<Self, DrainError> {
+        let trimmed = uri.trim();
+        let Some((scheme, rest)) = trimmed.split_once("://") else {
+            return Err(DrainError::Uri {
+                uri: uri.to_string(),
+                reason: "expected `<scheme>://…`, found no `://` separator".to_string(),
+            });
+        };
+
+        // Schemes are case-insensitive per RFC 3986; the rest of the URI is not.
+        let scheme_lower = scheme.to_ascii_lowercase();
+        let Some(known) = DestinationScheme::parse(&scheme_lower) else {
+            return Err(DrainError::UnsupportedScheme {
+                scheme: scheme_lower,
+                uri: uri.to_string(),
+            });
+        };
+
+        match known {
+            DestinationScheme::S3 => Self::parse_s3(uri, rest),
+            DestinationScheme::File => Self::parse_file(uri, rest),
+            // #6533: reserved on purpose — recognised so the message names what
+            // IS supported, but no backend is compiled behind either.
+            DestinationScheme::Gs | DestinationScheme::Az => Err(DrainError::UnsupportedScheme {
+                scheme: scheme_lower,
+                uri: uri.to_string(),
+            }),
+        }
+    }
+
+    /// Parse the remainder of an `s3://` URI: `bucket[/prefix][?region=…]`.
+    fn parse_s3(uri: &str, rest: &str) -> Result<Self, DrainError> {
+        let (path_part, query) = match rest.split_once('?') {
+            Some((p, q)) => (p, Some(q)),
+            None => (rest, None),
+        };
+
+        let (bucket, prefix) = match path_part.split_once('/') {
+            Some((b, p)) => (b, p),
+            None => (path_part, ""),
+        };
+
+        if bucket.is_empty() {
+            return Err(DrainError::Uri {
+                uri: uri.to_string(),
+                reason: "bucket name is empty — expected `s3://<bucket>[/<prefix>]`".to_string(),
+            });
+        }
+
+        let region = match query {
+            Some(q) => Some(parse_region_query(uri, q)?),
+            None => None,
+        };
+
+        Ok(Self::S3 {
+            bucket: bucket.to_string(),
+            prefix: normalise_prefix(prefix),
+            region,
+        })
+    }
+
+    /// Parse the remainder of a `file://` URI.
+    ///
+    /// Accepts the RFC-8089 local form `file:///abs/path` (empty authority), so
+    /// after the `://` split the remainder begins with `/`.
+    fn parse_file(uri: &str, rest: &str) -> Result<Self, DrainError> {
+        if rest.contains('?') {
+            return Err(DrainError::Uri {
+                uri: uri.to_string(),
+                reason: "`file://` takes no query parameters".to_string(),
+            });
+        }
+        if !rest.starts_with('/') {
+            return Err(DrainError::Uri {
+                uri: uri.to_string(),
+                reason: "expected an absolute path — `file:///abs/path`, with three slashes"
+                    .to_string(),
+            });
+        }
+        // A trailing `/` is cosmetic; `PathBuf` treats `/a/b/` and `/a/b` alike,
+        // but trimming keeps the Debug output stable across equivalent inputs.
+        let path = rest.trim_end_matches('/');
+        if path.is_empty() {
+            return Err(DrainError::Uri {
+                uri: uri.to_string(),
+                reason: "path is the filesystem root — refusing to drain into `/`".to_string(),
+            });
+        }
+        Ok(Self::File {
+            path: PathBuf::from(path),
+        })
+    }
+
+    /// The key prefix every object written to this destination sits beneath.
+    ///
+    /// Empty for `file://`, where the URI's path is the store root and keys are
+    /// already relative to it.
+    pub fn prefix(&self) -> &str {
+        match self {
+            Self::S3 { prefix, .. } => prefix,
+            Self::File { .. } => "",
+        }
+    }
+
+    /// The scheme this destination was parsed from.
+    pub fn scheme(&self) -> DestinationScheme {
+        match self {
+            Self::S3 { .. } => DestinationScheme::S3,
+            Self::File { .. } => DestinationScheme::File,
+        }
+    }
+}
+
+/// Extract `region=<value>` from an `s3://` query string.
+///
+/// Rejects any other parameter rather than ignoring it: a silently-dropped
+/// `?reigon=eu-west-1` would send logs to the wrong region with no signal.
+fn parse_region_query(uri: &str, query: &str) -> Result<String, DrainError> {
+    let mut region = None;
+    for pair in query.split('&').filter(|p| !p.is_empty()) {
+        let (key, value) = pair.split_once('=').ok_or_else(|| DrainError::Uri {
+            uri: uri.to_string(),
+            reason: format!("query parameter `{pair}` has no `=`"),
+        })?;
+        if key != "region" {
+            return Err(DrainError::Uri {
+                uri: uri.to_string(),
+                reason: format!("unknown query parameter `{key}` — only `region` is accepted"),
+            });
+        }
+        if value.is_empty() {
+            return Err(DrainError::Uri {
+                uri: uri.to_string(),
+                reason: "`region=` is empty".to_string(),
+            });
+        }
+        region = Some(value.to_string());
+    }
+    region.ok_or_else(|| DrainError::Uri {
+        uri: uri.to_string(),
+        reason: "query string is present but empty".to_string(),
+    })
+}
+
+/// Strip leading and trailing `/` and collapse the empty case.
+fn normalise_prefix(prefix: &str) -> String {
+    prefix.trim_matches('/').to_string()
+}

--- a/docs/reference/log-drain.md
+++ b/docs/reference/log-drain.md
@@ -1,0 +1,211 @@
+# Log Drain — Destinations, Key Layout, and Manifest Semantics
+
+> Reference for `trusty_common::log_drain`, added by
+> [#6533](https://github.com/bobmatnyc/trusty-tools/issues/6533) (epic phase
+> 1+2). This page covers the drain **core**: destination URIs, the key layout,
+> manifest semantics, the scrub, and the limits. It is not a configuration
+> guide — nothing reads a config file or schedules a run yet. See
+> [What Phase 3 adds](#what-phase-3-adds).
+
+The module is gated behind the `log-drain` feature and is not compiled by
+default:
+
+```bash
+cargo test -p trusty-common --features log-drain --no-fail-fast
+```
+
+## Why it exists
+
+Every trusty daemon writes logs to a local path that nothing prunes and nothing
+collects — `~/.trusty-mpm/logs/trusty-mpm.log.YYYY-MM-DD`,
+`~/Library/Logs/trusty-agents/daemon-*.log`, and so on. Diagnosing a failure on
+another machine means asking a human to find and send a file. The drain moves
+those bytes somewhere durable, scrubbed of credentials, without re-uploading
+what has not changed.
+
+## Destination URIs
+
+`DestinationUri::parse` accepts a closed set of schemes. There is no general URI
+crate behind it: the grammar is small, and a closed enum is what lets a
+Google-storage URI produce a message naming what *is* supported instead of a
+syntax error.
+
+| Form | Meaning |
+|---|---|
+| `s3://bucket` | Bucket root, region from the AWS credential chain |
+| `s3://bucket/prefix` | Every object written beneath `prefix` |
+| `s3://bucket/prefix?region=us-west-2` | Region override; the ONLY accepted query parameter |
+| `file:///abs/path` | A local directory. Used by the hermetic tests, and by an operator staging output before pointing at a bucket |
+| `gs://…`, `az://…` | **Reserved and refused** with `DrainError::UnsupportedScheme` |
+
+Rejected forms, each with `DrainError::Uri`: a missing `://`, an empty bucket
+(`s3:///prefix`), a relative `file://relative/path`, `file:///` (the filesystem
+root), a query on a `file://` URI, an empty or misspelled query parameter. A
+misspelled `?reigon=` is refused rather than ignored — silently dropping it
+would send logs to the wrong region with no signal.
+
+Schemes are matched case-insensitively; the rest of the URI is not.
+
+### S3 credentials
+
+The S3 adapter loads the **AWS default provider chain** — environment
+variables, `~/.aws/credentials`, SSO, IMDS — the same chain
+`inference::bedrock` uses, reused rather than reimplemented per the
+common-entry-point rule in [`CLAUDE.md`](../../CLAUDE.md). It is bridged into
+`object_store`'s own `CredentialProvider`, and re-fetched on each request so a
+rotated session token is picked up without rebuilding the store.
+
+**No bucket or region is ever hardcoded.** The region resolves as
+`?region=` → the credential chain → refusal with `DrainError::Credentials`.
+
+## Key layout
+
+```text
+<destination prefix>/<github_id>/<session_id>/logs/<crate>/<relative_file>
+```
+
+The destination prefix comes from the URI (`s3://bucket/PREFIX`) and is joined
+by the adapter; everything after it is built by `DrainTarget`. For
+`file://` destinations the URI's path is the store root, so the prefix is empty.
+
+`DrainTarget { github_id, session_id }` is **supplied by the caller**. The core
+does not resolve GitHub identity — that is Phase 3's job. An empty or
+whitespace-only `github_id` or `session_id` is refused with
+`DrainError::MissingIdentity` **before anything touches the filesystem or the
+network**: the drain never writes under an unknown id, because an empty
+component collapses one user's logs into a shared, unattributable prefix.
+
+`session_id` is opaque to the drain — it is whatever the consuming crate calls
+its own session.
+
+## Manifest semantics
+
+Each target carries a JSON manifest at
+`<…>/logs/.drain-manifest.json`, listing one entry per uploaded file:
+
+```json
+{
+  "version": 1,
+  "entries": [
+    {
+      "relative_file": "trusty-mpm/daemon.log",
+      "size": 48122,
+      "mtime_unix": 1788271952,
+      "sha256": "9f2c…",
+      "uploaded_at": "2026-09-01T14:12:32.273982+00:00"
+    }
+  ]
+}
+```
+
+`size` and `sha256` describe the **plaintext source file**, not the gzipped
+body — so a change to the level filter or the compression level never
+invalidates every recorded digest.
+
+### Two copies, and which one wins
+
+- **Remote** (`<…>/logs/.drain-manifest.json`) is **authoritative**. It is the
+  only copy that describes what is actually in the bucket.
+- **Local cache** (`<state_dir>/log-drain/<github_id>/<session_id>/manifest.json`)
+  exists so an unchanged run costs no network read at all.
+
+When both exist and disagree, the remote copy wins and the cache is rewritten
+from it. A stale cache that won would make the drain skip files that were never
+uploaded. A cache write failure is logged and swallowed — it costs the next run
+one extra remote read and nothing else.
+
+An **undecodable** manifest — corrupt JSON, or an unrecognised `version` — is
+treated as **absent**, never as an error. Re-uploading a file is strictly safer
+than skipping one that was never written.
+
+### Skip decision, and why SHA-256 wins
+
+Per source file, in order:
+
+1. **Stat-only fast path.** If a manifest entry exists and *both* `size` and
+   `mtime_unix` match, the file is skipped **without being opened**. This is
+   where an unchanged run's cheapness comes from: an unchanged machine reads no
+   log bytes at all.
+2. **Size ceiling.** A file over `max_file_bytes` is skipped — see
+   [Limits](#limits).
+3. **SHA-256 tiebreak.** Otherwise the file is read and hashed. **If the digest
+   matches the recorded entry, the file is still skipped**, and the entry's
+   `size`/`mtime_unix` are refreshed so the next run takes the fast path.
+
+Step 3 is the rule worth stating plainly: **content identity wins over mtime.**
+A file whose timestamp moved but whose bytes are identical — a `touch`, a log
+rotated back into place, a checkout that rewrote timestamps — is **not**
+re-uploaded. `mtime` is only ever an optimisation for avoiding the read.
+
+The manifest is rewritten once after a batch, reflecting only what actually
+landed, so a run interrupted partway still leaves the next run able to skip what
+did upload.
+
+## The scrub
+
+Every body passes through `credentials::scrub_secrets` before compression, with
+the caller-supplied secret list. The pipeline order is fixed inside the
+collector — decode, level-filter, **scrub**, gzip — so no body can reach a
+destination having skipped it. The `log-drain` feature *implies* `credentials`
+for exactly this reason: a build with the drain but without the scrubber would
+upload log text nothing had cleaned.
+
+**`scrub_secrets` removes values it is GIVEN.** It does not detect
+secret-shaped strings, and it ignores needles below its own minimum length. A
+caller that passes an empty list gets no scrubbing.
+
+## Level filtering
+
+When a `LogSource` sets `level_filter`, lines below that level are dropped
+before upload — a daemon's DEBUG output is the bulk of its bytes and almost
+never the reason anyone reads the log later.
+
+The collector recognises the `tracing_subscriber::fmt` default line shape,
+`<timestamp> <LEVEL> <target>: <message>`, including ANSI-colourised output.
+Two rules keep it from destroying a file it does not understand:
+
+- A line carrying **no recognisable level** is a *continuation* — a wrapped
+  message, a backtrace frame — and inherits the disposition of the line above
+  it.
+- A file containing **no recognisable level line at all** is not tracing output
+  and is passed through **verbatim** rather than filtered to nothing.
+
+## Limits
+
+| Limit | Value | Behaviour |
+|---|---|---|
+| `max_file_bytes` | 64 MiB default | Oversize files are **skipped**, never truncated or chunked |
+| `LIST_LIMIT` | 10 000 entries | `list` truncates with a `warn!` |
+
+**Why oversize files are skipped rather than streamed.** The scrub has to see a
+whole body to catch a secret that straddles a chunk boundary, so a chunked
+upload path could only ever write partially-scrubbed text. Refusing to upload is
+the safe half of that trade, and `DrainReport::skipped_too_large` plus a `warn!`
+say so out loud rather than silently truncating.
+
+## What the caller owns
+
+- **Identity** — `DrainTarget` is supplied, never resolved here.
+- **Single-flight** — `run_once` is one pass with no locking. Two concurrent
+  runs against one target will both upload and both rewrite the manifest, and
+  the loser's entries are lost. Mutual exclusion belongs to the scheduler.
+- **The secret list** — see [The scrub](#the-scrub).
+
+A **per-file** failure is collected into `DrainReport::errors` and the batch
+continues; one unreadable file must not strand every other log on the machine.
+Only a manifest read/write failure aborts a run.
+
+## What Phase 3 adds
+
+Not in this module, deliberately:
+
+- The **scheduler** — a `tokio::time::interval` + `CancellationToken` loop
+  beside `orphan_gc_loop`, with the single-flight guard `run_once` does not
+  provide.
+- **GitHub identity resolution** — one cached `gh api user` lookup feeding
+  `DrainTarget.github_id`, with the config value taking precedence.
+- **Configuration** — a `[log_drain]` section, and the `LogSource` list for the
+  daemons that actually produce logs.
+- **Consumers** — nothing calls `run_once` yet.
+- **Pruning** — the drain is upload-only; `prune_after_upload` is not
+  implemented.


### PR DESCRIPTION
## Summary

Refs #6534 (sub-issue of epic #6533). Implements Phase 3 (core module + infrastructure) of the log-drain feature.

## What Changed

- New `crates/trusty-common/src/log_drain/` module behind the `log-drain` feature flag
- `LogDestination` trait for pluggable destination backends
- `ObjectStoreDestination` implementing `s3://` and `file://` via `object_store` crate
- `DestinationUri` parser for destination URIs with scheme validation
- Per-session manifest with SHA-256 content deduplication
- `DrainCollector` with secret scrubbing and gzip compression
- `run_once` entry point for single-shot drain operations
- `DrainReport` for operation status and metrics
- Design document at `docs/reference/log-drain.md` (internal, not in public manifest)
- Changelog fragment `crates/trusty-common/changelog.d/6533-log-drain-core.md`
- New workspace dependency: `aws-credential-types` (already in Cargo.lock transitively)

## Three Implementation Decisions (Review Flag)

1. **Fourth trait method `get`**: Added because "remote manifest is authoritative" is unsatisfiable with put/head/list alone. The `get` method reads the manifest from storage to verify deduplication decisions against the remote source of truth.

2. **Oversize file handling**: Files exceeding the size threshold are skipped (not chunked or streamed), ensuring the secret scrub always sees a complete body. Oversized files are reported via `DrainReport::skipped_too_large` for observability.

3. **SHA-256 deduplication decision point**: Used when the size+mtime fast-path comparison misses (e.g., identical content with different timestamps). Balances safety (cryptographic identity) against performance.

## Test Ladder: Rung 4 (Cross-Crate Library Change)

Shared library additive change; `check_semver.sh --crate trusty-common` shows 196 pass / 58 skip, no version bump required (0.46.6 stands).

**All gates with `-p trusty-common --features log-drain`:**

- `cargo fmt --check` — EXIT 0
- `cargo check` — EXIT 0
- `cargo clippy --all-targets -- -D warnings` — EXIT 0
- `cargo test --no-fail-fast -- log_drain` — 27 passed; 0 failed
- Unfiltered `cargo test --no-fail-fast` — 506 passed; 1 failed; 6 ignored; `feature_coverage` 4 passed
- `--features unconditional-only` — 390 passed; 1 failed (feature compiles cleanly)
- `cargo check --workspace` — EXIT 0
- `check_line_cap.sh` — 0 violations
- `check_sld.sh` — 0/0
- `check_changelog_fragment.sh` — OK
- `check_test_pointers.sh` — 0 dangling
- `check_teardown_guard.sh` — OK

## Baseline Failures (Pre-Existing, Not This PR)

`launchd_labels::tests::no_stray_launchd_label_literals_in_workspace_sources` fails on `com.trusty.console.saver` literals from PR #6527 (commit 5dc182c5e, on origin/main).

**Proof of pre-existing:**
- `git diff origin/main...HEAD -- crates/trusty-common/src/launchd_labels/ crates/trusty-console/ scripts/` is empty on this branch
- Test fails identically with the `log-drain` feature off
- Not silenced; disposition being handled by ticketing separately

## Out of Scope (Phase 3 Work Only)

- Scheduler integration (#6535)
- `[log_drain]` configuration parsing
- Identity resolution for S3 credentials
- Consumer implementations (drain, analyze, inspect daemons)
- Automatic pruning policy and execution

Real-S3 integration exercised only by compilation; `s3_smoke` test is explicit opt-in via `TRUSTY_LOG_DRAIN_S3_SMOKE_URI` environment variable.

## Documentation and Changelog

- Design document: `docs/reference/log-drain.md` (internal reference)
- Changelog fragment: `crates/trusty-common/changelog.d/6533-log-drain-core.md` present

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools