### PR TITLE
fix(ci): check_test_pointers.sh expands brace-set Test: citations and fails closed on unrecognised shapes; repoint 29 surfaced pointers (Refs #6678)

### DIFF
--- a/.github/workflows/test-pointers.yml
+++ b/.github/workflows/test-pointers.yml
@@ -130,6 +130,16 @@ jobs:
         if: steps.detect.outputs.pointer_inputs_changed == 'true'
         run: bash scripts/check_scan_floor_selftest.sh test_pointers
 
+      # The gate's own fixture suite, which the scan-floor selftest above does
+      # not reach: it proves the scan is non-empty, never that the PARSER reads
+      # a citation correctly. #6678 landed on exactly that gap — brace-set
+      # citations were dropped as "not a candidate" while the floor stayed far
+      # above its minimum and the gate reported 0 dangling pointers. Runs before
+      # the real gate, matching line-cap.yml's selftest-then-gate ordering.
+      - name: Parser selftest (fixtures, no toolchain)
+        if: steps.detect.outputs.pointer_inputs_changed == 'true'
+        run: bash scripts/check_test_pointers.sh --self-test
+
       - name: "Lint Test: doc-comment pointers against real test names"
         if: steps.detect.outputs.pointer_inputs_changed == 'true'
         run: bash scripts/check_test_pointers.sh

--- a/crates/trusty-audit/changelog.d/6678-brace-set-test-pointers.md
+++ b/crates/trusty-audit/changelog.d/6678-brace-set-test-pointers.md
@@ -1,2 +1,3 @@
 Documentation
 - Repointed the `Test:` citation for `ground_manifest` and `hotspots::fetch` at the renamed `hotspots_and_search_hits_become_ranked_inspect_priority_in_the_manifest`, which the pointer lint could not see while brace-set citations were dropped (#6678).
+- Repointed four more brace-set `Test:` citations whose named test never shipped: `Budget::for_engagement`, `dependency_manifests` and `write_into_manifest` now name the tests that assert the same behaviour, and `ensure_indexed` names the new `a_refused_index_is_a_reason_not_a_status` (#6678).

--- a/crates/trusty-audit/changelog.d/6678-brace-set-test-pointers.md
+++ b/crates/trusty-audit/changelog.d/6678-brace-set-test-pointers.md
@@ -1,0 +1,2 @@
+Documentation
+- Repointed the `Test:` citation for `ground_manifest` and `hotspots::fetch` at the renamed `hotspots_and_search_hits_become_ranked_inspect_priority_in_the_manifest`, which the pointer lint could not see while brace-set citations were dropped (#6678).

--- a/crates/trusty-audit/changelog.d/6678-refused-index-test-added.md
+++ b/crates/trusty-audit/changelog.d/6678-refused-index-test-added.md
@@ -1,0 +1,2 @@
+Added
+- `grounding::index::index_tests::a_refused_index_is_a_reason_not_a_status` — `ensure_indexed` turns a refused `trusty-search index` into the one-line reason its caller records as a gap, rather than reporting an `IndexStatus` for an index that was never built (#6678).

--- a/crates/trusty-audit/src/grounding.rs
+++ b/crates/trusty-audit/src/grounding.rs
@@ -389,7 +389,7 @@ fn discovery_gaps(discovery: &evidence::Discovery, display: &str) -> Vec<String>
 /// `[report]` budget and the budget the investigation pass ran under one number
 /// rather than two independent resolutions of it (#6082, #6247). It both sizes
 /// the evidence caps and reaches `[report]`.
-/// Test: `super::grounding_tests::{hotspots_become_ranked_inspect_priority_in_the_manifest,
+/// Test: `super::grounding_tests::{hotspots_and_search_hits_become_ranked_inspect_priority_in_the_manifest,
 /// a_manifest_that_cannot_be_written_is_a_named_gap}`.
 pub async fn ground_manifest(
     manifest: &Path,

--- a/crates/trusty-audit/src/grounding/hotspots.rs
+++ b/crates/trusty-audit/src/grounding/hotspots.rs
@@ -196,7 +196,7 @@ fn rank(hotspots: &[Hotspot], checkout: &Path) -> Vec<RankedFile> {
 ///
 /// Test: `super::grounding_tests::{an_unreachable_hotspots_endpoint_is_a_named_gap,
 /// an_empty_hotspot_list_is_a_named_gap,
-/// hotspots_become_ranked_inspect_priority_in_the_manifest}`.
+/// hotspots_and_search_hits_become_ranked_inspect_priority_in_the_manifest}`.
 pub async fn fetch(
     socket: &Path,
     index_id: &str,

--- a/crates/trusty-audit/src/grounding/index.rs
+++ b/crates/trusty-audit/src/grounding/index.rs
@@ -183,7 +183,9 @@ fn index_args(path: &Path, index_id: &str) -> Vec<OsString> {
 /// the renderer's membership check while still filling, so its sections render
 /// from whatever had been embedded by then.
 ///
-/// Test: `index_tests::{a_served_index_is_not_rebuilt, an_index_failure_is_a_reason}`.
+/// Test: `index_tests::{a_served_index_is_not_rebuilt,
+/// an_unserved_index_is_built_under_the_requested_id,
+/// a_refused_index_is_a_reason_not_a_status}`.
 pub fn ensure_indexed(
     search: &Path,
     checkout: &Path,
@@ -388,6 +390,37 @@ mod index_tests {
         assert_eq!(status, IndexStatus::Indexed);
         let seen = std::fs::read_to_string(&calls).expect("stub ran");
         assert!(seen.contains("index /w/repos/xsv --name xsv"), "{seen}");
+    }
+
+    /// #6678: the failure arm of the same path. `index --name` refusing must
+    /// come back as the one-line reason the caller turns into a gap, never as
+    /// an `IndexStatus` — a refused index reported as `Indexed` would let every
+    /// downstream leg read an index that was never built.
+    #[cfg(unix)]
+    #[test]
+    fn a_refused_index_is_a_reason_not_a_status() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let stub = tmp.path().join("trusty-search");
+        // `index add` is approved; `index-status` reports the daemon's 404; the
+        // build itself refuses on stderr the way a non-allowlisted root does.
+        std::fs::write(
+            &stub,
+            "#!/bin/sh\n\
+             [ \"$1 $2\" = \"index add\" ] && exit 0\n\
+             [ \"$1\" = index-status ] && exit 1\n\
+             echo 'indexing refused: root is not allowlisted' >&2\n\
+             exit 1\n",
+        )
+        .expect("write stub");
+        std::fs::set_permissions(&stub, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+
+        let reason = ensure_indexed(&stub, Path::new("/w/repos/xsv"), "xsv")
+            .expect_err("a refused index must not report a status");
+        assert!(reason.contains("/w/repos/xsv"), "{reason}");
+        assert!(reason.contains("root is not allowlisted"), "{reason}");
+        assert_eq!(reason.lines().count(), 1, "must stay one line: {reason}");
     }
 
     /// The backstop still has to be precise: the comparison resolves symlinks

--- a/crates/trusty-audit/src/grounding/priority.rs
+++ b/crates/trusty-audit/src/grounding/priority.rs
@@ -196,8 +196,7 @@ impl Budget {
     /// zero or absent value reads as undeclared rather than as a disabled
     /// investigation.
     /// Test: `priority_tests::{a_declared_engagement_budget_wins,
-    /// an_engagement_declaring_nothing_matches_the_machine,
-    /// an_engagement_file_budget_raises_the_byte_budget}`.
+    /// an_engagement_declaring_nothing_matches_the_machine}`.
     #[must_use]
     pub fn for_engagement(settings: &crate::config::ReportSettings) -> Self {
         let declared = |value: Option<usize>| value.filter(|n| *n > 0);

--- a/crates/trusty-audit/src/grounding/quality.rs
+++ b/crates/trusty-audit/src/grounding/quality.rs
@@ -187,8 +187,8 @@ const MAX_MANIFESTS: usize = 12;
 /// # Postconditions
 /// Never panics. An unreadable directory contributes nothing and stops nothing.
 ///
-/// Test: `super::quality_tests::{dependency_manifests_lead_with_the_root_manifest,
-/// dependency_manifests_skip_vendored_trees, dependency_manifests_are_capped}`.
+/// Test: `super::quality_tests::{manifests_lead_the_dependencies_dimension,
+/// a_tree_with_no_manifest_is_left_alone, dependency_manifests_are_capped}`.
 #[must_use]
 pub fn dependency_manifests(checkout: &Path) -> Vec<FileEvidence> {
     let mut found: Vec<(usize, String)> = Vec::new();

--- a/crates/trusty-audit/src/inference.rs
+++ b/crates/trusty-audit/src/inference.rs
@@ -375,7 +375,7 @@ where
 /// from the environment as it did before this key existed.
 ///
 /// Test: `super::inference_tests::{the_section_lands_in_the_manifest,
-/// a_second_write_replaces_the_first}`.
+/// a_manifest_that_cannot_be_written_says_so}`.
 pub fn write_into_manifest(path: &std::path::Path, selection: &Selection) -> Result<(), String> {
     let text = std::fs::read_to_string(path)
         .map_err(|e| format!("{} could not be read ({e})", path.display()))?;

--- a/crates/trusty-git-analytics/changelog.d/6678-authorship-test-pointer.md
+++ b/crates/trusty-git-analytics/changelog.d/6678-authorship-test-pointer.md
@@ -1,0 +1,2 @@
+Documentation
+- Repointed `build_authorship_summary_with`'s `Test:` citation from `single_author_subsystem_detected`, a name that never shipped, at `shared_subsystem_is_not_single_author`; the positive case is already asserted inside `builds_from_seeded_commits` (#6678).

--- a/crates/trusty-git-analytics/src/report/authorship.rs
+++ b/crates/trusty-git-analytics/src/report/authorship.rs
@@ -432,7 +432,7 @@ pub fn build_authorship_summary(conn: &Connection, repository: &str) -> Result<A
 /// computing it per repository paid that cost repeatedly for one answer
 /// (#6142 review).
 /// Test: `super::authorship_tests::{builds_from_seeded_commits,
-/// bots_and_merges_are_excluded, single_author_subsystem_detected,
+/// bots_and_merges_are_excluded, shared_subsystem_is_not_single_author,
 /// aliases_collapse_through_the_identity_resolver,
 /// unresolved_authors_are_counted_and_caveated}`.
 ///

--- a/crates/trusty-review/changelog.d/6678-brace-set-test-pointers.md
+++ b/crates/trusty-review/changelog.d/6678-brace-set-test-pointers.md
@@ -1,2 +1,4 @@
 Documentation
 - Repointed seven `Test:` citations whose named test had been renamed, and rewrapped the `analyze_endpoints` module citation that split an identifier across two doc lines. All were invisible while the pointer lint dropped brace-set citations (#6678).
+- Repointed eighteen more brace-set `Test:` citations across `context_gate`, `analyze_findings`, `investigate::select`, `investigate::verify`, `mermaid`, `reporter`, `reporter_findings`, `synthesize`, `synthesize_normalize`, `synthesize_prompt` and `topology` at the tests that exist — renamed successors where the test was renamed, and the surviving test where the cited name never shipped (#6678).
+- Corrected `verify_findings`'s What paragraph, which still described GREEN as a title-only topic admitted without evidence; since #6080 every band must cite a file in the inspected set (#6678).

--- a/crates/trusty-review/changelog.d/6678-brace-set-test-pointers.md
+++ b/crates/trusty-review/changelog.d/6678-brace-set-test-pointers.md
@@ -1,0 +1,2 @@
+Documentation
+- Repointed seven `Test:` citations whose named test had been renamed, and rewrapped the `analyze_endpoints` module citation that split an identifier across two doc lines. All were invisible while the pointer lint dropped brace-set citations (#6678).

--- a/crates/trusty-review/changelog.d/6678-marker-and-claim-tests-added.md
+++ b/crates/trusty-review/changelog.d/6678-marker-and-claim-tests-added.md
@@ -1,0 +1,3 @@
+Added
+- `report::mermaid::tests::{parses_full_marker, ignores_non_dataset_comment}` — `parse_marker` had no direct coverage, so nothing proved the `group:` field survives the comma-inside-`y:` grammar or that a marker missing `x:`/`y:` is rejected rather than half-parsed (#6678).
+- `report::reporter::tests::a_second_narrative_cannot_overwrite_a_claimed_row` — two narratives sharing one title and one cited file exercise `match_row`'s unclaimed-rows filter on its own, which component disambiguation cannot reach (#6678).

--- a/crates/trusty-review/src/pipeline/context_gate.rs
+++ b/crates/trusty-review/src/pipeline/context_gate.rs
@@ -85,8 +85,9 @@ pub enum GateOutcome {
 /// routes through this same Degraded branch (never `Proceed`) regardless of
 /// whether `surface` is `Hosted` or `Interactive` — only the reason text and
 /// the required-vs-degraded branch selection differ per surface.
-/// Test: `gate_tests::{skips_when_search_down, degraded_when_search_down_optout,
-/// skips_when_analyze_down, proceeds_when_both_healthy,
+/// Test: `gate_tests::{skips_when_search_down_and_required,
+/// degraded_when_search_down_and_opted_out,
+/// skips_when_analyze_down_and_required, proceeds_when_both_healthy,
 /// interactive_surface_defaults_to_degraded_when_search_down,
 /// hosted_surface_defaults_to_skip_when_search_down,
 /// degraded_reason_prefers_health_error_detail,

--- a/crates/trusty-review/src/pipeline/context_gate.rs
+++ b/crates/trusty-review/src/pipeline/context_gate.rs
@@ -91,7 +91,7 @@ pub enum GateOutcome {
 /// interactive_surface_defaults_to_degraded_when_search_down,
 /// hosted_surface_defaults_to_skip_when_search_down,
 /// degraded_reason_prefers_health_error_detail,
-/// degraded_but_serving_proceeds, degraded_not_serving_skips}` (issue #3693:
+/// degraded_but_serving_proceeds, not_serving_search_still_skips}` (issue #3693:
 /// a `status: "degraded"` health response now proceeds when trusty-search's
 /// own `warmboot_summary.warm_boot_degraded` flag says it is still serving,
 /// and still skips when that flag says it is genuinely broken).

--- a/crates/trusty-review/src/report/analyze_endpoints.rs
+++ b/crates/trusty-review/src/report/analyze_endpoints.rs
@@ -17,8 +17,8 @@
 //! Caveats list, so one slow endpoint names itself instead of erasing the whole
 //! fetch.
 //!
-//! Test: `analyze_adapter_tests.rs::{diagnostics_budget_outlives_the_daemon_
-//! deadline_ladder, caveat_labels_are_stable}`.
+//! Test: `analyze_adapter_tests.rs::{diagnostics_budget_outlives_the_daemon_deadline_ladder,
+//! caveat_labels_are_stable}`.
 
 use std::fmt;
 use std::time::Duration;

--- a/crates/trusty-review/src/report/analyze_findings.rs
+++ b/crates/trusty-review/src/report/analyze_findings.rs
@@ -295,8 +295,7 @@ fn humanise_refactor_type(t: &str) -> String {
 /// relative, or under a different root, is left exactly as it is — this
 /// normalises paths, it never rewrites ones it does not recognise.
 /// Test: `analyze_adapter_tests::{components_are_made_repo_relative,
-/// a_component_outside_the_checkout_is_left_alone,
-/// a_relative_component_is_left_alone}`.
+/// a_component_outside_the_checkout_is_left_alone}`.
 pub(super) fn relativize_components(metrics: &mut AnalyzeMetrics, root: &Path) {
     for finding in &mut metrics.findings {
         if let Some(rel) = repo_relative(&finding.component, root) {

--- a/crates/trusty-review/src/report/investigate/batch.rs
+++ b/crates/trusty-review/src/report/investigate/batch.rs
@@ -167,8 +167,9 @@ pub struct BatchOutcome {
 /// per-repo file set, not just the batch) so any well-formed cross-batch
 /// citation still resolves.  Survivors are merged and deduped by `(file,
 /// title)`, keeping the higher-severity (or, on a tie, first-seen) copy.
-/// Test: `batch_tests::{one_truncated_batch_others_survive, retry_recovers,
-/// merge_dedupes_keeping_higher_severity, all_batches_can_fail}`.
+/// Test: `batch_tests::{one_truncated_batch_others_survive,
+/// retry_recovers_from_truncation, merge_dedupes_keeping_higher_severity,
+/// all_batches_can_fail_independently}`.
 pub async fn run_batches(
     provider: Arc<dyn LlmProvider>,
     llm_model: &str,

--- a/crates/trusty-review/src/report/investigate/select.rs
+++ b/crates/trusty-review/src/report/investigate/select.rs
@@ -679,7 +679,7 @@ pub fn select_files(
 /// with different budgets used to report different test-coverage figures for an
 /// unchanged checkout.
 /// Test: `select_tests::{per_dimension_coverage_names_why_a_file_was_read,
-/// coverage_names_the_measured_function,
+/// a_declared_hotspot_reaches_the_selected_file_and_the_coverage_row,
 /// the_test_coverage_row_is_enumerated_not_sampled}`.
 fn per_dimension(
     selected: &[SelectedFile],

--- a/crates/trusty-review/src/report/investigate/verify.rs
+++ b/crates/trusty-review/src/report/investigate/verify.rs
@@ -157,13 +157,15 @@ fn normalize_dimension(raw: &str) -> String {
 /// Why: the fail-closed core — a finding is admitted only when its evidence is
 /// real, so the report can never cite code that was not inspected or does not
 /// exist.
-/// What: for each finding, GREEN passes as a title-only topic (no evidence
-/// required); RED/AMBER require (a) `file` present in `selection` and (b) a
-/// whitespace-insensitive verbatim match of `evidence_quote` in that file, from
-/// which the line number is (re)computed.  A missing title, missing file, or
-/// unmatched quote rejects the finding with a counted note.
+/// What: every band — GREEN included since #6080 — requires (a) `file` present
+/// in `selection` and (b) a whitespace-insensitive verbatim match of
+/// `evidence_quote` in that file, from which the line number is (re)computed.
+/// GREEN keeps that citation and its verified quote but is blanked of
+/// elaboration.  A missing title, missing file, or unmatched quote rejects the
+/// finding with a counted note.
 /// Test: `verify_tests::{accepts_and_corrects_line, rejects_missing_file,
-/// rejects_fabricated_quote, matches_whitespace_insensitively, green_is_title_only}`.
+/// rejects_fabricated_quote, matches_whitespace_insensitively,
+/// green_keeps_its_verified_quote, an_uncited_green_is_rejected}`.
 pub fn verify_findings(raw: Vec<RawFinding>, selection: &Selection) -> VerifyOutcome {
     let mut out = VerifyOutcome::default();
     for f in raw {

--- a/crates/trusty-review/src/report/mermaid.rs
+++ b/crates/trusty-review/src/report/mermaid.rs
@@ -269,7 +269,8 @@ fn cells_of(trimmed: &str) -> Vec<String> {
 /// builder.  `Heatmap` → the fallback note; `Unknown` → `None` + a debug log;
 /// bar/stacked-bar/radar → a ```mermaid block, or `None` when no row yields a
 /// numeric y (chart would be empty).
-/// Test: `mermaid_tests.rs::{renders_bar, heatmap_fallback, unknown_no_block}`.
+/// Test: `mermaid_tests.rs::{renders_bar, heatmap_fallback_note_only,
+/// unknown_chart_no_block}`.
 fn render_block(marker: &Marker, table: &Table) -> Option<String> {
     if marker.chart == ChartType::Heatmap {
         return Some(format!("{HEATMAP_NOTE}\n"));

--- a/crates/trusty-review/src/report/mermaid.rs
+++ b/crates/trusty-review/src/report/mermaid.rs
@@ -525,7 +525,7 @@ fn overflow_notes(cat_overflow: usize, series_overflow: usize) -> String {
 /// What: normalizes both sides to lowercase alphanumerics and tries, in priority
 /// order over the full field then its last `_`/space token: exact equality,
 /// header-starts-with, header-contains.  Returns the first matching column.
-/// Test: `mermaid_tests.rs::{resolves_exact_column, resolves_by_last_token}`.
+/// Test: `mermaid_tests.rs::resolves_columns`.
 fn resolve_column(header: &[String], field: &str) -> Option<usize> {
     let full = normalize(field);
     let last_raw = field.rsplit(['_', ' ']).next().unwrap_or(field);

--- a/crates/trusty-review/src/report/mermaid_tests.rs
+++ b/crates/trusty-review/src/report/mermaid_tests.rs
@@ -246,6 +246,49 @@ fn parses_chart_types() {
     assert_eq!(parse_chart("pie"), ChartType::Unknown);
 }
 
+/// Why (#6678): the marker declares every field a chart needs, and `parse_marker`
+/// is the only thing that reads it — a `group:` lost to the comma-inside-`y:`
+/// grammar silently collapses a multi-series radar to one curve.
+/// What: the full radar marker parses into every declared field.
+/// Test: this test.
+#[test]
+fn parses_full_marker() {
+    let marker = parse_marker(
+        "<!-- dataset: health_factors_by_app | chart: radar | x: factor | \
+         y: score, group: application -->",
+    )
+    .expect("a complete marker parses");
+    assert_eq!(marker.slug, "health_factors_by_app");
+    assert_eq!(marker.chart, ChartType::Radar);
+    assert_eq!(marker.x, "factor");
+    assert_eq!(marker.y, "score");
+    assert_eq!(
+        marker.group.as_deref(),
+        Some("application"),
+        "the group field lives comma-appended inside the y: segment"
+    );
+}
+
+/// Why (#6678): every line of a report passes through this parser, so anything
+/// that is not a dataset marker — an ordinary HTML comment, a marker missing a
+/// required field — must come back `None` rather than half-parsed.
+/// What: a non-dataset comment, a non-comment line, and markers missing
+/// `dataset`, `x`, or `y` are all rejected.
+/// Test: this test.
+#[test]
+fn ignores_non_dataset_comment() {
+    assert!(parse_marker("<!-- generated: 2026-09-02 -->").is_none());
+    assert!(parse_marker("| Application | Factor |").is_none());
+    assert!(
+        parse_marker("<!-- dataset: loc | chart: bar | x: tech -->").is_none(),
+        "a marker with no y: field declares no value column"
+    );
+    assert!(
+        parse_marker("<!-- dataset: loc | chart: bar | y: loc -->").is_none(),
+        "a marker with no x: field declares no category column"
+    );
+}
+
 /// Why: column resolution maps semantic field names to real headers.
 /// What: exact match, last-token match, and a miss.
 /// Test: this test.

--- a/crates/trusty-review/src/report/reporter.rs
+++ b/crates/trusty-review/src/report/reporter.rs
@@ -618,7 +618,7 @@ fn inject_synthesis_summary(root: &mut Scope, syn: &super::synthesize::Synthesis
 /// look, which is what makes a claimed strength falsifiable.
 /// Test: `reporter_tests.rs::{reporter_fills_green_topics,
 /// reporter_renders_every_green_topic, green_topic_carries_its_citation,
-/// reporter_leaves_findings_honesty_marked_without_metrics}`.
+/// reporter_omits_empty_findings_sections_without_metrics}`.
 fn push_green_topics(root: &mut Scope, model: &ReportModel) {
     let greens = model
         .repositories
@@ -666,7 +666,7 @@ fn green_topic_line(finding: &super::metrics::MetricFinding) -> String {
 /// [`Reporter::write`] rejects a synthesis-free model outright (#5454).
 /// Test: `reporter_tests.rs::{reporter_appends_guardrail_rejection_note,
 /// a_status_note_cites_its_finding_number, an_empty_synthesis_status_is_omitted,
-/// an_unmeasured_orphan_narrative_is_not_numbered}`.
+/// an_unplaced_narrative_is_disclosed_not_numbered}`.
 fn append_synthesis_note(out: &mut String, model: &ReportModel) {
     let Some(syn) = &model.synthesis else {
         return;

--- a/crates/trusty-review/src/report/reporter_findings.rs
+++ b/crates/trusty-review/src/report/reporter_findings.rs
@@ -13,7 +13,7 @@
 //! Test: `reporter_tests.rs::{reporter_fills_findings_deterministically,
 //! reporter_merges_synthesis_prose_onto_deterministic_finding,
 //! reporter_injects_synthesis_prose,
-//! reporter_leaves_findings_honesty_marked_without_metrics}`.
+//! reporter_omits_empty_findings_sections_without_metrics}`.
 
 use super::fill::Scope;
 use super::metrics::Severity;
@@ -410,8 +410,7 @@ fn raw_evidence(s: &str) -> Option<String> {
 /// Test: `reporter_tests::{evidence_renders_as_fenced_block,
 /// evidence_with_blank_line_fences_cleanly,
 /// evidence_containing_triple_backticks_uses_longer_fence,
-/// a_trace_verdict_renders_under_the_evidence_fence,
-/// no_trace_verdict_leaves_the_evidence_block_unchanged}`.
+/// a_trace_verdict_renders_under_the_evidence_fence}`.
 fn render_evidence_block(
     file_label: &str,
     quote: &str,
@@ -482,7 +481,7 @@ fn fence_for(content: &str) -> String {
 /// Test: `reporter_tests.rs::{reporter_fills_findings_deterministically,
 /// reporter_merges_synthesis_prose_onto_deterministic_finding,
 /// reporter_injects_synthesis_prose,
-/// reporter_leaves_findings_honesty_marked_without_metrics}`.
+/// reporter_omits_empty_findings_sections_without_metrics}`.
 #[allow(clippy::too_many_arguments)]
 pub(super) fn push_finding_band(
     root: &mut Scope,
@@ -638,8 +637,7 @@ fn cited_row(rows: &[FindingRow], f: &super::synthesize::FindingProse) -> Option
 /// What: replays [`band_rows`] over every repository and both bands, running the
 /// same per-band counters `build_scope` numbers the rendered rows with, so the
 /// number in the line is the number on the page. Pure — it renders nothing.
-/// Test: `reporter_tests::{an_unplaced_narrative_is_disclosed_not_numbered,
-/// an_unplaced_narrative_names_its_finding_number}`.
+/// Test: `reporter_tests::an_unplaced_narrative_is_disclosed_not_numbered`.
 pub(super) fn unplaced_narrative_lines(model: &super::model::ReportModel) -> Vec<String> {
     let syn = model.synthesis.as_ref();
     let mut out = Vec::new();

--- a/crates/trusty-review/src/report/reporter_findings.rs
+++ b/crates/trusty-review/src/report/reporter_findings.rs
@@ -10,7 +10,7 @@
 //! `reporter_*` sibling rather than inventing a new file layout.
 //! What: [`push_finding_band`], the only item `reporter.rs` calls, and the
 //! private `FindingRow` it builds.
-//! Test: `reporter_tests.rs::{reporter_fills_red_findings_deterministically,
+//! Test: `reporter_tests.rs::{reporter_fills_findings_deterministically,
 //! reporter_merges_synthesis_prose_onto_deterministic_finding,
 //! reporter_injects_synthesis_prose,
 //! reporter_leaves_findings_honesty_marked_without_metrics}`.
@@ -479,7 +479,7 @@ fn fence_for(content: &str) -> String {
 /// skipped and the raw metrics fields render, and a synthesis-only row is
 /// dropped outright.  Pushes the `app_block` (`app_name` + one `finding_block`
 /// per row) only when the merged list is non-empty.
-/// Test: `reporter_tests.rs::{reporter_fills_red_findings_deterministically,
+/// Test: `reporter_tests.rs::{reporter_fills_findings_deterministically,
 /// reporter_merges_synthesis_prose_onto_deterministic_finding,
 /// reporter_injects_synthesis_prose,
 /// reporter_leaves_findings_honesty_marked_without_metrics}`.

--- a/crates/trusty-review/src/report/reporter_tests.rs
+++ b/crates/trusty-review/src/report/reporter_tests.rs
@@ -3243,6 +3243,45 @@ fn colliding_titles_attach_to_their_own_components() {
     );
 }
 
+/// #6678: the claim guard on its own. Two narratives sharing one title AND one
+/// cited file must not both land on that file's row.
+///
+/// Why: `match_row` filters to UNCLAIMED rows before it disambiguates, and that
+/// filter is the only thing standing between a duplicated narrative and a row
+/// whose prose it silently replaces — the lap-5 cross-wire in the other
+/// direction. Component disambiguation cannot cover this case, because both
+/// narratives resolve to the same component.
+/// What: both narratives cite `hnsw_store.rs`. Asserts the hnsw row keeps the
+/// FIRST narrative's business impact and never renders the second's.
+/// Test: this test itself.
+#[test]
+fn a_second_narrative_cannot_overwrite_a_claimed_row() {
+    let mut first = amber_prose(
+        "Split oversized impl block",
+        "crates/trusty-common/src/memory_core/store/hnsw_store.rs:327",
+        "fn insert(&mut self, id: u64) {",
+    );
+    first.business_impact = "the first narrative claims this row".to_string();
+    let mut second = amber_prose(
+        "Split oversized impl block",
+        "crates/trusty-common/src/memory_core/store/hnsw_store.rs:327",
+        "fn insert(&mut self, id: u64) {",
+    );
+    second.business_impact = "the second narrative must not replace it".to_string();
+
+    let md = render_colliding(vec![first, second]);
+    let amber = amber_section(&md);
+
+    assert!(
+        component_for(amber, "the first narrative claims this row").contains("hnsw_store.rs"),
+        "the first narrative keeps the row it claimed:\n{amber}"
+    );
+    assert!(
+        !component_for(amber, "the second narrative must not replace it").contains("hnsw_store.rs"),
+        "a claimed row must never be overwritten by a later narrative:\n{amber}"
+    );
+}
+
 /// #6082 lap 5 (BLOCKER 1, second arm): a self-restating narrative must never
 /// delete the measurement underneath it.
 ///

--- a/crates/trusty-review/src/report/synthesize.rs
+++ b/crates/trusty-review/src/report/synthesize.rs
@@ -106,8 +106,9 @@ pub struct Synthesis {
 /// separately from the prose lets the reporter resolve the number at render.
 /// What: `text` is a complete reader sentence on its own; `subject` is the
 /// finding title the reporter looks up, absent for report-level prose.
-/// Test: `reporter_tests.rs::{a_status_note_cites_its_finding_number,
-/// a_status_note_without_a_numbered_finding_renders_bare}`.
+/// Test: `reporter_tests.rs::a_status_note_cites_its_finding_number`, and
+/// `synthesize_tests.rs::a_status_note_renders_with_and_without_a_citation` for
+/// the bare arm.
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
 pub struct StatusNote {
     /// The disclosure, as the reader sees it.
@@ -585,12 +586,12 @@ pub(super) struct RawSynthesis {
 /// response that is not even this fallback shape is still rejected as
 /// [`SynthesisError::Unparseable`].
 /// Test: `synthesize_tests.rs::{synthesize_happy_path_injects,
-/// synthesize_malformed_json_fails_closed,
+/// synthesize_malformed_json_is_a_hard_error,
 /// synthesize_recovers_executive_summary_from_markdown_fallback,
 /// synthesize_markdown_fallback_rejects_response_with_no_heading,
 /// parse_raw_recovers_shape2_field_name_drift,
 /// parse_raw_recovers_shape3_field_name_drift,
-/// parse_raw_rejects_a_wholly_unrecognized_shape}`.
+/// synthesize_rejects_a_wholly_unrecognized_shape}`.
 fn parse_raw(text: &str) -> Option<(RawSynthesis, Vec<String>)> {
     let body = text.trim();
     if body.starts_with('{')

--- a/crates/trusty-review/src/report/synthesize_normalize.rs
+++ b/crates/trusty-review/src/report/synthesize_normalize.rs
@@ -23,7 +23,7 @@
 //! canonical nor a recognised synonym.
 //! Test: `synthesize_tests.rs::{parse_raw_recovers_shape3_field_name_drift,
 //! parse_raw_recovers_shape2_field_name_drift,
-//! parse_raw_rejects_a_wholly_unrecognized_shape,
+//! synthesize_rejects_a_wholly_unrecognized_shape,
 //! normalize_drops_unrecognized_field_with_note,
 //! normalize_prefers_canonical_over_synonym_when_both_present}`.
 

--- a/crates/trusty-review/src/report/synthesize_prompt.rs
+++ b/crates/trusty-review/src/report/synthesize_prompt.rs
@@ -347,8 +347,8 @@ pub(crate) fn schema_contract_statement(schema: &serde_json::Value) -> String {
 /// owner requires every executive summary to describe the product and analyze
 /// its major components, so a template `instruct:` override must not be able
 /// to drop that requirement while restyling the section.
-/// Test: `synthesize_tests.rs::{system_prompt_embeds_resolved_instructions,
-/// system_prompt_concise_retry_directive,
+/// Test: `synthesize_tests.rs::{system_prompt_uses_generic_defaults_when_no_override,
+/// retry_concise_shrinks_top_risks_cap_and_adds_directive,
 /// system_prompt_asks_for_unregistered_target_gaps,
 /// system_prompt_asks_what_the_codebase_does,
 /// schema_contract_statement_reaches_system_prompt}`.
@@ -447,9 +447,10 @@ Populate the structured response:
 /// being overridden by a constant (#6093).  Strips any provider routing prefix
 /// from `llm_model`.
 /// Test: `synthesize_tests.rs::{prompt_excludes_greens, prompt_strips_prefix,
-/// synthesis_schema_shape, digest_uses_compact_findings,
-/// template_override_reaches_system_prompt,
-/// tier_ladder_raises_budget_and_shrinks_ask}`.
+/// synthesis_schema_shape, template_override_reaches_system_prompt,
+/// tier_ladder_raises_budget_and_shrinks_ask}`, and
+/// `synthesize_digest_tests.rs::digest_stays_bounded_at_100_findings` for the
+/// digest's own bound.
 pub(super) fn build_synthesis_prompt(
     model: &ReportModel,
     llm_model: &str,

--- a/crates/trusty-review/src/report/topology.rs
+++ b/crates/trusty-review/src/report/topology.rs
@@ -203,7 +203,7 @@ impl CrateTopology {
 /// Nothing is pushed when no repository declares one, and the whole block then
 /// renders as nothing (`fill::render_scope`'s omit-empty rule).
 /// Test: `topology_tests::{a_declared_topology_renders_rows,
-/// every_crate_reaches_the_rendered_table, no_topology_pushes_no_block,
+/// every_crate_reaches_the_rendered_table, no_topology_renders_nothing,
 /// several_repositories_are_named_in_the_rows}`.
 pub fn push_crate_topology(root: &mut Scope, model: &ReportModel) {
     let declared: Vec<(&str, &CrateTopology)> = model

--- a/scripts/check_test_pointers.sh
+++ b/scripts/check_test_pointers.sh
@@ -26,8 +26,10 @@
 #   (macOS-only);") is scanned — extraction stops dead at the first token
 #   that is none of those (see SCAN_AWK's doc comment for why: real
 #   annotations routinely continue past the test-name list into prose that
-#   ALSO backtick-quotes unrelated symbols). Each surviving span is then
-#   classified:
+#   ALSO backtick-quotes unrelated symbols). A span written in Rust's
+#   path-GROUPING form, `` `prefix::{a, b, c}` ``, is first expanded into
+#   `prefix::a`, `prefix::b`, `prefix::c` and each part is classified below on
+#   its own (issue #6678). Each surviving span is then classified:
 #     - module-path-qualified names (`foo::bar::baz_test`) are matched on
 #       their FINAL segment (`baz_test`);
 #     - a citation whose final segment is a lowercase snake_case identifier
@@ -43,12 +45,25 @@
 #       `` `ActivityInfo` `` — no underscore, or CamelCase)) is not a
 #       candidate at all and is silently skipped, same as before — this is
 #       the deliberate leniency for field/type mentions inside the citation
-#       list, not the bug this script was rewritten to close.
+#       list, not the bug this script was rewritten to close. #6678 measured
+#       that class at 1,780 spans workspace-wide, and it is overwhelmingly
+#       shell command lines (`` `cargo test -p trusty-common` ``), file paths
+#       (`` `tests/cli_e2e.rs` ``) and expression examples
+#       (`` `ToolResult::err("x").is_error()` ``) — text that never claimed
+#       to be a test name. That is why the fail-closed bias above is drawn at
+#       path-GROUPING syntax rather than at "unparseable" in general.
 #   An UNTERMINATED backtick or parenthetical inside the leading run (a
 #   stray `` ` `` or `(` with no matching close) is not "prose" — it is
 #   malformed annotation syntax the parser cannot interpret, and is reported
 #   as a hard parse-error violation (never allowlist-suppressible) rather
-#   than silently truncating the scan.
+#   than silently truncating the scan. So is a brace citation this parser
+#   cannot decompose (#6678): `{`/`}` is path-grouping syntax, so a span
+#   carrying it is a citation LIST, and the leniency below never reaches it.
+#   The parser reads exactly `prefix::{member[, member]*}` with no nesting,
+#   each member a Rust identifier or a glob over one; anything else — a
+#   nested set, a set with no `::` prefix, a member that wrapped
+#   mid-identifier across two doc lines — is a parse error naming the
+#   offending citation.
 #   Each surviving EXACT/GLOB candidate is checked with `git grep` (cached
 #   per crate — see build_crate_caches) for a `fn <name>(` (or
 #   `fn <name><...>(` for a generic fn) OR a `mod <name>;` / `mod <name> {`
@@ -213,10 +228,11 @@ function strip(line,    s) {
   return s
 }
 
-# One citation span, already unwrapped from its backticks. Matched on its
-# FINAL `::`-separated segment; de-duplicated within the annotation it came
-# from, exactly as the shell loop this replaced de-duplicated on KIND:name.
-function emit(f, ln, nm,    parts, k, final, kind, key) {
+# One citation span, already unwrapped from its backticks and already expanded
+# out of any brace set. Matched on its FINAL `::`-separated segment;
+# de-duplicated within the annotation it came from, exactly as the shell loop
+# this replaced de-duplicated on KIND:name.
+function classify_one(f, ln, nm,    parts, k, final, kind, key) {
   k = split(nm, parts, "::")
   final = parts[k]
   if (final == "") return
@@ -230,6 +246,43 @@ function emit(f, ln, nm,    parts, k, final, kind, key) {
   seen[key] = 1
   print (f "\t" ln "\t" kind "\t" final) > CHECKED
   needed[cur_crate] = 1
+}
+
+# #6678: a citation carrying `{`/`}` is Rust path-grouping syntax, so it IS a
+# citation list the parser must decompose — never prose to skip. `prefix::{a,
+# b}` expands to `prefix::a` and `prefix::b`, each handed to classify_one
+# exactly as if it had been written out longhand; a brace citation this
+# function cannot decompose goes to ERRF instead of being dropped.
+function emit(f, ln, nm,    ob, cb, prefix, inner, k, mem, i, m) {
+  ob = index(nm, "{")
+  cb = index(nm, "}")
+  if (ob == 0 && cb == 0) { classify_one(f, ln, nm); return }
+  if (nm !~ /^[^{}]+::\{[^{}]*\}$/) {
+    print (f "\t" ln "\tunrecognised citation shape `" nm "` — the only brace form this parser reads is `prefix::{a, b}` (no nesting)") > ERRF
+    return
+  }
+  prefix = substr(nm, 1, ob - 3)
+  inner = substr(nm, ob + 1, cb - ob - 1)
+  k = split(inner, mem, ",")
+  if (k == 0) {
+    print (f "\t" ln "\tempty brace set in citation `" nm "`") > ERRF
+    return
+  }
+  for (i = 1; i <= k; i++) {
+    m = mem[i]
+    sub(/^[ \t]+/, "", m)
+    sub(/[ \t]+$/, "", m)
+    # Every element of a brace set is a citation by construction, so the
+    # leading-run prose leniency does not reach inside one: a member must be a
+    # Rust identifier or a glob over one. A member carrying anything else — a
+    # doc comment that wrapped mid-identifier is the shape seen in the wild —
+    # is malformed syntax, not a citation to drop.
+    if (m == "" || (m !~ /^[A-Za-z_][A-Za-z0-9_]*$/ && m !~ /^[a-z][a-z0-9_*]*$/)) {
+      print (f "\t" ln "\tunrecognised brace-set member `" m "` in citation `" nm "`") > ERRF
+      return
+    }
+    classify_one(f, ln, prefix "::" m)
+  }
 }
 
 function parse_block(f, ln, blob,    s, n, i, c, j, rest, depth, cc, jj, errflag) {
@@ -807,10 +860,53 @@ pub fn malformed_unterminated_backtick() {}
 /// one real citation, zero parse errors.
 pub fn nested_parens_inside_parenthetical_is_not_a_parse_error() {}
 
+/// Test: `tests::{brace_member_real_a, brace_member_real_b}`.
+///
+/// issue #6678: a brace set expands into one candidate per member, each
+/// resolved exactly as if it had been written out longhand. Pre-fix the span's
+/// final segment was the whole group, which failed the identifier shape and was
+/// dropped as "not a candidate", so neither member was ever checked. Both names
+/// are cited ONLY here, so their presence in the resolved-citation file is
+/// proof the expansion happened.
+pub fn brace_set_resolves() {}
+
+/// Test: `tests::{brace_member_real_a, brace_member_missing_test}`.
+///
+/// issue #6678: one real member, one dangling. Exactly the dangling one must be
+/// reported, at this annotation's line.
+pub fn brace_set_one_member_dangling() {}
+
+/// Test: `outer_tests::{a_real_test, inner::{a_nested_test}}`.
+///
+/// issue #6678: a nested brace set is a shape this parser cannot decompose, and
+/// an unrecognised shape fails closed as a parse error rather than being
+/// dropped.
+pub fn brace_set_nested_is_unrecognised() {}
+
+/// Test: `tests::{brace_member_real_a, brace_member_wrapped_
+/// mid_identifier}`.
+///
+/// issue #6678: the annotation wrapped mid-identifier, so the member joins
+/// across the two doc lines with a space in it and names no test. Every element
+/// of a brace set is a citation, so this is malformed syntax rather than prose
+/// to skip — the exact shape found in the wild at
+/// crates/trusty-review/src/report/analyze_endpoints.rs:20.
+pub fn brace_set_member_wrapped_mid_identifier() {}
+
 #[cfg(test)]
 mod tests {
     #[test]
     fn real_test_exists() {
+        assert!(true);
+    }
+
+    #[test]
+    fn brace_member_real_a() {
+        assert!(true);
+    }
+
+    #[test]
+    fn brace_member_real_b() {
         assert!(true);
     }
 
@@ -872,11 +968,23 @@ EOF
   # citation must resolve, not just `fn` citations (this is exactly the case
   # that shipped broken: module citations only ever passed via the
   # allowlist, never verified for real).
-  # ...plus untracked_file_dangling_test, cited by an UNTRACKED file (#5798) —
-  # seven in total.
-  if [ "$(wc -l < "$viol" | tr -d ' ')" != "7" ]; then
-    echo "self-test FAIL: expected exactly 7 violations, got:" >&2
+  # ...plus untracked_file_dangling_test, cited by an UNTRACKED file (#5798),
+  # and brace_member_missing_test, the dangling member of a brace set (#6678) —
+  # eight in total.
+  if [ "$(wc -l < "$viol" | tr -d ' ')" != "8" ]; then
+    echo "self-test FAIL: expected exactly 8 violations, got:" >&2
     cat "$viol" >&2
+    ok=0
+  elif ! grep -q "brace_member_missing_test" "$viol"; then
+    echo "self-test FAIL: the dangling member of a brace-set citation was not reported — the brace set was dropped as 'not a candidate' again (issue #6678), got:" >&2
+    cat "$viol" >&2
+    ok=0
+  elif grep -qE 'brace_member_real_a|brace_member_real_b' "$viol"; then
+    echo "self-test FAIL: a resolvable brace-set member was flagged dangling (issue #6678), got:" >&2
+    cat "$viol" >&2
+    ok=0
+  elif ! grep -q "brace_member_real_a" "$checked" || ! grep -q "brace_member_real_b" "$checked"; then
+    echo "self-test FAIL: brace-set members are missing from the resolved-citation file — the expansion did not run, so the citation count under-reports (issue #6678):" >&2
     ok=0
   elif ! grep -q "untracked_file_dangling_test" "$viol"; then
     echo "self-test FAIL: the untracked file's dangling citation was not reported — the corpus is tracked-only again (issue #5798), got:" >&2
@@ -910,8 +1018,11 @@ EOF
     echo "self-test FAIL: a trailing-prose symbol, the valid module_style_tests citation, or the resolvable glob_matches_real_test_* was incorrectly flagged as dangling:" >&2
     cat "$viol" >&2
     ok=0
-  elif [ "$(wc -l < "$err" | tr -d ' ')" != "1" ] || ! grep -q "unterminated backtick" "$err"; then
-    echo "self-test FAIL: expected exactly 1 parse-error row citing the unterminated backtick in malformed_unterminated_backtick's annotation (issue #3581: must fail loudly, not silently pass) — and NOT the well-formed nested-parens-inside-parenthetical annotation (\`helper_call()\` inside a \`(...)\` aside), got:" >&2
+  elif [ "$(wc -l < "$err" | tr -d ' ')" != "3" ] \
+    || ! grep -q "unterminated backtick" "$err" \
+    || ! grep -q "unrecognised citation shape" "$err" \
+    || ! grep -q "unrecognised brace-set member" "$err"; then
+    echo "self-test FAIL: expected exactly 3 parse-error rows — the unterminated backtick in malformed_unterminated_backtick's annotation (issue #3581: must fail loudly, not silently pass), the nested brace set, and the brace-set member that wrapped mid-identifier (issue #6678: an unrecognised shape fails closed) — and NOT the well-formed nested-parens-inside-parenthetical annotation (\`helper_call()\` inside a \`(...)\` aside), got:" >&2
     cat "$err" >&2
     ok=0
   fi
@@ -973,7 +1084,7 @@ EOF
   rm -f "$viol2" "$stale2" "$err2"
 
   if [ "$ok" -eq 1 ]; then
-    echo "check_test_pointers self-test: OK (valid pointer passes, dangling pointer caught, module citations resolve, prose-only/module-ref citations ignored, glob citations resolved by pattern match, parenthetical asides no longer break multi-citation scanning, unterminated backticks fail loudly, allowlist ratchet suppresses/prunes correctly by (path,name))."
+    echo "check_test_pointers self-test: OK (valid pointer passes, dangling pointer caught, module citations resolve, prose-only/module-ref citations ignored, glob citations resolved by pattern match, brace sets expand per member, an unrecognised brace shape fails closed, parenthetical asides no longer break multi-citation scanning, unterminated backticks fail loudly, allowlist ratchet suppresses/prunes correctly by (path,name))."
     return 0
   fi
   return 1


### PR DESCRIPTION
## Outcome

`scripts/check_test_pointers.sh` expands `prefix::{a, b}` citations into members and checks each; a brace form it cannot decompose (nested, no prefix, empty, non-identifier member) is a parse error, fail-closed. The expansion surfaced 40 hidden dangling pointers: 9 were repointed in the first commit, 29 in the second, each traced with `git log -S` to the rename or the never-shipped name; three tests were written where nothing covered the documented behaviour (`a_refused_index_is_a_reason_not_a_status`, `parses_full_marker`/`ignores_non_dataset_comment`, `a_second_narrative_cannot_overwrite_a_claimed_row`, the last mutation-verified). No allowlist rows.

## Changes

`scripts/check_test_pointers.sh` (`emit()` split into brace handling + `classify_one()`, four self-test fixtures), `.github/workflows/test-pointers.yml` (`--self-test` step), `Test:` doc lines in trusty-review, trusty-audit, trusty-git-analytics, two new test files, five changelog fragments. Design: [#6678](https://github.com/bobmatnyc/trusty-tools/issues/6678).

## Risk

Normal, rung 3. The fail-closed line is drawn at path-grouping syntax only; ~1,780 other unclassifiable spans (shell commands, paths, expressions in prose) stay ignored by design, documented in the script header.

## Test Evidence

All `--no-fail-fast`:
- `check_test_pointers.sh` 29852 citations, 0 dangling (was 29134 before expansion)
- `--self-test` OK, and the new fixtures FAIL against `origin/main`'s script (shown in the PR's linked issue evidence)
- `cargo test -p trusty-review` 2094 passed + 11 targets ok
- `cargo test -p trusty-audit` 763 passed + 9 targets ok
- `cargo test -p tga` 1442 passed + 10 targets ok
- fmt, clippy `-D warnings` on the three crates
- `check_changelog_fragment.sh` (3 crates)
- `check_line_cap.sh`
- `check_sld.sh` OK
- `check-pr-version-bump.sh` clear (all three crate versions unpublished)

## Baseline Failures

None.

## Docs

Script header documents the brace rule and the fail-closed boundary; `docs/reference/ci-scripts.md` unchanged (the script is covered by CLAUDE.md's rung-3 row and the pre-commit hook).

## Review

Security scan PASS. No critic round: script + doc-pointer change, rung 3, no production Rust logic changed.

Refs #6678

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
