### PR TITLE
feat(trusty-audit): distribute ships an instructions directory, a CAST template, and prompt-for-key packages

### DIFF
--- a/crates/trusty-audit/README.md
+++ b/crates/trusty-audit/README.md
@@ -394,6 +394,48 @@ variant; whether one should exist is deferred (#5495), not solved. The remedy
 today is to allow the GitHub release-asset host, or to ask for a package built
 for that network.
 
+## Building a handoff package for a recipient
+
+`trusty-audit distribute` writes the zip you send. It carries the `taudit`
+binary, a launcher that runs it from wherever the recipient extracts it, a
+generated `engagement.toml`, and an `instructions/` directory holding the
+sequence they run and a commented reference for every config key.
+
+The normal handover — a CAST-style report, no credential in the package, and
+the repository list already declared:
+
+```
+taudit distribute \
+  --config ./engagement-template.toml \
+  --template cast \
+  --prompt-for-key \
+  --repos ./client-repos.txt \
+  --out ~/duetto/audit
+```
+
+- `--prompt-for-key` ships no credential. The generated config carries a blank
+  `openrouter_key`, and the recipient's first `audit` asks for the key on the
+  terminal and saves it. Send the key separately. The flag beats both
+  `OPENROUTER_API_KEY` and the template's own key, so a variable left over from
+  an earlier command cannot bake one in. Omit it to keep the existing
+  behaviour, where the key is read from the environment or the template.
+- `--template cast` writes `[report] template = "cast"` and `code_only = true`
+  into the generated config — the CAST methodology, scoped to what a repository
+  checkout can prove. Omit it and the template's own `[report]` table decides.
+- `--repos <file>` pre-populates `[[targets]]`. It takes a `repos.txt` — one
+  `owner/name`, absolute checkout path, or GitHub URL per line, `#` starting a
+  comment — or a previous engagement's `engagement.toml`, whose `[[targets]]`
+  are reused. The recipient's `taudit audit` then audits exactly that list and
+  asks them to pick nothing; without it they register each repository
+  themselves.
+- `--binary <path>` ships a build for the recipient's platform instead of the
+  running one. The default is right when you are packaging for a machine like
+  yours.
+
+It refuses rather than overwriting a package already in the output directory,
+and a template's `[boards.*]` credentials never travel — they belong to
+whichever engagement they were set for.
+
 ## Sending the deliverable back
 
 `trusty-audit package` turns what the sweep produced into one file:

--- a/crates/trusty-audit/changelog.d/5483-distribute-instructions-and-prompt-for-key.md
+++ b/crates/trusty-audit/changelog.d/5483-distribute-instructions-and-prompt-for-key.md
@@ -1,0 +1,6 @@
+Added
+
+- `taudit distribute` ships an `instructions/` directory beside the binary: `instructions/README.md` is the numbered sequence the recipient runs — install, register, the one-shot `audit`, `package` — with the macOS Full Disk Access and quarantine notes and an "If something fails" section naming the log locations, and `instructions/engagement.template.toml` documents every config key with the CAST report preset set. The root `README.md` is now a pointer at them rather than a second copy of the sequence.
+- `taudit distribute --prompt-for-key` builds a package carrying no credential: the generated `engagement.toml` has a blank `openrouter_key`, and the recipient's first `audit` asks for the key on the terminal and saves it. The flag beats `OPENROUTER_API_KEY` and the template's own key, so a stale variable cannot bake one in.
+- `taudit distribute --template cast` writes `[report] template = "cast"` and `code_only = true` into the generated config, so the CAST-style report no longer needs a hand-edited template before every handoff.
+- `taudit distribute --repos <file>` pre-populates the package's `[[targets]]`, from a `repos.txt` list or a previous engagement's `engagement.toml`. The recipient's `taudit audit` then audits exactly that list and asks them to pick nothing.

--- a/crates/trusty-audit/src/cli.rs
+++ b/crates/trusty-audit/src/cli.rs
@@ -16,11 +16,11 @@
 
 use std::path::PathBuf;
 
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 
 use crate::chain::ChainOptions;
 use crate::clone::CloneOptions;
-use crate::distribute::DistributeOptions;
+use crate::distribute::{DistributeOptions, ReportPreset};
 use crate::registry::TargetKind;
 use crate::rerender::RerenderOptions;
 use crate::run::RunOptions;
@@ -67,6 +67,33 @@ pub struct Cli {
     /// Capability to run. Omit to enter the guided flow.
     #[command(subcommand)]
     pub verb: Option<Verb>,
+}
+
+/// The report preset `taudit distribute --template` accepts (#5483).
+///
+/// Why: a clap `ValueEnum` rather than a free-form string, so `--template cst`
+/// is a usage error naming the two accepted values instead of an engagement
+/// that renders a template nothing bundles. The set is deliberately narrow —
+/// this flag selects a PRESET, and an engagement wanting some other bundled
+/// template still writes `[report] template = "…"` in its own config.
+/// What: one variant per preset, converted into
+/// [`ReportPreset`](crate::distribute::ReportPreset) at the call site.
+/// Test: `super::cli_tests::the_cast_template_flag_selects_the_cast_preset`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum ReportTemplateArg {
+    /// CAST-style technical due diligence, scoped to the code.
+    Cast,
+    /// Leave the template's own `[report]` table in charge.
+    Default,
+}
+
+impl From<ReportTemplateArg> for ReportPreset {
+    fn from(arg: ReportTemplateArg) -> Self {
+        match arg {
+            ReportTemplateArg::Cast => ReportPreset::Cast,
+            ReportTemplateArg::Default => ReportPreset::Inherit,
+        }
+    }
 }
 
 /// One subcommand per capability.
@@ -199,6 +226,36 @@ pub enum Verb {
         /// platform instead.
         #[arg(long, value_name = "FILE")]
         binary: Option<PathBuf>,
+
+        /// Ship no OpenRouter key; the recipient is asked for one on first run.
+        ///
+        /// Use this whenever the key reaches the recipient out of band, which
+        /// is the normal handover — the package then carries a blank
+        /// `openrouter_key`, and the first `audit` asks for it on the terminal
+        /// and saves it. It beats `OPENROUTER_API_KEY` and the template's own
+        /// key, so a variable left over from an earlier command cannot bake one
+        /// in by accident.
+        #[arg(long)]
+        prompt_for_key: bool,
+
+        /// Which report the packaged engagement produces (default: whatever the
+        /// template's own `[report]` table says).
+        ///
+        /// `cast` writes `template = "cast"` and `code_only = true` into the
+        /// generated `engagement.toml` — the CAST-style technical due-diligence
+        /// report, scoped to what a repository checkout can prove.
+        #[arg(long = "template", value_name = "NAME", value_enum)]
+        report_template: Option<ReportTemplateArg>,
+
+        /// Pre-populate the package's repository list from a file.
+        ///
+        /// Takes a `repos.txt` — one `owner/name`, absolute checkout path, or
+        /// GitHub URL per line, `#` starting a comment — or an `engagement.toml`
+        /// from a previous engagement, whose `[[targets]]` are reused. The
+        /// generated config declares them, so `taudit audit` on the recipient's
+        /// machine audits exactly that list and asks them to pick nothing.
+        #[arg(long, value_name = "FILE")]
+        repos: Option<PathBuf>,
     },
     /// Regenerate the reports from a finished audit package.
     ///
@@ -332,9 +389,20 @@ impl Cli {
             }),
             // #5825: the inbound package. A separate variant from `Package`
             // because the two travel opposite ways — see `crate::distribute`.
-            Some(Verb::Distribute { out, binary }) => Command::Distribute(DistributeOptions {
+            Some(Verb::Distribute {
+                out,
+                binary,
+                prompt_for_key,
+                report_template,
+                repos,
+            }) => Command::Distribute(DistributeOptions {
                 output_dir: out.clone(),
                 binary: binary.clone(),
+                prompt_for_key: *prompt_for_key,
+                report_preset: report_template.map_or(ReportPreset::Inherit, Into::into),
+                // #5483: the PATH travels, not the parsed list — `to_command`
+                // cannot fail, so `distribute::assemble` does the read.
+                repos: repos.clone(),
             }),
             // #6080: every knob defaults — the source to the directory this was
             // run in — so `taudit render` is the whole invocation the recipient
@@ -664,6 +732,49 @@ mod cli_tests {
     fn a_bare_invocation_enters_the_guided_flow() {
         let cli = Cli::try_parse_from(["taudit"]).expect("bare invocation parses");
         assert_eq!(cli.to_command(), Command::Guided);
+    }
+
+    /// #5483: the three new knobs reach `DistributeOptions`, and a bare
+    /// `distribute` still means what it meant — no key mode, no preset, no
+    /// declared repositories.
+    #[test]
+    fn the_cast_template_flag_selects_the_cast_preset() {
+        let bare = Cli::try_parse_from(["taudit", "distribute"]).expect("parses");
+        assert_eq!(
+            bare.to_command(),
+            Command::Distribute(DistributeOptions::default())
+        );
+
+        let cli = Cli::try_parse_from([
+            "taudit",
+            "distribute",
+            "--prompt-for-key",
+            "--template",
+            "cast",
+            "--repos",
+            "/tmp/repos.txt",
+        ])
+        .expect("parses");
+        let Command::Distribute(options) = cli.to_command() else {
+            panic!("expected Distribute");
+        };
+        assert!(options.prompt_for_key);
+        assert_eq!(options.report_preset, ReportPreset::Cast);
+        assert_eq!(options.repos, Some(PathBuf::from("/tmp/repos.txt")));
+
+        // `--template default` is the explicit spelling of the default, not a
+        // second preset.
+        let cli =
+            Cli::try_parse_from(["taudit", "distribute", "--template", "default"]).expect("parses");
+        let Command::Distribute(options) = cli.to_command() else {
+            panic!("expected Distribute");
+        };
+        assert_eq!(options.report_preset, ReportPreset::Inherit);
+
+        assert!(
+            Cli::try_parse_from(["taudit", "distribute", "--template", "cst"]).is_err(),
+            "an unknown template must be a usage error, not a silent default"
+        );
     }
 
     #[test]
@@ -1168,6 +1279,8 @@ mod cli_tests {
             packaged_bytes: 5 * 1024 * 1024,
             platform: "macos-aarch64".to_owned(),
             key_from_environment,
+            prompts_for_key: false,
+            declared_repos: 0,
             dropped_board_credentials: vec!["boards.jira".to_owned()],
         };
 

--- a/crates/trusty-audit/src/cli/render.rs
+++ b/crates/trusty-audit/src/cli/render.rs
@@ -386,11 +386,24 @@ fn render_install_package(package: &InstallPackage) -> String {
     }
     // #5825: which key shipped is the one thing about this package the
     // operator cannot check by opening it without reading a credential.
-    out.push_str(if package.key_from_environment {
-        "  credential: from OPENROUTER_API_KEY\n"
-    } else {
-        "  credential: from the template config\n"
-    });
+    // #5483: a package built with --prompt-for-key shipped none at all, and
+    // saying "from the template config" for it would be a false statement about
+    // a credential, which is the one line here that has to be exact.
+    out.push_str(
+        match (package.prompts_for_key, package.key_from_environment) {
+            (true, _) => "  credential: none — the recipient is asked on first run\n",
+            (false, true) => "  credential: from OPENROUTER_API_KEY\n",
+            (false, false) => "  credential: from the template config\n",
+        },
+    );
+    // #5483: the operator confirms the list reached the package here rather
+    // than by opening the zip.
+    if package.declared_repos > 0 {
+        out.push_str(&format!(
+            "  declares {}: the recipient registers nothing\n",
+            count_of(package.declared_repos, "repository", "repositories")
+        ));
+    }
     // #5861: the template's board credentials belong to whichever engagement
     // they were set for, so they do not ship. Said out loud, because an auditor
     // whose template carries one would otherwise expect that board to collect.

--- a/crates/trusty-audit/src/cli/targets_file.rs
+++ b/crates/trusty-audit/src/cli/targets_file.rs
@@ -226,6 +226,98 @@ pub fn detect(config_path: &Path) -> Result<Option<Detected>, AuditError> {
     Ok(Some(Detected { specs, sources }))
 }
 
+/// Read one NAMED file as this engagement's target list (#5483).
+///
+/// Why: `taudit distribute --repos <file>` pre-populates the package's
+/// `engagement.toml` so the recipient audits a list the auditor already has
+/// rather than registering twenty repositories at a prompt. That list must be
+/// read by the same parser [`detect`] uses, or the handoff would have a second
+/// repository-list format with its own normalization and its own bugs. This is
+/// that parser, pointed at a path the operator named instead of at a fixed
+/// filename beside the config.
+///
+/// What: two shapes, both already this crate's own. A file that parses as TOML
+/// and carries a `targets` array is an `engagement.toml` — its declared targets
+/// come back verbatim, so an auditor can hand over the previous engagement's
+/// config. Anything else is read as [`REPOS_FILE`]: one `owner/name`, absolute
+/// checkout path, or GitHub URL per line, `#` starting a comment, every line
+/// normalized and validated through [`registry::parse`].
+///
+/// All-or-nothing, for the reason [`detect`] is: a list that registers
+/// nineteen of twenty repositories produces an audit that reports success over
+/// the one it never saw. Every bad line is named with its number and its own
+/// reason, so one run fixes them all.
+/// Test: `super::targets_file_tests::a_named_repo_list_reads_the_line_format`,
+/// `super::targets_file_tests::a_named_repo_list_reads_an_engagement_config`,
+/// `super::targets_file_tests::one_bad_line_refuses_a_named_repo_list`.
+///
+/// # Errors
+///
+/// [`AuditError::Read`] when the file cannot be opened;
+/// [`AuditError::TargetsFileRefused`] when any line is not a repository.
+pub fn read_repo_list(path: &Path) -> Result<Vec<registry::Target>, AuditError> {
+    let text = std::fs::read_to_string(path)
+        .map(without_bom)
+        .map_err(|source| AuditError::Read {
+            path: path.to_path_buf(),
+            source,
+        })?;
+
+    // An `engagement.toml` handed over from a previous engagement. Checked
+    // first because a repos.txt is not valid TOML, so there is no file both
+    // arms could claim.
+    if let Ok(table) = toml::from_str::<toml::Table>(&text)
+        && let Some(declared) = table.get(crate::config::TARGETS_FIELD)
+    {
+        return declared
+            .clone()
+            .try_into::<Vec<registry::Target>>()
+            .map_err(|source| AuditError::Parse {
+                path: path.to_path_buf(),
+                what: "engagement targets",
+                source: Box::new(source),
+            });
+    }
+
+    let name = path.file_name().map_or_else(
+        || REPOS_FILE.to_owned(),
+        |n| n.to_string_lossy().into_owned(),
+    );
+    let mut targets = Vec::new();
+    let mut bad = Vec::new();
+    for (offset, line) in text.lines().enumerate() {
+        let Some(entry) = meaningful(line) else {
+            continue;
+        };
+        match spec_of(TargetKind::Repo, entry) {
+            // `spec_of` already proved this parses; re-parsing is how the spec
+            // becomes the `Target` the config declares, with no second charset.
+            Ok(spec) => match registry::parse(Some(TargetKind::Repo), &spec) {
+                Ok(target) => targets.push(target),
+                Err(refusal) => bad.push(BadLine {
+                    file: name.clone(),
+                    line: offset + 1,
+                    entry: entry.to_owned(),
+                    reason: refusal.to_string(),
+                }),
+            },
+            Err(reason) => bad.push(BadLine {
+                file: name.clone(),
+                line: offset + 1,
+                entry: entry.to_owned(),
+                reason,
+            }),
+        }
+    }
+    if !bad.is_empty() {
+        return Err(AuditError::TargetsFileRefused {
+            bad: BadLines(bad),
+            unreadable: UnreadableFiles(Vec::new()),
+        });
+    }
+    Ok(targets)
+}
+
 /// A targets file that is there and could not be opened (#5993).
 ///
 /// Held rather than raised so [`detect`] can decide, once both files have been
@@ -452,6 +544,66 @@ fn issue_prefix(segment: &str) -> &str {
 #[cfg(test)]
 mod targets_file_tests {
     use super::*;
+
+    /// #5483: `--repos <file>` reads the same line format `repos.txt` uses,
+    /// through the same normalizer — a URL, a `.git` suffix and a short form
+    /// all reach the same target, and a comment is skipped.
+    #[test]
+    fn a_named_repo_list_reads_the_line_format() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("client-repos.txt");
+        std::fs::write(
+            &path,
+            "# the auditor's list\nacme/api\nhttps://github.com/acme/web.git\n\n",
+        )
+        .expect("write the list");
+
+        let targets = read_repo_list(&path).expect("reads");
+        assert_eq!(
+            targets.iter().map(registry::Target::id).collect::<Vec<_>>(),
+            vec!["acme/api", "acme/web"]
+        );
+    }
+
+    /// A previous engagement's config is the other shape an auditor has to
+    /// hand, and reusing its `[[targets]]` is what keeps this from being a
+    /// second repository-list format.
+    #[test]
+    fn a_named_repo_list_reads_an_engagement_config() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("previous-engagement.toml");
+        std::fs::write(
+            &path,
+            "openrouter_key = \"\"\ninstructions = \"x\"\n\n\
+             [tools]\ntga = \"5.0.3\"\ntrusty-search = \"0.52.0\"\n\
+             trusty-analyze = \"0.12.5\"\ntrusty-review = \"0.31.2\"\n\n\
+             [[targets]]\nkind = \"repo\"\nname_with_owner = \"acme/api\"\n",
+        )
+        .expect("write the config");
+
+        let targets = read_repo_list(&path).expect("reads");
+        assert_eq!(
+            targets.iter().map(registry::Target::id).collect::<Vec<_>>(),
+            vec!["acme/api"]
+        );
+    }
+
+    /// All-or-nothing, for the reason [`detect`] is: a list that registers
+    /// nineteen of twenty produces an audit reporting success over the one it
+    /// never saw.
+    #[test]
+    fn one_bad_line_refuses_a_named_repo_list() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("client-repos.txt");
+        std::fs::write(&path, "acme/api\nnot a repository\n").expect("write the list");
+
+        let error = read_repo_list(&path).expect_err("one bad line refuses the read");
+        let AuditError::TargetsFileRefused { bad, .. } = &error else {
+            panic!("{error}");
+        };
+        assert_eq!(bad.0.len(), 1);
+        assert_eq!(bad.0[0].line, 2);
+    }
 
     /// Write `repos.txt` / `boards.txt` beside a config path and read them.
     fn detected(dir: &Path, repos: Option<&str>, boards: Option<&str>) -> Option<Detected> {

--- a/crates/trusty-audit/src/config.rs
+++ b/crates/trusty-audit/src/config.rs
@@ -847,6 +847,67 @@ pub fn with_targets(template: &str, targets: &[Target], path: &Path) -> Result<S
     Ok(rendered)
 }
 
+/// The TOML table holding the engagement's report selection.
+///
+/// Named once so [`with_report_selection`] and [`ReportSettings`] cannot drift
+/// apart.
+pub const REPORT_FIELD: &str = "report";
+
+/// Re-render `template` with a report template and scope selected (#5483).
+///
+/// Why: `[report] template = "cast"` and `code_only = true` are the two lines
+/// that turn an engagement's output into a CAST-style due-diligence report
+/// (#6669), and until now an auditor hand-added them to the template before
+/// running `taudit distribute`. A step done by hand before every handoff is a
+/// step that gets forgotten, and the run that forgets it renders the wrong
+/// report and exits 0. `taudit distribute --template cast` writes them here
+/// instead.
+///
+/// What: the same table substitution [`with_targets`] uses, one table deeper.
+/// Only the two keys are set — an `investigate_max_files` the template declared
+/// survives, because the preset selects WHICH report is produced and says
+/// nothing about how much of each repository is read. A `[report]` that is not
+/// a table is replaced rather than merged into: there is nothing to preserve in
+/// a value this crate cannot read, and refusing would strand an auditor over a
+/// typo in a file they can fix in the generated config anyway.
+///
+/// The result is parsed back through [`EngagementConfig::from_toml`], so a
+/// substitution that would produce an unloadable config fails HERE rather than
+/// on the recipient's machine.
+/// Test: `config_tests::selecting_a_report_writes_both_keys_and_keeps_the_budget`,
+/// `config_tests::selecting_a_report_preserves_every_other_field`.
+///
+/// # Errors
+///
+/// [`AuditError::Parse`] when `template` is not TOML, or when the substituted
+/// result is not a loadable engagement config; [`AuditError::Render`] when the
+/// table cannot be re-serialized.
+pub fn with_report_selection(
+    template: &str,
+    report_template: &str,
+    code_only: bool,
+    path: &Path,
+) -> Result<String, AuditError> {
+    let mut table = parse_template(template, path)?;
+    let mut report = match table.remove(REPORT_FIELD) {
+        Some(toml::Value::Table(existing)) => existing,
+        _ => toml::Table::new(),
+    };
+    report.insert(
+        "template".to_owned(),
+        toml::Value::String(report_template.to_owned()),
+    );
+    report.insert("code_only".to_owned(), toml::Value::Boolean(code_only));
+    table.insert(REPORT_FIELD.to_owned(), toml::Value::Table(report));
+
+    let rendered = toml::to_string_pretty(&table).map_err(|source| AuditError::Render {
+        what: "engagement config",
+        source: Box::new(source),
+    })?;
+    EngagementConfig::from_toml(&rendered, path)?;
+    Ok(rendered)
+}
+
 #[cfg(test)]
 mod config_tests {
     use super::*;
@@ -883,6 +944,58 @@ mod config_tests {
             declared.iter().map(Target::id).collect::<Vec<_>>(),
             vec!["acme/api", "jira:ACME"]
         );
+        assert_eq!(loaded.openrouter_key.expose(), "sk-or-v1-not-a-real-key");
+        assert_eq!(loaded.tools.trusty_review.version(), "0.15.1");
+        assert_eq!(loaded.client.as_deref(), Some("Acme"));
+        assert_eq!(
+            loaded
+                .boards
+                .linear
+                .as_ref()
+                .expect("linear survives")
+                .api_key
+                .expose(),
+            "lin_api_secret"
+        );
+    }
+
+    /// #5483: the two CAST keys land, and the investigation budget the template
+    /// declared is not collateral damage — the preset selects WHICH report is
+    /// produced, not how much of each repository is read.
+    #[test]
+    fn selecting_a_report_writes_both_keys_and_keeps_the_budget() {
+        let source = format!("{SAMPLE}\n[report]\ninvestigate_max_files = 240\n");
+        let path = Path::new("engagement.toml");
+        let text = with_report_selection(&source, "cast", true, path).expect("writes");
+
+        let loaded = EngagementConfig::from_toml(&text, path).expect("loads");
+        assert_eq!(loaded.report.template.as_deref(), Some("cast"));
+        assert_eq!(loaded.report.code_only, Some(true));
+        assert_eq!(loaded.report.investigate_max_files, Some(240));
+        assert_eq!(
+            loaded.report.child_env(),
+            vec![
+                (
+                    trusty_common::env_vars::ENV_AUDIT_REPORT_TEMPLATE,
+                    "cast".to_owned()
+                ),
+                (
+                    trusty_common::env_vars::ENV_AUDIT_REPORT_CODE_ONLY,
+                    "true".to_owned()
+                ),
+            ]
+        );
+    }
+
+    /// Selecting a report must not cost the recipient their pins, their key or a
+    /// board credential, for the same reason a registration must not.
+    #[test]
+    fn selecting_a_report_preserves_every_other_field() {
+        let source = format!("{SAMPLE}\n[boards.linear]\napi_key = \"lin_api_secret\"\n");
+        let path = Path::new("engagement.toml");
+        let text = with_report_selection(&source, "cast", true, path).expect("writes");
+
+        let loaded = EngagementConfig::from_toml(&text, path).expect("loads");
         assert_eq!(loaded.openrouter_key.expose(), "sk-or-v1-not-a-real-key");
         assert_eq!(loaded.tools.trusty_review.version(), "0.15.1");
         assert_eq!(loaded.client.as_deref(), Some("Acme"));

--- a/crates/trusty-audit/src/distribute.rs
+++ b/crates/trusty-audit/src/distribute.rs
@@ -8,8 +8,9 @@
 //!
 //! What: [`assemble`] writes one zip holding the `taudit` binary, a launcher
 //! that runs it from wherever it was extracted, a generated `engagement.toml`,
-//! and a README naming the three commands in order. [`InstallPackage`] is what a
-//! front end renders.
+//! a root README pointing at the instructions, and an `instructions/` directory
+//! holding the sequence to run and a commented reference for every config key
+//! (#5483). [`InstallPackage`] is what a front end renders.
 //!
 //! ## Direction — the reason this is not [`crate::package`]
 //!
@@ -47,7 +48,10 @@ use crate::config::{self, EngagementConfig, SecretKey};
 use crate::error::AuditError;
 use crate::package::PackagedFile;
 use crate::progress::{Operation, Progress, UnitOutcome};
+use crate::registry::Target;
 use crate::run::ENV_INFERENCE_CREDENTIAL;
+
+pub mod instructions;
 
 /// Where the package lands when the operator names no directory.
 ///
@@ -80,6 +84,44 @@ pub const README_NAME: &str = "README.md";
 /// How much of the binary is read at a time while copying it.
 const CHUNK_BYTES: usize = 64 * 1024;
 
+/// How many members the package holds — the binary, the launcher, the config,
+/// the pointer README, and the two under `instructions/`.
+pub(crate) const MEMBER_COUNT: usize = 6;
+
+/// Which report the packaged engagement is set up to produce (#5483).
+///
+/// Why: the CAST methodology is two lines in the engagement config (#6669), and
+/// an auditor hand-adding them to their template before every handoff will
+/// eventually not. A run that forgets them renders the default report and exits
+/// 0, so the omission is invisible until the client reads the wrong document.
+/// What: an enum rather than a `--cast` boolean, because the report template is
+/// a NAME (`cast`, `default`, a bundled template) and the next preset is a
+/// variant rather than a second flag that contradicts the first.
+/// [`ReportPreset::Inherit`] is the default and writes nothing at all, so a
+/// `distribute` run that names no preset behaves exactly as it did.
+/// Test: `super::distribute_tests::the_cast_preset_writes_both_report_keys`,
+/// `super::distribute_tests::the_default_preset_leaves_the_templates_report_table_alone`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
+pub enum ReportPreset {
+    /// Whatever the template's own `[report]` table says. The default.
+    #[default]
+    Inherit,
+    /// CAST-style technical due diligence, scoped to what a checkout can prove:
+    /// `template = "cast"`, `code_only = true`.
+    Cast,
+}
+
+impl ReportPreset {
+    /// The `[report]` selection this preset writes, or `None` to write nothing.
+    fn selection(self) -> Option<(&'static str, bool)> {
+        match self {
+            Self::Inherit => None,
+            Self::Cast => Some(("cast", true)),
+        }
+    }
+}
+
 /// What the recipient chose about the package to build.
 ///
 /// Why: both fields are `Option` because both have a defensible default the
@@ -98,6 +140,33 @@ pub struct DistributeOptions {
     pub output_dir: Option<PathBuf>,
     /// The `taudit` binary to ship. `None` means the running executable.
     pub binary: Option<PathBuf>,
+    /// Ship NO credential, and let the recipient enter one (#5483).
+    ///
+    /// Why: the owner's handover conveys the key out of band, so the package
+    /// that travels by email should not carry it. `true` writes a blank
+    /// `openrouter_key`, which is exactly what
+    /// [`crate::cli::credential::resolve`] turns into the first-run terminal
+    /// prompt — there is no second mechanism, and no `key_env` indirection to
+    /// keep in step with the schema (#5478 retired that spelling).
+    /// What: it BEATS both the supplied key and the template's own, because it
+    /// is the operator saying explicitly not to ship one. `false` is the
+    /// existing behaviour, unchanged.
+    pub prompt_for_key: bool,
+    /// Which report the packaged engagement produces.
+    pub report_preset: ReportPreset,
+    /// A file naming the repositories the package declares (#5483).
+    ///
+    /// Why a PATH rather than a parsed list: `Cli::to_command` cannot fail, so
+    /// the CLI carries the operator's choice as data and the fallible read
+    /// happens here — the same shape `Command::AddTarget` uses for a target
+    /// spec, and the reason `registry::parse` rather than clap decides what a
+    /// target may be.
+    /// What: `None` is the existing behaviour — the package declares no
+    /// `targets` and the recipient registers each repository themselves. A path
+    /// is read by [`crate::cli::targets_file::read_repo_list`], the crate's one
+    /// repository-list parser, and written into the same `targets` key
+    /// `taudit add repo` writes.
+    pub repos: Option<PathBuf>,
 }
 
 /// The finished install package: what to send, and what it will run on.
@@ -108,7 +177,7 @@ pub struct DistributeOptions {
 /// built for the wrong target extracts and runs on nothing.
 /// What: the destination, every member, the sizes, and the host triple the
 /// binary was built for.
-/// Test: `super::distribute_tests::the_package_holds_the_four_members`.
+/// Test: `super::distribute_tests::the_package_holds_every_member`.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct InstallPackage {
@@ -124,7 +193,18 @@ pub struct InstallPackage {
     pub platform: String,
     /// Whether the credential came from the environment rather than the
     /// template. Recorded so the operator can see which one they shipped.
+    ///
+    /// Always `false` when [`Self::prompts_for_key`] is set: no key shipped at
+    /// all, so it did not come from the environment either.
     pub key_from_environment: bool,
+    /// Whether the package ships no credential, leaving the recipient to enter
+    /// one on first run (#5483).
+    pub prompts_for_key: bool,
+    /// Repositories the generated `engagement.toml` declares (#5483).
+    ///
+    /// Reported so the operator can confirm the list reached the package before
+    /// they send it — the alternative is opening the zip.
+    pub declared_repos: usize,
     /// Board-credential fields the template held that did NOT ship (#5861).
     ///
     /// Empty for a template that names no board. Reported rather than silent:
@@ -210,14 +290,29 @@ pub fn destination(options: &DistributeOptions) -> Result<PathBuf, AuditError> {
 /// What: `supplied` when it is not blank, else the template's own key when it is
 /// not blank, else a refusal. The `bool` says which, so the operator can see
 /// which key they shipped without the value being printed.
+///
+/// #5483: `prompt_for_key` is the third answer and it comes FIRST, ahead of
+/// both. It is the operator saying not to ship a credential at all, which an
+/// exported `OPENROUTER_API_KEY` left over from an earlier command must not
+/// quietly override — that would bake a key into a package built precisely to
+/// avoid carrying one, and nothing downstream would say so. The blank key it
+/// returns is what [`crate::cli::credential::resolve`] reads as "ask the
+/// recipient", so the two halves meet at the config field rather than at a
+/// flag either side has to remember.
 /// Test: `super::distribute_tests::a_supplied_key_beats_the_templates`,
 /// `super::distribute_tests::a_blank_supplied_key_falls_back_to_the_template`,
-/// `super::distribute_tests::a_blank_credential_is_refused_and_leaves_no_file`.
+/// `super::distribute_tests::a_blank_credential_is_refused_and_leaves_no_file`,
+/// `super::distribute_tests::a_prompt_for_key_package_ships_no_credential`,
+/// `super::distribute_tests::prompting_for_the_key_beats_a_supplied_one`.
 fn resolve_key(
     supplied: Option<&SecretKey>,
     template: &EngagementConfig,
     template_path: &Path,
+    prompt_for_key: bool,
 ) -> Result<(SecretKey, bool), AuditError> {
+    if prompt_for_key {
+        return Ok((SecretKey::new(""), false));
+    }
     if let Some(key) = supplied
         && !key.is_empty()
     {
@@ -290,34 +385,59 @@ pub fn assemble(
             source,
         })?;
     let template = EngagementConfig::from_toml(&template_text, template_path)?;
-    let (key, key_from_environment) = resolve_key(supplied_key, &template, template_path)?;
+    let (key, key_from_environment) = resolve_key(
+        supplied_key,
+        &template,
+        template_path,
+        options.prompt_for_key,
+    )?;
     // #5861: this config belongs to an engagement the template does not, so the
     // template's board credentials — the previous CLIENT's — never travel.
-    let (config_text, dropped_board_credentials) =
+    let (mut config_text, dropped_board_credentials) =
         config::generate_for_new_engagement(&template_text, &key, template_path)?;
+    // #5483: both are substitutions over the same table, applied in the order
+    // an operator names them — what to audit, then which report to render.
+    let repos: Vec<Target> = match &options.repos {
+        Some(path) => crate::cli::targets_file::read_repo_list(path)?,
+        None => Vec::new(),
+    };
+    if !repos.is_empty() {
+        config_text = config::with_targets(&config_text, &repos, template_path)?;
+    }
+    if let Some((report_template, code_only)) = options.report_preset.selection() {
+        config_text =
+            config::with_report_selection(&config_text, report_template, code_only, template_path)?;
+    }
 
     let platform = host_platform();
-    let readme = render_readme(&template, &platform, options.binary.is_some());
-    let launcher = render_launcher();
+    let platform_line = platform_line(&platform, options.binary.is_some());
+    let declared_repos = repos.len();
+    let members = Members {
+        config: config_text,
+        launcher: render_launcher(),
+        readme: instructions::render_pointer(&template, &platform_line),
+        instructions: instructions::render_readme(
+            &template,
+            &platform_line,
+            options.prompt_for_key,
+            declared_repos,
+        ),
+        engagement_template: instructions::ENGAGEMENT_TEMPLATE.to_owned(),
+    };
 
-    progress.operation_started(Operation::Distribute, 4);
-    let result = write_archive(
-        &destination,
-        &binary,
-        Members {
-            config: config_text,
-            launcher,
-            readme,
-        },
-        progress,
-    );
+    progress.operation_started(Operation::Distribute, MEMBER_COUNT);
+    let result = write_archive(&destination, &binary, members, progress);
     // #5825: the failing MEMBER is announced by the site that failed, inside
     // `fill_archive`, because only that site knows which one it was. This used
     // to report `BINARY_NAME` for every failure, so a README that could not be
     // written surfaced as "taudit failed". A failure with no member in flight —
     // creating the directory, finishing the archive, the rename — belongs to no
     // unit and names none.
-    progress.operation_finished(Operation::Distribute, if result.is_ok() { 4 } else { 0 }, 4);
+    progress.operation_finished(
+        Operation::Distribute,
+        if result.is_ok() { MEMBER_COUNT } else { 0 },
+        MEMBER_COUNT,
+    );
     let (files, packaged_bytes) = result?;
 
     Ok(InstallPackage {
@@ -327,16 +447,33 @@ pub fn assemble(
         packaged_bytes,
         platform,
         key_from_environment,
+        prompts_for_key: options.prompt_for_key,
+        declared_repos,
         dropped_board_credentials,
     })
 }
 
-/// The three generated text members, kept together so [`write_archive`]'s
-/// signature does not grow three `String` parameters a caller can transpose.
+/// The line naming what the packaged binary runs on.
+///
+/// Why: the default binary is the running executable, so its target IS the
+/// host. When the operator names one explicitly they are asserting the match,
+/// and the line says so rather than claiming a triple nothing checked.
+fn platform_line(platform: &str, explicit_binary: bool) -> String {
+    if explicit_binary {
+        format!("- Built for: {platform} (binary supplied by the auditor)")
+    } else {
+        format!("- Built for: {platform}")
+    }
+}
+
+/// The generated text members, kept together so [`write_archive`]'s signature
+/// does not grow five `String` parameters a caller can transpose.
 struct Members {
     config: String,
     launcher: String,
     readme: String,
+    instructions: String,
+    engagement_template: String,
 }
 
 /// Fill a `.zip.part`, then rename it into place.
@@ -464,9 +601,9 @@ where
     W: std::io::Write + std::io::Seek,
 {
     let mut zip = zip::ZipWriter::new(sink);
-    let mut files = Vec::with_capacity(4);
+    let mut files = Vec::with_capacity(MEMBER_COUNT);
 
-    progress.unit_started(Operation::Distribute, BINARY_NAME, 1, 4);
+    progress.unit_started(Operation::Distribute, BINARY_NAME, 1, MEMBER_COUNT);
     let entry = entry_path(BINARY_NAME);
     let bytes = copy_binary(&mut zip, &entry, binary, temporary)
         .map_err(|e| failed_unit(progress, BINARY_NAME, e))?;
@@ -483,11 +620,21 @@ where
         (LAUNCHER_NAME, members.launcher, 0o755),
         (EngagementConfig::FILE_NAME, members.config, 0o600),
         (README_NAME, members.readme, 0o644),
+        (
+            instructions::INSTRUCTIONS_README,
+            members.instructions,
+            0o644,
+        ),
+        (
+            instructions::ENGAGEMENT_TEMPLATE_NAME,
+            members.engagement_template,
+            0o644,
+        ),
     ]
     .into_iter()
     .enumerate()
     {
-        progress.unit_started(Operation::Distribute, name, index + 2, 4);
+        progress.unit_started(Operation::Distribute, name, index + 2, MEMBER_COUNT);
         let entry = entry_path(name);
         start(&mut zip, &entry, mode, temporary).map_err(|e| failed_unit(progress, name, e))?;
         zip.write_all(text.as_bytes()).map_err(|source| {
@@ -597,100 +744,6 @@ fn render_launcher() -> String {
     )
 }
 
-/// The README the recipient reads first.
-///
-/// Why: #5825 asks for the three commands in order and nothing else. The
-/// quarantine paragraph is here because it is the difference between a package
-/// that runs and one that produces "cannot be opened because the developer
-/// cannot be verified" — Developer-ID signing (#5484) is a separate milestone,
-/// and until it lands the recipient needs the one command that clears the flag.
-/// Test: `super::distribute_tests::the_readme_names_the_three_commands_in_order`.
-fn render_readme(config: &EngagementConfig, platform: &str, explicit_binary: bool) -> String {
-    let engagement = match (&config.client, &config.engagement) {
-        (Some(client), Some(label)) => format!("{client} — {label}"),
-        (Some(client), None) => client.clone(),
-        (None, Some(label)) => label.clone(),
-        (None, None) => "unlabelled".to_owned(),
-    };
-    let platform_line = if explicit_binary {
-        format!("- Built for: {platform} (binary supplied by the auditor)")
-    } else {
-        format!("- Built for: {platform}")
-    };
-    format!(
-        "# Audit client — {engagement}\n\
-         \n\
-         Extract this folder anywhere and run the three commands below from inside it.\n\
-         Nothing is installed into your system directories.\n\
-         \n\
-         {platform_line}\n\
-         - Configuration: `{config_file}` (readable — open it before you run anything)\n\
-         - Working directory: `{work}`, created on first run\n\
-         \n\
-         The working directory holds the clones, the collected database and the\n\
-         tooling. It is NOT inside this folder — the code analysis cannot read a\n\
-         checkout under `~/Downloads`, `~/Desktop`, `~/Documents` or a temporary\n\
-         directory, which is where this folder usually lands. Override it with\n\
-         `--work-dir <path>` if you want it somewhere else.\n\
-         \n\
-         ## 1. Register what to audit\n\
-         \n\
-         ```sh\n\
-         ./{launcher} add repo <owner>/<name>\n\
-         ./{launcher} targets\n\
-         ```\n\
-         \n\
-         Each repository is checked against your own GitHub credential before it is\n\
-         registered, so a typo is refused here rather than halfway through the audit.\n\
-         Repeat for every repository. `targets` lists what is registered.\n\
-         \n\
-         ## 2. Run the audit\n\
-         \n\
-         ```sh\n\
-         ./{launcher} run\n\
-         ```\n\
-         \n\
-         This clones the registered repositories and analyses them. It may run for\n\
-         hours and prints progress as it goes. A repository that fails does not stop\n\
-         the rest, and a re-run resumes rather than starting over.\n\
-         \n\
-         ## 3. Return the results\n\
-         \n\
-         ```sh\n\
-         ./{launcher} package\n\
-         ```\n\
-         \n\
-         This writes one zip and prints its path. Open it before you send it — it is\n\
-         unencrypted on purpose, so you can see exactly what leaves your network. It\n\
-         carries reports and metadata, and it never carries the credential in\n\
-         `{config_file}`.\n\
-         \n\
-         ## 4. Remove it afterwards\n\
-         \n\
-         ```sh\n\
-         rm -rf {work}\n\
-         trusty-search index remove <each cloned repository path>\n\
-         ```\n\
-         \n\
-         Then delete this folder. The second command matters: to analyse your code the\n\
-         client approves each clone with `trusty-search`, and that approval is recorded\n\
-         in `trusty-search`'s own settings, outside the working directory. `run` prints\n\
-         each path it approves. `trusty-search index list` shows what is approved.\n\
-         \n\
-         ## If macOS refuses to run it\n\
-         \n\
-         A zip that arrived over the network is quarantined, and this build is not yet\n\
-         notarized. Clear the flag once, from inside the extracted folder:\n\
-         \n\
-         ```sh\n\
-         xattr -dr com.apple.quarantine .\n\
-         ```\n",
-        config_file = EngagementConfig::FILE_NAME,
-        launcher = LAUNCHER_NAME,
-        work = crate::workdir::DEFAULT_ROOT_DISPLAY,
-    )
-}
-
 #[cfg(test)]
 mod distribute_tests {
     use super::*;
@@ -752,6 +805,7 @@ trusty-review = "0.16.0"
             DistributeOptions {
                 output_dir: Some(self.out.clone()),
                 binary: Some(self.binary.clone()),
+                ..DistributeOptions::default()
             }
         }
 
@@ -844,6 +898,47 @@ trusty-review = "0.16.0"
         }
     }
 
+    /// A terminal that answers every hidden read with the same key.
+    ///
+    /// Local rather than reusing `credential_tests`' fake: that one lives in
+    /// another module's `#[cfg(test)]` body and is not reachable from here.
+    /// This drives the public [`crate::cli::credential::Tty`] trait, so it
+    /// proves the same seam.
+    struct FakeTty(String);
+
+    impl FakeTty {
+        fn answering(key: &str) -> Self {
+            Self(key.to_owned())
+        }
+    }
+
+    impl crate::cli::credential::Tty for FakeTty {
+        fn read_hidden(&mut self, _prompt: &str) -> std::io::Result<String> {
+            Ok(self.0.clone())
+        }
+
+        fn read_line(&mut self, _prompt: &str) -> std::io::Result<Option<String>> {
+            Ok(None)
+        }
+
+        fn say(&mut self, _line: &str) -> std::io::Result<()> {
+            Ok(())
+        }
+
+        fn discard_typeahead(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// One member's extracted permission bits, or `None` off Unix.
+    fn mode_of(zip_path: &Path, name: &str) -> Option<u32> {
+        let file = std::fs::File::open(zip_path).expect("open package");
+        let mut archive = zip::ZipArchive::new(file).expect("read package");
+        let member = archive.by_name(&entry_path(name)).expect("member present");
+        // `unix_mode` carries the file-type bits too (0o100755, not 0o755).
+        member.unix_mode().map(|m| m & 0o777)
+    }
+
     /// Every entry name in a written package, in order.
     fn entries(zip_path: &Path) -> Vec<String> {
         let file = std::fs::File::open(zip_path).expect("open package");
@@ -854,7 +949,7 @@ trusty-review = "0.16.0"
     }
 
     #[test]
-    fn the_package_holds_the_four_members() {
+    fn the_package_holds_every_member() {
         let fixture = Fixture::new(TEMPLATE);
         let package = fixture.assemble().expect("assembles");
 
@@ -865,9 +960,11 @@ trusty-review = "0.16.0"
                 "trusty-audit/audit.sh",
                 "trusty-audit/engagement.toml",
                 "trusty-audit/README.md",
+                "trusty-audit/instructions/README.md",
+                "trusty-audit/instructions/engagement.template.toml",
             ],
         );
-        assert_eq!(package.files.len(), 4);
+        assert_eq!(package.files.len(), MEMBER_COUNT);
         assert!(package.packaged_bytes > 0);
         assert_eq!(package.platform, host_platform());
     }
@@ -1008,15 +1105,23 @@ api_key = "lin_api_client_a"
         );
     }
 
-    /// The README's uninstall instructions are the only place the recipient
-    /// learns that the tree is not beside the launcher and that approving a
-    /// clone wrote a row outside it (#5915).
+    /// Read the instructions member out of a written package.
+    fn instructions_of(package: &InstallPackage) -> String {
+        member(
+            &package.path,
+            &entry_path(instructions::INSTRUCTIONS_README),
+        )
+    }
+
+    /// The uninstall step is the only place the recipient learns that the tree
+    /// is not beside the launcher and that approving a clone wrote a row
+    /// outside it (#5915). It moved into `instructions/` with the rest (#5483).
     #[test]
-    fn the_readme_names_where_the_work_root_is_and_how_to_undo_the_approval() {
+    fn the_instructions_name_where_the_work_root_is_and_how_to_undo_the_approval() {
         let fixture = Fixture::new(TEMPLATE);
         let package = fixture.assemble().expect("assembles");
 
-        let readme = member(&package.path, "trusty-audit/README.md");
+        let readme = instructions_of(&package);
         assert!(
             readme.contains(crate::workdir::DEFAULT_ROOT_DISPLAY),
             "{readme}"
@@ -1026,29 +1131,100 @@ api_key = "lin_api_client_a"
             !readme.contains(
                 "deleting the folder\nremoves the client, its tooling, and everything it wrote"
             ),
-            "the README still promises a complete uninstall it cannot deliver: {readme}"
+            "the instructions still promise a complete uninstall they cannot deliver: {readme}"
         );
     }
 
+    /// #5483: the recipient is walked through install, then the ONE-SHOT
+    /// `audit` verb, then `package` — not the `run` + `package` pair the old
+    /// root README named, which predated `audit` (#5824) and left a
+    /// non-technical recipient a step they could forget or run too early.
+    ///
+    /// The Full Disk Access paragraph is here for the same reason the
+    /// quarantine one is: without it the code-analysis sections render empty
+    /// and nothing on the recipient's screen says why (root `CLAUDE.md`,
+    /// "macOS TCC scope split").
     #[test]
-    fn the_readme_names_the_three_commands_in_order() {
+    fn the_instructions_name_the_one_shot_verb_and_the_disk_access_prompt() {
         let fixture = Fixture::new(TEMPLATE);
         let package = fixture.assemble().expect("assembles");
 
-        let readme = member(&package.path, "trusty-audit/README.md");
-        let add = readme
-            .find("./audit.sh add repo")
-            .expect("registers targets");
-        let run = readme.find("./audit.sh run").expect("runs the audit");
+        let readme = instructions_of(&package);
+        let install = readme.find("./audit.sh install").expect("installs tools");
+        let audit = readme.find("./audit.sh audit").expect("runs the audit");
         let ret = readme
             .find("./audit.sh package")
             .expect("returns the package");
         assert!(
-            add < run && run < ret,
-            "the three commands are out of order"
+            install < audit && audit < ret,
+            "the commands are out of order: {readme}"
+        );
+        assert!(
+            !readme.contains("./audit.sh run"),
+            "the instructions still route through the two-step run: {readme}"
         );
         assert!(readme.contains("Acme — 2026-Q3"), "{readme}");
         assert!(readme.contains("com.apple.quarantine"), "{readme}");
+        assert!(readme.contains("Full Disk Access"), "{readme}");
+        assert!(readme.contains("gh auth login"), "{readme}");
+        // "If something fails" must name where the logs are, or a stopped run
+        // leaves the recipient with nothing to send back.
+        assert!(readme.contains("/logs/"), "{readme}");
+        assert!(readme.contains(&host_platform()), "{readme}");
+    }
+
+    /// #5483: one source of truth. The root README carries the platform and the
+    /// pointer, and must not grow a second copy of the sequence.
+    #[test]
+    fn the_root_readme_points_at_the_instructions() {
+        let fixture = Fixture::new(TEMPLATE);
+        let package = fixture.assemble().expect("assembles");
+
+        let readme = member(&package.path, "trusty-audit/README.md");
+        assert!(
+            readme.contains(instructions::INSTRUCTIONS_README),
+            "{readme}"
+        );
+        assert!(readme.contains("Acme — 2026-Q3"), "{readme}");
+        assert!(readme.contains(&host_platform()), "{readme}");
+        assert!(
+            !readme.contains("./audit.sh add repo"),
+            "the root README carries the sequence again: {readme}"
+        );
+    }
+
+    /// The shipped reference must be a config the client can actually load —
+    /// an auditor copies it, fills in the pins, and hands it back to
+    /// `taudit distribute --config`.
+    #[test]
+    fn the_shipped_config_reference_is_itself_loadable() {
+        let fixture = Fixture::new(TEMPLATE);
+        let package = fixture.assemble().expect("assembles");
+
+        let text = member(
+            &package.path,
+            &entry_path(instructions::ENGAGEMENT_TEMPLATE_NAME),
+        );
+        let loaded = EngagementConfig::from_toml(&text, Path::new("engagement.template.toml"))
+            .expect("the shipped reference loads");
+        assert!(
+            loaded.openrouter_key.is_empty(),
+            "the reference must ship no credential"
+        );
+        assert_eq!(loaded.report.template.as_deref(), Some("cast"));
+        assert_eq!(loaded.report.code_only, Some(true));
+        assert_eq!(loaded.models.provider.as_deref(), Some("openrouter"));
+        assert!(loaded.models.reviewer.is_some());
+        assert!(loaded.models.verifier.is_some());
+        assert!(loaded.models.summarizer.is_some());
+        assert!(
+            loaded.unsupported_keys().is_empty(),
+            "the reference declares a key this version ignores: {:?}",
+            loaded.unsupported_keys()
+        );
+        // The commented `[[targets]]` example the operator uncomments.
+        assert!(text.contains("name_with_owner = \"acme/api\""), "{text}");
+        assert!(text.contains("name_with_owner = \"acme/web\""), "{text}");
     }
 
     #[test]
@@ -1190,6 +1366,8 @@ api_key = "lin_api_client_a"
                 config: "openrouter_key = \"sk-or-v1-x\"\n".to_owned(),
                 launcher: "#!/bin/sh\n".to_owned(),
                 readme: "# Audit client\n".to_owned(),
+                instructions: "# Running the audit\n".to_owned(),
+                engagement_template: "openrouter_key = \"\"\n".to_owned(),
             },
             &progress,
         )
@@ -1236,7 +1414,7 @@ api_key = "lin_api_client_a"
             unit_verdicts(&recorder),
             vec![(BINARY_NAME.to_owned(), "failed")],
         );
-        assert_eq!(operation_verdict(&recorder), Some((0, 4)));
+        assert_eq!(operation_verdict(&recorder), Some((0, MEMBER_COUNT)));
     }
 
     #[test]
@@ -1266,6 +1444,231 @@ api_key = "lin_api_client_a"
         assert_eq!(loaded.openrouter_key.expose(), "sk-or-v1-per-engagement");
     }
 
+    /// 🔴 #5483: the package the owner hands over carries NO credential.
+    ///
+    /// The key reaches the recipient out of band and the config carries a blank
+    /// field, which is the exact state
+    /// [`crate::cli::credential::resolve`] turns into the first-run terminal
+    /// prompt. Scanning the whole member for `sk-or-` rather than checking the
+    /// parsed field is deliberate: a key that leaked into `instructions`, a
+    /// board credential, or a comment would pass the field check and still ship.
+    #[test]
+    fn a_prompt_for_key_package_ships_no_credential() {
+        let fixture = Fixture::new(TEMPLATE);
+        let mut options = fixture.options();
+        options.prompt_for_key = true;
+
+        let package = super::assemble(&fixture.template, &options, None, &Progress::none())
+            .expect("assembles without a key");
+        assert!(package.prompts_for_key);
+        assert!(!package.key_from_environment);
+
+        for entry in [
+            EngagementConfig::FILE_NAME,
+            README_NAME,
+            instructions::INSTRUCTIONS_README,
+            instructions::ENGAGEMENT_TEMPLATE_NAME,
+        ] {
+            let text = member(&package.path, &entry_path(entry));
+            assert!(
+                !text.contains("sk-or-"),
+                "{entry} carries a credential: {text}"
+            );
+        }
+
+        // The blank field is what selects the prompt, so prove the round trip
+        // rather than only the absence.
+        let text = member(&package.path, &entry_path(EngagementConfig::FILE_NAME));
+        let loaded =
+            EngagementConfig::from_toml(&text, Path::new("engagement.toml")).expect("loads");
+        assert!(loaded.openrouter_key.is_empty());
+        let resolved = crate::cli::credential::resolve(
+            None,
+            Some(&loaded.openrouter_key),
+            Path::new("engagement.toml"),
+            Some(&mut FakeTty::answering("sk-or-v1-typed-by-the-recipient")),
+        )
+        .expect("the recipient is asked");
+        assert_eq!(
+            resolved.source(),
+            crate::cli::credential::CredentialSource::Prompt
+        );
+    }
+
+    /// The flag beats a key in the environment, because it is the operator
+    /// saying not to ship one — an `OPENROUTER_API_KEY` left over from an
+    /// earlier command must not silently bake a credential into a package
+    /// built to travel without one.
+    #[test]
+    fn prompting_for_the_key_beats_a_supplied_one() {
+        let fixture = Fixture::new(TEMPLATE);
+        let mut options = fixture.options();
+        options.prompt_for_key = true;
+        let supplied = SecretKey::new("sk-or-v1-from-the-environment");
+
+        let package = super::assemble(
+            &fixture.template,
+            &options,
+            Some(&supplied),
+            &Progress::none(),
+        )
+        .expect("assembles");
+
+        let text = member(&package.path, &entry_path(EngagementConfig::FILE_NAME));
+        assert!(!text.contains("sk-or-v1-from-the-environment"), "{text}");
+        assert!(!text.contains("sk-or-v1-template-key"), "{text}");
+    }
+
+    /// The instructions must set the right expectation for the package shape —
+    /// telling a recipient with a baked-in key to wait for a prompt that never
+    /// comes is the failure this covers.
+    #[test]
+    fn a_prompt_for_key_package_tells_the_recipient_to_expect_the_prompt() {
+        // Two fixtures: `assemble` refuses to overwrite a package, so both
+        // shapes cannot be built into one output directory.
+        let asking = Fixture::new(TEMPLATE);
+        let mut options = asking.options();
+        options.prompt_for_key = true;
+        let asks = super::assemble(&asking.template, &options, None, &Progress::none())
+            .expect("assembles");
+        let asks = instructions_of(&asks);
+        assert!(asks.contains("ask for the OpenRouter key"), "{asks}");
+
+        let fixture = Fixture::new(TEMPLATE);
+        let baked = instructions_of(&fixture.assemble().expect("assembles"));
+        assert!(baked.contains("already in `../engagement.toml`"), "{baked}");
+        assert!(!baked.contains("ask for the OpenRouter key"), "{baked}");
+    }
+
+    /// #5483: `--template cast` writes the two keys that make the output a
+    /// CAST-style report (#6669), so an auditor no longer hand-edits the
+    /// template before every handoff.
+    #[test]
+    fn the_cast_preset_writes_both_report_keys() {
+        let fixture = Fixture::new(TEMPLATE);
+        let mut options = fixture.options();
+        options.report_preset = ReportPreset::Cast;
+
+        let package = super::assemble(&fixture.template, &options, None, &Progress::none())
+            .expect("assembles");
+
+        let text = member(&package.path, &entry_path(EngagementConfig::FILE_NAME));
+        let loaded =
+            EngagementConfig::from_toml(&text, Path::new("engagement.toml")).expect("loads");
+        assert_eq!(loaded.report.template.as_deref(), Some("cast"));
+        assert_eq!(loaded.report.code_only, Some(true));
+        // The pair the sweep hands down to `trusty-review report`.
+        assert_eq!(loaded.report.child_env().len(), 2);
+    }
+
+    /// The default preset must change nothing, or every existing engagement's
+    /// package silently switches report.
+    #[test]
+    fn the_default_preset_leaves_the_templates_report_table_alone() {
+        let fixture = Fixture::new(TEMPLATE);
+        let package = fixture.assemble().expect("assembles");
+
+        let text = member(&package.path, &entry_path(EngagementConfig::FILE_NAME));
+        let loaded =
+            EngagementConfig::from_toml(&text, Path::new("engagement.toml")).expect("loads");
+        assert_eq!(loaded.report.template, None);
+        assert_eq!(loaded.report.code_only, None);
+        assert!(loaded.report.child_env().is_empty());
+    }
+
+    /// 🔴 The acceptance case, end to end: a CAST package with no key and a
+    /// pre-populated repository list, unzipped and inspected.
+    ///
+    /// This is the shape the handover actually ships, so it is asserted as one
+    /// package rather than as three independent properties that could each hold
+    /// while the combination does not.
+    #[test]
+    fn a_cast_package_with_a_repo_list_and_no_key_carries_all_three() {
+        let fixture = Fixture::new(TEMPLATE);
+        let mut options = fixture.options();
+        options.prompt_for_key = true;
+        options.report_preset = ReportPreset::Cast;
+        let list = fixture.template.with_file_name("repos.txt");
+        std::fs::write(
+            &list,
+            "# the auditor's list\nacme/api\nhttps://github.com/acme/web.git\n",
+        )
+        .expect("write repos.txt");
+        options.repos = Some(list);
+
+        let package = super::assemble(&fixture.template, &options, None, &Progress::none())
+            .expect("assembles");
+        assert_eq!(package.declared_repos, 2);
+
+        // Both instruction members are present.
+        for entry in [
+            instructions::INSTRUCTIONS_README,
+            instructions::ENGAGEMENT_TEMPLATE_NAME,
+        ] {
+            assert!(
+                entries(&package.path).contains(&entry_path(entry)),
+                "{entry} is missing from {:?}",
+                entries(&package.path)
+            );
+        }
+
+        // The root config: CAST keys, the declared repositories, no credential.
+        let text = member(&package.path, &entry_path(EngagementConfig::FILE_NAME));
+        assert!(!text.contains("sk-or-"), "{text}");
+        let loaded =
+            EngagementConfig::from_toml(&text, Path::new("engagement.toml")).expect("loads");
+        assert_eq!(loaded.report.template.as_deref(), Some("cast"));
+        assert_eq!(loaded.report.code_only, Some(true));
+        assert!(loaded.openrouter_key.is_empty());
+        assert_eq!(
+            loaded
+                .declared_targets()
+                .expect("targets are declared")
+                .iter()
+                .map(Target::id)
+                .collect::<Vec<_>>(),
+            vec!["acme/api", "acme/web"],
+        );
+
+        // `taudit audit` reads exactly that list, with no picker — the property
+        // the instructions promise.
+        assert_eq!(
+            crate::registry::engagement_targets(
+                Some(&loaded),
+                &crate::workdir::WorkDir::new(fixture.out.join("work"))
+            )
+            .expect("reads the declared list")
+            .len(),
+            2,
+        );
+
+        // The launcher is executable, and the config is not.
+        #[cfg(unix)]
+        assert_eq!(mode_of(&package.path, LAUNCHER_NAME), Some(0o755));
+        #[cfg(unix)]
+        assert_eq!(
+            mode_of(&package.path, EngagementConfig::FILE_NAME),
+            Some(0o600)
+        );
+
+        let readme = instructions_of(&package);
+        assert!(readme.contains("2 repositories"), "{readme}");
+        assert!(
+            !readme.contains("register each repository"),
+            "the instructions still send the recipient to the picker: {readme}"
+        );
+    }
+
+    /// A package with no list keeps sending the recipient to the picker, which
+    /// is the fallback rather than the default.
+    #[test]
+    fn a_package_with_a_repo_list_says_the_targets_are_already_declared() {
+        let fixture = Fixture::new(TEMPLATE);
+        let readme = instructions_of(&fixture.assemble().expect("assembles"));
+        assert!(readme.contains("register each repository"), "{readme}");
+        assert!(readme.contains("./audit.sh add repo"), "{readme}");
+    }
+
     #[test]
     fn the_default_output_directory_is_under_home() {
         let Some(home) = dirs::home_dir() else {
@@ -1283,6 +1686,7 @@ api_key = "lin_api_client_a"
         let options = DistributeOptions {
             output_dir: Some(PathBuf::from("/tmp/elsewhere")),
             binary: None,
+            ..DistributeOptions::default()
         };
         assert_eq!(
             destination(&options).expect("resolves"),

--- a/crates/trusty-audit/src/distribute/instructions.rs
+++ b/crates/trusty-audit/src/distribute/instructions.rs
@@ -1,0 +1,186 @@
+//! The `instructions/` directory the recipient reads first (#5473, #5483).
+//!
+//! Why: the package used to carry one generated `README.md` at its root naming
+//! `add repo`, `run` and `package`. That is the three commands #5825 asked for
+//! and less than a recipient needs: it never mentioned the one-shot `audit`
+//! verb that already existed, never said `trusty-search` asks for Full Disk
+//! Access on macOS, named no log location for a run that failed, and gave the
+//! operator no reference for the config keys the package's own
+//! `engagement.toml` accepts. So the instructions move into their own directory
+//! beside the binary, and the root README becomes a pointer at them — one
+//! source of truth rather than two that drift.
+//!
+//! What: two members. `instructions/README.md` is the numbered sequence the
+//! recipient runs, rendered from [`README_TEMPLATE`] with the engagement's own
+//! labels substituted. `instructions/engagement.template.toml` is the fully
+//! commented config reference, shipped verbatim.
+//!
+//! Both live as files under `crates/trusty-audit/templates/` rather than as
+//! string literals here: recipient-facing prose is reviewed as prose, and a
+//! 150-line `format!` argument counts against this file's SLOC cap for no
+//! benefit. The placeholders are `{{NAME}}` rather than `{}` because the TOML
+//! reference is full of braces that a `format!` would have to escape.
+//!
+//! Test: `super::distribute_tests`.
+
+use crate::config::EngagementConfig;
+
+use super::{LAUNCHER_NAME, README_NAME};
+
+/// The directory the instructions land in, beside the binary.
+pub const INSTRUCTIONS_DIR: &str = "instructions";
+
+/// The instructions themselves.
+pub const INSTRUCTIONS_README: &str = "instructions/README.md";
+
+/// The commented config reference.
+pub const ENGAGEMENT_TEMPLATE_NAME: &str = "instructions/engagement.template.toml";
+
+/// The recipient's numbered sequence, before substitution.
+const README_TEMPLATE: &str = include_str!("../../templates/instructions-README.md");
+
+/// The commented config reference, shipped byte for byte.
+///
+/// It is a LOADABLE config as well as a reference — required keys present,
+/// optional ones commented — so an auditor can copy it, fill in the pins, and
+/// hand it straight back to `taudit distribute --config`.
+/// Test: `super::distribute_tests::the_shipped_config_reference_is_itself_loadable`.
+pub const ENGAGEMENT_TEMPLATE: &str = include_str!("../../templates/engagement.template.toml");
+
+/// What the recipient is told about obtaining the OpenRouter key.
+///
+/// Why: the two package shapes need opposite paragraphs. A package built with
+/// `--prompt-for-key` carries no credential, so the recipient must be told the
+/// key arrives out of band and that the first `audit` asks for it. A package
+/// with the key baked in must NOT tell them to expect a prompt they will never
+/// see.
+/// Test: `super::distribute_tests::a_prompt_for_key_package_tells_the_recipient_to_expect_the_prompt`.
+fn key_step(prompts_for_key: bool) -> &'static str {
+    if prompts_for_key {
+        "The first thing it does is ask for the OpenRouter key, on this terminal.\n\
+         Your auditor sends you that key separately — it is deliberately not in this\n\
+         package. What you type is not echoed, is asked for twice, and is saved into\n\
+         `../engagement.toml` readable only by your account. Export\n\
+         `OPENROUTER_API_KEY` before you run it and it never asks."
+    } else {
+        "The OpenRouter key for this engagement is already in `../engagement.toml`,\n\
+         so nothing is asked for. Export `OPENROUTER_API_KEY` before you run it to\n\
+         use a different one instead."
+    }
+}
+
+/// What the recipient is told about choosing repositories.
+///
+/// Why: a package built with `--repos` already declares its target list in
+/// `engagement.toml`, and telling that recipient to register repositories one
+/// at a time invites them to register the same set twice. The picker is the
+/// fallback for a package that shipped no list, not the default.
+/// Test: `super::distribute_tests::a_package_with_a_repo_list_says_the_targets_are_already_declared`.
+fn targets_step(declared_repos: usize) -> String {
+    if declared_repos > 0 {
+        return format!(
+            "Your auditor already listed the {} for this engagement — they are the\n\
+             `[[targets]]` entries in `../{config}`, and step 4 audits exactly that\n\
+             list without asking you to pick anything. Read them first:\n\
+             \n\
+             ```sh\n\
+             ./{LAUNCHER_NAME} targets\n\
+             ```\n\
+             \n\
+             Add one the list missed with `./{LAUNCHER_NAME} add repo <owner>/<name>`, or\n\
+             drop one with `./{LAUNCHER_NAME} remove <owner>/<name>`. Both write through to\n\
+             `../{config}`.",
+            match declared_repos {
+                1 => "repository".to_owned(),
+                n => format!("{n} repositories"),
+            },
+            config = EngagementConfig::FILE_NAME,
+        );
+    }
+    format!(
+        "This package ships no repository list, so register each repository you want\n\
+         audited. Every one is checked against your GitHub credential before it is\n\
+         registered, so a typo is refused here rather than halfway through the audit:\n\
+         \n\
+         ```sh\n\
+         ./{LAUNCHER_NAME} add repo <owner>/<name>\n\
+         ```\n\
+         \n\
+         Repeat for each. If you already have the list, put a `repos.txt` beside\n\
+         `../{config}` instead — one `owner/name` per line, `#` starts a comment — and\n\
+         the client reads it rather than asking.",
+        config = EngagementConfig::FILE_NAME,
+    )
+}
+
+/// The instructions, with this engagement's own labels substituted.
+///
+/// Why: the sequence is the same for every engagement, but four facts are not —
+/// which platform the binary was built for, where the work root is, whether a
+/// key ships, and whether a repository list does. Substituting rather than
+/// branching keeps the prose reviewable as one document.
+/// What: [`README_TEMPLATE`] with each `{{NAME}}` replaced. Every placeholder is
+/// replaced unconditionally, so a template that grows one this function does not
+/// know leaves it visible in the output rather than silently dropping it.
+/// Test: `super::distribute_tests::the_instructions_name_the_one_shot_verb_and_the_disk_access_prompt`,
+/// `super::distribute_tests::a_prompt_for_key_package_tells_the_recipient_to_expect_the_prompt`.
+pub fn render_readme(
+    config: &EngagementConfig,
+    platform_line: &str,
+    prompts_for_key: bool,
+    declared_repos: usize,
+) -> String {
+    README_TEMPLATE
+        .replace("{{ENGAGEMENT}}", &engagement_label(config))
+        .replace("{{PLATFORM_LINE}}", platform_line)
+        .replace("{{LAUNCHER}}", LAUNCHER_NAME)
+        .replace("{{CONFIG}}", EngagementConfig::FILE_NAME)
+        .replace("{{WORK}}", crate::workdir::DEFAULT_ROOT_DISPLAY)
+        .replace("{{KEY_STEP}}", key_step(prompts_for_key))
+        .replace("{{TARGETS_STEP}}", &targets_step(declared_repos))
+}
+
+/// How this engagement is named at the top of both generated documents.
+pub fn engagement_label(config: &EngagementConfig) -> String {
+    match (&config.client, &config.engagement) {
+        (Some(client), Some(label)) => format!("{client} — {label}"),
+        (Some(client), None) => client.clone(),
+        (None, Some(label)) => label.clone(),
+        (None, None) => "unlabelled".to_owned(),
+    }
+}
+
+/// The root `README.md`: a pointer, not a second copy of the instructions.
+///
+/// Why: #5483. The root README and `instructions/README.md` said overlapping
+/// things, and the root one was the stale half — it walked the recipient
+/// through `run` then `package` when the one-shot `audit` verb had existed
+/// since #5824, and never mentioned Full Disk Access. Two documents that must
+/// agree eventually do not, so only one carries the sequence.
+/// What: the engagement label, the platform, and the one command that opens the
+/// instructions. Short enough that a recipient reads all of it.
+/// Test: `super::distribute_tests::the_root_readme_points_at_the_instructions`.
+pub fn render_pointer(config: &EngagementConfig, platform_line: &str) -> String {
+    format!(
+        "# Audit client — {engagement}\n\
+         \n\
+         {platform_line}\n\
+         \n\
+         The instructions are in `{INSTRUCTIONS_DIR}/{README_NAME}`. Read that first —\n\
+         it is the whole sequence, in order, with the exact command for each step.\n\
+         \n\
+         ```sh\n\
+         open {INSTRUCTIONS_DIR}/{README_NAME}      # or: less {INSTRUCTIONS_DIR}/{README_NAME}\n\
+         ```\n\
+         \n\
+         `{INSTRUCTIONS_DIR}/engagement.template.toml` documents every key\n\
+         `{config_file}` accepts, beside this folder.\n\
+         \n\
+         Nothing else in this folder needs to be opened. `{config_file}` is plain,\n\
+         readable TOML and you are meant to read it; `{launcher}` runs the client\n\
+         from wherever you extracted this, with no install step and no `PATH` change.\n",
+        engagement = engagement_label(config),
+        config_file = EngagementConfig::FILE_NAME,
+        launcher = LAUNCHER_NAME,
+    )
+}

--- a/crates/trusty-audit/src/session.rs
+++ b/crates/trusty-audit/src/session.rs
@@ -1760,6 +1760,7 @@ trusty-review = "0.0.0-never-published"
             .execute(Command::Distribute(DistributeOptions {
                 output_dir: Some(tmp.join("packages")),
                 binary: Some(binary),
+                ..DistributeOptions::default()
             }))
             .await
             .expect("assembles");
@@ -1785,7 +1786,7 @@ trusty-review = "0.0.0-never-published"
             "the package lands where the operator asked"
         );
         assert!(package.path.is_file());
-        assert_eq!(package.files.len(), 4);
+        assert_eq!(package.files.len(), crate::distribute::MEMBER_COUNT);
         assert!(!package.platform.is_empty());
     }
 
@@ -1958,6 +1959,7 @@ trusty-review = "0.0.0-never-published"
             .execute(Command::Distribute(DistributeOptions {
                 output_dir: Some(out.clone()),
                 binary: None,
+                ..DistributeOptions::default()
             }))
             .await
             .expect_err("no template, no package");

--- a/crates/trusty-audit/templates/engagement.template.toml
+++ b/crates/trusty-audit/templates/engagement.template.toml
@@ -1,0 +1,142 @@
+# engagement.toml — every field this client accepts.
+#
+# The live copy of this file sits one directory up, beside `audit.sh`, and the
+# client reads it on every run. This copy is the reference: it names every key,
+# with the CAST report preset already set. Nothing reads THIS file — edit the
+# one beside `audit.sh`, or hand this one back to your auditor to rebuild the
+# package (`taudit distribute --config <this file>`).
+#
+# The file is plain TOML and is meant to be read. It is not encrypted and it is
+# not obfuscated: you can see exactly what the client is configured to do
+# before you run it. See #5473.
+
+# ---------------------------------------------------------------------------
+# Required
+# ---------------------------------------------------------------------------
+
+# The OpenRouter key this engagement runs inference with.
+#
+# Blank means the client asks for it on the terminal the first time it needs
+# one, and writes what you type back into the live `engagement.toml` with
+# owner-only permissions. That is the normal handover: the key reaches you out
+# of band, never in this package.
+#
+# `OPENROUTER_API_KEY` in the environment beats this field and skips the
+# prompt, which is what a scripted or CI run uses.
+openrouter_key = ""
+
+# What this engagement is asked to assess, in prose. Free-form; it steers the
+# report's emphasis and never authorizes inventing a fact.
+instructions = "Assess the maintainability, security posture and delivery risk of the repositories listed below."
+
+# Recorded in the report and shown in the package README. Both optional.
+#
+# These are top-level keys, so they must stay ABOVE the first `[table]` header
+# below — a bare key written after one belongs to that table, and `[models]`
+# refuses a key it does not know.
+client = "Acme"
+engagement = "2026-Q3"
+
+# The exact tool versions this engagement runs. All four are REQUIRED — there
+# is no "latest", because a new `tga` paired with an old `trusty-review`
+# produces a deterministic report and exits 0 (#5454).
+#
+# Replace these with the versions your auditor pinned for this engagement.
+[tools]
+tga = "5.0.3"
+trusty-search = "0.52.0"
+trusty-analyze = "0.12.5"
+trusty-review = "0.31.2"
+
+# A pin may name the artifact's digest as well as its version, in which case a
+# download whose bytes do not match is refused:
+#
+# [tools]
+# trusty-review = { version = "0.31.2", sha256 = "…" }
+
+# ---------------------------------------------------------------------------
+# Report selection — the CAST preset
+# ---------------------------------------------------------------------------
+
+# Which report the run produces (#6669). These two keys are what make the
+# output a CAST-style technical due-diligence report rather than the default
+# one. The client hands them to the renderer as `TRUSTY_AUDIT_REPORT_TEMPLATE`
+# and `TRUSTY_AUDIT_REPORT_CODE_ONLY`.
+[report]
+# `cast`, `default`, `generic`, or a full bundled template name.
+template = "cast"
+
+# Render the sections a repository checkout cannot answer — Peer Benchmark,
+# Next Steps, interviews, ops metrics, org chart — as stated out-of-scope
+# boundaries rather than leaving them silently blank. Only `true` has an
+# effect; the renderer's own flag can turn the mode on, never off.
+code_only = true
+
+# How much of each repository the investigation pass may read (#6247). Absent
+# means the compiled defaults apply.
+#
+# investigate_max_files = 240
+# investigate_max_bytes = 2457600
+
+# ---------------------------------------------------------------------------
+# Repositories and boards this engagement audits
+# ---------------------------------------------------------------------------
+
+# What to audit. `taudit add repo <owner>/<name>` appends to this list, and
+# `taudit audit` reads it — a non-empty list means the run never asks you to
+# pick anything. Declare it here to skip registration entirely.
+#
+# Uncomment and edit:
+#
+# [[targets]]
+# kind = "repo"
+# name_with_owner = "acme/api"
+#
+# [[targets]]
+# kind = "repo"
+# name_with_owner = "acme/web"
+#
+# A checkout already on this machine is a different variant, validated by
+# reading it rather than by asking GitHub:
+#
+# [[targets]]
+# kind = "local_repo"
+# path = "/Users/you/src/acme-legacy"
+#
+# A JIRA project or Linear team:
+#
+# [[targets]]
+# kind = "board"
+# provider = "jira"
+# key = "OPS"
+
+# The client's own board credentials, when the engagement collects from one.
+# These are YOUR credentials, not the auditor's — a package never ships
+# someone else's, and any the auditor's template carried are stripped when the
+# package is built (#5861).
+#
+# [boards.jira]
+# url = "https://acme.atlassian.net"
+# email = "you@acme.example"
+# token = "…"
+#
+# [boards.linear]
+# api_key = "lin_api_…"
+
+# ---------------------------------------------------------------------------
+# Inference identity
+# ---------------------------------------------------------------------------
+
+# Which provider and which model runs each review role. Every key is optional
+# and absent means the client's built-in defaults, which are the roles the CAST
+# runbook used. They are written out here so a model rename can be corrected in
+# this file rather than waiting on a release (#5671).
+#
+# An unknown key in this table is a parse error, deliberately: a typo silently
+# falling back to a default is exactly what naming the models is meant to stop.
+[models]
+provider = "openrouter"
+reviewer = "anthropic/claude-opus-4.8"
+verifier = "anthropic/claude-haiku-4.5"
+summarizer = "anthropic/claude-haiku-4.5"
+

--- a/crates/trusty-audit/templates/instructions-README.md
+++ b/crates/trusty-audit/templates/instructions-README.md
@@ -1,0 +1,159 @@
+# Running the audit — {{ENGAGEMENT}}
+
+Everything you need is in the folder above this one. Nothing is installed into
+your system directories, and nothing here needs a Rust toolchain.
+
+{{PLATFORM_LINE}}
+- Configuration: `../{{CONFIG}}` — plain TOML, readable. Open it before you run
+  anything. `engagement.template.toml`, beside this file, documents every key it
+  accepts.
+- Working directory: `{{WORK}}`, created on first run.
+
+The working directory holds the clones, the collected database, the tooling and
+the reports. It is NOT inside the extracted folder: the code analysis cannot
+read a checkout under `~/Downloads`, `~/Desktop`, `~/Documents` or a temporary
+directory, which is where an emailed zip usually lands. Pass
+`--work-dir <path>` to any command below to put it somewhere else.
+
+## 1. Extract the folder
+
+```sh
+unzip trusty-audit-install.zip
+cd trusty-audit
+```
+
+On macOS a zip that arrived over the network is quarantined, and this build is
+not yet notarized, so the first run reports "cannot be opened because the
+developer cannot be verified". Clear the flag once, from inside the extracted
+folder:
+
+```sh
+xattr -dr com.apple.quarantine .
+```
+
+## 2. Install the pinned tools
+
+```sh
+./{{LAUNCHER}} install
+```
+
+This downloads the four tools this engagement pins — `tga`, `trusty-search`,
+`trusty-analyze`, `trusty-review` — verifies each against its recorded version
+and digest, and puts them inside the working directory. It needs no OpenRouter
+key. A version or digest that does not match refuses the whole set rather than
+installing part of it.
+
+It needs outbound HTTPS to `github.com` and `objects.githubusercontent.com`. A
+network that blocks binary downloads is the one failure that has no workaround
+inside this package — tell your auditor and they will send the binaries.
+
+## 3. Choose what to audit
+
+{{TARGETS_STEP}}
+
+Repository access uses **your own GitHub credential**, not the auditor's. If
+you have never authenticated `gh` on this machine, do it first — this is your
+credential and it never leaves your machine:
+
+```sh
+gh auth login
+```
+
+`./{{LAUNCHER}} targets` prints what this engagement is registered to audit.
+Check the count before you start: `17 repositories, 2 boards` catches a
+truncated list at a glance.
+
+## 4. Run the audit
+
+```sh
+./{{LAUNCHER}} audit
+```
+
+One command, start to finish. It clones each registered repository, indexes the
+checkout in `trusty-search`, measures it with `trusty-analyze`, sweeps the git
+history with `tga`, renders the report, and assembles the package to send back.
+
+{{KEY_STEP}}
+
+Once it starts it asks you nothing else. It may run for hours and prints
+progress as it goes. A repository that fails does not stop the rest — the run
+names every repository it could not cover and exits non-zero so a partial sweep
+never reads as a complete one. Interrupt it and run the same command again:
+installed tools, finished clones and audited repositories are all carried over.
+
+**macOS: Full Disk Access.** `trusty-search` indexes your checkouts, and macOS
+will ask for Full Disk Access the first time it reads one outside your home
+directory — or refuse silently if you are not asked. Grant it in **System
+Settings → Privacy & Security → Full Disk Access**, click **+**, and add the
+`trusty-search` binary from `{{WORK}}/tools/`. Without it the report renders
+with the code-analysis sections empty.
+
+## 5. Read the report
+
+The reports land under `{{WORK}}/out/`, one directory per repository, as a
+markdown file and a JSON twin carrying the same data. Open the markdown.
+
+## 6. Send the results back
+
+```sh
+./{{LAUNCHER}} package
+```
+
+This writes one zip and prints its path on the last line. Send that file.
+
+Open it before you send it. It is unencrypted and has no password on purpose,
+so you can read exactly what leaves your network. It carries each repository's
+report and the git-metadata database those reports were computed from. It never
+carries the OpenRouter key: every member's bytes are scanned for it while the
+zip is written, and a match refuses the whole package.
+
+The metadata database holds no file content, diffs, patches, hunks or blobs. It
+does hold free-text fields — commit messages, pull-request and work-item titles
+— so a code snippet someone pasted into a commit message is in it.
+
+## 7. Remove it afterwards
+
+```sh
+rm -rf {{WORK}}
+trusty-search index remove <each cloned repository path>
+```
+
+Then delete the extracted folder. The second command matters: to analyse your
+code the client approves each clone with `trusty-search`, and that approval is
+recorded in `trusty-search`'s own settings, outside the working directory. The
+run prints each path it approves, and `trusty-search index list` shows what is
+still approved.
+
+## If something fails
+
+Every command names the phase it failed in — install, materialize, collect or
+package — so the message says which step to look at. Then:
+
+| What to read | Where |
+|---|---|
+| Output from the tools this client runs | `{{WORK}}/logs/` |
+| What the sweep actually covered | `{{WORK}}/out/manifest.toml` |
+| Where the run stopped, for a resume | `{{WORK}}/state/run-progress.toml` |
+| What is registered to be audited | `./{{LAUNCHER}} targets` |
+| Which tools are installed, at which versions | `./{{LAUNCHER}} tools` |
+
+Add `RUST_LOG=debug` before any command for more detail on stderr:
+
+```sh
+RUST_LOG=debug ./{{LAUNCHER}} audit
+```
+
+Four failures have a specific answer:
+
+- **"cannot be opened because the developer cannot be verified"** — the
+  quarantine flag. Step 1.
+- **The report's code-analysis sections are empty** — Full Disk Access. Step 4.
+- **A repository is refused when you register it** — `gh auth login`, or the
+  account you authenticated cannot read that repository. Step 3.
+- **A tool download is refused** — the version or digest did not match, or the
+  network blocked it. Nothing in the package works around this; send your
+  auditor the message.
+
+Anything else: send your auditor the last twenty lines of output and the
+contents of `{{WORK}}/logs/`. Neither carries your OpenRouter key — it is
+redacted everywhere it could otherwise be printed.


### PR DESCRIPTION
`taudit distribute` now builds the package the owner's handover actually needs: it ships an `instructions/` directory beside the binary, can bake the CAST report preset into the generated `engagement.toml`, and can build a package that carries no OpenRouter key at all so the recipient is prompted for one on first run. A `--repos <file>` option pre-populates the package's `[[targets]]` from the repository-list formats this crate already reads, so the recipient's one-shot `taudit audit` audits exactly that list and asks them to pick nothing. The root `README.md` becomes a pointer at `instructions/README.md` rather than a second, staler copy of the sequence.

### Acceptance criteria

- [x] `--prompt-for-key` builds a package with no baked key. The generated `engagement.toml` carries a blank `openrouter_key`, which is the exact state `cli::credential::resolve` turns into the first-run `/dev/tty` prompt, persisted by the existing `persist` path. The flag beats both `OPENROUTER_API_KEY` and the template's key. Proven by `a_prompt_for_key_package_ships_no_credential` (no `sk-or-` in any member, and the resolver selects `CredentialSource::Prompt`) and `prompting_for_the_key_beats_a_supplied_one`. The baked-key mode is unchanged — `a_supplied_key_beats_the_templates` and `a_blank_credential_is_refused_and_leaves_no_file` still pass.
- [x] `instructions/README.md` holds the ordered steps with exact commands: unzip and clear quarantine, `./audit.sh install`, `gh auth login` plus repository selection, the one-shot `./audit.sh audit`, where the report lands, `./audit.sh package`. Includes the macOS Full Disk Access note (what to click, and which binary to add), the platform line, and an "If something fails" section naming `logs/`, `manifest.toml` and `run-progress.toml`.
- [x] `instructions/engagement.template.toml` documents every config key with `[report] template = "cast"` / `code_only = true` set and `[models]` naming the runbook's openrouter roles. It is itself a loadable config — `the_shipped_config_reference_is_itself_loadable`.
- [x] `--template cast` writes those two keys into the live `engagement.toml`; the default preset writes nothing, so an existing package is byte-identical in that respect.
- [x] The root README is a pointer at `instructions/README.md` — one source of truth.
- [x] `a_cast_package_with_a_repo_list_and_no_key_carries_all_three` builds a package with `--template cast`, no key, and a repos file, reads every member back out, and asserts both instruction members exist, the root config has the CAST keys, the declared repositories and no key, `engagement_targets` returns that list, and the launcher extracts `0o755` with the config at `0o600`.
- [x] `crates/trusty-audit/README.md` gains "Building a handoff package for a recipient" with the exact prompt-for-key CAST command line. Why/What/Test doc comments on every new public item; `// #5483` at the change sites.
- [x] `crates/trusty-audit/changelog.d/5483-distribute-instructions-and-prompt-for-key.md`.

### Repository-list format — what was reused, not invented

The list is written into `engagement.toml`'s existing `targets` key (`config::TARGETS_FIELD`, `registry::Target`, `crates/trusty-audit/src/config.rs:462`), through the existing `config::with_targets` writer that `taudit add repo` already uses. `--repos` reads its input with `cli::targets_file::read_repo_list`, which reuses the same line normalizer and the same `registry::parse` decision `detect` uses for `repos.txt`. It also accepts a previous engagement's `engagement.toml` and reuses its `[[targets]]`. No second format.

`chain.rs:317` already reads `registry::engagement_targets`, which prefers a config-declared list, so `taudit audit` consumes it with no interactive picker and no code change — the picker stays the fallback for a package that shipped no list, and the instructions say so.

### Test ladder

Rung 3 — localized behavior inside one crate (`trusty-audit` is a binary crate; no library crate was touched).

```
cargo fmt --check                                        # EXIT=0
cargo check -p trusty-audit --all-targets                # EXIT=0
cargo clippy -p trusty-audit --all-targets -- -D warnings # EXIT=0
cargo test -p trusty-audit --no-fail-fast                # EXIT=0
  test result: ok. 778 passed; 0 failed; 5 ignored
  plus 8 integration targets: 3, 5, 4, 4, 8, 9, 0, 0 passed; 0 failed
bash scripts/check_line_cap.sh          # 4410 files, 0 violations
bash scripts/check_changelog_fragment.sh # 11 paths scanned, trusty-audit recorded
bash scripts/check_test_pointers.sh      # 29961 citations, 0 dangling
bash scripts/check_sld.sh                # 0 errors, 0 warnings
```

Refs #5473 #5483

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
