### PR TITLE
fix(trusty-search): refuse index-id derivation from $HOME or the filesystem root

### DIFF
--- a/crates/trusty-common/changelog.d/6550-refuse-unindexable-index-root.md
+++ b/crates/trusty-common/changelog.d/6550-refuse-unindexable-index-root.md
@@ -1,0 +1,14 @@
+Fixed
+
+- Index-id derivation no longer falls back to the home directory's basename
+  (#6550). `resolve_project_root` returns the start path when nothing above it
+  is a git repository, so a registration handed `$HOME` created an index named
+  after the operator — the live daemon held index `masa` for an unrelated
+  repository. `ensure_project_indexed_reporting` and the incremental
+  `index_files_best_effort` path now refuse a root that is the home directory
+  or the filesystem root, log at error, and return no id, so no caller can pin
+  one. New shared predicate `trusty_common::refuse_unindexable_root` (and its
+  pure `*_against` form) is the one implementation trusty-search's
+  `detect_project` routes through too.
+  - `IndexRegistration` gains a `RefusedUnindexableRoot(IndexRootRefusal)`
+    variant reporting that outcome.

--- a/crates/trusty-common/src/index_id.rs
+++ b/crates/trusty-common/src/index_id.rs
@@ -18,12 +18,16 @@
 //! [`derive_index_id`] turns a project root into its index id (the path
 //! basename, preserved verbatim for backward-compatibility with already-indexed
 //! projects). [`identifies_same_path`] answers "do these two paths name the same
-//! directory tree?" for every registration guard that has to compare one. No
-//! global state; pure functions.
+//! directory tree?" for every registration guard that has to compare one.
+//! [`refuse_unindexable_root`] answers the question that has to come FIRST —
+//! may this root become an index at all? — because the basename rule cannot
+//! tell a project root from `$HOME` (#6550). No global state; pure functions,
+//! save for the one home-directory lookup.
 //!
 //! Test: `cargo test -p trusty-common --features unconditional-only --
 //! index_id::tests` covers basename derivation, the git-root walk, the
-//! no-marker fallback, and same-tree identity across case variants.
+//! no-marker fallback, same-tree identity across case variants, and the
+//! unindexable-root refusals.
 
 use std::path::{Path, PathBuf};
 
@@ -215,6 +219,84 @@ pub fn identifies_same_path(a: &Path, b: &Path) -> bool {
         Some(same) => same,
         None => a == b,
     }
+}
+
+/// Why a resolved root must never become a trusty-search index (#6550).
+///
+/// Why: [`resolve_project_root`] falls back to the START path when no `.git`
+/// ancestor exists and [`derive_index_id`] then takes its basename, so a
+/// registration handed `/Users/masa` produced index `masa` — a well-formed id
+/// naming the operator rather than any project. The derivation cannot detect
+/// that itself: a basename looks equally plausible for a real project root and
+/// for a directory that identifies no project at all. So the caller refuses
+/// before it registers or pins one. trusty-mpm's `AutoInitRefusal` refuses
+/// `git init` in the same two directories for the same reason.
+/// What: the two directories that never name a project.
+/// Test: `refuse_unindexable_root_refuses_the_home_directory`,
+/// `refuse_unindexable_root_refuses_the_filesystem_root`,
+/// `refuse_unindexable_root_permits_an_ordinary_project_root`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum IndexRootRefusal {
+    /// The root is the operator's home directory.
+    HomeDirectory,
+    /// The root is the filesystem root.
+    FilesystemRoot,
+}
+
+impl std::fmt::Display for IndexRootRefusal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::HomeDirectory => "the operator's home directory",
+            Self::FilesystemRoot => "the filesystem root",
+        })
+    }
+}
+
+/// Should `root` be refused as a trusty-search index root (#6550)?
+///
+/// Why: see [`IndexRootRefusal`]. Two crates ask this question — trusty-common's
+/// [`crate::search_index::ensure_project_indexed_reporting`] before it registers,
+/// and trusty-search's `detect_project` before it derives — so per this
+/// workspace's common-entry-point rule it is one implementation here.
+/// What: resolves the home directory through `dirs::home_dir` and delegates to
+/// [`refuse_unindexable_root_against`]. `None` means the root is indexable.
+/// Test: `refuse_unindexable_root_refuses_the_filesystem_root`, plus the
+/// caller-side `ensure_project_indexed_refuses_the_real_home_directory` and
+/// `detect_project_refuses_the_real_home_directory`.
+#[must_use]
+pub fn refuse_unindexable_root(root: &Path) -> Option<IndexRootRefusal> {
+    refuse_unindexable_root_against(root, dirs::home_dir().as_deref())
+}
+
+/// [`refuse_unindexable_root`] with `home` supplied by the caller.
+///
+/// Why: the process-wide home directory is the one input a test cannot vary
+/// safely — `set_var("HOME")` races every other thread in the binary — so the
+/// decision is a pure function of its two arguments and the wrapper above owns
+/// the lookup. Same split as trusty-mpm's `plan_auto_init`.
+/// What: `FilesystemRoot` when `root` has no parent (`/`, and the empty path);
+/// `HomeDirectory` when `root` and `home` name one directory tree per
+/// [`identifies_same_path`], which sees through a symlinked `$HOME` and through
+/// APFS case-insensitivity. `None` otherwise. A `home` of `None` — a stripped
+/// environment with no resolvable home — refuses nothing beyond the root, since
+/// there is no directory to compare against.
+/// Test: `refuse_unindexable_root_refuses_the_home_directory`,
+/// `refuse_unindexable_root_refuses_the_filesystem_root`,
+/// `refuse_unindexable_root_permits_an_ordinary_project_root`,
+/// `refuse_unindexable_root_without_a_home_still_refuses_the_root`.
+#[must_use]
+pub fn refuse_unindexable_root_against(
+    root: &Path,
+    home: Option<&Path>,
+) -> Option<IndexRootRefusal> {
+    if root.parent().is_none() {
+        return Some(IndexRootRefusal::FilesystemRoot);
+    }
+    if home.is_some_and(|home| identifies_same_path(root, home)) {
+        return Some(IndexRootRefusal::HomeDirectory);
+    }
+    None
 }
 
 /// Compare `a` and `b` by `(dev, ino)`, or `None` when either cannot be stat'd.
@@ -470,6 +552,70 @@ mod tests {
 
         assert!(identifies_same_path(&gone, &gone));
         assert!(!identifies_same_path(&gone, &other));
+    }
+
+    /// #6550, the defect itself: `/Users/masa` has no `.git`, so
+    /// `resolve_project_root` returns it unchanged and `derive_index_id` names
+    /// the index after the operator. This is the guard that stops it.
+    #[test]
+    fn refuse_unindexable_root_refuses_the_home_directory() {
+        let home = scratch_dir("home");
+        fs::create_dir_all(&home).unwrap();
+
+        assert_eq!(
+            derive_index_id(&home),
+            home.file_name().unwrap().to_string_lossy(),
+            "the basename rule is what produces the wrong id"
+        );
+        assert_eq!(
+            refuse_unindexable_root_against(&home, Some(&home)),
+            Some(IndexRootRefusal::HomeDirectory)
+        );
+
+        let _ = fs::remove_dir_all(&home);
+    }
+
+    /// A path with no final component derives the empty id, which callers
+    /// already treated as "no index" — the refusal states the reason instead of
+    /// leaving each caller to infer it from an empty string.
+    #[test]
+    fn refuse_unindexable_root_refuses_the_filesystem_root() {
+        assert_eq!(
+            refuse_unindexable_root_against(Path::new("/"), None),
+            Some(IndexRootRefusal::FilesystemRoot)
+        );
+        assert_eq!(
+            refuse_unindexable_root(Path::new("/")),
+            Some(IndexRootRefusal::FilesystemRoot)
+        );
+    }
+
+    /// The guard has to stay usable: an ordinary checkout under the home
+    /// directory is refused nowhere.
+    #[test]
+    fn refuse_unindexable_root_permits_an_ordinary_project_root() {
+        let home = scratch_dir("home-with-project");
+        let project = home.join("code/acme-api");
+        fs::create_dir_all(&project).unwrap();
+
+        assert_eq!(refuse_unindexable_root_against(&project, Some(&home)), None);
+        assert_eq!(refuse_unindexable_root(&project), None);
+
+        let _ = fs::remove_dir_all(&home);
+    }
+
+    /// A stripped environment resolves no home directory. That must not turn
+    /// the guard off for the filesystem root, and must not refuse a real root.
+    #[test]
+    fn refuse_unindexable_root_without_a_home_still_refuses_the_root() {
+        assert_eq!(
+            refuse_unindexable_root_against(Path::new(""), None),
+            Some(IndexRootRefusal::FilesystemRoot)
+        );
+        assert_eq!(
+            refuse_unindexable_root_against(Path::new("/w/repos/acme-api"), None),
+            None
+        );
     }
 
     #[test]

--- a/crates/trusty-common/src/lib.rs
+++ b/crates/trusty-common/src/lib.rs
@@ -691,12 +691,16 @@ pub use slug::slugify_string;
 /// What: Exposes [`index_id::derive_index_id`], [`index_id::resolve_project_root`],
 /// [`index_id::find_git_root`], and [`index_id::identifies_same_path`] — the one
 /// implementation of "do these two paths name the same directory tree?" that
-/// both registration guards route through.
+/// both registration guards route through — plus
+/// [`index_id::refuse_unindexable_root`], the one implementation of "may this
+/// root become an index at all?" that both DERIVATION sites route through
+/// (#6550).
 /// Test: `cargo test -p trusty-common --features unconditional-only --
 /// index_id::tests`.
 pub mod index_id;
 pub use index_id::{
-    derive_checkout_index_id, derive_index_id, find_git_root, identifies_same_path,
+    IndexRootRefusal, derive_checkout_index_id, derive_index_id, find_git_root,
+    identifies_same_path, refuse_unindexable_root, refuse_unindexable_root_against,
     resolve_project_root,
 };
 

