### PR TITLE
docs(trusty-code): reconcile specs and ADRs against the current tree

### DIFF
--- a/.github/workflows/doc-numbers.yml
+++ b/.github/workflows/doc-numbers.yml
@@ -25,10 +25,12 @@ on:
     paths:
       - "docs/specs/**"
       - "docs/adr/**"
+      - "docs/trusty-code/**"
       - "docs/trusty-installer/research/02-design/**"
       - ".doc-number-allowlist.tsv"
       - "scripts/check_doc_numbers.sh"
       - "scripts/check_adr.sh"
+      - "scripts/check_trusty_code_specs.sh"
       - "scripts/check_scan_floor_selftest.sh"
       - ".github/workflows/doc-numbers.yml"
   pull_request:
@@ -42,10 +44,12 @@ on:
     paths:
       - "docs/specs/**"
       - "docs/adr/**"
+      - "docs/trusty-code/**"
       - "docs/trusty-installer/research/02-design/**"
       - ".doc-number-allowlist.tsv"
       - "scripts/check_doc_numbers.sh"
       - "scripts/check_adr.sh"
+      - "scripts/check_trusty_code_specs.sh"
       - "scripts/check_scan_floor_selftest.sh"
       - ".github/workflows/doc-numbers.yml"
 
@@ -88,3 +92,6 @@ jobs:
 
       - name: Check ADR corpus consistency
         run: bash scripts/check_adr.sh
+
+      - name: Check Trusty Code architecture reconciliation
+        run: bash scripts/check_trusty_code_specs.sh

--- a/docs/adr/0004-three-harnesses-shared-event-driven-common.md
+++ b/docs/adr/0004-three-harnesses-shared-event-driven-common.md
@@ -1,9 +1,11 @@
 # 0004. Three distinct harnesses (coding / meta / agentic) on a shared event-driven trusty-common foundation
 
-- **Status:** Accepted
+- **Status:** Amended by [0058](0058-trusty-code-is-an-independent-product-owned-harness.md)
 - **Date:** 2026-06-05
 - **Scope:** Workspace-wide (all harness crates + `trusty-common`)
-- **Supersedes / Superseded by:** —
+- **Supersedes / Superseded by:** ADR-0058 defines the now-implemented Trusty
+  Code ownership, state, transport, and integration boundary. The three-peer
+  harness decision remains in force.
 
 ## Context
 

--- a/docs/adr/0015-three-product-agent-composition-model.md
+++ b/docs/adr/0015-three-product-agent-composition-model.md
@@ -1,6 +1,6 @@
 # 0015. Unified Agent Composition: Shared `.md`+YAML+`extends` Format Across Three Products
 
-- **Status:** Proposed
+- **Status:** Superseded by [0059](0059-canonical-agent-behavior-has-generated-host-adapters.md)
 - **Date:** 2026-07-18
 - **Scope:** Workspace-wide (trusty-agents, trusty-mpm, trusty-code)
 - **Reversibility Cost:** High — the source format, inheritance semantics, and
@@ -8,7 +8,10 @@
 - **Decision Drivers:** Eliminate parser duplication, preserve product-specific
   composition semantics, share deterministic `extends` resolution, keep
   cross-product delegation behind explicit proxies
-- **Supersedes / Superseded by:** — (complements DOC-37, issues #2791/#2792)
+- **Supersedes / Superseded by:** Superseded by ADR-0059, which retains the
+  compatible format and composition semantics but requires one canonical
+  behavioral source plus generated host adapters (complements DOC-37, issues
+  #2791/#2792)
 
 ## Context
 
@@ -124,3 +127,23 @@ This agent forwards orchestration and session-management tasks to trusty-mpm's P
 - **#2897** — trusty-code `.md` unification onto the shared format.
 - **#2894** — Hierarchical delegation depth/cycle guards for trusty-agents' runtime orchestration.
 - **#2892** — Composition and reuse epic.
+
+## Related Decisions
+
+Vetted against the ADR corpus on 2026-09-03, at supersession:
+
+- **ADR-0004 (Three event-driven harnesses):** Consistent — shared authored
+  behavior does not collapse the three product runtimes.
+- **ADR-0024 (In-process leaf sub-agents):** Consistent — runtime topology is
+  independent of source identity and adapter generation.
+- **ADR-0025 (Collapse deployment hierarchies, Proposed):** Consistent — both
+  records resolve precedence at deployment time.
+- **ADR-0042 (Static persistent MCP configuration):** Consistent — MCP
+  declarations stay persistent and outside generated behavioral sources.
+- **ADR-0058 (Independent Trusty Code harness):** Consistent — host adapters
+  deploy into the product-owned boundary.
+- **ADR-0059 (Canonical agent behavior):** Supersedes — preserves this record's
+  Markdown/YAML format and deterministic composition, and replaces separate
+  behavioral catalogs with one canonical source plus generated host adapters.
+
+No Accepted decision depends on this record remaining Proposed.

--- a/docs/adr/0024-subagents-in-process-only-assistants-communicate-not-delegate.md
+++ b/docs/adr/0024-subagents-in-process-only-assistants-communicate-not-delegate.md
@@ -1,11 +1,14 @@
 # 0024. Assistants Are Level-0 Delegators; Sub-Agents Are In-Process, Single-Edge Leaves That Never Delegate
 
-- **Status:** Accepted
+- **Status:** Amended by [0058](0058-trusty-code-is-an-independent-product-owned-harness.md)
 - **Acceptance:** All six Decision clauses were ratified by the owner on
   2026-07-28 or 2026-07-29. Implementation remains incomplete for the
   three-tool-call router and assistant-to-assistant communication primitive;
   acceptance records the architectural choice, not implementation completion.
   See "Implementation status" for the clause-by-clause state.
+- **Current amendment:** ADR-0058 preserves this model for Trusty Agents L1
+  leaves and distinguishes a cross-product, daemon-owned Trusty Code coding task
+  from an in-process sub-agent.
 - **Date:** 2026-07-28
 - **Ratification:** L0-assistant clause recorded 2026-07-28;
   editable-whitelist clause recorded 2026-07-29

--- a/docs/adr/0042-mcp-configuration-is-static-and-persistent.md
+++ b/docs/adr/0042-mcp-configuration-is-static-and-persistent.md
@@ -1,12 +1,14 @@
 # 0042. MCP configuration is static and persistent — the declaration lives once in user scope, and nothing injects it into a workspace
 
-- **Status:** Accepted
+- **Status:** Amended by [0058](0058-trusty-code-is-an-independent-product-owned-harness.md)
 - **Date:** 2026-08-10
 - **Accepted:** 2026-08-11
 - **Scope:** crate `trusty-mpm` (`core/session_launch/{settings,native_mcp,custom_mcp,search_index,mod}.rs`, `core/mcp_config.rs`, `core/standalone/{global_config,trust_seed}.rs`, `bin/tm/commands/mcp.rs`); crate `trusty-search` (the `serve --index` pin, which is the one declaration that cannot be shared as written)
 - **Reversibility Cost:** Medium — the deletion itself is cheap and mechanical, but it removes the mechanism that currently pins MCP *content* behind a pre-approved *name*, so restoring the old shape after the fact means re-deriving the whole #3918 → #3924 → #3926 → #3934 → #3950 chain of security fixes rather than reverting one commit
 - **Decision Drivers:** owner ruling 2026-08-10 (verbatim below); issue [#4181](https://github.com/bobmatnyc/trusty-tools/issues/4181), which gates the `tm 1.3.6` milestone and is what currently blocks the owner from using trusty-mpm at all; live measurement showing that workspace-scope declaration is what creates Claude Code's approval gate while user-scope declaration does not; the standing preference for deleting a mechanism over hardening it
-- **Supersedes / Superseded by:** — (amends nothing; see Related Decisions)
+- **Supersedes / Superseded by:** Amended by ADR-0058, which preserves static
+  user-scope declarations and defines Trusty Code's product-owned resolution and
+  lifecycle boundary; see Related Decisions
 
 ## Context
 

--- a/docs/adr/0058-trusty-code-is-an-independent-product-owned-harness.md
+++ b/docs/adr/0058-trusty-code-is-an-independent-product-owned-harness.md
@@ -1,0 +1,146 @@
+# 0058. Trusty Code is an independent, product-owned coding harness
+
+- **Status:** Accepted
+- **Date:** 2026-09-03
+- **Scope:** crate `trusty-code` — runtime, daemon, configuration roots, private
+  state, delegated coding tasks, client transport, and structured integration
+  with `trusty-mpm`
+- **Reversibility Cost:** High — the state root, client transport, task
+  ownership, and integration boundary shape every Trusty Code client and every
+  migration path off `.claude/`
+- **Decision Drivers:** independent releaseability; the owner ruling that Trusty
+  Code's native root is `.trusty-code/`; durable coding work that survives
+  client detach; shared MCP and channel contracts that do not make `trusty-mpm`
+  the runtime owner; [#5433](https://github.com/bobmatnyc/trusty-tools/issues/5433)
+  finding that accepted records disagree on all four boundaries
+- **Supersedes / Superseded by:** Amends ADR-0004, ADR-0024, and ADR-0042 for
+  the `trusty-code` boundary; supersedes nothing
+
+## Context
+
+Trusty Code has grown from a scaffold into a daemon-backed coding harness with
+JSON-RPC clients, session events, workstreams, agents, skills, plugins, and an
+HTTP/SSE client API. The workspace decisions that describe it were written
+before that runtime existed, and #5433's audit found four unresolved
+ambiguities:
+
+1. whether Code is an independent product or a `trusty-mpm` execution detail;
+2. whether its native files belong under `.claude/`, `.open-mpm/`, or a
+   product-owned root;
+3. whether delegated coding agents are ephemeral in-process leaves under
+   ADR-0024 or durable daemon-owned tasks; and
+4. whether its local client API is compatible with ADR-0032, which makes
+   `trusty-console` the only HTTP surface.
+
+Those ambiguities block a clean independent release and let one harness
+overwrite another harness's state.
+
+The fourth ambiguity has since been settled by the owner rather than left open.
+The 2026-08-19 ruling recorded on
+[#6637](https://github.com/bobmatnyc/trusty-tools/issues/6637) is verbatim:
+
+> Unix domain socket (UDS), not HTTP+auth. Implementation should replace the
+> loopback TCP listener with a UDS endpoint (filesystem permissions as the auth
+> boundary) rather than adding token auth to HTTP.
+
+This ADR records that ruling as Code's target transport rather than carving an
+HTTP exception out of ADR-0032.
+
+## Decision
+
+1. **Trusty Code is an independent product.** Its daemon owns coding sessions,
+   workstreams, delegated coding tasks, event history, and resumable execution.
+   `trusty-mpm` may orchestrate Code through a versioned structured API; it does
+   not own Code's runtime and does not scrape terminal panes to infer Code
+   state.
+2. **Trusty Code separates project configuration from private runtime state.**
+   `<project>/.trusty-code/` is the native root for declarative project
+   configuration, generated adapters, manifests, and provenance.
+   `~/.trusty-code/` is the private root for mutable runtime state: credentials,
+   transcripts, logs, channel cursors, caches, process/task/session metadata,
+   and resolved executable MCP lifecycle data. Host directories such as
+   `.claude/` and `.codex/` are import and export targets, never Code's source
+   of truth.
+3. **Delegated Code agents are daemon-owned durable tasks.** Client attachment
+   is optional and repeatable; detaching a CLI or TUI does not cancel a task.
+   Cancellation, authorization, and credential grants stay explicit at each
+   delegation boundary.
+4. **Trusty Code's client transport converges on UDS under ADR-0032.** Local
+   JSON-RPC over stdio remains a supported client surface. The loopback TCP
+   HTTP/SSE listener is interim compatibility, not a permitted product HTTP
+   surface: it is bearer-authenticated today
+   ([#6491](https://github.com/bobmatnyc/trusty-tools/pull/6491), shipped in
+   `trusty-code` 0.5.0) and is retired by #6637. Code never binds off-loopback
+   and never becomes the workspace's public ingress; `trusty-console` remains
+   the only externally reachable HTTP surface.
+5. **MCP and channel interoperability is contract sharing, not state sharing.**
+   Code imports versioned MCP server definitions and channel envelope schemas,
+   records non-secret project references and provenance under
+   `<project>/.trusty-code/`, resolves trusted executable definitions and
+   mutable lifecycle state under `~/.trusty-code/`, and owns process lifecycle
+   for the servers and tasks it starts. Imported executable definitions require
+   explicit provenance and trust validation. Code does not mutate MPM's managed
+   configuration.
+6. **Cross-product integration is adapter-based and versioned.** MPM receives
+   structured task identity, lifecycle, status, event, cancellation, and result
+   contracts. Compatibility failures are explicit; no path-based aliasing or
+   best-effort parsing substitutes for a negotiated contract.
+
+## Consequences
+
+- Trusty Code can be installed, operated, upgraded, and released without a
+  running MPM service.
+- Existing `.claude/` agent, skill, and plugin readers become compatibility
+  adapters with an explicit migration path to `.trusty-code/`.
+- Project configuration can be reviewed and shared without committing
+  transcripts, secrets, logs, executable resolution state, or session data.
+  Private state requires restrictive permissions and symlink-safe writes.
+- In-memory session state is insufficient for release readiness. `SessionRegistry`
+  is in-memory only today, so daemon-owned task identity and recovery are
+  release work, not a shipped property.
+- The GUI blocks the transport conversion. `trusty-code-gui`'s webview dials
+  `http://127.0.0.1:7882` from TypeScript, and neither `fetch` nor `EventSource`
+  can open a UDS, so #6637 needs a design round before it can be scheduled. The
+  interim bearer auth stays in force until it lands and does not substitute for
+  it.
+- MPM integration work can proceed independently against a stable API contract;
+  its implementation stays outside the `trusty-code` crate.
+
+## Related Decisions
+
+Vetted against the ADR corpus on 2026-09-03:
+
+- **ADR-0004 (Three event-driven harnesses):** Amends — preserves the peer
+  harness model and adds Trusty Code's ownership boundary now that its daemon
+  exists.
+- **ADR-0005 and ADR-0019 (Shared event bus and unified IPC):** Extends — Code
+  adopts the shared envelope and acknowledged messaging contracts through a
+  product-owned adapter. Its `SessionEventEnvelope` stays a local stream and is
+  not that bus.
+- **ADR-0014 and ADR-0040 (Native MCP support and packaging):** Consistent —
+  Code consumes MCP contracts without changing which crates implement native
+  services.
+- **ADR-0024 (In-process leaf sub-agents):** Amends — that rule stays in force
+  inside `trusty-agents`; a delegated *Trusty Code coding task* is a
+  cross-product daemon task, not an Agents L1 leaf.
+- **ADR-0026 (Credential grants stop at delegation):** Consistent — durable task
+  identity does not imply inherited credentials.
+- **ADR-0031 (Transport by caller purpose):** Consistent — stdio is a local
+  product-client transport and UDS is the same-host transport this record
+  converges on.
+- **ADR-0032 (Console is the only HTTP surface):** Consistent, not amended — the
+  2026-08-19 owner ruling on #6637 applies ADR-0032's UDS decision to Trusty
+  Code rather than carving an exception. The surviving loopback TCP listener is
+  a tracked deviation, not a permission.
+- **ADR-0042 (Static persistent MCP configuration):** Amends — user-level
+  declarations stay static; Code resolves imported declarations into its own
+  private state and never injects them into a workspace or into MPM's
+  configuration.
+- **ADR-0044 (Main-checkout write boundary and agent worktree ownership):**
+  Consistent — Code owns the worktrees and task state for agents it launches.
+- **ADR-0059 (Canonical agent behavior):** Extends — defines how shared authored
+  behavior enters this product-owned boundary.
+
+The amendments above resolve every conflict the #5433 audit identified. No other
+Accepted ADR assigns Trusty Code runtime or native state ownership to another
+product.

--- a/docs/adr/0059-canonical-agent-behavior-has-generated-host-adapters.md
+++ b/docs/adr/0059-canonical-agent-behavior-has-generated-host-adapters.md
@@ -1,0 +1,104 @@
+# 0059. Canonical agent behavior has generated host adapters
+
+- **Status:** Accepted
+- **Date:** 2026-09-03
+- **Scope:** Workspace-wide — authored instructions, agent definitions, and
+  skills consumed by `trusty-code`, `trusty-agents`, and `trusty-mpm`, plus the
+  host adapter generation that deploys them
+- **Reversibility Cost:** High — canonical identity, provenance, and adapter
+  generation determine how every harness receives agent behavior
+- **Decision Drivers:** the owner ruling that agent and skill sources are
+  identical across products; prevention of silent drift between hand-maintained
+  copies; compatibility with the Agent Skills `SKILL.md` package and Codex agent
+  conventions; independent per-product deployment roots
+- **Supersedes / Superseded by:** Supersedes
+  [ADR-0015](0015-three-product-agent-composition-model.md); superseded by
+  nothing
+
+## Context
+
+ADR-0015 proposed a common Markdown-plus-YAML shape with shared `extends`
+semantics, but still described separate product catalogs and product-specific
+composition purposes. The workspace now carries copied agents, skills, and
+instructions in several host directories. Equivalent behavior can drift while
+every copy stays syntactically valid, and no consumer can prove which authored
+source produced a deployed artifact.
+
+Host formats are not identical. Codex Agent Skills, Claude-compatible agents,
+and Trusty Code's native catalog need different directory layouts or metadata.
+Treating those adapters as separate authored sources preserves the drift
+problem. Treating one host's deployment directory as canonical couples the other
+products to that host.
+
+## Decision
+
+1. **One canonical authored source represents each instruction, agent, and
+   skill.** Products do not maintain behaviorally equivalent hand-edited copies.
+2. **Canonical identity and content are host-neutral.** The source records a
+   stable identifier, version and provenance, behavioral instructions,
+   capabilities, and composition references. Host-only metadata is isolated in
+   declared adapter data and cannot silently change the behavioral source.
+3. **Host layouts are deterministic generated adapters.** Trusty Code, Codex,
+   Claude-compatible consumers, Trusty Agents, and MPM may require different
+   paths or manifests; those artifacts are generated or validated from the same
+   canonical source.
+4. **Trusty Code deploys its resolved native catalog below `.trusty-code/`.**
+   `.codex/` and `.claude/` outputs are compatibility exports. Their existence
+   does not change source ownership.
+5. **The common baseline is the interoperable standards set already in use:**
+   Markdown instructions, YAML frontmatter where structured metadata is
+   required, the Agent Skills `SKILL.md` package shape for skills, and declared
+   MCP references rather than host-private embedded configuration.
+6. **Generation is reproducible and provenance-bearing.** Given the same
+   canonical inputs and adapter version, output bytes and semantic behavior are
+   stable. Generated artifacts identify their source and are checked for drift.
+7. **Staleness is repaired at the canonical source.** If a deployed artifact
+   disagrees with an Accepted spec, the source is corrected and every adapter is
+   regenerated. A one-host patch is not a valid fix.
+8. **Unsupported host semantics fail explicitly.** An adapter may not drop a
+   capability, instruction, tool restriction, or delegation rule without a
+   declared, testable compatibility disposition.
+
+## Consequences
+
+- Behavioral review happens once; host packaging becomes mechanical and
+  testable.
+- Existing hand-maintained `.agents/`, `.claude/`, and `.codex/` copies need a
+  provenance audit and either adoption as canonical content or replacement by
+  generated output.
+- A shared parser and resolver stays useful, but shared parsing alone no longer
+  satisfies the architecture.
+- MPM can adopt the canonical catalog on its own schedule. Code and Agents can
+  implement adapters without writing MPM-owned runtime code.
+- CI needs drift checks that compare generated output against committed or
+  deployed adapters and name the canonical source to fix.
+- The work is not started. `trusty-code` still embeds its own assets under
+  `src/assets/agents/` and `src/assets/skills/` alongside host copies;
+  [#5425](https://github.com/bobmatnyc/trusty-tools/issues/5425) is the
+  implementation.
+
+## Related Decisions
+
+Vetted against the ADR corpus on 2026-09-03:
+
+- **ADR-0015 (Unified agent composition, Proposed):** Supersedes — retains its
+  common Markdown/YAML shape and deterministic composition goals, and replaces
+  separately authored product catalogs with one canonical behavior source plus
+  generated adapters.
+- **ADR-0024 (In-process leaf sub-agents):** Consistent — agent topology is a
+  behavioral rule carried by the canonical source; this record does not change
+  the Agents L0/L1 runtime boundary.
+- **ADR-0025 (Collapse deployment hierarchies, Proposed):** Extends — preserves
+  deployment-time precedence and adds the requirement that every deployed
+  artifact points back to canonical content.
+- **ADR-0026 (Credential grants stop at delegation):** Consistent — adapters
+  must preserve credential and delegation restrictions.
+- **ADR-0042 (Static persistent MCP configuration):** Consistent — canonical
+  agents reference MCP identities; product adapters resolve persistent
+  declarations without workspace injection.
+- **ADR-0058 (Independent Trusty Code harness):** Extends — defines how shared
+  behavior enters the product-owned `.trusty-code/` boundary.
+
+No Accepted ADR requires independently authored host copies. ADR-0015 was only
+Proposed, and this record preserves its compatible format and composition
+semantics while resolving the source-identity gap.

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -1,6 +1,6 @@
 # ADR Index — All Decisions
 
-**Last updated:** 2026-08-17 | **Format version:** 1.1
+**Last updated:** 2026-09-03 | **Format version:** 1.1
 
 This index is the complete, concise vetting surface for workspace ADRs. The ADR
 files remain authoritative for full context, decision text, and consequences.
@@ -14,7 +14,7 @@ Crate-specific ADRs have independent sequences and indexes under
 | [0001](0001-docs-live-top-level.md) | Documentation lives at top level | Accepted | Design, research, and ADR documentation lives under `docs/`. | Workspace |
 | [0002](0002-single-install-convention.md) | Single-install convention | Accepted | Major crates share one Cargo-based installation convention. | Workspace |
 | [0003](0003-msrv-and-edition-policy.md) | MSRV 1.88 and edition policy | Superseded by 0029 | The workspace MSRV drives each crate's Rust edition. | Workspace |
-| [0004](0004-three-harnesses-shared-event-driven-common.md) | Three event-driven harnesses | Accepted | `trusty-code`, `trusty-mpm`, and `trusty-agents` are peer harnesses sharing event infrastructure from `trusty-common`. | Workspace |
+| [0004](0004-three-harnesses-shared-event-driven-common.md) | Three event-driven harnesses | Amended by 0058 | `trusty-code`, `trusty-mpm`, and `trusty-agents` are peer harnesses sharing event infrastructure from `trusty-common`. | Workspace |
 | [0005](0005-harness-event-bus.md) | Shared harness event bus | Amended by 0019 | A common event envelope and process-global telemetry bus serve all harnesses; ADR-0019 adds durable messaging to that bus. | Workspace |
 | [0006](0006-trusty-controller-naming.md) | `trusty-controller` naming | Superseded by 0013 | The control plane was named `trusty-controller` with binary `tctl`. | Workspace |
 | [0007](0007-tool-contract-versioning-and-verb-model.md) | Tool contract versioning | Accepted | Tool contracts use monotonic integer versions and Base/Extended/Custom verb layers. | Workspace |
@@ -25,7 +25,7 @@ Crate-specific ADRs have independent sequences and indexes under
 | [0012](0012-per-instance-guid-and-marker-file-identity.md) | Per-instance search identity | Amended by 0051 | A full-path primary key plus local UUID marker (`config.yaml` or `local.yaml`) identifies each search source instance. | Workspace |
 | [0013](0013-rename-trusty-controller-to-trusty-installer.md) | Rename controller to installer | Accepted | `trusty-controller` becomes `trusty-installer`; `tctl` is transitional. | Workspace |
 | [0014](0014-native-mcp-support.md) | Native MCP support | Amended by 0040, 0041 | Key MCP integrations remain in-workspace Rust services, with packaging and consumer boundaries refined later. | Workspace |
-| [0015](0015-three-product-agent-composition-model.md) | Unified agent composition | Proposed | Three orchestration products share an `.md` plus YAML `extends` format. | Workspace |
+| [0015](0015-three-product-agent-composition-model.md) | Unified agent composition | Superseded by 0059 | Three orchestration products share an `.md` plus YAML `extends` format. | Workspace |
 | [0016](0016-orchestration-hierarchy-lead-pm-assistant.md) | Lead / PM / Assistant hierarchy | Proposed | Engineering Lead, PM, and Assistant form the proposed orchestration hierarchy. | Workspace |
 | [0017](0017-shared-ingress-via-console-tailscale-funnel.md) | Shared webhook ingress | Proposed | External webhooks enter through trusty-console and Tailscale Funnel. | Workspace |
 | [0018](0018-loopback-only-doctrine.md) | Loopback-only service HTTP | Superseded by 0032 | Sibling daemons could expose loopback HTTP while only trusty-console bound off-loopback. | Workspace |
@@ -34,7 +34,7 @@ Crate-specific ADRs have independent sequences and indexes under
 | [0021](0021-slack-inbound-hybrid-gateway-eventstream.md) | Slack hybrid inbound | Accepted | Socket Mode remains the reply path while inbound events are also mirrored to the generic event stream. | `trusty-agents` |
 | [0022](0022-knowledge-tree-sync-model.md) | Knowledge-tree synchronization | Accepted | Configuration stays in the monorepo while each knowledge store may sync through its own repository. | Workspace |
 | [0023](0023-worktree-authority-existence-vs-ownership.md) | Worktree authority split | Accepted | Git decides existence; a rebuildable, fail-closed index decides ownership. | `trusty-mpm` |
-| [0024](0024-subagents-in-process-only-assistants-communicate-not-delegate.md) | In-process leaf sub-agents | Accepted | Assistants delegate to in-process single-edge leaves; delegation authority follows agent kind. | `trusty-agents` |
+| [0024](0024-subagents-in-process-only-assistants-communicate-not-delegate.md) | In-process leaf sub-agents | Amended by 0058 | Assistants delegate to in-process single-edge leaves; delegation authority follows agent kind. | `trusty-agents` |
 | [0025](0025-collapse-agent-and-skill-tier-hierarchies.md) | Collapse deployment hierarchies | Proposed | Declared sources deploy to one target with precedence resolved at deployment time. | `trusty-mpm`, `trusty-agents-common` |
 | [0026](0026-credential-grants-do-not-survive-delegation.md) | Credential grants stop at delegation | Accepted | Every delegated agent is a distinct principal and receives no inherited credential grant. | `trusty-common`, `trusty-agents`, `trusty-code` |
 | [0027](0027-rooms-are-real-wings-are-scopes-closets-are-an-index.md) | Rooms, wings, and closets | Proposed | Rooms become persisted entities, wings are scope boundaries, and closets are indexes. | `trusty-common`, `trusty-memory` |
@@ -52,7 +52,7 @@ Crate-specific ADRs have independent sequences and indexes under
 | [0039](0039-operator-named-sessions-unique-by-construction.md) | Unique operator-named sessions | Accepted | Operator names are unique and unsuffixed; serials remain for automatic creation. | `trusty-mpm` |
 | [0040](0040-trusty-mcp-services-absorbs-trusty-gworkspace.md) | Split MCP framework and services | Accepted | `trusty-mcp` holds protocol primitives and `trusty-mcp-services` initially absorbs gworkspace only. | Workspace |
 | [0041](0041-trusty-okg-native-crate-search-absorbs-okf-indexing.md) | Native trusty-okg with search indexing | Accepted | trusty-okg stays native, trusty-search owns OKF indexing, and an MCP service fronts agent reads. | Workspace |
-| [0042](0042-mcp-configuration-is-static-and-persistent.md) | Static persistent MCP configuration | Accepted | MCP declarations live once in user scope and are not injected into workspaces. | `trusty-mpm`, `trusty-search` |
+| [0042](0042-mcp-configuration-is-static-and-persistent.md) | Static persistent MCP configuration | Amended by 0058 | MCP declarations live once in user scope and are not injected into workspaces. | `trusty-mpm`, `trusty-search` |
 | [0043](0043-cargo-bin-policy.md) | Traceable `$CARGO_HOME/bin` provenance | Proposed | Registry installs, prebuilt placements, and user-managed files are classified explicitly; path installs are forbidden. | Workspace |
 | [0044](0044-main-checkout-write-boundary-and-agent-worktree-ownership.md) | Main-checkout write boundary | Amended by 0048, 0056 | Main-checkout sessions write only docs/config, and the harness—not trusty-mpm—owns agent worktree creation. | `trusty-mpm` |
 | [0045](0045-distinguish-absent-from-undeterminable-on-destructive-paths.md) | Absent vs undeterminable on destructive paths | Proposed | A probe feeding a destructive, enumerating, or operator-reporting operation propagates every error but `NotFound`. | Workspace |
@@ -68,6 +68,8 @@ Crate-specific ADRs have independent sequences and indexes under
 | [0055](0055-trusty-mpm-stops-creating-worktrees-the-sentinel-becomes-authoritative.md) | Trusty-mpm stops creating worktrees; the sentinel becomes authoritative | Accepted | `session_new`'s clone-and-worktree path is removed and a non-local `repo_url` becomes a hard error naming the local-clone remedy; the `.trusty-mpm-worktree` sentinel stays and is extended to cover every worktree under `.claude/worktrees/`, not only the ones trusty-mpm creates. | `trusty-mpm` |
 | [0056](0056-main-checkout-write-access-is-granted-by-role.md) | Main-checkout write access is granted by role | Accepted | The `version-control` agent keeps the checkout it is dispatched into — it is neither diverted into an isolation worktree nor denied beside another writer — because its writes are the merge, the branch delete, and the worktree reclaim, none of which can be done from inside a worktree; it still counts as an occupant, and engineer source-write confinement is unchanged. | `trusty-mpm` |
 | [0057](0057-version-control-owns-worktree-removal.md) | version-control owns worktree removal | Accepted | A dispatched `version-control` agent may run `git worktree remove`, but only on a target the guard itself proves is a harness worktree, clean, fully pushed, held by no other live writer, and carrying a MERGED pull request on GitHub; `agent_type` counts only alongside an `agent_id`, every re-check fails closed, and `tm session prune-worktrees --merged-prs --force` stays the default sweep. | `trusty-mpm` |
+| [0058](0058-trusty-code-is-an-independent-product-owned-harness.md) | Trusty Code is an independent harness | Accepted | Trusty Code owns its daemon, `.trusty-code/` config and `~/.trusty-code/` private state, and durable delegated coding tasks; its client transport converges on UDS under ADR-0032 with the loopback TCP listener as a tracked interim, and `trusty-mpm` integrates only through a versioned structured API. | `trusty-code` |
+| [0059](0059-canonical-agent-behavior-has-generated-host-adapters.md) | Canonical agent behavior, generated adapters | Accepted | One host-neutral authored source represents each instruction, agent, and skill; `.trusty-code/`, `.claude/`, and `.codex/` layouts are deterministic generated adapters that carry provenance and are checked for drift. | Workspace |
 
 ## Notes
 

--- a/docs/architecture/harnesses.md
+++ b/docs/architecture/harnesses.md
@@ -4,7 +4,13 @@
 **Version:** v2
 **Subsystem:** HARNESSES
 **Owner:** Engineering / Architecture
-**Last-updated:** 2026-08-07
+**Last-updated:** 2026-09-03
+
+> **Trusty Code boundary:** This page describes both shipped compatibility
+> readers and target architecture. ADR-0058 makes `.trusty-code/` the native
+> Code root; the `.claude/` paths below are compatibility inputs. See the
+> [reconciliation catalog](../trusty-code/spec-adr-reconciliation.md) for the
+> shipped, partial, and deferred status of each Code contract.
 
 ---
 

--- a/docs/specs/DOC-51-tcode-plugin-support-phase1.md
+++ b/docs/specs/DOC-51-tcode-plugin-support-phase1.md
@@ -15,6 +15,12 @@ spec_refs:
 **Linked issues:** [#3539](https://github.com/bobmatnyc/trusty-tools/issues/3539) (Phase 1 scope decision); [#3542](https://github.com/bobmatnyc/trusty-tools/issues/3542) (base-agent listing filter, consumed unchanged); [#3465](https://github.com/bobmatnyc/trusty-tools/pull/3465) (skills whole-catalog-replacement threshold, consumed unchanged); [PR #3547 code-critic review](https://github.com/bobmatnyc/trusty-tools/pull/3547) (hostile-plugin-input hardening + dispatch wiring, §2.5)
 **Cross-ref:** `crates/trusty-code/src/plugins/{mod,agents,skills}.rs` (this spec's implementation, incl. `is_valid_namespaced_name`/`safe_plugin_subdir`); `crates/trusty-code/src/agents/{mod,md_loader,protocol}.rs` (agent discovery/loading/catalog, reused not forked); `crates/trusty-code/src/skills/{mod,protocol}.rs` (skill discovery/catalog, reused not forked); `crates/trusty-code/src/tools/{delegate,skill}.rs`, `crates/trusty-code/src/runner/in_process.rs`, `crates/trusty-code/src/main.rs` (namespaced-dispatch validation gates, §2.5)
 
+> **Reconciled status (2026-09-03):** Phase 1 local-directory discovery and
+> namespaced dispatch are implemented and tested. The spec stays Draft because
+> later plugin phases are unresolved. `.claude/plugins/` is a compatibility
+> input; ADR-0058 makes `.trusty-code/` the native product root. See the
+> [Trusty Code reconciliation catalog](../trusty-code/spec-adr-reconciliation.md).
+
 > **Scope note.** This is a **behavior contract** for Phase 1 of Claude Code
 > plugin support: ingesting a plugin's `agents/` and `skills/` from a **local
 > directory** only. It explicitly does **not** cover marketplace/git-fetched

--- a/docs/specs/DOC-60-bus-based-agent-messaging.md
+++ b/docs/specs/DOC-60-bus-based-agent-messaging.md
@@ -40,6 +40,11 @@ equally-specified first-class sections per owner instruction; documents
 assistant↔assistant as the replacement for the delegation lane closed by
 PR #4240/ADR-0024)
 
+> **Trusty Code disposition (2026-09-03):** This shared bus stays Draft and is
+> not implemented by Trusty Code. Its `SessionEventEnvelope` remains the local
+> ordered replay and live stream; it must not be presented as the durable
+> cross-agent channel. Adoption is tracked by #5429 and governed by ADR-0058.
+
 ## 1. Summary
 
 This spec unifies **three** communication paths onto **one** addressed,

--- a/docs/specs/DOC-61-canonical-agent-standard.md
+++ b/docs/specs/DOC-61-canonical-agent-standard.md
@@ -8,8 +8,14 @@ spec_refs: []
 **Spec ID:** `SPEC-AGENTSTD-01~draft`
 **Subsystem:** cross-crate — trusty-mpm (source model owner today), trusty-code (per-product builder, prospective), trusty-agents (assistant/sub-agent split, `agents::config`)
 **Owner:** Architecture / Technical Leadership
-**Last-updated:** 2026-07-28
+**Last-updated:** 2026-09-03
 **DOC-N claim:** `DOC-61`, scan-before-claim per DOC-38 §4.1. `DOC-60` is left open — a bus-messaging spec is being authored concurrently by another agent in this same review round and is expected to claim it; this document deliberately claims one number past it to avoid a collision. `DOC-42` is explicitly NOT reused: it is currently claimed by `docs/specs/agent-bundled-skills.md` (retiring) and is reserved for ADR-0016's Engineering Lead / Virtual Twin architecture (PR #3006) per owner instruction. See docs/specs/README.md's "next free DOC-N" note for the full collision ledger (DOC-42, DOC-46 both currently double-booked, neither touched by this document).
+
+> **Architecture amendment (2026-09-03):** ADR-0059 accepts one canonical
+> authored behavior source for instructions, agents, and skills. Per-product
+> builders and artifact layouts stay separate; per-product hand-authored
+> behavioral copies do not. Trusty Code's native output is under
+> `.trusty-code/`, with `.claude/` and `.codex/` as generated adapters.
 
 ## 1. Executive Summary {#SPEC-AGENTSTD-01~draft}
 

--- a/docs/specs/DOC-62-style-modes-coding-delegation.md
+++ b/docs/specs/DOC-62-style-modes-coding-delegation.md
@@ -30,6 +30,12 @@ spec_refs:
 **Cross-ref:** [#4346](https://github.com/bobmatnyc/trusty-tools/issues/4346) (this spec), [#4348](https://github.com/bobmatnyc/trusty-tools/issues/4348) (tcode style parameter), [#4349](https://github.com/bobmatnyc/trusty-tools/issues/4349) (`HandoffContext` style field + policy preamble), [#4350](https://github.com/bobmatnyc/trusty-tools/issues/4350) (addressable tcode PM target), [#4353](https://github.com/bobmatnyc/trusty-tools/issues/4353) (GUI selector), [#2596](https://github.com/bobmatnyc/trusty-tools/issues/2596) (VIBE execution tier), [#4126](https://github.com/bobmatnyc/trusty-tools/issues/4126) (prompt-injection floor)
 **DOC-N claim:** `DOC-62`, scan-before-claim per DOC-38 §4.1. The scan covered every tracked file under `docs/specs/**` and `docs/trusty-installer/research/02-design/**` on `origin/main` **and on every remote branch** (`git for-each-ref refs/remotes/origin`) — the highest claimed DOC number anywhere in the repository, on any branch, is `DOC-61`. `DOC-62` is also what the catalog's (advisory) "next free" note advertises, so hint and scan agree. Four pre-existing collisions are grandfathered in `.doc-number-allowlist.tsv` (`DUP-DOC 28/32/33`, `DUP-ADR 21`); this document deliberately adds no fifth.
 
+> **Implementation status (2026-09-03):** The behavior decision is Accepted,
+> but Trusty Code has no style-mode type or dispatch branch. The `~draft`
+> section IDs also need lifecycle cleanup before code may claim conformance.
+> Track implementation through #4348 and #4349; this document's acceptance is
+> not evidence that the feature ships.
+
 ---
 
 ## 1. Executive Summary {#SPEC-STYLE-01~draft}

--- a/docs/specs/DOC-65-universal-framework-agents.md
+++ b/docs/specs/DOC-65-universal-framework-agents.md
@@ -22,6 +22,12 @@ spec_refs:
 **Builds on:** [ADR-0025](../adr/0025-collapse-agent-and-skill-tier-hierarchies.md) and its 2026-08-03 addendum ("Manifest-Based Project Configuration and the Four-Category Agent Model", §B1–B6) — the deployment/sourcing/precedence model this document maps its catalog onto, cited not restated. [DOC-61](./DOC-61-canonical-agent-standard.md) — the compose-chain source format (`extends:` inheritance, frontmatter merge, per-product builders) every agent cataloged here is built from, cited not restated. `crates/trusty-mpm/src/assets/instructions/sections/agent-delegation.md` — the hand-authored routing prose this document formalizes into a governed spec artifact without duplicating its table.
 **Related issues:** **#4755** (this spec), **#4760** (the framework manifest this document was updated for), **#5202** (workflow/ticketing/version-control ownership) — scheduled in the 1.3.5 release line
 
+> **Source-ownership amendment (2026-09-03):** The MPM asset paths below are
+> current provenance, not permanent canonical ownership. ADR-0059 requires one
+> host-neutral authored source and generated per-product adapters. Trusty Code
+> and Trusty Agents implementation is #5425; MPM adoption is a separate
+> cross-product handoff.
+
 ---
 
 ## 1. Summary

--- a/docs/trusty-code/README.md
+++ b/docs/trusty-code/README.md
@@ -20,6 +20,7 @@ documentation. The crate `README.md` and rustdoc stay in-crate.
 ## Where to start
 
 - **Vision & Architecture (RE-VISION approved)?** [`vision-and-architecture-spec.md`](vision-and-architecture-spec.md) — foundational spec for the re-visioned trusty-code: daemon-first token-efficient coding harness (supersedes old benchmark scope). Includes axioms, feature audit, phased roadmap, and open questions for owner decision.
+- **What is actually shipped now?** [`spec-adr-reconciliation.md`](spec-adr-reconciliation.md) — maintained contract catalog linking each requirement to implementation evidence, tests, roadmap ownership, and its ADR disposition.
 - **What is tcode and how does it relate to trusty-agents / Claude Code?**
   [`research/claude-compat-spec-2026-06-02.md`](research/claude-compat-spec-2026-06-02.md)
   — the authoritative compatibility specification, including the full

--- a/docs/trusty-code/parity-spec.md
+++ b/docs/trusty-code/parity-spec.md
@@ -8,6 +8,12 @@
 > (cross-provider tool-calling), [#1028](https://github.com/bobmatnyc/trusty-tools/issues/1028)
 > (multi-turn agent loop).
 
+> **Scope correction (2026-09-03):** This contract applies only when the user
+> explicitly selects a cross-model parity run. It is not the product roadmap.
+> The per-agent source is canonical Markdown/YAML behavior rendered through host
+> adapters under ADR-0059, not `<project>/.claude/agents/<name>.toml`. See the
+> [reconciliation catalog](./spec-adr-reconciliation.md).
+
 This is a **decision document**. It defines the *parity floor*: the fixed
 system-instruction surface that trusty-code assembles into **every** agent
 prompt, identically across model slugs and providers, so that a cross-model
@@ -124,7 +130,7 @@ runs of the same task. Those either belong to other sections or are excluded
 
 Injected verbatim from the agent's `AgentConfig`
 (`crates/trusty-code/src/agents/config.rs`): the `[system_prompt].content`
-field of `<project>/.claude/agents/<name>.toml`. This is what differentiates
+field of the resolved canonical agent definition. This is what differentiates
 `engineer` from `python-engineer` from `qa`. Because it comes from on-disk
 config, it is identical across models for a given agent — satisfying parity.
 

--- a/docs/trusty-code/spec-adr-reconciliation.md
+++ b/docs/trusty-code/spec-adr-reconciliation.md
@@ -1,0 +1,132 @@
+---
+spec_refs:
+  - id: SPEC-TCUI-09~draft
+    path: docs/specs/trusty-code-harness-ui.md
+    anchor: SPEC-TCUI-09~draft
+  - id: SPEC-WS-01~draft
+    path: docs/specs/DOC-48-tcode-workstreams.md
+    anchor: SPEC-WS-01~draft
+  - id: SPEC-TCPLUGIN-01~draft
+    path: docs/specs/DOC-51-tcode-plugin-support-phase1.md
+    anchor: SPEC-TCPLUGIN-01~draft
+  - id: SPEC-AGENTBUS-01~draft
+    path: docs/specs/DOC-60-bus-based-agent-messaging.md
+    anchor: SPEC-AGENTBUS-01~draft
+  - id: SPEC-AGENTSTD-01~draft
+    path: docs/specs/DOC-61-canonical-agent-standard.md
+    anchor: SPEC-AGENTSTD-01~draft
+---
+
+# Trusty Code specification and ADR reconciliation
+
+**Status:** Accepted implementation-status catalog
+**Owner:** Trusty Code
+**Last updated:** 2026-09-03
+**Roadmap gate:** [#5433](https://github.com/bobmatnyc/trusty-tools/issues/5433)
+
+## Authority and lifecycle
+
+This catalog is the maintained implementation-status companion to the Trusty
+Code specifications. It does not replace their behavioral detail. When old
+prose, source, and roadmap state disagree, apply this precedence:
+
+1. Accepted ADRs define architecture and ownership.
+2. Accepted spec sections define behavior.
+3. This catalog states whether that behavior is shipped, partial, deferred, or
+   superseded, and names the work that closes the gap.
+4. Draft specs are design inputs. A draft is not a claim that its complete
+   surface ships.
+5. Historical research records host behavior observed on its stated date. It is
+   not a current Trusty Code product contract.
+
+`docs/trusty-code/vision-and-architecture-spec.md` remains the accepted product
+vision. Its dated phase tables are historical planning evidence; this catalog
+and milestones R1–R4 are authoritative for current implementation status.
+
+## Normative statement catalog
+
+| Contract | Status | Implementation owner | Code evidence | Verification | Roadmap | Disposition |
+|---|---|---|---|---|---|---|
+| Code is a daemon-first, independent coding harness | Implemented, hardening | Trusty Code | `src/main.rs`, `src/serve/mod.rs`, `src/jsonrpc/`, `src/session/` | `tests/m1_cutline_e2e.rs`, `tests/connector_e2e.rs` | #2063 / R1 | Retained; ownership fixed by ADR-0058 |
+| JSON-RPC stdio is a supported local client surface | Implemented | Trusty Code | `src/serve/mod.rs`, `src/jsonrpc/` | daemon and M1 end-to-end tests | #2063 / R1 | Retained |
+| The local client API converges on UDS; the loopback TCP listener is interim | Partially implemented | Trusty Code | `src/serve/http.rs`, `src/serve/transport.rs`, `src/session/connector.rs` | `src/serve/http_auth_tests.rs`, `src/serve/http_origin_guard_tests.rs` | #6637 / R1 | Bearer auth shipped (#6491, 0.5.0). ADR-0058 applies ADR-0032's UDS ruling to Code rather than granting an HTTP exception; the surviving TCP listener is a tracked deviation blocked on the GUI's `fetch`/`EventSource` transport |
+| Session create/list/status/send/attach/detach/cancel and transcript APIs are daemon-authoritative | Implemented in memory | Trusty Code | `src/session/protocol.rs`, `src/session/registry.rs` | `src/session/registry_tests.rs`, M1 end-to-end tests | #2063 / R1 | Retained; restart durability is not implied |
+| Workstreams are durable named aggregates with activation rules | Implemented core, draft spec remains broader | Trusty Code | `src/workstreams/store.rs`, `src/workstreams/activation.rs`, `src/workstreams/protocol.rs` | workstream module tests | #2063 / R1 | DOC-48 remains Draft; only code-linked clauses ship |
+| CLI and TUI are thin daemon clients | Partially implemented | Trusty Code | `src/cli/`, `src/cli_client/` | CLI/TUI unit and daemon-autospawn tests | #2063 / R1 | DOC-50 remains Draft; unbuilt Web/UI clauses are deferred |
+| Local Claude-compatible plugins contribute namespaced agents and skills | Implemented compatibility adapter | Trusty Code | `src/plugins/`, `src/agents/`, `src/skills/` | `src/plugins/agents_tests.rs`, `src/plugins/skills_tests.rs` | #5425 / R2 | DOC-51 Phase 1 ships; the native root moves to `.trusty-code/` |
+| Project `.trusty-code/` owns declarative config; user `~/.trusty-code/` owns private mutable state | Accepted, not complete | Trusty Code | `src/build_info.rs`, `src/workstreams/path.rs`, `src/agent_loop/telemetry.rs`; other readers still use `.claude/` | path, permission, symlink, and secret-exclusion tests required | #5426 / R2 | ADR-0058 supersedes native `.claude/` ownership. The private root is live; the project root is not |
+| Instructions, agents, and skills have one canonical authored source | Accepted, not complete | Trusty Code + Trusty Agents; MPM via handoff | `src/assets/agents/`, `src/assets/skills/` still coexist with host copies | provenance and byte/semantic drift tests required | #5425 / R2 | ADR-0059 supersedes ADR-0015 and narrows DOC-61's per-product-source wording |
+| Skills use the Agent Skills `SKILL.md` package as the interoperable baseline | Partially implemented | Trusty Code + Trusty Agents | `src/assets/skills/`, `src/skills/` | asset and skill protocol tests | #5425 / R2 | Retained; adapters may add host metadata without forking behavior |
+| MCP declarations are shared by definition while Code owns resolution and process lifecycle | Designed, not wired generically | Trusty Code; shared declaration work via MPM handoff | `src/tools/trusty_search.rs`, `src/session/registry_memory_sink.rs` are specific adapters; generic external invocation is absent | contract, import, and lifecycle tests required | #5428 / R3 | ADR-0058 amends ADR-0042; `.mcp.json`-as-native wording is superseded |
+| Code session events retain ordered replay and live streaming | Implemented | Trusty Code | `src/events.rs`, `src/session/registry.rs` | registry replay/eviction tests, connector tests | #2063 / R1 | `SessionEventEnvelope` remains the local session stream |
+| Cross-agent and cross-user messaging uses the shared durable channel contract | Designed, not adopted by Code | Trusty Code + Trusty Agents; bus host via MPM handoff | `src/events.rs` provides only the local session bus and the legacy stderr prefix | channel conformance tests required | #5429 / R3 | DOC-60 remains Draft; local session events are not the durable message bus |
+| Delegated coding agents are durable daemon-owned tasks | Accepted, not implemented | Trusty Code | `src/session/registry.rs` documents itself as in-memory only | restart, reattach, cancel, and credential-boundary tests required | #5430 / R3 | ADR-0058 distinguishes these from ADR-0024's Agents L1 leaves |
+| MPM integrates with Code only through a versioned structured API | Accepted; Code side pending | Trusty Code API; the MPM client is owned outside this crate | `src/jsonrpc/` provides the starting protocol types | compatibility and failure-contract tests required | #5431 / MPM release | No pane scraping and no shared state paths |
+| `run-workflow` is a supported workflow engine | Not implemented | None in R1–R4 | `src/main.rs` declares the command and exits as unimplemented | implementation and contract tests required if reactivated | Deferred | Historical phase promise; no clean-release requirement |
+| Style modes `hack`, `vibe`, and `engineer` are a public delegation contract | Accepted spec, implementation absent | Trusty Code + Trusty Agents | no style-mode type or dispatch branch exists under `src/` | contract tests required | #4348 / #4349 | DOC-62's status is Accepted, but its `~draft` IDs must be versioned before implementation is claimed |
+
+Paths above are relative to `crates/trusty-code/` unless they begin with
+`docs/`.
+
+## Source and deployment boundary
+
+| Artifact | Canonical authored source | Trusty Code native result | Compatibility outputs |
+|---|---|---|---|
+| Instructions | shared, host-neutral authored sections | `.trusty-code/instructions/` plus provenance | `AGENTS.md`, `CLAUDE.md`, host-specific instruction files |
+| Agents | shared canonical agent catalog | `.trusty-code/agents/` resolved catalog | `.codex/agents/`, `.claude/agents/` where supported |
+| Skills | shared Agent Skills-compatible packages | `.trusty-code/skills/` resolved catalog | `.codex/skills/`, `.claude/skills/` |
+| MCP | shared versioned server definitions | project `.trusty-code/mcp/` references and provenance; private `~/.trusty-code/mcp/` trusted resolution and lifecycle | host config import and export; never executable workspace injection |
+| Channels | shared versioned envelope schema | project `.trusty-code/channels/` declarations; private `~/.trusty-code/channels/` cursors and task routing | host transport adapters |
+| Runtime | Trusty Code daemon | private `~/.trusty-code/` logs, transcripts, credentials, and task/session state | read-only client views |
+
+Exact filenames and migration behavior remain implementation details of #5425,
+#5426, #5428, and #5429. The ownership and the direction of conversion are fixed
+by ADR-0058 and ADR-0059.
+
+## Reconciled document dispositions
+
+- **`architecture/harnesses.md`:** Accepted architecture overview. A `.claude/`
+  path there states current compatibility behavior, not native ownership.
+  ADR-0058 controls the target boundary.
+- **Vision and architecture spec:** Accepted product vision. Its implementation
+  gap table and phase issue numbers are historical as of 2026-07-06; use this
+  catalog for current status.
+- **Parity spec:** Accepted only for explicit cross-model parity runs. Its TOML
+  agent-source statement is superseded by canonical Markdown/YAML sources and
+  generated adapters under ADR-0059.
+- **DOC-39, DOC-48, DOC-50:** Draft product and UI specifications with partially
+  shipped API, workstream, and TUI slices. An unchecked or unlinked section is
+  not a release claim.
+- **DOC-51:** Draft specification whose local-directory Phase 1 behavior ships.
+  Its `.claude/plugins/` root becomes a compatibility adapter after R2.
+- **DOC-60:** Draft shared communication specification. Trusty Code's
+  `SessionEventEnvelope` survives as a local replay and live stream; it is not
+  the cross-agent durable bus.
+- **DOC-61:** Draft source-model specification, amended in direction by
+  ADR-0059: product builders stay separate, authored behavior does not.
+- **DOC-62:** Accepted behavior decision with stale `~draft` section IDs. Treat
+  implementation as absent until the IDs and code linkage are reconciled.
+- **DOC-65:** Draft catalog. Its MPM source paths describe current provenance,
+  not permanent canonical ownership; MPM implementation is #5431.
+- **Research under `docs/trusty-code/research/`:** Historical evidence only,
+  governed by the source date in each file.
+
+## Mechanical reconciliation gate
+
+`scripts/check_trusty_code_specs.sh` runs in the `Doc numbers` workflow and
+rejects these regressions:
+
+- a claim that `.claude/`, `.codex/`, or `.open-mpm/` is Code's native source,
+  or that repository-local `.trusty-code/` owns private mutable runtime state;
+- a new Trusty Code event prefix or cross-agent envelope that bypasses the
+  shared versioned contract;
+- an implementation claim for a Draft or `~draft` requirement with no code and
+  test evidence;
+- a normative Trusty Code requirement with no owner, verification target, and
+  roadmap disposition in this catalog; or
+- a generated agent, skill, or instruction artifact with no canonical-source
+  provenance.
+
+The repository ADR and document-number checks stay mandatory. R2 and R3 may
+begin only while this catalog, ADR-0058, and ADR-0059 are present and those
+checks pass.

--- a/docs/trusty-code/vision-and-architecture-spec.md
+++ b/docs/trusty-code/vision-and-architecture-spec.md
@@ -3,8 +3,16 @@
 **Status:** FOUNDATIONAL SPEC — RE-VISION APPROVED  
 **Epic:** [#2052](https://github.com/bobmatnyc/trusty-tools/issues/2052) — trusty-code: original best-of-breed coding harness  
 **Owned by:** Bob Matsuoka (owner decision points marked below)  
-**Last updated:** 2026-07-06  
+**Last updated:** 2026-09-03  
 **Supersedes:** Epic #1039 (old benchmark harness scope)
+
+> **Implementation status:** This remains the accepted product vision, but its
+> dated phase tables and gap inventory are historical planning evidence. The
+> [spec/ADR reconciliation catalog](./spec-adr-reconciliation.md) is
+> authoritative for shipped, partial, deferred, and superseded requirements.
+> ADR-0058 makes `.trusty-code/` the native product root; the `.claude/` and
+> `.mcp.json` references below describe compatibility inputs until their R2/R3
+> adapters land.
 
 ---
 

--- a/scripts/check_trusty_code_specs.sh
+++ b/scripts/check_trusty_code_specs.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Keep Trusty Code's reconciled architecture and status claims from drifting.
+#
+# #5433 found that Trusty Code's specs and ADRs disagreed with the shipped code
+# on four boundaries: native config root, event/channel authority, MCP topology,
+# and canonical agent composition. The reconciliation catalog
+# (docs/trusty-code/spec-adr-reconciliation.md) is the machine-readable record
+# that closed those gaps; this gate keeps prose from silently reopening them.
+#
+# Runs in .github/workflows/doc-numbers.yml alongside check_adr.sh and
+# check_doc_numbers.sh. Pure text scanning — no Rust toolchain needed.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CATALOG="$ROOT/docs/trusty-code/spec-adr-reconciliation.md"
+VISION="$ROOT/docs/trusty-code/vision-and-architecture-spec.md"
+PARITY="$ROOT/docs/trusty-code/parity-spec.md"
+ADR_CODE="$ROOT/docs/adr/0058-trusty-code-is-an-independent-product-owned-harness.md"
+ADR_SOURCE="$ROOT/docs/adr/0059-canonical-agent-behavior-has-generated-host-adapters.md"
+INDEX="$ROOT/docs/adr/INDEX.md"
+DOC60="$ROOT/docs/specs/DOC-60-bus-based-agent-messaging.md"
+DOC62="$ROOT/docs/specs/DOC-62-style-modes-coding-delegation.md"
+EVENTS="$ROOT/crates/trusty-code/src/events.rs"
+
+# The catalog table is the ownership/status/evidence map #5433 requires. Dropping
+# a row is an architecture change, so the floor tracks the current row count.
+CATALOG_ROW_FLOOR=17
+
+errors=0
+
+fail() {
+  printf 'trusty-code-spec-check: %s\n' "$*" >&2
+  errors=$((errors + 1))
+}
+
+require_file() {
+  [ -f "$1" ] || fail "missing ${1#"$ROOT/"}"
+}
+
+require_text() {
+  local file="$1"
+  local text="$2"
+  grep -qF -- "$text" "$file" ||
+    fail "${file#"$ROOT/"} is missing required contract marker: $text"
+}
+
+for file in "$CATALOG" "$VISION" "$PARITY" "$ADR_CODE" "$ADR_SOURCE" "$INDEX" \
+  "$DOC60" "$DOC62" "$EVENTS"; do
+  require_file "$file"
+done
+
+if ((errors == 0)); then
+  # Ownership and adapter direction are the non-negotiable reconciliation
+  # boundary. Exact markers keep this gate simple and reviewable.
+  require_text "$ADR_CODE" '**Status:** Accepted'
+  require_text "$ADR_CODE" '**Trusty Code separates project configuration from private runtime state.**'
+  require_text "$ADR_CODE" '`~/.trusty-code/` is the private root for mutable runtime state'
+  require_text "$ADR_CODE" '**Delegated Code agents are daemon-owned durable tasks.**'
+  require_text "$ADR_CODE" "**Trusty Code's client transport converges on UDS under ADR-0032.**"
+  require_text "$ADR_SOURCE" '**Status:** Accepted'
+  require_text "$ADR_SOURCE" '**One canonical authored source represents each instruction, agent, and'
+  require_text "$ADR_SOURCE" '**Host layouts are deterministic generated adapters.**'
+  require_text "$INDEX" '| [0058]('
+  require_text "$INDEX" '| [0059]('
+
+  # Every roadmap boundary named by #5433 keeps an owner/status/evidence row.
+  for issue in '#2063' '#5425' '#5426' '#5428' '#5429' '#5430' '#5431' '#6637'; do
+    require_text "$CATALOG" "$issue"
+  done
+  for status in 'Implemented' 'Partially implemented' 'Accepted, not complete' \
+    'Designed, not wired generically' 'Accepted, not implemented' 'Not implemented'; do
+    require_text "$CATALOG" "$status"
+  done
+
+  require_text "$VISION" '[spec/ADR reconciliation catalog](./spec-adr-reconciliation.md)'
+  require_text "$PARITY" 'canonical Markdown/YAML behavior rendered through'
+  require_text "$DOC60" 'Its `SessionEventEnvelope` remains the'
+  require_text "$DOC62" 'Trusty Code has no style-mode type or dispatch branch.'
+  require_text "$EVENTS" 'pub use trusty_agents_common::events::EVENT_LINE_PREFIX;'
+  require_text "$CATALOG" 'legacy stderr prefix'
+
+  # Trusty Code's client transport converges on UDS (ADR-0032 applied to Code by
+  # the 2026-08-19 owner ruling on #6637). The catalog must keep naming the
+  # surviving loopback TCP listener as interim, never as a granted exception.
+  require_text "$CATALOG" 'the loopback TCP listener is interim'
+  if grep -Eqi 'loopback( TCP)? HTTP (is|remains) (a |an |the )?(permitted|accepted|permanent)' \
+    "$CATALOG" "$ADR_CODE"; then
+    fail 'reconciled docs restored loopback HTTP as a permitted Trusty Code surface'
+  fi
+
+  # Validate every normative catalog row structurally.
+  catalog_rows="$(awk -F'|' '
+    /^## Normative statement catalog$/ { in_catalog=1; next }
+    in_catalog && /^Paths above / { exit }
+    in_catalog && /^\|/ && $2 !~ /^( Contract|---)/ { count++ }
+    END { print count + 0 }
+  ' "$CATALOG")"
+  if ((catalog_rows < CATALOG_ROW_FLOOR)); then
+    fail "normative catalog scan floor failed: found $catalog_rows row(s), expected at least $CATALOG_ROW_FLOOR"
+  fi
+  while IFS=$'\t' read -r contract status owner evidence verification roadmap disposition; do
+    for pair in \
+      "contract:$contract" "status:$status" "owner:$owner" \
+      "evidence:$evidence" "verification:$verification" \
+      "roadmap:$roadmap" "disposition:$disposition"; do
+      value="${pair#*:}"
+      [ -n "$value" ] || fail "normative catalog row has an empty ${pair%%:*} cell: $contract"
+    done
+    if [ "$verification" = "none" ]; then
+      fail "normative catalog row has no verification target: $contract"
+    fi
+    if [[ "$evidence" != *'`src/'* ]]; then
+      fail "normative catalog row has no Trusty Code source evidence or explicit absence path: $contract"
+    fi
+    if [[ "$roadmap" != *'#'* && "$roadmap" != "Deferred" ]]; then
+      fail "normative catalog row has no issue or Deferred disposition: $contract"
+    fi
+  done < <(
+    awk -F'|' '
+      /^## Normative statement catalog$/ { in_catalog=1; next }
+      in_catalog && /^Paths above / { exit }
+      in_catalog && /^\|/ && $2 !~ /^( Contract|---)/ {
+        for (i=2; i<=8; i++) {
+          gsub(/^[[:space:]]+|[[:space:]]+$/, "", $i)
+        }
+        printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", $2,$3,$4,$5,$6,$7,$8
+      }
+    ' "$CATALOG"
+  )
+
+  # Every source path cited as implementation evidence must exist. This caught
+  # the stale src/serve.rs, src/http.rs, and src/build_state.rs claims in the
+  # original reconciliation draft.
+  while IFS= read -r evidence_path; do
+    relative="${evidence_path#\`}"
+    relative="${relative%\`}"
+    [ -e "$ROOT/crates/trusty-code/$relative" ] ||
+      fail "catalog cites missing Trusty Code evidence path: $relative"
+  done < <(grep -oE '`src/[A-Za-z0-9_./-]+`' "$CATALOG" | sort -u)
+
+  # The obsolete TOML claim was a concrete source-format contradiction.
+  if grep -qF 'field of `<project>/.claude/agents/<name>.toml`' "$PARITY"; then
+    fail 'parity spec restored the superseded TOML agent-source claim'
+  fi
+
+  if grep -Eq 'native (source|state|deployment).*`?\.claude/' \
+    "$VISION" "$PARITY" "$CATALOG"; then
+    fail 'maintained Trusty Code docs restored .claude/ as a native product root'
+  fi
+fi
+
+if ((errors > 0)); then
+  printf 'trusty-code-spec-check: %d violation(s)\n' "$errors" >&2
+  exit 1
+fi
+
+printf 'trusty-code-spec-check: reconciliation contracts are consistent\n'

--- a/scripts/detect-docs-only.sh
+++ b/scripts/detect-docs-only.sh
@@ -89,6 +89,7 @@ is_inert_path() {
       .test-pointer-allowlist.tsv | \
       scripts/check_adr.sh | \
       scripts/check_doc_numbers.sh | \
+      scripts/check_trusty_code_specs.sh | \
       scripts/check_sld.sh | \
       scripts/check_test_pointers.sh | \
       scripts/check_token_drift.mjs | \


### PR DESCRIPTION
## Outcome

trusty-code's specs and ADRs had drifted from the shipped code. Reconciliation complete: catalog added (docs/trusty-code/spec-adr-reconciliation.md), stale specs corrected (harnesses.md, vision and parity specs, DOC-51/60/61/62/65), and two new ADRs recorded (0058: trusty-code as independent product-owned harness; 0059: canonical agent behavior with generated host adapters). ADR-0032 confirmed consistent, not amended.

## Changes

- Adds 17-contract reconciliation catalog cross-checking each normative claim against real evidence paths
- Records ADR-0058 (trusty-code product ownership, converging on 2026-08-19 UDS ruling for #6637)
- Records ADR-0059 (canonical agent behavior with generated host adapters, superseding ADR-0015)
- Amends Related Decisions in ADR-0004/0015/0024/0042
- Adds scripts/check_trusty_code_specs.sh as CI entry gate, wired into doc-numbers.yml

## Risk

Low — docs-only change. No crate source or test logic affected. Catalog is reconciliation record, not new specification. ADR amendments are cross-references only.

## Tests

Test ladder rung 1 (docs-only). Evidence:
- `scripts/check_trusty_code_specs.sh`: exit 0, mutation-tested against 12 induced violations
- `adr-check`: 59 workspace ADRs consistent, exit 0
- `scripts/check_sld.sh`: 0 errors/warnings
- `scripts/check_line_cap.sh`, doc-numbers gate: 0 violations
- code-analyzer: APPROVE

## Baseline

One of two named blockers of epic #2063 (trusty-code daemon core reliability); the other, #5441, is a parallel PR. No regressions expected; reconciliation only.

## Docs

- Adds docs/trusty-code/spec-adr-reconciliation.md (17-contract catalog)
- Updates docs/adr/0058-trusty-code-product-owned-harness.md (new)
- Updates docs/adr/0059-canonical-agent-behavior-generated-adapters.md (new)
- Updates docs/adr/0004*.md (Related Decisions cross-ref)
- Updates docs/adr/0015*.md (Related Decisions cross-ref)
- Updates docs/adr/0024*.md (Related Decisions cross-ref)
- Updates docs/adr/0042*.md (Related Decisions cross-ref)
- Updates scripts/check_trusty_code_specs.sh (new CI gate)

## Review

Closes #5433

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
