### PR TITLE
feat(trusty-search): /health names the indexes with a failed lane (Refs #6688)

### DIFF
--- a/crates/trusty-search/CLAUDE.md
+++ b/crates/trusty-search/CLAUDE.md
@@ -180,6 +180,20 @@ daemon.
     retries it, because a partial walk may have committed chunks and the cause
     that killed the first walk would likely kill the retry. Clear it with
     `POST /indexes/:id/reindex`.
+  - `indexes_stage_failed_ids` (#6688): the ids behind
+    `warmboot_summary.indexes_stage_failed`, so a consumer can act on the
+    specific index instead of polling `GET /indexes/:id/status` for every
+    registration. Same `IndexStages::any_failed()` predicate, same registry
+    scan, so `indexes_stage_failed_ids.len() == indexes_stage_failed` always,
+    including under the fail-open arm (a handle whose `stages` lock is
+    contended is skipped by both and counted in
+    `warmboot_summary.indexes_health_scan_skipped`). Sorted — the registry
+    iterates arbitrarily. **Omitted entirely when the count is `0`**, so a
+    consumer must spell it `Option<Vec<String>>` or add `#[serde(default)]`; a
+    bare `Vec<String>` hard-fails against a daemon that omits it. A
+    corpus-open failure marks every lane `Failed`, so those indexes are named
+    here too, but `indexes_corpus_failed`'s post-warm-boot backstop case is
+    not — this field tracks the lane counter, not the corpus one.
   - `indexes_watcher_network_degraded` (issue #3408): count of registered
     indexes whose file watcher was refused because `root_path` was detected as
     a network-mounted filesystem (NFS/EFS/SMB/CIFS). inotify/FSEvents cannot

--- a/crates/trusty-search/changelog.d/6688-health-failing-index-ids.md
+++ b/crates/trusty-search/changelog.d/6688-health-failing-index-ids.md
@@ -1,0 +1,14 @@
+Added
+
+- `GET /health` names the indexes behind `warmboot_summary.indexes_stage_failed`
+  in a new top-level `indexes_stage_failed_ids` array (#6688). Until now the
+  response carried counts only, so a consumer reading `indexes_stage_failed: 1`
+  on a 41-index daemon had to poll `GET /indexes/:id/status` for every
+  registration to find the broken one. The ids come from the same
+  `IndexStages::any_failed()` predicate, in the same registry scan, as the
+  counter, so the two can never disagree; they are sorted, because the registry
+  iterates arbitrarily. The field is optional and omitted entirely when nothing
+  is failing — every existing counter keeps its exact shape, and a consumer
+  built against an older daemon needs no change. A consumer that mirrors the
+  field must spell it `Option<Vec<String>>` or add `#[serde(default)]`; a bare
+  `Vec<String>` hard-fails against a daemon that omits it.

--- a/crates/trusty-search/src/service/server/health.rs
+++ b/crates/trusty-search/src/service/server/health.rs
@@ -1,14 +1,15 @@
-//! `GET /health` and `POST /upgrade` handlers.
+//! `GET /health` handler.
 //!
 //! Why: Health probes are polled at 2s intervals by external orchestrators;
 //! keeping them in a focused module makes response-shape changes easy to review.
 //! What: `health_handler` returns daemon liveness + embedder status + resource
-//! metrics. `upgrade_handler` drives `cargo install` and triggers a self-restart.
+//! metrics. `POST /upgrade` moved to `super::upgrade` in #6688, when this file
+//! crossed the 500-SLOC production cap.
 //! Test: `health_handler_reports_indexes_and_uptime` and related tests in
 //! `super::tests`.
 use axum::extract::State;
 use axum::Json;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use std::sync::Arc;
 
 use crate::core::embed::Embedder as _;
@@ -82,6 +83,42 @@ pub(super) struct HealthResponse {
     /// `~102`) immediately visible without tailing logs. The `warm_boot_degraded`
     /// boolean is the machine-readable flag external monitors should poll.
     pub(super) warmboot_summary: WarmBootSummary,
+    /// Issue #6688: the IDS of the indexes `warmboot_summary.indexes_stage_failed`
+    /// counts. Absent — not `null`, not `[]` — when that count is `0`.
+    ///
+    /// Why: every failing-index signal on this response was a COUNT, so a
+    /// consumer reading `indexes_stage_failed: 1` on a 41-index daemon could
+    /// not tell which index failed and had to poll `GET /indexes/:id/status`
+    /// for every registered index to find out. That blocks per-index
+    /// remediation and made trusty-review degrade every review because one
+    /// unrelated index on the host had failed lanes (#6686).
+    /// What: `IndexStages::any_failed()` — the SAME predicate, evaluated in the
+    /// SAME registry scan, on the same `handle.stages` read that produces
+    /// `indexes_stage_failed`. So `indexes_stage_failed_ids.len()` and that
+    /// counter can never disagree, including under the fail-open arm: a handle
+    /// whose `stages` lock is contended is skipped by both (and counted in
+    /// `indexes_health_scan_skipped`). Sorted, because the registry is a
+    /// `DashMap` and its iteration order is not stable across polls.
+    ///
+    /// `any_failed()` and NOT `indexes_corpus_failed`'s
+    /// `CodeIndexer::corpus_open_failed`: a corpus-open failure marks every
+    /// lane `Failed` (`derive_warm_boot_stages`' `corpus_open_failed` guard),
+    /// so a corpus-failed index is already named here by its lanes. Folding the
+    /// flag in would name indexes that no counter on this response counts, for
+    /// only the post-warm-boot backstop case #5927 added — a corpus-failure
+    /// id list is a separate additive field, not a widening of this one.
+    ///
+    /// Additive and optional by construction (`skip_serializing_if`): a
+    /// consumer built against an older daemon never sees the key, and every
+    /// existing counter keeps its exact shape. A consumer mirroring this field
+    /// MUST spell it `Option<Vec<String>>` or `#[serde(default)]` — a bare
+    /// `Vec<String>` hard-fails against a daemon that omits it (#628).
+    /// Test: `health_names_the_indexes_with_a_failed_lane`,
+    /// `health_omits_the_failing_index_ids_when_nothing_is_failing`, and
+    /// `health_counter_wire_shape_is_unchanged_by_the_id_field` in
+    /// `stage_failed_5927_tests`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) indexes_stage_failed_ids: Option<Vec<String>>,
     /// Number of registered indexes with the KG component disabled
     /// (`skip_kg == true`) — issue #2984 Phase 1.
     ///
@@ -657,6 +694,9 @@ pub(super) async fn health_handler(
     // the stage lanes, so it can never disagree with the per-index
     // `corpus_open_failure` block on `GET /indexes/:id/status`.
     let mut indexes_corpus_failed = 0usize;
+    // #6688: name the failing indexes, not just count them — same scan, same
+    // `stages` read, same `any_failed()` predicate as the counter below.
+    let mut indexes_stage_failed_ids: Vec<String> = Vec::new();
     let indexes_stage_failed = state
         .registry
         .list_handles()
@@ -752,7 +792,13 @@ pub(super) async fn health_handler(
                             indexes_stuck_mid_walk += 1;
                         }
                     }
-                    stages.any_failed()
+                    let failed = stages.any_failed();
+                    if failed {
+                        // #6688: recorded from the same `any_failed()` the
+                        // counter is derived from, so the two cannot diverge.
+                        indexes_stage_failed_ids.push(handle.id.to_string());
+                    }
+                    failed
                 }
                 Err(_) => {
                     indexes_health_scan_skipped += 1;
@@ -765,6 +811,19 @@ pub(super) async fn health_handler(
             }
         })
         .count();
+    // #6688: stable order — the registry is a `DashMap` and iterates arbitrarily.
+    indexes_stage_failed_ids.sort_unstable();
+    debug_assert_eq!(
+        indexes_stage_failed_ids.len(),
+        indexes_stage_failed,
+        "#6688: the id list and indexes_stage_failed come from one predicate in one scan"
+    );
+    // #6688: absent rather than `[]` on a healthy daemon — see the field's doc.
+    let indexes_stage_failed_ids = if indexes_stage_failed_ids.is_empty() {
+        None
+    } else {
+        Some(indexes_stage_failed_ids)
+    };
     warmboot_summary.indexes_corpus_failed = indexes_corpus_failed;
     warmboot_summary.indexes_stage_failed = indexes_stage_failed;
     warmboot_summary.indexes_health_scan_skipped = indexes_health_scan_skipped;
@@ -891,6 +950,8 @@ pub(super) async fn health_handler(
         indexes_empty,
         total_chunks,
         warmboot_summary,
+        // #6688: which indexes the counter above is about.
+        indexes_stage_failed_ids,
         boot_reconcile,
         indexes_watcher_network_degraded,
         embedder_bootstrap,
@@ -1042,20 +1103,6 @@ pub(super) fn recompute_warm_boot_degraded(state: &SearchAppState) -> bool {
     conclusive
 }
 
-/// Request body for `POST /upgrade` (issue #537).
-///
-/// Why: typed body avoids raw JSON field extraction in the handler, and serde
-/// provides friendly error messages for malformed requests.
-/// What: mirrors the MCP tool schema: `check` (default true) and `confirm`.
-/// Test: the MCP `upgrade` tool calls this endpoint.
-#[derive(Deserialize)]
-pub(super) struct UpgradeRequest {
-    #[serde(default = "bool_true")]
-    check: bool,
-    #[serde(default)]
-    confirm: bool,
-}
-
 /// The `/health` body, for a caller that is not an axum route (#6285).
 ///
 /// Why: `search.health` over the UDS socket and `GET /health` must never be
@@ -1074,103 +1121,6 @@ pub(crate) async fn health_report(state: Arc<SearchAppState>) -> serde_json::Val
     serde_json::to_value(resp).unwrap_or_else(
         |e| serde_json::json!({ "status": "error", "error": format!("serialize health: {e}") }),
     )
-}
-
-/// `POST /upgrade` — check for or install a new trusty-search version (issue #537).
-///
-/// Why: Exposes the upgrade workflow over HTTP so the MCP dispatcher (which
-/// calls the daemon's REST API) can trigger an upgrade and receive the response
-/// before the daemon self-exits. Never silently auto-installs.
-///
-/// What:
-/// - `check=true` or `confirm=false`: query crates.io and return version info.
-/// - `confirm=true`: install via `cargo install --locked`, health-gate, then
-///   schedule a 500 ms delayed exit (to flush this response) and return the
-///   result. When launchd-supervised the daemon exits non-zero so launchd
-///   respawns with the new binary. When unsupervised a restart hint is returned.
-///
-/// Test: manual via `curl -X POST http://127.0.0.1:$(trusty-search port)/upgrade \
-///  -H 'Content-Type: application/json' -d '{"check":true}'`.
-pub(super) async fn upgrade_handler(
-    State(state): State<Arc<SearchAppState>>,
-    Json(body): Json<UpgradeRequest>,
-) -> Json<serde_json::Value> {
-    let crate_name = env!("CARGO_PKG_NAME");
-    let current = env!("CARGO_PKG_VERSION");
-
-    let info = trusty_common::update::check_crates_io(crate_name, current).await;
-
-    let (latest, is_update) = match &info {
-        Some(u) => (u.latest.as_str(), true),
-        None => (current, false),
-    };
-
-    if body.check || !body.confirm {
-        let msg = if is_update {
-            format!(
-                "Update available: {crate_name} {latest} (you have {current}). \
-                 POST with confirm=true to install."
-            )
-        } else {
-            format!("{crate_name} {current} is already up to date.")
-        };
-        return Json(serde_json::json!({
-            "status": "checked",
-            "current": current,
-            "latest": latest,
-            "update_available": is_update,
-            "message": msg
-        }));
-    }
-
-    if !is_update {
-        return Json(serde_json::json!({
-            "status": "up_to_date",
-            "current": current,
-            "message": format!("{crate_name} {current} is already up to date.")
-        }));
-    }
-
-    let latest_owned = latest.to_string();
-    let crate_name_owned = crate_name.to_string();
-    let update_slot = state.update_available.clone();
-    let response = serde_json::json!({
-        "status": "installing",
-        "current": current,
-        "latest": latest_owned,
-        "message": format!(
-            "Installing {crate_name} {latest_owned} — daemon will restart \
-             under launchd (or print a restart hint if not supervised)."
-        )
-    });
-
-    // Spawn the install on a delayed task so this handler can return the
-    // response to the HTTP client (and thus to the MCP caller) before the
-    // process might exit. 500 ms gives the TCP stack time to flush.
-    tokio::spawn(async move {
-        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-        match trusty_common::update::upgrade_and_restart(&crate_name_owned, &crate_name_owned).await
-        {
-            Ok(Some(hint)) => {
-                tracing::info!("{hint}");
-                eprintln!("{hint}");
-            }
-            Ok(None) => {}
-            Err(e) => {
-                tracing::error!("upgrade_and_restart failed: {e:#}");
-                eprintln!("[trusty-search] upgrade failed: {e:#}");
-                if let Ok(mut g) = update_slot.lock() {
-                    *g = None;
-                }
-            }
-        }
-    });
-
-    Json(response)
-}
-
-fn bool_true() -> bool {
-    true
 }
 
 #[cfg(test)]

--- a/crates/trusty-search/src/service/server/mod.rs
+++ b/crates/trusty-search/src/service/server/mod.rs
@@ -44,6 +44,8 @@ mod state_impl;
 mod status;
 mod tickers;
 mod typeahead;
+// #6688: `POST /upgrade`, split out of `health.rs` when it crossed the cap.
+mod upgrade;
 
 // cfg(test) sub-modules — each < 500 lines
 #[cfg(test)]
@@ -197,7 +199,7 @@ pub use typeahead::{
     typeahead_handler as typeahead_handler_for_tests, TypeaheadParams as TypeaheadParamsForTests,
 };
 
-use self::health::upgrade_handler;
+use self::upgrade::upgrade_handler;
 
 // #6285: the one seam `service::socket` reads the health report through, so the
 // socket and `GET /health` cannot report different things.

--- a/crates/trusty-search/src/service/server/stage_failed_5927_tests.rs
+++ b/crates/trusty-search/src/service/server/stage_failed_5927_tests.rs
@@ -228,3 +228,228 @@ async fn health_stays_degraded_when_the_corpus_flag_read_is_contended() {
          'ok' while a lane is dead"
     );
 }
+
+/// #6688: `/health` must name the indexes whose lanes failed, not only count
+/// them.
+///
+/// Why: `indexes_stage_failed: 1` on a 41-index daemon told a consumer nothing
+/// about WHICH index was broken, so per-index remediation had to poll
+/// `GET /indexes/:id/status` for every registration to find it. Against the
+/// pre-#6688 implementation this test fails on the first assertion — the key
+/// does not exist.
+/// What: registers three indexes, fails a lane on two of them (a semantic-lane
+/// failure and a corpus-open failure, the two shapes #5927 separated), and
+/// asserts the id array names exactly those two, sorted, with a length equal to
+/// the counter it is derived from.
+/// Test: this IS the test.
+#[tokio::test]
+async fn health_names_the_indexes_with_a_failed_lane() {
+    use crate::service::warm_boot::{derive_warm_boot_stages, WarmBootInputs};
+
+    let (registry, semantic_failed) = registry_with_one_index("zeta-semantic-6688");
+    {
+        let mut stages = semantic_failed.stages.write().await;
+        stages.semantic = StageState::failed("embed backend unreachable".to_string());
+    }
+
+    let corpus_failed = registry.register(IndexHandle::bare(
+        IndexId::new("alpha-corpus-6688"),
+        Arc::new(RwLock::new(CodeIndexer::new(
+            "alpha-corpus-6688",
+            "/tmp/alpha-corpus-6688",
+        ))),
+        "/tmp/alpha-corpus-6688".into(),
+    ));
+    {
+        let mut indexer = corpus_failed.indexer.write().await;
+        indexer.corpus_open_failed = true;
+    }
+    {
+        let mut stages = corpus_failed.stages.write().await;
+        *stages = derive_warm_boot_stages(WarmBootInputs {
+            chunk_count: 1_000,
+            hnsw_snapshot_ready: true,
+            graph_node_count: 10,
+            lexical_only: false,
+            skip_kg: false,
+            skip_vector: false,
+            corpus_open_failure: Some(crate::core::corpus::CorpusOpenFailure::FormatIncompatible),
+        });
+    }
+
+    // A third, entirely healthy index that must NOT appear in the list.
+    registry.register(IndexHandle::bare(
+        IndexId::new("mid-healthy-6688"),
+        Arc::new(RwLock::new(CodeIndexer::new(
+            "mid-healthy-6688",
+            "/tmp/mid-healthy-6688",
+        ))),
+        "/tmp/mid-healthy-6688".into(),
+    ));
+
+    let state = Arc::new(SearchAppState::new(registry));
+    let Json(resp) = health_handler(State(state)).await;
+    let json: Value = serde_json::to_value(&resp).expect("serialize /health response");
+
+    let ids = json["indexes_stage_failed_ids"]
+        .as_array()
+        .unwrap_or_else(|| panic!("#6688: /health must carry the failing index ids; json={json}"));
+    let ids: Vec<&str> = ids.iter().filter_map(Value::as_str).collect();
+    assert_eq!(
+        ids,
+        vec!["alpha-corpus-6688", "zeta-semantic-6688"],
+        "#6688: exactly the two indexes with a failed lane, sorted — the healthy one must \
+         not appear; json={json}"
+    );
+    assert_eq!(
+        ids.len() as u64,
+        json["warmboot_summary"]["indexes_stage_failed"]
+            .as_u64()
+            .unwrap_or_default(),
+        "#6688: the ids and the counter come from one predicate in one scan, so their \
+         cardinalities must agree; json={json}"
+    );
+}
+
+/// #6688: the id array must be ABSENT from the serialized JSON when no index is
+/// failing — not `null`, not `[]`.
+///
+/// Why: that absence is the entire back-compat contract
+/// `skip_serializing_if = "Option::is_none"` buys. A consumer built against an
+/// older daemon must see a payload it already parses, and the healthy-path
+/// payload is what it sees almost always. Asserting on the STRUCT would prove
+/// nothing here — only the serialized output shows whether the key is emitted.
+/// What: polls `/health` against a registry whose one index has no failed lane
+/// and asserts the key is missing from the JSON object.
+/// Test: this IS the test.
+#[tokio::test]
+async fn health_omits_the_failing_index_ids_when_nothing_is_failing() {
+    let (registry, _handle) = registry_with_one_index("healthy-6688");
+
+    let state = Arc::new(SearchAppState::new(registry));
+    let Json(resp) = health_handler(State(state)).await;
+    let json: Value = serde_json::to_value(&resp).expect("serialize /health response");
+
+    assert_eq!(
+        json["warmboot_summary"]["indexes_stage_failed"].as_u64(),
+        Some(0),
+        "precondition: nothing is failing on this daemon; json={json}"
+    );
+    assert!(
+        json.get("indexes_stage_failed_ids").is_none(),
+        "#6688: the key must be ABSENT (not null, not []) when no index is failing — that \
+         is what keeps an older consumer's parse working; json={json}"
+    );
+}
+
+/// #6688: adding the id array must not move, rename, retype, or drop any
+/// counter the response already carried.
+///
+/// Why: the point of an additive optional field is that consumers can lag. Nine
+/// consumers read this payload today and none of them must change in this PR;
+/// `warm_boot_summary_wire_shape_is_pinned`
+/// (`crates/trusty-review/src/integrations/health.rs`) pins the nested
+/// `warmboot_summary` object from the other side of the workspace. This test
+/// pins the TOP-LEVEL keys from inside trusty-search, which that test does not
+/// reach.
+/// What: polls `/health` on a healthy daemon and asserts every pre-#6688
+/// top-level key is still present with its original JSON type, that the
+/// previously-absent optional keys are still absent, and that the response
+/// carries no key this pin does not name.
+/// Test: this IS the test.
+#[tokio::test]
+async fn health_counter_wire_shape_is_unchanged_by_the_id_field() {
+    let (registry, _handle) = registry_with_one_index("wire-shape-6688");
+
+    let state = Arc::new(SearchAppState::new(registry));
+    let Json(resp) = health_handler(State(state)).await;
+    let json: Value = serde_json::to_value(&resp).expect("serialize /health response");
+    let obj = json
+        .as_object()
+        .unwrap_or_else(|| panic!("#6688: /health must serialize to an object; json={json}"));
+
+    // Every key a pre-#6688 daemon emitted on this path (healthy index, no
+    // embedder installed, no boot reconcile), with the JSON type each one had.
+    let expected: &[(&str, &str)] = &[
+        ("status", "string"),
+        ("version", "string"),
+        ("indexes", "number"),
+        ("uptime_secs", "number"),
+        ("embedder", "string"),
+        ("embedder_recent_timeout_count", "number"),
+        ("rss_mb", "number"),
+        ("rss_limit_mb", "number"),
+        ("disk_bytes", "number"),
+        ("cpu_pct", "number"),
+        ("background_reindex_queue_depth", "number"),
+        ("deferred_embed_queue_depth", "number"),
+        ("warmboot_summary", "object"),
+        ("indexes_kg_disabled", "number"),
+        ("indexes_vector_disabled", "number"),
+        ("indexes_component_catch_up_in_progress", "number"),
+        ("indexes_embed_pool_missing", "number"),
+        ("indexes_stuck_empty", "number"),
+        ("indexes_stuck_mid_walk", "number"),
+        ("indexes_populated", "number"),
+        ("indexes_empty", "number"),
+        ("total_chunks", "number"),
+        ("indexes_watcher_network_degraded", "number"),
+        ("embedder_bootstrap", "string"),
+    ];
+    for (key, kind) in expected {
+        let value = obj
+            .get(*key)
+            .unwrap_or_else(|| panic!("#6688: pre-existing key `{key}` was dropped; json={json}"));
+        let actual = match value {
+            Value::String(_) => "string",
+            Value::Number(_) => "number",
+            Value::Object(_) => "object",
+            Value::Array(_) => "array",
+            Value::Bool(_) => "bool",
+            Value::Null => "null",
+        };
+        assert_eq!(
+            actual, *kind,
+            "#6688: pre-existing key `{key}` changed JSON type; json={json}"
+        );
+    }
+    for key in [
+        "embedder_error",
+        "embedder_last_ok_secs_ago",
+        "embedder_info",
+        "embedderd_rss_mb",
+        "update_available",
+        "boot_reconcile",
+        // The new field, absent on this healthy path for the same reason.
+        "indexes_stage_failed_ids",
+    ] {
+        assert!(
+            obj.get(key).is_none(),
+            "#6688: `{key}` must stay absent on a healthy daemon; json={json}"
+        );
+    }
+    assert_eq!(
+        obj.len(),
+        expected.len(),
+        "#6688: /health emitted a key this pin does not name — an unreviewed wire change; \
+         json={json}"
+    );
+
+    // The nested counters trusty-review pins from the other side.
+    let summary = warmboot_summary_of(&resp);
+    for key in [
+        "indexes_stage_failed",
+        "indexes_corpus_failed",
+        "indexes_health_scan_skipped",
+    ] {
+        assert!(
+            summary[key].is_number(),
+            "#6688: `warmboot_summary.{key}` must remain a number; summary={summary}"
+        );
+    }
+    assert_eq!(
+        summary["warm_boot_degraded"].as_bool(),
+        Some(false),
+        "#6688: adding a field must not change the degraded verdict; summary={summary}"
+    );
+}

--- a/crates/trusty-search/src/service/server/tests_stall.rs
+++ b/crates/trusty-search/src/service/server/tests_stall.rs
@@ -163,6 +163,8 @@ fn health_response_contains_stall_fields() {
         indexes_empty: 0,
         total_chunks: 0,
         warmboot_summary: WarmBootSummary::default(),
+        // #6688: nothing is failing in either fixture — the field is absent.
+        indexes_stage_failed_ids: None,
         boot_reconcile: None,
         indexes_watcher_network_degraded: 0,
         embedder_bootstrap: "n/a",
@@ -227,6 +229,8 @@ fn health_response_omits_last_ok_when_none() {
         indexes_empty: 0,
         total_chunks: 0,
         warmboot_summary: WarmBootSummary::default(),
+        // #6688: nothing is failing in either fixture — the field is absent.
+        indexes_stage_failed_ids: None,
         boot_reconcile: None,
         indexes_watcher_network_degraded: 0,
         embedder_bootstrap: "n/a",

--- a/crates/trusty-search/src/service/server/upgrade.rs
+++ b/crates/trusty-search/src/service/server/upgrade.rs
@@ -1,0 +1,127 @@
+//! `POST /upgrade` handler.
+//!
+//! Why: split out of `health.rs` in #6688, which pushed that file past the
+//! 500-SLOC production cap. The two endpoints shared a file only by history —
+//! `/health` is a 2s-interval probe and `/upgrade` drives `cargo install` and a
+//! self-restart, and nothing but the axum `State` type is common to them.
+//! What: `upgrade_handler` and its typed request body, moved verbatim.
+//! Test: unchanged by the move — the handler reaches crates.io and `cargo
+//! install`, so its coverage is the MCP `upgrade` tool's end-to-end path and
+//! the manual `curl` in `upgrade_handler`'s own doc.
+use axum::extract::State;
+use axum::Json;
+use serde::Deserialize;
+use std::sync::Arc;
+
+use super::state::SearchAppState;
+
+/// Request body for `POST /upgrade` (issue #537).
+///
+/// Why: typed body avoids raw JSON field extraction in the handler, and serde
+/// provides friendly error messages for malformed requests.
+/// What: mirrors the MCP tool schema: `check` (default true) and `confirm`.
+/// Test: the MCP `upgrade` tool calls this endpoint.
+#[derive(Deserialize)]
+pub(super) struct UpgradeRequest {
+    #[serde(default = "bool_true")]
+    check: bool,
+    #[serde(default)]
+    confirm: bool,
+}
+
+/// `POST /upgrade` — check for or install a new trusty-search version (issue #537).
+///
+/// Why: Exposes the upgrade workflow over HTTP so the MCP dispatcher (which
+/// calls the daemon's REST API) can trigger an upgrade and receive the response
+/// before the daemon self-exits. Never silently auto-installs.
+///
+/// What:
+/// - `check=true` or `confirm=false`: query crates.io and return version info.
+/// - `confirm=true`: install via `cargo install --locked`, health-gate, then
+///   schedule a 500 ms delayed exit (to flush this response) and return the
+///   result. When launchd-supervised the daemon exits non-zero so launchd
+///   respawns with the new binary. When unsupervised a restart hint is returned.
+///
+/// Test: manual via `curl -X POST http://127.0.0.1:$(trusty-search port)/upgrade \
+///  -H 'Content-Type: application/json' -d '{"check":true}'`.
+pub(super) async fn upgrade_handler(
+    State(state): State<Arc<SearchAppState>>,
+    Json(body): Json<UpgradeRequest>,
+) -> Json<serde_json::Value> {
+    let crate_name = env!("CARGO_PKG_NAME");
+    let current = env!("CARGO_PKG_VERSION");
+
+    let info = trusty_common::update::check_crates_io(crate_name, current).await;
+
+    let (latest, is_update) = match &info {
+        Some(u) => (u.latest.as_str(), true),
+        None => (current, false),
+    };
+
+    if body.check || !body.confirm {
+        let msg = if is_update {
+            format!(
+                "Update available: {crate_name} {latest} (you have {current}). \
+                 POST with confirm=true to install."
+            )
+        } else {
+            format!("{crate_name} {current} is already up to date.")
+        };
+        return Json(serde_json::json!({
+            "status": "checked",
+            "current": current,
+            "latest": latest,
+            "update_available": is_update,
+            "message": msg
+        }));
+    }
+
+    if !is_update {
+        return Json(serde_json::json!({
+            "status": "up_to_date",
+            "current": current,
+            "message": format!("{crate_name} {current} is already up to date.")
+        }));
+    }
+
+    let latest_owned = latest.to_string();
+    let crate_name_owned = crate_name.to_string();
+    let update_slot = state.update_available.clone();
+    let response = serde_json::json!({
+        "status": "installing",
+        "current": current,
+        "latest": latest_owned,
+        "message": format!(
+            "Installing {crate_name} {latest_owned} — daemon will restart \
+             under launchd (or print a restart hint if not supervised)."
+        )
+    });
+
+    // Spawn the install on a delayed task so this handler can return the
+    // response to the HTTP client (and thus to the MCP caller) before the
+    // process might exit. 500 ms gives the TCP stack time to flush.
+    tokio::spawn(async move {
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        match trusty_common::update::upgrade_and_restart(&crate_name_owned, &crate_name_owned).await
+        {
+            Ok(Some(hint)) => {
+                tracing::info!("{hint}");
+                eprintln!("{hint}");
+            }
+            Ok(None) => {}
+            Err(e) => {
+                tracing::error!("upgrade_and_restart failed: {e:#}");
+                eprintln!("[trusty-search] upgrade failed: {e:#}");
+                if let Ok(mut g) = update_slot.lock() {
+                    *g = None;
+                }
+            }
+        }
+    });
+
+    Json(response)
+}
+
+fn bool_true() -> bool {
+    true
+}


### PR DESCRIPTION
`/health` reported failing-index COUNTS with no ids, so no consumer could tell which index failed. It now also carries `indexes_stage_failed_ids`, an optional array, omitted entirely when nothing is failing.

Refs #6688

**Placement and SemVer.** The field is on the `pub(super)` `HealthResponse`, which is not public API and therefore invisible to `cargo-semver-checks`. It was deliberately NOT put on `WarmBootSummary`, which is `pub`, reachable, and not `#[non_exhaustive]` — a field there would be a MINOR semver event and would break external exhaustive construction.

**Predicate.** "failing" is `IndexStages::any_failed()` — exactly what `indexes_stage_failed` counts, read from the same `handle.stages` in the same scan, so counter and ids can never disagree (including under the fail-open arm, where a contended lock skips a handle from both and increments `indexes_health_scan_skipped`). Deliberately not unioned with `corpus_open_failed`: that flag marks every lane `Failed`, so those indexes are already named by their lanes, and folding it in would name indexes no counter counts.

**Consumers can lag.** Nine `/health` consumers were surveyed; none breaks. Every typed mirror uses `#[serde(default)]`, none uses `deny_unknown_fields`, and no consumer round-trips the payload. `trusty-review`'s `warm_boot_summary_wire_shape_is_pinned` passes unmodified — `cargo test -p trusty-review --no-fail-fast` was run as part of this change's gates and is green (2220 passed).

**Test ladder rung 6** (HTTP route change), with results:
```
cargo fmt --check                                            0
cargo check -p trusty-search --all-targets                   0
cargo clippy -p trusty-search --all-targets -- -D warnings   0
cargo test -p trusty-search --no-fail-fast                   0   (34 targets, 2488 passed, 0 failed, 41 ignored)
cargo test -p trusty-review --no-fail-fast                   0   (2220 passed, 0 failed, 5 ignored)
cargo check --workspace                                      0
bash scripts/check_line_cap.sh                               0   (4408 tracked .rs files, 0 violations)
bash scripts/check_changelog_fragment.sh                     0
bash scripts/check_sld.sh                                    0
bash scripts/check_test_pointers.sh                          0   (29920 citations, 0 dangling)
```

**Binary smoke evidence** — rung 6 requires direct API evidence, so both payloads are included. A debug binary ran on port 17878 against scratch dirs; two throwaway indexes were created, one's redb corpus corrupted, the daemon restarted. Failing state:
```json
"warmboot_summary": { "warm_boot_degraded": true, "indexes_corpus_failed": 1, "indexes_stage_failed": 1 },
"indexes_stage_failed_ids": ["smoke-broken-6688"]
```
The healthy sibling is not listed. After deleting the broken index, the same daemon returns `"status": "ok"` with the key **absent** — not `null`, not `[]`. Scratch dirs removed; the installed daemon on 7878 was never touched.

**Reviewer note on diff size.** Adding the field pushed `health.rs` to 508 SLOC over the 500 production cap, so `POST /upgrade` (`UpgradeRequest`, `upgrade_handler`, `bool_true`) moved verbatim into a new `crates/trusty-search/src/service/server/upgrade.rs` in this same commit, per the repo's no-standalone-SLOC-fix rule. 127 of the added lines are that move; nothing in it changed.

New tests in `stage_failed_5927_tests`: ids present and correct, key absent from the SERIALIZED JSON when nothing fails, and a wire-shape test pinning every pre-#6688 top-level key with its JSON type plus the total key count.

Changelog fragment: `crates/trusty-search/changelog.d/6688-health-failing-index-ids.md`.

Unblocks #6689.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
