### PR TITLE
fix(docs): resolve the five intra-doc links that fail the pre-publish rustdoc and contracts gates

### DIFF
--- a/crates/trusty-common/CHANGELOG.md
+++ b/crates/trusty-common/CHANGELOG.md
@@ -250,6 +250,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   the linter, which has a `file:line` to report it at. Safe, repo-root-relative
   paths behave exactly as before.
 - The kg.redb compaction swap now excludes every writer, not just the ones holding the palace write mutex (#6652). `KgWriter`'s actor commits on a blocking thread holding only `Arc<KgStoreRedb>`, so `KnowledgeGraph::assert`/`retract` — and everything behind them — never took that mutex; a commit landing between the swap's fingerprint re-check and its rename went to the inode the rename was about to unlink, and the caller was told it succeeded. Every kg.redb write transaction now rides a per-store `swap_lock` that the swap takes exclusively across the re-check, the rename, and the handle install.
+- Two intra-doc links that rustdoc could not resolve, so the pre-publish gate is
+  green again: `launchd_claim`'s reference to the macOS-gated `launchd` module,
+  which does not exist on the Linux runner that builds the docs, and
+  `github_path`'s `RemoteRepo` / `parse_remote_url` mentions, which had no link
+  reference definition alongside the module's other three (#6693).
 
 ### Changed
 

--- a/crates/trusty-common/src/github_path.rs
+++ b/crates/trusty-common/src/github_path.rs
@@ -35,6 +35,8 @@
 //! [`GithubPath`]: crate::github_path::GithubPath
 //! [`parse_github_path`]: crate::github_path::parse_github_path
 //! [`derive_github_path`]: crate::github_path::derive_github_path
+//! [`RemoteRepo`]: crate::github_path::RemoteRepo
+//! [`parse_remote_url`]: crate::github_path::parse_remote_url
 
 use std::path::Path;
 use std::process::Command;

--- a/crates/trusty-common/src/lib.rs
+++ b/crates/trusty-common/src/lib.rs
@@ -268,8 +268,10 @@ pub mod launchd_restart;
 /// onto the production path without the plist's environment.
 /// What: [`launchd_claim::socket_owner`] decides from the registration signals,
 /// and [`launchd_claim::launchd_socket_owner`] reads them off the real launchd.
-/// Deliberately NOT macOS-gated, unlike [`launchd`], so cross-platform daemon
+/// Deliberately NOT macOS-gated, unlike `launchd`, so cross-platform daemon
 /// guards call it without a `cfg` split — off macOS it answers "no unit".
+/// (`launchd` is named here, not linked: it is macOS-gated, so a link to it
+/// breaks on the Linux runner that documents this crate.)
 /// Test: `cargo test -p trusty-common --features unconditional-only launchd_claim`.
 pub mod launchd_claim;
 

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -358,6 +358,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   logs to the wrong AWS account, which is the requirement the override exists to
   satisfy. The tick reports `Failed`, the failing destination is named in the
   doctor row, and every other destination still drains.
+- Two intra-doc links that rustdoc could not resolve, so the pre-publish gate is
+  green again: `project_tier_agent_strays`' link to the private
+  `session_launch::quarantine_shadows` module, and a bare `argv[0]` in
+  `guided_outside_git` that markdown read as a link (#6693).
 
 ### Changed
 

--- a/crates/trusty-mpm/src/bin/tm/commands/guided_outside_git.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_outside_git.rs
@@ -300,7 +300,7 @@ pub(crate) async fn try_outside_git(
 /// `SessionAction` means the promise is kept by construction — a wrong flag
 /// would fail to parse rather than silently run something else — and nothing
 /// is spawned as a subprocess.
-/// What: prepends the `tm` argv[0] clap expects, parses, and calls
+/// What: prepends the `tm` `argv[0]` clap expects, parses, and calls
 /// [`crate::commands::session::session`]. Any other parsed command is an
 /// internal bug and returns `Err`.
 /// Test: `outside_git_dispatch_rejects_a_non_session_argv`; the happy paths are

--- a/crates/trusty-mpm/src/core/project_tier_agent_strays.rs
+++ b/crates/trusty-mpm/src/core/project_tier_agent_strays.rs
@@ -64,9 +64,10 @@ const SWEEP_WHAT: &str = "remove stray bundled agent copies from the project tie
 ///
 /// Why: spelled out from `project_dir` rather than taken from
 /// `paths.claude_agents_dir()`, for the reason
-/// [`crate::core::session_launch::quarantine_shadows`] states at length — those
+/// `core::session_launch::quarantine_shadows` states at length — those
 /// are the same directory for a managed layout and the operator's own
-/// `~/.claude/agents` for a home-tier one.
+/// `~/.claude/agents` for a home-tier one. (Named here, not linked: that module
+/// is private, so a link to it breaks the rustdoc gate.)
 /// Test: `a_tier_bundled_agents_deploy_to_is_never_swept`.
 pub fn project_agent_tier(project_dir: &Path) -> PathBuf {
     project_dir.join(".claude").join("agents")


### PR DESCRIPTION
## Baseline

A release-time PR fixing pre-publish gate failures on intra-doc links. During the release window, changelog fragments have been merged into the final `## [0.47.1]` and `## [1.5.16]` CHANGELOG.md entries; no per-PR fragments apply here.

## Outcome

Pre-publish gate run 33678146807 at 2e899e93b failed Gate 1 (check_rustdoc_links.sh) and Gate 5 (check_contracts.sh --crate trusty-common) on broken intra-doc links. This PR resolves them so the release train can pass.

## Changes

- trusty-common lib.rs: de-linked launchd_claim doc (cfg-gated target)
- trusty-common github_path.rs: adds the two missing link reference definitions for RemoteRepo and parse_remote_url
- trusty-mpm project_tier_agent_strays.rs: de-links the private quarantine_shadows
- trusty-mpm guided_outside_git.rs: backticks `argv[0]` (fifth link, landed by #6672 after the gate ran)

## Risk

Low, doc comments only.

## Tests

Rung 1; `bash scripts/check_rustdoc_links.sh` → 26 crates, 0 broken links; `bash scripts/check_contracts.sh --crate trusty-common` → 15 contracts extracted, OK (nightly); fmt/clippy clean for both crates; check_line_cap, check_test_pointers, check_sld OK. Changelog assembled and verified.

## Docs

None.

## Review

None required.

Refs #5973
Refs #6693

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
