### PR TITLE
fix(docs,deps): resolve 20 broken intra-doc links and pin object_store to 0.13 for the pre-publish gate (Refs #6549)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1291,7 +1291,7 @@ dependencies = [
  "encoding_rs",
  "fast-float2",
  "log",
- "quick-xml",
+ "quick-xml 0.41.0",
  "serde",
  "zip 8.6.0",
 ]
@@ -1984,16 +1984,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "crc-fast"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
-dependencies = [
- "digest 0.10.7",
- "spin 0.10.1",
 ]
 
 [[package]]
@@ -4389,7 +4379,7 @@ dependencies = [
  "hash32",
  "rustc_version",
  "serde",
- "spin 0.9.9",
+ "spin",
  "stable_deref_trait",
 ]
 
@@ -5193,15 +5183,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5274,36 +5255,6 @@ dependencies = [
  "thiserror 1.0.69",
  "walkdir",
  "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "jni"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
-dependencies = [
- "cfg-if",
- "combine",
- "jni-macros",
- "jni-sys 0.4.1",
- "log",
- "simd_cesu8",
- "thiserror 2.0.18",
- "walkdir",
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "jni-macros"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
-dependencies = [
- "proc-macro2",
- "quote",
- "rustc_version",
- "simd_cesu8",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -5785,7 +5736,7 @@ dependencies = [
  "indexmap 2.14.0",
  "itoa",
  "log",
- "md-5 0.10.6",
+ "md-5",
  "nom 8.0.0",
  "rand 0.10.2",
  "rangemap",
@@ -5955,16 +5906,6 @@ checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
  "digest 0.10.7",
-]
-
-[[package]]
-name = "md-5"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
-dependencies = [
- "cfg-if",
- "digest 0.11.3",
 ]
 
 [[package]]
@@ -6329,18 +6270,6 @@ name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
-dependencies = [
- "bitflags 2.13.1",
- "cfg-if",
- "cfg_aliases",
- "libc",
-]
-
-[[package]]
-name = "nix"
-version = "0.31.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags 2.13.1",
  "cfg-if",
@@ -6833,16 +6762,14 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.14.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d354792e39fa5f0009e47623cf8b15b099bf9a652fa55c6f817fe28ac84fea50"
+checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
 dependencies = [
  "async-trait",
- "aws-lc-rs",
  "base64 0.22.1",
  "bytes",
  "chrono",
- "crc-fast",
  "form_urlencoded",
  "futures-channel",
  "futures-core",
@@ -6851,15 +6778,14 @@ dependencies = [
  "http-body-util",
  "humantime",
  "hyper 1.9.0",
- "itertools 0.15.0",
- "md-5 0.11.0",
- "nix 0.31.3",
+ "itertools 0.14.0",
+ "md-5",
  "parking_lot",
  "percent-encoding",
- "quick-xml",
+ "quick-xml 0.39.4",
  "rand 0.10.2",
- "reqwest 0.13.3",
- "rustls-pki-types",
+ "reqwest 0.12.28",
+ "ring",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -6870,7 +6796,6 @@ dependencies = [
  "walkdir",
  "wasm-bindgen-futures",
  "web-time",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7393,7 +7318,7 @@ checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml",
+ "quick-xml 0.41.0",
  "serde",
  "time",
 ]
@@ -7742,13 +7667,22 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "quick-xml"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "encoding_rs",
  "memchr",
- "serde",
 ]
 
 [[package]]
@@ -7777,7 +7711,6 @@ version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
- "aws-lc-rs",
  "bytes",
  "getrandom 0.4.2",
  "lru-slab",
@@ -8425,26 +8358,19 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "h2 0.4.14",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.9.0",
- "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-pki-types",
- "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper 1.0.2",
  "tokio",
- "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -8689,33 +8615,6 @@ dependencies = [
  "web-time",
  "zeroize",
 ]
-
-[[package]]
-name = "rustls-platform-verifier"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
-dependencies = [
- "core-foundation 0.10.1",
- "core-foundation-sys",
- "jni 0.22.4",
- "log",
- "once_cell",
- "rustls",
- "rustls-native-certs",
- "rustls-platform-verifier-android",
- "rustls-webpki",
- "security-framework 3.7.0",
- "security-framework-sys",
- "webpki-root-certs",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls-platform-verifier-android"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -9323,16 +9222,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
-name = "simd_cesu8"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
-dependencies = [
- "rustc_version",
- "simdutf8",
-]
-
-[[package]]
 name = "simd_helpers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9340,12 +9229,6 @@ checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
 dependencies = [
  "quote",
 ]
-
-[[package]]
-name = "simdutf8"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "similar"
@@ -9492,12 +9375,6 @@ checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]
-
-[[package]]
-name = "spin"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 
 [[package]]
 name = "spm_precompiled"
@@ -9890,7 +9767,7 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni 0.21.1",
+ "jni",
  "libc",
  "log",
  "ndk",
@@ -9958,7 +9835,7 @@ dependencies = [
  "heck 0.5.0",
  "http 1.4.0",
  "image",
- "jni 0.21.1",
+ "jni",
  "libc",
  "log",
  "mime",
@@ -10122,7 +9999,7 @@ dependencies = [
  "dpi",
  "gtk",
  "http 1.4.0",
- "jni 0.21.1",
+ "jni",
  "objc2",
  "objc2-ui-kit",
  "objc2-web-kit",
@@ -10145,7 +10022,7 @@ checksum = "b83849ee63ecb27a8e8d0fe51915ca215076914aca43f96db1179f0f415f6cd9"
 dependencies = [
  "gtk",
  "http 1.4.0",
- "jni 0.21.1",
+ "jni",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -12075,7 +11952,7 @@ dependencies = [
  "ort",
  "pdf-extract",
  "petgraph 0.6.5",
- "quick-xml",
+ "quick-xml 0.41.0",
  "rand 0.8.6",
  "rayon",
  "redb 2.6.3",
@@ -13839,7 +13716,7 @@ dependencies = [
  "gtk",
  "http 1.4.0",
  "javascriptcore-rs",
- "jni 0.21.1",
+ "jni",
  "libc",
  "ndk",
  "objc2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -410,7 +410,22 @@ aws-credential-types   = { version = "1.2" }
 # extra TLS stack out of the graph — the drain only ever talks S3 or local disk.
 # `fs` is re-enabled explicitly because dropping the defaults also drops
 # `LocalFileSystem`, which the `file://` destination and every hermetic test need.
-object_store = { version = "0.14", default-features = false, features = ["aws", "fs"] }
+#
+# PINNED TO 0.13, NOT 0.14, TO KEEP THE DUPLICATE RATCHET AT ITS BASELINE.
+# 0.14.0 swapped three transitive pins at once, and each one lands as a second
+# copy of a crate the workspace already resolves:
+#   reqwest ^0.12 -> ^0.13   (the whole workspace, async-openai, teloxide-core,
+#                             hf-hub and reqwest-eventsource are all on 0.12)
+#   md-5    ^0.10 -> ^0.11   (lopdf holds 0.10)
+#   crc-fast (new)           (pulls spin 0.10; ring holds spin 0.9)
+# All three are semver-incompatible majors, so no `cargo update --precise` can
+# unify them — only the object_store major chooses. 0.13.2 needs none of them,
+# and the drain uses no 0.14-only API: AmazonS3Builder, AwsCredential,
+# LocalFileSystem, path::Path, ObjectMeta, CredentialProvider and the
+# NotFound/Unauthenticated variants all predate it. Staying on 0.13 also keeps a
+# second reqwest/hyper/rustls stack out of every binary. Revisit when the
+# workspace itself moves to reqwest 0.13. See #6549.
+object_store = { version = "0.13", default-features = false, features = ["aws", "fs"] }
 # Cheaply-cloneable reference-counted byte buffer. `object_store` already
 # resolves it (its `PutPayload` is built from `Bytes`), so declaring it direct
 # adds no new crate to the lockfile — it only lets `LogDestination::put` name

--- a/crates/trusty-common/changelog.d/6549-intra-doc-links.md
+++ b/crates/trusty-common/changelog.d/6549-intra-doc-links.md
@@ -1,0 +1,9 @@
+Documentation
+
+- Fixed 13 broken intra-doc links in the `host_metrics` and `log_drain` module
+  headers. Both headers are concatenated with the outer `///` block on their
+  `pub mod` declaration in `lib.rs`, so rustdoc resolves them in the crate-root
+  scope and bare item names never resolved. Link targets are now crate-qualified,
+  matching the `sys_metrics` link that already worked. A broken link is baked
+  into a docs.rs page permanently, so these had to land before publishing
+  (#6549).

--- a/crates/trusty-common/changelog.d/6549-object-store-pin.md
+++ b/crates/trusty-common/changelog.d/6549-object-store-pin.md
@@ -1,0 +1,11 @@
+Changed
+
+- Pinned `object_store` to 0.13 (from 0.14) for the `log-drain` feature. 0.14
+  moved to `reqwest` 0.13, `md-5` 0.11 and a new `crc-fast`, each of which lands
+  as a second copy of a crate the workspace already resolves — the workspace,
+  `async-openai`, `teloxide-core`, `hf-hub` and `reqwest-eventsource` are all on
+  `reqwest` 0.12, `lopdf` holds `md-5` 0.10, and `ring` holds `spin` 0.9. 0.13.2
+  needs none of them and the drain uses no 0.14-only API, so this drops three
+  duplicate crate versions and keeps a second reqwest/hyper/rustls stack out of
+  every binary. Revisit when the workspace itself moves to `reqwest` 0.13
+  (#6549).

--- a/crates/trusty-common/src/host_metrics.rs
+++ b/crates/trusty-common/src/host_metrics.rs
@@ -8,11 +8,13 @@
 //!      host-sampling capability lives here once rather than being reinvented in
 //!      trusty-console, so any future consumer (a second dashboard, a headless
 //!      health probe) reuses the same typed shapes.
-//! What: [`HostSampler`] wraps a `sysinfo::System` plus its `Networks`/`Disks`
-//!      handles and, on each [`HostSampler::sample`], returns a [`HostMetrics`]
-//!      snapshot. Health thresholds ([`HostThresholds`]) are PROVISIONAL — see
-//!      the type's docs; they need an owner ruling before any alarm is wired to
-//!      them.
+//! What: [`HostSampler`](crate::host_metrics::HostSampler) wraps a
+//!      `sysinfo::System` plus its `Networks`/`Disks` handles and, on each
+//!      [`HostSampler::sample`](crate::host_metrics::HostSampler::sample),
+//!      returns a [`HostMetrics`](crate::host_metrics::HostMetrics) snapshot.
+//!      Health thresholds ([`HostThresholds`](crate::host_metrics::HostThresholds))
+//!      are PROVISIONAL — see the type's docs; they need an owner ruling before
+//!      any alarm is wired to them.
 //! Test: the inline `tests` module — `sampler_produces_plausible_snapshot`,
 //!      `pressure_classification_boundaries`, `thresholds_are_configurable`,
 //!      and the serde round-trip.

--- a/crates/trusty-common/src/log_drain/mod.rs
+++ b/crates/trusty-common/src/log_drain/mod.rs
@@ -6,9 +6,12 @@
 //! those bytes somewhere durable, scrubbed of credentials, without re-uploading
 //! what has not changed.
 //!
-//! What: the drain CORE — a [`LogDestination`] trait with `s3://` and `file://`
-//! adapters, a [`DestinationUri`] parser, the key layout, an idempotency
-//! [`DrainManifest`], the [`collect`] pipeline, and [`run_once`]. Phase 1+2 is
+//! What: the drain CORE — a [`LogDestination`](crate::log_drain::LogDestination)
+//! trait with `s3://` and `file://` adapters, a
+//! [`DestinationUri`](crate::log_drain::DestinationUri) parser, the key layout,
+//! an idempotency [`DrainManifest`](crate::log_drain::DrainManifest), the
+//! [`collect`](crate::log_drain::collect) pipeline, and
+//! [`run_once`](crate::log_drain::run_once). Phase 1+2 is
 //! the core ONLY: there is no scheduler, no config plumbing, and no consumer
 //! wired up. Phase 3 adds those, plus GitHub-identity resolution — this module
 //! deliberately does not resolve an identity, it demands one.
@@ -23,15 +26,19 @@
 //! ```
 //!
 //! The destination prefix comes from the URI (`s3://bucket/PREFIX`); everything
-//! after it is built by [`DrainTarget::logs_prefix`]. Per-target reference
+//! after it is built by
+//! [`DrainTarget::logs_prefix`](crate::log_drain::DrainTarget::logs_prefix).
+//! Per-target reference
 //! documentation: `docs/reference/log-drain.md`.
 //!
 //! # What the caller owns
 //!
-//! - **Identity.** [`DrainTarget`] is supplied, never resolved here. An empty
-//!   `github_id` or `session_id` is refused with
-//!   [`DrainError::MissingIdentity`] rather than defaulted.
-//! - **Single-flight.** [`run_once`] is exactly what its name says: one pass,
+//! - **Identity.** [`DrainTarget`](crate::log_drain::DrainTarget) is supplied,
+//!   never resolved here. An empty `github_id` or `session_id` is refused with
+//!   [`DrainError::MissingIdentity`](crate::log_drain::DrainError::MissingIdentity)
+//!   rather than defaulted.
+//! - **Single-flight.** [`run_once`](crate::log_drain::run_once) is exactly what
+//!   its name says: one pass,
 //!   no locking. Two concurrent runs against one target will both upload and
 //!   both rewrite the manifest, and the loser's entries are lost. The scheduler
 //!   Phase 3 adds owns that mutual exclusion.

--- a/crates/trusty-mpm/changelog.d/6549-intra-doc-links.md
+++ b/crates/trusty-mpm/changelog.d/6549-intra-doc-links.md
@@ -1,0 +1,9 @@
+Documentation
+
+- Fixed 6 broken intra-doc links in the daemon `log_drain` module header. The
+  header is concatenated with the outer `///` block on `pub mod log_drain;` in
+  `daemon/mod.rs`, so rustdoc resolves it in the crate-root scope and bare item
+  names never resolved; `log_drain_loop`, `drain_once`, `LogDrainStatus`,
+  `DrainOutcome` and `DrainOutcome::Failed` are now crate-qualified.
+  `orphan_gc_loop` is private, so it reads as plain backticks rather than a link
+  (#6549).

--- a/crates/trusty-mpm/src/daemon/log_drain.rs
+++ b/crates/trusty-mpm/src/daemon/log_drain.rs
@@ -4,22 +4,26 @@
 //! identity resolution, and no memory of what it last did. A daemon that only
 //! ever called it would upload once and never again, under whatever identity
 //! the caller guessed. This module is the half that makes it a running service:
-//! an interval loop beside [`super::orphan_gc_loop`], `gh`-resolved identity,
-//! and a persisted last-run verdict the `log_drain` doctor row reads.
+//! an interval loop beside `orphan_gc_loop` (private, in `daemon/mod.rs`),
+//! `gh`-resolved identity, and a persisted last-run verdict the `log_drain`
+//! doctor row reads.
 //!
-//! What: [`log_drain_loop`] ticks on the configured interval until its
+//! What: [`log_drain_loop`](crate::daemon::log_drain::log_drain_loop) ticks on
+//! the configured interval until its
 //! [`CancellationToken`](tokio_util::sync::CancellationToken) fires;
-//! [`drain_once`] is one full pass (resolve config, resolve identity, connect,
-//! `run_once`, record); [`LogDrainStatus`] is what it writes to
-//! `<state_dir>/status.json`.
+//! [`drain_once`](crate::daemon::log_drain::drain_once) is one full pass
+//! (resolve config, resolve identity, connect, `run_once`, record);
+//! [`LogDrainStatus`](crate::daemon::log_drain::LogDrainStatus) is what it
+//! writes to `<state_dir>/status.json`.
 //!
 //! Test: `tests` submodule — every case drives a real `file://` destination in
 //! a `tempfile::TempDir`, so nothing here needs S3 or the network.
 //!
 //! # It never reports "drained" for a run that failed
 //!
-//! [`DrainOutcome`] has exactly three values, and the mapping is total:
-//! `run_once` returning `Err` is [`DrainOutcome::Failed`], and so is an `Ok`
+//! [`DrainOutcome`](crate::daemon::log_drain::DrainOutcome) has exactly three
+//! values, and the mapping is total: `run_once` returning `Err` is
+//! [`DrainOutcome::Failed`](crate::daemon::log_drain::DrainOutcome::Failed), and so is an `Ok`
 //! report carrying per-file errors — the core deliberately continues past an
 //! unreadable file, which means an `Ok` return is NOT proof every file landed.
 //! Collapsing either into "success" would let the doctor row read green while

--- a/crates/trusty-search/changelog.d/6549-intra-doc-links.md
+++ b/crates/trusty-search/changelog.d/6549-intra-doc-links.md
@@ -1,0 +1,5 @@
+Documentation
+
+- Fixed a broken intra-doc link on `CodeIndexer::pending_embed_count`, and four
+  stale prose references beside it. All named `embed_deferred_chunks`, which
+  #6524 renamed to `embed_deferred_chunks_gated` (#6549).

--- a/crates/trusty-search/src/core/indexer/ingest/mod.rs
+++ b/crates/trusty-search/src/core/indexer/ingest/mod.rs
@@ -748,13 +748,13 @@ impl CodeIndexer {
     }
 
     /// Count corpus chunks NOT yet embedded (issue #3748 slice A, review
-    /// finding 2) — the real cost [`Self::embed_deferred_chunks`] will pay, as
+    /// finding 2) — the real cost [`Self::embed_deferred_chunks_gated`] will pay, as
     /// opposed to `chunk_count()`'s TOTAL corpus size.
     ///
     /// Why: the deferred-embed catch-up queue (`service::reindex::defer_embed_queue`)
     /// originally keyed its size-ordered priority on `chunk_count()`,
     /// captured once by `finish_reindex` after every reindex — including
-    /// INCREMENTAL ones. But `embed_deferred_chunks` only ever embeds the
+    /// INCREMENTAL ones. But `embed_deferred_chunks_gated` only ever embeds the
     /// chunks the vector store does not already have (its own
     /// `contains_many` filter, see that method's docs) — so an incremental
     /// reindex of a 94k-chunk repo with a single changed chunk sorted as
@@ -771,15 +771,15 @@ impl CodeIndexer {
     /// are already resident — always true immediately after a reindex, the
     /// only caller of this today) and reads only the chunk IDs (`HashMap`
     /// keys — no `RawChunk` content/Vec fields cloned, unlike
-    /// `embed_deferred_chunks`, which legitimately needs the full chunks to
+    /// `embed_deferred_chunks_gated`, which legitimately needs the full chunks to
     /// embed them), runs the SAME single bulk `VectorStore::contains_many`
-    /// check `embed_deferred_chunks` runs, and counts the `false`
+    /// check `embed_deferred_chunks_gated` runs, and counts the `false`
     /// (not-yet-embedded) entries.
     /// Test: `pending_embed_count_matches_delta_not_total_chunk_count`,
     /// `pending_embed_count_equals_total_on_a_cold_index`.
     pub async fn pending_embed_count(&self) -> usize {
         if self.store.is_none() || self.embedder.is_none() {
-            // `embed_deferred_chunks` would short-circuit to `Ok((0, total))`
+            // `embed_deferred_chunks_gated` would short-circuit to `Ok((0, total))`
             // immediately in this case too, so the queue key is moot here —
             // fall back to the plain (non-blocking) chunk count rather than
             // loading/locking the chunk map for a membership check that

--- a/scripts/deny-duplicate-baseline.txt
+++ b/scripts/deny-duplicate-baseline.txt
@@ -15,5 +15,34 @@
 # versions. `cargo deny check bans` prints the full list and the dependency path
 # to every copy.
 #
+# RAISED 83 -> 84 on 2026-09-01 (#6549, log-drain dependency chain).
+#
+# The pair: quick-xml 0.39 (pulled by object_store) against quick-xml 0.41
+# (pulled by calamine 0.36, plist 1.10, and trusty-search's own direct
+# dependency).
+#
+# Why it cannot unify: 0.39 and 0.41 are semver-incompatible — for a 0.x crate
+# Cargo treats the MINOR as the major — so no `cargo update --precise` can
+# collapse them. Only object_store's major chooses which one it wants, and every
+# choice costs something:
+#
+#   object_store 0.14.1  quick-xml ^0.41 (unified) but reqwest ^0.13, md-5
+#                        ^0.11 and a new crc-fast (-> spin 0.10) — THREE new
+#                        duplicates, since the workspace, async-openai,
+#                        teloxide-core, hf-hub and reqwest-eventsource are all
+#                        on reqwest 0.12, lopdf holds md-5 0.10, and ring holds
+#                        spin 0.9. Count: 86.
+#   object_store 0.13.2  needs none of those three, but wants quick-xml ^0.39 —
+#                        ONE new duplicate. Count: 84.
+#
+# 0.13.2 is pinned in `[workspace.dependencies]` for exactly this reason: it
+# trades three duplicates for one and keeps a second reqwest/hyper/rustls stack
+# out of every binary. Moving the other side is not available either — calamine
+# and plist pin 0.41 at their latest releases, so pinning trusty-search down to
+# 0.39 would leave the duplicate in place and drag two more crates backwards.
+#
+# This row drops back to 83 when the workspace moves to reqwest 0.13, at which
+# point object_store 0.14 costs nothing and quick-xml unifies on 0.41.
+#
 # One bare integer, first non-comment line:
-83
+84


### PR DESCRIPTION
## Summary

Release-blocking: pre-publish gate run 33531796951 at 17c3a13b1 failed Gate 1 (20 broken intra-doc links: 13 trusty-common, 6 trusty-mpm, 1 trusty-search) and Gate 3 (cargo-deny duplicates 86 vs baseline 83).

## Links

Links: 19 were bare names in `//!` module headers resolving in crate-root scope → crate-qualified; 1 (`Self::embed_deferred_chunks`) was a #6524 rename leftover → now `embed_deferred_chunks_gated`, prose updated. One private-item link (`orphan_gc_loop`) became plain backticks; no visibility widened. Gate 1 re-run locally: `0 broken link(s)`.

## Duplicates

Duplicates: all three new dupes came from `object_store` 0.14 (`reqwest` 0.13, `md-5` 0.11, `crc-fast`→`spin` 0.10). Pinned `object_store = "0.13"` in `[workspace.dependencies]` — unifies all three and drops `crc-fast`/`jni`/`rustls-platform-verifier` from the graph. `quick-xml` (0.39 vs 0.41 via calamine/plist) is unavoidable at either object_store version → baseline raised 83→84 with the crate pair and revert condition documented in `scripts/deny-duplicate-baseline.txt`. Gate 3 re-run: `84 duplicated crate(s), at the baseline — PASS`.

## Changelog & Verification

Changelog: four new fragments (three `6549-intra-doc-links.md` + `6549-object-store-pin.md`); deliberately NOT merged into the assembled sections — fragment consumption is the release cut's job (#5674); the cut runs `assemble-changelog.sh <crate> <version> --merge` before tagging.

Test ladder: rung 4. `cargo fmt --check` 0; `SKIP_UI_BUILD=1 cargo check --workspace` 0; clippy trusty-common (log-drain,host-metrics) 0; `cargo test -p trusty-common --features log-drain,host-metrics --no-fail-fast` → `516 passed; 0 failed` (+4); `cargo test -p trusty-search --lib` → `1955 passed; 0 failed`; `check_line_cap.sh` 0; `check_sld.sh` 0/0; fragment + PR-assembled gates both pass. Known pre-existing flake `managed_prune_worktrees_parity_defaults_to_a_preview` ($HOME leak under parallel run) failed once in the full trusty-mpm run, passes in isolation both with and without this diff — being filed separately, not silenced.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools