### PR TITLE
fix(sld,trusty-mpm): inline spec references fail closed on unsafe paths; doctor parity normalizes host-sampled rows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11590,7 +11590,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-code-tui"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11997,7 +11997,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-review"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-agents-common/changelog.d/6605-canonical-spec-ref-paths.md
+++ b/crates/trusty-agents-common/changelog.d/6605-canonical-spec-ref-paths.md
@@ -1,0 +1,5 @@
+Fixed
+
+- `harness_doc`'s `# Spec References` block names its spec by the
+  repo-root-relative path DOC-38 §2.1 requires, not a `../../` traversal
+  (#6605).

--- a/crates/trusty-agents-common/src/harness_doc.rs
+++ b/crates/trusty-agents-common/src/harness_doc.rs
@@ -1,6 +1,6 @@
 //! # Spec References
 //!
-//! - [`SPEC-HARNESS-UNDERSTANDING-01~draft`](../../docs/specs/harness-understanding.md)
+//! - [`SPEC-HARNESS-UNDERSTANDING-01~draft`](docs/specs/harness-understanding.md)
 //!
 //! Canonical harness-understanding instructions shared between trusty-mpm SM and
 //! future t-code overseer (DOC-21).

--- a/crates/trusty-code-tui/Cargo.toml
+++ b/crates/trusty-code-tui/Cargo.toml
@@ -4,13 +4,18 @@ description = "Engine-agnostic terminal-UI seam (TuiEngine trait + ReplEvent) sh
 homepage = "https://github.com/bobmatnyc/trusty-tools"
 keywords = ["tui", "repl", "terminal", "ratatui", "engine-adapter"]
 categories = ["command-line-interface", "asynchronous"]
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
 readme = "README.md"
+# 0.1.1 (#6605/#6577): PATCH bump — 0.1.0 is already published and this PR
+# edits several doc comments' `# Spec References` link paths to be
+# repo-root-relative. No public item changes shape; the `PR version bump vs
+# crates.io` gate (#4421) requires the bump since `src/**` changed.
+#
 # #4713: this crate is published. `trusty-code` depends on it from production
 # code (`src/cli/tui.rs`, `src/tui_client/`), and `cargo publish` refuses a
 # crate whose non-dev dependency is unpublishable — so the earlier

--- a/crates/trusty-code-tui/changelog.d/6605-canonical-spec-ref-paths.md
+++ b/crates/trusty-code-tui/changelog.d/6605-canonical-spec-ref-paths.md
@@ -1,0 +1,6 @@
+Fixed
+
+- Every `# Spec References` block names DOC-50 by its repo-root-relative path
+  rather than a `../../../` traversal, so the 25 references they declare are
+  checked by `check_sld.sh` instead of skipped (#6605). DOC-38 §2.1 permits a
+  file-relative path only in a Markdown visible section.

--- a/crates/trusty-code-tui/src/app/mod.rs
+++ b/crates/trusty-code-tui/src/app/mod.rs
@@ -104,8 +104,8 @@
 //!   faithfully from tagent, see above), so both triggers work.
 //!
 //! # Spec References
-//! - [`SPEC-TTUI-03~draft`](../../../docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-03~draft) — §3.2, the generalization layer.
-//! - [`SPEC-TTUI-05~draft`](../../../docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-05~draft) — Slice 4 deliverable (§5, Slice 4): `ReplApp` state.
+//! - [`SPEC-TTUI-03~draft`](docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-03~draft) — §3.2, the generalization layer.
+//! - [`SPEC-TTUI-05~draft`](docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-05~draft) — Slice 4 deliverable (§5, Slice 4): `ReplApp` state.
 
 mod reduce;
 

--- a/crates/trusty-code-tui/src/app/reduce.rs
+++ b/crates/trusty-code-tui/src/app/reduce.rs
@@ -31,7 +31,7 @@
 //! `ReplApp::quit`, since a spawned task can't reach `&mut ReplApp` directly.
 //!
 //! # Spec References
-//! - [`SPEC-TTUI-05~draft`](../../../docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-05~draft) — Slice 5 deliverable (§5, Slice 5): line-editor keymap + Ctrl-C daemon cancel.
+//! - [`SPEC-TTUI-05~draft`](docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-05~draft) — Slice 5 deliverable (§5, Slice 5): line-editor keymap + Ctrl-C daemon cancel.
 
 use super::ReplApp;
 use crate::event::{KeyCode, KeyInput, ReplEvent};

--- a/crates/trusty-code-tui/src/commands.rs
+++ b/crates/trusty-code-tui/src/commands.rs
@@ -38,7 +38,7 @@
 //!   `engine.handle_input`.
 //!
 //! # Spec References
-//! - [`SPEC-TTUI-05~draft`](../../../docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-05~draft) — Slice 7 deliverable (§5, Slice 7) and Q4 (mixed routing), Q6 (inline pickers).
+//! - [`SPEC-TTUI-05~draft`](docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-05~draft) — Slice 7 deliverable (§5, Slice 7) and Q4 (mixed routing), Q6 (inline pickers).
 
 use tokio::sync::mpsc::UnboundedSender;
 

--- a/crates/trusty-code-tui/src/engine.rs
+++ b/crates/trusty-code-tui/src/engine.rs
@@ -22,8 +22,8 @@
 //! event loop two sources of truth to reconcile.
 //!
 //! # Spec References
-//! - [`SPEC-TTUI-02~draft`](../../../docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-02~draft) — architecture, the engine-adapter seam.
-//! - [`SPEC-TTUI-03~draft`](../../../docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-03~draft) — Slice 1 trait shape; §3.2, Slice 1.5 generalization layer.
+//! - [`SPEC-TTUI-02~draft`](docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-02~draft) — architecture, the engine-adapter seam.
+//! - [`SPEC-TTUI-03~draft`](docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-03~draft) — Slice 1 trait shape; §3.2, Slice 1.5 generalization layer.
 
 use crate::event::ReplEvent;
 use crate::model::{CommandDescriptor, PickerRequest};
@@ -53,7 +53,7 @@ use tokio::sync::mpsc::UnboundedSender;
 /// shareable across that task boundary (typically via `Arc<dyn TuiEngine>`).
 ///
 /// # Spec References
-/// - [`SPEC-TTUI-02~draft`](../../../docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-02~draft)
+/// - [`SPEC-TTUI-02~draft`](docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-02~draft)
 #[async_trait::async_trait]
 pub trait TuiEngine: Send + Sync {
     /// Process one submitted line — either free-form chat input or a slash

--- a/crates/trusty-code-tui/src/event.rs
+++ b/crates/trusty-code-tui/src/event.rs
@@ -16,8 +16,8 @@
 //! terminal-library-agnostic.
 //!
 //! # Spec References
-//! - [`SPEC-TTUI-03~draft`](../../../docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-03~draft) — Slice 1 `ReplEvent` deliverable (§5, Slice 1).
-//! - [`SPEC-TTUI-05~draft`](../../../docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-05~draft) — per-variant slice ownership (Slices 5/6/8/9).
+//! - [`SPEC-TTUI-03~draft`](docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-03~draft) — Slice 1 `ReplEvent` deliverable (§5, Slice 1).
+//! - [`SPEC-TTUI-05~draft`](docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-05~draft) — per-variant slice ownership (Slices 5/6/8/9).
 
 use crate::model::StatuslineSegment;
 use serde::{Deserialize, Serialize};
@@ -40,7 +40,7 @@ use serde::{Deserialize, Serialize};
 /// cards in Slice 8, permission prompts in Slice 9).
 ///
 /// # Spec References
-/// - [`SPEC-TTUI-05~draft`](../../../docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-05~draft)
+/// - [`SPEC-TTUI-05~draft`](docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-05~draft)
 #[derive(Debug, Clone, PartialEq)]
 pub enum ReplEvent {
     // ── Terminal-origin (Slice 2, #3414, wires the producer) ──────────

--- a/crates/trusty-code-tui/src/keys.rs
+++ b/crates/trusty-code-tui/src/keys.rs
@@ -18,7 +18,7 @@
 //! variant upstream.
 //!
 //! # Spec References
-//! - [`SPEC-TTUI-05~draft`](../../../docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-05~draft) — Slice 2 deliverable (§5, Slice 2).
+//! - [`SPEC-TTUI-05~draft`](docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-05~draft) — Slice 2 deliverable (§5, Slice 2).
 
 use crossterm::event::{KeyCode as CtKeyCode, KeyEvent, KeyModifiers as CtKeyModifiers};
 

--- a/crates/trusty-code-tui/src/layout.rs
+++ b/crates/trusty-code-tui/src/layout.rs
@@ -16,7 +16,7 @@
 //! row, another separator, and the statusline, with a trailing blank spacer.
 //!
 //! # Spec References
-//! - [`SPEC-TTUI-05~draft`](../../../docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-05~draft) — Slice 4 deliverable (§5, Slice 4): migrate `layout.rs`.
+//! - [`SPEC-TTUI-05~draft`](docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-05~draft) — Slice 4 deliverable (§5, Slice 4): migrate `layout.rs`.
 
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Modifier, Style};

--- a/crates/trusty-code-tui/src/lib.rs
+++ b/crates/trusty-code-tui/src/lib.rs
@@ -47,9 +47,9 @@
 //! type.
 //!
 //! # Spec References
-//! - [`SPEC-TTUI-02~draft`](../../../docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-02~draft) — architecture, the engine-adapter seam.
-//! - [`SPEC-TTUI-03~draft`](../../../docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-03~draft) — extraction and migration plan.
-//! - [`SPEC-TTUI-05~draft`](../../../docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-05~draft) — Slice 1, 2, and 4 deliverables and acceptance criteria.
+//! - [`SPEC-TTUI-02~draft`](docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-02~draft) — architecture, the engine-adapter seam.
+//! - [`SPEC-TTUI-03~draft`](docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-03~draft) — extraction and migration plan.
+//! - [`SPEC-TTUI-05~draft`](docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-05~draft) — Slice 1, 2, and 4 deliverables and acceptance criteria.
 
 // docs.rs builds a release's documentation once, from the uploaded tarball,
 // so a broken intra-doc link is baked into that version forever and only a new

--- a/crates/trusty-code-tui/src/model.rs
+++ b/crates/trusty-code-tui/src/model.rs
@@ -28,8 +28,8 @@
 //! the engine populates.
 //!
 //! # Spec References
-//! - [`SPEC-TTUI-03~draft`](../../../docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-03~draft) — §3.2, the generalization layer this module implements.
-//! - [`SPEC-TTUI-05~draft`](../../../docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-05~draft) — Slice 1.5 deliverable and acceptance criteria.
+//! - [`SPEC-TTUI-03~draft`](docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-03~draft) — §3.2, the generalization layer this module implements.
+//! - [`SPEC-TTUI-05~draft`](docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-05~draft) — Slice 1.5 deliverable and acceptance criteria.
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/trusty-code-tui/src/render/markdown.rs
+++ b/crates/trusty-code-tui/src/render/markdown.rs
@@ -16,7 +16,7 @@
 //! (see that module's doc comment for the distinction).
 //!
 //! # Spec References
-//! - [`SPEC-TTUI-05~draft`](../../../docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-05~draft) — Slice 4 deliverable (§5, Slice 4): migrate `markdown.rs`.
+//! - [`SPEC-TTUI-05~draft`](docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-05~draft) — Slice 4 deliverable (§5, Slice 4): migrate `markdown.rs`.
 
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};

--- a/crates/trusty-code-tui/src/render/mod.rs
+++ b/crates/trusty-code-tui/src/render/mod.rs
@@ -9,6 +9,6 @@
 //! visible from the module boundary, not just from reading each function.
 //!
 //! # Spec References
-//! - [`SPEC-TTUI-03~draft`](../../../docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-03~draft) — §3.1 module layout (`render/markdown.rs`).
+//! - [`SPEC-TTUI-03~draft`](docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-03~draft) — §3.1 module layout (`render/markdown.rs`).
 
 pub mod markdown;

--- a/crates/trusty-code-tui/src/run/mod.rs
+++ b/crates/trusty-code-tui/src/run/mod.rs
@@ -45,7 +45,7 @@
 //! before the (now-bounded) thread join, on every exit path.
 //!
 //! # Spec References
-//! - [`SPEC-TTUI-05~draft`](../../../docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-05~draft) — Slice 2 deliverable (§5, Slice 2): the event loop.
+//! - [`SPEC-TTUI-05~draft`](docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-05~draft) — Slice 2 deliverable (§5, Slice 2): the event loop.
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};

--- a/crates/trusty-code-tui/src/terminal.rs
+++ b/crates/trusty-code-tui/src/terminal.rs
@@ -26,7 +26,7 @@
 //! succeed on this particular host.
 //!
 //! # Spec References
-//! - [`SPEC-TTUI-05~draft`](../../../docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-05~draft) — Slice 2 deliverable (§5, Slice 2): panic-safe terminal guard.
+//! - [`SPEC-TTUI-05~draft`](docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-05~draft) — Slice 2 deliverable (§5, Slice 2): panic-safe terminal guard.
 
 use std::io::{self, Stdout};
 

--- a/crates/trusty-code-tui/src/text.rs
+++ b/crates/trusty-code-tui/src/text.rs
@@ -13,7 +13,7 @@
 //! `strip_interior_blank_lines` (DOC-50 §3.1/§5 Slice 4 migration).
 //!
 //! # Spec References
-//! - [`SPEC-TTUI-05~draft`](../../../docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-05~draft) — Slice 4 deliverable (§5, Slice 4).
+//! - [`SPEC-TTUI-05~draft`](docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-05~draft) — Slice 4 deliverable (§5, Slice 4).
 
 /// Strip leading and trailing whitespace-only lines from a multi-line string.
 ///

--- a/crates/trusty-code-tui/src/widgets/banner.rs
+++ b/crates/trusty-code-tui/src/widgets/banner.rs
@@ -20,7 +20,7 @@
 //! `ReplApp` fields instead of hard-coded content.
 //!
 //! # Spec References
-//! - [`SPEC-TTUI-05~draft`](../../../docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-05~draft) — Slice 4 deliverable (§5, Slice 4): migrate `banner.rs`.
+//! - [`SPEC-TTUI-05~draft`](docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-05~draft) — Slice 4 deliverable (§5, Slice 4): migrate `banner.rs`.
 
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};

--- a/crates/trusty-code-tui/src/widgets/input_composer.rs
+++ b/crates/trusty-code-tui/src/widgets/input_composer.rs
@@ -19,7 +19,7 @@
 //! text.
 //!
 //! # Spec References
-//! - [`SPEC-TTUI-05~draft`](../../../docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-05~draft) — Slice 4 deliverable (§5, Slice 4): migrate the input composer.
+//! - [`SPEC-TTUI-05~draft`](docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-05~draft) — Slice 4 deliverable (§5, Slice 4): migrate the input composer.
 
 use ratatui::layout::Rect;
 use ratatui::style::{Modifier, Style};

--- a/crates/trusty-code-tui/src/widgets/mod.rs
+++ b/crates/trusty-code-tui/src/widgets/mod.rs
@@ -15,8 +15,8 @@
 //! crate must never contain; see DOC-50 §3.2 and Q9).
 //!
 //! # Spec References
-//! - [`SPEC-TTUI-03~draft`](../../../docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-03~draft) — §3.1 module layout (`widgets/`).
-//! - [`SPEC-TTUI-05~draft`](../../../docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-05~draft) — Slice 4 deliverable (§5, Slice 4).
+//! - [`SPEC-TTUI-03~draft`](docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-03~draft) — §3.1 module layout (`widgets/`).
+//! - [`SPEC-TTUI-05~draft`](docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-05~draft) — Slice 4 deliverable (§5, Slice 4).
 
 pub mod banner;
 pub mod input_composer;

--- a/crates/trusty-code-tui/src/widgets/scrollback.rs
+++ b/crates/trusty-code-tui/src/widgets/scrollback.rs
@@ -18,7 +18,7 @@
 //! `app.last_max_scroll`.
 //!
 //! # Spec References
-//! - [`SPEC-TTUI-05~draft`](../../../docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-05~draft) — Slice 4 deliverable (§5, Slice 4): migrate `chat.rs`.
+//! - [`SPEC-TTUI-05~draft`](docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-05~draft) — Slice 4 deliverable (§5, Slice 4): migrate `chat.rs`.
 
 use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier, Style};

--- a/crates/trusty-code-tui/src/widgets/status_line.rs
+++ b/crates/trusty-code-tui/src/widgets/status_line.rs
@@ -26,8 +26,8 @@
 //! [`draw_statusline`] renders it into a `Frame`.
 //!
 //! # Spec References
-//! - [`SPEC-TTUI-03~draft`](../../../docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-03~draft) — §3.2, the generalization layer this renders.
-//! - [`SPEC-TTUI-05~draft`](../../../docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-05~draft) — Slice 4 deliverable (§5, Slice 4): the status-line widget.
+//! - [`SPEC-TTUI-03~draft`](docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-03~draft) — §3.2, the generalization layer this renders.
+//! - [`SPEC-TTUI-05~draft`](docs/specs/DOC-50-tcode-tui-claude-code-clone.md#SPEC-TTUI-05~draft) — Slice 4 deliverable (§5, Slice 4): the status-line widget.
 
 use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier, Style};

--- a/crates/trusty-common/changelog.d/6605-inline-spec-refs-fail-closed.md
+++ b/crates/trusty-common/changelog.d/6605-inline-spec-refs-fail-closed.md
@@ -1,0 +1,11 @@
+Fixed
+
+- `sld::parse_inline_refs` no longer drops an inline `# Spec References` entry
+  whose path carries a `..` traversal segment or is absolute. It used to
+  `continue` past one with no diagnostic, so the reference never reached
+  `check_reference` and its anchor was never validated — a whole block could
+  name a spec id that exists nowhere and `check_sld.sh` still reported
+  `0 error(s)` (#6605). The reader now returns every reference the DOC-38 §2.2
+  grammar matches, whatever the path shape, and leaves §2.1 path conformance to
+  the linter, which has a `file:line` to report it at. Safe, repo-root-relative
+  paths behave exactly as before.

--- a/crates/trusty-common/src/sld/inline.rs
+++ b/crates/trusty-common/src/sld/inline.rs
@@ -19,7 +19,7 @@
 
 use super::Reference;
 use super::comment::CommentSyntax;
-use super::grammar::{is_unsafe_path, reference_regex};
+use super::grammar::reference_regex;
 
 /// True when a stripped line opens or closes a Markdown code fence (§2.3).
 ///
@@ -94,12 +94,14 @@ fn comment_content(trimmed: &str, syntax: &CommentSyntax, in_doc: &mut bool) -> 
 /// stays part of the block (and is scanned by the §2.2 reference regex) only
 /// while it is blank or `-`-prefixed after stripping the comment lead-in — the
 /// first line that is neither closes the block WITHOUT being scanned, so trailing
-/// prose in the same comment run can never masquerade as a declaration. Extracted
-/// references drop any unsafe path (a `..` traversal segment or an absolute
-/// path, §2.1's repo-root-relative canonical form). Duplicates are retained
-/// (each keeps its own line) so a linter can flag each occurrence.
+/// prose in the same comment run can never masquerade as a declaration. Every
+/// reference the §2.2 regex matches is returned, whatever its path shape:
+/// conformance to §2.1's repo-root-relative canonical form is decided by the
+/// linter, which has a `file:line` diagnostic to report it with. Duplicates are
+/// retained (each keeps its own line) so a linter can flag each occurrence.
 /// Test: `super::tests::inline_rust`, `inline_bare_shell`, `inline_skips_fenced`,
-/// `inline_ignores_non_block_ref`, `inline_hash_block_closes_on_prose`.
+/// `inline_ignores_non_block_ref`, `inline_hash_block_closes_on_prose`,
+/// `inline_keeps_traversal_path_for_the_linter`.
 #[must_use]
 pub fn parse_inline_refs(source: &str, syntax: &CommentSyntax) -> Vec<Reference> {
     let mut refs = Vec::new();
@@ -153,13 +155,14 @@ pub fn parse_inline_refs(source: &str, syntax: &CommentSyntax) -> Vec<Reference>
                 continue;
             }
             for caps in reference_regex().captures_iter(&content) {
-                let path = caps[2].to_string();
-                if is_unsafe_path(&path) {
-                    continue;
-                }
+                // #6605: every declared reference is recovered, path shape
+                // included. Judging the path is the linter's job
+                // (`check_reference`'s `ref-traversal`), not the reader's —
+                // dropping one here made it invisible to the one gate meant to
+                // catch it.
                 refs.push(Reference {
                     id: caps[1].to_string(),
-                    path,
+                    path: caps[2].to_string(),
                     anchor: caps[3].to_string(),
                     line,
                 });

--- a/crates/trusty-common/src/sld/tests.rs
+++ b/crates/trusty-common/src/sld/tests.rs
@@ -154,6 +154,37 @@ fn inline_hash_block_closes_on_prose() {
 }
 
 #[test]
+fn inline_keeps_traversal_path_for_the_linter() {
+    // #6605: the reader used to drop a reference whose path carried a `..`
+    // traversal segment, with no diagnostic. That made the whole block
+    // invisible to `check_sld.sh` — `crates/trusty-git-analytics/src/audit/
+    // sweep.rs` carried a bogus anchor (`SPEC-TGAUDIT-98~draft`) that the gate
+    // reported as `0 error(s)`. The reader now returns every declared
+    // reference; DOC-38 §2.1 path conformance is the linter's call, and it
+    // reports it as `ref-traversal` at `file:line`.
+    let src = "//! # Spec References\n//! - [`SPEC-TGAUDIT-98~draft`](../../../../docs/specs/DOC-67-tga-audit-mode.md#SPEC-TGAUDIT-98~draft)";
+    let refs = parse_inline_refs(src, &syntax_for_extension("rs").unwrap());
+    assert_eq!(
+        refs.len(),
+        1,
+        "a traversal path must reach the linter, not vanish: {refs:?}"
+    );
+    assert_eq!(refs[0].id, "SPEC-TGAUDIT-98~draft");
+    assert_eq!(
+        refs[0].path,
+        "../../../../docs/specs/DOC-67-tga-audit-mode.md"
+    );
+    assert_eq!(refs[0].line, 2);
+
+    // An absolute path is the same class of non-conformance and is likewise
+    // handed on rather than swallowed.
+    let abs = "//! # Spec References\n//! - [`SPEC-SLD-01~draft`](/docs/specs/spec-linked-documentation.md#SPEC-SLD-01~draft)";
+    let abs_refs = parse_inline_refs(abs, &syntax_for_extension("rs").unwrap());
+    assert_eq!(abs_refs.len(), 1, "absolute path must reach the linter");
+    assert_eq!(abs_refs[0].path, "/docs/specs/spec-linked-documentation.md");
+}
+
+#[test]
 fn inline_skips_fenced() {
     // A fenced example inside the block must NOT be extracted; the block
     // survives the fence and the real ref after it IS extracted.

--- a/crates/trusty-git-analytics/changelog.d/6605-canonical-spec-ref-paths.md
+++ b/crates/trusty-git-analytics/changelog.d/6605-canonical-spec-ref-paths.md
@@ -1,0 +1,8 @@
+Fixed
+
+- The `audit` module's `# Spec References` blocks name DOC-67 by its
+  repo-root-relative path rather than a `../../../../` traversal, which DOC-38
+  §2.1 permits only in a Markdown visible section. Eleven references were
+  silently unchecked as a result (#6605). `run_full_sweep`'s stage-order note
+  moved out of the reference block, where its prose closed the block and left
+  two more references unscanned.

--- a/crates/trusty-git-analytics/src/audit/analyze.rs
+++ b/crates/trusty-git-analytics/src/audit/analyze.rs
@@ -34,8 +34,8 @@
 //! against the real `trusty-analyze` binary.
 //!
 //! # Spec References
-//! - [`SPEC-TGAUDIT-06~draft`](../../../../docs/specs/DOC-67-tga-audit-mode.md#SPEC-TGAUDIT-06~draft)
-//! - [`SPEC-TGAUDIT-09~draft`](../../../../docs/specs/DOC-67-tga-audit-mode.md#SPEC-TGAUDIT-09~draft)
+//! - [`SPEC-TGAUDIT-06~draft`](docs/specs/DOC-67-tga-audit-mode.md#SPEC-TGAUDIT-06~draft)
+//! - [`SPEC-TGAUDIT-09~draft`](docs/specs/DOC-67-tga-audit-mode.md#SPEC-TGAUDIT-09~draft)
 
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};

--- a/crates/trusty-git-analytics/src/audit/real_binary_tests.rs
+++ b/crates/trusty-git-analytics/src/audit/real_binary_tests.rs
@@ -34,7 +34,7 @@
 //! Test: this module.
 //!
 //! # Spec References
-//! - [`SPEC-TGAUDIT-06~draft`](../../../../docs/specs/DOC-67-tga-audit-mode.md#SPEC-TGAUDIT-06~draft)
+//! - [`SPEC-TGAUDIT-06~draft`](docs/specs/DOC-67-tga-audit-mode.md#SPEC-TGAUDIT-06~draft)
 
 use std::path::{Path, PathBuf};
 use std::time::Duration;

--- a/crates/trusty-git-analytics/src/audit/repo_index.rs
+++ b/crates/trusty-git-analytics/src/audit/repo_index.rs
@@ -51,8 +51,8 @@
 //! on.
 //!
 //! # Spec References
-//! - [`SPEC-TGAUDIT-06~draft`](../../../../docs/specs/DOC-67-tga-audit-mode.md#SPEC-TGAUDIT-06~draft)
-//! - [`SPEC-TGAUDIT-09~draft`](../../../../docs/specs/DOC-67-tga-audit-mode.md#SPEC-TGAUDIT-09~draft)
+//! - [`SPEC-TGAUDIT-06~draft`](docs/specs/DOC-67-tga-audit-mode.md#SPEC-TGAUDIT-06~draft)
+//! - [`SPEC-TGAUDIT-09~draft`](docs/specs/DOC-67-tga-audit-mode.md#SPEC-TGAUDIT-09~draft)
 
 use std::ffi::OsString;
 use std::path::Path;

--- a/crates/trusty-git-analytics/src/audit/search_daemon.rs
+++ b/crates/trusty-git-analytics/src/audit/search_daemon.rs
@@ -41,8 +41,8 @@
 //! against the real `trusty-search` binary.
 //!
 //! # Spec References
-//! - [`SPEC-TGAUDIT-06~draft`](../../../../docs/specs/DOC-67-tga-audit-mode.md#SPEC-TGAUDIT-06~draft)
-//! - [`SPEC-TGAUDIT-09~draft`](../../../../docs/specs/DOC-67-tga-audit-mode.md#SPEC-TGAUDIT-09~draft)
+//! - [`SPEC-TGAUDIT-06~draft`](docs/specs/DOC-67-tga-audit-mode.md#SPEC-TGAUDIT-06~draft)
+//! - [`SPEC-TGAUDIT-09~draft`](docs/specs/DOC-67-tga-audit-mode.md#SPEC-TGAUDIT-09~draft)
 
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};

--- a/crates/trusty-git-analytics/src/audit/sweep.rs
+++ b/crates/trusty-git-analytics/src/audit/sweep.rs
@@ -96,13 +96,15 @@ pub struct SweepOptions {
 /// `super::tests::failed_stage_is_recorded_and_does_not_stop_the_sweep`,
 /// `super::tests::sweep_emits_progress_for_non_collection_stages`.
 ///
+/// `SPEC-TGAUDIT-05~draft` §5 "Executed stage order" lists the nine stages this
+/// body runs, in this order (#5306). Changing the sequence here means changing
+/// that list.
+///
 /// # Spec References
-/// - [`SPEC-TGAUDIT-02~draft`](../../../../docs/specs/DOC-67-tga-audit-mode.md#SPEC-TGAUDIT-02~draft)
-/// - [`SPEC-TGAUDIT-05~draft`](../../../../docs/specs/DOC-67-tga-audit-mode.md#SPEC-TGAUDIT-05~draft)
-///   — §5 "Executed stage order" lists the nine stages this body runs, in this
-///   order (#5306). Changing the sequence here means changing that list.
-/// - [`SPEC-TGAUDIT-07~draft`](../../../../docs/specs/DOC-67-tga-audit-mode.md#SPEC-TGAUDIT-07~draft)
-/// - [`SPEC-TGAUDIT-09~draft`](../../../../docs/specs/DOC-67-tga-audit-mode.md#SPEC-TGAUDIT-09~draft)
+/// - [`SPEC-TGAUDIT-02~draft`](docs/specs/DOC-67-tga-audit-mode.md#SPEC-TGAUDIT-02~draft)
+/// - [`SPEC-TGAUDIT-05~draft`](docs/specs/DOC-67-tga-audit-mode.md#SPEC-TGAUDIT-05~draft)
+/// - [`SPEC-TGAUDIT-07~draft`](docs/specs/DOC-67-tga-audit-mode.md#SPEC-TGAUDIT-07~draft)
+/// - [`SPEC-TGAUDIT-09~draft`](docs/specs/DOC-67-tga-audit-mode.md#SPEC-TGAUDIT-09~draft)
 pub async fn run_full_sweep(
     config: &Config,
     db: &mut Database,

--- a/crates/trusty-mpm/src/daemon/rpc/core_tests.rs
+++ b/crates/trusty-mpm/src/daemon/rpc/core_tests.rs
@@ -32,11 +32,16 @@
 //!   and "83 of 511" on the next, because any process on the box opens or closes
 //!   a pty between the two reads (#6577).
 //!
-//! All four probes sample host state the daemon re-reads per call, which is
-//! what makes their messages the only host-sampled strings in the report. Their
-//! `name` and `status` are still compared, so a check that vanished or changed
-//! verdict between the transports still fails — see
-//! [`HOST_SAMPLED_MESSAGE_CHECKS`] and [`blank_host_sampled_messages`].
+//! All four probes sample host state the daemon re-reads per call, and #6577
+//! showed the STATUS is sampled with the message rather than beside it:
+//! `worktree_disk` answers `unknown` when its 3-second deadline expires and
+//! `warn` when it measured enough, so the same churn that moves its byte count
+//! moves its verdict. Four of ten runs on a 36-worktree host failed that way
+//! with the message already blanked. These four checks are therefore compared
+//! STRUCTURALLY — the check is present under its name, and it still reports
+//! some status — while both host-sampled fields are normalized. Every other
+//! check is compared whole, verdict included. See [`HOST_SAMPLED_CHECKS`] and
+//! [`normalize_host_sampled_checks`].
 //!
 //! Nothing else is excused. Every other method is compared whole, `pid`
 //! included — the two transports run in one process, so a `pid` that differed
@@ -420,9 +425,9 @@ async fn parity_tmux_sessions_agrees_across_transports() {
 
 /// Why `generated_at` is dropped: `DoctorReport::from_checks` stamps it with
 /// `Utc::now()` on every call, so two calls differ there by construction. The
-/// two [`HOST_SAMPLED_MESSAGE_CHECKS`] messages are blanked for the same
-/// reason. Every other field — the overall status, and every check's name,
-/// status and message — is compared whole.
+/// [`HOST_SAMPLED_CHECKS`] rows are normalized for the same reason, message and
+/// status alike (#6577). Every other field — the overall status, and every
+/// other check's name, status and message — is compared whole.
 ///
 /// Why serial: the agent, asset-tier and hooks checks resolve paths under
 /// `$HOME`, and several tests in this binary move `$HOME` process-wide through
@@ -457,76 +462,88 @@ async fn parity_doctor_agrees_across_transports() {
     );
     assert_same(
         "mpm.doctor",
-        blank_host_sampled_messages(body),
-        blank_host_sampled_messages(result),
+        normalize_host_sampled_checks(body),
+        normalize_host_sampled_checks(result),
         &["generated_at"],
     );
 }
 
-/// The doctor checks whose `message` samples live host state, by name (#6358,
+/// The doctor checks that RE-SAMPLE host state on every call, by name (#6358,
 /// #6490, #6577).
 ///
-/// The membership rule, so the next such check need not flake first: a check
-/// belongs here when its message embeds a number or a name it RE-SAMPLES FROM
-/// THE HOST on every call. A message built from config on disk, or from the
-/// daemon's own state, does not.
+/// **Membership rule:** a check belongs here when any part of its answer —
+/// message or status — is derived from a quantity it re-reads from the host on
+/// every call, rather than from config on disk or the daemon's own state.
 ///
-/// Why exactly these four: each puts live host state the daemon re-reads per
-/// call into its message. `worktree_disk` reports how far it got against a
-/// 3-second deadline ("6.2 GiB … 268 worktree(s) went unmeasured" on one call,
-/// "6.8 GiB … 267" on the next) and `worktrees` reports the reconciled
-/// inventory's counts ("14 live, 265 not reclaimable" against "266"), both
-/// changing whenever an agent elsewhere on the machine adds or removes a
-/// worktree between this test's two calls. `session_store` reports the record
-/// count and byte length of `sessions.json` ("43 session record(s), 59773
-/// byte(s)" against "44 … 60950"), which change whenever a concurrent managed
-/// session writes that file between the two reads (#6490). `pty_headroom`
-/// reports a live census of allocated pseudo-terminals ("82 of 511
-/// pseudo-terminals allocated" against "83 of 511"), which changes whenever any
-/// process on this machine opens or closes a pty between the two reads (#6577).
-/// All four are the
-/// PROBE varying, not the transports disagreeing. Only the MESSAGE is host-
-/// sampled: each check's `status` is a stable verdict (`session_store` stays
-/// `Ok` while only its counts churn), so it is still compared — a store that
-/// went `Fail` over one transport but not the other is a real finding this
-/// test must still catch. Every other check's message reads config on disk or a
-/// daemon's own answer, and is compared whole.
-/// What: the names [`blank_host_sampled_messages`] blanks.
+/// Why exactly these four: `worktree_disk` measures the worktree tree against a
+/// 3-second deadline, `worktrees` reports the reconciled inventory's counts,
+/// `session_store` reports `sessions.json`'s record count and byte length
+/// (#6490), and `pty_headroom` takes a live census of allocated pseudo-terminals
+/// (#6577). Each answer moves whenever another process on the machine adds a
+/// worktree, writes a session, or opens a pty between this test's two calls.
+///
+/// Why the status is normalized too, and not just the message (#6577): the
+/// status is computed FROM the sample, so it churns with it. `worktree_disk`
+/// answers `unknown` when its deadline expires mid-walk and `warn` when it
+/// measured enough to judge — four of ten runs on a 36-worktree host failed on
+/// exactly that pair, with the message already blanked. Blanking field-by-field
+/// as each one surfaced is what let #6358 (one message) and #6596 (a second)
+/// both land and leave the test flaking; the fields of a host-sampled probe are
+/// not independently stable, so the row is normalized whole.
+///
+/// What survives is structural, and it is not vacuous: the check must still be
+/// PRESENT under its name in both reports, and must still REPORT a status. A
+/// check that vanished over one transport, or answered with no status at all,
+/// still fails. Every check NOT named here is compared whole, verdict included.
+/// What: the names [`normalize_host_sampled_checks`] normalizes.
 /// Test: [`parity_doctor_agrees_across_transports`],
-/// [`session_store_message_is_excluded_from_parity_but_its_status_is_not`].
-const HOST_SAMPLED_MESSAGE_CHECKS: &[&str] = &[
+/// [`host_sampled_status_is_excused_from_parity_and_no_other_check_is`].
+const HOST_SAMPLED_CHECKS: &[&str] = &[
     "worktree_disk",
     "worktrees",
-    // #6490: session_store's message samples sessions.json's live record count.
+    // #6490: session_store samples sessions.json's live record count.
     "session_store",
-    // #6577: pty_headroom's message samples this machine's live pty census.
+    // #6577: pty_headroom samples this machine's live pty census.
     "pty_headroom",
 ];
 
-/// Blank each [`HOST_SAMPLED_MESSAGE_CHECKS`] message, keeping name and status.
+/// Reduce each [`HOST_SAMPLED_CHECKS`] row to what cannot churn: its name, and
+/// that it answered with a status at all.
 ///
-/// Why the presence assertion: a blank-by-name pass over a report that no
-/// longer contains the name would silently exclude nothing, and the test would
-/// go back to flaking on a message it believed it had dropped. Requiring every
-/// named check to appear turns a rename into a failure that says so.
-fn blank_host_sampled_messages(mut report: Value) -> Value {
-    let mut blanked: Vec<String> = Vec::new();
+/// Why the two assertions: a normalize-by-name pass over a report that no longer
+/// contains the name would silently exclude nothing, and the test would go back
+/// to flaking on a field it believed it had dropped — so every named check must
+/// appear. And a row whose `status` is missing or empty is a real defect the
+/// normalization must not hide, so the field's PRESENCE is asserted before its
+/// value is replaced (#6577). That is the whole of what "structural" gives up:
+/// the verdict's value, never the check or the field.
+fn normalize_host_sampled_checks(mut report: Value) -> Value {
+    let mut normalized: Vec<String> = Vec::new();
     if let Some(checks) = report.get_mut("checks").and_then(Value::as_array_mut) {
         for check in checks {
             let Some(name) = check.get("name").and_then(Value::as_str).map(str::to_owned) else {
                 continue;
             };
-            if HOST_SAMPLED_MESSAGE_CHECKS.contains(&name.as_str())
+            if HOST_SAMPLED_CHECKS.contains(&name.as_str())
                 && let Some(map) = check.as_object_mut()
             {
+                // #6577: the value is normalized, the field is not dropped.
+                assert!(
+                    map.get("status")
+                        .and_then(Value::as_str)
+                        .is_some_and(|s| !s.is_empty()),
+                    "the `{name}` check must still report a status — normalizing \
+                     its VALUE is what this allowlist buys, dropping the field is not"
+                );
                 map.insert("message".into(), json!("<host-sampled>"));
-                blanked.push(name);
+                map.insert("status".into(), json!("<host-sampled>"));
+                normalized.push(name);
             }
         }
     }
-    for name in HOST_SAMPLED_MESSAGE_CHECKS {
+    for name in HOST_SAMPLED_CHECKS {
         assert!(
-            blanked.iter().any(|seen| seen == name),
+            normalized.iter().any(|seen| seen == name),
             "the allowlist names the `{name}` check, which this report does not \
              contain — a renamed check must fail here rather than silently stop \
              being excluded"
@@ -535,58 +552,73 @@ fn blank_host_sampled_messages(mut report: Value) -> Value {
     report
 }
 
-/// Pin what adding `session_store` to the allowlist bought (#6490): its live-
-/// sampled MESSAGE is dropped from the parity comparison, while its STATUS is
-/// not — so the count/bytes churn that flaked the test is excused, but a genuine
-/// cross-transport verdict divergence still fails.
+/// Pin both halves of the #6577 contract: a [`HOST_SAMPLED_CHECKS`] row that
+/// differs in STATUS between the two samples passes parity, and a row that is
+/// not on that list and differs in status still fails it.
 ///
-/// Why a hand-built pair rather than the live parity test: the flake needs
-/// another process to write `sessions.json` between the two reads, which cannot
-/// be forced deterministically. Feeding [`blank_host_sampled_messages`] two
-/// reports directly reproduces both the churn (message differs, status same) and
-/// the real break (status differs) with no host dependency, and proves the
-/// exclusion is not vacuous — the exact bar #6358's fix was held to.
+/// Why a hand-built pair rather than the live parity test: the divergence needs
+/// another process to add a worktree, write `sessions.json`, or open a pty
+/// between the two reads, which cannot be forced deterministically. Feeding
+/// [`normalize_host_sampled_checks`] two reports directly reproduces both the
+/// churn and the real break with no host dependency, and proves the exclusion is
+/// not vacuous — the bar #6358 and #6490 were each held to, now applied to the
+/// status field the earlier message-only fixes left compared.
 /// Test: this function IS the test.
 #[test]
-fn session_store_message_is_excluded_from_parity_but_its_status_is_not() {
+fn host_sampled_status_is_excused_from_parity_and_no_other_check_is() {
     // Every host-sampled check is present, so the presence assertion inside
-    // `blank_host_sampled_messages` is satisfied and only the exclusion is tested.
-    let report = |session_store_status: &str, session_store_message: &str| {
+    // `normalize_host_sampled_checks` is satisfied and only the exclusion is
+    // under test. `instructions` is the control: it reads config on disk, so it
+    // is NOT on the allowlist and is compared whole.
+    let report = |worktree_disk_status: &str, instructions_status: &str| {
         json!({
             "checks": [
-                {"name": "worktree_disk", "status": "ok", "message": "6.2 GiB measured"},
+                {"name": "worktree_disk", "status": worktree_disk_status, "message": "6.2 GiB measured"},
                 {"name": "worktrees", "status": "ok", "message": "14 live, 265 not reclaimable"},
-                {"name": "session_store", "status": session_store_status, "message": session_store_message},
-                // #6577: present so the presence assertion is satisfied.
+                {"name": "session_store", "status": "ok", "message": "43 session record(s), 59773 byte(s)"},
                 {"name": "pty_headroom", "status": "ok", "message": "82 of 511 pseudo-terminals allocated"},
+                {"name": "instructions", "status": instructions_status, "message": "last-instructions.md not found"},
             ]
         })
     };
 
-    // The #6490 case: a concurrent session grew `sessions.json` between the two
-    // reads, so only the message differs. After blanking, the transports agree.
-    let http = blank_host_sampled_messages(report(
-        "ok",
-        "…/sessions.json loads cleanly — 43 session record(s), 59773 byte(s)",
-    ));
-    let socket = blank_host_sampled_messages(report(
-        "ok",
-        "…/sessions.json loads cleanly — 44 session record(s), 60950 byte(s)",
-    ));
+    // The #6577 case: `worktree_disk`'s 3-second deadline expired on one call
+    // and not the other, so its VERDICT differs — `unknown` against `warn` —
+    // with nothing else changed. That is the probe varying, not the transports
+    // disagreeing, and it must not fail parity.
+    let http = normalize_host_sampled_checks(report("unknown", "warn"));
+    let socket = normalize_host_sampled_checks(report("warn", "warn"));
     assert_eq!(
         http, socket,
-        "a session_store message that churned between the reads must not fail parity"
+        "a host-sampled check whose status churned between the reads must not fail parity"
     );
 
-    // Non-vacuous: a real verdict divergence survives the blanking, so the
-    // parity assertion still fails on it. A store one transport called healthy
-    // and the other called corrupt is a finding, not noise.
-    let http = blank_host_sampled_messages(report("ok", "loads cleanly"));
-    let socket = blank_host_sampled_messages(report("fail", "loads cleanly"));
+    // Non-vacuous: a check that is NOT host-sampled still has its verdict
+    // compared, so a genuine cross-transport divergence still fails. Weakening
+    // the comparison for the four named rows must not weaken it for any other.
+    let http = normalize_host_sampled_checks(report("warn", "ok"));
+    let socket = normalize_host_sampled_checks(report("warn", "fail"));
     assert_ne!(
         http, socket,
-        "a session_store STATUS divergence must still fail parity"
+        "a NON-host-sampled check's STATUS divergence must still fail parity"
     );
+}
+
+/// A host-sampled row that answers with no status at all is a defect, not churn
+/// — [`normalize_host_sampled_checks`] replaces the verdict's VALUE and must not
+/// paper over a missing field (#6577).
+/// Test: this function IS the test.
+#[test]
+#[should_panic(expected = "must still report a status")]
+fn normalizing_a_host_sampled_check_requires_it_to_report_a_status() {
+    normalize_host_sampled_checks(json!({
+        "checks": [
+            {"name": "worktree_disk", "message": "6.2 GiB measured"},
+            {"name": "worktrees", "status": "ok", "message": "14 live"},
+            {"name": "session_store", "status": "ok", "message": "43 record(s)"},
+            {"name": "pty_headroom", "status": "ok", "message": "82 of 511"},
+        ]
+    }));
 }
 
 /// Why an unknown fingerprint: it exercises the whole route — argument decode,

--- a/crates/trusty-review/Cargo.toml
+++ b/crates/trusty-review/Cargo.toml
@@ -72,7 +72,13 @@ name        = "trusty-review"
 # (`src/service/handlers.rs:187`), which stops a downstream crate constructing
 # or exhaustively matching it. Cargo's 0.x rule puts a break in the MINOR
 # position.
-version     = "0.31.0"
+#
+# 0.31.1 (#6605/#6577): PATCH bump — 0.31.0 is already published and this PR
+# edits `src/report/exec_summary.rs`'s doc comment, fixing a `# Spec
+# References` link path to be repo-root-relative. No public item changes
+# shape; the `PR version bump vs crates.io` gate (#4421) requires the bump
+# since `src/**` changed.
+version     = "0.31.1"
 edition     = "2024"
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/trusty-review/changelog.d/6605-canonical-spec-ref-paths.md
+++ b/crates/trusty-review/changelog.d/6605-canonical-spec-ref-paths.md
@@ -1,0 +1,5 @@
+Fixed
+
+- `report::exec_summary`'s `# Spec References` block names DOC-67 by its
+  repo-root-relative path rather than a `../../../../` traversal, so its
+  reference is checked by `check_sld.sh` instead of skipped (#6605).

--- a/crates/trusty-review/src/report/exec_summary.rs
+++ b/crates/trusty-review/src/report/exec_summary.rs
@@ -20,7 +20,7 @@
 //! Test: `exec_summary_tests.rs`.
 //!
 //! # Spec References
-//! - [`SPEC-TGAUDIT-08~draft`](../../../../docs/specs/DOC-67-tga-audit-mode.md#SPEC-TGAUDIT-08~draft)
+//! - [`SPEC-TGAUDIT-08~draft`](docs/specs/DOC-67-tga-audit-mode.md#SPEC-TGAUDIT-08~draft)
 
 use std::collections::BTreeMap;
 

--- a/crates/trusty-sld-lint/changelog.d/6605-report-rejected-references.md
+++ b/crates/trusty-sld-lint/changelog.d/6605-report-rejected-references.md
@@ -1,0 +1,14 @@
+Fixed
+
+- An inline reference with a non-conformant path now fails the lint as
+  `ref-traversal`, naming the declaring `file:line` and the offending path,
+  instead of being invisible to it (#6605). 38 such references across four
+  crates were being declared and checked never; the count of inline references
+  the gate resolved went from 37 to 77 once they were made conformant.
+- The scan summary reports resolved and rejected references separately —
+  `resolved N frontmatter + M inline reference(s), rejected P + Q on path
+  shape`. A reference refused on its path resolves against nothing, so it is
+  counted apart and cannot hold the scan floor up. `RefScan` and `LintReport`
+  gained the matching `rejected` counts.
+- `MIN_CODE_REFS` rises from 24 to 51, two-thirds of the corrected measurement,
+  so the ratchet still catches the loss it was sized for.

--- a/crates/trusty-sld-lint/src/checks.rs
+++ b/crates/trusty-sld-lint/src/checks.rs
@@ -120,16 +120,25 @@ pub fn check_reference(
 /// a tree it never actually checked. Returning the number of references put
 /// through [`check_reference`] is what lets [`crate::run`] floor the WORK instead
 /// of the discovery.
-/// What: `checked` counts references handed to [`check_reference`];
-/// `diagnostics` are the findings they produced. A file with no declared
-/// references contributes `checked == 0` — the floor is a whole-run total, never
-/// a per-file requirement.
+/// What: `checked` counts references whose path was conformant enough to be
+/// resolved against the tree; `rejected` counts those refused on the path alone
+/// (DOC-38 §2.1 traversal/absolute), which produce a `ref-traversal` error and
+/// resolve nothing; `diagnostics` are the findings both produced. A file with no
+/// declared references contributes `checked == 0` — the floor is a whole-run
+/// total, never a per-file requirement.
+///
+/// #6605: the two counts are separate because a rejected reference is not
+/// verified work. Folding it into `checked` would let a tree of unresolvable
+/// paths hold the scan floor up while nothing was actually checked — the same
+/// count-the-work-not-the-discovery argument that put `checked` here.
 /// Test: `super::tests::checks_code_file`, `checks_markdown_refs`,
-/// `checks_markdown_bad_frontmatter`.
+/// `checks_markdown_bad_frontmatter`, `checks_code_file_rejects_traversal`.
 #[derive(Debug, Default)]
 pub struct RefScan {
     /// References actually resolved (not merely files walked).
     pub checked: usize,
+    /// References refused on path shape alone, so resolved against nothing.
+    pub rejected: usize,
     /// Findings produced while resolving them.
     pub diagnostics: Vec<Diagnostic>,
 }
@@ -143,7 +152,14 @@ pub struct RefScan {
 /// yields an empty [`RefScan`] (never guess an idiom). Otherwise parses inline
 /// references, resolves each via [`check_reference`], and reports how many were
 /// resolved so the caller can floor that count.
-/// Test: `super::tests::checks_code_file`.
+///
+/// #6605: an inline reference whose path is unsafe (§2.1 traversal/absolute)
+/// used to be dropped by the parser without a diagnostic, so its anchor was
+/// never validated and the block passed the gate while saying nothing. Such a
+/// reference now reaches [`check_reference`], which fails it closed with
+/// `ref-traversal` at `file:line`, and is counted as `rejected` rather than
+/// `checked` — it resolved nothing, so it must not prop the scan floor up.
+/// Test: `super::tests::checks_code_file`, `checks_code_file_rejects_traversal`.
 pub fn check_code_file(
     decl_path: &str,
     content: &str,
@@ -153,14 +169,41 @@ pub fn check_code_file(
     let Some(syntax) = syntax_for_extension(ext) else {
         return RefScan::default();
     };
-    let refs = parse_inline_refs(content, &syntax);
-    RefScan {
-        checked: refs.len(),
-        diagnostics: refs
+    scan_refs(
+        parse_inline_refs(content, &syntax)
             .iter()
-            .flat_map(|r| check_reference(decl_path, &r.id, &r.path, &r.anchor, r.line, lookup))
-            .collect(),
+            .map(|r| (r.id.as_str(), r.path.as_str(), r.anchor.as_str(), r.line)),
+        decl_path,
+        lookup,
+    )
+}
+
+/// Resolve a sequence of declared references into one [`RefScan`].
+///
+/// Why: the inline and frontmatter readers recover the same `(id, path, anchor,
+/// line)` triple-plus-line, and both owe the caller the same checked/rejected
+/// split (#6605). Sharing the fold keeps that split defined once, so a future
+/// path-conformance rule cannot apply to one representation and not the other.
+/// What: partitions on [`is_unsafe_path`] to fill `checked`/`rejected`, and runs
+/// every reference — rejected ones included — through [`check_reference`], which
+/// is what emits `ref-traversal`.
+/// Test: `super::tests::checks_code_file_rejects_traversal`.
+fn scan_refs<'a>(
+    refs: impl Iterator<Item = (&'a str, &'a str, &'a str, usize)>,
+    decl_path: &str,
+    lookup: &impl Fn(&str) -> Option<String>,
+) -> RefScan {
+    let mut out = RefScan::default();
+    for (id, path, anchor, line) in refs {
+        if is_unsafe_path(path) {
+            out.rejected += 1;
+        } else {
+            out.checked += 1;
+        }
+        out.diagnostics
+            .extend(check_reference(decl_path, id, path, anchor, line, lookup));
     }
+    out
 }
 
 /// Validate and resolve a Markdown document's `spec_refs:` frontmatter.
@@ -169,8 +212,9 @@ pub fn check_code_file(
 /// violation is itself a defect, and each valid entry must resolve.
 /// What: on a schema error emits `frontmatter-schema` (file-scoped) and reports
 /// zero references checked — an unparseable block resolved nothing; otherwise
-/// resolves each frontmatter reference via [`check_reference`] and reports how
-/// many were resolved.
+/// folds the block through [`scan_refs`], which resolves each reference and
+/// splits the count into `checked` and `rejected` on the same §2.1 path rule the
+/// inline form uses (#6605).
 /// Test: `super::tests::checks_markdown_refs`, `checks_markdown_bad_frontmatter`.
 pub fn check_markdown_refs(
     decl_path: &str,
@@ -178,15 +222,15 @@ pub fn check_markdown_refs(
     lookup: &impl Fn(&str) -> Option<String>,
 ) -> RefScan {
     match parse_frontmatter_refs(content) {
-        Ok(refs) => RefScan {
-            checked: refs.len(),
-            diagnostics: refs
-                .iter()
-                .flat_map(|r| check_reference(decl_path, &r.id, &r.path, &r.anchor, r.line, lookup))
-                .collect(),
-        },
+        Ok(refs) => scan_refs(
+            refs.iter()
+                .map(|r| (r.id.as_str(), r.path.as_str(), r.anchor.as_str(), r.line)),
+            decl_path,
+            lookup,
+        ),
         Err(e) => RefScan {
             checked: 0,
+            rejected: 0,
             diagnostics: vec![Diagnostic::error(
                 decl_path,
                 0,

--- a/crates/trusty-sld-lint/src/lib.rs
+++ b/crates/trusty-sld-lint/src/lib.rs
@@ -96,7 +96,13 @@ impl LintOptions {
 /// checks ran. `spec_refs_checked`/`code_refs_checked` count the work — every
 /// reference put through [`checks::check_reference`] — and collapse to zero when
 /// the grammar drifts.
-/// Test: `tests::run_clean_tree`, `tests::run_counts_references_checked`.
+///
+/// `spec_refs_rejected`/`code_refs_rejected` are counted apart from those
+/// (#6605): a reference refused on its path alone (DOC-38 §2.1) resolves against
+/// nothing, so it is reported and never folded into the checked totals the floor
+/// reads.
+/// Test: `tests::run_clean_tree`, `tests::run_counts_references_checked`,
+/// `tests::run_counts_rejected_references`.
 #[derive(Debug, Default)]
 pub struct LintReport {
     /// All findings that survived the allowlist, in scan order.
@@ -109,6 +115,10 @@ pub struct LintReport {
     pub spec_refs_checked: usize,
     /// Inline `# Spec References` references resolved across `crates/**`.
     pub code_refs_checked: usize,
+    /// Frontmatter references refused on path shape, so resolved against nothing.
+    pub spec_refs_rejected: usize,
+    /// Inline references refused on path shape, so resolved against nothing.
+    pub code_refs_rejected: usize,
 }
 
 impl LintReport {
@@ -208,6 +218,7 @@ pub fn run(opts: &LintOptions) -> Result<LintReport, LintError> {
         // #5440-followup: tally the references RESOLVED, not just the file walked.
         let scan = checks::check_markdown_refs(&path, &content, &lookup);
         report.spec_refs_checked += scan.checked;
+        report.spec_refs_rejected += scan.rejected;
         report.diagnostics.extend(scan.diagnostics);
         report.diagnostics.extend(checks::check_spec_doc(
             &path,
@@ -226,6 +237,7 @@ pub fn run(opts: &LintOptions) -> Result<LintReport, LintError> {
         // #5440-followup: tally the references RESOLVED, not just the file walked.
         let scan = checks::check_code_file(&path, &content, ext, &lookup);
         report.code_refs_checked += scan.checked;
+        report.code_refs_rejected += scan.rejected;
         report.diagnostics.extend(scan.diagnostics);
     }
 

--- a/crates/trusty-sld-lint/src/main.rs
+++ b/crates/trusty-sld-lint/src/main.rs
@@ -70,9 +70,14 @@ const MIN_SPEC_REFS: usize = 26;
 /// inline block scanner and the YAML frontmatter reader — and either can break
 /// alone; a combined total would let a healthy frontmatter count mask the
 /// inline parser matching nothing, which is exactly the demonstrated defect.
-/// Measured tree: 37 inline references, floored on the same two-thirds basis.
+/// Measured tree: 77 inline references, floored on the same two-thirds basis.
+/// The measurement doubled at #6605 without a single reference being added —
+/// the reader used to drop every reference whose path carried a `..` traversal
+/// segment, so 40 declared references across four crates were counted nowhere
+/// and checked never. Re-floor when the measurement moves, or the ratchet
+/// tolerates a loss it was sized to catch.
 /// Test: `tests::floor_rejects_zeroed_references`.
-const MIN_CODE_REFS: usize = 24;
+const MIN_CODE_REFS: usize = 51;
 
 /// Reports why a run's scan coverage is too low to be trusted, if it is.
 ///
@@ -237,12 +242,18 @@ fn main() -> Result<ExitCode> {
     // #5440-followup: the resolved-reference counts are printed, not just
     // floored — a CI log that shows only file counts cannot distinguish a real
     // run from one whose grammar drifted to matching nothing.
+    // #6605: the rejected counts are printed beside them so a reader can tell a
+    // reference that resolved from one refused on its path shape. They were
+    // indistinguishable before — a refused reference was dropped silently and
+    // showed up nowhere at all.
     println!(
-        "sld-lint: scanned {} spec doc(s) + {} code file(s); resolved {} frontmatter + {} inline reference(s); {errors} error(s), {warnings} warning(s){}",
+        "sld-lint: scanned {} spec doc(s) + {} code file(s); resolved {} frontmatter + {} inline reference(s), rejected {} + {} on path shape; {errors} error(s), {warnings} warning(s){}",
         report.spec_docs,
         report.code_files,
         report.spec_refs_checked,
         report.code_refs_checked,
+        report.spec_refs_rejected,
+        report.code_refs_rejected,
         if strict { " [strict]" } else { "" }
     );
 

--- a/crates/trusty-sld-lint/src/tests.rs
+++ b/crates/trusty-sld-lint/src/tests.rs
@@ -239,6 +239,36 @@ fn checks_code_file() {
 }
 
 #[test]
+fn checks_code_file_rejects_traversal() {
+    // #6605: a `..`-traversal path used to be dropped by the inline reader with
+    // no diagnostic, so its anchor was never validated — a bogus id passed the
+    // gate as `0 error(s)`. It now fails closed at `file:line`, naming the path,
+    // and is counted as rejected rather than resolved.
+    let src = "//! # Spec References\n//! - [`SPEC-X-99~draft`](../../docs/specs/x.md#SPEC-X-99~draft)\ncode();";
+    let scan = checks::check_code_file("crates/x/src/s.rs", src, "rs", &lookup);
+    assert_eq!(scan.checked, 0, "a refused reference resolved nothing");
+    assert_eq!(scan.rejected, 1, "and must be counted as refused");
+    let diag = scan
+        .diagnostics
+        .iter()
+        .find(|d| d.check == "ref-traversal")
+        .expect("the traversal must be reported, never skipped");
+    assert_eq!(diag.line, 2, "the report names the declaring line");
+    assert!(
+        diag.message.contains("../../docs/specs/x.md"),
+        "the report names the offending path: {}",
+        diag.message
+    );
+
+    // A conformant path in the same position is untouched by the change.
+    let ok = "//! # Spec References\n//! - [`SPEC-X-01~draft`](docs/specs/x.md#SPEC-X-01~draft)\ncode();";
+    let ok_scan = checks::check_code_file("crates/x/src/s.rs", ok, "rs", &lookup);
+    assert!(ok_scan.diagnostics.is_empty(), "{:?}", ok_scan.diagnostics);
+    assert_eq!(ok_scan.checked, 1);
+    assert_eq!(ok_scan.rejected, 0);
+}
+
+#[test]
 fn checks_markdown_refs() {
     let md = "---\nspec_refs:\n  - id: SPEC-X-01~draft\n    path: docs/specs/x.md\n    anchor: SPEC-X-01~draft\n---\n# Doc\n";
     let scan = checks::check_markdown_refs("d.md", md, &lookup);
@@ -486,6 +516,51 @@ fn run_clean_tree() {
 /// #5440-followup: the discovery counts above stay healthy when the reference
 /// grammar stops matching, so they cannot tell a real run from one that checked
 /// nothing. This asserts the two counters the floor is built on actually move.
+#[test]
+fn run_counts_rejected_references() {
+    // #6605: a whole-tree run must surface a non-conformant path as an error and
+    // keep it out of the checked totals the scan floor reads.
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    write(
+        root,
+        "docs/specs/README.md",
+        "| DOC | Spec ID | Title | Subsystem |\n|---|---|---|---|\n| DOC-1 | `SPEC-X-01~draft` | [Foo](./foo.md) | x |\n",
+    );
+    write(
+        root,
+        "docs/specs/foo.md",
+        "# DOC-1 — Foo\n\n**Status:** Draft\n**Subsystem:** x\n**Owner:** eng\n**Last-updated:** 2026-01-01\n**Spec ID:** SPEC-X-01~draft\n\n## 1. Section {#SPEC-X-01~draft}\n**ID:** SPEC-X-01~draft\nbody\n",
+    );
+    write(
+        root,
+        "crates/x/src/lib.rs",
+        "//! # Spec References\n//!\n//! - [`SPEC-X-01~draft`](../../../docs/specs/foo.md#SPEC-X-01~draft)\npub fn f() {}\n",
+    );
+
+    let report = run(&LintOptions::new(root)).expect("runs");
+    assert!(
+        !report.is_clean(),
+        "a traversal path must fail the lint, not pass quietly"
+    );
+    assert!(
+        report
+            .diagnostics
+            .iter()
+            .any(|d| d.check == "ref-traversal" && d.line == 3),
+        "expected a ref-traversal at the declaring line: {:?}",
+        report.diagnostics
+    );
+    assert_eq!(
+        report.code_refs_checked, 0,
+        "a refused reference resolved nothing"
+    );
+    assert_eq!(
+        report.code_refs_rejected, 1,
+        "and is counted apart, so it cannot hold the scan floor up"
+    );
+}
+
 #[test]
 fn run_counts_references_checked() {
     let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
Refs #6605
Refs #6577

## Summary
- #6605: `parse_inline_refs` (`crates/trusty-common/src/sld/inline.rs:157`) skipped any inline reference whose path tripped `is_unsafe_path`, so the anchor was never checked — a bogus `SPEC-TGAUDIT-98~draft` passed the gate with 0 errors. The reader now returns every §2.2-grammar match and the linter emits `ref-traversal` / `ref-anchor-missing` at file:line. Turning the gate on surfaced 38 unscanned references across trusty-code-tui (25), trusty-git-analytics (11), trusty-review (1), trusty-agents-common (1), all rewritten to repo-root-relative form; resolved inline references 37 → 77, `MIN_CODE_REFS` 24 → 51; the lint summary now reports `checked` and `rejected` separately. Left for a DOC-38 ruling: an anchorless reference (`harness_doc.rs:3`) matches nothing and is still unchecked.
- #6577 follow-up: `parity_doctor_agrees_across_transports` still diverged on `worktree_disk` STATUS (`unknown` on the 3 s deadline vs measured `warn`). `HOST_SAMPLED_MESSAGE_CHECKS` → `HOST_SAMPLED_CHECKS`, normalizing status and message for the host-sampled rows, with the membership rule on the constant; the assertion stays structural and non-vacuous (row present, status present). 6/10 pre-fix on a 36-worktree host, 10/10 after.

## Test ladder
Rung 4 (trusty-common `sld` module; consumers trusty-sld-lint, trusty-mpm).
- `cargo fmt --check` — exit 0
- `cargo clippy -p trusty-common --all-targets --features sld -- -D warnings`; `-p trusty-sld-lint`; `-p trusty-mpm` — exit 0 each
- `cargo check --workspace` — exit 0
- `cargo test -p trusty-common --features sld --no-fail-fast` — 442 passed, 0 failed, 6 ignored; `--features unconditional-only` — 414 passed
- `cargo test -p trusty-sld-lint --no-fail-fast` — 54 + 3 + 1 + 1 + 3 passed, 0 failed
- `cargo test -p trusty-mpm --no-fail-fast` — lib 5767 passed, 0 failed, 8 ignored; 54 targets ok
- Regression `sld::tests::inline_keeps_traversal_path_for_the_linter` fails on origin/main (`left: 0, right: 1`); `bash scripts/check_sld.sh` exits 1 with the bogus anchor reintroduced, 0 on the branch
- `parity_doctor_agrees_across_transports` ×10 — 10/10
- `check_line_cap.sh` (4352 files, 0 violations), `check_changelog_fragment.sh` (6 crates recorded), `check_sld.sh`, `check_test_pointers.sh` (28651 citations, 0 dangling) — exit 0

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KsTGDrDYKBPmHmmbRsMm5w