### PR TITLE
fix(trusty-review): size the analyze complexity_distribution budget to the work and make it configurable

### DIFF
--- a/crates/trusty-review/changelog.d/6712-analyze-timeout-budget.md
+++ b/crates/trusty-review/changelog.d/6712-analyze-timeout-budget.md
@@ -1,0 +1,16 @@
+Fixed
+
+- `--analyze` sizes each request to the work the endpoint actually does
+  - `analyze.complexity_distribution` and `analyze.refactor_suggestions` grade
+    every chunk of the index rather than reading computed data, which takes
+    41-46 s on a 104k-chunk checkout against the 15 s they were allowed. Both
+    now get a corpus budget defaulting to 180 s, so the §7 complexity table is
+    filled instead of rendering `not stated in source data` on every large
+    repository (#6712)
+  - `--analyze-timeout-secs` and the manifest key `[report].analyze_timeout_secs`
+    set that budget, in that order of precedence; it also raises the diagnostics
+    budget when it exceeds that endpoint's own deadline ladder. The readiness
+    probe keeps its 15 s, so an unreachable daemon is still declared unreachable
+    in seconds (#6712)
+  - A completed analyze request logs its elapsed time at INFO, and a request
+    that runs out of time still names the budget it exhausted (#6712)

--- a/crates/trusty-review/src/cli_report.rs
+++ b/crates/trusty-review/src/cli_report.rs
@@ -123,6 +123,17 @@ pub struct ReportArgs {
     /// `PR_INTELLIGENCE_ANALYZER_SOCKET` > the derived default (#6287).
     #[arg(long)]
     pub analyze: bool,
+
+    /// Seconds one corpus-scanning `--analyze` request may take (#6712).
+    /// Applies to the complexity histogram and the refactor list, whose cost
+    /// scales with the repository: grading a 104k-chunk index takes 41-46 s,
+    /// against the 15 s these endpoints used to be allowed, so the §7 complexity
+    /// table rendered unavailable on every large repository. Raises the
+    /// diagnostics budget too when it exceeds that endpoint's own deadline
+    /// ladder; the readiness probe keeps its short budget either way.
+    /// Precedence: this flag > manifest `[report].analyze_timeout_secs` > 180.
+    #[arg(long, value_name = "SECS")]
+    pub analyze_timeout_secs: Option<u64>,
 }
 
 impl ReportArgs {
@@ -147,6 +158,7 @@ impl ReportArgs {
         req.benchmark = self.benchmark;
         req.no_mermaid = self.no_mermaid;
         req.analyze = self.analyze;
+        req.analyze_timeout_secs = self.analyze_timeout_secs;
         req
     }
 }
@@ -228,6 +240,29 @@ mod tests {
             .expect("parse");
         assert!(args.analyze);
         assert!(args.to_request().analyze);
+        assert!(
+            args.to_request().analyze_timeout_secs.is_none(),
+            "#6712: unset defers to the manifest key, then the default"
+        );
+    }
+
+    /// Why (#6712): a flag that parses but never reaches the request leaves an
+    /// operator raising the budget on a slow repository with nothing changed.
+    /// What: `--analyze-timeout-secs` parses and lands on the request.
+    /// Test: this test itself.
+    #[test]
+    fn report_args_parse_analyze_timeout() {
+        let args = ReportArgs::try_parse_from([
+            "report",
+            "--manifest",
+            "m.toml",
+            "--analyze",
+            "--analyze-timeout-secs",
+            "600",
+        ])
+        .expect("parse");
+        assert_eq!(args.analyze_timeout_secs, Some(600));
+        assert_eq!(args.to_request().analyze_timeout_secs, Some(600));
     }
 
     /// Why (#6669): `--template cast --code-only` is the exact invocation the

--- a/crates/trusty-review/src/report/analyze_adapter.rs
+++ b/crates/trusty-review/src/report/analyze_adapter.rs
@@ -43,7 +43,6 @@ use std::time::Duration;
 use async_trait::async_trait;
 use serde::Deserialize;
 
-use super::index_registry::resolve_report_index;
 use super::metrics::{
     AnalyzeMetrics, ComplexityBucket, ComplexityDistribution, MetricFinding, Severity,
 };
@@ -52,8 +51,12 @@ use crate::integrations::search_client::IndexInfo;
 // The per-endpoint paths, budgets, and failure vocabulary live one module over,
 // beside each other, so an endpoint's cost and its timeout cannot drift apart.
 pub use super::analyze_endpoints::{
-    AnalyzeCaveat, AnalyzeEndpoint, EndpointFailure, diagnostics_budget_for,
+    AnalyzeCaveat, AnalyzeEndpoint, DEFAULT_CORPUS_BUDGET, EndpointFailure,
+    corpus_budget_from_secs, diagnostics_budget_for,
 };
+// #6712: the model-enrichment half moved to `analyze_enrich` when this file
+// passed the SLOC cap; the paths callers already use resolve through here.
+pub use super::analyze_enrich::{enrich_with_analyze, enrich_with_analyze_gaps};
 
 // ─── Tunables ──────────────────────────────────────────────────────────────
 
@@ -322,7 +325,7 @@ fn map_distribution(env: &DistributionEnvelope) -> ComplexityDistribution {
     }
 }
 
-use super::analyze_findings::{diagnostic_finding, refactor_finding, relativize_components};
+use super::analyze_findings::{diagnostic_finding, refactor_finding};
 
 // ─── Pure mapping ────────────────────────────────────────────────────────────
 
@@ -503,6 +506,13 @@ pub struct HttpAnalyzeMetricsSource {
     /// What: `None` resolves the advertised daemon at read time — the production
     /// default, unchanged; `Some(url)` reads that URL instead.
     search_base_url: Option<String>,
+    /// Per-request budget for the endpoints that scan the whole corpus (#6712).
+    ///
+    /// Why a field rather than a constant: the cost of a corpus scan belongs to
+    /// the repository being reported on, so the run configures it — see
+    /// [`Self::with_corpus_budget`]. Holding it here is also what makes it
+    /// injectable at millisecond scale in a test.
+    corpus_budget: Duration,
 }
 
 impl HttpAnalyzeMetricsSource {
@@ -530,7 +540,28 @@ impl HttpAnalyzeMetricsSource {
             socket,
             started: tokio::sync::OnceCell::new(),
             search_base_url: None,
+            // #6712: the run overrides this through `with_corpus_budget`.
+            corpus_budget: DEFAULT_CORPUS_BUDGET,
         })
+    }
+
+    /// Give the corpus-scanning endpoints `budget` per request (#6712).
+    ///
+    /// Why: `analyze.complexity_distribution` grades every chunk in the index,
+    /// so how long it takes is a fact about the repository — 41–46 s on a
+    /// 104k-chunk checkout — and the caller is the only layer that knows which
+    /// repository this is. The CLI resolves the value from
+    /// `--analyze-timeout-secs`, the manifest's `[report].analyze_timeout_secs`,
+    /// and [`DEFAULT_CORPUS_BUDGET`], in that order.
+    /// What: consuming builder, matching [`Self::with_search_base_url`]. The
+    /// readiness probe is deliberately unaffected — a dead daemon must still be
+    /// declared dead in seconds.
+    /// Test: `a_corpus_endpoint_slower_than_the_probe_budget_still_arrives`,
+    /// `the_configured_corpus_budget_is_honoured_and_named_in_the_error`.
+    #[must_use]
+    pub fn with_corpus_budget(mut self, budget: Duration) -> Self {
+        self.corpus_budget = budget;
+        self
     }
 
     /// Read the trusty-search registry from `base_url` rather than from the
@@ -727,7 +758,9 @@ impl HttpAnalyzeMetricsSource {
     /// warning) from a transport error, per the indexing prerequisite (#2448).
     async fn index_served(&self, index_id: &str) -> AdapterResult<bool> {
         let endpoint = AnalyzeEndpoint::IndexList;
-        let indexes: Vec<ServedIndex> = self.call(endpoint, index_id, endpoint.budget()).await?;
+        let indexes: Vec<ServedIndex> = self
+            .call(endpoint, index_id, endpoint.budget(self.corpus_budget))
+            .await?;
         Ok(indexes.iter().any(|i| i.id == index_id))
     }
 
@@ -745,16 +778,34 @@ impl HttpAnalyzeMetricsSource {
     /// failure category, and returns `None`. The error text never reaches the
     /// caveat — it can quote a URL or a response body, and the artifact gets the
     /// category only.
+    /// #6712: a successful fetch logs how long it took at INFO. Until then the
+    /// only observable timing was a timeout, so an endpoint creeping up on its
+    /// budget looked identical to one answering instantly — and the histogram
+    /// had been over the old budget for the whole life of that budget with
+    /// nothing on the record saying so.
+    ///
     /// Test: `a_failing_endpoint_keeps_what_the_others_returned`,
-    /// `a_request_that_outlives_its_budget_is_a_timeout_not_a_transport_error`.
+    /// `a_request_that_outlives_its_budget_is_a_timeout_not_a_transport_error`,
+    /// `a_corpus_endpoint_slower_than_the_probe_budget_still_arrives`.
     async fn fetch_dataset<T: serde::de::DeserializeOwned>(
         &self,
         index_id: &str,
         endpoint: AnalyzeEndpoint,
         caveats: &mut Vec<AnalyzeCaveat>,
     ) -> Option<T> {
-        match self.call(endpoint, index_id, endpoint.budget()).await {
-            Ok(v) => Some(v),
+        let budget = endpoint.budget(self.corpus_budget);
+        let started = std::time::Instant::now();
+        match self.call(endpoint, index_id, budget).await {
+            Ok(v) => {
+                tracing::info!(
+                    index_id,
+                    endpoint = endpoint.as_str(),
+                    elapsed_ms = started.elapsed().as_millis(),
+                    budget_ms = budget.as_millis(),
+                    "--analyze: endpoint answered"
+                );
+                Some(v)
+            }
             Err(e) => {
                 let reason = classify_failure(&e);
                 tracing::warn!(index_id, endpoint = endpoint.as_str(), error = %e,
@@ -885,142 +936,6 @@ impl AnalyzeMetricsSource for HttpAnalyzeMetricsSource {
             }
         }
     }
-}
-
-// ─── Model enrichment (precedence seam, #2448) ───────────────────────────────
-
-/// Fill live analyze metrics into a built [`ReportModel`](crate::report::ReportModel), honouring the
-/// fail-open precedence: declared metrics file > `--analyze` live fetch > None.
-///
-/// Why: `--analyze` must populate the complexity chart + finding bands for a
-/// bare run, but must NEVER override a hand-authored metrics JSON, and must
-/// never abort the report — an unindexed repo or an unreachable daemon simply
-/// leaves the repo at its declared/scan state.
-/// What: for each repository that has NO declared metrics AND is a local
-/// checkout (remote repos are never indexed locally), derives the index id from
-/// the checkout path and fetches via `source`; a `Some` result populates
-/// `repo.metrics`. Repos with declared metrics or no local path are skipped.
-/// Test: `report_analyze_e2e.rs` drives this against an in-process HTTP mock.
-pub async fn enrich_with_analyze(
-    model: &mut super::model::ReportModel,
-    source: &dyn AnalyzeMetricsSource,
-) {
-    let _ = enrich_with_analyze_gaps(model, source).await;
-}
-
-/// Same enrichment, returning one Gaps & Caveats line per degraded condition
-/// (#5239, DOC-67 §9).
-///
-/// Why: fail-open is the right contract and fail-SILENT is not. A findings
-/// table that renders empty because the daemon was down is indistinguishable,
-/// on the page, from a codebase with no findings — so every repository the
-/// fetch could not populate is named, grouped by reason, in the report itself.
-/// The fetch contract is unchanged: nothing here aborts, and the report still
-/// renders from the built-in scan.
-/// What: walks the same repositories [`enrich_with_analyze`] does, using
-/// [`AnalyzeMetricsSource::fetch_named`]; returns at most one line per
-/// [`AnalyzeGap`] kind and one per [`AnalyzeCaveat`] kind, each naming the
-/// affected repositories in model order so two runs over the same state produce
-/// identical lines. Repositories with a declared metrics file, and remote
-/// entries, are skipped — neither is a gap. Returns an empty vec when every
-/// eligible repository was populated completely.
-/// Test: `analyze_adapter_tests.rs::{enrich_names_unreachable_repositories,
-/// enrich_reports_no_gaps_when_every_repo_is_populated,
-/// enrich_reports_caveats_for_partially_answered_repositories}`, plus
-/// `redact_tests.rs::enrich_scrubs_configured_credentials_from_findings` for
-/// the #5323 redaction boundary.
-pub async fn enrich_with_analyze_gaps(
-    model: &mut super::model::ReportModel,
-    source: &dyn AnalyzeMetricsSource,
-) -> Vec<String> {
-    // BTreeMap, not HashMap: the rendered line order must not depend on hash
-    // iteration order (DOC-67 §9's determinism requirement).
-    let mut missing: std::collections::BTreeMap<AnalyzeGap, Vec<String>> = Default::default();
-    let mut partial: std::collections::BTreeMap<AnalyzeCaveat, Vec<String>> = Default::default();
-    // #6137: one line per repository whose index described a different checkout.
-    let mut stale: Vec<String> = Vec::new();
-
-    // #5323: daemon-authored text lands in an acquirer-facing artifact, so it
-    // crosses the redaction boundary before it reaches the model. Resolved once
-    // per enrichment, not once per repository — it touches the filesystem.
-    let secrets = super::redact::report_secrets();
-    // #6677: one registry read for the whole walk — resolution needs the
-    // daemon's `root_path` values, and they do not change mid-enrichment.
-    let indexes = source.registered_indexes().await;
-
-    for repo in &mut model.repositories {
-        // Precedence: a declared metrics file always wins.
-        if repo.metrics.is_some() {
-            continue;
-        }
-        // Only local checkouts can be served by trusty-analyze/trusty-search.
-        let Some(path) = repo.local_path.as_ref() else {
-            continue;
-        };
-        // #6677: the derived id when the daemon holds it, otherwise the index
-        // registered at this checkout's root_path; `None` only for a path that
-        // derives to nothing, which is the skip this always made.
-        let Some(index_id) = resolve_report_index(path, &indexes).into_id() else {
-            continue;
-        };
-        match source.fetch_named(&index_id).await {
-            AnalyzeFetch::Fetched {
-                mut metrics,
-                caveats,
-            } => {
-                super::redact::scrub_metrics(&mut metrics, &secrets);
-                // #6082: the daemon reports absolute paths; the report cites
-                // repository-relative ones everywhere else.
-                relativize_components(&mut metrics, path);
-                // #6137: an index addressed by directory basename can serve a
-                // DIFFERENT checkout of the same repository. Data describing
-                // another tree is stale-index evidence, never a measurement of
-                // this one.
-                match super::analyze_scope::accept(&repo.name, &index_id, path, *metrics) {
-                    Ok(m) => {
-                        repo.metrics = Some(m);
-                        for caveat in caveats {
-                            partial.entry(caveat).or_default().push(repo.name.clone());
-                        }
-                    }
-                    Err(gap) => {
-                        // #6080: the investigation pass writes into the same
-                        // `metrics` struct, so a section reporting an
-                        // analyze-only figure needs this marker to tell a
-                        // measurement from an artefact of that sharing.
-                        repo.analyze_gap =
-                            Some(super::analyze_scope::STALE_INDEX_REMEDY.to_string());
-                        stale.push(gap);
-                    }
-                }
-            }
-            AnalyzeFetch::Missing(gap) => {
-                repo.analyze_gap = Some(super::analyze_scope::NO_ANALYZE_DATA_REMEDY.to_string());
-                missing.entry(gap).or_default().push(repo.name.clone());
-            }
-        }
-    }
-
-    let mut lines: Vec<String> = missing
-        .into_iter()
-        .map(|(gap, repos)| {
-            format!(
-                "{} — no analysis pass ran for: {}. \
-                 Those applications are described from the repository scan alone; \
-                 their findings, complexity, and health factors are not assessed, \
-                 not clean.",
-                gap.as_str(),
-                repos.join(", ")
-            )
-        })
-        .collect();
-    lines.extend(
-        partial
-            .into_iter()
-            .map(|(caveat, repos)| format!("{caveat} — affects: {}.", repos.join(", "))),
-    );
-    lines.extend(stale);
-    lines
 }
 
 #[cfg(test)]

--- a/crates/trusty-review/src/report/analyze_adapter_tests.rs
+++ b/crates/trusty-review/src/report/analyze_adapter_tests.rs
@@ -9,6 +9,9 @@
 use std::path::Path;
 
 use super::*;
+// #6712: `relativize_components` was in scope through `analyze_adapter`'s own
+// import until the enrichment split took its last non-test caller.
+use crate::report::analyze_findings::relativize_components;
 
 // ─── Severity map ────────────────────────────────────────────────────────────
 
@@ -429,11 +432,78 @@ fn diagnostics_budget_outlives_the_daemon_deadline_ladder() {
              never reaches the report"
         );
     }
+    // #6712: the histogram is no longer a memory read, so it no longer sits at
+    // the probe budget. Diagnostics still outlives it, because it runs external
+    // tooling ON TOP of the corpus scan the histogram does.
     assert!(
-        AnalyzeEndpoint::Diagnostics.budget() > AnalyzeEndpoint::ComplexityDistribution.budget(),
+        AnalyzeEndpoint::Diagnostics.budget(DEFAULT_CORPUS_BUDGET)
+            > AnalyzeEndpoint::IndexList.budget(DEFAULT_CORPUS_BUDGET),
         "the endpoint that runs external tooling must not share a budget with a \
-         memory read"
+         registry read"
     );
+}
+
+/// Why (#6712): `analyze.complexity_distribution` was classed with the registry
+/// read on the premise that it answered from computed data. It does not — it
+/// pulls every chunk from trusty-search and grades it, which measures 41–46 s on
+/// the 104k-chunk trusty-tools index against a 15 s budget. So the §7 complexity
+/// table rendered `not stated in source data` on every run against a large
+/// repository, and the report credited analyze with no distribution.
+/// What: pins the classification — both corpus-scanning endpoints get the
+/// caller's budget, the probe keeps its own, and the default is at least the
+/// 180 s a repository of this size needs.
+/// Test: This is the test. Against the pre-fix `budget()` the histogram reads
+/// 15 s at every corpus budget, which is the failure the report showed.
+#[test]
+fn a_corpus_scanning_endpoint_outlives_the_probe_budget() {
+    let probe = AnalyzeEndpoint::IndexList.budget(DEFAULT_CORPUS_BUDGET);
+    assert!(
+        DEFAULT_CORPUS_BUDGET >= Duration::from_secs(180),
+        "the default must cover a 104k-chunk corpus scan measured at 41-46s, \
+         with room for a larger one: {DEFAULT_CORPUS_BUDGET:?}"
+    );
+    for endpoint in [
+        AnalyzeEndpoint::ComplexityDistribution,
+        AnalyzeEndpoint::RefactorSuggestions,
+    ] {
+        assert!(
+            endpoint.budget(DEFAULT_CORPUS_BUDGET) > probe,
+            "{}: an endpoint that grades the whole corpus must not share the \
+             readiness probe's budget",
+            endpoint.as_str()
+        );
+        // The budget is the CALLER's, not a second constant: a run that
+        // configures one must reach every corpus endpoint.
+        let configured = Duration::from_secs(600);
+        assert_eq!(endpoint.budget(configured), configured);
+    }
+    assert_eq!(
+        probe,
+        Duration::from_secs(15),
+        "a dead daemon must still be declared dead in seconds, not minutes"
+    );
+    // Raising the corpus budget past the diagnostics ladder raises diagnostics
+    // with it; leaving it at the default does not lower that ladder.
+    let huge = Duration::from_secs(86_400);
+    assert_eq!(AnalyzeEndpoint::Diagnostics.budget(huge), huge);
+    assert!(
+        AnalyzeEndpoint::Diagnostics.budget(Duration::from_secs(1))
+            >= diagnostics_budget_for(Duration::from_secs(180)),
+        "a small corpus budget must never cut the diagnostics ladder below the \
+         daemon's own deadline"
+    );
+}
+
+/// Why (#6712): a manifest or flag that says `0` means "unset", never "give up
+/// instantly" — the same reading `configured_diagnostics_deadline` already
+/// takes of its environment variable.
+/// What: absent and zero both fall back; any positive value is honoured.
+/// Test: This is the test.
+#[test]
+fn the_corpus_budget_falls_back_to_the_default() {
+    assert_eq!(corpus_budget_from_secs(None), DEFAULT_CORPUS_BUDGET);
+    assert_eq!(corpus_budget_from_secs(Some(0)), DEFAULT_CORPUS_BUDGET);
+    assert_eq!(corpus_budget_from_secs(Some(600)), Duration::from_secs(600));
 }
 
 /// A JSON-RPC result frame carrying `body`, which must itself be valid JSON.
@@ -467,6 +537,21 @@ fn rpc_error(code: i64, message: &str) -> String {
 /// `a_request_that_outlives_its_budget_is_a_timeout_not_a_transport_error`,
 /// `a_daemon_side_deadline_is_a_timeout_not_a_rejection`.
 async fn routing_stub(routes: Vec<(&'static str, String)>) -> (tempfile::TempDir, PathBuf) {
+    routing_stub_after(routes, Duration::ZERO).await
+}
+
+/// The same stub, waiting `delay` before it answers (#6712).
+///
+/// Why: the defect is an endpoint that ANSWERS, just not inside the budget it
+/// was given — a stub that either replies instantly or never replies cannot
+/// express that. `delay` is what lets a test drive the same shape the field hit
+/// at 41–46 s, at millisecond scale.
+/// Test: `a_corpus_endpoint_slower_than_the_probe_budget_still_arrives`,
+/// `the_configured_corpus_budget_is_honoured_and_named_in_the_error`.
+async fn routing_stub_after(
+    routes: Vec<(&'static str, String)>,
+    delay: Duration,
+) -> (tempfile::TempDir, PathBuf) {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
     let tmp = tempfile::TempDir::new().expect("tempdir");
@@ -486,6 +571,9 @@ async fn routing_stub(routes: Vec<(&'static str, String)>) -> (tempfile::TempDir
                     .iter()
                     .find(|(method, _)| request.contains(method))
                     .map(|(_, body)| body.clone());
+                if !delay.is_zero() {
+                    tokio::time::sleep(delay).await;
+                }
                 match reply {
                     Some(r) if r.is_empty() => std::future::pending::<()>().await,
                     Some(r) => {
@@ -640,6 +728,155 @@ async fn a_request_that_outlives_its_budget_is_a_timeout_not_a_transport_error()
     assert!(
         matches!(err, AnalyzeAdapterError::Timeout(_)),
         "expected a timeout, got {err:?}"
+    );
+    assert_eq!(classify_failure(&err), EndpointFailure::TimedOut);
+}
+
+/// How long the scripted daemon takes to grade its corpus.
+///
+/// Stands in for the 41–46 s the real one takes on a 104k-chunk index — the
+/// ratios below are what the tests assert, so the wall-clock cost stays in the
+/// hundreds of milliseconds.
+const SCRIPTED_SCAN: Duration = Duration::from_millis(300);
+
+/// Every route a full fetch needs, with the histogram body the §7 table renders.
+fn full_routes() -> Vec<(&'static str, String)> {
+    vec![
+        (
+            "analyze.list_indexes",
+            rpc_result(r#"[{"id":"demo","root_path":"/tmp/demo"}]"#),
+        ),
+        (
+            "analyze.complexity_distribution",
+            rpc_result(DISTRIBUTION_BODY),
+        ),
+        (
+            "analyze.diagnostics",
+            rpc_result(r#"{"tools_run":["clippy"],"diagnostics":[]}"#),
+        ),
+        (
+            "analyze.refactor_suggestions",
+            rpc_result(r#"{"suggestions":[]}"#),
+        ),
+    ]
+}
+
+/// Why (#6712): the histogram answers, it is just slower than the budget it was
+/// given — 41–46 s of corpus grading against 15 s — so the §7 table rendered
+/// `not stated in source data` and the report said analyze contributed no
+/// distribution. The wall-clock numbers are not what a test can assert, so this
+/// drives the same SHAPE at millisecond scale: a daemon that answers after
+/// [`SCRIPTED_SCAN`], against a budget the run configured to outlast it. The
+/// default's own headroom over the field measurement is pinned separately by
+/// `a_corpus_scanning_endpoint_outlives_the_probe_budget`.
+/// What: asserts the five bands arrive, that no caveat was raised, and that the
+/// fetch really did wait — an assertion that passes vacuously if the stub
+/// answered instantly.
+/// Test: This is the test.
+#[tokio::test]
+async fn a_corpus_endpoint_slower_than_the_probe_budget_still_arrives() {
+    let (_tmp, socket) = routing_stub_after(full_routes(), SCRIPTED_SCAN).await;
+    let src = HttpAnalyzeMetricsSource::new(socket)
+        .expect("client builds")
+        .with_corpus_budget(SCRIPTED_SCAN * 20);
+
+    let started = std::time::Instant::now();
+    let fetched = src.fetch_named("demo").await;
+    let elapsed = started.elapsed();
+
+    match fetched {
+        AnalyzeFetch::Fetched { metrics, caveats } => {
+            assert_eq!(
+                metrics.complexity.buckets.len(),
+                5,
+                "a histogram that answers slower than the probe budget must still \
+                 fill the §7 table"
+            );
+            let counted: u64 = metrics.complexity.buckets.iter().map(|b| b.count).sum();
+            assert_eq!(counted, 100, "every band the daemon sent must survive");
+            let lines = caveats
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(" | ");
+            assert!(
+                caveats.is_empty(),
+                "an endpoint that answered must raise no caveat: {lines}"
+            );
+        }
+        AnalyzeFetch::Missing(gap) => panic!("the slow endpoint answered: {gap:?}"),
+    }
+    assert!(
+        elapsed >= SCRIPTED_SCAN,
+        "the stub must actually have made the fetch wait: {elapsed:?}"
+    );
+}
+
+/// Why (#6712): the budget has to be the run's, not a constant the run cannot
+/// reach — otherwise `--analyze-timeout-secs` is decoration. And when it does
+/// run out, the error must name the budget, because "raise the deadline" is
+/// unactionable without knowing what the deadline was.
+/// What: the same slow daemon against a budget SHORTER than its scan. The fetch
+/// degrades cleanly — metrics still render from the endpoints that answered,
+/// with a caveat naming the histogram — and it gives up on the run's budget
+/// rather than on the old flat one, which the elapsed bound is what proves. The
+/// error text is read from a direct `call`, since `fetch_dataset` keeps it on
+/// stderr and out of the artifact.
+/// Test: This is the test. Pre-fix the histogram used a fixed 15 s, so the fetch
+/// answered rather than timing out and the elapsed bound blew by two orders of
+/// magnitude.
+#[tokio::test]
+async fn the_configured_corpus_budget_is_honoured_and_named_in_the_error() {
+    let budget = SCRIPTED_SCAN / 3;
+    let (_tmp, socket) = routing_stub_after(full_routes(), SCRIPTED_SCAN).await;
+    let src = HttpAnalyzeMetricsSource::new(socket)
+        .expect("client builds")
+        .with_corpus_budget(budget);
+
+    let started = std::time::Instant::now();
+    let fetched = src.fetch_named("demo").await;
+    let elapsed = started.elapsed();
+
+    match fetched {
+        AnalyzeFetch::Fetched { metrics, caveats } => {
+            assert!(
+                metrics.complexity.buckets.is_empty(),
+                "the histogram never arrived, so no band may be rendered"
+            );
+            let lines = caveats
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(" | ");
+            assert!(
+                lines.contains("complexity distribution")
+                    && lines.contains("did not answer within the time allowed"),
+                "the gap must name the endpoint and say it ran out of time: {lines}"
+            );
+        }
+        AnalyzeFetch::Missing(gap) => {
+            panic!("diagnostics and refactors answered, so the fetch stands: {gap:?}")
+        }
+    }
+    assert!(
+        elapsed < SCRIPTED_SCAN * 10,
+        "the fetch must give up on the configured budget, not on a longer \
+         constant: {elapsed:?}"
+    );
+
+    // The budget the run configured is the one the message names.
+    let err = src
+        .call::<serde_json::Value>(
+            AnalyzeEndpoint::ComplexityDistribution,
+            "demo",
+            AnalyzeEndpoint::ComplexityDistribution.budget(budget),
+        )
+        .await
+        .expect_err("a 100ms budget cannot outlast a 300ms scan");
+    let text = err.to_string();
+    assert!(
+        text.contains("analyze.complexity_distribution") && text.contains(&format!("{budget:?}")),
+        "the timeout must name the endpoint and the budget it exhausted: {text}"
     );
     assert_eq!(classify_failure(&err), EndpointFailure::TimedOut);
 }

--- a/crates/trusty-review/src/report/analyze_endpoints.rs
+++ b/crates/trusty-review/src/report/analyze_endpoints.rs
@@ -11,6 +11,15 @@
 //! and what they found. The budgets therefore live beside the paths they apply
 //! to, so adding an endpoint forces a decision about its cost.
 //!
+//! #6712: that decision was made for diagnostics alone, and every other endpoint
+//! kept the 15 s constant on the premise that it read data already computed.
+//! `analyze.complexity_distribution` does not — it pulls the whole chunk corpus
+//! from trusty-search and grades every chunk, which measures 41–46 s on a
+//! 104k-chunk index. So the endpoint that fills the §7 table timed out on every
+//! run against a large repository, and the report said the distribution was
+//! unavailable. The cost of a corpus scan is a property of the REPOSITORY, not
+//! of this client, so its budget is configurable the way the diagnostics one is.
+//!
 //! What: [`AnalyzeEndpoint`] owns the path, the report-facing name, the
 //! consequence of losing it, and the request budget. [`AnalyzeCaveat`] and
 //! [`EndpointFailure`] carry a per-endpoint failure to the report's Gaps &
@@ -18,19 +27,58 @@
 //! fetch.
 //!
 //! Test: `analyze_adapter_tests.rs::{diagnostics_budget_outlives_the_daemon_deadline_ladder,
-//! caveat_labels_are_stable}`.
+//! a_corpus_scanning_endpoint_outlives_the_probe_budget,
+//! the_corpus_budget_falls_back_to_the_default, caveat_labels_are_stable}`.
 
 use std::fmt;
 use std::time::Duration;
 
 // ─── Request budgets ─────────────────────────────────────────────────────────
 
-/// Per-request budget for the endpoints that answer from data already computed.
+/// Per-request budget for the readiness probe.
 ///
-/// Why: `/indexes`, the complexity histogram, and the refactor list are reads
-/// over an in-memory corpus and answer in seconds. A short budget on them is
-/// what keeps an unreachable daemon from stalling a report for minutes.
-const CHEAP_BUDGET: Duration = Duration::from_secs(15);
+/// Why: `analyze.list_indexes` returns a registry the daemon already holds, so
+/// it answers in milliseconds at any corpus size. Keeping it short is what stops
+/// an unreachable daemon from holding a report open for minutes before the run
+/// falls back to scan.
+///
+/// #6712: the histogram and the refactor list used to share this budget on the
+/// premise that they too read computed data. They do not — see
+/// [`DEFAULT_CORPUS_BUDGET`].
+const PROBE_BUDGET: Duration = Duration::from_secs(15);
+
+/// Per-request budget for the endpoints that scan the whole chunk corpus, when
+/// the run configures none.
+///
+/// Why: `analyze.complexity_distribution` and `analyze.refactor_suggestions`
+/// each fetch every chunk of the index from trusty-search and then grade it, so
+/// their cost scales with the repository. Measured against the trusty-tools
+/// checkout (104,433 chunks / 77,148 graded / 4,384 files) the histogram takes
+/// 41–46 s — three times the 15 s these endpoints were given, so on a large
+/// repository the §7 table was never filled (#6712). 180 s is four times the
+/// measured cost, which leaves room for a corpus several times larger, and it
+/// matches the default deadline trusty-analyze already gives its own long
+/// operation. A starting point, not a measured optimum — the manifest key
+/// `[report].analyze_timeout_secs` and the CLI's `--analyze-timeout-secs`
+/// override it.
+pub const DEFAULT_CORPUS_BUDGET: Duration = Duration::from_secs(180);
+
+/// The budget a corpus-scanning endpoint gets, from what the run configured.
+///
+/// Why: taking the configured value as a parameter is what makes the budget
+/// injectable — a test proves the ordering and the honouring at millisecond
+/// scale instead of waiting out three minutes — and it is the same shape
+/// [`diagnostics_budget_for`] takes for the same reason.
+/// What: `None` and `Some(0)` both yield [`DEFAULT_CORPUS_BUDGET`]; zero would
+/// time out every request instantly, which is never what a `0` in a manifest
+/// means.
+/// Test: `the_corpus_budget_falls_back_to_the_default`.
+#[must_use]
+pub fn corpus_budget_from_secs(configured: Option<u64>) -> Duration {
+    configured
+        .filter(|&s| s > 0)
+        .map_or(DEFAULT_CORPUS_BUDGET, Duration::from_secs)
+}
 
 /// The environment variable trusty-analyze reads for its diagnostics deadline.
 ///
@@ -175,18 +223,26 @@ impl AnalyzeEndpoint {
         }
     }
 
-    /// The per-request timeout for this endpoint.
+    /// The per-request timeout for this endpoint, given the run's `corpus`
+    /// budget.
     ///
-    /// Why: diagnostics is the one endpoint that runs external tooling — a
-    /// project-scoped `cargo clippy` — under the daemon's own deadline, so its
-    /// budget is derived from that ladder. Everything else reads memory and
-    /// keeps the short budget, which is what stops a dead daemon from holding
-    /// the report open for minutes.
-    /// Test: `diagnostics_budget_outlives_the_daemon_deadline_ladder`.
-    pub fn budget(self) -> Duration {
+    /// Why: three costs, not two (#6712). The readiness probe reads a registry
+    /// and answers in milliseconds. The histogram and the refactor list scan the
+    /// whole corpus, so their cost is the repository's and the caller supplies
+    /// it. Diagnostics additionally runs external tooling under the daemon's own
+    /// deadline, so it takes the larger of that ladder and `corpus` — a run that
+    /// raises the corpus budget for a big repository must not leave the one
+    /// endpoint that spawns `cargo clippy` on a shorter leash, and taking the
+    /// max is what keeps the #6041 ordering invariant intact while doing it.
+    /// Test: `diagnostics_budget_outlives_the_daemon_deadline_ladder`,
+    /// `a_corpus_scanning_endpoint_outlives_the_probe_budget`.
+    pub fn budget(self, corpus: Duration) -> Duration {
         match self {
-            Self::Diagnostics => diagnostics_budget_for(configured_diagnostics_deadline()),
-            _ => CHEAP_BUDGET,
+            Self::IndexList => PROBE_BUDGET,
+            Self::ComplexityDistribution | Self::RefactorSuggestions => corpus,
+            Self::Diagnostics => {
+                diagnostics_budget_for(configured_diagnostics_deadline()).max(corpus)
+            }
         }
     }
 }

--- a/crates/trusty-review/src/report/analyze_enrich.rs
+++ b/crates/trusty-review/src/report/analyze_enrich.rs
@@ -1,0 +1,155 @@
+//! Filling a built [`ReportModel`](super::model::ReportModel) from a live
+//! analyze fetch, and naming every repository the fetch could not populate.
+//!
+//! Why: split out of `analyze_adapter.rs` when #6712 pushed that file past the
+//! 500-SLOC cap. The seam it splits on is the one the module already had —
+//! everything here walks the report MODEL, while what stays behind speaks to the
+//! daemon and maps its JSON. `analyze_findings.rs` was carved off the same file
+//! on the same principle.
+//!
+//! What: [`enrich_with_analyze`] and [`enrich_with_analyze_gaps`], moved
+//! verbatim. Both are re-exported from
+//! [`super::analyze_adapter`], so every existing path to them still resolves.
+//!
+//! Test: `analyze_adapter_tests.rs::{enrich_names_unreachable_repositories,
+//! enrich_reports_no_gaps_when_every_repo_is_populated,
+//! enrich_reports_caveats_for_partially_answered_repositories}`; end to end by
+//! `tests/report_analyze_e2e.rs`.
+
+use super::analyze_adapter::{AnalyzeCaveat, AnalyzeFetch, AnalyzeGap, AnalyzeMetricsSource};
+use super::analyze_findings::relativize_components;
+use super::index_registry::resolve_report_index;
+
+/// Fill live analyze metrics into a built [`ReportModel`](crate::report::ReportModel), honouring the
+/// fail-open precedence: declared metrics file > `--analyze` live fetch > None.
+///
+/// Why: `--analyze` must populate the complexity chart + finding bands for a
+/// bare run, but must NEVER override a hand-authored metrics JSON, and must
+/// never abort the report — an unindexed repo or an unreachable daemon simply
+/// leaves the repo at its declared/scan state.
+/// What: for each repository that has NO declared metrics AND is a local
+/// checkout (remote repos are never indexed locally), derives the index id from
+/// the checkout path and fetches via `source`; a `Some` result populates
+/// `repo.metrics`. Repos with declared metrics or no local path are skipped.
+/// Test: `report_analyze_e2e.rs` drives this against an in-process HTTP mock.
+pub async fn enrich_with_analyze(
+    model: &mut super::model::ReportModel,
+    source: &dyn AnalyzeMetricsSource,
+) {
+    let _ = enrich_with_analyze_gaps(model, source).await;
+}
+
+/// Same enrichment, returning one Gaps & Caveats line per degraded condition
+/// (#5239, DOC-67 §9).
+///
+/// Why: fail-open is the right contract and fail-SILENT is not. A findings
+/// table that renders empty because the daemon was down is indistinguishable,
+/// on the page, from a codebase with no findings — so every repository the
+/// fetch could not populate is named, grouped by reason, in the report itself.
+/// The fetch contract is unchanged: nothing here aborts, and the report still
+/// renders from the built-in scan.
+/// What: walks the same repositories [`enrich_with_analyze`] does, using
+/// [`AnalyzeMetricsSource::fetch_named`]; returns at most one line per
+/// [`AnalyzeGap`] kind and one per [`AnalyzeCaveat`] kind, each naming the
+/// affected repositories in model order so two runs over the same state produce
+/// identical lines. Repositories with a declared metrics file, and remote
+/// entries, are skipped — neither is a gap. Returns an empty vec when every
+/// eligible repository was populated completely.
+/// Test: `analyze_adapter_tests.rs::{enrich_names_unreachable_repositories,
+/// enrich_reports_no_gaps_when_every_repo_is_populated,
+/// enrich_reports_caveats_for_partially_answered_repositories}`, plus
+/// `redact_tests.rs::enrich_scrubs_configured_credentials_from_findings` for
+/// the #5323 redaction boundary.
+pub async fn enrich_with_analyze_gaps(
+    model: &mut super::model::ReportModel,
+    source: &dyn AnalyzeMetricsSource,
+) -> Vec<String> {
+    // BTreeMap, not HashMap: the rendered line order must not depend on hash
+    // iteration order (DOC-67 §9's determinism requirement).
+    let mut missing: std::collections::BTreeMap<AnalyzeGap, Vec<String>> = Default::default();
+    let mut partial: std::collections::BTreeMap<AnalyzeCaveat, Vec<String>> = Default::default();
+    // #6137: one line per repository whose index described a different checkout.
+    let mut stale: Vec<String> = Vec::new();
+
+    // #5323: daemon-authored text lands in an acquirer-facing artifact, so it
+    // crosses the redaction boundary before it reaches the model. Resolved once
+    // per enrichment, not once per repository — it touches the filesystem.
+    let secrets = super::redact::report_secrets();
+    // #6677: one registry read for the whole walk — resolution needs the
+    // daemon's `root_path` values, and they do not change mid-enrichment.
+    let indexes = source.registered_indexes().await;
+
+    for repo in &mut model.repositories {
+        // Precedence: a declared metrics file always wins.
+        if repo.metrics.is_some() {
+            continue;
+        }
+        // Only local checkouts can be served by trusty-analyze/trusty-search.
+        let Some(path) = repo.local_path.as_ref() else {
+            continue;
+        };
+        // #6677: the derived id when the daemon holds it, otherwise the index
+        // registered at this checkout's root_path; `None` only for a path that
+        // derives to nothing, which is the skip this always made.
+        let Some(index_id) = resolve_report_index(path, &indexes).into_id() else {
+            continue;
+        };
+        match source.fetch_named(&index_id).await {
+            AnalyzeFetch::Fetched {
+                mut metrics,
+                caveats,
+            } => {
+                super::redact::scrub_metrics(&mut metrics, &secrets);
+                // #6082: the daemon reports absolute paths; the report cites
+                // repository-relative ones everywhere else.
+                relativize_components(&mut metrics, path);
+                // #6137: an index addressed by directory basename can serve a
+                // DIFFERENT checkout of the same repository. Data describing
+                // another tree is stale-index evidence, never a measurement of
+                // this one.
+                match super::analyze_scope::accept(&repo.name, &index_id, path, *metrics) {
+                    Ok(m) => {
+                        repo.metrics = Some(m);
+                        for caveat in caveats {
+                            partial.entry(caveat).or_default().push(repo.name.clone());
+                        }
+                    }
+                    Err(gap) => {
+                        // #6080: the investigation pass writes into the same
+                        // `metrics` struct, so a section reporting an
+                        // analyze-only figure needs this marker to tell a
+                        // measurement from an artefact of that sharing.
+                        repo.analyze_gap =
+                            Some(super::analyze_scope::STALE_INDEX_REMEDY.to_string());
+                        stale.push(gap);
+                    }
+                }
+            }
+            AnalyzeFetch::Missing(gap) => {
+                repo.analyze_gap = Some(super::analyze_scope::NO_ANALYZE_DATA_REMEDY.to_string());
+                missing.entry(gap).or_default().push(repo.name.clone());
+            }
+        }
+    }
+
+    let mut lines: Vec<String> = missing
+        .into_iter()
+        .map(|(gap, repos)| {
+            format!(
+                "{} — no analysis pass ran for: {}. \
+                 Those applications are described from the repository scan alone; \
+                 their findings, complexity, and health factors are not assessed, \
+                 not clean.",
+                gap.as_str(),
+                repos.join(", ")
+            )
+        })
+        .collect();
+    lines.extend(
+        partial
+            .into_iter()
+            .map(|(caveat, repos)| format!("{caveat} — affects: {}.", repos.join(", "))),
+    );
+    lines.extend(stale);
+    lines
+}

--- a/crates/trusty-review/src/report/manifest.rs
+++ b/crates/trusty-review/src/report/manifest.rs
@@ -243,6 +243,23 @@ pub struct ReportSection {
     /// value would dial a port nothing binds.
     #[serde(default)]
     pub analyze_socket: Option<String>,
+    /// Seconds one corpus-scanning analyze request may take (#6712).
+    ///
+    /// Why: `analyze.complexity_distribution` grades every chunk of the index,
+    /// so its cost belongs to the repository — 41–46 s on a 104k-chunk checkout,
+    /// against the 15 s the endpoint used to be given, which is why the §7 table
+    /// rendered unavailable on every large repository. A manifest describes one
+    /// engagement's repositories, so it is the right place to say how long
+    /// theirs need.
+    /// What: applies to the complexity histogram and the refactor list, and
+    /// raises the diagnostics budget when it exceeds that endpoint's own ladder.
+    /// The readiness probe keeps its short budget either way. Absent or `0`
+    /// yields [`crate::report::analyze_endpoints::DEFAULT_CORPUS_BUDGET`].
+    /// Precedence: the CLI's `--analyze-timeout-secs` wins when set; otherwise
+    /// this key; otherwise the default.
+    /// Test: `manifest_tests.rs::parse_analyze_timeout_secs`.
+    #[serde(default)]
+    pub analyze_timeout_secs: Option<u64>,
 }
 
 /// The weight the FIRST unweighted `inspect_priority` entry receives (#6078).

--- a/crates/trusty-review/src/report/manifest_tests.rs
+++ b/crates/trusty-review/src/report/manifest_tests.rs
@@ -222,6 +222,33 @@ fn parse_ticketing_path() {
     );
 }
 
+/// Why (#6712): the corpus-scan budget is a property of the repositories a
+/// manifest describes, so an engagement over a large checkout declares it once
+/// here rather than passing a flag on every run.
+/// What: the key parses onto `[report]`, and its absence stays `None` so the
+/// default applies.
+/// Test: this test itself.
+#[test]
+fn parse_analyze_timeout_secs() {
+    let m = parse_manifest(
+        "[report]\ntitle = \"T\"\nanalyze_timeout_secs = 600\n\n\
+         [[repositories]]\nname = \"A\"\npath = \"/x\"\n",
+        Path::new("m.toml"),
+    )
+    .expect("parses");
+    assert_eq!(m.report.analyze_timeout_secs, Some(600));
+
+    let none = parse_manifest(
+        "[report]\ntitle = \"T\"\n\n[[repositories]]\nname = \"A\"\npath = \"/x\"\n",
+        Path::new("m.toml"),
+    )
+    .expect("parses");
+    assert!(
+        none.report.analyze_timeout_secs.is_none(),
+        "absent key defaults to None, which is what selects DEFAULT_CORPUS_BUDGET"
+    );
+}
+
 /// Why: `inspect_priority` is the interface trusty-audit writes its selection
 /// ranking to, and it must accept both a bare path list (hand-written) and a
 /// weighted table (generated) without a second key.

--- a/crates/trusty-review/src/report/mod.rs
+++ b/crates/trusty-review/src/report/mod.rs
@@ -14,6 +14,9 @@
 //! lives in `crates/trusty-review/tests/report_e2e.rs`.
 
 pub mod analyze_adapter;
+/// Filling a built model from a live analyze fetch (split from
+/// `analyze_adapter` under the SLOC cap, #6712).
+pub mod analyze_enrich;
 // #6041: per-endpoint paths, request budgets, and partial-fetch vocabulary.
 pub mod analyze_endpoints;
 // #6082: the per-finding half of the analyze mapping, split out under the cap.

--- a/crates/trusty-review/src/report/run.rs
+++ b/crates/trusty-review/src/report/run.rs
@@ -72,6 +72,9 @@ pub struct ReportRequest {
     pub no_mermaid: bool,
     /// Populate metrics deterministically from the trusty-analyze daemon.
     pub analyze: bool,
+    /// Seconds one corpus-scanning analyze request may take; `None` defers to
+    /// the manifest key then the default (#6712).
+    pub analyze_timeout_secs: Option<u64>,
 }
 
 impl ReportRequest {
@@ -91,6 +94,7 @@ impl ReportRequest {
             benchmark: false,
             no_mermaid: false,
             analyze: false,
+            analyze_timeout_secs: None,
         }
     }
 }
@@ -208,7 +212,7 @@ pub async fn run_report(config_path: Option<&Path>, req: &ReportRequest) -> Resu
     // the live metrics).  Fully fail-open — populates only local-path repos that
     // declared no metrics, and only when their index is served.
     if req.analyze {
-        enrich_from_analyze(&mut model, &manifest, &config).await;
+        enrich_from_analyze(&mut model, req, &manifest, &config).await;
     }
 
     // LLM synthesis plus the repo-evidence investigation. #5454: required, so a
@@ -401,20 +405,47 @@ fn flag_is_truthy(raw: &str) -> bool {
     )
 }
 
+/// The per-request budget the corpus-scanning analyze endpoints get (#6712).
+///
+/// Why: a free function so the precedence is tested directly rather than
+/// restated inside the fetch, exactly as `resolve_code_only_from` is.
+/// What: the request's value, else the manifest's, else the default; a `0` at
+/// either tier reads as absent, since zero would time out every request.
+/// Test: `run_tests::the_request_analyze_timeout_beats_the_manifest`.
+fn resolve_analyze_budget(req: &ReportRequest, manifest: &Manifest) -> std::time::Duration {
+    crate::report::analyze_endpoints::corpus_budget_from_secs(
+        req.analyze_timeout_secs
+            .or(manifest.report.analyze_timeout_secs),
+    )
+}
+
 /// Run the opt-in deterministic analyze fetch, recording what it could not
 /// reach (#2445, #5239).
-async fn enrich_from_analyze(model: &mut ReportModel, manifest: &Manifest, config: &ReviewConfig) {
+///
+/// #6712: the corpus-scanning endpoints take their per-request budget from
+/// `--analyze-timeout-secs`, else the manifest's `[report].analyze_timeout_secs`,
+/// else the default — the same request-beats-manifest precedence `--code-only`
+/// and `--no-mermaid` already follow.
+/// Test: `run_tests::the_request_analyze_timeout_beats_the_manifest`.
+async fn enrich_from_analyze(
+    model: &mut ReportModel,
+    req: &ReportRequest,
+    manifest: &Manifest,
+    config: &ReviewConfig,
+) {
     let analyze_socket = manifest
         .report
         .analyze_socket
         .clone()
         .map_or_else(|| config.analyzer_socket.clone(), std::path::PathBuf::from);
+    let corpus_budget = resolve_analyze_budget(req, manifest);
     eprintln!(
-        "[trusty-review report] --analyze: fetching over {}",
+        "[trusty-review report] --analyze: fetching over {} (corpus endpoints allowed {corpus_budget:?} each)",
         analyze_socket.display()
     );
     match crate::report::HttpAnalyzeMetricsSource::new(analyze_socket) {
         Ok(source) => {
+            let source = source.with_corpus_budget(corpus_budget);
             // #5239: every repo the fetch could not populate is named in the
             // report, not only warned about on stderr — a dimension missing
             // because the daemon was down must not read as a clean pass.

--- a/crates/trusty-review/src/report/run_tests.rs
+++ b/crates/trusty-review/src/report/run_tests.rs
@@ -219,6 +219,7 @@ fn defaults_match_the_cli() {
     assert!(!req.no_mermaid);
     assert!(req.template.is_none());
     assert!(req.corpus.is_none());
+    assert!(req.analyze_timeout_secs.is_none());
 }
 
 // ── Corpus and budget precedence ─────────────────────────────────────────────
@@ -232,6 +233,45 @@ fn the_explicit_corpus_beats_the_manifest() {
     req.corpus = Some(PathBuf::from("/tmp/corpus"));
     let dir = resolve_corpus_dir(&req, &manifest_with("")).expect("resolve");
     assert_eq!(dir, PathBuf::from("/tmp/corpus"));
+}
+
+/// Why (#6712): the corpus-scan budget has three tiers, and a flag that loses to
+/// the manifest is worse than no flag — an operator raising it on a slow run
+/// would see nothing change.
+/// What: the request wins; the manifest fills an unset request; neither set
+/// yields the default, and a `0` at either tier reads as unset.
+/// Test: this test itself.
+#[test]
+fn the_request_analyze_timeout_beats_the_manifest() {
+    use crate::report::analyze_endpoints::DEFAULT_CORPUS_BUDGET;
+    use std::time::Duration;
+
+    let mut req = ReportRequest::new("m.toml");
+    req.analyze_timeout_secs = Some(600);
+    let manifest = manifest_with("analyze_timeout_secs = 30");
+    assert_eq!(
+        resolve_analyze_budget(&req, &manifest),
+        Duration::from_secs(600),
+        "the flag wins over the manifest key"
+    );
+
+    let bare = ReportRequest::new("m.toml");
+    assert_eq!(
+        resolve_analyze_budget(&bare, &manifest),
+        Duration::from_secs(30),
+        "the manifest key fills an unset flag"
+    );
+    assert_eq!(
+        resolve_analyze_budget(&bare, &manifest_with("")),
+        DEFAULT_CORPUS_BUDGET,
+        "neither tier set leaves the default, which is what a 104k-chunk corpus \
+         scan needs"
+    );
+    assert_eq!(
+        resolve_analyze_budget(&bare, &manifest_with("analyze_timeout_secs = 0")),
+        DEFAULT_CORPUS_BUDGET,
+        "zero means unset, never give up instantly"
+    );
 }
 
 /// Why: the investigation budget resolves in the order request, manifest,


### PR DESCRIPTION
## Outcome
Refs #6712, #6691, #6669. `analyze.complexity_distribution` and `analyze.refactor_suggestions` scan the whole corpus (35–60 s on the 104k-chunk trusty-tools index) but shared the 15 s readiness-probe budget, so the CAST report never received analyze metrics on a repo this size (regression of #6041's class, which fixed Diagnostics only). Now: `PROBE_BUDGET` 15 s for `IndexList` only; corpus endpoints get a configurable budget, default 180 s (`--analyze-timeout-secs` > `[report].analyze_timeout_secs` > default); Diagnostics keeps #6041's ladder, never lowered. Elapsed and budget logged at INFO; the timeout error names the budget; a timeout still degrades to a named caveat.

## Changes
trusty-review only: analyze_endpoints.rs, analyze_adapter.rs (+ new analyze_enrich.rs split to stay under the 500-SLOC cap, verbatim move, re-exported), cli_report.rs, manifest.rs, run.rs, tests, changelog fragment `6712-analyze-timeout-budget.md`. trusty-review is 0.32.1 unpublished on main; no bump.

## Risk
Normal. Fail-closed on timeout as before (`EndpointFailure::TimedOut` → Gaps & Caveats line, never a partial dataset).

## Tests
Rung 3 `-p trusty-review`: fmt, check, clippy -D warnings, `cargo test --no-fail-fast` 2146 lib + 13 targets, 0 failed. Regression tests shown failing pre-fix: `a_corpus_scanning_endpoint_outlives_the_probe_budget`, `the_configured_corpus_budget_is_honoured_and_named_in_the_error`; plus `the_corpus_budget_falls_back_to_the_default`, `a_corpus_endpoint_slower_than_the_probe_budget_still_arrives`. Live CAST run on the main checkout: complexity 35 s / diagnostics 56 s / refactors 39 s all answered under 180/270 s; Code Quality cell renders `A: 68618 (89%); B: 5241 (7%); C: 1836 (2%); D: 720 (1%); F: 733 (1%)` and the prose agrees with it. Doc gates: test-pointers 0 dangling, line-cap 0 violations, changelog-fragment OK, check-pr-version-bump clear.

## Baseline
None.

## Docs
Changelog fragment; manifest key and CLI flag documented in their help text.

## Review
code-critic APPROVE, no findings at >80% confidence; noted that `--analyze-timeout-secs 0` falls to the default rather than the manifest value, consistent with the documented "0 means unset" contract.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
