### PR TITLE
fix(tga): one rate-limit sleep budget per run instead of per GitHub client

### DIFF
--- a/crates/trusty-git-analytics/changelog.d/6565-per-run-rate-limit-budget.md
+++ b/crates/trusty-git-analytics/changelog.d/6565-per-run-rate-limit-budget.md
@@ -1,0 +1,18 @@
+Fixed
+
+- `tga collect`'s rate-limit sleep allowance is now per-RUN rather than
+  per-client (#6565). #6084 gave each GitHub client a `FetchBudget`, which bounds
+  a client and not a run: one `collect` builds several — org discovery, the PR
+  sweep, the reviewer pass — so the 120 s ceiling was charged once per client and
+  the wall-clock a run could spend asleep scaled with the number of clients
+  instead of being the fixed bound the constant reads as. A breaker latched
+  during one pass also did not stop the next from spiralling again. The new
+  `RunBudget` is a shared handle every client takes via
+  `GitHubClient::with_run_budget`, constructed once on `CollectionPipeline`, so
+  there is one allowance, one breaker, and one truncation ledger for the whole
+  run.
+- `TGA_RATE_LIMIT_SLEEP_BUDGET_SECS` overrides the 120 s total. The same ceiling
+  now covers strictly more work than it did per-client, so a long multi-org sweep
+  that legitimately needs a larger allowance has a way to ask for one. A zero or
+  unparseable value falls back to the shipped default rather than latching the
+  breaker on the first rate-limited response.

--- a/crates/trusty-git-analytics/src/collect/collector.rs
+++ b/crates/trusty-git-analytics/src/collect/collector.rs
@@ -11,6 +11,7 @@ use crate::collect::bitbucket::BitbucketClient;
 use crate::collect::errors::Result;
 use crate::collect::fault::CollectionFault;
 use crate::collect::git::GitCollector;
+use crate::collect::github::budget::RunBudget;
 use crate::collect::github::GitHubClient;
 use crate::collect::identity::IdentityResolver;
 use crate::collect::linear_pipeline;
@@ -154,6 +155,11 @@ pub struct CollectionPipeline {
     /// [`ProgressBus::disabled`], on which every emit is a no-op — so the CLI
     /// path, including its `indicatif` bars, behaves exactly as before.
     progress: ProgressBus,
+    /// #6565: the ONE rate-limit sleep budget this run shares across every
+    /// GitHub client it builds — org discovery, the PR sweep, and the reviewer
+    /// pass. Each used to own its own, so the ceiling was charged once per
+    /// client and a breaker latched in one pass did not stop the next.
+    github_budget: RunBudget,
 }
 
 impl CollectionPipeline {
@@ -176,6 +182,9 @@ impl CollectionPipeline {
             strict_fetch: false,
             verbose_fetch: false,
             progress: ProgressBus::disabled(),
+            // #6565: constructed once here so every client this run builds
+            // charges the same allowance.
+            github_budget: RunBudget::new(),
         }
     }
 
@@ -605,7 +614,9 @@ impl CollectionPipeline {
                         "GitHub PR fetcher will scan {} repo(s) anonymously",
                         repos.len()
                     );
-                    match GitHubClient::new_for_prs(gh_cfg, repos) {
+                    match GitHubClient::new_for_prs(gh_cfg, repos)
+                        .map(|c| c.with_run_budget(&self.github_budget))
+                    {
                         Ok(gh) => providers.push(Box::new(gh)),
                         Err(e) => stats.fail_stage(format!("GitHub client init failed: {e}")),
                     }
@@ -615,7 +626,9 @@ impl CollectionPipeline {
                         "GitHub PR fetcher will scan {} repo(s)",
                         repos.len()
                     );
-                    match GitHubClient::new_for_prs(gh_cfg, repos) {
+                    match GitHubClient::new_for_prs(gh_cfg, repos)
+                        .map(|c| c.with_run_budget(&self.github_budget))
+                    {
                         Ok(gh) => providers.push(Box::new(gh)),
                         Err(e) => stats.fail_stage(format!("GitHub client init failed: {e}")),
                     }
@@ -674,7 +687,7 @@ impl CollectionPipeline {
         // repo set before constructing the GitHub client.
         let org_discovered = if let Some(gh_cfg) = &self.config.github {
             if gh_cfg.fetch_prs && (!gh_cfg.orgs.is_empty() || gh_cfg.org.is_some()) {
-                super::github_pipeline::run_github_org_discovery(gh_cfg).await
+                super::github_pipeline::run_github_org_discovery(gh_cfg, &self.github_budget).await
             } else {
                 Vec::new()
             }
@@ -718,6 +731,7 @@ impl CollectionPipeline {
                     gh_cfg,
                     self.force_refresh_prs,
                     stats,
+                    &self.github_budget,
                 )
                 .await;
             }

--- a/crates/trusty-git-analytics/src/collect/github/budget.rs
+++ b/crates/trusty-git-analytics/src/collect/github/budget.rs
@@ -40,6 +40,43 @@ pub(crate) const MAX_REFERENCE_LOOKUPS: usize = 500;
 /// Total wall-clock one run may spend asleep waiting out GitHub.
 pub(crate) const RATE_LIMIT_SLEEP_BUDGET: Duration = Duration::from_secs(120);
 
+/// Operator override for [`RATE_LIMIT_SLEEP_BUDGET`], in whole seconds.
+///
+/// Why (#6565): the allowance now bounds a whole run rather than one client, so
+/// the same 120 s covers strictly more work than it used to. A long multi-org
+/// sweep that legitimately needs a larger total has no other way to ask for one.
+/// What: `TGA_RATE_LIMIT_SLEEP_BUDGET_SECS`, a positive integer.
+/// Test: `run_sleep_budget_honours_a_valid_override`,
+/// `run_sleep_budget_ignores_junk_overrides`.
+pub(crate) const RATE_LIMIT_SLEEP_BUDGET_ENV: &str = "TGA_RATE_LIMIT_SLEEP_BUDGET_SECS";
+
+/// The total sleep allowance this run should use.
+///
+/// Why: reads the override in the one place that owns the policy, so no caller
+/// re-implements the parse.
+/// What: [`run_sleep_budget_from`] applied to [`RATE_LIMIT_SLEEP_BUDGET_ENV`].
+/// Test: covered through `run_sleep_budget_from`'s tests.
+pub(crate) fn run_sleep_budget() -> Duration {
+    run_sleep_budget_from(std::env::var(RATE_LIMIT_SLEEP_BUDGET_ENV).ok().as_deref())
+}
+
+/// Pure half of [`run_sleep_budget`], over an already-read value.
+///
+/// Why: pure so the parse is testable without mutating a process env shared with
+/// every other test in the binary.
+/// What: a trimmed, positive integer wins; unset, empty, `0`, and unparseable
+/// all fall back to [`RATE_LIMIT_SLEEP_BUDGET`]. A zero allowance would make the
+/// breaker latch on the first rate-limited response, so junk must never produce
+/// one.
+/// Test: `run_sleep_budget_honours_a_valid_override`,
+/// `run_sleep_budget_ignores_junk_overrides`.
+pub(crate) fn run_sleep_budget_from(value: Option<&str>) -> Duration {
+    value
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .filter(|&s| s > 0)
+        .map_or(RATE_LIMIT_SLEEP_BUDGET, Duration::from_secs)
+}
+
 /// Longest single wait honoured, however large `Retry-After` is.
 ///
 /// GitHub answers a drained primary limit with a reset up to an hour out.
@@ -227,6 +264,59 @@ impl FetchBudget {
 impl Default for FetchBudget {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// The ONE [`FetchBudget`] a `tga` run shares across every client it builds.
+///
+/// Why (#6565): #6084 gave each client a budget, which bounds a client and not
+/// a run. One `collect` builds several — org discovery, the PR sweep, the
+/// reviewer pass — so the 120 s ceiling was charged that many times over, and
+/// the wall-clock a run could spend asleep scaled with the number of clients
+/// rather than being the fixed bound the constant reads as. Handing every client
+/// a handle to the same budget is what makes the ceiling per-RUN, so a rate
+/// limit that latches during org discovery is already latched when the PR sweep
+/// starts instead of funding a fresh storm.
+///
+/// What: a cheap-to-clone handle over one shared [`FetchBudget`]. Cloning shares
+/// the allowance; constructing a new one does not, which is why construction is
+/// confined to a run's entry point and every other layer takes a handle.
+/// Test: `two_clients_draw_down_one_run_budget`,
+/// `separate_run_budgets_do_not_share_an_allowance`.
+#[derive(Clone)]
+pub struct RunBudget(std::sync::Arc<FetchBudget>);
+
+impl RunBudget {
+    /// A run budget with this run's allowance — see [`run_sleep_budget`].
+    pub fn new() -> Self {
+        Self::with_sleep_budget(run_sleep_budget())
+    }
+
+    /// A run budget with a caller-chosen allowance, so tests can exhaust it
+    /// without sleeping for two minutes.
+    pub fn with_sleep_budget(sleep_budget: Duration) -> Self {
+        Self(std::sync::Arc::new(FetchBudget::with_sleep_budget(
+            sleep_budget,
+        )))
+    }
+
+    /// The shared budget every call on this run charges against.
+    pub(crate) fn shared(&self) -> &FetchBudget {
+        &self.0
+    }
+}
+
+impl Default for RunBudget {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Debug for RunBudget {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RunBudget")
+            .field("sleep_budget", &self.0.sleep_budget)
+            .finish_non_exhaustive()
     }
 }
 

--- a/crates/trusty-git-analytics/src/collect/github/budget_tests.rs
+++ b/crates/trusty-git-analytics/src/collect/github/budget_tests.rs
@@ -150,3 +150,55 @@ fn the_shipped_bounds_are_the_documented_ones() {
     assert_eq!(RATE_LIMIT_SLEEP_BUDGET, Duration::from_secs(120));
     assert_eq!(MAX_RETRY_AFTER, Duration::from_secs(60));
 }
+
+/// Why (#6565): the allowance now bounds a whole run, so a long multi-org sweep
+/// that legitimately needs more than 120 s of total waiting needs a way to say
+/// so without a rebuild.
+/// What: a positive integer of seconds wins over the constant.
+/// Test: itself.
+#[test]
+fn run_sleep_budget_honours_a_valid_override() {
+    assert_eq!(run_sleep_budget_from(Some("300")), Duration::from_secs(300));
+    assert_eq!(run_sleep_budget_from(Some(" 45 ")), Duration::from_secs(45));
+}
+
+/// Why: a zero or unparseable value must never shorten the allowance to nothing
+/// — the breaker would latch on the first rate-limited response and the run
+/// would report itself throttled before it had waited at all.
+/// What: unset, empty, `0`, and junk all fall back to the constant.
+/// Test: itself.
+#[test]
+fn run_sleep_budget_ignores_junk_overrides() {
+    for value in [None, Some(""), Some("0"), Some("-5"), Some("soon")] {
+        assert_eq!(
+            run_sleep_budget_from(value),
+            RATE_LIMIT_SLEEP_BUDGET,
+            "{value:?} must fall back to the shipped allowance"
+        );
+    }
+}
+
+/// Why (#6565): sharing is what makes the ceiling per-run; cloning a handle must
+/// share the underlying allowance and constructing a new one must not.
+/// What: two clones of one `RunBudget` draw down together; two separately
+/// constructed ones do not.
+/// Test: itself.
+#[test]
+fn a_cloned_run_budget_shares_its_allowance() {
+    let run = RunBudget::with_sleep_budget(Duration::from_secs(3));
+    let clone = run.clone();
+
+    run.shared()
+        .reserve(Duration::from_secs(2), 429)
+        .expect("2s fits");
+    assert!(
+        clone.shared().reserve(Duration::from_secs(2), 429).is_err(),
+        "a clone shares the allowance, so only 1s remains"
+    );
+
+    let separate = RunBudget::with_sleep_budget(Duration::from_secs(3));
+    separate
+        .shared()
+        .reserve(Duration::from_secs(3), 429)
+        .expect("a separate run budget starts full");
+}

--- a/crates/trusty-git-analytics/src/collect/github/client.rs
+++ b/crates/trusty-git-analytics/src/collect/github/client.rs
@@ -7,7 +7,7 @@ use tracing::{debug, warn};
 use async_trait::async_trait;
 
 use crate::collect::errors::{CollectError, Result};
-use crate::collect::github::budget::{FetchBudget, MAX_PAGES};
+use crate::collect::github::budget::{RunBudget, MAX_PAGES};
 use crate::collect::github::repo_resolver::{build_http_client, parse_slug};
 use crate::collect::github::retry::retry_get;
 use crate::collect::github::types::{ApiPull, GitHubIssue, GitHubPrCommit, GitHubReview};
@@ -51,10 +51,16 @@ pub struct GitHubClient {
     /// client's credential (or lack of one) can see the primary repo — see
     /// [`Self::ensure_repo_visible`].
     repo_visible: tokio::sync::OnceCell<bool>,
-    /// #6084: the run-wide bound every call this client makes charges against.
-    /// One budget per client means the whole PR sweep — every page of every
-    /// repo, every review, every issue — shares one ceiling and one breaker.
-    budget: FetchBudget,
+    /// #6084: the bound every call this client makes charges against, so the
+    /// whole PR sweep — every page of every repo, every review, every issue —
+    /// shares one ceiling and one breaker.
+    ///
+    /// #6565: a HANDLE to the run's budget, not a budget of its own. A `collect`
+    /// builds several clients, so owning one charged the ceiling once per client
+    /// and let each start its own storm. Construction defaults to a fresh run
+    /// budget for standalone callers; a run hands its own in with
+    /// [`Self::with_run_budget`].
+    budget: RunBudget,
 }
 
 /// Compute the JSON-encoded `commit_shas` value for a PR row.
@@ -104,7 +110,7 @@ impl GitHubClient {
             repos: vec![(owner, repo)],
             api_base: GITHUB_API_BASE.to_string(),
             repo_visible: tokio::sync::OnceCell::new(),
-            budget: FetchBudget::new(),
+            budget: RunBudget::new(),
         })
     }
 
@@ -142,7 +148,7 @@ impl GitHubClient {
             repos,
             api_base: GITHUB_API_BASE.to_string(),
             repo_visible: tokio::sync::OnceCell::new(),
-            budget: FetchBudget::new(),
+            budget: RunBudget::new(),
         })
     }
 
@@ -170,8 +176,25 @@ impl GitHubClient {
             repos: Vec::new(),
             api_base: GITHUB_API_BASE.to_string(),
             repo_visible: tokio::sync::OnceCell::new(),
-            budget: FetchBudget::new(),
+            budget: RunBudget::new(),
         })
+    }
+
+    /// Charge this client's calls against `budget` instead of its own.
+    ///
+    /// Why (#6565): the sleep allowance is meant to bound a RUN. A `collect`
+    /// builds an org-discovery client, a PR client, and a reviewer client, so
+    /// while each owned its own budget the run could sleep the 120 s ceiling
+    /// once per client — and a rate limit that latched the breaker in one pass
+    /// left the next pass free to spiral again. Every client a run builds passes
+    /// through here so there is one ceiling and one breaker for the whole run.
+    /// What: replaces the budget handle with a clone of `budget`, which shares
+    /// the same underlying allowance, ledger, and breaker.
+    /// Test: `two_clients_draw_down_one_run_budget`.
+    #[must_use]
+    pub fn with_run_budget(mut self, budget: &RunBudget) -> Self {
+        self.budget = budget.clone();
+        self
     }
 
     /// Point every request at `base` instead of [`GITHUB_API_BASE`].
@@ -466,7 +489,7 @@ impl GitHubClient {
     /// against one run-wide ceiling (#6084).
     /// Test: covered indirectly by callers and by `wiremock` integration tests.
     async fn retry_request(&self, url: &str) -> Result<reqwest::Response> {
-        retry_get(&self.client, url, &self.budget).await
+        retry_get(&self.client, url, self.budget.shared()).await
     }
 
     /// Whether a paginated walk has reached [`MAX_PAGES`] and must stop.
@@ -489,7 +512,7 @@ impl GitHubClient {
             pages = MAX_PAGES,
             "GitHub listing hit the page cap; results for this scope are partial"
         );
-        self.budget.note_truncation(format!(
+        self.budget.shared().note_truncation(format!(
             "GitHub {endpoint} listing for {scope} stopped at the {MAX_PAGES}-page cap \
              ({} items); these results are PARTIAL",
             MAX_PAGES * PAGE_SIZE
@@ -502,7 +525,7 @@ impl GitHubClient {
     /// Empty when nothing was truncated. Non-empty means the data this client
     /// returned is incomplete and the caller must say so (#6084).
     pub(crate) fn fetch_notices(&self) -> Vec<String> {
-        self.budget.notices()
+        self.budget.shared().notices()
     }
 
     /// Fetch all reviews for a given pull request, paginating until exhausted.

--- a/crates/trusty-git-analytics/src/collect/github/client_tests.rs
+++ b/crates/trusty-git-analytics/src/collect/github/client_tests.rs
@@ -787,3 +787,105 @@ mod bounded_fetch_tests {
         );
     }
 }
+
+/// Why (#6565): #6084's budget bounds a CLIENT, and one `tga collect` builds
+/// several — org discovery, the PR sweep, the reviewer pass. Each owning its own
+/// allowance meant the 120 s ceiling was charged once per client, so the
+/// wall-clock a run could spend asleep scaled with the number of clients rather
+/// than being the fixed bound the constant reads as. This is the assertion that
+/// the allowance is now per-RUN.
+/// What: two clients built from one [`RunBudget`]; the first spends 2 s of a 3 s
+/// allowance and the second is refused a 2 s wait it would have been granted
+/// from a fresh budget. The breaker the refusal latches is then already latched
+/// for the first client too.
+/// Test: itself.
+#[test]
+fn two_clients_draw_down_one_run_budget() {
+    use std::time::Duration;
+
+    use crate::collect::github::budget::RunBudget;
+
+    let cfg = gh(Some("acme/widget"), None);
+    let run = RunBudget::with_sleep_budget(Duration::from_secs(3));
+    let first = GitHubClient::new_for_reviews(&cfg)
+        .expect("client builds")
+        .with_run_budget(&run);
+    let second = GitHubClient::new_for_reviews(&cfg)
+        .expect("client builds")
+        .with_run_budget(&run);
+
+    first
+        .budget
+        .shared()
+        .reserve(Duration::from_secs(2), 429)
+        .expect("2s fits in a 3s run allowance");
+
+    let refused = second.budget.shared().reserve(Duration::from_secs(2), 429);
+    assert!(
+        refused.is_err(),
+        "the second client must draw down the SAME allowance — 1s remains, not a fresh 3s"
+    );
+    assert!(
+        first.budget.shared().tripped_error().is_some(),
+        "a breaker latched by one client must already be latched for the other"
+    );
+}
+
+/// Why: the sharing must come from the handle a run passes down, not from
+/// clients being globally coupled — two independent runs (or a standalone
+/// caller like `tga profile`) must not exhaust each other's allowance.
+/// What: clients built from two different `RunBudget`s each get their own 3 s.
+/// Test: itself.
+#[test]
+fn separate_run_budgets_do_not_share_an_allowance() {
+    use std::time::Duration;
+
+    use crate::collect::github::budget::RunBudget;
+
+    let cfg = gh(Some("acme/widget"), None);
+    let first = GitHubClient::new_for_reviews(&cfg)
+        .expect("client builds")
+        .with_run_budget(&RunBudget::with_sleep_budget(Duration::from_secs(3)));
+    let second = GitHubClient::new_for_reviews(&cfg)
+        .expect("client builds")
+        .with_run_budget(&RunBudget::with_sleep_budget(Duration::from_secs(3)));
+
+    first
+        .budget
+        .shared()
+        .reserve(Duration::from_secs(3), 429)
+        .expect("3s fits");
+    second
+        .budget
+        .shared()
+        .reserve(Duration::from_secs(3), 429)
+        .expect("a separate run keeps its own allowance");
+}
+
+/// Why (#6565): a truncation one client records is a fact about the RUN, so the
+/// ledger has to be shared too — a caller reading notices off a different client
+/// than the one that hit the cap would report the results as complete.
+/// What: a page cap tripped on one client is visible in the other's
+/// `fetch_notices`.
+/// Test: itself.
+#[test]
+fn a_truncation_recorded_by_one_client_is_visible_to_the_other() {
+    use crate::collect::github::budget::RunBudget;
+
+    let cfg = gh(Some("acme/widget"), None);
+    let run = RunBudget::new();
+    let first = GitHubClient::new_for_reviews(&cfg)
+        .expect("client builds")
+        .with_run_budget(&run);
+    let second = GitHubClient::new_for_reviews(&cfg)
+        .expect("client builds")
+        .with_run_budget(&run);
+
+    assert!(second.fetch_notices().is_empty());
+    assert!(first.page_cap_reached("pulls", "acme/widget", super::MAX_PAGES + 1));
+    assert_eq!(
+        second.fetch_notices().len(),
+        1,
+        "the run's truncation ledger is shared, so either client reports it"
+    );
+}

--- a/crates/trusty-git-analytics/src/collect/github_pipeline.rs
+++ b/crates/trusty-git-analytics/src/collect/github_pipeline.rs
@@ -17,7 +17,7 @@ use futures::StreamExt as _;
 use tracing::{info, warn};
 
 use crate::collect::errors::CollectError;
-use crate::collect::github::budget::FetchBudget;
+use crate::collect::github::budget::RunBudget;
 use crate::collect::github::org_discovery::{discover_org_repos_within, effective_orgs};
 use crate::collect::github::repo_resolver::build_http_client;
 use crate::collect::github::reviewer_store::upsert_github_pr_reviewer;
@@ -40,7 +40,10 @@ use crate::collect::collector::CollectionStats;
 /// Test: the underlying discovery function is tested in
 /// `github::org_discovery::tests`; the serial aggregation here is
 /// exercised end-to-end by integration tests with `#[ignore]`.
-pub(super) async fn run_github_org_discovery(gh_cfg: &GithubConfig) -> Vec<(String, String)> {
+pub(super) async fn run_github_org_discovery(
+    gh_cfg: &GithubConfig,
+    budget: &RunBudget,
+) -> Vec<(String, String)> {
     let orgs = effective_orgs(gh_cfg.org.as_deref(), &gh_cfg.orgs);
     if orgs.is_empty() {
         return Vec::new();
@@ -58,12 +61,15 @@ pub(super) async fn run_github_org_discovery(gh_cfg: &GithubConfig) -> Vec<(Stri
 
     // #6084: one budget for the whole multi-org pass, so a rate limit that
     // terminates the first org does not let the second start the storm again.
-    let budget = FetchBudget::new();
+    // #6565: that budget is now the RUN's, not this pass's — the PR sweep and
+    // the reviewer pass charge the same allowance rather than each getting a
+    // fresh 120 s.
+    let budget = budget.shared();
     let mut all: Vec<(String, String)> = Vec::new();
     let mut seen = std::collections::HashSet::new();
     for org in &orgs {
         info!(org = %org, "discovering repositories for GitHub org");
-        match discover_org_repos_within(&http, org, &budget).await {
+        match discover_org_repos_within(&http, org, budget).await {
             Ok(repos) => {
                 info!(org = %org, count = repos.len(), "org discovery complete");
                 for p in repos {
@@ -109,6 +115,7 @@ pub(super) async fn fetch_and_store_github_reviewers(
     gh_cfg: &GithubConfig,
     force_refresh_prs: bool,
     stats: &mut CollectionStats,
+    budget: &RunBudget,
 ) {
     // Gather all GitHub PRs that need reviewer data.  When force_refresh_prs
     // is true we re-fetch all; otherwise we only fetch PRs that have no
@@ -157,7 +164,7 @@ pub(super) async fn fetch_and_store_github_reviewers(
     info!(count = prs.len(), "fetching GitHub PR reviews");
 
     // Build a reviews-only client (no dummy repo slugs needed).
-    let gh_client = match GitHubClient::new_for_reviews(gh_cfg) {
+    let gh_client = match GitHubClient::new_for_reviews(gh_cfg).map(|c| c.with_run_budget(budget)) {
         Ok(c) => c,
         Err(e) => {
             stats.fail_stage(format!("GitHub reviewer client init failed: {e}"));


### PR DESCRIPTION
Refs #6565

## Summary
`FetchBudget` bounded a client, and one `tga collect` builds several (org discovery, PR client, reviewer client), so the 120 s ceiling was charged once per client and a breaker latched in one client did not stop the next. `RunBudget` is a shared `Arc` handle over one `FetchBudget`; `CollectionPipeline` builds it once and hands it to every client via `GitHubClient::with_run_budget`, so a run has one allowance, one breaker, one truncation ledger. Standalone callers still get a fresh budget.

New knob: `TGA_RATE_LIMIT_SLEEP_BUDGET_SECS` (zero/junk fall back to the default). Behaviour change: a long multi-org sweep that previously got 120 s per client now gets 120 s total and may stop as throttled; the env var is the release valve.

## Test ladder
Rung 3 (localized to trusty-git-analytics).
- `cargo fmt --check` — exit 0
- `cargo clippy -p tga --all-targets -- -D warnings` — exit 0
- `cargo test -p tga --no-fail-fast` — 1407 passed, 0 failed, 7 ignored; 7 further targets, 0 failures
- Regression test that fails pre-fix: `collect::github::client::tests::two_clients_draw_down_one_run_budget`
- `check_line_cap.sh`, `check_changelog_fragment.sh`, `check_sld.sh`, `check_test_pointers.sh` — all OK

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools