### PR TITLE
docs(trusty-audit): handoff instructions tell the recipient how to fill in the engagement and add repositories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11481,7 +11481,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-audit"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/trusty-audit/Cargo.toml
+++ b/crates/trusty-audit/Cargo.toml
@@ -10,7 +10,7 @@ name = "trusty-audit"
 # the cut ships as 0.13.1 with that fragment folded in. This bump also carries
 # the `[tools]` pin refresh in templates/engagement.template.toml onto the
 # versions this cut publishes. No public API change.
-version = "0.13.1"
+version = "0.13.2"
 description = "Auditor client — installs its pinned audit tooling and drives an audit engagement on the recipient's own codebases."
 readme = "README.md"
 homepage = "https://github.com/bobmatnyc/trusty-tools"

--- a/crates/trusty-audit/changelog.d/5483-instructions-fill-in-engagement.md
+++ b/crates/trusty-audit/changelog.d/5483-instructions-fill-in-engagement.md
@@ -1,0 +1,9 @@
+Documentation
+
+- The handoff instructions now walk the recipient through a "Fill in the
+  engagement" step, placed before install and audit: replace the placeholder
+  `client`, `engagement`, and `instructions` fields in `engagement.toml`,
+  register a repository with `add repo` or by pasting `[[targets]]` TOML
+  directly, list and remove targets, and what `audit` does with nothing
+  registered. `engagement.template.toml`'s comments mark those three fields
+  "replace before running" (#5473, #5483).

--- a/crates/trusty-audit/src/distribute.rs
+++ b/crates/trusty-audit/src/distribute.rs
@@ -1173,6 +1173,53 @@ api_key = "lin_api_client_a"
         assert!(readme.contains(&host_platform()), "{readme}");
     }
 
+    /// #5473, #5483: the recipient must fill in the placeholder engagement
+    /// fields and register a repository BEFORE installing or auditing
+    /// anything, not after — a recipient who runs `install` first still has
+    /// no idea the config needs editing at all.
+    #[test]
+    fn the_engagement_setup_step_precedes_install_and_names_the_fields_to_replace() {
+        let fixture = Fixture::new(TEMPLATE);
+        let package = fixture.assemble().expect("assembles");
+
+        let readme = instructions_of(&package);
+        let setup = readme
+            .find("Fill in the engagement")
+            .expect("names the setup step");
+        let install = readme.find("./audit.sh install").expect("installs tools");
+        assert!(
+            setup < install,
+            "engagement setup must come before install: {readme}"
+        );
+
+        // (i) which fields to replace, with a worked example.
+        assert!(
+            readme.contains("Set `client`, `engagement`, and `instructions`"),
+            "{readme}"
+        );
+        assert!(readme.contains("client = \"Example Corp\""), "{readme}");
+
+        // (ii) the exact `[[targets]]` shape, for the paste-in alternative to
+        // `add repo`.
+        assert!(readme.contains("[[targets]]"), "{readme}");
+        assert!(readme.contains("kind = \"repo\""), "{readme}");
+        assert!(
+            readme.contains("name_with_owner = \"acme/api\""),
+            "{readme}"
+        );
+        assert!(readme.contains("./audit.sh remove"), "{readme}");
+
+        // (iii) private-repo access rides the recipient's own `gh` credential.
+        assert!(readme.contains("gh auth login"), "{readme}");
+
+        // (iv) what a zero-target run actually does.
+        assert!(readme.contains("nothing to audit"), "{readme}");
+        assert!(
+            readme.contains("resumes the existing selection"),
+            "the no-target note must name the fallback-to-prior-selection case: {readme}"
+        );
+    }
+
     /// #5483: one source of truth. The root README carries the platform and the
     /// pointer, and must not grow a second copy of the sequence.
     #[test]

--- a/crates/trusty-audit/src/distribute/instructions.rs
+++ b/crates/trusty-audit/src/distribute/instructions.rs
@@ -75,7 +75,13 @@ fn key_step(prompts_for_key: bool) -> &'static str {
 /// `engagement.toml`, and telling that recipient to register repositories one
 /// at a time invites them to register the same set twice. The picker is the
 /// fallback for a package that shipped no list, not the default.
-/// Test: `super::distribute_tests::a_package_with_a_repo_list_says_the_targets_are_already_declared`.
+///
+/// #5483: the no-list branch now names both ways to register a repository —
+/// `add repo` and pasting `[[targets]]` TOML directly — plus `remove`, so a
+/// recipient reading only this step can add, list, and drop a target without
+/// hunting through the reference config.
+/// Test: `super::distribute_tests::a_package_with_a_repo_list_says_the_targets_are_already_declared`,
+/// `super::distribute_tests::the_engagement_setup_step_precedes_install_and_names_the_fields_to_replace`.
 fn targets_step(declared_repos: usize) -> String {
     if declared_repos > 0 {
         return format!(
@@ -100,15 +106,31 @@ fn targets_step(declared_repos: usize) -> String {
     format!(
         "This package ships no repository list, so register each repository you want\n\
          audited. Every one is checked against your GitHub credential before it is\n\
-         registered, so a typo is refused here rather than halfway through the audit:\n\
+         registered, so a typo is refused here rather than halfway through the audit —\n\
+         one command per repository, for example two placeholders:\n\
          \n\
          ```sh\n\
-         ./{LAUNCHER_NAME} add repo <owner>/<name>\n\
+         ./{LAUNCHER_NAME} add repo acme/api\n\
+         ./{LAUNCHER_NAME} add repo acme/web\n\
          ```\n\
          \n\
-         Repeat for each. If you already have the list, put a `repos.txt` beside\n\
-         `../{config}` instead — one `owner/name` per line, `#` starts a comment — and\n\
-         the client reads it rather than asking.",
+         Or paste `[[targets]]` blocks straight into `../{config}` instead — the exact\n\
+         shape `add repo` writes:\n\
+         \n\
+         ```toml\n\
+         [[targets]]\n\
+         kind = \"repo\"\n\
+         name_with_owner = \"acme/api\"\n\
+         \n\
+         [[targets]]\n\
+         kind = \"repo\"\n\
+         name_with_owner = \"acme/web\"\n\
+         ```\n\
+         \n\
+         If you already have the list, put a `repos.txt` beside `../{config}` instead —\n\
+         one `owner/name` per line, `#` starts a comment — and the client reads it rather\n\
+         than asking. List what is registered with `./{LAUNCHER_NAME} targets`, and drop\n\
+         one with `./{LAUNCHER_NAME} remove <owner>/<name>`.",
         config = EngagementConfig::FILE_NAME,
     )
 }
@@ -122,8 +144,14 @@ fn targets_step(declared_repos: usize) -> String {
 /// What: [`README_TEMPLATE`] with each `{{NAME}}` replaced. Every placeholder is
 /// replaced unconditionally, so a template that grows one this function does not
 /// know leaves it visible in the output rather than silently dropping it.
+///
+/// #5483: "Fill in the engagement" — replacing the placeholder `client`,
+/// `engagement`, and `instructions` and registering a repository — now sits at
+/// step 2, before install and audit, so the recipient edits the config before
+/// running anything that reads it.
 /// Test: `super::distribute_tests::the_instructions_name_the_one_shot_verb_and_the_disk_access_prompt`,
-/// `super::distribute_tests::a_prompt_for_key_package_tells_the_recipient_to_expect_the_prompt`.
+/// `super::distribute_tests::a_prompt_for_key_package_tells_the_recipient_to_expect_the_prompt`,
+/// `super::distribute_tests::the_engagement_setup_step_precedes_install_and_names_the_fields_to_replace`.
 pub fn render_readme(
     config: &EngagementConfig,
     platform_line: &str,

--- a/crates/trusty-audit/templates/engagement.template.toml
+++ b/crates/trusty-audit/templates/engagement.template.toml
@@ -27,9 +27,13 @@ openrouter_key = ""
 
 # What this engagement is asked to assess, in prose. Free-form; it steers the
 # report's emphasis and never authorizes inventing a fact.
+#
+# Replace before running — this is a placeholder for the reference, not the
+# engagement's actual scope.
 instructions = "Assess the maintainability, security posture and delivery risk of the repositories listed below."
 
-# Recorded in the report and shown in the package README. Both optional.
+# Recorded in the report and shown in the package README. Both optional, and
+# both placeholders below — replace before running.
 #
 # These are top-level keys, so they must stay ABOVE the first `[table]` header
 # below — a bare key written after one belongs to that table, and `[models]`

--- a/crates/trusty-audit/templates/instructions-README.md
+++ b/crates/trusty-audit/templates/instructions-README.md
@@ -31,7 +31,44 @@ folder:
 xattr -dr com.apple.quarantine .
 ```
 
-## 2. Install the pinned tools
+## 2. Fill in the engagement
+
+`../{{CONFIG}}` ships with placeholder values for this engagement. It is
+already `chmod 0600` — open it in any text editor and edit it in place. Nothing
+reads `engagement.template.toml`, the reference beside it; that file exists to
+document every key, not to be run.
+
+1. Set `client`, `engagement`, and `instructions` to this engagement's real
+   values. For example:
+
+   ```toml
+   client = "Example Corp"
+   engagement = "2026-Q4"
+   ```
+
+2. {{TARGETS_STEP}}
+
+3. Repository access uses **your own GitHub credential**, not the auditor's.
+   If you have never authenticated `gh` on this machine, do it first — a
+   private repository is refused when you register it until you do, and this
+   credential never leaves your machine:
+
+   ```sh
+   gh auth login
+   ```
+
+`./{{LAUNCHER}} targets` prints what this engagement is registered to audit.
+Check the count before you start: `17 repositories, 2 boards` catches a
+truncated list at a glance.
+
+**If you skip this step:** step 4 below, with no repository registered,
+refuses to run rather than silently auditing nothing — it prints "nothing to audit … register one with `trusty-audit add repo <owner>/<name>`" (in
+this package, run `./{{LAUNCHER}} add repo <owner>/<name>`) and stops before
+touching the network. The one exception is a previously interrupted run that
+already cloned a repository: that resumes the existing selection instead of
+refusing.
+
+## 3. Install the pinned tools
 
 ```sh
 ./{{LAUNCHER}} install
@@ -46,22 +83,6 @@ installing part of it.
 It needs outbound HTTPS to `github.com` and `objects.githubusercontent.com`. A
 network that blocks binary downloads is the one failure that has no workaround
 inside this package — tell your auditor and they will send the binaries.
-
-## 3. Choose what to audit
-
-{{TARGETS_STEP}}
-
-Repository access uses **your own GitHub credential**, not the auditor's. If
-you have never authenticated `gh` on this machine, do it first — this is your
-credential and it never leaves your machine:
-
-```sh
-gh auth login
-```
-
-`./{{LAUNCHER}} targets` prints what this engagement is registered to audit.
-Check the count before you start: `17 repositories, 2 boards` catches a
-truncated list at a glance.
 
 ## 4. Run the audit
 
@@ -149,7 +170,7 @@ Four failures have a specific answer:
   quarantine flag. Step 1.
 - **The report's code-analysis sections are empty** — Full Disk Access. Step 4.
 - **A repository is refused when you register it** — `gh auth login`, or the
-  account you authenticated cannot read that repository. Step 3.
+  account you authenticated cannot read that repository. Step 2.
 - **A tool download is refused** — the version or digest did not match, or the
   network blocked it. Nothing in the package works around this; send your
   auditor the message.


### PR DESCRIPTION
The instructions README's \"Choose what to audit\" step moves earlier and becomes \"Fill in the engagement\" (step 2, before install and audit): it now tells the recipient to replace the placeholder `client`, `engagement`, and `instructions` fields in `engagement.toml`, register a repository with `add repo` or by pasting `[[targets]]` TOML directly, list and remove targets, confirm `gh auth login` works for private repos, and what `audit` does with nothing registered (refuses, unless a prior clone left a selection). `engagement.template.toml`'s comments mark those three fields "replace before running".

Rung 3 (localized, one crate). `cargo fmt -p trusty-audit --check`: clean. `cargo clippy -p trusty-audit --all-targets -- -D warnings`: clean. `cargo test -p trusty-audit --no-fail-fast`: `test result: ok. 779 passed; 0 failed; 5 ignored`. `bash scripts/check_sld.sh`: 0 errors. `bash scripts/check_changelog_fragment.sh`: OK.

Refs #5473 #5483

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools