### PR TITLE
fix(trusty-review): report pipeline resolves the trusty-search index by registered root_path when the derived id is absent (Refs #6677)

### DIFF
--- a/crates/trusty-audit/changelog.d/6677-index-id-doc-path.md
+++ b/crates/trusty-audit/changelog.d/6677-index-id-doc-path.md
@@ -1,0 +1,5 @@
+Documentation
+
+- `grounding::index`'s cross-process contract note points at
+  `trusty_review::report::index_registry::derive_index_id`, the module that
+  derivation moved to (#6677).

--- a/crates/trusty-audit/src/grounding/index.rs
+++ b/crates/trusty-audit/src/grounding/index.rs
@@ -9,7 +9,7 @@
 //! ## The index id is a cross-process contract
 //!
 //! Three crates derive the id independently — this one when it indexes,
-//! `trusty_review::report::analyze_adapter::derive_index_id` when the renderer
+//! `trusty_review::report::index_registry::derive_index_id` when the renderer
 //! looks it up, `tga::audit::repo_index::index_id_for` from the sweep's other
 //! side — and an id derived any other way indexes a repository under a name
 //! nobody ever queries. Until #6149 the rule was the checkout BASENAME, copied

--- a/crates/trusty-git-analytics/changelog.d/6677-index-id-doc-path.md
+++ b/crates/trusty-git-analytics/changelog.d/6677-index-id-doc-path.md
@@ -1,0 +1,5 @@
+Documentation
+
+- `audit::repo_index::index_id_for`'s agreement note points at
+  `trusty_review::report::index_registry::derive_index_id`, the module that
+  derivation moved to (#6677).

--- a/crates/trusty-git-analytics/src/audit/repo_index.rs
+++ b/crates/trusty-git-analytics/src/audit/repo_index.rs
@@ -143,7 +143,7 @@ pub(super) fn binary_from_override(override_value: Option<&str>) -> String {
 
 /// The trusty-search index id for a checkout path.
 ///
-/// Why: this must agree with `trusty_review::report::analyze_adapter::
+/// Why: this must agree with `trusty_review::report::index_registry::
 /// derive_index_id`, which is what the renderer looks the index up by. Until
 /// #6149 both were the checkout BASENAME, copied rather than called — and two
 /// checkouts of one repository therefore collided on one id, so the sweep

--- a/crates/trusty-review/changelog.d/6677-report-index-by-root-path.md
+++ b/crates/trusty-review/changelog.d/6677-report-index-by-root-path.md
@@ -1,0 +1,14 @@
+Fixed
+
+- The report pipeline finds a checkout's trusty-search index when it is
+  registered under an id the path does not derive to. `--analyze` and the trace
+  pass resolved by `derive_checkout_index_id` and an exact id match only, so a
+  ready index registered at the same `root_path` under another id — the main
+  checkout served as `trusty-tools-checkout` against a derived
+  `trusty-tools-4e2cf878` — could never be reached: analyze degraded to scan,
+  every trace lookup returned `IndexAbsent`, and the run exited 0. Both call
+  sites now resolve through `report::index_registry::resolve_report_index`,
+  which keeps the derived id when the daemon holds it, otherwise substitutes the
+  index whose canonicalised `root_path` IS the checkout (logging the
+  substitution), and otherwise names the derived id and says nothing registered
+  covers the path (#6677).

--- a/crates/trusty-review/changelog.d/6677-report-index-by-root-path.md
+++ b/crates/trusty-review/changelog.d/6677-report-index-by-root-path.md
@@ -12,3 +12,13 @@ Fixed
   index whose canonicalised `root_path` IS the checkout (logging the
   substitution), and otherwise names the derived id and says nothing registered
   covers the path (#6677).
+- `HttpAnalyzeMetricsSource::with_search_base_url` points the trusty-search
+  registry read at an explicit address. Without it the read resolved the
+  machine's advertised daemon whatever socket the source was built with, so a
+  caller holding the source over a stub analyze socket still issued a live HTTP
+  GET to whatever trusty-search was running and resolved against what that
+  daemon held (#6677).
+- The report's unresolved-index warning says which cause it hit —
+  `registry=empty` for a daemon that answered nothing, `registry=populated` for
+  one holding indexes none of which is rooted at this checkout — so the remedy
+  reads off one line instead of two (#6677).

--- a/crates/trusty-review/src/report/analyze_adapter.rs
+++ b/crates/trusty-review/src/report/analyze_adapter.rs
@@ -37,15 +37,17 @@
 //! per-endpoint budgets and independence (`a_failing_endpoint_keeps_what_the_
 //! others_returned`, `a_fetch_where_no_endpoint_answered_falls_back_to_scan`).
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::time::Duration;
 
 use async_trait::async_trait;
 use serde::Deserialize;
 
+use super::index_registry::resolve_report_index;
 use super::metrics::{
     AnalyzeMetrics, ComplexityBucket, ComplexityDistribution, MetricFinding, Severity,
 };
+use crate::integrations::search_client::IndexInfo;
 
 // The per-endpoint paths, budgets, and failure vocabulary live one module over,
 // beside each other, so an endpoint's cost and its timeout cannot drift apart.
@@ -150,9 +152,13 @@ const CODE_DEADLINE_EXCEEDED: i64 = -32005;
 
 // ─── Wire types (trusty-analyze JSON, minimal shapes) ────────────────────────
 
-/// One entry of `GET /indexes` (`[{"id": ..., "root_path": ...}]`).
+/// One entry of `analyze.list_indexes` (`[{"id": ...}, ...]`).
+///
+/// Named apart from [`IndexInfo`] since #6677: that is trusty-search's registry
+/// entry, `root_path` included, and this is the analyze daemon's id-only proxy
+/// of it — the readiness probe reads this one, resolution reads that one.
 #[derive(Debug, Deserialize)]
-struct IndexInfo {
+struct ServedIndex {
     id: String,
 }
 
@@ -387,6 +393,19 @@ pub trait AnalyzeMetricsSource: Send + Sync {
             },
             None => AnalyzeFetch::Missing(AnalyzeGap::Unavailable),
         }
+    }
+
+    /// The trusty-search indexes registered on this machine (#6677).
+    ///
+    /// Why: the id a checkout DERIVES to and the id it is REGISTERED under can
+    /// differ, and only the registry says so — `root_path` is what tells them
+    /// apart. The list is read once per enrichment and handed to
+    /// [`super::index_registry::resolve_report_index`].
+    /// What: the default is an empty list — a source with no daemon behind it
+    /// substitutes nothing, so every stub keeps resolving to the derived id.
+    /// Test: `analyze_adapter_tests.rs::a_repo_served_under_another_id_is_fetched_by_that_id`.
+    async fn registered_indexes(&self) -> Vec<IndexInfo> {
+        Vec::new()
     }
 }
 
@@ -678,7 +697,7 @@ impl HttpAnalyzeMetricsSource {
     /// warning) from a transport error, per the indexing prerequisite (#2448).
     async fn index_served(&self, index_id: &str) -> AdapterResult<bool> {
         let endpoint = AnalyzeEndpoint::IndexList;
-        let indexes: Vec<IndexInfo> = self.call(endpoint, index_id, endpoint.budget()).await?;
+        let indexes: Vec<ServedIndex> = self.call(endpoint, index_id, endpoint.budget()).await?;
         Ok(indexes.iter().any(|i| i.id == index_id))
     }
 
@@ -798,6 +817,13 @@ impl AnalyzeMetricsSource for HttpAnalyzeMetricsSource {
         }
     }
 
+    /// #6677: the registry is trusty-search's, not the analyze daemon's —
+    /// `analyze.list_indexes` proxies the ids and drops `root_path`, which is
+    /// the field resolution needs.
+    async fn registered_indexes(&self) -> Vec<IndexInfo> {
+        super::index_registry::registered_indexes().await
+    }
+
     /// #5239: the same fail-open fetch, naming which of the two conditions
     /// produced an empty result so the report can say so.
     async fn fetch_named(&self, index_id: &str) -> AnalyzeFetch {
@@ -824,24 +850,6 @@ impl AnalyzeMetricsSource for HttpAnalyzeMetricsSource {
             }
         }
     }
-}
-
-// ─── Index-id resolution ─────────────────────────────────────────────────────
-
-/// Derive the trusty-search/analyze index id for a local checkout path.
-///
-/// Why: the renderer must address the SAME index the audit indexed, and the two
-/// run as separate processes with no shared state but the manifest's checkout
-/// path. Until #6149 both derived the repo directory's BASENAME, so a machine
-/// holding two checkouts of one repository served whichever registered first and
-/// the report measured a tree it never audited. Both sides now call
-/// [`trusty_common::derive_checkout_index_id`], which hashes the canonical path
-/// into the id.
-/// What: forwards to that function — `"<slugified basename>-<8 hex>"`, or `None`
-/// for a path with no final component (e.g. `/`).
-/// Test: `derive_index_id_distinguishes_same_named_checkouts`.
-pub fn derive_index_id(path: &Path) -> Option<String> {
-    trusty_common::derive_checkout_index_id(path)
 }
 
 // ─── Model enrichment (precedence seam, #2448) ───────────────────────────────
@@ -901,6 +909,9 @@ pub async fn enrich_with_analyze_gaps(
     // crosses the redaction boundary before it reaches the model. Resolved once
     // per enrichment, not once per repository — it touches the filesystem.
     let secrets = super::redact::report_secrets();
+    // #6677: one registry read for the whole walk — resolution needs the
+    // daemon's `root_path` values, and they do not change mid-enrichment.
+    let indexes = source.registered_indexes().await;
 
     for repo in &mut model.repositories {
         // Precedence: a declared metrics file always wins.
@@ -911,7 +922,10 @@ pub async fn enrich_with_analyze_gaps(
         let Some(path) = repo.local_path.as_ref() else {
             continue;
         };
-        let Some(index_id) = derive_index_id(path) else {
+        // #6677: the derived id when the daemon holds it, otherwise the index
+        // registered at this checkout's root_path; `None` only for a path that
+        // derives to nothing, which is the skip this always made.
+        let Some(index_id) = resolve_report_index(path, &indexes).into_id() else {
             continue;
         };
         match source.fetch_named(&index_id).await {

--- a/crates/trusty-review/src/report/analyze_adapter.rs
+++ b/crates/trusty-review/src/report/analyze_adapter.rs
@@ -492,6 +492,17 @@ pub struct HttpAnalyzeMetricsSource {
     /// would otherwise pay a spawn budget per repository, and report the same
     /// failure N times.
     started: tokio::sync::OnceCell<Result<(), String>>,
+    /// Where [`AnalyzeMetricsSource::registered_indexes`] reads the trusty-search
+    /// registry from (#6677).
+    ///
+    /// Why: the read resolved `DaemonAddrLayout::TRUSTY_SEARCH` unconditionally,
+    /// so a caller holding this source over a stub analyze socket still issued a
+    /// real HTTP GET to whatever trusty-search daemon the host happened to be
+    /// running. The address is a property of the source now, so a caller that
+    /// stubs the analyze side stubs this side with it.
+    /// What: `None` resolves the advertised daemon at read time — the production
+    /// default, unchanged; `Some(url)` reads that URL instead.
+    search_base_url: Option<String>,
 }
 
 impl HttpAnalyzeMetricsSource {
@@ -518,7 +529,26 @@ impl HttpAnalyzeMetricsSource {
             launcher: trusty_common::uds::OnDemandAnalyze::at(&socket),
             socket,
             started: tokio::sync::OnceCell::new(),
+            search_base_url: None,
         })
+    }
+
+    /// Read the trusty-search registry from `base_url` rather than from the
+    /// daemon this machine advertises (#6677).
+    ///
+    /// Why: `enrich_with_analyze_gaps` reads the registry once per run, and
+    /// without this the read ignored the socket the source was built with and
+    /// went to the host's live trusty-search. A test standing up an in-process
+    /// analyze mock was therefore not hermetic — it depended on whether the
+    /// developer's own daemon was up and what it held.
+    /// What: consuming builder; the stored URL is handed to
+    /// [`super::index_registry::fetch_registered_indexes`], which is fail-open,
+    /// so an address with nothing behind it reads as an empty registry.
+    /// Test: `tests/report_analyze_e2e.rs::the_registry_read_goes_to_the_injected_search_url`.
+    #[must_use]
+    pub fn with_search_base_url(mut self, base_url: impl Into<String>) -> Self {
+        self.search_base_url = Some(base_url.into());
+        self
     }
 
     /// Start trusty-analyze if nothing is serving, exactly once per source.
@@ -819,9 +849,14 @@ impl AnalyzeMetricsSource for HttpAnalyzeMetricsSource {
 
     /// #6677: the registry is trusty-search's, not the analyze daemon's —
     /// `analyze.list_indexes` proxies the ids and drops `root_path`, which is
-    /// the field resolution needs.
+    /// the field resolution needs. The address is
+    /// [`Self::with_search_base_url`]'s when one was set, so a caller that
+    /// stubbed the analyze socket can stub this read too.
     async fn registered_indexes(&self) -> Vec<IndexInfo> {
-        super::index_registry::registered_indexes().await
+        match &self.search_base_url {
+            Some(url) => super::index_registry::fetch_registered_indexes(url).await,
+            None => super::index_registry::registered_indexes().await,
+        }
     }
 
     /// #5239: the same fail-open fetch, naming which of the two conditions

--- a/crates/trusty-review/src/report/analyze_adapter_tests.rs
+++ b/crates/trusty-review/src/report/analyze_adapter_tests.rs
@@ -6,6 +6,8 @@
 //! What: drives the private mapping helpers and the public fetch seam directly.
 //! Test: this file.
 
+use std::path::Path;
+
 use super::*;
 
 // ─── Severity map ────────────────────────────────────────────────────────────
@@ -701,36 +703,6 @@ fn new_accepts_a_socket_path() {
     assert_eq!(src.socket, socket);
 }
 
-/// #6149: the renderer and the audit are separate processes agreeing on one id.
-/// Two checkouts of one repository must not derive the same one — that is the
-/// collision that had this crate reading another tree's measurements.
-#[test]
-fn derive_index_id_distinguishes_same_named_checkouts() {
-    let engagement = std::path::Path::new("/w/dogfood/repos/local/northwind-web");
-    let working = std::path::Path::new("/home/me/northwind-web");
-
-    let a = derive_index_id(engagement).expect("id");
-    let b = derive_index_id(working).expect("id");
-    assert_ne!(a, b, "{a} vs {b}");
-    assert!(b.starts_with("northwind-web-"), "still readable: {b}");
-    assert_eq!(derive_index_id(std::path::Path::new("/")), None);
-}
-
-/// The agreement is a call, not a copy: this crate's id IS trusty-common's, so
-/// the audit that indexed under it and this renderer cannot drift.
-#[test]
-fn derive_index_id_is_the_shared_derivation() {
-    for path in ["/home/me/northwind-web", "/w/repos/acme-api", "/"] {
-        let path = std::path::Path::new(path);
-        assert_eq!(
-            derive_index_id(path),
-            trusty_common::derive_checkout_index_id(path),
-            "{}",
-            path.display()
-        );
-    }
-}
-
 #[test]
 fn error_display() {
     let e = AnalyzeAdapterError::Rpc {
@@ -760,6 +732,99 @@ impl AnalyzeMetricsSource for StubSource {
     async fn fetch_named(&self, _index_id: &str) -> AnalyzeFetch {
         (self.0)()
     }
+}
+
+/// A source that records the index ids it was asked for, over a registry it
+/// declares (#6677).
+struct RecordingSource {
+    /// What `registered_indexes` answers with.
+    registry: Vec<crate::integrations::search_client::IndexInfo>,
+    /// Every id `fetch_named` was called with, in order.
+    asked: std::sync::Mutex<Vec<String>>,
+}
+
+impl RecordingSource {
+    fn with_registry(registry: Vec<crate::integrations::search_client::IndexInfo>) -> Self {
+        Self {
+            registry,
+            asked: std::sync::Mutex::new(Vec::new()),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl AnalyzeMetricsSource for RecordingSource {
+    async fn fetch(&self, _index_id: &str) -> Option<AnalyzeMetrics> {
+        None
+    }
+
+    async fn fetch_named(&self, index_id: &str) -> AnalyzeFetch {
+        self.asked.lock().expect("lock").push(index_id.to_string());
+        AnalyzeFetch::Missing(AnalyzeGap::NotIndexed)
+    }
+
+    async fn registered_indexes(&self) -> Vec<crate::integrations::search_client::IndexInfo> {
+        self.registry.clone()
+    }
+}
+
+/// A registry entry as `GET /indexes?details=true` returns it.
+fn registry_entry(id: &str, root_path: &str) -> crate::integrations::search_client::IndexInfo {
+    crate::integrations::search_client::IndexInfo {
+        id: id.to_string(),
+        name: None,
+        root_path: Some(root_path.to_string()),
+    }
+}
+
+/// #6677: a checkout registered under an id other than its derived one is
+/// fetched by the id it IS registered under. Before this, the enrichment walk
+/// asked for the derived id, the daemon did not hold it, and every repository
+/// degraded to scan with a ready index sitting in the registry.
+#[tokio::test]
+async fn a_repo_served_under_another_id_is_fetched_by_that_id() {
+    let mut model = model_with_local_repo("northwind-web");
+    let path = model.repositories[0]
+        .local_path
+        .clone()
+        .expect("fixture pins a local path");
+    let source = RecordingSource::with_registry(vec![registry_entry(
+        "northwind-checkout",
+        &path.display().to_string(),
+    )]);
+
+    let _ = enrich_with_analyze_gaps(&mut model, &source).await;
+
+    assert_eq!(
+        source.asked.lock().expect("lock").as_slice(),
+        ["northwind-checkout".to_string()],
+        "the registered id must be the one addressed"
+    );
+}
+
+/// The unchanged half: with nothing registered at the path, the derived id is
+/// what goes to the daemon and the not-indexed fallback stands.
+#[tokio::test]
+async fn an_unregistered_repo_is_still_fetched_by_its_derived_id() {
+    let mut model = model_with_local_repo("northwind-web");
+    let path = model.repositories[0]
+        .local_path
+        .clone()
+        .expect("fixture pins a local path");
+    let derived = crate::report::derive_index_id(&path).expect("id");
+    let source = RecordingSource::with_registry(vec![registry_entry(
+        "elsewhere",
+        "/w/repos/some-other-tree",
+    )]);
+
+    let gaps = enrich_with_analyze_gaps(&mut model, &source).await;
+
+    assert_eq!(source.asked.lock().expect("lock").as_slice(), [derived]);
+    assert_eq!(
+        gaps.len(),
+        1,
+        "the not-indexed gap is still named: {gaps:?}"
+    );
 }
 
 /// A source that implements ONLY `fetch`, exercising the trait's default

--- a/crates/trusty-review/src/report/index_registry.rs
+++ b/crates/trusty-review/src/report/index_registry.rs
@@ -183,8 +183,8 @@ fn registry_state(indexes: &[IndexInfo]) -> &'static str {
 /// falls back to the raw path for a directory that no longer exists, so a
 /// registry entry naming a deleted tree matches only a `repo_path` whose raw
 /// string is the same — a real checkout never collides with one.
-/// Test: `index_registry_tests.rs::{a_root_path_match_substitutes_for_an_
-/// unregistered_derived_id, a_parent_rooted_index_is_not_substituted,
+/// Test: `index_registry_tests.rs::{a_root_path_match_substitutes_for_an_unregistered_derived_id,
+/// a_parent_rooted_index_is_not_substituted,
 /// a_registry_root_that_no_longer_exists_matches_only_its_own_raw_path}`.
 fn index_at_root(indexes: &[IndexInfo], repo_path: &Path) -> Option<String> {
     let root = canonical_source_root(repo_path);

--- a/crates/trusty-review/src/report/index_registry.rs
+++ b/crates/trusty-review/src/report/index_registry.rs
@@ -1,0 +1,211 @@
+//! The one place the report pipeline decides WHICH trusty-search index serves a
+//! checkout (#6677).
+//!
+//! Why: the report pass addressed an index by derived id alone —
+//! `trusty_common::derive_checkout_index_id(repo_path)` — and accepted only an
+//! exact id match. trusty-search holds one index per root path (409 on a second
+//! registration, #2305/#2336), so a checkout already registered under any other
+//! id could never be found: on 2026-09-02 the derived id was
+//! `trusty-tools-4e2cf878` while the daemon served the same tree, ready and
+//! 103,082 chunks, as `trusty-tools-checkout`. `--analyze` degraded to scan,
+//! all ten trace lookups returned `IndexAbsent`, and the run exited 0.
+//!
+//! What: [`resolve_report_index`] derives the id first — a registered derived id
+//! resolves exactly as it did — and only when the daemon does not hold it falls
+//! back to the index whose registered `root_path` IS this checkout. The
+//! root-path match is `config::index_resolver`'s, the matcher #661 gave the
+//! CLI/MCP entry points, narrowed to an exact root: a parent-rooted index covers
+//! the path but describes a wider tree than the one under audit (#6137).
+//! [`fetch_registered_indexes`] is the read that feeds it, fail-open to an empty
+//! list so an unreachable daemon lands back on the derived id.
+//!
+//! Both report call sites resolve through this module —
+//! `analyze_adapter::enrich_with_analyze_gaps` and
+//! `investigate::trace::assemble_traces` — and a second matcher in either fails
+//! `neither_report_call_site_derives_its_own_index_id`.
+//!
+//! Test: `index_registry_tests.rs`.
+
+use std::path::Path;
+
+use tracing::warn;
+use trusty_common::daemon_guard::DaemonAddrLayout;
+
+use crate::config::index_resolver::{best_matching_index, canonical_source_root};
+use crate::integrations::search_client::{HttpSearchClient, IndexInfo, SearchClient};
+
+/// Derive the trusty-search/analyze index id for a local checkout path.
+///
+/// Why: the renderer must address the SAME index the audit indexed, and the two
+/// run as separate processes with no shared state but the manifest's checkout
+/// path. Until #6149 both derived the repo directory's BASENAME, so a machine
+/// holding two checkouts of one repository served whichever registered first and
+/// the report measured a tree it never audited. Both sides now call
+/// [`trusty_common::derive_checkout_index_id`], which hashes the canonical path
+/// into the id.
+/// What: forwards to that function — `"<slugified basename>-<8 hex>"`, or `None`
+/// for a path with no final component (e.g. `/`).
+/// Test: `derive_index_id_distinguishes_same_named_checkouts`,
+/// `derive_index_id_is_the_shared_derivation`.
+pub fn derive_index_id(path: &Path) -> Option<String> {
+    trusty_common::derive_checkout_index_id(path)
+}
+
+/// Which index the report pass addresses for one checkout, and how it got there.
+///
+/// Why: the three outcomes carry different operator remedies, and collapsing
+/// them to `Option<String>` is what hid #6677 — a substitution and a derived hit
+/// read identically at the call site, and an unresolved id read as a derived
+/// one. The variant is what lets the pass log the substitution once and name the
+/// derived id when nothing covers the path.
+/// What: `Derived` is the daemon holding the derived id; `Substituted` is an
+/// index registered at this checkout's `root_path` under another id;
+/// `Unresolved` is neither, and still carries the derived id so the existing
+/// not-indexed fallback runs unchanged.
+/// Test: `index_registry_tests.rs::{a_registered_derived_id_is_used_as_is,
+/// a_root_path_match_substitutes_for_an_unregistered_derived_id,
+/// no_match_keeps_the_derived_id}`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ReportIndex {
+    /// The daemon holds the derived id; nothing was substituted.
+    Derived(String),
+    /// The derived id is absent; this index is registered at the checkout root.
+    Substituted {
+        /// The registered index id the pass will address.
+        id: String,
+        /// What the checkout path derives to, when it derives to anything.
+        derived: Option<String>,
+    },
+    /// Neither the derived id nor any registered `root_path` matched.
+    Unresolved {
+        /// What the checkout path derives to, when it derives to anything.
+        derived: Option<String>,
+    },
+}
+
+impl ReportIndex {
+    /// The index id to address, or `None` when the path derives to nothing.
+    ///
+    /// `Unresolved` still yields the derived id: the daemon gets asked, answers
+    /// that it does not hold it, and the caller's existing fallback runs. That
+    /// branch is unchanged by #6677.
+    #[must_use]
+    pub fn id(&self) -> Option<&str> {
+        match self {
+            Self::Derived(id) | Self::Substituted { id, .. } => Some(id.as_str()),
+            Self::Unresolved { derived } => derived.as_deref(),
+        }
+    }
+
+    /// [`Self::id`], owned.
+    #[must_use]
+    pub fn into_id(self) -> Option<String> {
+        match self {
+            Self::Derived(id) | Self::Substituted { id, .. } => Some(id),
+            Self::Unresolved { derived } => derived,
+        }
+    }
+}
+
+/// Resolve the index the report pass should address for `repo_path`.
+///
+/// Why/What: see the module doc. `indexes` is the daemon's registry as
+/// [`fetch_registered_indexes`] returns it; an empty list resolves to the
+/// derived id, which is the behaviour that predates #6677.
+/// Test: `index_registry_tests.rs` — one test per variant, plus
+/// `a_parent_rooted_index_is_not_substituted`.
+pub fn resolve_report_index(repo_path: &Path, indexes: &[IndexInfo]) -> ReportIndex {
+    let derived = derive_index_id(repo_path);
+    if let Some(id) = derived.as_ref()
+        && indexes.iter().any(|i| &i.id == id)
+    {
+        return ReportIndex::Derived(id.clone());
+    }
+    match index_at_root(indexes, repo_path) {
+        Some(id) => {
+            warn!(
+                index_id = %id,
+                derived = derived.as_deref().unwrap_or("<none>"),
+                repo_path = %repo_path.display(),
+                "report index resolution: the derived index id is not registered; \
+                 addressing the index registered at this checkout's root_path instead"
+            );
+            ReportIndex::Substituted { id, derived }
+        }
+        None => {
+            warn!(
+                derived = derived.as_deref().unwrap_or("<none>"),
+                repo_path = %repo_path.display(),
+                registered = indexes.len(),
+                "report index resolution: the derived index id is not registered and \
+                 no registered index root_path covers this checkout; the analyze fetch \
+                 falls back to scan and traces record no anchor"
+            );
+            ReportIndex::Unresolved { derived }
+        }
+    }
+}
+
+/// The registered index whose root IS this checkout.
+///
+/// Why: #661's `best_matching_index` picks the longest registered `root_path`
+/// COVERING a directory, which is right for `--source-root` and too loose here —
+/// a parent-rooted index answers about files outside the audited tree, the
+/// stale-scope failure #6137 exists to catch. Reusing that matcher and then
+/// demanding its winner BE the checkout keeps one root-path matcher in the crate
+/// and one report-side rule about which index describes this tree.
+/// What: `Some(id)` when the winning index's canonicalised `root_path` equals
+/// the canonicalised `repo_path`; `None` otherwise.
+/// Test: `index_registry_tests.rs::{a_root_path_match_substitutes_for_an_
+/// unregistered_derived_id, a_parent_rooted_index_is_not_substituted}`.
+fn index_at_root(indexes: &[IndexInfo], repo_path: &Path) -> Option<String> {
+    let root = canonical_source_root(repo_path);
+    let id = best_matching_index(indexes, &root)?;
+    let info = indexes.iter().find(|i| i.id == id)?;
+    let registered = canonical_source_root(Path::new(info.root_path.as_ref()?));
+    (registered == root).then_some(id)
+}
+
+/// Read one trusty-search daemon's registered indexes, fail-open.
+///
+/// Why: resolution needs `root_path`, which only `GET /indexes?details=true`
+/// carries. The request is [`HttpSearchClient::list_indexes`] — the crate's one
+/// implementation of it — pointed at an explicit base URL rather than
+/// `ReviewConfig::search_url`, because the report pass must address the daemon
+/// the audit indexed.
+/// What: the registry, or an empty list when the client will not build or the
+/// daemon does not answer. Empty resolves to the derived id, so a down daemon
+/// degrades exactly as it did before #6677.
+/// Test: `index_registry_tests.rs::an_unreachable_daemon_reads_an_empty_registry`.
+pub async fn fetch_registered_indexes(base_url: &str) -> Vec<IndexInfo> {
+    let client = match HttpSearchClient::new(base_url) {
+        Ok(c) => c,
+        Err(e) => {
+            warn!(base_url, error = %e, "report index resolution: no trusty-search client");
+            return Vec::new();
+        }
+    };
+    match client.list_indexes().await {
+        Ok(indexes) => indexes,
+        Err(e) => {
+            warn!(base_url, error = %e, "report index resolution: index list unavailable");
+            Vec::new()
+        }
+    }
+}
+
+/// [`fetch_registered_indexes`] against the daemon `trusty-search` advertises.
+///
+/// Why: a hard-coded `127.0.0.1:7878` misses an auto-ported daemon and every
+/// `TRUSTY_DATA_DIR`-isolated one — the same resolution `HttpTraceSource` makes.
+/// Test: the read is `an_unreachable_daemon_reads_an_empty_registry`; the
+/// address resolution is `DaemonAddrLayout`'s, covered by
+/// `the_shared_search_layout_is_the_one_being_resolved`.
+pub async fn registered_indexes() -> Vec<IndexInfo> {
+    fetch_registered_indexes(&DaemonAddrLayout::TRUSTY_SEARCH.resolve_base_url()).await
+}
+
+#[cfg(test)]
+#[path = "index_registry_tests.rs"]
+mod tests;

--- a/crates/trusty-review/src/report/index_registry.rs
+++ b/crates/trusty-review/src/report/index_registry.rs
@@ -134,16 +134,39 @@ pub fn resolve_report_index(repo_path: &Path, indexes: &[IndexInfo]) -> ReportIn
             ReportIndex::Substituted { id, derived }
         }
         None => {
+            // #6677 review: the cause rides on this line, so an operator reading
+            // one warning knows which remedy applies.
             warn!(
                 derived = derived.as_deref().unwrap_or("<none>"),
                 repo_path = %repo_path.display(),
+                registry = registry_state(indexes),
                 registered = indexes.len(),
-                "report index resolution: the derived index id is not registered and \
-                 no registered index root_path covers this checkout; the analyze fetch \
-                 falls back to scan and traces record no anchor"
+                "report index resolution: no registered index matches this checkout; \
+                 registry=empty means the daemon answered nothing — it is down, or it \
+                 holds no index — and registry=populated means it holds indexes but \
+                 none rooted here; the analyze fetch falls back to scan and traces \
+                 record no anchor"
             );
             ReportIndex::Unresolved { derived }
         }
+    }
+}
+
+/// Which of the two `Unresolved` causes produced an empty match.
+///
+/// Why: the warning had a count and no cause, so a reader had to correlate it
+/// with `fetch_registered_indexes`'s own line to tell "the daemon told us
+/// nothing" from "the daemon holds indexes, none of them this tree". The two
+/// have different remedies — start or reach the daemon, versus index this
+/// checkout — and they now ride on the one line.
+/// What: `"empty"` for a registry with no entries (an unreachable daemon reads
+/// as one, fail-open), `"populated"` otherwise.
+/// Test: `index_registry_tests::the_unresolved_warning_names_which_cause`.
+fn registry_state(indexes: &[IndexInfo]) -> &'static str {
+    if indexes.is_empty() {
+        "empty"
+    } else {
+        "populated"
     }
 }
 
@@ -156,9 +179,13 @@ pub fn resolve_report_index(repo_path: &Path, indexes: &[IndexInfo]) -> ReportIn
 /// demanding its winner BE the checkout keeps one root-path matcher in the crate
 /// and one report-side rule about which index describes this tree.
 /// What: `Some(id)` when the winning index's canonicalised `root_path` equals
-/// the canonicalised `repo_path`; `None` otherwise.
+/// the canonicalised `repo_path`; `None` otherwise. `canonical_source_root`
+/// falls back to the raw path for a directory that no longer exists, so a
+/// registry entry naming a deleted tree matches only a `repo_path` whose raw
+/// string is the same — a real checkout never collides with one.
 /// Test: `index_registry_tests.rs::{a_root_path_match_substitutes_for_an_
-/// unregistered_derived_id, a_parent_rooted_index_is_not_substituted}`.
+/// unregistered_derived_id, a_parent_rooted_index_is_not_substituted,
+/// a_registry_root_that_no_longer_exists_matches_only_its_own_raw_path}`.
 fn index_at_root(indexes: &[IndexInfo], repo_path: &Path) -> Option<String> {
     let root = canonical_source_root(repo_path);
     let id = best_matching_index(indexes, &root)?;

--- a/crates/trusty-review/src/report/index_registry_tests.rs
+++ b/crates/trusty-review/src/report/index_registry_tests.rs
@@ -173,6 +173,48 @@ fn the_root_comparison_is_canonicalised() {
     );
 }
 
+/// A registry entry can outlive the tree it describes — a worktree removed
+/// while its index stayed registered. `canonical_source_root` cannot resolve
+/// such a path and hands back the raw string, so this pins what the fallback
+/// then does: it matches nothing but an identically-spelled `repo_path`.
+#[test]
+fn a_registry_root_that_no_longer_exists_matches_only_its_own_raw_path() {
+    let gone = "/w/worktrees/removed-tree";
+    let indexes = vec![index("stale", Some(gone))];
+
+    // A real checkout canonicalises; the stale raw path is not a prefix of it.
+    let live = tempfile::tempdir().expect("tempdir");
+    assert!(
+        matches!(
+            resolve_report_index(live.path(), &indexes),
+            ReportIndex::Unresolved { .. }
+        ),
+        "a registry root that no longer exists must not stand in for a live checkout"
+    );
+
+    // Both sides fall back to the raw string, so the two spellings are equal
+    // and the entry does substitute. Stated so the fallback is a decision on
+    // record rather than an accident of `unwrap_or_else`.
+    assert!(
+        matches!(
+            resolve_report_index(Path::new(gone), &indexes),
+            ReportIndex::Substituted { .. }
+        ),
+        "with neither side resolvable, an exact raw-path match is still a match"
+    );
+}
+
+/// The `Unresolved` warning carries WHICH cause, so an operator does not have
+/// to correlate it with the registry read's own line.
+#[test]
+fn the_unresolved_warning_names_which_cause() {
+    assert_eq!(registry_state(&[]), "empty");
+    assert_eq!(
+        registry_state(&[index("unrelated", Some("/w/repos/other"))]),
+        "populated"
+    );
+}
+
 // ── The fail-open read ───────────────────────────────────────────────────────
 
 /// A daemon that is not there reads as an empty registry, never an error — the

--- a/crates/trusty-review/src/report/index_registry_tests.rs
+++ b/crates/trusty-review/src/report/index_registry_tests.rs
@@ -1,0 +1,223 @@
+//! Tests for report-pipeline index resolution (#6677).
+//!
+//! Why: the defect was structural — one derivation, one exact id match, no way
+//! for a ready index registered under another id to be found. The three
+//! resolution outcomes are asserted against a fake registry here rather than a
+//! live daemon, and a grep-level test keeps the two report call sites on this
+//! one resolver so a future second matcher goes red instead of shipping.
+//! What: the derivation, the three variants, the exactness of the root match,
+//! the fail-open read, and the call-site check.
+//! Test: included as `#[cfg(test)] mod tests` from `index_registry.rs`.
+
+use super::*;
+
+/// A registry entry, `root_path` and all.
+fn index(id: &str, root_path: Option<&str>) -> IndexInfo {
+    IndexInfo {
+        id: id.to_string(),
+        name: None,
+        root_path: root_path.map(str::to_string),
+    }
+}
+
+// ── Derivation ───────────────────────────────────────────────────────────────
+
+/// #6149: the renderer and the audit are separate processes agreeing on one id.
+/// Two checkouts of one repository must not derive the same one — that is the
+/// collision that had this crate reading another tree's measurements.
+#[test]
+fn derive_index_id_distinguishes_same_named_checkouts() {
+    let engagement = Path::new("/w/dogfood/repos/local/northwind-web");
+    let working = Path::new("/home/me/northwind-web");
+
+    let a = derive_index_id(engagement).expect("id");
+    let b = derive_index_id(working).expect("id");
+    assert_ne!(a, b, "{a} vs {b}");
+    assert!(b.starts_with("northwind-web-"), "still readable: {b}");
+    assert_eq!(derive_index_id(Path::new("/")), None);
+}
+
+/// The agreement is a call, not a copy: this crate's id IS trusty-common's, so
+/// the audit that indexed under it and this renderer cannot drift.
+#[test]
+fn derive_index_id_is_the_shared_derivation() {
+    for path in ["/home/me/northwind-web", "/w/repos/acme-api", "/"] {
+        let path = Path::new(path);
+        assert_eq!(
+            derive_index_id(path),
+            trusty_common::derive_checkout_index_id(path),
+            "{}",
+            path.display()
+        );
+    }
+}
+
+// ── The three resolution outcomes ────────────────────────────────────────────
+
+/// Case 1: the daemon holds the derived id. Nothing changes.
+#[test]
+fn a_registered_derived_id_is_used_as_is() {
+    let repo = Path::new("/w/repos/northwind-web");
+    let derived = derive_index_id(repo).expect("id");
+    // A root_path match under another id is present and must NOT win: an
+    // exact derived hit is the addressing both processes already agree on.
+    let indexes = vec![
+        index(&derived, Some("/w/repos/northwind-web")),
+        index("northwind-checkout", Some("/w/repos/northwind-web")),
+    ];
+
+    let resolved = resolve_report_index(repo, &indexes);
+    assert_eq!(resolved, ReportIndex::Derived(derived.clone()));
+    assert_eq!(resolved.id(), Some(derived.as_str()));
+}
+
+/// Case 2: the derived id is absent and a registered index IS this checkout —
+/// the field case, where `trusty-tools-checkout` served the tree the derived
+/// `trusty-tools-4e2cf878` could never address.
+#[test]
+fn a_root_path_match_substitutes_for_an_unregistered_derived_id() {
+    let repo = Path::new("/w/repos/trusty-tools");
+    let derived = derive_index_id(repo).expect("id");
+    let indexes = vec![
+        index("unrelated", Some("/w/repos/other")),
+        index("trusty-tools-checkout", Some("/w/repos/trusty-tools")),
+    ];
+
+    let resolved = resolve_report_index(repo, &indexes);
+    assert_eq!(
+        resolved,
+        ReportIndex::Substituted {
+            id: "trusty-tools-checkout".to_string(),
+            derived: Some(derived),
+        }
+    );
+    assert_eq!(resolved.into_id().as_deref(), Some("trusty-tools-checkout"));
+}
+
+/// Case 3: neither matches. The derived id still goes to the daemon, so the
+/// not-indexed fallback and `IndexAbsent` behave exactly as they did.
+#[test]
+fn no_match_keeps_the_derived_id() {
+    let repo = Path::new("/w/repos/northwind-web");
+    let derived = derive_index_id(repo).expect("id");
+    let indexes = vec![
+        index("unrelated", Some("/w/repos/other")),
+        index("no-root-path", None),
+    ];
+
+    let resolved = resolve_report_index(repo, &indexes);
+    assert_eq!(
+        resolved,
+        ReportIndex::Unresolved {
+            derived: Some(derived.clone()),
+        }
+    );
+    assert_eq!(resolved.id(), Some(derived.as_str()));
+}
+
+/// An empty registry — an unreachable daemon, or a machine with no index — is
+/// case 3 with nothing to match against.
+#[test]
+fn an_empty_registry_keeps_the_derived_id() {
+    let repo = Path::new("/w/repos/northwind-web");
+    let derived = derive_index_id(repo).expect("id");
+    assert_eq!(
+        resolve_report_index(repo, &[]).into_id(),
+        Some(derived),
+        "an empty list must resolve exactly as it did before #6677"
+    );
+}
+
+/// A path that derives to nothing and matches nothing yields no id at all, so
+/// the analyze walk skips the repository as it always has.
+#[test]
+fn a_path_that_derives_nothing_resolves_to_nothing() {
+    assert_eq!(
+        resolve_report_index(Path::new("/"), &[index("some-index", Some("/w/repos/x"))]).into_id(),
+        None
+    );
+}
+
+/// The root match is EXACT: an index rooted at the parent covers the path and
+/// describes a wider tree, which is the stale-scope failure #6137 catches.
+#[test]
+fn a_parent_rooted_index_is_not_substituted() {
+    let repo = Path::new("/w/repos/northwind-web");
+    let indexes = vec![index("monorepo", Some("/w/repos"))];
+
+    assert!(
+        matches!(
+            resolve_report_index(repo, &indexes),
+            ReportIndex::Unresolved { .. }
+        ),
+        "a parent-rooted index must not stand in for the checkout"
+    );
+}
+
+/// Two spellings of one directory are one root: the registry stores canonical
+/// paths and a manifest can hand over anything.
+#[test]
+fn the_root_comparison_is_canonicalised() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo = dir.path().join("sub/..").join("sub");
+    std::fs::create_dir_all(dir.path().join("sub")).expect("mkdir");
+    let canonical = dir.path().join("sub").canonicalize().expect("canonicalize");
+    let indexes = vec![index("registered", Some(&canonical.display().to_string()))];
+
+    assert!(
+        matches!(
+            resolve_report_index(&repo, &indexes),
+            ReportIndex::Substituted { .. }
+        ),
+        "an uncanonical spelling of the same directory must still match"
+    );
+}
+
+// ── The fail-open read ───────────────────────────────────────────────────────
+
+/// A daemon that is not there reads as an empty registry, never an error — the
+/// pass then addresses the derived id, which is the pre-#6677 path.
+#[tokio::test]
+async fn an_unreachable_daemon_reads_an_empty_registry() {
+    // Bind, read the port, drop: nothing listens there for the length of this
+    // test, which is what makes the read fail rather than hang.
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().expect("addr").port();
+    drop(listener);
+
+    let indexes = fetch_registered_indexes(&format!("http://127.0.0.1:{port}")).await;
+    assert!(indexes.is_empty(), "a dead daemon must read as no indexes");
+}
+
+// ── One resolver, both call sites ────────────────────────────────────────────
+
+/// Neither report call site derives or matches an index id of its own (#6677).
+///
+/// Why: the defect was two call sites each doing their own thing with the
+/// derived id. A second matcher — anywhere in either file — is the regression,
+/// and it is invisible to a behavioural test that stubs the source. This reads
+/// the two files at compile time and fails on the derivation escaping this
+/// module.
+#[test]
+fn neither_report_call_site_derives_its_own_index_id() {
+    for (name, src) in [
+        (
+            "report/analyze_adapter.rs",
+            include_str!("analyze_adapter.rs"),
+        ),
+        (
+            "report/investigate/trace.rs",
+            include_str!("investigate/trace.rs"),
+        ),
+    ] {
+        assert!(
+            !src.contains("derive_checkout_index_id"),
+            "{name} derives its own index id; it must resolve through \
+             report::index_registry (#6677)"
+        );
+        assert!(
+            src.contains("resolve_report_index"),
+            "{name} must take its index id from index_registry::resolve_report_index (#6677)"
+        );
+    }
+}

--- a/crates/trusty-review/src/report/investigate/trace.rs
+++ b/crates/trusty-review/src/report/investigate/trace.rs
@@ -30,6 +30,8 @@ use serde::Serialize;
 
 use crate::report::metrics::Severity;
 
+use crate::report::index_registry::{derive_index_id, resolve_report_index};
+
 use super::trace_client::{TraceError, TraceSource, TraceUsage};
 use super::trace_symbol::resolve_symbol;
 use super::verify::VerifiedFinding;
@@ -205,7 +207,7 @@ fn candidates(findings: &[VerifiedFinding], limits: TraceLimits) -> Vec<&Verifie
 ///
 /// Why: the whole pass in one place, so every fail-closed exit is visible
 /// beside the success path it replaces.
-/// What: probes the daemon once, derives the index id once, then per candidate
+/// What: probes the daemon once, resolves the index id once (#6677), then per candidate
 /// resolves the symbol from disk, confirms the `[ENTRY]` node, checks the entry
 /// file against the finding's, and collects in-file usages. An unreachable
 /// daemon or an absent index stops further HTTP work and gives every remaining
@@ -219,12 +221,20 @@ pub async fn assemble_traces(
     limits: TraceLimits,
 ) -> TraceSet {
     let candidates = candidates(findings, limits);
-    let index_id = trusty_common::derive_checkout_index_id(repo_path);
 
     let mut halt: Option<String> = if source.reachable().await {
         None
     } else {
         Some("no trace: trusty-search is not reachable".to_string())
+    };
+    // #6677: a checkout registered under an id other than its derived one is
+    // addressed by the id it IS registered under. A daemon that did not answer
+    // has no registry to substitute from, so that branch records what the path
+    // derives to and halts on the reason already set.
+    let index_id = if halt.is_some() {
+        derive_index_id(repo_path)
+    } else {
+        resolve_report_index(repo_path, &source.registered_indexes().await).into_id()
     };
     if halt.is_none() && index_id.is_none() {
         halt = Some(format!(

--- a/crates/trusty-review/src/report/investigate/trace_client.rs
+++ b/crates/trusty-review/src/report/investigate/trace_client.rs
@@ -24,6 +24,9 @@ use serde::Deserialize;
 
 use trusty_common::daemon_guard::DaemonAddrLayout;
 
+use crate::integrations::search_client::IndexInfo;
+use crate::report::index_registry::fetch_registered_indexes;
+
 /// Why one trusty-search read could not answer.
 ///
 /// Why: all three arrive as a failed HTTP call, and collapsing them would put
@@ -102,6 +105,19 @@ pub struct TraceUsage {
 pub trait TraceSource: Send + Sync {
     /// Whether the daemon answers `/health`.
     async fn reachable(&self) -> bool;
+
+    /// The daemon's registered indexes, `root_path` included (#6677).
+    ///
+    /// Why: the pass addresses an index the audit registered, and the id it
+    /// registered under need not be the one this checkout derives to. The
+    /// registry is what tells them apart, and
+    /// [`crate::report::index_registry::resolve_report_index`] is what reads it.
+    /// What: the default is an empty list, which resolves to the derived id —
+    /// the behaviour every stub had before #6677.
+    /// Test: `trace_tests::an_index_registered_at_the_checkout_root_is_traced_against`.
+    async fn registered_indexes(&self) -> Vec<IndexInfo> {
+        Vec::new()
+    }
 
     /// The `[ENTRY]` node for `symbol`, with every edge discarded.
     ///
@@ -203,6 +219,12 @@ struct SearchBody {
 impl TraceSource for HttpTraceSource {
     async fn reachable(&self) -> bool {
         trusty_common::daemon_guard::probe_once(&format!("{}/health", self.base_url)).await
+    }
+
+    /// #6677: read from THIS source's daemon, so a test server and an
+    /// auto-ported daemon are both addressed by the same code path.
+    async fn registered_indexes(&self) -> Vec<IndexInfo> {
+        fetch_registered_indexes(&self.base_url).await
     }
 
     async fn entry_node(&self, index_id: &str, symbol: &str) -> Result<CallChainEntry, TraceError> {

--- a/crates/trusty-review/src/report/investigate/trace_client_tests.rs
+++ b/crates/trusty-review/src/report/investigate/trace_client_tests.rs
@@ -110,6 +110,30 @@ fn an_explicit_base_url_loses_its_trailing_slash() {
     assert_eq!(source.base_url(), "http://127.0.0.1:9999");
 }
 
+/// #6677 review: the registry read is THIS source's, not the machine's.
+///
+/// Why: the sibling read on `HttpAnalyzeMetricsSource` resolved the advertised
+/// daemon whatever socket the source held, which made a stubbed suite issue a
+/// live GET to the developer's own trusty-search. `HttpTraceSource` reads
+/// `self.base_url` instead, and this pins that: a source pointed at a dead port
+/// reads an empty registry, where a machine-wide resolve would return whatever
+/// the host daemon holds.
+/// What: binds a port, drops it, and asserts the read from that address is
+/// empty. On a machine with no daemon the assertion is vacuous; on one with a
+/// daemon it is the leak check.
+#[tokio::test]
+async fn the_registry_read_uses_this_sources_base_url() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().expect("addr").port();
+    drop(listener);
+
+    let source = HttpTraceSource::at(format!("http://127.0.0.1:{port}")).expect("client builds");
+    assert!(
+        source.registered_indexes().await.is_empty(),
+        "the read must go to this source's base_url, never the machine's daemon"
+    );
+}
+
 /// The layout the source resolves through, pinned so a later edit cannot
 /// quietly swap it for a literal `127.0.0.1:7878` — which would miss an
 /// auto-ported daemon and every `TRUSTY_DATA_DIR`-isolated one. Nothing here

--- a/crates/trusty-review/src/report/investigate/trace_tests.rs
+++ b/crates/trusty-review/src/report/investigate/trace_tests.rs
@@ -62,6 +62,11 @@ struct Stub {
     answer: Answer,
     usages: Vec<TraceUsage>,
     entry_calls: Mutex<usize>,
+    /// What `registered_indexes` answers with (#6677); empty by default, which
+    /// is the pre-#6677 resolution.
+    registry: Vec<crate::integrations::search_client::IndexInfo>,
+    /// The index id `entry_node` was last asked for.
+    entry_index: Mutex<String>,
 }
 
 impl Stub {
@@ -71,6 +76,8 @@ impl Stub {
             answer,
             usages: Vec::new(),
             entry_calls: Mutex::new(0),
+            registry: Vec::new(),
+            entry_index: Mutex::new(String::new()),
         }
     }
 
@@ -90,12 +97,17 @@ impl TraceSource for Stub {
         self.reachable
     }
 
+    async fn registered_indexes(&self) -> Vec<crate::integrations::search_client::IndexInfo> {
+        self.registry.clone()
+    }
+
     async fn entry_node(
         &self,
-        _index_id: &str,
+        index_id: &str,
         _symbol: &str,
     ) -> Result<CallChainEntry, TraceError> {
         *self.entry_calls.lock().expect("lock") += 1;
+        index_id.clone_into(&mut self.entry_index.lock().expect("lock"));
         match &self.answer {
             Answer::Entry(e) => Ok(e.clone()),
             Answer::Fail(e) => Err(e.clone()),
@@ -117,6 +129,54 @@ impl TraceSource for Stub {
 async fn trace_with(stub: &Stub, findings: &[VerifiedFinding]) -> TraceSet {
     let dir = checkout();
     assemble_traces(dir.path(), findings, stub, TraceLimits::default()).await
+}
+
+/// #6677: the checkout is registered under an id it does not derive to, so the
+/// pass addresses the registered one. Before this, every candidate recorded
+/// `IndexAbsent` against an index that was ready and covered the exact path.
+#[tokio::test]
+async fn an_index_registered_at_the_checkout_root_is_traced_against() {
+    let dir = checkout();
+    let mut stub = Stub::entry_at(FILE);
+    stub.registry = vec![crate::integrations::search_client::IndexInfo {
+        id: "trusty-tools-checkout".to_string(),
+        name: None,
+        root_path: Some(dir.path().display().to_string()),
+    }];
+
+    let set = assemble_traces(
+        dir.path(),
+        &[finding("guard", Severity::Red, Some(2))],
+        &stub,
+        TraceLimits::default(),
+    )
+    .await;
+
+    assert_eq!(set.index_id.as_deref(), Some("trusty-tools-checkout"));
+    assert_eq!(
+        stub.entry_index.lock().expect("lock").as_str(),
+        "trusty-tools-checkout",
+        "the trace read must address the registered index, not the derived id"
+    );
+    assert_eq!(set.assembled, 1);
+}
+
+/// The unchanged half: an empty registry leaves the derived id in place.
+#[tokio::test]
+async fn an_empty_registry_traces_against_the_derived_id() {
+    let dir = checkout();
+    let stub = Stub::entry_at(FILE);
+    let derived = crate::report::derive_index_id(dir.path()).expect("id");
+
+    let set = assemble_traces(
+        dir.path(),
+        &[finding("guard", Severity::Red, Some(2))],
+        &stub,
+        TraceLimits::default(),
+    )
+    .await;
+
+    assert_eq!(set.index_id.as_deref(), Some(derived.as_str()));
 }
 
 // ─── The success path ─────────────────────────────────────────────────────────

--- a/crates/trusty-review/src/report/mod.rs
+++ b/crates/trusty-review/src/report/mod.rs
@@ -32,6 +32,8 @@ pub mod figures;
 pub mod fill;
 pub mod git_info;
 pub mod instructions;
+// #6677: the one place a checkout is resolved to a registered index id.
+pub mod index_registry;
 pub mod investigate;
 pub mod manifest;
 pub mod mermaid;
@@ -86,8 +88,10 @@ pub mod topology;
 
 pub use analyze_adapter::{
     AnalyzeAdapterError, AnalyzeCaveat, AnalyzeFetch, AnalyzeGap, AnalyzeMetricsSource,
-    HttpAnalyzeMetricsSource, derive_index_id, enrich_with_analyze, enrich_with_analyze_gaps,
+    HttpAnalyzeMetricsSource, enrich_with_analyze, enrich_with_analyze_gaps,
 };
+// #6677: `derive_index_id` moved here from `analyze_adapter`; the public path
+// `trusty_review::report::derive_index_id` is unchanged.
 pub use benchmark::{
     BenchmarkReport, BenchmarkStatus, CorpusSnapshot, LoadedCorpus, MetricPlacement,
     RepositoryBenchmark, build_benchmark_report, corpus_dir, load_corpus, write_snapshot,
@@ -96,6 +100,7 @@ pub use error::{ManifestError, ReportError, Result};
 pub use exec_summary::{DeterministicRisk, ExecSummary, TopRisks, compose as compose_exec_summary};
 pub use fill::{HONESTY_MARKER, Scope, render, strip_leading_comment};
 pub use git_info::{GitInfo, gather_git_info};
+pub use index_registry::{ReportIndex, derive_index_id, resolve_report_index};
 pub use instructions::{
     Instructions, MANIFEST_INSTRUCTIONS_FILE, discover_manifest_instructions, load_instructions,
 };

--- a/crates/trusty-review/tests/report_analyze_e2e.rs
+++ b/crates/trusty-review/tests/report_analyze_e2e.rs
@@ -12,10 +12,20 @@
 //! #6287 (ADR-0032): the mock was an HTTP/1.1 listener on loopback. trusty-analyze
 //! serves JSON-RPC over a Unix socket now, so the mock speaks that instead —
 //! the fixture bodies and every assertion below are unchanged.
+//!
+//! #6677: the enrichment reads trusty-search's index registry once per run, and
+//! that read went to whatever daemon the host advertised — a real HTTP GET out
+//! of a suite documented as never touching a real daemon. Every source built
+//! here now names where the registry comes from: [`DEAD_SEARCH_URL`] for the
+//! tests that want none, and a counting in-process mock for
+//! `the_registry_read_goes_to_the_injected_search_url`, which is the proof that
+//! the read follows the injection.
 //! Test: this file (only compiled with the default `report` feature).
 #![cfg(feature = "report")]
 
 use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 use trusty_review::report::{
@@ -113,6 +123,56 @@ fn spawn_mock(index_id: String, dir: &std::path::Path) -> PathBuf {
     socket
 }
 
+// ─── In-process trusty-search registry mock (#6677) ──────────────────────────
+
+/// A trusty-search address with nothing behind it.
+///
+/// Port 1 is never a trusty-search daemon, and a loopback connect to it is
+/// refused immediately rather than hanging. `fetch_registered_indexes` is
+/// fail-open, so the refusal reads as an empty registry and resolution falls
+/// back to the derived id — which is what every test below other than the
+/// injection proof expects.
+const DEAD_SEARCH_URL: &str = "http://127.0.0.1:1";
+
+/// Serve one `GET /indexes?details=true` body over loopback, counting
+/// connections.
+///
+/// Why: this is how the suite proves the registry read follows
+/// `with_search_base_url`. A request that reached the host's real daemon
+/// instead would leave this counter at zero AND leave the resolution deriving
+/// its own id, so the two assertions in the proof test fail together.
+/// What: binds `127.0.0.1:0`, answers every connection with `body` as
+/// `HTTP/1.1 200` and `connection: close`, and increments the returned counter
+/// once per accepted connection. Returns the base URL and that counter.
+async fn spawn_search_registry_mock(body: String) -> (String, Arc<AtomicUsize>) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind the registry mock");
+    let addr = listener.local_addr().expect("registry mock address");
+    let hits = Arc::new(AtomicUsize::new(0));
+    let counter = Arc::clone(&hits);
+    tokio::spawn(async move {
+        while let Ok((mut conn, _)) = listener.accept().await {
+            counter.fetch_add(1, Ordering::SeqCst);
+            let body = body.clone();
+            tokio::spawn(async move {
+                // One read is the whole request: a GET with no body, well
+                // under the buffer. The response does not depend on it.
+                let mut scratch = [0_u8; 2048];
+                let _ = conn.read(&mut scratch).await;
+                let reply = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\n\
+                     content-length: {}\r\nconnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                let _ = conn.write_all(reply.as_bytes()).await;
+                let _ = conn.flush().await;
+            });
+        }
+    });
+    (format!("http://{addr}"), hits)
+}
+
 // ─── Fixtures ────────────────────────────────────────────────────────────────
 
 /// Create a real local checkout named `acme-core` with one source file so the
@@ -171,7 +231,9 @@ async fn analyze_populates_complexity_and_findings() {
     // Precondition: no declared metrics — the chart/findings are empty pre-fetch.
     assert!(model.repositories[0].metrics.is_none());
 
-    let source = HttpAnalyzeMetricsSource::new(socket).expect("client");
+    let source = HttpAnalyzeMetricsSource::new(socket)
+        .expect("client")
+        .with_search_base_url(DEAD_SEARCH_URL);
     enrich_with_analyze(&mut model, &source).await;
 
     // The live fetch populated metrics.
@@ -286,7 +348,9 @@ async fn green_diagnostic_stays_dropped_under_a_path_that_spells_its_code() {
     let mut model =
         ReportModel::build(&manifest, &manifest_path, "report-technical-dd", None).expect("build");
 
-    let source = HttpAnalyzeMetricsSource::new(socket).expect("client");
+    let source = HttpAnalyzeMetricsSource::new(socket)
+        .expect("client")
+        .with_search_base_url(DEAD_SEARCH_URL);
     enrich_with_analyze(&mut model, &source).await;
 
     let metrics = model.repositories[0]
@@ -304,6 +368,71 @@ async fn green_diagnostic_stays_dropped_under_a_path_that_spells_its_code() {
     assert_green_diagnostic_dropped(metrics, &md);
 }
 
+/// #6677 HERMETICITY PROOF: the registry read goes where the source was pointed,
+/// and nowhere else.
+///
+/// Why: `HttpAnalyzeMetricsSource::registered_indexes` resolved
+/// `DaemonAddrLayout::TRUSTY_SEARCH` unconditionally, so this suite — documented
+/// as never touching a real daemon — issued a live HTTP GET to the developer's
+/// own trusty-search on every run, and its resolution depended on what that
+/// daemon happened to hold.
+/// What: stands up a counting loopback registry that reports ONE index rooted at
+/// the fixture tree under an id the path cannot derive to, points the source at
+/// it, and asserts both halves. The counter proves the read reached this mock;
+/// the analyze mock serving `INJECTED_INDEX_ID` and nothing else proves the id
+/// came from this mock's body — a read that went to the host's daemon could not
+/// have produced that id, would have left the counter at zero, and would have
+/// left metrics unpopulated.
+/// Test: this test itself.
+#[tokio::test]
+async fn the_registry_read_goes_to_the_injected_search_url() {
+    // An id `derive_index_id` cannot produce for the fixture path: the
+    // derivation always appends `-<8 hex>` to the basename.
+    const INJECTED_INDEX_ID: &str = "acme-core-registered";
+
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let manifest_path = write_fixture(tmp.path());
+    let repo = tmp
+        .path()
+        .join(REPO_DIR)
+        .canonicalize()
+        .expect("the fixture tree exists");
+    let derived = trusty_review::report::derive_index_id(&repo).expect("id");
+    assert_ne!(
+        derived, INJECTED_INDEX_ID,
+        "the proof rests on these two ids differing"
+    );
+
+    let (search_url, hits) = spawn_search_registry_mock(format!(
+        r#"{{"indexes":[{{"id":"{INJECTED_INDEX_ID}","name":null,"root_path":"{}"}}]}}"#,
+        repo.display()
+    ))
+    .await;
+    // The analyze mock serves ONLY the injected id, so a fetch under the
+    // derived id answers "not built" and leaves metrics unset.
+    let socket = spawn_mock(INJECTED_INDEX_ID.to_string(), tmp.path());
+
+    let manifest = load_manifest(&manifest_path).expect("manifest loads");
+    let mut model =
+        ReportModel::build(&manifest, &manifest_path, "report-technical-dd", None).expect("build");
+    let source = HttpAnalyzeMetricsSource::new(socket)
+        .expect("client")
+        .with_search_base_url(&search_url);
+
+    enrich_with_analyze(&mut model, &source).await;
+
+    assert_eq!(
+        hits.load(Ordering::SeqCst),
+        1,
+        "the enrichment must read the registry exactly once, from {search_url}"
+    );
+    assert!(
+        model.repositories[0].metrics.is_some(),
+        "the fetch must have addressed {INJECTED_INDEX_ID} — the id only this \
+         mock's registry carries"
+    );
+}
+
 /// Why: a fetch failure must fall through cleanly to scan-only output, never
 /// abort. What: points the source at a socket nothing bound; asserts metrics
 /// stays None and the report still renders. Test: this test itself.
@@ -319,8 +448,9 @@ async fn analyze_fetch_failure_falls_through_to_scan() {
         ReportModel::build(&manifest, &manifest_path, "report-technical-dd", None).expect("build");
 
     // Nothing ever bound this path — the probe fails, fetch is fail-open.
-    let source =
-        HttpAnalyzeMetricsSource::new(tmp.path().join("absent-analyze.sock")).expect("client");
+    let source = HttpAnalyzeMetricsSource::new(tmp.path().join("absent-analyze.sock"))
+        .expect("client")
+        .with_search_base_url(DEAD_SEARCH_URL);
     enrich_with_analyze(&mut model, &source).await;
 
     assert!(


### PR DESCRIPTION
## Outcome

`report::index_registry::resolve_report_index` is the one resolver for both `--analyze` enrichment and the trace pass: derived id when registered, else the index whose canonicalised `root_path` equals the checkout (never a parent-rooted index), else the derived id with a warning that now states whether the registry was empty or populated. The `Ok(None)` scan fallback and `IndexAbsent` behaviour are unchanged. `HttpAnalyzeMetricsSource` gains an injectable trusty-search base URL so the e2e suite stays hermetic (critic HIGH; proven: four real daemon GETs before, zero after).

## Changes

- `crates/trusty-review/src/report/index_registry.rs` (new) and tests
- `crates/trusty-review/src/analyze_adapter.rs`
- `crates/trusty-review/src/investigate/{trace.rs,trace_client.rs}` and tests
- `crates/trusty-review/tests/report_analyze_e2e.rs`
- `crates/trusty-review/src/mod.rs`
- One doc-comment line each in `trusty-audit` and `tga`
- Changelog fragments for all three crates

## Risk

Normal, rung 3. No version bumps needed (`trusty-review` 0.31.2, `trusty-audit` 0.13.0, `tga` 5.0.3 all unpublished; `check-pr-version-bump.sh` clear).

## Test Evidence

All tests run with `--no-fail-fast`:

- `cargo test -p trusty-review --no-fail-fast`: 2107 passed lib + 10 targets ok (`report_analyze_e2e` 4 passed)
- `cargo check -p trusty-audit -p tga`
- `cargo fmt --check`
- `cargo clippy -p trusty-review --all-targets -- -D warnings`
- `bash scripts/check_test_pointers.sh`: 0 dangling pointers
- `bash scripts/check_line_cap.sh`: OK
- `bash scripts/check_changelog_fragment.sh`: 3 crate fragments present
- `bash scripts/check_sld.sh`: OK

Regression proof: with both call sites reverted to `derive_index_id`, `a_repo_served_under_another_id_is_fetched_by_that_id` and `an_index_registered_at_the_checkout_root_is_traced_against` fail. Guard test `neither_report_call_site_derives_its_own_index_id` fails if a call site derives its own id again.

## Baseline Failures

None.

## Docs

Why/What/Test on new public items; changelog fragments included; live verification lands with the combined CAST run against the indexed main checkout.

## Review

Code-critic WARN, HIGH fixed (hermetic e2e), LOWs fixed; security scans PASS.

Refs #6677

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
