### PR TITLE
fix(launchd): restart waits for the unload before bootstrapping; memory bridge never spawns onto a launchd-owned socket (Refs #6618, Refs #6619)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11798,7 +11798,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-installer"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-common/changelog.d/6618-await-unload-before-bootstrap.md
+++ b/crates/trusty-common/changelog.d/6618-await-unload-before-bootstrap.md
@@ -1,0 +1,14 @@
+Added
+
+- `launchd_restart` — `await_unload` polls a label out of launchd, and
+  `restart_sequence` orders a live bounce around that wait: quiesce, boot out,
+  wait, bootstrap, and one retry after a second wait. `launchctl bootout` returns
+  when the unload is ACCEPTED, not when the job is gone, so a bootstrap issued
+  immediately afterwards raced its own bootout and launchd refused it with
+  `Bootstrap failed: 5: Input/output error` (#6618). Every effect is injected, so
+  the ordering is asserted rather than described.
+- `LaunchdConfig::restart_gracefully` binds that sequence to the real
+  `launchctl`, the real SIGTERM, and a one-second clock. Its wait budget is
+  `shutdown::termination_grace()` — launchd cannot deregister a job before the
+  process it is terminating has gone, so a shorter budget would give up
+  mid-unload.

--- a/crates/trusty-common/changelog.d/6618-guard-short-grace-shared.md
+++ b/crates/trusty-common/changelog.d/6618-guard-short-grace-shared.md
@@ -1,0 +1,6 @@
+Changed
+
+- `LaunchdConfig::guard_short_grace` (the #6590 short-`ExitTimeOut` quiesce) is
+  crate-visible instead of private to `launchd_activate`. `restart_gracefully`
+  needs the same guard for the same reason — its bootout is bounded by the same
+  loaded `ExitTimeOut` — and calls this one rather than growing a second copy.

--- a/crates/trusty-common/changelog.d/6619-launchd-socket-claim.md
+++ b/crates/trusty-common/changelog.d/6619-launchd-socket-claim.md
@@ -1,0 +1,13 @@
+Added
+
+- `launchd_claim` — `socket_owner` decides whether a launchd unit owns the socket
+  an on-demand spawn is about to bind, and `launchd_socket_owner` reads the two
+  registration signals off the real launchd. `launchctl print` alone cannot
+  answer it: in the bootout/bootstrap window that loses the race the unit is
+  booted out and launchd reports nothing, so the INSTALLED PLIST counts as
+  registration too (#6619). Not macOS-gated, so cross-platform daemon guards call
+  it without a `cfg` split; off macOS it answers "no unit".
+- `launchd::plist_path_for_label` and `launchd::label_is_loaded` — the label-only
+  readers behind that check. `LaunchdConfig::plist_path` and
+  `LaunchdConfig::is_loaded` now delegate to them, so there is one spelling of
+  `~/Library/LaunchAgents/<label>.plist` and one `launchctl print`.

--- a/crates/trusty-common/src/launchd.rs
+++ b/crates/trusty-common/src/launchd.rs
@@ -264,11 +264,7 @@ impl LaunchdConfig {
     /// cannot be resolved.
     /// Test: `plist_path_layout`.
     pub fn plist_path(&self) -> Result<PathBuf> {
-        let home = dirs::home_dir().context("could not resolve home directory")?;
-        Ok(home
-            .join("Library")
-            .join("LaunchAgents")
-            .join(format!("{}.plist", self.label)))
+        plist_path_for_label(&self.label).context("could not resolve home directory")
     }
 
     /// Install the agent: write the plist and ensure the log directory exists.
@@ -341,12 +337,7 @@ impl LaunchdConfig {
     /// Test: side-effecting `launchctl` call; exercised manually (mirrors the
     /// `service status` subcommands' identical `launchctl print` check).
     pub fn is_loaded(&self) -> bool {
-        let target = format!("gui/{}/{}", current_uid(), self.label);
-        Command::new("launchctl")
-            .args(["print", &target])
-            .output()
-            .map(|o| o.status.success())
-            .unwrap_or(false)
+        label_is_loaded(&self.label)
     }
 
     /// Bootout (stop and unload) the agent via `launchctl`.
@@ -383,6 +374,46 @@ impl LaunchdConfig {
             stderr.trim()
         );
     }
+}
+
+/// Where launchd looks for the per-user agent named `label`.
+///
+/// Why (#6619): a caller that has only a label — the on-demand spawn guard
+/// asking whether a unit is installed for the socket it is about to bind — would
+/// otherwise assemble this path itself, and a second spelling of
+/// `~/Library/LaunchAgents/<label>.plist` is exactly the drift the
+/// common-entry-point rule exists to prevent.
+/// What: `~/Library/LaunchAgents/<label>.plist`. `None` when the home directory
+/// cannot be resolved. [`LaunchdConfig::plist_path`] is this over its own label.
+/// Test: `plist_path_layout` covers the layout through the method.
+#[must_use]
+pub fn plist_path_for_label(label: &str) -> Option<PathBuf> {
+    Some(
+        dirs::home_dir()?
+            .join("Library")
+            .join("LaunchAgents")
+            .join(format!("{label}.plist")),
+    )
+}
+
+/// Whether launchd currently has `label` loaded in the GUI domain.
+///
+/// Why (#6619): same reason as [`plist_path_for_label`] — a label-only caller
+/// must reach launchd through the one `launchctl print` this crate owns rather
+/// than spawning its own.
+/// What: runs `launchctl print gui/<uid>/<label>` and reports whether it exited
+/// successfully; launchctl exits non-zero for a label it does not have. Never
+/// errors — an inability to query reads as "not loaded", so callers fall back to
+/// their safe path. [`LaunchdConfig::is_loaded`] is this over its own label.
+/// Test: side-effecting `launchctl` call; exercised manually.
+#[must_use]
+pub fn label_is_loaded(label: &str) -> bool {
+    let target = format!("gui/{}/{label}", current_uid());
+    Command::new("launchctl")
+        .args(["print", &target])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
 }
 
 /// Return the current process's real user ID.

--- a/crates/trusty-common/src/launchd_activate.rs
+++ b/crates/trusty-common/src/launchd_activate.rs
@@ -417,9 +417,17 @@ impl LaunchdConfig {
     /// bootout that follows unloads an already-exited job. Advisory throughout:
     /// a quiesce that fails still falls through to the bootout, which is no
     /// worse than the behaviour this replaces.
+    ///
+    /// #6618: `tctl restart` needs this same guard for the same reason — its
+    /// bootout is bounded by the same loaded `ExitTimeOut` — so
+    /// [`crate::launchd_restart::restart_sequence`] calls THIS, rather than
+    /// growing a second copy. That is why it is crate-visible rather than
+    /// private to this module.
+    ///
     /// Test: the verdict and the wait are unit-tested in `launchd_grace`; the
-    /// wiring is exercised by `trusty-search service install`.
-    fn guard_short_grace(&self, required_secs: u64) {
+    /// wiring is exercised by `trusty-search service install` and `tctl
+    /// restart`.
+    pub(crate) fn guard_short_grace(&self, required_secs: u64) {
         use crate::launchd_grace::{GraceVerdict, Quiesce};
 
         let GraceVerdict::TooShort {

--- a/crates/trusty-common/src/launchd_claim.rs
+++ b/crates/trusty-common/src/launchd_claim.rs
@@ -1,0 +1,211 @@
+//! Whether a launchd unit owns the socket an on-demand spawn is about to bind
+//! (#6619).
+//!
+//! Why: a daemon's client bridges spawn it on demand when nothing answers its
+//! socket. That contract is correct on a dev machine and wrong on a supervised
+//! one: during a `launchctl bootout`/`bootstrap` window the socket is
+//! transiently unserved, a bridge read that as "nothing is running", and spawned
+//! an unsupervised daemon onto the PRODUCTION socket path — without the plist's
+//! `EnvironmentVariables`. launchd's own instance then found the path already
+//! held and exited 0 ("another instance is already running"), so launchd
+//! reported success while a misconfigured orphan owned the socket.
+//!
+//! The single-flight `flock` those bridges share (#5267/#6286) cannot see this:
+//! it coordinates bridges with each other, not with launchd.
+//!
+//! 🔴 **`launchctl print` alone cannot answer this question.** In the exact
+//! window that loses the race the unit is BOOTED OUT, so launchd reports nothing
+//! and a check that trusted it would permit the spawn it exists to stop. The
+//! installed plist is what persists across the window, so its presence counts as
+//! registration — see [`socket_owner`].
+//!
+//! What: [`socket_owner`] is the pure decision over the two registration
+//! signals; [`launchd_socket_owner`] reads them off the real launchd. A caller
+//! that is not on its canonical production path (a test socket, a
+//! `TRUSTY_DATA_DIR_OVERRIDE` sandbox) passes `is_supervised_path: false` and is
+//! never affected.
+//!
+//! Test: `cargo test -p trusty-common --features unconditional-only
+//! launchd_claim`.
+
+/// Who owns the socket an on-demand spawn is about to bind.
+///
+/// Why: the caller's two options are opposite — wait for launchd, or spawn —
+/// and the waiting branch has to name the unit it is waiting for, so the label
+/// travels with the verdict rather than being re-derived at the message site.
+/// What: [`Launchd`](Self::Launchd) carries the owning label;
+/// [`OnDemand`](Self::OnDemand) is the unsupervised case the bridge contract was
+/// written for.
+/// Test: `socket_owner_defers_to_a_loaded_unit`,
+/// `socket_owner_defers_while_the_unit_is_booted_out`,
+/// `socket_owner_leaves_an_unmanaged_host_alone`,
+/// `socket_owner_ignores_a_socket_launchd_does_not_serve`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SocketOwner {
+    /// A launchd unit is registered for this path. A spawn here would race it.
+    Launchd {
+        /// The unit's label, for the caller's message.
+        label: String,
+    },
+    /// Nothing supervises this path — an on-demand spawn is the caller's to
+    /// make, exactly as before.
+    OnDemand,
+}
+
+impl SocketOwner {
+    /// The owning label, when launchd owns the path.
+    #[must_use]
+    pub fn label(&self) -> Option<&str> {
+        match self {
+            SocketOwner::Launchd { label } => Some(label),
+            SocketOwner::OnDemand => None,
+        }
+    }
+
+    /// Whether an on-demand spawn must stand down.
+    #[must_use]
+    pub fn is_launchd(&self) -> bool {
+        matches!(self, SocketOwner::Launchd { .. })
+    }
+}
+
+/// Decide whether launchd owns this socket, from the two registration signals.
+///
+/// Why: kept pure and separate from the `launchctl` read, because the decision
+/// is what governs whether a daemon gets spawned onto a production socket — the
+/// thing that went wrong — and it must be testable without a registered unit.
+///
+/// What: launchd owns the path when the caller is on its canonical production
+/// socket AND either signal says a unit exists.
+///
+/// - `is_supervised_path` — the caller compares the socket it is about to serve
+///   against its own canonical production path. A socket under a `TempDir` or a
+///   `TRUSTY_DATA_DIR_OVERRIDE` sandbox is never launchd's, whatever is
+///   registered, so tests and dev sandboxes keep the old behaviour.
+/// - `unit_loaded` — `launchctl print gui/<uid>/<label>` answered.
+/// - `plist_present` — `~/Library/LaunchAgents/<label>.plist` exists.
+///
+/// 🔴 `plist_present` is not redundant with `unit_loaded`; it is the whole fix.
+/// The #6619 window is precisely the one where the unit is booted out and
+/// `unit_loaded` is false, and the plist file is what survives it. A host that
+/// has genuinely uninstalled the service has no plist, so it still reads
+/// [`SocketOwner::OnDemand`].
+///
+/// Test: `socket_owner_defers_to_a_loaded_unit`,
+/// `socket_owner_defers_while_the_unit_is_booted_out`,
+/// `socket_owner_leaves_an_unmanaged_host_alone`,
+/// `socket_owner_ignores_a_socket_launchd_does_not_serve`.
+#[must_use]
+pub fn socket_owner(
+    label: &str,
+    is_supervised_path: bool,
+    unit_loaded: bool,
+    plist_present: bool,
+) -> SocketOwner {
+    if is_supervised_path && (unit_loaded || plist_present) {
+        SocketOwner::Launchd {
+            label: label.to_owned(),
+        }
+    } else {
+        SocketOwner::OnDemand
+    }
+}
+
+/// [`socket_owner`] over the launchd registration this host actually has.
+///
+/// Why/What: binds the two signals to `launchctl print` and the installed plist.
+/// On every non-macOS platform launchd does not exist, which is a positive
+/// negative rather than an unanswered question, so the answer is
+/// [`SocketOwner::OnDemand`] and nothing changes for those callers.
+///
+/// Test: the decision is covered by `socket_owner_*`; the `launchctl` and
+/// filesystem reads are side-effecting and are exercised by trusty-memory's
+/// stdio bridge.
+#[must_use]
+pub fn launchd_socket_owner(label: &str, is_supervised_path: bool) -> SocketOwner {
+    #[cfg(target_os = "macos")]
+    {
+        socket_owner(
+            label,
+            is_supervised_path,
+            crate::launchd::label_is_loaded(label),
+            crate::launchd::plist_path_for_label(label).is_some_and(|p| p.exists()),
+        )
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = is_supervised_path;
+        socket_owner(label, false, false, false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The unit that lost the #6619 race.
+    const LABEL: &str = "com.trusty.memory";
+
+    /// Why: the ordinary supervised steady state — launchd has the unit loaded
+    /// and a bridge must never spawn a second daemon onto its socket.
+    /// What: a loaded unit on the production path yields the owning label.
+    /// Test: itself.
+    #[test]
+    fn socket_owner_defers_to_a_loaded_unit() {
+        let owner = socket_owner(LABEL, true, true, true);
+        assert_eq!(
+            owner,
+            SocketOwner::Launchd {
+                label: LABEL.to_owned()
+            }
+        );
+        assert_eq!(owner.label(), Some(LABEL));
+    }
+
+    /// Why (#6619): this IS the losing window. Between `bootout` and
+    /// `bootstrap` launchd reports nothing for the label, so a check that
+    /// trusted `launchctl print` alone would permit exactly the spawn that stole
+    /// the production socket. The plist on disk is what survives the window.
+    /// What: `unit_loaded: false` with the plist still installed still yields
+    /// [`SocketOwner::Launchd`].
+    /// Test: itself.
+    #[test]
+    fn socket_owner_defers_while_the_unit_is_booted_out() {
+        assert_eq!(
+            socket_owner(LABEL, true, false, true),
+            SocketOwner::Launchd {
+                label: LABEL.to_owned()
+            },
+            "a booted-out unit still owns its socket — it is coming back"
+        );
+    }
+
+    /// Why: a dev machine that never installed the service must keep the
+    /// on-demand spawn the bridge contract promises. Refusing there would break
+    /// every developer running `trusty-memory serve --stdio` locally.
+    /// What: neither signal set yields [`SocketOwner::OnDemand`].
+    /// Test: itself.
+    #[test]
+    fn socket_owner_leaves_an_unmanaged_host_alone() {
+        let owner = socket_owner(LABEL, true, false, false);
+        assert_eq!(owner, SocketOwner::OnDemand);
+        assert!(!owner.is_launchd());
+        assert_eq!(owner.label(), None);
+    }
+
+    /// Why: the guard is about ONE path — the canonical production socket. A
+    /// test socket under a `TempDir` is not launchd's even on a fully installed
+    /// host, and treating it as such would make the daemon's own test suite
+    /// refuse to start.
+    /// What: `is_supervised_path: false` yields [`SocketOwner::OnDemand`]
+    /// regardless of registration.
+    /// Test: itself.
+    #[test]
+    fn socket_owner_ignores_a_socket_launchd_does_not_serve() {
+        assert_eq!(
+            socket_owner(LABEL, false, true, true),
+            SocketOwner::OnDemand
+        );
+    }
+}

--- a/crates/trusty-common/src/launchd_restart.rs
+++ b/crates/trusty-common/src/launchd_restart.rs
@@ -1,0 +1,462 @@
+//! Wait for launchd to finish a bootout before bootstrapping again (#6618).
+//!
+//! Why: a live restart issued `bootout` and `bootstrap` back to back. launchd
+//! unloads a job ASYNCHRONOUSLY — `launchctl bootout` returns as soon as the
+//! request is accepted, not when the job is gone — so the bootstrap arrived
+//! while the previous instance was still registered and launchd refused it with
+//! `Bootstrap failed: 5: Input/output error`. The same command seconds later
+//! succeeded, which is what identifies the failure as a race rather than a bad
+//! plist or a disabled service.
+//!
+//! [`crate::launchd_activate`] already solved the other half of this window for
+//! `service install` (#6590): a unit whose loaded `ExitTimeOut` is shorter than
+//! the daemon's flush gets a directly-delivered SIGTERM first. The restart path
+//! predates that and reached neither guard, so this module orders BOTH around
+//! one sequence and both callers share it.
+//!
+//! What: [`await_unload`] polls until launchd stops reporting the label, and
+//! [`restart_sequence`] orders the whole bounce — quiesce, boot out, wait,
+//! bootstrap, and one retry after a second wait. Every effect is injected, so
+//! the ORDERING is what the tests assert, without a real unit.
+//! [`crate::launchd::LaunchdConfig::restart_gracefully`] binds the real
+//! `launchctl` calls, the real signal, and the real clock.
+//!
+//! Test: `cargo test -p trusty-common --features unconditional-only
+//! launchd_restart`.
+#![cfg(target_os = "macos")]
+
+use std::time::Duration;
+
+use crate::launchd::LaunchdConfig;
+
+/// What a bounded wait for launchd to unload a label observed.
+///
+/// Why: "the label went away" and "the budget ran out with it still there" lead
+/// to the same next action — attempt the bootstrap — but they must be
+/// distinguishable in the failure message, because only the second explains a
+/// bootstrap that fails again for the same reason it failed the first time.
+/// What: both arms carry the seconds waited, so a message never has to say
+/// "some time".
+/// Test: `await_unload_is_immediate_when_the_label_is_already_gone`,
+/// `await_unload_waits_for_the_label_to_disappear`,
+/// `await_unload_gives_up_at_the_budget`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Unload {
+    /// launchd no longer reports the label. A bootstrap now cannot race it.
+    Gone {
+        /// Seconds waited before the label was observed gone.
+        waited_secs: u64,
+    },
+    /// The label was still registered when the budget ran out.
+    StillLoaded {
+        /// Seconds waited — the whole budget.
+        waited_secs: u64,
+    },
+}
+
+impl Unload {
+    /// Seconds this wait spent, whichever way it ended.
+    #[must_use]
+    pub fn waited_secs(&self) -> u64 {
+        match self {
+            Unload::Gone { waited_secs } | Unload::StillLoaded { waited_secs } => *waited_secs,
+        }
+    }
+
+    /// Whether launchd had actually let go of the label.
+    #[must_use]
+    pub fn is_gone(&self) -> bool {
+        matches!(self, Unload::Gone { .. })
+    }
+
+    /// One phrase naming both the duration and the outcome, for a message.
+    fn phrase(&self) -> String {
+        match self {
+            Unload::Gone { waited_secs } => format!("{waited_secs}s (label gone)"),
+            Unload::StillLoaded { waited_secs } => {
+                format!("{waited_secs}s (label STILL registered)")
+            }
+        }
+    }
+}
+
+/// Poll until launchd stops reporting `is_loaded`, bounded by `budget_secs`.
+///
+/// Why: this is the wait the #6618 restart never performed. `launchctl bootout`
+/// reports that the unload was ACCEPTED; the job stays registered while launchd
+/// terminates it, and a bootstrap issued in that window is refused. Polling the
+/// same `launchctl print` the rest of this crate uses is the only observation of
+/// "actually gone" available.
+///
+/// What: probes once before waiting at all — the overwhelmingly common case is a
+/// job that has already unloaded, and that case must cost nothing. Then one
+/// probe per tick for at most `budget_secs`. Effects are injected: `is_loaded`
+/// is the probe and `tick` is the wait between probes.
+///
+/// # Postconditions
+///
+/// [`Unload::Gone`] means `is_loaded` answered `false`. A budget of `0` can only
+/// return `Gone { waited_secs: 0 }` or `StillLoaded { waited_secs: 0 }`.
+///
+/// Test: `await_unload_is_immediate_when_the_label_is_already_gone`,
+/// `await_unload_waits_for_the_label_to_disappear`,
+/// `await_unload_gives_up_at_the_budget`.
+pub fn await_unload(
+    budget_secs: u64,
+    mut is_loaded: impl FnMut() -> bool,
+    mut tick: impl FnMut(),
+) -> Unload {
+    if !is_loaded() {
+        return Unload::Gone { waited_secs: 0 };
+    }
+    for waited_secs in 1..=budget_secs {
+        tick();
+        if !is_loaded() {
+            return Unload::Gone { waited_secs };
+        }
+    }
+    Unload::StillLoaded {
+        waited_secs: budget_secs,
+    }
+}
+
+/// What a completed restart did, so the caller can report the wait it paid.
+///
+/// Why: an operator reading `tctl restart` output needs to see that the wait
+/// happened — a silent fix for a race is indistinguishable from the race not
+/// having occurred, and the two demand different follow-up when it recurs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct Restarted {
+    /// What the wait preceding the SUCCESSFUL bootstrap observed.
+    pub unload: Unload,
+    /// `launchctl bootstrap` calls it took: `1`, or `2` after the retry.
+    pub attempts: u32,
+}
+
+/// Order one launchd bounce so no step races the one before it.
+///
+/// Why: the ordering IS the fix. Quiescing after the bootout is useless (launchd
+/// has already begun the termination the quiesce exists to pre-empt), and
+/// bootstrapping before the wait is the #6618 defect verbatim. Injecting every
+/// effect is what lets that order be asserted rather than described.
+///
+/// What, in order: (1) `quiesce` — the #6590 guard, which stops the daemon
+/// directly when the LOADED unit's grace is too short for its flush; (2)
+/// `bootout`; (3) `await_unload`; (4) `bootstrap`. A bootstrap that still fails
+/// gets exactly one retry, and only after a SECOND wait — retrying immediately
+/// would repeat the losing race, which is what makes a bare retry the wrong fix.
+///
+/// # Preconditions
+///
+/// `bootout` must not be fail-open: its `Err` aborts before any bootstrap, so a
+/// unit that could not be stopped is never bootstrapped on top of itself.
+///
+/// # Errors
+///
+/// When `bootout` fails, or when both bootstrap attempts fail — the message then
+/// names the label and both waits.
+///
+/// Test: `restart_waits_for_the_unload_before_bootstrapping`,
+/// `restart_retries_the_bootstrap_once_after_a_second_wait`,
+/// `restart_error_names_the_label_and_the_waits`,
+/// `restart_does_not_bootstrap_when_the_bootout_fails`.
+pub fn restart_sequence(
+    label: &str,
+    quiesce: impl FnOnce(),
+    bootout: impl FnOnce() -> Result<(), String>,
+    mut await_unload: impl FnMut() -> Unload,
+    mut bootstrap: impl FnMut() -> Result<(), String>,
+) -> Result<Restarted, String> {
+    quiesce();
+    bootout()?;
+
+    let first_wait = await_unload();
+    let Err(first_error) = bootstrap() else {
+        return Ok(Restarted {
+            unload: first_wait,
+            attempts: 1,
+        });
+    };
+
+    // #6618: the retry is what the operator did by hand, but it only worked
+    // because seconds had passed. Waiting again before it is the difference
+    // between a retry and a second roll of the same dice.
+    let second_wait = await_unload();
+    match bootstrap() {
+        Ok(()) => Ok(Restarted {
+            unload: second_wait,
+            attempts: 2,
+        }),
+        Err(second_error) => Err(format!(
+            "restarting {label} failed: booted out successfully, then `launchctl \
+             bootstrap` failed twice. After waiting {} — {first_error}. After a \
+             further {} — {second_error}",
+            first_wait.phrase(),
+            second_wait.phrase()
+        )),
+    }
+}
+
+impl LaunchdConfig {
+    /// Bounce this unit, giving launchd time to finish the bootout (#6618).
+    ///
+    /// Why/What: see [`restart_sequence`] — this binds it to the real
+    /// `launchctl`, the real SIGTERM (through
+    /// [`crate::launchd_activate`]'s #6590 guard), and a one-second clock. The
+    /// wait budget is [`crate::shutdown::termination_grace`], the same window
+    /// the daemon plans its flush inside: launchd cannot deregister the job
+    /// before the process it is terminating has gone, so a shorter budget would
+    /// give up while the unload was still legitimately in progress.
+    ///
+    /// # Errors
+    ///
+    /// As [`restart_sequence`].
+    ///
+    /// Test: the ordering and the retry are unit-tested over the injected
+    /// sequence; the `launchctl` calls themselves are side-effecting and are
+    /// exercised by `tctl restart`.
+    pub fn restart_gracefully(&self) -> anyhow::Result<Restarted> {
+        let budget_secs = crate::shutdown::termination_grace().as_secs();
+        restart_sequence(
+            &self.label,
+            || self.guard_short_grace(budget_secs),
+            || self.bootout().map_err(|e| format!("{e:#}")),
+            || self.await_unload(budget_secs),
+            || self.bootstrap().map_err(|e| format!("{e:#}")),
+        )
+        .map_err(anyhow::Error::msg)
+    }
+
+    /// [`await_unload`] over this label's real `launchctl print` and clock.
+    fn await_unload(&self, budget_secs: u64) -> Unload {
+        await_unload(
+            budget_secs,
+            || self.is_loaded(),
+            || std::thread::sleep(Duration::from_secs(1)),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+
+    /// The label the observed #6618 failure named.
+    const LABEL: &str = "com.trusty.memory";
+
+    /// The refusal launchd actually returned when the bootstrap raced the
+    /// bootout.
+    const RACE_ERROR: &str = "launchctl bootstrap gui/502 \
+                              …/com.trusty.memory.plist failed: Bootstrap \
+                              failed: 5: Input/output error";
+
+    /// Records the order effects ran in, so ordering is asserted not described.
+    #[derive(Default)]
+    struct Steps(RefCell<Vec<&'static str>>);
+
+    impl Steps {
+        fn push(&self, step: &'static str) {
+            self.0.borrow_mut().push(step);
+        }
+        fn taken(&self) -> Vec<&'static str> {
+            self.0.borrow().clone()
+        }
+    }
+
+    /// Why (#6618): this is the defect. The pre-fix restart ran
+    /// `bootout` then `bootstrap` with nothing between them, so the bootstrap
+    /// reached launchd while the label was still registered. Asserting the step
+    /// ORDER — not merely that a wait exists somewhere — is what makes the test
+    /// fail against that sequence.
+    /// What: a clean restart records quiesce, bootout, the wait, and exactly one
+    /// bootstrap, in that order.
+    /// Test: itself.
+    #[test]
+    fn restart_waits_for_the_unload_before_bootstrapping() {
+        let steps = Steps::default();
+        let outcome = restart_sequence(
+            LABEL,
+            || steps.push("quiesce"),
+            || {
+                steps.push("bootout");
+                Ok(())
+            },
+            || {
+                steps.push("await_unload");
+                Unload::Gone { waited_secs: 3 }
+            },
+            || {
+                steps.push("bootstrap");
+                Ok(())
+            },
+        )
+        .expect("a clean bounce succeeds");
+
+        assert_eq!(
+            steps.taken(),
+            vec!["quiesce", "bootout", "await_unload", "bootstrap"],
+            "the bootstrap must not be issued until launchd has released the label"
+        );
+        assert_eq!(
+            outcome,
+            Restarted {
+                unload: Unload::Gone { waited_secs: 3 },
+                attempts: 1,
+            }
+        );
+    }
+
+    /// Why (#6618): the operator's manual remedy was a plain retry, and it
+    /// worked only because seconds had elapsed. A retry that skips the second
+    /// wait re-runs the losing race, so the wait between the two attempts is the
+    /// part under test.
+    /// What: a first bootstrap that fails is followed by a SECOND wait and then
+    /// a second bootstrap; the report says it took two attempts.
+    /// Test: itself.
+    #[test]
+    fn restart_retries_the_bootstrap_once_after_a_second_wait() {
+        let steps = Steps::default();
+        let attempts = RefCell::new(0_u32);
+        let outcome = restart_sequence(
+            LABEL,
+            || steps.push("quiesce"),
+            || {
+                steps.push("bootout");
+                Ok(())
+            },
+            || {
+                steps.push("await_unload");
+                Unload::Gone { waited_secs: 2 }
+            },
+            || {
+                steps.push("bootstrap");
+                *attempts.borrow_mut() += 1;
+                if *attempts.borrow() == 1 {
+                    Err(RACE_ERROR.to_owned())
+                } else {
+                    Ok(())
+                }
+            },
+        )
+        .expect("the retry recovers the observed race");
+
+        assert_eq!(
+            steps.taken(),
+            vec![
+                "quiesce",
+                "bootout",
+                "await_unload",
+                "bootstrap",
+                "await_unload",
+                "bootstrap"
+            ],
+            "the retry must wait for the unload again, not re-roll the same race"
+        );
+        assert_eq!(outcome.attempts, 2);
+    }
+
+    /// Why: an error that says only "bootstrap failed" leaves the operator
+    /// unable to tell a race from a broken plist — which is precisely the
+    /// confusion #6618 was filed out of.
+    /// What: both attempts failing yields a message carrying the label, both
+    /// waits, and both underlying errors.
+    /// Test: itself.
+    #[test]
+    fn restart_error_names_the_label_and_the_waits() {
+        let err = restart_sequence(
+            LABEL,
+            || {},
+            || Ok(()),
+            || Unload::StillLoaded { waited_secs: 60 },
+            || Err(RACE_ERROR.to_owned()),
+        )
+        .expect_err("two failed bootstraps are an error");
+
+        assert!(err.contains(LABEL), "the label must be named: {err}");
+        assert!(
+            err.contains("60s (label STILL registered)"),
+            "the wait and its outcome must be named: {err}"
+        );
+        assert!(
+            err.contains("Input/output error"),
+            "launchd's own reason must survive: {err}"
+        );
+    }
+
+    /// Why: a bootout that failed leaves the old instance running. Bootstrapping
+    /// on top of it is the #4230 two-daemons-one-port shape, so the failure must
+    /// abort the sequence rather than fall through.
+    /// What: an erroring bootout reaches neither the wait nor the bootstrap.
+    /// Test: itself.
+    #[test]
+    fn restart_does_not_bootstrap_when_the_bootout_fails() {
+        let steps = Steps::default();
+        let err = restart_sequence(
+            LABEL,
+            || steps.push("quiesce"),
+            || Err("launchctl bootout failed: Operation not permitted".to_owned()),
+            || {
+                steps.push("await_unload");
+                unreachable!("no wait after a bootout that failed")
+            },
+            || {
+                steps.push("bootstrap");
+                unreachable!("never bootstrap on top of a unit still running")
+            },
+        )
+        .expect_err("a failed bootout is an error");
+
+        assert!(err.contains("Operation not permitted"));
+        assert_eq!(steps.taken(), vec!["quiesce"]);
+    }
+
+    /// Why: the common case is a job that has already unloaded, and paying a
+    /// tick for it would add a second to every restart on every host.
+    /// What: an already-absent label returns immediately, having never ticked.
+    /// Test: itself.
+    #[test]
+    fn await_unload_is_immediate_when_the_label_is_already_gone() {
+        let outcome = await_unload(60, || false, || unreachable!("nothing to wait for"));
+        assert_eq!(outcome, Unload::Gone { waited_secs: 0 });
+        assert!(outcome.is_gone());
+    }
+
+    /// Why (#6618): the observed race resolved in seconds — the operator's
+    /// retry succeeded on the first try after a short pause. The wait must
+    /// therefore outlive a couple of ticks and stop as soon as the label goes,
+    /// rather than sleeping the whole budget.
+    /// What: a label present for three probes and gone on the fourth reports
+    /// three ticks, well inside a 60 s budget.
+    /// Test: itself.
+    #[test]
+    fn await_unload_waits_for_the_label_to_disappear() {
+        let probes = RefCell::new(0_u64);
+        let ticks = RefCell::new(0_u64);
+        let outcome = await_unload(
+            60,
+            || {
+                *probes.borrow_mut() += 1;
+                *probes.borrow() <= 3
+            },
+            || *ticks.borrow_mut() += 1,
+        );
+        assert_eq!(outcome, Unload::Gone { waited_secs: 3 });
+        assert_eq!(*ticks.borrow(), 3, "one probe per tick, no busy loop");
+    }
+
+    /// Why: a wedged unit must not stall `tctl restart` forever — the wait is
+    /// bounded, and the caller still attempts the bootstrap afterwards.
+    /// What: a label that never goes away consumes exactly the budget.
+    /// Test: itself.
+    #[test]
+    fn await_unload_gives_up_at_the_budget() {
+        let ticks = RefCell::new(0_u64);
+        let outcome = await_unload(4, || true, || *ticks.borrow_mut() += 1);
+        assert_eq!(outcome, Unload::StillLoaded { waited_secs: 4 });
+        assert!(!outcome.is_gone());
+        assert_eq!(*ticks.borrow(), 4);
+    }
+}

--- a/crates/trusty-common/src/lib.rs
+++ b/crates/trusty-common/src/lib.rs
@@ -259,6 +259,20 @@ pub mod launchd_grace;
 #[cfg(target_os = "macos")]
 pub mod launchd_restart;
 
+/// Whether a launchd unit owns the socket an on-demand spawn would bind
+/// (#6619).
+///
+/// Why: a client bridge that spawns its daemon when nothing answers the socket
+/// cannot see launchd. During a bootout/bootstrap window it read the transiently
+/// unserved socket as "nothing is running" and spawned an unsupervised daemon
+/// onto the production path without the plist's environment.
+/// What: [`launchd_claim::socket_owner`] decides from the registration signals,
+/// and [`launchd_claim::launchd_socket_owner`] reads them off the real launchd.
+/// Deliberately NOT macOS-gated, unlike [`launchd`], so cross-platform daemon
+/// guards call it without a `cfg` split — off macOS it answers "no unit".
+/// Test: `cargo test -p trusty-common --features unconditional-only launchd_claim`.
+pub mod launchd_claim;
+
 /// Canonical launchd labels for every trusty-* LaunchAgent (#4919).
 ///
 /// Why: each daemon crate, the installer's mirror table, the Makefiles, and

--- a/crates/trusty-common/src/lib.rs
+++ b/crates/trusty-common/src/lib.rs
@@ -244,6 +244,21 @@ pub mod launchd_activate;
 #[cfg(target_os = "macos")]
 pub mod launchd_grace;
 
+/// Bootout-completion waiting for a live launchd restart (#6618). macOS-only,
+/// like [`launchd`] itself.
+///
+/// Why: `launchctl bootout` returns when the unload is ACCEPTED, not when the
+/// job is gone. A restart that bootstraps immediately afterwards races its own
+/// bootout and launchd refuses it with `Bootstrap failed: 5: Input/output
+/// error`.
+/// What: [`launchd_restart::await_unload`] polls the label out of launchd, and
+/// [`launchd_restart::restart_sequence`] orders the whole bounce around that
+/// wait — reusing [`launchd_grace`]'s quiesce for the short-grace half of the
+/// same window.
+/// Test: `cargo test -p trusty-common --features unconditional-only launchd_restart`.
+#[cfg(target_os = "macos")]
+pub mod launchd_restart;
+
 /// Canonical launchd labels for every trusty-* LaunchAgent (#4919).
 ///
 /// Why: each daemon crate, the installer's mirror table, the Makefiles, and

--- a/crates/trusty-installer/Cargo.toml
+++ b/crates/trusty-installer/Cargo.toml
@@ -1,10 +1,8 @@
 [package]
 name = "trusty-installer"
-# 0.13.3 (#4847, #4917): patch — 0.13.2 is published and this PR edits
-# `src/**`. `stack doctor`/`stack health` gain an `undetermined` verdict and
-# exit 4, and `MemberDoctor::ok` narrows (an `unknown` member no longer passes);
-# `MemberDoctor::failed`/`undetermined` are additive. No signature changes.
-version = "0.13.3"
+# 0.13.4 (#6618, #6619): patch — 0.13.3 is published and this PR edits
+# `src/**` (launchd restart-race fix). No public API changes.
+version = "0.13.4"
 edition = "2021"
 description = "Thin control plane for the claude-mpm stack: install, upgrade, restart, health, and config coordination across all trusty-* tools."
 readme = "README.md"

--- a/crates/trusty-installer/changelog.d/6618-restart-waits-for-the-unload.md
+++ b/crates/trusty-installer/changelog.d/6618-restart-waits-for-the-unload.md
@@ -1,0 +1,16 @@
+Fixed
+
+- `tctl restart <service>` waits for launchd to finish the bootout before it
+  bootstraps. The Restart arm called `bootout()` then `bootstrap()` back to back;
+  because `launchctl bootout` returns when the unload is accepted rather than
+  when the job is gone, the bootstrap reached launchd with the label still
+  registered and was refused — `trusty-memory: booted out successfully;
+  bootstrap failed: … Bootstrap failed: 5: Input/output error` — while a plain
+  retry seconds later succeeded (#6618). It now routes through
+  `trusty_common::launchd::LaunchdConfig::restart_gracefully`, which quiesces a
+  unit whose loaded `ExitTimeOut` is shorter than the daemon's flush (the #6590
+  guard `service install` already ran), waits the label out of launchd, and
+  retries the bootstrap once after a second wait. A restart that still fails
+  names the label, both waits, and launchd's own reason.
+- The success line reports the wait it paid and how many bootstrap attempts it
+  took, so a race that recurs is visible instead of silently absorbed.

--- a/crates/trusty-installer/src/commands/bootstrap_sites_tests.rs
+++ b/crates/trusty-installer/src/commands/bootstrap_sites_tests.rs
@@ -51,9 +51,15 @@ const ALLOWLISTED_BOOTSTRAP_SITES: &[(&str, usize, &str)] = &[
     ),
     (
         "commands/lifecycle.rs",
-        2,
-        "`launchd_control`'s Start and Restart `cfg.bootstrap()` calls; both GATED by \
-         `port_guard::guard_bootstrap`, Restart's placed before its bootout",
+        1,
+        "`launchd_control`'s Start `cfg.bootstrap()`, GATED by \
+         `port_guard::guard_bootstrap`. Restart's own `cfg.bootstrap()` left this file \
+         in #6618: it now issues through `LaunchdConfig::restart_gracefully`, which \
+         waits the label out of launchd first. That arm still calls \
+         `port_guard::guard_bootstrap` before its bootout, so the #4470 gate is \
+         unchanged — but the bootstrap itself is now in `trusty-common` and this scan \
+         only reads `trusty-installer/src`, so a future ungated bootstrap added THERE \
+         is invisible here",
     ),
 ];
 

--- a/crates/trusty-installer/src/commands/lifecycle.rs
+++ b/crates/trusty-installer/src/commands/lifecycle.rs
@@ -12,10 +12,12 @@
 //!
 //! What: resolves members via `stable_set::select_members`, filters to daemons,
 //! confirms the blast radius (mirroring `install::run`), then applies the verb in
-//! topological order (start = forward, stop = reverse, restart = bootout then
-//! bootstrap per member). launchd members use the shared
-//! `trusty_common::launchd::LaunchdConfig` `bootout`/`bootstrap` (macOS-only);
-//! `OwnVerb` members shell out to their own subcommand.
+//! topological order (start = forward, stop = reverse, restart = bootout, wait
+//! for launchd to finish the unload, then bootstrap per member). launchd members
+//! use the shared `trusty_common::launchd::LaunchdConfig` `bootout`/`bootstrap`
+//! (macOS-only), and restart routes through `restart_gracefully` so the two are
+//! never issued back to back (#6618); `OwnVerb` members shell out to their own
+//! subcommand.
 //!
 //! Test: `tests` covers ordering, the report shaping/exit code, the blast-radius
 //! gate, and the `Action` verb-name mapping; the actual launchctl/subprocess
@@ -32,7 +34,7 @@ use crate::output::render_json;
 /// per-member apply) but differ in ordering and the underlying action; encoding
 /// the verb as an enum keeps one code path with three small branch points.
 /// What: `Start` (forward order, bring up), `Stop` (reverse order, take down),
-/// `Restart` (bootout then bootstrap per member).
+/// `Restart` (bootout, wait for the unload, then bootstrap per member — #6618).
 /// Test: `tests::ordering_is_directional`, `tests::verb_name`.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -414,14 +416,23 @@ fn launchd_control(verb: Verb, binary: &str) -> anyhow::Result<String> {
             // correctly supervised daemon holds its own port here, so this
             // check passes for the ordinary restart.
             super::port_guard::guard_bootstrap(binary).map_err(anyhow::Error::msg)?;
-            // Bootout first (stop); only then bootstrap (start). If bootstrap
-            // fails after a successful bootout, surface that the daemon WAS
-            // stopped — the operator is now in a stopped (not still-running)
-            // state, which changes their next action.
-            cfg.bootout()?;
-            cfg.bootstrap()
-                .map_err(|e| anyhow::anyhow!("booted out successfully; bootstrap failed: {e}"))?;
-            Ok(format!("restarted {}", cfg.label))
+            // #6618: this used to be `bootout()` then `bootstrap()` back to
+            // back. `launchctl bootout` returns when the unload is ACCEPTED,
+            // not when the job is gone, so the bootstrap reached launchd while
+            // the label was still registered and was refused with `Bootstrap
+            // failed: 5: Input/output error`. `restart_gracefully` waits the
+            // label out of launchd first, quiesces a unit whose loaded grace is
+            // too short for the daemon's flush (the #6590 guard `service
+            // install` already ran), and retries the bootstrap once after a
+            // second wait. Its error still says the daemon WAS stopped, which
+            // is the state change the operator's next action depends on.
+            let restarted = cfg.restart_gracefully()?;
+            Ok(format!(
+                "restarted {} (waited {}s for launchd to unload; {} bootstrap attempt(s))",
+                cfg.label,
+                restarted.unload.waited_secs(),
+                restarted.attempts
+            ))
         }
     }
 }

--- a/crates/trusty-memory/changelog.d/6619-no-unsupervised-spawn-onto-launchd-socket.md
+++ b/crates/trusty-memory/changelog.d/6619-no-unsupervised-spawn-onto-launchd-socket.md
@@ -1,0 +1,23 @@
+Fixed
+
+- The stdio bridge no longer spawns an unsupervised daemon onto the production
+  socket while launchd is restarting the unit. `ensure_daemon_running`'s
+  single-flight `flock` (#5267/#6286) coordinates bridges with each other and
+  cannot see launchd, so a bridge that probed during a `bootout`/`bootstrap`
+  window read the transiently unserved socket as "nothing is running" and started
+  its own daemon — without the plist's `FASTEMBED_CACHE_DIR` /
+  `FASTEMBED_CACHE_PATH` — on the path launchd's own instance wanted. launchd's
+  process then found the socket held and exited 0 ("another instance is already
+  running"), reporting success while a misconfigured orphan owned the socket
+  (#6619). The guard now asks whether a launchd unit owns the path and waits for
+  it, bounded by the termination grace, erroring with the unit's label instead of
+  spawning.
+- A daemon startup refuses the production socket outright when a launchd unit is
+  registered for it and launchd positively reports it does not run this process.
+  This is the callee-side half, and it holds for a daemon started by anything —
+  by hand, by a script, by an older bridge. It refuses only on a positive
+  `NotSupervised`: `Unknown` means launchd could not be asked, and refusing on
+  that would take the daemon down on every host with an unreadable `launchctl`.
+- Both guards apply only to the canonical production socket. A daemon under a
+  `TRUSTY_DATA_DIR_OVERRIDE` sandbox, or on a host that never installed the
+  service, keeps the on-demand spawn unchanged.

--- a/crates/trusty-memory/src/commands/daemon_guard.rs
+++ b/crates/trusty-memory/src/commands/daemon_guard.rs
@@ -21,14 +21,22 @@
 //! spawn time reopens the race: a second caller would acquire, re-probe a daemon
 //! that has not bound yet, and start another.
 //!
+//! #6619 adds the exclusion trusty-analyze still does not need: the spawn is
+//! also serialised against LAUNCHD, because the `flock` above coordinates
+//! bridges with each other and cannot see a supervised unit. See
+//! [`ensure_daemon_running`].
+//!
 //! Test: `probe_returns_false_for_an_absent_socket`,
-//! `ensure_daemon_running_returns_early_when_something_is_serving`.
+//! `ensure_daemon_running_returns_early_when_something_is_serving`,
+//! `ensure_daemon_running_defers_to_a_launchd_unit_instead_of_spawning`,
+//! `ensure_daemon_running_spawns_when_no_launchd_unit_owns_the_socket`.
 
 use std::path::Path;
 use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, Context as _, Result};
 use colored::Colorize;
+use trusty_common::launchd_claim::SocketOwner;
 use trusty_mcp::StartLock;
 
 /// How long a liveness connect may take before the path is called dead.
@@ -44,6 +52,71 @@ const STARTUP_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// How often to re-probe while waiting.
 const POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+/// How long to wait for a launchd-supervised daemon to come back (#6619).
+///
+/// Why: a `bootout`/`bootstrap` cycle leaves the socket unserved for a moment,
+/// and a bridge that waits it out gets the correctly-configured daemon launchd
+/// is bringing up. The bound matches
+/// `trusty_common::shutdown::TERMINATION_GRACE_SECS`, the window the outgoing
+/// daemon is allowed to spend exiting — waiting less would give up while the
+/// restart was still legitimately in progress.
+const LAUNCHD_RESTART_TIMEOUT: Duration =
+    Duration::from_secs(trusty_common::shutdown::TERMINATION_GRACE_SECS);
+
+/// Whether launchd owns the socket this guard is about to spawn onto (#6619).
+///
+/// Why: the answer turns on the socket, not just the host. A test or a
+/// `TRUSTY_DATA_DIR_OVERRIDE` sandbox resolves a different path, and a daemon
+/// launchd does not serve must keep the on-demand spawn.
+/// What: asks [`trusty_common::launchd_claim`] about `com.trusty.memory`, having
+/// first established whether `socket` IS this daemon's canonical production
+/// path.
+/// Test: the decision is covered by trusty-common's `socket_owner_*`; both
+/// branches of the caller by `ensure_daemon_running_defers_to_a_launchd_unit_\
+/// instead_of_spawning` and `ensure_daemon_running_spawns_when_no_launchd_unit_\
+/// owns_the_socket`.
+fn socket_owner_for(socket: &Path) -> SocketOwner {
+    trusty_common::launchd_claim::launchd_socket_owner(
+        trusty_common::launchd_labels::MEMORY,
+        super::single_instance::is_production_socket(socket),
+    )
+}
+
+/// Wait for a launchd-supervised daemon to serve `socket` again (#6619).
+///
+/// Why: launchd is bringing this daemon back with the plist's
+/// `EnvironmentVariables`. Spawning our own in the gap produces a daemon without
+/// them holding the path launchd's instance wants — which is the defect, and it
+/// reports as success on both sides.
+/// What: polls until something serves, bounded by `wait`. The error names the
+/// unit, so an operator knows to look at launchd rather than at this bridge.
+///
+/// # Errors
+///
+/// When nothing serves the socket within `wait`.
+async fn await_launchd_daemon(socket: &Path, label: &str, wait: Duration) -> Result<()> {
+    eprintln!(
+        "{} Waiting for launchd unit {label} to serve trusty-memory…",
+        "◉".cyan()
+    );
+    let deadline = Instant::now() + wait;
+    while Instant::now() < deadline {
+        tokio::time::sleep(POLL_INTERVAL).await;
+        if probe(socket).await {
+            return Ok(());
+        }
+    }
+    Err(anyhow!(
+        "launchd unit {label} owns {} but nothing served it within {}s. Not \
+         spawning an unsupervised daemon onto that path — it would start without \
+         the plist's environment and launchd's own instance would then exit 0 \
+         reporting success (#6619). Check `launchctl print gui/$(id -u)/{label}` \
+         and the daemon's launchd stderr log",
+        socket.display(),
+        wait.as_secs()
+    ))
+}
 
 /// Is anything serving `socket`?
 ///
@@ -86,6 +159,42 @@ fn spawn_daemon() -> Result<u32> {
 ///
 /// Test: `ensure_daemon_running_returns_early_when_something_is_serving`.
 pub async fn ensure_daemon_running(socket: &Path, lock_path: &Path) -> Result<()> {
+    ensure_daemon_running_with(
+        socket,
+        lock_path,
+        socket_owner_for(socket),
+        LAUNCHD_RESTART_TIMEOUT,
+        spawn_daemon,
+    )
+    .await
+}
+
+/// [`ensure_daemon_running`] with the launchd verdict, the wait, and the spawn
+/// supplied by the caller (#6619).
+///
+/// Why: the branch that must never be taken on a supervised host is the SPAWN,
+/// so proving it is not taken means being able to hand in a spawn that panics if
+/// called. Reading launchd and forking a real daemon are both untestable in
+/// process; injecting them is what makes the exclusion an assertion rather than
+/// a claim.
+///
+/// What: identical to [`ensure_daemon_running`] up to the point of spawning. A
+/// [`SocketOwner::Launchd`] verdict diverts to [`await_launchd_daemon`] and
+/// `spawn` is never called.
+///
+/// # Errors
+///
+/// As [`ensure_daemon_running`], plus the launchd-wait timeout.
+///
+/// Test: `ensure_daemon_running_defers_to_a_launchd_unit_instead_of_spawning`,
+/// `ensure_daemon_running_spawns_when_no_launchd_unit_owns_the_socket`.
+pub(crate) async fn ensure_daemon_running_with(
+    socket: &Path,
+    lock_path: &Path,
+    owner: SocketOwner,
+    launchd_wait: Duration,
+    spawn: impl FnOnce() -> Result<u32>,
+) -> Result<()> {
     if probe(socket).await {
         return Ok(());
     }
@@ -101,8 +210,16 @@ pub async fn ensure_daemon_running(socket: &Path, lock_path: &Path) -> Result<()
         return Ok(());
     }
 
+    // #6619: the lock above serialises this bridge against other bridges, never
+    // against launchd. An unserved socket during a bootout/bootstrap window is
+    // launchd's restart, not an absent daemon — wait for it rather than spawning
+    // an unsupervised one onto its path.
+    if let SocketOwner::Launchd { label } = &owner {
+        return await_launchd_daemon(socket, label, launchd_wait).await;
+    }
+
     eprintln!("{} Starting trusty-memory daemon…", "◉".cyan());
-    spawn_daemon()?;
+    spawn()?;
 
     let deadline = Instant::now() + STARTUP_TIMEOUT;
     while Instant::now() < deadline {
@@ -158,6 +275,73 @@ mod tests {
             started.elapsed() < Duration::from_secs(3),
             "the fast path must not wait: {:?}",
             started.elapsed()
+        );
+    }
+
+    /// Why (#6619): this is the defect. With `com.trusty.memory` between
+    /// `bootout` and `bootstrap` the socket is transiently unserved, and the
+    /// pre-fix guard read that as licence to spawn — producing an unsupervised
+    /// daemon on the production socket without the plist's
+    /// `FASTEMBED_CACHE_DIR`, after which launchd's own instance exited 0
+    /// reporting success. The spawn here panics if reached, so passing proves
+    /// the exclusion rather than describing it.
+    /// What: a `Launchd` verdict over a socket nothing serves waits, never
+    /// spawns, and errors naming the unit.
+    /// Test: itself.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn ensure_daemon_running_defers_to_a_launchd_unit_instead_of_spawning() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let err = ensure_daemon_running_with(
+            &tmp.path().join("absent.sock"),
+            &tmp.path().join("start.lock"),
+            SocketOwner::Launchd {
+                label: "com.trusty.memory".to_owned(),
+            },
+            Duration::from_millis(600),
+            || unreachable!("a launchd-owned socket must never be spawned onto"),
+        )
+        .await
+        .expect_err("a unit that never comes back is an error, not a spawn");
+
+        assert!(
+            err.to_string().contains("com.trusty.memory"),
+            "the owning unit must be named: {err}"
+        );
+    }
+
+    /// Why: the exclusion must not reach a dev machine that never installed the
+    /// service — the #5267 on-demand contract is the whole reason the bridge
+    /// works there.
+    /// What: an `OnDemand` verdict reaches the spawn, which stands a listener up
+    /// on the socket; the readiness wait then succeeds exactly as it does for a
+    /// real daemon.
+    /// Test: itself.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn ensure_daemon_running_spawns_when_no_launchd_unit_owns_the_socket() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let socket = tmp.path().join("sockets").join("trusty-memory.sock");
+        let spawned = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let flag = std::sync::Arc::clone(&spawned);
+        let bind_at = socket.clone();
+
+        ensure_daemon_running_with(
+            &socket,
+            &tmp.path().join("start.lock"),
+            SocketOwner::OnDemand,
+            Duration::from_millis(600),
+            move || {
+                flag.store(true, std::sync::atomic::Ordering::SeqCst);
+                let listener = trusty_common::uds::bind_hardened(&bind_at)?;
+                tokio::spawn(async move { while listener.accept().await.is_ok() {} });
+                Ok(4242)
+            },
+        )
+        .await
+        .expect("an unmanaged host spawns and the daemon comes up");
+
+        assert!(
+            spawned.load(std::sync::atomic::Ordering::SeqCst),
+            "an unmanaged host must still get its on-demand spawn"
         );
     }
 }

--- a/crates/trusty-memory/src/commands/single_instance.rs
+++ b/crates/trusty-memory/src/commands/single_instance.rs
@@ -77,6 +77,82 @@ pub fn startup_action_from_probe_result(probe_ok: bool) -> StartupAction {
     }
 }
 
+/// Whether `socket` is the path a launchd-managed trusty-memory would serve
+/// (#6619).
+///
+/// Why: every #6619 guard turns on this one question, and getting it wrong in
+/// either direction is a bug — too broad refuses a sandboxed daemon that launchd
+/// never managed, too narrow lets the orphan back onto the production path. One
+/// definition, used by both the caller-side spawn guard and the callee-side bind
+/// refusal.
+/// What: `socket` must be what [`crate::socket_path`] resolves AND the process
+/// must not be running under a `TRUSTY_DATA_DIR_OVERRIDE` sandbox — the plist
+/// sets no such override, so a process that has one is by construction not the
+/// unit launchd runs.
+/// Test: `production_socket_is_the_resolved_path`,
+/// `production_socket_is_false_under_a_data_dir_override`.
+#[must_use]
+pub fn is_production_socket(socket: &Path) -> bool {
+    if std::env::var_os(trusty_common::DATA_DIR_OVERRIDE_ENV).is_some() {
+        return false;
+    }
+    crate::socket_path().is_ok_and(|p| p == socket)
+}
+
+/// Refuse the production socket when this process is not the launchd unit that
+/// owns it (#6619).
+///
+/// Why: the spawn guard stops a bridge from racing launchd, but only a bridge
+/// that runs the fixed code. This is the callee-side half, and it is the one
+/// that holds for a daemon started any other way — by hand, by an older bridge,
+/// by a script. Binding the production socket unsupervised is what left an
+/// orphan without the plist's `FASTEMBED_CACHE_DIR` owning the path while
+/// launchd's own instance exited 0 reporting success.
+///
+/// What: three inputs, and the refusal needs all three.
+///
+/// - `is_production_socket` — a test or sandbox socket is never launchd's.
+/// - `unit_registered` — [`trusty_common::launchd_claim`]'s verdict.
+/// - `launchd_runs_us` — a POSITIVE answer from launchd that it does NOT run
+///   this PID (`LaunchdSupervision::NotSupervised`), never
+///   [`trusty_common::supervision::LaunchdSupervision::Unknown`].
+///
+/// 🔴 The `Unknown` exclusion is deliberate and is the difference between a
+/// guard and an outage. Both signals here read launchd, so a host where
+/// `launchctl` cannot be queried would report "unit registered" from the plist
+/// on disk and "not supervised" from a failed query — and refuse to start the
+/// launchd-supervised daemon on every boot. Refusing only on a positive
+/// `NotSupervised` fails closed against the observed defect (an unsupervised
+/// spawn on a healthy host) and open against an unreadable launchd.
+///
+/// Test: `bind_refused_for_an_unsupervised_process_on_a_registered_socket`,
+/// `bind_permitted_for_the_launchd_unit_itself`,
+/// `bind_permitted_when_no_unit_is_registered`,
+/// `bind_permitted_on_a_socket_launchd_does_not_own`,
+/// `bind_permitted_when_launchd_cannot_be_asked`.
+#[must_use]
+pub fn production_bind_refusal(
+    label: &str,
+    is_production_socket: bool,
+    unit_registered: bool,
+    supervision: &trusty_common::supervision::LaunchdSupervision,
+) -> Option<String> {
+    use trusty_common::supervision::LaunchdSupervision;
+
+    let positively_unsupervised = matches!(supervision, LaunchdSupervision::NotSupervised);
+    if !(is_production_socket && unit_registered && positively_unsupervised) {
+        return None;
+    }
+    Some(format!(
+        "refusing to bind the trusty-memory production socket: launchd unit \
+         {label} is registered for it and launchd does not run this process. An \
+         unsupervised daemon here starts without the plist's EnvironmentVariables \
+         and launchd's own instance then exits 0 reporting success (#6619). Start \
+         it with `launchctl kickstart -k gui/$(id -u)/{label}`, or point this \
+         process at a different socket"
+    ))
+}
+
 /// Perform the single-instance check at daemon startup.
 ///
 /// Why: launchd respawns any non-zero exit, so a second instance that fails to
@@ -184,6 +260,138 @@ mod tests {
             single_instance_check(&socket).await,
             StartupAction::ExitAlreadyRunning,
             "a live socket must stop a second instance from binding"
+        );
+    }
+
+    use trusty_common::supervision::LaunchdSupervision;
+
+    /// The unit that owns the production socket.
+    const LABEL: &str = "com.trusty.memory";
+
+    /// Why (#6619): the observed orphan. A bridge-spawned daemon bound the
+    /// production socket while `com.trusty.memory` was mid-restart, without the
+    /// plist's `FASTEMBED_CACHE_DIR`, and launchd's own instance then exited 0
+    /// reporting success. The callee-side refusal is what holds even for a
+    /// daemon started by something this fix did not change.
+    /// What: production socket + registered unit + a positive "launchd does not
+    /// run this PID" refuses, naming the unit.
+    /// Test: itself.
+    #[test]
+    fn bind_refused_for_an_unsupervised_process_on_a_registered_socket() {
+        let refusal =
+            production_bind_refusal(LABEL, true, true, &LaunchdSupervision::NotSupervised)
+                .expect("an unsupervised bind of a registered socket must be refused");
+        assert!(refusal.contains(LABEL), "the unit must be named: {refusal}");
+    }
+
+    /// Why: the unit launchd runs IS the legitimate owner. Refusing it would
+    /// stop trusty-memory starting on every supervised host — an outage caused
+    /// by the guard.
+    /// What: a `Supervised` answer permits the bind.
+    /// Test: itself.
+    #[test]
+    fn bind_permitted_for_the_launchd_unit_itself() {
+        assert_eq!(
+            production_bind_refusal(
+                LABEL,
+                true,
+                true,
+                &LaunchdSupervision::Supervised(LABEL.to_owned())
+            ),
+            None
+        );
+    }
+
+    /// Why: a dev machine that never installed the service must keep starting
+    /// the daemon by hand.
+    /// What: no registered unit permits the bind.
+    /// Test: itself.
+    #[test]
+    fn bind_permitted_when_no_unit_is_registered() {
+        assert_eq!(
+            production_bind_refusal(LABEL, true, false, &LaunchdSupervision::NotSupervised),
+            None
+        );
+    }
+
+    /// Why: a sandboxed daemon under `TRUSTY_DATA_DIR_OVERRIDE` serves a path
+    /// launchd never manages, so the guard must not reach it — this is what
+    /// keeps the crate's own test daemons startable on an installed host.
+    /// What: a non-production socket permits the bind even with a unit
+    /// registered.
+    /// Test: itself.
+    #[test]
+    fn bind_permitted_on_a_socket_launchd_does_not_own() {
+        assert_eq!(
+            production_bind_refusal(LABEL, false, true, &LaunchdSupervision::NotSupervised),
+            None
+        );
+    }
+
+    /// Why: `Unknown` means launchd could not be ASKED, and both of this
+    /// guard's other signals read launchd too. Refusing on it would take the
+    /// daemon down on every host whose `launchctl list` is unreadable — trading
+    /// an orphan for an outage.
+    /// What: `Unknown` permits, unlike `NotSupervised`.
+    /// Test: itself.
+    #[test]
+    fn bind_permitted_when_launchd_cannot_be_asked() {
+        assert_eq!(
+            production_bind_refusal(
+                LABEL,
+                true,
+                true,
+                &LaunchdSupervision::Unknown("launchctl timed out".to_owned())
+            ),
+            None,
+            "an unanswerable launchd is not evidence of an orphan"
+        );
+    }
+
+    /// Why: every #6619 guard turns on this predicate, so the path it accepts
+    /// must be the one the daemon actually resolves — not a re-derived guess.
+    /// What: the resolved socket is production; a sibling path is not.
+    /// Test: itself.
+    #[test]
+    fn production_socket_is_the_resolved_path() {
+        let Ok(resolved) = crate::socket_path() else {
+            return; // no home directory in this environment; nothing to assert
+        };
+        if std::env::var_os(trusty_common::DATA_DIR_OVERRIDE_ENV).is_some() {
+            return; // a sibling test set the override; covered below instead
+        }
+        assert!(is_production_socket(&resolved));
+        assert!(!is_production_socket(Path::new("/tmp/not-the-daemon.sock")));
+    }
+
+    /// Why: a `TRUSTY_DATA_DIR_OVERRIDE` sandbox is by construction not the unit
+    /// launchd runs — the plist sets no override — so the guard must not reach
+    /// it whatever launchd has registered.
+    /// What: with the override set, even the resolved socket is not production.
+    /// Test: itself.
+    #[test]
+    #[serial_test::serial]
+    fn production_socket_is_false_under_a_data_dir_override() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let previous = std::env::var_os(trusty_common::DATA_DIR_OVERRIDE_ENV);
+        // SAFETY: serialised by `#[serial]`; no concurrent env access here.
+        unsafe { std::env::set_var(trusty_common::DATA_DIR_OVERRIDE_ENV, tmp.path()) };
+
+        let resolved = crate::socket_path();
+        let verdict = resolved.as_ref().map(|p| is_production_socket(p));
+
+        // SAFETY: same as above.
+        unsafe {
+            match previous {
+                Some(v) => std::env::set_var(trusty_common::DATA_DIR_OVERRIDE_ENV, v),
+                None => std::env::remove_var(trusty_common::DATA_DIR_OVERRIDE_ENV),
+            }
+        }
+
+        assert_eq!(
+            verdict.ok(),
+            Some(false),
+            "a sandboxed socket is never launchd's production path"
         );
     }
 }

--- a/crates/trusty-memory/src/main.rs
+++ b/crates/trusty-memory/src/main.rs
@@ -1004,6 +1004,25 @@ async fn run_serve(
                 anyhow::bail!("single-instance check failed unexpectedly: {msg}");
             }
         }
+
+        // #6619: the guard above answers "is someone serving?", which is blind
+        // to the bootout/bootstrap window — nothing serves the socket then, and
+        // an unsupervised process bound it and kept it. Refuse the production
+        // socket outright when a launchd unit owns it and launchd positively
+        // reports it does not run us.
+        let production = si::is_production_socket(&socket);
+        let owner = trusty_common::launchd_claim::launchd_socket_owner(
+            trusty_common::launchd_labels::MEMORY,
+            production,
+        );
+        if let Some(refusal) = si::production_bind_refusal(
+            trusty_common::launchd_labels::MEMORY,
+            production,
+            owner.is_launchd(),
+            &trusty_common::supervision::launchd_supervision(),
+        ) {
+            anyhow::bail!(refusal);
+        }
     }
 
     // Resolve the standard data dir, then descend into `palaces/` if that


### PR DESCRIPTION
Refs #6618, Refs #6619.

#6618: `launchctl bootout` returns when the unload is accepted, not when the job is gone. `tctl`'s Restart arm issued `bootstrap` immediately after and launchd refused it with `Bootstrap failed: 5: Input/output error`. New `trusty_common::launchd_restart`: quiesce (the #6590 `guard_short_grace`, now shared) → bootout → `await_unload` polls the label out → bootstrap, with one retry after a second wait. `tctl` calls `LaunchdConfig::restart_gracefully`. The bootstrap-site allowlist in trusty-installer drops from 2 to 1 for `lifecycle.rs`, with the reason recorded that the second site now lives in trusty-common.

#6619: trusty-memory's single-flight flock coordinates bridges with each other, never with launchd, so in the bootout/bootstrap window a bridge spawned an unsupervised daemon onto the production socket. `launchctl print` cannot answer ownership in that window, so the installed plist counts as registration. New `trusty_common::launchd_claim`: the caller waits for the unit (bounded by the termination grace) and errors naming the label; the callee refuses the production socket only when launchd positively reports it does not run this process (`Unknown` permits). A `TRUSTY_DATA_DIR_OVERRIDE` sandbox is never the canonical socket.

Test ladder: rung 4 (shared library trusty-common plus two consumers).
Regression tests that failed before the fix: `launchd_restart::tests::restart_waits_for_the_unload_before_bootstrapping` (sequence `["bootout","bootstrap"]` on origin/main); `ensure_daemon_running_defers_to_a_launchd_unit_instead_of_spawning` (hit `unreachable!` on origin/main).

cargo fmt --check: exit 0
cargo clippy --all-targets -- -D warnings: exit 0 on trusty-common, trusty-installer, trusty-memory
cargo check --workspace --all-targets: exit 0
cargo test -p trusty-common --features unconditional-only --no-fail-fast: 427 passed, 0 failed, 6 ignored (+4 targets)
cargo test -p trusty-memory --no-fail-fast: 846 passed, 0 failed, 4 ignored (+25 targets)
cargo test -p trusty-installer --no-fail-fast: 696 passed, 0 failed, 4 ignored (+2 targets)
cargo test -p trusty-console --no-fail-fast: 6 targets ok
check_line_cap.sh 0 violations; check_sld.sh 0 errors; check_test_pointers.sh 0 dangling; check_teardown_guard.sh OK; check_changelog_fragment.sh 3 crates recorded

Follow-up: trusty-analyze's `daemon_guard` has the same shape and is tracked separately.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KsTGDrDYKBPmHmmbRsMm5w
