### PR TITLE
chore(sessions): peer session pause snapshot 2026-09-02 03:31Z

### DIFF
--- a/.trusty-mpm/sessions/sessions-log.jsonl
+++ b/.trusty-mpm/sessions/sessions-log.jsonl
@@ -75,3 +75,4 @@
 {"session_id":"1852fea9-d45b-4288-96ff-9cda26abd845","event":"pause","snapshot":"1852fea9-d45b-4288-96ff-9cda26abd845/session-20260901-204005.md","timestamp":"2026-09-01T20:40:05.799937+00:00"}
 {"session_id":"1852fea9-d45b-4288-96ff-9cda26abd845","event":"pause","snapshot":"1852fea9-d45b-4288-96ff-9cda26abd845/session-20260901-232218.md","timestamp":"2026-09-01T23:22:18.564025+00:00"}
 {"session_id":"tm-trusty-tools-02-0-at2307-20260902","event":"pause","snapshot":"tm-trusty-tools-02-0-at2307-20260902/session-20260902-014402.md","timestamp":"2026-09-02T01:44:02.783351+00:00"}
+{"session_id":"tm-trusty-tools-02-0-at2307-20260902","event":"pause","snapshot":"tm-trusty-tools-02-0-at2307-20260902/session-20260902-033112.md","timestamp":"2026-09-02T03:31:12.708286+00:00"}

--- a/.trusty-mpm/sessions/tm-trusty-tools-02-0-at2307-20260902/session-20260902-033112.md
+++ b/.trusty-mpm/sessions/tm-trusty-tools-02-0-at2307-20260902/session-20260902-033112.md
@@ -1,0 +1,39 @@
+# Session Pause - 2026-09-02T03:31:12.708286+00:00
+
+## Summary
+Paused and STOPPED 2026-09-02 ~03:5xZ on owner instruction ("another session is running — complete tasks and shut down, inform the other session"). Handoff sent to peer session "Dog" (the other trusty-tools session); state on palace slot ws:tm-trusty-tools-02/resume (drawer a3d522c3). Supersedes snapshot tm-trusty-tools-02-0-at2307-20260902/session-20260902-014402.md. ZERO agents in flight at stop.
+
+This leg (resume → stop): all five paused-session agents survived and reported; a harness restart lost three completion records, all recovered via SendMessage. Merged: #6593 (#6590), #6594 (#6565), #6596 (#6580 #6577 #6574 #6575), #6597 (#6561), #6602 (#6586, owner option 1), #6599 (#6595, trusty-analyze 0.12.4), #6592 (snapshot). origin/main = b3d0e50f1. Closed status:tested: #6519 #6517 #6518 #6524 #6542 #6551. Red main triaged: shard-2 on_demand flake was a PRODUCT defect (idle-exit unlinked the socket while holding the redb lock) → #6595 fixed; residual gaps filed #6600 (supervisor blind to dead child) and #6601 (serve_until_idle no drain on signal). INSTALLED from b3d0e50f1: tm 1.5.16, trusty-analyze 0.12.4, trusty-search 0.52.0, tga 5.0.3; daemons restarted (mpm pid 51056, search pid 64558); index 95981 chunks intact. The owner's "rebuild and install once everything merges" is DISCHARGED — do not re-fire. NOT published.
+
+#6589 LSP: edit A/B incomplete (Arm A 15/15, Arm B 1/15, no report); plugin re-enabled at user scope; comment posted.
+
+## Completed
+- [web-qa] #6518 #6524 verified live on console 0.9.2 → closed with #6519 #6517
+- [research] red-main triage: pre-existing trusty-analyze on_demand flake, #6591 exonerated → #6542 #6551 closed
+- [rust-engineer] #6590 + #6565 → PRs #6593 #6594 merged
+- [rust-engineer] flakes #6580 #6577 #6574 #6575 → PR #6596 merged
+- [rust-engineer] #6561 → PR #6597 merged; #6586 finished under option 1 → PR #6602 merged
+- [rust-engineer] #6595 product fix + critic WARN round + 0.12.4 bump → PR #6599 merged
+- [ticketing] filed #6595 #6600 #6601; all lifecycle labels advanced
+- [local-ops] rebuild+install from b3d0e50f1, daemons restarted, index intact
+- [qa] #6589 A/B report recovery (incomplete), rust-analyzer-lsp plugin re-enabled
+
+## In Progress
+- NONE — zero agents in flight at stop. Handed to session Dog.
+
+## Next Steps
+- (Dog) live-verify on the installed binaries and close from status:tested: #6590 #6565 #6580 #6577 #6574 #6575 #6561 #6586 #6595 — each issue's last comment states its condition
+- (Dog) #6595 proof = push-to-main gate run on b3d0e50f1, shard 2 (trusty-analyze on_demand) green; note on #6511
+- (Dog) #6600 and #6601 unclaimed, trusty-common rung 4
+- OWNER: main checkout is on chore/local-state-20260902 with two snapshots + sessions-log STAGED (not by this session) — commit+land as a snapshot PR (recommended) or drop; `git checkout main` refuses until resolved
+- OWNER: #6589 — re-run Arm B (~1–2 h, plugin disabled) or hold on the navigation result (recommended: hold, fix the mise-shim toolchain install first)
+- OWNER: authorize the won't-do sweep over paused(126)/backlog(191) to reach <300; ticketing builds the candidate list, nothing closes without confirmation
+- Do NOT re-run the install; do NOT re-dispatch any agent listed under Completed
+
+## Git Context
+Branch: HEAD
+Last commit: b3d0e50f1 fix(trusty-analyze): idle exit drops the redb stores before unlinking the socket so a respawn never hits its lock (#6599)
+Uncommitted changes: 2 file(s) changed
+
+## Tmux Window
+tm-trusty-tools-02:0:@2307


### PR DESCRIPTION
Docs-only: the tracked pause snapshot and log line written by the peer PM session (tmux tm-trusty-tools-02:0:@2307) at its shutdown, committed per the 2026-08-31 owner ruling that `.trusty-mpm/sessions/` is tracked.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KsTGDrDYKBPmHmmbRsMm5w