### PR TITLE
feat(tga): fact_pm_effort table and v1 PM-effort scorer (Refs #3915)

### DIFF
--- a/crates/trusty-git-analytics/changelog.d/3915-fact-pm-effort.md
+++ b/crates/trusty-git-analytics/changelog.d/3915-fact-pm-effort.md
@@ -1,0 +1,27 @@
+Added
+
+- `tga backfill pm-effort` scores the complexity of every meaningful PM ticket
+  into the new `fact_pm_effort` table (#3915) — the EFFORT tier of the
+  Activity / Work / Effort model, above the `fact_pm_work` tier #3916 added.
+  The v1 formula (`formula_version = "pm-effort-1"`) sums a base of 1.0 with
+  five independently capped terms — child count, description length, comment
+  count, status-transition count and story points — into a 1.0–50.0 score,
+  bucketed LOW / MEDIUM / HIGH. Every weight, cap and boundary lives in one
+  `core::pm_effort::thresholds` block, because issue #3915 marks them all "TBD,
+  refine with product": a retune ships as a new `formula_version` string, never
+  as an edit of the v1 values, so a stored score always names the weight set
+  that produced it.
+- Two guards the raw formula does not provide. A ticket of a decomposable type
+  (epic, feature, initiative) younger than 7 days is recorded as
+  `DEFERRED_RECENT` with a NULL score rather than a low one — an epic filed
+  yesterday has no children because nobody has broken it down yet, not because
+  it is simple. And only tickets `fact_pm_work` marks meaningful are scored at
+  all: an excluded ticket gets no row, and one that later becomes excluded
+  loses the row an earlier run wrote.
+- Story points degrade rather than zero the score. They are 76% NULL across
+  four per-project custom-field IDs on the source JIRA instance, so the term is
+  simply dropped when absent, out of range, or unparseable, and the row's
+  `inputs_present` column names which terms actually fired. The offline
+  extractor reuses `JiraClient::get_story_point_field`'s discovery shape —
+  match by field name first, then fall back to the known ID list — because one
+  global lookup cannot cover four spellings.

--- a/crates/trusty-git-analytics/src/commands/backfill/mod.rs
+++ b/crates/trusty-git-analytics/src/commands/backfill/mod.rs
@@ -17,12 +17,14 @@
 //! - `flags`  — revert, ticket-ids, ticketed, ai-detection-commits, build SQL filter
 //! - `misc`   — reachability, complexity, top-level, quality
 //! - `pm_work` — #3916: PM ticket meaningfulness tier (`fact_pm_work`)
+//! - `pm_effort` — #3915: PM ticket complexity tier (`fact_pm_effort`)
 
 mod effort;
 mod effort_db;
 mod effort_git;
 mod flags;
 mod misc;
+mod pm_effort;
 mod pm_work;
 mod types;
 
@@ -118,5 +120,7 @@ pub async fn run(config: Config, db: &mut Database, args: BackfillArgs) -> anyho
         BackfillSubcommand::Quality => misc::backfill_quality(db, args.dry_run),
         // #3916: PM work meaningfulness tier.
         BackfillSubcommand::PmWork => pm_work::backfill_pm_work(db, args.dry_run),
+        // #3915: PM effort tier v1 — scores the pm-work tier's output.
+        BackfillSubcommand::PmEffort => pm_effort::backfill_pm_effort(db, args.dry_run),
     }
 }

--- a/crates/trusty-git-analytics/src/commands/backfill/pm_effort.rs
+++ b/crates/trusty-git-analytics/src/commands/backfill/pm_effort.rs
@@ -1,0 +1,181 @@
+//! `tga backfill pm-effort` — populate `fact_pm_effort` (issue #3915).
+//!
+//! Why: the PM-side sibling of `tga backfill effort`, and the tier above
+//! `tga backfill pm-work`. Running it after a sync materializes the
+//! complexity scores the cto-reports warehouse joins against, with the same
+//! `--dry-run` and idempotency contract as every other backfill.
+//!
+//! What: reads the tickets `fact_pm_work` marked meaningful, recovers
+//! reporter / description / creation date with the work tier's extractor and
+//! story points / parent key with the effort tier's, scores each with
+//! [`tga::core::pm_effort::score`], and upserts one `fact_pm_effort` row.
+//!
+//! Ordering: `pm-work` must run first. It is the gate — a database with no
+//! `fact_pm_work` rows yields no effort candidates, and this command says so
+//! rather than reporting a silent zero.
+
+use chrono::{DateTime, Utc};
+
+use tga::core::db::{
+    load_effort_candidates, prune_non_meaningful_effort, summarize_effort, upsert_pm_effort,
+    CheckpointMode, Database, PmEffortRow,
+};
+use tga::core::pm_effort::{self, EffortCounts, PmEffortInput};
+use tga::core::pm_work::extract as work_extract;
+
+/// Score every meaningful ticket's PM effort and persist the scores.
+///
+/// Why: see the module docs — the EFFORT tier of epic #3914, materialized so
+/// downstream dashboards join against a stored score instead of re-deriving
+/// one per query.
+/// What: delegates to [`backfill_pm_effort_at`] with the current time as the
+/// scoring instant, which is what the recency floor measures ticket age
+/// against.
+/// Test: `tests::backfill_pm_effort_scores_each_bucket`.
+///
+/// # Errors
+///
+/// Propagates database errors from the candidate read, the prune, or any
+/// upsert.
+pub(super) fn backfill_pm_effort(db: &mut Database, dry_run: bool) -> anyhow::Result<()> {
+    backfill_pm_effort_at(db, dry_run, Utc::now())
+}
+
+/// [`backfill_pm_effort`] with an explicit scoring instant.
+///
+/// Why: the recency floor is the one part of the formula that depends on
+/// wall-clock time, and a test that has to seed "four days ago" relative to
+/// a hidden `Utc::now()` proves less than one that states both the ticket's
+/// creation date and the instant it is scored at.
+/// What: identical to [`backfill_pm_effort`] except that `now` is supplied.
+/// Idempotent: the upsert is keyed on `(work_item_id, work_item_source)`, so
+/// a second run at the same instant rewrites the same rows and creates none.
+/// `--dry-run` reports the candidate count without writing.
+/// Test: `tests::a_recent_epic_is_recorded_as_deferred_not_scored_zero`,
+/// `tests::backfill_pm_effort_is_idempotent`,
+/// `tests::backfill_pm_effort_dry_run_writes_nothing`.
+///
+/// # Errors
+///
+/// Propagates database errors from the candidate read, the prune, or any
+/// upsert.
+pub(super) fn backfill_pm_effort_at(
+    db: &mut Database,
+    dry_run: bool,
+    now: DateTime<Utc>,
+) -> anyhow::Result<()> {
+    let candidates = load_effort_candidates(db.connection())
+        .map_err(|e| anyhow::anyhow!("pm-effort read failed: {e}"))?;
+
+    if dry_run {
+        println!(
+            "Dry run — would score {} meaningful work item(s) into fact_pm_effort \
+             (formula_version={}). No changes written.",
+            candidates.len(),
+            pm_effort::FORMULA_VERSION
+        );
+        return Ok(());
+    }
+
+    // #3915: re-apply the meaningfulness gate before writing, so a ticket
+    // that `pm-work` has since reclassified as boilerplate stops contributing.
+    let pruned = prune_non_meaningful_effort(db.connection())
+        .map_err(|e| anyhow::anyhow!("pm-effort prune failed: {e}"))?;
+
+    let mut written = 0usize;
+    for candidate in &candidates {
+        let row = score_candidate(candidate, now);
+        upsert_pm_effort(db.connection(), &row)
+            .map_err(|e| anyhow::anyhow!("pm-effort upsert failed for {}: {e}", candidate.id))?;
+        written += 1;
+    }
+
+    report(db, written, pruned, candidates.is_empty())?;
+    Ok(())
+}
+
+/// Build one `fact_pm_effort` row from one candidate.
+///
+/// Why: keeps the loop above a loop. The two extractors are called once
+/// each per ticket, and the scorer sees only already-extracted values.
+/// What: the work tier's extractor supplies reporter, description and
+/// creation date; the effort tier's supplies story points; the loader
+/// already supplied the three counts. Age is whole days from creation to
+/// `now`, and is `None` when the payload carried no parseable creation
+/// date — in which case the recency floor cannot fire and the ticket is
+/// scored on its other inputs.
+/// Test: `tests::backfill_pm_effort_scores_each_bucket`,
+/// `tests::a_ticket_with_no_creation_date_is_scored_not_deferred`.
+fn score_candidate(
+    candidate: &tga::core::db::PmEffortCandidate,
+    now: DateTime<Utc>,
+) -> PmEffortRow {
+    let work_fields = work_extract::extract_fields(candidate.raw_json.as_deref());
+    let effort_fields = pm_effort::extract::extract_fields(candidate.raw_json.as_deref());
+    let age_days = work_fields
+        .created
+        .map(|created| (now - created).num_days());
+
+    let counts = EffortCounts {
+        epic_children: candidate.epic_children_count,
+        description_words: description_word_count(work_fields.description.as_deref()),
+        comments: candidate.comment_count,
+        transitions: candidate.transition_count,
+        story_points: effort_fields.story_points,
+    };
+    let score = pm_effort::score(&PmEffortInput {
+        item_type: &candidate.item_type,
+        age_days,
+        counts,
+    });
+
+    PmEffortRow {
+        work_item_id: candidate.id.clone(),
+        work_item_source: candidate.source.clone(),
+        pm_name: work_fields.reporter.clone(),
+        week_key: work_fields.created.map(work_extract::week_key),
+        age_days,
+        counts,
+        score,
+    }
+}
+
+/// Words of description, reusing the work tier's counter so both tiers
+/// measure prose the same way.
+fn description_word_count(description: Option<&str>) -> u32 {
+    let words = description.map_or(0, tga::core::pm_work::word_count);
+    u32::try_from(words).unwrap_or(u32::MAX)
+}
+
+/// Print the run summary and flush the WAL.
+fn report(db: &mut Database, written: usize, pruned: usize, empty: bool) -> anyhow::Result<()> {
+    let (deferred, buckets) = summarize_effort(db.connection())
+        .map_err(|e| anyhow::anyhow!("pm-effort summary failed: {e}"))?;
+    println!(
+        "Backfilled fact_pm_effort: {written} row(s) written (UPSERT semantics), \
+         formula_version={}.",
+        pm_effort::FORMULA_VERSION
+    );
+    if pruned > 0 {
+        println!("  pruned {pruned} row(s) whose ticket is no longer meaningful");
+    }
+    for (bucket, count) in buckets {
+        println!("  {bucket}: {count}");
+    }
+    println!(
+        "  deferred (inside the {}-day recency floor): {deferred}",
+        pm_effort::thresholds::RECENCY_FLOOR_DAYS
+    );
+    if empty {
+        println!(
+            "  no meaningful tickets found — run `tga backfill pm-work` first: \
+             fact_pm_work is the gate this tier scores through."
+        );
+    }
+
+    // Flush the WAL so the new rows are durable in the main DB file.
+    if let Err(e) = db.wal_checkpoint(CheckpointMode::Truncate) {
+        tracing::warn!(error = %e, "WAL TRUNCATE checkpoint failed after pm-effort backfill");
+    }
+    Ok(())
+}

--- a/crates/trusty-git-analytics/src/commands/backfill/tests.rs
+++ b/crates/trusty-git-analytics/src/commands/backfill/tests.rs
@@ -15,6 +15,7 @@ use super::flags::{
     is_revert,
 };
 use super::misc::{backfill_complexity, backfill_quality, backfill_top_level};
+use super::pm_effort::backfill_pm_effort_at;
 use super::pm_work::backfill_pm_work;
 use super::types::{ComplexityBackfillArgs, EffortBackfillArgs, EffortRow};
 
@@ -1451,4 +1452,646 @@ fn a_human_transition_does_not_leak_across_pm_sources() {
         "AUTO_GENERATED",
         "the Linear ticket has no transitions of its own; JIRA's must not leak onto it"
     );
+}
+
+// --- `tga backfill pm-effort` (#3915) ---------------------------------------
+
+/// One seeded ticket for the effort-tier tests.
+struct EffortItemSpec<'a> {
+    id: &'a str,
+    source: &'a str,
+    title: &'a str,
+    item_type: &'a str,
+    reporter: &'a str,
+    description: &'a str,
+    created: &'a str,
+    parent: Option<&'a str>,
+    story_points: Option<f64>,
+}
+
+impl<'a> EffortItemSpec<'a> {
+    /// A substantive JIRA story authored well before the recency floor.
+    fn new(id: &'a str, title: &'a str) -> Self {
+        Self {
+            id,
+            source: "jira",
+            title,
+            item_type: "Story",
+            reporter: "Fabiana Calabrese",
+            description: "",
+            created: "2026-01-15T09:30:00.000+0000",
+            parent: None,
+            story_points: None,
+        }
+    }
+}
+
+/// Seed one `work_items` row with the effort-tier fields: item type, parent
+/// key, story points, description and creation date.
+///
+/// Separate from [`seed_work_item`], which seeds only what the WORK tier
+/// reads. Both write the same `raw_json` shape, so a ticket seeded here is
+/// also classifiable by `backfill_pm_work` — which is how these tests get
+/// the `fact_pm_work` rows the effort tier gates on.
+fn seed_effort_item(spec: &EffortItemSpec<'_>, db: &Database) {
+    let mut fields = serde_json::json!({
+        "reporter": { "displayName": spec.reporter },
+        "description": spec.description,
+        "created": spec.created,
+    });
+    if let Some(parent) = spec.parent {
+        fields["parent"] = serde_json::json!({ "key": parent });
+    }
+    if let Some(points) = spec.story_points {
+        fields["customfield_10004"] = serde_json::json!(points);
+    }
+    let raw = serde_json::json!({ "fields": fields }).to_string();
+    db.connection()
+        .execute(
+            "INSERT OR REPLACE INTO work_items \
+             (id, source, title, status, item_type, raw_json) \
+             VALUES (?1, ?2, ?3, 'In Progress', ?4, ?5)",
+            params![spec.id, spec.source, spec.title, spec.item_type, raw],
+        )
+        .expect("insert effort work item");
+}
+
+/// A description body of exactly `words` words, so a test can state the
+/// description term it expects instead of counting prose by hand.
+fn body_of(words: usize) -> String {
+    vec!["forecast"; words].join(" ")
+}
+
+/// Seed one `fact_jira_comment_detail` row.
+fn seed_comment(db: &Database, ticket: &str, comment_id: &str) {
+    db.connection()
+        .execute(
+            "INSERT OR REPLACE INTO fact_jira_comment_detail \
+             (ticket_key, comment_id, project_key, author, created_at, body_len, synced_at) \
+             VALUES (?1, ?2, 'PM', 'Fabiana Calabrese', '2026-01-16T10:00:00Z', 120, 1)",
+            params![ticket, comment_id],
+        )
+        .expect("insert comment");
+}
+
+/// Seed one `fact_ticket_transitions` row at a distinct timestamp, so
+/// repeat transitions on one ticket do not collide on the primary key.
+fn seed_transition_at(db: &Database, ticket: &str, at: &str) {
+    db.connection()
+        .execute(
+            "INSERT OR REPLACE INTO fact_ticket_transitions \
+             (ticket_key, project_key, from_status, to_status, transitioned_at, author, synced_at) \
+             VALUES (?1, 'PM', 'To Do', 'In Progress', ?2, 'Fabiana Calabrese', 1)",
+            params![ticket, at],
+        )
+        .expect("insert transition");
+}
+
+/// The fixed instant every effort test scores at, so ticket age is a stated
+/// number of days rather than whatever `Utc::now()` happens to be.
+fn scoring_instant() -> chrono::DateTime<chrono::Utc> {
+    "2026-03-01T00:00:00Z".parse().expect("parse instant")
+}
+
+/// An RFC3339 creation date `days` before [`scoring_instant`].
+fn created_days_before(days: i64) -> String {
+    (scoring_instant() - chrono::Duration::days(days)).to_rfc3339()
+}
+
+/// `(effort_score, effort_bucket, score_status, inputs_present, age_days)`.
+type EffortRowValues = (Option<f64>, Option<String>, String, String, Option<i64>);
+
+/// Read back the score row a test asserts on.
+fn read_effort(db: &Database, id: &str) -> EffortRowValues {
+    read_effort_in_source(db, id, "jira")
+}
+
+/// Read back one score row, scoped to an explicit `source`.
+fn read_effort_in_source(db: &Database, id: &str, source: &str) -> EffortRowValues {
+    db.connection()
+        .query_row(
+            "SELECT effort_score, effort_bucket, score_status, inputs_present, \
+             age_days_at_score FROM fact_pm_effort \
+             WHERE work_item_id = ?1 AND work_item_source = ?2",
+            params![id, source],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?)),
+        )
+        .unwrap_or_else(|e| panic!("read effort row for {source}/{id}: {e}"))
+}
+
+/// Whether `fact_pm_effort` holds a row for this ticket at all.
+fn has_effort_row(db: &Database, id: &str) -> bool {
+    let count: i64 = db
+        .connection()
+        .query_row(
+            "SELECT COUNT(*) FROM fact_pm_effort WHERE work_item_id = ?1",
+            params![id],
+            |r| r.get(0),
+        )
+        .expect("count effort rows");
+    count > 0
+}
+
+/// Read one integer column of one `fact_pm_effort` row.
+fn read_effort_int(db: &Database, id: &str, source: &str, column: &str) -> i64 {
+    let sql = format!(
+        "SELECT {column} FROM fact_pm_effort \
+         WHERE work_item_id = ?1 AND work_item_source = ?2"
+    );
+    db.connection()
+        .query_row(&sql, params![id, source], |r| r.get(0))
+        .unwrap_or_else(|e| panic!("read {column} for {source}/{id}: {e}"))
+}
+
+/// Run the WORK tier, then the EFFORT tier at [`scoring_instant`]. The
+/// effort tier reads `fact_pm_work`, so a test that skipped the first call
+/// would be asserting against an empty candidate set.
+fn run_both_tiers(db: &mut Database) {
+    backfill_pm_work(db, false).expect("pm-work backfill");
+    backfill_pm_effort_at(db, false, scoring_instant()).expect("pm-effort backfill");
+}
+
+/// Three tickets whose inputs put them in the three different buckets, so a
+/// single run proves the bucket boundaries reach the table.
+#[test]
+fn backfill_pm_effort_scores_each_bucket() {
+    let mut db = Database::open_in_memory().expect("db");
+
+    // LOW: a real story with a short body and nothing else. 1.0 + 40/40 = 2.0.
+    let low_body = body_of(40);
+    let mut low = EffortItemSpec::new("PM-60001", "Cap the rate-shop retry budget");
+    low.description = &low_body;
+    seed_effort_item(&low, &db);
+
+    // MEDIUM: 1.0 + 320/40 + 6*0.8 + 4*0.5 = 15.8.
+    let medium_body = body_of(320);
+    let mut medium = EffortItemSpec::new("PM-60002", "Blend the occupancy forecast");
+    medium.description = &medium_body;
+    seed_effort_item(&medium, &db);
+    for n in 1..=6 {
+        seed_comment(&db, "PM-60002", &format!("c{n}"));
+    }
+    for n in 1..=4 {
+        seed_transition_at(&db, "PM-60002", &format!("2026-01-2{n}T10:00:00Z"));
+    }
+
+    // HIGH: an epic with nine children. 1.0 + 18.0 + 10.0 + 4*0.8 + 3.0 = 35.2.
+    let high_body = body_of(400);
+    let mut high = EffortItemSpec::new("PM-60003", "ML Plat - Observability and Monitoring");
+    high.item_type = "Epic";
+    high.description = &high_body;
+    high.story_points = Some(8.0);
+    seed_effort_item(&high, &db);
+    for n in 1..=9 {
+        let child_id = format!("PM-6100{n}");
+        let mut child = EffortItemSpec::new(&child_id, "Wire the metric exporter into the mesh");
+        child.parent = Some("PM-60003");
+        seed_effort_item(&child, &db);
+    }
+    for n in 1..=4 {
+        seed_comment(&db, "PM-60003", &format!("h{n}"));
+    }
+
+    run_both_tiers(&mut db);
+
+    assert_eq!(
+        read_effort(&db, "PM-60001"),
+        (
+            Some(2.0),
+            Some("LOW".to_string()),
+            "SCORED".to_string(),
+            "DESCRIPTION".to_string(),
+            Some(44)
+        )
+    );
+    assert_eq!(
+        read_effort(&db, "PM-60002"),
+        (
+            Some(15.8),
+            Some("MEDIUM".to_string()),
+            "SCORED".to_string(),
+            "DESCRIPTION,COMMENTS,TRANSITIONS".to_string(),
+            Some(44)
+        )
+    );
+    assert_eq!(
+        read_effort(&db, "PM-60003"),
+        (
+            Some(35.2),
+            Some("HIGH".to_string()),
+            "SCORED".to_string(),
+            "CHILDREN,DESCRIPTION,COMMENTS,STORY_POINTS".to_string(),
+            Some(44)
+        )
+    );
+
+    let version: String = db
+        .connection()
+        .query_row(
+            "SELECT DISTINCT formula_version FROM fact_pm_effort",
+            [],
+            |r| r.get(0),
+        )
+        .expect("read formula_version");
+    assert_eq!(version, "pm-effort-1");
+}
+
+/// Issue #3915's motivating case: three epics authored the same day showed
+/// zero children at scoring time. Scoring them would have read "not yet
+/// decomposed" as "simple"; the row must say the score was deferred.
+#[test]
+fn a_recent_epic_is_recorded_as_deferred_not_scored_zero() {
+    let mut db = Database::open_in_memory().expect("db");
+    let body = body_of(60);
+
+    for (id, age) in [("ML-2314", 0), ("ML-2315", 3), ("ML-2316", 6)] {
+        let created = created_days_before(age);
+        let mut epic = EffortItemSpec::new(id, "ML Plat - Orchestration Layer");
+        epic.item_type = "Epic";
+        epic.reporter = "Rohit Puntambekar";
+        epic.description = &body;
+        epic.created = &created;
+        seed_effort_item(&epic, &db);
+    }
+    // The same epic exactly at the floor IS scored.
+    let created = created_days_before(7);
+    let mut old_epic = EffortItemSpec::new("ML-2200", "ML Plat - Feature Store");
+    old_epic.item_type = "Epic";
+    old_epic.reporter = "Rohit Puntambekar";
+    old_epic.description = &body;
+    old_epic.created = &created;
+    seed_effort_item(&old_epic, &db);
+
+    run_both_tiers(&mut db);
+
+    for (id, age) in [("ML-2314", 0), ("ML-2315", 3), ("ML-2316", 6)] {
+        let (score, bucket, status, inputs, age_days) = read_effort(&db, id);
+        assert_eq!(score, None, "{id} must not carry a score");
+        assert_eq!(bucket, None, "{id} must not carry a bucket");
+        assert_eq!(status, "DEFERRED_RECENT", "{id} status");
+        assert_eq!(inputs, "NONE", "{id} contributed no terms");
+        assert_eq!(age_days, Some(age), "{id} age is still recorded");
+    }
+
+    let (score, bucket, status, _, age_days) = read_effort(&db, "ML-2200");
+    assert_eq!(score, Some(2.5), "1.0 + 60/40 = 2.5");
+    assert_eq!(bucket.as_deref(), Some("LOW"));
+    assert_eq!(status, "SCORED");
+    assert_eq!(age_days, Some(7));
+}
+
+/// The recency floor guards types whose child count accrues after creation.
+/// A bug filed yesterday has no such input, so deferring it would withhold a
+/// score for nothing.
+#[test]
+fn a_recent_bug_is_scored_rather_than_deferred() {
+    let mut db = Database::open_in_memory().expect("db");
+    let body = body_of(80);
+    let created = created_days_before(1);
+    let mut bug = EffortItemSpec::new("PM-70001", "Rate-shop worker drops the retry budget");
+    bug.item_type = "Bug";
+    bug.description = &body;
+    bug.created = &created;
+    seed_effort_item(&bug, &db);
+
+    run_both_tiers(&mut db);
+
+    let (score, bucket, status, _, age_days) = read_effort(&db, "PM-70001");
+    assert_eq!(score, Some(3.0), "1.0 + 80/40 = 3.0");
+    assert_eq!(bucket.as_deref(), Some("LOW"));
+    assert_eq!(status, "SCORED");
+    assert_eq!(age_days, Some(1));
+}
+
+/// A ticket whose payload carries no parseable creation date cannot be
+/// aged, so the floor cannot fire; it is scored on its other inputs and the
+/// row records the unknown age as NULL.
+#[test]
+fn a_ticket_with_no_creation_date_is_scored_not_deferred() {
+    let mut db = Database::open_in_memory().expect("db");
+    db.connection()
+        .execute(
+            "INSERT INTO work_items (id, source, title, status, item_type, raw_json) \
+             VALUES ('PM-70002', 'jira', 'ML Plat - Serving Layer', 'To Do', 'Epic', \
+                     '{\"fields\":{\"description\":\"one two three four\"}}')",
+            [],
+        )
+        .expect("insert");
+
+    run_both_tiers(&mut db);
+
+    let (score, bucket, status, inputs, age_days) = read_effort(&db, "PM-70002");
+    assert_eq!(score, Some(1.1), "1.0 + 4/40 = 1.1");
+    assert_eq!(bucket.as_deref(), Some("LOW"));
+    assert_eq!(status, "SCORED");
+    assert_eq!(inputs, "DESCRIPTION");
+    assert_eq!(age_days, None, "an unparseable created date stores NULL");
+}
+
+/// Issue #3915: story_points is 76% NULL across four per-project
+/// custom-field IDs. Two otherwise identical tickets must differ only by the
+/// story-point term, and the one without must still carry a real score.
+#[test]
+fn missing_story_points_degrade_the_score_and_are_named_on_the_row() {
+    let mut db = Database::open_in_memory().expect("db");
+    let body = body_of(200);
+
+    let mut with_points = EffortItemSpec::new("PM-80001", "Blend the occupancy forecast");
+    with_points.description = &body;
+    with_points.story_points = Some(5.0);
+    seed_effort_item(&with_points, &db);
+
+    let mut without = EffortItemSpec::new("PM-80002", "Blend the compression forecast");
+    without.description = &body;
+    seed_effort_item(&without, &db);
+
+    // A value parked in the story-point field that is not an estimate must
+    // be treated as absent rather than crashing or skewing the score.
+    let mut nonsense = EffortItemSpec::new("PM-80003", "Blend the pickup forecast");
+    nonsense.description = &body;
+    nonsense.story_points = Some(86_400_000.0);
+    seed_effort_item(&nonsense, &db);
+
+    run_both_tiers(&mut db);
+
+    let (score, _, _, inputs, _) = read_effort(&db, "PM-80001");
+    assert_eq!(score, Some(8.0), "1.0 + 200/40 + 5*0.4 = 8.0");
+    assert_eq!(inputs, "DESCRIPTION,STORY_POINTS");
+
+    for id in ["PM-80002", "PM-80003"] {
+        let (score, bucket, status, inputs, _) = read_effort(&db, id);
+        assert_eq!(score, Some(6.0), "{id}: the description term still scores");
+        assert_eq!(bucket.as_deref(), Some("LOW"), "{id} bucket");
+        assert_eq!(status, "SCORED", "{id} status");
+        assert_eq!(
+            inputs, "DESCRIPTION",
+            "{id}: the row must say the story-point term did not fire"
+        );
+    }
+
+    let stored: Option<f64> = db
+        .connection()
+        .query_row(
+            "SELECT story_points FROM fact_pm_effort WHERE work_item_id = 'PM-80003'",
+            [],
+            |r| r.get(0),
+        )
+        .expect("read story_points");
+    assert_eq!(stored, None, "an implausible value is stored as NULL");
+}
+
+/// The effort tier scores the WORK tier's output. A ticket `fact_pm_work`
+/// excluded must get no row at all — scoring it would re-admit through the
+/// effort tier exactly the boilerplate the work tier removed.
+#[test]
+fn an_excluded_ticket_gets_no_effort_row() {
+    let mut db = Database::open_in_memory().expect("db");
+    seed_pm_work_corpus(&db);
+
+    run_both_tiers(&mut db);
+
+    for excluded in ["PM-10215", "PM-20001", "PM-20002"] {
+        assert!(
+            !has_effort_row(&db, excluded),
+            "{excluded} was excluded by fact_pm_work and must not be scored"
+        );
+    }
+    assert!(
+        has_effort_row(&db, "PM-30001"),
+        "the meaningful story must be scored"
+    );
+
+    let count: i64 = db
+        .connection()
+        .query_row("SELECT COUNT(*) FROM fact_pm_effort", [], |r| r.get(0))
+        .expect("count");
+    assert_eq!(count, 1, "exactly one of the four tickets is meaningful");
+}
+
+/// The meaningfulness gate is only durable if it is re-applied: a ticket
+/// that `pm-work` reclassifies as boilerplate must lose the effort row an
+/// earlier run wrote, or it goes on feeding every dashboard reading it.
+#[test]
+fn a_ticket_that_becomes_non_meaningful_loses_its_effort_row() {
+    let mut db = Database::open_in_memory().expect("db");
+    let body = body_of(120);
+    let mut story = EffortItemSpec::new("PM-90001", "Blend the occupancy forecast");
+    story.description = &body;
+    seed_effort_item(&story, &db);
+
+    run_both_tiers(&mut db);
+    assert!(has_effort_row(&db, "PM-90001"));
+
+    // The ticket is re-collected as a terse stub with no body, so the work
+    // tier now excludes it.
+    db.connection()
+        .execute(
+            "UPDATE work_items SET title = 'Final', raw_json = '{}' WHERE id = 'PM-90001'",
+            [],
+        )
+        .expect("update");
+
+    run_both_tiers(&mut db);
+    assert!(
+        !has_effort_row(&db, "PM-90001"),
+        "the stale effort row must be pruned once the ticket stops being meaningful"
+    );
+}
+
+/// Children are counted per source from the parent keys their own payloads
+/// carry, and a child's own meaningfulness verdict is irrelevant — a terse
+/// sub-task is still evidence the parent was decomposed.
+#[test]
+fn epic_children_are_counted_from_parent_keys() {
+    let mut db = Database::open_in_memory().expect("db");
+    let mut epic = EffortItemSpec::new("PM-91000", "ML Plat - Deployment and Serving Layer");
+    epic.item_type = "Epic";
+    seed_effort_item(&epic, &db);
+
+    // Two substantive children and one terse stub the work tier excludes.
+    for id in ["PM-91001", "PM-91002"] {
+        let mut child = EffortItemSpec::new(id, "Wire the exporter into the service mesh");
+        child.parent = Some("PM-91000");
+        seed_effort_item(&child, &db);
+    }
+    let mut stub = EffortItemSpec::new("PM-91003", "Final");
+    stub.parent = Some("PM-91000");
+    seed_effort_item(&stub, &db);
+    // A same-keyed epic in another source must not inherit the JIRA children.
+    let mut linear_epic = EffortItemSpec::new("PM-91000", "ML Plat - Deployment and Serving Layer");
+    linear_epic.source = "linear";
+    linear_epic.item_type = "Epic";
+    seed_effort_item(&linear_epic, &db);
+
+    run_both_tiers(&mut db);
+
+    assert_eq!(
+        read_effort_int(&db, "PM-91000", "jira", "epic_children_count"),
+        3,
+        "the terse stub still counts as decomposition"
+    );
+    assert_eq!(
+        read_effort(&db, "PM-91000").0,
+        Some(7.0),
+        "1.0 + 3 * 2.0 = 7.0"
+    );
+    assert_eq!(
+        read_effort_int(&db, "PM-91000", "linear", "epic_children_count"),
+        0,
+        "JIRA's children must not leak onto a same-keyed Linear epic"
+    );
+}
+
+/// `fact_jira_comment_detail` and `fact_ticket_transitions` carry no source
+/// column — every row in both comes from the JIRA sync (#3966). Looking a
+/// candidate up by bare ticket key would let a JIRA ticket's discussion
+/// inflate the score of a same-keyed ticket from another source.
+#[test]
+fn jira_comments_and_transitions_do_not_leak_across_pm_sources() {
+    let mut db = Database::open_in_memory().expect("db");
+    let body = body_of(40);
+    for source in ["jira", "linear"] {
+        let mut item = EffortItemSpec::new("ENG-42", "Retry budget exhausted on the worker");
+        item.source = source;
+        item.description = &body;
+        seed_effort_item(&item, &db);
+    }
+    for n in 1..=5 {
+        seed_comment(&db, "ENG-42", &format!("c{n}"));
+        seed_transition_at(&db, "ENG-42", &format!("2026-01-2{n}T10:00:00Z"));
+    }
+
+    run_both_tiers(&mut db);
+
+    assert_eq!(
+        read_effort_in_source(&db, "ENG-42", "jira"),
+        (
+            Some(8.5), // 1.0 + 1.0 + 5*0.8 + 5*0.5
+            Some("LOW".to_string()),
+            "SCORED".to_string(),
+            "DESCRIPTION,COMMENTS,TRANSITIONS".to_string(),
+            Some(44)
+        )
+    );
+    assert_eq!(
+        read_effort_in_source(&db, "ENG-42", "linear"),
+        (
+            Some(2.0), // 1.0 + 1.0, and nothing else
+            Some("LOW".to_string()),
+            "SCORED".to_string(),
+            "DESCRIPTION".to_string(),
+            Some(44)
+        ),
+        "the Linear ticket has no discussion of its own; JIRA's must not leak onto it"
+    );
+}
+
+/// Every stored column except `computed_at` — which is by design the
+/// wall-clock instant of the write — rendered as one comparable string per
+/// row, so the idempotency check compares whole rows rather than a subset.
+fn read_all_effort_rows(db: &Database) -> Vec<String> {
+    let conn = db.connection();
+    let mut stmt = conn
+        .prepare(
+            "SELECT work_item_id, work_item_source, pm_name, week_key, effort_score, \
+             effort_bucket, score_status, epic_children_count, description_word_count, \
+             comment_count, transition_count, story_points, inputs_present, \
+             age_days_at_score, formula_version FROM fact_pm_effort \
+             ORDER BY work_item_source, work_item_id",
+        )
+        .expect("prepare");
+    let rows = stmt
+        .query_map([], |r| {
+            Ok(format!(
+                "{}|{}|{:?}|{:?}|{:?}|{:?}|{}|{}|{}|{}|{}|{:?}|{}|{:?}|{}",
+                r.get::<_, String>(0)?,
+                r.get::<_, String>(1)?,
+                r.get::<_, Option<String>>(2)?,
+                r.get::<_, Option<String>>(3)?,
+                r.get::<_, Option<f64>>(4)?,
+                r.get::<_, Option<String>>(5)?,
+                r.get::<_, String>(6)?,
+                r.get::<_, i64>(7)?,
+                r.get::<_, i64>(8)?,
+                r.get::<_, i64>(9)?,
+                r.get::<_, i64>(10)?,
+                r.get::<_, Option<f64>>(11)?,
+                r.get::<_, String>(12)?,
+                r.get::<_, Option<i64>>(13)?,
+                r.get::<_, String>(14)?,
+            ))
+        })
+        .expect("query");
+    rows.map(|r| r.expect("row")).collect()
+}
+
+#[test]
+fn backfill_pm_effort_is_idempotent() {
+    let mut db = Database::open_in_memory().expect("db");
+    let body = body_of(200);
+
+    let mut epic = EffortItemSpec::new("PM-92000", "ML Plat - Orchestration Layer");
+    epic.item_type = "Epic";
+    epic.description = &body;
+    epic.story_points = Some(8.0);
+    seed_effort_item(&epic, &db);
+    for n in 1..=3 {
+        let child_id = format!("PM-9200{n}");
+        let mut child = EffortItemSpec::new(&child_id, "Wire the scheduler into the mesh");
+        child.parent = Some("PM-92000");
+        child.description = &body;
+        seed_effort_item(&child, &db);
+    }
+    // A deferred epic, so the idempotency check covers the NULL-score shape.
+    let created = created_days_before(2);
+    let mut recent = EffortItemSpec::new("PM-92100", "ML Plat - Observability");
+    recent.item_type = "Epic";
+    recent.description = &body;
+    recent.created = &created;
+    seed_effort_item(&recent, &db);
+    seed_comment(&db, "PM-92000", "c1");
+    seed_transition_at(&db, "PM-92000", "2026-01-21T10:00:00Z");
+
+    run_both_tiers(&mut db);
+    let first = read_all_effort_rows(&db);
+    assert_eq!(first.len(), 5, "one row per meaningful ticket");
+
+    backfill_pm_effort_at(&mut db, false, scoring_instant()).expect("second run");
+    let second = read_all_effort_rows(&db);
+    assert_eq!(
+        first, second,
+        "a second run at the same instant must produce identical rows, not duplicates"
+    );
+}
+
+#[test]
+fn backfill_pm_effort_dry_run_writes_nothing() {
+    let mut db = Database::open_in_memory().expect("db");
+    seed_pm_work_corpus(&db);
+    backfill_pm_work(&mut db, false).expect("pm-work backfill");
+
+    backfill_pm_effort_at(&mut db, true, scoring_instant()).expect("dry run");
+
+    let count: i64 = db
+        .connection()
+        .query_row("SELECT COUNT(*) FROM fact_pm_effort", [], |r| r.get(0))
+        .expect("count");
+    assert_eq!(count, 0, "--dry-run must not write any row");
+}
+
+/// `fact_pm_work` is the gate. With no work-tier rows there are no
+/// candidates, and the run must succeed with an empty table rather than
+/// scoring every ticket ungated.
+#[test]
+fn backfill_pm_effort_scores_nothing_when_the_work_tier_has_not_run() {
+    let mut db = Database::open_in_memory().expect("db");
+    seed_pm_work_corpus(&db);
+
+    backfill_pm_effort_at(&mut db, false, scoring_instant()).expect("backfill");
+
+    let count: i64 = db
+        .connection()
+        .query_row("SELECT COUNT(*) FROM fact_pm_effort", [], |r| r.get(0))
+        .expect("count");
+    assert_eq!(count, 0, "no fact_pm_work rows means no effort candidates");
 }

