### PR TITLE
chore(sessions): commit the 2026-09-01 pause snapshots

### DIFF
--- a/.trusty-mpm/sessions/0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260901-144157.md
+++ b/.trusty-mpm/sessions/0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260901-144157.md
@@ -1,0 +1,46 @@
+# Session Pause - 2026-09-01T14:41:57.381916+00:00
+
+## Summary
+Paused 2026-09-01 ~14:50Z mid-drive (owner priority order: cloud log drain [new top item, epic #6533] → console/screensaver → bugs → status:merged closures → release cleanup → P1s; palace drawer ws:tm-trusty-tools-02/priorities). 🔴 FOUR BACKGROUND AGENTS LIVE AT PAUSE — agents can survive a pause but cannot be SendMessage-resumed reliably after; on resume run ListAgents FIRST, then verify each via gh/worktree before any re-dispatch: (1) rust-engineer on #6529 orphan_gc pane-parse fix, branch fix/6529-orphan-gc-pane-parse; (2) rust-engineer on #6534 log_drain core in trusty-common, branch feat/6533-log-drain-core; (3) documentation agent on docs/setup-doc-review-edits (3 docs edits: tctl stack doctor cheat-sheet row, default local URLs table, btop GPU tip) — then security scan → version-control PR; (4) documentation agent editing the owner's Google Doc 1CiLXgV39whymD60HXTsBA_oBmYPcYqz-PXa1-pzQeg8 (install sequence, stale FDA/certificate paragraph, answered TODOs). Worktree prune skipped at pause to protect their trees.
+
+SHIPPED TODAY (all squash-merged to main, auto-merge, no critic round per owner "let's be efficient" except one focused critic on the destructive reclaim gate): epic #6516 all four phases — #6522 (#6517 data model + console header version), #6525 (#6518 Foundry Overview dashboard), #6526 (#6519 /ui/screensaver route), #6527 (#6520 TrustyConsole.saver bundle, scripts/build-console-saver.sh + install-console-saver.sh); #6524 search-dashboard embedding pause + file-events — #6532 (trusty-search 0.51.0 daemon API) + #6538 (console proxy + ui-search panel); trusty-mpm bug batch #6528 (#6507 count_unlanded squash-merge reclaim, #6497 tm session adopt-worktree + reaper stales dead-session delegations), #6530 (#6523 tmux fixture diagnosis + full_user_cycle HOME isolation), #6531 (tm-capabilities catalog regen). tagent reinstalled from origin/main 579482f53 (#4260 verified). 16 status:merged issues closed at status:tested; #4278 closed by owner ruling; #5439 kept open for its UDS half.
+
+UNPUBLISHED ON MAIN, publish authorization NOT given (drawer ws:tm-trusty-tools-02/release-state): trusty-common 0.46.6, trusty-search 0.51.0, trusty-console 0.9.2, trusty-mpm 1.5.15. Nine issues at status:merged wait on that install: #6505 #6507 #6497 #6523 #6517 #6518 #6519 #6520 #6524.
+
+🔴 HOST STATE: macOS pty pool exhausted (kern.tty.ptmx_max 511, 527 allocated) by 456 leaked idle tm-<uuid> tmux sessions (bare zsh, no children, no tm record). orphan_gc runs but misclassifies every pane (PaneInfo.session_name arrives as the 4 fields joined by '_', command empty) — #6529 (P1). Every tmux new-session / openpty on this host fails ENXIO until reaped; the trusty-mpm tmux test family is red here for that reason only. Owner NOT yet asked/answered on the manual reap.
+
+OWNER RULINGS this session: simple text changes need no ticket/PR (PM does them; branch protection still routes main-bound changes via PR); no review rounds on sprint work; pause = embedding stage only (#6524); close #4278 on the persona-chat half; cloud log drain prioritised.
+
+## Completed
+- Epic #6516 phases 1-4 merged: PRs #6522 #6525 #6526 #6527 (issues #6517-#6520 at status:merged)
+- #6524 embedding pause + file-events merged: PRs #6532 (trusty-search 0.51.0) + #6538 (console) — issue at status:merged
+- trusty-mpm bug batch merged: #6528 (#6507 + #6497), #6530 (#6523 fixtures), #6531 (capabilities regen)
+- tagent reinstalled from origin/main 579482f53; Slack daemon restarted (PID 83171)
+- Closed at status:tested: #4766 #6490 #4611 #3835 #4323 #6495 #4999 #5040 #6508 #4260 #4054 #4520 #4844 #4860 #3766; #4278 closed by owner ruling
+- Filed: #6523 (tmux-nested test failures → root cause #6529), #6524, #6529 (pty pool leak, P1), #6533 epic cloud log drain + sub-issues #6534-#6537
+- .saver feasibility spike: sandboxed loopback WKWebView REACHABLE under legacyScreenSaver.appex entitlement mirror; spike files in scratchpad/saver-spike/
+- Google Doc review (Duetto stack setup): 4 small internal doc gaps found, no website/manifest change warranted
+
+## In Progress
+- rust-engineer: #6529 fix on fix/6529-orphan-gc-pane-parse — live-trace PaneInfo parse, regression tests through real parse, tm doctor pty-headroom check, tm-<uuid> creator hunt; then scan → PR (Refs #6529); tm 1.5.15 or 1.5.16
+- rust-engineer: #6534 log_drain core on feat/6533-log-drain-core (trusty-common, feature log-drain: LogDestination trait, object_store s3://+file://, URI parser, manifest, collector+scrub+gzip, run_once, docs/reference/log-drain.md); then scan → PR; then Phase 3 #6535 (mpm scheduler/config/doctor) off its API
+- documentation: docs/setup-doc-review-edits (install-and-run-tm.md tctl stack doctor row; running-mcp-servers.md default URLs table; trusty-search README btop tip) → scan → version-control PR (docs-only, no ticket)
+- documentation: Google Doc 1CiLXgV39whymD60HXTsBA_oBmYPcYqz-PXa1-pzQeg8 corrections via gworkspace-mcp — report before/after to owner
+
+## Next Steps
+- ListAgents first; verify the four agents' branches/worktrees via git before re-dispatching anything
+- ASK OWNER (still unanswered): reap 456 leaked tm-<uuid> tmux sessions now (local-ops: dry-run list = tm-* absent from `tm session ls --all --json`, every pane zsh, no child; then tmux kill-session per line) vs wait for the #6529 fix install
+- ASK OWNER: HostThresholds ruling (CPU 80/95, memory 80/95, disk 85/95 provisional, #6517)
+- ASK OWNER: publish authorization — common 0.46.6 → search 0.51.0 → console 0.9.2, mpm 1.5.15 (Skill cargo-publish, local-ops); then install; then live-verify + close the nine status:merged issues; then owner's Preview click for the .saver (#6520); then prune the 13 verified worktrees (drawer ws:tm-trusty-tools-02/worktree-prune) with the fixed tm
+- #6533 remaining phases after #6534 lands: #6535 mpm scheduler + [log_drain] config + doctor row; #6536 prune_after_upload; #6537 trusty-code/agents adoption
+- #6529: after fix lands, orphan_gc should reap; then #6523's tmux family goes green — live-verify both
+- Open: Pending badge tone on the search dashboard pipeline panel (accent vs PAUSED amber) — owner call
+- P1 backlog (13 dormant) untouched — lowest priority
+
+## Git Context
+Branch: main
+Last commit: 7ecbf2f2a feat(trusty-console): Overview becomes the Foundry machine-status dashboard (Refs #6518) (#6525)
+Uncommitted changes: 6 file(s) changed
+
+## Tmux Window
+tm-trusty-tools-02:0:@2307

--- a/.trusty-mpm/sessions/sessions-log.jsonl
+++ b/.trusty-mpm/sessions/sessions-log.jsonl
@@ -69,3 +69,5 @@
 {"session_id":"tm-dogfood-0-at0-20260830","event":"pause","snapshot":"tm-dogfood-0-at0-20260830/session-20260831-001831.md","timestamp":"2026-08-31T00:18:31.782944+00:00"}
 {"session_id":"tm-dogfood-0-at0-20260831","event":"pause","snapshot":"tm-dogfood-0-at0-20260831/session-20260831-122741.md","timestamp":"2026-08-31T12:27:41.649425+00:00"}
 {"session_id":"tm-dogfood-0-at0-20260831","event":"pause","snapshot":"tm-dogfood-0-at0-20260831/session-20260831-170955.md","timestamp":"2026-08-31T17:09:55.446633+00:00"}
+{"session_id":"tm-trusty-tools-01-0-at2221","event":"pause","snapshot":"tm-trusty-tools-01-0-at2221/session-20260831-201746.md","timestamp":"2026-08-31T20:17:46.051171+00:00"}
+{"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260901-144157.md","timestamp":"2026-09-01T14:41:57.381916+00:00"}

--- a/.trusty-mpm/sessions/tm-trusty-tools-01-0-at2221/session-20260831-201746.md
+++ b/.trusty-mpm/sessions/tm-trusty-tools-01-0-at2221/session-20260831-201746.md
@@ -1,0 +1,43 @@
+# Session Pause - 2026-08-31T20:17:46.051171+00:00
+
+## Summary
+Paused mid bug-drive 2026-08-31 (owner: "keep driving to close all bugs"). 🔴 FIVE BACKGROUND AGENTS WERE LIVE AT PAUSE — agents can survive a pause but CANNOT be SendMessage-resumed reliably after; on resume run ListAgents FIRST, then verify each via gh (branch/PR/commit state) BEFORE any re-dispatch. Worktree pruning was SKIPPED at pause (prune_worktrees:false) to protect their in-flight trees.
+
+DRIVE ARC: the census correction is the key fact — a label-based pass showed "9 open bugs", but a deep pass over the 212 untyped issues surfaced a real ~20-bug layer, several security-grade. Roughly a third turned out ALREADY-FIXED on main (census read issue bodies, not main): #4847, #3715, #2764, #4917, #3696, #4999 parts A/B, #4327 (not-reproducing in tga defaults; real over-match is downstream cto-reports custom ruleset), #4964 phases 2+3. Every fix engineer now carries a "verify still-broken on main FIRST" instruction because of this.
+
+RELEASE STATE: trusty-mpm 1.5.13 published+installed earlier this session (daemon PID 47029). Unpublished-on-main version bumps now accumulating for the next train: trusty-mpm 1.5.14 (#6490), trusty-common 0.46.3 + trusty-code 0.5.0 (#6491 auth), trusty-review heading to 0.31.0 (#4999, in flight), tga 5.0.2 (#6487 merged). Publish authorization for these NOT yet given — ask owner when the drive's fixes land.
+
+OWNER RULINGS THIS SESSION (all recorded on issues): #4054 exfil→confirmation gate, EXTENDED to also strip manage_events+manage_drive_file (7 tools total); #4520 wildcard "*" excludes L0 tools; #4570 keychain enable-opt-in-first (NOT yet dispatched); #3766 templates defer-to-policy (NOT yet dispatched); #4579 prune-on-boot; #4844 drop stale gworkspace-calendar declaration + close; #4271 superseded-close; #5161 test-evidence close; tm 1.5.13 publish-now.
+
+CLAUDE CODE CONFIG (non-repo): set CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1 in ~/.claude/settings.json env block per owner request — fixes the "single window scrolling" complaint (Claude Code fullscreen renderer was capturing the wheel; classic renderer restores native+tmux scrollback). Takes effect on next Claude Code restart. NOT a trusty-tools change. The #6469/#6475 tmux_options fix is verified correct-and-live; it was aimed at a different layer (panes hosting the claude CLI), not the ratatui dashboard or the CC pane.
+
+## Completed
+- tm 1.5.13 published to crates.io (tag trusty-mpm-v1.5.13 @ 6830ceefa, 9/9 preflight, parity-verified) + installed + daemon restarted PID 47029; #6483 live-verified (tui multipane default) and CLOSED at status:tested
+- CLOSED this session: #4271 (superseded by #6464), #5161 (test evidence), #6414 (independent live re-measure: ~3s vs 53-60s baseline), #6444 (compliant path = ADR-0056 by-role grant + non-isolated version-control dispatch, proven by PR #6485), #6483, #4327 (not-reproducing in tga defaults), #2764 (lru CVE fixed by PR #2782), #4917 (vmtest skew fixed by console 0.9.x + #6448)
+- MERGED to main this session: #6485 (snapshot), #6486 (changelog assembly), #6487 (#4293 tga determinism, bumped 5.0.2), #6488 (#5657 red-main notifier), #6489 (#4260 tagent version provenance), #6491 (#5439+#6472 trusty-code auth hardening — shared daemon-token bearer, /health lockdown, SSE tickets; critic BLOCK→APPROVE, 2 CRITICAL+1 HIGH+4 MEDIUM closed), #6492 (#6490 parity flake), #6493 (#4700 stale .claude-mpm cleanup)
+- status:merged awaiting live-verify: #4260, #4293, #5657, #5439 (stays open, Refs not Closes — UDS transport owed), #6472, #6490, #4700, #4847 (already-fixed by #6448)
+- DISPOSITIONED: #4751→enhancement (build-info embedding is feature-scale), #3844 parked pending #3899, #4964 epic reconciled (phases 2+3 shipped 2026-08-15 f32dc1e17, remaining 4+5 scheduled), #3715 already-fixed by PR #3721 (kept open as pointer to blocked #3764/#4207 per owner), #3696 disposition in flight (already fixed by merged slices #4143/#4145/#4146)
+- Empty/finished worktrees pruned; main checkout returned to main and fast-forwarded (was on chore/session-snapshots-20260831)
+
+## In Progress
+- 🔴 #4999 APEX-retrieval-removal (trusty-review): branch fix/4999-drop-apex-retrieval, head 7d909e31 (removal ad31629ab + WARN-fix 7d909e31: 4 stale test-pointer-allowlist rows removed, test strengthened, 3 spec docs updated). Critic WARN CLEARED. Security scans CLEAN (both base + increment). local-ops agent afa2c6ee IS BUMPING trusty-review 0.30.0→0.31.0 (public-API removal = MINOR) and pushing — VERIFY its push landed, then route version-control PR+arm. Critic already APPROVE-equivalent (WARN fully addressed).
+- 🔴 #4054+#4520 agent tool-authz (trusty-agents): branch fix/4054-4520-agent-tool-authz, base b16a56a07. Critic APPROVED the base. rust-engineer afbe5122 IS EXTENDING the exfil strip to add manage_events+manage_drive_file (owner ruling) + fixing the LOW advisory-pane display drift (agent_subagents/knowledge/skills .rs use raw match_any_glob). On its report: LIGHT critic re-confirm on the delta → scan → PR+arm (NO bump, trusty-agents unpublished). Scan of base was CLEAN.
+- 🔴 #4323+#4766 trusty-mpm batch: branch fix/4323-4766-trusty-mpm. rust-engineer a29b0284 BUILDING — #4766 (rewrite ambient-tier double-scan test to use resolve_pm_prompt_with_roster seam, test-only) + #4323 (bound ~/.trusty-mpm state accumulation: test isolation is the big win, sessions-dir reaper with fail-closed guard, log-volume; deferrable parts to a follow-up). No bump (trusty-mpm 1.5.14 unpublished-on-main).
+- 🔴 #4579 (trusty-code): branch fix/4579-3696-trusty-code, head 89821e1aa, scan CLEAN, at status:coded. version-control a425d4f8 IS OPENING the PR + arming — verify the PR landed/armed with gh.
+- 🔴 #3696: ticketing acf8976b IS CLOSING it as already-fixed-on-main — verify it closed and whether it found/linked an existing GUI-incremental-append follow-up issue.
+
+## Next Steps
+- ListAgents FIRST; verify all five live agents via gh before any re-dispatch. For #4999: confirm local-ops pushed the 0.31.0 bump, then version-control opens PR + posts the critic-WARN-cleared summary + arms. For #4054/#4520: on engineer report, dispatch a LIGHT code-critic re-confirm on just the delta (the base mechanism is already APPROVED), then scan → version-control PR+arm.
+- Advance labels as PRs land: #4579→merged when its PR merges; #4999/#4054/#4520 through coded→merged.
+- REMAINING WAVE-B bugs NOT yet dispatched (dispatch as crates clear, verify-still-broken-first): trusty-agents correctness batch #4860 (cto-db silent fixture fallback — Python skill db.py:65, no crate bump), #3835 (run_pm_task_with_history hardcoded max_turns=4 — history.rs:547, needs bump), #4611 (for_instance_validates_the_id missing #[serial] — home_tests.rs:109, test-only), #4278 (chat UI never rehydrated — App.svelte:334, Svelte/TS rung 6) — ALL trusty-agents, hold until #4054/#4520 lands to avoid concurrent-writer collision; #4844 drop gworkspace-calendar declaration + close (owner-ruled); #3766 templates defer-to-policy (owner-ruled); #4570 keychain enable-opt-in-first (owner-ruled, trusty-common — hold until #6491's 0.46.3 area is clear).
+- Exact file:line pins for all wave-B bugs are in research sweep ac90f59 output (already-fixed vs still-broken verdicts). #4323 remaining-scope follow-up may need its own issue if the engineer defers the reaper.
+- When the drive's fixes have landed, ASK OWNER for publish authorization for the accumulated bumps (trusty-mpm 1.5.14, trusty-common 0.46.3, trusty-code 0.5.0, trusty-review 0.31.0, tga 5.0.2) — then run the publish+install train (cargo-publish skill, dependency-ordered).
+- Machine-load discipline held all session: cap ~3 concurrent cargo builders; batch by crate; never put a concurrent writer on a crate with an in-flight PR.
+
+## Git Context
+Branch: main
+Last commit: 6830ceefa fix: give `tagent --version` stable build provenance, not a per-run counter (#6489)
+Uncommitted changes: 3 file(s) changed
+
+## Tmux Window
+tm-trusty-tools-01:0:@2221


### PR DESCRIPTION
Session pause snapshots for 2026-09-01 (tm-trusty-tools-01 and -02) plus their `sessions-log.jsonl` entries. `.trusty-mpm/sessions/` is tracked by owner ruling (2026-08-31) so other sessions can read prior work and intent. Rung 1, docs/state only; no crate source touched.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools