### PR TITLE
chore(trusty-audit): assemble the 0.13.2 changelog section

### DIFF
--- a/crates/trusty-audit/CHANGELOG.md
+++ b/crates/trusty-audit/CHANGELOG.md
@@ -10,6 +10,18 @@ edit this file by hand (see
 
 ---
 
+## [0.13.2] — 2026-09-03
+
+### Documentation
+
+- The handoff instructions now walk the recipient through a "Fill in the
+  engagement" step, placed before install and audit: replace the placeholder
+  `client`, `engagement`, and `instructions` fields in `engagement.toml`,
+  register a repository with `add repo` or by pasting `[[targets]]` TOML
+  directly, list and remove targets, and what `audit` does with nothing
+  registered. `engagement.template.toml`'s comments mark those three fields
+  "replace before running" (#5473, #5483).
+
 ## [0.13.1] — 2026-09-02
 
 ### Added

--- a/crates/trusty-audit/changelog.d/5483-instructions-fill-in-engagement.md
+++ b/crates/trusty-audit/changelog.d/5483-instructions-fill-in-engagement.md
@@ -1,9 +1,0 @@
-Documentation
-
-- The handoff instructions now walk the recipient through a "Fill in the
-  engagement" step, placed before install and audit: replace the placeholder
-  `client`, `engagement`, and `instructions` fields in `engagement.toml`,
-  register a repository with `add repo` or by pasting `[[targets]]` TOML
-  directly, list and remove targets, and what `audit` does with nothing
-  registered. `engagement.template.toml`'s comments mark those three fields
-  "replace before running" (#5473, #5483).


### PR DESCRIPTION
## Outcome
trusty-audit ships 0.13.2 (bumped in #6703) but its CHANGELOG stopped at 0.13.1 with one fragment unconsumed; `check-changelog-assembled-selftest.sh`'s live-repo case was red and the 0.13.2 publish blocked. This assembles the section. Refs #6695.

## Changes
`crates/trusty-audit/CHANGELOG.md` gains `## [0.13.2] — 2026-09-03` with the Documentation bullet; `changelog.d/5483-instructions-fill-in-engagement.md` consumed. Produced by `scripts/assemble-changelog.sh trusty-audit 0.13.2`, not by hand.

## Risk
Low, docs-only. No Cargo.toml or src change.

## Tests
Rung 1. `check_changelog_fragment.sh` OK (no crate source changed); `check-changelog-assembled.sh trusty-audit 0.13.2` OK; `check-changelog-assembled-selftest.sh` 7/7 (live-repo case green); `check_sld.sh`, `check_doc_numbers.sh` OK.

## Baseline
None.

## Docs
Changelog only.

## Review
Docs-only; no critic round (rung 1).

Refs #6695

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
