### PR TITLE
fix(trusty-mcp): resolve rustdoc intra-doc link to the feature-gated bridge module (Refs #6316)

### DIFF
--- a/crates/trusty-mcp/changelog.d/6316-rustdoc-intra-doc-links.md
+++ b/crates/trusty-mcp/changelog.d/6316-rustdoc-intra-doc-links.md
@@ -1,0 +1,3 @@
+Fixed
+
+- **The crate-level doc no longer links a feature-gated module.** `lib.rs` described `daemon_bridge_json_rpc` with a `[bracketed]` intra-doc link, but that module is compiled only under `daemon-bridge-json-rpc` and this crate's default feature set is empty. `scripts/check_rustdoc_links.sh` runs `cargo doc` with DEFAULT features, so the link had no item to resolve against and `#![deny(rustdoc::broken_intra_doc_links)]` turned it into a hard error — the gate reported `trusty-mcp has 1 broken link(s) and no baseline row`. The module is now named in a plain code span, which reads the same with the feature on or off ([#6316](https://github.com/bobmatnyc/trusty-tools/issues/6316))

--- a/crates/trusty-mcp/src/lib.rs
+++ b/crates/trusty-mcp/src/lib.rs
@@ -11,7 +11,7 @@
 //! loop that accepts any `Fn(Request) -> Future<Output=Response>`.
 //!
 //! One capability is feature-gated: `daemon-bridge-json-rpc` compiles
-//! [`daemon_bridge_json_rpc`], the shared stdio↔UDS forwarder (#6316), and with
+//! `daemon_bridge_json_rpc`, the shared stdio↔UDS forwarder (#6316), and with
 //! it this crate's only `trusty-common` dependency. Off by default so the rlib
 //! every MCP server links stays as lean as ADR-0040 left it — see the README's
 //! Features table for the `cargo tree` proof that the edge is gated.
@@ -29,6 +29,11 @@
 // so a broken intra-doc link is baked into that version forever and only a new
 // release can correct it. Deny keeps this crate at zero rather than letting the
 // ratchet in `scripts/check_rustdoc_links.sh` absorb a new one.
+//
+// #6316: that ratchet runs `cargo doc` with DEFAULT features, and this crate's
+// default set is empty. A `[bracketed]` link to a `daemon-bridge-json-rpc`-gated
+// item therefore resolves only when the feature is on and is a hard error when
+// it is off, so gated items are named in plain code spans above.
 #![deny(rustdoc::broken_intra_doc_links)]
 
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
Follow-up to #6731. `crates/trusty-mcp/src/lib.rs` linked `daemon_bridge_json_rpc` with a bracketed intra-doc link, but that module is behind the non-default `daemon-bridge-json-rpc` feature and the crate denies `rustdoc::broken_intra_doc_links`, so `scripts/check_rustdoc_links.sh` (default features, workspace `cargo doc`) failed on the PR and on main at 8200a198f. The link is now a plain code span; a comment beside the `deny` records why.

Refs #6316

## Test rung

Rung 1-equivalent (doc comment + changelog fragment; no behaviour change).

```
bash scripts/check_rustdoc_links.sh        # GATE_EXIT=0 — 26 crates, 0 broken links
cargo doc -p trusty-mcp --no-deps --locked --all-features   # exit 0
cargo test -p trusty-mcp --all-features --no-fail-fast      # 37 + 9 + 7 passed, 0 failed
bash scripts/check_changelog_fragment.sh   # OK trusty-mcp
```

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
