### PR TITLE
fix(trusty-search): content-hash the overflow rescan; collapse duplicate chunk ids

### DIFF
--- a/crates/trusty-search/changelog.d/6570-bounded-overflow-rescan.md
+++ b/crates/trusty-search/changelog.d/6570-bounded-overflow-rescan.md
@@ -1,0 +1,6 @@
+Fixed
+
+- An FSEvents-overflow rescan no longer re-parses and re-commits the whole corpus when nothing changed. Every walked file is still read and fingerprinted, so full-tree coverage is unchanged, but a file whose content matches what the index already holds now skips the tree-sitter parse, the embed, and the redb commit. Observed before the fix: 22 overflow passes in 48h, each reporting 17,284 files reindexed and 183,348 chunks committed on an untouched tree (#6570).
+  - The fingerprint cache is warmed from the durable corpus when the process has not populated it, so the first overflow after a daemon restart is cheap too.
+  - The daemon's own colocated `.trusty-search/` storage joins the walker's skip list. It sits inside the watched root and is rewritten by every commit, and the watcher's per-event filter reads that list and never consults `.gitignore`.
+  - The reconcile log line adds `files_unchanged`, which is what says whether an overflow found real work.

--- a/crates/trusty-search/changelog.d/6571-duplicate-chunk-ids.md
+++ b/crates/trusty-search/changelog.d/6571-duplicate-chunk-ids.md
@@ -1,0 +1,6 @@
+Fixed
+
+- A file whose chunks collide on id is indexed and searchable again. `make_chunk_id` omits the end line, so a minified JS bundle — one line, many single-letter declarations — produced repeated ids. `UsearchStore::upsert_batch` resolved one key for all of them, added the first, failed every later one with usearch's "Duplicate keys not allowed in high-level wrappers", then rolled back the id-to-key mapping the successful add had installed, leaving a vector nothing could reach (#6571).
+  - `chunk_ast` now drops a chunk whose id an earlier chunk in the same file already claimed, so the duplicates are never embedded.
+  - `upsert_batch` collapses duplicate ids at the boundary that owns the one-vector-per-id contract.
+  - The skip warning reports the error the add actually returned instead of asserting a NaN or zero vector it did not observe.

--- a/crates/trusty-search/src/core/chunker/ast.rs
+++ b/crates/trusty-search/src/core/chunker/ast.rs
@@ -113,10 +113,56 @@ pub fn chunk_ast(file: &str, content: &str) -> (Vec<RawChunk>, Vec<RawEntity>) {
     }
 
     // Split oversized chunks; produces sub-chunks with `parent_chunk_id`.
-    let split = split_oversized(chunks);
+    // #6571: then collapse id collisions before anything downstream keys on them.
+    let split = dedupe_chunk_ids(file, split_oversized(chunks));
 
     // Entities (single pass over the same tree).
     let entities = extract_entities(&tree, src, file, lang);
 
     (split, entities)
+}
+
+/// Drop chunks whose id a preceding chunk in the same file already claimed.
+///
+/// Why (#6571): a chunk's id is the primary key in every downstream layer — the
+/// redb corpus, the BM25 document map, the HNSW key map, and `IndexedFiles`.
+/// `walk::make_chunk_id` builds a named chunk's id from
+/// `{file}::{kind}::{name}::{start_line}` and omits the end line, so two
+/// declarations that share a name and a start line share an id. A minified
+/// JavaScript bundle is one long line of single-letter functions and hits this
+/// constantly: `app/hiring/static/assets/index.js` produced 225 distinct ids for
+/// its declarations and 209 surplus chunks per pass carrying an id already used.
+///
+/// Every layer but one absorbed that quietly by overwriting. `UsearchStore` did
+/// not: it resolved one usearch key for all occurrences of an id, added the
+/// first, and then failed every later `add` with "Duplicate keys not allowed in
+/// high-level wrappers" — after which the failure rollback removed the id→key
+/// mapping the successful add had just installed. The vector stayed in the graph
+/// with nothing pointing at it and the file never became searchable.
+///
+/// What: keeps the FIRST chunk for each id and drops the rest. First rather than
+/// last because a sub-chunk's `parent_chunk_id` names the parent that preceded
+/// it, so keeping the earlier occurrence keeps that reference resolvable. The
+/// dropped chunks are duplicates by id only, not by content — the underlying id
+/// scheme cannot tell them apart, and repairing that is a corpus-wide key change
+/// this does not attempt.
+///
+/// Test: `duplicate_chunk_ids_are_collapsed` in `core/chunker/tests.rs`.
+fn dedupe_chunk_ids(file: &str, chunks: Vec<RawChunk>) -> Vec<RawChunk> {
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let before = chunks.len();
+    let out: Vec<RawChunk> = chunks
+        .into_iter()
+        .filter(|c| seen.insert(c.id.clone()))
+        .collect();
+    let dropped = before - out.len();
+    if dropped > 0 {
+        tracing::debug!(
+            %file,
+            dropped,
+            kept = out.len(),
+            "chunker: dropped chunks whose id collided with an earlier chunk in the same file",
+        );
+    }
+    out
 }