--- a/crates/trusty-common/src/search_index.rs
+++ b/crates/trusty-common/src/search_index.rs
@@ -59,7 +59,10 @@
 //!
 //! Test: `create_rejected_by_the_daemon_withholds_the_pinnable_id`,
 //! `ensure_project_indexed_withholds_id_when_nothing_was_registered`,
-//! `ensure_project_indexed_none_for_root`, the `index_is_fresh_*` predicate
+//! `ensure_project_indexed_none_for_root`,
+//! `ensure_project_indexed_refuses_the_real_home_directory`,
+//! `index_files_inner_refuses_the_real_home_directory`,
+//! the `index_is_fresh_*` predicate
 //! tests, the `index_files_inner_*` / `relative_index_path_*` /
 //! `index_file_request_body_*` tests, and the incremental-hardening tests
 //! `retry_backoff_is_bounded_and_increasing` /
@@ -221,6 +224,10 @@ pub enum IndexRegistration {
     /// This is a test process and the write was deliberately suppressed
     /// (#4255). Never a real registration.
     SkippedUnderTest,
+    /// The resolved root is a directory that names no project — the operator's
+    /// home directory or the filesystem root (#6550). Nothing was sent, and
+    /// `index_id` is `None` because the derived basename would have been wrong.
+    RefusedUnindexableRoot(crate::IndexRootRefusal),
 }
 
 /// The derived index id plus what actually happened daemon-side (#5065 review).
@@ -302,19 +309,41 @@ fn pinnable_index_id(report: EnsureIndexReport) -> Option<String> {
 /// silent no-op against a down daemon — see [`IndexRegistration`]. This is the
 /// ONE implementation; the two id-only entry points delegate here, so no third
 /// copy of the register-then-populate sequence exists.
-/// What: resolves the git-root, derives the id, and — when the id is non-empty,
-/// this is not a test process, and a daemon address resolves — issues the
-/// find-or-create `POST /indexes` followed by the freshness-gated reindex
-/// trigger. Returns the id in every case except empty derivation, alongside the
-/// registration outcome. Still fail-open: no step propagates an error.
+/// What: resolves the git-root, refuses an unindexable root (#6550), derives
+/// the id, and — when the id is non-empty, this is not a test process, and a
+/// daemon address resolves — issues the find-or-create `POST /indexes` followed
+/// by the freshness-gated reindex trigger. Returns the id in every case except
+/// a refusal or empty derivation, alongside the registration outcome. Still
+/// fail-open: no step propagates an error.
+///
+/// The refusal is the one place this function is deliberately NOT best-effort.
+/// `resolve_project_root` falls back to the start path when nothing above it is
+/// a git repository, so a caller that passed `$HOME` got index `masa` — a
+/// plausible id naming the operator, which a later reindex then repointed at a
+/// real repository (#6550). Registering the wrong index is worse than
+/// registering none, so the root is refused and no id comes back.
 /// Test: `reporting_says_skipped_under_test_harness`,
 /// `reporting_says_daemon_unreachable_when_no_daemon_is_discoverable`,
-/// `ensure_project_indexed_none_for_root`.
+/// `ensure_project_indexed_none_for_root`,
+/// `ensure_project_indexed_refuses_the_real_home_directory`.
 pub fn ensure_project_indexed_reporting(
     project_root: &Path,
     opts: IndexOptions,
 ) -> EnsureIndexReport {
     let root = crate::resolve_project_root(project_root);
+    // #6550: a basename is a plausible id for a directory that names no
+    // project, so refuse before deriving one rather than registering it.
+    if let Some(refusal) = crate::refuse_unindexable_root(&root) {
+        tracing::error!(
+            "refusing to register a trusty-search index for {}: it is {refusal}. \
+             Pass the project directory itself (see #6550).",
+            root.display()
+        );
+        return EnsureIndexReport {
+            index_id: None,
+            registration: IndexRegistration::RefusedUnindexableRoot(refusal),
+        };
+    }
     let index_id = crate::derive_index_id(&root);
     if index_id.trim().is_empty() {
         tracing::warn!(
@@ -633,12 +662,23 @@ fn stop_batch_for_budget(
 /// had not reached are abandoned, never retried from here.
 /// Test: `index_files_inner_is_noop_for_empty_paths`,
 /// `index_files_inner_skips_when_index_id_empty`,
-/// `index_files_inner_skips_gracefully_when_daemon_down`.
+/// `index_files_inner_skips_gracefully_when_daemon_down`,
+/// `index_files_inner_refuses_the_real_home_directory`.
 fn index_files_inner(project_root: &Path, paths: &[std::path::PathBuf]) {
     if paths.is_empty() {
         return;
     }
     let root = crate::resolve_project_root(project_root);
+    // #6550: same derivation as the registration path, so the same refusal —
+    // otherwise this posts file content into an index named after the operator.
+    if let Some(refusal) = crate::refuse_unindexable_root(&root) {
+        tracing::error!(
+            "refusing an incremental trusty-search index update for {}: it is {refusal} \
+             (see #6550)",
+            root.display()
+        );
+        return;
+    }
     let index_id = crate::derive_index_id(&root);
     if index_id.trim().is_empty() {
         tracing::debug!(

--- a/crates/trusty-common/src/search_index_tests.rs
+++ b/crates/trusty-common/src/search_index_tests.rs
@@ -180,10 +180,66 @@ fn reporting_says_daemon_unreachable_when_no_daemon_is_discoverable() {
 
 #[test]
 fn ensure_project_indexed_none_for_root() {
-    // Derivation yields an empty id for the filesystem root, so the helper
+    // The filesystem root is refused before derivation (#6550), so the helper
     // returns None without touching the daemon.
     assert_eq!(ensure_project_indexed(Path::new("/"), true), None);
     assert_eq!(ensure_project_indexed(Path::new("/"), false), None);
+    assert_eq!(
+        ensure_project_indexed_reporting(Path::new("/"), IndexOptions::default()).registration,
+        IndexRegistration::RefusedUnindexableRoot(crate::IndexRootRefusal::FilesystemRoot)
+    );
+}
+
+/// #6550, the defect itself: a registration handed `$HOME` derived index
+/// `masa` from the home directory's basename, and a later reindex repointed
+/// that id at a real repository it does not name.
+///
+/// Why: this asserts the guard at the REGISTRATION site, not just the
+/// predicate — the pre-fix code reached `derive_index_id` here and returned a
+/// pinnable id, so this assertion fails against it.
+/// What: calls the real entry point with the real home directory and asserts
+/// no id comes back and the refusal is reported. No daemon is touched: the
+/// refusal precedes both the `#[4255]` harness guard and address discovery.
+/// Test: this test.
+#[test]
+fn ensure_project_indexed_refuses_the_real_home_directory() {
+    let Some(home) = dirs::home_dir() else {
+        panic!("this test needs a resolvable home directory");
+    };
+    // `resolve_project_root` walks UP for a `.git`, so a repository ABOVE the
+    // home directory would resolve elsewhere and the case under test would not
+    // arise. Assert it, rather than skipping, so the test can never pass vacuously.
+    assert_eq!(
+        crate::resolve_project_root(&home),
+        home,
+        "no ancestor of $HOME may be a git repository for this case to exist"
+    );
+
+    let report = ensure_project_indexed_reporting(&home, IndexOptions::default());
+
+    assert_eq!(
+        report.registration,
+        IndexRegistration::RefusedUnindexableRoot(crate::IndexRootRefusal::HomeDirectory)
+    );
+    assert_eq!(
+        report.index_id, None,
+        "the home directory's basename is the wrong id and must not be handed back"
+    );
+    assert_eq!(ensure_project_indexed(&home, false), None);
+    assert_eq!(ensure_project_indexed(&home, true), None);
+}
+
+/// The incremental per-file path derives the same `(root, index_id)` pair, so
+/// it inherits the same refusal (#6550) rather than posting file content into
+/// an index named after the operator.
+#[test]
+fn index_files_inner_refuses_the_real_home_directory() {
+    let Some(home) = dirs::home_dir() else {
+        panic!("this test needs a resolvable home directory");
+    };
+    // Returns without panicking and without any daemon I/O; the guard runs
+    // before the id is derived, so nothing can be posted.
+    index_files_inner(&home, &[PathBuf::from("some/file.rs")]);
 }
 
 /// `index_files_inner` is a true no-op — no filesystem or network I/O —

--- a/crates/trusty-search/changelog.d/6550-detect-project-refuses-home.md
+++ b/crates/trusty-search/changelog.d/6550-detect-project-refuses-home.md
@@ -1,0 +1,8 @@
+Fixed
+
+- `detect_project` refuses to derive an index id from the home directory or the
+  filesystem root instead of using their basename (#6550). Running a
+  project-scoped command from `$HOME` derived an index named after the
+  operator; it now returns `ProjectRootRefused`, which the CLI reports with the
+  refused path and a pointer to `--index <id>`. `detect_project` and
+  `index_resolve::resolve_index` are fallible as a result.

--- a/crates/trusty-search/src/commands/add.rs
+++ b/crates/trusty-search/src/commands/add.rs
@@ -12,7 +12,7 @@ use anyhow::Result;
 /// delegates to `add_path`.
 /// Test: `cargo run -- add src/main.rs` POSTs to `/indexes/<id>/index-file`.
 pub async fn handle_add(explicit_index: &Option<String>, file: std::path::PathBuf) -> Result<()> {
-    let (index_id, warned) = resolve_index(explicit_index);
+    let (index_id, warned) = resolve_index(explicit_index)?;
     print_index_header(&index_id, warned);
     crate::commands::daemon_guard::ensure_daemon_running_or_exit(&daemon_base_url()).await?;
     add_path(&index_id, &file).await

--- a/crates/trusty-search/src/commands/index_remove.rs
+++ b/crates/trusty-search/src/commands/index_remove.rs
@@ -263,7 +263,8 @@ pub(crate) fn interpret_delete_body(delete_data: bool, body: &Value) -> Result<b
 /// What: returns the CLI path verbatim when present, otherwise walks upward
 ///       from CWD looking for `.git` / `.trusty-search` markers via
 ///       `detect::detect_project`. Falls back to the CWD itself if no marker
-///       is found (mirrors the `Fallback` branch elsewhere).
+///       is found (mirrors the `Fallback` branch elsewhere), and errors when
+///       detection refuses that root (#6550).
 /// Test: `index_remove_resolves_path_uses_cli` and
 ///       `index_remove_resolves_path_falls_back_to_cwd`.
 fn resolve_target_path(cli_path: Option<PathBuf>) -> Result<PathBuf> {
@@ -271,7 +272,8 @@ fn resolve_target_path(cli_path: Option<PathBuf>) -> Result<PathBuf> {
         return Ok(p);
     }
     let cwd = std::env::current_dir().context("could not resolve current directory")?;
-    let ctx = detect_project(&cwd);
+    // #6550: a refused root is an error here, not a path to remove by guess.
+    let ctx = detect_project(&cwd)?;
     Ok(ctx.root_path)
 }
 
@@ -425,7 +427,7 @@ mod tests {
 
         // Exercise the same helper detect uses by passing through detect_project
         // directly — we cannot safely change CWD inside a parallel test runner.
-        let ctx = detect_project(&nested);
+        let ctx = detect_project(&nested).expect("a git-rooted fixture is indexable");
         assert_eq!(ctx.root_path, tmp);
 
         let _ = fs::remove_dir_all(&tmp);

--- a/crates/trusty-search/src/commands/index_resolve.rs
+++ b/crates/trusty-search/src/commands/index_resolve.rs
@@ -10,6 +10,7 @@
 //! and `cargo run -- search foo` from inside this repo (auto-detect path).
 
 use crate::detect::{detect_project, DetectionMethod};
+use anyhow::Result;
 use colored::Colorize;
 
 /// Resolve the effective index ID: explicit `--index` flag wins, otherwise
@@ -17,17 +18,22 @@ use colored::Colorize;
 ///
 /// Why: every project-scoped command needs the same precedence rules.
 /// What: returns `(index_id, warned)` where `warned` is true when we fell back
-/// to the CWD basename and should print a warning.
+/// to the CWD basename and should print a warning. Errors when detection
+/// refuses the resolved root (#6550) — running from `$HOME` derived an index id
+/// naming the operator, and no command should proceed against that. An explicit
+/// `--index` is checked first and never reaches detection, so it stays the way
+/// out.
 /// Test: With explicit Some("foo") → returns ("foo", false). With None inside
 /// this repo → returns ("trusty-search", false) (detected via .git).
-pub fn resolve_index(explicit: &Option<String>) -> (String, bool) {
+/// `resolve_index_explicit_wins`, `resolve_index_none_falls_through_to_detection`.
+pub fn resolve_index(explicit: &Option<String>) -> Result<(String, bool)> {
     if let Some(id) = explicit {
-        return (id.clone(), false);
+        return Ok((id.clone(), false));
     }
     let cwd = std::env::current_dir().unwrap_or_default();
-    let ctx = detect_project(&cwd);
+    let ctx = detect_project(&cwd)?;
     let warned = matches!(ctx.detection_method, DetectionMethod::Fallback);
-    (ctx.index_id, warned)
+    Ok((ctx.index_id, warned))
 }
 
 /// Why: Make fallback detection visible so users know to run `init`.
@@ -51,7 +57,7 @@ mod tests {
     #[test]
     fn resolve_index_explicit_wins() {
         let explicit = Some("my-explicit-index".to_string());
-        let (id, warned) = resolve_index(&explicit);
+        let (id, warned) = resolve_index(&explicit).expect("explicit never detects");
         assert_eq!(id, "my-explicit-index");
         assert!(!warned, "explicit --index should never warn");
     }
@@ -61,7 +67,7 @@ mod tests {
         // Even an empty string is preferred over auto-detect: callers are
         // responsible for trimming/validating.
         let explicit = Some(String::new());
-        let (id, warned) = resolve_index(&explicit);
+        let (id, warned) = resolve_index(&explicit).expect("explicit never detects");
         assert_eq!(id, "");
         assert!(!warned);
     }
@@ -70,7 +76,7 @@ mod tests {
     fn resolve_index_none_falls_through_to_detection() {
         // We can't assert the exact id (depends on CWD when test runs) but we
         // can assert the contract: returns a non-empty index_id, doesn't panic.
-        let (id, _warned) = resolve_index(&None);
+        let (id, _warned) = resolve_index(&None).expect("the test CWD is a real project");
         assert!(
             !id.is_empty(),
             "auto-detected index_id should never be empty"

--- a/crates/trusty-search/src/commands/reindex.rs
+++ b/crates/trusty-search/src/commands/reindex.rs
@@ -19,15 +19,20 @@ pub async fn handle_reindex(
     path: Option<std::path::PathBuf>,
     timeout: Option<u64>,
 ) -> Result<()> {
-    let (index_id, warned) = resolve_index(explicit_index);
+    let (index_id, warned) = resolve_index(explicit_index)?;
     print_index_header(&index_id, warned);
     // Issue #24: prefer CPU EP for auto-spawned daemon (CoreML init OOMs the
     // indexing path on Apple Silicon). Already-running daemons are untouched.
     crate::commands::daemon_guard::ensure_daemon_running_for_indexing(&daemon_base_url()).await?;
-    let reindex_path = path.unwrap_or_else(|| {
-        let cwd = std::env::current_dir().unwrap_or_default();
-        detect_project(&cwd).root_path
-    });
+    // #6550: detection can refuse the resolved root, so this is a `match`, not
+    // an infallible `unwrap_or_else`.
+    let reindex_path = match path {
+        Some(p) => p,
+        None => {
+            let cwd = std::env::current_dir().unwrap_or_default();
+            detect_project(&cwd)?.root_path
+        }
+    };
     let (timeout_secs, timeout_explicit) = match timeout {
         Some(n) => (n, true),
         None => (0, false),

--- a/crates/trusty-search/src/commands/remove.rs
+++ b/crates/trusty-search/src/commands/remove.rs
@@ -14,7 +14,7 @@ pub async fn handle_remove(
     explicit_index: &Option<String>,
     file: std::path::PathBuf,
 ) -> Result<()> {
-    let (index_id, warned) = resolve_index(explicit_index);
+    let (index_id, warned) = resolve_index(explicit_index)?;
     print_index_header(&index_id, warned);
     let base = daemon_base_url();
     crate::commands::daemon_guard::ensure_daemon_running_or_exit(&base).await?;

--- a/crates/trusty-search/src/commands/search.rs
+++ b/crates/trusty-search/src/commands/search.rs
@@ -37,7 +37,7 @@ pub async fn handle_search(
     top_k: usize,
     full: bool,
 ) -> Result<()> {
-    let (index_id, _warned) = resolve_index(explicit_index);
+    let (index_id, _warned) = resolve_index(explicit_index)?;
     // Forward to the shared `query` implementation. `handle_query` itself
     // prints the index-header line, so we don't repeat it here.
     super::query::handle_query(&Some(index_id), json, query, "*".to_string(), top_k, full).await

--- a/crates/trusty-search/src/commands/watch.rs
+++ b/crates/trusty-search/src/commands/watch.rs
@@ -22,13 +22,18 @@ pub async fn handle_watch(
     explicit_index: &Option<String>,
     path: Option<std::path::PathBuf>,
 ) -> Result<()> {
-    let (index_id, warned) = resolve_index(explicit_index);
+    let (index_id, warned) = resolve_index(explicit_index)?;
     print_index_header(&index_id, warned);
     crate::commands::daemon_guard::ensure_daemon_running_or_exit(&daemon_base_url()).await?;
-    let watch_path = path.unwrap_or_else(|| {
-        let cwd = std::env::current_dir().unwrap_or_default();
-        detect_project(&cwd).root_path
-    });
+    // #6550: detection can refuse the resolved root, so this is a `match`, not
+    // an infallible `unwrap_or_else`.
+    let watch_path = match path {
+        Some(p) => p,
+        None => {
+            let cwd = std::env::current_dir().unwrap_or_default();
+            detect_project(&cwd)?.root_path
+        }
+    };
 
     // Issue #1621: the daemon watches every registered index automatically.
     let disabled = std::env::var("TRUSTY_DISABLE_WATCHER").as_deref() == Ok("1");

--- a/crates/trusty-search/src/detect.rs
+++ b/crates/trusty-search/src/detect.rs
@@ -6,12 +6,15 @@
 //! to identify the current project context.
 //!
 //! What: Provides `detect_project()` which returns a `ProjectContext` containing
-//! the inferred index ID, project root, and detection method used.
+//! the inferred index ID, project root, and detection method used — or refuses,
+//! when the walk resolves to a directory that names no project (#6550).
 //!
 //! Test: Create a temp directory with a `.git` subdirectory, call detect_project()
-//! from a nested path, assert the returned root and detection_method::GitRoot.
+//! from a nested path, assert the returned root and detection_method::GitRoot;
+//! `detect_project_refuses_the_home_directory` covers the refusal.
 
 use std::path::{Path, PathBuf};
+use trusty_common::IndexRootRefusal;
 
 /// Detected project context from the current working directory.
 #[derive(Debug, Clone)]
@@ -32,50 +35,103 @@ pub enum DetectionMethod {
     Fallback,
 }
 
+/// Auto-detection resolved a root that must not become an index (#6550).
+///
+/// Why: the fallback arm below returns the START path when no marker is found,
+/// and `derive_index_id` takes its basename — so running a project-scoped
+/// command from `$HOME` derived index `masa`, a well-formed id naming the
+/// operator rather than any project. The caller cannot tell that id apart from
+/// a correct one, so detection refuses instead of guessing, and the operator
+/// names the index explicitly with `--index`.
+/// What: carries the refused root and which of the two refusals fired. Its
+/// `Display` is the user-facing CLI message.
+/// Test: `detect_project_refuses_the_home_directory`,
+/// `detect_project_refuses_the_filesystem_root`.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error(
+    "refusing to derive an index id from {path}: it is {refusal}, which names no project. \
+     Run this command from inside the project, or pass `--index <id>`."
+)]
+pub struct ProjectRootRefused {
+    /// The root the upward walk resolved to.
+    pub path: PathBuf,
+    /// Why it was refused.
+    pub refusal: IndexRootRefusal,
+}
+
 /// Walk up from `start` looking for a `.git` directory or `.trusty-search` marker.
 ///
 /// Why: Centralizes project-root inference so every command (search, watch,
 /// status, etc.) shares the same detection logic.
-/// What: Returns the detected `ProjectContext`, falling back to the CWD basename
-/// if no marker is found.
+/// What: Returns the detected `ProjectContext`, falling back to the start-path
+/// basename if no marker is found — except when the resolved root is one that
+/// names no project, which is refused rather than guessed (#6550, see
+/// [`ProjectRootRefused`]). The refusal is checked against the resolved root,
+/// so it also covers a `$HOME` that IS a git repository or carries a
+/// `.trusty-search` marker: the id would be the operator's name either way.
 /// Test: Pass a path inside a `.git`-rooted tree → assert GitRoot. Pass a path
 /// with no markers → assert Fallback and that index_id == basename.
-pub fn detect_project(start: &Path) -> ProjectContext {
+/// `detect_project_refuses_the_home_directory` covers the refusal.
+pub fn detect_project(start: &Path) -> Result<ProjectContext, ProjectRootRefused> {
+    detect_project_against(start, dirs::home_dir().as_deref())
+}
+
+/// [`detect_project`] with the home directory supplied by the caller.
+///
+/// Why: `$HOME` is process-wide state a test cannot vary without racing every
+/// other thread in the binary, so the refusal decision takes it as an argument
+/// and [`detect_project`] owns the one lookup. Same split as
+/// `trusty_common::refuse_unindexable_root_against`, which this delegates to.
+/// What: performs the upward walk, then refuses or derives. Never reads the
+/// environment itself.
+/// Test: `detect_project_refuses_the_home_directory`,
+/// `detect_project_indexes_a_project_under_the_home_directory`.
+pub fn detect_project_against(
+    start: &Path,
+    home: Option<&Path>,
+) -> Result<ProjectContext, ProjectRootRefused> {
+    let (root_path, detection_method) = walk_for_root(start);
+    // #6550: refuse before deriving — a basename looks equally plausible for a
+    // real project root and for a directory that identifies no project at all.
+    if let Some(refusal) = trusty_common::refuse_unindexable_root_against(&root_path, home) {
+        return Err(ProjectRootRefused {
+            path: root_path,
+            refusal,
+        });
+    }
+    // Single source of truth (#1373): derive the id via the shared
+    // `trusty_common::derive_index_id` so trusty-mpm's register-and-pin and this
+    // CLI path always produce the identical index id.
+    Ok(ProjectContext {
+        index_id: trusty_common::derive_index_id(&root_path),
+        root_path,
+        detection_method,
+    })
+}
+
+/// The upward marker walk, with no derivation and no refusal.
+///
+/// Why/What/Test: see [`detect_project_against`], the only caller — split out so
+/// the walk has exactly one exit and the refusal cannot be bypassed by a future
+/// arm that forgets it.
+fn walk_for_root(start: &Path) -> (PathBuf, DetectionMethod) {
     let mut current = start.to_path_buf();
     loop {
         // Prefer .git as the strongest signal of a project root.
         if current.join(".git").exists() {
-            // Single source of truth (#1373): derive the id via the shared
-            // `trusty_common::derive_index_id` so trusty-mpm's register-and-pin
-            // and this CLI path always produce the identical index id.
-            let name = trusty_common::derive_index_id(&current);
-            return ProjectContext {
-                index_id: name,
-                root_path: current,
-                detection_method: DetectionMethod::GitRoot,
-            };
+            return (current, DetectionMethod::GitRoot);
         }
         // Then check for an explicit trusty-search marker.
         if current.join(".trusty-search").exists() {
-            let name = trusty_common::derive_index_id(&current);
-            return ProjectContext {
-                index_id: name,
-                root_path: current,
-                detection_method: DetectionMethod::MarkerFile,
-            };
+            return (current, DetectionMethod::MarkerFile);
         }
         if !current.pop() {
             break;
         }
     }
-    // Fallback: use CWD basename so commands still have something to call the index.
-    let cwd = start.to_path_buf();
-    let name = trusty_common::derive_index_id(&cwd);
-    ProjectContext {
-        index_id: name,
-        root_path: cwd,
-        detection_method: DetectionMethod::Fallback,
-    }
+    // Fallback: use the start path so commands still have something to call the
+    // index — subject to the caller's refusal check.
+    (start.to_path_buf(), DetectionMethod::Fallback)
 }
 
 /// Why: the tests below assert that the derived `index_id` equals the path
@@ -103,7 +159,7 @@ mod tests {
         let nested = tmp.join("a/b/c");
         fs::create_dir_all(&nested).unwrap();
 
-        let ctx = detect_project(&nested);
+        let ctx = detect_project(&nested).expect("a git-rooted project is indexable");
         assert_eq!(ctx.detection_method, DetectionMethod::GitRoot);
         assert_eq!(ctx.root_path, tmp);
         assert_eq!(ctx.index_id, basename(&tmp));
@@ -119,7 +175,7 @@ mod tests {
         let nested = tmp.join("sub");
         fs::create_dir_all(&nested).unwrap();
 
-        let ctx = detect_project(&nested);
+        let ctx = detect_project(&nested).expect("a marker-rooted project is indexable");
         assert_eq!(ctx.detection_method, DetectionMethod::MarkerFile);
         assert_eq!(ctx.root_path, tmp);
 
@@ -131,11 +187,83 @@ mod tests {
         let tmp = tempdir_unique("detect-fallback");
         fs::create_dir_all(&tmp).unwrap();
 
-        let ctx = detect_project(&tmp);
+        let ctx = detect_project(&tmp).expect("an ordinary directory is indexable");
         assert_eq!(ctx.detection_method, DetectionMethod::Fallback);
         assert_eq!(ctx.index_id, basename(&tmp));
 
         let _ = fs::remove_dir_all(&tmp);
+    }
+
+    /// #6550, the defect itself: with no marker anywhere up the chain the walk
+    /// returns the start path, and `$HOME`'s basename is the operator's name.
+    /// The live daemon held index `masa` for a real repository because of it.
+    /// This assertion fails against the pre-fix code, which returned
+    /// `ProjectContext { index_id: "masa", .. }` instead.
+    #[test]
+    fn detect_project_refuses_the_home_directory() {
+        let home = tempdir_unique("detect-home");
+        fs::create_dir_all(&home).unwrap();
+
+        let err = detect_project_against(&home, Some(&home)).expect_err("must refuse");
+        assert_eq!(err.refusal, IndexRootRefusal::HomeDirectory);
+        assert_eq!(err.path, home);
+        assert!(
+            err.to_string().contains("--index"),
+            "the message must say how to proceed: {err}"
+        );
+
+        let _ = fs::remove_dir_all(&home);
+    }
+
+    /// A `$HOME` that is itself a git repository (dotfiles) resolves to the same
+    /// root through a different arm, and the derived id is wrong in exactly the
+    /// same way — so the refusal is checked against the resolved root, not the
+    /// arm that produced it.
+    #[test]
+    fn detect_project_refuses_a_home_directory_that_is_a_git_repo() {
+        let home = tempdir_unique("detect-home-git");
+        fs::create_dir_all(home.join(".git")).unwrap();
+        let nested = home.join("notes");
+        fs::create_dir_all(&nested).unwrap();
+
+        let err = detect_project_against(&nested, Some(&home)).expect_err("must refuse");
+        assert_eq!(err.refusal, IndexRootRefusal::HomeDirectory);
+
+        let _ = fs::remove_dir_all(&home);
+    }
+
+    /// The guard has to stay usable: an ordinary checkout INSIDE the home
+    /// directory — where nearly every project lives — still detects normally.
+    #[test]
+    fn detect_project_indexes_a_project_under_the_home_directory() {
+        let home = tempdir_unique("detect-home-with-project");
+        let project = home.join("code/acme-api");
+        fs::create_dir_all(project.join(".git")).unwrap();
+
+        let ctx = detect_project_against(&project, Some(&home)).expect("indexable");
+        assert_eq!(ctx.index_id, "acme-api");
+        assert_eq!(ctx.root_path, project);
+
+        let _ = fs::remove_dir_all(&home);
+    }
+
+    /// The filesystem root derives the empty id, which every downstream caller
+    /// would have treated as a real index name.
+    #[test]
+    fn detect_project_refuses_the_filesystem_root() {
+        let err = detect_project_against(Path::new("/"), None).expect_err("must refuse");
+        assert_eq!(err.refusal, IndexRootRefusal::FilesystemRoot);
+    }
+
+    /// The real home directory reaches the same refusal through the real
+    /// `dirs::home_dir()` lookup, which is the path production takes.
+    #[test]
+    fn detect_project_refuses_the_real_home_directory() {
+        let Some(home) = dirs::home_dir() else {
+            panic!("this test needs a resolvable home directory");
+        };
+        let err = detect_project(&home).expect_err("must refuse the operator's home directory");
+        assert_eq!(err.refusal, IndexRootRefusal::HomeDirectory);
     }
 
     fn tempdir_unique(label: &str) -> PathBuf {


### PR DESCRIPTION
Refs #6550.

Derivation could fall back to the start-path basename and name an index after the operator's home directory (the live incident). Both sites — `ensure_project_indexed_reporting` / `index_files_inner` in trusty-common and `detect_project` in trusty-search — now refuse via one shared `refuse_unindexable_root` predicate, log at error, and point at `--index <id>`. An explicit `--index` never reaches detection.

PUBLIC API — `detect_project` and `resolve_index` in trusty-search now return `Result`; 0.x → MINOR bump at release time.

**Verification (rung 4):** `cargo check --workspace` ✓; `cargo test -p trusty-common --features search-index --no-fail-fast` 450 passed ✓; `cargo test -p trusty-search --no-fail-fast` 1954 lib + 455 bin + 33 targets ✓; dependents trusty-code and trusty-mpm green ✓; 7 regression tests proven failing against the pre-fix derivation ✓.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools