### PR TITLE
fix(trusty-mpm): pm bash guard denies rm/rmdir/unlink/find -delete against absolute-path roots (Refs #4031)

### DIFF
--- a/crates/trusty-mpm/changelog.d/4031-pm-guard-rm-rmdir.md
+++ b/crates/trusty-mpm/changelog.d/4031-pm-guard-rm-rmdir.md
@@ -15,3 +15,16 @@ Fixed
   .[!.]*`) against the same denylist, and resolves a leading `\` or a
   `command`/`builtin` wrapper (`\rm`, `command rm`) to the real verb — closing
   four bypasses of the rule above found in review (#4031).
+- Verb detection for `rm`/`rmdir`/`unlink`/`find` no longer enumerates wrapper
+  words at all — it scans every token of a Bash segment for the verb itself,
+  so `env -i rm -rf /root`, `nice rm -rf /root`, `exec rm -rf /root`, and
+  every other wrapper (known or future) deny the same as the plain form. A
+  delete verb whose target cannot be resolved (an unparseable segment, or a
+  bare invocation with no argument) now denies rather than silently allows.
+  The denylist also covers bare container roots (`/Users`, `/home`,
+  `/Volumes`, `/private`, `/var`, `/etc`, `/usr`, `/opt`, `/Library`,
+  `/System`, `/Applications`, and `$HOME`'s parent), not just a single user's
+  home. `shell_lex::git_subcommand` now shares the same wrapper-skip helper as
+  the `rm` guard's `cd`-tracker, so `command git apply -`, `command git
+  worktree remove --force <path>`, and `\git reset --hard` reach the existing
+  git guards where their plain forms already denied (#4031).

--- a/crates/trusty-mpm/changelog.d/4031-pm-guard-rm-rmdir.md
+++ b/crates/trusty-mpm/changelog.d/4031-pm-guard-rm-rmdir.md
@@ -9,3 +9,9 @@ Fixed
   source. Ordinary cleanup (`rm stale.txt`, `cargo clean`, `git clean -fd`) is
   unaffected, and `git worktree remove` / `git branch -D` are untouched by
   this rule (#4031).
+- The guard now also expands a literal `$PWD`/`${PWD}` target to the tracked
+  effective working directory, evaluates the PARENT directory of a
+  glob-suffixed target (`rm -rf ~/*`, `rm -rf /Users/<name>/*`, `rm -rf
+  .[!.]*`) against the same denylist, and resolves a leading `\` or a
+  `command`/`builtin` wrapper (`\rm`, `command rm`) to the real verb — closing
+  four bypasses of the rule above found in review (#4031).

--- a/crates/trusty-mpm/changelog.d/4031-pm-guard-rm-rmdir.md
+++ b/crates/trusty-mpm/changelog.d/4031-pm-guard-rm-rmdir.md
@@ -1,0 +1,11 @@
+Fixed
+- The PM bash guard now denies `rm`/`rmdir`/`unlink`/`find … -delete` when the
+  resolved target is a filesystem root (`/`, `/root`, `/Users/<name>`,
+  `$HOME`), a repository root, a `.git` directory, or a
+  `.claude/worktrees`/`.worktrees` entry. Previously no `rm`/`rmdir` verb
+  existed anywhere in the classifier, so a PM session — or an agent it
+  dispatches — could delete a filesystem root or another session's worktree
+  through Bash even though the guard already blocked `Edit`/`Write` on
+  source. Ordinary cleanup (`rm stale.txt`, `cargo clean`, `git clean -fd`) is
+  unaffected, and `git worktree remove` / `git branch -D` are untouched by
+  this rule (#4031).

--- a/crates/trusty-mpm/changelog.d/4031-pm-guard-rm-rmdir.md
+++ b/crates/trusty-mpm/changelog.d/4031-pm-guard-rm-rmdir.md
@@ -28,3 +28,6 @@ Fixed
   the `rm` guard's `cd`-tracker, so `command git apply -`, `command git
   worktree remove --force <path>`, and `\git reset --hard` reach the existing
   git guards where their plain forms already denied (#4031).
+- A specific user's home root now denies on Linux too — `rm -rf
+  /home/<name>` and its glob-suffixed form, previously recognized only as
+  `/Users/<name>` on macOS (#4031).

--- a/crates/trusty-mpm/src/bin/tm/commands/hook_rewrite.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/hook_rewrite.rs
@@ -245,6 +245,85 @@ fn is_orchestrator_command(command: &str) -> bool {
     }
 }
 
+/// Wrapper words that precede a real command without changing which program
+/// ultimately runs — privilege/environment wrappers (`sudo`, `env`,
+/// `command`, `builtin`, `doas`) and process/resource wrappers (`nice`,
+/// `time`, `nohup`, `exec`, `ionice`, `timeout`, `stdbuf`, `caffeinate`)
+/// alike. Issue #4031 review (pass 2): enumerating only `sudo`/`env` (then
+/// `command`/`builtin`) left `nice rm -rf /`, `nohup rm -rf /`, `exec rm -rf
+/// /`, and `env -i rm -rf /root` unresolved — each is a DIFFERENT wrapper
+/// bypassing the SAME enumeration weakness, so the fix is one list shared by
+/// every caller rather than another single word added to it.
+/// What: matched exactly (no prefix/substring matching) by [`strip_wrapper_prefix`].
+pub(crate) const COMMAND_WRAPPERS: &[&str] = &[
+    "sudo",
+    "env",
+    "command",
+    "builtin",
+    "doas",
+    "nice",
+    "time",
+    "nohup",
+    "exec",
+    "ionice",
+    "timeout",
+    "stdbuf",
+    "caffeinate",
+];
+
+/// Skip a leading run of `KEY=value` env-assignments and [`COMMAND_WRAPPERS`]
+/// tokens in `tokens` (a leading `\` on any token stripped before comparison,
+/// per the same alias-bypass idiom [`first_command_token`] documents),
+/// returning the index of the first token that is neither — the real command
+/// — or `None` when a wrapper is immediately followed by a flag-shaped token
+/// (`sudo -u root make`, `env -i cmd`): resolving the real program name past
+/// that needs argument-aware parsing this function doesn't do.
+///
+/// Why: [`first_command_token`] and [`super::pm_guard_bash::shell_lex::git_subcommand`]
+/// both need this exact skip — a wrapper reaching either unresolved is a
+/// classifier silently seeing a different (wrapped) command than the one
+/// that will actually run (issue #4031 review). One generic helper, indexing
+/// into whatever token slice the caller already has (`&[&str]` here,
+/// `&[String]` from `shlex::split` there), is what keeps the two from
+/// re-diverging the way `sudo`/`env`-only enumeration already had once.
+/// What: generic over any `T: AsRef<str>` token slice; loops advancing past
+/// each env-assignment or wrapper ONE TOKEN AT A TIME — a wrapper only
+/// consumes itself, then re-examines the following token (which may be
+/// another wrapper, an env-assignment, or the real command) — and returns
+/// the index it stops at. A wrapper followed by nothing, or by a
+/// flag-shaped token (ambiguous: might be the wrapper's own flag, e.g.
+/// `sudo -u root`), yields `None` rather than guessing.
+/// Test: `strip_wrapper_prefix_skips_env_assignment`,
+/// `strip_wrapper_prefix_skips_every_known_wrapper`,
+/// `strip_wrapper_prefix_none_for_wrapper_followed_by_flag`,
+/// `strip_wrapper_prefix_skips_backslash_before_a_wrapper`.
+pub(crate) fn strip_wrapper_prefix<T: AsRef<str>>(tokens: &[T]) -> Option<usize> {
+    let mut i = 0;
+    while i < tokens.len() {
+        let raw = tokens[i].as_ref();
+        let tok = raw.strip_prefix('\\').unwrap_or(raw);
+        if is_env_assignment(tok) {
+            i += 1;
+            continue;
+        }
+        if COMMAND_WRAPPERS.contains(&tok) {
+            match tokens.get(i + 1) {
+                // The wrapper itself is the only token consumed here — the
+                // NEXT token becomes the new candidate to re-examine (it may
+                // itself be another wrapper, an env-assignment, or the real
+                // command), which is why this advances by ONE, not two.
+                Some(next) if !next.as_ref().starts_with('-') => {
+                    i += 1;
+                    continue;
+                }
+                _ => return None,
+            }
+        }
+        break;
+    }
+    Some(i)
+}
+
 /// Extract the effective first command token, stripping noise prefixes.
 ///
 /// Why: A raw `command.split_whitespace().next()` would miss
@@ -252,26 +331,14 @@ fn is_orchestrator_command(command: &str) -> bool {
 /// `/usr/bin/make` (absolute path) — all of which should still match
 /// `make` for exclusion purposes. Being permissive here trades a little
 /// precision for staying on the safe (under-rewrite) side.
-/// What: Loops skipping any number of leading `KEY=value`-shaped tokens
-/// interleaved with `sudo`/`env` prefixes (so `env FOO=bar make build`
-/// resolves to `make` just like `sudo make build` does — see
-/// [`effective_tool_name`]'s doc comment for the same `env`-handling gap
-/// this mirrors), then returns the basename (post-`/`) of whatever token
-/// remains.
-/// Returns `None` — "can't confidently resolve" — when the token
-/// immediately after `sudo`/`env`/`command`/`builtin` is itself flag-shaped
-/// (starts with `-`, e.g. `sudo -u root make`, `env -i cmd`): the real
-/// program name in that case needs argument-aware parsing this function
-/// doesn't do, and [`is_orchestrator_command`] treats `None` as
-/// "conservatively assume orchestrator" rather than risk missing a real
+/// What: delegates the prefix-skip to [`strip_wrapper_prefix`], then returns
+/// the basename (post-`/`, post-`\`) of whatever token remains.
+/// Returns `None` — "can't confidently resolve" — under the same condition
+/// [`strip_wrapper_prefix`] does (a wrapper followed by a flag-shaped
+/// token): the real program name in that case needs argument-aware parsing
+/// this function doesn't do, and [`is_orchestrator_command`] treats `None`
+/// as "conservatively assume orchestrator" rather than risk missing a real
 /// exclusion (trusty-review finding, PR #1968).
-///
-/// A leading `\` and a `command`/`builtin` wrapper are the two standard
-/// POSIX idioms for bypassing a shell alias/function of the same name —
-/// `\rm -rf /` and `command rm -rf /` both run the real `rm` exactly as
-/// `rm -rf /` does. Neither was stripped here, so a resolved verb like `\rm`
-/// or `command rm` never matched a guard's `"rm"` literal and slipped past
-/// every classifier this function feeds (issue #4031 review, HIGH 3/4).
 /// Test: `first_command_token_strips_env_assignment`,
 /// `first_command_token_strips_sudo`, `first_command_token_strips_path`,
 /// `first_command_token_plain_command`,
@@ -280,38 +347,19 @@ fn is_orchestrator_command(command: &str) -> bool {
 /// `first_command_token_strips_leading_backslash`,
 /// `first_command_token_strips_command_wrapper`,
 /// `first_command_token_strips_builtin_wrapper`,
-/// `first_command_token_strips_backslash_after_sudo`.
+/// `first_command_token_strips_backslash_after_sudo`,
+/// `first_command_token_strips_nice_time_nohup_exec`.
 pub(crate) fn first_command_token(command: &str) -> Option<&str> {
-    let mut tokens = command.split_whitespace();
-    let mut tok = tokens.next()?;
-    loop {
-        // #4031: strip the alias-bypass backslash BEFORE every other check —
-        // it can precede an env assignment, `sudo`/`env`/`command`/`builtin`,
-        // or the real program name itself, and each `continue` below re-runs
-        // this strip on the next token.
-        if let Some(stripped) = tok.strip_prefix('\\') {
-            tok = stripped;
-        }
-        if is_env_assignment(tok) {
-            tok = tokens.next()?;
-            continue;
-        }
-        if tok == "sudo" || tok == "env" || tok == "command" || tok == "builtin" {
-            let next = tokens.next()?;
-            if next.starts_with('-') {
-                return None;
-            }
-            tok = next;
-            continue;
-        }
-        break;
-    }
+    let tokens: Vec<&str> = command.split_whitespace().collect();
+    let start = strip_wrapper_prefix(&tokens)?;
+    let tok = tokens.get(start)?;
+    let tok = tok.strip_prefix('\\').unwrap_or(tok);
     Some(tok.rsplit('/').next().unwrap_or(tok))
 }
 
 /// Whether `token` looks like a `KEY=value` shell environment assignment.
 ///
-/// Why: Shared by [`first_command_token`]; split out so the "what counts as
+/// Why: Shared by [`strip_wrapper_prefix`]; split out so the "what counts as
 /// an env assignment" rule has one definition.
 /// What: `KEY` must be non-empty, start with a letter or underscore, and
 /// contain only alphanumerics/underscores up to the first `=`.
@@ -637,6 +685,62 @@ mod tests {
         // as `sudo rm` — the backslash strip re-runs on every token the
         // `sudo`/`env`/`command`/`builtin` arm advances to.
         assert_eq!(first_command_token("sudo \\rm -rf /root"), Some("rm"));
+    }
+
+    #[test]
+    fn first_command_token_strips_nice_time_nohup_exec() {
+        // #4031 review pass 2: enumerating only sudo/env/command/builtin
+        // left process/resource wrappers unresolved — the whole class closes
+        // at once via `COMMAND_WRAPPERS`, not one word at a time.
+        //
+        // `env -i rm -rf /root` is deliberately excluded here: `-i` is env's
+        // OWN flag, and this function still degrades to `None` on a wrapper
+        // immediately followed by a flag-shaped token, unchanged from
+        // `sudo -u root make`. That case is closed instead in
+        // `destructive_delete.rs`, which no longer depends on this function
+        // for verb detection at all (issue #4031 review, item 1).
+        for command in [
+            "nice rm -rf /root",
+            "time rm -rf /root",
+            "nohup rm -rf /root",
+            "exec rm -rf /root",
+        ] {
+            assert_eq!(
+                first_command_token(command),
+                Some("rm"),
+                "expected \"rm\" for: {command}"
+            );
+        }
+    }
+
+    #[test]
+    fn strip_wrapper_prefix_skips_env_assignment() {
+        let tokens = ["FOO=bar", "make", "build"];
+        assert_eq!(strip_wrapper_prefix(&tokens), Some(1));
+    }
+
+    #[test]
+    fn strip_wrapper_prefix_skips_every_known_wrapper() {
+        for wrapper in COMMAND_WRAPPERS {
+            let tokens = [*wrapper, "rm", "-rf", "/root"];
+            assert_eq!(
+                strip_wrapper_prefix(&tokens),
+                Some(1),
+                "expected wrapper {wrapper} to be skipped"
+            );
+        }
+    }
+
+    #[test]
+    fn strip_wrapper_prefix_none_for_wrapper_followed_by_flag() {
+        let tokens = ["sudo", "-u", "root", "make"];
+        assert_eq!(strip_wrapper_prefix(&tokens), None);
+    }
+
+    #[test]
+    fn strip_wrapper_prefix_skips_backslash_before_a_wrapper() {
+        let tokens = ["\\nice", "rm", "-rf", "/root"];
+        assert_eq!(strip_wrapper_prefix(&tokens), Some(1));
     }
 
     #[test]

--- a/crates/trusty-mpm/src/bin/tm/commands/hook_rewrite.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/hook_rewrite.rs
@@ -259,26 +259,44 @@ fn is_orchestrator_command(command: &str) -> bool {
 /// this mirrors), then returns the basename (post-`/`) of whatever token
 /// remains.
 /// Returns `None` — "can't confidently resolve" — when the token
-/// immediately after `sudo`/`env` is itself flag-shaped (starts with `-`,
-/// e.g. `sudo -u root make`, `env -i cmd`): the real program name in that
-/// case needs argument-aware parsing this function doesn't do, and
-/// [`is_orchestrator_command`] treats `None` as "conservatively assume
-/// orchestrator" rather than risk missing a real exclusion (trusty-review
-/// finding, PR #1968).
+/// immediately after `sudo`/`env`/`command`/`builtin` is itself flag-shaped
+/// (starts with `-`, e.g. `sudo -u root make`, `env -i cmd`): the real
+/// program name in that case needs argument-aware parsing this function
+/// doesn't do, and [`is_orchestrator_command`] treats `None` as
+/// "conservatively assume orchestrator" rather than risk missing a real
+/// exclusion (trusty-review finding, PR #1968).
+///
+/// A leading `\` and a `command`/`builtin` wrapper are the two standard
+/// POSIX idioms for bypassing a shell alias/function of the same name —
+/// `\rm -rf /` and `command rm -rf /` both run the real `rm` exactly as
+/// `rm -rf /` does. Neither was stripped here, so a resolved verb like `\rm`
+/// or `command rm` never matched a guard's `"rm"` literal and slipped past
+/// every classifier this function feeds (issue #4031 review, HIGH 3/4).
 /// Test: `first_command_token_strips_env_assignment`,
 /// `first_command_token_strips_sudo`, `first_command_token_strips_path`,
 /// `first_command_token_plain_command`,
 /// `first_command_token_strips_env_command_prefix`,
-/// `first_command_token_none_for_sudo_followed_by_flag`.
+/// `first_command_token_none_for_sudo_followed_by_flag`,
+/// `first_command_token_strips_leading_backslash`,
+/// `first_command_token_strips_command_wrapper`,
+/// `first_command_token_strips_builtin_wrapper`,
+/// `first_command_token_strips_backslash_after_sudo`.
 pub(crate) fn first_command_token(command: &str) -> Option<&str> {
     let mut tokens = command.split_whitespace();
     let mut tok = tokens.next()?;
     loop {
+        // #4031: strip the alias-bypass backslash BEFORE every other check —
+        // it can precede an env assignment, `sudo`/`env`/`command`/`builtin`,
+        // or the real program name itself, and each `continue` below re-runs
+        // this strip on the next token.
+        if let Some(stripped) = tok.strip_prefix('\\') {
+            tok = stripped;
+        }
         if is_env_assignment(tok) {
             tok = tokens.next()?;
             continue;
         }
-        if tok == "sudo" || tok == "env" {
+        if tok == "sudo" || tok == "env" || tok == "command" || tok == "builtin" {
             let next = tokens.next()?;
             if next.starts_with('-') {
                 return None;
@@ -590,6 +608,35 @@ mod tests {
         // bogus token `"-u"`.
         assert_eq!(first_command_token("sudo -u root make build"), None);
         assert_eq!(first_command_token("env -i make build"), None);
+    }
+
+    #[test]
+    fn first_command_token_strips_leading_backslash() {
+        // #4031 review, HIGH 3: `\rm` is the standard alias-bypass idiom —
+        // Bash itself strips the backslash before exec, so this classifier
+        // must too, or a resolved verb like `\rm` never matches `"rm"`.
+        assert_eq!(first_command_token("\\rm -rf /root"), Some("rm"));
+    }
+
+    #[test]
+    fn first_command_token_strips_command_wrapper() {
+        // #4031 review, HIGH 4: `command rm` runs the real `rm`, bypassing
+        // any shell function/alias named `rm` — the same bypass class as a
+        // leading backslash, via the POSIX `command` builtin instead.
+        assert_eq!(first_command_token("command rm -rf /root"), Some("rm"));
+    }
+
+    #[test]
+    fn first_command_token_strips_builtin_wrapper() {
+        assert_eq!(first_command_token("builtin rm -rf /root"), Some("rm"));
+    }
+
+    #[test]
+    fn first_command_token_strips_backslash_after_sudo() {
+        // The two bypass idioms compose: `sudo \rm` must resolve the same
+        // as `sudo rm` — the backslash strip re-runs on every token the
+        // `sudo`/`env`/`command`/`builtin` arm advances to.
+        assert_eq!(first_command_token("sudo \\rm -rf /root"), Some("rm"));
     }
 
     #[test]

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard.rs
@@ -78,6 +78,19 @@
 //! in the file to pierce an automatic-marker exemption; see that call
 //! site's comment for why it must never be routed through [`evaluate_tool`]
 //! instead.
+//! **Destructive-root deletion guard (issue #4031):** immediately after the
+//! worktree-tmp guard, and ahead of the same two exemptions,
+//! [`crate::commands::pm_guard_bash::evaluate_destructive_delete_command`]
+//! denies `rm`/`rmdir`/`unlink`/`find … -delete` when the resolved target is a
+//! filesystem root (`/`, `/root`, `/Users/<name>`, `$HOME`), a repository
+//! root, a `.git` directory, or a `.claude/worktrees`/`.worktrees` entry — a
+//! TARGET-PATH classifier in the same shape as the worktree-tmp guard above,
+//! not a verb-name enumerator. It denies every caller, PM included, because
+//! none of those targets is ever legitimate; ordinary cleanup elsewhere
+//! (`rm stale.txt`, `cargo clean`, `git clean -fd`) is untouched, and neither
+//! is `git worktree remove` (governed by #5791 below) or `git branch -D`
+//! (never restricted). See `pm_guard_bash::destructive_delete` for the full
+//! denylist and its residual bypasses.
 //! **Main-checkout destructive-git guard (ADR-0037):** immediately after the
 //! worktree-tmp guard, and ahead of the same two exemptions,
 //! [`crate::commands::pm_guard_bash::evaluate_main_checkout_destructive_command`]
@@ -191,9 +204,10 @@ use std::path::{Path, PathBuf};
 use crate::commands::misc::{DISABLE_HOOKS_ENV, SUB_AGENT_ENV, read_stdin_hook_payload};
 use crate::commands::pm_guard_bash::{
     CommitVerdict, SHELL_EDIT_REASON, docs_commit_deny_reason, evaluate_bash_command,
-    evaluate_main_checkout_commit_command, evaluate_main_checkout_destructive_command,
-    evaluate_worktree_add_command, evaluate_worktree_remove_command, extract_shell_edit_target,
-    head_move_deny_reason, main_checkout_head_move,
+    evaluate_destructive_delete_command, evaluate_main_checkout_commit_command,
+    evaluate_main_checkout_destructive_command, evaluate_worktree_add_command,
+    evaluate_worktree_remove_command, extract_shell_edit_target, head_move_deny_reason,
+    main_checkout_head_move,
 };
 use crate::commands::pm_guard_budget::{self, BudgetDecision, DEFAULT_FILE_CHANGE_BUDGET};
 use crate::commands::pm_guard_cost;
@@ -378,6 +392,25 @@ pub(crate) async fn pm_guard(url: &str) -> anyhow::Result<()> {
             .and_then(|v| v.as_str())
             .unwrap_or_default();
         if let Some(reason) = evaluate_worktree_add_command(command, &hook_cwd) {
+            audit_denied_tool(url, session_id, tool_name, reason).await;
+            println!("{}", build_pretooluse_deny_response(reason));
+            return Ok(());
+        }
+        // ABSOLUTE guard (issue #4031) — the same placement, and for the same
+        // structural reason, as the worktree-tmp guard directly above: an
+        // agent with script drift can `rm -rf` another session's worktree, or
+        // a filesystem root, just as easily as it could provision a worktree
+        // under /tmp, so a rule reachable only after Guard 1/4 would be a
+        // no-op for exactly the calling pattern (a dispatched agent) it exists
+        // to catch. Unlike the sibling `evaluate_worktree_remove_command`
+        // below (PM-exempt, agent-only), this denies EVERY caller — the PM
+        // included — because none of its denylisted targets (a filesystem
+        // root, the repo root, a `.git` directory, a worktree root) is ever
+        // legitimate for anyone. See `pm_guard_bash::destructive_delete` for
+        // the target-path classifier and what stays allowed (ordinary file
+        // cleanup, `cargo clean`, `git clean -fd`, and — untouched by this
+        // rule entirely — `git worktree remove` and `git branch -D`).
+        if let Some(reason) = evaluate_destructive_delete_command(command, &hook_cwd) {
             audit_denied_tool(url, session_id, tool_name, reason).await;
             println!("{}", build_pretooluse_deny_response(reason));
             return Ok(());

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/destructive_delete.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/destructive_delete.rs
@@ -1,0 +1,468 @@
+//! `tm hook --pm-guard` — destructive-root deletion guard (#4031).
+//!
+//! Why: no `rm`/`rmdir`/`unlink`/`find … -delete` verb existed anywhere in
+//! [`super::classify_bash_segment`], so those deletions were entirely
+//! unenforced — a PM session, or an agent it dispatches, with script drift can
+//! recursively delete another session's worktree or in-flight work via
+//! `rm -rf`, even though the guard already blocks `Edit`/`Write` on source.
+//! This closes the SAFETY subset only (owner ruling on #3973): recursive
+//! force-deletion of a filesystem root (`/`, `/root`, `/Users/<name>`,
+//! `$HOME`), a repository root, a `.git` directory, or a
+//! `.claude/worktrees`/`.worktrees` entry. It deliberately does NOT block
+//! ordinary local cleanup (`rm stale.txt`), build-artifact cleanup
+//! (`cargo clean`), or local temp cleanup (`git clean -fd`) — none of those
+//! target a denylisted path.
+//! What: [`evaluate_destructive_delete_command`] is the same TARGET-PATH
+//! classifier shape as the sibling
+//! [`super::evaluate_worktree_add_command`] (issue #3977's precedent) rather
+//! than a verb-name enumerator — matching only the literal `rm` token would
+//! miss `rmdir`/`unlink`/`find -delete`, so instead every composition segment
+//! whose resolved program is one of those four is inspected for its
+//! DELETION-TARGET argument(s), which are resolved against a `cd`-tracked
+//! effective working directory (the same [`PathEnv`] expansion and lexical
+//! normalization [`super::evaluate_worktree_add_command`] uses) and checked
+//! against [`is_denylisted_delete_target`]. It is called from `pm_guard()`
+//! BEFORE Guard 1's and Guard 4's early returns, and applies to every caller —
+//! the PM and any subagent alike — matching the worktree-add-tmp and
+//! main-checkout-destructive guards' placement, not the PM-exempt shape of the
+//! sibling [`super::evaluate_worktree_remove_command`]: a filesystem-root,
+//! repo-root, `.git`, or worktree deletion is never legitimate for either
+//! caller, so there is no exemption to preserve. `git worktree remove` and
+//! `git branch -D` are untouched by this rule — they are different verbs,
+//! governed by their own existing rules (`git worktree remove` by #5791; `git
+//! branch -D` by no rule at all, allowed for both PM and subagent, unchanged).
+//!
+//! Residual bypasses accepted, stated rather than hidden (same shape as the
+//! sibling worktree-add guard's own list, which this module inherits by
+//! construction):
+//! - Indirection through a shell variable (`X=/; rm -rf "$X"`) or a command
+//!   substitution (`rm -rf "$(mktemp -d)"`) is not resolved.
+//! - A verb reached via `xargs`, `sh -c`, or a shell function/alias is not
+//!   resolved — this module reads the same [`first_command_token`] every
+//!   other verb in this file's classifier reads, and none of them unwrap those
+//!   wrappers either.
+//! - A symlink whose target is a denylisted root is not followed — resolution
+//!   here is purely lexical, never `fs::canonicalize`, for the same
+//!   fast/side-effect-free reason [`super::resolve_target_path`] documents.
+//! - The Guard 2/3 operator escape hatches
+//!   (`TRUSTY_MPM_DISABLE_HOOKS`/`TRUSTY_MPM_PM_UNRESTRICTED`) lift this rule
+//!   along with every other in the file — tracked separately as issue #3981.
+//!
+//! Test: `denies_filesystem_root_deletion`, `denies_repo_root_deletion`,
+//! `denies_dot_git_deletion`, `denies_worktree_root_deletion`,
+//! `allows_worktree_interior_paths`, `allows_ordinary_cleanup`,
+//! `denies_rmdir_of_a_denylisted_root`, `denies_find_delete_of_a_denylisted_root`,
+//! `denies_a_delete_hidden_in_a_composed_command`,
+//! `denies_home_expanded_from_a_literal_dollar_home` below;
+//! `pm_guard_denies_destructive_delete_of_repo_root` and siblings in
+//! `tests/tm_hook_pm_guard.rs` exercise the end-to-end binary path.
+
+use std::path::{Component, Path};
+
+use trusty_mpm::core::project_aliases::main_checkout_root;
+
+use super::{PathEnv, resolve_target_path, split_shell_segments};
+use crate::commands::hook_rewrite::first_command_token;
+
+/// Deny reason for `rm`/`rmdir`/`unlink`/`find -delete` targeting a
+/// denylisted destructive root (issue #4031).
+///
+/// Why: a bare refusal invites a retry with a different verb or a hand-rolled
+/// workaround, so the text names every denylisted category and the one
+/// sanctioned path for the worktree case (the PM's `tm session
+/// prune-worktrees`), the same way [`super::WORKTREE_REMOVE_DENY_REASON`]
+/// does for the sibling `git worktree remove` rule.
+/// What: the `permissionDecisionReason` string emitted on this deny.
+pub(crate) const DESTRUCTIVE_DELETE_REASON: &str = "`rm`/`rmdir`/`unlink`/`find -delete` must \
+     not target a filesystem root (`/`, `/root`, `/Users/<name>`, `$HOME`), a repository root, a \
+     `.git` directory, or a `.claude/worktrees`/`.worktrees` entry (issue #4031) — each is either \
+     unrecoverable data loss or another session's or workstream's uncommitted work. Ordinary file \
+     and directory cleanup elsewhere (build artifacts, stale files, `git clean -fd`) is unaffected. \
+     To remove a worktree, ask the PM to run `tm session prune-worktrees --merged-prs --force` — \
+     `rm -rf` on a worktree directory is never the workaround.";
+
+/// The four verbs this guard inspects — everything else falls through to
+/// [`super::classify_bash_segment`]'s ordinary rules unchanged.
+const DELETE_VERBS: &[&str] = &["rm", "rmdir", "unlink", "find"];
+
+/// Classify a Bash command for destructive-root deletion: `Some(reason)`
+/// denies, `None` allows.
+///
+/// Why: the one entry point `pm_guard` calls, kept to the same
+/// process-environment-reading wrapper shape as
+/// [`super::evaluate_worktree_add_command`] so the policy underneath stays
+/// testable without touching `std::env`.
+/// What: delegates to [`evaluate_destructive_delete_command_in`] against the
+/// guard process's real environment.
+/// Test: see the module doc's test list.
+pub(crate) fn evaluate_destructive_delete_command(
+    command: &str,
+    cwd: &Path,
+) -> Option<&'static str> {
+    evaluate_destructive_delete_command_in(command, cwd, &PathEnv::from_process())
+}
+
+/// [`evaluate_destructive_delete_command`] against an explicit environment —
+/// see [`PathEnv`] for why production and tests must not share `std::env`
+/// mutation.
+fn evaluate_destructive_delete_command_in(
+    command: &str,
+    cwd: &Path,
+    env: &PathEnv,
+) -> Option<&'static str> {
+    let mut effective_cwd = cwd.to_path_buf();
+    for segment in split_shell_segments(command) {
+        let trimmed = segment.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        // Same `cd`-tracking shape as `evaluate_worktree_add_command_in`: a
+        // deliberate, partial closing of `cd /tmp && rm -rf x` — see that
+        // function's doc for the residual (shell-variable / substitution
+        // built `cd` target) this shares.
+        if first_command_token(trimmed) == Some("cd") {
+            if let Some(argv) = shlex::split(trimmed)
+                && let Some(dest) = argv.get(1)
+            {
+                effective_cwd = resolve_target_path(dest, &effective_cwd, env);
+            }
+            continue;
+        }
+        let Some(program) = first_command_token(trimmed) else {
+            continue;
+        };
+        if !DELETE_VERBS.contains(&program) {
+            continue;
+        }
+        let Some(argv) = shlex::split(trimmed) else {
+            continue;
+        };
+        // Locate the resolved program's own position in argv rather than
+        // assuming index 0 — `first_command_token` already skipped any
+        // env-assignment (`FOO=bar rm …`) or `sudo`/`env` prefix to find
+        // `program`, and this reuses that same resolved name to find where
+        // the real argument list begins, without duplicating that skip logic.
+        let Some(start) = argv
+            .iter()
+            .position(|tok| tok.rsplit('/').next() == Some(program))
+        else {
+            continue;
+        };
+        let tail = &argv[start + 1..];
+        let targets = delete_targets(program, tail);
+        if targets.is_empty() {
+            continue;
+        }
+        let repo_root = main_checkout_root(&effective_cwd);
+        for target in targets {
+            let resolved = resolve_target_path(&target, &effective_cwd, env);
+            if is_denylisted_delete_target(&resolved, repo_root.as_deref(), env) {
+                return Some(DESTRUCTIVE_DELETE_REASON);
+            }
+        }
+    }
+    None
+}
+
+/// The path argument(s) a resolved deletion verb's argv tail would act on.
+///
+/// Why: `rm`/`rmdir`/`unlink` take one or more trailing paths with no
+/// value-taking flags, but `find`'s search root(s) are its LEADING positional
+/// tokens — anything after the first flag is an expression operand (e.g. the
+/// pattern in `-name '*.rs'`), not a path.
+/// What: `rm`/`rmdir`/`unlink` → every non-flag token (honoring a `--`
+/// end-of-options marker); `find` → the leading non-flag tokens, defaulting to
+/// `.` (find's own default search root) when none precede the first flag, and
+/// only when `-delete` appears somewhere in `tail` — a `find` with no
+/// `-delete` action never deletes anything and is not this rule's business.
+fn delete_targets(program: &str, tail: &[String]) -> Vec<String> {
+    if program == "find" {
+        if !tail.iter().any(|t| t == "-delete") {
+            return Vec::new();
+        }
+        let paths: Vec<String> = tail
+            .iter()
+            .take_while(|t| !t.starts_with('-'))
+            .cloned()
+            .collect();
+        return if paths.is_empty() {
+            vec![".".to_string()]
+        } else {
+            paths
+        };
+    }
+    let mut out = Vec::new();
+    let mut positional_only = false;
+    for tok in tail {
+        if !positional_only && tok == "--" {
+            positional_only = true;
+            continue;
+        }
+        if !positional_only && tok.starts_with('-') && tok.len() > 1 {
+            continue;
+        }
+        out.push(tok.clone());
+    }
+    out
+}
+
+/// Whether `path` is one of the destructive-root categories issue #4031
+/// denylists.
+///
+/// What: `true` when `path`, after [`resolve_target_path`]'s expansion and
+/// lexical normalization, is exactly `/`, `/root`, `$HOME`'s resolved value, a
+/// single-level `/Users/<name>` home root, the checkout's own repository root
+/// (`repo_root`, resolved once per segment by the caller via
+/// [`main_checkout_root`] — `None` for a worktree, whose own root is instead
+/// caught by [`is_worktree_root_or_container`]), a path whose basename is
+/// exactly `.git`, or a `.claude/worktrees`/`.worktrees` entry at or one level
+/// below the container directory. Deeper paths — a file or subdirectory
+/// inside a worktree, inside `$HOME`, or inside the repo — are NOT denylisted;
+/// this is a target-PATH classifier, not a target-root-prefix one, so ordinary
+/// cleanup under any of these stays allowed.
+fn is_denylisted_delete_target(path: &Path, repo_root: Option<&Path>, env: &PathEnv) -> bool {
+    if path == Path::new("/") || path == Path::new("/root") {
+        return true;
+    }
+    if let Some(home) = env.home.as_deref()
+        && path == Path::new(home)
+    {
+        return true;
+    }
+    if is_user_home_root(path) {
+        return true;
+    }
+    if path.file_name().and_then(|f| f.to_str()) == Some(".git") {
+        return true;
+    }
+    if repo_root.is_some_and(|root| path == root) {
+        return true;
+    }
+    is_worktree_root_or_container(path)
+}
+
+/// Whether `path` is exactly a single-level `/Users/<name>` entry — someone's
+/// entire home directory on macOS.
+///
+/// What: `true` only for `RootDir, Normal("Users"), Normal(_)` with nothing
+/// after — `/Users/bob/Projects/foo` (an ordinary subdirectory) is NOT
+/// matched, only `/Users/bob` itself.
+fn is_user_home_root(path: &Path) -> bool {
+    let mut comps = path.components();
+    matches!(comps.next(), Some(Component::RootDir))
+        && matches!(comps.next(), Some(Component::Normal(n)) if n.to_str() == Some("Users"))
+        && matches!(comps.next(), Some(Component::Normal(_)))
+        && comps.next().is_none()
+}
+
+/// Whether `path` is a `.claude/worktrees`/`.worktrees` container directory
+/// itself, or one specific worktree's root inside it.
+///
+/// Why: deleting the container destroys every worktree at once; deleting a
+/// direct child destroys one. A path deeper than that — a file or directory
+/// INSIDE a worktree — is ordinary work happening exactly where it is
+/// supposed to (issue #3977) and must stay allowed, so this does not match a
+/// bare path-contains check the way [`super::super::project_aliases::is_worktree_path`]
+/// does for its coarser "is this a worktree at all" question.
+/// What: finds the first `.worktrees` component, or the first adjacent
+/// `.claude`, `worktrees` pair, and denies only when at most one path
+/// component remains after it.
+fn is_worktree_root_or_container(path: &Path) -> bool {
+    let comps: Vec<Component<'_>> = path.components().collect();
+    for (i, component) in comps.iter().enumerate() {
+        let Component::Normal(name) = component else {
+            continue;
+        };
+        let container_end = if name.to_str() == Some(".worktrees") {
+            i + 1
+        } else if name.to_str() == Some(".claude")
+            && matches!(comps.get(i + 1), Some(Component::Normal(n)) if n.to_str() == Some("worktrees"))
+        {
+            i + 2
+        } else {
+            continue;
+        };
+        return comps.len() - container_end <= 1;
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn env_with_home(home: &str) -> PathEnv {
+        // #4031: PathEnv's fields are module-private, not per-field
+        // constructors — this test lives in the same module tree
+        // (`pm_guard_bash::destructive_delete`) as `PathEnv` itself, so
+        // constructing one directly here is the same seam
+        // `evaluate_worktree_add_command_expands_tmpdir_and_home` in
+        // `super::tests` uses.
+        PathEnv {
+            tmpdir: None,
+            tmp: None,
+            home: Some(home.to_string()),
+        }
+    }
+
+    #[test]
+    fn denies_filesystem_root_deletion() {
+        let env = env_with_home("/Users/agent");
+        for command in [
+            "rm -rf /",
+            "rm -rf /root",
+            "rm -rf $HOME",
+            "rm -rf /Users/someone",
+        ] {
+            assert_eq!(
+                evaluate_destructive_delete_command_in(command, Path::new("/work"), &env),
+                Some(DESTRUCTIVE_DELETE_REASON),
+                "expected deny for: {command}"
+            );
+        }
+    }
+
+    #[test]
+    fn denies_home_expanded_from_a_literal_dollar_home() {
+        let env = env_with_home("/Users/agent");
+        assert_eq!(
+            evaluate_destructive_delete_command_in("rm -rf ${HOME}", Path::new("/work"), &env),
+            Some(DESTRUCTIVE_DELETE_REASON)
+        );
+    }
+
+    #[test]
+    fn denies_repo_root_deletion() {
+        let repo = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir(repo.path().join(".git")).expect(".git dir");
+        let env = env_with_home("/Users/agent");
+        let command = format!("rm -rf {}", repo.path().display());
+        assert_eq!(
+            evaluate_destructive_delete_command_in(&command, repo.path(), &env),
+            Some(DESTRUCTIVE_DELETE_REASON)
+        );
+    }
+
+    #[test]
+    fn denies_dot_git_deletion() {
+        let env = env_with_home("/Users/agent");
+        assert_eq!(
+            evaluate_destructive_delete_command_in("rm -rf .git", Path::new("/repo"), &env),
+            Some(DESTRUCTIVE_DELETE_REASON)
+        );
+    }
+
+    #[test]
+    fn denies_worktree_root_deletion() {
+        let env = env_with_home("/Users/agent");
+        for command in [
+            "rm -rf /repo/.claude/worktrees/agent-x",
+            "rm -rf /repo/.claude/worktrees",
+            "rm -rf /repo/.worktrees/agent-x",
+        ] {
+            assert_eq!(
+                evaluate_destructive_delete_command_in(command, Path::new("/repo"), &env),
+                Some(DESTRUCTIVE_DELETE_REASON),
+                "expected deny for: {command}"
+            );
+        }
+    }
+
+    #[test]
+    fn allows_worktree_interior_paths() {
+        let env = env_with_home("/Users/agent");
+        // A file or directory INSIDE a worktree is ordinary cleanup, not the
+        // hazard this rule closes.
+        assert_eq!(
+            evaluate_destructive_delete_command_in(
+                "rm -rf /repo/.claude/worktrees/agent-x/target",
+                Path::new("/repo"),
+                &env
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn allows_ordinary_cleanup() {
+        let env = env_with_home("/Users/agent");
+        for command in [
+            "rm stale.txt",
+            "rm -rf crates/x/target",
+            "cargo clean",
+            "git clean -fd",
+            "rmdir empty-dir",
+            "",
+        ] {
+            assert_eq!(
+                evaluate_destructive_delete_command_in(command, Path::new("/repo"), &env),
+                None,
+                "expected allow for: {command}"
+            );
+        }
+    }
+
+    #[test]
+    fn denies_rmdir_of_a_denylisted_root() {
+        let env = env_with_home("/Users/agent");
+        assert_eq!(
+            evaluate_destructive_delete_command_in(
+                "rmdir /repo/.claude/worktrees/agent-x",
+                Path::new("/repo"),
+                &env
+            ),
+            Some(DESTRUCTIVE_DELETE_REASON)
+        );
+    }
+
+    #[test]
+    fn denies_unlink_of_a_denylisted_root() {
+        let env = env_with_home("/Users/agent");
+        assert_eq!(
+            evaluate_destructive_delete_command_in("unlink /root", Path::new("/repo"), &env),
+            Some(DESTRUCTIVE_DELETE_REASON)
+        );
+    }
+
+    #[test]
+    fn denies_find_delete_of_a_denylisted_root() {
+        let env = env_with_home("/Users/agent");
+        assert_eq!(
+            evaluate_destructive_delete_command_in(
+                "find /repo/.git -delete",
+                Path::new("/repo"),
+                &env
+            ),
+            Some(DESTRUCTIVE_DELETE_REASON)
+        );
+    }
+
+    #[test]
+    fn allows_find_without_delete_action() {
+        let env = env_with_home("/Users/agent");
+        assert_eq!(
+            evaluate_destructive_delete_command_in(
+                "find /repo/.git -name '*.pack'",
+                Path::new("/repo"),
+                &env
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn denies_a_delete_hidden_in_a_composed_command() {
+        let env = env_with_home("/Users/agent");
+        for command in [
+            "cargo test -p trusty-mpm && rm -rf /root",
+            "true; rm -rf .git",
+            "cd /repo && rm -rf .claude/worktrees/agent-x",
+        ] {
+            assert_eq!(
+                evaluate_destructive_delete_command_in(command, Path::new("/repo"), &env),
+                Some(DESTRUCTIVE_DELETE_REASON),
+                "expected deny for: {command}"
+            );
+        }
+    }
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/destructive_delete.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/destructive_delete.rs
@@ -12,35 +12,56 @@
 //! ordinary local cleanup (`rm stale.txt`), build-artifact cleanup
 //! (`cargo clean`), or local temp cleanup (`git clean -fd`) — none of those
 //! target a denylisted path.
-//! What: [`evaluate_destructive_delete_command`] is the same TARGET-PATH
-//! classifier shape as the sibling
-//! [`super::evaluate_worktree_add_command`] (issue #3977's precedent) rather
-//! than a verb-name enumerator — matching only the literal `rm` token would
-//! miss `rmdir`/`unlink`/`find -delete`, so instead every composition segment
-//! whose resolved program is one of those four is inspected for its
-//! DELETION-TARGET argument(s), which are resolved against a `cd`-tracked
-//! effective working directory (the same [`PathEnv`] expansion and lexical
-//! normalization [`super::evaluate_worktree_add_command`] uses) and checked
-//! against [`is_denylisted_delete_target`]. It is called from `pm_guard()`
-//! BEFORE Guard 1's and Guard 4's early returns, and applies to every caller —
-//! the PM and any subagent alike — matching the worktree-add-tmp and
-//! main-checkout-destructive guards' placement, not the PM-exempt shape of the
-//! sibling [`super::evaluate_worktree_remove_command`]: a filesystem-root,
-//! repo-root, `.git`, or worktree deletion is never legitimate for either
-//! caller, so there is no exemption to preserve. `git worktree remove` and
-//! `git branch -D` are untouched by this rule — they are different verbs,
-//! governed by their own existing rules (`git worktree remove` by #5791; `git
-//! branch -D` by no rule at all, allowed for both PM and subagent, unchanged).
+//! What: [`evaluate_destructive_delete_command`] is a TARGET-PATH classifier
+//! — matching only the literal `rm` token would miss `rmdir`/`unlink`/`find
+//! -delete`, so instead every composition segment is scanned TOKEN BY TOKEN
+//! for one of those four verbs (issue #4031 review, pass 2, item 1). This
+//! deliberately does NOT enumerate wrapper words (`sudo`, `env`, `nice`,
+//! `time`, `nohup`, `exec`, `command`, `builtin`, `doas`, `ionice`, `timeout`,
+//! `stdbuf`, `caffeinate`, …) the way the sibling `cd`-tracker and the git
+//! guards do — round 1 of this review enumerated only `sudo`/`env`, then
+//! `command`/`builtin`, and each addition missed the next wrapper someone
+//! actually used. Scanning every token for the verb itself makes the
+//! enumeration moot: no wrapper, known or future, changes which token IS
+//! `rm`, only what precedes it. **Over-matching is intentional and
+//! ACCEPTED**: this guard denies only when a resolved TARGET lands on the
+//! absolute denylist below, so a benign command that merely CONTAINS the word
+//! `rm` as a non-verb argument (`echo rm -rf /`) being denied is the safe
+//! direction for a safety rule, not a bug to special-case away — the
+//! alternative (verb-position enumeration) is exactly the defect this
+//! rewrite closes.
+//! Once a verb token is found, its DELETION-TARGET argument(s) are resolved
+//! against a `cd`-tracked effective working directory (the same [`PathEnv`]
+//! expansion and lexical normalization [`super::evaluate_worktree_add_command`]
+//! uses) and checked against [`is_denylisted_delete_target`], which also
+//! resolves a glob-suffixed target's PARENT ([`glob_parent`]) since this
+//! module classifies text and never expands a glob the way the shell would.
+//! **A delete verb whose target could not be resolved at all — an
+//! unparseable segment, or a verb found with no positional argument — FAILS
+//! CLOSED** ([`DESTRUCTIVE_DELETE_UNRESOLVED_REASON`], issue #4031 review item
+//! 2): the alternative (silently allow) is exactly how `first_command_token`
+//! returning `None` for `env -i rm -rf /root` bypassed the previous
+//! iteration of this guard, which depended on it for verb detection.
+//! It is called from `pm_guard()` BEFORE Guard 1's and Guard 4's early
+//! returns, and applies to every caller — the PM and any subagent alike —
+//! matching the worktree-add-tmp and main-checkout-destructive guards'
+//! placement, not the PM-exempt shape of the sibling
+//! [`super::evaluate_worktree_remove_command`]: a filesystem-root, repo-root,
+//! `.git`, or worktree deletion is never legitimate for either caller, so
+//! there is no exemption to preserve. `git worktree remove` and `git branch
+//! -D` are untouched by this rule — they are different verbs, governed by
+//! their own existing rules (`git worktree remove` by #5791, now also
+//! wrapper-resistant via `shell_lex::git_subcommand`'s shared
+//! `strip_wrapper_prefix`; `git branch -D` by no rule at all, allowed for
+//! both PM and subagent, unchanged).
 //!
-//! Residual bypasses accepted, stated rather than hidden (same shape as the
-//! sibling worktree-add guard's own list, which this module inherits by
-//! construction):
+//! Residual bypasses accepted, stated rather than hidden:
 //! - Indirection through a shell variable (`X=/; rm -rf "$X"`) or a command
 //!   substitution (`rm -rf "$(mktemp -d)"`) is not resolved.
-//! - A verb reached via `xargs`, `sh -c`, or a shell function/alias is not
-//!   resolved — this module reads the same [`first_command_token`] every
-//!   other verb in this file's classifier reads, and none of them unwrap those
-//!   wrappers either.
+//! - A verb reached via `xargs` or a genuine shell function/alias override of
+//!   `rm` itself (not the `\`/`command`/`builtin` bypass idioms, which this
+//!   module resolves) is not detected — this scans the command TEXT, it does
+//!   not execute the shell or consult its alias table.
 //! - A symlink whose target is a denylisted root is not followed — resolution
 //!   here is purely lexical, never `fs::canonicalize`, for the same
 //!   fast/side-effect-free reason [`super::resolve_target_path`] documents.
@@ -53,7 +74,10 @@
 //! `allows_worktree_interior_paths`, `allows_ordinary_cleanup`,
 //! `denies_rmdir_of_a_denylisted_root`, `denies_find_delete_of_a_denylisted_root`,
 //! `denies_a_delete_hidden_in_a_composed_command`,
-//! `denies_home_expanded_from_a_literal_dollar_home` below;
+//! `denies_home_expanded_from_a_literal_dollar_home`,
+//! `denies_wrapper_words_regardless_of_enumeration`,
+//! `denies_bare_container_roots`, `denies_unresolvable_delete_targets`,
+//! `allows_over_matched_non_verb_mentions_that_resolve_to_no_target` below;
 //! `pm_guard_denies_destructive_delete_of_repo_root` and siblings in
 //! `tests/tm_hook_pm_guard.rs` exercise the end-to-end binary path.
 
@@ -74,15 +98,37 @@ use crate::commands::hook_rewrite::first_command_token;
 /// does for the sibling `git worktree remove` rule.
 /// What: the `permissionDecisionReason` string emitted on this deny.
 pub(crate) const DESTRUCTIVE_DELETE_REASON: &str = "`rm`/`rmdir`/`unlink`/`find -delete` must \
-     not target a filesystem root (`/`, `/root`, `/Users/<name>`, `$HOME`), a repository root, a \
-     `.git` directory, or a `.claude/worktrees`/`.worktrees` entry (issue #4031) — each is either \
+     not target a filesystem root or bare container (`/`, `/root`, `/Users`, `/Users/<name>`, \
+     `/home`, `/Volumes`, `/private`, `/var`, `/etc`, `/usr`, `/opt`, `/Library`, `/System`, \
+     `/Applications`, `$HOME`, or `$HOME`'s parent directory), a repository root, a `.git` \
+     directory, or a `.claude/worktrees`/`.worktrees` entry (issue #4031) — each is either \
      unrecoverable data loss or another session's or workstream's uncommitted work. Ordinary file \
      and directory cleanup elsewhere (build artifacts, stale files, `git clean -fd`) is unaffected. \
      To remove a worktree, ask the PM to run `tm session prune-worktrees --merged-prs --force` — \
      `rm -rf` on a worktree directory is never the workaround.";
 
-/// The four verbs this guard inspects — everything else falls through to
-/// [`super::classify_bash_segment`]'s ordinary rules unchanged.
+/// Deny reason when a segment contains a delete verb this classifier cannot
+/// resolve a target for — an unparseable segment (unbalanced quotes) that
+/// plausibly names one, or a bare verb invocation with no positional
+/// argument at all (issue #4031 review, item 2).
+///
+/// Why: the alternative is silently allowing exactly the shape that bypassed
+/// the previous iteration of this guard (`env -i rm -rf /root`, where verb
+/// detection depended on [`first_command_token`] and that function
+/// conservatively returns `None` rather than guess past an ambiguous flag).
+/// A guard whose failure mode is "can't tell, so allow" is not a guard; this
+/// one's failure mode is "can't tell, so deny and say so".
+/// What: the `permissionDecisionReason` string emitted on this deny.
+pub(crate) const DESTRUCTIVE_DELETE_UNRESOLVED_REASON: &str = "A Bash segment names \
+     `rm`/`rmdir`/`unlink`/`find` but this guard could not resolve what it targets (issue #4031) \
+     — either the segment's quoting could not be parsed, or the verb carried no positional \
+     argument. Denying rather than guessing is this guard's fail-closed rule. Rewrite the command \
+     with an unambiguous, directly-quoted target.";
+
+/// The four verbs this guard scans every segment's TOKENS for — not just the
+/// first/wrapper-resolved one (issue #4031 review, item 1). Everything else
+/// falls through to [`super::classify_bash_segment`]'s ordinary rules
+/// unchanged.
 const DELETE_VERBS: &[&str] = &["rm", "rmdir", "unlink", "find"];
 
 /// Classify a Bash command for destructive-root deletion: `Some(reason)`
@@ -119,7 +165,11 @@ fn evaluate_destructive_delete_command_in(
         // Same `cd`-tracking shape as `evaluate_worktree_add_command_in`: a
         // deliberate, partial closing of `cd /tmp && rm -rf x` — see that
         // function's doc for the residual (shell-variable / substitution
-        // built `cd` target) this shares.
+        // built `cd` target) this shares. Unlike verb detection below, this
+        // still goes through `first_command_token` — a wrapped `cd` (`nice cd
+        // /tmp`) is a real but narrower gap than wrapper-enumerated VERB
+        // detection was, since a missed `cd` only leaves `effective_cwd`
+        // stale rather than letting a delete verb through unclassified.
         if first_command_token(trimmed) == Some("cd") {
             if let Some(argv) = shlex::split(trimmed)
                 && let Some(dest) = argv.get(1)
@@ -128,30 +178,38 @@ fn evaluate_destructive_delete_command_in(
             }
             continue;
         }
-        let Some(program) = first_command_token(trimmed) else {
-            continue;
-        };
-        if !DELETE_VERBS.contains(&program) {
-            continue;
-        }
         let Some(argv) = shlex::split(trimmed) else {
+            // Unbalanced quotes — cannot tokenize this segment at all. Fail
+            // CLOSED (item 2) only when the raw text plausibly names one of
+            // the delete verbs as a whole word; an unparseable segment with
+            // nothing suspicious in it is simply not this rule's business.
+            if segment_mentions_a_delete_verb(trimmed) {
+                return Some(DESTRUCTIVE_DELETE_UNRESOLVED_REASON);
+            }
             continue;
         };
-        // Locate the resolved program's own position in argv rather than
-        // assuming index 0 — `first_command_token` already skipped any
-        // env-assignment (`FOO=bar rm …`) or `sudo`/`env` prefix to find
-        // `program`, and this reuses that same resolved name to find where
-        // the real argument list begins, without duplicating that skip logic.
-        let Some(start) = argv
+        // #4031 review, item 1: scan EVERY token for a delete verb — no
+        // wrapper enumeration, see the module doc for why. A leading `\` is
+        // stripped before comparison (the same alias-bypass idiom
+        // `hook_rewrite::strip_wrapper_prefix` resolves).
+        let Some(verb_idx) = argv
             .iter()
-            .position(|tok| tok.rsplit('/').next() == Some(program))
+            .position(|tok| DELETE_VERBS.contains(&tok.strip_prefix('\\').unwrap_or(tok)))
         else {
             continue;
         };
-        let tail = &argv[start + 1..];
-        let targets = delete_targets(program, tail);
-        if targets.is_empty() {
+        let verb = argv[verb_idx].strip_prefix('\\').unwrap_or(&argv[verb_idx]);
+        let tail = &argv[verb_idx + 1..];
+        let targets = delete_targets(verb, tail);
+        if verb == "find" && targets.is_empty() {
+            // No `-delete` action present — a plain search, not this rule's
+            // business (see `delete_targets`).
             continue;
+        }
+        if targets.is_empty() {
+            // rm/rmdir/unlink found but no resolvable positional argument —
+            // fail CLOSED (item 2) rather than silently allow.
+            return Some(DESTRUCTIVE_DELETE_UNRESOLVED_REASON);
         }
         let repo_root = main_checkout_root(&effective_cwd);
         for target in targets {
@@ -162,6 +220,22 @@ fn evaluate_destructive_delete_command_in(
         }
     }
     None
+}
+
+/// Whether `text` — a segment [`shlex::split`] could not tokenize — plausibly
+/// names one of [`DELETE_VERBS`] as a whole word.
+///
+/// Why: an unparseable segment (unbalanced quotes) gives no argv to scan, but
+/// item 2's fail-closed rule still applies when the raw text looks like it
+/// might be a delete invocation — this is the conservative, over-matching
+/// fallback for that rare case, not the normal path (which shlex parses).
+/// What: splits on any non-alphanumeric/underscore byte (quotes, slashes,
+/// dashes, backslashes all separate) and checks the resulting words for an
+/// exact match — cruder than [`shlex::split`], deliberately, since a proper
+/// parse already failed.
+fn segment_mentions_a_delete_verb(text: &str) -> bool {
+    text.split(|c: char| !c.is_alphanumeric() && c != '_')
+        .any(|word| DELETE_VERBS.contains(&word))
 }
 
 /// The path argument(s) a resolved deletion verb's argv tail would act on.
@@ -226,10 +300,21 @@ fn is_denylisted_delete_target(path: &Path, repo_root: Option<&Path>, env: &Path
     if path == Path::new("/") || path == Path::new("/root") {
         return true;
     }
-    if let Some(home) = env.home.as_deref()
-        && path == Path::new(home)
+    if BARE_CONTAINER_ROOTS
+        .iter()
+        .any(|root| path == Path::new(root))
     {
         return true;
+    }
+    if let Some(home) = env.home.as_deref() {
+        if path == Path::new(home) {
+            return true;
+        }
+        if let Some(parent) = Path::new(home).parent()
+            && path == parent
+        {
+            return true;
+        }
     }
     if is_user_home_root(path) {
         return true;
@@ -242,6 +327,30 @@ fn is_denylisted_delete_target(path: &Path, repo_root: Option<&Path>, env: &Path
     }
     is_worktree_root_or_container(path)
 }
+
+/// Bare container directories — deleting the whole directory (not a specific
+/// entry inside it) destroys every user's / every app's / every mount's data
+/// at once (issue #4031 review, item 3). `/Users/<name>` (a SPECIFIC user's
+/// home) is [`is_user_home_root`]'s separate, narrower check; this list is
+/// the container ABOVE that.
+///
+/// Why: round 1 of this review only denylisted a specific user's home root
+/// and the literal filesystem root — `rm -rf /Users` (every user's home at
+/// once) and `rm -rf /etc` (system configuration) matched neither and were
+/// allowed.
+const BARE_CONTAINER_ROOTS: &[&str] = &[
+    "/Users",
+    "/home",
+    "/Volumes",
+    "/private",
+    "/var",
+    "/etc",
+    "/usr",
+    "/opt",
+    "/Library",
+    "/System",
+    "/Applications",
+];
 
 /// The directory a glob-suffixed delete target would actually clear, or
 /// `path` itself when it names no glob.
@@ -258,10 +367,13 @@ fn is_denylisted_delete_target(path: &Path, repo_root: Option<&Path>, env: &Path
 /// glob's PARENT directory — where the shell would actually perform the
 /// deletion — is evaluated against the denylist instead.
 /// What: gated on the LAST path component containing `*`, `?`, or `[`
-/// (POSIX glob metacharacters); when it does, returns `path`'s parent (or
-/// `path` itself if it has none — e.g. a bare `*` with no resolvable
-/// parent, which conservatively keeps the check running against something
-/// rather than nothing). A non-glob path is returned unchanged.
+/// (POSIX glob metacharacters); when it does, returns `path`'s parent —
+/// `Path::parent` yields an empty relative path for a bare single component
+/// (e.g. a literal `*` with no directory prefix, which in practice never
+/// reaches this function unresolved: [`resolve_target_path`] always joins a
+/// relative token onto the tracked effective cwd first) — or `path` itself in
+/// the (unreachable in practice) case `parent()` returns `None` at all. A
+/// non-glob path is returned unchanged.
 fn glob_parent(path: &Path) -> &Path {
     let has_glob = path
         .file_name()
@@ -578,5 +690,131 @@ mod tests {
                 "expected deny for: {command}"
             );
         }
+    }
+
+    #[test]
+    fn denies_wrapper_words_regardless_of_enumeration() {
+        // #4031 review pass 2, item 1: verb detection no longer depends on
+        // enumerating wrapper words at all — `env -i` and `command -p` (both
+        // followed by a FLAG, which `first_command_token`/`strip_wrapper_prefix`
+        // conservatively refuse to resolve past) still deny here, because
+        // this scans every token for the verb rather than resolving "the"
+        // program.
+        let env = env_with_home("/Users/agent");
+        for command in [
+            "env -i rm -rf /root",
+            "command -p rm -rf /root",
+            "nice rm -rf /root",
+            "exec rm -rf /root",
+        ] {
+            assert_eq!(
+                evaluate_destructive_delete_command_in(command, Path::new("/repo"), &env),
+                Some(DESTRUCTIVE_DELETE_REASON),
+                "expected deny for: {command}"
+            );
+        }
+    }
+
+    #[test]
+    fn denies_bare_container_roots() {
+        // #4031 review pass 2, item 3: a bare container (every user's home,
+        // every mounted volume, system configuration) is as destructive to
+        // delete whole as a single user's home root.
+        let env = env_with_home("/Users/agent");
+        for command in [
+            "rm -rf /Users",
+            "rm -rf /Users/*",
+            "rm -rf /home",
+            "rm -rf /Volumes",
+            "rm -rf /etc",
+            "rm -rf /var",
+        ] {
+            assert_eq!(
+                evaluate_destructive_delete_command_in(command, Path::new("/repo"), &env),
+                Some(DESTRUCTIVE_DELETE_REASON),
+                "expected deny for: {command}"
+            );
+        }
+    }
+
+    #[test]
+    fn denies_unresolvable_delete_targets() {
+        // #4031 review pass 2, item 2: a delete verb with no resolvable
+        // target — an unbalanced-quote segment mentioning one, or a bare verb
+        // invocation — fails CLOSED rather than silently allowing.
+        let env = env_with_home("/Users/agent");
+        assert_eq!(
+            evaluate_destructive_delete_command_in("echo 'rm -rf /root", Path::new("/repo"), &env),
+            Some(DESTRUCTIVE_DELETE_UNRESOLVED_REASON)
+        );
+        assert_eq!(
+            evaluate_destructive_delete_command_in("rm --", Path::new("/repo"), &env),
+            Some(DESTRUCTIVE_DELETE_UNRESOLVED_REASON)
+        );
+    }
+
+    #[test]
+    fn allows_over_matched_non_verb_mentions_that_resolve_to_no_target() {
+        // The companion property to `denies_unresolvable_delete_targets`: an
+        // unparseable segment that does NOT mention a delete verb at all is
+        // simply not this rule's business, and a `find` with no `-delete`
+        // action is a plain search, never denied regardless of its argument.
+        let env = env_with_home("/Users/agent");
+        assert_eq!(
+            evaluate_destructive_delete_command_in(
+                "echo 'unrelated unterminated",
+                Path::new("/repo"),
+                &env
+            ),
+            None
+        );
+        assert_eq!(
+            evaluate_destructive_delete_command_in(
+                "find /repo -name '*.rs'",
+                Path::new("/repo"),
+                &env
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn allows_wrapped_non_destructive_commands() {
+        // Companion allow cases: a wrapper preceding a NON-delete command, or
+        // a delete verb whose target is genuinely benign, must stay allowed
+        // — over-matching applies to the VERB, not to every wrapped command.
+        let env = env_with_home("/Users/agent");
+        for command in [
+            "nice cargo clean",
+            "time rm -rf ./target",
+            "env FOO=1 rm stale.txt",
+        ] {
+            assert_eq!(
+                evaluate_destructive_delete_command_in(command, Path::new("/repo"), &env),
+                None,
+                "expected allow for: {command}"
+            );
+        }
+    }
+
+    #[test]
+    fn glob_parent_resolves_the_directory_a_glob_would_clear() {
+        assert_eq!(glob_parent(Path::new("/repo/*")), Path::new("/repo"));
+        assert_eq!(glob_parent(Path::new("/repo/a*b")), Path::new("/repo"));
+        assert_eq!(
+            glob_parent(Path::new("/repo/dir/*")),
+            Path::new("/repo/dir")
+        );
+        assert_eq!(glob_parent(Path::new("/repo/.[!.]*")), Path::new("/repo"));
+        // A bare `*` with no directory prefix yields `Path::parent`'s empty
+        // relative path — unreachable in the real pipeline, since
+        // `resolve_target_path` always joins a relative token onto the
+        // tracked cwd first, but exercised here directly for completeness.
+        assert_eq!(glob_parent(Path::new("*")), Path::new(""));
+        // Non-glob paths are returned unchanged.
+        assert_eq!(
+            glob_parent(Path::new("/repo/file.txt")),
+            Path::new("/repo/file.txt")
+        );
     }
 }

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/destructive_delete.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/destructive_delete.rs
@@ -6,8 +6,9 @@
 //! recursively delete another session's worktree or in-flight work via
 //! `rm -rf`, even though the guard already blocks `Edit`/`Write` on source.
 //! This closes the SAFETY subset only (owner ruling on #3973): recursive
-//! force-deletion of a filesystem root (`/`, `/root`, `/Users/<name>`,
-//! `$HOME`), a repository root, a `.git` directory, or a
+//! force-deletion of a filesystem root (`/`, `/root`, `/Users/<name>` on
+//! macOS, `/home/<name>` on Linux, `$HOME`), a repository root, a `.git`
+//! directory, or a
 //! `.claude/worktrees`/`.worktrees` entry. It deliberately does NOT block
 //! ordinary local cleanup (`rm stale.txt`), build-artifact cleanup
 //! (`cargo clean`), or local temp cleanup (`git clean -fd`) — none of those
@@ -99,8 +100,8 @@ use crate::commands::hook_rewrite::first_command_token;
 /// What: the `permissionDecisionReason` string emitted on this deny.
 pub(crate) const DESTRUCTIVE_DELETE_REASON: &str = "`rm`/`rmdir`/`unlink`/`find -delete` must \
      not target a filesystem root or bare container (`/`, `/root`, `/Users`, `/Users/<name>`, \
-     `/home`, `/Volumes`, `/private`, `/var`, `/etc`, `/usr`, `/opt`, `/Library`, `/System`, \
-     `/Applications`, `$HOME`, or `$HOME`'s parent directory), a repository root, a `.git` \
+     `/home`, `/home/<name>`, `/Volumes`, `/private`, `/var`, `/etc`, `/usr`, `/opt`, `/Library`, \
+     `/System`, `/Applications`, `$HOME`, or `$HOME`'s parent directory), a repository root, a `.git` \
      directory, or a `.claude/worktrees`/`.worktrees` entry (issue #4031) — each is either \
      unrecoverable data loss or another session's or workstream's uncommitted work. Ordinary file \
      and directory cleanup elsewhere (build artifacts, stale files, `git clean -fd`) is unaffected. \
@@ -286,7 +287,8 @@ fn delete_targets(program: &str, tail: &[String]) -> Vec<String> {
 /// What: `true` when `path` — after [`resolve_target_path`]'s expansion and
 /// lexical normalization, and after [`glob_parent`]'s glob-aware
 /// substitution — is exactly `/`, `/root`, `$HOME`'s resolved value, a
-/// single-level `/Users/<name>` home root, the checkout's own repository root
+/// single-level `/Users/<name>`/`/home/<name>` home root, the checkout's own
+/// repository root
 /// (`repo_root`, resolved once per segment by the caller via
 /// [`main_checkout_root`] — `None` for a worktree, whose own root is instead
 /// caught by [`is_worktree_root_or_container`]), a path whose basename is
@@ -330,9 +332,15 @@ fn is_denylisted_delete_target(path: &Path, repo_root: Option<&Path>, env: &Path
 
 /// Bare container directories — deleting the whole directory (not a specific
 /// entry inside it) destroys every user's / every app's / every mount's data
-/// at once (issue #4031 review, item 3). `/Users/<name>` (a SPECIFIC user's
-/// home) is [`is_user_home_root`]'s separate, narrower check; this list is
-/// the container ABOVE that.
+/// at once (issue #4031 review, item 3). `/Users/<name>` and `/home/<name>`
+/// (a SPECIFIC user's home, macOS and Linux respectively) is
+/// [`is_user_home_root`]'s separate, narrower check; this list is the
+/// container ABOVE that — both platform spellings (`/Users` AND `/home`) are
+/// listed here regardless of which OS this guard happens to be running on, so
+/// the macOS/Linux parity this list implies is real rather than aspirational
+/// (pass 3 of this review: `is_user_home_root` recognized only `/Users/<name>`
+/// at first, leaving `/home/<name>` unenforced even though this list already
+/// named the bare `/home` container).
 ///
 /// Why: round 1 of this review only denylisted a specific user's home root
 /// and the literal filesystem root — `rm -rf /Users` (every user's home at
@@ -386,16 +394,23 @@ fn glob_parent(path: &Path) -> &Path {
     }
 }
 
-/// Whether `path` is exactly a single-level `/Users/<name>` entry — someone's
-/// entire home directory on macOS.
+/// Whether `path` is exactly a single-level `/Users/<name>` (macOS) or
+/// `/home/<name>` (Linux) entry — someone's entire home directory.
 ///
-/// What: `true` only for `RootDir, Normal("Users"), Normal(_)` with nothing
-/// after — `/Users/bob/Projects/foo` (an ordinary subdirectory) is NOT
-/// matched, only `/Users/bob` itself.
+/// Why (#4031 review, pass 3): the first cut recognized only `/Users/<name>`,
+/// so `rm -rf /home/someoneelse` and its glob-suffixed form denied on macOS
+/// but allowed on Linux — the same hazard, unenforced on half the platforms
+/// this guard runs on. [`BARE_CONTAINER_ROOTS`] already lists both `/Users`
+/// and `/home` as the CONTAINER; this is the narrower, one-level-deeper check
+/// for a SPECIFIC user's home under either.
+/// What: `true` only for `RootDir, Normal("Users" | "home"), Normal(_)` with
+/// nothing after — `/Users/bob/Projects/foo` and `/home/bob/project` (an
+/// ordinary subdirectory) are NOT matched, only `/Users/bob`/`/home/bob`
+/// themselves.
 fn is_user_home_root(path: &Path) -> bool {
     let mut comps = path.components();
     matches!(comps.next(), Some(Component::RootDir))
-        && matches!(comps.next(), Some(Component::Normal(n)) if n.to_str() == Some("Users"))
+        && matches!(comps.next(), Some(Component::Normal(n)) if matches!(n.to_str(), Some("Users" | "home")))
         && matches!(comps.next(), Some(Component::Normal(_)))
         && comps.next().is_none()
 }
@@ -735,6 +750,37 @@ mod tests {
                 "expected deny for: {command}"
             );
         }
+    }
+
+    #[test]
+    fn denies_a_linux_users_home_root_like_its_macos_equivalent() {
+        // #4031 review pass 3: `is_user_home_root` recognized only
+        // `/Users/<name>` at first — `rm -rf /home/someoneelse` and its
+        // glob-suffixed form denied on macOS but allowed on Linux, the same
+        // hazard unenforced on half the platforms this guard runs on.
+        let env = env_with_home("/Users/agent");
+        for command in ["rm -rf /home/someoneelse", "rm -rf /home/someoneelse/*"] {
+            assert_eq!(
+                evaluate_destructive_delete_command_in(command, Path::new("/repo"), &env),
+                Some(DESTRUCTIVE_DELETE_REASON),
+                "expected deny for: {command}"
+            );
+        }
+    }
+
+    #[test]
+    fn allows_an_ordinary_project_under_a_linux_user_home() {
+        // The companion allow case: a subdirectory INSIDE a Linux user's home
+        // is ordinary work, exactly like `/Users/bob/Projects/foo` on macOS.
+        let env = env_with_home("/Users/agent");
+        assert_eq!(
+            evaluate_destructive_delete_command_in(
+                "rm -rf /home/x/project/target",
+                Path::new("/repo"),
+                &env
+            ),
+            None
+        );
     }
 
     #[test]

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/destructive_delete.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/destructive_delete.rs
@@ -209,8 +209,9 @@ fn delete_targets(program: &str, tail: &[String]) -> Vec<String> {
 /// Whether `path` is one of the destructive-root categories issue #4031
 /// denylists.
 ///
-/// What: `true` when `path`, after [`resolve_target_path`]'s expansion and
-/// lexical normalization, is exactly `/`, `/root`, `$HOME`'s resolved value, a
+/// What: `true` when `path` — after [`resolve_target_path`]'s expansion and
+/// lexical normalization, and after [`glob_parent`]'s glob-aware
+/// substitution — is exactly `/`, `/root`, `$HOME`'s resolved value, a
 /// single-level `/Users/<name>` home root, the checkout's own repository root
 /// (`repo_root`, resolved once per segment by the caller via
 /// [`main_checkout_root`] — `None` for a worktree, whose own root is instead
@@ -221,6 +222,7 @@ fn delete_targets(program: &str, tail: &[String]) -> Vec<String> {
 /// this is a target-PATH classifier, not a target-root-prefix one, so ordinary
 /// cleanup under any of these stays allowed.
 fn is_denylisted_delete_target(path: &Path, repo_root: Option<&Path>, env: &PathEnv) -> bool {
+    let path = glob_parent(path);
     if path == Path::new("/") || path == Path::new("/root") {
         return true;
     }
@@ -239,6 +241,37 @@ fn is_denylisted_delete_target(path: &Path, repo_root: Option<&Path>, env: &Path
         return true;
     }
     is_worktree_root_or_container(path)
+}
+
+/// The directory a glob-suffixed delete target would actually clear, or
+/// `path` itself when it names no glob.
+///
+/// Why (#4031 review, CRITICAL 2): this module classifies TEXT — it never
+/// expands a glob the way the shell would at execution time — so
+/// `rm -rf /Users/bob/*` reached [`is_denylisted_delete_target`] as the
+/// literal path `/Users/bob/*`, which matched no denylist entry exactly,
+/// while the shell's own expansion would delete everything inside
+/// `/Users/bob`: exactly as destructive as `rm -rf /Users/bob` itself, and
+/// the same shape as `rm -rf ./*`/`rm -rf ~/*` run from `$HOME`, or
+/// `rm -rf .[!.]*` (a hidden-file glob). Rather than implement glob
+/// expansion (unbounded, and it would have to touch the filesystem), the
+/// glob's PARENT directory — where the shell would actually perform the
+/// deletion — is evaluated against the denylist instead.
+/// What: gated on the LAST path component containing `*`, `?`, or `[`
+/// (POSIX glob metacharacters); when it does, returns `path`'s parent (or
+/// `path` itself if it has none — e.g. a bare `*` with no resolvable
+/// parent, which conservatively keeps the check running against something
+/// rather than nothing). A non-glob path is returned unchanged.
+fn glob_parent(path: &Path) -> &Path {
+    let has_glob = path
+        .file_name()
+        .and_then(|f| f.to_str())
+        .is_some_and(|f| f.contains(['*', '?', '[']));
+    if has_glob {
+        path.parent().unwrap_or(path)
+    } else {
+        path
+    }
 }
 
 /// Whether `path` is exactly a single-level `/Users/<name>` entry — someone's
@@ -458,6 +491,87 @@ mod tests {
             "true; rm -rf .git",
             "cd /repo && rm -rf .claude/worktrees/agent-x",
         ] {
+            assert_eq!(
+                evaluate_destructive_delete_command_in(command, Path::new("/repo"), &env),
+                Some(DESTRUCTIVE_DELETE_REASON),
+                "expected deny for: {command}"
+            );
+        }
+    }
+
+    #[test]
+    fn denies_pwd_expansion_of_the_current_worktree_root() {
+        // #4031 review, CRITICAL 1: `$PWD` reached `resolve_target_path`
+        // unexpanded, so `rm -rf $PWD` from inside a session's own worktree
+        // root matched no denylist entry. `$PWD` must expand to the tracked
+        // effective cwd, not merely allow (the same property the sibling
+        // `$HOME` expansion test pins).
+        let env = env_with_home("/Users/agent");
+        let worktree = Path::new("/repo/.claude/worktrees/agent-x");
+        for command in ["rm -rf $PWD", "rm -rf ${PWD}"] {
+            assert_eq!(
+                evaluate_destructive_delete_command_in(command, worktree, &env),
+                Some(DESTRUCTIVE_DELETE_REASON),
+                "expected deny for: {command}"
+            );
+        }
+    }
+
+    #[test]
+    fn allows_pwd_expansion_of_a_subdirectory() {
+        // The other half: `$PWD/target` is an ordinary subdirectory of the
+        // worktree, not its root — must stay allowed.
+        let env = env_with_home("/Users/agent");
+        let worktree = Path::new("/repo/.claude/worktrees/agent-x");
+        assert_eq!(
+            evaluate_destructive_delete_command_in("rm -rf $PWD/target", worktree, &env),
+            None
+        );
+    }
+
+    #[test]
+    fn denies_glob_suffixed_deletes_of_a_denylisted_parent() {
+        // #4031 review, CRITICAL 2: this module classifies text, never
+        // expands a glob — `rm -rf /Users/bob/*` reached the denylist check
+        // as the literal path `/Users/bob/*`, which matched no entry exactly,
+        // while the shell's own expansion clears everything inside
+        // `/Users/bob`. The glob's PARENT must be evaluated instead.
+        let env = env_with_home("/Users/agent");
+        let home = Path::new("/Users/agent");
+        for (command, cwd) in [
+            ("rm -rf /Users/someone/*", home),
+            ("rm -rf ./*", home),
+            ("rm -rf ~/*", home),
+            ("rm -rf .[!.]*", home),
+        ] {
+            assert_eq!(
+                evaluate_destructive_delete_command_in(command, cwd, &env),
+                Some(DESTRUCTIVE_DELETE_REASON),
+                "expected deny for: {command}"
+            );
+        }
+    }
+
+    #[test]
+    fn allows_a_glob_inside_a_worktree_subdirectory() {
+        // The companion allow case: a glob whose parent is an ORDINARY
+        // subdirectory (not a denylisted root) is not this rule's business.
+        let env = env_with_home("/Users/agent");
+        let worktree = Path::new("/repo/.claude/worktrees/agent-x");
+        assert_eq!(
+            evaluate_destructive_delete_command_in("rm -rf ./target/*", worktree, &env),
+            None
+        );
+    }
+
+    #[test]
+    fn denies_backslash_and_command_wrapper_bypasses() {
+        // #4031 review, HIGH 3/4: `\rm` and `command rm` are the standard
+        // POSIX alias-bypass idioms — both run the real `rm` exactly as
+        // `rm` does, and both previously slipped past `first_command_token`
+        // unresolved.
+        let env = env_with_home("/Users/agent");
+        for command in ["\\rm -rf /root", "command rm -rf /root"] {
             assert_eq!(
                 evaluate_destructive_delete_command_in(command, Path::new("/repo"), &env),
                 Some(DESTRUCTIVE_DELETE_REASON),

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/mod.rs
@@ -28,11 +28,17 @@
 //! and the HEAD-moving `pull`/`merge`/`rebase` (ADR-0048). The sibling
 //! [`heredoc`] module tells the redirection check which bytes are
 //! here-document body content, so a `>` inside a `<<'PY'` script is a
-//! comparison rather than a file write (#5356).
+//! comparison rather than a file write (#5356). The sibling
+//! [`destructive_delete`] module carries the rule `pm_guard` calls directly,
+//! ahead of the subagent exemptions, alongside the worktree-add-tmp guard: a
+//! target-path denylist for `rm`/`rmdir`/`unlink`/`find … -delete` aimed at a
+//! filesystem root, a repository root, a `.git` directory, or a worktree
+//! entry (issue #4031).
 //! Test: `evaluate_bash_command_*`, `split_shell_segments_*`, and
 //! `has_file_write_redirection_*` in this module's `tests` submodule;
 //! `sed_awk::tests` for the sed/awk-specific safety analysis.
 
+mod destructive_delete;
 mod heredoc;
 mod main_checkout;
 mod persistence;
@@ -40,6 +46,7 @@ mod sed_awk;
 mod shell_lex;
 mod worktree_remove;
 
+pub(crate) use destructive_delete::evaluate_destructive_delete_command;
 pub(crate) use main_checkout::{
     CommitVerdict, docs_commit_deny_reason, evaluate_main_checkout_commit_command,
     evaluate_main_checkout_destructive_command, head_move_deny_reason, main_checkout_head_move,
@@ -828,17 +835,18 @@ fn worktree_add_target_token(tail: &[String]) -> Option<String> {
     None
 }
 
-/// Expand a leading `~`, `$TMPDIR`/`${TMPDIR}`, and `$TMP`/`${TMP}` in a path
-/// token using `env`, then resolve it against `base` if relative, then
-/// lexically normalize (collapse `.`/`..` components WITHOUT touching the
-/// filesystem).
+/// Expand a leading `~`, `$TMPDIR`/`${TMPDIR}`, `$TMP`/`${TMP}`, and
+/// `$HOME`/`${HOME}` in a path token using `env`, then resolve it against
+/// `base` if relative, then lexically normalize (collapse `.`/`..` components
+/// WITHOUT touching the filesystem).
 ///
 /// Why: `shlex::split` does not perform shell variable expansion, so a target
-/// argument like `$TMPDIR/wt-foo` or `~/scratch/wt-foo` reaches this function
-/// as literal text; the guard must expand it itself to see where it really
-/// points. Filesystem-touching resolution (`fs::canonicalize`) is deliberately
-/// avoided — the worktree target usually does not exist yet, and a
-/// `PreToolUse` hook must stay fast and side-effect-free.
+/// argument like `$TMPDIR/wt-foo`, `~/scratch/wt-foo`, or a literal `$HOME`
+/// (issue #4031 — an agent typing `rm -rf $HOME` verbatim) reaches this
+/// function as literal text; the guard must expand it itself to see where it
+/// really points. Filesystem-touching resolution (`fs::canonicalize`) is
+/// deliberately avoided — the worktree target usually does not exist yet, and
+/// a `PreToolUse` hook must stay fast and side-effect-free.
 /// What: string-replaces the env-var forms, expands a `~`/`~/…` prefix via
 /// `$HOME`, joins onto `base` if the result is still relative, then
 /// normalizes. The values arrive via [`PathEnv`] rather than being read here,
@@ -855,6 +863,9 @@ fn resolve_target_path(token: &str, base: &Path, env: &PathEnv) -> PathBuf {
     }
     if let Some(tmp) = env.tmp.as_deref() {
         expanded = expanded.replace("${TMP}", tmp).replace("$TMP", tmp);
+    }
+    if let Some(home) = env.home.as_deref() {
+        expanded = expanded.replace("${HOME}", home).replace("$HOME", home);
     }
     if expanded == "~" {
         if let Some(home) = env.home.as_deref() {

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/mod.rs
@@ -835,25 +835,34 @@ fn worktree_add_target_token(tail: &[String]) -> Option<String> {
     None
 }
 
-/// Expand a leading `~`, `$TMPDIR`/`${TMPDIR}`, `$TMP`/`${TMP}`, and
-/// `$HOME`/`${HOME}` in a path token using `env`, then resolve it against
-/// `base` if relative, then lexically normalize (collapse `.`/`..` components
-/// WITHOUT touching the filesystem).
+/// Expand a leading `~`, `$TMPDIR`/`${TMPDIR}`, `$TMP`/`${TMP}`,
+/// `$HOME`/`${HOME}`, and `$PWD`/`${PWD}` in a path token using `env`/`base`,
+/// then resolve it against `base` if still relative, then lexically
+/// normalize (collapse `.`/`..` components WITHOUT touching the filesystem).
 ///
 /// Why: `shlex::split` does not perform shell variable expansion, so a target
-/// argument like `$TMPDIR/wt-foo`, `~/scratch/wt-foo`, or a literal `$HOME`
-/// (issue #4031 — an agent typing `rm -rf $HOME` verbatim) reaches this
-/// function as literal text; the guard must expand it itself to see where it
-/// really points. Filesystem-touching resolution (`fs::canonicalize`) is
-/// deliberately avoided — the worktree target usually does not exist yet, and
-/// a `PreToolUse` hook must stay fast and side-effect-free.
-/// What: string-replaces the env-var forms, expands a `~`/`~/…` prefix via
-/// `$HOME`, joins onto `base` if the result is still relative, then
-/// normalizes. The values arrive via [`PathEnv`] rather than being read here,
-/// so a test can pin them without mutating process-global state — see
-/// [`PathEnv`] for the CI failure that motivated the seam. In production
-/// [`PathEnv::from_process`] supplies the guard process's own environment,
-/// which a `Bash` tool call inherits unchanged.
+/// argument like `$TMPDIR/wt-foo`, `~/scratch/wt-foo`, a literal `$HOME`
+/// (issue #4031 — an agent typing `rm -rf $HOME` verbatim), or `$PWD` (issue
+/// #4031 review — `rm -rf $PWD` from inside a session's own worktree root
+/// reached this function unexpanded, so the guard saw a literal `"$PWD"`
+/// token that matched nothing) reaches this function as literal text; the
+/// guard must expand it itself to see where it really points. `$PWD` expands
+/// to `base` — the SAME cwd this function's own `.`/`..` resolution already
+/// treats as "here" — rather than a second read of the process environment's
+/// `PWD`, so a command composed with a preceding `cd` (which updates `base`
+/// via the caller's tracking, never the process env) still resolves `$PWD`
+/// against where the command actually stands. Filesystem-touching resolution
+/// (`fs::canonicalize`) is deliberately avoided — the worktree target usually
+/// does not exist yet, and a `PreToolUse` hook must stay fast and
+/// side-effect-free.
+/// What: string-replaces the env-var forms (`$PWD`/`${PWD}` against `base`,
+/// the rest against `env`), expands a `~`/`~/…` prefix via `$HOME`, joins onto
+/// `base` if the result is still relative, then normalizes. The env values
+/// arrive via [`PathEnv`] rather than being read here, so a test can pin them
+/// without mutating process-global state — see [`PathEnv`] for the CI failure
+/// that motivated the seam. In production [`PathEnv::from_process`] supplies
+/// the guard process's own environment, which a `Bash` tool call inherits
+/// unchanged.
 fn resolve_target_path(token: &str, base: &Path, env: &PathEnv) -> PathBuf {
     let mut expanded = token.to_string();
     if let Some(tmpdir) = env.tmpdir.as_deref() {
@@ -867,6 +876,8 @@ fn resolve_target_path(token: &str, base: &Path, env: &PathEnv) -> PathBuf {
     if let Some(home) = env.home.as_deref() {
         expanded = expanded.replace("${HOME}", home).replace("$HOME", home);
     }
+    let pwd = base.to_string_lossy();
+    expanded = expanded.replace("${PWD}", &pwd).replace("$PWD", &pwd);
     if expanded == "~" {
         if let Some(home) = env.home.as_deref() {
             expanded = home.to_string();

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/shell_lex.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/shell_lex.rs
@@ -19,6 +19,8 @@
 //! leading env/`sudo` noise and git global options.
 //! Test: `shell_lex::tests`.
 
+use crate::commands::hook_rewrite::strip_wrapper_prefix;
+
 /// Quote context of a single byte of a shell command.
 ///
 /// Why: the guard's operator/redirection/substitution scanners must treat a
@@ -173,40 +175,28 @@ const GIT_GLOBAL_OPTS_WITH_ARG: &[&str] = &[
 /// leading git global flags, which the earlier two-token `effective_tool_name`
 /// matcher could not see past. Parsing the argv properly closes both the
 /// `git -C <path> commit` false positive and the `git -C <path> apply`
-/// false negative.
+/// false negative. Issue #4031 review (pass 2): this function had its OWN
+/// `sudo`/`env`-only prefix skip, a second enumeration site that inherited the
+/// same weakness `hook_rewrite::first_command_token` did — `command git apply
+/// -` and `command git worktree remove --force <path>` reached the git guards
+/// unresolved. It now shares [`crate::commands::hook_rewrite::strip_wrapper_prefix`]
+/// with that function instead of re-enumerating.
 /// What: shlex-splits `segment` (quote-aware; `None` on unbalanced quotes →
-/// caller falls back), skips leading `KEY=value`/`sudo`/`env` prefixes, requires
-/// the program basename to be `git`, then walks past global options — those in
-/// [`GIT_GLOBAL_OPTS_WITH_ARG`] consume an extra token, `=`-joined long options
-/// consume none, other dash-prefixed tokens are valueless global flags — and
-/// returns the first non-option token (the subcommand). `None` when the segment
-/// is not `git`, is unparseable, or has no subcommand after the options.
+/// caller falls back), delegates the leading `KEY=value`/wrapper skip to
+/// [`strip_wrapper_prefix`], requires the program basename to be `git`, then
+/// walks past global options — those in [`GIT_GLOBAL_OPTS_WITH_ARG`] consume
+/// an extra token, `=`-joined long options consume none, other dash-prefixed
+/// tokens are valueless global flags — and returns the first non-option token
+/// (the subcommand). `None` when the segment is not `git`, is unparseable, or
+/// has no subcommand after the options.
 /// Test: `git_subcommand_skips_global_flags`, `git_subcommand_plain`,
-/// `git_subcommand_none_for_non_git`, `git_subcommand_none_when_unbalanced`.
+/// `git_subcommand_none_for_non_git`, `git_subcommand_none_when_unbalanced`,
+/// `git_subcommand_resolves_through_command_and_nice_wrappers`.
 pub(super) fn git_subcommand(segment: &str) -> Option<String> {
     let argv = shlex::split(segment)?;
-    let mut i = 0;
-    // Skip env-assignment / sudo / env prefixes (mirrors first_command_token).
-    while i < argv.len() {
-        let tok = &argv[i];
-        if is_env_assignment(tok) {
-            i += 1;
-            continue;
-        }
-        if tok == "sudo" || tok == "env" {
-            match argv.get(i + 1) {
-                Some(next) if !next.starts_with('-') => {
-                    i += 1;
-                    continue;
-                }
-                // Flag or nothing after sudo/env — needs arg-aware parsing we
-                // don't do; not resolvable as git.
-                _ => return None,
-            }
-        }
-        break;
-    }
+    let mut i = strip_wrapper_prefix(&argv)?;
     let program = argv.get(i)?;
+    let program = program.strip_prefix('\\').unwrap_or(program);
     if program.rsplit('/').next().unwrap_or(program) != "git" {
         return None;
     }
@@ -242,23 +232,6 @@ pub(super) fn git_subcommand(segment: &str) -> Option<String> {
         return Some(tok.clone());
     }
     None
-}
-
-/// Whether `token` looks like a `KEY=value` shell environment assignment.
-///
-/// Why: a leading env assignment (`FOO=bar git …`) must be skipped before the
-/// `git` program token, mirroring `hook_rewrite::first_command_token`'s rule so
-/// both code paths agree on what a prefix is.
-/// What: `KEY` non-empty, starting with a letter/underscore, alphanumerics or
-/// underscores up to the first `=`.
-/// Test: covered via `git_subcommand_skips_global_flags`.
-fn is_env_assignment(token: &str) -> bool {
-    let Some((key, _)) = token.split_once('=') else {
-        return false;
-    };
-    let mut chars = key.chars();
-    matches!(chars.next(), Some(c) if c.is_ascii_alphabetic() || c == '_')
-        && chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
 }
 
 #[cfg(test)]
@@ -364,6 +337,29 @@ mod tests {
         assert_eq!(
             git_subcommand("/usr/bin/git -C /p commit").as_deref(),
             Some("commit")
+        );
+    }
+
+    #[test]
+    fn git_subcommand_resolves_through_command_and_nice_wrappers() {
+        // #4031 review, item 4: `git_subcommand` had its own sudo/env-only
+        // prefix skip, a second enumeration site independent of
+        // `hook_rewrite::first_command_token` — `command git apply -` and a
+        // `nice`-wrapped git call both reached the git guards unresolved
+        // before sharing `strip_wrapper_prefix`.
+        for command in ["command git apply -", "nice git reset --hard"] {
+            assert!(
+                git_subcommand(command).is_some(),
+                "expected a resolved subcommand for: {command}"
+            );
+        }
+        assert_eq!(
+            git_subcommand("command git apply -").as_deref(),
+            Some("apply")
+        );
+        assert_eq!(
+            git_subcommand("nice git reset --hard").as_deref(),
+            Some("reset")
         );
     }
 }

--- a/crates/trusty-mpm/tests/tm_hook_pm_guard.rs
+++ b/crates/trusty-mpm/tests/tm_hook_pm_guard.rs
@@ -949,6 +949,89 @@ fn pm_guard_denies_backslash_and_command_wrapper_bypasses() {
 }
 
 #[test]
+fn pm_guard_denies_destructive_delete_regardless_of_wrapper_enumeration() {
+    // #4031 review pass 2, item 1: verb detection no longer depends on
+    // enumerating wrapper words — `env -i` and `command -p` (both followed
+    // by a FLAG the wrapper-skip helper conservatively refuses to resolve
+    // past) still deny here, because every token is scanned for the verb.
+    for command in [
+        "env -i rm -rf /root",
+        "command -p rm -rf /root",
+        "nice rm -rf /root",
+        "exec rm -rf /root",
+    ] {
+        let payload = serde_json::json!({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": command}
+        })
+        .to_string();
+        assert_denied(&run_pm_guard(&payload, &[]));
+    }
+}
+
+#[test]
+fn pm_guard_denies_bare_container_root_deletion() {
+    // #4031 review pass 2, item 3: `/Users` (every user's home at once) and
+    // its glob-suffixed form must deny, not just a specific user's home.
+    for command in ["rm -rf /Users", "rm -rf /Users/*"] {
+        let payload = format!(
+            r#"{{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{{"command":"{command}"}}}}"#
+        );
+        assert_denied(&run_pm_guard(&payload, &[]));
+    }
+}
+
+#[test]
+fn pm_guard_allows_wrapped_non_destructive_commands() {
+    // Companion allow cases: a wrapper preceding a non-delete command, and a
+    // delete verb whose target is genuinely benign, stay allowed.
+    let (_dir, repo) = main_checkout_fixture();
+    for command in [
+        "nice cargo clean",
+        "time rm -rf ./target",
+        "env FOO=1 rm stale.txt",
+    ] {
+        assert_eq!(
+            run_pm_guard(&bash_payload_at(command, &repo, ""), &[]).trim(),
+            "",
+            "expected allow for: {command}"
+        );
+    }
+}
+
+#[test]
+fn pm_guard_denies_command_wrapped_git_apply() {
+    // #4031 review, item 4: `shell_lex::git_subcommand` had its own
+    // sudo/env-only wrapper skip — `command git apply -` reached the
+    // git-apply guard unresolved before sharing `strip_wrapper_prefix`.
+    // `git apply` is a SHELL_EDIT_REASON deny, budget-eligible (issue #2918)
+    // rather than absolute, so each variant needs its own fresh per-turn
+    // budget — `isolated_home` avoids the shared, persistent real-`$HOME`
+    // counter a bare `run_pm_guard` call would otherwise race against.
+    for command in ["git apply -", "command git apply -", r"\git apply -"] {
+        let home = isolated_home();
+        let home_s = home.path().to_string_lossy().to_string();
+        let payload = serde_json::json!({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": command}
+        })
+        .to_string();
+        for n in 1..=3 {
+            let stdout = run_pm_guard(&payload, &[("HOME", &home_s)]);
+            assert_eq!(
+                stdout.trim(),
+                "",
+                "call {n} of 3 for {command} should be within budget and allowed"
+            );
+        }
+        let stdout = run_pm_guard(&payload, &[("HOME", &home_s)]);
+        assert_denied(&stdout);
+    }
+}
+
+#[test]
 fn pm_guard_allows_benign_pipes_and_dev_null() {
     // Composition with no forbidden segment must still allow.
     let piped = run_pm_guard(
@@ -1134,6 +1217,17 @@ fn pm_guard_denies_worktree_remove_from_native_subagent() {
     // it completed. It must fire AHEAD of Guard 4, which would otherwise exempt
     // this exact payload.
     let payload = r#"{"hook_event_name":"PreToolUse","agent_id":"agent-abc123","agent_type":"version-control","tool_name":"Bash","tool_input":{"command":"git worktree remove --force .claude/worktrees/agent-x"}}"#;
+    assert_worktree_remove_denied(&run_pm_guard(payload, &[]));
+}
+
+#[test]
+fn pm_guard_denies_command_wrapped_worktree_remove_from_native_subagent() {
+    // #4031 review, item 4: `shell_lex::git_subcommand` had its own
+    // sudo/env-only wrapper skip, independent of
+    // `hook_rewrite::first_command_token` — `command git worktree remove
+    // --force <path>` reached this guard unresolved before both shared
+    // `strip_wrapper_prefix`.
+    let payload = r#"{"hook_event_name":"PreToolUse","agent_id":"agent-abc123","agent_type":"version-control","tool_name":"Bash","tool_input":{"command":"command git worktree remove --force .claude/worktrees/agent-x"}}"#;
     assert_worktree_remove_denied(&run_pm_guard(payload, &[]));
 }
 
@@ -1768,6 +1862,36 @@ fn pm_guard_denies_the_incident_commands_in_a_main_checkout() {
         "",
         "`git reset HEAD` unstages without destroying anything and must stay allowed"
     );
+}
+
+#[test]
+fn pm_guard_denies_wrapped_git_reset_hard_in_a_main_checkout() {
+    // #4031 review, item 4: confirm `\git reset --hard` and `command git
+    // reset --hard` deny exactly where the plain form does — proving
+    // `shell_lex::git_subcommand`'s shared `strip_wrapper_prefix` reaches
+    // this guard too, not just the git-apply/worktree-remove ones.
+    // Built via `serde_json::json!` (not `bash_payload_at`'s string
+    // interpolation) so the literal backslash is JSON-escaped correctly.
+    let (_dir, repo) = main_checkout_fixture();
+    for command in [
+        "git reset --hard",
+        r"\git reset --hard",
+        "command git reset --hard",
+    ] {
+        let payload = serde_json::json!({
+            "hook_event_name": "PreToolUse",
+            "cwd": repo.display().to_string(),
+            "tool_name": "Bash",
+            "tool_input": {"command": command}
+        })
+        .to_string();
+        let stdout = run_pm_guard(&payload, &[]);
+        assert_denied(&stdout);
+        assert!(
+            stdout.contains("ADR-0037"),
+            "expected deny for {command}, got: {stdout}"
+        );
+    }
 }
 
 #[test]

--- a/crates/trusty-mpm/tests/tm_hook_pm_guard.rs
+++ b/crates/trusty-mpm/tests/tm_hook_pm_guard.rs
@@ -804,6 +804,83 @@ fn pm_guard_allows_non_add_worktree_subcommands_and_ordinary_temp_usage() {
 }
 
 #[test]
+fn pm_guard_denies_destructive_delete_of_filesystem_roots() {
+    // Issue #4031: no `rm`/`rmdir`/`unlink`/`find -delete` verb existed
+    // anywhere in the classifier. Every case here is a native
+    // Task/Agent-dispatched subagent (`agent_id` present) — proving these deny
+    // proves the rule fires BEFORE Guard 4's subagent exemption, the same
+    // property `pm_guard_blocks_worktree_add_under_tmp_via_subagent_payload`
+    // proves for the sibling worktree-tmp guard.
+    for command in ["rm -rf /", "rm -rf /root", "unlink /root"] {
+        let payload = format!(
+            r#"{{"hook_event_name":"PreToolUse","agent_id":"agent-xyz789","agent_type":"rust-engineer","tool_name":"Bash","tool_input":{{"command":"{command}"}}}}"#
+        );
+        let stdout = run_pm_guard(&payload, &[]);
+        assert_denied(&stdout);
+        assert!(
+            stdout.contains("4031"),
+            "deny message must cite issue #4031: {stdout}"
+        );
+    }
+}
+
+#[test]
+fn pm_guard_denies_destructive_delete_of_repo_root_and_dot_git() {
+    let (_dir, repo) = main_checkout_fixture();
+    for command in [
+        format!("rm -rf {}", repo.display()),
+        "rm -rf .git".to_string(),
+        "rmdir .git".to_string(),
+        "find . -delete".to_string(),
+        "cargo build && rm -rf .git".to_string(),
+    ] {
+        let stdout = run_pm_guard(&bash_payload_at(&command, &repo, ""), &[]);
+        assert_denied(&stdout);
+    }
+}
+
+#[test]
+fn pm_guard_denies_destructive_delete_of_a_worktree_root() {
+    let payload = r#"{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"rm -rf /projects/example-repo/.claude/worktrees/agent-x"}}"#;
+    assert_denied(&run_pm_guard(payload, &[]));
+}
+
+#[test]
+fn pm_guard_allows_ordinary_delete_cleanup() {
+    // The other half of #4031's scope: none of these target a denylisted
+    // root, so they must stay allowed — the same fixture used for the deny
+    // cases above proves this isn't passing merely because the cwd resolves
+    // to nothing.
+    // `git clean -fd` is deliberately excluded here: ADR-0037 already denies
+    // it in a MAIN CHECKOUT (a pre-existing, unrelated rule), so asserting
+    // ALLOW for it against `main_checkout_fixture` would test that guard's
+    // absence rather than this one's.
+    let (_dir, repo) = main_checkout_fixture();
+    for command in [
+        "rm stale.txt",
+        "rm -rf crates/trusty-mpm/src",
+        "rmdir empty-dir",
+        "cargo clean",
+    ] {
+        assert_eq!(
+            run_pm_guard(&bash_payload_at(command, &repo, ""), &[]).trim(),
+            "",
+            "expected allow for: {command}"
+        );
+    }
+}
+
+#[test]
+fn pm_guard_destructive_delete_denial_is_not_budget_eligible() {
+    let home = isolated_home();
+    let home_s = home.path().to_string_lossy().to_string();
+    let payload = r#"{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"rm -rf /root"}}"#;
+    for _ in 1..=4 {
+        assert_denied(&run_pm_guard(payload, &[("HOME", &home_s)]));
+    }
+}
+
+#[test]
 fn pm_guard_allows_benign_pipes_and_dev_null() {
     // Composition with no forbidden segment must still allow.
     let piped = run_pm_guard(

--- a/crates/trusty-mpm/tests/tm_hook_pm_guard.rs
+++ b/crates/trusty-mpm/tests/tm_hook_pm_guard.rs
@@ -983,6 +983,28 @@ fn pm_guard_denies_bare_container_root_deletion() {
 }
 
 #[test]
+fn pm_guard_denies_a_linux_users_home_root_like_its_macos_equivalent() {
+    // #4031 review pass 3: `is_user_home_root` recognized only
+    // `/Users/<name>` at first — `rm -rf /home/someoneelse` and its
+    // glob-suffixed form denied on macOS but allowed on Linux, the same
+    // hazard unenforced on half the platforms this guard runs on.
+    for command in ["rm -rf /home/someoneelse", "rm -rf /home/someoneelse/*"] {
+        let payload = format!(
+            r#"{{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{{"command":"{command}"}}}}"#
+        );
+        assert_denied(&run_pm_guard(&payload, &[]));
+    }
+}
+
+#[test]
+fn pm_guard_allows_an_ordinary_project_under_a_linux_user_home() {
+    // The companion allow case: a subdirectory INSIDE a Linux user's home is
+    // ordinary work, exactly like `/Users/bob/Projects/foo` on macOS.
+    let payload = r#"{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"rm -rf /home/x/project/target"}}"#;
+    assert_eq!(run_pm_guard(payload, &[]).trim(), "");
+}
+
+#[test]
 fn pm_guard_allows_wrapped_non_destructive_commands() {
     // Companion allow cases: a wrapper preceding a non-delete command, and a
     // delete verb whose target is genuinely benign, stay allowed.

--- a/crates/trusty-mpm/tests/tm_hook_pm_guard.rs
+++ b/crates/trusty-mpm/tests/tm_hook_pm_guard.rs
@@ -881,6 +881,74 @@ fn pm_guard_destructive_delete_denial_is_not_budget_eligible() {
 }
 
 #[test]
+fn pm_guard_denies_pwd_expansion_of_the_current_worktree_root() {
+    // #4031 review, CRITICAL 1: `$PWD` reached the guard unexpanded, so a
+    // dispatched subagent's `rm -rf $PWD` from inside its OWN worktree root
+    // matched no denylist entry. `agent_id` is present so this also proves
+    // the rule still pierces Guard 4.
+    let worktree = std::path::Path::new("/projects/example-repo/.claude/worktrees/agent-x");
+    for command in ["rm -rf $PWD", "rm -rf ${PWD}"] {
+        let payload = bash_payload_at(
+            command,
+            worktree,
+            r#""agent_id":"agent-xyz789","agent_type":"rust-engineer","#,
+        );
+        assert_denied(&run_pm_guard(&payload, &[]));
+    }
+}
+
+#[test]
+fn pm_guard_allows_pwd_expansion_of_a_subdirectory() {
+    // The companion allow case: `$PWD/target` is an ordinary subdirectory of
+    // the worktree, not its root.
+    let worktree = std::path::Path::new("/projects/example-repo/.claude/worktrees/agent-x");
+    let payload = bash_payload_at("rm -rf $PWD/target", worktree, "");
+    assert_eq!(run_pm_guard(&payload, &[]).trim(), "");
+}
+
+#[test]
+fn pm_guard_denies_glob_suffixed_deletes_of_home() {
+    // #4031 review, CRITICAL 2: this classifier never expands a glob — a
+    // literal `$HOME/*` or a `./*` run from `$HOME` must still deny by
+    // evaluating the glob's PARENT (here, `$HOME` itself) against the
+    // denylist. `HOME` is pinned via `isolated_home` so the assertion does
+    // not depend on the runner's real home directory.
+    let home = isolated_home();
+    let home_s = home.path().to_string_lossy().to_string();
+    for command in ["rm -rf $HOME/*", "rm -rf ./*"] {
+        let payload = bash_payload_at(command, home.path(), "");
+        assert_denied(&run_pm_guard(&payload, &[("HOME", &home_s)]));
+    }
+}
+
+#[test]
+fn pm_guard_allows_a_glob_inside_a_worktree_subdirectory() {
+    // The companion allow case: a glob whose parent is an ORDINARY
+    // subdirectory (not a denylisted root) is not this rule's business.
+    let worktree = std::path::Path::new("/projects/example-repo/.claude/worktrees/agent-x");
+    let payload = bash_payload_at("rm -rf ./target/*", worktree, "");
+    assert_eq!(run_pm_guard(&payload, &[]).trim(), "");
+}
+
+#[test]
+fn pm_guard_denies_backslash_and_command_wrapper_bypasses() {
+    // #4031 review, HIGH 3/4: `\rm` and `command rm` are the standard POSIX
+    // alias-bypass idioms — both run the real `rm` exactly as `rm` does.
+    // Built via `serde_json::json!` rather than string interpolation so the
+    // literal backslash is JSON-escaped correctly (a hand-interpolated
+    // `"\rm …"` decodes as a carriage return, not a backslash).
+    for command in [r"rm -rf /root", r"\rm -rf /root", "command rm -rf /root"] {
+        let payload = serde_json::json!({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": command}
+        })
+        .to_string();
+        assert_denied(&run_pm_guard(&payload, &[]));
+    }
+}
+
+#[test]
 fn pm_guard_allows_benign_pipes_and_dev_null() {
     // Composition with no forbidden segment must still allow.
     let piped = run_pm_guard(


### PR DESCRIPTION
Refs #4031.

The `tm hook --pm-guard` Bash guard had no handling for delete verbs. New `pm_guard_bash/destructive_delete.rs`: an absolute target-path denylist (safety, not role), evaluated before Guards 1 and 4 for PM and subagents alike. Denied targets: filesystem roots, `/root`, `/Users/<name>` and `/home/<name>`, `$HOME` and its parent, bare containers (`/Users /home /Volumes /private /var /etc /usr /opt /Library /System /Applications`), the repo root, any `.git` (file or dir), and `.claude/worktrees` / `.worktrees` containers and worktree roots. A glob whose last component holds `*`/`?`/`[` is judged by its parent. Ordinary cleanup stays allowed (`rm -rf ./target`, `cargo clean`, `git clean -fd`, deletes inside a worktree, `git worktree remove` under the existing #5791 rule).

Design after three critic passes: the verb is detected by scanning every token of each segment, so wrappers (`sudo env nice time nohup exec command builtin \rm …`) do not matter; a delete verb with no resolvable target fails closed; `$PWD` resolves against the tracked cwd; `hook_rewrite::strip_wrapper_prefix` is shared by `first_command_token` and `shell_lex::git_subcommand`, so `command git apply -` / `command git worktree remove --force` / `command git reset --hard` reach their guards. Accepted residuals are listed in the module doc (`sh -c`, `xargs`, `eval`, command substitution).

Test ladder: rung 3 plus failure-path tests (security-adjacent). 121 e2e tests through the built binary in `tests/tm_hook_pm_guard.rs`, 180 unit tests in the `pm_guard_bash` filter. Pre-fix: `rm -rf $PWD` from a worktree root, `rm -rf ~/*`, `\rm -rf /root`, `command rm -rf /root`, `env -i rm -rf /root`, `nice rm -rf /root`, `rm -rf /Users`, `rm -rf /home/x` were all allowed; all deny now. Live hook outputs are in the critic reports.

cargo fmt --check: exit 0
cargo clippy -p trusty-mpm --all-targets -- -D warnings: exit 0
cargo test -p trusty-mpm --no-fail-fast: every target ok, 0 failures (largest 5794 passed)
check_line_cap 0 violations; check_sld 0 errors; check_test_pointers 0 dangling; check_changelog_fragment OK; check-pr-version-bump: tm 1.5.16 unpublished, no bump

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KsTGDrDYKBPmHmmbRsMm5w
