### PR TITLE
fix(trusty-common): quiesce a stale launchd unit before bootout so the flush window is not SIGKILLed

### DIFF
--- a/crates/trusty-common/changelog.d/6590-launchd-active-exit-timeout.md
+++ b/crates/trusty-common/changelog.d/6590-launchd-active-exit-timeout.md
@@ -1,0 +1,19 @@
+Fixed
+
+- `install_and_activate` now verifies the ACTIVE launchd unit's shutdown grace
+  before the bootout it performs, and stops the daemon itself when that grace is
+  too short (#6590). The corrected 60 s `ExitTimeOut` #4393 added to
+  `render_plist` could never govern the shutdown that matters: launchd applies
+  the `ExitTimeOut` of the job it has LOADED, and re-reads the plist file only
+  at `bootstrap` — which happens AFTER `bootstrap`'s own bootout. A host whose
+  loaded unit predated #4393 was therefore still granted launchd's 5 s default,
+  so a daemon flushing 50 index snapshots was SIGKILLed mid-write and
+  `KeepAlive` respawned the old binary as an orphan holding the port.
+- The new `launchd_grace` module reads the window launchd will really grant —
+  the loaded job's `exit timeout` first, falling back to the installed plist,
+  where an absent `ExitTimeOut` key resolves to the 5 s system default rather
+  than to "unknown". When it is shorter than
+  `shutdown::TERMINATION_GRACE_SECS`, the daemon is sent SIGTERM directly, which
+  launchd does not bound, and waited for; the bootout that follows then unloads
+  an already-exited job. An unreadable unit changes nothing, and a quiesce that
+  fails falls through to the bootout as before.

--- a/crates/trusty-common/src/launchd_activate.rs
+++ b/crates/trusty-common/src/launchd_activate.rs
@@ -276,6 +276,14 @@ impl LaunchdConfig {
         let replaced = previous.is_some();
         self.install()?;
 
+        // #6590: the plist is now correct on disk, but launchd is still running
+        // the OLD job definition — it re-reads the file only at `bootstrap`, and
+        // `bootstrap_and_verify` boots the old job out first. So the termination
+        // below is governed by the PREVIOUS unit's `ExitTimeOut`, which on a
+        // pre-#4393 host is launchd's 5 s default. Stop the daemon ourselves
+        // first when that window is too short; see `guard_short_grace`.
+        self.guard_short_grace(crate::shutdown::TERMINATION_GRACE_SECS);
+
         match self.bootstrap_and_verify() {
             Ok(()) => Ok(Activation::Activated { evicted, replaced }),
             Err(e) => {
@@ -389,6 +397,61 @@ impl LaunchdConfig {
             EvictionOutcome::Evicted
         } else {
             EvictionOutcome::Absent
+        }
+    }
+
+    /// Stop the daemon ourselves when launchd's own grace would cut it short.
+    ///
+    /// Why (#6590): `bootstrap` boots the old job out, and launchd bounds that
+    /// bootout by the `ExitTimeOut` of the job it LOADED — not by the corrected
+    /// plist `install()` just wrote, which it will not read until the bootstrap
+    /// that comes after. A unit loaded from a pre-#4393 plist grants
+    /// [`crate::launchd_grace::LAUNCHD_DEFAULT_EXIT_TIMEOUT_SECS`], so a daemon
+    /// flushing 50 index snapshots was SIGKILLed mid-write and `KeepAlive`
+    /// respawned the OLD binary as an orphan holding the port.
+    ///
+    /// What: reads the window launchd will really grant. When it covers
+    /// `required_secs`, or cannot be read at all, nothing happens — the bootout
+    /// proceeds as before. When it is too short, the daemon is sent SIGTERM
+    /// directly (bounded by nothing launchd controls) and waited for, so the
+    /// bootout that follows unloads an already-exited job. Advisory throughout:
+    /// a quiesce that fails still falls through to the bootout, which is no
+    /// worse than the behaviour this replaces.
+    /// Test: the verdict and the wait are unit-tested in `launchd_grace`; the
+    /// wiring is exercised by `trusty-search service install`.
+    fn guard_short_grace(&self, required_secs: u64) {
+        use crate::launchd_grace::{GraceVerdict, Quiesce};
+
+        let GraceVerdict::TooShort {
+            active_secs,
+            required_secs,
+        } = self.active_grace_verdict(required_secs)
+        else {
+            return;
+        };
+
+        tracing::warn!(
+            label = %self.label,
+            active_secs,
+            required_secs,
+            "the loaded launchd unit grants less shutdown grace than the daemon \
+             needs; stopping it directly before bootout so its flush is not \
+             SIGKILLed (#6590)"
+        );
+
+        match self.quiesce_before_bootout(required_secs) {
+            Quiesce::NotRunning => {}
+            Quiesce::Exited { waited_secs } => tracing::info!(
+                label = %self.label,
+                waited_secs,
+                "daemon exited cleanly before bootout"
+            ),
+            Quiesce::StillRunning => tracing::warn!(
+                label = %self.label,
+                required_secs,
+                "daemon did not exit within its own grace window; the bootout \
+                 that follows may still be cut short by launchd"
+            ),
         }
     }
 

--- a/crates/trusty-common/src/launchd_grace.rs
+++ b/crates/trusty-common/src/launchd_grace.rs
@@ -1,0 +1,541 @@
+//! Pre-bootout verification of the ACTIVE launchd unit's grace window (#6590).
+//!
+//! Why: [`crate::launchd::LaunchdConfig::render_plist`] has emitted a 60 s
+//! `ExitTimeOut` since #4393, and #4919 made activation label-correct — yet the
+//! 2026-09-02 reinstall still lost a 55 s snapshot flush to a 5 s SIGKILL. The
+//! two fixes cannot reach the shutdown that matters, because launchd reads a
+//! unit's `ExitTimeOut` from the job it has LOADED IN MEMORY, and it re-reads
+//! the plist file only at `bootstrap`. `install_and_activate` writes the
+//! corrected plist and then calls `bootstrap`, which boots the old job out
+//! FIRST — so the termination that races the flush is always governed by the
+//! window the PREVIOUS unit declared, never by the one just written. On a host
+//! whose installed plist predates #4393 that window is launchd's
+//! [`LAUNCHD_DEFAULT_EXIT_TIMEOUT_SECS`] default, and the daemon is killed
+//! mid-write while `KeepAlive` respawns the old binary as an orphan holding the
+//! port.
+//!
+//! What: pure readers for the grace a unit will actually be granted
+//! ([`parse_launchctl_exit_timeout`], [`parse_plist_exit_timeout`]), a verdict
+//! over it ([`grace_verdict`]), and a bounded quiesce ([`quiesce_job`]) that
+//! stops the live process with SIGTERM and waits for it to exit BEFORE the
+//! bootout, so launchd's short window has nothing left to cut off. The
+//! `launchctl` and signal effects are injected, so every decision is
+//! unit-tested without touching a real unit.
+//!
+//! Test: `cargo test -p trusty-common --features unconditional-only
+//! launchd_grace`.
+#![cfg(target_os = "macos")]
+
+use std::time::Duration;
+
+use crate::launchd::{LaunchdConfig, current_uid};
+
+/// Grace launchd grants a unit that declares no `ExitTimeOut` of its own.
+///
+/// Why: this is the number the whole issue turns on. launchd documents the
+/// value only as "system-defined"; 5 s is what #4393 measured on macOS and what
+/// #6590 observed cutting a 55 s flush short. A unit whose plist omits the key
+/// is therefore not "unknown" — it is known to be this, which is what lets
+/// [`plist_grace_secs`] answer for a legacy plist instead of giving up.
+/// What: `5`, in seconds.
+/// Test: `plist_grace_falls_back_to_the_system_default`.
+pub const LAUNCHD_DEFAULT_EXIT_TIMEOUT_SECS: u64 = 5;
+
+/// Whether the ACTIVE unit's grace window covers the flush the daemon plans.
+///
+/// Why: the caller needs three outcomes, not two. "Long enough" and "too short"
+/// demand opposite handling, and "could not read it" must not be silently
+/// folded into either — quiescing a daemon nobody asked us to stop is as wrong
+/// as SIGKILLing one mid-flush.
+/// What: the two decided states carry the numbers so the log line can name
+/// them; [`GraceVerdict::Unknown`] means launchd answered nothing and no plist
+/// was readable.
+/// Test: `grace_verdict_flags_the_measured_launchd_default`,
+/// `grace_verdict_accepts_an_equal_window`,
+/// `grace_verdict_is_unknown_when_unreadable`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum GraceVerdict {
+    /// The active unit grants at least the required window.
+    Sufficient {
+        /// Seconds launchd will actually wait.
+        active_secs: u64,
+    },
+    /// The active unit grants less than the flush needs — a bootout now would
+    /// SIGKILL the daemon mid-write.
+    TooShort {
+        /// Seconds launchd will actually wait.
+        active_secs: u64,
+        /// Seconds the daemon plans to spend flushing.
+        required_secs: u64,
+    },
+    /// Neither `launchctl` nor an installed plist could answer.
+    Unknown,
+}
+
+impl GraceVerdict {
+    /// Whether a bootout issued now would cut a flush short.
+    ///
+    /// [`GraceVerdict::Unknown`] reads as `false`: an unreadable unit is not
+    /// evidence of a short window, and acting on it would stop daemons on every
+    /// host whose `launchctl print` output cannot be parsed.
+    #[must_use]
+    pub fn is_too_short(&self) -> bool {
+        matches!(self, GraceVerdict::TooShort { .. })
+    }
+}
+
+/// Compare the grace launchd will grant against the window the daemon needs.
+///
+/// Why: kept pure and separate from the `launchctl` read so the comparison —
+/// the thing that decides whether a live daemon gets stopped — is testable
+/// without a loaded unit.
+/// What: `None` yields [`GraceVerdict::Unknown`]; otherwise the active value is
+/// [`GraceVerdict::Sufficient`] when it is at least `required_secs` and
+/// [`GraceVerdict::TooShort`] below that. Equality is sufficient: a unit that
+/// grants exactly the planned window is the state the renderer aims for.
+/// Test: `grace_verdict_flags_the_measured_launchd_default`,
+/// `grace_verdict_accepts_an_equal_window`,
+/// `grace_verdict_is_unknown_when_unreadable`.
+#[must_use]
+pub fn grace_verdict(active_secs: Option<u64>, required_secs: u64) -> GraceVerdict {
+    match active_secs {
+        None => GraceVerdict::Unknown,
+        Some(active_secs) if active_secs >= required_secs => {
+            GraceVerdict::Sufficient { active_secs }
+        }
+        Some(active_secs) => GraceVerdict::TooShort {
+            active_secs,
+            required_secs,
+        },
+    }
+}
+
+/// Read the `exit timeout` launchd reports for a loaded job.
+///
+/// Why: the LOADED job is the only authority on the window a bootout will
+/// respect — the plist on disk may already have been overwritten with the
+/// corrected one, which is exactly the state #6590 fails in.
+/// What: scans `launchctl print gui/<uid>/<label>` output for a line whose key
+/// is `exit timeout` and returns the integer after the `=`. Returns `None` when
+/// no such line is present.
+/// Test: `parse_launchctl_exit_timeout_reads_the_loaded_window`,
+/// `parse_launchctl_exit_timeout_ignores_unrelated_lines`.
+#[must_use]
+pub fn parse_launchctl_exit_timeout(printed: &str) -> Option<u64> {
+    keyed_value(printed, "exit timeout")?.parse().ok()
+}
+
+/// Read the pid launchd reports for a loaded job.
+///
+/// Why: the quiesce needs the process to signal, and the pid launchd holds is
+/// the one it will SIGKILL at the timeout boundary — reading it anywhere else
+/// risks signalling a different instance.
+/// What: scans `launchctl print` output for a `pid = <n>` line. `None` when the
+/// job is loaded but not currently running.
+/// Test: `parse_launchctl_pid_reads_a_running_job`,
+/// `parse_launchctl_pid_is_none_for_an_idle_job`.
+#[must_use]
+pub fn parse_launchctl_pid(printed: &str) -> Option<u32> {
+    keyed_value(printed, "pid")?.parse().ok()
+}
+
+/// Value of the `<key> = <value>` line whose key is exactly `key`.
+///
+/// Matching the whole trimmed key is what keeps `pid` from also matching
+/// launchd's `original pid` and `pid of last exit` lines.
+fn keyed_value<'a>(printed: &'a str, key: &str) -> Option<&'a str> {
+    printed.lines().find_map(|line| {
+        let (found, value) = line.split_once('=')?;
+        found.trim().eq_ignore_ascii_case(key).then(|| value.trim())
+    })
+}
+
+/// Read an `ExitTimeOut` declaration out of plist XML.
+///
+/// Why: when `launchctl print` cannot answer (the label is not loaded, or
+/// launchctl is unavailable) the installed plist still says what launchd would
+/// grant on the next load.
+/// What: finds `<key>ExitTimeOut</key>` and returns the integer in the
+/// `<integer>` element that follows it. `None` when the key is absent — see
+/// [`plist_grace_secs`] for why that is not the same as "unknown".
+/// Test: `parse_plist_exit_timeout_reads_a_declared_window`,
+/// `parse_plist_exit_timeout_is_none_when_undeclared`.
+#[must_use]
+pub fn parse_plist_exit_timeout(xml: &str) -> Option<u64> {
+    let after_key = xml.split_once("<key>ExitTimeOut</key>")?.1;
+    let open = after_key.find("<integer>")? + "<integer>".len();
+    let close = after_key[open..].find("</integer>")? + open;
+    after_key[open..close].trim().parse().ok()
+}
+
+/// Grace launchd will grant a unit whose plist reads `xml`.
+///
+/// Why: a plist with no `ExitTimeOut` is not an unreadable unit — it is a unit
+/// that will be granted [`LAUNCHD_DEFAULT_EXIT_TIMEOUT_SECS`]. Reporting it as
+/// unknown is what would let the #6590 host, whose installed plist predates
+/// #4393 and declares no key at all, slip past the guard.
+/// What: the declared value, or the system default when none is declared.
+/// Test: `plist_grace_falls_back_to_the_system_default`,
+/// `plist_grace_prefers_a_declared_window`.
+#[must_use]
+pub fn plist_grace_secs(xml: &str) -> u64 {
+    parse_plist_exit_timeout(xml).unwrap_or(LAUNCHD_DEFAULT_EXIT_TIMEOUT_SECS)
+}
+
+/// What a pre-bootout quiesce achieved.
+///
+/// Why: the caller must distinguish "the bootout is now safe" from "it is still
+/// not", because only the second is worth warning an operator about.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Quiesce {
+    /// No live process — the short window has nothing to cut off.
+    NotRunning,
+    /// The daemon exited on its own after SIGTERM, within the window.
+    Exited {
+        /// Seconds waited before the process was observed gone.
+        waited_secs: u64,
+    },
+    /// The daemon was still running when the window ran out. The bootout that
+    /// follows will be governed by launchd's short grace after all.
+    StillRunning,
+}
+
+/// Stop a live job ourselves, so the bootout that follows finds nothing to kill.
+///
+/// Why: launchd's `ExitTimeOut` bounds only terminations launchd performs. A
+/// SIGTERM delivered directly is bounded by nothing, so the daemon gets its full
+/// flush — this is precisely the `kill -TERM` remedy the #6590 operator applied
+/// by hand after the bootout had already truncated one. Doing it before the
+/// bootout means the subsequent `launchctl bootout` unloads an already-exited
+/// job, which is instant and cannot SIGKILL anything.
+///
+/// What: with a live pid, sends SIGTERM once and then polls liveness one tick
+/// per second for at most `required_secs`. Effects are injected: `terminate`
+/// reports whether the signal was delivered, `still_alive` probes the process,
+/// and `tick` is the wait between probes. A signal that cannot be delivered
+/// yields [`Quiesce::StillRunning`] rather than a spurious success.
+///
+/// Note the deliberate ordering against `KeepAlive`: a clean exit is followed
+/// immediately by the caller's bootout, well inside the agent's
+/// `ThrottleInterval`, so launchd does not get to respawn in the gap. Should it
+/// respawn anyway, the fresh instance has nothing flushed to lose.
+///
+/// Test: `quiesce_reports_not_running_without_a_pid`,
+/// `quiesce_reports_not_running_when_the_pid_is_already_gone`,
+/// `quiesce_waits_for_a_clean_exit`, `quiesce_gives_up_at_the_window`,
+/// `quiesce_reports_still_running_when_the_signal_fails`.
+pub fn quiesce_job(
+    pid: Option<u32>,
+    required_secs: u64,
+    terminate: impl FnOnce(u32) -> bool,
+    mut still_alive: impl FnMut(u32) -> bool,
+    mut tick: impl FnMut(),
+) -> Quiesce {
+    let Some(pid) = pid else {
+        return Quiesce::NotRunning;
+    };
+    if !still_alive(pid) {
+        return Quiesce::NotRunning;
+    }
+    if !terminate(pid) {
+        return Quiesce::StillRunning;
+    }
+    for waited_secs in 1..=required_secs {
+        tick();
+        if !still_alive(pid) {
+            return Quiesce::Exited { waited_secs };
+        }
+    }
+    Quiesce::StillRunning
+}
+
+impl LaunchdConfig {
+    /// Raw `launchctl print gui/<uid>/<label>` output, when the label is loaded.
+    ///
+    /// Why: both the active grace and the running pid come from this one read,
+    /// and taking it once keeps them describing the same instant.
+    /// What: `None` when launchctl cannot be spawned or exits non-zero (which is
+    /// how it reports a label that is not loaded).
+    /// Test: side-effecting; the parsing it feeds is covered by
+    /// `parse_launchctl_*`.
+    #[must_use]
+    pub fn launchctl_print(&self) -> Option<String> {
+        let target = format!("gui/{}/{}", current_uid(), self.label);
+        let output = std::process::Command::new("launchctl")
+            .args(["print", &target])
+            .output()
+            .ok()?;
+        output
+            .status
+            .success()
+            .then(|| String::from_utf8_lossy(&output.stdout).into_owned())
+    }
+
+    /// Seconds launchd will grant this unit before SIGKILL.
+    ///
+    /// Why: the loaded job outranks the file, because `install()` may already
+    /// have replaced the file with the corrected plist that is not yet loaded —
+    /// trusting the file there is what makes the guard report a 60 s window
+    /// while launchd is holding 5.
+    /// What: the loaded job's `exit timeout` if launchctl answers; otherwise the
+    /// installed plist's window per [`plist_grace_secs`]; otherwise `None`.
+    /// Test: side-effecting; both readers are unit-tested individually.
+    #[must_use]
+    pub fn active_exit_timeout_secs(&self) -> Option<u64> {
+        if let Some(printed) = self.launchctl_print()
+            && let Some(secs) = parse_launchctl_exit_timeout(&printed)
+        {
+            return Some(secs);
+        }
+        let path = self.plist_path().ok()?;
+        let xml = std::fs::read_to_string(path).ok()?;
+        Some(plist_grace_secs(&xml))
+    }
+
+    /// Verdict on whether a bootout now would cut `required_secs` of flush short.
+    #[must_use]
+    pub fn active_grace_verdict(&self, required_secs: u64) -> GraceVerdict {
+        grace_verdict(self.active_exit_timeout_secs(), required_secs)
+    }
+
+    /// SIGTERM the running job and wait for it, bounded by `required_secs`.
+    ///
+    /// Why/What: see [`quiesce_job`] — this binds it to the real pid, signal,
+    /// and clock.
+    /// Test: the decision is covered by `quiesce_*`; the signal itself is
+    /// side-effecting and is exercised by `service install`.
+    pub fn quiesce_before_bootout(&self, required_secs: u64) -> Quiesce {
+        let pid = self
+            .launchctl_print()
+            .as_deref()
+            .and_then(parse_launchctl_pid);
+        quiesce_job(
+            pid,
+            required_secs,
+            |pid| signal_process(pid, libc::SIGTERM),
+            |pid| signal_process(pid, 0),
+            || std::thread::sleep(Duration::from_secs(1)),
+        )
+    }
+}
+
+/// Send `sig` to `pid`, reporting whether it was delivered.
+///
+/// Signal `0` performs the permission and existence checks without delivering
+/// anything, which is the POSIX liveness probe.
+fn signal_process(pid: u32, sig: i32) -> bool {
+    // SAFETY: `kill` takes two scalars and reports failure through its return
+    // value; there are no pointers or lifetimes involved.
+    unsafe { libc::kill(pid as libc::pid_t, sig) == 0 }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A trimmed-down sample of real `launchctl print` output.
+    const PRINTED: &str = "\
+com.trusty.search = {
+\tactive count = 1
+\tpath = /Users/test/Library/LaunchAgents/com.trusty.search.plist
+\tstate = running
+\tpid = 23570
+\toriginal pid = 86880
+\tprogram = /Users/test/.cargo/bin/trusty-search
+\truns = 18
+\texit timeout = 5
+\tlast exit code = 1
+}";
+
+    /// Why (#6590): this is the observed failure — launchd holding the 5 s
+    /// system default while the daemon plans a 55 s flush. The guard exists only
+    /// to catch this, so it is asserted on the real number.
+    /// What: 5 s active against a 60 s requirement is `TooShort`, carrying both
+    /// numbers.
+    /// Test: itself.
+    #[test]
+    fn grace_verdict_flags_the_measured_launchd_default() {
+        assert_eq!(
+            grace_verdict(Some(LAUNCHD_DEFAULT_EXIT_TIMEOUT_SECS), 60),
+            GraceVerdict::TooShort {
+                active_secs: 5,
+                required_secs: 60,
+            },
+            "launchd's 5 s default cannot cover a 55 s snapshot flush"
+        );
+        assert!(grace_verdict(Some(5), 60).is_too_short());
+    }
+
+    /// Why: the renderer aims for exactly `TERMINATION_GRACE_SECS`, so treating
+    /// an equal window as short would make every correctly-installed host
+    /// quiesce its daemon on every install.
+    /// What: equal and larger windows are both `Sufficient`.
+    /// Test: itself.
+    #[test]
+    fn grace_verdict_accepts_an_equal_window() {
+        assert_eq!(
+            grace_verdict(Some(60), 60),
+            GraceVerdict::Sufficient { active_secs: 60 }
+        );
+        assert_eq!(
+            grace_verdict(Some(120), 60),
+            GraceVerdict::Sufficient { active_secs: 120 }
+        );
+        assert!(!grace_verdict(Some(60), 60).is_too_short());
+    }
+
+    /// Why: an unreadable unit must not be treated as a short one — the guard
+    /// would then stop a healthy daemon on every host whose launchctl output
+    /// cannot be parsed.
+    /// What: `None` is `Unknown`, and `Unknown` is not too short.
+    /// Test: itself.
+    #[test]
+    fn grace_verdict_is_unknown_when_unreadable() {
+        assert_eq!(grace_verdict(None, 60), GraceVerdict::Unknown);
+        assert!(!GraceVerdict::Unknown.is_too_short());
+    }
+
+    #[test]
+    fn parse_launchctl_exit_timeout_reads_the_loaded_window() {
+        assert_eq!(parse_launchctl_exit_timeout(PRINTED), Some(5));
+    }
+
+    #[test]
+    fn parse_launchctl_exit_timeout_ignores_unrelated_lines() {
+        assert_eq!(parse_launchctl_exit_timeout("\tstate = running\n"), None);
+        assert_eq!(parse_launchctl_exit_timeout(""), None);
+    }
+
+    /// Why: launchd prints `original pid` and `pid of last exit` beside the live
+    /// `pid`. A substring match would read one of those and signal a pid that is
+    /// either stale or belongs to something else entirely.
+    /// What: the live `pid` line wins over the `original pid` line below it in
+    /// the sample.
+    /// Test: itself.
+    #[test]
+    fn parse_launchctl_pid_reads_a_running_job() {
+        assert_eq!(parse_launchctl_pid(PRINTED), Some(23570));
+    }
+
+    #[test]
+    fn parse_launchctl_pid_is_none_for_an_idle_job() {
+        assert_eq!(parse_launchctl_pid("\tstate = waiting\n\truns = 3\n"), None);
+    }
+
+    #[test]
+    fn parse_plist_exit_timeout_reads_a_declared_window() {
+        let xml = "  <key>ExitTimeOut</key>\n  <integer>60</integer>\n";
+        assert_eq!(parse_plist_exit_timeout(xml), Some(60));
+    }
+
+    #[test]
+    fn parse_plist_exit_timeout_is_none_when_undeclared() {
+        let xml = "  <key>ThrottleInterval</key>\n  <integer>30</integer>\n";
+        assert_eq!(parse_plist_exit_timeout(xml), None);
+    }
+
+    /// Why (#6590): the host that lost the flush had an installed plist with no
+    /// `ExitTimeOut` key at all — a legacy unit predating #4393. Reading that as
+    /// "unknown" is what would let it past the guard, so it must read as the 5 s
+    /// launchd actually applies.
+    /// What: an undeclared window resolves to the system default.
+    /// Test: itself.
+    #[test]
+    fn plist_grace_falls_back_to_the_system_default() {
+        let legacy = "  <key>KeepAlive</key>\n  <dict/>\n";
+        assert_eq!(plist_grace_secs(legacy), LAUNCHD_DEFAULT_EXIT_TIMEOUT_SECS);
+        assert!(grace_verdict(Some(plist_grace_secs(legacy)), 60).is_too_short());
+    }
+
+    #[test]
+    fn plist_grace_prefers_a_declared_window() {
+        let current = "  <key>ExitTimeOut</key>\n  <integer>60</integer>\n";
+        assert_eq!(plist_grace_secs(current), 60);
+    }
+
+    #[test]
+    fn quiesce_reports_not_running_without_a_pid() {
+        let outcome = quiesce_job(
+            None,
+            60,
+            |_| unreachable!("nothing to signal"),
+            |_| unreachable!("nothing to probe"),
+            || unreachable!("nothing to wait for"),
+        );
+        assert_eq!(outcome, Quiesce::NotRunning);
+    }
+
+    #[test]
+    fn quiesce_reports_not_running_when_the_pid_is_already_gone() {
+        let outcome = quiesce_job(
+            Some(4242),
+            60,
+            |_| unreachable!("a dead process must not be signalled"),
+            |_| false,
+            || unreachable!("nothing to wait for"),
+        );
+        assert_eq!(outcome, Quiesce::NotRunning);
+    }
+
+    /// Why (#6590): the whole point of the quiesce is that a directly-delivered
+    /// SIGTERM is bounded by nothing, so the daemon gets the full flush launchd
+    /// would have cut off. The operator's manual remedy took 15 s; this asserts
+    /// the wait outlives launchd's 5 s window.
+    /// What: a process that is still alive on the first 16 probes and gone on
+    /// the next is reported as `Exited` after 16 ticks, inside a 60 s budget.
+    /// Test: itself.
+    #[test]
+    fn quiesce_waits_for_a_clean_exit() {
+        let mut probes = 0_u64;
+        let mut ticks = 0_u64;
+        let outcome = quiesce_job(
+            Some(4242),
+            60,
+            |_| true,
+            |_| {
+                probes += 1;
+                // Probe 1 is the liveness pre-check; the process goes away on
+                // the 16th post-signal probe, well past launchd's 5 s window.
+                probes <= 16
+            },
+            || ticks += 1,
+        );
+        assert_eq!(
+            outcome,
+            Quiesce::Exited { waited_secs: 16 },
+            "a direct SIGTERM must be allowed to outlive launchd's short window"
+        );
+        assert_eq!(ticks, 16, "one probe per second, no busy loop");
+        assert!(
+            ticks > LAUNCHD_DEFAULT_EXIT_TIMEOUT_SECS,
+            "a wait that fits inside launchd's default would not have helped"
+        );
+    }
+
+    #[test]
+    fn quiesce_gives_up_at_the_window() {
+        let mut ticks = 0_u64;
+        let outcome = quiesce_job(Some(4242), 3, |_| true, |_| true, || ticks += 1);
+        assert_eq!(outcome, Quiesce::StillRunning);
+        assert_eq!(ticks, 3, "the wait is bounded by the required window");
+    }
+
+    /// Why: a SIGTERM that was never delivered leaves the daemon running, and
+    /// reporting success would send the caller into a bootout believing the
+    /// process had already exited.
+    /// What: a failed signal yields `StillRunning` and skips the wait entirely.
+    /// Test: itself.
+    #[test]
+    fn quiesce_reports_still_running_when_the_signal_fails() {
+        let outcome = quiesce_job(
+            Some(4242),
+            60,
+            |_| false,
+            |_| true,
+            || unreachable!("no wait after a signal that never landed"),
+        );
+        assert_eq!(outcome, Quiesce::StillRunning);
+    }
+}

--- a/crates/trusty-common/src/lib.rs
+++ b/crates/trusty-common/src/lib.rs
@@ -228,6 +228,22 @@ pub mod launchd;
 #[cfg(target_os = "macos")]
 pub mod launchd_activate;
 
+/// Pre-bootout verification of the ACTIVE launchd unit's grace window (#6590).
+/// macOS-only, like [`launchd`] itself.
+///
+/// Why: launchd applies the `ExitTimeOut` of the job it has LOADED, and re-reads
+/// the plist only at `bootstrap` — so the corrected window
+/// [`launchd::LaunchdConfig::render_plist`] writes never governs the bootout
+/// that immediately precedes the bootstrap. A host whose loaded unit predates
+/// #4393 therefore still SIGKILLs the daemon 5 s into a 55 s snapshot flush.
+/// What: [`launchd_grace::grace_verdict`] over the window launchd will really
+/// grant, plus [`launchd_grace::quiesce_job`], which stops the process with a
+/// directly-delivered SIGTERM — bounded by nothing launchd controls — so the
+/// bootout finds it already gone.
+/// Test: `cargo test -p trusty-common --features unconditional-only launchd_grace`.
+#[cfg(target_os = "macos")]
+pub mod launchd_grace;
+
 /// Canonical launchd labels for every trusty-* LaunchAgent (#4919).
 ///
 /// Why: each daemon crate, the installer's mirror table, the Makefiles, and

--- a/crates/trusty-search/changelog.d/6590-already-running-remedy.md
+++ b/crates/trusty-search/changelog.d/6590-already-running-remedy.md
@@ -1,0 +1,11 @@
+Fixed
+
+- `trusty-search start`'s "daemon already running" refusal now names the remedy,
+  not just the pid (#6590). When a truncated shutdown leaves launchd respawning
+  the old binary, every subsequent start refuses against that orphan — one
+  reinstall looped 17 times on a message whose only advice was `trusty-search
+  stop`, which the operator had already run. The text now gives the signal to
+  send (`kill -TERM <pid>`), the seconds to allow for the index-snapshot flush,
+  and a warning against SIGKILL. Under launchd it says `KeepAlive` starts the
+  replacement, so the operator does not race it with a manual `start`;
+  unsupervised, it names the re-run.

--- a/crates/trusty-search/src/commands/start/daemon.rs
+++ b/crates/trusty-search/src/commands/start/daemon.rs
@@ -24,6 +24,47 @@ use super::graceful_bootstrap::run_graceful_python_bootstrap;
 use super::restore::restore_indexes;
 use crate::commands::prior_index_count::load_prior_index_count;
 
+/// Refusal text for a start that found another daemon holding the port.
+///
+/// Why (#6590): naming the pid was not enough to act on. When `launchctl
+/// bootout` cuts a snapshot flush short, `KeepAlive` respawns the OLD binary,
+/// and every subsequent start refuses against that orphan — the observed
+/// reinstall looped 17 times on a message whose only advice, `trusty-search
+/// stop`, reads as a no-op to an operator who has just run it. The remedy that
+/// worked was a direct SIGTERM, which is bounded by nothing launchd controls
+/// and let the flush finish in 15 s.
+///
+/// What: names the pid, the signal to send it, and the window to allow. Under
+/// launchd the message stops there, because `KeepAlive` starts the replacement
+/// on its own; unsupervised, it also names the re-run. The macOS code-signing
+/// warning is preserved from the message this replaces.
+/// Test: `already_running_message_names_the_pid_and_the_signal`,
+/// `already_running_message_defers_the_restart_to_launchd`.
+pub(super) fn already_running_message(
+    pid: u32,
+    grace_secs: u64,
+    launchd_supervised: bool,
+) -> String {
+    let restart = if launchd_supervised {
+        "launchd's KeepAlive then starts the replacement on its own.".to_string()
+    } else {
+        "Then re-run `trusty-search start`.".to_string()
+    };
+    format!(
+        "Daemon already running (pid {pid}).\n\
+         \n\
+         If you just replaced the binary, this is the OLD image: a truncated \
+         shutdown leaves launchd respawning it, and it keeps the port.\n\
+         \n\
+         Remedy:  kill -TERM {pid}\n\
+         Allow up to {grace_secs}s for its index-snapshot flush to finish — do not \
+         SIGKILL it, that is what loses snapshots. {restart}\n\
+         \n\
+         Replacing the binary while the daemon is running causes macOS to SIGKILL \
+         the process (Code Signature Invalid)."
+    )
+}
+
 /// Main entry point for `trusty-search start`.
 ///
 /// Why: extracted from `main()`. The boot sequence is intricate (lockfile
@@ -247,12 +288,17 @@ pub async fn handle_start(
     // *alive*, print an actionable warning and exit 1.
     if let Some(pid) = crate::service::running_daemon_pid() {
         tracing::warn!("daemon already running (pid {pid}); refusing to start a second instance");
-        anyhow::bail!(
-            "Daemon already running (pid {pid}).\n\
-             Stop it first with `trusty-search stop`, then re-run `trusty-search start`.\n\
-             Replacing the binary while the daemon is running causes macOS to SIGKILL \
-             the process (Code Signature Invalid)."
-        );
+        // #6590: name the remedy, not just the pid — the loop this refusal
+        // produced ran 17 times against a launchd-respawned orphan.
+        #[cfg(target_os = "macos")]
+        let supervised = crate::commands::service::launchd_agent_loaded();
+        #[cfg(not(target_os = "macos"))]
+        let supervised = false;
+        anyhow::bail!(already_running_message(
+            pid,
+            trusty_common::shutdown::termination_grace().as_secs(),
+            supervised
+        ));
     }
 
     // Issue #81: detect orphan daemons whose PIDs are NOT recorded in the

--- a/crates/trusty-search/src/commands/start/tests.rs
+++ b/crates/trusty-search/src/commands/start/tests.rs
@@ -2258,3 +2258,51 @@ async fn swap_back_real_hardware_kills_sidecar_past_max_restarts() {
         search_resp.status()
     );
 }
+
+/// Why (#6590): the refusal this asserts is what an operator reads while a
+/// launchd-respawned orphan holds the port. The pre-fix text named the pid and
+/// then advised `trusty-search stop` — which is what they had already tried.
+/// The remedy that worked was a direct SIGTERM allowed to run its full flush.
+/// What: the message names the pid, the signal, and the grace window, and warns
+/// against SIGKILL.
+/// Test: itself.
+#[test]
+fn already_running_message_names_the_pid_and_the_signal() {
+    let msg = super::daemon::already_running_message(86880, 60, false);
+    assert!(msg.contains("86880"), "must name the pid: {msg}");
+    assert!(
+        msg.contains("kill -TERM 86880"),
+        "must name the signal to send that pid: {msg}"
+    );
+    assert!(
+        msg.contains("60s"),
+        "must name the window the flush needs: {msg}"
+    );
+    assert!(
+        msg.contains("do not SIGKILL"),
+        "SIGKILL is what loses the snapshots: {msg}"
+    );
+    assert!(
+        msg.contains("re-run `trusty-search start`"),
+        "unsupervised, nothing restarts the daemon but the operator: {msg}"
+    );
+}
+
+/// Why: under `KeepAlive` the operator must NOT be told to re-run `start` —
+/// launchd brings the replacement up itself, and a manual start races it into
+/// the very "already running" refusal this message is about.
+/// What: the launchd-supervised variant names launchd and omits the re-run.
+/// Test: itself.
+#[test]
+fn already_running_message_defers_the_restart_to_launchd() {
+    let msg = super::daemon::already_running_message(86880, 60, true);
+    assert!(msg.contains("kill -TERM 86880"), "{msg}");
+    assert!(
+        msg.contains("KeepAlive"),
+        "must say what restarts it: {msg}"
+    );
+    assert!(
+        !msg.contains("re-run `trusty-search start`"),
+        "a manual start races launchd's own respawn: {msg}"
+    );
+}


### PR DESCRIPTION
Refs #6590

## Summary
`install_and_activate_forced` wrote the corrected plist and then booted out the OLD loaded unit, which launchd governs with the previous unit's `ExitTimeOut` (5 s default on hosts whose plist lacks the key), so a 55 s snapshot flush was SIGKILLed and `KeepAlive` respawned the old binary. New `launchd_grace.rs` reads the grace launchd will really grant (loaded job first, then the installed plist, absent key = 5 s) and, when it is shorter than `TERMINATION_GRACE_SECS`, sends SIGTERM directly and waits so the bootout unloads an exited job. `trusty-search start`'s already-running refusal now names `kill -TERM <pid>` and the flush window.

Behaviour change: on a host with a stale loaded unit, `service install` now stops the daemon and waits up to 60 s before bootout. Inert once the plist is correct.

## Test ladder
Rung 4 (touches trusty-common; consumer trusty-search).
- `cargo fmt --check` — exit 0
- `cargo clippy -p trusty-common --features unconditional-only --all-targets -- -D warnings` — exit 0
- `cargo clippy -p trusty-search --all-targets -- -D warnings` — exit 0
- `cargo check --workspace` — exit 0
- `cargo test -p trusty-common --features unconditional-only --no-fail-fast` — 414 passed, 0 failed, 6 ignored (+4 passed)
- `cargo test -p trusty-search --no-fail-fast` — 1959 passed, 0 failed, 1 ignored; 457 passed, 0 failed, 3 ignored; 20 further targets, 0 failures
- Regression tests that fail pre-fix: `launchd_grace::tests::grace_verdict_flags_the_measured_launchd_default`, `plist_grace_falls_back_to_the_system_default`, `grace_verdict_is_unknown_when_unreadable`, `commands::start::tests::already_running_message_*`
- `check_line_cap.sh`, `check_changelog_fragment.sh`, `check_sld.sh`, `check_test_pointers.sh` — all OK

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools