### PR TITLE
chore(sessions): commit tm-trusty-tools-02 pause snapshot 2026-09-03 02:21Z

### DIFF
--- a/.trusty-mpm/sessions/sessions-log.jsonl
+++ b/.trusty-mpm/sessions/sessions-log.jsonl
@@ -79,3 +79,4 @@
 {"session_id":"tm-trusty-tools-02-0-at2307-20260902","event":"pause","snapshot":"tm-trusty-tools-02-0-at2307-20260902/session-20260902-111042.md","timestamp":"2026-09-02T11:10:42.983115+00:00"}
 {"session_id":"tm-trusty-tools-02-0-at2307-20260902","event":"pause","snapshot":"tm-trusty-tools-02-0-at2307-20260902/session-20260902-162807.md","timestamp":"2026-09-02T16:28:07.264636+00:00"}
 {"session_id":"tm-trusty-tools-02-0-at5288-20260902","event":"pause","snapshot":"tm-trusty-tools-02-0-at5288-20260902/session-20260902-210316.md","timestamp":"2026-09-02T21:03:16.995522+00:00"}
+{"session_id":"tm-trusty-tools-02-0-at5288-20260902","event":"pause","snapshot":"tm-trusty-tools-02-0-at5288-20260902/session-20260903-022128.md","timestamp":"2026-09-03T02:21:28.822853+00:00"}

--- a/.trusty-mpm/sessions/tm-trusty-tools-02-0-at5288-20260902/session-20260903-022128.md
+++ b/.trusty-mpm/sessions/tm-trusty-tools-02-0-at5288-20260902/session-20260903-022128.md
@@ -1,0 +1,41 @@
+# Session Pause - 2026-09-03T02:21:28.822853+00:00
+
+## Summary
+Paused 2026-09-03 ~02:30Z, owner-invoked, leg 5 (resumed 21:1xZ from session-20260902-210316.md). Main checkout still parked on codex/documentation-inventory-2026-09-02 @ 1e4c2397f (do NOT commit or checkout there). origin/main = edaf9bfbf (PR #6702) or one ahead if PR #6703 landed. ONE monitor live at pause (b1hmv834b: PR #6703 merge) — it dies with the session; read the PR state directly on resume.
+
+RELEASE COMPLETE 2026-09-02 23:31–23:43Z: 13 crates published from edaf9bfbf and installed + signed here (tm 1.5.16, trusty-search 0.52.0, trusty-memory 0.25.6, trusty-analyze 0.12.5 --features review, trusty-review 0.32.0, taudit 0.13.1, tctl 0.13.4, tga 6.0.0, tcode 0.5.1, trusty-console 0.10.0, trusty-common 0.47.1, trusty-agents-common 0.6.3, trusty-code-tui 0.1.1); daemons restarted, search 52 indexes / trusty-tools-checkout 104433 chunks unchanged. Owner authorization "publish and install, then clean up the worktrees" DISCHARGED. Worktrees cleaned: only three held ones remain (agent-addd80fd PR #6607 owner review; agent-a259bfb3 locked; agent-a60e1286 feat/6657 hold) plus agent-ac3d9bceabbdd6383 (PR #6703 branch, remove after merge).
+
+Issues #6686 #6687 #6688 #6689 CLOSED status:tested with live evidence; #6699 filed (Indexes list view zero-vector flag).
+
+MATT HANDOFF PACKAGE (owner decisions: macOS arm64, unsigned, recipient adds repos + client fields himself): PR #6701 merged (distribute --prompt-for-key / --template cast / --repos, instructions/ dir); PR #6703 (docs/handoff-instructions-add-repos, head 5c7333b39) auto-merge ARMED adding step 2 "Fill in the engagement" before install. Package DELIVERED in the owner's engagement directory under ~/Projects/Audit/ (confidential client dir — never name it in repo/issues/commits): zip sha256 e243554f… + unzipped tree, built from edaf9bfbf, pins tga 6.0.0 / review 0.32.0 / search 0.52.0 / analyze 0.12.5 all verified fetchable as GitHub release assets. That copy predates #6703's instructions.
+
+LESSON RECORDED: never merge a source PR into a train crate between gate dispatch and publish (first train attempt at c18196442 halted on semver stops + my mid-train merge of #6701; fixed by bump PR #6702). trusty-audit main now carries unpublished changes past 0.13.1 (#6703) → 0.13.2 owed at next cut.
+
+## Completed
+- #6686 #6687 #6688 closed status:tested (throwaway failed index fixture via walk-budget refusal; trusty-search+trusty-review installed from 13eb98c2f)
+- #6689 closed status:tested (peer session closed on real zero-vector indexes; own verification on fixture-6689-zerovec matched); #6699 filed for the list view
+- PR #6700 merged (fold post-cut fragments trusty-search 0.52.0 / trusty-console 0.9.3)
+- PR #6702 merged edaf9bfbf (tga 6.0.0, trusty-console 0.10.0, trusty-review 0.32.0, trusty-audit 0.13.1 + pin refresh)
+- Publish train complete: 13 crates live on crates.io, tags at edaf9bfbf, installed + signed, daemons restarted
+- PR #6701 merged ed1b81ebf (taudit distribute: prompt-for-key, CAST preset, --repos, instructions/)
+- Matt package built and placed in the engagement dir (zip + unzipped taudit); pins verified fetchable
+- Worktree cleanup: verify-6686, fold-fragments, publish-train x2, matt-handoff-build x2, release-bumps, agent-afaf7b69 (PR #6698), agent-aa613998 (PR #6701) all removed
+
+## In Progress
+- [monitor b1hmv834b] PR #6703 (handoff instructions step 2) auto-merge armed, checks pending at pause — read `gh pr view 6703` on resume
+- [PM] after #6703 merges: remove worktree agent-ac3d9bceabbdd6383 + branch docs/handoff-instructions-add-repos; rebuild the Matt package from main into the engagement dir
+
+## Next Steps
+- Verify PR #6703 merged; if not, check its checks (non-required changelog-fragment check may be red per #6695)
+- local-ops: fresh worktree at origin/main → cargo build --release -p trusty-audit → `taudit distribute --config crates/trusty-audit/templates/engagement.template.toml --template cast --prompt-for-key --out <staging>` → replace zip + unzipped tree in the owner's engagement dir under ~/Projects/Audit/ → verify sha256, no `sk-or-`, instructions/README.md has step 2 'Fill in the engagement' → report path + sha256 to owner
+- Remove worktree agent-ac3d9bceabbdd6383 after merge; leave addd80fd (#6607), a259bfb3 (locked), a60e1286 (hold)
+- Owner decisions still open: revoke leaked duetto-frontend PAT; tm doctor log_drain ❌ (config.yaml source lacks owner/project, unknown key log_drain.github_id — #6657); return main checkout to `main`; review PR #6607; add changelog-fragment check to required contexts (#6695); trusty-review signed-install program; #6699 list-view flag approach
+- Next release cut owes trusty-audit 0.13.2 (unpublished #6703 changes) and Breaking bullets for tga 6.0.0 / console 0.10.0 / review 0.32.0 changelogs (flagged, not done)
+
+## Git Context
+Branch: codex/documentation-inventory-2026-09-02
+Last commit: 1e4c2397f docs: refresh workspace documentation inventory
+Uncommitted changes: 5 file(s) changed
+
+## Tmux Window
+tm-trusty-tools-02:0:@5288


### PR DESCRIPTION
## Outcome
Commit session snapshot for tm-trusty-tools-02 pause at 2026-09-03 02:21Z.

## Changes
Added session snapshot file to `.trusty-mpm/sessions/tm-trusty-tools-02-0-at5288-20260902/` and updated append-only log.

## Risk
Docs/session metadata only. No source changes.

## Tests
No tests required for session metadata commit.

## Baseline
N/A — docs-only change.

## Docs
Session snapshots are internal documentation tracked per owner ruling 2026-08-31.

## Review
No review required for docs-only session metadata.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
