### PR TITLE
feat(trusty-mpm): bare tm outside a git work tree lists sessions and offers untracked or managed new session (Refs #6666)

### DIFF
--- a/crates/trusty-mpm/changelog.d/6666-tm-outside-git-default-ls.md
+++ b/crates/trusty-mpm/changelog.d/6666-tm-outside-git-default-ls.md
@@ -1,0 +1,15 @@
+Changed
+- Bare `tm` in a directory that is not inside a git work tree now prints the
+  managed session list — the same `tm sessions ls` code path, not a second
+  renderer — followed by the two explicit ways to create a session:
+  `[n] tm sessions start --dir <cwd>` for an untracked session that registers
+  nothing, and `[m] tm sessions new <cwd> --task ''` for a managed, tracked one.
+  On an interactive terminal it reads one line and runs the choice; piped or
+  scripted it prints the listing and the options and exits 0; `q`, Enter, and
+  EOF quit without creating anything. Previously such an invocation ran
+  `git init` in that directory and carried on as though a project had been
+  asked for (#6274/#6276) — that auto-init is unchanged for every directory git
+  already knows, and a pane that belongs to a managed session still takes the
+  in-place relaunch path. The advertised command and the executed one are built
+  from one function and the argv is parsed back through the real CLI, so they
+  cannot drift. `tm --help` states the behaviour (#6666).

--- a/crates/trusty-mpm/src/bin/tm/cli/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli/mod.rs
@@ -79,6 +79,11 @@ pub(crate) const DEFAULT_ADDR: &str = trusty_mpm::core::DEFAULT_DAEMON_ADDR;
     name = "trusty-mpm",
     version,
     about = "trusty-mpm — unified binary",
+    // #6666: `--help` is where an operator looks after bare `tm` did something
+    // they did not expect, so the outside-a-work-tree behaviour is stated here.
+    long_about = "trusty-mpm — unified binary\n\n\
+                  Bare `tm` outside a git work tree lists managed sessions and offers a new \
+                  untracked session (`tm sessions start`) or a managed one (`tm sessions new`).",
     subcommand_required = false,
     arg_required_else_help = false,
     infer_subcommands = true

--- a/crates/trusty-mpm/src/bin/tm/commands/guided.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided.rs
@@ -47,7 +47,11 @@ use crate::formatters::info_box::DaemonInfo;
 /// written to; all managed sessions run in the protected base-clone workspace.
 /// What: (0) an operator-supplied `--url` / `TRUSTY_MPM_URL` that is
 /// unreachable errors out immediately (issue #1737 — see below) before any
-/// of the following runs; (1) tries the rich picker UX when the daemon is
+/// of the following runs; (0b) a cwd outside every git work tree hands off to
+/// [`super::guided_outside_git::run_outside_git_menu`] — the managed-session
+/// listing plus the two explicit ways to create a session (#6666) — so nothing
+/// below, `ensure_git_repo` included, runs for a plain directory; (1) tries the
+/// rich picker UX when the daemon is
 /// reachable and the CWD is a GitHub-backed git project; (2) falls through to
 /// [`fallback_protected`] for every other case (daemon unreachable, non-GitHub
 /// remote, non-git directory). Non-TTY piped invocations print project + session
@@ -281,6 +285,14 @@ pub(crate) async fn run_guided_default(
     }
 
     let cwd = std::env::current_dir().context("cannot resolve current directory")?;
+
+    // #6666: outside a git work tree, bare `tm` lists the managed sessions and
+    // offers the two ways to create one instead of running `git init` here.
+    // That auto-init (#6274) stays for every directory git already knows.
+    if let Some(result) = super::guided_outside_git::try_outside_git(client, url, &cwd).await {
+        return result;
+    }
+
     let workdir = cwd.to_string_lossy().to_string();
     eprintln!("tm: no subcommand — using guided default for {workdir}");
 

--- a/crates/trusty-mpm/src/bin/tm/commands/guided_outside_git.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_outside_git.rs
@@ -1,0 +1,327 @@
+//! Bare `tm` outside a git work tree — list managed sessions, then offer the
+//! two ways to start one (#6666).
+//!
+//! Why: bare `tm` in a plain directory used to run `git init` there and carry
+//! on as though the operator had asked for a project (#6274/#6276). The owner
+//! ruling of 2026-09-02 supersedes that OUTSIDE a work tree: show the managed
+//! session list — the thing an operator in an arbitrary directory almost always
+//! wants — and make the two ways to create a session explicit choices rather
+//! than a side effect. Inside a work tree nothing changes; the auto-`git init`
+//! still runs there for the directories that are already repositories.
+//!
+//! What: [`route_bare_tm`] is the pure decision (work tree vs not, TTY vs not);
+//! [`parse_outside_git_choice`] turns one line of input into an
+//! [`OutsideGitChoice`]; [`choice_argv`] turns that choice into the `tm
+//! sessions …` argv the options block advertises, so the displayed command and
+//! the executed one cannot drift; [`run_outside_git_menu`] is the orchestrator
+//! with every I/O edge injected. [`dispatch_session_argv`] is the production
+//! runner: it parses the argv back through the real `Cli` and calls the real
+//! `sessions` handler — no process spawn.
+//!
+//! Test: `guided_outside_git_tests.rs`.
+
+use std::future::Future;
+use std::path::Path;
+
+/// The `tm sessions` verb that creates an UNTRACKED session in place.
+///
+/// Why: `tm sessions start` runs the harness in the directory it is given and
+/// registers nothing in the managed fleet — the "non-tracked session" half of
+/// the ruling. Named here so the options block and [`choice_argv`] read the
+/// same constant.
+/// Test: `outside_git_untracked_choice_maps_to_sessions_start_argv`.
+const UNTRACKED_VERB: &str = "start";
+
+/// The `tm sessions` verb that creates a MANAGED, tracked session.
+///
+/// Why: `tm sessions new <path>` creates a managed-fleet record that `tm ls`
+/// then lists — the "managed tracked session" half of the ruling. For a path
+/// with no readable GitHub remote the daemon's in-project detection returns
+/// `Ok(None)` and the spawn falls through to its local-path form, so a plain
+/// directory is a valid target and nothing is initialised here.
+/// Test: `outside_git_managed_choice_maps_to_sessions_new_argv`.
+const MANAGED_VERB: &str = "new";
+
+/// What bare `tm` should do for the current directory.
+///
+/// Why: the interception has to answer two questions at once — is this a
+/// directory the existing guided default owns, and may we block on stdin? —
+/// and both must be decidable without touching a terminal or a daemon.
+/// What: `GuidedProject` means run the pre-#6666 flow unchanged.
+/// `OutsideGit { interactive }` means show the listing and the options;
+/// `interactive` is `true` only when a keypress can actually be read.
+/// Test: `route_bare_tm_*`.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum BareTmRoute {
+    /// Inside a git work tree, or a pane that belongs to a managed session —
+    /// the existing guided default handles it.
+    GuidedProject,
+    /// Not inside a git work tree — list sessions and offer the two actions.
+    OutsideGit {
+        /// Read one line and run the choice; `false` prints and exits 0.
+        interactive: bool,
+    },
+}
+
+/// Which action the operator picked from the options block.
+///
+/// Test: `parse_outside_git_choice_*`.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum OutsideGitChoice {
+    /// `[n]` — a session here with nothing registered anywhere.
+    UntrackedSession,
+    /// `[m]` — a managed-fleet session for this directory.
+    ManagedSession,
+    /// `[q]`, Enter, EOF, or anything unrecognised — do nothing.
+    Quit,
+}
+
+/// Decide what bare `tm` does, given the four facts that settle it.
+///
+/// Why: a pane that belongs to a managed session can sit in any directory,
+/// including one with no git work tree, and `fallback_protected`'s #4061 retry
+/// exists to give that pane's Active→Stopped settle race a second bounded
+/// attempt. Routing such a pane into this menu would print a session list at
+/// an operator who asked to get their agent back, so the managed-pane signal
+/// keeps the pre-#6666 flow.
+/// What: `inside_work_tree` or `managed_pane` → `GuidedProject`. Otherwise
+/// `OutsideGit`, interactive only when BOTH stdin and stdout are terminals —
+/// the same anti-hang pairing `session_ls_connector::should_show_picker` and
+/// `commands::projects::should_launch_bare_tui` use, because stdin redirected
+/// from `/dev/null` would EOF instantly and a piped stdout must stay clean.
+/// Test: `route_bare_tm_git_tree_is_guided`, `route_bare_tm_managed_pane_is_guided`,
+/// `route_bare_tm_outside_git_tty_is_interactive`,
+/// `route_bare_tm_outside_git_piped_stdin_is_static`,
+/// `route_bare_tm_outside_git_piped_stdout_is_static`.
+pub(crate) fn route_bare_tm(
+    inside_work_tree: bool,
+    managed_pane: bool,
+    stdin_tty: bool,
+    stdout_tty: bool,
+) -> BareTmRoute {
+    if inside_work_tree || managed_pane {
+        return BareTmRoute::GuidedProject;
+    }
+    BareTmRoute::OutsideGit {
+        interactive: stdin_tty && stdout_tty,
+    }
+}
+
+/// Read one line of operator input as a choice.
+///
+/// What: case-insensitive, whitespace-trimmed; `n` selects the untracked
+/// session, `m` the managed one, and everything else — `q`, a bare Enter, an
+/// EOF-empty string, a typo — quits without touching anything.
+/// Test: `parse_outside_git_choice_n_is_untracked`,
+/// `parse_outside_git_choice_m_is_managed`,
+/// `parse_outside_git_choice_empty_is_quit`,
+/// `parse_outside_git_choice_unknown_is_quit`.
+pub(crate) fn parse_outside_git_choice(input: &str) -> OutsideGitChoice {
+    match input.trim().to_ascii_lowercase().as_str() {
+        "n" => OutsideGitChoice::UntrackedSession,
+        "m" => OutsideGitChoice::ManagedSession,
+        _ => OutsideGitChoice::Quit,
+    }
+}
+
+/// The `tm sessions …` argv a choice runs, without the leading `tm`.
+///
+/// Why: the options block advertises a command the operator could type; this
+/// builds that same command as argv and [`dispatch_session_argv`] parses it
+/// back through the real CLI. One source for both means the printed command
+/// and the executed one cannot drift.
+/// What: `Some(argv)` for the two session choices, `None` for `Quit`. The
+/// managed form passes an empty `--task` because `tm sessions new` requires
+/// the flag and an interactive session has no task to inject — the same empty
+/// task `commands::session::start::start_session` builds for its own
+/// protected-path dispatch.
+/// Test: `outside_git_untracked_choice_maps_to_sessions_start_argv`,
+/// `outside_git_managed_choice_maps_to_sessions_new_argv`,
+/// `outside_git_quit_choice_maps_to_no_argv`.
+pub(crate) fn choice_argv(choice: &OutsideGitChoice, cwd: &Path) -> Option<Vec<String>> {
+    let path = cwd.to_string_lossy().into_owned();
+    match choice {
+        OutsideGitChoice::UntrackedSession => Some(vec![
+            "sessions".to_string(),
+            UNTRACKED_VERB.to_string(),
+            "--dir".to_string(),
+            path,
+        ]),
+        OutsideGitChoice::ManagedSession => Some(vec![
+            "sessions".to_string(),
+            MANAGED_VERB.to_string(),
+            path,
+            "--task".to_string(),
+            String::new(),
+        ]),
+        OutsideGitChoice::Quit => None,
+    }
+}
+
+/// The options block printed under the session listing.
+///
+/// Why: an operator standing outside a git project needs to know both that
+/// nothing was created and what the two real commands are — so the block names
+/// each command in full rather than describing it.
+/// What: a multi-line string naming `[n]`, `[m]`, and `[q]` with the exact
+/// commands [`choice_argv`] builds. Printed to stderr by
+/// [`run_outside_git_menu`] so the listing on stdout stays pipeable.
+/// Test: `outside_git_options_block_names_both_real_commands`,
+/// `outside_git_options_block_matches_choice_argv`.
+pub(crate) fn options_block(cwd: &Path) -> String {
+    let path = cwd.to_string_lossy();
+    format!(
+        "\ntm: {path} is not inside a git work tree — nothing was created here.\n\
+         tm:\n\
+         tm:   [n] new untracked session here  →  tm sessions {UNTRACKED_VERB} --dir {path}\n\
+         tm:   [m] new managed session here    →  tm sessions {MANAGED_VERB} {path} --task ''\n\
+         tm:   [q] quit (default)"
+    )
+}
+
+/// Read one line from stdin, treating EOF as an empty line.
+///
+/// Why: the menu's only blocking read. Kept separate from
+/// [`run_outside_git_menu`] so every test drives the orchestrator with a
+/// closure instead of a terminal.
+/// Test: covered through `run_outside_git_menu`'s injected reader.
+pub(crate) fn read_choice_line() -> std::io::Result<String> {
+    use std::io::BufRead as _;
+    let mut line = String::new();
+    std::io::stdin().lock().read_line(&mut line)?;
+    Ok(line)
+}
+
+/// List sessions, print the options, and run the operator's choice.
+///
+/// Why: every I/O edge is a parameter — the listing, the input read, and the
+/// action — so the whole outside-git behaviour is testable with no daemon, no
+/// terminal, and no spawned process.
+/// What: runs `list_sessions` first (a failure is reported and the options are
+/// still offered — a dead daemon is not a reason to hide the two commands),
+/// prints [`options_block`], then returns `Ok(())` when not interactive. When
+/// interactive it reads one line, maps it through [`parse_outside_git_choice`]
+/// and [`choice_argv`], and awaits `run_argv` for the two action choices.
+/// Test: `outside_git_menu_static_lists_then_prints_options`,
+/// `outside_git_menu_static_never_reads_or_runs`,
+/// `outside_git_menu_tty_choice_runs_the_advertised_argv`,
+/// `outside_git_menu_quit_runs_nothing`,
+/// `outside_git_menu_reports_a_listing_failure_and_still_offers_the_options`.
+pub(crate) async fn run_outside_git_menu<L, LFut, R, RFut>(
+    cwd: &Path,
+    interactive: bool,
+    list_sessions: L,
+    read_choice: impl FnOnce() -> std::io::Result<String>,
+    run_argv: R,
+) -> anyhow::Result<()>
+where
+    L: FnOnce() -> LFut,
+    LFut: Future<Output = anyhow::Result<()>>,
+    R: FnOnce(Vec<String>) -> RFut,
+    RFut: Future<Output = anyhow::Result<()>>,
+{
+    if let Err(e) = list_sessions().await {
+        eprintln!("tm: could not list managed sessions ({e})");
+    }
+    eprintln!("{}", options_block(cwd));
+
+    if !interactive {
+        return Ok(());
+    }
+
+    eprint!("tm: choice [n/m/q]: ");
+    let line = read_choice()?;
+    match choice_argv(&parse_outside_git_choice(&line), cwd) {
+        Some(argv) => run_argv(argv).await,
+        None => Ok(()),
+    }
+}
+
+/// The whole #6666 interception, wired to production I/O.
+///
+/// Why: `run_guided_default` reads as a sequence of "does this case own the
+/// invocation?" gates (`try_inplace_relaunch` is the same shape), and keeping
+/// the wiring here rather than inline there is also what holds `guided.rs`
+/// under the 500-SLOC production cap.
+/// What: evaluates [`route_bare_tm`] against the real classifier, the
+/// managed-session environment, and both terminals. `None` means the caller
+/// carries on unchanged. `Some(result)` is the finished menu — the listing
+/// comes from `commands::managed::session_ls`, the one `tm sessions ls`
+/// implementation, so there is no second renderer to drift from it.
+/// Test: the decision by `route_bare_tm_*`, the menu by
+/// `outside_git_menu_*`; the wiring itself by the binary smoke run in #6666.
+pub(crate) async fn try_outside_git(
+    client: &reqwest::Client,
+    url: &str,
+    cwd: &Path,
+) -> Option<anyhow::Result<()>> {
+    use std::io::IsTerminal as _;
+
+    let BareTmRoute::OutsideGit { interactive } = route_bare_tm(
+        !matches!(
+            super::guided::classify_cwd_project(cwd),
+            super::guided::CwdProject::NotGit
+        ),
+        super::guided_inplace::resolve_env_managed_session_id().is_some(),
+        std::io::stdin().is_terminal(),
+        std::io::stdout().is_terminal(),
+    ) else {
+        return None;
+    };
+
+    Some(
+        run_outside_git_menu(
+            cwd,
+            interactive,
+            || {
+                super::managed::session_ls(
+                    client,
+                    url,
+                    false,
+                    None,
+                    false,
+                    false,
+                    super::session_picker::SessionSortArg::default(),
+                    None,
+                    false,
+                )
+            },
+            read_choice_line,
+            |argv| dispatch_session_argv(client, url, argv),
+        )
+        .await,
+    )
+}
+
+/// Run a `tm sessions …` argv through the real CLI parser and handler.
+///
+/// Why: the options block promises the operator a command. Parsing that same
+/// argv back through [`crate::cli::Cli`] and dispatching the resulting
+/// `SessionAction` means the promise is kept by construction — a wrong flag
+/// would fail to parse rather than silently run something else — and nothing
+/// is spawned as a subprocess.
+/// What: prepends the `tm` argv[0] clap expects, parses, and calls
+/// [`crate::commands::session::session`]. Any other parsed command is an
+/// internal bug and returns `Err`.
+/// Test: `outside_git_dispatch_rejects_a_non_session_argv`; the happy paths are
+/// covered by the argv tests plus the `sessions` handler's own suite.
+pub(crate) async fn dispatch_session_argv(
+    client: &reqwest::Client,
+    url: &str,
+    argv: Vec<String>,
+) -> anyhow::Result<()> {
+    use clap::Parser as _;
+
+    let full = std::iter::once("tm".to_string()).chain(argv);
+    let cli = crate::cli::Cli::try_parse_from(full)?;
+    match cli.command {
+        Some(crate::cli::Command::Sessions { action }) => {
+            crate::commands::session::session(client, url, action).await
+        }
+        _ => anyhow::bail!("internal: the outside-git menu built a non-`sessions` command"),
+    }
+}
+
+#[cfg(test)]
+#[path = "guided_outside_git_tests.rs"]
+mod tests;

--- a/crates/trusty-mpm/src/bin/tm/commands/guided_outside_git_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_outside_git_tests.rs
@@ -1,0 +1,426 @@
+//! Unit tests for the bare-`tm`-outside-a-git-work-tree menu (#6666).
+//!
+//! Why: the whole point of `guided_outside_git` is that the routing decision,
+//! the input parse, the advertised commands, and the orchestrator are all
+//! reachable without a daemon, a terminal, or a spawned process. These tests
+//! exercise each of those seams directly.
+//! What: routing table, choice parsing, argv construction, the options block's
+//! agreement with that argv, and the orchestrator's static / interactive /
+//! quit / listing-failure paths.
+//! Test: this file.
+
+use std::cell::RefCell;
+use std::path::Path;
+
+use super::*;
+
+// ── route_bare_tm ────────────────────────────────────────────────────────────
+
+/// Inside a work tree the pre-#6666 guided default still owns the invocation.
+#[test]
+fn route_bare_tm_git_tree_is_guided() {
+    assert_eq!(
+        route_bare_tm(true, false, true, true),
+        BareTmRoute::GuidedProject
+    );
+}
+
+/// A managed pane keeps the guided default even with no work tree, so
+/// `fallback_protected`'s #4061 settle retry is still reachable.
+#[test]
+fn route_bare_tm_managed_pane_is_guided() {
+    assert_eq!(
+        route_bare_tm(false, true, true, true),
+        BareTmRoute::GuidedProject
+    );
+}
+
+/// Outside a work tree on a real terminal: the menu, and it may block on input.
+#[test]
+fn route_bare_tm_outside_git_tty_is_interactive() {
+    assert_eq!(
+        route_bare_tm(false, false, true, true),
+        BareTmRoute::OutsideGit { interactive: true }
+    );
+}
+
+/// Piped stdin would EOF instantly, so the menu prints and exits.
+#[test]
+fn route_bare_tm_outside_git_piped_stdin_is_static() {
+    assert_eq!(
+        route_bare_tm(false, false, false, true),
+        BareTmRoute::OutsideGit { interactive: false }
+    );
+}
+
+/// Piped stdout must stay a clean pipeable listing, so no prompt is written.
+#[test]
+fn route_bare_tm_outside_git_piped_stdout_is_static() {
+    assert_eq!(
+        route_bare_tm(false, false, true, false),
+        BareTmRoute::OutsideGit { interactive: false }
+    );
+}
+
+/// The dispatch path bare `tm` actually takes, fed by the real classifier
+/// rather than a hand-set boolean.
+///
+/// Why: #6666's contract has two halves — a plain directory reaches the menu,
+/// and a git work tree reaches the unchanged guided default. A boolean-only
+/// table proves neither half is wired to the predicate `run_guided_default`
+/// evaluates, which is `classify_cwd_project(&cwd) != NotGit`.
+fn route_for_dir(dir: &Path) -> BareTmRoute {
+    use crate::commands::guided::{CwdProject, classify_cwd_project};
+    route_bare_tm(
+        !matches!(classify_cwd_project(dir), CwdProject::NotGit),
+        false,
+        true,
+        true,
+    )
+}
+
+/// Create an empty temp directory, replacing any leftover from a prior run.
+fn tempdir_with_name(name: &str) -> std::path::PathBuf {
+    let tmp = std::env::temp_dir().join(name);
+    if tmp.exists() {
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+    std::fs::create_dir_all(&tmp).expect("create temp dir");
+    tmp
+}
+
+/// A real git work tree takes the pre-#6666 guided default, unchanged.
+#[test]
+fn route_bare_tm_real_git_work_tree_takes_the_guided_dispatch() {
+    let tmp = tempdir_with_name("trusty_test_outside_git_repo_6666");
+    let ok = std::process::Command::new("git")
+        .args(["init", "-q"])
+        .current_dir(&tmp)
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if !ok {
+        // No git on this machine — the claim is untestable, not false.
+        return;
+    }
+    assert_eq!(route_for_dir(&tmp), BareTmRoute::GuidedProject);
+}
+
+/// A real plain directory takes the #6666 menu.
+#[test]
+fn route_bare_tm_real_plain_dir_takes_the_outside_git_dispatch() {
+    let tmp = tempdir_with_name("trusty_test_outside_git_plain_6666");
+    // A temp dir that happens to sit inside someone's repo is not this case.
+    use crate::commands::guided::{CwdProject, classify_cwd_project};
+    if !matches!(classify_cwd_project(&tmp), CwdProject::NotGit) {
+        return;
+    }
+    assert_eq!(
+        route_for_dir(&tmp),
+        BareTmRoute::OutsideGit { interactive: true }
+    );
+}
+
+// ── parse_outside_git_choice ─────────────────────────────────────────────────
+
+#[test]
+fn parse_outside_git_choice_n_is_untracked() {
+    for input in ["n", "N", " n \n", "n\r\n"] {
+        assert_eq!(
+            parse_outside_git_choice(input),
+            OutsideGitChoice::UntrackedSession,
+            "input {input:?}"
+        );
+    }
+}
+
+#[test]
+fn parse_outside_git_choice_m_is_managed() {
+    for input in ["m", "M", " m\n"] {
+        assert_eq!(
+            parse_outside_git_choice(input),
+            OutsideGitChoice::ManagedSession,
+            "input {input:?}"
+        );
+    }
+}
+
+/// A bare Enter and an EOF-empty read both quit — the documented default.
+#[test]
+fn parse_outside_git_choice_empty_is_quit() {
+    for input in ["", "\n", "   "] {
+        assert_eq!(
+            parse_outside_git_choice(input),
+            OutsideGitChoice::Quit,
+            "input {input:?}"
+        );
+    }
+}
+
+#[test]
+fn parse_outside_git_choice_unknown_is_quit() {
+    for input in ["q", "yes", "1"] {
+        assert_eq!(
+            parse_outside_git_choice(input),
+            OutsideGitChoice::Quit,
+            "input {input:?}"
+        );
+    }
+}
+
+// ── choice_argv ──────────────────────────────────────────────────────────────
+
+#[test]
+fn outside_git_untracked_choice_maps_to_sessions_start_argv() {
+    let argv = choice_argv(&OutsideGitChoice::UntrackedSession, Path::new("/tmp/plain"));
+    assert_eq!(
+        argv,
+        Some(vec![
+            "sessions".to_string(),
+            "start".to_string(),
+            "--dir".to_string(),
+            "/tmp/plain".to_string(),
+        ])
+    );
+}
+
+#[test]
+fn outside_git_managed_choice_maps_to_sessions_new_argv() {
+    let argv = choice_argv(&OutsideGitChoice::ManagedSession, Path::new("/tmp/plain"));
+    assert_eq!(
+        argv,
+        Some(vec![
+            "sessions".to_string(),
+            "new".to_string(),
+            "/tmp/plain".to_string(),
+            "--task".to_string(),
+            String::new(),
+        ])
+    );
+}
+
+#[test]
+fn outside_git_quit_choice_maps_to_no_argv() {
+    assert_eq!(
+        choice_argv(&OutsideGitChoice::Quit, Path::new("/tmp")),
+        None
+    );
+}
+
+/// Both argv forms must parse back through the real CLI into the `sessions`
+/// group — the guarantee `dispatch_session_argv` relies on.
+#[test]
+fn outside_git_argv_parses_back_into_the_sessions_group() {
+    use clap::Parser as _;
+
+    for choice in [
+        OutsideGitChoice::UntrackedSession,
+        OutsideGitChoice::ManagedSession,
+    ] {
+        let argv = choice_argv(&choice, Path::new("/tmp/plain")).expect("action choice has argv");
+        let full = std::iter::once("tm".to_string()).chain(argv.clone());
+        let cli = crate::cli::Cli::try_parse_from(full)
+            .unwrap_or_else(|e| panic!("argv {argv:?} must parse: {e}"));
+        assert!(
+            matches!(cli.command, Some(crate::cli::Command::Sessions { .. })),
+            "argv {argv:?} must land in the sessions group"
+        );
+    }
+}
+
+// ── options_block ────────────────────────────────────────────────────────────
+
+#[test]
+fn outside_git_options_block_names_both_real_commands() {
+    let block = options_block(Path::new("/tmp/plain"));
+    assert!(
+        block.contains("tm sessions start --dir /tmp/plain"),
+        "block: {block}"
+    );
+    assert!(
+        block.contains("tm sessions new /tmp/plain --task ''"),
+        "block: {block}"
+    );
+    assert!(block.contains("[q] quit"), "block: {block}");
+    assert!(
+        block.contains("not inside a git work tree"),
+        "block: {block}"
+    );
+}
+
+/// The advertised text and the executed argv share one source, so every argv
+/// token must appear in the block.
+#[test]
+fn outside_git_options_block_matches_choice_argv() {
+    let cwd = Path::new("/tmp/plain");
+    let block = options_block(cwd);
+    for choice in [
+        OutsideGitChoice::UntrackedSession,
+        OutsideGitChoice::ManagedSession,
+    ] {
+        for token in choice_argv(&choice, cwd).expect("action choice has argv") {
+            if token.is_empty() {
+                continue;
+            }
+            assert!(
+                block.contains(&token),
+                "token {token:?} missing from block: {block}"
+            );
+        }
+    }
+}
+
+// ── run_outside_git_menu ─────────────────────────────────────────────────────
+
+/// Records what the orchestrator's injected edges were asked to do.
+#[derive(Default)]
+struct MenuSpy {
+    listed: RefCell<u32>,
+    read: RefCell<u32>,
+    ran: RefCell<Vec<Vec<String>>>,
+}
+
+/// The non-TTY path lists sessions through the injected lister, prints the
+/// options, and exits 0 without reading input or running an action.
+#[tokio::test]
+async fn outside_git_menu_static_lists_then_prints_options() {
+    let spy = MenuSpy::default();
+    let out = run_outside_git_menu(
+        Path::new("/tmp/plain"),
+        false,
+        || async {
+            *spy.listed.borrow_mut() += 1;
+            Ok(())
+        },
+        || {
+            *spy.read.borrow_mut() += 1;
+            Ok(String::new())
+        },
+        |argv| async {
+            spy.ran.borrow_mut().push(argv);
+            Ok(())
+        },
+    )
+    .await;
+
+    assert!(out.is_ok(), "static path must exit 0: {out:?}");
+    assert_eq!(*spy.listed.borrow(), 1, "the listing runs exactly once");
+}
+
+/// The same run proves the static path never blocks on stdin and never acts.
+#[tokio::test]
+async fn outside_git_menu_static_never_reads_or_runs() {
+    let spy = MenuSpy::default();
+    run_outside_git_menu(
+        Path::new("/tmp/plain"),
+        false,
+        || async { Ok(()) },
+        || {
+            *spy.read.borrow_mut() += 1;
+            Ok("n".to_string())
+        },
+        |argv| async {
+            spy.ran.borrow_mut().push(argv);
+            Ok(())
+        },
+    )
+    .await
+    .expect("static path must exit 0");
+
+    assert_eq!(*spy.read.borrow(), 0, "no stdin read on a non-TTY");
+    assert!(spy.ran.borrow().is_empty(), "no action on a non-TTY");
+}
+
+/// On a TTY the chosen key runs the exact argv the options block advertised.
+#[tokio::test]
+async fn outside_git_menu_tty_choice_runs_the_advertised_argv() {
+    for (key, expected) in [
+        (
+            "n\n",
+            vec!["sessions", "start", "--dir", "/tmp/plain"]
+                .into_iter()
+                .map(str::to_string)
+                .collect::<Vec<_>>(),
+        ),
+        (
+            "m\n",
+            vec!["sessions", "new", "/tmp/plain", "--task", ""]
+                .into_iter()
+                .map(str::to_string)
+                .collect::<Vec<_>>(),
+        ),
+    ] {
+        let spy = MenuSpy::default();
+        run_outside_git_menu(
+            Path::new("/tmp/plain"),
+            true,
+            || async { Ok(()) },
+            || Ok(key.to_string()),
+            |argv| async {
+                spy.ran.borrow_mut().push(argv);
+                Ok(())
+            },
+        )
+        .await
+        .unwrap_or_else(|e| panic!("key {key:?} must succeed: {e}"));
+
+        assert_eq!(*spy.ran.borrow(), vec![expected], "key {key:?}");
+    }
+}
+
+/// Enter (and `q`) quit without running anything, and still exit 0.
+#[tokio::test]
+async fn outside_git_menu_quit_runs_nothing() {
+    for key in ["\n", "q\n", ""] {
+        let spy = MenuSpy::default();
+        run_outside_git_menu(
+            Path::new("/tmp/plain"),
+            true,
+            || async { Ok(()) },
+            || Ok(key.to_string()),
+            |argv| async {
+                spy.ran.borrow_mut().push(argv);
+                Ok(())
+            },
+        )
+        .await
+        .unwrap_or_else(|e| panic!("key {key:?} must exit 0: {e}"));
+
+        assert!(spy.ran.borrow().is_empty(), "key {key:?} must run nothing");
+    }
+}
+
+/// An unreachable daemon must not hide the two commands — the listing failure
+/// is reported and the options are still offered.
+#[tokio::test]
+async fn outside_git_menu_reports_a_listing_failure_and_still_offers_the_options() {
+    let spy = MenuSpy::default();
+    let out = run_outside_git_menu(
+        Path::new("/tmp/plain"),
+        true,
+        || async { Err(anyhow::anyhow!("daemon unreachable")) },
+        || {
+            *spy.read.borrow_mut() += 1;
+            Ok("q\n".to_string())
+        },
+        |argv| async {
+            spy.ran.borrow_mut().push(argv);
+            Ok(())
+        },
+    )
+    .await;
+
+    assert!(out.is_ok(), "a dead daemon must not fail the menu: {out:?}");
+    assert_eq!(*spy.read.borrow(), 1, "the prompt is still offered");
+}
+
+// ── dispatch_session_argv ────────────────────────────────────────────────────
+
+/// A non-`sessions` argv is an internal bug, not a silently different command.
+#[tokio::test]
+async fn outside_git_dispatch_rejects_a_non_session_argv() {
+    let client = reqwest::Client::new();
+    let out =
+        dispatch_session_argv(&client, "http://127.0.0.1:1", vec!["status".to_string()]).await;
+    assert!(out.is_err(), "a non-sessions argv must be refused");
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/mod.rs
@@ -46,6 +46,7 @@ pub(crate) mod guided;
 pub(crate) mod guided_autostart;
 pub(crate) mod guided_inplace;
 pub(crate) mod guided_launch;
+pub(crate) mod guided_outside_git;
 pub(crate) mod guided_resolver;
 pub(crate) mod guided_resume;
 pub(crate) mod hook_payload;


### PR DESCRIPTION
## Summary

Bare `tm` from a directory not inside a git work tree now lists sessions and offers untracked or managed new session creation. When invoked with no git repo, users see a 23-row session list and an options block: `[n] new untracked → tm sessions start --dir <path>`, `[m] new managed → tm sessions new <path> --task ''`, `[q] quit (default)`. TTY reads a choice and dispatches the argv through the real `Cli` parser; non-TTY prints and exits 0. No `.git` is created. Inside a git tree, behavior is unchanged.

## Changes

New module `guided_outside_git.rs`, four-line gate in `guided.rs` before `ensure_git_repo`. Corrections from ticket sketch: no ephemeral flag exists on `sessions new`; untracked = `sessions start --dir`; `--task` is required on `sessions new`. `--help` documents the new behavior.

## Risk

Normal→High (CLI surface, rung 6). Extends the guided entry point to a new code path when git repo is absent. Decision routing validated; TTY/non-TTY paths tested; message formatting verified.

## Tests

Rust side: `cargo test -p trusty-mpm --bin tm --no-fail-fast`
- 2056 tests passed / 0 failed / 1 ignored
- Format and clippy -D warnings: PASS
- Line-cap: 4382 files, 0 violations (guided.rs under 500 SLOC)
- Capabilities, changelog, test pointers, SLD: all PASS

Coverage: pure `route_bare_tm` decision test, non-TTY path with injected lister, TTY choice → argv mapping with injected runner. Smoke test from scratch non-repo (no `TM_MANAGED_SESSION_ID`/`TMUX`): session list displayed, options block rendered, exit 0, no `.git` created. `tm --help | grep -i outside` confirmed.

## Baseline

Full `cargo test -p trusty-mpm` shows five integration targets failing on this host (manager_routes, project_registry_routes, manager_cli_client, manager_inference, mcp_spawn_gate) because they read the live project registry (counts 22/23 vs expected 0/1). Git diff outside `src/bin/tm/` is empty — linked lib identical to main. Ticketed separately. Two load flakes cleared on rerun (#6663 family).

## Docs

Changelog fragment in place. `--help` and `guided_outside_git.rs` doc comments updated. Owner ruling 2026-09-02 (verbatim in #6666) supersedes #6274/#6276 auto-`git init` outside a repo.

## Review

Ready for review. No review findings to carry forward.

Refs #6666

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
