### PR TITLE
fix(trusty-mpm): daemon gh spawns resolve GH_CONFIG_DIR from project or daemon config (Refs #6623)

### DIFF
--- a/crates/trusty-mpm/changelog.d/6623-daemon-gh-config-dir.md
+++ b/crates/trusty-mpm/changelog.d/6623-daemon-gh-config-dir.md
@@ -1,0 +1,13 @@
+Fixed
+- The daemon's `gh` spawns (merged-PR worktree reclaim, the `worktree_disk`
+  `tm doctor` check) now resolve `GH_CONFIG_DIR`/`GH_TOKEN`/`GH_HOST` from the
+  active project's `github:` binding, falling back to the global `github:`
+  section, exactly as an interactive `tm` invocation already does. Under
+  launchd the daemon inherits neither variable, so every lookup used to exit 4
+  ("gh auth login") on a host that keeps `gh` credentials in a scoped config
+  directory — 261 failed lookups in one reported sweep (#6561). A resolution
+  failure (an unreadable origin remote, an `account`-only binding) falls back
+  to the ambient environment rather than blocking the spawn.
+- The `worktree_disk` doctor check now names the resolved `gh` identity
+  alongside a failed lookup, so "used no config dir at all" reads differently
+  from "used the wrong one" (#6623).

--- a/crates/trusty-mpm/src/core/gh_identity.rs
+++ b/crates/trusty-mpm/src/core/gh_identity.rs
@@ -65,8 +65,20 @@
 //!
 //! Test: `resolve_*`, `precedence_*`, `host_*`, `account_*`, `clone_url_*`,
 //! `select_github_config_*` in the inline `tests` module.
+//!
+//! ## Directory-based resolution (#6623)
+//!
+//! [`select_config_for_origin`] promotes the CLI's project-matching glue
+//! (`bin/tm/gh_identity::resolve_project_aware`, which detects the active
+//! project from `std::env::current_dir()`'s git origin remote) to the
+//! library, so a daemon-side `gh` spawn — which has a WORKING DIRECTORY but no
+//! already-detected project — can apply the identical #2184 precedence. It is
+//! the pure half only: matching an already-resolved `origin_url` against
+//! `config.projects`. The impure half (reading the directory's origin remote,
+//! loading [`TrustyToolsConfig`] from disk) is production wiring left to each
+//! caller — see `session_manager::worktree_reclaim_gh::resolve_daemon_gh_env`.
 
-use crate::core::trusty_tools_config::{DEFAULT_GITHUB_HOST, GithubConfig};
+use crate::core::trusty_tools_config::{DEFAULT_GITHUB_HOST, GithubConfig, TrustyToolsConfig};
 
 /// `GH_CONFIG_DIR` — points gh at a private config/auth home.
 const ENV_GH_CONFIG_DIR: &str = "GH_CONFIG_DIR";
@@ -132,6 +144,35 @@ impl GhEnv {
     pub fn is_empty(&self) -> bool {
         self.vars.is_empty()
     }
+
+    /// One-line, secret-free description of the resolved overrides (#6623).
+    ///
+    /// Why: a daemon `gh` lookup that fails needs to say WHICH identity it
+    /// tried — the #6561 failure was invisible for so long precisely because
+    /// nothing distinguished "used no config dir at all" from "used the wrong
+    /// one". `GH_TOKEN`'s VALUE must never appear in a diagnostic string.
+    /// What: `"no github: binding resolved …"` for an empty `GhEnv`, else the
+    /// resolved `VAR=value` pairs joined by `, `, with `GH_TOKEN`'s value
+    /// redacted.
+    /// Test: `describe_empty_env`, `describe_config_dir`, `describe_redacts_token`.
+    pub fn describe(&self) -> String {
+        if self.vars.is_empty() {
+            return "no github: binding resolved — gh inherits the daemon's ambient \
+                    environment"
+                .to_string();
+        }
+        self.vars
+            .iter()
+            .map(|(k, v)| {
+                if k == ENV_GH_TOKEN {
+                    format!("{k}=<redacted>")
+                } else {
+                    format!("{k}={v}")
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
 }
 
 /// Apply the #2184 project-over-global precedence for a `github:` binding.
@@ -150,6 +191,40 @@ pub fn select_github_config<'a>(
     global: Option<&'a GithubConfig>,
 ) -> Option<&'a GithubConfig> {
     project.or(global)
+}
+
+/// Select the `GithubConfig` that governs `gh` spawns for an already-detected
+/// git origin remote (#6623).
+///
+/// Why: every daemon-side `gh` spawn has a WORKING DIRECTORY but no
+/// already-resolved project — `bin/tm/gh_identity::resolve_project_aware`
+/// performs this same match from `std::env::current_dir()`'s origin remote for
+/// an interactive `tm` invocation, but that helper is CLI-only (`bin/tm`),
+/// unreachable from library/daemon code. Promoting the pure "which config
+/// applies" step here lets both call sites share one implementation.
+/// What: matches `origin_url` (when `Some`) against `config.projects` via
+/// [`crate::project::record::repo_url_matches`]; the matched project's own
+/// `github:` binding, when it has one, wins outright over the global
+/// `config.github` section via [`select_github_config`]. `origin_url: None`,
+/// or a URL matching no registered project, resolves purely from
+/// `config.github` — matching pre-#2184 behaviour exactly.
+/// Test: `select_config_for_origin_project_wins`,
+/// `select_config_for_origin_falls_back_to_global`,
+/// `select_config_for_origin_no_match_uses_global`,
+/// `select_config_for_origin_no_origin_uses_global`.
+pub fn select_config_for_origin<'a>(
+    config: &'a TrustyToolsConfig,
+    origin_url: Option<&str>,
+) -> Option<&'a GithubConfig> {
+    let project_github = origin_url
+        .and_then(|url| {
+            config
+                .projects
+                .iter()
+                .find(|p| crate::project::record::repo_url_matches(&p.repo_url, url))
+        })
+        .and_then(|p| p.github.as_ref());
+    select_github_config(project_github, config.github.as_ref())
 }
 
 /// Resolve an optional [`GithubConfig`] into the [`GhEnv`] for `gh` subprocesses.
@@ -530,5 +605,139 @@ mod tests {
     #[test]
     fn select_github_config_none_when_neither_set() {
         assert_eq!(select_github_config(None, None), None);
+    }
+
+    // ── #6623: directory-based resolution ─────────────────────────────────
+
+    use crate::core::trusty_tools_config::ProjectConfig;
+
+    fn project_cfg(repo_url: &str, github: Option<GithubConfig>) -> ProjectConfig {
+        ProjectConfig {
+            name: "p".into(),
+            repo_url: repo_url.into(),
+            github,
+            ..ProjectConfig::default()
+        }
+    }
+
+    /// Why: a matched project's own `github:` binding must win outright over
+    /// the global one — the same #2184 precedence `select_github_config`
+    /// applies, now reachable from a bare origin URL rather than a `cwd`.
+    /// Test: itself.
+    #[test]
+    fn select_config_for_origin_project_wins() {
+        let config = TrustyToolsConfig {
+            github: Some(gh("/cfg/global")),
+            projects: vec![project_cfg(
+                "https://github.com/acme/widget",
+                Some(gh("/cfg/project")),
+            )],
+            ..TrustyToolsConfig::default()
+        };
+        let selected =
+            select_config_for_origin(&config, Some("https://github.com/acme/widget.git"));
+        assert_eq!(
+            selected.and_then(|c| c.config_dir.as_deref()),
+            Some(std::path::Path::new("/cfg/project"))
+        );
+    }
+
+    /// Why: a project match with no `github:` binding of its own must fall
+    /// back to the global tier.
+    /// Test: itself.
+    #[test]
+    fn select_config_for_origin_falls_back_to_global() {
+        let config = TrustyToolsConfig {
+            github: Some(gh("/cfg/global")),
+            projects: vec![project_cfg("https://github.com/acme/widget", None)],
+            ..TrustyToolsConfig::default()
+        };
+        let selected = select_config_for_origin(&config, Some("https://github.com/acme/widget"));
+        assert_eq!(
+            selected.and_then(|c| c.config_dir.as_deref()),
+            Some(std::path::Path::new("/cfg/global"))
+        );
+    }
+
+    /// Why: an origin that matches NO registered project must resolve purely
+    /// from the global tier, not fall through to ambient.
+    /// Test: itself.
+    #[test]
+    fn select_config_for_origin_no_match_uses_global() {
+        let config = TrustyToolsConfig {
+            github: Some(gh("/cfg/global")),
+            ..TrustyToolsConfig::default()
+        };
+        let selected = select_config_for_origin(&config, Some("https://github.com/someone/else"));
+        assert_eq!(
+            selected.and_then(|c| c.config_dir.as_deref()),
+            Some(std::path::Path::new("/cfg/global"))
+        );
+    }
+
+    /// Why: `origin_url: None` (a directory whose remote could not be read)
+    /// must resolve purely from the global tier — matching pre-#2184
+    /// behaviour exactly, the no-regression guarantee.
+    /// Test: itself.
+    #[test]
+    fn select_config_for_origin_no_origin_uses_global() {
+        let config = TrustyToolsConfig {
+            github: Some(gh("/cfg/global")),
+            ..TrustyToolsConfig::default()
+        };
+        let selected = select_config_for_origin(&config, None);
+        assert_eq!(
+            selected.and_then(|c| c.config_dir.as_deref()),
+            Some(std::path::Path::new("/cfg/global"))
+        );
+    }
+
+    fn gh(config_dir: &str) -> GithubConfig {
+        GithubConfig {
+            config_dir: Some(PathBuf::from(config_dir)),
+            ..GithubConfig::default()
+        }
+    }
+
+    /// Why: an empty `GhEnv` must describe itself as "no binding resolved"
+    /// rather than an empty string, which would render as a blank diagnostic.
+    /// Test: itself.
+    #[test]
+    fn describe_empty_env() {
+        assert!(GhEnv::default().describe().contains("no github: binding"));
+    }
+
+    /// Why: a resolved `GH_CONFIG_DIR` must appear verbatim — it names the
+    /// exact fix an operator applies.
+    /// Test: itself.
+    #[test]
+    fn describe_config_dir() {
+        let env = resolve_gh_env(Some(&gh("/cfg/dir"))).expect("ok");
+        assert_eq!(env.describe(), "GH_CONFIG_DIR=/cfg/dir");
+    }
+
+    /// Why: `GH_TOKEN`'s VALUE must never appear in a diagnostic string.
+    /// Test: itself.
+    #[test]
+    fn describe_redacts_token() {
+        let _g = env_lock();
+        let name = "TM_TEST_GH_TOKEN_DESCRIBE";
+        // SAFETY: guarded by env_lock; removed below.
+        unsafe { std::env::set_var(name, "ghp_super_secret") };
+        let c = GithubConfig {
+            token_env: Some(name.to_string()),
+            ..cfg()
+        };
+        let env = resolve_gh_env(Some(&c)).expect("ok");
+        unsafe { std::env::remove_var(name) };
+        let described = env.describe();
+        assert!(
+            described.contains("GH_TOKEN=<redacted>"),
+            "described: {described}"
+        );
+        assert!(
+            !described.contains("ghp_super_secret"),
+            "described: {described}"
+        );
     }
 }

--- a/crates/trusty-mpm/src/session_manager/worktree_reclaim.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_reclaim.rs
@@ -41,7 +41,9 @@ use super::worktree_ownership::{
     AgentDelegationState, AgentWorktreeOwner, SentinelOwner, is_harness_agent_worktree,
     read_sentinel_owner,
 };
-use super::worktree_reclaim_gh::{GH_TIMEOUT, PR_JSON_FIELDS, gh_command, run_with_timeout};
+use super::worktree_reclaim_gh::{
+    GH_TIMEOUT, PR_JSON_FIELDS, gh_command, resolve_daemon_gh_env, run_with_timeout,
+};
 use super::worktree_registry::{Admission, HarnessLockState, harness_lock_state};
 use super::worktree_safety::DirtyWorktree;
 
@@ -287,7 +289,12 @@ impl PrIndex {
     /// `pr_index_from_gh_reads_this_repository` (a real successful call);
     /// `pr_index_malformed_json_is_unavailable` (failure-to-unavailable).
     pub(crate) fn from_gh(registry_root: &Path) -> Self {
-        let mut cmd = gh_command(registry_root);
+        // #6623: resolved once per registry root — the daemon's own gh
+        // identity, since launchd hands it neither `GH_TOKEN` nor
+        // `GH_CONFIG_DIR`.
+        let gh_env = resolve_daemon_gh_env(registry_root);
+        let identity = gh_env.describe();
+        let mut cmd = gh_command(registry_root, &gh_env);
         cmd.args(["pr", "list", "--state", "all", "--limit"])
             .arg(PR_INDEX_LIMIT.to_string())
             .args(["--json", PR_JSON_FIELDS]);
@@ -308,14 +315,17 @@ impl PrIndex {
             Err(reason) => {
                 // #6561: WARN, not debug, and carrying the reason. A silent
                 // debug line is why an auth failure across all 261 worktrees
-                // surfaced only as "0 reclaimable".
+                // surfaced only as "0 reclaimable". #6623: the resolved
+                // identity rides along, so "used the wrong config dir" reads
+                // differently from "used none at all".
                 tracing::warn!(
                     root = %registry_root.display(),
                     reason = %reason,
+                    identity = %identity,
                     "worktree-reclaim: the pull-request lookup failed — every branch \
-                     will block, and the survey reports this reason (#6561)"
+                     will block, and the survey reports this reason (#6561, #6623)"
                 );
-                Self::unavailable_because(reason)
+                Self::unavailable_because(format!("{reason} (resolved gh identity: {identity})"))
             }
         }
     }
@@ -401,13 +411,20 @@ impl PrIndex {
 /// `pr_index_resolves_a_squash_merged_pr_whose_head_branch_was_deleted`.
 pub(crate) fn pr_state_for_branch(registry_root: &Path, branch: &str) -> BranchPrState {
     const PER_BRANCH_LIMIT: usize = 50;
-    let mut cmd = gh_command(registry_root);
+    // #6623: same resolution as the bulk index — this call has its own
+    // working directory and must not rely on the daemon's bare launchd
+    // environment either.
+    let gh_env = resolve_daemon_gh_env(registry_root);
+    let identity = gh_env.describe();
+    let mut cmd = gh_command(registry_root, &gh_env);
     cmd.args(["pr", "list", "--head", branch, "--state", "all", "--limit"])
         .arg(PER_BRANCH_LIMIT.to_string())
         .args(["--json", PR_JSON_FIELDS]);
     match run_with_timeout(cmd, GH_TIMEOUT) {
         Ok(stdout) => PrIndex::from_json(&stdout, PER_BRANCH_LIMIT).state_for(Some(branch)),
-        Err(reason) => BranchPrState::LookupFailed { reason },
+        Err(reason) => BranchPrState::LookupFailed {
+            reason: format!("{reason} (resolved gh identity: {identity})"),
+        },
     }
 }
 

--- a/crates/trusty-mpm/src/session_manager/worktree_reclaim_gh.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_reclaim_gh.rs
@@ -17,11 +17,20 @@
 //! Test: `run_with_timeout_captures_output`, `run_with_timeout_kills_a_hung_child`,
 //! `run_with_timeout_reports_the_exit_code_and_stderr` in
 //! `worktree_reclaim::worktree_reclaim_tests`.
+//!
+//! #6623: the daemon runs under launchd, which carries neither `GH_TOKEN` nor
+//! `GH_CONFIG_DIR` — every `gh` call made from this module used to inherit
+//! that bare environment and exit 4 ("gh auth login"). [`resolve_daemon_gh_env`]
+//! resolves the same per-project/global `github:` binding an interactive `tm`
+//! invocation would (via `core::gh_identity`), and [`gh_command`] applies it.
 
 use std::io::Read;
 use std::path::Path;
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
+
+use crate::core::gh_identity::{self, GhEnv};
+use crate::core::trusty_tools_config::TrustyToolsConfig;
 
 /// Environment variables that would point `gh`/`git` at a DIFFERENT repository.
 ///
@@ -74,7 +83,8 @@ pub(crate) const GH_TIMEOUT: Duration = Duration::from_secs(10);
 /// How long to wait for a drained pipe's contents after the child has exited.
 const PIPE_DRAIN_WAIT: Duration = Duration::from_secs(2);
 
-/// A `gh` invocation rooted at `dir` with a sanitised environment (#2919).
+/// A `gh` invocation rooted at `dir` with a sanitised environment and the
+/// resolved `gh` identity applied (#2919, #6623).
 ///
 /// Why: `gh` resolves the repository from its WORKING DIRECTORY. It has no
 /// global `-C` flag — that is a `git` habit, and carrying it across made every
@@ -88,12 +98,22 @@ const PIPE_DRAIN_WAIT: Duration = Duration::from_secs(2);
 /// The pager and prompt suppression are not cosmetic either — an interactive
 /// prompt in a daemon-run probe hangs it forever. See [`GH_STRIPPED_ENV`] for
 /// the environment scrub.
+///
+/// #6623: `gh_env` is applied BEFORE the pager/prompt overrides so a `gh`
+/// spawned under launchd — which inherits neither `GH_TOKEN` nor
+/// `GH_CONFIG_DIR` — authenticates the same way an interactive `tm`
+/// invocation would. It is injected rather than resolved internally so the
+/// existing hermetic tests (a bare `/tmp` directory, no real config on disk)
+/// stay pure; [`resolve_daemon_gh_env`] is the production resolver every real
+/// call site uses.
 /// What: `gh` with its working directory set to `dir`, the repository-
-/// redirecting variables removed, and pager/prompt/colour disabled.
+/// redirecting variables removed, `gh_env`'s overrides applied, and
+/// pager/prompt/colour disabled.
 /// Test: `gh_command_passes_no_dash_c_flag`,
 /// `gh_command_runs_in_the_requested_directory`,
-/// `gh_command_strips_repository_redirecting_env`.
-pub(crate) fn gh_command(dir: &Path) -> Command {
+/// `gh_command_strips_repository_redirecting_env`,
+/// `gh_command_applies_the_resolved_gh_env`.
+pub(crate) fn gh_command(dir: &Path, gh_env: &GhEnv) -> Command {
     // #5475: argv/binary/env come from trusty-common's single `gh` entry
     // point; this module keeps its own kill-on-timeout runner, which is why it
     // takes the unspawned `std::process::Command` rather than a runner method.
@@ -102,11 +122,61 @@ pub(crate) fn gh_command(dir: &Path) -> Command {
     for key in GH_STRIPPED_ENV {
         cmd = cmd.env_remove(key);
     }
+    for (key, value) in gh_env.vars() {
+        cmd = cmd.env(key, value);
+    }
     cmd.env("GH_PAGER", "")
         .env("GH_PROMPT_DISABLED", "1")
         .env("GH_NO_UPDATE_NOTIFIER", "1")
         .env("NO_COLOR", "1")
         .to_std_command()
+}
+
+/// Resolve the [`GhEnv`] to apply to a `gh` spawn rooted at `dir` — the
+/// production wiring every real call site in this module uses (#6623).
+///
+/// Why: the daemon's `gh` spawn sites have a WORKING DIRECTORY only. Under
+/// launchd they inherit neither `GH_TOKEN` nor `GH_CONFIG_DIR` (this issue's
+/// root cause), so each call must resolve its own identity the same way an
+/// interactive `tm` invocation's `resolve_project_aware` does. Kept separate
+/// from [`gh_identity::select_config_for_origin`] (the pure selection) so that
+/// function stays unit-testable without disk or subprocess I/O; this wrapper
+/// is the impure boundary, deliberately thin and exercised only through its
+/// callers — mirroring `bin/tm/gh_identity::load_gh_env`.
+/// What: reads `dir`'s `remote.origin.url` (best-effort — an unreadable or
+/// non-git directory falls through to the global tier, never a hard failure,
+/// and is logged at `warn`), loads [`TrustyToolsConfig`] from disk, and
+/// resolves via [`gh_identity::select_config_for_origin`] +
+/// [`gh_identity::resolve_gh_env`]. An `account`-only binding (refused by
+/// `resolve_gh_env` — see its module docs) is logged and treated as ambient:
+/// a housekeeping spawn must not mutate the operator's global `gh` account,
+/// and a misconfigured project must not block the whole reclaim survey.
+/// Test: exercised through the production `gh_command` call sites
+/// (`PrIndex::from_gh`, `pr_state_for_branch`); the pure selection is unit-
+/// tested via `select_config_for_origin_*` in `core::gh_identity`.
+pub(crate) fn resolve_daemon_gh_env(dir: &Path) -> GhEnv {
+    let origin_url = crate::daemon::managed_routes::inproject::get_origin_url(dir)
+        .inspect_err(|e| {
+            tracing::warn!(
+                dir = %dir.display(),
+                "worktree-reclaim: cannot read git origin remote for gh identity \
+                 resolution — falling back to the global github: binding (#6623): {e}"
+            );
+        })
+        .ok()
+        .flatten();
+    let config = TrustyToolsConfig::load();
+    let selected = gh_identity::select_config_for_origin(&config, origin_url.as_deref());
+    match gh_identity::resolve_gh_env(selected) {
+        Ok(env) => env,
+        Err(e) => {
+            tracing::warn!(
+                dir = %dir.display(),
+                "worktree-reclaim: {e} — spawning gh with the ambient environment (#6623)"
+            );
+            GhEnv::default()
+        }
+    }
 }
 
 /// Read `pipe` to EOF on its own thread, handing the text back over a channel.

--- a/crates/trusty-mpm/src/session_manager/worktree_reclaim_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_reclaim_tests.rs
@@ -660,7 +660,10 @@ fn pr_index_unrecognised_state_is_not_treated_as_merged() {
 fn gh_command_strips_repository_redirecting_env() {
     // `gh` resolves the repository through git, so an inherited GIT_DIR would
     // aim the PR query at a different repository entirely.
-    let cmd = gh_command(Path::new("/tmp"));
+    let cmd = gh_command(
+        Path::new("/tmp"),
+        &crate::core::gh_identity::GhEnv::default(),
+    );
     let removed: Vec<&str> = cmd
         .get_envs()
         .filter(|(_, v)| v.is_none())
@@ -672,6 +675,28 @@ fn gh_command_strips_repository_redirecting_env() {
             "{key} must be stripped: {removed:?}"
         );
     }
+}
+
+/// Why (#6623): the resolved daemon `gh` identity must reach the actual
+/// `Command` — this is what makes a `GH_CONFIG_DIR` resolved from a project's
+/// config take effect instead of leaving the daemon's bare launchd
+/// environment in place.
+#[test]
+fn gh_command_applies_the_resolved_gh_env() {
+    let env = crate::core::gh_identity::resolve_gh_env(Some(
+        &crate::core::trusty_tools_config::GithubConfig {
+            config_dir: Some(PathBuf::from("/cfg/daemon")),
+            ..Default::default()
+        },
+    ))
+    .expect("ok");
+    let cmd = gh_command(Path::new("/tmp"), &env);
+    let value = cmd
+        .get_envs()
+        .find(|(k, _)| *k == "GH_CONFIG_DIR")
+        .and_then(|(_, v)| v)
+        .expect("GH_CONFIG_DIR must be set");
+    assert_eq!(value, "/cfg/daemon");
 }
 
 // ---------------------------------------------------------------------------
@@ -1103,7 +1128,10 @@ fn classify_blocks_a_failed_lookup_and_names_the_reason() {
 /// distinguishes them.
 #[test]
 fn gh_command_passes_no_dash_c_flag() {
-    let cmd = gh_command(Path::new("/tmp"));
+    let cmd = gh_command(
+        Path::new("/tmp"),
+        &crate::core::gh_identity::GhEnv::default(),
+    );
     let args: Vec<String> = cmd
         .get_args()
         .map(|a| a.to_string_lossy().into_owned())
@@ -1124,7 +1152,10 @@ fn gh_command_runs_in_the_requested_directory() {
     // The repository is resolved from the working directory, so this IS the
     // repository selection — if it stops being set, every call silently
     // resolves whatever repository the daemon happens to be sitting in.
-    let cmd = gh_command(Path::new("/tmp"));
+    let cmd = gh_command(
+        Path::new("/tmp"),
+        &crate::core::gh_identity::GhEnv::default(),
+    );
     assert_eq!(cmd.get_current_dir(), Some(Path::new("/tmp")));
 }
 


### PR DESCRIPTION
Refs #6623, Refs #6561.

The `trusty-mpm daemon` under launchd carries no `GH_CONFIG_DIR`, so every daemon-side `gh` call exited 4 and worktree reclaim reported 261 failed lookups (#6561 made that visible). The daemon's `gh` spawns now resolve their environment the way interactive `tm` already does: `resolve_daemon_gh_env(dir)` reads the worktree's origin remote, loads `TrustyToolsConfig`, and applies `select_config_for_origin` (project `github:` binding over the top-level `github:` section) through `resolve_gh_env`, falling back to the ambient environment on any resolution failure. `gh_command` takes the resolved `GhEnv` explicitly so its hermetic tests stay pure. A failed lookup's reason now ends with `GhEnv::describe()` (token redacted), which reaches `ReclaimSurvey::lookup_failure` and the `worktree_disk` row in `tm doctor`.

Operator: the daemon-level fallback is the top-level `github: { config_dir: … }` in `~/.trusty-tools/trusty-mpm/config.yaml`; it is reloaded on every spawn, no daemon restart needed.

Test ladder: rung 3 (localized to trusty-mpm).
Regression test `gh_command_applies_the_resolved_gh_env` fails with `GH_CONFIG_DIR must be set` when the env application is reverted.

cargo fmt --check: clean
cargo check / clippy -p trusty-mpm --all-targets -- -D warnings: exit 0
cargo test -p trusty-mpm --no-fail-fast: 54/54 targets ok, 0 failures (5802 in the lib target)
check_line_cap 0 violations; check_sld 0 errors; check_test_pointers 0 dangling; check_changelog_fragment OK; check-pr-version-bump: tm 1.5.16 unpublished, no bump

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KsTGDrDYKBPmHmmbRsMm5w
