### PR TITLE
feat(trusty-mpm): project issue-state model for tm issue transition; ticketing docs stop hand-typing label swaps

### DIFF
--- a/.test-pointer-allowlist.tsv
+++ b/.test-pointer-allowlist.tsv
@@ -380,7 +380,6 @@ crates/trusty-mpm/src/bin/tm/commands/auth.rs	set_token_reads_from_stdin
 crates/trusty-mpm/src/bin/tm/commands/daemon.rs	group_sessions_by_git_root_groups_correctly
 crates/trusty-mpm/src/bin/tm/commands/install.rs	install_claude_hooks_is_idempotent
 crates/trusty-mpm/src/bin/tm/commands/issue/ops.rs	ops_transition_assignee_unchanged
-crates/trusty-mpm/src/bin/tm/commands/issue/ops.rs	ops_transition_rejects_invalid
 crates/trusty-mpm/src/bin/tm/commands/issue/state.rs	sm_assignee_none
 crates/trusty-mpm/src/bin/tm/commands/issue/state.rs	sm_assignee_self
 crates/trusty-mpm/src/bin/tm/commands/managed_root.rs	test_expand_tilde_noop

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,11 +191,18 @@ Four mutually exclusive labels between GitHub's native open/closed:
   claim is provably stale: the named session is gone AND nothing referencing
   the issue (branch push, PR, comment) has moved since the claim. When in
   doubt, leave it.
-- Advancing a state removes the prior label in the same edit:
-  `gh issue edit N --add-label status:merged --remove-label status:coded`.
+- Advance with `tm issue transition N status:merged`, run from the repo root.
+  It reads [`issue-state.yaml`](issue-state.yaml), refuses an undeclared edge
+  with exit 1, and issues the add and remove as ONE `gh issue edit`, so two
+  `status:*` labels on one issue is unreachable. `tm issue states` lists the
+  model; `tm issue current N` reads a state back; `tm issue repair N` fixes an
+  issue that already carries two. Fall back to a single
+  `gh issue edit N --add-label … --remove-label …` only on a host with no `tm`.
 - Fix PRs use `Refs #N`, **never** `Closes #N` — merge must not auto-close.
 - An issue closes only from `status:tested`, with live verification evidence in
-  the closing comment. A merged fix that fails live verification stays open.
+  the closing comment: `tm issue transition N closed --note "<evidence>"`, which
+  refuses to run without the note. A merged fix that fails live verification
+  stays open.
 
 🔴 **`.trusty-mpm/sessions/` is TRACKED** (owner ruling 2026-08-31) — session
 snapshots and the pause log are committed so other sessions and harnesses can

--- a/crates/trusty-agents-common/changelog.d/6651-ticketing-issue-transition.md
+++ b/crates/trusty-agents-common/changelog.d/6651-ticketing-issue-transition.md
@@ -1,0 +1,10 @@
+Changed
+- The `ticketing` agent's lifecycle section now advances a status label with
+  `tm issue transition <n> <state>` instead of a hand-typed
+  `gh issue edit --add-label … --remove-label …`. The transition validates the
+  edge against the project's `issue-state.yaml` and issues both label flags as
+  one `gh issue edit`, so two `status:*` labels on one issue is unreachable
+  rather than merely forbidden in prose. A close now names its evidence
+  (`--note`), and the hand-typed single-call edit is documented only as the
+  fallback for a host without `tm`. Claim comments at dispatch are unchanged —
+  the transition's own audit line is not the dated claim record.

--- a/crates/trusty-agents-common/src/assets/agents/ticketing.md
+++ b/crates/trusty-agents-common/src/assets/agents/ticketing.md
@@ -274,12 +274,31 @@ matters happens between them. Four labels carry that middle:
 | `status:merged` | PR merged to main; live verification pending |
 | `status:tested` | Verified live (installed binary, real run); eligible to close |
 
-🔴 **They are mutually exclusive. Advancing removes the prior label in the same
-edit** — two `status:` labels on one issue is a defect, not a history:
+🔴 **They are mutually exclusive. Advance with `tm issue transition`, never by
+hand** — two `status:` labels on one issue is a defect, not a history:
 
 ```bash
-gh issue edit N --add-label status:merged --remove-label status:coded
+tm issue transition N status:merged
 ```
+
+That reads the project's state model (`issue-state.yaml` at the repo root),
+refuses any edge the model does not declare, and issues the `--add-label` and
+`--remove-label` as ONE `gh issue edit`, so the issue is never observed carrying
+two of them.
+
+- `tm issue states` lists the states and legal edges; `tm issue current N`
+  prints where an issue is now.
+- A refusal exits 1 and names the states you may move to instead. An issue that
+  already carries two `status:` labels is refused with `tm issue repair N`,
+  which drops the stale one.
+- Closing needs evidence: `tm issue transition N closed --note "<what you ran
+  and what it printed>"`. Without `--note` the edge is refused.
+- **On a host with no `tm`**, and only there, fall back to a hand-typed edit —
+  both flags in ONE call, never two:
+
+  ```bash
+  gh issue edit N --add-label status:merged --remove-label status:coded
+  ```
 
 ### Claim at dispatch
 
@@ -287,9 +306,12 @@ gh issue edit N --add-label status:merged --remove-label status:coded
 finishes**, together with a dated comment naming the claiming session:
 
 ```bash
-gh issue edit N --add-label status:in-progress
+tm issue transition N status:in-progress
 gh issue comment N --body "Claimed by session <name>, <YYYY-MM-DD> — fix in flight."
 ```
+
+The claim comment stays a separate `gh issue comment` — the transition posts its
+own audit line, which is not the dated claim record.
 
 🔴 **Another session takes a claimed issue only when the claim is provably
 stale**, which means BOTH: the named session is gone, AND nothing referencing
@@ -302,12 +324,13 @@ sessions fixing one issue costs more than one issue sitting still.
 🔴 **Each advance is triggered by an event, and the agent that observed the
 event owes the label pass immediately.** Nothing sweeps for stale labels later.
 
-| Event | Advance to |
+| Event | Command |
 |---|---|
-| PR opened for the fix | `status:coded` |
-| Merge CONFIRMED — `gh pr view <n> --json state` reports `MERGED` | `status:merged` |
-| Live verification evidence in hand | `status:tested` |
-| Closed, with that evidence in the closing comment | — |
+| PR opened for the fix | `tm issue transition N status:coded` |
+| Merge CONFIRMED — `gh pr view <n> --json state` reports `MERGED` | `tm issue transition N status:merged` |
+| Live verification evidence in hand | `tm issue transition N status:tested` |
+| Closing, with that evidence | `tm issue transition N closed --note "<evidence>"` |
+| Claim released — the session is gone and nothing moved | `tm issue transition N open` |
 
 🔴 **A confirmed merge with no label pass is an incomplete step** (learned
 2026-08-31). Auto-merge lands PRs unattended, so nobody is watching at the
@@ -319,7 +342,9 @@ the advance happens then.
 
 🔴 **An issue closes only from `status:tested`, and the closing comment carries
 the live verification evidence** — what was run against the installed artifact
-and what it printed. A merged fix that fails live verification stays open at
+and what it printed. `tm issue transition N closed --note "<evidence>"` enforces
+both halves: the edge exists only from `status:tested`, and it refuses to run
+without the note. A merged fix that fails live verification stays open at
 `status:merged`.
 
 🔴 **A fix PR references `Refs #N`, never `Closes #N`.** A merge must not

--- a/crates/trusty-mpm/changelog.d/6651-issue-status-state-model-changed.md
+++ b/crates/trusty-mpm/changelog.d/6651-issue-status-state-model-changed.md
@@ -1,0 +1,7 @@
+Changed
+- `tm issue states` prints `(no label)` for a label-less state and marks the
+  edges that require a `--note`.
+- The bundled `tm-ticketing` skill replaces every hand-typed
+  `gh issue edit --add-label … --remove-label …` lifecycle example with the
+  `tm issue transition` form, keeping the single-`gh issue edit` fallback for a
+  host without `tm`.