--- a/crates/trusty-search/src/core/chunker/tests.rs
+++ b/crates/trusty-search/src/core/chunker/tests.rs
@@ -1221,3 +1221,34 @@ fn test_deeply_nested_modules_does_not_crash() {
         entities.len()
     );
 }
+
+/// Why (#6571): `walk::make_chunk_id` builds a named chunk's id from
+/// `{file}::{kind}::{name}::{start_line}` and omits the end line. A minified
+/// JavaScript bundle is one long line, so every declaration in it shares a start
+/// line and any repeated name collapses onto one id. A chunk id is the primary
+/// key in the redb corpus, the BM25 document map, the HNSW key map, and
+/// `IndexedFiles`; two chunks under one id is a corpus defect, and in the vector
+/// store it orphaned a live vector and left the file unsearchable.
+///
+/// Pre-fix `chunk_ast` returned both `e` chunks and this assertion failed.
+#[test]
+fn duplicate_chunk_ids_are_collapsed() {
+    // One line, two `function e(...)` declarations — the shape a bundler emits.
+    let minified = "function e(a){return a+1}function e(b){return b+2}function q(c){return c}\n";
+    let (chunks, _entities) = chunk_ast("assets/index.js", minified);
+
+    let mut ids: Vec<&str> = chunks.iter().map(|c| c.id.as_str()).collect();
+    ids.sort_unstable();
+    let mut distinct = ids.clone();
+    distinct.dedup();
+    assert_eq!(
+        ids.len(),
+        distinct.len(),
+        "chunk_ast must never emit two chunks under one id; got {ids:?}"
+    );
+    // The collision is real in this fixture — otherwise the test proves nothing.
+    assert!(
+        chunks.iter().any(|c| c.id.contains("::e::")),
+        "the fixture must produce the colliding `e` chunk; got {ids:?}"
+    );
+}

--- a/crates/trusty-search/src/core/store/tests.rs
+++ b/crates/trusty-search/src/core/store/tests.rs
@@ -258,6 +258,54 @@ async fn test_upsert_batch_isolates_bad_vector() {
     assert_eq!(store.len().await.unwrap(), 4);
 }
 
