### PR TITLE
chore(scripts): pre-commit line-cap scoped to staged files; wire changelog-assembled gate; CI-script docs

### DIFF
--- a/.github/workflows/changelog-fragment.yml
+++ b/.github/workflows/changelog-fragment.yml
@@ -1,4 +1,7 @@
-# Per-PR changelog fragment gate (issue #4476).
+# Per-PR changelog gates: the fragment gate (#4476) and the merge-time half of
+# the assembler gate (#6406). Both compare the branch against its base branch,
+# both need only git, and both belong to the same "the changelog is recorded
+# where release time can find it" contract, so they share one job.
 #
 # Enforces mechanically what was previously a review-gate-only rule: a PR that
 # changes `crates/<crate>/src/**` must record the change in a
@@ -123,3 +126,24 @@ jobs:
         env:
           CHANGELOG_GATE_BASE: origin/${{ github.event.pull_request.base.ref }}
         run: bash scripts/check_changelog_fragment.sh
+
+      # Merge-time half of the changelog-assembler gate (#6406). The publish-time
+      # half is preflight-publish.sh CHECK 9, which stops a bypass in the last
+      # seconds before `cargo publish`; this one catches the same shape while the
+      # PR is still open, so a hand-written `## [<version>]` section that left
+      # its fragments sitting in changelog.d/ never reaches main at all.
+      #
+      # Distinct from the step above, not a second spelling of it: that gate asks
+      # "did a source change record a fragment", this one asks "did a new release
+      # section consume the fragments it claims to have folded in". It fires ONLY
+      # on a NEW version heading, so an in-flight `bump-version.sh --no-changelog`
+      # bump stays silent — the scope note is in the script's own header.
+      #
+      # Base is origin/<base ref>, refreshed by the step above, never
+      # `github.event.pull_request.base.sha`: the frozen snapshot lags the merge
+      # ref's own first parent and blames crates the branch never touched
+      # (#5018 / run 31431273762, the same failure the refresh step exists for).
+      - name: Enforce assembled CHANGELOG sections (no stranded fragments)
+        env:
+          PR_CHANGELOG_ASSEMBLED_BASE: origin/${{ github.event.pull_request.base.ref }}
+        run: bash scripts/check-pr-changelog-assembled.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,16 +54,24 @@ repos:
   # Ratcheted 500-line file-size cap (issue #610). Fails the commit when a new
   # tracked .rs file exceeds 500 lines, or an allowlisted file grows past its
   # frozen budget, or an allowlisted file dropped <= 500 (remove its entry).
-  # Runs against the whole tracked tree (pass_filenames: false) so the
-  # allowlist ratchet is evaluated holistically, not just on staged paths.
+  #
+  # Scoped to the STAGED .rs files. Scanning all 4,363 tracked .rs files cost
+  # ~34s on every commit, and all three FAILs above are decided per file — a
+  # staged file over its cap fails the hook exactly as it fails the whole-tree
+  # run, because the path-list mode reuses the same SLOC counter and the same
+  # allowlist comparison rather than a second implementation. The two checks a
+  # subset genuinely cannot answer (the #4618 scan floor and the drift WARN for
+  # an allowlisted file that no longer exists) are skipped here and still run on
+  # every PR: line-cap.yml calls the no-argument whole-tree form, unchanged.
   - repo: local
     hooks:
       - id: line-cap
         name: 500-line file-size cap (ratcheted allowlist)
         entry: scripts/check_line_cap.sh
         language: system
-        pass_filenames: false
-        always_run: true
+        pass_filenames: true
+        files: \.rs$
+        types: [file]
 
   # Test: doc-comment pointer lint (issue #2458). Fails the commit when a
   # `/// Test:`/`//! Test:` annotation cites a test name that doesn't exist

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -509,6 +509,7 @@ already deployed in `trusty-console/ui-search`, `trusty-analyze/ui`,
 
 Most references are linked from the rule they serve, above. Not linked elsewhere:
 
+- [ci-scripts.md](docs/reference/ci-scripts.md) — the eight `scripts/` checks that run only in a workflow: where each runs, what it gates, and which have a self-test
 - [documentation-layout.md](docs/reference/documentation-layout.md) — docs layout conventions
 - [DOC-38](docs/specs/spec-linked-documentation.md) — SLD policy, enforced by `scripts/check_sld.sh`
 - [threat-model.md](docs/reference/threat-model.md) — per-daemon bind/guard/proxy inventory ([ADR-0018](docs/adr/0018-loopback-only-doctrine.md))

--- a/docs/reference/ci-scripts.md
+++ b/docs/reference/ci-scripts.md
@@ -1,0 +1,58 @@
+# CI-only check scripts
+
+Eight scripts in `scripts/` run in a GitHub Actions workflow and nowhere else —
+no pre-commit hook, no `Makefile` target, no other doc page. Each was written
+for a specific failure and none of them announced itself anywhere a reader
+would look, so a change to one of the workflows below could drop it with
+nothing to notice.
+
+Scripts that CLAUDE.md or another reference already covers are not repeated
+here: `check_line_cap.sh` ([sloc-cap.md](sloc-cap.md)), `check_semver.sh`
+([semver-gate.md](semver-gate.md)), `check_changelog_fragment.sh`
+([changelog-fragments.md](changelog-fragments.md)), `check_sld.sh`
+([DOC-38](../specs/spec-linked-documentation.md)), and
+`check_generated_regions.sh` ([generated-doc-regions.md](generated-doc-regions.md)).
+
+Every script here reads its own header first. This table says where it runs and
+what it stops; the header says why it exists.
+
+| Script | Workflow(s) | What it gates |
+|---|---|---|
+| `check_deny_duplicates.sh` | `pre-publish.yml` | Counts `cargo deny check bans` duplicate-version warnings against a frozen budget. `multiple-versions = "warn"` exits 0 while reporting them, so without this the warnings are never read; the count may only ratchet down. |
+| `check_test_count.sh` | `test-count.yml` | Wraps a `cargo test` invocation and refuses an aggregate of zero. A filter matching no tests exits 0 printing `0 passed; 775 filtered out` — a green run that proved nothing (#4307). |
+| `check_rustdoc_links.sh` | `pre-publish.yml` | Broken intra-doc links, against a frozen baseline of pre-existing ones. docs.rs builds a release's documentation once and never rebuilds it, so a broken link is permanent for that version. |
+| `generate-homebrew-formula.sh` | `homebrew-formula.yml`, `release.yml` | Renders `tap/Formula/<crate>.rb` for the `bobmatnyc/homebrew-trusty` tap. It is the single implementation (#5635); `release.yml` calls it instead of carrying an inline heredoc and a second copy of the crate→binary map. |
+| `classify-ci-results.sh` | `ci.yml`, `red-main-notify.yml` | Turns a set of job conclusions into the red-main verdict. `cancelled` is not `failure`, so the previous `contains(needs.*.result, 'failure')` test let an all-cancelled run report main verified (#4179). |
+| `ci-create-local-main.sh` | `ci.yml`, `pre-publish.yml` | Creates the local `main` branch the `trusty-agents` git tests need, and fails the step when creation genuinely fails. The `git fetch origin main:main \|\| true` it replaced swallowed a GitHub 500 and produced an unrelated test failure eleven minutes later (#5693). |
+| `detect-embedder-cuda-relevant.sh` | `ci.yml` | Decides whether a change can affect the `trusty-common` `embedder-cuda` build, so the CUDA leg runs when it is relevant and is skipped when it is not. |
+| `check_token_drift.mjs` | `token-drift.yml` | Compares each Tailwind app's hand-transcribed `--color-*` RGB triples against the canonical Foundry `tokens.css`. `ci.yml` deliberately does NOT duplicate it (`ci.yml`, `ui-checks` job): `token-drift.yml` already runs it across all seven crates directly rather than through each `package.json`. |
+
+## Self-tests
+
+Six of the eight have a companion test that proves the gate can still fail — a
+gate that cannot fail makes its own green meaningless:
+
+| Script | Its test |
+|---|---|
+| `check_test_count.sh` | `scripts/check_test_count_selftest.sh` |
+| `check_rustdoc_links.sh` | `scripts/check_rustdoc_links_selftest.sh` |
+| `generate-homebrew-formula.sh` | `scripts/generate-homebrew-formula-selftest.sh` |
+| `classify-ci-results.sh` | `scripts/check-ci-helpers-selftest.sh` |
+| `detect-embedder-cuda-relevant.sh` | `scripts/check-ci-helpers-selftest.sh` |
+| `check_token_drift.mjs` | `scripts/check_token_drift.test.mjs`, a `node:test` suite `token-drift.yml` runs before the gate |
+
+`check_deny_duplicates.sh` and `ci-create-local-main.sh` have no test of their
+own. Both carry a frozen baseline or a fetch that can fail open, which is the
+shape a self-test exists to pin, so both are candidates if either is edited.
+
+## Which of these block a merge
+
+None of these workflows appear in `main`'s required-status-check contexts as of
+2026-09-02. Read the list live before relying on any of them to stop a merge —
+a hand-copied list already cost
+[#5836](https://github.com/bobmatnyc/trusty-tools/pull/5836) a merge:
+
+```bash
+gh api repos/bobmatnyc/trusty-tools/branches/main/protection \
+  --jq '.required_status_checks.contexts'
+```

--- a/docs/reference/release-workflow.md
+++ b/docs/reference/release-workflow.md
@@ -1023,6 +1023,40 @@ The workflow is **not** triggered on every PR or every release; it is a delibera
 gh workflow run e2e-docker.yml
 ```
 
+### Live acceptance (manual) — `trusty-audit`
+
+`scripts/taudit-live-acceptance.sh` walks the whole `taudit` MVP path live
+(#5852, #5858): it builds the binary, runs `taudit distribute`, extracts the
+resulting zip as a recipient would, registers a real repository against a real
+`gh` credential, runs the one-shot `audit` chain through OpenRouter, and then
+checks the returned package's DATA — real rows in the extract database, more
+than one commit and author, real filenames in the report — before grepping every
+extracted member for the API key. No stubs and no offline variant: a stubbed run
+would pass while proving nothing.
+
+Run it before shipping a `trusty-audit` release, and after any change to
+`distribute`, the audit chain, or the return-package assembly. It is NOT wired
+into CI and cannot be — it needs a real credential and real network.
+
+```bash
+OPENROUTER_API_KEY=sk-or-v1-... scripts/taudit-live-acceptance.sh
+TAUDIT_E2E_REPO=owner/name OPENROUTER_API_KEY=... scripts/taudit-live-acceptance.sh
+```
+
+It needs a real `OPENROUTER_API_KEY` exported in the environment (never passed
+as a flag — argv is visible to `ps`), `gh` authenticated with access to a public
+GitHub repository, network access to crates.io, GitHub and OpenRouter, plus
+`cargo` and `unzip`; `sqlite3` is optional and the script falls back to a
+header-and-size check without it. A run takes several minutes.
+
+Each run writes to a fresh directory under `~/.taudit-acceptance` and touches
+nothing under `~/duetto/audit`. Two things survive it: `rm -rf`
+`~/.trusty-tools/trusty-audit/work`, and remove by hand the one `trusty-search`
+allowlist row per audited clone that the script prints (it deliberately does not
+remove its own — `trusty-search index remove` ignores its path argument in
+0.45.1 and would drop an unrelated index). Full rationale, including what the
+script deliberately stopped checking after #5915/#5916, is in its own header.
+
 ## Bundled Crates — Intentionally Skipped by `release.yml`
 
 `release.yml` only builds standalone distributable binaries. Three crates are

--- a/scripts/check_buildrs_sync.sh
+++ b/scripts/check_buildrs_sync.sh
@@ -14,6 +14,11 @@
 #               a placeholder there would ship a blank app. trusty-agents-ui and
 #               trusty-audit-ui are edition 2021, so this block must stay free
 #               of let-chains.
+#               Those last two are crate NAMES, not directory names: the first
+#               two live at crates/<name>/build.rs, but trusty-agents-ui is
+#               crates/trusty-agents/ui/src-tauri/build.rs and trusty-audit-ui
+#               is crates/trusty-audit/ui/src-tauri/build.rs. TAURI_UI_FILES
+#               below is the authoritative list.
 #
 # The two families are deliberately not merged: their failure semantics differ.
 #

--- a/scripts/check_line_cap.sh
+++ b/scripts/check_line_cap.sh
@@ -30,6 +30,26 @@
 #   - allowlisted, applicable_cap < current SLOC <= budget       -> OK    (grandfathered, not growing)
 #   Exit non-zero on any FAIL; exit 0 when clean. Prints a one-line summary.
 #
+# PATH-LIST MODE (issue #6406 sweep): with one or more `.rs` paths as positional
+#   arguments, the scan set is those paths instead of the whole tracked tree.
+#   Same SLOC counter, same cap_for_path, same allowlist comparison — there is
+#   no second implementation, only a smaller input list. The pre-commit hook
+#   passes the staged `.rs` files this way (`pass_filenames: true`), which drops
+#   a commit's line-cap cost from ~34s over 4,363 files to well under a second.
+#   CI keeps calling the no-argument whole-tree form, which is unchanged.
+#
+#   Two whole-tree-only checks are deliberately skipped in path-list mode
+#   because a subset cannot answer them, and CI still runs both on every PR:
+#     - the #4618 scan floor (MIN_RS_FILES), whose whole job is to catch a
+#       broken enumeration of the FULL tree; a 1-file scan is not that.
+#     - the informational drift WARN for an allowlisted file that no longer
+#       exists, which would otherwise fire for every allowlisted file merely
+#       absent from the staged set.
+#   Every FAIL a path-list run can reach — new oversized file, allowlisted file
+#   grown past its frozen budget, allowlisted file now under cap — is decided
+#   per file, so a staged file that violates the cap fails the hook exactly as
+#   it fails the whole-tree run.
+#
 #   --update     regenerates the allowlist but only SAFELY: it may LOWER an
 #                existing budget or REMOVE entries that dropped <= applicable cap.
 #                It REFUSES to raise a budget or add a brand-new > cap file
@@ -96,9 +116,13 @@ set -euo pipefail
 PROD_CAP=500
 TEST_CAP=3000
 
-# Resolve repo root so the script works from any cwd.
+# Resolve repo root so the script works from any cwd. INVOCATION_DIR is captured
+# BEFORE the cd so a relative path argument still resolves against the caller's
+# cwd, not silently against the repo root (a path that resolved to nothing would
+# be skipped, and a gate that skips the file it was handed fails open).
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+INVOCATION_DIR="$PWD"
 ALLOWLIST="$REPO_ROOT/.line-cap-allowlist.tsv"
 
 cd "$REPO_ROOT"
@@ -108,6 +132,8 @@ cd "$REPO_ROOT"
 # ---------------------------------------------------------------------------
 MODE="check"      # check | update
 ALLOW_GROW=0      # may add new >cap files / raise budgets (--seed or --force-add)
+PATH_MODE=0       # 1 when positional paths narrowed the scan set
+PATHS=()
 for arg in "$@"; do
   case "$arg" in
     --update)    MODE="update" ;;
@@ -117,13 +143,42 @@ for arg in "$@"; do
       grep '^#' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
       exit 0
       ;;
-    *)
+    -*)
       echo "check_line_cap: unknown argument: $arg" >&2
-      echo "usage: check_line_cap.sh [--update | --seed | --force-add]" >&2
+      echo "usage: check_line_cap.sh [--update | --seed | --force-add] [path.rs ...]" >&2
       exit 2
+      ;;
+    *)
+      PATH_MODE=1
+      PATHS[${#PATHS[@]}]="$arg"
       ;;
   esac
 done
+
+# The allowlist is regenerated holistically — a subset of paths would drop every
+# entry it did not scan. Refuse the combination rather than silently truncate.
+if [ "$MODE" = "update" ] && [ "$PATH_MODE" -eq 1 ]; then
+  echo "check_line_cap: --update/--seed/--force-add regenerate the whole allowlist" >&2
+  echo "      and cannot take path arguments. Run them with no paths." >&2
+  exit 2
+fi
+
+# resolve_repo_path: print the repo-relative form of one path argument.
+# Tries the repo root first, then the caller's cwd; fails when the result lies
+# outside the repo, because the allowlist is keyed by repo-relative path.
+resolve_repo_path() {
+  local p="$1" abs
+  case "$p" in
+    /*) abs="$p" ;;
+    *)
+      if [ -e "$REPO_ROOT/$p" ]; then abs="$REPO_ROOT/$p"; else abs="$INVOCATION_DIR/$p"; fi
+      ;;
+  esac
+  case "$abs" in
+    "$REPO_ROOT"/*) printf '%s\n' "${abs#"$REPO_ROOT"/}" ;;
+    *) return 1 ;;
+  esac
+}
 
 # ---------------------------------------------------------------------------
 # SLOC counter: shared awk program that counts code lines (SLOC) in one file.
@@ -182,7 +237,21 @@ MIN_RS_FILES=500
 
 # The enumeration is materialised before the loop so its exit status is
 # observable; `git ls-files | while` hid a failing git behind an empty stream.
-if ! git ls-files '*.rs' > "$RSLIST"; then
+if [ "$PATH_MODE" -eq 1 ]; then
+  : > "$RSLIST"
+  for f in "${PATHS[@]}"; do
+    case "$f" in *.rs) ;; *) continue ;; esac
+    if ! rel="$(resolve_repo_path "$f")"; then
+      echo "FAIL: '$f' resolves outside the repository; the allowlist is keyed by" >&2
+      echo "      repo-relative path, so this file cannot be judged. NOT a pass." >&2
+      exit 1
+    fi
+    # A path that no longer exists is a deletion or a rename's old side; there
+    # is nothing to measure and nothing the cap can be violated by.
+    [ -f "$rel" ] || continue
+    printf '%s\n' "$rel" >> "$RSLIST"
+  done
+elif ! git ls-files '*.rs' > "$RSLIST"; then
   echo "FAIL: TOOL ERROR — 'git ls-files *.rs' exited non-zero; the file set could" >&2
   echo "      not be enumerated, so nothing was measured. NOT a pass (#4618)." >&2
   exit 1
@@ -196,7 +265,7 @@ while IFS= read -r f; do
 done < "$RSLIST" > "$CURRENT"
 
 RS_SCANNED="$(awk 'END{print NR}' "$CURRENT")"
-if [ "${RS_SCANNED:-0}" -lt "$MIN_RS_FILES" ]; then
+if [ "$PATH_MODE" -eq 0 ] && [ "${RS_SCANNED:-0}" -lt "$MIN_RS_FILES" ]; then
   echo "FAIL: SCAN FLOOR — only ${RS_SCANNED} tracked .rs file(s) were measured, below" >&2
   echo "      the declared minimum of ${MIN_RS_FILES} (MIN_RS_FILES in scripts/check_line_cap.sh)." >&2
   echo "      A gate that measures nothing reports '0 violations' and cannot fail;" >&2
@@ -338,7 +407,7 @@ done < "$RSLIST" > "$CAPMAP_CHK"
   awk 'BEGIN{FS=OFS="\t"} $0 !~ /^#/ && NF>=2 {print "A", $1, $2}' "$ALLOWLIST_READ"
   awk 'BEGIN{FS=OFS="\t"} NF>=2 {print "P", $1, $2}' "$CAPMAP_CHK"
   awk 'BEGIN{FS=OFS="\t"} NF>=2 {print "C", $1, $2}' "$CURRENT"
-} | awk -v prod_cap="$PROD_CAP" -v test_cap="$TEST_CAP" '
+} | awk -v prod_cap="$PROD_CAP" -v test_cap="$TEST_CAP" -v path_mode="$PATH_MODE" '
   BEGIN { FS = OFS = "\t" }
   # ----- allowlist rows: A <path> <budget> -----
   $1 == "A" { budget[$2] = $3; have[$2] = 1; next }
@@ -369,7 +438,9 @@ done < "$RSLIST" > "$CAPMAP_CHK"
   }
   END {
     # Allowlist entries whose file no longer exists (drift, informational).
-    for (p in have) if (!(p in seen)) {
+    # Undecidable from a subset — every allowlisted file outside the scanned
+    # paths is absent for that reason alone, so the whole-tree run owns it.
+    if (path_mode == 0) for (p in have) if (!(p in seen)) {
       printf "WARN: allowlisted %s no longer exists as a tracked .rs file. Remove it from .line-cap-allowlist.tsv.\n", p
     }
     printf "@SUMMARY\t%d\t%d\n", allowlisted+0, viol+0
@@ -391,12 +462,18 @@ while IFS= read -r line; do
   esac
 done < "$RESULT"
 
+if [ "$PATH_MODE" -eq 1 ]; then
+  SCOPE="$RS_SCANNED .rs path(s) given (subset scan; CI runs the whole tree)"
+else
+  SCOPE="$RS_SCANNED tracked .rs file(s) (floor $MIN_RS_FILES)"
+fi
+
 if [ "$violations" -gt 0 ]; then
-  echo "line-cap: measured $RS_SCANNED tracked .rs file(s); $allowlisted allowlisted, $violations violation(s) — FAILED." >&2
+  echo "line-cap: measured $SCOPE; $allowlisted allowlisted, $violations violation(s) — FAILED." >&2
   echo "Caps: ${PROD_CAP} SLOC (production) / ${TEST_CAP} SLOC (test/benchmark)." >&2
   echo "To re-freeze after an intentional split, run: scripts/check_line_cap.sh --update" >&2
   exit 1
 fi
 
-echo "line-cap: measured $RS_SCANNED tracked .rs file(s) (floor $MIN_RS_FILES); $allowlisted allowlisted, 0 violations — OK."
+echo "line-cap: measured $SCOPE; $allowlisted allowlisted, 0 violations — OK."
 exit 0


### PR DESCRIPTION
Scripts sweep, docs-only / CI-only — no `crates/**` change, so no changelog fragment is owed.

**What changed**
- `scripts/check_line_cap.sh` accepts explicit paths; the pre-commit `line-cap` hook now scans only staged `.rs` files (34.1 s → 0.1 s per commit; full `pre-commit run` 50.4 s → 14.4 s). Whole-tree behaviour in CI is unchanged. `--update`/`--seed`/`--force-add` refuse a path subset with exit 2.
- `.github/workflows/changelog-fragment.yml` runs `scripts/check-pr-changelog-assembled.sh` alongside the fragment check. The context is not yet in branch protection, so it reports but does not block.
- `scripts/check_buildrs_sync.sh` header fixed.
- `docs/reference/ci-scripts.md` documents the 8 CI-only scripts; `docs/reference/release-workflow.md` documents `taudit-live-acceptance.sh`.
- `CLAUDE.md` pointer updates for the above.

**Test ladder** — rung 1 (docs/CI/scripts only). Gates run, all exit 0: `check_sld.sh`, `check_public_docs.sh`, `check_line_cap.sh` (4363 files, 4 allowlisted, 0 violations), `check_test_pointers.sh` (28,856 citations, 0 dangling), `check_doc_numbers.sh`, `check_buildrs_sync.sh`, `check_generation_artifacts.sh`, `check_line_cap_selftest.sh`, `check-changelog-assembled-selftest.sh` (7 passed), `check_changelog_fragment.sh`. Negative case verified: a 600-SLOC staged probe file fails the hook with exit 1.

**Follow-ups, not in this PR**
- Add `Per-PR changelog fragment` to required contexts to make the assembled gate block (wedges every open PR predating it; needs `update-branch` on each).
- The gate's `Test:` header cites `scripts/check-pr-changelog-assembled-selftest.sh`, which does not exist yet.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J2e8jdTM8JhJotobe3Uvv1