### PR TITLE
refactor(trusty-common): the tickets feature no longer depends on trusty-mcp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11684,7 +11684,6 @@ dependencies = [
  "tree-sitter-python",
  "tree-sitter-rust",
  "tree-sitter-typescript",
- "trusty-mcp",
  "unicode-normalization",
  "url",
  "uuid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6596,7 +6596,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11604,7 +11604,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-common"
-version = "0.47.1"
+version = "0.47.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -375,11 +375,6 @@ globset = { workspace = true, optional = true }
 # reqwest, dirs, serde, serde_json, anyhow, tokio) are already unconditional.
 rusqlite = { workspace = true, optional = true }
 
-# `tickets`' MCP stdio server speaks JSON-RPC through the shared primitives,
-# which ADR-0040 (#5803) moved out of this crate into `trusty-mcp`. Optional so
-# the 20-plus consumers that never enable `tickets` do not compile it.
-trusty-mcp = { workspace = true, optional = true }
-
 # libc on every unix target: the macOS `launchd` module needs getuid(2) for the
 # gui/<uid> domain, and (#5099) the `uds` module needs getuid(2) plus
 # SO_PEERCRED / getpeereid on both macOS and Linux for peer-credential checks.
@@ -711,8 +706,11 @@ embedder-client = ["dep:thiserror", "embedder", "uds"]
 # Enables the `tickets` module: unified ticketing MCP server with GitHub,
 # JIRA, and Linear backends (absorbed from the former standalone `trusty-tickets`
 # crate). Pulls in `chrono`, `uuid`, `base64`, `thiserror`, and `toml` as
-# additional optional deps. Pulls in `trusty-mcp` for the stdio loop.
-tickets = ["dep:trusty-mcp", "dep:uuid", "dep:base64", "dep:thiserror", "dep:toml", "gh-cli"]
+# additional optional deps. #6316: it must NOT pull in `trusty-mcp` — that crate
+# depends on this one, so the edge closed a cycle. The stdio loop the
+# `tickets-mcp` binary needs lives in `src/tickets/stdio.rs` instead, and
+# `tests/no_trusty_mcp_backedge.rs` fails if the dependency comes back.
+tickets = ["dep:uuid", "dep:base64", "dep:thiserror", "dep:toml", "gh-cli"]
 # Enables the `gh` module: the workspace's single entry point for invoking the
 # GitHub CLI (#5475). Pulls in `thiserror` only — `tokio/process`, `serde` and
 # `serde_json` are already unconditional here.

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -58,7 +58,10 @@ name = "trusty-common"
 # MINOR/breaking position for the pre-existing #6562/#6573 changes above).
 # This PR only adds two new public constants to `env_vars.rs`; additive, no
 # existing item changed shape.
-version = "0.47.1"
+# 0.47.2 (#6316): patch — version bump only, to clear the "PR version bump vs
+# crates.io" CI gate after src/** changes landed at the same version already
+# published as 0.47.1.
+version = "0.47.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/trusty-common/changelog.d/6316-tickets-drop-trusty-mcp-dep.md
+++ b/crates/trusty-common/changelog.d/6316-tickets-drop-trusty-mcp-dep.md
@@ -1,0 +1,11 @@
+Changed
+- The `tickets` feature no longer depends on `trusty-mcp`. That edge closed a
+  dependency cycle — `trusty-mcp` depends on this crate — and blocked the shared
+  stdio↔UDS JSON-RPC forwarder ([#6316](https://github.com/bobmatnyc/trusty-tools/issues/6316)).
+  The `tickets-mcp` binary now runs on a private, dependency-free JSON-RPC stdio
+  loop in `tickets::stdio`; `trusty_mcp::run_stdio_loop` stays the shared loop
+  for every MCP server outside this crate. The public API of
+  `trusty_common::tickets` is unchanged — `server::run_stdio`,
+  `server::handle_message` and `server::handle_tool_call` keep their signatures,
+  and the wire behaviour (handshake, notification suppression, error codes) is
+  byte-identical.

--- a/crates/trusty-common/src/tickets/mod.rs
+++ b/crates/trusty-common/src/tickets/mod.rs
@@ -11,4 +11,8 @@
 
 pub mod api;
 pub mod server;
+// #6316: trusty-common must not depend on trusty-mcp (cycle). Private, so the
+// crate's public API is unchanged and `trusty_mcp` stays the shared loop for
+// every server outside this crate.
+mod stdio;
 pub mod tools;

--- a/crates/trusty-common/src/tickets/server.rs
+++ b/crates/trusty-common/src/tickets/server.rs
@@ -17,7 +17,9 @@ use crate::tickets::api::backends::{
     UpdateIssueParams,
 };
 use crate::tickets::api::client::BackendClient;
-use trusty_mcp::{Request, Response, error_codes, initialize_response, run_stdio_loop};
+// #6316: trusty-common must not depend on trusty-mcp (cycle) — the loop is
+// this crate's own now. See `crate::tickets::stdio`.
+use crate::tickets::stdio::{Request, Response, error_codes, initialize_response, run_stdio_loop};
 
 /// Shared state passed to every dispatcher invocation.
 ///
@@ -331,7 +333,7 @@ async fn dispatch(state: &AppState, name: &str, args: Value) -> Result<Value> {
 pub async fn handle_message(state: AppState, req: Value) -> Value {
     let method = req["method"].as_str().unwrap_or("");
     match method {
-        "initialize" => initialize_response("tickets-mcp", env!("CARGO_PKG_VERSION"), None),
+        "initialize" => initialize_response("tickets-mcp", env!("CARGO_PKG_VERSION")),
         "notifications/initialized" | "notifications/cancelled" => Value::Null,
         "ping" => json!({}),
         "tools/list" => crate::tickets::tools::tool_list_response(),

--- a/crates/trusty-common/src/tickets/stdio.rs
+++ b/crates/trusty-common/src/tickets/stdio.rs
@@ -1,0 +1,303 @@
+//! Minimal JSON-RPC 2.0 stdio loop for the `tickets-mcp` binary.
+//!
+//! Why: `trusty-mcp` owns the shared stdio loop every other trusty-* MCP
+//! server uses, and it must depend on `trusty-common` (feature `uds`) to
+//! forward over a socket. `trusty-common` borrowing that loop back closed a
+//! dependency cycle the moment the `tickets` feature was on, which blocked
+//! [#6316](https://github.com/bobmatnyc/trusty-tools/issues/6316)'s shared
+//! `daemon_bridge_json_rpc`. This module is the base crate's own copy so the
+//! edge can be cut without moving the `tickets-mcp` binary out of this crate
+//! (that move is #6316 slice 4, `trusty-mcp <service>`).
+//! What: The four primitives `tickets::server` actually used — `error_codes`,
+//! `Request`, `Response`, `initialize_response` — plus a line-delimited
+//! read-dispatch-write loop over stdin/stdout. Deliberately narrower than
+//! `trusty_mcp`'s: no `data` field on errors, no `extra` server-info merge, no
+//! `INVALID_PARAMS`/`INVALID_REQUEST` constants, because nothing here uses
+//! them. Adds no dependency — `serde`, `serde_json`, `anyhow` and `tokio`
+//! (`io-std`, `io-util`) are already unconditional in this crate.
+//! Test: `initialize_response_has_required_fields`,
+//! `error_codes_are_spec_values`, `request_deserialises_without_params`,
+//! `ok_response_round_trips`, `err_response_carries_code_and_message`,
+//! `stdio_loop_dispatches_and_suppresses_notifications`,
+//! `stdio_loop_reports_parse_errors`, `stdio_loop_exits_on_eof`.
+//!
+//! Not the shared loop. A second MCP server in this crate is a signal to move
+//! the binary out to `trusty-mcp` rather than to widen this module.
+
+// #6316: trusty-common must not depend on trusty-mcp (cycle)
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
+
+/// The JSON-RPC 2.0 error codes this server returns.
+///
+/// Why: The spec's reserved range, kept numerically identical to
+/// `trusty_mcp::error_codes` so a client cannot tell the two loops apart.
+/// What: `i32` to match the spec; serde_json emits them as JSON numbers.
+/// Test: `error_codes_are_spec_values`.
+pub(crate) mod error_codes {
+    pub(crate) const PARSE_ERROR: i32 = -32700;
+    pub(crate) const METHOD_NOT_FOUND: i32 = -32601;
+    pub(crate) const INTERNAL_ERROR: i32 = -32603;
+}
+
+/// Incoming JSON-RPC 2.0 request envelope.
+///
+/// Why: The dispatcher re-serialises this to a `Value` before matching on
+/// `method`, so it must round-trip through serde in both directions.
+/// What: `id` is absent for notifications; `params` defaults to `None` so a
+/// caller that omits it still parses.
+/// Test: `request_deserialises_without_params`.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub(crate) struct Request {
+    /// Always `"2.0"` in practice. Optional so a legacy caller that omits it
+    /// reaches the dispatcher instead of failing at the parse layer.
+    #[serde(default)]
+    pub(crate) jsonrpc: Option<String>,
+    #[serde(default)]
+    pub(crate) id: Option<Value>,
+    pub(crate) method: String,
+    #[serde(default)]
+    pub(crate) params: Option<Value>,
+}
+
+/// Outgoing JSON-RPC 2.0 response envelope.
+///
+/// Why: Mirrors `Request` on the return path; exactly one of `result` /
+/// `error` is set on any response that reaches the wire.
+/// What: `suppress` never serialises — it tells the loop to write nothing at
+/// all, which is how notifications are answered.
+/// Test: `ok_response_round_trips`, `err_response_carries_code_and_message`.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct Response {
+    pub(crate) jsonrpc: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) id: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) result: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) error: Option<JsonRpcError>,
+    /// Internal: true = drop this response, emit nothing on the wire.
+    #[serde(skip)]
+    pub(crate) suppress: bool,
+}
+
+/// JSON-RPC 2.0 error object.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct JsonRpcError {
+    pub(crate) code: i32,
+    pub(crate) message: String,
+}
+
+impl Response {
+    /// Successful response carrying a `result` body.
+    pub(crate) fn ok(id: Option<Value>, result: Value) -> Self {
+        Self {
+            jsonrpc: "2.0".into(),
+            id,
+            result: Some(result),
+            error: None,
+            suppress: false,
+        }
+    }
+
+    /// Error response carrying a JSON-RPC code and message.
+    pub(crate) fn err(id: Option<Value>, code: i32, message: impl Into<String>) -> Self {
+        Self {
+            jsonrpc: "2.0".into(),
+            id,
+            result: None,
+            error: Some(JsonRpcError {
+                code,
+                message: message.into(),
+            }),
+            suppress: false,
+        }
+    }
+
+    /// A response the loop must not write — the reply to a notification.
+    pub(crate) fn suppressed() -> Self {
+        Self {
+            jsonrpc: "2.0".into(),
+            id: None,
+            result: None,
+            error: None,
+            suppress: true,
+        }
+    }
+}
+
+/// Build the `initialize` result payload.
+///
+/// Why: MCP hosts read `protocolVersion` and `serverInfo` from the handshake
+/// and refuse the session without them.
+/// What: Pins the same `2024-11-05` protocol revision and `tools`-only
+/// capability set the rest of the trusty-* family advertises.
+/// Test: `initialize_response_has_required_fields`.
+pub(crate) fn initialize_response(server_name: &str, version: &str) -> Value {
+    json!({
+        "protocolVersion": "2024-11-05",
+        "capabilities": { "tools": {} },
+        "serverInfo": { "name": server_name, "version": version },
+    })
+}
+
+/// Read line-delimited JSON-RPC from stdin, dispatch, write replies to stdout.
+///
+/// Why: The transport half of `tickets::server::run_stdio`; an MCP host
+/// launches the binary and speaks newline-framed JSON-RPC over the pipe.
+/// What: Blank lines are skipped, unparseable lines answer `PARSE_ERROR` with
+/// a null id, suppressed responses write nothing, and EOF returns `Ok`.
+/// Test: `stdio_loop_dispatches_and_suppresses_notifications`,
+/// `stdio_loop_reports_parse_errors`, `stdio_loop_exits_on_eof`.
+pub(crate) async fn run_stdio_loop<F, Fut>(dispatcher: F) -> anyhow::Result<()>
+where
+    F: Fn(Request) -> Fut + Send + Sync + 'static,
+    Fut: std::future::Future<Output = Response> + Send,
+{
+    run_stdio_loop_with_io(dispatcher, tokio::io::stdin(), tokio::io::stdout()).await
+}
+
+/// `run_stdio_loop` with the streams injected, so tests drive it over a pipe.
+///
+/// Why: stdin/stdout are process-global; a test that used them would fight
+/// every other test in the binary.
+/// What: Identical logic to `run_stdio_loop`, generic over the two streams.
+/// Test: the three `stdio_loop_*` tests call this directly.
+async fn run_stdio_loop_with_io<F, Fut, R, W>(
+    dispatcher: F,
+    reader: R,
+    mut writer: W,
+) -> anyhow::Result<()>
+where
+    F: Fn(Request) -> Fut + Send + Sync + 'static,
+    Fut: std::future::Future<Output = Response> + Send,
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    let mut lines = BufReader::new(reader).lines();
+    while let Some(line) = lines.next_line().await? {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let response = match serde_json::from_str::<Request>(trimmed) {
+            Ok(req) => dispatcher(req).await,
+            Err(e) => Response::err(
+                None,
+                error_codes::PARSE_ERROR,
+                format!("invalid JSON-RPC: {e}"),
+            ),
+        };
+        if response.suppress {
+            continue;
+        }
+        let serialised = serde_json::to_string(&response)?;
+        writer.write_all(serialised.as_bytes()).await?;
+        writer.write_all(b"\n").await?;
+        writer.flush().await?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Drive the loop over an in-memory pipe and return everything it wrote.
+    async fn drive(input: &str) -> String {
+        let (mut client_tx, server_rx) = tokio::io::duplex(8192);
+        client_tx.write_all(input.as_bytes()).await.unwrap();
+        drop(client_tx);
+
+        let mut out: Vec<u8> = Vec::new();
+        run_stdio_loop_with_io(
+            |req: Request| async move {
+                if req.id.is_none() {
+                    Response::suppressed()
+                } else {
+                    Response::ok(req.id, json!({ "method": req.method }))
+                }
+            },
+            server_rx,
+            &mut out,
+        )
+        .await
+        .expect("loop returns Ok on EOF");
+        String::from_utf8(out).unwrap()
+    }
+
+    #[test]
+    fn error_codes_are_spec_values() {
+        assert_eq!(error_codes::PARSE_ERROR, -32700);
+        assert_eq!(error_codes::METHOD_NOT_FOUND, -32601);
+        assert_eq!(error_codes::INTERNAL_ERROR, -32603);
+    }
+
+    #[test]
+    fn request_deserialises_without_params() {
+        let r: Request =
+            serde_json::from_str(r#"{"jsonrpc":"2.0","id":1,"method":"ping"}"#).unwrap();
+        assert_eq!(r.method, "ping");
+        assert!(r.params.is_none());
+        assert_eq!(r.jsonrpc.as_deref(), Some("2.0"));
+    }
+
+    #[test]
+    fn ok_response_round_trips() {
+        let s =
+            serde_json::to_string(&Response::ok(Some(json!(7)), json!({ "ok": true }))).unwrap();
+        assert!(s.contains(r#""jsonrpc":"2.0""#));
+        assert!(s.contains(r#""id":7"#));
+        assert!(s.contains(r#""ok":true"#));
+        assert!(!s.contains("error"));
+    }
+
+    #[test]
+    fn err_response_carries_code_and_message() {
+        let r = Response::err(Some(json!(1)), error_codes::METHOD_NOT_FOUND, "boom");
+        let err = r.error.as_ref().unwrap();
+        assert_eq!(err.code, error_codes::METHOD_NOT_FOUND);
+        assert_eq!(err.message, "boom");
+        assert!(r.result.is_none());
+    }
+
+    #[test]
+    fn initialize_response_has_required_fields() {
+        let v = initialize_response("tickets-mcp", "9.9.9");
+        assert_eq!(v["protocolVersion"], "2024-11-05");
+        assert!(v["capabilities"]["tools"].is_object());
+        assert_eq!(v["serverInfo"]["name"], "tickets-mcp");
+        assert_eq!(v["serverInfo"]["version"], "9.9.9");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn stdio_loop_dispatches_and_suppresses_notifications() {
+        let out = drive(concat!(
+            r#"{"jsonrpc":"2.0","id":1,"method":"ping"}"#,
+            "\n\n",
+            r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#,
+            "\n",
+        ))
+        .await;
+        let lines: Vec<&str> = out.lines().collect();
+        assert_eq!(lines.len(), 1, "notification must not be answered: {out:?}");
+        let v: Value = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(v["id"], 1);
+        assert_eq!(v["result"]["method"], "ping");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn stdio_loop_reports_parse_errors() {
+        let out = drive("{not json}\n").await;
+        let v: Value = serde_json::from_str(out.trim()).unwrap();
+        assert_eq!(v["error"]["code"], error_codes::PARSE_ERROR);
+        assert!(v.get("id").is_none(), "parse errors carry no id: {v}");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn stdio_loop_exits_on_eof() {
+        assert_eq!(drive("").await, "");
+    }
+}

--- a/crates/trusty-common/tests/no_trusty_mcp_backedge.rs
+++ b/crates/trusty-common/tests/no_trusty_mcp_backedge.rs
@@ -1,0 +1,144 @@
+//! Ratchet: `trusty-common` must never depend on `trusty-mcp`.
+//!
+//! Why: `trusty-mcp` depends on `trusty-common` (and #6316 slice 2 makes that
+//! edge unconditional, so the shared `daemon_bridge_json_rpc` can reach
+//! `trusty_common::uds`). An edge back the other way — which the `tickets`
+//! feature carried until #6316 — closes a cycle the moment `tickets` is on,
+//! and cargo reports it as an unrelated resolution failure far from the
+//! manifest line that caused it. This test names the cause instead.
+//! What: Parses this crate's own `Cargo.toml` and fails if `trusty-mcp`
+//! appears as a key in any dependency table, as a `[dependencies.trusty-mcp]`
+//! style header, or as `dep:trusty-mcp` / `trusty-mcp/<feature>` inside
+//! `[features]`. Comment lines are ignored, which is what keeps the
+//! explanatory comments in that manifest from tripping it.
+//! Test: this file — `manifest_declares_no_trusty_mcp_dependency` is the
+//! assertion, `scanner_flags_a_reintroduced_dependency` proves the scanner
+//! would actually catch a regression rather than passing vacuously.
+//!
+//! Scope: the DIRECT edge, which is the one a person reintroduces by editing a
+//! manifest. `cargo tree -p trusty-common -e features -i trusty-mcp` is the
+//! whole-graph check; run it when auditing, not on every build.
+//!
+//! No `required-features`: this target compiles under every feature lane,
+//! including `--features unconditional-only`, so no lane can skip the ratchet.
+
+// #6316: trusty-common must not depend on trusty-mcp (cycle)
+
+const FORBIDDEN: &str = "trusty-mcp";
+
+/// One reason a manifest fails the ratchet: the line and why it matched.
+#[derive(Debug, PartialEq, Eq)]
+struct Violation {
+    section: String,
+    line: String,
+}
+
+/// Scan a `Cargo.toml`'s text for any declaration of `trusty-mcp`.
+///
+/// Why: the check has to be exact about *where* a match counts — the same
+/// crate name appears legitimately in this manifest's prose comments.
+/// What: tracks the current table header, then flags a dependency-table key,
+/// a `[…dependencies.trusty-mcp]` header, or a feature-list mention.
+/// Test: `scanner_flags_a_reintroduced_dependency`,
+/// `scanner_ignores_comments_and_unrelated_keys`.
+fn scan(manifest: &str) -> Vec<Violation> {
+    let mut section = String::new();
+    let mut found = Vec::new();
+
+    for raw in manifest.lines() {
+        let line = raw.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+
+        if let Some(header) = line.strip_prefix('[').and_then(|l| l.strip_suffix(']')) {
+            section = header
+                .trim_start_matches('[')
+                .trim_end_matches(']')
+                .to_string();
+            // `[dependencies.trusty-mcp]`, `[target.'cfg(unix)'.dev-dependencies.trusty-mcp]`.
+            if section.ends_with(&format!("dependencies.{FORBIDDEN}")) {
+                found.push(Violation {
+                    section: section.clone(),
+                    line: line.to_string(),
+                });
+            }
+            continue;
+        }
+
+        let is_dep_table = section.ends_with("dependencies");
+        let key = line.split('=').next().unwrap_or("").trim();
+        if is_dep_table && key == FORBIDDEN {
+            found.push(Violation {
+                section: section.clone(),
+                line: line.to_string(),
+            });
+        }
+
+        if section == "features"
+            && (line.contains(&format!("dep:{FORBIDDEN}"))
+                || line.contains(&format!("\"{FORBIDDEN}/")))
+        {
+            found.push(Violation {
+                section: section.clone(),
+                line: line.to_string(),
+            });
+        }
+    }
+
+    found
+}
+
+#[test]
+fn manifest_declares_no_trusty_mcp_dependency() {
+    let manifest = include_str!("../Cargo.toml");
+    let violations = scan(manifest);
+    assert!(
+        violations.is_empty(),
+        "trusty-common regained a `{FORBIDDEN}` dependency, which closes a \
+         cycle (`trusty-mcp` depends on `trusty-common`). See #6316. \
+         Offending declarations: {violations:#?}"
+    );
+}
+
+#[test]
+fn scanner_flags_a_reintroduced_dependency() {
+    let regressed = "\
+[dependencies]
+anyhow = { workspace = true }
+trusty-mcp = { workspace = true, optional = true }
+
+[features]
+tickets = [\"dep:trusty-mcp\", \"gh-cli\"]
+";
+    let violations = scan(regressed);
+    assert_eq!(
+        violations.len(),
+        2,
+        "expected the dependency key and the feature entry: {violations:#?}"
+    );
+    assert_eq!(violations[0].section, "dependencies");
+    assert_eq!(violations[1].section, "features");
+}
+
+#[test]
+fn scanner_flags_a_dotted_dependency_header() {
+    let regressed = "[target.'cfg(unix)'.dev-dependencies.trusty-mcp]\nversion = \"0.1\"\n";
+    assert_eq!(scan(regressed).len(), 1, "dotted header must be caught");
+}
+
+#[test]
+fn scanner_ignores_comments_and_unrelated_keys() {
+    let clean = "\
+[dependencies]
+# trusty-mcp = { workspace = true } -- removed by #6316, do not restore
+trusty-mcp-adjacent = { workspace = true }
+
+[package.metadata.docs]
+note = \"see trusty-mcp for the shared loop\"
+
+[features]
+tickets = [\"dep:uuid\", \"gh-cli\"]
+";
+    assert_eq!(scan(clean), Vec::new());
+}

--- a/docs/trusty-common/spec/COMPONENTS.md
+++ b/docs/trusty-common/spec/COMPONENTS.md
@@ -283,8 +283,11 @@ from `trusty-tickets`).
 
 **Key types/modules.** `api::config`, `api::models`, `api::client`, the
 `Backend` trait + `backends::{github,jira,linear}`; `server` (MCP dispatch +
-`run_stdio`); `tools` (tool-list schema). Driven by the `tickets-mcp` binary shim
-(`src/bin/tickets_mcp.rs`). Requires `mcp`.
+`run_stdio`); `tools` (tool-list schema); the private `stdio` (JSON-RPC
+envelopes + the newline-framed stdin/stdout loop `run_stdio` drives). Driven by
+the `tickets-mcp` binary shim (`src/bin/tickets_mcp.rs`). Depends on no other
+trusty crate — #6316 removed the `trusty-mcp` edge, which closed a cycle, and
+`src/tickets/stdio.rs` is this crate's own loop as a result.
 
 **Current state.** ✅ Module unit tests cover dispatch, tool-list counts, config
 parsing, and serde round-trips.


### PR DESCRIPTION
## Outcome
Refs #6316 — slice 1 of 4 (break the cycle). Slices 2 (`daemon_bridge_json_rpc` shared forwarder), 3 (re-point trusty-memory / trusty-analyze bridges), 4 (`trusty-mcp <service>` bin) follow as separate PRs.

## Changes
`trusty-common`'s `tickets` feature dropped its `trusty-mcp` optional dependency (`crates/trusty-common/Cargo.toml`), which closed the cycle with `trusty-mcp → trusty-common`. The only consumer was the crate's own `[[bin]] tickets_mcp`, which cannot carry its own deps, so `tickets/stdio.rs` is a private, dependency-free JSON-RPC stdio loop (serde/serde_json/anyhow/tokio were already unconditional; `Cargo.lock` shrinks). `trusty_mcp::run_stdio_loop` stays the shared loop for every other server. No public symbol moved or removed; `tickets::stdio` is private. Ratchet: `crates/trusty-common/tests/no_trusty_mcp_backedge.rs` parses the manifest and fails on any reintroduced `trusty-mcp` edge — proven to fire against a temporarily re-added dep. `docs/trusty-common/spec/COMPONENTS.md` corrected (it named a feature ADR-0040 removed).

## Risk
Cross-crate library change, but no public API change. Only the `tickets` feature gating is affected; all dependent features and `--features unconditional-only` validated independently.

## Tests
Rung 4 (shared library):
- `cargo fmt --check` ✓
- `cargo check -p trusty-common --features tickets --all-targets` ✓
- `cargo check -p trusty-common --features unconditional-only` ✓
- `cargo clippy -p trusty-common --features tickets --all-targets -- -D warnings` ✓
- `cargo test -p trusty-common --features tickets --no-fail-fast` → 527 lib + 4 ratchet + 4 feature_coverage passed, 0 failed ✓
- `cargo check --workspace` ✓
- Dependents: `cargo test -p trusty-review --no-fail-fast` → 2146 + 112 passed, 0 failed (only crate enabling `tickets`, via `intent-source`) ✓
- `cargo test -p trusty-mcp --no-fail-fast` → 36 passed ✓
- Doc gates (test-pointers, line-cap, changelog-fragment, sld) green ✓

## Baseline
No pre-existing red gates on base branch.

## Docs
Version 0.47.1 → 0.47.2 for the version-bump gate; `check_semver.sh`: 196/196 pass, no semver update required. Changelog fragment added: `crates/trusty-common/changelog.d/6316-break-tickets-cycle.md`.

## Review
No external review findings carried forward; design decision to internalize `stdio.rs` is scoped to this PR.

Refs #6316

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
