### PR TITLE
fix: four nextest-unsafe test flakes — $HOME reads, pty census, embed-queue drain, proxy env domains

### DIFF
--- a/crates/trusty-common/changelog.d/6575-proxy-test-env-domains.md
+++ b/crates/trusty-common/changelog.d/6575-proxy-test-env-domains.md
@@ -1,0 +1,10 @@
+Fixed
+
+- `blocking_loopback_client_ignores_exported_http_proxy` no longer builds its
+  reqwest clients while another test is inside `setenv`/`unsetenv`. This binary
+  serializes environment mutation in three domains that do not exclude each
+  other — `#[serial]`'s default group, the named `dotenv_credential_env` group,
+  and `data_dir::ENV_LOCK` — and reqwest re-reads `HTTP_PROXY` / `http_proxy` /
+  `ALL_PROXY` at every client build, so holding one domain left the other two
+  free to republish the environment mid-test. Both proxy tests now hold the
+  named group and take `ENV_LOCK` (#6575).

--- a/crates/trusty-common/src/http_client.rs
+++ b/crates/trusty-common/src/http_client.rs
@@ -137,11 +137,33 @@ mod tests {
         addr
     }
 
-    /// Set `HTTP_PROXY`, run `body`, restore the previous value.
+    /// Set `HTTP_PROXY`, run `body`, restore the previous value, and hold
+    /// `ENV_LOCK` for the whole call (#6575).
     ///
-    /// SAFETY: every caller is `#[serial]`, so no other test in this binary is
-    /// reading or writing the environment concurrently.
+    /// Why more than one domain: this binary serializes environment mutation in
+    /// three domains that do not exclude each other — `#[serial]`'s default
+    /// group, the named `#[serial(dotenv_credential_env)]` group
+    /// (`credentials`, `inference`, `memory_core`), and `data_dir::ENV_LOCK`, a
+    /// plain mutex that excludes only the tests that take it
+    /// (`daemon_addr.rs`'s own comment records that gap). `reqwest` reads
+    /// `HTTP_PROXY` / `http_proxy` / `ALL_PROXY` through `std::env::var_os` at
+    /// every client build
+    /// (`hyper_util::client::proxy::matcher::Builder::from_env`, no cache), so
+    /// a proxy test holding one domain still builds its clients while a test in
+    /// another domain is inside `setenv`/`unsetenv` — and
+    /// `credentials::dotenv`'s `load_env_from_path` republishes arbitrary keys
+    /// in bulk. The callers moved to the `dotenv_credential_env` key, which is
+    /// where every bulk env writer lives, and this takes `ENV_LOCK`. The default
+    /// group is what they gave up, and it costs nothing: its env writers
+    /// (`bm25`, `catchup`, `daemon_token`) each set one named variable of their
+    /// own, none of them a proxy variable.
+    ///
+    /// SAFETY: the caller holds every domain above, so no other test in this
+    /// binary is reading or writing the environment concurrently.
     fn with_http_proxy<T>(value: &str, body: impl FnOnce() -> T) -> T {
+        let _env = crate::data_dir::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let previous = std::env::var("HTTP_PROXY").ok();
         unsafe { std::env::set_var("HTTP_PROXY", value) };
         let out = body();
@@ -164,14 +186,15 @@ mod tests {
     /// [`loopback_client`] must still reach the stub.
     /// What: exports `HTTP_PROXY` pointing at a released ephemeral port, builds
     /// both clients under it, and issues the same loopback GET with each.
-    /// `#[serial]` because `HTTP_PROXY` is process-global.
+    /// Serialized because `HTTP_PROXY` is process-global — both serial keys,
+    /// per [`with_http_proxy`] (#6575).
     /// Test: This is the test.
     ///
     /// If a future reqwest exempts loopback from proxies, the first assertion
     /// becomes obsolete and should be deleted — `.no_proxy()` itself must stay,
     /// because this crate cannot pin every consumer's reqwest patch level.
     #[tokio::test]
-    #[serial]
+    #[serial(dotenv_credential_env)]
     async fn loopback_client_ignores_exported_http_proxy() {
         let addr = stub_server().await;
         let url = format!("http://{addr}/health");
@@ -209,7 +232,7 @@ mod tests {
     /// Test: This is the test.
     #[cfg(feature = "blocking-http")]
     #[tokio::test]
-    #[serial]
+    #[serial(dotenv_credential_env)]
     async fn blocking_loopback_client_ignores_exported_http_proxy() {
         let addr = stub_server().await;
         let url = format!("http://{addr}/health");

--- a/crates/trusty-mpm/changelog.d/6580-home-races-in-session-assets-and-rpc-tmux.md
+++ b/crates/trusty-mpm/changelog.d/6580-home-races-in-session-assets-and-rpc-tmux.md
@@ -1,0 +1,9 @@
+Fixed
+
+- Two `cargo test -p trusty-mpm` cases no longer read whatever `$HOME` a sibling
+  test happened to have set. `session_plan_under_matches_session_plan_at_home`
+  resolved its two halves through two separate `$HOME` reads, and
+  `rpc_tmux_snapshot_unknown_session_reports_a_coded_error` compared a refusal
+  whose text quotes the live `$HOME`; a test moving `$HOME` between the reads
+  failed either one while proving nothing about the code under test. Both now
+  pin `$HOME` at a tempdir and join the crate-wide serial group (#6580).

--- a/crates/trusty-mpm/src/core/session_assets.rs
+++ b/crates/trusty-mpm/src/core/session_assets.rs
@@ -283,8 +283,18 @@ mod tests {
     /// #5040: the explicit-base form must be the same resolution
     /// [`session_plan`] performs, so a test built on `session_plan_under`
     /// proves what production actually does.
+    ///
+    /// #6580: both halves read `$HOME` — `session_plan` through
+    /// `FrameworkPaths::default()` and the explicit half through
+    /// `FrameworkPaths::home_base()` — in two separate calls. A sibling test
+    /// moving `$HOME` between them made the two halves resolve under different
+    /// roots, so the comparison failed while proving nothing about the two
+    /// forms. [`fake_home`] pins `$HOME` for the whole body and
+    /// `#[serial_test::serial]` keeps every other `$HOME` mover out.
     #[test]
+    #[serial_test::serial]
     fn session_plan_under_matches_session_plan_at_home() {
+        let (_home, _guard) = fake_home();
         let record = make_record(
             Some(PathBuf::from("/some/workspace")),
             PathBuf::from("/some/cwd"),

--- a/crates/trusty-mpm/src/daemon/rpc/core_tests.rs
+++ b/crates/trusty-mpm/src/daemon/rpc/core_tests.rs
@@ -77,6 +77,38 @@ fn rpc_router(state: &Arc<DaemonState>) -> RpcRouter {
     register(RpcRouter::new(), state)
 }
 
+/// RAII guard restoring `$HOME` on drop, including on a panic-driven unwind —
+/// mirrors `core::session_assets::tests::HomeGuard`.
+struct HomeGuard(Option<std::ffi::OsString>);
+
+impl Drop for HomeGuard {
+    fn drop(&mut self) {
+        // SAFETY: every caller is `#[serial_test::serial]`, so no other test
+        // thread reads or writes the environment concurrently.
+        match self.0.take() {
+            Some(v) => unsafe { std::env::set_var("HOME", v) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+    }
+}
+
+/// Pin `$HOME` at a fresh tempdir for the guard's lifetime (#6580).
+///
+/// Why: `core::host_state_gate` embeds the LIVE `$HOME` in the refusal it hands
+/// every tmux route, so a test that reads that refusal twice gets two different
+/// strings whenever a sibling moves `$HOME` between the reads. Pinning makes the
+/// classification — and therefore the message — the same for both reads. Both
+/// returned values must stay alive for the test's body: dropping the `TempDir`
+/// removes the directory `$HOME` names.
+/// Callers MUST be tagged `#[serial_test::serial]`.
+fn pinned_home() -> (TempDir, HomeGuard) {
+    let home = tempfile::tempdir().expect("temp dir for a pinned $HOME");
+    let prior = std::env::var_os("HOME");
+    // SAFETY: caller is `#[serial_test::serial]`.
+    unsafe { std::env::set_var("HOME", home.path()) };
+    (home, HomeGuard(prior))
+}
+
 /// Drive one HTTP request through the real daemon router and decode the answer.
 ///
 /// Why the real router rather than calling a handler directly: the parity claim
@@ -698,9 +730,20 @@ async fn rpc_claude_config_apply_unknown_recommendation_reports_not_found() {
 /// the machine rather than on the transport. What must hold either way is that
 /// the socket's code is the code the HTTP status maps to and its message is the
 /// HTTP body's message — which is the whole of requirement 3.
+///
+/// Why the pinned `$HOME` and the serial group (#6580): the refusal both
+/// transports carry comes from `core::host_state_gate`, whose message names the
+/// LIVE `$HOME` ("$HOME is /var/folders/… but this user's real home is
+/// /Users/…"). Several tests in this binary move `$HOME` process-wide, and one
+/// landing between the two calls below left the HTTP read and the socket read
+/// quoting different homes — the verbatim-message assertion then failed while
+/// proving nothing about the transports. `#[serial_test::serial]` keeps those
+/// tests out, and [`pinned_home`] fixes what the gate classifies for both reads.
 /// Test: this function IS the test.
+#[serial_test::serial]
 #[tokio::test]
 async fn rpc_tmux_snapshot_unknown_session_reports_a_coded_error() {
+    let (_home, _home_guard) = pinned_home();
     let (state, _dir) = hermetic();
 
     let (status, body) = http(

--- a/crates/trusty-mpm/src/daemon/rpc/core_tests.rs
+++ b/crates/trusty-mpm/src/daemon/rpc/core_tests.rs
@@ -10,7 +10,7 @@
 //!
 //! ## The comparison allowlist
 //!
-//! Three things are dropped before comparing, all on `mpm.doctor`, and all
+//! Five things are dropped before comparing, all on `mpm.doctor`, and all
 //! because the DAEMON varies them between two calls of the same code rather
 //! than because the transports disagree:
 //!
@@ -27,8 +27,12 @@
 //!   session record(s), 59773 byte(s)" on one call and "44 … 60950" on the
 //!   next, because a concurrent managed session writes that file between the two
 //!   reads (#6490).
+//! - the `pty_headroom` check's `message`, which reports the machine's live
+//!   pseudo-terminal census — "82 of 511 pseudo-terminals allocated" on one call
+//!   and "83 of 511" on the next, because any process on the box opens or closes
+//!   a pty between the two reads (#6577).
 //!
-//! All three probes sample host state the daemon re-reads per call, which is
+//! All four probes sample host state the daemon re-reads per call, which is
 //! what makes their messages the only host-sampled strings in the report. Their
 //! `name` and `status` are still compared, so a check that vanished or changed
 //! verdict between the transports still fails — see
@@ -460,9 +464,14 @@ async fn parity_doctor_agrees_across_transports() {
 }
 
 /// The doctor checks whose `message` samples live host state, by name (#6358,
-/// #6490).
+/// #6490, #6577).
 ///
-/// Why exactly these three: each puts live host state the daemon re-reads per
+/// The membership rule, so the next such check need not flake first: a check
+/// belongs here when its message embeds a number or a name it RE-SAMPLES FROM
+/// THE HOST on every call. A message built from config on disk, or from the
+/// daemon's own state, does not.
+///
+/// Why exactly these four: each puts live host state the daemon re-reads per
 /// call into its message. `worktree_disk` reports how far it got against a
 /// 3-second deadline ("6.2 GiB … 268 worktree(s) went unmeasured" on one call,
 /// "6.8 GiB … 267" on the next) and `worktrees` reports the reconciled
@@ -471,7 +480,11 @@ async fn parity_doctor_agrees_across_transports() {
 /// worktree between this test's two calls. `session_store` reports the record
 /// count and byte length of `sessions.json` ("43 session record(s), 59773
 /// byte(s)" against "44 … 60950"), which change whenever a concurrent managed
-/// session writes that file between the two reads (#6490). All three are the
+/// session writes that file between the two reads (#6490). `pty_headroom`
+/// reports a live census of allocated pseudo-terminals ("82 of 511
+/// pseudo-terminals allocated" against "83 of 511"), which changes whenever any
+/// process on this machine opens or closes a pty between the two reads (#6577).
+/// All four are the
 /// PROBE varying, not the transports disagreeing. Only the MESSAGE is host-
 /// sampled: each check's `status` is a stable verdict (`session_store` stays
 /// `Ok` while only its counts churn), so it is still compared — a store that
@@ -481,9 +494,14 @@ async fn parity_doctor_agrees_across_transports() {
 /// What: the names [`blank_host_sampled_messages`] blanks.
 /// Test: [`parity_doctor_agrees_across_transports`],
 /// [`session_store_message_is_excluded_from_parity_but_its_status_is_not`].
-const HOST_SAMPLED_MESSAGE_CHECKS: &[&str] =
+const HOST_SAMPLED_MESSAGE_CHECKS: &[&str] = &[
+    "worktree_disk",
+    "worktrees",
     // #6490: session_store's message samples sessions.json's live record count.
-    &["worktree_disk", "worktrees", "session_store"];
+    "session_store",
+    // #6577: pty_headroom's message samples this machine's live pty census.
+    "pty_headroom",
+];
 
 /// Blank each [`HOST_SAMPLED_MESSAGE_CHECKS`] message, keeping name and status.
 ///
@@ -539,6 +557,8 @@ fn session_store_message_is_excluded_from_parity_but_its_status_is_not() {
                 {"name": "worktree_disk", "status": "ok", "message": "6.2 GiB measured"},
                 {"name": "worktrees", "status": "ok", "message": "14 live, 265 not reclaimable"},
                 {"name": "session_store", "status": session_store_status, "message": session_store_message},
+                // #6577: present so the presence assertion is satisfied.
+                {"name": "pty_headroom", "status": "ok", "message": "82 of 511 pseudo-terminals allocated"},
             ]
         })
     };

--- a/crates/trusty-search/src/service/reindex/defer_embed_queue_tests.rs
+++ b/crates/trusty-search/src/service/reindex/defer_embed_queue_tests.rs
@@ -24,6 +24,32 @@ fn bare_handle(id: &str) -> StdArc<IndexHandle> {
     ))
 }
 
+/// Wait until [`QUEUE_DEPTH`] is back to zero, i.e. every job this test enqueued
+/// has left the shared heap AND decremented the counter (#6574).
+///
+/// Why an end-of-test wait rather than nothing: `queue_heap()` and `QUEUE_DEPTH`
+/// are process-global, and `wait_for_turn` is a `tokio::spawn`ed task on THIS
+/// test's runtime. A `#[tokio::test]` drops its runtime the moment the body
+/// returns, so a task still parked in the claim loop is killed with its job
+/// still on the heap and still counted — permanently, for the rest of the
+/// binary. Settling a handle's `semantic` stage is NOT that signal: the stage is
+/// written inside `run_embed_catch_up`, several awaits BEFORE the
+/// `QUEUE_DEPTH.fetch_sub` that follows it. A leftover job then blocks
+/// `best_pending_seq` for every larger job enqueued afterwards, which is how
+/// `embed_pause_tests`'s depth assertions came to read "the deferred-embed queue
+/// never emptied; depth is 1" for work that was never theirs.
+async fn wait_for_a_drained_queue(what: &str) {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(20);
+    while deferred_embed_queue_depth() > 0 {
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "{what}: the deferred-embed queue never drained; depth is {}",
+            deferred_embed_queue_depth()
+        );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
 /// Issue #3748: [`best_pending_seq`] must identify the job with the
 /// SMALLEST `chunk_count` (not the natural max-heap order).
 ///
@@ -268,7 +294,12 @@ fn same_burst_never_reverts_to_arrival_order_even_once_max_wait_has_elapsed() {
 /// chunk count is 1) then small (3), waits for both to reach a terminal
 /// stage, and asserts the RECORDED order is `[small, big]`.
 /// Test: this IS the test.
+///
+/// #6574: `#[serial_test::serial]` because this drives the process-global
+/// queue that `embed_pause_tests` reads the depth of, and that module's cases
+/// are already in the same default group.
 #[tokio::test]
+#[serial_test::serial]
 async fn enqueue_drains_smallest_first_end_to_end() {
     use crate::core::chunker::{ChunkType, RawChunk};
     use crate::core::embed::Embedder;
@@ -381,6 +412,8 @@ async fn enqueue_drains_smallest_first_end_to_end() {
          embed call BEFORE the bigger job (enqueued FIRST) — proves dispatch \
          honours size order, not arrival order"
     );
+    // Leave the process-global queue as this test found it (#6574).
+    wait_for_a_drained_queue("this test's own two jobs").await;
 }
 
 /// Issue #3748 slice A review finding 1: the full async dispatch
@@ -412,7 +445,12 @@ async fn enqueue_drains_smallest_first_end_to_end() {
 /// waits for every handle to leave Pending/InProgress, and asserts the
 /// giant is the LAST id in the recorded order.
 /// Test: this IS the test.
+///
+/// #6574: `#[serial_test::serial]` for the same reason as
+/// [`enqueue_drains_smallest_first_end_to_end`] — 27 jobs on the process-global
+/// queue is the largest cross-test disturbance in this binary.
 #[tokio::test]
+#[serial_test::serial]
 async fn burst_of_many_jobs_still_dispatches_the_giant_last_end_to_end() {
     use crate::core::chunker::{ChunkType, RawChunk};
     use crate::core::embed::Embedder;
@@ -538,4 +576,6 @@ async fn burst_of_many_jobs_still_dispatches_the_giant_last_end_to_end() {
          arrival, even under non-instant simulated embed durations — recorded \
          order={recorded:?}"
     );
+    // Leave the process-global queue as this test found it (#6574).
+    wait_for_a_drained_queue("this test's own 27 jobs").await;
 }

--- a/crates/trusty-search/src/service/reindex/embed_pause_tests.rs
+++ b/crates/trusty-search/src/service/reindex/embed_pause_tests.rs
@@ -66,7 +66,18 @@ fn write_fixture(root: &std::path::Path) {
 }
 
 /// Run one reindex to completion on `handle`, through the real pipeline.
+///
+/// Why the counter bump (#6574): `run_reindex` decrements
+/// `BACKGROUND_QUEUE_DEPTH` once it holds the background permit, and the only
+/// matching increment lives in `orchestrator::spawn_reindex_with_cleanup`, which
+/// this helper deliberately bypasses to run the pass inline. Calling
+/// `run_reindex` directly therefore drove the process-global counter BELOW zero,
+/// wrapping it to `usize::MAX`; `tests::background_reindex_queue_depth_counts_waiting_tasks`
+/// then panicked with "attempt to add with overflow" on `initial + 3` in every
+/// run of this module. Mirroring the orchestrator's increment keeps the pairing
+/// balanced without changing which semaphore the pass takes.
 async fn reindex(handle: &Arc<IndexHandle>) {
+    super::BACKGROUND_QUEUE_DEPTH.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let progress = Arc::new(ReindexProgress::new());
     super::runner::run_reindex(
         Arc::clone(handle),


### PR DESCRIPTION
Refs #6580
Refs #6577
Refs #6574
Refs #6575

## Summary
One commit per issue, each a mechanism fix with a 10× soak — no `#[ignore]`, no timeout stretch, no weakened assertion.

- #6580 (trusty-mpm): two tests read `$HOME` twice and compared the results; `host_state_gate.rs:121` quotes the live `$HOME` into the refusal text. Both now pin `$HOME` to a tempdir and join the crate-wide serial group — the pin is what holds under nextest, where `#[serial]` serializes nothing.
- #6577 (trusty-mpm): `pty_headroom`'s message embeds a live pty census; it joins `HOST_SAMPLED_MESSAGE_CHECKS` (message blanked, name and status still compared, row kept). The allowlist now states its membership rule.
- #6574 (trusty-search): `QUEUE_DEPTH` and the job heap are process-global and `wait_for_turn` is spawned on the enqueuing test's runtime; two direct-`enqueue` tests returned before the `fetch_sub` at `defer_embed_queue.rs:395`, leaving a phantom job that blocks every larger job after it. They now join the `embed_pause_tests` serial group and wait for depth zero. Same commit: `embed_pause_tests::reindex` calls `run_reindex` directly, which decrements `BACKGROUND_QUEUE_DEPTH` (`runner.rs:78`) with no matching increment, wrapping the counter and panicking `background_reindex_queue_depth_counts_waiting_tasks` with "attempt to add with overflow" — reproduced 10/10 on origin/main, 0/10 after.
- #6575 (trusty-common): env mutation is serialized in three non-excluding domains (`#[serial]` default, `#[serial(dotenv_credential_env)]`, `data_dir::ENV_LOCK`); the proxy tests held one while `credentials::dotenv` republished keys from another. Both proxy tests move to `dotenv_credential_env` and `with_http_proxy` takes `ENV_LOCK`. Port-reuse and cached-proxy-map hypotheses were measured and ruled out.

## Test ladder
Rung 2 (test-only stabilization across three crates).
- `cargo fmt --check` — exit 0
- `cargo clippy -p trusty-mpm|trusty-search|trusty-common --all-targets -- -D warnings` — exit 0 each
- `cargo test -p trusty-common --features blocking-http,credentials --no-fail-fast` — 488 passed, 0 failed, 6 ignored (+7 integration targets ok)
- `cargo test -p trusty-search --no-fail-fast` — 1959 passed, 0 failed, 1 ignored (+455, 3, 3, … ok)
- `cargo test -p trusty-mpm --no-fail-fast` — 5738 passed, 0 failed, 8 ignored (+1916, 1916, 103, … ok)
- Soaks, 10/10 each: `session_plan_under_matches_session_plan_at_home`, `rpc_tmux_snapshot_unknown_session_reports_a_coded_error`, `parity_doctor_agrees_across_transports`, `shutdown_drain_releases_a_parked_embed_pass`, `blocking_loopback_client_ignores_exported_http_proxy`; whole `service::reindex::` module 10×: 175 passed/1 failed → 176 passed/0 failed
- `check_line_cap.sh`, `check_changelog_fragment.sh`, `check_teardown_guard.sh`, `check_sld.sh`, `check_test_pointers.sh` — all exit 0

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools