### PR TITLE
ci: install the .NET SDK so trusty-analyze's C# adapter path runs in CI (Refs #1008)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,11 @@
 #   fmt      – cargo fmt --all --check (stable)
 #   clippy   – cargo clippy --workspace --all-targets -D warnings (stable, SKIP_UI_BUILD=1)
 #   test-shard – cargo nextest run --workspace, split 8 ways (stable,
-#              SKIP_UI_BUILD=1, full clone for git tests). PUSH TO MAIN AND
-#              workflow_dispatch ONLY — it does not run on pull requests; see
-#              that job's `if:` for why and for how to run it on a branch.
+#              SKIP_UI_BUILD=1, full clone for git tests, .NET SDK installed
+#              for trusty-analyze's C# Roslyn adapter tests, #1008). PUSH TO
+#              MAIN AND workflow_dispatch ONLY — it does not run on pull
+#              requests; see that job's `if:` for why and for how to run it
+#              on a branch.
 #   test-doc – cargo test --doc, on its own runner (nextest has no doctest
 #              harness, so the shards cannot run them). Same trigger scope as
 #              test-shard.
@@ -584,6 +586,23 @@ jobs:
             build-essential \
             pkg-config \
             libssl-dev
+
+      # #1008: trusty-analyze's `RoslynTool` (crates/trusty-analyze/src/core/
+      # tool_impls/csharp/mod.rs) shells out to `dotnet build` to produce SARIF
+      # diagnostics, but no job installed the .NET SDK, so
+      # tests/csharp_roslyn_integration.rs's real-build path — the only test
+      # that exercises that spawn rather than a captured SARIF fixture — was
+      # never covered. This is the only job in this workflow that actually
+      # EXECUTES trusty-analyze's tests (`test-shard` runs on push to `main` /
+      # `workflow_dispatch`, not on pull requests — see this job's own `if:`
+      # above); the PR-time `clippy` job only compiles `--all-targets` and
+      # needs no dotnet SDK to do that. 8.0.x matches the fixture project's
+      # `net8.0` TargetFramework in testdata/csharp/Fixture.csproj.
+      - name: Install .NET SDK (for trusty-analyze's C# Roslyn adapter tests)
+        if: needs.changes.outputs.docs_only != 'true'
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
 
       # The official prebuilt binary (get.nexte.st) rather than `cargo install
       # cargo-nextest`, which would compile the tool itself on every runner and

--- a/crates/trusty-analyze/testdata/csharp/.gitignore
+++ b/crates/trusty-analyze/testdata/csharp/.gitignore
@@ -1,0 +1,5 @@
+# dotnet build/restore output for the Fixture.csproj integration fixture
+# (#1008) — build_project_diags() runs `dotnet build`/`dotnet restore` with
+# this directory as its cwd, so a local test run leaves these here.
+bin/
+obj/

--- a/crates/trusty-analyze/testdata/csharp/Fixture.cs
+++ b/crates/trusty-analyze/testdata/csharp/Fixture.cs
@@ -1,0 +1,13 @@
+// Fixture for tests/csharp_roslyn_integration.rs (#1008).
+//
+// Deliberately fails to compile with CS0029 (cannot implicitly convert
+// string to int) — a plain compiler error, not an optional analyzer rule, so
+// the diagnostic is guaranteed regardless of which .NET SDK analyzer
+// packages happen to be installed on the CI runner.
+public class Fixture
+{
+    public static void Broken()
+    {
+        int mismatch = "not an int";
+    }
+}

--- a/crates/trusty-analyze/testdata/csharp/Fixture.csproj
+++ b/crates/trusty-analyze/testdata/csharp/Fixture.csproj
@@ -1,0 +1,21 @@
+<!--
+  Minimal fixture project for tests/csharp_roslyn_integration.rs (#1008).
+
+  Why: RoslynTool::run_project requires a real .csproj — `dotnet build`
+  operates at the project level, not the single-file level — so proving the
+  real dispatch path needs an on-disk project, not a synthetic string.
+  What: a bare net8.0 class-library project with no external package
+  references, so `dotnet restore` needs no network access even on a cold
+  NuGet cache. Fixture.cs deliberately fails to compile (a type mismatch) so
+  the test has a diagnostic guaranteed to appear regardless of which
+  analyzer packages ship with the installed SDK.
+-->
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/crates/trusty-analyze/tests/csharp_roslyn_integration.rs
+++ b/crates/trusty-analyze/tests/csharp_roslyn_integration.rs
@@ -1,0 +1,69 @@
+//! `RoslynTool` end-to-end against a real `dotnet build` (#1008).
+//!
+//! Why: `RoslynTool::run`/`run_project` compile- and unit-test clean without
+//! the .NET SDK (the SARIF *parser* is fixture-tested in
+//! `core::tool_impls::csharp::sarif`), but nothing exercised the real
+//! `dotnet build --no-restore --no-incremental -p:ErrorLog=...` spawn before
+//! this file: no CI workflow installed the SDK, so a regression in that
+//! invocation, the temp-file SARIF plumbing, or the file-matching filter
+//! could land with every unit test green.
+//! What: builds `testdata/csharp/Fixture.csproj` (a project with a
+//! deliberate `CS0029` type-mismatch error) through the real `RoslynTool` and
+//! asserts an `Error`-severity diagnostic comes back. When `dotnet` is
+//! missing this fails loudly under `CI=true` instead of silently skipping,
+//! so the coverage this issue restores cannot silently lapse again; a local,
+//! non-CI run without the SDK skips with a printed reason.
+//! Test: this file — `roslyn_tool_reports_real_build_error`.
+
+use std::path::PathBuf;
+
+use trusty_analyze::core::tool_impls::RoslynTool;
+use trusty_analyze::core::tools::{Severity, StaticTool};
+
+fn fixture_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("testdata/csharp")
+}
+
+#[test]
+fn roslyn_tool_reports_real_build_error() {
+    if which::which("dotnet").is_err() {
+        // #1008: a missing SDK under CI=true means the CI job forgot
+        // actions/setup-dotnet — fail loudly rather than let this coverage
+        // silently lapse again. Outside CI (a developer machine without the
+        // SDK), skip with a printed reason instead.
+        let running_in_ci = std::env::var("CI").as_deref() == Ok("true");
+        assert!(
+            !running_in_ci,
+            "dotnet SDK not found on PATH under CI=true — the C# adapter's \
+             real dispatch path (#1008) would go uncovered again; install \
+             actions/setup-dotnet in the job that runs this test"
+        );
+        eprintln!(
+            "roslyn_tool_reports_real_build_error: dotnet SDK not found on PATH; \
+             skipping (local, non-CI run)"
+        );
+        return;
+    }
+
+    let cs_file = fixture_dir().join("Fixture.cs");
+    assert!(
+        cs_file.exists(),
+        "fixture file missing: {}",
+        cs_file.display()
+    );
+
+    let diags = RoslynTool
+        .run_project(&[cs_file], None)
+        .expect("run_project must not error");
+
+    assert!(
+        !diags.is_empty(),
+        "expected at least one Roslyn diagnostic from the intentional \
+         CS0029 type error in Fixture.cs, got none — the real dotnet build \
+         path produced no SARIF output"
+    );
+    assert!(
+        diags.iter().any(|d| d.severity == Severity::Error),
+        "expected at least one Error-severity diagnostic, got: {diags:?}"
+    );
+}


### PR DESCRIPTION
Refs #1008.

`RoslynTool` shells out to `dotnet build` and no workflow installed the SDK, so the C# adapter's real dispatch path had zero CI coverage; only the SARIF parser was tested against a captured string.

Change: `actions/setup-dotnet@v4` (8.0.x) added to the `test-shard` job in `ci.yml` — the only job that executes trusty-analyze's tests; it runs on push to main and `workflow_dispatch`, so no new required context. New integration test `roslyn_tool_reports_real_build_error` runs a real `dotnet build` against a minimal net8.0 fixture with a deliberate CS0029 error and asserts an Error-severity diagnostic; with `CI=true` and no SDK it panics rather than skipping, so coverage cannot lapse silently. Fixture under `crates/trusty-analyze/testdata/csharp/` with `bin/`/`obj/` ignored.

Test ladder: rung 2 (CI + test-only; no `src/**` change, no fragment owed).
Local run with dotnet 8.0.424 on PATH: `test roslyn_tool_reports_real_build_error ... ok` (2.78 s, a real build); `CI=true` without the SDK panics as designed.

cargo fmt --check: clean
cargo clippy -p trusty-analyze --all-targets -- -D warnings: exit 0
cargo test -p trusty-analyze --no-fail-fast: 561 passed, 0 failed, 1 ignored (pre-existing stdio_harness)
scripts/check-red-main-coverage.sh: 20 workflows, all covered; actionlint clean; check_line_cap/check_sld/check_test_pointers clean

The proof for the CI path itself is the first `Rust tests (pre-publish gate)` shard run on main after merge; a red shard there means the runner's SDK differs from local.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KsTGDrDYKBPmHmmbRsMm5w