--- a/crates/trusty-git-analytics/src/commands/backfill/types.rs
+++ b/crates/trusty-git-analytics/src/commands/backfill/types.rs
@@ -174,6 +174,26 @@ pub enum BackfillSubcommand {
     /// --repos/--since/--until/--weeks do not scope this operation: it reads
     /// `work_items`, which carries no repository or commit-timestamp column.
     PmWork,
+    /// #3915: PM effort tier — score every meaningful ticket's complexity
+    /// and persist it to `fact_pm_effort`.
+    ///
+    /// Scores the WORK tier's output: only tickets `fact_pm_work` marks
+    /// meaningful are scored, so `tga backfill pm-work` must run first. The
+    /// v1 formula sums capped terms for child count, description length,
+    /// comment count, transition count and story points; a missing input
+    /// drops its term rather than zeroing the score, and the row names which
+    /// terms fired. Deterministic — no LLM tier in v1.
+    ///
+    /// A ticket of a decomposable type younger than the 7-day recency floor
+    /// is recorded as `DEFERRED_RECENT` with a NULL score, never as a zero:
+    /// an epic filed yesterday has no children yet because nobody has broken
+    /// it down, not because it is simple.
+    ///
+    /// Idempotent: UPSERT on `(work_item_id, work_item_source)`, so running
+    /// it twice produces the same rows. Supports --dry-run.
+    /// --repos/--since/--until/--weeks do not scope this operation: it reads
+    /// `work_items`, which carries no repository or commit-timestamp column.
+    PmEffort,
 }
 
 /// Arguments for `tga backfill complexity`.

--- a/crates/trusty-git-analytics/src/core/db/migrations/mod.rs
+++ b/crates/trusty-git-analytics/src/core/db/migrations/mod.rs
@@ -584,6 +584,125 @@ mod tests {
         );
     }
 
