### PR TITLE
chore(release): bump tga 6.0.0, trusty-console 0.10.0, trusty-review 0.32.0, trusty-audit 0.13.1 for the 2026-09-02 cut

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10439,7 +10439,7 @@ dependencies = [
 
 [[package]]
 name = "tga"
-version = "5.0.3"
+version = "6.0.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -11481,7 +11481,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-audit"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -11694,7 +11694,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-console"
-version = "0.9.3"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -11998,7 +11998,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-review"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,7 +161,7 @@ trusty-mpm = { path = "crates/trusty-mpm", version = "1.0.0" }
 #      this line existed. Both consumers name what they need: trusty-analyze's
 #      `review` feature pulls `trusty-review/mcp`; trusty-mpm's dev-dependency
 #      only touches `integrations`, which is unconditional.
-trusty-review = { path = "crates/trusty-review", version = "0.31", default-features = false }
+trusty-review = { path = "crates/trusty-review", version = "0.32", default-features = false }
 # trusty-console: web dashboard for trusty services. As of #1318 the standalone
 # `trusty-console` crate is the SOLE producer of the `trusty-console` binary
 # (de-bundled from the host crates for single-owner-per-binary). It is still a

--- a/crates/trusty-audit/CHANGELOG.md
+++ b/crates/trusty-audit/CHANGELOG.md
@@ -10,16 +10,21 @@ edit this file by hand (see
 
 ---
 
-## [0.13.0] — 2026-09-02
+## [0.13.1] — 2026-09-02
 
 ### Added
 
 - `engagement.toml` accepts `[report] template` and `[report] code_only`, so an engagement declares which report it wants once instead of the operator remembering a flag for a child this crate spawns. Both reach the renderer as environment pairs on the `audit` sweep and the `render` re-render, the same channel the investigation budget already uses — the manifest arrives too late on the sweep path, and an argument would break an older pinned renderer. (#6669)
 - `grounding::index::index_tests::a_refused_index_is_a_reason_not_a_status` — `ensure_indexed` turns a refused `trusty-search index` into the one-line reason its caller records as a gap, rather than reporting an `IndexStatus` for an index that was never built (#6678).
+- `taudit distribute` ships an `instructions/` directory beside the binary: `instructions/README.md` is the numbered sequence the recipient runs — install, register, the one-shot `audit`, `package` — with the macOS Full Disk Access and quarantine notes and an "If something fails" section naming the log locations, and `instructions/engagement.template.toml` documents every config key with the CAST report preset set. The root `README.md` is now a pointer at them rather than a second copy of the sequence.
+- `taudit distribute --prompt-for-key` builds a package carrying no credential: the generated `engagement.toml` has a blank `openrouter_key`, and the recipient's first `audit` asks for the key on the terminal and saves it. The flag beats `OPENROUTER_API_KEY` and the template's own key, so a stale variable cannot bake one in.
+- `taudit distribute --template cast` writes `[report] template = "cast"` and `code_only = true` into the generated config, so the CAST-style report no longer needs a hand-edited template before every handoff.
+- `taudit distribute --repos <file>` pre-populates the package's `[[targets]]`, from a `repos.txt` list or a previous engagement's `engagement.toml`. The recipient's `taudit audit` then audits exactly that list and asks them to pick nothing.
 
 ### Changed
 
 - The grounding guard's `analyze.health` frame carries `"params": {}` (#6555). It sent no `params` at all, which decodes to `Value::Null` and works only because `analyze.health` is bound to `NoParams`; binding that method to a struct would have turned the omission into a `-32602`, which the guard reads as a degraded daemon and refuses the run on
+- The `[tools]` pins in the bundled `engagement.template.toml` name the versions the 2026-09-02 cut publishes: `tga` moves to `6.0.0` and `trusty-review` to `0.32.0` (`trusty-search` stays `0.52.0`, `trusty-analyze` stays `0.12.5`). A template pinning `tga = "5.0.3"` and `trusty-review = "0.31.2"` named two versions that never reach crates.io, so a recipient's first `taudit audit` would refuse the pinned download. `cli::targets_file`'s previous-engagement fixture mirrors the template and moves with it. (#6695)
 
 ### Documentation
 

--- a/crates/trusty-audit/Cargo.toml
+++ b/crates/trusty-audit/Cargo.toml
@@ -5,7 +5,12 @@ name = "trusty-audit"
 # `.code_only` fields through). `cargo-semver-checks` reports this as
 # `function_parameter_count_changed` against the 0.12.0 baseline; for a 0.y.z
 # crate the breaking bump is the MINOR position.
-version = "0.13.0"
+# 0.13.0 -> 0.13.1 (#6695, 2026-09-02 cut): PATCH. #6701 merged `src/**` after
+# the 0.13.0 changelog section was assembled and left its fragment unfolded, so
+# the cut ships as 0.13.1 with that fragment folded in. This bump also carries
+# the `[tools]` pin refresh in templates/engagement.template.toml onto the
+# versions this cut publishes. No public API change.
+version = "0.13.1"
 description = "Auditor client — installs its pinned audit tooling and drives an audit engagement on the recipient's own codebases."
 readme = "README.md"
 homepage = "https://github.com/bobmatnyc/trusty-tools"

--- a/crates/trusty-audit/changelog.d/5483-distribute-instructions-and-prompt-for-key.md
+++ b/crates/trusty-audit/changelog.d/5483-distribute-instructions-and-prompt-for-key.md
@@ -1,6 +1,0 @@
-Added
-
-- `taudit distribute` ships an `instructions/` directory beside the binary: `instructions/README.md` is the numbered sequence the recipient runs — install, register, the one-shot `audit`, `package` — with the macOS Full Disk Access and quarantine notes and an "If something fails" section naming the log locations, and `instructions/engagement.template.toml` documents every config key with the CAST report preset set. The root `README.md` is now a pointer at them rather than a second copy of the sequence.
-- `taudit distribute --prompt-for-key` builds a package carrying no credential: the generated `engagement.toml` has a blank `openrouter_key`, and the recipient's first `audit` asks for the key on the terminal and saves it. The flag beats `OPENROUTER_API_KEY` and the template's own key, so a stale variable cannot bake one in.
-- `taudit distribute --template cast` writes `[report] template = "cast"` and `code_only = true` into the generated config, so the CAST-style report no longer needs a hand-edited template before every handoff.
-- `taudit distribute --repos <file>` pre-populates the package's `[[targets]]`, from a `repos.txt` list or a previous engagement's `engagement.toml`. The recipient's `taudit audit` then audits exactly that list and asks them to pick nothing.

--- a/crates/trusty-audit/src/cli/targets_file.rs
+++ b/crates/trusty-audit/src/cli/targets_file.rs
@@ -575,8 +575,8 @@ mod targets_file_tests {
         std::fs::write(
             &path,
             "openrouter_key = \"\"\ninstructions = \"x\"\n\n\
-             [tools]\ntga = \"5.0.3\"\ntrusty-search = \"0.52.0\"\n\
-             trusty-analyze = \"0.12.5\"\ntrusty-review = \"0.31.2\"\n\n\
+             [tools]\ntga = \"6.0.0\"\ntrusty-search = \"0.52.0\"\n\
+             trusty-analyze = \"0.12.5\"\ntrusty-review = \"0.32.0\"\n\n\
              [[targets]]\nkind = \"repo\"\nname_with_owner = \"acme/api\"\n",
         )
         .expect("write the config");

--- a/crates/trusty-audit/templates/engagement.template.toml
+++ b/crates/trusty-audit/templates/engagement.template.toml
@@ -43,16 +43,16 @@ engagement = "2026-Q3"
 #
 # Replace these with the versions your auditor pinned for this engagement.
 [tools]
-tga = "5.0.3"
+tga = "6.0.0"
 trusty-search = "0.52.0"
 trusty-analyze = "0.12.5"
-trusty-review = "0.31.2"
+trusty-review = "0.32.0"
 
 # A pin may name the artifact's digest as well as its version, in which case a
 # download whose bytes do not match is refused:
 #
 # [tools]
-# trusty-review = { version = "0.31.2", sha256 = "…" }
+# trusty-review = { version = "0.32.0", sha256 = "…" }
 
 # ---------------------------------------------------------------------------
 # Report selection — the CAST preset

--- a/crates/trusty-console/CHANGELOG.md
+++ b/crates/trusty-console/CHANGELOG.md
@@ -6,7 +6,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
-## [0.9.3] — 2026-09-02
+## [0.10.0] — 2026-09-02
 
 ### Added
 

--- a/crates/trusty-console/Cargo.toml
+++ b/crates/trusty-console/Cargo.toml
@@ -13,7 +13,11 @@ name        = "trusty-console"
 # (`src/connector.rs:100`). The struct was exhaustively constructible through
 # the public API, so a struct literal downstream stops compiling. Cargo's 0.x
 # rule puts a break in the MINOR position.
-version     = "0.9.3"
+# 0.9.3 -> 0.10.0 (#6695, 2026-09-02 cut): MINOR, which is the breaking position
+# for a 0.x crate. `preflight-publish.sh` CHECK 5 refused 0.9.3 against 0.9.2 on
+# two counts: `constructible_struct_adds_field` for `ServeArgs.host_sample_interval`
+# (src/lib.rs:204), and `function_missing` for `trusty_console::host_status::start`.
+version     = "0.10.0"
 edition     = "2024"
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/trusty-git-analytics/CHANGELOG.md
+++ b/crates/trusty-git-analytics/CHANGELOG.md
@@ -6,7 +6,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
-## [5.0.3] — 2026-09-02
+## [6.0.0] — 2026-09-02
 
 ### Added
 

--- a/crates/trusty-git-analytics/Cargo.toml
+++ b/crates/trusty-git-analytics/Cargo.toml
@@ -50,7 +50,12 @@ name = "tga"
 # already live on crates.io and #6564 edits `src/**` under it. Bumped on
 # `main` first so the `PR version bump vs crates.io` gate clears once #6564
 # updates its branch onto this commit.
-version = "5.0.3"
+# 5.0.3 -> 6.0.0 (#6695, 2026-09-02 cut): MAJOR. `preflight-publish.sh` CHECK 5
+# refused 5.0.3 against 5.0.2 with `constructible_struct_adds_field` on
+# `CollectionStats.repos_skipped` (src/collect/collector.rs:106). The struct is
+# publicly constructible and carries no `#[non_exhaustive]`, so a downstream
+# struct literal stops compiling. Post-1.0, a break sits in the MAJOR position.
+version = "6.0.0"
 publish = true
 edition = "2021"
 # Aligned with the workspace MSRV (1.94) per #254. Required for

--- a/crates/trusty-review/CHANGELOG.md
+++ b/crates/trusty-review/CHANGELOG.md
@@ -6,7 +6,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
-## [0.31.2] — 2026-09-02
+## [0.32.0] — 2026-09-02
 
 ### Added
 

--- a/crates/trusty-review/Cargo.toml
+++ b/crates/trusty-review/Cargo.toml
@@ -85,7 +85,14 @@ name        = "trusty-review"
 # `report/code_only.rs`; `ReportRequest`/`run_report` are new public items,
 # purely additive. `cargo-semver-checks` reports no breaking changes against
 # the 0.31.0 baseline, so PATCH is correct.
-version     = "0.31.2"
+# 0.31.2 -> 0.32.0 (#6695, 2026-09-02 cut): MINOR, the breaking position for a
+# 0.x crate. `preflight-publish.sh` CHECK 5 refused 0.31.2 against 0.31.0 on two
+# counts: `function_missing` for
+# `trusty_review::report::analyze_adapter::derive_index_id` (the derivation moved
+# to `report::index_registry` under #6677), and `trait_method_added` for
+# `SearchClient::index_status` (src/integrations/search_client.rs:229), which an
+# out-of-tree implementor of the trait would have to add.
+version     = "0.32.0"
 edition     = "2024"
 rust-version.workspace = true
 license.workspace      = true


### PR DESCRIPTION
Phase 1 of the 2026-09-02 publish train (`preflight-publish.sh --check-only` at
c18196442) failed CHECK 5 for three crates. Each bump here is the position that
verdict names. Nothing is silenced with an exclusions row.

## The verdicts that forced each bump

**tga 5.0.3 → 6.0.0** — baseline 5.0.2:

> `constructible_struct_adds_field`: field `CollectionStats.repos_skipped` in
> `crates/trusty-git-analytics/src/collect/collector.rs:106`
> Summary: semver requires new major version: 1 major and 0 minor checks failed

**trusty-console 0.9.3 → 0.10.0** — baseline 0.9.2:

> `constructible_struct_adds_field`: field `ServeArgs.host_sample_interval` in
> `crates/trusty-console/src/lib.rs:204`
> `function_missing`: function `trusty_console::host_status::start`, previously
> in `trusty-console-0.9.2/src/host_status.rs:83`
> Summary: semver requires new major version: 2 major and 0 minor checks failed

**trusty-review 0.31.2 → 0.32.0** — baseline 0.31.0:

> `function_missing`: function
> `trusty_review::report::analyze_adapter::derive_index_id`, previously in
> `trusty-review-0.31.0/src/report/analyze_adapter.rs:843`
> `trait_method_added`: trait method
> `trusty_review::integrations::search_client::SearchClient::index_status` in
> `crates/trusty-review/src/integrations/search_client.rs:229`
> Summary: semver requires new major version: 2 major and 0 minor checks failed

Cargo's 0.x rule puts a break in the MINOR position, so the two 0.x crates go to
0.10.0 and 0.32.0; tga is post-1.0 and goes to 6.0.0.

**trusty-audit 0.13.0 → 0.13.1** — no semver verdict forced this one. #6701
merged `src/**` after the 0.13.0 changelog section was assembled and left its
fragment unfolded, so the cut ships as 0.13.1 with that fragment folded in.

## trusty-analyze is not bumped

The root `[workspace.dependencies]` req for trusty-review moves `0.31` → `0.32`,
which changes trusty-analyze's published manifest. It still needs no bump:
`check-version-parity.sh` reports `trusty-analyze 0.12.5 — not yet published,
nothing to compare`, so there is no live manifest to drift from, and
`check_semver.sh --crate trusty-analyze` reports `no semver update required`
against its 0.12.3 baseline. Per the brief, nothing the scripts do not require
was bumped.

The `tga` (`version = "4.0.2"`) and `trusty-console` (`version = "0.9.0"`)
workspace entries are left as they are. No member consumes either through
`workspace = true` — trusty-analyze takes both as path-only dev-dependencies —
so those reqs are unreferenced and were already stale before this cut.

## Changelog re-homing

The assembled `## [5.0.3]`, `## [0.9.3]`, `## [0.31.2]` and `## [0.13.0]`
sections were cut for versions that will now never publish.
`scripts/assemble-changelog.sh --help` offers `--check`, `--merge` and
`--stdout` — **there is no rename or relabel mode**, so the heading line is the
only thing edited by hand. Every entry and every section date is unchanged, and
none of these four changelogs carries link-reference definitions, so there is
nothing else to keep in step.

trusty-audit's fold went through the assembler: a new fragment
(`6695-refresh-pinned-tool-versions.md`) for the pin refresh joined the unfolded
`5483-distribute-instructions-and-prompt-for-key.md`, then
`assemble-changelog.sh trusty-audit 0.13.1 --merge` folded both in and deleted
them — `Merged 2 fragment(s) into the existing [0.13.1] section`.

`check-changelog-assembled.sh` passes for all four new versions. No other
crate's fragments are touched.

## trusty-audit pinned tool versions

The `[tools]` pins named `tga = "5.0.3"` and `trusty-review = "0.31.2"` — two
versions this cut will never publish, so a recipient's first `taudit audit` would
refuse the pinned download. Two sites carried them:

- `crates/trusty-audit/templates/engagement.template.toml:46,49,55` — the live
  pins plus the `sha256` example comment.
- `crates/trusty-audit/src/cli/targets_file.rs:578-579` — the
  previous-engagement fixture in
  `a_named_repo_list_reads_an_engagement_config`, which mirrors the template
  verbatim.

Both now read `tga = "6.0.0"` and `trusty-review = "0.32.0"`; `trusty-search`
stays `0.52.0` and `trusty-analyze` stays `0.12.5`. `RequiredTool::ALL`
(`src/tools.rs:85`) carries no versions — pins come from the config via
`pin_in(pins)` — so there was no third site. Every other version literal under
`crates/trusty-audit` is a synthetic test fixture (`2.9.4`, `0.47.0`, `0.9.2`,
`0.15.1`) unrelated to the real pins; those are left alone. No test asserted the
old pins, so none needed updating.

## Rung

**Rung 1** for the version metadata and the changelog re-homing, plus the
trusty-audit source edit, which earns rung 3 on that crate:

- `cargo fmt --check` — clean
- `cargo check --workspace` — `Finished dev profile in 2m 08s`
- `cargo clippy -p {tga,trusty-console,trusty-review,trusty-audit} --all-targets -- -D warnings` — clean
- `cargo test -p trusty-audit --no-fail-fast` — `783 tests; 778 passed; 0 failed; 5 ignored`, plus 9 further targets all `ok` (0 failed)
- `check_semver.sh` for all five crates — every run reports `compared=1 … blind=0`
- `check-version-parity.sh` — `21 publishable crate(s) … 0 drifted, 0 unverifiable`
- `check-changelog-assembled.sh` × 4 — PASS
- `check_line_cap.sh` — `4410 tracked .rs file(s); 0 violations`
- `check_sld.sh` — `0 error(s), 0 warning(s)`
- `check_test_pointers.sh` — `29961 citations; 0 dangling`
- `check_teardown_guard.sh`, `check_generation_artifacts.sh` — OK

## Expected red

`scripts/check_changelog_fragment.sh` fails: `FAIL trusty-audit:
crates/trusty-audit/src/** changed with no changelog record`. This is #6695
exactly — the `--merge` needed to satisfy `check-changelog-assembled.sh`
consumes the fragment in the same commit, so `origin/main...HEAD` shows a
CHANGELOG bullet and a deleted fragment with no net-new fragment file. The
changelog-fragment context is **not** in
`required_status_checks.contexts`, so it does not block the merge.

Refs #6695

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
