### PR TITLE
fix(trusty-mpm): resume circuit-breaker, reap cwd-gone panes, single log sink under launchd

### DIFF
--- a/crates/trusty-mpm/changelog.d/6118-reap-cwd-gone-panes.md
+++ b/crates/trusty-mpm/changelog.d/6118-reap-cwd-gone-panes.md
@@ -7,6 +7,10 @@ Fixed
   - The evidence is positive only (ADR-0045): a path tmux never reported, or one
     the filesystem could not decide on, keeps the pane, and the kill still needs
     the same two consecutive sweeps an idle-shell orphan needs.
+  - An absent directory only counts when its PARENT still exists. An unmounted or
+    ejected volume answers with the same ENOENT a deleted worktree does, so
+    without that gate an agent working on an external disk would be killed about
+    two minutes after someone ejected it.
 - The orphan-GC's "untracked active managed session — skipping" line is now
   logged once per session per 60 sweeps rather than every sweep — it was
   992,078 lines in 48 hours, 76% of the daemon log — with the per-sweep total

--- a/crates/trusty-mpm/changelog.d/6118-reap-cwd-gone-panes.md
+++ b/crates/trusty-mpm/changelog.d/6118-reap-cwd-gone-panes.md
@@ -1,0 +1,14 @@
+Fixed
+- The orphan-GC now reaps a managed, untracked pane whose working directory is
+  confirmed gone, even when the pane still runs an agent rather than a bare
+  shell. That is the class `reconcile` declines to adopt because the cwd does
+  not resolve; nothing could act on them before and 478 accumulated as
+  permanent zombies (#6118).
+  - The evidence is positive only (ADR-0045): a path tmux never reported, or one
+    the filesystem could not decide on, keeps the pane, and the kill still needs
+    the same two consecutive sweeps an idle-shell orphan needs.
+- The orphan-GC's "untracked active managed session — skipping" line is now
+  logged once per session per 60 sweeps rather than every sweep — it was
+  992,078 lines in 48 hours, 76% of the daemon log — with the per-sweep total
+  kept in the sweep summary. Override with
+  `TRUSTY_MPM_ORPHAN_GC_SKIP_LOG_EVERY` (#6118).

--- a/crates/trusty-mpm/changelog.d/6568-resume-circuit-breaker.md
+++ b/crates/trusty-mpm/changelog.d/6568-resume-circuit-breaker.md
@@ -8,5 +8,8 @@ Fixed
   - Tunable via `TRUSTY_MPM_RESUME_FLAP_WINDOW_SECS` (default 120) and
     `TRUSTY_MPM_RESUME_FLAP_THRESHOLD` (default 5); a zero window disables the
     breaker entirely.
-  - The session list and status wire shape carries an `auto_resume_parked`
-    reason, so a parked session is distinguishable from an idle stopped one.
+  - An in-place reactivate (`tm`'s bare in-pane relaunch) clears the streak too,
+    so an operator relaunching by hand cannot park their own session.
+  - `tm session ls` marks a parked row `[resume-parked]` and `tm session info`
+    carries the full reason, so a parked session is no longer indistinguishable
+    from an idle stopped one.

--- a/crates/trusty-mpm/changelog.d/6568-resume-circuit-breaker.md
+++ b/crates/trusty-mpm/changelog.d/6568-resume-circuit-breaker.md
@@ -1,0 +1,12 @@
+Fixed
+- Auto-resume is now parked for a session whose runtime keeps exiting within
+  seconds of its own auto-resume, instead of stopping and resuming it every
+  60-70 seconds forever (2,170 stops against 2,128 resumes in one 48-hour
+  window). The park is recorded as a `resume_flapping` stop cause, so every
+  automatic resume path leaves the session down; an operator's own
+  `tm session resume` clears it (#6568).
+  - Tunable via `TRUSTY_MPM_RESUME_FLAP_WINDOW_SECS` (default 120) and
+    `TRUSTY_MPM_RESUME_FLAP_THRESHOLD` (default 5); a zero window disables the
+    breaker entirely.
+  - The session list and status wire shape carries an `auto_resume_parked`
+    reason, so a parked session is distinguishable from an idle stopped one.

--- a/crates/trusty-mpm/changelog.d/6569-single-log-sink-under-launchd.md
+++ b/crates/trusty-mpm/changelog.d/6569-single-log-sink-under-launchd.md
@@ -1,0 +1,17 @@
+Fixed
+- The daemon and supervisor no longer write every log line twice. Both modes
+  registered a stderr layer beside the rotated `~/.trusty-mpm/logs/trusty-mpm.log.*`
+  file layer, and under launchd the plist's `StandardErrorPath` captured that
+  stderr into a file launchd never rotates — 3.4 GB against 3.0 GB of rotated
+  logs over one 48-hour window. The stderr layer is now skipped when a file
+  layer is configured AND launchd positively reports it supervises this process
+  (#6569).
+  - A foreground run keeps stderr, so `tm daemon` in a terminal is unchanged.
+    So does a run where launchd could not be asked: the sink is only ever
+    removed on positive evidence, never on an unanswered question.
+  - Supervision is read through `trusty_common::supervision`, the same bounded
+    `launchctl list` PID match every other caller uses, rather than a second
+    environment-variable heuristic.
+  - Operators: the existing `~/Library/Logs/trusty-mpm/stderr.log` is not
+    truncated by this change or by a restart, because launchd appends. Truncate
+    or delete it once after installing this version.

--- a/crates/trusty-mpm/src/bin/tm/commands/guided_inplace/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_inplace/tests.rs
@@ -566,6 +566,7 @@ fn stopped_record_at(workspace: &std::path::Path) -> trusty_mpm::client::Managed
         attached: false,
         slot: 0,
         deleted: false,
+        auto_resume_parked: None,
     }
 }
 

--- a/crates/trusty-mpm/src/bin/tm/commands/guided_resolver_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_resolver_tests.rs
@@ -51,6 +51,7 @@ fn make_session(
         attached: false,
         slot: 0,
         deleted: false,
+        auto_resume_parked: None,
     }
 }
 

--- a/crates/trusty-mpm/src/bin/tm/commands/guided_resume.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_resume.rs
@@ -319,6 +319,9 @@ pub(crate) fn parse_pane_probes(
             // Unused by `pane_runtime_exited`; the session-scoped query below is
             // what establishes which session these panes belong to.
             pane_id: None,
+            // #6118: likewise unused here — the cwd gate belongs to the daemon's
+            // orphan-GC, and this CLI path never classifies a pane through it.
+            pane_current_path: None,
         });
     }
     (!panes.is_empty()).then_some(panes)

--- a/crates/trusty-mpm/src/bin/tm/commands/managed_render.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed_render.rs
@@ -186,6 +186,9 @@ fn row_state(s: &ManagedSessionSummary) -> String {
         s.unresumable,
         s.stale_assets,
         s.stale_assets_unchecked,
+        // #6568: the daemon sends the whole reason; the row shows only that
+        // there is one.
+        s.auto_resume_parked.is_some(),
     )
 }
 
@@ -284,9 +287,16 @@ pub(crate) fn format_tombstone_row(slot: u32, use_color: bool) -> String {
 /// mutually exclusive — an unprobed row has no verdict to report — so a stale
 /// verdict always wins if both flags somehow arrive set. Markers can otherwise
 /// appear together.
+///
+/// `" [resume-parked]"` (#6568) marks a session the supervisor has stopped
+/// auto-resuming because its runtime kept dying within seconds of each resume.
+/// Without it a parked row is indistinguishable from an ordinary `stopped` one,
+/// and the difference is that nothing will ever revive this one. `tm session
+/// status` prints the full reason; the row only has space for the fact.
 /// Test: `format_state_column_appends_dead_marker`,
 /// `format_state_column_appends_stale_assets_marker`,
 /// `format_state_column_appends_unchecked_assets_marker`,
+/// `format_state_column_appends_resume_parked_marker`,
 /// `format_state_column_leaves_healthy_state_unchanged`,
 /// `format_state_column_renders_deleted_marker`.
 pub(crate) fn format_state_column(
@@ -294,6 +304,7 @@ pub(crate) fn format_state_column(
     unresumable: bool,
     stale: bool,
     unchecked: bool,
+    resume_parked: bool,
 ) -> String {
     // A `deleted` record (soft-deleted via `tm sessions delete`) renders as the
     // `--deleted--` marker so the master list REFLECTS the deletion instead of
@@ -305,6 +316,10 @@ pub(crate) fn format_state_column(
     };
     if unresumable {
         out.push_str(" [dead]");
+    }
+    // #6568: nothing will auto-resume this row again until an operator does.
+    if resume_parked {
+        out.push_str(" [resume-parked]");
     }
     if stale {
         out.push_str(" [stale-assets]");

--- a/crates/trusty-mpm/src/bin/tm/commands/managed_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed_tests.rs
@@ -49,11 +49,11 @@ fn truncate_clips_and_appends_ellipsis() {
 #[test]
 fn format_state_column_appends_dead_marker() {
     assert_eq!(
-        format_state_column("stopped", true, false, false),
+        format_state_column("stopped", true, false, false, false),
         "stopped [dead]"
     );
     assert_eq!(
-        format_state_column("errored", true, false, false),
+        format_state_column("errored", true, false, false, false),
         "errored [dead]"
     );
 }
@@ -63,11 +63,11 @@ fn format_state_column_appends_dead_marker() {
 #[test]
 fn format_state_column_appends_stale_assets_marker() {
     assert_eq!(
-        format_state_column("active", false, true, false),
+        format_state_column("active", false, true, false, false),
         "active [stale-assets]"
     );
     assert_eq!(
-        format_state_column("stopped", true, true, false),
+        format_state_column("stopped", true, true, false, false),
         "stopped [dead] [stale-assets]",
         "both markers must be able to appear together"
     );
@@ -80,18 +80,41 @@ fn format_state_column_appends_stale_assets_marker() {
 #[test]
 fn format_state_column_appends_unchecked_assets_marker() {
     assert_eq!(
-        format_state_column("stopped", false, false, true),
+        format_state_column("stopped", false, false, true, false),
         "stopped [assets ?]"
     );
     assert_eq!(
-        format_state_column("stopped", true, false, true),
+        format_state_column("stopped", true, false, true, false),
         "stopped [dead] [assets ?]",
         "the dead marker and the undetermined-assets marker must compose"
     );
     assert_eq!(
-        format_state_column("stopped", false, true, true),
+        format_state_column("stopped", false, true, true, false),
         "stopped [stale-assets]",
         "a real stale verdict must win over 'undetermined' — never both"
+    );
+}
+
+/// #6568: a parked session must be distinguishable from an ordinary stopped
+/// one, because nothing will ever auto-resume it again.
+///
+/// Test: this is the test. RED before the fix: the column had no such marker,
+/// so a parked row rendered as a plain `stopped`.
+#[test]
+fn format_state_column_appends_resume_parked_marker() {
+    assert_eq!(
+        format_state_column("stopped", false, false, false, true),
+        "stopped [resume-parked]"
+    );
+    // Markers coexist rather than shadowing each other.
+    assert_eq!(
+        format_state_column("stopped", true, true, false, true),
+        "stopped [dead] [resume-parked] [stale-assets]"
+    );
+    // A session nothing parked is untouched.
+    assert_eq!(
+        format_state_column("stopped", false, false, false, false),
+        "stopped"
     );
 }
 
@@ -99,13 +122,16 @@ fn format_state_column_appends_unchecked_assets_marker() {
 /// unchanged — no regression for the common case.
 #[test]
 fn format_state_column_leaves_healthy_state_unchanged() {
-    assert_eq!(format_state_column("active", false, false, false), "active");
     assert_eq!(
-        format_state_column("stopped", false, false, false),
+        format_state_column("active", false, false, false, false),
+        "active"
+    );
+    assert_eq!(
+        format_state_column("stopped", false, false, false, false),
         "stopped"
     );
     assert_eq!(
-        format_state_column("provisioning", false, false, false),
+        format_state_column("provisioning", false, false, false, false),
         "provisioning"
     );
 }
@@ -123,12 +149,12 @@ fn format_state_column_renders_deleted_marker() {
     // A soft-deleted record renders the `--deleted--` marker (#2012) instead of
     // the raw `deleted` state, so the master list REFLECTS the deletion.
     assert_eq!(
-        format_state_column("deleted", false, false, false),
+        format_state_column("deleted", false, false, false, false),
         "--deleted--"
     );
     // Markers still compose on top of the deleted base.
     assert_eq!(
-        format_state_column("deleted", true, false, false),
+        format_state_column("deleted", true, false, false, false),
         "--deleted-- [dead]"
     );
 }
@@ -1034,6 +1060,7 @@ fn ls_session(name: &str, slot: u32) -> trusty_mpm::client::ManagedSessionSummar
         attached: false,
         slot,
         deleted: false,
+        auto_resume_parked: None,
     }
 }
 

--- a/crates/trusty-mpm/src/bin/tm/commands/picker_delete_glob_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/picker_delete_glob_tests.rs
@@ -44,6 +44,7 @@ fn session(name: &str, state: &str) -> ManagedSessionSummary {
         attached: false,
         slot: 1,
         deleted: false,
+        auto_resume_parked: None,
     }
 }
 

--- a/crates/trusty-mpm/src/bin/tm/commands/picker_launch_new_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/picker_launch_new_tests.rs
@@ -38,6 +38,7 @@ fn session(name: &str, state: &str, workspace_path: Option<&str>) -> ManagedSess
         attached: false,
         slot: 1,
         deleted: false,
+        auto_resume_parked: None,
     }
 }
 

--- a/crates/trusty-mpm/src/bin/tm/commands/session_picker_filter_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_picker_filter_tests.rs
@@ -37,6 +37,7 @@ fn s(name: &str, task: Option<&str>, source_id: Option<&str>) -> ManagedSessionS
         attached: false,
         slot: 1,
         deleted: false,
+        auto_resume_parked: None,
     }
 }
 

--- a/crates/trusty-mpm/src/bin/tm/commands/session_picker_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_picker_tests.rs
@@ -46,6 +46,7 @@ fn session(name: &str, state: &str, slot: u32) -> ManagedSessionSummary {
         attached: false,
         slot,
         deleted: false,
+        auto_resume_parked: None,
     }
 }
 

--- a/crates/trusty-mpm/src/bin/tm/main.rs
+++ b/crates/trusty-mpm/src/bin/tm/main.rs
@@ -297,58 +297,16 @@ async fn main() -> anyhow::Result<()> {
     ) {
         #[cfg(feature = "daemon")]
         {
-            // File logging: write daily-rotated logs to ~/.trusty-mpm/logs/ in
-            // addition to the existing stderr stream.
-            let log_dir = dirs::home_dir()
-                .ok_or_else(|| anyhow::anyhow!("cannot resolve home directory"))?
-                .join(".trusty-mpm")
-                .join("logs");
-            std::fs::create_dir_all(&log_dir)?;
-            let file_appender = tracing_appender::rolling::daily(&log_dir, "trusty-mpm.log");
-            let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
+            // #6569: the rotated file sink plus, under launchd, NO stderr layer
+            // — launchd's own StandardErrorPath capture was writing every line
+            // a second time to a file nothing rotates. `tracing_setup` owns the
+            // whole composition and the sink decision behind it.
+            let (guard, store) = tracing_setup::init_daemon_tracing()?;
+            // Both handles must outlive this block: the guard flushes the
+            // non-blocking appender, and the store is the read half of the
+            // capture ring (see the comments on their declarations above).
             _daemon_log_guard = Some(guard);
-
-            // EnvFilter is not Clone, so we build two independent instances that
-            // both re-parse RUST_LOG from the environment — one for the stderr
-            // layer, one for the file layer. This is intentional: each layer
-            // needs its own owned filter, and re-parsing is cheap at startup.
-            let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "info".into());
-            let file_filter = tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "info".into());
-
-            // Bug-reporting Phase 1 (#478): compose the bug-capture layer so
-            // ERROR events are captured to <data_dir>/trusty-mpm/errors.jsonl
-            // and an in-memory ring without modifying any call sites.
-            // Capture writes ONLY to JSONL + in-memory ring — never stdout —
-            // so this is safe for both the HTTP daemon and the MCP stdio path.
-            let (capture_layer, store) = trusty_common::error_capture::bug_capture_layer(
-                "trusty-mpm",
-                trusty_common::error_capture::DEFAULT_CAPTURE_CAPACITY,
-                env!("CARGO_PKG_VERSION"),
-            );
-            // Move store into the main-scope binding so it outlives this block
-            // and remains reachable for the entire daemon run (see comment above).
             _error_store = Some(store);
-
-            use tracing_subscriber::Layer as _;
-            use tracing_subscriber::layer::SubscriberExt as _;
-            use tracing_subscriber::util::SubscriberInitExt as _;
-            tracing_subscriber::registry()
-                .with(
-                    tracing_subscriber::fmt::layer()
-                        // MCP mode speaks JSON-RPC on stdout — keep tracing on stderr.
-                        .with_writer(std::io::stderr)
-                        .with_filter(env_filter),
-                )
-                .with(
-                    tracing_subscriber::fmt::layer()
-                        .with_writer(non_blocking)
-                        .with_ansi(false)
-                        .with_filter(file_filter),
-                )
-                .with(capture_layer)
-                .init();
         }
         // #4573: shares `tracing_setup`'s stderr-only builder with the CLI
         // inspection path — the two were byte-for-byte the same builder.

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
@@ -1294,6 +1294,7 @@ fn make_session(
         attached: false,
         slot: 0,
         deleted: false,
+        auto_resume_parked: None,
     }
 }
 

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_d_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_d_tests.rs
@@ -1193,6 +1193,7 @@ fn ls_test_session(
         attached: false,
         slot: 0,
         deleted: false,
+        auto_resume_parked: None,
     }
 }
 

--- a/crates/trusty-mpm/src/bin/tm/tracing_setup.rs
+++ b/crates/trusty-mpm/src/bin/tm/tracing_setup.rs
@@ -116,6 +116,135 @@ pub(crate) fn init_stderr_only(default: &str) {
         .try_init();
 }
 
+/// Whether the long-running modes should also write every event to stderr.
+///
+/// Why (#6569): under launchd the daemon plist's `StandardErrorPath` captures
+/// this process's stderr into a file launchd never rotates, so every line the
+/// rotated `~/.trusty-mpm/logs/trusty-mpm.log.*` already holds was written a
+/// second time to `~/Library/Logs/trusty-mpm/stderr.log`. That file reached
+/// 3.4 GB against 3.0 GB of rotated logs over one 48-hour window. Only one of
+/// the two sinks can be dropped without losing anything, and it is the stderr
+/// one — nothing reads it that the rotated file does not serve better.
+/// What: two states, decided by [`stderr_sink_decision`].
+/// Test: `stderr_sink_matrix`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StderrSink {
+    /// Register the stderr `fmt` layer — a foreground operator is watching, or
+    /// there is no file sink to fall back on.
+    Register,
+    /// Skip it: launchd is already capturing stderr, and the rotated file layer
+    /// has the same events.
+    Skip,
+}
+
+/// Decide whether to register the stderr layer beside the rotated file layer.
+///
+/// Why: the duplicate-write condition is a conjunction — a rotated file sink
+/// AND launchd capturing stderr — and getting either half wrong loses logs
+/// rather than merely duplicating them. Keeping it a pure function of those two
+/// inputs is what makes the whole 2x3 matrix assertable without a daemon, a
+/// plist, or a real `launchctl`.
+/// What: [`StderrSink::Skip`] only when a file layer is configured AND launchd
+/// positively reports it supervises this process. Every other cell registers:
+/// with no file layer there is nowhere else for events to go; `NotSupervised`
+/// is a foreground run whose operator is reading the terminal; and `Unknown`
+/// means launchd could not be asked, where duplicating output is strictly
+/// better than silently having none. That asymmetry is deliberate — this
+/// function may only ever remove a sink on positive evidence, the same rule
+/// `trusty_common::supervision` was built around (#4469).
+/// Test: `stderr_sink_matrix`, `stderr_sink_never_skips_without_a_file_layer`.
+pub(crate) fn stderr_sink_decision(
+    file_layer_configured: bool,
+    supervision: &trusty_common::supervision::LaunchdSupervision,
+) -> StderrSink {
+    use trusty_common::supervision::LaunchdSupervision;
+    match (file_layer_configured, supervision) {
+        (true, LaunchdSupervision::Supervised(_)) => StderrSink::Skip,
+        _ => StderrSink::Register,
+    }
+}
+
+/// Build the daemon/supervisor subscriber: rotated file, optional stderr, capture.
+///
+/// Why: this composition used to sit inline in `main.rs`, which is at the
+/// 500-SLOC cap, and it is where #6569's duplicate sink lived. Moving it here
+/// puts the sink choice next to [`stderr_sink_decision`] that governs it.
+/// What: creates `~/.trusty-mpm/logs/`, builds the daily-rotating appender, asks
+/// launchd once via `trusty_common::supervision::launchd_supervision` (bounded —
+/// see that function; an unreachable launchd answers `Unknown` and keeps
+/// stderr), and registers the layers a single `init` call. Returns the
+/// appender's `WorkerGuard` and the bug-capture `ErrorStore`, both of which the
+/// caller must hold for the process lifetime.
+///
+/// `EnvFilter` is not `Clone`, so each layer gets its own instance re-parsed
+/// from `RUST_LOG`; re-parsing is cheap and happens once at startup.
+/// Test: the sink choice by `stderr_sink_matrix`; the composition itself is a
+/// startup path exercised by every daemon run.
+#[cfg(feature = "daemon")]
+pub(crate) fn init_daemon_tracing() -> anyhow::Result<(
+    tracing_appender::non_blocking::WorkerGuard,
+    trusty_common::error_capture::ErrorStore,
+)> {
+    use tracing_subscriber::Layer as _;
+    use tracing_subscriber::layer::SubscriberExt as _;
+    use tracing_subscriber::util::SubscriberInitExt as _;
+
+    let log_dir = dirs::home_dir()
+        .ok_or_else(|| anyhow::anyhow!("cannot resolve home directory"))?
+        .join(".trusty-mpm")
+        .join("logs");
+    std::fs::create_dir_all(&log_dir)?;
+    let file_appender = tracing_appender::rolling::daily(&log_dir, "trusty-mpm.log");
+    let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
+
+    // Bug-reporting Phase 1 (#478): ERROR events are captured to
+    // <data_dir>/trusty-mpm/errors.jsonl and an in-memory ring. Capture never
+    // writes stdout, so it is safe for both the HTTP daemon and MCP stdio.
+    let (capture_layer, store) = trusty_common::error_capture::bug_capture_layer(
+        "trusty-mpm",
+        trusty_common::error_capture::DEFAULT_CAPTURE_CAPACITY,
+        env!("CARGO_PKG_VERSION"),
+    );
+
+    // #6569: a file sink is always configured on this path, so the only open
+    // question is whether launchd is also capturing stderr into its own
+    // unrotated file.
+    let supervision = trusty_common::supervision::launchd_supervision();
+    let stderr_sink = stderr_sink_decision(true, &supervision);
+
+    let file_layer = tracing_subscriber::fmt::layer()
+        .with_writer(non_blocking)
+        .with_ansi(false)
+        .with_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()),
+        );
+    // MCP mode speaks JSON-RPC on stdout — tracing never leaves stdout.
+    let stderr_layer = (stderr_sink == StderrSink::Register).then(|| {
+        tracing_subscriber::fmt::layer()
+            .with_writer(std::io::stderr)
+            .with_filter(
+                tracing_subscriber::EnvFilter::try_from_default_env()
+                    .unwrap_or_else(|_| "info".into()),
+            )
+    });
+
+    tracing_subscriber::registry()
+        .with(stderr_layer)
+        .with(file_layer)
+        .with(capture_layer)
+        .init();
+
+    // First line into the file sink, so an operator reading the rotated log can
+    // see which sink layout this process chose and why.
+    tracing::info!(
+        log_dir = %log_dir.display(),
+        stderr_sink = ?stderr_sink,
+        supervision = %supervision.describe(),
+        "tracing initialised for a long-running mode (#6569)"
+    );
+    Ok((guard, store))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -177,5 +306,64 @@ mod tests {
         // no-panic property in either order.
         init_stderr_only("warn");
         init_stderr_only("warn");
+    }
+
+    /// The whole #6569 decision, as a matrix: file layer x what launchd says.
+    ///
+    /// Why: the duplicate write only happens in ONE of these six cells, and the
+    /// cost of getting any other cell wrong is losing log output rather than
+    /// duplicating it. Asserting the matrix is what proves the fix removed a
+    /// sink in exactly the case that had two.
+    /// Test: this is the test. RED before the fix: `stderr_sink_decision` did
+    /// not exist and `main.rs` registered the stderr layer unconditionally.
+    #[test]
+    fn stderr_sink_matrix() {
+        use trusty_common::supervision::LaunchdSupervision;
+
+        let supervised = LaunchdSupervision::Supervised("com.trusty.mpm".into());
+        let not = LaunchdSupervision::NotSupervised;
+        let unknown = LaunchdSupervision::Unknown("launchctl not on PATH".into());
+
+        // The one cell that had two sinks: launchd captures stderr into its own
+        // unrotated file while the rotated file layer holds the same events.
+        assert_eq!(
+            stderr_sink_decision(true, &supervised),
+            StderrSink::Skip,
+            "a launchd-supervised process with a file sink must not also write stderr"
+        );
+
+        // A foreground run: the operator is reading the terminal.
+        assert_eq!(stderr_sink_decision(true, &not), StderrSink::Register);
+
+        // Unanswerable is not evidence. Duplicating beats going silent, and the
+        // sink may only be removed on a positive answer (#4469's rule).
+        assert_eq!(
+            stderr_sink_decision(true, &unknown),
+            StderrSink::Register,
+            "an unreachable launchd must never cost the operator their logs"
+        );
+
+        // With no file layer, stderr is the only sink there is.
+        for supervision in [&supervised, &not, &unknown] {
+            assert_eq!(
+                stderr_sink_decision(false, supervision),
+                StderrSink::Register,
+                "{supervision:?} must still keep stderr when nothing else is configured"
+            );
+        }
+    }
+
+    /// The invariant behind the matrix, stated on its own: no combination of
+    /// launchd answers may leave a process with zero sinks.
+    #[test]
+    fn stderr_sink_never_skips_without_a_file_layer() {
+        use trusty_common::supervision::LaunchdSupervision;
+        for supervision in [
+            LaunchdSupervision::Supervised("com.trusty.mpm".into()),
+            LaunchdSupervision::NotSupervised,
+            LaunchdSupervision::Unknown("timed out".into()),
+        ] {
+            assert_ne!(stderr_sink_decision(false, &supervision), StderrSink::Skip);
+        }
     }
 }

--- a/crates/trusty-mpm/src/client/http_client/types.rs
+++ b/crates/trusty-mpm/src/client/http_client/types.rs
@@ -584,6 +584,22 @@ pub struct ManagedSessionSummary {
     /// Test: `managed_session_summary_deserializes_slot_and_deleted`.
     #[serde(default)]
     pub deleted: bool,
+    /// Why the supervisor has stopped auto-resuming this session, if it has
+    /// (#6568).
+    ///
+    /// Why: a parked session renders exactly like an idle stopped one, and the
+    /// difference is that nothing will ever revive it. Carrying the reason to
+    /// the CLI lets `tm session ls` mark the row and `tm session status` print
+    /// the whole sentence, including how to clear it.
+    /// What: `Some(<reason>)` when the daemon reports one — mirroring
+    /// `daemon::managed_routes::SessionSummary::auto_resume_parked`, whose value
+    /// comes from `SessionRecord::auto_resume_park_reason`. `#[serde(default)]`
+    /// keeps an older daemon that omits the field deserializable; it reads as
+    /// "not parked", which is what such a daemon means.
+    /// Test: `format_state_column_appends_resume_parked_marker` in
+    /// `commands::managed_tests`.
+    #[serde(default)]
+    pub auto_resume_parked: Option<String>,
 }
 
 /// Wrapper for `GET /api/v1/sessions/managed` (the list endpoint).

--- a/crates/trusty-mpm/src/client/resolver.rs
+++ b/crates/trusty-mpm/src/client/resolver.rs
@@ -194,6 +194,7 @@ mod tests {
             attached: false,
             slot: 0,
             deleted: false,
+            auto_resume_parked: None,
         };
         let items = vec![summary("m-1", "tmpm-red-owl"), summary("m-2", "api")];
         assert_eq!(

--- a/crates/trusty-mpm/src/daemon/api_tests.rs
+++ b/crates/trusty-mpm/src/daemon/api_tests.rs
@@ -2203,6 +2203,7 @@ fn pane_for_gate_test(name: &str, cmd: &str) -> crate::daemon::orphan_gc::PaneIn
         pane_current_command: cmd.to_string(),
         pane_pid: Some(4242),
         pane_id: None,
+        pane_current_path: None,
     }
 }
 

--- a/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
@@ -56,7 +56,7 @@ mod resume_error;
 pub(crate) mod route_outcome_http;
 mod session_prep;
 mod session_summary;
-mod summary;
+pub(crate) mod summary;
 pub mod sync_assets;
 pub use activity::{ActivityResponse, get_session_activity};
 pub use delete::{delete_managed_session, stop_managed_session};

--- a/crates/trusty-mpm/src/daemon/managed_routes/reactivate.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/reactivate.rs
@@ -385,6 +385,7 @@ mod tests {
             pane_current_command: cmd.to_string(),
             pane_pid: Some(4242),
             pane_id: None,
+            pane_current_path: None,
         }
     }
 
@@ -396,6 +397,7 @@ mod tests {
             pane_current_command: cmd.to_string(),
             pane_pid: Some(4242),
             pane_id: Some(pane_id.to_string()),
+            pane_current_path: None,
         }
     }
 

--- a/crates/trusty-mpm/src/daemon/managed_routes/session_summary.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/session_summary.rs
@@ -243,4 +243,22 @@ pub struct SessionSummary {
     /// (handler integration test, `tests/session_manager_slots.rs`).
     #[serde(default)]
     pub deleted: bool,
+    /// Why the supervisor has stopped auto-resuming this session, if it has
+    /// (#6568).
+    ///
+    /// Why: a parked session looks exactly like an idle stopped one on every
+    /// listing surface — the difference is only that nothing will ever revive
+    /// it. Before this field the only trace was the absence of resume lines in
+    /// a multi-gigabyte log. Carrying the reason on the wire puts it in
+    /// `tm session ls`'s and `tm session status`'s JSON, and in the MCP
+    /// `session_list` / `session_status` tools that pass this shape through.
+    /// What: `Some(<reason>)` exactly when the record's `stop_cause` is
+    /// `ResumeFlapping` — the string comes from
+    /// [`crate::session_manager::SessionRecord::auto_resume_park_reason`], the
+    /// single place the wording lives. `None` for every other record, and
+    /// omitted from the JSON entirely so an older consumer sees no change.
+    /// Test: `summary_carries_the_resume_park_reason` in
+    /// `session_manager::resume_breaker_tests`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auto_resume_parked: Option<String>,
 }

