### PR TITLE
fix(trusty-mpm): tests tear down their tmux sessions and stop scanning the real $HOME

### DIFF
--- a/crates/trusty-mpm/changelog.d/6542-test-tmux-teardown.md
+++ b/crates/trusty-mpm/changelog.d/6542-test-tmux-teardown.md
@@ -1,0 +1,11 @@
+Fixed
+
+- Running `cargo test -p trusty-mpm` no longer leaves a live `tm-<uuid>` tmux
+  session behind per run. The two guided-fallback tests drive
+  `fallback_protected`, which launches a real session in the worktree it
+  provisions; nothing killed it, so 456 accumulated on one machine over five
+  days and exhausted its pseudo-terminal pool. The test-support fixture now
+  claims such a session by its pane's working directory and kills it on drop,
+  panicking assertions included (#6542, refs #6523).
+</content>
+</invoke>

--- a/crates/trusty-mpm/changelog.d/6542-test-tmux-teardown.md
+++ b/crates/trusty-mpm/changelog.d/6542-test-tmux-teardown.md
@@ -7,5 +7,3 @@ Fixed
   days and exhausted its pseudo-terminal pool. The test-support fixture now
   claims such a session by its pane's working directory and kills it on drop,
   panicking assertions included (#6542, refs #6523).
-</content>
-</invoke>

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_b_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_b_tests.rs
@@ -16,6 +16,9 @@ use crate::cli::{AuthAction, Cli, Command, RepairAction, ServicesAction, Sessctl
 use crate::commands::session::{
     compose_session_instructions, compose_session_instructions_with_roster,
 };
+// #6542: teardown for the tmux sessions the guided-fallback tests cause
+// `fallback_protected` to launch.
+use crate::test_support::tmux_session::{FixtureTmuxSessions, ScratchTmuxSession};
 
 #[test]
 fn cli_parses_attach() {
@@ -1734,6 +1737,11 @@ async fn guided_fallback_redirect_success_worktree_not_live_checkout() {
 
     let _repos_root_env = ReposRootEnv::set(repos_root.path());
 
+    // #6542: the fallback launches a REAL tmux session in the worktree it
+    // provisions, and this test never learns its name — the guard claims it by
+    // where its pane sits and kills it on every exit path.
+    let _tmux = fallback_tmux_guard(repos_root.path());
+
     let client = reqwest::Client::new();
     let _result =
         crate::commands::guided::fallback_protected(&client, "http://127.0.0.1:1", live_dir.path())
@@ -1814,6 +1822,10 @@ async fn guided_fallback_prepares_the_session_in_the_worktree_not_the_base_clone
 
     let _repos_root_env = ReposRootEnv::set(&repos_root_path);
 
+    // #6542: same unnamed tmux session as the test above — see
+    // `fallback_tmux_guard`.
+    let _tmux = fallback_tmux_guard(&repos_root_path);
+
     let client = reqwest::Client::new();
     let _result =
         crate::commands::guided::fallback_protected(&client, "http://127.0.0.1:1", live_dir.path())
@@ -1851,6 +1863,92 @@ async fn guided_fallback_prepares_the_session_in_the_worktree_not_the_base_clone
          has no .claude",
         worktree.display()
     );
+}
+
+/// The tmux binary the fallback's session-creation path resolves to.
+///
+/// The guard has to drive the same binary `create_managed_session` did, or it
+/// asks a different tmux server about a session it cannot see.
+fn fallback_tmux_bin() -> String {
+    trusty_mpm::core::tmux::resolve_tmux_binary_or_bare()
+}
+
+/// Kill-on-drop ownership of whatever tmux session the guided fallback launches
+/// under `repos_root` (#6542).
+///
+/// Why: `fallback_protected` provisions a worktree and launches a session named
+/// `tm-<session-uuid truncated>` — a name the test never sees, so
+/// `ScratchTmuxSession` (which owns a name it passed to `new-session`) does not
+/// fit. Before this guard, the two tests below each left one session behind on
+/// every run; 456 accumulated over five days and exhausted the host's
+/// pseudo-terminal pool (#6523).
+/// What: a [`FixtureTmuxSessions`] rooted at the repos-root temp dir, so it
+/// claims exactly the sessions this test's fallback created and nothing a
+/// concurrent suite owns. Construct it BEFORE the `fallback_protected` call —
+/// its snapshot is what separates "new" from "someone else's".
+/// Test: `guided_fallback_leaves_no_tmux_session_behind`.
+fn fallback_tmux_guard(repos_root: &std::path::Path) -> FixtureTmuxSessions {
+    FixtureTmuxSessions::watch(&fallback_tmux_bin(), repos_root)
+}
+
+/// The guided fallback's tmux session does not outlive the test (#6542).
+///
+/// Why: the two tests above assert on the FILESYSTEM — which directory got
+/// `.claude/`, which stayed clean — and both passed while leaking a live tmux
+/// session apiece. Nothing asserted on the session, so nothing noticed.
+/// What: drives the same fixture as
+/// `guided_fallback_prepares_the_session_in_the_worktree_not_the_base_clone`,
+/// then asserts on the SESSION: the fallback must launch one under the fixture
+/// root (otherwise the teardown assertion proves nothing), and dropping the
+/// guard must leave none alive.
+/// Test: this is the test. RED before this commit: a bare run of the two tests
+/// above left `tm-0c31ecd7-bb7e-4389-b` and `tm-b0561168-a6ca-44d9-b` behind,
+/// their panes rooted in the deleted fixture worktrees.
+#[tokio::test]
+#[serial_test::serial]
+async fn guided_fallback_leaves_no_tmux_session_behind() {
+    let tmux = fallback_tmux_bin();
+    if !ScratchTmuxSession::tmux_available(&tmux) {
+        eprintln!("guided_fallback_leaves_no_tmux_session_behind: tmux unavailable, skipping");
+        return;
+    }
+
+    let origin = "https://github.com/test-owner-6542/test-repo-6542.git";
+    let repos_root = tempfile::tempdir().unwrap();
+    let repos_root_path = repos_root.path().canonicalize().unwrap();
+    let base = repos_root_path
+        .join("test-owner-6542")
+        .join("test-repo-6542");
+    fallback_git_repo(&base);
+    fallback_git_remote(&base, origin);
+
+    let live_dir = tempfile::tempdir().unwrap();
+    fallback_git_repo(live_dir.path());
+    fallback_git_remote(live_dir.path(), origin);
+
+    let _repos_root_env = ReposRootEnv::set(&repos_root_path);
+    let guard = fallback_tmux_guard(&repos_root_path);
+
+    let client = reqwest::Client::new();
+    let _result =
+        crate::commands::guided::fallback_protected(&client, "http://127.0.0.1:1", live_dir.path())
+            .await;
+
+    let spawned = guard.spawned();
+    assert!(
+        !spawned.is_empty(),
+        "fixture precondition: the fallback must have launched a tmux session \
+         under {}, or the teardown assertion below proves nothing",
+        repos_root_path.display()
+    );
+    drop(guard);
+    for name in &spawned {
+        assert!(
+            !ScratchTmuxSession::exists(&tmux, name),
+            "session '{name}' outlived the test — this is #6542, the tm-<uuid> \
+             pty leak tracked in #6523"
+        );
+    }
 }
 
 /// A git repository with one empty commit at `path`, created or asserted.

--- a/crates/trusty-mpm/src/daemon/rpc/managed_tests.rs
+++ b/crates/trusty-mpm/src/daemon/rpc/managed_tests.rs
@@ -962,12 +962,85 @@ async fn managed_prune_rejects_an_unparseable_invoking_session() {
     assert_parity("mpm.managed.prune (bad invoker)", &http, &rpc);
 }
 
+/// Pin `TRUSTY_MPM_WORKSPACE_ROOT` at an empty fixture dir for one test (#6551).
+///
+/// Why: `prune_worktrees_core` and `reconcile_worktrees_core` resolve the
+/// worktree root through `TrustyToolsConfig::load()` on EVERY call, and with the
+/// variable unset that resolves to `$HOME/trusty-mpm-projects` — the operator's
+/// real fleet. Two consequences, both observed: the two transports enumerate
+/// ~200 real worktrees instead of the `TempDir` fixture, and a sibling test that
+/// sets or clears this same process-global variable between the HTTP call and
+/// the RPC call splits the parity comparison. Pinning it removes both, because
+/// the two calls then read one value that names an empty directory.
+///
+/// What: takes the crate-wide `env_test_lock` and sets the variable, restoring
+/// the previous value (or removing it) on drop, unwinding panics included.
+/// BOTH guards are needed and they cover different populations, exactly as
+/// `prune::tests::prune_spares_a_stopped_records_workspace` records:
+/// `env_test_lock` serialises the env-precedence tests, `#[serial_test::serial]`
+/// serialises `connectors::tm_tests`, which mutates this variable under
+/// `serial` alone. The lock is held across the awaited route calls on purpose —
+/// releasing it earlier is the race.
+///
+/// `#[serial_test::file_serial]` is deliberately NOT used: the pinned resource
+/// is a process environment variable, so under `cargo nextest`'s
+/// process-per-test model (#4162) each test already has its own copy and there
+/// is nothing shared across processes to serialise.
+///
+/// Test: `managed_prune_worktrees_enumerates_only_the_pinned_workspace_root`.
+struct WorkspaceRootEnv {
+    _lock: std::sync::MutexGuard<'static, ()>,
+    prev: Option<std::ffi::OsString>,
+}
+
+impl WorkspaceRootEnv {
+    fn pin(root: &std::path::Path) -> Self {
+        let lock = crate::core::trusty_tools_config::env_test_lock();
+        let key = crate::core::trusty_tools_config::WORKSPACE_ROOT_ENV;
+        let prev = std::env::var_os(key);
+        // SAFETY: the crate-wide `env_test_lock` is held for this value's whole
+        // lifetime, and every other mutator of this variable takes it too.
+        unsafe { std::env::set_var(key, root) };
+        Self { _lock: lock, prev }
+    }
+}
+
+impl Drop for WorkspaceRootEnv {
+    fn drop(&mut self) {
+        let key = crate::core::trusty_tools_config::WORKSPACE_ROOT_ENV;
+        // SAFETY: `_lock` is still held — it is dropped after this field.
+        unsafe {
+            match self.prev.take() {
+                Some(v) => std::env::set_var(key, v),
+                None => std::env::remove_var(key),
+            }
+        }
+    }
+}
+
+/// Every path a route reports, across the three path-carrying keys.
+fn reported_paths(body: &Value) -> Vec<String> {
+    ["paths", "owner_unknown_paths", "agent_owned_paths"]
+        .iter()
+        .filter_map(|key| body.get(*key).and_then(|v| v.as_array()))
+        .flatten()
+        .filter_map(|v| v.as_str().map(str::to_owned))
+        .collect()
+}
+
 /// The safe defaults survive the transport: an RPC `prune-worktrees` with no
 /// flags previews rather than deleting, exactly as an empty HTTP body does
 /// (#4091, #2919).
+///
+/// #6551: pinned to a fixture workspace root. Unpinned, the two transports read
+/// the ambient `$HOME` at different instants and `assert_parity` compares one
+/// side's real worktree inventory against the other's.
+#[serial_test::serial]
 #[tokio::test]
 async fn managed_prune_worktrees_parity_defaults_to_a_preview() {
     let (state, _dir) = test_state().await;
+    let workspace = tempfile::tempdir().expect("workspace root");
+    let _env = WorkspaceRootEnv::pin(workspace.path());
     let http = http_call(
         http_router(Arc::clone(&state)),
         Method::POST,
@@ -990,9 +1063,69 @@ async fn managed_prune_worktrees_parity_defaults_to_a_preview() {
     assert_parity("mpm.managed.prune_worktrees", &http, &rpc);
 }
 
+/// The prune preview reports the pinned workspace root and nothing outside it
+/// (#6551).
+///
+/// Why: `managed_prune_worktrees_parity_defaults_to_a_preview` compares the two
+/// transports to each other, so it stays green whenever they agree — including
+/// when they agree on the operator's real `~/trusty-mpm-projects`. This asserts
+/// on WHICH root was scanned, which is the thing that was wrong.
+/// What: pins the root at a `GitWorktreeFixture` holding one reclaimable
+/// orphaned worktree, then asserts every reported path is inside it. Seeding a
+/// real, reclaimable worktree is what stops an empty result from passing for
+/// isolation — the same fixture `prune::tests` uses.
+/// Test: this is the test. RED without `WorkspaceRootEnv::pin`: the preview
+/// enumerates the real home's worktrees, none of which is under the fixture.
+#[serial_test::serial]
+#[tokio::test]
+async fn managed_prune_worktrees_enumerates_only_the_pinned_workspace_root() {
+    use crate::session_manager::worktree_git_fixture::GitWorktreeFixture;
+
+    let (state, _dir) = test_state().await;
+    let fx = GitWorktreeFixture::new();
+    let orphan = fx.add_worktree("orphaned-6551");
+    GitWorktreeFixture::stamp_reclaimable_sentinel(&orphan);
+    let root = fx
+        .repos_root
+        .canonicalize()
+        .unwrap_or_else(|_| fx.repos_root.clone());
+
+    let _env = WorkspaceRootEnv::pin(&root);
+    let http = http_call(
+        http_router(Arc::clone(&state)),
+        Method::POST,
+        "/api/v1/sessions/managed/prune-worktrees",
+        Some(json!({})),
+    )
+    .await;
+    assert_eq!(http.status, 200);
+    let body = http.json.as_ref().expect("prune-worktrees returns json");
+    let paths = reported_paths(body);
+    assert!(
+        !paths.is_empty(),
+        "the seeded orphan at {} must be reported, or this proves nothing: {body}",
+        orphan.display()
+    );
+    let stray: Vec<&String> = paths
+        .iter()
+        .filter(|p| !std::path::Path::new(p).starts_with(&root))
+        .collect();
+    assert!(
+        stray.is_empty(),
+        "#6551: the preview scanned outside the pinned workspace root {} — \
+         these paths come from the ambient $HOME: {stray:?}",
+        root.display()
+    );
+}
+
+/// #6551: pinned for the same reason as the prune parity test above —
+/// `reconcile_worktrees_core` resolves the same ambient workspace root.
+#[serial_test::serial]
 #[tokio::test]
 async fn managed_reconcile_worktrees_parity() {
     let (state, _dir) = test_state().await;
+    let workspace = tempfile::tempdir().expect("workspace root");
+    let _env = WorkspaceRootEnv::pin(workspace.path());
     let http = http_call(
         http_router(Arc::clone(&state)),
         Method::GET,

--- a/crates/trusty-mpm/src/test_tmux_session.rs
+++ b/crates/trusty-mpm/src/test_tmux_session.rs
@@ -199,16 +199,42 @@ impl ScratchTmuxSession {
     /// machine fails until the panes are reaped. That is a machine fault, not a
     /// fixture one; no test-side change creates a pty.
     pub(crate) fn spawn(tmux_bin: &str, name: &str, pane_command: &str) -> Self {
+        Self::spawn_in(tmux_bin, name, None, pane_command)
+    }
+
+    /// [`ScratchTmuxSession::spawn`] with the pane's working directory pinned.
+    ///
+    /// Why: [`FixtureTmuxSessions`] claims a session by where its pane sits, so
+    /// its own tests need to place a session inside — and outside — a fixture
+    /// root on purpose (#6542). Every other caller wants the inherited cwd and
+    /// keeps [`ScratchTmuxSession::spawn`].
+    /// What: adds `-c <cwd>` when `cwd` is `Some`; otherwise identical.
+    /// Test: [`tests::a_session_opened_under_the_root_is_killed_on_drop`].
+    pub(crate) fn spawn_in(
+        tmux_bin: &str,
+        name: &str,
+        cwd: Option<&std::path::Path>,
+        pane_command: &str,
+    ) -> Self {
         // #6116: reap what an earlier hard-killed run leaked, before adding to
         // the namespace. Once per process, mirroring `test_support`'s
         // `sweep_stale_test_dirs`.
         SWEEP_ONCE.call_once(|| sweep_stale_reserved_sessions(tmux_bin));
+        let mut args: Vec<String> = ["new-session", "-d", "-s", name]
+            .iter()
+            .map(|s| (*s).to_string())
+            .collect();
+        if let Some(dir) = cwd {
+            args.push("-c".to_string());
+            args.push(dir.to_string_lossy().into_owned());
+        }
+        args.push(pane_command.to_string());
         // #6523: capture tmux's stderr instead of letting it through. `.status()`
         // sent the real cause to the test binary's stderr, unattached to the
         // panic, so five simultaneous failures each read only `exit status: 1`
         // and got misattributed to nested tmux.
         let out = Command::new(tmux_bin)
-            .args(["new-session", "-d", "-s", name, pane_command])
+            .args(&args)
             .output()
             .unwrap_or_else(|e| panic!("spawn `{tmux_bin} new-session -s {name}`: {e}"));
         assert!(
@@ -258,6 +284,126 @@ impl Drop for ScratchTmuxSession {
         let _ = Command::new(&self.tmux_bin)
             .args(["kill-session", "-t", &format!("={}", self.name)])
             .output();
+    }
+}
+
+/// Live session names, or an empty set when tmux will not answer.
+fn live_session_names(tmux_bin: &str) -> std::collections::BTreeSet<String> {
+    let Ok(out) = Command::new(tmux_bin)
+        .args(["list-sessions", "-F", "#{session_name}"])
+        .output()
+    else {
+        return std::collections::BTreeSet::new();
+    };
+    if !out.status.success() {
+        return std::collections::BTreeSet::new();
+    }
+    String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .map(|l| l.trim_end().to_string())
+        .filter(|l| !l.is_empty())
+        .collect()
+}
+
+/// Names of live sessions holding at least one pane whose working directory is
+/// inside `root`.
+///
+/// What: reads `<session-name>\t<pane-path>` from `list-panes -a`. A line that
+/// does not split on the tab is SKIPPED, never selected — an unparseable line
+/// leaves a session alive rather than killing one this guard cannot identify.
+/// `Path::starts_with` compares whole components, so `/tmp/ab` does not match a
+/// pane sitting in `/tmp/abc`.
+/// Test: [`tests::a_session_outside_the_root_is_left_alone`].
+fn sessions_with_pane_under(
+    tmux_bin: &str,
+    root: &std::path::Path,
+) -> std::collections::BTreeSet<String> {
+    let Ok(out) = Command::new(tmux_bin)
+        .args([
+            "list-panes",
+            "-a",
+            "-F",
+            "#{session_name}\t#{pane_current_path}",
+        ])
+        .output()
+    else {
+        return std::collections::BTreeSet::new();
+    };
+    if !out.status.success() {
+        return std::collections::BTreeSet::new();
+    }
+    String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .filter_map(|line| line.trim_end().split_once('\t'))
+        .filter(|(_, pane_path)| std::path::Path::new(pane_path).starts_with(root))
+        .map(|(name, _)| name.to_string())
+        .collect()
+}
+
+/// Sessions the CODE UNDER TEST created inside a fixture directory, killed when
+/// this value drops (#6542).
+///
+/// Why: [`ScratchTmuxSession`] guards a session the TEST spawns and therefore
+/// names. The guided-fallback tests spawn none — they call
+/// `commands::guided::fallback_protected`, which provisions a worktree and
+/// launches a session whose name is derived from a session uuid the test never
+/// sees. Two such sessions survived every run of `tests_behavior_b_tests`; 456
+/// accumulated on the owner's machine over five days and exhausted its
+/// pseudo-terminal pool (#6523).
+///
+/// What: snapshots the live session names at construction, and on drop kills
+/// every session that is BOTH absent from that snapshot AND holding a pane
+/// whose working directory is inside `root`. Both conditions are load-bearing —
+/// the snapshot alone would claim a session a concurrently running suite
+/// created, and the path alone would claim one this process created before the
+/// guard existed. `root` is canonicalized at construction because tmux reports
+/// `/private/var/…` where a macOS `TempDir` hands back `/var/…`.
+///
+/// What `Drop` cannot cover is the same gap [`ScratchTmuxSession`]'s module docs
+/// describe: a SIGKILL or an aborted run ends the process without unwinding.
+/// The sessions this guard reaps are named by the daemon's ordinary
+/// `tm-<uuid>` scheme, not the reserved test namespace, so
+/// [`sweep_stale_reserved_sessions`] does not reap them on the next run either.
+///
+/// Test: [`tests::a_session_opened_under_the_root_is_killed_on_drop`],
+/// [`tests::a_session_outside_the_root_is_left_alone`],
+/// [`tests::a_session_predating_the_guard_is_left_alone`].
+pub(crate) struct FixtureTmuxSessions {
+    tmux_bin: String,
+    root: std::path::PathBuf,
+    preexisting: std::collections::BTreeSet<String>,
+}
+
+impl FixtureTmuxSessions {
+    /// Start owning any session that appears under `root` from now on.
+    pub(crate) fn watch(tmux_bin: &str, root: &std::path::Path) -> Self {
+        Self {
+            tmux_bin: tmux_bin.to_string(),
+            root: root.canonicalize().unwrap_or_else(|_| root.to_path_buf()),
+            preexisting: live_session_names(tmux_bin),
+        }
+    }
+
+    /// The sessions this guard currently owns — new since [`Self::watch`] and
+    /// rooted under the fixture directory.
+    pub(crate) fn spawned(&self) -> Vec<String> {
+        sessions_with_pane_under(&self.tmux_bin, &self.root)
+            .into_iter()
+            .filter(|name| !self.preexisting.contains(name))
+            .collect()
+    }
+}
+
+impl Drop for FixtureTmuxSessions {
+    fn drop(&mut self) {
+        for name in self.spawned() {
+            eprintln!("test-support: killing fixture tmux session '{name}' (#6542)");
+            // Best-effort: `Drop` runs during unwinding, where a panic would
+            // abort the process and bury the original failure.
+            let _ = Command::new(&self.tmux_bin)
+                .args(["kill-session", "-t", &format!("={name}")])
+                .output();
+        }
     }
 }
 
@@ -399,6 +545,85 @@ not-an-epoch tm-xtest-garbage-01
              by someone else; a bare `-t` target would have killed it"
         );
         drop(sibling);
+    }
+
+    /// The defect #6542 reports, inverted: a session the test did not name,
+    /// sitting inside the fixture root, must be gone once the guard drops.
+    ///
+    /// The `owner` guard is a safety net, not the subject — if
+    /// [`FixtureTmuxSessions`] were broken, this test must still not leak.
+    #[test]
+    fn a_session_opened_under_the_root_is_killed_on_drop() {
+        if !ScratchTmuxSession::tmux_available(TMUX) {
+            eprintln!("tmux not available; skipping");
+            return;
+        }
+        let root = tempfile::tempdir().expect("fixture root");
+        let name = scratch_name("under");
+        let guard = FixtureTmuxSessions::watch(TMUX, root.path());
+        let owner = ScratchTmuxSession::spawn_in(TMUX, &name, Some(root.path()), "sh");
+        assert_eq!(
+            guard.spawned(),
+            vec![name.clone()],
+            "the guard must claim the session that appeared under its root"
+        );
+        drop(guard);
+        assert!(
+            !ScratchTmuxSession::exists(TMUX, &name),
+            "session '{name}' survived the guard — this is #6542, where the \
+             guided-fallback tests left one tm-<uuid> session behind per run"
+        );
+        drop(owner);
+    }
+
+    /// The guard's claim is bounded by the fixture root: a session that a
+    /// concurrent suite opens elsewhere is neither claimed nor killed.
+    #[test]
+    fn a_session_outside_the_root_is_left_alone() {
+        if !ScratchTmuxSession::tmux_available(TMUX) {
+            eprintln!("tmux not available; skipping");
+            return;
+        }
+        let root = tempfile::tempdir().expect("fixture root");
+        let elsewhere = tempfile::tempdir().expect("unrelated dir");
+        let name = scratch_name("outside");
+        let guard = FixtureTmuxSessions::watch(TMUX, root.path());
+        let sibling = ScratchTmuxSession::spawn_in(TMUX, &name, Some(elsewhere.path()), "sh");
+        assert!(
+            guard.spawned().is_empty(),
+            "a session outside the fixture root is not this guard's to claim"
+        );
+        drop(guard);
+        assert!(
+            ScratchTmuxSession::exists(TMUX, &name),
+            "'{name}' sits outside the fixture root and belongs to someone else"
+        );
+        drop(sibling);
+    }
+
+    /// A session already live when the guard is created is not the guard's,
+    /// even when it sits inside the root — the snapshot is what makes the
+    /// ownership claim honest.
+    #[test]
+    fn a_session_predating_the_guard_is_left_alone() {
+        if !ScratchTmuxSession::tmux_available(TMUX) {
+            eprintln!("tmux not available; skipping");
+            return;
+        }
+        let root = tempfile::tempdir().expect("fixture root");
+        let name = scratch_name("predates");
+        let earlier = ScratchTmuxSession::spawn_in(TMUX, &name, Some(root.path()), "sh");
+        let guard = FixtureTmuxSessions::watch(TMUX, root.path());
+        assert!(
+            guard.spawned().is_empty(),
+            "a session that predates the guard is not new, so not the guard's"
+        );
+        drop(guard);
+        assert!(
+            ScratchTmuxSession::exists(TMUX, &name),
+            "'{name}' predates the guard and must survive it"
+        );
+        drop(earlier);
     }
 
     /// A guard is only handed out for a session that was actually created, so


### PR DESCRIPTION
Refs #6542, Refs #6551.

The guided-fallback tests leaked two tmux sessions per run (the pty exhaustion behind #6523); a new `FixtureTmuxSessions` RAII guard (src/test_tmux_session.rs) claims sessions absent from a construction-time snapshot AND rooted in the fixture dir, and kills them on Drop including panic paths. The managed_prune parity tests enumerated ~190 real worktrees from the ambient $HOME; a `WorkspaceRootEnv` pin (env_test_lock + TRUSTY_MPM_WORKSPACE_ROOT + #[serial]) confines them. Note: the changelog fragment exists because the fragment gate classifies `test_tmux_session.rs` as production source (`test_` prefix, not `_tests` suffix). Gate line: rung 2 — leak proven red-before (2 sessions) / green-after 10×; #6551 revert-repro enumerated the real tree.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools