### PR TITLE
fix(trusty-review): report prose follows the rendered data and the recorded provenance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11998,7 +11998,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-review"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-review/Cargo.toml
+++ b/crates/trusty-review/Cargo.toml
@@ -92,7 +92,7 @@ name        = "trusty-review"
 # to `report::index_registry` under #6677), and `trait_method_added` for
 # `SearchClient::index_status` (src/integrations/search_client.rs:229), which an
 # out-of-tree implementor of the trait would have to add.
-version     = "0.32.0"
+version     = "0.32.1"
 edition     = "2024"
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/trusty-review/changelog.d/6691-6675-report-prose-provenance.md
+++ b/crates/trusty-review/changelog.d/6691-6675-report-prose-provenance.md
@@ -4,7 +4,10 @@ Fixed
   - The synthesis digest now states the complexity distribution in the same
     string the Code Quality table renders, and a Code Quality paragraph claiming
     no complexity data was provided is dropped with a Synthesis Status
-    disclosure when the table renders one (#6691)
+    disclosure when the table renders one — matched on the absence claim itself,
+    so a paraphrase ("complexity could not be measured") is caught too, and
+    scoped per application, so a true claim about an application that measured
+    nothing survives (#6691)
   - The digest no longer reports a metrics artifact's zero file/function counts
     as measurements; it falls through to the repository scan, as the Key Facts
     block already did (#6691)

--- a/crates/trusty-review/changelog.d/6691-6675-report-prose-provenance.md
+++ b/crates/trusty-review/changelog.d/6691-6675-report-prose-provenance.md
@@ -1,0 +1,14 @@
+Fixed
+
+- Report prose follows the rendered data and the recorded provenance
+  - The synthesis digest now states the complexity distribution in the same
+    string the Code Quality table renders, and a Code Quality paragraph claiming
+    no complexity data was provided is dropped with a Synthesis Status
+    disclosure when the table renders one (#6691)
+  - The digest no longer reports a metrics artifact's zero file/function counts
+    as measurements; it falls through to the repository scan, as the Key Facts
+    block already did (#6691)
+  - The CAST report's §1 "Analysis methodology" row is generated per run from
+    what actually contributed — trusty-analyze metrics per application and
+    trusty-search trace anchors — instead of fixed template text asserting both
+    tools were used (#6675)

--- a/crates/trusty-review/src/report/methodology.rs
+++ b/crates/trusty-review/src/report/methodology.rs
@@ -1,0 +1,86 @@
+//! The §1 "Analysis methodology" row, generated from what actually ran (#6675).
+//!
+//! Why: the row was fixed template text asserting that trusty-analyze and
+//! trusty-search were both used, rendered identically whether either one
+//! contributed. The 2026-09-02 dogfood run fell back to scan (the repository was
+//! not indexed) and every traced finding came back `IndexAbsent` — zero verified
+//! symbol anchors — and the report still told a reader who stopped at §1 that
+//! AST/complexity analysis and search-grounded tracing had happened. Only §9
+//! disclosed the degradation.
+//! What: [`analysis_methodology`] reads the provenance the run already recorded
+//! — `RepositoryReport::metrics`/`analyze_gap` for the analyze lane, and the
+//! investigation's own trace counts for the search lane — and states each lane's
+//! actual contribution. A lane that contributed nothing says so in the row
+//! itself, so no unqualified tool-use claim can be rendered for a run that made
+//! none.
+//! Test: `methodology_tests.rs`, and `tests/report_methodology_6675.rs` for the
+//! rendered CAST row.
+
+use super::model::ReportModel;
+
+/// The one thing every run does regardless of which daemon answered: it reads
+/// the checked-out sources itself.
+const BASE: &str = "Repository inspection over the checked-out sources";
+
+/// The §1 methodology sentence for this run.
+///
+/// Why: the single place the row's text is produced, so the claim and the
+/// recorded provenance cannot drift apart — a lane is named as used only when
+/// this run's own record says it contributed.
+/// What: `BASE`, then one clause per lane. The analyze clause counts the
+/// repositories carrying trusty-analyze metrics with no recorded gap; the search
+/// clause counts anchored traces against traced candidates across the
+/// investigation. Clauses are joined with `; `.
+/// Test: `methodology_tests::{both_lanes_absent_claim_neither,
+/// a_full_run_names_both_lanes, a_partial_analyze_lane_states_the_fraction}`.
+pub fn analysis_methodology(model: &ReportModel) -> String {
+    let total = model.repositories.len();
+    // #6675: a repository whose analyze fetch recorded a gap did not contribute,
+    // whatever else is on it — that gap is the fallback this row used to hide.
+    let analyzed = model
+        .repositories
+        .iter()
+        .filter(|r| r.analyze_gap.is_none() && r.metrics.is_some())
+        .count();
+    let (candidates, anchored) = trace_counts(model);
+
+    let analyze = match analyzed {
+        0 => format!(
+            "trusty-analyze contributed no data to this run ({total} application(s) assessed \
+             without it)"
+        ),
+        n if n == total => {
+            format!("trusty-analyze structural metrics for all {total} application(s)")
+        }
+        n => format!("trusty-analyze structural metrics for {n} of {total} application(s)"),
+    };
+    let search = match (candidates, anchored) {
+        (0, _) => "trusty-search symbol tracing did not run".to_string(),
+        (c, 0) => {
+            format!("trusty-search resolved no symbol anchor for any of the {c} traced finding(s)")
+        }
+        (c, a) => format!("trusty-search anchored {a} of {c} traced finding(s)"),
+    };
+    format!("{BASE}; {analyze}; {search}")
+}
+
+/// This run's traced-candidate and anchored-trace totals across every repository.
+///
+/// Why: the search lane's contribution is exactly what its traces anchored — a
+/// run where every lookup returned `IndexAbsent` traced candidates and anchored
+/// none, and the row must be able to say that.
+/// What: `(candidates, anchored)`, both `0` when the trace pass never ran.
+/// Test: `methodology_tests::both_lanes_absent_claim_neither`.
+fn trace_counts(model: &ReportModel) -> (usize, usize) {
+    let Some(inv) = &model.investigation else {
+        return (0, 0);
+    };
+    inv.repos
+        .iter()
+        .filter_map(|r| r.traces.as_ref())
+        .fold((0, 0), |(c, a), t| (c + t.candidates, a + t.assembled))
+}
+
+#[cfg(test)]
+#[path = "methodology_tests.rs"]
+mod tests;

--- a/crates/trusty-review/src/report/methodology_tests.rs
+++ b/crates/trusty-review/src/report/methodology_tests.rs
@@ -1,0 +1,133 @@
+//! Tests for the per-run §1 methodology line (#6675).
+
+use super::*;
+use crate::report::investigate::{
+    Investigation, InvestigationStatus, RepoInvestigation, TraceLimits, TraceSet,
+};
+use crate::report::metrics::AnalyzeMetrics;
+use crate::report::model::{ReportModel, RepositoryReport};
+
+/// One repository, optionally carrying analyze metrics and an analyze gap.
+fn repo(name: &str, metrics: bool, gap: Option<&str>) -> RepositoryReport {
+    RepositoryReport {
+        name: name.to_string(),
+        slug: name.to_lowercase(),
+        source: format!("/tmp/{name}"),
+        source_kind: "local_path".to_string(),
+        username: None,
+        git_ref: None,
+        git_info: None,
+        local_path: None,
+        scan: None,
+        metrics: metrics.then(AnalyzeMetrics::default),
+        analyze_gap: gap.map(str::to_string),
+        authorship: None,
+        inspect_priority: Vec::new(),
+        crate_topology: None,
+    }
+}
+
+fn model_with(repos: Vec<RepositoryReport>) -> ReportModel {
+    ReportModel {
+        title: "Test".to_string(),
+        template: "report-technical-dd-cast".to_string(),
+        analyst: None,
+        client: None,
+        vendor_methodology: crate::report::model::vendor_methodology(),
+        inference: None,
+        instructions: None,
+        instructions_source: None,
+        report_date: "2026-09-02".to_string(),
+        generated_date: "2026-09-02".to_string(),
+        manifest_path: "manifest.toml".to_string(),
+        repositories: repos,
+        gaps: vec![],
+        synthesis: None,
+        benchmark: None,
+        investigation: None,
+        section_instructions: Default::default(),
+        ticketing: None,
+    }
+}
+
+/// An investigation whose trace pass ran over `candidates` findings and anchored
+/// `assembled` of them.
+fn investigation(candidates: usize, assembled: usize) -> Investigation {
+    Investigation {
+        repos: vec![RepoInvestigation {
+            slug: "estate".to_string(),
+            name: "Estate".to_string(),
+            status: InvestigationStatus::Available,
+            findings: Vec::new(),
+            deps: Default::default(),
+            coverage: Default::default(),
+            traces: Some(TraceSet {
+                index_id: None,
+                traces: Vec::new(),
+                candidates,
+                assembled,
+                no_trace: candidates - assembled,
+                limits: TraceLimits::default(),
+            }),
+            verdicts: None,
+            exposure: Vec::new(),
+        }],
+    }
+}
+
+/// The live defect (#6675): `--analyze` fell back to scan and every trace
+/// lookup returned `IndexAbsent`, and §1 still asserted both tools were used.
+///
+/// Fails before the fix: the row was fixed template text with no per-run input
+/// at all, so there was nothing for this function to return.
+#[test]
+fn both_lanes_absent_claim_neither() {
+    let mut model = model_with(vec![repo("Estate", false, Some("re-run with --analyze"))]);
+    model.investigation = Some(investigation(10, 0));
+    let line = analysis_methodology(&model);
+    assert!(
+        line.contains("trusty-analyze contributed no data to this run"),
+        "the analyze lane must state its own absence: {line}"
+    );
+    assert!(
+        line.contains(
+            "trusty-search resolved no symbol anchor for any of the 10 traced finding(s)"
+        ),
+        "the search lane must state its own absence: {line}"
+    );
+}
+
+/// A run where both lanes did contribute names both, with its own figures.
+#[test]
+fn a_full_run_names_both_lanes() {
+    let mut model = model_with(vec![repo("Estate", true, None)]);
+    model.investigation = Some(investigation(10, 7));
+    let line = analysis_methodology(&model);
+    assert!(
+        line.contains("trusty-analyze structural metrics for all 1 application(s)"),
+        "{line}"
+    );
+    assert!(
+        line.contains("trusty-search anchored 7 of 10 traced finding(s)"),
+        "{line}"
+    );
+}
+
+/// A partly-populated analyze lane states the fraction rather than either
+/// extreme, and a run with no trace pass says the pass did not run.
+#[test]
+fn a_partial_analyze_lane_states_the_fraction() {
+    let model = model_with(vec![
+        repo("One", true, None),
+        repo("Two", false, Some("not indexed")),
+    ]);
+    let line = analysis_methodology(&model);
+    assert!(
+        line.contains("trusty-analyze structural metrics for 1 of 2 application(s)"),
+        "{line}"
+    );
+    assert!(
+        line.contains("trusty-search symbol tracing did not run"),
+        "{line}"
+    );
+}

--- a/crates/trusty-review/src/report/mod.rs
+++ b/crates/trusty-review/src/report/mod.rs
@@ -72,6 +72,8 @@ pub mod synthesize_guard;
 // prompt hints plus a fail-closed post-check for reachability and load-bearing
 // claims. Used only by `synthesize` and `synthesize_prompt`.
 pub(crate) mod synthesize_grounding;
+// #6691: the complexity-absence claim check, scoped per application.
+mod synthesize_grounding_complexity;
 mod synthesize_grounding_text;
 mod synthesize_grounding_vocab;
 mod synthesize_guardrail;

--- a/crates/trusty-review/src/report/mod.rs
+++ b/crates/trusty-review/src/report/mod.rs
@@ -37,6 +37,8 @@ pub mod index_registry;
 pub mod investigate;
 pub mod manifest;
 pub mod mermaid;
+// #6675: the §1 methodology row, generated from the run's own provenance.
+pub mod methodology;
 pub mod metrics;
 pub mod model;
 pub mod polish;
@@ -112,6 +114,7 @@ pub use manifest::{
     slugify,
 };
 pub use mermaid::inject as inject_mermaid;
+pub use methodology::analysis_methodology;
 pub use metrics::{AnalyzeMetrics, MetricFinding, Severity, load_metrics};
 pub use model::{ReportModel, RepositoryReport};
 pub use polish::{polish, polish_with_gaps, strip_template_comments};

--- a/crates/trusty-review/src/report/reporter.rs
+++ b/crates/trusty-review/src/report/reporter.rs
@@ -347,6 +347,16 @@ pub(super) fn build_scope(model: &ReportModel) -> Scope {
         tag(&model.vendor_methodology, Provenance::Measured),
     );
     root.set("report_version", tag(crate_version(), Provenance::Measured));
+    // #6675: the row states which lanes actually contributed, so a run that fell
+    // back to scan cannot render an unqualified trusty-analyze + trusty-search
+    // claim. Measured — read from the run's own recorded provenance.
+    root.set(
+        "analysis_methodology",
+        tag(
+            super::methodology::analysis_methodology(model),
+            Provenance::Measured,
+        ),
+    );
     // #6135: which models produced this report. Measured — the tool resolved it
     // and knows it. A model built outside the report command carries none, and
     // the row then says so rather than reading as a report with no inference.

--- a/crates/trusty-review/src/report/reporter_codesec.rs
+++ b/crates/trusty-review/src/report/reporter_codesec.rs
@@ -213,7 +213,15 @@ pub fn push_security_violation_rows(root: &mut Scope, model: &ReportModel) {
 /// A compact "label: count (pct%)" complexity summary for one repository's
 /// `AnalyzeMetrics.complexity` — the per-app counterpart of
 /// `reporter_facts::complexity_profile`'s engagement-wide merge.
-fn bucket_summary(m: &AnalyzeMetrics) -> Option<String> {
+///
+/// #6691: `synthesize_prompt::repo_profile_lines` states this same string to the
+/// synthesis model. Reading it from here rather than re-deriving it is what
+/// makes the prose and the `cq_complexity` cell beside it the same measurement,
+/// so a paragraph denying the distribution the table renders cannot be written
+/// from data that omitted it.
+/// Test: `reporter_codesec_tests::code_quality_rows_reproject_metrics`,
+/// `synthesize_tests::digest_carries_the_complexity_distribution_the_table_renders`.
+pub(super) fn bucket_summary(m: &AnalyzeMetrics) -> Option<String> {
     let total: u64 = m.complexity.buckets.iter().map(|b| b.count).sum();
     if total == 0 {
         return None;

--- a/crates/trusty-review/src/report/synthesize_grounding.rs
+++ b/crates/trusty-review/src/report/synthesize_grounding.rs
@@ -78,6 +78,14 @@
 //! sends a doubled determiner or a self-contrast down the reject-and-disclose
 //! path instead. A visible withholding is the better of the two failures.
 //!
+//! #6691 added a fourth claim, in the lap-7 shape: a Code Quality paragraph
+//! saying no complexity distribution was provided, four lines above the
+//! deterministic table that renders one. The model wrote it in good faith — the
+//! digest never carried the distribution. Both halves are fixed:
+//! `synthesize_prompt::repo_profile_lines` now states the same string the
+//! `cq_complexity` cell renders, and [`Grounding::check_field`] drops the claim
+//! afterwards whatever the model was given.
+//!
 //! #6082 lap 11 made a disclosure name the finding whose field it is. The tier
 //! is read from the FILE, so [`Grounding::reachability`] resolves it through
 //! that file's first loopback record — and it quoted that record's title. The
@@ -100,8 +108,8 @@ use super::synthesize_grounding_text::{
     remove_sentence, rewrite_reachability, sentences, subject_tokens,
 };
 use super::synthesize_grounding_vocab::{
-    CLEAN_SIGNAL_NEGATIONS, CLEAN_SIGNAL_WORDS, LOAD_BEARING_PHRASES, LOOPBACK_MARKERS,
-    REMOTE_MARKERS,
+    ABSENCE_NEGATIONS, CLEAN_SIGNAL_WORDS, COMPLEXITY_WORDS, DATA_SUPPLY_WORDS,
+    LOAD_BEARING_PHRASES, LOOPBACK_MARKERS, REMOTE_MARKERS,
 };
 use super::topology::CrateTopology;
 
@@ -211,6 +219,12 @@ pub(crate) struct Grounding {
     known_crates: Vec<String>,
     /// GREEN security findings the Security Posture section credits by name.
     clean_signals: usize,
+    /// Functions the Code Quality table's complexity distribution accounts for.
+    ///
+    /// #6691: the same buckets `reporter_codesec::bucket_summary` renders into
+    /// the `cq_complexity` cell. Non-zero means the report states a distribution,
+    /// and a paragraph above that table saying none was provided contradicts it.
+    complexity_functions: u64,
 }
 
 impl Grounding {
@@ -285,6 +299,14 @@ impl Grounding {
         // `apply_investigation`, so after that pass both loops see the same
         // signals. The larger count is the real one either way.
         out.clean_signals = from_metrics.max(from_inv);
+        // #6691: read from the same buckets the Code Quality table renders.
+        out.complexity_functions = model
+            .repositories
+            .iter()
+            .filter_map(|r| r.metrics.as_ref())
+            .flat_map(|m| m.complexity.buckets.iter())
+            .map(|b| b.count)
+            .sum();
         // #6191: the investigation's collected bind/exposure facts decide a
         // file's tier before any text marker gets a vote.
         let evidence = ExposureIndex::from_facts(
@@ -444,8 +466,8 @@ impl Grounding {
     /// can never be applied to one field and not another.
     /// What: runs the load-bearing check first (it can only reject, so there is
     /// nothing to rewrite afterwards), then drops any false no-clean-signal
-    /// claim, then runs the reachability check over what is left. Returns
-    /// `Clean` when none fired.
+    /// claim and any false no-complexity-data claim (#6691), then runs the
+    /// reachability check over what is left. Returns `Clean` when none fired.
     ///
     /// `owner` is the component of the finding this field belongs to, and `None`
     /// for report-level prose that belongs to no single finding — the executive,
@@ -475,6 +497,10 @@ impl Grounding {
             };
         }
         let (text, mut notes) = self.drop_false_no_clean_signal(text);
+        // #6691: the same shape, for a paragraph denying the complexity
+        // distribution the table under it renders.
+        let (text, complexity_notes) = self.drop_false_no_complexity_data(&text);
+        notes.extend(complexity_notes);
         match self.reachability(&text, owner, subject) {
             GroundingOutcome::Clean if notes.is_empty() => GroundingOutcome::Clean,
             GroundingOutcome::Clean => GroundingOutcome::Rewritten(text, notes),
@@ -497,7 +523,7 @@ impl Grounding {
     /// its absence in good faith.
     /// What: `(text, notes)` unchanged when the report credits no clean signal,
     /// which is the case the sentence is right about. Otherwise every sentence
-    /// carrying [`CLEAN_SIGNAL_WORDS`] under a [`CLEAN_SIGNAL_NEGATIONS`] word
+    /// carrying [`CLEAN_SIGNAL_WORDS`] under an [`ABSENCE_NEGATIONS`] word
     /// is cut out and one note records the cut. The rest of the paragraph
     /// survives: one contradicted sentence is not grounds to drop a paragraph of
     /// otherwise-grounded prose.
@@ -517,7 +543,7 @@ impl Grounding {
             if !lower[at..].contains(CLEAN_SIGNAL_WORDS.1) {
                 continue;
             }
-            if !CLEAN_SIGNAL_NEGATIONS.iter().any(|n| lower.contains(n)) {
+            if !ABSENCE_NEGATIONS.iter().any(|n| lower.contains(n)) {
                 continue;
             }
             out = remove_sentence(&out, sentence);
@@ -528,6 +554,61 @@ impl Grounding {
                     "a sentence claiming no clean signal was credited was dropped — the Security \
                      Posture section credits {} of them, each with the file it was read from",
                     self.clean_signals
+                ),
+                subject: None,
+            });
+        }
+        (out.trim().to_string(), notes)
+    }
+
+    /// Remove any sentence claiming the run was given no complexity data, when
+    /// the Code Quality table renders a distribution (#6691).
+    ///
+    /// Why: the graded report's Code Quality paragraph said "no complexity
+    /// distribution, code-smell taxonomy, or crate-topology/coupling data was
+    /// provided", and four lines under it the deterministic table rendered
+    /// A 68618 / B 5241 / C 1836 / D 720 / F 733. Feeding the distribution into
+    /// the digest (`synthesize_prompt::repo_profile_lines`) is the derivation
+    /// half; this is the mechanical half, so the contradiction cannot ship even
+    /// when the model writes past its input.
+    /// What: `(text, notes)` unchanged when no repository contributed a bucket —
+    /// the case the sentence is right about. Otherwise every sentence carrying
+    /// [`COMPLEXITY_WORDS`] under an [`ABSENCE_NEGATIONS`] word AND a
+    /// [`DATA_SUPPLY_WORDS`] word is cut out and one note records the cut. The
+    /// three conditions together are what leave a sentence about the
+    /// distribution's SHAPE alone; only a claim about what the run was given is
+    /// this check's business.
+    /// Test: `synthesize_grounding_tests.rs::{a_no_complexity_data_claim_is_dropped_when_the_table_renders_one,
+    /// a_no_complexity_data_claim_survives_when_no_bucket_was_measured,
+    /// a_claim_about_the_distributions_shape_is_left_alone}`.
+    fn drop_false_no_complexity_data(&self, text: &str) -> (String, Vec<Correction>) {
+        if self.complexity_functions == 0 {
+            return (text.to_string(), Vec::new());
+        }
+        let mut out = text.to_string();
+        let mut notes = Vec::new();
+        for sentence in sentences(text) {
+            let lower = sentence.to_lowercase();
+            let Some(at) = lower.find(COMPLEXITY_WORDS.0) else {
+                continue;
+            };
+            if !lower[at..].contains(COMPLEXITY_WORDS.1) {
+                continue;
+            }
+            if !ABSENCE_NEGATIONS.iter().any(|n| lower.contains(n)) {
+                continue;
+            }
+            if !DATA_SUPPLY_WORDS.iter().any(|w| lower.contains(w)) {
+                continue;
+            }
+            out = remove_sentence(&out, sentence);
+            // The distribution is the report's own measurement, not any one
+            // §5.x finding, so there is no subject to number.
+            notes.push(Correction {
+                text: format!(
+                    "a sentence claiming no complexity distribution was provided was dropped — \
+                     the Code Quality table renders one over {} functions",
+                    self.complexity_functions
                 ),
                 subject: None,
             });

--- a/crates/trusty-review/src/report/synthesize_grounding.rs
+++ b/crates/trusty-review/src/report/synthesize_grounding.rs
@@ -84,7 +84,9 @@
 //! digest never carried the distribution. Both halves are fixed:
 //! `synthesize_prompt::repo_profile_lines` now states the same string the
 //! `cq_complexity` cell renders, and [`Grounding::check_field`] drops the claim
-//! afterwards whatever the model was given.
+//! afterwards whatever the model was given — see
+//! [`super::synthesize_grounding_complexity`], which owns that check and scopes
+//! it to the applications a sentence is actually about.
 //!
 //! #6082 lap 11 made a disclosure name the finding whose field it is. The tier
 //! is read from the FILE, so [`Grounding::reachability`] resolves it through
@@ -103,13 +105,13 @@ use std::collections::BTreeSet;
 
 use super::investigate::ExposureIndex;
 use super::model::ReportModel;
+use super::synthesize_grounding_complexity::{ComplexityFacts, drop_false_absence};
 use super::synthesize_grounding_text::{
     asserts_reachability, asserts_reachability_claim, contains_name, grammar_debris,
     remove_sentence, rewrite_reachability, sentences, subject_tokens,
 };
 use super::synthesize_grounding_vocab::{
-    ABSENCE_NEGATIONS, CLEAN_SIGNAL_WORDS, COMPLEXITY_WORDS, DATA_SUPPLY_WORDS,
-    LOAD_BEARING_PHRASES, LOOPBACK_MARKERS, REMOTE_MARKERS,
+    ABSENCE_NEGATIONS, CLEAN_SIGNAL_WORDS, LOAD_BEARING_PHRASES, LOOPBACK_MARKERS, REMOTE_MARKERS,
 };
 use super::topology::CrateTopology;
 
@@ -219,12 +221,9 @@ pub(crate) struct Grounding {
     known_crates: Vec<String>,
     /// GREEN security findings the Security Posture section credits by name.
     clean_signals: usize,
-    /// Functions the Code Quality table's complexity distribution accounts for.
-    ///
-    /// #6691: the same buckets `reporter_codesec::bucket_summary` renders into
-    /// the `cq_complexity` cell. Non-zero means the report states a distribution,
-    /// and a paragraph above that table saying none was provided contradicts it.
-    complexity_functions: u64,
+    /// Per-application complexity measurements (#6691), read from the same
+    /// buckets `reporter_codesec::bucket_summary` renders into `cq_complexity`.
+    complexity: ComplexityFacts,
 }
 
 impl Grounding {
@@ -300,13 +299,7 @@ impl Grounding {
         // signals. The larger count is the real one either way.
         out.clean_signals = from_metrics.max(from_inv);
         // #6691: read from the same buckets the Code Quality table renders.
-        out.complexity_functions = model
-            .repositories
-            .iter()
-            .filter_map(|r| r.metrics.as_ref())
-            .flat_map(|m| m.complexity.buckets.iter())
-            .map(|b| b.count)
-            .sum();
+        out.complexity = ComplexityFacts::from_model(model);
         // #6191: the investigation's collected bind/exposure facts decide a
         // file's tier before any text marker gets a vote.
         let evidence = ExposureIndex::from_facts(
@@ -466,8 +459,10 @@ impl Grounding {
     /// can never be applied to one field and not another.
     /// What: runs the load-bearing check first (it can only reject, so there is
     /// nothing to rewrite afterwards), then drops any false no-clean-signal
-    /// claim and any false no-complexity-data claim (#6691), then runs the
-    /// reachability check over what is left. Returns `Clean` when none fired.
+    /// claim and any false no-complexity-data claim
+    /// ([`super::synthesize_grounding_complexity::drop_false_absence`], #6691),
+    /// then runs the reachability check over what is left. Returns `Clean` when
+    /// none fired.
     ///
     /// `owner` is the component of the finding this field belongs to, and `None`
     /// for report-level prose that belongs to no single finding — the executive,
@@ -499,7 +494,7 @@ impl Grounding {
         let (text, mut notes) = self.drop_false_no_clean_signal(text);
         // #6691: the same shape, for a paragraph denying the complexity
         // distribution the table under it renders.
-        let (text, complexity_notes) = self.drop_false_no_complexity_data(&text);
+        let (text, complexity_notes) = drop_false_absence(&self.complexity, &text);
         notes.extend(complexity_notes);
         match self.reachability(&text, owner, subject) {
             GroundingOutcome::Clean if notes.is_empty() => GroundingOutcome::Clean,
@@ -554,61 +549,6 @@ impl Grounding {
                     "a sentence claiming no clean signal was credited was dropped — the Security \
                      Posture section credits {} of them, each with the file it was read from",
                     self.clean_signals
-                ),
-                subject: None,
-            });
-        }
-        (out.trim().to_string(), notes)
-    }
-
-    /// Remove any sentence claiming the run was given no complexity data, when
-    /// the Code Quality table renders a distribution (#6691).
-    ///
-    /// Why: the graded report's Code Quality paragraph said "no complexity
-    /// distribution, code-smell taxonomy, or crate-topology/coupling data was
-    /// provided", and four lines under it the deterministic table rendered
-    /// A 68618 / B 5241 / C 1836 / D 720 / F 733. Feeding the distribution into
-    /// the digest (`synthesize_prompt::repo_profile_lines`) is the derivation
-    /// half; this is the mechanical half, so the contradiction cannot ship even
-    /// when the model writes past its input.
-    /// What: `(text, notes)` unchanged when no repository contributed a bucket —
-    /// the case the sentence is right about. Otherwise every sentence carrying
-    /// [`COMPLEXITY_WORDS`] under an [`ABSENCE_NEGATIONS`] word AND a
-    /// [`DATA_SUPPLY_WORDS`] word is cut out and one note records the cut. The
-    /// three conditions together are what leave a sentence about the
-    /// distribution's SHAPE alone; only a claim about what the run was given is
-    /// this check's business.
-    /// Test: `synthesize_grounding_tests.rs::{a_no_complexity_data_claim_is_dropped_when_the_table_renders_one,
-    /// a_no_complexity_data_claim_survives_when_no_bucket_was_measured,
-    /// a_claim_about_the_distributions_shape_is_left_alone}`.
-    fn drop_false_no_complexity_data(&self, text: &str) -> (String, Vec<Correction>) {
-        if self.complexity_functions == 0 {
-            return (text.to_string(), Vec::new());
-        }
-        let mut out = text.to_string();
-        let mut notes = Vec::new();
-        for sentence in sentences(text) {
-            let lower = sentence.to_lowercase();
-            let Some(at) = lower.find(COMPLEXITY_WORDS.0) else {
-                continue;
-            };
-            if !lower[at..].contains(COMPLEXITY_WORDS.1) {
-                continue;
-            }
-            if !ABSENCE_NEGATIONS.iter().any(|n| lower.contains(n)) {
-                continue;
-            }
-            if !DATA_SUPPLY_WORDS.iter().any(|w| lower.contains(w)) {
-                continue;
-            }
-            out = remove_sentence(&out, sentence);
-            // The distribution is the report's own measurement, not any one
-            // §5.x finding, so there is no subject to number.
-            notes.push(Correction {
-                text: format!(
-                    "a sentence claiming no complexity distribution was provided was dropped — \
-                     the Code Quality table renders one over {} functions",
-                    self.complexity_functions
                 ),
                 subject: None,
             });

--- a/crates/trusty-review/src/report/synthesize_grounding_complexity.rs
+++ b/crates/trusty-review/src/report/synthesize_grounding_complexity.rs
@@ -1,0 +1,132 @@
+//! The complexity-absence claim check (#6691).
+//!
+//! Why: the graded report's Code Quality paragraph said no complexity
+//! distribution was provided, four lines above the deterministic table that
+//! rendered A 68618 / B 5241 / C 1836 / D 720 / F 733. The first fix keyed on
+//! the two words that report happened to use, so every paraphrase of the same
+//! false claim — "complexity could not be measured", "no complexity metrics
+//! were computed" — still shipped. What separates an absence claim from a claim
+//! about the distribution's SHAPE is the negation and the supply verb, not the
+//! word "distribution", so the word pair is gone.
+//!
+//! It also summed the buckets report-wide. A CAST estate report covers several
+//! applications, and one of them genuinely having no metrics makes "App B's
+//! complexity was not available" TRUE — a sentence the report-wide sum deleted
+//! anyway, under a note quoting App A's count. Counts are per application here,
+//! and a sentence is refuted only by the applications it is about.
+//! What: [`ComplexityFacts`] holds one `(application, functions)` pair per
+//! repository, read from the same buckets `reporter_codesec::bucket_summary`
+//! renders into the `cq_complexity` cell. [`drop_false_absence`] cuts every
+//! sentence the facts refute and records one [`Correction`] per cut.
+//! Test: `synthesize_grounding_tests.rs`.
+
+use super::model::ReportModel;
+use super::synthesize_grounding::Correction;
+use super::synthesize_grounding_text::{contains_name, remove_sentence, sentences};
+use super::synthesize_grounding_vocab::{ABSENCE_NEGATIONS, COMPLEXITY_WORD, DATA_SUPPLY_WORDS};
+
+/// The complexity measurement each application contributed, as the Code Quality
+/// table renders it.
+///
+/// Why: both halves of the check need the same numbers the table shows — the
+/// gate that decides whether a sentence is false, and the note that says what
+/// refuted it.
+/// What: one entry per repository, `(display name, functions across its
+/// buckets)`; `0` for a repository whose analyze lane contributed nothing.
+/// Test: `synthesize_grounding_tests::a_per_application_absence_claim_survives_when_that_app_has_none`.
+#[derive(Debug, Default, Clone)]
+pub(super) struct ComplexityFacts {
+    per_app: Vec<(String, u64)>,
+}
+
+impl ComplexityFacts {
+    /// Read the per-application counts off the model.
+    pub(super) fn from_model(model: &ReportModel) -> Self {
+        ComplexityFacts {
+            per_app: model
+                .repositories
+                .iter()
+                .map(|r| {
+                    let functions = r.metrics.as_ref().map_or(0, |m| {
+                        m.complexity.buckets.iter().map(|b| b.count).sum::<u64>()
+                    });
+                    (r.name.clone(), functions)
+                })
+                .collect(),
+        }
+    }
+
+    /// The measured function count that refutes this sentence, or `None` when
+    /// the sentence is true for the applications it is about.
+    ///
+    /// Why: an absence claim naming one application is a claim about THAT
+    /// application, and only its own measurement can contradict it. A claim
+    /// naming none is report-wide, so it stands as long as any application
+    /// genuinely measured nothing.
+    /// What: `lower_sentence` is already lowercased. Applications are matched by
+    /// name on word boundaries ([`contains_name`]); `Some(total)` over the
+    /// matched set when every one of them measured a bucket, else `None`.
+    /// Test: `synthesize_grounding_tests::{a_no_complexity_data_claim_is_dropped_when_the_table_renders_one,
+    /// a_per_application_absence_claim_survives_when_that_app_has_none,
+    /// a_report_wide_absence_claim_survives_when_one_application_has_none}`.
+    fn refuted_by(&self, lower_sentence: &str) -> Option<u64> {
+        let named: Vec<u64> = self
+            .per_app
+            .iter()
+            .filter(|(name, _)| contains_name(lower_sentence, &name.to_lowercase()))
+            .map(|(_, n)| *n)
+            .collect();
+        let scope = if named.is_empty() {
+            self.per_app.iter().map(|(_, n)| *n).collect()
+        } else {
+            named
+        };
+        if scope.is_empty() || scope.contains(&0) {
+            return None;
+        }
+        Some(scope.iter().sum())
+    }
+}
+
+/// Remove every sentence claiming the run was given no complexity data that the
+/// rendered table refutes.
+///
+/// Why: feeding the distribution into the digest is the derivation half of
+/// #6691; this is the mechanical half, so the contradiction cannot ship even
+/// when the model writes past its input.
+/// What: a sentence qualifies when it carries [`COMPLEXITY_WORD`], an
+/// [`ABSENCE_NEGATIONS`] word and a [`DATA_SUPPLY_WORDS`] word — the last two
+/// together are what leave a claim about the distribution's shape alone. It is
+/// then cut only if [`ComplexityFacts::refuted_by`] says the applications it is
+/// about did measure one. Returns the surviving text and one note per cut.
+/// Test: `synthesize_grounding_tests.rs`.
+pub(super) fn drop_false_absence(facts: &ComplexityFacts, text: &str) -> (String, Vec<Correction>) {
+    let mut out = text.to_string();
+    let mut notes = Vec::new();
+    for sentence in sentences(text) {
+        let lower = sentence.to_lowercase();
+        if !lower.contains(COMPLEXITY_WORD) {
+            continue;
+        }
+        if !ABSENCE_NEGATIONS.iter().any(|n| lower.contains(n)) {
+            continue;
+        }
+        if !DATA_SUPPLY_WORDS.iter().any(|w| lower.contains(w)) {
+            continue;
+        }
+        let Some(measured) = facts.refuted_by(&lower) else {
+            continue;
+        };
+        out = remove_sentence(&out, sentence);
+        // The distribution is the report's own measurement, not any one §5.x
+        // finding, so there is no subject to number.
+        notes.push(Correction {
+            text: format!(
+                "a sentence claiming no complexity data was provided was dropped — the Code \
+                 Quality table renders one over {measured} functions"
+            ),
+            subject: None,
+        });
+    }
+    (out.trim().to_string(), notes)
+}

--- a/crates/trusty-review/src/report/synthesize_grounding_tests.rs
+++ b/crates/trusty-review/src/report/synthesize_grounding_tests.rs
@@ -738,6 +738,99 @@ fn a_claim_about_the_distributions_shape_is_left_alone() {
     );
 }
 
+/// Metrics carrying exactly the given complexity bands.
+fn metrics_with_buckets(bands: &[(&str, u64)]) -> AnalyzeMetrics {
+    AnalyzeMetrics {
+        complexity: ComplexityDistribution {
+            buckets: bands
+                .iter()
+                .map(|(label, count)| ComplexityBucket {
+                    label: (*label).to_string(),
+                    count: *count,
+                })
+                .collect(),
+        },
+        ..AnalyzeMetrics::default()
+    }
+}
+
+/// The paraphrases the first fix let through, each the same false claim in
+/// different words.
+///
+/// Fails before the fix: the matcher required the token `complexity` to precede
+/// the token `distribution` in one sentence, so none of these four matched and
+/// each shipped above the table that refutes it.
+#[test]
+fn every_paraphrase_of_the_absence_claim_is_dropped() {
+    for claim in [
+        "No per-function complexity figures were available.",
+        "Complexity could not be measured.",
+        "No complexity metrics were computed.",
+        "The distribution of code complexity was not resolved.",
+    ] {
+        let prose = format!("Test coverage is thin across the estate. {claim}");
+        let GroundingOutcome::Rewritten(text, notes) =
+            Grounding::from_model(&complexity_model()).check(&prose, None)
+        else {
+            panic!("expected {claim:?} to be dropped");
+        };
+        assert_eq!(
+            text, "Test coverage is thin across the estate.",
+            "{claim:?}"
+        );
+        assert_eq!(notes.len(), 1, "{claim:?} — notes were: {notes:?}");
+    }
+}
+
+/// A two-application estate; `second_has_metrics` decides whether the second
+/// application measured a distribution at all.
+fn two_app_model(second_has_metrics: bool) -> ReportModel {
+    let mut model = model_with(vec![
+        repo("Estate Core", Vec::new(), None),
+        repo("Ledger", Vec::new(), None),
+    ]);
+    model.repositories[0].metrics = Some(metrics_with_buckets(&[("A", 900), ("F", 100)]));
+    if second_has_metrics {
+        model.repositories[1].metrics = Some(metrics_with_buckets(&[("A", 40), ("F", 10)]));
+    }
+    model.gaps.clear();
+    model
+}
+
+/// An absence claim naming the application that HAS no distribution is TRUE and
+/// survives — the report-wide sum deleted it under a note quoting the other
+/// application's count.
+#[test]
+fn a_per_application_absence_claim_survives_when_that_app_has_none() {
+    assert_eq!(
+        Grounding::from_model(&two_app_model(false))
+            .check("No complexity distribution was provided for Ledger.", None),
+        GroundingOutcome::Clean
+    );
+}
+
+/// A report-wide claim stands as long as one application measured nothing; once
+/// every application has a distribution, the same claim is refuted.
+#[test]
+fn a_report_wide_absence_claim_survives_when_one_application_has_none() {
+    let claim = "No complexity distribution was provided.";
+    assert_eq!(
+        Grounding::from_model(&two_app_model(false)).check(claim, None),
+        GroundingOutcome::Clean
+    );
+    let GroundingOutcome::Rewritten(text, notes) =
+        Grounding::from_model(&two_app_model(true)).check(claim, None)
+    else {
+        panic!("every application measured one — the claim must be dropped");
+    };
+    assert_eq!(text, "");
+    assert!(
+        notes[0].text.contains("renders one over 1050 functions"),
+        "the note must sum the applications it is about: {}",
+        notes[0].text
+    );
+}
+
 // ─── #6082 lap 8: reachability is a property of the component ────────────────
 
 /// The lap-8 line, verbatim: §5.1 item 3's business impact.

--- a/crates/trusty-review/src/report/synthesize_grounding_tests.rs
+++ b/crates/trusty-review/src/report/synthesize_grounding_tests.rs
@@ -4,7 +4,9 @@ use super::*;
 use crate::report::investigate::{
     Investigation, InvestigationStatus, RepoInvestigation, VerifiedFinding,
 };
-use crate::report::metrics::{AnalyzeMetrics, MetricFinding, Severity};
+use crate::report::metrics::{
+    AnalyzeMetrics, ComplexityBucket, ComplexityDistribution, MetricFinding, Severity,
+};
 use crate::report::model::{ReportModel, RepositoryReport};
 use crate::report::synthesize_grounding_text::replace_ignore_case;
 use crate::report::topology::CrateNode;
@@ -653,6 +655,87 @@ fn prompt_facts_state_the_clean_signal_count() {
     let facts = Grounding::from_model(&clean_signal_model()).prompt_facts();
     assert!(facts.contains("credits 1 GREEN security finding(s)"));
     assert!(facts.contains("Never write that no clean signal was found"));
+}
+
+// --- #6691: a denied complexity distribution the table renders --------------
+
+/// The paragraph's own words from the 2026-09-02 CAST report, line 2189.
+const LIVE_NO_COMPLEXITY_CLAIM: &str = "No file or function counts were resolved (reported as 0), \
+     and no complexity distribution, code-smell taxonomy, or crate-topology/coupling data was \
+     provided, so module structure and dependency coupling cannot be commented on beyond the \
+     crate names surfaced in the finding paths.";
+
+/// A model carrying the distribution the Code Quality table renders — the same
+/// five bands, and the same counts, the graded report printed four lines under
+/// the paragraph that denied them.
+fn complexity_model() -> ReportModel {
+    let mut model = model_with(vec![repo("estate", Vec::new(), None)]);
+    model.repositories[0].metrics = Some(AnalyzeMetrics {
+        complexity: ComplexityDistribution {
+            buckets: [
+                ("A", 68618u64),
+                ("B", 5241),
+                ("C", 1836),
+                ("D", 720),
+                ("F", 733),
+            ]
+            .into_iter()
+            .map(|(label, count)| ComplexityBucket {
+                label: label.to_string(),
+                count,
+            })
+            .collect(),
+        },
+        ..AnalyzeMetrics::default()
+    });
+    model.gaps.clear();
+    model
+}
+
+/// The live contradiction (#6691): the synthesized paragraph denied the
+/// distribution the deterministic table beneath it rendered.
+///
+/// Fails before the fix: `check` knows nothing about the complexity buckets and
+/// returns `Clean`, so the sentence renders directly above the table refuting it.
+#[test]
+fn a_no_complexity_data_claim_is_dropped_when_the_table_renders_one() {
+    let prose = format!("Test coverage is thin across the estate. {LIVE_NO_COMPLEXITY_CLAIM}");
+    let GroundingOutcome::Rewritten(text, notes) =
+        Grounding::from_model(&complexity_model()).check(&prose, None)
+    else {
+        panic!("expected the false no-complexity-data claim to be dropped");
+    };
+    assert_eq!(text, "Test coverage is thin across the estate.");
+    assert_eq!(notes.len(), 1, "notes were: {notes:?}");
+    assert!(
+        notes[0].text.contains("renders one over 77148 functions"),
+        "the note must state the measured total: {}",
+        notes[0].text
+    );
+}
+
+/// The same sentence is CORRECT for a run that measured no bucket, and survives.
+#[test]
+fn a_no_complexity_data_claim_survives_when_no_bucket_was_measured() {
+    let model = model_with(vec![repo("estate", Vec::new(), None)]);
+    assert_eq!(
+        Grounding::from_model(&model).check(LIVE_NO_COMPLEXITY_CLAIM, None),
+        GroundingOutcome::Clean
+    );
+}
+
+/// A claim about the distribution's SHAPE is not a claim about what the run was
+/// given, and the guard must leave it alone.
+#[test]
+fn a_claim_about_the_distributions_shape_is_left_alone() {
+    assert_eq!(
+        Grounding::from_model(&complexity_model()).check(
+            "The complexity distribution is not evenly spread: the D and F bands cluster in one \
+             crate.",
+            None
+        ),
+        GroundingOutcome::Clean
+    );
 }
 
 // ─── #6082 lap 8: reachability is a property of the component ────────────────

--- a/crates/trusty-review/src/report/synthesize_grounding_vocab.rs
+++ b/crates/trusty-review/src/report/synthesize_grounding_vocab.rs
@@ -151,13 +151,43 @@ pub(super) const REACHABILITY_WORDS: &[&str] = &["remote", "network", "internet"
 /// Two words rather than one phrase, because the model puts the dimension
 /// between them — the graded report wrote "No clean security signal is credited
 /// here", and a literal `clean signal` match misses that. Paired with
-/// [`CLEAN_SIGNAL_NEGATIONS`], which is what turns the noun phrase into a claim
+/// [`ABSENCE_NEGATIONS`], which is what turns the noun phrase into a claim
 /// of absence.
 pub(super) const CLEAN_SIGNAL_WORDS: (&str, &str) = ("clean", "signal");
 
-/// The negations that turn [`CLEAN_SIGNAL_WORDS`] into a claim of absence.
-pub(super) const CLEAN_SIGNAL_NEGATIONS: &[&str] = &[
+/// The negations that turn a noun phrase into a claim of absence.
+///
+/// Shared by the clean-signal check and the complexity-data check (#6691) —
+/// both ask the same question of a sentence, and one list is what keeps the two
+/// answers consistent.
+pub(super) const ABSENCE_NEGATIONS: &[&str] = &[
     "no ", "not ", "none", "nothing", "never", "n't", "zero ", "absent", "without",
+];
+
+/// The two words every "no complexity distribution was provided" sentence is
+/// built around (#6691).
+///
+/// Two words rather than one phrase for the reason [`CLEAN_SIGNAL_WORDS`] is:
+/// the model puts its own qualifiers between them. Paired with
+/// [`ABSENCE_NEGATIONS`] and [`DATA_SUPPLY_WORDS`], which together are what
+/// separate "no complexity distribution was provided" (a claim about the DATA,
+/// and false when the Code Quality table renders one) from "the complexity
+/// distribution is not evenly spread" (a claim about its shape, which the
+/// guardrail has no business touching).
+pub(super) const COMPLEXITY_WORDS: (&str, &str) = ("complexity", "distribution");
+
+/// The verbs that make an absence sentence a claim about what the run was GIVEN.
+pub(super) const DATA_SUPPLY_WORDS: &[&str] = &[
+    "provided",
+    "available",
+    "resolved",
+    "supplied",
+    "given",
+    "present",
+    "reported",
+    "computed",
+    "surfaced",
+    "collected",
 ];
 
 /// Phrases that claim a crate is what the rest of the estate is built on.

--- a/crates/trusty-review/src/report/synthesize_grounding_vocab.rs
+++ b/crates/trusty-review/src/report/synthesize_grounding_vocab.rs
@@ -164,17 +164,17 @@ pub(super) const ABSENCE_NEGATIONS: &[&str] = &[
     "no ", "not ", "none", "nothing", "never", "n't", "zero ", "absent", "without",
 ];
 
-/// The two words every "no complexity distribution was provided" sentence is
-/// built around (#6691).
+/// The one word every claim about complexity data is built around (#6691).
 ///
-/// Two words rather than one phrase for the reason [`CLEAN_SIGNAL_WORDS`] is:
-/// the model puts its own qualifiers between them. Paired with
+/// One word, not the "complexity"+"distribution" pair the first fix used: that
+/// pair matched only the phrasing the graded report happened to use, so
+/// "complexity could not be measured" and "no complexity metrics were computed"
+/// — the same false claim, reworded — both shipped. Paired with
 /// [`ABSENCE_NEGATIONS`] and [`DATA_SUPPLY_WORDS`], which together are what
-/// separate "no complexity distribution was provided" (a claim about the DATA,
-/// and false when the Code Quality table renders one) from "the complexity
-/// distribution is not evenly spread" (a claim about its shape, which the
-/// guardrail has no business touching).
-pub(super) const COMPLEXITY_WORDS: (&str, &str) = ("complexity", "distribution");
+/// separate a claim about the DATA (false when the Code Quality table renders a
+/// distribution) from "the complexity distribution is not evenly spread" (a
+/// claim about its shape, which the guardrail has no business touching).
+pub(super) const COMPLEXITY_WORD: &str = "complexity";
 
 /// The verbs that make an absence sentence a claim about what the run was GIVEN.
 pub(super) const DATA_SUPPLY_WORDS: &[&str] = &[
@@ -186,6 +186,7 @@ pub(super) const DATA_SUPPLY_WORDS: &[&str] = &[
     "present",
     "reported",
     "computed",
+    "measured",
     "surfaced",
     "collected",
 ];

--- a/crates/trusty-review/src/report/synthesize_prompt.rs
+++ b/crates/trusty-review/src/report/synthesize_prompt.rs
@@ -486,12 +486,15 @@ pub(super) fn build_synthesis_prompt(
 /// (`reporter_fill::fill_profile`) but never the synthesis prompt.
 /// What: LoC and languages from `AnalyzeMetrics` when a `--analyze` run
 /// supplied it, else from `RepoScan`; file/function counts from whichever
-/// source carries them; and the scan's framework line rendered through
+/// source carries them; the complexity distribution as
+/// `reporter_codesec::bucket_summary` renders it into the Code Quality table
+/// (#6691); and the scan's framework line rendered through
 /// `reporter_fill::format_frameworks`, so the prompt and the report state the
 /// same manifests. Returns an empty string when neither source has anything —
 /// the caller then says so rather than emitting a headed but empty block.
 /// Test: `synthesize_tests.rs::{digest_carries_scan_profile_without_metrics,
-/// digest_names_build_manifests_as_component_evidence}`.
+/// digest_names_build_manifests_as_component_evidence,
+/// digest_carries_the_complexity_distribution_the_table_renders}`.
 fn repo_profile_lines(repo: &super::model::RepositoryReport) -> String {
     let metrics = repo.metrics.as_ref();
     let scan = repo.scan.as_ref();
@@ -516,13 +519,27 @@ fn repo_profile_lines(repo: &super::model::RepositoryReport) -> String {
         out.push_str(&format!("- Primary languages: {}\n", l.join(", ")));
     }
 
-    if let Some(m) = metrics {
-        out.push_str(&format!(
-            "- Files: {}; Functions: {}\n",
-            m.counts.files, m.counts.functions
-        ));
-    } else if let Some(s) = scan.filter(|s| s.file_count > 0) {
-        out.push_str(&format!("- Files: {}\n", s.file_count));
+    // #6691: a metrics artifact whose counts are zero used to print
+    // "Files: 0; Functions: 0", and the model reported those zeros as counts
+    // that could not be resolved — beside a Key Facts block rendering the scan's
+    // figures. Same metrics-then-scan precedence `reporter_facts::repo_files`
+    // uses, and a zero states nothing rather than stating a measurement.
+    let files = metrics
+        .map(|m| m.counts.files)
+        .filter(|n| *n > 0)
+        .or_else(|| scan.map(|s| s.file_count).filter(|n| *n > 0));
+    if let Some(n) = files {
+        out.push_str(&format!("- Files: {n}\n"));
+    }
+    if let Some(n) = metrics.map(|m| m.counts.functions).filter(|n| *n > 0) {
+        out.push_str(&format!("- Functions: {n}\n"));
+    }
+
+    // #6691: the same string the Code Quality table's `cq_complexity` cell
+    // renders, from the one function that renders it — the prose is written from
+    // the data the table shows, not from a digest that omitted it.
+    if let Some(summary) = metrics.and_then(super::reporter_codesec::bucket_summary) {
+        out.push_str(&format!("- Complexity distribution: {summary}\n"));
     }
 
     // #6030: the component evidence — which manifests exist, what project each

--- a/crates/trusty-review/src/report/synthesize_tests.rs
+++ b/crates/trusty-review/src/report/synthesize_tests.rs
@@ -21,7 +21,8 @@ use async_trait::async_trait;
 
 use crate::llm::{LlmError, LlmProvider, LlmRequest, LlmResponse};
 use crate::report::metrics::{
-    AnalyzeMetrics, CountMetrics, LanguageLoc, LocMetrics, MetricFinding, Severity,
+    AnalyzeMetrics, ComplexityBucket, ComplexityDistribution, CountMetrics, LanguageLoc,
+    LocMetrics, MetricFinding, Severity,
 };
 use crate::report::model::{ReportModel, RepositoryReport};
 use crate::report::synthesize_guard::{
@@ -1911,6 +1912,65 @@ fn digest_carries_scan_profile_without_metrics() {
     assert!(
         !digest.contains("No metrics available"),
         "a scanned application is not a metrics-free one: {digest}"
+    );
+}
+
+/// Why (#6691): the Code Quality paragraph denied the complexity distribution
+/// the deterministic table four lines under it rendered. The model wrote it
+/// from a digest that carried no distribution at all — so the prose and the
+/// table were never reading the same data.
+/// What: metrics carry the five bands; asserts the digest states them in the
+/// SAME string `reporter_codesec::bucket_summary` renders into `cq_complexity`,
+/// and that a zero file/function count states nothing rather than a measured 0.
+///
+/// Fails before the fix: `repo_profile_lines` never emitted the distribution,
+/// and printed "Files: 0; Functions: 0" for a metrics artifact with none.
+#[test]
+fn digest_carries_the_complexity_distribution_the_table_renders() {
+    let mut model = fixture_model(vec![]);
+    let repo = model.repositories.first_mut().expect("one repository");
+    let metrics = repo.metrics.as_mut().expect("fixture metrics");
+    metrics.counts = CountMetrics {
+        files: 0,
+        functions: 0,
+    };
+    metrics.complexity = ComplexityDistribution {
+        buckets: vec![
+            ComplexityBucket {
+                label: "A".to_string(),
+                count: 90,
+            },
+            ComplexityBucket {
+                label: "F".to_string(),
+                count: 10,
+            },
+        ],
+    };
+    let rendered = crate::report::reporter_codesec::bucket_summary(
+        model.repositories[0].metrics.as_ref().expect("metrics"),
+    )
+    .expect("the table renders a summary");
+
+    let digest = build_synthesis_prompt(
+        &model,
+        "stub/model",
+        SynthesisTier::Full,
+        SYNTHESIS_DEFAULT_MAX_TOKENS,
+    )
+    .messages[0]
+        .content
+        .clone();
+    assert!(
+        digest.contains(&format!("Complexity distribution: {rendered}")),
+        "the digest must state the table's own string ({rendered}): {digest}"
+    );
+    assert!(
+        !digest.contains("Files: 0"),
+        "a zero count is not a measurement to report: {digest}"
+    );
+    assert!(
+        !digest.contains("Functions: 0"),
+        "a zero count is not a measurement to report: {digest}"
     );
 }
 

--- a/crates/trusty-review/templates/report-technical-dd-cast.md
+++ b/crates/trusty-review/templates/report-technical-dd-cast.md
@@ -109,7 +109,7 @@ in the coverage data provided — and name it specifically.
 | Target / deal codename | {{target_codename}} |
 | Client | {{client_name}} |
 | Applications / systems assessed | {{applications_list}} |
-| Analysis methodology | Repository inspection via trusty-analyze (static code analysis, structural metrics, complexity measurement) + trusty-search (architecture context, KG-guided focus) |
+| Analysis methodology | {{analysis_methodology}} |
 | Audit scope | {{audit_scope}} |
 | Analyst (this instance) | {{analyst_name}} |
 | Analysis generated | {{analysis_generated_date}} |

--- a/crates/trusty-review/tests/report_methodology_6675.rs
+++ b/crates/trusty-review/tests/report_methodology_6675.rs
@@ -1,0 +1,118 @@
+//! The rendered CAST §1 methodology row reflects the run, not the template (#6675).
+//!
+//! Why: the row was fixed template text asserting trusty-analyze and
+//! trusty-search were both used. The 2026-09-02 dogfood run fell back to scan
+//! and anchored no symbol, and a reader who stopped at §1 was still told both
+//! tools had run. This asserts the rendered row against a run where neither
+//! lane contributed, which is the case the fixed text got wrong.
+//! What: renders the bundled CAST template over a fixture repository with no
+//! trusty-analyze metrics and no investigation, and asserts the row names both
+//! absences and carries no unqualified tool-use claim; then renders the same
+//! fixture WITH metrics and asserts the analyze lane is named as used.
+//! Test: this file.
+#![cfg(feature = "report")]
+
+use std::path::Path;
+
+use trusty_review::report::{Reporter, TemplateLoader, load_manifest, model::ReportModel};
+
+/// The bundled template name under test.
+const CAST: &str = "report-technical-dd-cast";
+
+/// The exact claim the fixed row made on every run, whatever ran.
+const FIXED_CLAIM: &str = "Repository inspection via trusty-analyze (static code analysis, \
+                           structural metrics, complexity measurement) + trusty-search \
+                           (architecture context, KG-guided focus)";
+
+/// A metrics artifact the manifest can declare, so the analyze lane has data.
+const FIXTURE_METRICS: &str = r#"{
+  "schema_version": "v0",
+  "repository": "fixture",
+  "loc": { "total": 3, "by_language": [ { "language": "Python", "loc": 3 } ] },
+  "counts": { "files": 1, "functions": 1 },
+  "complexity": { "buckets": [ { "label": "low (1-5)", "count": 1 } ] },
+  "findings": []
+}"#;
+
+fn write_fixture_repo(root: &Path) {
+    std::fs::create_dir_all(root.join("src")).expect("mkdir src");
+    std::fs::write(
+        root.join("src/app.py"),
+        "def total(items):\n    return sum(items)\n",
+    )
+    .expect("write app.py");
+}
+
+/// Render the bundled CAST template over the fixture, with or without a
+/// declared trusty-analyze metrics artifact.
+fn render(with_metrics: bool) -> String {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let dir = tmp.path();
+    let repo = dir.join("fixture-repo");
+    write_fixture_repo(&repo);
+
+    let metrics_line = if with_metrics {
+        std::fs::write(dir.join("metrics.json"), FIXTURE_METRICS).expect("write metrics");
+        "metrics = \"metrics.json\"\n"
+    } else {
+        ""
+    };
+    let manifest_toml = format!(
+        "[report]\n\
+         title = \"Fixture Technical DD\"\n\
+         template = \"cast\"\n\
+         analyst = \"bobmatnyc\"\n\n\
+         [[repositories]]\n\
+         name = \"Fixture App\"\n\
+         path = \"{}\"\n\
+         {metrics_line}",
+        repo.display()
+    );
+    let manifest_path = dir.join("manifest.toml");
+    std::fs::write(&manifest_path, manifest_toml).expect("write manifest");
+
+    let manifest = load_manifest(&manifest_path).expect("manifest loads");
+    let template = TemplateLoader::bundled_only()
+        .load(CAST)
+        .expect("bundled CAST template loads");
+    let mut model =
+        ReportModel::build(&manifest, &manifest_path, CAST, None).expect("model builds");
+    // #5454: `write`/`render` require a completed synthesis pass; this test is
+    // about the deterministic §1 fill, so an empty pass stands in for the LLM.
+    model.synthesis = Some(trusty_review::report::Synthesis::default());
+
+    Reporter::new(dir.join("reports")).render(&model, &template)
+}
+
+/// The live defect: a run where neither lane contributed still printed the
+/// fixed both-tools claim.
+///
+/// Fails before the fix: the row is template literal text, so `FIXED_CLAIM` is
+/// present in the render regardless of what the run recorded.
+#[test]
+fn the_methodology_row_states_a_run_where_neither_lane_contributed() {
+    let md = render(false);
+    assert!(
+        !md.contains(FIXED_CLAIM),
+        "the fixed both-tools claim must not survive a run that used neither tool:\n{md}"
+    );
+    assert!(
+        md.contains("trusty-analyze contributed no data to this run"),
+        "the row must name the analyze lane's absence:\n{md}"
+    );
+    assert!(
+        md.contains("trusty-search symbol tracing did not run"),
+        "the row must name the search lane's absence:\n{md}"
+    );
+}
+
+/// The row is not a blanket denial either: a run whose analyze lane did land
+/// says so, with its own count.
+#[test]
+fn the_methodology_row_credits_an_analyze_lane_that_landed() {
+    let md = render(true);
+    assert!(
+        md.contains("trusty-analyze structural metrics for all 1 application(s)"),
+        "the row must credit the analyze lane that contributed:\n{md}"
+    );
+}


### PR DESCRIPTION
## Outcome
Refs #6691, #6675.
- #6691: the synthesized Code Quality prose can no longer contradict the rendered complexity table. The synthesis digest states the same `bucket_summary` string the table cell renders (same data, same function), a zero-count metrics artifact falls through to the scan instead of printing zeros, and a grounding check drops any sentence claiming complexity data was absent, unmeasured, or unavailable when the table renders a non-empty distribution, scoped per application for multi-app reports. Shape claims ("not evenly spread") survive.
- #6675: the CAST §1 methodology line is derived from the run's recorded provenance (analyze metrics/gap, search trace counts) instead of a fixed claim; marked Measured.

## Changes
trusty-review only. New `report/methodology.rs`, new `report/synthesize_grounding_complexity.rs` (split to stay under the 500-SLOC cap), edits to synthesize_prompt.rs, synthesize_grounding.rs, synthesize_grounding_vocab.rs, reporter.rs, reporter_codesec.rs, template `report-technical-dd-cast.md`; tests in synthesize_tests.rs, synthesize_grounding_tests.rs, methodology_tests.rs, tests/report_methodology_6675.rs; changelog fragment `6691-6675-report-prose-provenance.md`; version bump 0.32.0 → 0.32.1 (required by the version-bump check).

## Risk
Normal, localized to trusty-review report rendering. Fail-closed cost recorded: a sentence pairing a negation with a supply verb for an unrelated reason is also withheld, with a Synthesis Status disclosure.

## Tests
Rung 3, all `-p trusty-review`: `cargo fmt --check`, `cargo check --all-targets`, `cargo clippy --all-targets -- -D warnings`, `cargo test --no-fail-fast` → 2251 passed, 0 failed, 5 ignored across 14 targets. Regression tests shown failing on origin/main and passing after: `digest_carries_the_complexity_distribution_the_table_renders`, `a_no_complexity_data_claim_is_dropped_when_the_table_renders_one`, `every_paraphrase_of_the_absence_claim_is_dropped`, `a_per_application_absence_claim_survives_when_that_app_has_none`, `a_report_wide_absence_claim_survives_when_one_application_has_none`, `the_methodology_row_credits_an_analyze_lane_that_landed`, `the_methodology_row_states_a_run_where_neither_lane_contributed`. Doc gates: check_test_pointers (0 dangling), check_line_cap (0 violations), check_changelog_fragment OK, check_sld OK. `PR_VERSION_BUMP_BASE=origin/main scripts/check-pr-version-bump.sh` clear.

## Baseline
None.

## Docs
Changelog fragment; Why/What/Test on the new modules.

## Review
code-critic WARN on 19a44707e: HIGH (matcher keyed on one phrasing; four paraphrases escaped) and MEDIUM (report-wide sum deleted true per-app claims). Both fixed in ad574759e with the tests named above.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
