### PR TITLE
fix(trusty-common): supervisor reports a child that died before binding; serve_until_idle drains in-flight connections on shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11860,7 +11860,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-memory"
-version = "0.25.5"
+version = "0.25.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-analyze/changelog.d/6601-drop-caller-side-router-poll.md
+++ b/crates/trusty-analyze/changelog.d/6601-drop-caller-side-router-poll.md
@@ -4,7 +4,16 @@ Changed
   poll it grew in #6595 waited for connection tasks to release the router before
   the socket unlink; `serve_until_idle` now performs that drain itself on the
   shutdown path (#6601), so keeping the caller-side loop would be two
-  implementations of one guarantee. The shutdown budget is the shared
-  `RpcServeOptions::shutdown_drain` — the process's termination grace — rather
-  than this crate's 1 s `SHUTDOWN_FLUSH_TIMEOUT`, which was too short for an
-  `analyze.review` handler that runs for minutes.
+  implementations of one guarantee.
+- `serve_options` sets `RpcServeOptions::shutdown_drain` explicitly, to this
+  crate's own `SHUTDOWN_FLUSH_TIMEOUT`. Inheriting the shared default would size
+  the drain to the process termination grace, which is not this server's
+  deadline: ADR-0032 makes it on-demand under `UdsServiceSupervisor`, whose
+  `ANALYZE_SIGTERM_PATIENCE` is 5 s, so the SIGKILL would land 5 s into a drain
+  planned for ten times that.
+- `SHUTDOWN_FLUSH_TIMEOUT` rises from 1 s to 3 s and is now an alias of
+  `trusty_common::uds::ANALYZE_SHUTDOWN_FLUSH` rather than a second literal
+  asserted equal to it. One second was the budget for an accept loop that
+  returned immediately; three is the budget for one that waits for in-flight
+  handlers, and it still leaves 2 s of the supervisor's patience for the socket
+  unlink, the redb store drop and exit.

--- a/crates/trusty-analyze/changelog.d/6601-drop-caller-side-router-poll.md
+++ b/crates/trusty-analyze/changelog.d/6601-drop-caller-side-router-poll.md
@@ -5,15 +5,18 @@ Changed
   the socket unlink; `serve_until_idle` now performs that drain itself on the
   shutdown path (#6601), so keeping the caller-side loop would be two
   implementations of one guarantee.
-- `serve_options` sets `RpcServeOptions::shutdown_drain` explicitly, to this
-  crate's own `SHUTDOWN_FLUSH_TIMEOUT`. Inheriting the shared default would size
-  the drain to the process termination grace, which is not this server's
-  deadline: ADR-0032 makes it on-demand under `UdsServiceSupervisor`, whose
-  `ANALYZE_SIGTERM_PATIENCE` is 5 s, so the SIGKILL would land 5 s into a drain
-  planned for ten times that.
+- `serve_options` inherits `RpcServeOptions::shutdown_drain` from the shared
+  default (`shutdown::plannable_grace()`). An override to this crate's 3 s
+  `SHUTDOWN_FLUSH_TIMEOUT` was reverted before release: it rested on the
+  supervisor SIGKILLing this server at `ANALYZE_SIGTERM_PATIENCE`, which no
+  supervisor path does. A bound analyze child is detached, so `ensure_running`
+  never enters it in the supervised population and no reap path reaches it;
+  `trusty-analyze stop` sends SIGTERM, polls 5 s and only reports. The 3 s drain
+  averted no SIGKILL and abandoned the #6595 guarantee — every redb handle
+  released before the socket unlink — three seconds into a multi-minute
+  `analyze.review`.
 - `SHUTDOWN_FLUSH_TIMEOUT` rises from 1 s to 3 s and is now an alias of
   `trusty_common::uds::ANALYZE_SHUTDOWN_FLUSH` rather than a second literal
-  asserted equal to it. One second was the budget for an accept loop that
-  returned immediately; three is the budget for one that waits for in-flight
-  handlers, and it still leaves 2 s of the supervisor's patience for the socket
-  unlink, the redb store drop and exit.
+  asserted equal to it. It bounds the supervisor's spawn-failure kill — the one
+  path that signals an analyze child — leaving 2 s of the 5 s patience for the
+  socket unlink, the redb store drop and exit.

--- a/crates/trusty-analyze/changelog.d/6601-drop-caller-side-router-poll.md
+++ b/crates/trusty-analyze/changelog.d/6601-drop-caller-side-router-poll.md
@@ -1,0 +1,10 @@
+Changed
+
+- `service::rpc::release_stores` is a plain drop again. The `Arc::strong_count`
+  poll it grew in #6595 waited for connection tasks to release the router before
+  the socket unlink; `serve_until_idle` now performs that drain itself on the
+  shutdown path (#6601), so keeping the caller-side loop would be two
+  implementations of one guarantee. The shutdown budget is the shared
+  `RpcServeOptions::shutdown_drain` — the process's termination grace — rather
+  than this crate's 1 s `SHUTDOWN_FLUSH_TIMEOUT`, which was too short for an
+  `analyze.review` handler that runs for minutes.

--- a/crates/trusty-analyze/src/service/rpc.rs
+++ b/crates/trusty-analyze/src/service/rpc.rs
@@ -334,13 +334,27 @@ pub fn build_router(state: AnalyzerAppState) -> RpcRouter {
 
 /// Per-connection budgets for this service.
 ///
-/// The read timeout is the shared default; only the frame budget moves. See
-/// [`MAX_FRAME_BYTES`] for why. The read bound does NOT cover a handler, which
-/// is what makes a multi-minute `analyze.diagnostics` compatible with a
-/// 30-second guard against a peer that connects and never writes.
+/// The read timeout is the shared default; the frame budget and the shutdown
+/// drain both move. See [`MAX_FRAME_BYTES`] for the first. The read bound does
+/// NOT cover a handler, which is what makes a multi-minute
+/// `analyze.diagnostics` compatible with a 30-second guard against a peer that
+/// connects and never writes.
+///
+/// 🔴 **`shutdown_drain` is set explicitly, not inherited (#6601 review).** The
+/// shared default is sized to the process's termination grace, which is the
+/// window a launchd-supervised daemon gets. This server is not one: ADR-0032
+/// makes it on-demand under `UdsServiceSupervisor`, whose
+/// `ANALYZE_SIGTERM_PATIENCE` is 5 s — so a drain inheriting a 55 s default
+/// would be SIGKILLed 5 s in, and the drain's whole purpose (release the redb
+/// handles BEFORE the socket unlink, #6595) would be defeated on exactly the
+/// path it was added for. [`SHUTDOWN_FLUSH_TIMEOUT`] is the budget this server
+/// actually has, and
+/// `serve_options_bind_the_shutdown_drain_to_this_services_own_budget` pins
+/// this field to it.
 fn serve_options() -> RpcServeOptions {
     RpcServeOptions {
         max_frame_bytes: MAX_FRAME_BYTES,
+        shutdown_drain: SHUTDOWN_FLUSH_TIMEOUT,
         ..RpcServeOptions::default()
     }
 }
@@ -378,18 +392,33 @@ fn serve_options() -> RpcServeOptions {
 /// `rpc_unlinks_its_socket_on_shutdown`.
 /// This server's own shutdown budget, as the supervisor contract requires.
 ///
-/// Why it is declared here and not only in `trusty-common`: `ServiceTimeouts`'
-/// sourcing rule says the supervisor's `shutdown_flush` must be the supervised
-/// binary's REAL budget, and `trusty-common` cannot import this crate to read
-/// it. So this is the definition, and
-/// `analyze_flush_budget_matches_the_supervisor_contract` pins
-/// `trusty_common::uds::ANALYZE_SHUTDOWN_FLUSH` against it — a drift is a test
-/// failure rather than a SIGKILL landing mid-shutdown.
+/// Why it is an ALIAS of [`trusty_common::uds::ANALYZE_SHUTDOWN_FLUSH`] rather
+/// than a second literal (#6601 review): `ServiceTimeouts`' sourcing rule says
+/// the supervisor's `shutdown_flush` must be the supervised binary's REAL
+/// budget, and `trusty-common` cannot import this crate to read it. The previous
+/// arrangement — two literals plus
+/// `analyze_flush_budget_matches_the_supervisor_contract` asserting they were
+/// equal — detected drift only after someone edited one of them. One definition
+/// makes the drift unrepresentable; that test now pins the equality this alias
+/// makes structural, and its companion binds this constant to the value the
+/// serve loop actually uses.
 ///
-/// One second is honest for this server: every handler commits its redb write
-/// before answering, so a SIGTERM discards nothing that was acked. The budget
-/// covers the accept loop returning and the socket unlink below.
-pub const SHUTDOWN_FLUSH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
+/// It is ALSO the loop's `shutdown_drain` — [`serve_options`] passes it — so
+/// this one number is what the supervisor waits for and what the server spends.
+/// Before #6601 those were two numbers: the supervisor waited 5 s while the loop
+/// inherited the shared 60 s default, and the SIGKILL landed 5 s into a drain
+/// sized for twelve times that.
+///
+/// Three seconds. Every handler commits its redb write before answering, so a
+/// SIGTERM discards nothing that was acked; what the budget buys is the #6601
+/// drain — time for connections already accepted to be answered and release
+/// their router clone, so the redb stores are closed BEFORE the unlink below
+/// tells a client to spawn a successor (#6595). Three leaves 2 s of the
+/// supervisor's 5 s patience for the unlink, the store drop and exit. An
+/// `analyze.review` handler that runs for minutes outlives it and always would:
+/// no budget under `ANALYZE_SIGTERM_PATIENCE` can cover one, and raising the
+/// patience to fit charges every supervisor reap for it.
+pub const SHUTDOWN_FLUSH_TIMEOUT: std::time::Duration = trusty_common::uds::ANALYZE_SHUTDOWN_FLUSH;
 
 pub async fn serve(state: AnalyzerAppState, socket: &Path) -> Result<()> {
     // Migration cleanup, deliberately OUTSIDE `serve_with_shutdown`: it resolves

--- a/crates/trusty-analyze/src/service/rpc.rs
+++ b/crates/trusty-analyze/src/service/rpc.rs
@@ -480,7 +480,11 @@ pub async fn serve_with_shutdown(
 /// leave corpses.
 ///
 /// The router is released BEFORE the unlink, through [`release_stores`]
-/// (#6595). The unlink is what tells a client this server is gone, and the
+/// (#6595). Since #6601 that release is a bare drop: `serve_until_idle` drains
+/// in-flight connections on the shutdown path too, so it returns only once every
+/// connection task has let go of its clone.
+///
+/// The unlink is what tells a client this server is gone, and the
 /// client's answer to that is to spawn a successor, whose first act is to open
 /// the same two redb files. redb takes an exclusive lock per file, so releasing
 /// those locks after the unlink hands the successor a `Database already open.
@@ -546,7 +550,7 @@ pub async fn serve_with_idle(
     // #6595: close the redb stores before the unlink advertises this server as
     // gone, so a successor never opens facts.redb against a lock this process
     // still holds.
-    release_stores(router, socket).await;
+    release_stores(router);
 
     if let Err(e) = std::fs::remove_file(socket) {
         tracing::debug!(socket = %socket.display(), error = %e, "socket already gone");
@@ -568,34 +572,23 @@ pub async fn serve_with_idle(
 /// unlink is what tells a client to spawn a successor, and the successor dies
 /// on `Database already open. Cannot acquire lock.`
 ///
-/// What: polls `Arc::strong_count` for up to [`SHUTDOWN_FLUSH_TIMEOUT`], whose
-/// doc already scopes it to "the accept loop returning and the socket unlink".
-/// The count only falls — nothing accepts once the loop has returned, and this
-/// function clones nothing — so reading 1 proves sole ownership rather than
-/// merely suggesting it. `Arc::into_inner` cannot be polled in its place: it
-/// consumes the `Arc` on the `None` arm, so a failed attempt cannot be retried.
+/// What: a plain drop. The WAIT this used to perform moved into
+/// `serve_until_idle` (#6601), which now drains in-flight connections on the
+/// shutdown path as it always did on the idle path — so by the time it returns,
+/// every connection task has released its clone and this one is the last. The
+/// caller-side `Arc::strong_count` poll that shipped with #6595 was the same
+/// wait done one layer too high, where only this service benefited; keeping both
+/// would be two implementations of one guarantee.
 ///
-/// A handler with no read budget — `analyze.review` runs for minutes by
-/// design — can outlast the budget. That case warns and proceeds: the process
-/// is exiting on a signal either way, and holding the path open longer trades
-/// one hazard for a socket file nobody unlinks.
+/// A handler with no read budget — `analyze.review` runs for minutes by design —
+/// can still outlast `RpcServeOptions::shutdown_drain`. That case warns inside
+/// the serve loop and proceeds: the process is exiting on a signal either way,
+/// and holding the path open longer trades one hazard for a socket file nobody
+/// unlinks. A clone outstanding at that point makes this drop a no-op, which is
+/// exactly what the old poll's timeout arm did.
 ///
 /// Test: `shutdown_with_a_connection_in_flight_frees_its_redb_lock_before_the_unlink`.
-async fn release_stores(router: Arc<RpcRouter>, socket: &Path) {
-    let deadline = std::time::Instant::now() + SHUTDOWN_FLUSH_TIMEOUT;
-    while Arc::strong_count(&router) > 1 {
-        if std::time::Instant::now() >= deadline {
-            tracing::warn!(
-                socket = %socket.display(),
-                holders = Arc::strong_count(&router),
-                "a connection task still holds the router after the flush budget; \
-                 the redb locks may outlive the socket and a successor spawned in \
-                 that window will fail to open them"
-            );
-            break;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
-    }
+fn release_stores(router: Arc<RpcRouter>) {
     drop(router);
 }
 

--- a/crates/trusty-analyze/src/service/rpc.rs
+++ b/crates/trusty-analyze/src/service/rpc.rs
@@ -334,42 +334,79 @@ pub fn build_router(state: AnalyzerAppState) -> RpcRouter {
 
 /// Per-connection budgets for this service.
 ///
-/// The read timeout is the shared default; the frame budget and the shutdown
-/// drain both move. See [`MAX_FRAME_BYTES`] for the first. The read bound does
-/// NOT cover a handler, which is what makes a multi-minute
-/// `analyze.diagnostics` compatible with a 30-second guard against a peer that
-/// connects and never writes.
+/// The read timeout and the shutdown drain are the shared defaults; only the
+/// frame budget moves. See [`MAX_FRAME_BYTES`]. The read bound does NOT cover a
+/// handler, which is what makes a multi-minute `analyze.diagnostics` compatible
+/// with a 30-second guard against a peer that connects and never writes.
 ///
-/// 🔴 **`shutdown_drain` is set explicitly, not inherited (#6601 review).** The
-/// shared default is sized to the process's termination grace, which is the
-/// window a launchd-supervised daemon gets. This server is not one: ADR-0032
-/// makes it on-demand under `UdsServiceSupervisor`, whose
-/// `ANALYZE_SIGTERM_PATIENCE` is 5 s — so a drain inheriting a 55 s default
-/// would be SIGKILLed 5 s in, and the drain's whole purpose (release the redb
-/// handles BEFORE the socket unlink, #6595) would be defeated on exactly the
-/// path it was added for. [`SHUTDOWN_FLUSH_TIMEOUT`] is the budget this server
-/// actually has, and
-/// `serve_options_bind_the_shutdown_drain_to_this_services_own_budget` pins
-/// this field to it.
+/// 🔴 **`shutdown_drain` is INHERITED, and the 3 s override this briefly
+/// carried was wrong (#6601 review).** That override rested on
+/// "`UdsServiceSupervisor` SIGKILLs this server at `ANALYZE_SIGTERM_PATIENCE`,
+/// 5 s". No supervisor path does. `ensure_running` returns early for a detached
+/// child and never enters it in `children` (`supervisor/mod.rs`, #6350), every
+/// `terminate_child` call site reads only `children` or the doomed queue, and
+/// `ANALYZE_TIMEOUTS` is built `with_detached(true)` — so the single place
+/// `sigterm_patience` reaches an analyze child is the spawn-probe timeout, a
+/// child that never bound.
+///
+/// Nothing in this repository escalates a SERVING analyze server to SIGKILL:
+/// `commands::daemon::handle_stop` sends SIGTERM, polls 5 s, and then merely
+/// REPORTS that the socket is still answering. The remaining bounded terminator
+/// is the OS at logout or shutdown, whose window this workspace models as
+/// [`trusty_common::shutdown::termination_grace`]; the part a component may
+/// plan inside is [`trusty_common::shutdown::plannable_grace`], which is what
+/// [`RpcServeOptions::default`] already supplies.
+///
+/// A 3 s drain averted no SIGKILL. It abandoned the #6595 guarantee — every
+/// redb handle released BEFORE the unlink — three seconds into a multi-minute
+/// `analyze.review`, narrowing that window rather than closing it. The drain is
+/// a MAXIMUM wait, so the larger budget costs a prompt shutdown nothing and
+/// buys a slow one the release it needs.
+/// Test: `serve_options_drain_for_as_long_as_this_server_may_actually_live`.
 fn serve_options() -> RpcServeOptions {
     RpcServeOptions {
         max_frame_bytes: MAX_FRAME_BYTES,
-        shutdown_drain: SHUTDOWN_FLUSH_TIMEOUT,
         ..RpcServeOptions::default()
     }
 }
 
+/// What this server declares to [`trusty_common::uds::on_demand::ANALYZE_TIMEOUTS`]
+/// as its own shutdown budget.
+///
+/// Why it is an ALIAS of [`trusty_common::uds::ANALYZE_SHUTDOWN_FLUSH`] rather
+/// than a second literal (#6601 review): `ServiceTimeouts`' sourcing rule says
+/// the supervisor's `shutdown_flush` must be the supervised binary's REAL
+/// budget, and `trusty-common` cannot import this crate to read it. The previous
+/// arrangement — two literals plus
+/// `analyze_flush_budget_matches_the_supervisor_contract` asserting they were
+/// equal — detected drift only after someone edited one of them. One definition
+/// makes the drift unrepresentable.
+///
+/// 🔴 **It is NOT the serve loop's drain, and binding the two was the #6601
+/// review's HIGH finding.** The relation this number participates in
+/// (`sigterm_patience > shutdown_flush`) governs the one path where the
+/// supervisor signals an analyze child: the spawn-probe timeout, a child that
+/// never bound. A child that DID bind is detached, so it is absent from the
+/// supervisor's population and no reap path can reach it — see [`serve_options`]
+/// for the walk through those call sites, and for the window the loop drains on
+/// instead.
+///
+/// Three seconds is right for what it does bound. Every handler commits its
+/// redb write before answering, so a SIGTERM discards nothing that was acked;
+/// what the child spends after SIGTERM is signal delivery, the socket unlink and
+/// exit, and 3 s leaves 2 s of the supervisor's 5 s patience for exactly that.
+pub const SHUTDOWN_FLUSH_TIMEOUT: std::time::Duration = trusty_common::uds::ANALYZE_SHUTDOWN_FLUSH;
+
 /// Bind `socket` and serve until SIGTERM/SIGINT, then unlink it.
 ///
 /// Why the bind is [`trusty_common::uds::bind_singleton_hardened`] and not
-/// [`trusty_common::uds::server::RpcServer::run`]: this daemon is supervised by
-/// launchd with `KeepAlive::Always` (`commands::service::launchd_config`). A
-/// predecessor that is SIGKILLed — which is what `launchctl kickstart -k` does
-/// at the `ExitTimeOut` boundary — never reaches the unlink below and leaves its
-/// socket file behind. `RpcServer::run` binds through `bind_hardened`, which
-/// refuses an occupied path rather than clobbering what might be a live owner,
-/// so the replacement launchd starts would fail its bind, exit, be restarted,
-/// and fail again — a crash loop with no operator-visible cause, the same shape
+/// [`trusty_common::uds::server::RpcServer::run`]: a predecessor that is
+/// SIGKILLed never reaches the unlink below and leaves its socket file behind.
+/// ADR-0032 retired this daemon's launchd unit, so the successor is whatever
+/// `OnDemandAnalyze` spawns on the next request — and `RpcServer::run` binds
+/// through `bind_hardened`, which refuses an occupied path rather than
+/// clobbering what might be a live owner. That successor would fail its bind and
+/// exit, and so would the next, with no operator-visible cause — the same shape
 /// as the #2566 port collision. `bind_singleton_hardened` probes first and takes
 /// over only a socket the kernel proves nobody is serving, so a live daemon is
 /// still never clobbered.
@@ -390,36 +427,6 @@ fn serve_options() -> RpcServeOptions {
 ///
 /// Test: `rpc_health_answers_over_a_real_socket`,
 /// `rpc_unlinks_its_socket_on_shutdown`.
-/// This server's own shutdown budget, as the supervisor contract requires.
-///
-/// Why it is an ALIAS of [`trusty_common::uds::ANALYZE_SHUTDOWN_FLUSH`] rather
-/// than a second literal (#6601 review): `ServiceTimeouts`' sourcing rule says
-/// the supervisor's `shutdown_flush` must be the supervised binary's REAL
-/// budget, and `trusty-common` cannot import this crate to read it. The previous
-/// arrangement — two literals plus
-/// `analyze_flush_budget_matches_the_supervisor_contract` asserting they were
-/// equal — detected drift only after someone edited one of them. One definition
-/// makes the drift unrepresentable; that test now pins the equality this alias
-/// makes structural, and its companion binds this constant to the value the
-/// serve loop actually uses.
-///
-/// It is ALSO the loop's `shutdown_drain` — [`serve_options`] passes it — so
-/// this one number is what the supervisor waits for and what the server spends.
-/// Before #6601 those were two numbers: the supervisor waited 5 s while the loop
-/// inherited the shared 60 s default, and the SIGKILL landed 5 s into a drain
-/// sized for twelve times that.
-///
-/// Three seconds. Every handler commits its redb write before answering, so a
-/// SIGTERM discards nothing that was acked; what the budget buys is the #6601
-/// drain — time for connections already accepted to be answered and release
-/// their router clone, so the redb stores are closed BEFORE the unlink below
-/// tells a client to spawn a successor (#6595). Three leaves 2 s of the
-/// supervisor's 5 s patience for the unlink, the store drop and exit. An
-/// `analyze.review` handler that runs for minutes outlives it and always would:
-/// no budget under `ANALYZE_SIGTERM_PATIENCE` can cover one, and raising the
-/// patience to fit charges every supervisor reap for it.
-pub const SHUTDOWN_FLUSH_TIMEOUT: std::time::Duration = trusty_common::uds::ANALYZE_SHUTDOWN_FLUSH;
-
 pub async fn serve(state: AnalyzerAppState, socket: &Path) -> Result<()> {
     // Migration cleanup, deliberately OUTSIDE `serve_with_shutdown`: it resolves
     // the real `$HOME` and the real data directory, so a test that drove it

--- a/crates/trusty-analyze/src/service/rpc_tests.rs
+++ b/crates/trusty-analyze/src/service/rpc_tests.rs
@@ -1269,29 +1269,40 @@ fn rpc_diagnostics_reports_deadline_exceeded_distinctly() {
     );
 }
 
-/// Why (#6601 review): `analyze_flush_budget_matches_the_supervisor_contract`
-/// pins two CONSTANTS against each other and neither was the value the serve
-/// loop spent — `serve_options` inherited `RpcServeOptions::default()`, so the
-/// supervisor waited 5 s while the loop drained on the process grace window.
-/// Both constants stayed equal throughout; the assertion could not see it. This
-/// is the missing link: the field the loop reads, pinned to the budget the
-/// supervisor was told about.
+/// Why (#6601 review): the first version of this test pinned the drain to
+/// `SHUTDOWN_FLUSH_TIMEOUT` and asserted it fitted inside `sigterm_patience` —
+/// a deadline that never applies to a serving analyze process. A bound analyze
+/// child is detached, so `ensure_running` never enters it in the supervisor's
+/// population and no `terminate_child` call site can reach it; `sigterm_patience`
+/// governs only a child that failed to bind. `trusty-analyze stop` sends SIGTERM
+/// and polls 5 s to REPORT, never to kill. The only bounded terminator left is
+/// the OS grace window, so that is what the drain must be sized to.
 ///
-/// What: `serve_options().shutdown_drain` must BE `SHUTDOWN_FLUSH_TIMEOUT`, and
-/// that must be strictly less than the patience the supervisor waits, or the
-/// SIGKILL lands inside the drain.
+/// What: `serve_options().shutdown_drain` must be the plannable grace — and the
+/// assertion pins the RELATION to the grace window, so an operator's
+/// `TRUSTY_TERMINATION_GRACE_SECS` moves both together instead of falsifying a
+/// hardcoded number. A 3 s drain fails the first assertion; a whole-window drain
+/// fails the second.
 /// Test: this is the test.
 #[test]
-fn serve_options_bind_the_shutdown_drain_to_this_services_own_budget() {
+fn serve_options_drain_for_as_long_as_this_server_may_actually_live() {
+    let drain = serve_options().shutdown_drain;
     assert_eq!(
-        serve_options().shutdown_drain,
-        SHUTDOWN_FLUSH_TIMEOUT,
-        "the loop must drain on this service's declared budget, not on the \
-         shared default sized to the process termination grace"
+        drain,
+        trusty_common::shutdown::plannable_grace(),
+        "the drain must be the part of the OS grace window this process may \
+         plan inside — no supervisor deadline binds a SERVING analyze child"
+    );
+    assert_eq!(
+        drain + trusty_common::shutdown::CLEANUP_RESERVE,
+        trusty_common::shutdown::termination_grace(),
+        "the drain must still leave the cleanup reserve for the socket unlink \
+         and the store drop that follow it"
     );
     assert!(
-        SHUTDOWN_FLUSH_TIMEOUT < trusty_common::uds::on_demand::ANALYZE_TIMEOUTS.sigterm_patience,
-        "the drain must finish inside the patience the supervisor actually waits"
+        drain > SHUTDOWN_FLUSH_TIMEOUT,
+        "the #6595 guarantee — redb released before the unlink — must not be \
+         abandoned at the supervisor's spawn-failure budget"
     );
 }
 
@@ -1306,7 +1317,7 @@ fn serve_options_bind_the_shutdown_drain_to_this_services_own_budget() {
 /// What closes it since #6601: `drain_shutdown` inside `serve_until_idle`. Every
 /// accepted connection holds an `IdleGuard`, and the shutdown arm waits for that
 /// count to reach zero — bounded by `RpcServeOptions::shutdown_drain`, which
-/// [`serve_options`] sets to this crate's `SHUTDOWN_FLUSH_TIMEOUT` — before it
+/// [`serve_options`] inherits from the plannable grace window — before it
 /// returns and [`release_stores`] drops the router.
 ///
 /// What forces that path deterministically: a peer that has been accepted but

--- a/crates/trusty-analyze/src/service/rpc_tests.rs
+++ b/crates/trusty-analyze/src/service/rpc_tests.rs
@@ -1269,19 +1269,50 @@ fn rpc_diagnostics_reports_deadline_exceeded_distinctly() {
     );
 }
 
-/// Why (#6595): the idle exit reaches the unlink with zero open connections —
-/// `IdleGuard` guarantees it — but the SIGTERM/SIGINT exit does not.
-/// `serve_until_idle` returns `ServeExit::Shutdown` the moment the signal
-/// future resolves, with no check on connections in flight, so a connection
-/// task still holds an `Arc<RpcRouter>` clone and with it the `FactStore`'s
-/// `Arc<Database>`. Without a wait, the unlink would run while that lock is
-/// held and hand the next `ensure_running` a successor that cannot open
-/// facts.redb — the same failure on the shutdown path that the idle path had.
+/// Why (#6601 review): `analyze_flush_budget_matches_the_supervisor_contract`
+/// pins two CONSTANTS against each other and neither was the value the serve
+/// loop spent — `serve_options` inherited `RpcServeOptions::default()`, so the
+/// supervisor waited 5 s while the loop drained on the process grace window.
+/// Both constants stayed equal throughout; the assertion could not see it. This
+/// is the missing link: the field the loop reads, pinned to the budget the
+/// supervisor was told about.
 ///
-/// What forces the arm deterministically: a peer that has been accepted but
-/// never completes its request frame parks the connection task in a read, so
-/// `Arc::into_inner` is on its `None` arm when the shutdown lands. The peer is
-/// then released, which is what the bounded wait is there to pick up.
+/// What: `serve_options().shutdown_drain` must BE `SHUTDOWN_FLUSH_TIMEOUT`, and
+/// that must be strictly less than the patience the supervisor waits, or the
+/// SIGKILL lands inside the drain.
+/// Test: this is the test.
+#[test]
+fn serve_options_bind_the_shutdown_drain_to_this_services_own_budget() {
+    assert_eq!(
+        serve_options().shutdown_drain,
+        SHUTDOWN_FLUSH_TIMEOUT,
+        "the loop must drain on this service's declared budget, not on the \
+         shared default sized to the process termination grace"
+    );
+    assert!(
+        SHUTDOWN_FLUSH_TIMEOUT < trusty_common::uds::on_demand::ANALYZE_TIMEOUTS.sigterm_patience,
+        "the drain must finish inside the patience the supervisor actually waits"
+    );
+}
+
+/// Why (#6595): the idle exit reaches the unlink with zero open connections —
+/// `IdleGuard` guarantees it — but the SIGTERM/SIGINT exit used not to.
+/// `serve_until_idle` returned `ServeExit::Shutdown` the moment the signal
+/// future resolved, with no check on connections in flight, so a connection
+/// task still held an `Arc<RpcRouter>` clone and with it the `FactStore`'s
+/// `Arc<Database>`. The unlink then ran while that lock was held and handed the
+/// next `ensure_running` a successor that could not open facts.redb.
+///
+/// What closes it since #6601: `drain_shutdown` inside `serve_until_idle`. Every
+/// accepted connection holds an `IdleGuard`, and the shutdown arm waits for that
+/// count to reach zero — bounded by `RpcServeOptions::shutdown_drain`, which
+/// [`serve_options`] sets to this crate's `SHUTDOWN_FLUSH_TIMEOUT` — before it
+/// returns and [`release_stores`] drops the router.
+///
+/// What forces that path deterministically: a peer that has been accepted but
+/// never completes its request frame parks the connection task in a read, so the
+/// guard count is above zero when the shutdown lands. The peer is then released,
+/// which is what the drain is there to pick up.
 /// Test: this is the test.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn shutdown_with_a_connection_in_flight_frees_its_redb_lock_before_the_unlink() {

--- a/crates/trusty-analyze/tests/on_demand.rs
+++ b/crates/trusty-analyze/tests/on_demand.rs
@@ -387,10 +387,13 @@ async fn two_concurrent_callers_share_one_server() {
 /// point, the drift is now unrepresentable rather than merely detected. The
 /// second is the one that still has work to do: it pins the value the SUPERVISOR
 /// was configured with, which a `ServiceTimeouts::new` call site could otherwise
-/// pass a literal to. What binds the SERVE LOOP to the same number is
-/// `serve_options_bind_the_shutdown_drain_to_this_services_own_budget`, in
-/// `rpc_tests.rs` — that link was the one missing when this test was written,
-/// and it is what let a 5 s patience sit under a 60 s drain.
+/// pass a literal to.
+///
+/// #6601 review: this budget bounds the supervisor's spawn-failure kill and
+/// nothing else — a bound analyze child is detached and no reap path reaches it.
+/// What the SERVE LOOP drains on is a different window, pinned by
+/// `serve_options_drain_for_as_long_as_this_server_may_actually_live` in
+/// `rpc_tests.rs`.
 /// Test: this is the test.
 #[test]
 fn analyze_flush_budget_matches_the_supervisor_contract() {

--- a/crates/trusty-analyze/tests/on_demand.rs
+++ b/crates/trusty-analyze/tests/on_demand.rs
@@ -381,6 +381,16 @@ async fn two_concurrent_callers_share_one_server() {
 /// import this crate to read it. This equality is what turns that rule from a
 /// comment into a check — the same shape trusty-memory's
 /// `sigterm_patience_exceeds_the_daemon_flush_budget` uses.
+///
+/// #6601 review: since `SHUTDOWN_FLUSH_TIMEOUT` became an alias of
+/// `ANALYZE_SHUTDOWN_FLUSH`, the first assertion cannot fail — which is the
+/// point, the drift is now unrepresentable rather than merely detected. The
+/// second is the one that still has work to do: it pins the value the SUPERVISOR
+/// was configured with, which a `ServiceTimeouts::new` call site could otherwise
+/// pass a literal to. What binds the SERVE LOOP to the same number is
+/// `serve_options_bind_the_shutdown_drain_to_this_services_own_budget`, in
+/// `rpc_tests.rs` — that link was the one missing when this test was written,
+/// and it is what let a 5 s patience sit under a 60 s drain.
 /// Test: this is the test.
 #[test]
 fn analyze_flush_budget_matches_the_supervisor_contract() {
@@ -389,6 +399,11 @@ fn analyze_flush_budget_matches_the_supervisor_contract() {
         trusty_analyze::service::SHUTDOWN_FLUSH_TIMEOUT,
         "the supervisor's flush budget must be this server's own, not a literal \
          that happens to match it today"
+    );
+    assert_eq!(
+        trusty_common::uds::on_demand::ANALYZE_TIMEOUTS.shutdown_flush,
+        trusty_analyze::service::SHUTDOWN_FLUSH_TIMEOUT,
+        "the timeouts handed to the supervisor must carry that same budget"
     );
 }
 

--- a/crates/trusty-common/changelog.d/6600-supervisor-observes-a-dead-child.md
+++ b/crates/trusty-common/changelog.d/6600-supervisor-observes-a-dead-child.md
@@ -26,3 +26,15 @@ Fixed
   cannot interleave mid-line.
 - A child that is alive but slow still gets the full probe window, and a
   `try_wait` that errors is treated as "still running" rather than as a death.
+- One over-cap stderr line now occupies ONE slot in the 20-line ring instead of
+  one slot per capped read (#6601 review). A child printing a real diagnosis and
+  then a megabyte of padding left `entries=20` of padding and evicted the
+  diagnosis — on the exact path this reporting exists to serve. The relay keeps
+  the capped prefix with a marker naming the dropped byte count, reads on to the
+  next newline without retaining it, and still relays every byte to stderr. A
+  line ending exactly at the cap no longer yields an empty entry, and a codepoint
+  the cap splits is dropped rather than rendered as U+FFFD.
+- `ensure_running`'s documentation now states that a detached child's
+  `ChildExited` and `SpawnTimeout` carry an EMPTY stderr tail: detached children
+  keep `Stdio::inherit()`, so there is nothing to quote. The status and the
+  one-probe-interval latency are unaffected.

--- a/crates/trusty-common/changelog.d/6600-supervisor-observes-a-dead-child.md
+++ b/crates/trusty-common/changelog.d/6600-supervisor-observes-a-dead-child.md
@@ -1,0 +1,17 @@
+Fixed
+
+- `UdsServiceSupervisor::ensure_running` now watches the child it spawned as
+  well as the socket, so a child that dies before binding is reported within one
+  poll interval instead of after the whole `ServiceTimeouts::spawn_probe` window
+  (#6600). The #6595 CI signature was a child that failed `FactStore::open` on a
+  held redb lock in ~100 ms and surfaced 20 s later as `SpawnTimeout`, whose
+  message blames the probe budget — a budget that had nothing to do with it.
+- New `SupervisorError::ChildExited` carries the child's exit status and the
+  last 20 lines it wrote to stderr. A supervised (non-detached) child's stderr is
+  piped and copied through to this process's stderr unchanged, so the operator's
+  log stream is unaffected while the tail stays quotable. A DETACHED child keeps
+  `Stdio::inherit()` and reports an empty tail: it outlives the process that
+  spawned it, and a pipe whose read end went with that process turns the child's
+  next log write into `EPIPE`.
+- A child that is alive but slow still gets the full probe window, and a
+  `try_wait` that errors is treated as "still running" rather than as a death.

--- a/crates/trusty-common/changelog.d/6600-supervisor-observes-a-dead-child.md
+++ b/crates/trusty-common/changelog.d/6600-supervisor-observes-a-dead-child.md
@@ -13,5 +13,16 @@ Fixed
   `Stdio::inherit()` and reports an empty tail: it outlives the process that
   spawned it, and a pipe whose read end went with that process turns the child's
   next log write into `EPIPE`.
+- `SupervisorError::SpawnTimeout` carries that same stderr tail. Its message
+  guesses the cause ("its spawn_probe is too small"), and a child still loading a
+  model and one spinning on a lock it will never get produce the same timeout and
+  different logs.
+- The stderr relay bounds each line at 8 KiB rather than only the line COUNT, so
+  a child that writes a megabyte before its first newline can no longer be
+  buffered and retained whole. An over-long line is passed through to stderr in
+  8 KiB pieces — no bytes are lost — and the retained tail is bounded at about
+  160 KiB per child. The relay also survives invalid UTF-8 rather than treating
+  it as EOF, and writes each line and its terminator in one call so two children
+  cannot interleave mid-line.
 - A child that is alive but slow still gets the full probe window, and a
   `try_wait` that errors is treated as "still running" rather than as a death.

--- a/crates/trusty-common/changelog.d/6601-serve-until-idle-drains-on-shutdown.md
+++ b/crates/trusty-common/changelog.d/6601-serve-until-idle-drains-on-shutdown.md
@@ -21,9 +21,17 @@ Fixed
   spent the time that flush needs. A handler that outlives the budget warns,
   naming the socket, and the loop returns anyway.
 - A service whose real SIGKILL deadline is shorter than the process grace window
-  sets `shutdown_drain` explicitly rather than inheriting the default;
-  `trusty-analyze` does, because its supervisor's `sigterm_patience` is what
-  actually applies to it.
+  may set `shutdown_drain` explicitly, but must first establish that the deadline
+  reaches the serving process. `trusty-analyze` does not qualify: it runs
+  detached, so it is absent from its supervisor's population and no reap path
+  signals it while it is serving.
+- The BM25 exit flush `trusty-memory` runs after `serve_until` is now awaited
+  under `shutdown::CLEANUP_RESERVE`. Holding the time back does not by itself
+  spend it well — `bm25_lane::shutdown` had no deadline, so a slow flush could
+  consume the whole reserve and the socket unlink after it would never run. An
+  abandoned flush is logged and costs nothing a SIGKILL would not: the snapshot
+  write is a temp-file rename, so every palace keeps what its last tick
+  published.
 - `shutdown::CLEANUP_RESERVE` and `shutdown::plannable_grace` are new, and
   `trusty-search`'s `ShutdownBudget` now subtracts through them instead of
   keeping its own copy of the same 5 s policy.

--- a/crates/trusty-common/changelog.d/6601-serve-until-idle-drains-on-shutdown.md
+++ b/crates/trusty-common/changelog.d/6601-serve-until-idle-drains-on-shutdown.md
@@ -13,7 +13,17 @@ Fixed
 - A client that dials during the drain is accepted and immediately closed, which
   reaches it as `UdsRpcError::NoResponse` rather than sitting in the kernel
   backlog until the listener drops and resets it.
-- New `RpcServeOptions::shutdown_drain` bounds that wait, defaulting to
-  `shutdown::termination_grace()` — the process's own SIGTERM-to-SIGKILL window,
-  including a `TRUSTY_TERMINATION_GRACE_SECS` override. A handler that outlives
-  it warns and the loop returns anyway.
+- New `RpcServeOptions::shutdown_drain` bounds that wait. It defaults to
+  `shutdown::plannable_grace()` — the SIGTERM-to-SIGKILL window MINUS the new
+  shared `shutdown::CLEANUP_RESERVE` — so the caller's post-serve work still has
+  a budget when the drain runs long. `trusty-memory` runs its BM25 exit flush
+  after `serve_until` returns, and a drain sized to the whole window would have
+  spent the time that flush needs. A handler that outlives the budget warns,
+  naming the socket, and the loop returns anyway.
+- A service whose real SIGKILL deadline is shorter than the process grace window
+  sets `shutdown_drain` explicitly rather than inheriting the default;
+  `trusty-analyze` does, because its supervisor's `sigterm_patience` is what
+  actually applies to it.
+- `shutdown::CLEANUP_RESERVE` and `shutdown::plannable_grace` are new, and
+  `trusty-search`'s `ShutdownBudget` now subtracts through them instead of
+  keeping its own copy of the same 5 s policy.

--- a/crates/trusty-common/changelog.d/6601-serve-until-idle-drains-on-shutdown.md
+++ b/crates/trusty-common/changelog.d/6601-serve-until-idle-drains-on-shutdown.md
@@ -1,0 +1,19 @@
+Fixed
+
+- `uds::server::serve_until_idle` now drains in-flight connections on
+  SIGTERM/SIGINT before returning `ServeExit::Shutdown` (#6601). It used to
+  return the instant the signal resolved, so the caller's socket unlink ran while
+  handlers still held their `Arc<RpcRouter>` clones — and through them whatever a
+  service's handlers own. In `trusty-analyze` that is a redb `Database`, and the
+  unlink is exactly the signal a client acts on by spawning a successor, which
+  then died on `Database already open. Cannot acquire lock.` (#6595).
+- Connections are now counted whether or not an idle policy is configured, so
+  every service behind this loop gets the guarantee rather than the one caller
+  that noticed and polled `Arc::strong_count` itself.
+- A client that dials during the drain is accepted and immediately closed, which
+  reaches it as `UdsRpcError::NoResponse` rather than sitting in the kernel
+  backlog until the listener drops and resets it.
+- New `RpcServeOptions::shutdown_drain` bounds that wait, defaulting to
+  `shutdown::termination_grace()` — the process's own SIGTERM-to-SIGKILL window,
+  including a `TRUSTY_TERMINATION_GRACE_SECS` override. A handler that outlives
+  it warns and the loop returns anyway.

--- a/crates/trusty-common/src/shutdown.rs
+++ b/crates/trusty-common/src/shutdown.rs
@@ -42,6 +42,49 @@
 /// `commands::start::reap_orphans`.
 pub const TERMINATION_GRACE_SECS: u64 = 60;
 
+/// Wall-clock time held back from the grace window for post-drain cleanup
+/// (#4393, shared since #6601).
+///
+/// Why: [`TERMINATION_GRACE_SECS`] is the window that ends in SIGKILL, so a
+/// component that spends ALL of it has left nothing for the work that runs
+/// after it. Two components run that work today. `trusty-search` flushes each
+/// index and then removes its port file, deregisters discovery and releases its
+/// lockfile. `trusty-common`'s `uds::server::serve_until_idle` drains in-flight
+/// connections and then hands control back to a caller that unlinks the socket —
+/// and in `trusty-memory` runs the BM25 exit flush AFTER `serve_until`
+/// (`transport::uds::serve_with_shutdown`), which `bm25_lane::shutdown`
+/// documents as having "no window in which a SIGKILL can land mid-flush". A
+/// drain defaulted to the whole grace window makes that claim false.
+///
+/// What: 5 s, subtracted from the grace window by every component that plans
+/// inside it. One definition rather than two, per the common-entry-point rule —
+/// `trusty-search`'s `service::shutdown_budget::CLEANUP_RESERVE` re-exports this.
+///
+/// Test: `default_serve_options_reserve_cleanup_time_inside_the_grace_window`.
+/// trusty-search's `shutdown_budget_tests.rs` covers the flush side.
+pub const CLEANUP_RESERVE: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// The part of the grace window a component may actually plan to spend.
+///
+/// Why: every caller that subtracts [`CLEANUP_RESERVE`] by hand is a place the
+/// saturation can be got wrong — a grace window shorter than the reserve must
+/// yield an immediately-exhausted budget, never a wrapped enormous one.
+/// What: [`termination_grace`] minus [`CLEANUP_RESERVE`], saturating at zero.
+/// Test: `plannable_grace_reserves_cleanup_time`,
+/// `plannable_grace_saturates_below_the_reserve`.
+pub fn plannable_grace() -> std::time::Duration {
+    plannable_grace_from(termination_grace())
+}
+
+/// Pure half of [`plannable_grace`], over an already-resolved window.
+///
+/// Why: pure so the saturation is testable without touching the process
+/// environment.
+/// Test: `plannable_grace_saturates_below_the_reserve`.
+pub fn plannable_grace_from(window: std::time::Duration) -> std::time::Duration {
+    window.saturating_sub(CLEANUP_RESERVE)
+}
+
 /// Operator override for [`TERMINATION_GRACE_SECS`].
 ///
 /// Why: a host whose launchd `ExitTimeOut` cannot be raised (a stale installed
@@ -185,6 +228,39 @@ mod tests {
             super::termination_grace_from(Some(" 12 ")),
             std::time::Duration::from_secs(12)
         );
+    }
+
+    /// Why (#6601): the grace window is the SIGKILL deadline, so a component
+    /// that plans to spend all of it leaves nothing for the work that runs
+    /// after — trusty-memory's BM25 exit flush runs after `serve_until`
+    /// returns, and trusty-search's discovery teardown after its flush sweep.
+    /// What: the plannable window is strictly smaller than the grace window by
+    /// the reserve.
+    /// Test: itself.
+    #[test]
+    fn plannable_grace_reserves_cleanup_time() {
+        let window = std::time::Duration::from_secs(60);
+        assert_eq!(
+            super::plannable_grace_from(window),
+            window - super::CLEANUP_RESERVE
+        );
+    }
+
+    /// Why (#6601): a host that declares a tiny window through
+    /// [`super::TERMINATION_GRACE_ENV`] must get an immediately-exhausted
+    /// budget, never a wrapped enormous one — the same saturation rule
+    /// `ShutdownBudget::from_window_at` records.
+    /// What: a window at or below the reserve yields zero.
+    /// Test: itself.
+    #[test]
+    fn plannable_grace_saturates_below_the_reserve() {
+        for secs in [0, 1, 5] {
+            assert_eq!(
+                super::plannable_grace_from(std::time::Duration::from_secs(secs)),
+                std::time::Duration::ZERO,
+                "a {secs}s window must not wrap below the cleanup reserve"
+            );
+        }
     }
 
     /// Why (#4393): a zero or unparseable override must never collapse the

--- a/crates/trusty-common/src/shutdown.rs
+++ b/crates/trusty-common/src/shutdown.rs
@@ -56,11 +56,21 @@ pub const TERMINATION_GRACE_SECS: u64 = 60;
 /// documents as having "no window in which a SIGKILL can land mid-flush". A
 /// drain defaulted to the whole grace window makes that claim false.
 ///
+/// 🔴 **Holding time back is not the same as spending it well (#6601 review).**
+/// This reserve bounds the drain; it cannot bound the cleanup itself, and
+/// `bm25_lane::shutdown` had no deadline of its own — a slow flush spent the
+/// reserve and the socket unlink after it never ran. So `trusty-memory`'s
+/// `transport::uds::serve_with_shutdown` now awaits that flush UNDER this
+/// duration (`flush_within_reserve`), which is what makes the sentence above
+/// true rather than aspirational. A component that adds post-drain work owes the
+/// same bound.
+///
 /// What: 5 s, subtracted from the grace window by every component that plans
 /// inside it. One definition rather than two, per the common-entry-point rule —
 /// `trusty-search`'s `service::shutdown_budget::CLEANUP_RESERVE` re-exports this.
 ///
-/// Test: `default_serve_options_reserve_cleanup_time_inside_the_grace_window`.
+/// Test: `default_serve_options_reserve_cleanup_time_inside_the_grace_window`,
+/// trusty-memory's `an_exit_flush_that_overruns_the_reserve_is_abandoned`.
 /// trusty-search's `shutdown_budget_tests.rs` covers the flush side.
 pub const CLEANUP_RESERVE: std::time::Duration = std::time::Duration::from_secs(5);
 

--- a/crates/trusty-common/src/uds/on_demand.rs
+++ b/crates/trusty-common/src/uds/on_demand.rs
@@ -85,24 +85,29 @@ pub const DEFAULT_ANALYZE_IDLE_TIMEOUT: Duration = Duration::from_secs(600);
 /// against it — the equality is checked, rather than assumed to have stayed
 /// true.
 ///
-/// Three seconds (#6601). The server holds no write buffer — `redb` commits
-/// inside each handler before it answers, so a SIGTERM discards nothing that was
-/// acked. What the budget has to cover since #6601 is the shutdown DRAIN:
-/// `serve_until_idle` waits for connections already accepted to be answered
-/// before it returns, because their handlers hold the router and through it the
-/// redb `Database` the successor must be able to open (#6595). One second was
-/// the budget for an accept loop that returned immediately; three is the budget
-/// for one that waits, and it still leaves 2 s of
-/// [`ANALYZE_SIGTERM_PATIENCE`]'s 5 s for signal delivery, the socket unlink and
-/// process exit.
+/// 🔴 **What this actually bounds, precisely (#6601 review).** It is the child's
+/// half of the `sigterm_patience > shutdown_flush` relation, and that relation
+/// governs the ONE path on which this supervisor signals an analyze child: the
+/// spawn-probe timeout in `UdsServiceSupervisor::ensure_running`. A child that
+/// BOUND is detached (see [`SupervisorConfig::with_detached`], #6350) — it is
+/// never entered in the supervisor's population, and every `terminate_child`
+/// call site reads only that population or the doomed queue — so no reap path
+/// can reach a serving analyze server, and this number says nothing about how
+/// long one lives after SIGTERM.
 ///
-/// It is deliberately NOT the process termination grace. This server is
-/// supervised by [`super::UdsServiceSupervisor`], so the deadline that actually
-/// applies to it is that supervisor's `sigterm_patience`, not launchd's window.
-/// A handler that outruns three seconds — `analyze.review` does — cannot be
-/// saved by any budget the supervisor will wait out; the drain's expiry warning
-/// is the designed outcome there, not a shortfall to paper over with a number
-/// the SIGKILL will not honour.
+/// It is therefore NOT the serve loop's shutdown drain. `trusty-analyze`'s
+/// `service::rpc::serve_options` drains on
+/// [`crate::shutdown::plannable_grace`], because the only bounded terminator of
+/// a SERVING analyze process is the OS at logout or shutdown — `trusty-analyze
+/// stop` sends SIGTERM, polls 5 s and then merely reports. Setting the drain to
+/// this budget instead gave up the #6595 guarantee three seconds into a
+/// multi-minute `analyze.review` while averting no SIGKILL at all.
+///
+/// Three seconds is right for what it does bound. The server holds no write
+/// buffer — `redb` commits inside each handler before it answers, so a SIGTERM
+/// discards nothing that was acked — and what a spawn-failure kill must leave
+/// room for is signal delivery, the socket unlink and exit. Three leaves 2 s of
+/// [`ANALYZE_SIGTERM_PATIENCE`]'s 5 s for exactly that.
 pub const ANALYZE_SHUTDOWN_FLUSH: Duration = Duration::from_secs(3);
 
 /// How long to wait for a freshly-spawned analyze server to accept.

--- a/crates/trusty-common/src/uds/on_demand.rs
+++ b/crates/trusty-common/src/uds/on_demand.rs
@@ -85,10 +85,25 @@ pub const DEFAULT_ANALYZE_IDLE_TIMEOUT: Duration = Duration::from_secs(600);
 /// against it — the equality is checked, rather than assumed to have stayed
 /// true.
 ///
-/// One second: the server holds no write buffer. `redb` commits inside each
-/// handler before it answers, so a SIGTERM at any point discards nothing that
-/// was acked; the budget covers the accept loop returning and the socket unlink.
-pub const ANALYZE_SHUTDOWN_FLUSH: Duration = Duration::from_secs(1);
+/// Three seconds (#6601). The server holds no write buffer — `redb` commits
+/// inside each handler before it answers, so a SIGTERM discards nothing that was
+/// acked. What the budget has to cover since #6601 is the shutdown DRAIN:
+/// `serve_until_idle` waits for connections already accepted to be answered
+/// before it returns, because their handlers hold the router and through it the
+/// redb `Database` the successor must be able to open (#6595). One second was
+/// the budget for an accept loop that returned immediately; three is the budget
+/// for one that waits, and it still leaves 2 s of
+/// [`ANALYZE_SIGTERM_PATIENCE`]'s 5 s for signal delivery, the socket unlink and
+/// process exit.
+///
+/// It is deliberately NOT the process termination grace. This server is
+/// supervised by [`super::UdsServiceSupervisor`], so the deadline that actually
+/// applies to it is that supervisor's `sigterm_patience`, not launchd's window.
+/// A handler that outruns three seconds — `analyze.review` does — cannot be
+/// saved by any budget the supervisor will wait out; the drain's expiry warning
+/// is the designed outcome there, not a shortfall to paper over with a number
+/// the SIGKILL will not honour.
+pub const ANALYZE_SHUTDOWN_FLUSH: Duration = Duration::from_secs(3);
 
 /// How long to wait for a freshly-spawned analyze server to accept.
 ///
@@ -99,6 +114,11 @@ pub const ANALYZE_SHUTDOWN_FLUSH: Duration = Duration::from_secs(1);
 const ANALYZE_SPAWN_PROBE: Duration = Duration::from_secs(20);
 
 /// SIGTERM-to-SIGKILL patience. Must strictly exceed [`ANALYZE_SHUTDOWN_FLUSH`].
+///
+/// The 2 s margin over the flush budget is what the child spends after its drain
+/// ends: unlinking the socket, dropping its redb stores, and exiting. Raising it
+/// costs every reap — `enforce_limits` waits this out per victim — so it is
+/// sized to that margin rather than to the process grace window.
 const ANALYZE_SIGTERM_PATIENCE: Duration = Duration::from_secs(5);
 
 /// The analyze service's timing budget.

--- a/crates/trusty-common/src/uds/server/idle.rs
+++ b/crates/trusty-common/src/uds/server/idle.rs
@@ -70,6 +70,23 @@ impl IdleTracker {
         })
     }
 
+    /// A tracker that only COUNTS open connections (#6601).
+    ///
+    /// Why: the shutdown drain in [`super::serve_until_idle`] asks exactly the
+    /// question this type already answers — "is anything in flight" — and needs
+    /// it whether or not an idle policy is configured. A second counter beside
+    /// [`IdleGuard`] would be a second thing to keep correct, and the guard is
+    /// the one accounting path every connection already goes through.
+    ///
+    /// What: [`Self::new`] with a window nothing races. `serve_until_idle` arms
+    /// its idle arm from the CALLER's tracker and never from this one, so
+    /// [`Self::expired`] is not awaited here; the year is a value that stays
+    /// inside `tokio`'s timer range if some future caller does.
+    /// Test: `shutdown_drains_an_in_flight_connection_before_it_returns`.
+    pub(super) fn counting_only() -> Arc<Self> {
+        Self::new(Duration::from_secs(365 * 24 * 60 * 60))
+    }
+
     /// The configured idle window.
     pub fn timeout(&self) -> Duration {
         self.timeout

--- a/crates/trusty-common/src/uds/server/mod.rs
+++ b/crates/trusty-common/src/uds/server/mod.rs
@@ -223,10 +223,35 @@ pub struct RpcServeOptions {
     /// `serve_rejects_an_oversized_frame`,
     /// `stream_refuses_an_item_larger_than_the_frame_budget`.
     pub max_frame_bytes: u64,
+
+    /// Longest [`serve_until_idle`] waits for in-flight connections to finish
+    /// after the shutdown signal, before it returns and the caller unlinks the
+    /// socket (#6601).
+    ///
+    /// Why a budget rather than an unbounded wait: the signal is the start of a
+    /// window that ends in SIGKILL, and a handler that never returns must not
+    /// spend it. When the budget expires the loop warns and returns anyway —
+    /// holding the socket path open longer trades one hazard for a socket file
+    /// nobody unlinks.
+    ///
+    /// Why this is NOT a per-connection read budget: [`Self::read_timeout`]
+    /// bounds how long a peer may take to DELIVER a request. This bounds how
+    /// long the loop waits for requests it already accepted to be answered, and
+    /// a service whose method runs for minutes needs the second to be large
+    /// while the first stays small.
+    ///
+    /// Defaults to [`crate::shutdown::termination_grace`] — the process-wide
+    /// SIGTERM-to-SIGKILL window, so the drain fits inside the time the daemon
+    /// actually has, including an operator's `TRUSTY_TERMINATION_GRACE_SECS`
+    /// override.
+    ///
+    /// Test: `shutdown_drains_an_in_flight_connection_before_it_returns`,
+    /// `shutdown_returns_when_the_drain_budget_expires`.
+    pub shutdown_drain: Duration,
 }
 
 impl Default for RpcServeOptions {
-    /// Thirty seconds, and [`MAX_FRAME_BYTES`].
+    /// Thirty seconds, [`MAX_FRAME_BYTES`], and the process's termination grace.
     ///
     /// The read covers a local socket writing one already-serialised frame, so
     /// thirty seconds is headroom for a stalled writer rather than a latency
@@ -235,6 +260,7 @@ impl Default for RpcServeOptions {
         Self {
             read_timeout: Duration::from_secs(30),
             max_frame_bytes: MAX_FRAME_BYTES,
+            shutdown_drain: crate::shutdown::termination_grace(),
         }
     }
 }
@@ -382,7 +408,9 @@ pub async fn serve_until(
 /// `serve_stops_on_shutdown`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ServeExit {
-    /// The caller's shutdown future resolved (SIGTERM/SIGINT, or a test).
+    /// The caller's shutdown future resolved (SIGTERM/SIGINT, or a test), and
+    /// the in-flight connections have finished or spent
+    /// [`RpcServeOptions::shutdown_drain`] (#6601).
     Shutdown,
     /// No connection answered anything for the whole idle window.
     Idle,
@@ -469,7 +497,7 @@ async fn drain_backlog(
     listener: &UnixListener,
     router: &Arc<RpcRouter>,
     options: RpcServeOptions,
-    idle: Option<&Arc<IdleTracker>>,
+    idle: &Arc<IdleTracker>,
 ) -> Drained {
     let Ok(accepted) = tokio::time::timeout(IDLE_EXIT_DRAIN, listener.accept()).await else {
         return Drained::Nothing;
@@ -481,22 +509,102 @@ async fn drain_backlog(
             return Drained::Nothing;
         }
     };
-    let mut guard = idle.map(IdleTracker::connection_opened);
+    let mut guard = IdleTracker::connection_opened(idle);
     let served = handle_connection(stream, Arc::clone(router), options).await;
     let answered = matches!(served, Ok(Served::Answered { .. }));
     if let Err(e) = &served {
         tracing::warn!(error = %e, "uds rpc connection failed during idle drain");
     }
-    if answered && let Some(g) = guard.as_mut() {
-        g.answered();
+    if answered {
+        guard.answered();
     }
-    if let Some(g) = guard {
-        g.release().await;
-    }
+    guard.release().await;
     if answered {
         Drained::Answered
     } else {
         Drained::Nothing
+    }
+}
+
+/// How often [`drain_shutdown`] re-reads the in-flight count.
+///
+/// Five milliseconds: the drain ends the moment the last handler releases its
+/// guard, so this bounds how long a clean shutdown lingers past that release.
+const DRAIN_POLL_INTERVAL: Duration = Duration::from_millis(5);
+
+/// Let in-flight connections finish before the caller unlinks the socket
+/// (#6601).
+///
+/// Why: the shutdown arm used to return the instant the signal resolved. Every
+/// accepted connection holds an `Arc<RpcRouter>` clone — and through it whatever
+/// the service's handlers own, a redb `Database` in `trusty-analyze`'s case — so
+/// returning under an open connection unlinked the socket while those handles
+/// were still live. The unlink is what tells a client to spawn a successor, and
+/// the successor then died opening a store this process had not let go of
+/// (#6595). Draining HERE gives that guarantee to every service behind this
+/// loop rather than to the one caller that noticed.
+///
+/// What, while the count is above zero and the budget has not expired:
+///   - the accept loop is over, so nothing new is served; and
+///   - a client that dials anyway is accepted and IMMEDIATELY closed, which
+///     reaches it as `UdsRpcError::NoResponse` on the next poll. Leaving it in
+///     the backlog instead would hold it open until the listener dropped and
+///     then reset it — a failure the client cannot tell from a broken service.
+///
+/// A budget that expires warns and returns: the process is exiting on a signal
+/// either way, and holding the path open longer trades one hazard for a socket
+/// file nobody unlinks.
+///
+/// Connections queued in the kernel backlog but never accepted are NOT counted —
+/// `connect(2)` succeeds before this server sees anything. Those are refused by
+/// the loop above when a drain is running, and reset by the listener drop when
+/// there was nothing to drain.
+///
+/// Test: `shutdown_drains_an_in_flight_connection_before_it_returns`,
+/// `shutdown_refuses_a_connection_dialled_after_the_signal`,
+/// `shutdown_returns_when_the_drain_budget_expires`.
+async fn drain_shutdown(listener: &UnixListener, open: &Arc<IdleTracker>, budget: Duration) {
+    if open.open_connections() == 0 {
+        return;
+    }
+    tracing::info!(
+        open = open.open_connections(),
+        ?budget,
+        "uds rpc shutdown signalled; draining in-flight connections"
+    );
+
+    let refuse = async {
+        loop {
+            match listener.accept().await {
+                Ok((stream, _)) => {
+                    tracing::debug!("refusing a connection dialled during the shutdown drain");
+                    drop(stream);
+                }
+                // Never a reason to stop refusing: the whole arm is bounded by
+                // the `select!`'s budget, and a bare `continue` on a persistent
+                // error (EMFILE, say) would spin.
+                Err(e) => {
+                    tracing::debug!(error = %e, "accept failed during the shutdown drain");
+                    tokio::time::sleep(DRAIN_POLL_INTERVAL).await;
+                }
+            }
+        }
+    };
+    let settled = async {
+        while open.open_connections() > 0 {
+            tokio::time::sleep(DRAIN_POLL_INTERVAL).await;
+        }
+    };
+
+    tokio::select! {
+        () = settled => {}
+        () = refuse => {}
+        () = tokio::time::sleep(budget) => tracing::warn!(
+            open = open.open_connections(),
+            ?budget,
+            "connections still in flight after the shutdown drain budget; \
+             unlinking anyway"
+        ),
     }
 }
 
@@ -521,10 +629,18 @@ async fn drain_backlog(
 /// queued before the window elapsed; one that appears is served like any other
 /// and the loop continues, so the exit only stands when nobody was waiting.
 ///
+/// #6601: the shutdown arm drains too. Every accepted connection is counted —
+/// with an idle policy or without one — and the signal runs [`drain_shutdown`]
+/// before [`ServeExit::Shutdown`] is returned, so the caller's unlink never
+/// lands on top of a handler that is still holding the router.
+///
 /// Test: `serve_until_idle_exits_when_the_window_elapses`,
 /// `serve_until_idle_is_reset_by_an_answered_request`,
 /// `serve_until_idle_ignores_liveness_probes`,
-/// `a_client_queued_when_the_idle_window_elapses_is_served_not_reset`.
+/// `a_client_queued_when_the_idle_window_elapses_is_served_not_reset`,
+/// `shutdown_drains_an_in_flight_connection_before_it_returns`,
+/// `shutdown_refuses_a_connection_dialled_after_the_signal`,
+/// `shutdown_returns_when_the_drain_budget_expires`.
 pub async fn serve_until_idle(
     listener: &UnixListener,
     router: Arc<RpcRouter>,
@@ -536,10 +652,21 @@ pub async fn serve_until_idle(
     let idle_expired = idle_expiry(idle.clone());
     tokio::pin!(idle_expired);
 
+    // #6601: connections are counted whether or not an idle policy exists — the
+    // shutdown drain asks the same question the idle window does.
+    let open = match &idle {
+        Some(tracker) => Arc::clone(tracker),
+        None => IdleTracker::counting_only(),
+    };
+
     loop {
         let step = tokio::select! {
             biased;
-            () = &mut shutdown => return ServeExit::Shutdown,
+            () = &mut shutdown => {
+                // #6601: in-flight handlers finish before the caller unlinks.
+                drain_shutdown(listener, &open, options.shutdown_drain).await;
+                return ServeExit::Shutdown;
+            }
             () = &mut idle_expired => Step::IdleElapsed,
             accepted = listener.accept() => Step::Accepted(accepted),
         };
@@ -553,15 +680,13 @@ pub async fn serve_until_idle(
         // forever.
         let accepted = match step {
             Step::Accepted(accepted) => accepted,
-            Step::IdleElapsed => {
-                match drain_backlog(listener, &router, options, idle.as_ref()).await {
-                    Drained::Answered => {
-                        idle_expired.set(idle_expiry(idle.clone()));
-                        continue;
-                    }
-                    Drained::Nothing => return ServeExit::Idle,
+            Step::IdleElapsed => match drain_backlog(listener, &router, options, &open).await {
+                Drained::Answered => {
+                    idle_expired.set(idle_expiry(idle.clone()));
+                    continue;
                 }
-            }
+                Drained::Nothing => return ServeExit::Idle,
+            },
         };
         let stream = match accepted {
             Ok((stream, _)) => stream,
@@ -573,7 +698,7 @@ pub async fn serve_until_idle(
         // Taken BEFORE the connection task is spawned: taking it inside would
         // leave a window in which the count is zero while a connection is
         // already accepted, and the idle future could win the race in it.
-        let guard = idle.as_ref().map(IdleTracker::connection_opened);
+        let guard = IdleTracker::connection_opened(&open);
         let router = Arc::clone(&router);
         tokio::spawn(async move {
             // #6277 review: the connection runs in an INNER task whose
@@ -586,11 +711,7 @@ pub async fn serve_until_idle(
             let inner = tokio::spawn(handle_connection(stream, router, options));
             let mut guard = guard;
             match inner.await {
-                Ok(Ok(Served::Answered { .. })) => {
-                    if let Some(g) = guard.as_mut() {
-                        g.answered();
-                    }
-                }
+                Ok(Ok(Served::Answered { .. })) => guard.answered(),
                 Ok(Ok(Served::LivenessProbe)) => {
                     tracing::debug!("liveness probe connected and closed without a frame");
                 }
@@ -610,9 +731,7 @@ pub async fn serve_until_idle(
                     tracing::warn!(error = %join, "uds rpc connection task was cancelled");
                 }
             }
-            if let Some(g) = guard {
-                g.release().await;
-            }
+            guard.release().await;
         });
     }
 }

--- a/crates/trusty-common/src/uds/server/mod.rs
+++ b/crates/trusty-common/src/uds/server/mod.rs
@@ -254,10 +254,13 @@ pub struct RpcServeOptions {
     /// SIGKILL can land mid-flush" — a full-window drain makes that false.
     ///
     /// A service whose real SIGKILL deadline is shorter than the process grace
-    /// window sets this explicitly rather than inheriting the default:
-    /// `trusty-analyze` is supervised by `UdsServiceSupervisor`, whose
-    /// `sigterm_patience` is the deadline that actually applies to it, so it
-    /// passes its own `service::rpc::SHUTDOWN_FLUSH_TIMEOUT`.
+    /// window sets this explicitly rather than inheriting the default — but
+    /// establish that the deadline REACHES this process first (#6601 review).
+    /// `trusty-analyze` briefly set it to its supervisor's `sigterm_patience`
+    /// and that was wrong: it runs detached, so it is absent from the
+    /// supervisor's population and no reap path signals it while it is serving.
+    /// Overriding on a deadline that never fires does not avert a SIGKILL; it
+    /// only gives up the drain early.
     ///
     /// Test: `shutdown_drains_an_in_flight_connection_before_it_returns`,
     /// `shutdown_returns_when_the_drain_budget_expires`,

--- a/crates/trusty-common/src/uds/server/mod.rs
+++ b/crates/trusty-common/src/uds/server/mod.rs
@@ -240,27 +240,52 @@ pub struct RpcServeOptions {
     /// a service whose method runs for minutes needs the second to be large
     /// while the first stays small.
     ///
-    /// Defaults to [`crate::shutdown::termination_grace`] — the process-wide
-    /// SIGTERM-to-SIGKILL window, so the drain fits inside the time the daemon
-    /// actually has, including an operator's `TRUSTY_TERMINATION_GRACE_SECS`
-    /// override.
+    /// Defaults to [`crate::shutdown::plannable_grace`] — the process-wide
+    /// SIGTERM-to-SIGKILL window MINUS [`crate::shutdown::CLEANUP_RESERVE`],
+    /// including an operator's `TRUSTY_TERMINATION_GRACE_SECS` override.
+    ///
+    /// 🔴 **Why the reserve rather than the whole window (#6601).** The signal
+    /// that starts this drain is the same signal that starts the SIGKILL
+    /// countdown, so a drain sized to the whole window leaves the caller's
+    /// post-serve work with no budget at all whenever the drain runs long.
+    /// `trusty-memory` is the concrete case: `transport::uds::
+    /// serve_with_shutdown` runs the BM25 exit flush AFTER `serve_until`
+    /// returns, and `bm25_lane::shutdown` states there is "no window in which a
+    /// SIGKILL can land mid-flush" — a full-window drain makes that false.
+    ///
+    /// A service whose real SIGKILL deadline is shorter than the process grace
+    /// window sets this explicitly rather than inheriting the default:
+    /// `trusty-analyze` is supervised by `UdsServiceSupervisor`, whose
+    /// `sigterm_patience` is the deadline that actually applies to it, so it
+    /// passes its own `service::rpc::SHUTDOWN_FLUSH_TIMEOUT`.
     ///
     /// Test: `shutdown_drains_an_in_flight_connection_before_it_returns`,
-    /// `shutdown_returns_when_the_drain_budget_expires`.
+    /// `shutdown_returns_when_the_drain_budget_expires`,
+    /// `default_serve_options_reserve_cleanup_time_inside_the_grace_window`.
     pub shutdown_drain: Duration,
 }
 
 impl Default for RpcServeOptions {
-    /// Thirty seconds, [`MAX_FRAME_BYTES`], and the process's termination grace.
+    /// Thirty seconds, [`MAX_FRAME_BYTES`], and the plannable termination grace.
     ///
     /// The read covers a local socket writing one already-serialised frame, so
     /// thirty seconds is headroom for a stalled writer rather than a latency
     /// budget.
+    ///
+    /// 🔴 **This `Default` reads the environment on every call (#6601).**
+    /// `shutdown_drain` comes from [`crate::shutdown::plannable_grace`], which
+    /// reads `TRUSTY_TERMINATION_GRACE_SECS` each time — so two values built
+    /// either side of a `set_var` differ, and this cannot be a `const`.
+    /// Deliberate: the override exists so a host whose supervisor window cannot
+    /// be raised can tell the daemon the truth, and a value frozen at first call
+    /// would ignore it. A caller wanting one stable budget for the process
+    /// builds the options once and copies them, which is what [`RpcServer`] and
+    /// `trusty-analyze`'s `serve_options` both do.
     fn default() -> Self {
         Self {
             read_timeout: Duration::from_secs(30),
             max_frame_bytes: MAX_FRAME_BYTES,
-            shutdown_drain: crate::shutdown::termination_grace(),
+            shutdown_drain: crate::shutdown::plannable_grace(),
         }
     }
 }
@@ -567,7 +592,17 @@ async fn drain_shutdown(listener: &UnixListener, open: &Arc<IdleTracker>, budget
     if open.open_connections() == 0 {
         return;
     }
+    // #6601 review: a process serving more than one socket needs the warn below
+    // to say WHICH one is still busy. `local_addr` is the listener's own answer,
+    // so it cannot disagree with the path actually bound; an unnamed socket
+    // (which this loop never binds) degrades to "<unknown>" rather than a panic.
+    let socket = listener
+        .local_addr()
+        .ok()
+        .and_then(|addr| addr.as_pathname().map(|p| p.display().to_string()))
+        .unwrap_or_else(|| "<unknown>".to_string());
     tracing::info!(
+        %socket,
         open = open.open_connections(),
         ?budget,
         "uds rpc shutdown signalled; draining in-flight connections"
@@ -600,6 +635,7 @@ async fn drain_shutdown(listener: &UnixListener, open: &Arc<IdleTracker>, budget
         () = settled => {}
         () = refuse => {}
         () = tokio::time::sleep(budget) => tracing::warn!(
+            %socket,
             open = open.open_connections(),
             ?budget,
             "connections still in flight after the shutdown drain budget; \

--- a/crates/trusty-common/src/uds/server/tests.rs
+++ b/crates/trusty-common/src/uds/server/tests.rs
@@ -1334,6 +1334,34 @@ fn spawn_draining_server(
     (socket, log, started_rx, stop_tx, handle)
 }
 
+/// Why (#6601 review): the drain and the caller's post-serve work are spent
+/// from ONE window — the SIGTERM-to-SIGKILL grace — so a default drain sized to
+/// the whole of it leaves the caller nothing. `trusty-memory` runs its BM25 exit
+/// flush after `serve_until` returns; `bm25_lane::shutdown` claims no SIGKILL
+/// can land mid-flush, and a full-window default is what would make that false.
+///
+/// What: the default drain plus the cleanup reserve must FIT in the grace
+/// window. Written as an inequality rather than an equality so a service that
+/// later shortens the default still passes, while restoring
+/// `termination_grace()` fails.
+/// Test: this is the test.
+#[test]
+fn default_serve_options_reserve_cleanup_time_inside_the_grace_window() {
+    let grace = crate::shutdown::termination_grace();
+    let drain = RpcServeOptions::default().shutdown_drain;
+    assert!(
+        drain + crate::shutdown::CLEANUP_RESERVE <= grace,
+        "the default drain ({drain:?}) plus the cleanup reserve ({:?}) must fit \
+         inside the termination grace window ({grace:?}), or the caller's \
+         post-serve work runs on borrowed time",
+        crate::shutdown::CLEANUP_RESERVE
+    );
+    assert!(
+        drain > Duration::ZERO,
+        "reserving cleanup time must not collapse the drain to nothing"
+    );
+}
+
 /// Why (#6601): the shutdown arm used to return the instant the signal
 /// resolved. Every accepted connection holds an `Arc<RpcRouter>` clone — in
 /// `trusty-analyze` that reaches a redb `Database` — so the caller's unlink ran
@@ -1389,11 +1417,22 @@ async fn shutdown_drains_an_in_flight_connection_before_it_returns() {
 /// there until the listener dropped and then see a reset, which it cannot tell
 /// from a broken service; accepted and closed at once it gets
 /// `UdsRpcError::NoResponse` immediately and can retry against a successor.
+///
+/// What makes this a test OF the drain (#6601 review): `refused.is_err()` alone
+/// is true of a dropped listener's reset too, so it passed with the drain arm
+/// replaced by a bare `return`. The two assertions below close that. The error
+/// must be `NoResponse` — the accept-and-close signature, which a dial against
+/// an already-unlinked path (`Dial`) is not — AND the loop must not yet have
+/// recorded `"returned"` when the refusal lands. Only one order produces both:
+/// the listener is still owned by a running drain. Replace the arm with a bare
+/// return and the loop records `"returned"` and drops the listener before any
+/// reset can reach the client, so whichever error the client gets, one of the
+/// two assertions fails.
 /// Test: this is the test.
 #[tokio::test]
 async fn shutdown_refuses_a_connection_dialled_after_the_signal() {
     let tmp = tempfile::tempdir().expect("tempdir");
-    let (socket, _log, mut started, stop, handle) = spawn_draining_server(
+    let (socket, log, mut started, stop, handle) = spawn_draining_server(
         tmp.path(),
         Duration::from_millis(600),
         Duration::from_secs(5),
@@ -1416,9 +1455,20 @@ async fn shutdown_refuses_a_connection_dialled_after_the_signal() {
     )
     .await
     .expect("a post-signal dial must be refused, not left hanging in the backlog");
+    // Snapshot BEFORE any further await, so the 600 ms handler cannot finish and
+    // let the loop return between the refusal and the assertion.
+    let during_refusal = log.events();
+
     assert!(
-        refused.is_err(),
-        "nothing may be served after the signal: {refused:?}"
+        matches!(refused, Err(crate::uds::UdsRpcError::NoResponse { .. })),
+        "a dial during the drain must be accepted and closed — not reset by a \
+         dropped listener, and not refused at connect by an unlinked path: \
+         {refused:?}"
+    );
+    assert!(
+        !during_refusal.contains(&"returned"),
+        "the refusal must land while the drain still owns the listener; the \
+         loop had already returned: {during_refusal:?}"
     );
 
     let _ = client.await;

--- a/crates/trusty-common/src/uds/server/tests.rs
+++ b/crates/trusty-common/src/uds/server/tests.rs
@@ -1251,3 +1251,218 @@ async fn a_client_queued_when_the_idle_window_elapses_is_served_not_reset() {
         .expect("join");
     assert_eq!(exit, ServeExit::Idle);
 }
+
+// ── shutdown drain (#6601) ──────────────────────────────────────────────────
+
+/// A recorder of the order two events happened in.
+///
+/// Why: the property #6601 fixes is an ORDER — the in-flight response must be
+/// written before `serve_until_idle` returns, because the caller unlinks the
+/// socket the moment it does. Asserting only that the client got its answer
+/// passes on the pre-fix code too: the connection task is detached, so it keeps
+/// running after the loop has returned.
+#[derive(Clone, Default)]
+struct EventLog(Arc<std::sync::Mutex<Vec<&'static str>>>);
+
+impl EventLog {
+    fn record(&self, event: &'static str) {
+        if let Ok(mut events) = self.0.lock() {
+            events.push(event);
+        }
+    }
+
+    fn events(&self) -> Vec<&'static str> {
+        self.0.lock().map(|e| e.clone()).unwrap_or_default()
+    }
+}
+
+/// Serve `dir/drain.sock` with one deliberately slow method.
+///
+/// The handler sleeps `handler_for`, then records `"answered"`; the loop records
+/// `"returned"` when `serve_until_idle` resolves. The returned receiver fires as
+/// the handler begins, so a test signals shutdown with a request genuinely in
+/// flight rather than after a sleep that only makes that likely.
+fn spawn_draining_server(
+    dir: &std::path::Path,
+    handler_for: Duration,
+    drain_budget: Duration,
+) -> (
+    std::path::PathBuf,
+    EventLog,
+    tokio::sync::mpsc::UnboundedReceiver<()>,
+    tokio::sync::oneshot::Sender<()>,
+    tokio::task::JoinHandle<ServeExit>,
+) {
+    let socket = dir.join("drain.sock");
+    let (stop_tx, stop_rx) = tokio::sync::oneshot::channel();
+    let (started_tx, started_rx) = tokio::sync::mpsc::unbounded_channel();
+    let log = EventLog::default();
+
+    let bound = socket.clone();
+    let handler_log = log.clone();
+    let loop_log = log.clone();
+    let handle = tokio::spawn(async move {
+        let router = RpcRouter::new().typed("slow", move |_req: ()| {
+            let log = handler_log.clone();
+            let started = started_tx.clone();
+            async move {
+                let _ = started.send(());
+                tokio::time::sleep(handler_for).await;
+                log.record("answered");
+                Ok::<_, RpcError>(json!({ "ok": true }))
+            }
+        });
+        let listener = crate::uds::bind_hardened(&bound).expect("bind");
+        let options = RpcServeOptions {
+            shutdown_drain: drain_budget,
+            ..RpcServeOptions::default()
+        };
+        let exit = serve_until_idle(
+            &listener,
+            Arc::new(router),
+            options,
+            async move {
+                let _ = stop_rx.await;
+            },
+            None,
+        )
+        .await;
+        loop_log.record("returned");
+        let _ = std::fs::remove_file(&bound);
+        exit
+    });
+    (socket, log, started_rx, stop_tx, handle)
+}
+
+/// Why (#6601): the shutdown arm used to return the instant the signal
+/// resolved. Every accepted connection holds an `Arc<RpcRouter>` clone — in
+/// `trusty-analyze` that reaches a redb `Database` — so the caller's unlink ran
+/// on top of handles still in use, and the successor a client spawned on seeing
+/// that unlink died opening the same store (#6595).
+///
+/// What: one 400 ms handler, the signal delivered while it runs. Both halves are
+/// asserted — the client gets a normal response, AND `"answered"` is recorded
+/// before `"returned"`. The second is the discriminator: the connection task is
+/// detached, so the response arrives either way and only the ORDER changes.
+/// Test: this is the test.
+#[tokio::test]
+async fn shutdown_drains_an_in_flight_connection_before_it_returns() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let (socket, log, mut started, stop, handle) = spawn_draining_server(
+        tmp.path(),
+        Duration::from_millis(400),
+        Duration::from_secs(5),
+    );
+    await_socket(&socket).await;
+
+    let dialled = socket.clone();
+    let client = tokio::spawn(async move { call(&dialled, 1, "slow", json!(null)).await });
+    started.recv().await.expect("the handler must start");
+
+    stop.send(()).expect("signal shutdown");
+
+    let response = tokio::time::timeout(Duration::from_secs(10), client)
+        .await
+        .expect("the in-flight request must complete during the drain")
+        .expect("join");
+    assert_eq!(
+        response.result,
+        Some(json!({ "ok": true })),
+        "a request already accepted must be answered, not dropped"
+    );
+
+    let exit = tokio::time::timeout(Duration::from_secs(10), handle)
+        .await
+        .expect("the loop must return once the drain finishes")
+        .expect("join");
+    assert_eq!(exit, ServeExit::Shutdown);
+    assert_eq!(
+        log.events(),
+        vec!["answered", "returned"],
+        "the loop must not return — and so let its caller unlink — until the \
+         in-flight handler is done"
+    );
+}
+
+/// Why (#6601): while the drain runs nothing is serving new work, and a client
+/// that dials anyway must be told so. Left in the kernel backlog it would sit
+/// there until the listener dropped and then see a reset, which it cannot tell
+/// from a broken service; accepted and closed at once it gets
+/// `UdsRpcError::NoResponse` immediately and can retry against a successor.
+/// Test: this is the test.
+#[tokio::test]
+async fn shutdown_refuses_a_connection_dialled_after_the_signal() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let (socket, _log, mut started, stop, handle) = spawn_draining_server(
+        tmp.path(),
+        Duration::from_millis(600),
+        Duration::from_secs(5),
+    );
+    await_socket(&socket).await;
+
+    let dialled = socket.clone();
+    let client = tokio::spawn(async move { call(&dialled, 1, "slow", json!(null)).await });
+    started.recv().await.expect("the handler must start");
+    stop.send(()).expect("signal shutdown");
+
+    let request = json!({ "jsonrpc": "2.0", "id": 2, "method": "slow", "params": null });
+    let refused = tokio::time::timeout(
+        Duration::from_secs(3),
+        crate::uds::send_framed_request::<_, RpcResponse>(
+            &socket,
+            &request,
+            Duration::from_secs(3),
+        ),
+    )
+    .await
+    .expect("a post-signal dial must be refused, not left hanging in the backlog");
+    assert!(
+        refused.is_err(),
+        "nothing may be served after the signal: {refused:?}"
+    );
+
+    let _ = client.await;
+    let exit = tokio::time::timeout(Duration::from_secs(10), handle)
+        .await
+        .expect("the loop must still return")
+        .expect("join");
+    assert_eq!(exit, ServeExit::Shutdown);
+}
+
+/// Why: the drain is bounded on purpose. The signal starts a window that ends in
+/// SIGKILL, so a handler that outlives the budget must not spend it — the loop
+/// warns and returns, and the caller unlinks. Without the bound a wedged handler
+/// would hold the socket path past the process's own grace window.
+/// Test: this is the test.
+#[tokio::test]
+async fn shutdown_returns_when_the_drain_budget_expires() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let budget = Duration::from_millis(150);
+    let (socket, log, mut started, stop, handle) =
+        spawn_draining_server(tmp.path(), Duration::from_secs(30), budget);
+    await_socket(&socket).await;
+
+    let dialled = socket.clone();
+    let client = tokio::spawn(async move { call(&dialled, 1, "slow", json!(null)).await });
+    started.recv().await.expect("the handler must start");
+
+    let signalled = std::time::Instant::now();
+    stop.send(()).expect("signal shutdown");
+    let exit = tokio::time::timeout(Duration::from_secs(10), handle)
+        .await
+        .expect("the drain must be bounded")
+        .expect("join");
+    let elapsed = signalled.elapsed();
+
+    assert_eq!(exit, ServeExit::Shutdown);
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "the loop must return on the budget, not on the handler: {elapsed:?}"
+    );
+    assert_eq!(
+        log.events(),
+        vec!["returned"],
+        "the handler had not finished, so only the loop's own event is recorded"
+    );
+    client.abort();
+}

--- a/crates/trusty-common/src/uds/supervisor/child.rs
+++ b/crates/trusty-common/src/uds/supervisor/child.rs
@@ -7,15 +7,35 @@
 //! What: [`ChildHandle`] (the per-instance bookkeeping), [`spawn_child`],
 //! [`terminate_child`], [`remove_socket_file`], and [`over_rss_limit`].
 //! Test: `tests.rs` — `over_rss_limit_is_false_without_a_measurement`,
-//! `over_rss_limit_is_false_when_disabled`, `terminate_child_reaps_a_live_child`.
+//! `over_rss_limit_is_false_when_disabled`, `terminate_child_reaps_a_live_child`,
+//! `a_child_that_exits_before_binding_reports_its_status_and_stderr`.
 
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::Duration;
 
-use tokio::process::{Child, Command};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, ChildStderr, Command};
+
+use crate::log_buffer::LogBuffer;
 
 use super::{SpawnSpec, SupervisorError};
+
+/// Stderr lines retained per child for a spawn-failure report (#6600).
+///
+/// Twenty covers a panic message with its header, or the handful of lines a
+/// service prints before it gives up on a lock, while a supervisor holding
+/// several children still costs kilobytes.
+pub(super) const STDERR_TAIL_LINES: usize = 20;
+
+/// How long [`SpawnedChild::stderr_tail`] waits for the relay to finish reading
+/// a dead child's pipe (#6600).
+///
+/// The write end is already closed by the time it is called, so the relay
+/// reaches EOF as soon as it has drained what the kernel buffered — microseconds
+/// in practice. The bound exists so an unreadable pipe cannot stall a path whose
+/// whole point is to fail fast.
+const STDERR_DRAIN: Duration = Duration::from_millis(200);
 
 /// Per-instance child bookkeeping stored in the supervisor's map.
 ///
@@ -35,6 +55,48 @@ pub(super) struct ChildHandle {
     pub(super) last_used: u64,
 }
 
+/// A freshly-launched child, plus the tail of its stderr when one was captured.
+///
+/// Why (#6600): `ensure_running` now reports a child that died before it bound,
+/// and an exit status alone rarely says which precondition failed — "exit
+/// status: 1" and "Database already open. Cannot acquire lock." send an
+/// operator to different places. Carrying the buffer beside the handle is what
+/// lets the error quote the second.
+/// What: the `tokio::process::Child`, and `Some(buffer)` when this supervisor
+/// piped the child's stderr. `None` means stderr was inherited — see
+/// [`spawn_child`] for which children get which.
+/// Test: `a_child_that_exits_before_binding_reports_its_status_and_stderr`.
+#[derive(Debug)]
+pub(super) struct SpawnedChild {
+    pub(super) child: Child,
+    stderr: Option<LogBuffer>,
+    relay: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl SpawnedChild {
+    /// The last [`STDERR_TAIL_LINES`] the child wrote; empty when stderr was
+    /// inherited rather than captured.
+    ///
+    /// 🔴 **Call this only once the child has EXITED.** The relay task is still
+    /// reading when the process dies, so the lines that explain the death may
+    /// not have reached the buffer yet — this waits for the relay to finish,
+    /// which only happens when the write end of the pipe is closed. On a live
+    /// child that wait would run for the child's whole lifetime.
+    ///
+    /// The wait is bounded by [`STDERR_DRAIN`] regardless, so a pipe that never
+    /// reaches EOF cannot hold the failure path open.
+    /// Test: `a_child_that_exits_before_binding_reports_its_status_and_stderr`.
+    pub(super) async fn stderr_tail(&mut self) -> Vec<String> {
+        let Some(buffer) = self.stderr.as_ref() else {
+            return Vec::new();
+        };
+        if let Some(relay) = self.relay.take() {
+            let _ = tokio::time::timeout(STDERR_DRAIN, relay).await;
+        }
+        buffer.tail(STDERR_TAIL_LINES)
+    }
+}
+
 /// Spawn one child from `spec`.
 ///
 /// Why: isolates the `Command` builder so the supervisor's state machine can be
@@ -42,23 +104,34 @@ pub(super) struct ChildHandle {
 /// place rather than at each service's call site.
 /// What: creates `spec.create_dirs` first (failing here gives a cleaner error
 /// than a child that immediately exits), closes stdin and stdout — a supervised
-/// UDS service speaks its socket, not its pipes — inherits stderr so the child's
-/// tracing output reaches the parent's log stream, and sets `kill_on_drop` so an
-/// unsupervised drop reaps the child rather than leaking it.
+/// UDS service speaks its socket, not its pipes — routes the child's stderr to
+/// this process's stderr, and sets `kill_on_drop` so an unsupervised drop reaps
+/// the child rather than leaking it.
 ///
 /// `detached` inverts that last decision (#6350). An on-demand service ends on
 /// its own idle window and is meant to be reused by the next client, so a
 /// transient caller's exit must not take it down — see
 /// [`super::SupervisorConfig::with_detached`].
+///
+/// 🔴 **`detached` also decides whether stderr is captured (#6600), and the two
+/// arms are not interchangeable.** A supervised child's stderr is PIPED and
+/// copied through by [`relay_stderr`], so its tail is quotable when the child
+/// dies before binding. A DETACHED child keeps `Stdio::inherit()`: it is meant
+/// to outlive the process that spawned it, and a pipe whose read end left with
+/// that process turns the child's next log write into `EPIPE` — which
+/// `eprintln!` turns into a panic. Capturing a detached child's stderr would
+/// kill the server detached mode exists to keep alive.
+///
 /// Test: `spawn_child_creates_requested_directories`,
 /// `spawn_child_reports_a_missing_binary`,
-/// `detached_children_are_not_retained_in_the_population`.
+/// `detached_children_are_not_retained_in_the_population`,
+/// `a_child_that_exits_before_binding_reports_its_status_and_stderr`.
 pub(super) async fn spawn_child(
     service: &str,
     key: &str,
     spec: &SpawnSpec,
     detached: bool,
-) -> Result<Child, SupervisorError> {
+) -> Result<SpawnedChild, SupervisorError> {
     for dir in &spec.create_dirs {
         if !dir.exists() {
             tokio::fs::create_dir_all(dir)
@@ -72,19 +145,68 @@ pub(super) async fn spawn_child(
         }
     }
 
-    Command::new(&spec.program)
+    let mut command = Command::new(&spec.program);
+    command
         .args(&spec.args)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
-        .stderr(Stdio::inherit())
-        .kill_on_drop(!detached)
-        .spawn()
-        .map_err(|source| SupervisorError::Spawn {
-            service: service.to_string(),
-            key: key.to_string(),
-            program: spec.program.clone(),
-            source,
+        // #6600: piped for a supervised child so its stderr is quotable,
+        // inherited for a detached one so it survives this process.
+        .stderr(if detached {
+            Stdio::inherit()
+        } else {
+            Stdio::piped()
         })
+        .kill_on_drop(!detached);
+
+    let mut child = command.spawn().map_err(|source| SupervisorError::Spawn {
+        service: service.to_string(),
+        key: key.to_string(),
+        program: spec.program.clone(),
+        source,
+    })?;
+
+    let relayed = child.stderr.take().map(relay_stderr);
+    let (stderr, relay) = match relayed {
+        Some((buffer, handle)) => (Some(buffer), Some(handle)),
+        None => (None, None),
+    };
+    Ok(SpawnedChild {
+        child,
+        stderr,
+        relay,
+    })
+}
+
+/// Copy a captured child's stderr to this process's stderr, keeping the tail.
+///
+/// Why: piping stderr for the sake of [`SpawnedChild::stderr_tail`] must not
+/// cost the operator the child's log stream, which `Stdio::inherit()` gave them
+/// for free. The relay passes each line through UNCHANGED — not through
+/// `tracing` — so the child's own formatting and level survive, and no line
+/// disappears because this process's `RUST_LOG` filters it out.
+/// What: a task that reads lines until the pipe closes (the child exited, or
+/// was reaped), writing each to `tokio::io::stderr()` and pushing it onto a
+/// bounded [`LogBuffer`]. The returned buffer is a cheap handle onto the same
+/// ring, so a caller reads the tail without stopping the relay; the returned
+/// join handle is how [`SpawnedChild::stderr_tail`] knows the pipe has been
+/// drained. Write failures are ignored: losing a log line must never take down
+/// a supervisor.
+/// Test: `a_child_that_exits_before_binding_reports_its_status_and_stderr`.
+fn relay_stderr(pipe: ChildStderr) -> (LogBuffer, tokio::task::JoinHandle<()>) {
+    let buffer = LogBuffer::new(STDERR_TAIL_LINES);
+    let sink = buffer.clone();
+    let handle = tokio::spawn(async move {
+        let mut out = tokio::io::stderr();
+        let mut lines = BufReader::new(pipe).lines();
+        while let Ok(Some(line)) = lines.next_line().await {
+            let _ = out.write_all(line.as_bytes()).await;
+            let _ = out.write_all(b"\n").await;
+            let _ = out.flush().await;
+            sink.push(line);
+        }
+    });
+    (buffer, handle)
 }
 
 /// Send SIGTERM, wait out the service's patience window, then SIGKILL.

--- a/crates/trusty-common/src/uds/supervisor/child.rs
+++ b/crates/trusty-common/src/uds/supervisor/child.rs
@@ -14,7 +14,7 @@ use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::Duration;
 
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStderr, Command};
 
 use crate::log_buffer::LogBuffer;
@@ -27,6 +27,23 @@ use super::{SpawnSpec, SupervisorError};
 /// service prints before it gives up on a lock, while a supervisor holding
 /// several children still costs kilobytes.
 pub(super) const STDERR_TAIL_LINES: usize = 20;
+
+/// Largest number of bytes the relay buffers for ONE stderr line (#6600 review).
+///
+/// Why: [`STDERR_TAIL_LINES`] bounds how MANY lines are retained and says
+/// nothing about how long one may be. A child that writes a megabyte before its
+/// first newline — a panic with a huge `Debug` payload, a serialised request
+/// echoed into a log — would otherwise be buffered whole by the reader and then
+/// retained whole by the ring, and twenty such lines per child is the supervisor
+/// carrying tens of megabytes for as long as the child lives. The bound is on
+/// the READ, not on a truncation after the fact, so the oversized line is never
+/// resident in the first place.
+///
+/// What: 8 KiB. A line longer than this is relayed to stderr in 8 KiB pieces and
+/// retained as those pieces — the operator loses no bytes, and the ring's
+/// worst case becomes `STDERR_TAIL_LINES * STDERR_LINE_CAP`, about 160 KiB.
+/// Test: `a_child_writing_an_enormous_line_does_not_grow_the_relay_buffer`.
+pub(super) const STDERR_LINE_CAP: u64 = 8 * 1024;
 
 /// How long [`SpawnedChild::stderr_tail`] waits for the relay to finish reading
 /// a dead child's pipe (#6600).
@@ -192,19 +209,71 @@ pub(super) async fn spawn_child(
 /// join handle is how [`SpawnedChild::stderr_tail`] knows the pipe has been
 /// drained. Write failures are ignored: losing a log line must never take down
 /// a supervisor.
-/// Test: `a_child_that_exits_before_binding_reports_its_status_and_stderr`.
+///
+/// Three details the obvious `lines()` loop gets wrong (#6600 review):
+///   - each read is bounded by [`STDERR_LINE_CAP`], so a child that writes
+///     without ever emitting a newline cannot grow this task's buffer;
+///   - the line and its terminator go out in ONE `write_all`, because two
+///     writes can interleave with another child's relay and split a line;
+///   - invalid UTF-8 is relayed lossily rather than ending the relay. `lines()`
+///     yields `Err` there, and the old `while let Ok(Some(_))` treated that as
+///     EOF — one bad byte and the operator silently lost the rest of the stream.
+///
+/// A read error DOES end the relay, with a `debug!`: the pipe is gone, and a
+/// bare `continue` on a persistent error would spin.
+/// Test: `a_child_that_exits_before_binding_reports_its_status_and_stderr`,
+/// `a_child_writing_an_enormous_line_does_not_grow_the_relay_buffer`.
 fn relay_stderr(pipe: ChildStderr) -> (LogBuffer, tokio::task::JoinHandle<()>) {
+    relay_stderr_into(pipe, tokio::io::stderr())
+}
+
+/// [`relay_stderr`] with the pass-through destination supplied by the caller.
+///
+/// Why the seam exists: the buffer bound is proven with a 1 MiB line, and
+/// `relay_stderr` would faithfully copy that megabyte to the test runner's own
+/// stderr — a megabyte in every CI log, on a property that has nothing to do
+/// with where the bytes go. The test passes `tokio::io::sink()`; production has
+/// exactly one caller and it passes `tokio::io::stderr()`.
+/// Test: `a_child_writing_an_enormous_line_does_not_grow_the_relay_buffer`.
+pub(super) fn relay_stderr_into<W>(
+    pipe: ChildStderr,
+    mut out: W,
+) -> (LogBuffer, tokio::task::JoinHandle<()>)
+where
+    W: tokio::io::AsyncWrite + Unpin + Send + 'static,
+{
     let buffer = LogBuffer::new(STDERR_TAIL_LINES);
     let sink = buffer.clone();
     let handle = tokio::spawn(async move {
-        let mut out = tokio::io::stderr();
-        let mut lines = BufReader::new(pipe).lines();
-        while let Ok(Some(line)) = lines.next_line().await {
-            let _ = out.write_all(line.as_bytes()).await;
-            let _ = out.write_all(b"\n").await;
-            let _ = out.flush().await;
+        let mut reader = BufReader::new(pipe);
+        let mut raw: Vec<u8> = Vec::new();
+        loop {
+            raw.clear();
+            let read = match (&mut reader)
+                .take(STDERR_LINE_CAP)
+                .read_until(b'\n', &mut raw)
+                .await
+            {
+                Ok(n) => n,
+                Err(e) => {
+                    tracing::debug!(error = %e, "supervised child stderr relay ended on a read error");
+                    break;
+                }
+            };
+            if read == 0 {
+                break;
+            }
+            // One write, terminator included — see the doc comment.
+            if !raw.ends_with(b"\n") {
+                raw.push(b'\n');
+            }
+            let _ = out.write_all(&raw).await;
+            let line = String::from_utf8_lossy(&raw[..raw.len() - 1]).into_owned();
             sink.push(line);
         }
+        // Flushed once at EOF rather than per line: `tokio::io::stderr` writes
+        // through, so a flush inside the loop bought nothing per line.
+        let _ = out.flush().await;
     });
     (buffer, handle)
 }

--- a/crates/trusty-common/src/uds/supervisor/child.rs
+++ b/crates/trusty-common/src/uds/supervisor/child.rs
@@ -219,10 +219,30 @@ pub(super) async fn spawn_child(
 ///     yields `Err` there, and the old `while let Ok(Some(_))` treated that as
 ///     EOF — one bad byte and the operator silently lost the rest of the stream.
 ///
+/// 🔴 **One LOGICAL line takes one ring slot, however long it is (#6601
+/// review).** Bounding the READ is not by itself enough: a 1 MiB line arrives as
+/// 128 capped reads, and pushing each one retained a single line as 20 entries
+/// and evicted every real line before it. Measured on the pre-fix code, a child
+/// printing `Database already open. Cannot acquire lock.` and then 1 MiB of
+/// padding left a ring of `[8192 × 18, 0, 5]` — nothing but padding, on the
+/// exact failure #6600 exists to diagnose, and one empty entry from a body that
+/// ended level with the cap. So an over-cap line keeps its capped prefix, and
+/// [`drain_over_cap_line`] reads to the next newline WITHOUT retaining any of
+/// it. The prefix carries a marker naming how many bytes were dropped, and
+/// prefix plus marker still fit [`STDERR_LINE_CAP`], so the ring's worst case
+/// stays `STDERR_TAIL_LINES * STDERR_LINE_CAP`.
+///
+/// Every byte still reaches this process's stderr — the drain relays what it
+/// discards. Only the RETAINED copy is truncated. The capped prefix is written
+/// without a synthesised terminator for the same reason: inserting one would
+/// split the operator's view of a line the child wrote whole. A terminator is
+/// supplied only at EOF, where the child left the stream mid-line.
+///
 /// A read error DOES end the relay, with a `debug!`: the pipe is gone, and a
 /// bare `continue` on a persistent error would spin.
 /// Test: `a_child_that_exits_before_binding_reports_its_status_and_stderr`,
-/// `a_child_writing_an_enormous_line_does_not_grow_the_relay_buffer`.
+/// `a_child_writing_an_enormous_line_does_not_grow_the_relay_buffer`,
+/// `a_real_line_survives_the_over_cap_line_that_follows_it`.
 fn relay_stderr(pipe: ChildStderr) -> (LogBuffer, tokio::task::JoinHandle<()>) {
     relay_stderr_into(pipe, tokio::io::stderr())
 }
@@ -263,19 +283,118 @@ where
             if read == 0 {
                 break;
             }
-            // One write, terminator included — see the doc comment.
-            if !raw.ends_with(b"\n") {
-                raw.push(b'\n');
+
+            if raw.ends_with(b"\n") {
+                // One write, terminator included — see the doc comment.
+                let _ = out.write_all(&raw).await;
+                sink.push(decode_line(&raw[..raw.len() - 1]));
+                continue;
             }
+
+            if read as u64 != STDERR_LINE_CAP {
+                // The pipe ended mid-line. Nothing was dropped; supply the
+                // terminator the child never wrote so stderr is not left
+                // hanging.
+                raw.push(b'\n');
+                let _ = out.write_all(&raw).await;
+                sink.push(decode_line(&raw[..raw.len() - 1]));
+                continue;
+            }
+
+            // Over the cap. Relay the prefix as-is, then relay-and-discard the
+            // rest so this one logical line takes one ring slot (#6601 review).
             let _ = out.write_all(&raw).await;
-            let line = String::from_utf8_lossy(&raw[..raw.len() - 1]).into_owned();
-            sink.push(line);
+            let dropped = drain_over_cap_line(&mut reader, &mut out).await;
+            sink.push(if dropped == 0 {
+                decode_line(&raw)
+            } else {
+                truncated_entry(&raw, dropped)
+            });
         }
         // Flushed once at EOF rather than per line: `tokio::io::stderr` writes
         // through, so a flush inside the loop bought nothing per line.
         let _ = out.flush().await;
     });
     (buffer, handle)
+}
+
+/// Relay the remainder of an over-cap line to `out` without retaining it.
+///
+/// Why: the retained copy of a line is capped, but the operator's copy must not
+/// be — losing the second half of a panic message is the outcome #6600 was filed
+/// against. This reads on, writing every byte through, and reports only how much
+/// it threw away.
+/// What: capped reads until a newline or EOF. Returns the count of
+/// NON-terminator bytes discarded, which is `0` when the line happened to end
+/// exactly at the cap — that case is not a truncation and earns no marker.
+/// Test: `a_real_line_survives_the_over_cap_line_that_follows_it`,
+/// `a_child_writing_an_enormous_line_does_not_grow_the_relay_buffer`.
+async fn drain_over_cap_line<W>(reader: &mut BufReader<ChildStderr>, out: &mut W) -> u64
+where
+    W: tokio::io::AsyncWrite + Unpin,
+{
+    let mut discarded: u64 = 0;
+    let mut chunk: Vec<u8> = Vec::new();
+    loop {
+        chunk.clear();
+        let read = match (&mut *reader)
+            .take(STDERR_LINE_CAP)
+            .read_until(b'\n', &mut chunk)
+            .await
+        {
+            Ok(n) => n,
+            Err(e) => {
+                tracing::debug!(error = %e, "supervised child stderr relay ended draining a long line");
+                break;
+            }
+        };
+        if read == 0 {
+            break;
+        }
+        let _ = out.write_all(&chunk).await;
+        if chunk.ends_with(b"\n") {
+            discarded += read as u64 - 1;
+            break;
+        }
+        discarded += read as u64;
+    }
+    discarded
+}
+
+/// Decode one retained stderr line, tolerating a codepoint split by the cap.
+///
+/// Why: [`STDERR_LINE_CAP`] is a BYTE bound, so it can land inside a multi-byte
+/// character. `from_utf8_lossy` alone turns that tail into a U+FFFD that reads
+/// like corrupt child output; the bytes are in fact intact and simply continue
+/// past the cap.
+/// What: an incomplete TRAILING sequence is dropped; genuinely invalid bytes
+/// anywhere else still become U+FFFD, because the relay must never end on one.
+/// Test: `a_child_writing_an_enormous_line_does_not_grow_the_relay_buffer`.
+fn decode_line(bytes: &[u8]) -> String {
+    match std::str::from_utf8(bytes) {
+        Ok(s) => s.to_owned(),
+        Err(e) if e.error_len().is_none() => {
+            String::from_utf8_lossy(&bytes[..e.valid_up_to()]).into_owned()
+        }
+        Err(_) => String::from_utf8_lossy(bytes).into_owned(),
+    }
+}
+
+/// The ring entry standing in for an over-cap line.
+///
+/// Why: a silently shortened line invites the reader to believe they have the
+/// whole message. Naming the dropped byte count is what tells an operator to go
+/// look at this process's stderr for the rest.
+/// What: the prefix, trimmed so prefix-plus-marker still fits
+/// [`STDERR_LINE_CAP`] — which is what keeps the ring's worst case at
+/// `STDERR_TAIL_LINES * STDERR_LINE_CAP`.
+/// Test: `a_real_line_survives_the_over_cap_line_that_follows_it`.
+fn truncated_entry(prefix: &[u8], dropped: u64) -> String {
+    let marker = format!("…[+{dropped} bytes truncated]");
+    let room = (STDERR_LINE_CAP as usize).saturating_sub(marker.len());
+    let mut kept = decode_line(&prefix[..prefix.len().min(room)]);
+    kept.push_str(&marker);
+    kept
 }
 
 /// Send SIGTERM, wait out the service's patience window, then SIGKILL.

--- a/crates/trusty-common/src/uds/supervisor/error.rs
+++ b/crates/trusty-common/src/uds/supervisor/error.rs
@@ -13,6 +13,19 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
+/// Render a captured stderr tail as a suffix, or nothing when there is none.
+///
+/// Why: `thiserror` formats one string per variant, and a bare "last stderr: "
+/// on a detached child — whose stderr is never captured — would read as a child
+/// that printed nothing rather than one nobody was listening to.
+fn format_stderr_tail(lines: &[String]) -> String {
+    if lines.is_empty() {
+        String::new()
+    } else {
+        format!(" — last stderr: {}", lines.join(" | "))
+    }
+}
+
 /// Why a supervised service could not be made available.
 ///
 /// `#[non_exhaustive]`: on an ENUM the attribute constrains *matching* — an
@@ -78,6 +91,33 @@ pub enum SupervisorError {
         socket: PathBuf,
         /// The budget that elapsed.
         budget: Duration,
+    },
+
+    /// The child exited before it bound its socket (#6600).
+    ///
+    /// Distinct from [`SupervisorError::SpawnTimeout`] because the remedies do
+    /// not overlap: a timeout points at the service's `spawn_probe` budget,
+    /// while this points at whatever the child itself refused to do. The
+    /// supervisor returns it within one probe interval rather than at the
+    /// budget boundary, so a child that dies in 100 ms is not reported 20 s
+    /// later as a slow bind.
+    #[error(
+        "{service} instance {key} exited before binding {socket}: {status}{}",
+        format_stderr_tail(.stderr)
+    )]
+    ChildExited {
+        /// Service label.
+        service: String,
+        /// Instance key.
+        key: String,
+        /// Socket the child was expected to bind.
+        socket: PathBuf,
+        /// How the child exited.
+        status: std::process::ExitStatus,
+        /// Last lines the child wrote to stderr. EMPTY for a detached child,
+        /// whose stderr is inherited rather than captured — see
+        /// `child::spawn_child` for why capturing it would kill the child.
+        stderr: Vec<String>,
     },
 
     /// Something is serving the socket, but it does not pass the

--- a/crates/trusty-common/src/uds/supervisor/error.rs
+++ b/crates/trusty-common/src/uds/supervisor/error.rs
@@ -77,10 +77,17 @@ pub enum SupervisorError {
 
     /// The child started but never bound its socket inside the service's
     /// `spawn_probe` budget.
+    ///
+    /// #6600 review: this carries the child's stderr tail for the same reason
+    /// [`SupervisorError::ChildExited`] does. "Its `spawn_probe` is too small"
+    /// is the message's guess, and the child's own last lines are what say
+    /// whether that guess is right — a model still loading and a child blocked
+    /// on a lock it will never get produce the same timeout and different logs.
     #[error(
         "{service} instance {key} did not bind {socket} within {budget:?} — \
          if this service loads a model at startup, its ServiceTimeouts::spawn_probe \
-         is too small"
+         is too small{}",
+        format_stderr_tail(.stderr)
     )]
     SpawnTimeout {
         /// Service label.
@@ -91,6 +98,10 @@ pub enum SupervisorError {
         socket: PathBuf,
         /// The budget that elapsed.
         budget: Duration,
+        /// Last lines the child wrote to stderr before it was killed. EMPTY for
+        /// a detached child, whose stderr is inherited rather than captured —
+        /// see `child::spawn_child` for why capturing it would kill the child.
+        stderr: Vec<String>,
     },
 
     /// The child exited before it bound its socket (#6600).

--- a/crates/trusty-common/src/uds/supervisor/mod.rs
+++ b/crates/trusty-common/src/uds/supervisor/mod.rs
@@ -198,9 +198,19 @@ impl UdsServiceSupervisor {
     /// its stderr, within one probe interval (#6600). Before that, such a child
     /// spent the whole `spawn_probe` budget and then blamed the budget.
     ///
+    /// 🔴 **Under [`SupervisorConfig::with_detached`] the tail is always empty
+    /// (#6601 review).** A detached child keeps `Stdio::inherit()` — see
+    /// `child::spawn_child` for why a pipe would kill the very server detached
+    /// mode exists to keep alive — so there is nothing to quote and the operator
+    /// reads the child's lines on this process's own stderr instead. The status
+    /// still arrives, and it still arrives within a probe interval; only the
+    /// quoting is lost. Both new error arms are affected: `ChildExited` and
+    /// `SpawnTimeout`.
+    ///
     /// Test: `external_mode_skips_spawn`,
     /// `adoption_refuses_a_world_writable_socket`,
     /// `a_child_that_exits_before_binding_reports_its_status_and_stderr`,
+    /// `a_detached_child_that_exits_before_binding_reports_an_empty_tail`,
     /// `adoption_accepts_a_hardened_socket_without_spawning`,
     /// `a_serving_child_is_reused_without_a_spawn`, plus `trusty-memory`'s
     /// concurrency suite for the racing cases.

--- a/crates/trusty-common/src/uds/supervisor/mod.rs
+++ b/crates/trusty-common/src/uds/supervisor/mod.rs
@@ -18,6 +18,10 @@
 //! **Two invariants a reader must not "simplify" away.**
 //!
 //! 1. Liveness is decided by the SOCKET, not by `try_wait()`. See `probe.rs`.
+//!    #6600 does not weaken this: the spawn probe asks the socket first on
+//!    every iteration and consults `try_wait` only to answer "has this child
+//!    already died", which is a reason to STOP waiting, never a reason to call
+//!    a still-running child dead.
 //! 2. The timeouts belong to the supervised service, not to supervision. See
 //!    `config.rs`.
 //!
@@ -50,6 +54,10 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use tokio::sync::Mutex;
 
 use child::{ChildHandle, remove_socket_file, spawn_child, terminate_child};
+
+// #6600: `wait_for_spawn` watches the child as well as the socket, so a child
+// that dies before binding is reported as `ChildExited` within one probe
+// interval instead of as a `SpawnTimeout` at the end of the whole budget.
 
 /// Supervisor that owns a keyed population of UDS-serving child processes.
 ///
@@ -185,8 +193,14 @@ impl UdsServiceSupervisor {
     /// [`SupervisorError::UntrustedSocket`] rather than a spawn that dies on
     /// EADDRINUSE.
     ///
+    /// A spawned child that EXITS before the socket answers is reported as
+    /// [`SupervisorError::ChildExited`], carrying its status and the tail of
+    /// its stderr, within one probe interval (#6600). Before that, such a child
+    /// spent the whole `spawn_probe` budget and then blamed the budget.
+    ///
     /// Test: `external_mode_skips_spawn`,
     /// `adoption_refuses_a_world_writable_socket`,
+    /// `a_child_that_exits_before_binding_reports_its_status_and_stderr`,
     /// `adoption_accepts_a_hardened_socket_without_spawning`,
     /// `a_serving_child_is_reused_without_a_spawn`, plus `trusty-memory`'s
     /// concurrency suite for the racing cases.
@@ -268,26 +282,54 @@ impl UdsServiceSupervisor {
             source,
         })?;
         let detached = self.config.detached;
-        let mut child = spawn_child(service, key, &spec, detached).await?;
+        let mut spawned = spawn_child(service, key, &spec, detached).await?;
         self.spawned.fetch_add(1, Ordering::Relaxed);
 
-        if !probe::wait_for_socket(socket_path, &self.config.timeouts).await {
-            // Explicit drop: `kill_on_drop` SIGKILLs the child that never bound.
-            // Nothing was acked to it, so there is nothing to flush.
-            // #6350: a DETACHED child was spawned without `kill_on_drop`, so
-            // dropping it would leave a process that never bound running with
-            // nothing left holding a handle to it. Terminate it here instead.
-            if detached {
-                let _ = terminate_child(&mut child, self.config.timeouts.sigterm_patience).await;
+        match probe::wait_for_spawn(socket_path, &self.config.timeouts, &mut spawned.child).await {
+            probe::SpawnWait::Bound => {}
+            // #6600: the child is already gone. Nothing to terminate, and the
+            // diagnosis the caller needs is its status and stderr — not the
+            // probe budget, which had nothing to do with it.
+            probe::SpawnWait::Exited(status) => {
+                let stderr = spawned.stderr_tail().await;
+                tracing::warn!(
+                    service = %service,
+                    instance = %key,
+                    socket = %socket_path.display(),
+                    ?status,
+                    "spawned child exited before binding its socket"
+                );
+                drop(spawned);
+                return Err(SupervisorError::ChildExited {
+                    service: service.to_string(),
+                    key: key.to_string(),
+                    socket: socket_path.to_path_buf(),
+                    status,
+                    stderr,
+                });
             }
-            drop(child);
-            return Err(SupervisorError::SpawnTimeout {
-                service: service.to_string(),
-                key: key.to_string(),
-                socket: socket_path.to_path_buf(),
-                budget: self.config.timeouts.spawn_probe,
-            });
+            probe::SpawnWait::TimedOut => {
+                // Explicit drop: `kill_on_drop` SIGKILLs the child that never
+                // bound. Nothing was acked to it, so there is nothing to flush.
+                // #6350: a DETACHED child was spawned without `kill_on_drop`, so
+                // dropping it would leave a process that never bound running with
+                // nothing left holding a handle to it. Terminate it here instead.
+                if detached {
+                    let _ =
+                        terminate_child(&mut spawned.child, self.config.timeouts.sigterm_patience)
+                            .await;
+                }
+                drop(spawned);
+                return Err(SupervisorError::SpawnTimeout {
+                    service: service.to_string(),
+                    key: key.to_string(),
+                    socket: socket_path.to_path_buf(),
+                    budget: self.config.timeouts.spawn_probe,
+                });
+            }
         }
+
+        let mut child = spawned.child;
 
         tracing::info!(
             service = %service,

--- a/crates/trusty-common/src/uds/supervisor/mod.rs
+++ b/crates/trusty-common/src/uds/supervisor/mod.rs
@@ -309,8 +309,11 @@ impl UdsServiceSupervisor {
                 });
             }
             probe::SpawnWait::TimedOut => {
-                // Explicit drop: `kill_on_drop` SIGKILLs the child that never
-                // bound. Nothing was acked to it, so there is nothing to flush.
+                // The child that never bound is killed here rather than by
+                // `kill_on_drop`, because the stderr tail below can only be read
+                // once the write end of the pipe is closed — which happens when
+                // the process dies. Nothing was acked to it, so there is nothing
+                // to flush.
                 // #6350: a DETACHED child was spawned without `kill_on_drop`, so
                 // dropping it would leave a process that never bound running with
                 // nothing left holding a handle to it. Terminate it here instead.
@@ -318,13 +321,19 @@ impl UdsServiceSupervisor {
                     let _ =
                         terminate_child(&mut spawned.child, self.config.timeouts.sigterm_patience)
                             .await;
+                } else {
+                    let _ = spawned.child.kill().await;
                 }
+                // #6600 review: the child's own last lines say whether the
+                // budget was too small or the child was never going to bind.
+                let stderr = spawned.stderr_tail().await;
                 drop(spawned);
                 return Err(SupervisorError::SpawnTimeout {
                     service: service.to_string(),
                     key: key.to_string(),
                     socket: socket_path.to_path_buf(),
                     budget: self.config.timeouts.spawn_probe,
+                    stderr,
                 });
             }
         }

--- a/crates/trusty-common/src/uds/supervisor/probe.rs
+++ b/crates/trusty-common/src/uds/supervisor/probe.rs
@@ -4,36 +4,79 @@
 //! simply "no listener", and for the accept-promptly REQUIREMENT that fact
 //! places on every supervised service.
 //!
-//! Test: `wait_for_socket_gives_up_within_the_spawn_budget`,
-//! `wait_for_socket_returns_once_the_socket_binds`.
+//! Test: `wait_for_spawn_gives_up_within_the_spawn_budget`,
+//! `wait_for_spawn_returns_once_the_socket_binds`,
+//! `wait_for_spawn_reports_a_child_that_exited`.
 
 use std::path::Path;
+use std::process::ExitStatus;
+
+use tokio::process::Child;
 
 use crate::uds::probe::socket_is_serving;
 
 use super::ServiceTimeouts;
 
-/// Poll the socket with exponential backoff until it accepts a connection or
-/// the service's spawn budget elapses.
+/// How a spawned child's first moments ended.
+///
+/// Why (#6600): "the socket never appeared" and "the process is already dead"
+/// are different failures with different remedies — a mistuned `spawn_probe`
+/// versus a precondition the child could not meet — and collapsing the second
+/// into the first cost the whole budget before saying anything useful.
+/// Test: see the module docs.
+pub(super) enum SpawnWait {
+    /// The socket accepted a connection.
+    Bound,
+    /// The child exited before the socket ever answered.
+    Exited(ExitStatus),
+    /// The child is still alive but the spawn budget elapsed.
+    TimedOut,
+}
+
+/// Poll the socket with exponential backoff until it accepts a connection, the
+/// child exits, or the service's spawn budget elapses.
 ///
 /// Why: a freshly-spawned child takes an unknown time to bind — a few ms for a
 /// service with nothing to load, tens of seconds for one that loads a model.
 /// Polling from a short initial interval and doubling gives sub-50 ms detection
 /// on the fast case without hammering the kernel on the slow one.
-/// What: loops [`socket_is_serving`] until success or until the cumulative wait
-/// exceeds `timeouts.spawn_probe`. Never sleeps past the deadline.
-/// Test: `wait_for_socket_gives_up_within_the_spawn_budget`,
-/// `wait_for_socket_returns_once_the_socket_binds`.
-pub(super) async fn wait_for_socket(path: &Path, timeouts: &ServiceTimeouts) -> bool {
+///
+/// Why the child is observed too (#6600): a child that dies on a held lock or a
+/// missing directory never binds, and waiting out a 20 s budget to say
+/// [`SpawnWait::TimedOut`] tells the caller nothing about why. `try_wait` costs
+/// one non-blocking `waitpid` per interval and turns that into an answer within
+/// one poll.
+///
+/// 🔴 The socket is asked FIRST on every iteration. A child that bound and then
+/// exited must still report [`SpawnWait::Bound`] — the caller's next act is to
+/// dial that socket, and something is answering it.
+///
+/// What: loops [`socket_is_serving`], then `child.try_wait()`, until one of them
+/// answers or the cumulative wait exceeds `timeouts.spawn_probe`. Never sleeps
+/// past the deadline. A `try_wait` that ERRORS is treated as "still running":
+/// the status is unreadable, not zero, and killing the wait on it would report a
+/// dead child that may be serving.
+/// Test: see the module docs.
+pub(super) async fn wait_for_spawn(
+    path: &Path,
+    timeouts: &ServiceTimeouts,
+    child: &mut Child,
+) -> SpawnWait {
     let deadline = tokio::time::Instant::now() + timeouts.spawn_probe;
     let mut interval = timeouts.initial_probe_interval;
     loop {
         if socket_is_serving(path, timeouts.connect_probe).await {
-            return true;
+            return SpawnWait::Bound;
+        }
+        // #6600: observe the child before deciding to keep waiting.
+        match child.try_wait() {
+            Ok(Some(status)) => return SpawnWait::Exited(status),
+            Ok(None) => {}
+            Err(e) => tracing::warn!("try_wait failed while probing a spawned child: {e:#}"),
         }
         let now = tokio::time::Instant::now();
         if now >= deadline {
-            return false;
+            return SpawnWait::TimedOut;
         }
         let sleep_for = interval.min(deadline.saturating_duration_since(now));
         tokio::time::sleep(sleep_for).await;

--- a/crates/trusty-common/src/uds/supervisor/tests.rs
+++ b/crates/trusty-common/src/uds/supervisor/tests.rs
@@ -867,6 +867,53 @@ async fn a_child_that_never_binds_fails_with_the_service_budget() {
     );
 }
 
+/// Why (#6600 review): `SpawnTimeout`'s message guesses at the cause — "its
+/// spawn_probe is too small" — and the child's own last lines are what say
+/// whether the guess is right. A model still loading and a child spinning on a
+/// lock it will never get produce the same timeout and different logs, and only
+/// one of them is fixed by raising the budget.
+///
+/// What: a child that logs and then hangs without ever binding. The timeout must
+/// carry the tail, and the operator-facing message must quote it.
+/// Test: this test itself.
+#[serial_test::serial]
+#[tokio::test]
+async fn a_child_that_never_binds_reports_the_stderr_it_did_write() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let socket = tmp.path().join("stuck.sock");
+    let cfg = SupervisorConfig::new(
+        "test-service",
+        3,
+        ServiceTimeouts::new(
+            Duration::from_millis(300),
+            Duration::from_millis(10),
+            Duration::from_secs(1),
+        ),
+    );
+    let sup = UdsServiceSupervisor::new(cfg);
+
+    let err = sup
+        .ensure_running("inst", &socket, || {
+            Ok(SpawnSpec::new("/bin/sh")
+                .arg("-c")
+                .arg("echo 'still loading the model' >&2; sleep 30"))
+        })
+        .await
+        .expect_err("a child that never binds must not be reported as running");
+
+    let SupervisorError::SpawnTimeout { stderr, .. } = &err else {
+        panic!("expected SpawnTimeout, got {err:?}");
+    };
+    assert!(
+        stderr.iter().any(|l| l.contains("still loading the model")),
+        "the child's own words must reach the caller, got {stderr:?}"
+    );
+    assert!(
+        err.to_string().contains("still loading the model"),
+        "the operator-facing message must quote the stderr tail: {err}"
+    );
+}
+
 /// Why (#6600): the #6595 CI signature was a child that died on a held redb
 /// lock in ~100 ms and was reported 20 s later as `SpawnTimeout`, whose message
 /// blames the spawn budget. `ensure_running` has to observe the child, not only
@@ -926,6 +973,64 @@ async fn a_child_that_exits_before_binding_reports_its_status_and_stderr() {
         sup.supervised_count().await,
         0,
         "a child that never bound must not be registered"
+    );
+}
+
+/// Why (#6600 review): `STDERR_TAIL_LINES` bounds how MANY lines the relay
+/// retains and says nothing about how long one may be. A child that writes a
+/// megabyte before its first newline — a panic carrying a big `Debug` payload —
+/// was buffered whole by `lines()` and then retained whole by the ring, so a
+/// supervisor holding several such children carried tens of megabytes for as
+/// long as they lived.
+///
+/// What: a child that writes 1 MiB with no newline at all. Every retained line
+/// must fit `STDERR_LINE_CAP`, and the whole tail must fit
+/// `STDERR_TAIL_LINES * STDERR_LINE_CAP` — the bound the fix establishes. On the
+/// `lines()` implementation the tail is one 1 MiB entry and both assertions
+/// fail: `no retained line may exceed the per-line cap (8192 bytes); longest was
+/// 1048576`.
+///
+/// Why the relay's pass-through goes to `sink()` here: the relay copies every
+/// byte through unchanged, which is correct and not what this bounds — running
+/// it against the real stderr would put a megabyte of `0`s in every CI log.
+/// Test: this test itself.
+#[tokio::test]
+async fn a_child_writing_an_enormous_line_does_not_grow_the_relay_buffer() {
+    use super::child::{STDERR_LINE_CAP, STDERR_TAIL_LINES, relay_stderr_into};
+
+    const WRITTEN: usize = 1024 * 1024;
+
+    let mut child = Command::new("/bin/sh")
+        .arg("-c")
+        .arg(format!("printf '%0{WRITTEN}d' 0 >&2"))
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn the shouty child");
+    let pipe = child.stderr.take().expect("stderr was piped");
+
+    let (buffer, relay) = relay_stderr_into(pipe, tokio::io::sink());
+    relay.await.expect("the relay must finish at EOF");
+    child.wait().await.expect("reap the child");
+
+    let tail = buffer.tail(STDERR_TAIL_LINES);
+    let longest = tail.iter().map(String::len).max().unwrap_or(0);
+    assert!(
+        longest as u64 <= STDERR_LINE_CAP,
+        "no retained line may exceed the per-line cap ({STDERR_LINE_CAP} bytes); \
+         longest was {longest}"
+    );
+    let retained: usize = tail.iter().map(String::len).sum();
+    let ceiling = STDERR_TAIL_LINES as u64 * STDERR_LINE_CAP;
+    assert!(
+        retained as u64 <= ceiling,
+        "the whole retained tail must fit {ceiling} bytes; it held {retained} \
+         out of the {WRITTEN} the child wrote"
+    );
+    assert!(
+        !tail.is_empty(),
+        "bounding the line must not throw the child's output away entirely"
     );
 }
 

--- a/crates/trusty-common/src/uds/supervisor/tests.rs
+++ b/crates/trusty-common/src/uds/supervisor/tests.rs
@@ -336,17 +336,24 @@ async fn probe_verdict_reports_serving_for_a_bound_socket() {
 /// Why: the backoff loop must terminate on the service's own budget, not on a
 /// constant. A loop that ignored `spawn_probe` would hang a caller for whatever
 /// the old BM25 3 s value happened to be.
+///
+/// The child is alive throughout — a LIVE child that has not bound is the case
+/// the budget is for, and #6600's `try_wait` arm must not shorten it.
 /// Test: this test itself.
 #[serial_test::serial]
 #[tokio::test]
-async fn wait_for_socket_gives_up_within_the_spawn_budget() {
+async fn wait_for_spawn_gives_up_within_the_spawn_budget() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let missing = tmp.path().join("never.sock");
     let budget = Duration::from_millis(120);
     let timeouts = ServiceTimeouts::new(budget, Duration::from_millis(10), Duration::from_secs(1));
+    let mut child = stub_child();
 
     let started = std::time::Instant::now();
-    assert!(!super::probe::wait_for_socket(&missing, &timeouts).await);
+    assert!(matches!(
+        super::probe::wait_for_spawn(&missing, &timeouts, &mut child).await,
+        super::probe::SpawnWait::TimedOut
+    ));
     let elapsed = started.elapsed();
     assert!(
         elapsed >= budget,
@@ -363,11 +370,54 @@ async fn wait_for_socket_gives_up_within_the_spawn_budget() {
 /// Test: this test itself.
 #[serial_test::serial]
 #[tokio::test]
-async fn wait_for_socket_returns_once_the_socket_binds() {
+async fn wait_for_spawn_returns_once_the_socket_binds() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let sock = tmp.path().join("bound.sock");
     let _listener = tokio::net::UnixListener::bind(&sock).expect("bind listener");
-    assert!(super::probe::wait_for_socket(&sock, &TEST_TIMEOUTS).await);
+    let mut child = stub_child();
+    assert!(matches!(
+        super::probe::wait_for_spawn(&sock, &TEST_TIMEOUTS, &mut child).await,
+        super::probe::SpawnWait::Bound
+    ));
+}
+
+/// Why (#6600): a child that dies before binding is the case the loop was blind
+/// to. It has to be reported as its own outcome, and inside one poll interval —
+/// polling the socket for the whole budget and then reporting a timeout blames
+/// the budget for a failure the budget had nothing to do with.
+/// Test: this test itself.
+#[serial_test::serial]
+#[tokio::test]
+async fn wait_for_spawn_reports_a_child_that_exited() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let missing = tmp.path().join("never.sock");
+    // A generous budget, so "returned early" is a claim the elapsed time can
+    // falsify rather than something the budget makes true on its own.
+    let budget = Duration::from_secs(3);
+    let timeouts = ServiceTimeouts::new(budget, Duration::from_millis(10), Duration::from_secs(1));
+    let mut child = Command::new("/bin/sh")
+        .args(["-c", "exit 3"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .kill_on_drop(true)
+        .spawn()
+        .expect("spawn a child that exits at once");
+
+    let started = std::time::Instant::now();
+    let outcome = super::probe::wait_for_spawn(&missing, &timeouts, &mut child).await;
+    let elapsed = started.elapsed();
+
+    match outcome {
+        super::probe::SpawnWait::Exited(status) => {
+            assert_eq!(status.code(), Some(3), "the real exit status must survive")
+        }
+        _ => panic!("a child that exited must not be reported as a timeout"),
+    }
+    assert!(
+        elapsed < budget / 3,
+        "the answer must not wait out the spawn budget: {elapsed:?}"
+    );
 }
 
 // ── Child lifecycle ───────────────────────────────────────────────────────
@@ -425,10 +475,10 @@ async fn spawn_child_creates_requested_directories() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let data = tmp.path().join("nested/data");
     let spec = SpawnSpec::new("/bin/echo").create_dir(&data);
-    let mut child = super::child::spawn_child("test-service", "k", &spec, false)
+    let mut spawned = super::child::spawn_child("test-service", "k", &spec, false)
         .await
         .expect("spawn");
-    let _ = child.wait().await;
+    let _ = spawned.child.wait().await;
     assert!(data.is_dir(), "the spec's directory must exist after spawn");
 }
 
@@ -809,6 +859,68 @@ async fn a_child_that_never_binds_fails_with_the_service_budget() {
         ),
         other => panic!("expected SpawnTimeout, got {other:?}"),
     }
+    assert_eq!(sup.spawned_count(), 1, "the launch itself did happen");
+    assert_eq!(
+        sup.supervised_count().await,
+        0,
+        "a child that never bound must not be registered"
+    );
+}
+
+/// Why (#6600): the #6595 CI signature was a child that died on a held redb
+/// lock in ~100 ms and was reported 20 s later as `SpawnTimeout`, whose message
+/// blames the spawn budget. `ensure_running` has to observe the child, not only
+/// the socket, so the operator gets the exit status and the child's own words.
+///
+/// What: a child that writes one line to stderr and exits 3, against a 3 s
+/// budget. Both halves of the fix are asserted — the VARIANT (not
+/// `SpawnTimeout`) and the LATENCY (well inside the budget, not at its
+/// boundary) — because either alone still passes on the pre-fix code path for
+/// one of the two reasons.
+/// Test: this test itself.
+#[serial_test::serial]
+#[tokio::test]
+async fn a_child_that_exits_before_binding_reports_its_status_and_stderr() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let socket = tmp.path().join("dead.sock");
+    let budget = Duration::from_secs(3);
+    let cfg = SupervisorConfig::new(
+        "test-service",
+        3,
+        ServiceTimeouts::new(budget, Duration::from_millis(10), Duration::from_secs(1)),
+    );
+    let sup = UdsServiceSupervisor::new(cfg);
+
+    let started = std::time::Instant::now();
+    let err = sup
+        .ensure_running("inst", &socket, || {
+            Ok(SpawnSpec::new("/bin/sh")
+                .arg("-c")
+                .arg("echo 'Database already open. Cannot acquire lock.' >&2; exit 3"))
+        })
+        .await
+        .expect_err("a child that exited must not be reported as running");
+    let elapsed = started.elapsed();
+
+    match &err {
+        SupervisorError::ChildExited { status, stderr, .. } => {
+            assert_eq!(status.code(), Some(3), "the real exit status must survive");
+            assert!(
+                stderr.iter().any(|l| l.contains("Cannot acquire lock")),
+                "the child's own diagnosis must reach the caller, got {stderr:?}"
+            );
+        }
+        other => panic!("expected ChildExited, got {other:?}"),
+    }
+    assert!(
+        elapsed < budget / 3,
+        "a dead child must be reported within a poll interval, not at the \
+         spawn budget: {elapsed:?}"
+    );
+    assert!(
+        err.to_string().contains("Cannot acquire lock"),
+        "the operator-facing message must quote the stderr tail: {err}"
+    );
     assert_eq!(sup.spawned_count(), 1, "the launch itself did happen");
     assert_eq!(
         sup.supervised_count().await,

--- a/crates/trusty-common/src/uds/supervisor/tests.rs
+++ b/crates/trusty-common/src/uds/supervisor/tests.rs
@@ -976,6 +976,131 @@ async fn a_child_that_exits_before_binding_reports_its_status_and_stderr() {
     );
 }
 
+/// Why (#6601 review): capping the READ bounded memory but not the RING. A
+/// 1 MiB line arrived as 128 capped reads and was pushed as 128 entries, so it
+/// evicted all twenty slots and every real line before it. Measured on the
+/// pre-fix relay with this exact child: `entries=20 kept_real_line=false` — the
+/// lock diagnosis `a_child_that_exits_before_binding_reports_its_status_and_stderr`
+/// asserts on was gone, on the one code path #6600 exists to serve.
+///
+/// What: a real line, then an over-cap line, then a second real line. The two
+/// real lines must survive and the giant one must occupy exactly ONE slot.
+/// Test: this test itself.
+#[serial_test::serial]
+#[tokio::test]
+async fn a_real_line_survives_the_over_cap_line_that_follows_it() {
+    use super::child::{STDERR_LINE_CAP, STDERR_TAIL_LINES, relay_stderr_into};
+
+    const PADDING: usize = 1024 * 1024;
+    const DIAGNOSIS: &str = "Database already open. Cannot acquire lock.";
+
+    let mut child = Command::new("/bin/sh")
+        .arg("-c")
+        .arg(format!(
+            "echo '{DIAGNOSIS}' >&2; printf '%0{PADDING}d\\n' 0 >&2; echo 'after' >&2"
+        ))
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn the shouty child");
+    let pipe = child.stderr.take().expect("stderr was piped");
+
+    let (buffer, relay) = relay_stderr_into(pipe, tokio::io::sink());
+    relay.await.expect("the relay must finish at EOF");
+    child.wait().await.expect("reap the child");
+
+    let tail = buffer.tail(STDERR_TAIL_LINES);
+    assert_eq!(
+        tail.len(),
+        3,
+        "three logical lines were written; the ring must hold three, not one \
+         per capped read: {:?}",
+        tail.iter().map(|l| l.len()).collect::<Vec<_>>()
+    );
+    assert!(
+        tail[0].contains(DIAGNOSIS),
+        "the line written BEFORE the giant one must survive it, got {:?}",
+        tail[0]
+    );
+    assert!(
+        tail[1].ends_with("bytes truncated]"),
+        "the over-cap line must be retained once, marked, got {:?}",
+        &tail[1][tail[1].len().saturating_sub(40)..]
+    );
+    assert_eq!(tail[2], "after", "the line after it must survive too");
+    let longest = tail.iter().map(String::len).max().unwrap_or(0);
+    assert!(
+        longest as u64 <= STDERR_LINE_CAP,
+        "the marker must fit inside the cap, not extend past it; longest was \
+         {longest}"
+    );
+}
+
+/// Why (#6601 review): `ensure_running`'s doc promised a stderr tail with no
+/// caveat, and every test of the #6600 arms drove a SUPERVISED child. The one
+/// production consumer that matters is detached — `OnDemandAnalyze` — and a
+/// detached child keeps `Stdio::inherit()`, so its tail is structurally empty.
+/// Nothing asserted that, so a future change that started piping a detached
+/// child's stderr (reintroducing the EPIPE the inherit avoids) would have gone
+/// unnoticed here.
+///
+/// What: the same dying child as
+/// `a_child_that_exits_before_binding_reports_its_status_and_stderr`, spawned
+/// through a `with_detached(true)` config. The variant and the exit status must
+/// be identical; the tail must be EMPTY rather than absent-or-populated.
+/// Test: this test itself.
+#[serial_test::serial]
+#[tokio::test]
+async fn a_detached_child_that_exits_before_binding_reports_an_empty_tail() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let socket = tmp.path().join("dead-detached.sock");
+    let budget = Duration::from_secs(3);
+    let cfg = SupervisorConfig::new(
+        "test-service",
+        3,
+        ServiceTimeouts::new(budget, Duration::from_millis(10), Duration::from_secs(1)),
+    )
+    .with_detached(true);
+    let sup = UdsServiceSupervisor::new(cfg);
+
+    let started = std::time::Instant::now();
+    let err = sup
+        .ensure_running("inst", &socket, || {
+            Ok(SpawnSpec::new("/bin/sh")
+                .arg("-c")
+                .arg("echo 'Database already open. Cannot acquire lock.' >&2; exit 3"))
+        })
+        .await
+        .expect_err("a detached child that exited must not be reported as running");
+    let elapsed = started.elapsed();
+
+    match &err {
+        SupervisorError::ChildExited { status, stderr, .. } => {
+            assert_eq!(
+                status.code(),
+                Some(3),
+                "detaching must not cost the exit status"
+            );
+            assert!(
+                stderr.is_empty(),
+                "a detached child's stderr is inherited, so there is nothing to \
+                 quote; got {stderr:?}"
+            );
+        }
+        other => panic!("expected ChildExited, got {other:?}"),
+    }
+    assert!(
+        elapsed < budget / 3,
+        "the #6600 latency fix must hold for a detached child too: {elapsed:?}"
+    );
+    assert_eq!(
+        sup.supervised_count().await,
+        0,
+        "a detached child that never bound must not be registered"
+    );
+}
+
 /// Why (#6600 review): `STDERR_TAIL_LINES` bounds how MANY lines the relay
 /// retains and says nothing about how long one may be. A child that writes a
 /// megabyte before its first newline — a panic carrying a big `Debug` payload —

--- a/crates/trusty-memory/Cargo.toml
+++ b/crates/trusty-memory/Cargo.toml
@@ -22,7 +22,12 @@ name = "trusty-memory"
 # requirement here could not resolve. 0.25.4 was tagged but never published, so
 # this is the version that reaches crates.io. No public item was removed or
 # changed.
-version = "0.25.5"
+# 0.25.6 (#6600, #6601): patch — the BM25 exit flush is bounded by
+# `trusty_common::shutdown::CLEANUP_RESERVE` so a slow flush still lets the UDS
+# socket unlink run, and one stderr line takes one ring slot with a bounded exit
+# flush. Internal to `transport::uds` and `bm25_lane`; no public item was
+# removed or changed.
+version = "0.25.6"
 edition = "2021"
 description = "MCP server (stdio + Unix socket) for trusty-memory"
 license.workspace = true

--- a/crates/trusty-memory/changelog.d/6601-bound-the-bm25-exit-flush.md
+++ b/crates/trusty-memory/changelog.d/6601-bound-the-bm25-exit-flush.md
@@ -1,0 +1,13 @@
+Fixed
+
+- `transport::uds::serve_with_shutdown` awaits the BM25 exit flush under
+  `trusty_common::shutdown::CLEANUP_RESERVE` (#6601 review). The reserve is the
+  time `serve_until`'s drain holds back so the work after it can run, and
+  `bm25_lane::shutdown` claimed there was "no window in which a SIGKILL can land
+  mid-flush" — but `flush_all` takes the residency mutex and flushes every
+  resident palace with no deadline. A slow flush spent the whole reserve, the
+  socket unlink after it never ran, and the SIGKILL left behind the stale socket
+  file `bind_singleton_hardened` exists to work around.
+- An abandoned flush warns, naming the budget, and costs nothing a SIGKILL would
+  not have: `BM25Index::flush` renames a temp file into place, so every palace
+  keeps the snapshot its last coalescing tick published.

--- a/crates/trusty-memory/src/bm25_lane.rs
+++ b/crates/trusty-memory/src/bm25_lane.rs
@@ -366,11 +366,21 @@ impl Bm25Lane {
     ///
     /// Why: trusty-memory's normal exit is a SIGTERM from launchd or a ctrl-c.
     /// This is the in-process replacement for the supervisor's SIGTERM→reap
-    /// sequence, and it is strictly stronger: there is no signal to deliver, no
-    /// child to wait for, and no window in which a SIGKILL can land mid-flush.
+    /// sequence: there is no signal to deliver and no child to wait for.
+    ///
+    /// 🔴 **This is not itself bounded (#6601 review).** [`Self::flush_all`]
+    /// takes the residency mutex and flushes every resident palace with no
+    /// deadline, so the caller supplies one — `transport::uds::
+    /// serve_with_shutdown` awaits this under
+    /// `trusty_common::shutdown::CLEANUP_RESERVE` so the socket unlink after it
+    /// is still reached. An abandoned flush costs nothing beyond a SIGKILL
+    /// would: `BM25Index::flush` renames a temp file into
+    /// place, so every palace keeps the snapshot its last tick published.
+    ///
     /// What: flushes every resident index, then aborts the ticker. Idempotent —
     /// a second call flushes nothing and finds no ticker.
-    /// Test: `shutdown_flushes_and_is_idempotent`.
+    /// Test: `shutdown_flushes_and_is_idempotent`,
+    /// `an_exit_flush_that_overruns_the_reserve_is_abandoned`.
     pub async fn shutdown(&self) {
         self.flush_all().await;
         let handle = self.flusher.lock().take();

--- a/crates/trusty-memory/src/transport/uds.rs
+++ b/crates/trusty-memory/src/transport/uds.rs
@@ -490,7 +490,9 @@ pub async fn serve_with_shutdown(
     serve_until(&listener, Arc::clone(&router), serve_options(), shutdown).await;
 
     if let Some(lane) = bm25 {
-        lane.shutdown().await;
+        // #6601: bounded, so the unlink below is still reached — see
+        // `flush_within_reserve`.
+        flush_within_reserve(lane.shutdown(), trusty_common::shutdown::CLEANUP_RESERVE).await;
     }
 
     if let Err(e) = std::fs::remove_file(socket) {
@@ -498,6 +500,44 @@ pub async fn serve_with_shutdown(
     }
     drop(listener);
     Ok(())
+}
+
+/// Run the BM25 exit flush inside the window the cleanup reserve promises.
+///
+/// Why (#6601 review): [`trusty_common::shutdown::CLEANUP_RESERVE`] is the time
+/// `serve_until`'s drain holds back from the grace window SO THAT the work after
+/// the drain can run, and `bm25_lane::shutdown` states there is "no window in
+/// which a SIGKILL can land mid-flush". Nothing enforced either claim.
+/// `BM25Lane::flush_all` takes the residency mutex and flushes every resident
+/// palace with no deadline, so a slow flush spends the whole reserve, the socket
+/// unlink never runs, and the SIGKILL lands anyway — leaving behind the stale
+/// socket file `bind_singleton_hardened` exists to work around.
+///
+/// Cutting the flush short is the safe side of that trade, and letting it run is
+/// not. `BM25Index::flush` writes a `.json.tmp` and renames it, so an abandoned
+/// flush leaves the previous snapshot intact and loses only what the coalescing
+/// ticker had not yet published — precisely what a SIGKILL would have cost,
+/// except this way it is logged and the unlink still happens.
+///
+/// What: awaits `flush` under `budget`. Returns whether it completed; a timeout
+/// warns and names the budget.
+/// Test: `an_exit_flush_that_overruns_the_reserve_is_abandoned`,
+/// `a_prompt_exit_flush_is_not_cut_short`.
+#[cfg(feature = "daemon")]
+async fn flush_within_reserve<F>(flush: F, budget: std::time::Duration) -> bool
+where
+    F: std::future::Future<Output = ()>,
+{
+    if tokio::time::timeout(budget, flush).await.is_err() {
+        tracing::warn!(
+            budget_secs = budget.as_secs(),
+            "BM25 exit flush exceeded the shutdown cleanup reserve and was \
+             abandoned so the socket is still unlinked; palaces not yet flushed \
+             keep the snapshot their last ticker published"
+        );
+        return false;
+    }
+    true
 }
 
 /// Delete the `http_addr` files the TCP daemon used to write (#6286).

--- a/crates/trusty-memory/src/transport/uds_tests.rs
+++ b/crates/trusty-memory/src/transport/uds_tests.rs
@@ -1390,6 +1390,54 @@ fn seed_palace(state: &AppState, name: &str) -> String {
     id.0
 }
 
+/// Why (#6601 review): the reserve was documented as bounding this flush and
+/// nothing enforced it — `bm25_lane::shutdown` holds the residency mutex and
+/// flushes every resident palace with no deadline. An unbounded flush spends the
+/// whole reserve, so `serve_with_shutdown` never reaches its socket unlink and
+/// the SIGKILL leaves the stale socket file behind.
+///
+/// What: a flush that never completes must be abandoned at the budget, and the
+/// wait must be the budget rather than the flush.
+/// Test: this test itself.
+#[tokio::test]
+async fn an_exit_flush_that_overruns_the_reserve_is_abandoned() {
+    let budget = std::time::Duration::from_millis(120);
+    let started = std::time::Instant::now();
+
+    let completed = super::flush_within_reserve(std::future::pending::<()>(), budget).await;
+
+    assert!(!completed, "a flush that never finishes must report as cut");
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed >= budget,
+        "the flush must get its whole budget, not less: {elapsed:?}"
+    );
+    assert!(
+        elapsed < budget * 8,
+        "an overrunning flush must not hold the exit path open: {elapsed:?}"
+    );
+}
+
+/// Why (#6601 review): the bound must not become a delay. A flush that finishes
+/// promptly — the normal case, and the only one on a small palace set — has to
+/// return as soon as it is done, or every clean shutdown pays the reserve.
+/// What: a flush that completes immediately returns immediately and reports
+/// completion.
+/// Test: this test itself.
+#[tokio::test]
+async fn a_prompt_exit_flush_is_not_cut_short() {
+    let budget = std::time::Duration::from_secs(30);
+    let started = std::time::Instant::now();
+
+    let completed = super::flush_within_reserve(async {}, budget).await;
+
+    assert!(completed, "a flush that finished must report as finished");
+    assert!(
+        started.elapsed() < std::time::Duration::from_secs(1),
+        "the bound must not delay a flush that already returned"
+    );
+}
+
 /// Create a real palace on disk WITHOUT registering it in `state`'s registry.
 ///
 /// Why: `create_palace` registers the handle it opened, and `open_palace`

--- a/crates/trusty-search/changelog.d/6601-cleanup-reserve-moves-to-common.md
+++ b/crates/trusty-search/changelog.d/6601-cleanup-reserve-moves-to-common.md
@@ -1,0 +1,9 @@
+Changed
+
+- `service::shutdown_budget::CLEANUP_RESERVE` is now an alias of
+  `trusty_common::shutdown::CLEANUP_RESERVE`, and `ShutdownBudget` subtracts it
+  through `shutdown::plannable_grace_from` instead of doing the saturating
+  subtraction itself (#6601). The UDS serve loop reserves the same time from the
+  same window for the same reason, so the policy has one definition. No number
+  changes: the reserve is still 5 s and a window shorter than it still yields an
+  immediately-exhausted budget.

--- a/crates/trusty-search/src/service/shutdown_budget.rs
+++ b/crates/trusty-search/src/service/shutdown_budget.rs
@@ -38,16 +38,6 @@
 use std::path::Path;
 use std::time::{Duration, Instant};
 
-/// Wall-clock time held back from the flush for post-flush cleanup.
-///
-/// Why: `run_daemon` still has work to do after the sweep returns — remove the
-/// port file, remove `http_addr`, deregister shared discovery, release the
-/// lockfile, exit. Spending the entire window on flushing would hand SIGKILL the
-/// cleanup instead of the flush, trading one truncated step for another.
-/// What: 5 s, subtracted from the grace window when a budget is created.
-/// Test: `budget_reserves_time_for_post_flush_cleanup`.
-pub(crate) const CLEANUP_RESERVE: Duration = Duration::from_secs(5);
-
 /// How much of its life this process has left to spend on the shutdown flush.
 ///
 /// Why: see the module doc. The type exists so that "how long may this index
@@ -102,7 +92,10 @@ impl ShutdownBudget {
     /// one — the seam the tests drive.
     pub fn from_window_at(sigterm_at: Instant, window: Duration) -> Self {
         Self {
-            deadline: sigterm_at + window.saturating_sub(CLEANUP_RESERVE),
+            // #6601: the subtraction and its saturation live in
+            // `trusty_common::shutdown` so the UDS drain cannot get it right
+            // while this gets it wrong, or the reverse.
+            deadline: sigterm_at + trusty_common::shutdown::plannable_grace_from(window),
         }
     }
 

--- a/crates/trusty-search/src/service/shutdown_budget.rs
+++ b/crates/trusty-search/src/service/shutdown_budget.rs
@@ -38,6 +38,17 @@
 use std::path::Path;
 use std::time::{Duration, Instant};
 
+/// Wall-clock time held back from the grace window for the cleanup that runs
+/// after the flush — the port file, discovery deregistration, the lockfile.
+///
+/// An alias of [`trusty_common::shutdown::CLEANUP_RESERVE`], not a second
+/// number (#6601). `trusty_common::shutdown` owns the value AND the saturating
+/// subtraction ([`trusty_common::shutdown::plannable_grace_from`]), so this
+/// flush planner and the UDS serve loop's drain cannot reserve different
+/// amounts of the same window. The re-export is what lets this module's docs
+/// and `shutdown_budget_tests.rs` name it without repeating the path.
+pub use trusty_common::shutdown::CLEANUP_RESERVE;
+
 /// How much of its life this process has left to spend on the shutdown flush.
 ///
 /// Why: see the module doc. The type exists so that "how long may this index

--- a/crates/trusty-search/src/service/shutdown_budget_tests.rs
+++ b/crates/trusty-search/src/service/shutdown_budget_tests.rs
@@ -10,8 +10,10 @@
 
 use super::*;
 use crate::service::shutdown_flush::MIN_FLUSH_TIMEOUT_SECS;
+// `CLEANUP_RESERVE` arrives through `use super::*` above — the module
+// re-exports it (#6601 review), so this file exercises the alias rather than
+// reaching past it to `trusty_common`.
 use serial_test::serial;
-use trusty_common::shutdown::CLEANUP_RESERVE;
 
 /// A snapshot path that does not exist, so `shutdown_flush_deadline_for` returns
 /// exactly its floor (`MIN_FLUSH_TIMEOUT_SECS`) with no size scaling.

--- a/crates/trusty-search/src/service/shutdown_budget_tests.rs
+++ b/crates/trusty-search/src/service/shutdown_budget_tests.rs
@@ -11,6 +11,7 @@
 use super::*;
 use crate::service::shutdown_flush::MIN_FLUSH_TIMEOUT_SECS;
 use serial_test::serial;
+use trusty_common::shutdown::CLEANUP_RESERVE;
 
 /// A snapshot path that does not exist, so `shutdown_flush_deadline_for` returns
 /// exactly its floor (`MIN_FLUSH_TIMEOUT_SECS`) with no size scaling.

--- a/crates/trusty-search/src/service/shutdown_flush.rs
+++ b/crates/trusty-search/src/service/shutdown_flush.rs
@@ -532,8 +532,8 @@ mod tests {
     /// cleanup reserve. There is deliberately no constructor from a bare
     /// `Duration` — that is the whole point of the type.
     fn deadline_of(millis: u64) -> FlushDeadline {
-        let window = std::time::Duration::from_millis(millis)
-            + crate::service::shutdown_budget::CLEANUP_RESERVE;
+        let window =
+            std::time::Duration::from_millis(millis) + trusty_common::shutdown::CLEANUP_RESERVE;
         ShutdownBudget::from_window(window)
             .flush_deadline_for(std::path::Path::new("/nonexistent/hnsw.usearch"))
             .expect("a positive window grants a deadline")


### PR DESCRIPTION
Refs #6600
Refs #6601

## Summary
- #6600: `ensure_running` polled only the socket, so a child that died before binding surfaced as `SpawnTimeout` after the whole `spawn_probe` window (the #6595 CI signature). `wait_for_spawn` now polls socket-then-`try_wait` and returns `Bound | Exited(status) | TimedOut`; new `SupervisorError::ChildExited{status, stderr}`; supervised children's stderr is relayed line-by-line to the parent's stderr and into the existing 20-line `LogBuffer` (per-line cap 8 KiB, an over-cap line occupies one slot with a truncation marker); `SpawnTimeout` carries the tail too; detached children report status with an empty tail (documented and tested).
- #6601: the shutdown arm of `serve_until_idle` returned at once, so callers unlinked over in-flight handlers. `drain_shutdown` waits for open connections to reach zero under `RpcServeOptions::shutdown_drain`, refuses post-signal dials with an immediate close, and names the socket in its logs. Default drain = `plannable_grace()` = termination grace minus a shared `CLEANUP_RESERVE` (5 s, moved to `trusty_common::shutdown`; trusty-search's copy is now a re-export), so post-serve work keeps its budget; trusty-memory's BM25 exit flush is bounded by that reserve; trusty-analyze's `release_stores` wait collapsed into the shared loop, its drain inherits the default (no supervisor deadline binds a serving analyze child), and its 3 s `ANALYZE_SHUTDOWN_FLUSH` now documents what it actually bounds (the spawn-failure kill).

## Review
Two code-critic rounds (BLOCK → fixes → WARN → fixes): drain budget reserve, analyze constant coherence, discriminating refuse test, bounded stderr relay, rustdoc link, BM25 bound, detached coverage.

## Test ladder
Rung 5 (process lifecycle in a shared crate) with critic rounds.
- `cargo fmt --check`; clippy `-D warnings` on trusty-common (`--features uds-supervisor`), trusty-analyze, trusty-memory, trusty-search — exit 0; `cargo check --workspace` — exit 0; `cargo doc -p trusty-search --no-deps` — exit 0
- `cargo test -p trusty-common --features uds-supervisor --no-fail-fast` — 570 passed, 0 failed, 6 ignored (+7 targets)
- `cargo test -p trusty-analyze --no-fail-fast` — 513 (+24, 2, 5, 8, 2, 3) passed, 0 failed
- `cargo test -p trusty-memory --no-fail-fast` — 837 passed, 0 failed, 4 ignored; 31 targets
- `cargo test -p trusty-search --no-fail-fast` — 1959 passed, 0 failed, 1 ignored; 34 targets
- `cargo test -p trusty-mpm --no-fail-fast` — 5767 passed, 0 failed, 8 ignored; 54 targets
- `cargo test -p trusty-console --no-fail-fast` — 356 passed, 0 failed, 4 ignored; 6 targets
- Regression tests failing pre-fix: `a_child_that_exits_before_binding_reports_its_status_and_stderr`, `wait_for_spawn_reports_a_child_that_exited`, `shutdown_drains_an_in_flight_connection_before_it_returns`, `shutdown_refuses_a_connection_dialled_after_the_signal` (with the drain removed), `a_real_line_survives_the_over_cap_line_that_follows_it`, `serve_options_drain_for_as_long_as_this_server_may_actually_live`, `default_serve_options_reserve_cleanup_time_inside_the_grace_window`, `an_exit_flush_that_overruns_the_reserve_is_abandoned`
- `check_line_cap.sh`, `check_changelog_fragment.sh` (4 crates), `check_sld.sh`, `check_test_pointers.sh` (28720, 0 dangling), `check_teardown_guard.sh` — exit 0. `check_rustdoc_links.sh`: the trusty-search row is gone; 11 pre-existing red links in trusty-common `lib.rs:231` and trusty-mpm `session_manager/*` are untouched by this branch.
- Release note: `SupervisorError::SpawnTimeout` and `RpcServeOptions` gained fields — next trusty-common publish is a MINOR bump.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KsTGDrDYKBPmHmmbRsMm5w