### PR TITLE
fix(trusty-analyze): daemon guard defers to a launchd-owned socket; version subcommand with --json (Refs #6624, Refs #6631)

### DIFF
--- a/crates/trusty-analyze/changelog.d/6624-launchd-claim-guard.md
+++ b/crates/trusty-analyze/changelog.d/6624-launchd-claim-guard.md
@@ -1,0 +1,9 @@
+Fixed
+- `ensure_daemon_running` no longer races a launchd-supervised
+  `com.trusty.analyze` unit onto its own socket. The PID-file check that
+  coordinates this daemon's own bridges cannot see launchd, so during a
+  bootout/bootstrap window left by a pre-#6350 install the socket read as
+  "nothing is running" and a bridge would spawn a second, unsupervised
+  process. The guard now asks `trusty_common::launchd_claim` first and waits
+  for the unit instead of spawning — a no-op on the ordinary host, where
+  ADR-0032 means no plist is installed at all (#6624).

--- a/crates/trusty-analyze/changelog.d/6631-version-subcommand.md
+++ b/crates/trusty-analyze/changelog.d/6631-version-subcommand.md
@@ -1,0 +1,6 @@
+Added
+- `trusty-analyze version` subcommand, so `tctl doctor trusty-analyze
+  --self-check` can spawn `version --json` instead of failing on a clap usage
+  error. `--json` emits the DOC-1 capability-discovery envelope
+  (`contract_version`, `tool_version`, `verbs`); without it, a one-line
+  `trusty-analyze v<version>` (#6631).

--- a/crates/trusty-analyze/src/commands/daemon_guard.rs
+++ b/crates/trusty-analyze/src/commands/daemon_guard.rs
@@ -18,8 +18,22 @@
 //! than the abstraction, and `trusty_common::uds::socket_is_serving` is the
 //! shared entry point that actually matters.
 //!
+//! #6624 adds the exclusion trusty-memory's `ensure_daemon_running` gained in
+//! #6619: the PID-file check below coordinates this daemon's OWN bridges with
+//! each other (whoever wrote `daemon.pid` is presumably already spawning) and
+//! cannot see launchd. ADR-0032 retired `com.trusty.analyze` — a client starts
+//! the daemon on demand and it exits on its own idle window — so today's
+//! ordinary host has no plist and [`socket_owner_for`] answers
+//! [`SocketOwner::OnDemand`], a pure no-op for this fix. A host that still
+//! carries a pre-#6350 plist (an upgrade that has not yet evicted it) is the
+//! case this guards: during that unit's `bootout`/`bootstrap` window the
+//! socket is transiently unserved, and spawning onto it races the very unit
+//! that is coming back for the same path. See [`ensure_daemon_running`].
+//!
 //! Test: `probe_health_returns_false_for_an_absent_socket`,
-//! `ensure_daemon_running_returns_ok_when_something_is_already_serving`.
+//! `ensure_daemon_running_returns_ok_when_something_is_already_serving`,
+//! `ensure_daemon_running_defers_to_a_launchd_unit_instead_of_spawning`,
+//! `ensure_daemon_running_spawns_when_no_launchd_unit_owns_the_socket`.
 //!
 //! Note: only call this from commands that *require* the daemon. Commands like
 //! `start`, `stop`, `serve`, `service`, and `completions` deliberately do not
@@ -28,8 +42,9 @@
 use std::path::Path;
 use std::time::{Duration, Instant};
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context as _, Result};
 use colored::Colorize;
+use trusty_common::launchd_claim::SocketOwner;
 
 /// How long a liveness connect may take before it is called dead.
 ///
@@ -42,6 +57,83 @@ const STARTUP_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// How often to re-probe while waiting.
 const POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+/// How long to wait for a launchd-supervised daemon to come back (#6624).
+///
+/// Matches `trusty_common::shutdown::TERMINATION_GRACE_SECS`, the window a
+/// launchd-managed daemon is allowed to spend exiting during a restart —
+/// waiting less would give up while a legitimate bootout/bootstrap was still
+/// in progress.
+const LAUNCHD_RESTART_TIMEOUT: Duration =
+    Duration::from_secs(trusty_common::shutdown::TERMINATION_GRACE_SECS);
+
+/// Whether `socket` is trusty-analyze's canonical production path (#6624).
+///
+/// Why: mirrors trusty-memory's `commands::single_instance::is_production_socket`
+/// — the launchd question only applies to the one path a fresh install ever
+/// bootstraps. A test temp-dir socket, or a `TRUSTY_DATA_DIR_OVERRIDE` sandbox,
+/// is never that path even on a host where the retired `com.trusty.analyze`
+/// plist is still installed.
+/// What: false whenever the override env var is set; otherwise compares
+/// `socket` against `trusty_analyze::service::socket_path()`.
+fn is_production_socket(socket: &Path) -> bool {
+    if std::env::var_os(trusty_common::DATA_DIR_OVERRIDE_ENV).is_some() {
+        return false;
+    }
+    trusty_analyze::service::socket_path().is_ok_and(|p| p == socket)
+}
+
+/// Whether launchd owns the socket this guard is about to spawn onto (#6624).
+///
+/// Why: the answer turns on the socket, not just the host — see
+/// [`is_production_socket`].
+/// What: asks [`trusty_common::launchd_claim`] about
+/// [`trusty_common::launchd_labels::ANALYZE`] (retired but still the label an
+/// upgrade must evict, per that constant's own doc).
+/// Test: the decision is covered by trusty-common's `socket_owner_*`; both
+/// branches of the caller by `ensure_daemon_running_defers_to_a_launchd_unit_\
+/// instead_of_spawning` and `ensure_daemon_running_spawns_when_no_launchd_unit_\
+/// owns_the_socket`.
+fn socket_owner_for(socket: &Path) -> SocketOwner {
+    trusty_common::launchd_claim::launchd_socket_owner(
+        trusty_common::launchd_labels::ANALYZE,
+        is_production_socket(socket),
+    )
+}
+
+/// Wait for a launchd-supervised daemon to serve `socket` again (#6624).
+///
+/// Why: launchd is bringing this daemon back. Spawning our own in the gap
+/// produces a second process racing for the same path, and this bridge has no
+/// way to tell which one launchd's own instance will find already bound.
+/// What: polls until something serves, bounded by `wait`. The error names the
+/// unit, so an operator knows to look at launchd rather than at this bridge.
+///
+/// # Errors
+///
+/// When nothing serves the socket within `wait`.
+async fn await_launchd_daemon(socket: &Path, label: &str, wait: Duration) -> Result<()> {
+    eprintln!(
+        "{} Waiting for launchd unit {label} to serve trusty-analyze…",
+        "◉".cyan()
+    );
+    let deadline = Instant::now() + wait;
+    while Instant::now() < deadline {
+        tokio::time::sleep(POLL_INTERVAL).await;
+        if probe_health(socket).await {
+            return Ok(());
+        }
+    }
+    Err(anyhow!(
+        "launchd unit {label} owns {} but nothing served it within {}s. Not \
+         spawning a second daemon onto that path while launchd's own instance \
+         may still be starting (#6624). Check `launchctl print \
+         gui/$(id -u)/{label}`, or evict the retired unit with `launchctl \
+         bootout gui/$(id -u)/{label}` if it should not be there at all",
+        socket.display(),
+        wait.as_secs()
+    ))
+}
 
 /// Is anything serving `socket`?
 ///
@@ -73,9 +165,8 @@ fn spawn_daemon() -> Result<u32> {
 ///
 /// Why: gives any daemon-requiring command a single shared "boot if absent"
 /// path so the user never has to run `trusty-analyze start` first.
-/// What: fast-path probes the socket; on miss, checks the PID file to avoid
-/// double-spawning a booting daemon, then spawns (or just waits), and polls for
-/// up to [`STARTUP_TIMEOUT`].
+/// What: delegates to [`ensure_daemon_running_with`] with the real launchd
+/// verdict, wait, and spawn.
 ///
 /// # Errors
 ///
@@ -83,29 +174,87 @@ fn spawn_daemon() -> Result<u32> {
 ///
 /// Test: `ensure_daemon_running_returns_ok_when_something_is_already_serving`.
 pub async fn ensure_daemon_running(socket: &Path) -> Result<()> {
-    // Fast path: daemon is already up.
-    if probe_health(socket).await {
-        return Ok(());
-    }
+    ensure_daemon_running_with(
+        socket,
+        socket_owner_for(socket),
+        LAUNCHD_RESTART_TIMEOUT,
+        pid_file_shows_a_starting_daemon,
+        spawn_daemon,
+    )
+    .await
+}
 
-    // Check for a stale-but-booting daemon via the PID file before spawning
-    // a duplicate.
-    let already_running = super::daemon::pid_file_path()
+/// Whether the PID file names a daemon that is presumably already booting.
+///
+/// Why: split out so a test can inject a fixed answer instead of reading the
+/// real `~/.trusty-analyze/daemon.pid` — a file this process does not own and
+/// whose presence on the host running the test is not the thing under test
+/// (#6624 regression coverage hit exactly this: a stale PID file left by an
+/// unrelated run made the guard wait instead of spawning, in a temp-dir socket
+/// scenario that has no PID file of its own to check).
+/// What: true iff the PID file exists and its contents parse as a `u32`. Does
+/// NOT check the PID is actually alive — this only coordinates against a
+/// bridge that is concurrently spawning, not against a stale leftover.
+fn pid_file_shows_a_starting_daemon() -> bool {
+    super::daemon::pid_file_path()
         .ok()
         .and_then(|p| {
             let raw = std::fs::read_to_string(&p).ok()?;
             raw.trim().parse::<u32>().ok()
         })
-        .is_some();
+        .is_some()
+}
 
-    if already_running {
+/// [`ensure_daemon_running`] with the launchd verdict, the wait, the PID-file
+/// check, and the spawn supplied by the caller (#6624).
+///
+/// Why: the branch that must never be taken while launchd owns the socket is
+/// the SPAWN, so proving it is not taken means being able to hand in a spawn
+/// that panics if called. Reading launchd and forking a real daemon are both
+/// untestable in process; injecting them — and the PID-file read, which
+/// otherwise touches the real `$HOME` — is what makes the exclusion an
+/// assertion rather than a claim.
+///
+/// What: identical to [`ensure_daemon_running`] up to the point of spawning. A
+/// [`SocketOwner::Launchd`] verdict diverts to [`await_launchd_daemon`] before
+/// `already_running` is even consulted, and `spawn` is never called.
+///
+/// # Errors
+///
+/// As [`ensure_daemon_running`], plus the launchd-wait timeout.
+///
+/// Test: `ensure_daemon_running_defers_to_a_launchd_unit_instead_of_spawning`,
+/// `ensure_daemon_running_spawns_when_no_launchd_unit_owns_the_socket`.
+pub(crate) async fn ensure_daemon_running_with(
+    socket: &Path,
+    owner: SocketOwner,
+    launchd_wait: Duration,
+    already_running: impl FnOnce() -> bool,
+    spawn: impl FnOnce() -> Result<u32>,
+) -> Result<()> {
+    // Fast path: daemon is already up.
+    if probe_health(socket).await {
+        return Ok(());
+    }
+
+    // #6624: the PID-file check below coordinates this daemon's bridges with
+    // each other, never with launchd. An unserved socket during a retired
+    // unit's bootout/bootstrap window is launchd's restart, not an absent
+    // daemon — wait for it rather than racing a second process onto its path.
+    if let SocketOwner::Launchd { label } = &owner {
+        return await_launchd_daemon(socket, label, launchd_wait).await;
+    }
+
+    // Check for a stale-but-booting daemon via the PID file before spawning
+    // a duplicate.
+    if already_running() {
         eprintln!(
             "{} trusty-analyze daemon already starting, waiting for it to become ready…",
             "◉".cyan()
         );
     } else {
         eprintln!("{} Starting trusty-analyze daemon…", "◉".cyan());
-        spawn_daemon()?;
+        spawn().context("spawning the trusty-analyze daemon")?;
     }
 
     let deadline = Instant::now() + STARTUP_TIMEOUT;
@@ -163,6 +312,77 @@ mod tests {
             started.elapsed() < Duration::from_secs(3),
             "the fast path must not wait: {:?}",
             started.elapsed()
+        );
+    }
+
+    /// Why (#6624): this is the defect. A retired `com.trusty.analyze` unit
+    /// left loaded by a pre-#6350 install boots the socket out transiently, and
+    /// the pre-fix guard read that as licence to spawn a second, unsupervised
+    /// process racing the unit that is coming back. The spawn here panics if
+    /// reached, so passing proves the exclusion rather than describing it.
+    /// What: a `Launchd` verdict over a socket nothing serves waits, never
+    /// spawns, and errors naming the unit.
+    /// Test: itself.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn ensure_daemon_running_defers_to_a_launchd_unit_instead_of_spawning() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let err = ensure_daemon_running_with(
+            &tmp.path().join("absent.sock"),
+            SocketOwner::Launchd {
+                label: "com.trusty.analyze".to_owned(),
+            },
+            Duration::from_millis(600),
+            || unreachable!("the launchd branch returns before checking the PID file"),
+            || unreachable!("a launchd-owned socket must never be spawned onto"),
+        )
+        .await
+        .expect_err("a unit that never comes back is an error, not a spawn");
+
+        assert!(
+            err.to_string().contains("com.trusty.analyze"),
+            "the owning unit must be named: {err}"
+        );
+    }
+
+    /// Why: the exclusion must not reach the ordinary host — ADR-0032 retired
+    /// `com.trusty.analyze`, so a fresh install has no plist and the #5267
+    /// on-demand contract (a client spawns the daemon, it exits on its own
+    /// idle window) must keep working exactly as before.
+    /// What: an `OnDemand` verdict reaches the spawn, which stands a listener
+    /// up on the socket; the readiness wait then succeeds exactly as it does
+    /// for a real daemon.
+    /// Test: itself.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn ensure_daemon_running_spawns_when_no_launchd_unit_owns_the_socket() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let socket = tmp.path().join("sockets").join("analyze.sock");
+        let spawned = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let flag = std::sync::Arc::clone(&spawned);
+        let bind_at = socket.clone();
+
+        ensure_daemon_running_with(
+            &socket,
+            SocketOwner::OnDemand,
+            Duration::from_millis(600),
+            // #6624 regression: this must be injected, not the real PID-file
+            // read — a stale `~/.trusty-analyze/daemon.pid` left by an
+            // unrelated process on the machine running this test would
+            // otherwise report "already starting" and this assertion would
+            // time out without `spawn` ever running.
+            || false,
+            move || {
+                flag.store(true, std::sync::atomic::Ordering::SeqCst);
+                let listener = trusty_common::uds::bind_hardened(&bind_at)?;
+                tokio::spawn(async move { while listener.accept().await.is_ok() {} });
+                Ok(4242)
+            },
+        )
+        .await
+        .expect("an unmanaged host spawns and the daemon comes up");
+
+        assert!(
+            spawned.load(std::sync::atomic::Ordering::SeqCst),
+            "an unmanaged host must still get its on-demand spawn"
         );
     }
 }

--- a/crates/trusty-analyze/src/commands/mod.rs
+++ b/crates/trusty-analyze/src/commands/mod.rs
@@ -6,3 +6,4 @@ pub mod run;
 pub mod service;
 pub mod setup;
 pub mod socket;
+pub mod version;

--- a/crates/trusty-analyze/src/commands/version.rs
+++ b/crates/trusty-analyze/src/commands/version.rs
@@ -1,0 +1,97 @@
+//! `trusty-analyze version` — the DOC-1 capability-discovery envelope tctl reads.
+//!
+//! Why (#6631): `tctl doctor <member> --self-check` spawns `<binary> version
+//! --json` and requires `contract_version` plus a non-empty `verbs[]` at the
+//! TOP LEVEL of that reply
+//! (`trusty-installer::commands::probe::validate_version_envelope`,
+//! ADR-0007/DOC-1). trusty-analyze had no `version` subcommand at all, so the
+//! self-check failed with a clap usage error before it could parse anything.
+//!
+//! What: [`envelope`] builds the JSON object; [`run`] prints it, or a
+//! one-line human summary without `--json`. `verbs` names only `"version"`
+//! itself — no other trusty-analyze subcommand emits the DOC-1 envelope yet
+//! (`health`/`doctor`/`start`/`stop` stay plain text), and advertising a verb
+//! this binary cannot answer in-contract would be the opposite defect: a
+//! controller trusting `verbs[]` (D3b) and getting a plain-text reply instead
+//! of an envelope.
+//!
+//! Test: `envelope_satisfies_the_doc1_self_check`,
+//! `envelope_carries_the_crate_version`; the subprocess-level
+//! `version_json_parses_and_carries_the_crate_version` in `main_tests.rs`
+//! proves the real binary, not just this function.
+
+use serde_json::{json, Value};
+
+/// DOC-1 `contract_version` baseline
+/// (`docs/trusty-installer/research/02-design/01-tool-contract.md`,
+/// ADR-0007). Bumped only for a non-additive envelope or verb-`data` shape
+/// change — never for adding a verb (D3, restated in that doc's ledger).
+const CONTRACT_VERSION: u32 = 1;
+
+/// Build the `version --json` envelope tctl's self-check parses.
+///
+/// Why/What: see the module doc — `contract_version` and `verbs` sit at the
+/// TOP level, not nested under a `data` key, because that is what
+/// `validate_version_envelope` actually reads off the spawned process's
+/// stdout.
+/// Test: `envelope_satisfies_the_doc1_self_check`,
+/// `envelope_carries_the_crate_version`.
+pub fn envelope() -> Value {
+    json!({
+        "contract_version": CONTRACT_VERSION,
+        "tool": "trusty-analyze",
+        "tool_version": env!("CARGO_PKG_VERSION"),
+        "verb": "version",
+        "status": "ok",
+        "verbs": ["version"],
+        "messages": [],
+    })
+}
+
+/// Entry point for `trusty-analyze version [--json]`.
+///
+/// What: `--json` prints [`envelope`]; otherwise a one-line human summary
+/// matching the other trusty-* binaries' plain-text `version` output.
+/// Test: `version_json_parses_and_carries_the_crate_version` in
+/// `main_tests.rs`.
+pub fn run(json: bool) {
+    if json {
+        println!("{}", envelope());
+    } else {
+        println!("trusty-analyze v{}", env!("CARGO_PKG_VERSION"));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why (#6631): this is the literal check `doctor --self-check` runs —
+    /// pinning it here means a future edit that drops either field fails in
+    /// this crate's own test run, not three hops away in trusty-installer's.
+    /// What: `contract_version` is a positive integer and `verbs` is a
+    /// non-empty array, both at the top level.
+    /// Test: itself.
+    #[test]
+    fn envelope_satisfies_the_doc1_self_check() {
+        let v = envelope();
+        assert!(
+            v["contract_version"].as_u64().is_some_and(|n| n >= 1),
+            "contract_version must be a positive integer: {v}"
+        );
+        assert!(
+            v["verbs"].as_array().is_some_and(|a| !a.is_empty()),
+            "verbs must be a non-empty array: {v}"
+        );
+    }
+
+    /// Why: tctl's self-check and any operator reading `version --json` need
+    /// the crate's actual release version, not a placeholder.
+    /// What: `tool_version` equals `CARGO_PKG_VERSION`.
+    /// Test: itself.
+    #[test]
+    fn envelope_carries_the_crate_version() {
+        let v = envelope();
+        assert_eq!(v["tool_version"], env!("CARGO_PKG_VERSION"));
+    }
+}

--- a/crates/trusty-analyze/src/main.rs
+++ b/crates/trusty-analyze/src/main.rs
@@ -237,6 +237,22 @@ enum Cmd {
     /// the facts-store path can be opened. Exits non-zero on any failure.
     /// Test: with the daemon down → ✗ for daemon, exits 1.
     Doctor,
+    /// Print the crate version, or (with `--json`) the DOC-1
+    /// capability-discovery envelope `tctl doctor --self-check` reads.
+    ///
+    /// Why (#6631): `tctl doctor trusty-analyze --self-check` spawns this
+    /// exact form and requires `contract_version` + a non-empty `verbs[]`;
+    /// trusty-analyze had no `version` subcommand at all, so the self-check
+    /// failed on a clap usage error before it reached the daemon.
+    /// What: delegates to `commands::version::run`. Needs no daemon and no
+    /// data-directory access — it answers from the binary alone.
+    /// Test: `commands::version::envelope_satisfies_the_doc1_self_check`,
+    /// `main_tests::version_json_parses_and_carries_the_crate_version`.
+    Version {
+        /// Emit the DOC-1 capability-discovery envelope as JSON.
+        #[arg(long)]
+        json: bool,
+    },
     /// Generate shell completion script.
     ///
     /// Why: shell completion massively improves discoverability for a CLI
@@ -637,6 +653,10 @@ async fn main() -> Result<()> {
         Cmd::Status => daemon_cmds::handle_status(&trusty_analyze::service::socket_path()?).await,
         Cmd::Doctor => {
             daemon_cmds::handle_doctor(&trusty_analyze::service::socket_path()?, &facts_path).await
+        }
+        Cmd::Version { json } => {
+            commands::version::run(json);
+            Ok(())
         }
         Cmd::Completions { shell } => {
             // Why: clap_complete renders a script for the requested shell from

--- a/crates/trusty-analyze/tests/version_cli.rs
+++ b/crates/trusty-analyze/tests/version_cli.rs
@@ -1,0 +1,70 @@
+//! Integration smoke test (#6631): `version --json` answers the way
+//! `tctl doctor trusty-analyze --self-check` actually invokes it.
+//!
+//! Why: `trusty-installer`'s self-check spawns `<binary> version --json` as a
+//! real subprocess and parses raw stdout (`spawn_json_at_path`), never calling
+//! into this crate as a library. A unit test on `commands::version::envelope`
+//! proves the JSON shape but not that the CLI is wired up to emit it — this
+//! drives the real built binary the way the self-check does.
+//! What: spawns the binary via the Cargo-provided `CARGO_BIN_EXE_*` path,
+//! parses stdout as JSON, and asserts the fields `validate_version_envelope`
+//! reads plus the crate's own version. `version` (no `--json`) gets the same
+//! offline-CLI-surface check the other integration tests here use.
+//! Test: this file IS the test.
+
+use std::process::Command;
+
+/// Absolute path to the freshly built binary (Cargo sets this for integration
+/// tests). Using it guarantees we exercise the real mounted CLI, not a stub.
+const BIN: &str = env!("CARGO_BIN_EXE_trusty-analyze");
+
+#[test]
+fn version_json_parses_and_carries_the_crate_version() {
+    let out = Command::new(BIN)
+        .args(["version", "--json"])
+        .output()
+        .expect("spawn `version --json`");
+    assert!(
+        out.status.success(),
+        "`version --json` should exit 0; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let v: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("`version --json` must emit valid JSON");
+
+    // The exact fields `validate_version_envelope` reads off this stdout
+    // (trusty-installer::commands::probe) — a positive `contract_version` and
+    // a non-empty `verbs[]`, both at the top level.
+    assert!(
+        v["contract_version"].as_u64().is_some_and(|n| n >= 1),
+        "contract_version must be a positive integer: {v}"
+    );
+    assert!(
+        v["verbs"].as_array().is_some_and(|a| !a.is_empty()),
+        "verbs must be a non-empty array: {v}"
+    );
+    assert_eq!(
+        v["tool_version"],
+        env!("CARGO_PKG_VERSION"),
+        "tool_version must be the crate's real release version: {v}"
+    );
+}
+
+#[test]
+fn version_without_json_prints_the_crate_version() {
+    let out = Command::new(BIN)
+        .arg("version")
+        .output()
+        .expect("spawn `version`");
+    assert!(
+        out.status.success(),
+        "`version` should exit 0; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains(env!("CARGO_PKG_VERSION")),
+        "plain `version` should print the crate version; got:\n{stdout}"
+    );
+}


### PR DESCRIPTION
Refs #6624, Refs #6631.

#6624: `ensure_daemon_running` had the shape #6619 fixed in trusty-memory — a flock coordinated bridges with each other, never with launchd. It now asks `trusty_common::launchd_claim::launchd_socket_owner` (label `launchd_labels::ANALYZE`) before spawning; a `Launchd` verdict waits, bounded by `TERMINATION_GRACE_SECS`, instead of racing the unit onto the canonical socket. The unit is retired (ADR-0032) so the guard is a no-op when no plist is installed. The PID-file check became an injected closure so the regression test is hermetic (a stale `~/.trusty-analyze/daemon.pid` on the dev host had made the first draft wait instead of spawn).

#6631: `tctl doctor trusty-analyze --self-check` runs `trusty-analyze version --json` and the CLI had no such verb. New `commands/version.rs` emits the DOC-1 envelope tctl's `validate_version_envelope` reads (`contract_version`, `tool`, `tool_version`, `verb`, `status`, `verbs`, `messages`); plain text without `--json`.

Test ladder: rung 3 (localized to trusty-analyze); `cargo check --workspace` also run.
Regression tests: `ensure_daemon_running_defers_to_a_launchd_unit_instead_of_spawning` and `ensure_daemon_running_spawns_when_no_launchd_unit_owns_the_socket`; `tests/version_cli.rs` spawns the built binary the way tctl does and asserts the envelope and `tool_version == CARGO_PKG_VERSION`.

cargo fmt --check: clean
cargo check / clippy -p trusty-analyze --all-targets -- -D warnings: exit 0
cargo test -p trusty-analyze --no-fail-fast: 514 passed (lib) + 30 (bin) + all integration targets, 0 failures
cargo check --workspace: exit 0
check_line_cap / check_sld / check_test_pointers / check_changelog_fragment: OK; check-pr-version-bump: trusty-analyze 0.12.4 unpublished, no bump

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KsTGDrDYKBPmHmmbRsMm5w
