### PR TITLE
fix(trusty-mpm): gate the compress hook on tools the filter dispatch can shrink

### DIFF
--- a/crates/trusty-agents-common/changelog.d/6566-filter-coverage-predicate.md
+++ b/crates/trusty-agents-common/changelog.d/6566-filter-coverage-predicate.md
@@ -1,0 +1,8 @@
+Added
+
+- `compress::has_filter_for(tool_name)` reports whether any native filter
+  covers a tool name, so a caller upstream of the dispatch can skip work that
+  would return its input unchanged. It is backed by `compress::classify_tool`,
+  which returns the new `ToolFilter` enum; `compress_tool_output` now routes
+  through that same classification with an exhaustive match, so a filter
+  cannot be added to the dispatch without the predicate seeing it.

--- a/crates/trusty-agents-common/src/compress/mod.rs
+++ b/crates/trusty-agents-common/src/compress/mod.rs
@@ -10,7 +10,9 @@
 //! What: Re-exports the `tool_output` dispatch/filter module — the
 //! `compress_tool_output` dispatch, the async RTK-then-native
 //! `compress_tool_output_async`, and the path-reporting
-//! `compress_tool_output_async_with_path` used for stats logging. `trusty-agents`
+//! `compress_tool_output_async_with_path` used for stats logging, plus the
+//! `has_filter_for` / `classify_tool` coverage predicate the `tm hook` rewrite
+//! gates on (#6566). `trusty-agents`
 //! re-exports the same symbols via `trusty_agents::compress` for source-level
 //! compatibility with existing call sites.
 //! Test: `cargo test -p trusty-agents-common` runs `tool_output::tests` in
@@ -20,6 +22,6 @@
 pub mod tool_output;
 
 pub use tool_output::{
-    CompressionPath, compress_tool_output, compress_tool_output_async,
-    compress_tool_output_async_with_path,
+    CompressionPath, ToolFilter, classify_tool, compress_tool_output, compress_tool_output_async,
+    compress_tool_output_async_with_path, has_filter_for,
 };

--- a/crates/trusty-agents-common/src/compress/tool_output/mod.rs
+++ b/crates/trusty-agents-common/src/compress/tool_output/mod.rs
@@ -5,10 +5,12 @@
 //! preserves signal while shrinking context.
 //! What: `compress_tool_output(name, output)` dispatches to a filter based on
 //! the tool name, returning a possibly-shorter string. Each filter is a pure
-//! `fn` for unit testability.
+//! `fn` for unit testability. `classify_tool` names that routing decision and
+//! `has_filter_for` exposes it as a predicate, so a caller upstream of the
+//! dispatch can tell whether a tool name reaches a filter at all (#6566).
 //!
 //! Module layout (see #366 split):
-//! - `mod.rs` — dispatch + the native per-tool filters
+//! - `mod.rs` — classification, dispatch, and the native per-tool filters
 //! - `structured.rs` — JSON/YAML/TOML/CSV passthrough detection
 //! - `strategy.rs` — generic `FilterLevel`/`Language`/`FilterStrategy`
 //! - `rtk.rs` — RTK subprocess delegation + async wrapper, plus
@@ -47,12 +49,126 @@ pub use structured::is_structured_format;
 /// the cognitive cost of compression artifacts. RTK uses 80 bytes.
 const SIZE_GATE_BYTES: usize = 80;
 
+/// Line count above which `git log` output is worth filtering.
+const GIT_LOG_LINE_GATE: usize = 30;
+/// Line count above which a file read is worth filtering.
+const FILE_READ_LINE_GATE: usize = 200;
+
+/// Which native filter [`compress_tool_output`] applies to a given tool name.
+///
+/// Why: #6566 — callers upstream of the dispatch (the `tm hook` `PreToolUse`
+/// Bash rewrite in `trusty-mpm`) need to know whether a tool name reaches a
+/// filter at all, so they can skip wrapping a command whose output nothing
+/// here would shrink. Naming the routing decision as a value lets
+/// [`classify_tool`] answer that question and lets the dispatch match on it
+/// exhaustively, so a new filter cannot appear in one without the other.
+/// What: One variant per filter branch. `Grep` covers `grep`/`rg`/`find`;
+/// `Ls` covers `ls`. Both delegate to the same line-list cap but stay
+/// separate so each keeps its own named filter entry point.
+/// Test: `classify_tool_*` and `has_filter_for_*` in `tests`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ToolFilter {
+    /// `cargo test` and other test runners — [`filter_test_runner`].
+    TestRunner,
+    /// `cargo check` / `cargo clippy` — [`filter_cargo_check`].
+    CargoCheck,
+    /// Unified diffs — [`filter_git_diff`].
+    GitDiff,
+    /// `git log` — [`filter_git_log`], above [`GIT_LOG_LINE_GATE`] lines.
+    GitLog,
+    /// File reads — [`filter_file_read`], above [`FILE_READ_LINE_GATE`] lines.
+    FileRead,
+    /// `grep`/`rg`/`find` match lists — [`filter_grep_output`].
+    Grep,
+    /// `ls` directory listings — [`filter_ls_output`].
+    Ls,
+}
+
+/// Route a tool name to the filter [`compress_tool_output`] would apply.
+///
+/// Why: The single source of truth for "which filter, if any, covers this
+/// tool name". [`compress_tool_output`] dispatches on its result and
+/// [`has_filter_for`] tests it, so the coverage question has exactly one
+/// answer (#6566, and the common-entry-point rule).
+/// What: Substring match against the lowercased name, in the order the
+/// dispatch has always used — the `test`/`cargo` family first (with
+/// `check`/`clippy` inside it taking the cargo-check filter), then `diff`,
+/// `log`, `read`/`cat`. `grep`/`rg`/`find`/`ls` match on the FIRST
+/// whitespace token rather than a substring, because `rg` is a substring of
+/// unrelated names this sees (`cargo`, `git merge`) that must not misfire
+/// (#1957). `None` means no filter covers the name.
+/// Test: `classify_tool_routes_known_tool_families`,
+/// `classify_tool_returns_none_for_uncovered_tools`.
+pub fn classify_tool(tool_name: &str) -> Option<ToolFilter> {
+    let n = tool_name.to_ascii_lowercase();
+    if n.contains("test") || n.contains("cargo") {
+        // Note: "cargo check"/"cargo clippy" go to the cargo_check filter
+        // which strips Compiling/Finished lines; "cargo test" goes here.
+        if n.contains("check") || n.contains("clippy") {
+            return Some(ToolFilter::CargoCheck);
+        }
+        return Some(ToolFilter::TestRunner);
+    }
+    if n.contains("diff") {
+        return Some(ToolFilter::GitDiff);
+    }
+    if n.contains("log") {
+        return Some(ToolFilter::GitLog);
+    }
+    if n.contains("read") || n.contains("cat") {
+        return Some(ToolFilter::FileRead);
+    }
+    // #1957: grep/rg/find emit a flat match-or-path list; ls emits a flat
+    // directory listing. Matched on the first whitespace token (not
+    // `.contains()`, unlike the branches above) — see this function's doc.
+    let first_word = n.split_whitespace().next().unwrap_or("");
+    if first_word == "grep" || first_word == "rg" || first_word == "find" {
+        return Some(ToolFilter::Grep);
+    }
+    if first_word == "ls" {
+        return Some(ToolFilter::Ls);
+    }
+    if n.contains("check") || n.contains("clippy") {
+        return Some(ToolFilter::CargoCheck);
+    }
+    None
+}
+
+/// Whether any native filter covers `tool_name`.
+///
+/// Why: #6566 — `tm hook`'s `PreToolUse` rewrite appended
+/// `| tm compress --tool "<name>"` to every eligible Bash command, but only
+/// the handful of names [`classify_tool`] recognises reach a filter. Measured
+/// over 48h of `~/.trusty-mpm/compression.jsonl`, 3,415 of 3,643 wrapped
+/// invocations (93.7%) returned their input byte-for-byte: each one paid a
+/// process spawn to change nothing. This predicate lets the rewrite decide
+/// before it wraps.
+/// What: `true` exactly when [`classify_tool`] returns a variant. It answers
+/// the NAME question only — the size gate ([`SIZE_GATE_BYTES`]), the
+/// structured-format passthrough, and the per-filter line gates all depend on
+/// the output, which a pre-execution caller cannot see, so a `true` here
+/// promises a filter branch is reached, not that bytes will drop.
+/// Note the RTK path is out of scope: `compress_tool_output_async` prefers
+/// the external `rtk` binary when installed, which can shrink names this
+/// returns `false` for. A hook gating on this under-wraps in that setup,
+/// which is the safe direction — see #6566.
+/// Test: `has_filter_for_true_for_covered_tools`,
+/// `has_filter_for_false_for_uncovered_tools`,
+/// `has_filter_for_agrees_with_classify_tool`.
+pub fn has_filter_for(tool_name: &str) -> bool {
+    classify_tool(tool_name).is_some()
+}
+
 /// Compress a tool's textual output based on its name.
 ///
 /// Why: Centralizes the per-tool filter dispatch so callers don't have to
 /// know which filter applies to which tool.
-/// What: Routes by substring match in `tool_name`. Applies a size gate and a
-/// structured-format passthrough before any filter runs. Unknown tools pass
+/// What: Applies a size gate and a structured-format passthrough, then routes
+/// on [`classify_tool`]. The match is exhaustive over [`ToolFilter`] with no
+/// catch-all arm, so adding a filter variant fails to compile until this
+/// dispatch handles it — that is what keeps [`has_filter_for`] from drifting
+/// away from what the dispatch actually filters (#6566). Unknown tools pass
 /// through unchanged. Always infallible.
 /// Test: `compress_tool_output_dispatch_test` plus per-filter tests.
 pub fn compress_tool_output(tool_name: &str, output: &str) -> String {
@@ -65,49 +181,28 @@ pub fn compress_tool_output(tool_name: &str, output: &str) -> String {
     if is_structured_format(output) {
         return output.to_string();
     }
-    let n = tool_name.to_ascii_lowercase();
-    if n.contains("test") || n.contains("cargo") {
-        // Note: "cargo check"/"cargo clippy" go to the cargo_check filter
-        // which strips Compiling/Finished lines; "cargo test" goes here.
-        if n.contains("check") || n.contains("clippy") {
-            return filter_cargo_check(output);
+    match classify_tool(tool_name) {
+        None => output.to_string(),
+        Some(ToolFilter::TestRunner) => filter_test_runner(output),
+        Some(ToolFilter::CargoCheck) => filter_cargo_check(output),
+        Some(ToolFilter::GitDiff) => filter_git_diff(output),
+        Some(ToolFilter::GitLog) => {
+            if output.lines().count() > GIT_LOG_LINE_GATE {
+                filter_git_log(output)
+            } else {
+                output.to_string()
+            }
         }
-        return filter_test_runner(output);
-    }
-    if n.contains("diff") {
-        return filter_git_diff(output);
-    }
-    if n.contains("log") {
-        let line_count = output.lines().count();
-        if line_count > 30 {
-            return filter_git_log(output);
+        Some(ToolFilter::FileRead) => {
+            if output.lines().count() > FILE_READ_LINE_GATE {
+                filter_file_read(output)
+            } else {
+                output.to_string()
+            }
         }
-        return output.to_string();
+        Some(ToolFilter::Grep) => filter_grep_output(output),
+        Some(ToolFilter::Ls) => filter_ls_output(output),
     }
-    if n.contains("read") || n.contains("cat") {
-        let line_count = output.lines().count();
-        if line_count > 200 {
-            return filter_file_read(output);
-        }
-        return output.to_string();
-    }
-    // #1957: grep/rg/find emit a flat match-or-path list; ls emits a flat
-    // directory listing. Neither had a filter branch — the #1953 spike
-    // measured 0% reduction for grep and ls output. Matched on the first
-    // whitespace token (not `.contains()`, unlike the branches above)
-    // because "rg" is a substring of unrelated tool names this dispatch
-    // sees (e.g. "cargo", "git merge") that must not misfire.
-    let first_word = n.split_whitespace().next().unwrap_or("");
-    if first_word == "grep" || first_word == "rg" || first_word == "find" {
-        return filter_grep_output(output);
-    }
-    if first_word == "ls" {
-        return filter_ls_output(output);
-    }
-    if n.contains("check") || n.contains("clippy") {
-        return filter_cargo_check(output);
-    }
-    output.to_string()
 }
 
 /// Strip passing test lines from `cargo test` output.

--- a/crates/trusty-agents-common/src/compress/tool_output/tests.rs
+++ b/crates/trusty-agents-common/src/compress/tool_output/tests.rs
@@ -549,3 +549,100 @@ async fn compress_tool_output_async_with_path_matches_plain_wrapper() {
     // must round-trip through a valid, stable string.
     assert!(matches!(path.as_str(), "rtk_binary" | "native_fallback"));
 }
+
+// ── Filter coverage classification (#6566) ──────────────────────────────
+
+#[test]
+fn classify_tool_routes_known_tool_families() {
+    assert_eq!(
+        classify_tool("cargo test -p x"),
+        Some(ToolFilter::TestRunner)
+    );
+    assert_eq!(classify_tool("cargo check"), Some(ToolFilter::CargoCheck));
+    assert_eq!(classify_tool("cargo clippy"), Some(ToolFilter::CargoCheck));
+    assert_eq!(classify_tool("git diff"), Some(ToolFilter::GitDiff));
+    assert_eq!(classify_tool("git log"), Some(ToolFilter::GitLog));
+    assert_eq!(classify_tool("cat file.rs"), Some(ToolFilter::FileRead));
+    assert_eq!(classify_tool("grep -n foo"), Some(ToolFilter::Grep));
+    assert_eq!(classify_tool("rg foo"), Some(ToolFilter::Grep));
+    assert_eq!(classify_tool("find ."), Some(ToolFilter::Grep));
+    assert_eq!(classify_tool("ls -la"), Some(ToolFilter::Ls));
+    // Case-insensitive, like the dispatch has always been.
+    assert_eq!(classify_tool("CARGO TEST"), Some(ToolFilter::TestRunner));
+}
+
+#[test]
+fn classify_tool_returns_none_for_uncovered_tools() {
+    // The names #6566 measured as the bulk of the no-op wraps.
+    for name in [
+        "git status",
+        "git add",
+        "git push",
+        "sed -n",
+        "gh pr",
+        "gh issue",
+        "wc -l",
+        "ssh",
+        "tm wait",
+        "bash",
+        "echo",
+    ] {
+        assert_eq!(classify_tool(name), None, "expected no filter for {name}");
+    }
+}
+
+#[test]
+fn has_filter_for_true_for_covered_tools() {
+    for name in ["cargo test", "git diff", "git log", "grep -n", "ls", "cat"] {
+        assert!(has_filter_for(name), "expected a filter for {name}");
+    }
+}
+
+#[test]
+fn has_filter_for_false_for_uncovered_tools() {
+    for name in ["git status", "sed -n", "gh pr", "wc -l", "ssh"] {
+        assert!(!has_filter_for(name), "expected no filter for {name}");
+    }
+}
+
+#[test]
+fn has_filter_for_agrees_with_classify_tool() {
+    // The predicate is defined as `classify_tool(..).is_some()`; this pins
+    // that equivalence so the two cannot answer differently (#6566). Drift
+    // between the PREDICATE and the DISPATCH is prevented structurally
+    // instead: `compress_tool_output` matches exhaustively over `ToolFilter`
+    // with no catch-all arm, so a new filter variant fails to compile until
+    // the dispatch handles it, and `classify_tool` is the only thing that
+    // produces one.
+    for name in [
+        "cargo test",
+        "cargo clippy",
+        "git diff",
+        "git log",
+        "read",
+        "grep",
+        "ls",
+        "git status",
+        "sed -n",
+        "gh pr",
+        "",
+    ] {
+        assert_eq!(
+            has_filter_for(name),
+            classify_tool(name).is_some(),
+            "{name}"
+        );
+    }
+}
+
+#[test]
+fn uncovered_tool_output_passes_through_unchanged() {
+    // The behavioural half of the predicate's contract: a name `has_filter_for`
+    // rejects gets its bytes back verbatim from the dispatch, which is exactly
+    // what made the unconditional hook wrap a no-op process spawn (#6566).
+    let input = "M  crates/trusty-mpm/src/main.rs\n".repeat(20);
+    for name in ["git status", "sed -n", "gh pr"] {
+        assert!(!has_filter_for(name));
+        assert_eq!(compress_tool_output(name, &input), input, "{name}");
+    }
+}

--- a/crates/trusty-mpm/changelog.d/6566-compress-hook-gating.md
+++ b/crates/trusty-mpm/changelog.d/6566-compress-hook-gating.md
@@ -1,0 +1,11 @@
+Fixed
+
+- `tm hook`'s `PreToolUse` Bash rewrite no longer appends
+  `| tm compress --tool "<name>"` to commands no compression filter covers.
+  `git status`, `sed`, `gh pr`, `wc`, `ssh` and the like each paid a process
+  spawn to get their own bytes back: 3,415 of 3,643 wrapped invocations
+  (93.7%) over a measured 48-hour window reduced nothing. The rewrite now asks
+  `trusty_agents_common::compress::has_filter_for` before wrapping. Commands
+  the dispatch does cover — `cargo test`, `cargo check`/`clippy`, `git diff`,
+  `git log`, `grep`/`rg`/`find`, `ls`, file reads — are wrapped exactly as
+  before.

--- a/crates/trusty-mpm/src/bin/tm/commands/hook_rewrite.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/hook_rewrite.rs
@@ -35,6 +35,10 @@
 //! Test: `rewrite_*`, `is_orchestrator_command_*`, `first_command_token_*`,
 //! `is_safe_tool_name_*`, `build_pretooluse_rewrite_response_*` below.
 
+// #6566: the tool-name coverage predicate lives beside the filter dispatch it
+// predicts, in `trusty-agents-common`, so the two cannot drift apart.
+use trusty_agents_common::compress::has_filter_for;
+
 /// Day-one orchestrator-command exclusion list.
 ///
 /// Why: These tools spawn long, multi-stage subprocess chains where an
@@ -83,11 +87,21 @@ const ORCHESTRATOR_EXCLUSIONS: &[&str] = &[
 /// command would silently pass through with 0% compression — defeating the
 /// entire point of this spike. Quoted because the derived name may contain
 /// a space (e.g. `"cargo test"`).
+/// Finally, it returns `None` when no compression filter covers the derived
+/// tool name (#6566): the wrap used to be unconditional, so a `git status`,
+/// `sed -n`, or `gh pr list` paid a `tm compress` process spawn to get its
+/// own bytes back. Over 48h of `~/.trusty-mpm/compression.jsonl`, 3,415 of
+/// 3,643 wrapped invocations (93.7%) reduced nothing. The tool-name list
+/// stays in `trusty-agents-common` — this module asks
+/// `compress::has_filter_for` rather than keeping a second copy that could
+/// drift from the dispatch it is meant to predict.
 /// Test: `rewrite_appends_compress_pipe_for_plain_command`,
 /// `rewrite_appends_compress_pipe_with_subcommand_tool_name`,
 /// `rewrite_skips_orchestrator_commands`, `rewrite_skips_piped_commands`,
 /// `rewrite_skips_chained_commands`, `rewrite_skips_empty_command`,
-/// `rewrite_skips_command_substitution_in_tool_name`.
+/// `rewrite_skips_command_substitution_in_tool_name`,
+/// `rewrite_skips_tools_with_no_compression_filter`,
+/// `rewrite_still_wraps_tools_with_a_compression_filter`.
 pub(crate) fn rewrite_bash_command_for_compression(command: &str) -> Option<String> {
     let trimmed = command.trim();
     if trimmed.is_empty() {
@@ -103,6 +117,11 @@ pub(crate) fn rewrite_bash_command_for_compression(command: &str) -> Option<Stri
     if !is_safe_tool_name(&tool) {
         return None;
     }
+    // #6566: no filter covers this tool name, so the wrap would spawn a
+    // process that returns its input unchanged.
+    if !has_filter_for(&tool) {
+        return None;
+    }
     Some(format!("{trimmed} | tm compress --tool \"{tool}\""))
 }
 
@@ -114,10 +133,9 @@ pub(crate) fn rewrite_bash_command_for_compression(command: &str) -> Option<Stri
 /// branches) — it has no branch for the literal string `"bash"`. Passing
 /// the command's actual program + subcommand lets the existing `cargo
 /// test`/`cargo check`/`git diff`/`git log` filters fire for the domains
-/// they already cover; commands outside that coverage (e.g. `grep`, `ls`)
-/// still pass through unchanged, which matches this repo's own documented
-/// filter-coverage gap (`docs/specs/tool-output-interception-seam.md`
-/// §Spike) rather than a new regression.
+/// they already cover. Commands outside that coverage (`git status`, `sed`,
+/// `gh pr list`, …) are no longer wrapped at all since #6566 — the caller
+/// checks the derived name against `compress::has_filter_for` first.
 /// What: Strips the same env-assignment/`sudo`/`env`/path noise
 /// [`first_command_token`] strips (looping so `env FOO=bar cargo test` and
 /// similar multi-prefix combinations resolve correctly — a trusty-review
@@ -459,6 +477,55 @@ mod tests {
             rewrite_bash_command_for_compression("sudo -u root make build"),
             None
         );
+    }
+
+    #[test]
+    fn rewrite_skips_tools_with_no_compression_filter() {
+        // #6566: these were wrapped unconditionally, each paying a `tm
+        // compress` process spawn to get its own bytes back — 93.7% of
+        // wrapped invocations over the measured 48h window. `git status`,
+        // `sed -n 1p f`, and `gh pr list` are the three highest-volume
+        // offenders; none reaches a filter branch in
+        // `trusty-agents-common::compress`.
+        for cmd in [
+            "git status",
+            "git add -A",
+            "git push",
+            "sed -n 1p f",
+            "gh pr list",
+            "gh issue view 6566",
+            "wc -l Cargo.toml",
+            "ssh host uptime",
+            "tm wait --for run",
+            "echo hello",
+        ] {
+            assert_eq!(
+                rewrite_bash_command_for_compression(cmd),
+                None,
+                "expected no compress wrap for uncovered tool: {cmd}"
+            );
+        }
+    }
+
+    #[test]
+    fn rewrite_still_wraps_tools_with_a_compression_filter() {
+        // The other half of #6566's gate: every tool the dispatch does cover
+        // must be wrapped exactly as before.
+        for (cmd, tool) in [
+            ("cargo test -p x", "cargo test"),
+            ("cargo clippy --all-targets", "cargo clippy"),
+            ("git diff", "git diff"),
+            ("git log --oneline", "git log"),
+            ("grep -n foo src/", "grep -n"),
+            ("ls -la", "ls -la"),
+        ] {
+            let expected = format!("{cmd} | tm compress --tool \"{tool}\"");
+            assert_eq!(
+                rewrite_bash_command_for_compression(cmd).as_deref(),
+                Some(expected.as_str()),
+                "expected a compress wrap for covered tool: {cmd}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Refs #6566.

PostToolUse rewrite appended `| tm compress` to every Bash call while only a handful of tool names have filter branches — 93.7% of 3,643 events/48h were no-op subprocess spawns. Now a shared `has_filter_for` predicate (trusty-agents-common, beside a `ToolFilter` enum the dispatch matches exhaustively with no catch-all) gates the rewrite; drift is structurally impossible. Documented caveat: with an external `rtk` binary installed the hook under-wraps for names the native filters reject (safe direction; rtk is not installed here).

Gate: rung 4 — fmt; check --workspace; clippy trusty-agents-common + trusty-mpm; tests: trusty-agents-common 516 passed, trusty-mpm 5657 passed + 1 environmental pty_headroom parity flake rerun green, trusty-agents 3601 passed. Regression test `rewrite_skips_tools_with_no_compression_filter` proven failing against the ungated rewrite.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools