### PR TITLE
test(trusty-mpm,trusty-memory,trusty-console): stabilize registry-isolation, load-sensitive, uds, and port-race flakes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6596,7 +6596,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11694,7 +11694,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-console"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -11860,7 +11860,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-memory"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11902,7 +11902,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-mpm"
-version = "1.5.16"
+version = "1.5.17"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-console/Cargo.toml
+++ b/crates/trusty-console/Cargo.toml
@@ -17,7 +17,9 @@ name        = "trusty-console"
 # for a 0.x crate. `preflight-publish.sh` CHECK 5 refused 0.9.3 against 0.9.2 on
 # two counts: `constructible_struct_adds_field` for `ServeArgs.host_sample_interval`
 # (src/lib.rs:204), and `function_missing` for `trusty_console::host_status::start`.
-version     = "0.10.0"
+# 0.10.1 (refs #6671, #6663, #6667, #6661): patch — test-flake stabilization
+# changes in the test suite under an already-published version.
+version     = "0.10.1"
 edition     = "2024"
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/trusty-console/changelog.d/6661-test-port-and-env-races.md
+++ b/crates/trusty-console/changelog.d/6661-test-port-and-env-races.md
@@ -1,0 +1,3 @@
+Fixed
+- Test-only: `TRUSTY_DATA_DIR_OVERRIDE` is now guarded by one crate-wide lock instead of two, so a `remove_var` in the `lib.rs` port tests can no longer land inside the connector tests' critical section and send `detect()` at the live daemon on 7880 (#6661).
+- Test-only: the closed-port probe assertion targets a privileged, non-ephemeral loopback port rather than a just-freed ephemeral one a parallel test can be handed (#6661).

--- a/crates/trusty-console/src/detect/helpers.rs
+++ b/crates/trusty-console/src/detect/helpers.rs
@@ -326,18 +326,26 @@ mod tests {
     // ── tcp_probe ───────────────────────────────────────────────────────────
 
     /// Why: a closed port must yield false (not panic or block).
-    /// What: binds port 0 (OS assigns a free port), captures the addr, drops
-    /// the listener so the port closes, then asserts tcp_probe returns false.
-    /// Using an OS-assigned port avoids CI flap from hardcoded port numbers.
+    ///
+    /// #6661: this used to bind `127.0.0.1:0`, drop the listener, and assert
+    /// nothing answered on the freed port. Dropping a listener returns its port
+    /// to the OS ephemeral pool, so a parallel test that binds `127.0.0.1:0` —
+    /// `mpm_connector_surfaces_url_via_http_addr` does exactly that — can be
+    /// handed the same port and start listening on it before the probe runs.
+    /// The premise "nothing can be here" then does not hold and the probe
+    /// correctly returns `true`.
+    /// What: probes loopback port 1 instead. Nothing listens there: binding it
+    /// needs root, and it sits below every ephemeral range the OS allocates
+    /// from (macOS 49152–65535, Linux's 32768–60999 default), so no other test
+    /// can be given it. The kernel answers `RST`, so the probe returns `false`
+    /// promptly rather than spending its 300 ms timeout.
     /// Test: this test itself.
     #[test]
     fn test_tcp_probe_unreachable() {
-        use std::net::TcpListener;
-        // Bind to get a free OS port, then drop so the port is closed.
-        let listener = TcpListener::bind("127.0.0.1:0").expect("bind free port");
-        let addr = listener.local_addr().expect("local_addr").to_string();
-        drop(listener);
-        assert!(!tcp_probe(&addr), "closed port must return false");
+        assert!(
+            !tcp_probe("127.0.0.1:1"),
+            "a privileged, non-ephemeral port nothing can bind must return false"
+        );
     }
 
     /// Why: a listening port must yield true.

--- a/crates/trusty-console/src/detect/mod.rs
+++ b/crates/trusty-console/src/detect/mod.rs
@@ -43,10 +43,19 @@ use crate::connector::{ServiceConnector, ServiceInfo, ServiceStatus};
 /// clobber each other's override and race (#3331 regression: the agents tests
 /// racing the mpm lock-file test). A single shared lock in the common parent
 /// module serialises them all.
-/// What: a `std::sync::Mutex<()>` locked by every env-mutating connector test.
-/// Test: used by `agents::tests` and `mpm::tests`; not itself a test.
+///
+/// #6661: `lib.rs` kept a SECOND lock over the same variable, so its
+/// `remove_var` landed inside this lock's critical section and
+/// `mpm_connector_surfaces_url_via_http_addr` read the live daemon on 7880
+/// instead of its fixture. This is now the crate's ONE lock for
+/// `TRUSTY_DATA_DIR_OVERRIDE`; a new env-mutating test takes this one or it is
+/// not serialised at all. (Under `cargo nextest` each test owns its process,
+/// so the variable is not shared there and the lock is inert — see CLAUDE.md.)
+/// What: a `std::sync::Mutex<()>` locked by every env-mutating test in the crate.
+/// Test: used by `agents::tests`, `mpm::tests`, `search_uds::tests` and the
+/// `port` verb tests in `lib.rs`; not itself a test.
 #[cfg(test)]
-pub(super) static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+pub(crate) static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 /// Return all connectors in display order.
 ///

--- a/crates/trusty-console/src/lib.rs
+++ b/crates/trusty-console/src/lib.rs
@@ -553,14 +553,11 @@ pub async fn run_serve(args: ServeArgs) -> Result<()> {
 mod tests {
     use super::*;
 
-    /// Serialises tests that mutate the `TRUSTY_DATA_DIR_OVERRIDE` env var.
-    ///
-    /// Why: `std::env::set_var`/`remove_var` are process-global; parallel test
-    /// threads racing on them cause flaky failures. A module-level mutex makes
-    /// the override-set / call / override-clear sequence atomic per test.
-    /// What: a `()` mutex acquired at the top of each env-mutating test.
-    /// Test: used by the `port` verb tests below.
-    static DATA_DIR_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    // #6661: this module used to declare its own `TRUSTY_DATA_DIR_OVERRIDE`
+    // mutex. Two locks over one process-global variable serialise nothing
+    // between them, so a `remove_var` here landed inside the connector tests'
+    // critical section. `detect::ENV_LOCK` is the crate's single lock.
+    use crate::detect::ENV_LOCK as DATA_DIR_ENV_LOCK;
 
     /// Why: default http address must be 127.0.0.1:7788 and tailscale off.
     /// What: parses `serve` with no flags and checks all defaults.

--- a/crates/trusty-memory/Cargo.toml
+++ b/crates/trusty-memory/Cargo.toml
@@ -27,7 +27,9 @@ name = "trusty-memory"
 # socket unlink run, and one stderr line takes one ring slot with a bounded exit
 # flush. Internal to `transport::uds` and `bm25_lane`; no public item was
 # removed or changed.
-version = "0.25.6"
+# 0.25.7 (refs #6671, #6663, #6667, #6661): patch — test-flake stabilization
+# changes in the test suite under an already-published version.
+version = "0.25.7"
 edition = "2021"
 description = "MCP server (stdio + Unix socket) for trusty-memory"
 license.workspace = true

--- a/crates/trusty-memory/src/transport/uds_tests.rs
+++ b/crates/trusty-memory/src/transport/uds_tests.rs
@@ -26,6 +26,7 @@ use tokio::sync::oneshot;
 use trusty_common::uds::server::{RpcResponse, CODE_METHOD_NOT_FOUND};
 use trusty_common::uds::{
     send_framed_request_capped, send_framed_stream_request_capped, verify_socket_for_connect,
+    UdsRpcError,
 };
 use trusty_common::{ChatEvent, ChatMessage, ChatProvider, ToolDef};
 
@@ -178,15 +179,48 @@ impl Daemon {
     }
 
     /// Dial, send one frame, read one back.
+    ///
+    /// #6667: a dial that fails, or a first write that fails, is retried until
+    /// [`CALL_TIMEOUT`] rather than failing the test. Under a full
+    /// `--no-fail-fast` run one to three of these tests died with
+    /// `write request frame to …/trusty-memory.sock: Socket is not connected
+    /// (os error 57)`, a different set each run, each passing on its own. Every
+    /// test here binds its own socket under its own tempdir, so the reported
+    /// "tests share the daemon socket" is not what happened — the dial returned
+    /// a stream the kernel had not finished connecting because the server's
+    /// accept task had not been scheduled, and the immediate write then found
+    /// no peer.
+    ///
+    /// Retrying is sound rather than papering over, and the reason is narrow:
+    /// [`UdsRpcError::Dial`] and [`UdsRpcError::Write`] both prove NOTHING
+    /// reached the peer, so a fresh dial repeats no request and can duplicate
+    /// no side effect. Every other variant — `NoResponse` above all — means the
+    /// frame was sent, and those still fail the test on the first occurrence.
     async fn call(&self, method: &str, params: Value) -> RpcResponse {
-        send_framed_request_capped(
-            &self.socket,
-            &frame(1, method, params),
-            CALL_TIMEOUT,
-            MAX_FRAME_BYTES,
-        )
-        .await
-        .unwrap_or_else(|e| panic!("call {method}: {e}"))
+        let deadline = tokio::time::Instant::now() + CALL_TIMEOUT;
+        loop {
+            let sent = send_framed_request_capped(
+                &self.socket,
+                &frame(1, method, params.clone()),
+                CALL_TIMEOUT,
+                MAX_FRAME_BYTES,
+            )
+            .await;
+            match sent {
+                Ok(response) => return response,
+                Err(e @ (UdsRpcError::Dial { .. } | UdsRpcError::Write { .. }))
+                    if tokio::time::Instant::now() < deadline =>
+                {
+                    tracing::warn!(
+                        method,
+                        error = %e,
+                        "nothing was written; redialling (#6667)"
+                    );
+                    tokio::time::sleep(Duration::from_millis(25)).await;
+                }
+                Err(e) => panic!("call {method}: {e}"),
+            }
+        }
     }
 
     /// Call and unwrap the success half, naming the error if there is one.

--- a/crates/trusty-memory/tests/uds_consumer_contract.rs
+++ b/crates/trusty-memory/tests/uds_consumer_contract.rs
@@ -38,6 +38,47 @@ use trusty_memory::AppState;
 /// Generous enough for a loaded machine; a local socket answers in microseconds.
 const CALL_TIMEOUT: Duration = Duration::from_secs(20);
 
+/// Block until `socket` ANSWERS a real request, not merely until it accepts one.
+///
+/// Why (#6667): the gate this replaces was `uds::socket_is_serving` — a bare
+/// connect-and-close. It proves the listener exists; it does not prove a client
+/// that dials can get a frame through. Under a full `--no-fail-fast` run
+/// `tctl_probe_sees_a_live_uds_daemon_as_serving` died on the first real call
+/// with `write request frame to …/trusty-memory.sock: Socket is not connected
+/// (os error 57)` — the dial returned a stream whose peer had not finished
+/// coming up, so nothing was written. Two known windows sit behind that gate:
+/// `bind_hardened` binds BEFORE it chmods, so a connect landing in between sees
+/// a socket a hardened dial would still refuse (#6315), and a connect that the
+/// server has not yet accepted has no peer to write to.
+///
+/// What: polls `memory.health` through the shared client until one call
+/// SUCCEEDS. That is the condition the tests actually depend on, and it cannot
+/// be satisfied by a half-open socket. Panics at the budget rather than letting
+/// the first assertion fail somewhere less legible.
+async fn wait_until_answering(socket: &std::path::Path) {
+    let deadline = std::time::Instant::now() + Duration::from_secs(20);
+    let mut last: Option<String> = None;
+    while std::time::Instant::now() < deadline {
+        match call_memory_tool_at_with_timeout(
+            socket,
+            "memory.health",
+            json!({}),
+            Duration::from_secs(1),
+        )
+        .await
+        {
+            Ok(_) => return,
+            Err(e) => last = Some(format!("{e:#}")),
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    panic!(
+        "nothing answered memory.health on {} within the budget: {}",
+        socket.display(),
+        last.unwrap_or_else(|| "no error recorded".to_string())
+    );
+}
+
 /// A running daemon on a temp socket, and the handle that stops it.
 struct Daemon {
     socket: PathBuf,
@@ -78,13 +119,7 @@ impl Daemon {
                 .await;
         });
 
-        // Poll rather than sleep: the bind is fast but a loaded machine is not.
-        for _ in 0..200 {
-            if trusty_common::uds::socket_is_serving(&socket, Duration::from_millis(50)).await {
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(25)).await;
-        }
+        wait_until_answering(&socket).await;
 
         Self {
             socket,
@@ -462,15 +497,7 @@ async fn tctl_probe_sees_a_live_uds_daemon_as_serving() {
         .await
     });
 
-    let mut up = false;
-    for _ in 0..200 {
-        if trusty_common::uds::socket_is_serving(&socket, Duration::from_millis(50)).await {
-            up = true;
-            break;
-        }
-        tokio::time::sleep(Duration::from_millis(25)).await;
-    }
-    assert!(up, "nothing came up on {}", socket.display());
+    wait_until_answering(&socket).await;
 
     let outcome = probe_daemon_http("trusty-memory", "trusty-memory").await;
     assert!(

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -21,7 +21,9 @@ name = "trusty-mpm"
 # #6579) edit `src/**` under it. Bumped on `main` first so the
 # `PR version bump vs crates.io` gate clears once each PR updates its branch
 # onto this commit.
-version = "1.5.16"
+# 1.5.17 (refs #6671, #6663, #6667, #6661): patch — test-flake stabilization
+# changes in the test suite under an already-published version.
+version = "1.5.17"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/trusty-mpm/changelog.d/6671-test-flake-isolation.md
+++ b/crates/trusty-mpm/changelog.d/6671-test-flake-isolation.md
@@ -1,0 +1,3 @@
+Fixed
+- Test-only: five integration targets (`manager_routes`, `project_registry_routes`, `manager_cli_client`, `manager_inference`, `mcp_spawn_gate`) now redirect `$HOME` to a per-process scratch directory, so the project registry no longer seeds itself from the developer's real `~/.trusty-tools/trusty-mpm/config.yaml` (#6671).
+- Test-only: three load-sensitive tests no longer assume a fixed timing budget — the orphan-GC canary owns its own `$HOME` instead of racing sibling `$HOME` overrides, and the statusline remote-slug and transcript-tail guards poll for their condition (#6663).

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_cost.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_cost.rs
@@ -550,7 +550,21 @@ mod tests {
             "transcript_path": parent.to_str().expect("utf8"),
             "agent_id": "huge",
         });
-        let (status, tokens) = evaluate_agent_cost(&payload, &opted_in_stop()).await;
+        // #6663: `evaluate_agent_cost` wraps BOTH tail reads in one 200 ms
+        // `EVAL_TIMEOUT`, and this fixture is ~600 KiB read twice. Under a
+        // loaded `--no-fail-fast` run that budget expired, the guard failed
+        // open, and the test saw `(Ok, 0)` — a timing loss, not a behaviour
+        // change. Retrying is sound because the call is a pure read with no
+        // side effect, so an attempt that timed out changed nothing. The
+        // assertion is unchanged: the record must be found, and a guard that
+        // genuinely could not find it still fails at the deadline.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        let mut measured = evaluate_agent_cost(&payload, &opted_in_stop()).await;
+        while measured == (BudgetStatus::Ok, 0) && std::time::Instant::now() < deadline {
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+            measured = evaluate_agent_cost(&payload, &opted_in_stop()).await;
+        }
+        let (status, tokens) = measured;
         assert_eq!(tokens, 500_000, "the larger window must find the record");
         assert_eq!(status, BudgetStatus::Exceeded);
     }

--- a/crates/trusty-mpm/src/bin/tm/commands/statusline/branch.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/statusline/branch.rs
@@ -372,6 +372,16 @@ mod tests {
 
     /// Why: the leading field must resolve to the GitHub `owner/repo` slug parsed
     /// from the git remote (both scp-style and https), matching `source_id`.
+    ///
+    /// #6663: [`git_owner_repo`] gives its worker thread a 100 ms
+    /// `recv_timeout`, and that worker shells out to `git`. Under a loaded
+    /// `--no-fail-fast` run one `git` invocation can exceed 100 ms, so a single
+    /// call returned `None` and the test failed on a tree it had just passed
+    /// on. The retry below waits for the condition — a resolved slug — rather
+    /// than assuming one attempt fits in the budget. Each attempt re-arms the
+    /// production timeout, so this loosens nothing about what is asserted: the
+    /// slug must still be exactly right, and an unresolvable remote still fails
+    /// at the deadline.
     /// Test: itself (temp git repo; skipped when git is unavailable on the runner).
     #[test]
     fn git_owner_repo_reads_remote() {
@@ -396,8 +406,15 @@ mod tests {
             "git@github.com:bobmatnyc/trusty-tools.git",
         ]));
         let cwd = dir.to_string_lossy().to_string();
+        // #6663: poll the condition instead of trusting one 100 ms attempt.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        let mut resolved = git_owner_repo(&cwd);
+        while resolved.is_none() && std::time::Instant::now() < deadline {
+            std::thread::sleep(std::time::Duration::from_millis(25));
+            resolved = git_owner_repo(&cwd);
+        }
         assert_eq!(
-            git_owner_repo(&cwd).as_deref(),
+            resolved.as_deref(),
             Some("bobmatnyc/trusty-tools"),
             "scp-style remote → owner/repo slug"
         );

--- a/crates/trusty-mpm/src/daemon/mod.rs
+++ b/crates/trusty-mpm/src/daemon/mod.rs
@@ -1159,17 +1159,32 @@ mod shutdown_reaper_tests {
     /// tick of this loop. Unlike
     /// `orphan_gc_loop_ticks_cleanly_on_a_scratch_framework_root`, this test is
     /// DISCRIMINATING: it fails against that revision.
-    /// What: plants an empty UUID-named directory under the real home sessions
-    /// dir, drives one tick on a scratch-rooted state, and asserts the canary
-    /// survived. Two independent things must hold for that: the sweep resolves
-    /// `state.framework_root()` rather than the home directory, and it sits
-    /// below the host-state gate.
+    /// What: plants an empty UUID-named directory under the sessions dir of a
+    /// `$HOME` this test owns, drives the loop on a scratch-rooted state, and
+    /// asserts the canary survived. Two independent things must hold for that:
+    /// the sweep resolves `state.framework_root()` rather than the home
+    /// directory, and it sits below the host-state gate.
+    ///
+    /// #6663: the canary used to be planted under `dirs::home_dir()`, i.e. the
+    /// ambient `$HOME`. About twenty tests in this same lib binary redirect
+    /// `$HOME` to a `TempDir`, so a canary planted while one of those overrides
+    /// was live landed inside that fixture's directory and was deleted by its
+    /// `Drop` — the loop under test never touched it. Owning `$HOME` here makes
+    /// the canary's parent a directory this test holds for its whole duration,
+    /// so no sibling's cleanup can reach it. A sibling that clobbers `$HOME`
+    /// mid-test can now only send a BUGGY sweep somewhere else, which loses
+    /// discrimination rather than failing; under `cargo nextest` (one process
+    /// per test, the CI shards) even that cannot happen.
     /// Test: this is the test.
     #[tokio::test]
     async fn orphan_gc_loop_leaves_the_home_session_dirs_alone_on_a_scratch_root() {
-        let Some(home) = dirs::home_dir() else {
-            return; // No home to protect; nothing to assert.
-        };
+        // #6663: a `$HOME` this test owns, not the operator's.
+        let home_dir = tempfile::tempdir().expect("scratch home");
+        let home = home_dir.path().to_path_buf();
+        // SAFETY: `set_var` is process-local and this test only widens the
+        // isolation the surrounding suite already relies on.
+        unsafe { std::env::set_var("HOME", &home) };
+
         let (state, dir) = scratch_root_state();
         assert!(
             host_state_refusal(&state).is_some(),
@@ -1182,7 +1197,7 @@ mod shutdown_reaper_tests {
         );
 
         // A canary the sweep would find reclaimable: empty, hyphenated-UUID
-        // named, directly under the real home sessions dir.
+        // named, directly under the home sessions dir.
         let canary = crate::core::session_store::sessions_root_in(&home)
             .join(uuid::Uuid::new_v4().to_string());
         std::fs::create_dir_all(&canary).expect("plant the canary");
@@ -1192,17 +1207,28 @@ mod shutdown_reaper_tests {
             Arc::clone(&state),
             cancel.child_token(),
         ));
-        // `tokio::time::interval` fires its first tick immediately.
-        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+        // #6663: poll for the failure instead of sleeping a fixed 250 ms and
+        // looking once. `tokio::time::interval` fires its first tick
+        // immediately, so a correct loop has already refused long before the
+        // budget expires, while a loaded machine gets the whole budget to get
+        // round to a tick that a fixed wait would have missed.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(1);
+        let mut survived = true;
+        while std::time::Instant::now() < deadline {
+            if !canary.is_dir() {
+                survived = false;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
         cancel.cancel();
         handle.await.expect("orphan_gc_loop must not panic");
 
-        let survived = canary.is_dir();
         // Clean up before asserting, so a failure does not also leave litter.
         let _ = std::fs::remove_dir(&canary);
         assert!(
             survived,
-            "a scratch-rooted daemon deleted {} out of the operator's real home",
+            "a scratch-rooted daemon deleted {} out of the home session tree",
             canary.display()
         );
     }

--- a/crates/trusty-mpm/src/daemon/mod.rs
+++ b/crates/trusty-mpm/src/daemon/mod.rs
@@ -1013,6 +1013,37 @@ mod shutdown_reaper_tests {
         (state, dir)
     }
 
+    /// RAII guard restoring `$HOME` on drop, panic included (#6663).
+    ///
+    /// A copy of `session_manager::naming_tests`'s guard rather than a shared
+    /// one: module-private visibility does not cross sibling module trees, and
+    /// several other test modules in this crate carry the same copy for the
+    /// same reason. Callers MUST be `#[serial_test::serial]` — the guard makes
+    /// the mutation reversible, not atomic, and ~20 tests in this binary write
+    /// `$HOME`.
+    /// Test: used by
+    /// `orphan_gc_loop_leaves_the_home_session_dirs_alone_on_a_scratch_root`.
+    struct HomeGuard(Option<String>);
+    impl Drop for HomeGuard {
+        fn drop(&mut self) {
+            // SAFETY: paired with `#[serial_test::serial]` — no other thread
+            // reads or writes the environment concurrently.
+            match self.0 {
+                Some(ref p) => unsafe { std::env::set_var("HOME", p) },
+                None => unsafe { std::env::remove_var("HOME") },
+            }
+        }
+    }
+
+    /// Point `$HOME` at `home` until the returned guard drops. Callers MUST be
+    /// `#[serial_test::serial]` — see [`HomeGuard`].
+    fn set_home(home: &std::path::Path) -> HomeGuard {
+        let prior = std::env::var("HOME").ok();
+        // SAFETY: serialized via `#[serial_test::serial]`.
+        unsafe { std::env::set_var("HOME", home) };
+        HomeGuard(prior)
+    }
+
     /// A tmux-origin session whose tmux name is certainly not live.
     fn dead_session() -> crate::core::session::Session {
         use crate::core::session::{ControlModel, Session, SessionId, SessionStatus};
@@ -1175,15 +1206,27 @@ mod shutdown_reaper_tests {
     /// mid-test can now only send a BUGGY sweep somewhere else, which loses
     /// discrimination rather than failing; under `cargo nextest` (one process
     /// per test, the CI shards) even that cannot happen.
+    ///
+    /// The redirect is reversible and serialized — [`set_home`] plus
+    /// `#[serial_test::serial]`. Leaving `$HOME` pointing at this test's
+    /// `TempDir` after it returns would hand every later test in the binary a
+    /// deleted home, which is a worse fault than the one being fixed.
+    ///
+    /// This is the ONE test here that leaves the inherited-`$HOME` quadrant
+    /// `scratch_root_state` documents, and it stays discriminating anyway: the
+    /// revision this guards against swept ABOVE the host-state gate, so which
+    /// arm of that gate refuses does not decide the outcome — whether the sweep
+    /// resolved the home directory does.
     /// Test: this is the test.
     #[tokio::test]
+    #[serial_test::serial]
     async fn orphan_gc_loop_leaves_the_home_session_dirs_alone_on_a_scratch_root() {
-        // #6663: a `$HOME` this test owns, not the operator's.
+        // #6663: a `$HOME` this test owns, not the operator's. Declared BEFORE
+        // the guard so the guard drops FIRST — `$HOME` is restored while this
+        // directory still exists, never left naming a removed path.
         let home_dir = tempfile::tempdir().expect("scratch home");
         let home = home_dir.path().to_path_buf();
-        // SAFETY: `set_var` is process-local and this test only widens the
-        // isolation the surrounding suite already relies on.
-        unsafe { std::env::set_var("HOME", &home) };
+        let _home = set_home(&home);
 
         let (state, dir) = scratch_root_state();
         assert!(

--- a/crates/trusty-mpm/src/daemon/rpc/registry/tests.rs
+++ b/crates/trusty-mpm/src/daemon/rpc/registry/tests.rs
@@ -53,6 +53,54 @@ fn hermetic() -> (Arc<DaemonState>, TempDir) {
     (Arc::new(DaemonState::with_paths(&paths)), dir)
 }
 
+/// RAII guard restoring `$HOME` on drop, panic included (#6671).
+///
+/// A copy of `session_manager::naming_tests`'s guard rather than a shared one:
+/// module-private visibility does not cross sibling module trees, and several
+/// other test modules in this crate carry the same copy for the same reason.
+/// Callers MUST be `#[serial_test::serial]` — the guard makes the mutation
+/// reversible, not atomic, and other tests in this binary write `$HOME`.
+/// Test: used by [`hermetic_isolated_home`]'s callers.
+struct HomeGuard(Option<String>);
+
+impl Drop for HomeGuard {
+    fn drop(&mut self) {
+        // SAFETY: paired with `#[serial_test::serial]` — no other thread reads
+        // or writes the environment concurrently.
+        match self.0 {
+            Some(ref p) => unsafe { std::env::set_var("HOME", p) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+    }
+}
+
+/// [`hermetic`], plus a scratch `$HOME` for the caller's scope (#6671).
+///
+/// Why: a hermetic ROOT is not a hermetic REGISTRY.
+/// `DaemonState::project_registry()` seeds itself from
+/// `TrustyToolsConfig::load()`, which resolves
+/// `~/.trusty-tools/trusty-mpm/config.yaml` through `$HOME`, so the four callers
+/// below read the DEVELOPER's registered projects — they asserted
+/// `project_count == 1` on a machine answering 23. Same defect #6671 reports for
+/// five integration targets, here in the lib.
+/// What: returns [`hermetic`]'s state and root, the scratch home, and a
+/// [`HomeGuard`]. The caller binds all four, so `$HOME` is restored when the
+/// test returns or panics, and restored BEFORE the scratch home is removed —
+/// tuple bindings drop in reverse order, so the guard goes first.
+/// Test: `parity_manager_status_agrees_across_transports`,
+/// `parity_projects_registry_list_agrees_across_transports`,
+/// `parity_projects_registry_register_agrees_across_transports`,
+/// `rpc_projects_registry_register_rejects_a_blank_name`.
+fn hermetic_isolated_home() -> (Arc<DaemonState>, TempDir, TempDir, HomeGuard) {
+    let home = tempfile::tempdir().expect("scratch $HOME");
+    let prior = std::env::var("HOME").ok();
+    // SAFETY: serialized via `#[serial_test::serial]` on every caller.
+    unsafe { std::env::set_var("HOME", home.path()) };
+    let guard = HomeGuard(prior);
+    let (state, dir) = hermetic();
+    (state, dir, home, guard)
+}
+
 /// The RPC router this slice registers, over `state`.
 fn rpc_router(state: &Arc<DaemonState>) -> RpcRouter {
     register(RpcRouter::new(), state)
@@ -362,8 +410,10 @@ async fn seed_project(state: &Arc<DaemonState>, name: &str) {
 
 /// Test: this function IS the test.
 #[tokio::test]
+// #6671: reads the project registry, which seeds from `$HOME`.
+#[serial_test::serial]
 async fn parity_projects_registry_list_agrees_across_transports() {
-    let (state, _dir) = hermetic();
+    let (state, _dir, _home_dir, _home) = hermetic_isolated_home();
     seed_project(&state, "alpha").await;
 
     let (status, body) = http(&state, "GET", "/api/v1/projects", None).await;
@@ -383,8 +433,10 @@ async fn parity_projects_registry_list_agrees_across_transports() {
 /// call reached it.
 /// Test: this function IS the test.
 #[tokio::test]
+// #6671: reads the project registry, which seeds from `$HOME`.
+#[serial_test::serial]
 async fn parity_projects_registry_register_agrees_across_transports() {
-    let (state, _dir) = hermetic();
+    let (state, _dir, _home_dir, _home) = hermetic_isolated_home();
 
     let body_for = |name: &str| {
         json!({
@@ -568,8 +620,10 @@ async fn rpc_projects_registry_patch_rejects_a_blank_required_field() {
 /// Why: a blank name is rejected before the store is touched on both paths.
 /// Test: this function IS the test.
 #[tokio::test]
+// #6671: reads the project registry, which seeds from `$HOME`.
+#[serial_test::serial]
 async fn rpc_projects_registry_register_rejects_a_blank_name() {
-    let (state, _dir) = hermetic();
+    let (state, _dir, _home_dir, _home) = hermetic_isolated_home();
     let payload = json!({ "name": "   ", "repo_url": "https://example.invalid/r" });
 
     let (status, _) = http(&state, "POST", "/api/v1/projects", Some(payload.clone())).await;
@@ -1057,8 +1111,10 @@ async fn parity_manager_version_agrees_across_transports() {
 
 /// Test: this function IS the test.
 #[tokio::test]
+// #6671: reads the project registry, which seeds from `$HOME`.
+#[serial_test::serial]
 async fn parity_manager_status_agrees_across_transports() {
-    let (state, _dir) = hermetic();
+    let (state, _dir, _home_dir, _home) = hermetic_isolated_home();
     seed_project(&state, "alpha").await;
 
     let (status, body) = http(&state, "GET", "/api/v1/manager/status", None).await;

--- a/crates/trusty-mpm/tests/common/mod.rs
+++ b/crates/trusty-mpm/tests/common/mod.rs
@@ -1,0 +1,52 @@
+//! Per-process `$HOME` isolation for trusty-mpm's integration targets (#6671).
+//!
+//! Why: `DaemonState::project_registry()` seeds itself from
+//! `TrustyToolsConfig::load()`, which resolves
+//! `~/.trusty-tools/trusty-mpm/config.yaml` through `dirs::home_dir()` — i.e.
+//! `$HOME`. A target that isolates only the daemon's framework root therefore
+//! still reads the DEVELOPER's registered projects, so assertions on portfolio
+//! counts describe that machine rather than the fixture (#6671 observed
+//! `left Number(22) right 0`). #4120 established the per-test `$HOME` redirect;
+//! these five targets never adopted it.
+//!
+//! What: [`scratch_home`] points the whole test PROCESS at a fresh scratch
+//! directory exactly once, inside a [`std::sync::OnceLock`] initialiser. A test
+//! that calls it either performs the redirect or blocks until another thread's
+//! redirect is visible, so no test can observe the real `$HOME`. Exactly one
+//! value is ever written, so — unlike the save-and-restore `HomeGuard` pattern
+//! used elsewhere in this suite — there is no window in which one test's
+//! restore un-isolates another test's read.
+//!
+//! Test: every test in `manager_routes`, `project_registry_routes`,
+//! `manager_cli_client`, `manager_inference` and `mcp_spawn_gate`. Each now
+//! asserts against a registry the host machine cannot reach.
+
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+/// Redirect this test process's `$HOME` to a scratch directory, once (#6671).
+///
+/// Returns the scratch home, so a caller may plant fixtures under it.
+///
+/// The directory is deliberately `keep()`-ed rather than dropped: it must
+/// outlive every test in the process, and a `static` is never dropped anyway.
+/// It carries the crate's `tm-test-` prefix under `/tmp`, so
+/// `test_support::sweep_stale_test_dirs` — which runs in the lib target on
+/// every `cargo test -p trusty-mpm` — reaps it after a day.
+pub fn scratch_home() -> &'static Path {
+    static HOME: OnceLock<PathBuf> = OnceLock::new();
+    HOME.get_or_init(|| {
+        let dir = tempfile::Builder::new()
+            .prefix("tm-test-home-")
+            .tempdir_in("/tmp")
+            .expect("create scratch $HOME")
+            .keep();
+        // SAFETY: this runs inside `OnceLock::get_or_init`, so exactly one
+        // thread ever writes `HOME` in this process and every other thread is
+        // blocked until that write is visible. Nothing else in these targets
+        // mutates `HOME`.
+        unsafe { std::env::set_var("HOME", &dir) };
+        dir
+    })
+    .as_path()
+}

--- a/crates/trusty-mpm/tests/manager_cli_client.rs
+++ b/crates/trusty-mpm/tests/manager_cli_client.rs
@@ -55,6 +55,9 @@ use trusty_mpm::client::DaemonClient;
 use trusty_mpm::daemon::{api, state::DaemonState};
 use trusty_mpm::project::Project;
 
+// #6671: the project registry seeds from the config file under `$HOME`.
+mod common;
+
 /// Serve the REAL daemon router on an ephemeral loopback port; return its base URL.
 async fn serve_real(state: Arc<DaemonState>) -> String {
     let router = api::router(state);
@@ -66,6 +69,7 @@ async fn serve_real(state: Arc<DaemonState>) -> String {
 
 /// A fresh, hermetic daemon state under a temp framework root.
 async fn fresh_state() -> Arc<DaemonState> {
+    common::scratch_home(); // #6671
     let root = tempfile::tempdir().unwrap().keep();
     Arc::new(DaemonState::with_root_isolated_managed(root).await)
 }

--- a/crates/trusty-mpm/tests/manager_inference.rs
+++ b/crates/trusty-mpm/tests/manager_inference.rs
@@ -37,6 +37,9 @@ use trusty_mpm::project::Project;
 use trusty_mpm::runtime::RuntimeKind;
 use trusty_mpm::session_manager::ManagedSessionId;
 
+// #6671: the project registry seeds from the config file under `$HOME`.
+mod common;
+
 /// Serve the real router on an ephemeral loopback port; return its base URL.
 async fn serve(state: Arc<DaemonState>) -> String {
     let router = api::router(state);
@@ -48,6 +51,7 @@ async fn serve(state: Arc<DaemonState>) -> String {
 
 /// A fresh, hermetic daemon state under a temp framework root.
 async fn fresh_state() -> Arc<DaemonState> {
+    common::scratch_home(); // #6671
     let root = tempfile::tempdir().unwrap().keep();
     Arc::new(DaemonState::with_root_isolated_managed(root).await)
 }

--- a/crates/trusty-mpm/tests/manager_routes.rs
+++ b/crates/trusty-mpm/tests/manager_routes.rs
@@ -18,6 +18,11 @@
 use std::future::IntoFuture;
 use std::sync::Arc;
 
+// #6671: `DaemonState::project_registry()` seeds from
+// `~/.trusty-tools/trusty-mpm/config.yaml`, so an isolated framework root is not
+// enough — this target must own its `$HOME` too.
+mod common;
+
 use trusty_mpm::daemon::{api, state::DaemonState};
 use trusty_mpm::deliverable::{
     Deliverable, DeliverableId, DeliverableKind, DeliverableStatus, EstimationTier,
@@ -25,6 +30,17 @@ use trusty_mpm::deliverable::{
 use trusty_mpm::project::Project;
 use trusty_mpm::runtime::RuntimeKind;
 use trusty_mpm::session_manager::ManagedSessionId;
+
+/// A daemon state on a scratch framework root AND a scratch `$HOME` (#6671).
+///
+/// Why both: `with_root_isolated_managed` isolates the framework root, but the
+/// registry additionally seeds itself from the config file under `$HOME`, so a
+/// root-only fixture still reports the developer's registered projects.
+async fn isolated_state() -> Arc<DaemonState> {
+    common::scratch_home();
+    let root = tempfile::tempdir().unwrap().keep();
+    Arc::new(DaemonState::with_root_isolated_managed(root).await)
+}
 
 /// Serve the real router on an ephemeral loopback port; return its base URL.
 async fn serve(state: Arc<DaemonState>) -> String {
@@ -109,8 +125,7 @@ async fn seed_deliverable(state: &Arc<DaemonState>, project_name: &str, status: 
 /// in a default build with no `manager-memory` feature, per the §4 degrade bar).
 #[tokio::test]
 async fn manager_version_route_reports_capabilities() {
-    let root = tempfile::tempdir().unwrap().keep();
-    let state = Arc::new(DaemonState::with_root_isolated_managed(root).await);
+    let state = isolated_state().await;
     let base = serve(Arc::clone(&state)).await;
 
     let resp = reqwest::Client::new()
@@ -180,8 +195,7 @@ async fn manager_version_route_reports_capabilities() {
 /// name — the thing L2 cannot do, with no LLM call.
 #[tokio::test]
 async fn manager_status_route_rolls_up_all_projects() {
-    let root = tempfile::tempdir().unwrap().keep();
-    let state = Arc::new(DaemonState::with_root_isolated_managed(root).await);
+    let state = isolated_state().await;
 
     let beta_url = "https://github.com/acme/beta";
     let alpha_url = "https://github.com/acme/alpha";
@@ -231,8 +245,7 @@ async fn manager_status_route_rolls_up_all_projects() {
 /// is registered.
 #[tokio::test]
 async fn manager_status_route_empty_portfolio() {
-    let root = tempfile::tempdir().unwrap().keep();
-    let state = Arc::new(DaemonState::with_root_isolated_managed(root).await);
+    let state = isolated_state().await;
     let base = serve(Arc::clone(&state)).await;
 
     let resp = reqwest::Client::new()

--- a/crates/trusty-mpm/tests/mcp_spawn_gate.rs
+++ b/crates/trusty-mpm/tests/mcp_spawn_gate.rs
@@ -24,6 +24,11 @@ use trusty_mpm::daemon::managed_routes::{SpawnParams, spawn_managed};
 use trusty_mpm::daemon::state::DaemonState;
 use trusty_mpm::project::Project;
 
+// #6671: `spawn_managed` reaches `DaemonState::project_registry()`, which seeds
+// from the config file under `$HOME`, so an isolated framework root alone still
+// admits the developer's registered projects.
+mod common;
+
 /// Env var the daemon reads to force-enable MCP spawning (mirrors
 /// `daemon::managed_routes::mcp_spawn_gate::ALLOW_MCP_SPAWN_ENV`, duplicated
 /// here as a literal so this test file has no dependency on that private
@@ -100,6 +105,7 @@ fn base_params(repo_url: &str, mcp_initiated: bool) -> SpawnParams {
 async fn mcp_initiated_spawn_rejected_by_default_creates_nothing() {
     let _env = EnvGuard::unset();
 
+    common::scratch_home(); // #6671
     let root = TempDir::new().expect("root tempdir");
     let state = std::sync::Arc::new(
         DaemonState::with_root_isolated_managed(root.path().to_path_buf()).await,
@@ -136,6 +142,7 @@ async fn mcp_initiated_spawn_rejected_by_default_creates_nothing() {
 async fn mcp_initiated_spawn_rejected_for_unregistered_repo_when_enabled() {
     let _env = EnvGuard::set("1");
 
+    common::scratch_home(); // #6671
     let root = TempDir::new().expect("root tempdir");
     let state = std::sync::Arc::new(
         DaemonState::with_root_isolated_managed(root.path().to_path_buf()).await,
@@ -177,6 +184,7 @@ async fn mcp_initiated_spawn_rejected_for_unregistered_repo_when_enabled() {
 async fn mcp_initiated_spawn_rejects_repo_name_impersonation() {
     let _env = EnvGuard::set("1");
 
+    common::scratch_home(); // #6671
     let root = TempDir::new().expect("root tempdir");
     let state = std::sync::Arc::new(
         DaemonState::with_root_isolated_managed(root.path().to_path_buf()).await,
@@ -235,6 +243,7 @@ async fn mcp_initiated_spawn_rejects_repo_name_impersonation() {
 async fn mcp_initiated_spawn_allowed_for_registered_project_reaches_provisioning() {
     let _env = EnvGuard::set("1");
 
+    common::scratch_home(); // #6671
     let root = TempDir::new().expect("root tempdir");
     let state = std::sync::Arc::new(
         DaemonState::with_root_isolated_managed(root.path().to_path_buf()).await,
@@ -297,6 +306,7 @@ async fn mcp_initiated_spawn_allowed_for_registered_project_reaches_provisioning
 async fn cli_origin_spawn_bypasses_mcp_gate_even_when_disabled() {
     let _env = EnvGuard::unset();
 
+    common::scratch_home(); // #6671
     let root = TempDir::new().expect("root tempdir");
     let state = std::sync::Arc::new(
         DaemonState::with_root_isolated_managed(root.path().to_path_buf()).await,

--- a/crates/trusty-mpm/tests/project_registry_routes.rs
+++ b/crates/trusty-mpm/tests/project_registry_routes.rs
@@ -30,11 +30,16 @@ use trusty_mpm::daemon::{api, state::DaemonState};
 use trusty_mpm::deliverable::{DeliverableKind, DeliverableStatus, EstimationTier};
 use trusty_mpm::project::Project;
 
+// #6671: the project registry seeds from the config file under `$HOME`, so this
+// target must own its `$HOME` as well as its framework root.
+mod common;
+
 /// Bind the real router on an ephemeral loopback port; return a client plus the
 /// backing [`DaemonState`] (some tests need to seed the store directly, bypassing
 /// HTTP, to set up state the HTTP request body cannot express — e.g. the
 /// per-project `github`/commit identity binding, #2184).
 async fn serve_with_state() -> (DaemonClient, Arc<DaemonState>) {
+    common::scratch_home(); // #6671
     let root = tempfile::tempdir().unwrap().keep();
     let state = Arc::new(DaemonState::with_root_isolated_managed(root).await);
     let router = api::router(Arc::clone(&state));
@@ -54,6 +59,7 @@ async fn serve() -> DaemonClient {
 /// must send a raw wire body the typed [`DaemonClient`] methods cannot
 /// express — `DaemonClient`'s `base` field is crate-private).
 async fn serve_with_base() -> (DaemonClient, String) {
+    common::scratch_home(); // #6671
     let root = tempfile::tempdir().unwrap().keep();
     let state = Arc::new(DaemonState::with_root_isolated_managed(root).await);
     let router = api::router(Arc::clone(&state));


### PR DESCRIPTION
## Outcome
Refs #6671, #6663, #6667, #6661. Four flake classes stabilized at their causes:
- #6671: five trusty-mpm integration targets (`manager_routes`, `project_registry_routes`, `manager_cli_client`, `manager_inference`, `mcp_spawn_gate`) read the developer's real project registry because `TrustyToolsConfig::load()` resolves through `$HOME`; a shared `tests/common/mod.rs` now redirects `$HOME` once per process. The same cause hid behind four `daemon::rpc::registry` lib tests, fixed at the fixture (`hermetic_isolated_home`).
- #6663: the orphan-GC canary was planted under an ambient `$HOME` that sibling tests redirect; `git_owner_repo` and `evaluate_agent_cost` tests replaced hard timing with bounded condition waits.
- #6667: the readiness gate proved a listener existed, not that a hardened dial gets a frame through; gates now wait for `memory.health` to answer, and the harness redials only on `Dial`/`Write` errors (nothing reached the peer), bounded at 20 s.
- #6661: ephemeral-port reuse and two different mutexes guarding `TRUSTY_DATA_DIR_OVERRIDE`; one lock now.

## Changes
Test harnesses and fixtures in trusty-mpm, trusty-memory, trusty-console; production files touched only for inline `#[cfg(test)]` modules. Changelog fragments for trusty-mpm and trusty-console. Version bumps required by the version-bump check: trusty-mpm 1.5.17, trusty-console 0.10.1, trusty-memory 0.25.7.

## Risk
Low (rung 2, test-only stabilization). No production behavior change.

## Tests
`cargo fmt --check`; `cargo clippy --all-targets -- -D warnings` for the three crates; `cargo test --no-fail-fast`: trusty-mpm 54 targets ok (lib 5862 passed), trusty-memory 31 targets ok (lib 852), trusty-console 6 targets ok (lib 378). Each affected target re-run 10× with no failure. Pre-fix evidence on this machine: `manager_status_route_empty_portfolio` asserted `left: Number(22), right: 0`. Doc gates: check_test_pointers (0 dangling), check_line_cap (0 violations), check_changelog_fragment OK. `PR_VERSION_BUMP_BASE=origin/main scripts/check-pr-version-bump.sh` clear.

## Baseline
None remaining after the fixture fix; the earlier lib-run green was invalidated by a `$HOME` leak the critic caught and is superseded by the final run above.

## Docs
Changelog fragments only.

## Review
code-critic WARN on 7acb5e37e: HIGH, the orphan-GC test set `$HOME` without the crate's HomeGuard/`#[serial]` pattern. Fixed in 2b4f3f474, which also surfaced and fixed the four registry lib tests. Noted for a follow-on, not filed: `trusty_common::uds::connect_hardened` can return a stream whose first write finds no peer; the fix here is confined to test harnesses.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
