### PR TITLE
feat(log-drain): owner/project object keys from the source root's git origin, per-source enabled flag, one remote-URL parser (Refs #6657)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11540,7 +11540,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-code"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-code/Cargo.toml
+++ b/crates/trusty-code/Cargo.toml
@@ -6,7 +6,10 @@ name = "trusty-code"
 # 0.5.0 (#5439): minor — `serve::http::build_axum_router` now takes 5
 # parameters instead of 4 (bearer-auth wiring); cargo-semver-checks reports a
 # function_parameter_count_changed break, so Cargo's 0.x rule puts it in MINOR.
-version = "0.5.0"
+# 0.5.1 (#6657): patch — `fs_browse::mpm_registry::parse_owner_repo` (a
+# private fn) now delegates to `trusty_common::github_path::parse_remote_url`
+# instead of its own split logic; no public item changed shape.
+version = "0.5.1"
 edition = "2024"
 rust-version.workspace = true
 # license.workspace resolves to "MIT"; LICENSE is kept in-crate for correctness.

--- a/crates/trusty-code/changelog.d/6657-one-remote-url-parser.md
+++ b/crates/trusty-code/changelog.d/6657-one-remote-url-parser.md
@@ -1,0 +1,10 @@
+Changed
+
+- `fs_browse`'s registry `repo_url` parse delegates to
+  `trusty_common::github_path::parse_remote_url` instead of splitting the URL
+  itself (#6657). A GitLab-style subgroup path is still rejected, so a
+  registry entry can never fabricate an owner containing a slash. A
+  port-qualified host (`https://git.example.com:8443/owner/repo`) now resolves
+  to `owner/repo` rather than being rejected: it was rejected only because the
+  local split treated the port's colon as the host/path boundary, and the shared
+  parser does not.

--- a/crates/trusty-code/src/fs_browse/mpm_registry.rs
+++ b/crates/trusty-code/src/fs_browse/mpm_registry.rs
@@ -185,59 +185,36 @@ async fn fetch_registry_projects(
 
 /// Parse `(owner, repo)` out of a registry `repo_url`.
 ///
-/// Why: the registry has no local filesystem path (it is keyed on
-/// `name`/`repo_url`, not a checkout location) — this recovers the
-/// `<owner>/<repo>` pair the workspace's own `~/trusty-mpm-projects/<owner>/
-/// <repo>` layout convention needs to resolve a local path (see
-/// [`resolve_local_path`]).
-/// What: handles both `https://github.com/<owner>/<repo>[.git]` and
-/// `git@github.com:<owner>/<repo>[.git]` (the two forms
-/// `trusty_mpm::project::record::Project::repo_url`'s own docs give as
-/// examples), trimming a trailing slash and `.git` suffix first. Returns
-/// `None` for anything that doesn't resolve to a non-empty `owner` and
-/// `repo` — a malformed/unexpected `repo_url` shape must never panic or
-/// fabricate a bogus path.
+/// Why: a registry entry names a project by its `repo_url`, and the picker
+/// needs the `<owner>/<repo>` pair the workspace's own
+/// `~/trusty-mpm-projects/<owner>/<repo>` layout convention takes to resolve a
+/// local path (see [`resolve_local_path`]).
+/// What: delegates to `trusty_common::github_path::parse_remote_url`, the
+/// workspace's one git-remote-URL parser (#6657). It accepts the HTTPS and SSH
+/// forms `trusty_mpm::project::record::Project::repo_url`'s own docs give as
+/// examples, trims a trailing slash and `.git`, and returns `None` for anything
+/// that does not resolve to a non-empty `owner` and `repo` — a malformed or
+/// unexpected `repo_url` shape must never panic or fabricate a bogus path.
 ///
 /// **Only an EXACT `<owner>/<repo>` pair is supported** (code-critic PR
 /// #3439 review, MEDIUM 1): a compound remainder after the host — a GitLab
-/// subgroup path (`gitlab.com/group/subgroup/repo`) or a port-qualified host
-/// that this function's simple `split_once(['/', ':'])` mis-splits (e.g.
-/// `git.example.com:8443/owner/repo` splits on the PORT's `:`, leaving
-/// `8443/owner/repo`) — is rejected outright rather than silently absorbed
-/// into a multi-segment "owner" via `rsplit_once`. Letting that through
-/// would hand [`resolve_local_path`]'s `Path::join` an owner string
-/// containing `/`, fabricating a 3+-level lookup path no `repo_url` of this
-/// shape was ever meant to produce.
+/// subgroup path (`gitlab.com/group/subgroup/repo`) — is rejected outright
+/// rather than absorbed into a multi-segment "owner". Letting that through
+/// would hand [`resolve_local_path`]'s `Path::join` an owner string containing
+/// `/`, fabricating a 3+-level lookup path no `repo_url` of this shape was ever
+/// meant to produce. A port-qualified host (`git.example.com:8443/owner/repo`)
+/// used to be rejected for the same reason, because this function's own
+/// `split_once(['/', ':'])` split on the PORT's colon; the shared parser splits
+/// the authority correctly, so that URL now yields the pair it names.
 /// Test: `tests::parse_owner_repo_handles_https_url`,
 /// `tests::parse_owner_repo_handles_https_url_with_git_suffix`,
 /// `tests::parse_owner_repo_handles_ssh_url`,
 /// `tests::parse_owner_repo_rejects_malformed_url`,
 /// `tests::parse_owner_repo_rejects_gitlab_style_subgroup_path`,
-/// `tests::parse_owner_repo_rejects_port_qualified_host_misparse`.
+/// `tests::parse_owner_repo_handles_port_qualified_host`.
 fn parse_owner_repo(repo_url: &str) -> Option<(String, String)> {
-    let trimmed = repo_url.trim().trim_end_matches('/');
-    let trimmed = trimmed.strip_suffix(".git").unwrap_or(trimmed);
-    // Strip a `<scheme>://` prefix when present (e.g. `https://`); an SSH
-    // shorthand URL (`git@host:owner/repo`) has no `://` and is left as-is.
-    let path_part = match trimmed.split_once("://") {
-        Some((_, rest)) => rest,
-        None => trimmed,
-    };
-    // `path_part` is now `<host>/<owner>/<repo>` (HTTPS) or
-    // `git@<host>:<owner>/<repo>` (SSH) — either way, the first `/` or `:`
-    // after the host separates it from the `<owner>/<repo>` pair.
-    let (_, after_host) = path_part.split_once(['/', ':'])?;
-    // Reject anything but an EXACT `<owner>/<repo>` pair — see the docs
-    // above for why a compound remainder must not fall through to
-    // `rsplit_once` below.
-    if after_host.matches('/').count() != 1 {
-        return None;
-    }
-    let (owner, repo) = after_host.rsplit_once('/')?;
-    if owner.is_empty() || repo.is_empty() {
-        return None;
-    }
-    Some((owner.to_string(), repo.to_string()))
+    let remote = trusty_common::github_path::parse_remote_url(repo_url).ok()?;
+    Some((remote.owner, remote.repo))
 }
 
 /// Resolve `<workspace_root>/<owner>/<repo>` to an existing local git-repo
@@ -487,16 +464,18 @@ mod tests {
         );
     }
 
-    /// A port-qualified host (`host:PORT/owner/repo`) must be rejected —
-    /// this function's simple `split_once(['/', ':'])` splits on the PORT's
-    /// `:`, not a host/path boundary, so without the compound-remainder
-    /// guard this would silently fabricate `owner = "PORT/owner"` (code-critic
-    /// PR #3439 review, MEDIUM 1).
+    /// A port-qualified host (`host:PORT/owner/repo`) must yield the pair the
+    /// URL names. The local parser this replaced split on the PORT's `:` and
+    /// so had to reject the whole shape to avoid fabricating
+    /// `owner = "PORT/owner"` (code-critic PR #3439 review, MEDIUM 1); the
+    /// shared parser splits the authority correctly, and the invariant that
+    /// guard protected — an owner never containing `/` — still holds, proved
+    /// by the subgroup case above.
     #[test]
-    fn parse_owner_repo_rejects_port_qualified_host_misparse() {
+    fn parse_owner_repo_handles_port_qualified_host() {
         assert_eq!(
             parse_owner_repo("https://git.example.com:8443/owner/repo"),
-            None
+            Some(("owner".to_string(), "repo".to_string()))
         );
     }
 

--- a/crates/trusty-common/changelog.d/6657-per-destination-s3-identity-changed.md
+++ b/crates/trusty-common/changelog.d/6657-per-destination-s3-identity-changed.md
@@ -5,3 +5,10 @@ Changed
   no longer silently re-point one destination at another account. Region
   resolution for such a destination is `?region=` → the profile's own `region` →
   refusal with `DrainError::Credentials`.
+- The log-drain key layout is now `<owner>/<project>/<crate>/<file>` beneath the
+  destination prefix, replacing `<github_id>/<session_id>/logs/…` (#6657).
+  `DrainTarget` carries `owner` and `project` instead, and `logs_prefix()` is
+  now `key_prefix()`. Objects already uploaded under the old layout stay where
+  they are — the manifest is keyed by destination and key, so the first pass
+  after the upgrade re-uploads the current files under the new prefix and then
+  dedupes as before.

--- a/crates/trusty-common/changelog.d/6657-per-destination-s3-identity-changed.md
+++ b/crates/trusty-common/changelog.d/6657-per-destination-s3-identity-changed.md
@@ -1,0 +1,7 @@
+Changed
+
+- A pinned `?profile=` is the WHOLE identity for that destination: the default
+  chain is not consulted, so `AWS_ACCESS_KEY_ID` in a daemon's environment can
+  no longer silently re-point one destination at another account. Region
+  resolution for such a destination is `?region=` → the profile's own `region` →
+  refusal with `DrainError::Credentials`.

--- a/crates/trusty-common/changelog.d/6657-per-destination-s3-identity.md
+++ b/crates/trusty-common/changelog.d/6657-per-destination-s3-identity.md
@@ -11,3 +11,10 @@ Added
   bucket, so a skip decision recorded under one profile is never read back under
   another. A destination that pins no identity keeps the namespace it already
   had, so upgrading orphans no existing manifest cache.
+- `github_path::parse_remote_url` parses a git remote URL into its host and its
+  `owner/repo`, keeping the case the remote spells them in, and
+  `github_path::derive_remote_repo` reads a directory's `origin` and parses it
+  (#6657). This is the workspace's one git-remote-URL parser: it replaces the
+  three private copies `trusty-git-analytics` (twice) and `trusty-code` carried.
+  Unlike `parse_github_path` it does not slugify, carries the host so a caller
+  can filter on it, and refuses a path that is not exactly `<owner>/<repo>`.

--- a/crates/trusty-common/changelog.d/6657-per-destination-s3-identity.md
+++ b/crates/trusty-common/changelog.d/6657-per-destination-s3-identity.md
@@ -1,0 +1,13 @@
+Added
+
+- An `s3://` log-drain destination can name its own AWS identity:
+  `?profile=<name>` reads credentials and region from that `~/.aws` profile
+  alone, and `?role_arn=<arn>` assumes that role over whatever base identity
+  resolved (#6657). Both combine, and both sit beside the existing `?region=`;
+  every other query key is still rejected, and a repeated key is now rejected
+  rather than resolving to the last occurrence. Without either, the destination
+  keeps today's AWS default provider chain.
+- `DestinationUri::cache_namespace()` now separates two identities against one
+  bucket, so a skip decision recorded under one profile is never read back under
+  another. A destination that pins no identity keeps the namespace it already
+  had, so upgrading orphans no existing manifest cache.

--- a/crates/trusty-common/src/github_path.rs
+++ b/crates/trusty-common/src/github_path.rs
@@ -18,9 +18,19 @@
 //! safety — lower-cased, non-alphanumerics collapsed to `-`, trailing `.git`
 //! stripped — so the result is always two clean path segments.
 //!
+//! [`RemoteRepo`] and [`parse_remote_url`] are the same parse WITHOUT the
+//! slugification, added by #6657: they keep the owner and repo exactly as the
+//! remote spells them and carry the host, because their callers hand the pair
+//! to the GitHub API or use it as an object-storage key rather than as a path.
+//! That pair is the workspace's single git-remote-URL parser —
+//! `trusty-git-analytics` and `trusty-code` route through it instead of each
+//! carrying their own.
+//!
 //! Test: `parse_*` unit tests cover SSH/HTTPS, with/without `.git`, trailing
-//! slashes, nested groups, owner-less and empty inputs; `derive_*` is covered by
-//! the `derive_github_path_reads_origin` test against a real temp git repo.
+//! slashes, nested groups, owner-less and empty inputs; `parse_remote_url_table`
+//! covers the verbatim parser; `derive_*` is covered by
+//! `derive_github_path_reads_origin` and `derive_remote_repo_reads_origin`
+//! against real temp git repos.
 //!
 //! [`GithubPath`]: crate::github_path::GithubPath
 //! [`parse_github_path`]: crate::github_path::parse_github_path
@@ -245,6 +255,18 @@ pub fn parse_owner_repo(s: &str) -> Option<GithubPath> {
 /// Test: `derive_github_path_reads_origin` (temp repo with an origin remote);
 /// `derive_github_path_none_outside_repo`.
 pub fn derive_github_path(dir: &Path) -> Option<GithubPath> {
+    origin_remote_url(dir).and_then(|url| parse_github_path(url.trim()))
+}
+
+/// Read `remote.origin.url` for the repo containing `dir`.
+///
+/// Shelling out to `git config` (rather than reading `.git/config`) is what
+/// makes this work inside a worktree, where `.git` is a file pointing at the
+/// parent repo, and inside a SUBDIRECTORY of a repo, where git walks up to the
+/// enclosing checkout. Returns `None` when git is absent, `dir` is not in a
+/// repo, or there is no origin remote.
+/// Test: `derive_github_path_reads_origin`, `derive_remote_repo_reads_origin`.
+fn origin_remote_url(dir: &Path) -> Option<String> {
     let output = Command::new("git")
         .arg("-C")
         .arg(dir)
@@ -256,8 +278,159 @@ pub fn derive_github_path(dir: &Path) -> Option<GithubPath> {
     if !output.status.success() {
         return None;
     }
-    let url = String::from_utf8_lossy(&output.stdout);
-    parse_github_path(url.trim())
+    Some(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// A git remote URL split into its host and its `owner/repo` pair, VERBATIM.
+///
+/// Why: [`GithubPath`] slugifies, because its consumers build filesystem paths
+/// from it. Three other call sites need the opposite — the identity exactly as
+/// the remote spells it, because they hand it to the GitHub API or use it as an
+/// object-storage key (#6657). Before this type each of them re-implemented git
+/// URL parsing: `tga`'s `extract_owner_repo_from_url` (twice) and
+/// `trusty-code`'s `mpm_registry::parse_owner_repo`.
+/// What: `host` carries any port and never the `user@` prefix; `owner` and
+/// `repo` keep their original case and punctuation, minus a trailing `.git`.
+/// A caller that only accepts one forge filters on `host` itself.
+/// Test: `parse_remote_url_table`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct RemoteRepo {
+    /// Remote host, with a port when the URL carried one, e.g. `github.com`.
+    pub host: String,
+    /// Repository owner exactly as the remote spells it, e.g. `duettoresearch`.
+    pub owner: String,
+    /// Repository name exactly as the remote spells it, minus a trailing `.git`.
+    pub repo: String,
+}
+
+impl RemoteRepo {
+    /// Render the identity as `<owner>/<repo>`.
+    pub fn owner_repo(&self) -> String {
+        format!("{}/{}", self.owner, self.repo)
+    }
+}
+
+/// Why a git remote URL yielded no `owner/repo`.
+///
+/// Why: the log drain refuses to upload under a guessed key, so it has to tell
+/// an operator which source could not be identified and what was wrong with it
+/// (#6657). An `Option` would name neither.
+/// What: hand-written `Display`/`Error` rather than `thiserror`, because
+/// [`mod@crate::github_path`] is compiled unconditionally and `thiserror` is an
+/// optional dependency of this crate.
+/// Test: `parse_remote_url_table`, `derive_remote_repo_without_origin`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum RemoteUrlError {
+    /// The string is not a git remote URL naming exactly one `owner/repo`.
+    Malformed {
+        /// The input, so the message names what the operator wrote.
+        url: String,
+        /// Which part of the grammar failed.
+        reason: &'static str,
+    },
+    /// The directory is not a git checkout, or has no `origin` remote.
+    NoOrigin {
+        /// The directory that was probed.
+        dir: String,
+    },
+}
+
+impl std::fmt::Display for RemoteUrlError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Malformed { url, reason } => {
+                write!(f, "`{url}` is not a git remote URL: {reason}")
+            }
+            Self::NoOrigin { dir } => {
+                write!(f, "{dir} is not a git checkout with an `origin` remote")
+            }
+        }
+    }
+}
+
+impl std::error::Error for RemoteUrlError {}
+
+/// Parse a git remote URL into its host and `owner/repo`, preserving case.
+///
+/// Why: the single implementation of git-remote-URL parsing for this workspace
+/// (#6657). See [`RemoteRepo`] for why [`parse_github_path`] does not serve
+/// these callers.
+/// What: accepts `https://host/owner/repo`, `http://…`, `ssh://[user@]host[:port]/owner/repo`,
+/// and the scp-style `[user@]host:owner/repo`, each with or without a trailing
+/// `.git` and trailing slashes. A `user@` prefix is dropped; a port stays with
+/// the host. The path must be EXACTLY two non-empty segments, so a GitLab
+/// subgroup path (`group/subgroup/repo`) is refused rather than collapsed into
+/// an owner containing a slash. Everything else — a bare word, a filesystem
+/// path, a host with no path — is [`RemoteUrlError::Malformed`].
+/// Test: `parse_remote_url_table`.
+///
+/// # Errors
+/// [`RemoteUrlError::Malformed`], naming the input and the reason.
+pub fn parse_remote_url(url: &str) -> Result<RemoteRepo, RemoteUrlError> {
+    let trimmed = url.trim();
+    let malformed = |reason: &'static str| RemoteUrlError::Malformed {
+        url: trimmed.to_string(),
+        reason,
+    };
+    if trimmed.is_empty() {
+        return Err(malformed("it is empty"));
+    }
+
+    // With a scheme the host ends at the first `/`; without one this is
+    // scp-syntax and the host ends at the first `:`. Splitting on the wrong
+    // one is how `host:PORT/owner/repo` used to parse as owner `PORT`.
+    let (authority, path) = match trimmed.split_once("://") {
+        Some((_, rest)) => rest
+            .split_once('/')
+            .ok_or_else(|| malformed("the URL has no path after the host"))?,
+        None => trimmed
+            .split_once(':')
+            .ok_or_else(|| malformed("expected `scheme://host/owner/repo` or `host:owner/repo`"))?,
+    };
+
+    let host = authority.rsplit_once('@').map_or(authority, |(_, h)| h);
+    if host.is_empty() {
+        return Err(malformed("the host is empty"));
+    }
+
+    let path = path.trim_matches('/');
+    let path = path.strip_suffix(".git").unwrap_or(path);
+    let path = path.trim_end_matches('/');
+    let segments: Vec<&str> = path.split('/').collect();
+    let [owner, repo] = segments.as_slice() else {
+        return Err(malformed("the path is not exactly `<owner>/<repo>`"));
+    };
+    if owner.is_empty() || repo.is_empty() {
+        return Err(malformed("the owner or the repository name is empty"));
+    }
+
+    Ok(RemoteRepo {
+        host: host.to_string(),
+        owner: (*owner).to_string(),
+        repo: (*repo).to_string(),
+    })
+}
+
+/// Read a directory's git `origin` remote and parse it with [`parse_remote_url`].
+///
+/// Why: the drain resolves a log source's `owner/project` from the checkout the
+/// logs belong to, and must fail rather than invent a key when it cannot
+/// (#6657).
+/// What: runs `git -C <dir> config --get remote.origin.url`, so a subdirectory
+/// of a repo resolves to the enclosing checkout and a worktree resolves to its
+/// parent. No network.
+/// Test: `derive_remote_repo_reads_origin`, `derive_remote_repo_without_origin`.
+///
+/// # Errors
+/// [`RemoteUrlError::NoOrigin`] when `dir` is not a checkout or has no origin;
+/// [`RemoteUrlError::Malformed`] when the origin URL does not parse.
+pub fn derive_remote_repo(dir: &Path) -> Result<RemoteRepo, RemoteUrlError> {
+    let url = origin_remote_url(dir).ok_or_else(|| RemoteUrlError::NoOrigin {
+        dir: dir.display().to_string(),
+    })?;
+    parse_remote_url(&url)
 }
 
 #[cfg(test)]
@@ -424,6 +597,148 @@ mod tests {
         assert_eq!(parse_owner_repo(""), None);
         assert_eq!(parse_owner_repo("   "), None);
         assert_eq!(parse_owner_repo("///"), None);
+    }
+
+    /// Why: `parse_remote_url` is the workspace's ONE git-remote-URL parser
+    /// (#6657), so every shape its three call sites relied on is pinned in one
+    /// table — including the case preservation `parse_github_path` does not
+    /// offer, and the strict two-segment path that keeps a subgroup URL from
+    /// fabricating an owner containing a slash.
+    /// Test: itself.
+    #[test]
+    fn parse_remote_url_table() {
+        for (url, host, owner, repo) in [
+            (
+                "https://github.com/bobmatnyc/Trusty-Tools.git",
+                "github.com",
+                "bobmatnyc",
+                "Trusty-Tools",
+            ),
+            (
+                "https://github.com/bobmatnyc/trusty-tools",
+                "github.com",
+                "bobmatnyc",
+                "trusty-tools",
+            ),
+            (
+                "https://user@github.com/acme/widget",
+                "github.com",
+                "acme",
+                "widget",
+            ),
+            (
+                "git@github.com:duettoresearch/pricing.git",
+                "github.com",
+                "duettoresearch",
+                "pricing",
+            ),
+            (
+                "ssh://git@github.com/acme/widget.git",
+                "github.com",
+                "acme",
+                "widget",
+            ),
+            (
+                "https://ghe.corp.example.com/Platform/Deploy_Tools.git",
+                "ghe.corp.example.com",
+                "Platform",
+                "Deploy_Tools",
+            ),
+            (
+                "git@ghe.corp.example.com:Platform/deploy.git",
+                "ghe.corp.example.com",
+                "Platform",
+                "deploy",
+            ),
+            (
+                "https://git.example.com:8443/owner/repo",
+                "git.example.com:8443",
+                "owner",
+                "repo",
+            ),
+            (
+                "https://github.com/acme/widget/",
+                "github.com",
+                "acme",
+                "widget",
+            ),
+        ] {
+            let parsed = parse_remote_url(url).unwrap_or_else(|e| panic!("`{url}`: {e}"));
+            assert_eq!(parsed.host, host, "host of `{url}`");
+            assert_eq!(parsed.owner, owner, "owner of `{url}`");
+            assert_eq!(parsed.repo, repo, "repo of `{url}`");
+            assert_eq!(parsed.owner_repo(), format!("{owner}/{repo}"));
+        }
+
+        for garbage in [
+            "",
+            "   ",
+            "nonsense",
+            "/var/log/trusty-mpm",
+            "https://github.com/",
+            "https://github.com/owner",
+            "https://gitlab.com/group/subgroup/repo",
+            "git@github.com:",
+        ] {
+            let err =
+                parse_remote_url(garbage).expect_err("garbage must be refused, never guessed at");
+            assert!(
+                matches!(err, RemoteUrlError::Malformed { .. }),
+                "`{garbage}` produced {err:?}"
+            );
+        }
+    }
+
+    /// Why: the I/O entry point must read a real `remote.origin.url` without
+    /// slugifying it, and must resolve from a SUBDIRECTORY of the checkout —
+    /// which is how the log drain identifies a project from its log directory.
+    /// Test: itself (skips cleanly if `git` is unavailable on the runner).
+    #[test]
+    fn derive_remote_repo_reads_origin() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let dir = tmp.path();
+        let git = |args: &[&str]| {
+            Command::new("git")
+                .arg("-C")
+                .arg(dir)
+                .args(args)
+                .output()
+                .map(|o| o.status.success())
+                .unwrap_or(false)
+        };
+        if !git(&["init"]) {
+            return;
+        }
+        let _ = git(&[
+            "remote",
+            "add",
+            "origin",
+            "git@github.com:duettoresearch/Pricing.git",
+        ]);
+        let parsed = derive_remote_repo(dir).expect("derived from origin");
+        assert_eq!(parsed.owner, "duettoresearch");
+        assert_eq!(parsed.repo, "Pricing", "the case the remote spells");
+
+        let nested = dir.join("logs");
+        std::fs::create_dir_all(&nested).expect("nested dir");
+        assert_eq!(
+            derive_remote_repo(&nested).expect("git walks up to the checkout"),
+            parsed
+        );
+    }
+
+    /// Why: a directory that is not a checkout must produce an error naming it,
+    /// not a fabricated identity — the drain refuses to upload without one.
+    /// Test: itself.
+    #[test]
+    fn derive_remote_repo_without_origin() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        match derive_remote_repo(tmp.path()) {
+            Err(RemoteUrlError::NoOrigin { dir }) => {
+                assert!(dir.contains(&*tmp.path().to_string_lossy()), "{dir}");
+            }
+            other => panic!("expected NoOrigin, got {other:?}"),
+        }
     }
 
     /// Why: `parse_owner_repo` treats its input as a canonical `owner/repo`

--- a/crates/trusty-common/src/lib.rs
+++ b/crates/trusty-common/src/lib.rs
@@ -575,7 +575,8 @@ pub mod host_metrics;
 /// with `s3://` and `file://` adapters, [`log_drain::DestinationUri`],
 /// [`log_drain::DrainManifest`], [`log_drain::collect`], and
 /// [`log_drain::run_once`]. This is the drain CORE — no scheduler, and no
-/// GitHub-identity resolution; the caller supplies a [`log_drain::DrainTarget`].
+/// project-identity resolution; the caller supplies a [`log_drain::DrainTarget`]
+/// naming the owner and project the logs belong to (#6657).
 /// Test: `cargo test -p trusty-common --features log-drain --no-fail-fast`.
 #[cfg(feature = "log-drain")]
 pub mod log_drain;
@@ -908,7 +909,10 @@ pub mod palace_alias;
 /// origin remote. Centralising the parsing here keeps the two crates in lockstep.
 /// What: Exposes [`github_path::GithubPath`], [`github_path::parse_github_path`]
 /// (pure URL parse), and [`github_path::derive_github_path`] (reads
-/// `remote.origin.url`).
+/// `remote.origin.url`). [`github_path::RemoteRepo`],
+/// [`github_path::parse_remote_url`], and [`github_path::derive_remote_repo`]
+/// are the same parse without slugification — the workspace's single
+/// git-remote-URL parser, for callers that need the identity verbatim (#6657).
 /// Test: `cargo test -p trusty-common --features unconditional-only --
 /// github_path::tests`.
 pub mod github_path;

--- a/crates/trusty-common/src/log_drain/destination.rs
+++ b/crates/trusty-common/src/log_drain/destination.rs
@@ -484,7 +484,9 @@ impl fmt::Debug for S3Auth {
 /// a bucket that is not there.
 ///
 /// Test: `super::tests::two_profiles_resolve_to_different_identities`,
-/// `super::tests::a_profile_without_a_region_is_refused`.
+/// `super::tests::a_profile_without_a_region_is_refused`,
+/// `super::tests::a_role_arn_resolves_to_an_assumed_role_identity`,
+/// `super::tests::a_profile_and_a_role_arn_do_not_collapse_onto_the_profile`.
 ///
 /// # Errors
 /// [`DrainError::Credentials`] when no region resolves, or when the default

--- a/crates/trusty-common/src/log_drain/destination.rs
+++ b/crates/trusty-common/src/log_drain/destination.rs
@@ -11,13 +11,20 @@
 //! selected by [`ObjectStoreDestination::connect`] from a [`DestinationUri`].
 //! S3 credentials come from the AWS default provider chain — the same chain
 //! `inference::bedrock` uses — bridged into `object_store`'s own
-//! `CredentialProvider` by [`AwsChainCredentials`].
+//! `CredentialProvider` by [`AwsChainCredentials`]. A URI carrying `?profile=`
+//! or `?role_arn=` narrows that to one named profile or an assumed role
+//! (#6657); see [`resolve_s3_auth`].
 //! Test: `super::tests::destination_roundtrip`, `super::tests::destination_roundtrip`,
 //! `super::tests::destination_list_is_bounded_and_prefix_scoped`, `super::tests::s3_smoke` (gated).
 
 use std::fmt;
 use std::sync::Arc;
 
+use aws_config::profile::ProfileFileCredentialsProvider;
+use aws_config::profile::region::ProfileFileRegionProvider;
+use aws_config::sts::AssumeRoleProvider;
+use aws_types::region::Region;
+use aws_types::sdk_config::SharedCredentialsProvider;
 use bytes::Bytes;
 use futures::StreamExt;
 use object_store::aws::{AmazonS3Builder, AwsCredential};
@@ -39,6 +46,17 @@ use super::uri::DestinationUri;
 /// looks at one session's worth. The cap is the "bounded" in the trait's
 /// contract; a caller that hits it is asking the wrong question.
 pub const LIST_LIMIT: usize = 10_000;
+
+/// The profile-file set `ProfileFileCredentialsProvider` and
+/// `ProfileFileRegionProvider` are pointed at.
+///
+/// #6657: `aws-config` deprecated this alias in favour of
+/// `aws_runtime::env_config::file::EnvConfigFiles`, but its own
+/// `profile_files()` builder methods still take the old name, so it cannot be
+/// avoided. Declaring `aws-runtime` directly to dodge one deprecation would pin
+/// an SDK-internal crate's version in the workspace manifest.
+#[allow(deprecated)]
+pub(super) type ProfileFiles = aws_config::profile::profile_file::ProfileFiles;
 
 /// Metadata attached to an object as it is written.
 ///
@@ -191,17 +209,17 @@ impl ObjectStoreDestination {
     /// through the AWS chain, which may reach IMDS or SSO), so it cannot be a
     /// `From` impl.
     /// What: `file://` creates the directory if absent and wraps a
-    /// `LocalFileSystem` rooted there. `s3://` loads the AWS default provider
-    /// chain, bridges it into `object_store`'s `CredentialProvider`, and builds
-    /// an `AmazonS3` for the bucket. The region comes from the URI's
-    /// `?region=` override when present and from the chain otherwise — no
-    /// bucket or region is ever hardcoded.
+    /// `LocalFileSystem` rooted there. `s3://` resolves an identity through
+    /// [`resolve_s3_auth`], bridges it into `object_store`'s
+    /// `CredentialProvider`, and builds an `AmazonS3` for the bucket. The
+    /// region comes from the URI's `?region=` override when present and from
+    /// the resolved identity otherwise — no bucket or region is ever hardcoded.
     /// Test: `super::tests::destination_roundtrip` (file),
     /// `super::tests::s3_smoke` (S3, gated on an env var).
     ///
     /// # Errors
     /// - [`DrainError::Io`] when a `file://` root cannot be created or opened.
-    /// - [`DrainError::Credentials`] when the AWS chain yields no region.
+    /// - [`DrainError::Credentials`] when no region or no credentials resolve.
     /// - [`DrainError::Transport`] when the S3 client cannot be constructed.
     pub async fn connect(uri: &DestinationUri) -> Result<Self, DrainError> {
         // #6548: derived here, from the URI, so no caller can supply an id that
@@ -229,50 +247,42 @@ impl ObjectStoreDestination {
                 bucket,
                 prefix,
                 region,
-            } => Self::connect_s3(bucket, prefix, region.as_deref(), cache_namespace).await,
+                profile,
+                role_arn,
+            } => {
+                Self::connect_s3(
+                    bucket,
+                    prefix,
+                    S3AuthRequest {
+                        region: region.as_deref(),
+                        profile: profile.as_deref(),
+                        role_arn: role_arn.as_deref(),
+                        profile_files: None,
+                    },
+                    cache_namespace,
+                )
+                .await
+            }
         }
     }
 
-    /// Build the S3 store: resolve credentials and region, then hand both to
+    /// Build the S3 store: resolve an identity and region, then hand both to
     /// `AmazonS3Builder`.
     async fn connect_s3(
         bucket: &str,
         prefix: &str,
-        region_override: Option<&str>,
+        auth: S3AuthRequest<'_>,
         cache_namespace: String,
     ) -> Result<Self, DrainError> {
         let label = format!("s3://{bucket}/{prefix}");
-
-        // #6533: the same default provider chain `inference::bedrock` loads —
-        // env vars, `~/.aws/credentials`, SSO, IMDS — reused rather than
-        // reimplemented, per the common-entry-point rule.
-        let sdk_config = aws_config::defaults(aws_config::BehaviorVersion::latest())
-            .load()
-            .await;
-
-        let region = region_override
-            .map(str::to_string)
-            .or_else(|| sdk_config.region().map(|r| r.as_ref().to_string()))
-            .ok_or_else(|| DrainError::Credentials {
-                uri: label.clone(),
-                source: "no AWS region: none in the URI's `?region=`, none from the \
-                         credential chain (set AWS_REGION or add `?region=` to the URI)"
-                    .into(),
-            })?;
-
-        let provider =
-            sdk_config
-                .credentials_provider()
-                .ok_or_else(|| DrainError::Credentials {
-                    uri: label.clone(),
-                    source: "the AWS default provider chain supplied no credentials provider"
-                        .into(),
-                })?;
+        let resolved = resolve_s3_auth(&label, auth).await?;
 
         let store = AmazonS3Builder::new()
             .with_bucket_name(bucket)
-            .with_region(&region)
-            .with_credentials(Arc::new(AwsChainCredentials { inner: provider }))
+            .with_region(&resolved.region)
+            .with_credentials(Arc::new(AwsChainCredentials {
+                inner: resolved.provider,
+            }))
             .build()
             .map_err(|source| DrainError::Transport {
                 op: "connect",
@@ -411,6 +421,171 @@ impl LogDestination for ObjectStoreDestination {
     }
 }
 
+/// What a caller knows about an `s3://` destination's identity (#6657).
+///
+/// Why a struct rather than four arguments: `profile_files` exists only so a
+/// test can supply profile text in memory, and a bare `Option<&ProfileFiles>`
+/// in the fourth position of a call is unreadable at every real call site.
+/// What: `profile_files` is `None` everywhere in production, which means the
+/// SDK's own file discovery (`~/.aws/config`, `~/.aws/credentials`, and the
+/// `AWS_CONFIG_FILE` / `AWS_SHARED_CREDENTIALS_FILE` overrides).
+/// Test: `super::tests::two_profiles_resolve_to_different_identities`.
+pub(super) struct S3AuthRequest<'a> {
+    /// `?region=` from the URI, when the operator pinned one.
+    pub region: Option<&'a str>,
+    /// `?profile=` from the URI.
+    pub profile: Option<&'a str>,
+    /// `?role_arn=` from the URI.
+    pub role_arn: Option<&'a str>,
+    /// Profile-file override. `None` in production; a test injects text here.
+    pub profile_files: Option<&'a ProfileFiles>,
+}
+
+/// A resolved S3 identity: which region to sign for, and with what credentials.
+pub(super) struct S3Auth {
+    /// Region the bucket is addressed in.
+    pub region: String,
+    /// Credentials every request is signed with.
+    pub provider: SharedCredentialsProvider,
+}
+
+impl fmt::Debug for S3Auth {
+    /// Prints the region only. A credential provider's own `Debug` can carry
+    /// key material, and this type ends up in test failure messages.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("S3Auth")
+            .field("region", &self.region)
+            .finish()
+    }
+}
+
+/// Resolve the region and credentials one `s3://` destination signs with.
+///
+/// Why: one daemon now drains to several destinations, and the owner ruling
+/// that this project's logs belong in one specific AWS account is only
+/// enforceable if a destination can name its own identity. Leaving every
+/// destination on the process-wide default chain meant whichever credentials
+/// the daemon happened to start with wrote to all of them (#6657).
+///
+/// What: three cases, in order.
+/// - `?profile=<name>` — credentials come from THAT profile alone, through
+///   `ProfileFileCredentialsProvider`, and the region falls back to the same
+///   profile's `region`. The default chain is not consulted, so an
+///   `AWS_ACCESS_KEY_ID` in the daemon's environment cannot override a pinned
+///   profile. That is the whole point of pinning one.
+/// - `?role_arn=<arn>` — the base identity above (or the default chain when no
+///   profile is named) signs an STS `AssumeRole`, and the assumed role's
+///   credentials are what reach S3. No STS call happens here: the provider is
+///   lazy, so a bad ARN surfaces on the first upload rather than at connect.
+/// - neither — the AWS default provider chain, exactly as before.
+///
+/// Region resolution is `?region=` → the identity's own region → refusal. It is
+/// never defaulted to a literal, because a wrong region is a request signed for
+/// a bucket that is not there.
+///
+/// Test: `super::tests::two_profiles_resolve_to_different_identities`,
+/// `super::tests::a_profile_without_a_region_is_refused`.
+///
+/// # Errors
+/// [`DrainError::Credentials`] when no region resolves, or when the default
+/// chain yields no credentials provider.
+pub(super) async fn resolve_s3_auth(
+    label: &str,
+    auth: S3AuthRequest<'_>,
+) -> Result<S3Auth, DrainError> {
+    let (identity_region, base) = match auth.profile {
+        Some(name) => resolve_profile_identity(name, auth.profile_files).await,
+        None => resolve_default_chain(label).await?,
+    };
+
+    let region = auth
+        .region
+        .map(str::to_string)
+        .or(identity_region)
+        .ok_or_else(|| DrainError::Credentials {
+            uri: label.to_string(),
+            source: "no AWS region: none in the URI's `?region=`, none from the \
+                     credential chain or the named profile (set AWS_REGION, give the \
+                     profile a `region`, or add `?region=` to the URI)"
+                .into(),
+        })?;
+
+    let provider = match auth.role_arn {
+        None => base,
+        Some(arn) => assume_role(arn, &region, base).await,
+    };
+
+    Ok(S3Auth { region, provider })
+}
+
+/// Credentials and region from one named `~/.aws` profile.
+///
+/// Both halves read the same profile files, so a profile that sets `region` in
+/// `~/.aws/config` needs no `?region=` in the URI.
+async fn resolve_profile_identity(
+    name: &str,
+    files: Option<&ProfileFiles>,
+) -> (Option<String>, SharedCredentialsProvider) {
+    let mut credentials = ProfileFileCredentialsProvider::builder().profile_name(name);
+    let mut region = ProfileFileRegionProvider::builder().profile_name(name);
+    if let Some(files) = files {
+        credentials = credentials.profile_files(files.clone());
+        region = region.profile_files(files.clone());
+    }
+    // `ProvideRegion` is the trait `region()` lives on.
+    use aws_config::meta::region::ProvideRegion;
+    let region = region
+        .build()
+        .region()
+        .await
+        .map(|r| r.as_ref().to_string());
+    (region, SharedCredentialsProvider::new(credentials.build()))
+}
+
+/// Credentials and region from the AWS default provider chain.
+///
+/// #6533: the same chain `inference::bedrock` loads — env vars,
+/// `~/.aws/credentials`, SSO, IMDS — reused rather than reimplemented, per the
+/// common-entry-point rule.
+async fn resolve_default_chain(
+    label: &str,
+) -> Result<(Option<String>, SharedCredentialsProvider), DrainError> {
+    let sdk_config = aws_config::defaults(aws_config::BehaviorVersion::latest())
+        .load()
+        .await;
+    let region = sdk_config.region().map(|r| r.as_ref().to_string());
+    let provider = sdk_config
+        .credentials_provider()
+        .ok_or_else(|| DrainError::Credentials {
+            uri: label.to_string(),
+            source: "the AWS default provider chain supplied no credentials provider".into(),
+        })?;
+    Ok((region, provider))
+}
+
+/// Wrap `base` in an STS `AssumeRole` for `arn`.
+///
+/// The region and credentials are pinned onto the `SdkConfig` the STS client is
+/// built from, so building it resolves nothing on its own — no IMDS probe, no
+/// network call until the first credential fetch.
+async fn assume_role(
+    arn: &str,
+    region: &str,
+    base: SharedCredentialsProvider,
+) -> SharedCredentialsProvider {
+    let sts_config = aws_config::defaults(aws_config::BehaviorVersion::latest())
+        .region(Region::new(region.to_string()))
+        .credentials_provider(base)
+        .load()
+        .await;
+    SharedCredentialsProvider::new(
+        AssumeRoleProvider::builder(arn)
+            .configure(&sts_config)
+            .build()
+            .await,
+    )
+}
+
 /// Bridges the AWS default credential chain into `object_store`'s provider trait.
 ///
 /// Why: `object_store` signs its own S3 requests and wants an
@@ -426,7 +601,7 @@ impl LogDestination for ObjectStoreDestination {
 /// there is no way to prove a credential bridge against a local filesystem.
 #[derive(Debug)]
 struct AwsChainCredentials {
-    inner: aws_types::sdk_config::SharedCredentialsProvider,
+    inner: SharedCredentialsProvider,
 }
 
 #[async_trait::async_trait]

--- a/crates/trusty-common/src/log_drain/error.rs
+++ b/crates/trusty-common/src/log_drain/error.rs
@@ -10,8 +10,8 @@
 //! What: [`DrainError`], a `thiserror` enum. `#[non_exhaustive]` so a later
 //! phase can add a variant without a breaking change on a `0.x` crate.
 //! Test: `super::tests::uri_*` (the URI and scheme variants),
-//! `super::tests::run_once_refuses_empty_github_id` and
-//! `super::tests::run_once_refuses_empty_session_id` (identity refusal).
+//! `super::tests::run_once_refuses_an_empty_owner` and
+//! `super::tests::run_once_refuses_an_empty_project` (identity refusal).
 
 use std::path::PathBuf;
 
@@ -23,7 +23,7 @@ use std::path::PathBuf;
 /// resolution, object-store transport, local IO, manifest decoding, and the
 /// fail-closed identity refusal.
 /// Test: `super::tests::uri_table_rejects`, `super::tests::uri_reserved_schemes`,
-/// `super::tests::run_once_refuses_empty_github_id`.
+/// `super::tests::run_once_refuses_an_empty_owner`.
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum DrainError {
@@ -104,15 +104,15 @@ pub enum DrainError {
     /// The caller supplied an empty identity component.
     ///
     /// Why this is an error and not a default: the key layout puts every
-    /// uploaded byte under `<github_id>/<session_id>`. An empty component
-    /// collapses one user's logs into a shared, unattributable prefix, so the
-    /// drain fails closed rather than uploading under an unknown id.
+    /// uploaded byte under `<owner>/<project>` (#6657). An empty component
+    /// collapses one project's logs into a shared, unattributable prefix, so
+    /// the drain fails closed rather than uploading under a guessed identity.
     #[error(
         "refusing to upload: `{field}` is empty — \
          the log drain never writes under an unknown identity"
     )]
     MissingIdentity {
-        /// Which component was empty: `github_id` or `session_id`.
+        /// Which component was empty: `owner` or `project`.
         field: &'static str,
     },
 }

--- a/crates/trusty-common/src/log_drain/manifest.rs
+++ b/crates/trusty-common/src/log_drain/manifest.rs
@@ -18,7 +18,7 @@
 //!
 //! [`DrainManifest::cache_path`] puts
 //! [`LogDestination::cache_namespace`] above the target's own segment. Before
-//! that, the cache lived at `<state_dir>/log-drain/<github_id>/<session_id>/`
+//! that, the cache lived at `<state_dir>/log-drain/<identity>/`
 //! and described no particular destination, so switching one session from
 //! bucket A to bucket B found A's record — and, since the fresh bucket had no
 //! remote manifest of its own to override it, skipped every file A already
@@ -373,9 +373,9 @@ impl DrainManifest {
     /// whose uploads are fine.
     ///
     /// Test: `super::tests::run_once_spot_checks_a_lying_remote_manifest`.
-    pub async fn spot_check(&self, dest: &dyn LogDestination, logs_prefix: &str) -> Option<String> {
+    pub async fn spot_check(&self, dest: &dyn LogDestination, key_prefix: &str) -> Option<String> {
         let entry = self.entries.get(sample_index(self.entries.len())?)?;
-        let key = format!("{logs_prefix}/{}", entry.relative_file);
+        let key = format!("{key_prefix}/{}", entry.relative_file);
         match dest.head(&key).await {
             Ok(Some(_)) => None,
             Ok(None) => Some(key),

--- a/crates/trusty-common/src/log_drain/mod.rs
+++ b/crates/trusty-common/src/log_drain/mod.rs
@@ -13,7 +13,7 @@
 //! [`collect`](crate::log_drain::collect) pipeline, and
 //! [`run_once`](crate::log_drain::run_once). Phase 1+2 is
 //! the core ONLY: there is no scheduler, no config plumbing, and no consumer
-//! wired up. Phase 3 adds those, plus GitHub-identity resolution — this module
+//! wired up. Phase 3 adds those, plus project-identity resolution — this module
 //! deliberately does not resolve an identity, it demands one.
 //!
 //! Test: `tests` (sibling module). Run it with
@@ -22,19 +22,21 @@
 //! # Key layout
 //!
 //! ```text
-//! <destination prefix>/<github_id>/<session_id>/logs/<crate>/<relative file>
+//! <destination prefix>/<owner>/<project>/<crate>/<relative file>
 //! ```
 //!
 //! The destination prefix comes from the URI (`s3://bucket/PREFIX`); everything
 //! after it is built by
-//! [`DrainTarget::logs_prefix`](crate::log_drain::DrainTarget::logs_prefix).
-//! Per-target reference
+//! [`DrainTarget::key_prefix`](crate::log_drain::DrainTarget::key_prefix).
+//! #6657 replaced the earlier `<github_id>/<session_id>/logs/…` layout;
+//! objects already uploaded under it stay where they are, because the manifest
+//! is keyed by destination and key. Per-target reference
 //! documentation: `docs/reference/log-drain.md`.
 //!
 //! # What the caller owns
 //!
 //! - **Identity.** [`DrainTarget`](crate::log_drain::DrainTarget) is supplied,
-//!   never resolved here. An empty `github_id` or `session_id` is refused with
+//!   never resolved here. An empty `owner` or `project` is refused with
 //!   [`DrainError::MissingIdentity`](crate::log_drain::DrainError::MissingIdentity)
 //!   rather than defaulted.
 //! - **Single-flight.** [`run_once`](crate::log_drain::run_once) is exactly what
@@ -70,22 +72,27 @@ pub use manifest::{
 };
 pub use uri::{DestinationScheme, DestinationUri};
 
-/// Who and what a drain run is uploading for.
+/// Which project's logs a drain run is uploading.
 ///
 /// Why: the two components are the whole key namespace below the destination
-/// prefix, and getting either wrong mixes one user's logs into another's. They
-/// are the caller's to supply because the core has no business shelling out to
-/// `gh` — Phase 3 owns identity resolution and passes the answer in.
+/// prefix, and getting either wrong files one project's logs under another's.
+/// They are the caller's to supply because the core has no business shelling
+/// out to git — the consumer resolves the identity and passes the answer in.
 /// What: [`DrainTarget::validate`] refuses an empty component, so no code path
 /// can produce a key containing `//` or an anonymous segment.
-/// Test: `tests::run_once_refuses_empty_github_id`,
-/// `tests::run_once_refuses_empty_session_id`, `tests::key_layout_shape`.
+/// Test: `tests::run_once_refuses_an_empty_owner`,
+/// `tests::run_once_refuses_an_empty_project`, `tests::key_layout_shape`.
+///
+/// #6657 replaced the previous `<github_id>/<session_id>` pair. A per-session
+/// segment made every project on a host share one namespace keyed by whoever
+/// ran the daemon; the owner and project of the repo the logs came from is what
+/// an operator actually looks under.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DrainTarget {
-    /// GitHub login the logs belong to. Never resolved here.
-    pub github_id: String,
-    /// The consumer's own session id. Opaque to the drain.
-    pub session_id: String,
+    /// Repository owner — the GitHub user or org, verbatim from the remote.
+    pub owner: String,
+    /// Repository name the logs belong to, verbatim from the remote.
+    pub project: String,
 }
 
 impl DrainTarget {
@@ -96,33 +103,31 @@ impl DrainTarget {
     /// # Errors
     /// [`DrainError::MissingIdentity`] naming the empty field.
     pub fn validate(&self) -> Result<(), DrainError> {
-        if self.github_id.trim().is_empty() {
-            return Err(DrainError::MissingIdentity { field: "github_id" });
+        if self.owner.trim().is_empty() {
+            return Err(DrainError::MissingIdentity { field: "owner" });
         }
-        if self.session_id.trim().is_empty() {
-            return Err(DrainError::MissingIdentity {
-                field: "session_id",
-            });
+        if self.project.trim().is_empty() {
+            return Err(DrainError::MissingIdentity { field: "project" });
         }
         Ok(())
     }
 
-    /// The `logs/` prefix every object for this target sits beneath.
+    /// The `<owner>/<project>` prefix every object for this target sits beneath.
     ///
     /// Destination-relative: the adapter joins the URI's own prefix on top.
     /// Test: `tests::key_layout_shape`.
-    pub fn logs_prefix(&self) -> String {
-        format!("{}/{}/logs", self.github_id, self.session_id)
+    pub fn key_prefix(&self) -> String {
+        format!("{}/{}", self.owner, self.project)
     }
 
     /// Full key for one collected file's `relative_key`.
     pub fn object_key(&self, relative_key: &str) -> String {
-        format!("{}/{}", self.logs_prefix(), relative_key)
+        format!("{}/{}", self.key_prefix(), relative_key)
     }
 
     /// Key of this target's manifest object.
     pub fn manifest_key(&self) -> String {
-        format!("{}/{}", self.logs_prefix(), MANIFEST_FILENAME)
+        format!("{}/{}", self.key_prefix(), MANIFEST_FILENAME)
     }
 
     /// Path segment identifying this target inside the local state directory.
@@ -131,7 +136,7 @@ impl DrainTarget {
     /// destination's namespace above it, so a record made for one destination
     /// is never read back for another (#6548).
     fn cache_key(&self) -> String {
-        format!("{}/{}", self.github_id, self.session_id)
+        self.key_prefix()
     }
 }
 
@@ -262,7 +267,7 @@ pub struct DrainReport {
 /// Single-flight is the CALLER's responsibility; see the module docs.
 ///
 /// Test: `tests::run_once_end_to_end`, `tests::run_once_is_idempotent`,
-/// `tests::run_once_reuploads_a_mutated_file`, `tests::run_once_refuses_empty_github_id`,
+/// `tests::run_once_reuploads_a_mutated_file`, `tests::run_once_refuses_an_empty_owner`,
 /// `tests::run_once_records_an_oversize_skip_once`,
 /// `tests::run_once_re_evaluates_a_skip_when_the_file_changes`.
 ///
@@ -299,7 +304,7 @@ pub async fn run_once(
     // this destination never received, and every one of them then skips
     // forever. One sampled `head` turns that into a warning an operator sees.
     if origin == ManifestOrigin::Remote
-        && let Some(missing) = manifest.spot_check(dest, &target.logs_prefix()).await
+        && let Some(missing) = manifest.spot_check(dest, &target.key_prefix()).await
     {
         report.manifest_spot_check_missing += 1;
         tracing::warn!(

--- a/crates/trusty-common/src/log_drain/tests.rs
+++ b/crates/trusty-common/src/log_drain/tests.rs
@@ -74,57 +74,29 @@ fn touch_forward(path: &Path) {
 
 // ── DestinationUri: the table ───────────────────────────────────────────────
 
+/// An `s3://` destination with no identity pinned — the shape of most cases.
+fn s3(bucket: &str, prefix: &str, region: Option<&str>) -> DestinationUri {
+    DestinationUri::S3 {
+        bucket: bucket.into(),
+        prefix: prefix.into(),
+        region: region.map(str::to_string),
+        profile: None,
+        role_arn: None,
+    }
+}
+
 #[test]
 fn uri_table_accepts() {
     let cases: &[(&str, DestinationUri)] = &[
-        (
-            "s3://my-bucket",
-            DestinationUri::S3 {
-                bucket: "my-bucket".into(),
-                prefix: String::new(),
-                region: None,
-            },
-        ),
-        (
-            "s3://my-bucket/",
-            DestinationUri::S3 {
-                bucket: "my-bucket".into(),
-                prefix: String::new(),
-                region: None,
-            },
-        ),
-        (
-            "s3://my-bucket/logs",
-            DestinationUri::S3 {
-                bucket: "my-bucket".into(),
-                prefix: "logs".into(),
-                region: None,
-            },
-        ),
+        ("s3://my-bucket", s3("my-bucket", "", None)),
+        ("s3://my-bucket/", s3("my-bucket", "", None)),
+        ("s3://my-bucket/logs", s3("my-bucket", "logs", None)),
         (
             "s3://my-bucket/logs/nested/",
-            DestinationUri::S3 {
-                bucket: "my-bucket".into(),
-                prefix: "logs/nested".into(),
-                region: None,
-            },
+            s3("my-bucket", "logs/nested", None),
         ),
-        (
-            "  s3://my-bucket/logs  ",
-            DestinationUri::S3 {
-                bucket: "my-bucket".into(),
-                prefix: "logs".into(),
-                region: None,
-            },
-        ),
-        (
-            "S3://my-bucket/logs",
-            DestinationUri::S3 {
-                bucket: "my-bucket".into(),
-                prefix: "logs".into(),
-                region: None,
-            },
-        ),
+        ("  s3://my-bucket/logs  ", s3("my-bucket", "logs", None)),
+        ("S3://my-bucket/logs", s3("my-bucket", "logs", None)),
         (
             "file:///var/log/trusty",
             DestinationUri::File {
@@ -149,14 +121,62 @@ fn uri_table_accepts() {
 #[test]
 fn uri_region_override() {
     let parsed = DestinationUri::parse("s3://bucket/logs?region=us-west-2").expect("parses");
-    assert_eq!(
-        parsed,
-        DestinationUri::S3 {
-            bucket: "bucket".into(),
-            prefix: "logs".into(),
-            region: Some("us-west-2".into()),
-        }
-    );
+    assert_eq!(parsed, s3("bucket", "logs", Some("us-west-2")));
+}
+
+#[test]
+fn uri_accepts_profile_and_role_arn() {
+    // #6657: a per-source destination has to be able to name its own identity,
+    // or every destination in one daemon signs with whatever the process-wide
+    // default chain happened to resolve.
+    /// One URI and the three query values it must parse to.
+    struct Case {
+        uri: &'static str,
+        region: Option<&'static str>,
+        profile: Option<&'static str>,
+        role_arn: Option<&'static str>,
+    }
+
+    let arn = "arn:aws:iam::141377423791:role/log-drain-writer";
+    let cases = [
+        Case {
+            uri: "s3://b/p?profile=logs-writer",
+            region: None,
+            profile: Some("logs-writer"),
+            role_arn: None,
+        },
+        Case {
+            uri: "s3://b/p?role_arn=arn:aws:iam::141377423791:role/log-drain-writer",
+            region: None,
+            profile: None,
+            role_arn: Some(arn),
+        },
+        // All three, in an order that is not the parser's own.
+        Case {
+            uri: "s3://b/p?role_arn=arn:aws:iam::141377423791:role/log-drain-writer\
+                  &profile=logs-writer&region=us-east-1",
+            region: Some("us-east-1"),
+            profile: Some("logs-writer"),
+            role_arn: Some(arn),
+        },
+    ];
+
+    for case in cases {
+        let parsed = DestinationUri::parse(case.uri)
+            .unwrap_or_else(|e| panic!("`{}` should parse, got {e}", case.uri));
+        assert_eq!(
+            parsed,
+            DestinationUri::S3 {
+                bucket: "b".into(),
+                prefix: "p".into(),
+                region: case.region.map(str::to_string),
+                profile: case.profile.map(str::to_string),
+                role_arn: case.role_arn.map(str::to_string),
+            },
+            "parsing `{}`",
+            case.uri
+        );
+    }
 }
 
 #[test]
@@ -187,6 +207,29 @@ fn cache_namespace_separates_destinations() {
 }
 
 #[test]
+fn cache_namespace_separates_identities() {
+    // #6657: two identities against one bucket can see different objects, so a
+    // skip decision made under one must not be read back under the other. The
+    // asymmetry with `?region=` below is deliberate — a region change cannot
+    // change what a bucket holds, an identity change can change what it shows.
+    let plain = DestinationUri::parse("s3://bucket-a/logs").expect("plain");
+    let profiled = DestinationUri::parse("s3://bucket-a/logs?profile=alpha").expect("profiled");
+    let other_profile = DestinationUri::parse("s3://bucket-a/logs?profile=beta").expect("beta");
+    let roled =
+        DestinationUri::parse("s3://bucket-a/logs?role_arn=arn:aws:iam::1:role/r").expect("roled");
+
+    assert_ne!(plain.cache_namespace(), profiled.cache_namespace());
+    assert_ne!(profiled.cache_namespace(), other_profile.cache_namespace());
+    assert_ne!(plain.cache_namespace(), roled.cache_namespace());
+    assert_ne!(profiled.cache_namespace(), roled.cache_namespace());
+
+    // A destination that pins no identity keeps the namespace it had before
+    // #6657, so upgrading does not orphan an existing cache directory.
+    let regioned = DestinationUri::parse("s3://bucket-a/logs?region=eu-west-1").expect("regioned");
+    assert_eq!(plain.cache_namespace(), regioned.cache_namespace());
+}
+
+#[test]
 fn cache_namespace_ignores_the_region_override() {
     // `?region=` changes which endpoint serves a bucket, never which objects it
     // holds, so adding one must not orphan a cache that is still valid (#6548).
@@ -210,6 +253,13 @@ fn uri_table_rejects() {
         ("s3://bucket/logs?region=", "empty region value"),
         ("s3://bucket/logs?reigon=eu-west-1", "misspelled parameter"),
         ("s3://bucket/logs?region", "parameter with no `=`"),
+        // #6657: the new keys are rejected the same way when misspelled or
+        // empty, and a repeated key never silently resolves to the last one.
+        ("s3://bucket/logs?porfile=writer", "misspelled profile"),
+        ("s3://bucket/logs?profile=", "empty profile value"),
+        ("s3://bucket/logs?role_arn=", "empty role_arn value"),
+        ("s3://bucket/logs?rolearn=arn:x", "misspelled role_arn"),
+        ("s3://bucket/logs?profile=a&profile=b", "repeated parameter"),
     ];
 
     for (input, why) in cases {
@@ -343,6 +393,125 @@ async fn destination_list_is_bounded_and_prefix_scoped() {
     assert!(
         listed.len() <= LIST_LIMIT,
         "list must never exceed its documented cap"
+    );
+}
+
+// ── #6657: per-destination S3 identity ──────────────────────────────────────
+
+/// Two profiles with distinct static keys, supplied in memory.
+///
+/// Nothing is written to disk and no env var is touched, so this cannot pick up
+/// the developer's own `~/.aws` files or collide with a concurrent test.
+#[allow(deprecated)]
+fn fixture_profiles() -> super::destination::ProfileFiles {
+    use aws_config::profile::profile_file::ProfileFileKind;
+    super::destination::ProfileFiles::builder()
+        .with_contents(
+            ProfileFileKind::Credentials,
+            "[alpha]\n\
+             aws_access_key_id = AKIAALPHAALPHAALPHA\n\
+             aws_secret_access_key = alpha-secret\n\
+             \n\
+             [beta]\n\
+             aws_access_key_id = AKIABETABETABETABET\n\
+             aws_secret_access_key = beta-secret\n\
+             \n\
+             [regionless]\n\
+             aws_access_key_id = AKIANOREGIONNOREGIO\n\
+             aws_secret_access_key = regionless-secret\n",
+        )
+        .with_contents(
+            ProfileFileKind::Config,
+            "[profile alpha]\nregion = us-east-1\n\n[profile beta]\nregion = eu-west-1\n",
+        )
+        .build()
+}
+
+/// Resolve one destination's identity against the in-memory profile fixture.
+async fn resolve_fixture_auth(
+    label: &str,
+    region: Option<&str>,
+    profile: Option<&str>,
+) -> Result<super::destination::S3Auth, DrainError> {
+    let files = fixture_profiles();
+    super::destination::resolve_s3_auth(
+        label,
+        super::destination::S3AuthRequest {
+            region,
+            profile,
+            role_arn: None,
+            profile_files: Some(&files),
+        },
+    )
+    .await
+}
+
+#[tokio::test]
+async fn two_profiles_resolve_to_different_identities() {
+    // #6657: the whole point of a per-source `?profile=` is that two
+    // destinations in ONE daemon sign with two different sets of credentials.
+    // Proving it needs no bucket and no network — the credentials the provider
+    // hands back are the observable.
+    use aws_credential_types::provider::ProvideCredentials;
+
+    let alpha = resolve_fixture_auth("s3://a/logs", None, Some("alpha"))
+        .await
+        .expect("alpha resolves");
+    let beta = resolve_fixture_auth("s3://b/logs", None, Some("beta"))
+        .await
+        .expect("beta resolves");
+
+    let alpha_key = alpha
+        .provider
+        .provide_credentials()
+        .await
+        .expect("alpha credentials")
+        .access_key_id()
+        .to_string();
+    let beta_key = beta
+        .provider
+        .provide_credentials()
+        .await
+        .expect("beta credentials")
+        .access_key_id()
+        .to_string();
+
+    assert_eq!(alpha_key, "AKIAALPHAALPHAALPHA");
+    assert_eq!(beta_key, "AKIABETABETABETABET");
+    assert_ne!(
+        alpha_key, beta_key,
+        "two profiles must not collapse onto one identity"
+    );
+
+    // Each profile's own `region` is used, so a two-account layout needs no
+    // `?region=` on either URI.
+    assert_eq!(alpha.region, "us-east-1");
+    assert_eq!(beta.region, "eu-west-1");
+}
+
+#[tokio::test]
+async fn a_uri_region_overrides_the_profile_region() {
+    let resolved = resolve_fixture_auth("s3://a/logs", Some("ap-south-1"), Some("alpha"))
+        .await
+        .expect("resolves");
+    assert_eq!(resolved.region, "ap-south-1");
+}
+
+#[tokio::test]
+async fn a_profile_without_a_region_is_refused() {
+    // Signing for the wrong region reaches a bucket that is not there, so there
+    // is no literal to fall back to — the refusal names both levers.
+    let err = resolve_fixture_auth("s3://a/logs", None, Some("regionless"))
+        .await
+        .expect_err("a profile with no region and no `?region=` cannot be signed for");
+    match err {
+        DrainError::Credentials { ref uri, .. } => assert_eq!(uri, "s3://a/logs"),
+        other => panic!("expected DrainError::Credentials, got {other:?}"),
+    }
+    let message = err.to_string();
+    assert!(
+        message.contains("?region=") && message.contains("profile"),
+        "the refusal must name what to set, got: {message}"
     );
 }
 

--- a/crates/trusty-common/src/log_drain/tests.rs
+++ b/crates/trusty-common/src/log_drain/tests.rs
@@ -26,8 +26,8 @@ async fn file_dest(root: &Path) -> ObjectStoreDestination {
 
 fn target() -> DrainTarget {
     DrainTarget {
-        github_id: "bobmatnyc".to_string(),
-        session_id: "sess-01".to_string(),
+        owner: "bobmatnyc".to_string(),
+        project: "trusty-tools".to_string(),
     }
 }
 
@@ -294,33 +294,35 @@ fn uri_reserved_schemes() {
 
 #[test]
 fn key_layout_shape() {
+    // #6657: `<owner>/<project>/<relative log path>`, with no session segment
+    // and no `logs/` interlayer.
     let t = target();
-    assert_eq!(t.logs_prefix(), "bobmatnyc/sess-01/logs");
+    assert_eq!(t.key_prefix(), "bobmatnyc/trusty-tools");
     assert_eq!(
         t.object_key("trusty-mpm/daemon.log"),
-        "bobmatnyc/sess-01/logs/trusty-mpm/daemon.log"
+        "bobmatnyc/trusty-tools/trusty-mpm/daemon.log"
     );
     assert_eq!(
         t.manifest_key(),
-        "bobmatnyc/sess-01/logs/.drain-manifest.json"
+        "bobmatnyc/trusty-tools/.drain-manifest.json"
     );
 }
 
 #[test]
 fn identity_refusal_is_fail_closed() {
-    for (github_id, session_id, field) in [
-        ("", "sess", "github_id"),
-        ("   ", "sess", "github_id"),
-        ("bob", "", "session_id"),
-        ("bob", "  ", "session_id"),
+    for (owner, project, field) in [
+        ("", "proj", "owner"),
+        ("   ", "proj", "owner"),
+        ("bob", "", "project"),
+        ("bob", "  ", "project"),
     ] {
         let t = DrainTarget {
-            github_id: github_id.to_string(),
-            session_id: session_id.to_string(),
+            owner: owner.to_string(),
+            project: project.to_string(),
         };
         match t.validate() {
             Err(DrainError::MissingIdentity { field: got }) => assert_eq!(got, field),
-            other => panic!("`{github_id}`/`{session_id}` should refuse, got {other:?}"),
+            other => panic!("`{owner}`/`{project}` should refuse, got {other:?}"),
         }
     }
 }
@@ -930,7 +932,7 @@ async fn run_once_reuploads_when_the_destination_changes() {
         .await
         .expect("run against A");
     assert_eq!(first.uploaded, 2);
-    let a_before = contents(&dest_a, &t.logs_prefix()).await;
+    let a_before = contents(&dest_a, &t.key_prefix()).await;
 
     // Same identity, same state dir, a destination that holds nothing. B has no
     // manifest of its own, so before #6548 the load fell back to the cache
@@ -968,7 +970,7 @@ async fn run_once_reuploads_when_the_destination_changes() {
 
     assert_eq!(
         a_before,
-        contents(&dest_a, &t.logs_prefix()).await,
+        contents(&dest_a, &t.key_prefix()).await,
         "a run aimed at B must not write to A"
     );
 }
@@ -1425,21 +1427,21 @@ async fn run_once_re_evaluates_a_skip_when_the_file_changes() {
 }
 
 #[tokio::test]
-async fn run_once_refuses_empty_github_id() {
+async fn run_once_refuses_an_empty_owner() {
     let dest_root = tempfile::tempdir().expect("tempdir");
     let state = tempfile::tempdir().expect("tempdir");
     let dest = file_dest(dest_root.path()).await;
 
     let t = DrainTarget {
-        github_id: String::new(),
-        session_id: "sess-01".to_string(),
+        owner: String::new(),
+        project: "trusty-tools".to_string(),
     };
     let err = run_once(&DrainConfig::new(state.path()), &dest, &t, &[])
         .await
-        .expect_err("an empty github_id must be refused");
+        .expect_err("an empty owner must be refused");
     assert!(matches!(
         err,
-        DrainError::MissingIdentity { field: "github_id" }
+        DrainError::MissingIdentity { field: "owner" }
     ));
 
     // Fail-closed means NOTHING was written, not even a manifest.
@@ -1453,23 +1455,21 @@ async fn run_once_refuses_empty_github_id() {
 }
 
 #[tokio::test]
-async fn run_once_refuses_empty_session_id() {
+async fn run_once_refuses_an_empty_project() {
     let dest_root = tempfile::tempdir().expect("tempdir");
     let state = tempfile::tempdir().expect("tempdir");
     let dest = file_dest(dest_root.path()).await;
 
     let t = DrainTarget {
-        github_id: "bobmatnyc".to_string(),
-        session_id: "   ".to_string(),
+        owner: "bobmatnyc".to_string(),
+        project: "   ".to_string(),
     };
     let err = run_once(&DrainConfig::new(state.path()), &dest, &t, &[])
         .await
-        .expect_err("an empty session_id must be refused");
+        .expect_err("an empty project must be refused");
     assert!(matches!(
         err,
-        DrainError::MissingIdentity {
-            field: "session_id"
-        }
+        DrainError::MissingIdentity { field: "project" }
     ));
 }
 
@@ -1574,8 +1574,8 @@ async fn s3_smoke() {
     write(&logs.path().join("smoke.log"), TRACING_FIXTURE);
 
     let t = DrainTarget {
-        github_id: "log-drain-smoke".to_string(),
-        session_id: format!("run-{}", chrono::Utc::now().timestamp()),
+        owner: "log-drain-smoke".to_string(),
+        project: format!("run-{}", chrono::Utc::now().timestamp()),
     };
     let cfg = DrainConfig::new(state.path());
 

--- a/crates/trusty-common/src/log_drain/tests.rs
+++ b/crates/trusty-common/src/log_drain/tests.rs
@@ -429,11 +429,29 @@ fn fixture_profiles() -> super::destination::ProfileFiles {
         .build()
 }
 
+/// The role every `?role_arn=` fixture assumes. Never contacted: the provider
+/// is lazy, so building one reaches no STS endpoint.
+const FIXTURE_ROLE_ARN: &str = "arn:aws:iam::123456789012:role/log-drain";
+
 /// Resolve one destination's identity against the in-memory profile fixture.
 async fn resolve_fixture_auth(
     label: &str,
     region: Option<&str>,
     profile: Option<&str>,
+) -> Result<super::destination::S3Auth, DrainError> {
+    resolve_fixture_auth_with_role(label, region, profile, None).await
+}
+
+/// The same, with an explicit `?role_arn=`.
+///
+/// Every caller also pins a `profile`. A role with no profile falls through to
+/// the AWS default chain, which reads the developer's own environment and
+/// `~/.aws` files — the one thing this fixture exists to avoid.
+async fn resolve_fixture_auth_with_role(
+    label: &str,
+    region: Option<&str>,
+    profile: Option<&str>,
+    role_arn: Option<&str>,
 ) -> Result<super::destination::S3Auth, DrainError> {
     let files = fixture_profiles();
     super::destination::resolve_s3_auth(
@@ -441,7 +459,7 @@ async fn resolve_fixture_auth(
         super::destination::S3AuthRequest {
             region,
             profile,
-            role_arn: None,
+            role_arn,
             profile_files: Some(&files),
         },
     )
@@ -515,6 +533,63 @@ async fn a_profile_without_a_region_is_refused() {
         message.contains("?region=") && message.contains("profile"),
         "the refusal must name what to set, got: {message}"
     );
+}
+
+#[tokio::test]
+async fn a_role_arn_resolves_to_an_assumed_role_identity() {
+    // #6657: `?role_arn=` is how one daemon writes into an account it holds no
+    // long-lived keys for. The provider the branch builds is the observable —
+    // reading credentials from it would call STS, and the design is that it
+    // does not until the first upload.
+    let resolved =
+        resolve_fixture_auth_with_role("s3://a/logs", None, Some("alpha"), Some(FIXTURE_ROLE_ARN))
+            .await
+            .expect("a role over a profile resolves");
+
+    // The region the STS client is pinned to comes off the same ladder an
+    // ordinary destination uses — here, the profile's own.
+    assert_eq!(resolved.region, "us-east-1");
+    let provider = format!("{:?}", resolved.provider);
+    assert!(
+        provider.contains("AssumeRoleProvider"),
+        "the role branch must wrap the base identity, got: {provider}"
+    );
+}
+
+#[tokio::test]
+async fn a_profile_and_a_role_arn_do_not_collapse_onto_the_profile() {
+    // The two knobs compose: the profile signs the AssumeRole, and the assumed
+    // role is what reaches S3. Returning the base provider unwrapped would
+    // still resolve, still carry the right region, and write with the wrong
+    // identity — so the with/without comparison is the assertion, not the Ok.
+    let plain = resolve_fixture_auth("s3://a/logs", None, Some("alpha"))
+        .await
+        .expect("the profile alone resolves");
+    let assumed = resolve_fixture_auth_with_role(
+        "s3://a/logs",
+        Some("ap-south-1"),
+        Some("alpha"),
+        Some(FIXTURE_ROLE_ARN),
+    )
+    .await
+    .expect("the profile plus a role resolves");
+
+    let plain_provider = format!("{:?}", plain.provider);
+    let assumed_provider = format!("{:?}", assumed.provider);
+    assert!(
+        !plain_provider.contains("AssumeRoleProvider"),
+        "no `?role_arn=` was given, got: {plain_provider}"
+    );
+    assert!(
+        assumed_provider.contains("AssumeRoleProvider"),
+        "the same profile plus a role must not resolve to the bare profile \
+         identity, got: {assumed_provider}"
+    );
+
+    // `?region=` still wins over the profile's own with a role in play, so the
+    // STS client is pinned to the region the operator asked for.
+    assert_eq!(plain.region, "us-east-1");
+    assert_eq!(assumed.region, "ap-south-1");
 }
 
 // ── collector: level filtering ──────────────────────────────────────────────

--- a/crates/trusty-common/src/log_drain/uri.rs
+++ b/crates/trusty-common/src/log_drain/uri.rs
@@ -11,7 +11,8 @@
 //! over `str` — split on `://`, dispatch on the scheme, then parse the
 //! remainder per-scheme. No generic URI crate is involved.
 //! Test: `super::tests::uri_table_accepts`, `super::tests::uri_table_rejects`,
-//! `super::tests::uri_reserved_schemes`, `super::tests::uri_region_override`.
+//! `super::tests::uri_reserved_schemes`, `super::tests::uri_region_override`,
+//! `super::tests::uri_accepts_profile_and_role_arn`.
 
 use std::path::PathBuf;
 
@@ -77,6 +78,19 @@ pub enum DestinationUri {
         prefix: String,
         /// Region override from `?region=…`. `None` defers to the AWS chain.
         region: Option<String>,
+        /// Named `~/.aws` profile from `?profile=…` (#6657).
+        ///
+        /// `Some` means the profile is the WHOLE identity: the adapter reads
+        /// credentials from that profile alone and never consults the default
+        /// chain, so `AWS_ACCESS_KEY_ID` in the daemon's environment cannot
+        /// silently re-point one destination at another account.
+        profile: Option<String>,
+        /// Role to assume from `?role_arn=…` (#6657).
+        ///
+        /// Combines with `profile`: the profile (or the default chain when
+        /// there is none) supplies the base credentials the STS
+        /// `AssumeRole` call is signed with.
+        role_arn: Option<String>,
     },
     /// A local directory. Used by the hermetic tests and by any operator who
     /// wants the drain's output on disk before pointing it at a bucket.
@@ -94,10 +108,13 @@ impl DestinationUri {
     /// config reader, the CLI, and the tests.
     /// What: splits at the first `://`, resolves the scheme through
     /// [`DestinationScheme::parse`], then parses the remainder per scheme.
-    /// `s3://bucket/prefix?region=us-west-2` overrides the region the AWS chain
-    /// would otherwise supply; no other query parameter is accepted.
+    /// An `s3://` URI accepts exactly three query parameters — `region`,
+    /// `profile`, and `role_arn` (#6657) — in any combination and any order.
+    /// Every other key is rejected, and a repeated key is rejected rather than
+    /// letting the last one win.
     /// Test: `super::tests::uri_table_accepts`, `super::tests::uri_table_rejects`,
-    /// `super::tests::uri_reserved_schemes`, `super::tests::uri_region_override`.
+    /// `super::tests::uri_reserved_schemes`, `super::tests::uri_region_override`,
+    /// `super::tests::uri_accepts_profile_and_role_arn`.
     ///
     /// # Errors
     /// - [`DrainError::UnsupportedScheme`] for `gs://` and `az://`, and for any
@@ -134,7 +151,8 @@ impl DestinationUri {
         }
     }
 
-    /// Parse the remainder of an `s3://` URI: `bucket[/prefix][?region=…]`.
+    /// Parse the remainder of an `s3://` URI:
+    /// `bucket[/prefix][?region=…&profile=…&role_arn=…]`.
     fn parse_s3(uri: &str, rest: &str) -> Result<Self, DrainError> {
         let (path_part, query) = match rest.split_once('?') {
             Some((p, q)) => (p, Some(q)),
@@ -153,15 +171,17 @@ impl DestinationUri {
             });
         }
 
-        let region = match query {
-            Some(q) => Some(parse_region_query(uri, q)?),
-            None => None,
+        let params = match query {
+            Some(q) => parse_s3_query(uri, q)?,
+            None => S3Params::default(),
         };
 
         Ok(Self::S3 {
             bucket: bucket.to_string(),
             prefix: normalise_prefix(prefix),
-            region,
+            region: params.region,
+            profile: params.profile,
+            role_arn: params.role_arn,
         })
     }
 
@@ -218,20 +238,44 @@ impl DestinationUri {
     /// has to be part of where that decision is stored.
     ///
     /// What: `<scheme>-<first 16 hex chars of SHA-256(canonical form)>`. The
-    /// canonical form carries scheme, bucket-or-path, and key prefix —
-    /// everything that changes WHICH objects a destination holds. `?region=` is
-    /// excluded on purpose: a region override changes which endpoint serves a
-    /// bucket, never its contents, so adding one must not orphan a valid cache.
+    /// canonical form carries scheme, bucket-or-path, key prefix, and the
+    /// identity (`profile`, `role_arn`) — everything that changes WHICH objects
+    /// a destination holds or can see. `?region=` is excluded on purpose: a
+    /// region override changes which endpoint serves a bucket, never its
+    /// contents, so adding one must not orphan a valid cache. The identity is
+    /// NOT excluded, because two identities against one bucket can see
+    /// different objects, and the cheap way to be wrong is the safe one — an
+    /// unnecessary split re-uploads, a wrong share skips (#6657).
     /// The value is hashed rather than spelled out because a key prefix and a
     /// filesystem path are both arbitrary strings, and a cache directory needs
     /// one segment with no `/`, no `..`, and no length surprise.
     ///
     /// Test: `super::tests::cache_namespace_separates_destinations`,
-    /// `super::tests::cache_namespace_ignores_the_region_override`.
+    /// `super::tests::cache_namespace_ignores_the_region_override`,
+    /// `super::tests::cache_namespace_separates_identities`.
     pub fn cache_namespace(&self) -> String {
         let (scheme, canonical) = match self {
             // #6548: `region` is deliberately absent from the canonical form.
-            Self::S3 { bucket, prefix, .. } => ("s3", format!("s3://{bucket}/{prefix}")),
+            Self::S3 {
+                bucket,
+                prefix,
+                profile,
+                role_arn,
+                ..
+            } => {
+                // The suffix is appended only when an identity is pinned, so a
+                // destination written before #6657 keeps the namespace its
+                // existing cache directory already carries.
+                let identity = match (profile.as_deref(), role_arn.as_deref()) {
+                    (None, None) => String::new(),
+                    (p, r) => format!(
+                        "#profile={}&role_arn={}",
+                        p.unwrap_or_default(),
+                        r.unwrap_or_default()
+                    ),
+                };
+                ("s3", format!("s3://{bucket}/{prefix}{identity}"))
+            }
             Self::File { path } => ("file", format!("file://{}", path.display())),
         };
         // `hex_digest` is a SHA-256 in hex, so it is always 64 characters.
@@ -248,35 +292,64 @@ impl DestinationUri {
     }
 }
 
-/// Extract `region=<value>` from an `s3://` query string.
+/// The three `s3://` query parameters, before they reach the enum variant.
+#[derive(Debug, Default)]
+struct S3Params {
+    region: Option<String>,
+    profile: Option<String>,
+    role_arn: Option<String>,
+}
+
+/// Extract `region=`, `profile=`, and `role_arn=` from an `s3://` query string.
 ///
 /// Rejects any other parameter rather than ignoring it: a silently-dropped
-/// `?reigon=eu-west-1` would send logs to the wrong region with no signal.
-fn parse_region_query(uri: &str, query: &str) -> Result<String, DrainError> {
-    let mut region = None;
+/// `?reigon=eu-west-1` would send logs to the wrong region with no signal, and
+/// a silently-dropped `?porfile=logs-writer` would send them to the wrong
+/// ACCOUNT under whatever identity the default chain happened to hold (#6657).
+/// A repeated key is rejected for the same reason — picking the last occurrence
+/// makes `?profile=a&profile=b` mean `b` with nothing on screen saying so.
+fn parse_s3_query(uri: &str, query: &str) -> Result<S3Params, DrainError> {
+    let mut params = S3Params::default();
     for pair in query.split('&').filter(|p| !p.is_empty()) {
         let (key, value) = pair.split_once('=').ok_or_else(|| DrainError::Uri {
             uri: uri.to_string(),
             reason: format!("query parameter `{pair}` has no `=`"),
         })?;
-        if key != "region" {
-            return Err(DrainError::Uri {
-                uri: uri.to_string(),
-                reason: format!("unknown query parameter `{key}` — only `region` is accepted"),
-            });
-        }
         if value.is_empty() {
             return Err(DrainError::Uri {
                 uri: uri.to_string(),
-                reason: "`region=` is empty".to_string(),
+                reason: format!("`{key}=` is empty"),
             });
         }
-        region = Some(value.to_string());
+        let slot = match key {
+            "region" => &mut params.region,
+            "profile" => &mut params.profile,
+            "role_arn" => &mut params.role_arn,
+            _ => {
+                return Err(DrainError::Uri {
+                    uri: uri.to_string(),
+                    reason: format!(
+                        "unknown query parameter `{key}` — only `region`, `profile`, \
+                         and `role_arn` are accepted"
+                    ),
+                });
+            }
+        };
+        if slot.is_some() {
+            return Err(DrainError::Uri {
+                uri: uri.to_string(),
+                reason: format!("query parameter `{key}` is given more than once"),
+            });
+        }
+        *slot = Some(value.to_string());
     }
-    region.ok_or_else(|| DrainError::Uri {
-        uri: uri.to_string(),
-        reason: "query string is present but empty".to_string(),
-    })
+    if params.region.is_none() && params.profile.is_none() && params.role_arn.is_none() {
+        return Err(DrainError::Uri {
+            uri: uri.to_string(),
+            reason: "query string is present but empty".to_string(),
+        });
+    }
+    Ok(params)
 }
 
 /// Strip leading and trailing `/` and collapse the empty case.

--- a/crates/trusty-git-analytics/changelog.d/6657-one-remote-url-parser.md
+++ b/crates/trusty-git-analytics/changelog.d/6657-one-remote-url-parser.md
@@ -1,0 +1,7 @@
+Changed
+
+- `extract_owner_repo_from_url` delegates to
+  `trusty_common::github_path::parse_remote_url` instead of parsing the URL
+  itself, and the second copy of it under `commands::deployments` is now a
+  re-export of the first (#6657). The accepted forms are unchanged — HTTPS,
+  scp-style SSH, `ssh://`, and `https://user@`, GitHub hosts only.

--- a/crates/trusty-git-analytics/src/collect/github/repo_resolver.rs
+++ b/crates/trusty-git-analytics/src/collect/github/repo_resolver.rs
@@ -83,48 +83,25 @@ pub fn owner_repo_from_remote(repo_path: &std::path::Path) -> Option<(String, St
     extract_owner_repo_from_url(url)
 }
 
+/// GitHub host this resolver accepts a remote from.
+///
+/// The shared parser is host-agnostic; the GitHub REST client this feeds is
+/// not, so the filter lives here rather than in `trusty-common`.
+const GITHUB_HOST: &str = "github.com";
+
 /// Pure-string helper: extracts `owner/name` from a GitHub remote URL string.
 /// Returns `None` for non-GitHub URLs or malformed input.
 ///
 /// Why: separating the pure URL-parse logic from the disk-touching
 /// `owner_repo_from_remote` makes the URL-parse path independently testable.
-/// What: handles HTTPS, SSH, and `https://user@` URL forms.
+/// What: delegates to `trusty_common::github_path::parse_remote_url` — the
+/// workspace's one git-remote-URL parser (#6657) — and keeps only the
+/// GitHub-host filter this crate needs. HTTPS, SSH scp-syntax, `ssh://`, and
+/// `https://user@` forms all reach it through that parser.
 /// Test: `extract_owner_repo_from_url_handles_common_forms` in `client.rs` tests.
 pub fn extract_owner_repo_from_url(url: &str) -> Option<(String, String)> {
-    let cleaned = url.strip_suffix(".git").unwrap_or(url);
-    if let Some(rest) = cleaned.strip_prefix("git@github.com:") {
-        return split_owner_repo(rest);
-    }
-    for prefix in [
-        "https://github.com/",
-        "http://github.com/",
-        "ssh://git@github.com/",
-    ] {
-        if let Some(rest) = cleaned.strip_prefix(prefix) {
-            return split_owner_repo(rest);
-        }
-    }
-    if let Some(after_scheme) = cleaned.strip_prefix("https://") {
-        if let Some(at_idx) = after_scheme.find('@') {
-            let after_at = &after_scheme[at_idx + 1..];
-            if let Some(rest) = after_at.strip_prefix("github.com/") {
-                return split_owner_repo(rest);
-            }
-        }
-    }
-    None
-}
-
-/// Split a `owner/name(/...)` tail into a `(String, String)` pair.
-/// Returns `None` if either segment is empty.
-fn split_owner_repo(rest: &str) -> Option<(String, String)> {
-    let mut parts = rest.splitn(3, '/');
-    let owner = parts.next()?;
-    let name = parts.next()?;
-    if owner.is_empty() || name.is_empty() {
-        return None;
-    }
-    Some((owner.to_string(), name.to_string()))
+    let remote = trusty_common::github_path::parse_remote_url(url).ok()?;
+    (remote.host == GITHUB_HOST).then_some((remote.owner, remote.repo))
 }
 
 /// Resolve the set of `(owner, repo)` pairs the GitHub PR fetcher should

--- a/crates/trusty-git-analytics/src/commands/deployments/github.rs
+++ b/crates/trusty-git-analytics/src/commands/deployments/github.rs
@@ -140,51 +140,15 @@ fn owner_repo_from_remote(repo_path: &std::path::Path) -> Option<(String, String
     extract_owner_repo_from_url(url)
 }
 
-/// Pure-string helper: extract an `owner/name` pair from a GitHub
-/// remote URL string. Returns `None` for non-GitHub URLs or malformed
-/// input.
+/// Extract an `owner/name` pair from a GitHub remote URL string.
 ///
-/// Why: kept independent of `git2` so it can be unit-tested without a
-/// real repo on disk.
-/// What: strips the `.git` suffix, recognises HTTPS, SSH, and
-/// `ssh://git@github.com/...` forms.
+/// Why: this module carried its own copy of the parse until #6657, and the two
+/// copies had already drifted apart in what their docs claimed to accept —
+/// which is how two parsers of one grammar start answering differently.
+/// What: re-exports `collect::github::repo_resolver`'s adapter, which
+/// delegates to `trusty_common::github_path::parse_remote_url`.
 /// Test: covered by `extract_owner_repo_from_url_handles_common_forms`.
-pub(super) fn extract_owner_repo_from_url(url: &str) -> Option<(String, String)> {
-    let cleaned = url.strip_suffix(".git").unwrap_or(url);
-    if let Some(rest) = cleaned.strip_prefix("git@github.com:") {
-        return split_owner_repo(rest);
-    }
-    for prefix in [
-        "https://github.com/",
-        "http://github.com/",
-        "ssh://git@github.com/",
-    ] {
-        if let Some(rest) = cleaned.strip_prefix(prefix) {
-            return split_owner_repo(rest);
-        }
-    }
-    if let Some(after_scheme) = cleaned.strip_prefix("https://") {
-        if let Some(at_idx) = after_scheme.find('@') {
-            let after_at = &after_scheme[at_idx + 1..];
-            if let Some(rest) = after_at.strip_prefix("github.com/") {
-                return split_owner_repo(rest);
-            }
-        }
-    }
-    None
-}
-
-/// Split a `owner/name(/...)` tail into a `(String, String)`. Returns
-/// `None` if either segment is empty.
-fn split_owner_repo(rest: &str) -> Option<(String, String)> {
-    let mut parts = rest.splitn(3, '/');
-    let owner = parts.next()?;
-    let name = parts.next()?;
-    if owner.is_empty() || name.is_empty() {
-        return None;
-    }
-    Some((owner.to_string(), name.to_string()))
-}
+pub(super) use crate::collect::github::repo_resolver::extract_owner_repo_from_url;
 
 /// Parse the `Link: <url>; rel="next"` header value, returning the URL of
 /// the `next` page when present.

--- a/crates/trusty-mpm/changelog.d/6657-per-project-log-drain-layout-changed.md
+++ b/crates/trusty-mpm/changelog.d/6657-per-project-log-drain-layout-changed.md
@@ -1,0 +1,15 @@
+Changed
+
+- The log drain writes to `<owner>/<project>/<crate>/<file>` beneath the
+  destination prefix, replacing `<github_id>/<session_id>/logs/…` (#6657). Each
+  source resolves its owner and project from its own `owner:`/`project:`, else
+  the git `origin` of its `root` (git walks up, so a log directory inside a
+  checkout resolves to that checkout), else the new section-level
+  `owner:`/`project:`. A source that resolves none of the three is a hard config
+  error naming the source and its root — the drain never uploads under a
+  placeholder key. Sources are grouped by destination AND project, so one bucket
+  holding three projects runs three passes.
+- `log_drain.github_id` and `log_drain.session_id` are gone with the key
+  segments they filled, along with the `gh api user` probe and the persisted
+  per-install session id. Objects already uploaded under the old layout stay
+  where they are; see `docs/reference/log-drain.md`.

--- a/crates/trusty-mpm/changelog.d/6657-per-source-log-drain-destination-fixed.md
+++ b/crates/trusty-mpm/changelog.d/6657-per-source-log-drain-destination-fixed.md
@@ -1,0 +1,7 @@
+Fixed
+
+- A per-source destination that cannot be reached is skipped for that tick and
+  never retried against the section default. Falling back would ship a project's
+  logs to the wrong AWS account, which is the requirement the override exists to
+  satisfy. The tick reports `Failed`, the failing destination is named in the
+  doctor row, and every other destination still drains.

--- a/crates/trusty-mpm/changelog.d/6657-per-source-log-drain-destination.md
+++ b/crates/trusty-mpm/changelog.d/6657-per-source-log-drain-destination.md
@@ -1,0 +1,15 @@
+Added
+
+- A `log_drain.sources[]` entry can carry its own `destination`, so one daemon
+  drains different projects to different object stores — and to different AWS
+  accounts, using the `?profile=` / `?role_arn=` support added in
+  `trusty-common` (#6657). A source that names none inherits the section's
+  `destination` as before. Sources are grouped by the destination they resolve
+  to and the scheduler runs one pass per group, each with its own connection and
+  its own manifest; the manifest cache was already keyed by destination (#6548),
+  so nothing about that changed. `log_drain.destination` is now required only
+  when some source still needs it.
+- The `log_drain` doctor row lists every configured destination and quotes each
+  one's own last-run outcome, instead of reporting a single verdict for all of
+  them. `status.json` gained a `destinations` array; a file written before this
+  change still decodes and the row falls back to its single detail line.

--- a/crates/trusty-mpm/changelog.d/6657-per-source-log-drain-destination.md
+++ b/crates/trusty-mpm/changelog.d/6657-per-source-log-drain-destination.md
@@ -13,3 +13,9 @@ Added
   one's own last-run outcome, instead of reporting a single verdict for all of
   them. `status.json` gained a `destinations` array; a file written before this
   change still decodes and the row falls back to its single detail line.
+- A `log_drain.sources[]` entry can set `owner:` and `project:` to name the
+  project its keys sit under, and `enabled: false` to opt one project out of the
+  drain entirely (#6657). A disabled source runs no pass and uploads nothing;
+  the `log_drain` doctor row still lists it as `disabled` beside the destination
+  it would have used, so a deliberate opt-out reads differently from a project
+  that fell out of the config. The row also names each pass's project.

--- a/crates/trusty-mpm/src/core/trusty_tools_config.rs
+++ b/crates/trusty-mpm/src/core/trusty_tools_config.rs
@@ -43,7 +43,7 @@ pub use untracked_sync::{
 pub mod log_drain;
 pub use log_drain::{
     DEFAULT_INTERVAL_SECS as LOG_DRAIN_DEFAULT_INTERVAL_SECS, LogDrainConfig, LogDrainConfigError,
-    LogDrainSetting, LogDrainSourceConfig, ResolvedLogDrain,
+    LogDrainSetting, LogDrainSourceConfig, ResolvedDrainDestination, ResolvedLogDrain,
     STATE_SUBDIR as LOG_DRAIN_STATE_SUBDIR, resolve_log_drain,
 };
 

--- a/crates/trusty-mpm/src/core/trusty_tools_config.rs
+++ b/crates/trusty-mpm/src/core/trusty_tools_config.rs
@@ -42,9 +42,9 @@ pub use untracked_sync::{
 /// section is an error rather than a silent fall-back to defaults.
 pub mod log_drain;
 pub use log_drain::{
-    DEFAULT_INTERVAL_SECS as LOG_DRAIN_DEFAULT_INTERVAL_SECS, LogDrainConfig, LogDrainConfigError,
-    LogDrainSetting, LogDrainSourceConfig, ResolvedDrainDestination, ResolvedLogDrain,
-    STATE_SUBDIR as LOG_DRAIN_STATE_SUBDIR, resolve_log_drain,
+    DEFAULT_INTERVAL_SECS as LOG_DRAIN_DEFAULT_INTERVAL_SECS, DisabledSource, LogDrainConfig,
+    LogDrainConfigError, LogDrainSetting, LogDrainSourceConfig, ResolvedDrainDestination,
+    ResolvedLogDrain, STATE_SUBDIR as LOG_DRAIN_STATE_SUBDIR, resolve_log_drain,
 };
 
 /// Crate name used as the `~/.trusty-tools/<crate>/` directory segment.

--- a/crates/trusty-mpm/src/core/trusty_tools_config/log_drain.rs
+++ b/crates/trusty-mpm/src/core/trusty_tools_config/log_drain.rs
@@ -129,9 +129,11 @@ pub struct LogDrainConfig {
 /// each writes somewhere different. Naming sources in config means adopting a
 /// new producer needs no code change here.
 /// What: `crate_name` becomes a key segment, `root` is the directory walked,
-/// `include` the globs relative to it, `level` the minimum line level kept.
+/// `include` the globs relative to it, `level` the minimum line level kept, and
+/// `destination` the object store this source alone goes to (#6657).
 /// Test: `tests::resolve_uses_configured_sources`,
-/// `tests::resolve_rejects_a_source_with_no_root`.
+/// `tests::resolve_rejects_a_source_with_no_root`,
+/// `tests::resolve_groups_sources_by_destination`.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct LogDrainSourceConfig {
@@ -148,6 +150,15 @@ pub struct LogDrainSourceConfig {
     /// `None` → every line.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub level: Option<String>,
+    /// Where THIS source's logs go. `None` → the section's `destination`.
+    ///
+    /// #6657: one host drains several projects, and a project's logs can be
+    /// required to land in a specific AWS account. Overriding per source is how
+    /// that requirement is expressed without splitting the daemon. A source
+    /// whose override cannot be reached is SKIPPED, never rerouted to the
+    /// section default — see [`resolve_log_drain`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub destination: Option<String>,
 }
 
 /// Every way the `log_drain:` section can be wrong.
@@ -189,6 +200,15 @@ pub enum LogDrainConfigError {
         field: &'static str,
     },
 
+    /// A `sources[].destination` override did not parse (#6657).
+    #[error("log_drain.sources[{index}].destination is invalid: {reason}")]
+    SourceDestination {
+        /// Position of the offending entry.
+        index: usize,
+        /// The parser's own message, which names the URI and what was wrong.
+        reason: String,
+    },
+
     /// A `sources[].level` value that is not a level name.
     #[error(
         "log_drain.sources[{index}].level `{value}` is not a level — \
@@ -202,12 +222,48 @@ pub enum LogDrainConfigError {
     },
 }
 
+/// One object store, and every source that resolved to it (#6657).
+///
+/// Why: the scheduler runs one `run_once` per destination, because `run_once`
+/// takes exactly one. Grouping here rather than in the scheduler means the
+/// doctor row and the scheduler read the same grouping, and a source can never
+/// be counted against a destination it was not configured for.
+/// What: `sources` is non-empty by construction — a destination nothing points
+/// at is not in the list at all, so no pass is ever run for one.
+/// Test: `tests::resolve_groups_sources_by_destination`,
+/// `tests::resolve_inherits_the_section_destination`.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct ResolvedDrainDestination {
+    /// The parsed destination.
+    pub destination: DestinationUri,
+    /// The destination as the operator wrote it, for log and doctor messages.
+    pub destination_display: String,
+    /// The directories collected for this destination. Never empty.
+    pub sources: Vec<LogSource>,
+}
+
+impl ResolvedDrainDestination {
+    /// The destination's scheme, as the doctor row reports it.
+    pub fn scheme(&self) -> &'static str {
+        match self.destination.scheme() {
+            DestinationScheme::S3 => "s3",
+            DestinationScheme::File => "file",
+            // `DestinationScheme` is `#[non_exhaustive]` and reserves `gs`/`az`
+            // for a later phase; `DestinationUri::parse` refuses both today, so
+            // this arm is unreachable rather than a silent mislabel.
+            _ => "other",
+        }
+    }
+}
+
 /// A validated, runnable drain plan.
 ///
 /// Why: the scheduler and the doctor row both need the same resolved answer,
 /// and re-deriving it in two places is how the two disagree.
 /// What: everything `run_once` needs except the identity, which the scheduler
-/// resolves at tick time.
+/// resolves at tick time. `destinations` is non-empty for any enabled plan; the
+/// knobs beside it are section-wide and apply to every pass.
 /// Test: `tests::resolve_fills_defaults`.
 ///
 /// Deliberately not `PartialEq`: `LogSource` (a `trusty-common` type) is not,
@@ -216,10 +272,8 @@ pub enum LogDrainConfigError {
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct ResolvedLogDrain {
-    /// The parsed destination.
-    pub destination: DestinationUri,
-    /// The destination as the operator wrote it, for log and doctor messages.
-    pub destination_display: String,
+    /// Every destination with at least one source, in config order (#6657).
+    pub destinations: Vec<ResolvedDrainDestination>,
     /// How long the scheduler sleeps between passes.
     pub interval: Duration,
     /// Plaintext source ceiling handed to `DrainConfig`.
@@ -232,22 +286,6 @@ pub struct ResolvedLogDrain {
     pub github_id: Option<String>,
     /// Operator-pinned session segment, when one was configured.
     pub session_id: Option<String>,
-    /// The directories to collect.
-    pub sources: Vec<LogSource>,
-}
-
-impl ResolvedLogDrain {
-    /// The destination's scheme, as the doctor row reports it.
-    pub fn scheme(&self) -> &'static str {
-        match self.destination.scheme() {
-            DestinationScheme::S3 => "s3",
-            DestinationScheme::File => "file",
-            // `DestinationScheme` is `#[non_exhaustive]` and reserves `gs`/`az`
-            // for a later phase; `DestinationUri::parse` refuses both today, so
-            // this arm is unreachable rather than a silent mislabel.
-            _ => "other",
-        }
-    }
 }
 
 /// What the config says the drain should do.
@@ -279,10 +317,26 @@ pub enum LogDrainSetting {
 /// `<home>/.trusty-mpm/logs` filtered at INFO, which is the file appender
 /// `bin/tm/main.rs` installs for the daemon.
 ///
+/// # Per-source destinations (#6657)
+///
+/// A source's own `destination` wins over the section's; a source that names
+/// none inherits the section default. Sources are then GROUPED by the
+/// destination they resolved to, in first-appearance order, and the scheduler
+/// runs one pass per group. `destination` at the section level is required only
+/// when at least one source still needs it — a config where every source names
+/// its own is complete without one.
+///
+/// Grouping is by the PARSED destination, so `s3://b/p` and `s3://b/p/` are one
+/// group, while two identities against one bucket (`?profile=`) are two. That
+/// asymmetry matches `DestinationUri::cache_namespace`, which the manifest
+/// cache is keyed by (#6548) — so each group's pass reads and writes its own
+/// record with no forking of that fix.
+///
 /// Test: `tests::resolve_disabled_when_section_absent`,
 /// `tests::resolve_fills_defaults`,
 /// `tests::resolve_rejects_a_malformed_destination`,
-/// `tests::resolve_validates_even_while_disabled`.
+/// `tests::resolve_validates_even_while_disabled`,
+/// `tests::resolve_groups_sources_by_destination`.
 ///
 /// # Errors
 /// Any [`LogDrainConfigError`]. The caller must not fall back to a default
@@ -329,47 +383,84 @@ pub fn resolve_log_drain(
 
     let sources = resolve_sources(&section.sources, home)?;
 
-    let Some((destination_display, destination)) = destination else {
-        // Reached only when `destination` is absent: a present-but-malformed
-        // one already returned above, disabled or not.
-        return if enabled {
-            Err(LogDrainConfigError::MissingDestination)
-        } else {
-            Ok(LogDrainSetting::Disabled)
-        };
-    };
-
     if !enabled {
         return Ok(LogDrainSetting::Disabled);
     }
 
+    let destinations = group_by_destination(sources, destination)?;
+
     Ok(LogDrainSetting::Enabled(Box::new(ResolvedLogDrain {
-        destination,
-        destination_display,
+        destinations,
         interval: Duration::from_secs(interval_secs),
         max_file_bytes,
         max_wire_bytes,
         secrets: section.secrets.clone(),
         github_id: non_empty(section.github_id.as_deref()),
         session_id: non_empty(section.session_id.as_deref()),
-        sources,
     })))
+}
+
+/// A destination as the operator wrote it, beside its parsed form.
+type NamedDestination = (String, DestinationUri);
+
+/// One source and the destination override it carried, if any.
+type SourceWithOverride = (LogSource, Option<NamedDestination>);
+
+/// Collect sources under the destination each one resolved to (#6657).
+///
+/// First-appearance order, so the doctor row and the log lines list
+/// destinations in the order the operator wrote them rather than in whatever
+/// order a hash map yields. A linear scan is the right structure here: a host
+/// drains to a handful of destinations, and `DestinationUri` is `Eq` but not
+/// `Hash`.
+///
+/// Test: `tests::resolve_groups_sources_by_destination`,
+/// `tests::resolve_rejects_enabled_with_no_destination`.
+fn group_by_destination(
+    sources: Vec<SourceWithOverride>,
+    default: Option<NamedDestination>,
+) -> Result<Vec<ResolvedDrainDestination>, LogDrainConfigError> {
+    let mut groups: Vec<ResolvedDrainDestination> = Vec::new();
+    for (source, over) in sources {
+        // A source with no override needs the section default; without one
+        // there is nowhere for it to go, and guessing is what #6657 forbids.
+        let (display, uri) = match over.or_else(|| default.clone()) {
+            Some(named) => named,
+            None => return Err(LogDrainConfigError::MissingDestination),
+        };
+        match groups.iter_mut().find(|g| g.destination == uri) {
+            Some(group) => group.sources.push(source),
+            None => groups.push(ResolvedDrainDestination {
+                destination: uri,
+                destination_display: display,
+                sources: vec![source],
+            }),
+        }
+    }
+    Ok(groups)
 }
 
 /// Validate the `sources[]` list, or supply the built-in daemon source.
 ///
-/// Test: `tests::resolve_fills_defaults`, `tests::resolve_uses_configured_sources`.
+/// Each entry's `destination` override is parsed here so a typo is refused
+/// while the drain is still disabled, exactly as the section's own is.
+///
+/// Test: `tests::resolve_fills_defaults`, `tests::resolve_uses_configured_sources`,
+/// `tests::resolve_rejects_a_malformed_source_destination`.
 fn resolve_sources(
     configured: &[LogDrainSourceConfig],
     home: &Path,
-) -> Result<Vec<LogSource>, LogDrainConfigError> {
+) -> Result<Vec<SourceWithOverride>, LogDrainConfigError> {
     if configured.is_empty() {
-        return Ok(vec![LogSource {
-            crate_name: super::CRATE_NAME.to_string(),
-            root: home.join(".trusty-mpm").join(DAEMON_LOG_SUBDIR),
-            include: DEFAULT_INCLUDE.iter().map(|s| (*s).to_string()).collect(),
-            level_filter: Some(Level::Info),
-        }]);
+        return Ok(vec![(
+            LogSource {
+                crate_name: super::CRATE_NAME.to_string(),
+                root: home.join(".trusty-mpm").join(DAEMON_LOG_SUBDIR),
+                include: DEFAULT_INCLUDE.iter().map(|s| (*s).to_string()).collect(),
+                level_filter: Some(Level::Info),
+            },
+            None,
+        )]);
     }
 
     configured
@@ -403,12 +494,27 @@ fn resolve_sources(
             } else {
                 entry.include.clone()
             };
-            Ok(LogSource {
-                crate_name,
-                root: expand_home(&root, home),
-                include,
-                level_filter,
-            })
+            let over = match non_empty(entry.destination.as_deref()) {
+                None => None,
+                Some(raw) => {
+                    let uri = DestinationUri::parse(&raw).map_err(|e| {
+                        LogDrainConfigError::SourceDestination {
+                            index,
+                            reason: e.to_string(),
+                        }
+                    })?;
+                    Some((raw, uri))
+                }
+            };
+            Ok((
+                LogSource {
+                    crate_name,
+                    root: expand_home(&root, home),
+                    include,
+                    level_filter,
+                },
+                over,
+            ))
         })
         .collect()
 }

--- a/crates/trusty-mpm/src/core/trusty_tools_config/log_drain.rs
+++ b/crates/trusty-mpm/src/core/trusty_tools_config/log_drain.rs
@@ -33,11 +33,15 @@ use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use trusty_common::log_drain::{
-    DEFAULT_MAX_FILE_BYTES, DEFAULT_MAX_WIRE_BYTES, DestinationScheme, DestinationUri, Level,
-    LogSource,
+    DEFAULT_MAX_FILE_BYTES, DEFAULT_MAX_WIRE_BYTES, DestinationScheme, DestinationUri, DrainTarget,
+    Level, LogSource,
 };
 
 use super::TrustyToolsConfig;
+
+mod plan;
+
+pub use plan::DisabledSource;
 
 /// Default interval between drain passes, in seconds.
 ///
@@ -46,8 +50,8 @@ use super::TrustyToolsConfig;
 /// object-store bill and fewer wakeups on a laptop.
 pub const DEFAULT_INTERVAL_SECS: u64 = 900;
 
-/// Directory under `~/.trusty-mpm/` holding the drain's manifest cache, the
-/// persisted session id, and the last-run status the doctor row reads.
+/// Directory under `~/.trusty-mpm/` holding the drain's manifest cache and the
+/// last-run status the doctor row reads.
 pub const STATE_SUBDIR: &str = "log-drain";
 
 /// Directory the trusty-mpm daemon's own rotating file log is written to,
@@ -107,16 +111,18 @@ pub struct LogDrainConfig {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub secrets: Vec<String>,
 
-    /// GitHub login to upload under. `None` → resolved once via `gh api user`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub github_id: Option<String>,
-
-    /// Session segment of the key layout. `None` → the persisted per-install id.
+    /// Fallback repository owner for a source that resolves none (#6657).
     ///
-    /// See `daemon::log_drain::resolve_session_id` for why the daemon's session
-    /// is per-INSTALL rather than per-boot.
+    /// Consulted only after a source's own `owner`/`project` and the git
+    /// `origin` of its root, so a source that sits inside a checkout keeps that
+    /// checkout's identity. It exists for roots no repo owns — the daemon's own
+    /// `~/.trusty-mpm/logs` among them.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub session_id: Option<String>,
+    pub owner: Option<String>,
+
+    /// Fallback project name, paired with [`LogDrainConfig::owner`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project: Option<String>,
 
     /// Directories to collect. Empty → the built-in daemon log source.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -133,10 +139,19 @@ pub struct LogDrainConfig {
 /// `destination` the object store this source alone goes to (#6657).
 /// Test: `tests::resolve_uses_configured_sources`,
 /// `tests::resolve_rejects_a_source_with_no_root`,
-/// `tests::resolve_groups_sources_by_destination`.
+/// `tests::resolve_groups_sources_by_destination`,
+/// `tests::resolve_skips_a_disabled_source`.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct LogDrainSourceConfig {
+    /// Whether this source drains at all. `None` → it does (#6657).
+    ///
+    /// `enabled: false` opts one project out without deleting its entry, and
+    /// `tm doctor` still lists it so an operator can see the drain is off for
+    /// that project rather than misconfigured.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+
     /// Producing crate, e.g. `trusty-mpm`. Required.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub crate_name: Option<String>,
@@ -159,6 +174,19 @@ pub struct LogDrainSourceConfig {
     /// section default — see [`resolve_log_drain`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub destination: Option<String>,
+
+    /// Repository owner for this source's key prefix (#6657).
+    ///
+    /// Set it only when `root` is not inside a git checkout, or its `origin`
+    /// does not name the project the logs belong to. `owner` and `project` are
+    /// set together; one without the other is an error, because half an
+    /// identity cannot make a key.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner: Option<String>,
+
+    /// Project name for this source's key prefix, paired with `owner` (#6657).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project: Option<String>,
 }
 
 /// Every way the `log_drain:` section can be wrong.
@@ -209,6 +237,27 @@ pub enum LogDrainConfigError {
         reason: String,
     },
 
+    /// A source whose `owner`/`project` could not be resolved (#6657).
+    ///
+    /// Fail-closed: the drain refuses the whole plan rather than uploading one
+    /// project's logs under a guessed key. The message names the source, its
+    /// root, and the two ways to fix it.
+    #[error(
+        "log_drain.sources[{index}] ({crate_name}, root {root}) has no owner/project: \
+         {reason} — set `owner:` and `project:` on that source, or point `root:` \
+         inside a git checkout whose `origin` names the project"
+    )]
+    SourceIdentity {
+        /// Position of the offending entry.
+        index: usize,
+        /// The entry's `crate_name`, so the operator can find it by name.
+        crate_name: String,
+        /// The root that was probed.
+        root: String,
+        /// What the probe found, from `trusty_common::github_path`.
+        reason: String,
+    },
+
     /// A `sources[].level` value that is not a level name.
     #[error(
         "log_drain.sources[{index}].level `{value}` is not a level — \
@@ -222,16 +271,19 @@ pub enum LogDrainConfigError {
     },
 }
 
-/// One object store, and every source that resolved to it (#6657).
+/// One drain pass: an object store, a project, and the sources feeding it.
 ///
-/// Why: the scheduler runs one `run_once` per destination, because `run_once`
-/// takes exactly one. Grouping here rather than in the scheduler means the
-/// doctor row and the scheduler read the same grouping, and a source can never
-/// be counted against a destination it was not configured for.
-/// What: `sources` is non-empty by construction — a destination nothing points
-/// at is not in the list at all, so no pass is ever run for one.
+/// Why: the scheduler runs one `run_once` per entry, because `run_once` takes
+/// exactly one destination and exactly one [`DrainTarget`]. Grouping here
+/// rather than in the scheduler means the doctor row and the scheduler read the
+/// same grouping, and a source can never be counted against a destination it
+/// was not configured for.
+/// What: `sources` is non-empty by construction — a pass nothing points at is
+/// not in the list at all. Two sources share an entry only when they resolved
+/// to the same destination AND the same `owner/project` (#6657), because those
+/// two together are what the object keys and the manifest are namespaced by.
 /// Test: `tests::resolve_groups_sources_by_destination`,
-/// `tests::resolve_inherits_the_section_destination`.
+/// `tests::resolve_splits_one_destination_by_project`.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct ResolvedDrainDestination {
@@ -239,6 +291,8 @@ pub struct ResolvedDrainDestination {
     pub destination: DestinationUri,
     /// The destination as the operator wrote it, for log and doctor messages.
     pub destination_display: String,
+    /// The `<owner>/<project>` every key in this pass sits under.
+    pub target: DrainTarget,
     /// The directories collected for this destination. Never empty.
     pub sources: Vec<LogSource>,
 }
@@ -272,8 +326,13 @@ impl ResolvedDrainDestination {
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct ResolvedLogDrain {
-    /// Every destination with at least one source, in config order (#6657).
+    /// Every pass this plan runs, in config order (#6657).
     pub destinations: Vec<ResolvedDrainDestination>,
+    /// Sources the operator opted out with `enabled: false` (#6657).
+    ///
+    /// Carried rather than dropped so `tm doctor` can say the project is off on
+    /// purpose. Nothing in the scheduler reads it.
+    pub disabled: Vec<DisabledSource>,
     /// How long the scheduler sleeps between passes.
     pub interval: Duration,
     /// Plaintext source ceiling handed to `DrainConfig`.
@@ -282,10 +341,6 @@ pub struct ResolvedLogDrain {
     pub max_wire_bytes: u64,
     /// Extra literal secrets to scrub.
     pub secrets: Vec<String>,
-    /// Operator-pinned GitHub login, when one was configured.
-    pub github_id: Option<String>,
-    /// Operator-pinned session segment, when one was configured.
-    pub session_id: Option<String>,
 }
 
 /// What the config says the drain should do.
@@ -317,14 +372,20 @@ pub enum LogDrainSetting {
 /// `<home>/.trusty-mpm/logs` filtered at INFO, which is the file appender
 /// `bin/tm/main.rs` installs for the daemon.
 ///
-/// # Per-source destinations (#6657)
+/// # Per-source destinations and projects (#6657)
 ///
 /// A source's own `destination` wins over the section's; a source that names
-/// none inherits the section default. Sources are then GROUPED by the
-/// destination they resolved to, in first-appearance order, and the scheduler
-/// runs one pass per group. `destination` at the section level is required only
-/// when at least one source still needs it — a config where every source names
-/// its own is complete without one.
+/// none inherits the section default. Each source also resolves an
+/// `<owner>/<project>` — its own `owner:`/`project:`, else the git `origin` of
+/// its `root`, else the section's `owner:`/`project:`. A source that resolves
+/// none is [`LogDrainConfigError::SourceIdentity`], never a placeholder key.
+///
+/// Sources are then GROUPED by the destination AND project they resolved to, in
+/// first-appearance order, and the scheduler runs one pass per group.
+/// `destination` at the section level is required only when at least one source
+/// still needs it — a config where every source names its own is complete
+/// without one. A source with `enabled: false` is left out of every group and
+/// recorded in [`ResolvedLogDrain::disabled`].
 ///
 /// Grouping is by the PARSED destination, so `s3://b/p` and `s3://b/p/` are one
 /// group, while two identities against one bucket (`?profile=`) are two. That
@@ -332,11 +393,17 @@ pub enum LogDrainSetting {
 /// cache is keyed by (#6548) — so each group's pass reads and writes its own
 /// record with no forking of that fix.
 ///
+/// Identity resolution runs only for an ENABLED plan: it reads git, and a
+/// checkout that has lost its origin is an environment fault rather than the
+/// config typo the disabled-path validation exists to catch.
+///
 /// Test: `tests::resolve_disabled_when_section_absent`,
 /// `tests::resolve_fills_defaults`,
 /// `tests::resolve_rejects_a_malformed_destination`,
 /// `tests::resolve_validates_even_while_disabled`,
-/// `tests::resolve_groups_sources_by_destination`.
+/// `tests::resolve_groups_sources_by_destination`,
+/// `tests::resolve_reads_owner_and_project_from_the_git_origin`,
+/// `tests::resolve_refuses_a_source_with_no_resolvable_identity`.
 ///
 /// # Errors
 /// Any [`LogDrainConfigError`]. The caller must not fall back to a default
@@ -381,86 +448,78 @@ pub fn resolve_log_drain(
         });
     }
 
-    let sources = resolve_sources(&section.sources, home)?;
+    let prepared = resolve_sources(&section.sources, home)?;
 
     if !enabled {
         return Ok(LogDrainSetting::Disabled);
     }
 
-    let destinations = group_by_destination(sources, destination)?;
+    let fallback_identity = match (
+        non_empty(section.owner.as_deref()),
+        non_empty(section.project.as_deref()),
+    ) {
+        (Some(owner), Some(project)) => Some(DrainTarget { owner, project }),
+        _ => None,
+    };
+    let (destinations, disabled) = plan::build(prepared, destination, fallback_identity.as_ref())?;
 
     Ok(LogDrainSetting::Enabled(Box::new(ResolvedLogDrain {
         destinations,
+        disabled,
         interval: Duration::from_secs(interval_secs),
         max_file_bytes,
         max_wire_bytes,
         secrets: section.secrets.clone(),
-        github_id: non_empty(section.github_id.as_deref()),
-        session_id: non_empty(section.session_id.as_deref()),
     })))
 }
 
 /// A destination as the operator wrote it, beside its parsed form.
 type NamedDestination = (String, DestinationUri);
 
-/// One source and the destination override it carried, if any.
-type SourceWithOverride = (LogSource, Option<NamedDestination>);
-
-/// Collect sources under the destination each one resolved to (#6657).
+/// One validated `sources[]` entry, before its identity is resolved.
 ///
-/// First-appearance order, so the doctor row and the log lines list
-/// destinations in the order the operator wrote them rather than in whatever
-/// order a hash map yields. A linear scan is the right structure here: a host
-/// drains to a handful of destinations, and `DestinationUri` is `Eq` but not
-/// `Hash`.
-///
-/// Test: `tests::resolve_groups_sources_by_destination`,
-/// `tests::resolve_rejects_enabled_with_no_destination`.
-fn group_by_destination(
-    sources: Vec<SourceWithOverride>,
-    default: Option<NamedDestination>,
-) -> Result<Vec<ResolvedDrainDestination>, LogDrainConfigError> {
-    let mut groups: Vec<ResolvedDrainDestination> = Vec::new();
-    for (source, over) in sources {
-        // A source with no override needs the section default; without one
-        // there is nowhere for it to go, and guessing is what #6657 forbids.
-        let (display, uri) = match over.or_else(|| default.clone()) {
-            Some(named) => named,
-            None => return Err(LogDrainConfigError::MissingDestination),
-        };
-        match groups.iter_mut().find(|g| g.destination == uri) {
-            Some(group) => group.sources.push(source),
-            None => groups.push(ResolvedDrainDestination {
-                destination: uri,
-                destination_display: display,
-                sources: vec![source],
-            }),
-        }
-    }
-    Ok(groups)
+/// Why: validation is pure and runs even while the drain is disabled, but
+/// identity resolution reads git and runs only for an enabled plan. This is
+/// what the first stage hands the second.
+struct PreparedSource {
+    /// Position in `sources[]`, for error messages.
+    index: usize,
+    /// `enabled: false` keeps the entry out of every pass (#6657).
+    enabled: bool,
+    /// The collector's view of this entry.
+    source: LogSource,
+    /// The entry's own `destination`, when it named one.
+    destination: Option<NamedDestination>,
+    /// The entry's own `owner`/`project`, when it named both.
+    identity: Option<DrainTarget>,
 }
 
 /// Validate the `sources[]` list, or supply the built-in daemon source.
 ///
 /// Each entry's `destination` override is parsed here so a typo is refused
-/// while the drain is still disabled, exactly as the section's own is.
+/// while the drain is still disabled, exactly as the section's own is. Nothing
+/// here touches git: identity resolution belongs to [`plan::build`], which runs
+/// only for an enabled plan.
 ///
 /// Test: `tests::resolve_fills_defaults`, `tests::resolve_uses_configured_sources`,
 /// `tests::resolve_rejects_a_malformed_source_destination`.
 fn resolve_sources(
     configured: &[LogDrainSourceConfig],
     home: &Path,
-) -> Result<Vec<SourceWithOverride>, LogDrainConfigError> {
+) -> Result<Vec<PreparedSource>, LogDrainConfigError> {
     if configured.is_empty() {
-        return Ok(vec![(
-            LogSource {
+        return Ok(vec![PreparedSource {
+            index: 0,
+            enabled: true,
+            source: LogSource {
                 crate_name: super::CRATE_NAME.to_string(),
                 root: home.join(".trusty-mpm").join(DAEMON_LOG_SUBDIR),
                 include: DEFAULT_INCLUDE.iter().map(|s| (*s).to_string()).collect(),
                 level_filter: Some(Level::Info),
             },
-            None,
-        )]);
+            destination: None,
+            identity: None,
+        }]);
     }
 
     configured
@@ -506,15 +565,39 @@ fn resolve_sources(
                     Some((raw, uri))
                 }
             };
-            Ok((
-                LogSource {
+            let identity = match (
+                non_empty(entry.owner.as_deref()),
+                non_empty(entry.project.as_deref()),
+            ) {
+                (None, None) => None,
+                (Some(owner), Some(project)) => Some(DrainTarget { owner, project }),
+                // Half an identity cannot make a key, and filling the other
+                // half from git would silently mix two projects' logs.
+                (owner, _) => {
+                    return Err(LogDrainConfigError::SourceIdentity {
+                        index,
+                        crate_name,
+                        root,
+                        reason: format!(
+                            "`{}` is set but `{}` is not",
+                            if owner.is_some() { "owner" } else { "project" },
+                            if owner.is_some() { "project" } else { "owner" },
+                        ),
+                    });
+                }
+            };
+            Ok(PreparedSource {
+                index,
+                enabled: entry.enabled.unwrap_or(true),
+                source: LogSource {
                     crate_name,
                     root: expand_home(&root, home),
                     include,
                     level_filter,
                 },
-                over,
-            ))
+                destination: over,
+                identity,
+            })
         })
         .collect()
 }

--- a/crates/trusty-mpm/src/core/trusty_tools_config/log_drain/plan.rs
+++ b/crates/trusty-mpm/src/core/trusty_tools_config/log_drain/plan.rs
@@ -1,0 +1,138 @@
+//! From validated `sources[]` entries to runnable drain passes (#6657).
+//!
+//! Why: a host drains several projects, each to its own object store, and the
+//! key every upload lands under is `<owner>/<project>/…`. Deciding which
+//! project a source belongs to is the step that must never guess: a wrong
+//! answer files one team's logs under another's prefix, in an account that may
+//! not be theirs. It lives beside the config parser rather than inside it
+//! because it reads git, while parsing is pure — and because the parent module
+//! is close to the 500-SLOC production cap.
+//!
+//! What: [`build`] resolves each enabled source's [`DrainTarget`], groups the
+//! sources by the `(destination, target)` pair they resolved to, and returns
+//! the disabled ones alongside so the doctor row can name them.
+//!
+//! Test: `super::tests` — the resolution matrix is driven through
+//! `resolve_log_drain`, over real temp git repos.
+
+use trusty_common::github_path::derive_remote_repo;
+use trusty_common::log_drain::DrainTarget;
+
+use super::{LogDrainConfigError, NamedDestination, PreparedSource, ResolvedDrainDestination};
+
+/// A source the operator turned off with `enabled: false`.
+///
+/// Why: dropping it silently would make `tm doctor` report a project as
+/// undrained with no way to tell "switched off" from "never configured".
+/// What: what the row needs and nothing else — the source's `crate_name` and
+/// the destination it WOULD have used, when one is known.
+/// Test: `super::tests::resolve_skips_a_disabled_source`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct DisabledSource {
+    /// The entry's `crate_name`.
+    pub crate_name: String,
+    /// The destination it would have drained to, as the operator wrote it.
+    pub destination_display: Option<String>,
+}
+
+/// Group enabled sources into passes, and collect the disabled ones.
+///
+/// Why: one place decides both the destination and the project of every source,
+/// so the scheduler and the doctor row can never disagree about either.
+/// What: for each enabled source, resolves its destination (its own, else
+/// `default`) and its identity (its own, else the git `origin` of its root,
+/// else `fallback`), then appends it to the pass with the same pair. Groups
+/// keep first-appearance order; a linear scan is right because a host drains to
+/// a handful of passes and `DestinationUri` is `Eq` but not `Hash`.
+/// Test: `super::tests::resolve_groups_sources_by_destination`,
+/// `super::tests::resolve_splits_one_destination_by_project`,
+/// `super::tests::resolve_skips_a_disabled_source`.
+///
+/// # Errors
+/// [`LogDrainConfigError::MissingDestination`] for a source with no destination
+/// at all; [`LogDrainConfigError::SourceIdentity`] for one whose owner and
+/// project cannot be resolved. Neither is recoverable by guessing — see the
+/// module docs.
+pub(super) fn build(
+    prepared: Vec<PreparedSource>,
+    default: Option<NamedDestination>,
+    fallback: Option<&DrainTarget>,
+) -> Result<(Vec<ResolvedDrainDestination>, Vec<DisabledSource>), LogDrainConfigError> {
+    let mut groups: Vec<ResolvedDrainDestination> = Vec::new();
+    let mut disabled = Vec::new();
+
+    for entry in prepared {
+        let named = entry.destination.clone().or_else(|| default.clone());
+        if !entry.enabled {
+            disabled.push(DisabledSource {
+                crate_name: entry.source.crate_name.clone(),
+                destination_display: named.map(|(display, _)| display),
+            });
+            continue;
+        }
+
+        // A source with no override needs the section default; without one
+        // there is nowhere for it to go, and guessing is what #6657 forbids.
+        let Some((display, uri)) = named else {
+            return Err(LogDrainConfigError::MissingDestination);
+        };
+        let target = resolve_target(&entry, fallback)?;
+
+        match groups
+            .iter_mut()
+            .find(|g| g.destination == uri && g.target == target)
+        {
+            Some(group) => group.sources.push(entry.source),
+            None => groups.push(ResolvedDrainDestination {
+                destination: uri,
+                destination_display: display,
+                target,
+                sources: vec![entry.source],
+            }),
+        }
+    }
+
+    Ok((groups, disabled))
+}
+
+/// Decide the `<owner>/<project>` one source's keys sit under.
+///
+/// Order: the entry's own `owner`/`project`, then the git `origin` of its
+/// `root`, then the section-level fallback. The repo beats the section default
+/// because it is the more specific statement about whose logs these are; the
+/// section default exists for roots no repo owns, such as the daemon's own
+/// `~/.trusty-mpm/logs`.
+///
+/// `derive_remote_repo` runs `git -C <root> config --get remote.origin.url`, so
+/// a log directory INSIDE a checkout resolves to that checkout.
+///
+/// # Errors
+/// [`LogDrainConfigError::SourceIdentity`] carrying git's own reason, so the
+/// operator sees whether the root is not a repo, has no origin, or has an
+/// origin that does not parse.
+fn resolve_target(
+    entry: &PreparedSource,
+    fallback: Option<&DrainTarget>,
+) -> Result<DrainTarget, LogDrainConfigError> {
+    if let Some(explicit) = entry.identity.clone() {
+        return Ok(explicit);
+    }
+    let probe = match derive_remote_repo(&entry.source.root) {
+        Ok(remote) => {
+            return Ok(DrainTarget {
+                owner: remote.owner,
+                project: remote.repo,
+            });
+        }
+        Err(e) => e.to_string(),
+    };
+    fallback
+        .cloned()
+        .ok_or_else(|| LogDrainConfigError::SourceIdentity {
+            index: entry.index,
+            crate_name: entry.source.crate_name.clone(),
+            root: entry.source.root.display().to_string(),
+            reason: probe,
+        })
+}

--- a/crates/trusty-mpm/src/core/trusty_tools_config/log_drain/tests.rs
+++ b/crates/trusty-mpm/src/core/trusty_tools_config/log_drain/tests.rs
@@ -7,6 +7,9 @@
 //! [`super::LogDrainConfigError`] variant.
 
 use std::path::Path;
+use std::process::Command;
+
+use trusty_common::log_drain::DrainTarget;
 
 use super::*;
 
@@ -30,8 +33,8 @@ log_drain:
   interval_secs: 60
   max_file_bytes: 1024
   secrets: ["hunter2"]
-  github_id: "octocat"
-  session_id: "sess-1"
+  owner: "octocat"
+  project: "fixtures"
   sources:
     - crate_name: trusty-code
       root: "~/Library/Logs/trusty-code"
@@ -90,6 +93,8 @@ fn resolve_fills_defaults() {
 log_drain:
   enabled: true
   destination: "file:///tmp/drain"
+  owner: "octocat"
+  project: "fixtures"
 "#,
     );
     let LogDrainSetting::Enabled(plan) = resolve_log_drain(&config, home()).expect("resolves")
@@ -101,8 +106,16 @@ log_drain:
     assert_eq!(plan.max_wire_bytes, DEFAULT_MAX_WIRE_BYTES);
     assert_eq!(plan.destinations.len(), 1);
     assert_eq!(plan.destinations[0].scheme(), "file");
-    assert_eq!(plan.github_id, None);
-    assert_eq!(plan.session_id, None);
+    assert!(plan.disabled.is_empty());
+    // The daemon's own log directory is inside no checkout, so the built-in
+    // source falls back to the section-level identity.
+    assert_eq!(
+        plan.destinations[0].target,
+        DrainTarget {
+            owner: "octocat".to_string(),
+            project: "fixtures".to_string()
+        }
+    );
 
     // The built-in source is the daemon's own rolling file log.
     let sources = &plan.destinations[0].sources;
@@ -121,6 +134,8 @@ fn resolve_uses_configured_sources() {
 log_drain:
   enabled: true
   destination: "s3://bucket/prefix"
+  owner: "octocat"
+  project: "fixtures"
   sources:
     - crate_name: trusty-agents
       root: "~/Library/Logs/trusty-agents"
@@ -159,6 +174,8 @@ fn resolve_groups_sources_by_destination() {
 log_drain:
   enabled: true
   destination: "s3://default-bucket/prefix"
+  owner: "octocat"
+  project: "fixtures"
   sources:
     - crate_name: trusty-mpm
       root: "/var/log/trusty-mpm"
@@ -208,6 +225,8 @@ fn resolve_needs_no_section_destination_when_every_source_names_one() {
         r#"
 log_drain:
   enabled: true
+  owner: "octocat"
+  project: "fixtures"
   sources:
     - crate_name: trusty-code
       root: "/var/log/trusty-code"
@@ -383,6 +402,8 @@ fn resolve_carries_a_configured_max_wire_bytes() {
 log_drain:
   enabled: true
   destination: "file:///tmp/drain"
+  owner: "octocat"
+  project: "fixtures"
   max_wire_bytes: 4096
 "#,
     );
@@ -453,4 +474,249 @@ log_drain:
             value: "verbose".to_string()
         }
     );
+}
+
+/// Initialise a real git repo at `dir` with `origin` set to `url`.
+///
+/// Returns `false` when the runner has no usable `git`, so the caller can skip
+/// rather than fail on a machine the assertion cannot be made on.
+fn init_repo(dir: &Path, url: &str) -> bool {
+    let git = |args: &[&str]| {
+        Command::new("git")
+            .arg("-C")
+            .arg(dir)
+            .args(args)
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    };
+    if !git(&["init"]) {
+        return false;
+    }
+    git(&["remote", "add", "origin", url])
+}
+
+#[test]
+fn resolve_reads_owner_and_project_from_the_git_origin() {
+    // #6657: the key layout is `<owner>/<project>/<log path>`, and both come
+    // from the checkout the logs were written inside — not from whoever
+    // happens to run the daemon.
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let repo = tmp.path().join("checkout");
+    std::fs::create_dir_all(repo.join("logs")).expect("repo dirs");
+    if !init_repo(&repo, "git@github.com:duettoresearch/pricing.git") {
+        return;
+    }
+
+    let config = config_from_yaml(&format!(
+        r#"
+log_drain:
+  enabled: true
+  destination: "file:///tmp/drain"
+  sources:
+    - crate_name: trusty-code
+      root: "{}"
+"#,
+        repo.join("logs").display()
+    ));
+    let LogDrainSetting::Enabled(plan) = resolve_log_drain(&config, home()).expect("resolves")
+    else {
+        panic!("expected an enabled plan");
+    };
+    // The log directory is a SUBDIRECTORY of the checkout; git walks up.
+    assert_eq!(
+        plan.destinations[0].target,
+        DrainTarget {
+            owner: "duettoresearch".to_string(),
+            project: "pricing".to_string()
+        }
+    );
+}
+
+#[test]
+fn resolve_prefers_an_explicit_owner_and_project_over_the_origin() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let repo = tmp.path().join("checkout");
+    std::fs::create_dir_all(&repo).expect("repo dir");
+    if !init_repo(&repo, "git@github.com:duettoresearch/pricing.git") {
+        return;
+    }
+
+    let config = config_from_yaml(&format!(
+        r#"
+log_drain:
+  enabled: true
+  destination: "file:///tmp/drain"
+  sources:
+    - crate_name: trusty-code
+      root: "{}"
+      owner: "acme"
+      project: "widget"
+"#,
+        repo.display()
+    ));
+    let LogDrainSetting::Enabled(plan) = resolve_log_drain(&config, home()).expect("resolves")
+    else {
+        panic!("expected an enabled plan");
+    };
+    assert_eq!(
+        plan.destinations[0].target,
+        DrainTarget {
+            owner: "acme".to_string(),
+            project: "widget".to_string()
+        }
+    );
+}
+
+#[test]
+fn resolve_refuses_a_source_with_no_resolvable_identity() {
+    // #6657 fail-closed guard: a root that is no checkout, with no override
+    // and no section fallback, must REFUSE — never upload under a placeholder
+    // key that mixes this project's logs into someone else's prefix.
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let root = tmp.path().join("orphan-logs");
+    std::fs::create_dir_all(&root).expect("root dir");
+
+    let config = config_from_yaml(&format!(
+        r#"
+log_drain:
+  enabled: true
+  destination: "file:///tmp/drain"
+  sources:
+    - crate_name: trusty-code
+      root: "{}"
+"#,
+        root.display()
+    ));
+    match resolve_log_drain(&config, home()).expect_err("an unresolvable identity is a hard error")
+    {
+        LogDrainConfigError::SourceIdentity {
+            index,
+            ref crate_name,
+            ref root,
+            ref reason,
+        } => {
+            assert_eq!(index, 0);
+            assert_eq!(crate_name, "trusty-code");
+            assert!(root.contains("orphan-logs"), "the row must name it: {root}");
+            assert!(
+                reason.contains("origin"),
+                "the reason must say what git found: {reason}"
+            );
+        }
+        other => panic!("expected SourceIdentity, got {other:?}"),
+    }
+}
+
+#[test]
+fn resolve_rejects_half_an_identity() {
+    // Filling the missing half from git would silently file half a project's
+    // logs under another project's name.
+    let config = config_from_yaml(
+        r#"
+log_drain:
+  enabled: true
+  destination: "file:///tmp/drain"
+  sources:
+    - crate_name: trusty-code
+      root: "/var/log/trusty-code"
+      owner: "acme"
+"#,
+    );
+    match resolve_log_drain(&config, home()).expect_err("half an identity is an error") {
+        LogDrainConfigError::SourceIdentity { ref reason, .. } => {
+            assert!(
+                reason.contains("`owner` is set but `project` is not"),
+                "unhelpful reason: {reason}"
+            );
+        }
+        other => panic!("expected SourceIdentity, got {other:?}"),
+    }
+}
+
+#[test]
+fn resolve_skips_a_disabled_source() {
+    // #6657: a project opts out with `enabled: false`. It runs no pass, and it
+    // is still named so `tm doctor` can distinguish off from misconfigured.
+    let config = config_from_yaml(
+        r#"
+log_drain:
+  enabled: true
+  destination: "s3://default-bucket/prefix"
+  owner: "octocat"
+  project: "fixtures"
+  sources:
+    - crate_name: trusty-mpm
+      root: "/var/log/trusty-mpm"
+    - crate_name: trusty-code
+      root: "/var/log/trusty-code"
+      enabled: false
+      destination: "s3://owner-bucket/logs?profile=owner"
+"#,
+    );
+    let LogDrainSetting::Enabled(plan) = resolve_log_drain(&config, home()).expect("resolves")
+    else {
+        panic!("expected an enabled plan");
+    };
+    assert_eq!(
+        plan.destinations.len(),
+        1,
+        "the disabled source runs no pass"
+    );
+    assert_eq!(
+        plan.destinations[0]
+            .sources
+            .iter()
+            .map(|s| s.crate_name.clone())
+            .collect::<Vec<_>>(),
+        vec!["trusty-mpm"]
+    );
+    assert_eq!(
+        plan.disabled,
+        vec![DisabledSource {
+            crate_name: "trusty-code".to_string(),
+            destination_display: Some("s3://owner-bucket/logs?profile=owner".to_string()),
+        }]
+    );
+}
+
+#[test]
+fn resolve_splits_one_destination_by_project() {
+    // One bucket can hold several projects, and each needs its own key prefix
+    // and its own manifest — so the grouping key is the PAIR, not the URI.
+    let config = config_from_yaml(
+        r#"
+log_drain:
+  enabled: true
+  destination: "s3://shared-bucket/live"
+  sources:
+    - crate_name: trusty-mpm
+      root: "/var/log/a"
+      owner: "duettoresearch"
+      project: "pricing"
+    - crate_name: trusty-mpm
+      root: "/var/log/b"
+      owner: "duettoresearch"
+      project: "insights"
+    - crate_name: trusty-code
+      root: "/var/log/c"
+      owner: "duettoresearch"
+      project: "pricing"
+"#,
+    );
+    let LogDrainSetting::Enabled(plan) = resolve_log_drain(&config, home()).expect("resolves")
+    else {
+        panic!("expected an enabled plan");
+    };
+    assert_eq!(plan.destinations.len(), 2, "two projects, two passes");
+    assert_eq!(
+        plan.destinations[0].target.key_prefix(),
+        "duettoresearch/pricing"
+    );
+    assert_eq!(plan.destinations[0].sources.len(), 2, "same pair, one pass");
+    assert_eq!(
+        plan.destinations[1].target.key_prefix(),
+        "duettoresearch/insights"
+    );
+    assert_eq!(plan.destinations[1].sources.len(), 1);
 }

--- a/crates/trusty-mpm/src/core/trusty_tools_config/log_drain/tests.rs
+++ b/crates/trusty-mpm/src/core/trusty_tools_config/log_drain/tests.rs
@@ -37,9 +37,14 @@ log_drain:
       root: "~/Library/Logs/trusty-code"
       include: ["*.log"]
       level: warn
+      destination: "s3://owner-bucket/logs?profile=owner"
 "#,
     );
     let section = config.log_drain.as_ref().expect("section present");
+    assert_eq!(
+        section.sources[0].destination.as_deref(),
+        Some("s3://owner-bucket/logs?profile=owner")
+    );
     assert_eq!(section.enabled, Some(true));
     assert_eq!(
         section.destination.as_deref(),
@@ -94,13 +99,15 @@ log_drain:
     assert_eq!(plan.interval.as_secs(), DEFAULT_INTERVAL_SECS);
     assert_eq!(plan.max_file_bytes, DEFAULT_MAX_FILE_BYTES);
     assert_eq!(plan.max_wire_bytes, DEFAULT_MAX_WIRE_BYTES);
-    assert_eq!(plan.scheme(), "file");
+    assert_eq!(plan.destinations.len(), 1);
+    assert_eq!(plan.destinations[0].scheme(), "file");
     assert_eq!(plan.github_id, None);
     assert_eq!(plan.session_id, None);
 
     // The built-in source is the daemon's own rolling file log.
-    assert_eq!(plan.sources.len(), 1);
-    let source = &plan.sources[0];
+    let sources = &plan.destinations[0].sources;
+    assert_eq!(sources.len(), 1);
+    let source = &sources[0];
     assert_eq!(source.crate_name, "trusty-mpm");
     assert_eq!(source.root, home().join(".trusty-mpm").join("logs"));
     assert_eq!(source.include, vec!["trusty-mpm.log*".to_string()]);
@@ -127,20 +134,121 @@ log_drain:
     else {
         panic!("expected an enabled plan");
     };
-    assert_eq!(plan.scheme(), "s3");
-    assert_eq!(plan.sources.len(), 2);
+    // Both sources inherit the section destination, so they share one group.
+    assert_eq!(plan.destinations.len(), 1);
+    assert_eq!(plan.destinations[0].scheme(), "s3");
+    let sources = &plan.destinations[0].sources;
+    assert_eq!(sources.len(), 2);
     // `~` expands against the supplied home, and the level name is
     // case-insensitive.
-    assert_eq!(
-        plan.sources[0].root,
-        home().join("Library/Logs/trusty-agents")
-    );
-    assert_eq!(plan.sources[0].level_filter, Some(Level::Warn));
+    assert_eq!(sources[0].root, home().join("Library/Logs/trusty-agents"));
+    assert_eq!(sources[0].level_filter, Some(Level::Warn));
     // An absent `include` collects everything under the root; an absent `level`
     // uploads every line.
-    assert_eq!(plan.sources[1].include, vec!["**/*".to_string()]);
-    assert_eq!(plan.sources[1].level_filter, None);
-    assert_eq!(plan.sources[1].root, Path::new("/var/log/trusty-code"));
+    assert_eq!(sources[1].include, vec!["**/*".to_string()]);
+    assert_eq!(sources[1].level_filter, None);
+    assert_eq!(sources[1].root, Path::new("/var/log/trusty-code"));
+}
+
+#[test]
+fn resolve_groups_sources_by_destination() {
+    // #6657: a source's own `destination` wins; a source without one inherits
+    // the section default. Sources sharing a destination share one pass.
+    let config = config_from_yaml(
+        r#"
+log_drain:
+  enabled: true
+  destination: "s3://default-bucket/prefix"
+  sources:
+    - crate_name: trusty-mpm
+      root: "/var/log/trusty-mpm"
+    - crate_name: trusty-code
+      root: "/var/log/trusty-code"
+      destination: "s3://owner-bucket/logs?profile=owner"
+    - crate_name: trusty-agents
+      root: "/var/log/trusty-agents"
+    - crate_name: trusty-search
+      root: "/var/log/trusty-search"
+      destination: "s3://owner-bucket/logs?profile=owner"
+"#,
+    );
+    let LogDrainSetting::Enabled(plan) = resolve_log_drain(&config, home()).expect("resolves")
+    else {
+        panic!("expected an enabled plan");
+    };
+
+    // Two distinct destinations, in first-appearance order.
+    assert_eq!(plan.destinations.len(), 2);
+    assert_eq!(
+        plan.destinations[0].destination_display,
+        "s3://default-bucket/prefix"
+    );
+    assert_eq!(
+        plan.destinations[1].destination_display,
+        "s3://owner-bucket/logs?profile=owner"
+    );
+
+    // The two inheriting sources landed on the default; the two overriding
+    // ones collapsed onto one group rather than opening a pass each.
+    let names = |index: usize| {
+        plan.destinations[index]
+            .sources
+            .iter()
+            .map(|s| s.crate_name.clone())
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(names(0), vec!["trusty-mpm", "trusty-agents"]);
+    assert_eq!(names(1), vec!["trusty-code", "trusty-search"]);
+}
+
+#[test]
+fn resolve_needs_no_section_destination_when_every_source_names_one() {
+    // The section default is required only by a source that still needs it.
+    let config = config_from_yaml(
+        r#"
+log_drain:
+  enabled: true
+  sources:
+    - crate_name: trusty-code
+      root: "/var/log/trusty-code"
+      destination: "file:///tmp/drain-a"
+"#,
+    );
+    let LogDrainSetting::Enabled(plan) = resolve_log_drain(&config, home()).expect("resolves")
+    else {
+        panic!("expected an enabled plan");
+    };
+    assert_eq!(plan.destinations.len(), 1);
+    assert_eq!(
+        plan.destinations[0].destination_display,
+        "file:///tmp/drain-a"
+    );
+}
+
+#[test]
+fn resolve_rejects_a_malformed_source_destination() {
+    // A per-source override is validated exactly as the section's own is: a
+    // typo must not fall back to the default, which is the wrong account.
+    let config = config_from_yaml(
+        r#"
+log_drain:
+  enabled: true
+  destination: "file:///tmp/drain"
+  sources:
+    - crate_name: trusty-code
+      root: "/var/log/trusty-code"
+      destination: "s3://bucket/logs?porfile=owner"
+"#,
+    );
+    let err = resolve_log_drain(&config, home())
+        .expect_err("a malformed source destination is a hard error");
+    match err {
+        LogDrainConfigError::SourceDestination { index, ref reason } => {
+            assert_eq!(index, 0);
+            assert!(reason.contains("porfile"), "unhelpful reason: {reason}");
+        }
+        other => panic!("expected SourceDestination, got {other:?}"),
+    }
 }
 
 #[test]

--- a/crates/trusty-mpm/src/daemon/doctor_log_drain.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_log_drain.rs
@@ -52,9 +52,16 @@ pub(crate) fn check_log_drain(framework_root: &Path, home: &Path) -> DoctorCheck
 ///
 /// A last run recorded as `SkippedDisabled` under a now-enabled config reads as
 /// the no-run case: the record predates the current setting.
+///
+/// #6657: the row names EVERY configured destination, and quotes each one's own
+/// last-run outcome. One unreachable account among three is a different repair
+/// from all three being down, and a row that named only the first would hide
+/// the difference.
+///
 /// Test: `tests::config_error_fails`, `tests::disabled_is_ok`,
 /// `tests::enabled_with_no_run_warns`, `tests::a_failed_run_fails`,
-/// `tests::a_successful_run_is_ok`.
+/// `tests::a_successful_run_is_ok`,
+/// `tests::the_row_lists_every_destination_with_its_own_outcome`.
 fn build_log_drain_check(
     setting: Result<&LogDrainSetting, &LogDrainConfigError>,
     status: Option<&LogDrainStatus>,
@@ -80,7 +87,12 @@ fn build_log_drain_check(
         Ok(LogDrainSetting::Enabled(plan)) => plan,
     };
 
-    let where_to = format!("{} → {}", plan.scheme(), plan.destination_display);
+    let where_to = plan
+        .destinations
+        .iter()
+        .map(|group| format!("{} → {}", group.scheme(), group.destination_display))
+        .collect::<Vec<_>>()
+        .join(", ");
     let Some(status) = status.filter(|s| s.outcome != DrainOutcome::SkippedDisabled) else {
         return DoctorCheck::new(
             "log_drain",
@@ -88,14 +100,15 @@ fn build_log_drain_check(
             format!("log drain enabled ({where_to}) but no run has been recorded yet"),
         );
     };
+    let outcomes = recorded_outcomes(status);
 
     match status.outcome {
         DrainOutcome::Success => DoctorCheck::new(
             "log_drain",
             CheckStatus::Ok,
             format!(
-                "log drain enabled ({where_to}); last run {} — {}",
-                status.at, status.detail
+                "log drain enabled ({where_to}); last run {} — {outcomes}",
+                status.at
             ),
         ),
         // #6535: an errored pass must never read as drained. See
@@ -104,8 +117,8 @@ fn build_log_drain_check(
             "log_drain",
             CheckStatus::Fail,
             format!(
-                "log drain enabled ({where_to}) but the last run FAILED at {} — {}",
-                status.at, status.detail
+                "log drain enabled ({where_to}) but the last run FAILED at {} — {outcomes}",
+                status.at
             ),
         ),
         // Filtered out above; kept total rather than `unreachable!`.
@@ -115,6 +128,30 @@ fn build_log_drain_check(
             format!("log drain enabled ({where_to}) but no run has been recorded yet"),
         ),
     }
+}
+
+/// Render each recorded destination's own outcome, one clause apiece (#6657).
+///
+/// A record written before #6657 carries no per-destination breakdown, so its
+/// single `detail` line is used unchanged rather than reported as "no
+/// destinations ran".
+fn recorded_outcomes(status: &LogDrainStatus) -> String {
+    if status.destinations.is_empty() {
+        return status.detail.clone();
+    }
+    status
+        .destinations
+        .iter()
+        .map(|d| {
+            let verdict = match d.outcome {
+                DrainOutcome::Success => "ok",
+                DrainOutcome::Failed => "FAILED",
+                DrainOutcome::SkippedDisabled => "skipped",
+            };
+            format!("{} → {}: {verdict} — {}", d.scheme, d.destination, d.detail)
+        })
+        .collect::<Vec<_>>()
+        .join("; ")
 }
 
 #[cfg(test)]

--- a/crates/trusty-mpm/src/daemon/doctor_log_drain.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_log_drain.rs
@@ -87,12 +87,7 @@ fn build_log_drain_check(
         Ok(LogDrainSetting::Enabled(plan)) => plan,
     };
 
-    let where_to = plan
-        .destinations
-        .iter()
-        .map(|group| format!("{} → {}", group.scheme(), group.destination_display))
-        .collect::<Vec<_>>()
-        .join(", ");
+    let where_to = configured_targets(plan);
     let Some(status) = status.filter(|s| s.outcome != DrainOutcome::SkippedDisabled) else {
         return DoctorCheck::new(
             "log_drain",
@@ -130,6 +125,39 @@ fn build_log_drain_check(
     }
 }
 
+/// Name every pass the plan will run, plus the sources switched off (#6657).
+///
+/// Each pass reads `<scheme> → <destination> [<owner>/<project>]`, because one
+/// destination can now hold several projects and "which project stopped
+/// draining" is the question the row has to answer. A source with
+/// `enabled: false` is listed after them as `disabled`, so an operator can tell
+/// a deliberate opt-out from a project that fell out of the config.
+///
+/// Test: `tests::the_row_lists_every_destination_with_its_own_outcome`,
+/// `tests::the_row_lists_a_disabled_source`.
+fn configured_targets(plan: &crate::core::trusty_tools_config::ResolvedLogDrain) -> String {
+    let mut parts: Vec<String> = plan
+        .destinations
+        .iter()
+        .map(|group| {
+            format!(
+                "{} → {} [{}]",
+                group.scheme(),
+                group.destination_display,
+                group.target.key_prefix()
+            )
+        })
+        .collect();
+    for off in &plan.disabled {
+        let dest = off
+            .destination_display
+            .as_deref()
+            .unwrap_or("no destination");
+        parts.push(format!("{} → {dest}: disabled", off.crate_name));
+    }
+    parts.join(", ")
+}
+
 /// Render each recorded destination's own outcome, one clause apiece (#6657).
 ///
 /// A record written before #6657 carries no per-destination breakdown, so its
@@ -148,7 +176,10 @@ fn recorded_outcomes(status: &LogDrainStatus) -> String {
                 DrainOutcome::Failed => "FAILED",
                 DrainOutcome::SkippedDisabled => "skipped",
             };
-            format!("{} → {}: {verdict} — {}", d.scheme, d.destination, d.detail)
+            format!(
+                "{} → {} [{}]: {verdict} — {}",
+                d.scheme, d.destination, d.project, d.detail
+            )
         })
         .collect::<Vec<_>>()
         .join("; ")

--- a/crates/trusty-mpm/src/daemon/doctor_log_drain_tests.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_log_drain_tests.rs
@@ -12,15 +12,22 @@ use std::time::Duration;
 use super::*;
 use crate::core::trusty_tools_config::LOG_DRAIN_DEFAULT_INTERVAL_SECS;
 use crate::daemon::log_drain::LogDrainDestinationStatus;
-use trusty_common::log_drain::DestinationUri;
+use trusty_common::log_drain::{DestinationUri, DrainTarget};
 
-/// One resolved destination group at `file://<path>`, with no sources.
+/// The project every fixture pass drains under.
+const FIXTURE_PROJECT: &str = "octocat/fixtures";
+
+/// One resolved pass at `file://<path>`, with no sources.
 fn group(path: &str) -> crate::core::trusty_tools_config::ResolvedDrainDestination {
     crate::core::trusty_tools_config::ResolvedDrainDestination {
         destination: DestinationUri::File {
             path: PathBuf::from(path),
         },
         destination_display: format!("file://{path}"),
+        target: DrainTarget {
+            owner: "octocat".to_string(),
+            project: "fixtures".to_string(),
+        },
         sources: Vec::new(),
     }
 }
@@ -29,15 +36,22 @@ fn group(path: &str) -> crate::core::trusty_tools_config::ResolvedDrainDestinati
 fn plan_over(
     destinations: Vec<crate::core::trusty_tools_config::ResolvedDrainDestination>,
 ) -> LogDrainSetting {
+    plan_with_disabled(destinations, Vec::new())
+}
+
+/// An enabled plan over `destinations`, plus the sources switched off.
+fn plan_with_disabled(
+    destinations: Vec<crate::core::trusty_tools_config::ResolvedDrainDestination>,
+    disabled: Vec<crate::core::trusty_tools_config::DisabledSource>,
+) -> LogDrainSetting {
     LogDrainSetting::Enabled(Box::new(
         crate::core::trusty_tools_config::ResolvedLogDrain {
             destinations,
+            disabled,
             interval: Duration::from_secs(LOG_DRAIN_DEFAULT_INTERVAL_SECS),
             max_file_bytes: 1024,
             max_wire_bytes: 1024,
             secrets: Vec::new(),
-            github_id: Some("octocat".to_string()),
-            session_id: Some("sess-1".to_string()),
         },
     ))
 }
@@ -51,6 +65,7 @@ fn plan() -> LogDrainSetting {
 fn recorded(path: &str, outcome: DrainOutcome, detail: &str) -> LogDrainDestinationStatus {
     LogDrainDestinationStatus {
         destination: format!("file://{path}"),
+        project: FIXTURE_PROJECT.to_string(),
         scheme: "file".to_string(),
         outcome,
         uploaded: 3,
@@ -110,8 +125,10 @@ fn enabled_with_no_run_warns() {
     let check = build_log_drain_check(Ok(&setting), None);
     assert_eq!(check.status, CheckStatus::Warn);
     assert!(
-        check.message.contains("file → file:///tmp/drain"),
-        "the row must name the scheme and destination: {}",
+        check
+            .message
+            .contains("file → file:///tmp/drain [octocat/fixtures]"),
+        "the row must name the scheme, destination, and project: {}",
         check.message
     );
     assert!(check.message.contains("no run"), "{}", check.message);
@@ -173,23 +190,24 @@ fn the_row_lists_every_destination_with_its_own_outcome() {
     assert_eq!(check.status, CheckStatus::Fail);
     // Both destinations are named, in plan order, with their own verdicts.
     assert!(
-        check
-            .message
-            .contains("file → file:///tmp/drain-a, file → file:///tmp/drain-b"),
-        "the row must name every configured destination: {}",
+        check.message.contains(
+            "file → file:///tmp/drain-a [octocat/fixtures], \
+             file → file:///tmp/drain-b [octocat/fixtures]"
+        ),
+        "the row must name every configured pass: {}",
         check.message
     );
     assert!(
         check
             .message
-            .contains("file:///tmp/drain-a: ok — 2 file(s) uploaded"),
+            .contains("file:///tmp/drain-a [octocat/fixtures]: ok — 2 file(s) uploaded"),
         "the healthy destination keeps its own verdict: {}",
         check.message
     );
     assert!(
         check
             .message
-            .contains("file:///tmp/drain-b: FAILED — cannot reach the destination"),
+            .contains("file:///tmp/drain-b [octocat/fixtures]: FAILED — cannot reach"),
         "the broken destination is named as the broken one: {}",
         check.message
     );
@@ -219,4 +237,25 @@ fn a_stale_disabled_record_under_an_enabled_config_warns() {
     let check = build_log_drain_check(Ok(&setting), Some(&recorded));
     assert_eq!(check.status, CheckStatus::Warn);
     assert!(check.message.contains("no run"), "{}", check.message);
+}
+
+#[test]
+fn the_row_lists_a_disabled_source() {
+    // #6657: `enabled: false` on one project is a deliberate opt-out, and the
+    // row has to distinguish it from a project that fell out of the config.
+    let setting = plan_with_disabled(
+        vec![group("/tmp/drain")],
+        vec![crate::core::trusty_tools_config::DisabledSource {
+            crate_name: "trusty-code".to_string(),
+            destination_display: Some("s3://owner-bucket/live".to_string()),
+        }],
+    );
+    let check = build_log_drain_check(Ok(&setting), None);
+    assert!(
+        check
+            .message
+            .contains("trusty-code → s3://owner-bucket/live: disabled"),
+        "the row must name the opted-out project and where it would have gone: {}",
+        check.message
+    );
 }

--- a/crates/trusty-mpm/src/daemon/doctor_log_drain_tests.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_log_drain_tests.rs
@@ -11,34 +11,73 @@ use std::time::Duration;
 
 use super::*;
 use crate::core::trusty_tools_config::LOG_DRAIN_DEFAULT_INTERVAL_SECS;
+use crate::daemon::log_drain::LogDrainDestinationStatus;
 use trusty_common::log_drain::DestinationUri;
 
-/// An enabled plan pointing at `file:///tmp/drain`.
-fn plan() -> LogDrainSetting {
+/// One resolved destination group at `file://<path>`, with no sources.
+fn group(path: &str) -> crate::core::trusty_tools_config::ResolvedDrainDestination {
+    crate::core::trusty_tools_config::ResolvedDrainDestination {
+        destination: DestinationUri::File {
+            path: PathBuf::from(path),
+        },
+        destination_display: format!("file://{path}"),
+        sources: Vec::new(),
+    }
+}
+
+/// An enabled plan over `destinations`.
+fn plan_over(
+    destinations: Vec<crate::core::trusty_tools_config::ResolvedDrainDestination>,
+) -> LogDrainSetting {
     LogDrainSetting::Enabled(Box::new(
         crate::core::trusty_tools_config::ResolvedLogDrain {
-            destination: DestinationUri::File {
-                path: PathBuf::from("/tmp/drain"),
-            },
-            destination_display: "file:///tmp/drain".to_string(),
+            destinations,
             interval: Duration::from_secs(LOG_DRAIN_DEFAULT_INTERVAL_SECS),
             max_file_bytes: 1024,
             max_wire_bytes: 1024,
             secrets: Vec::new(),
             github_id: Some("octocat".to_string()),
             session_id: Some("sess-1".to_string()),
-            sources: Vec::new(),
         },
     ))
 }
 
-/// A recorded status with `outcome` and `detail`.
+/// An enabled plan pointing at `file:///tmp/drain`.
+fn plan() -> LogDrainSetting {
+    plan_over(vec![group("/tmp/drain")])
+}
+
+/// One recorded destination outcome.
+fn recorded(path: &str, outcome: DrainOutcome, detail: &str) -> LogDrainDestinationStatus {
+    LogDrainDestinationStatus {
+        destination: format!("file://{path}"),
+        scheme: "file".to_string(),
+        outcome,
+        uploaded: 3,
+        skipped_unchanged: 1,
+        detail: detail.to_string(),
+    }
+}
+
+/// A recorded status with `outcome` and `detail`, over one destination.
 fn status(outcome: DrainOutcome, detail: &str) -> LogDrainStatus {
+    status_over(
+        outcome,
+        vec![recorded("/tmp/drain", outcome, detail)],
+        detail,
+    )
+}
+
+/// A recorded status over an explicit destination list.
+fn status_over(
+    outcome: DrainOutcome,
+    destinations: Vec<LogDrainDestinationStatus>,
+    detail: &str,
+) -> LogDrainStatus {
     LogDrainStatus {
         outcome,
         at: "2026-09-01T00:00:00Z".to_string(),
-        destination: Some("file:///tmp/drain".to_string()),
-        scheme: Some("file".to_string()),
+        destinations,
         uploaded: 3,
         skipped_unchanged: 1,
         detail: detail.to_string(),
@@ -106,6 +145,66 @@ fn a_failed_run_fails() {
     );
     assert!(
         check.message.contains("cannot reach the destination"),
+        "{}",
+        check.message
+    );
+}
+
+#[test]
+fn the_row_lists_every_destination_with_its_own_outcome() {
+    // #6657: one unreachable account among two is a different repair from both
+    // being down, so the row names each destination and quotes each verdict.
+    let setting = plan_over(vec![group("/tmp/drain-a"), group("/tmp/drain-b")]);
+    let recorded_status = status_over(
+        DrainOutcome::Failed,
+        vec![
+            recorded("/tmp/drain-a", DrainOutcome::Success, "2 file(s) uploaded"),
+            recorded(
+                "/tmp/drain-b",
+                DrainOutcome::Failed,
+                "cannot reach the destination: no such directory",
+            ),
+        ],
+        "aggregate detail nobody should be reading here",
+    );
+    let check = build_log_drain_check(Ok(&setting), Some(&recorded_status));
+
+    // One destination failing fails the row.
+    assert_eq!(check.status, CheckStatus::Fail);
+    // Both destinations are named, in plan order, with their own verdicts.
+    assert!(
+        check
+            .message
+            .contains("file → file:///tmp/drain-a, file → file:///tmp/drain-b"),
+        "the row must name every configured destination: {}",
+        check.message
+    );
+    assert!(
+        check
+            .message
+            .contains("file:///tmp/drain-a: ok — 2 file(s) uploaded"),
+        "the healthy destination keeps its own verdict: {}",
+        check.message
+    );
+    assert!(
+        check
+            .message
+            .contains("file:///tmp/drain-b: FAILED — cannot reach the destination"),
+        "the broken destination is named as the broken one: {}",
+        check.message
+    );
+}
+
+#[test]
+fn a_record_predating_per_destination_outcomes_still_reads() {
+    // A `status.json` written before #6657 carries no breakdown; the row falls
+    // back to its single detail line rather than claiming nothing ran.
+    let setting = plan();
+    let recorded_status = status_over(DrainOutcome::Success, Vec::new(), "3 file(s) uploaded");
+    let check = build_log_drain_check(Ok(&setting), Some(&recorded_status));
+    assert_eq!(check.status, CheckStatus::Ok);
+    assert!(
+        check.message.contains("3 file(s) uploaded"),
         "{}",
         check.message
     );

--- a/crates/trusty-mpm/src/daemon/log_drain.rs
+++ b/crates/trusty-mpm/src/daemon/log_drain.rs
@@ -35,6 +35,20 @@
 //! The loop awaits each pass to completion before arming the next tick, so two
 //! passes can never race the one manifest. `tokio::time::interval` compensates
 //! for a slow pass by firing immediately rather than by overlapping.
+//!
+//! # One pass per destination, and no fall-back between them (#6657)
+//!
+//! A tick runs `run_once` once per entry in
+//! [`ResolvedLogDrain::destinations`](crate::core::trusty_tools_config::ResolvedLogDrain),
+//! sequentially, each with its own connection and its own manifest — the cache
+//! is already keyed by destination (#6548), so nothing here forks that.
+//!
+//! A destination that cannot be reached fails ALONE. Its sources are skipped
+//! for that tick and the remaining destinations still run. There is deliberately
+//! no path that retries a source against the section default: a per-source
+//! destination exists precisely because those bytes belong in one specific
+//! account, so shipping them to the fallback would be worse than not shipping
+//! them at all.
 
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -47,7 +61,8 @@ use trusty_common::log_drain::{
 };
 
 use crate::core::trusty_tools_config::{
-    LOG_DRAIN_STATE_SUBDIR, LogDrainSetting, ResolvedLogDrain, TrustyToolsConfig, resolve_log_drain,
+    LOG_DRAIN_STATE_SUBDIR, LogDrainSetting, ResolvedDrainDestination, ResolvedLogDrain,
+    TrustyToolsConfig, resolve_log_drain,
 };
 
 /// Filename of the last-run record inside the drain state directory.
@@ -81,28 +96,56 @@ pub enum DrainOutcome {
     Failed,
 }
 
+/// How one destination's pass ended, within a tick (#6657).
+///
+/// Why: a tick now covers several object stores, and "the drain failed" is not
+/// actionable when only one of three destinations is unreachable. The doctor
+/// row lists these, so an operator sees which account stopped accepting logs.
+/// What: one record per entry in `ResolvedLogDrain::destinations`, in the same
+/// order.
+/// Test: `tests::one_failing_destination_does_not_stop_the_others`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct LogDrainDestinationStatus {
+    /// The destination as the operator wrote it.
+    pub destination: String,
+    /// Destination scheme (`s3`, `file`).
+    pub scheme: String,
+    /// How this destination's pass ended.
+    pub outcome: DrainOutcome,
+    /// Files uploaded to this destination.
+    pub uploaded: usize,
+    /// Files the manifest proved this destination already had.
+    pub skipped_unchanged: usize,
+    /// One line an operator can act on, for this destination alone.
+    pub detail: String,
+}
+
 /// The persisted result of the most recent drain pass.
 ///
 /// Why: `tm doctor` runs daemonless (see [`super::doctor::run_doctor`]), so the
 /// doctor row cannot read the scheduler's memory. A small JSON file is the only
 /// channel between the two.
-/// What: the outcome, when it happened, the destination it was aimed at, the
-/// upload counts, and a human-readable detail line.
+/// What: the aggregate outcome, when it happened, one
+/// [`LogDrainDestinationStatus`] per destination the tick covered, the summed
+/// counts, and a human-readable detail line. `destinations` is
+/// `#[serde(default)]`, so a `status.json` written before #6657 still decodes —
+/// it simply carries no per-destination breakdown and the doctor row falls back
+/// to `detail`.
 /// Test: `tests::status_round_trips_through_the_state_dir`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct LogDrainStatus {
-    /// Which of the three states this pass ended in.
+    /// The tick's verdict: `Failed` when ANY destination failed.
     pub outcome: DrainOutcome,
     /// RFC 3339 timestamp of the pass.
     pub at: String,
-    /// The destination as the operator wrote it, or `null` when disabled.
-    pub destination: Option<String>,
-    /// Destination scheme (`s3`, `file`), or `null` when disabled.
-    pub scheme: Option<String>,
-    /// Files uploaded this pass.
+    /// Per-destination outcomes, in plan order. Empty when disabled (#6657).
+    #[serde(default)]
+    pub destinations: Vec<LogDrainDestinationStatus>,
+    /// Files uploaded this pass, across every destination.
     pub uploaded: usize,
-    /// Files the manifest proved were already uploaded.
+    /// Files the manifests proved were already uploaded, across every destination.
     pub skipped_unchanged: usize,
     /// One line an operator can act on.
     pub detail: String,
@@ -114,8 +157,7 @@ impl LogDrainStatus {
         Self {
             outcome: DrainOutcome::SkippedDisabled,
             at: chrono::Utc::now().to_rfc3339(),
-            destination: None,
-            scheme: None,
+            destinations: Vec::new(),
             uploaded: 0,
             skipped_unchanged: 0,
             detail: detail.into(),
@@ -131,32 +173,95 @@ impl LogDrainStatus {
         Self {
             outcome: DrainOutcome::Failed,
             at: chrono::Utc::now().to_rfc3339(),
-            destination: None,
-            scheme: None,
+            destinations: Vec::new(),
             uploaded: 0,
             skipped_unchanged: 0,
             detail: format!("config error: {reason}"),
         }
     }
 
-    /// Build a failure record for `plan`.
+    /// Build a failure record covering every destination in `plan` at once.
+    ///
+    /// Used when the tick fails BEFORE any destination is reached — an
+    /// unresolvable identity, which is not a property of any one of them.
     fn failed(plan: &ResolvedLogDrain, detail: impl Into<String>) -> Self {
+        let detail = detail.into();
+        let destinations = plan
+            .destinations
+            .iter()
+            .map(|group| LogDrainDestinationStatus {
+                destination: group.destination_display.clone(),
+                scheme: group.scheme().to_string(),
+                outcome: DrainOutcome::Failed,
+                uploaded: 0,
+                skipped_unchanged: 0,
+                detail: detail.clone(),
+            })
+            .collect();
         Self {
             outcome: DrainOutcome::Failed,
             at: chrono::Utc::now().to_rfc3339(),
-            destination: Some(plan.destination_display.clone()),
-            scheme: Some(plan.scheme().to_string()),
+            destinations,
+            uploaded: 0,
+            skipped_unchanged: 0,
+            detail,
+        }
+    }
+
+    /// Fold every destination's record into the tick's verdict.
+    ///
+    /// The tick FAILS when any destination failed — the fail-open guard is
+    /// per-destination, so a partial success is still a failure to report.
+    fn from_destinations(destinations: Vec<LogDrainDestinationStatus>) -> Self {
+        let failed = destinations
+            .iter()
+            .any(|d| d.outcome == DrainOutcome::Failed);
+        let uploaded = destinations.iter().map(|d| d.uploaded).sum();
+        let skipped_unchanged = destinations.iter().map(|d| d.skipped_unchanged).sum();
+        // With one destination the tick's detail IS that destination's, so a
+        // single-destination host reads exactly as it did before #6657.
+        let detail = match destinations.as_slice() {
+            [] => "no destination had any source configured".to_string(),
+            [only] => only.detail.clone(),
+            many => many
+                .iter()
+                .map(|d| format!("{} → {}: {}", d.scheme, d.destination, d.detail))
+                .collect::<Vec<_>>()
+                .join("; "),
+        };
+        Self {
+            outcome: if failed {
+                DrainOutcome::Failed
+            } else {
+                DrainOutcome::Success
+            },
+            at: chrono::Utc::now().to_rfc3339(),
+            destinations,
+            uploaded,
+            skipped_unchanged,
+            detail,
+        }
+    }
+}
+
+impl LogDrainDestinationStatus {
+    /// Build a failure record for one destination.
+    fn failed(group: &ResolvedDrainDestination, detail: impl Into<String>) -> Self {
+        Self {
+            destination: group.destination_display.clone(),
+            scheme: group.scheme().to_string(),
+            outcome: DrainOutcome::Failed,
             uploaded: 0,
             skipped_unchanged: 0,
             detail: detail.into(),
         }
     }
 
-    /// Build the record for a completed `run_once`.
+    /// Build the record for one destination's completed `run_once`.
     ///
     /// A report carrying per-file errors is [`DrainOutcome::Failed`] even
     /// though `run_once` returned `Ok` — see the module docs.
-    fn from_report(plan: &ResolvedLogDrain, report: &DrainReport) -> Self {
+    fn from_report(group: &ResolvedDrainDestination, report: &DrainReport) -> Self {
         let failed = !report.errors.is_empty();
         let detail = if failed {
             let (key, message) = &report.errors[0];
@@ -179,14 +284,13 @@ impl LogDrainStatus {
             )
         };
         Self {
+            destination: group.destination_display.clone(),
+            scheme: group.scheme().to_string(),
             outcome: if failed {
                 DrainOutcome::Failed
             } else {
                 DrainOutcome::Success
             },
-            at: chrono::Utc::now().to_rfc3339(),
-            destination: Some(plan.destination_display.clone()),
-            scheme: Some(plan.scheme().to_string()),
             uploaded: report.uploaded,
             skipped_unchanged: report.skipped_unchanged,
             detail,
@@ -311,20 +415,46 @@ pub async fn resolve_github_id(plan: &ResolvedLogDrain) -> Result<String, String
 /// Why: separated from [`drain_once`] so the tests can drive a pass with an
 /// explicit identity and an explicit state directory — no config file, no `gh`,
 /// no home directory.
-/// What: connects the destination, calls `run_once`, and maps the outcome
-/// through [`LogDrainStatus`]. Every failure arm is [`DrainOutcome::Failed`];
-/// none can produce a success record.
+/// What: one [`run_destination_pass`] per entry in `plan.destinations`, in
+/// order, each folded into the tick's verdict by
+/// [`LogDrainStatus::from_destinations`]. Passes are sequential rather than
+/// concurrent: the single-flight guarantee this module provides is "one pass at
+/// a time", and running two destinations at once would double the drain's peak
+/// memory for no operator-visible gain at a 15-minute cadence.
 /// Test: `tests::a_successful_tick_uploads_and_records_success`,
-/// `tests::a_second_tick_dedupes`, `tests::a_failing_destination_records_failed`.
+/// `tests::a_second_tick_dedupes`, `tests::a_failing_destination_records_failed`,
+/// `tests::two_destinations_each_get_their_own_pass`.
 pub async fn run_tick(
     plan: &ResolvedLogDrain,
     state_dir: &Path,
     target: &DrainTarget,
 ) -> LogDrainStatus {
-    let dest = match ObjectStoreDestination::connect(&plan.destination).await {
+    let mut per_destination = Vec::with_capacity(plan.destinations.len());
+    for group in &plan.destinations {
+        per_destination.push(run_destination_pass(plan, group, state_dir, target).await);
+    }
+    LogDrainStatus::from_destinations(per_destination)
+}
+
+/// Drain one destination's own sources, and report only on that destination.
+///
+/// #6657: every failure arm ends here. Nothing retries these sources against
+/// another destination — a per-source destination is a statement about which
+/// account the bytes belong in, so a fallback would violate the very
+/// requirement the override exists to satisfy.
+async fn run_destination_pass(
+    plan: &ResolvedLogDrain,
+    group: &ResolvedDrainDestination,
+    state_dir: &Path,
+    target: &DrainTarget,
+) -> LogDrainDestinationStatus {
+    let dest = match ObjectStoreDestination::connect(&group.destination).await {
         Ok(dest) => dest,
         Err(e) => {
-            return LogDrainStatus::failed(plan, format!("cannot reach the destination: {e}"));
+            return LogDrainDestinationStatus::failed(
+                group,
+                format!("cannot reach the destination: {e}"),
+            );
         }
     };
     let cfg = DrainConfig::new(state_dir)
@@ -332,9 +462,12 @@ pub async fn run_tick(
         .with_max_file_bytes(plan.max_file_bytes)
         // #6547: the collector streams, so this is the bound that matters.
         .with_max_wire_bytes(plan.max_wire_bytes);
-    match run_once(&cfg, &dest, target, &plan.sources).await {
-        Ok(report) => LogDrainStatus::from_report(plan, &report),
-        Err(e) => LogDrainStatus::failed(plan, format!("drain run failed: {e}")),
+    // The manifest cache under `state_dir` is namespaced by destination
+    // (#6548), so each group reads and writes its own record from one shared
+    // directory.
+    match run_once(&cfg, &dest, target, &group.sources).await {
+        Ok(report) => LogDrainDestinationStatus::from_report(group, &report),
+        Err(e) => LogDrainDestinationStatus::failed(group, format!("drain run failed: {e}")),
     }
 }
 

--- a/crates/trusty-mpm/src/daemon/log_drain.rs
+++ b/crates/trusty-mpm/src/daemon/log_drain.rs
@@ -1,18 +1,18 @@
 //! The daemon's log-drain scheduler (#6535, Phase 3 of #6533).
 //!
-//! Why: `trusty_common::log_drain::run_once` is one pass with no locking, no
-//! identity resolution, and no memory of what it last did. A daemon that only
-//! ever called it would upload once and never again, under whatever identity
-//! the caller guessed. This module is the half that makes it a running service:
-//! an interval loop beside `orphan_gc_loop` (private, in `daemon/mod.rs`),
-//! `gh`-resolved identity, and a persisted last-run verdict the `log_drain`
-//! doctor row reads.
+//! Why: `trusty_common::log_drain::run_once` is one pass with no locking and no
+//! memory of what it last did. A daemon that only ever called it would upload
+//! once and never again. This module is the half that makes it a running
+//! service: an interval loop beside `orphan_gc_loop` (private, in
+//! `daemon/mod.rs`), one pass per configured project, and a persisted last-run
+//! verdict the `log_drain` doctor row reads. Each pass's `<owner>/<project>`
+//! comes from the resolved plan (#6657) — nothing is resolved here.
 //!
 //! What: [`log_drain_loop`](crate::daemon::log_drain::log_drain_loop) ticks on
 //! the configured interval until its
 //! [`CancellationToken`](tokio_util::sync::CancellationToken) fires;
 //! [`drain_once`](crate::daemon::log_drain::drain_once) is one full pass
-//! (resolve config, resolve identity, connect, `run_once`, record);
+//! (resolve config, then connect, `run_once`, and record per project);
 //! [`LogDrainStatus`](crate::daemon::log_drain::LogDrainStatus) is what it
 //! writes to `<state_dir>/status.json`.
 //!
@@ -56,9 +56,7 @@ use std::time::Duration;
 use serde::{Deserialize, Serialize};
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
-use trusty_common::log_drain::{
-    DrainConfig, DrainReport, DrainTarget, ObjectStoreDestination, run_once,
-};
+use trusty_common::log_drain::{DrainConfig, DrainReport, ObjectStoreDestination, run_once};
 
 use crate::core::trusty_tools_config::{
     LOG_DRAIN_STATE_SUBDIR, LogDrainSetting, ResolvedDrainDestination, ResolvedLogDrain,
@@ -67,15 +65,6 @@ use crate::core::trusty_tools_config::{
 
 /// Filename of the last-run record inside the drain state directory.
 const STATUS_FILENAME: &str = "status.json";
-
-/// Filename of the persisted per-install session id.
-const SESSION_ID_FILENAME: &str = "session-id";
-
-/// How long the `gh api user` identity probe may take before the pass gives up.
-///
-/// A pass that hangs on `gh` holds the single-flight slot and delays every
-/// later tick, so the probe is bounded rather than left to `gh`'s own defaults.
-const GH_PROBE_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// What one drain pass did, in the three states an operator distinguishes.
 ///
@@ -109,6 +98,12 @@ pub enum DrainOutcome {
 pub struct LogDrainDestinationStatus {
     /// The destination as the operator wrote it.
     pub destination: String,
+    /// The `<owner>/<project>` this pass uploaded under (#6657).
+    ///
+    /// `#[serde(default)]`, so a `status.json` written before the key layout
+    /// changed still decodes — it simply names no project.
+    #[serde(default)]
+    pub project: String,
     /// Destination scheme (`s3`, `file`).
     pub scheme: String,
     /// How this destination's pass ended.
@@ -180,34 +175,6 @@ impl LogDrainStatus {
         }
     }
 
-    /// Build a failure record covering every destination in `plan` at once.
-    ///
-    /// Used when the tick fails BEFORE any destination is reached — an
-    /// unresolvable identity, which is not a property of any one of them.
-    fn failed(plan: &ResolvedLogDrain, detail: impl Into<String>) -> Self {
-        let detail = detail.into();
-        let destinations = plan
-            .destinations
-            .iter()
-            .map(|group| LogDrainDestinationStatus {
-                destination: group.destination_display.clone(),
-                scheme: group.scheme().to_string(),
-                outcome: DrainOutcome::Failed,
-                uploaded: 0,
-                skipped_unchanged: 0,
-                detail: detail.clone(),
-            })
-            .collect();
-        Self {
-            outcome: DrainOutcome::Failed,
-            at: chrono::Utc::now().to_rfc3339(),
-            destinations,
-            uploaded: 0,
-            skipped_unchanged: 0,
-            detail,
-        }
-    }
-
     /// Fold every destination's record into the tick's verdict.
     ///
     /// The tick FAILS when any destination failed — the fail-open guard is
@@ -225,7 +192,12 @@ impl LogDrainStatus {
             [only] => only.detail.clone(),
             many => many
                 .iter()
-                .map(|d| format!("{} → {}: {}", d.scheme, d.destination, d.detail))
+                .map(|d| {
+                    format!(
+                        "{} → {} [{}]: {}",
+                        d.scheme, d.destination, d.project, d.detail
+                    )
+                })
                 .collect::<Vec<_>>()
                 .join("; "),
         };
@@ -249,6 +221,7 @@ impl LogDrainDestinationStatus {
     fn failed(group: &ResolvedDrainDestination, detail: impl Into<String>) -> Self {
         Self {
             destination: group.destination_display.clone(),
+            project: group.target.key_prefix(),
             scheme: group.scheme().to_string(),
             outcome: DrainOutcome::Failed,
             uploaded: 0,
@@ -285,6 +258,7 @@ impl LogDrainDestinationStatus {
         };
         Self {
             destination: group.destination_display.clone(),
+            project: group.target.key_prefix(),
             scheme: group.scheme().to_string(),
             outcome: if failed {
                 DrainOutcome::Failed
@@ -300,7 +274,7 @@ impl LogDrainDestinationStatus {
 
 /// The drain's state directory: `<framework root>/log-drain`.
 ///
-/// Holds the manifest cache, the persisted session id, and `status.json`.
+/// Holds the per-destination manifest cache and `status.json`.
 pub fn state_dir(framework_root: &Path) -> PathBuf {
     framework_root.join(LOG_DRAIN_STATE_SUBDIR)
 }
@@ -340,81 +314,10 @@ pub fn save_status(state_dir: &Path, status: &LogDrainStatus) {
     }
 }
 
-/// Resolve the session segment of the key layout.
+/// Run every pass in `plan`, and return the tick's verdict.
 ///
-/// Why: the epic's layout is `<github-id>/<session>/logs/…`, but the trusty-mpm
-/// DAEMON has no single "current session" — it supervises many, and the files
-/// it drains (`~/.trusty-mpm/logs/trusty-mpm.log.*`) belong to the daemon
-/// itself rather than to any one of them. A per-BOOT id would be worse than
-/// useless: the manifest is keyed by target, so every restart would re-upload
-/// every log file under a fresh prefix. So the daemon's session is
-/// per-INSTALL — one id, minted on first run and persisted beside the manifest
-/// cache. Phase 5 consumers (#6537) pass their own real session ids.
-/// What: the configured `session_id` when set, else the persisted file, else a
-/// freshly-minted UUID written to that file.
-/// Test: `tests::session_id_is_stable_across_calls`.
-///
-/// # Errors
-/// A message naming the path when the id can neither be read nor written.
-pub fn resolve_session_id(plan: &ResolvedLogDrain, state_dir: &Path) -> Result<String, String> {
-    if let Some(configured) = plan.session_id.as_deref() {
-        return Ok(configured.to_string());
-    }
-    let path = state_dir.join(SESSION_ID_FILENAME);
-    if let Ok(existing) = std::fs::read_to_string(&path) {
-        let trimmed = existing.trim();
-        if !trimmed.is_empty() {
-            return Ok(trimmed.to_string());
-        }
-    }
-    let minted = uuid::Uuid::new_v4().to_string();
-    std::fs::create_dir_all(state_dir)
-        .and_then(|()| std::fs::write(&path, &minted))
-        .map_err(|e| {
-            format!(
-                "cannot persist the drain session id at {}: {e}",
-                path.display()
-            )
-        })?;
-    Ok(minted)
-}
-
-/// Resolve the GitHub login the logs are filed under.
-///
-/// Why: an unattributed upload is worse than no upload — it mixes one
-/// operator's logs into a shared prefix nobody can reason about. The core
-/// refuses an empty id outright, so this has to produce a real one or fail.
-/// What: the configured `github_id` when set, else one `gh api user --jq
-/// .login` through `trusty_common::gh` — the workspace's single `gh` entry
-/// point (#5475), never a fresh `Command::new("gh")`. Bounded by
-/// [`GH_PROBE_TIMEOUT`]. The caller caches the answer across ticks.
-/// Test: covered indirectly — the tick tests supply an explicit id, because a
-/// test that shelled out to the developer's real `gh` would assert on their
-/// GitHub account.
-///
-/// # Errors
-/// A message naming what `gh` did, for the `warn!` and the status detail.
-pub async fn resolve_github_id(plan: &ResolvedLogDrain) -> Result<String, String> {
-    if let Some(configured) = plan.github_id.as_deref() {
-        return Ok(configured.to_string());
-    }
-    // #6535: single `gh` entry point. `nonempty_stdout` folds a non-zero exit
-    // and a blank login into the same `Err`, so no empty id can escape here.
-    let command = trusty_common::gh::GhCommand::new(["api", "user", "--jq", ".login"]);
-    match tokio::time::timeout(GH_PROBE_TIMEOUT, command.nonempty_stdout()).await {
-        Ok(Ok(login)) => Ok(login.trim().to_string()),
-        Ok(Err(e)) => Err(format!("`gh api user --jq .login` failed: {e}")),
-        Err(_) => Err(format!(
-            "`gh api user --jq .login` did not respond within {GH_PROBE_TIMEOUT:?}"
-        )),
-    }
-}
-
-/// Run one full drain pass against `plan` for `target`, and return its verdict.
-///
-/// Why: separated from [`drain_once`] so the tests can drive a pass with an
-/// explicit identity and an explicit state directory — no config file, no `gh`,
-/// no home directory.
+/// Why: separated from [`drain_once`] so the tests can drive a tick with an
+/// explicit state directory — no config file and no home directory.
 /// What: one [`run_destination_pass`] per entry in `plan.destinations`, in
 /// order, each folded into the tick's verdict by
 /// [`LogDrainStatus::from_destinations`]. Passes are sequential rather than
@@ -424,14 +327,10 @@ pub async fn resolve_github_id(plan: &ResolvedLogDrain) -> Result<String, String
 /// Test: `tests::a_successful_tick_uploads_and_records_success`,
 /// `tests::a_second_tick_dedupes`, `tests::a_failing_destination_records_failed`,
 /// `tests::two_destinations_each_get_their_own_pass`.
-pub async fn run_tick(
-    plan: &ResolvedLogDrain,
-    state_dir: &Path,
-    target: &DrainTarget,
-) -> LogDrainStatus {
+pub async fn run_tick(plan: &ResolvedLogDrain, state_dir: &Path) -> LogDrainStatus {
     let mut per_destination = Vec::with_capacity(plan.destinations.len());
     for group in &plan.destinations {
-        per_destination.push(run_destination_pass(plan, group, state_dir, target).await);
+        per_destination.push(run_destination_pass(plan, group, state_dir).await);
     }
     LogDrainStatus::from_destinations(per_destination)
 }
@@ -446,7 +345,6 @@ async fn run_destination_pass(
     plan: &ResolvedLogDrain,
     group: &ResolvedDrainDestination,
     state_dir: &Path,
-    target: &DrainTarget,
 ) -> LogDrainDestinationStatus {
     let dest = match ObjectStoreDestination::connect(&group.destination).await {
         Ok(dest) => dest,
@@ -465,20 +363,20 @@ async fn run_destination_pass(
     // The manifest cache under `state_dir` is namespaced by destination
     // (#6548), so each group reads and writes its own record from one shared
     // directory.
-    match run_once(&cfg, &dest, target, &group.sources).await {
+    match run_once(&cfg, &dest, &group.target, &group.sources).await {
         Ok(report) => LogDrainDestinationStatus::from_report(group, &report),
         Err(e) => LogDrainDestinationStatus::failed(group, format!("drain run failed: {e}")),
     }
 }
 
-/// One complete pass: read config, resolve identity, drain, record.
+/// One complete tick: read config, drain every project, record.
 ///
 /// Why: the loop body and the boot pass are the same work, and a caller that
 /// re-read the config itself would let the two drift.
 /// What: resolves `config` through [`resolve_log_drain`]; the loop passes a
 /// freshly loaded one every tick, so a config edit takes effect without a
-/// daemon restart. A config ERROR, an unresolvable identity, and a failed
-/// upload all record [`DrainOutcome::Failed`] — never a silent skip. Returns
+/// daemon restart. A config ERROR — an unresolvable project among them — and a
+/// failed upload both record [`DrainOutcome::Failed`], never a silent skip. Returns
 /// the status it wrote. `config` is a parameter rather than loaded here so the
 /// tests never read (or need) the developer's real config file.
 /// Test: `tests::a_config_error_records_failed`,
@@ -496,23 +394,10 @@ pub async fn drain_once(
         Ok(LogDrainSetting::Disabled) => {
             LogDrainStatus::disabled("log_drain is disabled in config")
         }
-        Ok(LogDrainSetting::Enabled(plan)) => match identity(&plan, &dir).await {
-            Ok(target) => run_tick(&plan, &dir, &target).await,
-            Err(detail) => LogDrainStatus::failed(&plan, detail),
-        },
+        Ok(LogDrainSetting::Enabled(plan)) => run_tick(&plan, &dir).await,
     };
     save_status(&dir, &status);
     status
-}
-
-/// Resolve both identity components, or say which one could not be resolved.
-async fn identity(plan: &ResolvedLogDrain, state_dir: &Path) -> Result<DrainTarget, String> {
-    let github_id = resolve_github_id(plan).await?;
-    let session_id = resolve_session_id(plan, state_dir)?;
-    Ok(DrainTarget {
-        github_id,
-        session_id,
-    })
 }
 
 /// Drain on the configured interval until `cancel` fires.

--- a/crates/trusty-mpm/src/daemon/log_drain.rs
+++ b/crates/trusty-mpm/src/daemon/log_drain.rs
@@ -178,7 +178,10 @@ impl LogDrainStatus {
     /// Fold every destination's record into the tick's verdict.
     ///
     /// The tick FAILS when any destination failed — the fail-open guard is
-    /// per-destination, so a partial success is still a failure to report.
+    /// per-destination, so a partial success is still a failure to report. An
+    /// EMPTY plan — every source individually `enabled: false` (#6657) — is a
+    /// clean tick that covered nothing, and its detail says exactly that.
+    /// Test: `tests::a_tick_over_only_disabled_sources_names_the_empty_plan`.
     fn from_destinations(destinations: Vec<LogDrainDestinationStatus>) -> Self {
         let failed = destinations
             .iter()
@@ -326,7 +329,8 @@ pub fn save_status(state_dir: &Path, status: &LogDrainStatus) {
 /// memory for no operator-visible gain at a 15-minute cadence.
 /// Test: `tests::a_successful_tick_uploads_and_records_success`,
 /// `tests::a_second_tick_dedupes`, `tests::a_failing_destination_records_failed`,
-/// `tests::two_destinations_each_get_their_own_pass`.
+/// `tests::two_destinations_each_get_their_own_pass`,
+/// `tests::a_tick_over_only_disabled_sources_names_the_empty_plan`.
 pub async fn run_tick(plan: &ResolvedLogDrain, state_dir: &Path) -> LogDrainStatus {
     let mut per_destination = Vec::with_capacity(plan.destinations.len());
     for group in &plan.destinations {

--- a/crates/trusty-mpm/src/daemon/log_drain_tests.rs
+++ b/crates/trusty-mpm/src/daemon/log_drain_tests.rs
@@ -14,17 +14,24 @@ use tempfile::TempDir;
 use super::*;
 use crate::core::trusty_tools_config::LogDrainConfig;
 
+/// The `<owner>/<project>` every fixture config drains under.
+///
+/// Pinned rather than resolved from git: a test that read the developer's own
+/// checkout would assert against their remote (#6657).
+const FIXTURE_OWNER: &str = "octocat";
+const FIXTURE_PROJECT: &str = "fixtures";
+
 /// Build a `log_drain:` config aimed at `dest_dir`, collecting `log_dir`.
 ///
-/// `github_id` and `session_id` are pinned so no test shells out to `gh` or
-/// asserts against the developer's own GitHub account.
+/// `owner` and `project` are pinned at the section level, so the temp log
+/// directories need not be checkouts.
 fn enabled_config(dest_dir: &Path, log_dir: &Path) -> TrustyToolsConfig {
     TrustyToolsConfig {
         log_drain: Some(LogDrainConfig {
             enabled: Some(true),
             destination: Some(format!("file://{}", dest_dir.display())),
-            github_id: Some("octocat".to_string()),
-            session_id: Some("sess-fixture".to_string()),
+            owner: Some(FIXTURE_OWNER.to_string()),
+            project: Some(FIXTURE_PROJECT.to_string()),
             sources: vec![crate::core::trusty_tools_config::LogDrainSourceConfig {
                 crate_name: Some("trusty-mpm".to_string()),
                 root: Some(log_dir.display().to_string()),
@@ -64,8 +71,8 @@ fn two_destination_config(
         log_drain: Some(LogDrainConfig {
             enabled: Some(true),
             destination: Some(format!("file://{}", default_dest.display())),
-            github_id: Some("octocat".to_string()),
-            session_id: Some("sess-fixture".to_string()),
+            owner: Some(FIXTURE_OWNER.to_string()),
+            project: Some(FIXTURE_PROJECT.to_string()),
             sources: vec![
                 source_entry("trusty-mpm", inheriting_logs, None),
                 source_entry("trusty-code", overriding_logs, Some(override_dest)),
@@ -77,10 +84,12 @@ fn two_destination_config(
 }
 
 /// Where a drained file for `crate_name` lands under `dest`.
+///
+/// `<owner>/<project>/<crate>/<file>` — the #6657 layout, with no session
+/// segment and no `logs/` interlayer.
 fn drained_path(dest: &Path, crate_name: &str, file: &str) -> std::path::PathBuf {
-    dest.join("octocat")
-        .join("sess-fixture")
-        .join("logs")
+    dest.join(FIXTURE_OWNER)
+        .join(FIXTURE_PROJECT)
         .join(crate_name)
         .join(file)
 }
@@ -113,14 +122,6 @@ fn plan_of(config: &TrustyToolsConfig, home: &Path) -> ResolvedLogDrain {
     }
 }
 
-/// The pinned identity the fixture config uploads under.
-fn fixture_target() -> DrainTarget {
-    DrainTarget {
-        github_id: "octocat".to_string(),
-        session_id: "sess-fixture".to_string(),
-    }
-}
-
 /// A temp directory holding one log file with `body`.
 fn log_dir_with(tmp: &TempDir, body: &str) -> std::path::PathBuf {
     let dir = tmp.path().join("logs");
@@ -138,26 +139,26 @@ async fn a_successful_tick_uploads_and_records_success() {
 
     let config = enabled_config(&dest, &logs);
     let plan = plan_of(&config, tmp.path());
-    let status = run_tick(&plan, &state, &fixture_target()).await;
+    let status = run_tick(&plan, &state).await;
 
     assert_eq!(status.outcome, DrainOutcome::Success, "{}", status.detail);
     assert_eq!(status.uploaded, 1, "{}", status.detail);
     assert_eq!(status.destinations.len(), 1);
     assert_eq!(status.destinations[0].scheme, "file");
 
-    // The object landed at `<github-id>/<session>/logs/<crate>/<file>`, which
-    // is the epic's key layout — proof this drained rather than merely
-    // reporting that it had.
-    let key = dest
-        .join("octocat")
-        .join("sess-fixture")
-        .join("logs")
-        .join("trusty-mpm")
-        .join("trusty-mpm.log");
+    // The object landed at `<owner>/<project>/<crate>/<file>`, which is the
+    // #6657 key layout — proof this drained rather than merely reporting that
+    // it had.
+    let key = drained_path(&dest, "trusty-mpm", "trusty-mpm.log");
     assert!(
         key.exists(),
         "expected an uploaded object at {}",
         key.display()
+    );
+    assert_eq!(
+        status.destinations[0].project,
+        format!("{FIXTURE_OWNER}/{FIXTURE_PROJECT}"),
+        "the record names the project it uploaded under"
     );
 }
 
@@ -170,12 +171,10 @@ async fn a_second_tick_dedupes() {
 
     let config = enabled_config(&dest, &logs);
     let plan = plan_of(&config, tmp.path());
-    let target = fixture_target();
-
-    let first = run_tick(&plan, &state, &target).await;
+    let first = run_tick(&plan, &state).await;
     assert_eq!(first.uploaded, 1, "{}", first.detail);
 
-    let second = run_tick(&plan, &state, &target).await;
+    let second = run_tick(&plan, &state).await;
     assert_eq!(second.outcome, DrainOutcome::Success, "{}", second.detail);
     assert_eq!(second.uploaded, 0, "{}", second.detail);
     assert_eq!(second.skipped_unchanged, 1, "{}", second.detail);
@@ -199,9 +198,7 @@ async fn a_ceiling_skip_is_decided_once_across_ticks() {
         .expect("fixture section")
         .max_file_bytes = Some(1024);
     let plan = plan_of(&config, tmp.path());
-    let target = fixture_target();
-
-    let first = run_tick(&plan, &state, &target).await;
+    let first = run_tick(&plan, &state).await;
     assert_eq!(first.outcome, DrainOutcome::Success, "{}", first.detail);
     assert_eq!(first.uploaded, 0, "{}", first.detail);
     assert!(
@@ -212,7 +209,7 @@ async fn a_ceiling_skip_is_decided_once_across_ticks() {
         first.detail
     );
 
-    let second = run_tick(&plan, &state, &target).await;
+    let second = run_tick(&plan, &state).await;
     assert!(
         second
             .detail
@@ -240,7 +237,7 @@ async fn the_wire_ceiling_reaches_the_drain_config() {
     let plan = plan_of(&config, tmp.path());
     assert_eq!(plan.max_wire_bytes, 8);
 
-    let status = run_tick(&plan, &state, &fixture_target()).await;
+    let status = run_tick(&plan, &state).await;
     assert_eq!(status.uploaded, 0, "{}", status.detail);
     assert!(
         status
@@ -272,7 +269,7 @@ async fn two_destinations_each_get_their_own_pass() {
         "two groups, one per destination"
     );
 
-    let status = run_tick(&plan, &state, &fixture_target()).await;
+    let status = run_tick(&plan, &state).await;
     assert_eq!(status.outcome, DrainOutcome::Success, "{}", status.detail);
     assert_eq!(status.uploaded, 2, "{}", status.detail);
     assert_eq!(status.destinations.len(), 2);
@@ -313,7 +310,7 @@ async fn one_failing_destination_does_not_stop_the_others() {
 
     let config = two_destination_config(&dest_a, &logs_a, &dest_b, &logs_b);
     let plan = plan_of(&config, tmp.path());
-    let status = run_tick(&plan, &state, &fixture_target()).await;
+    let status = run_tick(&plan, &state).await;
 
     // The tick as a whole failed, but the reachable destination still drained.
     assert_eq!(status.outcome, DrainOutcome::Failed, "{}", status.detail);
@@ -350,7 +347,7 @@ async fn a_failing_destination_records_failed() {
 
     let config = enabled_config(&dest, &logs);
     let plan = plan_of(&config, tmp.path());
-    let status = run_tick(&plan, &state, &fixture_target()).await;
+    let status = run_tick(&plan, &state).await;
 
     // The fail-open guard: a destination that cannot be reached must never
     // record a drained pass.
@@ -438,40 +435,6 @@ fn status_round_trips_through_the_state_dir() {
     assert_eq!(load_status(&dir).as_ref(), Some(&status));
 }
 
-#[test]
-fn session_id_is_stable_across_calls() {
-    let tmp = TempDir::new().expect("tempdir");
-    let dest = tmp.path().join("dest");
-    let logs = tmp.path().join("logs");
-    let state = tmp.path().join("state");
-
-    // With no configured id the drain mints one and persists it: a per-boot id
-    // would re-upload every log file under a fresh prefix on every restart.
-    let mut config = enabled_config(&dest, &logs);
-    config
-        .log_drain
-        .as_mut()
-        .expect("section present")
-        .session_id = None;
-    let plan = plan_of(&config, tmp.path());
-
-    let first = resolve_session_id(&plan, &state).expect("mints an id");
-    let second = resolve_session_id(&plan, &state).expect("reads the persisted id");
-    assert!(!first.is_empty());
-    assert_eq!(first, second);
-}
-
-#[test]
-fn a_configured_session_id_wins() {
-    let tmp = TempDir::new().expect("tempdir");
-    let config = enabled_config(&tmp.path().join("dest"), &tmp.path().join("logs"));
-    let plan = plan_of(&config, tmp.path());
-    assert_eq!(
-        resolve_session_id(&plan, &tmp.path().join("state")).expect("resolves"),
-        "sess-fixture"
-    );
-}
-
 #[tokio::test]
 async fn the_loop_exits_on_cancel() {
     let tmp = TempDir::new().expect("tempdir");
@@ -488,4 +451,44 @@ async fn the_loop_exits_on_cancel() {
     // A loop that ignored its token would hang here until the test harness
     // timed out; joining is the assertion.
     handle.await.expect("the loop exits cleanly on cancel");
+}
+
+#[tokio::test]
+async fn a_disabled_source_uploads_nothing_and_is_still_reported() {
+    // #6657 deliverable: a project opts out with `enabled: false`. It must run
+    // no pass and write no object, while the plan still names it so the doctor
+    // row can say the drain is off for that project on purpose.
+    let tmp = TempDir::new().expect("tempdir");
+    let dest = tmp.path().join("dest");
+    let logs_on = named_log_dir(&tmp, "alpha");
+    let logs_off = named_log_dir(&tmp, "beta");
+    let state = tmp.path().join("state");
+
+    let mut config = enabled_config(&dest, &logs_on);
+    let section = config.log_drain.as_mut().expect("fixture section");
+    section.sources[0].crate_name = Some("trusty-mpm".to_string());
+    section.sources[0].include = vec!["*.log".to_string()];
+    section
+        .sources
+        .push(crate::core::trusty_tools_config::LogDrainSourceConfig {
+            crate_name: Some("trusty-code".to_string()),
+            root: Some(logs_off.display().to_string()),
+            include: vec!["*.log".to_string()],
+            enabled: Some(false),
+            ..Default::default()
+        });
+
+    let plan = plan_of(&config, tmp.path());
+    assert_eq!(plan.destinations.len(), 1, "only the enabled source drains");
+    assert_eq!(plan.disabled.len(), 1);
+    assert_eq!(plan.disabled[0].crate_name, "trusty-code");
+
+    let status = run_tick(&plan, &state).await;
+    assert_eq!(status.outcome, DrainOutcome::Success, "{}", status.detail);
+    assert_eq!(status.uploaded, 1, "{}", status.detail);
+    assert!(drained_path(&dest, "trusty-mpm", "alpha.log").exists());
+    assert!(
+        !drained_path(&dest, "trusty-code", "beta.log").exists(),
+        "a disabled source must upload nothing"
+    );
 }

--- a/crates/trusty-mpm/src/daemon/log_drain_tests.rs
+++ b/crates/trusty-mpm/src/daemon/log_drain_tests.rs
@@ -390,6 +390,41 @@ async fn a_disabled_config_records_skipped() {
 }
 
 #[tokio::test]
+async fn a_tick_over_only_disabled_sources_names_the_empty_plan() {
+    // #6657: switching every project off one at a time leaves an ENABLED
+    // section with nothing in it, which is NOT the same state as
+    // `enabled: false` — `a_disabled_config_records_skipped` covers that one.
+    // The tick still runs, covers zero destinations, and has to say so.
+    let tmp = TempDir::new().expect("tempdir");
+    let dest = tmp.path().join("dest");
+    let logs = log_dir_with(&tmp, "INFO a line\n");
+    let state = tmp.path().join("state");
+
+    let mut config = enabled_config(&dest, &logs);
+    let section = config.log_drain.as_mut().expect("fixture section");
+    section.sources[0].enabled = Some(false);
+
+    let plan = plan_of(&config, tmp.path());
+    assert!(
+        plan.destinations.is_empty(),
+        "no source is left for a destination to carry"
+    );
+    assert_eq!(plan.disabled.len(), 1);
+
+    let status = run_tick(&plan, &state).await;
+    assert_eq!(status.outcome, DrainOutcome::Success, "{}", status.detail);
+    assert_eq!(status.detail, "no destination had any source configured");
+    assert!(status.destinations.is_empty());
+    assert_eq!(status.uploaded, 0);
+    assert_eq!(status.skipped_unchanged, 0);
+    // An empty plan connects to nothing, so the `file://` root is never made.
+    assert!(
+        !dest.exists(),
+        "an empty plan must not touch the destination"
+    );
+}
+
+#[tokio::test]
 async fn a_config_error_records_failed() {
     let tmp = TempDir::new().expect("tempdir");
     let root = tmp.path().join("framework");

--- a/crates/trusty-mpm/src/daemon/log_drain_tests.rs
+++ b/crates/trusty-mpm/src/daemon/log_drain_tests.rs
@@ -37,6 +37,62 @@ fn enabled_config(dest_dir: &Path, log_dir: &Path) -> TrustyToolsConfig {
     }
 }
 
+/// One `sources[]` entry over `root`, optionally pinned to its own destination.
+fn source_entry(
+    crate_name: &str,
+    root: &Path,
+    destination: Option<&Path>,
+) -> crate::core::trusty_tools_config::LogDrainSourceConfig {
+    crate::core::trusty_tools_config::LogDrainSourceConfig {
+        crate_name: Some(crate_name.to_string()),
+        root: Some(root.display().to_string()),
+        include: vec!["*.log".to_string()],
+        destination: destination.map(|d| format!("file://{}", d.display())),
+        ..Default::default()
+    }
+}
+
+/// Two sources, two destinations: one inherits the section default, one
+/// overrides it (#6657).
+fn two_destination_config(
+    default_dest: &Path,
+    inheriting_logs: &Path,
+    override_dest: &Path,
+    overriding_logs: &Path,
+) -> TrustyToolsConfig {
+    TrustyToolsConfig {
+        log_drain: Some(LogDrainConfig {
+            enabled: Some(true),
+            destination: Some(format!("file://{}", default_dest.display())),
+            github_id: Some("octocat".to_string()),
+            session_id: Some("sess-fixture".to_string()),
+            sources: vec![
+                source_entry("trusty-mpm", inheriting_logs, None),
+                source_entry("trusty-code", overriding_logs, Some(override_dest)),
+            ],
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+
+/// Where a drained file for `crate_name` lands under `dest`.
+fn drained_path(dest: &Path, crate_name: &str, file: &str) -> std::path::PathBuf {
+    dest.join("octocat")
+        .join("sess-fixture")
+        .join("logs")
+        .join(crate_name)
+        .join(file)
+}
+
+/// A temp directory named `name` holding one `<name>.log` file.
+fn named_log_dir(tmp: &TempDir, name: &str) -> std::path::PathBuf {
+    let dir = tmp.path().join(name);
+    std::fs::create_dir_all(&dir).expect("create log dir");
+    std::fs::write(dir.join(format!("{name}.log")), "INFO a line\n").expect("write log file");
+    dir
+}
+
 /// A config whose `log_drain:` section will not resolve.
 fn broken_config(destination: &str) -> TrustyToolsConfig {
     TrustyToolsConfig {
@@ -86,7 +142,8 @@ async fn a_successful_tick_uploads_and_records_success() {
 
     assert_eq!(status.outcome, DrainOutcome::Success, "{}", status.detail);
     assert_eq!(status.uploaded, 1, "{}", status.detail);
-    assert_eq!(status.scheme.as_deref(), Some("file"));
+    assert_eq!(status.destinations.len(), 1);
+    assert_eq!(status.destinations[0].scheme, "file");
 
     // The object landed at `<github-id>/<session>/logs/<crate>/<file>`, which
     // is the epic's key layout — proof this drained rather than merely
@@ -195,6 +252,92 @@ async fn the_wire_ceiling_reaches_the_drain_config() {
 }
 
 #[tokio::test]
+async fn two_destinations_each_get_their_own_pass() {
+    // #6657: the epic's whole point — one daemon, two accounts. Two `file://`
+    // roots stand in for two buckets, so the property is provable with no
+    // network: each source's bytes land under its OWN destination and nowhere
+    // else.
+    let tmp = TempDir::new().expect("tempdir");
+    let dest_a = tmp.path().join("dest-a");
+    let dest_b = tmp.path().join("dest-b");
+    let logs_a = named_log_dir(&tmp, "alpha");
+    let logs_b = named_log_dir(&tmp, "beta");
+    let state = tmp.path().join("state");
+
+    let config = two_destination_config(&dest_a, &logs_a, &dest_b, &logs_b);
+    let plan = plan_of(&config, tmp.path());
+    assert_eq!(
+        plan.destinations.len(),
+        2,
+        "two groups, one per destination"
+    );
+
+    let status = run_tick(&plan, &state, &fixture_target()).await;
+    assert_eq!(status.outcome, DrainOutcome::Success, "{}", status.detail);
+    assert_eq!(status.uploaded, 2, "{}", status.detail);
+    assert_eq!(status.destinations.len(), 2);
+    assert!(
+        status
+            .destinations
+            .iter()
+            .all(|d| d.outcome == DrainOutcome::Success && d.uploaded == 1),
+        "each destination uploads its own single file: {:?}",
+        status.destinations
+    );
+
+    let a = drained_path(&dest_a, "trusty-mpm", "alpha.log");
+    let b = drained_path(&dest_b, "trusty-code", "beta.log");
+    assert!(a.exists(), "expected {}", a.display());
+    assert!(b.exists(), "expected {}", b.display());
+    // Neither destination received the other's bytes.
+    assert!(!drained_path(&dest_a, "trusty-code", "beta.log").exists());
+    assert!(!drained_path(&dest_b, "trusty-mpm", "alpha.log").exists());
+}
+
+#[tokio::test]
+async fn one_failing_destination_does_not_stop_the_others() {
+    // #6657 fail-closed guard: a per-source destination that cannot be reached
+    // must be SKIPPED, never retried against the section default. Falling back
+    // would put this project's logs in the wrong AWS account, which is exactly
+    // what the override exists to prevent.
+    let tmp = TempDir::new().expect("tempdir");
+    let dest_a = tmp.path().join("dest-a");
+    // A `file://` root nested under a regular FILE: `create_dir_all` cannot
+    // make it, so connecting destination B fails.
+    let blocker = tmp.path().join("not-a-directory");
+    std::fs::write(&blocker, b"x").expect("write blocker");
+    let dest_b = blocker.join("dest-b");
+    let logs_a = named_log_dir(&tmp, "alpha");
+    let logs_b = named_log_dir(&tmp, "beta");
+    let state = tmp.path().join("state");
+
+    let config = two_destination_config(&dest_a, &logs_a, &dest_b, &logs_b);
+    let plan = plan_of(&config, tmp.path());
+    let status = run_tick(&plan, &state, &fixture_target()).await;
+
+    // The tick as a whole failed, but the reachable destination still drained.
+    assert_eq!(status.outcome, DrainOutcome::Failed, "{}", status.detail);
+    assert_eq!(status.destinations.len(), 2);
+    assert_eq!(status.destinations[0].outcome, DrainOutcome::Success);
+    assert_eq!(status.destinations[0].uploaded, 1);
+    assert_eq!(status.destinations[1].outcome, DrainOutcome::Failed);
+    assert!(
+        status.destinations[1]
+            .detail
+            .contains("cannot reach the destination"),
+        "unhelpful detail: {}",
+        status.destinations[1].detail
+    );
+
+    // The skipped source's bytes are nowhere under the working destination.
+    assert!(drained_path(&dest_a, "trusty-mpm", "alpha.log").exists());
+    assert!(
+        !drained_path(&dest_a, "trusty-code", "beta.log").exists(),
+        "a failed destination must not fall back to the section default"
+    );
+}
+
+#[tokio::test]
 async fn a_failing_destination_records_failed() {
     let tmp = TempDir::new().expect("tempdir");
     // A `file://` root nested under a regular FILE: `create_dir_all` cannot
@@ -246,7 +389,7 @@ async fn a_disabled_config_records_skipped() {
     let root = tmp.path().join("framework");
     let status = drain_once(&TrustyToolsConfig::default(), &root, tmp.path()).await;
     assert_eq!(status.outcome, DrainOutcome::SkippedDisabled);
-    assert_eq!(status.destination, None);
+    assert!(status.destinations.is_empty());
 }
 
 #[tokio::test]

--- a/crates/trusty-mpm/src/daemon/log_drain_tests.rs
+++ b/crates/trusty-mpm/src/daemon/log_drain_tests.rs
@@ -492,3 +492,77 @@ async fn a_disabled_source_uploads_nothing_and_is_still_reported() {
         "a disabled source must upload nothing"
     );
 }
+
+#[tokio::test]
+async fn the_object_key_comes_from_the_source_root_s_git_origin() {
+    // #6657, end to end: a real checkout, a real drain, a real object. The key
+    // must be `<owner>/<project>/<crate>/<file>` with owner and project read
+    // from the checkout's `origin` — nothing configured, nothing guessed.
+    let tmp = TempDir::new().expect("tempdir");
+    let repo = tmp.path().join("checkout");
+    let logs = repo.join("logs");
+    std::fs::create_dir_all(&logs).expect("repo dirs");
+    let git = |args: &[&str]| {
+        std::process::Command::new("git")
+            .arg("-C")
+            .arg(&repo)
+            .args(args)
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    };
+    if !git(&["init"]) {
+        return; // no usable git on this runner
+    }
+    let _ = git(&[
+        "remote",
+        "add",
+        "origin",
+        "git@github.com:duettoresearch/pricing.git",
+    ]);
+    std::fs::write(logs.join("trusty-code.log"), "INFO a line\n").expect("write log file");
+
+    let dest = tmp.path().join("dest");
+    let state = tmp.path().join("state");
+    let config = TrustyToolsConfig {
+        log_drain: Some(LogDrainConfig {
+            enabled: Some(true),
+            destination: Some(format!("file://{}", dest.display())),
+            sources: vec![crate::core::trusty_tools_config::LogDrainSourceConfig {
+                crate_name: Some("trusty-code".to_string()),
+                root: Some(logs.display().to_string()),
+                include: vec!["*.log".to_string()],
+                ..Default::default()
+            }],
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let plan = plan_of(&config, tmp.path());
+    assert_eq!(
+        plan.destinations[0].target.key_prefix(),
+        "duettoresearch/pricing"
+    );
+
+    let status = run_tick(&plan, &state).await;
+    assert_eq!(status.outcome, DrainOutcome::Success, "{}", status.detail);
+    assert_eq!(status.uploaded, 1, "{}", status.detail);
+
+    let key = dest
+        .join("duettoresearch")
+        .join("pricing")
+        .join("trusty-code")
+        .join("trusty-code.log");
+    assert!(
+        key.exists(),
+        "expected the drained object at {}",
+        key.display()
+    );
+    // The retired layout put a session segment and a `logs/` interlayer above
+    // the crate; neither may reappear.
+    assert!(
+        !dest.join("octocat").exists() && !key.parent().unwrap().join("logs").exists(),
+        "the old <github_id>/<session>/logs layout must be gone"
+    );
+}

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -15,6 +15,7 @@
 | `TRUSTY_AWS_REGION` | `trusty-analyze` (Bedrock deep pass) | AWS region for Bedrock `Converse` calls. Takes priority over `AWS_REGION`. Default: `us-east-1`. |
 | `AWS_REGION` | `trusty-analyze` (Bedrock deep pass) | Fallback AWS region for Bedrock calls. Overridden by `TRUSTY_AWS_REGION`. |
 | `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` | `trusty-analyze` (Bedrock deep pass) | Standard AWS credentials for Bedrock access. The full AWS credential chain (env vars, `~/.aws/credentials` profiles, IAM roles, SSO) is supported. No API key is needed when using a `bedrock/` model. |
+| `AWS_REGION`, `AWS_PROFILE`, `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` | `trusty-mpm` log drain (`s3://` destinations) | Read through the same AWS default provider chain, for any `s3://` log-drain destination that does NOT pin an identity. **A destination that carries `?profile=` ignores all of these** — that profile alone supplies its credentials and region, so an `AWS_ACCESS_KEY_ID` in the daemon's environment cannot re-point one destination at another account (#6657). See [log-drain.md](log-drain.md#s3-credentials). |
 
 ## Logging
 

--- a/docs/reference/log-drain.md
+++ b/docs/reference/log-drain.md
@@ -1,11 +1,10 @@
 # Log Drain — Destinations, Key Layout, and Manifest Semantics
 
-> Reference for `trusty_common::log_drain`, added by
-> [#6533](https://github.com/bobmatnyc/trusty-tools/issues/6533) (epic phase
-> 1+2). This page covers the drain **core**: destination URIs, the key layout,
-> manifest semantics, the scrub, and the limits. It is not a configuration
-> guide — nothing reads a config file or schedules a run yet. See
-> [What Phase 3 adds](#what-phase-3-adds).
+> Reference for `trusty_common::log_drain` and the `log_drain:` config section,
+> added by [#6533](https://github.com/bobmatnyc/trusty-tools/issues/6533). This
+> page covers the drain **core** — destination URIs, the key layout, manifest
+> semantics, the scrub, and the limits — and the
+> [`log_drain:` configuration](#configuration) trusty-mpm's daemon reads.
 
 The module is gated behind the `log-drain` feature and is not compiled by
 default:
@@ -34,29 +33,53 @@ syntax error.
 |---|---|
 | `s3://bucket` | Bucket root, region from the AWS credential chain |
 | `s3://bucket/prefix` | Every object written beneath `prefix` |
-| `s3://bucket/prefix?region=us-west-2` | Region override; the ONLY accepted query parameter |
+| `s3://bucket/prefix?region=us-west-2` | Region override |
+| `s3://bucket/prefix?profile=logs-writer` | Credentials and region from that `~/.aws` profile alone (#6657) |
+| `s3://bucket/prefix?role_arn=arn:aws:iam::…:role/…` | Assume that role over the base identity (#6657) |
 | `file:///abs/path` | A local directory. Used by the hermetic tests, and by an operator staging output before pointing at a bucket |
 | `gs://…`, `az://…` | **Reserved and refused** with `DrainError::UnsupportedScheme` |
 
+`region`, `profile`, and `role_arn` are the only accepted query parameters. They
+combine in any order, and `file://` takes none.
+
 Rejected forms, each with `DrainError::Uri`: a missing `://`, an empty bucket
 (`s3:///prefix`), a relative `file://relative/path`, `file:///` (the filesystem
-root), a query on a `file://` URI, an empty or misspelled query parameter. A
-misspelled `?reigon=` is refused rather than ignored — silently dropping it
-would send logs to the wrong region with no signal.
+root), a query on a `file://` URI, an empty or misspelled query parameter, and a
+parameter given twice. A misspelled `?reigon=` is refused rather than ignored —
+silently dropping it would send logs to the wrong region with no signal, and a
+dropped `?porfile=` would send them to the wrong ACCOUNT.
 
 Schemes are matched case-insensitively; the rest of the URI is not.
 
 ### S3 credentials
 
-The S3 adapter loads the **AWS default provider chain** — environment
-variables, `~/.aws/credentials`, SSO, IMDS — the same chain
-`inference::bedrock` uses, reused rather than reimplemented per the
+With no `?profile=` and no `?role_arn=`, the S3 adapter loads the **AWS default
+provider chain** — environment variables, `~/.aws/credentials`, SSO, IMDS — the
+same chain `inference::bedrock` uses, reused rather than reimplemented per the
 common-entry-point rule in [`CLAUDE.md`](../../CLAUDE.md). It is bridged into
 `object_store`'s own `CredentialProvider`, and re-fetched on each request so a
 rotated session token is picked up without rebuilding the store.
 
 **No bucket or region is ever hardcoded.** The region resolves as
-`?region=` → the credential chain → refusal with `DrainError::Credentials`.
+`?region=` → the identity's own region → refusal with `DrainError::Credentials`.
+
+#### Per-destination identity (#6657)
+
+`?profile=<name>` makes that profile the **whole** identity for the destination:
+credentials come from `ProfileFileCredentialsProvider` for that profile and
+nothing else, so an `AWS_ACCESS_KEY_ID` in the daemon's environment cannot
+re-point it at another account. Region falls back to the same profile's
+`region`, so a two-account layout needs no `?region=` on either URI.
+
+`?role_arn=<arn>` wraps whatever identity resolved — the named profile, or the
+default chain when none is named — in an STS `AssumeRole`. No STS call happens
+at connect time; the provider is lazy, so a bad ARN surfaces on the first upload
+rather than at daemon startup.
+
+The manifest cache namespace **includes** the identity, unlike `?region=`. A
+region override cannot change what a bucket holds; a different identity can
+change what it shows, and the cheap way to be wrong is the safe one — an
+unnecessary split re-uploads, a wrong share skips.
 
 ## Key layout
 
@@ -123,12 +146,16 @@ than skipping one that was never written.
 
 `<destination namespace>` is `DestinationUri::cache_namespace()`:
 `<scheme>-<16 hex chars of SHA-256(canonical form)>`, e.g. `s3-4f1c9ae0d2b7…`.
-The canonical form carries the **scheme**, the **bucket or path**, and the **key
-prefix** — everything that changes which objects a destination holds. `?region=`
-is deliberately **excluded**: a region override changes which endpoint serves a
-bucket, never its contents, so adding one must not orphan a cache that is still
-valid. The value is hashed because a key prefix and a filesystem path are both
-arbitrary strings, and a cache directory needs a single path segment.
+The canonical form carries the **scheme**, the **bucket or path**, the **key
+prefix**, and the **identity** (`?profile=`, `?role_arn=`) — everything that
+changes which objects a destination holds or can see. `?region=` is deliberately
+**excluded**: a region override changes which endpoint serves a bucket, never
+its contents, so adding one must not orphan a cache that is still valid. The
+value is hashed because a key prefix and a filesystem path are both arbitrary
+strings, and a cache directory needs a single path segment.
+
+A destination that pins no identity produces the same namespace it produced
+before #6657, so adding per-destination identities orphaned no existing cache.
 
 Before [#6548](https://github.com/bobmatnyc/trusty-tools/issues/6548) the cache
 was keyed by identity alone. Repointing one session from bucket A to a brand-new
@@ -280,17 +307,86 @@ A **per-file** failure is collected into `DrainReport::errors` and the batch
 continues; one unreadable file must not strand every other log on the machine.
 Only a manifest read/write failure aborts a run.
 
-## What Phase 3 adds
+## Configuration
 
-Not in this module, deliberately:
+The drain is off by default. trusty-mpm's daemon reads the `log_drain:` section
+of `~/.trusty-tools/trusty-mpm/config.yaml`; `resolve_log_drain` turns it into a
+plan, and the `log_drain` doctor row reports what that plan says.
 
-- The **scheduler** — a `tokio::time::interval` + `CancellationToken` loop
-  beside `orphan_gc_loop`, with the single-flight guard `run_once` does not
-  provide.
-- **GitHub identity resolution** — one cached `gh api user` lookup feeding
-  `DrainTarget.github_id`, with the config value taking precedence.
-- **Configuration** — a `[log_drain]` section, and the `LogSource` list for the
-  daemons that actually produce logs.
-- **Consumers** — nothing calls `run_once` yet.
-- **Pruning** — the drain is upload-only; `prune_after_upload` is not
-  implemented.
+| Key | Default | Meaning |
+|---|---|---|
+| `enabled` | `false` | Whether the scheduler runs at all |
+| `destination` | — | Section-default destination URI |
+| `interval_secs` | `900` | Seconds between passes. Zero is an error |
+| `max_file_bytes` | 4 GiB | Plaintext source ceiling |
+| `max_wire_bytes` | 64 MiB | Compressed body ceiling |
+| `secrets` | `[]` | Extra literal strings scrubbed from every body |
+| `github_id` | `gh api user` | First key segment |
+| `session_id` | persisted per-install id | Second key segment |
+| `sources[]` | the daemon's own log dir | Directories to collect |
+
+A `sources[]` entry takes `crate_name` and `root` (both required), `include`
+(globs relative to `root`, default `**/*`), `level` (minimum line level), and
+`destination`.
+
+**A malformed section is a hard error, never a silent skip.** Validation runs
+whenever the section is present, including while `enabled: false`, so a typo is
+found before the operator flips the switch. The scheduler refuses to start and
+the `log_drain` doctor row reports `Fail`.
+
+### Per-source destinations (#6657)
+
+A source's own `destination` wins; a source that names none inherits the
+section's. Sources are grouped by the destination they resolve to, and the
+scheduler runs **one pass per destination** — its own connection, its own
+manifest. `destination` at the section level is required only when some source
+still needs it.
+
+```yaml
+log_drain:
+  enabled: true
+  # Everything that does not say otherwise goes here.
+  destination: "s3://team-shared-logs/drain"
+  interval_secs: 900
+  sources:
+    - crate_name: trusty-mpm
+      root: "~/.trusty-mpm/logs"
+      include: ["trusty-mpm.log*"]
+      level: info
+    # This project's logs belong in one specific account, so this source names
+    # its own bucket AND the profile that writes to it.
+    - crate_name: trusty-code
+      root: "~/Library/Logs/trusty-code"
+      include: ["*.log"]
+      destination: "s3://trusty-tools-logs/drain?profile=trusty-logs&region=us-east-1"
+```
+
+That config produces two passes per tick: `trusty-mpm`'s logs to
+`team-shared-logs` under the default AWS chain, and `trusty-code`'s to
+`trusty-tools-logs` signed with the `trusty-logs` profile.
+
+Two sources naming the same destination share one pass. Grouping is by the
+PARSED URI, so `s3://b/p` and `s3://b/p/` are one group, while two identities
+against one bucket are two.
+
+### A destination that fails does not fall back
+
+If a destination cannot be reached, its sources are **skipped for that tick**.
+They are never retried against the section default — a per-source destination is
+a statement about which account those bytes belong in, so shipping them to the
+fallback would be worse than not shipping them. Every other destination still
+drains, the tick reports `Failed`, and the `log_drain` doctor row names which
+destination broke:
+
+```
+log drain enabled (s3 → s3://team-shared-logs/drain, s3 → s3://trusty-tools-logs/drain?profile=trusty-logs)
+  but the last run FAILED at 2026-09-02T11:40:12Z —
+  s3 → s3://team-shared-logs/drain: ok — 2 file(s) uploaded (48122 B), 7 unchanged, 0 over the size ceiling (0 newly recorded);
+  s3 → s3://trusty-tools-logs/drain?profile=trusty-logs: FAILED — cannot reach the destination: …
+```
+
+## Not implemented
+
+- **Pruning** — the drain is upload-only; `prune_after_upload` does not exist.
+- **`gs://` and `az://`** — recognised by the parser and refused; no backend is
+  compiled behind either.

--- a/docs/reference/log-drain.md
+++ b/docs/reference/log-drain.md
@@ -84,27 +84,44 @@ unnecessary split re-uploads, a wrong share skips.
 ## Key layout
 
 ```text
-<destination prefix>/<github_id>/<session_id>/logs/<crate>/<relative_file>
+<destination prefix>/<owner>/<project>/<crate>/<relative_file>
 ```
 
 The destination prefix comes from the URI (`s3://bucket/PREFIX`) and is joined
 by the adapter; everything after it is built by `DrainTarget`. For
 `file://` destinations the URI's path is the store root, so the prefix is empty.
+A destination of `s3://acme-logs/live` therefore writes
+`live/duettoresearch/pricing/trusty-code/daemon.log`.
 
-`DrainTarget { github_id, session_id }` is **supplied by the caller**. The core
-does not resolve GitHub identity — that is Phase 3's job. An empty or
-whitespace-only `github_id` or `session_id` is refused with
-`DrainError::MissingIdentity` **before anything touches the filesystem or the
-network**: the drain never writes under an unknown id, because an empty
-component collapses one user's logs into a shared, unattributable prefix.
+`DrainTarget { owner, project }` is **supplied by the caller**. The core does
+not resolve the identity — trusty-mpm's config layer does, from the git
+`origin` of each source's root. An empty or whitespace-only `owner` or
+`project` is refused with `DrainError::MissingIdentity` **before anything
+touches the filesystem or the network**: the drain never writes under a guessed
+identity, because an empty component collapses one project's logs into a
+shared, unattributable prefix.
 
-`session_id` is opaque to the drain — it is whatever the consuming crate calls
-its own session.
+### The layout changed in #6657
+
+The previous layout was `<github_id>/<session_id>/logs/<crate>/<relative_file>`
+— every project on a host under one prefix, keyed by whoever ran the daemon,
+split by a session id that meant nothing to anyone reading the bucket.
+
+**Objects already uploaded under the old layout stay exactly where they are.**
+Nothing moves them and nothing deletes them. The manifest is keyed by
+destination *and* key, so the new layout starts with an empty manifest of its
+own: the first pass after the upgrade re-uploads the current log files under
+`<owner>/<project>/…` and then dedupes as before. The old prefix simply stops
+growing. Delete it by hand if you want it gone:
+
+```bash
+aws s3 rm --recursive s3://<bucket>/<prefix>/<github_id>/<session_id>/
+```
 
 ## Manifest semantics
 
 Each target carries a JSON manifest at
-`<…>/logs/.drain-manifest.json`, listing one entry per uploaded file:
+`<owner>/<project>/.drain-manifest.json`, listing one entry per uploaded file:
 
 ```json
 {
@@ -127,10 +144,10 @@ invalidates every recorded digest.
 
 ### Two copies, and which one wins
 
-- **Remote** (`<…>/logs/.drain-manifest.json`) is **authoritative**. It is the
+- **Remote** (`<owner>/<project>/.drain-manifest.json`) is **authoritative**. It is the
   only copy that describes what is actually in the bucket.
 - **Local cache**
-  (`<state_dir>/log-drain/<destination namespace>/<github_id>/<session_id>/manifest.json`)
+  (`<state_dir>/log-drain/<destination namespace>/<owner>/<project>/manifest.json`)
   exists so an unchanged run costs no network read at all.
 
 When both exist and disagree, the remote copy wins and the cache is rewritten
@@ -174,7 +191,7 @@ forever.
 **Repair:** delete the manifest object.
 
 ```bash
-aws s3 rm s3://<bucket>/<prefix>/<github_id>/<session_id>/logs/.drain-manifest.json
+aws s3 rm s3://<bucket>/<prefix>/<owner>/<project>/.drain-manifest.json
 ```
 
 The next run finds no remote copy, falls back to a cache that is now
@@ -297,7 +314,7 @@ files. `run_once` now writes a `SkipRecord` — `relative_file`, `size`,
 
 ## What the caller owns
 
-- **Identity** — `DrainTarget` is supplied, never resolved here.
+- **Identity** — `DrainTarget { owner, project }` is supplied, never resolved here.
 - **Single-flight** — `run_once` is one pass with no locking. Two concurrent
   runs against one target will both upload and both rewrite the manifest, and
   the loser's entries are lost. Mutual exclusion belongs to the scheduler.
@@ -321,53 +338,99 @@ plan, and the `log_drain` doctor row reports what that plan says.
 | `max_file_bytes` | 4 GiB | Plaintext source ceiling |
 | `max_wire_bytes` | 64 MiB | Compressed body ceiling |
 | `secrets` | `[]` | Extra literal strings scrubbed from every body |
-| `github_id` | `gh api user` | First key segment |
-| `session_id` | persisted per-install id | Second key segment |
+| `owner` | — | Fallback owner for a source that resolves none |
+| `project` | — | Fallback project, paired with `owner` |
 | `sources[]` | the daemon's own log dir | Directories to collect |
 
 A `sources[]` entry takes `crate_name` and `root` (both required), `include`
-(globs relative to `root`, default `**/*`), `level` (minimum line level), and
-`destination`.
+(globs relative to `root`, default `**/*`), `level` (minimum line level),
+`destination`, `owner`/`project`, and `enabled`.
 
 **A malformed section is a hard error, never a silent skip.** Validation runs
 whenever the section is present, including while `enabled: false`, so a typo is
 found before the operator flips the switch. The scheduler refuses to start and
 the `log_drain` doctor row reports `Fail`.
 
-### Per-source destinations (#6657)
+### Per-project destinations (#6657)
 
 A source's own `destination` wins; a source that names none inherits the
-section's. Sources are grouped by the destination they resolve to, and the
-scheduler runs **one pass per destination** — its own connection, its own
-manifest. `destination` at the section level is required only when some source
+section's. `destination` at the section level is required only when some source
 still needs it.
+
+Each source also resolves an `<owner>/<project>`, in this order:
+
+1. the source's own `owner:` and `project:` — set both, or neither;
+2. the git `origin` of its `root`. `git -C <root> config --get
+   remote.origin.url` walks **up**, so a log directory inside a checkout
+   resolves to that checkout, and a worktree resolves to its parent;
+3. the section-level `owner:`/`project:`.
+
+A source that resolves none of the three is a **hard config error** naming the
+source, its root, and both ways to fix it. There is no placeholder key: the
+drain refuses the whole plan rather than file one project's logs under an
+invented prefix.
+
+The remote is parsed by `trusty_common::github_path::parse_remote_url`, the
+workspace's one git-remote-URL parser — HTTPS, `ssh://`, and scp-style
+`git@host:owner/repo`, with or without `.git`, on any host. The owner and
+project keep the case the remote spells them in.
+
+Sources are grouped by the destination **and** project they resolve to, and the
+scheduler runs **one pass per group** — its own connection, its own manifest.
+One bucket holding three projects is three passes.
 
 ```yaml
 log_drain:
   enabled: true
   # Everything that does not say otherwise goes here.
-  destination: "s3://team-shared-logs/drain"
+  destination: "s3://team-shared-logs/live"
   interval_secs: 900
+  # Used only by sources that resolve no project of their own — the daemon's
+  # own log directory is inside no checkout.
+  owner: "duettoresearch"
+  project: "workstation"
   sources:
     - crate_name: trusty-mpm
       root: "~/.trusty-mpm/logs"
       include: ["trusty-mpm.log*"]
       level: info
-    # This project's logs belong in one specific account, so this source names
-    # its own bucket AND the profile that writes to it.
+    # Inside the checkout, so owner and project come from its git origin.
     - crate_name: trusty-code
-      root: "~/Library/Logs/trusty-code"
+      root: "~/src/duettoresearch/pricing/logs"
       include: ["*.log"]
-      destination: "s3://trusty-tools-logs/drain?profile=trusty-logs&region=us-east-1"
+      destination: "s3://pricing-logs/live?profile=pricing&region=us-east-1"
+    # Logs live outside the checkout, so this one names its project.
+    - crate_name: trusty-agents
+      root: "~/Library/Logs/trusty-agents"
+      include: ["daemon-*.log"]
+      owner: "duettoresearch"
+      project: "insights"
+    # Off for now, without deleting the entry.
+    - crate_name: trusty-search
+      root: "~/Library/Logs/trusty-search"
+      enabled: false
 ```
 
-That config produces two passes per tick: `trusty-mpm`'s logs to
-`team-shared-logs` under the default AWS chain, and `trusty-code`'s to
-`trusty-tools-logs` signed with the `trusty-logs` profile.
+That config produces three passes per tick, writing
+`live/duettoresearch/workstation/trusty-mpm/…` to `team-shared-logs`,
+`live/duettoresearch/pricing/trusty-code/…` to `pricing-logs` signed with the
+`pricing` profile, and `live/duettoresearch/insights/trusty-agents/…` back to
+`team-shared-logs`.
 
-Two sources naming the same destination share one pass. Grouping is by the
-PARSED URI, so `s3://b/p` and `s3://b/p/` are one group, while two identities
-against one bucket are two.
+Two sources share a pass only when they resolved to the same destination AND
+the same project. Grouping is by the PARSED URI, so `s3://b/p` and `s3://b/p/`
+are one group, while two identities against one bucket are two.
+
+### Turning one project off
+
+`enabled: false` on a source skips it: no connection, no upload, no manifest.
+The entry stays in the config and `tm doctor` still names it, so an operator can
+tell a deliberate opt-out from a project that fell out of the file:
+
+```
+log drain enabled (s3 → s3://team-shared-logs/live [duettoresearch/workstation],
+  trusty-search → s3://team-shared-logs/live: disabled) ...
+```
 
 ### A destination that fails does not fall back
 
@@ -379,10 +442,10 @@ drains, the tick reports `Failed`, and the `log_drain` doctor row names which
 destination broke:
 
 ```
-log drain enabled (s3 → s3://team-shared-logs/drain, s3 → s3://trusty-tools-logs/drain?profile=trusty-logs)
+log drain enabled (s3 → s3://team-shared-logs/live [duettoresearch/workstation], s3 → s3://pricing-logs/live?profile=pricing [duettoresearch/pricing])
   but the last run FAILED at 2026-09-02T11:40:12Z —
-  s3 → s3://team-shared-logs/drain: ok — 2 file(s) uploaded (48122 B), 7 unchanged, 0 over the size ceiling (0 newly recorded);
-  s3 → s3://trusty-tools-logs/drain?profile=trusty-logs: FAILED — cannot reach the destination: …
+  s3 → s3://team-shared-logs/live [duettoresearch/workstation]: ok — 2 file(s) uploaded (48122 B), 7 unchanged, 0 over the size ceiling (0 newly recorded);
+  s3 → s3://pricing-logs/live?profile=pricing [duettoresearch/pricing]: FAILED — cannot reach the destination: …
 ```
 
 ## Not implemented


### PR DESCRIPTION
## Outcome

Log-drain object keys are now `<owner>/<project>/<crate>/<file>` under the destination prefix. Identity comes from each source root's git origin, then a section-level `owner:`/`project:` fallback, else a hard `SourceIdentity` error (no placeholder key). A source can set `enabled: false` and still appears in status/doctor rows. The three remote-URL parsers in trusty-common `github_path.rs`, tga `repo_resolver.rs`, and trusty-code `mpm_registry.rs` are now one unified `parse_remote_url`. The `github_id`/`session_id` config keys and the `gh api user` probe are removed.

## Changes

Crates touched: trusty-common (log_drain, github_path), trusty-mpm (core/trusty_tools_config/log_drain, daemon/log_drain, doctor_log_drain, new plan.rs), trusty-git-analytics, trusty-code. See [#6657](https://github.com/bobmatnyc/trusty-tools/issues/6657) for the design.

## Risk

High per the test ladder, rung 4 (cross-crate library change touching persisted config keys). One behaviour change: trusty-code `parse_owner_repo("https://git.example.com:8443/owner/repo")` now returns `("owner","repo")` instead of `None` (port-qualified host parsed correctly); documented at the call site with a regression test.

## Test Evidence

Passing gates with `--no-fail-fast`:
- `cargo test -p trusty-common --features log-drain` — 564 passed / 0 failed / 6 ignored (lib)
- `cargo test -p tga` — 1442 passed
- `cargo test -p trusty-code` — 1671 passed (lib) + 17 targets ok
- `cargo test -p trusty-mpm` — lib 5816 passed (see Baseline Failures for cross-crate failures)
- `cargo check --workspace` — clean
- `cargo fmt --check` — clean
- `cargo clippy -p trusty-common --features log-drain --all-targets -- -D warnings` — clean
- `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — clean
- `cargo clippy -p tga --all-targets -- -D warnings` — clean
- `cargo clippy -p trusty-code --all-targets -- -D warnings` — clean
- `scripts/check_line_cap.sh` — OK
- `scripts/check_changelog_fragment.sh` — OK (4 crates)
- `scripts/check_sld.sh` — OK
- `scripts/check_test_pointers.sh` — OK

Code-critic round: WARN, both MEDIUM findings fixed in commit 5ee492f6a with mutation-verified tests (`a_role_arn_resolves_to_an_assumed_role_identity`, `a_profile_and_a_role_arn_do_not_collapse_onto_the_profile`, `a_tick_over_only_disabled_sources_names_the_empty_plan`).

## Baseline Failures

`cargo test -p trusty-mpm --no-fail-fast` has 10 pre-existing failures across 6 targets from the [#6671](https://github.com/bobmatnyc/trusty-tools/issues/6671) family (the daemon's project registry reads the developer's live `~/.trusty-tools/trusty-mpm/config.yaml`, 22 projects):
- manager_status_route_empty_portfolio
- manager_status_route_rolls_up_all_projects
- manager_status_client_reads_live_route
- manager_digest_happy_path_scripted_narrative
- register_get_list_status_round_trip
- register_is_idempotent_upsert
- mcp_initiated_spawn_rejected_for_unregistered_repo_when_enabled
- three daemon::rpc::registry::tests parity/blank-name tests

Proof they are pre-existing: `git diff origin/main...HEAD --name-only -- crates/trusty-mpm/src/daemon/state/ crates/trusty-mpm/src/core/trusty_tools_config/` lists only log_drain files.

One additional single-occurrence flake, `orphan_gc_loop_leaves_the_home_session_dirs_alone_on_a_scratch_root`, is a same-process $HOME race tracked in [#6663](https://github.com/bobmatnyc/trusty-tools/issues/6663); passes alone and on rerun.

## Docs

docs/reference/log-drain.md updated on the branch; changelog fragments present for all four crates.

Operator note: a `log_drain:` source whose root is outside any checkout (the default `~/.trusty-mpm/logs`) now needs `owner:`/`project:` or a section-level pair, or the plan hard-errors.

## Review

Code-critic WARN → fixed; security scan PASS.

Refs [#6657](https://github.com/bobmatnyc/trusty-tools/issues/6657)

Refs #6657

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