+/// Why (#6571): a batch that named the same chunk id twice used to add the
+/// first occurrence, fail every later one with usearch's "Duplicate keys not
+/// allowed in high-level wrappers", and then let the failure-rollback delete the
+/// id→key mapping the successful add had installed. The vector stayed in the
+/// graph with nothing pointing at it, so the chunk was permanently unsearchable
+/// and every subsequent reindex re-computed and re-discarded it. Observed live
+/// on a minified bundle: 225 distinct ids, 209 surplus chunks skipped per pass,
+/// 2,299 warnings across 11 passes in 48h.
+///
+/// Pre-fix this test failed on the `search` assertion — `dup` resolved to
+/// nothing.
+#[tokio::test]
+async fn test_upsert_batch_collapses_duplicate_ids() {
+    let store = UsearchStore::new(4).expect("store init");
+    // `dup` appears three times, the way `chunk_ast` emitted it for a one-line
+    // bundle whose declarations all shared a name and a start line.
+    let items: Vec<(String, Vec<f32>)> = vec![
+        ("keep-a".to_string(), vec![1.0, 0.0, 0.0, 0.0]),
+        ("dup".to_string(), vec![0.0, 1.0, 0.0, 0.0]),
+        ("dup".to_string(), vec![0.0, 0.0, 1.0, 0.0]),
+        ("dup".to_string(), vec![0.0, 0.0, 0.0, 1.0]),
+        ("keep-b".to_string(), vec![1.0, 1.0, 0.0, 0.0]),
+    ];
+    store
+        .upsert_batch(&items)
+        .await
+        .expect("a batch carrying a duplicate id must not fail");
+
+    assert_eq!(
+        store.len().await.unwrap(),
+        3,
+        "three distinct ids means three vectors, not five adds and two orphans"
+    );
+    // The surviving `dup` vector must be the LAST one sent — upsert semantics.
+    let hits = store.search(&[0.0, 0.0, 0.0, 1.0], 1).await.unwrap();
+    assert_eq!(
+        hits[0].chunk_id, "dup",
+        "the duplicated id must resolve, not be rolled back into an orphan"
+    );
+    for (id, dir) in [
+        ("keep-a", [1.0f32, 0.0, 0.0, 0.0]),
+        ("keep-b", [1.0, 1.0, 0.0, 0.0]),
+    ] {
+        let hits = store.search(&dir, 1).await.unwrap();
+        assert_eq!(hits[0].chunk_id, id, "{id} must be unaffected");
+    }
+}
+
 #[tokio::test]
 async fn test_upsert_batch_all_bad_vectors_errors() {
     // When *every* vector is bad it's a systemic failure, not isolated

--- a/crates/trusty-search/src/core/store/usearch_impl.rs
+++ b/crates/trusty-search/src/core/store/usearch_impl.rs
@@ -16,7 +16,9 @@ use async_trait::async_trait;
 use super::types::StagedSwapOutcome;
 use super::types::VectorHit;
 use super::types::VectorStore;
-use super::usearch_store::{hnsw_max_elements, validate_embedding, UsearchStore};
+use super::usearch_store::{
+    dedupe_last_by_id, hnsw_max_elements, validate_embedding, UsearchStore,
+};
 
 #[async_trait]
 impl VectorStore for UsearchStore {
@@ -365,11 +367,20 @@ impl VectorStore for UsearchStore {
         if items.is_empty() {
             return Ok(());
         }
+        // #6571: one vector per chunk id is this store's contract, and a batch
+        // carrying an id twice used to break it. Both occurrences resolved to
+        // the same usearch key; the first `add` landed and every later one
+        // failed with "Duplicate keys not allowed in high-level wrappers", after
+        // which the failure rollback deleted the id→key mapping the successful
+        // add had installed — orphaning a live vector and making the file
+        // unsearchable. Collapsing here keeps the contract at the boundary that
+        // enforces it, whatever the caller sends.
+        let items: Vec<(&str, &[f32])> = dedupe_last_by_id(items);
         // Promote view → mutable on first write. No-op when already mutable.
         // Done before any other work so we never half-commit against a view.
         self.ensure_mutable().await?;
         // Phase 1: validate dims up front so we don't half-commit on a bad batch.
-        for (_, v) in items {
+        for (_, v) in &items {
             if v.len() != self.dim {
                 return Err(anyhow!(
                     "embedding dim mismatch: got {}, expected {}",
@@ -386,13 +397,13 @@ impl VectorStore for UsearchStore {
             let mut id_map = self.id_to_key.write().await;
             let mut key_map = self.key_to_id.write().await;
             let mut out = Vec::with_capacity(items.len());
-            for (id, _) in items {
-                let key = if let Some(&k) = id_map.get(id.as_str()) {
+            for (id, _) in &items {
+                let key = if let Some(&k) = id_map.get(*id) {
                     k
                 } else {
                     let k = self.next_key.fetch_add(1, Ordering::Relaxed);
-                    id_map.insert(id.clone(), k);
-                    key_map.insert(k, id.clone());
+                    id_map.insert((*id).to_string(), k);
+                    key_map.insert(k, (*id).to_string());
                     k
                 };
                 out.push(key);
@@ -455,15 +466,16 @@ impl VectorStore for UsearchStore {
         // try (and fail) to resolve.
         let mut failed: Vec<(String, String)> = Vec::new();
         for (key, (id, embedding)) in resolved_keys.iter().zip(items.iter()) {
+            let id = *id;
             // Screen the vector first: a NaN/zero vector is not reliably
             // rejected by usearch's `add`, but it poisons cosine search if it
             // lands in the graph. Catching it here keeps the index clean.
             if let Err(reason) = validate_embedding(embedding) {
-                failed.push((id.clone(), format!("embedding {reason}")));
+                failed.push((id.to_string(), format!("embedding {reason}")));
                 continue;
             }
             if let Err(e) = index.add(*key, embedding) {
-                failed.push((id.clone(), e.to_string()));
+                failed.push((id.to_string(), e.to_string()));
             }
         }
         // The graph was mutated above (removes and/or adds attempted) — mark
@@ -494,11 +506,11 @@ impl VectorStore for UsearchStore {
             for (id, key) in resolved_keys
                 .iter()
                 .zip(items.iter())
-                .filter(|(_, (id, _))| failed_ids.contains(id.as_str()))
-                .map(|(key, (id, _))| (id, key))
+                .filter(|(_, (id, _))| failed_ids.contains(id))
+                .map(|(key, (id, _))| (*id, key))
             {
-                if !existing.contains(key) && id_map.get(id.as_str()) == Some(key) {
-                    id_map.remove(id.as_str());
+                if !existing.contains(key) && id_map.get(id) == Some(key) {
+                    id_map.remove(id);
                     key_map.remove(key);
                 }
             }
@@ -506,9 +518,15 @@ impl VectorStore for UsearchStore {
 
         let succeeded = items.len() - failed.len();
         for (id, err) in &failed {
+            // #6571: report the error the add actually returned. This line used
+            // to append "likely a NaN or zero embedding vector" to every
+            // failure, which sent #6571 after an embedder defect for a batch
+            // whose real error text was "Duplicate keys not allowed in
+            // high-level wrappers". A degenerate vector already arrives here
+            // with its own reason from `validate_embedding`.
             tracing::warn!(
-                "usearch upsert_batch: skipped chunk '{id}' — add failed ({err}); \
-                 likely a NaN or zero embedding vector. The rest of the batch was indexed."
+                "usearch upsert_batch: skipped chunk '{id}' — add failed ({err}). \
+                 The rest of the batch was indexed."
             );
         }
 

--- a/crates/trusty-search/src/core/store/usearch_store.rs
+++ b/crates/trusty-search/src/core/store/usearch_store.rs
@@ -262,6 +262,43 @@ pub(super) fn validate_embedding(v: &[f32]) -> std::result::Result<(), &'static 
     Ok(())
 }
 
+/// Collapse a batch to one entry per chunk id, keeping the last occurrence.
+///
+/// Why (#6571): this store holds one vector per chunk id, and `upsert_batch`
+/// assumed its input already did. A batch carrying an id twice resolved one
+/// usearch key for both, added the first, and failed the second with usearch's
+/// "Duplicate keys not allowed in high-level wrappers" — whereupon the
+/// failure-rollback path removed the id→key mapping the successful add had just
+/// installed, leaving a vector in the graph that nothing could reach. A minified
+/// JS bundle reached this every reindex: `walk::make_chunk_id` omits the end
+/// line, so a one-line bundle's many `function e(…)` declarations all share the
+/// id `…/index.js::Function::e::1`.
+///
+/// What: last occurrence wins, matching upsert semantics — a caller sending the
+/// same id twice means the later vector. Output order follows the position of
+/// each id's surviving occurrence, so a batch with no duplicates comes back in
+/// its original order and pays only one hash pass.
+///
+/// Test: `tests::test_upsert_batch_collapses_duplicate_ids`.
+pub(super) fn dedupe_last_by_id(items: &[(String, Vec<f32>)]) -> Vec<(&str, &[f32])> {
+    let mut last_at: HashMap<&str, usize> = HashMap::with_capacity(items.len());
+    for (i, (id, _)) in items.iter().enumerate() {
+        last_at.insert(id.as_str(), i);
+    }
+    if last_at.len() == items.len() {
+        return items
+            .iter()
+            .map(|(id, v)| (id.as_str(), v.as_slice()))
+            .collect();
+    }
+    items
+        .iter()
+        .enumerate()
+        .filter(|(i, (id, _))| last_at.get(id.as_str()) == Some(i))
+        .map(|(_, (id, v))| (id.as_str(), v.as_slice()))
+        .collect()
+}
+
 /// `UsearchStore`: usearch HNSW index wrapped in `Arc<RwLock<>>` for concurrent reads.
 ///
 /// Why: The HNSW graph is shared across many concurrent search requests; reader-priority

--- a/crates/trusty-search/src/service/reindex/hash.rs
+++ b/crates/trusty-search/src/service/reindex/hash.rs
@@ -47,7 +47,7 @@ pub(super) fn file_hashes() -> &'static DashMap<IndexId, Arc<DashMap<PathBuf, St
 /// reindex of index A does not clear the cache for index B.
 /// What: `entry(id).or_insert_with(...)` on the global `DashMap`.
 /// Test: covered indirectly by all reindex tests.
-pub(super) fn hashes_for(id: &IndexId) -> Arc<DashMap<PathBuf, String>> {
+pub(crate) fn hashes_for(id: &IndexId) -> Arc<DashMap<PathBuf, String>> {
     file_hashes()
         .entry(id.clone())
         .or_insert_with(|| Arc::new(DashMap::new()))
@@ -97,7 +97,7 @@ pub(super) fn shrink_hashes_if_needed(map: &DashMap<PathBuf, String>) {
 /// Test: see `reindex_walks_directory_and_emits_events` — a re-run of the
 /// reindex with unchanged files must mark them as skipped (proves the hash
 /// is stable across two invocations within the same process).
-pub(super) fn hash_content(content: &str) -> String {
+pub(crate) fn hash_content(content: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(content.as_bytes());
     format!("{:x}", hasher.finalize())

--- a/crates/trusty-search/src/service/reindex/mod.rs
+++ b/crates/trusty-search/src/service/reindex/mod.rs
@@ -51,7 +51,8 @@ mod corpus_swap;
 mod finish;
 mod finish_teardown;
 mod guard;
-mod hash;
+// #6570: `watch_rescan` reuses the content-hash cache to skip unchanged files.
+pub(crate) mod hash;
 mod hnsw_swap;
 mod orchestrator;
 mod pollers;

--- a/crates/trusty-search/src/service/walker.rs
+++ b/crates/trusty-search/src/service/walker.rs
@@ -43,6 +43,14 @@ pub const SOURCE_EXTS: &[&str] = &[
 /// AWS CDK / SAM synth output (`cdk.out`, `.aws-sam`) is especially noisy: each
 /// Lambda asset is a full copy of a Python venv with vendored dependencies.
 pub const SKIP_DIRS: &[&str] = &[
+    // #6570: this daemon's own colocated storage
+    // (`colocated_storage::COLOCATED_DIR_NAME`). It sits INSIDE the watched
+    // root, so every corpus commit writes here and the watcher then delivers
+    // those writes back as file events. `.gitignore` already hides it from the
+    // walker on a git root; naming it here covers `respect_gitignore: false`
+    // and, more importantly, `path_in_skipped_dir`, which the watcher's
+    // per-event filter uses and which never consults `.gitignore`.
+    ".trusty-search",
     ".git",
     "target",
     "node_modules",

--- a/crates/trusty-search/src/service/watch_loop.rs
+++ b/crates/trusty-search/src/service/watch_loop.rs
@@ -173,9 +173,12 @@ pub fn spawn_watch_loop(
                     };
                     match &outcome {
                         Ok(stats) if retry_attempt.is_none() => {
+                            // #6570: `files_unchanged` is what says whether the
+                            // overflow found real work or nothing at all.
                             tracing::info!(
                                 index_id = %index_id,
                                 files_reindexed = stats.files_reindexed,
+                                files_unchanged = stats.files_unchanged,
                                 chunks_indexed = stats.chunks_indexed,
                                 files_removed = stats.files_removed,
                                 "reconciled watched tree after a dropped-event rescan",
@@ -188,6 +191,7 @@ pub fn spawn_watch_loop(
                                 index_id = %index_id,
                                 attempt = retry_attempt,
                                 files_reindexed = stats.files_reindexed,
+                                files_unchanged = stats.files_unchanged,
                                 chunks_indexed = stats.chunks_indexed,
                                 files_removed = stats.files_removed,
                                 files_unreadable = stats.files_unreadable,

--- a/crates/trusty-search/src/service/watch_rescan.rs
+++ b/crates/trusty-search/src/service/watch_rescan.rs
@@ -21,6 +21,15 @@
 //! all restore a file's old mtime, so an mtime filter can miss exactly the
 //! writes this module exists to catch.
 //!
+//! What the pass DOES narrow is the work it does per file, not which files it
+//! looks at (#6570). Every walked file is still read from disk and fingerprinted
+//! with the same SHA-256 the reindex pipeline uses, so nothing is trusted from
+//! file metadata. A file whose content bytes are byte-identical to what the
+//! index already holds skips the tree-sitter parse, the embed, and the redb
+//! commit — the pass keeps full-tree coverage and drops the cost that made an
+//! overflow expensive. Measured before this: 22 passes in 48h, each reporting
+//! `files_reindexed=17284 chunks_indexed=183348` on an unchanged tree.
+//!
 //! Two limits are worth stating plainly rather than leaving to be discovered.
 //! The walk uses [`WalkOptions::default`], so an index registered with
 //! `follow_links: true` does not get its symlinked subtrees reconciled here —
@@ -87,6 +96,15 @@ pub struct RescanStats {
     /// out and the watch loop reports a non-zero value at `warn` rather than
     /// letting it disappear into a `debug` line.
     pub files_unreadable: usize,
+    /// Files the walk read and fingerprinted, whose content was byte-identical
+    /// to what the index already holds, so nothing was re-parsed or committed
+    /// for them (#6570).
+    ///
+    /// Why: this is the number that separates "the overflow found real work" —
+    /// what a rescan is for — from "the overflow found nothing", which is what
+    /// every one of the 22 observed passes actually found. Reported beside
+    /// `files_reindexed` so the log line says which of the two happened.
+    pub files_unchanged: usize,
 }
 
 impl RescanStats {
@@ -147,7 +165,8 @@ pub enum RescanError {
 /// documents for leaving `index_files_batch*` ungated.
 ///
 /// Test: `rescan_reconcile_indexes_files_written_during_the_gap`,
-/// `rescan_reconcile_drops_files_deleted_during_the_gap`.
+/// `rescan_reconcile_drops_files_deleted_during_the_gap`,
+/// `rescan_reconcile_skips_files_whose_content_did_not_change`.
 pub async fn reconcile_after_rescan(
     index_id: &IndexId,
     canonical_root: &Path,
@@ -159,6 +178,13 @@ pub async fn reconcile_after_rescan(
     let mut stats = RescanStats::default();
     let mut live: HashSet<PathBuf> = HashSet::with_capacity(walked.len());
 
+    // #6570: the same per-index content-hash cache the reindex pipeline skips
+    // unchanged files with. Warmed from the durable corpus when this process
+    // has not populated it yet, so the FIRST overflow after a daemon restart is
+    // already cheap rather than only the second.
+    let hashes = crate::service::reindex::hash::hashes_for(index_id);
+    warm_hashes_from_corpus(indexer, &hashes).await;
+
     // #3049: the reconcile is a writer, so it takes this index's teardown-lock
     // read side for the whole pass, exactly as `handle_modified` does.
     let _teardown_guard = crate::service::reindex::acquire_index_teardown_read(index_id).await;
@@ -166,6 +192,7 @@ pub async fn reconcile_after_rescan(
     for batch in walked.chunks(RECONCILE_BATCH) {
         let mut payload: Vec<(String, String)> = Vec::with_capacity(batch.len());
         let mut recorded: Vec<(PathBuf, Vec<String>)> = Vec::with_capacity(batch.len());
+        let mut fingerprints: Vec<(PathBuf, String)> = Vec::with_capacity(batch.len());
 
         for abs in batch {
             let content = match crate::core::extract::read_content(abs).await {
@@ -181,11 +208,22 @@ pub async fn reconcile_after_rescan(
             // Same relative key `handle_modified` records, so the two paths
             // never disagree about what a file is called in the corpus.
             let rel = watcher_relative_path(canonical_root, raw_root, abs);
+            let key = PathBuf::from(&rel);
+            // #6570: the file was still read and hashed, so this is a decision
+            // about its CONTENT, not about its mtime. `live` is populated either
+            // way — a skipped file is present on disk and must never look like a
+            // deletion to `sweep_deleted`.
+            let fingerprint = crate::service::reindex::hash::hash_content(&content);
+            if hashes.get(&key).is_some_and(|h| *h == fingerprint) {
+                stats.files_unchanged += 1;
+                live.insert(key);
+                continue;
+            }
             let (chunks, _entities) = chunk_ast(&rel, &content);
             let ids: Vec<String> = chunks.iter().map(|c| c.id.clone()).collect();
-            let key = PathBuf::from(&rel);
             live.insert(key.clone());
-            recorded.push((key, ids));
+            recorded.push((key.clone(), ids));
+            fingerprints.push((key, fingerprint));
             payload.push((rel, content));
         }
 
@@ -209,6 +247,11 @@ pub async fn reconcile_after_rescan(
         for (key, ids) in recorded {
             indexed_files.record(key, ids).await;
         }
+        // #6570: recorded only after the batch committed, so a failed batch
+        // cannot leave a hash claiming content the index does not hold.
+        for (key, fingerprint) in fingerprints {
+            hashes.insert(key, fingerprint);
+        }
     }
 
     stats.files_removed =
@@ -222,6 +265,47 @@ pub async fn reconcile_after_rescan(
     }
 
     Ok(stats)
+}
+
+/// Populate an empty content-hash cache from the index's durable corpus (#6570).
+///
+/// Why: the in-process cache is per-daemon-lifetime, and `spawn_reindex` is the
+/// only thing that warms it today. A daemon that warm-booted an index and then
+/// took an FSEvents overflow before any reindex ran would see an empty cache and
+/// re-parse the whole tree — the exact cost this skip exists to remove, paid on
+/// the first overflow after every restart.
+///
+/// What: no-op unless the cache is empty for this index, so a cache the reindex
+/// pipeline already populated is never re-read and a cache this pass just filled
+/// is never overwritten. An index with no durable corpus (BM25-only, tests) and
+/// an unreadable hash table both leave the cache empty, which costs a full pass
+/// and is correct — the cache is an optimisation whose miss penalty is the old
+/// behaviour.
+///
+/// Test: `rescan_reconcile_warms_the_hash_cache_from_the_corpus`.
+async fn warm_hashes_from_corpus(
+    indexer: &Arc<RwLock<CodeIndexer>>,
+    hashes: &dashmap::DashMap<PathBuf, String>,
+) {
+    if !hashes.is_empty() {
+        return;
+    }
+    let Some(corpus) = indexer.read().await.corpus_store() else {
+        return;
+    };
+    match tokio::task::spawn_blocking(move || corpus.load_file_hashes()).await {
+        Ok(Ok(entries)) => {
+            for (path, hash) in entries {
+                hashes.insert(PathBuf::from(path), hash);
+            }
+        }
+        Ok(Err(err)) => {
+            tracing::debug!(%err, "rescan reconcile: no persisted file hashes to warm from");
+        }
+        Err(err) => {
+            tracing::debug!(%err, "rescan reconcile: file-hash warm task did not complete");
+        }
+    }
 }
 
 /// Drop chunks for tracked files that the walk did not find and that are gone

--- a/crates/trusty-search/src/service/watch_rescan_tests.rs
+++ b/crates/trusty-search/src/service/watch_rescan_tests.rs
@@ -53,10 +53,19 @@ fn pre_fix_watch_event(ev: &Event) -> Option<WatchEvent> {
     })
 }
 
+/// Build an index fixture under an id no other test in this binary uses.
+///
+/// #6570: the content-hash cache `reconcile_after_rescan` consults is a
+/// process-global map keyed by `IndexId`. A shared id would let one test's
+/// fingerprints decide whether another test's file is re-parsed, which is a
+/// cross-test dependency that shows up as a flake under parallel execution.
 fn fixture(dir: &std::path::Path) -> (IndexId, Arc<RwLock<CodeIndexer>>, IndexedFiles) {
+    static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let n = NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let id = format!("watch-rescan-test-{n}");
     (
-        IndexId::new("watch-rescan-test"),
-        Arc::new(RwLock::new(CodeIndexer::new("watch-rescan-test", dir))),
+        IndexId::new(&id),
+        Arc::new(RwLock::new(CodeIndexer::new(&id, dir))),
         IndexedFiles::new(),
     )
 }
@@ -405,6 +414,116 @@ async fn rescan_partial_pass_schedules_a_retry_that_fires() {
         rx.recv().await,
         Some(WatchEvent::Rescan),
         "the scheduled retry must put another Rescan back on the loop's channel"
+    );
+}
+
+/// Why (#6570): 22 overflows in 48h each reported
+/// `files_reindexed=17284 chunks_indexed=183348` on a tree where nothing had
+/// changed. The pass re-read, re-parsed and re-committed the whole corpus every
+/// time. Before this fix a second reconcile over an untouched tree did the same
+/// work as the first; the assertion below is what failed.
+///
+/// The full-tree contract is asserted alongside it: the skip is decided on the
+/// file's CONTENT, so editing a file makes the next pass reindex it again even
+/// though the walk and the tree are otherwise identical.
+#[tokio::test]
+async fn rescan_reconcile_skips_files_whose_content_did_not_change() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = std::fs::canonicalize(dir.path()).expect("canonicalize");
+    let (index_id, indexer, tracker) = fixture(&root);
+
+    std::fs::write(root.join("alpha.rs"), "fn alpha() {}\n").expect("write alpha");
+    std::fs::write(root.join("beta.rs"), "fn beta() {}\n").expect("write beta");
+
+    let first = reconcile_after_rescan(&index_id, &root, &root, &indexer, &tracker)
+        .await
+        .expect("first reconcile succeeds");
+    assert_eq!(
+        first.files_reindexed, 2,
+        "the first pass has nothing cached and must index both files"
+    );
+    assert_eq!(first.files_unchanged, 0, "and nothing was skippable yet");
+
+    // Nothing on disk changed between the two passes.
+    let second = reconcile_after_rescan(&index_id, &root, &root, &indexer, &tracker)
+        .await
+        .expect("second reconcile succeeds");
+    assert_eq!(
+        second.files_reindexed, 0,
+        "pre-fix this was 2 — an unchanged tree was re-parsed and re-committed in full"
+    );
+    assert_eq!(
+        second.chunks_indexed, 0,
+        "and no chunk was rewritten into the corpus"
+    );
+    assert_eq!(
+        second.files_unchanged, 2,
+        "both files must be reported as walked-and-unchanged, not as skipped-unreadable"
+    );
+    assert!(
+        second.is_complete(),
+        "a pass that skipped only unchanged files has fully reconciled the tree"
+    );
+    assert_eq!(
+        second.files_removed, 0,
+        "a hash-skipped file is still live on disk and must never look like a deletion"
+    );
+
+    // Content, not metadata: an edit must come back through the full path.
+    std::fs::write(root.join("beta.rs"), "fn beta() {}\nfn gamma() {}\n").expect("edit beta");
+    let third = reconcile_after_rescan(&index_id, &root, &root, &indexer, &tracker)
+        .await
+        .expect("third reconcile succeeds");
+    assert_eq!(
+        third.files_reindexed, 1,
+        "the edited file must be reindexed — the skip is a content decision"
+    );
+    assert_eq!(
+        third.files_unchanged, 1,
+        "and the untouched file stays skipped"
+    );
+}
+
+/// Why (#6570): the in-process hash cache is per-daemon-lifetime, so without
+/// warming it from the durable corpus the first overflow after every restart
+/// would still re-parse the whole tree. Simulates that restart by clearing the
+/// cache the previous pass populated and asserting the next pass still skips.
+#[tokio::test]
+async fn rescan_reconcile_warms_the_hash_cache_from_the_corpus() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = std::fs::canonicalize(dir.path()).expect("canonicalize");
+    let (index_id, indexer, tracker) = fixture(&root);
+
+    // A durable corpus is what the warm reads from; a BM25-only index has none.
+    {
+        let corpus = crate::core::corpus::CorpusStore::open(&root.join("index.redb"))
+            .expect("open test corpus");
+        corpus
+            .upsert_file_hashes(&[(
+                "alpha.rs",
+                &crate::service::reindex::hash::hash_content("fn alpha() {}\n"),
+            )])
+            .expect("seed the persisted hash");
+    }
+    std::fs::write(root.join("alpha.rs"), "fn alpha() {}\n").expect("write alpha");
+    {
+        let mut idx = indexer.write().await;
+        idx.set_corpus_store(Arc::new(
+            crate::core::corpus::CorpusStore::open(&root.join("index.redb"))
+                .expect("reopen test corpus"),
+        ));
+    }
+
+    let stats = reconcile_after_rescan(&index_id, &root, &root, &indexer, &tracker)
+        .await
+        .expect("reconcile succeeds");
+    assert_eq!(
+        stats.files_unchanged, 1,
+        "the persisted hash must be warmed into the cache and honoured on the first pass"
+    );
+    assert_eq!(
+        stats.files_reindexed, 0,
+        "so a restart does not buy the whole corpus a re-parse"
     );
 }
 


### PR DESCRIPTION
Refs #6570, Refs #6571.

FSEvents overflow was caused by the daemon's own `.trusty-search/` storage (1.08 GB redb + 310 MB HNSW, rewritten per commit) sitting inside the watched root; directory exclusion, buffer sizing and mtime-bounding were each unavailable or unsound, so `reconcile_after_rescan` now SHA-256s every walked file (warmed from the durable corpus after restart) and skips parse/embed/commit for unchanged content; `.trusty-search` added to SKIP_DIRS.

#6571 was not NaN vectors — `make_chunk_id` omits the end line, so a one-line minified bundle maps every `function e(...)` to one id (2,070 of 2,299 warnings on a single id); the failed duplicate add rolled back the successful vector's mapping, orphaning it. `chunk_ast` now drops duplicate ids per file and `upsert_batch` collapses them at the store boundary; the warning reports the real error. Note: repairing `make_chunk_id` itself changes the primary key across redb/BM25/HNSW/KG and is deferred to its own issue. Gate line: rung 3 as above; 4 regression tests proven failing on the pre-fix code.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools