### PR TITLE
feat(trusty-console): 1 s metric history and per-service CPU samples (Refs #6642)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6596,7 +6596,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11693,7 +11693,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-console"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/trusty-common/changelog.d/6642-one-second-host-window-changed.md
+++ b/crates/trusty-common/changelog.d/6642-one-second-host-window-changed.md
@@ -1,0 +1,6 @@
+Changed
+- The host-metric window is sampled every second instead of every five:
+  `HOST_SAMPLE_INTERVAL_SECS` is `1` and `HOST_HISTORY_CAPACITY` is `600`. The
+  span it covers is the same ten minutes; the console's home-page cards draw a
+  bar per second, which a five-second sample cannot render
+  ([#6642](https://github.com/bobmatnyc/trusty-tools/issues/6642)).

--- a/crates/trusty-common/changelog.d/6642-process-cpu-and-peer-pid-added.md
+++ b/crates/trusty-common/changelog.d/6642-process-cpu-and-peer-pid-added.md
@@ -1,0 +1,18 @@
+Added
+- `sys_metrics::ProcessCpuSampler` measures CPU for a SET of other processes.
+  `SysMetrics` only ever measured the current process, so a supervisor asking
+  "how much CPU is this child using" had nothing to call. One `sysinfo::System`
+  is refreshed once per tick over the tracked pids only — never the whole
+  process table — and a pid whose process exits is dropped, so `cpu_pct` answers
+  `None` rather than reporting a recycled pid's stranger under the old name
+  ([#6642](https://github.com/bobmatnyc/trusty-tools/issues/6642)).
+- `uds::peer_pid` reads which process is on the other end of a Unix-domain
+  connection (`SO_PEERCRED` on Linux, `LOCAL_PEERPID` on Darwin). A UDS daemon
+  publishes no pid anywhere, so the connection a client already makes is the
+  only identifier available. It returns `Option` rather than `Result` because
+  every caller treats "cannot identify the peer" as a metric it does not have —
+  unlike `peer_uid`, whose failure must refuse a connection
+  ([#6642](https://github.com/bobmatnyc/trusty-tools/issues/6642)).
+- `host_metrics::history::MetricRing::last` borrows the newest item, so a caller
+  that wants one point no longer clones the whole 600-point window through
+  `snapshot()` ([#6642](https://github.com/bobmatnyc/trusty-tools/issues/6642)).

--- a/crates/trusty-common/src/host_metrics/history.rs
+++ b/crates/trusty-common/src/host_metrics/history.rs
@@ -11,9 +11,13 @@
 //!      ONE write path; when the ring is full it evicts the oldest item before
 //!      appending, so capacity is never exceeded and insertion order is
 //!      preserved. [`HOST_HISTORY_CAPACITY`] and [`HOST_SAMPLE_INTERVAL_SECS`]
-//!      pin the owner's 10-minute window (120 points at 5 s). Nothing here
+//!      pin the owner's 10-minute window (600 points at 1 s). Nothing here
 //!      persists: the ring is in-memory only and a restart starts an empty
 //!      window by design (owner ruling, epic #6516 Phase 3).
+//!
+//! #6642: the cadence moved from 5 s to 1 s and the capacity from 120 to 600.
+//! The window is the same 10 minutes; each home-page card now draws one bar per
+//! second, which a 5 s sample cannot render.
 //! Test: the inline `tests` module — `push_evicts_oldest_at_capacity`,
 //!      `push_preserves_insertion_order`, `empty_ring_reads_empty`,
 //!      `host_window_is_the_owner_ruling`, `capacity_of_zero_is_clamped_to_one`.
@@ -22,24 +26,26 @@ use std::collections::VecDeque;
 
 use super::HostMetrics;
 
-/// Points retained per metric ring — 120 (#6641).
+/// Points retained per metric ring — 600 (#6641; raised from 120 by #6642).
 ///
-/// Why: the owner's Phase 3 ruling is a 10-minute window sampled every 5 s,
-///      which is exactly 120 points. Naming it once keeps the console, the
-///      history endpoint, and the UI from each hard-coding their own number.
-/// What: `120`.
+/// Why: the owner's ruling is a 10-minute window. #6641 sampled it every 5 s,
+///      which is 120 points; #6642 moved the cadence to 1 s, so the same ten
+///      minutes is 600 points. Naming it once keeps the console, the history
+///      endpoint, and the UI from each hard-coding their own number.
+/// What: `600`.
 /// Test: `host_window_is_the_owner_ruling`.
-pub const HOST_HISTORY_CAPACITY: usize = 120;
+pub const HOST_HISTORY_CAPACITY: usize = 600;
 
-/// Seconds between host samples — 5 (#6641).
+/// Seconds between host samples — 1 (#6641; lowered from 5 by #6642).
 ///
 /// Why: the other half of the owner's window ruling; the console's sampler
 ///      default and the `sample_interval_secs` the history payload advertises
 ///      both read it from here, so the graph's x-axis cannot disagree with the
-///      producer.
-/// What: `5`.
+///      producer. #6642 set it to 1 because each home-page card draws one bar
+///      per second.
+/// What: `1`.
 /// Test: `host_window_is_the_owner_ruling`.
-pub const HOST_SAMPLE_INTERVAL_SECS: u64 = 5;
+pub const HOST_SAMPLE_INTERVAL_SECS: u64 = 1;
 
 /// A fixed-capacity FIFO of metric samples, oldest first (#6641).
 ///
@@ -102,6 +108,19 @@ impl<T> MetricRing<T> {
         self.items.iter()
     }
 
+    /// The newest item, or `None` on an empty ring.
+    ///
+    /// Why (#6642): a caller that wants only the latest value — the console's
+    /// service list renders one number per service before its stream connects —
+    /// would otherwise call [`MetricRing::snapshot`] and take the last element,
+    /// cloning the whole 600-point window to read one point.
+    /// What: the back of the deque, borrowed.
+    /// Test: `last_reads_the_newest_item`.
+    #[must_use]
+    pub fn last(&self) -> Option<&T> {
+        self.items.back()
+    }
+
     /// Number of items currently held (never above [`MetricRing::capacity`]).
     ///
     /// Test: `push_evicts_oldest_at_capacity`.
@@ -144,7 +163,7 @@ impl<T: Clone> MetricRing<T> {
 impl MetricRing<HostMetrics> {
     /// A host-metrics ring sized to the owner's 10-minute window (#6641).
     ///
-    /// Why: the console should not restate `120`; the window is one ruling and
+    /// Why: the console should not restate `600`; the window is one ruling and
     ///      belongs to one constant.
     /// What: `MetricRing::new(HOST_HISTORY_CAPACITY)`.
     /// Test: `host_window_is_the_owner_ruling`.
@@ -160,8 +179,8 @@ mod tests {
 
     /// Why: the eviction rule is the whole point of a bounded ring — a ring that
     ///      grew past its capacity would leak in a long-lived daemon.
-    /// What: pushes `capacity + 1` items into a 120-slot ring and asserts the
-    ///      length stopped at 120, the oldest item is gone, and the newest is
+    /// What: pushes `capacity + 1` items into a 600-slot ring and asserts the
+    ///      length stopped at 600, the oldest item is gone, and the newest is
     ///      present.
     /// Test: this test.
     #[test]
@@ -173,7 +192,7 @@ mod tests {
         assert_eq!(ring.len(), HOST_HISTORY_CAPACITY);
         assert_eq!(ring.snapshot().first().copied(), Some(0));
 
-        // #6641: the 121st push must evict sample 0 and pin the length.
+        // #6642: the 601st push must evict sample 0 and pin the length.
         ring.push(HOST_HISTORY_CAPACITY as u32);
         assert_eq!(
             ring.len(),
@@ -204,11 +223,29 @@ mod tests {
         assert_eq!(ring.iter().copied().collect::<Vec<_>>(), vec![3, 4, 5]);
     }
 
+    /// Why (#6642): the console's service list renders the newest point per
+    ///      service. Reading it through `snapshot().last()` would clone the
+    ///      whole 600-point window per service per request.
+    /// What: asserts `last` follows the newest push, survives an eviction, and
+    ///      is `None` before the first push.
+    /// Test: this test.
+    #[test]
+    fn last_reads_the_newest_item() {
+        let mut ring: MetricRing<u32> = MetricRing::new(2);
+        assert_eq!(ring.last(), None, "an empty ring has no newest item");
+        ring.push(1);
+        assert_eq!(ring.last().copied(), Some(1));
+        ring.push(2);
+        ring.push(3);
+        assert_eq!(ring.snapshot(), vec![2, 3], "1 was evicted");
+        assert_eq!(ring.last().copied(), Some(3));
+    }
+
     /// Why: the history endpoint must answer `200` with an empty window before
-    ///      the first sample, so an empty ring has to read as empty rather than
-    ///      as an error or a panic.
+    /// the first sample, so an empty ring has to read as empty rather than as an
+    /// error or a panic.
     /// What: asserts `is_empty`, `len == 0`, and an empty snapshot on a fresh
-    ///      ring.
+    /// ring.
     /// Test: this test.
     #[test]
     fn empty_ring_reads_empty() {
@@ -222,17 +259,19 @@ mod tests {
 
     /// Why: the 10-minute window is an owner ruling; if the constants drift the
     ///      graph silently covers a different span than the UI labels claim.
-    /// What: pins 120 points × 5 s = 600 s and asserts the host-window
-    ///      constructor uses the constant.
+    /// What: pins 600 points × 1 s = 600 s and asserts the host-window
+    ///      constructor uses the constant. #6642 moved the pair from 120 × 5 to
+    ///      600 × 1; the PRODUCT is what the UI's x-axis depends on, so it is
+    ///      asserted separately from the two operands.
     /// Test: this test.
     #[test]
     fn host_window_is_the_owner_ruling() {
-        assert_eq!(HOST_HISTORY_CAPACITY, 120);
-        assert_eq!(HOST_SAMPLE_INTERVAL_SECS, 5);
+        assert_eq!(HOST_HISTORY_CAPACITY, 600);
+        assert_eq!(HOST_SAMPLE_INTERVAL_SECS, 1);
         assert_eq!(
             HOST_HISTORY_CAPACITY as u64 * HOST_SAMPLE_INTERVAL_SECS,
             600,
-            "120 points at 5s is the owner's 10-minute window"
+            "600 points at 1s is the owner's 10-minute window"
         );
         let ring = MetricRing::<HostMetrics>::host_window();
         assert_eq!(ring.capacity(), HOST_HISTORY_CAPACITY);

--- a/crates/trusty-common/src/sys_metrics.rs
+++ b/crates/trusty-common/src/sys_metrics.rs
@@ -203,6 +203,164 @@ impl Default for SysMetrics {
     }
 }
 
+/// CPU sampler for a SET of other processes, refreshed once per tick (#6642).
+///
+/// Why: [`SysMetrics`] answers "how much CPU am I using" and is bound to the
+/// current process, so a supervisor that wants a per-child figure has nothing to
+/// call. trusty-console needs exactly that — one `cpu_pct` per registered
+/// service, once per second — and the workspace's common-entry-point rule says
+/// the console must not grow a second `sysinfo::System`. This is the one
+/// implementation; a future supervisor with the same question calls it too.
+///
+/// Why a set rather than one pid per sampler: `sysinfo` derives CPU% from the
+/// delta in consumed CPU time between two refreshes, so the `System` must live
+/// across ticks. One `System` refreshed once for N pids costs one syscall batch;
+/// N samplers cost N of them and each keeps its own process table.
+///
+/// What: holds a `System` configured to refresh CPU only, plus the pid set the
+/// caller declared with [`ProcessCpuSampler::track`].
+/// [`ProcessCpuSampler::refresh`] updates ONLY those pids —
+/// `ProcessesToUpdate::Some`, never `All`, so the cost is proportional to what
+/// is tracked and not to how many processes the machine is running.
+/// [`ProcessCpuSampler::cpu_pct`] reads the last refresh's figure, and answers
+/// `None` for a pid that is not tracked or whose process is gone. `None` means
+/// "no measurement", never "measured zero" — a caller must not render it as 0.
+///
+/// CPU% follows `sysinfo`'s convention: `100.0` is one fully-saturated core, so
+/// a process spread over four cores can report above 100.
+/// Test: `process_cpu_sampler_measures_a_tracked_child`,
+/// `process_cpu_sampler_reports_none_for_a_vanished_pid`,
+/// `process_cpu_sampler_reports_none_for_an_untracked_pid`,
+/// `process_cpu_sampler_untrack_removes_a_pid`.
+pub struct ProcessCpuSampler {
+    sys: System,
+    tracked: Vec<Pid>,
+}
+
+impl ProcessCpuSampler {
+    /// An empty sampler tracking nothing.
+    ///
+    /// Why: the caller discovers pids over time (a daemon starts, another
+    /// exits), so the set is built with [`ProcessCpuSampler::track`] rather than
+    /// fixed at construction.
+    /// What: a `System` refreshing process CPU only — no memory, no disks, no
+    /// networks — because that is the whole measurement this type provides.
+    /// Test: `process_cpu_sampler_reports_none_for_an_untracked_pid`.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            sys: System::new_with_specifics(
+                RefreshKind::nothing().with_processes(ProcessRefreshKind::nothing().with_cpu()),
+            ),
+            tracked: Vec::new(),
+        }
+    }
+
+    /// Start tracking `pid`, priming its CPU baseline.
+    ///
+    /// Why the priming refresh: the first delta-based reading after a pid enters
+    /// the set has no previous sample to subtract, and `sysinfo` reports `0.0`
+    /// for it. Priming here means the caller's NEXT tick already carries a real
+    /// figure instead of a zero that looks like an idle daemon.
+    /// What: appends `pid` if absent (tracking is idempotent) and refreshes that
+    /// one pid. A pid that does not exist is still added — the next
+    /// [`ProcessCpuSampler::refresh`] drops it, which is the same path a process
+    /// that exits later takes.
+    /// Test: `process_cpu_sampler_measures_a_tracked_child`.
+    pub fn track(&mut self, pid: u32) {
+        let pid = Pid::from_u32(pid);
+        if self.tracked.contains(&pid) {
+            return;
+        }
+        self.tracked.push(pid);
+        self.sys.refresh_processes_specifics(
+            ProcessesToUpdate::Some(&[pid]),
+            true,
+            ProcessRefreshKind::nothing().with_cpu(),
+        );
+    }
+
+    /// Stop tracking `pid`.
+    ///
+    /// Why: a service the caller no longer watches must not keep costing a
+    /// syscall on every tick.
+    /// Test: `process_cpu_sampler_untrack_removes_a_pid`.
+    pub fn untrack(&mut self, pid: u32) {
+        let pid = Pid::from_u32(pid);
+        self.tracked.retain(|p| *p != pid);
+    }
+
+    /// `true` when `pid` is in the tracked set.
+    ///
+    /// Test: `process_cpu_sampler_untrack_removes_a_pid`.
+    #[must_use]
+    pub fn is_tracked(&self, pid: u32) -> bool {
+        self.tracked.contains(&Pid::from_u32(pid))
+    }
+
+    /// How many pids are tracked.
+    ///
+    /// Test: `process_cpu_sampler_untrack_removes_a_pid`.
+    #[must_use]
+    pub fn tracked_count(&self) -> usize {
+        self.tracked.len()
+    }
+
+    /// Refresh every tracked pid, dropping the ones whose process is gone.
+    ///
+    /// Why the drop: a pid the caller keeps asking about after its process
+    /// exited would be refreshed forever, and on a busy machine the number could
+    /// be reused by an unrelated process — which would report that stranger's
+    /// CPU under the dead service's name. Forgetting a vanished pid makes
+    /// [`ProcessCpuSampler::cpu_pct`] answer `None` and lets the caller
+    /// rediscover the real one.
+    /// What: one `refresh_processes_specifics` over the tracked slice with
+    /// `remove_dead_processes = true`, then prunes the set to the pids the
+    /// refresh still resolves. Returns immediately when nothing is tracked, so
+    /// an idle sampler costs no syscall at all — and, critically, never falls
+    /// back to a whole-process-table refresh.
+    /// Test: `process_cpu_sampler_measures_a_tracked_child`,
+    /// `process_cpu_sampler_reports_none_for_a_vanished_pid`.
+    pub fn refresh(&mut self) {
+        if self.tracked.is_empty() {
+            return;
+        }
+        self.sys.refresh_processes_specifics(
+            ProcessesToUpdate::Some(&self.tracked),
+            true,
+            ProcessRefreshKind::nothing().with_cpu(),
+        );
+        let sys = &self.sys;
+        self.tracked.retain(|pid| sys.process(*pid).is_some());
+    }
+
+    /// The CPU percentage recorded for `pid` by the last
+    /// [`ProcessCpuSampler::refresh`].
+    ///
+    /// Why `Option`: an untracked pid, a process that exited, and a permission
+    /// denial are all "no measurement". Collapsing them to `0.0` would draw an
+    /// idle daemon where there is no daemon at all.
+    /// What: reads the cached process entry. Never refreshes — the caller
+    /// refreshes once per tick and then reads every pid, so N reads cost one
+    /// refresh.
+    /// Test: `process_cpu_sampler_measures_a_tracked_child`,
+    /// `process_cpu_sampler_reports_none_for_a_vanished_pid`.
+    #[must_use]
+    pub fn cpu_pct(&self, pid: u32) -> Option<f32> {
+        let pid = Pid::from_u32(pid);
+        if !self.tracked.contains(&pid) {
+            return None;
+        }
+        self.sys.process(pid).map(sysinfo::Process::cpu_usage)
+    }
+}
+
+impl Default for ProcessCpuSampler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Maximum directory nesting the size walk will descend.
 ///
 /// Why (#4764): an explicit bound keeps a pathological or adversarially deep
@@ -408,6 +566,117 @@ mod tests {
         // pid 0 is the kernel scheduler on Linux and not addressable via
         // proc_pid_rusage on macOS; either way it must not yield a figure.
         assert_eq!(process_rss_mb(0), None);
+    }
+
+    /// Spawn a child that sleeps, so a test has a real pid it owns.
+    ///
+    /// Why `sleep` and not a spinner: this file's whole subject is CPU
+    /// measurement, and a test that generates machine-wide load to prove it
+    /// would slow every other test sharing the runner. A sleeping child is a
+    /// real process with a real pid; the assertions below are about the
+    /// measurement being TAKEN, not about it reaching a particular number.
+    #[cfg(unix)]
+    fn spawn_sleeper() -> std::process::Child {
+        std::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawn a sleeping child")
+    }
+
+    /// Why (#6642): the console samples six daemons once a second off this type.
+    /// If tracking a live pid did not yield a reading, every service card would
+    /// render an empty bar and nothing would say why.
+    /// What: spawns a child, tracks it, refreshes, and asserts a non-negative
+    /// figure comes back — then kills and reaps the child.
+    /// Test: this test itself.
+    #[cfg(unix)]
+    #[test]
+    fn process_cpu_sampler_measures_a_tracked_child() {
+        let mut child = spawn_sleeper();
+        let pid = child.id();
+
+        let mut sampler = ProcessCpuSampler::new();
+        sampler.track(pid);
+        sampler.refresh();
+        let cpu = sampler.cpu_pct(pid);
+
+        let _ = child.kill();
+        let _ = child.wait();
+
+        let cpu = cpu.expect("a live tracked pid must yield a measurement");
+        assert!(cpu >= 0.0, "cpu usage must be non-negative, got {cpu}");
+    }
+
+    /// REGRESSION (#6642): a process that exits between two samples must read as
+    /// `None`, and the sampler must keep working afterwards.
+    ///
+    /// Why: `Some(0.0)` for a dead daemon draws a flat idle bar — visually
+    /// identical to a healthy but quiet service. The fail-open contract is that
+    /// an unmeasurable service reports nothing and the tick continues.
+    /// What: tracks a child, kills and reaps it, refreshes, and asserts the pid
+    /// reads `None`, is no longer tracked, and that a second refresh with an
+    /// empty set is still safe to call.
+    /// Test: this test itself.
+    #[cfg(unix)]
+    #[test]
+    fn process_cpu_sampler_reports_none_for_a_vanished_pid() {
+        let mut child = spawn_sleeper();
+        let pid = child.id();
+
+        let mut sampler = ProcessCpuSampler::new();
+        sampler.track(pid);
+        sampler.refresh();
+
+        child.kill().expect("kill the sleeper");
+        child.wait().expect("reap the sleeper");
+
+        sampler.refresh();
+        assert_eq!(
+            sampler.cpu_pct(pid),
+            None,
+            "a vanished process must read as no-measurement, never as 0.0"
+        );
+        assert!(
+            !sampler.is_tracked(pid),
+            "a vanished pid must be dropped so a reused pid cannot be misread"
+        );
+        // The tick must not stop: refreshing an now-empty sampler is a no-op.
+        sampler.refresh();
+        assert_eq!(sampler.tracked_count(), 0);
+    }
+
+    /// Why: reading a pid the caller never declared would silently measure a
+    /// process the sampler is not paying for, and hide a bug in the caller's
+    /// discovery step.
+    /// What: asserts `cpu_pct` on an untracked pid is `None`, before and after a
+    /// refresh.
+    /// Test: this test itself.
+    #[test]
+    fn process_cpu_sampler_reports_none_for_an_untracked_pid() {
+        let mut sampler = ProcessCpuSampler::new();
+        assert_eq!(sampler.cpu_pct(std::process::id()), None);
+        sampler.refresh();
+        assert_eq!(sampler.cpu_pct(std::process::id()), None);
+    }
+
+    /// Why: a service the console stops watching must stop costing a syscall per
+    /// tick, and `track` must be idempotent so a re-discovered pid does not
+    /// enter the set twice.
+    /// What: tracks the current process twice, asserts one entry, then untracks.
+    /// Test: this test itself.
+    #[test]
+    fn process_cpu_sampler_untrack_removes_a_pid() {
+        let me = std::process::id();
+        let mut sampler = ProcessCpuSampler::new();
+        sampler.track(me);
+        sampler.track(me);
+        assert_eq!(sampler.tracked_count(), 1, "track must be idempotent");
+        assert!(sampler.is_tracked(me));
+
+        sampler.untrack(me);
+        assert_eq!(sampler.tracked_count(), 0);
+        assert!(!sampler.is_tracked(me));
+        assert_eq!(sampler.cpu_pct(me), None);
     }
 
     #[test]

--- a/crates/trusty-common/src/uds/mod.rs
+++ b/crates/trusty-common/src/uds/mod.rs
@@ -97,7 +97,7 @@ pub use on_demand::{
     DEFAULT_ANALYZE_IDLE_TIMEOUT, OnDemandAnalyze, analyze_idle_timeout,
     analyze_idle_timeout_from_env,
 };
-pub use peer::{ensure_peer_is_self, peer_uid, self_uid};
+pub use peer::{ensure_peer_is_self, peer_pid, peer_uid, self_uid};
 pub use probe::{SocketVerdict, probe_socket_verdict, socket_is_serving};
 pub use rpc::{
     MAX_FRAME_BYTES, UdsRpcError, encode_frame, send_framed_notification, send_framed_request,

--- a/crates/trusty-common/src/uds/peer.rs
+++ b/crates/trusty-common/src/uds/peer.rs
@@ -11,6 +11,8 @@
 //! What: [`peer_uid`] wraps the platform syscall — `SO_PEERCRED` on Linux,
 //! `getpeereid` on macOS and the BSDs — [`peer_uid_verdict`] is the pure
 //! comparison behind the refusal, and [`ensure_peer_is_self`] joins them.
+//! [`peer_pid`] (#6642) answers the adjacent question — WHICH process is on the
+//! other end — for a caller that wants to meter it rather than refuse it.
 //! Targets with neither syscall fail closed via
 //! [`UdsSecurityError::UnsupportedPlatform`] rather than compiling to an
 //! unchecked accept.
@@ -125,6 +127,93 @@ pub fn peer_uid(stream: &UnixStream) -> Result<u32, UdsSecurityError> {
         });
     }
     Ok(uid)
+}
+
+/// Read the pid of the process on the other end of `stream` (#6642).
+///
+/// Why: trusty-console has to answer "how much CPU is trusty-search using", and
+/// a UDS daemon publishes no pid anywhere — no pid file, no field in its health
+/// response. The kernel already knows, and the console already dials that exact
+/// socket to detect the service, so the connection it makes IS the identifier.
+/// This is the one implementation; a second consumer with the same question
+/// calls it rather than shelling out to `lsof`.
+///
+/// Why the return type is `Option` and not `Result`: every caller so far treats
+/// "cannot identify the peer" as a metric it simply does not have. There is no
+/// remediation to report and nothing to fail on, so the platform gap, the
+/// syscall error, and a nonsensical pid all collapse into the one answer the
+/// caller acts on. Contrast [`peer_uid`], whose failure MUST refuse a
+/// connection and therefore owes the caller a reason.
+///
+/// What: `getsockopt(SO_PEERCRED)`'s `ucred.pid` on Linux,
+/// `getsockopt(SOL_LOCAL, LOCAL_PEERPID)` on macOS/iOS. The other BSDs expose
+/// no peer-pid option, so they answer `None`. Like [`peer_uid`], the credentials
+/// are those captured at `connect` time.
+///
+/// The pid identifies the process that was listening when the connection was
+/// made. It can be reused after that process exits, so a caller holding one
+/// across time must re-verify the process still exists — see
+/// [`ProcessCpuSampler::refresh`](crate::sys_metrics::ProcessCpuSampler::refresh),
+/// which drops a vanished pid for exactly this reason.
+/// Test: `peer_pid_of_self_connection_is_this_process`.
+#[cfg(target_os = "linux")]
+#[must_use]
+pub fn peer_pid(stream: &UnixStream) -> Option<u32> {
+    let mut cred = libc::ucred {
+        pid: 0,
+        uid: 0,
+        gid: 0,
+    };
+    let mut len = size_of::<libc::ucred>() as libc::socklen_t;
+
+    // SAFETY: `stream` owns a live connected socket fd for the duration of the
+    // call; `cred` and `len` are a correctly-sized, correctly-typed
+    // out-parameter pair for SO_PEERCRED on SOL_SOCKET.
+    let rc = unsafe {
+        libc::getsockopt(
+            stream.as_raw_fd(),
+            libc::SOL_SOCKET,
+            libc::SO_PEERCRED,
+            (&raw mut cred).cast::<libc::c_void>(),
+            &raw mut len,
+        )
+    };
+    if rc != 0 || cred.pid <= 0 {
+        return None;
+    }
+    u32::try_from(cred.pid).ok()
+}
+
+/// See the Linux variant for the contract; this is the Darwin syscall.
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[must_use]
+pub fn peer_pid(stream: &UnixStream) -> Option<u32> {
+    let mut pid: libc::pid_t = 0;
+    let mut len = size_of::<libc::pid_t>() as libc::socklen_t;
+
+    // SAFETY: `stream` owns a live connected socket fd for the duration of the
+    // call; `pid` and `len` are a correctly-sized, correctly-typed
+    // out-parameter pair for LOCAL_PEERPID on SOL_LOCAL.
+    let rc = unsafe {
+        libc::getsockopt(
+            stream.as_raw_fd(),
+            libc::SOL_LOCAL,
+            libc::LOCAL_PEERPID,
+            (&raw mut pid).cast::<libc::c_void>(),
+            &raw mut len,
+        )
+    };
+    if rc != 0 || pid <= 0 {
+        return None;
+    }
+    u32::try_from(pid).ok()
+}
+
+/// No peer-pid option on this target — the caller has no measurement.
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "ios")))]
+#[must_use]
+pub fn peer_pid(_stream: &UnixStream) -> Option<u32> {
+    None
 }
 
 /// Fail closed on a unix target with neither `SO_PEERCRED` nor `getpeereid`.

--- a/crates/trusty-common/src/uds/tests.rs
+++ b/crates/trusty-common/src/uds/tests.rs
@@ -558,6 +558,33 @@ async fn peer_uid_of_self_connection_is_self() {
     );
 }
 
+/// Why (#6642): the console identifies a UDS daemon's process by asking the
+/// kernel who is on the other end of the connection it already makes. A stub
+/// returning `None` would leave every UDS service's CPU graph permanently
+/// empty, with nothing failing to say so.
+/// What: connects to a socket this process is also listening on, so the peer pid
+/// has one correct answer — this process's own.
+#[tokio::test]
+async fn peer_pid_of_self_connection_is_this_process() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let sock = tmp.path().join("sockets").join("pid.sock");
+    let listener = bind_hardened(&sock).expect("bind");
+
+    let _client = UnixStream::connect(&sock).await.expect("connect");
+    let (accepted, _) = listener.accept().await.expect("accept");
+
+    // Darwin and Linux both implement this; every other target answers None by
+    // design, so the assertion is scoped to the two that must work.
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "ios"))]
+    assert_eq!(
+        super::peer::peer_pid(&accepted),
+        Some(std::process::id()),
+        "a connection from this process must report this process's pid"
+    );
+    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "ios")))]
+    assert_eq!(super::peer::peer_pid(&accepted), None);
+}
+
 // ── singleton bind (#5182) ──────────────────────────────────────────────────
 
 #[tokio::test]

--- a/crates/trusty-console/Cargo.toml
+++ b/crates/trusty-console/Cargo.toml
@@ -19,7 +19,13 @@ name        = "trusty-console"
 # (src/lib.rs:204), and `function_missing` for `trusty_console::host_status::start`.
 # 0.10.1 (refs #6671, #6663, #6667, #6661): patch — test-flake stabilization
 # changes in the test suite under an already-published version.
-version     = "0.10.1"
+# 0.11.0 (#6642): MINOR, the breaking position for a 0.x crate.
+# `cargo-semver-checks` refuses 0.10.1 against 0.10.0 on two counts:
+# `constructible_struct_adds_field` for `ServiceInfo.cpu_pct`
+# (src/connector.rs:100) and `enum_variant_added` for
+# `machine_history::events::HistoryEvent::Services`. Both are the shape the
+# console's per-service graphs are read from, so neither is avoidable.
+version     = "0.11.0"
 edition     = "2024"
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/trusty-console/changelog.d/6642-one-second-cadence-changed.md
+++ b/crates/trusty-console/changelog.d/6642-one-second-cadence-changed.md
@@ -1,0 +1,10 @@
+Changed
+- `--host-sample-interval` defaults to 1 second instead of 5, and the history
+  window holds 600 points instead of 120. The span is the same ten minutes and
+  the payload still advertises the cadence in use, so an operator who raises the
+  interval stretches the span the same 600 points cover
+  ([#6642](https://github.com/bobmatnyc/trusty-tools/issues/6642)).
+- `HistorySnapshot.schema_version` is `2`. The payload gained `service_samples`
+  and `service_sample_capacity`; a client built against schema 1 parses it fine
+  but renders no per-service graph, which is the difference the version
+  announces ([#6642](https://github.com/bobmatnyc/trusty-tools/issues/6642)).

--- a/crates/trusty-console/changelog.d/6642-per-service-cpu-samples-added.md
+++ b/crates/trusty-console/changelog.d/6642-per-service-cpu-samples-added.md
@@ -1,0 +1,19 @@
+Added
+- Each registered service gets a per-second sample — `{ id, status, cpu_pct }` —
+  recorded into a bounded 600-point in-memory ring, fanned out on
+  `/api/console/machine-status/stream` as a new `services` event, and carried in
+  the `history` snapshot under `service_samples`. `cpu_pct` is `null`, never
+  `0.0`, whenever no measurement was taken: an idle bar and an unmeasurable one
+  must look different on the card
+  ([#6642](https://github.com/bobmatnyc/trusty-tools/issues/6642)).
+- `GET /api/console/services` entries carry `cpu_pct`, so the list renders a CPU
+  figure before the stream connects. It is read from the same rings the graph
+  draws, so the number and the newest bar cannot disagree
+  ([#6642](https://github.com/bobmatnyc/trusty-tools/issues/6642)).
+- A service's process is identified from the discovery artifact it already
+  publishes: the `pid` line in trusty-mpm's `daemon.lock`, and the peer pid of
+  the Unix socket for trusty-search and trusty-memory. trusty-agents serves TCP
+  loopback, which carries no pid, and trusty-analyze and trusty-review are
+  on-demand members with no resident process — those three report `null`. A
+  lookup that fails backs off for 15 s rather than retrying every tick
+  ([#6642](https://github.com/bobmatnyc/trusty-tools/issues/6642)).

--- a/crates/trusty-console/changelog.d/6642-sampler-buffer-and-panic-guard-fixed.md
+++ b/crates/trusty-console/changelog.d/6642-sampler-buffer-and-panic-guard-fixed.md
@@ -1,0 +1,16 @@
+Fixed
+- The history broadcast buffer is sized for the 1 Hz cadence. `EVENT_BUFFER` was
+  128, chosen when a tick emitted one event every 5 s; a tick now emits two
+  events every second, so a stalled browser was told it lagged after 64 s
+  instead of 640 s. It is `HOST_HISTORY_CAPACITY * 2` — 1200 — which is two
+  events per tick across the whole 10-minute window, and moves with the cadence
+  rather than being a second number that can drift from it
+  ([#6642](https://github.com/bobmatnyc/trusty-tools/issues/6642)).
+- A panicking sampler tick no longer stops the history. The loop is one bare
+  `tokio::spawn`, so a panic anywhere in a tick ended the task: the window
+  froze, every open SSE stream stayed connected emitting nothing, and no log
+  line said why. Each half of a tick now runs under `catch_unwind`, logs the
+  panic payload at `error!`, and lets the next tick run — a panic in the service
+  half leaves a gap in that series while the host graph keeps drawing. The
+  loop's `JoinHandle` is kept and logs at `error!` if the task ever ends
+  ([#6642](https://github.com/bobmatnyc/trusty-tools/issues/6642)).

--- a/crates/trusty-console/src/connector.rs
+++ b/crates/trusty-console/src/connector.rs
@@ -98,6 +98,22 @@ pub struct ServiceInfo {
     /// so a payload written before #6416 still deserialises, as a daemon.
     #[serde(default)]
     pub lifecycle: ServiceLifecycle,
+    /// The newest per-second CPU sample for this service, if any (#6642).
+    ///
+    /// Why it is on this struct at all: the home-page list must render a CPU
+    /// figure on first paint, before the SSE stream connects. Detection cannot
+    /// produce it — a connector is a synchronous probe with no sampler — so the
+    /// route overlays it from the same per-service history the graph reads,
+    /// which is what keeps the number and the newest bar identical.
+    ///
+    /// Serialised UNCONDITIONALLY, as `null` when absent, unlike the optional
+    /// fields above. `None` means no measurement was taken (on-demand member,
+    /// stopped daemon, or a process the console cannot identify); rendering that
+    /// as `0.0` would draw an idle service where there is none. A key that is
+    /// sometimes missing and sometimes null would be two spellings of one fact.
+    /// `#[serde(default)]` so a payload written before #6642 still deserialises.
+    #[serde(default)]
+    pub cpu_pct: Option<f32>,
 }
 
 /// Per-service adapter contract.

--- a/crates/trusty-console/src/detect/agents.rs
+++ b/crates/trusty-console/src/detect/agents.rs
@@ -97,6 +97,7 @@ impl ServiceConnector for AgentsConnector {
             // #6416: trusty-agents is a resident daemon — `Available` here means
             // installed but stopped, which is what the card should say.
             lifecycle: ServiceLifecycle::Daemon,
+            cpu_pct: None,
         }
     }
 }

--- a/crates/trusty-console/src/detect/analyze.rs
+++ b/crates/trusty-console/src/detect/analyze.rs
@@ -381,6 +381,7 @@ impl AnalyzeConnector {
                 // `Available` is its resting state and the card must not offer
                 // to start a daemon.
                 lifecycle: self.lifecycle(),
+                cpu_pct: None,
             };
 
         if !binary_on_path(BINARY) {

--- a/crates/trusty-console/src/detect/helpers.rs
+++ b/crates/trusty-console/src/detect/helpers.rs
@@ -248,6 +248,7 @@ pub(super) fn detect_service(
             url: None,
             hint: None,
             lifecycle: ServiceLifecycle::Daemon,
+            cpu_pct: None,
         };
     }
 
@@ -268,6 +269,7 @@ pub(super) fn detect_service(
             url: Some(base_url),
             hint: None,
             lifecycle: ServiceLifecycle::Daemon,
+            cpu_pct: None,
         };
     }
 
@@ -279,6 +281,7 @@ pub(super) fn detect_service(
         url: None,
         hint: None,
         lifecycle: ServiceLifecycle::Daemon,
+        cpu_pct: None,
     }
 }
 

--- a/crates/trusty-console/src/detect/memory.rs
+++ b/crates/trusty-console/src/detect/memory.rs
@@ -263,6 +263,7 @@ impl MemoryConnector {
                 hint,
                 // #6416: trusty-memory is a resident daemon; `Available` means stopped.
                 lifecycle: ServiceLifecycle::Daemon,
+                cpu_pct: None,
             };
 
         if !binary_on_path("trusty-memory") {

--- a/crates/trusty-console/src/detect/mod.rs
+++ b/crates/trusty-console/src/detect/mod.rs
@@ -182,6 +182,7 @@ mod tests {
             url: None,
             hint: None,
             lifecycle: ServiceLifecycle::Daemon,
+            cpu_pct: None,
         }
     }
 

--- a/crates/trusty-console/src/detect/mpm.rs
+++ b/crates/trusty-console/src/detect/mpm.rs
@@ -150,6 +150,7 @@ impl ServiceConnector for MpmConnector {
                 url: None,
                 hint: None,
                 lifecycle: ServiceLifecycle::Daemon,
+                cpu_pct: None,
             };
         }
 
@@ -185,6 +186,7 @@ impl ServiceConnector for MpmConnector {
                     "daemon is running but pre-dates #1849 — restart to enable proxy".to_string(),
                 ),
                 lifecycle: ServiceLifecycle::Daemon,
+                cpu_pct: None,
             };
         }
 
@@ -197,6 +199,7 @@ impl ServiceConnector for MpmConnector {
             hint: None,
             // #6416: trusty-mpm is a resident daemon; `Available` means stopped.
             lifecycle: ServiceLifecycle::Daemon,
+            cpu_pct: None,
         }
     }
 }

--- a/crates/trusty-console/src/detect/review.rs
+++ b/crates/trusty-console/src/detect/review.rs
@@ -117,6 +117,7 @@ impl ServiceConnector for ReviewConnector {
                 // #6416: even the not-installed row must say this is not a daemon
                 // — the card's remediation text branches on it.
                 lifecycle: self.lifecycle(),
+                cpu_pct: None,
             };
         }
 
@@ -145,6 +146,7 @@ impl ServiceConnector for ReviewConnector {
             // #6416: `Available` is trusty-review's healthy resting state, not a
             // stopped daemon; this is what stops the card rendering it as a fault.
             lifecycle: self.lifecycle(),
+            cpu_pct: None,
         }
     }
 }

--- a/crates/trusty-console/src/detect/search.rs
+++ b/crates/trusty-console/src/detect/search.rs
@@ -182,6 +182,7 @@ impl SearchConnector {
                 hint,
                 // #6416: trusty-search is a resident daemon; `Available` means stopped.
                 lifecycle: ServiceLifecycle::Daemon,
+                cpu_pct: None,
             };
 
         if !binary_on_path(SEARCH_SERVICE) {

--- a/crates/trusty-console/src/lib.rs
+++ b/crates/trusty-console/src/lib.rs
@@ -65,6 +65,8 @@ pub mod routes;
 pub mod search_uds;
 pub mod server;
 pub mod service;
+// #6642: per-service pid discovery + CPU sampling for the home-page graphs.
+pub mod service_cpu;
 // #6155: the trusty-search SPA, mounted under /tools/search/.
 pub mod tools_ui;
 pub mod webhook;
@@ -188,15 +190,17 @@ pub struct ServeArgs {
     #[arg(long, default_value_t = 15u64)]
     pub poll_interval: u64,
 
-    /// Host-metrics sampling interval in seconds (default: 5).
+    /// Host-metrics sampling interval in seconds (default: 1).
     ///
     /// #6641: the cadence of the real-time graphs, kept separate from
     /// `--poll-interval` because they answer different questions. The service
     /// pollers each spawn a stdio-MCP round trip, so 15 s is deliberate there;
-    /// a host sample is a local sysinfo refresh, and the owner's Phase 3 ruling
-    /// is a 10-minute window at 5 s (120 points). Raising this stretches the
-    /// window the same 120 points cover, and the history payload advertises the
-    /// value so the graph's x-axis follows.
+    /// a host sample is a local sysinfo refresh.
+    ///
+    /// #6642: the owner's home-page ruling is a bar per SECOND, so the default
+    /// is 1 s and the window is 600 points. Raising this stretches the span the
+    /// same 600 points cover, and the history payload advertises the value so
+    /// the graph's x-axis follows.
     #[arg(
         long,
         default_value_t = trusty_common::host_metrics::history::HOST_SAMPLE_INTERVAL_SECS
@@ -453,9 +457,10 @@ pub async fn run_serve(args: ServeArgs) -> Result<()> {
     // One loop writes both the point-in-time cache
     // (GET /api/console/machine-status) and the bounded 10-minute window
     // (GET /api/console/machine-status/history and its SSE stream), so the two
-    // can never disagree about the newest sample. It runs on its own 5 s
+    // can never disagree about the newest sample. It runs on its own 1 s
     // cadence rather than the service pollers' 15 s: a host sample is a local
-    // sysinfo refresh, not an MCP round trip.
+    // sysinfo refresh, not an MCP round trip. #6642: the same loop also records
+    // one per-service status + CPU sample per tick.
     machine_history::sampler::start(
         state.clone(),
         Duration::from_secs(args.host_sample_interval),
@@ -571,15 +576,19 @@ mod tests {
                 assert!(!args.open);
                 assert!(!args.tailscale);
                 assert_eq!(args.poll_interval, 15);
-                // #6641: the owner's Phase 3 cadence — 5 s, distinct from the
-                // 15 s service poll.
-                assert_eq!(args.host_sample_interval, 5);
+                // #6642: the owner's home-page cadence — 1 s, distinct from the
+                // 15 s service poll. Read from the constant so the default and
+                // the window ruling cannot drift apart.
+                assert_eq!(
+                    args.host_sample_interval,
+                    trusty_common::host_metrics::history::HOST_SAMPLE_INTERVAL_SECS
+                );
             }
             other => panic!("expected Serve, got {other:?}"),
         }
     }
 
-    /// Why (#6641): the 5 s cadence is the shipped default, not a hard-coded
+    /// Why (#6641, #6642): the 1 s cadence is the shipped default, not a hard-coded
     /// constant — an operator who wants a longer window must be able to say so,
     /// and the two intervals must stay independent.
     /// What: parses `serve --host-sample-interval 10` and asserts only that

--- a/crates/trusty-console/src/machine_history/events.rs
+++ b/crates/trusty-console/src/machine_history/events.rs
@@ -19,6 +19,7 @@ use axum::body::Bytes;
 use serde::Serialize;
 use trusty_common::host_metrics::HostMetrics;
 
+use super::service_samples::ServiceSampleBatch;
 use super::transitions::ServiceTransition;
 
 /// One event pushed to every open machine-status stream (#6641).
@@ -38,17 +39,28 @@ pub enum HistoryEvent {
     Sample(Box<HostMetrics>),
     /// A service changed state.
     Transition(Box<ServiceTransition>),
+    /// One tick's per-service status + CPU samples, whole roster (#6642).
+    ///
+    /// Why its own event rather than a field on `Sample`: the host sample is one
+    /// object and this is a list, and the #6284 transport inversion will have
+    /// services push their own samples — at which point the two halves arrive
+    /// from different producers on different schedules. Keeping them separate
+    /// events now means that cutover changes who sends, not what the browser
+    /// parses.
+    Services(Box<ServiceSampleBatch>),
 }
 
 impl HistoryEvent {
     /// The `event:` name this variant is delivered under.
     ///
-    /// Test: `a_frame_names_its_kind_on_one_line`.
+    /// Test: `a_frame_names_its_kind_on_one_line`,
+    /// `a_services_frame_carries_the_whole_roster`.
     #[must_use]
     pub fn kind(&self) -> &'static str {
         match self {
             HistoryEvent::Sample(_) => "sample",
             HistoryEvent::Transition(_) => "transition",
+            HistoryEvent::Services(_) => "services",
         }
     }
 
@@ -63,6 +75,7 @@ impl HistoryEvent {
         match self {
             HistoryEvent::Sample(m) => sse_frame("sample", m.as_ref()),
             HistoryEvent::Transition(t) => sse_frame("transition", t.as_ref()),
+            HistoryEvent::Services(b) => sse_frame("services", b.as_ref()),
         }
     }
 }
@@ -134,6 +147,52 @@ mod tests {
             .expect("sample frame shape");
         let parsed: serde_json::Value = serde_json::from_str(data).expect("sample json");
         assert_eq!(parsed["cpu"]["logical_cores"], cores);
+    }
+
+    /// Why (#6642): PR-B adds one `EventSource` listener per event name, so the
+    /// per-service batch must arrive under `services` with the roster intact —
+    /// a rename or a dropped field leaves the card graphs empty with nothing red
+    /// anywhere.
+    /// What: frames a two-service batch and asserts the kind line, the
+    /// timestamp, and both rows including an absent `cpu_pct` as null.
+    /// Test: this test.
+    #[test]
+    fn a_services_frame_carries_the_whole_roster() {
+        use crate::connector::ServiceStatus;
+        use crate::machine_history::service_samples::{ServiceSample, ServiceSampleBatch};
+
+        let event = HistoryEvent::Services(Box::new(ServiceSampleBatch {
+            sampled_at_unix: 1_700_000_000,
+            services: vec![
+                ServiceSample {
+                    id: "trusty-search".to_string(),
+                    status: ServiceStatus::Running,
+                    cpu_pct: Some(3.25),
+                },
+                ServiceSample {
+                    id: "trusty-review".to_string(),
+                    status: ServiceStatus::Available,
+                    cpu_pct: None,
+                },
+            ],
+        }));
+        assert_eq!(event.kind(), "services");
+
+        let text = String::from_utf8(event.frame().to_vec()).expect("utf8 frame");
+        let data = text
+            .strip_prefix("event: services\ndata: ")
+            .and_then(|r| r.strip_suffix("\n\n"))
+            .expect("services frame shape");
+        let parsed: serde_json::Value = serde_json::from_str(data).expect("services json");
+        assert_eq!(parsed["sampled_at_unix"], 1_700_000_000_u64);
+        assert_eq!(parsed["services"][0]["id"], "trusty-search");
+        assert_eq!(parsed["services"][0]["status"], "running");
+        assert_eq!(parsed["services"][0]["cpu_pct"], 3.25);
+        assert_eq!(parsed["services"][1]["id"], "trusty-review");
+        assert!(
+            parsed["services"][1]["cpu_pct"].is_null(),
+            "an unmeasurable service is null, never 0.0"
+        );
     }
 
     /// Why: a lag the viewer cannot see is a graph that lies about continuity.

--- a/crates/trusty-console/src/machine_history/mod.rs
+++ b/crates/trusty-console/src/machine_history/mod.rs
@@ -81,10 +81,28 @@ pub const TRANSITION_LOG_CAPACITY: usize = 256;
 /// Why: `tokio::sync::broadcast` keeps one shared ring; a receiver that falls
 /// further behind than this gets `RecvError::Lagged` with the dropped count,
 /// which the stream forwards as a `lagged` event (see [`events::lagged_frame`]).
-/// 128 absorbs a browser stalling for several minutes at the 5 s cadence.
-/// What: `128`.
-/// Test: `stream::tests::a_lagging_subscriber_is_told_what_it_missed`.
-pub const EVENT_BUFFER: usize = 128;
+///
+/// The arithmetic, for the cadence actually shipped (#6642): the sampler emits
+/// TWO events per tick — one `sample` for the host and one `services` for the
+/// roster — at one tick per second. 128 events was sized when a tick was one
+/// event every 5 s, which was 640 s of slack; at 2 events per second it is 64,
+/// so a browser that stalled for barely over a minute was told it lagged.
+///
+/// `HOST_HISTORY_CAPACITY * 2` restores the intended margin AND ties it to the
+/// window: a subscriber further behind than this has missed more than the rings
+/// retain, so the channel could not have caught it up anyway — it is better
+/// served by the `lagged` frame and the full window a reconnect brings. The two
+/// numbers move together, so a later cadence change cannot leave the buffer
+/// covering a different span than the graph.
+///
+/// Transitions share the channel but are not counted: they are recorded only
+/// when a service CHANGES state, which is rare next to the per-tick pair, and a
+/// machine flapping fast enough to matter overflows
+/// [`TRANSITION_LOG_CAPACITY`] first.
+/// What: `1200` — 600 ticks of both event kinds, which is the 10-minute window.
+/// Test: `a_subscriber_stalled_for_the_whole_window_is_not_lagged`,
+/// `stream::tests::a_lagging_subscriber_is_told_what_it_missed`.
+pub const EVENT_BUFFER: usize = HOST_HISTORY_CAPACITY * 2;
 
 /// The history payload served by the endpoint and by the stream's first event.
 ///
@@ -612,6 +630,65 @@ mod tests {
         let latest = h.latest_service_cpu().await;
         assert!(!latest.contains_key("trusty-search"));
         assert_eq!(latest["trusty-mpm"], 3.0);
+    }
+
+    /// REGRESSION (#6642): a subscriber that stalls for the length of the whole
+    /// window must still receive every event rather than being told it lagged.
+    ///
+    /// Why: `EVENT_BUFFER` was 128, sized when a tick emitted ONE event every
+    /// 5 s. #6642 made a tick emit TWO events every second, which cut the slack
+    /// from 640 s to 64 s — a browser tab backgrounded for barely over a minute
+    /// came back to a `lagged` frame and a hole in its graph. This test pins the
+    /// buffer against the cadence rather than against the number 1200: it fails
+    /// on the old constant and on any future cadence change that outruns it.
+    /// What: subscribes, records 200 full ticks (400 events — comfortably past
+    /// the old 128 and inside the new 1200) WITHOUT reading, then drains and
+    /// asserts every event arrived in order with no `Lagged`.
+    /// Test: this test itself.
+    #[tokio::test]
+    async fn a_subscriber_stalled_for_the_whole_window_is_not_lagged() {
+        use tokio::sync::broadcast::error::TryRecvError;
+
+        const TICKS: u64 = 200;
+
+        let h = MachineHistory::new();
+        let (_snap, mut rx) = h.subscribe().await;
+
+        // Two events per tick, exactly as `sampler::start` emits them.
+        for seq in 0..TICKS {
+            h.record_sample(tagged_sample(seq)).await;
+            h.record_service_samples(service_batch("trusty-search", Some(1.0), seq))
+                .await;
+        }
+
+        let mut samples = 0u64;
+        let mut batches = 0u64;
+        loop {
+            match rx.try_recv() {
+                Ok(HistoryEvent::Sample(m)) => {
+                    assert_eq!(
+                        m.sampled_at_unix,
+                        Some(samples),
+                        "samples must arrive in order with no gap"
+                    );
+                    samples += 1;
+                }
+                Ok(HistoryEvent::Services(b)) => {
+                    assert_eq!(b.sampled_at_unix, batches);
+                    batches += 1;
+                }
+                Ok(HistoryEvent::Transition(_)) => {}
+                Err(TryRecvError::Empty | TryRecvError::Closed) => break,
+                Err(TryRecvError::Lagged(n)) => panic!(
+                    "a subscriber stalled for {TICKS} ticks ({} events) was told it lagged by \
+                     {n}; EVENT_BUFFER is {EVENT_BUFFER}, which must cover two events per tick \
+                     across the whole {HOST_HISTORY_CAPACITY}-point window",
+                    TICKS * 2
+                ),
+            }
+        }
+        assert_eq!(samples, TICKS, "every host sample survived the stall");
+        assert_eq!(batches, TICKS, "every service batch survived the stall");
     }
 
     /// Why: an operator who slows the cadence would otherwise get a graph whose

--- a/crates/trusty-console/src/machine_history/mod.rs
+++ b/crates/trusty-console/src/machine_history/mod.rs
@@ -30,9 +30,11 @@
 
 pub mod events;
 pub mod sampler;
+pub mod service_samples;
 pub mod stream;
 pub mod transitions;
 
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
@@ -46,6 +48,7 @@ use trusty_common::host_metrics::history::{
 };
 
 use events::HistoryEvent;
+use service_samples::{ServiceSample, ServiceSampleBatch};
 use transitions::{SERVICE_REPORT_GRACE_SECS, ServiceTransition, TransitionTracker};
 
 /// The schema version the history payload advertises.
@@ -54,8 +57,14 @@ use transitions::{SERVICE_REPORT_GRACE_SECS, ServiceTransition, TransitionTracke
 /// shape change instead of silently mis-rendering one.
 /// What: a monotonically increasing integer, bumped on any breaking change to
 /// [`HistorySnapshot`].
+///
+/// `2` (#6642): the payload gained `service_samples` and
+/// `service_sample_capacity`, and the stream gained a `services` event. The
+/// addition is backward-compatible on the wire, but a client built against
+/// schema 1 renders no per-service graph at all, which is exactly the
+/// difference the version exists to announce.
 /// Test: `history_starts_empty`.
-pub const MACHINE_HISTORY_SCHEMA_VERSION: u32 = 1;
+pub const MACHINE_HISTORY_SCHEMA_VERSION: u32 = 2;
 
 /// Transitions retained before the oldest is evicted.
 ///
@@ -84,17 +93,28 @@ pub const EVENT_BUFFER: usize = 128;
 /// interval travel with the data because the graph's x-axis is derived from
 /// them — a UI that hard-coded 120 × 5 s would silently mis-scale the moment an
 /// operator changed the cadence.
-/// What: the sample ring and the transition log oldest-first, the two
-/// capacities, the configured sample interval, and the schema version.
-/// Test: `history_starts_empty`, `the_ring_bounds_what_history_returns`.
+/// What: the sample ring and the transition log oldest-first, the per-service
+/// sample rings keyed by service id (#6642), the capacities, the configured
+/// sample interval, and the schema version.
+/// Test: `history_starts_empty`, `the_ring_bounds_what_history_returns`,
+/// `the_snapshot_carries_a_ring_per_service`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HistorySnapshot {
     /// Host samples, oldest first. Empty before the first sample.
     pub samples: Vec<HostMetrics>,
     /// Service state changes, oldest first. Empty until a service changes state.
     pub transitions: Vec<ServiceTransition>,
+    /// Per-service samples keyed by service id, oldest first within each id
+    /// (#6642).
+    ///
+    /// A `BTreeMap` rather than a `HashMap` so the JSON object's key order is
+    /// deterministic across responses; the UI still sorts for display, but a
+    /// stable payload makes a diff between two snapshots readable.
+    pub service_samples: BTreeMap<String, Vec<ServiceSample>>,
     /// Maximum samples retained (the ring's capacity).
     pub sample_capacity: usize,
+    /// Maximum samples retained PER SERVICE (#6642).
+    pub service_sample_capacity: usize,
     /// Maximum transitions retained.
     pub transition_capacity: usize,
     /// Seconds between samples, as the running sampler is configured.
@@ -107,6 +127,16 @@ pub struct HistorySnapshot {
 struct Inner {
     samples: MetricRing<HostMetrics>,
     transitions: MetricRing<ServiceTransition>,
+    /// One ring per service id, created on that service's first sample (#6642).
+    ///
+    /// A service that disappears from the roster keeps its ring rather than
+    /// having it dropped: the window is what the operator is looking at, and a
+    /// daemon that stopped 30 s ago is exactly the case where the last minute of
+    /// history matters. The map is bounded by the connector roster, which is a
+    /// compile-time list of six.
+    service_samples: BTreeMap<String, MetricRing<ServiceSample>>,
+    /// Capacity every per-service ring is built with.
+    service_capacity: usize,
     tracker: TransitionTracker,
 }
 
@@ -142,10 +172,12 @@ impl Default for MachineHistory {
 impl MachineHistory {
     /// Build a history sized to the owner's 10-minute window.
     ///
-    /// Why: the common case — 120 points at 5 s, 256 transitions, the 60 s
+    /// Why: the common case — 600 points at 1 s, 256 transitions, the 60 s
     /// report-staleness grace.
     /// What: delegates to [`MachineHistory::with_limits`] with the shipped
-    /// constants.
+    /// constants. The per-service rings get
+    /// [`SERVICE_HISTORY_CAPACITY`](service_samples::SERVICE_HISTORY_CAPACITY),
+    /// which IS the host capacity — one window, one number.
     /// Test: `history_starts_empty`.
     #[must_use]
     pub fn new() -> Self {
@@ -161,8 +193,13 @@ impl MachineHistory {
     ///
     /// Why: a test needs a ring it can overflow and a broadcast buffer it can
     /// outrun without producing thousands of samples.
-    /// What: constructs both rings, the tracker, and the broadcast channel.
+    /// What: constructs every ring, the tracker, and the broadcast channel. The
+    /// per-service rings take `sample_capacity` too, deliberately: the host
+    /// graph and the service graph share one x-axis, so a test that shrinks one
+    /// window must shrink the other or it is testing a shape production never
+    /// has.
     /// Test: `the_ring_bounds_what_history_returns`,
+    /// `the_service_ring_bounds_what_history_returns`,
     /// `stream::tests::a_lagging_subscriber_is_told_what_it_missed`.
     #[must_use]
     pub fn with_limits(
@@ -177,6 +214,8 @@ impl MachineHistory {
                 inner: RwLock::new(Inner {
                     samples: MetricRing::new(sample_capacity),
                     transitions: MetricRing::new(transition_capacity),
+                    service_samples: BTreeMap::new(),
+                    service_capacity: sample_capacity,
                     tracker: TransitionTracker::new(grace),
                 }),
                 events,
@@ -218,6 +257,65 @@ impl MachineHistory {
             .shared
             .events
             .send(HistoryEvent::Sample(Box::new(sample)));
+    }
+
+    /// Record one tick's worth of per-service samples — THE write path (#6642).
+    ///
+    /// Why one function for the whole batch: it mirrors
+    /// [`MachineHistory::record_sample`] for the host half, and it is what makes
+    /// the ring and the stream atomic against each other. Both happen under the
+    /// write lock, so a subscriber that took its snapshot between the ring push
+    /// and the broadcast cannot exist.
+    ///
+    /// Why a service with no ring gets one here: the roster is discovered at
+    /// runtime, and a service that appears mid-window (a binary installed while
+    /// the console runs) must start collecting immediately rather than waiting
+    /// for a restart.
+    /// What: pushes each [`ServiceSample`] onto its service's ring, creating the
+    /// ring on first sight, then broadcasts ONE
+    /// [`HistoryEvent::Services`](events::HistoryEvent::Services) carrying the
+    /// whole batch. A send with no live subscribers is not an error — the rings
+    /// are the durable half.
+    /// Test: `recording_service_samples_fans_out_to_subscribers`,
+    /// `the_service_ring_bounds_what_history_returns`,
+    /// `the_snapshot_carries_a_ring_per_service`.
+    pub async fn record_service_samples(&self, batch: ServiceSampleBatch) {
+        let mut inner = self.shared.inner.write().await;
+        let capacity = inner.service_capacity;
+        for sample in &batch.services {
+            inner
+                .service_samples
+                .entry(sample.id.clone())
+                .or_insert_with(|| MetricRing::new(capacity))
+                .push(sample.clone());
+        }
+        let _ = self
+            .shared
+            .events
+            .send(HistoryEvent::Services(Box::new(batch)));
+    }
+
+    /// The newest recorded `cpu_pct` for each service (#6642).
+    ///
+    /// Why: `GET /api/console/services` must render a CPU figure before the
+    /// stream connects, and the newest ring entry is exactly that figure. Taking
+    /// it from the ring rather than from a second cache means the list and the
+    /// graph cannot disagree about the same instant.
+    /// What: reads the last entry of every per-service ring under the read lock.
+    /// A service with no ring, or whose newest sample carries no measurement, is
+    /// absent from the map — the caller renders `null`, never `0.0`.
+    /// Test: `latest_service_cpu_reads_the_newest_sample`.
+    pub async fn latest_service_cpu(&self) -> std::collections::HashMap<String, f32> {
+        let inner = self.shared.inner.read().await;
+        inner
+            .service_samples
+            .iter()
+            .filter_map(|(id, ring)| {
+                ring.last()
+                    .and_then(|s| s.cpu_pct)
+                    .map(|cpu| (id.clone(), cpu))
+            })
+            .collect()
     }
 
     /// Fold one observation of the service report set into the transition log.
@@ -287,7 +385,13 @@ impl MachineHistory {
         HistorySnapshot {
             samples: inner.samples.snapshot(),
             transitions: inner.transitions.snapshot(),
+            service_samples: inner
+                .service_samples
+                .iter()
+                .map(|(id, ring)| (id.clone(), ring.snapshot()))
+                .collect(),
             sample_capacity: inner.samples.capacity(),
+            service_sample_capacity: inner.service_capacity,
             transition_capacity: inner.transitions.capacity(),
             sample_interval_secs: self.shared.sample_interval_secs.load(Ordering::Relaxed),
             schema_version: MACHINE_HISTORY_SCHEMA_VERSION,
@@ -397,6 +501,117 @@ mod tests {
         let snap = h.snapshot().await;
         assert_eq!(snap.transitions.len(), 1);
         assert_eq!(snap.transitions[0].to, transitions::ServiceState::Degraded);
+    }
+
+    /// Build a one-service batch.
+    fn service_batch(id: &str, cpu: Option<f32>, at: u64) -> ServiceSampleBatch {
+        use crate::connector::ServiceStatus;
+        ServiceSampleBatch {
+            sampled_at_unix: at,
+            services: vec![ServiceSample {
+                id: id.to_string(),
+                status: ServiceStatus::Running,
+                cpu_pct: cpu,
+            }],
+        }
+    }
+
+    /// Why (#6642): the per-service rings and the `services` broadcast are
+    /// written together; a batch that reached one but not the other would leave
+    /// an open stream and a fresh reload drawing different graphs.
+    /// What: subscribes, records one batch, and asserts both the receiver and
+    /// the rings saw it.
+    /// Test: this test itself.
+    #[tokio::test]
+    async fn recording_service_samples_fans_out_to_subscribers() {
+        let h = MachineHistory::new();
+        let (snap, mut rx) = h.subscribe().await;
+        assert!(snap.service_samples.is_empty());
+
+        h.record_service_samples(service_batch("trusty-search", Some(2.0), 10))
+            .await;
+
+        match rx.try_recv() {
+            Ok(HistoryEvent::Services(b)) => {
+                assert_eq!(b.sampled_at_unix, 10);
+                assert_eq!(b.services.len(), 1);
+            }
+            other => panic!("expected a services event, got {other:?}"),
+        }
+        let snap = h.snapshot().await;
+        assert_eq!(snap.service_samples["trusty-search"].len(), 1);
+    }
+
+    /// Why (#6642): each per-service ring must be bounded for the same reason
+    /// the host ring is — the console runs for weeks at one sample a second.
+    /// What: records four batches into a three-slot history and asserts the ring
+    /// holds three, oldest evicted, with the capacity reported honestly.
+    /// Test: this test itself.
+    #[tokio::test]
+    async fn the_service_ring_bounds_what_history_returns() {
+        let h = MachineHistory::with_limits(3, 4, 8, Duration::from_secs(60));
+        for at in 1..=4 {
+            h.record_service_samples(service_batch("trusty-search", Some(at as f32), at))
+                .await;
+        }
+        let snap = h.snapshot().await;
+        let ring = &snap.service_samples["trusty-search"];
+        assert_eq!(ring.len(), 3, "the ring bounds the per-service window");
+        assert_eq!(
+            ring.first().and_then(|s| s.cpu_pct),
+            Some(2.0),
+            "the oldest sample was evicted"
+        );
+        assert_eq!(snap.service_sample_capacity, 3);
+    }
+
+    /// Why: a service that appears mid-window — a binary installed while the
+    /// console runs — must start collecting immediately rather than waiting for
+    /// a restart, and each service must get its OWN ring.
+    /// What: records two services, then a third on a later tick, and asserts the
+    /// snapshot carries three independently-sized rings.
+    /// Test: this test itself.
+    #[tokio::test]
+    async fn the_snapshot_carries_a_ring_per_service() {
+        let h = MachineHistory::new();
+        h.record_service_samples(service_batch("trusty-search", Some(1.0), 1))
+            .await;
+        h.record_service_samples(service_batch("trusty-search", Some(2.0), 2))
+            .await;
+        h.record_service_samples(service_batch("trusty-mpm", None, 3))
+            .await;
+
+        let snap = h.snapshot().await;
+        assert_eq!(snap.service_samples.len(), 2);
+        assert_eq!(snap.service_samples["trusty-search"].len(), 2);
+        assert_eq!(snap.service_samples["trusty-mpm"].len(), 1);
+        assert_eq!(snap.schema_version, 2, "#6642 bumped the payload shape");
+    }
+
+    /// Why (#6642): the services route renders this number before the stream
+    /// connects, so it must be the NEWEST sample and must omit a service whose
+    /// newest sample carries no measurement.
+    /// What: records a measured sample then an unmeasurable one for the same
+    /// service, plus a measured one for another, and asserts the map.
+    /// Test: this test itself.
+    #[tokio::test]
+    async fn latest_service_cpu_reads_the_newest_sample() {
+        let h = MachineHistory::new();
+        h.record_service_samples(service_batch("trusty-search", Some(1.0), 1))
+            .await;
+        h.record_service_samples(service_batch("trusty-search", Some(9.5), 2))
+            .await;
+        h.record_service_samples(service_batch("trusty-mpm", Some(3.0), 2))
+            .await;
+        assert_eq!(h.latest_service_cpu().await["trusty-search"], 9.5);
+
+        // The daemon stops: its newest sample has no measurement, so it drops
+        // out of the map rather than reporting its last live figure forever.
+        h.record_service_samples(service_batch("trusty-search", None, 3))
+            .await;
+        let latest = h.latest_service_cpu().await;
+        assert!(!latest.contains_key("trusty-search"));
+        assert_eq!(latest["trusty-mpm"], 3.0);
     }
 
     /// Why: an operator who slows the cadence would otherwise get a graph whose
@@ -537,7 +752,7 @@ mod tests {
             let first_live = loop {
                 match rx.try_recv() {
                     Ok(HistoryEvent::Sample(m)) => break m.sampled_at_unix.expect("tagged sample"),
-                    Ok(HistoryEvent::Transition(_)) => {}
+                    Ok(HistoryEvent::Transition(_) | HistoryEvent::Services(_)) => {}
                     Err(TryRecvError::Empty | TryRecvError::Closed) => panic!(
                         "subscription {nth} snapshotted through {last_snapshotted:?} of {TOTAL} \
                          samples and then received nothing live"

--- a/crates/trusty-console/src/machine_history/sampler.rs
+++ b/crates/trusty-console/src/machine_history/sampler.rs
@@ -23,12 +23,62 @@
 //! halves it calls are covered: `machine_history::tests` for the ring and the
 //! log, `host_status::tests` for the cache.
 
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use tracing::{debug, info};
 use trusty_common::host_metrics::HostSampler;
 
 use crate::server::AppState;
+use crate::service_cpu::{ServiceCpuSampler, resolve_pid};
+
+/// Resolve any missing pids, then record one per-service sample (#6642).
+///
+/// Why the two steps are split: resolving a pid reads a lock file or dials a
+/// socket, which must not run on the reactor thread; taking a CPU reading on an
+/// already-known pid is a `sysinfo` refresh that must not pay for a thread hop.
+/// Steady state does the second only — every service either has a pid or is
+/// inside its backoff window, so `pending` is empty and no blocking task is
+/// spawned at all.
+///
+/// Fail-open: a panic inside the lookup task degrades to "no pids resolved this
+/// tick", and the sample is still recorded for every service. Nothing here can
+/// stop the loop.
+/// What: asks the sampler which ids need a lookup, runs
+/// [`resolve_pid`] for each on the blocking pool, feeds the answers back, then
+/// records the batch through
+/// [`MachineHistory::record_service_samples`](super::MachineHistory::record_service_samples).
+/// Test: `service_cpu::tests` covers the sampler's own behaviour; this function
+/// is the wiring, exercised whenever the daemon runs.
+async fn sample_services(
+    state: &AppState,
+    service_cpu: &mut ServiceCpuSampler,
+    services: &[crate::connector::ServiceInfo],
+) {
+    let pending = service_cpu.pending_lookups(services, Instant::now());
+    if !pending.is_empty() {
+        let found = tokio::task::spawn_blocking(move || {
+            pending
+                .into_iter()
+                .map(|id| {
+                    let pid = resolve_pid(&id);
+                    (id, pid)
+                })
+                .collect::<Vec<_>>()
+        })
+        .await
+        .unwrap_or_else(|e| {
+            debug!("machine_history: service pid lookup task failed: {e}");
+            Vec::new()
+        });
+        service_cpu.record_lookups(found, Instant::now());
+    }
+
+    let now_unix = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs());
+    let batch = service_cpu.sample(services, now_unix);
+    state.machine_history().record_service_samples(batch).await;
+}
 
 /// Spawn the host sampling + service observation loop.
 ///
@@ -50,6 +100,9 @@ pub fn start(state: AppState, interval: Duration) {
             state.machine_history().snapshot().await.sample_capacity
         );
         let mut sampler = HostSampler::new();
+        // #6642: one sampler across ticks — `sysinfo` derives CPU% from the
+        // delta between two refreshes, so it cannot be rebuilt per tick.
+        let mut service_cpu = ServiceCpuSampler::new();
         loop {
             let metrics = sampler.sample();
             debug!(
@@ -69,6 +122,13 @@ pub fn start(state: AppState, interval: Duration) {
                     to = ?change.to,
                     "machine_history: service changed state"
                 );
+            }
+
+            // #6642: one per-service sample per tick. The status comes from the
+            // health poller's cache rather than a fresh detection pass — this
+            // loop runs every second and a detection pass dials six services.
+            if let Some(snapshot) = state.poller_cache().snapshot().await {
+                sample_services(&state, &mut service_cpu, &snapshot.services).await;
             }
 
             tokio::time::sleep(interval).await;

--- a/crates/trusty-console/src/machine_history/sampler.rs
+++ b/crates/trusty-console/src/machine_history/sampler.rs
@@ -16,20 +16,83 @@
 //! same task publishes `interval` to the history so the payload advertises the
 //! cadence actually in use.
 //!
+//! Why each half of a tick is panic-guarded (#6642): this is ONE bare
+//! `tokio::spawn`, so a panic anywhere inside it ends the task. The history then
+//! freezes, every open SSE stream stays connected emitting nothing, and no log
+//! line says why — the failure looks exactly like a quiet machine. `guarded`
+//! contains a panic to the half that raised it, logs the payload at `error!`,
+//! and lets the next tick run. `start` also keeps the loop's `JoinHandle` and
+//! logs at `error!` if the loop ever ends, which after this guard it cannot do
+//! except by cancellation.
+//!
 //! When #6284 inverts the transport, the service half of this loop becomes a
 //! push handler calling `observe_services` and the host half becomes a push
 //! handler calling `record_sample`; neither the ring nor any reader changes.
-//! Test: not tested directly — it spawns a real OS sampler on a timer. Both
-//! halves it calls are covered: `machine_history::tests` for the ring and the
-//! log, `host_status::tests` for the cache.
+//! Test: the loop itself is not tested directly — it spawns a real OS sampler on
+//! a timer. Its parts are: `a_panicking_step_is_contained_and_the_next_one_runs`
+//! and `a_panicking_service_half_leaves_the_host_half_recording` cover the
+//! guard, `machine_history::tests` the rings and the log, `host_status::tests`
+//! the cache.
 
+use std::any::Any;
+use std::panic::AssertUnwindSafe;
 use std::time::{Duration, Instant};
 
-use tracing::{debug, info};
+use futures_util::FutureExt;
+use tracing::{debug, error, info};
 use trusty_common::host_metrics::HostSampler;
 
 use crate::server::AppState;
 use crate::service_cpu::{ServiceCpuSampler, resolve_pid};
+
+/// Render a caught panic payload as text.
+///
+/// Why: `catch_unwind` hands back `Box<dyn Any + Send>`, which formats as
+/// nothing useful. The two shapes `panic!` and `assert!` actually produce are
+/// `&'static str` and `String`; anything else is a custom payload no log line
+/// can render, and saying so is better than printing a type id.
+/// Test: `a_panicking_step_is_contained_and_the_next_one_runs`.
+fn panic_text(payload: &(dyn Any + Send)) -> String {
+    if let Some(s) = payload.downcast_ref::<&'static str>() {
+        (*s).to_string()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "<non-string panic payload>".to_string()
+    }
+}
+
+/// Run one step of a tick, containing a panic rather than ending the loop.
+///
+/// Why: see the module docs — an unguarded panic in this task freezes the
+/// history silently. Guarding per STEP rather than per tick is what makes the
+/// host half survive a panic in the service half: the graph then shows a gap in
+/// one series instead of going flat in all of them.
+///
+/// Why `AssertUnwindSafe` is sound here: the state crossing the boundary is the
+/// `AppState` handles (`tokio::sync::RwLock`, which has no poisoning — a panic
+/// while a guard is held releases it) and the `&mut ServiceCpuSampler`, whose
+/// fields are two maps and a `Vec` with no invariant a half-finished tick
+/// breaks. The next tick re-reads both from scratch.
+/// What: awaits `body` under `catch_unwind`. Returns `true` when it completed,
+/// `false` after logging the panic payload at `error!` with `step` naming which
+/// half raised it. Never propagates.
+/// Test: `a_panicking_step_is_contained_and_the_next_one_runs`,
+/// `a_panicking_service_half_leaves_the_host_half_recording`.
+async fn guarded<F: Future<Output = ()>>(step: &'static str, body: F) -> bool {
+    match AssertUnwindSafe(body).catch_unwind().await {
+        Ok(()) => true,
+        Err(payload) => {
+            error!(
+                step,
+                panic = %panic_text(payload.as_ref()),
+                "machine_history: a sampler step panicked; the loop continues and this tick \
+                 records nothing for that step"
+            );
+            false
+        }
+    }
+}
 
 /// Resolve any missing pids, then record one per-service sample (#6642).
 ///
@@ -93,7 +156,7 @@ pub fn start(state: AppState, interval: Duration) {
     state
         .machine_history()
         .set_sample_interval(interval.as_secs());
-    tokio::spawn(async move {
+    let loop_task = tokio::spawn(async move {
         info!(
             "machine_history: sampling host metrics every {}s (window={} points)",
             interval.as_secs(),
@@ -104,34 +167,216 @@ pub fn start(state: AppState, interval: Duration) {
         // delta between two refreshes, so it cannot be rebuilt per tick.
         let mut service_cpu = ServiceCpuSampler::new();
         loop {
-            let metrics = sampler.sample();
-            debug!(
-                overall = ?metrics.overall_pressure,
-                cpu_pct = metrics.cpu.usage_pct,
-                mem_pct = metrics.memory.usage_pct,
-                "machine_history: sampled host metrics"
-            );
-            state.host_metrics_cache().set(metrics.clone()).await;
-            state.machine_history().record_sample(metrics).await;
-
-            let reports = state.collect_service_reports().await;
-            for change in state.machine_history().observe_services(&reports).await {
-                info!(
-                    service = %change.service_id,
-                    from = ?change.from,
-                    to = ?change.to,
-                    "machine_history: service changed state"
-                );
-            }
-
-            // #6642: one per-service sample per tick. The status comes from the
-            // health poller's cache rather than a fresh detection pass — this
-            // loop runs every second and a detection pass dials six services.
-            if let Some(snapshot) = state.poller_cache().snapshot().await {
-                sample_services(&state, &mut service_cpu, &snapshot.services).await;
-            }
-
+            // #6642: each half is guarded separately, so a panic in one leaves a
+            // gap in that series rather than freezing every graph.
+            guarded("host", host_tick(&state, &mut sampler)).await;
+            guarded("services", service_tick(&state, &mut service_cpu)).await;
             tokio::time::sleep(interval).await;
         }
     });
+
+    // #6642: the loop above cannot return, so reaching this log means the task
+    // was cancelled or aborted — which would otherwise stop the history with no
+    // trace anywhere.
+    tokio::spawn(async move {
+        match loop_task.await {
+            Ok(()) => error!("machine_history: the sampler loop ended; history has stopped"),
+            Err(e) => error!(
+                error = %e,
+                "machine_history: the sampler task ended abnormally; history has stopped"
+            ),
+        }
+    });
+}
+
+/// Sample the host once and write both the cache and the ring.
+///
+/// Why both from ONE sample: `GET /api/console/machine-status` and the history
+/// window must never disagree about the newest reading.
+/// Test: `host_status::tests` for the cache, `machine_history::tests` for the
+/// ring; the guard around it by
+/// `a_panicking_service_half_leaves_the_host_half_recording`.
+async fn host_tick(state: &AppState, sampler: &mut HostSampler) {
+    let metrics = sampler.sample();
+    debug!(
+        overall = ?metrics.overall_pressure,
+        cpu_pct = metrics.cpu.usage_pct,
+        mem_pct = metrics.memory.usage_pct,
+        "machine_history: sampled host metrics"
+    );
+    state.host_metrics_cache().set(metrics.clone()).await;
+    state.machine_history().record_sample(metrics).await;
+}
+
+/// Fold the warm service reports into the transition log, then sample CPU.
+///
+/// Why the status comes from the health poller's cache and not a fresh detection
+/// pass: this runs every second and a detection pass dials six services.
+/// Test: `service_cpu::tests` for the sampling; `machine_history::tests` for the
+/// log.
+async fn service_tick(state: &AppState, service_cpu: &mut ServiceCpuSampler) {
+    let reports = state.collect_service_reports().await;
+    for change in state.machine_history().observe_services(&reports).await {
+        info!(
+            service = %change.service_id,
+            from = ?change.from,
+            to = ?change.to,
+            "machine_history: service changed state"
+        );
+    }
+
+    if let Some(snapshot) = state.poller_cache().snapshot().await {
+        sample_services(state, service_cpu, &snapshot.services).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::connector::ServiceStatus;
+    use crate::machine_history::MachineHistory;
+    use crate::machine_history::service_samples::{ServiceSample, ServiceSampleBatch};
+
+    /// Why not a real `HostSampler`: the subject is panic containment, and a
+    /// deterministic sample keeps the assertion about the ring rather than about
+    /// the machine. No load is generated — nothing here spins a CPU.
+    fn stub_sample(seq: u64) -> trusty_common::host_metrics::HostMetrics {
+        use trusty_common::host_metrics::{
+            CpuMetrics, DiskMetrics, HostMetrics, MemoryMetrics, NetworkMetrics, Pressure,
+        };
+        HostMetrics {
+            cpu: CpuMetrics {
+                usage_pct: 0.0,
+                logical_cores: 1,
+                physical_cores: None,
+                pressure: Pressure::Nominal,
+            },
+            memory: MemoryMetrics {
+                total_bytes: 1,
+                used_bytes: 0,
+                available_bytes: 1,
+                usage_pct: 0.0,
+                swap_total_bytes: 0,
+                swap_used_bytes: 0,
+                pressure: Pressure::Nominal,
+            },
+            disks: DiskMetrics {
+                aggregate_total_bytes: 1,
+                aggregate_available_bytes: 1,
+                aggregate_used_bytes: 0,
+                aggregate_usage_pct: 0.0,
+                pressure: Pressure::Nominal,
+                mounts: Vec::new(),
+            },
+            network: NetworkMetrics {
+                rx_bytes_per_sec: 0.0,
+                tx_bytes_per_sec: 0.0,
+                rx_total_bytes: 0,
+                tx_total_bytes: 0,
+                window_secs: 1.0,
+            },
+            overall_pressure: Pressure::Nominal,
+            sampled_at_unix: Some(seq),
+        }
+    }
+
+    /// REGRESSION (#6642): a panicking step must not end the loop.
+    ///
+    /// Why: the sampler is one bare `tokio::spawn`. Before the guard, a panic
+    /// anywhere in a tick killed the task — the history froze, every open SSE
+    /// stream stayed connected emitting nothing, and no log line said why. That
+    /// is indistinguishable from a quiet machine. Remove the `catch_unwind` in
+    /// `guarded` and this test aborts the runtime instead of failing.
+    /// What: runs a panicking step, asserts it reports `false`, then runs a
+    /// second step that records into a real history and asserts it reports
+    /// `true` and the sample landed. Also pins the payload rendering both
+    /// `panic!` shapes produce.
+    /// Test: this test itself.
+    #[tokio::test]
+    async fn a_panicking_step_is_contained_and_the_next_one_runs() {
+        let history = MachineHistory::new();
+
+        let survived = guarded("panicking", async { panic!("sampler exploded") }).await;
+        assert!(
+            !survived,
+            "a panicking step reports that it did not complete"
+        );
+
+        let survived = guarded("recording", async {
+            history.record_sample(stub_sample(1)).await;
+        })
+        .await;
+        assert!(survived, "the step after a panic still runs");
+        assert_eq!(
+            history.snapshot().await.samples.len(),
+            1,
+            "the loop kept recording after a panicking step"
+        );
+
+        assert_eq!(panic_text(&"static str payload"), "static str payload");
+        assert_eq!(panic_text(&"owned payload".to_string()), "owned payload");
+        assert_eq!(panic_text(&7u8), "<non-string panic payload>");
+    }
+
+    /// REGRESSION (#6642): the two halves of a tick are guarded separately.
+    ///
+    /// Why: `sample_services` is new in #6642 and runs in the same task as the
+    /// host sample. Guarding the whole tick as one unit would let a panic in the
+    /// service half discard that tick's host sample too, so the machine graph
+    /// would go flat for a fault that belongs to one row of the service list.
+    /// What: drives three ticks where the service half always panics and the
+    /// host half always records, then a fourth where both succeed. Asserts the
+    /// host ring grew on every tick, the service rings stayed empty while the
+    /// service half was failing — which the UI reads as a gap, not as `0.0` —
+    /// and that a later good tick still records a service sample.
+    /// Test: this test itself.
+    #[tokio::test]
+    async fn a_panicking_service_half_leaves_the_host_half_recording() {
+        let history = MachineHistory::new();
+
+        for seq in 1..=3u64 {
+            guarded("host", async {
+                history.record_sample(stub_sample(seq)).await;
+            })
+            .await;
+            guarded("services", async {
+                panic!("service sampling exploded on tick {seq}")
+            })
+            .await;
+
+            let snap = history.snapshot().await;
+            assert_eq!(
+                snap.samples.len() as u64,
+                seq,
+                "the host ring keeps growing while the service half panics"
+            );
+            assert!(
+                snap.service_samples.is_empty(),
+                "a panicking service half records nothing for that tick — the UI reads the gap \
+                 as no measurement, never as 0.0"
+            );
+        }
+
+        guarded("services", async {
+            history
+                .record_service_samples(ServiceSampleBatch {
+                    sampled_at_unix: 4,
+                    services: vec![ServiceSample {
+                        id: "trusty-search".to_string(),
+                        status: ServiceStatus::Running,
+                        cpu_pct: Some(2.0),
+                    }],
+                })
+                .await;
+        })
+        .await;
+
+        let snap = history.snapshot().await;
+        assert_eq!(snap.samples.len(), 3);
+        assert_eq!(
+            snap.service_samples["trusty-search"].len(),
+            1,
+            "the service half recovers once its next tick succeeds"
+        );
+    }
 }

--- a/crates/trusty-console/src/machine_history/service_samples.rs
+++ b/crates/trusty-console/src/machine_history/service_samples.rs
@@ -1,0 +1,163 @@
+//! The per-second, per-service sample the home-page cards graph (#6642).
+//!
+//! Why: #6641 gave the console a 10-minute window of WHOLE-MACHINE samples plus
+//! a log of the moments a service changed state. The owner's ruling for the home
+//! page needs a third thing: a bar per second per service, showing that
+//! service's own CPU. A transition log cannot draw it (it records changes, not
+//! levels) and the host sample cannot either (it is one number for the whole
+//! machine).
+//!
+//! Why `cpu_pct` is an `Option` and never `0.0` for an absent service: a service
+//! that is not installed, is on-demand and idle, or whose process the console
+//! could not identify has NO measurement. Rendering that as zero draws a flat
+//! idle bar, which is visually identical to a healthy service doing nothing —
+//! the one reading the operator must be able to tell apart. `None` is the honest
+//! answer and the UI renders it as a gap.
+//!
+//! What: [`ServiceSample`] is one service at one instant; [`ServiceSampleBatch`]
+//! is the whole roster at one instant, which is what the sampler produces per
+//! tick, what the `services` SSE event carries, and what
+//! [`MachineHistory::record_service_samples`] folds into the per-service rings.
+//! [`SERVICE_HISTORY_CAPACITY`] sizes those rings to the same 10-minute window
+//! the host ring covers.
+//! Test: `a_sample_serialises_the_shape_the_ui_reads`,
+//! `an_absent_cpu_serialises_as_null`, `a_batch_names_its_services`.
+//!
+//! [`MachineHistory::record_service_samples`]:
+//!     crate::machine_history::MachineHistory::record_service_samples
+
+use serde::{Deserialize, Serialize};
+use trusty_common::host_metrics::history::HOST_HISTORY_CAPACITY;
+
+use crate::connector::ServiceStatus;
+
+/// Samples retained per service — the same 10-minute window the host ring holds.
+///
+/// Why: the home-page card draws the host graph and the service graph on one
+/// x-axis. Two different capacities would put two different spans side by side
+/// with nothing saying so, so this is defined as the host constant rather than
+/// as a second number that could drift from it.
+/// What: [`HOST_HISTORY_CAPACITY`] — 600 points at the 1 s cadence.
+/// Test: `the_service_window_matches_the_host_window`.
+pub const SERVICE_HISTORY_CAPACITY: usize = HOST_HISTORY_CAPACITY;
+
+/// One service's state and CPU at one instant (#6642).
+///
+/// Why: the card needs both halves together. CPU alone cannot say whether a
+/// missing bar means "idle" or "stopped", and status alone cannot draw a graph.
+/// What: the service id (the same `ServiceInfo::id` the services route serves,
+/// so the UI joins the two by string), the status the poller last detected, and
+/// the CPU percentage — `None` whenever no measurement was taken. The percentage
+/// follows `sysinfo`'s convention: `100.0` is one fully-saturated core, so a
+/// multi-threaded daemon can exceed 100.
+/// Test: `a_sample_serialises_the_shape_the_ui_reads`,
+/// `an_absent_cpu_serialises_as_null`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ServiceSample {
+    /// Stable service identifier, e.g. `"trusty-search"`.
+    pub id: String,
+    /// The status the health poller last detected for this service.
+    pub status: ServiceStatus,
+    /// Process CPU percentage, or `None` when no measurement was taken.
+    ///
+    /// Serialised UNCONDITIONALLY, as `null` when absent — unlike the optional
+    /// fields on `ServiceInfo`, which are skipped. The UI must distinguish "no
+    /// measurement" from a value, and a key that is sometimes missing and
+    /// sometimes `null` is two spellings of the same fact for the client to
+    /// handle.
+    pub cpu_pct: Option<f32>,
+}
+
+/// The whole service roster at one instant (#6642).
+///
+/// Why one batch rather than N independent samples: the graphs are read
+/// together, and a client that received six separate events would have to
+/// re-group them by timestamp to draw one column. Batching also means one
+/// broadcast send per tick instead of six.
+/// What: the wall-clock second the batch was taken plus one [`ServiceSample`]
+/// per registered service, in the order the poller reported them (the UI sorts;
+/// see #6642 PR-B).
+/// Test: `a_batch_names_its_services`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ServiceSampleBatch {
+    /// Unix seconds when the batch was taken. `0` when the clock is unreadable.
+    pub sampled_at_unix: u64,
+    /// One entry per registered service.
+    pub services: Vec<ServiceSample>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample(id: &str, cpu: Option<f32>) -> ServiceSample {
+        ServiceSample {
+            id: id.to_string(),
+            status: ServiceStatus::Running,
+            cpu_pct: cpu,
+        }
+    }
+
+    /// Why: PR-B renders straight off these three keys; a rename that only
+    /// changed the Rust identifier would leave the card blank with nothing red.
+    /// What: asserts the exact JSON keys and value spellings.
+    /// Test: this test itself.
+    #[test]
+    fn a_sample_serialises_the_shape_the_ui_reads() {
+        let json = serde_json::to_value(sample("trusty-search", Some(12.5))).expect("serialise");
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "id": "trusty-search",
+                "status": "running",
+                "cpu_pct": 12.5,
+            })
+        );
+    }
+
+    /// REGRESSION (#6642): an unmeasurable service must serialise `cpu_pct` as
+    /// an explicit `null`, not omit the key and not report `0.0`.
+    ///
+    /// Why: a zero draws a flat idle bar, which reads as a healthy quiet daemon.
+    /// An omitted key makes the client handle two spellings of "absent".
+    /// What: serialises a `None` sample and asserts the key is present and null.
+    /// Test: this test itself.
+    #[test]
+    fn an_absent_cpu_serialises_as_null() {
+        let json = serde_json::to_value(sample("trusty-review", None)).expect("serialise");
+        assert!(
+            json.get("cpu_pct").is_some(),
+            "the key must be present so the client has one shape to parse"
+        );
+        assert!(json["cpu_pct"].is_null(), "absent must be null, not 0.0");
+    }
+
+    /// Why: the SSE consumer keys the column on `sampled_at_unix` and the rows
+    /// on `services`.
+    /// What: round-trips a batch and asserts both fields survive.
+    /// Test: this test itself.
+    #[test]
+    fn a_batch_names_its_services() {
+        let batch = ServiceSampleBatch {
+            sampled_at_unix: 1_700_000_000,
+            services: vec![
+                sample("trusty-search", Some(1.0)),
+                sample("trusty-mpm", None),
+            ],
+        };
+        let text = serde_json::to_string(&batch).expect("serialise");
+        let back: ServiceSampleBatch = serde_json::from_str(&text).expect("deserialise");
+        assert_eq!(back, batch);
+        assert_eq!(back.services.len(), 2);
+    }
+
+    /// Why: the host graph and the service graph share one x-axis, so two
+    /// capacities would silently put two different spans side by side.
+    /// What: asserts the service capacity IS the host capacity.
+    /// Test: this test itself.
+    #[test]
+    fn the_service_window_matches_the_host_window() {
+        assert_eq!(SERVICE_HISTORY_CAPACITY, HOST_HISTORY_CAPACITY);
+        assert_eq!(SERVICE_HISTORY_CAPACITY, 600);
+    }
+}

--- a/crates/trusty-console/src/machine_history/stream.rs
+++ b/crates/trusty-console/src/machine_history/stream.rs
@@ -144,8 +144,16 @@ mod tests {
             3,
             "the connecting subscriber gets the three samples it missed"
         );
-        assert_eq!(data["sample_capacity"], 120);
-        assert_eq!(data["sample_interval_secs"], 5);
+        // #6642: read from the constants rather than restating 600 × 1, so the
+        // next cadence change fails in ONE place — history.rs's own window test.
+        assert_eq!(
+            data["sample_capacity"],
+            trusty_common::host_metrics::history::HOST_HISTORY_CAPACITY
+        );
+        assert_eq!(
+            data["sample_interval_secs"],
+            trusty_common::host_metrics::history::HOST_SAMPLE_INTERVAL_SECS
+        );
 
         let second = stream
             .next()

--- a/crates/trusty-console/src/poller.rs
+++ b/crates/trusty-console/src/poller.rs
@@ -220,6 +220,7 @@ mod tests {
                 url: self.url.map(|u| u.to_string()),
                 hint: None,
                 lifecycle: self.lifecycle(),
+                cpu_pct: None,
             }
         }
     }
@@ -273,6 +274,7 @@ mod tests {
                     url: Some("http://127.0.0.1:7878".to_string()),
                     hint: None,
                     lifecycle: ServiceLifecycle::Daemon,
+                    cpu_pct: None,
                 },
                 ServiceInfo {
                     id: "trusty-memory".to_string(),
@@ -282,6 +284,7 @@ mod tests {
                     url: None,
                     hint: None,
                     lifecycle: ServiceLifecycle::Daemon,
+                    cpu_pct: None,
                 },
             ],
             refreshed_at: Instant::now(),

--- a/crates/trusty-console/src/server/mod.rs
+++ b/crates/trusty-console/src/server/mod.rs
@@ -795,6 +795,7 @@ async fn services_handler(State(state): State<AppState>) -> axum::response::Resp
     if let Some(snap) = state.poller_cache().snapshot().await {
         let mut services = snap.services;
         apply_handle_overrides(&mut services, &handles).await;
+        crate::service_cpu::apply_cpu_overlay(&mut services, state.machine_history()).await; // #6642
         // #6370: sort AFTER the overrides so a service demoted to Degraded here
         // ranks as degraded, not as the Running the poller recorded.
         crate::detect::order_for_display(&mut services);
@@ -810,6 +811,7 @@ async fn services_handler(State(state): State<AppState>) -> axum::response::Resp
     {
         Ok(mut infos) => {
             apply_handle_overrides(&mut infos, &handles).await;
+            crate::service_cpu::apply_cpu_overlay(&mut infos, state.machine_history()).await; // #6642
             crate::detect::order_for_display(&mut infos); // #6370
             axum::Json(infos).into_response()
         }

--- a/crates/trusty-console/src/server/tests.rs
+++ b/crates/trusty-console/src/server/tests.rs
@@ -43,6 +43,7 @@ impl ServiceConnector for StubConnector {
             url: None,
             hint: None,
             lifecycle: self.lifecycle(),
+            cpu_pct: None,
         }
     }
 }
@@ -197,6 +198,7 @@ async fn test_services_route_returns_degraded_with_hint() {
                 url: None,
                 hint: Some("reachable but `console_metrics` tool not registered".to_string()),
                 lifecycle: self.lifecycle(),
+                cpu_pct: None,
             }
         }
     }
@@ -1067,8 +1069,22 @@ async fn machine_history_route_cold_cache_returns_empty_200() {
         serde_json::from_slice(&bytes).expect("parse HistorySnapshot");
     assert!(snap.samples.is_empty());
     assert!(snap.transitions.is_empty());
-    assert_eq!(snap.sample_capacity, 120);
-    assert_eq!(snap.sample_interval_secs, 5);
+    // #6642: read from the constants rather than restating 600 × 1, so the next
+    // cadence change fails in ONE place — history.rs's own window test.
+    assert_eq!(
+        snap.sample_capacity,
+        trusty_common::host_metrics::history::HOST_HISTORY_CAPACITY
+    );
+    assert_eq!(
+        snap.sample_interval_secs,
+        trusty_common::host_metrics::history::HOST_SAMPLE_INTERVAL_SECS
+    );
+    // #6642: the per-service rings share the host window and start empty.
+    assert!(snap.service_samples.is_empty());
+    assert_eq!(
+        snap.service_sample_capacity,
+        crate::machine_history::service_samples::SERVICE_HISTORY_CAPACITY
+    );
     assert_eq!(
         snap.schema_version,
         crate::machine_history::MACHINE_HISTORY_SCHEMA_VERSION

--- a/crates/trusty-console/src/service_cpu.rs
+++ b/crates/trusty-console/src/service_cpu.rs
@@ -1,0 +1,604 @@
+//! Per-service CPU sampling for the home-page card graphs (#6642).
+//!
+//! Why: `GET /api/console/services` says WHETHER each service is running. The
+//! owner's home-page ruling needs how HARD it is running, once a second. Nothing
+//! in the console measured another process before this module.
+//!
+//! Why pid discovery is a separate step from sampling: a pid costs I/O to find
+//! (a lock file to read, a socket to dial) and a CPU reading costs a syscall on
+//! an already-known pid. Doing both every tick would put a file read and six
+//! socket dials on a one-second loop. [`ServiceCpuSampler::pending_lookups`]
+//! names the services that still need a pid, [`resolve_pid`] does the I/O off
+//! the reactor, and [`ServiceCpuSampler::record_lookups`] feeds the answers
+//! back — so steady state is one `sysinfo` refresh per second and nothing else.
+//!
+//! Which services yield a pid, and why the rest do not:
+//!
+//! | Service | pid source |
+//! |---|---|
+//! | `trusty-mpm` | the `pid = N` line in its `daemon.lock` |
+//! | `trusty-search` | `LOCAL_PEERPID` / `SO_PEERCRED` on its Unix socket |
+//! | `trusty-memory` | the same, on its own Unix socket |
+//! | `trusty-agents` | none — it serves TCP loopback, and a TCP peer carries no pid |
+//! | `trusty-analyze`, `trusty-review` | none — on-demand members with no resident process |
+//!
+//! A service with no pid reports `cpu_pct: None`. It does NOT report `0.0`: an
+//! idle bar and an unmeasurable one must look different on the card.
+//!
+//! Fail-open contract: a pid that will not resolve, a process that exits between
+//! two samples, and a sampler error each yield `None` for that ONE service and
+//! leave the tick running for the others. Nothing here returns an error, and
+//! nothing here can stop the loop.
+//! Test: the inline `tests` module, plus
+//! `machine_history::tests::the_service_ring_bounds_what_history_returns` for
+//! what happens to the samples afterwards.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use trusty_common::sys_metrics::ProcessCpuSampler;
+
+use crate::connector::{ServiceInfo, ServiceStatus};
+use crate::machine_history::service_samples::{ServiceSample, ServiceSampleBatch};
+
+/// How long before a failed pid lookup is retried.
+///
+/// Why: a service that is `Running` but whose process the console cannot
+/// identify — trusty-agents, always — would otherwise be looked up every second
+/// forever. Fifteen seconds matches the health poller's cadence, which is the
+/// rate at which the answer can actually change.
+/// What: `15s`.
+/// Test: `a_failed_lookup_is_not_retried_immediately`.
+const LOOKUP_BACKOFF: Duration = Duration::from_secs(15);
+
+/// Read a service's pid, or `None` when it cannot be identified.
+///
+/// Why free rather than a method: it does blocking I/O (a file read, a socket
+/// dial) and the caller runs it on the blocking pool, away from the sampler's
+/// borrowed state.
+/// What: dispatches on the service id to the one discovery artifact that service
+/// actually publishes — see the table in the module docs. An id with no known
+/// source returns `None` immediately, doing no I/O at all.
+/// Test: `resolve_pid_is_none_for_a_service_with_no_source`,
+/// `mpm_pid_is_read_from_the_lock_file`.
+#[must_use]
+pub fn resolve_pid(service_id: &str) -> Option<u32> {
+    match service_id {
+        "trusty-mpm" => mpm_lock_pid(&mpm_lock_path()?),
+        "trusty-search" => socket_peer_pid(crate::search_uds::socket_path().ok()?),
+        "trusty-memory" => {
+            socket_peer_pid(trusty_common::daemon_socket_path("trusty-memory").ok()?)
+        }
+        _ => None,
+    }
+}
+
+/// Where trusty-mpm's daemon lock lives.
+fn mpm_lock_path() -> Option<PathBuf> {
+    Some(dirs::home_dir()?.join(".trusty-mpm").join("daemon.lock"))
+}
+
+/// Extract the `pid` field from a trusty-mpm `daemon.lock` TOML body.
+///
+/// Why a line scan rather than a TOML parse: `detect::mpm` already reads this
+/// same file for its `addr` field with a line scan, for the reason recorded
+/// there — one field does not justify a TOML dependency in the console.
+/// What: splits each line on the FIRST `=`, matches the key EXACTLY against
+/// `pid` (so `pid_file` is rejected), and parses the value. Returns `None` when
+/// the file is absent, unreadable, or carries no well-formed `pid`.
+/// Test: `mpm_pid_is_read_from_the_lock_file`,
+/// `mpm_pid_rejects_a_prefixed_key`, `mpm_pid_is_none_for_a_missing_file`.
+fn mpm_lock_pid(path: &std::path::Path) -> Option<u32> {
+    let body = std::fs::read_to_string(path).ok()?;
+    for line in body.lines() {
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        if key.trim() != "pid" {
+            continue;
+        }
+        if let Ok(pid) = value.trim().trim_matches('"').parse::<u32>()
+            && pid > 0
+        {
+            return Some(pid);
+        }
+    }
+    None
+}
+
+/// Dial `socket` and ask the kernel which process is listening.
+///
+/// Why a connect rather than a health call: the pid is a property of the
+/// CONNECTION, and the kernel answers it the moment the connect completes. There
+/// is no request to send and no response to parse, so this is strictly cheaper
+/// than the detection probe the connector already runs against the same path.
+/// What: a blocking `UnixStream::connect`, converted to the tokio type
+/// [`trusty_common::uds::peer_pid`] takes, then dropped. Any failure — no
+/// socket, nothing listening, no peer-pid support on this platform — is `None`.
+/// Test: `socket_peer_pid_reads_this_process_from_its_own_socket`,
+/// `socket_peer_pid_is_none_when_nothing_is_listening`.
+fn socket_peer_pid(socket: PathBuf) -> Option<u32> {
+    let std_stream = std::os::unix::net::UnixStream::connect(&socket).ok()?;
+    std_stream.set_nonblocking(true).ok()?;
+    // `peer_pid` reads a socket option; it never awaits, so the stream does not
+    // need a running reactor to be interrogated. `from_std` only registers it.
+    let stream = tokio::net::UnixStream::from_std(std_stream).ok()?;
+    trusty_common::uds::peer_pid(&stream)
+}
+
+/// Per-service CPU sampling across ticks (#6642).
+///
+/// Why it holds state: `sysinfo` derives CPU% from the delta between two
+/// refreshes, so the underlying sampler must live for the console's lifetime,
+/// and a resolved pid is worth keeping until its process exits.
+/// What: one [`ProcessCpuSampler`] (the workspace's single multi-pid CPU entry
+/// point), the service-id → pid map, and a per-service backoff clock for
+/// lookups that failed. Not `Clone` — it carries mutable sampling state and is
+/// owned by the one sampler task.
+/// Test: see the inline `tests` module.
+pub struct ServiceCpuSampler {
+    cpu: ProcessCpuSampler,
+    pids: HashMap<String, u32>,
+    retry_after: HashMap<String, Instant>,
+}
+
+impl Default for ServiceCpuSampler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ServiceCpuSampler {
+    /// An empty sampler that has resolved nothing yet.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            cpu: ProcessCpuSampler::new(),
+            pids: HashMap::new(),
+            retry_after: HashMap::new(),
+        }
+    }
+
+    /// Which services need a pid lookup on this tick.
+    ///
+    /// Why only `Running` services: an `Absent` or `Available` member has no
+    /// resident process to find, so dialling its socket would be I/O that cannot
+    /// succeed. `Degraded` counts as running — a daemon answering but missing a
+    /// tool is still a process burning CPU.
+    /// What: the ids that are running, have no pid recorded, and are not inside
+    /// their [`LOOKUP_BACKOFF`] window.
+    /// Test: `pending_lookups_skips_a_service_that_is_not_running`,
+    /// `a_failed_lookup_is_not_retried_immediately`.
+    #[must_use]
+    pub fn pending_lookups(&self, services: &[ServiceInfo], now: Instant) -> Vec<String> {
+        services
+            .iter()
+            .filter(|s| is_live(&s.status))
+            .filter(|s| !self.pids.contains_key(&s.id))
+            .filter(|s| self.retry_after.get(&s.id).is_none_or(|at| now >= *at))
+            .map(|s| s.id.clone())
+            .collect()
+    }
+
+    /// Record what [`resolve_pid`] found for each pending service.
+    ///
+    /// Why the failures are recorded too: without a backoff entry, a service
+    /// that can never yield a pid would be looked up on every tick forever.
+    /// What: a `Some` starts tracking the pid (priming its CPU baseline, so the
+    /// NEXT tick already carries a real figure); a `None` arms the backoff.
+    /// Test: `a_failed_lookup_is_not_retried_immediately`,
+    /// `a_resolved_pid_is_tracked`.
+    pub fn record_lookups(&mut self, found: Vec<(String, Option<u32>)>, now: Instant) {
+        for (id, pid) in found {
+            match pid {
+                Some(pid) => {
+                    self.cpu.track(pid);
+                    self.pids.insert(id.clone(), pid);
+                    self.retry_after.remove(&id);
+                }
+                None => {
+                    self.retry_after.insert(id, now + LOOKUP_BACKOFF);
+                }
+            }
+        }
+    }
+
+    /// Take one tick's sample for every service.
+    ///
+    /// Why the whole roster and not just the running half: the card grid renders
+    /// every registered service, and a row that stopped emitting samples when
+    /// its daemon stopped would leave the graph frozen at its last value rather
+    /// than showing the gap.
+    /// What: refreshes every tracked pid in ONE `sysinfo` call — the tracked
+    /// pids only, never the process table — then reads a figure per service. A
+    /// service whose pid vanished has already been dropped by the refresh, so it
+    /// reads `None` and its entry is forgotten here, which lets
+    /// [`ServiceCpuSampler::pending_lookups`] rediscover it after a restart.
+    /// Never returns an error and never panics: an unmeasurable service is one
+    /// `None` among the others.
+    /// Test: `a_vanished_pid_samples_as_none_and_the_tick_continues`,
+    /// `every_service_gets_a_sample`.
+    #[must_use]
+    pub fn sample(&mut self, services: &[ServiceInfo], sampled_at_unix: u64) -> ServiceSampleBatch {
+        self.cpu.refresh();
+
+        let mut samples = Vec::with_capacity(services.len());
+        for service in services {
+            let cpu_pct = match self.pids.get(&service.id) {
+                Some(pid) => self.cpu.cpu_pct(*pid),
+                None => None,
+            };
+            // #6642: a tracked pid whose process is gone reads None; forget it
+            // so the next tick can rediscover the restarted daemon.
+            if cpu_pct.is_none()
+                && let Some(pid) = self.pids.remove(&service.id)
+            {
+                self.cpu.untrack(pid);
+            }
+            samples.push(ServiceSample {
+                id: service.id.clone(),
+                status: service.status.clone(),
+                cpu_pct,
+            });
+        }
+
+        ServiceSampleBatch {
+            sampled_at_unix,
+            services: samples,
+        }
+    }
+
+    /// The pid currently recorded for `service_id`, if any.
+    ///
+    /// Test: `a_resolved_pid_is_tracked`.
+    #[must_use]
+    pub fn pid_of(&self, service_id: &str) -> Option<u32> {
+        self.pids.get(service_id).copied()
+    }
+}
+
+/// Stamp each entry with the newest CPU sample the history holds (#6642).
+///
+/// Why here rather than in the route handler: it belongs to this module's
+/// subject, and `server::mod` is at its SLOC cap. Why on the ROUTE rather than
+/// in detection: a connector is a synchronous probe with no sampler, and the
+/// number must come from the same rings the graph reads or the list and the
+/// newest bar could disagree.
+/// What: overwrites `ServiceInfo::cpu_pct` for every entry the history has a
+/// measurement for, and leaves the rest `None` — which the route serialises as
+/// an explicit `null`. Before the first tick the history is empty and every
+/// entry stays `None`, which is the correct reading of "not measured yet".
+/// Test: `the_overlay_stamps_only_the_services_with_a_measurement`.
+pub async fn apply_cpu_overlay(
+    services: &mut [ServiceInfo],
+    history: &crate::machine_history::MachineHistory,
+) {
+    let latest = history.latest_service_cpu().await;
+    for service in services.iter_mut() {
+        service.cpu_pct = latest.get(&service.id).copied();
+    }
+}
+
+/// Does this status mean a process should exist right now?
+///
+/// Why `Degraded` counts: a daemon that answers but is missing a tool is still a
+/// running process with real CPU, and hiding its graph would hide the case an
+/// operator most wants to look at.
+/// Test: `pending_lookups_skips_a_service_that_is_not_running`.
+fn is_live(status: &ServiceStatus) -> bool {
+    matches!(status, ServiceStatus::Running | ServiceStatus::Degraded)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::connector::ServiceLifecycle;
+
+    fn info(id: &str, status: ServiceStatus) -> ServiceInfo {
+        ServiceInfo {
+            id: id.to_string(),
+            display_name: id.to_string(),
+            status,
+            version: None,
+            url: None,
+            hint: None,
+            lifecycle: ServiceLifecycle::Daemon,
+            cpu_pct: None,
+        }
+    }
+
+    /// Spawn a child that sleeps, so a test has a real pid it owns.
+    ///
+    /// Why not a spinner: this test suite must never generate machine-wide load
+    /// to prove a CPU reading. The assertions are about a measurement being
+    /// taken and dropped, not about it reaching a value.
+    fn spawn_sleeper() -> std::process::Child {
+        std::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawn a sleeping child")
+    }
+
+    /// Why: the whole card grid renders from this batch, so a service the
+    /// sampler skipped is a row with a frozen graph.
+    /// What: samples four services with no pids resolved and asserts one entry
+    /// each, every `cpu_pct` absent rather than zero.
+    /// Test: this test itself.
+    #[test]
+    fn every_service_gets_a_sample() {
+        let services = vec![
+            info("trusty-search", ServiceStatus::Running),
+            info("trusty-review", ServiceStatus::Available),
+            info("trusty-analyze", ServiceStatus::Absent),
+            info("trusty-agents", ServiceStatus::Degraded),
+        ];
+        let batch = ServiceCpuSampler::new().sample(&services, 42);
+
+        assert_eq!(batch.sampled_at_unix, 42);
+        assert_eq!(batch.services.len(), 4);
+        for sample in &batch.services {
+            assert_eq!(
+                sample.cpu_pct, None,
+                "{} has no pid, so it must report no measurement rather than 0.0",
+                sample.id
+            );
+        }
+    }
+
+    /// Why: dialling a socket for a service that is not running is I/O that
+    /// cannot succeed, on a one-second loop.
+    /// What: asserts only the running and degraded rows are pending.
+    /// Test: this test itself.
+    #[test]
+    fn pending_lookups_skips_a_service_that_is_not_running() {
+        let services = vec![
+            info("trusty-search", ServiceStatus::Running),
+            info("trusty-memory", ServiceStatus::Available),
+            info("trusty-review", ServiceStatus::Absent),
+            info("trusty-mpm", ServiceStatus::Degraded),
+        ];
+        let mut pending = ServiceCpuSampler::new().pending_lookups(&services, Instant::now());
+        pending.sort();
+        assert_eq!(pending, vec!["trusty-mpm", "trusty-search"]);
+    }
+
+    /// REGRESSION (#6642): a lookup that failed must not be retried on the very
+    /// next tick.
+    ///
+    /// Why: trusty-agents can never yield a pid — it serves TCP loopback. Without
+    /// a backoff the console would attempt a resolution for it every second for
+    /// as long as it runs.
+    /// What: records a failed lookup, asserts the service is not pending
+    /// immediately, and that it is pending again once the backoff has elapsed.
+    /// Test: this test itself.
+    #[test]
+    fn a_failed_lookup_is_not_retried_immediately() {
+        let services = vec![info("trusty-agents", ServiceStatus::Running)];
+        let now = Instant::now();
+        let mut sampler = ServiceCpuSampler::new();
+
+        assert_eq!(sampler.pending_lookups(&services, now).len(), 1);
+        sampler.record_lookups(vec![("trusty-agents".to_string(), None)], now);
+        assert!(
+            sampler.pending_lookups(&services, now).is_empty(),
+            "a failed lookup must back off, not retry on the next tick"
+        );
+        assert_eq!(
+            sampler
+                .pending_lookups(&services, now + LOOKUP_BACKOFF)
+                .len(),
+            1,
+            "the backoff must expire so a daemon that starts later is found"
+        );
+    }
+
+    /// Why: a resolved pid must enter the CPU sampler, or the reading never
+    /// arrives however well discovery worked.
+    /// What: resolves a live child's pid, asserts it is recorded and tracked and
+    /// that the sample carries a figure, then reaps the child.
+    /// Test: this test itself.
+    #[test]
+    fn a_resolved_pid_is_tracked() {
+        let mut child = spawn_sleeper();
+        let pid = child.id();
+        let services = vec![info("trusty-search", ServiceStatus::Running)];
+
+        let mut sampler = ServiceCpuSampler::new();
+        sampler.record_lookups(
+            vec![("trusty-search".to_string(), Some(pid))],
+            Instant::now(),
+        );
+        let batch = sampler.sample(&services, 1);
+
+        let recorded = sampler.pid_of("trusty-search");
+        let cpu = batch.services[0].cpu_pct;
+
+        let _ = child.kill();
+        let _ = child.wait();
+
+        assert_eq!(recorded, Some(pid));
+        assert!(
+            cpu.is_some(),
+            "a live tracked process must produce a measurement"
+        );
+    }
+
+    /// REGRESSION (#6642): a process that exits between two samples reports
+    /// `None`, its pid is forgotten, and the tick keeps producing samples for
+    /// every other service.
+    ///
+    /// Why: this is the fail-open contract. A sampler that panicked, stalled, or
+    /// reported `0.0` on a dead daemon would each be a distinct silent failure.
+    /// What: tracks a real child alongside a service that never had a pid, kills
+    /// and reaps the child, samples again, and asserts both rows are present,
+    /// both `cpu_pct` are `None`, and the dead pid was dropped.
+    /// Test: this test itself.
+    #[test]
+    fn a_vanished_pid_samples_as_none_and_the_tick_continues() {
+        let mut child = spawn_sleeper();
+        let pid = child.id();
+        let services = vec![
+            info("trusty-search", ServiceStatus::Running),
+            info("trusty-agents", ServiceStatus::Running),
+        ];
+
+        let mut sampler = ServiceCpuSampler::new();
+        sampler.record_lookups(
+            vec![("trusty-search".to_string(), Some(pid))],
+            Instant::now(),
+        );
+        // Prime the CPU delta; the reading itself is asserted on tick 2.
+        let _ = sampler.sample(&services, 1);
+
+        child.kill().expect("kill the sleeper");
+        child.wait().expect("reap the sleeper");
+
+        let batch = sampler.sample(&services, 2);
+        assert_eq!(
+            batch.services.len(),
+            2,
+            "the tick must not stop or truncate"
+        );
+        assert_eq!(
+            batch.services[0].cpu_pct, None,
+            "a vanished process reports no measurement, never 0.0"
+        );
+        assert_eq!(batch.services[1].cpu_pct, None);
+        assert_eq!(
+            sampler.pid_of("trusty-search"),
+            None,
+            "the dead pid must be forgotten so a restart can be rediscovered"
+        );
+
+        // And the tick after that still works.
+        assert_eq!(sampler.sample(&services, 3).services.len(), 2);
+    }
+
+    /// Why (#6642): the list must render a CPU figure on first paint, and a
+    /// service with no measurement must stay `None` rather than inherit a
+    /// neighbour's number or fall back to zero.
+    /// What: records one measured and one unmeasurable service into a real
+    /// history, then overlays a three-entry list and asserts exactly one entry
+    /// was stamped.
+    /// Test: this test itself.
+    #[tokio::test]
+    async fn the_overlay_stamps_only_the_services_with_a_measurement() {
+        let history = crate::machine_history::MachineHistory::new();
+        history
+            .record_service_samples(ServiceSampleBatch {
+                sampled_at_unix: 1,
+                services: vec![
+                    ServiceSample {
+                        id: "trusty-search".to_string(),
+                        status: ServiceStatus::Running,
+                        cpu_pct: Some(7.5),
+                    },
+                    ServiceSample {
+                        id: "trusty-review".to_string(),
+                        status: ServiceStatus::Available,
+                        cpu_pct: None,
+                    },
+                ],
+            })
+            .await;
+
+        let mut services = vec![
+            info("trusty-search", ServiceStatus::Running),
+            info("trusty-review", ServiceStatus::Available),
+            info("trusty-agents", ServiceStatus::Absent),
+        ];
+        apply_cpu_overlay(&mut services, &history).await;
+
+        assert_eq!(services[0].cpu_pct, Some(7.5));
+        assert_eq!(
+            services[1].cpu_pct, None,
+            "a sampled-but-unmeasurable service stays null"
+        );
+        assert_eq!(
+            services[2].cpu_pct, None,
+            "a service the history never saw stays null"
+        );
+    }
+
+    /// Why: the three services with no discovery artifact must cost no I/O at
+    /// all, or the one-second loop pays for a lookup that can never succeed.
+    /// What: asserts `resolve_pid` answers `None` for an unknown id.
+    /// Test: this test itself.
+    #[test]
+    fn resolve_pid_is_none_for_a_service_with_no_source() {
+        assert_eq!(resolve_pid("trusty-agents"), None);
+        assert_eq!(resolve_pid("trusty-review"), None);
+        assert_eq!(resolve_pid("not-a-service"), None);
+    }
+
+    /// Why: trusty-mpm is the one member that publishes its pid on disk, so the
+    /// parse is the whole discovery path for it.
+    /// What: writes a lock file in the shape the daemon writes and asserts the
+    /// pid comes back.
+    /// Test: this test itself.
+    #[test]
+    fn mpm_pid_is_read_from_the_lock_file() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let lock = tmp.path().join("daemon.lock");
+        std::fs::write(
+            &lock,
+            "pid = 4242\naddr = \"http://127.0.0.1:7880\"\nstarted_at = \"x\"\n",
+        )
+        .expect("write");
+        assert_eq!(mpm_lock_pid(&lock), Some(4242));
+    }
+
+    /// Why: `pid_file = "…"` in the same TOML must not be read as the pid — the
+    /// sibling `addr` parser in `detect::mpm` records the same finding.
+    /// What: asserts a prefixed key, a zero pid, and a missing file all yield
+    /// `None`.
+    /// Test: this test itself.
+    #[test]
+    fn mpm_pid_rejects_a_prefixed_key() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let lock = tmp.path().join("daemon.lock");
+        std::fs::write(&lock, "pid_file = \"/tmp/x\"\npidx = 7\n").expect("write");
+        assert_eq!(mpm_lock_pid(&lock), None);
+
+        std::fs::write(&lock, "pid = 0\n").expect("write");
+        assert_eq!(mpm_lock_pid(&lock), None, "pid 0 is not a process");
+    }
+
+    /// Why: a stale lock file removed under the console must degrade to no
+    /// measurement, not to an error.
+    /// Test: this test itself.
+    #[test]
+    fn mpm_pid_is_none_for_a_missing_file() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        assert_eq!(mpm_lock_pid(&tmp.path().join("absent.lock")), None);
+    }
+
+    /// Why (#6642): trusty-search and trusty-memory publish no pid anywhere, so
+    /// the peer pid of their socket is the entire discovery path. A stub here
+    /// leaves both graphs permanently empty.
+    /// What: binds a socket in this process, dials it through the same helper
+    /// the sampler uses, and asserts the pid is this process's own.
+    /// Test: this test itself.
+    #[tokio::test]
+    async fn socket_peer_pid_reads_this_process_from_its_own_socket() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("peer.sock");
+        let _listener = tokio::net::UnixListener::bind(&path).expect("bind");
+
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        assert_eq!(socket_peer_pid(path), Some(std::process::id()));
+        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+        assert_eq!(socket_peer_pid(path), None);
+    }
+
+    /// Why: a daemon that is not running must degrade to no measurement rather
+    /// than to a hang or an error.
+    /// What: dials a path nothing is listening on.
+    /// Test: this test itself.
+    #[test]
+    fn socket_peer_pid_is_none_when_nothing_is_listening() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        assert_eq!(socket_peer_pid(tmp.path().join("nothing.sock")), None);
+    }
+}


### PR DESCRIPTION
## Outcome

PR-A (backend) of #6642, the owner's 2026-09-03 ruling: home-page cards get 1 s history bar graphs and the services section becomes a sortable list with %CPU. Cadence moves from 5 s/120 to 1 s/600 (10-minute window kept); every registered service gets a per-second `{id, status, cpu_pct}` sample into a 600-point ring, fanned out as a new SSE `services` event and included in the `history` snapshot (`schema_version` 2). `ServiceInfo` gains `cpu_pct` (null when unmeasurable, never 0).

Refs #6642

## Changes

Per-process CPU lives in `trusty_common::sys_metrics::ProcessCpuSampler` (refreshes only tracked pids); pids come from trusty-mpm's daemon.lock and from the socket peer credential on trusty-search/trusty-memory. trusty-agents (TCP) and on-demand services report null — wiring `cpu_pct` into daemon console_metrics payloads is a follow-up noted on the issue. Fix round after code-critic WARN: broadcast buffer sized for 1 Hz × 2 event kinds (1200), and each sampler tick half is panic-guarded so a panicking tick logs and the loop continues. PR-B (Svelte UI) follows.

## Risk

Rung 4 (trusty-common library + trusty-console consumer). trusty-common 0.47.2 (already above crates.io), trusty-console 0.10.1 → 0.11.0 (semver gate: `ServiceInfo.cpu_pct`, `HistoryEvent::Services`).

## Tests

```
cargo fmt --check && cargo clippy -p trusty-common --all-targets --features host-metrics,uds -- -D warnings && SKIP_UI_BUILD=1 cargo clippy -p trusty-console --all-targets -- -D warnings   # exit 0
SKIP_UI_BUILD=1 cargo check --workspace                                    # exit 0
cargo test -p trusty-common --features host-metrics,uds --no-fail-fast    # lib 557 passed, 0 failed; all targets ok
SKIP_UI_BUILD=1 cargo test -p trusty-console --no-fail-fast               # lib 402 passed, 0 failed; 5 targets ok
bash scripts/check_semver.sh --crate trusty-console                       # 0.11.0 permits the inventoried breaks
bash scripts/check_changelog_fragment.sh && bash scripts/check_line_cap.sh && bash scripts/check_test_pointers.sh && bash scripts/check_sld.sh && bash scripts/check_rustdoc_links.sh   # OK
```

## Baseline

Fail-Open Check: vanished pid → null and the tick continues; failed pid lookup backs off 15 s; ring bound 600; subscriber stalled 200 ticks is not `Lagged`; a panicking service half leaves the host half recording — each pinned by a test shown to fail on the old code. Per-tick cost measured at 179 µs for six pids.

`check_semver.sh --crate trusty-common` returns NO VERDICT on this machine because cargo-semver-checks' scratch resolution pulls the broken upstream tinyvec 1.13.0 (#6740); reproduced identically on origin/main. It compared cleanly earlier today (196 pass) before that release entered resolution.

## Docs

Pre-push credential scan over `git diff origin/main...HEAD`: PASS, 30 + 3 files.

## Review

Code-critic round completed; all findings addressed in this commit.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
