### PR TITLE
chore(sessions): commit the 2026-09-02 01:44Z pause snapshot

### DIFF
--- a/.trusty-mpm/sessions/sessions-log.jsonl
+++ b/.trusty-mpm/sessions/sessions-log.jsonl
@@ -74,3 +74,4 @@
 {"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260901-172730.md","timestamp":"2026-09-01T17:27:30.579162+00:00"}
 {"session_id":"1852fea9-d45b-4288-96ff-9cda26abd845","event":"pause","snapshot":"1852fea9-d45b-4288-96ff-9cda26abd845/session-20260901-204005.md","timestamp":"2026-09-01T20:40:05.799937+00:00"}
 {"session_id":"1852fea9-d45b-4288-96ff-9cda26abd845","event":"pause","snapshot":"1852fea9-d45b-4288-96ff-9cda26abd845/session-20260901-232218.md","timestamp":"2026-09-01T23:22:18.564025+00:00"}
+{"session_id":"tm-trusty-tools-02-0-at2307-20260902","event":"pause","snapshot":"tm-trusty-tools-02-0-at2307-20260902/session-20260902-014402.md","timestamp":"2026-09-02T01:44:02.783351+00:00"}

--- a/.trusty-mpm/sessions/tm-trusty-tools-02-0-at2307-20260902/session-20260902-014402.md
+++ b/.trusty-mpm/sessions/tm-trusty-tools-02-0-at2307-20260902/session-20260902-014402.md
@@ -1,0 +1,61 @@
+# Session Pause - 2026-09-02T01:44:02.783351+00:00
+
+## Summary
+Paused 2026-09-02 ~01:4xZ mid bug-drive (owner: "drive to under 300 open issues"), owner-invoked. Supersedes snapshot 1852fea9-…/session-20260901-232218.md. Palace drawers: 8c56a500 (install state), a5780083 (<300 directive), de98a3db (#6589 edit A/B decision), 6cc9826e (LSP A/B #1 result), 2090717d + 82e0a1a7 (PM errors: recall-before-dispatch; brief never says push).
+
+🔴 FIVE BACKGROUND AGENTS WERE LIVE AT PAUSE — they may or may not survive; VERIFY EACH WORKTREE/ARTIFACT DIRECTLY on resume (`ls .claude/worktrees/`, `git -C <wt> log --oneline -3 && git status --porcelain`), never assume:
+(1) rust-engineer flakes #6580 #6577 #6574 #6575 → branch fix/flakes-6580-6577-6574-6575, commit-only (no push); (2) rust-engineer #6561 (prune agent-* worktrees) + #6586 (skills user-tier only) → two branches fix/6561-prune-agent-worktrees, fix/6586-skills-user-tier-only; (3) rust-engineer #6590 (launchd ExitTimeOut) + #6565 (tga per-run rate budget) → fix/6590-launchd-exit-timeout, fix/6565-tga-ratelimit-budget; (4) qa LSP edit-workload A/B for #6589 → scratchpad lsp-ab-edit/report.md, throwaway worktree .claude/worktrees/lsp-ab-edit (remove if left), plugin rust-analyzer-lsp must be re-ENABLED at user scope; (5) web-qa verifying #6518 dashboard + #6524 console pause/resume on the freshly installed trusty-console 0.9.2.
+For each engineer branch found committed with green gates: security scan (three-dot) → version-control push+PR (Refs, auto-merge) → ticketing status:coded. Engineer briefs must say "do NOT push".
+
+PR #6591 (fix/6542-guided-fallback-tmux-on-runner, f479e7dea) OPEN, auto-merge armed; the pre-publish gate does not run on PRs — proof is the gate run on the merge commit; on green, #6542 + #6551 → status:tested + close.
+
+INSTALLED THIS LEG (from origin/main 8c7075623, worktree install-20260901b, prunable): tm 1.5.16, trusty-search 0.52.0, tga 5.0.3, trusty-console 0.9.2. NOT published. stderr.log truncated. Ready to close on install evidence: #6519 (/screensaver → 200), #6517 (/api/console/machine-status → JSON, 5/5 ok) — batch with web-qa's #6518/#6524 result via ticketing.
+
+CLOSED THIS LEG (12, status:tested): #6548 #6550 #6566 #6441 #6570 #6571 #6569 #6547 #6523 #6505 #6497 #6520. Open count 436 → 432 at pause (census scratchpad census-20260902/census.md).
+
+MERGED THIS LEG: #6583 (609527d7), #6585, #6587 (8c707562, cluster A), #6588 (eafd94e1, #6547 drain).
+
+STAY OPEN at status:merged (trigger not reproducible non-destructively or evidence pending): #6553 #6556 #6568 #6118 #812 (Gate 4 run) #6542 #6551 (PR #6591) #6507 (re-verify after #6561 lands) #6524 (console half). #6555 status:coded, PR #6558 red on version-bump gate, other session's claim. #5439: claim released — HTTP auth shipped in #6491; owner's answer is UDS (design round needed).
+
+#6589 LSP-by-default (status:in-progress): A/B #1 (navigation, headless) = no measured benefit, 0/18 LSP invocations; rust-analyzer mise-shim + pinned toolchain recursion bug found (install per --toolchain). Owner: "run the edit-workload A/B first" → running (agent 4). Build HELD until it reports. Decision then: hold / build with toolchain-aware install.
+
+OWNER DECISION PENDING: fix pipeline caps at ~60–70 closes; reaching <300 needs a won't-do sweep over `paused` (126) / `backlog` (191) — ticketing builds the candidate list on authorization, nothing closes without confirmation.
+
+## Completed
+- Resumed from 20260901-232218 snapshot; both pause-time engineers survived and finished (cluster A 55842d647, #6547 9a8325b23)
+- PR #6587 opened (cluster A), doc-pointer lint fixed via 1 PM edit + qa gates (3431f70f3), merged 8c707562
+- PR #6588 opened (#6547 drain), merged eafd94e1
+- #6583/#6585 confirmed merged; #6556 → status:merged
+- Rebuild+install standing instruction DISCHARGED: tm 1.5.16, trusty-search 0.52.0, tga 5.0.3 from 8c7075623; stderr.log 3.4G→0; trusty-search restart orphan remedied (→ #6590)
+- trusty-console 0.9.2 installed and restarted (pid 92933)
+- Live-verified 15 + 9 status:merged issues; 12 closed at status:tested
+- Filed #6586 (duplicate skill tiers), #6589 (LSP by default), #6590 (launchd ExitTimeOut orphan); #6542 commented + ci-red-main
+- LSP A/B #1 measured and posted on #6589 (comment 5502530188)
+- #6542 red-main test fix: PR #6591 armed (f479e7dea)
+- Backlog census 436/436 scanned (scratchpad census-20260902/)
+- #5439 audited: HTTP auth already shipped (#6491); claim released with UDS note
+
+## In Progress
+- [rust-engineer] flakes #6580 #6577 #6574 #6575 on fix/flakes-6580-6577-6574-6575 (commit-only)
+- [rust-engineer] #6561 fix/6561-prune-agent-worktrees + #6586 fix/6586-skills-user-tier-only (commit-only)
+- [rust-engineer] #6590 fix/6590-launchd-exit-timeout + #6565 fix/6565-tga-ratelimit-budget (commit-only)
+- [qa] LSP edit-workload A/B (#6589) → scratchpad lsp-ab-edit/report.md; worktree lsp-ab-edit; plugin restore
+- [web-qa] #6518 dashboard + #6524 console pause/resume on trusty-console 0.9.2
+- PR #6591 armed; #6542/#6551 close on the merge-commit gate run
+
+## Next Steps
+- Verify the five agents' artifacts directly; for each committed branch: security scan → version-control PR (auto-merge) → ticketing status:coded
+- Ticketing batch: close #6519 + #6517 on install evidence (+ #6518/#6524 per web-qa); after #6591 merges and the gate is green: #6542 #6551 → status:tested + close
+- Post LSP edit-workload result on #6589; decide hold vs build (toolchain-aware install) — owner call
+- Ask owner: authorize a won't-do sweep over paused/backlog (candidate list for confirmation) — required to reach <300
+- Wave 2 candidates (unclaimed): #6581 (chunk-id migration, schema change), release-cleanup label (16: #5441 #5433 #5306 #5176 #5116 #5083 #5082 #5081 #4922 #1661 #1660 #1632 #1008 #129 …), tga bugs/enhancements (34), P1 non-epics (#4031 #2555 #4158)
+- After next install: re-verify #6507 with #6561 landed; #812 needs a post-fix Gate 4 run (workflow_dispatch Pre-publish gate)
+- Housekeeping: prune merged agent worktrees + install-20260901b (local-ops, explicit list only, never bulk); main checkout back to `main`; #6555's PR #6558 needs a trusty-installer version bump (other session)
+
+## Git Context
+Branch: fix/6542-6551-test-isolation
+Last commit: 7d86cfe4c fix: drop scanner-flagged artifact from test isolation change (Refs #6542, Refs #6551)
+Uncommitted changes: 4 file(s) changed
+
+## Tmux Window
+tm-trusty-tools-02:0:@2307


### PR DESCRIPTION
Session snapshot for tm-trusty-tools-02, paused 2026-09-02 01:44Z. Docs-only; no crate source touched.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools