### PR TITLE
feat(trusty-mcp): trusty-mcp <service> — stdio MCP bridge to any trusty daemon's UDS socket (Refs #6316)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11845,7 +11845,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-mcp"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",

--- a/crates/trusty-mcp/Cargo.toml
+++ b/crates/trusty-mcp/Cargo.toml
@@ -8,7 +8,10 @@ name = "trusty-mcp"
 # release moves forward to a gate-clean commit instead.
 #
 # 0.1.2 -> 0.1.3: additive, feature-gated `daemon_bridge_json_rpc` (#6316).
-version = "0.1.3"
+# 0.1.3 -> 0.1.4: additive, feature-gated `trusty-mcp <service>` binary (#6316
+# slice 4). One bump per merged slice, so a release cut from any commit names
+# exactly what it carries.
+version = "0.1.4"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -22,6 +25,15 @@ homepage = "https://github.com/bobmatnyc/trusty-tools"
 
 [lib]
 crate-type = ["rlib"]
+
+# #6316: the one MCP stdio bridge, per the 2026-07-24 "no per-crate MCP
+# binaries" directive. `required-features` keeps `cargo check -p trusty-mcp` and
+# `cargo check --workspace` (both default-featured) free of `trusty-common` —
+# the bin is simply not a target then.
+[[bin]]
+name = "trusty-mcp"
+path = "src/bin/trusty-mcp.rs"
+required-features = ["daemon-bridge-json-rpc"]
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/trusty-mcp/README.md
+++ b/crates/trusty-mcp/README.md
@@ -16,6 +16,7 @@ implementation so a parse-error fix or a `serverInfo` change lands once.
 | `daemon_bridge` | `DaemonBridgeConfig`, `ensure_daemon_up` — probe/spawn/poll a service's HTTP daemon before entering the dispatch loop |
 | `single_flight` | `StartLock`, `ensure_daemon_up_single_flight` — `flock(2)`-guarded variant so N concurrent bridge processes start exactly one daemon (#1152) |
 | `daemon_bridge_json_rpc` | `UdsBridgeConfig`, `DaemonBridgeJsonRpc`, `run_stdio_bridge` — the shared stdio↔UDS JSON-RPC forwarder (#6316). **Feature-gated**, see below |
+| `bin/trusty-mcp` | `trusty-mcp <service>` — the one stdio MCP bridge binary, driving the forwarder against any trusty daemon's socket (#6316). **Feature-gated**, see below |
 
 ## Features
 
@@ -35,6 +36,48 @@ cargo tree -p trusty-mcp -e features -i trusty-common
 cargo tree -p trusty-mcp -e features -i trusty-common --features daemon-bridge-json-rpc
 # trusty-common v0.47.2 … └── trusty-mcp feature "daemon-bridge-json-rpc"
 ```
+
+The feature also builds the `trusty-mcp` binary below — `required-features` on
+the `[[bin]]`, so a default-featured `cargo check` simply has no such target.
+
+## The `trusty-mcp <service>` binary
+
+One stdio MCP bridge for every UDS-backed trusty daemon, per the 2026-07-24
+"no per-crate MCP binaries" directive (#6316). An MCP client config names this
+binary and a service instead of a different binary and a different verb per
+daemon.
+
+```bash
+cargo install --path crates/trusty-mcp --features daemon-bridge-json-rpc --locked
+trusty-mcp memory          # or trusty-mcp trusty-memory
+trusty-mcp search
+trusty-mcp analyze
+```
+
+It resolves the socket with `trusty_common::daemon_socket_path(<app>)` — the
+same call the daemon makes to decide where to bind — and runs
+`run_stdio_bridge`. Two things it deliberately does not do:
+
+- **It starts nothing.** No probe, no spawn, no lock; a daemon's readiness guard
+  stays that daemon's own (#1152 is the record of what N independently-spawning
+  bridges cost). A request that arrives with nothing listening comes back as a
+  JSON-RPC error carrying the request's own id — never silence, because an
+  unmatchable answer is a hang to the client (#6309).
+- **It writes nothing to stdout but JSON-RPC.** The usage text, the startup line
+  and every failure go to stderr, a `--help` included.
+
+| Exit | Meaning |
+|---|---|
+| 0 | stdin reached EOF, which is how an MCP client says stop (#457) — or `--help` |
+| 1 | the socket path could not be resolved, or stdin/stdout failed |
+| 2 | usage error: no service, an unknown service, or an extra argument |
+
+The per-service streaming-method lists and frame budgets in `SERVICES` are a
+second copy of each daemon's own constants — importing them would pull
+trusty-memory, trusty-search and trusty-analyze into this crate's build for
+three arrays and three integers. `the_table_matches_each_daemons_own_constants`
+reads those crates' sources and fails on drift, which is the case #6286 showed
+goes silent otherwise.
 
 Two names sit close together and are not the same thing. `daemon_bridge` probes
 and spawns a service's **HTTP** daemon before the dispatch loop starts.

--- a/crates/trusty-mcp/changelog.d/6316-bridge-bin.md
+++ b/crates/trusty-mcp/changelog.d/6316-bridge-bin.md
@@ -1,0 +1,7 @@
+Added
+
+- **`trusty-mcp <service>` — one stdio MCP bridge binary for every trusty daemon.** `trusty-mcp memory`, `trusty-mcp search` and `trusty-mcp analyze` (each also spelled in full, `trusty-mcp trusty-memory`) read line-delimited JSON-RPC on stdin and forward it to that daemon's Unix socket, resolving the socket through `trusty_common::daemon_socket_path` — the same call the daemon makes to decide where to bind. This is the 2026-07-24 "no per-crate MCP binaries" directive: an MCP client config names one binary and a service rather than a different binary and a different verb per daemon ([#6316](https://github.com/bobmatnyc/trusty-tools/issues/6316))
+  - It starts nothing. A daemon's readiness guard stays that daemon's own, and a request arriving with nothing listening is answered with a JSON-RPC error carrying the request's id rather than silence (#6309, #1152)
+  - Stdout carries JSON-RPC frames and nothing else — the usage text, the startup line and every failure go to stderr, a `--help` included. An unknown service exits 2 with an empty stdout
+  - Behind `required-features = ["daemon-bridge-json-rpc"]`, so `cargo check -p trusty-mcp` and `cargo check --workspace` stay free of `trusty-common`
+  - Per-service streaming-method lists and frame budgets are a second copy of each daemon's own constants, because importing them would pull trusty-memory, trusty-search and trusty-analyze into this crate's build. `the_table_matches_each_daemons_own_constants` reads those crates' sources and fails on drift — the case #6286 showed goes silent otherwise

--- a/crates/trusty-mcp/src/bin/trusty-mcp.rs
+++ b/crates/trusty-mcp/src/bin/trusty-mcp.rs
@@ -1,0 +1,501 @@
+//! `trusty-mcp <service>` — one stdio MCP bridge for every trusty daemon (#6316).
+//!
+//! Why: the 2026-07-24 owner directive is "no per-crate MCP binaries". Each
+//! daemon crate was growing its own `serve --stdio` verb, and every one of them
+//! is the same program: resolve that daemon's Unix socket, read line-delimited
+//! JSON-RPC from stdin, forward each request over the socket, write the answer
+//! to stdout. Slice 2 of #6316 made the forwarding itself shared
+//! (`trusty_mcp::daemon_bridge_json_rpc`); this binary is the one entry point
+//! that drives it, so an MCP client's config names `trusty-mcp <service>`
+//! rather than a different binary and a different verb per daemon.
+//!
+//! What: a table of the three UDS-backed daemons and the two facts that differ
+//! between them — which methods answer as a stream, and how large a response
+//! frame may be. Everything else comes from the shared crate: the socket path
+//! from `trusty_common::daemon_socket_path`, which is the same call the daemon
+//! itself makes to decide where to bind, and the transport from
+//! `trusty_mcp::run_stdio_bridge`.
+//!
+//! ## It does not start anything
+//!
+//! No probe, no spawn, no lock. A daemon's readiness guard is that daemon's own
+//! (trusty-memory's `serve --stdio` still takes the `StartLock` #5267 gave it),
+//! and #1152 is the record of what N independently-spawning bridges cost. A
+//! request that arrives here with nothing listening is answered with a JSON-RPC
+//! error carrying the request's own id — never silence, because an unmatchable
+//! answer is indistinguishable from a hang to the client (#6309).
+//!
+//! ## STDOUT is the JSON-RPC channel
+//!
+//! Nothing here writes to stdout but the forwarder. The usage text, the startup
+//! line and every failure go to stderr, including a `--help` a human typed:
+//! one rule with no exception is what keeps a stray `println!` reviewable.
+//!
+//! Test: `tests/bridge_bin_cli.rs` drives the built binary end to end; the unit
+//! tests below cover the service table and pin it against the daemons' own
+//! constants.
+
+use std::process::ExitCode;
+
+use anyhow::Context;
+use trusty_mcp::{UdsBridgeConfig, run_stdio_bridge};
+
+/// Exit code for a usage error, distinct from a runtime failure's `1`.
+///
+/// Why: a wrapper that spawns this binary needs to tell "you asked for a
+/// service that does not exist" from "the daemon could not be reached". The
+/// first is the caller's config to fix, the second is the machine's state.
+const EXIT_USAGE: u8 = 2;
+
+/// One mebibyte, so the frame budgets below read as the figures they mirror.
+const MIB: u64 = 1024 * 1024;
+
+/// A daemon this binary can bridge to.
+///
+/// Why: `app` is the only identifier that matters — it is what
+/// `trusty_common::daemon_socket_path` resolves under, what the daemon binds
+/// under, and what names the daemon in error text. The other two fields are the
+/// only things that genuinely differ between the three daemons.
+/// What: `streaming_methods` is the refusal list the bridge applies before it
+/// dials; `max_frame_bytes` is the response budget, which must be at least the
+/// daemon's own or a frame the daemon served becomes a `FrameTooLarge` on the
+/// way back.
+/// Test: `the_table_matches_each_daemons_own_constants`.
+struct Service {
+    /// The daemon's app name, e.g. `"trusty-memory"`.
+    app: &'static str,
+    /// Methods that answer in many frames, which MCP stdio cannot carry.
+    streaming_methods: &'static [&'static str],
+    /// Response-frame budget, matching the daemon's own listener budget.
+    max_frame_bytes: u64,
+}
+
+/// Every daemon `trusty-mcp <service>` can bridge to.
+///
+/// Why these values are here and not imported: each list belongs to a crate
+/// that already depends on `trusty-mcp`, so importing them would put the whole
+/// of trusty-memory, trusty-search and trusty-analyze into this crate's build
+/// — for three string arrays and three integers. `the_table_matches_each_
+/// daemons_own_constants` reads those crates' sources instead and fails on
+/// drift, which is what the import would have bought.
+///
+/// trusty-analyze streams nothing: its socket router registers no streaming
+/// method, and its MCP surface is a tool translator that answers each call in
+/// one frame.
+///
+/// Test: `the_table_matches_each_daemons_own_constants`,
+/// `every_service_is_reachable_by_both_of_its_names`.
+const SERVICES: &[Service] = &[
+    // #6316: mirrors `trusty_memory::transport::uds::{STREAM_METHODS,
+    // MAX_FRAME_BYTES}`.
+    Service {
+        app: "trusty-memory",
+        streaming_methods: &["memory.chat", "memory.activity_stream"],
+        max_frame_bytes: 32 * MIB,
+    },
+    // #6316: mirrors `trusty_search::service::rpc::streams::METHODS` and
+    // `trusty_search::service::socket::MAX_FRAME_BYTES`.
+    Service {
+        app: "trusty-search",
+        streaming_methods: &[
+            "search.status.stream",
+            "search.index.reindex.stream",
+            "search.index.file_events",
+        ],
+        max_frame_bytes: 64 * MIB,
+    },
+    // #6316: mirrors `trusty_analyze::service::rpc::MAX_FRAME_BYTES`.
+    Service {
+        app: "trusty-analyze",
+        streaming_methods: &[],
+        max_frame_bytes: 32 * MIB,
+    },
+];
+
+/// The short name a caller may type instead of the full app name.
+fn short_name(app: &str) -> &str {
+    app.strip_prefix("trusty-").unwrap_or(app)
+}
+
+/// Resolve the `<service>` positional to a table row.
+///
+/// Why both spellings: a human types `trusty-mcp memory`, while an MCP client
+/// config generated from a daemon's own name carries `trusty-memory`. Refusing
+/// one of them would be a usage error for a name that is unambiguous.
+/// What: matches the app name exactly, or the app name with its `trusty-`
+/// prefix removed. Returns `None` for anything else, which is what produces the
+/// exit-2 usage error.
+/// Test: `every_service_is_reachable_by_both_of_its_names`,
+/// `an_unknown_service_resolves_to_nothing`.
+fn lookup(arg: &str) -> Option<&'static Service> {
+    SERVICES
+        .iter()
+        .find(|s| s.app == arg || short_name(s.app) == arg)
+}
+
+/// What the command line asked for.
+enum Parsed {
+    /// Print the usage text and exit 0.
+    Help,
+    /// Bridge stdio to this daemon.
+    Serve(&'static Service),
+    /// The command line is wrong; this says how.
+    Usage(String),
+}
+
+/// Classify the arguments after the program name.
+///
+/// Why an extra argument is a usage error rather than something ignored: a
+/// silently-dropped flag is a config that looks applied and is not. The only
+/// shape this binary accepts is exactly one positional.
+/// What: no arguments, an unknown service, or a second argument each become
+/// [`Parsed::Usage`]; `-h` / `--help` becomes [`Parsed::Help`].
+/// Test: `no_arguments_is_a_usage_error`, `an_unknown_service_is_a_usage_error`,
+/// `a_second_argument_is_a_usage_error`, `help_is_recognised`.
+fn parse<'a>(args: impl IntoIterator<Item = &'a str>) -> Parsed {
+    let mut args = args.into_iter();
+
+    let Some(first) = args.next() else {
+        return Parsed::Usage("a service is required".to_string());
+    };
+
+    if first == "-h" || first == "--help" {
+        return Parsed::Help;
+    }
+
+    let Some(service) = lookup(first) else {
+        return Parsed::Usage(format!(
+            "unknown service {first:?} — expected one of {}",
+            service_names().join(", ")
+        ));
+    };
+
+    if let Some(extra) = args.next() {
+        return Parsed::Usage(format!(
+            "unexpected argument {extra:?} — the only argument is the service"
+        ));
+    }
+
+    Parsed::Serve(service)
+}
+
+/// The short service names, in table order, for the usage text.
+fn service_names() -> Vec<&'static str> {
+    SERVICES.iter().map(|s| short_name(s.app)).collect()
+}
+
+/// The usage text, written to stderr in every case.
+///
+/// Test: `usage_names_every_service`.
+fn usage() -> String {
+    let mut out = String::from(
+        "trusty-mcp — stdio MCP bridge to a trusty daemon's Unix socket\n\
+         \n\
+         Usage:\n  \
+         trusty-mcp <service>\n\
+         \n\
+         Services (either spelling):\n",
+    );
+    for service in SERVICES {
+        out.push_str(&format!(
+            "  {:<10} {}\n",
+            short_name(service.app),
+            service.app
+        ));
+    }
+    out.push_str(
+        "\n\
+         Reads line-delimited JSON-RPC 2.0 on stdin and writes one response per\n\
+         request to stdout; every diagnostic goes to stderr. It does not start the\n\
+         daemon — a request that arrives with nothing listening is answered with a\n\
+         JSON-RPC error carrying the request's id.\n\
+         \n\
+         Exit: 0 when stdin reaches EOF, 2 on a usage error, 1 on an I/O failure.\n",
+    );
+    out
+}
+
+/// Resolve the socket, build the config, and run the forwarder.
+///
+/// # Errors
+///
+/// The data directory could not be resolved, or stdin/stdout failed. A daemon
+/// that is down is not an error here — it is a JSON-RPC error response.
+///
+/// Test: `a_dead_socket_answers_with_a_matchable_error` in
+/// `tests/bridge_bin_cli.rs`.
+async fn serve(service: &Service) -> anyhow::Result<()> {
+    // The ONE resolver: the same call the daemon makes to decide where to bind,
+    // so a bridge and its daemon cannot disagree about the path (#6316).
+    let socket = trusty_common::daemon_socket_path(service.app)
+        .with_context(|| format!("could not resolve the {} socket path", service.app))?;
+
+    // Stderr, never stdout — stdout is the JSON-RPC channel.
+    eprintln!(
+        "trusty-mcp: bridging stdio to {} at {}",
+        service.app,
+        socket.display()
+    );
+
+    run_stdio_bridge(
+        UdsBridgeConfig::new(socket, service.app)
+            .with_streaming_methods(service.streaming_methods.iter().copied())
+            .with_max_frame_bytes(service.max_frame_bytes),
+    )
+    .await
+}
+
+/// Parse, then either explain or serve.
+///
+/// A non-UTF-8 argument is read lossily rather than panicking: it cannot match
+/// a service name, so it falls through to the same usage error any other
+/// unknown service produces.
+async fn run() -> anyhow::Result<ExitCode> {
+    let args: Vec<String> = std::env::args_os()
+        .skip(1)
+        .map(|a| a.to_string_lossy().into_owned())
+        .collect();
+
+    match parse(args.iter().map(String::as_str)) {
+        Parsed::Help => {
+            eprint!("{}", usage());
+            Ok(ExitCode::SUCCESS)
+        }
+        Parsed::Usage(problem) => {
+            eprintln!("trusty-mcp: {problem}");
+            eprint!("{}", usage());
+            Ok(ExitCode::from(EXIT_USAGE))
+        }
+        Parsed::Serve(service) => {
+            serve(service).await?;
+            Ok(ExitCode::SUCCESS)
+        }
+    }
+}
+
+/// Current-thread runtime: this process multiplexes nothing — one stdin, one
+/// request at a time, one socket dial. A work-stealing pool would add threads
+/// with nothing to steal.
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> ExitCode {
+    match run().await {
+        Ok(code) => code,
+        Err(cause) => {
+            eprintln!("trusty-mcp: {cause:#}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    /// Read a sibling crate's source out of this checkout.
+    ///
+    /// Returns `None` in a published tarball, where no sibling crate exists and
+    /// there is nothing for the table to drift from.
+    fn sibling_source(rel: &str) -> Option<String> {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("..").join(rel);
+        std::fs::read_to_string(path).ok()
+    }
+
+    /// The string literals in a `pub const NAME: &[&str] = &[…];` declaration.
+    fn string_array_const(src: &str, name: &str) -> Vec<String> {
+        let decl = format!("pub const {name}: &[&str] = &[");
+        let start = src
+            .find(&decl)
+            .unwrap_or_else(|| panic!("{name} is declared"))
+            + decl.len();
+        let end = start + src[start..].find("];").expect("the array is terminated");
+        src[start..end]
+            .split('"')
+            .skip(1)
+            .step_by(2)
+            .map(str::to_string)
+            .collect()
+    }
+
+    /// Every `pub const NAME: &str = "…";` literal in a file, in source order.
+    fn str_const_literals(src: &str) -> Vec<String> {
+        src.lines()
+            .filter_map(|line| line.trim().strip_prefix("pub const "))
+            .filter_map(|rest| rest.split_once(": &str = "))
+            .filter_map(|(_, value)| value.trim().strip_prefix('"'))
+            .filter_map(|value| value.split('"').next())
+            .map(str::to_string)
+            .collect()
+    }
+
+    /// The value of a `pub const NAME: u64 = a * b * c;` declaration.
+    fn u64_const(src: &str, name: &str) -> u64 {
+        let decl = format!("pub const {name}: u64 = ");
+        let start = src
+            .find(&decl)
+            .unwrap_or_else(|| panic!("{name} is declared"))
+            + decl.len();
+        let end = start + src[start..].find(';').expect("the declaration ends");
+        src[start..end]
+            .split('*')
+            .map(|part| {
+                part.trim()
+                    .replace('_', "")
+                    .parse::<u64>()
+                    .expect("a product of integer literals")
+            })
+            .product()
+    }
+
+    fn service(app: &str) -> &'static Service {
+        lookup(app).expect("the service is in the table")
+    }
+
+    /// Why: the table is a second copy of three daemons' constants, and the
+    /// silent failure mode of a second copy is exactly #6286 — a method the
+    /// daemon streams and the bridge's list omits leaves an MCP client waiting
+    /// for a frame that is never coming. Importing the crates would cost this
+    /// lean rlib the whole of trusty-memory, trusty-search and trusty-analyze,
+    /// so the equality is asserted against their sources instead.
+    /// What: reads each daemon's own declaration and compares it with the row
+    /// here — the streaming list for memory and search, the frame budget for
+    /// all three. A frame budget below the daemon's would turn a response the
+    /// daemon served into a `FrameTooLarge` on the way back.
+    /// Test: this test.
+    #[test]
+    fn the_table_matches_each_daemons_own_constants() {
+        if let Some(src) = sibling_source("trusty-memory/src/transport/uds.rs") {
+            assert_eq!(
+                string_array_const(&src, "STREAM_METHODS"),
+                service("memory").streaming_methods,
+                "trusty-memory's streaming methods drifted from this table"
+            );
+            assert_eq!(
+                u64_const(&src, "MAX_FRAME_BYTES"),
+                service("memory").max_frame_bytes,
+                "trusty-memory's frame budget drifted from this table"
+            );
+        }
+
+        if let Some(src) = sibling_source("trusty-search/src/service/rpc/streams.rs") {
+            assert_eq!(
+                str_const_literals(&src),
+                service("search").streaming_methods,
+                "trusty-search's streaming methods drifted from this table"
+            );
+        }
+        if let Some(src) = sibling_source("trusty-search/src/service/socket.rs") {
+            assert_eq!(
+                u64_const(&src, "MAX_FRAME_BYTES"),
+                service("search").max_frame_bytes,
+                "trusty-search's frame budget drifted from this table"
+            );
+        }
+
+        if let Some(src) = sibling_source("trusty-analyze/src/service/rpc.rs") {
+            assert_eq!(
+                u64_const(&src, "MAX_FRAME_BYTES"),
+                service("analyze").max_frame_bytes,
+                "trusty-analyze's frame budget drifted from this table"
+            );
+        }
+    }
+
+    /// Why: an MCP client config generated from a daemon's own name carries the
+    /// full `trusty-<name>`; a human types the short one. Both are unambiguous.
+    /// What: each row resolves from its app name and from that name without the
+    /// `trusty-` prefix, and resolves to the same row.
+    /// Test: this test.
+    #[test]
+    fn every_service_is_reachable_by_both_of_its_names() {
+        for row in SERVICES {
+            let long = lookup(row.app).expect("the app name resolves");
+            let short = lookup(short_name(row.app)).expect("the short name resolves");
+            assert_eq!(long.app, row.app);
+            assert_eq!(short.app, row.app);
+        }
+    }
+
+    /// Why: an unmatched service must reach the exit-2 arm, not a default.
+    /// What: names that are close to a real one, and the empty string, all miss.
+    /// Test: this test.
+    #[test]
+    fn an_unknown_service_resolves_to_nothing() {
+        for arg in [
+            "",
+            "trusty-",
+            "mem",
+            "trusty-mcp",
+            "trusty-review",
+            "MEMORY",
+        ] {
+            assert!(lookup(arg).is_none(), "{arg:?} must not resolve");
+        }
+    }
+
+    /// Why: Fail-Open Check — every wrong command line must name what is wrong.
+    /// What: no arguments produces a usage error mentioning the service.
+    /// Test: this test.
+    #[test]
+    fn no_arguments_is_a_usage_error() {
+        let Parsed::Usage(problem) = parse(std::iter::empty()) else {
+            panic!("an empty command line is a usage error");
+        };
+        assert!(problem.contains("service"), "{problem}");
+    }
+
+    /// Why: the message has to say which name was rejected and what was valid,
+    /// or the caller cannot fix their config from it.
+    /// What: the usage error quotes the rejected name and lists every service.
+    /// Test: this test.
+    #[test]
+    fn an_unknown_service_is_a_usage_error() {
+        let Parsed::Usage(problem) = parse(["review"]) else {
+            panic!("an unknown service is a usage error");
+        };
+        assert!(problem.contains("review"), "{problem}");
+        for name in service_names() {
+            assert!(problem.contains(name), "{problem} omits {name}");
+        }
+    }
+
+    /// Why: a silently-ignored flag is a config that looks applied and is not.
+    /// What: a second positional is refused and named.
+    /// Test: this test.
+    #[test]
+    fn a_second_argument_is_a_usage_error() {
+        let Parsed::Usage(problem) = parse(["memory", "--socket=/tmp/x.sock"]) else {
+            panic!("an extra argument is a usage error");
+        };
+        assert!(problem.contains("--socket=/tmp/x.sock"), "{problem}");
+    }
+
+    /// Why: `--help` is not a failure, so it must not take the exit-2 arm.
+    /// What: both spellings parse as help; a service still parses as serve.
+    /// Test: this test.
+    #[test]
+    fn help_is_recognised() {
+        assert!(matches!(parse(["-h"]), Parsed::Help));
+        assert!(matches!(parse(["--help"]), Parsed::Help));
+        assert!(matches!(parse(["memory"]), Parsed::Serve(_)));
+    }
+
+    /// Why: the usage text is the only place a caller learns what to type, and
+    /// a service added to the table without a row there is invisible.
+    /// What: every service appears under both spellings, and the no-spawn
+    /// contract is stated.
+    /// Test: this test.
+    #[test]
+    fn usage_names_every_service() {
+        let text = usage();
+        for row in SERVICES {
+            assert!(text.contains(row.app), "usage omits {}", row.app);
+            assert!(
+                text.contains(short_name(row.app)),
+                "usage omits {}",
+                short_name(row.app)
+            );
+        }
+        assert!(text.contains("does not start the"), "{text}");
+    }
+}

--- a/crates/trusty-mcp/tests/bridge_bin_cli.rs
+++ b/crates/trusty-mcp/tests/bridge_bin_cli.rs
@@ -1,0 +1,186 @@
+//! The `trusty-mcp <service>` binary, driven end to end (#6316).
+//!
+//! Why: the unit tests in `src/bin/trusty-mcp.rs` cover the service table as
+//! values. What they cannot cover is the two contracts that only exist once the
+//! process runs: stdout carries JSON-RPC frames and nothing else, and every
+//! failure arm produces something the caller can match on rather than silence.
+//! Both are Fail-Open Checks — a bridge that exits 0 with an empty stdout looks
+//! to an MCP client exactly like a bridge that is still thinking.
+//!
+//! What: spawns the built binary with a temp data directory, so
+//! `trusty_common::daemon_socket_path` resolves to a socket nothing is
+//! listening on and no daemon on this machine is touched. Each test writes at
+//! most one request, closes stdin, and reads the child to completion — nothing
+//! outlives the test.
+//!
+//! Test: this file.
+
+#![cfg(all(unix, feature = "daemon-bridge-json-rpc"))]
+
+use std::io::Write;
+use std::process::{Command, Output, Stdio};
+
+use serde_json::Value;
+
+/// Run the binary with `args`, an isolated data directory, and `stdin` piped in.
+///
+/// `TRUSTY_DATA_DIR_OVERRIDE` is what makes this hermetic on macOS, where
+/// `dirs::data_dir()` ignores `HOME` (see `trusty_common::data_dir`). Without
+/// it the resolver would find the real trusty-memory socket on the developer's
+/// machine and the dead-socket arm would depend on whether a daemon happened to
+/// be running.
+fn run(args: &[&str], stdin: &str) -> Output {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut child = Command::new(env!("CARGO_BIN_EXE_trusty-mcp"))
+        .args(args)
+        .env("TRUSTY_DATA_DIR_OVERRIDE", dir.path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn the bridge");
+
+    child
+        .stdin
+        .take()
+        .expect("stdin is piped")
+        .write_all(stdin.as_bytes())
+        .expect("write the request");
+
+    child.wait_with_output().expect("the child is reaped")
+}
+
+/// Why: Fail-Open Check, arm 1 — an unknown service must be an error the caller
+/// can act on, and must not corrupt a stdio channel a client may already be
+/// reading.
+/// What: exit 2, empty stdout, and a stderr that names both the rejected
+/// service and the ones that exist.
+/// Test: this test.
+#[test]
+fn an_unknown_service_exits_two_with_nothing_on_stdout() {
+    let out = run(&["review"], "");
+
+    assert_eq!(out.status.code(), Some(2), "an unknown service exits 2");
+    assert!(
+        out.stdout.is_empty(),
+        "stdout must stay clean: {:?}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("review"), "{stderr}");
+    assert!(stderr.contains("memory"), "{stderr}");
+    assert!(stderr.contains("search"), "{stderr}");
+    assert!(stderr.contains("analyze"), "{stderr}");
+}
+
+/// Why: a bare invocation is the most likely mistake, and the least useful
+/// outcome would be an empty exit 0.
+/// What: no argument exits 2 with the usage text on stderr.
+/// Test: this test.
+#[test]
+fn no_service_exits_two_with_the_usage_text() {
+    let out = run(&[], "");
+
+    assert_eq!(out.status.code(), Some(2));
+    assert!(out.stdout.is_empty());
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("Usage:"),
+        "the usage text is printed"
+    );
+}
+
+/// Why: `--help` is a question, not a failure — it must not take the exit-2
+/// arm, and it must not write to the JSON-RPC channel either.
+/// What: exit 0, usage on stderr, stdout empty.
+/// Test: this test.
+#[test]
+fn help_exits_zero_and_still_writes_nothing_to_stdout() {
+    let out = run(&["--help"], "");
+
+    assert_eq!(out.status.code(), Some(0));
+    assert!(out.stdout.is_empty(), "stdout is the JSON-RPC channel");
+    assert!(String::from_utf8_lossy(&out.stderr).contains("trusty-mcp <service>"));
+}
+
+/// Why: the arm this binary exists to get right (#6309). Nothing is listening
+/// on the resolved socket, and the client is waiting on an `initialize` it
+/// matches by id — an id-less answer, or no answer, is a hang.
+/// What: pipes one `initialize` request in, asserts stdout is exactly one
+/// JSON-RPC error frame carrying that request's id and naming the daemon, and
+/// that the process still exits 0 because stdin reached EOF.
+/// Test: this test.
+#[test]
+fn a_dead_socket_answers_with_a_matchable_error() {
+    let request = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#;
+    let out = run(&["memory"], &format!("{request}\n"));
+
+    let stdout = String::from_utf8(out.stdout).expect("stdout is UTF-8");
+    let frames: Vec<&str> = stdout.lines().filter(|l| !l.trim().is_empty()).collect();
+    assert_eq!(
+        frames.len(),
+        1,
+        "exactly one response per request: {stdout}"
+    );
+
+    let frame: Value = serde_json::from_str(frames[0]).expect("stdout carries a JSON-RPC frame");
+    assert_eq!(frame["jsonrpc"], "2.0");
+    assert_eq!(frame["id"], 1, "the error is matchable to the request");
+    assert!(frame.get("result").is_none(), "a failure is never a result");
+
+    let message = frame["error"]["message"]
+        .as_str()
+        .expect("the error names its cause");
+    assert!(message.contains("trusty-memory"), "{message}");
+    assert!(message.contains(".sock"), "{message}");
+
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "EOF on stdin is how an MCP server is told to exit"
+    );
+}
+
+/// Why: MCP §4.1 — replying to a notification puts a frame on the channel the
+/// client is not expecting, which desynchronises every response after it.
+/// What: a notification produces no frame at all, and the process still exits
+/// cleanly on EOF.
+/// Test: this test.
+#[test]
+fn a_notification_produces_no_frame() {
+    let out = run(
+        &["memory"],
+        "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}\n",
+    );
+
+    assert!(
+        out.stdout.is_empty(),
+        "a notification is answered with silence: {:?}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    assert_eq!(out.status.code(), Some(0));
+}
+
+/// Why: a streaming method must be refused before the socket is dialled, and
+/// the refusal must reach the client as an error rather than as a hang — the
+/// #6286 case, seen from outside the process.
+/// What: `memory.chat` wrapped in the `tools/call` envelope a real MCP client
+/// sends comes back as an `INVALID_REQUEST` naming the method.
+/// Test: this test.
+#[test]
+fn a_streaming_method_is_refused_by_the_binary() {
+    let request =
+        r#"{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"memory.chat"}}"#;
+    let out = run(&["memory"], &format!("{request}\n"));
+
+    let stdout = String::from_utf8(out.stdout).expect("stdout is UTF-8");
+    let frame: Value = serde_json::from_str(stdout.trim()).expect("one JSON-RPC frame");
+    assert_eq!(frame["id"], 9);
+    assert_eq!(frame["error"]["code"], -32600);
+    assert!(
+        frame["error"]["message"]
+            .as_str()
+            .is_some_and(|m| m.contains("memory.chat")),
+        "{frame}"
+    );
+}


### PR DESCRIPTION
## Outcome

Slice 4 of #6316, the last. A `trusty-mcp <service>` binary (`memory`/`search`/`analyze`, either spelling) behind the `daemon-bridge-json-rpc` feature. It resolves the socket through the one resolver, `trusty_common::daemon_socket_path`, and calls `run_stdio_bridge`; it never starts a daemon.

Refs #6316

## Changes

Binary added (`[[bin]]` with `required-features = ["daemon-bridge-json-rpc"]`); feature-gated so default builds stay free of trusty-common. Stdout carries JSON-RPC frames only — usage, `--help`, and every diagnostic go to stderr. Unknown service exits 2 with zero stdout bytes. Per-service streaming lists and frame budgets live in a `SERVICES` table whose drift test reads the sibling daemons' own constants and fails closed on a parse miss. trusty-mcp version: 0.1.3 → 0.1.4 (0.1.3 unpublished on main; crates.io holds 0.1.2).

## Risk

Low — isolated binary feature-gated behind `daemon-bridge-json-rpc`, no changes to existing code paths.

## Tests

Rung 3 with binary smoke run:

```
cargo fmt --check && cargo clippy -p trusty-mcp --all-features --all-targets -- -D warnings && cargo check -p trusty-mcp && cargo check --workspace   # exit 0
cargo test -p trusty-mcp --all-features --no-fail-fast    # lib 37, bin 8, bridge_bin_cli 6, daemon_bridge_json_rpc_uds 9, single_flight_exclusion 7 — all passed, 0 failed
bash scripts/check_semver.sh --crate trusty-mcp           # 0.1.2 -> 0.1.4, 196 pass, compared=1
bash scripts/check_changelog_fragment.sh && bash scripts/check_line_cap.sh && bash scripts/check_test_pointers.sh && bash scripts/check_sld.sh && bash scripts/check_rustdoc_links.sh   # OK
cargo tree -p trusty-mcp -e features -i trusty-common     # no match without the feature; resolves with it
```

Smoke against live trusty-memory daemon (found via resolver, nothing started): `initialize` piped into `trusty-mcp memory` returned `{"jsonrpc":"2.0","id":1,"result":{"capabilities":{"tools":{}},"protocolVersion":"2024-11-05","serverInfo":{"name":"trusty-memory","version":"0.25.7"}}}`, exit 0 on EOF. `trusty-mcp review` exits 2 with no stdout. Fail-Open Check: dead socket answers with request id; notification produces no frame; streaming method refused with error — all driven through real child binary in `tests/bridge_bin_cli.rs`.

## Baseline

None — new code only.

## Docs

Changelog fragment present. Rustdoc links checked.

## Review

Code-critic: APPROVE (one LOW for parent: trusty-search const extractor matches by order, not name). Pre-push credential scan over `git diff origin/main...HEAD`: PASS, 6 files.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
