### PR TITLE
fix(trusty-mpm): worktree prune reads the harness agent-lifetime lock instead of refusing on an empty registry

### DIFF
--- a/crates/trusty-mpm/changelog.d/6561-prune-agent-worktrees.md
+++ b/crates/trusty-mpm/changelog.d/6561-prune-agent-worktrees.md
@@ -1,0 +1,11 @@
+Fixed
+
+- `tm session prune-worktrees --merged-prs` now reclaims the harness's own
+  `.claude/worktrees/agent-*` worktrees. It reads git's lock reason, which tells
+  the harness's agent-lifetime lock from an operator's `git worktree lock`: a
+  tree the harness still holds is spared and reported as agent-owned instead of
+  being dropped silently, and a tree the harness has released is reclaimable
+  even when the delegation registry — rebuilt empty at every daemon restart —
+  has never heard of its agent. The merged-PR and unsaved-work gates are
+  unchanged, so an unmerged branch or an uncommitted file still refuses, and a
+  tree carrying no ownership sentinel at all stays unreclaimable (#6561).

--- a/crates/trusty-mpm/src/session_manager/worktree_git_fixture.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_git_fixture.rs
@@ -317,6 +317,30 @@ impl GitWorktreeFixture {
         );
     }
 
+    /// Lock `wt` the way the Claude Code HARNESS locks an agent's worktree
+    /// (#6561).
+    ///
+    /// Why: the harness's agent-lifetime lock and an operator's standing veto
+    /// are the same `locked` flag and differ only in the reason string, so a
+    /// test that used [`Self::lock_worktree`] would prove nothing about the
+    /// distinction. Reproducing the real reason is the whole fixture — this is
+    /// the exact shape observed on this machine (git 2.54.0).
+    /// What: `git worktree lock --reason "claude agent <id> (pid … start …)"`.
+    /// Test: `scan_separates_a_harness_agent_lock_from_an_operator_lock`,
+    /// `survey_discloses_a_harness_locked_agent_worktree`.
+    pub(crate) fn harness_lock_worktree(&self, wt: &Path, agent_id: &str) {
+        git_ok(
+            &self.repo,
+            &[
+                "worktree",
+                "lock",
+                "--reason",
+                &format!("claude agent {agent_id} (pid 4242 start Mon Sep 1 20:33:51 2026)"),
+                wt.to_str().expect("utf8 worktree path"),
+            ],
+        );
+    }
+
     /// Create a bare `.base` clone inside the checkout and register a worktree
     /// in ITS registry (#4207).
     ///

--- a/crates/trusty-mpm/src/session_manager/worktree_ownership.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_ownership.rs
@@ -228,7 +228,7 @@ pub(crate) enum SentinelOwner {
 /// [`Unknown`](Self::Unknown) — the registry holds no delegation naming this
 /// agent, so its silence proves nothing.
 /// Test: `classify_blocks_a_live_agents_worktree`,
-/// `classify_blocks_an_agent_the_registry_never_heard_of`,
+/// `classify_blocks_an_agent_the_harness_still_holds_after_a_restart`,
 /// `classify_allows_a_finished_agents_merged_worktree`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum AgentDelegationState {

--- a/crates/trusty-mpm/src/session_manager/worktree_reclaim.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_reclaim.rs
@@ -40,7 +40,7 @@ use super::worktree_ownership::{
     AgentDelegationState, AgentWorktreeOwner, SentinelOwner, is_harness_agent_worktree,
     read_sentinel_owner,
 };
-use super::worktree_registry::Admission;
+use super::worktree_registry::{Admission, HarnessLockState, harness_lock_state};
 use super::worktree_safety::DirtyWorktree;
 
 /// Resolves the delegation registry's answer for the agent a sentinel names.
@@ -528,11 +528,21 @@ pub(crate) fn tm_provisioned(path: &Path) -> bool {
 /// parse the orphan path uses, not a second one — and refuses on two answers.
 ///
 /// 1. [`SentinelOwner::Agent`] whose agent the registry calls
-///    [`Live`](AgentDelegationState::Live) or
-///    [`Unknown`](AgentDelegationState::Unknown). `Unknown` refuses because the
-///    delegation map is rebuilt empty at every daemon boot: after a restart it
-///    reports nothing for an agent that is still working, and an unanswerable
-///    liveness question must never resolve to "free" (ADR-0045).
+///    [`Live`](AgentDelegationState::Live).
+///
+///    [`Unknown`](AgentDelegationState::Unknown) used to refuse outright,
+///    because the delegation map is rebuilt empty at every daemon boot: after a
+///    restart it reports nothing for an agent that is still working, and an
+///    unanswerable liveness question must never resolve to "free" (ADR-0045).
+///    That reasoning is intact; what changed in #6561 is that the question is no
+///    longer unanswerable. Git holds a second, DURABLE record of the same fact:
+///    the Claude Code harness locks an agent's worktree for the life of that
+///    agent and releases the lock when the agent ends, and that lock is a file
+///    under `.git/worktrees/<id>/` which no daemon writes and no daemon restart
+///    clears. So an `Unknown` registry answer now consults
+///    [`harness_lock_state`]: `Released` is POSITIVE evidence the harness let go
+///    and permits; `Held` and `Undeterminable` both refuse. Two silences still
+///    do not make an answer — only a positive `Released` does.
 /// 2. [`SentinelOwner::Unknown`] for ANY path inside the harness agent store
 ///    ([`is_harness_agent_worktree`]) — whether the sentinel is unreadable or
 ///    absent entirely. Undeterminable, not absent.
@@ -566,12 +576,14 @@ pub(crate) fn tm_provisioned(path: &Path) -> bool {
 /// this module was written to reclaim — permanently unreclaimable, which is the
 /// opposite failure and not #5661's.
 /// Test: `classify_blocks_a_live_agents_worktree`,
-/// `classify_blocks_an_agent_the_registry_never_heard_of`,
+/// `classify_blocks_an_agent_the_harness_still_holds_after_a_restart`,
 /// `classify_allows_a_finished_agents_merged_worktree`,
 /// `classify_blocks_an_agent_store_worktree_with_an_unreadable_sentinel`,
 /// `classify_leaves_a_session_owned_worktree_alone`,
 /// `an_unattributed_agent_store_worktree_is_never_reclaimable`,
-/// `an_unreadable_agent_sentinel_still_blocks_an_agent_store_worktree`.
+/// `an_unreadable_agent_sentinel_still_blocks_an_agent_store_worktree`,
+/// `classify_allows_a_merged_agent_tree_the_harness_released`,
+/// `classify_blocks_an_agent_tree_git_cannot_be_asked_about`.
 pub(crate) fn agent_ownership_blocks(
     path: &Path,
     agent_state: AgentStateProbe<'_>,
@@ -583,13 +595,22 @@ pub(crate) fn agent_ownership_blocks(
                  still working in this tree (#5661)",
                 owner.agent_id
             )),
-            AgentDelegationState::Unknown => Some(format!(
-                "owned by dispatched agent {} and the delegation registry holds no record of \
-                 that agent — a registry rebuilt empty at daemon boot cannot tell a finished \
-                 agent from a working one, so its silence is undeterminable, not absent \
-                 (#5661, ADR-0045)",
-                owner.agent_id
-            )),
+            // #6561: the registry's silence is not the last word — ask git.
+            AgentDelegationState::Unknown => match harness_lock_state(path) {
+                HarnessLockState::Released => None,
+                HarnessLockState::Held => Some(format!(
+                    "owned by dispatched agent {} and git still reports the harness's \
+                     agent-lifetime lock on this worktree (#6561)",
+                    owner.agent_id
+                )),
+                HarnessLockState::Undeterminable => Some(format!(
+                    "owned by dispatched agent {} — the delegation registry holds no record of \
+                     that agent, and git could not be asked whether the harness still holds the \
+                     worktree. Two silences are not an answer: undeterminable, not absent \
+                     (#5661, #6561, ADR-0045)",
+                    owner.agent_id
+                )),
+            },
             AgentDelegationState::Ended => None,
         },
         // #6561 critic round: absent and unreadable are BOTH undeterminable
@@ -704,7 +725,7 @@ impl ReclaimVerdict {
 /// `classify_blocks_live_session_workspace`,
 /// `classify_blocks_a_worktree_trusty_mpm_does_not_own`,
 /// `classify_blocks_a_live_agents_worktree`,
-/// `classify_blocks_an_agent_the_registry_never_heard_of`,
+/// `classify_blocks_an_agent_the_harness_still_holds_after_a_restart`,
 /// `classify_blocks_an_agent_store_worktree_with_an_unreadable_sentinel`,
 /// `classify_records_an_agent_refusal_as_its_own_verdict_kind`,
 /// `classify_blocks_open_pr`,
@@ -722,6 +743,13 @@ pub(crate) fn classify(
     agent_state: AgentStateProbe<'_>,
 ) -> ReclaimVerdict {
     // Gate 1 (#2919): git decides existence and eligibility, per ADR-0023.
+    // #6561: a harness agent lock is a refusal the operator must be TOLD about
+    // — it means an agent is working in that tree — so it leaves gate 1 as its
+    // own verdict kind and reaches `ReclaimSurvey::agent_owned`. Every other
+    // non-admitted verdict is an ordinary block, as before.
+    if admission == Admission::HarnessAgentLock {
+        return ReclaimVerdict::blocked_by_agent(admission.reason());
+    }
     if admission != Admission::Admitted {
         return ReclaimVerdict::blocked(admission.reason());
     }

--- a/crates/trusty-mpm/src/session_manager/worktree_reclaim_sweep_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_reclaim_sweep_tests.rs
@@ -16,7 +16,7 @@
 //! fails if its re-check is removed.
 
 use std::cell::RefCell;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use super::*;
 use crate::session_manager::worktree_git_fixture::GitWorktreeFixture;
@@ -969,5 +969,182 @@ fn survey_separates_deadline_skips_from_lookup_failures() {
     assert!(
         unresolved.pr_state_unknown > 0,
         "but the lookup resolved nothing"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The harness agent store, end to end (#6561)
+// ---------------------------------------------------------------------------
+
+/// Add a `.claude/worktrees/agent-<name>` worktree carrying an agent sentinel,
+/// landed and pushed — the shape Claude Code's `isolation: "worktree"` leaves
+/// behind when its agent has ended (#6561).
+///
+/// The harness lock is deliberately NOT applied: the harness releases it when
+/// the agent ends, and that release is the evidence the sweep now reads.
+fn released_agent_worktree(fx: &GitWorktreeFixture, name: &str) -> PathBuf {
+    let path = fx.add_worktree_at(&fx.repo.join(".claude").join("worktrees"), name);
+    land(&path);
+    GitWorktreeFixture::stamp_agent_sentinel(&path, name);
+    path
+}
+
+/// A registry that has never heard of the agent — what every registry answers
+/// after a daemon restart, and the answer that made the whole agent store
+/// unreclaimable (#6561).
+fn restarted_registry(_: &AgentWorktreeOwner) -> AgentDelegationState {
+    AgentDelegationState::Unknown
+}
+
+/// The issue's acceptance, dry-run half: an `agent-*` worktree whose branch's
+/// PR merged is LISTED as a reclaimable candidate (#6561).
+///
+/// Fails before #6561: the candidate is blocked at gate 4 with "the delegation
+/// registry holds no record of that agent", `reclaimable` is 0, and the run
+/// prints the reported `0 of 0 measured`.
+#[test]
+fn survey_offers_a_merged_agent_worktree_the_harness_released() {
+    let fx = GitWorktreeFixture::new();
+    let path = released_agent_worktree(&fx, "agent-6561e2e");
+    let out = reclaim_with_probes(
+        &fx.repos_root,
+        &FreshProbes {
+            agent_state: &restarted_registry,
+            in_use_now: &|| Some(Vec::new()),
+            index_for: &|_: &Path| merged_index("wt/agent-6561e2e", 6561),
+        },
+        ReclaimMode::Report,
+    );
+    let found = out
+        .survey
+        .candidates
+        .iter()
+        .find(|c| c.path == path)
+        .unwrap_or_else(|| panic!("survey missed {}", path.display()));
+    assert_eq!(found.verdict, ReclaimVerdict::Reclaimable { pr: 6561 });
+    assert_eq!(out.survey.reclaimable, 1, "outcome: {out:?}");
+    assert!(
+        out.removed.is_empty() && path.exists(),
+        "a dry run must delete nothing"
+    );
+}
+
+/// The issue's acceptance, real-run half: the same worktree is RECLAIMED
+/// (#6561).
+///
+/// Fails before #6561: `out.removed` is empty and the directory is still there.
+#[test]
+fn reclaim_reclaims_a_merged_agent_worktree_the_harness_released() {
+    let fx = GitWorktreeFixture::new();
+    let path = released_agent_worktree(&fx, "agent-6561reclaim");
+    let out = reclaim_with_probes(
+        &fx.repos_root,
+        &FreshProbes {
+            agent_state: &restarted_registry,
+            in_use_now: &|| Some(Vec::new()),
+            index_for: &|_: &Path| merged_index("wt/agent-6561reclaim", 6562),
+        },
+        ReclaimMode::Remove,
+    );
+    assert_eq!(out.removed, vec![path.clone()], "outcome: {out:?}");
+    assert!(!path.exists(), "the directory must be gone");
+    assert!(out.removal_failed.is_empty(), "outcome: {out:?}");
+}
+
+/// An agent worktree whose branch's PR is still OPEN is never a candidate
+/// (#6561).
+///
+/// The permit above must not have widened past the landing-evidence gate: this
+/// asserts the refusal is gate 5's, not the ownership gate's.
+#[test]
+fn reclaim_never_offers_an_agent_worktree_whose_pr_is_open() {
+    let fx = GitWorktreeFixture::new();
+    let path = released_agent_worktree(&fx, "agent-6561open");
+    let out = reclaim_with_probes(
+        &fx.repos_root,
+        &FreshProbes {
+            agent_state: &restarted_registry,
+            in_use_now: &|| Some(Vec::new()),
+            index_for: &|_: &Path| open_index("wt/agent-6561open", 6563),
+        },
+        ReclaimMode::Remove,
+    );
+    assert_eq!(out.survey.reclaimable, 0, "outcome: {out:?}");
+    assert!(out.removed.is_empty() && path.exists());
+    let found = out
+        .survey
+        .candidates
+        .iter()
+        .find(|c| c.path == path)
+        .expect("listed");
+    assert_eq!(
+        found.verdict,
+        ReclaimVerdict::blocked("PR #6563 is still open"),
+        "the refusal must be the landing-evidence gate's"
+    );
+}
+
+/// An agent worktree holding uncommitted work is never a candidate, merged PR
+/// or not (#6561). This assertion must never be relaxed.
+#[test]
+fn reclaim_never_offers_a_dirty_agent_worktree() {
+    let fx = GitWorktreeFixture::new();
+    let path = released_agent_worktree(&fx, "agent-6561dirty");
+    std::fs::write(path.join("in-flight.rs"), "// unsaved\n").expect("write unsaved file");
+    let out = reclaim_with_probes(
+        &fx.repos_root,
+        &FreshProbes {
+            agent_state: &restarted_registry,
+            in_use_now: &|| Some(Vec::new()),
+            index_for: &|_: &Path| merged_index("wt/agent-6561dirty", 6564),
+        },
+        ReclaimMode::Remove,
+    );
+    assert_eq!(out.survey.reclaimable, 0, "outcome: {out:?}");
+    assert!(out.removed.is_empty() && path.exists());
+    let found = out
+        .survey
+        .candidates
+        .iter()
+        .find(|c| c.path == path)
+        .expect("listed");
+    assert!(
+        matches!(&found.verdict, ReclaimVerdict::Blocked { reason }
+            if reason.contains("holds unsaved work")),
+        "the refusal must be the unsaved-work gate's: {:?}",
+        found.verdict
+    );
+}
+
+/// A worktree the harness STILL holds is spared, and the operator is told
+/// (#6561).
+///
+/// Fails before #6561: the harness lock read as an operator `git worktree lock`,
+/// so the candidate was dropped at gate 1 as a plain `Blocked` and
+/// `survey.agent_owned` came back empty — the silent `0 of 0` the issue reports.
+#[test]
+fn survey_discloses_a_harness_locked_agent_worktree() {
+    let fx = GitWorktreeFixture::new();
+    let path = released_agent_worktree(&fx, "agent-6561locked");
+    fx.harness_lock_worktree(&path, "agent-6561locked");
+    let out = reclaim_with_probes(
+        &fx.repos_root,
+        &FreshProbes {
+            agent_state: &restarted_registry,
+            in_use_now: &|| Some(Vec::new()),
+            index_for: &|_: &Path| merged_index("wt/agent-6561locked", 6565),
+        },
+        ReclaimMode::Remove,
+    );
+    assert!(out.removed.is_empty() && path.exists(), "outcome: {out:?}");
+    let disclosed = out.survey.agent_owned.join("\n");
+    assert_eq!(
+        out.survey.agent_owned.len(),
+        1,
+        "the spared worktree must be reported exactly once: {disclosed}"
+    );
+    assert!(
+        disclosed.contains("agent-6561locked"),
+        "the disclosure must name the worktree: {disclosed}"
     );
 }

--- a/crates/trusty-mpm/src/session_manager/worktree_reclaim_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_reclaim_tests.rs
@@ -122,6 +122,9 @@ fn classify_blocks_non_admitted_worktree() {
         Admission::MainCheckout,
         Admission::Bare,
         Admission::Locked,
+        // #6561: the harness's own agent-lifetime lock refuses too — it is
+        // reported differently, never more permissively.
+        Admission::HarnessAgentLock,
         Admission::Prunable,
         Admission::Unresolvable,
         Admission::OutsideProject,
@@ -336,15 +339,23 @@ fn classify_blocks_a_live_agents_worktree() {
     );
 }
 
+/// The post-restart shape, with the harness still holding the tree (#5661,
+/// retargeted by #6561; was `classify_blocks_an_agent_the_registry_never_heard_of`).
+///
+/// `DaemonState::delegations` is rebuilt empty at every boot, so "no delegation
+/// names this agent" is what the registry says about an agent that is still
+/// working, and an empty observation on a destructive path is undeterminable,
+/// not absent (ADR-0045). #6561 did not weaken that: it found a SECOND source
+/// for the same fact. The harness locks an agent's worktree for the life of that
+/// agent, and the lock is a file under `.git/worktrees/<id>/` that no daemon
+/// restart clears — so the fixture now states the fact the registry lost, and the
+/// refusal must still stand.
 #[test]
-fn classify_blocks_an_agent_the_registry_never_heard_of() {
-    // The post-restart shape. `DaemonState::delegations` is rebuilt empty at
-    // every boot, so "no delegation names this agent" is what the registry says
-    // about an agent that is still working. An empty observation on a
-    // destructive path is undeterminable, not absent (ADR-0045).
+fn classify_blocks_an_agent_the_harness_still_holds_after_a_restart() {
     let fx = GitWorktreeFixture::new();
     let path = agent_store_worktree(&fx, "forgotten-agent-5661");
     GitWorktreeFixture::stamp_agent_sentinel(&path, "agent-lost-to-a-restart");
+    fx.harness_lock_worktree(&path, "agent-lost-to-a-restart");
     let v = classify(
         &path,
         Admission::Admitted,
@@ -354,7 +365,11 @@ fn classify_blocks_an_agent_the_registry_never_heard_of() {
         &no_agents,
     );
     assert!(!v.is_reclaimable(), "{v:?}");
-    assert!(reason(&v).contains("undeterminable"), "{}", reason(&v));
+    assert!(
+        reason(&v).contains("still reports the harness"),
+        "{}",
+        reason(&v)
+    );
 }
 
 #[test]
@@ -367,7 +382,9 @@ fn classify_records_an_agent_refusal_as_its_own_verdict_kind() {
     //
     // Both registry answers that refuse are pinned, because the post-restart
     // `Unknown` case is the one a fail-open implementation would quietly
-    // reclassify as an ordinary block.
+    // reclassify as an ordinary block. #6561: the `Unknown` row now also holds
+    // the harness lock, which is what carries that refusal since the registry's
+    // silence alone stopped being the whole answer.
     let fx = GitWorktreeFixture::new();
     for (name, probe, agent) in [
         (
@@ -383,6 +400,7 @@ fn classify_records_an_agent_refusal_as_its_own_verdict_kind() {
     ] {
         let path = agent_store_worktree(&fx, name);
         GitWorktreeFixture::stamp_agent_sentinel(&path, agent);
+        fx.harness_lock_worktree(&path, agent);
         let v = classify(
             &path,
             Admission::Admitted,
@@ -789,6 +807,70 @@ fn an_unattributed_agent_store_worktree_is_never_reclaimable() {
         "and the refusal must be the ownership one, naming why: {}",
         reason(&v)
     );
+}
+
+/// A merged, clean agent tree the HARNESS HAS RELEASED is reclaimable even
+/// though the delegation registry never heard of its agent (#6561).
+///
+/// This is the issue's headline case. The registry is a `DashMap` rebuilt empty
+/// at every daemon boot, so on a restarted daemon it answers `Unknown` for every
+/// agent — which refused every `.claude/worktrees/agent-*` tree in the store and
+/// produced the reported `0 of 0 measured`. Git's lock is the durable second
+/// source: the harness holds it for the agent's life and releases it when the
+/// agent ends, and no daemon writes or clears it.
+///
+/// Fails before #6561: `classify` refuses with "the delegation registry holds no
+/// record of that agent".
+#[test]
+fn classify_allows_a_merged_agent_tree_the_harness_released() {
+    let fx = GitWorktreeFixture::new();
+    let path = agent_store_worktree(&fx, "agent-6561released");
+    GitWorktreeFixture::stamp_agent_sentinel(&path, "agent-6561released");
+    // No `harness_lock_worktree` call: the harness released this tree when its
+    // agent ended, which is what `git worktree list` now reports.
+    let v = classify_no_agent(&path, Admission::Admitted, false, &merged(759), &clean);
+    assert_eq!(
+        v,
+        ReclaimVerdict::Reclaimable { pr: 759 },
+        "a released, attributed, merged, clean agent tree must be reclaimable"
+    );
+}
+
+/// Git being unaskable is still undeterminable, never released (#6561).
+///
+/// The permit above rests entirely on `Released` being POSITIVE evidence. Its
+/// `Held` complement is `classify_blocks_an_agent_the_harness_still_holds_after_a_restart`;
+/// this is the third arm, where git answers nothing at all.
+#[test]
+fn classify_blocks_an_agent_tree_git_cannot_be_asked_about() {
+    let fx = GitWorktreeFixture::new();
+    let path = agent_store_worktree(&fx, "agent-6561unaskable");
+    GitWorktreeFixture::stamp_agent_sentinel(&path, "agent-6561unaskable");
+    let _restore = deny_all(&path.join(".git"));
+    let v = classify_no_agent(&path, Admission::Admitted, false, &merged(759), &clean);
+    assert!(!v.is_reclaimable(), "two silences are not an answer: {v:?}");
+}
+
+/// A harness-locked agent tree reaches gate 1 as its own verdict KIND, so the
+/// survey can tell the operator it spared an agent (#6561).
+///
+/// Fails before #6561: the verdict is a plain `Blocked` naming the operator's
+/// `git worktree lock`, so `ReclaimSurvey::agent_owned` stays empty and the run
+/// prints `0 of 0` with no mention of the agent it protected.
+#[test]
+fn classify_discloses_a_harness_locked_agent_tree_as_agent_owned() {
+    let v = classify_no_agent(
+        &wt(),
+        Admission::HarnessAgentLock,
+        false,
+        &merged(760),
+        &clean,
+    );
+    assert!(
+        matches!(v, ReclaimVerdict::BlockedByAgent { .. }),
+        "a harness lock must be disclosed as an agent refusal, not an operator one: {v:?}"
+    );
+    assert_eq!(reason(&v), Admission::HarnessAgentLock.reason());
 }
 
 /// The #4091 dirty-work guard, asserted on the agent store specifically: unsaved

--- a/crates/trusty-mpm/src/session_manager/worktree_registry.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_registry.rs
@@ -92,8 +92,103 @@ pub(crate) struct RegisteredWorktree {
     /// "do not remove this", which `git worktree remove` refuses to override
     /// without `--force`.
     pub locked: bool,
+    /// The lock's REASON when git reported one, else `None` (#6561).
+    ///
+    /// Why: a lock is not one thing. The operator's `git worktree lock` is a
+    /// standing veto; the Claude Code harness's own agent-worktree isolation
+    /// also locks, for the life of the dispatched agent, with a reason naming
+    /// that agent. Discarding the reason made both indistinguishable, so a tree
+    /// a live agent was working in was dropped at [`Admission::Locked`] and
+    /// never reached the gate that would have SAID SO — which is half of the
+    /// silent `0 of 0` #6561 reports.
+    /// Test: `parse_worktree_list_reads_locked_with_and_without_reason`,
+    /// `parse_worktree_list_keeps_the_harness_agent_lock_reason`.
+    pub lock_reason: Option<String>,
     /// `true` for the first record — git always lists the main worktree first.
     pub is_main: bool,
+}
+
+/// Does `reason` name the Claude Code harness's own agent-worktree lock (#6561)?
+///
+/// Why: this is the ONE fact that separates the harness's agent-lifetime lock
+/// from an operator's standing veto, and it has to be read from the reason
+/// string because git records nothing else about who locked a worktree. Measured
+/// on this machine (git 2.54.0, Claude Code agent isolation): every live agent's
+/// tree carries `claude agent agent-<id> (pid <n> start <time>)`, and every
+/// finished agent's tree carries no lock at all — the harness releases it when
+/// the agent ends.
+/// What: a case-insensitive `claude agent` prefix test on the trimmed reason.
+/// Deliberately a PREFIX and not a parse: nothing downstream reads the agent id
+/// or the pid out of this string, so recognising the shape is the whole job, and
+/// a reason that merely mentions "claude agent" further along is not matched.
+/// Test: `harness_agent_lock_reason_matches_the_harness_shape`,
+/// `harness_agent_lock_reason_rejects_an_operator_lock`.
+pub(crate) fn is_harness_agent_lock_reason(reason: &str) -> bool {
+    reason
+        .trim_start()
+        .get(..12)
+        .is_some_and(|head| head.eq_ignore_ascii_case("claude agent"))
+}
+
+/// What git can say, right now, about whether the harness holds `path` (#6561).
+///
+/// Why: the delegation registry is a `DashMap` rebuilt empty at every daemon
+/// boot, so after a restart it answers "nothing claims it" for an agent that is
+/// still working — [`super::worktree_ownership::AgentDelegationState::Unknown`],
+/// which ADR-0045 forbids reading as "free". Git's lock does not have that
+/// defect: it is a file under `.git/worktrees/<id>/locked`, written by the
+/// harness when it dispatches an agent into the tree and removed when that agent
+/// ends, and it survives a daemon restart because no daemon writes it. So it is
+/// the durable second source that can answer the question the registry cannot.
+/// What: three answers, and the third is the point. [`Held`](Self::Held) — git
+/// reports a harness agent lock. [`Released`](Self::Released) — git lists the
+/// worktree and reports no lock on it, which is POSITIVE evidence the harness
+/// let go. [`Undeterminable`](Self::Undeterminable) — git could not be asked, or
+/// no longer lists the path; never read as released.
+/// Test: `harness_lock_state_reports_a_harness_locked_tree_held`,
+/// `harness_lock_state_reports_an_unlocked_tree_released`,
+/// `harness_lock_state_of_a_non_worktree_is_undeterminable`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum HarnessLockState {
+    /// Git reports a lock whose reason names a harness agent.
+    Held,
+    /// Git lists this worktree and reports no lock on it at all.
+    Released,
+    /// Git could not be asked, or does not list this path.
+    Undeterminable,
+}
+
+/// Ask git whether the harness still holds `path` (#6561).
+///
+/// Why: see [`HarnessLockState`]. Resolved from the candidate itself so the
+/// answer comes from the repository that actually registered the worktree.
+/// What: one `git -C <path> worktree list --porcelain`, matched on the
+/// canonicalized path. An operator lock — a lock whose reason is not the
+/// harness's — is reported [`Undeterminable`](HarnessLockState::Undeterminable)
+/// rather than `Released`, because it is not evidence about the harness either
+/// way and must never advance a destructive path.
+/// Test: `harness_lock_state_reports_a_harness_locked_tree_held`,
+/// `harness_lock_state_reports_an_unlocked_tree_released`,
+/// `harness_lock_state_of_an_operator_locked_tree_is_undeterminable`,
+/// `harness_lock_state_of_a_non_worktree_is_undeterminable`.
+pub(crate) fn harness_lock_state(path: &Path) -> HarnessLockState {
+    let Some(registered) = list_registered_worktrees(path) else {
+        return HarnessLockState::Undeterminable;
+    };
+    let canonical = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    let found = registered
+        .into_iter()
+        .find(|w| std::fs::canonicalize(&w.path).unwrap_or_else(|_| w.path.clone()) == canonical);
+    let Some(record) = found else {
+        return HarnessLockState::Undeterminable;
+    };
+    if !record.locked {
+        return HarnessLockState::Released;
+    }
+    match record.lock_reason.as_deref() {
+        Some(reason) if is_harness_agent_lock_reason(reason) => HarnessLockState::Held,
+        _ => HarnessLockState::Undeterminable,
+    }
 }
 
 /// Parse `git worktree list --porcelain` output into records (#4207).
@@ -123,6 +218,7 @@ pub(crate) fn parse_worktree_list(stdout: &str) -> Vec<RegisteredWorktree> {
                 bare: false,
                 prunable: false,
                 locked: false,
+                lock_reason: None,
                 is_main: out.is_empty(),
             });
             continue;
@@ -141,8 +237,13 @@ pub(crate) fn parse_worktree_list(stdout: &str) -> Vec<RegisteredWorktree> {
             current.bare = true;
         } else if line == "prunable" || line.starts_with("prunable ") {
             current.prunable = true;
-        } else if line == "locked" || line.starts_with("locked ") {
+        } else if line == "locked" {
             current.locked = true;
+        } else if let Some(reason) = line.strip_prefix("locked ") {
+            // #6561: the reason is kept, not discarded — it is the only thing
+            // that tells the harness's agent-lifetime lock from an operator veto.
+            current.locked = true;
+            current.lock_reason = Some(reason.to_string());
         }
     }
     out
@@ -373,6 +474,19 @@ pub(crate) enum Admission {
     Prunable,
     /// The operator ran `git worktree lock` — an explicit removal veto.
     Locked,
+    /// The Claude Code harness holds its own agent-lifetime lock (#6561).
+    ///
+    /// Why a variant of its own rather than [`Locked`](Self::Locked): both are
+    /// refusals, but only one of them is a fact the operator has to be told.
+    /// An operator lock is the operator's own standing decision; a harness lock
+    /// means a DISPATCHED AGENT is working in that tree right now, and folding
+    /// it into `Locked` dropped the candidate at gate 1 of
+    /// `worktree_reclaim::classify` — before the gate that reports a spared
+    /// agent tree ever ran. So `--merged-prs` printed `0 of 0` over a store
+    /// full of agent worktrees and named none of them.
+    /// Test: `scan_separates_a_harness_agent_lock_from_an_operator_lock`,
+    /// `classify_discloses_a_harness_locked_agent_tree_as_agent_owned`.
+    HarnessAgentLock,
     /// The path could not be canonicalized, so nothing about it is comparable.
     Unresolvable,
     /// Registered, but not a strict descendant of the managed project.
@@ -395,6 +509,10 @@ impl Admission {
             Self::MainCheckout => "excluded: the repository's main checkout",
             Self::Prunable => "excluded: git reports the directory is already gone",
             Self::Locked => "excluded: git-locked by the operator",
+            Self::HarnessAgentLock => {
+                "excluded: the harness holds its agent-lifetime lock on this worktree — a \
+                 dispatched agent is still working in it (#6561)"
+            }
             Self::Unresolvable => "excluded: path could not be canonicalized",
             Self::OutsideProject => "excluded: not inside the managed project that registered it",
             Self::OutsideReposRoot => "excluded: outside the managed repos root",
@@ -597,7 +715,18 @@ fn admission_for(
             return Admission::Prunable;
         }
         if wt.locked {
-            return Admission::Locked;
+            // #6561: which KIND of lock, because only one of them names a
+            // dispatched agent the operator must be told about.
+            let harness = wt
+                .lock_reason
+                .as_deref()
+                .is_some_and(is_harness_agent_lock_reason)
+                && super::worktree_ownership::is_harness_agent_worktree(&wt.path);
+            return if harness {
+                Admission::HarnessAgentLock
+            } else {
+                Admission::Locked
+            };
         }
         // #1845 item 8, preserved: a path that cannot be canonicalized is
         // SKIPPED, never proposed. A dangling symlink, a deletion race, an

--- a/crates/trusty-mpm/src/session_manager/worktree_registry_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_registry_tests.rs
@@ -604,3 +604,134 @@ fn enumerate_orders_nested_worktree_before_its_parent() {
         "the nested worktree must precede its container; got {found:?}"
     );
 }
+
+// ── harness agent lock vs operator lock (#6561) ──────────────────────────
+
+/// The porcelain parse keeps the lock REASON, not just the flag (#6561).
+///
+/// Fails before #6561: `lock_reason` did not exist, and the reason text was
+/// dropped by a `starts_with("locked ")` arm that set only the boolean — so
+/// nothing downstream could tell the harness's agent-lifetime lock from an
+/// operator's standing veto.
+#[test]
+fn parse_worktree_list_keeps_the_harness_agent_lock_reason() {
+    let stdout = "\
+worktree /repos/owner/repo
+HEAD abc123
+branch refs/heads/main
+
+worktree /repos/owner/repo/.claude/worktrees/agent-a1c
+HEAD def456
+branch refs/heads/worktree-agent-a1c
+locked claude agent agent-a1c (pid 11002 start Mon Aug 31 20:33:51 2026)
+
+worktree /repos/owner/repo/.worktrees/kept
+HEAD 999999
+branch refs/heads/session/kept
+locked
+";
+    let got = parse_worktree_list(stdout);
+    assert_eq!(got.len(), 3, "one record per stanza; got {got:?}");
+    assert!(got[1].locked);
+    assert_eq!(
+        got[1].lock_reason.as_deref(),
+        Some("claude agent agent-a1c (pid 11002 start Mon Aug 31 20:33:51 2026)"),
+        "the reason must survive the parse"
+    );
+    assert!(got[2].locked, "a bare `locked` line still locks");
+    assert_eq!(
+        got[2].lock_reason, None,
+        "and carries no reason to misread as the harness's"
+    );
+}
+
+#[test]
+fn harness_agent_lock_reason_matches_the_harness_shape() {
+    assert!(is_harness_agent_lock_reason(
+        "claude agent agent-a1c (pid 11002 start Mon Aug 31 20:33:51 2026)"
+    ));
+    assert!(
+        is_harness_agent_lock_reason("Claude Agent agent-a1c (pid 1)"),
+        "the shape is what matters, not the casing"
+    );
+}
+
+#[test]
+fn harness_agent_lock_reason_rejects_an_operator_lock() {
+    assert!(!is_harness_agent_lock_reason(""));
+    assert!(!is_harness_agent_lock_reason(
+        "do not remove - salvaging work"
+    ));
+    assert!(
+        !is_harness_agent_lock_reason("held for review by claude agent later"),
+        "a mention further along the string is not the harness's own reason"
+    );
+}
+
+/// The scan reports the harness's agent lock as its OWN admission verdict
+/// (#6561).
+///
+/// Fails before #6561: both worktrees came back `Admission::Locked`, so the
+/// merged-PR sweep dropped a live agent's tree at gate 1 with a message naming
+/// the operator, and the operator was never told an agent had been spared.
+#[test]
+fn scan_separates_a_harness_agent_lock_from_an_operator_lock() {
+    let fixture = GitWorktreeFixture::new();
+    let store = fixture.repo.join(".claude").join("worktrees");
+    let agent = fixture.add_worktree_at(&store, "agent-6561");
+    let session = fixture.add_worktree("operator-held");
+    fixture.harness_lock_worktree(&agent, "agent-6561");
+    fixture.lock_worktree(&session);
+
+    let scanned = scan_registered_worktrees(&fixture.repos_root);
+    let canonical = |p: &std::path::Path| std::fs::canonicalize(p).unwrap_or_else(|_| p.into());
+    let verdict = |p: &std::path::Path| {
+        scanned
+            .iter()
+            .find(|s| s.path == canonical(p))
+            .unwrap_or_else(|| panic!("{} must be scanned; got {scanned:?}", p.display()))
+            .admission
+    };
+    assert_eq!(verdict(&agent), Admission::HarnessAgentLock);
+    assert_eq!(verdict(&session), Admission::Locked);
+}
+
+#[test]
+fn harness_lock_state_reports_a_harness_locked_tree_held() {
+    let fixture = GitWorktreeFixture::new();
+    let store = fixture.repo.join(".claude").join("worktrees");
+    let agent = fixture.add_worktree_at(&store, "agent-held");
+    fixture.harness_lock_worktree(&agent, "agent-held");
+    assert_eq!(harness_lock_state(&agent), HarnessLockState::Held);
+}
+
+/// An unlocked registered worktree is POSITIVE evidence the harness let go
+/// (#6561) — the one answer that permits reclamation past an empty registry.
+#[test]
+fn harness_lock_state_reports_an_unlocked_tree_released() {
+    let fixture = GitWorktreeFixture::new();
+    let store = fixture.repo.join(".claude").join("worktrees");
+    let agent = fixture.add_worktree_at(&store, "agent-released");
+    assert_eq!(harness_lock_state(&agent), HarnessLockState::Released);
+}
+
+/// An OPERATOR lock says nothing about the harness either way, so it is
+/// undeterminable rather than released (#6561).
+#[test]
+fn harness_lock_state_of_an_operator_locked_tree_is_undeterminable() {
+    let fixture = GitWorktreeFixture::new();
+    let store = fixture.repo.join(".claude").join("worktrees");
+    let agent = fixture.add_worktree_at(&store, "agent-operator-held");
+    fixture.lock_worktree(&agent);
+    assert_eq!(harness_lock_state(&agent), HarnessLockState::Undeterminable);
+}
+
+#[test]
+fn harness_lock_state_of_a_non_worktree_is_undeterminable() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    assert_eq!(
+        harness_lock_state(tmp.path()),
+        HarnessLockState::Undeterminable,
+        "git cannot be asked here, and silence is never `Released`"
+    );
+}


### PR DESCRIPTION
Refs #6561

## Summary
`tm prune` reported `0 of 0` agent worktrees reclaimable after a daemon restart. Two causes. `parse_worktree_list` discarded the lock reason, so Claude Code's agent-lifetime lock and an operator's `git worktree lock` were the same fact and every live agent tree was dropped at gate 1 as `Admission::Locked` — before the gate that reports a spared agent tree, hence the silent zero. And the delegation registry is a `DashMap` rebuilt empty at every daemon boot, so gate 4 refused the whole store on `Unknown`.

Git holds the same fact durably: the harness locks an agent's worktree for its life (`locked claude agent agent-<id> (pid …)` under `.git/worktrees/<id>/`) and releases it when the agent ends. `Admission::HarnessAgentLock` is now its own verdict, classified as `BlockedByAgent`; an `Unknown` registry answer consults `harness_lock_state`, where only a positive `Released` permits — `Held` and `Undeterminable` both refuse. Unattributed, unmerged and uncommitted trees stay unreclaimable as before.

## Test ladder
Rung 3 (localized to trusty-mpm `session_manager`).
- `cargo fmt --check` — exit 0
- `cargo check -p trusty-mpm` — exit 0
- `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — exit 0
- `cargo test -p trusty-mpm --no-fail-fast` — 5753 passed, 1 failed, 8 ignored. The one failure is `core::session_assets::tests::session_plan_under_matches_session_plan_at_home`, reproduced identically on `origin/main` with this branch's changes stashed (passes alone on both trees) — it is #6580, fixed on #6596.
- Five regression tests fail pre-fix (behavioural edits reverted, API kept): `0 passed; 5 failed`, e.g. `verdict: BlockedByAgent { reason: "undeterminable: agent-6561reclaim" }`.
- `check_test_pointers.sh`, `check_line_cap.sh`, `check_changelog_fragment.sh`, `check_sld.sh` — all exit 0

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools