### PR TITLE
docs(runbooks): use the neutral placeholder client name in the CAST runbook example

### DIFF
--- a/docs/runbooks/cast-code-only-audit.md
+++ b/docs/runbooks/cast-code-only-audit.md
@@ -84,10 +84,10 @@ Minimum manifest for one local checkout at `<repo-path>`:
 ```toml
 # report-manifest.toml
 [report]
-title = "FLYR Technical DD"
+title = "Acme Technical DD"
 
 [[repositories]]
-name = "FLYR"
+name = "Acme"
 path = "<repo-path>"
 ```
 
@@ -100,12 +100,12 @@ Optional keys for a code-only run:
 
 ```toml
 [report]
-title = "FLYR Technical DD"
+title = "Acme Technical DD"
 analyst = "Matt"
 code_only = true
 
 [[repositories]]
-name = "FLYR"
+name = "Acme"
 path = "<repo-path>"
 ref  = "main"
 investigate_max_files = 40


### PR DESCRIPTION
## Outcome
The CAST runbook's example manifest used a real client's name. Replaced with the neutral placeholder `Acme` already used by `crates/trusty-audit/templates/engagement.template.toml`. No functional change.

## Changes
`docs/runbooks/cast-code-only-audit.md`, 4 lines.

## Risk
Low, docs-only.

## Tests
Rung 1: `check_sld.sh`, `check_doc_numbers.sh`, `check_public_docs.sh` all pass.

## Baseline
None.

## Docs
This is the doc.

## Review
Docs-only; no critic round.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
