### PR TITLE
feat(tga): non-interactive install path with org repo discovery

### DIFF
--- a/crates/trusty-git-analytics/README.md
+++ b/crates/trusty-git-analytics/README.md
@@ -415,7 +415,7 @@ tga dora --since 2026-04-01
 | `tga author` | Per-engineer drill-down (commits, effort, PRs, categories) | `<email>`, `--format`, `--since`, `--until` |
 | `tga pr-metrics` | Pull-request metrics per engineer | `--weeks`, `--csv`, `--output` |
 | `tga profile` | Longitudinal per-contributor quality profile ([#5468](https://github.com/bobmatnyc/trusty-tools/issues/5468)) | `<contributor>`, `--since`, `--until`, `--window`, `--dry-run`, `--model`, `--github-issue` |
-| `tga install` | Interactive first-time config wizard | `--output`, `--force` |
+| `tga install` | First-time config wizard, interactive or flag-driven ([#5216](https://github.com/bobmatnyc/trusty-tools/issues/5216)) | `--output`, `--force`, `--non-interactive`, `--host`, `--org`, `--workspace`, `--repo`, `--repo-path`, `--repo-cache`, `--host-token`, `--pm`, `--jira-*`, `--linear-*`, `--output-dir`, `--llm-provider`, `--llm-api-key` |
 | `tga aliases` | Manage developer identity aliases | `list`, `merge <src> <dst>`, `add-login <email> <provider> <login>` |
 | `tga backfill` | Retroactive maintenance on existing rows | `--repos`, `--weeks`, `--since`, `--until`, `--dry-run` |
 | `tga override` | Pin classification verdicts (Tier 0) | `add`, `list`, `remove` |

--- a/crates/trusty-git-analytics/changelog.d/5216-install-noninteractive.md
+++ b/crates/trusty-git-analytics/changelog.d/5216-install-noninteractive.md
@@ -1,0 +1,24 @@
+Added
+
+- `tga install` runs without a terminal. `--host <local|github|bitbucket>` and
+  `--pm <none|github|jira|linear>` select the non-interactive path, along with
+  `--org`, `--workspace`, `--repo`, `--repo-path`, `--repo-cache`,
+  `--host-token`, the `--jira-*` / `--linear-*` credentials, `--output-dir`,
+  `--llm-provider` and `--llm-api-key`; `--non-interactive` forces it, and stdin
+  not being a terminal implies it. A flag value wins over its environment
+  variable (`GITHUB_TOKEN`, `BITBUCKET_TOKEN`, `JIRA_URL`, `JIRA_EMAIL`,
+  `JIRA_API_TOKEN`, `LINEAR_API_KEY`), and a credential taken from the
+  environment is written to the config as a `${VAR}` reference rather than in
+  the clear. Run with no terminal and no flags, install now names every missing
+  flag at once instead of blocking on the first prompt. (#5216)
+- `tga install --host github --org <ORG>` derives the repository set from the
+  GitHub API — `discover_org_repos` was already paging `GET /orgs/{org}/repos`
+  for PR collection and is now what populates a generated config's
+  `repositories:` list, so an operator no longer has to name paths that already
+  exist locally. An org the token cannot see records that in the config instead
+  of emitting a silently empty one. (#5216)
+- Linear joins JIRA and GitHub Issues in the project-management choices, and
+  Bitbucket Cloud joins GitHub in the host choices, in both the wizard and the
+  flag path. Bitbucket takes an explicit `--repo <workspace/slug>` list and says
+  workspace discovery is not available yet (#5220) rather than producing an
+  empty repository set. (#5216)

--- a/crates/trusty-git-analytics/changelog.d/5216-install-shared-config-emission.md
+++ b/crates/trusty-git-analytics/changelog.d/5216-install-shared-config-emission.md
@@ -1,0 +1,6 @@
+Changed
+
+- The wizard and the flag path render config through one function. Both collect
+  the same answers and hand them to `commands::install_plan::render_yaml`, so a
+  scripted install and a hand-walked one produce identical output for identical
+  answers. (#5216)

--- a/crates/trusty-git-analytics/help.yaml
+++ b/crates/trusty-git-analytics/help.yaml
@@ -66,7 +66,7 @@ commands:
   profile:
     description: Longitudinal per-contributor quality profile
   install:
-    description: Interactive configuration wizard
+    description: Configuration wizard — interactive, or flag-driven with --host/--pm
   aliases:
     description: List or merge developer identities (aliases)
   backfill:

--- a/crates/trusty-git-analytics/src/collect/github/mod.rs
+++ b/crates/trusty-git-analytics/src/collect/github/mod.rs
@@ -13,7 +13,10 @@ pub use client::GitHubClient;
 pub use issue_writer::{
     find_thread_by_marker, issue_search_query, thread_marker_anchor, IssueUpsert,
 };
-pub use org_discovery::{discover_org_repos, effective_orgs};
+pub use org_discovery::{discover_org_repos, discover_org_repos_at, effective_orgs};
 pub use repo_resolver::resolve_github_repos;
+// #5216: the non-interactive `tga install` path needs the one authed GitHub
+// client builder rather than a second `reqwest::Client::builder()` of its own.
+pub(crate) use repo_resolver::build_http_client;
 pub use reviewer_store::{lookup_github_pr_id, upsert_github_pr_reviewer};
 pub use types::{GhLabel, GitHubIssue};

--- a/crates/trusty-git-analytics/src/collect/github/org_discovery.rs
+++ b/crates/trusty-git-analytics/src/collect/github/org_discovery.rs
@@ -9,7 +9,8 @@
 //! the async pipeline can inject discovery results without a separate dedup
 //! pass.
 //!
-//! What: [`discover_org_repos`] paginates org repos; [`effective_orgs`]
+//! What: [`discover_org_repos`] paginates org repos ([`discover_org_repos_at`]
+//! is the same walk against a caller-supplied REST root); [`effective_orgs`]
 //! merges singular/plural config fields;
 //! [`resolve_github_repos_with_discovered`] unions the sync resolver output
 //! with org-discovery results and is called by the async pipeline after
@@ -59,7 +60,37 @@ pub async fn discover_org_repos(
     client: &reqwest::Client,
     org: &str,
 ) -> Result<Vec<(String, String)>> {
-    discover_org_repos_within(client, org, &FetchBudget::new()).await
+    discover_org_repos_inner(client, GITHUB_API_BASE, org, &FetchBudget::new()).await
+}
+
+/// [`discover_org_repos`] against a caller-supplied REST root.
+///
+/// Why (#5216): the non-interactive `tga install` path derives a config's
+/// repository set from this call, and a test of that path that reaches
+/// github.com is not a test. This is the same seam
+/// [`GitHubClient::with_api_base`](super::GitHubClient::with_api_base) gives
+/// the PR client; a GitHub Enterprise host would use it too.
+/// What: identical to [`discover_org_repos`], except the REST root is passed
+/// in. A trailing `/` is trimmed so a `wiremock` server URI can be handed over
+/// unchanged.
+/// Test: `flag_path_discovers_org_repos_and_writes_them` in
+/// `crate::commands::install_flags` drives a local mock through it.
+///
+/// # Errors
+///
+/// Same as [`discover_org_repos`].
+pub async fn discover_org_repos_at(
+    client: &reqwest::Client,
+    api_base: &str,
+    org: &str,
+) -> Result<Vec<(String, String)>> {
+    discover_org_repos_inner(
+        client,
+        api_base.trim_end_matches('/'),
+        org,
+        &FetchBudget::new(),
+    )
+    .await
 }
 
 /// [`discover_org_repos`] against a caller-supplied budget.
@@ -84,11 +115,29 @@ pub(crate) async fn discover_org_repos_within(
     org: &str,
     budget: &FetchBudget,
 ) -> Result<Vec<(String, String)>> {
+    discover_org_repos_inner(client, GITHUB_API_BASE, org, budget).await
+}
+
+/// The single page walk every `discover_org_repos*` wrapper funnels into.
+///
+/// Why: the three entry points differ only in which REST root and which budget
+/// they supply. One body is what stops the retry, rate-limit and page-cap
+/// handling from drifting apart between them.
+/// What: pages `GET {api_base}/orgs/{org}/repos?type=all` until a short page
+/// ends the list or [`MAX_PAGES`] caps it.
+/// Test: `api_org_repo_full_name_splits_correctly` below covers the parse;
+/// `flag_path_discovers_org_repos_and_writes_them` in
+/// `crate::commands::install_flags` covers the page walk against a mock server.
+async fn discover_org_repos_inner(
+    client: &reqwest::Client,
+    api_base: &str,
+    org: &str,
+    budget: &FetchBudget,
+) -> Result<Vec<(String, String)>> {
     let mut out = Vec::new();
     let mut page = 1u32;
     loop {
-        let url =
-            format!("{GITHUB_API_BASE}/orgs/{org}/repos?type=all&per_page={PAGE_SIZE}&page={page}");
+        let url = format!("{api_base}/orgs/{org}/repos?type=all&per_page={PAGE_SIZE}&page={page}");
         debug!(url = %url, "GET (org repo discovery)");
         // Route through the shared retry helper so transient 5xx/429 are
         // retried with the same backoff as the main PR client.

--- a/crates/trusty-git-analytics/src/commands/install.rs
+++ b/crates/trusty-git-analytics/src/commands/install.rs
@@ -1,33 +1,78 @@
-//! `tga install` — interactive configuration wizard.
+//! `tga install` — the configuration wizard and its non-interactive twin.
 //!
-//! Prompts the operator for the minimal set of values required to bootstrap
-//! a working `config.yaml`. We deliberately keep the wizard dependency-free
-//! (plain stdin) so the CLI stays small and the binary cross-compiles
-//! cleanly to musl / Apple Silicon without optional terminal crates.
+//! Why (#5216): the wizard could only be driven by a human at a terminal, so a
+//! stranger scripting tga, or running it in CI, had nothing to run. This module
+//! keeps the prompts and adds a flag path beside them; both collect the same
+//! `install_flags::Answers` and both render through
+//! [`install_plan::render_yaml`](super::install_plan::render_yaml), so the two
+//! cannot drift.
+//!
+//! What: [`run`] picks a front end — the flag path when non-interactive flags
+//! were supplied or stdin is not a terminal, the wizard otherwise — then writes
+//! the rendered config. The wizard stays dependency-free (plain stdin) so the
+//! CLI keeps cross-compiling to musl / Apple Silicon without terminal crates.
+//!
+//! Test: `wizard_and_flag_paths_render_identical_config` below pins the two
+//! front ends together; `install_flags` covers the flag path's own behaviour.
 
-use std::io::{self, BufRead, Write};
+use std::io::{self, BufRead, IsTerminal, Write};
 use std::path::PathBuf;
 
-use clap::Args;
+use clap::{Args, ValueEnum};
 use tga::core::config::Config;
 
+use super::install_flags::{plan_from_answers, resolve_plan, Answers};
+use super::install_plan::{render_yaml, Credential, InstallPlan, JiraSettings, LinearSettings};
+
+/// Where repositories come from.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, ValueEnum)]
+pub enum InstallHost {
+    /// Repositories are already cloned locally and named by path.
+    #[default]
+    Local,
+    /// A GitHub org (or an explicit `owner/name` list).
+    Github,
+    /// A Bitbucket Cloud workspace with an explicit `workspace/slug` list.
+    Bitbucket,
+}
+
+/// Which project-management system supplies work items.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, ValueEnum)]
+pub enum InstallPm {
+    /// No PM integration.
+    #[default]
+    None,
+    /// GitHub Issues — uses the GitHub credential already configured.
+    Github,
+    /// Atlassian JIRA.
+    Jira,
+    /// Linear.
+    Linear,
+}
+
 /// Arguments for `tga install`.
-#[derive(Args, Debug)]
+#[derive(Args, Debug, Clone)]
 #[command(
-    about = "Interactive configuration wizard for first-time setup.",
-    long_about = "Walk through a series of prompts to generate a config.yaml bootstrapped\n\
-with the minimal required fields (git repo paths, date range, optional API keys).\n\n\
-Press <enter> at each prompt to accept the default shown in brackets.\n\
-Optional credentials left blank are omitted from the generated file.\n\n\
-The wizard does NOT need an existing database or config — it is designed to\n\
-run on a fresh checkout before any other tga command.",
+    about = "Configuration wizard for first-time setup — interactive or flag-driven.",
+    long_about = "Generate a config.yaml bootstrapped with the minimal required fields.\n\n\
+On a terminal with no flags this walks through a series of prompts; press\n\
+<enter> at each to accept the default shown in brackets.\n\n\
+Given --host and --pm (or with stdin not a terminal) it runs non-interactively\n\
+from flags and environment variables instead, and never prompts. With --host\n\
+github and --org it discovers the org's repositories over the GitHub API and\n\
+writes them into the generated config.\n\n\
+Flag values win over environment variables. A credential taken from the\n\
+environment is written to the config as a ${VAR} reference, not as the secret.",
     after_help = "EXAMPLES:\n\
-  # First-time setup (writes config.yaml in the current directory)\n\
+  # First-time setup on a terminal (writes config.yaml in the current directory)\n\
   tga install\n\n\
-  # Write config to a custom path\n\
-  tga install --output /etc/tga/config.yaml\n\n\
-  # Overwrite an existing config without prompting\n\
-  tga install --force\n\n\
+  # Zero-config org audit, no terminal required\n\
+  GITHUB_TOKEN=ghp_… tga install --host github --org acme --pm github\n\n\
+  # Bitbucket Cloud — workspace discovery is not available yet (#5220), so name the repos\n\
+  tga install --host bitbucket --workspace acme --repo acme/widget --pm jira \\\n\
+    --jira-url https://acme.atlassian.net --jira-user me@acme.com\n\n\
+  # Write config to a custom path, overwriting any existing file\n\
+  tga install --output /etc/tga/config.yaml --force\n\n\
 TIPS:\n\
   - After running install, validate the config with `tga collect --validate-only`.\n\
   - Re-run at any time to regenerate the config from scratch."
@@ -42,19 +87,119 @@ pub struct InstallArgs {
     /// Overwrite an existing config file without prompting.
     #[arg(long, default_value_t = false)]
     pub force: bool,
+
+    /// Run from flags only, never prompting. Implied when stdin is not a terminal.
+    #[arg(long, default_value_t = false)]
+    pub non_interactive: bool,
+
+    /// Where repositories come from.
+    #[arg(long, value_enum)]
+    pub host: Option<InstallHost>,
+
+    /// GitHub org to discover repositories from (`--host github`).
+    #[arg(long, value_name = "ORG")]
+    pub org: Option<String>,
+
+    /// Bitbucket Cloud workspace (`--host bitbucket`).
+    #[arg(long, value_name = "WORKSPACE")]
+    pub workspace: Option<String>,
+
+    /// Explicit remote repository, `owner/name` or `workspace/slug`. Repeatable.
+    #[arg(long, value_name = "OWNER/NAME")]
+    pub repo: Vec<String>,
+
+    /// Already-cloned repository to collect from. Repeatable.
+    #[arg(long, value_name = "PATH")]
+    pub repo_path: Vec<PathBuf>,
+
+    /// Directory remote repositories are expected under in the generated config.
+    #[arg(long, value_name = "DIR", default_value = "./repos")]
+    pub repo_cache: PathBuf,
+
+    /// Host API token. Falls back to `$GITHUB_TOKEN` / `$BITBUCKET_TOKEN`.
+    #[arg(long, value_name = "TOKEN")]
+    pub host_token: Option<String>,
+
+    /// Project-management system supplying work items.
+    #[arg(long, value_enum)]
+    pub pm: Option<InstallPm>,
+
+    /// JIRA base URL. Falls back to `$JIRA_URL`.
+    #[arg(long, value_name = "URL")]
+    pub jira_url: Option<String>,
+
+    /// JIRA username or email. Falls back to `$JIRA_EMAIL`.
+    #[arg(long, value_name = "EMAIL")]
+    pub jira_user: Option<String>,
+
+    /// JIRA API token. Falls back to `$JIRA_API_TOKEN`.
+    #[arg(long, value_name = "TOKEN")]
+    pub jira_token: Option<String>,
+
+    /// Linear API key. Falls back to `$LINEAR_API_KEY`.
+    #[arg(long, value_name = "KEY")]
+    pub linear_api_key: Option<String>,
+
+    /// Linear team key to scope issue fetches to. Repeatable.
+    #[arg(long, value_name = "TEAM")]
+    pub linear_team: Vec<String>,
+
+    /// Directory reports are written to.
+    #[arg(long, value_name = "DIR", default_value = "./tga-output")]
+    pub output_dir: String,
+
+    /// LLM provider for Tier-4 classification: `none`, `openai` or `openrouter`.
+    #[arg(long, value_name = "PROVIDER", default_value = "none")]
+    pub llm_provider: String,
+
+    /// LLM API key. Falls back to the provider's conventional env var.
+    #[arg(long, value_name = "KEY")]
+    pub llm_api_key: Option<String>,
 }
 
-/// Run the interactive install wizard.
+impl InstallArgs {
+    /// Whether the caller asked for the flag path.
+    ///
+    /// Why: a flag the wizard would silently ignore is worse than no flag at
+    /// all, so supplying any non-interactive flag selects the flag path even on
+    /// a terminal.
+    /// What: true for `--non-interactive` or any answer-bearing flag.
+    /// Test: `answer_flags_select_the_flag_path` below.
+    #[must_use]
+    pub fn wants_non_interactive(&self) -> bool {
+        self.non_interactive
+            || self.host.is_some()
+            || self.pm.is_some()
+            || self.org.is_some()
+            || self.workspace.is_some()
+            || !self.repo.is_empty()
+            || !self.repo_path.is_empty()
+            || self.host_token.is_some()
+            || self.jira_url.is_some()
+            || self.jira_user.is_some()
+            || self.jira_token.is_some()
+            || self.linear_api_key.is_some()
+            || !self.linear_team.is_empty()
+            || self.llm_api_key.is_some()
+    }
+}
+
+/// Run `tga install`.
 ///
-/// Reads from stdin and writes a YAML config to `args.output`. The wizard
-/// is intentionally tolerant: every field has a sensible default and empty
-/// optional credentials are simply omitted from the resulting YAML.
+/// Why: one entry point picks the front end so the overwrite guard, the output
+/// directory creation and the config write happen exactly once each.
+/// What: refuses to clobber an existing config without `--force`, resolves an
+/// [`InstallPlan`] from either the flag path or the wizard, then renders and
+/// writes it.
+/// Test: `install_flags::flag_path_discovers_org_repos_and_writes_them` and
+/// `wizard_and_flag_paths_render_identical_config` below.
 ///
 /// # Errors
 ///
-/// Returns an error if stdin reads fail, if the output path is not
-/// writable, or if `args.output` exists and `--force` was not supplied.
-pub fn run(_config: Config, args: InstallArgs) -> anyhow::Result<()> {
+/// Returns an error if `args.output` exists and `--force` was not supplied, if
+/// required flags are missing on the non-interactive path, if stdin reads fail,
+/// if org discovery fails, or if the output path is not writable.
+pub async fn run(_config: Config, args: InstallArgs) -> anyhow::Result<()> {
     if args.output.exists() && !args.force {
         anyhow::bail!(
             "{} already exists. Re-run with --force to overwrite.",
@@ -62,28 +207,190 @@ pub fn run(_config: Config, args: InstallArgs) -> anyhow::Result<()> {
         );
     }
 
-    let stdin = io::stdin();
-    let mut input = stdin.lock();
+    // #5216: non-interactive install path — flags win, then the environment.
+    let plan = if args.wants_non_interactive() || !io::stdin().is_terminal() {
+        resolve_plan(&args).await?
+    } else {
+        let stdin = io::stdin();
+        let mut input = stdin.lock();
+        let answers = collect_answers(&mut input, &args)?;
+        plan_from_answers(answers).await?
+    };
 
+    write_plan(&plan, &args.output)
+}
+
+/// Render `plan` and write it to `output`, creating the report directory.
+///
+/// # Errors
+///
+/// Returns an error if the report directory cannot be created or the config
+/// cannot be written.
+fn write_plan(plan: &InstallPlan, output: &std::path::Path) -> anyhow::Result<()> {
+    let output_dir_path = PathBuf::from(&plan.output_dir);
+    if let Err(e) = std::fs::create_dir_all(&output_dir_path) {
+        anyhow::bail!(
+            "cannot create output directory {}: {e}",
+            output_dir_path.display()
+        );
+    }
+    for note in &plan.notes {
+        eprintln!("  note: {note}");
+    }
+    std::fs::write(output, render_yaml(plan))?;
+    println!(
+        "\nConfig written to {}. Run: tga analyze --config {}",
+        output.display(),
+        output.display()
+    );
+    Ok(())
+}
+
+/// Walk the operator through the prompts and return their answers.
+///
+/// Why: returning [`Answers`] rather than YAML is what lets the wizard and the
+/// flag path share one renderer and one org-discovery call.
+/// What: prompts for host, repositories, credentials, PM system, output
+/// directory and LLM provider, defaulting from `args` where a flag was given.
+/// Test: `wizard_and_flag_paths_render_identical_config` drives this with a
+/// scripted stdin.
+///
+/// # Errors
+///
+/// Returns an error on a stdin read failure, on EOF where a value is required,
+/// or when a required answer is left blank.
+fn collect_answers<R: BufRead>(reader: &mut R, args: &InstallArgs) -> anyhow::Result<Answers> {
     println!("tga install — interactive configuration wizard");
     println!("Press <enter> to accept the default shown in [brackets].\n");
 
-    let repos_raw = prompt(
-        &mut input,
+    let mut answers = Answers {
+        repo_cache: args.repo_cache.clone(),
+        ..Answers::default()
+    };
+
+    let host = prompt(
+        reader,
+        "Code host — choose one: local / github / bitbucket",
+        Some("local"),
+    )?;
+    answers.host = match host.to_lowercase().as_str() {
+        "github" => InstallHost::Github,
+        "bitbucket" => InstallHost::Bitbucket,
+        _ => InstallHost::Local,
+    };
+    prompt_host(reader, &mut answers)?;
+    prompt_pm(reader, &mut answers)?;
+
+    answers.output_dir = prompt(reader, "Output directory", Some("./tga-output"))?;
+
+    let llm_provider = prompt(
+        reader,
+        "LLM provider — choose one: none / openai / openrouter",
+        Some("none"),
+    )?
+    .to_lowercase();
+    answers.llm_api_key = if llm_provider == "openai" || llm_provider == "openrouter" {
+        prompt_optional(
+            reader,
+            &format!("{llm_provider} API key (leave blank to set later via env var)"),
+        )?
+        .map(Credential::literal)
+    } else {
+        None
+    };
+    answers.llm_provider = llm_provider;
+
+    Ok(answers)
+}
+
+/// Prompt for the host-specific answers: repositories and the host credential.
+fn prompt_host<R: BufRead>(reader: &mut R, answers: &mut Answers) -> anyhow::Result<()> {
+    match answers.host {
+        InstallHost::Local => {
+            answers.repo_paths = prompt_paths(reader)?;
+        }
+        InstallHost::Github => {
+            answers.org = prompt_optional(
+                reader,
+                "GitHub org to discover repositories from (leave blank to list paths instead)",
+            )?;
+            if answers.org.is_none() {
+                answers.repo_paths = prompt_paths(reader)?;
+            }
+            answers.host_token =
+                prompt_optional(reader, "GitHub token (optional, leave blank to skip)")?
+                    .map(Credential::literal);
+        }
+        InstallHost::Bitbucket => {
+            answers.workspace = Some(prompt(reader, "Bitbucket Cloud workspace", None)?);
+            println!(
+                "  Bitbucket workspace discovery is not available yet (#5220) — name the repositories."
+            );
+            answers.repo_slugs = split_list(&prompt(
+                reader,
+                "Bitbucket repositories (comma-separated <workspace>/<slug>)",
+                None,
+            )?);
+            answers.host_token =
+                prompt_optional(reader, "Bitbucket token (optional, leave blank to skip)")?
+                    .map(Credential::literal);
+        }
+    }
+    Ok(())
+}
+
+/// Prompt for the PM system and whatever credentials it needs.
+fn prompt_pm<R: BufRead>(reader: &mut R, answers: &mut Answers) -> anyhow::Result<()> {
+    let pm = prompt(
+        reader,
+        "Project-management system — choose one: none / github / jira / linear",
+        Some("none"),
+    )?;
+    answers.pm = match pm.to_lowercase().as_str() {
+        "github" => InstallPm::Github,
+        "jira" => InstallPm::Jira,
+        "linear" => InstallPm::Linear,
+        _ => InstallPm::None,
+    };
+    match answers.pm {
+        InstallPm::Jira => {
+            let url = prompt(reader, "JIRA URL", None)?;
+            let username = prompt(reader, "JIRA username/email", None)?;
+            let token = prompt(reader, "JIRA API token", None)?;
+            answers.jira = Some(JiraSettings {
+                url,
+                username,
+                token: Credential::literal(token),
+            });
+        }
+        InstallPm::Linear => {
+            let api_key = prompt(reader, "Linear API key", None)?;
+            let teams = prompt_optional(
+                reader,
+                "Linear team keys (comma-separated, blank for every visible team)",
+            )?;
+            answers.linear = Some(LinearSettings {
+                api_key: Credential::literal(api_key),
+                team_keys: teams.as_deref().map(split_list).unwrap_or_default(),
+            });
+        }
+        InstallPm::None | InstallPm::Github => {}
+    }
+    Ok(())
+}
+
+/// Prompt for one or more local repository paths, warning about missing ones.
+fn prompt_paths<R: BufRead>(reader: &mut R) -> anyhow::Result<Vec<PathBuf>> {
+    let raw = prompt(
+        reader,
         "Path(s) to git repository (comma-separated for multiple)",
         None,
     )?;
-    let repo_paths: Vec<PathBuf> = repos_raw
-        .split(',')
-        .map(|s| s.trim())
-        .filter(|s| !s.is_empty())
-        .map(PathBuf::from)
-        .collect();
-
-    if repo_paths.is_empty() {
+    let paths: Vec<PathBuf> = split_list(&raw).into_iter().map(PathBuf::from).collect();
+    if paths.is_empty() {
         anyhow::bail!("at least one repository path is required");
     }
-    for p in &repo_paths {
+    for p in &paths {
         if !p.exists() {
             eprintln!(
                 "  warning: {} does not exist (continuing anyway — fix before running `tga analyze`)",
@@ -91,63 +398,16 @@ pub fn run(_config: Config, args: InstallArgs) -> anyhow::Result<()> {
             );
         }
     }
+    Ok(paths)
+}
 
-    let github_token = prompt_optional(&mut input, "GitHub token (optional, leave blank to skip)")?;
-
-    let jira_url = prompt_optional(&mut input, "JIRA URL (optional, leave blank to skip)")?;
-    let (jira_user, jira_token) = if jira_url.is_some() {
-        let user = prompt_optional(&mut input, "JIRA username/email")?;
-        let token = prompt_optional(&mut input, "JIRA API token")?;
-        (user, token)
-    } else {
-        (None, None)
-    };
-
-    let output_dir = prompt(&mut input, "Output directory", Some("./tga-output"))?;
-    let output_dir_path = PathBuf::from(&output_dir);
-    if let Err(e) = std::fs::create_dir_all(&output_dir_path) {
-        anyhow::bail!(
-            "cannot create output directory {}: {e}",
-            output_dir_path.display()
-        );
-    }
-
-    let llm_provider = prompt(
-        &mut input,
-        "LLM provider — choose one: none / openai / openrouter",
-        Some("none"),
-    )?;
-    let llm_provider = llm_provider.to_lowercase();
-    let llm_api_key = if llm_provider == "openai" || llm_provider == "openrouter" {
-        prompt_optional(
-            &mut input,
-            &format!(
-                "{} API key (leave blank to set later via env var)",
-                llm_provider
-            ),
-        )?
-    } else {
-        None
-    };
-
-    let yaml = render_yaml(&RenderYamlConfig {
-        repos: &repo_paths,
-        github_token: github_token.as_deref(),
-        jira_url: jira_url.as_deref(),
-        jira_user: jira_user.as_deref(),
-        jira_token: jira_token.as_deref(),
-        output_dir: &output_dir,
-        llm_provider: &llm_provider,
-        llm_api_key: llm_api_key.as_deref(),
-    });
-
-    std::fs::write(&args.output, yaml)?;
-    println!(
-        "\nConfig written to {}. Run: tga analyze --config {}",
-        args.output.display(),
-        args.output.display()
-    );
-    Ok(())
+/// Split a comma-separated answer into trimmed, non-empty entries.
+pub(super) fn split_list(raw: &str) -> Vec<String> {
+    raw.split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .collect()
 }
 
 /// Print `prompt` (with optional default), read a line, return it trimmed.
@@ -201,176 +461,122 @@ fn prompt_optional<R: BufRead>(reader: &mut R, prompt: &str) -> anyhow::Result<O
     }
 }
 
-/// Inputs to [`render_yaml`].
-///
-/// Why: groups the wizard's collected values into a single named struct so
-/// the renderer signature stays readable and call sites are self-documenting
-/// (no long positional `Option<&str>` argument lists).
-struct RenderYamlConfig<'a> {
-    /// Repository paths to emit under `repositories:`.
-    repos: &'a [PathBuf],
-    /// Optional GitHub personal access token.
-    github_token: Option<&'a str>,
-    /// Optional JIRA base URL.
-    jira_url: Option<&'a str>,
-    /// Optional JIRA username / email.
-    jira_user: Option<&'a str>,
-    /// Optional JIRA API token.
-    jira_token: Option<&'a str>,
-    /// Output directory for generated reports.
-    output_dir: &'a str,
-    /// LLM provider identifier (`none`, `openai`, or `openrouter`).
-    llm_provider: &'a str,
-    /// Optional LLM API key (emitted only as a hint comment).
-    llm_api_key: Option<&'a str>,
-}
-
-/// Render a YAML configuration string. Optional sections are omitted when
-/// the corresponding credential set is empty so the generated file is
-/// minimal and round-trips through `Config::load` cleanly.
-fn render_yaml(cfg: &RenderYamlConfig<'_>) -> String {
-    let RenderYamlConfig {
-        repos,
-        github_token,
-        jira_url,
-        jira_user,
-        jira_token,
-        output_dir,
-        llm_provider,
-        llm_api_key,
-    } = *cfg;
-
-    let mut out = String::new();
-    out.push_str("# Generated by `tga install`\n");
-    out.push_str("version: \"1.0\"\n\n");
-
-    out.push_str("repositories:\n");
-    for p in repos {
-        let name = p
-            .file_name()
-            .and_then(|s| s.to_str())
-            .unwrap_or("repo")
-            .to_string();
-        out.push_str(&format!("  - path: \"{}\"\n", p.display()));
-        out.push_str(&format!("    name: \"{}\"\n", name));
-    }
-    out.push('\n');
-
-    out.push_str("output:\n");
-    out.push_str(&format!("  directory: \"{}\"\n", output_dir));
-    out.push_str("  formats: [csv, json, markdown]\n\n");
-
-    if let Some(token) = github_token {
-        out.push_str("github:\n");
-        out.push_str(&format!("  token: \"{}\"\n", token));
-        out.push_str("  fetch_prs: true\n\n");
-    }
-
-    if let (Some(url), Some(user), Some(token)) = (jira_url, jira_user, jira_token) {
-        out.push_str("jira:\n");
-        out.push_str(&format!("  url: \"{}\"\n", url));
-        out.push_str(&format!("  username: \"{}\"\n", user));
-        out.push_str(&format!("  token: \"{}\"\n\n", token));
-    }
-
-    if llm_provider == "openai" || llm_provider == "openrouter" {
-        out.push_str("classification:\n");
-        out.push_str("  use_llm: true\n");
-        out.push_str(&format!(
-            "  llm_model: \"{}\"\n",
-            default_model_for(llm_provider)
-        ));
-        if let Some(key) = llm_api_key {
-            out.push_str(&format!(
-                "  # API key (also pickable from ${} env var)\n",
-                env_var_for(llm_provider)
-            ));
-            out.push_str(&format!("  # llm_api_key: \"{}\"\n", key));
-        }
-        out.push('\n');
-    }
-
-    out
-}
-
-/// Suggest a default model identifier for the chosen provider.
-fn default_model_for(provider: &str) -> &'static str {
-    match provider {
-        "openai" => "gpt-4o-mini",
-        "openrouter" => "openrouter/auto",
-        _ => "",
-    }
-}
-
-/// Suggest the conventional environment variable name for the provider's
-/// API key. Surfaces in the generated YAML as a hint comment.
-fn env_var_for(provider: &str) -> &'static str {
-    match provider {
-        "openai" => "OPENAI_API_KEY",
-        "openrouter" => "OPENROUTER_API_KEY",
-        _ => "LLM_API_KEY",
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::Path;
+    use crate::commands::install_flags::args_for_tests;
 
-    fn render_yaml_for_tests(repo: &Path, output_dir: &str) -> String {
-        render_yaml(&RenderYamlConfig {
-            repos: &[repo.to_path_buf()],
-            github_token: None,
-            jira_url: None,
-            jira_user: None,
-            jira_token: None,
-            output_dir,
-            llm_provider: "none",
-            llm_api_key: None,
-        })
-    }
-
+    /// Why: a flag the wizard would ignore must not silently select the wizard.
+    /// What: an otherwise-bare `InstallArgs` plus one answer-bearing flag.
+    /// Test: this test itself.
     #[test]
-    fn render_yaml_minimal() {
-        let yaml = render_yaml_for_tests(Path::new("/tmp/repo"), "./out");
-        assert!(yaml.contains("repositories:"));
-        assert!(yaml.contains("path: \"/tmp/repo\""));
-        assert!(yaml.contains("output:"));
-        assert!(yaml.contains("directory: \"./out\""));
-        // No optional integrations included.
-        assert!(!yaml.contains("github:"));
-        assert!(!yaml.contains("jira:"));
-        assert!(!yaml.contains("classification:"));
+    fn answer_flags_select_the_flag_path() {
+        assert!(!args_for_tests(&["tga"]).wants_non_interactive());
+        assert!(args_for_tests(&["tga", "--non-interactive"]).wants_non_interactive());
+        assert!(args_for_tests(&["tga", "--org", "acme"]).wants_non_interactive());
+        assert!(args_for_tests(&["tga", "--repo-path", "/tmp/r"]).wants_non_interactive());
+        assert!(args_for_tests(&["tga", "--linear-team", "ENG"]).wants_non_interactive());
+        // Flags with clap defaults are not answers and must not flip the switch.
+        assert!(!args_for_tests(&["tga", "--output", "x.yaml", "--force"]).wants_non_interactive());
     }
 
-    #[test]
-    fn render_yaml_with_github_and_llm() {
-        let yaml = render_yaml(&RenderYamlConfig {
-            repos: &[PathBuf::from("/tmp/repo")],
-            github_token: Some("ghp_xxx"),
-            jira_url: None,
-            jira_user: None,
-            jira_token: None,
-            output_dir: "./out",
-            llm_provider: "openai",
-            llm_api_key: Some("sk-xxx"),
-        });
-        assert!(yaml.contains("github:"));
-        assert!(yaml.contains("ghp_xxx"));
-        assert!(yaml.contains("classification:"));
-        assert!(yaml.contains("use_llm: true"));
-        assert!(yaml.contains("gpt-4o-mini"));
+    /// Why (#5216): the wizard and the flag path must be two doors onto the
+    /// same room. If they can render different config for the same answers,
+    /// scripting `tga install` stops being equivalent to running it by hand.
+    /// What: drives the wizard with a scripted stdin, drives the flag path with
+    /// the equivalent flags, and compares the rendered YAML byte for byte.
+    /// Test: this test itself.
+    #[tokio::test]
+    async fn wizard_and_flag_paths_render_identical_config() {
+        // local host, one repo path, JIRA, ./out, no LLM.
+        let script = "local\n\
+                      /tmp/widget\n\
+                      jira\n\
+                      https://acme.atlassian.net\n\
+                      me@acme.com\n\
+                      jira-token\n\
+                      ./out\n\
+                      none\n";
+        let mut input = script.as_bytes();
+        let wizard_args = args_for_tests(&["tga"]);
+        let wizard_answers = collect_answers(&mut input, &wizard_args).expect("wizard completes");
+        let wizard_plan = plan_from_answers(wizard_answers).await.expect("plan");
+
+        let flag_args = args_for_tests(&[
+            "tga",
+            "--host",
+            "local",
+            "--repo-path",
+            "/tmp/widget",
+            "--pm",
+            "jira",
+            "--jira-url",
+            "https://acme.atlassian.net",
+            "--jira-user",
+            "me@acme.com",
+            "--jira-token",
+            "jira-token",
+            "--output-dir",
+            "./out",
+        ]);
+        let flag_plan = resolve_plan(&flag_args).await.expect("flag path resolves");
+
+        assert_eq!(wizard_plan, flag_plan, "plans diverged");
+        assert_eq!(
+            render_yaml(&wizard_plan),
+            render_yaml(&flag_plan),
+            "rendered config diverged"
+        );
     }
 
+    /// Why: the wizard's Linear branch is new in #5216 and must reach the
+    /// renderer, not just the prompt.
+    /// What: drives the wizard through the Linear answers.
+    /// Test: this test itself.
+    #[tokio::test]
+    async fn wizard_collects_linear_answers() {
+        let script = "local\n/tmp/widget\nlinear\nlin_key\nENG, OPS\n./out\nnone\n";
+        let mut input = script.as_bytes();
+        let answers =
+            collect_answers(&mut input, &args_for_tests(&["tga"])).expect("wizard completes");
+        let yaml = render_yaml(&plan_from_answers(answers).await.expect("plan"));
+        assert!(yaml.contains("linear:"), "{yaml}");
+        assert!(yaml.contains("api_key: \"lin_key\""), "{yaml}");
+        assert!(yaml.contains("team_keys: [\"ENG\", \"OPS\"]"), "{yaml}");
+    }
+
+    /// Why: the Bitbucket wizard branch must record the workspace and the
+    /// explicit repository list rather than producing an empty config.
+    /// What: drives the wizard through the Bitbucket answers.
+    /// Test: this test itself.
+    #[tokio::test]
+    async fn wizard_collects_bitbucket_workspace_and_repos() {
+        let script = "bitbucket\nacme\nacme/widget, acme/gadget\nbb-token\nnone\n./out\nnone\n";
+        let mut input = script.as_bytes();
+        let answers =
+            collect_answers(&mut input, &args_for_tests(&["tga"])).expect("wizard completes");
+        let plan = plan_from_answers(answers).await.expect("plan");
+        let yaml = render_yaml(&plan);
+        assert!(yaml.contains("workspace: \"acme\""), "{yaml}");
+        assert!(yaml.contains("name: \"widget\""), "{yaml}");
+        assert!(yaml.contains("name: \"gadget\""), "{yaml}");
+        assert!(
+            plan.notes.iter().any(|n| n.contains("#5220")),
+            "{:?}",
+            plan.notes
+        );
+    }
+
+    /// Why: the two prompt helpers carry the default/EOF contract the rest of
+    /// the wizard relies on.
+    /// What: empty line on each.
+    /// Test: this test itself.
     #[test]
     fn prompt_uses_default_on_empty() {
         let mut input: &[u8] = b"\n";
         let v = prompt(&mut input, "Q", Some("def")).expect("ok");
         assert_eq!(v, "def");
-    }
 
-    #[test]
-    fn prompt_optional_returns_none_on_empty() {
         let mut input: &[u8] = b"\n";
         let v = prompt_optional(&mut input, "Q").expect("ok");
         assert!(v.is_none());

--- a/crates/trusty-git-analytics/src/commands/install_flags.rs
+++ b/crates/trusty-git-analytics/src/commands/install_flags.rs
@@ -1,0 +1,760 @@
+//! The non-interactive front end for `tga install` (#5216).
+//!
+//! Why: the wizard needed a terminal, so a stranger could not script tga, run
+//! it from CI, or reach a populated config without answering prompts by hand.
+//! This module turns flags and environment variables into the same [`Answers`]
+//! the wizard collects, and — for a GitHub org — derives the repository set
+//! from the API instead of asking for paths that already exist locally.
+//!
+//! What: [`resolve_plan`] is the entry point. [`answers_from_flags`] applies
+//! the precedence (flag value first, then the environment) and refuses with a
+//! list of exactly the missing flags rather than blocking on stdin.
+//! [`plan_from_answers`] runs GitHub org discovery and produces the
+//! [`InstallPlan`] both front ends render from.
+//!
+//! Test: `missing_flags_are_named_not_prompted_for`,
+//! `flag_path_discovers_org_repos_and_writes_them` and the credential
+//! precedence tests below.
+
+use std::path::PathBuf;
+
+use crate::collect::github::{build_http_client, discover_org_repos_at};
+use crate::commands::install::{split_list, InstallArgs, InstallHost, InstallPm};
+use crate::commands::install_plan::{
+    env_var_for, Credential, InstallPlan, JiraSettings, LinearSettings, RepoEntry,
+};
+use crate::core::config::GithubConfig;
+
+/// Environment variable holding the Bitbucket Cloud token.
+const ENV_BITBUCKET_TOKEN: &str = "BITBUCKET_TOKEN";
+/// Environment variable holding the JIRA base URL.
+const ENV_JIRA_URL: &str = "JIRA_URL";
+/// Environment variable holding the JIRA account email.
+const ENV_JIRA_EMAIL: &str = "JIRA_EMAIL";
+/// Environment variable holding the JIRA API token.
+const ENV_JIRA_API_TOKEN: &str = "JIRA_API_TOKEN";
+/// Environment variable holding the Linear API key.
+const ENV_LINEAR_API_KEY: &str = "LINEAR_API_KEY";
+
+/// The answers both `tga install` front ends collect, before discovery runs.
+///
+/// Why: the wizard asks and the flag path reads; naming the result once is
+/// what lets a scripted install and a hand-walked one reach the same config.
+/// What: a plain data struct. Nothing here prompts, reads the environment, or
+/// makes a network call — [`plan_from_answers`] does the last of those.
+/// Test: `wizard_and_flag_paths_render_identical_config` in `install.rs`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct Answers {
+    /// Where repositories come from.
+    pub host: InstallHost,
+    /// GitHub org to discover repositories from.
+    pub org: Option<String>,
+    /// Bitbucket Cloud workspace.
+    pub workspace: Option<String>,
+    /// Explicit remote repositories, `owner/name` or `workspace/slug`.
+    pub repo_slugs: Vec<String>,
+    /// Already-cloned repositories, named by path.
+    pub repo_paths: Vec<PathBuf>,
+    /// Directory remote repositories are expected under.
+    pub repo_cache: PathBuf,
+    /// Host API token.
+    pub host_token: Option<Credential>,
+    /// Chosen project-management system.
+    pub pm: InstallPm,
+    /// JIRA settings, when JIRA was chosen.
+    pub jira: Option<JiraSettings>,
+    /// Linear settings, when Linear was chosen.
+    pub linear: Option<LinearSettings>,
+    /// Directory reports are written to.
+    pub output_dir: String,
+    /// LLM provider identifier.
+    pub llm_provider: String,
+    /// LLM API key.
+    pub llm_api_key: Option<Credential>,
+    /// GitHub REST root override. `None` means api.github.com; tests point it
+    /// at a local mock server.
+    pub github_api_base: Option<String>,
+}
+
+/// Resolve an [`InstallPlan`] from flags and the process environment.
+///
+/// Why: this is what `tga install` calls when there is no terminal to prompt.
+/// What: [`answers_from_flags`] against `std::env::var`, then
+/// [`plan_from_answers`].
+/// Test: `flag_path_discovers_org_repos_and_writes_them`.
+///
+/// # Errors
+///
+/// Returns an error naming every missing required flag, or propagates a GitHub
+/// org-discovery failure.
+pub(crate) async fn resolve_plan(args: &InstallArgs) -> anyhow::Result<InstallPlan> {
+    let answers = answers_from_flags(args, &|k| std::env::var(k).ok())?;
+    plan_from_answers(answers).await
+}
+
+/// Apply flag-then-environment precedence and validate the required set.
+///
+/// Why: a token supplied through the environment must not be copied into the
+/// generated config, and a missing flag must be named rather than prompted
+/// for — a prompt with no terminal behind it hangs.
+/// What: resolves every credential through [`credential`], collects the
+/// missing required flags, and refuses with all of them at once. The `env`
+/// lookup is injected so no test touches the real process environment (#1653).
+/// Test: `missing_flags_are_named_not_prompted_for`,
+/// `flag_value_beats_the_environment` and `env_token_is_emitted_as_a_reference`.
+///
+/// # Errors
+///
+/// Returns an error listing exactly the flags that are missing.
+pub(crate) fn answers_from_flags(
+    args: &InstallArgs,
+    env: &dyn Fn(&str) -> Option<String>,
+) -> anyhow::Result<Answers> {
+    let token_var = host_token_env(args.host);
+    let host_token = token_var.and_then(|var| credential(args.host_token.as_deref(), var, env));
+
+    let jira_url = value(args.jira_url.as_deref(), ENV_JIRA_URL, env);
+    let jira_user = value(args.jira_user.as_deref(), ENV_JIRA_EMAIL, env);
+    let jira_token = credential(args.jira_token.as_deref(), ENV_JIRA_API_TOKEN, env);
+    let linear_key = credential(args.linear_api_key.as_deref(), ENV_LINEAR_API_KEY, env);
+
+    let missing = missing_flags(
+        args,
+        host_token.is_some(),
+        &[
+            ("--jira-url <URL>", jira_url.is_some()),
+            ("--jira-user <EMAIL>", jira_user.is_some()),
+            ("--jira-token <TOKEN>", jira_token.is_some()),
+            ("--linear-api-key <KEY>", linear_key.is_some()),
+        ],
+    );
+    if !missing.is_empty() {
+        anyhow::bail!(
+            "`tga install` has no terminal to prompt on and these required flags are missing:\n  {}\n\n\
+             Supply them, or run `tga install` on a terminal for the interactive wizard.",
+            missing.join("\n  ")
+        );
+    }
+
+    let pm = args.pm.unwrap_or(InstallPm::None);
+    let llm_provider = args.llm_provider.to_lowercase();
+    Ok(Answers {
+        host: args.host.unwrap_or(InstallHost::Local),
+        org: args.org.clone(),
+        workspace: args.workspace.clone(),
+        repo_slugs: args.repo.clone(),
+        repo_paths: args.repo_path.clone(),
+        repo_cache: args.repo_cache.clone(),
+        host_token,
+        pm,
+        jira: match pm {
+            InstallPm::Jira => Some(JiraSettings {
+                url: jira_url.unwrap_or_default(),
+                username: jira_user.unwrap_or_default(),
+                token: jira_token.unwrap_or_else(|| Credential::literal("")),
+            }),
+            _ => None,
+        },
+        linear: match pm {
+            InstallPm::Linear => Some(LinearSettings {
+                api_key: linear_key.unwrap_or_else(|| Credential::literal("")),
+                team_keys: args.linear_team.clone(),
+            }),
+            _ => None,
+        },
+        llm_api_key: credential(args.llm_api_key.as_deref(), env_var_for(&llm_provider), env),
+        llm_provider,
+        output_dir: args.output_dir.clone(),
+        github_api_base: None,
+    })
+}
+
+/// The required flags that are absent, in the order the error lists them.
+///
+/// Why: "listing exactly which flags are missing" is the whole contract — an
+/// error naming one flag at a time costs a round trip per flag.
+/// What: checks the two always-required flags first; host- and PM-specific
+/// requirements are only judged once `--host` / `--pm` are known.
+/// Test: `missing_flags_are_named_not_prompted_for`.
+fn missing_flags(args: &InstallArgs, has_token: bool, pm_creds: &[(&str, bool)]) -> Vec<String> {
+    let mut missing = Vec::new();
+    if args.host.is_none() {
+        missing.push("--host <local|github|bitbucket>".to_string());
+    }
+    if args.pm.is_none() {
+        missing.push("--pm <none|github|jira|linear>".to_string());
+    }
+
+    match args.host {
+        None => return missing,
+        Some(InstallHost::Local) => {
+            if args.repo_path.is_empty() {
+                missing.push("--repo-path <PATH> (repeatable)".to_string());
+            }
+        }
+        Some(InstallHost::Github) => {
+            if args.org.is_none() && args.repo.is_empty() && args.repo_path.is_empty() {
+                missing.push("--org <ORG> (or --repo <OWNER/NAME>, repeatable)".to_string());
+            }
+            if !has_token {
+                missing.push("--host-token <TOKEN> (or set $GITHUB_TOKEN)".to_string());
+            }
+        }
+        Some(InstallHost::Bitbucket) => {
+            if args.workspace.is_none() {
+                missing.push("--workspace <WORKSPACE>".to_string());
+            }
+            if args.repo.is_empty() {
+                missing.push(
+                    "--repo <WORKSPACE/SLUG> (repeatable — Bitbucket workspace discovery \
+                     is not available yet, see #5220)"
+                        .to_string(),
+                );
+            }
+            if !has_token {
+                missing.push("--host-token <TOKEN> (or set $BITBUCKET_TOKEN)".to_string());
+            }
+        }
+    }
+
+    let needed: &[usize] = match args.pm {
+        Some(InstallPm::Jira) => &[0, 1, 2],
+        Some(InstallPm::Linear) => &[3],
+        _ => &[],
+    };
+    for i in needed {
+        let (flag, present) = pm_creds[*i];
+        if !present {
+            missing.push(flag.to_string());
+        }
+    }
+    missing
+}
+
+/// Turn collected answers into a renderable plan, discovering org repos.
+///
+/// Why (#5216): "given an org and a token, tga derives the repo set itself" is
+/// the issue's closure condition, and [`discover_org_repos_at`] already knows
+/// how to page it — this is the call site that was missing.
+/// What: local paths pass through unchanged; a GitHub org is paged over the
+/// API and unioned with any explicit `--repo` slugs; a Bitbucket workspace
+/// takes the explicit list only, and records why.
+/// Test: `flag_path_discovers_org_repos_and_writes_them` and
+/// `bitbucket_records_that_discovery_is_unavailable`.
+///
+/// # Errors
+///
+/// Propagates a GitHub client-build or org-discovery failure.
+pub(crate) async fn plan_from_answers(answers: Answers) -> anyhow::Result<InstallPlan> {
+    let Answers {
+        host,
+        org,
+        workspace,
+        repo_slugs,
+        repo_paths,
+        repo_cache,
+        host_token,
+        pm: _,
+        jira,
+        linear,
+        output_dir,
+        llm_provider,
+        llm_api_key,
+        github_api_base,
+    } = answers;
+
+    let mut plan = InstallPlan {
+        output_dir,
+        llm_provider,
+        llm_api_key,
+        jira,
+        linear,
+        ..InstallPlan::default()
+    };
+
+    for p in &repo_paths {
+        plan.repos.push(RepoEntry {
+            name: leaf_name(p),
+            path: p.clone(),
+            org: None,
+        });
+    }
+
+    match host {
+        InstallHost::Local => {}
+        InstallHost::Github => {
+            let mut pairs = parse_slugs(&repo_slugs, None);
+            if let Some(org) = &org {
+                pairs.extend(discover(host_token.as_ref(), github_api_base.as_deref(), org).await?);
+                if pairs.is_empty() {
+                    plan.notes.push(format!(
+                        "GitHub org `{org}` returned no repositories the supplied token can see"
+                    ));
+                }
+            }
+            plan.github_token = host_token;
+            plan.github_org = org;
+            push_remote(&mut plan, &repo_cache, pairs);
+        }
+        InstallHost::Bitbucket => {
+            // #5216: non-interactive install path — Bitbucket workspace-to-repo
+            // discovery is #5220, so the explicit list is the repository set.
+            plan.notes.push(
+                "Bitbucket Cloud workspace discovery is not available yet (#5220); the \
+                 repositories listed here are the ones you named explicitly."
+                    .to_string(),
+            );
+            let pairs = parse_slugs(&repo_slugs, workspace.as_deref());
+            plan.bitbucket_workspace = workspace;
+            plan.bitbucket_token = host_token;
+            push_remote(&mut plan, &repo_cache, pairs);
+        }
+    }
+
+    Ok(plan)
+}
+
+/// Page `org`'s repositories over the GitHub API.
+///
+/// `api_base` of `None` means api.github.com; tests point it at a mock server.
+async fn discover(
+    token: Option<&Credential>,
+    api_base: Option<&str>,
+    org: &str,
+) -> anyhow::Result<Vec<(String, String)>> {
+    let cfg = GithubConfig {
+        token: token.map(|c| c.value.clone()),
+        ..GithubConfig::default()
+    };
+    let http = build_http_client(&cfg)?;
+    let base = api_base.unwrap_or("https://api.github.com");
+    Ok(discover_org_repos_at(&http, base, org).await?)
+}
+
+/// Append `pairs` as `repositories[]` entries under `cache`, deduplicating.
+fn push_remote(plan: &mut InstallPlan, cache: &std::path::Path, pairs: Vec<(String, String)>) {
+    let mut seen: std::collections::HashSet<(String, String)> = std::collections::HashSet::new();
+    for (owner, name) in pairs {
+        if !seen.insert((owner.clone(), name.clone())) {
+            continue;
+        }
+        plan.repos.push(RepoEntry {
+            path: cache.join(&owner).join(&name),
+            name,
+            org: Some(owner),
+        });
+    }
+}
+
+/// Split `owner/name` slugs, falling back to `default_owner` for a bare name.
+fn parse_slugs(slugs: &[String], default_owner: Option<&str>) -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    for raw in slugs.iter().flat_map(|s| split_list(s)) {
+        match raw.split_once('/') {
+            Some((owner, name)) if !owner.is_empty() && !name.is_empty() => {
+                out.push((owner.to_string(), name.to_string()));
+            }
+            _ => {
+                if let Some(owner) = default_owner {
+                    out.push((owner.to_string(), raw));
+                }
+            }
+        }
+    }
+    out
+}
+
+/// The final path component, or `repo` when there is none.
+fn leaf_name(p: &std::path::Path) -> String {
+    p.file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("repo")
+        .to_string()
+}
+
+/// The environment variable that stands in for `--host-token`.
+fn host_token_env(host: Option<InstallHost>) -> Option<&'static str> {
+    match host {
+        Some(InstallHost::Github) => Some(trusty_common::env_vars::ENV_GITHUB_TOKEN),
+        Some(InstallHost::Bitbucket) => Some(ENV_BITBUCKET_TOKEN),
+        _ => None,
+    }
+}
+
+/// Flag value, else `var` from `env`; blank counts as absent.
+fn value(flag: Option<&str>, var: &str, env: &dyn Fn(&str) -> Option<String>) -> Option<String> {
+    flag.map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .or_else(|| {
+            env(var)
+                .map(|v| v.trim().to_string())
+                .filter(|s| !s.is_empty())
+        })
+}
+
+/// [`value`], tagged with where it came from so an env-sourced secret is
+/// written to the config as `${VAR}` rather than in the clear.
+fn credential(
+    flag: Option<&str>,
+    var: &str,
+    env: &dyn Fn(&str) -> Option<String>,
+) -> Option<Credential> {
+    if let Some(v) = flag.map(str::trim).filter(|s| !s.is_empty()) {
+        return Some(Credential::literal(v));
+    }
+    env(var)
+        .map(|v| v.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .map(|v| Credential::from_env(var, v))
+}
+
+/// Parse `argv` into [`InstallArgs`] the way clap does at the real call site.
+///
+/// Why: tests must exercise the same defaults and value parsing the CLI
+/// applies; a hand-built struct would silently diverge from the derive.
+/// What: flattens `InstallArgs` behind a throwaway parser.
+/// Test: used by every test in this file and in `install.rs`.
+#[cfg(test)]
+pub(crate) fn args_for_tests(argv: &[&str]) -> InstallArgs {
+    use clap::Parser;
+
+    #[derive(Parser)]
+    struct Wrapper {
+        /// The flags under test.
+        #[command(flatten)]
+        args: InstallArgs,
+    }
+    Wrapper::parse_from(argv).args
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::install_plan::render_yaml;
+    use serde_json::json;
+    use wiremock::matchers::{method, path, query_param};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    /// An env lookup over an in-memory map — no process environment touched.
+    fn env_map<'a>(pairs: &'a [(&'a str, &'a str)]) -> impl Fn(&str) -> Option<String> + 'a {
+        move |k: &str| {
+            pairs
+                .iter()
+                .find(|(name, _)| *name == k)
+                .map(|(_, v)| (*v).to_string())
+        }
+    }
+
+    /// No environment at all.
+    fn no_env(_: &str) -> Option<String> {
+        None
+    }
+
+    /// Why (#5216): with no terminal the wizard would block on the first
+    /// prompt forever. The flag path must name every missing flag instead.
+    /// What: resolves a bare `tga install`, then a half-specified GitHub one.
+    /// Test: this test itself.
+    #[test]
+    fn missing_flags_are_named_not_prompted_for() {
+        let err = answers_from_flags(&args_for_tests(&["tga"]), &no_env)
+            .expect_err("bare install must be refused");
+        let msg = err.to_string();
+        assert!(msg.contains("--host <local|github|bitbucket>"), "{msg}");
+        assert!(msg.contains("--pm <none|github|jira|linear>"), "{msg}");
+        // Host-specific flags cannot be judged before --host is known.
+        assert!(!msg.contains("--org"), "{msg}");
+
+        let err = answers_from_flags(
+            &args_for_tests(&["tga", "--host", "github", "--pm", "none"]),
+            &no_env,
+        )
+        .expect_err("github install without org or token must be refused");
+        let msg = err.to_string();
+        assert!(msg.contains("--org <ORG>"), "{msg}");
+        assert!(msg.contains("$GITHUB_TOKEN"), "{msg}");
+        assert!(!msg.contains("--host <"), "{msg}");
+    }
+
+    /// Why: Bitbucket has no discovery yet, so a workspace alone would produce
+    /// an empty repository list. The refusal must say so rather than write it.
+    /// What: `--host bitbucket --workspace acme` with no `--repo`.
+    /// Test: this test itself.
+    #[test]
+    fn bitbucket_without_repos_is_refused_and_says_why() {
+        let err = answers_from_flags(
+            &args_for_tests(&[
+                "tga",
+                "--host",
+                "bitbucket",
+                "--workspace",
+                "acme",
+                "--pm",
+                "none",
+                "--host-token",
+                "bb",
+            ]),
+            &no_env,
+        )
+        .expect_err("bitbucket without --repo must be refused");
+        let msg = err.to_string();
+        assert!(msg.contains("--repo <WORKSPACE/SLUG>"), "{msg}");
+        assert!(msg.contains("#5220"), "{msg}");
+    }
+
+    /// Why: a JIRA or Linear choice with no credentials writes a config that
+    /// cannot collect; the refusal must name the credential flags too.
+    /// What: `--pm jira` and `--pm linear` with nothing else.
+    /// Test: this test itself.
+    #[test]
+    fn pm_choice_pulls_in_its_own_credential_flags() {
+        let args = args_for_tests(&[
+            "tga",
+            "--host",
+            "local",
+            "--repo-path",
+            "/r",
+            "--pm",
+            "jira",
+        ]);
+        let msg = answers_from_flags(&args, &no_env)
+            .expect_err("jira without creds")
+            .to_string();
+        assert!(msg.contains("--jira-url <URL>"), "{msg}");
+        assert!(msg.contains("--jira-user <EMAIL>"), "{msg}");
+        assert!(msg.contains("--jira-token <TOKEN>"), "{msg}");
+
+        let args = args_for_tests(&[
+            "tga",
+            "--host",
+            "local",
+            "--repo-path",
+            "/r",
+            "--pm",
+            "linear",
+        ]);
+        let msg = answers_from_flags(&args, &no_env)
+            .expect_err("linear without a key")
+            .to_string();
+        assert!(msg.contains("--linear-api-key <KEY>"), "{msg}");
+    }
+
+    /// Why: the crate resolves credentials config-first then env (see
+    /// `bitbucket::client::resolve_auth`); the flag path mirrors that with the
+    /// flag standing in for the config value.
+    /// What: token supplied both ways, then only through the environment.
+    /// Test: this test itself.
+    #[test]
+    fn flag_value_beats_the_environment() {
+        let args = args_for_tests(&[
+            "tga",
+            "--host",
+            "github",
+            "--org",
+            "acme",
+            "--pm",
+            "none",
+            "--host-token",
+            "from-flag",
+        ]);
+        let answers =
+            answers_from_flags(&args, &env_map(&[("GITHUB_TOKEN", "from-env")])).expect("resolves");
+        let token = answers.host_token.expect("token resolved");
+        assert_eq!(token.value, "from-flag");
+        assert_eq!(token.emitted, "from-flag");
+    }
+
+    /// Why: an env-sourced token copied into config.yaml is a secret written
+    /// into a file the operator is likely to commit.
+    /// What: token only in the environment.
+    /// Test: this test itself.
+    #[test]
+    fn env_token_is_emitted_as_a_reference() {
+        let args = args_for_tests(&["tga", "--host", "github", "--org", "acme", "--pm", "none"]);
+        let answers = answers_from_flags(&args, &env_map(&[("GITHUB_TOKEN", "ghp_secret")]))
+            .expect("resolves");
+        let token = answers.host_token.expect("token resolved");
+        assert_eq!(token.value, "ghp_secret");
+        assert_eq!(token.emitted, "${GITHUB_TOKEN}");
+    }
+
+    /// Why (#5216): the closure condition is that an org plus a token yields a
+    /// populated config with no local paths supplied. This is that end to end,
+    /// against a local mock — no test here can reach github.com.
+    /// What: serves two pages of `GET /orgs/acme/repos`, resolves the flag
+    /// path against them, and asserts every discovered repo reaches the YAML.
+    /// Test: this test itself.
+    #[tokio::test]
+    async fn flag_path_discovers_org_repos_and_writes_them() {
+        let server = MockServer::start().await;
+        let page1: Vec<serde_json::Value> = (0..100)
+            .map(|i| json!({"full_name": format!("acme/repo{i}")}))
+            .collect();
+        Mock::given(method("GET"))
+            .and(path("/orgs/acme/repos"))
+            .and(query_param("page", "1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(page1))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/orgs/acme/repos"))
+            .and(query_param("page", "2"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(json!([{"full_name": "acme/widget"}])),
+            )
+            .mount(&server)
+            .await;
+
+        let args = args_for_tests(&[
+            "tga",
+            "--host",
+            "github",
+            "--org",
+            "acme",
+            "--pm",
+            "github",
+            "--host-token",
+            "ghp_test",
+            "--repo-cache",
+            "/cache",
+        ]);
+        let mut answers = answers_from_flags(&args, &no_env).expect("resolves");
+        answers.github_api_base = Some(server.uri());
+        let plan = plan_from_answers(answers)
+            .await
+            .expect("discovery succeeds");
+
+        assert_eq!(plan.repos.len(), 101, "both pages must be collected");
+        assert_eq!(plan.github_org.as_deref(), Some("acme"));
+        let yaml = render_yaml(&plan);
+        assert!(yaml.contains("path: \"/cache/acme/widget\""), "{yaml}");
+        assert!(yaml.contains("name: \"widget\""), "{yaml}");
+        assert!(yaml.contains("name: \"repo0\""), "{yaml}");
+        assert!(yaml.contains("  org: \"acme\""), "{yaml}");
+        assert!(yaml.contains("token: \"ghp_test\""), "{yaml}");
+    }
+
+    /// Why (#5216): a generated config that `Config::load` cannot read back is
+    /// worse than no config — install would report success and every later
+    /// command would fail. The discovered-org shape is the new one, so it is
+    /// the one that has to be proven loadable.
+    /// What: renders the discovered plan, writes it to a temp file, and loads
+    /// it through the real deserializer.
+    /// Test: this test itself.
+    #[tokio::test]
+    async fn generated_config_loads_back_through_config_load() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/orgs/acme/repos"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(json!([{"full_name": "acme/widget"}])),
+            )
+            .mount(&server)
+            .await;
+
+        let args = args_for_tests(&[
+            "tga",
+            "--host",
+            "github",
+            "--org",
+            "acme",
+            "--pm",
+            "linear",
+            "--host-token",
+            "ghp_test",
+            "--linear-api-key",
+            "lin_key",
+            "--linear-team",
+            "ENG",
+            "--repo-cache",
+            "/cache",
+        ]);
+        let mut answers = answers_from_flags(&args, &no_env).expect("resolves");
+        answers.github_api_base = Some(server.uri());
+        let plan = plan_from_answers(answers).await.expect("resolves");
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cfg_path = dir.path().join("config.yaml");
+        std::fs::write(&cfg_path, render_yaml(&plan)).expect("write");
+        let loaded = crate::core::config::Config::load(&cfg_path).expect("config loads back");
+
+        assert_eq!(loaded.repositories.len(), 1);
+        assert_eq!(
+            loaded.repositories[0].path,
+            std::path::PathBuf::from("/cache/acme/widget")
+        );
+        assert_eq!(loaded.repositories[0].org.as_deref(), Some("acme"));
+        let github = loaded.github.expect("github block");
+        assert_eq!(github.org.as_deref(), Some("acme"));
+        let linear = loaded.linear.expect("linear block");
+        assert_eq!(linear.team_keys, vec!["ENG".to_string()]);
+    }
+
+    /// Why: an org that the token cannot see returns an empty list, and a
+    /// config with no repositories must say why rather than look complete.
+    /// What: serves an empty first page.
+    /// Test: this test itself.
+    #[tokio::test]
+    async fn empty_org_listing_is_recorded_as_a_note() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/orgs/ghost/repos"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+            .mount(&server)
+            .await;
+
+        let args = args_for_tests(&[
+            "tga",
+            "--host",
+            "github",
+            "--org",
+            "ghost",
+            "--pm",
+            "none",
+            "--host-token",
+            "ghp_test",
+        ]);
+        let mut answers = answers_from_flags(&args, &no_env).expect("resolves");
+        answers.github_api_base = Some(server.uri());
+        let plan = plan_from_answers(answers).await.expect("resolves");
+        assert!(plan.repos.is_empty());
+        assert!(
+            plan.notes.iter().any(|n| n.contains("no repositories")),
+            "{:?}",
+            plan.notes
+        );
+    }
+
+    /// Why: the Bitbucket option must accept an explicit repo list and say
+    /// discovery is not available, not silently emit an empty config.
+    /// What: resolves a Bitbucket install with two explicit repos.
+    /// Test: this test itself.
+    #[tokio::test]
+    async fn bitbucket_records_that_discovery_is_unavailable() {
+        let args = args_for_tests(&[
+            "tga",
+            "--host",
+            "bitbucket",
+            "--workspace",
+            "acme",
+            "--repo",
+            "acme/widget",
+            "--repo",
+            "gadget",
+            "--pm",
+            "none",
+            "--host-token",
+            "bb-token",
+            "--repo-cache",
+            "/cache",
+        ]);
+        let answers = answers_from_flags(&args, &no_env).expect("resolves");
+        let plan = plan_from_answers(answers).await.expect("resolves");
+        let yaml = render_yaml(&plan);
+        assert!(yaml.contains("workspace: \"acme\""), "{yaml}");
+        assert!(yaml.contains("path: \"/cache/acme/widget\""), "{yaml}");
+        // A bare slug inherits the workspace.
+        assert!(yaml.contains("path: \"/cache/acme/gadget\""), "{yaml}");
+        assert!(yaml.contains("#5220"), "{yaml}");
+    }
+}

--- a/crates/trusty-git-analytics/src/commands/install_plan.rs
+++ b/crates/trusty-git-analytics/src/commands/install_plan.rs
@@ -1,0 +1,374 @@
+//! The single config-emission path shared by both `tga install` front ends.
+//!
+//! Why (#5216): `tga install` grew a non-interactive flag path beside the TTY
+//! wizard. Two front ends writing their own YAML would drift — one would gain
+//! a `linear:` block or a repo `org:` field the other never learned to emit,
+//! and a config generated non-interactively would stop matching the one an
+//! operator walked through by hand. Both paths therefore build an
+//! [`InstallPlan`] and hand it to [`render_yaml`]; nothing else writes config
+//! text.
+//!
+//! What: [`InstallPlan`] is the resolved answer set — repositories, host,
+//! credentials, PM system, output directory, LLM provider — with no notion of
+//! where those answers came from. [`render_yaml`] turns one into the YAML that
+//! `Config::load` reads back.
+//!
+//! Test: `render_yaml_minimal` and `render_yaml_with_github_and_llm` below;
+//! `wizard_and_flag_paths_render_identical_config` in `install.rs` asserts the
+//! two front ends reach byte-identical output for the same answers.
+
+use std::path::PathBuf;
+
+/// One entry under `repositories:` in the generated config.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RepoEntry {
+    /// Working-tree path the collector will walk.
+    pub path: PathBuf,
+    /// Display name recorded against the repository's rows.
+    pub name: String,
+    /// Owning GitHub org / Bitbucket workspace, when it is known.
+    pub org: Option<String>,
+}
+
+/// A secret plus the text that stands in for it in the generated YAML.
+///
+/// Why: a token supplied through the environment must not be copied into a
+/// file the operator may well commit. tga already expands `${VAR}` references
+/// in config values, so an env-sourced credential is written as its reference
+/// and re-read from the environment at collect time.
+/// What: `value` is the live secret (used for the discovery calls `install`
+/// itself makes); `emitted` is what [`render_yaml`] writes.
+/// Test: `env_sourced_credentials_emit_a_reference_not_the_secret`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Credential {
+    /// The live secret, used for HTTP calls made during install.
+    pub value: String,
+    /// What gets written to YAML — `${VAR}` for an env-sourced credential.
+    pub emitted: String,
+}
+
+impl Credential {
+    /// A credential given directly (a flag, or a wizard prompt).
+    #[must_use]
+    pub fn literal(value: impl Into<String>) -> Self {
+        let value = value.into();
+        Self {
+            emitted: value.clone(),
+            value,
+        }
+    }
+
+    /// A credential read from environment variable `var`.
+    #[must_use]
+    pub fn from_env(var: &str, value: impl Into<String>) -> Self {
+        Self {
+            value: value.into(),
+            emitted: format!("${{{var}}}"),
+        }
+    }
+}
+
+/// JIRA connection settings for the generated `jira:` block.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JiraSettings {
+    /// Base URL of the JIRA instance.
+    pub url: String,
+    /// Account username or email.
+    pub username: String,
+    /// API token.
+    pub token: Credential,
+}
+
+/// Linear connection settings for the generated `linear:` block.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LinearSettings {
+    /// Linear API key.
+    pub api_key: Credential,
+    /// Team keys to scope issue fetches to; empty means every visible team.
+    pub team_keys: Vec<String>,
+}
+
+/// The resolved answers a generated config is rendered from.
+///
+/// Why: the wizard and the flag path collect the same facts by different
+/// means. Naming those facts once is what lets [`render_yaml`] stay the only
+/// place that knows the YAML schema.
+/// What: a plain data struct — every field is already resolved, with no
+/// defaults left to apply and no prompting or env lookup remaining.
+/// Test: both front ends construct one in `install.rs` / `install_flags.rs`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct InstallPlan {
+    /// Repositories to collect from.
+    pub repos: Vec<RepoEntry>,
+    /// GitHub org the repository set was discovered from, when there was one.
+    pub github_org: Option<String>,
+    /// GitHub token.
+    pub github_token: Option<Credential>,
+    /// Bitbucket Cloud workspace.
+    pub bitbucket_workspace: Option<String>,
+    /// Bitbucket Cloud token.
+    pub bitbucket_token: Option<Credential>,
+    /// JIRA settings, when JIRA is the chosen PM system.
+    pub jira: Option<JiraSettings>,
+    /// Linear settings, when Linear is the chosen PM system.
+    pub linear: Option<LinearSettings>,
+    /// Directory reports are written to.
+    pub output_dir: String,
+    /// LLM provider identifier (`none`, `openai`, or `openrouter`).
+    pub llm_provider: String,
+    /// LLM API key, emitted only as a hint comment.
+    pub llm_api_key: Option<Credential>,
+    /// Operator-facing caveats written into the config as leading comments —
+    /// for example that Bitbucket workspace discovery is not implemented yet.
+    pub notes: Vec<String>,
+}
+
+/// Render a plan as the YAML `tga` reads back through `Config::load`.
+///
+/// Why: one renderer means the wizard and the flag path cannot emit different
+/// schemas for the same answers.
+/// What: writes `repositories:`, `output:`, then only those optional blocks
+/// the plan actually populated, so the generated file stays minimal.
+/// Test: `render_yaml_minimal`, `render_yaml_with_github_and_llm`,
+/// `render_yaml_emits_discovered_org_repos` and
+/// `render_yaml_emits_linear_and_bitbucket` below.
+#[must_use]
+pub fn render_yaml(plan: &InstallPlan) -> String {
+    let mut out = String::new();
+    out.push_str("# Generated by `tga install`\n");
+    for note in &plan.notes {
+        out.push_str(&format!("# NOTE: {note}\n"));
+    }
+    out.push_str("version: \"1.0\"\n\n");
+
+    out.push_str("repositories:\n");
+    for r in &plan.repos {
+        out.push_str(&format!("  - path: \"{}\"\n", r.path.display()));
+        out.push_str(&format!("    name: \"{}\"\n", r.name));
+        if let Some(org) = &r.org {
+            out.push_str(&format!("    org: \"{org}\"\n"));
+        }
+    }
+    out.push('\n');
+
+    out.push_str("output:\n");
+    out.push_str(&format!("  directory: \"{}\"\n", plan.output_dir));
+    out.push_str("  formats: [csv, json, markdown]\n\n");
+
+    render_hosts(plan, &mut out);
+    render_pm(plan, &mut out);
+    render_classification(plan, &mut out);
+    out
+}
+
+/// Emit the `github:` and `bitbucket:` blocks a plan populated.
+fn render_hosts(plan: &InstallPlan, out: &mut String) {
+    if plan.github_token.is_some() || plan.github_org.is_some() {
+        out.push_str("github:\n");
+        if let Some(token) = &plan.github_token {
+            out.push_str(&format!("  token: \"{}\"\n", token.emitted));
+        }
+        if let Some(org) = &plan.github_org {
+            out.push_str(&format!("  org: \"{org}\"\n"));
+        }
+        out.push_str("  fetch_prs: true\n\n");
+    }
+
+    if plan.bitbucket_workspace.is_some() || plan.bitbucket_token.is_some() {
+        out.push_str("bitbucket:\n");
+        if let Some(ws) = &plan.bitbucket_workspace {
+            out.push_str(&format!("  workspace: \"{ws}\"\n"));
+        }
+        if let Some(token) = &plan.bitbucket_token {
+            out.push_str(&format!("  token: \"{}\"\n", token.emitted));
+        }
+        out.push_str("  fetch_prs: true\n\n");
+    }
+}
+
+/// Emit the `jira:` and `linear:` blocks a plan populated.
+fn render_pm(plan: &InstallPlan, out: &mut String) {
+    if let Some(jira) = &plan.jira {
+        out.push_str("jira:\n");
+        out.push_str(&format!("  url: \"{}\"\n", jira.url));
+        out.push_str(&format!("  username: \"{}\"\n", jira.username));
+        out.push_str(&format!("  token: \"{}\"\n\n", jira.token.emitted));
+    }
+
+    if let Some(linear) = &plan.linear {
+        out.push_str("linear:\n");
+        out.push_str(&format!("  api_key: \"{}\"\n", linear.api_key.emitted));
+        if !linear.team_keys.is_empty() {
+            let keys = linear
+                .team_keys
+                .iter()
+                .map(|k| format!("\"{k}\""))
+                .collect::<Vec<_>>()
+                .join(", ");
+            out.push_str(&format!("  team_keys: [{keys}]\n"));
+        }
+        out.push('\n');
+    }
+}
+
+/// Emit the `classification:` block when an LLM provider was chosen.
+fn render_classification(plan: &InstallPlan, out: &mut String) {
+    if plan.llm_provider != "openai" && plan.llm_provider != "openrouter" {
+        return;
+    }
+    out.push_str("classification:\n");
+    out.push_str("  use_llm: true\n");
+    out.push_str(&format!(
+        "  llm_model: \"{}\"\n",
+        default_model_for(&plan.llm_provider)
+    ));
+    if let Some(key) = &plan.llm_api_key {
+        out.push_str(&format!(
+            "  # API key (also pickable from ${} env var)\n",
+            env_var_for(&plan.llm_provider)
+        ));
+        out.push_str(&format!("  # llm_api_key: \"{}\"\n", key.emitted));
+    }
+    out.push('\n');
+}
+
+/// Suggest a default model identifier for the chosen provider.
+#[must_use]
+pub fn default_model_for(provider: &str) -> &'static str {
+    match provider {
+        "openai" => "gpt-4o-mini",
+        "openrouter" => "openrouter/auto",
+        _ => "",
+    }
+}
+
+/// The conventional environment variable holding the provider's API key.
+/// Surfaces in the generated YAML as a hint comment.
+#[must_use]
+pub fn env_var_for(provider: &str) -> &'static str {
+    match provider {
+        "openai" => "OPENAI_API_KEY",
+        "openrouter" => "OPENROUTER_API_KEY",
+        _ => "LLM_API_KEY",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A plan carrying one local repository and nothing optional.
+    fn minimal_plan(path: &str, output_dir: &str) -> InstallPlan {
+        InstallPlan {
+            repos: vec![RepoEntry {
+                path: PathBuf::from(path),
+                name: "repo".to_string(),
+                org: None,
+            }],
+            output_dir: output_dir.to_string(),
+            llm_provider: "none".to_string(),
+            ..InstallPlan::default()
+        }
+    }
+
+    /// Why: the minimal config must round-trip through `Config::load`, so no
+    /// optional block may appear when nothing populated it.
+    /// What: renders a repo-only plan.
+    /// Test: this test itself.
+    #[test]
+    fn render_yaml_minimal() {
+        let yaml = render_yaml(&minimal_plan("/tmp/repo", "./out"));
+        assert!(yaml.contains("repositories:"));
+        assert!(yaml.contains("path: \"/tmp/repo\""));
+        assert!(yaml.contains("output:"));
+        assert!(yaml.contains("directory: \"./out\""));
+        assert!(!yaml.contains("github:"));
+        assert!(!yaml.contains("bitbucket:"));
+        assert!(!yaml.contains("jira:"));
+        assert!(!yaml.contains("linear:"));
+        assert!(!yaml.contains("classification:"));
+    }
+
+    /// Why: the GitHub + LLM combination is what the wizard emitted before
+    /// #5216; the renderer must keep emitting it unchanged.
+    /// What: renders a plan with a literal token and the `openai` provider.
+    /// Test: this test itself.
+    #[test]
+    fn render_yaml_with_github_and_llm() {
+        let mut plan = minimal_plan("/tmp/repo", "./out");
+        plan.github_token = Some(Credential::literal("ghp_xxx"));
+        plan.llm_provider = "openai".to_string();
+        plan.llm_api_key = Some(Credential::literal("sk-xxx"));
+        let yaml = render_yaml(&plan);
+        assert!(yaml.contains("github:"));
+        assert!(yaml.contains("ghp_xxx"));
+        assert!(yaml.contains("classification:"));
+        assert!(yaml.contains("use_llm: true"));
+        assert!(yaml.contains("gpt-4o-mini"));
+    }
+
+    /// Why (#5216): org discovery is pointless if the discovered repos never
+    /// reach the file, so the org and every discovered entry must be written.
+    /// What: renders a two-repo plan carrying a `github_org`.
+    /// Test: this test itself.
+    #[test]
+    fn render_yaml_emits_discovered_org_repos() {
+        let mut plan = minimal_plan("/cache/acme/widget", "./out");
+        plan.repos = vec![
+            RepoEntry {
+                path: PathBuf::from("/cache/acme/widget"),
+                name: "widget".to_string(),
+                org: Some("acme".to_string()),
+            },
+            RepoEntry {
+                path: PathBuf::from("/cache/acme/gadget"),
+                name: "gadget".to_string(),
+                org: Some("acme".to_string()),
+            },
+        ];
+        plan.github_org = Some("acme".to_string());
+        let yaml = render_yaml(&plan);
+        assert!(yaml.contains("name: \"widget\""), "{yaml}");
+        assert!(yaml.contains("name: \"gadget\""), "{yaml}");
+        assert!(yaml.contains("    org: \"acme\""), "{yaml}");
+        assert!(yaml.contains("  org: \"acme\""), "{yaml}");
+    }
+
+    /// Why (#5216): Linear and Bitbucket are the two options the issue adds,
+    /// and an option that renders nothing is not an option.
+    /// What: renders a plan carrying both.
+    /// Test: this test itself.
+    #[test]
+    fn render_yaml_emits_linear_and_bitbucket() {
+        let mut plan = minimal_plan("/tmp/repo", "./out");
+        plan.bitbucket_workspace = Some("acme".to_string());
+        plan.bitbucket_token = Some(Credential::literal("bb-token"));
+        plan.linear = Some(LinearSettings {
+            api_key: Credential::literal("lin_xxx"),
+            team_keys: vec!["ENG".to_string(), "OPS".to_string()],
+        });
+        plan.notes = vec!["workspace discovery is not available yet".to_string()];
+        let yaml = render_yaml(&plan);
+        assert!(yaml.contains("bitbucket:"), "{yaml}");
+        assert!(yaml.contains("workspace: \"acme\""), "{yaml}");
+        assert!(yaml.contains("linear:"), "{yaml}");
+        assert!(yaml.contains("team_keys: [\"ENG\", \"OPS\"]"), "{yaml}");
+        assert!(
+            yaml.contains("# NOTE: workspace discovery is not available yet"),
+            "{yaml}"
+        );
+    }
+
+    /// Why: an env-sourced token copied into config.yaml is a secret written
+    /// to a file the operator is likely to commit.
+    /// What: renders a plan whose credentials all came from the environment.
+    /// Test: this test itself.
+    #[test]
+    fn env_sourced_credentials_emit_a_reference_not_the_secret() {
+        let mut plan = minimal_plan("/tmp/repo", "./out");
+        plan.github_token = Some(Credential::from_env("GITHUB_TOKEN", "ghp_secret"));
+        let yaml = render_yaml(&plan);
+        assert!(yaml.contains("token: \"${GITHUB_TOKEN}\""), "{yaml}");
+        assert!(!yaml.contains("ghp_secret"), "{yaml}");
+    }
+}

--- a/crates/trusty-git-analytics/src/commands/mod.rs
+++ b/crates/trusty-git-analytics/src/commands/mod.rs
@@ -16,6 +16,10 @@ pub mod deployments;
 pub mod dora;
 pub mod incidents;
 pub mod install;
+// #5216: the non-interactive install path and the config emission both front
+// ends share, split out to keep `install.rs` under the SLOC cap.
+pub(crate) mod install_flags;
+pub mod install_plan;
 pub mod jira;
 pub mod override_cmd;
 pub mod pr_metrics;

--- a/crates/trusty-git-analytics/src/main.rs
+++ b/crates/trusty-git-analytics/src/main.rs
@@ -331,7 +331,7 @@ async fn run() -> anyhow::Result<()> {
     // config file. Handle it before the DB open call so a missing/locked
     // `tga.db` cannot block bootstrapping a fresh project.
     if let Commands::Install(args) = cli.command {
-        return commands::install::run(config, args);
+        return commands::install::run(config, args).await;
     }
 
     // #2405: the universal `config` command manages inference provider keys and

--- a/docs/trusty-git-analytics/requirements/cli-commands.md
+++ b/docs/trusty-git-analytics/requirements/cli-commands.md
@@ -168,12 +168,50 @@ Manage manual classification overrides (Tier 0).
 
 ### `tga install`
 
-Interactive setup wizard. Creates `config.yaml`, prompts for tokens, validates connectivity.
+Setup wizard. Creates `config.yaml`. On a terminal with no flags it prompts;
+given `--host` / `--pm`, or with stdin not a terminal, it runs from flags and
+environment variables and never prompts ([#5216](https://github.com/bobmatnyc/trusty-tools/issues/5216)).
+With `--host github --org <ORG>` it pages the GitHub API for the org's
+repositories and writes them into the generated config.
 
 | Flag | Description |
 |------|-------------|
 | `--output <PATH>` | Output config path (default `./config.yaml`) |
 | `--force` | Overwrite existing config |
+| `--non-interactive` | Never prompt; implied when stdin is not a terminal |
+| `--host <local\|github\|bitbucket>` | Where repositories come from (required non-interactively) |
+| `--org <ORG>` | GitHub org to discover repositories from |
+| `--workspace <WORKSPACE>` | Bitbucket Cloud workspace |
+| `--repo <OWNER/NAME>` | Explicit remote repository; repeatable |
+| `--repo-path <PATH>` | Already-cloned repository; repeatable |
+| `--repo-cache <DIR>` | Where remote repositories are expected on disk (default `./repos`) |
+| `--host-token <TOKEN>` | Host API token; falls back to `$GITHUB_TOKEN` / `$BITBUCKET_TOKEN` |
+| `--pm <none\|github\|jira\|linear>` | PM system supplying work items (required non-interactively) |
+| `--jira-url`, `--jira-user`, `--jira-token` | JIRA credentials; fall back to `$JIRA_URL`, `$JIRA_EMAIL`, `$JIRA_API_TOKEN` |
+| `--linear-api-key <KEY>` | Linear API key; falls back to `$LINEAR_API_KEY` |
+| `--linear-team <TEAM>` | Linear team key to scope issue fetches to; repeatable |
+| `--output-dir <DIR>` | Report output directory (default `./tga-output`) |
+| `--llm-provider <PROVIDER>` | `none`, `openai` or `openrouter` (default `none`) |
+| `--llm-api-key <KEY>` | LLM API key; falls back to the provider's conventional env var |
+
+**Precedence:** a flag value wins over its environment variable. A credential
+taken from the environment is written to the config as a `${VAR}` reference,
+not as the secret itself.
+
+Run non-interactively with a required flag missing, install names every missing
+flag at once rather than blocking on a prompt:
+
+```bash
+$ tga install --host github --pm none < /dev/null
+Error: `tga install` has no terminal to prompt on and these required flags are missing:
+  --org <ORG> (or --repo <OWNER/NAME>, repeatable)
+  --host-token <TOKEN> (or set $GITHUB_TOKEN)
+```
+
+Bitbucket Cloud workspace-to-repo discovery is not implemented yet
+([#5220](https://github.com/bobmatnyc/trusty-tools/issues/5220)), so
+`--host bitbucket` requires an explicit `--repo <workspace/slug>` list and
+records that limitation as a comment in the generated config.
 
 ### `tga help`
 

--- a/docs/trusty-git-analytics/user/user-guide.md
+++ b/docs/trusty-git-analytics/user/user-guide.md
@@ -108,13 +108,33 @@ tga install
 ```
 
 The wizard prompts for:
-- Path(s) to your local git repositories
-- GitHub personal access token (optional — for PR metadata)
-- JIRA credentials (optional)
+- Code host — `local` (repositories you have already cloned), `github` (an org
+  it discovers repositories from) or `bitbucket` (a workspace plus an explicit
+  repository list)
+- The host's API token (optional for `local`)
+- Project-management system — `none`, `github`, `jira` or `linear` — and that
+  system's credentials
 - Output directory for reports
 - LLM provider for classification (optional)
 
 The wizard writes `config.yaml` in the current directory.
+
+#### Without a terminal
+
+`tga install` runs from flags instead of prompts when you supply `--host` and
+`--pm`, or whenever stdin is not a terminal — CI, a container, a script. Given
+a GitHub org and a token it discovers the org's repositories itself, so nothing
+has to be cloned first:
+
+```bash
+GITHUB_TOKEN=ghp_… tga install --host github --org acme --pm github
+```
+
+A flag value wins over its environment variable, and a credential read from the
+environment is written to the config as `${GITHUB_TOKEN}` rather than as the
+secret. Run it with a required flag missing and it names every missing flag at
+once instead of hanging on a prompt. The full flag list is in the
+[CLI reference](../requirements/cli-commands.md#tga-install).
 
 ### Step 3: Review config.yaml
 


### PR DESCRIPTION
## Outcome

Refs #5216 (epic #5223, discovery mode). `tga install` gains a flag/env-driven non-interactive path beside the TTY wizard, selected by `--non-interactive`, by any answer-bearing flag, or by stdin not being a terminal.

## Changes

New flags: `--host`, `--pm`, `--org`/`--workspace`, `--repo`/`--repo-path` (repeatable), `--host-token` (env `GITHUB_TOKEN`/`BITBUCKET_TOKEN`), JIRA/Linear/LLM credential flags with env fallbacks, `--output`, `--output-dir`. Precedence: flag, then env. A credential taken from the environment is written to the config as `${VAR}`, never its value (`commands/install_plan.rs` `Credential::from_env`). 

For a GitHub org the path calls `discover_org_repos` (new `discover_org_repos_at` seam for tests) and writes the discovered repos. Both front ends emit config through one `InstallPlan`/`render_yaml`. 

Bitbucket and Linear added as host/PM options; Bitbucket without an explicit repo list is refused with a message that discovery is #5220. `install.rs` split into `install_plan.rs` + `install_flags.rs` under the 500-SLOC cap. 

Docs, README, help.yaml updated; two changelog fragments (Added + Changed).

## Risk

Localized to install path, no public API changes to existing consumers, no version bump needed (tga 6.0.1 on main > crates.io 6.0.0).

## Tests

Rung 3 (`-p tga`) plus its one reverse dependent:
- `cargo fmt --check` ✓
- `cargo check -p tga --all-targets` ✓
- `cargo clippy -p tga --all-targets -- -D warnings` ✓
- `cargo test -p tga --no-fail-fast` → 1457 lib + 24 integration passed, 0 failed (15 new: wiremock org discovery over two pages, missing-flags refusal, wizard-vs-flag byte-identical config, round-trip through `Config::load`, env-token-as-reference, and more)
- `cargo test -p trusty-analyze --no-fail-fast` → 515 + 8 targets, 0 failed

Non-TTY binary smoke: four cases (missing flags → exit 1 naming them; partial → names `--org`/`$GITHUB_TOKEN`; fake token → dies at the 401, not at parsing; local + linear → config written).

## Baseline

Rebased onto main after #6727 (tga 6.0.1 migration 0026). No pre-existing failures in scope.

## Docs

Doc gates green. README, help.yaml, requirements/cli-commands.md, and user-guide.md updated. Changelog fragments in place.

## Review

None at this time — ready for code-critic.

Refs #5216

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
