### PR TITLE
chore(sessions): commit tm-trusty-tools-02 pause snapshot 2026-09-02 21:03Z

### DIFF
--- a/.trusty-mpm/sessions/sessions-log.jsonl
+++ b/.trusty-mpm/sessions/sessions-log.jsonl
@@ -78,3 +78,4 @@
 {"session_id":"tm-trusty-tools-02-0-at2307-20260902","event":"pause","snapshot":"tm-trusty-tools-02-0-at2307-20260902/session-20260902-033112.md","timestamp":"2026-09-02T03:31:12.708286+00:00"}
 {"session_id":"tm-trusty-tools-02-0-at2307-20260902","event":"pause","snapshot":"tm-trusty-tools-02-0-at2307-20260902/session-20260902-111042.md","timestamp":"2026-09-02T11:10:42.983115+00:00"}
 {"session_id":"tm-trusty-tools-02-0-at2307-20260902","event":"pause","snapshot":"tm-trusty-tools-02-0-at2307-20260902/session-20260902-162807.md","timestamp":"2026-09-02T16:28:07.264636+00:00"}
+{"session_id":"tm-trusty-tools-02-0-at5288-20260902","event":"pause","snapshot":"tm-trusty-tools-02-0-at5288-20260902/session-20260902-210316.md","timestamp":"2026-09-02T21:03:16.995522+00:00"}

