### PR TITLE
feat(trusty-audit): cargo-audit CVE-scan collector with fail-open gaps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11481,7 +11481,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-audit"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -11997,7 +11997,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-review"
-version = "0.33.0"
+version = "0.33.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-audit/Cargo.toml
+++ b/crates/trusty-audit/Cargo.toml
@@ -10,7 +10,7 @@ name = "trusty-audit"
 # the cut ships as 0.13.1 with that fragment folded in. This bump also carries
 # the `[tools]` pin refresh in templates/engagement.template.toml onto the
 # versions this cut publishes. No public API change.
-version = "0.13.2"
+version = "0.13.3"
 description = "Auditor client — installs its pinned audit tooling and drives an audit engagement on the recipient's own codebases."
 readme = "README.md"
 homepage = "https://github.com/bobmatnyc/trusty-tools"

--- a/crates/trusty-audit/changelog.d/6075-cargo-audit-collector.md
+++ b/crates/trusty-audit/changelog.d/6075-cargo-audit-collector.md
@@ -1,0 +1,11 @@
+Added
+
+- The audit sweep now scans each Rust repository's `Cargo.lock` with
+  `cargo audit` and writes every advisory into the report manifest's
+  `[report].findings`, so the DD report states dependency CVE exposure instead
+  of disclaiming it (#6075).
+  - Fail-open, and never silently: a target with no `cargo-audit` installed
+    gets a gap naming the binary and `cargo install cargo-audit`; a non-Rust
+    target gets `cve-scan: no cargo-audit-equivalent for <language>`; a scan
+    that ran clean states what its lockfile scan did not cover. A repository
+    declaring no dependency manifest at all is a declared skip and says nothing.

--- a/crates/trusty-audit/src/grounding.rs
+++ b/crates/trusty-audit/src/grounding.rs
@@ -17,7 +17,7 @@
 //! investigation pass inspects the code a tool already flagged rather than the
 //! code whose PATH NAME looked interesting.
 //!
-//! What: four legs, in prerequisite order, each with one job.
+//! What: one leg per row below, in prerequisite order, each with one job.
 //!
 //! | Module | Owns |
 //! |---|---|
@@ -26,6 +26,7 @@
 //! | [`hotspots`] | asking trusty-analyze which files are worst, and ranking them |
 //! | [`evidence`] | asking trusty-search where each DD dimension's evidence is (#6082) |
 //! | [`topology`] | reading a Cargo workspace's own crate graph (#6147) |
+//! | [`cve`] | scanning the pinned dependency set for advisories (#6075) |
 //! | [`priority`] | writing that ranking, and the gaps, into the manifest |
 //!
 //! ## Fail-open, and never silently
@@ -55,6 +56,7 @@ use std::time::Duration;
 use crate::tools::RequiredTool;
 use crate::workdir::WorkDir;
 
+pub mod cve;
 pub mod daemons;
 pub mod evidence;
 pub mod hotspots;
@@ -404,7 +406,12 @@ pub async fn ground_manifest(
     // depends on neither daemon and is measured whether or not either answered.
     // It writes its own key, after the ranking, so one leg's write failure
     // cannot take the other's data with it.
-    let topology_gaps = topology::ground_into(manifest, checkout, display);
+    let mut manifest_leg_gaps = topology::ground_into(manifest, checkout, display);
+    // #6075: the CVE scan writes its own `[report].findings` key, after the
+    // ranking and for the same reason — one leg's write failure must not take
+    // the other's data with it. Its gaps join topology's rather than earning a
+    // third `priority::write_into` call.
+    manifest_leg_gaps.extend(cve::ground_into(manifest, checkout, display));
     // #6082: read BEFORE the write, which is what would otherwise make the two
     // states indistinguishable afterwards.
     let already_rendered = investigation_exists(manifest);
@@ -423,16 +430,16 @@ pub async fn ground_manifest(
     }
     // Recorded through the same `[report].gaps` key every other leg uses, which
     // `priority::write_into` above owns — so they are appended after it ran.
-    if !topology_gaps.is_empty()
+    if !manifest_leg_gaps.is_empty()
         && let Err(cause) =
-            priority::write_into(manifest, checkout, &[], None, false, &topology_gaps)
+            priority::write_into(manifest, checkout, &[], None, false, &manifest_leg_gaps)
     {
         grounding.gaps.push(format!(
             "{display}: {cause} — the rendered report does not state why its crate topology \
-             is missing"
+             and dependency CVE scan are missing"
         ));
     }
-    grounding.gaps.extend(topology_gaps);
+    grounding.gaps.extend(manifest_leg_gaps);
     if already_rendered && !grounding.priorities.is_empty() {
         // Returned to the caller and deliberately NOT written into
         // `[report].gaps`: the manifest now carries the ranking, so a re-render

--- a/crates/trusty-audit/src/grounding/cve.rs
+++ b/crates/trusty-audit/src/grounding/cve.rs
@@ -1,0 +1,547 @@
+//! The dependency CVE scan the DD report used to disclaim (#6075, epic #6074).
+//!
+//! Why: the report's Security Posture section states, correctly, that its
+//! findings are an LLM's reading of selected source files and NOT a dependency
+//! CVE scan. Nothing in the pipeline then performed one, so "CVE exposure" was
+//! named as an assurance gap and left there. `cargo audit` answers the question
+//! deterministically for a Rust target in one subprocess, and the answer belongs
+//! in the report rather than in this process's stderr.
+//!
+//! Owner ruling 2026-08-19 puts the collector HERE rather than in trusty-review:
+//! all collector intelligence lives in trusty-audit and the manifest is the
+//! interface, so tuning what is scanned is a single-crate rebuild.
+//!
+//! What: one leg, `cargo-audit audit --json` against the checkout, reduced to
+//! one [`Advisory`] per row. [`write_into`] puts them in `[report].findings`,
+//! where trusty-review renders them; [`ground_into`] is the caller-facing shape
+//! every other grounding leg has — gap lines and nothing else to decide about.
+//!
+//! ## Why the subprocess, and why `cargo-audit` rather than `cargo audit`
+//!
+//! `rustsec` is not in this workspace's lock file and pulling it in would pin a
+//! second crate to the advisory-database format for the six fields below.
+//! [`super::topology`] next door already spawns its tool exactly this way. The
+//! binary is resolved through `trusty_common::bin_resolve::resolve_binary` —
+//! the workspace's one answer to "is this tool installed, and where" — rather
+//! than through `cargo audit`, because a missing subcommand surfaces from cargo
+//! as an exit status among others while an unresolved binary is a fact this
+//! module can state precisely and name the install command for.
+//!
+//! ## Degradation
+//!
+//! Three outcomes ([`Outcome`]), and the fail-open rule is the one every leg in
+//! this module follows: the sweep continues, and the cost is a NAMED line in
+//! `[report].gaps`, never a silent zero-findings result (#5620 — a recorded skip
+//! permits, a blind gate does not).
+//!
+//! | Target | Outcome |
+//! |---|---|
+//! | `Cargo.lock` present | scanned, or a gap naming why the scan failed |
+//! | `Cargo.toml` but no lock, or a non-Rust ecosystem | a gap naming the language |
+//! | no recognised dependency manifest at all | a declared skip: nothing written, nothing said |
+//!
+//! The last row is the same distinction [`super::topology`] draws. A repository
+//! declaring no dependencies in any ecosystem this module knows has no CVE
+//! surface to report on, and the Dependency Inventory section already carries
+//! trusty-review's own "not examined / declares nothing" caveat for it — a
+//! second line restating it would be noise in every such report.
+//!
+//! Test: `cve_tests`.
+
+use std::path::Path;
+use std::process::Command;
+
+use toml_edit::{Array, DocumentMut, InlineTable, Item, Table, Value};
+
+/// The collector's name, as it appears at the head of every gap line it writes.
+pub const COLLECTOR: &str = "cve-scan";
+
+/// The `category` every advisory this collector records carries.
+///
+/// The reuse point for the rest of epic #6074: #6076's license collector and
+/// #6077's secrets collector write the same `[report].findings` rows under
+/// `license` and `secrets`, and trusty-review groups the rendered table by this
+/// key. Spelled here because this collector is the one that establishes it.
+pub const CATEGORY: &str = "dependencies";
+
+/// The binary that performs the scan.
+pub const BINARY: &str = "cargo-audit";
+
+/// What an operator runs to get [`BINARY`], named in the missing-binary gap.
+pub const INSTALL_COMMAND: &str = "cargo install cargo-audit";
+
+/// One advisory `cargo audit` reported against the target's lock file.
+///
+/// Why: these six fields are what a due-diligence reader acts on — which
+/// advisory, against which pinned version, how bad, and where to read it. The
+/// description cargo-audit also emits is deliberately not carried: it is
+/// paragraphs of prose per row, and the URL is the better place for it.
+/// What: `severity` is this collector's own band, not a CVSS score — see
+/// [`Severity`]. `url` is the advisory's own reference when it states one,
+/// else the RUSTSEC page derived from the id.
+/// Test: `cve_tests::{a_vulnerability_becomes_a_red_advisory,
+/// a_warning_becomes_an_amber_advisory}`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct Advisory {
+    /// Advisory id, e.g. `RUSTSEC-2024-0421`.
+    pub id: String,
+    /// The affected package's name.
+    pub package: String,
+    /// The version the lock file pins.
+    pub version: String,
+    /// The band this row renders under.
+    pub severity: Severity,
+    /// The advisory's one-line title.
+    pub title: String,
+    /// Where to read it, when there is somewhere to read it.
+    pub url: Option<String>,
+}
+
+/// The band an advisory renders under.
+///
+/// Why: cargo-audit states a CVSS *vector* and not a score, and scoring a
+/// vector here would be a second implementation of a published algorithm for a
+/// number the report renders as a band anyway. The split cargo-audit itself
+/// draws is the one that carries the information: a `vulnerabilities` row is an
+/// exploitable defect against a pinned version, a `warnings` row is a
+/// maintenance signal (unmaintained, unsound, yanked). That maps onto the
+/// report's existing RED/AMBER vocabulary exactly.
+/// What: `Red` for every `vulnerabilities.list` row, `Amber` for every
+/// `warnings` row. There is no green band — a clean scan produces no rows.
+/// Test: `cve_tests::a_warning_becomes_an_amber_advisory`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Severity {
+    /// An exploitable advisory against the pinned version.
+    Red,
+    /// A maintenance signal: unmaintained, unsound, or yanked.
+    Amber,
+}
+
+impl Severity {
+    /// The band as trusty-review's report vocabulary spells it.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Severity::Red => "RED",
+            Severity::Amber => "AMBER",
+        }
+    }
+}
+
+/// What the leg produced for one repository.
+///
+/// Why: "no advisories" has three meanings that must not share a variant, and
+/// only one of them is a clean result. See the module docs' table.
+/// What: the scan's rows (possibly empty, which IS a clean bill for the pinned
+/// dependency set), a declared skip carrying why the leg does not apply, or a
+/// failure carrying the one line the caller turns into a gap.
+/// Test: `cve_tests::{a_repository_with_no_manifest_is_a_declared_skip,
+/// a_non_rust_repository_names_its_language}`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Outcome {
+    /// No recognised dependency manifest; the reason it does not apply.
+    NotApplicable(String),
+    /// The scan ran; these are its rows, in the order cargo-audit reported them.
+    Scanned(Vec<Advisory>),
+    /// The scan could not run, or could not be read; why not.
+    Unavailable(String),
+}
+
+/// One completed `cargo-audit` invocation, as this module needs to see it.
+///
+/// Why: `cargo audit` exits NON-ZERO when it finds vulnerabilities, so the exit
+/// status alone cannot say whether the run failed — the stdout document does.
+/// Carrying both is what lets [`scan_with`] apply that rule in one place, and
+/// what lets the failure arms be tested without a `cargo-audit` on the machine.
+/// What: whether the process exited 0, plus both streams as text.
+/// Test: `cve_tests::a_nonzero_exit_with_readable_json_is_still_a_scan`.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct Run {
+    /// Whether the process exited zero.
+    pub success: bool,
+    /// The JSON document `--json` writes to stdout.
+    pub stdout: String,
+    /// Diagnostics, used only to explain a failure.
+    pub stderr: String,
+}
+
+/// Marker files that identify a dependency ecosystem, and what to call it.
+///
+/// Why: the gap line owes the reader the LANGUAGE, not a filename — "no
+/// cargo-audit-equivalent for JavaScript/TypeScript" is actionable and "no
+/// package.json handler" is not. Ordered most-specific first so a polyglot
+/// repository is named by the ecosystem whose manifest sits at its root.
+const ECOSYSTEMS: &[(&str, &str)] = &[
+    ("package.json", "JavaScript/TypeScript"),
+    ("go.mod", "Go"),
+    ("pyproject.toml", "Python"),
+    ("requirements.txt", "Python"),
+    ("Pipfile", "Python"),
+    ("Gemfile", "Ruby"),
+    ("composer.json", "PHP"),
+    ("pom.xml", "Java"),
+    ("build.gradle", "Java/Kotlin"),
+    ("build.gradle.kts", "Java/Kotlin"),
+    ("mix.exs", "Elixir"),
+    ("pubspec.yaml", "Dart/Flutter"),
+    ("Package.swift", "Swift"),
+];
+
+/// Scan `checkout`, or say why there is no scan.
+///
+/// Why/What: see the module docs. Runs no subprocess at all unless the checkout
+/// has a `Cargo.lock`, so every other repository in a sweep costs one
+/// `Path::is_file` per ecosystem marker.
+///
+/// # Postconditions
+/// Never panics and never returns an error: every failure is an
+/// [`Outcome::Unavailable`] reason string, safe to show the recipient.
+///
+/// Test: `cve_tests`.
+#[must_use]
+pub fn scan(checkout: &Path) -> Outcome {
+    scan_with(checkout, run_cargo_audit)
+}
+
+/// [`scan`] with the subprocess supplied by the caller.
+///
+/// Why: the two failure arms this collector MUST get right — the binary is not
+/// installed, and the run exited non-zero without usable JSON — are precisely
+/// the arms a test cannot reach through a real `cargo-audit`, which is either
+/// installed on the machine or not. `run` is the seam, and it also keeps the
+/// subprocess out of every unit test, so nothing here spawns a process or
+/// touches the network.
+/// What: the applicability ladder, then `run`, then [`parse`]. A `run` that
+/// hands back an `Err` is [`Outcome::Unavailable`] carrying its reason
+/// verbatim. A run whose stdout parses is a scan WHATEVER its exit status —
+/// `cargo audit` exits 1 on finding vulnerabilities, which is a successful scan
+/// and its most important result. A run whose stdout does not parse is
+/// unavailable, and names the exit status so a caller can tell a crash from a
+/// format change.
+/// Test: `cve_tests::{an_uninstalled_binary_is_a_named_gap,
+/// a_nonzero_exit_with_malformed_json_is_a_named_gap,
+/// a_nonzero_exit_with_readable_json_is_still_a_scan}`.
+#[must_use]
+pub fn scan_with<F>(checkout: &Path, run: F) -> Outcome
+where
+    F: FnOnce(&Path) -> Result<Run, String>,
+{
+    if !checkout.join("Cargo.lock").is_file() {
+        return match not_scannable(checkout) {
+            Some(reason) => Outcome::Unavailable(reason),
+            None => Outcome::NotApplicable(
+                "the repository root declares no dependency manifest this collector recognises"
+                    .to_string(),
+            ),
+        };
+    }
+    let output = match run(checkout) {
+        Ok(output) => output,
+        Err(cause) => return Outcome::Unavailable(cause),
+    };
+    match parse(&output.stdout) {
+        Ok(advisories) => Outcome::Scanned(advisories),
+        Err(cause) if output.success => Outcome::Unavailable(cause),
+        Err(cause) => Outcome::Unavailable(format!(
+            "{cause}, and `{BINARY}` exited non-zero ({})",
+            first_line(&output.stderr)
+        )),
+    }
+}
+
+/// Why this checkout cannot be scanned, when it has a dependency surface anyway.
+///
+/// Why: a Rust repository with no lock file and a Go repository are both
+/// unscannable and owe the report DIFFERENT sentences, and neither may be a
+/// silent zero — the acquirer is reading this section for CVE exposure that is
+/// there in both cases. `None` is reserved for the declared skip: no manifest
+/// this collector recognises, so no exposure it can claim to be missing.
+/// What: an unlocked Cargo workspace first, since a Rust repository is the one
+/// case where the tool exists and only the input is absent; then the first
+/// [`ECOSYSTEMS`] marker present at the root, spelled with the exact wording
+/// #6075 asks for.
+/// Test: `cve_tests::{a_non_rust_repository_names_its_language,
+/// a_rust_repository_with_no_lockfile_says_so}`.
+fn not_scannable(checkout: &Path) -> Option<String> {
+    if checkout.join("Cargo.toml").is_file() {
+        return Some(format!(
+            "{COLLECTOR}: the repository declares a Cargo.toml but no Cargo.lock, so `{BINARY}` \
+             has no pinned dependency set to scan"
+        ));
+    }
+    ECOSYSTEMS
+        .iter()
+        .find(|(marker, _)| checkout.join(marker).is_file())
+        .map(|(_, language)| format!("{COLLECTOR}: no cargo-audit-equivalent for {language}"))
+}
+
+/// Reduce one `cargo audit --json` document to its advisories.
+///
+/// Why: split from [`scan_with`] so every row shape — a vulnerability, each
+/// warning kind, a yanked crate with no advisory record — is testable against a
+/// captured document with no `cargo-audit`, no checkout and no subprocess in
+/// the test.
+/// What: `vulnerabilities.list` rows become [`Severity::Red`]; every array
+/// under `warnings`, whatever its key, becomes [`Severity::Amber`] — the key
+/// set grows with the advisory database, so it is read rather than enumerated.
+/// A row with no resolvable package name is skipped: it has nothing a reader
+/// could act on.
+///
+/// # Errors
+/// One line when the document is not JSON, or carries no `vulnerabilities`
+/// object — the shape every `--json` run emits, so its absence means the output
+/// is not cargo-audit's.
+///
+/// Test: `cve_tests::{the_fixture_yields_every_row,
+/// output_that_is_not_json_is_a_reason}`.
+pub fn parse(json: &str) -> Result<Vec<Advisory>, String> {
+    let doc: serde_json::Value = serde_json::from_str(json.trim())
+        .map_err(|e| format!("`{BINARY}` output is not readable as JSON ({e})"))?;
+    let vulnerabilities = doc
+        .get("vulnerabilities")
+        .ok_or_else(|| format!("`{BINARY}` output declares no `vulnerabilities` object"))?;
+
+    let mut advisories = Vec::new();
+    for row in vulnerabilities
+        .get("list")
+        .and_then(serde_json::Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or_default()
+    {
+        advisories.extend(advisory(row, Severity::Red));
+    }
+    if let Some(kinds) = doc.get("warnings").and_then(serde_json::Value::as_object) {
+        for rows in kinds.values() {
+            for row in rows.as_array().map(Vec::as_slice).unwrap_or_default() {
+                advisories.extend(advisory(row, Severity::Amber));
+            }
+        }
+    }
+    Ok(advisories)
+}
+
+/// One cargo-audit row as an [`Advisory`], when it names a package.
+///
+/// A yanked-crate warning carries no `advisory` record at all — cargo-audit
+/// knows only that the registry withdrew the version — so its `kind` stands in
+/// for the id and its title is written here rather than quoted from a record
+/// that does not exist.
+fn advisory(row: &serde_json::Value, severity: Severity) -> Option<Advisory> {
+    let string = |value: &serde_json::Value, key: &str| {
+        value
+            .get(key)
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string)
+    };
+    let package = row.get("package");
+    let record = row.get("advisory").filter(|a| !a.is_null());
+    let kind = string(row, "kind").unwrap_or_else(|| "yanked".to_string());
+
+    let name = package
+        .and_then(|p| string(p, "name"))
+        .or_else(|| record.and_then(|a| string(a, "package")))?;
+    let version = package
+        .and_then(|p| string(p, "version"))
+        .unwrap_or_else(|| "unknown".to_string());
+    let id = record
+        .and_then(|a| string(a, "id"))
+        .unwrap_or_else(|| kind.to_uppercase());
+    let title = record.and_then(|a| string(a, "title")).unwrap_or_else(|| {
+        format!("the pinned version is {kind}; no advisory record accompanies it")
+    });
+    let url = record
+        .and_then(|a| string(a, "url"))
+        .filter(|u| !u.trim().is_empty())
+        .or_else(|| {
+            id.starts_with("RUSTSEC-")
+                .then(|| format!("https://rustsec.org/advisories/{id}.html"))
+        });
+
+    Some(Advisory {
+        id,
+        package: name,
+        version,
+        severity,
+        title,
+        url,
+    })
+}
+
+/// Run `cargo-audit audit --json` in `checkout`.
+///
+/// `--json` writes the whole document to stdout, so nothing is streamed and the
+/// process is reaped by `output()` before this returns. The working directory
+/// is the checkout rather than a `--file` flag, so the only flag surface is
+/// `--json` and cargo-audit resolves its own default lock file.
+fn run_cargo_audit(checkout: &Path) -> Result<Run, String> {
+    let binary = trusty_common::bin_resolve::resolve_binary(BINARY).ok_or_else(|| {
+        format!(
+            "{COLLECTOR}: `{BINARY}` is not installed, so no dependency CVE scan ran (install it \
+             with `{INSTALL_COMMAND}`)"
+        )
+    })?;
+    let output = Command::new(&binary)
+        .arg("audit")
+        .arg("--json")
+        .current_dir(checkout)
+        .output()
+        .map_err(|e| format!("{COLLECTOR}: `{BINARY}` could not be run ({e})"))?;
+    Ok(Run {
+        success: output.status.success(),
+        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+    })
+}
+
+/// The first non-empty line of a diagnostic stream, for a one-line gap.
+fn first_line(stderr: &str) -> &str {
+    stderr
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .unwrap_or("no diagnostic")
+}
+
+/// Record `advisories` in the manifest at `path` as `[report].findings`.
+///
+/// Why: the manifest is the interface (owner ruling 2026-08-19). A scan this
+/// process performs and does not write reaches no renderer — not the sweep's,
+/// and not the recipient's own re-render of the delivered package.
+///
+/// Why nothing is written for an EMPTY scan: the presence of the key is what
+/// trusty-review renders the Assurance Scans section from, and an empty array
+/// would put an empty table in the report. A clean scan states itself through
+/// its `[report].gaps` scope line instead — see [`ground_into`].
+/// What: appends to `[report].findings`, skipping a row already declared under
+/// the same id/package/version so a resumed sweep does not restate it. Written
+/// format-preserving with `toml_edit`, exactly as
+/// [`super::priority::write_into`] writes its ranking, so the two other crates
+/// that own this document keep their key order and their comments.
+///
+/// # Errors
+/// One line, safe to show the recipient, when the manifest cannot be read,
+/// parsed, or written back. The caller turns it into a gap of its own.
+///
+/// # Postconditions
+/// On `Ok`, every advisory is declared exactly once in `[report].findings` and
+/// nothing else in the document changed. An empty `advisories` writes nothing
+/// and cannot fail.
+///
+/// Test: `cve_tests::{the_advisories_land_in_the_manifest,
+/// a_resumed_sweep_does_not_duplicate_a_row}`.
+pub fn write_into(path: &Path, advisories: &[Advisory]) -> Result<(), String> {
+    if advisories.is_empty() {
+        return Ok(());
+    }
+    let text = std::fs::read_to_string(path)
+        .map_err(|e| format!("{} could not be read ({e})", path.display()))?;
+    let mut doc: DocumentMut = text
+        .parse()
+        .map_err(|e| format!("{} is not readable as TOML ({e})", path.display()))?;
+
+    let report = doc
+        .entry("report")
+        .or_insert_with(|| Item::Table(Table::new()));
+    let table = report
+        .as_table_like_mut()
+        .ok_or_else(|| "the manifest's `report` is not a table".to_string())?;
+    let item = table
+        .entry("findings")
+        .or_insert_with(|| Item::Value(Value::Array(Array::new())));
+    let array = item
+        .as_array_mut()
+        .ok_or_else(|| "the manifest's `report.findings` is not an array".to_string())?;
+
+    for advisory in advisories {
+        if array.iter().any(|declared| same_row(declared, advisory)) {
+            continue;
+        }
+        let mut value = Value::InlineTable(row(advisory));
+        value.decor_mut().set_prefix("\n    ");
+        array.push_formatted(value);
+    }
+    array.set_trailing("\n");
+    array.set_trailing_comma(true);
+
+    std::fs::write(path, doc.to_string())
+        .map_err(|e| format!("{} could not be written ({e})", path.display()))
+}
+
+/// Whether a declared row is this advisory against this pinned version.
+///
+/// Identity is the triple, not the id: one advisory can affect two members of
+/// the same sweep at two different versions, and both are worth stating.
+fn same_row(declared: &Value, advisory: &Advisory) -> bool {
+    let Some(table) = declared.as_inline_table() else {
+        return false;
+    };
+    let field = |key: &str| table.get(key).and_then(Value::as_str);
+    field("id") == Some(advisory.id.as_str())
+        && field("package") == Some(advisory.package.as_str())
+        && field("version") == Some(advisory.version.as_str())
+}
+
+/// One advisory as the inline table trusty-review deserialises.
+fn row(advisory: &Advisory) -> InlineTable {
+    let mut table = InlineTable::new();
+    table.insert("category", Value::from(CATEGORY));
+    table.insert("id", Value::from(advisory.id.as_str()));
+    table.insert("package", Value::from(advisory.package.as_str()));
+    table.insert("version", Value::from(advisory.version.as_str()));
+    table.insert("severity", Value::from(advisory.severity.as_str()));
+    table.insert("title", Value::from(advisory.title.as_str()));
+    if let Some(url) = &advisory.url {
+        table.insert("url", Value::from(url.as_str()));
+    }
+    table
+}
+
+/// [`scan`], then write what it produced into `manifest`.
+///
+/// Why: the same shape [`super::ground_manifest`] gives every other leg — the
+/// caller gets gap lines and nothing else to decide about.
+/// What: the declared skip writes nothing and says nothing; an unavailable scan
+/// is one gap naming `display`, the cause, and what the report therefore will
+/// not carry; a scan that found rows writes them, and a write failure becomes a
+/// gap of its own. A scan that found NOTHING writes no rows and states its own
+/// scope, because "cargo-audit found no advisory" and "no cargo-audit ran" must
+/// not read the same on the page.
+/// Test: `cve_tests::{an_uninstalled_binary_is_a_named_gap,
+/// a_nonzero_exit_with_malformed_json_is_a_named_gap,
+/// a_clean_scan_states_its_own_scope}`.
+pub fn ground_into(manifest: &Path, checkout: &Path, display: &str) -> Vec<String> {
+    ground_into_with(manifest, checkout, display, run_cargo_audit)
+}
+
+/// [`ground_into`] with the subprocess supplied by the caller — see [`scan_with`].
+pub fn ground_into_with<F>(manifest: &Path, checkout: &Path, display: &str, run: F) -> Vec<String>
+where
+    F: FnOnce(&Path) -> Result<Run, String>,
+{
+    match scan_with(checkout, run) {
+        Outcome::NotApplicable(_) => Vec::new(),
+        Outcome::Unavailable(cause) => vec![format!(
+            "{display}: {cause} — the report states no dependency CVE exposure for it, which must \
+             be read as unassessed rather than as a clean dependency set"
+        )],
+        Outcome::Scanned(advisories) if advisories.is_empty() => vec![format!(
+            "{display}: {COLLECTOR}: `{BINARY}` scanned its Cargo.lock and reported no advisory. \
+             Vendored code, build-time downloads, and dependencies outside the Rust lock file are \
+             not covered by that scan"
+        )],
+        Outcome::Scanned(advisories) => match write_into(manifest, &advisories) {
+            Ok(()) => Vec::new(),
+            Err(cause) => vec![format!(
+                "{display}: {COLLECTOR}: {cause} — the report states none of the {} advisory/ies \
+                 `{BINARY}` reported for it",
+                advisories.len()
+            )],
+        },
+    }
+}
+
+#[cfg(test)]
+#[path = "cve_tests.rs"]
+mod cve_tests;

--- a/crates/trusty-audit/src/grounding/cve_tests.rs
+++ b/crates/trusty-audit/src/grounding/cve_tests.rs
@@ -1,0 +1,379 @@
+//! Tests for the cargo-audit CVE-scan collector (#6075).
+//!
+//! Why: the collector is fail-open, so every arm that produces NOTHING has to
+//! be pinned by a test that reads the gap it produced instead. A regression
+//! here does not fail a build — it ships a report whose empty CVE section reads
+//! as a clean dependency set.
+//! What: the fixture parse, the two error arms #6075 names explicitly, the
+//! applicability ladder, and the manifest write-back.
+//! Test: this file.
+
+use super::*;
+use std::path::PathBuf;
+
+/// A captured `cargo audit --json` document: one vulnerability, one
+/// unmaintained warning, one yanked crate with no advisory record.
+const FIXTURE: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/testdata/cargo-audit.json"
+));
+
+/// A manifest with the one `[report]` table `write_into` edits.
+const MANIFEST: &str = "[report]\ntitle = \"Acme\"\n\n[[repositories]]\nname = \"acme-api\"\npath = \"/tmp/acme-api\"\n";
+
+/// A run that never happened: the seam every failure-arm test injects.
+fn refuses(reason: &'static str) -> impl FnOnce(&Path) -> Result<Run, String> {
+    move |_| Err(reason.to_string())
+}
+
+/// A run that completed, with the streams and status the test wants to assert.
+fn returns(
+    success: bool,
+    stdout: &'static str,
+    stderr: &'static str,
+) -> impl FnOnce(&Path) -> Result<Run, String> {
+    move |_| {
+        Ok(Run {
+            success,
+            stdout: stdout.to_string(),
+            stderr: stderr.to_string(),
+        })
+    }
+}
+
+/// A checkout with a `Cargo.lock`, so the ladder reaches the subprocess seam.
+fn locked_checkout(tmp: &Path) -> PathBuf {
+    let checkout = tmp.join("repos").join("acme-api");
+    std::fs::create_dir_all(&checkout).expect("mkdir checkout");
+    std::fs::write(checkout.join("Cargo.toml"), "[workspace]\n").expect("manifest");
+    std::fs::write(checkout.join("Cargo.lock"), "version = 4\n").expect("lockfile");
+    checkout
+}
+
+/// A manifest file the write-back can edit.
+fn manifest_at(tmp: &Path) -> PathBuf {
+    let path = tmp.join("manifest.toml");
+    std::fs::write(&path, MANIFEST).expect("write manifest");
+    path
+}
+
+// ─── Parsing ────────────────────────────────────────────────────────────────
+
+#[test]
+fn the_fixture_yields_every_row() {
+    let rows = parse(FIXTURE).expect("the captured document parses");
+    assert_eq!(rows.len(), 3, "{rows:?}");
+}
+
+/// The six fields #6075 requires, read off a real vulnerability row.
+#[test]
+fn a_vulnerability_becomes_a_red_advisory() {
+    let rows = parse(FIXTURE).expect("parses");
+    let found = rows
+        .iter()
+        .find(|a| a.id == "RUSTSEC-2024-0421")
+        .unwrap_or_else(|| panic!("the vulnerability row is missing: {rows:?}"));
+    assert_eq!(found.package, "idna");
+    assert_eq!(found.version, "0.5.0");
+    assert_eq!(found.severity, Severity::Red);
+    assert!(found.title.contains("Punycode"), "{}", found.title);
+    assert_eq!(
+        found.url.as_deref(),
+        Some("https://github.com/servo/rust-url/pull/1017"),
+        "the advisory's own reference is preferred over a derived one"
+    );
+}
+
+#[test]
+fn a_warning_becomes_an_amber_advisory() {
+    let rows = parse(FIXTURE).expect("parses");
+    let found = rows
+        .iter()
+        .find(|a| a.id == "RUSTSEC-2024-0413")
+        .unwrap_or_else(|| panic!("the unmaintained row is missing: {rows:?}"));
+    assert_eq!(found.severity, Severity::Amber);
+    assert_eq!(found.package, "atk");
+}
+
+/// A yanked crate has no advisory record at all, and must still be reported —
+/// dropping it would be exactly the silent zero this collector exists to stop.
+#[test]
+fn a_yanked_crate_with_no_advisory_record_is_still_reported() {
+    let rows = parse(FIXTURE).expect("parses");
+    let found = rows
+        .iter()
+        .find(|a| a.package == "ghost-crate")
+        .unwrap_or_else(|| panic!("the yanked row is missing: {rows:?}"));
+    assert_eq!(found.id, "YANKED", "the kind stands in for the absent id");
+    assert_eq!(found.version, "1.0.1");
+    assert_eq!(found.severity, Severity::Amber);
+    assert!(found.url.is_none(), "there is no advisory page to link");
+}
+
+#[test]
+fn output_that_is_not_json_is_a_reason() {
+    let cause = parse("error: no such subcommand").expect_err("not JSON");
+    assert!(cause.contains("not readable as JSON"), "{cause}");
+}
+
+#[test]
+fn json_that_is_not_cargo_audits_is_a_reason() {
+    let cause = parse(r#"{"ok":true}"#).expect_err("wrong document");
+    assert!(cause.contains("`vulnerabilities`"), "{cause}");
+}
+
+// ─── The applicability ladder ───────────────────────────────────────────────
+
+/// #6075: a non-Rust target is a NAMED gap, never a silent zero-findings
+/// result, and the gap names the language rather than the marker file.
+#[test]
+fn a_non_rust_repository_names_its_language() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let checkout = tmp.path().join("web");
+    std::fs::create_dir_all(&checkout).expect("mkdir");
+    std::fs::write(checkout.join("package.json"), "{}").expect("manifest");
+
+    let Outcome::Unavailable(reason) = scan_with(&checkout, refuses("must not spawn")) else {
+        panic!("a JavaScript repository has CVE exposure this collector cannot measure");
+    };
+    assert_eq!(
+        reason, "cve-scan: no cargo-audit-equivalent for JavaScript/TypeScript",
+        "the gap states the language"
+    );
+}
+
+#[test]
+fn a_rust_repository_with_no_lockfile_says_so() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let checkout = tmp.path().join("lib");
+    std::fs::create_dir_all(&checkout).expect("mkdir");
+    std::fs::write(checkout.join("Cargo.toml"), "[package]\nname = \"x\"\n").expect("manifest");
+
+    let Outcome::Unavailable(reason) = scan_with(&checkout, refuses("must not spawn")) else {
+        panic!("an unlocked Cargo project is unscannable, not inapplicable");
+    };
+    assert!(reason.contains("no Cargo.lock"), "{reason}");
+}
+
+/// A repository declaring no dependency manifest at all has no CVE surface to
+/// claim is missing — the same declared-skip distinction `topology` draws.
+#[test]
+fn a_repository_with_no_manifest_is_a_declared_skip() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let checkout = tmp.path().join("docs");
+    std::fs::create_dir_all(&checkout).expect("mkdir");
+
+    assert!(
+        matches!(
+            scan_with(&checkout, refuses("must not spawn")),
+            Outcome::NotApplicable(_)
+        ),
+        "a manifest-less repository is a skip, not a degradation"
+    );
+    assert!(
+        ground_into_with(
+            &manifest_at(tmp.path()),
+            &checkout,
+            "docs",
+            refuses("must not spawn")
+        )
+        .is_empty(),
+        "and it says nothing at all"
+    );
+}
+
+// ─── Fail-open: the two error arms #6075 names ──────────────────────────────
+
+/// Error arm 1. Fails before the collector existed by producing nothing at all;
+/// fails against a silent implementation by producing an empty findings list.
+#[test]
+fn an_uninstalled_binary_is_a_named_gap() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let checkout = locked_checkout(tmp.path());
+    let manifest = manifest_at(tmp.path());
+
+    let missing = format!(
+        "cve-scan: `cargo-audit` is not installed, so no dependency CVE scan ran (install it with \
+         `{INSTALL_COMMAND}`)"
+    );
+    let leaked: &'static str = Box::leak(missing.into_boxed_str());
+    let gaps = ground_into_with(&manifest, &checkout, "acme-api", refuses(leaked));
+
+    assert_eq!(gaps.len(), 1, "{gaps:?}");
+    assert!(gaps[0].starts_with("acme-api: cve-scan:"), "{}", gaps[0]);
+    assert!(gaps[0].contains("cargo-audit"), "{}", gaps[0]);
+    assert!(
+        gaps[0].contains("cargo install cargo-audit"),
+        "the gap names the install command: {}",
+        gaps[0]
+    );
+    assert!(
+        gaps[0].contains("unassessed rather than as a clean dependency set"),
+        "{}",
+        gaps[0]
+    );
+    assert_eq!(
+        std::fs::read_to_string(&manifest).expect("read back"),
+        MANIFEST,
+        "no findings list — not even an empty one — is recorded for a scan that never ran"
+    );
+}
+
+/// Error arm 2. `cargo audit` exits non-zero on finding vulnerabilities too, so
+/// the status alone cannot condemn a run: what condemns this one is that its
+/// stdout is not a document, and the gap says both.
+#[test]
+fn a_nonzero_exit_with_malformed_json_is_a_named_gap() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let checkout = locked_checkout(tmp.path());
+    let manifest = manifest_at(tmp.path());
+
+    let gaps = ground_into_with(
+        &manifest,
+        &checkout,
+        "acme-api",
+        returns(
+            false,
+            "{\"vulnerabilities\": ",
+            "error: couldn't fetch advisory database\n",
+        ),
+    );
+
+    assert_eq!(gaps.len(), 1, "{gaps:?}");
+    assert!(gaps[0].contains("not readable as JSON"), "{}", gaps[0]);
+    assert!(
+        gaps[0].contains("exited non-zero"),
+        "the exit status is named so a crash is distinguishable from a format change: {}",
+        gaps[0]
+    );
+    assert!(
+        gaps[0].contains("couldn't fetch advisory database"),
+        "and the tool's own first diagnostic is quoted: {}",
+        gaps[0]
+    );
+    assert_eq!(
+        std::fs::read_to_string(&manifest).expect("read back"),
+        MANIFEST,
+        "no findings list — not even an empty one — is recorded for a scan that failed"
+    );
+}
+
+/// The inverse of the arm above, and the reason the status cannot be the test:
+/// `cargo audit` exits 1 precisely when it has the result that matters most.
+#[test]
+fn a_nonzero_exit_with_readable_json_is_still_a_scan() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let checkout = locked_checkout(tmp.path());
+
+    let Outcome::Scanned(rows) = scan_with(&checkout, returns(false, FIXTURE, "")) else {
+        panic!("a non-zero exit carrying a readable document is a successful scan");
+    };
+    assert_eq!(rows.len(), 3, "{rows:?}");
+}
+
+/// A clean scan and an absent scan must not read the same on the page, and the
+/// clean one states what it did NOT cover rather than claiming a clean tree.
+#[test]
+fn a_clean_scan_states_its_own_scope() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let checkout = locked_checkout(tmp.path());
+    let manifest = manifest_at(tmp.path());
+
+    let clean = r#"{"vulnerabilities":{"found":false,"count":0,"list":[]},"warnings":{}}"#;
+    let gaps = ground_into_with(&manifest, &checkout, "acme-api", returns(true, clean, ""));
+
+    assert_eq!(gaps.len(), 1, "{gaps:?}");
+    assert!(gaps[0].contains("reported no advisory"), "{}", gaps[0]);
+    assert!(gaps[0].contains("Vendored code"), "{}", gaps[0]);
+    assert_eq!(
+        std::fs::read_to_string(&manifest).expect("read back"),
+        MANIFEST,
+        "an empty scan writes no empty table for trusty-review to render"
+    );
+}
+
+// ─── The manifest write-back ────────────────────────────────────────────────
+
+#[test]
+fn the_advisories_land_in_the_manifest() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let checkout = locked_checkout(tmp.path());
+    let manifest = manifest_at(tmp.path());
+
+    let gaps = ground_into_with(&manifest, &checkout, "acme-api", returns(true, FIXTURE, ""));
+    assert!(
+        gaps.is_empty(),
+        "a scan that wrote its rows says nothing: {gaps:?}"
+    );
+
+    let written = std::fs::read_to_string(&manifest).expect("read back");
+    let parsed: toml::Value = toml::from_str(&written).expect("still valid TOML");
+    let declared = parsed["report"]["findings"]
+        .as_array()
+        .expect("findings were declared");
+    assert_eq!(declared.len(), 3, "{written}");
+
+    let first = &declared[0];
+    assert_eq!(first["category"].as_str(), Some("dependencies"));
+    assert_eq!(first["id"].as_str(), Some("RUSTSEC-2024-0421"));
+    assert_eq!(first["package"].as_str(), Some("idna"));
+    assert_eq!(first["version"].as_str(), Some("0.5.0"));
+    assert_eq!(first["severity"].as_str(), Some("RED"));
+    assert!(
+        first["title"]
+            .as_str()
+            .expect("a title")
+            .contains("Punycode")
+    );
+    assert!(
+        first["url"]
+            .as_str()
+            .expect("a url")
+            .starts_with("https://")
+    );
+
+    assert_eq!(
+        parsed["repositories"].as_array().expect("array").len(),
+        1,
+        "the repository list this crate does not own is untouched: {written}"
+    );
+}
+
+/// A sweep resumed over a manifest it already wrote must not restate a row —
+/// the same rule `priority::write_into` applies to `[report].gaps`.
+#[test]
+fn a_resumed_sweep_does_not_duplicate_a_row() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let manifest = manifest_at(tmp.path());
+    let rows = parse(FIXTURE).expect("parses");
+
+    write_into(&manifest, &rows).expect("first write");
+    write_into(&manifest, &rows).expect("second write");
+
+    let written = std::fs::read_to_string(&manifest).expect("read back");
+    let parsed: toml::Value = toml::from_str(&written).expect("valid TOML");
+    assert_eq!(
+        parsed["report"]["findings"]
+            .as_array()
+            .expect("array")
+            .len(),
+        3,
+        "{written}"
+    );
+}
+
+#[test]
+fn a_manifest_that_cannot_be_read_is_a_named_gap() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let checkout = locked_checkout(tmp.path());
+    let manifest = tmp.path().join("nowhere").join("manifest.toml");
+
+    let gaps = ground_into_with(&manifest, &checkout, "acme-api", returns(true, FIXTURE, ""));
+    assert_eq!(gaps.len(), 1, "{gaps:?}");
+    assert!(gaps[0].contains("could not be read"), "{}", gaps[0]);
+    assert!(
+        gaps[0].contains("3 advisory/ies"),
+        "the gap states what was lost: {}",
+        gaps[0]
+    );
+}

--- a/crates/trusty-audit/testdata/cargo-audit.json
+++ b/crates/trusty-audit/testdata/cargo-audit.json
@@ -1,0 +1,60 @@
+{
+  "database": { "advisory-count": 812, "last-commit": "0000000000000000000000000000000000000000" },
+  "lockfile": { "dependency-count": 3 },
+  "settings": { "target_arch": null, "target_os": null },
+  "vulnerabilities": {
+    "found": true,
+    "count": 1,
+    "list": [
+      {
+        "advisory": {
+          "id": "RUSTSEC-2024-0421",
+          "package": "idna",
+          "title": "`idna` accepts Punycode labels that do not produce any non-ASCII when decoded",
+          "description": "A long description cargo-audit also emits; the collector does not carry it.",
+          "date": "2024-12-09",
+          "aliases": ["CVE-2024-12224"],
+          "cvss": null,
+          "informational": null,
+          "url": "https://github.com/servo/rust-url/pull/1017",
+          "withdrawn": null
+        },
+        "versions": { "patched": [">=1.0.0"], "unaffected": [] },
+        "affected": null,
+        "package": {
+          "name": "idna",
+          "version": "0.5.0",
+          "source": "registry+https://github.com/rust-lang/crates.io-index"
+        }
+      }
+    ]
+  },
+  "warnings": {
+    "unmaintained": [
+      {
+        "kind": "unmaintained",
+        "package": { "name": "atk", "version": "0.18.2" },
+        "advisory": {
+          "id": "RUSTSEC-2024-0413",
+          "package": "atk",
+          "title": "gtk-rs GTK3 bindings - no longer maintained",
+          "date": "2024-03-04",
+          "cvss": null,
+          "informational": "unmaintained",
+          "url": "https://github.com/gtk-rs/gtk3-rs/commit/508a69b6"
+        },
+        "affected": null,
+        "versions": null
+      }
+    ],
+    "yanked": [
+      {
+        "kind": "yanked",
+        "package": { "name": "ghost-crate", "version": "1.0.1" },
+        "advisory": null,
+        "affected": null,
+        "versions": null
+      }
+    ]
+  }
+}

--- a/crates/trusty-review/Cargo.toml
+++ b/crates/trusty-review/Cargo.toml
@@ -92,7 +92,7 @@ name        = "trusty-review"
 # to `report::index_registry` under #6677), and `trait_method_added` for
 # `SearchClient::index_status` (src/integrations/search_client.rs:229), which an
 # out-of-tree implementor of the trait would have to add.
-version     = "0.33.0"
+version     = "0.33.1"
 edition     = "2024"
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/trusty-review/changelog.d/6075-cargo-audit-collector.md
+++ b/crates/trusty-review/changelog.d/6075-cargo-audit-collector.md
@@ -1,0 +1,11 @@
+Added
+
+- The report manifest carries `[report].findings`, and a report that declares
+  any renders a new Assurance Scans section — one table per collector category,
+  worst band first, each row linked to its advisory (#6075). `trusty-audit`'s
+  cargo-audit collector is the first producer; the license and secrets
+  collectors of #6076/#6077 reuse the same key under a different `category`.
+- The Security Posture disclaimer is narrowed rather than dropped: it still
+  denies a SAST result, a license review, a secrets scan and a penetration
+  test, and now points at Assurance Scans for dependency CVE exposure instead
+  of denying that a CVE scan exists.

--- a/crates/trusty-review/src/report/assurance.rs
+++ b/crates/trusty-review/src/report/assurance.rs
@@ -1,0 +1,161 @@
+//! The Assurance Scans section: deterministic scanner output (#6075, epic #6074).
+//!
+//! Why: the report named CVE exposure, license risk and secret leakage as
+//! assurance gaps it does not fill, and that was true only because nothing
+//! reached this crate with the answer. `trusty-audit` now runs the scanners and
+//! declares their rows in the manifest (owner ruling 2026-08-19: the collectors
+//! live there, the manifest is the interface). This module is the consumer —
+//! without it the rows land in a file nothing renders, which is the same
+//! silence one file further along.
+//!
+//! What: [`report_section`], a pure `model → string` transform appended after
+//! polish, exactly as `super::investigate::report_sections` is. Appending
+//! rather than filling a template placeholder is what keeps the rows out of the
+//! omit-empty pass, which would drop a table it does not recognise, and what
+//! keeps the section absent from every report whose manifest declares nothing.
+//!
+//! ## Why the rows are rendered rather than summarised
+//!
+//! They are a scanner's own output, not synthesis. The renderer reorders them
+//! by band and groups them by collector, and changes nothing else — an id, a
+//! version and a title the tool stated reach the page as the tool stated them.
+//!
+//! Test: `assurance_tests.rs`.
+
+use crate::report::manifest::ManifestFinding;
+use crate::report::model::ReportModel;
+use crate::report::provenance::MEASURED_TAG;
+
+/// The heading this section renders under, and the one the disclaimers point at.
+pub const HEADING: &str = "Assurance Scans";
+
+/// Render the Assurance Scans section, or `""` when nothing was scanned.
+///
+/// Why: a report whose manifest declares no findings must be byte-identical to
+/// one produced before this section existed — a heading over an empty table
+/// would read as a scan that found nothing, which is the false clean claim this
+/// whole epic exists to remove. A producer that scanned and found nothing says
+/// so in Gaps & Caveats instead, so the empty case here genuinely means "no
+/// collector ran".
+/// What: one `###` subsection per collector category, in the order the
+/// categories first appear, each a table sorted RED band first and then by the
+/// order the collector reported. Rows are rendered verbatim; nothing is
+/// dropped, capped, or re-worded.
+/// Test: `assurance_tests::{a_declared_finding_reaches_the_report,
+/// no_findings_render_nothing_at_all}`.
+#[must_use]
+pub fn report_section(model: &ReportModel) -> String {
+    if model.findings.is_empty() {
+        return String::new();
+    }
+    let mut out = format!("\n\n## {HEADING}\n\n");
+    out.push_str(&format!(
+        "_Deterministic scanner output collected against the target repositories{MEASURED_TAG}, \
+         recorded verbatim. These rows are tool findings, not the LLM's readings that populate \
+         Security Posture. A scan that did not run is named under Gaps & Caveats rather than \
+         omitted here._\n",
+    ));
+    for category in categories(&model.findings) {
+        out.push_str(&format!("\n### {}\n\n", subsection_title(category)));
+        out.push_str(&table(&model.findings, category));
+    }
+    out
+}
+
+/// The collector categories present, in the order they first appear.
+///
+/// First-appearance order rather than alphabetical: the producer writes its
+/// collectors in the order it ran them, and a reader following the report is
+/// better served by that than by an ordering neither side chose.
+fn categories(findings: &[ManifestFinding]) -> Vec<&str> {
+    let mut seen: Vec<&str> = Vec::new();
+    for finding in findings {
+        let category = finding.category.trim();
+        if !seen.contains(&category) {
+            seen.push(category);
+        }
+    }
+    seen
+}
+
+/// The heading one collector's subsection renders under.
+///
+/// The three categories epic #6074 defines get a name a due-diligence reader
+/// recognises; anything else is titled by its own category string, so a
+/// collector added after this crate was built still renders rather than
+/// arriving under a wrong label.
+fn subsection_title(category: &str) -> String {
+    match category {
+        "dependencies" => "Dependency CVE Exposure".to_string(),
+        "license" => "License / IP Exposure".to_string(),
+        "secrets" => "Secret Leakage".to_string(),
+        "" => "Uncategorised Findings".to_string(),
+        other => other.to_string(),
+    }
+}
+
+/// One collector's findings as a markdown table, worst band first.
+fn table(findings: &[ManifestFinding], category: &str) -> String {
+    let mut rows: Vec<&ManifestFinding> = findings
+        .iter()
+        .filter(|f| f.category.trim() == category)
+        .collect();
+    // A stable sort, so within a band the collector's own order survives.
+    rows.sort_by_key(|f| band_rank(&f.severity));
+
+    let mut out = String::from("| Finding | Component | Version | Severity | Summary |\n");
+    out.push_str("|---|---|---|---|---|\n");
+    for row in rows {
+        out.push_str(&format!(
+            "| {} | {} | {} | {} | {} |\n",
+            linked(row),
+            cell(&row.package),
+            cell(&row.version),
+            cell(&row.severity),
+            cell(&row.title),
+        ));
+    }
+    out
+}
+
+/// Sort key: RED before AMBER before every band this crate does not recognise.
+///
+/// An unrecognised band sorts last rather than erroring — the producer owns the
+/// vocabulary, and a band added later must still render.
+fn band_rank(severity: &str) -> u8 {
+    match severity.trim().to_ascii_uppercase().as_str() {
+        "RED" => 0,
+        "AMBER" => 1,
+        _ => 2,
+    }
+}
+
+/// The finding cell: its id, linked when the collector supplied a URL.
+fn linked(finding: &ManifestFinding) -> String {
+    let id = cell(&finding.id);
+    match finding
+        .url
+        .as_deref()
+        .map(str::trim)
+        .filter(|u| !u.is_empty())
+    {
+        Some(url) => format!("[{id}]({url})"),
+        None => id,
+    }
+}
+
+/// One cell, with the pipes that would break the table escaped.
+///
+/// An advisory title is upstream prose and may contain anything; an unescaped
+/// `|` silently splits the row into the wrong columns.
+fn cell(value: &str) -> String {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return "—".to_string();
+    }
+    trimmed.replace('|', "\\|").replace('\n', " ")
+}
+
+#[cfg(test)]
+#[path = "assurance_tests.rs"]
+mod assurance_tests;

--- a/crates/trusty-review/src/report/assurance_tests.rs
+++ b/crates/trusty-review/src/report/assurance_tests.rs
@@ -1,0 +1,181 @@
+//! Tests for the Assurance Scans section (#6075).
+//!
+//! Why: the section exists to stop a false clean claim, so both directions need
+//! pinning — a declared finding must reach the rendered report, and a manifest
+//! declaring none must leave the report byte-identical to one produced before
+//! the section existed.
+//! What: the end-to-end render through `Reporter::render`, the empty case, the
+//! band ordering, the per-collector grouping #6076/#6077 reuse, and the cell
+//! escaping an upstream advisory title can break.
+//! Test: this file.
+
+use std::path::Path;
+
+use super::report_section;
+use crate::report::Reporter;
+use crate::report::manifest::parse_manifest;
+use crate::report::model::ReportModel;
+use crate::report::template::TemplateLoader;
+
+/// A manifest declaring `count` assurance findings, plus one repository.
+fn manifest_declaring(findings: &str) -> String {
+    format!(
+        "[report]\ntitle = \"Acme Due Diligence\"\n{findings}\n\n\
+         [[repositories]]\nname = \"Acme Web\"\npath = \"/nonexistent/acme-web\"\n"
+    )
+}
+
+fn model_from(dir: &Path, toml: &str) -> ReportModel {
+    let manifest_path = dir.join("manifest.toml");
+    let manifest = parse_manifest(toml, &manifest_path).expect("manifest parse");
+    ReportModel::build(&manifest, &manifest_path, "report-technical-dd", None).expect("model")
+}
+
+/// One `cargo audit` row, as `trusty_audit::grounding::cve::write_into` spells it.
+const CVE_ROW: &str = "findings = [\n  { category = \"dependencies\", id = \"RUSTSEC-2024-0421\", \
+     package = \"idna\", version = \"0.5.0\", severity = \"RED\", \
+     title = \"Punycode labels that decode to pure ASCII\", \
+     url = \"https://rustsec.org/advisories/RUSTSEC-2024-0421.html\" },\n]";
+
+/// The deliverable: a finding trusty-audit wrote into the manifest reaches the
+/// report an acquirer reads. Fails before #6075 — the key parsed nowhere and
+/// nothing rendered it.
+#[test]
+fn a_declared_finding_reaches_the_report() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let model = model_from(tmp.path(), &manifest_declaring(CVE_ROW));
+    let template = TemplateLoader::bundled_only()
+        .load("report-technical-dd")
+        .expect("bundled template");
+    let md = Reporter::new(tmp.path()).render(&model, &template);
+
+    assert!(md.contains("## Assurance Scans"), "{md}");
+    assert!(md.contains("### Dependency CVE Exposure"), "{md}");
+    assert!(md.contains("RUSTSEC-2024-0421"), "{md}");
+    assert!(md.contains("idna"), "{md}");
+    assert!(md.contains("0.5.0"), "{md}");
+    assert!(md.contains("RED"), "{md}");
+    assert!(
+        md.contains("Punycode labels that decode to pure ASCII"),
+        "{md}"
+    );
+    assert!(
+        md.contains("https://rustsec.org/advisories/RUSTSEC-2024-0421.html"),
+        "the advisory is linked so a reader can verify it: {md}"
+    );
+}
+
+/// The narrowed disclaimer must point at the section that now carries the
+/// answer, and must still deny everything the run genuinely does not cover.
+#[test]
+fn the_security_disclaimer_is_narrowed_rather_than_dropped() {
+    let instruction = crate::report::section_instructions::default_instruction(
+        crate::report::section_instructions::SECURITY_SUMMARY,
+    )
+    .expect("the security summary carries an instruction");
+
+    assert!(
+        instruction.contains("Assurance Scans"),
+        "it points at the section that now reports CVE exposure: {instruction}"
+    );
+    for still_uncovered in ["SAST", "license review", "secrets scan", "penetration test"] {
+        assert!(
+            instruction.contains(still_uncovered),
+            "`{still_uncovered}` is still not covered and must still be disclaimed: {instruction}"
+        );
+    }
+    assert!(
+        !instruction.contains("SAST/CVE/secrets/pen-test"),
+        "the blanket denial is gone: {instruction}"
+    );
+}
+
+/// A report whose manifest declares nothing is byte-identical to one produced
+/// before this section existed — a heading over an empty table would read as a
+/// scan that found nothing.
+#[test]
+fn no_findings_render_nothing_at_all() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let model = model_from(tmp.path(), &manifest_declaring(""));
+    assert_eq!(report_section(&model), "");
+}
+
+/// RED before AMBER, whatever order the collector reported them in.
+#[test]
+fn the_worst_band_leads_the_table() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let model = model_from(
+        tmp.path(),
+        &manifest_declaring(
+            "findings = [\n  { category = \"dependencies\", id = \"W-1\", package = \"atk\", \
+             version = \"0.18.2\", severity = \"AMBER\", title = \"unmaintained\" },\n  \
+             { category = \"dependencies\", id = \"V-1\", package = \"idna\", version = \"0.5.0\", \
+             severity = \"RED\", title = \"exploitable\" },\n]",
+        ),
+    );
+    let section = report_section(&model);
+    let red = section.find("V-1").expect("the RED row renders");
+    let amber = section.find("W-1").expect("the AMBER row renders");
+    assert!(red < amber, "{section}");
+}
+
+/// The channel #6076 and #6077 reuse: a second category becomes its own
+/// subsection rather than being folded into the CVE table.
+#[test]
+fn a_second_category_gets_its_own_subsection() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let model = model_from(
+        tmp.path(),
+        &manifest_declaring(
+            "findings = [\n  { category = \"dependencies\", id = \"V-1\", package = \"idna\", \
+             version = \"0.5.0\", severity = \"RED\", title = \"exploitable\" },\n  \
+             { category = \"secrets\", id = \"S-1\", package = \"src/auth.rs\", version = \"—\", \
+             severity = \"RED\", title = \"AWS key literal\" },\n]",
+        ),
+    );
+    let section = report_section(&model);
+    assert!(section.contains("### Dependency CVE Exposure"), "{section}");
+    assert!(section.contains("### Secret Leakage"), "{section}");
+    assert!(section.contains("S-1"), "{section}");
+}
+
+/// An advisory title is upstream prose. An unescaped pipe silently shifts every
+/// later cell into the wrong column, which is worse than a missing row.
+#[test]
+fn a_pipe_in_an_advisory_title_does_not_break_the_table() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let model = model_from(
+        tmp.path(),
+        &manifest_declaring(
+            "findings = [{ category = \"dependencies\", id = \"V-1\", package = \"p\", \
+             version = \"1.0\", severity = \"RED\", title = \"a | b\" }]",
+        ),
+    );
+    let section = report_section(&model);
+    let row = section
+        .lines()
+        .find(|line| line.contains("V-1"))
+        .expect("the row renders");
+    assert!(row.contains("a \\| b"), "{row}");
+    assert_eq!(
+        row.match_indices(" | ").count(),
+        4,
+        "five columns, four separators: {row}"
+    );
+}
+
+/// A row with no URL renders its id as plain text rather than an empty link.
+#[test]
+fn a_finding_with_no_url_renders_a_bare_id() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let model = model_from(
+        tmp.path(),
+        &manifest_declaring(
+            "findings = [{ category = \"dependencies\", id = \"YANKED\", package = \"ghost\", \
+             version = \"1.0.1\", severity = \"AMBER\", title = \"withdrawn from the registry\" }]",
+        ),
+    );
+    let section = report_section(&model);
+    assert!(section.contains("| YANKED |"), "{section}");
+    assert!(!section.contains("]()"), "no empty link: {section}");
+}

