### PR TITLE
fix(trusty-mpm): per-project gh binding drops the inherited token; pm_guard refuses commands it cannot classify

### DIFF
--- a/crates/trusty-mpm/changelog.d/6668-6660-gh-token-pm-guard-wrappers.md
+++ b/crates/trusty-mpm/changelog.d/6668-6660-gh-token-pm-guard-wrappers.md
@@ -9,12 +9,22 @@ Fixed
   `GITHUB_ENTERPRISE_TOKEN`, `GH_USER` and — under a `token_env` binding —
   `GH_CONFIG_DIR` from the child, keeping only what the binding itself sets.
   The removal applies ONLY when a binding resolves an identity: an unbound
-  call, and a binding that sets only `host`, still inherit the ambient
-  environment unchanged (#6668).
+  call, and a binding that sets only `host` or the informational `GH_USER`,
+  still inherit the ambient environment unchanged (#6668).
+- The env file every managed Claude Code / tmux session sources now carries
+  `unset` lines ahead of its exports, so a daemon started from a shell that
+  exports another account's `GH_TOKEN` no longer hands that token to the
+  spawned session for its whole lifetime. Which vars are cleared comes from
+  the same resolver the `gh` subprocess path uses (#6668).
 - `pm_guard` classifies the command inside a `sh -c` / `bash -c` / `zsh -c` /
   `env -S` / `xargs` wrapper instead of the wrapper itself. The worktree-remove
   deny, the main-checkout HEAD-move rule and the destructive-delete rule all
   read their segments from one splitter, which now also emits the wrapped
-  command; nested wrappers and quoting are followed up to eight layers. A
-  wrapper whose inner command cannot be lexed is denied rather than allowed
+  command; nested wrappers and quoting are followed up to eight layers.
+  `pm_guard` refuses outright, ahead of every Bash rule and ahead of the
+  subagent exemption, when it cannot establish what a command would run: a
+  wrapper whose inner command will not lex, `$'…'`/`$"…"` quoting the lexer
+  cannot decode (`sh -c $'git worktree remove x'` used to read as `$git` and
+  match no rule), or nesting past the descent budget. Each of the three was a
+  live bypass of the #5791 worktree-remove deny from a real subagent dispatch
   (#6660).

--- a/crates/trusty-mpm/changelog.d/6668-6660-gh-token-pm-guard-wrappers.md
+++ b/crates/trusty-mpm/changelog.d/6668-6660-gh-token-pm-guard-wrappers.md
@@ -1,0 +1,20 @@
+Fixed
+
+- A per-project `github.config_dir` binding now wins over the shell's own
+  `GH_TOKEN`. `gh` reads an environment token ahead of `GH_CONFIG_DIR`, so a
+  `tm` run from a shell exporting another account's token authenticated as that
+  account and `tm session prune-worktrees --merged-prs` reported "Could not
+  resolve to a Repository" for every repo that token could not see. A resolved
+  binding now removes `GH_TOKEN`, `GITHUB_TOKEN`, `GH_ENTERPRISE_TOKEN`,
+  `GITHUB_ENTERPRISE_TOKEN`, `GH_USER` and — under a `token_env` binding —
+  `GH_CONFIG_DIR` from the child, keeping only what the binding itself sets.
+  The removal applies ONLY when a binding resolves an identity: an unbound
+  call, and a binding that sets only `host`, still inherit the ambient
+  environment unchanged (#6668).
+- `pm_guard` classifies the command inside a `sh -c` / `bash -c` / `zsh -c` /
+  `env -S` / `xargs` wrapper instead of the wrapper itself. The worktree-remove
+  deny, the main-checkout HEAD-move rule and the destructive-delete rule all
+  read their segments from one splitter, which now also emits the wrapped
+  command; nested wrappers and quoting are followed up to eight layers. A
+  wrapper whose inner command cannot be lexed is denied rather than allowed
+  (#6660).

--- a/crates/trusty-mpm/src/bin/tm/commands/hook_rewrite.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/hook_rewrite.rs
@@ -363,7 +363,7 @@ pub(crate) fn first_command_token(command: &str) -> Option<&str> {
 /// an env assignment" rule has one definition.
 /// What: `KEY` must be non-empty, start with a letter or underscore, and
 /// contain only alphanumerics/underscores up to the first `=`.
-fn is_env_assignment(token: &str) -> bool {
+pub(crate) fn is_env_assignment(token: &str) -> bool {
     let Some((key, _value)) = token.split_once('=') else {
         return false;
     };

--- a/crates/trusty-mpm/src/bin/tm/commands/issue/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/issue/mod.rs
@@ -44,9 +44,7 @@ pub(crate) fn issue(cmd: IssueCmd, system: TicketSystemKind) -> anyhow::Result<(
     // verb makes (empty binding → ambient gh identity, no regression).
     let gh_env = crate::gh_identity::load_gh_env()?;
     let backend = match system {
-        TicketSystemKind::Gh => {
-            GhTicketSystem::new(RealCommandRunner::with_env(gh_env.vars().to_vec()))
-        }
+        TicketSystemKind::Gh => GhTicketSystem::new(RealCommandRunner::with_gh_env(&gh_env)),
         TicketSystemKind::Jira => return Err(not_yet_supported("jira")),
         TicketSystemKind::Linear => return Err(not_yet_supported("linear")),
     };

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard.rs
@@ -213,6 +213,7 @@ use crate::commands::pm_guard_bash::{
     evaluate_main_checkout_commit_command, evaluate_main_checkout_destructive_command,
     evaluate_removal_rechecks, evaluate_worktree_add_command, evaluate_worktree_remove_command,
     extract_shell_edit_target, head_move_deny_reason, main_checkout_head_move,
+    unclassifiable_command,
 };
 use crate::commands::pm_guard_budget::{self, BudgetDecision, DEFAULT_FILE_CHANGE_BUDGET};
 use crate::commands::pm_guard_cost;
@@ -396,6 +397,20 @@ pub(crate) async fn pm_guard(url: &str) -> anyhow::Result<()> {
             .and_then(|v| v.get("command"))
             .and_then(|v| v.as_str())
             .unwrap_or_default();
+        // ABSOLUTE guard (#6660) — FIRST, ahead of every Bash rule below and
+        // ahead of Guard 4's subagent short-circuit, because it answers a
+        // question those rules all presuppose: can the guard establish what
+        // this command would run at all? Each rule below reads the command
+        // through the shared segment splitter and skips what it cannot lex, so
+        // a wrapper with unbalanced quoting, `$'…'` quoting the lexer mangles,
+        // or nesting past the descent budget silently satisfied every one of
+        // them. Placing the refusal here rather than inside each rule is what
+        // keeps a rule added later from inheriting the same hole.
+        if let Some(reason) = unclassifiable_command(command) {
+            audit_denied_tool(url, session_id, tool_name, reason).await;
+            println!("{}", build_pretooluse_deny_response(reason));
+            return Ok(());
+        }
         if let Some(reason) = evaluate_worktree_add_command(command, &hook_cwd) {
             audit_denied_tool(url, session_id, tool_name, reason).await;
             println!("{}", build_pretooluse_deny_response(reason));

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/mod.rs
@@ -82,6 +82,20 @@ pub(crate) const BUILD_TEST_REASON: &str = "PM must not run builds or tests dire
 pub(crate) const NETWORK_REASON: &str = "PM must not fetch over the network from Bash \
      (prohibition P-network). Use WebFetch/WebSearch or delegate the task.";
 
+/// Deny reason for a wrapper whose inner command cannot be lexed (#6660).
+pub(crate) const UNLEXABLE_WRAPPER_REASON: &str = "this command's `sh -c`/`bash -c`/`env -S`/\
+     `xargs` wrapper carries an inner command with unbalanced quoting, so the guard cannot \
+     classify what would actually run. Run the command without the wrapper, or fix the quoting.";
+
+/// How many wrapper layers [`split_shell_segments`] descends through (#6660).
+///
+/// Why: `sh -c "bash -c '…'"` is a real shape, and an adversarial one nests
+/// without bound. Each layer is strictly shorter than the one above it, so the
+/// recursion terminates on its own — the cap turns a pathological input into a
+/// bounded (and still safe-direction) partial scan rather than trusting that.
+/// What: the budget threaded through [`expand_shell_segments`].
+const MAX_WRAPPER_DEPTH: usize = 8;
+
 /// Maximum command-substitution recursion depth before conservatively denying.
 ///
 /// Why: [`classify_command_substitutions`] recurses through
@@ -128,7 +142,7 @@ fn evaluate_bash_command_inner(command: &str, depth: usize) -> Option<&'static s
         return None;
     }
     for segment in split_shell_segments(trimmed) {
-        if let Some(reason) = classify_bash_segment(segment, depth) {
+        if let Some(reason) = classify_bash_segment(&segment, depth) {
             return Some(reason);
         }
     }
@@ -162,7 +176,51 @@ fn evaluate_bash_command_inner(command: &str, depth: usize) -> Option<&'static s
 /// `split_shell_segments_splits_bare_ampersand`,
 /// `split_shell_segments_single_command`,
 /// `split_shell_segments_ignores_quoted_operators`.
-fn split_shell_segments(command: &str) -> Vec<&str> {
+///
+/// #6660: the returned list also carries the commands hidden inside a leading
+/// `sh -c` / `bash -c` / `env -S` / `xargs` wrapper — see
+/// [`expand_shell_segments`]. Every rule in this module reads its segments from
+/// here, which is what makes one descent reach all of them.
+fn split_shell_segments(command: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    expand_shell_segments(command, 0, &mut out);
+    out
+}
+
+/// Emit each of `command`'s segments, followed by the segments of whatever a
+/// leading command wrapper would run (#6660).
+///
+/// Why: `sh -c "git worktree remove …"` reached every rule as a segment whose
+/// program is `sh`, and no rule has an opinion about `sh`. Emitting the inner
+/// command as ADDITIONAL segments is additive by construction: every segment
+/// the caller saw before is still present, byte-identical and in the same
+/// order, so no existing classification changes and the wrapped command is now
+/// classified too.
+///
+/// The `cd`-tracking rules read these segments in order, so a `cd` inside a
+/// wrapped string leaks into the segments that follow the wrapper — a subshell
+/// `cd` does not really leak. That over-resolves a later relative path against
+/// the subshell's directory, which is the over-blocking direction this guard
+/// already prefers everywhere else.
+/// What: recurses through [`shell_lex::wrapped_command`] up to
+/// [`MAX_WRAPPER_DEPTH`] layers. An [`shell_lex::WrappedCommand::Unlexable`]
+/// wrapper contributes no inner segments; [`classify_bash_segment`] denies it
+/// instead.
+/// Test: `wrappers_do_not_hide_the_inner_command_from_the_git_verb_rules`.
+fn expand_shell_segments(command: &str, depth: usize, out: &mut Vec<String>) {
+    for raw in split_shell_segments_raw(command) {
+        out.push(raw.to_string());
+        if depth >= MAX_WRAPPER_DEPTH {
+            continue;
+        }
+        if let shell_lex::WrappedCommand::Inner(inner) = shell_lex::wrapped_command(raw.trim()) {
+            expand_shell_segments(&inner, depth + 1, out);
+        }
+    }
+}
+
+/// The composition-operator split itself, without the #6660 wrapper descent.
+fn split_shell_segments_raw(command: &str) -> Vec<&str> {
     let scan = QuoteScan::new(command);
     let quoted = |i: usize| scan.balanced && !scan.is_unquoted(i);
     let bytes = command.as_bytes();
@@ -230,6 +288,11 @@ fn classify_bash_segment(segment: &str, depth: usize) -> Option<&'static str> {
     let trimmed = segment.trim();
     if trimmed.is_empty() {
         return None;
+    }
+    // #6660: a wrapper whose inner command will not lex is a command the guard
+    // cannot classify at all — fail closed, or broken quoting is the bypass.
+    if shell_lex::wrapped_command(trimmed) == shell_lex::WrappedCommand::Unlexable {
+        return Some(UNLEXABLE_WRAPPER_REASON);
     }
     if let Some(program) = first_command_token(trimmed) {
         match program {

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/mod.rs
@@ -87,14 +87,82 @@ pub(crate) const UNLEXABLE_WRAPPER_REASON: &str = "this command's `sh -c`/`bash 
      `xargs` wrapper carries an inner command with unbalanced quoting, so the guard cannot \
      classify what would actually run. Run the command without the wrapper, or fix the quoting.";
 
-/// How many wrapper layers [`split_shell_segments`] descends through (#6660).
+/// Deny reason for `$'…'`/`$"…"` quoting the guard cannot decode (#6660 review).
+pub(crate) const ANSI_C_QUOTING_REASON: &str = "this command uses `$'…'`/`$\"…\"` quoting, which \
+     the guard's lexer cannot decode — it cannot establish which program would actually run \
+     (`sh -c $'git worktree remove x'` reads as `$git`, matching no rule). Rewrite the command \
+     with ordinary `'…'` or `\"…\"` quoting.";
+
+/// Deny reason for a wrapper nested past [`MAX_WRAPPER_DEPTH`] (#6660 review).
+pub(crate) const WRAPPER_DEPTH_REASON: &str = "this command nests `sh -c`/`bash -c`/`xargs` \
+     wrappers deeper than the guard will follow, so it cannot classify what would actually run. \
+     Run the command without the nesting.";
+
+/// How many wrapper layers the guard descends through (#6660).
 ///
 /// Why: `sh -c "bash -c '…'"` is a real shape, and an adversarial one nests
-/// without bound. Each layer is strictly shorter than the one above it, so the
-/// recursion terminates on its own — the cap turns a pathological input into a
-/// bounded (and still safe-direction) partial scan rather than trusting that.
-/// What: the budget threaded through [`expand_shell_segments`].
+/// without bound. The cap bounds the recursion; exhausting it DENIES rather
+/// than falling through, matching [`MAX_SUBSTITUTION_DEPTH`] — the first cut
+/// stopped recursing instead, which made a 9-layer wrapper an allow while an
+/// 8-layer one denied.
+/// What: the budget threaded through [`unclassifiable_command`] and
+/// [`expand_shell_segments`].
 const MAX_WRAPPER_DEPTH: usize = 8;
+
+/// Whether the guard is unable to establish what `command` would run (#6660).
+///
+/// Why: the three ABSOLUTE guards a dispatched subagent actually hits —
+/// `evaluate_worktree_remove_command`, the main-checkout destructive/commit/
+/// HEAD-move rules, and `evaluate_destructive_delete_command` — are reached
+/// from `pm_guard` BEFORE `payload_is_subagent_dispatch` short-circuits, and
+/// none of them routes through [`evaluate_bash_command`]. A fail-closed check
+/// that lived only in [`classify_bash_segment`] was therefore unreachable for
+/// exactly the caller #5791/#6660 exist to bind: `sh -c "git worktree remove
+/// 'unterminated"` from a subagent was allowed. Making this ONE function the
+/// answer, called from `pm_guard`'s ABSOLUTE band ahead of every Bash rule,
+/// is what stops a future rule from inheriting the same hole.
+/// What: `Some(reason)` when any segment, at any wrapper depth, carries
+/// `$'…'`/`$"…"` quoting the lexer mangles ([`shell_lex::has_live_ansi_c_quoting`]),
+/// a wrapper whose inner command will not lex
+/// ([`shell_lex::WrappedCommand::Unlexable`]), or a wrapper nested past
+/// [`MAX_WRAPPER_DEPTH`]. `None` — the ordinary case — leaves every rule to
+/// classify the command as before.
+/// Test: `unclassifiable_command_flags_ansi_c_quoting`,
+/// `unclassifiable_command_flags_an_unlexable_wrapper`,
+/// `unclassifiable_command_denies_past_the_depth_cap`,
+/// `unclassifiable_command_allows_ordinary_commands`, and end to end in
+/// `tests/tm_hook_pm_guard.rs`.
+pub(crate) fn unclassifiable_command(command: &str) -> Option<&'static str> {
+    unclassifiable_at(command, 0)
+}
+
+/// Depth-aware core of [`unclassifiable_command`].
+fn unclassifiable_at(command: &str, depth: usize) -> Option<&'static str> {
+    for raw in split_shell_segments_raw(command) {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if shell_lex::has_live_ansi_c_quoting(trimmed) {
+            return Some(ANSI_C_QUOTING_REASON);
+        }
+        match shell_lex::wrapped_command(trimmed) {
+            shell_lex::WrappedCommand::Unlexable => return Some(UNLEXABLE_WRAPPER_REASON),
+            shell_lex::WrappedCommand::Inner(inner) => {
+                // A wrapper AT the cap is refused, not skipped: the guard has
+                // run out of budget to see what it hides.
+                if depth >= MAX_WRAPPER_DEPTH {
+                    return Some(WRAPPER_DEPTH_REASON);
+                }
+                if let Some(reason) = unclassifiable_at(&inner, depth + 1) {
+                    return Some(reason);
+                }
+            }
+            shell_lex::WrappedCommand::None => {}
+        }
+    }
+    None
+}
 
 /// Maximum command-substitution recursion depth before conservatively denying.
 ///
@@ -140,6 +208,12 @@ fn evaluate_bash_command_inner(command: &str, depth: usize) -> Option<&'static s
     let trimmed = command.trim();
     if trimmed.is_empty() {
         return None;
+    }
+    // #6660: refuse before classifying — a command the guard cannot lex is a
+    // command it cannot clear. The same check runs in `pm_guard`'s ABSOLUTE
+    // band for the callers that never reach here.
+    if let Some(reason) = unclassifiable_command(trimmed) {
+        return Some(reason);
     }
     for segment in split_shell_segments(trimmed) {
         if let Some(reason) = classify_bash_segment(&segment, depth) {
@@ -288,11 +362,6 @@ fn classify_bash_segment(segment: &str, depth: usize) -> Option<&'static str> {
     let trimmed = segment.trim();
     if trimmed.is_empty() {
         return None;
-    }
-    // #6660: a wrapper whose inner command will not lex is a command the guard
-    // cannot classify at all — fail closed, or broken quoting is the bypass.
-    if shell_lex::wrapped_command(trimmed) == shell_lex::WrappedCommand::Unlexable {
-        return Some(UNLEXABLE_WRAPPER_REASON);
     }
     if let Some(program) = first_command_token(trimmed) {
         match program {

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/persistence.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/persistence.rs
@@ -339,7 +339,7 @@ pub(crate) fn command_is_persistence_only(command: &str) -> bool {
             continue;
         }
         saw_one = true;
-        if !segment_is_persistence(segment) {
+        if !segment_is_persistence(&segment) {
             return false;
         }
     }

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/shell_lex.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/shell_lex.rs
@@ -19,7 +19,224 @@
 //! leading env/`sudo` noise and git global options.
 //! Test: `shell_lex::tests`.
 
-use crate::commands::hook_rewrite::strip_wrapper_prefix;
+use crate::commands::hook_rewrite::{COMMAND_WRAPPERS, is_env_assignment, strip_wrapper_prefix};
+
+/// Shell programs that run their `-c` argument as a command string.
+///
+/// Why (#6660): the guard resolved a segment's program basename and required it
+/// to be `git`. `sh -c "git worktree remove …"` resolves to `sh`, so every rule
+/// built on [`git_subcommand`] — the #5791 worktree-remove deny, the ADR-0048
+/// main-checkout HEAD-move rule, the destructive-delete rule — saw a program it
+/// had no opinion about and allowed the command underneath. Naming the shells
+/// in one list is what stops the fix from covering a single spelling.
+/// What: the basenames whose `-c` argument is an inner command to re-classify.
+/// Test: `wrappers_do_not_hide_the_inner_command_from_the_git_verb_rules`.
+const DASH_C_SHELLS: &[&str] = &["sh", "bash", "zsh", "dash", "ksh", "ash"];
+
+/// `xargs` options that consume the FOLLOWING token as their value.
+///
+/// Why: skipping only the flag would leave its value (`4` in `xargs -n 4 git …`)
+/// read as the program. The separated spelling is the one that needs a table;
+/// an attached (`-n4`) or `=`-joined (`--max-args=4`) value is one token and
+/// skips itself.
+/// What: the separated-value option spellings, short and long.
+/// Test: `wrappers_do_not_hide_the_inner_command_from_the_git_verb_rules`.
+const XARGS_OPTS_WITH_ARG: &[&str] = &[
+    "-a",
+    "-d",
+    "-E",
+    "-e",
+    "-I",
+    "-i",
+    "-L",
+    "-l",
+    "-n",
+    "-P",
+    "-s",
+    "--arg-file",
+    "--delimiter",
+    "--eof",
+    "--replace",
+    "--max-lines",
+    "--max-args",
+    "--max-procs",
+    "--max-chars",
+    "--process-slot-var",
+];
+
+/// What a segment's leading wrapper hides, if anything (#6660).
+///
+/// Why: three answers, not two. A segment that is not a wrapper classifies
+/// as-is; a wrapper hands back the inner command text to classify instead; and
+/// a wrapper whose inner text cannot be lexed is a command the guard cannot
+/// classify AT ALL, which must deny rather than fall through — otherwise broken
+/// quoting is the bypass.
+/// What: see the variants.
+/// Test: `wrappers_do_not_hide_the_inner_command_from_the_git_verb_rules`,
+/// `an_unparseable_wrapped_command_is_denied`,
+/// `wrappers_around_benign_commands_still_allow`.
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum WrappedCommand {
+    /// No wrapper — classify the segment as given.
+    None,
+    /// The command text the wrapper would actually run.
+    Inner(String),
+    /// A wrapper carrying an inner command the guard cannot lex. Fail closed.
+    Unlexable,
+}
+
+/// Resolve the command a leading `sh -c` / `bash -c` / `env -S` / `xargs`
+/// wrapper would actually run (#6660).
+///
+/// Why: [`strip_wrapper_prefix`] advances past a wrapper TOKEN but never
+/// descends into an argument that is itself a command — a `-c` string or an
+/// `xargs` argv. Every rule downstream therefore classified the wrapper instead
+/// of the command. Doing the descent here, on the shared segment text, is what
+/// makes one fix reach all of them.
+/// What: shlex-splits `segment`, skips leading `KEY=value` assignments and
+/// [`COMMAND_WRAPPERS`] tokens, then: a [`DASH_C_SHELLS`] program yields the
+/// token after its `-c` (a short cluster ending in `c`, such as `-lc`, counts);
+/// `env` yields the value of `-S`/`--split-string` in any of its three
+/// spellings; `xargs` yields its argv past [`XARGS_OPTS_WITH_ARG`], re-joined.
+/// The result is [`WrappedCommand::Unlexable`] when the inner text will not
+/// shlex-split, and [`WrappedCommand::None`] when the segment carries no such
+/// wrapper — an unlexable OUTER segment included, since that case already falls
+/// back to the quote-unaware scan and is not this function's to change.
+/// Test: as [`WrappedCommand`].
+pub(super) fn wrapped_command(segment: &str) -> WrappedCommand {
+    let Some(argv) = shlex::split(segment) else {
+        return WrappedCommand::None;
+    };
+    let mut i = 0;
+    while i < argv.len() {
+        let raw = argv[i].as_str();
+        let tok = raw.strip_prefix('\\').unwrap_or(raw);
+        if is_env_assignment(tok) {
+            i += 1;
+            continue;
+        }
+        let base = tok.rsplit('/').next().unwrap_or(tok);
+        let rest = &argv[i + 1..];
+        if DASH_C_SHELLS.contains(&base) {
+            return inner_or_none(dash_c_argument(rest));
+        }
+        if base == "env" {
+            match env_split_string(rest) {
+                Some(inner) => return inner_or_none(Some(inner)),
+                // Plain `env` / `env FOO=1 cmd` — keep walking to the real
+                // program, exactly as `strip_wrapper_prefix` would.
+                None => {
+                    i += 1;
+                    continue;
+                }
+            }
+        }
+        if base == "xargs" {
+            return inner_or_none(xargs_argument(rest));
+        }
+        if COMMAND_WRAPPERS.contains(&tok) {
+            i += 1;
+            continue;
+        }
+        return WrappedCommand::None;
+    }
+    WrappedCommand::None
+}
+
+/// Classify an extracted inner command string.
+///
+/// Why: the fail-closed decision lives in ONE place so no wrapper shape can
+/// forget it.
+/// What: lexable → [`WrappedCommand::Inner`], not → [`WrappedCommand::Unlexable`],
+/// absent or whitespace-only (it runs nothing) → [`WrappedCommand::None`].
+/// Test: `an_unparseable_wrapped_command_is_denied`.
+fn inner_or_none(inner: Option<String>) -> WrappedCommand {
+    let Some(inner) = inner else {
+        return WrappedCommand::None;
+    };
+    if inner.trim().is_empty() {
+        return WrappedCommand::None;
+    }
+    match shlex::split(&inner) {
+        Some(_) => WrappedCommand::Inner(inner),
+        None => WrappedCommand::Unlexable,
+    }
+}
+
+/// The command string a shell's `-c` option carries, if present.
+///
+/// Why: shells accept their options in any order and in clusters, so scanning
+/// for the exact token `-c` alone would miss `bash -lc "…"`, a spelling a
+/// wrapper script reaches for routinely.
+/// What: the token after the first `-c`, or after the first short cluster
+/// (`-`-led, not `--`-led) ending in `c`. `None` when the shell runs a script
+/// file instead, or when `-c` ends the argv.
+/// Test: `wrappers_do_not_hide_the_inner_command_from_the_git_verb_rules`.
+fn dash_c_argument(rest: &[String]) -> Option<String> {
+    for (n, tok) in rest.iter().enumerate() {
+        let cluster =
+            tok.starts_with('-') && !tok.starts_with("--") && tok.len() > 1 && tok.ends_with('c');
+        if tok == "-c" || cluster {
+            return rest.get(n + 1).cloned();
+        }
+    }
+    None
+}
+
+/// The command string `env -S` / `--split-string` carries, if present.
+///
+/// Why: `env -S "git worktree remove …"` runs the string as a command, and
+/// [`strip_wrapper_prefix`] refuses a wrapper followed by a flag — so this shape
+/// resolved to nothing at all and every rule allowed it.
+/// What: handles `-S <str>`, `-S<str>` and `--split-string=<str>`. `None` for a
+/// plain `env`, which stays an ordinary wrapper for the caller to walk past.
+/// Test: `wrappers_do_not_hide_the_inner_command_from_the_git_verb_rules`.
+fn env_split_string(rest: &[String]) -> Option<String> {
+    for (n, tok) in rest.iter().enumerate() {
+        if tok == "-S" || tok == "--split-string" {
+            return rest.get(n + 1).cloned();
+        }
+        if let Some(value) = tok.strip_prefix("--split-string=") {
+            return Some(value.to_string());
+        }
+        if let Some(value) = tok.strip_prefix("-S")
+            && !value.is_empty()
+        {
+            return Some(value.to_string());
+        }
+    }
+    None
+}
+
+/// The command `xargs` would run, re-joined into a command string.
+///
+/// Why: `xargs git worktree remove <path>` runs `git`, and reading only the
+/// first token gave `xargs`. The stdin-supplied arguments are unknowable here,
+/// but the verb and every literal argument on the command line are not — and
+/// those are what the git-verb rules classify.
+/// What: skips xargs' own options (those in [`XARGS_OPTS_WITH_ARG`] consume the
+/// next token; attached and `=`-joined values consume none) and re-quotes the
+/// remaining argv with `shlex::try_join`. `None` when nothing follows the
+/// options, or when a token cannot be re-quoted (it contains a NUL).
+/// Test: `wrappers_do_not_hide_the_inner_command_from_the_git_verb_rules`.
+fn xargs_argument(rest: &[String]) -> Option<String> {
+    let mut i = 0;
+    while i < rest.len() {
+        let tok = rest[i].as_str();
+        if !tok.starts_with('-') || tok == "-" {
+            break;
+        }
+        if XARGS_OPTS_WITH_ARG.contains(&tok) {
+            i += 2;
+            continue;
+        }
+        i += 1;
+    }
+    if i >= rest.len() {
+        return None;
+    }
+    shlex::try_join(rest[i..].iter().map(String::as_str)).ok()
+}
 
 /// Quote context of a single byte of a shell command.
 ///

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/shell_lex.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/shell_lex.rs
@@ -64,6 +64,35 @@ const XARGS_OPTS_WITH_ARG: &[&str] = &[
     "--process-slot-var",
 ];
 
+/// Whether `segment` contains live `$'…'` or `$"…"` quoting (#6660 review).
+///
+/// Why: `shlex` 1.3.0 does not implement bash's ANSI-C (`$'…'`) or
+/// locale-translation (`$"…"`) quoting. It drops the quotes and keeps the `$`,
+/// so `sh -c $'git worktree remove x'` tokenizes as
+/// `["sh", "-c", "$git worktree remove x"]` and the program token becomes
+/// `$git`, which matches no rule. That is a one-character bypass of every
+/// git-verb rule, wrapper or not — `git $'worktree' remove x` mangles the same
+/// way with no wrapper at all. Since the guard cannot decode the escapes, the
+/// only correct answer is to refuse to classify the segment.
+/// What: true when a `$` immediately followed by `'` or `"` appears OUTSIDE any
+/// quoted span. An unbalanced-quote segment has an untrustworthy
+/// [`QuoteScan`] map, so every such `$` reads as live — the conservative
+/// direction. A `$'` that is itself quoted (`echo "cost: $'5'"`) is literal
+/// text and is not flagged; when it sits inside a wrapper's `-c` string the
+/// caller re-scans that string on its own, where it IS live.
+/// Test: `unclassifiable_command_flags_ansi_c_quoting`,
+/// `unclassifiable_command_allows_ordinary_commands`, and end to end in
+/// `pm_guard_denies_a_wrapped_command_it_cannot_classify_via_subagent_payload`.
+pub(super) fn has_live_ansi_c_quoting(segment: &str) -> bool {
+    let scan = QuoteScan::new(segment);
+    let bytes = segment.as_bytes();
+    bytes.iter().enumerate().any(|(i, b)| {
+        *b == b'$'
+            && matches!(bytes.get(i + 1), Some(b'\'') | Some(b'"'))
+            && (!scan.balanced || scan.is_unquoted(i))
+    })
+}
+
 /// What a segment's leading wrapper hides, if anything (#6660).
 ///
 /// Why: three answers, not two. A segment that is not a wrapper classifies

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/tests.rs
@@ -1456,6 +1456,135 @@ fn an_unparseable_wrapped_command_is_denied() {
     }
 }
 
+// ── #6660 review: the three shapes that reached the ABSOLUTE guards ─────────
+
+/// Why (#6660 review, CRITICAL 2): `shlex` 1.3.0 drops the quotes of `$'…'`
+/// and keeps the `$`, so `sh -c $'git worktree remove x'` lexes to a program
+/// token of `$git` and matches no rule. The critic confirmed the live bypass
+/// against the compiled binary. The guard cannot decode the escapes, so it
+/// must refuse — and the bypass needs no wrapper, which is why the bare `git`
+/// spelling is asserted too.
+/// Test: itself.
+#[test]
+fn unclassifiable_command_flags_ansi_c_quoting() {
+    for command in [
+        "sh -c $'git worktree remove /repo/.claude/worktrees/agent-x'",
+        "bash -c $'rm -rf /repo/.claude/worktrees/agent-x'",
+        "git $'worktree' remove /repo/.claude/worktrees/agent-x",
+        "env -S $'git worktree remove x'",
+        // Inside the wrapped string, where the outer quote map reads it as
+        // literal text — the recursion re-scans it where it is live.
+        "sh -c \"git $'worktree' remove /repo/.claude/worktrees/agent-x\"",
+        "$\"git\" worktree remove x",
+    ] {
+        assert_eq!(
+            unclassifiable_command(command),
+            Some(ANSI_C_QUOTING_REASON),
+            "ANSI-C quoting must be refused: {command}"
+        );
+    }
+}
+
+/// Why (#6660 review, CRITICAL 1): the fail-closed answer has to come from a
+/// function the ABSOLUTE guards' caller reaches, not only from
+/// `evaluate_bash_command`.
+/// Test: itself.
+#[test]
+fn unclassifiable_command_flags_an_unlexable_wrapper() {
+    for command in [
+        "sh -c \"git worktree remove 'unterminated\"",
+        "bash -c 'rm -rf \"unterminated'",
+        "xargs sh -c \"git worktree remove 'x\"",
+    ] {
+        assert_eq!(
+            unclassifiable_command(command),
+            Some(UNLEXABLE_WRAPPER_REASON),
+            "an unlexable wrapper must be refused: {command}"
+        );
+    }
+}
+
+/// Why (#6660 review, CRITICAL 3): the first cut STOPPED recursing at the cap
+/// instead of denying, so 8 nested layers denied and 9 allowed. Asserted at
+/// the exact boundary the critic measured.
+/// Test: itself.
+#[test]
+fn unclassifiable_command_denies_past_the_depth_cap() {
+    /// `sh -c <cmd>` wrapped `layers` deep around `inner`, shell-quoting at
+    /// each layer so every level is a legal single token (naive alternating
+    /// quotes stop nesting correctly past two levels).
+    fn nest(inner: &str, layers: usize) -> String {
+        let mut command = inner.to_string();
+        for _ in 0..layers {
+            let quoted = shlex::try_quote(&command).expect("quotable");
+            command = format!("sh -c {quoted}");
+        }
+        command
+    }
+    let inner = "git worktree remove /repo/.claude/worktrees/agent-x";
+
+    // Within budget: resolvable, so this function has no opinion — the
+    // worktree-remove rule classifies it (asserted below).
+    for layers in 1..=MAX_WRAPPER_DEPTH {
+        let command = nest(inner, layers);
+        assert_eq!(
+            unclassifiable_command(&command),
+            None,
+            "{layers} layers are within budget: {command}"
+        );
+    }
+    // Past budget: refused, not skipped.
+    for layers in [MAX_WRAPPER_DEPTH + 1, MAX_WRAPPER_DEPTH + 4] {
+        let command = nest(inner, layers);
+        assert_eq!(
+            unclassifiable_command(&command),
+            Some(WRAPPER_DEPTH_REASON),
+            "{layers} layers exhaust the budget and must be refused"
+        );
+    }
+    // And the rule that matters still denies on both sides of the boundary,
+    // through the guard entry point a subagent actually reaches.
+    let engineer = DispatchIdentity {
+        agent_id: Some("agent-abc123"),
+        agent_type: Some("rust-engineer"),
+    };
+    for layers in [MAX_WRAPPER_DEPTH, MAX_WRAPPER_DEPTH + 1] {
+        let command = nest(inner, layers);
+        let denied = unclassifiable_command(&command).is_some()
+            || matches!(
+                evaluate_worktree_remove_command(&command, true, engineer, Path::new("/repo")),
+                WorktreeRemoveVerdict::Deny(_)
+            );
+        assert!(denied, "{layers} layers must deny: {command}");
+    }
+}
+
+/// Why (#6660 review): the refusal must not swallow ordinary work — a guard
+/// that denies `bash -c 'cargo build'` is retried differently and worse
+/// (ADR-0048 decision 6).
+/// Test: itself.
+#[test]
+fn unclassifiable_command_allows_ordinary_commands() {
+    for command in [
+        "git status --porcelain",
+        "sh -c 'git status --porcelain'",
+        "bash -c \"cargo build\"",
+        "xargs git add",
+        "cargo test -p trusty-mpm && git log --oneline -5",
+        // A `$` that is not opening ANSI-C quoting stays fine.
+        "echo $HOME",
+        "git log --format='%h $ %s'",
+        // ...including a literal `$'` that is itself quoted into prose.
+        "git commit -m \"cost: $'5' per unit\"",
+    ] {
+        assert_eq!(
+            unclassifiable_command(command),
+            None,
+            "ordinary command must not be refused: {command}"
+        );
+    }
+}
+
 /// Why (#6660): the unwrapping must not turn ordinary wrapped work into a
 /// denial — a guard that denies `bash -c 'cargo build'` is retried differently
 /// and worse (ADR-0048 decision 6).

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/tests.rs
@@ -1358,3 +1358,121 @@ fn evaluate_bash_command_allows_quoted_process_substitution_prose() {
         );
     }
 }
+
+// ── #6660: wrapper spellings must not hide the inner command ────────────────
+
+/// Every wrapper spelling that runs `inner` as a real command.
+///
+/// `inner` must contain no quote characters — the nested-quoting shapes are
+/// asserted separately by each rule's own test so the quoting under test is
+/// visible at the assertion, not buried in a formatter.
+fn wrapper_spellings(inner: &str) -> Vec<String> {
+    vec![
+        format!("sh -c \"{inner}\""),
+        format!("bash -c '{inner}'"),
+        format!("zsh -c \"{inner}\""),
+        format!("/bin/sh -c \"{inner}\""),
+        format!("bash -lc \"{inner}\""),
+        format!("env -S \"{inner}\""),
+        format!("xargs {inner}"),
+        format!("xargs -0 {inner}"),
+        format!("xargs -n 4 {inner}"),
+        // A wrapper over a wrapper, and a shell over a shell.
+        format!("sudo sh -c \"{inner}\""),
+        format!("sh -c \"bash -c '{inner}'\""),
+        // Composition inside the wrapped string.
+        format!("sh -c \"true && {inner}\""),
+    ]
+}
+
+/// Why (#6660): `git_subcommand` required the resolved program basename to be
+/// `git`, and `strip_wrapper_prefix` never descended into a `-c` string or an
+/// `xargs` argv. Every rule built on that classifier — the #5791 worktree-remove
+/// deny, the ADR-0048 main-checkout HEAD-move rule, and the destructive-delete
+/// rule — therefore saw `sh`/`bash`/`zsh`/`env`/`xargs` and allowed the command
+/// underneath. One spelling handled is not a fix, so all three rules are
+/// asserted against every spelling in [`wrapper_spellings`] plus the nested
+/// quoting each rule can meet on its own.
+/// Test: itself.
+#[test]
+fn wrappers_do_not_hide_the_inner_command_from_the_git_verb_rules() {
+    const WT: &str = "/repo/.claude/worktrees/agent-x";
+    let engineer = DispatchIdentity {
+        agent_id: Some("agent-abc123"),
+        agent_type: Some("rust-engineer"),
+    };
+
+    // --- Rule 1: `git worktree remove` by a non-version-control subagent. ---
+    let mut worktree_cases = wrapper_spellings(&format!("git worktree remove {WT}"));
+    // Nested quoting: the inner command quotes its own argument.
+    worktree_cases.push(format!("bash -c \"git worktree remove '{WT}'\""));
+    worktree_cases.push(format!("sh -c 'git worktree remove \"{WT}\"'"));
+    // A `cd` inside the wrapped string still moves the resolution base.
+    worktree_cases
+        .push("sh -c \"cd /repo && git worktree remove .claude/worktrees/agent-x\"".to_string());
+    for command in &worktree_cases {
+        let verdict = evaluate_worktree_remove_command(command, true, engineer, Path::new("/repo"));
+        assert!(
+            matches!(verdict, WorktreeRemoveVerdict::Deny(_)),
+            "the #5791 worktree-remove deny must see through: {command}"
+        );
+    }
+
+    // --- Rule 2: a HEAD move inside a main checkout (ADR-0048). ------------
+    let checkout = tempfile::tempdir().expect("tempdir");
+    std::fs::create_dir(checkout.path().join(".git")).expect("mkdir .git");
+    for command in wrapper_spellings("git merge origin/main") {
+        let resolved = main_checkout_head_move(&command, checkout.path());
+        assert!(
+            resolved.is_some(),
+            "the main-checkout HEAD-move rule must see through: {command}"
+        );
+        assert_eq!(resolved.expect("resolved").0, "merge");
+    }
+
+    // --- Rule 3: destructive delete of a worktree root. --------------------
+    for command in wrapper_spellings(&format!("rm -rf {WT}")) {
+        assert!(
+            evaluate_destructive_delete_command(&command, Path::new("/repo")).is_some(),
+            "the destructive-delete rule must see through: {command}"
+        );
+    }
+}
+
+/// Why (#6660): a wrapped command whose inner string cannot be lexed is a
+/// command the guard cannot classify at all. Allowing it would make broken
+/// quoting the bypass, so the guard fails closed and denies.
+/// Test: itself.
+#[test]
+fn an_unparseable_wrapped_command_is_denied() {
+    for command in [
+        "sh -c \"git worktree remove 'unterminated\"",
+        "bash -c 'rm -rf \"unterminated'",
+    ] {
+        assert!(
+            evaluate_bash_command(command).is_some(),
+            "an unlexable wrapped command must deny: {command}"
+        );
+    }
+}
+
+/// Why (#6660): the unwrapping must not turn ordinary wrapped work into a
+/// denial — a guard that denies `bash -c 'cargo build'` is retried differently
+/// and worse (ADR-0048 decision 6).
+/// Test: itself.
+#[test]
+fn wrappers_around_benign_commands_still_allow() {
+    for command in [
+        "sh -c 'git status --porcelain'",
+        "bash -c \"git log --oneline -5\"",
+        "xargs git add",
+        "sh -c 'echo hello'",
+        "bash -c 'cargo build'",
+    ] {
+        assert_eq!(
+            evaluate_bash_command(command),
+            None,
+            "expected allow for benign wrapped command: {command}"
+        );
+    }
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/pr/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pr/mod.rs
@@ -101,6 +101,8 @@ pub(crate) trait GhRunner {
 pub(crate) struct RealGhRunner {
     /// `GH_*` overrides resolved from the active project's config.
     env: Vec<(String, String)>,
+    /// #6668: inherited identity vars removed before `env` is applied.
+    unset: Vec<String>,
 }
 
 impl RealGhRunner {
@@ -109,6 +111,8 @@ impl RealGhRunner {
         let gh_env = crate::gh_identity::load_gh_env()?;
         Ok(Self {
             env: gh_env.vars().to_vec(),
+            // #6668: an inherited GH_TOKEN outranks a resolved GH_CONFIG_DIR.
+            unset: gh_env.unset_vars().to_vec(),
         })
     }
 }
@@ -116,6 +120,10 @@ impl RealGhRunner {
 impl GhRunner for RealGhRunner {
     fn run(&self, args: &[String]) -> anyhow::Result<GhRun> {
         let mut cmd = trusty_common::gh::GhCommand::new(args);
+        // #6668: removals first, then the overrides.
+        for k in &self.unset {
+            cmd = cmd.env_remove(k);
+        }
         for (k, v) in &self.env {
             cmd = cmd.env(k, v);
         }

--- a/crates/trusty-mpm/src/bin/tm/commands/ticket/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/ticket/mod.rs
@@ -171,11 +171,9 @@ pub(crate) async fn ticket(
     // (one for the backend's issue-level calls, one for repo-level `gh repo
     // view`) each carry the SAME resolved overrides.
     let gh_env = crate::gh_identity::load_gh_env()?;
-    let runner = RealCommandRunner::with_env(gh_env.vars().to_vec());
+    let runner = RealCommandRunner::with_gh_env(&gh_env);
     let backend = match system {
-        TicketSystemKind::Gh => {
-            GhTicketSystem::new(RealCommandRunner::with_env(gh_env.vars().to_vec()))
-        }
+        TicketSystemKind::Gh => GhTicketSystem::new(RealCommandRunner::with_gh_env(&gh_env)),
         TicketSystemKind::Jira => return Err(not_yet_supported("jira")),
         TicketSystemKind::Linear => return Err(not_yet_supported("linear")),
     };

--- a/crates/trusty-mpm/src/bin/tm/commands/ticket/runner.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/ticket/runner.rs
@@ -9,7 +9,9 @@
 //! `gh_identity` module) and sets them on every spawned `Command`, so the
 //! identity is bound centrally rather than at each of `tm`'s many `gh` call
 //! sites. config_dir/token_env bind the identity WITHOUT mutating global gh
-//! state (they only set `GH_CONFIG_DIR`/`GH_TOKEN`/`GH_HOST` on the child).
+//! state: they set `GH_CONFIG_DIR`/`GH_TOKEN`/`GH_HOST` on the child, and
+//! (#6668) remove from that child every other identity var gh would otherwise
+//! read ahead of them.
 //! What: the [`CommandRunner`] trait with one `run` method returning captured
 //! stdout/stderr/exit-status, a [`CommandOutput`] value type, and the
 //! [`RealCommandRunner`] that executes via `std::process::Command` after applying
@@ -85,32 +87,40 @@ pub(crate) trait CommandRunner {
 /// `GH_TOKEN`, `GH_HOST`) are set on the spawned child only — never on the
 /// parent process — so the binding does not mutate the operator's global gh
 /// state and cannot leak across unrelated invocations.
-/// What: holds an ordered list of `(name, value)` env overrides. The unit-style
-/// `RealCommandRunner::default()` / `RealCommandRunner::new` carry NO overrides
-/// (ambient identity, pre-#1265 behaviour); [`RealCommandRunner::with_env`]
+/// What: holds an ordered list of `(name, value)` env overrides plus the #6668
+/// removal list. The unit-style `RealCommandRunner::default()` carries NEITHER
+/// (ambient identity, pre-#1265 behaviour); [`RealCommandRunner::with_gh_env`]
 /// binds a resolved set. `run` spawns the program via
-/// `std::process::Command::output` with the overrides applied, capturing both
-/// streams; an inability to spawn (e.g. binary not installed) is surfaced as an
-/// actionable `anyhow` error rather than a panic.
+/// `std::process::Command::output` with the removals applied first and the
+/// overrides second, capturing both streams; an inability to spawn (e.g. binary
+/// not installed) is surfaced as an actionable `anyhow` error rather than a
+/// panic.
 /// Test: `real_runner_applies_env_overrides` asserts the child sees the vars; the
 /// no-override default is exercised by every existing live path.
 #[derive(Debug, Clone, Default)]
 pub(crate) struct RealCommandRunner {
     /// Per-project env overrides applied to each spawned child (#1265).
     env: Vec<(String, String)>,
+    /// #6668: inherited identity vars removed from each child before `env` is
+    /// applied, so a shell-exported `GH_TOKEN` cannot outrank the binding.
+    unset: Vec<String>,
 }
 
 impl RealCommandRunner {
-    /// Construct a runner that applies `env` overrides to every spawned child.
+    /// Construct a runner bound to a resolved
+    /// [`GhEnv`](trusty_mpm::core::gh_identity::GhEnv) (#6668).
     ///
-    /// Why: the #1265 entry points resolve the active project's `GhEnv` once
-    /// and bind it here so every `gh` call in that command uses the same
-    /// identity.
-    /// What: stores the `(name, value)` pairs; `run` calls `Command::env` for
-    /// each before spawning.
+    /// Why: the constructor this replaces took only the vars to SET, which is
+    /// what let an inherited `GH_TOKEN` beat a per-project `GH_CONFIG_DIR`.
+    /// Taking the whole `GhEnv` carries the removals with it, so a call site
+    /// cannot bind half the identity.
+    /// What: stores both the overrides and the removal list.
     /// Test: `real_runner_applies_env_overrides`.
-    pub(crate) fn with_env(env: Vec<(String, String)>) -> Self {
-        Self { env }
+    pub(crate) fn with_gh_env(gh_env: &trusty_mpm::core::gh_identity::GhEnv) -> Self {
+        Self {
+            env: gh_env.vars().to_vec(),
+            unset: gh_env.unset_vars().to_vec(),
+        }
     }
 }
 
@@ -118,6 +128,10 @@ impl CommandRunner for RealCommandRunner {
     fn run(&self, program: &str, args: &[&str]) -> anyhow::Result<CommandOutput> {
         let mut cmd = std::process::Command::new(program);
         cmd.args(args);
+        // #6668: removals first, then the overrides.
+        for k in &self.unset {
+            cmd.env_remove(k);
+        }
         for (k, v) in &self.env {
             cmd.env(k, v);
         }
@@ -138,29 +152,47 @@ mod tests {
 
     /// Why: the central #1265 guarantee — env overrides bound to a
     /// [`RealCommandRunner`] are actually applied to the spawned child (and only
-    /// the child, not the parent). We prove it by running `printenv` for a var
-    /// we set via `with_env` and asserting the child echoes the value.
+    /// the child, not the parent). We prove it by running `printenv` for the
+    /// var a `config_dir` binding resolves to and asserting the child echoes
+    /// the value. #6668 adds the other half: the same binding must strip the
+    /// inherited `GH_TOKEN`, which `printenv GH_TOKEN` proves by exiting
+    /// non-zero even when this process has one.
     /// Test: itself (uses the always-present `/usr/bin/env`-style `printenv`).
     #[test]
     fn real_runner_applies_env_overrides() {
-        let runner = RealCommandRunner::with_env(vec![(
-            "TM_TEST_GH_IDENTITY_VAR".to_string(),
-            "bound-value".to_string(),
-        )]);
+        let gh_env = trusty_mpm::core::gh_identity::resolve_gh_env(Some(
+            &trusty_mpm::core::trusty_tools_config::GithubConfig {
+                config_dir: Some(std::path::PathBuf::from("/cfg/project")),
+                ..Default::default()
+            },
+        ))
+        .expect("a config_dir binding resolves");
+        let runner = RealCommandRunner::with_gh_env(&gh_env);
         // `printenv VAR` prints the value and exits 0 when set. It is present on
         // Linux and macOS; skip gracefully if the platform lacks it.
-        match runner.run("printenv", &["TM_TEST_GH_IDENTITY_VAR"]) {
+        match runner.run("printenv", &["GH_CONFIG_DIR"]) {
             Ok(out) => {
                 assert!(out.success, "printenv failed: {}", out.stderr);
-                assert_eq!(out.stdout.trim(), "bound-value");
+                assert_eq!(out.stdout.trim(), "/cfg/project");
             }
             Err(_) => {
                 // `printenv` not available — the env-application path is still
                 // covered by the gh_identity resolution tests; nothing to assert.
             }
         }
-        // The override must NOT have leaked into the parent process.
-        assert!(std::env::var("TM_TEST_GH_IDENTITY_VAR").is_err());
+        if let Ok(out) = runner.run("printenv", &["GH_TOKEN"]) {
+            assert!(
+                !out.success,
+                "#6668: a bound child must not inherit GH_TOKEN, got {:?}",
+                out.stdout
+            );
+        }
+        // Neither the override nor the removal may leak into the parent.
+        assert_ne!(
+            std::env::var("GH_CONFIG_DIR").ok().as_deref(),
+            Some("/cfg/project"),
+            "the binding must apply to the child only"
+        );
     }
 
     /// Why: a default/ambient runner must apply no overrides (no regression).

--- a/crates/trusty-mpm/src/bin/tm/commands/watch/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/watch/mod.rs
@@ -149,8 +149,8 @@ pub(crate) async fn poll(
 
     // #1265: bind the active project's GitHub identity to every `gh` call.
     let gh_env = load_gh_env()?;
-    let runner = RealCommandRunner::with_env(gh_env.vars().to_vec());
-    let lister = GhIssueLister::new(RealCommandRunner::with_env(gh_env.vars().to_vec()));
+    let runner = RealCommandRunner::with_gh_env(&gh_env);
+    let lister = GhIssueLister::new(RealCommandRunner::with_gh_env(&gh_env));
     run_poll_once(
         client,
         url,
@@ -246,9 +246,9 @@ pub(crate) async fn listen(
 
     // #1265: bind the active project's GitHub identity to every `gh` call.
     let gh_env = load_gh_env()?;
-    let runner = RealCommandRunner::with_env(gh_env.vars().to_vec());
+    let runner = RealCommandRunner::with_gh_env(&gh_env);
     let board = resolve_board_repo(&runner, &settings.repo, github.as_ref())?;
-    let lister = GhIssueLister::new(RealCommandRunner::with_env(gh_env.vars().to_vec()));
+    let lister = GhIssueLister::new(RealCommandRunner::with_gh_env(&gh_env));
     run_listen_loop(
         client,
         url,

--- a/crates/trusty-mpm/src/core/gh_identity.rs
+++ b/crates/trusty-mpm/src/core/gh_identity.rs
@@ -358,20 +358,9 @@ pub fn resolve_gh_env(config: Option<&GithubConfig>) -> Result<GhEnv, GhIdentity
     }
 
     // #6668: an identity strategy that resolved must also CLEAR every other
-    // identity var the child would otherwise inherit — gh reads `GH_TOKEN`
-    // ahead of `GH_CONFIG_DIR`, so leaving the shell's token in place applies
-    // the binding and still authenticates as the wrong account. Computed
-    // before `GH_HOST` is appended so a host-only binding (which selects no
-    // identity) removes nothing and stays exactly as ambient as before.
-    let unset: Vec<String> = if vars.is_empty() {
-        Vec::new()
-    } else {
-        GH_INHERITED_IDENTITY_ENV
-            .iter()
-            .filter(|name| !vars.iter().any(|(k, _)| k == *name))
-            .map(|name| (*name).to_string())
-            .collect()
-    };
+    // identity var the child would otherwise inherit. Computed before `GH_HOST`
+    // is appended, though `inherited_identity_to_clear` would ignore it anyway.
+    let unset = inherited_identity_to_clear(&vars);
 
     // --- Host is applied independently of the identity strategy. ------------
     if let Some(host) = cfg.host.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
@@ -379,6 +368,42 @@ pub fn resolve_gh_env(config: Option<&GithubConfig>) -> Result<GhEnv, GhIdentity
     }
 
     Ok(GhEnv { vars, unset })
+}
+
+/// Which inherited identity vars a child must NOT keep, given what is set on it.
+///
+/// Why (#6668): two places bind a gh identity onto a child and neither may
+/// decide this for itself — [`resolve_gh_env`] for a `gh`/git subprocess, and
+/// `runtime::claude_code_gh_env::write_gh_env_file` for the sourced env file
+/// every managed Claude Code / tmux session starts from. The second carries
+/// only a `Vec<(String, String)>` of vars to SET, so before this function it
+/// could not express a removal at all: a daemon started from a shell that
+/// exports `GH_TOKEN` handed that token to every spawned session, outranking
+/// the project's pinned `GH_CONFIG_DIR` for the session's whole lifetime.
+/// Deriving the answer from the set-vars, in one function both callers ask,
+/// keeps the precedence rule single-sourced rather than restated per site.
+/// What: EMPTY unless `set_vars` selects an identity (`GH_CONFIG_DIR` or
+/// `GH_TOKEN`) — a host-only or informational-only binding changes nothing.
+/// Otherwise every [`GH_INHERITED_IDENTITY_ENV`] entry `set_vars` does not
+/// itself set. `GH_USER` alone does not count as selecting an identity: it is
+/// `trusty-mpm`'s own informational var, not one gh reads.
+/// Test: `binding_removes_the_inherited_identity_vars`,
+/// `absent_config_and_host_only_binding_remove_nothing`,
+/// `inherited_identity_to_clear_ignores_an_informational_only_binding`,
+/// and `gh_env_file_unsets_an_inherited_token` in
+/// `runtime::claude_code_gh_env_tests`.
+pub fn inherited_identity_to_clear(set_vars: &[(String, String)]) -> Vec<String> {
+    let selects_identity = set_vars
+        .iter()
+        .any(|(k, _)| k == ENV_GH_CONFIG_DIR || k == ENV_GH_TOKEN);
+    if !selects_identity {
+        return Vec::new();
+    }
+    GH_INHERITED_IDENTITY_ENV
+        .iter()
+        .filter(|name| !set_vars.iter().any(|(k, _)| k == *name))
+        .map(|name| (*name).to_string())
+        .collect()
 }
 
 /// Resolve the token NAMEd by `token_env` from the process environment.
@@ -494,6 +519,28 @@ mod tests {
         );
         // The var this resolution SETS is never also removed.
         assert!(!unset.contains(&ENV_GH_CONFIG_DIR));
+    }
+
+    /// Why (#6668, review HIGH): `GH_USER` is trusty-mpm's own informational
+    /// var, not one gh reads, so a binding that emits only it selects no
+    /// identity and must leave the operator's ambient token alone. This is the
+    /// case that keeps the managed-session spawn file from clearing a token it
+    /// has nothing to replace with.
+    /// Test: itself.
+    #[test]
+    fn inherited_identity_to_clear_ignores_an_informational_only_binding() {
+        assert!(
+            inherited_identity_to_clear(&[("GH_USER".to_string(), "bobmatnyc".to_string())])
+                .is_empty()
+        );
+        assert!(inherited_identity_to_clear(&[]).is_empty());
+        // A config_dir pin alongside it DOES select an identity.
+        let cleared = inherited_identity_to_clear(&[
+            (ENV_GH_CONFIG_DIR.to_string(), "/cfg".to_string()),
+            ("GH_USER".to_string(), "bobmatnyc".to_string()),
+        ]);
+        assert!(cleared.contains(&ENV_GH_TOKEN.to_string()), "{cleared:?}");
+        assert!(!cleared.contains(&"GH_USER".to_string()), "{cleared:?}");
     }
 
     /// Why (#6668): the mirror case — a `token_env` binding sets `GH_TOKEN`, so

--- a/crates/trusty-mpm/src/core/gh_identity.rs
+++ b/crates/trusty-mpm/src/core/gh_identity.rs
@@ -37,6 +37,19 @@
 //!
 //! `host` is applied independently of the identity strategy whenever set.
 //!
+//! ## Clearing the inherited identity (#6668)
+//!
+//! Selecting an identity is only half the job. `gh` reads `GH_TOKEN` (and its
+//! `GITHUB_TOKEN` / `*_ENTERPRISE_TOKEN` spellings) BEFORE it reads
+//! `GH_CONFIG_DIR`, so a `tm` invoked from a shell that exports one account's
+//! token authenticated as that account even with a per-project `config_dir`
+//! binding applied. Whenever an identity strategy resolves, every OTHER
+//! [`GH_INHERITED_IDENTITY_ENV`] var is therefore listed in
+//! [`GhEnv::unset_vars`] and removed from the child by
+//! [`GhEnv::apply_to`]. An unbound (`None`) config, and a binding that sets
+//! only `host`, remove nothing — an operator whose sole credential is an
+//! ambient `GH_TOKEN` is unaffected.
+//!
 //! ## `account`-strategy caveat (deliberate decision)
 //!
 //! `gh` has NO universal per-invocation `--user`/`--account` flag, and
@@ -87,6 +100,28 @@ const ENV_GH_TOKEN: &str = "GH_TOKEN";
 /// `GH_HOST` — the default host gh targets.
 const ENV_GH_HOST: &str = "GH_HOST";
 
+/// Every env var that can select a gh identity on its own (#6668).
+///
+/// Why: gh resolves auth from the environment BEFORE it reads a scoped config
+/// dir, so an inherited `GH_TOKEN` silently outranks the `GH_CONFIG_DIR` this
+/// resolver emits — the binding is applied and still loses. Naming the full
+/// set once is what keeps the removal complete: `GITHUB_TOKEN` is gh's
+/// documented fallback for `GH_TOKEN`, and the two `*_ENTERPRISE_TOKEN`
+/// spellings are the same pair for a GHE host.
+/// What: the removal candidates [`resolve_gh_env`] clears from a bound child.
+/// A var this resolution SETS is never also removed.
+/// Test: `binding_removes_the_inherited_identity_vars`,
+/// `token_env_binding_removes_the_config_dir`,
+/// `absent_config_and_host_only_binding_remove_nothing`.
+const GH_INHERITED_IDENTITY_ENV: &[&str] = &[
+    ENV_GH_TOKEN,
+    "GITHUB_TOKEN",
+    "GH_ENTERPRISE_TOKEN",
+    "GITHUB_ENTERPRISE_TOKEN",
+    ENV_GH_CONFIG_DIR,
+    "GH_USER",
+];
+
 /// Typed failures from resolving a [`GithubConfig`] into a [`GhEnv`].
 ///
 /// Why: the `account`-only strategy cannot be honoured without mutating global
@@ -122,6 +157,9 @@ pub enum GhIdentityError {
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct GhEnv {
     vars: Vec<(String, String)>,
+    /// #6668: identity vars to REMOVE from the child so an inherited one
+    /// cannot outrank the binding in `vars`. Empty when nothing binds.
+    unset: Vec<String>,
 }
 
 impl GhEnv {
@@ -135,6 +173,44 @@ impl GhEnv {
         &self.vars
     }
 
+    /// The env vars to REMOVE from the child before applying [`vars`](Self::vars) (#6668).
+    ///
+    /// Why: setting `GH_CONFIG_DIR` is not enough to bind an identity. gh reads
+    /// `GH_TOKEN` (and its `GITHUB_TOKEN`/enterprise spellings) ahead of any
+    /// scoped config dir, so a shell that exports another account's token wins
+    /// over the project binding — the #6668 symptom was `tm session
+    /// prune-worktrees --merged-prs` reporting "Could not resolve to a
+    /// Repository" for every repo the shell token could not see. Every spawn
+    /// site must clear these before setting the binding's own vars.
+    /// What: the [`GH_INHERITED_IDENTITY_ENV`] entries this resolution does not
+    /// itself set, or EMPTY when no identity strategy resolved (ambient stays
+    /// ambient — an unbound `gh` call still inherits the operator's token).
+    /// Test: `binding_removes_the_inherited_identity_vars`,
+    /// `token_env_binding_removes_the_config_dir`,
+    /// `absent_config_and_host_only_binding_remove_nothing`.
+    pub fn unset_vars(&self) -> &[String] {
+        &self.unset
+    }
+
+    /// Apply this binding to `cmd`: remove the inherited identity, then set the
+    /// resolved overrides (#6668).
+    ///
+    /// Why: the removal must precede the set, and getting that order wrong at
+    /// one call site reintroduces the bug there alone. One applier is what
+    /// keeps every `std::process::Command` spawn site identical.
+    /// What: `env_remove` for each [`unset_vars`](Self::unset_vars) entry, then
+    /// `env` for each [`vars`](Self::vars) pair. A default (`is_empty`) `GhEnv`
+    /// touches nothing.
+    /// Test: `apply_to_removes_then_sets`.
+    pub fn apply_to(&self, cmd: &mut std::process::Command) {
+        for key in &self.unset {
+            cmd.env_remove(key);
+        }
+        for (key, value) in &self.vars {
+            cmd.env(key, value);
+        }
+    }
+
     /// Whether any override is set (i.e. an identity binding is active).
     ///
     /// Why: lets callers cheaply distinguish "bound" from "ambient" without
@@ -142,7 +218,7 @@ impl GhEnv {
     /// What: true when at least one override is present.
     /// Test: `resolve_absent_config_is_empty` asserts `is_empty()` for None.
     pub fn is_empty(&self) -> bool {
-        self.vars.is_empty()
+        self.vars.is_empty() && self.unset.is_empty()
     }
 
     /// One-line, secret-free description of the resolved overrides (#6623).
@@ -156,11 +232,13 @@ impl GhEnv {
     /// redacted.
     /// Test: `describe_empty_env`, `describe_config_dir`, `describe_redacts_token`.
     pub fn describe(&self) -> String {
-        if self.vars.is_empty() {
+        if self.is_empty() {
             return "no github: binding resolved — gh inherits the daemon's ambient \
                     environment"
                 .to_string();
         }
+        // #6668: the removals are named too — "GH_CONFIG_DIR=… " alone did not
+        // say whether an inherited token was still in play.
         self.vars
             .iter()
             .map(|(k, v)| {
@@ -170,6 +248,7 @@ impl GhEnv {
                     format!("{k}={v}")
                 }
             })
+            .chain(self.unset.iter().map(|k| format!("-{k}")))
             .collect::<Vec<_>>()
             .join(", ")
     }
@@ -239,7 +318,11 @@ pub fn select_config_for_origin<'a>(
 /// ALWAYS appends `GH_HOST` when `host` is set. The `account`-only case returns
 /// [`GhIdentityError::AccountStrategyUnsupported`] (see module docs). A
 /// `token_env` whose named var is ABSENT is skipped, falling through to the next
-/// strategy.
+/// strategy. #6668: when an identity strategy DOES resolve, every other
+/// [`GH_INHERITED_IDENTITY_ENV`] var is listed in
+/// [`GhEnv::unset_vars`] for the spawn site to remove — otherwise a shell
+/// exporting `GH_TOKEN` outranks the `GH_CONFIG_DIR` this emits and the binding
+/// loses. A host-only binding selects no identity and removes nothing.
 /// Test: `resolve_absent_config_is_empty`, `resolve_config_dir`,
 /// `resolve_token_env_present`, `resolve_token_env_absent_falls_through`,
 /// `precedence_config_dir_beats_token_env`,
@@ -274,12 +357,28 @@ pub fn resolve_gh_env(config: Option<&GithubConfig>) -> Result<GhEnv, GhIdentity
         ));
     }
 
+    // #6668: an identity strategy that resolved must also CLEAR every other
+    // identity var the child would otherwise inherit — gh reads `GH_TOKEN`
+    // ahead of `GH_CONFIG_DIR`, so leaving the shell's token in place applies
+    // the binding and still authenticates as the wrong account. Computed
+    // before `GH_HOST` is appended so a host-only binding (which selects no
+    // identity) removes nothing and stays exactly as ambient as before.
+    let unset: Vec<String> = if vars.is_empty() {
+        Vec::new()
+    } else {
+        GH_INHERITED_IDENTITY_ENV
+            .iter()
+            .filter(|name| !vars.iter().any(|(k, _)| k == *name))
+            .map(|name| (*name).to_string())
+            .collect()
+    };
+
     // --- Host is applied independently of the identity strategy. ------------
     if let Some(host) = cfg.host.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
         vars.push((ENV_GH_HOST.to_string(), host.to_string()));
     }
 
-    Ok(GhEnv { vars })
+    Ok(GhEnv { vars, unset })
 }
 
 /// Resolve the token NAMEd by `token_env` from the process environment.
@@ -367,6 +466,103 @@ mod tests {
                 ENV_GH_CONFIG_DIR.to_string(),
                 "/home/bob/.config/gh-work".to_string()
             )]
+        );
+    }
+
+    /// Why (#6668): a `config_dir` binding that leaves an inherited `GH_TOKEN`
+    /// in the child is not a binding — gh reads the env token first, so the
+    /// scoped config dir is decorative and the wrong account answers. The
+    /// removal list must name every identity var this resolution did not set.
+    /// Test: itself.
+    #[test]
+    fn binding_removes_the_inherited_identity_vars() {
+        let c = GithubConfig {
+            config_dir: Some(PathBuf::from("/cfg/duetto")),
+            ..cfg()
+        };
+        let env = resolve_gh_env(Some(&c)).expect("ok");
+        let unset: Vec<&str> = env.unset_vars().iter().map(String::as_str).collect();
+        assert_eq!(
+            unset,
+            vec![
+                "GH_TOKEN",
+                "GITHUB_TOKEN",
+                "GH_ENTERPRISE_TOKEN",
+                "GITHUB_ENTERPRISE_TOKEN",
+                "GH_USER",
+            ]
+        );
+        // The var this resolution SETS is never also removed.
+        assert!(!unset.contains(&ENV_GH_CONFIG_DIR));
+    }
+
+    /// Why (#6668): the mirror case — a `token_env` binding sets `GH_TOKEN`, so
+    /// the var it must clear is the inherited `GH_CONFIG_DIR` (and the other
+    /// token spellings), not the one it just set.
+    /// Test: itself.
+    #[test]
+    fn token_env_binding_removes_the_config_dir() {
+        // SAFETY: single-threaded test setup for a name no other test reads.
+        unsafe { std::env::set_var("TM_TEST_6668_TOKEN", "t") };
+        let c = GithubConfig {
+            token_env: Some("TM_TEST_6668_TOKEN".to_string()),
+            ..cfg()
+        };
+        let env = resolve_gh_env(Some(&c)).expect("ok");
+        let unset: Vec<&str> = env.unset_vars().iter().map(String::as_str).collect();
+        assert!(unset.contains(&ENV_GH_CONFIG_DIR), "{unset:?}");
+        assert!(unset.contains(&"GITHUB_TOKEN"), "{unset:?}");
+        assert!(!unset.contains(&ENV_GH_TOKEN), "{unset:?}");
+        unsafe { std::env::remove_var("TM_TEST_6668_TOKEN") };
+    }
+
+    /// Why (#6668): removal is scoped to a resolved IDENTITY. An absent config
+    /// — and a binding that sets only `host` — must stay exactly as ambient as
+    /// before, or an operator whose only credential is `GH_TOKEN` loses it.
+    /// Test: itself.
+    #[test]
+    fn absent_config_and_host_only_binding_remove_nothing() {
+        assert!(resolve_gh_env(None).expect("ok").unset_vars().is_empty());
+        let c = GithubConfig {
+            host: Some("github.example.com".to_string()),
+            ..cfg()
+        };
+        assert!(
+            resolve_gh_env(Some(&c))
+                .expect("ok")
+                .unset_vars()
+                .is_empty()
+        );
+    }
+
+    /// Why (#6668): the removal must reach the spawned command, and it must run
+    /// BEFORE the set — the reverse order would clear the var just bound.
+    /// Test: itself.
+    #[test]
+    fn apply_to_removes_then_sets() {
+        let c = GithubConfig {
+            config_dir: Some(PathBuf::from("/cfg/duetto")),
+            ..cfg()
+        };
+        let env = resolve_gh_env(Some(&c)).expect("ok");
+        let mut cmd = std::process::Command::new("true");
+        env.apply_to(&mut cmd);
+        let seen: Vec<(String, Option<String>)> = cmd
+            .get_envs()
+            .map(|(k, v)| {
+                (
+                    k.to_string_lossy().into_owned(),
+                    v.map(|v| v.to_string_lossy().into_owned()),
+                )
+            })
+            .collect();
+        assert!(seen.contains(&("GH_TOKEN".to_string(), None)), "{seen:?}");
+        assert!(
+            seen.contains(&(
+                ENV_GH_CONFIG_DIR.to_string(),
+                Some("/cfg/duetto".to_string())
+            )),
+            "{seen:?}"
         );
     }
 
@@ -713,7 +909,13 @@ mod tests {
     #[test]
     fn describe_config_dir() {
         let env = resolve_gh_env(Some(&gh("/cfg/dir"))).expect("ok");
-        assert_eq!(env.describe(), "GH_CONFIG_DIR=/cfg/dir");
+        // #6668: a `-VAR` entry names each identity var the spawn removes, so
+        // the diagnostic says whether an inherited token was still in play.
+        assert_eq!(
+            env.describe(),
+            "GH_CONFIG_DIR=/cfg/dir, -GH_TOKEN, -GITHUB_TOKEN, -GH_ENTERPRISE_TOKEN, \
+             -GITHUB_ENTERPRISE_TOKEN, -GH_USER"
+        );
     }
 
     /// Why: `GH_TOKEN`'s VALUE must never appear in a diagnostic string.

--- a/crates/trusty-mpm/src/core/git_identity.rs
+++ b/crates/trusty-mpm/src/core/git_identity.rs
@@ -66,6 +66,10 @@ pub struct GitIdentity {
     /// `GH_TOKEN`, `GH_HOST`) so an HTTPS credential helper picks the right
     /// identity.
     pub env: Vec<(String, String)>,
+    /// #6668: identity vars REMOVED from the git subprocess before `env` is
+    /// applied. A credential helper resolves an inherited `GH_TOKEN` ahead of
+    /// the `GH_CONFIG_DIR` this identity binds, so setting alone is not enough.
+    pub env_remove: Vec<String>,
     /// Git commit author name override, applied as `-c user.name=<name>`.
     pub commit_name: Option<String>,
     /// Git commit author email override, applied as `-c user.email=<email>`.
@@ -80,7 +84,10 @@ impl GitIdentity {
     /// What: true when `env` is empty and both commit fields are `None`.
     /// Test: covered by `resolve_git_identity_none_when_nothing_configured`.
     pub fn is_empty(&self) -> bool {
-        self.env.is_empty() && self.commit_name.is_none() && self.commit_email.is_none()
+        self.env.is_empty()
+            && self.env_remove.is_empty()
+            && self.commit_name.is_none()
+            && self.commit_email.is_none()
     }
 
     /// Render the `-c user.name=…`/`-c user.email=…` args for a `git` command.
@@ -132,6 +139,9 @@ pub fn resolve_git_identity(
     let env = resolve_gh_env(selected)?;
     Ok(GitIdentity {
         env: env.vars().to_vec(),
+        // #6668: carry the removals with the overrides — a bound identity that
+        // leaves an inherited GH_TOKEN in place is not bound.
+        env_remove: env.unset_vars().to_vec(),
         commit_name: commit_name.map(str::to_string),
         commit_email: commit_email.map(str::to_string),
     })

--- a/crates/trusty-mpm/src/provisioner/workspace.rs
+++ b/crates/trusty-mpm/src/provisioner/workspace.rs
@@ -218,6 +218,11 @@ impl RealGitBackend {
     fn command(&self) -> std::process::Command {
         let mut cmd = std::process::Command::new("git");
         cmd.args(self.identity.commit_config_args());
+        // #6668: clear the inherited identity before applying the bound one —
+        // a credential helper reads GH_TOKEN ahead of GH_CONFIG_DIR.
+        for key in &self.identity.env_remove {
+            cmd.env_remove(key);
+        }
         cmd.envs(self.identity.env.iter().cloned());
         cmd
     }

--- a/crates/trusty-mpm/src/provisioner/workspace/tests.rs
+++ b/crates/trusty-mpm/src/provisioner/workspace/tests.rs
@@ -1047,6 +1047,7 @@ fn default_identity_produces_plain_git_command() {
 fn git_identity_env_applied_to_command() {
     let identity = crate::core::git_identity::GitIdentity {
         env: vec![("GH_CONFIG_DIR".to_string(), "/cfg/project".to_string())],
+        env_remove: vec!["GH_TOKEN".to_string()],
         commit_name: None,
         commit_email: None,
     };
@@ -1060,6 +1061,13 @@ fn git_identity_env_applied_to_command() {
         }),
         "GH_CONFIG_DIR override must be applied: {envs:?}"
     );
+    // #6668: a credential helper reads GH_TOKEN ahead of GH_CONFIG_DIR, so the
+    // removal has to reach the command too or the binding stays decorative.
+    assert!(
+        envs.iter()
+            .any(|(k, v)| *k == std::ffi::OsStr::new("GH_TOKEN") && v.is_none()),
+        "GH_TOKEN must be removed: {envs:?}"
+    );
 }
 
 /// Why: a resolved commit-identity override must render as `-c user.name=…`/
@@ -1070,6 +1078,7 @@ fn git_identity_env_applied_to_command() {
 fn git_identity_commit_args_applied_to_command() {
     let identity = crate::core::git_identity::GitIdentity {
         env: vec![],
+        env_remove: vec![],
         commit_name: Some("Bot".to_string()),
         commit_email: Some("bot@example.com".to_string()),
     };

--- a/crates/trusty-mpm/src/runtime/claude_code_gh_env.rs
+++ b/crates/trusty-mpm/src/runtime/claude_code_gh_env.rs
@@ -57,18 +57,32 @@ fn secure_write(path: &Path, data: &[u8]) -> std::io::Result<()> {
 /// Why: isolates the file-write step so `ClaudeCodeAdapter::spawn`/
 /// `spawn_resume` stay a one-line call; testable without touching a real
 /// tmux pane.
+/// #6668: the file also carries `unset` lines. A `GH_CONFIG_DIR` pin binds
+/// nothing while the shell that started the daemon exported another account's
+/// `GH_TOKEN` — gh reads the env token first, so every `gh` call the spawned
+/// session makes for its whole lifetime used the wrong account. Which vars
+/// must go is NOT decided here: it comes from
+/// [`crate::core::gh_identity::inherited_identity_to_clear`], the same function
+/// `resolve_gh_env` uses, so the precedence rule has one definition.
 /// What: `gh_env.is_empty()` → `None` (no file, no regression for the common
-/// unconfigured case). Otherwise writes one line per pair, single-quoting
-/// each value via the shared [`shell_single_quote`], to
-/// `<tmp>/trusty-mpm-gh-env-<uuid>.sh`; returns `None` (logged) on any write
-/// failure so the spawn proceeds without `GH_TOKEN` rather than failing.
+/// unconfigured case). Otherwise writes the `unset NAME` lines FIRST — a
+/// removal after the export would clear the var just bound — then one
+/// `export NAME='value'` line per pair, single-quoting each value via the
+/// shared [`shell_single_quote`], to `<tmp>/trusty-mpm-gh-env-<uuid>.sh`;
+/// returns `None` (logged) on any write failure so the spawn proceeds without
+/// `GH_TOKEN` rather than failing.
 /// Test: `write_gh_env_file_writes_export_lines_in_order`, `write_gh_env_file_empty_is_none`,
-/// `write_gh_env_file_is_mode_0600`.
+/// `write_gh_env_file_is_mode_0600`, `gh_env_file_unsets_an_inherited_token`,
+/// `gh_env_file_unsets_nothing_without_an_identity_binding`.
 pub(super) fn write_gh_env_file(gh_env: &[(String, String)]) -> Option<PathBuf> {
     if gh_env.is_empty() {
         return None;
     }
     let mut content = String::new();
+    // #6668: removals first, then the exports.
+    for name in crate::core::gh_identity::inherited_identity_to_clear(gh_env) {
+        content.push_str(&format!("unset {name}\n"));
+    }
     for (name, value) in gh_env {
         content.push_str(&format!("export {name}={}\n", shell_single_quote(value)));
     }

--- a/crates/trusty-mpm/src/runtime/claude_code_gh_env_tests.rs
+++ b/crates/trusty-mpm/src/runtime/claude_code_gh_env_tests.rs
@@ -63,6 +63,72 @@ fn write_gh_env_file_writes_export_lines_in_order() {
     );
 }
 
+/// Why (#6668, review HIGH): a `GH_CONFIG_DIR` pin binds nothing while the
+/// shell that started the daemon exported another account's `GH_TOKEN` — gh
+/// reads the env token ahead of the config dir, so every `gh` call the spawned
+/// session makes runs as the wrong account for its whole lifetime. The sourced
+/// env file could not express a removal at all before this; now it carries
+/// `unset` lines, and they must precede the exports or they would clear the
+/// var just bound.
+/// Test: itself.
+#[test]
+fn gh_env_file_unsets_an_inherited_token() {
+    let gh_env = vec![
+        (
+            "GH_CONFIG_DIR".to_string(),
+            "/Users/masa/.config/gh-duetto".to_string(),
+        ),
+        ("GH_USER".to_string(), "bob-duetto".to_string()),
+    ];
+    let file = write_gh_env_file(&gh_env).expect("file written");
+    let content = std::fs::read_to_string(&file).expect("read gh-env file");
+    let _ = std::fs::remove_file(&file);
+
+    for name in [
+        "GH_TOKEN",
+        "GITHUB_TOKEN",
+        "GH_ENTERPRISE_TOKEN",
+        "GITHUB_ENTERPRISE_TOKEN",
+    ] {
+        assert!(
+            content.contains(&format!("unset {name}\n")),
+            "{name} must be unset by a config_dir pin: {content}"
+        );
+    }
+    // A var this file SETS is never also unset.
+    assert!(
+        !content.contains("unset GH_CONFIG_DIR"),
+        "the pinned config dir must not be unset: {content}"
+    );
+    assert!(
+        !content.contains("unset GH_USER"),
+        "an emitted GH_USER must not be unset: {content}"
+    );
+    // Ordering: every unset precedes every export.
+    let last_unset = content.rfind("unset ").expect("an unset line");
+    let first_export = content.find("export ").expect("an export line");
+    assert!(
+        last_unset < first_export,
+        "unset lines must precede export lines: {content}"
+    );
+}
+
+/// Why (#6668): the removal is scoped to a resolved IDENTITY. `GH_USER` is
+/// trusty-mpm's own informational var, not one gh reads, so a file carrying
+/// only that must leave an operator's ambient token alone.
+/// Test: itself.
+#[test]
+fn gh_env_file_unsets_nothing_without_an_identity_binding() {
+    let gh_env = vec![("GH_USER".to_string(), "bobmatnyc".to_string())];
+    let file = write_gh_env_file(&gh_env).expect("file written");
+    let content = std::fs::read_to_string(&file).expect("read gh-env file");
+    let _ = std::fs::remove_file(&file);
+    assert!(
+        !content.contains("unset "),
+        "an informational-only binding must remove nothing: {content}"
+    );
+}
+
 /// Why (Unix only): the file must be mode 0600 — owner-read/write only,
 /// never group/world-readable, even momentarily. Matches the established
 /// `secure_write` contract this module mirrors from `core::oauth_token`.

--- a/crates/trusty-mpm/src/session_manager/worktree_reclaim_gh.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_reclaim_gh.rs
@@ -122,6 +122,12 @@ pub(crate) fn gh_command(dir: &Path, gh_env: &GhEnv) -> Command {
     for key in GH_STRIPPED_ENV {
         cmd = cmd.env_remove(key);
     }
+    // #6668: clear the inherited identity BEFORE applying the binding — gh
+    // reads an env token ahead of `GH_CONFIG_DIR`, so leaving the shell's
+    // `GH_TOKEN` in place left the binding decorative.
+    for key in gh_env.unset_vars() {
+        cmd = cmd.env_remove(key);
+    }
     for (key, value) in gh_env.vars() {
         cmd = cmd.env(key, value);
     }

--- a/crates/trusty-mpm/src/session_manager/worktree_reclaim_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_reclaim_tests.rs
@@ -699,6 +699,70 @@ fn gh_command_applies_the_resolved_gh_env() {
     assert_eq!(value, "/cfg/daemon");
 }
 
+/// Why (#6668): `resolve_gh_env` set `GH_CONFIG_DIR` and nothing else, so a
+/// `gh` spawned from a shell that exports a DIFFERENT account's `GH_TOKEN`
+/// authenticated as that account — an env token outranks a scoped config dir
+/// in gh's own resolution order. The per-project binding lost to the shell,
+/// and `tm session prune-worktrees --merged-prs` reported "Could not resolve
+/// to a Repository" for every repo the shell token could not see. A resolved
+/// binding must therefore REMOVE the inherited identity vars from the child.
+/// Test: itself.
+#[test]
+fn gh_command_removes_an_inherited_token_when_a_config_dir_binds() {
+    let env = crate::core::gh_identity::resolve_gh_env(Some(
+        &crate::core::trusty_tools_config::GithubConfig {
+            config_dir: Some(PathBuf::from("/cfg/duetto")),
+            ..Default::default()
+        },
+    ))
+    .expect("ok");
+    let cmd = gh_command(Path::new("/tmp"), &env);
+    let removed: Vec<&str> = cmd
+        .get_envs()
+        .filter(|(_, v)| v.is_none())
+        .filter_map(|(k, _)| k.to_str())
+        .collect();
+    for key in [
+        "GH_TOKEN",
+        "GITHUB_TOKEN",
+        "GH_ENTERPRISE_TOKEN",
+        "GITHUB_ENTERPRISE_TOKEN",
+        "GH_USER",
+    ] {
+        assert!(
+            removed.contains(&key),
+            "{key} must be removed when a config_dir binds: {removed:?}"
+        );
+    }
+    let value = cmd
+        .get_envs()
+        .find(|(k, _)| *k == "GH_CONFIG_DIR")
+        .and_then(|(_, v)| v)
+        .expect("GH_CONFIG_DIR must still be set");
+    assert_eq!(value, "/cfg/duetto");
+}
+
+/// Why (#6668): with no binding the spawn must stay exactly as ambient as it
+/// was — removing an inherited token from an UNBOUND `gh` call would break
+/// every operator whose only credential is `GH_TOKEN`.
+/// Test: itself.
+#[test]
+fn gh_command_keeps_an_inherited_token_when_nothing_binds() {
+    let cmd = gh_command(
+        Path::new("/tmp"),
+        &crate::core::gh_identity::GhEnv::default(),
+    );
+    let removed: Vec<&str> = cmd
+        .get_envs()
+        .filter(|(_, v)| v.is_none())
+        .filter_map(|(k, _)| k.to_str())
+        .collect();
+    assert!(
+        !removed.contains(&"GH_TOKEN"),
+        "an unbound spawn must inherit GH_TOKEN: {removed:?}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Byte measurement
 // ---------------------------------------------------------------------------

--- a/crates/trusty-mpm/tests/tm_hook_pm_guard.rs
+++ b/crates/trusty-mpm/tests/tm_hook_pm_guard.rs
@@ -3437,3 +3437,101 @@ fn pm_guard_operator_escape_hatches_still_allow_a_head_move() {
         );
     }
 }
+
+// ── #6660 review: unclassifiable wrapped commands, through the subagent path ─
+
+/// A native Task/Agent subagent's Bash payload for `command`.
+///
+/// Why (#6660 review): the three CRITICAL findings were all reproduced from a
+/// genuine subagent dispatch, where `payload_is_subagent_dispatch` short-
+/// circuits Guard 4 before `evaluate_bash_command` is ever called. Only a
+/// payload carrying `agent_id` exercises that path, which is why the unit
+/// tests in `pm_guard_bash/tests.rs` did not catch any of them.
+/// What: the same shape as `pm_guard_denies_destructive_delete_of_filesystem_roots`,
+/// built through `serde_json` so a command with embedded quotes escapes
+/// correctly.
+/// Test: used by the three tests below.
+fn subagent_bash_payload(command: &str) -> String {
+    serde_json::json!({
+        "hook_event_name": "PreToolUse",
+        "agent_id": "agent-xyz789",
+        "agent_type": "rust-engineer",
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+    })
+    .to_string()
+}
+
+/// `sh -c <cmd>` wrapped `layers` deep, shell-quoting at each layer.
+fn nest_sh_c(inner: &str, layers: usize) -> String {
+    let mut command = inner.to_string();
+    for _ in 0..layers {
+        let quoted = shlex::try_quote(&command).expect("quotable");
+        command = format!("sh -c {quoted}");
+    }
+    command
+}
+
+/// Why (#6660 review, CRITICAL 1/2/3): each of these was live-confirmed as an
+/// ALLOW from a real subagent dispatch against the compiled binary — an
+/// unlexable wrapper, an ANSI-C-quoted wrapper, and one nested past the
+/// descent budget. All three reach the ABSOLUTE guard band, which never routes
+/// through `evaluate_bash_command`, so a unit test on that function proved
+/// nothing about them.
+/// Test: itself.
+#[test]
+fn pm_guard_denies_a_wrapped_command_it_cannot_classify_via_subagent_payload() {
+    let inner = "git worktree remove /repo/.claude/worktrees/agent-x";
+    let mut cases: Vec<String> = vec![
+        // CRITICAL 1 — unlexable inner command.
+        r#"sh -c "git worktree remove 'unterminated""#.to_string(),
+        r#"bash -c 'rm -rf "unterminated'"#.to_string(),
+        // CRITICAL 2 — ANSI-C quoting shlex mangles into `$git`.
+        format!("sh -c $'{inner}'"),
+        "git $'worktree' remove /repo/.claude/worktrees/agent-x".to_string(),
+    ];
+    // CRITICAL 3 — one layer past the descent budget, and well past it.
+    cases.push(nest_sh_c(inner, 9));
+    cases.push(nest_sh_c(inner, 12));
+
+    for command in &cases {
+        let stdout = run_pm_guard(&subagent_bash_payload(command), &[]);
+        assert_denied(&stdout);
+    }
+}
+
+/// Why (#6660 review, CRITICAL 3): the boundary itself. Eight layers stay
+/// classifiable and are denied by the #5791 worktree-remove rule; nine exhaust
+/// the budget and are denied by the refusal. Both must deny — the reported bug
+/// was that 8 denied and 9 allowed.
+/// Test: itself.
+#[test]
+fn pm_guard_denies_a_wrapped_worktree_remove_on_both_sides_of_the_depth_cap() {
+    let inner = "git worktree remove /repo/.claude/worktrees/agent-x";
+    for layers in [1, 8, 9] {
+        let command = nest_sh_c(inner, layers);
+        let stdout = run_pm_guard(&subagent_bash_payload(&command), &[]);
+        assert_denied(&stdout);
+    }
+}
+
+/// Why (#6660 review): the refusal denies what it cannot read, not ordinary
+/// wrapped work. A subagent's `sh -c 'git status'` must stay allowed, or the
+/// guard is retried differently and worse (ADR-0048 decision 6).
+/// Test: itself.
+#[test]
+fn pm_guard_allows_ordinary_wrapped_commands_via_subagent_payload() {
+    for command in [
+        "sh -c 'git status --porcelain'",
+        r#"bash -c "git log --oneline -5""#,
+        "sh -c 'cargo build'",
+        "xargs git add",
+        "echo $HOME",
+    ] {
+        assert_eq!(
+            run_pm_guard(&subagent_bash_payload(command), &[]).trim(),
+            "",
+            "expected allow for: {command}"
+        );
+    }
+}


### PR DESCRIPTION
## Outcome
Refs #6668, #6660.
- #6668: when a per-project GitHub identity binding resolves, every spawned `gh` (and the managed-session env file) drops the inherited identity vars (`GH_TOKEN`, `GITHUB_TOKEN`, `GH_ENTERPRISE_TOKEN`, `GITHUB_ENTERPRISE_TOKEN`, `GH_CONFIG_DIR`, `GH_USER`) that the binding does not itself set, so the binding wins over the shell's token. Unbound and host-only bindings remove nothing. One authority: `core::gh_identity::inherited_identity_to_clear`, used by `resolve_gh_env` and by `runtime::claude_code_gh_env::write_gh_env_file` (emits `unset` lines before its exports; sourced before `claude` execs).
- #6660: the pm_guard classifier descends into `sh|bash|zsh|dash|ksh|ash -c`, `env -S`, and `xargs` wrappers, and a new first absolute guard `unclassifiable_command` refuses, before the subagent exemption, any command whose wrapped inner text is unlexable, uses live ANSI-C `$'…'`/`$"…"` quoting, or nests wrappers past the depth cap. Live `tm hook --pm-guard` shows DENY for `sh -c "git worktree remove 'unterminated"`, `sh -c $'git worktree remove x'`, and 9-deep nesting; ordinary wrapped commands still ALLOW.

## Changes
trusty-mpm only: core/gh_identity.rs, core/git_identity.rs, provisioner/workspace.rs, session_manager/worktree_reclaim_gh.rs, runtime/claude_code_gh_env.rs, bin/tm/commands/{pm_guard.rs, pm_guard_bash/{mod,shell_lex,persistence,tests}.rs, hook_rewrite.rs, issue/mod.rs, pr/mod.rs, ticket/{mod,runner}.rs, watch/mod.rs}, tests/tm_hook_pm_guard.rs, changelog fragment `6668-6660-gh-token-pm-guard-wrappers.md`. trusty-mpm is already 1.5.17 on main (unpublished), so no bump.

## Risk
High (guard and identity paths). Fail-closed: unlexable, ANSI-C-quoted, and over-deep wrapped commands deny with a named reason. Residual, documented: a `cd` inside a wrapped string leaks into later segments (over-blocking direction). Pre-existing gaps not addressed: `eval`, `find -exec`. `runtime::tcode.rs` discards `gh_env` entirely (pre-existing, out of scope).

## Tests
Rung 3, all `-p trusty-mpm` on the rebased tree: `cargo fmt --check`, `cargo check --all-targets`, `cargo clippy --all-targets -- -D warnings` exit 0; `cargo test --no-fail-fast`: 54 targets ok, lib 5871 passed, `tm_hook_pm_guard` 128 passed, 0 failures. Regression tests shown failing before: `wrappers_do_not_hide_the_inner_command_from_the_git_verb_rules` (12 wrapper spellings plus nested quoting), `an_unparseable_wrapped_command_is_denied`, `gh_command_removes_an_inherited_token_when_a_config_dir_binds`; post-critic: `pm_guard_denies_a_wrapped_command_it_cannot_classify_via_subagent_payload`, `pm_guard_denies_a_wrapped_worktree_remove_on_both_sides_of_the_depth_cap`, `pm_guard_allows_ordinary_wrapped_commands_via_subagent_payload`, `unclassifiable_command_flags_ansi_c_quoting`, `gh_env_file_unsets_an_inherited_token`. Doc gates: check_test_pointers (0 dangling), check_line_cap (0 violations), check_changelog_fragment OK. `check-pr-version-bump.sh` clear.

## Baseline
None on the rebased tree.

## Docs
Changelog fragment; Why/What/Test on the new functions.

## Review
code-critic BLOCK on ad6575b8d: three CRITICAL live bypasses (unlexable-wrapper deny unreachable on the subagent path; ANSI-C quoting defeats shlex tokenization; depth cap failed open at 9) and one HIGH (managed-session env kept an inherited token over a config_dir pin). All fixed in the second commit; critic re-ran its reproductions on a fresh build and returned APPROVE.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