+    /// Why: #3915 lands `fact_pm_effort` on databases that already hold v26
+    /// data — `work_items` rows and the `fact_pm_work` verdicts derived from
+    /// them. `migration_v27_creates_fact_pm_effort` only opens a brand-new
+    /// in-memory database, which runs every migration from v1 forward and so
+    /// never exercises the upgrade path a deployed database takes. A v27 that
+    /// dropped or rebuilt `fact_pm_work` would pass that test while silently
+    /// destroying every stored verdict.
+    /// What: builds a genuine v26 database (the schema shipped before #3915),
+    /// writes a `work_items` row and the `fact_pm_work` verdict for it,
+    /// upgrades to v27, then asserts both rows survive unchanged, a
+    /// `fact_pm_effort` row referencing that same ticket inserts, and the
+    /// registry reads 27. Mirrors
+    /// `migration_v24_preserves_an_existing_v23_database`.
+    /// Test: this test itself.
+    #[test]
+    fn migration_v27_preserves_an_existing_v26_database() {
+        let mut conn = rusqlite::Connection::open_in_memory().expect("open");
+        // The pragma every real connection carries — see `Database::apply_pragmas`.
+        // Without it the new table's FOREIGN KEY is inert.
+        conn.execute_batch("PRAGMA foreign_keys = ON;")
+            .expect("enable foreign keys");
+        super::run_through(&mut conn, 26).expect("migrate to v26");
+
+        let version: i64 = conn
+            .query_row("SELECT MAX(version) FROM schema_migrations", [], |r| {
+                r.get(0)
+            })
+            .expect("read version");
+        assert_eq!(version, 26, "the fixture must be a real pre-#3915 database");
+
+        // Rows written the way the v26 classifier wrote them, before
+        // `fact_pm_effort` existed.
+        conn.execute(
+            "INSERT INTO work_items (id, source, title, status, item_type) \
+             VALUES ('ML-2200', 'jira', 'ML Plat - Feature store rollout', 'Done', 'Epic')",
+            [],
+        )
+        .expect("insert v26-era work item");
+        conn.execute(
+            "INSERT INTO fact_pm_work \
+             (work_item_id, work_item_source, pm_name, week_key, is_meaningful, \
+              exclusion_reason, title_word_count, body_word_count, formula_version, computed_at) \
+             VALUES ('ML-2200', 'jira', 'Rohit Puntambekar', '2026-W20', 1, 'NONE', 5, 180, \
+                     'pm-work-1', 1700000000)",
+            [],
+        )
+        .expect("insert v26-era verdict");
+
+        // The upgrade every existing v26 database performs on next open.
+        super::run_through(&mut conn, 27).expect("migrate to v27");
+
+        let upgraded: i64 = conn
+            .query_row("SELECT MAX(version) FROM schema_migrations", [], |r| {
+                r.get(0)
+            })
+            .expect("read version");
+        assert_eq!(upgraded, 27, "the registry must record the new migration");
+
+        // The seeded rows survive the new CREATE TABLE untouched.
+        let (title, status): (String, String) = conn
+            .query_row(
+                "SELECT title, status FROM work_items \
+                 WHERE id = 'ML-2200' AND source = 'jira'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .expect("the pre-migration work item must still be readable");
+        assert_eq!(title, "ML Plat - Feature store rollout");
+        assert_eq!(status, "Done");
+
+        let (pm, week, meaningful, body_words, computed): (String, String, i64, i64, i64) = conn
+            .query_row(
+                "SELECT pm_name, week_key, is_meaningful, body_word_count, computed_at \
+                 FROM fact_pm_work WHERE work_item_id = 'ML-2200' AND work_item_source = 'jira'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?)),
+            )
+            .expect("the pre-migration verdict must still be readable");
+        assert_eq!(pm, "Rohit Puntambekar");
+        assert_eq!(week, "2026-W20");
+        assert_eq!(meaningful, 1);
+        assert_eq!(body_words, 180);
+        assert_eq!(computed, 1_700_000_000);
+
+        let verdicts: i64 = conn
+            .query_row("SELECT COUNT(*) FROM fact_pm_work", [], |r| r.get(0))
+            .expect("count verdicts");
+        assert_eq!(verdicts, 1, "v27 must not drop or duplicate v26 rows");
+
+        // The new table accepts a score for that pre-existing ticket.
+        conn.execute(
+            "INSERT INTO fact_pm_effort \
+             (work_item_id, work_item_source, pm_name, week_key, effort_score, \
+              effort_bucket, score_status, epic_children_count, description_word_count, \
+              comment_count, transition_count, story_points, inputs_present, \
+              age_days_at_score, formula_version, computed_at) \
+             VALUES ('ML-2200', 'jira', 'Rohit Puntambekar', '2026-W20', 22.5, 'MEDIUM', \
+                     'SCORED', 4, 180, 3, 7, NULL, \
+                     'CHILDREN,DESCRIPTION,COMMENTS,TRANSITIONS', 90, 'pm-effort-1', \
+                     1700000001)",
+            [],
+        )
+        .expect("scoring a ticket the v26 database already knew must succeed");
+
+        let (score, bucket): (Option<f64>, Option<String>) = conn
+            .query_row(
+                "SELECT effort_score, effort_bucket FROM fact_pm_effort \
+                 WHERE work_item_id = 'ML-2200' AND work_item_source = 'jira'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .expect("read the new row back");
+        assert_eq!(score, Some(22.5));
+        assert_eq!(bucket.as_deref(), Some("MEDIUM"));
+
+        // Re-running is a no-op, per the runner's idempotence contract.
+        super::run_through(&mut conn, 27).expect("re-run is idempotent");
+    }
+
     /// Why: regression guard for issue #445 batch B. Migration v18 creates
     /// `fact_weekly_quality` with all required columns and a PRIMARY KEY on
     /// (author_email, iso_year, iso_week, repository).

--- a/crates/trusty-git-analytics/src/core/db/migrations/mod.rs
+++ b/crates/trusty-git-analytics/src/core/db/migrations/mod.rs
@@ -168,6 +168,12 @@ pub const MIGRATIONS: &[Migration] = &[
         name: "fact_pm_work",
         sql: include_str!("../sql/0026_fact_pm_work.sql"),
     },
+    // #3915: PM effort tier — `fact_pm_effort`.
+    Migration {
+        version: 27,
+        name: "fact_pm_effort",
+        sql: include_str!("../sql/0027_fact_pm_effort.sql"),
+    },
 ];
 
 /// Ensure the `schema_migrations` bookkeeping table exists.
@@ -382,6 +388,199 @@ mod tests {
         assert!(
             err.is_err(),
             "a verdict without its work_items parent must be rejected"
+        );
+    }
+
+    /// Why: #3915 — `fact_pm_effort` is the first fact table in this schema
+    /// whose measure columns are deliberately NULLABLE. A ticket inside the
+    /// recency floor stores NULL in `effort_score` and `effort_bucket` and
+    /// says why in `score_status`; a migration that made either column NOT
+    /// NULL would force the zero the issue exists to prevent, and would fail
+    /// only at backfill time on a real database.
+    /// What: opens an in-memory DB (running every migration through v27),
+    /// inserts the parent `work_items` row, writes one scored row and one
+    /// deferred row, reads every column back, then re-inserts the same grain
+    /// and asserts the row count is unchanged.
+    /// Test: this test itself.
+    #[test]
+    fn migration_v27_creates_fact_pm_effort() {
+        let db = Database::open_in_memory().expect("open db");
+        let conn = db.connection();
+
+        for id in ["ML-2314", "ML-2315"] {
+            conn.execute(
+                "INSERT INTO work_items (id, source, title, status, item_type) \
+                 VALUES (?1, 'jira', 'ML Plat - Observability', 'To Do', 'Epic')",
+                params![id],
+            )
+            .expect("insert parent work item");
+        }
+
+        let insert = "INSERT OR REPLACE INTO fact_pm_effort \
+             (work_item_id, work_item_source, pm_name, week_key, effort_score, effort_bucket, \
+              score_status, epic_children_count, description_word_count, comment_count, \
+              transition_count, story_points, inputs_present, age_days_at_score, \
+              formula_version, computed_at) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)";
+        conn.execute(
+            insert,
+            params![
+                "ML-2314",
+                "jira",
+                "Rohit Puntambekar",
+                "2026-W28",
+                31.5_f64,
+                "HIGH",
+                "SCORED",
+                9_i64,
+                400_i64,
+                5_i64,
+                6_i64,
+                8.0_f64,
+                "CHILDREN,DESCRIPTION,COMMENTS,TRANSITIONS,STORY_POINTS",
+                45_i64,
+                "pm-effort-1",
+                1_000_000_i64,
+            ],
+        )
+        .expect("insert scored row");
+
+        // The deferred shape: NULL score and NULL bucket, with the reason in
+        // score_status and no story points.
+        conn.execute(
+            insert,
+            params![
+                "ML-2315",
+                "jira",
+                "Rohit Puntambekar",
+                "2026-W28",
+                None::<f64>,
+                None::<String>,
+                "DEFERRED_RECENT",
+                0_i64,
+                12_i64,
+                0_i64,
+                0_i64,
+                None::<f64>,
+                "NONE",
+                2_i64,
+                "pm-effort-1",
+                1_000_000_i64,
+            ],
+        )
+        .expect("insert deferred row");
+
+        /// Every column `migration_v27_creates_fact_pm_effort` reads back.
+        type ScoredRow = (
+            Option<f64>,
+            Option<String>,
+            String,
+            i64,
+            Option<f64>,
+            String,
+            Option<i64>,
+            String,
+        );
+        let (score, bucket, status, children, points, inputs, age, version): ScoredRow = conn
+            .query_row(
+                "SELECT effort_score, effort_bucket, score_status, epic_children_count, \
+                 story_points, inputs_present, age_days_at_score, formula_version \
+                 FROM fact_pm_effort WHERE work_item_id = 'ML-2314' AND work_item_source = 'jira'",
+                [],
+                |r| {
+                    Ok((
+                        r.get(0)?,
+                        r.get(1)?,
+                        r.get(2)?,
+                        r.get(3)?,
+                        r.get(4)?,
+                        r.get(5)?,
+                        r.get(6)?,
+                        r.get(7)?,
+                    ))
+                },
+            )
+            .expect("read scored row back");
+        assert_eq!(score, Some(31.5));
+        assert_eq!(bucket.as_deref(), Some("HIGH"));
+        assert_eq!(status, "SCORED");
+        assert_eq!(children, 9);
+        assert_eq!(points, Some(8.0));
+        assert_eq!(
+            inputs,
+            "CHILDREN,DESCRIPTION,COMMENTS,TRANSITIONS,STORY_POINTS"
+        );
+        assert_eq!(age, Some(45));
+        assert_eq!(version, "pm-effort-1");
+
+        let (deferred_score, deferred_bucket, deferred_status): (
+            Option<f64>,
+            Option<String>,
+            String,
+        ) = conn
+            .query_row(
+                "SELECT effort_score, effort_bucket, score_status FROM fact_pm_effort \
+                 WHERE work_item_id = 'ML-2315'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .expect("read deferred row back");
+        assert_eq!(
+            deferred_score, None,
+            "a deferred ticket stores NULL, never a zero"
+        );
+        assert_eq!(deferred_bucket, None);
+        assert_eq!(deferred_status, "DEFERRED_RECENT");
+
+        // Re-running the scorer over the same ticket replaces the row.
+        conn.execute(
+            insert,
+            params![
+                "ML-2314",
+                "jira",
+                "Rohit Puntambekar",
+                "2026-W28",
+                12.0_f64,
+                "LOW",
+                "SCORED",
+                1_i64,
+                400_i64,
+                0_i64,
+                0_i64,
+                None::<f64>,
+                "CHILDREN,DESCRIPTION",
+                60_i64,
+                "pm-effort-1",
+                2_000_000_i64,
+            ],
+        )
+        .expect("upsert pm effort row");
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM fact_pm_effort", [], |r| r.get(0))
+            .expect("count");
+        assert_eq!(count, 2, "UPSERT must not duplicate the grain row");
+    }
+
+    /// Why: same reasoning as `fact_pm_work_rejects_a_verdict_with_no_work_item`
+    /// — every `fact_pm_effort` row is DERIVED from a `work_items` row
+    /// (#3915), so one for a ticket the database has never seen is a bug.
+    /// What: writes a score whose parent grain does not exist and asserts
+    /// SQLite rejects it.
+    /// Test: this test itself.
+    #[test]
+    fn fact_pm_effort_rejects_a_score_with_no_work_item() {
+        let db = Database::open_in_memory().expect("open db");
+        let err = db.connection().execute(
+            "INSERT INTO fact_pm_effort \
+             (work_item_id, work_item_source, score_status, epic_children_count, \
+              description_word_count, comment_count, transition_count, inputs_present, \
+              formula_version, computed_at) \
+             VALUES ('NOPE-1', 'jira', 'SCORED', 0, 0, 0, 0, 'NONE', 'pm-effort-1', 1)",
+            [],
+        );
+        assert!(
+            err.is_err(),
+            "a score without its work_items parent must be rejected"
         );
     }
 

--- a/crates/trusty-git-analytics/src/core/db/mod.rs
+++ b/crates/trusty-git-analytics/src/core/db/mod.rs
@@ -41,6 +41,7 @@ pub mod collection_runs;
 pub mod correlation;
 pub mod jira_facts;
 pub mod migrations;
+pub mod pm_effort;
 pub mod pm_work;
 pub mod work_items;
 
@@ -53,6 +54,11 @@ pub use jira_facts::{
     check_freshness, get_cursor, list_cursor_projects, set_cursor, upsert_comment_detail,
     upsert_ticket_transition, CommentDetailRow, FreshnessStatus, JiraSyncCursor,
     TicketTransitionRow,
+};
+// #3915: PM effort tier.
+pub use pm_effort::{
+    load_effort_candidates, prune_non_meaningful_effort, summarize_effort, upsert_pm_effort,
+    PmEffortCandidate, PmEffortRow,
 };
 // #3916: PM work meaningfulness tier.
 pub use pm_work::{load_candidates, summarize, upsert_pm_work, PmWorkCandidate, PmWorkRow};

--- a/crates/trusty-git-analytics/src/core/db/pm_effort.rs
+++ b/crates/trusty-git-analytics/src/core/db/pm_effort.rs
@@ -1,0 +1,339 @@
+//! Persistence for `fact_pm_effort` — the PM effort tier (issue #3915).
+//! Schema: `sql/0027_fact_pm_effort.sql`.
+//!
+//! Why: the scorer in [`crate::core::pm_effort`] is a pure function; this
+//! module is the only thing that reads its inputs out of the database and
+//! writes its scores back, so the scorer stays unit-testable on fixtures
+//! with no connection. Same split as [`super::pm_work`].
+//!
+//! What: [`load_effort_candidates`] reads the meaningful tickets and the
+//! three count inputs that live in other tables; [`upsert_pm_effort`] writes
+//! one score; [`prune_non_meaningful_effort`] removes rows whose ticket is
+//! no longer meaningful.
+//!
+//! Scale separation: `effort_score` here is counted in PM complexity points
+//! and `fact_commit_effort.effort_score` in commit effort points. The two
+//! must never share a visualization axis. See #3917.
+
+use std::collections::HashMap;
+
+use rusqlite::{params, Connection};
+use tracing::debug;
+
+use crate::core::errors::{Result, TgaError};
+use crate::core::pm_effort::{self, EffortBucket, EffortCounts, PmEffortScore, ScoreStatus};
+
+/// The `work_items.source` tag whose tickets `fact_ticket_transitions` and
+/// `fact_jira_comment_detail` hold.
+///
+/// Why: neither table has a source column, and their only production writer
+/// is the JIRA sync (#3966). A ticket key is unique per PM source, not
+/// globally, so matching a candidate on the bare key would let a JIRA
+/// ticket's comments inflate the effort score of an unrelated ticket that
+/// happens to share its key in another source — the same defect
+/// [`super::pm_work`] fixed for the transition signal.
+/// What: the literal `work_items.source` tag JIRA rows carry
+/// (`sql/0005_work_items.sql`).
+/// Test: `jira_comments_and_transitions_do_not_leak_across_pm_sources`.
+const TRANSITIONS_SOURCE: &str = "jira";
+
+/// One meaningful `work_items` row plus every count input that lives
+/// outside it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PmEffortCandidate {
+    /// `work_items.id`.
+    pub id: String,
+    /// `work_items.source`: `"azdo"`, `"jira"`, `"github"`, or `"linear"`.
+    pub source: String,
+    /// `work_items.item_type`, which decides whether the recency floor
+    /// applies.
+    pub item_type: String,
+    /// `work_items.raw_json`, the preserved upstream payload.
+    pub raw_json: Option<String>,
+    /// `work_items` rows in the same source naming this ticket as parent.
+    pub epic_children_count: u32,
+    /// `fact_jira_comment_detail` rows for this ticket.
+    pub comment_count: u32,
+    /// `fact_ticket_transitions` rows for this ticket.
+    pub transition_count: u32,
+}
+
+/// One row of `fact_pm_effort`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PmEffortRow {
+    /// `work_items.id` of the scored ticket.
+    pub work_item_id: String,
+    /// `work_items.source` of the scored ticket.
+    pub work_item_source: String,
+    /// Reporter display name, when the upstream payload carried one.
+    pub pm_name: Option<String>,
+    /// ISO week the ticket was created, `YYYY-Www`; `None` when unknown.
+    pub week_key: Option<String>,
+    /// Ticket age in whole days at scoring time; `None` when the payload
+    /// carried no parseable creation timestamp.
+    pub age_days: Option<i64>,
+    /// The measured inputs, stored alongside the score so a retune can be
+    /// evaluated without re-reading upstream payloads.
+    pub counts: EffortCounts,
+    /// The scorer verdict.
+    pub score: PmEffortScore,
+}
+
+/// Read every meaningful ticket, with its three external count inputs.
+///
+/// Why: the meaningfulness gate is issue #3915's first exclusion — a ticket
+/// `fact_pm_work` excluded must get no effort row at all, or the effort tier
+/// re-admits exactly the boilerplate the work tier removed. Enforcing it in
+/// the JOIN rather than in the scorer means there is no code path that can
+/// score an excluded ticket.
+/// What: an inner join from `work_items` to `fact_pm_work` on
+/// `is_meaningful = 1`, plus three lookups — child counts derived from every
+/// ticket's parent key (including non-meaningful children, which still
+/// represent decomposition), and comment/transition counts from the JIRA
+/// fact tables, both scoped to [`TRANSITIONS_SOURCE`].
+/// Test: `an_excluded_ticket_gets_no_effort_row`,
+/// `epic_children_are_counted_from_parent_keys`,
+/// `jira_comments_and_transitions_do_not_leak_across_pm_sources`.
+///
+/// # Errors
+///
+/// Returns [`TgaError::DbError`] if any of the four queries fails.
+pub fn load_effort_candidates(conn: &Connection) -> Result<Vec<PmEffortCandidate>> {
+    let children = child_counts_by_parent(conn)?;
+    let comments = counts_by_ticket(conn, "fact_jira_comment_detail")?;
+    let transitions = counts_by_ticket(conn, "fact_ticket_transitions")?;
+
+    let mut stmt = conn
+        .prepare(
+            "SELECT w.id, w.source, w.item_type, w.raw_json \
+             FROM work_items w \
+             JOIN fact_pm_work f \
+               ON f.work_item_id = w.id AND f.work_item_source = w.source \
+             WHERE f.is_meaningful = 1 \
+             ORDER BY w.source, w.id",
+        )
+        .map_err(TgaError::from)?;
+    let rows = stmt
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, Option<String>>(3)?,
+            ))
+        })
+        .map_err(TgaError::from)?;
+
+    let mut out = Vec::new();
+    for row in rows {
+        let (id, source, item_type, raw_json) = row.map_err(TgaError::from)?;
+        // #3915: scope every cross-table lookup by source — ticket keys are
+        // unique per PM source, not globally.
+        let jira = source == TRANSITIONS_SOURCE;
+        out.push(PmEffortCandidate {
+            epic_children_count: children
+                .get(&(source.clone(), id.clone()))
+                .copied()
+                .unwrap_or(0),
+            comment_count: if jira {
+                comments.get(&id).copied().unwrap_or(0)
+            } else {
+                0
+            },
+            transition_count: if jira {
+                transitions.get(&id).copied().unwrap_or(0)
+            } else {
+                0
+            },
+            id,
+            source,
+            item_type,
+            raw_json,
+        });
+    }
+    Ok(out)
+}
+
+/// `(source, parent_key) -> child count` over every `work_items` row.
+///
+/// Children are counted regardless of their own meaningfulness verdict: a
+/// terse sub-task is still evidence that the parent was decomposed, which is
+/// what the child term measures.
+fn child_counts_by_parent(conn: &Connection) -> Result<HashMap<(String, String), u32>> {
+    let mut stmt = conn
+        .prepare("SELECT source, raw_json FROM work_items WHERE raw_json IS NOT NULL")
+        .map_err(TgaError::from)?;
+    let rows = stmt
+        .query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })
+        .map_err(TgaError::from)?;
+
+    let mut out: HashMap<(String, String), u32> = HashMap::new();
+    for row in rows {
+        let (source, raw_json) = row.map_err(TgaError::from)?;
+        if let Some(parent) = pm_effort::extract::extract_fields(Some(&raw_json)).parent_key {
+            *out.entry((source, parent)).or_insert(0) += 1;
+        }
+    }
+    Ok(out)
+}
+
+/// `ticket_key -> row count` for one of the JIRA fact tables.
+///
+/// `table` is a compile-time literal chosen by the caller, never user input,
+/// so interpolating it carries no injection risk; `rusqlite` cannot bind a
+/// table name as a parameter.
+fn counts_by_ticket(conn: &Connection, table: &'static str) -> Result<HashMap<String, u32>> {
+    let sql = format!("SELECT ticket_key, COUNT(*) FROM {table} GROUP BY ticket_key");
+    let mut stmt = conn.prepare(&sql).map_err(TgaError::from)?;
+    let rows = stmt
+        .query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+        })
+        .map_err(TgaError::from)?;
+
+    let mut out = HashMap::new();
+    for row in rows {
+        let (key, count) = row.map_err(TgaError::from)?;
+        out.insert(key, u32::try_from(count).unwrap_or(u32::MAX));
+    }
+    Ok(out)
+}
+
+/// Upsert one `fact_pm_effort` row.
+///
+/// Idempotent: `INSERT OR REPLACE` against the
+/// `(work_item_id, work_item_source)` primary key, so re-running the scorer
+/// over an unchanged corpus rewrites the same rows and adds none.
+/// `formula_version` is written from
+/// [`crate::core::pm_effort::FORMULA_VERSION`] and is deliberately NOT part
+/// of the key — the table holds the current score per ticket, and the
+/// version column records which weight set produced it.
+///
+/// A deferred ticket stores NULL in both `effort_score` and `effort_bucket`,
+/// never a zero: see the `score_status` column's rationale in the migration.
+///
+/// Test: `backfill_pm_effort_is_idempotent`,
+/// `a_recent_epic_is_recorded_as_deferred_not_scored_zero`.
+///
+/// # Errors
+///
+/// Returns [`TgaError::DbError`] if the SQL execution fails. A foreign-key
+/// violation surfaces here when the referenced `work_items` row is absent.
+pub fn upsert_pm_effort(conn: &Connection, row: &PmEffortRow) -> Result<()> {
+    let computed_at = chrono::Utc::now().timestamp();
+    conn.execute(
+        "INSERT OR REPLACE INTO fact_pm_effort \
+         (work_item_id, work_item_source, pm_name, week_key, effort_score, effort_bucket, \
+          score_status, epic_children_count, description_word_count, comment_count, \
+          transition_count, story_points, inputs_present, age_days_at_score, \
+          formula_version, computed_at) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)",
+        params![
+            row.work_item_id,
+            row.work_item_source,
+            row.pm_name,
+            row.week_key,
+            row.score.effort_score,
+            row.score.effort_bucket.map(EffortBucket::as_wire_str),
+            row.score.status.as_wire_str(),
+            row.counts.epic_children,
+            row.counts.description_words,
+            row.counts.comments,
+            row.counts.transitions,
+            row.counts.story_points,
+            row.score.inputs_present.to_wire_string(),
+            row.age_days,
+            pm_effort::FORMULA_VERSION,
+            computed_at,
+        ],
+    )
+    .map_err(TgaError::from)?;
+    debug!(
+        id = %row.work_item_id,
+        source = %row.work_item_source,
+        status = %row.score.status,
+        score = ?row.score.effort_score,
+        "upserted pm effort score"
+    );
+    Ok(())
+}
+
+/// Delete `fact_pm_effort` rows whose ticket is no longer meaningful.
+///
+/// Why: the meaningfulness gate is only durable if it is re-applied. Without
+/// this, a ticket that `tga backfill pm-work` reclassified as boilerplate —
+/// after a retune, or after its payload was re-collected — would keep the
+/// effort row an earlier run wrote, and the excluded ticket would go on
+/// contributing to every dashboard that reads this table.
+/// What: one `DELETE` for every row with no matching
+/// `fact_pm_work` row marked meaningful. Returns the number deleted.
+/// Test: `a_ticket_that_becomes_non_meaningful_loses_its_effort_row`.
+///
+/// # Errors
+///
+/// Returns [`TgaError::DbError`] if the delete fails.
+pub fn prune_non_meaningful_effort(conn: &Connection) -> Result<usize> {
+    let deleted = conn
+        .execute(
+            "DELETE FROM fact_pm_effort WHERE NOT EXISTS ( \
+               SELECT 1 FROM fact_pm_work f \
+               WHERE f.work_item_id = fact_pm_effort.work_item_id \
+                 AND f.work_item_source = fact_pm_effort.work_item_source \
+                 AND f.is_meaningful = 1)",
+            [],
+        )
+        .map_err(TgaError::from)?;
+    Ok(deleted)
+}
+
+/// Count `fact_pm_effort` rows per bucket, plus the deferred total.
+///
+/// Returns `(deferred_count, [(bucket, count), ...])` with the buckets in
+/// LOW / MEDIUM / HIGH order. A row whose stored bucket or status this
+/// binary does not recognise — written by a newer `formula_version` — is
+/// skipped rather than miscounted.
+///
+/// # Errors
+///
+/// Returns [`TgaError::DbError`] if the query fails.
+pub fn summarize_effort(conn: &Connection) -> Result<(i64, Vec<(EffortBucket, i64)>)> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT score_status, effort_bucket, COUNT(*) FROM fact_pm_effort \
+             GROUP BY score_status, effort_bucket",
+        )
+        .map_err(TgaError::from)?;
+    let rows = stmt
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, Option<String>>(1)?,
+                row.get::<_, i64>(2)?,
+            ))
+        })
+        .map_err(TgaError::from)?;
+
+    let mut deferred = 0i64;
+    let mut by_bucket: HashMap<EffortBucket, i64> = HashMap::new();
+    for row in rows {
+        let (status, bucket, count) = row.map_err(TgaError::from)?;
+        match ScoreStatus::from_wire_str(&status) {
+            Some(ScoreStatus::DeferredRecent) => deferred += count,
+            Some(ScoreStatus::Scored) => {
+                match bucket.as_deref().and_then(EffortBucket::from_wire_str) {
+                    Some(b) => *by_bucket.entry(b).or_insert(0) += count,
+                    None => debug!(bucket = ?bucket, "skipping unrecognised effort_bucket"),
+                }
+            }
+            None => debug!(status = %status, "skipping unrecognised score_status"),
+        }
+    }
+
+    let ordered = [EffortBucket::Low, EffortBucket::Medium, EffortBucket::High]
+        .into_iter()
+        .map(|b| (b, by_bucket.get(&b).copied().unwrap_or(0)))
+        .collect();
+    Ok((deferred, ordered))
+}

--- a/crates/trusty-git-analytics/src/core/db/sql/0027_fact_pm_effort.sql
+++ b/crates/trusty-git-analytics/src/core/db/sql/0027_fact_pm_effort.sql
@@ -1,0 +1,79 @@
+-- Migration v27: PM effort tier — complexity score per meaningful ticket
+-- (issue #3915).
+--
+-- The Activity / Work / Effort model (epic #3914) realizes its EFFORT tier
+-- for PM tickets here. `fact_pm_work` (migration v26) answered "is this
+-- ticket real management labor?"; `fact_pm_effort` answers "how much
+-- complexity did producing it require?". `fact_commit_effort` (migration
+-- v16) is the engineering counterpart.
+--
+-- SCALE SEPARATION: `effort_score` here runs 1.0–50.0 and is counted in PM
+-- complexity points; `fact_commit_effort.effort_score` runs 2.5–45 and is
+-- counted in commit effort points. The overlapping numeric ranges are a
+-- coincidence of scaling, not a shared unit — the two must never share a
+-- visualization axis. See #3917.
+--
+-- Design decisions:
+--   * Grain and key: (work_item_id, work_item_source), matching
+--     `work_items(id, source)` and `fact_pm_work`. Ticket IDs are unique per
+--     PM source, not globally (see migration v5).
+--   * FOREIGN KEY back to `work_items`, same reasoning as v26: every row is
+--     DERIVED from a `work_items` row.
+--   * ONLY tickets that `fact_pm_work` marks `is_meaningful = 1` are scored.
+--     An excluded ticket gets NO row here at all — scoring boilerplate would
+--     re-admit through the effort tier exactly what the work tier removed.
+--     The backfill deletes rows whose ticket has since become non-meaningful,
+--     so the meaningfulness gate cannot go stale.
+--   * `effort_score` and `effort_bucket` are NULLABLE and `score_status`
+--     says why. A ticket inside the recency floor is recorded as
+--     'DEFERRED_RECENT' with a NULL score, never as a zero: issue #3915's
+--     Rohit case is three epics authored the same day that had no children
+--     yet, and a zero would have read as "no complexity" rather than "too
+--     early to tell".
+--   * The inputs the score was computed from are stored alongside it
+--     (`epic_children_count`, `description_word_count`, `comment_count`,
+--     `transition_count`, `story_points`) so a retune can be evaluated
+--     against stored rows without re-reading upstream payloads.
+--   * `story_points` is NULLABLE and carries no weight when absent. It is
+--     76% NULL across four per-project custom-field IDs on the source JIRA
+--     instance (see migration v23 and `core::pm_effort::extract`), so a row
+--     with a NULL here is the common case, not a defect. `inputs_present`
+--     names which inputs actually contributed, so a consumer can compare
+--     like with like instead of assuming every score used the same signals.
+--   * `formula_version` names the weight set that produced the score
+--     ('pm-effort-1' for v1). A retune is a NEW version string, never an
+--     edit of the v1 constants — see `core::pm_effort::thresholds`.
+--   * No `formula_version` in the primary key: the table holds the CURRENT
+--     score per ticket, and re-running the scorer replaces a row rather than
+--     accumulating one per version. Same choice as v16 and v26.
+--   * `computed_at` is a Unix timestamp (integer seconds), matching v16/v26.
+--
+-- Additive migration: no existing table is modified.
+
+CREATE TABLE IF NOT EXISTS fact_pm_effort (
+    work_item_id          TEXT NOT NULL,
+    work_item_source      TEXT NOT NULL,     -- 'azdo' | 'jira' | 'github' | 'linear'
+    pm_name               TEXT,              -- reporter display name; NULL when the payload has none
+    week_key              TEXT,              -- ISO week the ticket was created, 'YYYY-Www'; NULL when unknown
+    effort_score          REAL,              -- 1.0–50.0; NULL when score_status <> 'SCORED'
+    effort_bucket         TEXT,              -- 'LOW' | 'MEDIUM' | 'HIGH'; NULL when not scored
+    score_status          TEXT NOT NULL,     -- 'SCORED' | 'DEFERRED_RECENT'
+    epic_children_count   INTEGER NOT NULL,  -- work_items naming this ticket as parent
+    description_word_count INTEGER NOT NULL, -- words of plain-text description
+    comment_count         INTEGER NOT NULL,  -- fact_jira_comment_detail rows
+    transition_count      INTEGER NOT NULL,  -- fact_ticket_transitions rows
+    story_points          REAL,              -- NULL when absent or outside the plausible range
+    inputs_present        TEXT NOT NULL,     -- comma-separated contributing inputs, or 'NONE'
+    age_days_at_score     INTEGER,           -- ticket age in days when scored; NULL when the creation date is unknown
+    formula_version       TEXT NOT NULL DEFAULT 'pm-effort-1',
+    computed_at           INTEGER NOT NULL,  -- unix timestamp (seconds)
+    PRIMARY KEY (work_item_id, work_item_source),
+    FOREIGN KEY (work_item_id, work_item_source) REFERENCES work_items(id, source)
+);
+
+CREATE INDEX IF NOT EXISTS idx_fact_pm_effort_bucket
+    ON fact_pm_effort(effort_bucket);
+CREATE INDEX IF NOT EXISTS idx_fact_pm_effort_status
+    ON fact_pm_effort(score_status);
+CREATE INDEX IF NOT EXISTS idx_fact_pm_effort_pm_week
+    ON fact_pm_effort(pm_name, week_key);

--- a/crates/trusty-git-analytics/src/core/mod.rs
+++ b/crates/trusty-git-analytics/src/core/mod.rs
@@ -11,6 +11,7 @@
 //! - [`db`] — SQLite database wrapper with WAL mode and versioned migrations
 //! - [`errors`] — crate-wide error enum and `Result` alias
 //! - [`models`] — domain structs for commits, authors, classifications, etc.
+//! - [`pm_effort`] — PM ticket complexity scoring (#3915)
 //! - [`pm_work`] — PM ticket meaningfulness classification (#3916)
 //! - [`progress`] — optional, non-blocking pipeline progress bus (#5197)
 //! - [`quality`] — per-engineer-per-week quality scoring (1–5 T-shirt)
@@ -23,6 +24,7 @@ pub mod effort;
 pub mod effort_percentile;
 pub mod errors;
 pub mod models;
+pub mod pm_effort;
 pub mod pm_work;
 pub mod progress;
 pub mod quality;

--- a/crates/trusty-git-analytics/src/core/pm_effort/extract.rs
+++ b/crates/trusty-git-analytics/src/core/pm_effort/extract.rs
@@ -1,0 +1,164 @@
+//! Pull the two effort-only fields out of a `work_items.raw_json` payload
+//! (issue #3915): story points, and the parent key that makes a ticket a
+//! child of some epic.
+//!
+//! Why: [`crate::core::pm_work::extract`] already recovers reporter,
+//! description and creation date, and the effort scorer reuses it verbatim.
+//! What it does not recover is story points — the one field issue #3915
+//! calls out as structurally unreliable — or the parent link that lets the
+//! loader count an epic's children. Both are effort-tier concerns, so they
+//! live here rather than widening the work-tier extractor.
+//!
+//! What: [`extract_fields`] is a best-effort parse. A missing or
+//! unparseable field yields `None` rather than failing the row.
+//!
+//! # Story points across four custom-field IDs
+//!
+//! `JiraClient::get_story_point_field` (`collect/jira/client.rs`) discovers
+//! the field at COLLECT time by asking `/rest/api/3/field` for a descriptor
+//! whose NAME is "Story Points" or "Story point estimate", then caches the
+//! single ID it found. That discovery is unavailable here: the backfill
+//! reads payloads already on disk, with no descriptor list and no HTTP.
+//!
+//! This module reuses the same discovery SHAPE offline — match by field
+//! name first, fall back to a known-ID list — because one global lookup is
+//! exactly what migration v23 warns is insufficient. The source instance
+//! spells the field as four different per-project custom-field IDs
+//! (`customfield_10004` / `10016` / `13001` / `13737`), so a payload
+//! collected from one project carries a key a payload from another never
+//! will. [`super::thresholds::STORY_POINT_FIELD_NAMES`] and
+//! [`super::thresholds::STORY_POINT_FIELD_IDS`] are the v1 lists, tried in
+//! that order.
+//!
+//! Test: `tests` in `tests.rs`.
+
+use serde_json::Value;
+
+use super::{plausible_story_points, thresholds};
+
+/// The effort-only fields recovered from one `raw_json` payload.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct EffortFields {
+    /// Story points, already range-checked by
+    /// [`super::plausible_story_points`]. `None` when the payload carried
+    /// no recognised field, an unparseable value, or an implausible one —
+    /// all three are the same thing to the scorer, which simply drops the
+    /// term.
+    pub story_points: Option<f64>,
+    /// The key of this ticket's parent, when it has one. The loader inverts
+    /// these into per-parent child counts.
+    pub parent_key: Option<String>,
+}
+
+/// Parse `raw_json` into the fields the effort scorer reads.
+///
+/// Why: see the module docs.
+/// What: parses once and reads both fields off the same tree, so the
+/// backfill pays one `serde_json` parse per ticket for the effort tier.
+/// An unparseable payload yields [`EffortFields::default`].
+/// Test: `extracts_story_points_from_a_named_field`,
+/// `extracts_story_points_from_each_known_custom_field_id`,
+/// `implausible_story_points_are_treated_as_absent`,
+/// `extracts_a_jira_parent_key`, `unparseable_payload_yields_no_fields`.
+#[must_use]
+pub fn extract_fields(raw_json: Option<&str>) -> EffortFields {
+    let Some(text) = raw_json else {
+        return EffortFields::default();
+    };
+    let Ok(v) = serde_json::from_str::<Value>(text) else {
+        return EffortFields::default();
+    };
+    let fields = v.get("fields");
+
+    EffortFields {
+        story_points: extract_story_points(&v, fields),
+        parent_key: extract_parent_key(&v, fields),
+    }
+}
+
+/// Story points, by field name first and known custom-field ID second.
+///
+/// The name pass is what keeps this working on an instance whose field ID
+/// is not in the v1 list: JIRA payloads collected with `*all` carry the
+/// custom-field keys, but Linear and Azure DevOps payloads name the field
+/// outright. The ID pass is what keeps it working on the four spellings
+/// issue #3915 measured.
+fn extract_story_points(root: &Value, fields: Option<&Value>) -> Option<f64> {
+    for object in [fields, Some(root)].into_iter().flatten() {
+        let Some(map) = object.as_object() else {
+            continue;
+        };
+        for (key, value) in map {
+            if thresholds::STORY_POINT_FIELD_NAMES.contains(&normalize_key(key).as_str()) {
+                if let Some(points) = numeric(value).and_then(plausible_story_points) {
+                    return Some(points);
+                }
+            }
+        }
+        for id in thresholds::STORY_POINT_FIELD_IDS {
+            if let Some(points) = map
+                .get(*id)
+                .and_then(numeric)
+                .and_then(plausible_story_points)
+            {
+                return Some(points);
+            }
+        }
+    }
+    None
+}
+
+/// Lowercase `key` and drop every non-alphanumeric character, so
+/// `"Story Points"`, `"story_points"` and `"storyPoints"` all compare equal.
+fn normalize_key(key: &str) -> String {
+    key.chars()
+        .filter(|c| c.is_alphanumeric())
+        .flat_map(char::to_lowercase)
+        .collect()
+}
+
+/// A number from either a JSON number or a numeric string.
+///
+/// Some JIRA custom fields serialize the estimate as a string; a value that
+/// is neither is not an error, just not a story point.
+fn numeric(value: &Value) -> Option<f64> {
+    match value {
+        Value::Number(n) => n.as_f64(),
+        Value::String(s) => s.trim().parse::<f64>().ok(),
+        _ => None,
+    }
+}
+
+/// Parent ticket key across the four providers.
+///
+/// JIRA nests it at `fields.parent.key`; Azure DevOps flattens the parent
+/// work-item id into `fields["System.Parent"]`; Linear and GitHub expose a
+/// top-level `parent` object. Migration v23 records that decomposition on
+/// the source instance runs through `parent_key`, never `epic_key`, which is
+/// 100% NULL there — so this is the only link that yields a child count.
+fn extract_parent_key(root: &Value, fields: Option<&Value>) -> Option<String> {
+    let candidates = [
+        fields.and_then(|f| f.get("parent")),
+        fields.and_then(|f| f.get("System.Parent")),
+        root.get("parent"),
+    ];
+    candidates.into_iter().flatten().find_map(key_of)
+}
+
+/// A ticket key from either a bare scalar or a provider's parent object.
+fn key_of(value: &Value) -> Option<String> {
+    match value {
+        Value::String(s) => non_empty(s),
+        Value::Number(n) => Some(n.to_string()),
+        Value::Object(_) => ["key", "identifier", "id", "number"]
+            .into_iter()
+            .find_map(|k| value.get(k).and_then(key_of)),
+        _ => None,
+    }
+}
+
+/// `Some(trimmed)` when `s` has non-whitespace content.
+fn non_empty(s: &str) -> Option<String> {
+    let trimmed = s.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
+}

--- a/crates/trusty-git-analytics/src/core/pm_effort/mod.rs
+++ b/crates/trusty-git-analytics/src/core/pm_effort/mod.rs
@@ -1,0 +1,482 @@
+//! PM effort scoring — the EFFORT tier of the Activity / Work / Effort model
+//! for tickets (issue #3915, epic #3914).
+//!
+//! Why: `fact_pm_work` (#3916) answers whether a ticket is real management
+//! labor. It does not say how much complexity producing it required, so a
+//! one-paragraph bug and a decomposed platform epic still count the same.
+//! This module scores that complexity, and the score is persisted to
+//! `fact_pm_effort` (`core::db::pm_effort`).
+//!
+//! What: [`score`] is a deterministic function of one ticket's item type,
+//! age, child count, description length, comment count, transition count and
+//! story points. Every input is already in the database — there is no LLM
+//! tier in v1, matching `core::pm_work`.
+//!
+//! Test: `tests` in `tests.rs`.
+//!
+//! # Two guards the raw formula does not provide
+//!
+//! **Recency.** Issue #3915's motivating case is three epics authored on
+//! 2026-07-09 that had zero children at scoring time — too new to have been
+//! decomposed, not simple. A ticket whose type accrues children and that is
+//! younger than [`thresholds::RECENCY_FLOOR_DAYS`] is recorded as
+//! [`ScoreStatus::DeferredRecent`] with NO score rather than a low one. See
+//! [`score`].
+//!
+//! **Meaningfulness.** Only tickets `fact_pm_work` marks meaningful are
+//! scored at all. That gate lives in the loader
+//! ([`crate::core::db::load_effort_candidates`]) rather than here, because it
+//! is a question about a different table's verdict, not about this ticket's
+//! complexity.
+//!
+//! # Versioning
+//!
+//! Every persisted row records [`FORMULA_VERSION`]. The numbers in
+//! [`thresholds`] are v1 constants: a retune ships as a NEW version string,
+//! never as an edit of the values there.
+
+pub mod extract;
+
+use std::fmt;
+
+/// Weight set version baked into every persisted `fact_pm_effort` row.
+///
+/// Why: issue #3915 marks every threshold and weight "TBD, refine with
+/// product", so v1 will be retuned. An already-stored score must keep naming
+/// the weight set that produced it.
+/// What: the string `"pm-effort-1"`, written to
+/// `fact_pm_effort.formula_version`.
+/// Test: `scorer_reports_the_v1_formula_version`.
+pub const FORMULA_VERSION: &str = "pm-effort-1";
+
+/// v1 weights, caps and thresholds (`formula_version = "pm-effort-1"`).
+///
+/// Why: issue #3915 states the scoring formula as an example and marks the
+/// bucket boundaries "TBD by data distribution". Everything tunable
+/// therefore lives in this one block, so a retune is a reviewable diff of
+/// this module plus a bump of [`FORMULA_VERSION`] — never a scattered edit
+/// that silently changes what already-stored rows meant. Nothing outside
+/// this block is tunable.
+/// What: the additive weights, their per-input caps, the score range, the
+/// bucket boundaries, the recency floor, and the story-point field
+/// spellings.
+/// Test: `weights_sum_to_the_documented_score_ceiling`,
+/// `bucket_boundaries_are_the_documented_thresholds`.
+pub mod thresholds {
+    /// Floor of the v1 score range. Every scored ticket gets at least this,
+    /// because a meaningful ticket is by definition non-zero labor.
+    pub const BASE_SCORE: f64 = 1.0;
+
+    /// Lower bound of the stored `effort_score`, equal to [`BASE_SCORE`].
+    pub const MIN_SCORE: f64 = 1.0;
+
+    /// Upper bound of the stored `effort_score`. Issue #3915 asks for a
+    /// 1–50 range so a reader cannot mistake a PM score for an engineering
+    /// one (`fact_commit_effort` runs 2.5–45). The two remain incommensurable
+    /// units regardless — see #3917.
+    pub const MAX_SCORE: f64 = 50.0;
+
+    /// Score added per direct child of a decomposed ticket.
+    pub const CHILD_WEIGHT: f64 = 2.0;
+    /// Children beyond this count add nothing: past ten, child count says
+    /// more about decomposition style than about complexity.
+    pub const CHILD_COUNT_CAP: u32 = 10;
+
+    /// Description words that buy one point of score.
+    pub const BODY_WORDS_PER_POINT: f64 = 40.0;
+    /// Ceiling on the description term, so a pasted stack trace cannot
+    /// dominate the score.
+    pub const BODY_POINTS_CAP: f64 = 12.0;
+
+    /// Score added per comment on the ticket.
+    pub const COMMENT_WEIGHT: f64 = 0.8;
+    /// Comments beyond this count add nothing.
+    pub const COMMENT_COUNT_CAP: u32 = 10;
+
+    /// Score added per recorded status transition.
+    pub const TRANSITION_WEIGHT: f64 = 0.5;
+    /// Transitions beyond this count add nothing.
+    pub const TRANSITION_COUNT_CAP: u32 = 12;
+
+    /// Score added per story point, when story points are present at all.
+    pub const STORY_POINT_WEIGHT: f64 = 0.4;
+    /// Ceiling on the story-point term. Deliberately small: the field is 76%
+    /// NULL on the source instance (issue #3915), so letting it move the
+    /// score much would systematically advantage the minority of tickets
+    /// that carry it.
+    pub const STORY_POINT_CAP: f64 = 3.0;
+    /// Smallest story-point value treated as real. Below this is a
+    /// placeholder, not an estimate.
+    pub const STORY_POINTS_MIN: f64 = 0.5;
+    /// Largest story-point value treated as real. Above this the field is
+    /// being used for something other than an estimate — the same custom
+    /// field ID means something different in another project.
+    pub const STORY_POINTS_MAX: f64 = 40.0;
+
+    /// Lowest score in the MEDIUM bucket; below it is LOW.
+    pub const BUCKET_MEDIUM_MIN: f64 = 15.0;
+    /// Lowest score in the HIGH bucket.
+    pub const BUCKET_HIGH_MIN: f64 = 30.0;
+
+    /// A ticket of an age-floored type younger than this many days is not
+    /// scored. Issue #3915's acceptance criterion, stated verbatim: "only
+    /// score epics ≥7 days old".
+    pub const RECENCY_FLOOR_DAYS: i64 = 7;
+
+    /// Item types whose complexity accrues after creation, lowercased.
+    ///
+    /// These are the types that get DECOMPOSED — their `epic_children_count`
+    /// input is zero on the day they are filed and grows as the team breaks
+    /// them down. Scoring one immediately reads "not yet decomposed" as
+    /// "simple", which is the recency bias the floor exists to prevent. A
+    /// bug or task has no such input, so the floor would only delay its
+    /// score for nothing.
+    pub const AGE_FLOORED_ITEM_TYPES: &[&str] = &["epic", "feature", "initiative"];
+
+    /// Per-project story-point custom-field IDs observed on the source JIRA
+    /// instance (issue #3915). Tried in order after the name-keyed
+    /// spellings.
+    pub const STORY_POINT_FIELD_IDS: &[&str] = &[
+        "customfield_10004",
+        "customfield_10016",
+        "customfield_13001",
+        "customfield_13737",
+    ];
+
+    /// Story-point field spellings matched by name rather than ID, compared
+    /// after lowercasing and dropping non-alphanumeric characters. The first
+    /// two mirror `JiraClient::get_story_point_field`'s live discovery;
+    /// `estimate` is Linear's spelling of the same quantity.
+    pub const STORY_POINT_FIELD_NAMES: &[&str] = &["storypoints", "storypointestimate", "estimate"];
+}
+
+/// T-shirt bucket for a scored ticket.
+///
+/// Why: the consumer (cto-reports) groups by bucket rather than by raw
+/// score, the same way `fact_commit_effort` is read through its T-shirt bin.
+/// What: a three-valued enum stored as text in
+/// `fact_pm_effort.effort_bucket`, NULL when the ticket was not scored.
+/// Test: `effort_bucket_round_trips_through_its_wire_string`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum EffortBucket {
+    /// Score below [`thresholds::BUCKET_MEDIUM_MIN`].
+    Low,
+    /// Score in `[BUCKET_MEDIUM_MIN, BUCKET_HIGH_MIN)`.
+    Medium,
+    /// Score at or above [`thresholds::BUCKET_HIGH_MIN`].
+    High,
+}
+
+impl EffortBucket {
+    /// The value stored in `fact_pm_effort.effort_bucket`.
+    #[must_use]
+    pub const fn as_wire_str(self) -> &'static str {
+        match self {
+            Self::Low => "LOW",
+            Self::Medium => "MEDIUM",
+            Self::High => "HIGH",
+        }
+    }
+
+    /// Parse a stored `fact_pm_effort.effort_bucket` value.
+    ///
+    /// Returns `None` for an unrecognised string — a row written by a newer
+    /// `formula_version` — so callers decide whether to skip or fail.
+    #[must_use]
+    pub fn from_wire_str(s: &str) -> Option<Self> {
+        match s {
+            "LOW" => Some(Self::Low),
+            "MEDIUM" => Some(Self::Medium),
+            "HIGH" => Some(Self::High),
+            _ => None,
+        }
+    }
+
+    /// The bucket a v1 score falls in.
+    #[must_use]
+    pub fn of_score(score: f64) -> Self {
+        if score >= thresholds::BUCKET_HIGH_MIN {
+            Self::High
+        } else if score >= thresholds::BUCKET_MEDIUM_MIN {
+            Self::Medium
+        } else {
+            Self::Low
+        }
+    }
+}
+
+impl fmt::Display for EffortBucket {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_wire_str())
+    }
+}
+
+/// Whether a ticket was scored, and if not, why not.
+///
+/// Why: a deferred ticket must be distinguishable from a genuinely simple
+/// one. Storing the deferral as a status with a NULL score is what stops a
+/// consumer averaging "too early to tell" in as a zero — issue #3915's
+/// stated failure mode.
+/// What: stored as text in `fact_pm_effort.score_status`; every row carries
+/// one, so a consumer can filter without a COALESCE.
+/// Test: `score_status_round_trips_through_its_wire_string`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ScoreStatus {
+    /// The ticket carries an `effort_score` and an `effort_bucket`.
+    Scored,
+    /// The ticket is inside the recency floor: too new for its complexity to
+    /// have materialized. Score and bucket are NULL.
+    DeferredRecent,
+}
+
+impl ScoreStatus {
+    /// The value stored in `fact_pm_effort.score_status`.
+    #[must_use]
+    pub const fn as_wire_str(self) -> &'static str {
+        match self {
+            Self::Scored => "SCORED",
+            Self::DeferredRecent => "DEFERRED_RECENT",
+        }
+    }
+
+    /// Parse a stored `fact_pm_effort.score_status` value; `None` when
+    /// unrecognised.
+    #[must_use]
+    pub fn from_wire_str(s: &str) -> Option<Self> {
+        match s {
+            "SCORED" => Some(Self::Scored),
+            "DEFERRED_RECENT" => Some(Self::DeferredRecent),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for ScoreStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_wire_str())
+    }
+}
+
+/// The five measured quantities the v1 formula reads, as stored on the row.
+///
+/// Separate from [`PmEffortInput`] so the persistence layer can carry the
+/// inputs and the score together without restating each field.
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct EffortCounts {
+    /// `work_items` rows naming this ticket as their parent.
+    pub epic_children: u32,
+    /// Words of plain-text description.
+    pub description_words: u32,
+    /// `fact_jira_comment_detail` rows for this ticket.
+    pub comments: u32,
+    /// `fact_ticket_transitions` rows for this ticket.
+    pub transitions: u32,
+    /// Story points, when the payload carried a plausible value. `None` is
+    /// the common case (76% NULL on the source instance) and costs the
+    /// ticket nothing beyond that one term — see [`score`].
+    pub story_points: Option<f64>,
+}
+
+/// Everything the v1 scorer reads about one ticket.
+#[derive(Debug, Clone, Copy)]
+pub struct PmEffortInput<'a> {
+    /// `work_items.item_type`, matched case-insensitively against
+    /// [`thresholds::AGE_FLOORED_ITEM_TYPES`].
+    pub item_type: &'a str,
+    /// Whole days between the ticket's creation and the scoring run. `None`
+    /// when the payload carried no parseable creation timestamp, in which
+    /// case the recency floor cannot be applied and the ticket is scored.
+    pub age_days: Option<i64>,
+    /// The measured inputs.
+    pub counts: EffortCounts,
+}
+
+/// Which inputs contributed a non-zero term to a score.
+///
+/// Why: issue #3915 requires that a missing story-point value degrade the
+/// formula rather than zero it. A consumer therefore cannot assume two
+/// scores were built from the same signals, and needs the row to say which
+/// ones were.
+/// What: one flag per formula term, serialized to
+/// `fact_pm_effort.inputs_present` by [`InputsPresent::to_wire_string`].
+/// A flag is set when the term's contribution is greater than zero — an
+/// epic with no children and a ticket whose children could not be resolved
+/// are both recorded as not having contributed a child term, because
+/// neither moved the score.
+/// Test: `inputs_present_names_only_contributing_terms`,
+/// `a_ticket_with_no_signal_records_no_inputs`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct InputsPresent {
+    /// The child-count term contributed.
+    pub children: bool,
+    /// The description-length term contributed.
+    pub description: bool,
+    /// The comment-count term contributed.
+    pub comments: bool,
+    /// The transition-count term contributed.
+    pub transitions: bool,
+    /// The story-point term contributed.
+    pub story_points: bool,
+}
+
+impl InputsPresent {
+    /// Serialize to the comma-separated `inputs_present` column value.
+    ///
+    /// Order is fixed (never the order the flags were set) so two runs over
+    /// unchanged data produce byte-identical rows. `"NONE"` when nothing
+    /// contributed, so the column is never empty.
+    #[must_use]
+    pub fn to_wire_string(self) -> String {
+        let mut parts: Vec<&'static str> = Vec::with_capacity(5);
+        if self.children {
+            parts.push("CHILDREN");
+        }
+        if self.description {
+            parts.push("DESCRIPTION");
+        }
+        if self.comments {
+            parts.push("COMMENTS");
+        }
+        if self.transitions {
+            parts.push("TRANSITIONS");
+        }
+        if self.story_points {
+            parts.push("STORY_POINTS");
+        }
+        if parts.is_empty() {
+            return "NONE".to_string();
+        }
+        parts.join(",")
+    }
+}
+
+/// One ticket's effort verdict.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PmEffortScore {
+    /// Whether the ticket was scored at all.
+    pub status: ScoreStatus,
+    /// The score, in `[MIN_SCORE, MAX_SCORE]`, rounded to two decimals.
+    /// `None` exactly when `status` is not [`ScoreStatus::Scored`].
+    pub effort_score: Option<f64>,
+    /// The bucket the score falls in; `None` alongside a `None` score.
+    pub effort_bucket: Option<EffortBucket>,
+    /// Which terms contributed. All false for a deferred ticket.
+    pub inputs_present: InputsPresent,
+}
+
+/// Whether `item_type` names a ticket type whose complexity accrues after
+/// creation, and which the recency floor therefore guards.
+///
+/// Test: `the_recency_floor_applies_only_to_decomposable_types`.
+#[must_use]
+pub fn is_age_floored_type(item_type: &str) -> bool {
+    let lower = item_type.trim().to_lowercase();
+    thresholds::AGE_FLOORED_ITEM_TYPES.contains(&lower.as_str())
+}
+
+/// A story-point value the scorer will use, or `None`.
+///
+/// Why: the field is sourced from four per-project custom-field IDs and is
+/// 76% NULL, so an out-of-range or nonsensical value is a routine
+/// occurrence rather than a corrupt row. Issue #3915's acceptance criterion
+/// is "no crash on inconsistent data".
+/// What: rejects NaN, infinities, and anything outside
+/// `[STORY_POINTS_MIN, STORY_POINTS_MAX]`, which the scorer then treats
+/// identically to an absent value.
+/// Test: `implausible_story_points_are_treated_as_absent`.
+#[must_use]
+pub fn plausible_story_points(points: f64) -> Option<f64> {
+    (points.is_finite()
+        && (thresholds::STORY_POINTS_MIN..=thresholds::STORY_POINTS_MAX).contains(&points))
+    .then_some(points)
+}
+
+/// Score one ticket's PM effort under `formula_version = "pm-effort-1"`.
+///
+/// Why: see the module docs — the EFFORT tier of #3914.
+/// What: the recency floor is applied first, then the score is the sum of
+/// [`thresholds::BASE_SCORE`] and five independently capped terms, clamped
+/// to `[MIN_SCORE, MAX_SCORE]` and rounded to two decimals:
+///
+/// | Term | Weight | Cap |
+/// |---|---|---|
+/// | children | [`thresholds::CHILD_WEIGHT`] each | [`thresholds::CHILD_COUNT_CAP`] children |
+/// | description | 1 per [`thresholds::BODY_WORDS_PER_POINT`] words | [`thresholds::BODY_POINTS_CAP`] |
+/// | comments | [`thresholds::COMMENT_WEIGHT`] each | [`thresholds::COMMENT_COUNT_CAP`] comments |
+/// | transitions | [`thresholds::TRANSITION_WEIGHT`] each | [`thresholds::TRANSITION_COUNT_CAP`] transitions |
+/// | story points | [`thresholds::STORY_POINT_WEIGHT`] each | [`thresholds::STORY_POINT_CAP`] |
+///
+/// The terms are additive and independent, which is what makes a missing
+/// input DEGRADE the score rather than zero it: an absent or implausible
+/// story-point value simply drops its term, and the other four still
+/// produce a score. [`PmEffortScore::inputs_present`] records which terms
+/// actually fired so a consumer never has to assume.
+///
+/// Test: `a_substantive_epic_scores_in_the_high_bucket`,
+/// `missing_story_points_degrade_rather_than_zero_the_score`,
+/// `a_recent_epic_is_deferred_rather_than_scored_low`,
+/// `each_term_is_capped_independently`,
+/// `the_score_never_leaves_the_documented_range`.
+#[must_use]
+pub fn score(input: &PmEffortInput<'_>) -> PmEffortScore {
+    if is_age_floored_type(input.item_type)
+        && input
+            .age_days
+            .is_some_and(|days| days < thresholds::RECENCY_FLOOR_DAYS)
+    {
+        return PmEffortScore {
+            status: ScoreStatus::DeferredRecent,
+            effort_score: None,
+            effort_bucket: None,
+            inputs_present: InputsPresent::default(),
+        };
+    }
+
+    let counts = input.counts;
+    let children =
+        capped_count(counts.epic_children, thresholds::CHILD_COUNT_CAP) * thresholds::CHILD_WEIGHT;
+    let description = (f64::from(counts.description_words) / thresholds::BODY_WORDS_PER_POINT)
+        .min(thresholds::BODY_POINTS_CAP);
+    let comments =
+        capped_count(counts.comments, thresholds::COMMENT_COUNT_CAP) * thresholds::COMMENT_WEIGHT;
+    let transitions = capped_count(counts.transitions, thresholds::TRANSITION_COUNT_CAP)
+        * thresholds::TRANSITION_WEIGHT;
+    let story_points = counts
+        .story_points
+        .and_then(plausible_story_points)
+        .map_or(0.0, |p| {
+            (p * thresholds::STORY_POINT_WEIGHT).min(thresholds::STORY_POINT_CAP)
+        });
+
+    let raw =
+        thresholds::BASE_SCORE + children + description + comments + transitions + story_points;
+    let clamped = round2(raw.clamp(thresholds::MIN_SCORE, thresholds::MAX_SCORE));
+
+    PmEffortScore {
+        status: ScoreStatus::Scored,
+        effort_score: Some(clamped),
+        effort_bucket: Some(EffortBucket::of_score(clamped)),
+        inputs_present: InputsPresent {
+            children: children > 0.0,
+            description: description > 0.0,
+            comments: comments > 0.0,
+            transitions: transitions > 0.0,
+            story_points: story_points > 0.0,
+        },
+    }
+}
+
+/// `count`, capped at `cap`, as an `f64`.
+fn capped_count(count: u32, cap: u32) -> f64 {
+    f64::from(count.min(cap))
+}
+
+/// Round to two decimals so a re-run over unchanged inputs stores a
+/// byte-identical `effort_score` and the idempotency contract holds.
+fn round2(value: f64) -> f64 {
+    (value * 100.0).round() / 100.0
+}
+
+#[cfg(test)]
+#[path = "tests.rs"]
+mod tests;