--- a/.trusty-mpm/sessions/tm-trusty-tools-02-0-at5288-20260902/session-20260902-210316.md
+++ b/.trusty-mpm/sessions/tm-trusty-tools-02-0-at5288-20260902/session-20260902-210316.md
@@ -1,0 +1,40 @@
+# Session Pause - 2026-09-02T21:03:16.995522+00:00
+
+## Summary
+Paused 2026-09-02 ~22:10Z, owner-invoked, leg 4 (resumed 18:35Z from session-20260902-162807.md). ZERO agents in flight; ONE monitor live (bm98dlcum: main ci.yml run 33682596938 at 53eeca482, in_progress at pause). Main checkout still parked on codex/documentation-inventory-2026-09-02 @ 1e4c2397f (merged via #6655; do NOT commit or checkout there; it is why `tm issue states` shows the unicorn model — owner decision to return it to main). origin/main = 53eeca482.
+
+🔴 OWNER AUTHORIZATION LIVE, verbatim: "publish and install, then clean up the worktrees" (~20:40Z). NOTHING TAGGED, PUBLISHED, OR INSTALLED YET. Two pre-publish blockers cleared: PR #6693 (changelog assembly for 13 crates, 2e899e93b) and PR #6696 (five intra-doc links that failed Gate 1 rustdoc + Gate 5 contracts, squash 53eeca482). Gate run 33678146807 at 2e899e93b failed on those links plus the ci-parity race (dispatched before main CI finished). 13 crates to publish, versions FINAL on main, no bumps: trusty-common 0.47.1 (0.x MINOR = breaking; semver CHECK 5 passed at c44044671), trusty-agents-common 0.6.3, trusty-memory 0.25.6, trusty-search 0.52.0, trusty-console 0.9.3, trusty-analyze 0.12.5, trusty-review 0.31.2, trusty-audit 0.13.0, trusty-installer 0.13.4, tga 5.0.3, trusty-code 0.5.1, trusty-code-tui 0.1.1, trusty-mpm 1.5.16. Computed order (publish-dry-run-order.sh): trusty-agents-common, trusty-code-tui, trusty-common, tga, trusty-code, trusty-console, trusty-installer, trusty-audit, trusty-memory, trusty-review, trusty-search, trusty-analyze, trusty-mpm.
+
+DONE THIS LEG: #6677 #6649 #6669 closed status:tested (PRs #6682 #6683 #6680 #6690); #6684 closed not-planned; #6691 filed (synthesis prose vs table); #6695 filed (fragment-gate vs assembled-gate contradiction); #5973 REOPENED (no per-PR rustdoc gate); #6556 commented. Installed+Developer-ID signed from main 9023b2ac0: tm 1.5.16, trusty-analyze 0.12.5 (+review feature), trusty-audit 0.13.0, trusty-review 0.31.2 — these are the unpublished workspace builds. CAST combined test ran twice (runbook merged #6690). 20 agent worktrees removed today; remaining: agent-addd80fd0a7b12b70 (PR #6607 DOC-72 open, owner review), agent-a259bfb3a32b159ef (locked, unknown owner), agent-a60e12861bbce07b6 (feat/6657 @ 7e9928a81, ancestor of merged #6676 head, 1605 files deleted on disk — HOLD).
+
+LESSONS RECORDED: worktree removal is PM-executed (#5791) — never brief agents to remove; `--merge` assembler folds fragments after a cut; dispatch the pre-publish gate only after main ci.yml for the SHA is green; never SendMessage a train agent whose worktree may be reclaimed — fresh isolation dispatch.
+
+## Completed
+- #6677 root_path index resolution: PR #6682 merged 9023b2ac0, live-verified, closed status:tested
+- #6649 startup asset-tier checks: PR #6683 merged d0e884382, tm doctor shows asset_tier + asset_duplicates, closed status:tested
+- #6669 CAST epic: PRs #6680 #6682 #6690 merged; two live runs (3m43s without --analyze, 5m26s with); closed status:tested
+- Four binaries Developer-ID signed from main 9023b2ac0 (tm, trusty-analyze +review, trusty-audit, trusty-review via new inode)
+- PR #6693 changelog assembly for 13 crates merged 2e899e93b
+- PR #6696 five intra-doc links fixed, merged 53eeca482
+- Issues: #6684 closed not-planned; #6691 and #6695 filed; #5973 reopened; #6556 commented
+- 20 agent worktrees removed (11 by version-control under ADR-0057, 9 by the PM)
+
+## In Progress
+- [monitor bm98dlcum] main ci.yml run 33682596938 at 53eeca482 — in_progress at pause; emits MAIN_CI 53eeca482 <conclusion> when terminal
+- [PM] publish train: blocked only on (a) main CI green at 53eeca482, then (b) pre-publish gate green at 53eeca482 — neither dispatched yet
+
+## Next Steps
+- Verify main ci.yml run 33682596938 for 53eeca482 is completed success (`gh run view 33682596938 --json status,conclusion`); if the monitor died with the session, read it directly
+- local-ops (haiku): `gh workflow run pre-publish.yml --repo bobmatnyc/trusty-tools --ref main -f sha=53eeca482<full>`; report run id; PM arms ONE until-terminal Monitor on it
+- On gate SUCCESS: FRESH local-ops (opus, isolation:"worktree") runs the full train — Phase 0 identity bobmatnyc + publish-dry-run-order + version-parity; Phase 1 check-publish-ready + preflight-publish.sh --check-only for ALL 13 before any tag; Phase 2 per crate in order: dry-run → tag → push tag → preflight-publish.sh (full) → SKIP_UI_BUILD=1 cargo publish → check-tag-publish-parity --vcs-info auto → live-verify; Phase 3 install binaries present on this machine via signed scripts / cargo install (never cp), connection-safe bootout/bootstrap, trusty-search index trusty-tools-checkout chunk_count 103082 before/after. Stop rules: any gate FAIL stops that crate + downstream; report raw text; no overrides
+- On gate FAILURE: research classifies from --log-failed (race vs pre-existing vs new) before any fix; a fix PR must fold fragments with `assemble-changelog.sh --merge <crate> <version>` (see #6695) and expect the non-required 'Per-PR changelog fragment' check red
+- After publish+install: record RELEASE COMPLETE in palace slot release:trusty-tools/publish-state; remove the train worktree (PM-executed `git worktree remove --force` after clean-tree + ancestor checks); leave addd80fd (PR #6607), a259bfb3 (locked), a60e1286 (hold)
+- Owner decisions open: revoke leaked duetto-frontend PAT; tm doctor deployment/log_drain ❌ + hooks_contamination/stray ~/.mcp.json/legacy_sources ⚠️; return main checkout to `main`; review PR #6607; add changelog-fragment to required contexts (wedges open PRs; see #6695); whether trusty-review joins the signed-install program (release-workflow.md:841 excludes it)
+
+## Git Context
+Branch: codex/documentation-inventory-2026-09-02
+Last commit: 1e4c2397f docs: refresh workspace documentation inventory
+Uncommitted changes: 4 file(s) changed
+
+## Tmux Window
+tm-trusty-tools-02:0:@5288


### PR DESCRIPTION
## Outcome
Tracked session snapshot per the 2026-08-31 owner ruling

## Changes
Session files committed to .trusty-mpm/sessions/

## Risk
None, docs/state only

## Tests
Rung 1, none

## Baseline
N/A

## Docs
None

## Review
None

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