--- a/crates/trusty-review/src/report/figures_tests.rs
+++ b/crates/trusty-review/src/report/figures_tests.rs
@@ -37,6 +37,7 @@ fn model_with(repos: Vec<RepositoryReport>) -> ReportModel {
         manifest_path: "manifest.toml".to_string(),
         repositories: repos,
         gaps: vec![],
+        findings: Vec::new(),
         synthesis: None,
         benchmark: None,
         investigation: None,

--- a/crates/trusty-review/src/report/investigate/render_tests.rs
+++ b/crates/trusty-review/src/report/investigate/render_tests.rs
@@ -32,6 +32,7 @@ fn empty_model() -> crate::report::model::ReportModel {
         manifest_path: "manifest.toml".to_string(),
         repositories: Vec::new(),
         gaps: Vec::new(),
+        findings: Vec::new(),
         synthesis: None,
         benchmark: None,
         investigation: None,

--- a/crates/trusty-review/src/report/manifest.rs
+++ b/crates/trusty-review/src/report/manifest.rs
@@ -6,7 +6,7 @@
 //! `thiserror` loader means every malformed manifest fails loudly with a
 //! correctable message instead of silently producing an empty report.
 //! What: defines [`Manifest`], [`ReportSection`], [`RepositoryEntry`],
-//! [`InspectionPriority`], and the [`RepositorySource`] enum, plus
+//! [`InspectionPriority`], [`ManifestFinding`], and the [`RepositorySource`] enum, plus
 //! [`load_manifest`] which reads TOML, validates the exactly-one-of
 //! `path`/`remote` rule, and returns a resolved `Manifest`.  Per-repository
 //! `inspect_priority` (#6078) is the stable interface an external ranker writes
@@ -212,6 +212,23 @@ pub struct ReportSection {
     /// Test: `manifest_tests.rs::parse_declared_gaps`.
     #[serde(default)]
     pub gaps: Vec<String>,
+    /// Deterministic assurance-scan findings the producer collected (#6075).
+    ///
+    /// Why: `gaps`'s twin. An upstream orchestrator that ran a real scanner
+    /// against the target — `cargo audit` for #6075, and the license and
+    /// secrets scanners of #6076/#6077 next — holds results nothing inside
+    /// trusty-review can observe, and until this key existed it had nowhere to
+    /// put them. The report therefore disclaimed CVE exposure as an assurance
+    /// gap over a scan that had in fact run.
+    /// What: zero or more [`ManifestFinding`] rows, rendered as the report's
+    /// Assurance Scans section. Absent — the default, and every hand-written
+    /// manifest — leaves output byte-identical to a manifest without the key.
+    /// An EMPTY array is never written by a producer, so absence and "the scan
+    /// found nothing" do not have to be told apart here: a scan that ran clean
+    /// says so in `gaps`.
+    /// Test: `manifest_tests.rs::parse_declared_findings`.
+    #[serde(default)]
+    pub findings: Vec<ManifestFinding>,
     /// Optional path to the run's ticketing artifact (#5405).
     ///
     /// Why: `tga audit` correlates commits against the board items it synced,
@@ -260,6 +277,48 @@ pub struct ReportSection {
     /// Test: `manifest_tests.rs::parse_analyze_timeout_secs`.
     #[serde(default)]
     pub analyze_timeout_secs: Option<u64>,
+}
+
+/// One deterministic finding an external assurance collector recorded (#6075).
+///
+/// Why: the report's Security Posture paragraph is an LLM's reading of selected
+/// source files, and it disclaimed CVE exposure because nothing in this crate
+/// could measure it. `trusty-audit` can — it runs `cargo audit` against the
+/// target and writes the rows here (owner ruling 2026-08-19: the collectors run
+/// from trusty-audit, the manifest is the interface). This is the channel the
+/// rest of epic #6074 reuses: #6076's license rows and #6077's secrets rows
+/// arrive in the same array under a different `category`.
+/// What: `category` groups the rendered tables (`dependencies` for #6075);
+/// `id`, `package`, `version`, `severity` and `title` are the row; `url` is
+/// where to read the advisory when the collector knew one. `severity` is the
+/// producer's own band string, rendered verbatim rather than parsed — a band
+/// this crate does not recognise must still reach the page.
+/// Test: `manifest_tests.rs::parse_declared_findings`;
+/// `assurance_tests.rs::a_declared_finding_reaches_the_report`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[non_exhaustive]
+pub struct ManifestFinding {
+    /// Which collector produced it — `dependencies`, `license`, `secrets`.
+    #[serde(default)]
+    pub category: String,
+    /// The finding's identifier, e.g. `RUSTSEC-2024-0421`.
+    #[serde(default)]
+    pub id: String,
+    /// The affected component.
+    #[serde(default)]
+    pub package: String,
+    /// The version the target pins.
+    #[serde(default)]
+    pub version: String,
+    /// The producer's severity band, e.g. `RED` / `AMBER`.
+    #[serde(default)]
+    pub severity: String,
+    /// One-line summary of the finding.
+    #[serde(default)]
+    pub title: String,
+    /// Where to read it, when the producer knew.
+    #[serde(default)]
+    pub url: Option<String>,
 }
 
 /// The weight the FIRST unweighted `inspect_priority` entry receives (#6078).

--- a/crates/trusty-review/src/report/manifest_tests.rs
+++ b/crates/trusty-review/src/report/manifest_tests.rs
@@ -189,6 +189,58 @@ fn parse_declared_gaps() {
     assert!(none.report.gaps.is_empty(), "absent key defaults to empty");
 }
 
+/// Why: #6075 — `gaps`'s twin. An assurance collector's rows reach the report
+/// only through this key, and a manifest declaring none must behave exactly as
+/// it did before the key existed.
+/// Test: itself.
+#[test]
+fn parse_declared_findings() {
+    let m = parse_manifest(
+        "[report]\ntitle = \"T\"\nfindings = [\n  { category = \"dependencies\", \
+         id = \"RUSTSEC-2024-0421\", package = \"idna\", version = \"0.5.0\", \
+         severity = \"RED\", title = \"Punycode labels\", \
+         url = \"https://rustsec.org/advisories/RUSTSEC-2024-0421.html\" },\n]\n\n\
+         [[repositories]]\nname = \"A\"\npath = \"/x\"\n",
+        Path::new("m.toml"),
+    )
+    .expect("parses");
+    assert_eq!(m.report.findings.len(), 1);
+    let row = &m.report.findings[0];
+    assert_eq!(row.category, "dependencies");
+    assert_eq!(row.id, "RUSTSEC-2024-0421");
+    assert_eq!(row.package, "idna");
+    assert_eq!(row.version, "0.5.0");
+    assert_eq!(row.severity, "RED");
+    assert_eq!(row.title, "Punycode labels");
+    assert!(row.url.as_deref().expect("a url").starts_with("https://"));
+
+    let none = parse_manifest(
+        "[report]\ntitle = \"T\"\n\n[[repositories]]\nname = \"A\"\npath = \"/x\"\n",
+        Path::new("m.toml"),
+    )
+    .expect("parses");
+    assert!(
+        none.report.findings.is_empty(),
+        "absent key defaults to empty"
+    );
+}
+
+/// A row missing every optional field still parses: the producer owns the
+/// vocabulary, and a partially-written row must render rather than fail the
+/// whole manifest — the same rule `FunctionHotspot` follows.
+#[test]
+fn a_partial_finding_row_still_parses() {
+    let m = parse_manifest(
+        "[report]\ntitle = \"T\"\nfindings = [{ id = \"X-1\" }]\n\n\
+         [[repositories]]\nname = \"A\"\npath = \"/x\"\n",
+        Path::new("m.toml"),
+    )
+    .expect("parses");
+    assert_eq!(m.report.findings[0].id, "X-1");
+    assert!(m.report.findings[0].url.is_none());
+    assert!(m.report.findings[0].category.is_empty());
+}
+
 /// #5405: the ticketing artifact rides on `[report]`, and `metrics` rides on a
 /// repository entry. The fixture declares both, so each must land in its own
 /// field with the other's value untouched — `metrics` is asserted nowhere else

--- a/crates/trusty-review/src/report/methodology_tests.rs
+++ b/crates/trusty-review/src/report/methodology_tests.rs
@@ -42,6 +42,7 @@ fn model_with(repos: Vec<RepositoryReport>) -> ReportModel {
         manifest_path: "manifest.toml".to_string(),
         repositories: repos,
         gaps: vec![],
+        findings: Vec::new(),
         synthesis: None,
         benchmark: None,
         investigation: None,

--- a/crates/trusty-review/src/report/mod.rs
+++ b/crates/trusty-review/src/report/mod.rs
@@ -22,6 +22,8 @@ pub mod analyze_endpoints;
 // #6082: the per-finding half of the analyze mapping, split out under the cap.
 pub(crate) mod analyze_findings;
 pub mod analyze_scope;
+// #6075: rendering the assurance-scan rows trusty-audit declares in the manifest.
+pub mod assurance;
 // #5453/#6004: the tga-authored authorship artifact, receiving half.
 pub mod authorship;
 pub mod benchmark;
@@ -115,8 +117,8 @@ pub use investigate::{
     Budget, Investigation, InvestigationStatus, RepoInvestigation, run_investigation,
 };
 pub use manifest::{
-    Manifest, ReportSection, RepositoryEntry, RepositorySource, load_manifest, parse_manifest,
-    slugify,
+    Manifest, ManifestFinding, ReportSection, RepositoryEntry, RepositorySource, load_manifest,
+    parse_manifest, slugify,
 };
 pub use mermaid::inject as inject_mermaid;
 pub use methodology::analysis_methodology;

--- a/crates/trusty-review/src/report/model.rs
+++ b/crates/trusty-review/src/report/model.rs
@@ -204,6 +204,19 @@ pub struct ReportModel {
     /// `polish_tests.rs::declared_gaps_render_as_bullets`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub gaps: Vec<String>,
+    /// Deterministic assurance-scan findings the manifest declared (#6075).
+    ///
+    /// Why: `gaps`'s twin, and it travels the same way. The rows come from a
+    /// scanner that ran BEFORE this process (`cargo audit`, via trusty-audit),
+    /// so they reach the renderer only by riding the model — and recording them
+    /// here keeps the JSON twin a faithful record of what the assurance section
+    /// was built from.
+    /// What: seeded from the manifest's `[report].findings` and never appended
+    /// to at run time; this crate runs no scanner of its own. Empty is the
+    /// common case and renders exactly as before.
+    /// Test: `assurance_tests.rs::a_declared_finding_reaches_the_report`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub findings: Vec<super::manifest::ManifestFinding>,
     /// The verified LLM synthesis result.
     ///
     /// Why: recording it on the model keeps the JSON twin a faithful record of
@@ -409,6 +422,8 @@ impl ReportModel {
             // report; the analyze pass appends its named gaps to the same list.
             // #5453/#6004: per-repository authorship-load failures joined in above.
             gaps,
+            // #6075: the collector's rows, as the producer wrote them.
+            findings: manifest.report.findings.clone(),
             synthesis: None,
             benchmark: None,
             investigation: None,

--- a/crates/trusty-review/src/report/reporter.rs
+++ b/crates/trusty-review/src/report/reporter.rs
@@ -176,6 +176,9 @@ impl Reporter {
         // sections, plus the rejected-evidence note, are appended after polish so
         // their measured/inferred rows are never subject to omit-empty.
         out.push_str(&super::investigate::report_sections(model));
+        // #6075: the assurance-scan rows the manifest declared, appended for the
+        // same reason — a scanner's table must never be subject to omit-empty.
+        out.push_str(&super::assurance::report_section(model));
         // #6082 lap 7: the template signs off at its own end, which is no longer
         // the document's — three sections are appended above. Move the signature
         // down so nothing follows it.

--- a/crates/trusty-review/src/report/reporter_authorship_tests.rs
+++ b/crates/trusty-review/src/report/reporter_authorship_tests.rs
@@ -36,6 +36,7 @@ fn model_with(repos: Vec<RepositoryReport>) -> ReportModel {
         manifest_path: "manifest.toml".to_string(),
         repositories: repos,
         gaps: vec![],
+        findings: Vec::new(),
         synthesis: None,
         benchmark: None,
         investigation: None,

--- a/crates/trusty-review/src/report/reporter_codesec_tests.rs
+++ b/crates/trusty-review/src/report/reporter_codesec_tests.rs
@@ -39,6 +39,7 @@ fn model_with(repos: Vec<RepositoryReport>) -> ReportModel {
         manifest_path: "manifest.toml".to_string(),
         repositories: repos,
         gaps: vec![],
+        findings: Vec::new(),
         synthesis: None,
         benchmark: None,
         investigation: None,

--- a/crates/trusty-review/src/report/reporter_facts_tests.rs
+++ b/crates/trusty-review/src/report/reporter_facts_tests.rs
@@ -50,6 +50,7 @@ fn model_with(repos: Vec<RepositoryReport>) -> ReportModel {
         manifest_path: "manifest.toml".to_string(),
         repositories: repos,
         gaps: vec![],
+        findings: Vec::new(),
         synthesis: None,
         benchmark: None,
         investigation: None,

--- a/crates/trusty-review/src/report/reporter_performance_tests.rs
+++ b/crates/trusty-review/src/report/reporter_performance_tests.rs
@@ -35,6 +35,7 @@ fn model_with(findings: Vec<MetricFinding>) -> ReportModel {
             crate_topology: None,
         }],
         gaps: vec![],
+        findings: Vec::new(),
         synthesis: None,
         benchmark: None,
         investigation: None,

--- a/crates/trusty-review/src/report/section_instructions.rs
+++ b/crates/trusty-review/src/report/section_instructions.rs
@@ -123,14 +123,21 @@ pub fn default_instruction(id: &str) -> Option<&'static str> {
             // They are an LLM's readings of source files with every quote
             // mechanically verified — which the disclaimer directly above this
             // paragraph says correctly, so the paragraph contradicted it.
+            // #6075: the disclaimer used to deny a CVE scan outright. The audit
+            // runs one now and its rows render under Assurance Scans, so the
+            // denial is narrowed to what is still uncovered rather than dropped.
             "Write ONE paragraph characterising the security posture strictly from the \
              RED/AMBER findings provided — an LLM's readings of the source files that \
              were inspected, each with its evidence quote verified against the file it \
-             cites. This is code-hygiene signal, NOT a SAST/CVE/secrets/pen-test result \
+             cites. This is code-hygiene signal, NOT a SAST result, NOT a license \
+             review, NOT a secrets scan of the whole tree, and NOT a penetration test \
              — never write as though it were, and never call it lint output; state that \
-             limitation if it changes how a risk should be read. Take the acquirer's \
-             skeptical side while still crediting a genuinely clean signal where the data \
-             supports it.",
+             limitation if it changes how a risk should be read. Dependency CVE exposure \
+             is NOT this section's subject either: where the run scanned for it, its \
+             findings are reported under Assurance Scans, and where it did not, Gaps & \
+             Caveats says so — do not restate or contradict either here. Take the \
+             acquirer's skeptical side while still crediting a genuinely clean signal \
+             where the data supports it.",
         ),
         AUTHORSHIP_SUMMARY => Some(
             "Write ONE high-level paragraph on the codebase's health from an authorship \

--- a/crates/trusty-review/src/report/synthesize_digest_tests.rs
+++ b/crates/trusty-review/src/report/synthesize_digest_tests.rs
@@ -63,6 +63,7 @@ fn model_with(repos: Vec<RepositoryReport>, investigation: Option<Investigation>
         manifest_path: "m.toml".to_string(),
         repositories: repos,
         gaps: Vec::new(),
+        findings: Vec::new(),
         synthesis: None,
         benchmark: None,
         investigation,

--- a/crates/trusty-review/src/report/synthesize_grounding_tests.rs
+++ b/crates/trusty-review/src/report/synthesize_grounding_tests.rs
@@ -106,6 +106,7 @@ fn model_with(repos: Vec<RepositoryReport>) -> ReportModel {
         manifest_path: "manifest.toml".to_string(),
         repositories: repos,
         gaps: vec![],
+        findings: Vec::new(),
         synthesis: None,
         benchmark: None,
         investigation: None,

--- a/crates/trusty-review/src/report/synthesize_prompt.rs
+++ b/crates/trusty-review/src/report/synthesize_prompt.rs
@@ -192,9 +192,12 @@ pub(crate) fn synthesis_schema(top_risks_cap: usize, findings_cap: usize) -> Res
                     "type": "string",
                     "description": "ONE paragraph on code quality and architecture, grounded ONLY in the complexity/findings/LoC data provided. Empty string if the data supports nothing."
                 },
+                // #6075: narrowed, not dropped — the audit's cargo-audit
+                // collector reports dependency CVE exposure under Assurance
+                // Scans, so this paragraph no longer denies that a scan exists.
                 "security_summary": {
                     "type": "string",
-                    "description": "ONE paragraph characterising security posture from the evidence-inspected RED/AMBER findings ONLY — this is code-hygiene signal, not lint output and not a SAST/CVE/secrets scan. Empty string if the data supports nothing."
+                    "description": "ONE paragraph characterising security posture from the evidence-inspected RED/AMBER findings ONLY — this is code-hygiene signal, not lint output, not a SAST scan, not a license review, not a secrets scan and not a penetration test. Dependency CVE exposure belongs to the Assurance Scans section, not here. Empty string if the data supports nothing."
                 },
                 // #5453/#6004: high-level authorship/key-person-risk narrative slot.
                 "authorship_summary": {

--- a/crates/trusty-review/src/report/synthesize_tests.rs
+++ b/crates/trusty-review/src/report/synthesize_tests.rs
@@ -186,6 +186,7 @@ fn fixture_model(findings: Vec<MetricFinding>) -> ReportModel {
             crate_topology: None,
         }],
         gaps: Vec::new(),
+        findings: Vec::new(),
         synthesis: None,
         benchmark: None,
         investigation: None,

--- a/crates/trusty-review/src/report/topology_tests.rs
+++ b/crates/trusty-review/src/report/topology_tests.rs
@@ -59,6 +59,7 @@ fn model_with(repos: Vec<RepositoryReport>) -> ReportModel {
         manifest_path: "manifest.toml".to_string(),
         repositories: repos,
         gaps: vec![],
+        findings: Vec::new(),
         synthesis: None,
         benchmark: None,
         investigation: None,


### PR DESCRIPTION
## Outcome

Refs #6075 (epic #6074, collector 1 of 4). #6076 (license), #6077 (secrets), #6079 (churn) follow and reuse the `[report].findings` channel this PR adds.

## Changes

Per the 2026-08-19 ruling on #6074, the collector lives in trusty-audit: `src/grounding/cve.rs` resolves `cargo-audit` through `trusty_common::bin_resolve`, runs `cargo-audit audit --json` in the target checkout, and appends each advisory (`id, package, version, severity, title, url`) to `[report].findings` via `toml_edit`, deduped on id+package+version, mirroring `priority::write_into`. trusty-review gains `ManifestFinding` / `ReportSection.findings` (serde default; old manifests parse) and a new "Assurance Scans" section (RED band first, one subsection per category, pipes escaped). The CVE/secrets disclaimers in `section_instructions.rs` / `synthesize_prompt.rs` are narrowed, not removed. Engagement-package paths (`src/package/`, `templates/`) untouched.

## Risk

Collector surface: every failure path is a named `Manifest.gaps` line, never a silent zero. Coverage: binary missing (with install command), spawn error, non-zero exit with malformed JSON, unreadable manifest, non-Rust ecosystem (names language), Rust without lockfile. A non-zero exit with readable JSON is a successful scan. A repository with no dependency manifest of any recognised kind is a declared skip. An empty `findings = []` is never written.

## Tests

Rung 4 (trusty-review's manifest type changed). `cargo fmt --check`; `cargo check -p trusty-audit --all-targets`; `cargo clippy -p trusty-audit --all-targets -- -D warnings` and `-p trusty-review`; `cargo check --workspace --all-targets`; `cargo test -p trusty-audit --no-fail-fast` → 807 lib + 33 integration passed, 0 failed (16 new `cve` tests); `cargo test -p trusty-review --no-fail-fast` → 2155 lib + 112 passed, 0 failed (7 new `assurance` tests). Doc gates (line-cap, test-pointers, sld, changelog-fragment ×2) green.

## Baseline

None; change is isolated to trusty-audit and trusty-review.

## Docs

Bumps: trusty-audit 0.13.2 → 0.13.3, trusty-review 0.33.0 → 0.33.1; `check_semver.sh` 196/196 on both. Changelog fragments present for both crates.

## Review

code-critic APPROVE — Fail-Open Check walked every branch; the two error-arm tests assert the manifest is byte-identical after a failed scan.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
