### PR TITLE
fix(trusty-common): log-drain manifest cache key includes destination namespace

### DIFF
--- a/crates/trusty-common/changelog.d/6548-log-drain-manifest-cache-key.md
+++ b/crates/trusty-common/changelog.d/6548-log-drain-manifest-cache-key.md
@@ -1,0 +1,22 @@
+Fixed
+
+- `log_drain`'s local manifest cache is now keyed by the destination as well as
+  the identity, so switching `log_drain.destination` from one bucket to another
+  re-uploads instead of silently skipping. The cache lived at
+  `<state_dir>/log-drain/<github_id>/<session_id>/`, which described no
+  particular destination: repointing a session at a brand-new bucket found the
+  record written for the old one, and because the new bucket had no remote
+  manifest to override it, every previously drained file was classified
+  `SkipUnchanged` — 86 of them never arrived, while sources with no prior entry
+  uploaded normally (#6548). The cache path now carries
+  `DestinationUri::cache_namespace()` — scheme, bucket-or-path and key prefix,
+  hashed; `?region=` is excluded so a region override does not orphan a valid
+  cache. `LogDestination` gained a `cache_namespace` method, so the identity
+  comes from the destination rather than from a caller who could name the wrong
+  one.
+- A run whose manifest came from the destination now `head`s one sampled entry
+  and warns when that object is missing, reporting it in `DrainReport`'s new
+  `manifest_spot_check_missing` counter. Manifests written before the keying fix
+  list objects their bucket never received, and every file such a manifest names
+  skips forever; the repair is to delete the manifest object, documented in
+  `docs/reference/log-drain.md`.

--- a/crates/trusty-common/src/log_drain/collector.rs
+++ b/crates/trusty-common/src/log_drain/collector.rs
@@ -338,8 +338,8 @@ fn gzip(body: &[u8]) -> std::io::Result<Vec<u8>> {
     encoder.finish()
 }
 
-/// Hex SHA-256 of a byte slice.
-fn hex_digest(body: &[u8]) -> String {
+/// Hex SHA-256 of a byte slice. Always 64 characters.
+pub(super) fn hex_digest(body: &[u8]) -> String {
     let mut hasher = Sha256::new();
     hasher.update(body);
     format!("{:x}", hasher.finalize())

--- a/crates/trusty-common/src/log_drain/destination.rs
+++ b/crates/trusty-common/src/log_drain/destination.rs
@@ -128,6 +128,22 @@ pub trait LogDestination: Send + Sync + fmt::Debug {
 
     /// List objects under `prefix`, capped at [`LIST_LIMIT`] entries.
     async fn list(&self, prefix: &str) -> Result<Vec<ObjectMeta>, DrainError>;
+
+    /// Stable, filesystem-safe identity of this destination for local state.
+    ///
+    /// Why: a skip decision recorded against one destination says nothing about
+    /// another. The local manifest cache is stored under this string, so
+    /// switching buckets can no longer reuse the record written for the
+    /// previous one (#6548). It belongs on the DESTINATION rather than in a
+    /// caller-supplied config field because an id the caller passes in can
+    /// drift from the destination it names, and that drift is the bug again.
+    ///
+    /// What: any value that differs whenever two destinations could hold
+    /// different objects, and that is safe as a single path segment.
+    /// [`ObjectStoreDestination`] returns [`DestinationUri::cache_namespace`].
+    ///
+    /// Test: `super::tests::run_once_reuploads_when_the_destination_changes`.
+    fn cache_namespace(&self) -> &str;
 }
 
 /// The `object_store`-backed destination: `s3://` and `file://`.
@@ -154,6 +170,8 @@ pub struct ObjectStoreDestination {
     /// than failing. Nothing is lost: `Content-Encoding` exists to tell an HTTP
     /// client the body is gzipped, and a local destination has no HTTP client.
     supports_attributes: bool,
+    /// `DestinationUri::cache_namespace` for the URI this was built from (#6548).
+    cache_namespace: String,
 }
 
 impl fmt::Debug for ObjectStoreDestination {
@@ -186,6 +204,9 @@ impl ObjectStoreDestination {
     /// - [`DrainError::Credentials`] when the AWS chain yields no region.
     /// - [`DrainError::Transport`] when the S3 client cannot be constructed.
     pub async fn connect(uri: &DestinationUri) -> Result<Self, DrainError> {
+        // #6548: derived here, from the URI, so no caller can supply an id that
+        // disagrees with the destination it is naming.
+        let cache_namespace = uri.cache_namespace();
         match uri {
             DestinationUri::File { path } => {
                 std::fs::create_dir_all(path).map_err(|source| DrainError::Io {
@@ -201,13 +222,14 @@ impl ObjectStoreDestination {
                     prefix: String::new(),
                     label: format!("file://{}", path.display()),
                     supports_attributes: false,
+                    cache_namespace,
                 })
             }
             DestinationUri::S3 {
                 bucket,
                 prefix,
                 region,
-            } => Self::connect_s3(bucket, prefix, region.as_deref()).await,
+            } => Self::connect_s3(bucket, prefix, region.as_deref(), cache_namespace).await,
         }
     }
 
@@ -217,6 +239,7 @@ impl ObjectStoreDestination {
         bucket: &str,
         prefix: &str,
         region_override: Option<&str>,
+        cache_namespace: String,
     ) -> Result<Self, DrainError> {
         let label = format!("s3://{bucket}/{prefix}");
 
@@ -262,6 +285,7 @@ impl ObjectStoreDestination {
             prefix: prefix.to_string(),
             label,
             supports_attributes: true,
+            cache_namespace,
         })
     }
 
@@ -380,6 +404,10 @@ impl LogDestination for ObjectStoreDestination {
             }
         }
         Ok(out)
+    }
+
+    fn cache_namespace(&self) -> &str {
+        &self.cache_namespace
     }
 }
 

--- a/crates/trusty-common/src/log_drain/manifest.rs
+++ b/crates/trusty-common/src/log_drain/manifest.rs
@@ -13,6 +13,17 @@
 //! `super::tests::run_once_reuploads_a_mutated_file`,
 //! `super::tests::run_once_sha_beats_a_moved_mtime`,
 //! `super::tests::manifest_remote_wins_over_local_cache`.
+//!
+//! # The cache is per DESTINATION as well as per target (#6548)
+//!
+//! [`DrainManifest::cache_path`] puts
+//! [`LogDestination::cache_namespace`] above the target's own segment. Before
+//! that, the cache lived at `<state_dir>/log-drain/<github_id>/<session_id>/`
+//! and described no particular destination, so switching one session from
+//! bucket A to bucket B found A's record — and, since the fresh bucket had no
+//! remote manifest of its own to override it, skipped every file A already
+//! held. A skip decision is only ever valid for the destination it was made
+//! against.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -85,6 +96,23 @@ pub enum StatDecision {
     SkipUnchanged,
     /// No entry, or the stat differs. The file must be read and hashed.
     NeedsHash,
+}
+
+/// Which copy [`DrainManifest::load_with_origin`] actually returned.
+///
+/// Why: only a manifest that came from the destination makes a claim about what
+/// that destination holds, so only that one is worth spot-checking against it
+/// (#6548). A cached or empty manifest has nothing to be caught lying about.
+/// Test: `super::tests::run_once_spot_checks_a_lying_remote_manifest`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ManifestOrigin {
+    /// The destination's own copy — the authoritative one.
+    Remote,
+    /// The local cache; the destination had no decodable manifest.
+    LocalCache,
+    /// Neither copy existed, so the manifest is empty.
+    Absent,
 }
 
 impl DrainManifest {
@@ -170,14 +198,36 @@ impl DrainManifest {
         remote_key: &str,
         cache_key: &str,
     ) -> Result<Self, DrainError> {
-        let cache_path = cache_file(state_dir, cache_key);
+        Self::load_with_origin(dest, state_dir, remote_key, cache_key)
+            .await
+            .map(|(manifest, _)| manifest)
+    }
+
+    /// [`DrainManifest::load`], also saying which copy answered.
+    ///
+    /// Why: [`DrainManifest::spot_check`] is only meaningful against a manifest
+    /// the destination itself supplied, and `load` alone cannot say whether it
+    /// returned one (#6548).
+    /// What: identical to `load` in every other respect; the second element is
+    /// [`ManifestOrigin`].
+    /// Test: `super::tests::run_once_spot_checks_a_lying_remote_manifest`.
+    ///
+    /// # Errors
+    /// As [`DrainManifest::load`].
+    pub async fn load_with_origin(
+        dest: &dyn LogDestination,
+        state_dir: &Path,
+        remote_key: &str,
+        cache_key: &str,
+    ) -> Result<(Self, ManifestOrigin), DrainError> {
+        let cache_path = Self::cache_path(state_dir, dest, cache_key);
 
         if let Some(raw) = dest.get(remote_key).await? {
             match Self::decode(&raw) {
                 Ok(remote) => {
                     // Remote is authoritative: overwrite whatever the cache held.
                     write_cache(&cache_path, &remote);
-                    return Ok(remote);
+                    return Ok((remote, ManifestOrigin::Remote));
                 }
                 Err(reason) => {
                     tracing::warn!(
@@ -189,7 +239,64 @@ impl DrainManifest {
             }
         }
 
-        Ok(read_cache(&cache_path).unwrap_or_default())
+        Ok(match read_cache(&cache_path) {
+            Some(cached) => (cached, ManifestOrigin::LocalCache),
+            None => (Self::default(), ManifestOrigin::Absent),
+        })
+    }
+
+    /// Confirm that one sampled entry's object really is at the destination.
+    ///
+    /// Why: the runs made before #6548 was fixed wrote manifests that LIE — a
+    /// pass against a new bucket saved a record copied from a different
+    /// bucket's cache, so the document lists objects that bucket never
+    /// received, and every listed file skips forever. Keying the cache by
+    /// destination stops new ones being written; it cannot repair the ones
+    /// already in a bucket. One `head` per run buys an operator that signal
+    /// without putting a `head` per FILE on every steady-state pass — roughly
+    /// 150 extra round trips a run, forever, to guard against a defect that can
+    /// no longer occur.
+    ///
+    /// What: samples ONE entry, `head`s its key, and returns that key when the
+    /// object is absent. Detection only: nothing is re-uploaded and the
+    /// manifest is not rewritten, because an object a bucket lifecycle rule
+    /// legitimately expired would otherwise re-upload the whole session on
+    /// every run. The repair is deliberate and manual — delete the remote
+    /// manifest object; see `docs/reference/log-drain.md`. A transport error is
+    /// not an answer either way, so it yields `None` rather than failing a run
+    /// whose uploads are fine.
+    ///
+    /// Test: `super::tests::run_once_spot_checks_a_lying_remote_manifest`.
+    pub async fn spot_check(&self, dest: &dyn LogDestination, logs_prefix: &str) -> Option<String> {
+        let entry = self.entries.get(sample_index(self.entries.len())?)?;
+        let key = format!("{logs_prefix}/{}", entry.relative_file);
+        match dest.head(&key).await {
+            Ok(Some(_)) => None,
+            Ok(None) => Some(key),
+            Err(e) => {
+                tracing::debug!(
+                    %key,
+                    error = %e,
+                    "log-drain manifest spot check could not reach the destination"
+                );
+                None
+            }
+        }
+    }
+
+    /// Where this destination's local cache copy of a target's manifest lives.
+    ///
+    /// Why: public because clearing the cache is the operator-facing half of
+    /// the #6548 story, and a path an operator has to reconstruct by hand is a
+    /// path that will be reconstructed wrongly.
+    /// What: `<state_dir>/log-drain/<destination namespace>/<cache_key>/manifest.json`.
+    /// Test: `super::tests::manifest_remote_wins_over_local_cache`.
+    pub fn cache_path(state_dir: &Path, dest: &dyn LogDestination, cache_key: &str) -> PathBuf {
+        state_dir
+            .join("log-drain")
+            .join(dest.cache_namespace())
+            .join(cache_key)
+            .join("manifest.json")
     }
 
     /// Write the manifest to the destination and refresh the local cache.
@@ -218,7 +325,7 @@ impl DrainManifest {
         )
         .await?;
 
-        write_cache(&cache_file(state_dir, cache_key), self);
+        write_cache(&Self::cache_path(state_dir, dest, cache_key), self);
         Ok(())
     }
 
@@ -235,12 +342,19 @@ impl DrainManifest {
     }
 }
 
-/// Where the local cache copy of a target's manifest lives.
-fn cache_file(state_dir: &Path, cache_key: &str) -> PathBuf {
-    state_dir
-        .join("log-drain")
-        .join(cache_key)
-        .join("manifest.json")
+/// Pick one entry index out of `len`, or `None` when there is nothing to pick.
+///
+/// Sub-second wall clock is the source of variation, so consecutive scheduled
+/// runs land on different entries and a lying manifest is found within a few
+/// passes rather than only when the same entry keeps being drawn.
+fn sample_index(len: usize) -> Option<usize> {
+    if len == 0 {
+        return None;
+    }
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.subsec_nanos() as usize);
+    Some(nanos % len)
 }
 
 /// Read the cache, returning `None` for anything unreadable or undecodable.

--- a/crates/trusty-common/src/log_drain/mod.rs
+++ b/crates/trusty-common/src/log_drain/mod.rs
@@ -63,7 +63,7 @@ pub use collector::{
 pub use destination::{LIST_LIMIT, LogDestination, ObjectMeta, ObjectStoreDestination, PutMeta};
 pub use error::DrainError;
 pub use manifest::{
-    DrainManifest, MANIFEST_FILENAME, MANIFEST_VERSION, ManifestEntry, StatDecision,
+    DrainManifest, MANIFEST_FILENAME, MANIFEST_VERSION, ManifestEntry, ManifestOrigin, StatDecision,
 };
 pub use uri::{DestinationScheme, DestinationUri};
 
@@ -123,6 +123,10 @@ impl DrainTarget {
     }
 
     /// Path segment identifying this target inside the local state directory.
+    ///
+    /// The TARGET half only. [`DrainManifest::cache_path`] puts the
+    /// destination's namespace above it, so a record made for one destination
+    /// is never read back for another (#6548).
     fn cache_key(&self) -> String {
         format!("{}/{}", self.github_id, self.session_id)
     }
@@ -194,6 +198,13 @@ pub struct DrainReport {
     pub bytes_wire: u64,
     /// Per-file failures, as `(key or path, message)`. Never aborts the batch.
     pub errors: Vec<(String, String)>,
+    /// Sampled remote-manifest entries whose object was missing (#6548).
+    ///
+    /// 0 or 1 per run — one entry is sampled, not all of them. Non-zero means
+    /// the destination's own manifest lists something the destination does not
+    /// have, so every file it lists is being skipped rather than uploaded.
+    /// Repair is documented in `docs/reference/log-drain.md`.
+    pub manifest_spot_check_missing: usize,
 }
 
 /// Run the drain once: collect, compare against the manifest, upload what changed.
@@ -204,7 +215,10 @@ pub struct DrainReport {
 ///
 /// What: validates `target` FIRST, so a bad identity costs no filesystem walk
 /// and can never reach a `put`. Loads the manifest (remote authoritative, local
-/// cache as fallback). Collects every matching file. For each: the stat-only
+/// cache as fallback, and the cache is scoped to the DESTINATION as well as the
+/// target — see [`DrainManifest::cache_path`]). Collects every matching file.
+/// A manifest that came from the destination gets one sampled
+/// [`DrainManifest::spot_check`]. For each file: the stat-only
 /// fast path skips unchanged files without comparing digests; a file whose stat
 /// moved but whose SHA-256 matches is still skipped, with its manifest entry
 /// refreshed so the next run takes the fast path. Everything else is uploaded.
@@ -234,7 +248,8 @@ pub async fn run_once(
 
     let manifest_key = target.manifest_key();
     let cache_key = target.cache_key();
-    let mut manifest = DrainManifest::load(dest, &cfg.state_dir, &manifest_key, &cache_key).await?;
+    let (mut manifest, origin) =
+        DrainManifest::load_with_origin(dest, &cfg.state_dir, &manifest_key, &cache_key).await?;
 
     let collected = collect(sources, &cfg.secrets, cfg.max_file_bytes)?;
 
@@ -244,6 +259,21 @@ pub async fn run_once(
     };
     for (path, message) in collected.errors {
         report.errors.push((path.display().to_string(), message));
+    }
+
+    // #6548: a manifest written before the cache-keying fix can list objects
+    // this destination never received, and every one of them then skips
+    // forever. One sampled `head` turns that into a warning an operator sees.
+    if origin == ManifestOrigin::Remote
+        && let Some(missing) = manifest.spot_check(dest, &target.logs_prefix()).await
+    {
+        report.manifest_spot_check_missing += 1;
+        tracing::warn!(
+            key = %missing,
+            manifest = %manifest_key,
+            "log-drain manifest lists an object this destination does not have; \
+             delete the manifest object to force a full re-upload (see #6548)"
+        );
     }
 
     let now = chrono::Utc::now().to_rfc3339();

--- a/crates/trusty-common/src/log_drain/tests.rs
+++ b/crates/trusty-common/src/log_drain/tests.rs
@@ -160,6 +160,42 @@ fn uri_region_override() {
 }
 
 #[test]
+fn cache_namespace_separates_destinations() {
+    let a = DestinationUri::parse("s3://bucket-a/logs").expect("bucket-a");
+    let b = DestinationUri::parse("s3://bucket-b/logs").expect("bucket-b");
+    let other_prefix = DestinationUri::parse("s3://bucket-a/other").expect("other prefix");
+    let local = DestinationUri::parse("file:///tmp/drain-a").expect("file");
+
+    assert_ne!(a.cache_namespace(), b.cache_namespace(), "bucket");
+    assert_ne!(
+        a.cache_namespace(),
+        other_prefix.cache_namespace(),
+        "prefix"
+    );
+    assert_ne!(a.cache_namespace(), local.cache_namespace(), "scheme");
+
+    // A cache directory is named with this, so it is one segment and it is
+    // recognisable to an operator reading `ls`.
+    assert!(a.cache_namespace().starts_with("s3-"));
+    assert!(local.cache_namespace().starts_with("file-"));
+    assert!(!a.cache_namespace().contains('/'));
+    assert!(!local.cache_namespace().contains('/'));
+
+    // Unstable between calls would mean the cache is written and never read.
+    let a_again = DestinationUri::parse("s3://bucket-a/logs").expect("bucket-a again");
+    assert_eq!(a.cache_namespace(), a_again.cache_namespace());
+}
+
+#[test]
+fn cache_namespace_ignores_the_region_override() {
+    // `?region=` changes which endpoint serves a bucket, never which objects it
+    // holds, so adding one must not orphan a cache that is still valid (#6548).
+    let plain = DestinationUri::parse("s3://bucket-a/logs").expect("plain");
+    let regioned = DestinationUri::parse("s3://bucket-a/logs?region=eu-west-1").expect("regioned");
+    assert_eq!(plain.cache_namespace(), regioned.cache_namespace());
+}
+
+#[test]
 fn uri_table_rejects() {
     // Each case must fail with DrainError::Uri, not a scheme error.
     let cases = [
@@ -535,11 +571,7 @@ async fn manifest_remote_wins_over_local_cache() {
         sha256: "stale".into(),
         uploaded_at: "2026-01-01T00:00:00Z".into(),
     });
-    let cache_path = state
-        .path()
-        .join("log-drain")
-        .join("bob/sess")
-        .join("manifest.json");
+    let cache_path = DrainManifest::cache_path(state.path(), &dest, "bob/sess");
     std::fs::create_dir_all(cache_path.parent().expect("parent")).expect("cache dir");
     std::fs::write(&cache_path, serde_json::to_vec(&stale).expect("encode")).expect("cache write");
 
@@ -683,6 +715,135 @@ async fn run_once_is_idempotent() {
     assert_eq!(second.uploaded, 0, "nothing changed, so nothing re-uploads");
     assert_eq!(second.skipped_unchanged, 1);
     assert_eq!(second.bytes_wire, 0);
+    assert_eq!(
+        second.manifest_spot_check_missing, 0,
+        "the manifest describes a file that really is there"
+    );
+}
+
+/// Every key under `prefix`, with its size, sorted — a stable snapshot of what
+/// a destination holds.
+async fn contents(dest: &dyn LogDestination, prefix: &str) -> Vec<(String, u64)> {
+    let mut out: Vec<(String, u64)> = dest
+        .list(prefix)
+        .await
+        .expect("list")
+        .into_iter()
+        .map(|m| (m.key, m.size))
+        .collect();
+    out.sort();
+    out
+}
+
+#[tokio::test]
+async fn run_once_reuploads_when_the_destination_changes() {
+    let logs = tempfile::tempdir().expect("tempdir");
+    let dest_a_root = tempfile::tempdir().expect("tempdir");
+    let dest_b_root = tempfile::tempdir().expect("tempdir");
+    // ONE state dir across both runs: the operator changed
+    // `log_drain.destination`, not their machine.
+    let state = tempfile::tempdir().expect("tempdir");
+
+    write(&logs.path().join("daemon.log"), TRACING_FIXTURE);
+    write(&logs.path().join("nested/worker.log"), TRACING_FIXTURE);
+
+    let cfg = DrainConfig::new(state.path());
+    let t = target();
+    let sources = [source(logs.path(), Some(Level::Info))];
+
+    let dest_a = file_dest(dest_a_root.path()).await;
+    let first = run_once(&cfg, &dest_a, &t, &sources)
+        .await
+        .expect("run against A");
+    assert_eq!(first.uploaded, 2);
+    let a_before = contents(&dest_a, &t.logs_prefix()).await;
+
+    // Same identity, same state dir, a destination that holds nothing. B has no
+    // manifest of its own, so before #6548 the load fell back to the cache
+    // written for A and classified every file SkipUnchanged — the files never
+    // arrived, and B's manifest then claimed they had.
+    let dest_b = file_dest(dest_b_root.path()).await;
+    let second = run_once(&cfg, &dest_b, &t, &sources)
+        .await
+        .expect("run against B");
+
+    assert_eq!(
+        second.uploaded, 2,
+        "a fresh destination holds none of these files yet"
+    );
+    assert_eq!(
+        second.skipped_unchanged, 0,
+        "a skip decision made for A must decide nothing for B"
+    );
+
+    for relative in ["trusty-mpm/daemon.log", "trusty-mpm/nested/worker.log"] {
+        let key = t.object_key(relative);
+        assert!(
+            dest_b.head(&key).await.expect("head B").is_some(),
+            "expected an object at `{key}` under B"
+        );
+    }
+    assert!(
+        dest_b
+            .head(&t.manifest_key())
+            .await
+            .expect("head B")
+            .is_some(),
+        "B gets its own manifest"
+    );
+
+    assert_eq!(
+        a_before,
+        contents(&dest_a, &t.logs_prefix()).await,
+        "a run aimed at B must not write to A"
+    );
+}
+
+#[tokio::test]
+async fn run_once_spot_checks_a_lying_remote_manifest() {
+    let logs = tempfile::tempdir().expect("tempdir");
+    let dest_root = tempfile::tempdir().expect("tempdir");
+    let state = tempfile::tempdir().expect("tempdir");
+    write(&logs.path().join("daemon.log"), TRACING_FIXTURE);
+
+    let dest = file_dest(dest_root.path()).await;
+    let cfg = DrainConfig::new(state.path());
+    let t = target();
+    let sources = [source(logs.path(), Some(Level::Info))];
+
+    run_once(&cfg, &dest, &t, &sources)
+        .await
+        .expect("first run");
+
+    // Exactly what #6548 left in the wild: a remote manifest naming an object
+    // this destination never received. One entry, so the sample is determined.
+    let mut lying = DrainManifest::default();
+    lying.record(ManifestEntry {
+        relative_file: "trusty-mpm/never-uploaded.log".into(),
+        size: 1,
+        mtime_unix: 1,
+        sha256: "ghost".into(),
+        uploaded_at: "2026-01-01T00:00:00Z".into(),
+    });
+    dest.put(
+        &t.manifest_key(),
+        bytes::Bytes::from(serde_json::to_vec(&lying).expect("encode")),
+        PutMeta::default(),
+    )
+    .await
+    .expect("put the lying manifest");
+
+    let report = run_once(&cfg, &dest, &t, &sources)
+        .await
+        .expect("second run");
+    assert_eq!(
+        report.manifest_spot_check_missing, 1,
+        "the sampled entry names an object the destination does not have"
+    );
+    assert_eq!(
+        report.uploaded, 1,
+        "detection only — the run still uploads what the lying manifest omits"
+    );
 }
 
 #[tokio::test]
@@ -934,6 +1095,10 @@ impl LogDestination for FailingDestination {
 
     async fn list(&self, prefix: &str) -> Result<Vec<ObjectMeta>, DrainError> {
         self.inner.list(prefix).await
+    }
+
+    fn cache_namespace(&self) -> &str {
+        self.inner.cache_namespace()
     }
 }
 

--- a/crates/trusty-common/src/log_drain/uri.rs
+++ b/crates/trusty-common/src/log_drain/uri.rs
@@ -15,6 +15,7 @@
 
 use std::path::PathBuf;
 
+use super::collector::hex_digest;
 use super::error::DrainError;
 
 /// The scheme half of a destination URI.
@@ -205,6 +206,37 @@ impl DestinationUri {
             Self::S3 { prefix, .. } => prefix,
             Self::File { .. } => "",
         }
+    }
+
+    /// Stable, filesystem-safe identity of this destination for local state.
+    ///
+    /// Why: the local manifest cache used to live at a path built from the
+    /// identity alone, so pointing one session at a second bucket reused the
+    /// record written for the first and skipped every file that record listed —
+    /// 86 files that never reached the new bucket (#6548). A skip decision is
+    /// only valid for the destination it was made against, so the destination
+    /// has to be part of where that decision is stored.
+    ///
+    /// What: `<scheme>-<first 16 hex chars of SHA-256(canonical form)>`. The
+    /// canonical form carries scheme, bucket-or-path, and key prefix —
+    /// everything that changes WHICH objects a destination holds. `?region=` is
+    /// excluded on purpose: a region override changes which endpoint serves a
+    /// bucket, never its contents, so adding one must not orphan a valid cache.
+    /// The value is hashed rather than spelled out because a key prefix and a
+    /// filesystem path are both arbitrary strings, and a cache directory needs
+    /// one segment with no `/`, no `..`, and no length surprise.
+    ///
+    /// Test: `super::tests::cache_namespace_separates_destinations`,
+    /// `super::tests::cache_namespace_ignores_the_region_override`.
+    pub fn cache_namespace(&self) -> String {
+        let (scheme, canonical) = match self {
+            // #6548: `region` is deliberately absent from the canonical form.
+            Self::S3 { bucket, prefix, .. } => ("s3", format!("s3://{bucket}/{prefix}")),
+            Self::File { path } => ("file", format!("file://{}", path.display())),
+        };
+        // `hex_digest` is a SHA-256 in hex, so it is always 64 characters.
+        let digest = hex_digest(canonical.as_bytes());
+        format!("{scheme}-{}", &digest[..16])
     }
 
     /// The scheme this destination was parsed from.

--- a/docs/reference/log-drain.md
+++ b/docs/reference/log-drain.md
@@ -106,7 +106,8 @@ invalidates every recorded digest.
 
 - **Remote** (`<…>/logs/.drain-manifest.json`) is **authoritative**. It is the
   only copy that describes what is actually in the bucket.
-- **Local cache** (`<state_dir>/log-drain/<github_id>/<session_id>/manifest.json`)
+- **Local cache**
+  (`<state_dir>/log-drain/<destination namespace>/<github_id>/<session_id>/manifest.json`)
   exists so an unchanged run costs no network read at all.
 
 When both exist and disagree, the remote copy wins and the cache is rewritten
@@ -117,6 +118,55 @@ one extra remote read and nothing else.
 An **undecodable** manifest — corrupt JSON, or an unrecognised `version` — is
 treated as **absent**, never as an error. Re-uploading a file is strictly safer
 than skipping one that was never written.
+
+### The cache is scoped to the destination
+
+`<destination namespace>` is `DestinationUri::cache_namespace()`:
+`<scheme>-<16 hex chars of SHA-256(canonical form)>`, e.g. `s3-4f1c9ae0d2b7…`.
+The canonical form carries the **scheme**, the **bucket or path**, and the **key
+prefix** — everything that changes which objects a destination holds. `?region=`
+is deliberately **excluded**: a region override changes which endpoint serves a
+bucket, never its contents, so adding one must not orphan a cache that is still
+valid. The value is hashed because a key prefix and a filesystem path are both
+arbitrary strings, and a cache directory needs a single path segment.
+
+Before [#6548](https://github.com/bobmatnyc/trusty-tools/issues/6548) the cache
+was keyed by identity alone. Repointing one session from bucket A to a brand-new
+bucket B found A's record; B had no remote manifest of its own to override it,
+so **every file A already held was classified `SkipUnchanged` and never reached
+B** — 86 of them in the live incident — while sources with no prior entry
+uploaded normally. B's manifest was then written from that record, so it now
+lists objects B never received.
+
+### Repairing a tainted remote manifest
+
+The keying fix stops new ones being written. It cannot repair a manifest already
+sitting in a bucket, and a manifest that lies makes every file it lists skip
+forever.
+
+**Repair:** delete the manifest object.
+
+```bash
+aws s3 rm s3://<bucket>/<prefix>/<github_id>/<session_id>/logs/.drain-manifest.json
+```
+
+The next run finds no remote copy, falls back to a cache that is now
+destination-scoped (and therefore empty for that destination), and re-uploads
+everything. Nothing else needs clearing; the local cache directory can also be
+deleted, but on its own that is not enough, because the tainted remote copy
+wins.
+
+**Detection.** Each run whose manifest came from the destination `head`s **one
+sampled entry**. When that object is absent, `DrainReport`'s
+`manifest_spot_check_missing` counter goes to 1 and a `warn!` names the key and
+the repair. One `head` per run, not one per file: a per-file check would put
+roughly 150 extra round trips on every steady-state pass, forever, to guard
+against a defect that can no longer occur. Sub-second wall clock picks the
+sample, so consecutive scheduled runs cover different entries.
+
+Detection **only** — nothing is re-uploaded automatically and the manifest is
+not rewritten. An object a bucket lifecycle rule legitimately expired would
+otherwise re-upload the whole session on every run.
 
 ### Skip decision, and why SHA-256 wins
 


### PR DESCRIPTION
Refs #6548.

The drain manifest cache key omitted the destination namespace, so switching buckets reused a stale manifest. This adds `cache_namespace` to the `LogDestination` trait.

NOTE — this is a breaking change to public trait `LogDestination`; the next trusty-common release must be 0.47.0 (0.x MINOR rule).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools