### PR TITLE
test(trusty-common): serve_until_idle liveness-probe test gets timing margin (Refs #6629)

### DIFF
--- a/crates/trusty-common/src/uds/server/tests.rs
+++ b/crates/trusty-common/src/uds/server/tests.rs
@@ -1147,12 +1147,23 @@ async fn serve_until_idle_ignores_liveness_probes() {
     let (socket, _stop, handle) = spawn_idle_server(tmp.path(), window);
     await_socket(&socket).await;
 
-    // `await_socket` already probed; keep probing across the whole window.
-    for _ in 0..8 {
+    // `await_socket` already probed; keep probing for half the window — four
+    // probes at a window/8 cadence sum to 200ms of the 400ms window, leaving
+    // a 200ms margin (many times typical scheduler jitter) before the
+    // deadline. The original 8-probe loop summed to exactly the window, so
+    // any scheduling delay before it started let the server idle-exit
+    // mid-loop and this same assertion fail under load (#6629).
+    for _ in 0..4 {
         assert!(crate::uds::socket_is_serving(&socket, Duration::from_millis(200)).await);
         tokio::time::sleep(window / 8).await;
     }
+    assert!(
+        !handle.is_finished(),
+        "liveness probes across half the window must not have exited it early"
+    );
 
+    // The join below has no timing race of its own: it waits for whatever
+    // actually happens, up to the 10s timeout, well past the window.
     let exit = tokio::time::timeout(Duration::from_secs(10), handle)
         .await
         .expect("probes must not hold the window open")


### PR DESCRIPTION
Refs #6629.

`serve_until_idle_ignores_liveness_probes` slept `window/8` eight times, summing to exactly the 400 ms idle window, so any scheduling delay before the loop let the server idle-exit mid-loop and the `socket_is_serving` assertion failed under load. It now probes 4× at `window/8` (200 ms of the 400 ms window), asserts the server task is not finished after the loop, then joins under the existing 10 s timeout and asserts `ServeExit::Idle`. The sibling liveness tests already had margin and are unchanged.

Test ladder: rung 2 (test-only stabilization; no fragment owed).
cargo fmt --check: exit 0
cargo clippy -p trusty-common --features uds-supervisor --all-targets -- -D warnings: exit 0
cargo test -p trusty-common --features uds-supervisor --no-fail-fast: 587 passed, 0 failed, 6 ignored
Flake loop: 10/10 passes with a concurrent `cargo clippy --workspace --all-targets` as load
check_line_cap / check_sld / check_test_pointers / check_changelog_fragment: OK

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KsTGDrDYKBPmHmmbRsMm5w