--- a/crates/trusty-mpm/changelog.d/6651-issue-status-state-model.md
+++ b/crates/trusty-mpm/changelog.d/6651-issue-status-state-model.md
@@ -1,0 +1,18 @@
+Added
+- `tm issue` state models can now declare a LABEL-LESS state — one whose only
+  artifact is the absence of every state label — plus a `gh_state:
+  open|closed` per state and a `requires_note: true` per transition. A
+  label-less state is resolved from the issue's own open/closed flag, reaching
+  a `gh_state: closed` state closes the issue, and an edge marked
+  `requires_note` is refused unless `--note` is given. Load-time validation
+  rejects two label-less states sharing one `gh_state`, since nothing could
+  tell them apart.
+- A project-level `issue-state.yaml` at the repo root encoding this
+  workspace's own lifecycle — `open → status:in-progress → status:coded →
+  status:merged → status:tested → closed`, plus the release-a-claim and reopen
+  edges back to `open`. `tm issue transition <n> <state>` run from the repo
+  root now performs each advance as ONE `gh issue edit` carrying both
+  `--add-label` and `--remove-label`, so an issue can never be observed
+  carrying two `status:*` labels; an undeclared edge exits 1 naming the states
+  you may move to, and an issue that already carries two is refused with a
+  pointer to `tm issue repair <n>`.

--- a/crates/trusty-mpm/src/assets/skills/tm-ticketing.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-ticketing.md
@@ -230,10 +230,17 @@ GitHub's native `open` and `closed`:
 | `status:merged` | PR merged to main; live verification pending |
 | `status:tested` | Verified live (installed binary, real run); eligible to close |
 
-Advancing a state removes the prior label in the same edit —
-`gh issue edit N --add-label status:merged --remove-label status:coded`. Two
-`status:` labels on one issue is a defect. The `ticketing` agent runs every one
-of these edits; the PM never runs `gh issue` itself.
+Advance with `tm issue transition N status:merged`, never a hand-typed label
+swap. It reads the project's state model (`issue-state.yaml` at the repo root),
+refuses any edge the model does not declare with exit 1 and the list of states
+you may move to, and issues the `--add-label` and `--remove-label` as ONE
+`gh issue edit`. Two `status:` labels on one issue is a defect the tool makes
+unreachable; an issue that already has two is refused with a pointer to
+`tm issue repair N`. `tm issue states` lists the model, `tm issue current N`
+reads an issue's state back. On a host with no `tm` — and only there — fall back
+to `gh issue edit N --add-label status:merged --remove-label status:coded`, both
+flags in one call. The `ticketing` agent runs every one of these; the PM never
+runs `gh issue` or `tm issue` itself.
 
 **Claim at dispatch.** `status:in-progress` goes on when the work is dispatched,
 with a dated comment naming the claiming session ("Claimed by session `<name>`,
@@ -245,11 +252,12 @@ not enough. When in doubt, leave it.
 **Advances are event-driven, not swept.** The agent that observed the event owes
 the label pass then and there:
 
-| Event | Advance to |
+| Event | Command |
 |---|---|
-| PR opened for the fix | `status:coded` |
-| Merge CONFIRMED (`gh pr view <n> --json state` reports `MERGED`) | `status:merged` |
-| Live verification evidence in hand | `status:tested` |
+| PR opened for the fix | `tm issue transition N status:coded` |
+| Merge CONFIRMED (`gh pr view <n> --json state` reports `MERGED`) | `tm issue transition N status:merged` |
+| Live verification evidence in hand | `tm issue transition N status:tested` |
+| Claim released — session gone, nothing moved | `tm issue transition N open` |
 
 A confirmed merge with no label pass is an incomplete step, not a tidy-up for
 later (learned 2026-08-31: auto-merge lands PRs unattended, so nothing is
@@ -259,8 +267,10 @@ confirmed merge and flags the advance it owes; the PM routes that report to
 
 **The close bar.** An issue closes only from `status:tested`, with the live
 verification evidence in the closing comment — what ran against the installed
-artifact and what it printed. A merged fix that fails live verification stays
-open at `status:merged`. A fix PR carries `Refs #N`, never `Closes #N`, so a
+artifact and what it printed: `tm issue transition N closed --note "<evidence>"`.
+The model declares that edge only from `status:tested` and marks it
+`requires_note`, so a close without evidence is refused. A merged fix that fails
+live verification stays open at `status:merged`. A fix PR carries `Refs #N`, never `Closes #N`, so a
 merge cannot auto-close something nobody has verified.
 
 **Comments along the way.** A progress comment at each meaningful transition —

--- a/crates/trusty-mpm/src/bin/tm/commands/issue/config.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/issue/config.rs
@@ -94,14 +94,39 @@ pub(crate) struct LabelConfig {
 pub(crate) struct StateDef {
     /// Machine state name (e.g. `queued`).
     pub(crate) name: String,
-    /// The GitHub label representing this state.
-    pub(crate) label: StateLabel,
+    /// The GitHub label representing this state, or `None` for a *label-less*
+    /// state — one whose only artifact is the ABSENCE of every state label
+    /// (e.g. trusty-tools' `open`, and `closed` which is GitHub's own state).
+    #[serde(default)]
+    pub(crate) label: Option<StateLabel>,
+    /// Whether this state means the GitHub issue is open or closed.
+    #[serde(default)]
+    pub(crate) gh_state: GhState,
     /// Optional display/sort ordering (informational; does not gate transitions).
     #[serde(default)]
     pub(crate) order: Option<u32>,
     /// `true` for terminal states (no outbound edges allowed).
     #[serde(default)]
     pub(crate) terminal: bool,
+}
+
+/// Whether a state corresponds to an open or a closed GitHub issue.
+///
+/// Why: a lifecycle can end by CLOSING the issue rather than by labelling it
+/// (trusty-tools' `status:tested → closed`). Recording that on the state lets
+/// `tm issue transition` close the issue, and lets a label-less state be
+/// resolved from the issue's own open/closed flag rather than from a label.
+/// What: `Open` (the default, so every pre-existing model keeps its meaning)
+/// and `Closed`.
+/// Test: `project_model_closed_state_is_gh_closed` in `project_model_tests.rs`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum GhState {
+    /// The issue is open (every labelled lifecycle state).
+    #[default]
+    Open,
+    /// The issue is closed.
+    Closed,
 }
 
 /// A state's GitHub label (name + color + description).
