### PR TITLE
chore(release): post-publish version bumps — common 0.47.0, search 0.52.0, mpm 1.5.16, tga 5.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6596,7 +6596,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -10439,7 +10439,7 @@ dependencies = [
 
 [[package]]
 name = "tga"
-version = "5.0.2"
+version = "5.0.3"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -11604,7 +11604,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-common"
-version = "0.46.6"
+version = "0.47.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11901,7 +11901,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-mpm"
-version = "1.5.15"
+version = "1.5.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12033,7 +12033,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-search"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,7 @@ trusty-code = { path = "crates/trusty-code", version = "0.5.0" }
 # is the first upload.
 trusty-code-tui = { path = "crates/trusty-code-tui", version = "0.1.0" }
 trusty-agents-common = { path = "crates/trusty-agents-common", version = "0.6.0" }
-trusty-common = { path = "crates/trusty-common", version = "0.46" }
+trusty-common = { path = "crates/trusty-common", version = "0.47" }
 # Shared JSON-RPC 2.0 / MCP protocol primitives, extracted from
 # `trusty_common::mcp` by ADR-0040 (#5803).
 trusty-mcp = { path = "crates/trusty-mcp", version = "0.1.2" }

--- a/crates/trusty-agents/Cargo.toml
+++ b/crates/trusty-agents/Cargo.toml
@@ -72,7 +72,7 @@ trusty-common = { workspace = true, features = ["symgraph-parser", "memory-core"
 #      compile the trusty-memory HTTP daemon code paths just to pick up a
 #      zero-sized service descriptor.
 trusty-memory = { path = "../trusty-memory", version = "0.25", default-features = false }
-trusty-search = { path = "../trusty-search", version = "0.51" }
+trusty-search = { path = "../trusty-search", version = "0.52" }
 # Gmail/Calendar eventstream listeners (#3820, DOC-54 SPEC-AGENTS-06) call
 # trusty-gworkspace's connector layer (`api::client::BaseClient` +
 # `api::services::gmail::*`) DIRECTLY as library functions — the same code

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -47,7 +47,13 @@ name = "trusty-common"
 # position, so 0.46.0 is where they ship.
 # 0.46.3 (#5439): patch — new public `daemon_token` module and
 # `server::bearer_auth` are additive; cargo-semver-checks reports no break.
-version = "0.46.6"
+# 0.47.0 (issue #4421, post-publish wave 2026-09-01): minor — 0.46.6 is
+# already live on crates.io and two queued PRs change `src/**` under it.
+# #6562 adds a required method to the public `LogDestination` trait — a
+# breaking change under Cargo's 0.x rule. #6573 also adds public API. Bumped
+# on `main` first, ahead of either PR, so the `PR version bump vs crates.io`
+# gate clears once each PR updates its branch onto this commit.
+version = "0.47.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/trusty-git-analytics/Cargo.toml
+++ b/crates/trusty-git-analytics/Cargo.toml
@@ -46,7 +46,11 @@ name = "tga"
 # identity resolution, plus routing the team-config constructor through the
 # same alias contract. No public signature changes — `cargo-semver-checks`
 # reports no semver update required. PATCH.
-version = "5.0.2"
+# 5.0.2 → 5.0.3 (issue #4421, post-publish wave 2026-09-01): patch — 5.0.2 is
+# already live on crates.io and #6564 edits `src/**` under it. Bumped on
+# `main` first so the `PR version bump vs crates.io` gate clears once #6564
+# updates its branch onto this commit.
+version = "5.0.3"
 publish = true
 edition = "2021"
 # Aligned with the workspace MSRV (1.94) per #254. Required for

--- a/crates/trusty-gworkspace/Cargo.toml
+++ b/crates/trusty-gworkspace/Cargo.toml
@@ -15,7 +15,7 @@ name = "trusty-gworkspace-mcp"
 path = "src/bin/trusty-gworkspace-mcp.rs"
 
 [dependencies]
-trusty-common = { path = "../trusty-common", version = "0.46" }
+trusty-common = { path = "../trusty-common", version = "0.47" }
 # JSON-RPC / MCP primitives, extracted from `trusty_common::mcp` by ADR-0040 (#5803).
 trusty-mcp = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/trusty-memory/Cargo.toml
+++ b/crates/trusty-memory/Cargo.toml
@@ -98,7 +98,7 @@ trusty-mcp = { workspace = true }  # JSON-RPC / MCP primitives (ADR-0040, #5803)
 # supplies the bind, the peer check, the framing and the accept loop, and
 # `uds::stream_client` the reader `memory.chat` needs. It replaces
 # `axum-server`, which was here for the retired HTTP listener.
-trusty-common = { path = "../trusty-common", version = "0.46", default-features = false, features = ["memory-core", "monitor-tui", "bm25", "cli-help", "update-check", "bug-capture", "console-metrics", "config-cli", "crate-config", "palace-resolve", "codex-config", "uds"] }
+trusty-common = { path = "../trusty-common", version = "0.47", default-features = false, features = ["memory-core", "monitor-tui", "bm25", "cli-help", "update-check", "bug-capture", "console-metrics", "config-cli", "crate-config", "palace-resolve", "codex-config", "uds"] }
 # `bug-capture` enables Phase 1 ERROR event capture to JSONL + in-memory ring (bug-reporting #478)
 # Why (issue #1318): the `trusty-console` dependency was REMOVED. The console
 # is no longer bundled into trusty-memory (single-owner-per-binary); the
@@ -190,7 +190,7 @@ serial_test = { workspace = true }
 # `memory-rpc` (#6286): `tests/uds_consumer_contract.rs` drives the SHARED
 # client against a real daemon on a temp socket — the one place the two halves
 # of this migration are proven to agree.
-trusty-common = { path = "../trusty-common", version = "0.46", default-features = false, features = ["memory-core", "embedder-test-support", "docgen", "memory-rpc"] }
+trusty-common = { path = "../trusty-common", version = "0.47", default-features = false, features = ["memory-core", "embedder-test-support", "docgen", "memory-rpc"] }
 chrono = { workspace = true }
 
 [features]

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -16,7 +16,12 @@ name = "trusty-mpm"
 # 1.5.11 (#6391): patch — 1.5.10 is published and this PR edits `src/**` to
 # harden worktree removal and unwedge the reap wait; no public item changed
 # signature.
-version = "1.5.15"
+# 1.5.16 (issue #4421, post-publish wave 2026-09-01): patch — 1.5.15 is
+# already live on crates.io and several queued PRs (#6562, #6576, #6578,
+# #6579) edit `src/**` under it. Bumped on `main` first so the
+# `PR version bump vs crates.io` gate clears once each PR updates its branch
+# onto this commit.
+version = "1.5.16"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -32,7 +32,12 @@ name = "trusty-search"
 # `DeleteIndex` gains `expected_root_path` (`rpc/writes.rs:172`); all three
 # structs were exhaustively constructible through the public API. Cargo's 0.x
 # rule puts a break in the MINOR position.
-version = "0.51.0"
+# 0.52.0 (issue #4421, post-publish wave 2026-09-01): minor — 0.51.0 is
+# already live on crates.io and #6573 changes the public `detect_project` /
+# `resolve_index` signatures to return `Result`. Bumped on `main` first so
+# the `PR version bump vs crates.io` gate clears once #6573 (and #6582)
+# update their branches onto this commit.
+version = "0.52.0"
 edition = "2021"
 description = "Machine-wide hybrid code search service: BM25 + vector + KG, zero cold-start, MCP server"
 readme = "README.md"


### PR DESCRIPTION
Refs #4421

- trusty-common 0.47.0 (MINOR — #6562 adds required method to LogDestination; #6573 adds public API)
- trusty-search 0.52.0 (MINOR — #6573 changes detect_project/resolve_index to Result)
- trusty-mpm 1.5.16 (patch)
- tga 5.0.3 (patch)

Version-only — no changelog fragment owed. Unblocks the "PR version bump vs crates.io" gate for the fix wave (#6562, #6564, #6573, #6576, #6578, #6579, #6582).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools