### PR TITLE
fix(log-drain): stream oversize logs through the existing upload path; record skips durably

### DIFF
--- a/crates/trusty-common/changelog.d/6547-drain-oversize-logs.md
+++ b/crates/trusty-common/changelog.d/6547-drain-oversize-logs.md
@@ -1,0 +1,28 @@
+Fixed
+
+- `log_drain` now streams each log file instead of reading it whole, so a file
+  over the old 64 MiB ceiling uploads rather than being skipped forever. The
+  collector held five live copies of a body — plaintext, decoded, filtered,
+  scrubbed, gzipped — which is the only reason the ceiling existed; 29 of 86
+  daily-rotated daemon logs, up to 176 MB each, were permanently undrainable on
+  the first live run (#6547). The new `pipeline` module reads 1 MiB at a time,
+  splitting on the last line terminator, and carries the level filter's
+  disposition and a scrub window across each boundary, so the streamed result
+  matches the buffered one. The scrub window holds back the last
+  `longest needle - 1` bytes of every chunk, which is what makes chunking safe
+  for a secret that straddles a boundary (the hazard #6534 refused to chunk
+  over).
+- `DEFAULT_MAX_FILE_BYTES` moved from 64 MiB to 4 GiB, and a second bound,
+  `DEFAULT_MAX_WIRE_BYTES` (64 MiB), caps the COMPRESSED body — the one buffer
+  that still scales with the file, since `LogDestination::put` takes an
+  in-memory `Bytes`. `collect` now takes a `CollectLimits` in place of a bare
+  `max_file_bytes`, and `DrainConfig` gained `with_max_wire_bytes`.
+- A file that does trip either bound has the decision recorded in the manifest
+  as a `SkipRecord`, so it is made once per `(file, size, mtime)` rather than
+  every cycle. The drain re-decided ~40 permanently-oversize files every 15
+  minutes and re-logged the same warning — 1,276 of them in 48 hours. A later
+  pass that sees an unchanged file counts it silently; a size or mtime change
+  re-evaluates it; and any file the pass can read has its record dropped, so
+  raising a bound takes effect on the next pass. `DrainReport` gained
+  `skips_recorded`, the count of decisions that actually warned. `skips` is
+  `#[serde(default)]`, so manifests written before this change still decode.

--- a/crates/trusty-common/src/log_drain/collector.rs
+++ b/crates/trusty-common/src/log_drain/collector.rs
@@ -1,66 +1,98 @@
-//! Reading log files and preparing them for upload (#6533).
+//! Finding log files and handing each one to the streaming pipeline (#6533).
 //!
 //! Why: everything that must happen to a log line before it leaves the machine
-//! happens here, in one order, once. Splitting the level filter, the secret
-//! scrub, and the compression across call sites is how a body eventually
-//! reaches a bucket having skipped one of them.
+//! happens in one order, once. Splitting the level filter, the secret scrub,
+//! and the compression across call sites is how a body eventually reaches a
+//! bucket having skipped one of them.
 //! What: [`collect`] walks each [`LogSource`]'s root, matches its globs, and
-//! for every file: filters by level, scrubs secrets, gzips, and yields a
-//! [`CollectedFile`]. The SHA-256 it reports is over the PLAINTEXT bytes as
-//! read, before filtering — so the manifest's identity tracks the source file,
-//! not the drain's own processing, and a change to the filter never invalidates
+//! hands every match to [`super::pipeline::stream_file`], which reads it in
+//! bounded chunks. The SHA-256 it reports is over the PLAINTEXT bytes as read,
+//! before filtering — so the manifest's identity tracks the source file, not
+//! the drain's own processing, and a change to the filter never invalidates
 //! every recorded digest.
 //! Test: `super::tests::collect_filters_below_info`,
 //! `super::tests::collect_passes_through_non_tracing`,
-//! `super::tests::collect_scrubs_secrets_before_they_reach_the_destination`, `super::tests::collect_skips_oversize`.
+//! `super::tests::collect_scrubs_secrets_before_they_reach_the_destination`,
+//! `super::tests::collect_skips_oversize`.
+//!
+//! # The ceiling is a cost decision, not a memory one (#6547)
+//!
+//! Before #6547 a file over `max_file_bytes` was skipped because the collector
+//! read it whole; five copies of a 176 MB log is not a working set a daemon can
+//! take. [`super::pipeline::stream_file`] removed that constraint, so the
+//! DEFAULT ceiling moved from 64 MiB to [`DEFAULT_MAX_FILE_BYTES`] — high
+//! enough that no daily-rotated daemon log reaches it. What survives is an
+//! operator-facing guard against spending a pass on an absurd file, plus
+//! [`CollectLimits::max_wire_bytes`], which bounds the one thing still held
+//! whole: the COMPRESSED body `LogDestination::put` takes.
+//!
+//! A file that does trip either bound is reported as an [`OversizeFile`] and
+//! the decision is recorded in the manifest by [`super::run_once`], so it is
+//! made ONCE per `(file, size, mtime)` rather than re-logged every cycle.
 
-use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use bytes::Bytes;
+
 use globset::{Glob, GlobSetBuilder};
-use sha2::{Digest, Sha256};
 
 use super::error::DrainError;
+use super::manifest::SkipReason;
+use super::pipeline::{StreamOutcome, stream_file};
+
+pub use super::pipeline::Level;
 
 /// Default ceiling on a single source file, in bytes.
 ///
-/// 64 MiB is well above the trusty daemons' daily rolled logs and well below
-/// anything that would embarrass a machine holding one plaintext copy, one
-/// scrubbed copy, and one gzip buffer at once.
-pub const DEFAULT_MAX_FILE_BYTES: u64 = 64 * 1024 * 1024;
+/// 4 GiB. Since #6547 the collector streams, so this no longer bounds memory —
+/// it bounds how much reading and hashing one pass will spend on one file. No
+/// daily-rotated trusty daemon log has come within two orders of magnitude of
+/// it; the largest observed was 176 MB.
+pub const DEFAULT_MAX_FILE_BYTES: u64 = 4 * 1024 * 1024 * 1024;
 
-/// Log levels the drain can filter on, ordered least to most severe.
+/// Default ceiling on one file's COMPRESSED body, in bytes.
 ///
-/// Deliberately not `tracing::Level`: the drain reads level names out of
-/// already-written TEXT, and coupling that string parsing to `tracing`'s type
-/// would make the drain depend on the crate that produced the file rather than
-/// on the file format.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+/// 64 MiB — the number the source ceiling used to carry, moved to where memory
+/// is actually spent. `LogDestination::put` takes an in-memory `Bytes`, so the
+/// gzip output is the one buffer that still scales with the file. At the ~20x
+/// ratio daemon log text compresses at, this admits well over a gigabyte of
+/// source.
+pub const DEFAULT_MAX_WIRE_BYTES: u64 = 64 * 1024 * 1024;
+
+/// The two size bounds one [`collect`] pass enforces.
+///
+/// Why: two adjacent `u64` parameters are two parameters waiting to be
+/// transposed, and the pair grew from one at #6547. Naming them makes a call
+/// site say which bound it is setting.
+/// What: `max_file_bytes` bounds the plaintext source, `max_wire_bytes` the
+/// compressed body. Either being exceeded yields an [`OversizeFile`], never a
+/// truncated upload.
+/// Test: `super::tests::collect_skips_oversize`,
+/// `super::tests::collect_skips_a_body_over_the_wire_cap`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
-pub enum Level {
-    /// `TRACE`
-    Trace,
-    /// `DEBUG`
-    Debug,
-    /// `INFO`
-    Info,
-    /// `WARN`
-    Warn,
-    /// `ERROR`
-    Error,
+pub struct CollectLimits {
+    /// Plaintext source ceiling. See [`DEFAULT_MAX_FILE_BYTES`].
+    pub max_file_bytes: u64,
+    /// Compressed body ceiling. See [`DEFAULT_MAX_WIRE_BYTES`].
+    pub max_wire_bytes: u64,
 }
 
-impl Level {
-    /// Map a bare level token to its variant.
-    fn parse(token: &str) -> Option<Self> {
-        match token {
-            "TRACE" => Some(Self::Trace),
-            "DEBUG" => Some(Self::Debug),
-            "INFO" => Some(Self::Info),
-            "WARN" | "WARNING" => Some(Self::Warn),
-            "ERROR" => Some(Self::Error),
-            _ => None,
+impl Default for CollectLimits {
+    fn default() -> Self {
+        Self {
+            max_file_bytes: DEFAULT_MAX_FILE_BYTES,
+            max_wire_bytes: DEFAULT_MAX_WIRE_BYTES,
+        }
+    }
+}
+
+impl CollectLimits {
+    /// Both bounds, in bytes.
+    pub fn new(max_file_bytes: u64, max_wire_bytes: u64) -> Self {
+        Self {
+            max_file_bytes,
+            max_wire_bytes,
         }
     }
 }
@@ -103,13 +135,27 @@ pub struct CollectedFile {
     pub source_path: PathBuf,
 }
 
-/// A source file the collector declined to read.
+/// A source file the collector declined to upload.
+///
+/// Why: `path` and `size` were enough to log a warning, and logging a warning
+/// every cycle for a file that can never change its answer is exactly what
+/// #6547 is about. The extra three fields are what [`super::run_once`] needs to
+/// record the decision durably: the key it is recorded under, the mtime half of
+/// the identity that invalidates it, and which bound was hit.
+/// Test: `super::tests::run_once_records_an_oversize_skip_once`.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct OversizeFile {
     /// The path that was skipped.
     pub path: PathBuf,
+    /// `<crate>/<relative path>` — the manifest's identity for this file.
+    pub relative_key: String,
     /// Its size in bytes.
     pub size: u64,
+    /// Source file's modification time, Unix seconds.
+    pub mtime_unix: i64,
+    /// Which bound the file hit.
+    pub reason: SkipReason,
 }
 
 /// What one [`collect`] pass found.
@@ -117,26 +163,27 @@ pub struct OversizeFile {
 pub struct Collected {
     /// Files read and ready to upload.
     pub files: Vec<CollectedFile>,
-    /// Files skipped for exceeding `max_file_bytes`.
+    /// Files skipped for exceeding one of the [`CollectLimits`].
     pub oversize: Vec<OversizeFile>,
     /// Per-file failures. A failure here never aborts the pass.
     pub errors: Vec<(PathBuf, String)>,
 }
 
-/// Enumerate, read, filter, scrub, and compress every matching log file.
+/// Enumerate every matching log file and stream each one into an upload body.
 ///
 /// Why: see the module docs — one ordered pipeline, so no body can reach a
 /// destination having skipped the scrub.
-/// What: for each source, compiles its globs once, walks `root`, and processes
-/// each matching file. Files larger than `max_file_bytes` are SKIPPED with a
-/// `warn!` and an [`OversizeFile`] entry rather than streamed in chunks: the
-/// scrub has to see a whole body to catch a secret that straddles a chunk
-/// boundary, so a chunked path could only ever upload partially-scrubbed text.
-/// Refusing to upload is the safe half of that trade, and the report says so
-/// out loud rather than silently truncating.
+/// What: for each source, compiles its globs once, walks `root`, and hands each
+/// matching file to [`super::pipeline::stream_file`]. A file over
+/// [`CollectLimits::max_file_bytes`] is never opened; one whose compressed body
+/// passes [`CollectLimits::max_wire_bytes`] is abandoned mid-stream. Both land
+/// in [`Collected::oversize`] rather than being truncated, and neither logs
+/// here — [`super::run_once`] owns that, because only it can tell a new
+/// decision from one already recorded (#6547).
 /// `secrets` is passed straight to [`crate::credentials::scrub_secrets`],
 /// which ignores needles under its own minimum length.
-/// Test: `super::tests::collect_skips_oversize`, `super::tests::collect_scrubs_secrets_before_they_reach_the_destination`.
+/// Test: `super::tests::collect_skips_oversize`,
+/// `super::tests::collect_scrubs_secrets_before_they_reach_the_destination`.
 ///
 /// # Errors
 /// Returns [`DrainError::Uri`] only for a malformed glob pattern, which is a
@@ -145,7 +192,7 @@ pub struct Collected {
 pub fn collect(
     sources: &[LogSource],
     secrets: &[String],
-    max_file_bytes: u64,
+    limits: CollectLimits,
 ) -> Result<Collected, DrainError> {
     let mut out = Collected::default();
 
@@ -178,20 +225,20 @@ pub fn collect(
             if !globs.is_match(relative) {
                 continue;
             }
-            process_file(source, path, relative, secrets, max_file_bytes, &mut out);
+            process_file(source, path, relative, secrets, limits, &mut out);
         }
     }
 
     Ok(out)
 }
 
-/// Read one matched file into `out`, recording an error rather than failing.
+/// Stream one matched file into `out`, recording an error rather than failing.
 fn process_file(
     source: &LogSource,
     path: &Path,
     relative: &Path,
     secrets: &[String],
-    max_file_bytes: u64,
+    limits: CollectLimits,
     out: &mut Collected,
 ) {
     let metadata = match std::fs::metadata(path) {
@@ -203,146 +250,44 @@ fn process_file(
     };
 
     let size = metadata.len();
-    if size > max_file_bytes {
-        // #6533: skip, never truncate — see `collect`'s docs for why a chunked
-        // path cannot scrub a secret that straddles a boundary.
-        tracing::warn!(
-            path = %path.display(),
-            size,
-            max_file_bytes,
-            "log-drain skipping oversize file; it will not be uploaded"
-        );
-        out.oversize.push(OversizeFile {
-            path: path.to_path_buf(),
-            size,
-        });
-        return;
-    }
-
-    let plaintext = match std::fs::read(path) {
-        Ok(b) => b,
-        Err(e) => {
-            out.errors.push((path.to_path_buf(), e.to_string()));
-            return;
-        }
-    };
-
-    let sha256_plaintext = hex_digest(&plaintext);
     let mtime_unix = mtime_seconds(&metadata);
+    let relative_key = format!("{}/{}", source.crate_name, relative.to_string_lossy());
 
-    // Order is load-bearing: decode, then filter, then scrub, then compress.
-    let text = String::from_utf8_lossy(&plaintext);
-    let filtered = match source.level_filter {
-        Some(min) => filter_by_level(&text, min),
-        None => text.into_owned(),
-    };
-    let scrubbed = crate::credentials::scrub_secrets(&filtered, secrets);
-
-    let body = match gzip(scrubbed.as_bytes()) {
-        Ok(b) => b,
-        Err(e) => {
-            out.errors.push((path.to_path_buf(), e.to_string()));
-            return;
-        }
-    };
-
-    out.files.push(CollectedFile {
-        relative_key: format!("{}/{}", source.crate_name, relative.to_string_lossy()),
-        body: Bytes::from(body),
-        sha256_plaintext,
-        plaintext_len: size,
-        mtime_unix,
-        source_path: path.to_path_buf(),
-    });
-}
-
-/// Drop lines below `min`, leaving non-tracing files untouched.
-///
-/// Why: a daemon's DEBUG output is the bulk of its log bytes and almost never
-/// the reason anyone reads it later. Dropping it before compression is where
-/// the drain's egress saving actually comes from.
-/// What: recognises the `tracing_subscriber::fmt` default line shape —
-/// `<timestamp> <LEVEL> <target>: <message>` — and keeps a line when its level
-/// is at or above `min`. A line carrying no recognisable level is a
-/// CONTINUATION (a wrapped message, a backtrace frame) and inherits the
-/// disposition of the line above it. If the file contains no recognisable
-/// level line at all, it is not tracing output and is returned VERBATIM rather
-/// than filtered to nothing.
-/// Test: `super::tests::collect_filters_below_info`,
-/// `super::tests::collect_passes_through_non_tracing`.
-fn filter_by_level(text: &str, min: Level) -> String {
-    let mut saw_any_level = false;
-    let mut keeping = true;
-    let mut kept = String::with_capacity(text.len());
-
-    for line in text.split_inclusive('\n') {
-        // No level token means a continuation line, which keeps whatever
-        // disposition the line above it had — hence no `else` branch.
-        if let Some(level) = line_level(line) {
-            saw_any_level = true;
-            keeping = level >= min;
-        }
-        if keeping {
-            kept.push_str(line);
-        }
-    }
-
-    if saw_any_level {
-        kept
+    // #6547: no `warn!` on either arm. `run_once` decides whether the skip is
+    // news, because only it can see the manifest's record of the last answer.
+    let reason = if size > limits.max_file_bytes {
+        SkipReason::SourceTooLarge
     } else {
-        text.to_string()
-    }
-}
-
-/// Extract the level from a `tracing_subscriber::fmt` line, if it has one.
-///
-/// Scans the first few whitespace-separated tokens with ANSI escapes stripped,
-/// so a colourised log (`fmt` with `with_ansi(true)`, which the console layer
-/// uses) is recognised the same as a plain file appender's output.
-fn line_level(line: &str) -> Option<Level> {
-    let plain = strip_ansi(line);
-    // The level is the second token in the default format; allow a little slack
-    // for a prefixed thread name or span without scanning the whole message.
-    plain
-        .split_whitespace()
-        .take(4)
-        .find_map(|token| Level::parse(token.trim_matches(|c: char| !c.is_ascii_alphabetic())))
-}
-
-/// Remove ANSI CSI escape sequences so level detection survives colour output.
-fn strip_ansi(line: &str) -> String {
-    let mut out = String::with_capacity(line.len());
-    let mut chars = line.chars();
-    while let Some(c) = chars.next() {
-        if c != '\u{1b}' {
-            out.push(c);
-            continue;
-        }
-        // ESC [ … <final byte in @-~>. Consume through the terminator.
-        if chars.next() != Some('[') {
-            continue;
-        }
-        for tail in chars.by_ref() {
-            if ('\u{40}'..='\u{7e}').contains(&tail) {
-                break;
+        match stream_file(path, source.level_filter, secrets, limits.max_wire_bytes) {
+            Ok(StreamOutcome::Body {
+                body,
+                sha256_plaintext,
+            }) => {
+                out.files.push(CollectedFile {
+                    relative_key,
+                    body,
+                    sha256_plaintext,
+                    plaintext_len: size,
+                    mtime_unix,
+                    source_path: path.to_path_buf(),
+                });
+                return;
+            }
+            Ok(StreamOutcome::CompressedTooLarge) => SkipReason::CompressedTooLarge,
+            Err(e) => {
+                out.errors.push((path.to_path_buf(), e.to_string()));
+                return;
             }
         }
-    }
-    out
-}
+    };
 
-/// Gzip a body at the default compression level.
-fn gzip(body: &[u8]) -> std::io::Result<Vec<u8>> {
-    let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
-    encoder.write_all(body)?;
-    encoder.finish()
-}
-
-/// Hex SHA-256 of a byte slice. Always 64 characters.
-pub(super) fn hex_digest(body: &[u8]) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(body);
-    format!("{:x}", hasher.finalize())
+    out.oversize.push(OversizeFile {
+        path: path.to_path_buf(),
+        relative_key,
+        size,
+        mtime_unix,
+        reason,
+    });
 }
 
 /// Modification time in Unix seconds, or `0` when the platform withholds it.

--- a/crates/trusty-common/src/log_drain/manifest.rs
+++ b/crates/trusty-common/src/log_drain/manifest.rs
@@ -65,12 +65,64 @@ pub struct ManifestEntry {
     pub uploaded_at: String,
 }
 
+/// Which bound a [`SkipRecord`] was written for.
+///
+/// Why: an operator reading the manifest needs to know whether raising
+/// `max_file_bytes` or `max_wire_bytes` is the lever that would drain the file.
+/// Test: `super::tests::run_once_records_an_oversize_skip_once`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum SkipReason {
+    /// The plaintext file is over `CollectLimits::max_file_bytes`.
+    SourceTooLarge,
+    /// The compressed body passed `CollectLimits::max_wire_bytes` mid-stream.
+    CompressedTooLarge,
+}
+
+impl SkipReason {
+    /// The knob an operator would raise to make this file drain.
+    pub fn limit_name(self) -> &'static str {
+        match self {
+            Self::SourceTooLarge => "max_file_bytes",
+            Self::CompressedTooLarge => "max_wire_bytes",
+        }
+    }
+}
+
+/// One source file the drain decided NOT to upload, and the facts behind it.
+///
+/// Why: before #6547 an oversize file was re-stat'd, re-decided, and re-warned
+/// every cycle — 1,276 identical WARNs in 48 hours over ~40 files that can
+/// never shrink. The decision is a function of `(relative_file, size,
+/// mtime_unix)` and the configured bounds, so recording it makes it once.
+/// What: the same identity pair [`ManifestEntry`] uses, plus the bound that was
+/// hit. A file whose size OR mtime moves no longer matches its record, so the
+/// next pass re-evaluates it from scratch — which is also how a file becomes
+/// drainable again after the operator raises the bound and it next rotates.
+/// Test: `super::tests::run_once_records_an_oversize_skip_once`,
+/// `super::tests::run_once_re_evaluates_a_skip_when_the_file_changes`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SkipRecord {
+    /// `<crate>/<relative path>` — the entry's identity, as [`ManifestEntry`].
+    pub relative_file: String,
+    /// Size in bytes of the plaintext source file when the decision was made.
+    pub size: u64,
+    /// Source file's modification time at that moment, Unix seconds.
+    pub mtime_unix: i64,
+    /// Which bound was hit.
+    pub reason: SkipReason,
+    /// When this decision was made, RFC 3339.
+    pub decided_at: String,
+}
+
 /// The per-target upload record.
 ///
 /// Why: see the module docs.
-/// What: a versioned list of [`ManifestEntry`]. Stored as a list rather than a
-/// map so the on-disk document is a stable, diffable, order-independent
-/// artifact an operator can read; the lookup index is built on demand.
+/// What: a versioned list of [`ManifestEntry`], plus the [`SkipRecord`] list
+/// #6547 added. Stored as lists rather than maps so the on-disk document is a
+/// stable, diffable, order-independent artifact an operator can read; the
+/// lookup index is built on demand.
 /// Test: `super::tests::manifest_roundtrip`, `super::tests::manifest_stat_fast_path_and_sha_tiebreak`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DrainManifest {
@@ -78,6 +130,12 @@ pub struct DrainManifest {
     pub version: u32,
     /// One entry per successfully uploaded source file, sorted by `relative_file`.
     pub entries: Vec<ManifestEntry>,
+    /// One entry per file the drain decided not to upload (#6547).
+    ///
+    /// `#[serde(default)]` so a manifest written before #6547 still decodes —
+    /// it simply carries no recorded decisions, and the next pass makes them.
+    #[serde(default)]
+    pub skips: Vec<SkipRecord>,
 }
 
 impl Default for DrainManifest {
@@ -85,6 +143,7 @@ impl Default for DrainManifest {
         Self {
             version: MANIFEST_VERSION,
             entries: Vec::new(),
+            skips: Vec::new(),
         }
     }
 }
@@ -157,6 +216,53 @@ impl DrainManifest {
         self.index()
             .get(relative_file)
             .is_some_and(|entry| entry.sha256 == sha256)
+    }
+
+    /// Has this exact `(file, size, mtime)` already been decided un-drainable?
+    ///
+    /// Why: the answer for an oversize file cannot change while the file does
+    /// not, so re-deciding it every 15 minutes is 96 identical warnings a day
+    /// per file (#6547). A `true` here is what turns the second cycle's log
+    /// line off.
+    /// What: matches on all three fields. A file that grew, was rotated, or was
+    /// rewritten no longer matches and is evaluated again from scratch.
+    /// Test: `super::tests::run_once_records_an_oversize_skip_once`,
+    /// `super::tests::run_once_re_evaluates_a_skip_when_the_file_changes`.
+    pub fn skip_recorded(&self, relative_file: &str, size: u64, mtime_unix: i64) -> bool {
+        self.skips.iter().any(|s| {
+            s.relative_file == relative_file && s.size == size && s.mtime_unix == mtime_unix
+        })
+    }
+
+    /// Insert or replace the skip decision for one source file.
+    ///
+    /// One record per file: a new decision supersedes the old one rather than
+    /// accumulating, so the manifest cannot grow without bound as a daily log
+    /// is appended to and re-decided.
+    pub fn record_skip(&mut self, record: SkipRecord) {
+        match self
+            .skips
+            .iter_mut()
+            .find(|s| s.relative_file == record.relative_file)
+        {
+            Some(existing) => *existing = record,
+            None => self.skips.push(record),
+        }
+        self.skips
+            .sort_by(|a, b| a.relative_file.cmp(&b.relative_file));
+    }
+
+    /// Drop any skip decision for `relative_file`; `true` when one was there.
+    ///
+    /// Called for every file a pass CAN read, so raising a bound — or a
+    /// rotation that shrinks a file back under one — clears the record rather
+    /// than leaving a stale "we decided not to upload this" beside a successful
+    /// upload of the same key.
+    /// Test: `super::tests::run_once_re_evaluates_a_skip_when_the_file_changes`.
+    pub fn forget_skip(&mut self, relative_file: &str) -> bool {
+        let before = self.skips.len();
+        self.skips.retain(|s| s.relative_file != relative_file);
+        self.skips.len() != before
     }
 
     /// Insert or replace the entry for one source file.

--- a/crates/trusty-common/src/log_drain/mod.rs
+++ b/crates/trusty-common/src/log_drain/mod.rs
@@ -50,6 +50,7 @@ mod collector;
 mod destination;
 mod error;
 mod manifest;
+mod pipeline;
 mod uri;
 
 #[cfg(test)]
@@ -58,12 +59,14 @@ mod tests;
 use std::path::PathBuf;
 
 pub use collector::{
-    Collected, CollectedFile, DEFAULT_MAX_FILE_BYTES, Level, LogSource, OversizeFile, collect,
+    CollectLimits, Collected, CollectedFile, DEFAULT_MAX_FILE_BYTES, DEFAULT_MAX_WIRE_BYTES, Level,
+    LogSource, OversizeFile, collect,
 };
 pub use destination::{LIST_LIMIT, LogDestination, ObjectMeta, ObjectStoreDestination, PutMeta};
 pub use error::DrainError;
 pub use manifest::{
-    DrainManifest, MANIFEST_FILENAME, MANIFEST_VERSION, ManifestEntry, ManifestOrigin, StatDecision,
+    DrainManifest, MANIFEST_FILENAME, MANIFEST_VERSION, ManifestEntry, ManifestOrigin, SkipReason,
+    SkipRecord, StatDecision,
 };
 pub use uri::{DestinationScheme, DestinationUri};
 
@@ -143,20 +146,24 @@ pub struct DrainConfig {
     pub state_dir: PathBuf,
     /// Values [`collect`] removes from every body before upload.
     pub secrets: Vec<String>,
-    /// Files larger than this are skipped, never truncated.
+    /// Plaintext source ceiling. Files over it are skipped, never truncated.
     pub max_file_bytes: u64,
+    /// Compressed body ceiling (#6547). See [`DEFAULT_MAX_WIRE_BYTES`].
+    pub max_wire_bytes: u64,
 }
 
 impl DrainConfig {
-    /// A config with [`DEFAULT_MAX_FILE_BYTES`] and no secrets.
+    /// A config with the default [`CollectLimits`] and no secrets.
     ///
     /// A caller that leaves `secrets` empty gets no scrubbing — see the module
     /// docs.
     pub fn new(state_dir: impl Into<PathBuf>) -> Self {
+        let limits = CollectLimits::default();
         Self {
             state_dir: state_dir.into(),
             secrets: Vec::new(),
-            max_file_bytes: DEFAULT_MAX_FILE_BYTES,
+            max_file_bytes: limits.max_file_bytes,
+            max_wire_bytes: limits.max_wire_bytes,
         }
     }
 
@@ -167,11 +174,23 @@ impl DrainConfig {
         self
     }
 
-    /// Set the per-file size ceiling.
+    /// Set the plaintext source ceiling.
     #[must_use]
     pub fn with_max_file_bytes(mut self, max: u64) -> Self {
         self.max_file_bytes = max;
         self
+    }
+
+    /// Set the compressed-body ceiling (#6547).
+    #[must_use]
+    pub fn with_max_wire_bytes(mut self, max: u64) -> Self {
+        self.max_wire_bytes = max;
+        self
+    }
+
+    /// The two bounds, as [`collect`] takes them.
+    pub fn limits(&self) -> CollectLimits {
+        CollectLimits::new(self.max_file_bytes, self.max_wire_bytes)
     }
 }
 
@@ -190,8 +209,15 @@ pub struct DrainReport {
     pub uploaded: usize,
     /// Files skipped because the manifest already had them.
     pub skipped_unchanged: usize,
-    /// Files skipped for exceeding `max_file_bytes`.
+    /// Files skipped for exceeding one of the size bounds.
     pub skipped_too_large: usize,
+    /// Of those, the ones whose decision was recorded for the FIRST time (#6547).
+    ///
+    /// A steady state where every oversize file has already been decided reads
+    /// `skipped_too_large: 29, skips_recorded: 0` — which is the signal that no
+    /// warning was logged this pass, and the difference between a backlog that
+    /// is settled and one that keeps churning.
+    pub skips_recorded: usize,
     /// Total plaintext bytes of everything uploaded.
     pub bytes_plain: u64,
     /// Total gzipped bytes actually written to the destination.
@@ -227,10 +253,18 @@ pub struct DrainReport {
 /// machine. The manifest is rewritten once at the end, reflecting only what
 /// actually landed.
 ///
+/// A file over one of the size bounds is decided ONCE and the decision is
+/// written to the manifest as a [`SkipRecord`] (#6547); a later pass that sees
+/// the same `(file, size, mtime)` counts it and says nothing. Any file the pass
+/// CAN read has its skip record dropped, so raising a bound takes effect on the
+/// next pass rather than needing the manifest cleared by hand.
+///
 /// Single-flight is the CALLER's responsibility; see the module docs.
 ///
 /// Test: `tests::run_once_end_to_end`, `tests::run_once_is_idempotent`,
-/// `tests::run_once_reuploads_a_mutated_file`, `tests::run_once_refuses_empty_github_id`.
+/// `tests::run_once_reuploads_a_mutated_file`, `tests::run_once_refuses_empty_github_id`,
+/// `tests::run_once_records_an_oversize_skip_once`,
+/// `tests::run_once_re_evaluates_a_skip_when_the_file_changes`.
 ///
 /// # Errors
 /// - [`DrainError::MissingIdentity`] when `target` has an empty component.
@@ -251,7 +285,7 @@ pub async fn run_once(
     let (mut manifest, origin) =
         DrainManifest::load_with_origin(dest, &cfg.state_dir, &manifest_key, &cache_key).await?;
 
-    let collected = collect(sources, &cfg.secrets, cfg.max_file_bytes)?;
+    let collected = collect(sources, &cfg.secrets, cfg.limits())?;
 
     let mut report = DrainReport {
         skipped_too_large: collected.oversize.len(),
@@ -279,7 +313,44 @@ pub async fn run_once(
     let now = chrono::Utc::now().to_rfc3339();
     let mut manifest_dirty = false;
 
+    // #6547: decide each oversize file ONCE. A file that has already been
+    // recorded at this exact size and mtime cannot have changed its answer, so
+    // it is counted and passed over in silence rather than warned about again
+    // every cycle.
+    for over in &collected.oversize {
+        if manifest.skip_recorded(&over.relative_key, over.size, over.mtime_unix) {
+            tracing::debug!(
+                path = %over.path.display(),
+                size = over.size,
+                "log-drain skip already recorded for this size and mtime"
+            );
+            continue;
+        }
+        tracing::warn!(
+            path = %over.path.display(),
+            size = over.size,
+            limit = over.reason.limit_name(),
+            "log-drain is not uploading this file; the decision is recorded in the \
+             manifest and is not logged again until the file's size or mtime changes"
+        );
+        manifest.record_skip(SkipRecord {
+            relative_file: over.relative_key.clone(),
+            size: over.size,
+            mtime_unix: over.mtime_unix,
+            reason: over.reason,
+            decided_at: now.clone(),
+        });
+        report.skips_recorded += 1;
+        manifest_dirty = true;
+    }
+
     for file in collected.files {
+        // A file the pass CAN read has no business carrying a skip record —
+        // raising a bound, or a rotation that shrank it, makes it drainable.
+        if manifest.forget_skip(&file.relative_key) {
+            manifest_dirty = true;
+        }
+
         // Fast path: stat alone says nothing changed, so never compare digests.
         if manifest.decide(&file.relative_key, file.plaintext_len, file.mtime_unix)
             == StatDecision::SkipUnchanged

--- a/crates/trusty-common/src/log_drain/pipeline.rs
+++ b/crates/trusty-common/src/log_drain/pipeline.rs
@@ -1,0 +1,352 @@
+//! Streaming one log file from disk into an upload-ready body (#6547).
+//!
+//! Why: the drain used to `std::fs::read` a whole file, decode it, filter it,
+//! scrub it, and gzip it — five live copies of the same bytes. That is the only
+//! reason a size ceiling existed, and the ceiling is what left 29 days of
+//! daemon logs permanently undrained (#6547). Reading in bounded chunks makes
+//! peak memory a function of the CHUNK size and the COMPRESSED body, never of
+//! the source file, so a 176 MB log costs the same working set as a 1 MB one.
+//!
+//! What: [`stream_file`] reads `READ_CHUNK_BYTES` at a time, hashes the raw
+//! bytes, and pushes each chunk through the same fixed order the whole-file
+//! path used — decode, level-filter, scrub, gzip — via [`LineFilter`] and
+//! [`ScrubCarry`], which carry exactly enough state across a chunk boundary to
+//! make the streamed result identical to the buffered one.
+//!
+//! Test: `super::tests::stream_matches_the_buffered_pipeline`,
+//! `super::tests::stream_scrubs_a_secret_straddling_a_chunk_boundary`,
+//! `super::tests::collect_filters_below_info`.
+//!
+//! # Why chunking is safe for the scrub (#6534 revisited)
+//!
+//! The original refusal to chunk was correct about the hazard: a needle that
+//! straddles a chunk boundary is not found by scrubbing each chunk alone. It is
+//! wrong that the hazard forces a whole-file read. [`ScrubCarry`] holds back the
+//! last `max needle length - 1` bytes of every scrubbed chunk and prepends them
+//! to the next one, so every occurrence is scrubbed in a window that contains it
+//! whole. Nothing is emitted until it can no longer participate in a
+//! boundary-crossing match.
+
+use std::io::{Read, Write};
+use std::path::Path;
+
+use bytes::Bytes;
+use sha2::{Digest, Sha256};
+
+/// Plaintext held at once while streaming one file.
+///
+/// 1 MiB is large enough that a 176 MB log costs ~170 read syscalls and small
+/// enough that the working set is invisible beside the daemon's own heap.
+const READ_CHUNK_BYTES: usize = 1024 * 1024;
+
+/// Hard cap on bytes buffered while waiting for a line terminator.
+///
+/// A log with no newline in 8 MiB is not line-oriented output, and buffering it
+/// whole would reintroduce exactly the unbounded read this module removes. Past
+/// this the chunk is flushed at a UTF-8 boundary; the level filter treats the
+/// remainder as a continuation line, which is the same disposition a wrapped
+/// message already gets.
+const MAX_PENDING_BYTES: usize = 8 * 1024 * 1024;
+
+/// Log levels the drain can filter on, ordered least to most severe.
+///
+/// Deliberately not `tracing::Level`: the drain reads level names out of
+/// already-written TEXT, and coupling that string parsing to `tracing`'s type
+/// would make the drain depend on the crate that produced the file rather than
+/// on the file format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[non_exhaustive]
+pub enum Level {
+    /// `TRACE`
+    Trace,
+    /// `DEBUG`
+    Debug,
+    /// `INFO`
+    Info,
+    /// `WARN`
+    Warn,
+    /// `ERROR`
+    Error,
+}
+
+impl Level {
+    /// Map a bare level token to its variant.
+    fn parse(token: &str) -> Option<Self> {
+        match token {
+            "TRACE" => Some(Self::Trace),
+            "DEBUG" => Some(Self::Debug),
+            "INFO" => Some(Self::Info),
+            "WARN" | "WARNING" => Some(Self::Warn),
+            "ERROR" => Some(Self::Error),
+            _ => None,
+        }
+    }
+}
+
+/// What streaming one file produced.
+pub(super) enum StreamOutcome {
+    /// The finished gzip body and the plaintext digest.
+    Body {
+        /// Gzipped, scrubbed, level-filtered body.
+        body: Bytes,
+        /// Hex SHA-256 of the plaintext source bytes as read.
+        sha256_plaintext: String,
+    },
+    /// The compressed body passed `max_wire_bytes` before the file ran out.
+    ///
+    /// The only remaining bound on the streamed path: `put` takes an in-memory
+    /// `Bytes`, so the COMPRESSED body is the one thing still held whole.
+    CompressedTooLarge,
+}
+
+/// Read, filter, scrub, and compress one file without ever holding it whole.
+///
+/// Why: see the module docs — this is what makes the size ceiling a cost
+/// decision rather than a memory one.
+/// What: streams `path` in [`READ_CHUNK_BYTES`] chunks split on the last line
+/// terminator in each read, so every chunk is whole-line and whole-UTF-8. The
+/// SHA-256 is over the RAW bytes, unchanged from the buffered path, so a
+/// manifest written before this change stays valid. Stops early with
+/// [`StreamOutcome::CompressedTooLarge`] once the gzip output passes
+/// `max_wire_bytes`, rather than growing a buffer without limit.
+/// Test: `super::tests::stream_matches_the_buffered_pipeline`,
+/// `super::tests::stream_scrubs_a_secret_straddling_a_chunk_boundary`.
+///
+/// # Errors
+/// Any `std::io::Error` from opening, reading, or finishing the gzip stream.
+pub(super) fn stream_file(
+    path: &Path,
+    level_filter: Option<Level>,
+    secrets: &[String],
+    max_wire_bytes: u64,
+) -> std::io::Result<StreamOutcome> {
+    let mut reader =
+        std::io::BufReader::with_capacity(READ_CHUNK_BYTES, std::fs::File::open(path)?);
+    let mut hasher = Sha256::new();
+    let mut encoder =
+        flate2::write::GzEncoder::new(Vec::<u8>::new(), flate2::Compression::default());
+    let mut filter = LineFilter::new(level_filter);
+    let mut scrub = ScrubCarry::new(secrets);
+
+    let mut raw = vec![0u8; READ_CHUNK_BYTES];
+    let mut pending: Vec<u8> = Vec::with_capacity(READ_CHUNK_BYTES);
+
+    loop {
+        let read = reader.read(&mut raw)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&raw[..read]);
+        pending.extend_from_slice(&raw[..read]);
+
+        let Some(split) = flush_point(&pending) else {
+            continue;
+        };
+        let chunk: Vec<u8> = pending.drain(..split).collect();
+        encoder.write_all(scrub.push(&filter.push(&decode(&chunk))).as_bytes())?;
+        if encoder.get_ref().len() as u64 > max_wire_bytes {
+            return Ok(StreamOutcome::CompressedTooLarge);
+        }
+    }
+
+    if !pending.is_empty() {
+        encoder.write_all(scrub.push(&filter.push(&decode(&pending))).as_bytes())?;
+    }
+    // The carry is whatever could still have been the head of a straddling
+    // needle. Nothing follows it, so it is emitted as-is.
+    encoder.write_all(scrub.finish().as_bytes())?;
+
+    let body = encoder.finish()?;
+    if body.len() as u64 > max_wire_bytes {
+        return Ok(StreamOutcome::CompressedTooLarge);
+    }
+    Ok(StreamOutcome::Body {
+        body: Bytes::from(body),
+        sha256_plaintext: format!("{:x}", hasher.finalize()),
+    })
+}
+
+/// Hex SHA-256 of a byte slice. Always 64 characters.
+pub(super) fn hex_digest(body: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(body);
+    format!("{:x}", hasher.finalize())
+}
+
+/// How many bytes of `pending` are safe to process now, or `None` to read more.
+///
+/// Prefers the byte after the last line terminator, so a chunk is always whole
+/// lines and therefore whole UTF-8. Falls back to a character boundary once
+/// [`MAX_PENDING_BYTES`] is passed with no terminator in sight.
+fn flush_point(pending: &[u8]) -> Option<usize> {
+    if let Some(last) = pending.iter().rposition(|b| *b == b'\n') {
+        return Some(last + 1);
+    }
+    if pending.len() < MAX_PENDING_BYTES {
+        return None;
+    }
+    // Defer any byte that could belong to a character whose tail has not been
+    // read: continuation bytes are `10xxxxxx`, lead bytes `11xxxxxx`.
+    let mut end = pending.len();
+    let floor = end.saturating_sub(4);
+    while end > floor && (pending[end - 1] & 0b1100_0000) == 0b1000_0000 {
+        end -= 1;
+    }
+    if end > floor && pending[end - 1] >= 0b1100_0000 {
+        end -= 1;
+    }
+    Some(end)
+}
+
+/// Decode one whole-line chunk, replacing invalid sequences.
+fn decode(chunk: &[u8]) -> String {
+    String::from_utf8_lossy(chunk).into_owned()
+}
+
+/// The level filter, as a value that survives a chunk boundary.
+///
+/// Why: the whole-file filter carried two pieces of state across lines —
+/// whether the current line's disposition is "keep", and whether the file has
+/// shown any recognisable level at all. Only the first is real: a file with NO
+/// level line never flips `keeping` away from its initial `true`, so every line
+/// is kept and the "return verbatim" fallback the buffered version wrote out
+/// explicitly was already a no-op. Streaming keeps only the state that matters.
+/// What: [`LineFilter::push`] evaluates each whole line of a chunk and keeps it
+/// when its level is at or above the minimum. A line carrying no recognisable
+/// level is a CONTINUATION — a wrapped message, a backtrace frame — and
+/// inherits the disposition of the line above it, across a chunk boundary
+/// included.
+/// Test: `super::tests::collect_filters_below_info`,
+/// `super::tests::collect_drops_continuation_of_a_dropped_line`,
+/// `super::tests::collect_passes_through_non_tracing`.
+struct LineFilter {
+    min: Option<Level>,
+    keeping: bool,
+}
+
+impl LineFilter {
+    fn new(min: Option<Level>) -> Self {
+        Self { min, keeping: true }
+    }
+
+    fn push(&mut self, text: &str) -> String {
+        let Some(min) = self.min else {
+            return text.to_string();
+        };
+        let mut kept = String::with_capacity(text.len());
+        for line in text.split_inclusive('\n') {
+            // No level token means a continuation line, which keeps whatever
+            // disposition the line above it had — hence no `else` branch.
+            if let Some(level) = line_level(line) {
+                self.keeping = level >= min;
+            }
+            if self.keeping {
+                kept.push_str(line);
+            }
+        }
+        kept
+    }
+}
+
+/// The scrub, as a value that survives a chunk boundary.
+///
+/// Why: a needle split across two chunks is found by neither, which is the
+/// hazard that made #6534 refuse to chunk at all. See the module docs.
+/// What: holds back the last `window` bytes of every scrubbed chunk — one less
+/// than the longest needle — and prepends them to the next chunk. Any
+/// occurrence starting before the emitted prefix's end lies entirely inside the
+/// window that was just scrubbed; any occurrence starting inside the held-back
+/// tail is scrubbed on the next push, where its continuation has arrived. With
+/// no secrets the window is zero and the carry never allocates.
+/// Test: `super::tests::stream_scrubs_a_secret_straddling_a_chunk_boundary`.
+struct ScrubCarry {
+    secrets: Vec<String>,
+    window: usize,
+    carry: String,
+}
+
+impl ScrubCarry {
+    fn new(secrets: &[String]) -> Self {
+        // An over-approximation of the longest needle is always safe: a wider
+        // window only delays emission. `scrub_secrets` skips needles under its
+        // own minimum length, so measuring every one costs nothing.
+        let window = secrets
+            .iter()
+            .map(String::len)
+            .max()
+            .unwrap_or(0)
+            .saturating_sub(1);
+        Self {
+            secrets: secrets.to_vec(),
+            window,
+            carry: String::new(),
+        }
+    }
+
+    fn push(&mut self, text: &str) -> String {
+        if self.window == 0 {
+            return crate::credentials::scrub_secrets(text, &self.secrets);
+        }
+        let mut buf = std::mem::take(&mut self.carry);
+        buf.push_str(text);
+        let scrubbed = crate::credentials::scrub_secrets(&buf, &self.secrets);
+        let split = floor_char_boundary(&scrubbed, scrubbed.len().saturating_sub(self.window));
+        self.carry = scrubbed[split..].to_string();
+        scrubbed[..split].to_string()
+    }
+
+    fn finish(&mut self) -> String {
+        std::mem::take(&mut self.carry)
+    }
+}
+
+/// Largest character boundary at or below `index`.
+///
+/// `str::floor_char_boundary` is still unstable, and slicing a `String` at a
+/// byte index that is not a boundary panics.
+fn floor_char_boundary(text: &str, mut index: usize) -> usize {
+    if index >= text.len() {
+        return text.len();
+    }
+    while index > 0 && !text.is_char_boundary(index) {
+        index -= 1;
+    }
+    index
+}
+
+/// Extract the level from a `tracing_subscriber::fmt` line, if it has one.
+///
+/// Scans the first few whitespace-separated tokens with ANSI escapes stripped,
+/// so a colourised log (`fmt` with `with_ansi(true)`, which the console layer
+/// uses) is recognised the same as a plain file appender's output.
+fn line_level(line: &str) -> Option<Level> {
+    let plain = strip_ansi(line);
+    // The level is the second token in the default format; allow a little slack
+    // for a prefixed thread name or span without scanning the whole message.
+    plain
+        .split_whitespace()
+        .take(4)
+        .find_map(|token| Level::parse(token.trim_matches(|c: char| !c.is_ascii_alphabetic())))
+}
+
+/// Remove ANSI CSI escape sequences so level detection survives colour output.
+fn strip_ansi(line: &str) -> String {
+    let mut out = String::with_capacity(line.len());
+    let mut chars = line.chars();
+    while let Some(c) = chars.next() {
+        if c != '\u{1b}' {
+            out.push(c);
+            continue;
+        }
+        // ESC [ … <final byte in @-~>. Consume through the terminator.
+        if chars.next() != Some('[') {
+            continue;
+        }
+        for tail in chars.by_ref() {
+            if ('\u{40}'..='\u{7e}').contains(&tail) {
+                break;
+            }
+        }
+    }
+    out
+}

--- a/crates/trusty-common/src/log_drain/tests.rs
+++ b/crates/trusty-common/src/log_drain/tests.rs
@@ -366,7 +366,7 @@ fn collect_filters_below_info() {
     let collected = collect(
         &[source(root.path(), Some(Level::Info))],
         &[],
-        DEFAULT_MAX_FILE_BYTES,
+        CollectLimits::default(),
     )
     .expect("collect succeeds");
 
@@ -404,7 +404,7 @@ fn collect_drops_continuation_of_a_dropped_line() {
     let collected = collect(
         &[source(root.path(), Some(Level::Info))],
         &[],
-        DEFAULT_MAX_FILE_BYTES,
+        CollectLimits::default(),
     )
     .expect("collect");
     let mut decoder = flate2::read::GzDecoder::new(&collected.files[0].body[..]);
@@ -424,7 +424,7 @@ fn collect_passes_through_non_tracing() {
     let collected = collect(
         &[source(root.path(), Some(Level::Info))],
         &[],
-        DEFAULT_MAX_FILE_BYTES,
+        CollectLimits::default(),
     )
     .expect("collect");
 
@@ -451,7 +451,7 @@ fn collect_recognises_ansi_coloured_levels() {
     let collected = collect(
         &[source(root.path(), Some(Level::Info))],
         &[],
-        DEFAULT_MAX_FILE_BYTES,
+        CollectLimits::default(),
     )
     .expect("collect");
     let mut decoder = flate2::read::GzDecoder::new(&collected.files[0].body[..]);
@@ -473,7 +473,12 @@ fn collect_skips_oversize() {
     write(&root.path().join("big.log"), &"x".repeat(4096));
     write(&root.path().join("small.log"), "tiny\n");
 
-    let collected = collect(&[source(root.path(), None)], &[], 1024).expect("collect");
+    let collected = collect(
+        &[source(root.path(), None)],
+        &[],
+        CollectLimits::new(1024, DEFAULT_MAX_WIRE_BYTES),
+    )
+    .expect("collect");
 
     assert_eq!(collected.files.len(), 1, "only the small file is collected");
     assert_eq!(collected.files[0].relative_key, "trusty-mpm/small.log");
@@ -983,6 +988,270 @@ async fn run_once_counts_oversize_without_uploading() {
             .expect("head")
             .is_none(),
         "an oversize file must never be uploaded, not even truncated"
+    );
+}
+
+// ── #6547: streaming, and skip decisions made once ──────────────────────────
+
+/// Read the destination's own manifest object.
+async fn remote_manifest(dest: &dyn LogDestination, t: &DrainTarget) -> DrainManifest {
+    let raw = dest
+        .get(&t.manifest_key())
+        .await
+        .expect("get manifest")
+        .expect("manifest object exists");
+    serde_json::from_slice(&raw).expect("manifest decodes")
+}
+
+/// A tracing-shaped fixture larger than the pipeline's 1 MiB read chunk, with
+/// `secret` planted so it straddles the boundary.
+///
+/// The straddle is the point: a needle split across two reads is found by
+/// neither chunk alone, which is the hazard `ScrubCarry` exists for.
+fn chunk_straddling_fixture(secret: &str) -> String {
+    const CHUNK: usize = 1024 * 1024;
+    let line = "2026-09-01T14:12:32.2Z  INFO tm: filler line to reach the chunk boundary\n";
+    let mut text = String::with_capacity(CHUNK + 4096);
+    // Stop a few bytes short of the boundary so the secret spans it.
+    while text.len() + line.len() < CHUNK - (secret.len() / 2) {
+        text.push_str(line);
+    }
+    let pad = CHUNK - (secret.len() / 2) - text.len();
+    text.push_str(&"p".repeat(pad));
+    text.push_str(secret);
+    text.push_str(" tail\n2026-09-01T14:12:33.0Z  INFO tm: after the boundary\n");
+    text
+}
+
+#[tokio::test]
+async fn stream_scrubs_a_secret_straddling_a_chunk_boundary() {
+    let logs = tempfile::tempdir().expect("tempdir");
+    let dest_root = tempfile::tempdir().expect("tempdir");
+    let state = tempfile::tempdir().expect("tempdir");
+
+    let secret = "sk-straddle-0123456789abcdef0123456789abcdef";
+    let fixture = chunk_straddling_fixture(secret);
+    assert!(
+        fixture.len() > 1024 * 1024,
+        "the fixture must cross the read chunk"
+    );
+    write(&logs.path().join("daemon.log"), &fixture);
+
+    let dest = file_dest(dest_root.path()).await;
+    let cfg = DrainConfig::new(state.path()).with_secrets(vec![secret.to_string()]);
+    let t = target();
+
+    let report = run_once(&cfg, &dest, &t, &[source(logs.path(), None)])
+        .await
+        .expect("run_once");
+    assert_eq!(report.uploaded, 1);
+
+    let text = read_gunzipped(&dest, &t.object_key("trusty-mpm/daemon.log")).await;
+    assert!(
+        !text.contains(secret),
+        "a secret split across two read chunks reached the destination"
+    );
+    assert!(
+        text.contains("[REDACTED]"),
+        "the scrub must leave its marker"
+    );
+    assert!(
+        text.contains("after the boundary"),
+        "text past the boundary must survive"
+    );
+}
+
+#[tokio::test]
+async fn stream_matches_the_buffered_pipeline() {
+    let logs = tempfile::tempdir().expect("tempdir");
+    let dest_root = tempfile::tempdir().expect("tempdir");
+    let state = tempfile::tempdir().expect("tempdir");
+
+    // Levels on both sides of a chunk boundary: the filter's `keeping` state
+    // has to survive the split, not reset to its default.
+    let mut fixture = chunk_straddling_fixture("sk-unused-needle-value-000000");
+    fixture.push_str("2026-09-01T14:12:34.0Z DEBUG tm: dropped after the boundary\n");
+    fixture.push_str("        continuation of the dropped line\n");
+    fixture.push_str("2026-09-01T14:12:35.0Z ERROR tm: kept after the boundary\n");
+    write(&logs.path().join("daemon.log"), &fixture);
+
+    let dest = file_dest(dest_root.path()).await;
+    let cfg = DrainConfig::new(state.path());
+    let t = target();
+
+    run_once(&cfg, &dest, &t, &[source(logs.path(), Some(Level::Info))])
+        .await
+        .expect("run_once");
+
+    let text = read_gunzipped(&dest, &t.object_key("trusty-mpm/daemon.log")).await;
+    assert!(
+        !text.contains("dropped after the boundary"),
+        "DEBUG past the chunk boundary must still be dropped"
+    );
+    assert!(
+        !text.contains("continuation of the dropped line"),
+        "a continuation inherits its parent's disposition across a chunk boundary"
+    );
+    assert!(
+        text.contains("kept after the boundary"),
+        "ERROR must survive"
+    );
+    assert!(
+        text.contains("filler line to reach the chunk boundary"),
+        "INFO before the boundary must survive"
+    );
+}
+
+#[tokio::test]
+async fn run_once_uploads_a_file_over_the_old_ceiling() {
+    // The 64 MiB ceiling is what left 29 days of daemon logs permanently
+    // undrained; the streamed pipeline is what let the default move past it.
+    const {
+        assert!(
+            DEFAULT_MAX_FILE_BYTES > 64 * 1024 * 1024,
+            "the default source ceiling must clear the pre-#6547 64 MiB"
+        );
+    }
+
+    let logs = tempfile::tempdir().expect("tempdir");
+    let dest_root = tempfile::tempdir().expect("tempdir");
+    let state = tempfile::tempdir().expect("tempdir");
+
+    let line = "2026-09-01T14:12:32.2Z  INFO tm: a rotated daemon log line\n";
+    let big = line.repeat((65 * 1024 * 1024 / line.len()) + 1);
+    assert!(big.len() > 64 * 1024 * 1024, "fixture must clear 64 MiB");
+    write(&logs.path().join("trusty-mpm.2026-09-01.log"), &big);
+
+    let dest = file_dest(dest_root.path()).await;
+    let t = target();
+
+    let report = run_once(
+        &DrainConfig::new(state.path()),
+        &dest,
+        &t,
+        &[source(logs.path(), Some(Level::Info))],
+    )
+    .await
+    .expect("run_once");
+
+    assert_eq!(report.uploaded, 1, "{:?}", report.errors);
+    assert_eq!(report.skipped_too_large, 0);
+    assert_eq!(report.bytes_plain, big.len() as u64);
+    assert!(
+        report.bytes_wire < 1024 * 1024,
+        "the gzip body is what stays in memory: {} B",
+        report.bytes_wire
+    );
+}
+
+#[tokio::test]
+async fn collect_skips_a_body_over_the_wire_cap() {
+    let root = tempfile::tempdir().expect("tempdir");
+    // Random-ish text so gzip cannot squeeze it under a 64-byte wire cap.
+    let body: String = (0..8192u32)
+        .map(|i| char::from(b'a' + (i % 26) as u8))
+        .collect();
+    write(&root.path().join("wide.log"), &body);
+
+    let collected = collect(
+        &[source(root.path(), None)],
+        &[],
+        CollectLimits::new(DEFAULT_MAX_FILE_BYTES, 64),
+    )
+    .expect("collect");
+
+    assert!(collected.files.is_empty(), "the body must not be truncated");
+    assert_eq!(collected.oversize.len(), 1);
+    assert_eq!(collected.oversize[0].reason, SkipReason::CompressedTooLarge);
+    assert_eq!(collected.oversize[0].reason.limit_name(), "max_wire_bytes");
+}
+
+#[tokio::test]
+async fn run_once_records_an_oversize_skip_once() {
+    let logs = tempfile::tempdir().expect("tempdir");
+    let dest_root = tempfile::tempdir().expect("tempdir");
+    let state = tempfile::tempdir().expect("tempdir");
+    write(&logs.path().join("big.log"), &"x".repeat(4096));
+
+    let dest = file_dest(dest_root.path()).await;
+    let cfg = DrainConfig::new(state.path()).with_max_file_bytes(1024);
+    let t = target();
+    let sources = [source(logs.path(), None)];
+
+    let first = run_once(&cfg, &dest, &t, &sources)
+        .await
+        .expect("first pass");
+    assert_eq!(first.skipped_too_large, 1);
+    assert_eq!(
+        first.skips_recorded, 1,
+        "the first pass decides, and that is the pass that warns"
+    );
+
+    let manifest = remote_manifest(&dest, &t).await;
+    assert_eq!(manifest.skips.len(), 1, "the decision must be durable");
+    assert_eq!(manifest.skips[0].relative_file, "trusty-mpm/big.log");
+    assert_eq!(manifest.skips[0].size, 4096);
+    assert_eq!(manifest.skips[0].reason, SkipReason::SourceTooLarge);
+
+    // The cycle that produced 1,276 identical WARNs in 48 hours. `warn!` is
+    // gated on the same branch that increments `skips_recorded`, so a zero here
+    // is a pass that logged nothing about this file.
+    for pass in 0..3 {
+        let again = run_once(&cfg, &dest, &t, &sources)
+            .await
+            .expect("repeat pass");
+        assert_eq!(again.skipped_too_large, 1, "pass {pass}");
+        assert_eq!(
+            again.skips_recorded, 0,
+            "pass {pass} re-decided a file that cannot have changed"
+        );
+    }
+}
+
+#[tokio::test]
+async fn run_once_re_evaluates_a_skip_when_the_file_changes() {
+    let logs = tempfile::tempdir().expect("tempdir");
+    let dest_root = tempfile::tempdir().expect("tempdir");
+    let state = tempfile::tempdir().expect("tempdir");
+    let path = logs.path().join("big.log");
+    write(&path, &"x".repeat(4096));
+
+    let dest = file_dest(dest_root.path()).await;
+    let cfg = DrainConfig::new(state.path()).with_max_file_bytes(1024);
+    let t = target();
+    let sources = [source(logs.path(), None)];
+
+    assert_eq!(
+        run_once(&cfg, &dest, &t, &sources)
+            .await
+            .expect("first pass")
+            .skips_recorded,
+        1
+    );
+
+    // A daily log is appended to all day. Its size moved, so the recorded
+    // answer no longer describes it and the decision is made again.
+    write(&path, &"x".repeat(8192));
+    let after_growth = run_once(&cfg, &dest, &t, &sources)
+        .await
+        .expect("pass after growth");
+    assert_eq!(
+        after_growth.skips_recorded, 1,
+        "a file whose size changed must be re-evaluated"
+    );
+    assert_eq!(remote_manifest(&dest, &t).await.skips[0].size, 8192);
+
+    // Raising the ceiling makes the same file drainable, and the stale
+    // decision must not outlive the upload that contradicts it.
+    let raised = DrainConfig::new(state.path()).with_max_file_bytes(1024 * 1024);
+    let uploaded = run_once(&raised, &dest, &t, &sources)
+        .await
+        .expect("pass with a raised ceiling");
+    assert_eq!(uploaded.uploaded, 1);
+    assert_eq!(uploaded.skipped_too_large, 0);
+    assert!(
+        remote_manifest(&dest, &t).await.skips.is_empty(),
+        "a file that uploaded must carry no skip record"
     );
 }
 

--- a/crates/trusty-common/src/log_drain/uri.rs
+++ b/crates/trusty-common/src/log_drain/uri.rs
@@ -15,8 +15,8 @@
 
 use std::path::PathBuf;
 
-use super::collector::hex_digest;
 use super::error::DrainError;
+use super::pipeline::hex_digest;
 
 /// The scheme half of a destination URI.
 ///

--- a/crates/trusty-mpm/changelog.d/6547-drain-oversize-logs.md
+++ b/crates/trusty-mpm/changelog.d/6547-drain-oversize-logs.md
@@ -1,0 +1,15 @@
+Fixed
+
+- The daemon's log-drain scheduler no longer re-logs the same "skipping oversize
+  file" warning every 15-minute cycle. `trusty-common`'s drain records each skip
+  decision in the manifest, so a file whose size and mtime have not moved is
+  counted in silence; the drain produced 1,276 identical warnings in 48 hours
+  over ~40 files that can never shrink (#6547). The `log_drain` doctor row now
+  reads `N over the size ceiling (M newly recorded)`, where a zero `M` says the
+  backlog is settled.
+- `log_drain.max_wire_bytes` is a new config knob (default 64 MiB) bounding the
+  COMPRESSED body handed to the destination. The collector streams since #6547,
+  so the source size no longer bounds memory and `log_drain.max_file_bytes`
+  defaults to 4 GiB — high enough that a daily-rotated daemon log drains rather
+  than being skipped. A zero `max_wire_bytes` is a config error, not a drain
+  that quietly sends nothing.

--- a/crates/trusty-mpm/src/core/trusty_tools_config/log_drain.rs
+++ b/crates/trusty-mpm/src/core/trusty_tools_config/log_drain.rs
@@ -33,7 +33,8 @@ use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use trusty_common::log_drain::{
-    DEFAULT_MAX_FILE_BYTES, DestinationScheme, DestinationUri, Level, LogSource,
+    DEFAULT_MAX_FILE_BYTES, DEFAULT_MAX_WIRE_BYTES, DestinationScheme, DestinationUri, Level,
+    LogSource,
 };
 
 use super::TrustyToolsConfig;
@@ -87,9 +88,16 @@ pub struct LogDrainConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub interval_secs: Option<u64>,
 
-    /// Per-file size ceiling. `None` → [`DEFAULT_MAX_FILE_BYTES`].
+    /// Plaintext source ceiling. `None` → [`DEFAULT_MAX_FILE_BYTES`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_file_bytes: Option<u64>,
+
+    /// Compressed-body ceiling (#6547). `None` → [`DEFAULT_MAX_WIRE_BYTES`].
+    ///
+    /// The collector streams, so the source size no longer bounds memory; the
+    /// gzip body handed to `put` does. This is the knob for that bound.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_wire_bytes: Option<u64>,
 
     /// Extra literal strings scrubbed from every body before upload.
     ///
@@ -168,7 +176,7 @@ pub enum LogDrainConfigError {
     /// A numeric knob was set to zero.
     #[error("log_drain.{field} must be greater than zero")]
     NonPositive {
-        /// `interval_secs` or `max_file_bytes`.
+        /// `interval_secs`, `max_file_bytes`, or `max_wire_bytes`.
         field: &'static str,
     },
 
@@ -214,8 +222,10 @@ pub struct ResolvedLogDrain {
     pub destination_display: String,
     /// How long the scheduler sleeps between passes.
     pub interval: Duration,
-    /// Per-file size ceiling handed to `DrainConfig`.
+    /// Plaintext source ceiling handed to `DrainConfig`.
     pub max_file_bytes: u64,
+    /// Compressed-body ceiling handed to `DrainConfig` (#6547).
+    pub max_wire_bytes: u64,
     /// Extra literal secrets to scrub.
     pub secrets: Vec<String>,
     /// Operator-pinned GitHub login, when one was configured.
@@ -308,6 +318,14 @@ pub fn resolve_log_drain(
             field: "max_file_bytes",
         });
     }
+    // #6547: a zero wire cap would skip every file with a recorded decision,
+    // which reads exactly like a working drain with nothing to send.
+    let max_wire_bytes = section.max_wire_bytes.unwrap_or(DEFAULT_MAX_WIRE_BYTES);
+    if max_wire_bytes == 0 {
+        return Err(LogDrainConfigError::NonPositive {
+            field: "max_wire_bytes",
+        });
+    }
 
     let sources = resolve_sources(&section.sources, home)?;
 
@@ -330,6 +348,7 @@ pub fn resolve_log_drain(
         destination_display,
         interval: Duration::from_secs(interval_secs),
         max_file_bytes,
+        max_wire_bytes,
         secrets: section.secrets.clone(),
         github_id: non_empty(section.github_id.as_deref()),
         session_id: non_empty(section.session_id.as_deref()),

--- a/crates/trusty-mpm/src/core/trusty_tools_config/log_drain/tests.rs
+++ b/crates/trusty-mpm/src/core/trusty_tools_config/log_drain/tests.rs
@@ -93,6 +93,7 @@ log_drain:
     };
     assert_eq!(plan.interval.as_secs(), DEFAULT_INTERVAL_SECS);
     assert_eq!(plan.max_file_bytes, DEFAULT_MAX_FILE_BYTES);
+    assert_eq!(plan.max_wire_bytes, DEFAULT_MAX_WIRE_BYTES);
     assert_eq!(plan.scheme(), "file");
     assert_eq!(plan.github_id, None);
     assert_eq!(plan.session_id, None);
@@ -245,6 +246,43 @@ log_drain:
             field: "max_file_bytes"
         }
     );
+}
+
+#[test]
+fn resolve_rejects_a_zero_max_wire_bytes() {
+    // #6547: a zero wire cap skips every file with a recorded decision, which
+    // reads exactly like a working drain with nothing to send.
+    let config = config_from_yaml(
+        r#"
+log_drain:
+  enabled: true
+  destination: "file:///tmp/drain"
+  max_wire_bytes: 0
+"#,
+    );
+    assert_eq!(
+        resolve_log_drain(&config, home()).expect_err("zero wire cap is an error"),
+        LogDrainConfigError::NonPositive {
+            field: "max_wire_bytes"
+        }
+    );
+}
+
+#[test]
+fn resolve_carries_a_configured_max_wire_bytes() {
+    let config = config_from_yaml(
+        r#"
+log_drain:
+  enabled: true
+  destination: "file:///tmp/drain"
+  max_wire_bytes: 4096
+"#,
+    );
+    let LogDrainSetting::Enabled(plan) = resolve_log_drain(&config, home()).expect("resolves")
+    else {
+        panic!("expected an enabled plan");
+    };
+    assert_eq!(plan.max_wire_bytes, 4096);
 }
 
 #[test]

--- a/crates/trusty-mpm/src/daemon/doctor_log_drain_tests.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_log_drain_tests.rs
@@ -23,6 +23,7 @@ fn plan() -> LogDrainSetting {
             destination_display: "file:///tmp/drain".to_string(),
             interval: Duration::from_secs(LOG_DRAIN_DEFAULT_INTERVAL_SECS),
             max_file_bytes: 1024,
+            max_wire_bytes: 1024,
             secrets: Vec::new(),
             github_id: Some("octocat".to_string()),
             session_id: Some("sess-1".to_string()),

--- a/crates/trusty-mpm/src/daemon/log_drain.rs
+++ b/crates/trusty-mpm/src/daemon/log_drain.rs
@@ -166,12 +166,16 @@ impl LogDrainStatus {
                 report.errors.len()
             )
         } else {
+            // #6547: the second number is what says whether the backlog is
+            // settled. A pass that recorded no new decision logged no warning.
             format!(
-                "{} file(s) uploaded ({} B), {} unchanged, {} over the size ceiling",
+                "{} file(s) uploaded ({} B), {} unchanged, {} over the size ceiling \
+                 ({} newly recorded)",
                 report.uploaded,
                 report.bytes_plain,
                 report.skipped_unchanged,
-                report.skipped_too_large
+                report.skipped_too_large,
+                report.skips_recorded
             )
         };
         Self {
@@ -325,7 +329,9 @@ pub async fn run_tick(
     };
     let cfg = DrainConfig::new(state_dir)
         .with_secrets(plan.secrets.clone())
-        .with_max_file_bytes(plan.max_file_bytes);
+        .with_max_file_bytes(plan.max_file_bytes)
+        // #6547: the collector streams, so this is the bound that matters.
+        .with_max_wire_bytes(plan.max_wire_bytes);
     match run_once(&cfg, &dest, target, &plan.sources).await {
         Ok(report) => LogDrainStatus::from_report(plan, &report),
         Err(e) => LogDrainStatus::failed(plan, format!("drain run failed: {e}")),

--- a/crates/trusty-mpm/src/daemon/log_drain_tests.rs
+++ b/crates/trusty-mpm/src/daemon/log_drain_tests.rs
@@ -125,6 +125,76 @@ async fn a_second_tick_dedupes() {
 }
 
 #[tokio::test]
+async fn a_ceiling_skip_is_decided_once_across_ticks() {
+    // #6547: the drain re-stat'd ~40 permanently-oversize files every 15-minute
+    // cycle and re-logged the same WARN — 1,276 of them in 48 hours. The
+    // scheduler is the loop that produced them, so the "decided once" property
+    // is proved here at tick granularity, not only inside `run_once`.
+    let tmp = TempDir::new().expect("tempdir");
+    let dest = tmp.path().join("dest");
+    let logs = log_dir_with(&tmp, &"x".repeat(4096));
+    let state = tmp.path().join("state");
+
+    let mut config = enabled_config(&dest, &logs);
+    config
+        .log_drain
+        .as_mut()
+        .expect("fixture section")
+        .max_file_bytes = Some(1024);
+    let plan = plan_of(&config, tmp.path());
+    let target = fixture_target();
+
+    let first = run_tick(&plan, &state, &target).await;
+    assert_eq!(first.outcome, DrainOutcome::Success, "{}", first.detail);
+    assert_eq!(first.uploaded, 0, "{}", first.detail);
+    assert!(
+        first
+            .detail
+            .contains("1 over the size ceiling (1 newly recorded)"),
+        "the first tick decides: {}",
+        first.detail
+    );
+
+    let second = run_tick(&plan, &state, &target).await;
+    assert!(
+        second
+            .detail
+            .contains("1 over the size ceiling (0 newly recorded)"),
+        "a later tick must not re-decide an unchanged file: {}",
+        second.detail
+    );
+}
+
+#[tokio::test]
+async fn the_wire_ceiling_reaches_the_drain_config() {
+    // The knob #6547 added has to survive config → plan → `DrainConfig`, or the
+    // bound that actually governs memory is unreachable from YAML.
+    let tmp = TempDir::new().expect("tempdir");
+    let dest = tmp.path().join("dest");
+    let logs = log_dir_with(&tmp, "INFO a line that will not gzip under 8 bytes\n");
+    let state = tmp.path().join("state");
+
+    let mut config = enabled_config(&dest, &logs);
+    config
+        .log_drain
+        .as_mut()
+        .expect("fixture section")
+        .max_wire_bytes = Some(8);
+    let plan = plan_of(&config, tmp.path());
+    assert_eq!(plan.max_wire_bytes, 8);
+
+    let status = run_tick(&plan, &state, &fixture_target()).await;
+    assert_eq!(status.uploaded, 0, "{}", status.detail);
+    assert!(
+        status
+            .detail
+            .contains("1 over the size ceiling (1 newly recorded)"),
+        "the wire ceiling must be reported like any other skip: {}",
+        status.detail
+    );
+}
+
+#[tokio::test]
 async fn a_failing_destination_records_failed() {
     let tmp = TempDir::new().expect("tempdir");
     // A `file://` root nested under a regular FILE: `create_dir_all` cannot

--- a/docs/reference/log-drain.md
+++ b/docs/reference/log-drain.md
@@ -176,8 +176,9 @@ Per source file, in order:
    `mtime_unix` match, the file is skipped **without being opened**. This is
    where an unchanged run's cheapness comes from: an unchanged machine reads no
    log bytes at all.
-2. **Size ceiling.** A file over `max_file_bytes` is skipped — see
-   [Limits](#limits).
+2. **Size ceiling.** A file over `max_file_bytes`, or whose compressed body
+   passes `max_wire_bytes` mid-stream, is skipped and the decision is written to
+   the manifest as a `SkipRecord` — see [Limits](#limits).
 3. **SHA-256 tiebreak.** Otherwise the file is read and hashed. **If the digest
    matches the recorded entry, the file is still skipped**, and the entry's
    `size`/`mtime_unix` are refreshed so the next run takes the fast path.
@@ -195,8 +196,8 @@ did upload.
 
 Every body passes through `credentials::scrub_secrets` before compression, with
 the caller-supplied secret list. The pipeline order is fixed inside the
-collector — decode, level-filter, **scrub**, gzip — so no body can reach a
-destination having skipped it. The `log-drain` feature *implies* `credentials`
+collector — decode, level-filter, **scrub**, gzip — and holds per chunk on the
+streamed path, so no body can reach a destination having skipped it. The `log-drain` feature *implies* `credentials`
 for exactly this reason: a build with the drain but without the scrubber would
 upload log text nothing had cleaned.
 
@@ -224,14 +225,48 @@ Two rules keep it from destroying a file it does not understand:
 
 | Limit | Value | Behaviour |
 |---|---|---|
-| `max_file_bytes` | 64 MiB default | Oversize files are **skipped**, never truncated or chunked |
+| `max_file_bytes` | 4 GiB default | Plaintext source ceiling. Over it, the file is never opened |
+| `max_wire_bytes` | 64 MiB default | Compressed body ceiling. Over it, the stream is abandoned |
 | `LIST_LIMIT` | 10 000 entries | `list` truncates with a `warn!` |
 
-**Why oversize files are skipped rather than streamed.** The scrub has to see a
-whole body to catch a secret that straddles a chunk boundary, so a chunked
-upload path could only ever write partially-scrubbed text. Refusing to upload is
-the safe half of that trade, and `DrainReport::skipped_too_large` plus a `warn!`
-say so out loud rather than silently truncating.
+Neither bound truncates. A file that trips one is skipped whole, counted in
+`DrainReport::skipped_too_large`, and recorded in the manifest.
+
+**The collector streams (#6547).** It reads 1 MiB at a time, splitting on the
+last line terminator, so peak memory is a function of the chunk and the
+compressed body rather than of the source file. That is why the source ceiling
+moved from 64 MiB to 4 GiB: at 64 MiB, 29 of 86 daily-rotated daemon logs — up
+to 176 MB each — were permanently undrainable, and a file that cannot shrink
+could never become drainable.
+
+**Chunking is safe for the scrub.** The hazard #6534 named is real: a secret
+split across two chunks is found by neither. `ScrubCarry` holds back the last
+`longest needle - 1` bytes of every scrubbed chunk and prepends them to the
+next, so every occurrence is scrubbed in a window that contains it whole, and
+nothing is emitted until it can no longer participate in a boundary-crossing
+match.
+
+**What still bounds memory** is `max_wire_bytes`. `LogDestination::put` takes an
+in-memory `Bytes`, so the gzip output is the one buffer that still scales with
+the file; at the ~20x ratio daemon log text compresses at, 64 MiB of wire admits
+well over a gigabyte of source.
+
+### Skip decisions are made once (#6547)
+
+An oversize file's answer cannot change while the file does not, so re-deciding
+it every 15-minute cycle produced 1,276 identical `WARN`s in 48 hours over ~40
+files. `run_once` now writes a `SkipRecord` — `relative_file`, `size`,
+`mtime_unix`, `reason`, `decided_at` — into the manifest's `skips` list:
+
+- A later pass that sees the same `(file, size, mtime)` counts the file and logs
+  nothing. `DrainReport::skips_recorded` is the count that did warn, so a steady
+  state reads `skipped_too_large: 29, skips_recorded: 0`.
+- A file whose size or mtime moved no longer matches its record and is evaluated
+  again from scratch.
+- Any file a pass CAN read has its record dropped, so raising a bound takes
+  effect on the next pass rather than needing the manifest cleared by hand.
+- `skips` is `#[serde(default)]`, so a manifest written before #6547 still
+  decodes; it simply carries no decisions, and the next pass makes them.
 
 ## What the caller owns
 


### PR DESCRIPTION
Refs #6547

The 64 MiB `DEFAULT_MAX_FILE_BYTES` ceiling guarded memory, not the destination — `process_file` held ~5 in-memory copies of a body. New `log_drain/pipeline.rs` streams 1 MiB whole-line chunks through level filter → scrub → gzip; `ScrubCarry` holds back `longest needle − 1` bytes so a secret straddling a chunk boundary is still scrubbed (#6534 hazard). SHA-256 stays over raw plaintext, so existing manifests remain valid. Upload still goes through the single `LogDestination::put` — no multipart sink (a second upload path would breach the common-entry-point rule).

Bounds: file ceiling 64 MiB → 4 GiB; new `max_wire_bytes` (64 MiB) caps the compressed body. Documented in `docs/reference/log-drain.md` §Limits.

Durable skips: `DrainManifest.skips: Vec<SkipRecord>` with `#[serde(default)]`, `MANIFEST_VERSION` unchanged; a skip is decided once per (path, size, mtime) and the warn moved from `collector.rs` to `run_once`.

Review point for the reader: an incompressible file whose gzip exceeds `max_wire_bytes` is skipped, durably, with the doctor row naming the knob.

Test ladder: rung 4 (trusty-common library change + trusty-mpm consumer). Commands and counts on 9a8325b23: `cargo fmt --check`; `cargo clippy -p trusty-common --features log-drain --all-targets -- -D warnings`; `cargo test -p trusty-common --features log-drain --no-fail-fast` → 524 + 4 passed, 0 failed; `SKIP_UI_BUILD=1 cargo check --workspace`; `cargo clippy -p trusty-mpm --all-targets -- -D warnings`; `cargo test -p trusty-mpm --no-fail-fast` → 5666 + 1913 + 1913 passed, 0 failed; `check_line_cap.sh`, `check_sld.sh`, `check_changelog_fragment.sh` (both crates) clean.

Regression evidence: three tests captured failing with the mechanism reverted — `run_once_uploads_a_file_over_the_old_ceiling`, `run_once_records_an_oversize_skip_once`, `run_once_re_evaluates_a_skip_when_the_file_changes`.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
