### PR TITLE
chore(sessions): commit tm-trusty-tools-02 pause snapshot 2026-09-02 16:28Z

### DIFF
--- a/.trusty-mpm/sessions/sessions-log.jsonl
+++ b/.trusty-mpm/sessions/sessions-log.jsonl
@@ -77,3 +77,4 @@
 {"session_id":"tm-trusty-tools-02-0-at2307-20260902","event":"pause","snapshot":"tm-trusty-tools-02-0-at2307-20260902/session-20260902-014402.md","timestamp":"2026-09-02T01:44:02.783351+00:00"}
 {"session_id":"tm-trusty-tools-02-0-at2307-20260902","event":"pause","snapshot":"tm-trusty-tools-02-0-at2307-20260902/session-20260902-033112.md","timestamp":"2026-09-02T03:31:12.708286+00:00"}
 {"session_id":"tm-trusty-tools-02-0-at2307-20260902","event":"pause","snapshot":"tm-trusty-tools-02-0-at2307-20260902/session-20260902-111042.md","timestamp":"2026-09-02T11:10:42.983115+00:00"}
+{"session_id":"tm-trusty-tools-02-0-at2307-20260902","event":"pause","snapshot":"tm-trusty-tools-02-0-at2307-20260902/session-20260902-162807.md","timestamp":"2026-09-02T16:28:07.264636+00:00"}

--- a/.trusty-mpm/sessions/tm-trusty-tools-02-0-at2307-20260902/session-20260902-162807.md
+++ b/.trusty-mpm/sessions/tm-trusty-tools-02-0-at2307-20260902/session-20260902-162807.md
@@ -1,0 +1,34 @@
+# Session Pause - 2026-09-02T16:28:07.264636+00:00
+
+## Summary
+Paused 2026-09-02 ~16:30Z, owner-invoked, leg 3 (resumed 11:xxZ on "audit version-control + deterministic-work pass"). Main checkout is on branch codex/documentation-inventory-2026-09-02 at 1e4c2397f (another workstream's branch — do NOT commit or checkout there; the snapshot commit already reached main via #6655). Installed: tm 1.5.16 from 6bf71b4ee (ADR-0057 guard) BUT predates #6656 (tm issue state model) and #6659 (tm pr) — `tm issue transition` still errors with the embedded default model until the next tm install; trusty-console 0.9.3, tctl 0.13.4, tga 5.0.3, trusty-audit 0.12.1 all from 9dc8a4fbc. Config edits this leg: ~/.trusty-tools/trusty-mpm/config.yaml gained `github.config_dir: /Users/masa/.config/gh-bobmatnyc` plus 22 `projects:` entries binding duettoresearch/bob-duetto repos to /Users/masa/.config/gh-duetto (backup config.yaml.bak-projects-add); duetto-frontend origin URL stripped of an embedded PAT (token itself NOT yet revoked on GitHub — owner action). Merged-PR sweep now classifies; 21 remaining failures are hotstats/hotstats-product-poc (repo gone). trusty-memory daemon SATURATED not hung (342 MB kg.redb, 94% redb slack) — #6652 fixes it; palace writes/reads still time out intermittently, so this snapshot file is the record.
+
+🔴 SIX BACKGROUND AGENTS LIVE AT PAUSE — VERIFY EACH ARTIFACT DIRECTLY on resume (SendMessage the agent id; never re-dispatch a duplicate): (1) rust-engineer ad20e873524d6e1f7 on feat/6652-dream-compaction, worktree agent-ad20e873524d6e1f7, PR #6670 OPEN red on "Doc-comment pointer lint" + Clippy `manual checked division` at crates/trusty-memory/src/commands/palace.rs:255 — fixing both as a new commit; on push → CI → merge → OWNER STANDING ORDER: rebuild+install trusty-memory (signed script, connection-safe restart; first dream cycle will rewrite the 342 MB palace with a backup) → verify `tm issue transition` works after ALSO reinstalling tm from a post-#6656/#6659 main → #6652 status:tested. Monitor task bpnzgwkka polls #6670 every 5 min. (2) rust-engineer aa38357ec2edf3dbb on feat/6669-cast-code-only-report (trusty-analyze `report --template cast --code-only`, tr_report MCP, trusty-audit [report] keys, golden test) — on report: scan → critic (rung 4/6) → PR Refs #6669; THEN SendMessage documentation a434570ca857a59cd (branch docs/6669-cast-audit-runbook @ 433da4a22, worktree agent-a434570ca857a59cd) to reconcile docs/runbooks/cast-code-only-audit.md with the real flags/install/runtime, then one PR for the runbook. (3) rust-engineer a60e12861bbce07b6 on feat/6657-log-drain-per-project (stacked on 7793f498d from agent-a77c267637651494d): owner/project key layout from git remote, per-source enabled:false, consolidate three remote-URL parsers into trusty-common — on report: scan → critic (rung 4) → PR Refs #6657 → status:coded; the base commit's worktree agent-a77c267637651494d can be removed once #6657's PR merges. (4) mpm-agent-manager a20fd1a015d9e32bd on docs/engineer-gate-test-pointers (rust-engineer/BASE-AGENT/tm-delegation-patterns/CLAUDE.md name check_test_pointers.sh; security.md scans a baseline COPY) — on report: scan → PR (rung 1). (5) PR #6672 (#6666 tm-outside-git) auto-merge armed, CI pending at pause — on merge: #6666 status:merged; reinstall tm; live check bare `tm` from a non-repo dir → status:tested. (6) monitor bpnzgwkka (see 1).
+
+DONE THIS LEG: audit + sweep reports in scratchpad (version-control-audit.md, deterministic-sweep.md, design-6652-dream-compaction.md, design-cast-audit.md). MERGED: #6651 scripts sweep, #6653 (#6641 SSE), #6654 version-control docs, #6656 tm issue state model, #6658 console scroll fix (#6662), #6659 tm pr open/queue-check + gate scripts, #6558 (#6555 UDS params; trusty-audit 0.12.1), #6664 docs tm pr, #6665 ADR-0057 version-control worktree removal (critic BLOCK→fixed→APPROVE). CLOSED status:tested: #6641 #6638 #6555 #6658 #4031 #6629 #6630 #6624 #6631 #6623. FILED: #6652 (in-progress, PR #6670), #6657 (in-progress), #6658 (closed), #6660 sh -c/xargs guard bypass, #6661 console port-race flakes, #6663 trusty-mpm load flakes, #6666 (coded, PR #6672), #6667 trusty-memory uds flake, #6668 GH_TOKEN precedence, #6669 CAST epic (in-progress), #6671 registry-leaking integration tests; #6556 commented (SubagentStop fail-open recurred 3x today — workaround: POST /hooks SubagentStop by agent_id). Worktrees: 12 preserve/merged trees removed by PM path; 7 remain (all live agents or pending PRs). Peer session Dog closed. Owner decisions still open: tm doctor hooks_contamination sweep (40 files, $HOME-wide) and stray ~/.mcp.json quarantine; revoke the leaked duetto-frontend PAT; whether to add `Per-PR changelog fragment` to required contexts (wedges open PRs).
+
+## In Progress
+- [rust-engineer ad20e873524d6e1f7] #6652 PR #6670: fix test-pointer lint + clippy manual checked division (palace.rs:255), new commit, not yet pushed
+- [rust-engineer aa38357ec2edf3dbb] #6669 trusty-analyze report --template cast --code-only + tr_report MCP + golden test
+- [rust-engineer a60e12861bbce07b6] #6657 amendment: owner/project keys, per-source enabled:false, remote-URL parser consolidation (stacked on 7793f498d)
+- [mpm-agent-manager a20fd1a015d9e32bd] docs: engineer gates name check_test_pointers.sh; security scans baseline copy
+- [documentation a434570ca857a59cd] runbook committed 433da4a22 on docs/6669-cast-audit-runbook, AWAITING reconciliation with the real CAST command surface
+- [monitor bpnzgwkka] PR #6670 5-min poll; PR #6672 auto-merge armed, unmonitored
+
+## Next Steps
+- Verify each live agent's artifact directly (SendMessage id), never re-dispatch
+- #6670: on engineer report → version-control pushes → on merge: local-ops installs trusty-memory (signed, connection-safe restart) AND reinstalls tm from post-#6656/#6659 main; verify `tm issue transition`, `tm pr open`, first dream cycle compaction on trusty-tools palace (backup kept) → #6652 status:tested
+- #6672: on merge → #6666 status:merged → live check bare `tm` outside a repo → status:tested
+- #6669: engineer report → scan → critic → PR; then reconcile runbook (a434570ca857a59cd) → runbook PR; live run against this workspace closes the epic
+- #6657: engineer report → scan → critic → PR → status:coded; remove worktree agent-a77c267637651494d after merge
+- docs/engineer-gate-test-pointers: scan → PR rung 1
+- Owner decisions: revoke leaked duetto-frontend PAT; hooks_contamination sweep; stray ~/.mcp.json; required-context for changelog fragment
+- Do NOT re-run the install, the sweep, the prune, or the milestone closes; check state first
+
+## Git Context
+Branch: codex/documentation-inventory-2026-09-02
+Last commit: 1e4c2397f docs: refresh workspace documentation inventory
+Uncommitted changes: 1 file(s) changed
+
+## Tmux Window
+tm-trusty-tools-02:0:@5288


### PR DESCRIPTION
## Outcome

Commits pause snapshot for tm-trusty-tools-02 session (2026-09-02 16:28Z).

## Changes

- Added `.trusty-mpm/sessions/tm-trusty-tools-02-0-at2307-20260902/session-20260902-162807.md` — session snapshot recording pause state.
- Updated `.trusty-mpm/sessions/sessions-log.jsonl` with new session entry.

Docs-only, rung-1 change per owner ruling 2026-08-31.

## Risk

None — session metadata only. No source changes.

## Test Evidence

Not applicable to docs-only changes.

## Baseline Failures

None.

## Docs

Session snapshots are tracked per CLAUDE.md (owner ruling 2026-08-31). This commit records the pause state for transparent session recovery.

## Review

No review findings.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