@@ -153,6 +178,10 @@ pub(crate) struct Transition {
     pub(crate) to: String,
     /// What drives this edge.
     pub(crate) trigger: Trigger,
+    /// When `true`, `tm issue transition` refuses this edge unless `--note` is
+    /// given — the note is the evidence the edge exists to record.
+    #[serde(default)]
+    pub(crate) requires_note: bool,
     /// Optional human description.
     #[serde(default)]
     pub(crate) description: String,

--- a/crates/trusty-mpm/src/bin/tm/commands/issue/config.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/issue/config.rs
@@ -118,7 +118,8 @@ pub(crate) struct StateDef {
 /// resolved from the issue's own open/closed flag rather than from a label.
 /// What: `Open` (the default, so every pre-existing model keeps its meaning)
 /// and `Closed`.
-/// Test: `project_model_closed_state_is_gh_closed` in `project_model_tests.rs`.
+/// Test: `sm_closes_issue`, `sm_resolve_falls_back_to_labelless`,
+/// `project_close_requires_evidence_and_then_closes`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum GhState {

--- a/crates/trusty-mpm/src/bin/tm/commands/issue/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/issue/mod.rs
@@ -18,6 +18,10 @@ pub(crate) mod ops;
 pub(crate) mod state;
 pub(crate) mod validate;
 
+#[cfg(test)]
+#[path = "project_model_tests.rs"]
+mod project_model_tests;
+
 use std::path::PathBuf;
 
 use crate::cli::IssueCmd;
@@ -118,18 +122,26 @@ fn print_seed_report(report: &ops::SeedReport) {
 /// Print the configured states and transitions.
 ///
 /// Why: operator introspection of the active model (reads YAML only, no `gh`).
-/// What: lists each state (label, terminal flag) then each transition edge.
+/// What: lists each state (its label, or `(no label)` for a label-less state,
+/// plus the terminal flag) then each transition edge, marking the edges that
+/// require a `--note`.
 /// Test: side-effect-only (stdout); the model is unit-tested in `config`.
 fn print_states(model: &StateModel) {
     println!("states ({}):", model.states.len());
     for s in &model.states {
         let term = if s.terminal { " [terminal]" } else { "" };
-        println!("  {} → {}{}", s.name, s.label.name, term);
+        let label = s.label.as_ref().map_or("(no label)", |l| l.name.as_str());
+        println!("  {} → {}{}", s.name, label, term);
     }
     println!("transitions ({}):", model.transitions.len());
     for t in &model.transitions {
         let from = t.from.as_deref().unwrap_or("null");
-        println!("  {from} → {} ({:?})", t.to, t.trigger);
+        let note = if t.requires_note {
+            " [--note required]"
+        } else {
+            ""
+        };
+        println!("  {from} → {} ({:?}){note}", t.to, t.trigger);
     }
 }
 

--- a/crates/trusty-mpm/src/bin/tm/commands/issue/ops.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/issue/ops.rs
@@ -59,10 +59,12 @@ fn declared_labels(model: &StateModel) -> Vec<RepoLabel> {
     let mut out: Vec<RepoLabel> = model
         .states
         .iter()
-        .map(|s| RepoLabel {
-            name: s.label.name.clone(),
-            color: s.label.color.clone(),
-            description: s.label.description.clone(),
+        // A label-less state (`open`, `closed`) has nothing to seed.
+        .filter_map(|s| s.label.as_ref())
+        .map(|l| RepoLabel {
+            name: l.name.clone(),
+            color: l.color.clone(),
+            description: l.description.clone(),
         })
         .collect();
     out.extend(model.extra_labels.iter().map(|l| RepoLabel {
@@ -114,13 +116,17 @@ pub(crate) fn seed_labels<S: TicketSystem>(
 /// (visibility + safety), perform the swap in one call, apply the per-state
 /// assignee rule, and post an audit comment so the change is reconstructable.
 /// What: resolves `<to>` to a known state; fetches the issue; resolves the
-/// current state from its labels (erroring clearly on zero/multiple); checks the
-/// `from → to` edge; performs the single-call swap (`swap_labels`); applies the
-/// assignee rule via `set_assignee` (no-op for the factory `unchanged` rules);
-/// and posts an audit comment with any `note`. Returns a [`TransitionReport`].
-/// Test: `ops_transition_happy_path`, `ops_transition_rejects_invalid`,
+/// current state from its labels and open/closed flag (erroring clearly on
+/// multiple); checks the `from → to` edge; refuses an edge whose
+/// `requires_note` is set when no `--note` was given; performs the single-call
+/// swap (`swap_labels`), or a plain add/remove when one end is label-less;
+/// applies the assignee rule via `set_assignee` (no-op for the factory
+/// `unchanged` rules); posts an audit comment with any `note`; and closes the
+/// issue when the target state IS GitHub's closed state. Returns a
+/// [`TransitionReport`].
+/// Test: `ops_transition_happy_path`, `ops_transition_rejects_invalid_terminal`,
 /// `ops_transition_rejects_zero_state`, `ops_transition_rejects_multi_state`,
-/// `ops_transition_assignee_unchanged`.
+/// plus `project_*` in `project_model_tests.rs`.
 pub(crate) fn transition<S: TicketSystem>(
     sys: &S,
     model: &StateModel,
@@ -140,7 +146,7 @@ pub(crate) fn transition<S: TicketSystem>(
 
     // 2. Fetch the issue and resolve its current state from labels.
     let issue_obj = sys.validate(issue)?;
-    let from: Option<String> = match sm.resolve_current_state(&issue_obj.labels) {
+    let from: Option<String> = match sm.resolve_current_state(&issue_obj.labels, issue_obj.open) {
         CurrentState::One(s) => Some(s.to_string()),
         CurrentState::None => None,
         CurrentState::Many(states) => {
@@ -161,17 +167,31 @@ pub(crate) fn transition<S: TicketSystem>(
         );
     }
 
-    // 4. Atomic label swap (single-call default). The creation edge (from=None)
-    //    only adds the entry label.
-    let to_label = sm
-        .state_label(to)
-        .ok_or_else(|| anyhow::anyhow!("internal: state `{to}` has no label"))?;
-    match from.as_deref().and_then(|f| sm.state_label(f)) {
-        Some(from_label) => sys.swap_labels(issue, to_label, from_label)?,
-        None => sys.add_label(issue, to_label)?,
+    // 4. The edge requires evidence and none was given → refuse before any
+    //    mutation (trusty-tools closes an issue only with live-verification
+    //    evidence in the comment).
+    let note = note.filter(|n| !n.trim().is_empty());
+    if sm.requires_note(from.as_deref(), to) && note.is_none() {
+        let from_disp = from.as_deref().unwrap_or("null");
+        anyhow::bail!(
+            "transition {from_disp} → {to} requires evidence; \
+             re-run with `--note \"<what proves it>\"`"
+        );
     }
 
-    // 5. Apply the per-state assignee rule (no-op for factory `unchanged`).
+    // 5. The label mutation, always ONE call when both ends are labelled, so an
+    //    issue can never be observed carrying two state labels.
+    let to_label = sm.state_label(to);
+    let from_label = from.as_deref().and_then(|f| sm.state_label(f));
+    match (to_label, from_label) {
+        (Some(add), Some(remove)) => sys.swap_labels(issue, add, remove)?,
+        (Some(add), None) => sys.add_label(issue, add)?,
+        // Moving to a label-less state (`open`, `closed`) drops the old label.
+        (None, Some(remove)) => sys.remove_label(issue, remove)?,
+        (None, None) => {}
+    }
+
+    // 6. Apply the per-state assignee rule (no-op for factory `unchanged`).
     let mut assignee_changed = false;
     if let Some(target) = sm.assignee_target_for(to) {
         // The `None` clear-all rule needs the current assignee set (read side).
@@ -184,7 +204,8 @@ pub(crate) fn transition<S: TicketSystem>(
         assignee_changed = true;
     }
 
-    // 6. Audit comment (visibility): record from → to + any note.
+    // 7. Audit comment (visibility): record from → to + any note. Posted BEFORE
+    //    any close so the evidence lands on an issue that is still open.
     let from_disp = from.as_deref().unwrap_or("(none)");
     let mut body = format!("tm issue transition: `{from_disp}` → `{to}`");
     if assignee_changed {
@@ -195,6 +216,11 @@ pub(crate) fn transition<S: TicketSystem>(
         body.push_str(n);
     }
     sys.comment(issue, &body)?;
+
+    // 8. A state that IS GitHub's closed state closes the issue.
+    if sm.closes_issue(to) {
+        sys.close_issue(issue)?;
+    }
 
     Ok(TransitionReport {
         from,
@@ -217,7 +243,7 @@ pub(crate) fn current<S: TicketSystem>(
 ) -> anyhow::Result<String> {
     let sm = StateMachine::new(model);
     let issue_obj = sys.validate(issue)?;
-    match sm.resolve_current_state(&issue_obj.labels) {
+    match sm.resolve_current_state(&issue_obj.labels, issue_obj.open) {
         CurrentState::One(s) => Ok(s.to_string()),
         CurrentState::None => anyhow::bail!(
             "issue #{issue} carries no recognised state label; valid states: [{}]",
@@ -248,7 +274,7 @@ pub(crate) fn repair<S: TicketSystem>(
 ) -> anyhow::Result<String> {
     let sm = StateMachine::new(model);
     let issue_obj = sys.validate(issue)?;
-    let present: Vec<&str> = match sm.resolve_current_state(&issue_obj.labels) {
+    let present: Vec<&str> = match sm.resolve_current_state(&issue_obj.labels, issue_obj.open) {
         CurrentState::One(s) => {
             // Nothing to repair — already a single, unambiguous state.
             return Ok(s.to_string());

--- a/crates/trusty-mpm/src/bin/tm/commands/issue/ops_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/issue/ops_tests.rs
@@ -181,10 +181,11 @@ fn ops_seed_idempotent_when_all_present() {
         let mut v: Vec<RepoLabel> = m
             .states
             .iter()
-            .map(|s| RepoLabel {
-                name: s.label.name.clone(),
-                color: s.label.color.clone(),
-                description: s.label.description.clone(),
+            .filter_map(|s| s.label.as_ref())
+            .map(|l| RepoLabel {
+                name: l.name.clone(),
+                color: l.color.clone(),
+                description: l.description.clone(),
             })
             .collect();
         v.extend(m.extra_labels.iter().map(|l| RepoLabel {

--- a/crates/trusty-mpm/src/bin/tm/commands/issue/project_model_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/issue/project_model_tests.rs
@@ -1,0 +1,361 @@
+//! Tests binding `tm issue` to THIS repo's own lifecycle model.
+//!
+//! Why: the four `status:*` labels are mutually exclusive, and the only thing
+//! that made that true was an agent remembering to pass `--add-label` and
+//! `--remove-label` in one `gh issue edit`. These tests pin the repo-root
+//! `issue-state.yaml` to the exact edge set CLAUDE.md documents (an extra or a
+//! missing edge FAILS), and prove the label swap reaches `gh` as ONE call.
+//! What: [`project_model`] loads the real YAML; the `project_*` tests assert the
+//! edge set, the single-call swap through a fake `gh` (no network), the
+//! two-label refusal, and the evidence-required close.
+//! Test: this IS the test module (classified test file: 3000-SLOC cap).
+
+use std::cell::RefCell;
+
+use super::config::StateModel;
+use super::ops;
+use super::state::{CurrentState, StateMachine};
+use crate::commands::ticket::runner::{CommandOutput, CommandRunner};
+use crate::commands::ticket::system::GhTicketSystem;
+
+/// Load + validate the repo-root `issue-state.yaml` — the file `tm issue`'s
+/// CWD tier reads.
+///
+/// A deleted, renamed, unparseable, or invalid model fails every test in this
+/// file rather than skipping them.
+fn project_model() -> StateModel {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join("issue-state.yaml");
+    let yaml =
+        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    let model: StateModel = serde_yaml::from_str(&yaml).expect("repo-root issue-state.yaml parses");
+    super::validate::validate_model(&model).expect("repo-root issue-state.yaml is valid");
+    model
+}
+
+/// The lifecycle CLAUDE.md documents, as `(from, to)` pairs.
+///
+/// `open` and `closed` are label-less; the middle four are the mutually
+/// exclusive `status:*` labels.
+const EXPECTED_EDGES: &[(&str, &str)] = &[
+    // Forward, one rung at a time.
+    ("open", "status:in-progress"),
+    ("status:in-progress", "status:coded"),
+    ("status:coded", "status:merged"),
+    ("status:merged", "status:tested"),
+    ("status:tested", "closed"),
+    // Release a claim, and reopen from anywhere.
+    ("status:in-progress", "open"),
+    ("status:coded", "open"),
+    ("status:merged", "open"),
+    ("status:tested", "open"),
+    ("closed", "open"),
+];
+
+#[test]
+fn project_model_declares_the_documented_states() {
+    let m = project_model();
+    let names: Vec<&str> = m.states.iter().map(|s| s.name.as_str()).collect();
+    assert_eq!(
+        names,
+        vec![
+            "open",
+            "status:in-progress",
+            "status:coded",
+            "status:merged",
+            "status:tested",
+            "closed",
+        ]
+    );
+    // `open` and `closed` are the absence of a label; the rest carry theirs.
+    let sm = StateMachine::new(&m);
+    assert_eq!(sm.state_label("open"), None);
+    assert_eq!(sm.state_label("closed"), None);
+    assert_eq!(sm.state_label("status:coded"), Some("status:coded"));
+    assert!(sm.closes_issue("closed"));
+    assert!(!sm.closes_issue("open"));
+}
+
+#[test]
+fn project_model_declares_exactly_the_documented_edges() {
+    let m = project_model();
+    let mut actual: Vec<(&str, &str)> = m
+        .transitions
+        .iter()
+        .map(|t| (t.from.as_deref().unwrap_or("null"), t.to.as_str()))
+        .collect();
+    let mut expected: Vec<(&str, &str)> = EXPECTED_EDGES.to_vec();
+    actual.sort_unstable();
+    expected.sort_unstable();
+    // An EXTRA or a MISSING edge fails here, naming both sides.
+    assert_eq!(
+        actual, expected,
+        "issue-state.yaml's edge set drifted from the lifecycle in CLAUDE.md"
+    );
+}
+
+#[test]
+fn project_model_rejects_skipping_a_rung() {
+    let m = project_model();
+    let sm = StateMachine::new(&m);
+    // Every non-adjacent forward move is absent from the graph.
+    assert!(!sm.transition_allowed(Some("open"), "status:coded"));
+    assert!(!sm.transition_allowed(Some("status:in-progress"), "status:merged"));
+    assert!(!sm.transition_allowed(Some("status:coded"), "status:tested"));
+    assert!(!sm.transition_allowed(Some("status:merged"), "closed"));
+}
+
+#[test]
+fn project_model_resolves_an_unlabelled_open_issue_as_open() {
+    let m = project_model();
+    let sm = StateMachine::new(&m);
+    let labels = vec!["bug".to_string(), "P1".to_string()];
+    assert_eq!(
+        sm.resolve_current_state(&labels, true),
+        CurrentState::One("open")
+    );
+}
+
+// ---- injected `gh` (no network) --------------------------------------------
+
+/// A scripted [`CommandRunner`] standing in for the `gh` binary.
+///
+/// Returns queued outputs in order and records every `(program, args)` so a
+/// test can assert what reached `gh` — including that a label swap was ONE
+/// invocation carrying both flags.
+struct FakeGh {
+    outputs: RefCell<Vec<CommandOutput>>,
+    calls: RefCell<Vec<Vec<String>>>,
+}
+
+impl FakeGh {
+    fn new(outputs: Vec<CommandOutput>) -> Self {
+        Self {
+            outputs: RefCell::new(outputs),
+            calls: RefCell::new(Vec::new()),
+        }
+    }
+    fn calls(&self) -> Vec<Vec<String>> {
+        self.calls.borrow().clone()
+    }
+}
+
+impl CommandRunner for FakeGh {
+    fn run(&self, program: &str, args: &[&str]) -> anyhow::Result<CommandOutput> {
+        let mut argv = vec![program.to_string()];
+        argv.extend(args.iter().map(|a| (*a).to_string()));
+        self.calls.borrow_mut().push(argv);
+        let mut queued = self.outputs.borrow_mut();
+        if queued.is_empty() {
+            return Ok(ok_out(""));
+        }
+        Ok(queued.remove(0))
+    }
+}
+
+fn ok_out(stdout: &str) -> CommandOutput {
+    CommandOutput {
+        success: true,
+        stdout: stdout.to_string(),
+        stderr: String::new(),
+    }
+}
+
+/// The `gh issue view --json …` payload for an open issue carrying `labels`.
+fn issue_json(number: u64, labels: &[&str]) -> String {
+    let labels: Vec<String> = labels
+        .iter()
+        .map(|l| format!("{{\"name\":\"{l}\"}}"))
+        .collect();
+    format!(
+        "{{\"number\":{number},\"title\":\"t\",\"body\":\"\",\"state\":\"OPEN\",\
+         \"labels\":[{}],\"assignees\":[]}}",
+        labels.join(",")
+    )
+}
+
+#[test]
+fn project_transition_coded_to_merged_is_one_gh_edit_with_both_flags() {
+    let m = project_model();
+    // 1: `gh issue view`; the rest default to a bare success.
+    let gh = FakeGh::new(vec![ok_out(&issue_json(1234, &["status:coded"]))]);
+    let sys = GhTicketSystem::new(gh);
+
+    let report = ops::transition(&sys, &m, 1234, "status:merged", None).expect("transition");
+    assert_eq!(report.from.as_deref(), Some("status:coded"));
+    assert_eq!(report.to, "status:merged");
+
+    let edits: Vec<Vec<String>> = sys
+        .runner()
+        .calls()
+        .into_iter()
+        .filter(|c| {
+            c.get(1).map(String::as_str) == Some("issue")
+                && c.get(2).map(String::as_str) == Some("edit")
+        })
+        .collect();
+    assert_eq!(
+        edits.len(),
+        1,
+        "the swap must be ONE gh issue edit: {edits:?}"
+    );
+    let edit = &edits[0];
+    let pos = |flag: &str, value: &str| edit.windows(2).any(|w| w[0] == flag && w[1] == value);
+    assert!(
+        pos("--add-label", "status:merged"),
+        "missing --add-label status:merged in {edit:?}"
+    );
+    assert!(
+        pos("--remove-label", "status:coded"),
+        "missing --remove-label status:coded in {edit:?}"
+    );
+    // No separate add/remove call could have left two labels visible.
+    assert!(
+        !sys.runner()
+            .calls()
+            .iter()
+            .any(|c| c.get(2).map(String::as_str) == Some("close")),
+        "merging does not close the issue"
+    );
+}
+
+#[test]
+fn project_transition_refuses_two_status_labels_and_names_repair() {
+    let m = project_model();
+    let gh = FakeGh::new(vec![ok_out(&issue_json(
+        1234,
+        &["status:coded", "status:merged"],
+    ))]);
+    let sys = GhTicketSystem::new(gh);
+
+    let err = ops::transition(&sys, &m, 1234, "status:tested", None)
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("multiple state labels"), "got: {err}");
+    assert!(
+        err.contains("tm issue repair 1234"),
+        "must name the repair command, got: {err}"
+    );
+    // Nothing was mutated: the only gh call is the read.
+    let calls = sys.runner().calls();
+    assert_eq!(calls.len(), 1, "must not mutate on refusal: {calls:?}");
+    assert_eq!(calls[0].get(2).map(String::as_str), Some("view"));
+}
+
+#[test]
+fn project_repair_resolves_two_status_labels_to_the_later_one() {
+    let m = project_model();
+    let gh = FakeGh::new(vec![ok_out(&issue_json(
+        1234,
+        &["status:coded", "status:merged"],
+    ))]);
+    let sys = GhTicketSystem::new(gh);
+
+    let kept = ops::repair(&sys, &m, 1234).expect("repair");
+    assert_eq!(kept, "status:merged", "keeps the more advanced state");
+    let removed: Vec<Vec<String>> = sys
+        .runner()
+        .calls()
+        .into_iter()
+        .filter(|c| c.iter().any(|a| a == "--remove-label"))
+        .collect();
+    assert_eq!(removed.len(), 1, "one removal: {removed:?}");
+    assert!(
+        removed[0].iter().any(|a| a == "status:coded"),
+        "must remove the stale label, got {:?}",
+        removed[0]
+    );
+}
+
+#[test]
+fn project_close_requires_evidence_and_then_closes() {
+    let m = project_model();
+
+    // Without --note the edge is refused before any mutation.
+    let gh = FakeGh::new(vec![ok_out(&issue_json(1234, &["status:tested"]))]);
+    let sys = GhTicketSystem::new(gh);
+    let err = ops::transition(&sys, &m, 1234, "closed", None)
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("requires evidence"), "got: {err}");
+    assert!(err.contains("--note"), "got: {err}");
+    assert_eq!(sys.runner().calls().len(), 1, "read only");
+
+    // With --note it drops the label, comments the evidence, then closes.
+    let gh = FakeGh::new(vec![ok_out(&issue_json(1234, &["status:tested"]))]);
+    let sys = GhTicketSystem::new(gh);
+    ops::transition(&sys, &m, 1234, "closed", Some("tm 0.9.1 live run: OK"))
+        .expect("transition with evidence");
+    let verbs: Vec<String> = sys
+        .runner()
+        .calls()
+        .iter()
+        .filter_map(|c| c.get(2).cloned())
+        .collect();
+    assert_eq!(
+        verbs,
+        vec!["view", "edit", "comment", "close"],
+        "got {verbs:?}"
+    );
+    let comment = sys
+        .runner()
+        .calls()
+        .into_iter()
+        .find(|c| c.get(2).map(String::as_str) == Some("comment"))
+        .expect("comment call");
+    assert!(
+        comment.iter().any(|a| a.contains("tm 0.9.1 live run: OK")),
+        "the evidence must reach the issue, got {comment:?}"
+    );
+}
+
+#[test]
+fn project_release_a_claim_removes_the_label_without_closing() {
+    let m = project_model();
+    let gh = FakeGh::new(vec![ok_out(&issue_json(1234, &["status:in-progress"]))]);
+    let sys = GhTicketSystem::new(gh);
+
+    let report = ops::transition(&sys, &m, 1234, "open", Some("claim stale")).expect("release");
+    assert_eq!(report.to, "open");
+    let verbs: Vec<String> = sys
+        .runner()
+        .calls()
+        .iter()
+        .filter_map(|c| c.get(2).cloned())
+        .collect();
+    assert_eq!(verbs, vec!["view", "edit", "comment"], "got {verbs:?}");
+    let edit = sys
+        .runner()
+        .calls()
+        .into_iter()
+        .find(|c| c.get(2).map(String::as_str) == Some("edit"))
+        .expect("edit call");
+    assert!(
+        edit.windows(2)
+            .any(|w| w[0] == "--remove-label" && w[1] == "status:in-progress"),
+        "got {edit:?}"
+    );
+    assert!(
+        !edit.iter().any(|a| a == "--add-label"),
+        "`open` has no label to add, got {edit:?}"
+    );
+}
+
+#[test]
+fn project_seed_labels_skips_the_labelless_states() {
+    let m = project_model();
+    let gh = FakeGh::new(vec![ok_out("[]")]);
+    let sys = GhTicketSystem::new(gh);
+    let report = ops::seed_labels(&sys, &m, true).expect("seed dry-run");
+    assert_eq!(
+        report.created,
+        vec![
+            "status:in-progress".to_string(),
+            "status:coded".to_string(),
+            "status:merged".to_string(),
+            "status:tested".to_string(),
+        ],
+        "only the four labelled states are seeded"
+    );
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/issue/state.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/issue/state.rs
@@ -6,11 +6,12 @@
 //! `ops.rs` focused on the `gh` orchestration and keeps the pure logic unit-
 //! testable without a runner.
 //! What: [`StateMachine`] wrapping a `&StateModel` with `transition_allowed`,
-//! `resolve_current_state` (from an issue's labels), `state_label`,
-//! `assignee_target_for`, and `allowed_targets_from`.
+//! `resolve_current_state` (from an issue's labels and open/closed flag),
+//! `state_label`, `closes_issue`, `requires_note`, `assignee_target_for`, and
+//! `allowed_targets_from`.
 //! Test: the `sm_*` tests in this file.
 
-use super::config::StateModel;
+use super::config::{GhState, StateModel};
 use crate::commands::ticket::labels::AssigneeTarget;
 
 /// A read-only state-machine view over a validated model.
@@ -34,17 +35,50 @@ impl<'a> StateMachine<'a> {
         Self { model }
     }
 
-    /// The GitHub label for a state name, if the state exists.
+    /// The GitHub label for a state name, if the state exists AND is labelled.
     ///
     /// Why: the transition swap and seeding need the visible label for a state.
-    /// What: linear lookup by state name → `&label.name`.
-    /// Test: `sm_state_label`.
+    /// What: linear lookup by state name → `&label.name`. Returns `None` both
+    /// for an unknown state and for a label-less one; callers that need to tell
+    /// those apart pair it with [`Self::is_state`].
+    /// Test: `sm_state_label`, `sm_state_label_none_for_labelless`.
     pub(crate) fn state_label(&self, state: &str) -> Option<&'a str> {
         self.model
             .states
             .iter()
             .find(|s| s.name == state)
-            .map(|s| s.label.name.as_str())
+            .and_then(|s| s.label.as_ref())
+            .map(|l| l.name.as_str())
+    }
+
+    /// Whether reaching `state` means the GitHub issue must be closed.
+    ///
+    /// Why: a lifecycle can end by closing the issue rather than by labelling
+    /// it, and `tm issue transition` performs that close.
+    /// What: looks the state up and compares its `gh_state` to `Closed`; an
+    /// unknown state is not closing.
+    /// Test: `sm_closes_issue`.
+    pub(crate) fn closes_issue(&self, state: &str) -> bool {
+        self.model
+            .states
+            .iter()
+            .any(|s| s.name == state && s.gh_state == GhState::Closed)
+    }
+
+    /// Whether the `from → to` edge refuses to run without a `--note`.
+    ///
+    /// Why: some edges exist to RECORD something (trusty-tools closes an issue
+    /// only with live-verification evidence). Making the note a model property
+    /// keeps that rule in the YAML instead of in prose.
+    /// What: finds the matching edge and returns its `requires_note`; an edge
+    /// that is not in the graph never requires a note (the edge check rejects
+    /// it first anyway).
+    /// Test: `sm_requires_note`.
+    pub(crate) fn requires_note(&self, from: Option<&str>, to: &str) -> bool {
+        self.model
+            .transitions
+            .iter()
+            .any(|t| t.from.as_deref() == from && t.to == to && t.requires_note)
     }
 
     /// Whether `state` is a known state name.
@@ -93,28 +127,60 @@ impl<'a> StateMachine<'a> {
             .collect()
     }
 
-    /// Resolve the issue's current state from the labels present on it.
+    /// Resolve the issue's current state from its labels and open/closed flag.
     ///
-    /// Why: the visibility north star requires exactly one state label; this
-    /// reconstructs state from GitHub artifacts alone. Zero or multiple matches
-    /// is surfaced as an error (the caller turns `Multiple` into a `repair`
-    /// hint).
-    /// What: intersects the issue's labels with the state labels and classifies
-    /// the result as `None` / `One` / `Many`.
-    /// Test: `sm_resolve_one`, `sm_resolve_none`, `sm_resolve_many`.
-    pub(crate) fn resolve_current_state(&self, issue_labels: &[String]) -> CurrentState<'a> {
+    /// Why: the visibility north star requires exactly one state; this
+    /// reconstructs it from GitHub artifacts alone. Multiple matches is
+    /// surfaced as an error (the caller turns `Many` into a `repair` hint).
+    /// What: intersects the issue's labels with the state labels. On zero
+    /// matches it falls back to the model's label-less state for the issue's
+    /// open/closed flag (trusty-tools' `open`), and only reports `None` when
+    /// the model declares no such state.
+    /// Test: `sm_resolve_one`, `sm_resolve_none`, `sm_resolve_many`,
+    /// `sm_resolve_falls_back_to_labelless`.
+    pub(crate) fn resolve_current_state(
+        &self,
+        issue_labels: &[String],
+        gh_open: bool,
+    ) -> CurrentState<'a> {
         let matches: Vec<&'a str> = self
             .model
             .states
             .iter()
-            .filter(|s| issue_labels.iter().any(|l| l == &s.label.name))
+            .filter(|s| {
+                s.label
+                    .as_ref()
+                    .is_some_and(|lbl| issue_labels.iter().any(|l| l == &lbl.name))
+            })
             .map(|s| s.name.as_str())
             .collect();
         match matches.len() {
-            0 => CurrentState::None,
+            0 => self
+                .labelless_state(gh_open)
+                .map_or(CurrentState::None, CurrentState::One),
             1 => CurrentState::One(matches[0]),
             _ => CurrentState::Many(matches),
         }
+    }
+
+    /// The label-less state for an open (or closed) issue, if the model has one.
+    ///
+    /// Why: `open` and `closed` have no label of their own, so they are named
+    /// by the issue's own open/closed flag. Validation guarantees at most one
+    /// such state per flag, so the first match is the only match.
+    /// What: finds the first state with no label whose `gh_state` matches.
+    /// Test: `sm_resolve_falls_back_to_labelless`.
+    fn labelless_state(&self, gh_open: bool) -> Option<&'a str> {
+        let want = if gh_open {
+            GhState::Open
+        } else {
+            GhState::Closed
+        };
+        self.model
+            .states
+            .iter()
+            .find(|s| s.label.is_none() && s.gh_state == want)
+            .map(|s| s.name.as_str())
     }
 
     /// The effective assignee rule for a target state.
@@ -242,7 +308,7 @@ mod tests {
         let sm = StateMachine::new(&m);
         let labels = vec!["unicorn".to_string(), "unicorn:approved".to_string()];
         assert_eq!(
-            sm.resolve_current_state(&labels),
+            sm.resolve_current_state(&labels, true),
             CurrentState::One("approved")
         );
     }
@@ -252,7 +318,8 @@ mod tests {
         let m = model();
         let sm = StateMachine::new(&m);
         let labels = vec!["unicorn".to_string(), "blast:high".to_string()];
-        assert_eq!(sm.resolve_current_state(&labels), CurrentState::None);
+        // The factory model has no label-less state, so zero matches is `None`.
+        assert_eq!(sm.resolve_current_state(&labels, true), CurrentState::None);
     }
 
     #[test]
@@ -260,12 +327,79 @@ mod tests {
         let m = model();
         let sm = StateMachine::new(&m);
         let labels = vec!["unicorn:queued".to_string(), "unicorn:approved".to_string()];
-        match sm.resolve_current_state(&labels) {
+        match sm.resolve_current_state(&labels, true) {
             CurrentState::Many(v) => {
                 assert!(v.contains(&"queued") && v.contains(&"approved"));
             }
             other => panic!("expected Many, got {other:?}"),
         }
+    }
+
+    /// A two-label-less-state model mirroring trusty-tools' `open`/`closed`.
+    fn labelless_model() -> StateModel {
+        let yaml = r#"
+version: 1
+label_config: { base: "", approved: "", blast_prefix: "", status_prefix: "s:" }
+states:
+  - { name: open, gh_state: open, order: 0 }
+  - { name: "s:working", label: { name: "s:working", color: "AABBCC" }, order: 1 }
+  - { name: closed, gh_state: closed, order: 2 }
+transitions:
+  - { from: open, to: "s:working", trigger: executor_start }
+  - { from: "s:working", to: closed, trigger: human_label, requires_note: true }
+  - { from: "s:working", to: open, trigger: human_label }
+assignee_model: { strategy: unchanged, per_state: {} }
+"#;
+        serde_yaml::from_str(yaml).expect("label-less model parses")
+    }
+
+    #[test]
+    fn sm_state_label_none_for_labelless() {
+        let m = labelless_model();
+        let sm = StateMachine::new(&m);
+        assert_eq!(sm.state_label("open"), None);
+        assert!(sm.is_state("open"), "label-less states are still states");
+        assert_eq!(sm.state_label("s:working"), Some("s:working"));
+    }
+
+    #[test]
+    fn sm_resolve_falls_back_to_labelless() {
+        let m = labelless_model();
+        let sm = StateMachine::new(&m);
+        // No state label + issue open → the label-less `open` state.
+        assert_eq!(
+            sm.resolve_current_state(&["chore".to_string()], true),
+            CurrentState::One("open")
+        );
+        // No state label + issue closed → the label-less `closed` state.
+        assert_eq!(
+            sm.resolve_current_state(&["chore".to_string()], false),
+            CurrentState::One("closed")
+        );
+        // A state label still wins over the flag.
+        assert_eq!(
+            sm.resolve_current_state(&["s:working".to_string()], true),
+            CurrentState::One("s:working")
+        );
+    }
+
+    #[test]
+    fn sm_closes_issue() {
+        let m = labelless_model();
+        let sm = StateMachine::new(&m);
+        assert!(sm.closes_issue("closed"));
+        assert!(!sm.closes_issue("open"));
+        assert!(!sm.closes_issue("s:working"));
+        assert!(!sm.closes_issue("nonexistent"));
+    }
+
+    #[test]
+    fn sm_requires_note() {
+        let m = labelless_model();
+        let sm = StateMachine::new(&m);
+        assert!(sm.requires_note(Some("s:working"), "closed"));
+        assert!(!sm.requires_note(Some("s:working"), "open"));
+        assert!(!sm.requires_note(Some("open"), "s:working"));
     }
 
     #[test]

--- a/crates/trusty-mpm/src/bin/tm/commands/issue/validate.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/issue/validate.rs
@@ -6,12 +6,13 @@
 //! message and keeps the checks testable in isolation.
 //! What: [`validate_model`] runs every load-time rule — known version, unique
 //! state names, transition refs resolve, 6-hex colors, generic terminal-edge
-//! check, and `bot` strategy requires an identity.
+//! check, at most one label-less state per `gh_state`, and `bot` strategy
+//! requires an identity.
 //! Test: the `validate_*` tests in this file cover each rejection path.
 
 use std::collections::BTreeSet;
 
-use super::config::{SUPPORTED_VERSION, StateModel};
+use super::config::{GhState, SUPPORTED_VERSION, StateModel};
 
 /// Structured validation failures for the issue state model.
 ///
@@ -65,6 +66,23 @@ pub(crate) enum ModelError {
     /// The `bot` strategy was selected without an identity.
     #[error("assignee strategy `bot` requires an `identity_pattern` (or `identity_example`)")]
     BotStrategyMissingIdentity,
+
+    /// Two label-less states share one GitHub open/closed flag.
+    ///
+    /// A label-less state is resolved from the issue's open/closed flag alone,
+    /// so two of them on the same flag would be indistinguishable.
+    #[error(
+        "label-less states `{first}` and `{second}` both map to gh_state \
+         `{gh_state}`; at most one label-less state per gh_state"
+    )]
+    AmbiguousLabellessState {
+        /// The first label-less state declared for this flag.
+        first: String,
+        /// The second (conflicting) one.
+        second: String,
+        /// The shared `open`/`closed` flag.
+        gh_state: &'static str,
+    },
 }
 
 /// Whether `s` is exactly six hexadecimal digits (no `#`).
@@ -84,7 +102,8 @@ fn is_six_hex(s: &str) -> bool {
 /// preserved as the source.
 /// What: checks version, non-empty + unique states, transition ref integrity,
 /// 6-hex colors (states + extra labels), terminal states have no outbound edge,
-/// and (for the `bot` strategy) an identity is present.
+/// at most one label-less state per `gh_state`, and (for the `bot` strategy) an
+/// identity is present.
 /// Test: `validate_default_ok` and the `validate_rejects_*` tests.
 pub(crate) fn validate_model(model: &StateModel) -> anyhow::Result<()> {
     validate_model_inner(model).map_err(|e| anyhow::anyhow!(e))
@@ -140,12 +159,14 @@ fn validate_model_inner(model: &StateModel) -> Result<(), ModelError> {
         }
     }
 
-    // 4. Colors are 6-hex (states + extra labels).
+    // 4. Colors are 6-hex (states + extra labels). A label-less state has no
+    //    color to check.
     for s in &model.states {
-        if !is_six_hex(&s.label.color) {
+        let Some(label) = &s.label else { continue };
+        if !is_six_hex(&label.color) {
             return Err(ModelError::BadColor {
-                label: s.label.name.clone(),
-                color: s.label.color.clone(),
+                label: label.name.clone(),
+                color: label.color.clone(),
             });
         }
     }
@@ -171,7 +192,27 @@ fn validate_model_inner(model: &StateModel) -> Result<(), ModelError> {
         }
     }
 
-    // 6. `bot` strategy requires an identity.
+    // 6. At most one label-less state per gh_state, so `resolve_current_state`
+    //    can name it unambiguously from the issue's open/closed flag.
+    let mut labelless: [Option<&str>; 2] = [None, None];
+    for s in &model.states {
+        if s.label.is_some() {
+            continue;
+        }
+        let slot = usize::from(s.gh_state == GhState::Closed);
+        match labelless[slot] {
+            None => labelless[slot] = Some(s.name.as_str()),
+            Some(first) => {
+                return Err(ModelError::AmbiguousLabellessState {
+                    first: first.to_string(),
+                    second: s.name.clone(),
+                    gh_state: if slot == 0 { "open" } else { "closed" },
+                });
+            }
+        }
+    }
+
+    // 7. `bot` strategy requires an identity.
     if model.assignee_model.strategy == "bot"
         && model.assignee_model.identity_pattern.is_none()
         && model.assignee_model.identity_example.is_none()
@@ -246,7 +287,11 @@ mod tests {
     #[test]
     fn validate_rejects_bad_hex() {
         let mut m = default_model();
-        m.states[0].label.color = "ZZZ".to_string();
+        m.states[0]
+            .label
+            .as_mut()
+            .expect("every factory state is labelled")
+            .color = "ZZZ".to_string();
         let err = validate_model_inner(&m).unwrap_err();
         assert!(matches!(err, ModelError::BadColor { .. }), "got: {err:?}");
     }
@@ -268,6 +313,7 @@ mod tests {
             from: Some("done".to_string()),
             to: "queued".to_string(),
             trigger: super::super::config::Trigger::HumanLabel,
+            requires_note: false,
             description: String::new(),
         });
         assert_eq!(
@@ -303,6 +349,48 @@ mod tests {
             validate_model_inner(&m),
             Err(ModelError::BotStrategyMissingIdentity)
         );
+    }
+
+    #[test]
+    fn validate_rejects_two_labelless_states_on_one_gh_state() {
+        // Two label-less `open` states cannot be told apart from an issue's
+        // labels or its open/closed flag, so the model must be refused.
+        let yaml = r#"
+version: 1
+label_config: { base: x, approved: x:a, blast_prefix: "b:", status_prefix: "x:" }
+states:
+  - { name: open, order: 0 }
+  - { name: also-open, order: 1 }
+transitions:
+  - { from: open, to: also-open, trigger: human_label }
+assignee_model: { strategy: unchanged, per_state: {} }
+"#;
+        let m: StateModel = serde_yaml::from_str(yaml).expect("synthetic parses");
+        assert_eq!(
+            validate_model_inner(&m),
+            Err(ModelError::AmbiguousLabellessState {
+                first: "open".to_string(),
+                second: "also-open".to_string(),
+                gh_state: "open",
+            })
+        );
+    }
+
+    #[test]
+    fn validate_accepts_one_labelless_state_per_gh_state() {
+        // One `open` + one `closed` label-less state IS resolvable.
+        let yaml = r#"
+version: 1
+label_config: { base: x, approved: x:a, blast_prefix: "b:", status_prefix: "x:" }
+states:
+  - { name: open, gh_state: open, order: 0 }
+  - { name: closed, gh_state: closed, order: 1 }
+transitions:
+  - { from: open, to: closed, trigger: human_label }
+assignee_model: { strategy: unchanged, per_state: {} }
+"#;
+        let m: StateModel = serde_yaml::from_str(yaml).expect("synthetic parses");
+        assert!(validate_model_inner(&m).is_ok());
     }
 
     #[test]

--- a/crates/trusty-mpm/src/bin/tm/commands/ticket/system.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/ticket/system.rs
@@ -128,6 +128,15 @@ pub(crate) trait TicketSystem {
         anyhow::bail!("swap_labels not supported for this ticket system")
     }
 
+    /// Close the issue.
+    ///
+    /// A lifecycle state can be GitHub's own closed state rather than a label
+    /// (trusty-tools' `status:tested → closed`); reaching such a state closes
+    /// the issue.
+    fn close_issue(&self, _issue: u64) -> anyhow::Result<()> {
+        anyhow::bail!("close_issue not supported for this ticket system")
+    }
+
     /// Apply an assignee rule to an issue; `current` is the issue's existing
     /// assignee set (needed for the `None` clear-all rule — RFC §5.4).
     fn set_assignee(
@@ -160,6 +169,12 @@ impl<R: CommandRunner> GhTicketSystem<R> {
     /// Test: used by every `gh_*` test.
     pub(crate) fn new(runner: R) -> Self {
         Self { runner }
+    }
+
+    /// Borrow the underlying runner so a test can assert what reached `gh`.
+    #[cfg(test)]
+    pub(crate) fn runner(&self) -> &R {
+        &self.runner
     }
 }
 
@@ -290,6 +305,14 @@ impl<R: CommandRunner> TicketSystem for GhTicketSystem<R> {
 
     fn swap_labels(&self, issue: u64, add: &str, remove: &str) -> anyhow::Result<()> {
         gh_swap_labels(&self.runner, issue, add, remove)
+    }
+
+    fn close_issue(&self, issue: u64) -> anyhow::Result<()> {
+        let n = issue.to_string();
+        self.runner
+            .run("gh", &["issue", "close", &n])?
+            .ok_or_stderr("gh issue close")?;
+        Ok(())
     }
 
     fn set_assignee(

--- a/docs/reference/issue-search-keys.md
+++ b/docs/reference/issue-search-keys.md
@@ -41,3 +41,32 @@ unfixed problems, so a hit there is prior art worth reading, not a dead end.
 When a problem looks new, check this pool alongside the four keys above. A
 match means someone described it before: reopen that issue rather than filing
 a fresh one.
+
+## Once the issue exists: move it with `tm issue transition`
+
+The lifecycle labels (`status:in-progress` → `status:coded` → `status:merged` →
+`status:tested`) are mutually exclusive, and the repo encodes that as a state
+machine in [`issue-state.yaml`](../../issue-state.yaml) at the repo root — the
+file `tm issue`'s CWD tier reads, so every `tm issue` verb run from the repo
+root uses it with no flag.
+
+```bash
+tm issue states                  # the states and the legal edges
+tm issue current 1234            # where this issue is now
+tm issue transition 1234 status:merged
+tm issue transition 1234 closed --note "tm 1.5.16 live run: <what it printed>"
+tm issue repair 1234             # an issue that already carries two status: labels
+```
+
+`transition` refuses an edge the model does not declare (exit 1, naming the
+states you may move to), and performs the add and the remove as ONE
+`gh issue edit`, so two `status:` labels can never be observed on one issue. The
+`status:tested → closed` edge is declared `requires_note`, which is CLAUDE.md's
+"an issue closes only from `status:tested`, with live verification evidence"
+made mechanical.
+
+Two limits worth knowing. `tm issue current` and `tm issue transition` both read
+the issue through the shared ticket backend, which refuses a CLOSED issue — so
+the `closed → open` reopen edge is declared but cannot be driven by `tm` today;
+use `gh issue reopen`. And the model is resolved from the process working
+directory: run these from the repo root, or pass `--config <path>`.

--- a/issue-state.yaml
+++ b/issue-state.yaml
@@ -1,0 +1,131 @@
+# issue-state.yaml — the trusty-tools issue lifecycle, as a state machine.
+#
+# Why this file is at the repo root: `tm issue` resolves its model in the order
+# `--config` flag > ./issue-state.yaml (this file) > ~/.trusty-tools/trusty-mpm/
+# issue-state.yaml > the embedded default (the Unicorn Factory example). Running
+# any `tm issue` verb from the repo root therefore picks this model up with no
+# flag. See crates/trusty-mpm/src/bin/tm/commands/issue/config.rs.
+#
+# What it encodes: CLAUDE.md's "Issue lifecycle — open → in-progress → coded →
+# merged → tested → closed". The four `status:*` labels are MUTUALLY EXCLUSIVE:
+# `tm issue transition` performs the add+remove as ONE `gh issue edit`, so an
+# issue can never carry two of them.
+#
+# State names are the label names for the four labeled states, so
+# `tm issue transition 1234 status:merged` reads the same as the label it sets.
+# `open` and `closed` carry no label: `open` is the absence of every `status:*`
+# label, `closed` is GitHub's own closed state.
+
+version: 1
+
+# This repo has no ownership (`unicorn`) or blast-radius label family — only the
+# lifecycle prefix. The unused prefixes are empty rather than invented.
+label_config:
+  base: ""
+  approved: ""
+  blast_prefix: ""
+  status_prefix: "status:"
+
+states:
+
+  # No `status:*` label. A freshly-filed issue is here, and so is one whose
+  # claim was released.
+  - name: open
+    gh_state: open
+    order: 0
+
+  - name: "status:in-progress"
+    label:
+      name: "status:in-progress"
+      color: "1D76DB"
+      description: "A session/agent has claimed it and is actively working it"
+    order: 1
+
+  - name: "status:coded"
+    label:
+      name: "status:coded"
+      color: "5319E7"
+      description: "Implementation pushed on a branch; PR not yet merged"
+    order: 2
+
+  - name: "status:merged"
+    label:
+      name: "status:merged"
+      color: "0E8A16"
+      description: "PR merged to main; live verification pending"
+    order: 3
+
+  - name: "status:tested"
+    label:
+      name: "status:tested"
+      color: "C2E0C6"
+      description: "Verified live (installed binary / real run); eligible to close"
+    order: 4
+
+  # GitHub's closed state. Not terminal: a closed issue can be reopened.
+  - name: closed
+    gh_state: closed
+    order: 5
+
+transitions:
+
+  # --- forward: one rung at a time -----------------------------------------
+  - from: open
+    to: "status:in-progress"
+    trigger: executor_start
+    description: "Claimed at dispatch; comment naming the session and date"
+
+  - from: "status:in-progress"
+    to: "status:coded"
+    trigger: executor_complete
+    description: "Implementation pushed on a branch"
+
+  - from: "status:coded"
+    to: "status:merged"
+    trigger: executor_complete
+    description: "PR squash-merged to main"
+
+  - from: "status:merged"
+    to: "status:tested"
+    trigger: human_label
+    description: "Live verification passed"
+
+  - from: "status:tested"
+    to: closed
+    trigger: human_label
+    # CLAUDE.md: an issue closes only from status:tested, WITH live verification
+    # evidence in the closing comment. `--note` is that evidence and is required.
+    requires_note: true
+    description: "Closed with live-verification evidence (--note required)"
+
+  # --- back to open: release a claim, or reopen ----------------------------
+  - from: "status:in-progress"
+    to: open
+    trigger: human_label
+    description: "Release a claim — the session is gone and nothing has moved"
+
+  - from: "status:coded"
+    to: open
+    trigger: human_label
+    description: "Reopened: the coded work was abandoned or reverted"
+
+  - from: "status:merged"
+    to: open
+    trigger: human_label
+    description: "Reopened: a merged fix that failed live verification stays open"
+
+  - from: "status:tested"
+    to: open
+    trigger: human_label
+    description: "Reopened: the live verification was later invalidated"
+
+  - from: closed
+    to: open
+    trigger: human_label
+    description: "Reopened: back to no status label"
+
+assignee_model:
+  # `tm issue` never touches assignees in this repo — the claim is recorded by
+  # the `status:in-progress` label plus the dispatch comment.
+  strategy: unchanged
+  per_state: {}


### PR DESCRIPTION
What: `issue-state.yaml` at repo root encodes the CLAUDE.md lifecycle (open, status:in-progress, status:coded, status:merged, status:tested, closed; ten edges; tested→closed requires `--note`). Schema additions: label-less states resolved from the issue's open/closed flag, `gh_state` so reaching `closed` calls `gh issue close`, `requires_note` on an edge. `tm issue transition` refuses an unlisted edge (exit 1, names allowed next states) and a two-label issue (points at `tm issue repair`). `ticketing.md` and `tm-ticketing.md` now use `tm issue transition`; raw `gh issue edit` with both flags in one call is the fallback only where `tm` is absent. Docs: `issue-search-keys.md`, CLAUDE.md pointer.

Why: a deterministic-work sweep found `tm issue` already implemented the state machine but no project model existed, so every agent hand-typed the label swap the docs forbid getting wrong.

Known limits, documented not fixed: the shared ticket backend's `validate()` refuses a closed issue, so `tm issue current <closed>` errors and the `closed → open` edge is declared but driven by `gh issue reopen`.

Test ladder: rung 3 plus rung-6 binary smoke. Gates exit 0: fmt, check, clippy, `cargo test -p trusty-mpm --no-fail-fast` (lib 5802 passed / bin 1973 passed / 52 further targets ok), `cargo test -p trusty-agents-common --no-fail-fast` (516 passed), line-cap, agent-assets, changelog (both crates), sld. Edge-set test proven to fail on an extra edge and on a missing edge. Smoke: `tm issue states`, `tm issue current 6650` → status:in-progress, two refusals exit 1, no real issue transitioned.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J2e8jdTM8JhJotobe3Uvv1