--- a/crates/trusty-git-analytics/src/core/pm_effort/tests.rs
+++ b/crates/trusty-git-analytics/src/core/pm_effort/tests.rs
@@ -1,0 +1,430 @@
+//! Unit tests for the PM effort scorer and its payload extractor
+//! (issue #3915).
+//!
+//! Why a separate file: keeps `mod.rs` and `extract.rs` under the 500-SLOC
+//! production cap while covering every bucket, the recency floor, and each
+//! story-point spelling on fixtures.
+
+use super::extract::extract_fields;
+use super::{
+    is_age_floored_type, plausible_story_points, score, thresholds, EffortBucket, EffortCounts,
+    InputsPresent, PmEffortInput, ScoreStatus, FORMULA_VERSION,
+};
+
+/// A ticket with no signal at all, for tests that vary one input.
+fn bare(item_type: &str) -> PmEffortInput<'_> {
+    PmEffortInput {
+        item_type,
+        age_days: Some(365),
+        counts: EffortCounts::default(),
+    }
+}
+
+/// The scored `effort_score`, or a panic naming the status that blocked it.
+fn scored(input: &PmEffortInput<'_>) -> f64 {
+    let verdict = score(input);
+    verdict
+        .effort_score
+        .unwrap_or_else(|| panic!("expected a score, got status {}", verdict.status))
+}
+
+// --- versioning ------------------------------------------------------------
+
+#[test]
+fn scorer_reports_the_v1_formula_version() {
+    assert_eq!(FORMULA_VERSION, "pm-effort-1");
+}
+
+#[test]
+fn effort_bucket_round_trips_through_its_wire_string() {
+    for bucket in [EffortBucket::Low, EffortBucket::Medium, EffortBucket::High] {
+        let wire = bucket.as_wire_str();
+        assert_eq!(
+            EffortBucket::from_wire_str(wire),
+            Some(bucket),
+            "{wire} must round-trip"
+        );
+    }
+    assert_eq!(
+        EffortBucket::from_wire_str("XXL"),
+        None,
+        "an unknown bucket must not be read as LOW"
+    );
+}
+
+#[test]
+fn score_status_round_trips_through_its_wire_string() {
+    for status in [ScoreStatus::Scored, ScoreStatus::DeferredRecent] {
+        let wire = status.as_wire_str();
+        assert_eq!(ScoreStatus::from_wire_str(wire), Some(status));
+    }
+    assert_eq!(ScoreStatus::from_wire_str("DEFERRED_NO_PARENT"), None);
+}
+
+/// The v1 weights are chosen so a ticket that maxes out every term lands
+/// exactly on the documented ceiling. A retune that breaks this arithmetic
+/// has silently changed the range the buckets were calibrated against.
+#[test]
+fn weights_sum_to_the_documented_score_ceiling() {
+    let ceiling = thresholds::BASE_SCORE
+        + f64::from(thresholds::CHILD_COUNT_CAP) * thresholds::CHILD_WEIGHT
+        + thresholds::BODY_POINTS_CAP
+        + f64::from(thresholds::COMMENT_COUNT_CAP) * thresholds::COMMENT_WEIGHT
+        + f64::from(thresholds::TRANSITION_COUNT_CAP) * thresholds::TRANSITION_WEIGHT
+        + thresholds::STORY_POINT_CAP;
+    assert!(
+        (ceiling - thresholds::MAX_SCORE).abs() < f64::EPSILON,
+        "capped terms sum to {ceiling}, not MAX_SCORE {}",
+        thresholds::MAX_SCORE
+    );
+}
+
+#[test]
+fn bucket_boundaries_are_the_documented_thresholds() {
+    assert_eq!(EffortBucket::of_score(1.0), EffortBucket::Low);
+    assert_eq!(EffortBucket::of_score(14.99), EffortBucket::Low);
+    assert_eq!(
+        EffortBucket::of_score(thresholds::BUCKET_MEDIUM_MIN),
+        EffortBucket::Medium,
+        "the boundary belongs to the higher bucket"
+    );
+    assert_eq!(EffortBucket::of_score(29.99), EffortBucket::Medium);
+    assert_eq!(
+        EffortBucket::of_score(thresholds::BUCKET_HIGH_MIN),
+        EffortBucket::High
+    );
+    assert_eq!(EffortBucket::of_score(50.0), EffortBucket::High);
+}
+
+// --- buckets ---------------------------------------------------------------
+
+/// A bare meaningful ticket scores the base and nothing else: LOW.
+#[test]
+fn a_ticket_with_no_signal_records_no_inputs() {
+    let verdict = score(&bare("Task"));
+    assert_eq!(verdict.status, ScoreStatus::Scored);
+    assert_eq!(verdict.effort_score, Some(1.0));
+    assert_eq!(verdict.effort_bucket, Some(EffortBucket::Low));
+    assert_eq!(verdict.inputs_present, InputsPresent::default());
+    assert_eq!(verdict.inputs_present.to_wire_string(), "NONE");
+}
+
+/// A story with a real body and some discussion: MEDIUM.
+#[test]
+fn a_discussed_story_scores_in_the_medium_bucket() {
+    let mut input = bare("Story");
+    input.counts = EffortCounts {
+        epic_children: 0,
+        description_words: 320, // 320/40 = 8.0
+        comments: 6,            // 6 * 0.8 = 4.8
+        transitions: 4,         // 4 * 0.5 = 2.0
+        story_points: None,
+    };
+    // 1.0 + 8.0 + 4.8 + 2.0 = 15.8
+    let verdict = score(&input);
+    assert_eq!(verdict.effort_score, Some(15.8));
+    assert_eq!(verdict.effort_bucket, Some(EffortBucket::Medium));
+}
+
+/// A decomposed, long-lived epic: HIGH.
+#[test]
+fn a_substantive_epic_scores_in_the_high_bucket() {
+    let mut input = bare("Epic");
+    input.counts = EffortCounts {
+        epic_children: 9,        // 9 * 2.0 = 18.0
+        description_words: 400,  // 10.0
+        comments: 5,             // 4.0
+        transitions: 6,          // 3.0
+        story_points: Some(8.0), // 3.2 -> capped at 3.0
+    };
+    // 1.0 + 18.0 + 10.0 + 4.0 + 3.0 + 3.0 = 39.0
+    let verdict = score(&input);
+    assert_eq!(verdict.effort_score, Some(39.0));
+    assert_eq!(verdict.effort_bucket, Some(EffortBucket::High));
+    assert_eq!(
+        verdict.inputs_present.to_wire_string(),
+        "CHILDREN,DESCRIPTION,COMMENTS,TRANSITIONS,STORY_POINTS"
+    );
+}
+
+#[test]
+fn each_term_is_capped_independently() {
+    // Children past the cap add nothing.
+    let mut many_children = bare("Epic");
+    many_children.counts.epic_children = thresholds::CHILD_COUNT_CAP + 40;
+    let mut at_cap = bare("Epic");
+    at_cap.counts.epic_children = thresholds::CHILD_COUNT_CAP;
+    assert_eq!(scored(&many_children), scored(&at_cap));
+
+    // A pasted 100k-word log cannot dominate.
+    let mut huge_body = bare("Bug");
+    huge_body.counts.description_words = 100_000;
+    assert_eq!(
+        scored(&huge_body),
+        thresholds::BASE_SCORE + thresholds::BODY_POINTS_CAP
+    );
+
+    // Comments and transitions likewise.
+    let mut chatty = bare("Bug");
+    chatty.counts.comments = 500;
+    chatty.counts.transitions = 500;
+    assert_eq!(
+        scored(&chatty),
+        thresholds::BASE_SCORE
+            + f64::from(thresholds::COMMENT_COUNT_CAP) * thresholds::COMMENT_WEIGHT
+            + f64::from(thresholds::TRANSITION_COUNT_CAP) * thresholds::TRANSITION_WEIGHT
+    );
+}
+
+#[test]
+fn the_score_never_leaves_the_documented_range() {
+    let mut maxed = bare("Epic");
+    maxed.counts = EffortCounts {
+        epic_children: u32::MAX,
+        description_words: u32::MAX,
+        comments: u32::MAX,
+        transitions: u32::MAX,
+        story_points: Some(thresholds::STORY_POINTS_MAX),
+    };
+    assert_eq!(scored(&maxed), thresholds::MAX_SCORE);
+    assert_eq!(scored(&bare("Task")), thresholds::MIN_SCORE);
+}
+
+// --- story points ----------------------------------------------------------
+
+/// Issue #3915: story_points is 76% NULL, so a missing value must degrade
+/// the formula to its other inputs, never zero the score.
+#[test]
+fn missing_story_points_degrade_rather_than_zero_the_score() {
+    let mut with_points = bare("Story");
+    with_points.counts = EffortCounts {
+        epic_children: 2,
+        description_words: 160,
+        comments: 3,
+        transitions: 2,
+        story_points: Some(5.0),
+    };
+    let mut without = with_points;
+    without.counts.story_points = None;
+
+    // 1.0 + 4.0 + 4.0 + 2.4 + 1.0 = 12.4, plus 2.0 of story points.
+    assert_eq!(scored(&with_points), 14.4);
+    assert_eq!(
+        scored(&without),
+        12.4,
+        "the other four terms must still produce a score"
+    );
+
+    let verdict = score(&without);
+    assert!(
+        !verdict.inputs_present.story_points,
+        "the row must say the story-point term did not fire"
+    );
+    assert_eq!(
+        verdict.inputs_present.to_wire_string(),
+        "CHILDREN,DESCRIPTION,COMMENTS,TRANSITIONS"
+    );
+}
+
+#[test]
+fn implausible_story_points_are_treated_as_absent() {
+    for bad in [
+        0.0,
+        -3.0,
+        thresholds::STORY_POINTS_MAX + 1.0,
+        86_400_000.0,
+        f64::NAN,
+        f64::INFINITY,
+    ] {
+        assert_eq!(
+            plausible_story_points(bad),
+            None,
+            "{bad} must not be read as an estimate"
+        );
+        let mut input = bare("Story");
+        input.counts.story_points = Some(bad);
+        let verdict = score(&input);
+        assert_eq!(
+            verdict.effort_score,
+            Some(thresholds::MIN_SCORE),
+            "{bad} must degrade to the base score, not crash or skew it"
+        );
+        assert!(!verdict.inputs_present.story_points);
+    }
+
+    for good in [
+        thresholds::STORY_POINTS_MIN,
+        3.0,
+        thresholds::STORY_POINTS_MAX,
+    ] {
+        assert_eq!(plausible_story_points(good), Some(good));
+    }
+}
+
+#[test]
+fn inputs_present_names_only_contributing_terms() {
+    let mut input = bare("Epic");
+    input.counts.comments = 2;
+    let verdict = score(&input);
+    assert_eq!(verdict.inputs_present.to_wire_string(), "COMMENTS");
+
+    // Fewer words than one point still contributes a fraction, so the flag
+    // fires; zero words does not.
+    let mut one_word = bare("Task");
+    one_word.counts.description_words = 1;
+    assert!(score(&one_word).inputs_present.description);
+    assert!(!score(&bare("Task")).inputs_present.description);
+}
+
+// --- recency floor ---------------------------------------------------------
+
+/// Issue #3915's motivating case: three epics authored the same day with
+/// zero children. A zero score would read as "no complexity"; the correct
+/// record is "too early to tell".
+#[test]
+fn a_recent_epic_is_deferred_rather_than_scored_low() {
+    for age in [0, 1, thresholds::RECENCY_FLOOR_DAYS - 1] {
+        let mut input = bare("Epic");
+        input.age_days = Some(age);
+        let verdict = score(&input);
+        assert_eq!(
+            verdict.status,
+            ScoreStatus::DeferredRecent,
+            "an epic {age} day(s) old must not be scored"
+        );
+        assert_eq!(verdict.effort_score, None, "never a zero, always NULL");
+        assert_eq!(verdict.effort_bucket, None);
+        assert_eq!(verdict.inputs_present, InputsPresent::default());
+    }
+}
+
+#[test]
+fn an_epic_at_or_past_the_floor_is_scored() {
+    let mut input = bare("Epic");
+    input.age_days = Some(thresholds::RECENCY_FLOOR_DAYS);
+    let verdict = score(&input);
+    assert_eq!(verdict.status, ScoreStatus::Scored);
+    assert_eq!(verdict.effort_score, Some(thresholds::MIN_SCORE));
+}
+
+/// The floor guards types whose child count accrues after creation. A bug
+/// filed yesterday has no such input, so deferring it would withhold a
+/// score for nothing.
+#[test]
+fn the_recency_floor_applies_only_to_decomposable_types() {
+    for floored in ["Epic", "epic", " EPIC ", "Feature", "Initiative"] {
+        assert!(is_age_floored_type(floored), "{floored} must be floored");
+        let mut input = bare(floored);
+        input.age_days = Some(2);
+        assert_eq!(score(&input).status, ScoreStatus::DeferredRecent);
+    }
+    for open in ["Bug", "Task", "Sub-task", "User Story", ""] {
+        assert!(!is_age_floored_type(open), "{open} must not be floored");
+        let mut input = bare(open);
+        input.age_days = Some(2);
+        assert_eq!(
+            score(&input).status,
+            ScoreStatus::Scored,
+            "{open} carries no child input, so the floor must not apply"
+        );
+    }
+}
+
+/// A payload with no parseable creation date cannot be aged, so the floor
+/// cannot fire. Scoring on the other inputs is better than withholding a
+/// score for every ticket whose provider spelled `created` differently.
+#[test]
+fn an_epic_with_an_unknown_age_is_scored_not_deferred() {
+    let mut input = bare("Epic");
+    input.age_days = None;
+    input.counts.epic_children = 3;
+    let verdict = score(&input);
+    assert_eq!(verdict.status, ScoreStatus::Scored);
+    assert_eq!(verdict.effort_score, Some(7.0));
+}
+
+// --- extractor -------------------------------------------------------------
+
+#[test]
+fn extracts_story_points_from_a_named_field() {
+    for (key, raw) in [
+        ("Story Points", serde_json::json!(5)),
+        ("story_points", serde_json::json!(5.0)),
+        ("storyPoints", serde_json::json!("5")),
+        ("Story point estimate", serde_json::json!(5)),
+        ("estimate", serde_json::json!(5)),
+    ] {
+        let payload = serde_json::json!({ "fields": { key: raw } }).to_string();
+        assert_eq!(
+            extract_fields(Some(&payload)).story_points,
+            Some(5.0),
+            "spelling {key} must be recognised"
+        );
+    }
+}
+
+/// Issue #3915: the source instance spells the field as four different
+/// per-project custom-field IDs, so one global lookup is not enough.
+#[test]
+fn extracts_story_points_from_each_known_custom_field_id() {
+    for id in thresholds::STORY_POINT_FIELD_IDS {
+        let payload = serde_json::json!({
+            "fields": { *id: 13.0, "summary": "Blend the occupancy forecast" }
+        })
+        .to_string();
+        assert_eq!(
+            extract_fields(Some(&payload)).story_points,
+            Some(13.0),
+            "{id} must be recognised"
+        );
+    }
+}
+
+#[test]
+fn an_unrecognised_custom_field_yields_no_story_points() {
+    let payload = serde_json::json!({ "fields": { "customfield_99999": 8.0 } }).to_string();
+    assert_eq!(extract_fields(Some(&payload)).story_points, None);
+}
+
+#[test]
+fn an_implausible_stored_value_is_extracted_as_absent() {
+    let payload = serde_json::json!({ "fields": { "customfield_10004": 86_400_000 } }).to_string();
+    assert_eq!(
+        extract_fields(Some(&payload)).story_points,
+        None,
+        "a duration parked in the story-point field is not an estimate"
+    );
+}
+
+#[test]
+fn extracts_a_jira_parent_key() {
+    let payload = serde_json::json!({ "fields": { "parent": { "key": "ML-2314" } } }).to_string();
+    assert_eq!(
+        extract_fields(Some(&payload)).parent_key,
+        Some("ML-2314".to_string())
+    );
+}
+
+#[test]
+fn extracts_a_parent_key_from_each_provider_spelling() {
+    for payload in [
+        serde_json::json!({ "fields": { "System.Parent": 4417 } }),
+        serde_json::json!({ "parent": { "identifier": "4417" } }),
+        serde_json::json!({ "parent": { "number": 4417 } }),
+    ] {
+        assert_eq!(
+            extract_fields(Some(&payload.to_string())).parent_key,
+            Some("4417".to_string()),
+            "payload {payload} must yield a parent key"
+        );
+    }
+}
+
+#[test]
+fn unparseable_payload_yields_no_fields() {
+    for raw in [None, Some("not json"), Some("[]"), Some("{}")] {
+        let fields = extract_fields(raw);
+        assert_eq!(fields.story_points, None, "{raw:?}");
+        assert_eq!(fields.parent_key, None, "{raw:?}");
+    }
+}

--- a/docs/trusty-git-analytics/requirements/database-schema.md
+++ b/docs/trusty-git-analytics/requirements/database-schema.md
@@ -292,6 +292,58 @@ future expansion to GitHub review requests.
 
 ---
 
+### `fact_pm_effort`
+
+PM effort tier (issue #3915): one row per meaningful PM ticket, carrying the
+complexity score that producing it required. Written by `tga backfill pm-effort`
+from `src/core/pm_effort/`. Migration `0027_fact_pm_effort.sql`.
+
+Only tickets `fact_pm_work` marks `is_meaningful = 1` are scored — an excluded
+ticket gets no row at all, and the backfill deletes a row whose ticket has since
+stopped being meaningful. `tga backfill pm-work` must therefore run first.
+
+| Column | Type | Nullable | Notes |
+|---|---|---|---|
+| `work_item_id` | TEXT | no | PK part 1; FK → `work_items(id)` |
+| `work_item_source` | TEXT | no | PK part 2; FK → `work_items(source)`. `jira`, `azdo`, `github`, `linear` |
+| `pm_name` | TEXT | yes | Reporter display name from the upstream payload |
+| `week_key` | TEXT | yes | ISO week the ticket was created, `YYYY-Www` |
+| `effort_score` | REAL | yes | 1.0–50.0; NULL when `score_status <> 'SCORED'` |
+| `effort_bucket` | TEXT | yes | `LOW` (<15) / `MEDIUM` (15–30) / `HIGH` (≥30); NULL alongside a NULL score |
+| `score_status` | TEXT | no | `SCORED` or `DEFERRED_RECENT` |
+| `epic_children_count` | INTEGER | no | `work_items` rows in the same source naming this ticket as parent |
+| `description_word_count` | INTEGER | no | Words of plain-text description |
+| `comment_count` | INTEGER | no | `fact_jira_comment_detail` rows for this ticket |
+| `transition_count` | INTEGER | no | `fact_ticket_transitions` rows for this ticket |
+| `story_points` | REAL | yes | NULL when absent, unparseable, or outside 0.5–40 |
+| `inputs_present` | TEXT | no | Comma-separated contributing terms, or `NONE` |
+| `age_days_at_score` | INTEGER | yes | Ticket age in days when scored; NULL when the creation date is unknown |
+| `formula_version` | TEXT | no | Weight set that produced the score; `pm-effort-1` for v1 |
+| `computed_at` | INTEGER | no | Unix timestamp (seconds) of the write |
+
+**Indexes**: INDEX(`effort_bucket`), INDEX(`score_status`),
+INDEX(`pm_name`, `week_key`).
+
+**Recency floor.** A ticket of a decomposable type (epic, feature, initiative)
+younger than 7 days stores `score_status = 'DEFERRED_RECENT'` with NULL score
+and NULL bucket. A zero would read as "no complexity"; the correct record is
+"too early to tell", because that ticket's child count grows only as the team
+breaks it down. A bug or task has no such input, so the floor does not apply
+to it.
+
+**Story points degrade the score rather than zeroing it.** The field is 76%
+NULL across four per-project custom-field IDs on the source JIRA instance, so
+its term is simply dropped when absent and the other four still produce a
+score. `inputs_present` names which terms fired, so a consumer can compare
+like with like.
+
+**Scale separation.** `effort_score` here is counted in PM complexity points
+and `fact_commit_effort.effort_score` in commit effort points. The overlapping
+numeric ranges (1–50 and 2.5–45) are a coincidence of scaling, not a shared
+unit — the two must never share a visualization axis. See #3917.
+
+---
+
 ## Migration History
 
 Migrations are applied in order from `src/core/db/sql/`. Never modify an applied


### PR DESCRIPTION
Adds `fact_pm_effort` (migration 0027) and a v1 scorer (`formula_version = "pm-effort-1"`): five capped additive terms — children, description length, comments, transitions, story points — clamped to [1, 50] with LOW/MEDIUM/HIGH buckets at 15 and 30, every weight in one `core::pm_effort::thresholds` block marked TBD per the issue. Recency guard defers epic-shaped tickets younger than 7 days (`DEFERRED_RECENT`). Candidates inner-join `fact_pm_work.is_meaningful = 1`, and `prune_non_meaningful_effort` runs on every backfill. New CLI: `tga backfill pm-effort` (`--dry-run`, idempotent via `INSERT OR REPLACE`). Schema doc gains a `fact_pm_effort` section; scale-separation notes cite #3917.

Refs #3915

## Test rung

Rung 5 (new migration + persisted derived rows; code-critic round requested).

```
cargo fmt --all --check && cargo check -p tga --all-targets && cargo clippy -p tga --all-targets -- -D warnings   # exit 0
cargo test -p tga --no-fail-fast              # 1506 passed, 0 failed, 7 ignored (lib) + integration targets all ok
cargo test -p trusty-analyze --no-fail-fast   # direct dependent: 515 + 30 + … passed, 0 failed
bash scripts/check_changelog_fragment.sh && bash scripts/check_line_cap.sh && bash scripts/check_test_pointers.sh && bash scripts/check_sld.sh   # OK
```

26 new tests: 24 unit (`core::pm_effort::tests`), 12 backfill integration, 2 migration. Live verification against a real JIRA corpus (distribution histogram from the issue) is still owed and stays on the issue.

Fix round after code-critic APPROVE (one MEDIUM): migration_v27_preserves_an_existing_v26_database added, shown to fail against a mutated 0027 migration and pass restored.

Pre-push credential scan over `git diff origin/main...HEAD`: PASS, 14 files, confined to crates/trusty-git-analytics and docs/trusty-git-analytics.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
