### PR TITLE
fix(trusty-audit): refusal() skips the update-availability notice when picking the real failure reason

### DIFF
--- a/crates/trusty-audit/changelog.d/6720-index-refusal-skips-update-notice.md
+++ b/crates/trusty-audit/changelog.d/6720-index-refusal-skips-update-notice.md
@@ -1,0 +1,13 @@
+Fixed
+
+- A failed `trusty-search index` or `index add` now reports the real failure
+  instead of the update-availability notice. `trusty-search` prints that notice
+  on stderr ahead of every human-facing subcommand when crates.io has a newer
+  version, and both refusal messages quoted the first non-empty stderr line — so
+  on a machine one release behind, the notice became "the reason" and the actual
+  diagnostic was discarded. One delivered audit run masked 60 of 61
+  repositories this way, and because an indexing failure short-circuits the
+  evidence-grounding pass, all 60 reports rendered "not assessed" with nothing
+  recorded to diagnose. Stderr carrying only a notice is now reported as
+  `no reason given (stderr carried only an update-availability notice)` rather
+  than as a cause (#6720).

--- a/crates/trusty-audit/src/grounding/index.rs
+++ b/crates/trusty-audit/src/grounding/index.rs
@@ -217,16 +217,26 @@ fn run(search: &Path, args: &[OsString]) -> Result<Output, String> {
 }
 
 /// A non-zero index exit rendered as one line naming what the report loses.
+///
+/// Why: the caller turns this into a report gap and nothing else records why
+/// the index failed, so a wrong line here is the whole diagnosis. Until #6720
+/// the line was the first non-empty one on stderr, which on a machine one
+/// release behind is `trusty-search`'s update-availability notice rather than
+/// the failure.
+/// What: quotes [`crate::search_stderr::reason`] — the first stderr line that
+/// is neither blank nor an update notice, or an explicit statement that there
+/// was none. Always one line.
+/// Test: `index_tests::{an_index_failure_names_the_checkout_and_quotes_what_search_said,
+/// a_silent_index_failure_still_produces_a_reason,
+/// an_update_notice_never_masks_the_real_index_failure,
+/// an_index_failure_reporting_only_a_notice_says_so}`.
 fn refusal(checkout: &Path, index_id: &str, output: &Output) -> Option<String> {
     if output.status.success() {
         return None;
     }
-    let said = String::from_utf8_lossy(&output.stderr);
-    let detail = said
-        .lines()
-        .map(str::trim)
-        .find(|line| !line.is_empty())
-        .unwrap_or("no reason given");
+    // #6720: the update-availability notice trusty-search prints ahead of every
+    // human-facing subcommand is not the failure.
+    let detail = crate::search_stderr::reason(&output.stderr);
     Some(format!(
         "`trusty-search index {} --name {index_id}` failed ({}): {detail}",
         checkout.display(),
@@ -324,6 +334,73 @@ mod index_tests {
         let reason = refusal(Path::new("/w/repos/xsv"), "xsv", &output(2, ""))
             .expect("a non-zero exit is a refusal");
         assert!(reason.contains("no reason given"), "{reason}");
+    }
+
+    /// The stderr of the delivered client run of 2026-08-25, verbatim in shape:
+    /// `trusty-search` one release behind printed its update notice first and
+    /// #6720 reported THAT as the reason, for 60 of 61 repositories.
+    const REAL_NOTICE: &str = "Update available: trusty-search 0.49.1 (you have 0.47.0) — run: cargo install \
+         trusty-search --locked";
+
+    /// #6720: the regression. The notice is informational; the line after it is
+    /// the failure, and the failure is what the report gap must carry.
+    #[test]
+    fn an_update_notice_never_masks_the_real_index_failure() {
+        let said = format!("{REAL_NOTICE}\nindexing refused: root is not allowlisted\n");
+        let reason = refusal(Path::new("/w/repos/xsv"), "xsv", &output(1, &said))
+            .expect("a non-zero exit is a refusal");
+        assert!(
+            reason.contains("indexing refused: root is not allowlisted"),
+            "{reason}"
+        );
+        assert!(!reason.contains("Update available"), "{reason}");
+        assert_eq!(reason.lines().count(), 1, "must stay one line: {reason}");
+    }
+
+    /// The edge: the notice was the only thing on stderr. The gap says so
+    /// explicitly rather than quoting an upgrade instruction as a cause.
+    #[test]
+    fn an_index_failure_reporting_only_a_notice_says_so() {
+        let said = format!("{REAL_NOTICE}\n");
+        let reason = refusal(Path::new("/w/repos/xsv"), "xsv", &output(1, &said))
+            .expect("a non-zero exit is a refusal");
+        assert!(reason.contains("no reason given"), "{reason}");
+        assert!(!reason.contains("cargo install"), "{reason}");
+        assert_eq!(reason.lines().count(), 1, "must stay one line: {reason}");
+    }
+
+    /// The whole spawn path, against a stub that behaves like the real binary
+    /// on a machine one release behind: the notice goes to stderr ahead of
+    /// EVERY subcommand, and the index then fails for its own reason. What
+    /// reaches the caller must be that reason (#6720).
+    #[cfg(unix)]
+    #[test]
+    fn an_update_notice_from_the_real_spawn_path_does_not_become_the_reason() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let stub = tmp.path().join("trusty-search");
+        std::fs::write(
+            &stub,
+            format!(
+                "#!/bin/sh\n\
+                 echo '{REAL_NOTICE}' >&2\n\
+                 [ \"$1 $2\" = \"index add\" ] && exit 0\n\
+                 [ \"$1\" = index-status ] && exit 1\n\
+                 echo 'indexing refused: root is not allowlisted' >&2\n\
+                 exit 1\n"
+            ),
+        )
+        .expect("write stub");
+        std::fs::set_permissions(&stub, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+
+        let reason = ensure_indexed(&stub, Path::new("/w/repos/xsv"), "xsv")
+            .expect_err("a refused index must not report a status");
+        assert!(
+            reason.contains("indexing refused: root is not allowlisted"),
+            "{reason}"
+        );
+        assert!(!reason.contains("Update available"), "{reason}");
     }
 
     /// A binary that cannot be run is this repository's gap, never a panic.

--- a/crates/trusty-audit/src/lib.rs
+++ b/crates/trusty-audit/src/lib.rs
@@ -109,6 +109,10 @@ mod relay;
 // turning an `Outcome` into text; the verb the recipient types is `render`.
 pub mod rerender;
 pub mod run;
+// #6720: the one line a failed `trusty-search` invocation's stderr is worth
+// quoting. Shared by both refusal messages in this crate because both spawn
+// the same binary and both were masked by the same update-availability notice.
+pub(crate) mod search_stderr;
 pub mod session;
 pub mod tools;
 pub mod validate;

--- a/crates/trusty-audit/src/run/approve.rs
+++ b/crates/trusty-audit/src/run/approve.rs
@@ -87,16 +87,23 @@ fn index_add_args(checkout: &Path) -> Vec<OsString> {
 /// in what the recipient must do about them — a denylisted path needs a different
 /// working directory, an unreadable allowlist needs a permissions fix — and only
 /// `trusty-search` knows which one fired.
+///
+/// Which line is quoted is [`crate::search_stderr::reason`]'s decision, shared
+/// with `crate::grounding::index`'s refusal because both spawn the same binary
+/// and #6720 masked both the same way: `trusty-search` prints an
+/// update-availability notice ahead of every human-facing subcommand, and the
+/// first non-empty stderr line was therefore that notice rather than the
+/// refusal.
+///
+/// Test: `approve_tests::{a_refusal_names_the_checkout_and_quotes_what_search_said,
+/// an_update_notice_never_masks_the_real_approval_refusal,
+/// an_approval_refusal_reporting_only_a_notice_says_so}`.
 fn refusal(checkout: &Path, output: &Output) -> Option<String> {
     if output.status.success() {
         return None;
     }
-    let said = String::from_utf8_lossy(&output.stderr);
-    let detail = said
-        .lines()
-        .map(str::trim)
-        .find(|line| !line.is_empty())
-        .unwrap_or("no reason given");
+    // #6720: the update-availability notice is informational, never the refusal.
+    let detail = crate::search_stderr::reason(&output.stderr);
     Some(format!(
         "`trusty-search index add {}` refused ({}): {detail} — the code analysis \
          would have read nothing for this repository",
@@ -171,6 +178,36 @@ mod approve_tests {
         let reason = refusal(Path::new("/w/repos/xsv"), &output(2, ""))
             .expect("a non-zero exit is a refusal");
         assert!(reason.contains("no reason given"), "{reason}");
+    }
+
+    /// #6720 on the approval leg. `index add` is a human-facing subcommand too,
+    /// so the update-availability notice lands ahead of its refusal exactly as
+    /// it does ahead of `index`'s.
+    #[test]
+    fn an_update_notice_never_masks_the_real_approval_refusal() {
+        let said = "Update available: trusty-search 0.49.1 (you have 0.47.0) — run: cargo \
+                    install trusty-search --locked\n\
+                    indexing refused: path is under a temporary directory\n";
+        let reason = refusal(Path::new("/w/repos/xsv"), &output(1, said))
+            .expect("a non-zero exit is a refusal");
+        assert!(
+            reason.contains("indexing refused: path is under a temporary directory"),
+            "{reason}"
+        );
+        assert!(!reason.contains("Update available"), "{reason}");
+        assert_eq!(reason.lines().count(), 1, "must stay one line: {reason}");
+    }
+
+    /// The notice alone is not a refusal reason — the recipient is told the
+    /// child said nothing usable rather than pointed at an upgrade.
+    #[test]
+    fn an_approval_refusal_reporting_only_a_notice_says_so() {
+        let said = "Update available: trusty-search 0.49.1 (you have 0.47.0) — run: cargo \
+                    install trusty-search --locked\n";
+        let reason = refusal(Path::new("/w/repos/xsv"), &output(1, said))
+            .expect("a non-zero exit is a refusal");
+        assert!(reason.contains("no reason given"), "{reason}");
+        assert!(!reason.contains("cargo install"), "{reason}");
     }
 
     /// The spawn itself, not just the two pure halves: a stub standing in for

--- a/crates/trusty-audit/src/search_stderr.rs
+++ b/crates/trusty-audit/src/search_stderr.rs
@@ -1,0 +1,153 @@
+//! What a failed `trusty-search` invocation actually said, once its
+//! informational chatter is set aside.
+//!
+//! Why: `trusty-search`'s `main.rs` prints an update-availability notice on
+//! stderr before every human-facing subcommand, `index` and `index add`
+//! included, whenever crates.io has a newer version. Both of this crate's
+//! trusty-search refusal messages used to report the FIRST non-empty stderr
+//! line as the reason, so on a machine one release behind the notice landed
+//! first and became "the reason" while the real diagnostic was discarded. In a
+//! delivered client audit that masked 60 of 61 repositories, and because
+//! `crate::grounding` short-circuits the whole evidence-grounding pass on an
+//! indexing failure, every one of those reports rendered "not assessed" with
+//! nothing recorded to diagnose (#6720).
+//!
+//! What: [`reason`], the one line both refusal messages quote. It skips blank
+//! lines and update-availability notices and returns the first line that is
+//! neither. When nothing is left it says so explicitly, and it distinguishes
+//! stderr that was empty from stderr that carried only a notice — the second
+//! is the state this module exists to make visible, so it must not read as the
+//! first.
+//!
+//! The notice's wording is owned by `trusty_common::update::notice`, which this
+//! crate cannot name: `trusty-common`'s `update` module is behind the
+//! `update-check` feature and this crate does not enable it. The coupling is
+//! held by a test fixture carrying the real emitted text instead.
+//!
+//! Test: `search_stderr_tests`.
+
+/// The prefix every trusty-* update-availability notice starts with.
+///
+/// `trusty_common::update::notice` formats `"Update available: {crate} {latest}
+/// (you have {current}) — run: cargo install {crate} --locked"`, and the
+/// shorter `upgrade`-command variants in `trusty-search` and `trusty-memory`
+/// open the same way. Matching the prefix covers all of them without pinning
+/// the rest of the sentence.
+const UPDATE_NOTICE_PREFIX: &str = "Update available:";
+
+/// Said when a failed invocation wrote nothing to stderr at all.
+const NO_REASON: &str = "no reason given";
+
+/// Said when everything a failed invocation wrote was informational.
+///
+/// Kept distinct from [`NO_REASON`] deliberately: silence and
+/// "it only told us about an upgrade" are different facts to whoever reads the
+/// gap, and collapsing them would hide the case #6720 was filed about.
+const ONLY_A_NOTICE: &str = "no reason given (stderr carried only an update-availability notice)";
+
+/// The one line of a failed `trusty-search` invocation's stderr worth quoting.
+///
+/// Why: see the module docs — an update-availability notice is not a failure,
+/// and reporting it as one silently discards the real diagnostic.
+/// What: decodes `stderr` lossily, trims each line, and returns the first that
+/// is neither empty nor an update-availability notice. With no such line it
+/// returns [`ONLY_A_NOTICE`] if a notice was skipped and [`NO_REASON`]
+/// otherwise. Always one line, because both callers embed it in a single-line
+/// refusal the recipient reads in a report gap.
+/// Test: `search_stderr_tests::{a_real_reason_survives_a_leading_update_notice,
+/// a_notice_alone_is_not_a_reason, empty_stderr_is_distinguished_from_a_notice,
+/// the_first_real_line_wins_when_nothing_is_informational}`.
+pub(crate) fn reason(stderr: &[u8]) -> String {
+    let said = String::from_utf8_lossy(stderr);
+    let mut skipped_a_notice = false;
+    for line in said.lines().map(str::trim) {
+        if line.is_empty() {
+            continue;
+        }
+        // #6720: informational, never the failure — skip wherever it lands
+        // rather than only in the leading position, so an ordering change in
+        // the child does not quietly restore the masking.
+        if line.starts_with(UPDATE_NOTICE_PREFIX) {
+            skipped_a_notice = true;
+            continue;
+        }
+        return line.to_owned();
+    }
+    if skipped_a_notice {
+        ONLY_A_NOTICE.to_owned()
+    } else {
+        NO_REASON.to_owned()
+    }
+}
+
+#[cfg(test)]
+mod search_stderr_tests {
+    use super::*;
+
+    /// Verbatim from the delivered audit run of 2026-08-25 that #6720 was filed
+    /// from: `trusty-search` 0.47.0 with 0.49.1 on crates.io. Held as a literal
+    /// because this crate does not enable `trusty-common`'s `update-check`
+    /// feature and so cannot call the formatter that produced it.
+    const REAL_NOTICE: &str = "Update available: trusty-search 0.49.1 (you have 0.47.0) — run: cargo install \
+         trusty-search --locked";
+
+    /// The regression. Before #6720 this returned the notice and the real
+    /// diagnostic was lost — across 60 of 61 repositories in one client run.
+    #[test]
+    fn a_real_reason_survives_a_leading_update_notice() {
+        let said = format!("{REAL_NOTICE}\nindexing refused: root is not allowlisted\n");
+        assert_eq!(
+            reason(said.as_bytes()),
+            "indexing refused: root is not allowlisted"
+        );
+    }
+
+    /// The edge the fix has to answer explicitly: the notice is all there was.
+    /// Reporting it would be the original bug; reporting plain silence would
+    /// hide that a notice was printed at all.
+    #[test]
+    fn a_notice_alone_is_not_a_reason() {
+        let said = format!("{REAL_NOTICE}\n");
+        let reason = reason(said.as_bytes());
+        assert!(!reason.contains("Update available"), "{reason}");
+        assert_eq!(reason, ONLY_A_NOTICE);
+    }
+
+    /// A silent failure and a notice-only failure are different diagnoses.
+    #[test]
+    fn empty_stderr_is_distinguished_from_a_notice() {
+        assert_eq!(reason(b""), NO_REASON);
+        assert_eq!(reason(b"   \n\n  \n"), NO_REASON);
+        assert_ne!(NO_REASON, ONLY_A_NOTICE);
+    }
+
+    /// The unchanged behaviour: with no notice in the way, the first real line
+    /// is still the answer, still trimmed, still one line.
+    #[test]
+    fn the_first_real_line_wins_when_nothing_is_informational() {
+        let reason = reason(b"\n  indexing refused: root is not allowlisted\nsecond line\n");
+        assert_eq!(reason, "indexing refused: root is not allowlisted");
+        assert_eq!(reason.lines().count(), 1);
+    }
+
+    /// The notice is skipped wherever it lands, not only first — the child is
+    /// free to reorder its own stderr.
+    #[test]
+    fn a_trailing_notice_is_skipped_too() {
+        let said = format!("boom: the daemon refused\n{REAL_NOTICE}\n");
+        assert_eq!(reason(said.as_bytes()), "boom: the daemon refused");
+    }
+
+    /// The shorter `upgrade`-command wording matches the same prefix.
+    #[test]
+    fn the_short_upgrade_wording_is_a_notice_too() {
+        let said = "Update available: trusty-search 0.49.1 (you have 0.47.0)\n";
+        assert_eq!(reason(said.as_bytes()), ONLY_A_NOTICE);
+    }
+
+    /// Invalid UTF-8 degrades rather than panicking.
+    #[test]
+    fn non_utf8_stderr_is_a_reason_not_a_panic() {
+        assert_eq!(reason(&[0xff, 0xfe]), "\u{fffd}\u{fffd}");
+    }
+}


### PR DESCRIPTION
## Outcome

`refusal()` in `crates/trusty-audit/src/grounding/index.rs` and `run/approve.rs` was picking the first non-empty stderr line as the subprocess failure reason. `trusty-search` unconditionally prints an update-availability notice before any human-facing subcommand, masking the real error when an index or approval call failed for an unrelated reason. Discovered via a delivered audit run where 60 of 61 repositories hit this masking; the real index failures were never surfaced, and trusty-audit's evidence-grounding pass short-circuits on index failure.

## Changes

New shared helper `search_stderr::reason()` skips blank lines and any line starting `Update available:`, used at both call sites. Stderr carrying only the notice reports a distinct `no reason given (stderr carried only an update-availability notice)` to keep this exact masking visible if it recurs in a different shape.

## Risk

Localized to trusty-audit grounding paths; no public API change. Fixes a masking bug that prevented real errors from surfacing.

## Tests

- 10 new tests; 8 fail against the pre-fix logic (verified by reverting `reason()` to old first-non-empty-line pick, confirming 8 failures, then restoring)
- `cargo test -p trusty-audit --no-fail-fast`: 791 + 33 across 10 targets, 0 failed

## Baseline

- `cargo fmt --check`: exit 0
- `cargo clippy -p trusty-audit --all-targets -- -D warnings`: exit 0
- Doc gates (line-cap, test-pointers, changelog fragment, sld-lint): all exit 0

## Docs

No doc updates required.

## Review

Refs #6720

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
