### PR TITLE
chore: ignore .trusty-agents/ and the machine-local .claude/settings.json; drop the dead re-include

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,10 @@
 # ignored, full stop.
 !/.claude/
 
+# settings.json bakes in absolute per-machine hook paths and is machine-local,
+# never a deliverable — same as settings.local.json below.
+/.claude/settings.json
+
 # Project-tier agent files are NEVER tracked in this repo. They are deployed
 # artifacts, not source: the bundled roster is the product and lives in
 # crates/trusty-mpm/src/assets/agents/ (and crates/trusty-code/src/assets/agents/).

--- a/.gitignore
+++ b/.gitignore
@@ -24,8 +24,8 @@
 .claude/
 .claude-mpm/*
 
-# Re-include tracked files from .claude/ — root only (#4789). These negations
-# are ANCHORED with a leading slash on purpose: an unanchored `!.claude/` /
+# Re-include tracked files from .claude/ — root only (#4789). This negation
+# is ANCHORED with a leading slash on purpose: an unanchored `!.claude/` /
 # `!.claude/settings.json` would re-include `.claude/` at every depth just
 # like the ignore above, silently cancelling it out everywhere except the one
 # specific nested path a later rule happens to re-ignore. That was the actual
@@ -35,7 +35,6 @@
 # that nested re-ignore rule entirely: nested `.claude/` dirs now simply stay
 # ignored, full stop.
 !/.claude/
-!/.claude/settings.json
 
 # Project-tier agent files are NEVER tracked in this repo. They are deployed
 # artifacts, not source: the bundled roster is the product and lives in
@@ -168,6 +167,9 @@ docs/certificates/*.mobileprovision
 # claude-mpm (unrelated Python project) leftovers — synced skills/agents, never a deliverable here
 .agents/
 .codex/
+
+# trusty-agents (tagent) local runtime state at the repo root — machine-local, never a deliverable
+.trusty-agents/
 
 # The per-worktree ownership sentinel (#3649, #4311). It is written INTO a
 # worktree by the daemon, so it appears in that tree as an untracked file and


### PR DESCRIPTION
Repo-root sweep, owner-ruled 2026-09-02.

## Summary
- `.trusty-agents/` (tagent local runtime state at the repo root) joins its siblings `.agents/`, `.codex/`, `.trusty-search/` in `.gitignore`.
- `.claude/settings.json` bakes in absolute per-machine hook paths; it is now ignored explicitly, mirroring `settings.local.json`. The former `!/.claude/settings.json` negation was dead text — `!/.claude/` already re-included the tree and nothing re-ignored the file — so it is removed and the comment adjusted.
- Verified: `.trusty-agents/state` ignored; `.claude/settings.json` ignored by the new line; tracked `.claude/skills/**` unaffected; `.trusty-mpm/sessions/**` still tracked.

## Test ladder
Rung 1 (config only): `bash scripts/check_sld.sh` exit 0, `bash scripts/check_line_cap.sh` exit 0.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools