### PR TITLE
feat(trusty-audit): license collector feeding [report].findings (Refs #6076)

### DIFF
--- a/crates/trusty-audit/changelog.d/6076-license-collector.md
+++ b/crates/trusty-audit/changelog.d/6076-license-collector.md
@@ -1,0 +1,17 @@
+Added
+
+- The audit sweep now reviews each Rust repository's dependency licenses with
+  `cargo-deny list` and writes every copyleft, unlicensed, or unrecognised term
+  into the report manifest's `[report].findings` under the `license` category,
+  so the DD report states license/IP exposure instead of disclaiming it (#6076).
+  - Strong copyleft (AGPL, GPL, SSPL, OSL, EUPL) bands RED; weak copyleft
+    (MPL, LGPL, EPL, CDDL) and any license the policy table does not recognise
+    band AMBER; a crate declaring no license at all bands RED. A crate offering
+    any permissive term is cleared, so a `GPL OR MIT` dual license is not a
+    finding.
+  - Fail-open, and never silently: a target with no `cargo-deny` installed gets
+    a gap naming the binary and `cargo install cargo-deny`; a non-Rust target
+    gets `license-review: no cargo-deny-equivalent for <language>`; a non-zero
+    exit or unreadable output names which it was; a review that ran clean states
+    what it did not cover. A repository declaring no dependency manifest at all
+    is a declared skip and says nothing.

--- a/crates/trusty-audit/src/grounding.rs
+++ b/crates/trusty-audit/src/grounding.rs
@@ -27,6 +27,7 @@
 //! | [`evidence`] | asking trusty-search where each DD dimension's evidence is (#6082) |
 //! | [`topology`] | reading a Cargo workspace's own crate graph (#6147) |
 //! | [`cve`] | scanning the pinned dependency set for advisories (#6075) |
+//! | [`license`] | banding that same set by license obligation (#6076) |
 //! | [`priority`] | writing that ranking, and the gaps, into the manifest |
 //!
 //! ## Fail-open, and never silently
@@ -58,9 +59,11 @@ use crate::workdir::WorkDir;
 
 pub mod cve;
 pub mod daemons;
+pub mod ecosystem;
 pub mod evidence;
 pub mod hotspots;
 pub mod index;
+pub mod license;
 pub mod priority;
 pub mod quality;
 pub mod search_rpc;
@@ -412,6 +415,10 @@ pub async fn ground_manifest(
     // the other's data with it. Its gaps join topology's rather than earning a
     // third `priority::write_into` call.
     manifest_leg_gaps.extend(cve::ground_into(manifest, checkout, display));
+    // #6076: the license review reuses the `[report].findings` channel #6075
+    // opened rather than adding a second one, and joins the same gap list for
+    // the same reason — its write failing must cost only its own rows.
+    manifest_leg_gaps.extend(license::ground_into(manifest, checkout, display));
     // #6082: read BEFORE the write, which is what would otherwise make the two
     // states indistinguishable afterwards.
     let already_rendered = investigation_exists(manifest);
@@ -436,7 +443,7 @@ pub async fn ground_manifest(
     {
         grounding.gaps.push(format!(
             "{display}: {cause} — the rendered report does not state why its crate topology \
-             and dependency CVE scan are missing"
+             dependency CVE scan and license review are missing"
         ));
     }
     grounding.gaps.extend(manifest_leg_gaps);

--- a/crates/trusty-audit/src/grounding.rs
+++ b/crates/trusty-audit/src/grounding.rs
@@ -442,8 +442,8 @@ pub async fn ground_manifest(
             priority::write_into(manifest, checkout, &[], None, false, &manifest_leg_gaps)
     {
         grounding.gaps.push(format!(
-            "{display}: {cause} — the rendered report does not state why its crate topology \
-             dependency CVE scan and license review are missing"
+            "{display}: {cause} — the rendered report does not state why its crate topology, \
+             dependency CVE scan, and license review are missing"
         ));
     }
     grounding.gaps.extend(manifest_leg_gaps);

--- a/crates/trusty-audit/src/grounding/cve.rs
+++ b/crates/trusty-audit/src/grounding/cve.rs
@@ -109,6 +109,13 @@ pub struct Advisory {
 /// report's existing RED/AMBER vocabulary exactly.
 /// What: `Red` for every `vulnerabilities.list` row, `Amber` for every
 /// `warnings` row. There is no green band — a clean scan produces no rows.
+///
+/// // #6076: this is the whole band vocabulary trusty-review's `band_rank`
+/// reads, so the license leg reuses this type rather than declaring a second
+/// enum whose `as_str` returns the same two strings. The variant names below
+/// describe the CVE reading of each band; a collector that reuses them owes its
+/// own definition of what earns each one.
+///
 /// Test: `cve_tests::a_warning_becomes_an_amber_advisory`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Severity {
@@ -166,28 +173,6 @@ pub struct Run {
     /// Diagnostics, used only to explain a failure.
     pub stderr: String,
 }
-
-/// Marker files that identify a dependency ecosystem, and what to call it.
-///
-/// Why: the gap line owes the reader the LANGUAGE, not a filename — "no
-/// cargo-audit-equivalent for JavaScript/TypeScript" is actionable and "no
-/// package.json handler" is not. Ordered most-specific first so a polyglot
-/// repository is named by the ecosystem whose manifest sits at its root.
-const ECOSYSTEMS: &[(&str, &str)] = &[
-    ("package.json", "JavaScript/TypeScript"),
-    ("go.mod", "Go"),
-    ("pyproject.toml", "Python"),
-    ("requirements.txt", "Python"),
-    ("Pipfile", "Python"),
-    ("Gemfile", "Ruby"),
-    ("composer.json", "PHP"),
-    ("pom.xml", "Java"),
-    ("build.gradle", "Java/Kotlin"),
-    ("build.gradle.kts", "Java/Kotlin"),
-    ("mix.exs", "Elixir"),
-    ("pubspec.yaml", "Dart/Flutter"),
-    ("Package.swift", "Swift"),
-];
 
 /// Scan `checkout`, or say why there is no scan.
 ///
@@ -259,9 +244,10 @@ where
 /// there in both cases. `None` is reserved for the declared skip: no manifest
 /// this collector recognises, so no exposure it can claim to be missing.
 /// What: an unlocked Cargo workspace first, since a Rust repository is the one
-/// case where the tool exists and only the input is absent; then the first
-/// [`ECOSYSTEMS`] marker present at the root, spelled with the exact wording
-/// #6075 asks for.
+/// case where the tool exists and only the input is absent; then the language
+/// [`super::ecosystem::detect`] names, spelled with the exact wording #6075
+/// asks for. // #6076: the marker table moved to `super::ecosystem` when the
+/// license leg needed the same detection with different wording.
 /// Test: `cve_tests::{a_non_rust_repository_names_its_language,
 /// a_rust_repository_with_no_lockfile_says_so}`.
 fn not_scannable(checkout: &Path) -> Option<String> {
@@ -271,10 +257,8 @@ fn not_scannable(checkout: &Path) -> Option<String> {
              has no pinned dependency set to scan"
         ));
     }
-    ECOSYSTEMS
-        .iter()
-        .find(|(marker, _)| checkout.join(marker).is_file())
-        .map(|(_, language)| format!("{COLLECTOR}: no cargo-audit-equivalent for {language}"))
+    super::ecosystem::detect(checkout)
+        .map(|language| format!("{COLLECTOR}: no cargo-audit-equivalent for {language}"))
 }
 
 /// Reduce one `cargo audit --json` document to its advisories.

--- a/crates/trusty-audit/src/grounding/ecosystem.rs
+++ b/crates/trusty-audit/src/grounding/ecosystem.rs
@@ -1,0 +1,63 @@
+//! Which dependency ecosystem a checkout declares, and what to call it (#6076).
+//!
+//! Why: every collector in this module that scans a dependency set owes the
+//! same sentence when it cannot — the report must name the LANGUAGE it did not
+//! cover, because "no cargo-deny-equivalent for Go" is actionable and "no
+//! go.mod handler" is not. #6075's CVE leg established that table; #6076's
+//! license leg needs the identical one, and a second copy would drift the
+//! moment either grew a marker (CLAUDE.md's common-entry-point rule).
+//!
+//! What: [`ECOSYSTEMS`], the marker-file table, and [`detect`], which returns
+//! the first language whose marker sits at the checkout root. Each collector
+//! words its own gap sentence around that name — the wording differs per tool,
+//! the detection does not.
+//!
+//! Test: `super::license::license_tests::{a_non_rust_repository_names_its_language,
+//! a_repository_with_no_manifest_is_a_declared_skip}`, and the same pair in
+//! `super::cve::cve_tests`.
+
+use std::path::Path;
+
+/// Marker files that identify a dependency ecosystem, and what to call it.
+///
+/// Ordered most-specific first so a polyglot repository is named by the
+/// ecosystem whose manifest sits at its root. Rust is deliberately absent: a
+/// collector that handles Rust checks its own `Cargo.toml` / `Cargo.lock` pair
+/// before consulting this table, and owes a different sentence when it finds
+/// one.
+pub const ECOSYSTEMS: &[(&str, &str)] = &[
+    ("package.json", "JavaScript/TypeScript"),
+    ("go.mod", "Go"),
+    ("pyproject.toml", "Python"),
+    ("requirements.txt", "Python"),
+    ("Pipfile", "Python"),
+    ("Gemfile", "Ruby"),
+    ("composer.json", "PHP"),
+    ("pom.xml", "Java"),
+    ("build.gradle", "Java/Kotlin"),
+    ("build.gradle.kts", "Java/Kotlin"),
+    ("mix.exs", "Elixir"),
+    ("pubspec.yaml", "Dart/Flutter"),
+    ("Package.swift", "Swift"),
+];
+
+/// The non-Rust ecosystem `checkout` declares at its root, if any.
+///
+/// Why: `None` is what separates a DEGRADATION from a declared skip. A
+/// repository declaring no dependency manifest of any kind this table
+/// recognises has no dependency surface a collector can claim to have missed,
+/// so it earns silence rather than a gap line restating that.
+/// What: one `Path::is_file` per [`ECOSYSTEMS`] row, first match wins. Costs
+/// nothing beyond those stats — no subprocess and no directory walk.
+///
+/// # Postconditions
+/// Never panics; an unreadable or absent `checkout` yields `None`.
+///
+/// Test: `super::license::license_tests::a_non_rust_repository_names_its_language`.
+#[must_use]
+pub fn detect(checkout: &Path) -> Option<&'static str> {
+    ECOSYSTEMS
+        .iter()
+        .find(|(marker, _)| checkout.join(marker).is_file())
+        .map(|(_, language)| *language)
+}

--- a/crates/trusty-audit/src/grounding/license.rs
+++ b/crates/trusty-audit/src/grounding/license.rs
@@ -413,6 +413,7 @@ pub fn parse(json: &str) -> Result<Vec<Package>, String> {
 /// a_weak_copyleft_dependency_is_an_amber_finding,
 /// a_dual_licensed_crate_takes_its_permissive_option,
 /// an_unrecognised_term_is_reported_rather_than_dropped,
+/// an_unparsed_compound_expression_is_reported_rather_than_cleared,
 /// a_crate_with_no_license_is_the_worst_finding}`.
 #[must_use]
 pub fn classify(package: &Package) -> Option<Finding> {

--- a/crates/trusty-audit/src/grounding/license.rs
+++ b/crates/trusty-audit/src/grounding/license.rs
@@ -1,0 +1,715 @@
+//! The dependency license review the DD report used to disclaim (#6076, epic #6074).
+//!
+//! Why: the report's exec summary names license risk as an assurance gap it
+//! does not fill, and Security Posture is an LLM's reading of selected source
+//! files — it never sees the license of a transitive dependency at all. An
+//! acquirer's first question about a Rust codebase is whether anything in the
+//! dependency graph imposes a copyleft obligation on the combined work, and
+//! that question has a deterministic answer one subprocess away.
+//!
+//! Owner ruling 2026-08-19 puts the collector HERE rather than in trusty-review,
+//! for the reason [`super::cve`] states: collector intelligence lives in
+//! trusty-audit, the manifest is the interface, so tuning the policy below is a
+//! single-crate rebuild.
+//!
+//! What: one leg, `cargo-deny list --format json --layout crate` against the
+//! checkout, each crate classified by [`classify`] into at most one
+//! [`Finding`]. [`write_into`] puts them in `[report].findings` under the
+//! `license` category trusty-review already renders as "License / IP
+//! Exposure"; [`ground_into`] is the caller-facing shape every other grounding
+//! leg has.
+//!
+//! ## Why `list` rather than `check licenses`
+//!
+//! #6076 names `cargo deny check licenses` as the preferred invocation. It is
+//! the wrong one for a due-diligence target, and measurably so: `check
+//! licenses` reports against a `deny.toml` policy, and a third-party target
+//! does not carry one. Run against this very workspace with no config it
+//! reports `{"licenses":{"errors":0,"helps":914,...}}` — zero findings over 914
+//! crates, which is precisely the silent zero epic #6074 exists to remove.
+//! Supplying a generated policy instead would pin this crate to cargo-deny's
+//! config schema, which changed shape between its v1 and v2 configs.
+//!
+//! `list` needs no config, changes shape far less, and hands over the raw
+//! license set per crate. The POLICY — what an acquirer must plan around —
+//! then lives here, in [`STRONG_COPYLEFT`] / [`WEAK_COPYLEFT`] / [`PERMISSIVE`],
+//! where it is uniform across every repository in a sweep rather than being
+//! whatever risk appetite each target happened to write down. `cargo-license`,
+//! #6076's alternative, is a second binary for the same data; cargo-deny is
+//! already the tool this leg's sibling ecosystem needs, so requiring one
+//! binary rather than two is the smaller ask of the auditor's machine.
+//!
+//! ## The one thing `list` cannot tell us
+//!
+//! It flattens an SPDX expression to a SET, so `GPL-3.0 OR MIT` and
+//! `GPL-3.0 AND MIT` both arrive as `["GPL-3.0", "MIT"]`. [`classify`]
+//! therefore clears a crate as soon as ANY term is permissive: for the `OR`
+//! case that is exactly right (the permissive option is available), and for the
+//! far rarer `AND` case it under-reports. The clean-scan gap line in
+//! [`ground_into_with`] states that limit rather than leaving the reader to
+//! assume it away.
+//!
+//! ## Degradation
+//!
+//! Three outcomes ([`Outcome`]), and the fail-open rule every leg in this
+//! module follows: the sweep continues, and the cost is a NAMED line in
+//! `[report].gaps`, never a silent zero-findings result (#5620 — a recorded
+//! skip permits, a blind gate does not).
+//!
+//! | Target | Outcome |
+//! |---|---|
+//! | `Cargo.lock` present | reviewed, or a gap naming why the review failed |
+//! | `Cargo.toml` but no lock, or a non-Rust ecosystem | a gap naming the language |
+//! | no recognised dependency manifest at all | a declared skip: nothing written, nothing said |
+//!
+//! Test: `license_tests`.
+
+use std::path::Path;
+use std::process::Command;
+
+use toml_edit::{Array, DocumentMut, InlineTable, Item, Table, Value};
+
+use super::cve::{Run, Severity};
+
+/// The collector's name, as it appears at the head of every gap line it writes.
+pub const COLLECTOR: &str = "license-review";
+
+/// The `category` every finding this collector records carries.
+///
+/// trusty-review's `assurance::subsection_title` already maps it to "License /
+/// IP Exposure" — #6075 spelled the three categories epic #6074 defines when it
+/// built the renderer, so nothing in that crate changes for this leg.
+pub const CATEGORY: &str = "license";
+
+/// The binary that performs the review.
+pub const BINARY: &str = "cargo-deny";
+
+/// What an operator runs to get [`BINARY`], named in the missing-binary gap.
+pub const INSTALL_COMMAND: &str = "cargo install cargo-deny";
+
+/// The id a crate declaring no license at all is reported under.
+///
+/// Not an SPDX identifier, and deliberately not one: SPDX's `NONE` means "the
+/// expression is absent", while this row means the acquirer has no established
+/// right to redistribute the crate. It is the worst finding this leg produces.
+pub const UNLICENSED: &str = "UNLICENSED";
+
+// ─── Policy ─────────────────────────────────────────────────────────────────
+
+/// Licenses that impose no obligation on the combined work.
+///
+/// Why: an acquirer plans around obligations, not around licenses. Everything
+/// here asks for attribution and nothing more, so a crate offering any one of
+/// them is not a finding — see the module docs on why "offering ANY" is the
+/// right test given cargo-deny's flattened set.
+/// What: SPDX identifiers, matched after [`normalise`] strips version
+/// qualifiers and `WITH` exceptions. `Apache-2.0 WITH LLVM-exception` therefore
+/// matches through its `Apache-2.0` base.
+/// Test: `license_tests::a_permissive_dependency_set_produces_no_finding`.
+pub const PERMISSIVE: &[&str] = &[
+    "0BSD",
+    "APAFML",
+    "Apache-1.1",
+    "Apache-2.0",
+    "BSD-1-Clause",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "CC-BY-4.0",
+    "CC0-1.0",
+    "CDLA-Permissive-1.0",
+    "CDLA-Permissive-2.0",
+    "ISC",
+    "MIT",
+    "MIT-0",
+    "MPL-2.0-no-copyleft-exception",
+    "NCSA",
+    "OpenSSL",
+    "PostgreSQL",
+    "Python-2.0",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+    "Unlicense",
+    "WTFPL",
+    "X11",
+    "Zlib",
+    "bzip2-1.0.6",
+    "libpng-2.0",
+    "zlib-acknowledgement",
+];
+
+/// Licenses whose obligation reaches the whole combined work.
+///
+/// Why: this is the finding an acquirer's counsel acts on. Linking one of these
+/// into a proprietary product obliges publishing that product's source under
+/// the same terms, and AGPL/SSPL extend that to network use — so a single such
+/// crate deep in a transitive graph can bind the entire codebase.
+/// What: [`Severity::Red`], with the obligation stated in the row's title.
+/// Test: `license_tests::a_strong_copyleft_dependency_is_a_red_finding`.
+pub const STRONG_COPYLEFT: &[&str] = &[
+    "AGPL-1.0",
+    "AGPL-3.0",
+    "CPAL-1.0",
+    "EUPL-1.1",
+    "EUPL-1.2",
+    "GPL-1.0",
+    "GPL-2.0",
+    "GPL-3.0",
+    "OSL-1.0",
+    "OSL-2.1",
+    "OSL-3.0",
+    "Parity-6.0.0",
+    "Parity-7.0.0",
+    "RPL-1.5",
+    "SSPL-1.0",
+];
+
+/// Licenses whose obligation stops at the files they cover.
+///
+/// Why: real, plannable, and not the same risk as [`STRONG_COPYLEFT`] — a
+/// proprietary product may link these provided the covered sources stay
+/// available and modifications to them are published. It is a condition on the
+/// acquirer's release process, not on their source.
+/// What: [`Severity::Amber`].
+/// Test: `license_tests::a_weak_copyleft_dependency_is_an_amber_finding`.
+pub const WEAK_COPYLEFT: &[&str] = &[
+    "APSL-2.0",
+    "CC-BY-SA-4.0",
+    "CDDL-1.0",
+    "CDDL-1.1",
+    "EPL-1.0",
+    "EPL-2.0",
+    "LGPL-2.0",
+    "LGPL-2.1",
+    "LGPL-3.0",
+    "MPL-1.0",
+    "MPL-1.1",
+    "MPL-2.0",
+    "Ms-RL",
+    "Sleepycat",
+];
+
+// ─── Model ──────────────────────────────────────────────────────────────────
+
+/// One crate in the target's dependency graph, as `cargo-deny list` reported it.
+///
+/// Why: the collector's own shape rather than cargo-deny's, so [`classify`] is
+/// testable against a hand-written graph and [`parse`] is the only place the
+/// tool's key format is understood.
+/// What: `licenses` is the SPDX term SET, flattened by cargo-deny — see the
+/// module docs. An empty vector means the crate declared none.
+/// Test: `license_tests::the_fixture_yields_every_crate`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct Package {
+    /// The crate's name.
+    pub name: String,
+    /// The version the lock file pins.
+    pub version: String,
+    /// The SPDX terms cargo-deny resolved for it, in the order it listed them.
+    pub licenses: Vec<String>,
+}
+
+/// One license obligation this collector is reporting against a pinned crate.
+///
+/// Why: these five fields are what a due-diligence reader acts on — which
+/// license, on which pinned dependency, how binding, and what it obliges.
+/// What: `license` is the SPDX term that earned the band, or [`UNLICENSED`].
+/// `url` is the SPDX page for a recognised identifier and `None` otherwise,
+/// which is also how a reader tells a real identifier from a string the crate
+/// invented.
+/// Test: `license_tests::{a_strong_copyleft_dependency_is_a_red_finding,
+/// a_crate_with_no_license_is_the_worst_finding}`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct Finding {
+    /// The SPDX term that earned the band, or [`UNLICENSED`].
+    pub license: String,
+    /// The affected crate's name.
+    pub package: String,
+    /// The version the lock file pins.
+    pub version: String,
+    /// The band this row renders under.
+    pub severity: Severity,
+    /// What the license obliges, in one line.
+    pub obligation: String,
+    /// The SPDX page, when the term is a recognised identifier.
+    pub url: Option<String>,
+}
+
+/// What the leg produced for one repository.
+///
+/// Why: "no license risk" has three meanings that must not share a variant, and
+/// only one of them is a clean result. See the module docs' table.
+/// What: the review's rows (possibly empty, which IS a clean bill for the
+/// pinned dependency set), a declared skip carrying why the leg does not apply,
+/// or a failure carrying the one line the caller turns into a gap.
+/// Test: `license_tests::{a_repository_with_no_manifest_is_a_declared_skip,
+/// a_non_rust_repository_names_its_language}`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Outcome {
+    /// No recognised dependency manifest; the reason it does not apply.
+    NotApplicable(String),
+    /// The review ran; these are its rows, in the order cargo-deny listed them.
+    Reviewed(Vec<Finding>),
+    /// The review could not run, or could not be read; why not.
+    Unavailable(String),
+}
+
+// ─── Scanning ───────────────────────────────────────────────────────────────
+
+/// Review `checkout`, or say why there is no review.
+///
+/// Why/What: see the module docs. Runs no subprocess at all unless the checkout
+/// has a `Cargo.lock`, so every other repository in a sweep costs one
+/// `Path::is_file` per ecosystem marker.
+///
+/// # Postconditions
+/// Never panics and never returns an error: every failure is an
+/// [`Outcome::Unavailable`] reason string, safe to show the recipient.
+///
+/// Test: `license_tests`.
+#[must_use]
+pub fn review(checkout: &Path) -> Outcome {
+    review_with(checkout, run_cargo_deny)
+}
+
+/// [`review`] with the subprocess supplied by the caller.
+///
+/// Why: the failure arms this collector MUST get right — the binary is not
+/// installed, and the run produced output this module cannot read — are exactly
+/// the arms a test cannot reach through a real `cargo-deny`, which is either
+/// installed on the machine or not. `run` is the seam, and it keeps the
+/// subprocess out of every unit test, so nothing here spawns a process or
+/// touches the network.
+/// What: the applicability ladder, then `run`, then [`parse`] and
+/// [`classify`]. A `run` that hands back an `Err` is [`Outcome::Unavailable`]
+/// carrying its reason verbatim. Unlike [`super::cve::scan_with`], a non-zero
+/// exit is NOT a successful review: `cargo-deny list` exits zero whenever it
+/// produced a listing, so a non-zero exit means there is no listing to read.
+/// Its stderr is quoted so a caller can tell a crash from a format change.
+/// Test: `license_tests::{an_uninstalled_binary_is_a_named_gap,
+/// a_nonzero_exit_is_a_named_gap, unreadable_output_is_a_named_gap}`.
+#[must_use]
+pub fn review_with<F>(checkout: &Path, run: F) -> Outcome
+where
+    F: FnOnce(&Path) -> Result<Run, String>,
+{
+    if !checkout.join("Cargo.lock").is_file() {
+        return match not_reviewable(checkout) {
+            Some(reason) => Outcome::Unavailable(reason),
+            None => Outcome::NotApplicable(
+                "the repository root declares no dependency manifest this collector recognises"
+                    .to_string(),
+            ),
+        };
+    }
+    let output = match run(checkout) {
+        Ok(output) => output,
+        Err(cause) => return Outcome::Unavailable(cause),
+    };
+    if !output.success {
+        return Outcome::Unavailable(format!(
+            "{COLLECTOR}: `{BINARY}` exited non-zero without a listing ({})",
+            first_line(&output.stderr)
+        ));
+    }
+    match parse(&output.stdout) {
+        Ok(packages) => Outcome::Reviewed(packages.iter().filter_map(classify).collect()),
+        Err(cause) => Outcome::Unavailable(format!("{COLLECTOR}: {cause}")),
+    }
+}
+
+/// Why this checkout cannot be reviewed, when it has a dependency surface anyway.
+///
+/// Why: a Rust repository with no lock file and a Go repository are both
+/// unreviewable and owe the report DIFFERENT sentences, and neither may be a
+/// silent zero — the acquirer is reading this section for license exposure that
+/// is there in both cases. `None` is reserved for the declared skip: no
+/// manifest this collector recognises, so no exposure it can claim to be
+/// missing.
+/// What: an unlocked Cargo workspace first, since a Rust repository is the one
+/// case where the tool exists and only the input is absent; then the language
+/// [`super::ecosystem::detect`] names.
+/// Test: `license_tests::{a_non_rust_repository_names_its_language,
+/// a_rust_repository_with_no_lockfile_says_so}`.
+fn not_reviewable(checkout: &Path) -> Option<String> {
+    if checkout.join("Cargo.toml").is_file() {
+        return Some(format!(
+            "{COLLECTOR}: the repository declares a Cargo.toml but no Cargo.lock, so `{BINARY}` \
+             has no pinned dependency set to review"
+        ));
+    }
+    super::ecosystem::detect(checkout)
+        .map(|language| format!("{COLLECTOR}: no cargo-deny-equivalent for {language}"))
+}
+
+/// Reduce one `cargo-deny list --layout crate` document to its crates.
+///
+/// Why: split from [`review_with`] so every row shape — a dual license, a
+/// single copyleft term, a crate declaring none — is testable against a
+/// captured document with no `cargo-deny`, no checkout and no subprocess.
+/// What: the document is one object whose KEY is `"<name> <version> <source>"`
+/// and whose value carries a `licenses` array. Name and version are the first
+/// two whitespace-separated fields; a key with fewer than two is skipped, since
+/// nothing in it identifies a crate a reader could act on.
+///
+/// # Errors
+/// One line when the document is not JSON, or is not the object `--layout
+/// crate` emits — so its absence means the output is not cargo-deny's.
+///
+/// Test: `license_tests::{the_fixture_yields_every_crate,
+/// output_that_is_not_json_is_a_reason}`.
+pub fn parse(json: &str) -> Result<Vec<Package>, String> {
+    let doc: serde_json::Value = serde_json::from_str(json.trim())
+        .map_err(|e| format!("`{BINARY}` output is not readable as JSON ({e})"))?;
+    let rows = doc
+        .as_object()
+        .ok_or_else(|| format!("`{BINARY}` output is not the crate-layout listing object"))?;
+
+    let mut packages = Vec::with_capacity(rows.len());
+    for (key, value) in rows {
+        let mut fields = key.split_whitespace();
+        let (Some(name), Some(version)) = (fields.next(), fields.next()) else {
+            continue;
+        };
+        let licenses = value
+            .get("licenses")
+            .and_then(serde_json::Value::as_array)
+            .map(Vec::as_slice)
+            .unwrap_or_default()
+            .iter()
+            .filter_map(serde_json::Value::as_str)
+            .map(str::trim)
+            .filter(|term| !term.is_empty())
+            .map(str::to_string)
+            .collect();
+        packages.push(Package {
+            name: name.to_string(),
+            version: version.to_string(),
+            licenses,
+        });
+    }
+    Ok(packages)
+}
+
+/// The one finding `package` earns, if it earns any.
+///
+/// Why: this IS the policy. Everything above it is transport.
+/// What: a crate declaring nothing is [`Severity::Red`] under [`UNLICENSED`] —
+/// no declared license is a stronger claim against redistribution than any
+/// copyleft term. Otherwise a crate offering ANY [`PERMISSIVE`] term is
+/// cleared, for the reason the module docs give. What remains is banded by its
+/// worst term: [`STRONG_COPYLEFT`] is [`Severity::Red`], [`WEAK_COPYLEFT`] and
+/// anything unrecognised are [`Severity::Amber`] — an unrecognised term is
+/// reported rather than dropped, because a license this table has never seen is
+/// the case most needing a human, and dropping it would be the silent zero.
+///
+/// # Postconditions
+/// At most one finding per crate, so a 900-crate graph cannot produce a table
+/// longer than its own dependency list.
+///
+/// Test: `license_tests::{a_strong_copyleft_dependency_is_a_red_finding,
+/// a_weak_copyleft_dependency_is_an_amber_finding,
+/// a_dual_licensed_crate_takes_its_permissive_option,
+/// an_unrecognised_term_is_reported_rather_than_dropped,
+/// a_crate_with_no_license_is_the_worst_finding}`.
+#[must_use]
+pub fn classify(package: &Package) -> Option<Finding> {
+    let finding = |license: &str, severity, obligation: String, url| Finding {
+        license: license.to_string(),
+        package: package.name.clone(),
+        version: package.version.clone(),
+        severity,
+        obligation,
+        url,
+    };
+    if package.licenses.is_empty() {
+        return Some(finding(
+            UNLICENSED,
+            Severity::Red,
+            "the crate declares no license, so no right to redistribute it is established"
+                .to_string(),
+            None,
+        ));
+    }
+    if package
+        .licenses
+        .iter()
+        .any(|term| contains(PERMISSIVE, term))
+    {
+        return None;
+    }
+    let (term, severity, obligation) = worst(&package.licenses);
+    let url = spdx_url(term);
+    Some(finding(term, severity, obligation.to_string(), url))
+}
+
+/// The binding term of a license set, with its band and its obligation.
+///
+/// Strong copyleft outranks weak, which outranks a term this policy has never
+/// seen — so a crate under `GPL-3.0 AND LGPL-2.1` is reported as the GPL row it
+/// is. The set is non-empty and holds no permissive term when this is reached.
+fn worst(licenses: &[String]) -> (&str, Severity, &'static str) {
+    const STRONG: &str = "copyleft: linking this into a distributed work obliges releasing that \
+                          work's source under the same license";
+    const WEAK: &str = "file-level copyleft: modifications to the covered sources must be \
+                        published, and the sources kept available";
+    const UNKNOWN: &str = "this license is not in the collector's policy table; its obligations \
+                           must be reviewed by hand";
+
+    if let Some(term) = licenses.iter().find(|t| contains(STRONG_COPYLEFT, t)) {
+        return (term, Severity::Red, STRONG);
+    }
+    if let Some(term) = licenses.iter().find(|t| contains(WEAK_COPYLEFT, t)) {
+        return (term, Severity::Amber, WEAK);
+    }
+    // Non-empty by the caller's contract; the fallback keeps this total anyway.
+    let term = licenses.first().map_or("", String::as_str);
+    (term, Severity::Amber, UNKNOWN)
+}
+
+/// Whether `table` names `term`, comparing normalised identifiers.
+fn contains(table: &[&str], term: &str) -> bool {
+    let term = normalise(term);
+    table.iter().any(|known| normalise(known) == term)
+}
+
+/// An SPDX identifier reduced to the form the policy tables spell.
+///
+/// Why: SPDX writes one license several ways — `GPL-3.0`, `GPL-3.0-only`,
+/// `GPL-3.0-or-later`, `GPL-3.0+` are all the GPL, and `Apache-2.0 WITH
+/// LLVM-exception` is Apache-2.0 with a patent carve-out that does not change
+/// its obligation. Listing every spelling in three tables would be a table that
+/// silently misses the next one.
+/// What: lowercased, `WITH <exception>` dropped, then the `-only` / `-or-later`
+/// / `+` qualifiers stripped from the tail.
+/// Test: `license_tests::spdx_qualifiers_do_not_defeat_the_policy`.
+fn normalise(term: &str) -> String {
+    let base = term
+        .split(" WITH ")
+        .next()
+        .unwrap_or(term)
+        .trim()
+        .to_ascii_lowercase();
+    let base = base.strip_suffix('+').unwrap_or(&base);
+    base.strip_suffix("-or-later")
+        .or_else(|| base.strip_suffix("-only"))
+        .unwrap_or(base)
+        .to_string()
+}
+
+/// The SPDX page for a term this policy recognises, else `None`.
+///
+/// A term absent from all three tables gets no link: inventing an SPDX URL for
+/// a string a crate made up would send the reader to a 404 that looks
+/// authoritative.
+fn spdx_url(term: &str) -> Option<String> {
+    let known = contains(PERMISSIVE, term)
+        || contains(STRONG_COPYLEFT, term)
+        || contains(WEAK_COPYLEFT, term);
+    let id = term.split(" WITH ").next().unwrap_or(term).trim();
+    (known && !id.is_empty()).then(|| format!("https://spdx.org/licenses/{id}.html"))
+}
+
+/// Run `cargo-deny list --format json --layout crate` in `checkout`.
+///
+/// `--format json` writes the whole listing to stdout, so nothing is streamed
+/// and the process is reaped by `output()` before this returns. `--layout
+/// crate` is what makes the document one row per crate rather than one per
+/// license, which is the shape [`parse`] reads. The working directory is the
+/// checkout, so cargo-deny resolves the target's own crate graph.
+fn run_cargo_deny(checkout: &Path) -> Result<Run, String> {
+    let binary = trusty_common::bin_resolve::resolve_binary(BINARY).ok_or_else(|| {
+        format!(
+            "{COLLECTOR}: `{BINARY}` is not installed, so no dependency license review ran \
+             (install it with `{INSTALL_COMMAND}`)"
+        )
+    })?;
+    let output = Command::new(&binary)
+        .arg("list")
+        .arg("--format")
+        .arg("json")
+        .arg("--layout")
+        .arg("crate")
+        .current_dir(checkout)
+        .output()
+        .map_err(|e| format!("{COLLECTOR}: `{BINARY}` could not be run ({e})"))?;
+    Ok(Run {
+        success: output.status.success(),
+        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+    })
+}
+
+/// The first non-empty line of a diagnostic stream, for a one-line gap.
+///
+/// // #6720: a leading informational line masking the real cause is the bug
+/// that issue records against `index::refusal`. cargo-deny writes no update
+/// notice, and this stream is quoted only ALONGSIDE a cause this module already
+/// determined ("exited non-zero without a listing") rather than standing in for
+/// it — so an unhelpful first line degrades the detail, never the diagnosis.
+fn first_line(stderr: &str) -> &str {
+    stderr
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .unwrap_or("no diagnostic")
+}
+
+// ─── Writing ────────────────────────────────────────────────────────────────
+
+/// Record `findings` in the manifest at `path` as `[report].findings`.
+///
+/// Why: the manifest is the interface (owner ruling 2026-08-19). A review this
+/// process performs and does not write reaches no renderer — not the sweep's,
+/// and not the recipient's own re-render of the delivered package. This is
+/// #6075's channel, reused rather than reinvented: the rows land in the same
+/// array, and trusty-review groups them by their `license` category with no
+/// change to that crate.
+///
+/// Why nothing is written for an EMPTY review: the presence of the key is what
+/// trusty-review renders the Assurance Scans section from, and an empty array
+/// would put an empty table in the report. A clean review states itself through
+/// its `[report].gaps` scope line instead — see [`ground_into`].
+/// What: appends to `[report].findings`, skipping a row already declared under
+/// the same license/package/version so a resumed sweep does not restate it.
+/// Written format-preserving with `toml_edit`, exactly as
+/// [`super::cve::write_into`] writes its advisories, so the two other crates
+/// that own this document keep their key order and their comments.
+///
+/// # Errors
+/// One line, safe to show the recipient, when the manifest cannot be read,
+/// parsed, or written back. The caller turns it into a gap of its own.
+///
+/// # Postconditions
+/// On `Ok`, every finding is declared exactly once in `[report].findings` and
+/// nothing else in the document changed. An empty `findings` writes nothing and
+/// cannot fail.
+///
+/// Test: `license_tests::{the_findings_land_in_the_manifest,
+/// a_resumed_sweep_does_not_duplicate_a_row,
+/// a_cve_row_already_present_is_left_alone}`.
+pub fn write_into(path: &Path, findings: &[Finding]) -> Result<(), String> {
+    if findings.is_empty() {
+        return Ok(());
+    }
+    let text = std::fs::read_to_string(path)
+        .map_err(|e| format!("{} could not be read ({e})", path.display()))?;
+    let mut doc: DocumentMut = text
+        .parse()
+        .map_err(|e| format!("{} is not readable as TOML ({e})", path.display()))?;
+
+    let report = doc
+        .entry("report")
+        .or_insert_with(|| Item::Table(Table::new()));
+    let table = report
+        .as_table_like_mut()
+        .ok_or_else(|| "the manifest's `report` is not a table".to_string())?;
+    let item = table
+        .entry("findings")
+        .or_insert_with(|| Item::Value(Value::Array(Array::new())));
+    let array = item
+        .as_array_mut()
+        .ok_or_else(|| "the manifest's `report.findings` is not an array".to_string())?;
+
+    for finding in findings {
+        if array.iter().any(|declared| same_row(declared, finding)) {
+            continue;
+        }
+        let mut value = Value::InlineTable(row(finding));
+        value.decor_mut().set_prefix("\n    ");
+        array.push_formatted(value);
+    }
+    array.set_trailing("\n");
+    array.set_trailing_comma(true);
+
+    std::fs::write(path, doc.to_string())
+        .map_err(|e| format!("{} could not be written ({e})", path.display()))
+}
+
+/// Whether a declared row is this license against this pinned crate.
+///
+/// Identity is the triple, not the license: one copyleft term binds many crates
+/// in a sweep, and each is worth stating. The `category` is not compared —
+/// nothing else writes a `license`-banded row for the same crate and version,
+/// and comparing it would let a category rename duplicate every row.
+fn same_row(declared: &Value, finding: &Finding) -> bool {
+    let Some(table) = declared.as_inline_table() else {
+        return false;
+    };
+    let field = |key: &str| table.get(key).and_then(Value::as_str);
+    field("id") == Some(finding.license.as_str())
+        && field("package") == Some(finding.package.as_str())
+        && field("version") == Some(finding.version.as_str())
+}
+
+/// One finding as the inline table trusty-review deserialises.
+///
+/// The key names are `ManifestFinding`'s, not this module's: `id` carries the
+/// license and `title` the obligation, which is what puts the SPDX term in the
+/// rendered table's "Finding" column and the obligation in its "Summary".
+fn row(finding: &Finding) -> InlineTable {
+    let mut table = InlineTable::new();
+    table.insert("category", Value::from(CATEGORY));
+    table.insert("id", Value::from(finding.license.as_str()));
+    table.insert("package", Value::from(finding.package.as_str()));
+    table.insert("version", Value::from(finding.version.as_str()));
+    table.insert("severity", Value::from(finding.severity.as_str()));
+    table.insert("title", Value::from(finding.obligation.as_str()));
+    if let Some(url) = &finding.url {
+        table.insert("url", Value::from(url.as_str()));
+    }
+    table
+}
+
+/// [`review`], then write what it produced into `manifest`.
+///
+/// Why: the same shape [`super::ground_manifest`] gives every other leg — the
+/// caller gets gap lines and nothing else to decide about.
+/// What: the declared skip writes nothing and says nothing; an unavailable
+/// review is one gap naming `display`, the cause, and what the report therefore
+/// will not carry; a review that found rows writes them, and a write failure
+/// becomes a gap of its own. A review that found NOTHING writes no rows and
+/// states its own scope, because "cargo-deny found no copyleft obligation" and
+/// "no license review ran" must not read the same on the page — and because the
+/// `AND`-expression limit in the module docs is a caveat on the clean result,
+/// not on the failed one.
+/// Test: `license_tests::{an_uninstalled_binary_is_a_named_gap,
+/// a_nonzero_exit_is_a_named_gap, a_clean_review_states_its_own_scope,
+/// a_manifest_that_cannot_be_written_is_a_named_gap}`.
+pub fn ground_into(manifest: &Path, checkout: &Path, display: &str) -> Vec<String> {
+    ground_into_with(manifest, checkout, display, run_cargo_deny)
+}
+
+/// [`ground_into`] with the subprocess supplied by the caller — see [`review_with`].
+pub fn ground_into_with<F>(manifest: &Path, checkout: &Path, display: &str, run: F) -> Vec<String>
+where
+    F: FnOnce(&Path) -> Result<Run, String>,
+{
+    match review_with(checkout, run) {
+        Outcome::NotApplicable(_) => Vec::new(),
+        Outcome::Unavailable(cause) => vec![format!(
+            "{display}: {cause} — the report states no dependency license exposure for it, which \
+             must be read as unassessed rather than as a permissively licensed dependency set"
+        )],
+        Outcome::Reviewed(findings) if findings.is_empty() => vec![format!(
+            "{display}: {COLLECTOR}: `{BINARY}` reviewed its Cargo.lock and every dependency \
+             offers a permissive license. Vendored code, build-time downloads, dependencies \
+             outside the Rust lock file, and a crate combining a permissive term WITH a copyleft \
+             one in a single expression are not covered by that review"
+        )],
+        Outcome::Reviewed(findings) => match write_into(manifest, &findings) {
+            Ok(()) => Vec::new(),
+            Err(cause) => vec![format!(
+                "{display}: {COLLECTOR}: {cause} — the report states none of the {} license \
+                 obligation(s) `{BINARY}` reported for it",
+                findings.len()
+            )],
+        },
+    }
+}
+
+#[cfg(test)]
+#[path = "license_tests.rs"]
+mod license_tests;

--- a/crates/trusty-audit/src/grounding/license_tests.rs
+++ b/crates/trusty-audit/src/grounding/license_tests.rs
@@ -1,0 +1,558 @@
+//! Tests for the cargo-deny license-review collector (#6076).
+//!
+//! Why: the collector is fail-open, so every arm that produces NOTHING has to
+//! be pinned by a test that reads the gap it produced instead. A regression
+//! here does not fail a build — it ships a report whose empty License / IP
+//! Exposure section reads as a permissively licensed dependency graph, which is
+//! the false clean claim epic #6074 exists to remove.
+//! What: the policy bands, the two fixtures #6076 asks for (a problematic
+//! dependency set and a permissive one), the applicability ladder, every
+//! failure arm, and the manifest write-back.
+//! Test: this file.
+
+use super::*;
+use std::path::PathBuf;
+
+/// A `cargo-deny list --layout crate` document carrying one crate per band:
+/// unlicensed, strong copyleft, weak copyleft, an unrecognised term, a
+/// `GPL OR MIT` dual license, and three plainly permissive crates.
+const FIXTURE: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/testdata/cargo-deny-list.json"
+));
+
+/// The same shape with nothing but permissive terms — #6076's second path.
+const PERMISSIVE_FIXTURE: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/testdata/cargo-deny-list-permissive.json"
+));
+
+/// A manifest with the one `[report]` table `write_into` edits.
+const MANIFEST: &str = "[report]\ntitle = \"Acme\"\n\n[[repositories]]\nname = \"acme-api\"\npath = \"/tmp/acme-api\"\n";
+
+/// A run that never happened: the seam every failure-arm test injects.
+fn refuses(reason: &'static str) -> impl FnOnce(&Path) -> Result<Run, String> {
+    move |_| Err(reason.to_string())
+}
+
+/// A run that completed, with the streams and status the test wants to assert.
+fn returns(
+    success: bool,
+    stdout: &'static str,
+    stderr: &'static str,
+) -> impl FnOnce(&Path) -> Result<Run, String> {
+    move |_| {
+        Ok(Run {
+            success,
+            stdout: stdout.to_string(),
+            stderr: stderr.to_string(),
+        })
+    }
+}
+
+/// A checkout with a `Cargo.lock`, so the ladder reaches the subprocess seam.
+fn locked_checkout(tmp: &Path) -> PathBuf {
+    let checkout = tmp.join("repos").join("acme-api");
+    std::fs::create_dir_all(&checkout).expect("mkdir checkout");
+    std::fs::write(checkout.join("Cargo.toml"), "[workspace]\n").expect("manifest");
+    std::fs::write(checkout.join("Cargo.lock"), "version = 4\n").expect("lockfile");
+    checkout
+}
+
+/// A manifest file the write-back can edit.
+fn manifest_at(tmp: &Path) -> PathBuf {
+    let path = tmp.join("manifest.toml");
+    std::fs::write(&path, MANIFEST).expect("write manifest");
+    path
+}
+
+/// The crate named, as [`classify`] banded it.
+fn finding_for(json: &str, package: &str) -> Option<Finding> {
+    parse(json)
+        .expect("the fixture parses")
+        .iter()
+        .filter_map(classify)
+        .find(|f| f.package == package)
+}
+
+// ─── Parsing ────────────────────────────────────────────────────────────────
+
+#[test]
+fn the_fixture_yields_every_crate() {
+    let packages = parse(FIXTURE).expect("the captured document parses");
+    assert_eq!(packages.len(), 8, "{packages:?}");
+    let dual = packages
+        .iter()
+        .find(|p| p.name == "readerwriterqueue")
+        .unwrap_or_else(|| panic!("the dual-licensed row is missing: {packages:?}"));
+    assert_eq!(
+        dual.version, "1.0.6",
+        "the version is the key's second field"
+    );
+    assert_eq!(dual.licenses, ["GPL-2.0-only", "MIT"]);
+}
+
+#[test]
+fn output_that_is_not_json_is_a_reason() {
+    let cause = parse("error: no such subcommand").expect_err("not JSON");
+    assert!(cause.contains("not readable as JSON"), "{cause}");
+}
+
+#[test]
+fn json_that_is_not_the_crate_layout_is_a_reason() {
+    let cause = parse(r#"["MIT (1): acme"]"#).expect_err("wrong layout");
+    assert!(cause.contains("crate-layout listing object"), "{cause}");
+}
+
+// ─── The policy ─────────────────────────────────────────────────────────────
+
+/// The finding an acquirer's counsel acts on: one AGPL crate binds the work.
+#[test]
+fn a_strong_copyleft_dependency_is_a_red_finding() {
+    let found = finding_for(FIXTURE, "libfoo-sys").expect("AGPL is a finding");
+    assert_eq!(found.license, "AGPL-3.0-or-later");
+    assert_eq!(found.version, "0.9.1");
+    assert_eq!(found.severity, Severity::Red);
+    assert!(found.obligation.contains("same license"), "{found:?}");
+    assert_eq!(
+        found.url.as_deref(),
+        Some("https://spdx.org/licenses/AGPL-3.0-or-later.html"),
+        "a recognised identifier links to its SPDX page"
+    );
+}
+
+#[test]
+fn a_weak_copyleft_dependency_is_an_amber_finding() {
+    let found = finding_for(FIXTURE, "colored").expect("MPL-2.0 is a finding");
+    assert_eq!(found.license, "MPL-2.0");
+    assert_eq!(found.severity, Severity::Amber);
+    assert!(found.obligation.contains("file-level"), "{found:?}");
+}
+
+/// A crate declaring nothing is worse than any copyleft term: there is no
+/// stated right to redistribute it at all.
+#[test]
+fn a_crate_with_no_license_is_the_worst_finding() {
+    let found = finding_for(FIXTURE, "acme-core").expect("an unlicensed crate is a finding");
+    assert_eq!(found.license, UNLICENSED);
+    assert_eq!(found.severity, Severity::Red);
+    assert!(found.obligation.contains("no license"), "{found:?}");
+    assert!(
+        found.url.is_none(),
+        "UNLICENSED is not an SPDX identifier and gets no link: {found:?}"
+    );
+}
+
+/// `GPL-2.0-only OR MIT` costs the acquirer nothing — they take the MIT option.
+/// Flagging it would put a copyleft row in every report that depends on a
+/// dual-licensed crate, which is most of them.
+#[test]
+fn a_dual_licensed_crate_takes_its_permissive_option() {
+    assert!(
+        finding_for(FIXTURE, "readerwriterqueue").is_none(),
+        "a permissive term in the set clears the crate"
+    );
+    assert!(
+        finding_for(FIXTURE, "aho-corasick").is_none(),
+        "Unlicense/MIT is permissive on both terms"
+    );
+}
+
+/// A term the policy table has never seen is the case that most needs a human,
+/// so it is reported rather than dropped — dropping it is the silent zero.
+#[test]
+fn an_unrecognised_term_is_reported_rather_than_dropped() {
+    let found = finding_for(FIXTURE, "vendor-blob").expect("an unknown term is a finding");
+    assert_eq!(found.license, "LicenseRef-Acme-Commercial");
+    assert_eq!(found.severity, Severity::Amber);
+    assert!(found.obligation.contains("reviewed by hand"), "{found:?}");
+    assert!(
+        found.url.is_none(),
+        "no SPDX link is invented for a term SPDX does not define: {found:?}"
+    );
+}
+
+/// #6076's second closure condition, at the policy layer: a permissive-only
+/// dependency set produces no finding at all.
+#[test]
+fn a_permissive_dependency_set_produces_no_finding() {
+    let findings: Vec<Finding> = parse(PERMISSIVE_FIXTURE)
+        .expect("parses")
+        .iter()
+        .filter_map(classify)
+        .collect();
+    assert!(findings.is_empty(), "{findings:?}");
+}
+
+/// `Apache-2.0 WITH LLVM-exception`, `GPL-3.0-only` and `GPL-3.0+` are all
+/// spellings the policy tables do not list literally.
+#[test]
+fn spdx_qualifiers_do_not_defeat_the_policy() {
+    let package = |licenses: &[&str]| Package {
+        name: "x".to_string(),
+        version: "1.0.0".to_string(),
+        licenses: licenses.iter().map(|s| (*s).to_string()).collect(),
+    };
+    assert!(
+        classify(&package(&["Apache-2.0 WITH LLVM-exception"])).is_none(),
+        "a WITH exception does not hide a permissive base"
+    );
+    for spelling in ["GPL-3.0-only", "GPL-3.0-or-later", "GPL-3.0+", "gpl-3.0"] {
+        let found = classify(&package(&[spelling]))
+            .unwrap_or_else(|| panic!("{spelling} must still band as copyleft"));
+        assert_eq!(found.severity, Severity::Red, "{spelling}");
+    }
+}
+
+/// One row per crate at most, so the rendered table can never outgrow the
+/// dependency list it was built from.
+#[test]
+fn a_crate_earns_at_most_one_row() {
+    let packages = parse(FIXTURE).expect("parses");
+    let findings: Vec<Finding> = packages.iter().filter_map(classify).collect();
+    assert!(findings.len() <= packages.len(), "{findings:?}");
+    assert_eq!(findings.len(), 4, "{findings:?}");
+}
+
+// ─── The applicability ladder ───────────────────────────────────────────────
+
+/// #6076: a non-Rust target is a NAMED gap, never a silent zero-findings
+/// result, and the gap names the language rather than the marker file.
+#[test]
+fn a_non_rust_repository_names_its_language() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let checkout = tmp.path().join("web");
+    std::fs::create_dir_all(&checkout).expect("mkdir");
+    std::fs::write(checkout.join("go.mod"), "module acme\n").expect("manifest");
+
+    let Outcome::Unavailable(reason) = review_with(&checkout, refuses("must not spawn")) else {
+        panic!("a Go repository has license exposure this collector cannot measure");
+    };
+    assert_eq!(
+        reason, "license-review: no cargo-deny-equivalent for Go",
+        "the gap states the language"
+    );
+}
+
+#[test]
+fn a_rust_repository_with_no_lockfile_says_so() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let checkout = tmp.path().join("lib");
+    std::fs::create_dir_all(&checkout).expect("mkdir");
+    std::fs::write(checkout.join("Cargo.toml"), "[package]\nname = \"x\"\n").expect("manifest");
+
+    let Outcome::Unavailable(reason) = review_with(&checkout, refuses("must not spawn")) else {
+        panic!("an unlocked Cargo project is unreviewable, not inapplicable");
+    };
+    assert!(reason.contains("no Cargo.lock"), "{reason}");
+}
+
+/// A repository declaring no dependency manifest at all has no license surface
+/// to claim is missing — the declared-skip distinction `cve` and `topology`
+/// both draw.
+#[test]
+fn a_repository_with_no_manifest_is_a_declared_skip() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let checkout = tmp.path().join("docs");
+    std::fs::create_dir_all(&checkout).expect("mkdir");
+
+    assert!(
+        matches!(
+            review_with(&checkout, refuses("must not spawn")),
+            Outcome::NotApplicable(_)
+        ),
+        "a manifest-less repository is a skip, not a degradation"
+    );
+    assert!(
+        ground_into_with(
+            &manifest_at(tmp.path()),
+            &checkout,
+            "docs",
+            refuses("must not spawn")
+        )
+        .is_empty(),
+        "and it says nothing at all"
+    );
+}
+
+// ─── Fail-open: every arm that produces no findings ─────────────────────────
+
+/// Error arm 1, and #6076's Fail-Open Check. Fails before the collector existed
+/// by producing nothing at all; fails against a silent implementation by
+/// producing an empty findings list and no gap.
+#[test]
+fn an_uninstalled_binary_is_a_named_gap() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let checkout = locked_checkout(tmp.path());
+    let manifest = manifest_at(tmp.path());
+
+    let missing = format!(
+        "license-review: `cargo-deny` is not installed, so no dependency license review ran \
+         (install it with `{INSTALL_COMMAND}`)"
+    );
+    let leaked: &'static str = Box::leak(missing.into_boxed_str());
+    let gaps = ground_into_with(&manifest, &checkout, "acme-api", refuses(leaked));
+
+    assert_eq!(gaps.len(), 1, "{gaps:?}");
+    assert!(
+        gaps[0].starts_with("acme-api: license-review:"),
+        "{}",
+        gaps[0]
+    );
+    assert!(gaps[0].contains("cargo-deny"), "{}", gaps[0]);
+    assert!(
+        gaps[0].contains("cargo install cargo-deny"),
+        "the gap names the install command: {}",
+        gaps[0]
+    );
+    assert!(
+        gaps[0].contains("unassessed rather than as a permissively licensed dependency set"),
+        "{}",
+        gaps[0]
+    );
+    assert_eq!(
+        std::fs::read_to_string(&manifest).expect("read back"),
+        MANIFEST,
+        "no findings list — not even an empty one — is recorded for a review that never ran"
+    );
+}
+
+/// Error arm 2. `cargo-deny list` exits zero whenever it produced a listing, so
+/// a non-zero exit is a failure and never a result — the opposite of `cargo
+/// audit`, whose non-zero exit IS its most important finding.
+#[test]
+fn a_nonzero_exit_is_a_named_gap() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let checkout = locked_checkout(tmp.path());
+    let manifest = manifest_at(tmp.path());
+
+    let gaps = ground_into_with(
+        &manifest,
+        &checkout,
+        "acme-api",
+        returns(
+            false,
+            "",
+            "error: failed to read lock file: not a lock file\n",
+        ),
+    );
+
+    assert_eq!(gaps.len(), 1, "{gaps:?}");
+    assert!(
+        gaps[0].contains("exited non-zero without a listing"),
+        "{}",
+        gaps[0]
+    );
+    assert!(
+        gaps[0].contains("failed to read lock file"),
+        "the gap carries the tool's own cause, not a generic one: {}",
+        gaps[0]
+    );
+    assert_eq!(
+        std::fs::read_to_string(&manifest).expect("read back"),
+        MANIFEST,
+        "the manifest is byte-identical after a failed review"
+    );
+}
+
+/// #6720: a leading informational line must not become "the reason". Here the
+/// cause this module determined leads, and the tool's stderr follows it — so an
+/// unhelpful first line costs detail, never the diagnosis.
+#[test]
+fn a_noisy_first_stderr_line_does_not_replace_the_diagnosis() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let checkout = locked_checkout(tmp.path());
+    let manifest = manifest_at(tmp.path());
+
+    let gaps = ground_into_with(
+        &manifest,
+        &checkout,
+        "acme-api",
+        returns(
+            false,
+            "",
+            "Update available: cargo-deny 0.21.0\nerror: real cause\n",
+        ),
+    );
+
+    assert_eq!(gaps.len(), 1, "{gaps:?}");
+    assert!(
+        gaps[0].contains("license-review: `cargo-deny` exited non-zero without a listing"),
+        "the diagnosis is this module's own, stated before any borrowed stderr: {}",
+        gaps[0]
+    );
+}
+
+/// A zero exit whose stdout is unreadable is still a failure, and the gap says
+/// which of the two it was.
+#[test]
+fn unreadable_output_is_a_named_gap() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let checkout = locked_checkout(tmp.path());
+    let manifest = manifest_at(tmp.path());
+
+    let gaps = ground_into_with(
+        &manifest,
+        &checkout,
+        "acme-api",
+        returns(true, "<html>", ""),
+    );
+
+    assert_eq!(gaps.len(), 1, "{gaps:?}");
+    assert!(gaps[0].contains("not readable as JSON"), "{}", gaps[0]);
+    assert_eq!(
+        std::fs::read_to_string(&manifest).expect("read back"),
+        MANIFEST,
+        "the manifest is byte-identical after an unreadable review"
+    );
+}
+
+/// #6076's second closure condition end to end: a permissive-only target writes
+/// no findings AND still says what was reviewed, so the empty License section
+/// is never read as an unrun scan.
+#[test]
+fn a_clean_review_states_its_own_scope() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let checkout = locked_checkout(tmp.path());
+    let manifest = manifest_at(tmp.path());
+
+    let gaps = ground_into_with(
+        &manifest,
+        &checkout,
+        "acme-api",
+        returns(true, PERMISSIVE_FIXTURE, ""),
+    );
+
+    assert_eq!(gaps.len(), 1, "{gaps:?}");
+    assert!(
+        gaps[0].contains("every dependency offers a permissive license"),
+        "{}",
+        gaps[0]
+    );
+    assert!(
+        gaps[0].contains("Vendored code"),
+        "the clean line states what it did NOT cover: {}",
+        gaps[0]
+    );
+    assert_eq!(
+        std::fs::read_to_string(&manifest).expect("read back"),
+        MANIFEST,
+        "an empty findings array is never written"
+    );
+}
+
+#[test]
+fn a_manifest_that_cannot_be_written_is_a_named_gap() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let checkout = locked_checkout(tmp.path());
+    let missing = tmp.path().join("nowhere").join("manifest.toml");
+
+    let gaps = ground_into_with(&missing, &checkout, "acme-api", returns(true, FIXTURE, ""));
+
+    assert_eq!(gaps.len(), 1, "{gaps:?}");
+    assert!(gaps[0].contains("could not be read"), "{}", gaps[0]);
+    assert!(
+        gaps[0].contains("license obligation(s)"),
+        "the gap says how many rows the report is therefore missing: {}",
+        gaps[0]
+    );
+}
+
+// ─── The manifest write-back ────────────────────────────────────────────────
+
+/// #6076's first closure condition: the findings reach `[report].findings`
+/// under the `license` category trusty-review renders.
+#[test]
+fn the_findings_land_in_the_manifest() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let checkout = locked_checkout(tmp.path());
+    let manifest = manifest_at(tmp.path());
+
+    let gaps = ground_into_with(&manifest, &checkout, "acme-api", returns(true, FIXTURE, ""));
+    assert!(
+        gaps.is_empty(),
+        "a review that wrote its rows says nothing: {gaps:?}"
+    );
+
+    let written = std::fs::read_to_string(&manifest).expect("read back");
+    assert!(written.contains("category = \"license\""), "{written}");
+    assert!(written.contains("id = \"AGPL-3.0-or-later\""), "{written}");
+    assert!(written.contains("package = \"libfoo-sys\""), "{written}");
+    assert!(written.contains("severity = \"RED\""), "{written}");
+    assert!(written.contains("id = \"MPL-2.0\""), "{written}");
+    assert!(written.contains("id = \"UNLICENSED\""), "{written}");
+    assert!(
+        written.starts_with("[report]\ntitle = \"Acme\""),
+        "the edit is format-preserving: {written}"
+    );
+    assert!(
+        written.contains("[[repositories]]"),
+        "nothing else in the document changed: {written}"
+    );
+
+    // The rows are what trusty-review deserialises into `ManifestFinding`.
+    let doc: toml::Value = written.parse().expect("the edited manifest is valid TOML");
+    let rows = doc["report"]["findings"]
+        .as_array()
+        .expect("findings is an array");
+    assert_eq!(rows.len(), 4, "{rows:?}");
+    assert!(
+        rows.iter()
+            .all(|r| r["category"].as_str() == Some("license")),
+        "{rows:?}"
+    );
+}
+
+#[test]
+fn a_resumed_sweep_does_not_duplicate_a_row() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let checkout = locked_checkout(tmp.path());
+    let manifest = manifest_at(tmp.path());
+
+    let _ = ground_into_with(&manifest, &checkout, "acme-api", returns(true, FIXTURE, ""));
+    let once = std::fs::read_to_string(&manifest).expect("read back");
+    let _ = ground_into_with(&manifest, &checkout, "acme-api", returns(true, FIXTURE, ""));
+    let twice = std::fs::read_to_string(&manifest).expect("read back");
+
+    assert_eq!(once, twice, "the second pass restates nothing");
+}
+
+/// The channel is shared with #6075: a CVE row already in the array must
+/// survive a license write, and must not be mistaken for one of its rows.
+#[test]
+fn a_cve_row_already_present_is_left_alone() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let checkout = locked_checkout(tmp.path());
+    let manifest = tmp.path().join("manifest.toml");
+    std::fs::write(
+        &manifest,
+        "[report]\ntitle = \"Acme\"\nfindings = [\n    { category = \"dependencies\", id = \
+         \"RUSTSEC-2024-0421\", package = \"idna\", version = \"0.5.0\", severity = \"RED\", \
+         title = \"Punycode\" },\n]\n\n[[repositories]]\nname = \"acme-api\"\npath = \
+         \"/tmp/acme-api\"\n",
+    )
+    .expect("seed manifest");
+
+    let gaps = ground_into_with(&manifest, &checkout, "acme-api", returns(true, FIXTURE, ""));
+    assert!(gaps.is_empty(), "the seeded manifest is writable: {gaps:?}");
+
+    let doc: toml::Value = std::fs::read_to_string(&manifest)
+        .expect("read back")
+        .parse()
+        .expect("valid TOML");
+    let rows = doc["report"]["findings"]
+        .as_array()
+        .expect("findings is an array");
+    assert_eq!(
+        rows.len(),
+        5,
+        "the CVE row plus four license rows: {rows:?}"
+    );
+    assert_eq!(
+        rows.iter()
+            .filter(|r| r["category"].as_str() == Some("dependencies"))
+            .count(),
+        1,
+        "the CVE row is untouched: {rows:?}"
+    );
+}

--- a/crates/trusty-audit/src/grounding/license_tests.rs
+++ b/crates/trusty-audit/src/grounding/license_tests.rs
@@ -204,6 +204,42 @@ fn spdx_qualifiers_do_not_defeat_the_policy() {
     }
 }
 
+/// A whole expression arriving as ONE license term, which `normalise` cannot
+/// take apart.
+///
+/// Why: pre-SPDX crate metadata wrote a dual license as the slash-joined
+/// `MIT/Apache-2.0`, and a vendored or hand-edited manifest still can — while
+/// `cargo-deny list` normally flattens an expression into separate terms, this
+/// module must not assume it always did. The permissive halves inside such a
+/// string are invisible to the policy tables, and the safe direction is to
+/// UNDER-clear: report the crate for a human rather than clear it on a
+/// substring nobody parsed. What must not happen is a panic, a silent clear, or
+/// an SPDX link built from a string SPDX does not define — `spdx_url` returning
+/// `Some` here would send the reader to an authoritative-looking 404.
+#[test]
+fn an_unparsed_compound_expression_is_reported_rather_than_cleared() {
+    let package = |license: &str| Package {
+        name: "x".to_string(),
+        version: "1.0.0".to_string(),
+        licenses: vec![license.to_string()],
+    };
+    // The legacy slash form, and a compound spelling no table lists.
+    for spelling in ["MIT/Apache-2.0", "Apache-2.0 OR LGPL-3.0"] {
+        let found = classify(&package(spelling))
+            .unwrap_or_else(|| panic!("{spelling} must not clear the crate"));
+        assert_eq!(found.license, spelling, "reported verbatim: {found:?}");
+        assert_eq!(found.severity, Severity::Amber, "{spelling}");
+        assert!(
+            found.obligation.contains("reviewed by hand"),
+            "{spelling}: {found:?}"
+        );
+        assert!(
+            found.url.is_none(),
+            "{spelling} is not an SPDX identifier and must get no link: {found:?}"
+        );
+    }
+}
+
 /// One row per crate at most, so the rendered table can never outgrow the
 /// dependency list it was built from.
 #[test]

--- a/crates/trusty-audit/testdata/cargo-deny-list-permissive.json
+++ b/crates/trusty-audit/testdata/cargo-deny-list-permissive.json
@@ -1,0 +1,20 @@
+{
+  "adler2 2.0.1 registry+https://github.com/rust-lang/crates.io-index": {
+    "licenses": ["0BSD", "MIT", "Apache-2.0"]
+  },
+  "anyhow 1.0.102 registry+https://github.com/rust-lang/crates.io-index": {
+    "licenses": ["MIT", "Apache-2.0"]
+  },
+  "acme-core 0.4.2 (path+file:///src/acme-core)": {
+    "licenses": ["MIT"]
+  },
+  "objc-sys 0.3.5 registry+https://github.com/rust-lang/crates.io-index": {
+    "licenses": ["Apache-2.0 WITH LLVM-exception"]
+  },
+  "rustls 0.23.36 registry+https://github.com/rust-lang/crates.io-index": {
+    "licenses": ["Apache-2.0", "ISC", "MIT"]
+  },
+  "unicode-ident 1.0.24 registry+https://github.com/rust-lang/crates.io-index": {
+    "licenses": ["Unicode-3.0", "MIT", "Apache-2.0"]
+  }
+}

--- a/crates/trusty-audit/testdata/cargo-deny-list.json
+++ b/crates/trusty-audit/testdata/cargo-deny-list.json
@@ -1,0 +1,26 @@
+{
+  "adler2 2.0.1 registry+https://github.com/rust-lang/crates.io-index": {
+    "licenses": ["0BSD", "MIT", "Apache-2.0"]
+  },
+  "aho-corasick 1.1.4 registry+https://github.com/rust-lang/crates.io-index": {
+    "licenses": ["Unlicense", "MIT"]
+  },
+  "acme-core 0.4.2 (path+file:///src/acme-core)": {
+    "licenses": []
+  },
+  "colored 2.2.0 registry+https://github.com/rust-lang/crates.io-index": {
+    "licenses": ["MPL-2.0"]
+  },
+  "libfoo-sys 0.9.1 registry+https://github.com/rust-lang/crates.io-index": {
+    "licenses": ["AGPL-3.0-or-later"]
+  },
+  "objc-sys 0.3.5 registry+https://github.com/rust-lang/crates.io-index": {
+    "licenses": ["Apache-2.0 WITH LLVM-exception"]
+  },
+  "readerwriterqueue 1.0.6 registry+https://github.com/rust-lang/crates.io-index": {
+    "licenses": ["GPL-2.0-only", "MIT"]
+  },
+  "vendor-blob 3.1.0 registry+https://github.com/rust-lang/crates.io-index": {
+    "licenses": ["LicenseRef-Acme-Commercial"]
+  }
+}

--- a/crates/trusty-review/src/report/assurance_tests.rs
+++ b/crates/trusty-review/src/report/assurance_tests.rs
@@ -65,6 +65,41 @@ fn a_declared_finding_reaches_the_report() {
     );
 }
 
+/// One `cargo-deny list` row, as `trusty_audit::grounding::license::write_into`
+/// spells it (#6076).
+const LICENSE_ROW: &str = "findings = [\n  { category = \"license\", id = \"AGPL-3.0-or-later\", \
+     package = \"libfoo-sys\", version = \"0.9.1\", severity = \"RED\", \
+     title = \"copyleft: linking this into a distributed work obliges releasing that work's \
+     source under the same license\", url = \"https://spdx.org/licenses/AGPL-3.0-or-later.html\" \
+     },\n]";
+
+/// #6076's deliverable, through the same channel #6075 opened: a license
+/// obligation trusty-audit wrote into the manifest reaches the report an
+/// acquirer reads, under its own subsection heading.
+#[test]
+fn a_declared_license_finding_reaches_the_report() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let model = model_from(tmp.path(), &manifest_declaring(LICENSE_ROW));
+    let template = TemplateLoader::bundled_only()
+        .load("report-technical-dd")
+        .expect("bundled template");
+    let md = Reporter::new(tmp.path()).render(&model, &template);
+
+    assert!(md.contains("## Assurance Scans"), "{md}");
+    assert!(md.contains("### License / IP Exposure"), "{md}");
+    assert!(md.contains("AGPL-3.0-or-later"), "{md}");
+    assert!(md.contains("libfoo-sys"), "{md}");
+    assert!(md.contains("RED"), "{md}");
+    assert!(
+        md.contains("obliges releasing that work's source under the same license"),
+        "the obligation, not just the license name, reaches the page: {md}"
+    );
+    assert!(
+        md.contains("https://spdx.org/licenses/AGPL-3.0-or-later.html"),
+        "the license is linked so a reader can verify it: {md}"
+    );
+}
+
 /// The narrowed disclaimer must point at the section that now carries the
 /// answer, and must still deny everything the run genuinely does not cover.
 #[test]


