### PR TITLE
fix: object_store back to 0.14 — quick-xml 0.39.4 carries RUSTSEC-2026-0194/0195

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1291,7 +1291,7 @@ dependencies = [
  "encoding_rs",
  "fast-float2",
  "log",
- "quick-xml 0.41.0",
+ "quick-xml",
  "serde",
  "zip 8.6.0",
 ]
@@ -1984,6 +1984,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc-fast"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
+dependencies = [
+ "digest 0.10.7",
+ "spin 0.10.1",
 ]
 
 [[package]]
@@ -4379,7 +4389,7 @@ dependencies = [
  "hash32",
  "rustc_version",
  "serde",
- "spin",
+ "spin 0.9.9",
  "stable_deref_trait",
 ]
 
@@ -5183,6 +5193,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5255,6 +5274,36 @@ dependencies = [
  "thiserror 1.0.69",
  "walkdir",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5736,7 +5785,7 @@ dependencies = [
  "indexmap 2.14.0",
  "itoa",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "nom 8.0.0",
  "rand 0.10.2",
  "rangemap",
@@ -5906,6 +5955,16 @@ checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -6270,6 +6329,18 @@ name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags 2.13.1",
  "cfg-if",
@@ -6762,14 +6833,16 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.13.2"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
+checksum = "d354792e39fa5f0009e47623cf8b15b099bf9a652fa55c6f817fe28ac84fea50"
 dependencies = [
  "async-trait",
+ "aws-lc-rs",
  "base64 0.22.1",
  "bytes",
  "chrono",
+ "crc-fast",
  "form_urlencoded",
  "futures-channel",
  "futures-core",
@@ -6778,14 +6851,15 @@ dependencies = [
  "http-body-util",
  "humantime",
  "hyper 1.9.0",
- "itertools 0.14.0",
- "md-5",
+ "itertools 0.15.0",
+ "md-5 0.11.0",
+ "nix 0.31.3",
  "parking_lot",
  "percent-encoding",
- "quick-xml 0.39.4",
+ "quick-xml",
  "rand 0.10.2",
- "reqwest 0.12.28",
- "ring",
+ "reqwest 0.13.3",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -6796,6 +6870,7 @@ dependencies = [
  "walkdir",
  "wasm-bindgen-futures",
  "web-time",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7318,7 +7393,7 @@ checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml 0.41.0",
+ "quick-xml",
  "serde",
  "time",
 ]
@@ -7667,22 +7742,13 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.39.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
-name = "quick-xml"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "encoding_rs",
  "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -7711,6 +7777,7 @@ version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.4.2",
  "lru-slab",
@@ -8358,19 +8425,26 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
+ "h2 0.4.14",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.9.0",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper 1.0.2",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -8615,6 +8689,33 @@ dependencies = [
  "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni 0.22.4",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework 3.7.0",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -9222,6 +9323,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
 name = "simd_helpers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9229,6 +9340,12 @@ checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
 dependencies = [
  "quote",
 ]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "similar"
@@ -9375,6 +9492,12 @@ checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]
+
+[[package]]
+name = "spin"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 
 [[package]]
 name = "spm_precompiled"
@@ -9767,7 +9890,7 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "ndk",
@@ -9835,7 +9958,7 @@ dependencies = [
  "heck 0.5.0",
  "http 1.4.0",
  "image",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "mime",
@@ -9999,7 +10122,7 @@ dependencies = [
  "dpi",
  "gtk",
  "http 1.4.0",
- "jni",
+ "jni 0.21.1",
  "objc2",
  "objc2-ui-kit",
  "objc2-web-kit",
@@ -10022,7 +10145,7 @@ checksum = "b83849ee63ecb27a8e8d0fe51915ca215076914aca43f96db1179f0f415f6cd9"
 dependencies = [
  "gtk",
  "http 1.4.0",
- "jni",
+ "jni 0.21.1",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -11952,7 +12075,7 @@ dependencies = [
  "ort",
  "pdf-extract",
  "petgraph 0.6.5",
- "quick-xml 0.41.0",
+ "quick-xml",
  "rand 0.8.6",
  "rayon",
  "redb 2.6.3",
@@ -13716,7 +13839,7 @@ dependencies = [
  "gtk",
  "http 1.4.0",
  "javascriptcore-rs",
- "jni",
+ "jni 0.21.1",
  "libc",
  "ndk",
  "objc2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -411,21 +411,30 @@ aws-credential-types   = { version = "1.2" }
 # `fs` is re-enabled explicitly because dropping the defaults also drops
 # `LocalFileSystem`, which the `file://` destination and every hermetic test need.
 #
-# PINNED TO 0.13, NOT 0.14, TO KEEP THE DUPLICATE RATCHET AT ITS BASELINE.
-# 0.14.0 swapped three transitive pins at once, and each one lands as a second
-# copy of a crate the workspace already resolves:
+# PINNED TO 0.14, NOT 0.13, BECAUSE 0.13 CARRIES A VULNERABLE quick-xml.
+# object_store 0.13.2 wants quick-xml ^0.39, and quick-xml 0.39.4 carries
+# RUSTSEC-2026-0194 (quadratic run time on duplicate start-tag attributes) and
+# RUSTSEC-2026-0195 (unbounded namespace-declaration allocation in `NsReader`),
+# both 7.5 high, both fixed only in 0.41.0. `cargo audit` and `cargo deny check
+# advisories` — pre-publish Gates 2 and 3 — hard-fail on either one. 0.13 is the
+# end of its line: 0.13.2 is the newest 0.13.x on crates.io, so no patch release
+# moves it off 0.39. Only the object_store major chooses, and 0.14.1 wants
+# quick-xml ^0.41, which the workspace already resolves for calamine, plist and
+# trusty-search.
+#
+# The price is three duplicate versions, all semver-incompatible majors that no
+# `cargo update --precise` can unify:
 #   reqwest ^0.12 -> ^0.13   (the whole workspace, async-openai, teloxide-core,
 #                             hf-hub and reqwest-eventsource are all on 0.12)
 #   md-5    ^0.10 -> ^0.11   (lopdf holds 0.10)
 #   crc-fast (new)           (pulls spin 0.10; ring holds spin 0.9)
-# All three are semver-incompatible majors, so no `cargo update --precise` can
-# unify them — only the object_store major chooses. 0.13.2 needs none of them,
-# and the drain uses no 0.14-only API: AmazonS3Builder, AwsCredential,
-# LocalFileSystem, path::Path, ObjectMeta, CredentialProvider and the
-# NotFound/Unauthenticated variants all predate it. Staying on 0.13 also keeps a
-# second reqwest/hyper/rustls stack out of every binary. Revisit when the
-# workspace itself moves to reqwest 0.13. See #6549.
-object_store = { version = "0.13", default-features = false, features = ["aws", "fs"] }
+# That raises the duplicate ratchet from 84 to 86 and puts a second
+# reqwest/hyper/rustls stack in every binary that enables `log-drain`. A real
+# advisory outranks a duplicate count, so the ratchet baseline moves instead.
+# The reqwest duplicate collapses when the workspace itself moves to reqwest
+# 0.13; md-5 and spin need lopdf and ring to move. See #6549 and
+# scripts/deny-duplicate-baseline.txt.
+object_store = { version = "0.14", default-features = false, features = ["aws", "fs"] }
 # Cheaply-cloneable reference-counted byte buffer. `object_store` already
 # resolves it (its `PutPayload` is built from `Bytes`), so declaring it direct
 # adds no new crate to the lockfile — it only lets `LogDestination::put` name

--- a/scripts/deny-duplicate-baseline.txt
+++ b/scripts/deny-duplicate-baseline.txt
@@ -2,7 +2,9 @@
 #
 # The number below is how many crates appear at more than one version in this
 # workspace's dependency graph, as counted by `cargo deny check bans` with the
-# policy in deny.toml. Measured 2026-08-15 at e39183c3, with the default feature set (NOT --all-features).
+# policy in deny.toml. Always measured with the default feature set (NOT
+# --all-features); the date and commit of the current measurement are in the
+# most recent raise note below.
 #
 # The gate FAILS when the live count exceeds this number, so a dependency bump
 # that introduces a new duplicate has to be noticed and justified. It PASSES and
@@ -11,38 +13,44 @@
 # LOWERING IT IS ALWAYS WELCOME. Raising it is a review decision that belongs in
 # the PR body, not a quiet edit.
 #
-# The three worst offenders today are base64, derive_more and lru, each at three
-# versions. `cargo deny check bans` prints the full list and the dependency path
-# to every copy.
+# The worst offenders today are itertools and toml at four versions each, then
+# base64, derive_more, getrandom, lru, nix, rand, rand_core, toml_datetime,
+# toml_edit and winnow at three. `cargo deny check bans` prints the full list
+# and the dependency path to every copy.
 #
-# RAISED 83 -> 84 on 2026-09-01 (#6549, log-drain dependency chain).
+# RAISED 83 -> 84 on 2026-09-01 (#6549, log-drain dependency chain), then
+# 84 -> 86 the same day (#6549) when the 84 pin turned out to be vulnerable.
+# Measured 86 on 2026-09-01 at f3d825341 plus this commit's dependency change.
+# The 84 and 86 lists differ by exactly four crates: quick-xml leaves, md-5,
+# reqwest and spin arrive.
 #
-# The pair: quick-xml 0.39 (pulled by object_store) against quick-xml 0.41
-# (pulled by calamine 0.36, plist 1.10, and trusty-search's own direct
-# dependency).
+# What the 84 row bought and why it was given back. object_store 0.13.2 was
+# pinned in `[workspace.dependencies]` to hold the count at 84: it wants
+# quick-xml ^0.39, ONE new duplicate against the quick-xml 0.41 that calamine
+# 0.36, plist 1.10 and trusty-search already pull. object_store 0.14.1 wants
+# quick-xml ^0.41 (unified) but also reqwest ^0.13, md-5 ^0.11 and a new
+# crc-fast (-> spin 0.10) — THREE new duplicates, since the workspace,
+# async-openai, teloxide-core, hf-hub and reqwest-eventsource are all on
+# reqwest 0.12, lopdf holds md-5 0.10, and ring holds spin 0.9.
 #
-# Why it cannot unify: 0.39 and 0.41 are semver-incompatible — for a 0.x crate
-# Cargo treats the MINOR as the major — so no `cargo update --precise` can
-# collapse them. Only object_store's major chooses which one it wants, and every
-# choice costs something:
+# The 0.39 side is not merely older. quick-xml 0.39.4 carries RUSTSEC-2026-0194
+# (quadratic run time checking a start tag for duplicate attribute names) and
+# RUSTSEC-2026-0195 (unbounded namespace-declaration allocation in `NsReader`),
+# both 7.5 high, both fixed only in 0.41.0. `cargo audit` (Gate 2) and
+# `cargo deny check advisories` (Gate 3) hard-fail on either, so the 84 pin
+# could not clear the pre-publish gate at all.
 #
-#   object_store 0.14.1  quick-xml ^0.41 (unified) but reqwest ^0.13, md-5
-#                        ^0.11 and a new crc-fast (-> spin 0.10) — THREE new
-#                        duplicates, since the workspace, async-openai,
-#                        teloxide-core, hf-hub and reqwest-eventsource are all
-#                        on reqwest 0.12, lopdf holds md-5 0.10, and ring holds
-#                        spin 0.9. Count: 86.
-#   object_store 0.13.2  needs none of those three, but wants quick-xml ^0.39 —
-#                        ONE new duplicate. Count: 84.
+# Nothing cheaper exists. 0.13.2 is the newest 0.13.x on crates.io, so no patch
+# release moves that line off 0.39; 0.39 and 0.41 are semver-incompatible — for
+# a 0.x crate Cargo treats the MINOR as the major — so no `cargo update
+# --precise` collapses them; and moving the other side is not available either,
+# since calamine and plist pin 0.41 at their latest releases. Only the
+# object_store major chooses. A real advisory outranks two duplicate versions,
+# so object_store moves to 0.14 and this number moves to 86.
 #
-# 0.13.2 is pinned in `[workspace.dependencies]` for exactly this reason: it
-# trades three duplicates for one and keeps a second reqwest/hyper/rustls stack
-# out of every binary. Moving the other side is not available either — calamine
-# and plist pin 0.41 at their latest releases, so pinning trusty-search down to
-# 0.39 would leave the duplicate in place and drag two more crates backwards.
-#
-# This row drops back to 83 when the workspace moves to reqwest 0.13, at which
-# point object_store 0.14 costs nothing and quick-xml unifies on 0.41.
+# This row drops to 85 when the workspace itself moves to reqwest 0.13. The
+# remaining two need their other side to move: lopdf off md-5 0.10, and ring
+# off spin 0.9.
 #
 # One bare integer, first non-comment line:
-84
+86


### PR DESCRIPTION
Refs #6549.

PR #6552's object_store 0.13 pin pulled quick-xml 0.39.4, which carries RUSTSEC-2026-0194/0195; cargo audit and cargo deny advisories hard-fail on it (pre-publish gate run 33538979335). This restores object_store 0.14.1 (quick-xml 0.41.0 only) and re-raises the duplicate baseline 84→86 with the measured delta recorded in scripts/deny-duplicate-baseline.txt.

The +2 ratchet raise means a second reqwest/hyper/rustls stack lands in every binary enabling `log-drain`; the advisory forces the trade.

Gate evidence summary: `cargo audit` 0 vulnerabilities; `cargo deny check advisories|bans|licenses|sources` all ok; ratchet [PASS] 86 at baseline; `cargo check --workspace` clean. No crate src changed, no changelog fragment required (check_changelog_fragment.sh exit 0).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools