### PR TITLE
fix(tga): extract_issue_ids skips non-ticket identifier families; DOC-67 §5 states the executed sweep order

### DIFF
--- a/crates/trusty-git-analytics/changelog.d/5664-non-ticket-identifier-prefixes.md
+++ b/crates/trusty-git-analytics/changelog.d/5664-non-ticket-identifier-prefixes.md
@@ -1,0 +1,17 @@
+Fixed
+
+- `tga collect`: Linear enrichment no longer spends a GraphQL lookup on
+  documentation, standard, digest and advisory tokens that merely share a ticket's
+  shape (#5664). `LinearClient::extract_issue_ids` now drops `UTF-8`, `SHA-256`,
+  `ADR-0029`, `RFC-2119`, `ISO-8601`, `ECMA-48`, `RUSTSEC-2026` and their families
+  before any request is issued; a live 52-week collect on this repository sent 369
+  such lookups, none of which could ever resolve. The decision is made offline by
+  `collect::ticket::is_non_ticket_identifier`, which `extract_ticket_id`,
+  `is_ticketed` and `branch_ticket_key` already used under its former name — one
+  prefix list, so the pre-lookup gate and the subject-position rule cannot drift
+  apart. That list widened from four documentation prefixes to the measured
+  families, so a subject led by `CVE-2024-3094` or `SHA-256` no longer counts as a
+  declared ticket key either. Ticket-shaped tokens that simply do not resolve
+  (`WI-1`, `AC-1`, `CREDPANEL-01`) are deliberately still looked up: nothing
+  separates them from another organization's real board keys, and DOC-70 §9.1
+  reads an unresolved key as the signal it is.

--- a/crates/trusty-git-analytics/src/audit/mod.rs
+++ b/crates/trusty-git-analytics/src/audit/mod.rs
@@ -12,14 +12,18 @@
 //!
 //! ## Stage order
 //!
-//! DOC-67 §5's prose lists the sweep as "collect → classify → report →
-//! pr-metrics → jira → dora → deployments → incidents". That is the spec's
-//! enumeration of which subcommands participate, not a runnable order: `dora`
-//! reduces `fact_deployments` / `fact_incidents` (§8), so running it before the
-//! two commands that populate those tables would compute the four DORA keys
-//! over empty input, and `report` renders what the earlier stages produced, so
-//! running it third would render a mostly empty report. The executed order is
-//! therefore data-flow order — see [`SweepStage`].
+//! Data-flow order: collect → correlate → classify → jira sync → deployments →
+//! incidents → dora → pr-metrics → report. See [`SweepStage`] for what each
+//! stage does and [`run_full_sweep`] for the body that runs them.
+//!
+//! DOC-67 §5 "Executed stage order" lists the same nine stages and is the
+//! spec-side statement of this contract (#5306). It used to list
+//! "collect → classify → report → pr-metrics → jira → dora → deployments →
+//! incidents", which cannot execute: `dora` reduces `fact_deployments` /
+//! `fact_incidents` (§8), so running it before the two commands that populate
+//! those tables computes the four DORA keys over empty input, and `report`
+//! renders what the earlier stages produced, so running it third renders a
+//! mostly empty report.
 
 mod analyze;
 mod gaps;

--- a/crates/trusty-git-analytics/src/audit/sweep.rs
+++ b/crates/trusty-git-analytics/src/audit/sweep.rs
@@ -98,6 +98,9 @@ pub struct SweepOptions {
 ///
 /// # Spec References
 /// - [`SPEC-TGAUDIT-02~draft`](../../../../docs/specs/DOC-67-tga-audit-mode.md#SPEC-TGAUDIT-02~draft)
+/// - [`SPEC-TGAUDIT-05~draft`](../../../../docs/specs/DOC-67-tga-audit-mode.md#SPEC-TGAUDIT-05~draft)
+///   — §5 "Executed stage order" lists the nine stages this body runs, in this
+///   order (#5306). Changing the sequence here means changing that list.
 /// - [`SPEC-TGAUDIT-07~draft`](../../../../docs/specs/DOC-67-tga-audit-mode.md#SPEC-TGAUDIT-07~draft)
 /// - [`SPEC-TGAUDIT-09~draft`](../../../../docs/specs/DOC-67-tga-audit-mode.md#SPEC-TGAUDIT-09~draft)
 pub async fn run_full_sweep(
@@ -160,8 +163,8 @@ pub async fn run_full_sweep(
     finish(progress, &mut stats, SweepStage::JiraSync, t, result);
 
     // Deployments and incidents populate `fact_deployments` / `fact_incidents`,
-    // which `dora` reduces — so they precede it here even though DOC-67 §5's
-    // prose lists dora first. See the module-level note in `super`.
+    // which `dora` reduces — so they precede it. #5306: DOC-67 §5 states this
+    // same order; it used to list dora first, which cannot execute.
     let t = begin(progress, &stats, SweepStage::Deployments);
     let result = deployments::run(config.clone(), db, DeploymentsCollectArgs::default()).await;
     finish(progress, &mut stats, SweepStage::Deployments, t, result);

--- a/crates/trusty-git-analytics/src/audit/tests.rs
+++ b/crates/trusty-git-analytics/src/audit/tests.rs
@@ -12,10 +12,15 @@ use crate::core::progress::{ProgressBus, Stage};
 
 /// The order `run_full_sweep` is contracted to execute in.
 ///
-/// Data-flow order, not DOC-67 §5's prose order — deployments and incidents
-/// populate what dora reduces, and report renders what everything else wrote.
-/// #5405 puts correlate immediately after collect, which is where every
-/// production writer of `work_items` runs.
+/// Data-flow order — deployments and incidents populate what dora reduces, and
+/// report renders what everything else wrote. #5405 puts correlate immediately
+/// after collect, which is where every production writer of `work_items` runs.
+///
+/// #5306: DOC-67 §5 "Executed stage order" lists these same nine stages. This
+/// array is what stops the two from drifting apart — a change to either that is
+/// not made to the other fails
+/// `sweep_runs_every_stage_in_order_and_survives_failures` or leaves the spec
+/// describing a sweep that does not run.
 const EXPECTED_ORDER: [SweepStage; 9] = [
     SweepStage::Collect,
     SweepStage::Correlate,

--- a/crates/trusty-git-analytics/src/collect/linear/client.rs
+++ b/crates/trusty-git-analytics/src/collect/linear/client.rs
@@ -7,7 +7,10 @@
 //! CLI on this path.
 //!
 //! Issue identifiers are matched against commit messages with the pattern
-//! `[A-Z][A-Z0-9]{0,9}-\d+` (e.g. `ENG-123`, `FE-456`).
+//! `[A-Z][A-Z0-9]{0,9}-\d+` (e.g. `ENG-123`, `FE-456`), then filtered through
+//! [`crate::collect::ticket::is_non_ticket_identifier`] so that documentation,
+//! standard, digest and advisory tokens of the same shape never reach the
+//! network (#5664).
 
 use std::collections::HashSet;
 
@@ -17,6 +20,7 @@ use serde::{Deserialize, Serialize};
 use trusty_common::credentials::scrub_secrets;
 
 use crate::collect::errors::{CollectError, Result};
+use crate::collect::ticket::is_non_ticket_identifier;
 use crate::core::config::LinearConfig;
 use crate::core::db::Database;
 
@@ -239,14 +243,41 @@ impl LinearClient {
 
     /// Extract Linear issue identifiers from a commit message.
     ///
-    /// Matches patterns like `ENG-123`, `FE-456`, `PROJ-789`.
-    /// Returns a deduplicated list of identifiers found (order preserved).
+    /// Why: the shape `[A-Z][A-Z0-9]{0,9}-\d+` is also the shape of every
+    /// `UTF-8`, `SHA-256`, `ADR-0029`, `RFC-2119`, `ISO-8601` and `RUSTSEC-2026`
+    /// a commit message carries, and [`Self::fetch_referenced_issues`] resolves
+    /// whatever this yields. A live 52-week `tga collect` on this repository
+    /// issued 369 distinct GraphQL lookups, not one of which was a Linear
+    /// ticket (#5664): the round-trip was the only thing that could tell an
+    /// encoding name from an issue key, and its answer — "no such issue" — is
+    /// indistinguishable from a real ticket that has been deleted.
+    ///
+    /// What: matches the pattern, then drops every token whose prefix is a
+    /// known non-ticket family before returning, so no lookup is issued for
+    /// one. [`crate::collect::ticket::is_non_ticket_identifier`] owns that
+    /// decision and its calibration; this function holds no list of its own.
+    /// Returns a deduplicated list of identifiers found, order preserved.
+    ///
+    /// Ticket-shaped tokens that simply do not resolve (`WI-1`, `AC-1`,
+    /// `CREDPANEL-01`) are still returned and still cost a lookup: nothing
+    /// distinguishes them from another org's real board keys, and DOC-70 §9.1
+    /// counts an unresolved key as the signal it is.
+    ///
+    /// Test: `extract_issue_ids_finds_linear_patterns`,
+    /// `extract_issue_ids_rejects_non_ticket_identifiers`,
+    /// `extract_issue_ids_deduplicates`,
+    /// `extract_issue_ids_ignores_lowercase_prefix`.
     pub fn extract_issue_ids(message: &str) -> Vec<String> {
         let re = regex::Regex::new(r"\b([A-Z][A-Z0-9]{0,9}-\d+)\b").expect("valid regex");
         let mut seen = HashSet::new();
         let mut out = Vec::new();
         for cap in re.captures_iter(message) {
             let id = cap[1].to_string();
+            // #5664: reject before the lookup — a resolved "not found" costs a
+            // round-trip and answers nothing this test cannot answer offline.
+            if is_non_ticket_identifier(&id) {
+                continue;
+            }
             if seen.insert(id.clone()) {
                 out.push(id);
             }
@@ -496,6 +527,81 @@ mod tests {
         let msg = "abc-123 should not match";
         let ids = LinearClient::extract_issue_ids(msg);
         assert!(ids.is_empty());
+    }
+
+    /// Why: #5664 — every token here is the shape `extract_issue_ids` matches
+    /// and none is a Linear issue, so before this filter each one bought a
+    /// GraphQL round-trip whose only possible answer was "no such issue".
+    /// A live 52-week `tga collect` on this repository issued 369 such lookups.
+    /// What: the identifiers the #5664 measurement observed, plus the families
+    /// named alongside them, yield nothing at all — no lookup can be issued for
+    /// a token that never leaves the extractor.
+    /// Test: this test itself.
+    #[test]
+    fn extract_issue_ids_rejects_non_ticket_identifiers() {
+        for msg in [
+            // Observed in the #5664 measurement.
+            "docs: DOC-67 §5 sweep order",
+            "spec: DOC-70 board axis",
+            "docs: amend ADR-0029 point 3",
+            "docs: supersede ADR-0038",
+            "fix: a multi-byte UTF-8 name breaks the stem",
+            "chore: verify the artifact against the published SHA-256",
+            "feat: strip ECMA-48 control sequences",
+            "chore: avoid reintroducing RUSTSEC-2026-0187",
+            // Families named alongside them in #5664.
+            "fix: ISO-8601 offsets were dropped",
+            "docs: RFC-2119 keyword sweep",
+            "chore: drop the MD-5 fallback",
+            "chore: patch CVE-2024-3094",
+            "docs: map the finding to CWE-79",
+            "build: mirror the AL2023/GCC-11 desync",
+            "chore: rotate to RSA-4096 and AES-256",
+            "docs: SPEC-14 tightened",
+        ] {
+            assert_eq!(
+                LinearClient::extract_issue_ids(msg),
+                Vec::<String>::new(),
+                "message: {msg:?}"
+            );
+        }
+    }
+
+    /// Why: #5664's filter is a deny-list, and a deny-list that over-reaches
+    /// loses genuine board links silently — the failure mode the network cost
+    /// it removes is far cheaper than.
+    /// What: real tracker keys still extract, including the two-letter and
+    /// single-digit shapes closest to the excluded families. The ticket-shaped
+    /// tokens the measurement could not resolve (`WI-1`, `AC-1`,
+    /// `CREDPANEL-01`) still extract too: that is the deliberate calibration
+    /// boundary recorded on `NON_TICKET_PREFIXES`, not an oversight.
+    /// Test: this test itself.
+    #[test]
+    fn extract_issue_ids_keeps_genuine_tracker_ids() {
+        for (msg, want) in [
+            ("ABC-123: add the thing", "ABC-123"),
+            ("fix: land GH-12", "GH-12"),
+            ("PROJ-9 tighten the check", "PROJ-9"),
+            ("ENG-123: add login feature", "ENG-123"),
+            ("also fixes FE-456", "FE-456"),
+            // Unresolvable but ticket-shaped: deliberately still extracted.
+            ("WI-1 spike", "WI-1"),
+            ("AC-1 acceptance", "AC-1"),
+            ("CREDPANEL-01 wiring", "CREDPANEL-01"),
+        ] {
+            assert_eq!(
+                LinearClient::extract_issue_ids(msg),
+                vec![want.to_string()],
+                "message: {msg:?}"
+            );
+        }
+        // A GitHub bare `#N` is a genuine reference of a different shape — this
+        // extractor never matched it, and `ticket::extract_ticket_id` still does.
+        assert!(LinearClient::extract_issue_ids("closes #1234").is_empty());
+        assert_eq!(
+            crate::collect::ticket::extract_ticket_id("closes #1234"),
+            Some("#1234".to_string())
+        );
     }
 
     /// #5983: asserted against [`resolve_api_key_with`], not `LinearClient::new`.

--- a/crates/trusty-git-analytics/src/collect/ticket.rs
+++ b/crates/trusty-git-analytics/src/collect/ticket.rs
@@ -11,14 +11,20 @@
 //!   `resolves #7` (case-insensitive, also matches `fix`/`close`/`resolve`).
 //! - **Azure DevOps work-item refs**: `AB#123`.
 //!
-//! **Note on JIRA-shaped tokens (issues #5199, #5735):** [`extract_ticket_id`]
-//! and [`is_ticketed`] read a JIRA/Linear key the same way — from the
-//! **subject line only**, rejecting documentation prefixes (`ADR`, `DOC`,
-//! `RFC`, `SPEC`) via [`subject_ticket_key`]. #5199 narrowed
+//! **Note on JIRA-shaped tokens (issues #5199, #5735, #5664):**
+//! [`extract_ticket_id`] and [`is_ticketed`] read a JIRA/Linear key the same
+//! way — from the **subject line only**, rejecting the
+//! [`NON_TICKET_PREFIXES`] families via [`subject_ticket_key`]. #5199 narrowed
 //! [`extract_ticket_id`] and left [`is_ticketed`] scanning the whole message
 //! with the unrestricted pattern; #5735 measured what that cost — 237 of this
 //! repository's 2633 commits counted ticketed on nothing but a `UTF-8`- or
 //! `ADR-0034`-shaped string in a body. The two now agree.
+//!
+//! This module also owns the prefix list itself. [`NON_TICKET_PREFIXES`] and
+//! [`is_non_ticket_identifier`] are the single answer to "is this token a
+//! document rather than a ticket", which `LinearClient::extract_issue_ids`
+//! consults before issuing a GraphQL lookup (#5664) — a second list there
+//! would drift from this one.
 //!
 //! **Note on bare `#N` refs (issue #445):** A bare `#N` preceded by
 //! whitespace (the `gh_bare` pattern) is explicitly *excluded* from
@@ -67,16 +73,49 @@ fn patterns() -> &'static TicketPatterns {
     })
 }
 
-/// Prefixes that name a *document*, never a work item (#5199).
+/// Prefixes that name a document, standard, encoding, digest or advisory —
+/// never a work item (#5199, #5735, #5664).
 ///
 /// Why: `ADR-0029` and `PROJ-1234` are the same shape, so shape alone cannot
-/// separate them. These four prefixes are cross-industry documentation
-/// conventions, and a repo that writes them in a commit subject is citing a
-/// document, not a ticket.
-/// What: compared against the segment before the first `-` of an otherwise
-/// well-formed key.
-/// Test: `tests::adr_reference_is_not_a_ticket_key`.
-const DOC_REF_PREFIXES: &[&str] = &["ADR", "DOC", "RFC", "SPEC"];
+/// separate them, and each consumer of that shape pays for the confusion
+/// differently. [`extract_ticket_id`] reported such tokens as coverage gaps
+/// against tickets that exist on no board (#5199); [`is_ticketed`] counted 237
+/// of this repository's 2633 commits ticketed on one alone (#5735); and
+/// `LinearClient::extract_issue_ids` spent 369 GraphQL round-trips on a single
+/// 52-week `tga collect`, none of which can ever resolve, because a lookup was
+/// the only thing that could tell it `UTF-8` is not a Linear issue (#5664).
+///
+/// What: the segment before the first `-` of an otherwise well-formed key,
+/// compared case-sensitively against this list.
+///
+/// Membership rule (the #5664 calibration): a prefix belongs here only when it
+/// names a published standard, encoding, digest, advisory registry or document
+/// convention **whose numeric suffix is a version, bit width or year rather
+/// than a sequence number**, and it was either observed in the #5664 / #5735
+/// measurements or is a sibling within the same registry. Prefixes that are
+/// merely unresolvable in those measurements — `WI`, `MR`, `C`, `AC`,
+/// `MULTIREPO`, `CREDPANEL` — are deliberately absent: they are indistinguishable
+/// from a real board's keys, so listing them would trade a bounded network cost
+/// for a silent, unreported loss of genuine links.
+///
+/// Test: `tests::adr_reference_is_not_a_ticket_key`,
+/// `tests::non_ticket_prefixes_cover_the_measured_families`,
+/// `collect::linear::client::tests::extract_issue_ids_rejects_non_ticket_identifiers`.
+// #5664: the threshold is the *shape of the number*, not the prefix's length or
+// its frequency in the corpus. A version/bit-width/year suffix means the token
+// names one fixed thing, so no board can ever mint more of them; a sequence
+// number means a board might. Frequency was rejected as the threshold because
+// the measured tail is long and flat — `ECMA-48` appeared as often as a real
+// key would on a quiet team.
+const NON_TICKET_PREFIXES: &[&str] = &[
+    // Decision and specification documents.
+    "ADR", "DOC", "RFC", "SPEC", // Standards bodies.
+    "ANSI", "ECMA", "IEC", "IEEE", "ISO", "ITU", // Character encodings.
+    "ASCII", "UTF", // Digests and ciphers.
+    "AES", "CRC", "MD", "RSA", "SHA", // Vulnerability and weakness registries.
+    "CAPEC", "CVE", "CWE", "GHSA", "RUSTSEC", // Toolchain releases.
+    "GCC", "LLVM",
+];
 
 /// Compiled extraction patterns used by [`extract_ticket_id`], ordered from
 /// most-specific to least-specific so the highest-fidelity match wins.
@@ -134,14 +173,19 @@ fn extract_patterns() -> &'static ExtractPatterns {
     })
 }
 
-/// Is `key` a documentation reference rather than a work-tracking key?
+/// Is `key` a document, standard, digest or advisory reference rather than a
+/// work-tracking key?
 ///
-/// Why: see [`DOC_REF_PREFIXES`].
+/// Why: see [`NON_TICKET_PREFIXES`]. This is the one place that answers the
+/// question, so the subject-position rule here and the pre-lookup gate in
+/// `LinearClient::extract_issue_ids` cannot drift apart (#5664).
 /// What: splits at the first `-` and matches the prefix against that list.
-/// Test: `tests::adr_reference_is_not_a_ticket_key`.
-fn is_doc_reference(key: &str) -> bool {
+/// A token with no `-` is not a key at all and answers `false`.
+/// Test: `tests::adr_reference_is_not_a_ticket_key`,
+/// `tests::non_ticket_prefixes_cover_the_measured_families`.
+pub(crate) fn is_non_ticket_identifier(key: &str) -> bool {
     key.split_once('-')
-        .is_some_and(|(prefix, _)| DOC_REF_PREFIXES.contains(&prefix))
+        .is_some_and(|(prefix, _)| NON_TICKET_PREFIXES.contains(&prefix))
 }
 
 /// The JIRA/Linear key a commit *subject* declares, if any.
@@ -153,7 +197,7 @@ fn is_doc_reference(key: &str) -> bool {
 /// prefixes on this repo's own 2633 commits, against zero genuine ones (#5199).
 /// What: strips an optional conventional-commit prefix and an optional opening
 /// bracket, then requires the key to be the very first token of what remains
-/// and not a [`DOC_REF_PREFIXES`] citation.
+/// and not a [`NON_TICKET_PREFIXES`] citation.
 /// Test: `tests::extract_ticket_id_subject_forms`,
 /// `tests::adr_reference_is_not_a_ticket_key`,
 /// `tests::body_prose_identifier_is_not_a_ticket_key`.
@@ -166,7 +210,7 @@ fn subject_ticket_key(subject: &str) -> Option<String> {
         .get(1)?
         .as_str()
         .to_string();
-    if is_doc_reference(&key) {
+    if is_non_ticket_identifier(&key) {
         None
     } else {
         Some(key)
@@ -316,7 +360,7 @@ pub fn extract_ticket_id(message: &str) -> Option<String> {
 /// tries each `/`-separated segment in order and returns the first key anchored
 /// at that segment's START. The right boundary accepts `-` and `_` as well as
 /// end-of-segment, because a branch slug runs the key into its description with
-/// no space. [`DOC_REF_PREFIXES`] is applied unchanged, so `ADR`, `DOC`, `RFC`
+/// no space. [`NON_TICKET_PREFIXES`] is applied unchanged, so `ADR`, `DOC`, `RFC`
 /// and `SPEC` are rejected here exactly as they are in a commit subject.
 /// Anchoring at `^` also keeps `SPEC-INSTALLER-01` from yielding
 /// `INSTALLER-01`, the tail-segment case #5199 closed.
@@ -360,7 +404,7 @@ pub fn branch_ticket_key(branch: &str) -> Option<String> {
             continue;
         };
         // #5734: the same deny-list #5199 applied to a commit subject.
-        if !is_doc_reference(&key) {
+        if !is_non_ticket_identifier(&key) {
             return Some(key);
         }
     }
@@ -532,6 +576,60 @@ mod tests {
         assert_eq!(extract_ticket_id("docs: DOC-67 §2 rewrite"), None);
         assert_eq!(extract_ticket_id("RFC-2119 keyword sweep"), None);
         assert_eq!(extract_ticket_id("SPEC-14 tightened"), None);
+    }
+
+    /// Why: #5664 — `is_non_ticket_identifier` is now consulted by a second
+    /// caller that has no subject line to anchor to, so the list's contents
+    /// are load-carrying on their own rather than a backstop behind position.
+    /// What: every family the #5664 and #5735 measurements observed answers
+    /// `true`, and the ticket-shaped tokens those measurements could not
+    /// resolve answer `false` — the calibration boundary stated on
+    /// [`NON_TICKET_PREFIXES`], asserted rather than only described.
+    /// Test: this test itself.
+    #[test]
+    fn non_ticket_prefixes_cover_the_measured_families() {
+        for key in [
+            "ADR-0029",
+            "DOC-67",
+            "RFC-2119",
+            "SPEC-14",
+            "ISO-8601",
+            "ECMA-48",
+            "IEEE-754",
+            "UTF-8",
+            "ASCII-7",
+            "SHA-256",
+            "MD-5",
+            "CRC-32",
+            "AES-256",
+            "RSA-4096",
+            "CVE-2024-3094",
+            "CWE-79",
+            "RUSTSEC-2026",
+            "GHSA-1234",
+            "GCC-11",
+            "LLVM-18",
+        ] {
+            assert!(is_non_ticket_identifier(key), "key: {key:?}");
+        }
+        // Deliberately absent: ticket-shaped, unresolvable in the #5664 run,
+        // and indistinguishable from another org's real board keys.
+        for key in [
+            "WI-1",
+            "MR-1",
+            "C-6",
+            "AC-1",
+            "MULTIREPO-01",
+            "CREDPANEL-01",
+            "PROJ-1234",
+            "ENG-123",
+            "GH-12",
+        ] {
+            assert!(!is_non_ticket_identifier(key), "key: {key:?}");
+        }
+        // A token with no `-` is not a key and is never claimed as one.
+        assert!(!is_non_ticket_identifier("ADR"));
+        assert!(!is_non_ticket_identifier(""));
     }
 
     /// Why: #5199 — the long tail of false keys was not documentation
@@ -710,7 +808,7 @@ mod tests {
     /// What: every one of these is a JIRA-SHAPED string sitting where prose
     /// sits — a body line, a mid-subject parenthetical, a tail segment — and
     /// none of them makes a commit ticketed. The last two are the documentation
-    /// prefixes [`DOC_REF_PREFIXES`] rejects even in declaring position.
+    /// prefixes [`NON_TICKET_PREFIXES`] rejects even in declaring position.
     /// Test: this test itself.
     #[test]
     fn jira_shaped_prose_is_not_ticketed() {
@@ -799,7 +897,7 @@ mod tests {
     /// Why: #5734's central risk — a branch named `fix/ADR-0029-followup` is
     /// exactly the shape #5199 spent its effort excluding, and harvesting one
     /// would reintroduce that noise through a side door.
-    /// What: every [`DOC_REF_PREFIXES`] entry is rejected in a branch name, the
+    /// What: every [`NON_TICKET_PREFIXES`] entry is rejected in a branch name, the
     /// hyphenated-tail case stays unreachable, and a lowercase or
     /// numeric-leading branch yields nothing.
     /// Test: this test itself.

--- a/docs/specs/DOC-67-tga-audit-mode.md
+++ b/docs/specs/DOC-67-tga-audit-mode.md
@@ -231,11 +231,42 @@ flowchart LR
 
 **Seam 1 — tga owns acquisition and collection.** Everything under "Data
 Acquisition" (org/workspace discovery, clone-on-demand, JIRA/Linear/GitHub-
-Issues/Bitbucket collection into `work_items`, the full collect → classify →
-report → pr-metrics → jira → dora → deployments → incidents sweep) is epic
+Issues/Bitbucket collection into `work_items`, and the full sweep over the
+data-collection subcommands) is epic
 [#5223](https://github.com/bobmatnyc/trusty-tools/issues/5223)'s six children.
 This spec's new orchestrator code calls into that machinery once it exists;
 it does not restate it (§7).
+
+**Executed stage order.** `tga::audit::run_full_sweep`
+(`crates/trusty-git-analytics/src/audit/sweep.rs`) runs nine stages, in this
+order:
+
+1. `collect` — walk the configured repositories into `commits`.
+2. `correlate` — the deterministic commit ↔ board-item join
+   ([#5405](https://github.com/bobmatnyc/trusty-tools/issues/5405)). It sits
+   here because every production writer of `work_items` runs inside `collect`,
+   so this is the earliest point at which the join sees a complete board.
+3. `classify` — the four-tier classification cascade.
+4. `jira sync` — ingest JIRA transitions and comments.
+5. `deployments collect` — populate `fact_deployments`.
+6. `incidents collect` — populate `fact_incidents`.
+7. `dora` — reduce those two fact tables to the four DORA keys.
+8. `pr-metrics` — aggregate pull-request metrics per engineer.
+9. `report` — render the CSV / JSON / Markdown reports.
+
+This is data-flow order, and it deliberately replaces the order this section
+carried until
+[#5306](https://github.com/bobmatnyc/trusty-tools/issues/5306) — `collect →
+classify → report → pr-metrics → jira → dora → deployments → incidents` — which
+cannot execute as written: `dora` reduces the two tables `deployments` and
+`incidents` populate after it (§8), and `report` renders what the five stages
+following it produce.
+
+The order is asserted, not only described. `EXPECTED_ORDER` in
+`crates/trusty-git-analytics/src/audit/tests.rs` holds the same nine stages, and
+`audit::tests::sweep_runs_every_stage_in_order_and_survives_failures` fails if
+`run_full_sweep`'s body departs from it — so this list and the code cannot drift
+apart silently.
 
 **Seam 2 — trusty-review owns rendering.** `manifest.rs`, `model.rs`
 (`ReportModel::build`, folding in `scan.rs`'s `RepoScan` baseline),


### PR DESCRIPTION
Refs #5664
Refs #5306

## Summary
- #5664: `LinearClient::extract_issue_ids` matched `\b([A-Z][A-Z0-9]{0,9}-\d+)\b` and returned everything, so `fetch_referenced_issues` spent a GraphQL round-trip per `UTF-8` / `SHA-256` / `ADR-0029` (the issue measured ~369 wasted calls per collect). `collect/ticket.rs` already held a prefix deny-list for the same shape collision (#5199, #5735); it is renamed `NON_TICKET_PREFIXES` / `is_non_ticket_identifier`, widened to the measured families, and `extract_issue_ids` now calls it — one list, both consumers. Calibration recorded on the const: a prefix qualifies when its numeric suffix is a version, bit width, or year, never a sequence number; `WI-1`, `MR-1`, `AC-1`, `CREDPANEL-01` deliberately stay lookups, asserted in the tests. `team_filter` still runs after extraction, so a Linear team keyed `MD`/`ISO` would lose links — recorded in the extractor doc rather than splitting it from `build_commit_refs`.
- #5306: DOC-67 §5 named an order `run_full_sweep` never ran (it listed `dora` before the fact tables it reduces, and omitted `correlate` from #5405). §5 now lists the nine executed stages matching the function body, says in one sentence why the earlier order cannot execute, and cross-references `EXPECTED_ORDER` and `sweep_runs_every_stage_in_order_and_survives_failures`; the function's Spec References point back at §5.

## Test ladder
Rung 3 (localized to trusty-git-analytics; #5306 is docs-only).
- `cargo fmt --check` — exit 0
- `cargo check -p tga --all-targets` — exit 0
- `cargo clippy -p tga --all-targets -- -D warnings` — exit 0
- `cargo test -p tga --no-fail-fast` — 1410 passed, 0 failed, 7 ignored (pre-existing); 10 integration targets ok
- Regression `extract_issue_ids_rejects_non_ticket_identifiers` fails on origin/main (`left: ["DOC-67"]  right: []`); `extract_issue_ids_keeps_genuine_tracker_ids` pins the true positives
- `check_line_cap.sh` (4350 files, 0 violations), `check_changelog_fragment.sh`, `check_sld.sh`, `check_test_pointers.sh` (28633 citations, 0 dangling) — exit 0

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KsTGDrDYKBPmHmmbRsMm5w