--- a/crates/trusty-mpm/src/daemon/managed_routes/summary.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/summary.rs
@@ -95,7 +95,7 @@ fn injection_status_wire(status: InjectionStatus) -> Option<String> {
 /// (#2595) overwrite the field on the returned value when they can await the
 /// probe.
 /// Test: covered by the list/get handler tests.
-pub(super) fn record_to_summary(r: &SessionRecord) -> SessionSummary {
+pub(crate) fn record_to_summary(r: &SessionRecord) -> SessionSummary {
     SessionSummary {
         id: r.id.to_string(),
         name: r.tmux_name.clone(),
@@ -134,6 +134,9 @@ pub(super) fn record_to_summary(r: &SessionRecord) -> SessionSummary {
         // them at their "not applicable" defaults.
         slot: 0,
         deleted: false,
+        // #6568: read straight off the record's `stop_cause`, so every listing
+        // surface says the same thing about a parked session.
+        auto_resume_parked: r.auto_resume_park_reason().map(str::to_string),
     }
 }
 
@@ -301,6 +304,7 @@ pub(super) fn tombstone_summary(slot: u32) -> SessionSummary {
         attached: false,
         slot,
         deleted: true,
+        auto_resume_parked: None,
     }
 }
 

--- a/crates/trusty-mpm/src/daemon/managed_routes/tests.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/tests.rs
@@ -509,6 +509,7 @@ fn decommission_workspace_removed_reflects_ownership() {
         attached: false,
         slot: 0,
         deleted: false,
+        auto_resume_parked: None,
     };
     let resp_owned = DecommissionResponse {
         summary: owned_summary,
@@ -549,6 +550,7 @@ fn decommission_workspace_removed_reflects_ownership() {
         attached: false,
         slot: 0,
         deleted: false,
+        auto_resume_parked: None,
     };
     let resp_unowned = DecommissionResponse {
         summary: unowned_summary,

--- a/crates/trusty-mpm/src/daemon/mod.rs
+++ b/crates/trusty-mpm/src/daemon/mod.rs
@@ -736,7 +736,9 @@ async fn orphan_gc_loop(state: Arc<DaemonState>, cancel: tokio_util::sync::Cance
         interval_secs,
         "orphan-GC enabled; running startup sweep then periodic reconciliation"
     );
-    let mut gc = orphan_gc::OrphanGc::new();
+    // #6118: the untracked-active skip log repeats once every N sweeps per
+    // session rather than every sweep; N is overridable for live debugging.
+    let mut gc = orphan_gc::OrphanGc::from_env();
     // Cross-restart debounce for the PID-file sweep (#1918): owned here (not
     // reconstructed per-tick) so its two-pass candidate history persists across
     // sweeps, exactly like `gc` above.
@@ -831,7 +833,11 @@ async fn orphan_gc_loop(state: Arc<DaemonState>, cancel: tokio_util::sync::Cance
                 let tracked = state.gather_tracked_names().await;
                 let mgr = state.session_manager().await;
                 let mtmux = mgr.tmux_driver();
-                let reaped = orphan_gc::run_sweep(&mut gc, &panes, &tracked, &probe, mtmux.as_ref());
+                // #6118: `run_sweep_fs` supplies the filesystem cwd probe, which
+                // is what lets the sweep reap a pane whose worktree was deleted
+                // underneath it — see `orphan_gc::CwdProbe`.
+                let reaped =
+                    orphan_gc::run_sweep_fs(&mut gc, &panes, &tracked, &probe, mtmux.as_ref());
                 if reaped > 0 {
                     info!("orphan-GC reaped {reaped} orphaned managed session(s)");
                 }

--- a/crates/trusty-mpm/src/daemon/orphan_gc.rs
+++ b/crates/trusty-mpm/src/daemon/orphan_gc.rs
@@ -132,14 +132,20 @@ pub struct PaneInfo {
 ///
 /// Why (ADR-0045): "the directory is gone" and "I could not tell" are different
 /// answers, and only the first is evidence for a kill. Collapsing them into a
-/// bool is exactly the fail-open shape that ADR forbids on a destructive path —
-/// a permission error, a stalled network mount, or a tmux that reported nothing
-/// would all read as "gone" and kill a pane doing real work.
+/// bool is exactly the fail-open shape that ADR forbids on a destructive path.
+///
+/// ADR-0045's trigger table names the case that makes this more than a
+/// formality: an unmounted or ejected volume returns plain ENOENT, NOT an error
+/// kind that could be recognised as "undeterminable". An external disk carrying
+/// a live agent's worktree therefore looks byte-for-byte like a deleted
+/// worktree to `symlink_metadata` alone. [`FsCwdProbe`] separates them by asking
+/// about the PARENT — see its doc.
 /// What: three states. `Exists` and `Gone` are decided answers; `Undeterminable`
 /// covers every case where the answer was not obtained, including tmux reporting
 /// no path at all.
 /// Test: `fs_cwd_probe_reports_exists_for_a_real_dir`,
 /// `fs_cwd_probe_reports_gone_for_a_deleted_dir`,
+/// `fs_cwd_probe_is_undeterminable_when_the_parent_is_gone_too`,
 /// `classify_keeps_active_pane_when_cwd_is_undeterminable`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CwdEvidence {
@@ -156,9 +162,10 @@ pub enum CwdEvidence {
 /// Why: keeps [`classify_session`] pure and lets tests decide the answer without
 /// creating and deleting real directories, mirroring [`ChildLivenessProbe`].
 /// What: one method mapping a non-empty path string to a [`CwdEvidence`].
-/// Fail-closed contract: return [`CwdEvidence::Gone`] ONLY when the path is
-/// confirmed absent. Any error that is not "not found" — a permission denial, an
-/// unresponsive mount, an interrupted call — MUST return
+/// Fail-closed contract: return [`CwdEvidence::Gone`] ONLY when the path's
+/// absence is attributable to that path itself. An error that is not "not
+/// found" — a permission denial, an I/O failure, a stale NFS handle — and an
+/// absence that extends to the path's whole enclosing subtree both MUST return
 /// [`CwdEvidence::Undeterminable`], which keeps the pane.
 /// Test: [`FsCwdProbe`]'s tests below; the fakes in the `tests` submodule drive
 /// the classifier.
@@ -170,21 +177,51 @@ pub trait CwdProbe {
 /// The production [`CwdProbe`], backed by `std::fs`.
 ///
 /// Why: the reap decision must consult the real filesystem, and the
-/// absent-vs-undeterminable split has to be made from the actual `io::Error`
-/// kind rather than from an `is_ok()` bool.
-/// What: `symlink_metadata` — never `metadata`, which follows the link and would
-/// call a dangling symlink "gone" when the pane's own path entry is very much
-/// there. `Ok` → [`CwdEvidence::Exists`]; `ErrorKind::NotFound` →
-/// [`CwdEvidence::Gone`]; every other error → [`CwdEvidence::Undeterminable`].
+/// absent-vs-undeterminable split cannot be made from the `io::Error` kind
+/// alone. ADR-0045's trigger table is explicit that an unmounted or ejected
+/// volume answers plain ENOENT — the SAME answer a deleted worktree gives. A
+/// probe that stopped at `NotFound` would kill an agent working on an external
+/// disk about two minutes after someone ejected it, which is the opposite of
+/// what #6118 asks for.
+///
+/// What separates the two is the PARENT. #6118's target is a worktree removed
+/// from an intact `.claude/worktrees/`, so the parent survives. An ejected
+/// volume, an unmounted share, and a deleted parent tree all take the parent
+/// with them, and none of those is evidence about this pane's own directory.
+/// What: `symlink_metadata` on the path — never `metadata`, which follows the
+/// link and would call a dangling symlink "gone" when the pane's own entry is
+/// very much there. `Ok` → [`CwdEvidence::Exists`]. `ErrorKind::NotFound` →
+/// [`CwdEvidence::Gone`] only when the parent directory is itself present;
+/// otherwise [`CwdEvidence::Undeterminable`]. A path with no parent, and every
+/// other error kind, are [`CwdEvidence::Undeterminable`].
 /// Test: `fs_cwd_probe_reports_exists_for_a_real_dir`,
-/// `fs_cwd_probe_reports_gone_for_a_deleted_dir`.
+/// `fs_cwd_probe_reports_gone_for_a_deleted_dir`,
+/// `fs_cwd_probe_is_undeterminable_when_the_parent_is_gone_too`,
+/// `fs_cwd_probe_is_undeterminable_on_a_non_notfound_error`.
 pub struct FsCwdProbe;
 
 impl CwdProbe for FsCwdProbe {
     fn evidence(&self, path: &str) -> CwdEvidence {
         match std::fs::symlink_metadata(path) {
             Ok(_) => CwdEvidence::Exists,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => CwdEvidence::Gone,
+            // #6118: absent — but absent WHY? Only a surviving parent makes this
+            // about this directory rather than about its whole volume.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                let Some(parent) = std::path::Path::new(path).parent() else {
+                    return CwdEvidence::Undeterminable;
+                };
+                if std::fs::symlink_metadata(parent).is_ok() {
+                    CwdEvidence::Gone
+                } else {
+                    debug!(
+                        path = %path,
+                        "orphan-GC: a pane's cwd is absent and so is its parent — an unmounted \
+                         volume answers exactly like a deleted directory (ADR-0045), so this is \
+                         not evidence; keeping the pane (#6118)"
+                    );
+                    CwdEvidence::Undeterminable
+                }
+            }
             Err(e) => {
                 warn!(
                     path = %path,
@@ -1227,7 +1264,66 @@ mod tests {
         assert_eq!(
             FsCwdProbe.evidence(&path.to_string_lossy()),
             CwdEvidence::Gone,
-            "a deleted worktree is the exact live condition #6118 reports"
+            "a deleted worktree inside an intact parent is the exact live \
+             condition #6118 reports"
+        );
+    }
+
+    /// ADR-0045's first trigger row: an unmounted or ejected volume answers
+    /// plain ENOENT, indistinguishable from a deleted directory by error kind
+    /// alone. The surviving-parent gate is what separates them — an ejected disk
+    /// takes the parent with it, a removed worktree does not.
+    ///
+    /// Input this reproduces: an untracked pane running `claude` with its cwd on
+    /// an external volume, ejected. Without the gate the agent is killed about
+    /// two sweeps (~2 minutes) later.
+    /// Test: this is the test. RED before the parent gate: `Gone`.
+    #[test]
+    fn fs_cwd_probe_is_undeterminable_when_the_parent_is_gone_too() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let mount = tmp.path().join("Volumes-Ext");
+        let workdir = mount.join("work").join("repo");
+        std::fs::create_dir_all(&workdir).expect("create");
+        assert_eq!(
+            FsCwdProbe.evidence(&workdir.to_string_lossy()),
+            CwdEvidence::Exists
+        );
+
+        // The whole subtree disappears at once, as an eject does.
+        std::fs::remove_dir_all(&mount).expect("eject");
+        assert_eq!(
+            FsCwdProbe.evidence(&workdir.to_string_lossy()),
+            CwdEvidence::Undeterminable,
+            "an absent path whose parent is also absent is not evidence about \
+             that path — it is an unmounted volume (ADR-0045)"
+        );
+    }
+
+    /// The `Err(other)` arm: an error that is not `NotFound` must keep the pane.
+    ///
+    /// What: probing `<regular file>/child` yields ENOTDIR on every supported
+    /// target — a non-`NotFound` error reachable without root or a real mount.
+    #[test]
+    fn fs_cwd_probe_is_undeterminable_on_a_non_notfound_error() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let file = tmp.path().join("not-a-dir");
+        std::fs::write(&file, b"x").expect("write");
+        let under_a_file = file.join("child");
+        assert_eq!(
+            FsCwdProbe.evidence(&under_a_file.to_string_lossy()),
+            CwdEvidence::Undeterminable,
+            "an unexpected errno must never read as absence"
+        );
+    }
+
+    /// A path with no parent cannot be gated, so it is never evidence.
+    #[test]
+    fn fs_cwd_probe_is_undeterminable_for_a_parentless_path() {
+        assert_eq!(FsCwdProbe.evidence("/"), CwdEvidence::Exists);
+        // A bare relative name has an empty parent, which does not stat.
+        assert_eq!(
+            FsCwdProbe.evidence("definitely-not-here-6118"),
+            CwdEvidence::Undeterminable
         );
     }
 

--- a/crates/trusty-mpm/src/daemon/orphan_gc.rs
+++ b/crates/trusty-mpm/src/daemon/orphan_gc.rs
@@ -26,12 +26,33 @@
 //! exercise the full decision matrix with a fake driver; `run_sweep` is covered
 //! by `tests/orphan_gc_sweep.rs` against a fake [`ManagedTmuxDriver`](crate::session_manager::ManagedTmuxDriver).
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::process::Command;
 
 use tracing::{debug, info, warn};
 
 use crate::core::names::is_managed_session_name;
+
+/// How many sweeps pass between two "untracked active managed session" lines
+/// for the SAME session, when nothing else changes.
+///
+/// Why (#6118): the previous code logged one line per warned session per sweep.
+/// 478 permanently-warned sessions on a 60-second sweep produced 992,078 lines
+/// in 48 hours — 76% of every daemon log line written. The set of warned
+/// sessions is stable for hours at a time, so re-stating it every minute adds
+/// no information after the first line.
+/// What: a session is logged on its FIRST sweep as a warn candidate and then
+/// once every `DEFAULT_SKIP_LOG_EVERY_SWEEPS` sweeps thereafter; the per-sweep
+/// TOTAL stays in the sweep-complete summary either way. At the daemon's
+/// 60-second cadence this is one line per session per hour.
+/// Test: `skip_log_is_throttled_per_session`, `skip_log_repeats_after_n_sweeps`.
+pub const DEFAULT_SKIP_LOG_EVERY_SWEEPS: u32 = 60;
+
+/// Environment override for [`DEFAULT_SKIP_LOG_EVERY_SWEEPS`].
+///
+/// `0` or an unparsable value falls back to the default; `1` restores the
+/// pre-#6118 log-every-sweep behavior.
+pub const ENV_SKIP_LOG_EVERY_SWEEPS: &str = "TRUSTY_MPM_ORPHAN_GC_SKIP_LOG_EVERY";
 
 /// Shell commands that mark a pane as *idle* (no agent running inside it).
 ///
@@ -92,6 +113,104 @@ pub struct PaneInfo {
     /// Distinct from `pane_pid` (which the OS can reuse across a pane's
     /// lifetime); never inherited across panes, unlike an env var.
     pub pane_id: Option<String>,
+    /// The pane's working directory as tmux reports it, when the enumeration
+    /// captured one (#6118).
+    ///
+    /// Why: the GC's only reap path used to be "bare shell, no live child",
+    /// which never covers a pane whose worktree was deleted underneath it — the
+    /// pane keeps running an agent, `reconcile` declines to adopt it because its
+    /// cwd does not resolve, and nothing else can act. tmux still reports the
+    /// path it recorded for the pane, so comparing that path against the
+    /// filesystem is POSITIVE evidence the pane has nothing left to work in.
+    /// What: `Some(path)` when tmux reported a non-empty `#{pane_current_path}`;
+    /// `None` when it reported an empty field or the enumeration predates this
+    /// column. `None` is NO evidence and can never select a pane for reaping.
+    pub pane_current_path: Option<String>,
+}
+
+/// What the filesystem says about a pane's reported working directory (#6118).
+///
+/// Why (ADR-0045): "the directory is gone" and "I could not tell" are different
+/// answers, and only the first is evidence for a kill. Collapsing them into a
+/// bool is exactly the fail-open shape that ADR forbids on a destructive path —
+/// a permission error, a stalled network mount, or a tmux that reported nothing
+/// would all read as "gone" and kill a pane doing real work.
+/// What: three states. `Exists` and `Gone` are decided answers; `Undeterminable`
+/// covers every case where the answer was not obtained, including tmux reporting
+/// no path at all.
+/// Test: `fs_cwd_probe_reports_exists_for_a_real_dir`,
+/// `fs_cwd_probe_reports_gone_for_a_deleted_dir`,
+/// `classify_keeps_active_pane_when_cwd_is_undeterminable`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CwdEvidence {
+    /// The path tmux reported resolves to something on disk.
+    Exists,
+    /// The path tmux reported is confirmed ABSENT — the one reapable answer.
+    Gone,
+    /// No answer: tmux reported no path, or the filesystem could not say.
+    Undeterminable,
+}
+
+/// A probe answering whether a pane's reported working directory still exists.
+///
+/// Why: keeps [`classify_session`] pure and lets tests decide the answer without
+/// creating and deleting real directories, mirroring [`ChildLivenessProbe`].
+/// What: one method mapping a non-empty path string to a [`CwdEvidence`].
+/// Fail-closed contract: return [`CwdEvidence::Gone`] ONLY when the path is
+/// confirmed absent. Any error that is not "not found" — a permission denial, an
+/// unresponsive mount, an interrupted call — MUST return
+/// [`CwdEvidence::Undeterminable`], which keeps the pane.
+/// Test: [`FsCwdProbe`]'s tests below; the fakes in the `tests` submodule drive
+/// the classifier.
+pub trait CwdProbe {
+    /// Classify `path` (guaranteed non-empty by the caller).
+    fn evidence(&self, path: &str) -> CwdEvidence;
+}
+
+/// The production [`CwdProbe`], backed by `std::fs`.
+///
+/// Why: the reap decision must consult the real filesystem, and the
+/// absent-vs-undeterminable split has to be made from the actual `io::Error`
+/// kind rather than from an `is_ok()` bool.
+/// What: `symlink_metadata` — never `metadata`, which follows the link and would
+/// call a dangling symlink "gone" when the pane's own path entry is very much
+/// there. `Ok` → [`CwdEvidence::Exists`]; `ErrorKind::NotFound` →
+/// [`CwdEvidence::Gone`]; every other error → [`CwdEvidence::Undeterminable`].
+/// Test: `fs_cwd_probe_reports_exists_for_a_real_dir`,
+/// `fs_cwd_probe_reports_gone_for_a_deleted_dir`.
+pub struct FsCwdProbe;
+
+impl CwdProbe for FsCwdProbe {
+    fn evidence(&self, path: &str) -> CwdEvidence {
+        match std::fs::symlink_metadata(path) {
+            Ok(_) => CwdEvidence::Exists,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => CwdEvidence::Gone,
+            Err(e) => {
+                warn!(
+                    path = %path,
+                    error = %e,
+                    "orphan-GC: cannot determine whether a pane's cwd still exists; keeping the pane (#6118)"
+                );
+                CwdEvidence::Undeterminable
+            }
+        }
+    }
+}
+
+/// Classify a pane's reported cwd, treating an unreported path as no evidence.
+///
+/// Why: `None` and `Some("")` both mean tmux told us nothing, and neither may
+/// ever reach the filesystem probe as a path to test — an empty string would
+/// resolve to the process cwd and answer `Exists` for a pane we know nothing
+/// about.
+/// What: returns [`CwdEvidence::Undeterminable`] for a missing or blank path;
+/// otherwise delegates to `probe`.
+/// Test: `pane_cwd_evidence_is_undeterminable_without_a_path`.
+pub fn pane_cwd_evidence(pane: &PaneInfo, probe: &dyn CwdProbe) -> CwdEvidence {
+    match pane.pane_current_path.as_deref().map(str::trim) {
+        Some(p) if !p.is_empty() => probe.evidence(p),
+        _ => CwdEvidence::Undeterminable,
+    }
 }
 
 /// The GC's verdict for a single tmux session.
@@ -114,6 +233,11 @@ pub enum GcDecision {
     /// The session is a reap candidate this pass (managed + untracked + idle).
     /// Debounce still gates whether it is actually killed.
     ReapCandidate,
+    /// The session is a reap candidate for a DIFFERENT reason (#6118): it is
+    /// managed, untracked, and its pane's working directory is confirmed gone,
+    /// even though the pane's foreground command is not a bare shell. Debounce
+    /// gates this exactly as it gates [`Self::ReapCandidate`].
+    ReapCandidateCwdGone,
 }
 
 /// Why a session was kept by [`classify_session`].
@@ -232,16 +356,30 @@ impl ChildLivenessProbe for AlwaysIdleProbe {
 /// 3. it is genuinely idle: `pane_current_command` is a bare shell
 ///    ([`is_idle_shell`]) AND the `probe` finds no live agent child.
 ///
-/// A managed, untracked, but *active* (non-shell) session yields
-/// [`GcDecision::WarnUntrackedActive`] (keep + warn). Everything else is a
-/// [`GcDecision::Keep`] with the precise [`KeepReason`].
+/// A managed, untracked, *active* (non-shell) session whose pane's working
+/// directory is CONFIRMED gone yields [`GcDecision::ReapCandidateCwdGone`]
+/// (#6118) — the pane has no directory left to work in, `reconcile` has already
+/// declined to adopt it for that reason, and nothing else could ever act on it.
+/// Any other active untracked session yields [`GcDecision::WarnUntrackedActive`]
+/// (keep + warn). Everything else is a [`GcDecision::Keep`] with the precise
+/// [`KeepReason`].
+///
+/// The cwd gate is POSITIVE evidence only (ADR-0045): a pane whose path tmux
+/// never reported, or whose existence the filesystem could not decide, is KEPT
+/// exactly as before. Both reap candidates still pass through the same two-sweep
+/// debounce in [`OrphanGc::plan_sweep`] before anything is killed.
 /// Test: `classify_keeps_non_managed`, `classify_keeps_tracked_legacy`,
 /// `classify_keeps_tracked_managed`, `classify_warns_untracked_active`,
-/// `classify_reaps_untracked_idle`, `classify_keeps_live_child`.
+/// `classify_reaps_untracked_idle`, `classify_keeps_live_child`,
+/// `classify_reaps_active_pane_whose_cwd_is_gone`,
+/// `classify_keeps_active_pane_when_cwd_is_undeterminable`,
+/// `classify_keeps_active_pane_whose_cwd_exists`,
+/// `classify_keeps_tracked_pane_whose_cwd_is_gone`.
 pub fn classify_session(
     pane: &PaneInfo,
     tracked: &TrackedNames,
     probe: &dyn ChildLivenessProbe,
+    cwd_probe: &dyn CwdProbe,
 ) -> GcDecision {
     // Gate 1: managed prefix. Anything not ours is untouchable.
     if !is_managed_session_name(&pane.session_name) {
@@ -259,9 +397,17 @@ pub fn classify_session(
     debug_assert!(!tracked.contains(&pane.session_name));
 
     // Gate 3: idleness. A managed+untracked session running an agent is the
-    // dangerous case — surface it loudly and KEEP it.
+    // dangerous case — surface it loudly and KEEP it, UNLESS its working
+    // directory is provably gone.
     if !is_idle_shell(&pane.pane_current_command) {
-        return GcDecision::WarnUntrackedActive;
+        // #6118: a declined-adopt pane (reconcile refused it because its cwd
+        // does not resolve) stayed here forever — 478 of them, re-logged every
+        // sweep. A confirmed-absent cwd is the positive evidence that makes it
+        // reapable; anything less keeps the pre-#6118 warn-and-keep outcome.
+        return match pane_cwd_evidence(pane, cwd_probe) {
+            CwdEvidence::Gone => GcDecision::ReapCandidateCwdGone,
+            CwdEvidence::Exists | CwdEvidence::Undeterminable => GcDecision::WarnUntrackedActive,
+        };
     }
 
     // Belt-and-braces: even a bare-shell pane is spared if a live agent child
@@ -291,6 +437,12 @@ pub struct SweepPlan {
     pub kept: usize,
     /// Untracked active managed sessions that were warned-and-kept.
     pub warned: usize,
+    /// How many of `warned` actually produced a log line this sweep (#6118).
+    /// The rest were suppressed by the per-session throttle.
+    pub warn_logged: usize,
+    /// Names in `to_reap` selected because their pane's cwd is gone, not
+    /// because the pane is an idle shell (#6118). Drives the kill-log reason.
+    pub cwd_gone: HashSet<String>,
 }
 
 /// Cross-pass orphan garbage-collector with a debounce.
@@ -313,6 +465,14 @@ pub struct SweepPlan {
 pub struct OrphanGc {
     /// Names that were reap candidates on the previous sweep.
     prev_candidates: HashSet<String>,
+    /// #6118: how many sweeps each currently-warned session has been warned
+    /// for. Drives the per-session log throttle; entries for sessions that
+    /// stopped being warned are dropped each sweep so the map cannot grow past
+    /// the live warned set.
+    warn_sweeps: HashMap<String, u32>,
+    /// #6118: log a warned session on its first sweep and then once every this
+    /// many sweeps. `0` is normalised to `1` (log every sweep) on construction.
+    skip_log_every: u32,
 }
 
 impl OrphanGc {
@@ -320,10 +480,56 @@ impl OrphanGc {
     ///
     /// Why: the daemon owns one long-lived `OrphanGc` across the process
     /// lifetime so debounce state persists between sweeps.
-    /// What: returns a default-initialised instance.
+    /// What: an empty debounce set and the default #6118 log throttle
+    /// ([`DEFAULT_SKIP_LOG_EVERY_SWEEPS`]).
     /// Test: used by every `debounce_*` test and the async runner.
     pub fn new() -> Self {
-        Self::default()
+        Self::with_skip_log_every(DEFAULT_SKIP_LOG_EVERY_SWEEPS)
+    }
+
+    /// Construct a GC whose #6118 log throttle comes from the process env.
+    ///
+    /// Why: the daemon's reap loop is the one production construction site, and
+    /// it should read the override without spelling out the env plumbing there —
+    /// `daemon/mod.rs` sits at its 500-SLOC cap.
+    /// What: [`Self::with_skip_log_every`] over [`Self::skip_log_every_from_env`].
+    /// Test: the parsing is covered by `skip_log_every_from_env_parsing`.
+    pub fn from_env() -> Self {
+        Self::with_skip_log_every(Self::skip_log_every_from_env(|k| std::env::var(k).ok()))
+    }
+
+    /// Construct a GC whose untracked-active log repeats every `sweeps` sweeps.
+    ///
+    /// Why (#6118): the throttle interval has to be settable so a test can
+    /// assert both the suppression and the eventual repeat without running 60
+    /// sweeps, and so an operator debugging a live host can restore the old
+    /// every-sweep behavior through [`ENV_SKIP_LOG_EVERY_SWEEPS`].
+    /// What: stores `sweeps`, normalising `0` to `1` — a modulus of zero has no
+    /// meaning and silently disabling the log would hide the very sessions this
+    /// line exists to surface.
+    /// Test: `skip_log_is_throttled_per_session`, `skip_log_repeats_after_n_sweeps`,
+    /// `skip_log_every_zero_logs_every_sweep`.
+    pub fn with_skip_log_every(sweeps: u32) -> Self {
+        Self {
+            prev_candidates: HashSet::new(),
+            warn_sweeps: HashMap::new(),
+            skip_log_every: sweeps.max(1),
+        }
+    }
+
+    /// Read the #6118 log-throttle interval from an injectable environment.
+    ///
+    /// Why: the daemon constructs its `OrphanGc` from the process environment,
+    /// and threading a resolver keeps that reachable from a test without any
+    /// process-wide `set_var`.
+    /// What: parses [`ENV_SKIP_LOG_EVERY_SWEEPS`]; an absent, unparsable, or
+    /// zero value yields [`DEFAULT_SKIP_LOG_EVERY_SWEEPS`].
+    /// Test: `skip_log_every_from_env_parsing`.
+    pub fn skip_log_every_from_env(get: impl Fn(&str) -> Option<String>) -> u32 {
+        get(ENV_SKIP_LOG_EVERY_SWEEPS)
+            .and_then(|v| v.trim().parse::<u32>().ok())
+            .filter(|n| *n > 0)
+            .unwrap_or(DEFAULT_SKIP_LOG_EVERY_SWEEPS)
     }
 
     /// Forget the previous pass's reap candidates, restarting the debounce.
@@ -355,36 +561,62 @@ impl OrphanGc {
     /// `info!` (downgraded from `warn!` in #1813 — these are informational, not
     /// emergencies; frequent `warn!` here was filling logs at 56 MB/day).
     /// True anomalies (kill failures, degraded snapshots) remain at `warn!`.
+    /// #6118 adds a second candidate class — a pane whose cwd is confirmed gone
+    /// ([`GcDecision::ReapCandidateCwdGone`]) — through the SAME debounce, and
+    /// throttles the untracked-active log to once per session per
+    /// `skip_log_every` sweeps.
     /// Test: `debounce_skips_first_observation`, `debounce_reaps_second_observation`,
-    /// `gc_key_is_session_name_only_not_composite` (regression for #1813).
+    /// `gc_key_is_session_name_only_not_composite` (regression for #1813);
+    /// `cwd_gone_pane_is_debounced_then_reaped`, `skip_log_is_throttled_per_session`
+    /// (#6118).
     pub fn plan_sweep(
         &mut self,
         panes: &[PaneInfo],
         tracked: &TrackedNames,
         probe: &dyn ChildLivenessProbe,
+        cwd_probe: &dyn CwdProbe,
     ) -> SweepPlan {
         let mut plan = SweepPlan {
             scanned: panes.len(),
             ..SweepPlan::default()
         };
         let mut this_pass: HashSet<String> = HashSet::new();
+        let mut warned_this_pass: HashMap<String, u32> = HashMap::new();
 
         for pane in panes {
-            match classify_session(pane, tracked, probe) {
+            match classify_session(pane, tracked, probe, cwd_probe) {
                 GcDecision::ReapCandidate => {
                     this_pass.insert(pane.session_name.clone());
                 }
+                GcDecision::ReapCandidateCwdGone => {
+                    this_pass.insert(pane.session_name.clone());
+                    plan.cwd_gone.insert(pane.session_name.clone());
+                }
                 GcDecision::WarnUntrackedActive => {
                     plan.warned += 1;
-                    // Downgraded from warn! (#1813): an untracked active pane is
-                    // informational — we intentionally skip it every sweep. Logging
-                    // at warn! caused 56 MB/day of log growth for users with live
-                    // managed sessions. Reserve warn! for genuine anomalies.
-                    info!(
-                        session = %pane.session_name,
-                        command = %pane.pane_current_command,
-                        "orphan-GC: untracked active managed session — skipping"
-                    );
+                    // #6118: the same ids were re-logged every 60s forever —
+                    // 992,078 lines in 48h. Count the sweeps this session has
+                    // been warned for and log only the 1st and every Nth.
+                    let seen = self
+                        .warn_sweeps
+                        .get(pane.session_name.as_str())
+                        .copied()
+                        .unwrap_or(0);
+                    warned_this_pass.insert(pane.session_name.clone(), seen + 1);
+                    if seen % self.skip_log_every == 0 {
+                        plan.warn_logged += 1;
+                        // Downgraded from warn! (#1813): an untracked active pane is
+                        // informational — we intentionally skip it every sweep. Logging
+                        // at warn! caused 56 MB/day of log growth for users with live
+                        // managed sessions. Reserve warn! for genuine anomalies.
+                        info!(
+                            session = %pane.session_name,
+                            command = %pane.pane_current_command,
+                            sweeps_skipped = seen,
+                            repeats_every = self.skip_log_every,
+                            "orphan-GC: untracked active managed session — skipping"
+                        );
+                    }
                 }
                 GcDecision::Keep(reason) => {
                     plan.kept += 1;
@@ -404,9 +636,15 @@ impl OrphanGc {
             }
         }
         plan.to_reap.sort();
+        // A cwd-gone name still held back by the debounce must not be reported
+        // as a reason for a kill that is not happening.
+        plan.cwd_gone.retain(|n| plan.to_reap.contains(n));
 
-        // Remember this pass's candidates for next time's intersection.
+        // Remember this pass's candidates for next time's intersection, and
+        // replace (never merge) the warn counters so a session that stopped
+        // being warned is forgotten rather than accumulating forever.
         self.prev_candidates = this_pass;
+        self.warn_sweeps = warned_this_pass;
         plan
     }
 }
@@ -510,6 +748,7 @@ pub fn run_sweep(
     panes: &[PaneInfo],
     tracked: &TrackedNames,
     probe: &dyn ChildLivenessProbe,
+    cwd_probe: &dyn CwdProbe,
     driver: &dyn crate::session_manager::ManagedTmuxDriver,
 ) -> usize {
     // Fail-closed: an incomplete protected set means a tracked session might be
@@ -523,17 +762,20 @@ pub fn run_sweep(
         );
         return 0;
     }
-    let plan = gc.plan_sweep(panes, tracked, probe);
+    let plan = gc.plan_sweep(panes, tracked, probe, cwd_probe);
     let mut reaped = 0usize;
     for name in &plan.to_reap {
+        // #6118: name the evidence that selected this pane — an idle shell and
+        // a vanished working directory are different kills to audit.
+        let reason = if plan.cwd_gone.contains(name) {
+            "untracked managed session whose working directory is gone (orphan-GC, debounced, #6118)"
+        } else {
+            "untracked idle managed session (orphan-GC, debounced)"
+        };
         match driver.kill_session(name) {
             Ok(()) => {
                 reaped += 1;
-                info!(
-                    session = %name,
-                    reason = "untracked idle managed session (orphan-GC, debounced)",
-                    "reaped orphaned tmux session"
-                );
+                info!(session = %name, reason, "reaped orphaned tmux session");
             }
             Err(e) => {
                 warn!(session = %name, error = %e, "orphan-GC kill failed");
@@ -543,12 +785,34 @@ pub fn run_sweep(
     debug!(
         scanned = plan.scanned,
         kept = plan.kept,
+        // #6118: the per-session lines are throttled, so the aggregate is the
+        // only place the full warned count is still stated every sweep.
         warned = plan.warned,
+        warn_logged = plan.warn_logged,
         candidates = plan.to_reap.len(),
+        cwd_gone = plan.cwd_gone.len(),
         reaped,
         "orphan-GC sweep complete"
     );
     reaped
+}
+
+/// [`run_sweep`] with the production filesystem cwd probe (#6118).
+///
+/// Why: the daemon's reap loop is the only production caller and always wants
+/// [`FsCwdProbe`]; naming it at the call site cost `daemon/mod.rs` five lines it
+/// does not have against its 500-SLOC cap. Tests keep using `run_sweep` so they
+/// can inject a deterministic probe.
+/// What: forwards every argument, supplying [`FsCwdProbe`].
+/// Test: `tests/orphan_gc_sweep.rs` covers the wrapped function directly.
+pub fn run_sweep_fs(
+    gc: &mut OrphanGc,
+    panes: &[PaneInfo],
+    tracked: &TrackedNames,
+    probe: &dyn ChildLivenessProbe,
+    driver: &dyn crate::session_manager::ManagedTmuxDriver,
+) -> usize {
+    run_sweep(gc, panes, tracked, probe, &FsCwdProbe, driver)
 }
 
 #[cfg(test)]
@@ -563,12 +827,46 @@ mod tests {
         }
     }
 
+    /// A cwd probe that never answers — the pre-#6118 world, where nothing is
+    /// known about any pane's working directory.
+    struct NoCwdEvidence;
+    impl CwdProbe for NoCwdEvidence {
+        fn evidence(&self, _path: &str) -> CwdEvidence {
+            CwdEvidence::Undeterminable
+        }
+    }
+
+    /// A cwd probe that reports every path as CONFIRMED absent.
+    struct AllCwdGone;
+    impl CwdProbe for AllCwdGone {
+        fn evidence(&self, _path: &str) -> CwdEvidence {
+            CwdEvidence::Gone
+        }
+    }
+
+    /// A cwd probe that reports every path as present.
+    struct AllCwdExists;
+    impl CwdProbe for AllCwdExists {
+        fn evidence(&self, _path: &str) -> CwdEvidence {
+            CwdEvidence::Exists
+        }
+    }
+
     fn pane(name: &str, cmd: &str) -> PaneInfo {
         PaneInfo {
             session_name: name.to_string(),
             pane_current_command: cmd.to_string(),
             pane_pid: Some(4242),
             pane_id: None,
+            pane_current_path: None,
+        }
+    }
+
+    /// A pane that reports a working directory (#6118).
+    fn pane_at(name: &str, cmd: &str, path: &str) -> PaneInfo {
+        PaneInfo {
+            pane_current_path: Some(path.to_string()),
+            ..pane(name, cmd)
         }
     }
 
@@ -691,6 +989,7 @@ mod tests {
             &pane("work", "zsh"),
             &TrackedNames::default(),
             &AlwaysIdleProbe,
+            &NoCwdEvidence,
         );
         assert_eq!(d, GcDecision::Keep(KeepReason::NotManaged));
     }
@@ -699,7 +998,12 @@ mod tests {
     fn classify_keeps_tracked_legacy() {
         // (b-ish) tracked in old DaemonState registry, even if idle → KEEP.
         let tracked = tracked_with(&["tmpm-tracked"], &[]);
-        let d = classify_session(&pane("tmpm-tracked", "zsh"), &tracked, &AlwaysIdleProbe);
+        let d = classify_session(
+            &pane("tmpm-tracked", "zsh"),
+            &tracked,
+            &AlwaysIdleProbe,
+            &NoCwdEvidence,
+        );
         assert_eq!(d, GcDecision::Keep(KeepReason::TrackedLegacy));
     }
 
@@ -707,7 +1011,12 @@ mod tests {
     fn classify_keeps_tracked_managed() {
         // (b) tracked in new SessionManager store, even if idle → KEEP.
         let tracked = tracked_with(&[], &["tmpm-managed"]);
-        let d = classify_session(&pane("tmpm-managed", "zsh"), &tracked, &AlwaysIdleProbe);
+        let d = classify_session(
+            &pane("tmpm-managed", "zsh"),
+            &tracked,
+            &AlwaysIdleProbe,
+            &NoCwdEvidence,
+        );
         assert_eq!(d, GcDecision::Keep(KeepReason::TrackedManaged));
     }
 
@@ -715,7 +1024,12 @@ mod tests {
     fn classify_keeps_tracked_active() {
         // (a) tracked active session → KEEP (tracking wins before idleness).
         let tracked = tracked_with(&[], &["tmpm-busy"]);
-        let d = classify_session(&pane("tmpm-busy", "claude"), &tracked, &AlwaysIdleProbe);
+        let d = classify_session(
+            &pane("tmpm-busy", "claude"),
+            &tracked,
+            &AlwaysIdleProbe,
+            &NoCwdEvidence,
+        );
         assert_eq!(d, GcDecision::Keep(KeepReason::TrackedManaged));
     }
 
@@ -726,6 +1040,7 @@ mod tests {
             &pane("tmpm-rogue", "claude"),
             &TrackedNames::default(),
             &AlwaysIdleProbe,
+            &NoCwdEvidence,
         );
         assert_eq!(d, GcDecision::WarnUntrackedActive);
     }
@@ -737,6 +1052,7 @@ mod tests {
             &pane("tmpm-orphan", "zsh"),
             &TrackedNames::default(),
             &AlwaysIdleProbe,
+            &NoCwdEvidence,
         );
         assert_eq!(d, GcDecision::ReapCandidate);
     }
@@ -749,6 +1065,7 @@ mod tests {
             &pane("tmpm-spawning", "zsh"),
             &TrackedNames::default(),
             &AlwaysLiveProbe,
+            &NoCwdEvidence,
         );
         assert_eq!(d, GcDecision::Keep(KeepReason::LiveChildProcess));
     }
@@ -760,6 +1077,7 @@ mod tests {
             &pane("trusty-mpm-deadbeef", "bash"),
             &TrackedNames::default(),
             &AlwaysIdleProbe,
+            &NoCwdEvidence,
         );
         assert_eq!(d, GcDecision::ReapCandidate);
     }
@@ -779,7 +1097,7 @@ mod tests {
 
         // First pass: (d) is a candidate but debounce holds it back.
         let mut gc = OrphanGc::new();
-        let p1 = gc.plan_sweep(&panes, &tracked, &AlwaysIdleProbe);
+        let p1 = gc.plan_sweep(&panes, &tracked, &AlwaysIdleProbe, &NoCwdEvidence);
         assert!(
             p1.to_reap.is_empty(),
             "debounce must spare a first-seen candidate, got {:?}",
@@ -789,9 +1107,324 @@ mod tests {
         assert_eq!(p1.scanned, 5);
 
         // Second pass: (d) is still the only orphan → reaped; nothing else.
-        let p2 = gc.plan_sweep(&panes, &tracked, &AlwaysIdleProbe);
+        let p2 = gc.plan_sweep(&panes, &tracked, &AlwaysIdleProbe, &NoCwdEvidence);
         assert_eq!(p2.to_reap, vec!["tmpm-d-untracked-idle".to_string()]);
         assert_eq!(p2.warned, 1);
+    }
+
+    // ---------------------------------------------------------------------
+    // #6118 — reaping a pane whose working directory is gone.
+    // ---------------------------------------------------------------------
+
+    /// The gap this issue reopened for: an untracked pane running an agent whose
+    /// worktree was deleted underneath it. `reconcile` declines to adopt it
+    /// (its cwd does not resolve), and before this fix `classify_session`
+    /// answered `WarnUntrackedActive` forever — 478 permanent zombies. RED
+    /// before the fix: the pre-fix classifier had no cwd input at all.
+    #[test]
+    fn classify_reaps_active_pane_whose_cwd_is_gone() {
+        let d = classify_session(
+            &pane_at("tm-zombie", "claude", "/gone/worktree"),
+            &TrackedNames::default(),
+            &AlwaysIdleProbe,
+            &AllCwdGone,
+        );
+        assert_eq!(
+            d,
+            GcDecision::ReapCandidateCwdGone,
+            "a confirmed-gone cwd is positive evidence an untracked pane has \
+             nothing left to work in (#6118)"
+        );
+    }
+
+    /// ADR-0045: an undeterminable answer is not an absent one. A pane whose cwd
+    /// the probe could not decide keeps the pre-#6118 warn-and-keep outcome.
+    #[test]
+    fn classify_keeps_active_pane_when_cwd_is_undeterminable() {
+        let d = classify_session(
+            &pane_at("tm-unknown", "claude", "/maybe/here"),
+            &TrackedNames::default(),
+            &AlwaysIdleProbe,
+            &NoCwdEvidence,
+        );
+        assert_eq!(d, GcDecision::WarnUntrackedActive);
+    }
+
+    /// A pane whose cwd is present is ordinary live work — never a candidate.
+    #[test]
+    fn classify_keeps_active_pane_whose_cwd_exists() {
+        let d = classify_session(
+            &pane_at("tm-busy", "claude", "/real/dir"),
+            &TrackedNames::default(),
+            &AlwaysIdleProbe,
+            &AllCwdExists,
+        );
+        assert_eq!(d, GcDecision::WarnUntrackedActive);
+    }
+
+    /// The #4091-family protection the cwd gate must never weaken: tracking wins
+    /// before any idleness or cwd reasoning. A TRACKED session whose cwd is gone
+    /// stays kept — the store, not the GC, owns that record's fate.
+    #[test]
+    fn classify_keeps_tracked_pane_whose_cwd_is_gone() {
+        let tracked = tracked_with(&[], &["tm-tracked-gone"]);
+        let d = classify_session(
+            &pane_at("tm-tracked-gone", "claude", "/gone"),
+            &tracked,
+            &AlwaysIdleProbe,
+            &AllCwdGone,
+        );
+        assert_eq!(d, GcDecision::Keep(KeepReason::TrackedManaged));
+    }
+
+    /// A non-managed pane is untouchable whatever its cwd says.
+    #[test]
+    fn classify_keeps_non_managed_pane_whose_cwd_is_gone() {
+        let d = classify_session(
+            &pane_at("my-own-work", "vim", "/gone"),
+            &TrackedNames::default(),
+            &AlwaysIdleProbe,
+            &AllCwdGone,
+        );
+        assert_eq!(d, GcDecision::Keep(KeepReason::NotManaged));
+    }
+
+    /// Fail-open check: tmux reporting no path must never reach the filesystem
+    /// probe, because an empty path would resolve to the process cwd and answer
+    /// `Exists` for a pane we know nothing about.
+    #[test]
+    fn pane_cwd_evidence_is_undeterminable_without_a_path() {
+        assert_eq!(
+            pane_cwd_evidence(&pane("tm-a", "claude"), &AllCwdGone),
+            CwdEvidence::Undeterminable
+        );
+        assert_eq!(
+            pane_cwd_evidence(&pane_at("tm-a", "claude", "   "), &AllCwdGone),
+            CwdEvidence::Undeterminable
+        );
+    }
+
+    /// The real probe against the real filesystem — the absent/present split.
+    #[test]
+    fn fs_cwd_probe_reports_exists_for_a_real_dir() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        assert_eq!(
+            FsCwdProbe.evidence(&tmp.path().to_string_lossy()),
+            CwdEvidence::Exists
+        );
+    }
+
+    #[test]
+    fn fs_cwd_probe_reports_gone_for_a_deleted_dir() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let path = tmp.path().join("worktree");
+        std::fs::create_dir(&path).expect("create");
+        assert_eq!(
+            FsCwdProbe.evidence(&path.to_string_lossy()),
+            CwdEvidence::Exists
+        );
+        std::fs::remove_dir(&path).expect("remove");
+        assert_eq!(
+            FsCwdProbe.evidence(&path.to_string_lossy()),
+            CwdEvidence::Gone,
+            "a deleted worktree is the exact live condition #6118 reports"
+        );
+    }
+
+    /// A cwd-gone pane earns the SAME two-sweep confirmation an idle-shell
+    /// orphan does before anything is killed — a pane running a live foreground
+    /// process is never reaped on one observation.
+    #[test]
+    fn cwd_gone_pane_is_debounced_then_reaped() {
+        let panes = vec![pane_at("tm-zombie", "claude", "/gone")];
+        let mut gc = OrphanGc::new();
+
+        let p1 = gc.plan_sweep(
+            &panes,
+            &TrackedNames::default(),
+            &AlwaysIdleProbe,
+            &AllCwdGone,
+        );
+        assert!(
+            p1.to_reap.is_empty(),
+            "first sighting must never kill a pane with a live foreground process"
+        );
+
+        let p2 = gc.plan_sweep(
+            &panes,
+            &TrackedNames::default(),
+            &AlwaysIdleProbe,
+            &AllCwdGone,
+        );
+        assert_eq!(p2.to_reap, vec!["tm-zombie".to_string()]);
+        assert!(
+            p2.cwd_gone.contains("tm-zombie"),
+            "the kill must be attributed to the cwd-gone reason, not to idleness"
+        );
+    }
+
+    /// A cwd-gone candidate whose directory reappears between sweeps restarts
+    /// the debounce, exactly as a lapsed idle-shell candidate does.
+    #[test]
+    fn cwd_gone_debounce_resets_when_the_directory_returns() {
+        let panes = vec![pane_at("tm-flaky", "claude", "/maybe")];
+        let mut gc = OrphanGc::new();
+        let _ = gc.plan_sweep(
+            &panes,
+            &TrackedNames::default(),
+            &AlwaysIdleProbe,
+            &AllCwdGone,
+        );
+        let p2 = gc.plan_sweep(
+            &panes,
+            &TrackedNames::default(),
+            &AlwaysIdleProbe,
+            &AllCwdExists,
+        );
+        assert!(p2.to_reap.is_empty(), "got {:?}", p2.to_reap);
+        let p3 = gc.plan_sweep(
+            &panes,
+            &TrackedNames::default(),
+            &AlwaysIdleProbe,
+            &AllCwdGone,
+        );
+        assert!(
+            p3.to_reap.is_empty(),
+            "a lapsed candidate must restart the debounce, got {:?}",
+            p3.to_reap
+        );
+    }
+
+    /// `cwd_gone` names only what is ACTUALLY being killed this sweep, so the
+    /// kill log can never attribute a reason to a pane it is not touching.
+    #[test]
+    fn cwd_gone_reason_is_dropped_while_the_debounce_holds() {
+        let panes = vec![pane_at("tm-zombie", "claude", "/gone")];
+        let mut gc = OrphanGc::new();
+        let p1 = gc.plan_sweep(
+            &panes,
+            &TrackedNames::default(),
+            &AlwaysIdleProbe,
+            &AllCwdGone,
+        );
+        assert!(p1.cwd_gone.is_empty(), "got {:?}", p1.cwd_gone);
+    }
+
+    // ---------------------------------------------------------------------
+    // #6118 — throttling the untracked-active skip log.
+    // ---------------------------------------------------------------------
+
+    /// The log flood: the same warned session used to emit one line per sweep.
+    /// RED before the fix — `warn_logged` did not exist and every sweep logged.
+    #[test]
+    fn skip_log_is_throttled_per_session() {
+        let panes = vec![pane("tm-warned", "claude")];
+        let mut gc = OrphanGc::with_skip_log_every(3);
+        let p1 = gc.plan_sweep(
+            &panes,
+            &TrackedNames::default(),
+            &AlwaysIdleProbe,
+            &NoCwdEvidence,
+        );
+        assert_eq!(p1.warned, 1);
+        assert_eq!(p1.warn_logged, 1, "the first sighting is always logged");
+        for sweep in 2..=3 {
+            let p = gc.plan_sweep(
+                &panes,
+                &TrackedNames::default(),
+                &AlwaysIdleProbe,
+                &NoCwdEvidence,
+            );
+            assert_eq!(p.warned, 1, "sweep {sweep} still counts the session");
+            assert_eq!(p.warn_logged, 0, "sweep {sweep} must be suppressed");
+        }
+    }
+
+    #[test]
+    fn skip_log_repeats_after_n_sweeps() {
+        let panes = vec![pane("tm-warned", "claude")];
+        let mut gc = OrphanGc::with_skip_log_every(3);
+        for _ in 0..3 {
+            let _ = gc.plan_sweep(
+                &panes,
+                &TrackedNames::default(),
+                &AlwaysIdleProbe,
+                &NoCwdEvidence,
+            );
+        }
+        let p4 = gc.plan_sweep(
+            &panes,
+            &TrackedNames::default(),
+            &AlwaysIdleProbe,
+            &NoCwdEvidence,
+        );
+        assert_eq!(
+            p4.warn_logged, 1,
+            "the line must reappear every N sweeps so a zombie is never invisible"
+        );
+    }
+
+    /// A zero interval would make the modulus meaningless and could silence the
+    /// line entirely; it is normalised to log-every-sweep instead.
+    #[test]
+    fn skip_log_every_zero_logs_every_sweep() {
+        let panes = vec![pane("tm-warned", "claude")];
+        let mut gc = OrphanGc::with_skip_log_every(0);
+        for _ in 0..3 {
+            let p = gc.plan_sweep(
+                &panes,
+                &TrackedNames::default(),
+                &AlwaysIdleProbe,
+                &NoCwdEvidence,
+            );
+            assert_eq!(p.warn_logged, 1);
+        }
+    }
+
+    /// The throttle map must not grow without bound: a session that stops being
+    /// warned is forgotten, and its next appearance logs as a first sighting.
+    #[test]
+    fn skip_log_counter_resets_when_a_session_stops_being_warned() {
+        let warned = vec![pane("tm-warned", "claude")];
+        let mut gc = OrphanGc::with_skip_log_every(10);
+        let _ = gc.plan_sweep(
+            &warned,
+            &TrackedNames::default(),
+            &AlwaysIdleProbe,
+            &NoCwdEvidence,
+        );
+        // The session becomes tracked, so it is no longer warned at all.
+        let tracked = tracked_with(&[], &["tm-warned"]);
+        let _ = gc.plan_sweep(&warned, &tracked, &AlwaysIdleProbe, &NoCwdEvidence);
+        // It goes untracked again — a fresh first sighting, logged.
+        let p3 = gc.plan_sweep(
+            &warned,
+            &TrackedNames::default(),
+            &AlwaysIdleProbe,
+            &NoCwdEvidence,
+        );
+        assert_eq!(p3.warn_logged, 1);
+    }
+
+    #[test]
+    fn skip_log_every_from_env_parsing() {
+        assert_eq!(
+            OrphanGc::skip_log_every_from_env(|_| None),
+            DEFAULT_SKIP_LOG_EVERY_SWEEPS
+        );
+        assert_eq!(
+            OrphanGc::skip_log_every_from_env(|_| Some("  7 ".to_string())),
+            7
+        );
+        // Zero and garbage both fall back rather than silencing the line.
+        assert_eq!(
+            OrphanGc::skip_log_every_from_env(|_| Some("0".to_string())),
+            DEFAULT_SKIP_LOG_EVERY_SWEEPS
+        );
+        assert_eq!(
+            OrphanGc::skip_log_every_from_env(|_| Some("nope".to_string())),
+            DEFAULT_SKIP_LOG_EVERY_SWEEPS
+        );
     }
 
     #[test]
@@ -799,7 +1432,12 @@ mod tests {
         // A freshly-appeared untracked-idle candidate is NOT reaped on first sight.
         let panes = vec![pane("tmpm-fresh", "zsh")];
         let mut gc = OrphanGc::new();
-        let plan = gc.plan_sweep(&panes, &TrackedNames::default(), &AlwaysIdleProbe);
+        let plan = gc.plan_sweep(
+            &panes,
+            &TrackedNames::default(),
+            &AlwaysIdleProbe,
+            &NoCwdEvidence,
+        );
         assert!(plan.to_reap.is_empty());
     }
 
@@ -808,8 +1446,18 @@ mod tests {
         // Observed orphaned on two consecutive passes → reaped on the second.
         let panes = vec![pane("tmpm-persist", "zsh")];
         let mut gc = OrphanGc::new();
-        let _ = gc.plan_sweep(&panes, &TrackedNames::default(), &AlwaysIdleProbe);
-        let plan = gc.plan_sweep(&panes, &TrackedNames::default(), &AlwaysIdleProbe);
+        let _ = gc.plan_sweep(
+            &panes,
+            &TrackedNames::default(),
+            &AlwaysIdleProbe,
+            &NoCwdEvidence,
+        );
+        let plan = gc.plan_sweep(
+            &panes,
+            &TrackedNames::default(),
+            &AlwaysIdleProbe,
+            &NoCwdEvidence,
+        );
         assert_eq!(plan.to_reap, vec!["tmpm-persist".to_string()]);
     }
 
@@ -821,12 +1469,17 @@ mod tests {
         let orphan = vec![pane("tmpm-flaky", "zsh")];
         let mut gc = OrphanGc::new();
         // Pass 1: orphan present (1st sighting).
-        let _ = gc.plan_sweep(&orphan, &TrackedNames::default(), &AlwaysIdleProbe);
+        let _ = gc.plan_sweep(
+            &orphan,
+            &TrackedNames::default(),
+            &AlwaysIdleProbe,
+            &NoCwdEvidence,
+        );
         // Pass 2: the pane is STILL present, but it is now tracked (the tracked
         // set changed, not the pane) — so it is no longer a reap candidate and
         // the debounce history is cleared of it. Nothing may be reaped this pass.
         let tracked = tracked_with(&[], &["tmpm-flaky"]);
-        let p2 = gc.plan_sweep(&orphan, &tracked, &AlwaysIdleProbe);
+        let p2 = gc.plan_sweep(&orphan, &tracked, &AlwaysIdleProbe, &NoCwdEvidence);
         assert!(
             p2.to_reap.is_empty(),
             "a now-tracked pane must not be reaped, got {:?}",
@@ -834,7 +1487,12 @@ mod tests {
         );
         // Pass 3: it becomes an orphan candidate again — but this is a *fresh*
         // 1st sighting after the reset, so it still must not be reaped.
-        let p3 = gc.plan_sweep(&orphan, &TrackedNames::default(), &AlwaysIdleProbe);
+        let p3 = gc.plan_sweep(
+            &orphan,
+            &TrackedNames::default(),
+            &AlwaysIdleProbe,
+            &NoCwdEvidence,
+        );
         assert!(
             p3.to_reap.is_empty(),
             "a candidate that lapsed must restart the debounce, got {:?}",
@@ -851,11 +1509,21 @@ mod tests {
         let orphan = vec![pane("tmpm-flaky", "zsh")];
         let mut gc = OrphanGc::new();
         // 1st sighting → candidate remembered, nothing reaped.
-        let _ = gc.plan_sweep(&orphan, &TrackedNames::default(), &AlwaysIdleProbe);
+        let _ = gc.plan_sweep(
+            &orphan,
+            &TrackedNames::default(),
+            &AlwaysIdleProbe,
+            &NoCwdEvidence,
+        );
         // Reset wipes the remembered candidate.
         gc.reset_debounce();
         // Next sighting is therefore a fresh 1st sighting → still not reaped.
-        let after = gc.plan_sweep(&orphan, &TrackedNames::default(), &AlwaysIdleProbe);
+        let after = gc.plan_sweep(
+            &orphan,
+            &TrackedNames::default(),
+            &AlwaysIdleProbe,
+            &NoCwdEvidence,
+        );
         assert!(
             after.to_reap.is_empty(),
             "reset must restart the debounce, got {:?}",
@@ -892,9 +1560,11 @@ mod tests {
                 pane_current_command: "claude".to_string(),
                 pane_pid: Some(45162),
                 pane_id: None,
+                pane_current_path: None,
             },
             &tracked,
             &AlwaysIdleProbe,
+            &NoCwdEvidence,
         );
         assert_eq!(
             decision,
@@ -910,9 +1580,11 @@ mod tests {
                 pane_current_command: "zsh".to_string(),
                 pane_pid: Some(99999),
                 pane_id: None,
+                pane_current_path: None,
             },
             &tracked,
             &AlwaysIdleProbe,
+            &NoCwdEvidence,
         );
         assert_eq!(
             decision,
@@ -927,9 +1599,11 @@ mod tests {
                 pane_current_command: "zsh".to_string(),
                 pane_pid: Some(55555),
                 pane_id: None,
+                pane_current_path: None,
             },
             &tracked,
             &AlwaysIdleProbe,
+            &NoCwdEvidence,
         );
         assert_eq!(
             decision,
@@ -955,21 +1629,30 @@ mod tests {
         use crate::daemon::tmux::TmuxDriver;
 
         let tracked = tracked_with(&[], &["tm-trusty-tools-01"]);
-        let listing = "tm-trusty-tools-01\tclaude\t10302\t%2306\n\
-                       tm-00b14f3b-dd31-4474-9\tzsh\t74149\t%1860\n";
+        let listing = "tm-trusty-tools-01\tclaude\t10302\t%2306\t/Users/masa/trusty-tools\n\
+                       tm-00b14f3b-dd31-4474-9\tzsh\t74149\t%1860\t/tmp/gone\n\
+                       tm-declined-adopt-01\tclaude\t81234\t%1900\t/tmp/gone\n";
         let panes = TmuxDriver::parse_managed_pane_rows(listing);
-        assert_eq!(panes.len(), 2, "both rows must parse: {panes:?}");
+        assert_eq!(panes.len(), 3, "every row must parse: {panes:?}");
 
         assert_eq!(
-            classify_session(&panes[0], &tracked, &AlwaysIdleProbe),
+            classify_session(&panes[0], &tracked, &AlwaysIdleProbe, &NoCwdEvidence),
             GcDecision::Keep(KeepReason::TrackedManaged),
             "a tracked session must be kept even when its pane runs an agent"
         );
         assert_eq!(
-            classify_session(&panes[1], &tracked, &AlwaysIdleProbe),
+            classify_session(&panes[1], &tracked, &AlwaysIdleProbe, &NoCwdEvidence),
             GcDecision::ReapCandidate,
             "an untracked idle managed session parsed from a real row must be \
              reapable — the live failure was that it never could be (#6529)"
+        );
+        // #6118: the third row is the declined-adopt zombie — an agent pane
+        // whose worktree is gone. Its cwd must survive the parse and reach the
+        // classifier as the evidence that selects it.
+        assert_eq!(
+            classify_session(&panes[2], &tracked, &AlwaysIdleProbe, &AllCwdGone),
+            GcDecision::ReapCandidateCwdGone,
+            "a real row's cwd column must carry through to the cwd-gone gate (#6118)"
         );
 
         // The tmux-sanitized shape of the SAME listing: no panes, so nothing is

--- a/crates/trusty-mpm/src/daemon/runtime_reap.rs
+++ b/crates/trusty-mpm/src/daemon/runtime_reap.rs
@@ -288,6 +288,7 @@ mod tests {
             pane_current_command: cmd.to_string(),
             pane_pid: Some(4242),
             pane_id: None,
+            pane_current_path: None,
         }
     }
 

--- a/crates/trusty-mpm/src/daemon/tmux.rs
+++ b/crates/trusty-mpm/src/daemon/tmux.rs
@@ -660,7 +660,10 @@ impl TmuxDriver {
             "list-panes",
             "-a",
             "-F",
-            "#{session_name}\t#{pane_current_command}\t#{pane_pid}\t#{pane_id}",
+            // #6118: `pane_current_path` is the evidence the cwd-gone reap path
+            // needs. Asking for it in the SAME listing keeps the sweep at one
+            // tmux call rather than one per untracked pane.
+            "#{session_name}\t#{pane_current_command}\t#{pane_pid}\t#{pane_id}\t#{pane_current_path}",
         ]);
         // #6529: without a UTF-8 client locale tmux rewrites every tab to `_`.
         crate::core::tmux::force_utf8_client_env(&mut cmd);
@@ -727,13 +730,24 @@ impl TmuxDriver {
     /// session forever (#6529, and the #1813 shape before it). A dropped row
     /// makes a pane invisible to the sweep, which can only ever spare a session
     /// — never kill one.
-    /// Test: `parses_managed_pane_row`, `sanitized_pane_row_is_dropped_not_coerced`.
+    ///
+    /// #6118 added a FIFTH column, `pane_current_path`. It is the only optional
+    /// one: an empty value parses to `None`, which the orphan-GC reads as "no
+    /// evidence about this pane's cwd" and so can never reap on. A row carrying
+    /// only the old four columns is REJECTED like any other shape mismatch —
+    /// accepting it would mean guessing that the absent column is the trailing
+    /// one.
+    /// Test: `parses_managed_pane_row`, `sanitized_pane_row_is_dropped_not_coerced`,
+    /// `parses_pane_row_with_empty_current_path`,
+    /// `four_column_pane_row_is_dropped`.
     fn parse_managed_pane_row(line: &str) -> Option<crate::daemon::orphan_gc::PaneInfo> {
         let mut parts = line.split('\t');
         let session_name = parts.next()?.trim();
         let pane_current_command = parts.next()?.trim();
         let pane_pid = parts.next()?.trim();
         let pane_id = parts.next()?.trim();
+        // #6118: the pane's working directory, as tmux recorded it.
+        let pane_current_path = parts.next()?.trim();
         // More columns than the format asked for means this is not the reply we
         // requested — refuse to guess which column is which.
         if parts.next().is_some() {
@@ -747,6 +761,9 @@ impl TmuxDriver {
             pane_current_command: pane_current_command.to_string(),
             pane_pid: Some(pane_pid.parse::<u32>().ok()?),
             pane_id: Some(pane_id.to_string()),
+            // Empty is NO evidence, never a path to test against the filesystem.
+            pane_current_path: (!pane_current_path.is_empty())
+                .then(|| pane_current_path.to_string()),
         })
     }
 

--- a/crates/trusty-mpm/src/daemon/tmux_tests.rs
+++ b/crates/trusty-mpm/src/daemon/tmux_tests.rs
@@ -227,20 +227,42 @@ fn attachment_flips_to_detached_when_client_count_drops_to_zero() {
 
 #[test]
 fn parses_managed_pane_row() {
-    let row = TmuxDriver::parse_managed_pane_row("tmpm-brave-otter\tclaude\t12345\t%7").unwrap();
+    let row = TmuxDriver::parse_managed_pane_row("tmpm-brave-otter\tclaude\t12345\t%7\t/work/repo")
+        .unwrap();
     assert_eq!(row.session_name, "tmpm-brave-otter");
     assert_eq!(row.pane_current_command, "claude");
     assert_eq!(row.pane_pid, Some(12345));
     assert_eq!(row.pane_id.as_deref(), Some("%7"));
+    assert_eq!(row.pane_current_path.as_deref(), Some("/work/repo"));
 
-    // #6529: the four columns the format string asks for are all required. A
-    // short, over-long, or non-numeric row is a reply we did not request, and
-    // guessing which column is which is exactly what produced the live failure.
-    assert!(TmuxDriver::parse_managed_pane_row("tmpm-x\tzsh\t\t%9").is_none());
+    // #6529: the columns the format string asks for are all required. A short,
+    // over-long, or non-numeric row is a reply we did not request, and guessing
+    // which column is which is exactly what produced the live failure.
+    assert!(TmuxDriver::parse_managed_pane_row("tmpm-x\tzsh\t\t%9\t/w").is_none());
     assert!(TmuxDriver::parse_managed_pane_row("tmpm-y\tclaude\t222").is_none());
-    assert!(TmuxDriver::parse_managed_pane_row("tmpm-z\tzsh\t1\t%1\textra").is_none());
-    assert!(TmuxDriver::parse_managed_pane_row("\tzsh\t1\t%1").is_none());
-    assert!(TmuxDriver::parse_managed_pane_row("tmpm-q\t\t1\t%1").is_none());
+    assert!(TmuxDriver::parse_managed_pane_row("tmpm-z\tzsh\t1\t%1\t/w\textra").is_none());
+    assert!(TmuxDriver::parse_managed_pane_row("\tzsh\t1\t%1\t/w").is_none());
+    assert!(TmuxDriver::parse_managed_pane_row("tmpm-q\t\t1\t%1\t/w").is_none());
+}
+
+/// #6118: the fifth column is the only OPTIONAL one — an empty value is "tmux
+/// told us nothing about this pane's cwd", which the orphan-GC can never reap
+/// on. It must parse to `None`, not to an empty path that would resolve to the
+/// daemon's own working directory.
+#[test]
+fn parses_pane_row_with_empty_current_path() {
+    let row = TmuxDriver::parse_managed_pane_row("tm-a\tclaude\t12\t%1\t").expect("row parses");
+    assert_eq!(row.pane_current_path, None);
+    let row = TmuxDriver::parse_managed_pane_row("tm-a\tclaude\t12\t%1\t   ").expect("row parses");
+    assert_eq!(row.pane_current_path, None);
+}
+
+/// #6118: a row carrying only the pre-#6118 four columns is DROPPED, not
+/// accepted with a guessed-absent trailing field. Dropping a row can only ever
+/// spare a session — accepting a shape we did not ask for is how #6529 happened.
+#[test]
+fn four_column_pane_row_is_dropped() {
+    assert!(TmuxDriver::parse_managed_pane_row("tm-a\tclaude\t12\t%1").is_none());
 }
 
 /// A captured REAL `list-panes -a -F` listing parses column-for-column (#6529).
@@ -253,16 +275,21 @@ fn parses_managed_pane_row() {
 /// Test: this is the test.
 #[test]
 fn parses_a_real_tab_delimited_listing() {
-    let captured = "tm-00b14f3b-dd31-4474-9\tzsh\t74149\t%1860\n\
-                    tm-trusty-tools-01\tzsh\t10302\t%2306\n\
-                    tm-trusty-tools-02\ttrusty-mpm\t10738\t%2307\n\
-                    tm-writing-03\tzsh\t53398\t%2105\n";
+    let captured = "tm-00b14f3b-dd31-4474-9\tzsh\t74149\t%1860\t/tmp/gone-worktree\n\
+                    tm-trusty-tools-01\tzsh\t10302\t%2306\t/Users/masa/trusty-tools\n\
+                    tm-trusty-tools-02\ttrusty-mpm\t10738\t%2307\t/Users/masa/trusty-tools\n\
+                    tm-writing-03\tzsh\t53398\t%2105\t/Users/masa/writing\n";
     let rows = TmuxDriver::parse_managed_pane_rows(captured);
     assert_eq!(rows.len(), 4, "every captured row must parse: {rows:?}");
     assert_eq!(rows[0].session_name, "tm-00b14f3b-dd31-4474-9");
     assert_eq!(rows[0].pane_current_command, "zsh");
     assert_eq!(rows[0].pane_pid, Some(74149));
     assert_eq!(rows[0].pane_id.as_deref(), Some("%1860"));
+    // #6118: the cwd column is what makes a declined-adopt pane reapable.
+    assert_eq!(
+        rows[0].pane_current_path.as_deref(),
+        Some("/tmp/gone-worktree")
+    );
     assert_eq!(rows[2].session_name, "tm-trusty-tools-02");
     assert_eq!(rows[2].pane_current_command, "trusty-mpm");
     assert_eq!(rows[2].pane_id.as_deref(), Some("%2307"));

--- a/crates/trusty-mpm/src/session_manager/json_file.rs
+++ b/crates/trusty-mpm/src/session_manager/json_file.rs
@@ -1,0 +1,137 @@
+//! The cross-process JSON-file mechanism `sessions.json` and its siblings share.
+//!
+//! Why: the daemon and `tm supervisor` are separate processes reading and
+//! writing the same files in `<data_dir>` (#1219). Two rules make that safe, and
+//! both have already been learned the hard way here: a reader must re-stat the
+//! file before trusting its in-memory copy, and a writer must stage through a
+//! private temp file and rename, because a plain truncate-and-rewrite lets a
+//! concurrent reader observe a half-written file. `SessionStore` grew both;
+//! `resume_breaker.rs` (#6568) needs exactly the same two, over a file in the
+//! same directory. A second, weaker copy is the defect this module prevents —
+//! see CLAUDE.md's common-entry-point rule.
+//!
+//! What: [`FileSig`] and [`sig_of`] are the freshness fingerprint; [`staging_path`]
+//! mints the per-instance temp name; [`write_atomic`] does the stage-and-rename.
+//! Nothing here parses or knows about any payload type — the caller owns
+//! serialisation, so the same three primitives serve a `Vec<SessionRecord>` and
+//! a `HashMap<String, FlapState>` alike.
+//!
+//! What this is NOT: a lock. Two processes that read-modify-write concurrently
+//! can still lose one update — the rename makes each write ATOMIC, not
+//! EXCLUSIVE. Both current callers tolerate that (a lost session-state write is
+//! re-derived on the next reconcile; a lost flap counter delays a park by one
+//! cycle), and neither may be extended to data where a lost update is
+//! unacceptable without adding real locking first.
+//!
+//! Test: `json_file_tests.rs`; the cross-process reload path is additionally
+//! covered by `store_reload_picks_up_external_write` and, for the #6568
+//! sidecar, `two_managers_over_one_data_dir_still_park_a_flapping_session`.
+
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use tokio::fs;
+
+/// A cheap freshness fingerprint for a backing file.
+///
+/// Why: the cross-process reload check (#1219) keys off "did the file change
+/// since we last touched it". An mtime alone is insufficient on filesystems
+/// whose mtime resolution is coarse (1s on some): two writes in the same second
+/// would compare equal and the reader would miss the second write. Pairing the
+/// mtime with the byte length catches a same-second write that changed the file
+/// size, which a state transition (different JSON length) almost always does.
+/// What: the file's last-modified `SystemTime` (an `Option` — `None` when the
+/// platform/filesystem cannot report an mtime) and its length in bytes. The
+/// whole `FileSig` is wrapped in an `Option` by callers, where `None` means
+/// "file absent / could not be stat'd".
+/// Test: `store_reload_picks_up_external_write`, `store_reload_noop_when_unchanged`,
+/// `sig_of_is_none_for_a_missing_file`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) struct FileSig {
+    /// File modification time, if the platform/filesystem reports one.
+    pub(crate) mtime: Option<SystemTime>,
+    /// File length in bytes.
+    pub(crate) len: u64,
+}
+
+/// True when `current` and `last` prove the file has not changed since `last`.
+///
+/// Why: every caller made the same three-case judgement by hand — present and
+/// equal is unchanged, and a `None` on EITHER side (absent now, or never
+/// observed) must read as CHANGED so an external write is never missed. Stating
+/// it once keeps a future caller from inverting the `None` case, which would
+/// serve stale data silently.
+/// What: `true` only when both are `Some` and equal.
+/// Test: `unchanged_requires_both_signatures`.
+pub(crate) fn is_unchanged(current: Option<FileSig>, last: Option<FileSig>) -> bool {
+    matches!((current, last), (Some(a), Some(b)) if a == b)
+}
+
+/// Stat `path` and return its freshness fingerprint, or `None` if absent.
+///
+/// Why: the reload check and the save path need the same (mtime, len) signature;
+/// centralising it keeps "what counts as this file's identity" in one place.
+/// What: on `metadata` success returns `Some(FileSig)`; on any stat error (most
+/// commonly: the file does not exist) returns `None`, which
+/// [`is_unchanged`] reads as changed.
+/// Test: `sig_of_is_none_for_a_missing_file`, `sig_of_changes_after_a_write`.
+pub(crate) async fn sig_of(path: &Path) -> Option<FileSig> {
+    let meta = fs::metadata(path).await.ok()?;
+    Some(FileSig {
+        // `modified()` can be unsupported on exotic filesystems; `None` there
+        // makes the (mtime, len) pair compare unequal so reads reload — correct,
+        // just less efficient — rather than risk serving stale data.
+        mtime: meta.modified().ok(),
+        len: meta.len(),
+    })
+}
+
+/// The private staging path one writer instance renames over `path`.
+///
+/// Why (#5007): saving used to stage through `path.with_extension("json.tmp")` —
+/// one fixed name shared by every writer of that file, in every process. The
+/// rename is atomic, but the staging WRITE is not exclusive: two writers racing
+/// on one staging name interleave their bytes and the survivor renames a
+/// corrupt file into place.
+/// Two writers racing on one staging name interleave their bytes, and the
+/// survivor renames a document with the length of the longer serialization and
+/// the head of the shorter one into place — the exact shape #5007 reported.
+/// What: `<path>.tmp.<pid>.<uuid>` — the pid separates processes, the uuid
+/// separates instances within one process (tests routinely hold two stores over
+/// one directory, and `agent_reset_workspace` builds its own alongside the
+/// daemon's).
+/// Test: `two_stores_over_one_path_do_not_share_a_staging_file`,
+/// `staging_paths_are_unique_per_instance`.
+pub(crate) fn staging_path(path: &Path) -> PathBuf {
+    let mut name = path.file_name().unwrap_or_default().to_os_string();
+    name.push(format!(
+        ".tmp.{}.{}",
+        std::process::id(),
+        uuid::Uuid::new_v4().simple()
+    ));
+    path.with_file_name(name)
+}
+
+/// Write `bytes` to `path` atomically, staging through `tmp`.
+///
+/// Why: a plain `fs::write` truncates then rewrites, so a reader in the other
+/// process can observe an empty or half-written file and parse it as corrupt.
+/// A rename over the target is atomic on POSIX, so a cross-process reader always
+/// sees either the old file or the new one, whole.
+/// What: creates `path`'s parent if needed, writes `tmp`, renames it over
+/// `path`. On a failed rename the staging file is removed — it is named after
+/// this process and nothing else would ever clean it up — and the error is
+/// returned.
+/// Test: `write_atomic_replaces_the_target`,
+/// `write_atomic_leaves_no_staging_file_behind`.
+pub(crate) async fn write_atomic(path: &Path, tmp: &Path, bytes: &str) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).await?;
+    }
+    fs::write(tmp, bytes).await?;
+    if let Err(e) = fs::rename(tmp, path).await {
+        let _ = fs::remove_file(tmp).await;
+        return Err(e);
+    }
+    Ok(())
+}

--- a/crates/trusty-mpm/src/session_manager/json_file.rs
+++ b/crates/trusty-mpm/src/session_manager/json_file.rs
@@ -10,11 +10,15 @@
 //! same directory. A second, weaker copy is the defect this module prevents —
 //! see CLAUDE.md's common-entry-point rule.
 //!
-//! What: [`FileSig`] and [`sig_of`] are the freshness fingerprint; [`staging_path`]
-//! mints the per-instance temp name; [`write_atomic`] does the stage-and-rename.
-//! Nothing here parses or knows about any payload type — the caller owns
-//! serialisation, so the same three primitives serve a `Vec<SessionRecord>` and
-//! a `HashMap<String, FlapState>` alike.
+//! What: [`staging_path`] mints the per-instance temp name and [`write_atomic`]
+//! does the stage-and-rename — both callers use both. [`FileSig`], [`sig_of`]
+//! and [`is_unchanged`] are the freshness fingerprint, which `SessionStore`
+//! uses and the breaker sidecar deliberately does not: that payload keeps a
+//! constant serialized length across a cycle, so the fingerprint would rest on
+//! mtime alone and could skip a needed reload on a coarse-mtime filesystem (see
+//! `resume_breaker::ResumeBreakerStore`). Nothing here parses or knows about any
+//! payload type — the caller owns serialisation, so the same primitives serve a
+//! `Vec<SessionRecord>` and a `HashMap<String, FlapState>` alike.
 //!
 //! What this is NOT: a lock. Two processes that read-modify-write concurrently
 //! can still lose one update — the rename makes each write ATOMIC, not

--- a/crates/trusty-mpm/src/session_manager/json_file_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/json_file_tests.rs
@@ -1,0 +1,119 @@
+//! Tests for the shared cross-process JSON-file primitives.
+//!
+//! Why: `SessionStore` and the #6568 resume-breaker sidecar both depend on these
+//! three, and both depend on them for CORRECTNESS across processes, not merely
+//! for convenience. Testing them once here is what makes it safe for the two
+//! callers to stop carrying their own copies.
+//! What: the fingerprint's absent/changed cases, the `None`-means-changed rule,
+//! staging-path uniqueness, and the atomic write's success and cleanup paths.
+//! Test: this is the test module.
+
+use super::json_file::{FileSig, is_unchanged, sig_of, staging_path, write_atomic};
+
+#[tokio::test]
+async fn sig_of_is_none_for_a_missing_file() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    assert_eq!(sig_of(&tmp.path().join("absent.json")).await, None);
+}
+
+#[tokio::test]
+async fn sig_of_changes_after_a_write() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let path = tmp.path().join("f.json");
+    tokio::fs::write(&path, "{}").await.expect("write");
+    let first = sig_of(&path).await.expect("present");
+    // A different LENGTH is what catches a same-second rewrite whose mtime has
+    // not moved — the case the fingerprint pairs length with mtime for.
+    tokio::fs::write(&path, "{\"a\":1}").await.expect("rewrite");
+    let second = sig_of(&path).await.expect("present");
+    assert_ne!(first, second);
+}
+
+#[test]
+fn unchanged_requires_both_signatures() {
+    let a = FileSig::default();
+    assert!(is_unchanged(Some(a), Some(a)));
+    // A `None` on EITHER side must read as CHANGED. Inverting this is how a
+    // reader silently serves stale data forever after one absent observation.
+    assert!(!is_unchanged(None, Some(a)));
+    assert!(!is_unchanged(Some(a), None));
+    assert!(!is_unchanged(None, None));
+}
+
+#[test]
+fn staging_paths_are_unique_per_instance() {
+    // #5007: two writers sharing one staging name interleave their bytes and
+    // rename a corrupt document into place.
+    let path = std::path::Path::new("/tmp/x/sessions.json");
+    let a = staging_path(path);
+    let b = staging_path(path);
+    assert_ne!(a, b);
+    assert_eq!(a.parent(), path.parent());
+    assert!(
+        a.file_name()
+            .expect("named")
+            .to_string_lossy()
+            .starts_with("sessions.json.tmp."),
+        "got {a:?}"
+    );
+}
+
+#[tokio::test]
+async fn write_atomic_replaces_the_target() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    // A nested target proves the parent is created rather than erroring.
+    let path = tmp.path().join("nested").join("f.json");
+    let staging = staging_path(&path);
+
+    write_atomic(&path, &staging, "{\"v\":1}")
+        .await
+        .expect("first");
+    assert_eq!(
+        tokio::fs::read_to_string(&path).await.expect("read"),
+        "{\"v\":1}"
+    );
+
+    write_atomic(&path, &staging, "{\"v\":2}")
+        .await
+        .expect("second");
+    assert_eq!(
+        tokio::fs::read_to_string(&path).await.expect("read"),
+        "{\"v\":2}"
+    );
+}
+
+#[tokio::test]
+async fn write_atomic_leaves_no_staging_file_behind() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let path = tmp.path().join("f.json");
+    let staging = staging_path(&path);
+    write_atomic(&path, &staging, "{}").await.expect("write");
+    assert!(
+        !staging.exists(),
+        "the staging file must be renamed away, not left for nothing to clean up"
+    );
+}
+
+#[tokio::test]
+async fn write_atomic_cleans_up_when_the_rename_fails() {
+    // Failure path: renaming a file over an existing DIRECTORY fails on every
+    // supported target. The staging file must not survive that — it is named
+    // after this process and nothing else would ever remove it.
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let path = tmp.path().join("target-is-a-dir");
+    tokio::fs::create_dir(&path).await.expect("mkdir");
+    tokio::fs::write(path.join("occupant"), "x")
+        .await
+        .expect("occupy so the dir is non-empty");
+    let staging = staging_path(&path);
+
+    let err = write_atomic(&path, &staging, "{}").await;
+    assert!(
+        err.is_err(),
+        "renaming over a non-empty directory must fail"
+    );
+    assert!(
+        !staging.exists(),
+        "a failed swap must still remove its staging file"
+    );
+}

--- a/crates/trusty-mpm/src/session_manager/manager.rs
+++ b/crates/trusty-mpm/src/session_manager/manager.rs
@@ -29,7 +29,7 @@ use tracing::{error, info, warn};
 use crate::core::names::SessionNameError;
 use crate::core::sm::control::Submit;
 
-use super::record::{ManagedSessionId, ManagedSessionState, SessionRecord, StopCause};
+use super::record::{ManagedSessionId, ManagedSessionState, SessionRecord};
 use super::resume_workdir;
 use super::slots::SlotRegistry;
 use super::store::{SessionStore, StoreError};
@@ -223,6 +223,12 @@ pub struct SessionManager {
     /// per daemon process is exactly the "reset numbering on restart"
     /// requirement. `pub(crate)` for the sibling `numbering.rs`.
     pub(crate) slots: RwLock<SlotRegistry>,
+    /// #6568: per-session auto-resume flap counters, persisted beside the store
+    /// because the reaper and the poller run in separate processes.
+    /// `pub(crate)` for the sibling `resume_breaker.rs`, which owns every read.
+    pub(crate) resume_breaker: RwLock<super::resume_breaker::ResumeBreakerStore>,
+    /// #6568: the breaker's window/threshold, read once at construction.
+    pub(crate) resume_breaker_cfg: super::resume_breaker::ResumeBreakerConfig,
 }
 
 impl std::fmt::Debug for SessionManager {
@@ -254,6 +260,10 @@ impl SessionManager {
             tmux,
             data_dir: data_dir.to_owned(),
             slots: RwLock::new(SlotRegistry::new()),
+            // #6568: a missing or unreadable sidecar starts empty — see
+            // `ResumeBreakerStore::load` for why that can only ever delay a park.
+            resume_breaker: RwLock::new(super::resume_breaker::ResumeBreakerStore::load(data_dir)),
+            resume_breaker_cfg: super::resume_breaker::ResumeBreakerConfig::from_env(),
         })
     }
 
@@ -730,7 +740,10 @@ impl SessionManager {
         record.state = ManagedSessionState::Stopped;
         // #6194: nothing asked for this stop — the runtime exited on its own —
         // so relaunching it is the self-healing action auto-resume exists for.
-        record.stop_cause = Some(StopCause::Unexpected);
+        // #6568: unless relaunching it has already been tried and has already
+        // failed to change anything K times in a row — see
+        // `SessionManager::runtime_exit_stop_cause` in `resume_breaker.rs`.
+        record.stop_cause = Some(self.runtime_exit_stop_cause(id, &record.tmux_name).await);
         guard.upsert(record.clone()).await?;
         drop(guard);
         info!(
@@ -817,7 +830,24 @@ impl SessionManager {
     /// `liveness_tests.rs`'s `resume_refuses_when_the_tmux_probe_fails` —
     /// asserts an unobservable probe refuses instead of killing the pane
     /// (#5859).
+    ///
+    /// #6568: this is the OPERATOR entry point. It forgives the auto-resume flap
+    /// streak, because a person resuming a session by hand is saying the cause
+    /// is addressed and the session deserves a fresh budget. The automatic
+    /// callers — the supervisor poller and the boot-reconcile tail — go through
+    /// [`Self::resume_auto`] instead (in the sibling `resume_breaker` module),
+    /// which stamps the attempt without forgiving anything.
     pub async fn resume(&self, id: &ManagedSessionId) -> Result<SessionRecord, ManagedError> {
+        let record = self.resume_inner(id).await?;
+        self.note_operator_resume(id).await;
+        Ok(record)
+    }
+
+    /// The shared resume body — see [`Self::resume`] for the full contract.
+    pub(crate) async fn resume_inner(
+        &self,
+        id: &ManagedSessionId,
+    ) -> Result<SessionRecord, ManagedError> {
         let mut record = self.get(id).await?;
         match record.state {
             ManagedSessionState::Stopped | ManagedSessionState::Errored => {}

--- a/crates/trusty-mpm/src/session_manager/manager.rs
+++ b/crates/trusty-mpm/src/session_manager/manager.rs
@@ -261,8 +261,12 @@ impl SessionManager {
             data_dir: data_dir.to_owned(),
             slots: RwLock::new(SlotRegistry::new()),
             // #6568: a missing or unreadable sidecar starts empty — see
-            // `ResumeBreakerStore::load` for why that can only ever delay a park.
-            resume_breaker: RwLock::new(super::resume_breaker::ResumeBreakerStore::load(data_dir)),
+            // `ResumeBreakerStore::load` for why that can only ever delay a
+            // park. Every later read reloads from disk, because the process
+            // that writes the stamp is not the one that reads it.
+            resume_breaker: RwLock::new(
+                super::resume_breaker::ResumeBreakerStore::load(data_dir).await,
+            ),
             resume_breaker_cfg: super::resume_breaker::ResumeBreakerConfig::from_env(),
         })
     }

--- a/crates/trusty-mpm/src/session_manager/mod.rs
+++ b/crates/trusty-mpm/src/session_manager/mod.rs
@@ -27,6 +27,8 @@ mod reconcile;
 pub mod record;
 pub mod rename;
 pub mod restart_ops;
+/// #6568: the auto-resume circuit breaker's policy and its persisted counters.
+pub mod resume_breaker;
 pub(crate) mod resume_workdir;
 /// Age-based eviction of terminal records and the slot numbers they hold.
 pub mod retention;
@@ -119,6 +121,9 @@ mod set_deliverable_id_tests;
 
 #[cfg(test)]
 mod dedup_tests;
+
+#[cfg(test)]
+mod resume_breaker_tests;
 
 #[cfg(test)]
 mod runtime_exit_reconcile_tests;

--- a/crates/trusty-mpm/src/session_manager/mod.rs
+++ b/crates/trusty-mpm/src/session_manager/mod.rs
@@ -18,6 +18,10 @@ pub mod hook_sync;
 // #4743: the single capability every destructive index DELETE must hold.
 mod index_delete_guard;
 pub mod injection_status;
+/// The cross-process JSON-file mechanism `sessions.json` and its siblings share.
+pub(crate) mod json_file;
+#[cfg(test)]
+mod json_file_tests;
 pub mod manager;
 pub mod naming;
 mod numbering;

--- a/crates/trusty-mpm/src/session_manager/naming_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/naming_tests.rs
@@ -630,12 +630,16 @@ async fn a_declined_pane_is_reapable_by_the_orphan_gc() {
             pane_current_command: "sh".into(),
             pane_pid: None,
             pane_id: None,
+            pane_current_path: None,
         },
         &TrackedNames {
             managed,
             ..Default::default()
         },
         &AlwaysIdleProbe,
+        // #6118: this pane is already reapable on idleness alone, so the cwd
+        // gate must not be what carries the assertion.
+        &crate::daemon::orphan_gc::FsCwdProbe,
     );
     assert_eq!(
         decision,

--- a/crates/trusty-mpm/src/session_manager/reactivate.rs
+++ b/crates/trusty-mpm/src/session_manager/reactivate.rs
@@ -119,6 +119,11 @@ impl SessionManager {
         // #6194: the operator is relaunching into this pane, so the reason it
         // last stopped no longer describes it — same clear `resume` does.
         record.stop_cause = None;
+        // #6568: and the same forgiveness. This path feeds `record_death`
+        // through `mark_runtime_exited_stopped`, so without this an operator
+        // reactivating repeatedly would build the flap streak with their own
+        // hands and get parked on the next ordinary exit.
+        self.note_operator_resume(id).await;
         // #4337: a reactivation always precedes the client `exec`-ing a fresh
         // `claude` back into this SAME pane, guaranteeing a genuinely NEW
         // top-level `SessionStart` is imminent. Clearing the old id here

--- a/crates/trusty-mpm/src/session_manager/reconcile.rs
+++ b/crates/trusty-mpm/src/session_manager/reconcile.rs
@@ -482,7 +482,10 @@ impl SessionManager {
                 to_resume.len()
             );
             for sid in to_resume {
-                if let Err(e) = self.resume(&sid).await {
+                // #6568: boot reconciliation is an automatic path like the
+                // supervisor's, so it stamps the attempt rather than forgiving
+                // the flap streak an operator's own resume forgives.
+                if let Err(e) = self.resume_auto(&sid).await {
                     warn!(id = %sid, "reconcile: auto_resume failed: {e}");
                 }
             }

--- a/crates/trusty-mpm/src/session_manager/record.rs
+++ b/crates/trusty-mpm/src/session_manager/record.rs
@@ -273,6 +273,23 @@ pub enum StopCause {
     /// server itself went away, or the daemon restarted and found the session's
     /// tmux target already gone.
     Unexpected,
+    /// The runtime kept exiting within the flap window of its own auto-resume,
+    /// enough times in a row that auto-resume is now PARKED (#6568).
+    ///
+    /// Why: `Unexpected` says "relaunch this", and for seven sessions the
+    /// relaunch succeeded and the runtime was gone again ~60 seconds later —
+    /// 2,170 stops against 2,128 resumes in 48 hours, forever. A repeatedly
+    /// SUCCEEDING resume that restores nothing is not a transient failure, so it
+    /// needs a cause of its own rather than a retry budget layered onto
+    /// `Unexpected`.
+    /// What: written only by
+    /// [`super::SessionManager::mark_runtime_exited_stopped`], only when
+    /// [`super::resume_breaker::evaluate`] returns
+    /// [`super::resume_breaker::BreakerVerdict::Park`]. Read back by
+    /// [`SessionRecord::is_auto_resumable`] (false) and
+    /// [`SessionRecord::auto_resume_park_reason`] (the operator-facing string).
+    /// An operator's own `tm session resume` clears it like any other cause.
+    ResumeFlapping,
 }
 
 /// Full record for a managed session, persisted to disk.
@@ -582,13 +599,43 @@ impl SessionRecord {
     /// `stop_cause_tests.rs`.
     pub fn is_auto_resumable(&self) -> bool {
         matches!(self.state, ManagedSessionState::Stopped)
-            && self.stop_cause != Some(StopCause::Deliberate)
+            // #6568: `ResumeFlapping` joins `Deliberate` here — a session whose
+            // runtime died within the flap window of its own auto-resume K
+            // times in a row is parked, and an automatic path must leave it
+            // down until an operator resumes it by hand.
+            && !matches!(
+                self.stop_cause,
+                Some(StopCause::Deliberate) | Some(StopCause::ResumeFlapping)
+            )
             // #6116: never relaunch a test's session. The reaper stamps a
             // gone-tmux record `Unexpected` when other sessions are live, which
             // is auto-resumable — so without this the supervisor RECREATES the
             // leaked pane, reconcile re-adopts it, and the loop sustains itself
             // (observed three times in one day's daemon log).
             && !self.is_leaked_test_adoption()
+    }
+
+    /// The operator-facing reason auto-resume is parked, if it is (#6568).
+    ///
+    /// Why: "the supervisor stopped resuming this" must be readable somewhere an
+    /// operator looks, not inferable only from the absence of resume lines in a
+    /// 3GB log. This is the one place the wording lives, so the wire summary and
+    /// any future surface cannot describe the same state two ways.
+    /// What: `Some(<reason>)` exactly when `stop_cause` is
+    /// [`StopCause::ResumeFlapping`]; `None` for every other record, including a
+    /// deliberately stopped one — that is an operator's own decision, not a
+    /// circuit-breaker trip.
+    /// Test: `park_reason_is_set_only_for_a_flapping_record` in
+    /// `resume_breaker_tests.rs`.
+    pub fn auto_resume_park_reason(&self) -> Option<&'static str> {
+        match self.stop_cause {
+            Some(StopCause::ResumeFlapping) => Some(
+                "auto-resume parked: the runtime kept exiting within seconds of \
+                 each auto-resume (#6568). Resume it by hand once the cause is \
+                 fixed — `tm session resume <id>` clears the park.",
+            ),
+            _ => None,
+        }
     }
 
     /// Whether this record is an AUTOMATIC adoption of a session in the

--- a/crates/trusty-mpm/src/session_manager/resume_breaker.rs
+++ b/crates/trusty-mpm/src/session_manager/resume_breaker.rs
@@ -1,0 +1,465 @@
+//! Auto-resume circuit breaker for a session whose runtime keeps dying (#6568).
+//!
+//! Why: `runtime_reap` marks a session `Stopped` when the pane's runtime exits,
+//! and the supervisor poller auto-resumes any `Stopped` record whose stop nobody
+//! asked for. For a session whose pane SURVIVED the runtime exit, `resume` takes
+//! the #2148 re-attach branch — it verifies the pane is alive and flips the
+//! record back to `Active` WITHOUT relaunching anything in that pane. The pane
+//! is still the bare shell the reaper just classified, so the next reap tick
+//! marks it `Stopped` again. That is a stable two-step cycle, and it ran for
+//! seven sessions for the full 48 hours of the audit: 2,170 stops against 2,128
+//! resumes, one pair every 60-70 seconds, each doing real tmux and store work.
+//!
+//! What: the policy is a counter and a window. Each auto-resume stamps
+//! `last_auto_resume_at`. Each runtime-exit stop asks [`evaluate`] whether this
+//! death came within [`ResumeBreakerConfig::flap_window`] of that stamp; if it
+//! did, the consecutive count rises, and at
+//! [`ResumeBreakerConfig::max_consecutive`] the session is PARKED — the reaper
+//! writes [`StopCause::ResumeFlapping`](super::record::StopCause::ResumeFlapping)
+//! instead of `Unexpected`, `is_auto_resumable` goes false, and no automatic
+//! path relaunches it again. A death OUTSIDE the window resets the count: a
+//! session that ran for a while and then crashed is not flapping.
+//!
+//! This does not change `auto_resume` control-state semantics. `auto_resume`
+//! still decides WHETHER automatic resumes happen at all; the breaker only
+//! decides that ONE session has exhausted its budget, and it is expressed
+//! through the existing `stop_cause` gate every automatic caller already reads.
+//! An operator's own `tm session resume` is unaffected and clears the park.
+//!
+//! The counter is kept beside the store rather than on `SessionRecord` because
+//! it is supervision bookkeeping, not session identity: the daemon and the
+//! `tm supervisor` process are separate processes, so it must be persisted, but
+//! losing the file only costs a session one extra resume cycle. The PARK itself
+//! lives on the record, so a lost sidecar can never un-park anything.
+//!
+//! Test: `resume_breaker_tests.rs`.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use tracing::warn;
+
+use super::record::ManagedSessionId;
+
+/// Default flap window: a death this soon after an auto-resume counts (#6568).
+///
+/// The observed cycle was 60-70 seconds end to end, so 120 seconds catches it
+/// with margin while leaving a session that ran for minutes uncounted.
+pub const DEFAULT_FLAP_WINDOW_SECS: u64 = 120;
+
+/// Default consecutive fast deaths before auto-resume is parked (#6568).
+///
+/// Five cycles is roughly five minutes of thrash — long enough that a genuine
+/// transient (a machine waking, a tmux server restart) rides it out, short
+/// enough that a permanent flap stops costing work almost immediately.
+pub const DEFAULT_MAX_CONSECUTIVE: u32 = 5;
+
+/// Environment override for [`DEFAULT_FLAP_WINDOW_SECS`]. Zero disables the
+/// breaker (no death is ever inside a zero-length window).
+pub const ENV_FLAP_WINDOW_SECS: &str = "TRUSTY_MPM_RESUME_FLAP_WINDOW_SECS";
+
+/// Environment override for [`DEFAULT_MAX_CONSECUTIVE`].
+pub const ENV_MAX_CONSECUTIVE: &str = "TRUSTY_MPM_RESUME_FLAP_THRESHOLD";
+
+/// The breaker's two tunables.
+///
+/// Why: N and K have to be settable without a rebuild — the right values depend
+/// on how long a healthy session on this host takes to come up — and settable
+/// from a test without touching the process environment.
+/// What: `flap_window` is N (how soon after an auto-resume a death counts) and
+/// `max_consecutive` is K (how many in a row park the session).
+/// Test: `config_defaults`, `config_env_parsing`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResumeBreakerConfig {
+    /// A runtime exit within this long of the last auto-resume is a flap.
+    pub flap_window: Duration,
+    /// Consecutive flaps that park the session. `0` is normalised to `1`.
+    pub max_consecutive: u32,
+}
+
+impl Default for ResumeBreakerConfig {
+    fn default() -> Self {
+        Self {
+            flap_window: Duration::from_secs(DEFAULT_FLAP_WINDOW_SECS),
+            max_consecutive: DEFAULT_MAX_CONSECUTIVE,
+        }
+    }
+}
+
+impl ResumeBreakerConfig {
+    /// Build the config from the process environment.
+    ///
+    /// Why: the daemon is launched unattended by launchd, which can only pass
+    /// configuration through the environment.
+    /// What: delegates to [`Self::from_env_with`] over [`std::env::var`].
+    /// Test: covered through `from_env_with` by `config_env_parsing`.
+    pub fn from_env() -> Self {
+        Self::from_env_with(|k| std::env::var(k).ok())
+    }
+
+    /// Build the config from an injectable environment resolver.
+    ///
+    /// What: an absent or unparsable value keeps the default. A zero window is
+    /// honoured (it disables the breaker); a zero threshold is normalised to
+    /// `1`, because parking on the zeroth flap would park a session that never
+    /// flapped.
+    /// Test: `config_defaults`, `config_env_parsing`,
+    /// `a_zero_window_disables_the_breaker`.
+    pub fn from_env_with(get: impl Fn(&str) -> Option<String>) -> Self {
+        let defaults = Self::default();
+        let flap_window = get(ENV_FLAP_WINDOW_SECS)
+            .and_then(|v| v.trim().parse::<u64>().ok())
+            .map(Duration::from_secs)
+            .unwrap_or(defaults.flap_window);
+        let max_consecutive = get(ENV_MAX_CONSECUTIVE)
+            .and_then(|v| v.trim().parse::<u32>().ok())
+            .map(|k| k.max(1))
+            .unwrap_or(defaults.max_consecutive);
+        Self {
+            flap_window,
+            max_consecutive,
+        }
+    }
+}
+
+/// One session's flap bookkeeping.
+///
+/// Why: the decision needs both halves — when the session was last auto-resumed
+/// and how many fast deaths have followed in a row — and they must move
+/// together.
+/// What: `last_auto_resume_at` is `None` until an automatic path resumes this
+/// session; `consecutive` counts deaths inside the window since the last reset.
+/// Test: `resume_breaker_tests.rs`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FlapState {
+    /// When an automatic path last resumed this session.
+    #[serde(default)]
+    pub last_auto_resume_at: Option<DateTime<Utc>>,
+    /// Consecutive runtime exits inside the flap window.
+    #[serde(default)]
+    pub consecutive: u32,
+}
+
+/// What [`evaluate`] decided about one runtime-exit stop.
+///
+/// Why: the caller has to distinguish "not flapping" from "flapping but not yet
+/// parked" from "park it", and a bool cannot carry the count the log line needs.
+/// What: `Reset` when this death is not attributable to a recent auto-resume;
+/// `Counting` while the streak is below the threshold; `Park` once it reaches it.
+/// Test: `evaluate_*` in `resume_breaker_tests.rs`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BreakerVerdict {
+    /// Not a flap — the streak restarts at zero.
+    Reset,
+    /// A flap, but the session still has budget left.
+    Counting {
+        /// The streak length after counting this death.
+        consecutive: u32,
+    },
+    /// The streak reached the threshold — park auto-resume for this session.
+    Park {
+        /// The streak length that tripped the breaker.
+        consecutive: u32,
+    },
+}
+
+impl BreakerVerdict {
+    /// The streak length this verdict carries (`0` for [`Self::Reset`]).
+    pub fn consecutive(&self) -> u32 {
+        match self {
+            Self::Reset => 0,
+            Self::Counting { consecutive } | Self::Park { consecutive } => *consecutive,
+        }
+    }
+}
+
+/// Decide what one runtime-exit stop means for a session's resume budget.
+///
+/// Why: this is the whole policy, and keeping it a pure function of (config,
+/// state, now) means the flap can be reproduced in a unit test in microseconds
+/// rather than by waiting out real 60-second cycles.
+/// What: a death with no recorded auto-resume, or one that landed at or after
+/// `flap_window` past the last auto-resume, is [`BreakerVerdict::Reset`] — the
+/// session ran long enough that relaunching it is still the right answer.
+/// Otherwise the streak increments; at `max_consecutive` it is
+/// [`BreakerVerdict::Park`], below it [`BreakerVerdict::Counting`]. A `now`
+/// EARLIER than the stamp (a clock step backwards) is treated as outside the
+/// window and resets, because a negative age is not evidence of a fast death.
+/// Test: `evaluate_resets_without_a_prior_auto_resume`,
+/// `evaluate_resets_for_a_slow_death`, `evaluate_counts_a_fast_death`,
+/// `evaluate_parks_at_the_threshold`, `evaluate_resets_on_a_backwards_clock`,
+/// `a_zero_window_disables_the_breaker`.
+pub fn evaluate(
+    cfg: &ResumeBreakerConfig,
+    state: &FlapState,
+    now: DateTime<Utc>,
+) -> BreakerVerdict {
+    let Some(last) = state.last_auto_resume_at else {
+        // Nothing auto-resumed this session, so this death is not evidence that
+        // auto-resume is failing to fix anything.
+        return BreakerVerdict::Reset;
+    };
+    let age = now.signed_duration_since(last);
+    // A negative age means the clock moved; `to_std` fails and we reset rather
+    // than treat an impossible age as the fastest possible death.
+    let Ok(age) = age.to_std() else {
+        return BreakerVerdict::Reset;
+    };
+    if age >= cfg.flap_window {
+        return BreakerVerdict::Reset;
+    }
+    let consecutive = state.consecutive.saturating_add(1);
+    if consecutive >= cfg.max_consecutive.max(1) {
+        BreakerVerdict::Park { consecutive }
+    } else {
+        BreakerVerdict::Counting { consecutive }
+    }
+}
+
+/// Persisted per-session flap counters, stored beside the session store.
+///
+/// Why: the reaper (in the daemon) and the poller (in `tm supervisor`) run in
+/// SEPARATE processes, so an in-memory counter would never see the other half of
+/// the cycle. A small JSON file beside `sessions.json` is the cheapest thing
+/// both can read.
+/// What: a `HashMap<session id, FlapState>` loaded on construction and rewritten
+/// after each mutation. Every I/O failure is logged and swallowed: losing this
+/// file costs a session one extra resume cycle, while failing a runtime-exit
+/// reconcile because a counter could not be written would be strictly worse.
+/// Test: `store_round_trips_state`, `store_survives_a_missing_file`,
+/// `store_survives_a_corrupt_file`.
+#[derive(Debug)]
+pub struct ResumeBreakerStore {
+    path: PathBuf,
+    states: HashMap<String, FlapState>,
+}
+
+impl ResumeBreakerStore {
+    /// File name of the sidecar inside the session-manager data directory.
+    pub const FILE_NAME: &'static str = "resume-breaker.json";
+
+    /// Load (or start empty) the sidecar under `data_dir`.
+    ///
+    /// What: reads `<data_dir>/resume-breaker.json`. A missing file, an
+    /// unreadable one, and an unparsable one all yield an EMPTY map — never an
+    /// error — because a lost counter can only delay a park, never cause one.
+    /// Test: `store_survives_a_missing_file`, `store_survives_a_corrupt_file`.
+    pub fn load(data_dir: &Path) -> Self {
+        let path = data_dir.join(Self::FILE_NAME);
+        let states = match std::fs::read_to_string(&path) {
+            Ok(body) => serde_json::from_str(&body).unwrap_or_else(|e| {
+                warn!(
+                    path = %path.display(),
+                    "resume-breaker: sidecar unparsable ({e}); starting from an empty counter set"
+                );
+                HashMap::new()
+            }),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => HashMap::new(),
+            Err(e) => {
+                warn!(
+                    path = %path.display(),
+                    "resume-breaker: sidecar unreadable ({e}); starting from an empty counter set"
+                );
+                HashMap::new()
+            }
+        };
+        Self { path, states }
+    }
+
+    /// This session's current bookkeeping (default when never seen).
+    pub fn state_of(&self, id: &ManagedSessionId) -> FlapState {
+        self.states
+            .get(&id.to_string())
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    /// Record that an AUTOMATIC path just resumed this session.
+    ///
+    /// Why: the stamp is what makes the next death attributable. It is written
+    /// by the auto-resume path only — an operator's manual resume goes through
+    /// [`Self::note_operator_resume`], which also forgives the streak.
+    /// What: stamps `last_auto_resume_at = now`, keeping `consecutive`.
+    /// Test: `a_fast_death_after_an_auto_resume_counts`.
+    pub fn note_auto_resume(&mut self, id: &ManagedSessionId, now: DateTime<Utc>) {
+        let entry = self.states.entry(id.to_string()).or_default();
+        entry.last_auto_resume_at = Some(now);
+        self.persist();
+    }
+
+    /// Record that an OPERATOR resumed this session, clearing its streak.
+    ///
+    /// Why: a manual resume is the operator saying the cause is addressed. If it
+    /// did not clear the streak, a parked session unparked by hand would re-park
+    /// on its very next fast death instead of getting a fresh budget.
+    /// What: drops the entry entirely — an absent entry IS the zero state, so
+    /// this also keeps the sidecar from accumulating rows for healthy sessions.
+    /// Test: `an_operator_resume_forgives_the_streak`.
+    pub fn note_operator_resume(&mut self, id: &ManagedSessionId) {
+        if self.states.remove(&id.to_string()).is_some() {
+            self.persist();
+        }
+    }
+
+    /// Apply one runtime-exit stop and return what it means.
+    ///
+    /// What: evaluates through [`evaluate`], then stores the resulting streak —
+    /// `Reset` clears the entry (including the stamp, so the NEXT death is not
+    /// attributed to a resume that is now old news), `Counting`/`Park` keep the
+    /// stamp and store the new count.
+    /// Test: `record_death_*` in `resume_breaker_tests.rs`.
+    pub fn record_death(
+        &mut self,
+        id: &ManagedSessionId,
+        cfg: &ResumeBreakerConfig,
+        now: DateTime<Utc>,
+    ) -> BreakerVerdict {
+        let state = self.state_of(id);
+        let verdict = evaluate(cfg, &state, now);
+        match verdict {
+            BreakerVerdict::Reset => {
+                self.states.remove(&id.to_string());
+            }
+            BreakerVerdict::Counting { consecutive } | BreakerVerdict::Park { consecutive } => {
+                self.states.insert(
+                    id.to_string(),
+                    FlapState {
+                        last_auto_resume_at: state.last_auto_resume_at,
+                        consecutive,
+                    },
+                );
+            }
+        }
+        self.persist();
+        verdict
+    }
+
+    /// Write the map back, best-effort.
+    ///
+    /// Fail-open by design: a sidecar that cannot be written must never abort a
+    /// reconcile. The warning names the path so an operator can see it.
+    fn persist(&self) {
+        let body = match serde_json::to_string_pretty(&self.states) {
+            Ok(b) => b,
+            Err(e) => {
+                warn!("resume-breaker: could not serialise counters ({e}); not persisted");
+                return;
+            }
+        };
+        if let Err(e) = std::fs::write(&self.path, body) {
+            warn!(
+                path = %self.path.display(),
+                "resume-breaker: could not persist counters ({e}); they will restart empty"
+            );
+        }
+    }
+}
+
+/// The manager-side wiring the breaker owns (#6568).
+///
+/// Why: `manager.rs` sits at the 500-SLOC production cap, and these methods are
+/// the breaker's rather than the manager's — keeping them beside the policy
+/// they implement means the resume/park pair cannot drift from [`evaluate`].
+/// Same extraction precedent `reconcile.rs` and `create.rs` set for that file.
+impl super::SessionManager {
+    /// Resume a session on behalf of an AUTOMATIC path.
+    ///
+    /// Why: the breaker only means anything if the two halves of the cycle can
+    /// be told apart. An auto-resume must STAMP the attempt so the next runtime
+    /// exit can be attributed to it; an operator's resume must CLEAR the streak.
+    /// One function doing both would let every auto-resume reset the counter it
+    /// is supposed to be filling, and the breaker could never trip.
+    /// What: [`super::SessionManager::resume`]'s shared body, followed by
+    /// [`ResumeBreakerStore::note_auto_resume`]. The caller still owns the
+    /// `is_auto_resumable` gate — this does not re-check it, exactly as `resume`
+    /// does not.
+    /// Test: `the_supervisor_parks_a_flapping_session_after_k_cycles` in
+    /// `resume_breaker_tests.rs`.
+    pub async fn resume_auto(
+        &self,
+        id: &ManagedSessionId,
+    ) -> Result<super::SessionRecord, super::manager::ManagedError> {
+        let record = self.resume_inner(id).await?;
+        self.resume_breaker
+            .write()
+            .await
+            .note_auto_resume(id, Utc::now());
+        Ok(record)
+    }
+
+    /// Resume a session on behalf of an OPERATOR, forgiving the flap streak.
+    ///
+    /// What: [`super::SessionManager::resume`] calls this after its shared body;
+    /// see that method's doc for the resume contract itself.
+    /// Test: `an_operator_resume_forgives_the_streak`.
+    pub(crate) async fn note_operator_resume(&self, id: &ManagedSessionId) {
+        self.resume_breaker.write().await.note_operator_resume(id);
+    }
+
+    /// Decide the `stop_cause` one runtime-exit stop earns.
+    ///
+    /// Why: this is where the breaker actually trips, and the only place a
+    /// [`BreakerVerdict`] becomes a persisted decision — so the log line and the
+    /// recorded cause cannot disagree about what happened.
+    /// What: records the death against this session's counter, then maps the
+    /// verdict. `Park` warns and returns
+    /// [`StopCause::ResumeFlapping`](super::record::StopCause::ResumeFlapping);
+    /// `Counting` and `Reset` both return
+    /// [`StopCause::Unexpected`](super::record::StopCause::Unexpected), which is
+    /// the pre-#6568 behavior.
+    /// Test: `the_supervisor_parks_a_flapping_session_after_k_cycles`,
+    /// `a_session_that_dies_slowly_is_never_parked`.
+    pub(crate) async fn runtime_exit_stop_cause(
+        &self,
+        id: &ManagedSessionId,
+        tmux_name: &str,
+    ) -> super::record::StopCause {
+        use super::record::StopCause;
+        let verdict = self.resume_breaker.write().await.record_death(
+            id,
+            &self.resume_breaker_cfg,
+            Utc::now(),
+        );
+        match verdict {
+            BreakerVerdict::Park { consecutive } => {
+                warn!(
+                    id = %id,
+                    name = %tmux_name,
+                    consecutive,
+                    window_secs = self.resume_breaker_cfg.flap_window.as_secs(),
+                    "runtime-reap: parking auto-resume — this session's runtime exited within the \
+                     flap window of its own auto-resume {consecutive} times in a row (#6568). \
+                     Resume it by hand once the cause is fixed; that clears the park"
+                );
+                StopCause::ResumeFlapping
+            }
+            BreakerVerdict::Counting { consecutive } => {
+                tracing::debug!(
+                    id = %id,
+                    name = %tmux_name,
+                    consecutive,
+                    threshold = self.resume_breaker_cfg.max_consecutive,
+                    "runtime-reap: auto-resume flap streak (#6568)"
+                );
+                StopCause::Unexpected
+            }
+            BreakerVerdict::Reset => StopCause::Unexpected,
+        }
+    }
+
+    /// Override the breaker tunables on an already-built manager.
+    ///
+    /// Why: the policy is time-based, and a test that had to wait out a real
+    /// 120-second window five times over is not a test anyone runs. This is the
+    /// seam that lets the flap be reproduced in milliseconds.
+    /// What: replaces `resume_breaker_cfg`. Production never calls it —
+    /// `SessionManager::new` reads the environment.
+    /// Test: `resume_breaker_tests.rs`.
+    #[cfg(test)]
+    pub(crate) fn set_resume_breaker_config(&mut self, cfg: ResumeBreakerConfig) {
+        self.resume_breaker_cfg = cfg;
+    }
+}

--- a/crates/trusty-mpm/src/session_manager/resume_breaker.rs
+++ b/crates/trusty-mpm/src/session_manager/resume_breaker.rs
@@ -228,9 +228,19 @@ pub fn evaluate(
 /// authoritative, exactly as `sessions.json` is: every read reloads it and every
 /// write goes out atomically, through the shared [`super::json_file`]
 /// primitives `SessionStore` uses for the sibling file in the same directory.
-/// What: a `HashMap<session id, FlapState>` plus the fingerprint of the bytes
-/// last observed. [`Self::reload_if_changed`] re-reads when that fingerprint
-/// moved; [`Self::persist`] stages through a per-instance temp file and renames.
+/// What: a `HashMap<session id, FlapState>`. [`Self::reload`] re-reads on every
+/// access; [`Self::persist`] stages through a per-instance temp file and renames.
+///
+/// Deliberately WITHOUT the (mtime, len) fingerprint short-circuit
+/// `SessionStore` uses, because this payload defeats it. One cycle restamps a
+/// fixed-width timestamp and steps a counter `1`→`2`→`3`, so the serialized
+/// length does not move and freshness would rest on mtime alone; on a
+/// filesystem with 1-second mtime resolution the supervisor's stamp and the
+/// daemon's read can land in the same tick, compare equal, and skip the reload
+/// that is the entire point of this file. The sidecar is a few hundred bytes
+/// read about once a minute per process, so the stat saves nothing worth that
+/// risk. `SessionStore`'s own use of the fingerprint is unaffected — its
+/// records change length on almost every transition.
 ///
 /// Not a lock: two processes read-modify-writing concurrently can still lose an
 /// update. That is tolerable here and only here — a lost counter delays a park
@@ -248,7 +258,6 @@ pub struct ResumeBreakerStore {
     path: PathBuf,
     tmp_path: PathBuf,
     states: HashMap<String, FlapState>,
-    last_sig: Option<super::json_file::FileSig>,
 }
 
 impl ResumeBreakerStore {
@@ -268,37 +277,32 @@ impl ResumeBreakerStore {
             path,
             tmp_path,
             states: HashMap::new(),
-            last_sig: None,
         };
-        store.reload_if_changed().await;
+        store.reload().await;
         store
     }
 
-    /// Re-read the sidecar when the file on disk moved since we last saw it.
+    /// Re-read the sidecar from disk, unconditionally.
     ///
     /// Why (#6568): this is the whole cross-process fix. `note_auto_resume` runs
-    /// in `tm supervisor` and `record_death` runs in the daemon; without this
-    /// the daemon never observes the supervisor's stamp, so every death
+    /// in `tm supervisor` and `record_death` runs in the daemon; without a
+    /// reload the daemon never observes the supervisor's stamp, so every death
     /// evaluates as `Reset` and the breaker is inert in production while passing
     /// every single-process test.
-    /// What: compares the file's current fingerprint against the last observed
-    /// one via [`super::json_file::is_unchanged`] — one stat and no parse when
-    /// nothing moved. On a changed or first-seen file, re-reads and replaces the
-    /// map. A read or parse failure keeps the current map and logs; it never
-    /// errors.
+    ///
+    /// Unconditional, with no (mtime, len) short-circuit: this payload keeps a
+    /// constant serialized length across a cycle, so the fingerprint would rest
+    /// on mtime alone and a coarse-mtime filesystem could skip the very reload
+    /// this exists for. See the type's doc for the full reasoning.
+    /// What: reads and replaces the map. A read or parse failure keeps the map
+    /// already in memory and logs; it never errors. A file that is simply absent
+    /// is a legitimate empty state, not a failure.
     /// Test: `an_external_write_is_picked_up_by_the_next_read`,
     /// `two_managers_over_one_data_dir_still_park_a_flapping_session`.
-    async fn reload_if_changed(&mut self) {
-        let current = super::json_file::sig_of(&self.path).await;
-        if super::json_file::is_unchanged(current, self.last_sig) {
-            return;
-        }
+    async fn reload(&mut self) {
         match tokio::fs::read_to_string(&self.path).await {
             Ok(body) => match serde_json::from_str(&body) {
-                Ok(states) => {
-                    self.states = states;
-                    self.last_sig = current;
-                }
+                Ok(states) => self.states = states,
                 Err(e) => warn!(
                     path = %self.path.display(),
                     "resume-breaker: sidecar unparsable ({e}); keeping the counters already in memory"
@@ -308,7 +312,6 @@ impl ResumeBreakerStore {
                 // Absent is a legitimate state, not a failure: nothing has
                 // flapped yet, or the file was cleaned up between passes.
                 self.states.clear();
-                self.last_sig = None;
             }
             Err(e) => warn!(
                 path = %self.path.display(),
@@ -319,7 +322,7 @@ impl ResumeBreakerStore {
 
     /// This session's current bookkeeping, reconciled with disk first.
     pub async fn state_of(&mut self, id: &ManagedSessionId) -> FlapState {
-        self.reload_if_changed().await;
+        self.reload().await;
         self.states
             .get(&id.to_string())
             .cloned()
@@ -337,7 +340,7 @@ impl ResumeBreakerStore {
     /// Test: `a_fast_death_after_an_auto_resume_counts`,
     /// `two_managers_over_one_data_dir_still_park_a_flapping_session`.
     pub async fn note_auto_resume(&mut self, id: &ManagedSessionId, now: DateTime<Utc>) {
-        self.reload_if_changed().await;
+        self.reload().await;
         let entry = self.states.entry(id.to_string()).or_default();
         entry.last_auto_resume_at = Some(now);
         self.persist().await;
@@ -354,7 +357,7 @@ impl ResumeBreakerStore {
     /// Test: `an_operator_resume_forgives_the_streak`,
     /// `an_in_place_reactivate_forgives_the_streak`.
     pub async fn note_operator_resume(&mut self, id: &ManagedSessionId) {
-        self.reload_if_changed().await;
+        self.reload().await;
         if self.states.remove(&id.to_string()).is_some() {
             self.persist().await;
         }
@@ -401,10 +404,10 @@ impl ResumeBreakerStore {
     /// file — the hazard `SessionStore::save` documents for the sibling file in
     /// this same directory. Routing through [`super::json_file::write_atomic`]
     /// means there is one implementation of that rule, not two.
-    /// What: serialises, stages through this instance's private temp path,
-    /// renames, then records the resulting fingerprint so the next
-    /// [`Self::reload_if_changed`] treats our own write as unchanged. Failures
-    /// log and return — see the type's doc for why this never errors.
+    /// What: serialises, stages through this instance's private temp path, and
+    /// renames. Records no fingerprint — [`Self::reload`] re-reads
+    /// unconditionally, so there is nothing for one to short-circuit. Failures
+    /// log and return; see the type's doc for why this never errors.
     async fn persist(&mut self) {
         let body = match serde_json::to_string_pretty(&self.states) {
             Ok(b) => b,
@@ -418,9 +421,7 @@ impl ResumeBreakerStore {
                 path = %self.path.display(),
                 "resume-breaker: could not persist counters ({e}); they will restart empty"
             );
-            return;
         }
-        self.last_sig = super::json_file::sig_of(&self.path).await;
     }
 }
 

--- a/crates/trusty-mpm/src/session_manager/resume_breaker.rs
+++ b/crates/trusty-mpm/src/session_manager/resume_breaker.rs
@@ -222,55 +222,104 @@ pub fn evaluate(
 /// Persisted per-session flap counters, stored beside the session store.
 ///
 /// Why: the reaper (in the daemon) and the poller (in `tm supervisor`) run in
-/// SEPARATE processes, so an in-memory counter would never see the other half of
-/// the cycle. A small JSON file beside `sessions.json` is the cheapest thing
-/// both can read.
-/// What: a `HashMap<session id, FlapState>` loaded on construction and rewritten
-/// after each mutation. Every I/O failure is logged and swallowed: losing this
-/// file costs a session one extra resume cycle, while failing a runtime-exit
-/// reconcile because a counter could not be written would be strictly worse.
+/// SEPARATE PROCESSES, so an in-memory counter never sees the other half of the
+/// cycle — the daemon's `last_auto_resume_at` stays `None`, every death
+/// evaluates as `Reset`, and the breaker cannot trip. The file is therefore
+/// authoritative, exactly as `sessions.json` is: every read reloads it and every
+/// write goes out atomically, through the shared [`super::json_file`]
+/// primitives `SessionStore` uses for the sibling file in the same directory.
+/// What: a `HashMap<session id, FlapState>` plus the fingerprint of the bytes
+/// last observed. [`Self::reload_if_changed`] re-reads when that fingerprint
+/// moved; [`Self::persist`] stages through a per-instance temp file and renames.
+///
+/// Not a lock: two processes read-modify-writing concurrently can still lose an
+/// update. That is tolerable here and only here — a lost counter delays a park
+/// by one cycle, and the PARK itself lives on the session record, so no lost
+/// write can un-park anything or cause a park that was not earned.
+///
+/// Every I/O failure is logged and swallowed for the same reason: failing a
+/// runtime-exit reconcile because a counter could not be written would be
+/// strictly worse than losing the counter.
 /// Test: `store_round_trips_state`, `store_survives_a_missing_file`,
-/// `store_survives_a_corrupt_file`.
+/// `store_survives_a_corrupt_file`,
+/// `two_managers_over_one_data_dir_still_park_a_flapping_session`.
 #[derive(Debug)]
 pub struct ResumeBreakerStore {
     path: PathBuf,
+    tmp_path: PathBuf,
     states: HashMap<String, FlapState>,
+    last_sig: Option<super::json_file::FileSig>,
 }
 
 impl ResumeBreakerStore {
     /// File name of the sidecar inside the session-manager data directory.
     pub const FILE_NAME: &'static str = "resume-breaker.json";
 
-    /// Load (or start empty) the sidecar under `data_dir`.
+    /// Open the sidecar under `data_dir`, loading whatever is there.
     ///
     /// What: reads `<data_dir>/resume-breaker.json`. A missing file, an
     /// unreadable one, and an unparsable one all yield an EMPTY map — never an
     /// error — because a lost counter can only delay a park, never cause one.
     /// Test: `store_survives_a_missing_file`, `store_survives_a_corrupt_file`.
-    pub fn load(data_dir: &Path) -> Self {
+    pub async fn load(data_dir: &Path) -> Self {
         let path = data_dir.join(Self::FILE_NAME);
-        let states = match std::fs::read_to_string(&path) {
-            Ok(body) => serde_json::from_str(&body).unwrap_or_else(|e| {
-                warn!(
-                    path = %path.display(),
-                    "resume-breaker: sidecar unparsable ({e}); starting from an empty counter set"
-                );
-                HashMap::new()
-            }),
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => HashMap::new(),
-            Err(e) => {
-                warn!(
-                    path = %path.display(),
-                    "resume-breaker: sidecar unreadable ({e}); starting from an empty counter set"
-                );
-                HashMap::new()
-            }
+        let tmp_path = super::json_file::staging_path(&path);
+        let mut store = Self {
+            path,
+            tmp_path,
+            states: HashMap::new(),
+            last_sig: None,
         };
-        Self { path, states }
+        store.reload_if_changed().await;
+        store
     }
 
-    /// This session's current bookkeeping (default when never seen).
-    pub fn state_of(&self, id: &ManagedSessionId) -> FlapState {
+    /// Re-read the sidecar when the file on disk moved since we last saw it.
+    ///
+    /// Why (#6568): this is the whole cross-process fix. `note_auto_resume` runs
+    /// in `tm supervisor` and `record_death` runs in the daemon; without this
+    /// the daemon never observes the supervisor's stamp, so every death
+    /// evaluates as `Reset` and the breaker is inert in production while passing
+    /// every single-process test.
+    /// What: compares the file's current fingerprint against the last observed
+    /// one via [`super::json_file::is_unchanged`] — one stat and no parse when
+    /// nothing moved. On a changed or first-seen file, re-reads and replaces the
+    /// map. A read or parse failure keeps the current map and logs; it never
+    /// errors.
+    /// Test: `an_external_write_is_picked_up_by_the_next_read`,
+    /// `two_managers_over_one_data_dir_still_park_a_flapping_session`.
+    async fn reload_if_changed(&mut self) {
+        let current = super::json_file::sig_of(&self.path).await;
+        if super::json_file::is_unchanged(current, self.last_sig) {
+            return;
+        }
+        match tokio::fs::read_to_string(&self.path).await {
+            Ok(body) => match serde_json::from_str(&body) {
+                Ok(states) => {
+                    self.states = states;
+                    self.last_sig = current;
+                }
+                Err(e) => warn!(
+                    path = %self.path.display(),
+                    "resume-breaker: sidecar unparsable ({e}); keeping the counters already in memory"
+                ),
+            },
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                // Absent is a legitimate state, not a failure: nothing has
+                // flapped yet, or the file was cleaned up between passes.
+                self.states.clear();
+                self.last_sig = None;
+            }
+            Err(e) => warn!(
+                path = %self.path.display(),
+                "resume-breaker: sidecar unreadable ({e}); keeping the counters already in memory"
+            ),
+        }
+    }
+
+    /// This session's current bookkeeping, reconciled with disk first.
+    pub async fn state_of(&mut self, id: &ManagedSessionId) -> FlapState {
+        self.reload_if_changed().await;
         self.states
             .get(&id.to_string())
             .cloned()
@@ -279,45 +328,54 @@ impl ResumeBreakerStore {
 
     /// Record that an AUTOMATIC path just resumed this session.
     ///
-    /// Why: the stamp is what makes the next death attributable. It is written
-    /// by the auto-resume path only — an operator's manual resume goes through
-    /// [`Self::note_operator_resume`], which also forgives the streak.
-    /// What: stamps `last_auto_resume_at = now`, keeping `consecutive`.
-    /// Test: `a_fast_death_after_an_auto_resume_counts`.
-    pub fn note_auto_resume(&mut self, id: &ManagedSessionId, now: DateTime<Utc>) {
+    /// Why: the stamp is what makes the next death attributable, and it is
+    /// written in a DIFFERENT process from the one that reads it — so it
+    /// reloads before mutating, or it would write back a map missing every row
+    /// the daemon added since this process last looked.
+    /// What: reloads, stamps `last_auto_resume_at = now` (keeping
+    /// `consecutive`), persists.
+    /// Test: `a_fast_death_after_an_auto_resume_counts`,
+    /// `two_managers_over_one_data_dir_still_park_a_flapping_session`.
+    pub async fn note_auto_resume(&mut self, id: &ManagedSessionId, now: DateTime<Utc>) {
+        self.reload_if_changed().await;
         let entry = self.states.entry(id.to_string()).or_default();
         entry.last_auto_resume_at = Some(now);
-        self.persist();
+        self.persist().await;
     }
 
     /// Record that an OPERATOR resumed this session, clearing its streak.
     ///
     /// Why: a manual resume is the operator saying the cause is addressed. If it
-    /// did not clear the streak, a parked session unparked by hand would re-park
-    /// on its very next fast death instead of getting a fresh budget.
-    /// What: drops the entry entirely — an absent entry IS the zero state, so
-    /// this also keeps the sidecar from accumulating rows for healthy sessions.
-    /// Test: `an_operator_resume_forgives_the_streak`.
-    pub fn note_operator_resume(&mut self, id: &ManagedSessionId) {
+    /// did not clear the streak, a session unparked by hand would re-park on its
+    /// very next fast death instead of getting a fresh budget.
+    /// What: reloads, drops the entry — an absent entry IS the zero state, so
+    /// this also keeps the sidecar from accumulating rows for healthy sessions —
+    /// and persists.
+    /// Test: `an_operator_resume_forgives_the_streak`,
+    /// `an_in_place_reactivate_forgives_the_streak`.
+    pub async fn note_operator_resume(&mut self, id: &ManagedSessionId) {
+        self.reload_if_changed().await;
         if self.states.remove(&id.to_string()).is_some() {
-            self.persist();
+            self.persist().await;
         }
     }
 
     /// Apply one runtime-exit stop and return what it means.
     ///
-    /// What: evaluates through [`evaluate`], then stores the resulting streak —
-    /// `Reset` clears the entry (including the stamp, so the NEXT death is not
-    /// attributed to a resume that is now old news), `Counting`/`Park` keep the
-    /// stamp and store the new count.
-    /// Test: `record_death_*` in `resume_breaker_tests.rs`.
-    pub fn record_death(
+    /// What: reloads (so the other process's stamp is visible), evaluates
+    /// through [`evaluate`], then stores the resulting streak — `Reset` clears
+    /// the entry, including the stamp, so the NEXT death is not attributed to a
+    /// resume that is now old news; `Counting`/`Park` keep the stamp and store
+    /// the new count.
+    /// Test: `record_death_*`,
+    /// `two_managers_over_one_data_dir_still_park_a_flapping_session`.
+    pub async fn record_death(
         &mut self,
         id: &ManagedSessionId,
         cfg: &ResumeBreakerConfig,
         now: DateTime<Utc>,
     ) -> BreakerVerdict {
-        let state = self.state_of(id);
+        let state = self.state_of(id).await;
         let verdict = evaluate(cfg, &state, now);
         match verdict {
             BreakerVerdict::Reset => {
@@ -333,15 +391,21 @@ impl ResumeBreakerStore {
                 );
             }
         }
-        self.persist();
+        self.persist().await;
         verdict
     }
 
-    /// Write the map back, best-effort.
+    /// Write the map back atomically, best-effort.
     ///
-    /// Fail-open by design: a sidecar that cannot be written must never abort a
-    /// reconcile. The warning names the path so an operator can see it.
-    fn persist(&self) {
+    /// Why: a plain truncate-and-rewrite lets the other process read a torn
+    /// file — the hazard `SessionStore::save` documents for the sibling file in
+    /// this same directory. Routing through [`super::json_file::write_atomic`]
+    /// means there is one implementation of that rule, not two.
+    /// What: serialises, stages through this instance's private temp path,
+    /// renames, then records the resulting fingerprint so the next
+    /// [`Self::reload_if_changed`] treats our own write as unchanged. Failures
+    /// log and return — see the type's doc for why this never errors.
+    async fn persist(&mut self) {
         let body = match serde_json::to_string_pretty(&self.states) {
             Ok(b) => b,
             Err(e) => {
@@ -349,12 +413,14 @@ impl ResumeBreakerStore {
                 return;
             }
         };
-        if let Err(e) = std::fs::write(&self.path, body) {
+        if let Err(e) = super::json_file::write_atomic(&self.path, &self.tmp_path, &body).await {
             warn!(
                 path = %self.path.display(),
                 "resume-breaker: could not persist counters ({e}); they will restart empty"
             );
+            return;
         }
+        self.last_sig = super::json_file::sig_of(&self.path).await;
     }
 }
 
@@ -386,7 +452,8 @@ impl super::SessionManager {
         self.resume_breaker
             .write()
             .await
-            .note_auto_resume(id, Utc::now());
+            .note_auto_resume(id, Utc::now())
+            .await;
         Ok(record)
     }
 
@@ -396,7 +463,11 @@ impl super::SessionManager {
     /// see that method's doc for the resume contract itself.
     /// Test: `an_operator_resume_forgives_the_streak`.
     pub(crate) async fn note_operator_resume(&self, id: &ManagedSessionId) {
-        self.resume_breaker.write().await.note_operator_resume(id);
+        self.resume_breaker
+            .write()
+            .await
+            .note_operator_resume(id)
+            .await;
     }
 
     /// Decide the `stop_cause` one runtime-exit stop earns.
@@ -418,11 +489,12 @@ impl super::SessionManager {
         tmux_name: &str,
     ) -> super::record::StopCause {
         use super::record::StopCause;
-        let verdict = self.resume_breaker.write().await.record_death(
-            id,
-            &self.resume_breaker_cfg,
-            Utc::now(),
-        );
+        let verdict = self
+            .resume_breaker
+            .write()
+            .await
+            .record_death(id, &self.resume_breaker_cfg, Utc::now())
+            .await;
         match verdict {
             BreakerVerdict::Park { consecutive } => {
                 warn!(

--- a/crates/trusty-mpm/src/session_manager/resume_breaker.rs
+++ b/crates/trusty-mpm/src/session_manager/resume_breaker.rs
@@ -370,7 +370,8 @@ impl ResumeBreakerStore {
     /// the entry, including the stamp, so the NEXT death is not attributed to a
     /// resume that is now old news; `Counting`/`Park` keep the stamp and store
     /// the new count.
-    /// Test: `record_death_*`,
+    /// Test: `a_reset_forgets_the_stamp_as_well_as_the_count`,
+    /// `a_fast_death_after_an_auto_resume_counts`,
     /// `two_managers_over_one_data_dir_still_park_a_flapping_session`.
     pub async fn record_death(
         &mut self,

--- a/crates/trusty-mpm/src/session_manager/resume_breaker_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/resume_breaker_tests.rs
@@ -189,6 +189,54 @@ async fn an_external_write_is_picked_up_by_the_next_read() {
     );
 }
 
+/// A same-length rewrite is still picked up — the class an (mtime, len)
+/// fingerprint short-circuit would have missed.
+///
+/// Why: this payload keeps a constant serialized length across a cycle (a
+/// fixed-width timestamp restamped, a counter stepping 1 -> 2 -> 3), so `len`
+/// contributes nothing and freshness would rest on mtime alone. On a
+/// filesystem with 1-second mtime resolution the two writes land in one tick,
+/// compare equal, and the reload that this whole file exists for is skipped.
+/// `ResumeBreakerStore` therefore reloads unconditionally; this asserts the
+/// resulting behavior rather than the absence of the optimisation.
+/// What: writes the sidecar twice with byte-identical LENGTHS and different
+/// counter values, and requires the second to be visible.
+/// Test: this is the test.
+#[tokio::test]
+async fn a_same_length_external_rewrite_is_still_picked_up() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let id = ManagedSessionId::new();
+    let now = Utc::now();
+
+    let mut writer = ResumeBreakerStore::load(tmp.path()).await;
+    let mut reader = ResumeBreakerStore::load(tmp.path()).await;
+
+    writer.note_auto_resume(&id, now).await;
+    let first = writer.record_death(&id, &cfg(3600, 9), now).await;
+    assert_eq!(first, BreakerVerdict::Counting { consecutive: 1 });
+    let len_after_first = std::fs::metadata(tmp.path().join(ResumeBreakerStore::FILE_NAME))
+        .expect("sidecar exists")
+        .len();
+    assert_eq!(reader.state_of(&id).await.consecutive, 1);
+
+    // 1 -> 2 is a single-digit step, so the file is the same size as before.
+    let second = writer.record_death(&id, &cfg(3600, 9), now).await;
+    assert_eq!(second, BreakerVerdict::Counting { consecutive: 2 });
+    let len_after_second = std::fs::metadata(tmp.path().join(ResumeBreakerStore::FILE_NAME))
+        .expect("sidecar exists")
+        .len();
+    assert_eq!(
+        len_after_first, len_after_second,
+        "the premise of this test is that the length does not move"
+    );
+
+    assert_eq!(
+        reader.state_of(&id).await.consecutive,
+        2,
+        "a same-length rewrite must still reach the other instance (#6568)"
+    );
+}
+
 /// The other half: one instance's write must not erase rows another added.
 #[tokio::test]
 async fn a_write_does_not_erase_another_instances_rows() {

--- a/crates/trusty-mpm/src/session_manager/resume_breaker_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/resume_breaker_tests.rs
@@ -143,81 +143,129 @@ fn verdict_reports_its_streak_length() {
 // Sidecar store — including the failure paths (Fail-Open Check)
 // -------------------------------------------------------------------------
 
-#[test]
-fn store_round_trips_state() {
+#[tokio::test]
+async fn store_round_trips_state() {
     let tmp = tempfile::TempDir::new().expect("tempdir");
     let id = ManagedSessionId::new();
     let now = Utc::now();
     {
-        let mut store = ResumeBreakerStore::load(tmp.path());
-        store.note_auto_resume(&id, now);
+        let mut store = ResumeBreakerStore::load(tmp.path()).await;
+        store.note_auto_resume(&id, now).await;
         assert_eq!(
-            store.record_death(&id, &cfg(120, 3), now),
+            store.record_death(&id, &cfg(120, 3), now).await,
             BreakerVerdict::Counting { consecutive: 1 }
         );
     }
-    // A fresh load in a DIFFERENT process would see the same counter — this is
-    // why the sidecar exists at all (the reaper and the poller are separate
+    // A fresh load in a DIFFERENT process sees the same counter — this is why
+    // the sidecar exists at all (the reaper and the poller are separate
     // processes).
-    let reloaded = ResumeBreakerStore::load(tmp.path());
-    assert_eq!(reloaded.state_of(&id).consecutive, 1);
+    let mut reloaded = ResumeBreakerStore::load(tmp.path()).await;
+    assert_eq!(reloaded.state_of(&id).await.consecutive, 1);
 }
 
-#[test]
-fn store_survives_a_missing_file() {
+/// The cross-process contract at the store level: a write by ANOTHER instance
+/// over the same file is visible to the next read, without reconstruction.
+///
+/// Why: a store that loaded once and never re-read is exactly the defect the
+/// critic round found — the daemon's copy would never see the supervisor's
+/// stamp, so every death evaluated as `Reset` and the breaker could not trip.
+/// Test: this is the test. RED before the fix: `store_b` kept its load-time map.
+#[tokio::test]
+async fn an_external_write_is_picked_up_by_the_next_read() {
     let tmp = tempfile::TempDir::new().expect("tempdir");
-    let store = ResumeBreakerStore::load(tmp.path());
+    let id = ManagedSessionId::new();
+    let now = Utc::now();
+
+    let mut store_a = ResumeBreakerStore::load(tmp.path()).await;
+    let mut store_b = ResumeBreakerStore::load(tmp.path()).await;
+    assert_eq!(store_b.state_of(&id).await, FlapState::default());
+
+    store_a.note_auto_resume(&id, now).await;
+
     assert_eq!(
-        store.state_of(&ManagedSessionId::new()),
+        store_b.state_of(&id).await.last_auto_resume_at,
+        Some(now),
+        "a read must reconcile with disk before answering (#6568)"
+    );
+}
+
+/// The other half: one instance's write must not erase rows another added.
+#[tokio::test]
+async fn a_write_does_not_erase_another_instances_rows() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let (a, b) = (ManagedSessionId::new(), ManagedSessionId::new());
+    let now = Utc::now();
+
+    let mut store_a = ResumeBreakerStore::load(tmp.path()).await;
+    let mut store_b = ResumeBreakerStore::load(tmp.path()).await;
+
+    store_a.note_auto_resume(&a, now).await;
+    store_b.note_auto_resume(&b, now).await;
+
+    let mut reader = ResumeBreakerStore::load(tmp.path()).await;
+    assert_eq!(reader.state_of(&a).await.last_auto_resume_at, Some(now));
+    assert_eq!(reader.state_of(&b).await.last_auto_resume_at, Some(now));
+}
+
+#[tokio::test]
+async fn store_survives_a_missing_file() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let mut store = ResumeBreakerStore::load(tmp.path()).await;
+    assert_eq!(
+        store.state_of(&ManagedSessionId::new()).await,
         FlapState::default()
     );
 }
 
-#[test]
-fn store_survives_a_corrupt_file() {
+#[tokio::test]
+async fn store_survives_a_corrupt_file() {
     // Fail-open: a corrupt sidecar starts empty rather than erroring. Losing
     // the counter can only DELAY a park; it can never cause one, because the
     // park itself lives on the record.
     let tmp = tempfile::TempDir::new().expect("tempdir");
     std::fs::write(tmp.path().join(ResumeBreakerStore::FILE_NAME), "{ not json")
         .expect("write corrupt sidecar");
-    let store = ResumeBreakerStore::load(tmp.path());
+    let mut store = ResumeBreakerStore::load(tmp.path()).await;
     assert_eq!(
-        store.state_of(&ManagedSessionId::new()),
+        store.state_of(&ManagedSessionId::new()).await,
         FlapState::default()
     );
 }
 
-#[test]
-fn a_reset_forgets_the_stamp_as_well_as_the_count() {
+#[tokio::test]
+async fn a_reset_forgets_the_stamp_as_well_as_the_count() {
     // After a slow death the previous auto-resume is no longer the thing this
     // session died after, so the NEXT death must not be attributed to it.
     let tmp = tempfile::TempDir::new().expect("tempdir");
     let id = ManagedSessionId::new();
     let now = Utc::now();
-    let mut store = ResumeBreakerStore::load(tmp.path());
-    store.note_auto_resume(&id, now - TimeDelta::seconds(500));
+    let mut store = ResumeBreakerStore::load(tmp.path()).await;
+    store
+        .note_auto_resume(&id, now - TimeDelta::seconds(500))
+        .await;
     assert_eq!(
-        store.record_death(&id, &cfg(120, 2), now),
+        store.record_death(&id, &cfg(120, 2), now).await,
         BreakerVerdict::Reset
     );
-    assert_eq!(store.state_of(&id), FlapState::default());
+    assert_eq!(store.state_of(&id).await, FlapState::default());
     // A second death immediately afterwards is still not a flap.
     assert_eq!(
-        store.record_death(&id, &cfg(120, 2), now),
+        store.record_death(&id, &cfg(120, 2), now).await,
         BreakerVerdict::Reset
     );
 }
 
-#[test]
-fn a_fast_death_after_an_auto_resume_counts() {
+#[tokio::test]
+async fn a_fast_death_after_an_auto_resume_counts() {
     let tmp = tempfile::TempDir::new().expect("tempdir");
     let id = ManagedSessionId::new();
     let now = Utc::now();
-    let mut store = ResumeBreakerStore::load(tmp.path());
-    store.note_auto_resume(&id, now);
+    let mut store = ResumeBreakerStore::load(tmp.path()).await;
+    store.note_auto_resume(&id, now).await;
     assert_eq!(
-        store.record_death(&id, &cfg(120, 9), now + TimeDelta::seconds(30)),
+        store
+            .record_death(&id, &cfg(120, 9), now + TimeDelta::seconds(30))
+            .await,
         BreakerVerdict::Counting { consecutive: 1 }
     );
 }
@@ -273,6 +321,87 @@ async fn one_cycle(mgr: &Arc<SessionManager>, id: &ManagedSessionId) -> super::S
         mgr.resume_auto(id).await.expect("auto-resume");
     }
     stopped
+}
+
+/// Build a manager over an EXISTING data dir, without re-seeding a record.
+///
+/// Why: the production topology has two `SessionManager`s over one directory —
+/// the daemon's and `tm supervisor`'s. Reproducing it needs a second manager
+/// that adopts the first's store rather than creating its own session.
+async fn attach(dir: &tempfile::TempDir, k: u32) -> Arc<SessionManager> {
+    let mut mgr = SessionManager::new(dir.path(), Arc::new(FakeNoopTmuxDriver))
+        .await
+        .expect("session manager");
+    mgr.set_resume_breaker_config(ResumeBreakerConfig {
+        flap_window: Duration::from_secs(3600),
+        max_consecutive: k,
+    });
+    Arc::new(mgr)
+}
+
+/// The production topology: the reaper and the poller are DIFFERENT processes.
+///
+/// Why: this is the defect the critic round caught. The single-manager test
+/// below passes over it, because one manager's in-memory sidecar carries the
+/// stamp from its own `resume_auto` straight into its own `record_death`. In
+/// production those two calls are made by two processes over one file, and a
+/// sidecar loaded once at construction leaves the daemon's
+/// `last_auto_resume_at` permanently `None` — every death evaluates as `Reset`
+/// and the breaker never trips.
+/// What: `daemon` marks the runtime exited; `supervisor`, a SEPARATE manager
+/// over the same `data_dir`, does the auto-resume. Only a sidecar that reloads
+/// from disk on every read can carry the stamp between them.
+/// Test: this is the test. RED at 0e357cfd8 — `daemon` never observes
+/// `supervisor`'s stamp, so the loop runs forever and the final assertion that
+/// the record is parked fails with `Some(Unexpected)`.
+#[tokio::test]
+async fn two_managers_over_one_data_dir_still_park_a_flapping_session() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let (daemon, id) = seeded(&tmp, 3).await;
+    let supervisor = attach(&tmp, 3).await;
+
+    // Cycle 1: the first death follows no auto-resume at all, so it resets.
+    let first = daemon
+        .mark_runtime_exited_stopped(&id)
+        .await
+        .expect("mark stopped");
+    assert_eq!(first.stop_cause, Some(StopCause::Unexpected));
+    supervisor.resume_auto(&id).await.expect("auto-resume");
+
+    // Cycles 2 and 3 build the streak across the process boundary.
+    for cycle in 2..=3 {
+        let r = daemon
+            .mark_runtime_exited_stopped(&id)
+            .await
+            .expect("mark stopped");
+        assert_eq!(
+            r.stop_cause,
+            Some(StopCause::Unexpected),
+            "cycle {cycle} must still be resumable"
+        );
+        supervisor.resume_auto(&id).await.expect("auto-resume");
+    }
+
+    // Cycle 4 reaches the threshold — in the daemon, off a stamp the supervisor
+    // wrote in the other process.
+    let parked = daemon
+        .mark_runtime_exited_stopped(&id)
+        .await
+        .expect("mark stopped");
+    assert_eq!(
+        parked.stop_cause,
+        Some(StopCause::ResumeFlapping),
+        "the breaker must trip when the two halves of the cycle run in different \
+         processes — the only topology that exists in production (#6568)"
+    );
+    assert!(!parked.is_auto_resumable());
+
+    // And the supervisor's own view of the record agrees, so it stops resuming.
+    let seen_by_supervisor = supervisor.get(&id).await.expect("get");
+    assert!(
+        !seen_by_supervisor.is_auto_resumable(),
+        "the process that does the resuming must be the one that sees the park"
+    );
 }
 
 /// The headline regression. RED before the fix: every cycle wrote
@@ -348,6 +477,44 @@ async fn an_operator_resume_forgives_the_streak() {
         next.stop_cause,
         Some(StopCause::Unexpected),
         "an operator resume must restore the full budget, not one death of it"
+    );
+    assert!(next.is_auto_resumable());
+}
+
+/// The in-place reactivate is an operator action too, so it forgives the streak.
+///
+/// Why: `mark_reactivated` (#2023 C) is the bare-`tm` in-pane relaunch. It feeds
+/// `record_death` through the same `mark_runtime_exited_stopped` the reaper
+/// uses, so before this fix an operator relaunching repeatedly built the flap
+/// streak with their own hands and got parked on the next ordinary exit.
+/// Test: this is the test. RED before the fix: the streak survived the
+/// reactivate and the fourth death parked the session.
+#[tokio::test]
+async fn an_in_place_reactivate_forgives_the_streak() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let (mgr, id) = seeded(&tmp, 2).await;
+
+    // Build the streak to one short of the threshold.
+    one_cycle(&mgr, &id).await; // reset + resume
+    let counted = mgr
+        .mark_runtime_exited_stopped(&id)
+        .await
+        .expect("mark stopped");
+    assert_eq!(counted.stop_cause, Some(StopCause::Unexpected));
+
+    // The operator relaunches in place rather than through `resume`.
+    let revived = mgr.mark_reactivated(&id).await.expect("reactivate");
+    assert_eq!(revived.state, ManagedSessionState::Active);
+    assert_eq!(revived.stop_cause, None);
+
+    let next = mgr
+        .mark_runtime_exited_stopped(&id)
+        .await
+        .expect("mark stopped");
+    assert_eq!(
+        next.stop_cause,
+        Some(StopCause::Unexpected),
+        "an in-place reactivate must restore the full budget, like `resume` does"
     );
     assert!(next.is_auto_resumable());
 }

--- a/crates/trusty-mpm/src/session_manager/resume_breaker_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/resume_breaker_tests.rs
@@ -1,0 +1,470 @@
+//! Tests for the #6568 auto-resume circuit breaker.
+//!
+//! Why: the live defect is a two-process, 60-second cycle that ran 2,128 times
+//! in 48 hours. Reproducing it means driving the SAME two calls the daemon and
+//! the supervisor make — `mark_runtime_exited_stopped` and `resume_auto` — with
+//! a compressed window, and asserting the streak eventually parks the session.
+//! What: the pure-policy cases against [`super::resume_breaker::evaluate`], the
+//! sidecar's failure paths, and the end-to-end park/unpark cycle against a real
+//! [`SessionManager`] on a [`FakeNoopTmuxDriver`].
+//! Test: this is the test module.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::{TimeDelta, Utc};
+
+use super::record::{ManagedSessionId, ManagedSessionState, StopCause};
+use super::resume_breaker::{
+    BreakerVerdict, DEFAULT_MAX_CONSECUTIVE, ENV_FLAP_WINDOW_SECS, ENV_MAX_CONSECUTIVE, FlapState,
+    ResumeBreakerConfig, ResumeBreakerStore, evaluate,
+};
+use super::{FakeNoopTmuxDriver, SessionManager};
+
+// -------------------------------------------------------------------------
+// Config
+// -------------------------------------------------------------------------
+
+#[test]
+fn config_defaults() {
+    let cfg = ResumeBreakerConfig::default();
+    assert_eq!(cfg.flap_window, Duration::from_secs(120));
+    assert_eq!(cfg.max_consecutive, DEFAULT_MAX_CONSECUTIVE);
+}
+
+#[test]
+fn config_env_parsing() {
+    let cfg = ResumeBreakerConfig::from_env_with(|k| match k {
+        ENV_FLAP_WINDOW_SECS => Some(" 45 ".to_string()),
+        ENV_MAX_CONSECUTIVE => Some("3".to_string()),
+        _ => None,
+    });
+    assert_eq!(cfg.flap_window, Duration::from_secs(45));
+    assert_eq!(cfg.max_consecutive, 3);
+
+    // Garbage falls back rather than silently disabling the breaker.
+    let cfg = ResumeBreakerConfig::from_env_with(|_| Some("nope".to_string()));
+    assert_eq!(cfg, ResumeBreakerConfig::default());
+
+    // A zero threshold would park a session on its zeroth flap — normalised.
+    let cfg =
+        ResumeBreakerConfig::from_env_with(|k| (k == ENV_MAX_CONSECUTIVE).then(|| "0".to_string()));
+    assert_eq!(cfg.max_consecutive, 1);
+}
+
+// -------------------------------------------------------------------------
+// Pure policy
+// -------------------------------------------------------------------------
+
+fn cfg(window_secs: u64, k: u32) -> ResumeBreakerConfig {
+    ResumeBreakerConfig {
+        flap_window: Duration::from_secs(window_secs),
+        max_consecutive: k,
+    }
+}
+
+#[test]
+fn evaluate_resets_without_a_prior_auto_resume() {
+    // A session nobody auto-resumed cannot be evidence that auto-resume is
+    // failing to fix anything — the very first crash must stay resumable.
+    let v = evaluate(&cfg(120, 3), &FlapState::default(), Utc::now());
+    assert_eq!(v, BreakerVerdict::Reset);
+}
+
+#[test]
+fn evaluate_resets_for_a_slow_death() {
+    let now = Utc::now();
+    let state = FlapState {
+        last_auto_resume_at: Some(now - TimeDelta::seconds(500)),
+        consecutive: 2,
+    };
+    assert_eq!(evaluate(&cfg(120, 3), &state, now), BreakerVerdict::Reset);
+}
+
+#[test]
+fn evaluate_counts_a_fast_death() {
+    let now = Utc::now();
+    let state = FlapState {
+        last_auto_resume_at: Some(now - TimeDelta::seconds(60)),
+        consecutive: 1,
+    };
+    assert_eq!(
+        evaluate(&cfg(120, 5), &state, now),
+        BreakerVerdict::Counting { consecutive: 2 }
+    );
+}
+
+#[test]
+fn evaluate_parks_at_the_threshold() {
+    let now = Utc::now();
+    let state = FlapState {
+        last_auto_resume_at: Some(now - TimeDelta::seconds(60)),
+        consecutive: 2,
+    };
+    assert_eq!(
+        evaluate(&cfg(120, 3), &state, now),
+        BreakerVerdict::Park { consecutive: 3 }
+    );
+}
+
+#[test]
+fn evaluate_resets_on_a_backwards_clock() {
+    // A death "before" the resume that preceded it is a clock step, not the
+    // fastest possible death. Reading it as age zero would park a healthy
+    // session the moment NTP corrected the host.
+    let now = Utc::now();
+    let state = FlapState {
+        last_auto_resume_at: Some(now + TimeDelta::seconds(600)),
+        consecutive: 4,
+    };
+    assert_eq!(evaluate(&cfg(120, 5), &state, now), BreakerVerdict::Reset);
+}
+
+#[test]
+fn a_zero_window_disables_the_breaker() {
+    // The documented escape hatch: no death is ever inside a zero-length
+    // window, so an operator can restore the pre-#6568 behavior exactly.
+    let now = Utc::now();
+    let state = FlapState {
+        last_auto_resume_at: Some(now),
+        consecutive: 99,
+    };
+    assert_eq!(evaluate(&cfg(0, 1), &state, now), BreakerVerdict::Reset);
+}
+
+#[test]
+fn verdict_reports_its_streak_length() {
+    assert_eq!(BreakerVerdict::Reset.consecutive(), 0);
+    assert_eq!(BreakerVerdict::Counting { consecutive: 2 }.consecutive(), 2);
+    assert_eq!(BreakerVerdict::Park { consecutive: 7 }.consecutive(), 7);
+}
+
+// -------------------------------------------------------------------------
+// Sidecar store — including the failure paths (Fail-Open Check)
+// -------------------------------------------------------------------------
+
+#[test]
+fn store_round_trips_state() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let id = ManagedSessionId::new();
+    let now = Utc::now();
+    {
+        let mut store = ResumeBreakerStore::load(tmp.path());
+        store.note_auto_resume(&id, now);
+        assert_eq!(
+            store.record_death(&id, &cfg(120, 3), now),
+            BreakerVerdict::Counting { consecutive: 1 }
+        );
+    }
+    // A fresh load in a DIFFERENT process would see the same counter — this is
+    // why the sidecar exists at all (the reaper and the poller are separate
+    // processes).
+    let reloaded = ResumeBreakerStore::load(tmp.path());
+    assert_eq!(reloaded.state_of(&id).consecutive, 1);
+}
+
+#[test]
+fn store_survives_a_missing_file() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let store = ResumeBreakerStore::load(tmp.path());
+    assert_eq!(
+        store.state_of(&ManagedSessionId::new()),
+        FlapState::default()
+    );
+}
+
+#[test]
+fn store_survives_a_corrupt_file() {
+    // Fail-open: a corrupt sidecar starts empty rather than erroring. Losing
+    // the counter can only DELAY a park; it can never cause one, because the
+    // park itself lives on the record.
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    std::fs::write(tmp.path().join(ResumeBreakerStore::FILE_NAME), "{ not json")
+        .expect("write corrupt sidecar");
+    let store = ResumeBreakerStore::load(tmp.path());
+    assert_eq!(
+        store.state_of(&ManagedSessionId::new()),
+        FlapState::default()
+    );
+}
+
+#[test]
+fn a_reset_forgets_the_stamp_as_well_as_the_count() {
+    // After a slow death the previous auto-resume is no longer the thing this
+    // session died after, so the NEXT death must not be attributed to it.
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let id = ManagedSessionId::new();
+    let now = Utc::now();
+    let mut store = ResumeBreakerStore::load(tmp.path());
+    store.note_auto_resume(&id, now - TimeDelta::seconds(500));
+    assert_eq!(
+        store.record_death(&id, &cfg(120, 2), now),
+        BreakerVerdict::Reset
+    );
+    assert_eq!(store.state_of(&id), FlapState::default());
+    // A second death immediately afterwards is still not a flap.
+    assert_eq!(
+        store.record_death(&id, &cfg(120, 2), now),
+        BreakerVerdict::Reset
+    );
+}
+
+#[test]
+fn a_fast_death_after_an_auto_resume_counts() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let id = ManagedSessionId::new();
+    let now = Utc::now();
+    let mut store = ResumeBreakerStore::load(tmp.path());
+    store.note_auto_resume(&id, now);
+    assert_eq!(
+        store.record_death(&id, &cfg(120, 9), now + TimeDelta::seconds(30)),
+        BreakerVerdict::Counting { consecutive: 1 }
+    );
+}
+
+// -------------------------------------------------------------------------
+// End to end, through the real SessionManager
+// -------------------------------------------------------------------------
+
+/// Build an isolated manager whose breaker parks after `k` fast deaths, and
+/// seed one `Active` session on a fake tmux driver.
+async fn seeded(dir: &tempfile::TempDir, k: u32) -> (Arc<SessionManager>, ManagedSessionId) {
+    let mut mgr = SessionManager::new(dir.path(), Arc::new(FakeNoopTmuxDriver))
+        .await
+        .expect("session manager");
+    // A one-hour window makes every death in this test a "fast" one without
+    // any sleeping; `k` is the only knob under test.
+    mgr.set_resume_breaker_config(ResumeBreakerConfig {
+        flap_window: Duration::from_secs(3600),
+        max_consecutive: k,
+    });
+    let mgr = Arc::new(mgr);
+    let record = mgr
+        .create(
+            "flap-test".into(),
+            Some(std::path::PathBuf::from("/tmp")),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("create");
+    let id = record.id;
+    mgr.set_workspace(
+        &id,
+        std::path::PathBuf::from("/tmp"),
+        ManagedSessionState::Active,
+    )
+    .await
+    .expect("set Active");
+    (mgr, id)
+}
+
+/// Drive one full cycle of the live defect: the reaper marks the session
+/// `Stopped`, the supervisor auto-resumes it, and the pane is unchanged so it
+/// dies again. Returns the record as the reaper left it.
+async fn one_cycle(mgr: &Arc<SessionManager>, id: &ManagedSessionId) -> super::SessionRecord {
+    let stopped = mgr
+        .mark_runtime_exited_stopped(id)
+        .await
+        .expect("mark stopped");
+    if stopped.is_auto_resumable() {
+        mgr.resume_auto(id).await.expect("auto-resume");
+    }
+    stopped
+}
+
+/// The headline regression. RED before the fix: every cycle wrote
+/// `StopCause::Unexpected`, `is_auto_resumable` stayed true forever, and this
+/// loop would never terminate the thrash — which is exactly the 2,128
+/// resumes/48h the audit measured.
+#[tokio::test]
+async fn the_supervisor_parks_a_flapping_session_after_k_cycles() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let (mgr, id) = seeded(&tmp, 3).await;
+
+    // The first death follows no auto-resume, so it resets and resumes.
+    let first = one_cycle(&mgr, &id).await;
+    assert_eq!(first.stop_cause, Some(StopCause::Unexpected));
+    assert!(first.is_auto_resumable());
+
+    // Two more fast deaths build the streak without parking.
+    for cycle in 1..=2 {
+        let r = one_cycle(&mgr, &id).await;
+        assert_eq!(
+            r.stop_cause,
+            Some(StopCause::Unexpected),
+            "cycle {cycle} must still be resumable"
+        );
+        assert!(r.is_auto_resumable(), "cycle {cycle}");
+    }
+
+    // The third fast death reaches the threshold.
+    let parked = one_cycle(&mgr, &id).await;
+    assert_eq!(
+        parked.stop_cause,
+        Some(StopCause::ResumeFlapping),
+        "the breaker must trip at K consecutive fast deaths (#6568)"
+    );
+    assert!(
+        !parked.is_auto_resumable(),
+        "a parked session must be invisible to every automatic resume path"
+    );
+
+    // And it STAYS parked: the store's own record still refuses.
+    let after = mgr.get(&id).await.expect("get");
+    assert_eq!(after.stop_cause, Some(StopCause::ResumeFlapping));
+    assert!(!after.is_auto_resumable());
+}
+
+/// The park must be operator-recoverable, or it is a trap rather than a
+/// breaker. A manual `resume` clears both the cause and the streak.
+#[tokio::test]
+async fn an_operator_resume_forgives_the_streak() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let (mgr, id) = seeded(&tmp, 2).await;
+
+    one_cycle(&mgr, &id).await; // reset + resume
+    one_cycle(&mgr, &id).await; // streak 1, resumed
+    let parked = mgr
+        .mark_runtime_exited_stopped(&id)
+        .await
+        .expect("mark stopped");
+    assert_eq!(parked.stop_cause, Some(StopCause::ResumeFlapping));
+
+    // The operator fixes the cause and resumes by hand.
+    let revived = mgr.resume(&id).await.expect("operator resume");
+    assert_eq!(revived.state, ManagedSessionState::Active);
+    assert_eq!(revived.stop_cause, None);
+
+    // The next fast death must NOT re-park immediately — the streak was
+    // forgiven, so the session gets its full budget back.
+    let next = mgr
+        .mark_runtime_exited_stopped(&id)
+        .await
+        .expect("mark stopped");
+    assert_eq!(
+        next.stop_cause,
+        Some(StopCause::Unexpected),
+        "an operator resume must restore the full budget, not one death of it"
+    );
+    assert!(next.is_auto_resumable());
+}
+
+/// A session that runs for longer than the window between deaths is a crashing
+/// session, not a flapping one, and auto-resume must keep helping it.
+#[tokio::test]
+async fn a_session_that_dies_slowly_is_never_parked() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let mut mgr = SessionManager::new(tmp.path(), Arc::new(FakeNoopTmuxDriver))
+        .await
+        .expect("session manager");
+    // A zero window means no death is ever "fast" — the slow-death case in the
+    // limit, with no sleeping.
+    mgr.set_resume_breaker_config(ResumeBreakerConfig {
+        flap_window: Duration::from_secs(0),
+        max_consecutive: 2,
+    });
+    let mgr = Arc::new(mgr);
+    let record = mgr
+        .create(
+            "slow".into(),
+            Some(std::path::PathBuf::from("/tmp")),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("create");
+    let id = record.id;
+    mgr.set_workspace(
+        &id,
+        std::path::PathBuf::from("/tmp"),
+        ManagedSessionState::Active,
+    )
+    .await
+    .expect("set Active");
+
+    for cycle in 1..=6 {
+        let r = one_cycle(&mgr, &id).await;
+        assert_eq!(
+            r.stop_cause,
+            Some(StopCause::Unexpected),
+            "cycle {cycle}: a slow death must never park the session"
+        );
+        assert!(r.is_auto_resumable(), "cycle {cycle}");
+    }
+}
+
+/// Build a `Stopped` record carrying `cause`, through the real create path.
+async fn stopped_record_with(
+    dir: &tempfile::TempDir,
+    cause: Option<StopCause>,
+) -> super::SessionRecord {
+    let mgr = SessionManager::new(dir.path(), Arc::new(FakeNoopTmuxDriver))
+        .await
+        .expect("session manager");
+    let mut r = mgr
+        .create(
+            "cause".into(),
+            Some(std::path::PathBuf::from("/tmp")),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("create");
+    r.state = ManagedSessionState::Stopped;
+    r.stop_cause = cause;
+    r
+}
+
+/// `auto_resume` control-state semantics are untouched: the breaker expresses
+/// itself through `stop_cause`, the same gate `Deliberate` already used, and it
+/// never relabels a deliberately-stopped record as a breaker trip.
+#[tokio::test]
+async fn park_reason_is_set_only_for_a_flapping_record() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    for cause in [
+        None,
+        Some(StopCause::Unexpected),
+        Some(StopCause::Deliberate),
+    ] {
+        let r = stopped_record_with(&tmp, cause).await;
+        assert!(
+            r.auto_resume_park_reason().is_none(),
+            "{cause:?} is not a breaker trip"
+        );
+    }
+
+    let parked = stopped_record_with(&tmp, Some(StopCause::ResumeFlapping)).await;
+    let reason = parked
+        .auto_resume_park_reason()
+        .expect("a flapping record must name its park reason");
+    assert!(reason.contains("#6568"), "reason was: {reason}");
+    assert!(
+        reason.contains("tm session resume"),
+        "the reason must tell an operator how to clear it: {reason}"
+    );
+}
+
+/// The wire shape every listing surface reads carries the reason (#6568).
+#[tokio::test]
+async fn summary_carries_the_resume_park_reason() {
+    use crate::daemon::managed_routes::summary::record_to_summary;
+
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+
+    let ordinary = stopped_record_with(&tmp, Some(StopCause::Unexpected)).await;
+    assert!(record_to_summary(&ordinary).auto_resume_parked.is_none());
+
+    let parked = stopped_record_with(&tmp, Some(StopCause::ResumeFlapping)).await;
+    assert_eq!(
+        record_to_summary(&parked).auto_resume_parked.as_deref(),
+        parked.auto_resume_park_reason(),
+        "the summary must not restate the reason in its own words"
+    );
+}

--- a/crates/trusty-mpm/src/session_manager/store.rs
+++ b/crates/trusty-mpm/src/session_manager/store.rs
@@ -9,13 +9,13 @@
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::time::SystemTime;
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::fs;
 use tracing::{debug, warn};
 
+use super::json_file;
 use super::record::{ManagedSessionId, SessionRecord};
 use super::store_integrity::{StoreIntegrity, validate};
 
@@ -117,53 +117,6 @@ pub(crate) struct StoredData {
     pub(crate) sessions: HashMap<String, SessionRecord>,
 }
 
-/// A cheap freshness fingerprint for the backing file.
-///
-/// Why: the cross-process reload check (#1219) keys off "did the file change
-/// since we last touched it". An mtime alone is insufficient on filesystems
-/// whose mtime resolution is coarse (1s on some): two writes in the same second
-/// would compare equal and the reader would miss the second write. Pairing the
-/// mtime with the byte length catches a same-second write that changed the file
-/// size, which a state transition (different JSON length) almost always does.
-/// What: the file's last-modified `SystemTime` (an `Option` — `None` when the
-/// platform/filesystem cannot report an mtime) and its length in bytes. The whole
-/// `FileSig` is wrapped in an `Option` by callers, where `None` means "file
-/// absent / could not be stat'd".
-/// Test: `store_reload_picks_up_external_write`, `store_reload_noop_when_unchanged`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-struct FileSig {
-    /// File modification time, if the platform/filesystem reports one.
-    mtime: Option<SystemTime>,
-    /// File length in bytes.
-    len: u64,
-}
-
-/// The private staging path a store instance renames over `path` on save.
-///
-/// Why (#5007): `save` used to stage through `path.with_extension("json.tmp")`
-/// — one fixed name shared by every writer of that store, in every process.
-/// The rename is atomic, but the staging write is not exclusive: two writers
-/// each open that one name with truncate, each stream their own serialization
-/// into it, and the file that gets renamed into place has the length of the
-/// longer document and the head of the shorter one. That is the exact shape
-/// #5007 reports — a complete document followed by a stale tail whose length
-/// equals the difference between the two serializations. Making the staging
-/// name private to one store instance removes the shared resource entirely.
-/// What: `<path>.tmp.<pid>.<uuid>` — the pid separates processes, the uuid
-/// separates instances within one process (tests routinely hold two stores over
-/// one directory, and `agent_reset_workspace` builds its own alongside the
-/// daemon's).
-/// Test: `two_stores_over_one_path_do_not_share_a_staging_file`.
-fn staging_path(path: &Path) -> PathBuf {
-    let mut name = path.file_name().unwrap_or_default().to_os_string();
-    name.push(format!(
-        ".tmp.{}.{}",
-        std::process::id(),
-        uuid::Uuid::new_v4().simple()
-    ));
-    path.with_file_name(name)
-}
-
 /// Async, file-backed store for [`SessionRecord`]s.
 ///
 /// Why: the session manager must be able to reload all known sessions after a
@@ -194,7 +147,7 @@ pub struct SessionStore {
     /// not exist at last observation (a fresh, never-saved store).
     /// What: the (mtime, len) pair captured from the file's metadata.
     /// Test: `store_reload_picks_up_external_write`.
-    last_sig: Option<FileSig>,
+    last_sig: Option<json_file::FileSig>,
     /// Private staging path this instance renames over `path` on every save.
     ///
     /// Why (#5007): every `SessionStore` used to stage through the SAME
@@ -228,7 +181,7 @@ impl SessionStore {
     pub async fn load(data_dir: &Path) -> Result<Self, StoreError> {
         let path = data_dir.join("sessions.json");
         let (data, last_sig) = Self::read_file(&path).await?;
-        let tmp_path = staging_path(&path);
+        let tmp_path = json_file::staging_path(&path);
         Ok(Self {
             data,
             path,
@@ -273,25 +226,6 @@ impl SessionStore {
         &self.tmp_path
     }
 
-    /// Stat `path` and return its freshness fingerprint, or `None` if absent.
-    ///
-    /// Why: both the reload check and `save` need to capture the same (mtime,
-    /// len) signature; centralising it keeps "what counts as the file's
-    /// identity" in one place.
-    /// What: on `metadata` success returns `Some(FileSig { mtime, len })`; on any
-    /// stat error (most commonly: file does not exist) returns `None`.
-    /// Test: exercised via `store_reload_*` tests.
-    async fn sig_of(path: &Path) -> Option<FileSig> {
-        let meta = fs::metadata(path).await.ok()?;
-        Some(FileSig {
-            // `modified()` can be unsupported on exotic filesystems; `None` there
-            // makes the (mtime, len) pair compare unequal so reads reload — correct,
-            // just less efficient — rather than risk serving stale data.
-            mtime: meta.modified().ok(),
-            len: meta.len(),
-        })
-    }
-
     /// Read and parse the backing file, returning the data and its fingerprint.
     ///
     /// Why: both [`Self::load`] and [`Self::reload_if_changed`] need the exact
@@ -310,7 +244,9 @@ impl SessionStore {
     /// which compares unequal and harmlessly forces a future reload.
     /// Test: `store_reload_picks_up_external_write`, `store_load_save_round_trip`,
     /// `store_read_file_sig_matches_post_read_bytes`.
-    async fn read_file(path: &Path) -> Result<(StoredData, Option<FileSig>), StoreError> {
+    async fn read_file(
+        path: &Path,
+    ) -> Result<(StoredData, Option<json_file::FileSig>), StoreError> {
         let raw = match fs::read_to_string(path).await {
             Ok(raw) => raw,
             // ONLY a genuinely absent file means "fresh store" (#5007). Before
@@ -349,7 +285,7 @@ impl SessionStore {
         let data =
             validate(path, &raw).map_err(|integrity| StoreError::Corrupt(Box::new(integrity)))?;
         // Stat AFTER the read so the signature matches the bytes we parsed.
-        let sig = Self::sig_of(path).await.unwrap_or_default();
+        let sig = json_file::sig_of(path).await.unwrap_or_default();
         Ok((data, Some(sig)))
     }
 
@@ -369,11 +305,11 @@ impl SessionStore {
     /// Test: `store_reload_picks_up_external_write`,
     /// `store_reload_noop_when_unchanged`.
     pub async fn reload_if_changed(&mut self) -> Result<(), StoreError> {
-        let current = Self::sig_of(&self.path).await;
+        let current = json_file::sig_of(&self.path).await;
         // Reload unless the file is present AND its fingerprint exactly matches
         // what we last observed. A `None` on either side (file absent, or never
         // saved) is treated as "changed" so we never miss an external write.
-        let unchanged = matches!((current, self.last_sig), (Some(a), Some(b)) if a == b);
+        let unchanged = json_file::is_unchanged(current, self.last_sig);
         if unchanged {
             return Ok(());
         }
@@ -436,7 +372,7 @@ impl SessionStore {
         // Record the fingerprint of the bytes we just wrote so a subsequent
         // `reload_if_changed` treats our own write as "unchanged" and does not
         // pointlessly re-read the file we just authored (#1219).
-        self.last_sig = Self::sig_of(&self.path).await;
+        self.last_sig = json_file::sig_of(&self.path).await;
         debug!(path = %self.path.display(), "session store saved");
         Ok(())
     }

--- a/crates/trusty-mpm/src/session_manager/store.rs
+++ b/crates/trusty-mpm/src/session_manager/store.rs
@@ -344,31 +344,25 @@ impl SessionStore {
     /// a concurrent reader can observe a half-written (unparseable) file. Writing
     /// a temp file and renaming it into place makes the swap atomic on POSIX, so
     /// a cross-process reader always sees either the old or the new file whole.
-    /// What: serializes `self.data` to JSON, creates parent directories if
-    /// needed, writes a sibling `sessions.json.tmp`, then renames it over the
-    /// real path; finally records the resulting mtime so a subsequent
-    /// [`Self::reload_if_changed`] treats our own write as "unchanged".
+    /// What: serializes `self.data` to JSON and hands the bytes to
+    /// [`json_file::write_atomic`], which creates the parent, stages through
+    /// this instance's private temp path and renames; then records the
+    /// resulting mtime so a subsequent [`Self::reload_if_changed`] treats our
+    /// own write as "unchanged". The stage-and-rename itself lives in
+    /// `json_file` because the #6568 breaker sidecar in this same directory
+    /// needs the identical rule — two copies of it is how one of them drifts.
     /// Test: verified indirectly by every mutating store test;
-    /// `store_reload_picks_up_external_write` exercises the cross-process path.
+    /// `store_reload_picks_up_external_write` exercises the cross-process path;
+    /// the write mechanics by `write_atomic_*` in `json_file_tests.rs`.
     pub async fn save(&mut self) -> Result<(), StoreError> {
-        if let Some(parent) = self.path.parent() {
-            fs::create_dir_all(parent).await?;
-        }
         let json = serde_json::to_string_pretty(&self.data)
             .map_err(|e| StoreError::Serialize(e.to_string()))?;
-        // Atomic swap: write to a temp sibling then rename over the target so a
-        // concurrent reader in another process never sees a torn file.
         // #5007: the staging name is PER STORE INSTANCE, not the shared
-        // `sessions.json.tmp` it used to be — see `tmp_path`'s doc for why a
-        // shared one produces exactly the corruption this issue was filed for.
-        let tmp = &self.tmp_path;
-        fs::write(tmp, json).await?;
-        if let Err(e) = fs::rename(tmp, &self.path).await {
-            // Do not leave the staging file behind on a failed swap; it is
-            // named after this process and nothing else will ever clean it up.
-            let _ = fs::remove_file(tmp).await;
-            return Err(StoreError::Io(e));
-        }
+        // `sessions.json.tmp` it used to be — see `json_file::staging_path` for
+        // why a shared one produces exactly the corruption that issue reports.
+        json_file::write_atomic(&self.path, &self.tmp_path, &json)
+            .await
+            .map_err(StoreError::Io)?;
         // Record the fingerprint of the bytes we just wrote so a subsequent
         // `reload_if_changed` treats our own write as "unchanged" and does not
         // pointlessly re-read the file we just authored (#1219).

--- a/crates/trusty-mpm/src/supervisor/poller.rs
+++ b/crates/trusty-mpm/src/supervisor/poller.rs
@@ -83,7 +83,10 @@ pub async fn run_tick<C: LlmClassifier>(
             // candidate, which respawned sessions the operator had just killed.
             // `is_auto_resumable` reads the recorded stop cause.
             ManagedSessionState::Stopped if cfg.auto_resume && record.is_auto_resumable() => {
-                match mgr.resume(&record.id).await {
+                // #6568: `resume_auto`, not `resume` — the automatic path stamps
+                // the attempt so the next runtime exit can be attributed to it.
+                // `resume` is the operator's entry point and forgives the streak.
+                match mgr.resume_auto(&record.id).await {
                     Ok(_) => {
                         info!(
                             id = %record.id,

--- a/crates/trusty-mpm/src/tui/project_ctl/poll/rows.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/poll/rows.rs
@@ -220,6 +220,7 @@ mod tests {
             attached: false,
             slot: 0,
             deleted: false,
+            auto_resume_parked: None,
         }
     }
 

--- a/crates/trusty-mpm/src/tui/project_ctl/poll/tests.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/poll/tests.rs
@@ -44,6 +44,7 @@ fn summary(id: &str, state: &str) -> ManagedSessionSummary {
         attached: false,
         slot: 0,
         deleted: false,
+        auto_resume_parked: None,
     }
 }
 

--- a/crates/trusty-mpm/src/tui/project_ctl/tests.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/tests.rs
@@ -61,6 +61,7 @@ fn summary(id: &str, state: &str) -> ManagedSessionSummary {
         attached: false,
         slot: 0,
         deleted: false,
+        auto_resume_parked: None,
     }
 }
 

--- a/crates/trusty-mpm/tests/orphan_gc_sweep.rs
+++ b/crates/trusty-mpm/tests/orphan_gc_sweep.rs
@@ -13,7 +13,7 @@
 use std::sync::Mutex;
 
 use trusty_mpm::daemon::orphan_gc::{
-    AlwaysIdleProbe, ChildLivenessProbe, OrphanGc, PaneInfo, TrackedNames, run_sweep,
+    AlwaysIdleProbe, ChildLivenessProbe, FsCwdProbe, OrphanGc, PaneInfo, TrackedNames, run_sweep,
 };
 use trusty_mpm::session_manager::{ManagedError, ManagedTmuxDriver};
 
@@ -58,6 +58,7 @@ fn pane(name: &str, cmd: &str) -> PaneInfo {
         pane_current_command: cmd.to_string(),
         pane_pid: Some(9999),
         pane_id: None,
+        pane_current_path: None,
     }
 }
 
@@ -86,7 +87,7 @@ fn sweep_reaps_only_untracked_idle_managed_session_after_debounce() {
     let mut gc = OrphanGc::new();
 
     // Pass 1: (d) is a candidate but the debounce must spare it — nothing killed.
-    let reaped1 = run_sweep(&mut gc, &panes, &tracked, &probe, &driver);
+    let reaped1 = run_sweep(&mut gc, &panes, &tracked, &probe, &FsCwdProbe, &driver);
     assert_eq!(reaped1, 0, "no session may be reaped on first observation");
     assert!(
         driver.killed().is_empty(),
@@ -95,7 +96,7 @@ fn sweep_reaps_only_untracked_idle_managed_session_after_debounce() {
     );
 
     // Pass 2: (d) seen orphaned twice in a row → reaped. NOTHING else, ever.
-    let reaped2 = run_sweep(&mut gc, &panes, &tracked, &probe, &driver);
+    let reaped2 = run_sweep(&mut gc, &panes, &tracked, &probe, &FsCwdProbe, &driver);
     assert_eq!(reaped2, 1);
     assert_eq!(
         driver.killed(),
@@ -114,7 +115,14 @@ fn sweep_never_reaps_untracked_active_managed_session() {
     let mut gc = OrphanGc::new();
 
     for _ in 0..5 {
-        run_sweep(&mut gc, &panes, &TrackedNames::default(), &probe, &driver);
+        run_sweep(
+            &mut gc,
+            &panes,
+            &TrackedNames::default(),
+            &probe,
+            &FsCwdProbe,
+            &driver,
+        );
     }
     assert!(
         driver.killed().is_empty(),
@@ -133,7 +141,14 @@ fn sweep_never_reaps_foreign_session() {
     let mut gc = OrphanGc::new();
 
     for _ in 0..5 {
-        run_sweep(&mut gc, &panes, &TrackedNames::default(), &probe, &driver);
+        run_sweep(
+            &mut gc,
+            &panes,
+            &TrackedNames::default(),
+            &probe,
+            &FsCwdProbe,
+            &driver,
+        );
     }
     assert!(
         driver.killed().is_empty(),
@@ -166,7 +181,7 @@ fn sweep_skips_reap_on_degraded_snapshot() {
 
     // Many passes off a degraded snapshot — never a single kill.
     for _ in 0..5 {
-        let reaped = run_sweep(&mut gc, &panes, &degraded, &probe, &driver);
+        let reaped = run_sweep(&mut gc, &panes, &degraded, &probe, &FsCwdProbe, &driver);
         assert_eq!(reaped, 0, "a degraded snapshot must reap nothing");
     }
     assert!(
@@ -195,19 +210,28 @@ fn degraded_pass_resets_debounce_between_trustworthy_passes() {
     let mut gc = OrphanGc::new();
 
     // Pass 1 (trustworthy): first sighting — candidate, not reaped.
-    assert_eq!(run_sweep(&mut gc, &panes, &complete, &probe, &driver), 0);
+    assert_eq!(
+        run_sweep(&mut gc, &panes, &complete, &probe, &FsCwdProbe, &driver),
+        0
+    );
     // Pass 2 (degraded): aborts and clears the debounce history.
-    assert_eq!(run_sweep(&mut gc, &panes, &degraded, &probe, &driver), 0);
+    assert_eq!(
+        run_sweep(&mut gc, &panes, &degraded, &probe, &FsCwdProbe, &driver),
+        0
+    );
     // Pass 3 (trustworthy): debounce was reset, so this is a *first* sighting
     // again — must NOT reap despite the candidate having been seen before.
     assert_eq!(
-        run_sweep(&mut gc, &panes, &complete, &probe, &driver),
+        run_sweep(&mut gc, &panes, &complete, &probe, &FsCwdProbe, &driver),
         0,
         "a degraded pass must restart the two-pass debounce"
     );
     // Pass 4 (trustworthy): now seen orphaned on two consecutive trustworthy
     // passes → finally reaped, proving the gate only *delays*, never breaks, GC.
-    assert_eq!(run_sweep(&mut gc, &panes, &complete, &probe, &driver), 1);
+    assert_eq!(
+        run_sweep(&mut gc, &panes, &complete, &probe, &FsCwdProbe, &driver),
+        1
+    );
     assert_eq!(driver.killed(), vec!["tmpm-d-untracked-idle".to_string()]);
 }
 
@@ -230,12 +254,141 @@ fn sweep_spares_session_with_live_child() {
             &panes,
             &TrackedNames::default(),
             &LiveProbe,
+            &FsCwdProbe,
             &driver,
         );
     }
     assert!(
         driver.killed().is_empty(),
         "a session with a live agent child must be spared, killed: {:?}",
+        driver.killed()
+    );
+}
+
+/// #6118 end to end: a pane running an AGENT whose working directory is gone is
+/// killed by the sweep — but only on the second consecutive observation, and
+/// only when the directory is really absent.
+///
+/// Why: the unit tests prove the classifier; only this one proves the kill
+/// reaches the driver through the real `run_sweep` path with the real
+/// filesystem probe. RED before the fix: `run_sweep` had no cwd input, so this
+/// pane was warned-and-kept forever — 478 of them on the reporting host.
+/// What: creates two directories, points one pane at each, deletes one, sweeps.
+/// Test: this is the test.
+#[test]
+fn sweep_reaps_an_agent_pane_whose_cwd_is_gone_after_debounce() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let gone = tmp.path().join("deleted-worktree");
+    let alive = tmp.path().join("live-worktree");
+    std::fs::create_dir(&gone).expect("create gone");
+    std::fs::create_dir(&alive).expect("create alive");
+
+    let mut zombie = pane("tm-zombie-01", "claude");
+    zombie.pane_current_path = Some(gone.to_string_lossy().to_string());
+    let mut healthy = pane("tm-healthy-01", "claude");
+    healthy.pane_current_path = Some(alive.to_string_lossy().to_string());
+    let panes = vec![zombie, healthy];
+
+    let driver = RecordingDriver::new();
+    let probe = AlwaysIdleProbe;
+    let mut gc = OrphanGc::new();
+
+    // While both directories exist, neither pane is ever a candidate.
+    for _ in 0..3 {
+        let reaped = run_sweep(
+            &mut gc,
+            &panes,
+            &TrackedNames::default(),
+            &probe,
+            &FsCwdProbe,
+            &driver,
+        );
+        assert_eq!(reaped, 0, "an agent pane with a live cwd must be kept");
+    }
+
+    std::fs::remove_dir(&gone).expect("remove");
+
+    // First sighting after the deletion: still spared by the debounce.
+    let first = run_sweep(
+        &mut gc,
+        &panes,
+        &TrackedNames::default(),
+        &probe,
+        &FsCwdProbe,
+        &driver,
+    );
+    assert_eq!(first, 0, "a live foreground process needs two sweeps");
+    assert!(driver.killed().is_empty(), "killed: {:?}", driver.killed());
+
+    // Second consecutive sighting: reaped, and ONLY the zombie.
+    let second = run_sweep(
+        &mut gc,
+        &panes,
+        &TrackedNames::default(),
+        &probe,
+        &FsCwdProbe,
+        &driver,
+    );
+    assert_eq!(second, 1);
+    assert_eq!(driver.killed(), vec!["tm-zombie-01".to_string()]);
+}
+
+/// The #4091-family protection, end to end: a TRACKED session whose cwd is gone
+/// is never touched. Tracking wins before the cwd gate, so a record the store
+/// still owns stays the store's to dispose of.
+#[test]
+fn sweep_never_reaps_a_tracked_session_whose_cwd_is_gone() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    // Deliberately never created — the path is absent from the start.
+    let gone = tmp.path().join("never-existed");
+
+    let mut tracked_pane = pane("tm-tracked-01", "claude");
+    tracked_pane.pane_current_path = Some(gone.to_string_lossy().to_string());
+    let panes = vec![tracked_pane];
+    let tracked = TrackedNames {
+        managed: ["tm-tracked-01".to_string()].into_iter().collect(),
+        ..TrackedNames::default()
+    };
+
+    let driver = RecordingDriver::new();
+    let mut gc = OrphanGc::new();
+    for _ in 0..5 {
+        run_sweep(
+            &mut gc,
+            &panes,
+            &tracked,
+            &AlwaysIdleProbe,
+            &FsCwdProbe,
+            &driver,
+        );
+    }
+    assert!(
+        driver.killed().is_empty(),
+        "a tracked session must never be reaped on cwd evidence, killed: {:?}",
+        driver.killed()
+    );
+}
+
+/// Fail-open check (ADR-0045): a pane whose cwd tmux never reported is kept
+/// forever, no matter how many sweeps run. No evidence is not absence.
+#[test]
+fn sweep_never_reaps_an_agent_pane_with_no_reported_cwd() {
+    let panes = vec![pane("tm-unknown-cwd-01", "claude")];
+    let driver = RecordingDriver::new();
+    let mut gc = OrphanGc::new();
+    for _ in 0..5 {
+        run_sweep(
+            &mut gc,
+            &panes,
+            &TrackedNames::default(),
+            &AlwaysIdleProbe,
+            &FsCwdProbe,
+            &driver,
+        );
+    }
+    assert!(
+        driver.killed().is_empty(),
+        "no cwd evidence must never become a kill, killed: {:?}",
         driver.killed()
     );
 }


### PR DESCRIPTION
Refs #6568, Refs #6118, Refs #6569

#6568: adds a resume circuit-breaker with cross-process breaker state kept in a sidecar (`ResumeBreakerStore`), plus a parked marker (`auto_resume_parked`) surfaced when the breaker trips.

#6118: reaps panes whose working directory is gone, gated on parent-process evidence before reaping.

#6569: consolidates daemon logging to a single sink under launchd (`tracing_setup.rs`).

Test ladder: rung 3 (localized to trusty-mpm) plus rung-5 concurrency tests on the breaker.

- `cargo fmt --check`
- `cargo check -p trusty-mpm --all-targets`
- `cargo clippy -p trusty-mpm --all-targets -- -D warnings`
- `cargo test -p trusty-mpm --no-fail-fast` → 5714 + 1916 + 103 passed, 0 failed, on 55842d647
- `check_line_cap.sh`, `check_changelog_fragment.sh`, `check_sld.sh` all clean

Review: code-critic APPROVED at 4611b678c after two rounds; the two remaining findings (`SessionStore::save` dedupe onto `json_file::write_atomic`; `ResumeBreakerStore::reload_if_changed` always reads) closed in 55842d647.

SemVer note: `auto_resume_parked` is a new public field on `ManagedSessionSummary` (crates/trusty-mpm/src/client/http_client/types.rs) and `SessionSummary` (crates/trusty-mpm/src/daemon/managed_routes/session_summary.rs); neither is `#[non_exhaustive]`, so `preflight-publish.sh` CHECK 5 will fire at the next trusty-mpm publish — local-ops chooses MINOR bump vs `#[non_exhaustive]` at that time.

Flake observed, not caused by this branch: `core::session_assets::tests::session_plan_under_matches_session_plan_at_home` lost its `$HOME` redirect once under parallel execution, passed on re-run and 3/3 in isolation; `git diff --name-only origin/main...HEAD -- crates/trusty-mpm/src/core/` is empty. Same family as #6580.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
