### PR TITLE
commit tm-trusty-tools-02 pause snapshot 2026-09-03 07:51Z

### DIFF
--- a/.trusty-mpm/sessions/sessions-log.jsonl
+++ b/.trusty-mpm/sessions/sessions-log.jsonl
@@ -80,3 +80,4 @@
 {"session_id":"tm-trusty-tools-02-0-at2307-20260902","event":"pause","snapshot":"tm-trusty-tools-02-0-at2307-20260902/session-20260902-162807.md","timestamp":"2026-09-02T16:28:07.264636+00:00"}
 {"session_id":"tm-trusty-tools-02-0-at5288-20260902","event":"pause","snapshot":"tm-trusty-tools-02-0-at5288-20260902/session-20260902-210316.md","timestamp":"2026-09-02T21:03:16.995522+00:00"}
 {"session_id":"tm-trusty-tools-02-0-at5288-20260902","event":"pause","snapshot":"tm-trusty-tools-02-0-at5288-20260902/session-20260903-022128.md","timestamp":"2026-09-03T02:21:28.822853+00:00"}
+{"session_id":"tm-trusty-tools-02-0-at5288-20260902","event":"pause","snapshot":"tm-trusty-tools-02-0-at5288-20260902/session-20260903-075149.md","timestamp":"2026-09-03T07:51:49.975689+00:00"}

--- a/.trusty-mpm/sessions/tm-trusty-tools-02-0-at5288-20260902/session-20260903-075149.md
+++ b/.trusty-mpm/sessions/tm-trusty-tools-02-0-at5288-20260902/session-20260903-075149.md
@@ -1,0 +1,43 @@
+# Session Pause - 2026-09-03T07:51:49.975689+00:00
+
+## Summary
+Paused 2026-09-03 ~08:0xZ, owner-invoked, leg 6 (resumed 02:3xZ from session-20260903-022128.md). Main checkout still parked on codex/documentation-inventory-2026-09-02 @ 1e4c2397f (do NOT commit or checkout there). origin/main = 7616cb4bc (#6713). OWNER DIRECTIVE this leg (03:0xZ, verbatim): "continue fixing bugs, getting log drain to work, p1 issues, let's get to under 200 open issues"; then "Then let's work on the mpm/code dashboard that's spec'd"; then "build me an audit package specifically for FLYR…"; then "confirm that taudit updates to the latest versions of the tools." OPEN ISSUES 275 (288 at scan; target <200). LOG DRAIN WORKING (config-only fix: config.yaml github_id→owner/project; 6 destinations, 188 files, 0 failures; #6657 closed). BUG WAVE: 12 claimed bugs all merged (#6705 #6708 #6709 #6710) + #6706 assembly + #6707 runbook scrub + #6713 (#6712 analyze budget); CLOSED status:tested: #6657 #6678 #6568 #6556 #6118 #812 #5973 #6660 #6668 #6671 #6663 #6667 #6661 #6675. INSTALLED + signed from 1a64db697: tm 1.5.17 (daemon pid 62526), trusty-review 0.32.1, trusty-console 0.10.1 (pid 98733), trusty-memory 0.25.7 (pid 39940); #6713 (review analyze budget) merged AFTER that install → trusty-review needs reinstall. TWO AGENTS LIVE AT PAUSE — VERIFY ARTIFACTS DIRECTLY, never re-dispatch: (1) rust-engineer aa6f13b5a938a062c, worktree agent-aa6f13b5a938a062c: told to fix two broken intra-doc links at crates/trusty-review/src/report/mod.rs:17 (`super::model::ReportModel`, `super::analyze_adapter`, left by #6713's analyze_enrich split; main's rustdoc-links job is RED because of them) on NEW branch fix/6712-doc-links off main, commit, no push → then security scan → version-control push + PR rung 1 + auto-merge. (2) rust-engineer a34fddc31417ea4bc, worktree agent-a34fddc31417ea4bc, branch fix/6507-prune-pr-state-visibility: #6507 follow-on — WARN tracing on pr_state_for_branch fallback failure, per-candidate blocked reason in the --merged-prs report, and the real gate-5 cause for worktree agent-aaa8224037483f135 (squash-merged #6705, remote head deleted); regression test; no bump (1.5.17 unpublished) → critic (High, guard/prune) → scan → PR. FLYR package delivered ~/Projects/Audit/FLYR-audit.zip sha256 f00725da…; Matt generic package delivered (sha256 64f9e135…); taudit installs EXACT pins (never latest); pins = latest published today. Runbook client-name scrub merged (#6707). DOC-73 dashboard (#6611): nothing implemented; phase-1 dep #3157 closed not-planned; awaiting owner on §10 Q1–Q8. New issues filed: #6711 (parity_claude_config_get flake), #6712 (analyze budget; merged). Unpublished on main: trusty-audit 0.13.2, trusty-review 0.32.1, trusty-mpm 1.5.17, trusty-console 0.10.1, trusty-memory 0.25.7 — publish needs owner authorization.
+
+## Completed
+- #6703 audit 0.13.2 bump + handoff step 2 merged; #6704 snapshot merged
+- Log drain working: config.yaml fix, daemon restart, S3 evidence; #6657 closed status:tested; feat/6657 held worktree retired (branch kept local)
+- Matt handoff package rebuilt from #6703 main and delivered (sha256 64f9e135…)
+- FLYR audit package built and delivered ~/Projects/Audit/FLYR-audit.zip (sha256 f00725da…) with instructions.md; runbook client-name scrub PR #6707 merged
+- Backlog scan (288/288), closed-milestone triage (172), epic decision map (36 groups; 15 CLOSE groups = 67 issues → 197)
+- #6705 CI gates (#6695 release-window path, #5973 rustdoc-links job) merged; #6706 audit changelog assembly merged; #5973 closed tested
+- #6708 trusty-review 0.32.1 (#6691 #6675) merged; #6709 flakes (#6671 #6663 #6667 #6661; mpm 1.5.17, console 0.10.1, memory 0.25.7) merged; #6710 gh-token drop + pm_guard unclassifiable guard (#6668 #6660; critic BLOCK→APPROVE) merged; #6713 analyze budget (#6712) merged
+- Rebuilt + signed-installed from 1a64db697: tm 1.5.17, trusty-review 0.32.1, trusty-console 0.10.1, trusty-memory 0.25.7 (connection-safe, no orphans)
+- Closed status:tested: #6678 #6568 #6556 #6118 #812 #6660 #6668 #6671 #6663 #6667 #6661 #6675 (+#6657 #5973)
+- taudit update semantics confirmed for owner: exact pins, never latest; pins current
+- Filed #6711 (parity flake), #6712 (analyze budget)
+
+## In Progress
+- [rust-engineer aa6f13b5a938a062c] docs-only fix of the two broken intra-doc links (report/mod.rs:17) on branch fix/6712-doc-links off main — commit expected, not pushed; main rustdoc-links job RED until it lands
+- [rust-engineer a34fddc31417ea4bc] #6507 follow-on on fix/6507-prune-pr-state-visibility: fallback tracing + per-candidate blocked reason + real gate-5 cause; not yet reported
+- [PM] #6691 at status:merged: with real analyze data (after #6713) the prose agreed with the table in two live runs; drop-side covered by 9 unit tests — close as tested after trusty-review is reinstalled from 7616cb4bc and one more CAST run confirms
+- [PM] #6712 at status:merged: live-verify after reinstall (CAST run renders distribution under 180 s)
+- [PM] #6695 at status:merged: needs a src+assembly PR to exercise the release-window path (next cut)
+- [PM] #6507 at status:merged: live case = worktree agent-aaa8224037483f135 (KEEP until verified)
+
+## Next Steps
+- Verify both live agents' artifacts (SendMessage by id; git log in their worktrees); never re-dispatch duplicates
+- Doc-links PR: scan → version-control push + PR (rung 1, docs-only) + auto-merge → main rustdoc-links green
+- #6507 PR: critic (High) → scan → PR → merge → reinstall tm → live `tm session prune-worktrees --merged-prs --dry-run` must list agent-aaa8224037483f135 → close #6507 tested → remove that worktree
+- Reinstall trusty-review from main after the doc-links PR merges (cargo install --path, ad-hoc sign) → CAST run on main checkout → close #6691 and #6712 tested
+- OWNER RULINGS PENDING: (1) close #2555 #3411 #2591 #2592 #3890 (evidence in scratchpad/closed-milestone-triage.md); (2) which of the 15 CLOSE groups (67 issues, scratchpad/epic-decision-map.md) close not-planned — all 15 → 197; (3) DOC-73 §10 Q1–Q8 (recommend spec defaults + reopen #3157); (4) scrub client name from 5 tracked session snapshots; (5) `tm doctor --fix-skills --include-frozen` (2 frozen hand-edited skills); (6) promote 'Rustdoc intra-doc links' to a required context (evidence: #6713 merged red); (7) publish authorization for the 5 unpublished crates
+- Stale debug trusty-memory processes from reclaimed worktrees (pids 13052-13055, 13203, 13258, 17885) — local-ops sweep when convenient
+- Do NOT re-run installs, the FLYR/Matt package builds, or closures already recorded; check state first
+- Held worktrees: agent-a259bfb3 (locked, unknown owner), agent-addd80fd (PR #6607 owner review), agent-aaa8224037483f135 (#6507 live case)
+
+## Git Context
+Branch: codex/documentation-inventory-2026-09-02
+Last commit: 1e4c2397f docs: refresh workspace documentation inventory
+Uncommitted changes: clean
+
+## Tmux Window
+tm-trusty-tools-02:0:@5288


### PR DESCRIPTION
## Outcome
Commit the session pause snapshot for tm-trusty-tools-02 (2026-09-03 07:51Z) and its log line so other sessions can resume from it.

## Changes
- `.trusty-mpm/sessions/tm-trusty-tools-02-0-at5288-20260902/session-20260903-075149.md` — new session snapshot
- `.trusty-mpm/sessions/sessions-log.jsonl` — appended log line for the new pause

## Risk
None — this is a documentation-only record of session state.

## Tests
n/a docs-only

## Baseline
None — no pre-existing red gates.

## Docs
This is the record itself.

## Review
None — docs-only snapshot commit.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
