### PR TITLE
fix(trusty-installer): stack doctor's UDS health probe sends explicit params so trusty-memory answers (Refs #6630)

### DIFF
--- a/crates/trusty-installer/changelog.d/6630-memory-uds-health-params.md
+++ b/crates/trusty-installer/changelog.d/6630-memory-uds-health-params.md
@@ -1,0 +1,11 @@
+Fixed
+
+- `stack doctor` (and every other `tctl` health rollup) no longer reports
+  `trusty-memory … health:down` against a healthy daemon. The UDS probe built
+  its `memory.health` request with no `params` field, which decodes
+  server-side as `Value::Null`; `HealthQuery` is a plain derived `Deserialize`
+  that refuses `null` however many of its fields carry `#[serde(default)]`, so
+  every probe answered with a coded `invalid_params` error that rendered
+  `down`. The request now carries an explicit `"params": {}`, matching the fix
+  `trusty-console`'s own probe already carries for the identical mismatch
+  (#6356) ([#6630](https://github.com/bobmatnyc/trusty-tools/issues/6630)).

--- a/crates/trusty-installer/src/commands/probe_http.rs
+++ b/crates/trusty-installer/src/commands/probe_http.rs
@@ -848,13 +848,28 @@ pub fn classify_rpc_response(frame: &serde_json::Value) -> ProbeOutcome {
 /// What: one `send_framed_request` for `method` at [`REQUEST_TIMEOUT`], then
 /// [`classify_rpc_response`].
 ///
+/// #6630: the frame carries an explicit `"params": {}`, never an absent
+/// `params` field. `RpcRouter::typed` decodes a missing `params` as
+/// `Value::Null`, and trusty-memory's `memory.health` binds `HealthQuery` — a
+/// plain derived `Deserialize` that refuses `null` however many of its fields
+/// carry `#[serde(default)]` (that attribute governs a MISSING key inside an
+/// object, not a `null` in place of the object). `analyze.health` and
+/// `search.health` bind `NoParams`, whose hand-written `Deserialize` calls
+/// `IgnoredAny` and accepts anything including `null` or `{}` — so this was
+/// invisible for both and reached only trusty-memory, exactly as
+/// `trusty-console`'s `detect::memory::probe_health` documents at its own
+/// `#6356` fix for the identical mismatch. Sending `{}` here fixed it there;
+/// it fixes the same defect in this crate's independent copy of the request.
+///
 /// Test: `tests::probe_uds_reads_the_health_envelope_off_a_result_frame`,
-/// `tests::probe_uds_reports_refused_for_an_absent_socket`.
+/// `tests::probe_uds_reports_refused_for_an_absent_socket`,
+/// `tests::probe_uds_sends_explicit_empty_params_so_a_strict_handler_answers`.
 async fn probe_socket(socket: &std::path::Path, method: &str) -> ProbeOutcome {
     let request = serde_json::json!({
         "jsonrpc": "2.0",
         "id": 1,
         "method": method,
+        "params": {},
     });
     match trusty_common::uds::send_framed_request::<_, serde_json::Value>(
         socket,

--- a/crates/trusty-installer/src/commands/probe_http_tests.rs
+++ b/crates/trusty-installer/src/commands/probe_http_tests.rs
@@ -884,6 +884,60 @@ async fn probe_uds_reports_refused_for_an_absent_socket() {
     );
 }
 
+/// REGRESSION (#6630): trusty-memory's `memory.health` binds `HealthQuery`, a
+/// plain derived `Deserialize` that refuses a `null` params value even though
+/// every field of the struct is `#[serde(default)]` — that attribute governs a
+/// MISSING key inside an object, not a `null` standing in for the object
+/// itself. A request with no `params` field decodes server-side as `Value::
+/// Null`, so a live trusty-memory answered every `tctl` probe with a coded
+/// `invalid_params` error and `stack doctor` printed `health:down` for a
+/// healthy daemon — the exact symptom #6630 reported. `analyze.health` and
+/// `search.health` bind `NoParams` (an `IgnoredAny` deserializer that accepts
+/// anything, `null` included), which is why only trusty-memory was affected.
+///
+/// What: binds a socket, captures the raw request bytes `probe_socket` sends,
+/// and asserts the parsed frame carries a `params` field that is a JSON object
+/// (never absent, never `null`) — the shape a strict handler like
+/// `HealthQuery` can decode. The stub still answers so the call completes.
+/// Test: This is the test.
+#[tokio::test]
+async fn probe_uds_sends_explicit_empty_params_so_a_strict_handler_answers() {
+    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let socket = tmp.path().join("sockets").join("memory.sock");
+    let listener = trusty_common::uds::bind_hardened(&socket).expect("bind");
+
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    tokio::spawn(async move {
+        let Ok((mut conn, _)) = listener.accept().await else {
+            return;
+        };
+        let mut buf = vec![0u8; 4096];
+        let n = conn.read(&mut buf).await.unwrap_or(0);
+        let _ = tx.send(buf[..n].to_vec());
+        let reply = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"status\":\"ok\"}}\n";
+        let _ = conn.write_all(reply.as_bytes()).await;
+        let _ = conn.flush().await;
+    });
+
+    let outcome = super::probe_socket(&socket, "memory.health").await;
+    assert!(
+        matches!(outcome, ProbeOutcome::Serving { .. }),
+        "got {outcome:?}"
+    );
+
+    let sent = rx.await.expect("the request frame must be captured");
+    let frame: serde_json::Value =
+        serde_json::from_slice(&sent).expect("the sent frame must be valid JSON");
+    assert!(
+        frame
+            .get("params")
+            .is_some_and(serde_json::Value::is_object),
+        "params must be an explicit object, never absent or null: {frame}"
+    );
+}
+
 /// A short-path data dir for a test that has to BIND the derived socket.
 ///
 /// Why not `test_support::stub_data_dir`: a `sun_path` is 104 bytes on macOS,


### PR DESCRIPTION
Refs #6630.

`tctl stack doctor` reported trusty-memory `health:down` while the daemon was healthy. The routing was already UDS (`uds_socket_for` / `uds_health_method` since #6286); the defect was that `probe_socket` built the JSON-RPC frame with no `params` field. `RpcRouter::typed` decodes an absent `params` as `null`, and trusty-memory's `memory.health` binds `HealthQuery`, a derived `Deserialize` that refuses `null` (`#[serde(default)]` covers a missing key, not a null object), so every probe got `-32602 params do not decode` and rendered as `down`. `analyze.health` / `search.health` bind `NoParams` and were unaffected, the same asymmetry trusty-console fixed for itself in #6356.

Fix: `probe_socket` sends `"params": {}` on every UDS health dial.

Live on this host, read-only, nothing restarted: before (installed tctl 0.13.4) `trusty-memory 0.25.6 … health:down`, verdict degraded (exit 2); after (built from this branch) `health:healthy`, verdict ok (exit 0).

Test ladder: rung 3 (localized to trusty-installer).
Regression test `probe_uds_sends_explicit_empty_params_so_a_strict_handler_answers` captures the raw frame and asserts `params` is an object; it fails on origin/main with `{"id":1,"jsonrpc":"2.0","method":"memory.health"}`.

cargo fmt --check: exit 0
cargo check / clippy -p trusty-installer --all-targets -- -D warnings: clean
cargo test -p trusty-installer --no-fail-fast: 697 passed, 0 failed, 4 ignored (lib) + 3 + 3 (integration)
check_line_cap / check_sld / check_test_pointers / check_changelog_fragment: OK; check-pr-version-bump: trusty-installer 0.13.4 unpublished, no bump

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KsTGDrDYKBPmHmmbRsMm5w
