### PR TITLE
chore(sessions): commit the 2026-09-01 23:22Z pause snapshot

### DIFF
--- a/.trusty-mpm/sessions/1852fea9-d45b-4288-96ff-9cda26abd845/session-20260901-232218.md
+++ b/.trusty-mpm/sessions/1852fea9-d45b-4288-96ff-9cda26abd845/session-20260901-232218.md
@@ -1,0 +1,46 @@
+# Session Pause - 2026-09-01T23:22:18.564025+00:00
+
+## Summary
+Paused 2026-09-01 ~23:2xZ mid bug-wave close-out, owner-invoked. Supersedes this session's 20:40Z snapshot. Palace: drawer 2198e85b (board), 05b833ba (rebuild+install standing instruction), e2597796 (tm gh-url priority).
+
+🔴 TWO ENGINEERS WERE LIVE AT PAUSE — background agents die with the session; VERIFY EACH WORKTREE DIRECTLY on resume (`git -C <wt> log --oneline -3 && git status --porcelain`), never assume:
+(1) fix/6568-6118-6569-daemon-efficiency in .claude/worktrees/agent-a9f94dac65b4b1ab1 — code-critic APPROVED at 4611b678c (two rounds; round-2 verdict: MEDIUM store.rs:353-371 dedupe SessionStore::save onto json_file::write_atomic; LOW ResumeBreakerStore::reload_if_changed must always read, not fingerprint). Engineer was committing those two closes. If the worktree shows a commit after 4611b678c with both closes → version-control opens the PR (title `fix(trusty-mpm): resume circuit-breaker, reap cwd-gone panes, single log sink under launchd`, Refs #6568 #6118 #6569, auto-merge; PR body must note the semver-relevant public field `auto_resume_parked` on ManagedSessionSummary/SessionSummary, not #[non_exhaustive]). If not, re-dispatch a rust-engineer into that worktree to finish the two closes first. No further critic round needed.
+(2) fix/6547-drain-size-ceiling in .claude/worktrees/agent-abaea13574b8e0ee0 — rust-engineer was building (oversize log drain via multipart/streamed + durable skip decision; rung 4 trusty-common --features log-drain). Unknown completion state. If a commit exists with green gates in its message → version-control PR (Refs #6547); if partial/dirty → re-dispatch to finish. #6547 is status:in-progress.
+
+PR #6583 (fix/6556-6561, e3fb9cf00) OPEN, auto-merge armed, CI re-running after fragment+test-pointer fixes; a monitor was watching it (monitors survive pause). On merge: #6556 status:coded→merged. #6561 stays open/unclaimed (consolidation only; needs durable delegation state).
+
+🔴 STANDING INSTRUCTION (owner): "rebuild and install once everything merges" — fires when #6583 + cluster-A PR + #6547 PR are all MERGED. local-ops: fresh worktree at main tip, cargo install --locked (never cp) tm/trusty-search/tga, connection-safe daemon restarts, then live-verify + close at status:tested the ten status:merged issues (#6548 #6553 #6550 #6566 #6441 #6570 #6571 #6542 #6551 #812 [gate-4 evidence]) plus #6556 #6568 #6118 #6569 #6547. Operator step after #6569: truncate ~/Library/Logs/trusty-mpm/stderr.log (3.4GB). NOT a publish.
+
+MERGED THIS LEG: #6562 (#6548), #6564 (#6553), #6573 (#6550), #6576 (#6566), #6578 (#6441 tm <gh-url>), #6579 (#6542+#6551), #6582 (#6570+#6571), #6584 (post-publish bumps: common 0.47.0, search 0.52.0, mpm 1.5.16, tga 5.0.3), #6567 (#812), #6563 (snapshots). Ten issues at status:merged awaiting reinstall.
+
+Owner rulings this leg: fix the new bugs; prioritize #6441 (done, merged); implement compression hook gating (#6566, merged); file all audit findings + start both clusters (done); rebuild+install once everything merges (armed).
+
+## Completed
+- Bug wave A: 7 fix PRs merged (#6562 #6564 #6573 #6576 #6578 #6579 #6582) covering #6548 #6553 #6550 #6566 #6441 #6542 #6551 #6570 #6571; all advanced to status:merged
+- #812 embedder gate root-caused (hard-coded cache dir bypassed the pre-seed) — PR #6567 merged, status:merged
+- Post-publish version-bump gate (#4421) unblocked via PR #6584 + gh pr update-branch on all blocked PRs
+- Compression observation: tm hook fires on ~94% no-op calls, filters real where present, no LLM path (rtk absent); Anthropic side has no per-tool-result compression — complementary; #6566 gating fix merged
+- Efficiency audit (48h logs): 5 ranked findings + 4 lower; filed #6568 #6569 #6570 #6571 #6572, reopened #6118, commented #6547; cluster B (search) merged; cluster A (daemon) critic-APPROVED
+- #6556/#6561 branch: 3 critic rounds → APPROVE; PR #6583 open/armed; #6561 scoped as consolidation-only, unclaimed
+- Filed: #6565 (tga per-client sleep budget), #6574 #6575 #6577 #6580 (test flakes), #6581 (chunk-id key migration)
+- Two engineer-discovered corrections recorded on issues: #6441 criterion 3 was unachievable (tm sta already ambiguous); #6571 was duplicate chunk ids, not NaN vectors
+
+## In Progress
+- fix/6568-6118-6569-daemon-efficiency @ 4611b678c + pending final commit (2 critic closes) in worktree agent-a9f94dac65b4b1ab1 — engineer was live at pause; verify worktree state, then PR via version-control
+- fix/6547-drain-size-ceiling in worktree agent-abaea13574b8e0ee0 — engineer was building at pause; verify state, finish or PR
+- PR #6583 (#6556/#6561) open, auto-merge armed, CI re-running after gate fixes; on merge advance #6556 to status:merged
+
+## Next Steps
+- Verify both live worktrees; land cluster-A PR and #6547 PR (version-control, auto-merge); each will need `gh pr update-branch` only if the version-bump gate complains (main already carries 1.5.16 / common 0.47.0)
+- When #6583 + cluster-A + #6547 all merge: fire the owner's rebuild+install chain (local-ops), then live-verify and close the status:merged issues at status:tested; truncate stderr.log after #6569 installs
+- Wave B candidates (unclaimed): #6577 (mask live-sampled doctor rows), #6580 ($HOME races), #6574/#6575 (flakes), #6581 (chunk-id migration), #6565 (tga budget), #6572 (observability), #6561 (durable delegation state design), #6568 true fix (relaunch runtime in reused pane — owner design call)
+- Release note for next publish: trusty-common 0.47.0 / trusty-search 0.52.0 MINOR already bumped; cluster A adds public field auto_resume_parked (preflight CHECK 5 will flag); tga 5.0.3
+- Housekeeping: merged-PR agent worktrees under .claude/worktrees/ are prunable (pause prune skips them — they are Agent-tool trees, not managed-session trees); commit this snapshot (main-checkout commit guard may still block → docs-only PR from a worktree, as #6563)
+
+## Git Context
+Branch: fix/6542-6551-test-isolation
+Last commit: 7d86cfe4c fix: drop scanner-flagged artifact from test isolation change (Refs #6542, Refs #6551)
+Uncommitted changes: 2 file(s) changed
+
+## Tmux Window
+tm-trusty-tools-02:0:@2307

--- a/.trusty-mpm/sessions/sessions-log.jsonl
+++ b/.trusty-mpm/sessions/sessions-log.jsonl
@@ -73,3 +73,4 @@
 {"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260901-144157.md","timestamp":"2026-09-01T14:41:57.381916+00:00"}
 {"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260901-172730.md","timestamp":"2026-09-01T17:27:30.579162+00:00"}
 {"session_id":"1852fea9-d45b-4288-96ff-9cda26abd845","event":"pause","snapshot":"1852fea9-d45b-4288-96ff-9cda26abd845/session-20260901-204005.md","timestamp":"2026-09-01T20:40:05.799937+00:00"}
+{"session_id":"1852fea9-d45b-4288-96ff-9cda26abd845","event":"pause","snapshot":"1852fea9-d45b-4288-96ff-9cda26abd845/session-20260901-232218.md","timestamp":"2026-09-01T23:22:18.564025+00:00"}


### PR DESCRIPTION
Session snapshot from the 2026-09-01 bug-wave session; Refs #6556 for the guard workaround.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools