### PR TITLE
chore(trusty-search): assemble changelog for v0.51.0

### DIFF
--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -18,6 +18,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - `CodeIndexer::embed_deferred_chunks` — folded into `embed_deferred_chunks_gated(progress_tx, pause)`, which does the same work and takes an optional pause gate. Pass `pause: None` for the previous behaviour. Keeping both left a second, unguarded entry point to a durable write, which `scripts/check_teardown_guard.sh` flags (#6524, #3049).
 
+### Documentation
+
+- Fixed a broken intra-doc link on `CodeIndexer::pending_embed_count`, and four
+  stale prose references beside it. All named `embed_deferred_chunks`, which
+  #6524 renamed to `embed_deferred_chunks_gated` (#6549).
+
 ## [0.50.0] — 2026-08-31
 
 ### Breaking

--- a/crates/trusty-search/changelog.d/6549-intra-doc-links.md
+++ b/crates/trusty-search/changelog.d/6549-intra-doc-links.md
@@ -1,5 +1,0 @@
-Documentation
-
-- Fixed a broken intra-doc link on `CodeIndexer::pending_embed_count`, and four
-  stale prose references beside it. All named `embed_deferred_chunks`, which
-  #6524 renamed to `embed_deferred_chunks_gated` (#6549).


### PR DESCRIPTION
## Summary
- Assembles the trusty-search 0.51.0 changelog.d fragment (#6549 intra-doc-links) into CHANGELOG.md ahead of the publish-train tag/publish step.
- Part of the owner-authorized publish train (trusty-common 0.46.6 -> trusty-search 0.51.0 -> trusty-console 0.9.2 -> trusty-mpm 1.5.15).

## Test plan
- Docs-only change (changelog assembly); no source touched.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools