### PR TITLE
feat(trusty-mpm): tm accepts a bare GitHub URL or owner/repo and runs it

### DIFF
--- a/crates/trusty-mpm/changelog.d/6441-bare-url-run.md
+++ b/crates/trusty-mpm/changelog.d/6441-bare-url-run.md
@@ -1,0 +1,12 @@
+Added
+
+- `tm <github-url>` and `tm <owner>/<repo>` now provision and run a managed
+  session in one command, instead of exiting with clap's unknown-subcommand
+  error. The token routes through the same register → load → run chain
+  `tm run <target>` already drives, so an already-registered repo refreshes and
+  runs rather than duplicating a registration (#6441).
+  - A leading token that is not repo-shaped — a subcommand typo such as
+    `tm statuss` — still gets clap's usage error and the "did you mean?" hint.
+  - Abbreviated subcommands (`tm sta` → `tm status`) keep resolving by prefix
+    inference; they never fall through to the new catch-all.
+  - Bare `tm` with no argument is unchanged.

--- a/crates/trusty-mpm/src/bin/tm/cli/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli/mod.rs
@@ -1322,6 +1322,31 @@ pub(crate) enum Command {
     /// from tm's MCP-native `config_read`/`config_write` daemon config tools —
     /// different domain, deliberately not merged.
     Config(trusty_common::inference::config::ConfigCommand),
+
+    /// Catch-all for a leading token that names no subcommand (#6441).
+    ///
+    /// Why: `tm https://github.com/<owner>/<repo>` and `tm <owner>/<repo>`
+    /// should provision and run the repo in ONE command, and clap has no way
+    /// to express "a positional, but only when it matches no subcommand"
+    /// except this variant. Adding a plain top-level positional instead would
+    /// make every subcommand name ambiguous with it.
+    /// What: clap collects the unrecognized token and everything after it.
+    /// [`crate::commands::run_target::classify_bare`] then decides which of two
+    /// outcomes it gets, and the gate is deliberately narrow: only a token
+    /// [`crate::commands::register_args::looks_like_repo`] accepts becomes a
+    /// managed run. Everything else — a typo like `tm statuss` — falls back to
+    /// clap's usage error plus the workspace "did you mean?" hint, exactly as
+    /// it did before this variant existed. Without that gate a typo would
+    /// become a registry-alias lookup and report the wrong problem.
+    ///
+    /// This is POST-parse, so `--url` / `TRUSTY_MPM_URL` still bind normally.
+    /// An exact or unambiguously-inferred subcommand name always wins over this
+    /// arm; `infer_subcommands` is matched first.
+    /// Test: `cli_parses_bare_github_url`, `cli_parses_bare_owner_repo`,
+    /// `cli_bare_infers_abbreviated_subcommand_over_external`,
+    /// `cli_bare_unknown_subcommand_is_not_a_repo`.
+    #[command(external_subcommand)]
+    External(Vec<String>),
 }
 
 /// Post-report local actions for `tm doctor`.

--- a/crates/trusty-mpm/src/bin/tm/commands/run_target.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/run_target.rs
@@ -159,6 +159,160 @@ pub(crate) async fn run(
     }
 }
 
+/// Decide whether a token clap could not match names a repo to run (#6441).
+///
+/// Why: `tm <github-url>` has to reach the same register→load→run chain
+/// `tm run <url>` already drives, and clap surfaces such a token through
+/// [`crate::cli::Command::External`] — the same arm EVERY token clap cannot
+/// resolve lands in: a typo (`statuss`), an ambiguous prefix (`sta`, which
+/// matches `start`/`status`/`statusline`), and a retired subcommand
+/// (`coordinator-tui`). So the gate is the whole design: each of those must
+/// keep getting clap's usage error and the "did you mean?" hint, never a
+/// managed run and never an alias lookup reporting "alias 'statuss' not found".
+/// Only a token [`super::register_args::looks_like_repo`] accepts — the SAME
+/// predicate `tm register` and [`classify_run_target`] use — is a repo.
+/// What: `None` means "not a repo, hand it back to the usage-error path".
+/// `Some(Ok(..))` is always [`RunTarget::Repo`]; `Some(Err(..))` is a
+/// repo-shaped token that [`super::register_args::resolved_url`] refuses (a
+/// host with no path, a browser paste into a repo's web UI), and that
+/// descriptive error is what the user should see rather than a usage dump.
+///
+/// A relative path is `None` on purpose: it is neither a repo nor a
+/// subcommand, and clap's usage error names the real problem more usefully
+/// than a clone attempt would.
+/// Test: `classify_bare_accepts_repo_shapes`,
+/// `classify_bare_declines_subcommand_typos`,
+/// `classify_bare_surfaces_resolved_url_errors`.
+pub(crate) fn classify_bare(token: &str) -> Option<anyhow::Result<RunTarget>> {
+    let token = token.trim();
+    if !super::register_args::looks_like_repo(token) {
+        return None;
+    }
+    Some(classify_run_target(token))
+}
+
+/// `tm <token>` where `<token>` matched no subcommand (#6441).
+///
+/// Why: keeping the fallback here rather than in `main.rs` keeps that file's
+/// dispatch arm one line wide — it sits against the 500-SLOC production cap —
+/// and gives the two-outcome decision a testable home next to the predicate it
+/// depends on.
+/// What: a repo-shaped token runs through [`run_managed`], the same cold start
+/// `tm run <owner>/<repo>` uses, so an already-registered repo refreshes and
+/// runs rather than erroring. Anything else goes to
+/// [`reject_unknown_subcommand`], which reproduces the exact usage error the
+/// invocation produced before [`crate::cli::Command::External`] existed.
+/// Trailing tokens are refused rather than silently dropped: `tm <url> extra`
+/// means something the CLI cannot honour.
+/// Test: the repo half is [`classify_bare`]'s coverage plus `tm run`'s existing
+/// managed-checkout tests; the usage-error half exits the process and is
+/// covered at the parse layer by `cli_bare_unknown_subcommand_is_not_a_repo`,
+/// `cli_bare_ambiguous_prefix_is_not_a_repo`, and
+/// `cli_bare_retired_subcommand_is_not_a_repo`.
+pub(crate) async fn run_external(
+    client: &reqwest::Client,
+    url: &str,
+    tokens: &[String],
+    argv: &[String],
+    help: &trusty_common::help::HelpConfig,
+) -> anyhow::Result<()> {
+    let token = tokens.first().map(String::as_str).unwrap_or_default();
+    let Some(classified) = classify_bare(token) else {
+        reject_unknown_subcommand(argv, help);
+    };
+
+    if tokens.len() > 1 {
+        anyhow::bail!(
+            "tm {token} takes no further arguments (got {extra:?}). \
+             Use `tm run {token}` for the flag-bearing form.",
+            extra = &tokens[1..]
+        );
+    }
+
+    match classified? {
+        RunTarget::Repo {
+            owner,
+            repo,
+            clone_url,
+        } => run_managed(client, url, &owner, &repo, &clone_url).await,
+        // `classify_bare` returns `None` rather than an alias, so this is
+        // unreachable; routing it to the same cold start keeps the arm total.
+        RunTarget::Alias(alias) => Err(super::register_args::rejection(&alias)),
+    }
+}
+
+/// Print the usage error a token would have produced before #6441, and exit.
+///
+/// Why: `external_subcommand` makes clap ACCEPT any leading token it does not
+/// recognize, so three previously-failing invocations now parse — a typo
+/// (`tm statuss`), an AMBIGUOUS prefix (`tm sta`, which matches `start`,
+/// `status`, and `statusline`), and a retired subcommand (`tm coordinator-tui`,
+/// #1392). All three must still be refused, and with clap's own wording: its
+/// "tip: some similar subcommands exist" line names the real candidates, which
+/// a hand-written message cannot reproduce.
+/// What: re-parses the ORIGINAL argv against a command carrying the same
+/// arguments and subcommands but WITHOUT the external catch-all — which is
+/// exactly the pre-#6441 definition — then prints that error, appends the
+/// workspace "did you mean?" hint the way `main` does, and exits with clap's
+/// own code.
+///
+/// 🔴 The rebuild is required. Calling `allow_external_subcommands(false)` on
+/// the command `clap::CommandFactory` hands back does NOT disable the
+/// catch-all: the flag reads back as `false` and `sta` still matches as the
+/// external subcommand `sta`, because the derive already wired the match path
+/// during augmentation. Only a command built fresh from
+/// [`clap::Command::new`] honours the absence of the flag. Do not "simplify"
+/// this back to a flag flip.
+///
+/// The re-parse cannot succeed — the token reached this function precisely
+/// because nothing matched it — but an `Ok` is handled rather than unwrapped.
+/// Test: `reject_unknown_subcommand_rebuild_reproduces_claps_error`,
+/// `cli_bare_ambiguous_prefix_is_not_a_repo`,
+/// `cli_bare_unknown_subcommand_is_not_a_repo`,
+/// `cli_bare_retired_subcommand_is_not_a_repo`.
+fn reject_unknown_subcommand(argv: &[String], help: &trusty_common::help::HelpConfig) -> ! {
+    let code = match without_external_catch_all().try_get_matches_from(argv) {
+        Err(e) => {
+            e.print().ok();
+            trusty_common::help::print_suggestion_hint(argv, help);
+            e.exit_code()
+        }
+        // Unreachable: this token matched no subcommand a moment ago.
+        Ok(_) => {
+            eprintln!("error: unrecognized subcommand");
+            2
+        }
+    };
+    std::process::exit(code);
+}
+
+/// The `tm` command definition as it stood before #6441.
+///
+/// Why: see [`reject_unknown_subcommand`] — the pre-#6441 error can only be
+/// reproduced by a command that never had the external catch-all wired in.
+/// What: copies [`crate::cli::Cli`]'s own arguments and subcommands onto a
+/// fresh [`clap::Command`], keeping `infer_subcommands` so an unambiguous
+/// prefix still resolves and an ambiguous one still reports every candidate.
+/// The name is spelled out because `clap::builder::Str` only accepts a
+/// `&'static str`; `command_name_matches_the_rebuild` pins it against the
+/// derive so the two cannot drift.
+/// Test: `command_name_matches_the_rebuild`,
+/// `reject_unknown_subcommand_rebuild_reproduces_claps_error`.
+pub(crate) fn without_external_catch_all() -> clap::Command {
+    use clap::CommandFactory as _;
+
+    let src = crate::cli::Cli::command();
+    clap::Command::new(CLI_NAME)
+        .infer_subcommands(true)
+        .args(src.get_arguments().cloned())
+        .subcommands(src.get_subcommands().cloned())
+}
+
+/// The `#[command(name = ...)]` on [`crate::cli::Cli`].
+///
+/// Test: `command_name_matches_the_rebuild`.
+pub(crate) const CLI_NAME: &str = "trusty-mpm";
+
 /// Cold-start a daemon-managed session for a GitHub `owner/repo`.
 ///
 /// Why: this is the whole point of #4990 — a bare string ends in a real

--- a/crates/trusty-mpm/src/bin/tm/commands/run_target_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/run_target_tests.rs
@@ -170,6 +170,85 @@ fn classify_rejects_browser_pastes_and_paths() {
     }
 }
 
+/// #6441: every repo shape `tm run` accepts is also a bare-`tm` target.
+///
+/// Why: `tm <url>` and `tm run <url>` must not disagree about what a string
+/// means, so `classify_bare` delegates to `classify_run_target` rather than
+/// re-deriving. This pins the delegation on the shapes both see.
+/// Test: itself.
+#[test]
+fn classify_bare_accepts_repo_shapes() {
+    for spec in [
+        "bobmatnyc/mcp-a-protocol",
+        "https://github.com/bobmatnyc/mcp-a-protocol",
+        "https://github.com/bobmatnyc/mcp-a-protocol.git",
+        "git@github.com:bobmatnyc/mcp-a-protocol.git",
+    ] {
+        let bare = classify_bare(spec)
+            .unwrap_or_else(|| panic!("'{spec}' is a repo shape, not a typo"))
+            .unwrap_or_else(|e| panic!("'{spec}' must resolve: {e}"));
+        assert_eq!(
+            bare,
+            classify_run_target(spec).expect("tm run accepts it too"),
+            "'{spec}' must mean the same thing bare as it does after `tm run`"
+        );
+        assert!(matches!(bare, RunTarget::Repo { .. }));
+    }
+}
+
+/// THE GATE: anything that is not repo-shaped declines, and declines QUIETLY.
+///
+/// Why: `Command::External` catches subcommand typos as well as URLs. `None`
+/// is what hands a typo back to clap's usage error; a `Some(Err(..))` here
+/// would replace "did you mean status?" with a repository complaint, and a
+/// `Some(Ok(Alias(..)))` would turn it into a registry lookup for an alias
+/// nobody registered. A relative path declines for the same reason — clap's
+/// usage error names the real problem better than a clone attempt would.
+/// Test: itself.
+#[test]
+fn classify_bare_declines_subcommand_typos() {
+    for not_a_repo in [
+        "statuss",
+        "sessionz",
+        "instal",
+        "notacommand",
+        "",
+        "   ",
+        "./some/dir",
+        "../sibling",
+    ] {
+        assert!(
+            classify_bare(not_a_repo).is_none(),
+            "'{not_a_repo}' must fall through to the usage-error path, not become a target"
+        );
+    }
+}
+
+/// A repo-shaped token that names no repo keeps `resolved_url`'s message.
+///
+/// Why: `https://example.com/` is a URL, so it is not a typo and the usage
+/// error would be the wrong answer. The remedy is the one `tm register`
+/// already writes, inherited rather than restated.
+/// Test: itself.
+#[test]
+fn classify_bare_surfaces_resolved_url_errors() {
+    for (bad, expected) in [
+        ("https://example.com/", "names a host"),
+        (
+            "https://github.com/bobmatnyc/trusty-tools/issues",
+            "points inside a repository",
+        ),
+    ] {
+        let err = classify_bare(bad)
+            .unwrap_or_else(|| panic!("'{bad}' is repo-SHAPED, so it is never the typo path"))
+            .expect_err("but it does not name a repository");
+        assert!(
+            err.to_string().contains(expected),
+            "rejection of '{bad}' must say '{expected}', got: {err}"
+        );
+    }
+}
+
 /// An empty or whitespace-only target names nothing and must say so.
 ///
 /// Test: itself.

--- a/crates/trusty-mpm/src/bin/tm/main.rs
+++ b/crates/trusty-mpm/src/bin/tm/main.rs
@@ -62,6 +62,13 @@ mod tests_behavior_a;
 #[path = "install_policy_tests.rs"]
 mod install_policy_tests;
 
+// #6441: parse-layer coverage for the bare `tm <github-url>` form. Its own
+// file rather than `tests.rs` because the `infer_subcommands` /
+// `external_subcommand` precedence it pins is one cohesive claim.
+#[cfg(test)]
+#[path = "tests_behavior_bare_run_tests.rs"]
+mod tests_behavior_bare_run;
+
 #[cfg(test)]
 #[path = "tests_behavior_b_tests.rs"]
 mod tests_behavior_b;
@@ -620,6 +627,12 @@ async fn main() -> anyhow::Result<()> {
         // routing decision lives in `run_target` so it is unit-testable.
         Some(Command::Run { target, task, root }) => {
             commands::run_target::run(&client, &url, &target, task, root).await
+        }
+        // #6441: a leading token that matched no subcommand. A repo shape runs
+        // the same cold start as `tm run`; anything else is a typo and gets
+        // clap's usage error back.
+        Some(Command::External(ref tokens)) => {
+            commands::run_target::run_external(&client, &url, tokens, &argv, &HELP).await
         }
         Some(Command::Path { alias, root }) => {
             let paths = commands::managed_root::resolve_managed_paths(root.as_deref())?;

--- a/crates/trusty-mpm/src/bin/tm/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests.rs
@@ -1107,14 +1107,25 @@ fn cli_parses_session_singular() {
 
 #[test]
 fn cli_rejects_removed_coordinator_tui() {
-    // #1392: the old top-level `tm coordinator-tui` was deleted (not aliased).
-    // Parsing it must now fail with an unrecognized-subcommand error.
-    let err = Cli::try_parse_from(["trusty-mpm", "coordinator-tui"]).unwrap_err();
-    assert_eq!(
-        err.kind(),
-        clap::error::ErrorKind::InvalidSubcommand,
-        "expected InvalidSubcommand, got {:?}",
-        err.kind()
+    // #1392: the old top-level `tm coordinator-tui` was deleted (not aliased),
+    // and the invocation must stay refused.
+    //
+    // #6441 moved WHERE that refusal happens. `Command::External` is a clap
+    // `external_subcommand`, so the parse itself now SUCCEEDS for any token no
+    // subcommand matches — this one included. The rejection is enforced one
+    // step later instead: `commands::run_target::classify_bare` answers `None`
+    // for a token that does not name a repository, and
+    // `run_target::reject_unknown_subcommand` then reproduces the same clap
+    // usage error and exit code this test used to read off the parse. The
+    // behaviour a user sees is unchanged; only the layer asserting it moved.
+    let cli = Cli::try_parse_from(["trusty-mpm", "coordinator-tui"]).unwrap();
+    match cli.command.unwrap() {
+        Command::External(tokens) => assert_eq!(tokens, ["coordinator-tui"]),
+        other => panic!("expected the External catch-all, got {other:?}"),
+    }
+    assert!(
+        crate::commands::run_target::classify_bare("coordinator-tui").is_none(),
+        "a retired subcommand must route to the usage error, never to a managed run"
     );
 }
 

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_bare_run_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_bare_run_tests.rs
@@ -1,0 +1,264 @@
+//! Parse-layer coverage for the bare `tm <github-url>` form (#6441).
+//!
+//! Why: the feature is one clap variant — `Command::External` — plus one gate,
+//! and BOTH halves fail silently if they are wrong. A missing variant means
+//! `tm https://github.com/o/r` exits 2 with a "did you mean?" hint; a gate that
+//! is too wide means `tm statuss` becomes a registry-alias lookup reporting
+//! "alias 'statuss' not found" instead of the usage error it used to get. The
+//! interaction between `infer_subcommands` and `external_subcommand` is
+//! untested in clap's own docs, so the precedence is pinned here rather than
+//! assumed.
+//! What: the two accepted repo shapes, the two regressions (prefix inference
+//! and subcommand typos), and the descriptive error a repo-shaped non-repo URL
+//! must surface.
+//! Test: this file IS the test module.
+
+use clap::{CommandFactory as _, Parser as _};
+
+use crate::cli::{Cli, Command};
+use crate::commands::run_target::{RunTarget, classify_bare};
+
+/// Pull the `External` token list out of a parsed `Cli`, or fail loudly.
+///
+/// Why: every test here asserts on the same two-step shape — the parse reached
+/// `External`, and its first token classified a particular way — so the
+/// unwrapping is factored out rather than repeated five times.
+fn external_token(argv: &[&str]) -> String {
+    let cli = Cli::try_parse_from(argv).expect("bare token must parse");
+    match cli.command.expect("a token is not the no-subcommand case") {
+        Command::External(tokens) => tokens.first().cloned().expect("one token"),
+        other => panic!("{argv:?} must reach the External arm, got {other:?}"),
+    }
+}
+
+/// ACCEPTANCE: `tm https://github.com/<owner>/<repo>` classifies to the repo.
+///
+/// Why: the owner's acceptance-test invocation, and the headline of #6441.
+/// Without the `External` variant this parse fails outright with clap's
+/// unknown-subcommand error.
+/// Test: itself.
+#[test]
+fn cli_parses_bare_github_url() {
+    let token = external_token(&["tm", "https://github.com/bobmatnyc/mcp-a-protocol"]);
+    let target = classify_bare(&token)
+        .expect("a github URL is a repo, not a typo")
+        .expect("it resolves");
+    assert_eq!(
+        target,
+        RunTarget::Repo {
+            owner: "bobmatnyc".into(),
+            repo: "mcp-a-protocol".into(),
+            clone_url: "https://github.com/bobmatnyc/mcp-a-protocol".into(),
+        }
+    );
+}
+
+/// ACCEPTANCE: the `owner/repo` shorthand takes the same path.
+///
+/// Why: #4912 made `owner/repo` the primary way to name a repo; the bare form
+/// must not be URL-only, and both spellings must resolve to the SAME clone URL
+/// or `tm <url>` and `tm <owner>/<repo>` would provision two checkouts.
+/// Test: itself.
+#[test]
+fn cli_parses_bare_owner_repo() {
+    let token = external_token(&["tm", "bobmatnyc/mcp-a-protocol"]);
+    let target = classify_bare(&token)
+        .expect("shorthand is a repo")
+        .expect("it resolves");
+    assert_eq!(
+        target,
+        RunTarget::Repo {
+            owner: "bobmatnyc".into(),
+            repo: "mcp-a-protocol".into(),
+            clone_url: "https://github.com/bobmatnyc/mcp-a-protocol".into(),
+        }
+    );
+}
+
+/// REGRESSION: an UNAMBIGUOUS prefix still infers; it does NOT go external.
+///
+/// Why: `infer_subcommands` (#4398) and `external_subcommand` both want an
+/// unrecognized leading token, and clap documents no precedence between them.
+/// Measured here: inference wins whenever it resolves to exactly one
+/// subcommand, so every abbreviation users type today keeps working. Only a
+/// token inference CANNOT resolve reaches `External`.
+/// Test: itself.
+#[test]
+fn cli_bare_infers_abbreviated_subcommand_over_external() {
+    for (argv, label) in [
+        (["tm", "doc"], "doctor"),
+        (["tm", "heal"], "health"),
+        (["tm", "rest"], "restart"),
+        (["tm", "instal"], "install"),
+    ] {
+        let cli = Cli::try_parse_from(argv).expect("abbreviation must parse");
+        let command = cli.command.expect("an abbreviation names a subcommand");
+        assert!(
+            !matches!(command, Command::External(_)),
+            "'{}' must infer {label}, not fall through to External — got {command:?}",
+            argv[1]
+        );
+    }
+
+    // The exact resolution, not merely "not External".
+    assert!(matches!(
+        Cli::try_parse_from(["tm", "heal"])
+            .expect("parses")
+            .command
+            .expect("has a command"),
+        Command::Health
+    ));
+}
+
+/// REGRESSION: an AMBIGUOUS prefix is not a repo, so it keeps its usage error.
+///
+/// Why: `sta` prefixes `start`, `status`, AND `statusline`, so inference
+/// cannot resolve it and it lands in `External` — where, before this gate, it
+/// would have become a registry-alias lookup. On `origin/main` the same
+/// invocation exits 2 with clap's "tip: some similar subcommands exist: …
+/// 'status', 'start'" line, and `classify_bare` returning `None` is what
+/// routes it back to exactly that error.
+/// Test: itself.
+#[test]
+fn cli_bare_ambiguous_prefix_is_not_a_repo() {
+    let token = external_token(&["tm", "sta"]);
+    assert_eq!(token, "sta");
+    assert!(
+        classify_bare(&token).is_none(),
+        "an ambiguous prefix must reach the usage-error path, not a managed run"
+    );
+}
+
+/// REGRESSION: a subcommand typo is NOT a repo, so it keeps the usage error.
+///
+/// Why: this is the gate `classify_bare` exists for. `statuss` reaches the
+/// `External` arm (no subcommand starts with it), and if `classify_bare`
+/// accepted it the dispatcher would try a registry-alias lookup and report
+/// "alias 'statuss' not found" — naming the wrong problem for what is plainly
+/// a typo. `None` is what routes it back to clap's usage error plus the
+/// workspace "did you mean?" hint.
+/// Test: itself.
+#[test]
+fn cli_bare_unknown_subcommand_is_not_a_repo() {
+    for typo in ["statuss", "sessionz", "notacommand"] {
+        let token = external_token(&["tm", typo]);
+        assert_eq!(token, typo);
+        assert!(
+            classify_bare(&token).is_none(),
+            "'{typo}' has no '/' or ':', so it must fall back to the usage error"
+        );
+    }
+}
+
+/// REGRESSION: the retired `tm coordinator-tui` stays refused (#1392).
+///
+/// Why: `external_subcommand` makes clap ACCEPT this token at the parse layer,
+/// so the rejection `cli_rejects_removed_coordinator_tui` used to assert there
+/// moves here. The guarantee is unchanged — the invocation still exits with a
+/// usage error — but it is now enforced by the `classify_bare` gate rather than
+/// by the parse failing.
+/// Test: itself.
+#[test]
+fn cli_bare_retired_subcommand_is_not_a_repo() {
+    let token = external_token(&["tm", "coordinator-tui"]);
+    assert_eq!(token, "coordinator-tui");
+    assert!(
+        classify_bare(&token).is_none(),
+        "a retired subcommand must never become a managed run"
+    );
+}
+
+/// A repo-SHAPED token that names no repo surfaces `resolved_url`'s message.
+///
+/// Why: `https://example.com/` passes `looks_like_repo` (it is a URL) but has
+/// no owner/repo path, so it is not a typo and a usage error would be useless.
+/// The remedy belongs in the message `tm register` already writes, inherited
+/// here rather than restated.
+/// Test: itself.
+#[test]
+fn cli_bare_non_repo_url_surfaces_the_descriptive_error() {
+    for (bad, expected) in [
+        ("https://example.com/", "names a host"),
+        (
+            "https://github.com/bobmatnyc/trusty-tools/pull/6441",
+            "points inside a repository",
+        ),
+    ] {
+        let token = external_token(&["tm", bad]);
+        let err = classify_bare(&token)
+            .expect("a URL is repo-shaped, so it is never the typo path")
+            .expect_err("but it does not name a repository");
+        assert!(
+            err.to_string().contains(expected),
+            "rejection of '{bad}' must say '{expected}', got: {err}"
+        );
+    }
+}
+
+/// The rebuilt command reproduces the usage error `origin/main` printed.
+///
+/// Why: this is the load-bearing half of the fallback, and the obvious
+/// alternative silently does nothing. Calling
+/// `Cli::command().allow_external_subcommands(false)` reads the flag back as
+/// `false` and STILL matches `sta` as the external subcommand `sta` — the
+/// derive wires the match path during augmentation, so the flag arrives too
+/// late. Measured, not assumed. Only a fresh `clap::Command` refuses it, which
+/// is why `run_target::without_external_catch_all` rebuilds rather than flips a
+/// flag; this test fails if anyone simplifies it back.
+///
+/// The expected text is `origin/main`'s own output for `tm sta`, captured
+/// before this change:
+///
+/// ```text
+/// error: unrecognized subcommand 'sta'
+///
+///   tip: some similar subcommands exist: 'stop', 'meta', 'statusline', …
+///
+/// Usage: tm [OPTIONS] [COMMAND]
+/// ```
+/// Test: itself.
+#[test]
+fn reject_unknown_subcommand_rebuild_reproduces_claps_error() {
+    let argv = ["tm".to_string(), "sta".to_string()];
+
+    // The mutation that looks equivalent and is not.
+    let flag_flip = Cli::command().allow_external_subcommands(false);
+    assert!(
+        flag_flip.try_get_matches_from(argv.clone()).is_ok(),
+        "if this now ERRORS, clap has changed and the rebuild may be simplifiable"
+    );
+
+    let err = crate::commands::run_target::without_external_catch_all()
+        .try_get_matches_from(argv)
+        .expect_err("an ambiguous prefix must not parse");
+    assert_eq!(err.kind(), clap::error::ErrorKind::InvalidSubcommand);
+
+    let rendered = err.to_string();
+    for fragment in [
+        "unrecognized subcommand 'sta'",
+        "tip: some similar subcommands exist",
+        "'status'",
+        "'start'",
+        "Usage: tm [OPTIONS] [COMMAND]",
+    ] {
+        assert!(
+            rendered.contains(fragment),
+            "the rebuilt error must still say '{fragment}':\n{rendered}"
+        );
+    }
+}
+
+/// The hardcoded rebuild name still matches the derive's own.
+///
+/// Why: `clap::builder::Str` accepts only a `&'static str`, so
+/// `without_external_catch_all` cannot read the name off the source command at
+/// runtime and spells it out instead. This is the guard against that copy
+/// drifting from `#[command(name = ...)]`.
+/// Test: itself.
+#[test]
+fn command_name_matches_the_rebuild() {
+    assert_eq!(
+        Cli::command().get_name(),
+        crate::commands::run_target::CLI_NAME
+    );
+}


### PR DESCRIPTION
Refs #6441.

tm https://github.com/<owner>/<repo> and tm owner/repo now route through the existing tm run path (classify → ensure_managed_checkout → launch) via a clap external_subcommand catch-all gated by register_args::looks_like_repo; a non-repo-shaped unknown token keeps today's "did you mean?" UX byte-identical to main; a non-repo URL surfaces resolved_url's error. Two measured clap findings (pinned by tests): an unambiguous prefix still infers (doc, heal) while an ambiguous one like sta was already exit-2 on main; allow_external_subcommands(false) is a no-op on a derived Command, so reject_unknown_subcommand rebuilds the command instead. Acceptance URL https://github.com/bobmatnyc/mcp-a-protocol is classification-proven by unit test; end-to-end (clone + live session) deferred to live verification after install. Gate line: rung 3; 1 pre-existing failure (#6551, fix in flight on another branch).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools