### PR TITLE
fix(trusty-mpm): prune --merged-prs reclaims multi-commit squash merges and names why a candidate is blocked

### DIFF
--- a/crates/trusty-mpm/changelog.d/6507-prune-pr-state-visibility.md
+++ b/crates/trusty-mpm/changelog.d/6507-prune-pr-state-visibility.md
@@ -1,0 +1,4 @@
+Fixed
+
+- `tm session prune-worktrees --merged-prs` reclaims a worktree whose branch squash-merged from two or more commits. The previous fix compared patch ids one commit at a time, and a squash carries the union of the branch's patches, so it matched none of them and the unsaved-work gate reported the landed work as unsaved (#6507).
+- The merged-PR pass discloses every non-reclaimable candidate as `<path>: blocked at <gate>: <reason>`, and a failed per-branch `gh pr list` logs at WARN with the branch, the repository, and the resolved `gh` identity. Only the agent-ownership gate's refusals were visible before (#6507).

--- a/crates/trusty-mpm/changelog.d/6507-prune-pr-state-visibility.md
+++ b/crates/trusty-mpm/changelog.d/6507-prune-pr-state-visibility.md
@@ -1,4 +1,4 @@
 Fixed
 
 - `tm session prune-worktrees --merged-prs` reclaims a worktree whose branch squash-merged from two or more commits. The previous fix compared patch ids one commit at a time, and a squash carries the union of the branch's patches, so it matched none of them and the unsaved-work gate reported the landed work as unsaved (#6507).
-- The merged-PR pass discloses every non-reclaimable candidate as `<path>: blocked at <gate>: <reason>`, and a failed per-branch `gh pr list` logs at WARN with the branch, the repository, and the resolved `gh` identity. Only the agent-ownership gate's refusals were visible before (#6507).
+- The merged-PR pass names why every non-reclaimable candidate was refused, each candidate exactly once: a tree a dispatched agent holds keeps its agent-skip line, and every other refusal reads `<path>: blocked at <gate>: <reason>`. A failed per-branch `gh pr list` logs at WARN with the branch, the repository, and the resolved `gh` identity. Only the agent-ownership gate's refusals were visible before (#6507).

--- a/crates/trusty-mpm/src/bin/tm/commands/managed_merged_prs.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed_merged_prs.rs
@@ -176,6 +176,14 @@ fn diagnostic_lines(merged: &serde_json::Value) -> Vec<String> {
     for s in strings("removal_failed") {
         out.push(format!("  removal FAILED (still on disk): {s}"));
     }
+    // #6507: every candidate the survey refused, naming the gate. The three
+    // families above disclose only what happened AFTER classification, so a
+    // worktree refused during classification by any gate but 4 appeared
+    // nowhere — which is why one merged, clean worktree read as simply absent
+    // from the report for three verification passes running.
+    for s in strings("blocked_reasons") {
+        out.push(format!("  {s}"));
+    }
     out
 }
 

--- a/crates/trusty-mpm/src/bin/tm/commands/managed_merged_prs_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed_merged_prs_tests.rs
@@ -103,6 +103,35 @@ fn merged_pr_pass_diagnostics_keep_their_kinds_apart() {
     assert!(lines[2].contains("removal FAILED"), "{}", lines[2]);
 }
 
+/// Every refused candidate reaches the operator, naming its gate (#6507).
+///
+/// Why: the three families above disclose only what happened AFTER
+/// classification. A worktree refused DURING classification by any gate but 4
+/// appeared in no line at all, so `--merged-prs --dry-run` printed
+/// `0 worktree(s) reclaimable` and nothing about the tree it had just refused.
+#[test]
+fn merged_pr_pass_names_the_gate_that_blocked_each_candidate() {
+    let body = serde_json::json!({
+        "spared_agent_owned": [],
+        "refused_at_recheck": [],
+        "removal_failed": [],
+        "blocked_reasons": [
+            "/repo/.claude/worktrees/agent-aaa: blocked at gate 6 (unsaved work): \
+             holds unsaved work: 0 uncommitted/untracked file(s), 2 unpushed commit(s)",
+        ],
+    });
+    let lines = diagnostic_lines(&body);
+    assert_eq!(lines.len(), 1, "{lines:?}");
+    assert!(
+        lines[0].contains("blocked at gate 6 (unsaved work)"),
+        "{}",
+        lines[0]
+    );
+    assert!(lines[0].contains("agent-aaa"), "{}", lines[0]);
+    // The summary line the operator already reads must be untouched by it.
+    print_merged_pr_pass(Some(&body), true);
+}
+
 #[test]
 fn merged_pr_pass_diagnostics_tolerate_absent_and_malformed_keys() {
     // An older daemon omits the key entirely; a malformed one sends a non-array

--- a/crates/trusty-mpm/src/daemon/doctor_worktree_disk_tests.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_worktree_disk_tests.rs
@@ -11,7 +11,9 @@
 use std::path::PathBuf;
 
 use super::*;
-use crate::session_manager::worktree_reclaim::{BranchPrState, ReclaimCandidate, ReclaimVerdict};
+use crate::session_manager::worktree_reclaim::{
+    BranchPrState, ReclaimCandidate, ReclaimGate, ReclaimVerdict,
+};
 
 /// Build a survey holding `candidates`, with the totals derived the same way
 /// the real survey derives them.
@@ -82,6 +84,7 @@ fn worktree_disk_check_warns_when_bytes_are_reclaimable() {
             Some(2 * 1024 * 1024 * 1024),
             BranchPrState::Open { pr: 9 },
             ReclaimVerdict::Blocked {
+                gate: ReclaimGate::PrState,
                 reason: "PR #9 is still open".into(),
             },
         ),
@@ -108,6 +111,7 @@ fn worktree_disk_check_is_unknown_when_no_pr_state_resolved() {
             Some(1024),
             BranchPrState::Unknown,
             ReclaimVerdict::Blocked {
+                gate: ReclaimGate::PrState,
                 reason: "unknown".into(),
             },
         ),
@@ -115,6 +119,7 @@ fn worktree_disk_check_is_unknown_when_no_pr_state_resolved() {
             Some(2048),
             BranchPrState::Unknown,
             ReclaimVerdict::Blocked {
+                gate: ReclaimGate::PrState,
                 reason: "unknown".into(),
             },
         ),
@@ -133,6 +138,7 @@ fn worktree_disk_check_is_ok_when_nothing_is_reclaimable() {
         Some(3 * 1024 * 1024),
         BranchPrState::Open { pr: 3 },
         ReclaimVerdict::Blocked {
+            gate: ReclaimGate::PrState,
             reason: "PR #3 is still open".into(),
         },
     )]);
@@ -151,6 +157,7 @@ fn worktree_disk_check_is_unknown_when_the_walk_is_incomplete() {
             Some(1024),
             BranchPrState::Open { pr: 1 },
             ReclaimVerdict::Blocked {
+                gate: ReclaimGate::PrState,
                 reason: "open".into(),
             },
         ),
@@ -158,6 +165,7 @@ fn worktree_disk_check_is_unknown_when_the_walk_is_incomplete() {
             None,
             BranchPrState::Open { pr: 2 },
             ReclaimVerdict::Blocked {
+                gate: ReclaimGate::PrState,
                 reason: "open".into(),
             },
         ),
@@ -183,6 +191,7 @@ fn worktree_disk_check_flags_an_undercounted_total() {
             Some(1024),
             BranchPrState::Open { pr: 1 },
             ReclaimVerdict::Blocked {
+                gate: ReclaimGate::PrState,
                 reason: "open".into(),
             },
         ),
@@ -190,6 +199,7 @@ fn worktree_disk_check_flags_an_undercounted_total() {
             None,
             BranchPrState::Open { pr: 2 },
             ReclaimVerdict::Blocked {
+                gate: ReclaimGate::PrState,
                 reason: "open".into(),
             },
         ),

--- a/crates/trusty-mpm/src/daemon/managed_routes/prune.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/prune.rs
@@ -330,6 +330,13 @@ pub(crate) async fn prune_worktrees_core(
                         // protected a live agent's tree was indistinguishable
                         // from one that found nothing to reclaim.
                         "spared_agent_owned": o.survey.agent_owned,
+                        // #6507: one line per non-reclaimable candidate naming
+                        // the GATE that refused it. Without it a plain
+                        // `Blocked` — every gate but 4 — appears in no field of
+                        // this reply and in no log line, which is how a merged,
+                        // clean worktree sat unreclaimed with nothing saying
+                        // why.
+                        "blocked_reasons": o.survey.blocked_reasons,
                         "reclaimable": o.survey.reclaimable,
                         "reclaimable_measured": o.survey.reclaimable_measured,
                         "reclaimable_bytes": o.survey.reclaimable_bytes,

--- a/crates/trusty-mpm/src/session_manager/mod.rs
+++ b/crates/trusty-mpm/src/session_manager/mod.rs
@@ -64,6 +64,8 @@ pub(crate) mod worktree_reclaim;
 // #6561: the `gh` runner `worktree_reclaim` calls, which reports WHY a lookup
 // failed instead of collapsing every failure into an unexplained unknown.
 pub(crate) mod worktree_reclaim_gh;
+// #6507: the verdict vocabulary, including which GATE refused a candidate.
+pub(crate) mod worktree_reclaim_verdict;
 // #4732: the tri-state "does git still hold state here?" classifier that gates
 // every raw directory removal on the worktree teardown path.
 mod worktree_protection;

--- a/crates/trusty-mpm/src/session_manager/worktree_git_fixture.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_git_fixture.rs
@@ -238,6 +238,35 @@ impl GitWorktreeFixture {
         git_ok(&self.repo, &["fetch", "--prune", "origin"]);
     }
 
+    /// Commit `files` as SEPARATE commits in `wt`, then squash-merge the branch
+    /// to `origin/main` and prune the refs that made them reachable (#6507).
+    ///
+    /// Why: [`Self::squash_merge_to_origin`] lands ONE commit, and one commit is
+    /// the only case a patch-id comparison per commit can clear — the squash
+    /// carries that commit's patch unchanged. Every real pull request with two
+    /// or more commits produces a squash whose patch matches none of them
+    /// individually, which is the shape PR #6705 was in when
+    /// `prune-worktrees --merged-prs` refused its worktree on 2026-09-03.
+    /// What: one commit per entry in `files`, then `merge --squash` +
+    /// `commit` + `push` on `main` in the owning checkout, then a pruning
+    /// fetch. The branch is never pushed, so it has no upstream — the same
+    /// pruned shape, with a divergence of more than one commit.
+    /// Test: `inspect_dirt_clears_a_two_commit_squash_merge`,
+    /// `survey_reclaims_a_worktree_whose_two_commits_squash_merged_as_one`.
+    pub(crate) fn squash_merge_commits_to_origin(&self, wt: &Path, files: &[&str]) {
+        let branch = git_stdout_ok(wt, &["rev-parse", "--abbrev-ref", "HEAD"]);
+        for file in files {
+            std::fs::write(wt.join(file), format!("landed content of {file}\n"))
+                .expect("fixture: write file");
+            git_ok(wt, &["add", file]);
+            git_ok(wt, &["commit", "-m", &format!("feat: {file}")]);
+        }
+        git_ok(&self.repo, &["merge", "--squash", branch.trim()]);
+        git_ok(&self.repo, &["commit", "-m", "feat: squashed work (#6705)"]);
+        git_ok(&self.repo, &["push", "origin", "main"]);
+        git_ok(&self.repo, &["fetch", "--prune", "origin"]);
+    }
+
     /// Commit `file` in `wt`, PUSH that commit under `remote_branch`, and ALSO
     /// squash-merge its patch onto `origin/main` (#6507).
     ///

--- a/crates/trusty-mpm/src/session_manager/worktree_reclaim.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_reclaim.rs
@@ -46,6 +46,10 @@ use super::worktree_reclaim_gh::{
 };
 use super::worktree_registry::{Admission, HarnessLockState, harness_lock_state};
 use super::worktree_safety::DirtyWorktree;
+// #6507: the verdict vocabulary lives next door so this file stays under the
+// SLOC cap; the re-export keeps every call site (and `super::*` in the tests)
+// unchanged.
+pub(crate) use super::worktree_reclaim_verdict::{ReclaimGate, ReclaimVerdict};
 
 /// Resolves the delegation registry's answer for the agent a sentinel names.
 ///
@@ -422,9 +426,24 @@ pub(crate) fn pr_state_for_branch(registry_root: &Path, branch: &str) -> BranchP
         .args(["--json", PR_JSON_FIELDS]);
     match run_with_timeout(cmd, GH_TIMEOUT) {
         Ok(stdout) => PrIndex::from_json(&stdout, PER_BRANCH_LIMIT).state_for(Some(branch)),
-        Err(reason) => BranchPrState::LookupFailed {
-            reason: format!("{reason} (resolved gh identity: {identity})"),
-        },
+        Err(reason) => {
+            // #6507: WARN, matching `PrIndex::from_gh`. This arm used to be
+            // silent at every level, so a per-branch failure — the path this
+            // repository's 4526-PR history forces every older branch through —
+            // left no trace in the log at all and the survey reported only a
+            // count.
+            tracing::warn!(
+                root = %registry_root.display(),
+                branch = %branch,
+                reason = %reason,
+                identity = %identity,
+                "worktree-reclaim: the per-branch pull-request lookup failed — this \
+                 branch will block, and the survey reports this reason (#6507)"
+            );
+            BranchPrState::LookupFailed {
+                reason: format!("{reason} (resolved gh identity: {identity})"),
+            }
+        }
     }
 }
 
@@ -582,60 +601,6 @@ pub(crate) fn agent_ownership_blocks(
 /// Test: `survey_separates_deadline_skips_from_lookup_failures`.
 pub(crate) const NOT_INSPECTED_REASON: &str = "survey deadline reached before inspection";
 
-/// Whether a worktree may be reclaimed, or the first reason it may not (#2919).
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub(crate) enum ReclaimVerdict {
-    /// Every gate passed; the named pull request is the landing evidence.
-    Reclaimable {
-        /// The merged pull request that proves the branch's work landed.
-        pr: u64,
-    },
-    /// Refused — `reason` names the FIRST gate that said no.
-    Blocked {
-        /// Operator-facing explanation of the refusal.
-        reason: String,
-    },
-    /// Refused by gate 4 because a DISPATCHED AGENT owns the worktree (#5829).
-    ///
-    /// Why a separate variant rather than a `Blocked` carrying agent wording:
-    /// the operator has to be TOLD about this one. Every other refusal leaves
-    /// a directory the operator can see and re-run against; this one spares a
-    /// tree an agent is working in right now, and a sweep that spared it
-    /// silently is indistinguishable from a sweep that found nothing to do —
-    /// which is what `--merged-prs --force` printed while the gate was working
-    /// correctly. Matching on the reason STRING to recover the distinction
-    /// would re-couple the operator surface to the wording of a refusal
-    /// message, so the survey records the kind instead.
-    /// Test: `survey_discloses_a_live_agents_spared_worktree`,
-    /// `classify_blocks_a_live_agents_worktree`.
-    BlockedByAgent {
-        /// Operator-facing explanation naming the agent being protected.
-        reason: String,
-    },
-}
-
-impl ReclaimVerdict {
-    /// Shorthand for a refusal.
-    pub(crate) fn blocked(reason: impl Into<String>) -> Self {
-        Self::Blocked {
-            reason: reason.into(),
-        }
-    }
-
-    /// Shorthand for gate 4's agent-ownership refusal (#5829).
-    pub(crate) fn blocked_by_agent(reason: impl Into<String>) -> Self {
-        Self::BlockedByAgent {
-            reason: reason.into(),
-        }
-    }
-
-    /// True when this verdict permits deletion.
-    pub(crate) fn is_reclaimable(&self) -> bool {
-        matches!(self, Self::Reclaimable { .. })
-    }
-}
-
 /// Decide whether one worktree may be reclaimed (#2919).
 ///
 /// Why: this is the whole safety argument in one function, deliberately
@@ -693,15 +658,18 @@ pub(crate) fn classify(
     // own verdict kind and reaches `ReclaimSurvey::agent_owned`. Every other
     // non-admitted verdict is an ordinary block, as before.
     if admission == Admission::HarnessAgentLock {
-        return ReclaimVerdict::blocked_by_agent(admission.reason());
+        return ReclaimVerdict::blocked_by_agent(ReclaimGate::Admission, admission.reason());
     }
     if admission != Admission::Admitted {
-        return ReclaimVerdict::blocked(admission.reason());
+        return ReclaimVerdict::blocked(ReclaimGate::Admission, admission.reason());
     }
     // Gate 2 (#2919): a live session can occupy a directory whose record reads
     // terminal — measured on this repo 2026-07-28. Never trust the state field.
     if live {
-        return ReclaimVerdict::blocked("a session still claims this workspace");
+        return ReclaimVerdict::blocked(
+            ReclaimGate::Liveness,
+            "a session still claims this workspace",
+        );
     }
     // Gate 3 (#2919): only worktrees trusty-mpm provisioned can actually be
     // removed. Classifying one it cannot remove as `Reclaimable` made
@@ -713,6 +681,7 @@ pub(crate) fn classify(
         // now act on it. What remains excluded is a path with none of the three
         // ownership marks.
         return ReclaimVerdict::blocked(
+            ReclaimGate::Removability,
             "not a trusty-mpm-removable worktree — no ownership sentinel, not under \
              `.worktrees/`, and not in the harness `.claude/worktrees/` store, so \
              `prune-worktrees` cannot remove it",
@@ -725,7 +694,7 @@ pub(crate) fn classify(
     // tree is the one refusal the operator must be told about by name — see
     // `ReclaimVerdict::BlockedByAgent`.
     if let Some(reason) = agent_ownership_blocks(path, agent_state) {
-        return ReclaimVerdict::blocked_by_agent(reason);
+        return ReclaimVerdict::blocked_by_agent(ReclaimGate::AgentOwnership, reason);
     }
     // Gate 5 (#2919): the merged PR is the landing evidence DOC-52 §3.4 makes
     // the reclamation trigger. Everything else — including "we could not find
@@ -733,16 +702,26 @@ pub(crate) fn classify(
     let merged_pr = match pr {
         BranchPrState::Merged { pr } => *pr,
         BranchPrState::Open { pr } => {
-            return ReclaimVerdict::blocked(format!("PR #{pr} is still open"));
+            return ReclaimVerdict::blocked(
+                ReclaimGate::PrState,
+                format!("PR #{pr} is still open"),
+            );
         }
         BranchPrState::ClosedUnmerged { pr } => {
-            return ReclaimVerdict::blocked(format!("PR #{pr} was closed without merging"));
+            return ReclaimVerdict::blocked(
+                ReclaimGate::PrState,
+                format!("PR #{pr} was closed without merging"),
+            );
         }
         BranchPrState::NoPr => {
-            return ReclaimVerdict::blocked("no pull request found for this branch");
+            return ReclaimVerdict::blocked(
+                ReclaimGate::PrState,
+                "no pull request found for this branch",
+            );
         }
         BranchPrState::Unknown => {
             return ReclaimVerdict::blocked(
+                ReclaimGate::PrState,
                 "pull-request state could not be determined (is `gh` installed \
                  and authenticated?)",
             );
@@ -751,14 +730,20 @@ pub(crate) fn classify(
         // operator can act on `gh exited 4: … gh auth login`; they cannot act
         // on "could not be determined".
         BranchPrState::LookupFailed { reason } => {
-            return ReclaimVerdict::blocked(format!("the pull-request lookup failed: {reason}"));
+            return ReclaimVerdict::blocked(
+                ReclaimGate::PrState,
+                format!("the pull-request lookup failed: {reason}"),
+            );
         }
     };
     // Gate 6 (#2919): a merged PR does NOT prove the directory holds nothing
     // novel — the 2026-07-21 salvage found merged-PR worktrees carrying real
     // unpushed source. This is the last gate and it fails toward dirty.
     if let Some(dirt) = probe_dirt(path) {
-        return ReclaimVerdict::blocked(format!("holds unsaved work: {}", dirt.reason));
+        return ReclaimVerdict::blocked(
+            ReclaimGate::UnsavedWork,
+            format!("holds unsaved work: {}", dirt.reason),
+        );
     }
     ReclaimVerdict::Reclaimable { pr: merged_pr }
 }
@@ -862,6 +847,18 @@ pub(crate) struct ReclaimSurvey {
     /// fails identically, so 261 copies of one line would bury the count.
     /// Test: `survey_counts_a_failed_lookup_apart_from_an_unknown_state`.
     pub lookup_failure: Option<String>,
+    /// One line per NON-RECLAIMABLE candidate, as
+    /// `"<path>: blocked at <gate>: <reason>"` (#6507).
+    ///
+    /// Why: `agent_owned` names gate 4's refusals and nothing else, so an
+    /// ordinary `Blocked` — every other gate — reached no log line and no field
+    /// of the prune reply. On 2026-09-03 that left a worktree whose work had
+    /// fully landed sitting unreclaimed with nothing anywhere saying which gate
+    /// refused it, and three verification passes attributed it by elimination
+    /// to the wrong gate. A refusal the operator cannot read is a refusal
+    /// nobody can debug.
+    /// Test: `survey_names_the_gate_that_blocked_each_candidate`.
+    pub blocked_reasons: Vec<String>,
 }
 
 impl ReclaimSurvey {
@@ -884,9 +881,20 @@ impl ReclaimSurvey {
             lookup_failed: 0,
             lookup_failure: None,
             agent_owned: Vec::new(),
+            blocked_reasons: Vec::new(),
             candidates: Vec::new(),
         };
         for c in &candidates {
+            // #6507: folded here, with the totals, for the same reason
+            // `agent_owned` is — a disclosed line that is derived anywhere else
+            // can disagree with the candidate list it claims to describe.
+            if let Some((gate, reason)) = c.verdict.refusal() {
+                out.blocked_reasons.push(format!(
+                    "{}: blocked at {}: {reason}",
+                    c.path.display(),
+                    gate.label()
+                ));
+            }
             match c.bytes {
                 Some(b) => {
                     out.total_bytes = out.total_bytes.saturating_add(b);
@@ -916,12 +924,19 @@ impl ReclaimSurvey {
             }
             // #5829: collected here, with the totals, so the disclosed list can
             // never disagree with the candidate list it is derived from.
-            if let ReclaimVerdict::BlockedByAgent { reason } = &c.verdict {
+            if let ReclaimVerdict::BlockedByAgent { reason, .. } = &c.verdict {
                 out.agent_owned
                     .push(format!("{}: {reason}", c.path.display()));
             }
-            if matches!(&c.verdict, ReclaimVerdict::Blocked { reason } if reason == NOT_INSPECTED_REASON)
-            {
+            // #6507: the deadline skip is now a gate of its own, so the count no
+            // longer depends on matching the refusal's wording.
+            if matches!(
+                &c.verdict,
+                ReclaimVerdict::Blocked {
+                    gate: ReclaimGate::Deadline,
+                    ..
+                }
+            ) {
                 out.not_inspected += 1;
             }
         }

--- a/crates/trusty-mpm/src/session_manager/worktree_reclaim.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_reclaim.rs
@@ -847,8 +847,8 @@ pub(crate) struct ReclaimSurvey {
     /// fails identically, so 261 copies of one line would bury the count.
     /// Test: `survey_counts_a_failed_lookup_apart_from_an_unknown_state`.
     pub lookup_failure: Option<String>,
-    /// One line per NON-RECLAIMABLE candidate, as
-    /// `"<path>: blocked at <gate>: <reason>"` (#6507).
+    /// One line per candidate refused by an ordinary [`ReclaimVerdict::Blocked`],
+    /// as `"<path>: blocked at <gate>: <reason>"` (#6507).
     ///
     /// Why: `agent_owned` names gate 4's refusals and nothing else, so an
     /// ordinary `Blocked` — every other gate — reached no log line and no field
@@ -857,7 +857,16 @@ pub(crate) struct ReclaimSurvey {
     /// refused it, and three verification passes attributed it by elimination
     /// to the wrong gate. A refusal the operator cannot read is a refusal
     /// nobody can debug.
-    /// Test: `survey_names_the_gate_that_blocked_each_candidate`.
+    ///
+    /// This list and `agent_owned` PARTITION the blocked set: every
+    /// [`ReclaimVerdict::BlockedByAgent`] belongs to `agent_owned` alone, so a
+    /// candidate appears in exactly one of them and their lengths sum to
+    /// `blocked`. The exclusion is by VARIANT, never by gate — `BlockedByAgent`
+    /// is constructed at gate 1 (the harness agent lock) as well as at gate 4,
+    /// so excluding [`ReclaimGate::AgentOwnership`] would leave the harness-lock
+    /// candidate in both lists.
+    /// Test: `survey_names_the_gate_that_blocked_each_candidate`,
+    /// `survey_lists_an_agent_held_candidate_in_exactly_one_place`.
     pub blocked_reasons: Vec<String>,
 }
 
@@ -888,7 +897,10 @@ impl ReclaimSurvey {
             // #6507: folded here, with the totals, for the same reason
             // `agent_owned` is — a disclosed line that is derived anywhere else
             // can disagree with the candidate list it claims to describe.
-            if let Some((gate, reason)) = c.verdict.refusal() {
+            // Matched on the VARIANT so every `BlockedByAgent` — gate 1's
+            // harness lock as well as gate 4's — is left to `agent_owned` and
+            // no candidate is disclosed twice.
+            if let ReclaimVerdict::Blocked { gate, reason } = &c.verdict {
                 out.blocked_reasons.push(format!(
                     "{}: blocked at {}: {reason}",
                     c.path.display(),

--- a/crates/trusty-mpm/src/session_manager/worktree_reclaim_sweep.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_reclaim_sweep.rs
@@ -38,9 +38,9 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use super::worktree_reclaim::{
-    AgentStateProbe, BranchPrState, NOT_INSPECTED_REASON, PrIndex, ReclaimCandidate, ReclaimMode,
-    ReclaimOutcome, ReclaimSurvey, ReclaimVerdict, agent_ownership_blocks, classify, is_live,
-    measure_bytes_until, pr_state_for_branch, tm_provisioned,
+    AgentStateProbe, BranchPrState, NOT_INSPECTED_REASON, PrIndex, ReclaimCandidate, ReclaimGate,
+    ReclaimMode, ReclaimOutcome, ReclaimSurvey, ReclaimVerdict, agent_ownership_blocks, classify,
+    is_live, measure_bytes_until, pr_state_for_branch, tm_provisioned,
 };
 use super::worktree_registry::{list_registered_worktrees, scan_registered_worktrees};
 use super::worktree_safety::inspect_dirt;
@@ -124,7 +124,7 @@ pub(crate) fn survey_with_index(
                 registry_root: scanned.registry_root,
                 bytes: None,
                 pr: BranchPrState::Unknown,
-                verdict: ReclaimVerdict::blocked(NOT_INSPECTED_REASON),
+                verdict: ReclaimVerdict::blocked(ReclaimGate::Deadline, NOT_INSPECTED_REASON),
             });
             continue;
         }

--- a/crates/trusty-mpm/src/session_manager/worktree_reclaim_sweep_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_reclaim_sweep_tests.rs
@@ -432,8 +432,11 @@ fn survey_names_the_gate_that_blocked_each_candidate() {
             path.display()
         )
     );
+    // #6507: the two lists partition the blocked set — an agent-held candidate
+    // is disclosed by `agent_owned` alone, so the sum is what may never
+    // disagree with the count. Both are folded in one pass.
     assert_eq!(
-        s.blocked_reasons.len(),
+        s.blocked_reasons.len() + s.agent_owned.len(),
         s.blocked,
         "the disclosed lines and the blocked count are folded from one pass and \
          may never disagree"

--- a/crates/trusty-mpm/src/session_manager/worktree_reclaim_sweep_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_reclaim_sweep_tests.rs
@@ -358,6 +358,88 @@ fn survey_reports_a_merged_worktree_as_reclaimable() {
     assert!(s.total_bytes > 0);
 }
 
+/// The live #6507 shape end to end: a branch whose TWO commits squash-merged
+/// into one, with the remote branch pruned, is reclaimable.
+///
+/// Why this needs the survey rather than a `classify` unit test: the refusal
+/// came from gate 6's real [`inspect_dirt`] probe, which `classify`'s tests
+/// stub out. Reproduced against the live worktree
+/// `.claude/worktrees/agent-aaa8224037483f135` (PR #6705, squash commit
+/// `7933d406d`) on 2026-09-03, where the survey said
+/// `holds unsaved work: 0 uncommitted/untracked file(s), 2 unpushed commit(s)`
+/// for a tree whose work was entirely on `main`.
+#[test]
+fn survey_reclaims_a_worktree_whose_two_commits_squash_merged_as_one() {
+    let fx = GitWorktreeFixture::new();
+    let path = fx.add_worktree("squash-6507");
+    fx.squash_merge_commits_to_origin(&path, &["first.rs", "second.rs"]);
+    let s = survey_with_index(
+        &fx.repos_root,
+        &[],
+        &|_: &Path| merged_index("session/squash-6507", 6705),
+        &no_agents,
+        SurveyBudget::default(),
+        false,
+    );
+    let found = s
+        .candidates
+        .iter()
+        .find(|c| c.path == path)
+        .unwrap_or_else(|| panic!("survey missed {}", path.display()));
+    assert_eq!(
+        found.verdict,
+        ReclaimVerdict::Reclaimable { pr: 6705 },
+        "a squash-merged branch whose upstream is pruned holds nothing unsaved; \
+         blocked_reasons was {:?}",
+        s.blocked_reasons
+    );
+}
+
+/// Every refusal names its gate, and a failed lookup names gate 5 (#6507).
+///
+/// Why: `agent_owned` disclosed gate 4 alone, so a plain `Blocked` reached no
+/// field of the prune reply and no log line — which is how the worktree above
+/// sat unreclaimed while three verification passes attributed its refusal, by
+/// elimination, to the wrong gate.
+#[test]
+fn survey_names_the_gate_that_blocked_each_candidate() {
+    let fx = GitWorktreeFixture::new();
+    let path = fx.add_worktree("blocked-6507");
+    land(&path);
+    let s = survey_with_index(
+        &fx.repos_root,
+        &[],
+        &|_: &Path| PrIndex::unavailable_because("gh exited 4: gh auth login".to_string()),
+        &no_agents,
+        SurveyBudget::default(),
+        false,
+    );
+    let line = s
+        .blocked_reasons
+        .iter()
+        .find(|l| l.starts_with(&format!("{}: ", path.display())))
+        .unwrap_or_else(|| {
+            panic!(
+                "every non-reclaimable candidate owes a line; got {:?}",
+                s.blocked_reasons
+            )
+        });
+    assert_eq!(
+        line,
+        &format!(
+            "{}: blocked at gate 5 (pull-request state): the pull-request lookup failed: \
+             gh exited 4: gh auth login",
+            path.display()
+        )
+    );
+    assert_eq!(
+        s.blocked_reasons.len(),
+        s.blocked,
+        "the disclosed lines and the blocked count are folded from one pass and \
+         may never disagree"
+    );
+}
+
 #[test]
 fn survey_excludes_a_worktree_trusty_mpm_cannot_remove() {
     // #2919 HIGH: a worktree the remover would refuse used to be classified
@@ -1129,7 +1211,7 @@ fn reclaim_never_offers_an_agent_worktree_whose_pr_is_open() {
         .expect("listed");
     assert_eq!(
         found.verdict,
-        ReclaimVerdict::blocked("PR #6563 is still open"),
+        ReclaimVerdict::blocked(ReclaimGate::PrState, "PR #6563 is still open"),
         "the refusal must be the landing-evidence gate's"
     );
 }
@@ -1159,7 +1241,7 @@ fn reclaim_never_offers_a_dirty_agent_worktree() {
         .find(|c| c.path == path)
         .expect("listed");
     assert!(
-        matches!(&found.verdict, ReclaimVerdict::Blocked { reason }
+        matches!(&found.verdict, ReclaimVerdict::Blocked { reason, .. }
             if reason.contains("holds unsaved work")),
         "the refusal must be the unsaved-work gate's: {:?}",
         found.verdict

--- a/crates/trusty-mpm/src/session_manager/worktree_reclaim_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_reclaim_tests.rs
@@ -447,6 +447,132 @@ fn classify_reserves_the_agent_verdict_for_agent_refusals() {
     );
 }
 
+/// `agent_owned` and `blocked_reasons` PARTITION the blocked set (#6507).
+///
+/// Why: `blocked_reasons` was folded from every refusal, so a tree an agent
+/// holds was disclosed twice — once as the agent skip and once as an ordinary
+/// block — and an operator reading the prune reply counts one spared worktree
+/// as two separate refusals.
+///
+/// Both `BlockedByAgent` construction sites are exercised, because the harness
+/// lock builds that verdict at GATE 1 and the registry probe builds it at gate
+/// 4. An exclusion written against `ReclaimGate::AgentOwnership` alone leaves
+/// the harness-locked candidate in both lists and fails here.
+#[test]
+fn survey_lists_an_agent_held_candidate_in_exactly_one_place() {
+    let fx = GitWorktreeFixture::new();
+
+    // Gate 1: the harness holds the tree for the life of the agent.
+    let harness_held = agent_store_worktree(&fx, "harness-lock-6507");
+    GitWorktreeFixture::stamp_agent_sentinel(&harness_held, "agent-under-a-harness-lock");
+    fx.harness_lock_worktree(&harness_held, "agent-under-a-harness-lock");
+    let harness_verdict = classify_no_agent(
+        &harness_held,
+        Admission::HarnessAgentLock,
+        false,
+        &merged(6507),
+        &clean,
+    );
+    assert!(
+        matches!(
+            harness_verdict,
+            ReclaimVerdict::BlockedByAgent {
+                gate: ReclaimGate::Admission,
+                ..
+            }
+        ),
+        "gate 1's harness lock must build the agent verdict: {harness_verdict:?}"
+    );
+
+    // Gate 4: the registry reports the sentinel's agent as still working.
+    let registry_held = agent_store_worktree(&fx, "live-agent-6507");
+    GitWorktreeFixture::stamp_agent_sentinel(&registry_held, "agent-still-writing");
+    let registry_verdict = classify(
+        &registry_held,
+        Admission::Admitted,
+        false,
+        &merged(6508),
+        &inspect_dirt,
+        &agent_live,
+    );
+    assert!(
+        matches!(
+            registry_verdict,
+            ReclaimVerdict::BlockedByAgent {
+                gate: ReclaimGate::AgentOwnership,
+                ..
+            }
+        ),
+        "gate 4 must build the agent verdict: {registry_verdict:?}"
+    );
+
+    // The control: an ordinary refusal still owes a `blocked_reasons` line.
+    let dirty_tree = fx.add_worktree("dirty-6507");
+    let dirty_verdict = classify_no_agent(
+        &dirty_tree,
+        Admission::Admitted,
+        false,
+        &merged(6509),
+        &dirty,
+    );
+    assert!(
+        matches!(dirty_verdict, ReclaimVerdict::Blocked { .. }),
+        "the control must be an ordinary block: {dirty_verdict:?}"
+    );
+
+    let candidate = |path: &Path, verdict: ReclaimVerdict| ReclaimCandidate {
+        path: path.to_path_buf(),
+        branch: None,
+        registry_root: fx.repo.clone(),
+        bytes: Some(1),
+        pr: merged(6507),
+        verdict,
+    };
+    let survey = ReclaimSurvey::from_candidates(vec![
+        candidate(&harness_held, harness_verdict),
+        candidate(&registry_held, registry_verdict),
+        candidate(&dirty_tree, dirty_verdict),
+    ]);
+
+    let lines_for = |list: &[String], path: &Path| {
+        let prefix = format!("{}: ", path.display());
+        list.iter().filter(|l| l.starts_with(&prefix)).count()
+    };
+    for held in [&harness_held, &registry_held] {
+        assert_eq!(
+            lines_for(&survey.agent_owned, held),
+            1,
+            "an agent-held tree owes exactly one agent line; got {:?}",
+            survey.agent_owned
+        );
+        assert_eq!(
+            lines_for(&survey.blocked_reasons, held),
+            0,
+            "and it must not be disclosed a second time as an ordinary block; got {:?}",
+            survey.blocked_reasons
+        );
+    }
+    assert_eq!(
+        lines_for(&survey.blocked_reasons, &dirty_tree),
+        1,
+        "an ordinary refusal still owes its line; got {:?}",
+        survey.blocked_reasons
+    );
+    assert_eq!(
+        lines_for(&survey.agent_owned, &dirty_tree),
+        0,
+        "a dirty tree is nobody's agent skip; got {:?}",
+        survey.agent_owned
+    );
+    assert_eq!(
+        survey.agent_owned.len() + survey.blocked_reasons.len(),
+        survey.blocked,
+        "the two lists partition the blocked set: {:?} / {:?}",
+        survey.agent_owned,
+        survey.blocked_reasons
+    );
+}
+
 #[test]
 fn classify_allows_a_finished_agents_merged_worktree() {
     // The complement, and the whole reason the gate consults the registry

--- a/crates/trusty-mpm/src/session_manager/worktree_reclaim_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_reclaim_tests.rs
@@ -102,7 +102,7 @@ fn wt() -> PathBuf {
 /// carries it (#5829).
 fn reason(v: &ReclaimVerdict) -> String {
     match v {
-        ReclaimVerdict::Blocked { reason } | ReclaimVerdict::BlockedByAgent { reason } => {
+        ReclaimVerdict::Blocked { reason, .. } | ReclaimVerdict::BlockedByAgent { reason, .. } => {
             reason.clone()
         }
         ReclaimVerdict::Reclaimable { pr } => panic!("expected a refusal, got Reclaimable {pr}"),
@@ -1176,7 +1176,7 @@ fn classify_blocks_a_failed_lookup_and_names_the_reason() {
         &no_agents,
     );
     assert!(!verdict.is_reclaimable());
-    let ReclaimVerdict::Blocked { reason } = verdict else {
+    let ReclaimVerdict::Blocked { reason, .. } = verdict else {
         panic!("a failed lookup is an ordinary block, not an agent refusal");
     };
     assert!(reason.contains("lookup failed"), "{reason}");

--- a/crates/trusty-mpm/src/session_manager/worktree_reclaim_verdict.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_reclaim_verdict.rs
@@ -84,8 +84,13 @@ pub(crate) enum ReclaimVerdict {
     /// correctly. Matching on the reason STRING to recover the distinction
     /// would re-couple the operator surface to the wording of a refusal
     /// message, so the survey records the kind instead.
+    ///
+    /// #6507: the survey discloses this kind through `ReclaimSurvey::agent_owned`
+    /// alone. `blocked_reasons` skips it by VARIANT rather than by gate, because
+    /// gate 1's harness lock builds it too, so no candidate is named twice.
     /// Test: `survey_discloses_a_live_agents_spared_worktree`,
-    /// `classify_blocks_a_live_agents_worktree`.
+    /// `classify_blocks_a_live_agents_worktree`,
+    /// `survey_lists_an_agent_held_candidate_in_exactly_one_place`.
     BlockedByAgent {
         /// Which gate refused (#6507) — gate 1 or gate 4.
         gate: ReclaimGate,
@@ -114,18 +119,5 @@ impl ReclaimVerdict {
     /// True when this verdict permits deletion.
     pub(crate) fn is_reclaimable(&self) -> bool {
         matches!(self, Self::Reclaimable { .. })
-    }
-
-    /// The gate that refused, and its message — `None` when nothing refused.
-    ///
-    /// Why: the survey folds one disclosure line per non-reclaimable candidate
-    /// and must not have to match on either verdict kind to build it (#6507).
-    pub(crate) fn refusal(&self) -> Option<(ReclaimGate, &str)> {
-        match self {
-            Self::Reclaimable { .. } => None,
-            Self::Blocked { gate, reason } | Self::BlockedByAgent { gate, reason } => {
-                Some((*gate, reason.as_str()))
-            }
-        }
     }
 }

--- a/crates/trusty-mpm/src/session_manager/worktree_reclaim_verdict.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_reclaim_verdict.rs
@@ -1,0 +1,131 @@
+//! The verdict a merged-PR reclaim candidate carries, and the gate that set it
+//! (#2919, #6507).
+//!
+//! Why: split out of `worktree_reclaim` so that file stays under the 500-SLOC
+//! production cap. The two halves also answer different questions — that module
+//! RUNS the gates, this one is the vocabulary their answers are expressed in,
+//! and the operator surfaces (`managed_merged_prs`, the prune route) read only
+//! this vocabulary.
+//! Test: `worktree_reclaim_tests` — every gate's refusal test asserts on the
+//! kind and the gate recorded here.
+
+use serde::Serialize;
+
+/// Which of [`classify`]'s gates refused a candidate (#6507).
+///
+/// Why: the survey used to record a refusal as prose only, and the HTTP report
+/// disclosed a per-candidate reason for gate 4 alone. Every other refusal —
+/// including the gate-6 squash-merge misread this issue is about — was
+/// invisible at every log level and in every field of the reply, so three
+/// verification passes attributed one live worktree's refusal by elimination
+/// and got it wrong. Naming the gate as DATA rather than as wording keeps the
+/// operator surface from having to match on a message string.
+/// What: one variant per gate, plus [`Deadline`](Self::Deadline) for the
+/// candidate the survey ran out of time to inspect.
+/// Test: `survey_names_the_gate_that_blocked_each_candidate`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ReclaimGate {
+    /// Gate 1 — git's own admission verdict.
+    Admission,
+    /// Gate 2 — a session still claims the workspace.
+    Liveness,
+    /// Gate 3 — trusty-mpm cannot remove this worktree.
+    Removability,
+    /// Gate 4 — a dispatched agent owns it.
+    AgentOwnership,
+    /// Gate 5 — the branch's pull-request state is not a merge.
+    PrState,
+    /// Gate 6 — the working tree holds unsaved work.
+    UnsavedWork,
+    /// Not a gate: the survey's classify budget expired first.
+    Deadline,
+}
+
+impl ReclaimGate {
+    /// The operator-facing name of this gate.
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::Admission => "gate 1 (admission)",
+            Self::Liveness => "gate 2 (liveness)",
+            Self::Removability => "gate 3 (removability)",
+            Self::AgentOwnership => "gate 4 (agent ownership)",
+            Self::PrState => "gate 5 (pull-request state)",
+            Self::UnsavedWork => "gate 6 (unsaved work)",
+            Self::Deadline => "the survey deadline",
+        }
+    }
+}
+
+/// Whether a worktree may be reclaimed, or the first reason it may not (#2919).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ReclaimVerdict {
+    /// Every gate passed; the named pull request is the landing evidence.
+    Reclaimable {
+        /// The merged pull request that proves the branch's work landed.
+        pr: u64,
+    },
+    /// Refused — `reason` names the FIRST gate that said no.
+    Blocked {
+        /// Which gate refused (#6507).
+        gate: ReclaimGate,
+        /// Operator-facing explanation of the refusal.
+        reason: String,
+    },
+    /// Refused by gate 4 because a DISPATCHED AGENT owns the worktree (#5829).
+    ///
+    /// Why a separate variant rather than a `Blocked` carrying agent wording:
+    /// the operator has to be TOLD about this one. Every other refusal leaves
+    /// a directory the operator can see and re-run against; this one spares a
+    /// tree an agent is working in right now, and a sweep that spared it
+    /// silently is indistinguishable from a sweep that found nothing to do —
+    /// which is what `--merged-prs --force` printed while the gate was working
+    /// correctly. Matching on the reason STRING to recover the distinction
+    /// would re-couple the operator surface to the wording of a refusal
+    /// message, so the survey records the kind instead.
+    /// Test: `survey_discloses_a_live_agents_spared_worktree`,
+    /// `classify_blocks_a_live_agents_worktree`.
+    BlockedByAgent {
+        /// Which gate refused (#6507) — gate 1 or gate 4.
+        gate: ReclaimGate,
+        /// Operator-facing explanation naming the agent being protected.
+        reason: String,
+    },
+}
+
+impl ReclaimVerdict {
+    /// Shorthand for a refusal.
+    pub(crate) fn blocked(gate: ReclaimGate, reason: impl Into<String>) -> Self {
+        Self::Blocked {
+            gate,
+            reason: reason.into(),
+        }
+    }
+
+    /// Shorthand for gate 4's agent-ownership refusal (#5829).
+    pub(crate) fn blocked_by_agent(gate: ReclaimGate, reason: impl Into<String>) -> Self {
+        Self::BlockedByAgent {
+            gate,
+            reason: reason.into(),
+        }
+    }
+
+    /// True when this verdict permits deletion.
+    pub(crate) fn is_reclaimable(&self) -> bool {
+        matches!(self, Self::Reclaimable { .. })
+    }
+
+    /// The gate that refused, and its message — `None` when nothing refused.
+    ///
+    /// Why: the survey folds one disclosure line per non-reclaimable candidate
+    /// and must not have to match on either verdict kind to build it (#6507).
+    pub(crate) fn refusal(&self) -> Option<(ReclaimGate, &str)> {
+        match self {
+            Self::Reclaimable { .. } => None,
+            Self::Blocked { gate, reason } | Self::BlockedByAgent { gate, reason } => {
+                Some((*gate, reason.as_str()))
+            }
+        }
+    }
+}

--- a/crates/trusty-mpm/src/session_manager/worktree_safety.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_safety.rs
@@ -709,6 +709,15 @@ fn count_unlanded(
 /// discounted. An empty commit carries no file content, so nothing recoverable
 /// is at risk. `git cherry` also skips merge commits, which therefore never
 /// appear here and stay counted — the conservative direction.
+///
+/// The same residual runs through [`squashed_divergence`], one size larger
+/// (#6507). An exact patch-id match is CONTENT equivalence, not merge
+/// provenance: a landing commit whose diff is byte-identical to the branch's
+/// whole divergence discounts that divergence, whether or not it is the squash
+/// of it. The window keeps that narrow — the match has to land inside the
+/// [`SQUASH_CANDIDATE_MAX`] commits on the base that touch a path the branch
+/// touched — and a byte-identical diff means the branch's content is already on
+/// the landing branch either way, so nothing unique to the worktree is at risk.
 /// Test: `inspect_dirt_clears_a_squash_merged_branch_whose_upstream_was_pruned`,
 /// `inspect_dirt_clears_a_two_commit_squash_merge`.
 fn landed_on_a_remote(path: &Path, tips: &[&str]) -> HashSet<String> {
@@ -738,6 +747,8 @@ fn landed_on_a_remote(path: &Path, tips: &[&str]) -> HashSet<String> {
 /// the true squash commit is always in the list; this only bounds how far back
 /// a match is looked for when many commits touch that path. A miss keeps the
 /// raw count, so the cap can only ever over-report.
+/// Test: `inspect_dirt_keeps_the_raw_count_when_the_squash_falls_outside_the_window`
+/// pins the boundary — 25 newer commits on the path hide the squash.
 const SQUASH_CANDIDATE_MAX: usize = 25;
 
 /// The commits in `<base>..<tip>` when the branch's WHOLE divergence is already
@@ -761,7 +772,11 @@ const SQUASH_CANDIDATE_MAX: usize = 25;
 /// The match is exact and aggregate, so a commit added AFTER the squash changes
 /// the aggregate diff and nothing is discounted: the fail-closed direction.
 /// Test: `inspect_dirt_clears_a_two_commit_squash_merge`,
-/// `inspect_dirt_reports_a_commit_added_after_a_two_commit_squash_merge`.
+/// `inspect_dirt_reports_a_commit_added_after_a_two_commit_squash_merge`, and
+/// one per early return (#6507) —
+/// `inspect_dirt_keeps_the_raw_count_when_there_is_no_merge_base`,
+/// `inspect_dirt_keeps_the_raw_count_when_the_divergence_has_no_diff`,
+/// `inspect_dirt_keeps_the_raw_count_when_the_squash_falls_outside_the_window`.
 fn squashed_divergence(path: &Path, base: &str, tip: &str) -> Vec<String> {
     let nothing = Vec::new();
     let Ok(merge_base) = git_stdout(path, &["merge-base", base, tip]) else {

--- a/crates/trusty-mpm/src/session_manager/worktree_safety.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_safety.rs
@@ -100,8 +100,9 @@
 //! Test: `worktree_safety_tests`.
 
 use std::collections::HashSet;
+use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 use serde::Serialize;
 
@@ -579,10 +580,14 @@ fn is_worktree_root(path: &Path) -> Result<bool, String> {
 /// them all as unpushed, gate 6 of the merged-PR reclaim reports "holds unsaved
 /// work", and `prune-worktrees --merged-prs` reclaims nothing on a repository
 /// that squash-merges every PR. [`count_unlanded`] subtracts the commits whose
-/// PATCH is provably already on a remote landing branch.
+/// PATCH is provably already on a remote landing branch — per commit for a
+/// one-commit branch, and per whole divergence for the two-or-more-commit
+/// branch a squash collapses into a patch none of them matches
+/// ([`squashed_divergence`]).
 /// Test: `inspect_dirt_reports_unpushed_commit`,
 /// `inspect_dirt_clean_pushed_worktree_is_none`,
-/// `inspect_dirt_clears_a_squash_merged_branch_whose_upstream_was_pruned`.
+/// `inspect_dirt_clears_a_squash_merged_branch_whose_upstream_was_pruned`,
+/// `inspect_dirt_clears_a_two_commit_squash_merge`.
 fn count_unpushed(path: &Path) -> Result<usize, String> {
     let upstream = git_stdout(
         path,
@@ -694,7 +699,9 @@ fn count_unlanded(
 /// into "already landed". `git cherry <base> <tip>` marks a commit `-` when its
 /// patch id matches one on `base` — which is exactly what a squash merge
 /// produces — and `+` otherwise.
-/// What: the `-` SHAs, unioned over every [`landing_bases`] base and every tip.
+/// What: the `-` SHAs, unioned over every [`landing_bases`] base and every tip,
+/// plus whatever [`squashed_divergence`] proves landed as ONE squash commit —
+/// which is the only thing that clears a branch of two or more commits.
 /// An empty set on every failure path, which leaves the caller's count intact.
 ///
 /// Residual, stated rather than hidden: an EMPTY commit has an empty patch id,
@@ -702,7 +709,8 @@ fn count_unlanded(
 /// discounted. An empty commit carries no file content, so nothing recoverable
 /// is at risk. `git cherry` also skips merge commits, which therefore never
 /// appear here and stay counted — the conservative direction.
-/// Test: `inspect_dirt_clears_a_squash_merged_branch_whose_upstream_was_pruned`.
+/// Test: `inspect_dirt_clears_a_squash_merged_branch_whose_upstream_was_pruned`,
+/// `inspect_dirt_clears_a_two_commit_squash_merge`.
 fn landed_on_a_remote(path: &Path, tips: &[&str]) -> HashSet<String> {
     let mut landed = HashSet::new();
     for base in landing_bases(path) {
@@ -715,9 +723,134 @@ fn landed_on_a_remote(path: &Path, tips: &[&str]) -> HashSet<String> {
                     landed.insert(sha.trim().to_string());
                 }
             }
+            // #6507: `git cherry` compares one commit's patch at a time, so a
+            // squash of TWO OR MORE commits matches none of them. Ask the
+            // whole-divergence question too.
+            landed.extend(squashed_divergence(path, &base, tip));
         }
     }
     landed
+}
+
+/// How many landing-branch commits one squash probe patch-compares (#6507).
+///
+/// Why: the probe narrows candidates by a path the branch actually touched, so
+/// the true squash commit is always in the list; this only bounds how far back
+/// a match is looked for when many commits touch that path. A miss keeps the
+/// raw count, so the cap can only ever over-report.
+const SQUASH_CANDIDATE_MAX: usize = 25;
+
+/// The commits in `<base>..<tip>` when the branch's WHOLE divergence is already
+/// on `base` as ONE squash commit (#6507).
+///
+/// Why: `git cherry` — the #6528 fix — compares commits pairwise, so it clears
+/// a branch that squash-merged from a SINGLE commit and nothing else. Live on
+/// 2026-09-03: PR #6705 squashed two commits (`37540d9cb`, `4c8e11de8`) into
+/// `7933d406d`, neither commit's patch id matched, and gate 6 of the merged-PR
+/// reclaim reported "0 uncommitted/untracked file(s), 2 unpushed commit(s)" for
+/// a worktree whose work had fully landed. A squash's patch is the UNION of the
+/// branch's commits, so the branch's aggregate diff is the only thing that can
+/// match it.
+/// What: `git diff <merge-base> <tip>` reduced to one patch id, compared
+/// against the patch ids of up to [`SQUASH_CANDIDATE_MAX`] commits on `base`
+/// that touch a path the branch touched. An exact match means every commit in
+/// `<merge-base>..<tip>` landed, and those SHAs are returned; anything else —
+/// no merge base, an empty diff, no candidate, a git failure — returns nothing
+/// and leaves the caller's count untouched.
+///
+/// The match is exact and aggregate, so a commit added AFTER the squash changes
+/// the aggregate diff and nothing is discounted: the fail-closed direction.
+/// Test: `inspect_dirt_clears_a_two_commit_squash_merge`,
+/// `inspect_dirt_reports_a_commit_added_after_a_two_commit_squash_merge`.
+fn squashed_divergence(path: &Path, base: &str, tip: &str) -> Vec<String> {
+    let nothing = Vec::new();
+    let Ok(merge_base) = git_stdout(path, &["merge-base", base, tip]) else {
+        return nothing;
+    };
+    let merge_base = merge_base.trim().to_string();
+    if merge_base.is_empty() {
+        return nothing;
+    }
+    let Some((aggregate, _)) = patch_ids(path, &["diff", &merge_base, tip])
+        .into_iter()
+        .next()
+    else {
+        return nothing;
+    };
+    let Ok(names) = git_stdout(path, &["diff", "--name-only", &merge_base, tip]) else {
+        return nothing;
+    };
+    let Some(probe) = names.lines().map(str::trim).find(|l| !l.is_empty()) else {
+        return nothing;
+    };
+    let limit = SQUASH_CANDIDATE_MAX.to_string();
+    let range = format!("{merge_base}..{base}");
+    let Ok(listing) = git_stdout(
+        path,
+        &["log", "--format=%H", "-n", &limit, &range, "--", probe],
+    ) else {
+        return nothing;
+    };
+    let mut show: Vec<&str> = vec!["show"];
+    show.extend(listing.split_whitespace());
+    if show.len() == 1
+        || !patch_ids(path, &show)
+            .iter()
+            .any(|(id, _)| *id == aggregate)
+    {
+        return nothing;
+    }
+    let Ok(landed) = git_stdout(path, &["rev-list", &format!("{merge_base}..{tip}")]) else {
+        return nothing;
+    };
+    landed.split_whitespace().map(str::to_string).collect()
+}
+
+/// `git patch-id --stable` over the patch a git command prints (#6507).
+///
+/// Why: patch equivalence is the only signal that survives a squash, and
+/// `git patch-id` is the only thing that computes it. It reads a patch STREAM
+/// and emits one `<patch-id> <commit-id>` line per patch in it, so a single
+/// pair of subprocesses covers both `git diff` (one line, no commit) and
+/// `git show <sha>…` (one line per commit).
+/// What: runs `git <args>`, feeds its stdout to `git patch-id --stable`, and
+/// parses the reply. Every failure — the first command, the spawn, a non-zero
+/// exit — yields an empty vector, which discounts nothing.
+/// Test: `inspect_dirt_clears_a_two_commit_squash_merge`.
+fn patch_ids(path: &Path, args: &[&str]) -> Vec<(String, String)> {
+    let Ok(patch) = git_stdout(path, args) else {
+        return Vec::new();
+    };
+    if patch.trim().is_empty() {
+        return Vec::new();
+    }
+    let Ok(mut child) = git_command(path, &["patch-id", "--stable"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+    else {
+        return Vec::new();
+    };
+    if let Some(mut stdin) = child.stdin.take() {
+        let _ = stdin.write_all(patch.as_bytes());
+    }
+    let Ok(out) = child.wait_with_output() else {
+        return Vec::new();
+    };
+    if !out.status.success() {
+        return Vec::new();
+    }
+    String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .filter_map(|line| {
+            let mut fields = line.split_whitespace();
+            Some((
+                fields.next()?.to_string(),
+                fields.next().unwrap_or_default().to_string(),
+            ))
+        })
+        .collect()
 }
 
 /// Remote refs a squash merge could have landed on, deduplicated by commit

--- a/crates/trusty-mpm/src/session_manager/worktree_safety_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_safety_tests.rs
@@ -908,6 +908,108 @@ fn inspect_dirt_reports_a_commit_added_after_a_two_commit_squash_merge() {
     );
 }
 
+/// `squashed_divergence` arm 1 — NO MERGE BASE keeps the raw count (#6507).
+///
+/// Why: every arm of the aggregate probe has to fail toward "still unsaved", and
+/// this is the arm reached whenever the branch shares no ancestor with a landing
+/// branch. A probe that treated an unanswerable comparison as a match would
+/// discount commits that exist nowhere else.
+#[test]
+fn inspect_dirt_keeps_the_raw_count_when_there_is_no_merge_base() {
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree("orphan-6507");
+    git_must(&wt, &["checkout", "--orphan", "unrelated-6507"]);
+    git_must(&wt, &["rm", "-rf", "."]);
+    std::fs::write(wt.join("only-here.rs"), "work that shares no ancestor\n").unwrap();
+    git_must(&wt, &["add", "only-here.rs"]);
+    git_must(&wt, &["commit", "-m", "feat: unrelated root commit"]);
+
+    // The precondition this arm needs: git can name no common ancestor at all.
+    assert!(
+        git_stdout(&wt, &["merge-base", "refs/remotes/origin/main", "HEAD"]).is_err(),
+        "the fixture must reproduce a history with no merge base"
+    );
+
+    let dirt = inspect_dirt(&wt).expect("an unrelated root commit is unsaved work");
+    assert_eq!(
+        dirt.unpushed_commits, 1,
+        "an unanswerable comparison discounts nothing; reason was: {}",
+        dirt.reason
+    );
+}
+
+/// `squashed_divergence` arm 2 — an EMPTY DIVERGENCE DIFF keeps the raw count
+/// (#6507).
+///
+/// Why: a branch that adds a file and then removes it has two real commits and
+/// no aggregate diff, so there is no patch to compare and no path to narrow
+/// candidates by. The probe returns before it lists a single candidate, and
+/// those two commits stay counted — they exist nowhere but this worktree.
+#[test]
+fn inspect_dirt_keeps_the_raw_count_when_the_divergence_has_no_diff() {
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree("netzero-6507");
+    std::fs::write(wt.join("ephemeral.rs"), "added, then taken away\n").unwrap();
+    git_must(&wt, &["add", "ephemeral.rs"]);
+    git_must(&wt, &["commit", "-m", "feat: add a file"]);
+    git_must(&wt, &["rm", "ephemeral.rs"]);
+    git_must(&wt, &["commit", "-m", "fix: remove it again"]);
+
+    // The precondition: two commits whose AGGREGATE diff is empty, so the probe
+    // has no patch to match and no path to narrow the candidate list by.
+    let names = git_stdout(
+        &wt,
+        &["diff", "--name-only", "refs/remotes/origin/main", "HEAD"],
+    )
+    .expect("diff must run");
+    assert!(
+        names.trim().is_empty(),
+        "the divergence must cancel out; got {names}"
+    );
+
+    let dirt = inspect_dirt(&wt).expect("two commits that landed nowhere are unsaved work");
+    assert_eq!(
+        dirt.unpushed_commits, 2,
+        "an empty aggregate proves nothing landed; reason was: {}",
+        dirt.reason
+    );
+}
+
+/// `squashed_divergence` arm 3 — a squash BEYOND the candidate window keeps the
+/// raw count (#6507).
+///
+/// Why: the probe compares at most `SQUASH_CANDIDATE_MAX` (25) landing commits
+/// that touch a path the branch touched. This pins the boundary exactly: 25
+/// newer commits on `main` touch `first.rs`, so the squash is the 26th and the
+/// window never lists it. Missing it costs a reclaim, never a deletion.
+#[test]
+fn inspect_dirt_keeps_the_raw_count_when_the_squash_falls_outside_the_window() {
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree("windowed-6507");
+    fx.squash_merge_commits_to_origin(&wt, &["first.rs", "second.rs"]);
+
+    // `first.rs` is the probe path — the first name the branch's aggregate diff
+    // lists — so commits touching it are what fill the window.
+    for i in 0..25 {
+        std::fs::write(fx.repo.join("first.rs"), format!("later edit {i}\n")).unwrap();
+        git_must(&fx.repo, &["add", "first.rs"]);
+        git_must(
+            &fx.repo,
+            &["commit", "-m", &format!("chore: later edit {i}")],
+        );
+    }
+    git_must(&fx.repo, &["push", "origin", "main"]);
+    git_must(&fx.repo, &["fetch", "--prune", "origin"]);
+
+    let dirt =
+        inspect_dirt(&wt).expect("a squash the window cannot reach is not proof the work landed");
+    assert_eq!(
+        dirt.unpushed_commits, 2,
+        "an exhausted window discounts nothing; reason was: {}",
+        dirt.reason
+    );
+}
+
 /// The control the #6507 fix may never break: a commit that landed NOWHERE is
 /// still unsaved work, in the same worktree, beside one that did land.
 #[test]

--- a/crates/trusty-mpm/src/session_manager/worktree_safety_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_safety_tests.rs
@@ -850,6 +850,64 @@ fn inspect_dirt_clears_a_squash_merged_branch_whose_upstream_was_pruned() {
     );
 }
 
+/// A squash of TWO commits clears too — the shape that survived the first fix.
+///
+/// Why: `git cherry` compares patch ids one commit at a time, and a squash
+/// carries the UNION of the branch's patches, so a two-commit branch matches
+/// nothing. Live on 2026-09-03: PR #6705 squashed `37540d9cb` and `4c8e11de8`
+/// into `7933d406d`, `git cherry refs/remotes/origin/main HEAD` marked both
+/// `+`, and gate 6 reported "2 unpushed commit(s)" for a fully landed worktree.
+#[test]
+fn inspect_dirt_clears_a_two_commit_squash_merge() {
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree("squashed-two");
+    fx.squash_merge_commits_to_origin(&wt, &["first.rs", "second.rs"]);
+
+    // The pre-fix state, pinned: both commits are unreachable from every remote
+    // ref AND neither matches a landed commit's patch id on its own.
+    let reachability = git_stdout(&wt, &["rev-list", "--count", "HEAD", "--not", "--remotes"])
+        .expect("rev-list must run");
+    assert_eq!(
+        reachability.trim(),
+        "2",
+        "the fixture must reproduce a divergence of more than one commit"
+    );
+    let cherry =
+        git_stdout(&wt, &["cherry", "refs/remotes/origin/main", "HEAD"]).expect("cherry must run");
+    assert!(
+        !cherry.contains("- "),
+        "the per-commit comparison must find NO match — that is the whole bug; got {cherry}"
+    );
+
+    assert!(
+        inspect_dirt(&wt).is_none(),
+        "a branch whose two commits squash-merged as one holds no unsaved work; got {:?}",
+        inspect_dirt(&wt)
+    );
+}
+
+/// The control for the two-commit fix: work added AFTER the squash still counts.
+///
+/// Why: the aggregate comparison discounts a whole divergence at once, so it
+/// has to stop discounting the moment the divergence stops matching.
+#[test]
+fn inspect_dirt_reports_a_commit_added_after_a_two_commit_squash_merge() {
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree("squashed-two-plus");
+    fx.squash_merge_commits_to_origin(&wt, &["first.rs", "second.rs"]);
+
+    std::fs::write(wt.join("never-landed.rs"), "work that exists only here\n").unwrap();
+    git_must(&wt, &["add", "never-landed.rs"]);
+    git_must(&wt, &["commit", "-m", "feat: never pushed anywhere"]);
+
+    let dirt = inspect_dirt(&wt).expect("a commit added after the squash must still read as dirty");
+    assert_eq!(
+        dirt.unpushed_commits, 3,
+        "an aggregate that no longer matches discounts nothing; reason was: {}",
+        dirt.reason
+    );
+}
+
 /// The control the #6507 fix may never break: a commit that landed NOWHERE is
 /// still unsaved work, in the same worktree, beside one that did land.
 #[test]


### PR DESCRIPTION
Refs #6507

`tm session prune-worktrees --merged-prs` refused any worktree whose PR squash-merged more than one commit: the `git cherry` check from #6528 compares one commit's patch id at a time, and a squash carries the union of the branch's patches, so it matched neither. `squashed_divergence` now reduces the merge-base..tip diff to one patch id and compares it against landing-branch commits touching the same paths; an exact match discounts the divergence, and every failure arm keeps the raw unpushed count (fail-closed, each arm has a test). The survey also names the gate that blocked each candidate (`blocked_reasons`, one line per candidate, agent-held trees only in `agent_owned`), and the PR-state fallback logs a WARN on failure.

Live case: `.claude/worktrees/agent-aaa8224037483f135` (two commits squash-merged as #6705) now classifies as reclaimable.

Test ladder rung 5 (destructive path guard). Evidence:
- `cargo fmt --check`, `cargo check -p trusty-mpm --all-targets`, `cargo clippy -p trusty-mpm --all-targets -- -D warnings`: exit 0
- `cargo test -p trusty-mpm --no-fail-fast`: 54 targets, 53 ok; the one failure is the pre-existing #5784 `$HOME` race in `tmux_service` (passes solo, not in this diff)
- Regression tests that fail on the reverted code: `inspect_dirt_clears_a_two_commit_squash_merge`, `survey_reclaims_a_worktree_whose_two_commits_squash_merged_as_one`, `survey_names_the_gate_that_blocked_each_candidate`, `survey_lists_an_agent_held_candidate_in_exactly_one_place`
- code-critic: APPROVE; its three findings are fixed in the second commit
- Doc gates (line-cap, test-pointers, changelog fragment, sld): OK

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
