### PR TITLE
fix(trusty-common): kg_writer docs match the unconditional apply_batch path; single/batch assert equivalence test (Refs #4922)

### DIFF
--- a/crates/trusty-common/changelog.d/4922-kg-redb-assert-dup.md
+++ b/crates/trusty-common/changelog.d/4922-kg-redb-assert-dup.md
@@ -1,0 +1,16 @@
+Fixed
+
+- `KgStoreRedb::assert` and `apply_batch`'s `Assert` op already shared one
+  close-and-replace implementation (`batch_assert`) as of the #4810 triple-key
+  rework — this closes the remaining gap #4922 found: `kg_writer.rs`'s module
+  and `commit_and_reply` doc comments claimed a single queued op falls back to
+  "the matching single-op method," but `commit_and_reply` calls
+  `KgStoreRedb::apply_batch` unconditionally, for every batch size from 1
+  upward. The comments now describe that unconditional path; the single-op
+  methods on `KgStoreRedb` are reachable only via `KgWriter::bypass` (no
+  running actor) and the actor's own closed-channel fallback, never from the
+  coalescing loop. Added
+  `single_assert_and_apply_batch_one_op_agree_on_valid_from`, which pins that
+  the sync single-op path and a one-element `apply_batch` produce
+  byte-identical stored triples (`valid_from`/`valid_to` included) — the
+  agreement PR #4920's Tier S `affirmed_at` derivation depends on.

--- a/crates/trusty-common/src/memory_core/store/kg_redb/tests.rs
+++ b/crates/trusty-common/src/memory_core/store/kg_redb/tests.rs
@@ -70,6 +70,86 @@ mod tests {
         assert!(objects.contains(&"Beta"));
     }
 
+    /// A sortable projection of a `Triple`'s stored fields, used to compare
+    /// two stores' contents without requiring `Triple: PartialEq`.
+    fn triple_fingerprint(
+        t: &Triple,
+    ) -> (
+        String,
+        String,
+        String,
+        i64,
+        Option<i64>,
+        u32,
+        Option<String>,
+    ) {
+        (
+            t.subject.clone(),
+            t.predicate.clone(),
+            t.object.clone(),
+            t.valid_from.timestamp_millis(),
+            t.valid_to.map(|d| d.timestamp_millis()),
+            t.confidence.to_bits(),
+            t.provenance.clone(),
+        )
+    }
+
+    #[test]
+    fn single_assert_and_apply_batch_one_op_agree_on_valid_from() {
+        // #4922: `KgStoreRedb::assert` (the sync/bypass path) and
+        // `apply_batch`'s `Assert` op (the daemon's hot path, taken even for
+        // a lone queued op — see `kg_writer::commit_and_reply`) both
+        // delegate to the same `batch_assert` helper. This pins that
+        // agreement so it cannot regress silently: #4920 derives a Tier S
+        // fact's `affirmed_at` from `valid_from`, which is only safe if both
+        // call paths stamp it identically on both the closed-history row and
+        // the new active row.
+        let (_d1, via_single) = open_kg();
+        let (_d2, via_batch) = open_kg();
+
+        // First assertion, then a superseding one — exercises the
+        // close-and-replace path (a history row plus a new active row) on
+        // both sides, not just a bare insert.
+        let first = t("alice", "is_alias_for", "Acme");
+        let second = t("alice", "is_alias_for", "Beta");
+
+        via_single.assert(&first).unwrap();
+        via_single.assert(&second).unwrap();
+
+        via_batch
+            .apply_batch(&[BatchWriteOp::Assert(first.clone())])
+            .unwrap();
+        via_batch
+            .apply_batch(&[BatchWriteOp::Assert(second.clone())])
+            .unwrap();
+
+        let mut single_all: Vec<_> = via_single
+            .dump_all_triples()
+            .unwrap()
+            .iter()
+            .map(triple_fingerprint)
+            .collect();
+        let mut batch_all: Vec<_> = via_batch
+            .dump_all_triples()
+            .unwrap()
+            .iter()
+            .map(triple_fingerprint)
+            .collect();
+        single_all.sort();
+        batch_all.sort();
+
+        assert_eq!(
+            single_all.len(),
+            2,
+            "one closed history row + one active row"
+        );
+        assert_eq!(
+            single_all, batch_all,
+            "single-op assert and a one-element apply_batch must produce \
+             byte-identical stored triples, valid_from/valid_to included"
+        );
+    }
+
     #[test]
     fn retract_closes_active_interval() {
         let (_d, kg) = open_kg();

--- a/crates/trusty-common/src/memory_core/store/kg_redb/write_ops.rs
+++ b/crates/trusty-common/src/memory_core/store/kg_redb/write_ops.rs
@@ -44,10 +44,12 @@ impl KgStoreRedb {
     /// `room:General --contains--> drawer:N` asserts left one row.
     /// What: Single write transaction over TRIPLES + secondary indexes +
     /// ACTIVE_SUBJECT_COUNTS, delegating to [`batch_assert`] so the single-op
-    /// and batched paths cannot drift.
+    /// and batched paths cannot drift (#4922) — including on `valid_from`,
+    /// which #4920's Tier S `affirmed_at` derivation depends on.
     /// Test: `assert_then_query_returns_triple`,
     /// `assert_functional_predicate_still_supersedes`,
-    /// `assert_multiple_objects_for_multivalued_predicate_all_survive`.
+    /// `assert_multiple_objects_for_multivalued_predicate_all_survive`,
+    /// `single_assert_and_apply_batch_one_op_agree_on_valid_from`.
     pub fn assert(&self, triple: &Triple) -> Result<()> {
         self.check_writable()?;
         let wtx = self.db().begin_write().context("begin assert txn")?;

--- a/crates/trusty-common/src/memory_core/store/kg_writer.rs
+++ b/crates/trusty-common/src/memory_core/store/kg_writer.rs
@@ -18,15 +18,26 @@
 //! What: `KgWriter` owns an `Arc<KgStoreRedb>` and an `mpsc::Sender`. The
 //! background task `writer_loop` blocks on `recv()` for the first op,
 //! then drains any further ops already buffered on the channel (up to a
-//! configurable cap, default 64). If the drained batch has >1 op, the
-//! whole set is committed via `KgStoreRedb::apply_batch`; if exactly 1
-//! op, it goes through the corresponding single-op method for symmetry.
+//! configurable cap, default 64). `commit_and_reply` then commits the
+//! drained batch via `KgStoreRedb::apply_batch` unconditionally — a
+//! lone op still travels as a one-element batch rather than through a
+//! separate single-op method, so the actor's write path is always
+//! `apply_batch` regardless of how many ops coalesced (#4922: this
+//! comment used to claim a buf-length branch to a "matching single-op
+//! method" that the code has never had). The single-op methods on
+//! `KgStoreRedb` (`assert`, `retract`, …) exist for the bypass path
+//! (`KgWriter::bypass`, used by synchronous callers with no running
+//! actor) and this actor's own closed-channel fallback, not for the
+//! coalescing loop itself.
 //! Errors are reported per-op via the matching `oneshot::Sender`. The
 //! actor shuts down cleanly when the last sender drops.
 //!
 //! Test: `writer_serialises_concurrent_asserts`,
 //! `writer_batches_burst_into_single_commit`,
-//! `writer_reports_error_per_op`, `writer_drops_cleanly_on_shutdown`.
+//! `writer_reports_error_per_op`, `writer_drops_cleanly_on_shutdown`;
+//! `single_assert_and_apply_batch_one_op_agree_on_valid_from`
+//! (`kg_redb::tests`) pins that the always-`apply_batch` path described
+//! above and the bypass/fallback single-op path stay identical.
 
 use crate::memory_core::palace::Drawer;
 use crate::memory_core::store::kg::Triple;
@@ -446,10 +457,12 @@ async fn writer_loop(store: Arc<KgStoreRedb>, mut rx: mpsc::Receiver<QueuedOp>) 
 /// commit path is easy to unit-test (callers can poke a batch through
 /// it directly if needed). Replies are matched positionally to the ops
 /// in `buf` because `apply_batch` returns results in the same order.
-/// What: Calls `store.apply_batch` when `buf` has ≥ 2 ops; otherwise
-/// uses the matching single-op method. On a transaction-level error,
-/// every queued op gets the same error (the batch was atomic — none of
-/// them committed). On success, each reply gets its op's result.
+/// What: Calls `store.apply_batch` unconditionally, for every `buf` size
+/// from 1 upward (#4922) — there is no branch to a separate single-op
+/// method here; a solo op is simply a one-element batch. On a
+/// transaction-level error, every queued op gets the same error (the
+/// batch was atomic — none of them committed). On success, each reply
+/// gets its op's result.
 /// Test: `writer_batches_burst_into_single_commit`,
 /// `writer_reports_error_per_op`.
 async fn commit_and_reply(store: &Arc<KgStoreRedb>, buf: &mut Vec<QueuedOp>) {


### PR DESCRIPTION
Refs #4922.

The duplication the issue describes no longer exists: PR #5360 (b5f968ca3, 2026-08-10) already made `KgStoreRedb::assert` delegate to `batch_assert`, and `retract`/`retract_triple` share `retract_rows`. `KgStoreRedb::assert` is still called (`KgWriter::assert_sync`, the closed-channel fallback, unit tests), so nothing is removed and there is no public-API change.

What was still wrong: `kg_writer.rs`'s module doc and `commit_and_reply`'s doc claimed a lone queued op falls back to "the matching single-op method"; the code calls `store.apply_batch` unconditionally for every batch size. Both docs now state the actual path.

Regression test `single_assert_and_apply_batch_one_op_agree_on_valid_from` asserts then supersedes the same triple through `KgStoreRedb::assert` and a one-element `apply_batch` and compares stored triples field-by-field, pinning the `valid_from` agreement that #4920's Tier S `affirmed_at` derivation depends on.

Test ladder: rung 4 (trusty-common; only doc comments and a test changed in the library).
cargo fmt --check: clean
cargo clippy -p trusty-common --features memory-core,embedder-test-support --all-targets -- -D warnings: 0 warnings
cargo test -p trusty-common --features memory-core,embedder-test-support --no-fail-fast: 1254 passed, 0 failed, 13 ignored across 8 targets
cargo check --workspace: clean
cargo test -p trusty-memory --no-fail-fast: 977 passed, 0 failed across 30 targets
check_line_cap / check_sld / check_test_pointers / check_changelog_fragment: OK; check-pr-version-bump: trusty-common 0.47.0 unpublished, no bump needed

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KsTGDrDYKBPmHmmbRsMm5w
