### PR TITLE
feat(trusty-console): bounded machine-metric history with SSE stream (Refs #6641)

### DIFF
--- a/crates/trusty-common/changelog.d/6641-bounded-metric-history.md
+++ b/crates/trusty-common/changelog.d/6641-bounded-metric-history.md
@@ -1,0 +1,7 @@
+Added
+- `host_metrics::history` — a bounded FIFO of metric samples behind the console's
+  real-time graphs. `MetricRing::push` is the single write path, so a sample the
+  console takes itself and one a service pushes (#6284) enter the buffer
+  identically; at capacity it evicts the oldest and preserves insertion order.
+  `HOST_HISTORY_CAPACITY` (120) and `HOST_SAMPLE_INTERVAL_SECS` (5) pin the
+  owner's 10-minute window (#6641).

--- a/crates/trusty-common/src/host_metrics.rs
+++ b/crates/trusty-common/src/host_metrics.rs
@@ -15,9 +15,13 @@
 //!      Health thresholds ([`HostThresholds`](crate::host_metrics::HostThresholds))
 //!      are PROVISIONAL — see the type's docs; they need an owner ruling before
 //!      any alarm is wired to them.
+//!      The [`history`](crate::host_metrics::history) submodule adds the
+//!      bounded sliding window of those snapshots the console's real-time
+//!      graphs read (#6641).
 //! Test: the inline `tests` module — `sampler_produces_plausible_snapshot`,
 //!      `pressure_classification_boundaries`, `thresholds_are_configurable`,
-//!      and the serde round-trip.
+//!      and the serde round-trip; the window itself is covered by
+//!      `push_evicts_oldest_at_capacity` and its siblings in `history`.
 //!
 //! ## OS-agnostic sampling
 //!
@@ -36,6 +40,12 @@
 use serde::{Deserialize, Serialize};
 use std::time::Instant;
 use sysinfo::{CpuRefreshKind, Disks, MemoryRefreshKind, Networks, RefreshKind, System};
+
+// #6641: the bounded sample history the console's real-time graphs read. It
+// lives beside the sampler rather than in trusty-console because the buffer has
+// two writers by design — today's sampler and the pushed samples #6284 will
+// deliver — and both must enter through `MetricRing::push`.
+pub mod history;
 
 /// Coarse pressure classification for one host subsystem (#6517).
 ///

--- a/crates/trusty-common/src/host_metrics/history.rs
+++ b/crates/trusty-common/src/host_metrics/history.rs
@@ -1,0 +1,254 @@
+//! Bounded in-memory history for host-metric samples (#6641).
+//!
+//! Why: the console's real-time graphs need the last 10 minutes of host
+//!      samples, not just the newest one. A ring lives here rather than in
+//!      trusty-console because the buffer has two writers by design: the
+//!      console's own sampler today, and the services that will PUSH their
+//!      samples once the #6284 transport inversion lands. Per the workspace
+//!      "common entry point" rule both writers must enter through the same
+//!      function, so that function is defined once, here.
+//! What: [`MetricRing`] is a fixed-capacity FIFO — [`MetricRing::push`] is the
+//!      ONE write path; when the ring is full it evicts the oldest item before
+//!      appending, so capacity is never exceeded and insertion order is
+//!      preserved. [`HOST_HISTORY_CAPACITY`] and [`HOST_SAMPLE_INTERVAL_SECS`]
+//!      pin the owner's 10-minute window (120 points at 5 s). Nothing here
+//!      persists: the ring is in-memory only and a restart starts an empty
+//!      window by design (owner ruling, epic #6516 Phase 3).
+//! Test: the inline `tests` module — `push_evicts_oldest_at_capacity`,
+//!      `push_preserves_insertion_order`, `empty_ring_reads_empty`,
+//!      `host_window_is_the_owner_ruling`, `capacity_of_zero_is_clamped_to_one`.
+
+use std::collections::VecDeque;
+
+use super::HostMetrics;
+
+/// Points retained per metric ring — 120 (#6641).
+///
+/// Why: the owner's Phase 3 ruling is a 10-minute window sampled every 5 s,
+///      which is exactly 120 points. Naming it once keeps the console, the
+///      history endpoint, and the UI from each hard-coding their own number.
+/// What: `120`.
+/// Test: `host_window_is_the_owner_ruling`.
+pub const HOST_HISTORY_CAPACITY: usize = 120;
+
+/// Seconds between host samples — 5 (#6641).
+///
+/// Why: the other half of the owner's window ruling; the console's sampler
+///      default and the `sample_interval_secs` the history payload advertises
+///      both read it from here, so the graph's x-axis cannot disagree with the
+///      producer.
+/// What: `5`.
+/// Test: `host_window_is_the_owner_ruling`.
+pub const HOST_SAMPLE_INTERVAL_SECS: u64 = 5;
+
+/// A fixed-capacity FIFO of metric samples, oldest first (#6641).
+///
+/// Why: an unbounded `Vec` of samples grows without limit in a daemon that runs
+///      for weeks. A ring caps memory at `capacity` items and drops the oldest
+///      sample when a new one arrives, which is exactly the shape a
+///      sliding-window graph reads.
+/// What: wraps a `VecDeque<T>` whose length never exceeds `capacity`.
+///      [`MetricRing::push`] is the single mutation point — every producer
+///      (today's sampler, tomorrow's pushed sample from #6284) calls it, so the
+///      eviction rule cannot diverge between them. Iteration and
+///      [`MetricRing::snapshot`] yield oldest → newest.
+/// Test: `push_evicts_oldest_at_capacity`, `push_preserves_insertion_order`,
+///      `empty_ring_reads_empty`.
+#[derive(Debug, Clone)]
+pub struct MetricRing<T> {
+    capacity: usize,
+    items: VecDeque<T>,
+}
+
+impl<T> MetricRing<T> {
+    /// Build an empty ring holding at most `capacity` items.
+    ///
+    /// Why: capacity is a construction-time decision (the owner's 120 for the
+    ///      host window, a smaller number in tests), never a per-push argument.
+    /// What: allocates a `VecDeque` with room for `capacity`. A `capacity` of
+    ///      `0` is clamped to `1` — a ring that can hold nothing would silently
+    ///      discard every sample, which the caller would never see, so the type
+    ///      refuses to be useless instead.
+    /// Test: `capacity_of_zero_is_clamped_to_one`.
+    #[must_use]
+    pub fn new(capacity: usize) -> Self {
+        let capacity = capacity.max(1);
+        Self {
+            capacity,
+            items: VecDeque::with_capacity(capacity),
+        }
+    }
+
+    /// Append `item`, evicting the oldest when the ring is already full.
+    ///
+    /// Why: THE write path. Both the console's sampler and a future pushed
+    ///      sample (#6284) enter here, so a pushed sample and a sampled one are
+    ///      indistinguishable to every reader.
+    /// What: when `len == capacity`, pops the front (oldest) before pushing the
+    ///      new item at the back. Length therefore never exceeds `capacity`, and
+    ///      insertion order is preserved.
+    /// Test: `push_evicts_oldest_at_capacity`, `push_preserves_insertion_order`.
+    pub fn push(&mut self, item: T) {
+        if self.items.len() == self.capacity {
+            self.items.pop_front();
+        }
+        self.items.push_back(item);
+    }
+
+    /// Items currently held, oldest first.
+    ///
+    /// Test: `push_preserves_insertion_order`.
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = &T> {
+        self.items.iter()
+    }
+
+    /// Number of items currently held (never above [`MetricRing::capacity`]).
+    ///
+    /// Test: `push_evicts_oldest_at_capacity`.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+
+    /// `true` before the first push.
+    ///
+    /// Test: `empty_ring_reads_empty`.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+
+    /// The configured maximum item count.
+    ///
+    /// Test: `capacity_of_zero_is_clamped_to_one`.
+    #[must_use]
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+}
+
+impl<T: Clone> MetricRing<T> {
+    /// Copy the ring out as a `Vec`, oldest first.
+    ///
+    /// Why: the history endpoint and the SSE `history` event both serialise the
+    ///      window as a JSON array, and neither may hold the console's lock
+    ///      while doing it.
+    /// What: clones every item in iteration order.
+    /// Test: `push_preserves_insertion_order`, `empty_ring_reads_empty`.
+    #[must_use]
+    pub fn snapshot(&self) -> Vec<T> {
+        self.items.iter().cloned().collect()
+    }
+}
+
+impl MetricRing<HostMetrics> {
+    /// A host-metrics ring sized to the owner's 10-minute window (#6641).
+    ///
+    /// Why: the console should not restate `120`; the window is one ruling and
+    ///      belongs to one constant.
+    /// What: `MetricRing::new(HOST_HISTORY_CAPACITY)`.
+    /// Test: `host_window_is_the_owner_ruling`.
+    #[must_use]
+    pub fn host_window() -> Self {
+        Self::new(HOST_HISTORY_CAPACITY)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why: the eviction rule is the whole point of a bounded ring — a ring that
+    ///      grew past its capacity would leak in a long-lived daemon.
+    /// What: pushes `capacity + 1` items into a 120-slot ring and asserts the
+    ///      length stopped at 120, the oldest item is gone, and the newest is
+    ///      present.
+    /// Test: this test.
+    #[test]
+    fn push_evicts_oldest_at_capacity() {
+        let mut ring: MetricRing<u32> = MetricRing::new(HOST_HISTORY_CAPACITY);
+        for i in 0..HOST_HISTORY_CAPACITY as u32 {
+            ring.push(i);
+        }
+        assert_eq!(ring.len(), HOST_HISTORY_CAPACITY);
+        assert_eq!(ring.snapshot().first().copied(), Some(0));
+
+        // #6641: the 121st push must evict sample 0 and pin the length.
+        ring.push(HOST_HISTORY_CAPACITY as u32);
+        assert_eq!(
+            ring.len(),
+            HOST_HISTORY_CAPACITY,
+            "capacity must never be exceeded"
+        );
+        let items = ring.snapshot();
+        assert_eq!(items.first().copied(), Some(1), "oldest sample was evicted");
+        assert_eq!(
+            items.last().copied(),
+            Some(HOST_HISTORY_CAPACITY as u32),
+            "newest sample is at the back"
+        );
+    }
+
+    /// Why: a graph plotted from a ring that reordered its points would be
+    ///      wrong in a way no type check catches.
+    /// What: pushes a known sequence through a wrap-around and asserts the
+    ///      snapshot and the iterator both read oldest → newest.
+    /// Test: this test.
+    #[test]
+    fn push_preserves_insertion_order() {
+        let mut ring: MetricRing<u32> = MetricRing::new(3);
+        for i in 1..=5 {
+            ring.push(i);
+        }
+        assert_eq!(ring.snapshot(), vec![3, 4, 5]);
+        assert_eq!(ring.iter().copied().collect::<Vec<_>>(), vec![3, 4, 5]);
+    }
+
+    /// Why: the history endpoint must answer `200` with an empty window before
+    ///      the first sample, so an empty ring has to read as empty rather than
+    ///      as an error or a panic.
+    /// What: asserts `is_empty`, `len == 0`, and an empty snapshot on a fresh
+    ///      ring.
+    /// Test: this test.
+    #[test]
+    fn empty_ring_reads_empty() {
+        let ring: MetricRing<u32> = MetricRing::new(HOST_HISTORY_CAPACITY);
+        assert!(ring.is_empty());
+        assert_eq!(ring.len(), 0);
+        assert!(ring.snapshot().is_empty());
+        assert_eq!(ring.iter().count(), 0);
+        assert_eq!(ring.capacity(), HOST_HISTORY_CAPACITY);
+    }
+
+    /// Why: the 10-minute window is an owner ruling; if the constants drift the
+    ///      graph silently covers a different span than the UI labels claim.
+    /// What: pins 120 points × 5 s = 600 s and asserts the host-window
+    ///      constructor uses the constant.
+    /// Test: this test.
+    #[test]
+    fn host_window_is_the_owner_ruling() {
+        assert_eq!(HOST_HISTORY_CAPACITY, 120);
+        assert_eq!(HOST_SAMPLE_INTERVAL_SECS, 5);
+        assert_eq!(
+            HOST_HISTORY_CAPACITY as u64 * HOST_SAMPLE_INTERVAL_SECS,
+            600,
+            "120 points at 5s is the owner's 10-minute window"
+        );
+        let ring = MetricRing::<HostMetrics>::host_window();
+        assert_eq!(ring.capacity(), HOST_HISTORY_CAPACITY);
+        assert!(ring.is_empty());
+    }
+
+    /// Why: a zero-capacity ring would drop every sample and report an empty
+    ///      graph forever, with nothing to distinguish it from "no data yet".
+    /// What: builds a ring with capacity 0 and asserts it holds one item.
+    /// Test: this test.
+    #[test]
+    fn capacity_of_zero_is_clamped_to_one() {
+        let mut ring: MetricRing<u32> = MetricRing::new(0);
+        assert_eq!(ring.capacity(), 1);
+        ring.push(7);
+        ring.push(8);
+        assert_eq!(ring.snapshot(), vec![8]);
+    }
+}

--- a/crates/trusty-console/changelog.d/6641-machine-status-history-stream-changed.md
+++ b/crates/trusty-console/changelog.d/6641-machine-status-history-stream-changed.md
@@ -1,0 +1,7 @@
+Changed
+- History is in-memory only and resets on restart, by owner ruling — a restarted
+  console begins a new, empty window (#6641).
+- `host_status::start` is gone; one loop in `machine_history::sampler` now writes
+  both the point-in-time host cache and the history ring, so the two can never
+  disagree about the newest sample. `host_status::HostMetricsCache` is unchanged
+  (#6641).

--- a/crates/trusty-console/changelog.d/6641-machine-status-history-stream.md
+++ b/crates/trusty-console/changelog.d/6641-machine-status-history-stream.md
@@ -1,0 +1,19 @@
+Added
+- `GET /api/console/machine-status/history` returns the last 10 minutes of host
+  samples (120 points at 5 s) plus the per-service transition log, oldest first.
+  Before the first sample it answers 200 with empty arrays rather than the 503
+  the point-in-time route returns — an empty window is a complete answer (#6641).
+- `GET /api/console/machine-status/stream` is a `text/event-stream`. It opens
+  with one `history` event carrying the current window, then sends a `sample`
+  event per new sample and a `transition` event per service state change. A
+  subscriber that falls behind the broadcast buffer gets a `lagged` event naming
+  the dropped count instead of a silent gap (#6641).
+- A per-service transition log records only the moments a service's derived state
+  (`up` / `degraded` / `down` / `unknown`) changed — never a row per poll. A
+  service whose report goes stale past a 60 s grace window, or that drops out of
+  the report set for that long, transitions to `down`; a retained cache entry is
+  not evidence a service is alive (#6641).
+- `serve --host-sample-interval` sets the host sampling cadence, default 5 s. It
+  is independent of `--poll-interval` (still 15 s), which drives the stdio-MCP
+  service polls. The history payload advertises the configured value so the
+  graph's x-axis follows it (#6641).

--- a/crates/trusty-console/src/host_status.rs
+++ b/crates/trusty-console/src/host_status.rs
@@ -1,23 +1,21 @@
-//! Background whole-machine host-metrics sampler + cache for the console (#6517).
+//! Point-in-time whole-machine host-metrics cache for the console (#6517).
 //!
 //! Why: the machine-status route must serve a host snapshot instantly, never
-//! blocking on a live sysinfo refresh. A background task owns the stateful
-//! [`HostSampler`] (CPU and network readings are deltas between refreshes, so
-//! the sampler must persist across polls) and writes each snapshot into a shared
-//! cache the route reads. This mirrors [`crate::metrics_poller`], which does the
-//! same for the per-service `ConsoleMetricsReport`s.
-//! What: [`HostMetricsCache`] is the `Arc<RwLock<Option<HostMetrics>>>` handle;
-//! [`start`] spawns the sampling loop. The whole-machine sampler itself lives in
-//! `trusty_common::host_metrics` (the shared, cross-crate capability); this
-//! module only schedules it and caches its output.
+//! blocking on a live sysinfo refresh, so a background task writes each snapshot
+//! into a shared cache the route reads. This mirrors [`crate::metrics_poller`],
+//! which does the same for the per-service `ConsoleMetricsReport`s.
+//! What: [`HostMetricsCache`] is the `Arc<RwLock<Option<HostMetrics>>>` handle.
+//! The sampling loop that fills it moved to
+//! [`crate::machine_history::sampler`] in #6641, because the same sample must
+//! also enter the bounded history ring and one stateful `HostSampler` cannot be
+//! shared by two tasks. The sampler itself lives in
+//! `trusty_common::host_metrics` (the shared, cross-crate capability).
 //! Test: `cache_initialises_empty`, `cache_write_read_roundtrip` in this module.
 
 use std::sync::Arc;
-use std::time::Duration;
 
 use tokio::sync::RwLock;
-use tracing::{debug, info};
-use trusty_common::host_metrics::{HostMetrics, HostSampler};
+use trusty_common::host_metrics::HostMetrics;
 
 /// Shared read/write handle to the latest [`HostMetrics`] snapshot.
 ///
@@ -69,41 +67,10 @@ impl HostMetricsCache {
     }
 }
 
-/// Spawn the background host-metrics sampling loop, writing into `cache`.
-///
-/// Why: one place owns the sampler and the sampling cadence. The sampler is
-/// stateful (CPU + network deltas), so it must live for the whole task rather
-/// than being reconstructed each tick.
-/// What: spawns a tokio task that constructs one [`HostSampler`], samples it
-/// immediately (to warm the cache before the first request), then re-samples
-/// every `interval`. Sampling never fails, so there is no error path to log —
-/// unlike `metrics_poller`, whose MCP poll can fail.
-/// Test: not tested directly (spawns a real OS sampler on a timer); the cache
-/// round-trip is covered in this module and the sampler in `trusty-common`.
-pub fn start(cache: HostMetricsCache, interval: Duration) {
-    tokio::spawn(async move {
-        info!(
-            "host_status: starting host-metrics sampler (interval={}s)",
-            interval.as_secs()
-        );
-        let mut sampler = HostSampler::new();
-        loop {
-            let metrics = sampler.sample();
-            debug!(
-                overall = ?metrics.overall_pressure,
-                cpu_pct = metrics.cpu.usage_pct,
-                mem_pct = metrics.memory.usage_pct,
-                "host_status: sampled host metrics"
-            );
-            cache.set(metrics).await;
-            tokio::time::sleep(interval).await;
-        }
-    });
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use trusty_common::host_metrics::HostSampler;
 
     /// Why: a fresh cache must return `None` so the route can answer 503 before
     /// the first sample.

--- a/crates/trusty-console/src/lib.rs
+++ b/crates/trusty-console/src/lib.rs
@@ -53,6 +53,9 @@ pub mod detect;
 // #6517: background whole-machine host-metrics sampler + cache feeding the
 // machine-status route.
 pub mod host_status;
+// #6641: the bounded 10-minute sample window, the per-service transition log,
+// and the SSE fan-out the Phase 3 graphs read.
+pub mod machine_history;
 pub mod mcp_handle;
 pub mod metrics_poller;
 pub mod poller;
@@ -184,6 +187,21 @@ pub struct ServeArgs {
     /// the stdio MCP `console_metrics` tool calls against trusty-analyze.
     #[arg(long, default_value_t = 15u64)]
     pub poll_interval: u64,
+
+    /// Host-metrics sampling interval in seconds (default: 5).
+    ///
+    /// #6641: the cadence of the real-time graphs, kept separate from
+    /// `--poll-interval` because they answer different questions. The service
+    /// pollers each spawn a stdio-MCP round trip, so 15 s is deliberate there;
+    /// a host sample is a local sysinfo refresh, and the owner's Phase 3 ruling
+    /// is a 10-minute window at 5 s (120 points). Raising this stretches the
+    /// window the same 120 points cover, and the history payload advertises the
+    /// value so the graph's x-axis follows.
+    #[arg(
+        long,
+        default_value_t = trusty_common::host_metrics::history::HOST_SAMPLE_INTERVAL_SECS
+    )]
+    pub host_sample_interval: u64,
 }
 
 // ─── public entry point ────────────────────────────────────────────────────
@@ -431,14 +449,16 @@ pub async fn run_serve(args: ServeArgs) -> Result<()> {
         }
     }
 
-    // ── whole-machine host-metrics sampler (#6517) ──────────────────────────
-    // Runs in the background and keeps `host_metrics_cache` warm so
-    // GET /api/console/machine-status serves the host snapshot without a
-    // per-request sysinfo refresh. Sampled on the same interval as the service
-    // pollers.
-    host_status::start(
-        state.host_metrics_cache().clone(),
-        Duration::from_secs(args.poll_interval),
+    // ── whole-machine host sampler (#6517) + history feed (#6641) ───────────
+    // One loop writes both the point-in-time cache
+    // (GET /api/console/machine-status) and the bounded 10-minute window
+    // (GET /api/console/machine-status/history and its SSE stream), so the two
+    // can never disagree about the newest sample. It runs on its own 5 s
+    // cadence rather than the service pollers' 15 s: a host sample is a local
+    // sysinfo refresh, not an MCP round trip.
+    machine_history::sampler::start(
+        state.clone(),
+        Duration::from_secs(args.host_sample_interval),
     );
 
     // #3269: trust the console's own non-loopback bind address(es) (e.g. the
@@ -554,6 +574,27 @@ mod tests {
                 assert!(!args.open);
                 assert!(!args.tailscale);
                 assert_eq!(args.poll_interval, 15);
+                // #6641: the owner's Phase 3 cadence — 5 s, distinct from the
+                // 15 s service poll.
+                assert_eq!(args.host_sample_interval, 5);
+            }
+            other => panic!("expected Serve, got {other:?}"),
+        }
+    }
+
+    /// Why (#6641): the 5 s cadence is the shipped default, not a hard-coded
+    /// constant — an operator who wants a longer window must be able to say so,
+    /// and the two intervals must stay independent.
+    /// What: parses `serve --host-sample-interval 10` and asserts only that
+    /// value moved.
+    /// Test: this test itself.
+    #[test]
+    fn test_serve_args_custom_host_sample_interval() {
+        let cli = Cli::parse_from(["trusty-console", "serve", "--host-sample-interval", "10"]);
+        match cli.command {
+            Commands::Serve(args) => {
+                assert_eq!(args.host_sample_interval, 10);
+                assert_eq!(args.poll_interval, 15, "the service poll is unaffected");
             }
             other => panic!("expected Serve, got {other:?}"),
         }

--- a/crates/trusty-console/src/machine_history/events.rs
+++ b/crates/trusty-console/src/machine_history/events.rs
@@ -1,0 +1,147 @@
+//! The events `/api/console/machine-status/stream` carries, and their SSE
+//! framing (#6641).
+//!
+//! Why: the browser needs to tell a fresh sample from a service transition from
+//! a gap in its own delivery, and an SSE `data:` line alone cannot say which.
+//! Naming the kind on an `event:` line lets `EventSource.addEventListener`
+//! dispatch each kind to its own handler, which is what the Phase 3 PR2 UI
+//! (#6642) wires the sparklines and the timeline to.
+//! What: [`HistoryEvent`] is what the console broadcasts to every connected
+//! subscriber; [`sse_frame`] renders any payload as
+//! `event: <kind>\ndata: {json}\n\n`, the same one-line-per-event framing the
+//! #6524 search relay uses. [`lagged_frame`] is the fourth kind: a subscriber
+//! that fell far enough behind for the broadcast channel to drop messages is
+//! told how many it lost rather than being left with a silent gap in its graph.
+//! Test: `a_frame_names_its_kind_on_one_line`,
+//! `a_sample_frame_carries_the_host_snapshot`, `a_lagged_frame_carries_the_count`.
+
+use axum::body::Bytes;
+use serde::Serialize;
+use trusty_common::host_metrics::HostMetrics;
+
+use super::transitions::ServiceTransition;
+
+/// One event pushed to every open machine-status stream (#6641).
+///
+/// Why: the sampler and the transition tracker both produce updates on the same
+/// cadence, and a single broadcast channel keeps them ordered relative to each
+/// other for every subscriber.
+/// What: `Sample` carries a whole new [`HostMetrics`] snapshot; `Transition`
+/// carries one [`ServiceTransition`]. Both are `Clone` because
+/// `tokio::sync::broadcast` hands each receiver its own copy. The `history`
+/// event is deliberately NOT a variant — it is sent once, per connection, from
+/// the subscriber's own snapshot and never broadcast.
+/// Test: `a_sample_frame_carries_the_host_snapshot`.
+#[derive(Debug, Clone)]
+pub enum HistoryEvent {
+    /// A new host-metrics sample entered the ring.
+    Sample(Box<HostMetrics>),
+    /// A service changed state.
+    Transition(Box<ServiceTransition>),
+}
+
+impl HistoryEvent {
+    /// The `event:` name this variant is delivered under.
+    ///
+    /// Test: `a_frame_names_its_kind_on_one_line`.
+    #[must_use]
+    pub fn kind(&self) -> &'static str {
+        match self {
+            HistoryEvent::Sample(_) => "sample",
+            HistoryEvent::Transition(_) => "transition",
+        }
+    }
+
+    /// Render this event as one SSE frame.
+    ///
+    /// Why: keeping the kind and its payload together here means a new variant
+    /// cannot be added without also giving it a name on the wire.
+    /// What: delegates to [`sse_frame`] with [`HistoryEvent::kind`].
+    /// Test: `a_sample_frame_carries_the_host_snapshot`.
+    #[must_use]
+    pub fn frame(&self) -> Bytes {
+        match self {
+            HistoryEvent::Sample(m) => sse_frame("sample", m.as_ref()),
+            HistoryEvent::Transition(t) => sse_frame("transition", t.as_ref()),
+        }
+    }
+}
+
+/// Render `payload` as `event: <kind>\ndata: {json}\n\n`.
+///
+/// Why serialising rather than passing raw text through: SSE terminates an
+/// event at a blank line, so an embedded newline would split one event into two
+/// malformed ones. `serde_json::to_string` emits no newlines, which is what
+/// keeps every event exactly one `data:` line — the same reason the #6524 relay
+/// re-serialises its parsed frames.
+/// What: a `Bytes` frame. A payload that fails to serialise (which no type here
+/// can) degrades to a JSON object naming the error rather than dropping the
+/// event silently.
+/// Test: `a_frame_names_its_kind_on_one_line`.
+#[must_use]
+pub fn sse_frame(kind: &str, payload: &impl Serialize) -> Bytes {
+    let json = serde_json::to_string(payload)
+        .unwrap_or_else(|e| format!(r#"{{"error":"serialise {kind}: {e}"}}"#));
+    Bytes::from(format!("event: {kind}\ndata: {json}\n\n"))
+}
+
+/// The frame a subscriber gets when the broadcast channel dropped messages.
+///
+/// Why: a browser that stalls (a backgrounded tab, a slow machine) can fall
+/// further behind than the channel's buffer. `tokio::sync::broadcast` then drops
+/// the oldest messages and reports how many. Saying so is the difference between
+/// a graph the viewer knows has a hole and one that silently lies.
+/// What: `event: lagged` carrying `{"dropped": <n>}`.
+/// Test: `a_lagged_frame_carries_the_count`.
+#[must_use]
+pub fn lagged_frame(dropped: u64) -> Bytes {
+    sse_frame("lagged", &serde_json::json!({ "dropped": dropped }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why: an `EventSource` listener keyed on the event name never fires if the
+    /// `event:` line is missing or on the wrong line.
+    /// What: asserts the exact three-part shape — name line, data line, blank
+    /// terminator — and that the data is a single line.
+    /// Test: this test.
+    #[test]
+    fn a_frame_names_its_kind_on_one_line() {
+        let frame = sse_frame("transition", &serde_json::json!({ "a": 1 }));
+        let text = String::from_utf8(frame.to_vec()).expect("utf8 frame");
+        assert_eq!(text, "event: transition\ndata: {\"a\":1}\n\n");
+        let data_lines = text.lines().filter(|l| l.starts_with("data: ")).count();
+        assert_eq!(data_lines, 1, "one data line per event");
+    }
+
+    /// Why: the sparkline reads the sample straight off the frame, so the frame
+    /// must carry the whole snapshot under the `sample` name.
+    /// What: frames a real sample and asserts the kind line plus a field the UI
+    /// reads back out of the JSON.
+    /// Test: this test.
+    #[test]
+    fn a_sample_frame_carries_the_host_snapshot() {
+        let metrics = trusty_common::host_metrics::HostSampler::new().sample();
+        let cores = metrics.cpu.logical_cores;
+        let event = HistoryEvent::Sample(Box::new(metrics));
+        assert_eq!(event.kind(), "sample");
+        let text = String::from_utf8(event.frame().to_vec()).expect("utf8 frame");
+        let data = text
+            .strip_prefix("event: sample\ndata: ")
+            .and_then(|r| r.strip_suffix("\n\n"))
+            .expect("sample frame shape");
+        let parsed: serde_json::Value = serde_json::from_str(data).expect("sample json");
+        assert_eq!(parsed["cpu"]["logical_cores"], cores);
+    }
+
+    /// Why: a lag the viewer cannot see is a graph that lies about continuity.
+    /// What: asserts the frame names `lagged` and carries the dropped count.
+    /// Test: this test.
+    #[test]
+    fn a_lagged_frame_carries_the_count() {
+        let text = String::from_utf8(lagged_frame(7).to_vec()).expect("utf8 frame");
+        assert_eq!(text, "event: lagged\ndata: {\"dropped\":7}\n\n");
+    }
+}

--- a/crates/trusty-console/src/machine_history/mod.rs
+++ b/crates/trusty-console/src/machine_history/mod.rs
@@ -1,0 +1,412 @@
+//! The console's in-memory machine-status history and its live fan-out (#6641).
+//!
+//! Why: `GET /api/console/machine-status` serves ONE point in time, so the
+//! dashboard can draw a number but not a graph. Phase 3 of epic #6516 needs the
+//! last 10 minutes of host samples plus the moments each service changed state,
+//! and it needs them to keep arriving while the page is open. This module is the
+//! buffer both of those read from, and the broadcast that pushes each new entry
+//! to every open stream.
+//!
+//! Why in-memory only: the owner's Phase 3 ruling is "no persistence". A restart
+//! therefore begins a new, empty 10-minute window BY DESIGN — the dashboard
+//! shows a graph that fills from the left rather than a stale one recovered from
+//! disk. Nothing here writes to disk and nothing tries to.
+//!
+//! Why the write path is one function: the #6284 transport inversion will have
+//! services PUSH their samples to the console instead of the console sampling
+//! them. [`MachineHistory::record_sample`] is the single entry point, so a
+//! pushed sample and a sampled one enter the ring, the broadcast, and every
+//! reader identically — the cutover swaps who calls it, not what it does.
+//!
+//! What: [`MachineHistory`] holds a
+//! [`MetricRing`](trusty_common::host_metrics::history::MetricRing) of host
+//! samples, a bounded transition log, the [`TransitionTracker`] that decides
+//! what belongs in that log, and the `tokio::sync::broadcast` sender every open
+//! SSE stream subscribes to. [`HistorySnapshot`] is the JSON shape both
+//! `/machine-status/history` and the stream's first `history` event serve.
+//! Test: `history_starts_empty`, `recording_a_sample_fans_out_to_subscribers`,
+//! `the_ring_bounds_what_history_returns`,
+//! `an_unchanged_service_adds_nothing_to_the_log`.
+
+pub mod events;
+pub mod sampler;
+pub mod stream;
+pub mod transitions;
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+use tokio::sync::{RwLock, broadcast};
+use trusty_common::console_metrics::ConsoleMetricsReport;
+use trusty_common::host_metrics::HostMetrics;
+use trusty_common::host_metrics::history::{
+    HOST_HISTORY_CAPACITY, HOST_SAMPLE_INTERVAL_SECS, MetricRing,
+};
+
+use events::HistoryEvent;
+use transitions::{SERVICE_REPORT_GRACE_SECS, ServiceTransition, TransitionTracker};
+
+/// The schema version the history payload advertises.
+///
+/// Why: mirrors `MachineStatus::schema_version` so the Phase 3 UI can detect a
+/// shape change instead of silently mis-rendering one.
+/// What: a monotonically increasing integer, bumped on any breaking change to
+/// [`HistorySnapshot`].
+/// Test: `history_starts_empty`.
+pub const MACHINE_HISTORY_SCHEMA_VERSION: u32 = 1;
+
+/// Transitions retained before the oldest is evicted.
+///
+/// Why: the log must be bounded for the same reason the sample ring is — the
+/// console runs for weeks. 256 entries is far more than a healthy machine
+/// produces in a 10-minute window, and a machine flapping fast enough to
+/// overflow it has a bigger problem than a truncated log.
+/// What: `256`.
+/// Test: `the_ring_bounds_what_history_returns`.
+pub const TRANSITION_LOG_CAPACITY: usize = 256;
+
+/// Events buffered per subscriber before the slowest one is told it lagged.
+///
+/// Why: `tokio::sync::broadcast` keeps one shared ring; a receiver that falls
+/// further behind than this gets `RecvError::Lagged` with the dropped count,
+/// which the stream forwards as a `lagged` event (see [`events::lagged_frame`]).
+/// 128 absorbs a browser stalling for several minutes at the 5 s cadence.
+/// What: `128`.
+/// Test: `stream::tests::a_lagging_subscriber_is_told_what_it_missed`.
+pub const EVENT_BUFFER: usize = 128;
+
+/// The history payload served by the endpoint and by the stream's first event.
+///
+/// Why: one shape for both, so a client that reconnects mid-window and a client
+/// that polls the endpoint parse the same thing. The capacities and the sample
+/// interval travel with the data because the graph's x-axis is derived from
+/// them — a UI that hard-coded 120 × 5 s would silently mis-scale the moment an
+/// operator changed the cadence.
+/// What: the sample ring and the transition log oldest-first, the two
+/// capacities, the configured sample interval, and the schema version.
+/// Test: `history_starts_empty`, `the_ring_bounds_what_history_returns`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HistorySnapshot {
+    /// Host samples, oldest first. Empty before the first sample.
+    pub samples: Vec<HostMetrics>,
+    /// Service state changes, oldest first. Empty until a service changes state.
+    pub transitions: Vec<ServiceTransition>,
+    /// Maximum samples retained (the ring's capacity).
+    pub sample_capacity: usize,
+    /// Maximum transitions retained.
+    pub transition_capacity: usize,
+    /// Seconds between samples, as the running sampler is configured.
+    pub sample_interval_secs: u64,
+    /// See [`MACHINE_HISTORY_SCHEMA_VERSION`].
+    pub schema_version: u32,
+}
+
+/// The rings and the tracker, behind one lock.
+struct Inner {
+    samples: MetricRing<HostMetrics>,
+    transitions: MetricRing<ServiceTransition>,
+    tracker: TransitionTracker,
+}
+
+/// The state every clone of a [`MachineHistory`] shares.
+struct Shared {
+    inner: RwLock<Inner>,
+    events: broadcast::Sender<HistoryEvent>,
+    /// Published by the sampler at startup so the payload advertises the cadence
+    /// actually in use, not the compiled-in default.
+    sample_interval_secs: AtomicU64,
+}
+
+/// The console's bounded machine-status history plus its live fan-out (#6641).
+///
+/// Why: see the module docs — one buffer, one write path, one broadcast.
+/// What: a cheap-to-clone handle (`Arc` inside) held in `AppState`. Writers call
+/// [`MachineHistory::record_sample`] and
+/// [`MachineHistory::observe_services`]; readers call
+/// [`MachineHistory::snapshot`] or [`MachineHistory::subscribe`].
+/// Test: `recording_a_sample_fans_out_to_subscribers`,
+/// `an_unchanged_service_adds_nothing_to_the_log`.
+#[derive(Clone)]
+pub struct MachineHistory {
+    shared: Arc<Shared>,
+}
+
+impl Default for MachineHistory {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MachineHistory {
+    /// Build a history sized to the owner's 10-minute window.
+    ///
+    /// Why: the common case — 120 points at 5 s, 256 transitions, the 60 s
+    /// report-staleness grace.
+    /// What: delegates to [`MachineHistory::with_limits`] with the shipped
+    /// constants.
+    /// Test: `history_starts_empty`.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::with_limits(
+            HOST_HISTORY_CAPACITY,
+            TRANSITION_LOG_CAPACITY,
+            EVENT_BUFFER,
+            Duration::from_secs(SERVICE_REPORT_GRACE_SECS),
+        )
+    }
+
+    /// Build a history with explicit limits.
+    ///
+    /// Why: a test needs a ring it can overflow and a broadcast buffer it can
+    /// outrun without producing thousands of samples.
+    /// What: constructs both rings, the tracker, and the broadcast channel.
+    /// Test: `the_ring_bounds_what_history_returns`,
+    /// `stream::tests::a_lagging_subscriber_is_told_what_it_missed`.
+    #[must_use]
+    pub fn with_limits(
+        sample_capacity: usize,
+        transition_capacity: usize,
+        event_buffer: usize,
+        grace: Duration,
+    ) -> Self {
+        let (events, _) = broadcast::channel(event_buffer.max(1));
+        Self {
+            shared: Arc::new(Shared {
+                inner: RwLock::new(Inner {
+                    samples: MetricRing::new(sample_capacity),
+                    transitions: MetricRing::new(transition_capacity),
+                    tracker: TransitionTracker::new(grace),
+                }),
+                events,
+                sample_interval_secs: AtomicU64::new(HOST_SAMPLE_INTERVAL_SECS),
+            }),
+        }
+    }
+
+    /// Publish the cadence the running sampler actually uses.
+    ///
+    /// Why: the payload's `sample_interval_secs` drives the graph's x-axis, and
+    /// the operator can override the default with `--host-sample-interval`. The
+    /// sampler calls this once at startup so the advertised value is the real
+    /// one.
+    /// What: stores `secs` in a relaxed atomic — a single startup write read by
+    /// every later request, with no ordering requirement against the rings.
+    /// Test: `the_advertised_interval_follows_the_sampler`.
+    pub fn set_sample_interval(&self, secs: u64) {
+        self.shared
+            .sample_interval_secs
+            .store(secs, Ordering::Relaxed);
+    }
+
+    /// Record one host sample — THE write path (#6641).
+    ///
+    /// Why: both today's console-side sampler and the pushed samples #6284 will
+    /// deliver enter here, so the ring, the broadcast, and every reader cannot
+    /// tell them apart.
+    /// What: pushes onto the ring (evicting the oldest at capacity) and
+    /// broadcasts a [`HistoryEvent::Sample`], both under the write lock so a
+    /// subscriber can never observe the ring and the stream disagreeing. A send
+    /// with no live subscribers is not an error — the ring is the durable half.
+    /// Test: `recording_a_sample_fans_out_to_subscribers`,
+    /// `the_ring_bounds_what_history_returns`.
+    pub async fn record_sample(&self, sample: HostMetrics) {
+        let mut inner = self.shared.inner.write().await;
+        inner.samples.push(sample.clone());
+        let _ = self
+            .shared
+            .events
+            .send(HistoryEvent::Sample(Box::new(sample)));
+    }
+
+    /// Fold one observation of the service report set into the transition log.
+    ///
+    /// Why: the log records CHANGES. Handing the whole report set to the tracker
+    /// on every tick — rather than appending per poll — is what keeps it to the
+    /// two entries an operator cares about.
+    /// What: asks the [`TransitionTracker`] which services moved, appends each
+    /// resulting [`ServiceTransition`] to the bounded log, and broadcasts one
+    /// [`HistoryEvent::Transition`] per entry. Returns the transitions recorded,
+    /// which is empty on a tick that changed nothing.
+    /// Test: `an_unchanged_service_adds_nothing_to_the_log`.
+    pub async fn observe_services(
+        &self,
+        reports: &[ConsoleMetricsReport],
+    ) -> Vec<ServiceTransition> {
+        let now_unix = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0, |d| d.as_secs());
+        let mut inner = self.shared.inner.write().await;
+        let changes = inner.tracker.observe(reports, Instant::now(), now_unix);
+        for change in &changes {
+            inner.transitions.push(change.clone());
+            let _ = self
+                .shared
+                .events
+                .send(HistoryEvent::Transition(Box::new(change.clone())));
+        }
+        changes
+    }
+
+    /// The current window, oldest first.
+    ///
+    /// Why: the history endpoint serves this directly; it must never block on a
+    /// sample in flight beyond the read lock.
+    /// What: clones both rings out under a read lock and stamps the capacities,
+    /// the advertised interval, and the schema version.
+    /// Test: `history_starts_empty`, `the_ring_bounds_what_history_returns`.
+    pub async fn snapshot(&self) -> HistorySnapshot {
+        let inner = self.shared.inner.read().await;
+        self.snapshot_locked(&inner)
+    }
+
+    /// Subscribe to live events, taking the current window in the same breath.
+    ///
+    /// Why the two happen under ONE lock: snapshotting first and subscribing
+    /// after would lose any sample recorded in between, and subscribing first
+    /// would deliver a sample the snapshot already contains. Because
+    /// [`MachineHistory::record_sample`] holds the WRITE lock across both its
+    /// ring push and its broadcast, holding the READ lock here makes the pair
+    /// atomic against it: the subscriber sees every sample exactly once.
+    /// What: returns the snapshot the stream sends as its first `history` event,
+    /// plus the receiver every later event arrives on.
+    /// Test: `stream::tests::a_late_subscriber_gets_the_window_then_the_next_sample`.
+    pub async fn subscribe(&self) -> (HistorySnapshot, broadcast::Receiver<HistoryEvent>) {
+        let inner = self.shared.inner.read().await;
+        let rx = self.shared.events.subscribe();
+        (self.snapshot_locked(&inner), rx)
+    }
+
+    /// Build the payload from an already-held guard.
+    ///
+    /// Why: [`MachineHistory::snapshot`] and [`MachineHistory::subscribe`] must
+    /// produce the identical shape, and only one of them may take the lock.
+    /// Test: covered through both callers.
+    fn snapshot_locked(&self, inner: &Inner) -> HistorySnapshot {
+        HistorySnapshot {
+            samples: inner.samples.snapshot(),
+            transitions: inner.transitions.snapshot(),
+            sample_capacity: inner.samples.capacity(),
+            transition_capacity: inner.transitions.capacity(),
+            sample_interval_secs: self.shared.sample_interval_secs.load(Ordering::Relaxed),
+            schema_version: MACHINE_HISTORY_SCHEMA_VERSION,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use trusty_common::console_metrics::{ServiceHealth, make_report};
+    use trusty_common::host_metrics::HostSampler;
+
+    fn sample() -> HostMetrics {
+        HostSampler::new().sample()
+    }
+
+    /// Why: the history endpoint must answer `200` with an empty window before
+    /// the first sample rather than the `503` the point-in-time route returns.
+    /// What: asserts a fresh history reports empty rings, the shipped
+    /// capacities, and the schema version.
+    /// Test: this test.
+    #[tokio::test]
+    async fn history_starts_empty() {
+        let h = MachineHistory::new();
+        let snap = h.snapshot().await;
+        assert!(snap.samples.is_empty());
+        assert!(snap.transitions.is_empty());
+        assert_eq!(snap.sample_capacity, HOST_HISTORY_CAPACITY);
+        assert_eq!(snap.transition_capacity, TRANSITION_LOG_CAPACITY);
+        assert_eq!(snap.sample_interval_secs, HOST_SAMPLE_INTERVAL_SECS);
+        assert_eq!(snap.schema_version, MACHINE_HISTORY_SCHEMA_VERSION);
+    }
+
+    /// Why: the ring and the broadcast are written together; a sample that
+    /// reached one but not the other would leave an open stream and a fresh
+    /// reload disagreeing.
+    /// What: subscribes, records one sample, and asserts both the receiver and
+    /// the ring saw it.
+    /// Test: this test.
+    #[tokio::test]
+    async fn recording_a_sample_fans_out_to_subscribers() {
+        let h = MachineHistory::new();
+        let (snap, mut rx) = h.subscribe().await;
+        assert!(snap.samples.is_empty());
+
+        h.record_sample(sample()).await;
+
+        match rx.try_recv() {
+            Ok(HistoryEvent::Sample(_)) => {}
+            other => panic!("expected a sample event, got {other:?}"),
+        }
+        assert_eq!(h.snapshot().await.samples.len(), 1);
+    }
+
+    /// Why: an unbounded window would grow for as long as the console runs.
+    /// What: records four samples into a three-slot ring and asserts the
+    /// snapshot holds three, with the capacity reported honestly.
+    /// Test: this test.
+    #[tokio::test]
+    async fn the_ring_bounds_what_history_returns() {
+        let h = MachineHistory::with_limits(3, 4, 8, Duration::from_secs(60));
+        for _ in 0..4 {
+            h.record_sample(sample()).await;
+        }
+        let snap = h.snapshot().await;
+        assert_eq!(snap.samples.len(), 3, "the ring bounds the window");
+        assert_eq!(snap.sample_capacity, 3);
+        assert_eq!(snap.transition_capacity, 4);
+    }
+
+    /// Why: the log must not grow by one row per poll — that is the failure this
+    /// whole design avoids.
+    /// What: observes the same `ok` report five times, then a `degraded` one,
+    /// and asserts the log holds exactly one entry.
+    /// Test: this test.
+    #[tokio::test]
+    async fn an_unchanged_service_adds_nothing_to_the_log() {
+        let h = MachineHistory::new();
+        let ok = make_report(
+            "trusty-search",
+            "Trusty Search",
+            "1.0.0",
+            ServiceHealth::Ok,
+            serde_json::json!({}),
+            1,
+        );
+        for _ in 0..5 {
+            assert!(
+                h.observe_services(std::slice::from_ref(&ok))
+                    .await
+                    .is_empty()
+            );
+        }
+        assert!(h.snapshot().await.transitions.is_empty());
+
+        let degraded = make_report(
+            "trusty-search",
+            "Trusty Search",
+            "1.0.0",
+            ServiceHealth::Degraded,
+            serde_json::json!({}),
+            1,
+        );
+        let changes = h.observe_services(&[degraded]).await;
+        assert_eq!(changes.len(), 1);
+        let snap = h.snapshot().await;
+        assert_eq!(snap.transitions.len(), 1);
+        assert_eq!(snap.transitions[0].to, transitions::ServiceState::Degraded);
+    }
+
+    /// Why: an operator who slows the cadence would otherwise get a graph whose
+    /// x-axis still claims 5 s per point.
+    /// What: sets a custom interval and asserts the snapshot advertises it.
+    /// Test: this test.
+    #[tokio::test]
+    async fn the_advertised_interval_follows_the_sampler() {
+        let h = MachineHistory::new();
+        h.set_sample_interval(30);
+        assert_eq!(h.snapshot().await.sample_interval_secs, 30);
+    }
+}

--- a/crates/trusty-console/src/machine_history/mod.rs
+++ b/crates/trusty-console/src/machine_history/mod.rs
@@ -409,4 +409,155 @@ mod tests {
         h.set_sample_interval(30);
         assert_eq!(h.snapshot().await.sample_interval_secs, 30);
     }
+
+    /// A minimal snapshot carrying `seq` in `sampled_at_unix`.
+    ///
+    /// Why not `HostSampler::sample()`: the concurrency test below needs the
+    /// writer bounded by the lock, not by cloning a real sample's mount list,
+    /// and it needs a sequence number the reader can check contiguity on.
+    fn tagged_sample(seq: u64) -> HostMetrics {
+        use trusty_common::host_metrics::{
+            CpuMetrics, DiskMetrics, MemoryMetrics, NetworkMetrics, Pressure,
+        };
+        HostMetrics {
+            cpu: CpuMetrics {
+                usage_pct: 0.0,
+                logical_cores: 1,
+                physical_cores: None,
+                pressure: Pressure::Nominal,
+            },
+            memory: MemoryMetrics {
+                total_bytes: 1,
+                used_bytes: 0,
+                available_bytes: 1,
+                usage_pct: 0.0,
+                swap_total_bytes: 0,
+                swap_used_bytes: 0,
+                pressure: Pressure::Nominal,
+            },
+            disks: DiskMetrics {
+                aggregate_total_bytes: 1,
+                aggregate_available_bytes: 1,
+                aggregate_used_bytes: 0,
+                aggregate_usage_pct: 0.0,
+                pressure: Pressure::Nominal,
+                mounts: Vec::new(),
+            },
+            network: NetworkMetrics {
+                rx_bytes_per_sec: 0.0,
+                tx_bytes_per_sec: 0.0,
+                rx_total_bytes: 0,
+                tx_total_bytes: 0,
+                window_secs: 1.0,
+            },
+            overall_pressure: Pressure::Nominal,
+            sampled_at_unix: Some(seq),
+        }
+    }
+
+    /// Why: `subscribe` takes its snapshot and its receiver under ONE read lock,
+    /// and until this test that guarantee rested on reading the lock scope. Move
+    /// `events.subscribe()` outside the guard — the obvious refactor, and what
+    /// `let snapshot = self.snapshot().await;` would do — and a sample recorded
+    /// in the gap between the two is in neither half, which the dashboard draws
+    /// as a hole it cannot see.
+    ///
+    /// Why the check is "first live sequence == last snapshotted sequence + 1":
+    /// the writer emits `0..TOTAL` in order and the broadcast buffer is sized
+    /// above the run, so no subscriber can lag. A subscription is then correct
+    /// exactly when its receiver resumes one past where its snapshot stopped —
+    /// resuming later means a sample fell in the gap, resuming at the same
+    /// sequence means it was delivered in both halves. One number per
+    /// subscription is what makes tens of thousands of attempts affordable, and
+    /// that volume is what turns a nanosecond-wide race into a failure that
+    /// shows up rather than one that hides.
+    ///
+    /// Why the ring is deliberately tiny and the run deliberately long: the gap
+    /// is a few nanoseconds between releasing the read lock and subscribing, so
+    /// what matters is how many subscriptions fit inside the run. A full-size
+    /// ring makes each snapshot an O(window) clone, the subscriber spends nearly
+    /// all its time inside the lock, and the race almost never lands. Measured
+    /// against the broken version: 1 failure in 10 runs with a full ring at
+    /// 3000 samples, 6 in 10 with an 8-slot ring at 10 000, and 10 in 10 at
+    /// 20 000 — which is the shape kept here, at about 5 s. Eviction is harmless
+    /// because the check reads the last sequence, not the count.
+    /// What: one task records `TOTAL` sequence-tagged samples as fast as it can
+    /// while the main task subscribes in a tight loop for the whole run, then
+    /// checks that resume point for every subscription that landed mid-run.
+    /// Test: this test.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn every_sample_reaches_a_mid_run_subscriber_exactly_once() {
+        use tokio::sync::broadcast::error::TryRecvError;
+
+        const TOTAL: u64 = 20_000;
+        const MAX_SUBSCRIPTIONS: usize = 200_000;
+
+        let history = MachineHistory::with_limits(
+            8,
+            8,
+            // Above the whole run, so a receiver read at the end cannot lag and
+            // every gap it reports is the ordering bug.
+            TOTAL as usize * 2,
+            Duration::from_secs(60),
+        );
+
+        let writer = {
+            let history = history.clone();
+            tokio::spawn(async move {
+                for seq in 0..TOTAL {
+                    history.record_sample(tagged_sample(seq)).await;
+                }
+            })
+        };
+
+        // One subscriber, not several: the window only opens when the writer is
+        // already running on another core as the reader releases the lock, and
+        // extra subscriber tasks compete for the same worker threads. Three
+        // subscribers measured 5 failures in 10 runs against the broken version
+        // where one measured 10 in 10.
+        let mut taken: Vec<(Option<u64>, broadcast::Receiver<HistoryEvent>)> = Vec::new();
+        while !writer.is_finished() && taken.len() < MAX_SUBSCRIPTIONS {
+            let (snapshot, rx) = history.subscribe().await;
+            let last = snapshot
+                .samples
+                .last()
+                .map(|m| m.sampled_at_unix.expect("tagged sample"));
+            taken.push((last, rx));
+        }
+        writer.await.expect("writer task");
+
+        let mut mid_run = 0usize;
+        for (nth, (last_snapshotted, mut rx)) in taken.into_iter().enumerate() {
+            // Subscribed after the last sample — nothing live to resume at.
+            if last_snapshotted == Some(TOTAL - 1) {
+                continue;
+            }
+            let expected = last_snapshotted.map_or(0, |s| s + 1);
+            mid_run += 1;
+            let first_live = loop {
+                match rx.try_recv() {
+                    Ok(HistoryEvent::Sample(m)) => break m.sampled_at_unix.expect("tagged sample"),
+                    Ok(HistoryEvent::Transition(_)) => {}
+                    Err(TryRecvError::Empty | TryRecvError::Closed) => panic!(
+                        "subscription {nth} snapshotted through {last_snapshotted:?} of {TOTAL} \
+                         samples and then received nothing live"
+                    ),
+                    Err(TryRecvError::Lagged(n)) => panic!(
+                        "subscription {nth} lagged by {n} — the buffer was sized to prevent it"
+                    ),
+                }
+            };
+            assert_eq!(
+                first_live, expected,
+                "subscription {nth} snapshotted through {last_snapshotted:?} and must resume live \
+                 at {expected}; resuming later means a sample fell between the snapshot and the \
+                 subscription, resuming at the same sequence means it landed in both"
+            );
+        }
+        assert!(
+            mid_run >= 500,
+            "only {mid_run} subscription(s) landed mid-run — the race this test exists to catch \
+             was never given a chance"
+        );
+    }
 }

--- a/crates/trusty-console/src/machine_history/sampler.rs
+++ b/crates/trusty-console/src/machine_history/sampler.rs
@@ -1,0 +1,75 @@
+//! The background loop that feeds the history and the point-in-time cache
+//! (#6641).
+//!
+//! Why one loop rather than two: the host cache
+//! ([`crate::host_status::HostMetricsCache`], which
+//! `GET /api/console/machine-status` serves) and the history ring must never
+//! disagree about the newest sample. Sampling once and writing both is the only
+//! way to guarantee that; the stateful [`HostSampler`] also cannot be shared
+//! across two tasks, because its CPU and network readings are deltas between
+//! refreshes.
+//! What: [`start`] spawns a task that samples the host, writes the cache, feeds
+//! the ring through [`MachineHistory::record_sample`], and folds the current
+//! service reports into the transition log — then sleeps for `interval`. The
+//! same task publishes `interval` to the history so the payload advertises the
+//! cadence actually in use.
+//!
+//! When #6284 inverts the transport, the service half of this loop becomes a
+//! push handler calling `observe_services` and the host half becomes a push
+//! handler calling `record_sample`; neither the ring nor any reader changes.
+//! Test: not tested directly — it spawns a real OS sampler on a timer. Both
+//! halves it calls are covered: `machine_history::tests` for the ring and the
+//! log, `host_status::tests` for the cache.
+
+use std::time::Duration;
+
+use tracing::{debug, info};
+use trusty_common::host_metrics::HostSampler;
+
+use crate::server::AppState;
+
+/// Spawn the host sampling + service observation loop.
+///
+/// Why `AppState` rather than the three handles: the loop needs the host cache,
+/// the history, and whichever per-service reports are currently warm, and the
+/// state already owns all three.
+/// What: spawns a tokio task that constructs one [`HostSampler`], samples it
+/// immediately (so the first request finds a warm cache), then repeats every
+/// `interval`. Sampling itself never fails, so there is no error path to log.
+/// Test: see the module docs.
+pub fn start(state: AppState, interval: Duration) {
+    state
+        .machine_history()
+        .set_sample_interval(interval.as_secs());
+    tokio::spawn(async move {
+        info!(
+            "machine_history: sampling host metrics every {}s (window={} points)",
+            interval.as_secs(),
+            state.machine_history().snapshot().await.sample_capacity
+        );
+        let mut sampler = HostSampler::new();
+        loop {
+            let metrics = sampler.sample();
+            debug!(
+                overall = ?metrics.overall_pressure,
+                cpu_pct = metrics.cpu.usage_pct,
+                mem_pct = metrics.memory.usage_pct,
+                "machine_history: sampled host metrics"
+            );
+            state.host_metrics_cache().set(metrics.clone()).await;
+            state.machine_history().record_sample(metrics).await;
+
+            let reports = state.collect_service_reports().await;
+            for change in state.machine_history().observe_services(&reports).await {
+                info!(
+                    service = %change.service_id,
+                    from = ?change.from,
+                    to = ?change.to,
+                    "machine_history: service changed state"
+                );
+            }
+
+            tokio::time::sleep(interval).await;
+        }
+    });
+}

--- a/crates/trusty-console/src/machine_history/stream.rs
+++ b/crates/trusty-console/src/machine_history/stream.rs
@@ -1,0 +1,195 @@
+//! The byte stream behind `GET /api/console/machine-status/stream` (#6641).
+//!
+//! Why this is a module and not an inline closure in the route: the ordering
+//! contract — the whole current window first, then every later event, with no
+//! gap and no duplicate — is the part that can silently break, so it is built
+//! where a test can drive it without an HTTP client or a running server.
+//! What: [`event_stream`] subscribes to a [`MachineHistory`], emits its snapshot
+//! as one `history` event, then one frame per broadcast event, with a `lagged`
+//! frame carrying the dropped count whenever a slow subscriber falls behind the
+//! channel, and a `: heartbeat` comment on an idle timer so an intermediary does
+//! not close a quiet connection.
+//! Test: `a_late_subscriber_gets_the_window_then_the_next_sample`,
+//! `a_lagging_subscriber_is_told_what_it_missed`.
+
+use std::convert::Infallible;
+use std::time::Duration;
+
+use axum::body::Bytes;
+use tokio::sync::broadcast::error::RecvError;
+use tracing::debug;
+
+use super::MachineHistory;
+use super::events::{lagged_frame, sse_frame};
+
+/// How often a silent stream emits an SSE comment.
+///
+/// Why: samples arrive every 5 s by default, so a healthy stream is never
+/// silent. An operator who slows the cadence, or a proxy with a short idle
+/// timeout, still needs traffic — the same reason the #6524 search relay
+/// heartbeats.
+/// What: `20` seconds, matching that relay's interval.
+/// Test: covered structurally by `a_late_subscriber_gets_the_window_then_the_next_sample`,
+/// which must not see a heartbeat before its live event.
+pub const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(20);
+
+/// The SSE comment sent to keep an idle connection open.
+const HEARTBEAT: &[u8] = b": heartbeat\n\n";
+
+/// Build the SSE byte stream for one subscriber.
+///
+/// Why the snapshot and the subscription are taken together (see
+/// [`MachineHistory::subscribe`]): a client that connects mid-window must get
+/// every sample exactly once — no gap where a sample landed between the
+/// snapshot and the subscription, and no duplicate where it landed in both.
+/// What: yields one `history` frame built from the snapshot, then unfolds the
+/// receiver: an event becomes its own frame, a `RecvError::Lagged(n)` becomes a
+/// `lagged` frame carrying `n`, a closed channel ends the stream, and an idle
+/// [`HEARTBEAT_INTERVAL`] emits a comment. The stream ends when the browser
+/// disconnects and axum drops the body.
+/// Test: `a_late_subscriber_gets_the_window_then_the_next_sample`,
+/// `a_lagging_subscriber_is_told_what_it_missed`.
+pub async fn event_stream(
+    history: &MachineHistory,
+) -> impl futures_util::Stream<Item = Result<Bytes, Infallible>> + Send + 'static {
+    let (snapshot, rx) = history.subscribe().await;
+    let head = futures_util::stream::iter(std::iter::once(Ok(sse_frame("history", &snapshot))));
+
+    let heartbeat = tokio::time::interval_at(
+        tokio::time::Instant::now() + HEARTBEAT_INTERVAL,
+        HEARTBEAT_INTERVAL,
+    );
+
+    let tail = futures_util::stream::unfold(Some((rx, heartbeat)), |state| async move {
+        let (mut rx, mut heartbeat) = state?;
+        tokio::select! {
+            biased;
+            received = rx.recv() => match received {
+                Ok(event) => Some((Ok(event.frame()), Some((rx, heartbeat)))),
+                // #6641: never a silent gap — the viewer is told how many
+                // samples its own slowness cost it.
+                Err(RecvError::Lagged(dropped)) => {
+                    debug!(dropped, "machine_history: subscriber lagged the event buffer");
+                    Some((Ok(lagged_frame(dropped)), Some((rx, heartbeat))))
+                }
+                // Only reachable once the console's own `AppState` is gone,
+                // i.e. at shutdown. Ending the stream is the honest answer.
+                Err(RecvError::Closed) => None,
+            },
+            _ = heartbeat.tick() => Some((
+                Ok(Bytes::from_static(HEARTBEAT)),
+                Some((rx, heartbeat)),
+            )),
+        }
+    });
+
+    futures_util::StreamExt::chain(head, tail)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures_util::StreamExt as _;
+    use trusty_common::host_metrics::HostSampler;
+
+    /// Split one SSE frame into its event name and its JSON data.
+    fn parse(frame: &Bytes) -> (String, serde_json::Value) {
+        let text = String::from_utf8(frame.to_vec()).expect("utf8 frame");
+        let (name, rest) = text
+            .strip_prefix("event: ")
+            .and_then(|r| r.split_once('\n'))
+            .unwrap_or_else(|| panic!("frame has no event line: {text:?}"));
+        let data = rest
+            .strip_prefix("data: ")
+            .and_then(|d| d.strip_suffix("\n\n"))
+            .unwrap_or_else(|| panic!("frame has no data line: {text:?}"));
+        (
+            name.to_string(),
+            serde_json::from_str(data).expect("frame data is json"),
+        )
+    }
+
+    /// Why: this is the contract a browser reconnecting mid-window depends on —
+    /// the samples it missed arrive in the first event, and the next live sample
+    /// follows without being duplicated into the history.
+    /// What: records three samples, opens a stream, records a fourth, and
+    /// asserts frame 1 is a `history` event holding exactly the first three and
+    /// frame 2 is a `sample` event for the fourth.
+    /// Test: this test.
+    #[tokio::test]
+    async fn a_late_subscriber_gets_the_window_then_the_next_sample() {
+        let history = MachineHistory::new();
+        let mut sampler = HostSampler::new();
+        for _ in 0..3 {
+            history.record_sample(sampler.sample()).await;
+        }
+
+        let mut stream = Box::pin(event_stream(&history).await);
+
+        // The fourth sample is recorded AFTER the subscription, so it must
+        // arrive live rather than inside the history event.
+        let fourth = sampler.sample();
+        let fourth_cores = fourth.cpu.logical_cores;
+        history.record_sample(fourth).await;
+
+        let first = stream
+            .next()
+            .await
+            .expect("history frame")
+            .expect("infallible");
+        let (name, data) = parse(&first);
+        assert_eq!(name, "history");
+        assert_eq!(
+            data["samples"].as_array().expect("samples array").len(),
+            3,
+            "the connecting subscriber gets the three samples it missed"
+        );
+        assert_eq!(data["sample_capacity"], 120);
+        assert_eq!(data["sample_interval_secs"], 5);
+
+        let second = stream
+            .next()
+            .await
+            .expect("live frame")
+            .expect("infallible");
+        let (name, data) = parse(&second);
+        assert_eq!(name, "sample", "the fourth sample arrives live");
+        assert_eq!(data["cpu"]["logical_cores"], fourth_cores);
+    }
+
+    /// Why: a subscriber that falls behind the broadcast buffer loses events. A
+    /// graph with a silent hole in it is worse than one that says it has a hole.
+    /// What: opens a stream against a two-event buffer, records five samples
+    /// without reading, then reads: the history frame first, then a `lagged`
+    /// frame naming a non-zero dropped count.
+    /// Test: this test.
+    #[tokio::test]
+    async fn a_lagging_subscriber_is_told_what_it_missed() {
+        let history = MachineHistory::with_limits(120, 16, 2, Duration::from_secs(60));
+        let mut stream = Box::pin(event_stream(&history).await);
+
+        let mut sampler = HostSampler::new();
+        for _ in 0..5 {
+            history.record_sample(sampler.sample()).await;
+        }
+
+        let first = stream
+            .next()
+            .await
+            .expect("history frame")
+            .expect("infallible");
+        assert_eq!(parse(&first).0, "history");
+
+        let second = stream
+            .next()
+            .await
+            .expect("lagged frame")
+            .expect("infallible");
+        let (name, data) = parse(&second);
+        assert_eq!(name, "lagged", "the gap is reported, not hidden");
+        assert!(
+            data["dropped"].as_u64().expect("dropped count") >= 1,
+            "the dropped count is reported: {data}"
+        );
+    }
+}

--- a/crates/trusty-console/src/machine_history/transitions.rs
+++ b/crates/trusty-console/src/machine_history/transitions.rs
@@ -1,0 +1,434 @@
+//! Per-service state transitions derived from `console_metrics` reports (#6641).
+//!
+//! Why: the dashboard's service timeline needs the MOMENTS a service changed
+//! state, not a row per poll. Polling every few seconds and logging each result
+//! would bury the two entries an operator cares about ("search went degraded at
+//! 14:02, recovered at 14:05") under hundreds of identical lines. So this module
+//! records a transition only when the derived state actually differs from the
+//! previous observation.
+//! What: [`ServiceState`] is the four-state derivation (`up` / `degraded` /
+//! `down` / `unknown`); [`ServiceTransition`] is one logged change;
+//! [`TransitionTracker`] holds the last observed state per service and emits a
+//! transition only on a change. A service whose report has gone stale past
+//! [`SERVICE_REPORT_GRACE_SECS`] — or that stops appearing in the report set for
+//! that long — transitions to `down`, because a retained cache entry is not
+//! evidence the service is alive (`metrics_poller::poll_once` keeps the previous
+//! report when a poll fails).
+//! Test: `first_observation_seeds_without_a_transition`,
+//! `repeated_identical_reports_log_one_transition`,
+//! `a_stale_report_transitions_to_down`,
+//! `a_service_that_stops_reporting_goes_down_after_the_grace`,
+//! `an_unseen_service_reads_unknown`.
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+use trusty_common::console_metrics::{ConsoleMetricsReport, ServiceHealth};
+
+/// How long a service may go without a fresh report before it reads `down`.
+///
+/// Why: the metrics poller retains the previous cached report when a poll fails
+/// (`metrics_poller::poll_once`), so a dead service keeps presenting its last
+/// healthy report forever. Freshness is therefore the only honest liveness
+/// signal the console has. 60 s comfortably clears the default 15 s poll cadence
+/// plus a slow stdio-MCP round trip, while still surfacing a dead daemon inside
+/// a minute.
+/// What: `60` seconds; [`TransitionTracker::new`] takes it as a `Duration` so a
+/// test can shrink it.
+/// Test: `a_stale_report_transitions_to_down`.
+pub const SERVICE_REPORT_GRACE_SECS: u64 = 60;
+
+/// The state a service is in, as the transition log records it (#6641).
+///
+/// Why: [`ServiceHealth`] describes what a service says about ITSELF and has no
+/// way to say "we have not heard from you". The timeline needs that fourth
+/// state, so the console derives its own.
+/// What: `Up` / `Degraded` map from the service's own `Ok` / `Degraded`; `Down`
+/// covers both a self-reported `Error` and a report that has gone stale past the
+/// grace window; `Unknown` is the state of a service the tracker has never
+/// observed. Serialised lowercase.
+/// Test: `repeated_identical_reports_log_one_transition`,
+/// `an_unseen_service_reads_unknown`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ServiceState {
+    /// The service reported `ok` within the grace window.
+    Up,
+    /// The service reported `degraded` within the grace window.
+    Degraded,
+    /// The service reported `error`, or has not reported within the grace window.
+    Down,
+    /// The tracker has never observed this service.
+    Unknown,
+}
+
+impl From<&ServiceHealth> for ServiceState {
+    /// Map a service's self-reported health onto the log's state.
+    fn from(h: &ServiceHealth) -> Self {
+        match h {
+            ServiceHealth::Ok => ServiceState::Up,
+            ServiceHealth::Degraded => ServiceState::Degraded,
+            ServiceHealth::Error => ServiceState::Down,
+        }
+    }
+}
+
+/// One recorded change of a service's state (#6641).
+///
+/// Why: the timeline draws a band per state, so it needs both endpoints of the
+/// change and when it happened — a `to` alone would leave the UI re-deriving the
+/// previous state by scanning backwards.
+/// What: the service's id and display name (so the UI need not join against the
+/// rollup), the state it left, the state it entered, and the wall-clock second
+/// the console observed the change.
+/// Test: `repeated_identical_reports_log_one_transition`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ServiceTransition {
+    /// Machine-readable service id (e.g. `"trusty-search"`).
+    pub service_id: String,
+    /// Human-readable display name for the timeline row.
+    pub display_name: String,
+    /// The state the service was in before this observation.
+    pub from: ServiceState,
+    /// The state the service is in now.
+    pub to: ServiceState,
+    /// Unix seconds when the console observed the change.
+    pub at_unix: u64,
+}
+
+/// What the tracker remembers about one service between observations.
+struct Observed {
+    state: ServiceState,
+    display_name: String,
+    last_report: Instant,
+}
+
+/// Last-observed state per service, emitting a transition only on a change
+/// (#6641).
+///
+/// Why: this is the "never on every poll" rule made mechanical. Callers hand it
+/// the whole current report set on every tick and get back only the changes.
+/// What: keyed by `service_id`. [`TransitionTracker::observe`] derives each
+/// service's state, applies the grace window to stale and missing reports, and
+/// returns one [`ServiceTransition`] per service whose state moved. The FIRST
+/// observation of a service seeds its state and emits nothing — the log is a
+/// record of changes, and a service's current state is already served by the
+/// machine-status rollup.
+/// Test: `first_observation_seeds_without_a_transition`,
+/// `repeated_identical_reports_log_one_transition`,
+/// `a_service_that_stops_reporting_goes_down_after_the_grace`.
+pub struct TransitionTracker {
+    grace: Duration,
+    seen: HashMap<String, Observed>,
+}
+
+impl Default for TransitionTracker {
+    fn default() -> Self {
+        Self::new(Duration::from_secs(SERVICE_REPORT_GRACE_SECS))
+    }
+}
+
+impl TransitionTracker {
+    /// Build a tracker with an explicit staleness grace window.
+    ///
+    /// Why: the console uses [`SERVICE_REPORT_GRACE_SECS`]; a test needs a
+    /// window it can cross without sleeping for a minute.
+    /// What: stores `grace` and an empty per-service map.
+    /// Test: `a_stale_report_transitions_to_down`.
+    #[must_use]
+    pub fn new(grace: Duration) -> Self {
+        Self {
+            grace,
+            seen: HashMap::new(),
+        }
+    }
+
+    /// The state currently attributed to `service_id`.
+    ///
+    /// Why: the history payload can state where each service stands without the
+    /// caller replaying the log.
+    /// What: the stored state, or [`ServiceState::Unknown`] for a service never
+    /// observed.
+    /// Test: `an_unseen_service_reads_unknown`.
+    #[must_use]
+    pub fn state_of(&self, service_id: &str) -> ServiceState {
+        self.seen
+            .get(service_id)
+            .map_or(ServiceState::Unknown, |o| o.state)
+    }
+
+    /// Fold one observation of the whole report set into the log.
+    ///
+    /// Why: one entry point keeps the change rule in a single place — a caller
+    /// cannot accidentally append on a poll that changed nothing.
+    /// What: derives each reported service's state (stale reports past `grace`
+    /// read `down`), then marks any previously-known service missing from
+    /// `reports` for longer than `grace` as `down`. Returns a transition only
+    /// where the derived state differs from the stored one; a service seen for
+    /// the first time is seeded silently. `now` and `now_unix` are passed in so
+    /// the grace window is testable without sleeping.
+    /// Test: `repeated_identical_reports_log_one_transition`,
+    /// `a_stale_report_transitions_to_down`,
+    /// `a_service_that_stops_reporting_goes_down_after_the_grace`.
+    pub fn observe(
+        &mut self,
+        reports: &[ConsoleMetricsReport],
+        now: Instant,
+        now_unix: u64,
+    ) -> Vec<ServiceTransition> {
+        let mut out = Vec::new();
+
+        for report in reports {
+            // #6641: a retained cache entry is not liveness — a report the
+            // service collected before the grace window reads `down` whatever
+            // health it claims.
+            let stale = report
+                .collected_at_unix
+                .is_some_and(|t| now_unix.saturating_sub(t) > self.grace.as_secs());
+            let state = if stale {
+                ServiceState::Down
+            } else {
+                ServiceState::from(&report.status)
+            };
+            self.apply(
+                &report.service_id,
+                &report.display_name,
+                state,
+                now,
+                now_unix,
+                &mut out,
+            );
+        }
+
+        // A service that has dropped out of the report set entirely — its
+        // binary is gone, or the poller never got a first report — goes down
+        // once the grace window has passed since its last report.
+        let missing: Vec<(String, String)> = self
+            .seen
+            .iter()
+            .filter(|(id, o)| {
+                o.state != ServiceState::Down
+                    && now.duration_since(o.last_report) > self.grace
+                    && !reports.iter().any(|r| &r.service_id == *id)
+            })
+            .map(|(id, o)| (id.clone(), o.display_name.clone()))
+            .collect();
+        for (id, display_name) in missing {
+            self.mark_down(&id, &display_name, now_unix, &mut out);
+        }
+
+        out
+    }
+
+    /// Store `state` for `service_id`, pushing a transition when it changed.
+    ///
+    /// Why: the single mutation point, so the "changed only" rule and the
+    /// last-report timestamp update can never drift apart.
+    /// What: seeds an unseen service silently; otherwise compares against the
+    /// stored state and appends a [`ServiceTransition`] on a difference. Always
+    /// refreshes `last_report`, because this path is only reached from a live
+    /// report.
+    /// Test: `first_observation_seeds_without_a_transition`.
+    fn apply(
+        &mut self,
+        service_id: &str,
+        display_name: &str,
+        state: ServiceState,
+        now: Instant,
+        now_unix: u64,
+        out: &mut Vec<ServiceTransition>,
+    ) {
+        match self.seen.get_mut(service_id) {
+            None => {
+                self.seen.insert(
+                    service_id.to_string(),
+                    Observed {
+                        state,
+                        display_name: display_name.to_string(),
+                        last_report: now,
+                    },
+                );
+            }
+            Some(prev) => {
+                prev.last_report = now;
+                prev.display_name = display_name.to_string();
+                if prev.state != state {
+                    let from = prev.state;
+                    prev.state = state;
+                    out.push(ServiceTransition {
+                        service_id: service_id.to_string(),
+                        display_name: display_name.to_string(),
+                        from,
+                        to: state,
+                        at_unix: now_unix,
+                    });
+                }
+            }
+        }
+    }
+
+    /// Move a known service to `Down` without refreshing its last-report time.
+    ///
+    /// Why: the missing-report path must not pretend it heard from the service;
+    /// refreshing `last_report` here would re-arm the grace window forever.
+    /// What: sets the stored state to `Down` and appends the transition.
+    /// Test: `a_service_that_stops_reporting_goes_down_after_the_grace`.
+    fn mark_down(
+        &mut self,
+        service_id: &str,
+        display_name: &str,
+        now_unix: u64,
+        out: &mut Vec<ServiceTransition>,
+    ) {
+        if let Some(prev) = self.seen.get_mut(service_id) {
+            let from = prev.state;
+            prev.state = ServiceState::Down;
+            out.push(ServiceTransition {
+                service_id: service_id.to_string(),
+                display_name: display_name.to_string(),
+                from,
+                to: ServiceState::Down,
+                at_unix: now_unix,
+            });
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use trusty_common::console_metrics::make_report;
+
+    fn unix_now() -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0, |d| d.as_secs())
+    }
+
+    fn report(status: ServiceHealth, collected_at: u64) -> ConsoleMetricsReport {
+        let mut r = make_report(
+            "trusty-search",
+            "Trusty Search",
+            "1.0.0",
+            status,
+            serde_json::json!({}),
+            1,
+        );
+        r.collected_at_unix = Some(collected_at);
+        r
+    }
+
+    /// Why: a service the console has never seen has no previous state to have
+    /// changed FROM, so its first report must not manufacture a transition.
+    /// What: one report into a fresh tracker returns no transitions, and the
+    /// state is nevertheless recorded.
+    /// Test: this test.
+    #[test]
+    fn first_observation_seeds_without_a_transition() {
+        let mut t = TransitionTracker::default();
+        let now = Instant::now();
+        let unix = unix_now();
+        let out = t.observe(&[report(ServiceHealth::Ok, unix)], now, unix);
+        assert!(out.is_empty(), "the first observation must log nothing");
+        assert_eq!(t.state_of("trusty-search"), ServiceState::Up);
+    }
+
+    /// Why: this is the rule the whole module exists for — an entry is appended
+    /// ONLY on a change, never on every poll.
+    /// What: feeds five identical `ok` reports, then one `degraded` report, and
+    /// asserts exactly ONE transition entry across all six observations.
+    /// Test: this test.
+    #[test]
+    fn repeated_identical_reports_log_one_transition() {
+        let mut t = TransitionTracker::default();
+        let start = Instant::now();
+        let unix = unix_now();
+        let mut log: Vec<ServiceTransition> = Vec::new();
+
+        for i in 0..5u64 {
+            log.extend(t.observe(
+                &[report(ServiceHealth::Ok, unix + i)],
+                start + Duration::from_secs(i),
+                unix + i,
+            ));
+        }
+        assert!(
+            log.is_empty(),
+            "five identical reports must log nothing, got {log:?}"
+        );
+
+        log.extend(t.observe(
+            &[report(ServiceHealth::Degraded, unix + 5)],
+            start + Duration::from_secs(5),
+            unix + 5,
+        ));
+
+        assert_eq!(log.len(), 1, "exactly one transition, got {log:?}");
+        assert_eq!(log[0].from, ServiceState::Up);
+        assert_eq!(log[0].to, ServiceState::Degraded);
+        assert_eq!(log[0].service_id, "trusty-search");
+        assert_eq!(log[0].display_name, "Trusty Search");
+    }
+
+    /// Why: `metrics_poller::poll_once` retains the previous report when a poll
+    /// fails, so a dead service keeps presenting a healthy report. Freshness is
+    /// the only honest liveness signal.
+    /// What: seeds an `ok` report, then re-observes the SAME report 30 s later
+    /// against a 10 s grace, and asserts it transitioned to `down`.
+    /// Test: this test.
+    #[test]
+    fn a_stale_report_transitions_to_down() {
+        let mut t = TransitionTracker::new(Duration::from_secs(10));
+        let start = Instant::now();
+        let unix = unix_now();
+        assert!(
+            t.observe(&[report(ServiceHealth::Ok, unix)], start, unix)
+                .is_empty()
+        );
+
+        let out = t.observe(
+            &[report(ServiceHealth::Ok, unix)],
+            start + Duration::from_secs(30),
+            unix + 30,
+        );
+        assert_eq!(out.len(), 1, "a stale report is a transition, got {out:?}");
+        assert_eq!(out[0].to, ServiceState::Down);
+        assert_eq!(t.state_of("trusty-search"), ServiceState::Down);
+    }
+
+    /// Why: a service whose binary vanishes drops out of the report set
+    /// entirely; nothing else would ever move it off `up`.
+    /// What: seeds an `ok` report, then observes an EMPTY report set inside the
+    /// grace (no transition) and again past it (one `down` transition), then a
+    /// third time to prove the down state is not re-logged.
+    /// Test: this test.
+    #[test]
+    fn a_service_that_stops_reporting_goes_down_after_the_grace() {
+        let mut t = TransitionTracker::new(Duration::from_secs(10));
+        let start = Instant::now();
+        let unix = unix_now();
+        t.observe(&[report(ServiceHealth::Ok, unix)], start, unix);
+
+        let inside = t.observe(&[], start + Duration::from_secs(5), unix + 5);
+        assert!(inside.is_empty(), "inside the grace nothing changes");
+
+        let past = t.observe(&[], start + Duration::from_secs(30), unix + 30);
+        assert_eq!(past.len(), 1, "past the grace the service goes down");
+        assert_eq!(past[0].from, ServiceState::Up);
+        assert_eq!(past[0].to, ServiceState::Down);
+
+        let again = t.observe(&[], start + Duration::from_secs(60), unix + 60);
+        assert!(again.is_empty(), "down is not re-logged every tick");
+    }
+
+    /// Why: the payload must be able to state where a service stands without
+    /// inventing a state for one it has never heard of.
+    /// What: asserts `state_of` on an unobserved id reads `unknown`.
+    /// Test: this test.
+    #[test]
+    fn an_unseen_service_reads_unknown() {
+        let t = TransitionTracker::default();
+        assert_eq!(t.state_of("trusty-memory"), ServiceState::Unknown);
+    }
+}

--- a/crates/trusty-console/src/machine_history/transitions.rs
+++ b/crates/trusty-console/src/machine_history/transitions.rs
@@ -14,6 +14,17 @@
 //! that long — transitions to `down`, because a retained cache entry is not
 //! evidence the service is alive (`metrics_poller::poll_once` keeps the previous
 //! report when a poll fails).
+//!
+//! Two deliberate choices a consumer of this log inherits (#6642 renders it):
+//! - A service's FIRST observation is seeded silently, so a daemon that starts
+//!   after the console produces no `up` entry — its timeline begins at the first
+//!   time it CHANGES state. Current state comes from the machine-status rollup,
+//!   never from replaying this log.
+//! - A report with `collected_at_unix: None` is never judged stale, because
+//!   there is no timestamp to judge it against. Such a service is held at its
+//!   self-reported health until it drops out of the report set entirely, and
+//!   only the missing-report path can then take it down.
+//!
 //! Test: `first_observation_seeds_without_a_transition`,
 //! `repeated_identical_reports_log_one_transition`,
 //! `a_stale_report_transitions_to_down`,
@@ -166,8 +177,12 @@ impl TransitionTracker {
     /// read `down`), then marks any previously-known service missing from
     /// `reports` for longer than `grace` as `down`. Returns a transition only
     /// where the derived state differs from the stored one; a service seen for
-    /// the first time is seeded silently. `now` and `now_unix` are passed in so
-    /// the grace window is testable without sleeping.
+    /// the first time is seeded silently, so a late-starting daemon gets no `up`
+    /// entry and its timeline opens at its first real change. A report carrying
+    /// no `collected_at_unix` is never counted stale — there is no timestamp to
+    /// judge — so only the missing-report sweep below can take it down. `now`
+    /// and `now_unix` are passed in so the grace window is testable without
+    /// sleeping.
     /// Test: `repeated_identical_reports_log_one_transition`,
     /// `a_stale_report_transitions_to_down`,
     /// `a_service_that_stops_reporting_goes_down_after_the_grace`.

--- a/crates/trusty-console/src/routes/machine_history.rs
+++ b/crates/trusty-console/src/routes/machine_history.rs
@@ -1,0 +1,75 @@
+//! `GET /api/console/machine-status/history` and `…/stream` (#6641).
+//!
+//! Why: `GET /api/console/machine-status` answers with one point in time, which
+//! draws a number but not a graph. Phase 3 of epic #6516 needs the last 10
+//! minutes of host samples and the moments each service changed state, arriving
+//! live while the dashboard is open. These two routes are the pull and the push
+//! halves of that: the history endpoint seeds a page load, the stream keeps it
+//! moving.
+//!
+//! Why history resets on restart: the owner's Phase 3 ruling is no persistence —
+//! the window is in-memory only, so a restarted console begins an empty 10-minute
+//! window and the graph fills from the left. This is by design, not a bug to
+//! work around: nothing here reads or writes disk, and a client that reconnects
+//! after a restart correctly sees a short window rather than a stale one.
+//!
+//! Why history answers `200` on a cold cache while `/machine-status` answers
+//! `503`: an empty window is a complete, true answer — "no samples yet" — and
+//! the graph renders it as an empty axis. The point-in-time route has no such
+//! answer, because there is no host snapshot to return.
+//! What: [`history_handler`] serves the
+//! [`HistorySnapshot`](crate::machine_history::HistorySnapshot) as JSON;
+//! [`stream_handler`] serves the same snapshot as the first `history` event of a
+//! `text/event-stream`, then one `sample` event per new sample, one `transition`
+//! event per service change, and a `lagged` event carrying the dropped count
+//! whenever a slow subscriber falls behind.
+//! Test: `crate::server::tests::machine_history_route_*` and
+//! `crate::machine_history::stream::tests`.
+
+use axum::body::Body;
+use axum::extract::State;
+use axum::http::{StatusCode, header};
+use axum::response::{IntoResponse, Response};
+
+use crate::machine_history::stream::event_stream;
+use crate::server::AppState;
+
+/// `GET /api/console/machine-status/history` — the bounded window as JSON.
+///
+/// Why: a page load needs the whole window in one request before it opens a
+/// stream; polling the stream's first event would mean holding a connection
+/// open just to read it.
+/// What: returns the sample ring and the transition log oldest-first, plus the
+/// capacities and the sample interval the graph's axes are derived from. Always
+/// `200` — before the first sample the arrays are simply empty.
+/// Test: `machine_history_route_cold_cache_returns_empty_200`,
+/// `machine_history_route_returns_recorded_samples`.
+pub async fn history_handler(State(state): State<AppState>) -> Response {
+    axum::Json(state.machine_history().snapshot().await).into_response()
+}
+
+/// `GET /api/console/machine-status/stream` — the live event stream.
+///
+/// Why the history is sent first rather than left to the client: a browser that
+/// connects mid-window would otherwise draw an empty graph until the next
+/// sample, and reconciling a separately-fetched history against a stream that
+/// started at an unknown moment is exactly the gap-or-duplicate problem
+/// `MachineHistory::subscribe` exists to remove.
+/// What: `200 text/event-stream`. The first frame is `event: history` carrying
+/// the current window; every later frame is `event: sample`, `event:
+/// transition`, or `event: lagged` (with the count a slow subscriber dropped),
+/// each framed `data: {json}\n\n`. `X-Accel-Buffering: no` keeps a reverse proxy
+/// from buffering the stream into uselessness — the same headers the #6524
+/// search relay sets.
+/// Test: `machine_history_stream_route_is_an_event_stream`, plus
+/// `crate::machine_history::stream::tests` for the frame sequence.
+pub async fn stream_handler(State(state): State<AppState>) -> Response {
+    let stream = event_stream(state.machine_history()).await;
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, "text/event-stream")
+        .header(header::CACHE_CONTROL, "no-cache")
+        .header("X-Accel-Buffering", "no")
+        .body(Body::from_stream(stream))
+        .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response())
+}

--- a/crates/trusty-console/src/routes/metrics.rs
+++ b/crates/trusty-console/src/routes/metrics.rs
@@ -1,0 +1,79 @@
+//! The five per-service `GET /api/console/metrics/<service>` handlers.
+//!
+//! Why here rather than in `server/mod.rs`: adding the #6641 machine-status
+//! history and stream routes pushed that file to 504 SLOC, four over the
+//! production cap. These five handlers are the most cohesive group in it — one
+//! shape repeated per service, none of them touching the router, the app state's
+//! construction, or the SPA — so they are the split that leaves `server/mod.rs`
+//! about what it is for. The `routes` module already exists for exactly this
+//! (see its module docs).
+//! What: one handler per polled service, each reading that service's
+//! `MetricsCache` and answering `200` with the cached
+//! `ConsoleMetricsReport` or `503` when no poll has completed yet — the binary
+//! is absent, or this is first boot.
+//! Test: `crate::server::tests::test_metrics_*_route_cold_cache_returns_503`.
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+
+use crate::server::AppState;
+
+/// `GET /api/console/metrics/analyze` — the latest trusty-analyze report.
+///
+/// Why: surfaces analyze health to the SPA without a per-request MCP call; the
+/// background poller keeps the cache warm.
+/// What: cached `ConsoleMetricsReport` as JSON (200), or 503 before the first
+/// successful poll.
+/// Test: `test_metrics_analyze_route_cold_cache_returns_503`.
+pub async fn metrics_analyze_handler(State(state): State<AppState>) -> axum::response::Response {
+    match state.metrics_cache().get().await {
+        Some(report) => axum::Json(report).into_response(),
+        None => StatusCode::SERVICE_UNAVAILABLE.into_response(),
+    }
+}
+
+/// `GET /api/console/metrics/memory` — the latest trusty-memory report.
+///
+/// Test: `test_metrics_memory_route_cold_cache_returns_503`.
+pub async fn metrics_memory_handler(State(state): State<AppState>) -> axum::response::Response {
+    match state.memory_metrics_cache().get().await {
+        Some(report) => axum::Json(report).into_response(),
+        None => StatusCode::SERVICE_UNAVAILABLE.into_response(),
+    }
+}
+
+/// `GET /api/console/metrics/search` — the latest trusty-search report.
+///
+/// Test: `test_metrics_search_route_cold_cache_returns_503`.
+pub async fn metrics_search_handler(State(state): State<AppState>) -> axum::response::Response {
+    match state.search_metrics_cache().get().await {
+        Some(report) => axum::Json(report).into_response(),
+        None => StatusCode::SERVICE_UNAVAILABLE.into_response(),
+    }
+}
+
+/// `GET /api/console/metrics/review` — the latest trusty-review report.
+///
+/// Test: `test_metrics_review_route_cold_cache_returns_503`.
+pub async fn metrics_review_handler(State(state): State<AppState>) -> axum::response::Response {
+    match state.review_metrics_cache().get().await {
+        Some(report) => axum::Json(report).into_response(),
+        None => StatusCode::SERVICE_UNAVAILABLE.into_response(),
+    }
+}
+
+/// `GET /api/console/metrics/mpm` — the latest trusty-mpm report.
+///
+/// Why this one is coarse: it is the low-frequency session-fleet + supervisor
+/// health cache. The Sessions tab polls the live `/api/console/sessions` list at
+/// a faster cadence for active monitoring (#1222).
+/// What: cached `ConsoleMetricsReport` as JSON (200), or 503 before the first
+/// successful poll.
+/// Test: `test_metrics_mpm_route_cold_cache_returns_503`.
+pub async fn metrics_mpm_handler(State(state): State<AppState>) -> axum::response::Response {
+    match state.mpm_metrics_cache().get().await {
+        Some(report) => axum::Json(report).into_response(),
+        None => StatusCode::SERVICE_UNAVAILABLE.into_response(),
+    }
+}

--- a/crates/trusty-console/src/routes/mod.rs
+++ b/crates/trusty-console/src/routes/mod.rs
@@ -21,9 +21,15 @@ pub mod census_guard;
 pub mod cleanup;
 pub mod config;
 pub mod deletes;
+// #6641: the bounded sample window + per-service transition log, as JSON and as
+// a live event stream.
+pub mod machine_history;
 // #6517: the aggregated whole-machine + per-service status endpoint.
 pub mod machine_status;
 pub mod memory_rpc;
+// #6641: the five per-service metrics handlers, split out of `server/mod.rs`
+// when the machine-status history routes pushed it over the 500-SLOC cap.
+pub mod metrics;
 pub mod origin_guard;
 pub mod sessions;
 // #6423: review and settle a registration trusty-search could not check.

--- a/crates/trusty-console/src/server/mod.rs
+++ b/crates/trusty-console/src/server/mod.rs
@@ -90,6 +90,11 @@ pub struct AppState {
     /// host sampler (`crate::host_status`); served by
     /// `GET /api/console/machine-status`.
     host_metrics_cache: crate::host_status::HostMetricsCache,
+    /// Bounded 10-minute sample window + per-service transition log (#6641).
+    /// Written by `machine_history::sampler`; served by
+    /// `GET /api/console/machine-status/history` and its SSE stream. In-memory
+    /// only — a restart begins an empty window by design (owner ruling, #6516).
+    machine_history: crate::machine_history::MachineHistory,
     http_client: Arc<reqwest::Client>,
     /// The client the proxy uses for Server-Sent Events (#6155).
     ///
@@ -229,6 +234,7 @@ impl AppState {
             review_metrics_cache: MetricsCache::new(),
             mpm_metrics_cache: MetricsCache::new(),
             host_metrics_cache: crate::host_status::HostMetricsCache::new(),
+            machine_history: crate::machine_history::MachineHistory::new(),
             http_client: Arc::new(client),
             stream_client: Arc::new(stream_client),
             analyze_handle,
@@ -336,6 +342,18 @@ impl AppState {
     /// Test: `machine_status_route_cold_cache_returns_503`.
     pub fn host_metrics_cache(&self) -> &crate::host_status::HostMetricsCache {
         &self.host_metrics_cache
+    }
+
+    /// Access the bounded machine-status history (#6641).
+    ///
+    /// Why: `machine_history::sampler` writes every sample and every service
+    /// transition here; the history endpoint and the SSE stream read it. One
+    /// handle in the state means an open stream and a fresh page load are
+    /// looking at the same buffer.
+    /// What: returns a reference to the `MachineHistory` handle (cheap to clone).
+    /// Test: `machine_history_route_cold_cache_returns_empty_200`.
+    pub fn machine_history(&self) -> &crate::machine_history::MachineHistory {
+        &self.machine_history
     }
 
     /// Gather whichever per-service `ConsoleMetricsReport`s are currently cached
@@ -451,15 +469,44 @@ fn build_router_inner(
     let core = Router::new()
         .route("/health", get(health_handler))
         .route("/api/console/services", get(services_handler))
-        .route("/api/console/metrics/analyze", get(metrics_analyze_handler))
-        .route("/api/console/metrics/memory", get(metrics_memory_handler))
-        .route("/api/console/metrics/search", get(metrics_search_handler))
-        .route("/api/console/metrics/review", get(metrics_review_handler))
-        .route("/api/console/metrics/mpm", get(metrics_mpm_handler))
+        // The five per-service handlers moved to `crate::routes::metrics` when
+        // #6641's new routes pushed this file over the 500-SLOC cap.
+        .route(
+            "/api/console/metrics/analyze",
+            get(crate::routes::metrics::metrics_analyze_handler),
+        )
+        .route(
+            "/api/console/metrics/memory",
+            get(crate::routes::metrics::metrics_memory_handler),
+        )
+        .route(
+            "/api/console/metrics/search",
+            get(crate::routes::metrics::metrics_search_handler),
+        )
+        .route(
+            "/api/console/metrics/review",
+            get(crate::routes::metrics::metrics_review_handler),
+        )
+        .route(
+            "/api/console/metrics/mpm",
+            get(crate::routes::metrics::metrics_mpm_handler),
+        )
         // #6517: aggregated whole-machine host resources + per-service rollup.
         .route(
             "/api/console/machine-status",
             get(crate::routes::machine_status::machine_status_handler),
+        )
+        // #6641: the bounded 10-minute window behind the Phase 3 graphs, and the
+        // live stream that keeps an open dashboard moving. Both are static
+        // segments under `/machine-status`, so neither shadows nor is shadowed
+        // by the point-in-time route above.
+        .route(
+            "/api/console/machine-status/history",
+            get(crate::routes::machine_history::history_handler),
+        )
+        .route(
+            "/api/console/machine-status/stream",
+            get(crate::routes::machine_history::stream_handler),
         )
         // ── trusty-mpm session-manager surface (#1222: P2 tab + P3 front door) ──
         // The console is the SINGLE HTTP front door for the session REST API;
@@ -770,78 +817,6 @@ async fn services_handler(State(state): State<AppState>) -> axum::response::Resp
             tracing::error!("service detection task panicked: {e}");
             StatusCode::INTERNAL_SERVER_ERROR.into_response()
         }
-    }
-}
-
-/// `GET /api/console/metrics/analyze` — return the latest metrics report.
-///
-/// Why: Surfaces trusty-analyze health/metrics to the SPA without per-request
-/// MCP calls (the background poller keeps the cache warm).
-/// What: Returns the cached `ConsoleMetricsReport` as JSON (200) or 503 when
-/// no poll has completed yet (binary absent or first boot).
-/// Test: `test_metrics_analyze_route_cold_cache_returns_503` below.
-async fn metrics_analyze_handler(State(state): State<AppState>) -> axum::response::Response {
-    match state.metrics_cache().get().await {
-        Some(report) => axum::Json(report).into_response(),
-        None => StatusCode::SERVICE_UNAVAILABLE.into_response(),
-    }
-}
-
-/// `GET /api/console/metrics/memory` — return the latest memory metrics report.
-///
-/// Why: Surfaces trusty-memory health/metrics to the SPA without per-request
-/// MCP calls (the background poller keeps the cache warm).
-/// What: Returns the cached `ConsoleMetricsReport` as JSON (200) or 503 when
-/// no poll has completed yet (binary absent or first boot).
-/// Test: `test_metrics_memory_route_cold_cache_returns_503` below.
-async fn metrics_memory_handler(State(state): State<AppState>) -> axum::response::Response {
-    match state.memory_metrics_cache().get().await {
-        Some(report) => axum::Json(report).into_response(),
-        None => StatusCode::SERVICE_UNAVAILABLE.into_response(),
-    }
-}
-
-/// `GET /api/console/metrics/search` — return the latest search metrics report.
-///
-/// Why: Surfaces trusty-search health/metrics to the SPA without per-request
-/// MCP calls (the background poller keeps the cache warm).
-/// What: Returns the cached `ConsoleMetricsReport` as JSON (200) or 503 when
-/// no poll has completed yet (binary absent or first boot).
-/// Test: `test_metrics_search_route_cold_cache_returns_503` below.
-async fn metrics_search_handler(State(state): State<AppState>) -> axum::response::Response {
-    match state.search_metrics_cache().get().await {
-        Some(report) => axum::Json(report).into_response(),
-        None => StatusCode::SERVICE_UNAVAILABLE.into_response(),
-    }
-}
-
-/// `GET /api/console/metrics/review` — return the latest review metrics report.
-///
-/// Why: Surfaces trusty-review health/metrics to the SPA without per-request
-/// MCP calls (the background poller keeps the cache warm).
-/// What: Returns the cached `ConsoleMetricsReport` as JSON (200) or 503 when
-/// no poll has completed yet (binary absent or first boot).
-/// Test: `test_metrics_review_route_cold_cache_returns_503` below.
-async fn metrics_review_handler(State(state): State<AppState>) -> axum::response::Response {
-    match state.review_metrics_cache().get().await {
-        Some(report) => axum::Json(report).into_response(),
-        None => StatusCode::SERVICE_UNAVAILABLE.into_response(),
-    }
-}
-
-/// `GET /api/console/metrics/mpm` — return the latest trusty-mpm metrics report.
-///
-/// Why: surfaces trusty-mpm session-fleet + supervisor health to the SPA without
-/// per-request MCP calls (the background poller keeps the cache warm). This is
-/// the coarse, low-frequency health cache; the Sessions tab polls the live
-/// `/api/console/sessions` list at a faster cadence for active monitoring.
-/// What: returns the cached `ConsoleMetricsReport` as JSON (200) or 503 when no
-/// poll has completed yet (binary absent or first boot).
-/// Test: `test_metrics_mpm_route_cold_cache_returns_503` below.
-async fn metrics_mpm_handler(State(state): State<AppState>) -> axum::response::Response {
-    match state.mpm_metrics_cache().get().await {
-        Some(report) => axum::Json(report).into_response(),
-        None => StatusCode::SERVICE_UNAVAILABLE.into_response(),
     }
 }
 

--- a/crates/trusty-console/src/server/tests.rs
+++ b/crates/trusty-console/src/server/tests.rs
@@ -1034,3 +1034,159 @@ async fn machine_status_route_warm_cache_returns_json() {
     assert_eq!(status.services.ok, 1);
     assert!(status.host.cpu.logical_cores >= 1);
 }
+
+/// Why (#6641): the graph must render an empty axis before the first sample
+/// rather than an error. Unlike the point-in-time route above, "no samples yet"
+/// is a complete answer, so the history route answers 200 with empty arrays —
+/// this test pins that difference so a later change cannot quietly make it a 503.
+/// What: GET /api/console/machine-status/history on a fresh state, asserts 200
+/// and a body whose two arrays are empty while the capacities and interval are
+/// still advertised.
+/// Test: this test itself.
+#[tokio::test]
+async fn machine_history_route_cold_cache_returns_empty_200() {
+    let router = build_router(make_test_state());
+    let req = Request::builder()
+        .uri("/api/console/machine-status/history")
+        .body(Body::empty())
+        .expect("request");
+    let resp = router.oneshot(req).await.expect("response");
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "an empty window is a 200, not a 503"
+    );
+
+    let bytes = resp
+        .into_body()
+        .collect()
+        .await
+        .expect("collect body")
+        .to_bytes();
+    let snap: crate::machine_history::HistorySnapshot =
+        serde_json::from_slice(&bytes).expect("parse HistorySnapshot");
+    assert!(snap.samples.is_empty());
+    assert!(snap.transitions.is_empty());
+    assert_eq!(snap.sample_capacity, 120);
+    assert_eq!(snap.sample_interval_secs, 5);
+    assert_eq!(
+        snap.schema_version,
+        crate::machine_history::MACHINE_HISTORY_SCHEMA_VERSION
+    );
+}
+
+/// Why (#6641): the history endpoint is what a page load reads before it opens a
+/// stream, so it must return the recorded window oldest-first together with the
+/// transition log — not one or the other.
+/// What: records two samples and drives one service from `ok` to `error`, then
+/// asserts the JSON carries both samples and the single transition.
+/// Test: this test itself.
+#[tokio::test]
+async fn machine_history_route_returns_recorded_samples() {
+    use trusty_common::console_metrics::{ServiceHealth, make_report};
+    use trusty_common::host_metrics::HostSampler;
+
+    let state = make_test_state();
+    let mut sampler = HostSampler::new();
+    state
+        .machine_history()
+        .record_sample(sampler.sample())
+        .await;
+    state
+        .machine_history()
+        .record_sample(sampler.sample())
+        .await;
+    for status in [ServiceHealth::Ok, ServiceHealth::Error] {
+        state
+            .machine_history()
+            .observe_services(&[make_report(
+                "trusty-search",
+                "Trusty Search",
+                "1.0.0",
+                status,
+                serde_json::json!({}),
+                1,
+            )])
+            .await;
+    }
+
+    let router = build_router(state);
+    let req = Request::builder()
+        .uri("/api/console/machine-status/history")
+        .body(Body::empty())
+        .expect("request");
+    let resp = router.oneshot(req).await.expect("response");
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let bytes = resp
+        .into_body()
+        .collect()
+        .await
+        .expect("collect body")
+        .to_bytes();
+    let snap: crate::machine_history::HistorySnapshot =
+        serde_json::from_slice(&bytes).expect("parse HistorySnapshot");
+    assert_eq!(snap.samples.len(), 2);
+    assert_eq!(
+        snap.transitions.len(),
+        1,
+        "only the ok→error change is logged, got {:?}",
+        snap.transitions
+    );
+    assert_eq!(
+        snap.transitions[0].to,
+        crate::machine_history::transitions::ServiceState::Down
+    );
+}
+
+/// Why (#6641): `EventSource` refuses any response whose content type is not
+/// `text/event-stream`, and a buffering reverse proxy turns a correct stream into
+/// a dead one — so the status and the three headers are the contract.
+/// What: GET /api/console/machine-status/stream, asserts 200 with the SSE
+/// content type, `no-cache`, and `X-Accel-Buffering: no`, then reads the first
+/// body frame and asserts it is the `history` event.
+/// Test: this test itself.
+#[tokio::test]
+async fn machine_history_stream_route_is_an_event_stream() {
+    let router = build_router(make_test_state());
+    let req = Request::builder()
+        .uri("/api/console/machine-status/stream")
+        .body(Body::empty())
+        .expect("request");
+    let resp = router.oneshot(req).await.expect("response");
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(
+        resp.headers()
+            .get(CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok()),
+        Some("text/event-stream")
+    );
+    assert_eq!(
+        resp.headers()
+            .get("cache-control")
+            .and_then(|v| v.to_str().ok()),
+        Some("no-cache")
+    );
+    assert_eq!(
+        resp.headers()
+            .get("x-accel-buffering")
+            .and_then(|v| v.to_str().ok()),
+        Some("no")
+    );
+
+    // #6641: the stream never ends on its own, so read exactly the first frame
+    // rather than collecting the body.
+    let mut body = resp.into_body();
+    let frame = body
+        .frame()
+        .await
+        .expect("a first frame")
+        .expect("frame ok")
+        .into_data()
+        .expect("data frame");
+    let text = String::from_utf8(frame.to_vec()).expect("utf8 frame");
+    assert!(
+        text.starts_with("event: history\ndata: {"),
+        "the stream opens with the current window, got {text:?}"
+    );
+}


### PR DESCRIPTION
## What

Bounded per-host metric history ring in trusty-common `host_metrics::history`; trusty-console `machine_history` module (events, sampler, stream, transitions) with SSE route `routes/machine_history.rs`. Removes `host_status::start` — 0.x breaking change for trusty-console consumers.

## Why

Epic #6516 Phase 3, PR1 of three. Enables UI sparklines (#6642) and screensaver (#6643).

See #6516.

## Risk

**MEDIUM**: exactly-once subscription ordering. Concurrency test in c22e77684 fails 10/10 against snapshot-then-subscribe mutation; passes 10/10 on the fix.

**LOW** (2): transitions concurrency documented at `machine_history/transitions.rs`.

## Test

Rung 4 (trusty-common library change):
- `cargo fmt --check` — PASS
- `cargo clippy -p trusty-console --all-targets -- -D warnings` — PASS
- `cargo test -p trusty-console --no-fail-fast` — 378 lib passed, 0 failed, 4 ignored; 25 integration targets (2 + 18 + 5) all PASS
- `check_line_cap.sh` — 4368 files, 0 violations
- `check_test_pointers.sh` — 28886 citations, 0 dangling
- `check_changelog_fragment.sh` — PASS

## Known Flake

`detect::helpers::tests::test_tcp_probe_unreachable` — pre-existing, environmental (ephemeral-port re-bind race). No `git diff origin/main...HEAD -- crates/trusty-console/src/detect/` — passed 20/20 in isolation.

## Follow-ups

#6642 (UI sparklines), #6643 (screensaver).

---

Refs #6641

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J2e8jdTM8JhJotobe3Uvv1