### PR DESCRIPTION
Adds the license collector to trusty-audit's grounding stage, mirroring #6075's cargo-audit collector (PR #6730). It runs `cargo-deny list --format json --layout crate` (resolved through `trusty_common::bin_resolve`) and applies its own policy: strong copyleft RED, weak copyleft or unrecognised terms AMBER, no declared license RED, any permissive term clears the crate; one row per crate, SPDX link where one exists, category `license`, rendered by trusty-review under "License / IP Exposure" with no production change there. The ecosystem marker table moves out of `cve.rs` into a shared `ecosystem.rs`.

Deviation from the issue text: `cargo deny check licenses` needs a `deny.toml` a third-party target does not carry and returned zero findings over 914 crates on this workspace without one — the silent zero #6074 exists to remove — so the collector reads `list` and holds the policy itself (module docs). Known limit: `list` flattens SPDX expressions, so `GPL-2.0 AND MIT` is indistinguishable from `GPL-2.0 OR MIT` and both clear; disclosed in the module docs and the clean-scan gap sentence.

Refs #6076

## Test rung

Rung 3 (localized to trusty-audit; one test-only touch in trusty-review). trusty-audit 0.13.3 (unpublished, above crates.io 0.13.2); trusty-review 0.33.1 unchanged.

```
cargo fmt --all --check && cargo clippy -p trusty-audit --all-targets -- -D warnings && cargo clippy -p trusty-review --all-targets -- -D warnings && cargo check --workspace --all-targets   # exit 0
cargo test -p trusty-audit --no-fail-fast    # lib 831 passed, 0 failed; 9 targets ok
cargo test -p trusty-review --no-fail-fast   # lib 2156 passed, 0 failed; all targets ok
bash scripts/check_semver.sh --crate trusty-audit && bash scripts/check_changelog_fragment.sh && bash scripts/check_line_cap.sh && bash scripts/check_test_pointers.sh && bash scripts/check_sld.sh && bash scripts/check_rustdoc_links.sh   # OK
```

Fail-Open Check: seven named-gap arms (binary missing, spawn error, nonzero exit, unreadable stdout, unwritable manifest, non-Rust ecosystem, no lockfile), each leaving the manifest byte-identical, each with a test; per #6720 the module's own diagnosis leads and stderr line 1 never replaces it (`a_noisy_first_stderr_line_does_not_replace_the_diagnosis`). Live probe against this checkout with cargo-deny 0.20.2: 9 findings, all MPL-2.0 AMBER, matching an independent count.

Code-critic: APPROVE; two LOW items fixed in the second commit (gap-sentence punctuation; slash-form and unlisted-compound tests). Pre-push credential scan over `git diff origin/main...HEAD`: PASS, 9 files.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
