### PR TITLE
fix(tga): reviewer pass survives secondary rate limits as a partial run

### DIFF
--- a/crates/trusty-git-analytics/changelog.d/6553-reviewer-secondary-ratelimit.md
+++ b/crates/trusty-git-analytics/changelog.d/6553-reviewer-secondary-ratelimit.md
@@ -1,0 +1,12 @@
+Fixed
+
+- `tga collect`: a GitHub secondary rate limit during the reviewer pass no longer
+  fails the run (#6553). The pass now tells a throttled pull request apart from a
+  broken one, records the shortfall once — naming how many pull requests got no
+  reviewer rows — and records it at `ItemSkipped` severity, so `tga collect`
+  exits 0 with `pr_reviewers` partial rather than exiting 1 with every other
+  stage's data already persisted. The reviewer query is forward-only, so the next
+  run resumes at the pull requests the throttled one never reached. This replaces
+  the #6084 abort, which made `github.fetch_pr_reviews: true` unusable on an
+  unattended schedule and emitted one warning line per remaining pull request
+  (21,230 in the reported run).

--- a/crates/trusty-git-analytics/src/collect/github/client.rs
+++ b/crates/trusty-git-analytics/src/collect/github/client.rs
@@ -505,15 +505,6 @@ impl GitHubClient {
         self.budget.notices()
     }
 
-    /// Whether this client's budget latched, meaning it stopped fetching early.
-    ///
-    /// A caller that continued past per-item failures uses this to tell "the
-    /// items I skipped were individually bad" from "GitHub stopped answering
-    /// and everything after the trip was never attempted" (#6084).
-    pub(crate) fn throttled(&self) -> bool {
-        self.budget.tripped_error().is_some()
-    }
-
     /// Fetch all reviews for a given pull request, paginating until exhausted.
     ///
     /// Why: review counts, approval status, and review latency are core PR

--- a/crates/trusty-git-analytics/src/collect/github/client_tests.rs
+++ b/crates/trusty-git-analytics/src/collect/github/client_tests.rs
@@ -763,7 +763,6 @@ mod bounded_fetch_tests {
             .await
             .expect_err("a permanent rate limit must not read as `no reviews`");
         assert!(matches!(first, CollectError::Throttled { status: 429, .. }));
-        assert!(client.throttled());
 
         let before = server
             .received_requests()

--- a/crates/trusty-git-analytics/src/collect/github_pipeline.rs
+++ b/crates/trusty-git-analytics/src/collect/github_pipeline.rs
@@ -16,6 +16,7 @@
 use futures::StreamExt as _;
 use tracing::{info, warn};
 
+use crate::collect::errors::CollectError;
 use crate::collect::github::budget::FetchBudget;
 use crate::collect::github::org_discovery::{discover_org_repos_within, effective_orgs};
 use crate::collect::github::repo_resolver::build_http_client;
@@ -100,6 +101,9 @@ pub(super) async fn run_github_org_discovery(gh_cfg: &GithubConfig) -> Vec<(Stri
 /// logged and non-fatal.
 /// Test: `fetch_reviewers_concurrency_upserts_all` in this module; the
 /// live API path is gated `#[ignore]`.
+///
+/// #6553: a secondary rate limit no longer fails the run — see
+/// [`ingest_reviews`], which this delegates to once the client is built.
 pub(super) async fn fetch_and_store_github_reviewers(
     db: &mut Database,
     gh_cfg: &GithubConfig,
@@ -165,35 +169,94 @@ pub(super) async fn fetch_and_store_github_reviewers(
     // "unlimited" (buffer_unordered(0) would block indefinitely).
     let concurrency = (gh_cfg.review_fetch_concurrency as usize).max(1);
 
-    // Phase 1: fetch reviews concurrently, bounded by `concurrency`.
-    // Each future returns (pr_db_id, repository, pr_number, reviews_or_err).
-    type FetchResult = (i64, String, u64, Result<Vec<GitHubReview>, String>);
-    let fetched: Vec<FetchResult> = futures::stream::iter(prs.iter().cloned())
-        .map(|(pr_db_id, repository, pr_number)| {
-            let repo_clone = repository.clone();
-            let client_ref = &gh_client;
-            async move {
-                // Parse (owner, repo) from the stored repository slug.
-                let result = match repo_clone.split_once('/') {
-                    Some((o, r)) if !o.is_empty() && !r.is_empty() => client_ref
-                        .fetch_pr_reviews_for_repo(o, r, pr_number)
-                        .await
-                        .map_err(|e| e.to_string()),
-                    _ => Err(format!(
-                        "malformed repository slug '{repo_clone}'; skipping reviewer fetch"
-                    )),
-                };
-                (pr_db_id, repo_clone, pr_number, result)
-            }
+    ingest_reviews(db, &gh_client, concurrency, &prs, stats).await;
+}
+
+/// What one pull request's reviewer fetch produced.
+///
+/// Why: #6553 — every outcome used to collapse into `Result<Vec<_>, String>`,
+/// which made "this one pull request is broken" and "GitHub stopped answering
+/// the whole run" the same value. A field run turned one run-wide condition
+/// into 21,230 identical per-PR warnings and then a stage failure that failed
+/// the entire `tga collect`.
+/// What: the three outcomes the pass treats differently — reviews came back,
+/// this PR alone failed, or GitHub was rate-limiting so this PR contributed no
+/// reviewer rows.
+/// Test: `a_secondary_rate_limit_leaves_the_reviewer_pass_partial_not_failed`.
+enum ReviewFetch {
+    /// Reviews came back; the vector may legitimately be empty.
+    Fetched(Vec<GitHubReview>),
+    /// This PR alone failed and the pass carried on.
+    Failed(String),
+    /// GitHub was rate-limiting, so no reviewer rows exist for this PR.
+    RateLimited,
+}
+
+/// Fetch reviews for `prs` with up to `concurrency` requests in flight.
+///
+/// Why: #6553 — the run-wide [`FetchBudget`] already stops a latched client
+/// from sending anything, so past the trip every call fails without a request.
+/// What this pass was missing is the ability to tell that outcome apart from a
+/// broken pull request: both arrived as a `String` and both got a warning line,
+/// which is how one rate limit produced 21,230 of them.
+/// What: separates [`CollectError::Throttled`] from every other error, so the
+/// caller can count the rate-limited pull requests instead of narrating each
+/// one.
+/// Test: `a_secondary_rate_limit_leaves_the_reviewer_pass_partial_not_failed`.
+async fn fetch_reviews(
+    client: &GitHubClient,
+    prs: &[(i64, String, u64)],
+    concurrency: usize,
+) -> Vec<(i64, String, u64, ReviewFetch)> {
+    futures::stream::iter(prs.iter().cloned())
+        .map(|(pr_db_id, repository, pr_number)| async move {
+            // Parse (owner, repo) from the stored repository slug.
+            let outcome = match repository.split_once('/') {
+                Some((o, r)) if !o.is_empty() && !r.is_empty() => {
+                    match client.fetch_pr_reviews_for_repo(o, r, pr_number).await {
+                        Ok(reviews) => ReviewFetch::Fetched(reviews),
+                        Err(CollectError::Throttled { .. }) => ReviewFetch::RateLimited,
+                        Err(e) => ReviewFetch::Failed(e.to_string()),
+                    }
+                }
+                _ => ReviewFetch::Failed(format!(
+                    "malformed repository slug '{repository}'; skipping reviewer fetch"
+                )),
+            };
+            (pr_db_id, repository, pr_number, outcome)
         })
         .buffer_unordered(concurrency)
         .collect()
-        .await;
+        .await
+}
 
-    // Phase 2: serialize all DB upserts (rusqlite Connection is not Send).
-    for (pr_db_id, repository, pr_number, result) in fetched {
-        match result {
-            Ok(reviews) => {
+/// Fetch and persist reviewer rows for `prs` using an already-built client.
+///
+/// Why: #6553 — `fetch_and_store_github_reviewers` constructs its own client
+/// against api.github.com, so the rate-limit path had no seam a test could
+/// drive. Taking the client as an argument is what lets the regression test
+/// point the pass at a local mock.
+/// What: runs [`fetch_reviews`], then serializes the upserts (a rusqlite
+/// `Connection` is not `Send`). A rate limit is recorded ONCE, as
+/// [`crate::collect::CollectionStats::skip_item`] rather than `fail_stage`: the
+/// PR query is forward-only, so the next `tga collect` resumes at the PRs this
+/// run never reached, and failing the whole run made `fetch_pr_reviews: true`
+/// unusable unattended.
+/// Test: `a_secondary_rate_limit_leaves_the_reviewer_pass_partial_not_failed`,
+/// `fetch_reviewers_concurrency_upserts_all`.
+async fn ingest_reviews(
+    db: &mut Database,
+    gh_client: &GitHubClient,
+    concurrency: usize,
+    prs: &[(i64, String, u64)],
+    stats: &mut CollectionStats,
+) {
+    let fetched = fetch_reviews(gh_client, prs, concurrency).await;
+
+    let mut rate_limited = 0usize;
+    for (pr_db_id, repository, pr_number, outcome) in fetched {
+        match outcome {
+            ReviewFetch::Fetched(reviews) => {
                 let conn = db.connection();
                 for review in &reviews {
                     match upsert_github_pr_reviewer(conn, pr_db_id, review) {
@@ -208,7 +271,7 @@ pub(super) async fn fetch_and_store_github_reviewers(
                     }
                 }
             }
-            Err(msg) => {
+            ReviewFetch::Failed(msg) => {
                 // Per-PR failure is non-fatal; log and continue.
                 warn!(
                     repository = %repository,
@@ -216,6 +279,8 @@ pub(super) async fn fetch_and_store_github_reviewers(
                     "GitHub reviewer fetch failed for PR: {msg}; continuing"
                 );
             }
+            // #6553: counted, not logged — see the aggregate below.
+            ReviewFetch::RateLimited => rate_limited += 1,
         }
     }
 
@@ -225,13 +290,19 @@ pub(super) async fn fetch_and_store_github_reviewers(
     for notice in gh_client.fetch_notices() {
         stats.skip_item(format!("github reviewers: {notice}"));
     }
-    if gh_client.throttled() {
-        stats.fail_stage(
-            "GitHub rate-limited the reviewer pass, which stopped early; pr_reviewers is \
-             incomplete for this run. Retry later, or set github.fetch_pr_reviews: false \
-             (see #6084)"
-                .to_string(),
+    if rate_limited > 0 {
+        // #6553: one recorded fault for a run-wide condition, at a severity
+        // that leaves `tga collect` at exit 0 — the reviewer pass is resumable
+        // and the rest of the run's data is complete.
+        let msg = format!(
+            "github reviewers: GitHub rate-limited the reviewer pass; {rate_limited} of {} \
+             pull request(s) got no reviewer rows, so pr_reviewers is INCOMPLETE for this \
+             run. The pass is forward-only, so a later `tga collect` resumes at the pull \
+             requests this one never reached (see #6553)",
+            prs.len()
         );
+        warn!("{msg}");
+        stats.skip_item(msg);
     }
 
     if stats.reviewers_fetched > 0 {
@@ -338,6 +409,93 @@ mod tests {
             count, 3,
             "all three reviewer rows must be present after concurrent ingestion"
         );
+    }
+
+    /// Why: #6553 — the reviewer pass met a secondary rate limit, recorded a
+    /// `fail_stage`, and made three consecutive unattended `tga collect` runs
+    /// exit 1 while every other stage had persisted cleanly. Each remaining
+    /// pull request also got its own warning line — 21,230 of them for one
+    /// run-wide condition. A secondary limit must leave the run partial and
+    /// resumable, not failed.
+    /// What: a mock that answers every reviews call `403` with `Retry-After: 0`
+    /// (the field shape). At `concurrency = 1` the first PR spends its four
+    /// attempts and latches the run-wide budget, after which the budget refuses
+    /// to send. Asserts the pass records no stage failure, records ONE fault
+    /// naming how many pull requests went unfetched, and sends exactly
+    /// `MAX_RETRIES + 1` requests for 50 pull requests.
+    /// Test: this test itself. Pre-fix it fails on the first assertion — a
+    /// latched budget drove `fail_stage`, which `tga collect` turns into a
+    /// non-zero exit (`crate::commands::collect::stage_failure_report`).
+    #[tokio::test]
+    async fn a_secondary_rate_limit_leaves_the_reviewer_pass_partial_not_failed() {
+        use crate::collect::github::retry::MAX_RETRIES;
+        use wiremock::matchers::method;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        const PR_COUNT: i64 = 50;
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(403).insert_header("retry-after", "0"))
+            .mount(&server)
+            .await;
+
+        let mut db = open_db();
+        let prs: Vec<(i64, String, u64)> = {
+            let conn = db.connection();
+            (1..=PR_COUNT)
+                .map(|n| {
+                    let id = seed_pr(conn, "acme/widgets", n);
+                    (id, "acme/widgets".to_string(), n as u64)
+                })
+                .collect()
+        };
+
+        let client = GitHubClient::new_for_reviews(&make_gh_cfg(1))
+            .expect("client builds")
+            .with_api_base(server.uri());
+
+        let mut stats = CollectionStats::default();
+        ingest_reviews(&mut db, &client, 1, &prs, &mut stats).await;
+
+        assert!(
+            stats.stage_failures().is_empty(),
+            "a rate limit must not fail the run; got: {:?}",
+            stats.stage_failures()
+        );
+        assert_eq!(
+            stats.errors.len(),
+            1,
+            "one aggregated fault for a run-wide condition, not one per PR; got: {:?}",
+            stats.errors
+        );
+        let msg = &stats.errors[0].message;
+        assert!(
+            msg.contains(&format!("{PR_COUNT} of {PR_COUNT}")),
+            "the fault must name how many PRs went unfetched: {msg}"
+        );
+        assert!(
+            msg.contains("INCOMPLETE"),
+            "the fault must say the reviewer data is incomplete: {msg}"
+        );
+
+        let requests = server
+            .received_requests()
+            .await
+            .map(|r| r.len())
+            .unwrap_or_default();
+        assert_eq!(
+            requests,
+            (MAX_RETRIES + 1) as usize,
+            "only the first PR may be attempted; the other 49 must cost zero requests"
+        );
+
+        let rows: i64 = {
+            let conn = db.connection();
+            conn.query_row("SELECT COUNT(*) FROM pr_reviewers", [], |r| r.get(0))
+                .expect("count")
+        };
+        assert_eq!(rows, 0, "a throttled pass writes no reviewer rows");
     }
 
     /// Why: a `review_fetch_concurrency` value of 0 must be clamped to 1


### PR DESCRIPTION
Refs #6553.

A secondary rate limit during the reviewer pass previously failed the whole `tga collect` run; the pass now records rate-limited PRs as one ItemSkipped fault naming `{n} of {total}` INCOMPLETE and exits 0; backoff untouched — the pass still routes through the existing retry_send/FetchBudget.

Tested: `cargo test -p tga --no-fail-fast` — 1401 passed lib + all integration targets green; regression test `a_secondary_rate_limit_leaves_the_reviewer_pass_partial_not_failed` provably failed against the pre-fix behavior.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools