### PR TITLE
chore(trusty-mpm): assemble changelog for v1.5.15

### DIFF
--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -69,6 +69,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   of the `catch_unwind` that was swallowing its failure (#6523).
 - **orphan-GC reads pane rows correctly again; `tm doctor` reports pty headroom** ([#6529](https://github.com/bobmatnyc/trusty-tools/issues/6529)): tmux sets its `CLIENT_UTF8` flag purely from `LC_ALL`/`LC_CTYPE`/`LANG`, and without it the server pushes every printed line through `utf8_sanitize()`, which replaces each byte below `0x20` with `_`. A launchd-started daemon inherits no locale variables, so the TABs separating the columns of `tmux list-panes -a -F` were rewritten and every pane row arrived as one field: `PaneInfo.session_name` held the whole joined row, `pane_current_command` came back empty, and `classify_session`'s idleness gate could never fire — 456 orphaned `tm-*` sessions survived every 60-second sweep for five days and exhausted the host's pseudo-terminal pool. Pane listings now spawn tmux through `core::tmux::force_utf8_client_env`, which injects `LC_ALL=en_US.UTF-8` only when the inherited environment does not already declare UTF-8 by tmux's own precedence. `parse_managed_pane_row` now requires exactly the four columns it asked for and DROPS anything else with one warning per listing, rather than folding a whole row into a session name. A new `pty_headroom` doctor check reports allocated pseudo-terminals against `kern.tty.ptmx_max`, warning at 80% and failing at 95%.
 
+### Documentation
+
+- Fixed 6 broken intra-doc links in the daemon `log_drain` module header. The
+  header is concatenated with the outer `///` block on `pub mod log_drain;` in
+  `daemon/mod.rs`, so rustdoc resolves it in the crate-root scope and bare item
+  names never resolved; `log_drain_loop`, `drain_once`, `LogDrainStatus`,
+  `DrainOutcome` and `DrainOutcome::Failed` are now crate-qualified.
+  `orphan_gc_loop` is private, so it reads as plain backticks rather than a link
+  (#6549).
+
 ## [1.5.14] — 2026-08-31
 
 ### Fixed

--- a/crates/trusty-mpm/changelog.d/6549-intra-doc-links.md
+++ b/crates/trusty-mpm/changelog.d/6549-intra-doc-links.md
@@ -1,9 +1,0 @@
-Documentation
-
-- Fixed 6 broken intra-doc links in the daemon `log_drain` module header. The
-  header is concatenated with the outer `///` block on `pub mod log_drain;` in
-  `daemon/mod.rs`, so rustdoc resolves it in the crate-root scope and bare item
-  names never resolved; `log_drain_loop`, `drain_once`, `LogDrainStatus`,
-  `DrainOutcome` and `DrainOutcome::Failed` are now crate-qualified.
-  `orphan_gc_loop` is private, so it reads as plain backticks rather than a link
-  (#6549).


### PR DESCRIPTION
## Summary
- Assembles the trusty-mpm 1.5.15 changelog.d fragment (#6549 intra-doc-links) into CHANGELOG.md ahead of the publish-train tag/publish step.
- Part of the owner-authorized publish train (trusty-common 0.46.6 -> trusty-search 0.51.0 -> trusty-console 0.9.2 -> trusty-mpm 1.5.15).

## Test plan
- Docs-only change (changelog assembly); no source touched.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools