### PR TITLE
fix(trusty-review): render the diff once, assign Degraded once, calibrate returns errors (Refs #1660, Refs #1661, Refs #1632)

### DIFF
--- a/crates/trusty-review/changelog.d/1660-1661-1632-review-runner-cleanups.md
+++ b/crates/trusty-review/changelog.d/1660-1661-1632-review-runner-cleanups.md
@@ -1,0 +1,5 @@
+Fixed
+- The review runner rendered the full noise-filtered diff twice (once unbounded just to measure its length, once bounded for the prompt) — now renders once; the map-reduce decision reuses the bounded render's own truncation marker (Refs #1660).
+- The map-reduce branch assigned `ReviewStatus::Degraded` from two independent sites (partial coverage, opted-out context dependency) — consolidated to one assignment so a future finer-grained status can't be silently clobbered by whichever site ran second (Refs #1661).
+- The calibration harness's `run_pipeline_for_entry` built its own `GithubClient`/token instead of reusing the runner's shared `resolve_diff_token` helper — now routes through the same funnel, removing an auth-path divergence risk (Refs #1632).
+- `compute_metrics` panicked via `assert_eq!` on a corpus/results length mismatch — now returns a `Result` error instead (Refs #1632).

--- a/crates/trusty-review/src/commands/calibrate.rs
+++ b/crates/trusty-review/src/commands/calibrate.rs
@@ -22,12 +22,12 @@ use tracing::warn;
 
 use trusty_review::{
     config::{InvocationSurface, ReviewConfig},
-    integrations::{
-        github::{AuthStrategy, GithubClient, RunMode},
-        search_client::HttpSearchClient,
-    },
+    integrations::{github::RunMode, search_client::HttpSearchClient},
     models::{Finding, Verdict},
-    pipeline::{CallerContext, DiffSource, ReviewDeps, ReviewInput, TriggerDecision, run_review},
+    pipeline::{
+        CallerContext, DiffSource, ReviewDeps, ReviewInput, TriggerDecision, run_review,
+        runner_helpers::resolve_diff_token,
+    },
 };
 
 use super::run::build_deps_async;
@@ -347,14 +347,21 @@ pub fn is_rust_semantic(finding: &Finding) -> bool {
 /// findings, false-positive trusty findings, and accumulates into aggregate
 /// recall/precision and the TRUE Rust semantic FP rate (lower = better).
 /// Test: `compute_metrics_three_pr_corpus` in `calibrate_tests.rs`.
+///
+/// # Errors
+/// Returns an error, rather than panicking, when `corpus` and `trusty_results`
+/// have different lengths (#1632) — a mismatched pair is a caller bug, and a
+/// library function must let the caller handle that as a `Result` rather than
+/// take down the whole calibration run on an `assert_eq!` panic.
 pub fn compute_metrics(
     corpus: &[CorpusEntry],
     trusty_results: &[Vec<Finding>],
-) -> CalibrationReport {
-    assert_eq!(
+) -> Result<CalibrationReport> {
+    anyhow::ensure!(
+        corpus.len() == trusty_results.len(),
+        "corpus and trusty_results must have the same length (corpus={}, trusty_results={})",
         corpus.len(),
-        trusty_results.len(),
-        "corpus and trusty_results must have the same length"
+        trusty_results.len()
     );
 
     let mut total_human: usize = 0;
@@ -446,13 +453,13 @@ pub fn compute_metrics(
         1.0_f64 - (rust_sem_recalled as f64 / rust_sem_total as f64)
     };
 
-    CalibrationReport {
+    Ok(CalibrationReport {
         recall: aggregate_recall,
         precision: aggregate_precision,
         per_pr,
         verdict_bars: None,
         rust_semantic_fp_rate,
-    }
+    })
 }
 
 // ─── I/O helpers ─────────────────────────────────────────────────────────────
@@ -504,31 +511,26 @@ async fn run_pipeline_for_entry(
     reviewer_model: &str,
     deps: ReviewDeps,
 ) -> (Vec<Finding>, Verdict) {
-    let client = match GithubClient::new() {
-        Ok(c) => c,
-        Err(e) => {
-            warn!(pr = entry.pr, owner = %entry.owner, repo = %entry.repo,
-                  "calibrate: failed to build GitHub client: {e}");
-            return (Vec::new(), Verdict::Unknown);
-        }
+    // #1632: resolve the token through `resolve_diff_token` — the SAME funnel
+    // `run_review`'s own Step 2c uses (`runner.rs`) — instead of re-deriving the
+    // `GithubClient`/`AuthStrategy` dance here. A second independent
+    // implementation is exactly the auth-path divergence risk the issue
+    // flagged: a future change to token resolution would silently not apply to
+    // calibration runs. An empty `token` placeholder is what signals
+    // `resolve_diff_token` to resolve it (see its doc comment).
+    let unresolved = DiffSource::Github {
+        owner: entry.owner.clone(),
+        repo: entry.repo.clone(),
+        pr: entry.pr,
+        token: String::new(),
     };
-    let token = match AuthStrategy::select(RunMode::Cli, None)
-        .resolve_token(&client, config, &entry.owner)
-        .await
-    {
-        Ok(t) => t,
+    let diff_source = match resolve_diff_token(&unresolved, config, RunMode::Cli).await {
+        Ok(source) => source,
         Err(e) => {
             warn!(pr = entry.pr, owner = %entry.owner, repo = %entry.repo,
                   "calibrate: GitHub token resolution failed: {e}");
             return (Vec::new(), Verdict::Unknown);
         }
-    };
-
-    let diff_source = DiffSource::Github {
-        owner: entry.owner.clone(),
-        repo: entry.repo.clone(),
-        pr: entry.pr,
-        token,
     };
 
     let input = ReviewInput {
@@ -626,7 +628,7 @@ pub async fn cmd_calibrate(_config: ReviewConfig, args: CalibrateArgs) -> Result
         trusty_verdicts.push(verdict);
     }
 
-    let mut report = compute_metrics(&corpus, &trusty_results);
+    let mut report = compute_metrics(&corpus, &trusty_results)?;
     report.verdict_bars = compute_verdict_bars(&corpus, &trusty_verdicts);
     let json = serde_json::to_string_pretty(&report).context("serialising calibration report")?;
 

--- a/crates/trusty-review/src/commands/calibrate_tests.rs
+++ b/crates/trusty-review/src/commands/calibrate_tests.rs
@@ -148,7 +148,7 @@ fn three_pr_corpus() -> (Vec<CorpusEntry>, Vec<Vec<Finding>>) {
 #[test]
 fn compute_metrics_three_pr_corpus() {
     let (corpus, trusty_results) = three_pr_corpus();
-    let report = compute_metrics(&corpus, &trusty_results);
+    let report = compute_metrics(&corpus, &trusty_results).expect("matching lengths");
 
     // PR 101: recall=2/2=1.0, precision=2/2=1.0
     assert!(
@@ -215,7 +215,7 @@ fn compute_metrics_three_pr_corpus() {
 #[test]
 fn rust_semantic_fp_rate_computed_correctly() {
     let (corpus, trusty_results) = three_pr_corpus();
-    let report = compute_metrics(&corpus, &trusty_results);
+    let report = compute_metrics(&corpus, &trusty_results).expect("matching lengths");
 
     // Rust semantic findings (kind=logic-error|ownership on .rs files):
     // PR 101 trusty: src/db.rs/logic-error → recalled (human has it) → +1 recalled, +1 total
@@ -241,7 +241,7 @@ fn rust_semantic_fp_rate_neutral_when_no_rust_semantic_findings() {
     }];
     // Only a Python-file finding (not rust-semantic)
     let results = vec![vec![make_finding("src/main.py", "logic-error")]];
-    let report = compute_metrics(&corpus, &results);
+    let report = compute_metrics(&corpus, &results).expect("matching lengths");
     assert!(
         (report.rust_semantic_fp_rate - 0.0).abs() < 1e-9,
         "expected neutral 0.0 (no FPs) when no Rust semantic findings, got {}",
@@ -273,7 +273,7 @@ fn recall_does_not_exceed_one_when_two_trusty_match_same_human_finding() {
         make_finding("src/lib.rs", "logic-error"),
         make_finding("src/lib.rs", "logic-error"),
     ]];
-    let report = compute_metrics(&corpus, &results);
+    let report = compute_metrics(&corpus, &results).expect("matching lengths");
     // Recall: 1 distinct human finding recalled / 1 total → 1.0 (not 2.0)
     assert!(
         (report.per_pr[0].recall - 1.0).abs() < 1e-9,
@@ -347,7 +347,7 @@ fn load_corpus_empty_file_returns_empty_vec() {
 #[test]
 fn pr_label_formatted_correctly() {
     let (corpus, trusty_results) = three_pr_corpus();
-    let report = compute_metrics(&corpus, &trusty_results);
+    let report = compute_metrics(&corpus, &trusty_results).expect("matching lengths");
     assert_eq!(report.per_pr[0].pr, "acme/api#101");
     assert_eq!(report.per_pr[1].pr, "acme/api#102");
     assert_eq!(report.per_pr[2].pr, "acme/api#103");
@@ -506,4 +506,66 @@ fn a_corpus_line_with_a_reference_verdict_parses_it() {
     let line = r#"{"owner":"acme","repo":"api","pr":1,"human_findings":[],"reference_verdict":"REQUEST_CHANGES"}"#;
     let entry: CorpusEntry = serde_json::from_str(line).expect("labelled corpus line parses");
     assert_eq!(entry.reference_verdict, Some(Verdict::RequestChanges));
+}
+
+// ─── #1632: compute_metrics returns an error instead of panicking ─────────
+
+/// Why: `compute_metrics` used `assert_eq!` on the two slice lengths — a
+/// mismatch panicked the whole calibration run (and, being a `pub fn` in
+/// library-adjacent code, any caller) rather than letting the caller decide
+/// how to handle a caller bug. #1632 replaces that with a `Result`.
+/// What: a corpus of 2 entries against a `trusty_results` of 1 must return
+/// `Err`, not panic, and the message must name both lengths.
+/// Test: this test.
+#[test]
+fn compute_metrics_mismatched_lengths_return_err_not_panic() {
+    let corpus = vec![
+        labelled(1, Verdict::Approve),
+        labelled(2, Verdict::RequestChanges),
+    ];
+    let trusty_results: Vec<Vec<Finding>> = vec![vec![]]; // only 1, corpus has 2
+
+    let result = compute_metrics(&corpus, &trusty_results);
+    let err = result.expect_err("mismatched lengths must return Err, not panic");
+    let msg = err.to_string();
+    assert!(
+        msg.contains('2') && msg.contains('1'),
+        "error must name both lengths (corpus=2, trusty_results=1): {msg}"
+    );
+}
+
+// ─── #1632: run_pipeline_for_entry reuses resolve_diff_token ──────────────
+
+/// Why: `run_pipeline_for_entry` used to build its own `GithubClient` and call
+/// `AuthStrategy::select(...).resolve_token(...)` directly — a second,
+/// independent implementation of exactly what `resolve_diff_token`
+/// (`pipeline::runner_helpers`, the SAME funnel `run_review`'s own Step 2c
+/// uses) already does, risking silent auth-path divergence. A value-level test
+/// can't distinguish "calls the shared helper" from "reimplements the same
+/// two calls inline" when both resolve successfully, so this pins it at the
+/// source level: the pre-fix source called `GithubClient::new()` and
+/// `AuthStrategy::select(` directly (2 call sites); this asserts 0, and that
+/// `resolve_diff_token(` is called instead.
+/// What: reads `calibrate.rs`'s own source.
+/// Test: this test.
+#[test]
+fn run_pipeline_for_entry_reuses_resolve_diff_token_helper() {
+    let src = std::fs::read_to_string(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/src/commands/calibrate.rs"
+    ))
+    .expect("read calibrate.rs source");
+    let direct_derivation =
+        src.matches("GithubClient::new()").count() + src.matches("AuthStrategy::select(").count();
+    assert_eq!(
+        direct_derivation, 0,
+        "calibrate.rs must not re-derive GithubClient/AuthStrategy directly (#1632) — \
+         found {direct_derivation} call site(s)"
+    );
+    assert_eq!(
+        src.matches("resolve_diff_token(").count(),
+        1,
+        "calibrate.rs must resolve the GitHub token via the shared \
+         `resolve_diff_token` helper exactly once"
+    );
 }

--- a/crates/trusty-review/src/pipeline/diff_analyzer/models.rs
+++ b/crates/trusty-review/src/pipeline/diff_analyzer/models.rs
@@ -102,6 +102,21 @@ impl FilteredHunk {
         }
         out
     }
+
+    /// Exact length `render()` would produce, without allocating it.
+    ///
+    /// Why: a caller that only needs the length (e.g. `FilteredDiff::
+    /// total_rendered_len`, #1660) must not pay for a full `String` per hunk
+    /// just to call `.len()` on it — hunks are the bulk of a large diff's
+    /// content.
+    /// What: `header.len()` plus, per line, `1 (the '\n' separator) +
+    /// line.len()` — the same arithmetic `render()` performs, without the
+    /// allocation.
+    /// Test: `total_rendered_len_is_exact_inside_the_reserve_band_where_the_marker_lies`
+    /// (exercises this via `FilteredDiff::total_rendered_len`).
+    pub fn rendered_len(&self) -> usize {
+        self.header.len() + self.lines.iter().map(|l| l.len() + 1).sum::<usize>()
+    }
 }
 
 /// A hunk that was dropped in Stage B or Stage C (spec §4).
@@ -292,6 +307,48 @@ impl FilteredDiff {
         }
 
         out
+    }
+
+    /// Exact length `render_for_prompt(usize::MAX)` would produce, without
+    /// materializing that (potentially huge) string.
+    ///
+    /// Why: `render_for_prompt`'s own truncation-marker decision is
+    /// deliberately conservative — it reserves headroom for the marker +
+    /// suffix before it will place each segment, so it sets the marker (and
+    /// therefore looks "truncated") for a diff whose true, uncapped length is
+    /// actually AT OR UNDER `max_chars` (follow-up to #1660: a caller cannot
+    /// infer "would exceed `max_chars`" from marker presence). A caller that
+    /// needs the exact untruncated length for a `> max_chars` comparison
+    /// (`select_review_mode`'s `DiffStats::diff_chars`) must not use that
+    /// marker as a proxy. This computes the same number
+    /// `render_for_prompt(usize::MAX).len()` would return, via arithmetic
+    /// over segment lengths instead of building the string — keeping the
+    /// crate's one real (bounded) render as the only allocation of that size.
+    /// What: sums the same segments `render_for_prompt` emits at an unbounded
+    /// budget (`SummaryOnly` line, `Kept` file header + each hunk's
+    /// `rendered_len` + trailing newline) plus the noise-summary suffix — no
+    /// truncation marker, since an unbounded render never sets one.
+    /// Test: `total_rendered_len_is_exact_inside_the_reserve_band_where_the_marker_lies`,
+    /// `reserve_band_diff_selects_unified_not_mapreduce`.
+    pub fn total_rendered_len(&self) -> usize {
+        let mut len = 0usize;
+        for file in &self.files {
+            match file.disposition {
+                FileDisposition::SummaryOnly => {
+                    if let Some(ref summary) = file.summary_line {
+                        len += format!("# {}: {}\n", file.filename, summary).len();
+                    }
+                }
+                FileDisposition::Kept => {
+                    len += format!("--- a/{0}\n+++ b/{0}\n", file.filename).len();
+                    for hunk in &file.hunks {
+                        len += hunk.rendered_len() + 1;
+                    }
+                }
+                FileDisposition::Dropped => {}
+            }
+        }
+        len + self.build_noise_summary().len()
     }
 
     /// Build the noise-summary line appended to the prompt (spec REV-209).

--- a/crates/trusty-review/src/pipeline/diff_analyzer/models_tests.rs
+++ b/crates/trusty-review/src/pipeline/diff_analyzer/models_tests.rs
@@ -276,3 +276,138 @@ fn render_for_prompt_marker_does_not_cause_large_overflow() {
         "truncation marker must appear: {rendered}"
     );
 }
+
+// ─── #1660 follow-up: exact untruncated length vs the marker-based proxy ──
+//
+// `render_for_prompt`'s truncation-marker decision reserves headroom
+// (`suffix.len() + 120`, `TRUNC_MARKER_RESERVE`) before it will place each
+// segment, so it can set `RENDER TRUNCATED` for a diff whose TRUE, uncapped
+// length is actually at or under `max_chars`.  A caller inferring "untruncated
+// length > max_chars" from that marker's presence (as `runner.rs` briefly did
+// on commit 73962068e) gets a false positive for any diff landing in that
+// ~120-char reserve band just under the cap.  These two tests build such a
+// diff and prove: (1) `total_rendered_len` returns its EXACT length, matching
+// an unbounded render, even though the marker is a false positive here; (2)
+// feeding that exact length into `select_review_mode` (what `runner.rs` now
+// does) correctly picks `Unified`, while the OLD marker-based formula
+// (reproduced inline, matching commit 73962068e) incorrectly picks
+// `MapReduce`.
+
+/// Build a one-file, one-hunk `FilteredDiff` whose real (uncapped) rendered
+/// length is exactly `target` chars — no dropped files/hunks, so
+/// `build_noise_summary` is empty and the only variables are the file header,
+/// hunk header, and one padded content line.
+fn diff_with_exact_rendered_len(target: usize) -> FilteredDiff {
+    let filename = "src/a.rs";
+    let file_header_len = format!("--- a/{filename}\n+++ b/{filename}\n").len();
+    let hunk_header = "@@ -1,3 +1,3 @@";
+    // total_rendered_len = file_header + (hunk_header.len() + line.len() + 1) + 1
+    // (the `+1` inside is the hunk's own line-separator; the trailing `+1` is
+    // the newline `render_for_prompt` pushes after each rendered hunk).
+    let fixed_overhead = file_header_len + hunk_header.len() + 1 + 1;
+    let line_len = target
+        .checked_sub(fixed_overhead)
+        .expect("target must exceed the fixed header/newline overhead");
+    let line = format!("+{}", "x".repeat(line_len.saturating_sub(1)));
+
+    FilteredDiff {
+        files: vec![FilteredFile {
+            filename: filename.to_string(),
+            status: "modified".to_string(),
+            disposition: FileDisposition::Kept,
+            hunks: vec![FilteredHunk {
+                header: hunk_header.to_string(),
+                lines: vec![line],
+                substantive_confidence: 1.0,
+                reason_kept: "test".to_string(),
+            }],
+            dropped_hunks: vec![],
+            summary_line: None,
+        }],
+        dropped_files: vec![],
+        drop_hunk_counts: HashMap::new(),
+        original_byte_size: target,
+        filtered_byte_size: target,
+    }
+}
+
+/// Test: this test.
+#[test]
+fn total_rendered_len_is_exact_inside_the_reserve_band_where_the_marker_lies() {
+    let target = crate::config::constants::MAX_DIFF_CHARS - 60; // inside the 120-char reserve band, still <= cap
+    let diff = diff_with_exact_rendered_len(target);
+
+    assert_eq!(
+        diff.total_rendered_len(),
+        target,
+        "total_rendered_len must be the exact constructed length"
+    );
+    assert_eq!(
+        diff.total_rendered_len(),
+        diff.render_for_prompt(usize::MAX).len(),
+        "total_rendered_len must match what an unbounded render actually produces"
+    );
+
+    let bounded = diff.render_for_prompt(crate::config::constants::MAX_DIFF_CHARS);
+    assert!(
+        bounded.contains("RENDER TRUNCATED"),
+        "the reserve-band diff must trip render_for_prompt's own conservative \
+         marker even though its true length ({target}) is under the cap \
+         ({}) — this is the false positive that made the marker unsafe as a \
+         `diff_chars` proxy: {bounded}",
+        crate::config::constants::MAX_DIFF_CHARS
+    );
+}
+
+/// Why (#1660 follow-up): this reproduces the actual bug commit 73962068e
+/// introduced. `runner.rs` derived `DiffStats::diff_chars` from
+/// `render_for_prompt`'s marker (`max_chars + 1` whenever the marker was
+/// set) — a false positive for this diff per the test above — which made
+/// `select_review_mode` pick `MapReduce` for a diff that fits comfortably
+/// under `MAX_DIFF_CHARS`. This proves both halves: the OLD (marker-based)
+/// formula selects `MapReduce` here; the FIXED (`total_rendered_len`-based)
+/// one selects `Unified`.
+/// What: same reserve-band `FilteredDiff`, fed through `select_review_mode`
+/// two ways.
+/// Test: this test.
+#[test]
+fn reserve_band_diff_selects_unified_not_mapreduce() {
+    use crate::config::{DiffStats, MapReduceConfig, ReviewPath, select_review_mode};
+    use crate::pipeline::diff::diff_was_truncated;
+
+    let max = crate::config::constants::MAX_DIFF_CHARS;
+    let target = max - 60;
+    let diff = diff_with_exact_rendered_len(target);
+    let mr_config = MapReduceConfig::default(); // Auto mode, file_threshold=12 — 1 file never trips it
+
+    // OLD formula (commit 73962068e): infer diff_chars from the served
+    // render's truncation marker.
+    let bounded = diff.render_for_prompt(max);
+    let old_diff_chars = if diff_was_truncated(&bounded) {
+        max.saturating_add(1)
+    } else {
+        bounded.len()
+    };
+    let old_stats = DiffStats {
+        diff_chars: old_diff_chars,
+        file_count: diff.files.len(),
+    };
+    assert_eq!(
+        select_review_mode(old_stats, &mr_config),
+        ReviewPath::MapReduce,
+        "reproduces the bug on 73962068e: the marker-based diff_chars picks \
+         MapReduce for a diff that is actually under the cap"
+    );
+
+    // Fixed formula: the exact untruncated length via total_rendered_len.
+    let new_stats = DiffStats {
+        diff_chars: diff.total_rendered_len(),
+        file_count: diff.files.len(),
+    };
+    assert_eq!(
+        select_review_mode(new_stats, &mr_config),
+        ReviewPath::Unified,
+        "the exact untruncated length correctly selects Unified for a diff \
+         under the cap"
+    );
+}

--- a/crates/trusty-review/src/pipeline/runner.rs
+++ b/crates/trusty-review/src/pipeline/runner.rs
@@ -390,10 +390,18 @@ pub async fn run_review(
     };
     let filtered = DiffAnalyzer::default().analyze(&raw_diff).await;
     let max = crate::config::constants::MAX_DIFF_CHARS;
-    // Render ONCE at no cap so DiffStats sees the true (untruncated) length the
-    // selector needs; the unified path re-bounds to `max` below.
-    let rendered_full = filtered.render_for_prompt(usize::MAX);
+    // #1660: render ONCE, bounded to `max` — NOT a second, unbounded render at
+    // `usize::MAX` just to learn the length.  `render_for_prompt` already
+    // stays within its own budget and self-announces with
+    // `RENDER_TRUNCATED_MARKER` whenever it had to drop content to do so
+    // (see `diff_was_truncated`), so that single bounded render tells us
+    // everything the selector needs: when nothing was dropped, this render's
+    // length IS the true (untruncated) length; when something was dropped, the
+    // marker alone proves the untruncated length exceeds `max`, which is all
+    // `select_review_mode` compares against (`diff_chars > MAX_DIFF_CHARS`) —
+    // the exact untruncated figure is never otherwise consumed.
     let diff = truncate_diff(&filtered.render_for_prompt(max));
+    let would_truncate = diff_was_truncated(&diff);
     debug!(orig = raw_diff.len(), filt = diff.len(), "diff filtered");
 
     // ── Step 3a: select review path (unified vs map-reduce) (#1643 / #680) ─
@@ -403,7 +411,14 @@ pub async fn run_review(
     // forces map-reduce; `never` forces the unified path (today's behaviour).
     let mr_config = MapReduceConfig::from_env();
     let stats = DiffStats {
-        diff_chars: rendered_full.len(),
+        // Exact only when nothing was dropped (see the render comment above);
+        // once truncation happened the precise count is moot — `max + 1` still
+        // satisfies the selector's sole `> MAX_DIFF_CHARS` comparison.
+        diff_chars: if would_truncate {
+            max.saturating_add(1)
+        } else {
+            diff.len()
+        },
         file_count: filtered.files.len(),
     };
     let review_path = select_review_mode(stats, &mr_config);
@@ -431,7 +446,7 @@ pub async fn run_review(
     // silently reviewing only the visible portion.  The map-reduce path (#680) will
     // later review over-cap diffs per-file with no truncation; until that fan-out
     // lands, fail-closed is the safe behaviour.
-    if review_path == ReviewPath::Unified && diff_was_truncated(&diff) {
+    if review_path == ReviewPath::Unified && would_truncate {
         warn!(
             orig_chars = raw_diff.len(),
             rendered_chars = diff.len(),

--- a/crates/trusty-review/src/pipeline/runner.rs
+++ b/crates/trusty-review/src/pipeline/runner.rs
@@ -390,18 +390,22 @@ pub async fn run_review(
     };
     let filtered = DiffAnalyzer::default().analyze(&raw_diff).await;
     let max = crate::config::constants::MAX_DIFF_CHARS;
-    // #1660: render ONCE, bounded to `max` — NOT a second, unbounded render at
-    // `usize::MAX` just to learn the length.  `render_for_prompt` already
-    // stays within its own budget and self-announces with
-    // `RENDER_TRUNCATED_MARKER` whenever it had to drop content to do so
-    // (see `diff_was_truncated`), so that single bounded render tells us
-    // everything the selector needs: when nothing was dropped, this render's
-    // length IS the true (untruncated) length; when something was dropped, the
-    // marker alone proves the untruncated length exceeds `max`, which is all
-    // `select_review_mode` compares against (`diff_chars > MAX_DIFF_CHARS`) —
-    // the exact untruncated figure is never otherwise consumed.
+    // #1660: render ONCE, bounded to `max`, for the actual prompt/served text
+    // — NOT a second, unbounded render at `usize::MAX` just to learn a
+    // length.  The exact untruncated length the selector needs comes from
+    // `total_rendered_len` (arithmetic over segment lengths, no second string
+    // materialized): `render_for_prompt`'s own truncation-marker decision is
+    // deliberately conservative (it reserves headroom for the marker+suffix
+    // before placing each segment), so a diff whose true length sits just
+    // under `max` can still trip that marker — the marker alone is NOT a
+    // reliable proxy for "untruncated length > MAX_DIFF_CHARS" (follow-up to
+    // #1660's original fix). `would_truncate` below answers a different,
+    // still-valid question — "was the text actually SERVED to the reviewer
+    // cut" — which Step 3b's fail-closed guard needs and which the marker DOES
+    // answer correctly.
     let diff = truncate_diff(&filtered.render_for_prompt(max));
     let would_truncate = diff_was_truncated(&diff);
+    let diff_chars = filtered.total_rendered_len();
     debug!(orig = raw_diff.len(), filt = diff.len(), "diff filtered");
 
     // ── Step 3a: select review path (unified vs map-reduce) (#1643 / #680) ─
@@ -411,14 +415,7 @@ pub async fn run_review(
     // forces map-reduce; `never` forces the unified path (today's behaviour).
     let mr_config = MapReduceConfig::from_env();
     let stats = DiffStats {
-        // Exact only when nothing was dropped (see the render comment above);
-        // once truncation happened the precise count is moot — `max + 1` still
-        // satisfies the selector's sole `> MAX_DIFF_CHARS` comparison.
-        diff_chars: if would_truncate {
-            max.saturating_add(1)
-        } else {
-            diff.len()
-        },
+        diff_chars,
         file_count: filtered.files.len(),
     };
     let review_path = select_review_mode(stats, &mr_config);

--- a/crates/trusty-review/src/pipeline/runner_helpers.rs
+++ b/crates/trusty-review/src/pipeline/runner_helpers.rs
@@ -184,7 +184,12 @@ pub(super) async fn fetch_github_pr_meta(
 /// `resolve_diff_token_passes_through_already_resolved_token`,
 /// `resolve_diff_token_serve_mode_without_app_creds_errors`,
 /// `resolve_diff_token_cli_mode_resolves_from_config_token`.
-pub(super) async fn resolve_diff_token(
+///
+/// #1632: `pub` (not `pub(super)`) so `commands::calibrate` (a different
+/// crate — the `trusty-review` binary) can call this SAME funnel instead of
+/// re-deriving the `GithubClient`/`AuthStrategy` dance independently, which is
+/// exactly the auth-path divergence risk this function exists to close.
+pub async fn resolve_diff_token(
     source: &DiffSource,
     config: &ReviewConfig,
     run_mode: RunMode,

--- a/crates/trusty-review/src/pipeline/runner_mapreduce.rs
+++ b/crates/trusty-review/src/pipeline/runner_mapreduce.rs
@@ -202,9 +202,8 @@ pub(super) async fn run_mapreduce_branch(
     // authoritative.  Surface it in BOTH the posted body (a visible banner) and
     // the internal `error` field so neither the PR author nor a log consumer
     // mistakes a partial review for a complete one.
-    //
-    // Note: status is set AFTER the fold so finalize_run cannot clobber it.
-    if reduced.stats.is_partial() {
+    let is_partial_coverage = reduced.stats.is_partial();
+    if is_partial_coverage {
         let llm_errors = reduced
             .stats
             .files_failed
@@ -215,7 +214,6 @@ pub(super) async fn run_mapreduce_branch(
             reduced.stats.files_failed, llm_errors, reduced.stats.hunks_oversized,
         );
         result.review_body = format!("{notice}{}", result.review_body);
-        result.status = ReviewStatus::Degraded;
         if result.error.is_none() {
             result.error = Some(format!(
                 "map-reduce coverage partial: {} reviewed, {} skipped, {} failed \
@@ -233,7 +231,6 @@ pub(super) async fn run_mapreduce_branch(
     // opted out of a required context dependency, prepend a banner and set the
     // error reason so no consumer mistakes the review for authoritative.
     if let Some(reason) = degraded_reason.as_ref() {
-        result.status = ReviewStatus::Degraded;
         result.review_body = format!(
             "{}{}",
             crate::pipeline::context_gate::degraded_banner(reason),
@@ -242,6 +239,21 @@ pub(super) async fn run_mapreduce_branch(
         if result.error.is_none() {
             result.error = Some(format!("degraded (non-authoritative): {reason}"));
         }
+    }
+
+    // #1661: both triggers above make the review non-authoritative; consolidate
+    // to the ONE status assignment below instead of each block writing
+    // `Degraded` independently.  Previously that duplication was harmless only
+    // because both sites wrote the identical value — a future finer-grained
+    // status for one trigger (e.g. distinguishing partial-coverage from an
+    // opted-out dependency) would have been silently overwritten by whichever
+    // block ran second.  `result.error` above already establishes the intended
+    // precedence when both fire (partial-coverage's message wins, since its
+    // `is_none()` guard runs first); this mirrors that by deriving the single
+    // status write from the same two conditions.
+    // Note: status is set AFTER the fold so finalize_run cannot clobber it.
+    if is_partial_coverage || degraded_reason.is_some() {
+        result.status = ReviewStatus::Degraded;
     }
 
     finalize_run(result, config, input, deps.dedup.as_ref()).await

--- a/crates/trusty-review/src/pipeline/runner_mapreduce_tests.rs
+++ b/crates/trusty-review/src/pipeline/runner_mapreduce_tests.rs
@@ -168,6 +168,39 @@ fn deps(llm: Arc<dyn LlmProvider>) -> ReviewDeps {
     }
 }
 
+/// A search client that is always down — used with `require_search = Some(false)`
+/// (#590 opt-out) to drive `preflight_context` into `GateOutcome::Degraded`
+/// alongside a separately-triggered partial-coverage map-reduce run (#1661).
+struct FailingSearch;
+
+#[async_trait]
+impl SearchClient for FailingSearch {
+    async fn health(&self) -> Result<HealthResponse, SearchClientError> {
+        Err(SearchClientError::Unavailable("down".to_string()))
+    }
+    async fn list_indexes(&self) -> Result<Vec<IndexInfo>, SearchClientError> {
+        Err(SearchClientError::Unavailable("down".to_string()))
+    }
+    async fn search(
+        &self,
+        _: &str,
+        _: &str,
+        _: Option<u32>,
+    ) -> Result<Vec<SearchResult>, SearchClientError> {
+        Err(SearchClientError::Transport("refused".to_string()))
+    }
+}
+
+fn deps_with_failing_search(llm: Arc<dyn LlmProvider>) -> ReviewDeps {
+    ReviewDeps {
+        llm,
+        verifier: None,
+        search: Arc::new(FailingSearch),
+        analyze: Some(Arc::new(OkAnalyze)),
+        dedup: None,
+    }
+}
+
 fn local_source(diff: &str) -> (DiffSource, tempfile::NamedTempFile) {
     use std::io::Write as _;
     let mut tmp = tempfile::NamedTempFile::new().expect("tempfile");
@@ -1005,5 +1038,83 @@ async fn mapreduce_path_emits_no_finding_citing_a_path_outside_the_diff() {
         Verdict::Approve,
         "the only non-APPROVE chunk rested on the fabricated finding, so the merged \
          verdict must relax to APPROVE rather than block a clean diff"
+    );
+}
+
+// ── #1661: the two Degraded triggers collapse to ONE status assignment ─
+
+/// Why: `run_mapreduce_branch` used to write `result.status = ReviewStatus::
+/// Degraded` at two independent sites — the partial-coverage block and the
+/// context-opt-out (`degraded_reason`) block — with no guard between them.
+/// Both wrote the same value today, so no test over either trigger ALONE can
+/// distinguish "one consolidated write" from "two writes that happen to
+/// agree"; only counting the literal assignment site in the source proves it.
+/// What: reads `runner_mapreduce.rs`'s own source and counts literal
+/// `result.status = ReviewStatus::Degraded` assignments — the pre-fix source
+/// had 2 (lines ~218 and ~236); this asserts exactly 1.
+/// Test: this test.
+#[test]
+fn mapreduce_degraded_status_assigned_exactly_once() {
+    let src = std::fs::read_to_string(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/src/pipeline/runner_mapreduce.rs"
+    ))
+    .expect("read runner_mapreduce.rs source");
+    let count = src
+        .matches("result.status = ReviewStatus::Degraded")
+        .count();
+    assert_eq!(
+        count, 1,
+        "runner_mapreduce.rs must assign ReviewStatus::Degraded exactly once \
+         (#1661) — found {count} site(s); the partial-coverage and \
+         context-opt-out triggers must consolidate to one write instead of \
+         each writing it independently"
+    );
+}
+
+/// When BOTH Degraded triggers fire in the SAME run — partial coverage (one
+/// chunk fails via LLM error) AND an opted-out required dependency (search
+/// down, `require_search=false`) — the review must still end Degraded, and
+/// the VISIBLE reason must be the partial-coverage message, since its
+/// `result.error` `is_none()` guard runs first (the precedence the two
+/// blocks' consolidated status write is now built on, #1661). Swapping the
+/// block order, or reintroducing an unconditional second `result.status =
+/// Degraded` write, is invisible to a test that exercises either trigger
+/// alone — only running both together pins it.
+#[tokio::test]
+async fn run_review_mapreduce_both_degraded_triggers_partial_coverage_reason_wins() {
+    let (diff, fail_marker, _tail_signature) = partial_coverage_diff();
+    let (source, _tmp) = local_source(&diff);
+
+    let reviewer = Arc::new(SelectivelyFailingReviewer::fail_on(fail_marker));
+    let llm: Arc<dyn LlmProvider> = reviewer.clone();
+
+    let mut config = ReviewConfig::load(None);
+    config.context.require_search = Some(false); // explicit opt-out (#590)
+
+    let result = run_review(&config, input(source), deps_with_failing_search(llm)).await;
+
+    assert_eq!(
+        result.status,
+        ReviewStatus::Degraded,
+        "both triggers (partial coverage + opted-out search) must still end Degraded"
+    );
+    let err = result
+        .error
+        .expect("a degraded run must record a non-authoritative reason");
+    assert!(
+        err.contains("map-reduce coverage partial"),
+        "partial-coverage's message must win when both triggers fire: {err}"
+    );
+    assert!(
+        result.review_body.contains("Coverage notice"),
+        "partial-coverage banner must still be present: {:?}",
+        result.review_body
+    );
+    assert!(
+        result.review_body.contains("NOT AUTHORITATIVE"),
+        "context-opt-out banner must also still be present (both banners prepend \
+         independently of the consolidated status write): {:?}",
+        result.review_body
     );
 }

--- a/crates/trusty-review/src/pipeline/runner_tests.rs
+++ b/crates/trusty-review/src/pipeline/runner_tests.rs
@@ -2743,33 +2743,13 @@ async fn unified_path_emits_no_finding_citing_a_path_outside_the_diff() {
 }
 
 // ── #1660: the diff is rendered ONCE for stats + prompt, not twice ─────
-
-/// Why: `run_review` used to call `FilteredDiff::render_for_prompt` twice on
-/// the same filtered diff — once unbounded (`usize::MAX`) purely to learn its
-/// length for `DiffStats`, and once bounded to `MAX_DIFF_CHARS` for the actual
-/// prompt/truncation-guard text. On a large diff that doubled peak render
-/// cost for no behavioural difference: the exact untruncated length was never
-/// used for anything but a `> MAX_DIFF_CHARS` comparison, which the bounded
-/// render's own truncation marker already answers (#1660). A source-scan
-/// pins the count directly, since a value-level test can't distinguish "one
-/// render" from "two renders that happen to agree" — the pre-fix source had 2
-/// call sites here (`rendered_full` at `usize::MAX`, `diff` at `max`); this
-/// asserts exactly 1.
-/// What: reads `runner.rs`'s own source and counts literal `render_for_prompt(`
-/// call sites.
-/// Test: this test.
-#[test]
-fn run_review_renders_the_diff_only_once() {
-    let src = std::fs::read_to_string(concat!(
-        env!("CARGO_MANIFEST_DIR"),
-        "/src/pipeline/runner.rs"
-    ))
-    .expect("read runner.rs source");
-    let count = src.matches("render_for_prompt(").count();
-    assert_eq!(
-        count, 1,
-        "runner.rs must render the filtered diff exactly once (#1660) — found \
-         {count} call site(s) of render_for_prompt(...); a second (unbounded) \
-         render was removed by that fix, so a regression here re-adds it"
-    );
-}
+//
+// The value-level regression tests for #1660 (exact-length correctness at
+// the `MAX_DIFF_CHARS` reserve-band boundary, and the `select_review_mode`
+// path decision it drives) live in
+// `pipeline::diff_analyzer::models_tests::total_rendered_len_is_exact_inside_the_reserve_band_where_the_marker_lies`
+// and `..::reserve_band_diff_selects_unified_not_mapreduce` — a source-scan
+// count of `render_for_prompt(` call sites used to stand in for this but
+// could not catch the actual defect (a marker-based `diff_chars` proxy that
+// silently agrees with an exact length everywhere except a narrow band), so
+// it was replaced rather than kept alongside these.

--- a/crates/trusty-review/src/pipeline/runner_tests.rs
+++ b/crates/trusty-review/src/pipeline/runner_tests.rs
@@ -2741,3 +2741,35 @@ async fn unified_path_emits_no_finding_citing_a_path_outside_the_diff() {
         result.findings
     );
 }
+
+// ── #1660: the diff is rendered ONCE for stats + prompt, not twice ─────
+
+/// Why: `run_review` used to call `FilteredDiff::render_for_prompt` twice on
+/// the same filtered diff — once unbounded (`usize::MAX`) purely to learn its
+/// length for `DiffStats`, and once bounded to `MAX_DIFF_CHARS` for the actual
+/// prompt/truncation-guard text. On a large diff that doubled peak render
+/// cost for no behavioural difference: the exact untruncated length was never
+/// used for anything but a `> MAX_DIFF_CHARS` comparison, which the bounded
+/// render's own truncation marker already answers (#1660). A source-scan
+/// pins the count directly, since a value-level test can't distinguish "one
+/// render" from "two renders that happen to agree" — the pre-fix source had 2
+/// call sites here (`rendered_full` at `usize::MAX`, `diff` at `max`); this
+/// asserts exactly 1.
+/// What: reads `runner.rs`'s own source and counts literal `render_for_prompt(`
+/// call sites.
+/// Test: this test.
+#[test]
+fn run_review_renders_the_diff_only_once() {
+    let src = std::fs::read_to_string(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/src/pipeline/runner.rs"
+    ))
+    .expect("read runner.rs source");
+    let count = src.matches("render_for_prompt(").count();
+    assert_eq!(
+        count, 1,
+        "runner.rs must render the filtered diff exactly once (#1660) — found \
+         {count} call site(s) of render_for_prompt(...); a second (unbounded) \
+         render was removed by that fix, so a regression here re-adds it"
+    );
+}


### PR DESCRIPTION
Refs #1660, Refs #1661, Refs #1632.

#1660: `runner.rs` rendered the filtered diff twice, once unbounded to measure `diff_chars` and once bounded for the prompt. Now one bounded render; `diff_chars` comes from a new `FilteredDiff::total_rendered_len()` that computes the exact unbounded length arithmetically (no allocation). A first cut used the bounded render's truncation marker as the size proxy; the critic showed that marker fires inside a ~120-char reserve band under `MAX_DIFF_CHARS`, which would have flipped `select_review_mode` to MapReduce for diffs in that band. The exact-length method removes that.

#1661: `runner_mapreduce.rs` wrote `ReviewStatus::Degraded` in two independent blocks; now one write gated on partial-coverage or a degraded reason, with the partial-coverage message keeping precedence when both fire.

#1632: `calibrate.rs` reuses `resolve_diff_token` (promoted to `pub` in `runner_helpers.rs`) instead of re-deriving `GithubClient`/`AuthStrategy`; `compute_metrics` returns `anyhow::Result` instead of `assert_eq!` panicking in a `pub fn`.

Test ladder: rung 3 (localized to trusty-review).
Regression tests: `total_rendered_len_is_exact_inside_the_reserve_band_where_the_marker_lies` and `reserve_band_diff_selects_unified_not_mapreduce` (the latter reproduces the marker-based formula and shows it selects MapReduce where the exact length selects Unified); `run_review_mapreduce_both_degraded_triggers_partial_coverage_reason_wins`; `compute_metrics_mismatched_lengths_return_err_not_panic`; plus two source-shape tests pinning the single Degraded write and the helper reuse.

cargo fmt --check: clean
cargo clippy -p trusty-review --all-targets -- -D warnings: clean
cargo test -p trusty-review --no-fail-fast: lib 2058 passed, 0 failed, 5 ignored; bin 85 passed; all integration targets green
check_line_cap / check_sld / check_test_pointers / check_changelog_fragment: OK; check-pr-version-bump: trusty-review 0.31.1 unpublished, no bump

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KsTGDrDYKBPmHmmbRsMm5w
