### PR TITLE
feat(website): nine-audience install walkthrough

### DIFF
--- a/website/src/lib/components/AudienceSteps.svelte
+++ b/website/src/lib/components/AudienceSteps.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+	/**
+	 * Why: one audience's ordered install, rendered on its own. Splitting it
+	 * out of the walkthrough is what lets a test mount a single audience and
+	 * assert that every command belonging to it — and nothing belonging to
+	 * another — reached the DOM.
+	 *
+	 * What: the prerequisite roster (names and requirement only; the setup
+	 * itself is written once, above the picker, and linked back to), the
+	 * numbered steps, and the macOS permission note. The permission note reads
+	 * its label from the typed `TccCategory` rather than from prose, so the
+	 * category a product gets cannot drift from the one the data declares.
+	 *
+	 * Test: `src/lib/install/render.test.ts`.
+	 */
+	import CommandBlock from './CommandBlock.svelte';
+	import { prerequisite, type Audience } from '$lib/install/audiences';
+
+	let { audience }: { audience: Audience } = $props();
+
+	/** The heading shown above the permission note, per category. */
+	const TCC_LABEL = {
+		none: 'macOS: no permission needed',
+		'full-disk-access': 'macOS: Full Disk Access',
+		'app-data': 'macOS: App Data'
+	} as const;
+</script>
+
+<div class="min-w-0">
+	<p class="eyebrow">{audience.tagline} · {audience.binary}</p>
+	<p class="mt-3 max-w-3xl text-foundry-secondary">{audience.lede}</p>
+
+	<h3 class="mt-8 font-display text-lg font-semibold">Before you start</h3>
+	<ul class="mt-3 flex flex-col gap-2">
+		{#each audience.prerequisites as ref (ref.id)}
+			<li class="max-w-3xl text-sm text-foundry-secondary">
+				<a
+					href="#prereq-{ref.id}"
+					class="font-semibold text-foundry-primary underline underline-offset-2"
+					>{prerequisite(ref.id).title}</a
+				>
+				<span class="badge ml-2">{ref.requirement}</span>
+				<span class="mt-1 block">{ref.note}</span>
+			</li>
+		{/each}
+	</ul>
+
+	<ol class="mt-8 flex flex-col gap-8">
+		{#each audience.steps as step, i (step.title)}
+			<li class="min-w-0">
+				<h3 class="font-display text-lg font-semibold">{i + 1} · {step.title}</h3>
+				<p class="mt-2 max-w-3xl text-foundry-secondary">{step.body}</p>
+				{#each step.commands as block (block.command)}
+					<CommandBlock {block} />
+				{/each}
+				{#each step.notes as note (note)}
+					<p class="mt-3 max-w-3xl text-sm text-foundry-secondary">{note}</p>
+				{/each}
+			</li>
+		{/each}
+	</ol>
+
+	<div class="card mt-8 max-w-3xl min-w-0 border-l-4 border-l-foundry-primary">
+		<p class="eyebrow">{TCC_LABEL[audience.tcc.category]}</p>
+		<p class="mt-3 text-sm text-foundry-secondary">{audience.tcc.summary}</p>
+	</div>
+</div>

--- a/website/src/lib/components/CommandBlock.svelte
+++ b/website/src/lib/components/CommandBlock.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	/**
+	 * Why: the install walkthrough prints twenty-odd command blocks and every
+	 * one of them owes the same three things — a `<pre>` that scrolls instead
+	 * of widening the page, a copy button with its own accessible name, and,
+	 * when the command carries a `<placeholder>`, the line that says what to
+	 * substitute. Repeating that markup per block is how one of the three goes
+	 * missing.
+	 *
+	 * What: the `<pre>` + `CopyButton` pair the tga audit page established,
+	 * lifted into one component, plus the placeholder instruction. The
+	 * `min-w-0` and `pr-14` are that page's own containment fix: a `<pre>`
+	 * never wraps, so without them the flex child widens to the longest
+	 * command and the page scrolls sideways at 375px.
+	 *
+	 * Test: `src/lib/install/render.test.ts` asserts every command in
+	 * `$lib/install/audiences` reaches the DOM with a labelled copy button, and
+	 * that no placeholder is rendered without its instruction.
+	 */
+	import CopyButton from './CopyButton.svelte';
+	import { hasPlaceholder, type CommandBlock } from '$lib/install/audiences';
+
+	let { block }: { block: CommandBlock } = $props();
+</script>
+
+<div class="mt-4 max-w-3xl min-w-0">
+	<div class="relative">
+		<pre
+			class="overflow-x-auto rounded-sm border border-foundry-border bg-foundry-card p-4 pr-14 text-xs leading-relaxed text-foundry-text">{block.command}</pre>
+		<div class="absolute right-2 top-2">
+			<CopyButton text={block.command} label={block.label} />
+		</div>
+	</div>
+	{#if hasPlaceholder(block.command)}
+		<p class="mt-2 text-sm text-foundry-secondary">{block.placeholderNote}</p>
+	{/if}
+</div>

--- a/website/src/lib/components/InstallWalkthrough.svelte
+++ b/website/src/lib/components/InstallWalkthrough.svelte
@@ -1,0 +1,127 @@
+<script lang="ts">
+	/**
+	 * Why: nine products, nine install sequences, and a large shared middle.
+	 * Printing all nine at once buries the four lines a given reader needs;
+	 * printing the shared setup inside each one repeats the tctl bootstrap and
+	 * the API-key section nine times, and a repeated instruction is one that
+	 * gets edited in eight places out of nine.
+	 *
+	 * What: the shared prerequisites once, then an ARIA tablist over the nine
+	 * audiences with one panel each. Every panel is rendered into the
+	 * prerendered HTML and hidden with the `hidden` attribute rather than
+	 * mounted on selection, so the page ships every command as static HTML and
+	 * the picker only changes which one is on screen.
+	 *
+	 * Keyboard: the tablist follows the ARIA authoring-practices pattern —
+	 * roving tabindex, so Tab enters and leaves the whole picker as one stop,
+	 * with Left/Right moving between audiences and Home/End jumping to the
+	 * ends. Selection follows focus, which is the pattern's default for a
+	 * picker whose panels are already in the document.
+	 *
+	 * Test: `src/lib/install/render.test.ts` mounts this component and asserts
+	 * every audience gets a tab and a panel, that each panel carries its own
+	 * audience's commands, and that arrow keys move the selection.
+	 */
+	import AudienceSteps from './AudienceSteps.svelte';
+	import CommandBlock from './CommandBlock.svelte';
+	import { AUDIENCES, usedPrerequisites } from '$lib/install/audiences';
+
+	const prerequisites = usedPrerequisites();
+
+	let selected = $state(0);
+	let tabs: HTMLButtonElement[] = $state([]);
+
+	function select(index: number) {
+		selected = (index + AUDIENCES.length) % AUDIENCES.length;
+		tabs[selected]?.focus();
+	}
+
+	function onTabKeydown(event: KeyboardEvent) {
+		const step = event.key === 'ArrowRight' ? 1 : event.key === 'ArrowLeft' ? -1 : 0;
+		if (step !== 0) {
+			event.preventDefault();
+			select(selected + step);
+		} else if (event.key === 'Home') {
+			event.preventDefault();
+			select(0);
+		} else if (event.key === 'End') {
+			event.preventDefault();
+			select(AUDIENCES.length - 1);
+		}
+	}
+</script>
+
+<!-- SHARED PREREQUISITES — written once, linked to from every audience. -->
+<section class="mx-auto max-w-content px-4 py-16 sm:px-6">
+	<h2 id="prerequisites" class="scroll-mt-24 font-display text-2xl font-bold sm:text-3xl">
+		Shared prerequisites
+	</h2>
+	<p class="mt-4 max-w-3xl text-foundry-secondary">
+		Set up only what your product's roster names. Nothing here is needed by all nine, and every
+		audience below says which of these it wants and how badly.
+	</p>
+	<div class="mt-8 grid gap-4 sm:grid-cols-2">
+		{#each prerequisites as prereq (prereq.id)}
+			<div id="prereq-{prereq.id}" class="card min-w-0 scroll-mt-24">
+				<h3 class="font-display text-lg font-semibold">{prereq.title}</h3>
+				<p class="mt-2 text-sm text-foundry-secondary">{prereq.body}</p>
+				{#each prereq.commands as block (block.command)}
+					<CommandBlock {block} />
+				{/each}
+			</div>
+		{/each}
+	</div>
+</section>
+
+<!-- PICKER + PANELS -->
+<section class="border-t border-foundry-border bg-foundry-raised">
+	<div class="mx-auto max-w-content px-4 py-16 sm:px-6">
+		<h2 id="walkthrough" class="scroll-mt-24 font-display text-2xl font-bold sm:text-3xl">
+			Pick what you are installing
+		</h2>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			Nine paths. Seven go through tctl; trusty-code and trusty-agents do not, and are the two
+			places the commands genuinely differ rather than just naming a different crate.
+		</p>
+
+		<div
+			role="tablist"
+			aria-label="Install audience"
+			aria-orientation="horizontal"
+			class="mt-8 flex flex-wrap gap-2"
+		>
+			{#each AUDIENCES as audience, i (audience.id)}
+				<button
+					bind:this={tabs[i]}
+					type="button"
+					role="tab"
+					id="tab-{audience.id}"
+					aria-selected={i === selected}
+					aria-controls="panel-{audience.id}"
+					tabindex={i === selected ? 0 : -1}
+					onclick={() => (selected = i)}
+					onkeydown={onTabKeydown}
+					class="rounded-sm border-[1.5px] px-3 py-1.5 font-mono text-xs tracking-wide transition-colors
+						{i === selected
+						? 'border-foundry-primary bg-foundry-primary text-foundry-inverse'
+						: 'border-foundry-border-strong bg-foundry-card text-foundry-secondary hover:border-foundry-primary hover:text-foundry-text'}"
+				>
+					{audience.label}
+				</button>
+			{/each}
+		</div>
+
+		{#each AUDIENCES as audience, i (audience.id)}
+			<div
+				id="panel-{audience.id}"
+				role="tabpanel"
+				aria-labelledby="tab-{audience.id}"
+				tabindex="0"
+				hidden={i !== selected}
+				class="mt-10"
+			>
+				<AudienceSteps {audience} />
+			</div>
+		{/each}
+	</div>
+</section>

--- a/website/src/lib/install/audiences.test.ts
+++ b/website/src/lib/install/audiences.test.ts
@@ -1,0 +1,261 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+	AUDIENCES,
+	audienceText,
+	hasPlaceholder,
+	PREREQUISITES,
+	prerequisite,
+	usedPrerequisites,
+	type CommandBlock
+} from './audiences';
+import { STABLE_SET } from '../site';
+
+/**
+ * Why: a published install command that does not work is the worst failure
+ * this site has, and prose review does not catch it — `tctl install
+ * trusty-code` reads exactly like the seven lines above it and fails with an
+ * unknown-member error. The macOS permission is the same class of defect with
+ * a worse blast radius: telling a reader to grant `tm` the disk-wide category
+ * would be a security regression, not a typo (#5110).
+ *
+ * What: re-derives every install target from the repository — crate
+ * directories, package names in their own `Cargo.toml`, and `tctl` stable-set
+ * membership — and pins the two permission invariants the research doc
+ * establishes.
+ *
+ * Not covered here: whether a sentence reads well. This asserts the claims a
+ * reader will paste into a terminal or a system-settings pane.
+ *
+ * Test: this file.
+ */
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, '../../../..');
+
+/** Package name from a crate's own manifest — `trusty-git-analytics` is `tga`. */
+function packageNames(): Set<string> {
+	const cratesDir = path.join(REPO_ROOT, 'crates');
+	const names = new Set<string>();
+	for (const entry of readdirSync(cratesDir, { withFileTypes: true })) {
+		if (!entry.isDirectory()) continue;
+		const manifest = path.join(cratesDir, entry.name, 'Cargo.toml');
+		if (!existsSync(manifest)) continue;
+		// Anchored: a `[dependencies]` entry further down also matches `name`.
+		const declared = readFileSync(manifest, 'utf8').match(/^name\s*=\s*"([^"]+)"/m);
+		if (declared) names.add(declared[1]);
+	}
+	return names;
+}
+
+/** Every command block the page can render, audience commands and shared setup. */
+function allCommands(): CommandBlock[] {
+	return [
+		...PREREQUISITES.flatMap((p) => p.commands),
+		...AUDIENCES.flatMap((a) => a.steps.flatMap((s) => s.commands))
+	];
+}
+
+describe('the nine install audiences', () => {
+	it('covers the nine paths the research doc establishes, with unique ids', () => {
+		expect(AUDIENCES.length).toBe(9);
+		expect(new Set(AUDIENCES.map((a) => a.id)).size).toBe(9);
+		expect(AUDIENCES.map((a) => a.id)).toEqual([
+			'trusty-memory',
+			'trusty-search',
+			'search-and-memory',
+			'trusty-analyze',
+			'trusty-review',
+			'trusty-mpm',
+			'trusty-code',
+			'trusty-agents',
+			'tga'
+		]);
+	});
+
+	it('gives every audience at least one ordered step', () => {
+		for (const audience of AUDIENCES) {
+			expect(audience.steps.length, audience.id).toBeGreaterThan(0);
+			expect(audience.prerequisites.length, audience.id).toBeGreaterThan(0);
+		}
+	});
+
+	it('resolves every prerequisite reference, and renders each one once', () => {
+		for (const audience of AUDIENCES) {
+			for (const ref of audience.prerequisites) {
+				expect(() => prerequisite(ref.id), `${audience.id} → ${ref.id}`).not.toThrow();
+			}
+			// A prerequisite named twice by one audience would render twice in
+			// its roster, which is the duplication this module exists to avoid.
+			const ids = audience.prerequisites.map((r) => r.id);
+			expect(new Set(ids).size, audience.id).toBe(ids.length);
+		}
+		// The shared section renders exactly the prerequisites something asks
+		// for — a row nothing references is dead copy on a public page.
+		expect(usedPrerequisites().length).toBe(PREREQUISITES.length);
+	});
+});
+
+describe('every command is one the repository can actually run', () => {
+	it('names a stable-set member on every tctl install line', () => {
+		const targets = allCommands()
+			.flatMap((block) => block.command.split('\n'))
+			.filter((line) => line.startsWith('tctl install '))
+			.flatMap((line) => line.slice('tctl install '.length).split(' '));
+		expect(targets.length).toBeGreaterThan(0);
+		for (const target of targets) {
+			expect(STABLE_SET, `tctl install ${target}`).toContain(target);
+		}
+	});
+
+	/**
+	 * The two products `tctl` cannot install. `stable_set.rs` has seven entries
+	 * and neither is among them, so a `tctl install` line on either audience is
+	 * a command that fails with `unknown member(s)`.
+	 */
+	it('offers no tctl install line to trusty-code or trusty-agents', () => {
+		for (const id of ['trusty-code', 'trusty-agents']) {
+			const audience = AUDIENCES.find((a) => a.id === id)!;
+			for (const step of audience.steps) {
+				for (const block of step.commands) {
+					expect(block.command, `${id} step "${step.title}"`).not.toContain('tctl install');
+				}
+			}
+			expect(STABLE_SET).not.toContain(id);
+		}
+	});
+
+	it('names a real package on every cargo install line', () => {
+		const packages = packageNames();
+		const named = allCommands()
+			.flatMap((block) => block.command.split('\n'))
+			.map((line) => line.match(/^cargo install ([a-z0-9-]+) --locked$/))
+			.filter((match): match is RegExpMatchArray => match !== null)
+			.map((match) => match[1]);
+		expect(named.length).toBeGreaterThan(0);
+		for (const name of named) {
+			expect(packages, `cargo install ${name}`).toContain(name);
+		}
+	});
+
+	it('names a crate directory that exists on every cargo install --path line', () => {
+		const paths = allCommands()
+			.flatMap((block) => block.command.split('\n'))
+			.map((line) => line.match(/^cargo install --path (\S+) --locked$/))
+			.filter((match): match is RegExpMatchArray => match !== null)
+			.map((match) => match[1]);
+		expect(paths).toEqual(['crates/trusty-agents']);
+		for (const dir of paths) {
+			expect(existsSync(path.join(REPO_ROOT, dir, 'Cargo.toml')), dir).toBe(true);
+		}
+	});
+
+	it('gives every command block a distinct, non-empty copy label', () => {
+		const labels = allCommands().map((block) => block.label);
+		for (const label of labels) {
+			expect(label.length).toBeGreaterThan(0);
+		}
+		expect(new Set(labels).size).toBe(labels.length);
+	});
+});
+
+describe('placeholders always arrive with the instruction that replaces them', () => {
+	it('carries a note naming each placeholder it prints', () => {
+		const withPlaceholders = allCommands().filter((block) => hasPlaceholder(block.command));
+		// Not a vacuous pass: the provider-key exports genuinely print one.
+		expect(withPlaceholders.length).toBeGreaterThan(0);
+		for (const block of withPlaceholders) {
+			expect(block.placeholderNote, block.command).toBeTruthy();
+			for (const placeholder of block.command.match(/<[^<>\s]+>/g) ?? []) {
+				expect(block.placeholderNote, `${block.command} → ${placeholder}`).toContain(placeholder);
+			}
+		}
+	});
+
+	it('leaves no note on a command that has nothing to substitute', () => {
+		for (const block of allCommands()) {
+			if (hasPlaceholder(block.command)) continue;
+			expect(block.placeholderNote, block.command).toBeUndefined();
+		}
+	});
+});
+
+describe('macOS permission categories are per product and never widened', () => {
+	it('asks for Full Disk Access only where trusty-search is involved', () => {
+		const fda = AUDIENCES.filter((a) => a.tcc.category === 'full-disk-access').map((a) => a.id);
+		expect(fda).toEqual(['trusty-search', 'search-and-memory']);
+	});
+
+	/**
+	 * The invariant this whole page was gated on. `tm` and `tagent` read other
+	 * apps' `$HOME` containers, which raises the SEPARATE "access data from
+	 * other apps" prompt; the disk-wide category is a different, wider grant
+	 * that neither should ever be offered. The doc is explicit that it "should
+	 * never be granted" to `tm`, so its name may not appear in that audience's
+	 * copy at all — not even as a warning a reader could skim into an
+	 * instruction.
+	 */
+	it('never prints the wider category anywhere in an App Data audience', () => {
+		const appData = AUDIENCES.filter((a) => a.tcc.category === 'app-data').map((a) => a.id);
+		expect(appData).toEqual(['trusty-mpm', 'trusty-agents']);
+		for (const id of appData) {
+			const audience = AUDIENCES.find((a) => a.id === id)!;
+			expect(audienceText(audience), id).not.toContain('Full Disk Access');
+			expect(audienceText(audience), id).toContain('App Data');
+		}
+	});
+
+	it('says so explicitly where no permission applies', () => {
+		const none = AUDIENCES.filter((a) => a.tcc.category === 'none');
+		expect(none.map((a) => a.id)).toEqual([
+			'trusty-memory',
+			'trusty-analyze',
+			'trusty-review',
+			'trusty-code',
+			'tga'
+		]);
+		for (const audience of none) {
+			expect(audience.tcc.summary, audience.id).not.toContain('Full Disk Access');
+			expect(audience.tcc.summary.length, audience.id).toBeGreaterThan(0);
+		}
+	});
+});
+
+describe('the MCP registration each audience publishes', () => {
+	/**
+	 * Argument vectors, verbatim from the research doc's per-audience sections.
+	 * `trusty-review` is the one with two accepted spellings; `["mcp"]` is the
+	 * canonical one to publish and `["serve", "--stdio"]` survives only as a
+	 * back-compat alias, so the canonical form is what the block prints.
+	 */
+	const EXPECTED: Record<string, string> = {
+		'trusty-memory': '"args": ["serve","--stdio"]',
+		'trusty-search': '"args": ["serve"]',
+		'trusty-analyze': '"args": ["serve","--mcp"]',
+		'trusty-review': '"args": ["mcp"]',
+		'trusty-agents': '"args": ["mcp-serve"]'
+	};
+
+	it('prints the argument vector the crate actually parses', () => {
+		for (const [id, args] of Object.entries(EXPECTED)) {
+			const audience = AUDIENCES.find((a) => a.id === id)!;
+			const commands = audience.steps.flatMap((s) => s.commands.map((c) => c.command));
+			expect(
+				commands.some((c) => c.includes(args)),
+				`${id} MCP args`
+			).toBe(true);
+		}
+	});
+
+	it('registers nothing for tga, which has no MCP transport', () => {
+		const tga = AUDIENCES.find((a) => a.id === 'tga')!;
+		for (const step of tga.steps) {
+			for (const block of step.commands) {
+				expect(block.command, 'tga').not.toContain('mcpServers');
+			}
+		}
+		expect(audienceText(tga)).toContain('no MCP transport');
+	});
+});

--- a/website/src/lib/install/audiences.ts
+++ b/website/src/lib/install/audiences.ts
@@ -1,0 +1,728 @@
+/**
+ * Why: nine products install nine different ways, and the differences that
+ * matter most are the ones a reader cannot guess — `tctl install trusty-code`
+ * fails, `tctl install trusty-review` quietly installs three crates, and the
+ * macOS permission a product needs is per-product and easy to publish
+ * backwards. Keeping the walkthrough as data rather than as markup means each
+ * of those facts has one place to be checked, and the page cannot show a
+ * command for one audience while claiming a different one for another.
+ *
+ * What: nine `Audience` rows, plus the `Prerequisite` rows they share. A
+ * prerequisite is written ONCE and referenced by id, so the page renders the
+ * `tctl` bootstrap and the API-key setup a single time instead of nine.
+ *
+ * Sourcing rule, stricter than `$lib/tools`: every command, env-var name, TCC
+ * category, API-key requirement and MCP registration below comes from
+ * `docs/research/install-paths-by-audience.md` (#5109, its UNKNOWNs resolved
+ * in #5116/#6725), which checked all nine paths against crate source,
+ * crates.io and the release tooling. Nothing here was derived from a README or
+ * from an adjacent product's shape. Two deliberate, marked exceptions:
+ *
+ *   - `export <NAME>=<value>` lines. The env-var NAMES are verbatim from that
+ *     doc; `export` is the shell mechanism for setting them, which the doc
+ *     states as a requirement rather than as a command line.
+ *   - the `.mcp.json` wrapper object. `command` and `args` are verbatim from
+ *     the doc; the surrounding `mcpServers` key is the config file's own
+ *     schema, not a claim about any crate.
+ *
+ * Anything the doc leaves as prose stays prose here — tga's `--config` flag
+ * and trusty-agents' signing script are named, not turned into a command
+ * block, because the doc gives no exact invocation for either and inventing
+ * one is the failure mode this module exists to prevent.
+ *
+ * Test: `src/lib/install/audiences.test.ts` re-derives crate directories and
+ * `tctl` stable-set membership from the repository and pins the TCC
+ * invariants; `src/lib/install/render.test.ts` mounts the walkthrough and
+ * asserts every command reaches the DOM under its own audience.
+ */
+
+/** A shell (or config-file) block rendered with its own copy button. */
+export interface CommandBlock {
+	/** Exact text to copy — what lands in the terminal, verbatim. */
+	command: string;
+	/** Accessible name for the copy button, e.g. "Copy the tctl bootstrap". */
+	label: string;
+	/**
+	 * What to substitute. REQUIRED whenever `command` contains a
+	 * `<placeholder>`: a block that ships a placeholder with no instruction is
+	 * what `audiences.test.ts` fails on.
+	 */
+	placeholderNote?: string;
+}
+
+/** Does this command carry a `<placeholder>` the reader must replace? */
+export function hasPlaceholder(command: string): boolean {
+	return /<[^<>\s]+>/.test(command);
+}
+
+export type PrerequisiteId =
+	'tctl' | 'rust' | 'pnpm' | 'git' | 'ram-16' | 'ram-8' | 'llm-key' | 'claude-code';
+
+/**
+ * Setup more than one audience needs. Rendered once, above the picker, and
+ * referenced by id from each audience — the deduplication this walkthrough is
+ * built around.
+ */
+export interface Prerequisite {
+	id: PrerequisiteId;
+	title: string;
+	body: string;
+	commands: CommandBlock[];
+}
+
+/** How badly a given audience needs a prerequisite. */
+export type Requirement = 'required' | 'recommended' | 'optional';
+
+export interface PrerequisiteRef {
+	id: PrerequisiteId;
+	requirement: Requirement;
+	/** What this audience uses it for, in the research doc's own terms. */
+	note: string;
+}
+
+export interface InstallStep {
+	title: string;
+	body: string;
+	commands: CommandBlock[];
+	/** What the reader needs after running the commands. */
+	notes: string[];
+}
+
+/**
+ * The macOS permission category, kept as an enum rather than as prose.
+ *
+ * `full-disk-access` is trusty-search alone. `app-data` is the SEPARATE,
+ * narrower "would like to access data from other apps" category `tm` and
+ * `tagent` need; a page that offers those two the disk-wide category instead
+ * is a security regression, which is why `audiences.test.ts` asserts the wider
+ * category's name appears nowhere in their copy.
+ */
+export type TccCategory = 'none' | 'full-disk-access' | 'app-data';
+
+export interface Audience {
+	/** Picker id, and the `#install-<id>` panel anchor. */
+	id: string;
+	/** Short picker label. */
+	label: string;
+	/** Binary or binaries this audience ends up with. */
+	binary: string;
+	tagline: string;
+	lede: string;
+	prerequisites: PrerequisiteRef[];
+	steps: InstallStep[];
+	tcc: { category: TccCategory; summary: string };
+}
+
+/** The bootstrap line, identical to `$lib/site`'s `INSTALL_OPTIONS` tctl entry. */
+const TCTL_BOOTSTRAP =
+	'curl -sSf https://raw.githubusercontent.com/bobmatnyc/trusty-tools/main/install.sh | sh';
+
+/** `.mcp.json` entry for one server. The wrapper is the file's schema. */
+function mcpEntry(name: string, command: string, args: string[]): string {
+	return [
+		'{',
+		'  "mcpServers": {',
+		`    "${name}": {`,
+		`      "command": "${command}",`,
+		`      "args": ${JSON.stringify(args)}`,
+		'    }',
+		'  }',
+		'}'
+	].join('\n');
+}
+
+export const PREREQUISITES: Prerequisite[] = [
+	{
+		id: 'tctl',
+		title: 'The tctl control plane',
+		body: 'tctl installs seven of the nine products on this page. It prefers a prebuilt tarball on macOS arm64, Linux x86_64 and Linux arm64, verifies its published SHA-256, and falls back to cargo install --locked from crates.io on any other host. It is also the only path that resolves a product’s runtime dependencies for you and keeps macOS signing identities stable across upgrades, so a permission you grant once survives the next install.',
+		commands: [{ command: TCTL_BOOTSTRAP, label: 'Copy the tctl bootstrap command' }]
+	},
+	{
+		id: 'rust',
+		title: 'A Rust toolchain',
+		body: 'Rust 1.94 or newer — the workspace MSRV. Needed only when you build from source: on a prebuilt platform tctl never invokes cargo, and trusty-agents is the one product with no prebuilt at all.',
+		commands: []
+	},
+	{
+		id: 'pnpm',
+		title: 'pnpm',
+		body: 'Only trusty-agents needs it. trusty-search, trusty-memory and trusty-analyze commit their built Svelte UI to git, so installing those from crates.io never runs a JavaScript build. trusty-agents does not commit its UI: without pnpm the crate still compiles, but its build script writes a placeholder page and the embedded UI does nothing.',
+		commands: []
+	},
+	{
+		id: 'git',
+		title: 'git',
+		body: 'trusty-agents is installed by cloning this repository. trusty-code reads git metadata for branch context and tga reads git history through git2, so both want a git repository to point at.',
+		commands: []
+	},
+	{
+		id: 'ram-16',
+		title: '16 GB RAM, ~2 GB disk',
+		body: 'trusty-search checks available memory at startup and refuses to run below 16 GB; TRUSTY_SKIP_RAM_CHECK=1 bypasses that check. The disk is for the ONNX embedding model it downloads on first run. Apple Silicon uses CoreML automatically; NVIDIA CUDA is an opt-in --features cuda build.',
+		commands: []
+	},
+	{
+		id: 'ram-8',
+		title: '8 GB RAM, ~500 MB disk',
+		body: 'The floor for trusty-analyze and trusty-review, plus room for their model cache.',
+		commands: []
+	},
+	{
+		id: 'llm-key',
+		title: 'A model provider key',
+		body: 'OpenRouter is the default provider everywhere a key is read. It is required only for trusty-review, which will not produce a review without one. It is optional for trusty-memory, trusty-analyze, trusty-code and trusty-agents: each starts fine with no key and asks for one only when a feature that needs it actually runs. AWS Bedrock is the documented alternative for trusty-analyze and trusty-review.',
+		commands: [
+			{
+				command: 'export OPENROUTER_API_KEY=<your-openrouter-key>',
+				label: 'Copy the OpenRouter key export',
+				placeholderNote:
+					'Replace <your-openrouter-key> with the key from your own OpenRouter account — nothing on this page is a real key.'
+			},
+			{
+				command: 'export TRUSTY_LLM_MODEL=<bedrock-model-id>\nexport AWS_REGION=<your-aws-region>',
+				label: 'Copy the AWS Bedrock exports',
+				placeholderNote:
+					'Replace <bedrock-model-id> with a Bedrock model you have access to and <your-aws-region> with the region it is enabled in. These two replace the OpenRouter key rather than joining it.'
+			}
+		]
+	},
+	{
+		id: 'claude-code',
+		title: 'Claude Code',
+		body: 'Recommended, never enforced at install time. trusty-mpm orchestrates Claude Code sessions, so it is what tm drives.',
+		commands: []
+	}
+];
+
+/** Every audience, in the order the picker lists them. */
+export const AUDIENCES: Audience[] = [
+	{
+		id: 'trusty-memory',
+		label: 'trusty-memory',
+		binary: 'trusty-memory',
+		tagline: 'Semantic memory, on its own',
+		lede: 'A standalone daemon with no external database and nothing else to install first. tctl installs it alone — it has no runtime dependency on any other product.',
+		prerequisites: [
+			{ id: 'tctl', requirement: 'recommended', note: 'The install path this page recommends.' },
+			{
+				id: 'llm-key',
+				requirement: 'optional',
+				note: 'Only the embedded chat panel reads OPENROUTER_API_KEY. Everything else works without it.'
+			}
+		],
+		steps: [
+			{
+				title: 'Install it',
+				body: 'One member, no dependency closure.',
+				commands: [
+					{ command: 'tctl install trusty-memory', label: 'Copy the trusty-memory tctl install' },
+					{
+						command: 'cargo install trusty-memory --locked',
+						label: 'Copy the trusty-memory cargo install'
+					}
+				],
+				notes: [
+					'The second line is the escape hatch: it pulls the published crates.io release directly, which is also what tctl falls back to off a prebuilt platform.',
+					'The Svelte UI ships pre-built inside the crate, so this never runs pnpm.'
+				]
+			},
+			{
+				title: 'Find the port it serves on',
+				body: 'The daemon picks its port at startup and reports it back. The UI is on the same port, on loopback.',
+				commands: [{ command: 'trusty-memory port', label: 'Copy the trusty-memory port command' }],
+				notes: []
+			},
+			{
+				title: 'Register it as an MCP server',
+				body: 'Add the entry to your .mcp.json. The command and args are what the crate’s own CLI parses.',
+				commands: [
+					{
+						command: mcpEntry('trusty-memory', 'trusty-memory', ['serve', '--stdio']),
+						label: 'Copy the trusty-memory MCP entry'
+					}
+				],
+				notes: []
+			}
+		],
+		tcc: {
+			category: 'none',
+			summary:
+				'Nothing to grant. trusty-memory reads $HOME locations only, and it carries no signing identity because it has no permission to preserve.'
+		}
+	},
+	{
+		id: 'trusty-search',
+		label: 'trusty-search',
+		binary: 'trusty-search',
+		tagline: 'Hybrid code search, on its own',
+		lede: 'One machine-wide daemon over as many named project indexes as you like. It is a leaf in the dependency graph — tctl installs it alone.',
+		prerequisites: [
+			{ id: 'tctl', requirement: 'recommended', note: 'The install path this page recommends.' },
+			{
+				id: 'ram-16',
+				requirement: 'required',
+				note: 'Checked at startup. This is the highest floor of any product here.'
+			}
+		],
+		steps: [
+			{
+				title: 'Install it',
+				body: 'One member, no dependency closure.',
+				commands: [
+					{ command: 'tctl install trusty-search', label: 'Copy the trusty-search tctl install' },
+					{
+						command: 'cargo install trusty-search --locked',
+						label: 'Copy the trusty-search cargo install'
+					}
+				],
+				notes: ['The Svelte UI ships pre-built inside the crate, so this never runs pnpm.']
+			},
+			{
+				title: 'Start the daemon and read its port',
+				body: 'First start downloads the embedding model, which is what the ~2 GB of disk is for.',
+				commands: [
+					{ command: 'trusty-search start', label: 'Copy the trusty-search start command' },
+					{ command: 'trusty-search port', label: 'Copy the trusty-search port command' }
+				],
+				notes: []
+			},
+			{
+				title: 'Register it as an MCP server',
+				body: 'Add the entry to your .mcp.json.',
+				commands: [
+					{
+						command: mcpEntry('trusty-search', 'trusty-search', ['serve']),
+						label: 'Copy the trusty-search MCP entry'
+					}
+				],
+				notes: []
+			}
+		],
+		tcc: {
+			category: 'full-disk-access',
+			summary:
+				'trusty-search is the one product here that needs Full Disk Access, and only when its index data lives on an external or removable volume. An index on the local disk never triggers the prompt. Installing through tctl re-signs the binary under a stable identity, so the grant survives an upgrade.'
+		}
+	},
+	{
+		id: 'search-and-memory',
+		label: 'search + memory',
+		binary: 'trusty-search, trusty-memory',
+		tagline: 'Both daemons together',
+		lede: 'The common pairing: search indexes your code, memory stores what you and your agents learned about it. Neither calls the other — they are complementary, not layered, and each runs fine with the other absent.',
+		prerequisites: [
+			{ id: 'tctl', requirement: 'recommended', note: 'Installs both in one command.' },
+			{
+				id: 'ram-16',
+				requirement: 'required',
+				note: 'trusty-search sets the floor; trusty-memory adds no requirement of its own.'
+			},
+			{
+				id: 'llm-key',
+				requirement: 'optional',
+				note: 'Only trusty-memory’s chat panel reads OPENROUTER_API_KEY.'
+			}
+		],
+		steps: [
+			{
+				title: 'Install both',
+				body: 'There is no dependency edge between them, so the order does not matter and they can be installed in parallel.',
+				commands: [
+					{
+						command: 'tctl install trusty-search trusty-memory',
+						label: 'Copy the combined tctl install'
+					},
+					{
+						command: 'cargo install trusty-search --locked\ncargo install trusty-memory --locked',
+						label: 'Copy the two cargo installs'
+					}
+				],
+				notes: [
+					'What the two share is a library, not a process: both link the same embedder out of trusty-common. Neither daemon talks to the other over the network.'
+				]
+			},
+			{
+				title: 'Register both MCP servers',
+				body: 'Two independent entries in the same .mcp.json — each keeps the command and args from its own section.',
+				commands: [
+					{
+						command: [
+							'{',
+							'  "mcpServers": {',
+							'    "trusty-search": {',
+							'      "command": "trusty-search",',
+							'      "args": ["serve"]',
+							'    },',
+							'    "trusty-memory": {',
+							'      "command": "trusty-memory",',
+							'      "args": ["serve", "--stdio"]',
+							'    }',
+							'  }',
+							'}'
+						].join('\n'),
+						label: 'Copy both MCP entries'
+					}
+				],
+				notes: []
+			}
+		],
+		tcc: {
+			category: 'full-disk-access',
+			summary:
+				'Only trusty-search needs Full Disk Access, and only for indexes on an external volume. trusty-memory needs nothing — do not grant it anything on trusty-search’s account.'
+		}
+	},
+	{
+		id: 'trusty-analyze',
+		label: 'trusty-analyze',
+		binary: 'trusty-analyze',
+		tagline: 'Complexity and smell analysis',
+		lede: 'A leaf install: nothing requires it, and it requires nothing. It is an optional stable-set member, so a missing prebuilt for your platform will not fail a wider tctl run.',
+		prerequisites: [
+			{ id: 'tctl', requirement: 'recommended', note: 'The install path this page recommends.' },
+			{ id: 'ram-8', requirement: 'required', note: 'Plus room for the model cache.' },
+			{
+				id: 'llm-key',
+				requirement: 'optional',
+				note: 'Complexity and smell analysis needs no model at all. Only the deep-analysis pass reads a key.'
+			}
+		],
+		steps: [
+			{
+				title: 'Install it',
+				body: 'One member, no dependency closure.',
+				commands: [
+					{ command: 'tctl install trusty-analyze', label: 'Copy the trusty-analyze tctl install' },
+					{
+						command: 'cargo install trusty-analyze --locked',
+						label: 'Copy the trusty-analyze cargo install'
+					}
+				],
+				notes: ['The Svelte UI ships pre-built inside the crate, so this never runs pnpm.']
+			},
+			{
+				title: 'Register it as an MCP server',
+				body: 'Add the entry to your .mcp.json. Both args are required — the crate generates exactly this pair itself.',
+				commands: [
+					{
+						command: mcpEntry('trusty-analyze', 'trusty-analyze', ['serve', '--mcp']),
+						label: 'Copy the trusty-analyze MCP entry'
+					}
+				],
+				notes: []
+			}
+		],
+		tcc: {
+			category: 'none',
+			summary:
+				'Nothing to grant. trusty-analyze reads $HOME locations only, the same explicit carve-out trusty-memory gets.'
+		}
+	},
+	{
+		id: 'trusty-review',
+		label: 'trusty-review',
+		binary: 'trusty-review',
+		tagline: 'Code review with real context',
+		lede: 'The one product with a hard runtime dependency on two others. tctl installs three members for you — trusty-review, trusty-search and trusty-analyze — because a review produced without that context is worse than no review.',
+		prerequisites: [
+			{
+				id: 'tctl',
+				requirement: 'recommended',
+				note: 'It resolves the three-member closure and orders it for you.'
+			},
+			{ id: 'ram-8', requirement: 'required', note: 'Plus room for the model cache.' },
+			{
+				id: 'llm-key',
+				requirement: 'required',
+				note: 'Not optional here, unlike trusty-analyze’s deep pass. Set OPENROUTER_API_KEY, or the two Bedrock variables instead.'
+			}
+		],
+		steps: [
+			{
+				title: 'Install it, and what it needs',
+				body: 'One tctl line installs three members. The cargo path installs one, so bring up trusty-search and trusty-analyze first if you take it.',
+				commands: [
+					{ command: 'tctl install trusty-review', label: 'Copy the trusty-review tctl install' },
+					{
+						command: 'cargo install trusty-review --locked',
+						label: 'Copy the trusty-review cargo install'
+					}
+				],
+				notes: [
+					'trusty-review checks for both before it starts a review and skips the review entirely if either is unreachable, absent an explicit degraded-mode opt-in.',
+					'Install order does not matter under tctl: it resolves the closure and orders it topologically.'
+				]
+			},
+			{
+				title: 'Point it at a model',
+				body: 'Set the provider key from the prerequisites above before the first review — this is the one product that will not run without it.',
+				commands: [],
+				notes: []
+			},
+			{
+				title: 'Register it as an MCP server',
+				body: 'Add the entry to your .mcp.json.',
+				commands: [
+					{
+						command: mcpEntry('trusty-review', 'trusty-review', ['mcp']),
+						label: 'Copy the trusty-review MCP entry'
+					}
+				],
+				notes: [
+					'["serve", "--stdio"] still parses as an alias, so an older .mcp.json keeps working. ["mcp"] is the current spelling to write.'
+				]
+			}
+		],
+		tcc: {
+			category: 'none',
+			summary:
+				'Nothing to grant, and this was checked rather than assumed: trusty-review was evaluated alongside trusty-memory and trusty-analyze and deliberately excluded — it walks no $HOME tree and reads no other application’s files.'
+		}
+	},
+	{
+		id: 'trusty-mpm',
+		label: 'trusty-mpm (tm)',
+		binary: 'tm, trusty-mpm',
+		tagline: 'The session orchestrator',
+		lede: 'tctl installs three members here — trusty-mpm, trusty-memory and trusty-search — because tm injects both MCP servers into every managed session by default.',
+		prerequisites: [
+			{
+				id: 'tctl',
+				requirement: 'recommended',
+				note: 'It resolves the three-member closure and orders it for you.'
+			},
+			{
+				id: 'claude-code',
+				requirement: 'recommended',
+				note: 'tm orchestrates Claude Code sessions. Not enforced at install time.'
+			},
+			{
+				id: 'rust',
+				requirement: 'optional',
+				note: 'Only if no prebuilt exists for your platform.'
+			}
+		],
+		steps: [
+			{
+				title: 'Install it, and check what landed',
+				body: 'One line installs three binaries. tctl status prints what it manages and what is running.',
+				commands: [
+					{
+						command: 'tctl install trusty-mpm\ntctl status',
+						label: 'Copy the trusty-mpm install and status check'
+					},
+					{
+						command: 'cargo install trusty-mpm --locked',
+						label: 'Copy the trusty-mpm cargo install'
+					}
+				],
+				notes: [
+					'The crate ships two binaries, tm and trusty-mpm, from the same source — either name drives it.'
+				]
+			},
+			{
+				title: 'Know where its config lives',
+				body: 'Configuration is TOML at ~/.config/trusty-mpm/config.toml, honouring $XDG_CONFIG_HOME when you set it.',
+				commands: [],
+				notes: [
+					'Two older docs point at a config.yaml and at a trusty-mpmd binary. Neither exists: the file is TOML, and the daemon runs in-process as a mode of tm itself.'
+				]
+			},
+			{
+				title: 'Run the daemon',
+				body: 'tm owns its own lifecycle rather than handing it to launchd.',
+				commands: [{ command: 'tm start', label: 'Copy the tm start command' }],
+				notes: ['tm stop and tm restart are the other two halves of the same verb set.']
+			}
+		],
+		tcc: {
+			category: 'app-data',
+			summary:
+				'tm needs the App Data category, and only that. It reads other applications’ $HOME containers — Claude config directories, tmux state — which raises the separate “would like to access data from other apps” prompt. Grant that category and nothing wider. Installing through tctl signs tm and trusty-mpm together under a stable identity, so the grant survives an upgrade.'
+		}
+	},
+	{
+		id: 'trusty-code',
+		label: 'trusty-code',
+		binary: 'tcode',
+		tagline: 'A per-project coding harness',
+		lede: 'Not a tctl product. trusty-code is published on crates.io but is not a stable-set member, so cargo install is the path — tctl install trusty-code fails with an unknown-member error.',
+		prerequisites: [
+			{ id: 'git', requirement: 'required', note: 'It reads git metadata for branch context.' },
+			{
+				id: 'claude-code',
+				requirement: 'optional',
+				note: 'Useful alongside it, never required by it.'
+			},
+			{
+				id: 'llm-key',
+				requirement: 'optional',
+				note: 'Resolved lazily: tcode serve starts with no key, and a key is only demanded the first time a chat or task dispatches to a provider that needs one. OpenRouter is the default route.'
+			}
+		],
+		steps: [
+			{
+				title: 'Install it from crates.io',
+				body: 'The published crate, direct. There is no prebuilt tarball and no tctl membership.',
+				commands: [
+					{ command: 'cargo install trusty-code --locked', label: 'Copy the trusty-code install' }
+				],
+				notes: [
+					'trusty-code has no Svelte build step, so pnpm is not involved at any point.',
+					'Its README points at a GitHub release tag that has never existed — an unreplaced template placeholder. Use the line above.'
+				]
+			},
+			{
+				title: 'Run one process per project',
+				body: 'The harness is scoped to a project’s .claude/ root, so it is one running process per project rather than one per machine.',
+				commands: [{ command: 'tcode serve', label: 'Copy the tcode serve command' }],
+				notes: []
+			}
+		],
+		tcc: {
+			category: 'none',
+			summary:
+				'No category applies. trusty-code implements no macOS permission state machine at all: it inherits whatever entitlements it is given, and a refusal from the OS surfaces as an ordinary error. It reads only the directory you navigate to.'
+		}
+	},
+	{
+		id: 'trusty-agents',
+		label: 'trusty-agents (tagent)',
+		binary: 'tagent',
+		tagline: 'The agentic harness',
+		lede: 'The only product here with no published crate and no release binary. Cloning this repository and building it is the install path, not a fallback from one.',
+		prerequisites: [
+			{ id: 'git', requirement: 'required', note: 'The install starts with a clone.' },
+			{
+				id: 'rust',
+				requirement: 'required',
+				note: 'Mandatory here — there is no prebuilt and no crates.io package to fall back to.'
+			},
+			{
+				id: 'pnpm',
+				requirement: 'recommended',
+				note: 'Without it the build still succeeds, but the embedded web UI is a placeholder page.'
+			},
+			{
+				id: 'llm-key',
+				requirement: 'optional',
+				note: 'Any ONE of CLAUDE_CODE_OAUTH_TOKEN, ANTHROPIC_API_KEY or OPENROUTER_API_KEY, checked in that order. None is required to launch; without one tagent prints an onboarding banner rather than failing.'
+			}
+		],
+		steps: [
+			{
+				title: 'Clone and build it',
+				body: 'This is the same cargo install --path form the project’s own signed-install script uses.',
+				commands: [
+					{
+						command:
+							'git clone https://github.com/bobmatnyc/trusty-tools\ncd trusty-tools\ncargo install --path crates/trusty-agents --locked',
+						label: 'Copy the trusty-agents clone and build'
+					}
+				],
+				notes: [
+					'tctl install trusty-agents fails — it is not a stable-set member. Older docs naming an open-mpm repository or crate are wrong; neither has ever existed.'
+				]
+			},
+			{
+				title: 'Supply one credential, or none',
+				body: 'Each credential resolves from the environment, then a project or user .env.local, then the store tagent config keys set writes to. A run against Bedrock or a local Ollama model needs none of the three.',
+				commands: [],
+				notes: []
+			},
+			{
+				title: 'Register it as an MCP server',
+				body: 'tagent exposes itself to other MCP clients over stdio.',
+				commands: [
+					{
+						command: mcpEntry('trusty-agents', 'tagent', ['mcp-serve']),
+						label: 'Copy the trusty-agents MCP entry'
+					}
+				],
+				notes: []
+			}
+		],
+		tcc: {
+			category: 'app-data',
+			summary:
+				'tagent needs the App Data category, the same narrow one tm needs and nothing wider. It reads $HOME and project .trusty-agents/ state, and project-local .claude/ directories that live under another application’s data category. Because it is installed outside tctl, its signing identity is not maintained for you — run scripts/install-trusty-agents-signed.sh from the clone if you want the grant to survive a rebuild.'
+		}
+	},
+	{
+		id: 'tga',
+		label: 'tga',
+		binary: 'tga',
+		tagline: 'Git analytics',
+		lede: 'A pure CLI over git history, and the only product whose published version matches this repository exactly. It is an optional stable-set member and a leaf: tctl installs it alone.',
+		prerequisites: [
+			{ id: 'tctl', requirement: 'recommended', note: 'The install path this page recommends.' },
+			{
+				id: 'git',
+				requirement: 'required',
+				note: 'It reads repository history through git2. SQLite is bundled — nothing to install.'
+			}
+		],
+		steps: [
+			{
+				title: 'Install it',
+				body: 'The package is named tga even though its directory is crates/trusty-git-analytics.',
+				commands: [
+					{ command: 'tctl install tga', label: 'Copy the tga tctl install' },
+					{ command: 'cargo install tga --locked', label: 'Copy the tga cargo install' }
+				],
+				notes: [
+					'Do not copy a built binary onto your PATH by hand. tga’s own user guide still shows a cp and an mv into /usr/local/bin; on macOS that leaves a stale kernel signature cache and the next run is killed in a way that looks like an out-of-memory kill. cargo install renames atomically instead.'
+				]
+			},
+			{
+				title: 'Point it at a config file',
+				body: 'One global flag, -c or --config, on every subcommand. It defaults to config.yaml resolved against your current directory.',
+				commands: [],
+				notes: [
+					'There is no ~/.config/tga/ fallback and no environment-variable override, whatever INSTALL-CONVENTION.md says.',
+					'tga has no MCP transport at all — nothing to register, by design.'
+				]
+			}
+		],
+		tcc: {
+			category: 'none',
+			summary:
+				'Nothing to grant. tga reads local git history and nothing else, which has never raised a prompt.'
+		}
+	}
+];
+
+/** Prerequisites any audience references, in `PREREQUISITES` order. */
+export function usedPrerequisites(): Prerequisite[] {
+	const used = new Set(AUDIENCES.flatMap((a) => a.prerequisites.map((p) => p.id)));
+	return PREREQUISITES.filter((p) => used.has(p.id));
+}
+
+/** Look one up by id. Throws rather than rendering an empty card. */
+export function prerequisite(id: PrerequisiteId): Prerequisite {
+	const found = PREREQUISITES.find((p) => p.id === id);
+	if (!found) throw new Error(`unknown prerequisite: ${id}`);
+	return found;
+}
+
+/**
+ * Every string an audience renders, joined. The TCC assertions read this, so
+ * a category named anywhere in an audience's copy is a category the test sees.
+ */
+export function audienceText(audience: Audience): string {
+	return [
+		audience.label,
+		audience.binary,
+		audience.tagline,
+		audience.lede,
+		...audience.prerequisites.map((p) => p.note),
+		...audience.steps.flatMap((s) => [
+			s.title,
+			s.body,
+			...s.commands.flatMap((c) => [c.command, c.label, c.placeholderNote ?? '']),
+			...s.notes
+		]),
+		audience.tcc.summary
+	].join('\n');
+}

--- a/website/src/lib/install/render.test.ts
+++ b/website/src/lib/install/render.test.ts
@@ -1,0 +1,206 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import InstallWalkthrough from '../components/InstallWalkthrough.svelte';
+import { AUDIENCES, hasPlaceholder, usedPrerequisites } from './audiences';
+
+/**
+ * Why: `audiences.test.ts` proves the data is right. It cannot prove the page
+ * SHOWS it — a panel wired to the wrong audience, a command dropped by a
+ * mis-keyed `{#each}`, or a copy button with no accessible name would all pass
+ * there and ship. #5110 asks for the rendered form to be asserted, because a
+ * command a reader cannot see is as useless as one that is wrong.
+ *
+ * What: mounts the walkthrough into jsdom and reads the DOM back — one tab and
+ * one panel per audience, every command inside ITS OWN panel, every copy
+ * button named, no placeholder without its instruction, and the App Data
+ * audience free of the wider permission's name. The keyboard case is here for
+ * the same reason: a picker that only responds to a mouse locks out the
+ * readers most likely to be pasting these commands into a terminal.
+ *
+ * Test: this file.
+ */
+
+let mounted: Record<string, unknown> | undefined;
+let target: HTMLElement | undefined;
+
+function render(): HTMLElement {
+	target = document.createElement('div');
+	document.body.appendChild(target);
+	mounted = mount(InstallWalkthrough, { target });
+	flushSync();
+	return target;
+}
+
+afterEach(() => {
+	if (mounted) unmount(mounted);
+	target?.remove();
+	mounted = undefined;
+	target = undefined;
+});
+
+/** Collapsed text, so a line break in the markup cannot fail a match. */
+function text(node: Element): string {
+	return (node.textContent ?? '').replace(/\s+/g, ' ');
+}
+
+describe('every audience reaches the page', () => {
+	it('renders a tab and a panel for all nine', () => {
+		const root = render();
+		const tabs = root.querySelectorAll('[role="tab"]');
+		expect(tabs.length).toBe(AUDIENCES.length);
+		for (const audience of AUDIENCES) {
+			const tab = root.querySelector(`#tab-${audience.id}`);
+			const panel = root.querySelector(`#panel-${audience.id}`);
+			expect(tab, `${audience.id} tab`).not.toBeNull();
+			expect(panel, `${audience.id} panel`).not.toBeNull();
+			expect(text(tab!)).toContain(audience.label);
+			expect(text(panel!)).toContain(audience.lede);
+		}
+	});
+
+	it('shows one audience at a time, and the picker changes which', () => {
+		const root = render();
+		const hidden = () =>
+			AUDIENCES.filter((a) => root.querySelector(`#panel-${a.id}`)!.hasAttribute('hidden'));
+
+		expect(hidden().length).toBe(AUDIENCES.length - 1);
+		expect(hidden().map((a) => a.id)).not.toContain(AUDIENCES[0].id);
+
+		const third = root.querySelector<HTMLButtonElement>(`#tab-${AUDIENCES[2].id}`)!;
+		third.click();
+		flushSync();
+		expect(hidden().length).toBe(AUDIENCES.length - 1);
+		expect(hidden().map((a) => a.id)).not.toContain(AUDIENCES[2].id);
+		expect(third.getAttribute('aria-selected')).toBe('true');
+	});
+});
+
+describe('every command in the data module is rendered under its own audience', () => {
+	it('prints each step command inside that audience’s panel', () => {
+		const root = render();
+		for (const audience of AUDIENCES) {
+			const panel = root.querySelector(`#panel-${audience.id}`)!;
+			const rendered = text(panel);
+			for (const step of audience.steps) {
+				for (const block of step.commands) {
+					// The `<pre>` keeps the newlines; comparing collapsed text on
+					// both sides makes a multi-line command match line for line.
+					const expected = block.command.replace(/\s+/g, ' ');
+					expect(rendered, `${audience.id} → ${block.label}`).toContain(expected);
+				}
+			}
+		}
+	});
+
+	it('prints every shared prerequisite command exactly once, above the picker', () => {
+		const root = render();
+		for (const prereq of usedPrerequisites()) {
+			const card = root.querySelector(`#prereq-${prereq.id}`);
+			expect(card, prereq.id).not.toBeNull();
+			for (const block of prereq.commands) {
+				const expected = block.command.replace(/\s+/g, ' ');
+				expect(text(card!), `${prereq.id} → ${block.label}`).toContain(expected);
+				// One card, one copy of the command: a prerequisite repeated per
+				// audience is the duplication this page is built to avoid.
+				const everywhere = [...root.querySelectorAll('pre')].filter(
+					(pre) => text(pre) === expected
+				);
+				expect(everywhere.length, `${prereq.id} → ${block.label}`).toBe(1);
+			}
+		}
+	});
+});
+
+describe('accessibility of the picker and the copy buttons', () => {
+	it('names every copy button', () => {
+		const root = render();
+		const buttons = [...root.querySelectorAll('button')].filter(
+			(button) => button.getAttribute('role') !== 'tab'
+		);
+		expect(buttons.length).toBeGreaterThan(0);
+		for (const button of buttons) {
+			expect(button.getAttribute('aria-label')?.length ?? 0).toBeGreaterThan(0);
+		}
+	});
+
+	it('wires the tablist to its panels with a roving tabindex', () => {
+		const root = render();
+		const list = root.querySelector('[role="tablist"]')!;
+		expect(list.getAttribute('aria-label')).toBeTruthy();
+		for (const audience of AUDIENCES) {
+			const tab = root.querySelector(`#tab-${audience.id}`)!;
+			const panel = root.querySelector(`#panel-${audience.id}`)!;
+			expect(tab.getAttribute('aria-controls')).toBe(panel.id);
+			expect(panel.getAttribute('aria-labelledby')).toBe(tab.id);
+			expect(panel.getAttribute('role')).toBe('tabpanel');
+		}
+		const focusable = [...root.querySelectorAll('[role="tab"]')].filter(
+			(tab) => tab.getAttribute('tabindex') === '0'
+		);
+		expect(focusable.length, 'exactly one tab is in the tab order').toBe(1);
+	});
+
+	it('moves the selection with the arrow keys and Home/End', () => {
+		const root = render();
+		const selected = () => root.querySelector('[role="tab"][aria-selected="true"]')!;
+		const selectedId = () => selected().id.replace('tab-', '');
+
+		// Dispatched on the focused tab, not on the tablist: the handler lives on
+		// each tab, which is where the ARIA pattern puts it and the only element
+		// in the picker that is ever focused.
+		const press = (key: string) =>
+			selected().dispatchEvent(
+				new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true })
+			);
+
+		expect(selectedId()).toBe(AUDIENCES[0].id);
+		press('ArrowRight');
+		flushSync();
+		expect(selectedId()).toBe(AUDIENCES[1].id);
+		press('End');
+		flushSync();
+		expect(selectedId()).toBe(AUDIENCES[AUDIENCES.length - 1].id);
+		press('ArrowRight');
+		flushSync();
+		expect(selectedId(), 'wraps past the last tab').toBe(AUDIENCES[0].id);
+		press('ArrowLeft');
+		flushSync();
+		expect(selectedId(), 'wraps before the first tab').toBe(AUDIENCES[AUDIENCES.length - 1].id);
+		press('Home');
+		flushSync();
+		expect(selectedId()).toBe(AUDIENCES[0].id);
+	});
+});
+
+describe('what the rendered page must never do', () => {
+	it('renders no placeholder without the line that replaces it', () => {
+		const root = render();
+		const blocks = [...root.querySelectorAll('pre')].filter((pre) => hasPlaceholder(text(pre)));
+		expect(blocks.length, 'the provider-key exports print one').toBeGreaterThan(0);
+		for (const pre of blocks) {
+			// CommandBlock.svelte: `<pre>` sits in a wrapper whose sibling `<p>`
+			// carries the instruction.
+			const wrapper = pre.parentElement!.parentElement!;
+			const note = wrapper.querySelector('p');
+			expect(note, text(pre)).not.toBeNull();
+			for (const placeholder of text(pre).match(/<[^<>\s]+>/g) ?? []) {
+				expect(text(note!), `${text(pre)} → ${placeholder}`).toContain(placeholder);
+			}
+		}
+	});
+
+	/**
+	 * The security invariant, asserted on the DOM rather than on the data: `tm`
+	 * needs the App Data category and must never be offered the disk-wide one.
+	 * Scoped to the panel, because the trusty-search panel on the same page
+	 * legitimately names it.
+	 */
+	it('never names Full Disk Access inside the trusty-mpm panel', () => {
+		const root = render();
+		const panel = root.querySelector('#panel-trusty-mpm')!;
+		expect(text(panel)).not.toContain('Full Disk Access');
+		expect(text(panel)).toContain('App Data');
+		expect(text(root.querySelector('#panel-trusty-agents')!)).not.toContain('Full Disk Access');
+		expect(text(root.querySelector('#panel-trusty-search')!)).toContain('Full Disk Access');
+	});
+});

--- a/website/src/routes/+page.svelte
+++ b/website/src/routes/+page.svelte
@@ -233,6 +233,16 @@
 		The bootstrap installer verifies every downloaded tarball against its published SHA-256
 		checksum. The install script itself is unsigned — read it first if you need higher assurance.
 	</p>
+	<!-- #5110: these three cards are the generic paths. The walkthrough is the
+	     per-product one, and is the only place that says which macOS permission
+	     a given product asks for. -->
+	<p class="mt-6 max-w-3xl text-sm text-foundry-secondary">
+		Installing one specific product? The
+		<a href="/install" class="text-foundry-primary underline underline-offset-2"
+			>install walkthrough</a
+		> has the exact sequence for each of the nine, what it needs first, and the macOS permission it asks
+		for.
+	</p>
 </section>
 
 <!-- NEXT -->

--- a/website/src/routes/install/+page.svelte
+++ b/website/src/routes/install/+page.svelte
@@ -1,0 +1,101 @@
+<script lang="ts">
+	/**
+	 * Why: the landing page's install section answers "how do I install
+	 * something" with three generic paths. It does not answer the question a
+	 * reader actually arrives with, which is "how do I install THIS one" — and
+	 * the nine answers differ in ways that are not guessable: two products
+	 * cannot be installed by tctl at all, one of them has no published crate,
+	 * one silently installs three crates, and the macOS permission is
+	 * per-product. Publishing that permission backwards would be a security
+	 * regression rather than a typo, which is why every fact on this page comes
+	 * from one verified document (#5110, epic #5092).
+	 *
+	 * What: chrome and framing only. The content is `$lib/install/audiences`
+	 * and the picker is `InstallWalkthrough.svelte`; this file adds the hero,
+	 * the `<svelte:head>` wiring and the outbound links. It is not built on
+	 * `ToolPage.svelte` for the same reason `/claude-mpm-migration` is not:
+	 * that component derives its heading and its single install line from one
+	 * `Tool` record, and this page is about nine products at once.
+	 *
+	 * Test: `src/lib/install/render.test.ts` covers the walkthrough itself;
+	 * `tests/build-smoke.test.ts` asserts this route prerenders with every
+	 * audience's commands in it.
+	 */
+	import InstallWalkthrough from '$lib/components/InstallWalkthrough.svelte';
+	import { AUDIENCES } from '$lib/install/audiences';
+	import { GITHUB_URL } from '$lib/site';
+
+	const description =
+		'Install any of the nine trusty-tools products: the exact commands per product, what each needs first, which MCP entry to register, and which macOS permission it actually asks for.';
+
+	const facts = [
+		{ label: 'Paths', value: `${AUDIENCES.length} audiences` },
+		{ label: 'Via tctl', value: '7 of 9' },
+		{ label: 'MSRV', value: 'Rust 1.94' },
+		{ label: 'Prebuilt for', value: 'macOS arm64, Linux x86_64, Linux arm64' }
+	];
+</script>
+
+<svelte:head>
+	<title>Install — pick your product — trusty-tools</title>
+	<meta name="description" content={description} />
+</svelte:head>
+
+<!-- HERO -->
+<section class="border-b border-foundry-border">
+	<div class="mx-auto max-w-content px-4 py-14 sm:px-6 sm:py-20">
+		<p class="eyebrow">Install · nine products, nine paths</p>
+		<h1
+			class="mt-4 break-words font-display text-4xl font-bold leading-tight tracking-tight text-foundry-primary sm:text-5xl"
+		>
+			Install walkthrough
+		</h1>
+		<p class="mt-6 max-w-2xl text-lg text-foundry-secondary">
+			Pick the product you want and this page shows that install and nothing else — the commands in
+			order, the setup it shares with the others, the MCP entry to register, and the macOS
+			permission it genuinely needs. Every command here was checked against crate source rather than
+			against a README.
+		</p>
+
+		<div class="mt-8 flex flex-wrap gap-3">
+			<a href="#walkthrough" class="btn btn-primary">Pick a product</a>
+			<a href="#prerequisites" class="btn btn-secondary">Shared prerequisites</a>
+			<a href="/#flagships" class="btn btn-secondary">What each one does</a>
+		</div>
+
+		<dl class="mt-12 flex flex-wrap gap-x-10 gap-y-4">
+			{#each facts as fact (fact.label)}
+				<div>
+					<dt class="eyebrow">{fact.label}</dt>
+					<dd class="mt-1 font-mono text-sm text-foundry-text">{fact.value}</dd>
+				</div>
+			{/each}
+		</dl>
+	</div>
+</section>
+
+<InstallWalkthrough />
+
+<!-- NEXT -->
+<section class="mx-auto max-w-content px-4 py-16 sm:px-6">
+	<div class="card flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+		<div class="min-w-0">
+			<h2 class="font-display text-xl font-semibold">Already running claude-mpm?</h2>
+			<p class="mt-1 text-sm text-foundry-secondary">
+				The migration page covers what carries over and what behaves differently, rather than
+				repeating the install.
+			</p>
+		</div>
+		<a href="/claude-mpm-migration" class="btn btn-primary shrink-0">Migration guide</a>
+	</div>
+	<p class="mt-8 flex flex-wrap gap-x-6 gap-y-2">
+		<a href="/docs" class="text-sm text-foundry-primary underline underline-offset-2"
+			>Documentation</a
+		>
+		<a
+			href={GITHUB_URL}
+			rel="noreferrer noopener"
+			class="text-sm text-foundry-primary underline underline-offset-2">Source on GitHub</a
+		>
+	</p>
+</section>

--- a/website/tests/build-smoke.test.ts
+++ b/website/tests/build-smoke.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { beforeAll, describe, expect, it } from 'vitest';
 import { installCommand, TOOLS } from '../src/lib/tools';
 import { RELEASED_FLAGSHIPS } from '../src/lib/site';
+import { AUDIENCES } from '../src/lib/install/audiences';
 
 /**
  * Why: every other test here reads source files. None of them prove the site
@@ -73,6 +74,26 @@ const AUDIT_ROUTE = '/tools/trusty-git-analytics/audit';
  */
 const MIGRATION_PAGE = 'claude-mpm-migration.html';
 const MIGRATION_ROUTE = '/claude-mpm-migration';
+
+/**
+ * The nine-audience install walkthrough (#5110).
+ *
+ * Like the two above, it is a route with no `TOOLS` record. Its panels are
+ * rendered into the prerendered HTML and hidden with the `hidden` attribute
+ * rather than mounted on selection, so every audience's commands are in this
+ * artifact whether or not JavaScript ever runs — which is what makes asserting
+ * them here worth anything.
+ */
+const INSTALL_PAGE = 'install.html';
+const INSTALL_ROUTE = '/install';
+
+/** One audience's panel, sliced out of the built page by its anchor id. */
+function installPanel(html: string, id: string): string {
+	const start = html.indexOf(`id="panel-${id}"`);
+	if (start < 0) return '';
+	const next = html.indexOf('id="panel-', start + 1);
+	return html.slice(start, next < 0 ? undefined : next);
+}
 
 /** Prerendered doc artifacts on disk, as paths relative to the static root. */
 function docPages(): Set<string> {
@@ -369,6 +390,55 @@ describe('production build', () => {
 	});
 
 	/**
+	 * Why: `src/lib/install/render.test.ts` proves the walkthrough renders in
+	 * jsdom. It cannot prove the route PRERENDERS — a page that only assembles
+	 * after hydration ships nothing to a reader with JavaScript off and nothing
+	 * to a crawler, and the whole point of holding the nine audiences in one
+	 * static document is that they arrive as HTML.
+	 * What: the artifact, its own `<title>` (it does not use `ToolPage.svelte`,
+	 * so nothing else pins that), every install command from the data module,
+	 * the macOS permission invariant read off the built panels, and the round
+	 * trip from the landing page.
+	 */
+	it('prerenders every install audience, with the permission split intact', () => {
+		expect(existsSync(path.join(STATIC, INSTALL_PAGE)), INSTALL_PAGE).toBe(true);
+		const html = readFileSync(path.join(STATIC, INSTALL_PAGE), 'utf8');
+
+		const title = html.match(/<title>([\s\S]*?)<\/title>/);
+		expect(title?.[1], 'install page title').toContain('Install');
+
+		const text = visibleText(html);
+		for (const audience of AUDIENCES) {
+			expect(text, `${audience.id} is missing`).toContain(audience.label);
+			for (const step of audience.steps) {
+				for (const block of step.commands) {
+					expect(text, `${audience.id} → ${block.label}`).toContain(
+						block.command.replace(/\s+/g, ' ')
+					);
+				}
+			}
+		}
+		// The shared setup, rendered once above the picker.
+		expect(text, 'the tctl bootstrap is missing').toContain(
+			'curl -sSf https://raw.githubusercontent.com/bobmatnyc/trusty-tools/main/install.sh | sh'
+		);
+
+		// `tm` and `tagent` take the App Data category and must never be offered
+		// the disk-wide one; trusty-search is the only product that gets it.
+		for (const id of ['trusty-mpm', 'trusty-agents']) {
+			const panel = visibleText(installPanel(html, id));
+			expect(panel.length, `${id} panel`).toBeGreaterThan(0);
+			expect(panel, `${id} is offered Full Disk Access`).not.toContain('Full Disk Access');
+			expect(panel, `${id} does not name its own category`).toContain('App Data');
+		}
+		expect(visibleText(installPanel(html, 'trusty-search'))).toContain('Full Disk Access');
+
+		expect(landingPage, 'the landing page does not link the walkthrough').toContain(
+			`href="${INSTALL_ROUTE}"`
+		);
+	});
+
+	/**
 	 * Why: the binary still ships under both `trusty-audit` and `taudit`, and the
 	 * alias is being dropped. `src/lib/tools.test.ts` guards the RECORDS; this
 	 * guards the rendered PAGES, which is where the prose actually lives.
@@ -387,6 +457,7 @@ describe('production build', () => {
 			'docs.html',
 			AUDIT_PAGE,
 			MIGRATION_PAGE,
+			INSTALL_PAGE,
 			...docPages(),
 			...toolPages()
 		]) {

--- a/website/tests/mobile-overflow.test.ts
+++ b/website/tests/mobile-overflow.test.ts
@@ -109,6 +109,11 @@ const MAIN_TOLERANCE_PX = 1;
 // `ToolPage.svelte`, so it inherits none of that component's already-measured
 // containment. It is also the page that pushed the nav to four links, which is
 // the header's own wrap case at 320px.
+// `/install` (#5110) carries more `<pre>` blocks than any other page here —
+// every audience's commands are in the document at once, hidden panels
+// included — and a `<pre>` never wraps, so it is the strongest case for the
+// containment rule this file measures. It does not go through
+// `ToolPage.svelte` either.
 const ROUTES = [
 	'/whats-new',
 	'/',
@@ -117,7 +122,8 @@ const ROUTES = [
 	'/tools/trusty-search',
 	'/tools/trusty-git-analytics',
 	'/tools/trusty-git-analytics/audit',
-	'/claude-mpm-migration'
+	'/claude-mpm-migration',
+	'/install'
 ];
 const WIDTHS = [375, 320];
 

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -20,6 +20,15 @@ export default defineConfig({
 		projects: [
 			{
 				extends: true,
+				// #5110: the install walkthrough's test mounts a real component,
+				// and `mount()` only exists in Svelte's CLIENT build. Vitest
+				// resolves packages under the `ssr` conditions by default even in
+				// a jsdom environment, which hands the test `svelte/index-server`
+				// and fails with `mount(...) is not available on the server`. This
+				// is the resolution SvelteKit's own testing guidance prescribes,
+				// scoped to this project so the `smoke` project — which shells out
+				// to a real `vite build` — keeps the build's own conditions.
+				resolve: { conditions: ['browser'] },
 				test: {
 					name: 'unit',
 					environment: 'jsdom',


### PR DESCRIPTION
## Outcome

Refs #5110 (epic #5092). Unblocked by #5116 (PR #6725).

## Changes

New `/install` route: a nine-audience picker (ARIA tablist, roving tabindex, Left/Right/Home/End) over per-audience install steps rendered from a typed data module (`website/src/lib/install/audiences.ts`: 9 `Audience` rows, 8 shared `Prerequisite` rows de-duplicated above the picker). All nine panels ship in the prerendered HTML (`hidden` attribute, not mounted on select), so every command is static and copyable without JavaScript. Every command, env-var name, TCC category and MCP registration step is taken verbatim from `docs/research/install-paths-by-audience.md`; the only placeholder-bearing lines are `export <VAR>=<…>` with an instruction line beside each. Landing page links to `/install`. `vite.config.ts`: the `unit` Vitest project sets `resolve.conditions = ['browser']` so components can mount under jsdom (scoped; the `smoke` project keeps the build's own conditions).

## Risk

Low—UI surface addition with no public API changes or cross-crate dependencies. All nine install paths are static HTML; no runtime data fetching or side effects beyond user interaction.

## Tests

Rung 6 (UI surface). From inside `website/` on Node 20: `pnpm lint` (Prettier clean), `pnpm check` (502 files, 0 errors), `pnpm test` → 16 files, 295 tests passed. New tests: `audiences.test.ts`, `render.test.ts` — every audience renders, every command appears in its panel, no placeholder without an instruction line, trusty-mpm panel never says "Full Disk Access"; mirrored on built artifact in `build-smoke.test.ts`; `/install` added to `mobile-overflow.test.ts` at 375/320px. `pnpm build` (adapter-vercel) OK. Preview smoke against served HTML: all nine `panel-*` ids present once; per-panel TCC — trusty-mpm/trusty-agents FullDiskAccess=0 AppData=2, trusty-search FullDiskAccess=2 AppData=0.

## Baseline

No pre-existing failures.

## Docs

Repo doc gates (`check_sld.sh`, `check_public_docs.sh`) green. Website tests run under `website-tests.yml`. No changelog fragment required (website docs-only).

## Review

Trusty-review gate passed; ready for merge.

Refs #5110

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
