### PR TITLE
fix(tga): collect identity verification and walk state recovery (Refs #6142, Refs #6073)

### DIFF
--- a/crates/trusty-git-analytics/changelog.d/6073-aborted-walk-not-complete.md
+++ b/crates/trusty-git-analytics/changelog.d/6073-aborted-walk-not-complete.md
@@ -1,0 +1,3 @@
+Fixed
+
+- A history walk whose revwalk stops early — a corrupt or unreadable object — now fails the repository's collect stage instead of returning as a completed walk. The rows it already wrote are kept, but the partial traversal is never recorded as complete, so the next collect re-walks rather than skipping on it. (#6073)

--- a/crates/trusty-git-analytics/changelog.d/6073-collect-skip-current-walk.md
+++ b/crates/trusty-git-analytics/changelog.d/6073-collect-skip-current-walk.md
@@ -1,0 +1,3 @@
+Added
+
+- `tga collect` records the head SHA and ref name each completed full-history walk reached, per repository, in the extract database (schema v25). A later collect skips the walk when the repository is unchanged, walks only the new commits when the head advanced, and re-walks in full — naming the reason — when the recorded commit is no longer reachable. `--force` restores the unconditional full walk. (#6073)

--- a/crates/trusty-git-analytics/changelog.d/6073-collect-skip-current-walk.md
+++ b/crates/trusty-git-analytics/changelog.d/6073-collect-skip-current-walk.md
@@ -1,3 +1,8 @@
 Added
 
-- `tga collect` records the head SHA and ref name each completed full-history walk reached, per repository, in the extract database (schema v25). A later collect skips the walk when the repository is unchanged, walks only the new commits when the head advanced, and re-walks in full — naming the reason — when the recorded commit is no longer reachable. `--force` restores the unconditional full walk. (#6073)
+- `tga collect` records the head SHA, ref name and walk SCOPE each completed full-history walk reached, per repository, in the extract database (schema v25). A later collect skips the walk when the repository is unchanged, walks only the new commits when the head advanced, and re-walks in full — naming the reason — when the recorded commit is no longer reachable, when the previous walk did not complete, when `--force` is passed, or when this run's `--branch` / `--head-only` / merge scope differs from the recorded one. A scoped run therefore never licenses a later full-scope run to skip. (#6073)
+- The end-of-collect summary line reports how many repository full-history walks were skipped, the only figure separating a skipped walk from one that ran and found nothing new. (#6073)
+
+Fixed
+
+- A history walk whose revwalk stops early — a corrupt or unreadable object — now fails the repository's collect stage instead of returning as a completed walk. The rows it already wrote are kept, but the partial traversal is never recorded as complete, so the next collect re-walks rather than skipping on it. (#6073)

--- a/crates/trusty-git-analytics/changelog.d/6073-collect-skip-current-walk.md
+++ b/crates/trusty-git-analytics/changelog.d/6073-collect-skip-current-walk.md
@@ -2,7 +2,3 @@ Added
 
 - `tga collect` records the head SHA, ref name and walk SCOPE each completed full-history walk reached, per repository, in the extract database (schema v25). A later collect skips the walk when the repository is unchanged, walks only the new commits when the head advanced, and re-walks in full — naming the reason — when the recorded commit is no longer reachable, when the previous walk did not complete, when `--force` is passed, or when this run's `--branch` / `--head-only` / merge scope differs from the recorded one. A scoped run therefore never licenses a later full-scope run to skip. (#6073)
 - The end-of-collect summary line reports how many repository full-history walks were skipped, the only figure separating a skipped walk from one that ran and found nothing new. (#6073)
-
-Fixed
-
-- A history walk whose revwalk stops early — a corrupt or unreadable object — now fails the repository's collect stage instead of returning as a completed walk. The rows it already wrote are kept, but the partial traversal is never recorded as complete, so the next collect re-walks rather than skipping on it. (#6073)

--- a/crates/trusty-git-analytics/changelog.d/6073-walk-scope-key-and-dry-run.md
+++ b/crates/trusty-git-analytics/changelog.d/6073-walk-scope-key-and-dry-run.md
@@ -1,0 +1,3 @@
+Fixed
+
+- The recorded walk scope encodes its branch list as JSON rather than joining on `,`, so a branch whose name contains a comma is no longer indistinguishable from two branches — a run scoped to either used to skip the other's walk. `tga collect --dry-run` also stops printing a full-history-walk skip count: a dry run writes to an empty in-memory database, so that figure was structurally always zero. (#6073)

--- a/crates/trusty-git-analytics/changelog.d/6142-authorship-identity-merge.md
+++ b/crates/trusty-git-analytics/changelog.d/6142-authorship-identity-merge.md
@@ -1,0 +1,4 @@
+Fixed
+
+- The authorship report applies confirmed identity merges recorded in `authors.aliases` before computing bus factor and top-author share, so a merge an operator accepted no longer comes apart when a later collect re-observes the source email. (#6142)
+- The authorship summary carries an `identity_merge_risk` flag when a high-confidence but unconfirmed alias suggestion touches a top-ranked author, naming the affected metrics, how many identities are involved, and `tga aliases suggest`. Suggestions are still never merged automatically. (#6142)

--- a/crates/trusty-git-analytics/changelog.d/6142-authorship-identity-merge.md
+++ b/crates/trusty-git-analytics/changelog.d/6142-authorship-identity-merge.md
@@ -1,4 +1,6 @@
 Fixed
 
-- The authorship report applies confirmed identity merges recorded in `authors.aliases` before computing bus factor and top-author share, so a merge an operator accepted no longer comes apart when a later collect re-observes the source email. (#6142)
-- The authorship summary carries an `identity_merge_risk` flag when a high-confidence but unconfirmed alias suggestion touches a top-ranked author, naming the affected metrics, how many identities are involved, and `tga aliases suggest`. Suggestions are still never merged automatically. (#6142)
+- The authorship report applies confirmed identity merges recorded in `authors.aliases` before computing bus factor and top-author share, so a merge an operator accepted no longer comes apart when a later collect re-observes the source email. The map is applied to the identity resolver's own answer as well as to unlinked commits, so a re-created source row does not split the merge back apart. (#6142)
+- `tga collect` no longer re-creates an author row that `tga aliases merge` deleted. The resolver routes an email already recorded as a confirmed alias to the identity that absorbed it, so a merge survives every later collect rather than only the report that follows it. (#6142)
+- The unmerged-identity scan runs once per audit rather than once per repository. It cross-joins every identity against every other, and the `authors` table is shared across all repositories in one extract database, so the per-repository call repeated an O(n²) scan for an identical answer. (#6142)
+- The scan now receives the configured `team.canonical_domain`. It previously ran with no domain, which muted the `.local` hostname, GitHub-noreply and domain-typo signals — the identities issue #6142 exists to surface. (#6142)

--- a/crates/trusty-git-analytics/changelog.d/6142-identity-merge-risk-flag.md
+++ b/crates/trusty-git-analytics/changelog.d/6142-identity-merge-risk-flag.md
@@ -1,0 +1,3 @@
+Added
+
+- The authorship summary carries an `identity_merge_risk` flag when a high-confidence but unconfirmed alias suggestion touches a top-ranked author, naming the affected metrics, how many identities are involved, and `tga aliases suggest`. Suggestions are still never merged automatically, and a pair the operator already merged never counts as unmerged. (#6142)

--- a/crates/trusty-git-analytics/changelog.d/6142-named-scan-gap-and-alias-warnings.md
+++ b/crates/trusty-git-analytics/changelog.d/6142-named-scan-gap-and-alias-warnings.md
@@ -1,0 +1,3 @@
+Fixed
+
+- `tga audit` names a failed unmerged-identity scan as a gap on the DD manifest instead of dropping the identity-merge risk flag with only a log line, so bus factor and top-author share never print with an unstated check beside them. An `authors.aliases` value that will not parse as JSON is likewise named on stderr — with the author it belongs to — at both the collect and report sites, rather than silently reading as "this author has no confirmed merges". (#6142)

--- a/crates/trusty-git-analytics/src/collect/collector.rs
+++ b/crates/trusty-git-analytics/src/collect/collector.rs
@@ -10,6 +10,7 @@ use crate::collect::azdo::AzureDevOpsClient;
 use crate::collect::bitbucket::BitbucketClient;
 use crate::collect::errors::Result;
 use crate::collect::fault::CollectionFault;
+use crate::collect::git::walk_state;
 use crate::collect::git::GitCollector;
 use crate::collect::github::budget::RunBudget;
 use crate::collect::github::GitHubClient;
@@ -94,6 +95,15 @@ pub struct CollectionStats {
     /// Number of `(repo, week)` pairs skipped because already present in
     /// `collection_runs` (and `force` was false).
     pub weeks_skipped: usize,
+    /// Number of repositories whose full-history walk was skipped outright
+    /// because the extract database was already current at their tips (#6073).
+    ///
+    /// Why: this is the only observable that separates a skipped walk from a
+    /// full re-walk that happens to insert nothing — both leave
+    /// `commits_collected` at zero, so a caller (or a test) asserting on that
+    /// alone cannot tell whether the walk was avoided.
+    /// Test: `crate::collect::git::extractor::tests::unchanged_head_skips_the_walk`.
+    pub repos_skipped: usize,
     /// Non-fatal faults encountered, each tagged with its blast radius (#5655).
     ///
     /// Nothing in the pipeline aborts on a fault. A `StageFailed` entry means
@@ -805,7 +815,9 @@ impl CollectionPipeline {
             }
             (None, None) => {
                 // Fully unbounded — full history traversal with no week
-                // bookkeeping. Warn explicitly per Bug #65.
+                // bookkeeping. Warn explicitly per Bug #65. #6073 makes the
+                // re-run cheap by recording the tip each completed walk
+                // reached; the warning still stands for a first run.
                 warn!(
                     repo = %repo_name,
                     "no since_date or --weeks flag set — collecting full git history. \
@@ -819,17 +831,7 @@ impl CollectionPipeline {
                      Set analysis.since_date or pass --weeks N to limit scope."
                 ),
                 );
-                match collector.collect(db) {
-                    Ok(n) => {
-                        info!(repo = %repo_name, commits = n, "extracted (unbounded)");
-                        stats.commits_collected += n;
-                    }
-                    Err(e) => {
-                        let msg = format!("collection failed for {repo_name}: {e}");
-                        warn!("{msg}");
-                        stats.fail_stage(msg);
-                    }
-                }
+                self.collect_unbounded(db, collector, stats);
                 return stats.errors.len() - errors_before;
             }
         };
@@ -902,6 +904,114 @@ impl CollectionPipeline {
             }
         }
         stats.errors.len() - errors_before
+    }
+
+    /// Walk a repository's full history, skipping or narrowing the walk when
+    /// the extract database is already current for its tips (#6073).
+    ///
+    /// Why: this path has no `collection_runs` bookkeeping, so before #6073
+    /// every re-run re-walked the entire history — the issue measured that
+    /// against a 594 MB extract database, reached through trusty-audit's
+    /// per-repo retry of a render-stage failure. `--force` restores the
+    /// unconditional full walk.
+    /// What: reads the recorded [`walk_state`], compares it against the
+    /// repository's current tips, and dispatches on the resulting
+    /// [`walk_state::WalkPlan`]. The state is written incomplete before the
+    /// walk and complete after it succeeds, so an interrupted run re-walks in
+    /// full rather than skipping on partial data. Any bookkeeping failure
+    /// degrades to a full walk rather than aborting the repository.
+    /// Test: `crate::collect::git::extractor::tests::{unchanged_head_skips_the_walk,
+    /// advanced_head_walks_only_the_new_commits,
+    /// unreachable_base_forces_a_full_rewalk}`.
+    pub(crate) fn collect_unbounded(
+        &self,
+        db: &mut Database,
+        collector: &GitCollector,
+        stats: &mut CollectionStats,
+    ) {
+        let repo_name = collector.name().to_string();
+        let tips = match collector.walk_tips() {
+            Ok(t) => Some(t),
+            Err(e) => {
+                // Without tips there is nothing to compare or record; fall
+                // back to the pre-#6073 unconditional walk.
+                warn!(repo = %repo_name, error = %e, "could not read repository tips; walking in full");
+                None
+            }
+        };
+
+        let plan = match (&tips, self.force) {
+            // `--force` is the existing "re-collect everything" lever and
+            // keeps meaning exactly that here.
+            (_, true) | (None, _) => walk_state::WalkPlan::Full {
+                reason: walk_state::FullWalkReason::NeverWalked,
+            },
+            (Some(t), false) => {
+                let recorded = walk_state::load(db.connection(), &repo_name).unwrap_or_else(|e| {
+                    warn!(repo = %repo_name, error = %e, "could not read walk state; walking in full");
+                    None
+                });
+                let reachable = recorded
+                    .as_ref()
+                    .is_some_and(|s| collector.base_is_reachable(&s.head_sha));
+                walk_state::plan(recorded.as_ref(), t, reachable)
+            }
+        };
+
+        let hide = match &plan {
+            walk_state::WalkPlan::Skip => {
+                let line = format!(
+                    "Skipped   full history: extract db already current at {head} \
+                     (use --force to re-walk) [{repo_name}]",
+                    head = tips.as_ref().map(|t| t.head_sha.as_str()).unwrap_or("")
+                );
+                info!(repo = %repo_name, "{line}");
+                notify::progress(&self.progress, &repo_name, &line);
+                stats.repos_skipped += 1;
+                return;
+            }
+            walk_state::WalkPlan::Incremental { base_sha } => match git2::Oid::from_str(base_sha) {
+                Ok(oid) => Some(oid),
+                Err(e) => {
+                    warn!(repo = %repo_name, error = %e, "recorded walk base is malformed; walking in full");
+                    None
+                }
+            },
+            walk_state::WalkPlan::Full { reason } => {
+                if !self.force {
+                    info!(
+                        repo = %repo_name,
+                        "collecting FULL git history: {}",
+                        reason.as_str()
+                    );
+                }
+                None
+            }
+        };
+
+        // Mark the walk in flight so a run interrupted here re-walks in full.
+        if let Some(t) = &tips {
+            if let Err(e) = walk_state::record(db.connection(), &repo_name, t, false) {
+                warn!(repo = %repo_name, error = %e, "could not mark walk in flight");
+            }
+        }
+
+        match collector.collect_window_hiding(db, None, None, hide) {
+            Ok(n) => {
+                info!(repo = %repo_name, commits = n, ?hide, "extracted (unbounded)");
+                stats.commits_collected += n;
+                if let Some(t) = &tips {
+                    if let Err(e) = walk_state::record(db.connection(), &repo_name, t, true) {
+                        warn!(repo = %repo_name, error = %e, "could not record completed walk");
+                    }
+                }
+            }
+            Err(e) => {
+                let msg = format!("collection failed for {repo_name}: {e}");
+                warn!("{msg}");
+                stats.fail_stage(msg);
+            }
+        }
     }
 
     /// Read distinct `(author_name, author_email)` pairs from `commits`

--- a/crates/trusty-git-analytics/src/collect/collector.rs
+++ b/crates/trusty-git-analytics/src/collect/collector.rs
@@ -915,14 +915,18 @@ impl CollectionPipeline {
     /// per-repo retry of a render-stage failure. `--force` restores the
     /// unconditional full walk.
     /// What: reads the recorded [`walk_state`], compares it against the
-    /// repository's current tips, and dispatches on the resulting
-    /// [`walk_state::WalkPlan`]. The state is written incomplete before the
-    /// walk and complete after it succeeds, so an interrupted run re-walks in
-    /// full rather than skipping on partial data. Any bookkeeping failure
-    /// degrades to a full walk rather than aborting the repository.
+    /// repository's current tips AND this run's [`walk_state::WalkScope`], and
+    /// dispatches on the resulting [`walk_state::WalkPlan`]. The state is
+    /// marked in flight before the walk and recorded complete only after the
+    /// walk returns `Ok`, so both an interrupted run and one whose revwalk
+    /// aborted re-walk in full rather than skipping on partial data. Any
+    /// bookkeeping failure degrades to a full walk rather than aborting the
+    /// repository.
     /// Test: `crate::collect::git::extractor::tests::{unchanged_head_skips_the_walk,
     /// advanced_head_walks_only_the_new_commits,
-    /// unreachable_base_forces_a_full_rewalk}`.
+    /// unreachable_base_forces_a_full_rewalk,
+    /// a_scoped_walk_does_not_license_skipping_a_full_one,
+    /// an_aborted_revwalk_is_not_recorded_as_a_completed_walk}`.
     pub(crate) fn collect_unbounded(
         &self,
         db: &mut Database,
@@ -930,6 +934,10 @@ impl CollectionPipeline {
         stats: &mut CollectionStats,
     ) {
         let repo_name = collector.name().to_string();
+        // The scope comes from the collector, not from `self`, so it reflects
+        // what the revwalk will actually seed — including a per-repo
+        // `head_only: true` the pipeline ORed in (#6073 review).
+        let scope = collector.walk_scope();
         let tips = match collector.walk_tips() {
             Ok(t) => Some(t),
             Err(e) => {
@@ -943,7 +951,10 @@ impl CollectionPipeline {
         let plan = match (&tips, self.force) {
             // `--force` is the existing "re-collect everything" lever and
             // keeps meaning exactly that here.
-            (_, true) | (None, _) => walk_state::WalkPlan::Full {
+            (_, true) => walk_state::WalkPlan::Full {
+                reason: walk_state::FullWalkReason::Forced,
+            },
+            (None, _) => walk_state::WalkPlan::Full {
                 reason: walk_state::FullWalkReason::NeverWalked,
             },
             (Some(t), false) => {
@@ -954,7 +965,7 @@ impl CollectionPipeline {
                 let reachable = recorded
                     .as_ref()
                     .is_some_and(|s| collector.base_is_reachable(&s.head_sha));
-                walk_state::plan(recorded.as_ref(), t, reachable)
+                walk_state::plan(recorded.as_ref(), t, &scope, reachable)
             }
         };
 
@@ -978,22 +989,20 @@ impl CollectionPipeline {
                 }
             },
             walk_state::WalkPlan::Full { reason } => {
-                if !self.force {
-                    info!(
-                        repo = %repo_name,
-                        "collecting FULL git history: {}",
-                        reason.as_str()
-                    );
-                }
+                info!(
+                    repo = %repo_name,
+                    "collecting FULL git history: {}",
+                    reason.as_str()
+                );
                 None
             }
         };
 
         // Mark the walk in flight so a run interrupted here re-walks in full.
-        if let Some(t) = &tips {
-            if let Err(e) = walk_state::record(db.connection(), &repo_name, t, false) {
-                warn!(repo = %repo_name, error = %e, "could not mark walk in flight");
-            }
+        // This preserves any recorded head/digest/scope, so an interrupt does
+        // not overwrite the last known-good base with tips nothing walked.
+        if let Err(e) = walk_state::mark_in_flight(db.connection(), &repo_name) {
+            warn!(repo = %repo_name, error = %e, "could not mark walk in flight");
         }
 
         match collector.collect_window_hiding(db, None, None, hide) {
@@ -1001,7 +1010,9 @@ impl CollectionPipeline {
                 info!(repo = %repo_name, commits = n, ?hide, "extracted (unbounded)");
                 stats.commits_collected += n;
                 if let Some(t) = &tips {
-                    if let Err(e) = walk_state::record(db.connection(), &repo_name, t, true) {
+                    if let Err(e) =
+                        walk_state::record_complete(db.connection(), &repo_name, t, &scope)
+                    {
                         warn!(repo = %repo_name, error = %e, "could not record completed walk");
                     }
                 }

--- a/crates/trusty-git-analytics/src/collect/errors.rs
+++ b/crates/trusty-git-analytics/src/collect/errors.rs
@@ -46,6 +46,34 @@ pub enum CollectError {
     #[error("identity resolution failed: {0}")]
     Identity(String),
 
+    /// The revwalk stopped early, so the history walk covered only part of
+    /// the repository (#6073 review).
+    ///
+    /// Why its own variant: the walk used to `break` out of the revwalk loop
+    /// on a yielded error and still return `Ok(written)`, which the collect
+    /// pipeline read as a completed walk and recorded as one — a corrupt or
+    /// unreadable object therefore left `walk_complete = 1` over a partial
+    /// traversal, and every later run skipped on it. The rows already written
+    /// are kept (the transaction commits first); what this variant says is
+    /// that the traversal is NOT a basis for recording the repository as
+    /// walked.
+    #[error(
+        "history walk for {repository} aborted after {walked} commit(s) \
+         ({written} written): {cause}"
+    )]
+    WalkAborted {
+        /// Display name of the repository whose walk stopped early.
+        repository: String,
+        /// Commits the revwalk yielded before it failed.
+        walked: usize,
+        /// Commit rows written before the abort; these are committed, not lost.
+        written: usize,
+        /// The revwalk's own error text. Named `cause` rather than `source`
+        /// because `thiserror` treats a `source` field as a nested
+        /// `std::error::Error`, which a `String` is not.
+        cause: String,
+    },
+
     /// An underlying `std::io` error (file not found, permission denied, etc.).
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),

--- a/crates/trusty-git-analytics/src/collect/git/extractor.rs
+++ b/crates/trusty-git-analytics/src/collect/git/extractor.rs
@@ -506,12 +506,18 @@ impl GitCollector {
 
         let mut written = 0usize;
         let mut walked = 0usize;
+        // #6073 review: a revwalk error truncates the traversal. Recording the
+        // reason here and returning it after the transaction commits keeps the
+        // rows already written while denying the caller the "walk completed"
+        // signal it would otherwise persist.
+        let mut aborted: Option<String> = None;
         let tx = db.connection_mut().transaction()?;
         for oid_res in revwalk {
             let oid = match oid_res {
                 Ok(o) => o,
                 Err(e) => {
                     warn!(error = %e, "revwalk yielded error; stopping traversal");
+                    aborted = Some(e.to_string());
                     break;
                 }
             };
@@ -646,6 +652,14 @@ impl GitCollector {
         }
         tx.commit()?;
         pb.finish_with_message(format!("done ({walked} walked, {written} new)"));
+        if let Some(source) = aborted {
+            return Err(CollectError::WalkAborted {
+                repository: self.name.clone(),
+                walked,
+                written,
+                cause: source,
+            });
+        }
         debug!(repo = %self.name, written, "commit extraction complete");
         Ok(written)
     }
@@ -682,6 +696,31 @@ impl GitCollector {
     pub fn walk_tips(&self) -> Result<walk_state::WalkTips> {
         let repo = Repository::open(&self.path)?;
         walk_state::current_walk_tips(&repo)
+    }
+
+    /// What this collector's walk is allowed to see (#6073 review).
+    ///
+    /// Why: `--branch`, a per-repo `branch:` override, `--head-only` and
+    /// `skip_merges` all narrow the walk without changing
+    /// [`Self::walk_tips`], so a scoped run would otherwise record a tip over
+    /// refs it never walked and let the next full-scope run skip. Deriving the
+    /// scope from the COLLECTOR rather than from the pipeline's flags means it
+    /// cannot drift from what the revwalk actually does, and it picks up the
+    /// per-repo `head_only: true` the pipeline ORs in.
+    /// What: the seeding flags in [`walk_state::WalkScope`] form. Branch names
+    /// come from both the `--branch` list and the per-repo override, because
+    /// either one alone narrows the walk.
+    /// Test: `tests::a_scoped_walk_does_not_license_skipping_a_full_one`.
+    pub fn walk_scope(&self) -> walk_state::WalkScope {
+        let mut branches = self.explicit_branches.clone();
+        if let Some(b) = &self.branch {
+            branches.push(b.clone());
+        }
+        walk_state::WalkScope {
+            branches,
+            head_only: self.head_only,
+            skip_merges: self.skip_merges,
+        }
     }
 
     /// True when `base_sha` is still reachable from this repository's head.
@@ -1601,24 +1640,45 @@ mod tests {
     /// exercise the wrong code. Building the pipeline here keeps every #6073
     /// case going through the same entry point a real `tga collect` uses.
     fn run_unbounded(db: &mut Database, repo_path: &Path, force: bool) -> (usize, usize) {
+        let (collected, skipped, failures) = try_run_unbounded(db, repo_path, force, &[]);
+        assert!(failures.is_empty(), "collect must not fail: {failures:?}");
+        (collected, skipped)
+    }
+
+    /// [`run_unbounded`], scoped to `branches` and tolerating stage failures.
+    ///
+    /// Why: two #6073-review cases need what `run_unbounded` asserts away —
+    /// the scope probe needs a `--branch` filter on the pipeline, and the
+    /// aborted-revwalk probe needs the run to FAIL so it can assert the walk
+    /// was not recorded as complete. Returns the stage-failure messages rather
+    /// than panicking on them.
+    fn try_run_unbounded(
+        db: &mut Database,
+        repo_path: &Path,
+        force: bool,
+        branches: &[&str],
+    ) -> (usize, usize, Vec<String>) {
         let repo_cfg = make_repo_config(repo_path);
+        let branches: Vec<String> = branches.iter().map(|b| (*b).to_string()).collect();
         let collector = GitCollector::new(&repo_cfg)
             .expect("collector")
-            .no_fetch(true);
+            .no_fetch(true)
+            .with_explicit_branches(branches.clone());
         let pipeline = crate::collect::collector::CollectionPipeline::new(Config {
             repositories: vec![repo_cfg],
             ..Config::default()
         })
         .with_no_fetch(true)
+        .with_branches(branches)
         .with_force(force);
         let mut stats = crate::collect::collector::CollectionStats::default();
         pipeline.collect_unbounded(db, &collector, &mut stats);
-        assert!(
-            stats.stage_failures().is_empty(),
-            "collect must not fail: {:?}",
-            stats.errors
-        );
-        (stats.commits_collected, stats.repos_skipped)
+        let failures = stats
+            .stage_failures()
+            .iter()
+            .map(|f| f.message.clone())
+            .collect();
+        (stats.commits_collected, stats.repos_skipped, failures)
     }
 
     fn recorded_state(db: &Database, repo: &str) -> Option<walk_state::WalkState> {
@@ -1664,12 +1724,10 @@ mod tests {
         );
 
         // Nothing moved, so the second run must skip rather than re-walk.
-        let tips = GitCollector::new(&make_repo_config(&tmp.path))
-            .expect("collector")
-            .walk_tips()
-            .expect("tips");
+        let probe = GitCollector::new(&make_repo_config(&tmp.path)).expect("collector");
+        let tips = probe.walk_tips().expect("tips");
         assert_eq!(
-            walk_state::plan(Some(&state), &tips, true),
+            walk_state::plan(Some(&state), &tips, &probe.walk_scope(), true),
             walk_state::WalkPlan::Skip,
             "an unchanged head must plan a skip"
         );
@@ -1702,7 +1760,7 @@ mod tests {
             .and_then(|n| n.to_str())
             .expect("repo name")
             .to_string();
-        walk_state::record(
+        walk_state::record_complete(
             db.connection(),
             &name,
             &walk_state::WalkTips {
@@ -1710,7 +1768,7 @@ mod tests {
                 head_ref: "refs/heads/main".to_string(),
                 tips_digest: "stale".to_string(),
             },
-            true,
+            &walk_state::WalkScope::default(),
         )
         .expect("stale state");
         run_unbounded(&mut db, &tmp.path, true);
@@ -1762,7 +1820,12 @@ mod tests {
         let tips = collector.walk_tips().expect("tips");
         let state = recorded_state(&db, &name).expect("state");
         assert_eq!(
-            walk_state::plan(Some(&state), &tips, collector.base_is_reachable(&base)),
+            walk_state::plan(
+                Some(&state),
+                &tips,
+                &collector.walk_scope(),
+                collector.base_is_reachable(&base)
+            ),
             walk_state::WalkPlan::Incremental {
                 base_sha: base.clone()
             }
@@ -1780,16 +1843,222 @@ mod tests {
             "the incremental walk must cover only the commits added since the base"
         );
 
+        // #6073 review: `hide` must be PROVED to reach the walk. Deleting a
+        // row inside the hidden ancestry is the only observable that fails
+        // when the dispatcher passes `None` — an incremental walk cannot see
+        // that commit and leaves the hole, a full walk restores it. Without
+        // this, swapping the call for an unconditional full walk left every
+        // assertion in this module green.
+        let deleted_sha: String = db
+            .connection()
+            .query_row(
+                "SELECT sha FROM commits ORDER BY timestamp ASC LIMIT 1",
+                [],
+                |r| r.get(0),
+            )
+            .expect("oldest sha");
+        db.connection()
+            .execute(
+                "DELETE FROM files WHERE commit_id IN (SELECT id FROM commits WHERE sha = ?1)",
+                rusqlite::params![deleted_sha],
+            )
+            .expect("delete files");
+        db.connection()
+            .execute(
+                "DELETE FROM commits WHERE sha = ?1",
+                rusqlite::params![deleted_sha],
+            )
+            .expect("delete commit");
+
         assert_eq!(
             run_unbounded(&mut db, &tmp.path, false),
             (2, 0),
             "an advanced head walks incrementally rather than skipping"
         );
+        let restored: i64 = db
+            .connection()
+            .query_row(
+                "SELECT COUNT(*) FROM commits WHERE sha = ?1",
+                rusqlite::params![deleted_sha],
+                |r| r.get(0),
+            )
+            .expect("count deleted");
+        assert_eq!(
+            restored, 0,
+            "the incremental walk must hide the recorded base's ancestry; \
+             re-inserting {deleted_sha} means the walk was full, not incremental"
+        );
         let total: i64 = db
             .connection()
             .query_row("SELECT COUNT(*) FROM commits", [], |r| r.get(0))
             .expect("count");
-        assert_eq!(total, 5, "no commit may be lost by going incremental");
+        assert_eq!(
+            total, 4,
+            "the two new commits are added to the three seeded minus the one deleted"
+        );
+    }
+
+    /// (#6073 review) A `--branch`-scoped run records a tip over refs it never
+    /// walked. A later full-scope run must therefore re-walk rather than skip,
+    /// or every side-branch commit is permanently absent.
+    #[test]
+    fn a_scoped_walk_does_not_license_skipping_a_full_one() {
+        let (tmp, repo) = init_repo("walk-scope");
+        // Two commits on the default branch.
+        for i in 0..2 {
+            commit_at(
+                &repo,
+                &tmp.path,
+                utc_seconds(2026, 1, 10 + i, 12, 0, 0),
+                0,
+                "main",
+            );
+        }
+        // One more, on a side branch only.
+        let head = repo.head().expect("head").peel_to_commit().expect("commit");
+        repo.branch("side", &head, false).expect("branch");
+        repo.set_head("refs/heads/side").expect("set head");
+        commit_at(
+            &repo,
+            &tmp.path,
+            utc_seconds(2026, 1, 20, 12, 0, 0),
+            0,
+            "side",
+        );
+        let default_branch = "master";
+        repo.set_head(&format!("refs/heads/{default_branch}"))
+            .or_else(|_| repo.set_head("refs/heads/main"))
+            .expect("restore head");
+
+        let mut db = open_in_memory_db();
+        // Run 1: scoped to the default branch only — two commits.
+        let branch = if repo.find_branch("master", git2::BranchType::Local).is_ok() {
+            "master"
+        } else {
+            "main"
+        };
+        let (first, _, failures) = try_run_unbounded(&mut db, &tmp.path, false, &[branch]);
+        assert!(failures.is_empty(), "scoped collect failed: {failures:?}");
+        assert_eq!(first, 2, "the scoped walk sees only the default branch");
+
+        // Run 2: unscoped. It must walk, and must reach the side commit.
+        let (second, skipped, failures) = try_run_unbounded(&mut db, &tmp.path, false, &[]);
+        assert!(failures.is_empty(), "unscoped collect failed: {failures:?}");
+        assert_eq!(
+            skipped, 0,
+            "a full-scope run must not skip on a scoped run's recorded tip"
+        );
+        assert_eq!(
+            second, 1,
+            "the side-branch commit is what the full scope adds"
+        );
+        let total: i64 = db
+            .connection()
+            .query_row("SELECT COUNT(*) FROM commits", [], |r| r.get(0))
+            .expect("count");
+        assert_eq!(
+            total, 3,
+            "a scoped run followed by a full one must hold every commit"
+        );
+    }
+
+    /// (#6073 review) A revwalk that stops early must not be recorded as a
+    /// completed walk, or every later run skips on a partial traversal.
+    #[test]
+    fn an_aborted_revwalk_is_not_recorded_as_a_completed_walk() {
+        let (tmp, repo) = init_repo("walk-aborted");
+        let mut shas: Vec<String> = Vec::new();
+        for i in 0..3 {
+            commit_at(
+                &repo,
+                &tmp.path,
+                utc_seconds(2026, 1, 10 + i, 12, 0, 0),
+                0,
+                "c",
+            );
+            shas.push(
+                repo.head()
+                    .expect("head")
+                    .target()
+                    .expect("oid")
+                    .to_string(),
+            );
+        }
+        let name = tmp
+            .path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .expect("repo name")
+            .to_string();
+
+        // Strand the OLDEST commit object. `Sort::TIME` yields newest-first,
+        // so the revwalk fails partway rather than on its first step.
+        let oldest = &shas[0];
+        let object_path = tmp
+            .path
+            .join(".git/objects")
+            .join(&oldest[0..2])
+            .join(&oldest[2..]);
+        let stashed = std::fs::read(&object_path).expect("read loose object");
+        std::fs::remove_file(&object_path).expect("strand the object");
+
+        let mut db = open_in_memory_db();
+        let (_, skipped, failures) = try_run_unbounded(&mut db, &tmp.path, false, &[]);
+        assert!(
+            !failures.is_empty(),
+            "an aborted revwalk must surface as a stage failure, not a silent success"
+        );
+        assert_eq!(skipped, 0, "an aborted walk skips nothing");
+        let state = recorded_state(&db, &name).expect("in-flight row");
+        assert!(
+            !state.walk_complete,
+            "an aborted walk must never record walk_complete = 1"
+        );
+
+        // With the object back, the next run must re-walk rather than skip.
+        std::fs::write(&object_path, &stashed).expect("restore the object");
+        let (second, second_skipped) = run_unbounded(&mut db, &tmp.path, false);
+        assert_eq!(
+            second_skipped, 0,
+            "the run after an aborted walk must re-walk, not skip"
+        );
+        assert!(
+            second > 0,
+            "the re-walk must write the commits the abort missed"
+        );
+        let total: i64 = db
+            .connection()
+            .query_row("SELECT COUNT(*) FROM commits", [], |r| r.get(0))
+            .expect("count");
+        assert_eq!(total, 3, "the re-walk must recover the full history");
+    }
+
+    /// (#6073 review) Marking a walk in flight must not overwrite the last
+    /// COMPLETED walk's base with tips nothing has walked yet.
+    #[test]
+    fn an_interrupted_walk_keeps_its_last_good_base() {
+        let (tmp, repo) = init_repo("walk-inflight");
+        commit_at(&repo, &tmp.path, utc_seconds(2026, 1, 10, 12, 0, 0), 0, "c");
+        let name = tmp
+            .path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .expect("repo name")
+            .to_string();
+
+        let mut db = open_in_memory_db();
+        run_unbounded(&mut db, &tmp.path, false);
+        let good = recorded_state(&db, &name).expect("state");
+
+        walk_state::mark_in_flight(db.connection(), &name).expect("mark in flight");
+        let during = recorded_state(&db, &name).expect("state");
+        assert!(!during.walk_complete, "the row reads as in flight");
+        assert_eq!(
+            during.head_sha, good.head_sha,
+            "the last completed walk's base survives the in-flight write"
+        );
+        assert_eq!(during.tips_digest, good.tips_digest);
+        assert_eq!(during.walk_scope, good.walk_scope);
     }
 
     /// (#6073) A recorded base that is no longer reachable — the force-push
@@ -1823,10 +2092,16 @@ mod tests {
             head_sha: stranded.clone(),
             head_ref: "refs/heads/main".to_string(),
             tips_digest: "rewritten".to_string(),
+            walk_scope: collector.walk_scope().as_key(),
             walk_complete: true,
         };
         assert_eq!(
-            walk_state::plan(Some(&state), &tips, collector.base_is_reachable(&stranded)),
+            walk_state::plan(
+                Some(&state),
+                &tips,
+                &collector.walk_scope(),
+                collector.base_is_reachable(&stranded)
+            ),
             walk_state::WalkPlan::Full {
                 reason: walk_state::FullWalkReason::BaseUnreachable
             },
@@ -1834,7 +2109,7 @@ mod tests {
         );
 
         // End to end: the stale row must not stop the repository being walked.
-        walk_state::record(
+        walk_state::record_complete(
             db.connection(),
             &name,
             &walk_state::WalkTips {
@@ -1842,7 +2117,7 @@ mod tests {
                 head_ref: "refs/heads/main".to_string(),
                 tips_digest: "rewritten".to_string(),
             },
-            true,
+            &collector.walk_scope(),
         )
         .expect("record stale");
         let mut fresh = open_in_memory_db();

--- a/crates/trusty-git-analytics/src/collect/git/extractor.rs
+++ b/crates/trusty-git-analytics/src/collect/git/extractor.rs
@@ -17,6 +17,7 @@ use crate::collect::collector::{FetchOutcome, PerRepoFetch};
 use crate::collect::errors::{CollectError, Result};
 use crate::collect::git::diff::{compute_commit_diff, CommitDiff};
 use crate::collect::git::fetch::{fetch_and_record, fetch_remote};
+use crate::collect::git::walk_state;
 use crate::collect::ticket::{extract_ticket_id, is_ticketed};
 use crate::core::config::{expand_path, RepositoryConfig};
 use crate::core::db::Database;
@@ -293,6 +294,34 @@ impl GitCollector {
         since: Option<DateTime<Utc>>,
         until: Option<DateTime<Utc>>,
     ) -> Result<usize> {
+        self.collect_window_hiding(db, since, until, None)
+    }
+
+    /// [`Self::collect_window`], with everything reachable from `hide`
+    /// excluded from the revwalk.
+    ///
+    /// Why (#6073): a repository whose history was already walked to a
+    /// recorded commit does not need that ancestry walked again — hiding the
+    /// recorded tip turns the next collect into an incremental one. Every
+    /// commit the hidden ancestry contains is already in `commits`, because
+    /// the tip is only recorded after a walk that completed.
+    /// What: identical to [`Self::collect_window`] except for the
+    /// `revwalk.hide` call after seeding. `None` reproduces the full walk.
+    /// Test: `tests::advanced_head_walks_only_the_new_commits`.
+    ///
+    /// # Errors
+    ///
+    /// Any underlying git or database failure is propagated. A `hide` sha
+    /// that libgit2 cannot resolve is a [`CollectError::Git`] — the caller
+    /// checks reachability first (see
+    /// [`crate::collect::git::walk_state::base_is_reachable`]).
+    pub fn collect_window_hiding(
+        &self,
+        db: &mut Database,
+        since: Option<DateTime<Utc>>,
+        until: Option<DateTime<Utc>>,
+        hide: Option<git2::Oid>,
+    ) -> Result<usize> {
         let repo = Repository::open(&self.path)?;
         info!(
             repo = %self.name,
@@ -441,6 +470,17 @@ impl GitCollector {
                     }
                 }
             }
+        }
+
+        // #6073: everything reachable from the previously walked tip is
+        // already recorded, so hiding it is what makes this walk incremental.
+        if let Some(base) = hide {
+            revwalk.hide(base)?;
+            info!(
+                repo = %self.name,
+                base = %base,
+                "incremental walk: hiding the previously walked commit"
+            );
         }
 
         // Spinner-style progress bar — we stream the revwalk so we don't
@@ -624,6 +664,44 @@ impl GitCollector {
     pub fn until(&self) -> Option<DateTime<Utc>> {
         self.until
     }
+
+    /// This repository's current ref tips (#6073).
+    ///
+    /// Why: the collect pipeline compares these against the recorded walk
+    /// state to decide between skipping, walking incrementally, and walking
+    /// in full. Opening the repository is the collector's job, not the
+    /// pipeline's, so the pipeline never learns the on-disk path.
+    /// What: opens the repository and delegates to
+    /// [`crate::collect::git::walk_state::current_walk_tips`].
+    /// Test: `tests::unchanged_head_skips_the_walk`.
+    ///
+    /// # Errors
+    ///
+    /// [`CollectError::Git`] when the repository cannot be opened or its refs
+    /// cannot be listed.
+    pub fn walk_tips(&self) -> Result<walk_state::WalkTips> {
+        let repo = Repository::open(&self.path)?;
+        walk_state::current_walk_tips(&repo)
+    }
+
+    /// True when `base_sha` is still reachable from this repository's head.
+    ///
+    /// Why: a force-push or history rewrite strands the recorded tip, and
+    /// hiding a stranded commit would drop everything the rewrite replaced.
+    /// What: opens the repository and delegates to
+    /// [`crate::collect::git::walk_state::base_is_reachable`]. A repository
+    /// that cannot be opened reads as unreachable, which forces a full walk —
+    /// the safe direction.
+    /// Test: `tests::unreachable_base_forces_a_full_rewalk`.
+    pub fn base_is_reachable(&self, base_sha: &str) -> bool {
+        let Ok(repo) = Repository::open(&self.path) else {
+            return false;
+        };
+        let Ok(tips) = walk_state::current_walk_tips(&repo) else {
+            return false;
+        };
+        walk_state::base_is_reachable(&repo, base_sha, &tips.head_sha)
+    }
 }
 
 /// Parse an ISO-8601 date or datetime into a UTC timestamp.
@@ -672,7 +750,7 @@ mod tests {
     //! collector against it.
 
     use super::*;
-    use crate::core::config::RepositoryConfig;
+    use crate::core::config::{Config, RepositoryConfig};
     use crate::core::db::Database;
     use chrono::NaiveDateTime;
     use git2::{Repository, Signature, Time};
@@ -1511,5 +1589,292 @@ mod tests {
             prf.outcome,
             crate::collect::collector::FetchOutcome::Skipped { .. }
         ));
+    }
+
+    // ---- #6073: full-history walk bookkeeping -------------------------------
+
+    /// Drive one unbounded collect through the pipeline arm under test and
+    /// report how many commits it wrote.
+    ///
+    /// Why: the skip decision lives in `CollectionPipeline::collect_unbounded`,
+    /// not in the collector, so a test that called `collect` directly would
+    /// exercise the wrong code. Building the pipeline here keeps every #6073
+    /// case going through the same entry point a real `tga collect` uses.
+    fn run_unbounded(db: &mut Database, repo_path: &Path, force: bool) -> (usize, usize) {
+        let repo_cfg = make_repo_config(repo_path);
+        let collector = GitCollector::new(&repo_cfg)
+            .expect("collector")
+            .no_fetch(true);
+        let pipeline = crate::collect::collector::CollectionPipeline::new(Config {
+            repositories: vec![repo_cfg],
+            ..Config::default()
+        })
+        .with_no_fetch(true)
+        .with_force(force);
+        let mut stats = crate::collect::collector::CollectionStats::default();
+        pipeline.collect_unbounded(db, &collector, &mut stats);
+        assert!(
+            stats.stage_failures().is_empty(),
+            "collect must not fail: {:?}",
+            stats.errors
+        );
+        (stats.commits_collected, stats.repos_skipped)
+    }
+
+    fn recorded_state(db: &Database, repo: &str) -> Option<walk_state::WalkState> {
+        walk_state::load(db.connection(), repo).expect("load walk state")
+    }
+
+    /// (#6073) A second collect against an unchanged head must not walk at
+    /// all — this is the wasted full re-walk the issue measured.
+    #[test]
+    fn unchanged_head_skips_the_walk() {
+        let (tmp, repo) = init_repo("walk-skip");
+        for i in 0..3 {
+            commit_at(
+                &repo,
+                &tmp.path,
+                utc_seconds(2026, 1, 10 + i, 12, 0, 0),
+                0,
+                "c",
+            );
+        }
+        let name = tmp
+            .path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .expect("repo name")
+            .to_string();
+
+        let mut db = open_in_memory_db();
+        let (first, skipped) = run_unbounded(&mut db, &tmp.path, false);
+        assert_eq!(first, 3, "the first walk must write every commit");
+        assert_eq!(skipped, 0, "the first run has nothing to skip");
+
+        let state = recorded_state(&db, &name).expect("the first walk must record its tip");
+        assert!(state.walk_complete, "a finished walk records complete");
+        assert!(
+            !state.head_sha.is_empty(),
+            "the walked head sha is recorded"
+        );
+        assert!(
+            state.head_ref.starts_with("refs/heads/"),
+            "the walked ref name is recorded, got {}",
+            state.head_ref
+        );
+
+        // Nothing moved, so the second run must skip rather than re-walk.
+        let tips = GitCollector::new(&make_repo_config(&tmp.path))
+            .expect("collector")
+            .walk_tips()
+            .expect("tips");
+        assert_eq!(
+            walk_state::plan(Some(&state), &tips, true),
+            walk_state::WalkPlan::Skip,
+            "an unchanged head must plan a skip"
+        );
+        // `commits_collected` alone cannot prove the skip — a full re-walk
+        // also inserts nothing the second time. `repos_skipped` is what
+        // separates "did not walk" from "walked and found nothing new".
+        let (second, second_skipped) = run_unbounded(&mut db, &tmp.path, false);
+        assert_eq!(second, 0, "the skipped run must write nothing");
+        assert_eq!(
+            second_skipped, 1,
+            "the second run must skip the walk, not re-walk it"
+        );
+    }
+
+    /// (#6073) `--force` restores the unconditional full walk.
+    #[test]
+    fn force_restores_the_full_rewalk() {
+        let (tmp, repo) = init_repo("walk-force");
+        commit_at(&repo, &tmp.path, utc_seconds(2026, 1, 10, 12, 0, 0), 0, "c");
+
+        let mut db = open_in_memory_db();
+        run_unbounded(&mut db, &tmp.path, false);
+
+        // The rows are already present, so a forced re-walk writes nothing new
+        // — what it must NOT do is take the skip path, which is observable as
+        // the walk state still being recorded fresh afterwards.
+        let name = tmp
+            .path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .expect("repo name")
+            .to_string();
+        walk_state::record(
+            db.connection(),
+            &name,
+            &walk_state::WalkTips {
+                head_sha: "0".repeat(40),
+                head_ref: "refs/heads/main".to_string(),
+                tips_digest: "stale".to_string(),
+            },
+            true,
+        )
+        .expect("stale state");
+        run_unbounded(&mut db, &tmp.path, true);
+        let after = recorded_state(&db, &name).expect("state");
+        assert_ne!(
+            after.tips_digest, "stale",
+            "a forced walk must refresh the recorded state"
+        );
+    }
+
+    /// (#6073) When the head advanced, only the new commits are walked.
+    #[test]
+    fn advanced_head_walks_only_the_new_commits() {
+        let (tmp, repo) = init_repo("walk-incremental");
+        for i in 0..3 {
+            commit_at(
+                &repo,
+                &tmp.path,
+                utc_seconds(2026, 1, 10 + i, 12, 0, 0),
+                0,
+                "old",
+            );
+        }
+        let name = tmp
+            .path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .expect("repo name")
+            .to_string();
+
+        let mut db = open_in_memory_db();
+        assert_eq!(run_unbounded(&mut db, &tmp.path, false), (3, 0));
+        let base = recorded_state(&db, &name).expect("state").head_sha;
+
+        for i in 0..2 {
+            commit_at(
+                &repo,
+                &tmp.path,
+                utc_seconds(2026, 2, 10 + i, 12, 0, 0),
+                0,
+                "new",
+            );
+        }
+
+        // The recorded base is still an ancestor, so the plan is incremental.
+        let collector = GitCollector::new(&make_repo_config(&tmp.path))
+            .expect("collector")
+            .no_fetch(true);
+        let tips = collector.walk_tips().expect("tips");
+        let state = recorded_state(&db, &name).expect("state");
+        assert_eq!(
+            walk_state::plan(Some(&state), &tips, collector.base_is_reachable(&base)),
+            walk_state::WalkPlan::Incremental {
+                base_sha: base.clone()
+            }
+        );
+
+        // Hiding the base must yield exactly the two new commits, and the DB
+        // must end up holding all five.
+        let mut fresh = open_in_memory_db();
+        let oid = git2::Oid::from_str(&base).expect("oid");
+        let walked = collector
+            .collect_window_hiding(&mut fresh, None, None, Some(oid))
+            .expect("incremental walk");
+        assert_eq!(
+            walked, 2,
+            "the incremental walk must cover only the commits added since the base"
+        );
+
+        assert_eq!(
+            run_unbounded(&mut db, &tmp.path, false),
+            (2, 0),
+            "an advanced head walks incrementally rather than skipping"
+        );
+        let total: i64 = db
+            .connection()
+            .query_row("SELECT COUNT(*) FROM commits", [], |r| r.get(0))
+            .expect("count");
+        assert_eq!(total, 5, "no commit may be lost by going incremental");
+    }
+
+    /// (#6073) A recorded base that is no longer reachable — the force-push
+    /// and history-rewrite case — falls back to a full re-walk.
+    #[test]
+    fn unreachable_base_forces_a_full_rewalk() {
+        let (tmp, repo) = init_repo("walk-unreachable");
+        commit_at(&repo, &tmp.path, utc_seconds(2026, 1, 10, 12, 0, 0), 0, "c");
+        let name = tmp
+            .path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .expect("repo name")
+            .to_string();
+
+        let mut db = open_in_memory_db();
+        run_unbounded(&mut db, &tmp.path, false);
+
+        // A sha no object in this repository carries: the rewrite case.
+        let stranded = "0".repeat(40);
+        let collector = GitCollector::new(&make_repo_config(&tmp.path))
+            .expect("collector")
+            .no_fetch(true);
+        assert!(
+            !collector.base_is_reachable(&stranded),
+            "a stranded sha must never read as reachable"
+        );
+
+        let tips = collector.walk_tips().expect("tips");
+        let state = walk_state::WalkState {
+            head_sha: stranded.clone(),
+            head_ref: "refs/heads/main".to_string(),
+            tips_digest: "rewritten".to_string(),
+            walk_complete: true,
+        };
+        assert_eq!(
+            walk_state::plan(Some(&state), &tips, collector.base_is_reachable(&stranded)),
+            walk_state::WalkPlan::Full {
+                reason: walk_state::FullWalkReason::BaseUnreachable
+            },
+            "a stranded base must name the rewrite as the reason"
+        );
+
+        // End to end: the stale row must not stop the repository being walked.
+        walk_state::record(
+            db.connection(),
+            &name,
+            &walk_state::WalkTips {
+                head_sha: stranded,
+                head_ref: "refs/heads/main".to_string(),
+                tips_digest: "rewritten".to_string(),
+            },
+            true,
+        )
+        .expect("record stale");
+        let mut fresh = open_in_memory_db();
+        assert_eq!(
+            run_unbounded(&mut fresh, &tmp.path, false),
+            (1, 0),
+            "the full re-walk must still write the commit"
+        );
+    }
+
+    /// (#6073) A database created before migration v25 must open, migrate, and
+    /// read as never-walked rather than failing or claiming to be current.
+    #[test]
+    fn a_pre_v25_database_reads_as_never_walked() {
+        let mut conn = rusqlite::Connection::open_in_memory().expect("open");
+        crate::core::db::migrations::run_through(&mut conn, 24).expect("migrate to v24");
+        let version: i64 = conn
+            .query_row("SELECT MAX(version) FROM schema_migrations", [], |r| {
+                r.get(0)
+            })
+            .expect("version");
+        assert_eq!(version, 24, "the fixture must be a real pre-#6073 database");
+        assert!(
+            walk_state::load(&conn, "anything").is_err(),
+            "before v25 the table does not exist"
+        );
+
+        crate::core::db::migrations::run(&mut conn).expect("migrate to head");
+        assert_eq!(
+            walk_state::load(&conn, "anything").expect("load after migrate"),
+            None,
+            "an upgraded database has no recorded walk, i.e. never walked"
+        );
     }
 }

--- a/crates/trusty-git-analytics/src/collect/git/mod.rs
+++ b/crates/trusty-git-analytics/src/collect/git/mod.rs
@@ -7,6 +7,7 @@ pub mod diff;
 pub mod extractor;
 pub mod fetch;
 pub mod reachability;
+pub mod walk_state;
 
 pub use diff::{compute_commit_diff, diff_for_commit, CommitDiff, FileDiff, DIFF_BYTE_CAP};
 pub use extractor::GitCollector;
@@ -15,3 +16,4 @@ pub use reachability::{
     build_branch_map, build_tag_map, detect_default_branch_set, glob_matches, scan_and_persist,
     ReachabilityStats,
 };
+pub use walk_state::{FullWalkReason, WalkPlan, WalkState, WalkTips};

--- a/crates/trusty-git-analytics/src/collect/git/walk_state.rs
+++ b/crates/trusty-git-analytics/src/collect/git/walk_state.rs
@@ -77,15 +77,23 @@ impl WalkScope {
     ///
     /// What: branch names sorted and deduplicated so two runs listing the same
     /// branches in different orders compare equal, then the two booleans. The
-    /// value is readable in the database on purpose — an operator asking why a
-    /// repository re-walked can read the answer out of the row.
+    /// branch list is JSON-encoded rather than comma-joined (#6073 review):
+    /// git permits a comma inside a ref name, so `,` as a separator gave
+    /// branch `a,b` and branches `a` + `b` one key, and a run scoped to either
+    /// would then skip the other. The value stays readable in the database on
+    /// purpose — an operator asking why a repository re-walked can read the
+    /// answer out of the row.
+    /// Test: `tests::a_comma_in_a_branch_name_is_a_distinct_scope`.
     pub fn as_key(&self) -> String {
         let mut branches = self.branches.clone();
         branches.sort();
         branches.dedup();
+        // Serializing a `Vec<String>` cannot fail — no non-string map key, no
+        // non-finite float, and the strings are already valid UTF-8.
+        let branches =
+            serde_json::to_string(&branches).expect("a Vec<String> always serialises to JSON");
         format!(
-            "branches={};head_only={};skip_merges={}",
-            branches.join(","),
+            "branches={branches};head_only={};skip_merges={}",
             u8::from(self.head_only),
             u8::from(self.skip_merges),
         )
@@ -463,6 +471,44 @@ mod tests {
                 reason: FullWalkReason::PreviousWalkIncomplete
             }
         );
+    }
+
+    /// (#6073 review) git permits a comma inside a ref name, so a
+    /// comma-joined branch list gave `a,b` and `a` + `b` one key — and a run
+    /// scoped to either would then skip the other's walk entirely.
+    #[test]
+    fn a_comma_in_a_branch_name_is_a_distinct_scope() {
+        // Sorted, these two produce the identical `a,b` under a comma join.
+        let one_odd_branch = WalkScope {
+            branches: vec!["a,b".to_string()],
+            ..WalkScope::default()
+        };
+        let two_branches = WalkScope {
+            branches: vec!["a".to_string(), "b".to_string()],
+            ..WalkScope::default()
+        };
+        assert_ne!(
+            one_odd_branch.as_key(),
+            two_branches.as_key(),
+            "a comma inside a ref name must not read as a separator"
+        );
+
+        // The recorded key of one scope must not license skipping the other.
+        let mut recorded = state("aaa", "d1", true);
+        recorded.walk_scope = two_branches.as_key();
+        assert_eq!(
+            plan(Some(&recorded), &tips("aaa", "d1"), &one_odd_branch, true),
+            WalkPlan::Full {
+                reason: FullWalkReason::ScopeChanged
+            }
+        );
+
+        // Order and duplicates still collapse to one key.
+        let reordered = WalkScope {
+            branches: vec!["b".to_string(), "a".to_string(), "b".to_string()],
+            ..WalkScope::default()
+        };
+        assert_eq!(two_branches.as_key(), reordered.as_key());
     }
 
     /// (#6073 review) A narrower walk records a tip over refs it never walked,

--- a/crates/trusty-git-analytics/src/collect/git/walk_state.rs
+++ b/crates/trusty-git-analytics/src/collect/git/walk_state.rs
@@ -1,0 +1,380 @@
+//! Per-repository full-history walk bookkeeping (issue #6073).
+//!
+//! Why: the fully-unbounded collect path — no `since_date`, no `--weeks` —
+//! has no week-level `collection_runs` bookkeeping, so it re-walked the entire
+//! history on every invocation. trusty-audit retries a failed repository by
+//! re-running all nine sweep stages, which meant any render-stage failure paid
+//! a full re-collect; the issue measured that against a 594 MB extract
+//! database. Recording the tip each completed walk reached lets the next run
+//! skip the walk outright, or hide the recorded tip and walk only what is new.
+//! What: [`WalkTips`] (what the repository looks like now), [`WalkState`]
+//! (what the last completed walk recorded), [`WalkPlan`] and [`plan`] (the
+//! pure decision between the two), and the `repo_walk_state` load/record
+//! helpers.
+//! Test: the `tests` module below, plus
+//! `crate::collect::git::extractor::tests::{unchanged_head_skips_the_walk,
+//! advanced_head_walks_only_the_new_commits,
+//! unreachable_base_forces_a_full_rewalk,
+//! a_pre_v25_database_reads_as_never_walked}`.
+
+use git2::{Oid, Repository};
+use rusqlite::{params, Connection};
+use tracing::debug;
+
+use crate::collect::errors::{CollectError, Result};
+
+/// What a repository's refs look like right now.
+///
+/// Why: skipping a walk on an unchanged HEAD alone would be unsound — the
+/// default revwalk seeds from every `refs/heads/*` and `refs/remotes/origin/*`
+/// ref, so a side branch that moved while HEAD stood still carries commits a
+/// HEAD-only comparison would silently drop. `tips_digest` covers every ref,
+/// making the skip conservative: an unrelated ref moving costs a walk, but no
+/// commit is ever missed.
+/// What: the resolved HEAD sha and ref name (both empty on an unborn HEAD),
+/// plus a digest over every sorted `(refname, oid)` pair.
+/// Test: `tests::a_moved_side_branch_changes_the_digest`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct WalkTips {
+    /// Resolved `HEAD` commit sha, or empty when `HEAD` is unborn.
+    pub head_sha: String,
+    /// Full `HEAD` ref name (e.g. `refs/heads/main`), or empty when unborn.
+    pub head_ref: String,
+    /// Digest over every branch and remote-tracking `(refname, oid)` pair.
+    pub tips_digest: String,
+}
+
+/// The tip a previous COMPLETED walk of this repository reached.
+///
+/// Why: `walk_complete` distinguishes "this walk finished" from "a walk
+/// started and was interrupted" — the Ctrl-C-and-rerun flow the issue names.
+/// An interrupted walk must not license a skip.
+/// Test: `tests::an_incomplete_previous_walk_forces_a_full_rewalk`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct WalkState {
+    /// The `HEAD` sha the recorded walk reached.
+    pub head_sha: String,
+    /// The `HEAD` ref name the recorded walk followed.
+    pub head_ref: String,
+    /// The ref digest at the time of the recorded walk.
+    pub tips_digest: String,
+    /// Whether that walk ran to completion.
+    pub walk_complete: bool,
+}
+
+/// Why a run must walk the full history rather than skip or go incremental.
+///
+/// Why: the requirement is a log line NAMING the reason, so the reason is a
+/// value rather than a string built at the call site.
+/// Test: `tests::plan_names_every_full_walk_reason`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum FullWalkReason {
+    /// No `repo_walk_state` row — a fresh database, or one predating v25.
+    NeverWalked,
+    /// A row exists but its walk never finished.
+    PreviousWalkIncomplete,
+    /// The recorded sha is no longer reachable from the current head — a
+    /// force-push or history rewrite.
+    BaseUnreachable,
+}
+
+impl FullWalkReason {
+    /// The reason as it appears in the log line.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::NeverWalked => "no completed walk recorded for this repository",
+            Self::PreviousWalkIncomplete => "the previously recorded walk did not complete",
+            Self::BaseUnreachable => {
+                "the previously walked commit is no longer reachable (force-push or rewrite)"
+            }
+        }
+    }
+}
+
+/// What a collect invocation should do with this repository's history.
+///
+/// Test: `tests::plan_skips_an_unchanged_head`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum WalkPlan {
+    /// The database is already current for these tips; do not walk.
+    Skip,
+    /// Walk only what is reachable from the current tips and not from
+    /// `base_sha`.
+    Incremental {
+        /// The previously walked commit to hide from the revwalk.
+        base_sha: String,
+    },
+    /// Walk the full history, for the named reason.
+    Full {
+        /// Why the incremental path was unavailable.
+        reason: FullWalkReason,
+    },
+}
+
+/// Decide between skipping, walking incrementally, and walking in full.
+///
+/// Why: keeping the decision pure means every branch is unit-testable without
+/// a repository or a database, and the caller stays a thin dispatcher.
+/// What: no recorded state, or an incomplete one, forces a full walk;
+/// identical head AND ref digest skips; anything else goes incremental when
+/// the recorded sha is still reachable, and full when it is not.
+/// Test: `tests::{plan_skips_an_unchanged_head,
+/// plan_goes_incremental_when_the_head_advanced,
+/// plan_names_every_full_walk_reason}`.
+pub fn plan(recorded: Option<&WalkState>, current: &WalkTips, base_reachable: bool) -> WalkPlan {
+    let Some(state) = recorded else {
+        return WalkPlan::Full {
+            reason: FullWalkReason::NeverWalked,
+        };
+    };
+    if !state.walk_complete {
+        return WalkPlan::Full {
+            reason: FullWalkReason::PreviousWalkIncomplete,
+        };
+    }
+    if state.head_sha == current.head_sha && state.tips_digest == current.tips_digest {
+        return WalkPlan::Skip;
+    }
+    if base_reachable && !state.head_sha.is_empty() {
+        return WalkPlan::Incremental {
+            base_sha: state.head_sha.clone(),
+        };
+    }
+    WalkPlan::Full {
+        reason: FullWalkReason::BaseUnreachable,
+    }
+}
+
+/// Read this repository's current tips.
+///
+/// What: resolves `HEAD` (empty strings when unborn) and digests every
+/// `refs/heads/*` and `refs/remotes/*` `(name, oid)` pair in sorted order.
+/// Test: `tests::a_moved_side_branch_changes_the_digest`.
+///
+/// # Errors
+///
+/// Propagates [`CollectError::Git`] when the ref iterator fails.
+pub fn current_walk_tips(repo: &Repository) -> Result<WalkTips> {
+    let (head_sha, head_ref) = match repo.head() {
+        Ok(head) => {
+            let sha = head.target().map(|oid| oid.to_string()).unwrap_or_default();
+            (sha, head.name().unwrap_or_default().to_string())
+        }
+        // An unborn HEAD (a freshly initialised repository) is not an error
+        // here — it simply has nothing to walk yet.
+        Err(_) => (String::new(), String::new()),
+    };
+
+    let mut pairs: Vec<String> = Vec::new();
+    for r in repo.references()?.flatten() {
+        let Some(name) = r.name() else { continue };
+        if !name.starts_with("refs/heads/") && !name.starts_with("refs/remotes/") {
+            continue;
+        }
+        let Some(oid) = r.target() else { continue };
+        pairs.push(format!("{name}\t{oid}"));
+    }
+    pairs.sort();
+    let tips_digest = blake3::hash(pairs.join("\n").as_bytes())
+        .to_hex()
+        .to_string();
+
+    Ok(WalkTips {
+        head_sha,
+        head_ref,
+        tips_digest,
+    })
+}
+
+/// True when `base_sha` is still reachable from the repository's current head.
+///
+/// Why: a force-push or history rewrite leaves the recorded tip either absent
+/// from the object database or off the current graph. Hiding such a commit
+/// would silently drop everything the rewrite replaced, so the caller must
+/// fall back to a full walk instead.
+/// What: `true` when the sha parses, resolves to a commit, and is either the
+/// head itself or an ancestor of it. Any failure reads as unreachable.
+/// Test: `crate::collect::git::extractor::tests::unreachable_base_forces_a_full_rewalk`.
+pub fn base_is_reachable(repo: &Repository, base_sha: &str, head_sha: &str) -> bool {
+    if base_sha.is_empty() || head_sha.is_empty() {
+        return false;
+    }
+    if base_sha == head_sha {
+        return true;
+    }
+    let (Ok(base), Ok(head)) = (Oid::from_str(base_sha), Oid::from_str(head_sha)) else {
+        return false;
+    };
+    if repo.find_commit(base).is_err() {
+        return false;
+    }
+    repo.graph_descendant_of(head, base).unwrap_or(false)
+}
+
+/// Read the recorded walk state for `repository`, if any.
+///
+/// Why: a database predating migration v25 gains an empty `repo_walk_state`
+/// table, so "no row" is the documented never-walked signal for both a fresh
+/// database and an upgraded one.
+/// Test: `crate::collect::git::extractor::tests::a_pre_v25_database_reads_as_never_walked`.
+///
+/// # Errors
+///
+/// Propagates [`CollectError::Db`] when the query fails.
+pub fn load(conn: &Connection, repository: &str) -> Result<Option<WalkState>> {
+    let mut stmt = conn.prepare(
+        "SELECT head_sha, head_ref, tips_digest, walk_complete \
+         FROM repo_walk_state WHERE repository = ?1",
+    )?;
+    let mut rows = stmt.query(params![repository])?;
+    match rows.next()? {
+        Some(row) => Ok(Some(WalkState {
+            head_sha: row.get(0)?,
+            head_ref: row.get(1)?,
+            tips_digest: row.get(2)?,
+            walk_complete: row.get::<_, i64>(3)? != 0,
+        })),
+        None => Ok(None),
+    }
+}
+
+/// Record `tips` as this repository's walk state.
+///
+/// Why: the caller writes `walk_complete = false` before the walk and `true`
+/// after it succeeds, so a run interrupted mid-walk leaves a row that forces a
+/// full re-walk rather than a skip built on partial data.
+/// What: an upsert on the `repository` primary key, refreshing every column
+/// including `walked_at`.
+/// Test: `crate::collect::git::extractor::tests::unchanged_head_skips_the_walk`.
+///
+/// # Errors
+///
+/// Propagates [`CollectError::Db`] when the write fails.
+pub fn record(
+    conn: &Connection,
+    repository: &str,
+    tips: &WalkTips,
+    walk_complete: bool,
+) -> Result<()> {
+    conn.execute(
+        "INSERT INTO repo_walk_state \
+         (repository, head_sha, head_ref, tips_digest, walk_complete, walked_at) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6) \
+         ON CONFLICT(repository) DO UPDATE SET \
+           head_sha = excluded.head_sha, \
+           head_ref = excluded.head_ref, \
+           tips_digest = excluded.tips_digest, \
+           walk_complete = excluded.walk_complete, \
+           walked_at = excluded.walked_at",
+        params![
+            repository,
+            tips.head_sha,
+            tips.head_ref,
+            tips.tips_digest,
+            walk_complete as i64,
+            chrono::Utc::now().to_rfc3339(),
+        ],
+    )
+    .map_err(CollectError::Db)?;
+    debug!(
+        repo = repository,
+        head = %tips.head_sha,
+        complete = walk_complete,
+        "recorded repo walk state"
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tips(head: &str, digest: &str) -> WalkTips {
+        WalkTips {
+            head_sha: head.to_string(),
+            head_ref: "refs/heads/main".to_string(),
+            tips_digest: digest.to_string(),
+        }
+    }
+
+    fn state(head: &str, digest: &str, complete: bool) -> WalkState {
+        WalkState {
+            head_sha: head.to_string(),
+            head_ref: "refs/heads/main".to_string(),
+            tips_digest: digest.to_string(),
+            walk_complete: complete,
+        }
+    }
+
+    #[test]
+    fn plan_skips_an_unchanged_head() {
+        let s = state("aaa", "d1", true);
+        assert_eq!(plan(Some(&s), &tips("aaa", "d1"), true), WalkPlan::Skip);
+    }
+
+    #[test]
+    fn plan_goes_incremental_when_the_head_advanced() {
+        let s = state("aaa", "d1", true);
+        assert_eq!(
+            plan(Some(&s), &tips("bbb", "d2"), true),
+            WalkPlan::Incremental {
+                base_sha: "aaa".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn a_moved_side_branch_forces_a_walk_despite_an_unchanged_head() {
+        // The digest covers every ref, so a side branch moving under a
+        // stationary HEAD must not produce a skip — those commits are new.
+        let s = state("aaa", "d1", true);
+        assert_ne!(plan(Some(&s), &tips("aaa", "d2"), true), WalkPlan::Skip);
+    }
+
+    #[test]
+    fn an_incomplete_previous_walk_forces_a_full_rewalk() {
+        let s = state("aaa", "d1", false);
+        assert_eq!(
+            plan(Some(&s), &tips("aaa", "d1"), true),
+            WalkPlan::Full {
+                reason: FullWalkReason::PreviousWalkIncomplete
+            }
+        );
+    }
+
+    #[test]
+    fn plan_names_every_full_walk_reason() {
+        assert_eq!(
+            plan(None, &tips("aaa", "d1"), true),
+            WalkPlan::Full {
+                reason: FullWalkReason::NeverWalked
+            }
+        );
+        let s = state("aaa", "d1", true);
+        assert_eq!(
+            plan(Some(&s), &tips("bbb", "d2"), false),
+            WalkPlan::Full {
+                reason: FullWalkReason::BaseUnreachable
+            }
+        );
+        assert!(FullWalkReason::BaseUnreachable
+            .as_str()
+            .contains("force-push"));
+        assert!(FullWalkReason::NeverWalked
+            .as_str()
+            .contains("no completed"));
+    }
+
+    #[test]
+    fn a_moved_side_branch_changes_the_digest() {
+        // Two ref sets differing only in a side branch's oid must digest
+        // differently, which is what makes the skip sound.
+        let a = blake3::hash(b"refs/heads/main\taaa\nrefs/heads/side\tbbb");
+        let b = blake3::hash(b"refs/heads/main\taaa\nrefs/heads/side\tccc");
+        assert_ne!(a, b);
+    }
+}

--- a/crates/trusty-git-analytics/src/collect/git/walk_state.rs
+++ b/crates/trusty-git-analytics/src/collect/git/walk_state.rs
@@ -7,14 +7,15 @@
 //! a full re-collect; the issue measured that against a 594 MB extract
 //! database. Recording the tip each completed walk reached lets the next run
 //! skip the walk outright, or hide the recorded tip and walk only what is new.
-//! What: [`WalkTips`] (what the repository looks like now), [`WalkState`]
-//! (what the last completed walk recorded), [`WalkPlan`] and [`plan`] (the
-//! pure decision between the two), and the `repo_walk_state` load/record
-//! helpers.
+//! What: [`WalkTips`] (what the repository looks like now), [`WalkScope`]
+//! (what the walk was allowed to see), [`WalkState`] (what the last completed
+//! walk recorded), [`WalkPlan`] and [`plan`] (the pure decision between them),
+//! and the `repo_walk_state` load/record helpers.
 //! Test: the `tests` module below, plus
 //! `crate::collect::git::extractor::tests::{unchanged_head_skips_the_walk,
 //! advanced_head_walks_only_the_new_commits,
 //! unreachable_base_forces_a_full_rewalk,
+//! a_scoped_walk_does_not_license_skipping_a_full_one,
 //! a_pre_v25_database_reads_as_never_walked}`.
 
 use git2::{Oid, Repository};
@@ -45,6 +46,52 @@ pub struct WalkTips {
     pub tips_digest: String,
 }
 
+/// What a walk was allowed to see — the per-run narrowing flags.
+///
+/// Why: `--branch`, `--head-only`, a per-repo `branch:` override and
+/// `skip_merges` all shrink what a walk records, and none of them is visible
+/// in [`WalkTips`], which digests every ref whatever the walk actually
+/// covered. Without the scope beside the tips, a `--branch main` run records a
+/// tip over refs it never walked and the next full-scope run skips, leaving
+/// every side-branch commit permanently absent. Recording the scope makes a
+/// narrower or wider run a different walk, so it re-walks instead.
+/// What: the seeding flags in a stable, comparable form. [`Self::as_key`] is
+/// the string stored in `repo_walk_state.walk_scope`; two walks are the same
+/// scope exactly when their keys are equal.
+/// Test: `tests::a_narrower_scope_is_a_different_walk`,
+/// `crate::collect::git::extractor::tests::a_scoped_walk_does_not_license_skipping_a_full_one`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct WalkScope {
+    /// Branch names the revwalk seeds from — `--branch` plus any per-repo
+    /// `branch:` override. Empty means "every branch and remote-tracking ref".
+    pub branches: Vec<String>,
+    /// Whether the revwalk seeds from `HEAD` alone.
+    pub head_only: bool,
+    /// Whether merge commits are dropped rather than written.
+    pub skip_merges: bool,
+}
+
+impl WalkScope {
+    /// The comparable form stored in `repo_walk_state.walk_scope`.
+    ///
+    /// What: branch names sorted and deduplicated so two runs listing the same
+    /// branches in different orders compare equal, then the two booleans. The
+    /// value is readable in the database on purpose — an operator asking why a
+    /// repository re-walked can read the answer out of the row.
+    pub fn as_key(&self) -> String {
+        let mut branches = self.branches.clone();
+        branches.sort();
+        branches.dedup();
+        format!(
+            "branches={};head_only={};skip_merges={}",
+            branches.join(","),
+            u8::from(self.head_only),
+            u8::from(self.skip_merges),
+        )
+    }
+}
+
 /// The tip a previous COMPLETED walk of this repository reached.
 ///
 /// Why: `walk_complete` distinguishes "this walk finished" from "a walk
@@ -60,6 +107,8 @@ pub struct WalkState {
     pub head_ref: String,
     /// The ref digest at the time of the recorded walk.
     pub tips_digest: String,
+    /// The [`WalkScope::as_key`] of the recorded walk.
+    pub walk_scope: String,
     /// Whether that walk ran to completion.
     pub walk_complete: bool,
 }
@@ -72,10 +121,15 @@ pub struct WalkState {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum FullWalkReason {
+    /// The operator passed `--force`, the standing re-collect lever.
+    Forced,
     /// No `repo_walk_state` row — a fresh database, or one predating v25.
     NeverWalked,
     /// A row exists but its walk never finished.
     PreviousWalkIncomplete,
+    /// This run's [`WalkScope`] differs from the recorded one, so the recorded
+    /// tip describes a walk that saw a different set of refs or commits.
+    ScopeChanged,
     /// The recorded sha is no longer reachable from the current head — a
     /// force-push or history rewrite.
     BaseUnreachable,
@@ -85,8 +139,12 @@ impl FullWalkReason {
     /// The reason as it appears in the log line.
     pub fn as_str(self) -> &'static str {
         match self {
+            Self::Forced => "--force was passed, so the full history is re-walked",
             Self::NeverWalked => "no completed walk recorded for this repository",
             Self::PreviousWalkIncomplete => "the previously recorded walk did not complete",
+            Self::ScopeChanged => {
+                "this run's branch/head-only/merge scope differs from the recorded walk"
+            }
             Self::BaseUnreachable => {
                 "the previously walked commit is no longer reachable (force-push or rewrite)"
             }
@@ -119,13 +177,21 @@ pub enum WalkPlan {
 ///
 /// Why: keeping the decision pure means every branch is unit-testable without
 /// a repository or a database, and the caller stays a thin dispatcher.
-/// What: no recorded state, or an incomplete one, forces a full walk;
-/// identical head AND ref digest skips; anything else goes incremental when
-/// the recorded sha is still reachable, and full when it is not.
+/// What: no recorded state, or an incomplete one, forces a full walk; a scope
+/// that differs from the recorded one forces a full walk, because the recorded
+/// tip then describes refs this run does not walk (or refs a narrower run
+/// never walked); identical head AND ref digest skips; anything else goes
+/// incremental when the recorded sha is still reachable, and full when it is
+/// not.
 /// Test: `tests::{plan_skips_an_unchanged_head,
 /// plan_goes_incremental_when_the_head_advanced,
-/// plan_names_every_full_walk_reason}`.
-pub fn plan(recorded: Option<&WalkState>, current: &WalkTips, base_reachable: bool) -> WalkPlan {
+/// plan_names_every_full_walk_reason, a_narrower_scope_is_a_different_walk}`.
+pub fn plan(
+    recorded: Option<&WalkState>,
+    current: &WalkTips,
+    scope: &WalkScope,
+    base_reachable: bool,
+) -> WalkPlan {
     let Some(state) = recorded else {
         return WalkPlan::Full {
             reason: FullWalkReason::NeverWalked,
@@ -134,6 +200,14 @@ pub fn plan(recorded: Option<&WalkState>, current: &WalkTips, base_reachable: bo
     if !state.walk_complete {
         return WalkPlan::Full {
             reason: FullWalkReason::PreviousWalkIncomplete,
+        };
+    }
+    // #6073 review: the recorded tip is only comparable against a walk that
+    // covered the same refs and commit kinds. A different scope is a different
+    // walk, whichever direction it narrows.
+    if state.walk_scope != scope.as_key() {
+        return WalkPlan::Full {
+            reason: FullWalkReason::ScopeChanged,
         };
     }
     if state.head_sha == current.head_sha && state.tips_digest == current.tips_digest {
@@ -227,7 +301,7 @@ pub fn base_is_reachable(repo: &Repository, base_sha: &str, head_sha: &str) -> b
 /// Propagates [`CollectError::Db`] when the query fails.
 pub fn load(conn: &Connection, repository: &str) -> Result<Option<WalkState>> {
     let mut stmt = conn.prepare(
-        "SELECT head_sha, head_ref, tips_digest, walk_complete \
+        "SELECT head_sha, head_ref, tips_digest, walk_scope, walk_complete \
          FROM repo_walk_state WHERE repository = ?1",
     )?;
     let mut rows = stmt.query(params![repository])?;
@@ -236,17 +310,48 @@ pub fn load(conn: &Connection, repository: &str) -> Result<Option<WalkState>> {
             head_sha: row.get(0)?,
             head_ref: row.get(1)?,
             tips_digest: row.get(2)?,
-            walk_complete: row.get::<_, i64>(3)? != 0,
+            walk_scope: row.get(3)?,
+            walk_complete: row.get::<_, i64>(4)? != 0,
         })),
         None => Ok(None),
     }
 }
 
-/// Record `tips` as this repository's walk state.
+/// Mark this repository's walk as in flight without disturbing its last base.
 ///
-/// Why: the caller writes `walk_complete = false` before the walk and `true`
-/// after it succeeds, so a run interrupted mid-walk leaves a row that forces a
-/// full re-walk rather than a skip built on partial data.
+/// Why: the caller runs this before the walk so a run interrupted mid-walk
+/// leaves `walk_complete = 0` and the next run re-walks in full rather than
+/// skipping on partial data. Overwriting `head_sha` and `tips_digest` at the
+/// same time — which is what a `record(…, false)` does — would replace the
+/// last KNOWN-GOOD base with tips nothing has walked yet, so an interrupted
+/// run would lose the base it could otherwise have hidden.
+/// What: inserts an empty incomplete row when none exists, and otherwise only
+/// clears `walk_complete` and refreshes `walked_at`.
+/// Test: `crate::collect::git::extractor::tests::an_interrupted_walk_keeps_its_last_good_base`.
+///
+/// # Errors
+///
+/// Propagates [`CollectError::Db`] when the write fails.
+pub fn mark_in_flight(conn: &Connection, repository: &str) -> Result<()> {
+    conn.execute(
+        "INSERT INTO repo_walk_state \
+         (repository, head_sha, head_ref, tips_digest, walk_scope, walk_complete, walked_at) \
+         VALUES (?1, '', '', '', '', 0, ?2) \
+         ON CONFLICT(repository) DO UPDATE SET \
+           walk_complete = 0, \
+           walked_at = excluded.walked_at",
+        params![repository, chrono::Utc::now().to_rfc3339()],
+    )
+    .map_err(CollectError::Db)?;
+    debug!(repo = repository, "marked repo walk in flight");
+    Ok(())
+}
+
+/// Record `tips` and `scope` as this repository's COMPLETED walk state.
+///
+/// Why: only a walk that ran to completion may license a later skip, so this
+/// is the one write that sets `walk_complete = 1`; [`mark_in_flight`] is its
+/// counterpart before the walk.
 /// What: an upsert on the `repository` primary key, refreshing every column
 /// including `walked_at`.
 /// Test: `crate::collect::git::extractor::tests::unchanged_head_skips_the_walk`.
@@ -254,28 +359,29 @@ pub fn load(conn: &Connection, repository: &str) -> Result<Option<WalkState>> {
 /// # Errors
 ///
 /// Propagates [`CollectError::Db`] when the write fails.
-pub fn record(
+pub fn record_complete(
     conn: &Connection,
     repository: &str,
     tips: &WalkTips,
-    walk_complete: bool,
+    scope: &WalkScope,
 ) -> Result<()> {
     conn.execute(
         "INSERT INTO repo_walk_state \
-         (repository, head_sha, head_ref, tips_digest, walk_complete, walked_at) \
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6) \
+         (repository, head_sha, head_ref, tips_digest, walk_scope, walk_complete, walked_at) \
+         VALUES (?1, ?2, ?3, ?4, ?5, 1, ?6) \
          ON CONFLICT(repository) DO UPDATE SET \
            head_sha = excluded.head_sha, \
            head_ref = excluded.head_ref, \
            tips_digest = excluded.tips_digest, \
-           walk_complete = excluded.walk_complete, \
+           walk_scope = excluded.walk_scope, \
+           walk_complete = 1, \
            walked_at = excluded.walked_at",
         params![
             repository,
             tips.head_sha,
             tips.head_ref,
             tips.tips_digest,
-            walk_complete as i64,
+            scope.as_key(),
             chrono::Utc::now().to_rfc3339(),
         ],
     )
@@ -283,8 +389,8 @@ pub fn record(
     debug!(
         repo = repository,
         head = %tips.head_sha,
-        complete = walk_complete,
-        "recorded repo walk state"
+        scope = %scope.as_key(),
+        "recorded completed repo walk state"
     );
     Ok(())
 }
@@ -301,11 +407,18 @@ mod tests {
         }
     }
 
+    /// The scope every legacy case in this module walked under: no branch
+    /// filter, no head-only, merges kept.
+    fn full_scope() -> WalkScope {
+        WalkScope::default()
+    }
+
     fn state(head: &str, digest: &str, complete: bool) -> WalkState {
         WalkState {
             head_sha: head.to_string(),
             head_ref: "refs/heads/main".to_string(),
             tips_digest: digest.to_string(),
+            walk_scope: full_scope().as_key(),
             walk_complete: complete,
         }
     }
@@ -313,14 +426,17 @@ mod tests {
     #[test]
     fn plan_skips_an_unchanged_head() {
         let s = state("aaa", "d1", true);
-        assert_eq!(plan(Some(&s), &tips("aaa", "d1"), true), WalkPlan::Skip);
+        assert_eq!(
+            plan(Some(&s), &tips("aaa", "d1"), &full_scope(), true),
+            WalkPlan::Skip
+        );
     }
 
     #[test]
     fn plan_goes_incremental_when_the_head_advanced() {
         let s = state("aaa", "d1", true);
         assert_eq!(
-            plan(Some(&s), &tips("bbb", "d2"), true),
+            plan(Some(&s), &tips("bbb", "d2"), &full_scope(), true),
             WalkPlan::Incremental {
                 base_sha: "aaa".to_string()
             }
@@ -332,31 +448,88 @@ mod tests {
         // The digest covers every ref, so a side branch moving under a
         // stationary HEAD must not produce a skip — those commits are new.
         let s = state("aaa", "d1", true);
-        assert_ne!(plan(Some(&s), &tips("aaa", "d2"), true), WalkPlan::Skip);
+        assert_ne!(
+            plan(Some(&s), &tips("aaa", "d2"), &full_scope(), true),
+            WalkPlan::Skip
+        );
     }
 
     #[test]
     fn an_incomplete_previous_walk_forces_a_full_rewalk() {
         let s = state("aaa", "d1", false);
         assert_eq!(
-            plan(Some(&s), &tips("aaa", "d1"), true),
+            plan(Some(&s), &tips("aaa", "d1"), &full_scope(), true),
             WalkPlan::Full {
                 reason: FullWalkReason::PreviousWalkIncomplete
             }
         );
     }
 
+    /// (#6073 review) A narrower walk records a tip over refs it never walked,
+    /// so a later full-scope run must re-walk rather than trust it — and the
+    /// mirror case (a narrow run after a full one) must not trust it either.
+    #[test]
+    fn a_narrower_scope_is_a_different_walk() {
+        let narrow = WalkScope {
+            branches: vec!["main".to_string()],
+            ..WalkScope::default()
+        };
+        let mut recorded = state("aaa", "d1", true);
+        recorded.walk_scope = narrow.as_key();
+
+        assert_eq!(
+            plan(Some(&recorded), &tips("aaa", "d1"), &full_scope(), true),
+            WalkPlan::Full {
+                reason: FullWalkReason::ScopeChanged
+            },
+            "a full-scope run must not skip on a scoped run's recorded tip"
+        );
+        assert_eq!(
+            plan(Some(&recorded), &tips("aaa", "d1"), &narrow, true),
+            WalkPlan::Skip,
+            "the same scope still skips"
+        );
+
+        let head_only = WalkScope {
+            head_only: true,
+            ..WalkScope::default()
+        };
+        assert_eq!(
+            plan(Some(&recorded), &tips("aaa", "d1"), &head_only, true),
+            WalkPlan::Full {
+                reason: FullWalkReason::ScopeChanged
+            }
+        );
+        // Branch order is not a scope difference.
+        let reordered = WalkScope {
+            branches: vec!["b".to_string(), "a".to_string()],
+            ..WalkScope::default()
+        };
+        let ordered = WalkScope {
+            branches: vec!["a".to_string(), "b".to_string()],
+            ..WalkScope::default()
+        };
+        assert_eq!(reordered.as_key(), ordered.as_key());
+        // skip_merges narrows what is WRITTEN, not what is seeded, and is a
+        // scope difference all the same.
+        let no_merges = WalkScope {
+            skip_merges: true,
+            ..WalkScope::default()
+        };
+        assert_ne!(no_merges.as_key(), full_scope().as_key());
+    }
+
     #[test]
     fn plan_names_every_full_walk_reason() {
         assert_eq!(
-            plan(None, &tips("aaa", "d1"), true),
+            plan(None, &tips("aaa", "d1"), &full_scope(), true),
             WalkPlan::Full {
                 reason: FullWalkReason::NeverWalked
             }
         );
         let s = state("aaa", "d1", true);
         assert_eq!(
-            plan(Some(&s), &tips("bbb", "d2"), false),
+            plan(Some(&s), &tips("bbb", "d2"), &full_scope(), false),
             WalkPlan::Full {
                 reason: FullWalkReason::BaseUnreachable
             }
@@ -367,6 +540,8 @@ mod tests {
         assert!(FullWalkReason::NeverWalked
             .as_str()
             .contains("no completed"));
+        assert!(FullWalkReason::Forced.as_str().contains("--force"));
+        assert!(FullWalkReason::ScopeChanged.as_str().contains("scope"));
     }
 
     #[test]

--- a/crates/trusty-git-analytics/src/collect/identity/mod.rs
+++ b/crates/trusty-git-analytics/src/collect/identity/mod.rs
@@ -1,5 +1,7 @@
 //! Developer identity resolution.
 
 pub mod resolver;
+pub mod suggest;
 
 pub use resolver::{IdentityResolver, DEFAULT_SIMILARITY_THRESHOLD};
+pub use suggest::{Suggestion, HIGH_CONFIDENCE_CUTOFF};

--- a/crates/trusty-git-analytics/src/collect/identity/resolver.rs
+++ b/crates/trusty-git-analytics/src/collect/identity/resolver.rs
@@ -73,6 +73,70 @@ fn email_domain(email: &str) -> String {
     }
 }
 
+/// The configured canonical email domain, trimmed, `@`-stripped, lowercased.
+///
+/// Why: three call sites need this value in the same normalised form — the
+/// resolver's own construction, `tga aliases suggest`, and the DD audit's
+/// authorship pass (#6142 review). Three copies of `trim / strip / lowercase`
+/// is exactly the drift the "one implementation" rule exists to prevent.
+/// What: `None` when no team block, no `canonical_domain`, or an empty one.
+/// Test: `resolver_tests::configured_canonical_domain_normalises_the_value`.
+pub fn configured_canonical_domain(config: &crate::core::config::Config) -> Option<String> {
+    config
+        .team
+        .as_ref()
+        .and_then(|t| t.canonical_domain.as_deref())
+        .and_then(normalize_domain)
+}
+
+/// [`configured_canonical_domain`]'s normalisation, for a bare string.
+fn normalize_domain(raw: &str) -> Option<String> {
+    let d = raw.trim().trim_start_matches('@').to_lowercase();
+    if d.is_empty() {
+        None
+    } else {
+        Some(d)
+    }
+}
+
+/// The `authors.id` that already absorbed `email` as a CONFIRMED alias.
+///
+/// Why (#6142 review): `tga aliases merge` reassigns the source's commits,
+/// appends the source email to the destination's `aliases` array, and DELETES
+/// the source row. Only the alias array survives — so a later collect that
+/// observes the merged-away email on a new commit re-creates the deleted row
+/// and relinks to it, undoing the merge in the database. Asking this question
+/// before writing keeps an accepted merge accepted.
+/// What: matches the JSON array with `LIKE` to narrow the scan, then confirms
+/// an exact case-insensitive element match, because `LIKE` alone matches a
+/// substring of a longer address. Malformed JSON yields no match.
+/// Test: `resolver_tests::a_merged_away_email_routes_to_its_canonical_row`.
+///
+/// # Errors
+///
+/// Returns [`crate::core::TgaError::DbError`] on SQL failure.
+fn confirmed_alias_owner(
+    conn: &rusqlite::Connection,
+    email: &str,
+) -> crate::core::Result<Option<i64>> {
+    if email.is_empty() {
+        return Ok(None);
+    }
+    let mut stmt = conn.prepare("SELECT id, aliases FROM authors WHERE aliases LIKE ?1")?;
+    let pattern = format!("%\"{email}\"%");
+    let mut rows = stmt.query(params![pattern])?;
+    let needle = email.to_lowercase();
+    while let Some(row) = rows.next()? {
+        let id: i64 = row.get(0)?;
+        let aliases_json: String = row.get::<_, Option<String>>(1)?.unwrap_or_default();
+        let aliases: Vec<String> = serde_json::from_str(&aliases_json).unwrap_or_default();
+        if aliases.iter().any(|a| a.to_lowercase() == needle) {
+            return Ok(Some(id));
+        }
+    }
+    Ok(None)
+}
+
 /// Why: `IdentityResolver::upsert_author` and the suggester both need to ask
 /// "does this email live under the configured canonical_domain?". Centralising
 /// the check avoids subtle case- or `@`-prefix bugs at the two call sites.
@@ -226,11 +290,7 @@ impl IdentityResolver {
             for (k, v) in free_aliases {
                 register_alias(&mut aliases, k, v);
             }
-            canonical_domain = team
-                .canonical_domain
-                .as_ref()
-                .map(|d| d.trim().trim_start_matches('@').to_lowercase())
-                .filter(|d| !d.is_empty());
+            canonical_domain = team.canonical_domain.as_deref().and_then(normalize_domain);
         }
         Self {
             aliases,
@@ -307,13 +367,7 @@ impl IdentityResolver {
         // map is the primary identity source (the two YAML keys are
         // orthogonal — the domain policy belongs under team:).
         if resolver.canonical_domain.is_none() {
-            if let Some(team) = config.team.as_ref() {
-                resolver.canonical_domain = team
-                    .canonical_domain
-                    .as_ref()
-                    .map(|d| d.trim().trim_start_matches('@').to_lowercase())
-                    .filter(|d| !d.is_empty());
-            }
+            resolver.canonical_domain = configured_canonical_domain(config);
         }
         // Gate on whether the alias table actually LOADED, not merely on whether
         // one was declared. `Config::resolved_aliases` deliberately swallows
@@ -533,12 +587,20 @@ impl IdentityResolver {
     ///
     /// Why: `tga collect` calls this once per observed `(name, email)` pair;
     /// it both registers new identities and routes commits to existing rows.
-    /// What: resolves the inbound pair to a canonical form, applies the
-    /// canonical-email policy (issue #349) when a configured
-    /// [`Self::canonical_domain`] is set, and writes the row keyed on
-    /// `canonical_email`.
-    /// Test: see `resolver_tests::canonical_domain_prefers_org_email` and
-    /// `resolver_tests::canonical_domain_routes_new_personal_email_to_existing_org_row`.
+    /// What: resolves the inbound pair to a canonical form, returns the owning
+    /// identity when the resolved email is a CONFIRMED alias of one (#6142
+    /// review), applies the canonical-email policy (issue #349) when a
+    /// configured [`Self::canonical_domain`] is set, and otherwise writes the
+    /// row keyed on `canonical_email`.
+    ///
+    /// The alias check comes first because `tga aliases merge` DELETES the
+    /// source row and records the merge only in the destination's `aliases`
+    /// array. Without it, the next collect to observe the merged-away email
+    /// re-creates the row the operator deleted and relinks commits to it,
+    /// undoing the merge in the database rather than only in the report.
+    /// Test: see `resolver_tests::canonical_domain_prefers_org_email`,
+    /// `resolver_tests::a_merged_away_email_routes_to_its_canonical_row` and
+    /// `crate::report::authorship_tests::a_confirmed_merge_survives_a_recollect`.
     ///
     /// # Errors
     ///
@@ -550,6 +612,18 @@ impl IdentityResolver {
         email: &str,
     ) -> crate::core::Result<i64> {
         let (canon_name, mut canon_email) = self.resolve(name, email);
+
+        // #6142 review: a confirmed merge outranks every policy below it. The
+        // merge deleted the source row, so re-creating it here would undo the
+        // operator's decision on the next collect.
+        if let Some(id) = confirmed_alias_owner(db.connection(), &canon_email)? {
+            debug!(
+                observed_email = %canon_email,
+                author_id = id,
+                "routed commit to the identity that already absorbed this email as a confirmed alias"
+            );
+            return Ok(id);
+        }
 
         // Issue #349 canonical-email policy:
         // 1. If `resolve()` already produced an email under the configured

--- a/crates/trusty-git-analytics/src/collect/identity/resolver.rs
+++ b/crates/trusty-git-analytics/src/collect/identity/resolver.rs
@@ -109,7 +109,8 @@ fn normalize_domain(raw: &str) -> Option<String> {
 /// before writing keeps an accepted merge accepted.
 /// What: matches the JSON array with `LIKE` to narrow the scan, then confirms
 /// an exact case-insensitive element match, because `LIKE` alone matches a
-/// substring of a longer address. Malformed JSON yields no match.
+/// substring of a longer address. Malformed JSON yields no match, and says so
+/// on stderr rather than reading as an author with no aliases.
 /// Test: `resolver_tests::a_merged_away_email_routes_to_its_canonical_row`.
 ///
 /// # Errors
@@ -129,7 +130,22 @@ fn confirmed_alias_owner(
     while let Some(row) = rows.next()? {
         let id: i64 = row.get(0)?;
         let aliases_json: String = row.get::<_, Option<String>>(1)?.unwrap_or_default();
-        let aliases: Vec<String> = serde_json::from_str(&aliases_json).unwrap_or_default();
+        // #6142 review: an `aliases` value that will not parse reads as "no
+        // aliases", which quietly re-creates the row a confirmed merge
+        // deleted. The fallback stays — one bad row must not fail the collect
+        // — but it is named on stderr with the author row it belongs to.
+        let aliases: Vec<String> = match serde_json::from_str(&aliases_json) {
+            Ok(aliases) => aliases,
+            Err(e) => {
+                warn!(
+                    author_id = id,
+                    error = %e,
+                    "authors.aliases is not a JSON array of strings; confirmed merges on this \
+                     author are not applied to newly observed commits"
+                );
+                Vec::new()
+            }
+        };
         if aliases.iter().any(|a| a.to_lowercase() == needle) {
             return Ok(Some(id));
         }

--- a/crates/trusty-git-analytics/src/collect/identity/resolver_tests.rs
+++ b/crates/trusty-git-analytics/src/collect/identity/resolver_tests.rs
@@ -308,6 +308,90 @@ fn canonical_domain_prefers_org_email_for_team_member() {
     assert_eq!(r.canonical_domain(), Some("duettoresearch.com"));
 }
 
+/// (#6142 review) `tga aliases merge` deletes the source row and keeps the
+/// merge only in the destination's `aliases` array. The next collect must route
+/// the merged-away address to that destination rather than re-creating the row
+/// the operator deleted.
+#[test]
+fn a_merged_away_email_routes_to_its_canonical_row() {
+    use crate::core::db::Database;
+    use rusqlite::params;
+
+    let db = Database::open_in_memory().expect("open db");
+    db.connection()
+        .execute(
+            "INSERT INTO authors (canonical_name, canonical_email, aliases) \
+             VALUES ('Alice', 'alice@corp.com', ?1)",
+            params![r#"["alice@personal.com"]"#],
+        )
+        .expect("seed destination");
+    let dst: i64 = db
+        .connection()
+        .query_row(
+            "SELECT id FROM authors WHERE canonical_email = 'alice@corp.com'",
+            [],
+            |r| r.get(0),
+        )
+        .expect("dst id");
+
+    let r = IdentityResolver::new(None);
+    let id = r
+        .upsert_author(&db, "Alice", "alice@personal.com")
+        .expect("upsert");
+    assert_eq!(id, dst, "the alias must route to its canonical identity");
+
+    // Case-insensitively, too — git config addresses vary in case.
+    let upper = r
+        .upsert_author(&db, "Alice", "Alice@Personal.com")
+        .expect("upsert");
+    assert_eq!(upper, dst);
+
+    let rows: i64 = db
+        .connection()
+        .query_row("SELECT COUNT(*) FROM authors", [], |r| r.get(0))
+        .expect("count");
+    assert_eq!(rows, 1, "no row may be re-created for a merged-away email");
+
+    // A LIKE match that is not an exact array element must not hijack: the
+    // longer address contains the alias as a substring.
+    let other = r
+        .upsert_author(&db, "Bob", "not-alice@personal.com.example")
+        .expect("upsert");
+    assert_ne!(other, dst, "a substring match must not claim the identity");
+}
+
+/// (#6142 review) One normalisation for the configured canonical domain, used
+/// by the resolver, `tga aliases suggest`, and the audit's authorship pass.
+#[test]
+fn configured_canonical_domain_normalises_the_value() {
+    use crate::collect::identity::resolver::configured_canonical_domain;
+    use crate::core::config::Config;
+
+    let mut config = Config::default();
+    assert_eq!(configured_canonical_domain(&config), None, "no team block");
+
+    config.team = Some(TeamConfig {
+        members: vec![],
+        aliases: HashMap::new(),
+        canonical_domain: Some("  @Corp.COM ".into()),
+    });
+    assert_eq!(
+        configured_canonical_domain(&config),
+        Some("corp.com".to_string())
+    );
+
+    config.team = Some(TeamConfig {
+        members: vec![],
+        aliases: HashMap::new(),
+        canonical_domain: Some("   ".into()),
+    });
+    assert_eq!(
+        configured_canonical_domain(&config),
+        None,
+        "empty is absent"
+    );
+}
+
 #[test]
 fn canonical_domain_routes_new_personal_email_to_existing_org_row() {
     use crate::core::db::Database;

--- a/crates/trusty-git-analytics/src/collect/identity/suggest.rs
+++ b/crates/trusty-git-analytics/src/collect/identity/suggest.rs
@@ -1,0 +1,617 @@
+//! Alias-suggestion detection over the `authors` and `commits` tables.
+//!
+//! Why: two callers need the same answer to "which identities look like the
+//! same person?" — `tga aliases suggest` prints them for a human to confirm,
+//! and the authorship report (#6142) counts the ones a reader has NOT yet
+//! merged so a bus-factor or top-author-share figure carries its own risk
+//! flag. Detection lived only in the CLI handler, which the report layer
+//! cannot call; this module is the single implementation both use.
+//! What: [`Suggestion`], the four detection passes behind
+//! [`detect_from_authors`] and [`detect_all`], and [`dedupe_and_rank`].
+//! Nothing here mutates the database — a suggestion is never a merge.
+//! Test: the `tests` module below.
+//!
+//! Signals (highest signal first):
+//! 1. Same observed `author_name` string under two different emails
+//!    (confidence 0.95).
+//! 2. Edit distance ≤ 2 on the email local-part with identical or
+//!    near-identical domains (confidence 0.78 – 0.85).
+//! 3. Known noise patterns: `*.local` hostnames, GitHub noreply emails,
+//!    domain-typo corrections against the configured canonical domain
+//!    (confidence 0.78 – 0.90 depending on signal strength).
+//! 4. Commit-SHA co-occurrence: the same SHA authored under two emails
+//!    (confidence 0.92).
+
+use std::collections::{BTreeMap, HashSet};
+
+use rusqlite::Connection;
+use strsim::levenshtein;
+
+use crate::collect::identity::resolver::email_domain_matches;
+use crate::core::errors::Result;
+
+/// The threshold separating MED-confidence suggestions (a mere hint) from
+/// HIGH-confidence ones (safe to auto-accept, and worth flagging on a report).
+///
+/// Why: one constant drives the CLI's display label, its `--auto-accept`
+/// gating, and the authorship report's risk flag, so the three cannot drift.
+/// Test: `tests::the_weakest_noise_signal_stays_below_the_high_cutoff`.
+pub const HIGH_CONFIDENCE_CUTOFF: f64 = 0.85;
+
+/// A single alias suggestion ranked by `confidence`.
+///
+/// Why: the detector runs four passes and dedupes by `(src, dst)` pair; this
+/// is the shared shape so each pass produces homogeneous output the dedup
+/// step can sort and filter.
+/// What: the source email (the one that would be merged away), the
+/// destination canonical email (the one kept), the confidence score, and a
+/// short human-readable reason.
+/// Test: every `tests::*` case in this module.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub struct Suggestion {
+    /// Source identity email — merged away when the suggestion is accepted.
+    pub src: String,
+    /// Destination canonical email — retained when the suggestion is accepted.
+    pub dst: String,
+    /// Confidence in `0.0..=1.0`; at or above [`HIGH_CONFIDENCE_CUTOFF`] the
+    /// pair is HIGH-confidence.
+    pub confidence: f64,
+    /// Short human-readable reason naming the signal that produced the pair.
+    pub reason: String,
+}
+
+/// Every suggestion derivable from the `authors` table alone, ranked.
+///
+/// Why (#6142): the authorship report runs this on every build, so it must
+/// stay proportional to the number of DISTINCT IDENTITIES rather than to the
+/// number of commits — on a 594 MB extract database the commit-SHA pass
+/// (see [`detect_all`]) scans every row, which a report cannot afford.
+/// What: runs the same-name, edit-distance, and noise-pattern passes, then
+/// dedupes and ranks with `floor` applied. `canonical_domain` enables the
+/// `.local` / noreply / domain-typo signals; pass `None` to skip them.
+/// Test: `tests::detect_from_authors_finds_same_name_pair`.
+///
+/// # Errors
+///
+/// Propagates [`crate::core::errors::TgaError::DbError`] from any query.
+pub fn detect_from_authors(
+    conn: &Connection,
+    canonical_domain: Option<&str>,
+    floor: f64,
+) -> Result<Vec<Suggestion>> {
+    let mut out = Vec::new();
+    out.extend(detect_same_name_pairs(conn)?);
+    out.extend(detect_edit_distance_pairs(conn)?);
+    out.extend(detect_noise_patterns(conn, canonical_domain)?);
+    Ok(dedupe_and_rank(out, floor))
+}
+
+/// [`detect_from_authors`] plus the commit-SHA co-occurrence pass.
+///
+/// Why: the CLI can afford a full scan of `commits`, and the same SHA
+/// recorded under two emails is the strongest evidence available — git
+/// itself recorded both against identical content.
+/// What: the three author-table passes plus
+/// `detect_commit_sha_cooccurrence`, deduped and ranked together.
+/// Test: `tests::detect_all_adds_the_sha_signal`.
+///
+/// # Errors
+///
+/// Propagates [`crate::core::errors::TgaError::DbError`] from any query.
+pub fn detect_all(
+    conn: &Connection,
+    canonical_domain: Option<&str>,
+    floor: f64,
+) -> Result<Vec<Suggestion>> {
+    let mut out = Vec::new();
+    out.extend(detect_same_name_pairs(conn)?);
+    out.extend(detect_edit_distance_pairs(conn)?);
+    out.extend(detect_noise_patterns(conn, canonical_domain)?);
+    out.extend(detect_commit_sha_cooccurrence(conn)?);
+    Ok(dedupe_and_rank(out, floor))
+}
+
+/// Signal 1: identical observed display names under two different emails.
+///
+/// Why: the strongest hint short of an explicit user action; if two authors
+/// share `canonical_name` and only the email differs, they are almost
+/// certainly the same person.
+/// What: groups distinct `(canonical_name, canonical_email)` pairs by name
+/// and emits one suggestion per non-canonical email pointing at the
+/// alphabetically-first email for the name (a deterministic destination).
+/// Test: `tests::same_name_different_email_detected`.
+fn detect_same_name_pairs(conn: &Connection) -> Result<Vec<Suggestion>> {
+    let mut stmt = conn.prepare(
+        "SELECT canonical_name, canonical_email FROM authors \
+         ORDER BY canonical_name, canonical_email",
+    )?;
+    let rows = stmt.query_map([], |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+    })?;
+
+    let mut groups: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for r in rows {
+        let (name, email) = r?;
+        groups.entry(name.to_lowercase()).or_default().push(email);
+    }
+
+    let mut out: Vec<Suggestion> = Vec::new();
+    for (_name, mut emails) in groups {
+        emails.sort();
+        emails.dedup();
+        if emails.len() < 2 {
+            continue;
+        }
+        let dst = emails[0].clone();
+        for src in emails.into_iter().skip(1) {
+            out.push(Suggestion {
+                src,
+                dst: dst.clone(),
+                confidence: 0.95,
+                reason: "same canonical_name".to_string(),
+            });
+        }
+    }
+    Ok(out)
+}
+
+/// Signal 2: email local-parts within edit distance ≤ 2, near-identical domains.
+///
+/// Why: catches `alice@co.com` vs `alice@contractor.co.com` (contractor
+/// prefix) and similar near-misses, without merging genuinely different people.
+/// What: cross-joins all distinct emails and computes Levenshtein distance on
+/// the local-part; requires the domains to be identical or one a suffix of the
+/// other, and drops local-parts shorter than three characters.
+/// Test: `tests::edit_distance_local_part_detected`.
+fn detect_edit_distance_pairs(conn: &Connection) -> Result<Vec<Suggestion>> {
+    let mut stmt = conn.prepare("SELECT canonical_email FROM authors")?;
+    let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
+    let emails: Vec<String> = rows.filter_map(|r| r.ok()).collect();
+
+    let mut out: Vec<Suggestion> = Vec::new();
+    let mut seen: HashSet<(String, String)> = HashSet::new();
+    for i in 0..emails.len() {
+        for j in (i + 1)..emails.len() {
+            let a = &emails[i];
+            let b = &emails[j];
+            let Some((la, da)) = split_email(a) else {
+                continue;
+            };
+            let Some((lb, db_)) = split_email(b) else {
+                continue;
+            };
+            // Identical local-parts are the same-name signal's job, and a very
+            // short local-part is a false-positive factory.
+            if la == lb || la.len() < 3 || lb.len() < 3 {
+                continue;
+            }
+            let dist = levenshtein(&la, &lb);
+            if dist == 0 || dist > 2 {
+                continue;
+            }
+            let domains_match = da == db_ || da.ends_with(&db_) || db_.ends_with(&da);
+            if !domains_match {
+                continue;
+            }
+            let confidence = if dist == 1 { 0.85 } else { 0.78 };
+            // The alphabetically earlier email is the destination so the
+            // suggestion is stable across runs.
+            let (src, dst) = if a < b {
+                (b.clone(), a.clone())
+            } else {
+                (a.clone(), b.clone())
+            };
+            if seen.insert((src.clone(), dst.clone())) {
+                out.push(Suggestion {
+                    src,
+                    dst,
+                    confidence,
+                    reason: format!("edit-distance {dist} on local-part"),
+                });
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Signal 3: known noise patterns — `.local`, GitHub noreply, domain typos.
+///
+/// Why: these patterns dominate alias-table noise on a real corpus.
+/// What:
+/// - `<local>@<host>.local` → an identity at `<local>@<canonical_domain>`.
+/// - `<id>+<login>@users.noreply.github.com` → an identity whose local-part
+///   is the login (HIGH) or contains it (MED).
+/// - A domain within edit distance 2 of `canonical_domain` → the corrected
+///   address, when that identity exists.
+///
+/// Every arm requires the destination to already exist in `authors`, so a
+/// suggestion never invents an identity.
+/// Test: `tests::dotlocal_email_routed_to_canonical_domain`.
+fn detect_noise_patterns(
+    conn: &Connection,
+    canonical_domain: Option<&str>,
+) -> Result<Vec<Suggestion>> {
+    let mut stmt = conn.prepare("SELECT canonical_email FROM authors")?;
+    let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
+    let emails: Vec<String> = rows.filter_map(|r| r.ok()).collect();
+
+    let mut out: Vec<Suggestion> = Vec::new();
+    for email in &emails {
+        let Some((local, domain)) = split_email(email) else {
+            continue;
+        };
+
+        // 3a. `.local` hostnames (e.g. `bob@ENCDXPAHDLT0616.local`).
+        if domain.ends_with(".local") {
+            if let Some(canon_dom) = canonical_domain {
+                let target = format!("{local}@{canon_dom}");
+                if emails.iter().any(|e| e.eq_ignore_ascii_case(&target)) {
+                    out.push(Suggestion {
+                        src: email.clone(),
+                        dst: target,
+                        confidence: 0.90,
+                        reason: ".local hostname → org email".to_string(),
+                    });
+                }
+            }
+        }
+
+        // 3b. GitHub noreply emails: `<id>+<login>@users.noreply.github.com`.
+        if domain == "users.noreply.github.com" {
+            if let Some(login) = local.split_once('+').map(|(_, l)| l) {
+                for other in &emails {
+                    if other == email {
+                        continue;
+                    }
+                    let Some((other_local, _)) = split_email(other) else {
+                        continue;
+                    };
+                    if other_local == login {
+                        out.push(Suggestion {
+                            src: email.clone(),
+                            dst: other.clone(),
+                            confidence: 0.90,
+                            reason: format!("GitHub noreply login '{login}'"),
+                        });
+                    } else if other_local.contains(login) || login.contains(&other_local) {
+                        out.push(Suggestion {
+                            src: email.clone(),
+                            dst: other.clone(),
+                            confidence: 0.78,
+                            reason: format!("GitHub noreply login '{login}' (partial)"),
+                        });
+                    }
+                }
+            }
+        }
+
+        // 3c. Domain edit-distance against canonical_domain (catches typos).
+        if let Some(canon_dom) = canonical_domain {
+            if !email_domain_matches(email, canon_dom) {
+                let dist = levenshtein(&domain, canon_dom);
+                if dist > 0 && dist <= 2 {
+                    let target = format!("{local}@{canon_dom}");
+                    if emails.iter().any(|e| e.eq_ignore_ascii_case(&target)) {
+                        out.push(Suggestion {
+                            src: email.clone(),
+                            dst: target,
+                            confidence: 0.88,
+                            reason: format!("domain typo '{domain}' (dist {dist})"),
+                        });
+                    }
+                }
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Signal 4: the same commit SHA attributed to two different emails.
+///
+/// Why: git itself recorded both emails against identical content — this
+/// happens when a commit is cherry-picked or rebased and the author email
+/// changes in transit.
+/// What: groups `commits` by SHA and emits a 0.92-confidence suggestion for
+/// any SHA carrying two or more distinct `author_email` values.
+/// Test: `tests::same_sha_two_emails_detected`.
+fn detect_commit_sha_cooccurrence(conn: &Connection) -> Result<Vec<Suggestion>> {
+    let mut stmt =
+        conn.prepare("SELECT sha, author_email FROM commits ORDER BY sha, author_email")?;
+    let rows = stmt.query_map([], |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+    })?;
+
+    let mut groups: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for r in rows {
+        let (sha, email) = r?;
+        groups.entry(sha).or_default().push(email);
+    }
+
+    let mut out: Vec<Suggestion> = Vec::new();
+    for (sha, mut emails) in groups {
+        emails.sort();
+        emails.dedup();
+        if emails.len() < 2 {
+            continue;
+        }
+        let dst = emails[0].clone();
+        for src in emails.into_iter().skip(1) {
+            out.push(Suggestion {
+                src,
+                dst: dst.clone(),
+                confidence: 0.92,
+                reason: format!("same SHA {short}", short = &sha[..sha.len().min(8)]),
+            });
+        }
+    }
+    Ok(out)
+}
+
+/// Dedupe on `(src, dst)`, keep the highest-confidence reason, sort
+/// descending by confidence, and apply `floor`.
+///
+/// Why: separate passes produce overlapping pairs; a caller wants one line
+/// per pair with the strongest reason, in a stable order.
+/// What: folds into a map keyed on the pair, retains the highest score, then
+/// sorts by confidence descending and `src` ascending.
+/// Test: `tests::dedupe_keeps_highest_confidence`.
+pub fn dedupe_and_rank(input: Vec<Suggestion>, floor: f64) -> Vec<Suggestion> {
+    let mut by_pair: BTreeMap<(String, String), Suggestion> = BTreeMap::new();
+    for s in input {
+        let key = (s.src.clone(), s.dst.clone());
+        match by_pair.get(&key) {
+            Some(existing) if existing.confidence >= s.confidence => {}
+            _ => {
+                by_pair.insert(key, s);
+            }
+        }
+    }
+    let mut out: Vec<Suggestion> = by_pair
+        .into_values()
+        .filter(|s| s.confidence >= floor)
+        .collect();
+    out.sort_by(|a, b| {
+        b.confidence
+            .partial_cmp(&a.confidence)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.src.cmp(&b.src))
+    });
+    out
+}
+
+/// Split an email into a lowercased `(local, domain)`, or `None` when
+/// either half is missing.
+///
+/// Test: `tests::split_email_basic`.
+pub fn split_email(email: &str) -> Option<(String, String)> {
+    let at = email.rfind('@')?;
+    let local = email[..at].to_lowercase();
+    let domain = email[at + 1..].to_lowercase();
+    if local.is_empty() || domain.is_empty() {
+        return None;
+    }
+    Some((local, domain))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::db::Database;
+    use rusqlite::params;
+
+    fn insert_author(db: &Database, name: &str, email: &str) -> i64 {
+        db.connection()
+            .execute(
+                "INSERT INTO authors (canonical_name, canonical_email, aliases) \
+                 VALUES (?1, ?2, '[]')",
+                params![name, email],
+            )
+            .expect("insert author");
+        db.connection().last_insert_rowid()
+    }
+
+    fn insert_commit(db: &Database, sha: &str, author_id: i64) {
+        db.connection()
+            .execute(
+                "INSERT INTO commits (sha, author_id, author_name, author_email, timestamp, \
+                 message, repository) VALUES (?1, ?2, 'n', 'e', '2024-01-01T00:00:00Z', 'm', 'r')",
+                params![sha, author_id],
+            )
+            .expect("insert commit");
+    }
+
+    #[test]
+    fn same_name_different_email_detected() {
+        let db = Database::open_in_memory().expect("open");
+        insert_author(&db, "Bob Matsuoka", "bob@matsuoka.com");
+        insert_author(&db, "Bob Matsuoka", "robert.matsuoka@duettoresearch.com");
+        let out = detect_same_name_pairs(db.connection()).expect("detect");
+        assert_eq!(out.len(), 1, "exactly one pair expected, got {out:?}");
+        assert!(out[0].confidence >= 0.9);
+        assert!(out[0].reason.contains("same canonical_name"));
+    }
+
+    #[test]
+    fn edit_distance_local_part_detected() {
+        let db = Database::open_in_memory().expect("open");
+        insert_author(&db, "Alice", "alice@example.com");
+        insert_author(&db, "Other", "alicea@example.com");
+        let out = detect_edit_distance_pairs(db.connection()).expect("detect");
+        assert!(
+            out.iter().any(|s| s.reason.contains("edit-distance")),
+            "expected an edit-distance suggestion, got {out:?}"
+        );
+    }
+
+    #[test]
+    fn dotlocal_email_routed_to_canonical_domain() {
+        let db = Database::open_in_memory().expect("open");
+        insert_author(&db, "Bob", "bob@HOST.local");
+        insert_author(&db, "Bob", "bob@duettoresearch.com");
+        let out =
+            detect_noise_patterns(db.connection(), Some("duettoresearch.com")).expect("detect");
+        assert!(
+            out.iter().any(|s| s.reason.contains(".local hostname")),
+            "expected .local suggestion, got {out:?}"
+        );
+    }
+
+    #[test]
+    fn github_noreply_routed_to_login() {
+        let db = Database::open_in_memory().expect("open");
+        insert_author(
+            &db,
+            "A",
+            "129991831+andreramosduetto@users.noreply.github.com",
+        );
+        insert_author(&db, "B", "andreramosduetto@duettoresearch.com");
+        let out =
+            detect_noise_patterns(db.connection(), Some("duettoresearch.com")).expect("detect");
+        assert!(
+            out.iter().any(|s| s.reason.contains("GitHub noreply")),
+            "expected github noreply suggestion, got {out:?}"
+        );
+    }
+
+    #[test]
+    fn domain_typo_detected_against_canonical_domain() {
+        let db = Database::open_in_memory().expect("open");
+        insert_author(&db, "Carol", "carol@duettoresearh.com"); // typo
+        insert_author(&db, "Carol", "carol@duettoresearch.com");
+        let out =
+            detect_noise_patterns(db.connection(), Some("duettoresearch.com")).expect("detect");
+        assert!(
+            out.iter().any(|s| s.reason.contains("domain typo")),
+            "expected domain-typo suggestion, got {out:?}"
+        );
+    }
+
+    #[test]
+    fn same_sha_two_emails_detected() {
+        // The production schema enforces UNIQUE on `commits.sha`, so two rows
+        // sharing a SHA cannot be staged against the standard `Database`. The
+        // detector reads only `(sha, author_email)`, so a stripped-down table
+        // on a fresh connection reproduces the data shape it consumes.
+        let conn = rusqlite::Connection::open_in_memory().expect("open");
+        conn.execute("CREATE TABLE commits (sha TEXT, author_email TEXT)", [])
+            .expect("create commits");
+        conn.execute(
+            "INSERT INTO commits (sha, author_email) VALUES \
+             ('shared-sha', 'a@example.com'), ('shared-sha', 'b@example.com')",
+            [],
+        )
+        .expect("insert");
+
+        let out = detect_commit_sha_cooccurrence(&conn).expect("detect");
+        assert!(
+            out.iter().any(|s| s.reason.contains("same SHA")),
+            "expected commit-SHA co-occurrence, got {out:?}"
+        );
+    }
+
+    #[test]
+    fn dedupe_keeps_highest_confidence() {
+        let input = vec![
+            Suggestion {
+                src: "x".into(),
+                dst: "y".into(),
+                confidence: 0.7,
+                reason: "weak".into(),
+            },
+            Suggestion {
+                src: "x".into(),
+                dst: "y".into(),
+                confidence: 0.95,
+                reason: "strong".into(),
+            },
+        ];
+        let out = dedupe_and_rank(input, 0.5);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].reason, "strong");
+        assert!((out[0].confidence - 0.95).abs() < 1e-9);
+    }
+
+    #[test]
+    fn confidence_floor_filters() {
+        let input = vec![
+            Suggestion {
+                src: "a".into(),
+                dst: "b".into(),
+                confidence: 0.6,
+                reason: "weak".into(),
+            },
+            Suggestion {
+                src: "c".into(),
+                dst: "d".into(),
+                confidence: 0.95,
+                reason: "strong".into(),
+            },
+        ];
+        let out = dedupe_and_rank(input, 0.85);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].src, "c");
+    }
+
+    #[test]
+    fn the_weakest_noise_signal_stays_below_the_high_cutoff() {
+        // The report flags HIGH pairs only, so a partial GitHub-noreply match
+        // (0.78) must not survive a floor set at the cutoff — otherwise the
+        // flag would fire on a hint nobody considers actionable.
+        let db = Database::open_in_memory().expect("open");
+        insert_author(&db, "A", "1+alicedev@users.noreply.github.com");
+        insert_author(&db, "B", "alicedevlead@corp.com");
+        let below = detect_from_authors(db.connection(), Some("corp.com"), 0.5).expect("detect");
+        assert!(
+            below.iter().any(|s| s.reason.contains("(partial)")),
+            "the fixture must produce the partial-match signal, got {below:?}"
+        );
+        let at_cutoff =
+            detect_from_authors(db.connection(), Some("corp.com"), HIGH_CONFIDENCE_CUTOFF)
+                .expect("detect");
+        assert!(
+            !at_cutoff.iter().any(|s| s.reason.contains("(partial)")),
+            "a 0.78 partial match must not reach the HIGH floor, got {at_cutoff:?}"
+        );
+    }
+
+    #[test]
+    fn detect_from_authors_finds_same_name_pair() {
+        let db = Database::open_in_memory().expect("open");
+        insert_author(&db, "Alice", "alice@corp.com");
+        insert_author(&db, "Alice", "alice@personal.com");
+        let out =
+            detect_from_authors(db.connection(), None, HIGH_CONFIDENCE_CUTOFF).expect("detect");
+        assert_eq!(out.len(), 1, "one HIGH pair expected, got {out:?}");
+        assert_eq!(out[0].src, "alice@personal.com");
+        assert_eq!(out[0].dst, "alice@corp.com");
+    }
+
+    #[test]
+    fn detect_all_adds_the_sha_signal() {
+        // `detect_from_authors` must not read `commits`; `detect_all` must.
+        let db = Database::open_in_memory().expect("open");
+        let a = insert_author(&db, "A", "aaa@example.com");
+        let b = insert_author(&db, "B", "bbb@example.com");
+        insert_commit(&db, "sha-a", a);
+        insert_commit(&db, "sha-b", b);
+
+        // Neither pass finds anything: different names, distant local-parts,
+        // distinct SHAs.
+        let from_authors = detect_from_authors(db.connection(), None, 0.5).expect("authors pass");
+        assert!(from_authors.is_empty(), "got {from_authors:?}");
+        let all = detect_all(db.connection(), None, 0.5).expect("all passes");
+        assert!(all.is_empty(), "got {all:?}");
+    }
+
+    #[test]
+    fn split_email_basic() {
+        assert_eq!(
+            split_email("Bob@Example.COM"),
+            Some(("bob".to_string(), "example.com".to_string()))
+        );
+        assert_eq!(split_email("no-at"), None);
+        assert_eq!(split_email("@nolocal.com"), None);
+        assert_eq!(split_email("local@"), None);
+    }
+}

--- a/crates/trusty-git-analytics/src/commands/aliases/suggest.rs
+++ b/crates/trusty-git-analytics/src/commands/aliases/suggest.rs
@@ -1,65 +1,27 @@
-//! `tga aliases suggest` — auto-detect probable alias pairs (issue #347).
+//! `tga aliases suggest` — print probable alias pairs (issue #347).
 //!
-//! Scans the `authors` and `commits` tables for high-signal hints that two
-//! rows likely refer to the same engineer, ranks them by confidence, and
-//! prints suggestions. With `--auto-accept`, applies the merge directly
-//! for HIGH-confidence pairs above the threshold.
-//!
-//! Signals (highest signal first):
-//! 1. Same observed `author_name` string under two different emails
-//!    (confidence 0.95).
-//! 2. Edit distance ≤ 2 on the email local-part with identical or
-//!    near-identical domains (confidence 0.85).
-//! 3. Known noise patterns: `*.local` hostnames, GitHub noreply emails,
-//!    domain-typo corrections against the configured canonical_domain
-//!    (confidence 0.75 – 0.90 depending on signal strength).
-//! 4. Commit-SHA co-occurrence: the same SHA authored under two emails
-//!    (confidence 0.90).
-
-use std::collections::{BTreeMap, HashSet};
+//! Why: detection itself moved to [`tga::collect::identity::suggest`] under
+//! #6142, because the authorship report needs the same answer and cannot call
+//! a CLI handler. What remains here is presentation and the `--auto-accept`
+//! merge, both of which are CLI-only concerns.
+//! What: [`run`] resolves the configured canonical domain, calls
+//! [`tga::collect::identity::suggest::detect_all`], prints the ranked pairs,
+//! and optionally applies the HIGH-confidence ones.
+//! Test: `tests` in `suggest_tests.rs`.
 
 use rusqlite::params;
-use strsim::levenshtein;
+use tga::collect::identity::suggest::{detect_all, HIGH_CONFIDENCE_CUTOFF};
 use tga::core::config::Config;
 use tga::core::db::Database;
 
-use tga::collect::identity::resolver::email_domain_matches;
-
-/// Why: the threshold separating MED-confidence suggestions (mere hint) from
-/// HIGH-confidence ones (safe to auto-accept). Pinned at the top so a single
-/// constant drives both display labels and `--auto-accept` gating.
-/// What: confidence at or above this value renders as `HIGH`; below it but
-/// above the user's `--confidence` floor renders as `MED`.
-/// Test: covered indirectly by `tests::auto_accept_only_merges_high`.
-const HIGH_CONFIDENCE_CUTOFF: f64 = 0.85;
-
-/// A single alias suggestion ranked by `confidence`.
-///
-/// Why: the suggester runs four passes and dedupes by `(src, dst)` pair; this
-/// is the shared shape so each pass produces homogeneous output the dedup
-/// step can sort and filter.
-/// What: holds the source email (to be merged), the destination canonical
-/// email (kept), the confidence score, and a short human-readable reason
-/// surfaced in the printed output.
-/// Test: indirectly via every `tests::*` case in this module.
-#[derive(Debug, Clone)]
-pub(crate) struct Suggestion {
-    src: String,
-    dst: String,
-    confidence: f64,
-    reason: String,
-}
-
 /// Public entry point invoked by the CLI dispatcher.
 ///
-/// Why: the dispatcher only knows about config + DB + flag values; concrete
-/// detection lives here so unit tests can exercise the algorithm without
-/// going through clap.
-/// What: collects suggestions from every detection pass, sorts by descending
-/// confidence, applies the `--confidence` floor, prints, and (optionally)
-/// auto-merges the HIGH-confidence pairs.
-/// Test: see `tests::same_name_different_email_detected` and the other
-/// signal-specific tests below.
+/// Why: the dispatcher only knows about config + DB + flag values; the
+/// detection algorithm lives in the library so the report layer shares it.
+/// What: collects ranked suggestions above `confidence_floor`, prints them,
+/// and (with `auto_accept`) merges the HIGH-confidence pairs.
+/// Test: `tests::auto_accept_only_merges_high`,
+/// `tests::config_canonical_domain_threads_through`.
 pub(super) fn run(
     config: &Config,
     db: &mut Database,
@@ -73,13 +35,11 @@ pub(super) fn run(
         .map(|d| d.trim().trim_start_matches('@').to_lowercase())
         .filter(|d| !d.is_empty());
 
-    let mut suggestions: Vec<Suggestion> = Vec::new();
-    suggestions.extend(detect_same_name_pairs(db)?);
-    suggestions.extend(detect_edit_distance_pairs(db)?);
-    suggestions.extend(detect_noise_patterns(db, canonical_domain.as_deref())?);
-    suggestions.extend(detect_commit_sha_cooccurrence(db)?);
-
-    let suggestions = dedupe_and_rank(suggestions, confidence_floor);
+    let suggestions = detect_all(
+        db.connection(),
+        canonical_domain.as_deref(),
+        confidence_floor,
+    )?;
 
     if suggestions.is_empty() {
         println!(
@@ -138,299 +98,11 @@ pub(super) fn run(
     Ok(())
 }
 
-/// Signal 1: identical observed display names under two different emails.
-///
-/// Why: the strongest possible hint short of an explicit user action; if two
-/// authors share `author_name` and only the email differs, they are almost
-/// certainly the same person.
-/// What: groups distinct `(canonical_name, canonical_email)` pairs by name
-/// and emits one suggestion per non-canonical email pointing at the
-/// alphabetically-first email for the name (deterministic destination).
-/// Test: see `tests::same_name_different_email_detected`.
-fn detect_same_name_pairs(db: &Database) -> anyhow::Result<Vec<Suggestion>> {
-    let conn = db.connection();
-    let mut stmt = conn.prepare(
-        "SELECT canonical_name, canonical_email FROM authors \
-         ORDER BY canonical_name, canonical_email",
-    )?;
-    let rows = stmt.query_map([], |row| {
-        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
-    })?;
-
-    let mut groups: BTreeMap<String, Vec<String>> = BTreeMap::new();
-    for r in rows {
-        let (name, email) = r?;
-        groups.entry(name.to_lowercase()).or_default().push(email);
-    }
-
-    let mut out: Vec<Suggestion> = Vec::new();
-    for (_name, mut emails) in groups {
-        if emails.len() < 2 {
-            continue;
-        }
-        emails.sort();
-        emails.dedup();
-        if emails.len() < 2 {
-            continue;
-        }
-        let dst = emails[0].clone();
-        for src in emails.into_iter().skip(1) {
-            out.push(Suggestion {
-                src,
-                dst: dst.clone(),
-                confidence: 0.95,
-                reason: "same canonical_name".to_string(),
-            });
-        }
-    }
-    Ok(out)
-}
-
-/// Signal 2: email local-parts within edit distance ≤ 2, near-identical domains.
-///
-/// Why: catches `alice@co.com` vs `alice@contractor.co.com` (contractor
-/// prefix), `bob@co.com` vs `b.matsuoka@co.com` only when truly close, etc.
-/// What: cross-joins all distinct emails, computes Levenshtein on the
-/// local-part. Emits MED-confidence (0.80) for distance ≤ 2 with matching
-/// domains; lower for cross-domain matches.
-/// Test: see `tests::edit_distance_local_part_detected`.
-fn detect_edit_distance_pairs(db: &Database) -> anyhow::Result<Vec<Suggestion>> {
-    let conn = db.connection();
-    let mut stmt = conn.prepare("SELECT canonical_email FROM authors")?;
-    let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
-    let emails: Vec<String> = rows.filter_map(|r| r.ok()).collect();
-
-    let mut out: Vec<Suggestion> = Vec::new();
-    let mut seen: HashSet<(String, String)> = HashSet::new();
-    for i in 0..emails.len() {
-        for j in (i + 1)..emails.len() {
-            let a = &emails[i];
-            let b = &emails[j];
-            let (la, da) = match split_email(a) {
-                Some(x) => x,
-                None => continue,
-            };
-            let (lb, db_) = match split_email(b) {
-                Some(x) => x,
-                None => continue,
-            };
-            // Skip if local-parts are identical (the same-name signal is
-            // already a stronger producer for that case) or if either is
-            // very short (false-positive risk).
-            if la == lb || la.len() < 3 || lb.len() < 3 {
-                continue;
-            }
-            let dist = levenshtein(&la, &lb);
-            if dist == 0 || dist > 2 {
-                continue;
-            }
-            // Domain check: must be identical, or one domain must be a
-            // suffix of the other (e.g. `co.com` vs `contractor.co.com`).
-            let domains_match = da == db_ || da.ends_with(&db_) || db_.ends_with(&da);
-            if !domains_match {
-                continue;
-            }
-            // Lower confidence the larger the edit distance.
-            let confidence = if dist == 1 { 0.85 } else { 0.78 };
-            // Pick the shorter / alphabetically earlier as the destination
-            // so the suggestion is stable across runs.
-            let (src, dst) = if a < b {
-                (b.clone(), a.clone())
-            } else {
-                (a.clone(), b.clone())
-            };
-            let key = (src.clone(), dst.clone());
-            if seen.insert(key) {
-                out.push(Suggestion {
-                    src,
-                    dst,
-                    confidence,
-                    reason: format!("edit-distance {dist} on local-part"),
-                });
-            }
-        }
-    }
-    Ok(out)
-}
-
-/// Signal 3: known noise patterns — `.local`, GitHub noreply, domain typos.
-///
-/// Why: these patterns appear constantly in commit history and account for
-/// most of the alias-table noise on a real corpus.
-/// What:
-/// - `<local>@<host>.local` → try to find an identity at
-///   `<local>@<canonical_domain>` (HIGH if found, no suggestion otherwise).
-/// - `<id>+<login>@users.noreply.github.com` → look for any identity whose
-///   local-part contains the login (HIGH on exact local-part match, MED on
-///   substring match).
-/// - Domain edit-distance to `canonical_domain`: catches typos like
-///   `duettoresearh.com` vs `duettoresearch.com` (HIGH on dist ≤ 2).
-///
-/// Test: see `tests::dotlocal_email_routed_to_canonical_domain`.
-fn detect_noise_patterns(
-    db: &Database,
-    canonical_domain: Option<&str>,
-) -> anyhow::Result<Vec<Suggestion>> {
-    let conn = db.connection();
-    let mut stmt = conn.prepare("SELECT canonical_email FROM authors")?;
-    let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
-    let emails: Vec<String> = rows.filter_map(|r| r.ok()).collect();
-
-    let mut out: Vec<Suggestion> = Vec::new();
-    for email in &emails {
-        let (local, domain) = match split_email(email) {
-            Some(x) => x,
-            None => continue,
-        };
-
-        // 3a. `.local` hostnames (e.g. `bob@ENCDXPAHDLT0616.local`).
-        if domain.ends_with(".local") {
-            if let Some(canon_dom) = canonical_domain {
-                let target = format!("{local}@{canon_dom}");
-                if emails.iter().any(|e| e.eq_ignore_ascii_case(&target)) {
-                    out.push(Suggestion {
-                        src: email.clone(),
-                        dst: target,
-                        confidence: 0.90,
-                        reason: ".local hostname → org email".to_string(),
-                    });
-                }
-            }
-        }
-
-        // 3b. GitHub noreply emails: `<id>+<login>@users.noreply.github.com`.
-        if domain == "users.noreply.github.com" {
-            if let Some(login) = local.split_once('+').map(|(_, l)| l) {
-                // Look for an identity whose local-part is exactly the login.
-                for other in &emails {
-                    if other == email {
-                        continue;
-                    }
-                    let (other_local, _) = match split_email(other) {
-                        Some(x) => x,
-                        None => continue,
-                    };
-                    if other_local == login {
-                        out.push(Suggestion {
-                            src: email.clone(),
-                            dst: other.clone(),
-                            confidence: 0.90,
-                            reason: format!("GitHub noreply login '{login}'"),
-                        });
-                    } else if other_local.contains(login) || login.contains(&other_local) {
-                        out.push(Suggestion {
-                            src: email.clone(),
-                            dst: other.clone(),
-                            confidence: 0.78,
-                            reason: format!("GitHub noreply login '{login}' (partial)"),
-                        });
-                    }
-                }
-            }
-        }
-
-        // 3c. Domain edit-distance against canonical_domain (catches typos).
-        if let Some(canon_dom) = canonical_domain {
-            if !email_domain_matches(email, canon_dom) {
-                let dist = levenshtein(&domain, canon_dom);
-                if dist > 0 && dist <= 2 {
-                    let target = format!("{local}@{canon_dom}");
-                    if emails.iter().any(|e| e.eq_ignore_ascii_case(&target)) {
-                        out.push(Suggestion {
-                            src: email.clone(),
-                            dst: target,
-                            confidence: 0.88,
-                            reason: format!("domain typo '{domain}' (dist {dist})"),
-                        });
-                    }
-                }
-            }
-        }
-    }
-    Ok(out)
-}
-
-/// Signal 4: same commit SHA attributed to two different emails.
-///
-/// Why: this is the strongest possible evidence — git itself recorded both
-/// emails against the same content. Happens when a commit was cherry-picked
-/// or rebased and the author email changed in transit.
-/// What: groups commits by SHA and emits HIGH-confidence (0.92) suggestions
-/// for any SHA with two distinct author_email values.
-/// Test: see `tests::same_sha_two_emails_detected`.
-fn detect_commit_sha_cooccurrence(db: &Database) -> anyhow::Result<Vec<Suggestion>> {
-    let conn = db.connection();
-    let mut stmt =
-        conn.prepare("SELECT sha, author_email FROM commits ORDER BY sha, author_email")?;
-    let rows = stmt.query_map([], |row| {
-        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
-    })?;
-
-    let mut groups: BTreeMap<String, Vec<String>> = BTreeMap::new();
-    for r in rows {
-        let (sha, email) = r?;
-        groups.entry(sha).or_default().push(email);
-    }
-
-    let mut out: Vec<Suggestion> = Vec::new();
-    for (sha, mut emails) in groups {
-        emails.sort();
-        emails.dedup();
-        if emails.len() < 2 {
-            continue;
-        }
-        let dst = emails[0].clone();
-        for src in emails.into_iter().skip(1) {
-            out.push(Suggestion {
-                src,
-                dst: dst.clone(),
-                confidence: 0.92,
-                reason: format!("same SHA {short}", short = &sha[..sha.len().min(8)]),
-            });
-        }
-    }
-    Ok(out)
-}
-
-/// Dedupe suggestions on `(src, dst)`, keep the highest-confidence reason,
-/// then sort descending by confidence and apply the user's floor.
-///
-/// Why: separate detection passes may produce overlapping pairs; we want a
-/// single line per pair with the strongest reason, and stable ordering for
-/// deterministic CLI output.
-/// What: walks the input, builds a map keyed on the canonical pair, retains
-/// the highest score, then sorts.
-/// Test: see `tests::dedupe_keeps_highest_confidence`.
-fn dedupe_and_rank(input: Vec<Suggestion>, floor: f64) -> Vec<Suggestion> {
-    let mut by_pair: BTreeMap<(String, String), Suggestion> = BTreeMap::new();
-    for s in input {
-        let key = (s.src.clone(), s.dst.clone());
-        match by_pair.get(&key) {
-            Some(existing) if existing.confidence >= s.confidence => {}
-            _ => {
-                by_pair.insert(key, s);
-            }
-        }
-    }
-    let mut out: Vec<Suggestion> = by_pair
-        .into_values()
-        .filter(|s| s.confidence >= floor)
-        .collect();
-    out.sort_by(|a, b| {
-        b.confidence
-            .partial_cmp(&a.confidence)
-            .unwrap_or(std::cmp::Ordering::Equal)
-            .then_with(|| a.src.cmp(&b.src))
-    });
-    out
-}
-
 /// Apply a merge between two existing identities, returning the number of
 /// commits reassigned.
 ///
 /// Why: `--auto-accept` needs to perform merges without going through the
-/// interactive confirm path in the parent module; this is a small private
-/// helper that runs the same DB transaction.
+/// interactive confirm path in the parent module.
 /// What: identical to the body of [`super::merge`] but with no prompt and a
 /// numeric return for the auto-accept summary line.
 /// Test: covered by `tests::auto_accept_only_merges_high` end-to-end.
@@ -459,20 +131,6 @@ fn apply_merge(db: &mut Database, src_email: &str, dst_email: &str) -> anyhow::R
     tx.execute("DELETE FROM authors WHERE id = ?1", params![src_id])?;
     tx.commit()?;
     Ok(n)
-}
-
-/// Why: every detection pass needs to split an email into (local, domain)
-/// lowercased; pulling this into one place keeps casing logic consistent.
-/// What: returns `Some((local, domain))` or `None` for malformed input.
-/// Test: implicit in every pass that calls it.
-fn split_email(email: &str) -> Option<(String, String)> {
-    let at = email.rfind('@')?;
-    let local = email[..at].to_lowercase();
-    let domain = email[at + 1..].to_lowercase();
-    if local.is_empty() || domain.is_empty() {
-        return None;
-    }
-    Some((local, domain))
 }
 
 #[cfg(test)]

--- a/crates/trusty-git-analytics/src/commands/aliases/suggest.rs
+++ b/crates/trusty-git-analytics/src/commands/aliases/suggest.rs
@@ -10,6 +10,7 @@
 //! Test: `tests` in `suggest_tests.rs`.
 
 use rusqlite::params;
+use tga::collect::identity::resolver::configured_canonical_domain;
 use tga::collect::identity::suggest::{detect_all, HIGH_CONFIDENCE_CUTOFF};
 use tga::core::config::Config;
 use tga::core::db::Database;
@@ -28,12 +29,7 @@ pub(super) fn run(
     confidence_floor: f64,
     auto_accept: bool,
 ) -> anyhow::Result<()> {
-    let canonical_domain = config
-        .team
-        .as_ref()
-        .and_then(|t| t.canonical_domain.as_deref())
-        .map(|d| d.trim().trim_start_matches('@').to_lowercase())
-        .filter(|d| !d.is_empty());
+    let canonical_domain = configured_canonical_domain(config);
 
     let suggestions = detect_all(
         db.connection(),

--- a/crates/trusty-git-analytics/src/commands/aliases/suggest_tests.rs
+++ b/crates/trusty-git-analytics/src/commands/aliases/suggest_tests.rs
@@ -1,6 +1,15 @@
+//! CLI-level tests for `tga aliases suggest`.
+//!
+//! Detection-algorithm coverage lives with the algorithm, in
+//! `tga::collect::identity::suggest::tests` (#6142). What remains here is the
+//! handler's own behaviour: threading the configured canonical domain through,
+//! and the `--auto-accept` merge.
+
 use super::*;
-use crate::commands::aliases::tests::{insert_author, insert_commit};
+use rusqlite::params;
 use tga::core::config::TeamConfig;
+
+use crate::commands::aliases::tests::{insert_author, insert_commit};
 
 fn config_with_domain(domain: &str) -> Config {
     Config {
@@ -11,171 +20,6 @@ fn config_with_domain(domain: &str) -> Config {
         }),
         ..Config::default()
     }
-}
-
-#[test]
-fn same_name_different_email_detected() {
-    let db = Database::open_in_memory().expect("open");
-    insert_author(&db, "Bob Matsuoka", "bob@matsuoka.com");
-    insert_author(&db, "Bob Matsuoka", "robert.matsuoka@duettoresearch.com");
-    let out = detect_same_name_pairs(&db).expect("detect");
-    assert_eq!(out.len(), 1, "exactly one pair expected, got {out:?}");
-    assert!(out[0].confidence >= 0.9);
-    assert!(out[0].reason.contains("same canonical_name"));
-}
-
-#[test]
-fn edit_distance_local_part_detected() {
-    let db = Database::open_in_memory().expect("open");
-    insert_author(&db, "Alice", "alice@example.com");
-    // `aliace` is edit-distance 2 from `alice` (insert + transpose),
-    // but actually it's distance 1 (one insert). Make distance exactly 1.
-    insert_author(&db, "Other", "alicea@example.com");
-    let out = detect_edit_distance_pairs(&db).expect("detect");
-    assert!(
-        out.iter().any(|s| s.reason.contains("edit-distance")),
-        "expected an edit-distance suggestion, got {out:?}"
-    );
-}
-
-#[test]
-fn dotlocal_email_routed_to_canonical_domain() {
-    let db = Database::open_in_memory().expect("open");
-    insert_author(&db, "Bob", "bob@HOST.local");
-    insert_author(&db, "Bob", "bob@duettoresearch.com");
-    let out = detect_noise_patterns(&db, Some("duettoresearch.com")).expect("detect");
-    assert!(
-        out.iter().any(|s| s.reason.contains(".local hostname")),
-        "expected .local suggestion, got {out:?}"
-    );
-}
-
-#[test]
-fn github_noreply_routed_to_login() {
-    let db = Database::open_in_memory().expect("open");
-    insert_author(
-        &db,
-        "A",
-        "129991831+andreramosduetto@users.noreply.github.com",
-    );
-    insert_author(&db, "B", "andreramosduetto@duettoresearch.com");
-    let out = detect_noise_patterns(&db, Some("duettoresearch.com")).expect("detect");
-    assert!(
-        out.iter().any(|s| s.reason.contains("GitHub noreply")),
-        "expected github noreply suggestion, got {out:?}"
-    );
-}
-
-#[test]
-fn domain_typo_detected_against_canonical_domain() {
-    let db = Database::open_in_memory().expect("open");
-    insert_author(&db, "Carol", "carol@duettoresearh.com"); // typo
-    insert_author(&db, "Carol", "carol@duettoresearch.com");
-    let out = detect_noise_patterns(&db, Some("duettoresearch.com")).expect("detect");
-    assert!(
-        out.iter().any(|s| s.reason.contains("domain typo")),
-        "expected domain-typo suggestion, got {out:?}"
-    );
-}
-
-#[test]
-fn same_sha_two_emails_detected() {
-    // Why: the production schema enforces UNIQUE on commits.sha so we
-    // cannot directly stage two rows with the same SHA against the
-    // standard `Database`. The detector only reads `(sha, author_email)`,
-    // so we exercise it against a fresh in-memory connection where we
-    // own a stripped-down commits table without the UNIQUE constraint.
-    // This mirrors the data shape the query actually consumes.
-    let db = Database::open_in_memory().expect("open");
-    // Replace the commits table with one that lacks UNIQUE on sha.
-    // We must also drop the FK-bearing children (fact_commit_reachability,
-    // fact_commit_effort, etc.) first because SQLite refuses to drop a
-    // table while another table references it via FK.
-    let conn = db.connection();
-    conn.execute("PRAGMA foreign_keys = OFF", [])
-        .expect("fk off");
-    // Discover and drop all tables that reference `commits` via FK so
-    // the `DROP TABLE commits` is unconstrained.
-    let mut stmt = conn
-        .prepare("SELECT name FROM sqlite_master WHERE type='table'")
-        .expect("prepare");
-    let names: Vec<String> = stmt
-        .query_map([], |row| row.get::<_, String>(0))
-        .expect("rows")
-        .filter_map(|r| r.ok())
-        .collect();
-    drop(stmt);
-    for n in &names {
-        if n != "authors" && n != "sqlite_sequence" {
-            let _ = conn.execute(&format!("DROP TABLE IF EXISTS \"{n}\""), []);
-        }
-    }
-    conn.execute(
-        "CREATE TABLE commits (sha TEXT, author_id INTEGER, author_name TEXT, \
-         author_email TEXT, timestamp TEXT, message TEXT, repository TEXT)",
-        [],
-    )
-    .expect("recreate commits");
-
-    let a = insert_author(&db, "A", "a@example.com");
-    let b = insert_author(&db, "B", "b@example.com");
-    conn.execute(
-        "INSERT INTO commits (sha, author_id, author_name, author_email, timestamp, \
-         message, repository) VALUES \
-         ('shared-sha', ?1, 'A', 'a@example.com', '2024-01-01T00:00:00Z', 'm', 'r'),\
-         ('shared-sha', ?2, 'B', 'b@example.com', '2024-01-01T00:00:00Z', 'm', 'r')",
-        params![a, b],
-    )
-    .expect("insert");
-
-    let out = detect_commit_sha_cooccurrence(&db).expect("detect");
-    assert!(
-        out.iter().any(|s| s.reason.contains("same SHA")),
-        "expected commit-SHA co-occurrence, got {out:?}"
-    );
-}
-
-#[test]
-fn dedupe_keeps_highest_confidence() {
-    let input = vec![
-        Suggestion {
-            src: "x".into(),
-            dst: "y".into(),
-            confidence: 0.7,
-            reason: "weak".into(),
-        },
-        Suggestion {
-            src: "x".into(),
-            dst: "y".into(),
-            confidence: 0.95,
-            reason: "strong".into(),
-        },
-    ];
-    let out = dedupe_and_rank(input, 0.5);
-    assert_eq!(out.len(), 1);
-    assert_eq!(out[0].reason, "strong");
-    assert!((out[0].confidence - 0.95).abs() < 1e-9);
-}
-
-#[test]
-fn confidence_floor_filters() {
-    let input = vec![
-        Suggestion {
-            src: "a".into(),
-            dst: "b".into(),
-            confidence: 0.6,
-            reason: "weak".into(),
-        },
-        Suggestion {
-            src: "c".into(),
-            dst: "d".into(),
-            confidence: 0.95,
-            reason: "strong".into(),
-        },
-    ];
-    let out = dedupe_and_rank(input, 0.85);
-    assert_eq!(out.len(), 1);
-    assert_eq!(out[0].src, "c");
 }
 
 #[test]
@@ -220,6 +64,24 @@ fn auto_accept_only_merges_high() {
 }
 
 #[test]
+fn suggest_without_auto_accept_never_merges() {
+    // #6142: a suggestion is not a merge. The report's risk flag depends on
+    // an unconfirmed pair staying unconfirmed until a human accepts it.
+    let mut db = Database::open_in_memory().expect("open");
+    insert_author(&db, "Bob", "alt@example.com");
+    insert_author(&db, "Bob", "bob@example.com");
+
+    let cfg = Config::default();
+    run(&cfg, &mut db, 0.85, false).expect("run");
+
+    let rows: i64 = db
+        .connection()
+        .query_row("SELECT COUNT(*) FROM authors", [], |r| r.get(0))
+        .expect("count");
+    assert_eq!(rows, 2, "both identities must survive a suggest-only run");
+}
+
+#[test]
 fn config_canonical_domain_threads_through() {
     // Smoke test: with a configured canonical_domain, the suggester
     // produces a domain-typo suggestion when the corpus contains one.
@@ -229,15 +91,4 @@ fn config_canonical_domain_threads_through() {
     let cfg = config_with_domain("duettoresearch.com");
     // Run with auto_accept=false so we don't mutate; just ensure no panic.
     run(&cfg, &mut db, 0.5, false).expect("run");
-}
-
-#[test]
-fn split_email_basic() {
-    assert_eq!(
-        split_email("Bob@Example.COM"),
-        Some(("bob".to_string(), "example.com".to_string()))
-    );
-    assert_eq!(split_email("no-at"), None);
-    assert_eq!(split_email("@nolocal.com"), None);
-    assert_eq!(split_email("local@"), None);
 }

--- a/crates/trusty-git-analytics/src/commands/audit.rs
+++ b/crates/trusty-git-analytics/src/commands/audit.rs
@@ -39,7 +39,8 @@ use tga::report::build_ticketing_summary;
 use tga::collect::identity::resolver::configured_canonical_domain;
 use tga::collect::identity::suggest::Suggestion;
 use tga::report::{
-    build_authorship_summary, merge_suggestions, recorded_repository_names, repository_has_commits,
+    build_authorship_summary_with, merge_suggestions, recorded_repository_names,
+    repository_has_commits,
 };
 use trusty_common::credentials::scrub_secrets;
 
@@ -291,15 +292,12 @@ pub async fn run(config: Config, db: &mut Database, args: AuditArgs) -> anyhow::
     // in. Passing `None` there mutes the `.local`, GitHub-noreply and
     // domain-typo signals #6142 exists to surface.
     let mut authorship_gaps: Vec<String> = Vec::new();
-    let suggestions = merge_suggestions(
+    let suggestions = scan_merge_suggestions(
         db.connection(),
         configured_canonical_domain(&config).as_deref(),
-    )
-    .unwrap_or_else(|e| {
-        // A failed scan costs the risk FLAG, never the figures beside it.
-        tracing::warn!(error = %e, "could not scan for unmerged identities; the authorship risk flag is omitted");
-        Vec::new()
-    });
+        &configured_secrets(&config),
+        &mut authorship_gaps,
+    );
     for (i, (entry, repo_cfg)) in manifest
         .repositories
         .iter_mut()
@@ -498,10 +496,46 @@ fn authorship_artifact(
             recorded_repository_names(db.connection())?,
         ));
     }
-    let summary = build_authorship_summary(db.connection(), repository, suggestions)?;
+    let summary = build_authorship_summary_with(db.connection(), repository, suggestions)?;
     let filename = format!("authorship-{index}.json");
     std::fs::write(output.join(&filename), summary.to_json()?)?;
     Ok(AuthorshipArtifact::Written(PathBuf::from(filename)))
+}
+
+/// Scan for unmerged identities once for the sweep, naming a failed scan.
+///
+/// Why (#6142 review): the scan feeds only
+/// [`tga::report::IdentityMergeRisk`], so a failure costs the risk FLAG while
+/// bus factor and top-author share still render from the same rows. Degrading
+/// to an empty suggestion set with only a `warn!` therefore prints those
+/// figures with no indication that the check beside them never ran — the
+/// silent absence DOC-67 §9 forbids.
+/// What: runs [`merge_suggestions`] once against the shared `authors` table
+/// (it is O(n²) in identities, so it must not run per repository), and on
+/// failure pushes a scrubbed gap naming the scan and returns an empty set.
+/// Test: `tests::a_failed_suggestion_scan_becomes_a_named_gap`.
+fn scan_merge_suggestions(
+    conn: &rusqlite::Connection,
+    canonical_domain: Option<&str>,
+    secrets: &[String],
+    gaps: &mut Vec<String>,
+) -> Vec<Suggestion> {
+    match merge_suggestions(conn, canonical_domain) {
+        Ok(suggestions) => suggestions,
+        Err(e) => {
+            tracing::warn!(error = %e, "could not scan for unmerged identities");
+            gaps.push(scrub_secrets(
+                &format!(
+                    "Authorship: the unmerged-identity scan failed ({e:#}), so no repository \
+                     carries the identity-merge risk flag. The ownership-concentration figures \
+                     are unaffected, but nothing in this report states whether identities that \
+                     should have been merged are inflating them."
+                ),
+                secrets,
+            ));
+            Vec::new()
+        }
+    }
 }
 
 /// The gap line for a repository whose name matched no collected commit.
@@ -728,6 +762,46 @@ mod tests {
         announce(None, PHASE_INDEX);
         finish_phase(None, PHASE_INDEX);
         fail_phase(None, PHASE_RENDER, "ignored".to_string());
+    }
+
+    /// (#6142 review) A failed unmerged-identity scan must reach the reader.
+    /// The scan feeds only the identity-merge risk flag, so its failure leaves
+    /// bus factor and top-author share rendering normally — without a named
+    /// gap the reader cannot tell the check ran and found nothing from the
+    /// check never running at all (DOC-67 §9).
+    #[test]
+    fn a_failed_suggestion_scan_becomes_a_named_gap() {
+        let db = Database::open_in_memory().expect("open");
+        // The scan reads `authors`; without that table it can only fail.
+        db.connection()
+            .execute("DROP TABLE authors", [])
+            .expect("drop authors");
+
+        let mut gaps: Vec<String> = Vec::new();
+        let suggestions = super::scan_merge_suggestions(
+            db.connection(),
+            None,
+            &["s3cret".to_string()],
+            &mut gaps,
+        );
+
+        assert!(
+            suggestions.is_empty(),
+            "a failed scan yields no suggestions, so the figures beside it still render"
+        );
+        assert_eq!(gaps.len(), 1, "the failure is named exactly once: {gaps:?}");
+        assert!(
+            gaps[0].contains("unmerged-identity scan failed")
+                && gaps[0].contains("identity-merge risk flag"),
+            "the gap must name the scan and what it cost: {}",
+            gaps[0]
+        );
+
+        // A successful scan on the same shape of database adds no gap.
+        let ok_db = Database::open_in_memory().expect("open");
+        let mut none: Vec<String> = Vec::new();
+        super::scan_merge_suggestions(ok_db.connection(), None, &[], &mut none);
+        assert!(none.is_empty(), "a clean scan says nothing: {none:?}");
     }
 
     /// Proves DOC-67 §9's "named gap, never a silent skip" obligation at the

--- a/crates/trusty-git-analytics/src/commands/audit.rs
+++ b/crates/trusty-git-analytics/src/commands/audit.rs
@@ -36,7 +36,11 @@ use tga::report::build_ticketing_summary;
 // #5453/#6004: per-repository ownership/bus-factor/trajectory figures, plus the
 // name-match probe that keeps an unmatched repository name from rendering as a
 // derived zero.
-use tga::report::{build_authorship_summary, recorded_repository_names, repository_has_commits};
+use tga::collect::identity::resolver::configured_canonical_domain;
+use tga::collect::identity::suggest::Suggestion;
+use tga::report::{
+    build_authorship_summary, merge_suggestions, recorded_repository_names, repository_has_commits,
+};
 use trusty_common::credentials::scrub_secrets;
 
 /// Arguments for `tga audit`.
@@ -280,7 +284,22 @@ pub async fn run(config: Config, db: &mut Database, args: AuditArgs) -> anyhow::
     // itself (DOC-67 §9's "named gap, never a silent one" rule) rather than
     // an aborted run — the report's Authorship section degrades to that gap
     // for exactly the repositories it could not compute.
+    //
+    // #6142 review: the suggestion scan is O(n²) in identities and reads the
+    // `authors` table, which is shared across every repository here — so it
+    // runs ONCE for the sweep, with the configured canonical domain threaded
+    // in. Passing `None` there mutes the `.local`, GitHub-noreply and
+    // domain-typo signals #6142 exists to surface.
     let mut authorship_gaps: Vec<String> = Vec::new();
+    let suggestions = merge_suggestions(
+        db.connection(),
+        configured_canonical_domain(&config).as_deref(),
+    )
+    .unwrap_or_else(|e| {
+        // A failed scan costs the risk FLAG, never the figures beside it.
+        tracing::warn!(error = %e, "could not scan for unmerged identities; the authorship risk flag is omitted");
+        Vec::new()
+    });
     for (i, (entry, repo_cfg)) in manifest
         .repositories
         .iter_mut()
@@ -288,7 +307,7 @@ pub async fn run(config: Config, db: &mut Database, args: AuditArgs) -> anyhow::
         .enumerate()
     {
         let repository = repo_name(repo_cfg.name.as_deref(), &repo_cfg.path);
-        match authorship_artifact(db, &output, &repository, i) {
+        match authorship_artifact(db, &output, &repository, i, &suggestions) {
             Ok(AuthorshipArtifact::Written(path)) => entry.authorship = Some(path),
             Ok(AuthorshipArtifact::NameMatchedNothing(recorded)) => {
                 authorship_gaps.push(scrub_secrets(
@@ -472,13 +491,14 @@ fn authorship_artifact(
     output: &Path,
     repository: &str,
     index: usize,
+    suggestions: &[Suggestion],
 ) -> anyhow::Result<AuthorshipArtifact> {
     if !repository_has_commits(db.connection(), repository)? {
         return Ok(AuthorshipArtifact::NameMatchedNothing(
             recorded_repository_names(db.connection())?,
         ));
     }
-    let summary = build_authorship_summary(db.connection(), repository)?;
+    let summary = build_authorship_summary(db.connection(), repository, suggestions)?;
     let filename = format!("authorship-{index}.json");
     std::fs::write(output.join(&filename), summary.to_json()?)?;
     Ok(AuthorshipArtifact::Written(PathBuf::from(filename)))
@@ -888,8 +908,9 @@ mod tests {
         seed_commit(&db, "a1", "acme-web");
         seed_commit(&db, "b1", "acme-api");
 
-        let first = super::authorship_artifact(&db, dir.path(), "acme-web", 0).expect("write");
-        let second = super::authorship_artifact(&db, dir.path(), "acme-api", 1).expect("write");
+        let first = super::authorship_artifact(&db, dir.path(), "acme-web", 0, &[]).expect("write");
+        let second =
+            super::authorship_artifact(&db, dir.path(), "acme-api", 1, &[]).expect("write");
 
         let (super::AuthorshipArtifact::Written(first), super::AuthorshipArtifact::Written(second)) =
             (first, second)
@@ -926,7 +947,7 @@ mod tests {
         let blocked = dir.path().join("not-a-directory");
         std::fs::write(&blocked, "").expect("create blocking file");
 
-        let err = super::authorship_artifact(&db, &blocked, "acme-web", 0)
+        let err = super::authorship_artifact(&db, &blocked, "acme-web", 0, &[])
             .expect_err("an unwritable output must surface, not be swallowed");
         let rendered = format!("{err:#}");
         assert!(
@@ -951,7 +972,8 @@ mod tests {
         // Collection recorded `acme_web`; the manifest asks for `acme-web`.
         seed_commit(&db, "a1", "acme_web");
 
-        let outcome = super::authorship_artifact(&db, dir.path(), "acme-web", 0).expect("no error");
+        let outcome =
+            super::authorship_artifact(&db, dir.path(), "acme-web", 0, &[]).expect("no error");
         let super::AuthorshipArtifact::NameMatchedNothing(recorded) = outcome else {
             panic!("an unmatched name must never produce an artifact of zeroes");
         };

--- a/crates/trusty-git-analytics/src/commands/collect.rs
+++ b/crates/trusty-git-analytics/src/commands/collect.rs
@@ -172,24 +172,31 @@ pub async fn run_reporting_fetch(
     };
 
     if args.dry_run {
+        // #6073: `repos_skipped` is the only figure separating a skipped
+        // full-history walk from one that ran and found nothing new — both
+        // leave `commits_collected` at zero.
         println!(
             "Dry run complete. Would have written {} commits, {} authors, \
-             {} PRs ({} weeks collected, {} weeks skipped). No changes persisted.",
+             {} PRs ({} weeks collected, {} weeks skipped, \
+             {} repo full-history walks skipped). No changes persisted.",
             stats.commits_collected,
             stats.authors_resolved,
             stats.prs_fetched,
             stats.weeks_collected,
             stats.weeks_skipped,
+            stats.repos_skipped,
         );
     } else {
         println!(
             "Collected {} commits from {} authors ({} PRs fetched, \
-             {} weeks collected, {} weeks skipped)",
+             {} weeks collected, {} weeks skipped, \
+             {} repo full-history walks skipped)",
             stats.commits_collected,
             stats.authors_resolved,
             stats.prs_fetched,
             stats.weeks_collected,
             stats.weeks_skipped,
+            stats.repos_skipped,
         );
     }
     if !stats.errors.is_empty() {

--- a/crates/trusty-git-analytics/src/commands/collect.rs
+++ b/crates/trusty-git-analytics/src/commands/collect.rs
@@ -172,21 +172,23 @@ pub async fn run_reporting_fetch(
     };
 
     if args.dry_run {
-        // #6073: `repos_skipped` is the only figure separating a skipped
-        // full-history walk from one that ran and found nothing new — both
-        // leave `commits_collected` at zero.
+        // #6073 review: no `repos_skipped` here. A dry run walks against an
+        // empty in-memory shadow database, which holds no `repo_walk_state`
+        // row for any repository, so the figure is structurally always 0 and
+        // reads as "nothing was skipped" whatever the real database records.
         println!(
             "Dry run complete. Would have written {} commits, {} authors, \
-             {} PRs ({} weeks collected, {} weeks skipped, \
-             {} repo full-history walks skipped). No changes persisted.",
+             {} PRs ({} weeks collected, {} weeks skipped). No changes persisted.",
             stats.commits_collected,
             stats.authors_resolved,
             stats.prs_fetched,
             stats.weeks_collected,
             stats.weeks_skipped,
-            stats.repos_skipped,
         );
     } else {
+        // #6073: `repos_skipped` is the only figure separating a skipped
+        // full-history walk from one that ran and found nothing new — both
+        // leave `commits_collected` at zero.
         println!(
             "Collected {} commits from {} authors ({} PRs fetched, \
              {} weeks collected, {} weeks skipped, \

--- a/crates/trusty-git-analytics/src/core/db/migrations/mod.rs
+++ b/crates/trusty-git-analytics/src/core/db/migrations/mod.rs
@@ -156,6 +156,12 @@ pub const MIGRATIONS: &[Migration] = &[
         name: "pull_requests_head_ref_and_body_ticket",
         sql: include_str!("../sql/0024_pull_requests_head_ref_and_body_ticket.sql"),
     },
+    // #6073: per-repo full-history walk bookkeeping.
+    Migration {
+        version: 25,
+        name: "repo_walk_state",
+        sql: include_str!("../sql/0025_repo_walk_state.sql"),
+    },
 ];
 
 /// Ensure the `schema_migrations` bookkeeping table exists.
@@ -224,7 +230,7 @@ pub fn run(conn: &mut Connection) -> Result<()> {
 /// # Errors
 ///
 /// Returns [`TgaError::MigrationError`] if a migration's SQL fails.
-fn run_through(conn: &mut Connection, max_version: i64) -> Result<()> {
+pub(crate) fn run_through(conn: &mut Connection, max_version: i64) -> Result<()> {
     ensure_migrations_table(conn)?;
     let current = current_version(conn)?;
     debug!(current_version = current, "running migrations");

--- a/crates/trusty-git-analytics/src/core/db/sql/0025_repo_walk_state.sql
+++ b/crates/trusty-git-analytics/src/core/db/sql/0025_repo_walk_state.sql
@@ -12,6 +12,14 @@
 -- silent skip. `walk_complete` is written 0 before the walk and 1 after it
 -- succeeds, so an interrupted run falls back to a full re-walk.
 --
+-- `walk_scope` records what the walk was ALLOWED to see: the `--branch` /
+-- per-repo `branch:` filter, `--head-only`, and `skip_merges`. None of those
+-- appears in `tips_digest`, which digests every ref whatever the walk covered,
+-- so without this column a `--branch main` run would record a tip over refs it
+-- never walked and the next full-scope run would skip — leaving every
+-- side-branch commit permanently absent. A run whose scope differs from the
+-- recorded one walks in full.
+--
 -- Additive only. An older database has no rows here after the migration runs,
 -- which reads as "never walked" and produces the pre-#6073 full walk.
 CREATE TABLE IF NOT EXISTS repo_walk_state (
@@ -19,6 +27,7 @@ CREATE TABLE IF NOT EXISTS repo_walk_state (
     head_sha      TEXT    NOT NULL,
     head_ref      TEXT    NOT NULL,
     tips_digest   TEXT    NOT NULL,
+    walk_scope    TEXT    NOT NULL DEFAULT '',
     walk_complete INTEGER NOT NULL DEFAULT 0,
     walked_at     TEXT    NOT NULL
 );

--- a/crates/trusty-git-analytics/src/core/db/sql/0025_repo_walk_state.sql
+++ b/crates/trusty-git-analytics/src/core/db/sql/0025_repo_walk_state.sql
@@ -1,0 +1,24 @@
+-- Migration v25: per-repository full-history walk bookkeeping (issue #6073).
+--
+-- The fully-unbounded collect path (no `since_date`, no `--weeks`) has no
+-- week-level bookkeeping, so every re-run re-walks the entire history. A
+-- render-stage failure in trusty-audit's nine-stage sweep therefore paid a
+-- full re-collect: the issue measured this against a 594 MB extract database.
+--
+-- One row per repository records the tip the last COMPLETED full walk reached.
+-- `head_sha` is the base a later incremental walk hides; `tips_digest` is a
+-- digest over every `refs/heads/*` and `refs/remotes/*` (name, oid) pair, so a
+-- side branch moving without HEAD moving still forces a walk rather than a
+-- silent skip. `walk_complete` is written 0 before the walk and 1 after it
+-- succeeds, so an interrupted run falls back to a full re-walk.
+--
+-- Additive only. An older database has no rows here after the migration runs,
+-- which reads as "never walked" and produces the pre-#6073 full walk.
+CREATE TABLE IF NOT EXISTS repo_walk_state (
+    repository    TEXT    PRIMARY KEY,
+    head_sha      TEXT    NOT NULL,
+    head_ref      TEXT    NOT NULL,
+    tips_digest   TEXT    NOT NULL,
+    walk_complete INTEGER NOT NULL DEFAULT 0,
+    walked_at     TEXT    NOT NULL
+);

--- a/crates/trusty-git-analytics/src/report/authorship.rs
+++ b/crates/trusty-git-analytics/src/report/authorship.rs
@@ -248,7 +248,24 @@ fn confirmed_alias_map(conn: &Connection) -> Result<HashMap<String, String>> {
         if canonical.is_empty() {
             continue;
         }
-        let aliases: Vec<String> = serde_json::from_str(&aliases_json).unwrap_or_default();
+        // #6142 review: a row whose `aliases` value will not parse is treated
+        // as having none, which silently un-applies a merge the operator
+        // accepted. The fallback stays — one bad row must not fail the whole
+        // report — but it is named on stderr with the author it belongs to.
+        let aliases: Vec<String> = match serde_json::from_str(&aliases_json) {
+            Ok(aliases) => aliases,
+            Err(e) => {
+                if !aliases_json.trim().is_empty() {
+                    tracing::warn!(
+                        author = %canonical,
+                        error = %e,
+                        "authors.aliases is not a JSON array of strings; this author's confirmed \
+                         merges are not applied to the authorship figures"
+                    );
+                }
+                Vec::new()
+            }
+        };
         for alias in aliases {
             let key = alias.to_lowercase();
             if key.is_empty() || key == canonical.to_lowercase() {
@@ -366,6 +383,30 @@ fn month_of(timestamp: &str) -> Option<String> {
     timestamp.get(0..7).map(str::to_string)
 }
 
+/// [`build_authorship_summary_with`] for a caller that has no suggestion set.
+///
+/// Why (#6142 review): the suggestion set became a required parameter when the
+/// scan moved out to the audit caller, which would break every existing caller
+/// of this function. Keeping the previous signature working keeps tga's public
+/// surface additive.
+/// What: runs [`merge_suggestions`] itself, then delegates. That scan is O(n²)
+/// in identities, so this wrapper pays one full scan PER CALL — a caller
+/// summarising several repositories from one database should call
+/// [`build_authorship_summary_with`] with a set scanned once. It also passes
+/// `None` for the canonical domain, which mutes the `.local`, GitHub-noreply
+/// and domain-typo signals; a caller with a configured domain must use
+/// [`build_authorship_summary_with`].
+/// Test: `super::authorship_tests::the_wrapper_scans_its_own_suggestions`.
+///
+/// # Errors
+///
+/// Propagates [`crate::core::errors::TgaError::DbError`] from the scan or the
+/// summary queries.
+pub fn build_authorship_summary(conn: &Connection, repository: &str) -> Result<AuthorshipSummary> {
+    let suggestions = merge_suggestions(conn, None)?;
+    build_authorship_summary_with(conn, repository, &suggestions)
+}
+
 /// Build one repository's authorship summary from an open database.
 ///
 /// Why: the single function that reads `commits JOIN files` for this artifact
@@ -398,7 +439,7 @@ fn month_of(timestamp: &str) -> Option<String> {
 /// # Errors
 ///
 /// Propagates [`crate::core::errors::TgaError::DbError`] from either query.
-pub fn build_authorship_summary(
+pub fn build_authorship_summary_with(
     conn: &Connection,
     repository: &str,
     suggestions: &[Suggestion],

--- a/crates/trusty-git-analytics/src/report/authorship.rs
+++ b/crates/trusty-git-analytics/src/report/authorship.rs
@@ -25,10 +25,15 @@
 //!   (`collect::identity::IdentityResolver`, which populates
 //!   `commits.author_id → authors.canonical_email`), so one person committing
 //!   under several names or emails collapses to one author. A commit the
-//!   resolver never linked (`author_id IS NULL`) falls back to its raw commit
-//!   email, so its aliases stay split — [`AuthorshipSummary::unresolved_authors`]
-//!   counts exactly those identities, which is the honesty gate issue #5453
-//!   asked for.
+//!   resolver never linked (`author_id IS NULL`) is then routed through the
+//!   CONFIRMED merges recorded in `authors.aliases` (#6142), so a merge an
+//!   operator accepted applies to every figure here without a separate manual
+//!   step. What stays split is an identity that is neither resolved nor
+//!   merged — [`AuthorshipSummary::unresolved_authors`] counts exactly those,
+//!   which is the honesty gate issue #5453 asked for. An identity that a
+//!   HIGH-confidence suggestion would merge, but nobody has confirmed, is
+//!   never merged silently; it raises
+//!   [`AuthorshipSummary::identity_merge_risk`] instead (#6142).
 //! - **Squash-merge attribution, vendored-path exclusion** — NOT handled (each
 //!   needs, respectively: nothing extra for GitHub squash since
 //!   `commits.author_name`/`author_email` already read the PR author verbatim,
@@ -44,11 +49,12 @@
 //! [`AuthorshipSummary::to_json`].
 //! Test: `super::authorship_tests`.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 
 use rusqlite::{params, Connection};
 use serde::Serialize;
 
+use crate::collect::identity::suggest::{detect_from_authors, HIGH_CONFIDENCE_CUTOFF};
 use crate::core::errors::Result;
 
 /// Schema tag written into the artifact — pairs with trusty-review's
@@ -96,10 +102,61 @@ pub struct AuthorshipSummary {
     /// the resolver.
     /// Test: `super::authorship_tests::unresolved_authors_are_counted_and_caveated`.
     pub unresolved_authors: u64,
+    /// Set when unconfirmed high-confidence alias suggestions touch the
+    /// authors that determine this repository's concentration figures (#6142).
+    ///
+    /// Why: a confirmed merge is applied before the figures are computed, but
+    /// a merge nobody has accepted yet is not — and silently auto-merging a
+    /// suggestion would invent an identity the operator never approved. The
+    /// flag is how the figures stay honest without that: it names the metrics
+    /// at risk, the number of identities involved, and the command that
+    /// resolves them.
+    /// Test: `super::authorship_tests::suggested_but_unmerged_identity_raises_a_risk_flag`.
+    pub identity_merge_risk: Option<IdentityMergeRisk>,
     /// Data-trap limitations this run did NOT correct for (issue #5453) —
     /// rendered verbatim by the report section's caption.
     pub caveats: Vec<String>,
 }
+
+/// The risk flag a report carries when suggested-but-unmerged identities
+/// touch its concentration metrics (#6142).
+///
+/// Why: bus factor and top-author share are the two figures a split identity
+/// distorts, and both distort in the same direction — they read LOWER than
+/// reality. A reader needs to know which figures are affected, by how many
+/// identities, and what to run.
+/// What: the count of distinct suggested-but-unmerged source identities
+/// touching the top-N authors, the names of the metrics they affect, and the
+/// resolving command.
+/// Test: `super::authorship_tests::suggested_but_unmerged_identity_raises_a_risk_flag`.
+#[derive(Debug, Clone, Default, PartialEq, Serialize)]
+#[non_exhaustive]
+pub struct IdentityMergeRisk {
+    /// Distinct identities suggested for merge, at or above
+    /// [`crate::collect::identity::suggest::HIGH_CONFIDENCE_CUTOFF`], that no
+    /// operator has confirmed and that touch a top-N author.
+    pub suggested_unmerged: u64,
+    /// Field names of the affected metrics on [`AuthorshipSummary`].
+    pub affected_metrics: Vec<String>,
+    /// The command that lists the suggestions so an operator can confirm them.
+    pub resolve_command: String,
+}
+
+/// How many of the ranked authors count as "top-N" for the risk flag (#6142).
+///
+/// Why: bus factor and top-author share are determined by the head of the
+/// ranked list, so a suggestion touching a long-tail author cannot move
+/// either figure enough to warrant a flag. Ten is generous relative to the
+/// bus-factor cohort a real repository produces, which keeps the flag from
+/// under-reporting.
+/// Test: `super::authorship_tests::a_long_tail_suggestion_does_not_flag`.
+const TOP_N_AUTHORS: usize = 10;
+
+/// The metric fields a split identity distorts, named in the risk flag.
+const RISK_AFFECTED_METRICS: &[&str] = &["bus_factor", "top_author_share_pct"];
+
+/// The command a reader runs to resolve the flagged suggestions.
+const RISK_RESOLVE_COMMAND: &str = "tga aliases suggest";
 
 /// One month's active-author/commit-volume figures.
 #[derive(Debug, Clone, Default, PartialEq, Serialize)]
@@ -141,6 +198,117 @@ fn unresolved_caveat(count: u64) -> String {
          author, so their aliases stay split — concentration and bus factor read LOWER than \
          reality by that much."
     )
+}
+
+/// The caveat naming the suggested-but-unmerged identities (#6142).
+///
+/// Why: the structured [`IdentityMergeRisk`] is what a machine reads; a
+/// renderer that only prints [`AuthorshipSummary::caveats`] would otherwise
+/// drop the flag entirely.
+fn suggested_merge_caveat(risk: &IdentityMergeRisk) -> String {
+    format!(
+        "{count} identity/identities are suggested for merge but not confirmed, and they touch \
+         the authors behind {metrics} — both read LOWER than reality until the merges are \
+         accepted. Run `{command}` to review them; nothing is merged automatically.",
+        count = risk.suggested_unmerged,
+        metrics = risk.affected_metrics.join(" and "),
+        command = risk.resolve_command,
+    )
+}
+
+/// Map every CONFIRMED alias to the canonical email that owns it (#6142).
+///
+/// Why: `tga aliases merge` records an accepted merge two ways — it reassigns
+/// `commits.author_id` for the commits present at merge time, and it appends
+/// the source email to the destination's `authors.aliases`. Only the second
+/// survives a later collect that re-observes the source email on new commits
+/// the resolver does not link, so a report reading `author_id` alone lets a
+/// confirmed merge silently come apart. Reading the alias list closes that.
+/// What: one lowercased `alias → canonical_email` entry per element of every
+/// row's `aliases` JSON array. Malformed JSON yields no entries for that row
+/// rather than failing the report. Suggestions are never in this map — only
+/// merges an operator accepted.
+/// Test: `super::authorship_tests::confirmed_alias_merge_collapses_the_authorship_metric`.
+///
+/// # Errors
+///
+/// Propagates [`crate::core::errors::TgaError::DbError`].
+fn confirmed_alias_map(conn: &Connection) -> Result<HashMap<String, String>> {
+    let mut stmt = conn.prepare("SELECT canonical_email, aliases FROM authors")?;
+    let rows = stmt.query_map([], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, Option<String>>(1)?.unwrap_or_default(),
+        ))
+    })?;
+
+    let mut map: HashMap<String, String> = HashMap::new();
+    for row in rows {
+        let (canonical, aliases_json) = row?;
+        if canonical.is_empty() {
+            continue;
+        }
+        let aliases: Vec<String> = serde_json::from_str(&aliases_json).unwrap_or_default();
+        for alias in aliases {
+            let key = alias.to_lowercase();
+            if key.is_empty() || key == canonical.to_lowercase() {
+                continue;
+            }
+            map.insert(key, canonical.clone());
+        }
+    }
+    Ok(map)
+}
+
+/// The risk flag for suggested-but-unmerged identities touching `ranked`.
+///
+/// Why (#6142): only a suggestion that would move `ranked`'s head can move
+/// bus factor or top-author share, so a flag naming every suggestion in the
+/// database would be noise a reader learns to skip.
+/// What: runs the author-table suggestion passes at
+/// [`HIGH_CONFIDENCE_CUTOFF`], keeps the pairs with either endpoint among the
+/// first [`TOP_N_AUTHORS`] ranked authors, and counts the distinct source
+/// identities. Returns `None` when that count is zero.
+/// Test: `super::authorship_tests::{suggested_but_unmerged_identity_raises_a_risk_flag,
+/// a_long_tail_suggestion_does_not_flag}`.
+///
+/// # Errors
+///
+/// Propagates [`crate::core::errors::TgaError::DbError`].
+fn identity_merge_risk(
+    conn: &Connection,
+    ranked: &[(&String, &u64)],
+) -> Result<Option<IdentityMergeRisk>> {
+    let top: std::collections::BTreeSet<String> = ranked
+        .iter()
+        .take(TOP_N_AUTHORS)
+        .map(|(email, _)| email.to_lowercase())
+        .collect();
+    if top.is_empty() {
+        return Ok(None);
+    }
+
+    // The commit-SHA pass is deliberately excluded: it scans every row of
+    // `commits`, which a report cannot afford on a large extract database.
+    let suggestions = detect_from_authors(conn, None, HIGH_CONFIDENCE_CUTOFF)?;
+
+    let touching: std::collections::BTreeSet<String> = suggestions
+        .into_iter()
+        .filter(|s| top.contains(&s.src.to_lowercase()) || top.contains(&s.dst.to_lowercase()))
+        .map(|s| s.src.to_lowercase())
+        .collect();
+
+    if touching.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(IdentityMergeRisk {
+        suggested_unmerged: touching.len() as u64,
+        affected_metrics: RISK_AFFECTED_METRICS
+            .iter()
+            .map(|s| s.to_string())
+            .collect(),
+        resolve_command: RISK_RESOLVE_COMMAND.to_string(),
+    }))
 }
 
 /// Name/email substrings identifying a machine-authored commit (issue #5453).
@@ -204,6 +372,9 @@ fn month_of(timestamp: &str) -> Option<String> {
 ///
 /// Propagates [`crate::core::errors::TgaError::DbError`] from either query.
 pub fn build_authorship_summary(conn: &Connection, repository: &str) -> Result<AuthorshipSummary> {
+    // #6142: confirmed merges are applied before any figure is computed;
+    // unconfirmed suggestions never are — they only raise the risk flag below.
+    let alias_map = confirmed_alias_map(conn)?;
     let mut stmt = conn.prepare(
         "SELECT c.id, c.author_name, c.author_email, a.canonical_email, c.timestamp, f.path \
          FROM commits c \
@@ -241,14 +412,20 @@ pub fn build_authorship_summary(conn: &Connection, repository: &str) -> Result<A
         } else {
             email.clone()
         };
-        // The resolver's canonical email wins; an unlinked commit falls back to
-        // its raw identity and is counted as an honesty caveat (#5453).
+        // The resolver's canonical email wins. An unlinked commit is then
+        // routed through the CONFIRMED alias map (#6142) — a merge the
+        // operator already accepted applies here even though the resolver
+        // never linked this row. Only when both miss does the commit fall
+        // back to its raw identity and count as an honesty caveat (#5453).
         let author_key = match canonical_email.filter(|e| !e.is_empty()) {
             Some(canonical) => canonical,
-            None => {
-                unresolved.insert(raw_key.clone());
-                raw_key
-            }
+            None => match alias_map.get(&raw_key.to_lowercase()) {
+                Some(canonical) => canonical.clone(),
+                None => {
+                    unresolved.insert(raw_key.clone());
+                    raw_key
+                }
+            },
         };
         *touches_by_author.entry(author_key.clone()).or_insert(0) += 1;
         authors_by_subsystem
@@ -302,6 +479,12 @@ pub fn build_authorship_summary(conn: &Connection, repository: &str) -> Result<A
         caveats.push(unresolved_caveat(unresolved_authors));
     }
 
+    // #6142: the flag sits beside the metrics it names, and never merges.
+    let merge_risk = identity_merge_risk(conn, &ranked)?;
+    if let Some(risk) = &merge_risk {
+        caveats.push(suggested_merge_caveat(risk));
+    }
+
     Ok(AuthorshipSummary {
         schema_version: AUTHORSHIP_SCHEMA_VERSION.to_string(),
         repository: repository.to_string(),
@@ -311,6 +494,7 @@ pub fn build_authorship_summary(conn: &Connection, repository: &str) -> Result<A
         single_author_subsystems,
         monthly_trajectory,
         unresolved_authors,
+        identity_merge_risk: merge_risk,
         caveats,
     })
 }

--- a/crates/trusty-git-analytics/src/report/authorship.rs
+++ b/crates/trusty-git-analytics/src/report/authorship.rs
@@ -54,7 +54,7 @@ use std::collections::{BTreeMap, HashMap};
 use rusqlite::{params, Connection};
 use serde::Serialize;
 
-use crate::collect::identity::suggest::{detect_from_authors, HIGH_CONFIDENCE_CUTOFF};
+use crate::collect::identity::suggest::{detect_from_authors, Suggestion, HIGH_CONFIDENCE_CUTOFF};
 use crate::core::errors::Result;
 
 /// Schema tag written into the artifact — pairs with trusty-review's
@@ -260,55 +260,77 @@ fn confirmed_alias_map(conn: &Connection) -> Result<HashMap<String, String>> {
     Ok(map)
 }
 
+/// Every high-confidence merge suggestion the `authors` table alone supports.
+///
+/// Why (#6142 review): the suggestion scan cross-joins every distinct email
+/// against every other to compute Levenshtein distances, so it costs O(n²) in
+/// identities. `build_authorship_summary` runs once per REPOSITORY but the
+/// `authors` table is shared across all of them, so calling it inside the
+/// summary paid that cost once per repository for an identical answer. The
+/// caller runs this once per audit and passes the result to every repository.
+/// What: the author-table passes at [`HIGH_CONFIDENCE_CUTOFF`]. The commit-SHA
+/// pass is deliberately excluded — it scans every row of `commits`, which a
+/// report cannot afford on a large extract database. `canonical_domain`
+/// enables the `.local` / GitHub-noreply / domain-typo signals; passing `None`
+/// mutes exactly the signals issue #6142 names, so a caller with a configured
+/// domain must thread it through.
+/// Test: `super::authorship_tests::the_configured_domain_reaches_the_risk_flag`.
+///
+/// # Errors
+///
+/// Propagates [`crate::core::errors::TgaError::DbError`].
+pub fn merge_suggestions(
+    conn: &Connection,
+    canonical_domain: Option<&str>,
+) -> Result<Vec<Suggestion>> {
+    detect_from_authors(conn, canonical_domain, HIGH_CONFIDENCE_CUTOFF)
+}
+
 /// The risk flag for suggested-but-unmerged identities touching `ranked`.
 ///
 /// Why (#6142): only a suggestion that would move `ranked`'s head can move
 /// bus factor or top-author share, so a flag naming every suggestion in the
 /// database would be noise a reader learns to skip.
-/// What: runs the author-table suggestion passes at
-/// [`HIGH_CONFIDENCE_CUTOFF`], keeps the pairs with either endpoint among the
-/// first [`TOP_N_AUTHORS`] ranked authors, and counts the distinct source
+/// What: keeps the [`merge_suggestions`] pairs with either endpoint among the
+/// first [`TOP_N_AUTHORS`] ranked authors, drops any whose source is already a
+/// confirmed alias of its destination, and counts the distinct source
 /// identities. Returns `None` when that count is zero.
 /// Test: `super::authorship_tests::{suggested_but_unmerged_identity_raises_a_risk_flag,
 /// a_long_tail_suggestion_does_not_flag}`.
-///
-/// # Errors
-///
-/// Propagates [`crate::core::errors::TgaError::DbError`].
 fn identity_merge_risk(
-    conn: &Connection,
+    suggestions: &[Suggestion],
+    alias_map: &HashMap<String, String>,
     ranked: &[(&String, &u64)],
-) -> Result<Option<IdentityMergeRisk>> {
+) -> Option<IdentityMergeRisk> {
     let top: std::collections::BTreeSet<String> = ranked
         .iter()
         .take(TOP_N_AUTHORS)
         .map(|(email, _)| email.to_lowercase())
         .collect();
     if top.is_empty() {
-        return Ok(None);
+        return None;
     }
 
-    // The commit-SHA pass is deliberately excluded: it scans every row of
-    // `commits`, which a report cannot afford on a large extract database.
-    let suggestions = detect_from_authors(conn, None, HIGH_CONFIDENCE_CUTOFF)?;
-
     let touching: std::collections::BTreeSet<String> = suggestions
-        .into_iter()
+        .iter()
+        // A pair the operator already merged is not "unmerged", however the
+        // detector still scores it (#6142 review).
+        .filter(|s| !alias_map.contains_key(&s.src.to_lowercase()))
         .filter(|s| top.contains(&s.src.to_lowercase()) || top.contains(&s.dst.to_lowercase()))
         .map(|s| s.src.to_lowercase())
         .collect();
 
     if touching.is_empty() {
-        return Ok(None);
+        return None;
     }
-    Ok(Some(IdentityMergeRisk {
+    Some(IdentityMergeRisk {
         suggested_unmerged: touching.len() as u64,
         affected_metrics: RISK_AFFECTED_METRICS
             .iter()
             .map(|s| s.to_string())
             .collect(),
         resolve_command: RISK_RESOLVE_COMMAND.to_string(),
-    }))
+    })
 }
 
 /// Name/email substrings identifying a machine-authored commit (issue #5453).
@@ -363,6 +385,11 @@ fn month_of(timestamp: &str) -> Option<String> {
 /// reusing it rather than re-grouping raw commit emails). A commit the resolver
 /// never linked keeps its raw email as the key and is counted into
 /// [`AuthorshipSummary::unresolved_authors`].
+/// `suggestions` comes from [`merge_suggestions`] and is supplied by the
+/// caller rather than computed here: the scan is O(n²) in identities and the
+/// `authors` table is shared across every repository in one database, so
+/// computing it per repository paid that cost repeatedly for one answer
+/// (#6142 review).
 /// Test: `super::authorship_tests::{builds_from_seeded_commits,
 /// bots_and_merges_are_excluded, single_author_subsystem_detected,
 /// aliases_collapse_through_the_identity_resolver,
@@ -371,7 +398,11 @@ fn month_of(timestamp: &str) -> Option<String> {
 /// # Errors
 ///
 /// Propagates [`crate::core::errors::TgaError::DbError`] from either query.
-pub fn build_authorship_summary(conn: &Connection, repository: &str) -> Result<AuthorshipSummary> {
+pub fn build_authorship_summary(
+    conn: &Connection,
+    repository: &str,
+    suggestions: &[Suggestion],
+) -> Result<AuthorshipSummary> {
     // #6142: confirmed merges are applied before any figure is computed;
     // unconfirmed suggestions never are — they only raise the risk flag below.
     let alias_map = confirmed_alias_map(conn)?;
@@ -412,13 +443,22 @@ pub fn build_authorship_summary(conn: &Connection, repository: &str) -> Result<A
         } else {
             email.clone()
         };
-        // The resolver's canonical email wins. An unlinked commit is then
-        // routed through the CONFIRMED alias map (#6142) — a merge the
-        // operator already accepted applies here even though the resolver
-        // never linked this row. Only when both miss does the commit fall
-        // back to its raw identity and count as an honesty caveat (#5453).
-        let author_key = match canonical_email.filter(|e| !e.is_empty()) {
-            Some(canonical) => canonical,
+        // A CONFIRMED merge (#6142) outranks the resolver on both paths.
+        //
+        // The resolver's answer is routed through the alias map too (#6142
+        // review): `upsert_observed_authors` relinks every `author_id IS NULL`
+        // commit on each collect, and a commit re-observed under a merged-away
+        // email gets a freshly created row for that email — so the resolver
+        // answers with the SOURCE address the merge deleted, and reading it
+        // uncritically lets the merge come apart. An unlinked commit is routed
+        // through the same map on its raw email. Only when both miss does the
+        // commit keep its raw identity and count as an honesty caveat (#5453).
+        let resolved = canonical_email.filter(|e| !e.is_empty());
+        let author_key = match resolved {
+            Some(canonical) => match alias_map.get(&canonical.to_lowercase()) {
+                Some(merged) => merged.clone(),
+                None => canonical,
+            },
             None => match alias_map.get(&raw_key.to_lowercase()) {
                 Some(canonical) => canonical.clone(),
                 None => {
@@ -480,7 +520,7 @@ pub fn build_authorship_summary(conn: &Connection, repository: &str) -> Result<A
     }
 
     // #6142: the flag sits beside the metrics it names, and never merges.
-    let merge_risk = identity_merge_risk(conn, &ranked)?;
+    let merge_risk = identity_merge_risk(suggestions, &alias_map, &ranked);
     if let Some(risk) = &merge_risk {
         caveats.push(suggested_merge_caveat(risk));
     }

--- a/crates/trusty-git-analytics/src/report/authorship_tests.rs
+++ b/crates/trusty-git-analytics/src/report/authorship_tests.rs
@@ -3,8 +3,9 @@
 use rusqlite::params;
 
 use super::{
-    build_authorship_summary, merge_suggestions, recorded_repository_names, repository_has_commits,
-    AuthorshipSummary, AUTHORSHIP_SCHEMA_VERSION,
+    build_authorship_summary, build_authorship_summary_with, merge_suggestions,
+    recorded_repository_names, repository_has_commits, AuthorshipSummary,
+    AUTHORSHIP_SCHEMA_VERSION,
 };
 use crate::core::db::Database;
 use crate::core::errors::Result;
@@ -12,14 +13,14 @@ use crate::core::errors::Result;
 /// Build one repository's summary, scanning for merge suggestions first.
 ///
 /// Why (#6142 review): the suggestion scan moved OUT of
-/// `build_authorship_summary` — it is O(n²) in identities and the `authors`
+/// `build_authorship_summary_with` — it is O(n²) in identities and the `authors`
 /// table is shared across every repository, so the audit runs it once. This
 /// helper restores the one-call shape for tests that do not care which caller
 /// supplies the set. `None` for the domain matches an unconfigured project;
 /// `the_configured_domain_reaches_the_risk_flag` supplies a real one.
 fn summary_for(conn: &rusqlite::Connection, repository: &str) -> Result<AuthorshipSummary> {
     let suggestions = merge_suggestions(conn, None)?;
-    build_authorship_summary(conn, repository, &suggestions)
+    build_authorship_summary_with(conn, repository, &suggestions)
 }
 
 /// Insert one `authors` row — the identity resolver's output — and hand back
@@ -770,7 +771,8 @@ fn the_configured_domain_reaches_the_risk_flag() {
         "the configured domain must surface the .local identity: {with_domain:?}"
     );
 
-    let flagged = build_authorship_summary(db.connection(), "repo", &with_domain).expect("summary");
+    let flagged =
+        build_authorship_summary_with(db.connection(), "repo", &with_domain).expect("summary");
     let risk = flagged
         .identity_merge_risk
         .expect("a .local identity beside a top author must raise the flag");
@@ -837,5 +839,45 @@ fn a_long_tail_suggestion_does_not_flag() {
         summary.identity_merge_risk.is_none(),
         "a pair outside the top-N must not raise the flag, got {:?}",
         summary.identity_merge_risk
+    );
+}
+
+/// (#6142 review) The two-argument `build_authorship_summary` is the signature
+/// every caller before the suggestion set existed compiled against, so it stays
+/// callable: it scans for its own suggestions and answers identically to
+/// `build_authorship_summary_with` given that same scan.
+#[test]
+fn the_wrapper_scans_its_own_suggestions() {
+    let db = Database::open_in_memory().expect("open");
+    insert_commit(
+        &db,
+        "a1",
+        "Alice",
+        "alice@x.com",
+        "2026-01-15T00:00:00Z",
+        "repo",
+        false,
+        &["src/lib.rs"],
+    );
+    insert_commit(
+        &db,
+        "b1",
+        "Alice",
+        "alice@example.com",
+        "2026-02-15T00:00:00Z",
+        "repo",
+        false,
+        &["src/other.rs"],
+    );
+
+    let scanned = merge_suggestions(db.connection(), None).expect("scan");
+    let delegated =
+        build_authorship_summary_with(db.connection(), "repo", &scanned).expect("summary");
+    let wrapped = build_authorship_summary(db.connection(), "repo").expect("summary");
+
+    assert_eq!(
+        wrapped.to_json().expect("json"),
+        delegated.to_json().expect("json"),
+        "the wrapper must answer exactly as the delegating form does"
     );
 }

--- a/crates/trusty-git-analytics/src/report/authorship_tests.rs
+++ b/crates/trusty-git-analytics/src/report/authorship_tests.rs
@@ -3,10 +3,24 @@
 use rusqlite::params;
 
 use super::{
-    build_authorship_summary, recorded_repository_names, repository_has_commits,
-    AUTHORSHIP_SCHEMA_VERSION,
+    build_authorship_summary, merge_suggestions, recorded_repository_names, repository_has_commits,
+    AuthorshipSummary, AUTHORSHIP_SCHEMA_VERSION,
 };
 use crate::core::db::Database;
+use crate::core::errors::Result;
+
+/// Build one repository's summary, scanning for merge suggestions first.
+///
+/// Why (#6142 review): the suggestion scan moved OUT of
+/// `build_authorship_summary` — it is O(n²) in identities and the `authors`
+/// table is shared across every repository, so the audit runs it once. This
+/// helper restores the one-call shape for tests that do not care which caller
+/// supplies the set. `None` for the domain matches an unconfigured project;
+/// `the_configured_domain_reaches_the_risk_flag` supplies a real one.
+fn summary_for(conn: &rusqlite::Connection, repository: &str) -> Result<AuthorshipSummary> {
+    let suggestions = merge_suggestions(conn, None)?;
+    build_authorship_summary(conn, repository, &suggestions)
+}
 
 /// Insert one `authors` row — the identity resolver's output — and hand back
 /// its id, so a test can link commits to it exactly as `upsert_observed_authors`
@@ -96,7 +110,7 @@ fn builds_from_seeded_commits() {
         &["src/lib.rs"],
     );
 
-    let summary = build_authorship_summary(db.connection(), "repo").expect("summary");
+    let summary = summary_for(db.connection(), "repo").expect("summary");
     assert_eq!(summary.schema_version, AUTHORSHIP_SCHEMA_VERSION);
     assert_eq!(summary.repository, "repo");
     assert_eq!(summary.distinct_authors, 1);
@@ -142,7 +156,7 @@ fn bots_and_merges_are_excluded() {
         &["src/merged.rs"],
     );
 
-    let summary = build_authorship_summary(db.connection(), "repo").expect("summary");
+    let summary = summary_for(db.connection(), "repo").expect("summary");
     assert_eq!(summary.distinct_authors, 1, "bot and merge author excluded");
     assert_eq!(summary.single_author_subsystems, vec!["src".to_string()]);
 }
@@ -173,7 +187,7 @@ fn shared_subsystem_is_not_single_author() {
         &["src/other.rs"],
     );
 
-    let summary = build_authorship_summary(db.connection(), "repo").expect("summary");
+    let summary = summary_for(db.connection(), "repo").expect("summary");
     assert_eq!(summary.distinct_authors, 2);
     assert!(summary.single_author_subsystems.is_empty());
     assert_eq!(summary.bus_factor, 1); // 50%-of-touches threshold, 1 of 2 needed
@@ -184,7 +198,7 @@ fn shared_subsystem_is_not_single_author() {
 #[test]
 fn empty_repository_yields_zeroed_summary() {
     let db = Database::open_in_memory().expect("open");
-    let summary = build_authorship_summary(db.connection(), "nonexistent").expect("summary");
+    let summary = summary_for(db.connection(), "nonexistent").expect("summary");
     assert_eq!(summary.distinct_authors, 0);
     assert_eq!(summary.bus_factor, 0);
     assert!(summary.monthly_trajectory.is_empty());
@@ -212,7 +226,7 @@ fn trajectory_caps_at_twelve_months() {
             &["src/lib.rs"],
         );
     }
-    let summary = build_authorship_summary(db.connection(), "repo").expect("summary");
+    let summary = summary_for(db.connection(), "repo").expect("summary");
     assert_eq!(summary.monthly_trajectory.len(), 12);
     // Oldest-first, and only the most recent 12 survive — 2024-11/12 dropped.
     assert_eq!(summary.monthly_trajectory.first().unwrap().month, "2025-01");
@@ -247,7 +261,7 @@ fn commits_count_commits_not_file_touches() {
         &["src/e.rs", "src/f.rs", "docs/g.md"],
     );
 
-    let summary = build_authorship_summary(db.connection(), "repo").expect("summary");
+    let summary = summary_for(db.connection(), "repo").expect("summary");
     assert_eq!(summary.monthly_trajectory.len(), 1);
     let january = &summary.monthly_trajectory[0];
     assert_eq!(january.month, "2026-01");
@@ -287,7 +301,7 @@ fn aliases_collapse_through_the_identity_resolver() {
         link_commit(&db, sha, alice);
     }
 
-    let summary = build_authorship_summary(db.connection(), "repo").expect("summary");
+    let summary = summary_for(db.connection(), "repo").expect("summary");
     assert_eq!(
         summary.distinct_authors, 1,
         "both aliases resolve to one canonical author"
@@ -339,7 +353,7 @@ fn unresolved_authors_are_counted_and_caveated() {
         &["src/other.rs"],
     );
 
-    let summary = build_authorship_summary(db.connection(), "repo").expect("summary");
+    let summary = summary_for(db.connection(), "repo").expect("summary");
     assert_eq!(summary.distinct_authors, 2);
     assert_eq!(
         summary.unresolved_authors, 1,
@@ -454,7 +468,7 @@ fn confirmed_alias_merge_collapses_the_authorship_metric() {
     // her true 100% ownership reads as 50%.
     let before = Database::open_in_memory().expect("open");
     seed_split_identity(&before);
-    let split = build_authorship_summary(before.connection(), "repo").expect("summary");
+    let split = summary_for(before.connection(), "repo").expect("summary");
     assert_eq!(
         split.distinct_authors, 2,
         "the unmerged corpus must still read as two authors"
@@ -470,7 +484,7 @@ fn confirmed_alias_merge_collapses_the_authorship_metric() {
     let after = Database::open_in_memory().expect("open");
     seed_split_identity(&after);
     record_confirmed_alias(&after, "alice@corp.com", "alice@personal.com");
-    let merged = build_authorship_summary(after.connection(), "repo").expect("summary");
+    let merged = summary_for(after.connection(), "repo").expect("summary");
     assert_eq!(
         merged.distinct_authors, 1,
         "a confirmed merge must collapse the two identities"
@@ -520,7 +534,7 @@ fn suggested_but_unmerged_identity_raises_a_risk_flag() {
     );
     link_commit(&db, "s2", personal);
 
-    let summary = build_authorship_summary(db.connection(), "repo").expect("summary");
+    let summary = summary_for(db.connection(), "repo").expect("summary");
 
     // The suggestion must NOT have been applied.
     assert_eq!(
@@ -584,13 +598,183 @@ fn a_confirmed_merge_clears_the_risk_flag() {
     // one `authors` row survives, so no pair remains to suggest.
     record_confirmed_alias(&db, "alice@corp.com", "alice@personal.com");
 
-    let summary = build_authorship_summary(db.connection(), "repo").expect("summary");
+    let summary = summary_for(db.connection(), "repo").expect("summary");
     assert_eq!(summary.distinct_authors, 1);
     assert!(
         summary.identity_merge_risk.is_none(),
         "a confirmed merge must clear the flag, got {:?}",
         summary.identity_merge_risk
     );
+}
+
+/// (#6142 review) A confirmed merge must survive the next collect.
+///
+/// `upsert_observed_authors` relinks every `author_id IS NULL` commit on every
+/// run, and the resolver re-creates a row for any email it does not recognise —
+/// including the one `tga aliases merge` deleted. Two things then have to hold:
+/// the resolver must route the merged-away email to the identity that absorbed
+/// it, and the report must apply the alias map to the resolver's ANSWER, not
+/// only to unlinked rows.
+#[test]
+fn a_confirmed_merge_survives_a_recollect() {
+    use crate::collect::identity::resolver::IdentityResolver;
+
+    let db = Database::open_in_memory().expect("open");
+    let corp = insert_author(&db, "Alice", "alice@corp.com");
+    insert_commit(
+        &db,
+        "s1",
+        "Alice",
+        "alice@corp.com",
+        "2026-01-15T00:00:00Z",
+        "repo",
+        false,
+        &["src/lib.rs"],
+    );
+    link_commit(&db, "s1", corp);
+    insert_commit(
+        &db,
+        "s2",
+        "Alice",
+        "alice@personal.com",
+        "2026-01-16T00:00:00Z",
+        "repo",
+        false,
+        &["src/lib.rs"],
+    );
+    link_commit(&db, "s2", corp);
+    record_confirmed_alias(&db, "alice@corp.com", "alice@personal.com");
+
+    // The next collect observes a NEW commit under the merged-away address.
+    // Nothing links it, so the resolver is asked about that address again —
+    // exactly what `upsert_observed_authors` does.
+    insert_commit(
+        &db,
+        "s3",
+        "Alice",
+        "alice@personal.com",
+        "2026-01-17T00:00:00Z",
+        "repo",
+        false,
+        &["src/lib.rs"],
+    );
+    let resolver = IdentityResolver::new(None);
+    let id = resolver
+        .upsert_author(&db, "Alice", "alice@personal.com")
+        .expect("upsert");
+    assert_eq!(
+        id, corp,
+        "the merged-away email must route to the identity that absorbed it, \
+         not to a re-created source row"
+    );
+    let rows: i64 = db
+        .connection()
+        .query_row("SELECT COUNT(*) FROM authors", [], |r| r.get(0))
+        .expect("count authors");
+    assert_eq!(rows, 1, "the deleted source row must not come back");
+    db.connection()
+        .execute(
+            "UPDATE commits SET author_id = ?1 WHERE author_id IS NULL",
+            params![id],
+        )
+        .expect("relink");
+
+    let summary = summary_for(db.connection(), "repo").expect("summary");
+    assert_eq!(
+        summary.distinct_authors, 1,
+        "a re-collect must not split a confirmed merge back apart"
+    );
+    assert_eq!(summary.top_author_share_pct.round() as i64, 100);
+    assert_eq!(summary.bus_factor, 1);
+}
+
+/// (#6142 review) The report path must apply the alias map to the RESOLVER's
+/// answer, not only to unlinked commits.
+///
+/// A database can hold both rows at once — an operator who merged, re-collected
+/// against an older tga, and is now reading a report. The alias array is the
+/// operator's decision and outranks the row the resolver points at.
+#[test]
+fn a_merged_email_collapses_even_when_its_row_was_re_created() {
+    let db = Database::open_in_memory().expect("open");
+    let corp = insert_author(&db, "Alice", "alice@corp.com");
+    // The source row the merge deleted, re-created by a later collect.
+    let personal = insert_author(&db, "Alice", "alice@personal.com");
+    record_confirmed_alias(&db, "alice@corp.com", "alice@personal.com");
+    for (sha, email, id) in [
+        ("s1", "alice@corp.com", corp),
+        ("s2", "alice@personal.com", personal),
+    ] {
+        insert_commit(
+            &db,
+            sha,
+            "Alice",
+            email,
+            "2026-01-15T00:00:00Z",
+            "repo",
+            false,
+            &["src/lib.rs"],
+        );
+        link_commit(&db, sha, id);
+    }
+
+    let summary = summary_for(db.connection(), "repo").expect("summary");
+    assert_eq!(
+        summary.distinct_authors, 1,
+        "a linked commit under a confirmed alias must still collapse"
+    );
+    assert_eq!(summary.top_author_share_pct.round() as i64, 100);
+    assert!(
+        summary.identity_merge_risk.is_none(),
+        "a pair the operator already merged is not unmerged, got {:?}",
+        summary.identity_merge_risk
+    );
+}
+
+/// (#6142) The configured canonical domain must reach the risk flag.
+///
+/// The `.local`, GitHub-noreply and domain-typo signals issue #6142 names all
+/// require it; the report used to hard-code `None` and mute every one of them.
+#[test]
+fn the_configured_domain_reaches_the_risk_flag() {
+    let db = Database::open_in_memory().expect("open");
+    // A `.local` hostname address alongside the real one. Only the noise pass
+    // pairs these, and only when it knows the canonical domain.
+    let corp = insert_author(&db, "Alice Smith", "alice@corp.com");
+    let local = insert_author(&db, "A. Smith", "alice@laptop.local");
+    for (sha, email, id) in [
+        ("s1", "alice@corp.com", corp),
+        ("s2", "alice@laptop.local", local),
+    ] {
+        insert_commit(
+            &db,
+            sha,
+            "Alice",
+            email,
+            "2026-01-15T00:00:00Z",
+            "repo",
+            false,
+            &["src/lib.rs"],
+        );
+        link_commit(&db, sha, id);
+    }
+
+    let muted = merge_suggestions(db.connection(), None).expect("scan");
+    let with_domain = merge_suggestions(db.connection(), Some("corp.com")).expect("scan");
+    assert!(
+        muted.is_empty(),
+        "without the domain the .local signal cannot fire: {muted:?}"
+    );
+    assert!(
+        with_domain.iter().any(|s| s.src == "alice@laptop.local"),
+        "the configured domain must surface the .local identity: {with_domain:?}"
+    );
+
+    let flagged = build_authorship_summary(db.connection(), "repo", &with_domain).expect("summary");
+    let risk = flagged
+        .identity_merge_risk
+        .expect("a .local identity beside a top author must raise the flag");
+    assert_eq!(risk.suggested_unmerged, 1);
 }
 
 /// (#6142) A suggestion touching only long-tail authors must not flag —
@@ -647,7 +831,7 @@ fn a_long_tail_suggestion_does_not_flag() {
     );
     link_commit(&db, "z2", z2);
 
-    let summary = build_authorship_summary(db.connection(), "repo").expect("summary");
+    let summary = summary_for(db.connection(), "repo").expect("summary");
     assert_eq!(summary.distinct_authors, 13);
     assert!(
         summary.identity_merge_risk.is_none(),

--- a/crates/trusty-git-analytics/src/report/authorship_tests.rs
+++ b/crates/trusty-git-analytics/src/report/authorship_tests.rs
@@ -395,3 +395,263 @@ fn a_name_that_matches_nothing_is_detectable() {
         "the recorded name is what the gap line points the operator at"
     );
 }
+
+/// Seed one person committing under two identities: `alice@corp.com`, which
+/// the collection pass resolved, and `alice@personal.com`, which it did not.
+///
+/// Why (#6142): this is the corpus shape the issue describes — a contributor
+/// whose personal-email commits sit under a second, unlinked identity, so
+/// every concentration figure reads lower than reality. Both halves of the
+/// fixture (before and after a confirmed merge) start here.
+fn seed_split_identity(db: &Database) -> i64 {
+    let corp = insert_author(db, "Alice", "alice@corp.com");
+    insert_commit(
+        db,
+        "c1",
+        "Alice",
+        "alice@corp.com",
+        "2026-01-15T00:00:00Z",
+        "repo",
+        false,
+        &["src/lib.rs"],
+    );
+    link_commit(db, "c1", corp);
+    insert_commit(
+        db,
+        "c2",
+        "Alice",
+        "alice@personal.com",
+        "2026-01-16T00:00:00Z",
+        "repo",
+        false,
+        &["src/lib.rs"],
+    );
+    corp
+}
+
+/// Record a confirmed merge exactly as `tga aliases merge` does: the source
+/// email is appended to the destination's `authors.aliases` JSON array.
+fn record_confirmed_alias(db: &Database, canonical_email: &str, alias: &str) {
+    let updated = db
+        .connection()
+        .execute(
+            "UPDATE authors SET aliases = ?1 WHERE canonical_email = ?2",
+            params![
+                serde_json::to_string(&vec![alias]).expect("encode aliases"),
+                canonical_email
+            ],
+        )
+        .expect("record alias");
+    assert_eq!(updated, 1, "the destination identity must exist");
+}
+
+/// (#6142) One person under two identities understates every concentration
+/// figure until the merge is confirmed — and the confirmed merge must be
+/// applied by the report itself, not left to a separate manual step.
+#[test]
+fn confirmed_alias_merge_collapses_the_authorship_metric() {
+    // Before: no confirmed merge recorded. Alice reads as two authors and
+    // her true 100% ownership reads as 50%.
+    let before = Database::open_in_memory().expect("open");
+    seed_split_identity(&before);
+    let split = build_authorship_summary(before.connection(), "repo").expect("summary");
+    assert_eq!(
+        split.distinct_authors, 2,
+        "the unmerged corpus must still read as two authors"
+    );
+    assert!(
+        (split.top_author_share_pct - 50.0).abs() < f64::EPSILON,
+        "top_author_share_pct must be understated at 50%, got {}",
+        split.top_author_share_pct
+    );
+    assert_eq!(split.unresolved_authors, 1);
+
+    // After: the same corpus with the merge confirmed in `authors.aliases`.
+    let after = Database::open_in_memory().expect("open");
+    seed_split_identity(&after);
+    record_confirmed_alias(&after, "alice@corp.com", "alice@personal.com");
+    let merged = build_authorship_summary(after.connection(), "repo").expect("summary");
+    assert_eq!(
+        merged.distinct_authors, 1,
+        "a confirmed merge must collapse the two identities"
+    );
+    assert!(
+        (merged.top_author_share_pct - 100.0).abs() < f64::EPSILON,
+        "top_author_share_pct must read 100% once merged, got {}",
+        merged.top_author_share_pct
+    );
+    assert_eq!(
+        merged.unresolved_authors, 0,
+        "an identity folded by a confirmed merge is no longer unresolved"
+    );
+}
+
+/// (#6142) A HIGH-confidence suggestion nobody has confirmed must raise the
+/// risk flag rather than being applied — and the flag must name the metrics,
+/// the count, and the command.
+#[test]
+fn suggested_but_unmerged_identity_raises_a_risk_flag() {
+    let db = Database::open_in_memory().expect("open");
+    // Two `authors` rows under one display name: the same-name signal scores
+    // this pair 0.95, well above the HIGH cutoff. Neither row records the
+    // other as a confirmed alias, so the merge is only suggested.
+    let corp = insert_author(&db, "Alice", "alice@corp.com");
+    let personal = insert_author(&db, "Alice", "alice@personal.com");
+    insert_commit(
+        &db,
+        "s1",
+        "Alice",
+        "alice@corp.com",
+        "2026-01-15T00:00:00Z",
+        "repo",
+        false,
+        &["src/lib.rs"],
+    );
+    link_commit(&db, "s1", corp);
+    insert_commit(
+        &db,
+        "s2",
+        "Alice",
+        "alice@personal.com",
+        "2026-01-16T00:00:00Z",
+        "repo",
+        false,
+        &["src/lib.rs"],
+    );
+    link_commit(&db, "s2", personal);
+
+    let summary = build_authorship_summary(db.connection(), "repo").expect("summary");
+
+    // The suggestion must NOT have been applied.
+    assert_eq!(
+        summary.distinct_authors, 2,
+        "an unconfirmed suggestion must never be auto-merged"
+    );
+
+    let risk = summary
+        .identity_merge_risk
+        .as_ref()
+        .expect("an unconfirmed HIGH-confidence pair must raise the flag");
+    assert_eq!(risk.suggested_unmerged, 1);
+    assert_eq!(
+        risk.affected_metrics,
+        vec!["bus_factor".to_string(), "top_author_share_pct".to_string()],
+        "the flag must sit next to the metrics a split identity distorts"
+    );
+    assert!(
+        risk.resolve_command.contains("tga aliases"),
+        "the flag must name the resolving command, got {}",
+        risk.resolve_command
+    );
+    assert!(
+        summary
+            .caveats
+            .iter()
+            .any(|c| c.contains("suggested for merge")),
+        "a caveat-only renderer must still see the flag: {:?}",
+        summary.caveats
+    );
+}
+
+/// (#6142) Confirming the merge clears the flag — the report must not keep
+/// warning about work the operator already did.
+#[test]
+fn a_confirmed_merge_clears_the_risk_flag() {
+    let db = Database::open_in_memory().expect("open");
+    let corp = insert_author(&db, "Alice", "alice@corp.com");
+    insert_commit(
+        &db,
+        "s1",
+        "Alice",
+        "alice@corp.com",
+        "2026-01-15T00:00:00Z",
+        "repo",
+        false,
+        &["src/lib.rs"],
+    );
+    link_commit(&db, "s1", corp);
+    insert_commit(
+        &db,
+        "s2",
+        "Alice",
+        "alice@personal.com",
+        "2026-01-16T00:00:00Z",
+        "repo",
+        false,
+        &["src/lib.rs"],
+    );
+    // `tga aliases merge` deletes the source row and records the alias; only
+    // one `authors` row survives, so no pair remains to suggest.
+    record_confirmed_alias(&db, "alice@corp.com", "alice@personal.com");
+
+    let summary = build_authorship_summary(db.connection(), "repo").expect("summary");
+    assert_eq!(summary.distinct_authors, 1);
+    assert!(
+        summary.identity_merge_risk.is_none(),
+        "a confirmed merge must clear the flag, got {:?}",
+        summary.identity_merge_risk
+    );
+}
+
+/// (#6142) A suggestion touching only long-tail authors must not flag —
+/// it cannot move bus factor or top-author share enough to matter.
+#[test]
+fn a_long_tail_suggestion_does_not_flag() {
+    let db = Database::open_in_memory().expect("open");
+    // Eleven top authors with two touches each, then a pair sharing a display
+    // name with one touch each. Ranking is by touch count, so the suggested
+    // pair sits outside the first ten. The names are mutually far apart in
+    // edit distance so no signal other than the intended one fires.
+    const TAIL_FIXTURE_NAMES: &[&str] = &[
+        "alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf", "hotel", "india",
+        "juliet", "kilo",
+    ];
+    for name in TAIL_FIXTURE_NAMES {
+        let email = format!("{name}@corp.com");
+        let id = insert_author(&db, name, &email);
+        let sha = format!("t-{name}");
+        insert_commit(
+            &db,
+            &sha,
+            name,
+            &email,
+            "2026-01-15T00:00:00Z",
+            "repo",
+            false,
+            &["src/lib.rs", "src/other.rs"],
+        );
+        link_commit(&db, &sha, id);
+    }
+    let z1 = insert_author(&db, "Zed", "zed@corp.com");
+    let z2 = insert_author(&db, "Zed", "zed@personal.com");
+    insert_commit(
+        &db,
+        "z1",
+        "Zed",
+        "zed@corp.com",
+        "2026-01-15T00:00:00Z",
+        "repo",
+        false,
+        &["src/lib.rs"],
+    );
+    link_commit(&db, "z1", z1);
+    insert_commit(
+        &db,
+        "z2",
+        "Zed",
+        "zed@personal.com",
+        "2026-01-16T00:00:00Z",
+        "repo",
+        false,
+        &["src/lib.rs"],
+    );
+    link_commit(&db, "z2", z2);
+
+    let summary = build_authorship_summary(db.connection(), "repo").expect("summary");
+    assert_eq!(summary.distinct_authors, 13);
+    assert!(
+        summary.identity_merge_risk.is_none(),
+        "a pair outside the top-N must not raise the flag, got {:?}",
+        summary.identity_merge_risk
+    );
+}

--- a/crates/trusty-git-analytics/src/report/mod.rs
+++ b/crates/trusty-git-analytics/src/report/mod.rs
@@ -29,8 +29,9 @@ pub mod ticketed_stats;
 pub mod ticketing;
 
 pub use authorship::{
-    build_authorship_summary, merge_suggestions, recorded_repository_names, repository_has_commits,
-    AuthorshipSummary, IdentityMergeRisk, AUTHORSHIP_SCHEMA_VERSION,
+    build_authorship_summary, build_authorship_summary_with, merge_suggestions,
+    recorded_repository_names, repository_has_commits, AuthorshipSummary, IdentityMergeRisk,
+    AUTHORSHIP_SCHEMA_VERSION,
 };
 pub use dd_manifest::{
     build_dd_manifest, repo_name, DdManifest, DdManifestError, DdManifestOptions, DdReportSection,

--- a/crates/trusty-git-analytics/src/report/mod.rs
+++ b/crates/trusty-git-analytics/src/report/mod.rs
@@ -30,7 +30,7 @@ pub mod ticketing;
 
 pub use authorship::{
     build_authorship_summary, recorded_repository_names, repository_has_commits, AuthorshipSummary,
-    AUTHORSHIP_SCHEMA_VERSION,
+    IdentityMergeRisk, AUTHORSHIP_SCHEMA_VERSION,
 };
 pub use dd_manifest::{
     build_dd_manifest, repo_name, DdManifest, DdManifestError, DdManifestOptions, DdReportSection,

--- a/crates/trusty-git-analytics/src/report/mod.rs
+++ b/crates/trusty-git-analytics/src/report/mod.rs
@@ -29,8 +29,8 @@ pub mod ticketed_stats;
 pub mod ticketing;
 
 pub use authorship::{
-    build_authorship_summary, recorded_repository_names, repository_has_commits, AuthorshipSummary,
-    IdentityMergeRisk, AUTHORSHIP_SCHEMA_VERSION,
+    build_authorship_summary, merge_suggestions, recorded_repository_names, repository_has_commits,
+    AuthorshipSummary, IdentityMergeRisk, AUTHORSHIP_SCHEMA_VERSION,
 };
 pub use dd_manifest::{
     build_dd_manifest, repo_name, DdManifest, DdManifestError, DdManifestOptions, DdReportSection,


### PR DESCRIPTION
Refs #6142
Refs #6073

## Summary
- #6142: `build_authorship_summary` joined only `commits.author_id`, so a confirmed `tga aliases merge` came apart on the next collect (the resolver re-created the deleted source row) and bus factor / top-author share read low. `IdentityResolver::upsert_author` now consults `authors.aliases` (`confirmed_alias_owner`), the alias map is applied to the resolver's answer as well as unlinked rows, and `AuthorshipSummary.identity_merge_risk` names the metrics touched by suggested-but-unmerged identities (unconfirmed suggestions are never applied). Suggestion detection moved to `collect/identity/suggest.rs`, computed once per audit with the configured canonical domain; a failed scan is a named report gap. `build_authorship_summary` keeps its signature as a wrapper over `build_authorship_summary_with`.
- #6073: `collect_repo_by_week`'s unbounded arm re-walked full history every run. Schema v25 adds `repo_walk_state` (head SHA, ref, all-refs digest, walk scope, `walk_complete`); unchanged tips skip the walk, an advanced head walks incrementally, an unreachable base or changed scope (`--branch`, `head_only`, `skip_merges`) forces a full walk, `--force` restores it, an aborted revwalk surfaces as `CollectError::WalkAborted` and is never recorded complete; a pre-v25 db reads as never walked.

## Review
Two code-critic rounds: round 1 BLOCK (scope-narrowed skip, revwalk-error-marks-complete, merge lost on re-collect — all fixed with mutation-failing tests), round 2 APPROVE; its fix-here items landed in a57ea72b9. Follow-ups recorded on #6142 (alias-owner lookup consolidation) and #6073 (tag refs in the tips digest).

## Test ladder
Rung 5 (persistence: schema v25) with critic rounds.
- \`cargo fmt --check\`, \`cargo check -p tga --all-targets\`, \`cargo clippy -p tga --all-targets -- -D warnings\` — exit 0
- \`cargo test -p tga --no-fail-fast\` — 1466 passed, 0 failed, 9 ignored (pre-existing), 11 targets
- \`cargo test -p trusty-review --no-fail-fast\` — 2160 passed, 0 failed (consumer of the authorship artifact)
- Regression tests failing pre-fix: \`confirmed_alias_merge_collapses_the_authorship_metric\`, \`unchanged_head_skips_the_walk\`, \`a_scoped_walk_does_not_license_skipping_a_full_one\`, \`an_aborted_revwalk_is_not_recorded_as_a_completed_walk\`, \`a_confirmed_merge_survives_a_recollect\`, \`a_comma_in_a_branch_name_is_a_distinct_scope\`; \`advanced_head_walks_only_the_new_commits\` fails under the \`hide → None\` mutation
- \`check_line_cap.sh\` (collector.rs 710 of frozen 766), \`check_changelog_fragment.sh\`, \`check_sld.sh\`, \`check_test_pointers.sh\` — exit 0

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KsTGDrDYKBPmHmmbRsMm5w