### PR TITLE
test(trusty-mpm): regenerate PM-prompt goldens after #6673 (Refs #6511)

### DIFF
--- a/crates/trusty-mpm/src/core/testdata/pm-prompt-bundled-fallback.md
+++ b/crates/trusty-mpm/src/core/testdata/pm-prompt-bundled-fallback.md
@@ -68,7 +68,8 @@ Delegation Authority roster below it is authoritative for which agents exist.
 - Every engineer delegation MUST end with: "Before returning: run
   linters/formatters, fix any issues, run tests, verify all pass. Verify ALL
   deliverables from the prompt are present (README, config, etc.). Show raw test
-  output."
+  output. Including this repo's doc gates: `check_test_pointers.sh`,
+  `check_line_cap.sh`, `check_changelog_fragment.sh`."
 - A running agent's scope is fixed. New work is a new agent, or it waits.
 - A brief carries findings, evidence and constraints, never the implementation
   mechanism: state what must be TRUE.

--- a/crates/trusty-mpm/src/core/testdata/pm-prompt-claude-md-override.md
+++ b/crates/trusty-mpm/src/core/testdata/pm-prompt-claude-md-override.md
@@ -68,7 +68,8 @@ Delegation Authority roster below it is authoritative for which agents exist.
 - Every engineer delegation MUST end with: "Before returning: run
   linters/formatters, fix any issues, run tests, verify all pass. Verify ALL
   deliverables from the prompt are present (README, config, etc.). Show raw test
-  output."
+  output. Including this repo's doc gates: `check_test_pointers.sh`,
+  `check_line_cap.sh`, `check_changelog_fragment.sh`."
 - A running agent's scope is fixed. New work is a new agent, or it waits.
 - A brief carries findings, evidence and constraints, never the implementation
   mechanism: state what must be TRUE.

--- a/crates/trusty-mpm/src/core/testdata/pm-prompt-roster-absent.md
+++ b/crates/trusty-mpm/src/core/testdata/pm-prompt-roster-absent.md
@@ -68,7 +68,8 @@ Delegation Authority roster below it is authoritative for which agents exist.
 - Every engineer delegation MUST end with: "Before returning: run
   linters/formatters, fix any issues, run tests, verify all pass. Verify ALL
   deliverables from the prompt are present (README, config, etc.). Show raw test
-  output."
+  output. Including this repo's doc gates: `check_test_pointers.sh`,
+  `check_line_cap.sh`, `check_changelog_fragment.sh`."
 - A running agent's scope is fixed. New work is a new agent, or it waits.
 - A brief carries findings, evidence and constraints, never the implementation
   mechanism: state what must be TRUE.


### PR DESCRIPTION
## Outcome

main is red on three `core::pm_prompt_golden_tests` (`golden_bundled_fallback_prompt`, `golden_claude_md_override_prompt`, `golden_roster_absent_assembly_prompt`) because [#6673](https://github.com/bobmatnyc/trusty-tools/pull/6673) (squash [de962e31d](https://github.com/bobmatnyc/trusty-tools/commit/de962e31d)) added the doc-gates sentence to the composed PM prompt without regenerating fixtures; this regenerates them.

## Changes

three files under `crates/trusty-mpm/src/core/testdata/`, each +1 sentence.

## Risk

Low, rung 2, fixtures only.

## Test Evidence

`cargo test -p trusty-mpm --no-fail-fast --lib golden` 4 passed / 0 failed
`cargo test -p trusty-mpm --no-fail-fast --lib` 5805 passed / 0 failed / 8 ignored

## Baseline Failures

none observed on this run.

## Docs

none; no changelog fragment (test-only).

## Review

none needed, fixture regeneration via the documented `UPDATE_GOLDEN=1` path.

Refs #6511

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
