### PR TITLE
docs(runbook): CAST code-only audit runbook, corrected against the 2026-09-02 live run (Refs #6669)

### DIFF
--- a/docs/runbooks/cast-code-only-audit.md
+++ b/docs/runbooks/cast-code-only-audit.md
@@ -1,0 +1,244 @@
+# Runbook: Code-Only CAST Audit on Another Codebase
+
+Run a CAST-style technical due-diligence report against a codebase outside
+this workspace, using only what a repository checkout can tell you — no
+interviews, no ops data, no organizational input.
+
+## Required versions
+
+This runbook targets `trusty-analyze report --template cast --code-only
+--manifest <path>` — a command not yet released. It is tracked alongside the
+CAST template's own gaps in [#6004](https://github.com/bobmatnyc/trusty-tools/issues/6004)
+and the DD-dimension gap analysis in
+[DOC-71](../specs/DOC-71-audit-dimensions-and-templates.md). Confirm it
+exists before following this runbook: `trusty-analyze report --help` must
+list a `--code-only` flag.
+
+| Crate | Current version (this repo) | Needed |
+|---|---|---|
+| `trusty-analyze` | 0.12.4 | ≥ next release after 0.12.4 (adds the `report`/`--code-only` verb) |
+| `trusty-review` | 0.31.1 | ≥ next release after 0.31.1 (adds the `code_only` marker plumbing) |
+| `trusty-audit` | 0.12.1 | ≥ next release after 0.12.1 — only if you drive this through a full `trusty-audit` engagement instead of calling `trusty-analyze report` directly (see "Producing the manifest") |
+
+`trusty-analyze report` embeds `trusty-review`'s report generator as a
+library; the CAST template and its section-rendering logic live in
+`trusty-review`, not `trusty-analyze` — both versions matter even though you
+only invoke one binary.
+
+## Prerequisites
+
+- **Rust toolchain**, MSRV 1.94, via `rustup`:
+
+  ```bash
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+  ```
+
+- **Binaries:**
+
+  ```bash
+  cargo install trusty-analyze trusty-review --locked
+  ```
+
+  Add `trusty-audit` only if you plan to drive the run through a full
+  engagement (`trusty-audit init` / `add repo` / `audit`) instead of calling
+  `trusty-analyze report` directly against a hand-written manifest:
+
+  ```bash
+  cargo install trusty-audit --locked
+  ```
+
+- **Cloud credentials:** none, for a local checkout. Report generation always
+  makes one LLM call (synthesis is unconditional since
+  [#5454](https://github.com/bobmatnyc/trusty-tools/issues/5454)), so you need
+  one of:
+
+  ```bash
+  export OPENROUTER_API_KEY=sk-or-v1-...
+  # or leave AWS Bedrock credentials in ~/.aws/credentials / the AWS env vars / an IAM role
+  ```
+
+  Neither key is written into the rendered report or the manifest — a
+  manifest's `[inference]` section carries provider/model identity, never a
+  credential (`crates/trusty-review/src/report/manifest.rs`).
+
+- **`GITHUB_TOKEN`** — optional. Only needed if a manifest repository entry
+  uses `remote = "owner/repo"` instead of a local `path`, or if you separately
+  enable `trusty-review`'s GitHub Issues context source
+  (`TRUSTY_REVIEW_CONTEXT_GITHUB_ISSUES_ENABLED=true`). A code-only audit
+  against a local checkout needs neither.
+
+## Producing the manifest
+
+`trusty-analyze report --manifest` takes a `trusty-review` report manifest —
+a single TOML file. There is no generator command for an arbitrary,
+unregistered repository; write it by hand, following the schema in
+`crates/trusty-review/src/report/manifest.rs` and documented in
+`crates/trusty-review/README.md` ("Manifest").
+
+Minimum manifest for one local checkout at `<repo-path>`:
+
+```toml
+# report-manifest.toml
+[report]
+title = "FLYR Technical DD"
+
+[[repositories]]
+name = "FLYR"
+path = "<repo-path>"
+```
+
+`path` must be a local checkout — `trusty-analyze report --manifest` reads
+tracked files directly (`git ls-files`, or a filtered walk for a non-git
+directory) and needs no prior indexing. Local entries get deterministic git
+enrichment (branch, short SHA, origin, dirty flag) for free.
+
+Optional keys worth setting for a code-only run:
+
+```toml
+[report]
+title = "FLYR Technical DD"
+analyst = "Matt"
+
+[[repositories]]
+name = "FLYR"
+path = "<repo-path>"
+ref  = "main"
+```
+
+`--instructions <file>` (or the manifest's `[report].instructions` key) can
+steer emphasis in the executive summary and findings; it never authorizes
+inventing a fact.
+
+If you instead drive this through `trusty-audit` (multiple repositories, or
+you want `tga`'s git-history sweep alongside the code scan), `trusty-audit
+add repo <repo-path>` and `trusty-audit audit` write and consume this same
+manifest shape for you — see `crates/trusty-audit/README.md`. That path is
+out of scope for the rest of this runbook, which assumes the direct
+`trusty-analyze report` invocation the task names.
+
+## Running the audit
+
+```bash
+trusty-analyze report \
+  --template cast \
+  --code-only \
+  --manifest report-manifest.toml
+```
+
+`trusty-review`'s own `report` subcommand takes the same manifest and accepts
+`--out <dir>` (default `./reports`), `--instructions <file>`, `--no-mermaid`,
+and `--analyze`; `trusty-analyze report` is expected to carry the same flags
+since it calls the identical generator — confirm the exact set with
+`trusty-analyze report --help` once the command ships, rather than assuming
+this list is final.
+
+**Where it lands.** The generator writes a markdown + JSON pair per run,
+`{slug}.md` / `{slug}.json`, under the output directory (`./reports` unless
+overridden). The JSON twin carries the same data as the markdown, including
+which models ran per role — read it if you need the report's data
+programmatically rather than by scraping the markdown.
+
+**Rendering to PDF/HTML.** Nothing in this workspace converts the report to
+PDF or HTML — hand the markdown to a general-purpose converter (e.g.
+`pandoc report.md -o report.pdf`) if a client wants a non-markdown
+deliverable. Mermaid charts render fine on GitHub and most markdown viewers;
+a converter that does not support Mermaid fences will drop them.
+
+**Expected runtime.** Scales with repository size and the number of LLM
+calls, not with binary download time. No fixed SLA exists in the codebase —
+a first run against a large, previously unindexed repository takes
+noticeably longer than a small one. Give it time rather than assuming a
+hang.
+
+## Reading the report
+
+**Provenance markers.** Every substantive fact carries a trailing
+superscript, defined once in a legend near the top of the report:
+
+| Marker | Meaning |
+|---|---|
+| ⁽ᵐ⁾ | **Measured** — computed directly from the repository (LoC, complexity, dependency versions) |
+| ⁽ᵈ⁾ | **Declared** — taken from the manifest or an analyst-supplied value (a day rate, a model name) |
+| ⁽ⁱ⁾ | **Inferred** — an LLM judgment grounded in cited evidence (file:line), never a bare guess |
+
+A genuinely unknowable field is dropped rather than shown with a marker.
+
+**Code-only markers.** `--code-only` adds two more things to watch for,
+beyond the three-way legend:
+
+- A line ending **"Inferred from code; not validated by interview or ops
+  data."** — the section rendered real, code-derived content, but nothing in
+  it was cross-checked against a conversation or an ops dashboard the way a
+  full CAST engagement would. Treat it as directionally useful, not as a
+  validated finding the way a ⁽ᵐ⁾ fact is.
+- A cell reading **"Out of scope for a code-only audit — requires
+  [interview / CAST's proprietary benchmark corpus / ops metrics], not
+  available from repository inspection alone."** — trusty deliberately did
+  not attempt that measurement. This is the run's stated boundary, not a bug
+  or a missing feature; the section heading still renders so the gap is
+  never mistaken for a silent omission.
+
+**The CAST 1.00–4.00 scale.** The CAST template documents CAST's own scoring
+model: five health factors (Robustness, Efficiency, Security, Changeability,
+Transferability), each scored 1.00 (very-high-risk) to 4.00 (low-risk) from
+rule-violation percentages, rolled up into a TQI. Age-adjusted acceptability
+bands apply (`<2yr` expects `>3.40`; `2–5yr` `>3.20`; `5–10yr` `>3.00`;
+`>10yr` `>2.70`). As of this writing, not every health-factor cell has a real
+computation behind it — some render the code-only PARTIAL marker rather than
+a genuine 1.00–4.00 score; check the report's own Gaps & Caveats section for
+which cells are live versus placeholder for your run.
+
+**trusty's own Code Quality / Security / Performance sections are NOT
+CAST-scored.** The default (non-CAST) template carries these sections on
+trusty's native 0–100 scale (RED `<33` / AMBER `33–66` / GREEN `>66`) — a
+different scale from CAST's 1.00–4.00. The CAST template variant currently
+defers these sections outright (tracked in #6004); if a future version of
+the CAST template includes them, they still report on trusty's native scale,
+not CAST's. Do not read a number from one of these sections as a CAST health
+factor, or vice versa.
+
+## Troubleshooting
+
+- **Missing language adapter.** `trusty-analyze` ships adapters for Rust,
+  TypeScript/JavaScript, Python, Go, Java, C#, C, C++, PHP, Ruby, Scala,
+  Swift, and Kotlin (`crates/trusty-analyze/src/lang/adapters/`). There is no
+  SQL / stored-procedure adapter and no Roslyn-based `.NET` linter in
+  `run_diagnostics`'s tool roster — a codebase with a large SQL or .NET
+  surface gets weaker per-file findings there than CAST's own
+  Stored-Procedures deep dive. This is a known gap, not a misconfiguration.
+- **`SKIP_UI_BUILD=1` needed.** `trusty-analyze` embeds a Svelte UI built by
+  `build.rs` via `pnpm`. `cargo install --locked` from crates.io ships a
+  prebuilt UI and does not trigger this; building from a git checkout
+  without `pnpm` on `PATH` does. Set `SKIP_UI_BUILD=1` before the build to
+  skip it:
+
+  ```bash
+  SKIP_UI_BUILD=1 cargo install --git https://github.com/bobmatnyc/trusty-tools trusty-analyze --locked
+  ```
+
+- **Large-repo runtime.** A large, previously unindexed repository costs
+  noticeably more wall-clock time than a small one — both in the file scan
+  and in the LLM calls. There is no fixed SLA; a run that is still making
+  progress (growing log output, no error) is not stuck.
+- **Missing `OPENROUTER_API_KEY` / AWS credentials.** The run stops before
+  reading any repository, naming the missing credential — this is the
+  intended fail-fast behavior (#5454), not a bug.
+
+## What this run does NOT cover
+
+A code-only audit is bounded by what a repository checkout can tell you.
+These CAST sections have no code-derived equivalent and render as explicitly
+out of scope, never silently blank:
+
+- **Peer Benchmark** — CAST's industry-quartile/rank placement needs their
+  proprietary corpus of thousands of scanned applications; no comparable
+  population exists here.
+- **Next Steps (organizational/process recommendations)** — "empower Scrum
+  Master," team-behavior change, modernization-readiness timing — inherently
+  organizational, not derivable from source.
+- **Interviews** — no interview transcript section exists in this run's
+  output, and none is collected.
+- **Ops metrics / cloud bills** — no cloud-spend, infrastructure, or
+  operational-metrics data is read or reported.
+- **Team org-chart / team structure** — no org-chart or team-structure
+  section exists in this run's output.

--- a/docs/runbooks/cast-code-only-audit.md
+++ b/docs/runbooks/cast-code-only-audit.md
@@ -4,26 +4,11 @@ Run a CAST-style technical due-diligence report against a codebase outside
 this workspace, using only what a repository checkout can tell you — no
 interviews, no ops data, no organizational input.
 
-## Required versions
-
 This runbook targets `trusty-analyze report --template cast --code-only
---manifest <path>` — a command not yet released. It is tracked alongside the
-CAST template's own gaps in [#6004](https://github.com/bobmatnyc/trusty-tools/issues/6004)
-and the DD-dimension gap analysis in
-[DOC-71](../specs/DOC-71-audit-dimensions-and-templates.md). Confirm it
-exists before following this runbook: `trusty-analyze report --help` must
-list a `--code-only` flag.
-
-| Crate | Current version (this repo) | Needed |
-|---|---|---|
-| `trusty-analyze` | 0.12.4 | ≥ next release after 0.12.4 (adds the `report`/`--code-only` verb) |
-| `trusty-review` | 0.31.1 | ≥ next release after 0.31.1 (adds the `code_only` marker plumbing) |
-| `trusty-audit` | 0.12.1 | ≥ next release after 0.12.1 — only if you drive this through a full `trusty-audit` engagement instead of calling `trusty-analyze report` directly (see "Producing the manifest") |
-
-`trusty-analyze report` embeds `trusty-review`'s report generator as a
-library; the CAST template and its section-rendering logic live in
-`trusty-review`, not `trusty-analyze` — both versions matter even though you
-only invoke one binary.
+--manifest <path>`. It is tracked alongside the CAST template's own gaps in
+[#6004](https://github.com/bobmatnyc/trusty-tools/issues/6004) and the
+DD-dimension gap analysis in
+[DOC-71](../specs/DOC-71-audit-dimensions-and-templates.md).
 
 ## Prerequisites
 
@@ -35,31 +20,42 @@ only invoke one binary.
 
 - **Binaries:**
 
+  Path A — use `trusty-analyze report` directly against a hand-written manifest:
+
   ```bash
-  cargo install trusty-analyze trusty-review --locked
+  cargo install trusty-analyze --features review --locked
+  cargo install trusty-review --locked
   ```
 
-  Add `trusty-audit` only if you plan to drive the run through a full
-  engagement (`trusty-audit init` / `add repo` / `audit`) instead of calling
-  `trusty-analyze report` directly against a hand-written manifest:
+  Path B — drive the run through a full `trusty-audit` engagement (`trusty-audit
+  init` / `add repo` / `audit`), which coordinates the same pipeline:
 
   ```bash
-  cargo install trusty-audit --locked
+  cargo install trusty-audit trusty-review --locked
   ```
 
-- **Cloud credentials:** none, for a local checkout. Report generation always
-  makes one LLM call (synthesis is unconditional since
-  [#5454](https://github.com/bobmatnyc/trusty-tools/issues/5454)), so you need
-  one of:
+  `trusty-analyze report` embeds `trusty-review`'s report generator as a
+  library — both binaries reach the same implementation entry point. The
+  `--features review` flag is required for `trusty-analyze report`; without it,
+  the `report` verb and `--code-only` flag are unavailable.
+
+- **LLM credentials:** Required. Report generation always makes inference calls
+  [#5454](https://github.com/bobmatnyc/trusty-tools/issues/5454). Provide one of:
 
   ```bash
+  # OpenRouter (default provider):
   export OPENROUTER_API_KEY=sk-or-v1-...
-  # or leave AWS Bedrock credentials in ~/.aws/credentials / the AWS env vars / an IAM role
+
+  # or AWS Bedrock (standard credential chain):
+  export AWS_REGION=us-east-1            # if not already set
+  export TRUSTY_LLM_MODEL=bedrock/us.anthropic.claude-sonnet-4-6
+  # AWS credentials via env vars, ~/.aws/credentials, IAM role, or SSO
   ```
 
-  Neither key is written into the rendered report or the manifest — a
-  manifest's `[inference]` section carries provider/model identity, never a
-  credential (`crates/trusty-review/src/report/manifest.rs`).
+  Neither credential is written into the rendered report or the manifest — a
+  manifest's `[report]` section carries provider/model identity, never a
+  credential. The run stops before reading any repository if credentials are
+  missing, naming the missing key.
 
 - **`GITHUB_TOKEN`** — optional. Only needed if a manifest repository entry
   uses `remote = "owner/repo"` instead of a local `path`, or if you separately
@@ -92,22 +88,37 @@ tracked files directly (`git ls-files`, or a filtered walk for a non-git
 directory) and needs no prior indexing. Local entries get deterministic git
 enrichment (branch, short SHA, origin, dirty flag) for free.
 
-Optional keys worth setting for a code-only run:
+Optional keys for a code-only run:
 
 ```toml
 [report]
 title = "FLYR Technical DD"
 analyst = "Matt"
+code_only = true
 
 [[repositories]]
 name = "FLYR"
 path = "<repo-path>"
 ref  = "main"
+investigate_max_files = 40
 ```
 
-`--instructions <file>` (or the manifest's `[report].instructions` key) can
-steer emphasis in the executive summary and findings; it never authorizes
-inventing a fact.
+Key notes:
+- `[report] code_only = true` is optional in the manifest; the `--code-only` CLI
+  flag also sets it. The flag turns the mode ON only — omitting it never widens
+  a scope the manifest declared.
+- Each `[[repositories]]` entry declares **exactly one** of `path` (local
+  checkout) or `remote` (`owner/repo` for GitHub repositories).
+- `investigate_max_files` caps how many files are sent to the LLM per repository;
+  default is built-in (roughly 40 files). `--investigate-max-files` CLI flag
+  takes precedence.
+- `ref` is optional; when omitted, the current checked-out branch is used.
+- `metrics` can reference a pre-produced `trusty-analyze` metrics JSON file;
+  when omitted, a scan is performed.
+
+`--instructions <file>` (or the manifest's `[report].instructions` key) hands
+the generator a free-form markdown brief. It steers emphasis in synthesis (if
+enabled) but never authorizes inventing a fact.
 
 If you instead drive this through `trusty-audit` (multiple repositories, or
 you want `tga`'s git-history sweep alongside the code scan), `trusty-audit
@@ -120,17 +131,32 @@ out of scope for the rest of this runbook, which assumes the direct
 
 ```bash
 trusty-analyze report \
+  --manifest report-manifest.toml \
   --template cast \
   --code-only \
-  --manifest report-manifest.toml
+  --out ./dd-reports
 ```
 
-`trusty-review`'s own `report` subcommand takes the same manifest and accepts
-`--out <dir>` (default `./reports`), `--instructions <file>`, `--no-mermaid`,
-and `--analyze`; `trusty-analyze report` is expected to carry the same flags
-since it calls the identical generator — confirm the exact set with
-`trusty-analyze report --help` once the command ships, rather than assuming
-this list is final.
+Both `trusty-analyze report` and `trusty-review report` call the same generator
+and accept the same flags:
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--manifest <FILE>` | required | The report manifest TOML file |
+| `--template <NAME>` | `report-technical-dd` | Template name: `cast`, `default`, `generic`, or a full/override name |
+| `--code-only` | off | Mark non-code sections as out-of-scope; mark code-derived sections as inferred |
+| `--out <DIR>` | `./reports` | Output directory for the markdown + JSON pair |
+| `--instructions <FILE>` | unset | Free-form analyst brief (markdown) for synthesis focus |
+| `--synthesize` | off | Add LLM-written prose to executive summary, top risks, and RED/AMBER findings |
+| `--corpus <DIR>` | XDG data dir | Deterministic cross-repo benchmark corpus directory |
+| `--benchmark` | off | Compute percentile/quartile placement in the corpus |
+| `--analyze` | on | Fetch trusty-analyze metrics on-demand (fail-open; built-in scan used if unavailable) |
+| `--no-mermaid` | off | Skip Mermaid chart generation beneath graph-ready data tables |
+
+Template aliases: `cast` → `report-technical-dd-cast`, `default` / `generic` →
+`report-technical-dd`. Override either by dropping a same-named file in
+`~/.trusty-review/templates/`; the override directory is checked before the
+bundled default.
 
 **Where it lands.** The generator writes a markdown + JSON pair per run,
 `{slug}.md` / `{slug}.json`, under the output directory (`./reports` unless
@@ -144,11 +170,12 @@ PDF or HTML — hand the markdown to a general-purpose converter (e.g.
 deliverable. Mermaid charts render fine on GitHub and most markdown viewers;
 a converter that does not support Mermaid fences will drop them.
 
-**Expected runtime.** Scales with repository size and the number of LLM
-calls, not with binary download time. No fixed SLA exists in the codebase —
-a first run against a large, previously unindexed repository takes
-noticeably longer than a small one. Give it time rather than assuming a
-hang.
+**Expected runtime.** Scales with the file investigation budget and the number
+of LLM calls. A default run (40-file investigation budget per repository) takes
+roughly 60–120 seconds per repository; scales roughly linearly with the file
+budget. Large repositories with non-default `investigate_max_files` settings
+cost correspondingly more. No fixed SLA — a run that is still logging output is
+not stuck.
 
 ## Reading the report
 
@@ -163,30 +190,25 @@ superscript, defined once in a legend near the top of the report:
 
 A genuinely unknowable field is dropped rather than shown with a marker.
 
-**Code-only markers.** `--code-only` adds two more things to watch for,
-beyond the three-way legend:
+**Code-only markers.** `--code-only` adds two categories of output:
 
-- A line ending **"Inferred from code; not validated by interview or ops
-  data."** — the section rendered real, code-derived content, but nothing in
-  it was cross-checked against a conversation or an ops dashboard the way a
-  full CAST engagement would. Treat it as directionally useful, not as a
-  validated finding the way a ⁽ᵐ⁾ fact is.
-- A cell reading **"Out of scope for a code-only audit — requires
-  [interview / CAST's proprietary benchmark corpus / ops metrics], not
-  available from repository inspection alone."** — trusty deliberately did
-  not attempt that measurement. This is the run's stated boundary, not a bug
-  or a missing feature; the section heading still renders so the gap is
-  never mistaken for a silent omission.
+- **Non-code sections** (Peer Benchmark, Next Steps) render with an explicit
+  marker: "Out of scope for a code-only audit — requires <what it needs>, not
+  available from repository inspection alone." The section heading still renders
+  so the gap is never mistaken for a silent omission.
+- **Partial sections** (OSS/CVE exposure, License/IP risk, Remediation Economics)
+  render their code-derived content with an added marker: "Inferred from code;
+  not validated by interview or operational data." Treat these findings as
+  directionally useful, not as validated facts the way a ⁽ᵐ⁾ measurement is.
 
-**The CAST 1.00–4.00 scale.** The CAST template documents CAST's own scoring
-model: five health factors (Robustness, Efficiency, Security, Changeability,
-Transferability), each scored 1.00 (very-high-risk) to 4.00 (low-risk) from
-rule-violation percentages, rolled up into a TQI. Age-adjusted acceptability
-bands apply (`<2yr` expects `>3.40`; `2–5yr` `>3.20`; `5–10yr` `>3.00`;
-`>10yr` `>2.70`). As of this writing, not every health-factor cell has a real
-computation behind it — some render the code-only PARTIAL marker rather than
-a genuine 1.00–4.00 score; check the report's own Gaps & Caveats section for
-which cells are live versus placeholder for your run.
+The Report Metadata table states the scope, so a reader never has to infer it.
+
+**The CAST 1.00–4.00 scale.** The CAST template renders CAST's scoring model:
+five health factors (Robustness, Efficiency, Security, Changeability,
+Transferability), each scored 1.00 (very-high-risk) to 4.00 (low-risk). Known gap:
+not every health-factor cell has a computation behind it yet. The report's own
+"Gaps & Caveats" section names which cells are live versus placeholder for your
+run. This gap is tracked in #6004.
 
 **trusty's own Code Quality / Security / Performance sections are NOT
 CAST-scored.** The default (non-CAST) template carries these sections on
@@ -216,13 +238,13 @@ factor, or vice versa.
   SKIP_UI_BUILD=1 cargo install --git https://github.com/bobmatnyc/trusty-tools trusty-analyze --locked
   ```
 
-- **Large-repo runtime.** A large, previously unindexed repository costs
-  noticeably more wall-clock time than a small one — both in the file scan
-  and in the LLM calls. There is no fixed SLA; a run that is still making
-  progress (growing log output, no error) is not stuck.
-- **Missing `OPENROUTER_API_KEY` / AWS credentials.** The run stops before
-  reading any repository, naming the missing credential — this is the
-  intended fail-fast behavior (#5454), not a bug.
+- **Engagement-level configuration.** If driving through `trusty-audit`, set
+  `[report] template = "cast"` and `code_only = true` in the engagement
+  manifest; `trusty-audit` passes these to the child renderer as environment
+  variables `TRUSTY_AUDIT_REPORT_TEMPLATE` and `TRUSTY_AUDIT_REPORT_CODE_ONLY`.
+- **Missing LLM credentials.** The run stops before reading any repository,
+  naming the missing credential — this is the intended fail-fast behavior
+  (#5454), not a bug.
 
 ## What this run does NOT cover
 

--- a/docs/runbooks/cast-code-only-audit.md
+++ b/docs/runbooks/cast-code-only-audit.md
@@ -37,7 +37,9 @@ DD-dimension gap analysis in
   `trusty-analyze report` embeds `trusty-review`'s report generator as a
   library — both binaries reach the same implementation entry point. The
   `--features review` flag is required for `trusty-analyze report`; without it,
-  the `report` verb and `--code-only` flag are unavailable.
+  the `report` verb and `--code-only` flag are unavailable. `trusty-review
+  report` is that same generator's own front door. It needs no extra feature
+  flag: `cargo install trusty-review --locked` is enough on its own.
 
 - **LLM credentials:** Required. Report generation always makes inference calls
   [#5454](https://github.com/bobmatnyc/trusty-tools/issues/5454). Provide one of:
@@ -62,6 +64,12 @@ DD-dimension gap analysis in
   enable `trusty-review`'s GitHub Issues context source
   (`TRUSTY_REVIEW_CONTEXT_GITHUB_ISSUES_ENABLED=true`). A code-only audit
   against a local checkout needs neither.
+
+- **Index resolution for `--analyze`** (#6677): if you use `--analyze`, the
+  report resolves the trusty-search index by the checkout's registered
+  `root_path` when the derived index id is absent from the daemon's registry,
+  and logs a WARN line naming both the derived and the resolved id. A
+  checkout indexed under any id still works.
 
 ## Producing the manifest
 
@@ -116,6 +124,27 @@ Key notes:
 - `metrics` can reference a pre-produced `trusty-analyze` metrics JSON file;
   when omitted, a scan is performed.
 
+**Evidence discovery.** A manifest declaring only `[report]`, `[inference]`,
+and `[[repositories]] name/path` gets no search-derived evidence. The
+2026-09-02 live run against this checkout reported: "evidence discovery:
+path-name heuristics only — the manifest declared no search-derived evidence
+for this repository." This is a prerequisite, not a permanent gap:
+`crates/trusty-review/src/report/manifest.rs` documents the
+`inspect_priority` key for exactly this purpose.
+
+```rust
+/// Ranked repo-relative paths the investigation pass must inspect first
+/// (#6078). Empty — the default — leaves selection byte-identical to a
+/// manifest without the key. See [`InspectionPriority`].
+pub inspect_priority: Vec<InspectionPriority>,
+```
+
+Each entry also accepts `dimension` and `reason` (#6082), attributing the
+file to a DD dimension and naming the query that found it. `trusty-audit`
+writes this automatically from its search and knowledge-graph ranking; a
+hand-written manifest can declare it too. Track follow-up work in
+[#6669](https://github.com/bobmatnyc/trusty-tools/issues/6669).
+
 `--instructions <file>` (or the manifest's `[report].instructions` key) hands
 the generator a free-form markdown brief. It steers emphasis in synthesis (if
 enabled) but never authorizes inventing a fact.
@@ -137,8 +166,24 @@ trusty-analyze report \
   --out ./dd-reports
 ```
 
-Both `trusty-analyze report` and `trusty-review report` call the same generator
-and accept the same flags:
+`trusty-analyze report` fetches trusty-analyze metrics on demand by default;
+pass `--no-analyze` to skip that fetch. `trusty-review report` defaults the
+same fetch OFF, so run it with `--analyze` explicitly, or the complexity
+profile renders "not stated in source data":
+
+```bash
+trusty-review report \
+  --manifest report-manifest.toml \
+  --template cast \
+  --code-only \
+  --analyze \
+  --out ./dd-reports
+```
+
+Both binaries call the same generator and accept nearly the same flags. The
+analyzer-metrics fetch is the one exception: `trusty-analyze report` takes
+`--no-analyze` (on by default); `trusty-review report` takes `--analyze` (off
+by default), listed below as the shared table's one binary-specific row.
 
 | Flag | Default | Meaning |
 |---|---|---|
@@ -147,11 +192,14 @@ and accept the same flags:
 | `--code-only` | off | Mark non-code sections as out-of-scope; mark code-derived sections as inferred |
 | `--out <DIR>` | `./reports` | Output directory for the markdown + JSON pair |
 | `--instructions <FILE>` | unset | Free-form analyst brief (markdown) for synthesis focus |
-| `--synthesize` | off | Add LLM-written prose to executive summary, top risks, and RED/AMBER findings |
 | `--corpus <DIR>` | XDG data dir | Deterministic cross-repo benchmark corpus directory |
 | `--benchmark` | off | Compute percentile/quartile placement in the corpus |
-| `--analyze` | on | Fetch trusty-analyze metrics on-demand (fail-open; built-in scan used if unavailable) |
+| `--analyze` (trusty-review report only) | off | Fetch trusty-analyze metrics on demand for local-path repos declaring no `metrics` file, only when already indexed. Fully fail-open |
 | `--no-mermaid` | off | Skip Mermaid chart generation beneath graph-ready data tables |
+
+`--synthesize` is deprecated and ignored (#5454): synthesis now runs
+unconditionally on every report. Passing the flag only prints a deprecation
+line to stderr and changes nothing.
 
 Template aliases: `cast` → `report-technical-dd-cast`, `default` / `generic` →
 `report-technical-dd`. Override either by dropping a same-named file in
@@ -170,12 +218,14 @@ PDF or HTML — hand the markdown to a general-purpose converter (e.g.
 deliverable. Mermaid charts render fine on GitHub and most markdown viewers;
 a converter that does not support Mermaid fences will drop them.
 
-**Expected runtime.** Scales with the file investigation budget and the number
-of LLM calls. A default run (40-file investigation budget per repository) takes
-roughly 60–120 seconds per repository; scales roughly linearly with the file
-budget. Large repositories with non-default `investigate_max_files` settings
-cost correspondingly more. No fixed SLA — a run that is still logging output is
-not stuck.
+**Expected runtime.** Measured once, 2026-09-02, one repository: a
+103082-chunk index of this checkout took about 3m45s wall-clock, using
+`trusty-review report --code-only` with the default OpenRouter roles
+(reviewer, verifier, and summarizer). Most of that time is LLM synthesis.
+The scan-only phases finish in well under a minute. Treat this figure as one
+data point, not an SLA. Runtime scales with the file investigation budget and
+the number of LLM calls, so a larger `investigate_max_files` costs more. A run
+that is still logging output is not stuck.
 
 ## Reading the report
 

--- a/docs/runbooks/cast-code-only-audit.md
+++ b/docs/runbooks/cast-code-only-audit.md
@@ -139,6 +139,12 @@ for this repository." This is a prerequisite, not a permanent gap:
 pub inspect_priority: Vec<InspectionPriority>,
 ```
 
+The companion `[report].attributed_only` key governs what happens when that
+declared list runs short. Its doc comment: "Select ONLY files this manifest
+declared, never padding with path-name heuristics (#6082)." Set `true`, a
+short `inspect_priority` list renders as a stated shortfall in Investigation
+Coverage, never padded with heuristic-scored files.
+
 Each entry also accepts `dimension` and `reason` (#6082), attributing the
 file to a DD dimension and naming the query that found it. `trusty-audit`
 writes this automatically from its search and knowledge-graph ranking; a


### PR DESCRIPTION
## Outcome
Publish corrected CAST code-only audit runbook reflecting 2026-09-02 live-run evidence and implementation state.

## Changes
New runbook: `docs/runbooks/cast-code-only-audit.md`

Corrections applied:
- `--analyze` default off for trusty-review report; inverse `--no-analyze` polarity on trusty-analyze report
- `--synthesize` deprecated (#5454)
- Measured runtime ~3m45s for 103k-chunk index
- Root path index resolution (#6677)
- Evidence discovery prerequisites: `inspect_priority` / `attributed_only` with trusty-audit as upstream writer

## Risk
Documentation only. No crate source or test changes.

## Tests
Rung 1 (docs only): `bash scripts/check_sld.sh` PASS.

## Baseline
No baseline changes — this is a new runbook. See #6669 comment thread for live-run evidence.

## Docs
New runbook published to documentation inventory at `docs/runbooks/cast-code-only-audit.md`.

## Review
Ready for merge; docs-only PR requires no test suite beyond SLD gate.

See #6669 for live-run evidence and implementation details.

Refs #6669

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
