### PR TITLE
feat(tga): inspect schema/attest commands and a migration-derived schema doc (Refs #5218)

### DIFF
--- a/crates/trusty-git-analytics/changelog.d/5218-database-schema-doc.md
+++ b/crates/trusty-git-analytics/changelog.d/5218-database-schema-doc.md
@@ -1,0 +1,14 @@
+Documentation
+- `docs/trusty-git-analytics/requirements/database-schema.md` is rebuilt from
+  the migrations. The migration-history table stopped at 0013 and now runs
+  through 0027, one row per migration naming its file; two of the rows it did
+  have were wrong (`0012` is `pull_requests_repository`, not
+  `repository_analysis_status`, and `0013` puts `complexity` on
+  `classifications`, not on `commits`). Thirteen tables and all four DORA views
+  had no section at all. Eight existing sections described columns the shipped
+  schema does not have — `work_items` still listed the `provider` /
+  `external_id` / `work_item_type` / `state` shape migration 0005 never used,
+  `linear_issues` named `issue_id` instead of `identifier`, `commit_work_items`
+  and `classification_overrides` described integer keys where both use composite
+  text ones, `repository_analysis_status` named four columns it does not have,
+  and `pull_requests` listed a `merge_commit_sha` that has never existed.

--- a/crates/trusty-git-analytics/changelog.d/5218-inspect-attest.md
+++ b/crates/trusty-git-analytics/changelog.d/5218-inspect-attest.md
@@ -1,0 +1,32 @@
+Added
+
+- `tga inspect schema` prints every table, view, and column the database in
+  front of you actually holds, with row counts and the free-text columns marked
+  (#5218). It reads the file rather than the migration set, because a database
+  collected by an older `tga` is missing later tables and nothing in
+  `src/core/db/sql/` says so.
+- `tga inspect attest` states the data-handling claim — "tga's database stores
+  no file content, diffs, patches, hunks, or blobs" — and prints the live
+  evidence for it: the scan that found no BLOB and no diff-named column, and a
+  per-column reading of every free-text column in that database. The claim is
+  never "contains no code", because a pasted snippet in a commit message is
+  stored verbatim; the caveat saying so travels with it, and
+  `claim_never_says_no_code` fails if a later edit loosens either. DOC-67 §10
+  quotes these two strings rather than paraphrasing them.
+- `work_items.raw_json` is read at runtime rather than cited from
+  `0005_work_items.sql`. Today's writer serializes a struct with no description
+  field, but that is a property of the writer, not of the column.
+- Both subcommands open the database read-only and refuse a missing path, a
+  directory, or a non-SQLite file, each naming the cause. The shared
+  `Database::open` would have CREATED and migrated a missing file, so an
+  inspection routed through it would print a complete, empty, freshly-minted
+  schema and exit 0 for a database the caller cannot read. `attest` also exits
+  non-zero when its verdict is `findings`, so a hand-over script can gate on it.
+- Two standing guards replace one-time reads. `every_text_column_is_classified`
+  fails when a migration adds a `TEXT` column that is in none of the three
+  inventories in `core::inspect::text_columns`, so the free-text list cannot go
+  stale silently. `diff_for_commit_callers_match_the_attestation` re-derives the
+  non-test callers of `collect::git::diff::diff_for_commit` from the source tree
+  and compares them against the pinned list — #5218 asked for "zero callers",
+  which #5465 has since made false, so the enforceable property is now "these
+  callers and no others".

--- a/crates/trusty-git-analytics/changelog.d/5218-inspect-attest.md
+++ b/crates/trusty-git-analytics/changelog.d/5218-inspect-attest.md
@@ -15,7 +15,14 @@ Added
   quotes these two strings rather than paraphrasing them.
 - `work_items.raw_json` is read at runtime rather than cited from
   `0005_work_items.sql`. Today's writer serializes a struct with no description
-  field, but that is a property of the writer, not of the column.
+  field, but that is a property of the writer, not of the column. The diff probe
+  unescapes JSON line breaks before matching, because a diff serialized into
+  that column carries the two-character `\n` escape rather than a newline byte —
+  four of the five markers anchor on a real line start and would otherwise miss
+  the one column the attestation most needs to read. The probe reads plain text
+  and that escaping; a base64-encoded or compressed diff reads as opaque text
+  and is not counted, which is part of why the "not a claim that the database
+  contains no code" caveat is not optional.
 - Both subcommands open the database read-only and refuse a missing path, a
   directory, or a non-SQLite file, each naming the cause. The shared
   `Database::open` would have CREATED and migrated a missing file, so an

--- a/crates/trusty-git-analytics/help.yaml
+++ b/crates/trusty-git-analytics/help.yaml
@@ -36,6 +36,15 @@ commands:
     examples:
       - cmd: tga audit
       - cmd: tga audit --org acme --client "Acme Holdings" --weeks 26
+  inspect:
+    description: Show the live database schema, or attest what it holds (no file content, diffs, patches, hunks, or blobs)
+    flags:
+      - name: json
+        description: Emit JSON instead of the human-readable report
+    examples:
+      - cmd: tga inspect schema
+      - cmd: tga inspect attest
+      - cmd: tga inspect attest --json
   analyze:
     description: Run the full pipeline (collect → classify → report)
     flags:

--- a/crates/trusty-git-analytics/src/commands/inspect.rs
+++ b/crates/trusty-git-analytics/src/commands/inspect.rs
@@ -1,0 +1,187 @@
+//! `tga inspect` — show the live database schema, or attest what it holds.
+//!
+//! Why: #5218 — a reviewer asked what tga retained has, until now, had to read
+//! 27 migration files and trust that the operator's database matches them.
+//! What: two subcommands over one read-only connection — `schema` prints every
+//! table, view, and column with the free-text ones marked, and `attest` prints
+//! the data-handling claim together with the live evidence for it.
+//! Test: `core::inspect::tests`, plus `tests::inspect_errors_on_a_missing_database`
+//! below for the CLI's own fail-open arm.
+
+use std::path::Path;
+
+use clap::{Args, Subcommand};
+
+use tga::core::inspect::{attest, render, schema};
+
+/// Arguments for `tga inspect`.
+#[derive(Args, Debug)]
+pub struct InspectArgs {
+    /// What to inspect.
+    #[command(subcommand)]
+    pub what: InspectSubcommand,
+}
+
+/// The two things worth inspecting.
+#[derive(Subcommand, Debug)]
+pub enum InspectSubcommand {
+    /// Every table, view, and column the database actually holds.
+    Schema(InspectFormatArgs),
+    /// The data-handling attestation, with the live evidence behind it.
+    Attest(InspectFormatArgs),
+}
+
+/// Output-format flag shared by both subcommands.
+#[derive(Args, Debug, Default)]
+pub struct InspectFormatArgs {
+    /// Emit JSON instead of the human-readable report.
+    #[arg(long)]
+    pub json: bool,
+}
+
+/// Run `tga inspect`.
+///
+/// Why: dispatched from `main` BEFORE the shared `Database::open`, because that
+/// call creates and migrates a missing file — an inspection built on it would
+/// print a complete, empty, freshly-minted schema and exit 0 for a database the
+/// caller cannot actually read (#5218).
+/// What: opens `db_path` read-only through
+/// [`tga::core::inspect::open_read_only`], which names the cause for a missing
+/// path, a directory, or a non-SQLite file, then renders the requested report to
+/// stdout.
+/// Test: `tests::inspect_errors_on_a_missing_database`,
+/// `tests::attest_exits_non_zero_on_findings`,
+/// `core::inspect::tests::open_read_only_names_a_missing_database`.
+///
+/// # Errors
+///
+/// Propagates the open failure, or any SQLite error raised while reading the
+/// schema. Never returns `Ok` having printed an empty report for a database it
+/// could not read. `attest` additionally errors, after printing its report, when
+/// the verdict is [`attest::Verdict::Findings`].
+pub fn run(db_path: &Path, args: InspectArgs) -> anyhow::Result<()> {
+    let conn = tga::core::inspect::open_read_only(db_path)?;
+    let snapshot = schema::snapshot(&conn)?;
+
+    match args.what {
+        InspectSubcommand::Schema(fmt) => {
+            if fmt.json {
+                println!("{}", serde_json::to_string_pretty(&snapshot)?);
+            } else {
+                print!("{}", render::schema_report(&snapshot));
+            }
+        }
+        InspectSubcommand::Attest(fmt) => {
+            let attestation = attest::attest(&conn, &snapshot)?;
+            if fmt.json {
+                println!("{}", serde_json::to_string_pretty(&attestation)?);
+            } else {
+                print!("{}", render::attestation_report(&attestation));
+            }
+            // #5218: the report is on stdout either way; a findings verdict also
+            // exits non-zero so a release or hand-over script can gate on it
+            // instead of grepping the text it just printed.
+            if attestation.verdict == attest::Verdict::Findings {
+                let flagged: i64 = attestation
+                    .scanned_columns
+                    .iter()
+                    .map(|s| s.diff_shaped_rows)
+                    .sum();
+                anyhow::bail!(
+                    "attestation findings: {} content-bearing column(s), {flagged} row(s) \
+                     carrying diff-shaped text — the claim above does not hold unreviewed",
+                    attestation.content_columns.len()
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why: the command layer is where the fail-open would actually reach a
+    /// user, so the arm is pinned here as well as in the library.
+    /// What: runs both subcommands against a path that does not exist and
+    /// asserts each errors, names the path, and creates nothing.
+    /// Test: this test itself.
+    #[test]
+    fn inspect_errors_on_a_missing_database() {
+        let mut path = std::env::temp_dir();
+        path.push(format!("tga-inspect-cmd-{}-absent.db", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+
+        for what in [
+            InspectSubcommand::Schema(InspectFormatArgs::default()),
+            InspectSubcommand::Attest(InspectFormatArgs::default()),
+        ] {
+            let err = run(&path, InspectArgs { what }).expect_err("must not succeed");
+            let text = err.to_string();
+            assert!(
+                text.contains("no database at"),
+                "the error must name the cause: {text}"
+            );
+            assert!(
+                text.contains("absent.db"),
+                "the error must name the path: {text}"
+            );
+        }
+        assert!(!path.exists(), "inspection must not create a database");
+    }
+
+    /// Why: an attestation that exits 0 on findings is a gate nothing can hang
+    /// a release script on, and a report a reader skims to the wrong verdict.
+    /// What: seeds a diff into `commits.message`, runs `inspect attest`, and
+    /// asserts the command errors while the clean database beside it succeeds.
+    /// Test: this test itself.
+    #[test]
+    fn attest_exits_non_zero_on_findings() {
+        let mut dir = std::env::temp_dir();
+        dir.push(format!("tga-inspect-verdict-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let path = dir.join("tga.db");
+
+        {
+            let db = tga::core::db::Database::open(&path).expect("migrate");
+            db.connection()
+                .execute(
+                    "INSERT INTO commits (sha, author_name, author_email, timestamp, message, repository) \
+                     VALUES ('c1', 'Ada', 'ada@example.com', '2026-01-01T00:00:00Z', 'ok', 'r')",
+                    [],
+                )
+                .expect("clean commit");
+        }
+        run(
+            &path,
+            InspectArgs {
+                what: InspectSubcommand::Attest(InspectFormatArgs::default()),
+            },
+        )
+        .expect("a clean database must attest cleanly");
+
+        {
+            let db = tga::core::db::Database::open(&path).expect("reopen");
+            db.connection()
+                .execute(
+                    "UPDATE commits SET message = ?1 WHERE sha = 'c1'",
+                    ["fix\n\ndiff --git a/x b/x\n@@ -1 +1 @@\n-a\n+b\n"],
+                )
+                .expect("paste a diff");
+        }
+        let err = run(
+            &path,
+            InspectArgs {
+                what: InspectSubcommand::Attest(InspectFormatArgs::default()),
+            },
+        )
+        .expect_err("a diff in a free-text column must fail the gate");
+        assert!(
+            err.to_string().contains("diff-shaped text"),
+            "the error must name what was found: {err}"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/crates/trusty-git-analytics/src/commands/mod.rs
+++ b/crates/trusty-git-analytics/src/commands/mod.rs
@@ -15,6 +15,8 @@ pub mod date_range;
 pub mod deployments;
 pub mod dora;
 pub mod incidents;
+// #5218: read-only database inspection and the data-handling attestation.
+pub mod inspect;
 pub mod install;
 // #5216: the non-interactive install path and the config emission both front
 // ends share, split out to keep `install.rs` under the SLOC cap.

--- a/crates/trusty-git-analytics/src/core/inspect/attest.rs
+++ b/crates/trusty-git-analytics/src/core/inspect/attest.rs
@@ -1,0 +1,297 @@
+//! The data-handling attestation `tga inspect attest` prints (#5218).
+//!
+//! Why: the question a counterparty asks before granting repository access is
+//! what the tool kept. The answer has to be checkable, so every part of it here
+//! is either a live read of the operator's own database or a claim a test
+//! re-checks on every run — never a sentence someone wrote once after reading
+//! the migration files.
+//! What: [`NO_CONTENT_CLAIM`] and [`NOT_A_NO_CODE_CLAIM`] are the exact wording
+//! DOC-67 §10 quotes. [`attest`] pairs them with a scan for content-bearing
+//! columns, a runtime read of every free-text column, and the pinned inventory
+//! of [`DIFF_TEXT_CONSUMERS`].
+//! Test: `core::inspect::tests`.
+
+use rusqlite::Connection;
+use serde::Serialize;
+
+use crate::core::errors::{Result, TgaError};
+
+use super::schema::{ObjectKind, SchemaSnapshot};
+use super::text_columns::TextClass;
+
+/// The claim tga's schema supports, in the wording a report may quote verbatim.
+///
+/// Why: #5218 — every looser paraphrase that has been tried ("contains no
+/// code") is false, because a commit message can carry a pasted snippet. This
+/// sentence is a claim about what the schema has columns FOR, which is exactly
+/// what the scan below can verify.
+/// Test: `core::inspect::tests::claim_never_says_no_code`.
+pub const NO_CONTENT_CLAIM: &str =
+    "tga's database stores no file content, diffs, patches, hunks, or blobs.";
+
+/// The caveat that must travel with [`NO_CONTENT_CLAIM`].
+///
+/// Why: quoting the claim alone recreates the overreach it exists to prevent.
+/// Test: `core::inspect::tests::claim_never_says_no_code`.
+pub const NOT_A_NO_CODE_CLAIM: &str =
+    "This is not a claim that the database contains no code. Free-text columns hold text a \
+     human or an upstream system typed, so a pasted snippet in a commit message, a ticket \
+     title, or an override note is stored verbatim. Those columns are named below and scanned \
+     in this database, not assumed clean from the schema.";
+
+/// Column-name substrings that would indicate a content-bearing column.
+///
+/// A hit is a finding, not proof: the reviewer sees the column name and decides.
+const CONTENT_NAME_TOKENS: &[&str] = &[
+    "blob",
+    "diff",
+    "patch",
+    "hunk",
+    "content",
+    "payload",
+    "snippet",
+    "file_text",
+    "source_code",
+];
+
+/// A caller of `collect::git::diff::diff_for_commit`, and what it does with the
+/// diff text.
+#[derive(Debug, Clone, Serialize)]
+#[non_exhaustive]
+pub struct DiffConsumer {
+    /// Path to the calling file, relative to the crate root.
+    pub source_path: &'static str,
+    /// What that caller does with the returned diff.
+    pub disposition: &'static str,
+}
+
+/// Every non-test caller of `diff_for_commit`, pinned.
+///
+/// Why: #5218 asked for an enforced check that this function has no non-test
+/// caller, because a diff reaching a persistence path would break the claim
+/// above silently. #5465 then wired the profile diff sampler onto it, so the
+/// enforceable property is no longer "zero callers" — it is "these callers and
+/// no others". `tests::diff_for_commit_callers_match_the_attestation` re-derives
+/// the set from the source tree on every `cargo test -p tga` and fails on a
+/// caller nobody added here.
+/// Test: `core::inspect::tests::diff_for_commit_callers_match_the_attestation`.
+pub const DIFF_TEXT_CONSUMERS: &[DiffConsumer] = &[DiffConsumer {
+    source_path: "src/profile/diff_sampler/sampler.rs",
+    disposition: "holds the diff in memory for the profile period-review prompt \
+                  (`profile::batch_reviewer`) and never binds it to a SQL statement",
+}];
+
+/// The files that define and re-export `diff_for_commit`, which the caller
+/// check must not count as callers.
+pub const DIFF_API_SITES: &[&str] = &["src/collect/git/diff.rs", "src/collect/git/mod.rs"];
+
+/// A column whose name or declared type suggests it carries file content.
+#[derive(Debug, Clone, Serialize)]
+#[non_exhaustive]
+pub struct ContentColumnFinding {
+    /// Owning table.
+    pub table: String,
+    /// Column name.
+    pub column: String,
+    /// Declared type.
+    pub declared_type: String,
+    /// Why the scan flagged it.
+    pub reason: String,
+}
+
+/// What one scanned column actually holds in this database.
+#[derive(Debug, Clone, Serialize)]
+#[non_exhaustive]
+pub struct ColumnContentScan {
+    /// Owning table.
+    pub table: String,
+    /// Column name.
+    pub column: String,
+    /// Why the column is scanned rather than trusted.
+    pub class: TextClass,
+    /// Rows in the table.
+    pub rows: i64,
+    /// Rows whose value is not NULL and not empty.
+    pub populated: i64,
+    /// Longest value in bytes, or 0 when the column is empty everywhere.
+    pub max_len: i64,
+    /// Rows carrying a unified-diff marker (`diff --git`, a hunk header, or a
+    /// `---`/`+++` file header). Non-zero is a finding a reviewer must see.
+    pub diff_shaped_rows: i64,
+}
+
+/// Whether the scan found anything a reviewer must look at.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Verdict {
+    /// No content-bearing column and no diff-shaped value in any scanned column.
+    Consistent,
+    /// At least one finding — the claim above does not hold unreviewed.
+    Findings,
+}
+
+/// The full attestation for one database.
+#[derive(Debug, Clone, Serialize)]
+#[non_exhaustive]
+pub struct Attestation {
+    /// [`NO_CONTENT_CLAIM`].
+    pub claim: &'static str,
+    /// [`NOT_A_NO_CODE_CLAIM`].
+    pub caveat: &'static str,
+    /// Highest applied migration version, or `None` when absent.
+    pub schema_version: Option<i64>,
+    /// Tables inspected (views excluded — they project the same columns).
+    pub tables_scanned: usize,
+    /// Columns whose name or type suggests file content. Empty is the pass.
+    pub content_columns: Vec<ContentColumnFinding>,
+    /// Live reading of every free-text, embedded-payload, and unclassified
+    /// column.
+    pub scanned_columns: Vec<ColumnContentScan>,
+    /// The pinned non-test callers of `diff_for_commit`.
+    pub diff_text_consumers: &'static [DiffConsumer],
+    /// Overall result.
+    pub verdict: Verdict,
+}
+
+/// Build the attestation for an open, read-only connection.
+///
+/// Why: see the module docs — the value of this over reading `src/core/db/sql/`
+/// is that it reports the operator's rows, not the binary's intentions.
+/// What: takes the already-read `snapshot`, flags any column whose name or
+/// declared type is content-shaped, then reads counts, maximum length, and a
+/// unified-diff marker probe out of every column [`TextClass::is_scanned`]
+/// selects.
+/// Test: `core::inspect::tests::attest_on_a_fresh_database_is_consistent`,
+/// `core::inspect::tests::attest_flags_a_diff_pasted_into_a_commit_message`.
+///
+/// # Errors
+///
+/// Returns [`TgaError::DbError`] if a scan query fails.
+pub fn attest(conn: &Connection, snapshot: &SchemaSnapshot) -> Result<Attestation> {
+    let mut content_columns = Vec::new();
+    let mut scanned_columns = Vec::new();
+    let mut tables_scanned = 0_usize;
+
+    for table in snapshot
+        .objects
+        .iter()
+        .filter(|o| o.kind == ObjectKind::Table)
+    {
+        tables_scanned += 1;
+        for column in &table.columns {
+            if let Some(reason) = content_reason(&column.name, &column.declared_type) {
+                content_columns.push(ContentColumnFinding {
+                    table: table.name.clone(),
+                    column: column.name.clone(),
+                    declared_type: column.declared_type.clone(),
+                    reason,
+                });
+            }
+            let Some(class) = column.text_class else {
+                continue;
+            };
+            if !class.is_scanned() {
+                continue;
+            }
+            scanned_columns.push(scan_column(
+                conn,
+                &table.name,
+                &column.name,
+                class,
+                table.row_count.unwrap_or(0),
+            )?);
+        }
+    }
+
+    let verdict =
+        if content_columns.is_empty() && scanned_columns.iter().all(|s| s.diff_shaped_rows == 0) {
+            Verdict::Consistent
+        } else {
+            Verdict::Findings
+        };
+
+    Ok(Attestation {
+        claim: NO_CONTENT_CLAIM,
+        caveat: NOT_A_NO_CODE_CLAIM,
+        schema_version: snapshot.schema_version,
+        tables_scanned,
+        content_columns,
+        scanned_columns,
+        diff_text_consumers: DIFF_TEXT_CONSUMERS,
+        verdict,
+    })
+}
+
+/// Why a column looks content-bearing, or `None` when it does not.
+fn content_reason(name: &str, declared_type: &str) -> Option<String> {
+    if declared_type.eq_ignore_ascii_case("BLOB") {
+        return Some("declared BLOB".to_string());
+    }
+    let lower = name.to_ascii_lowercase();
+    CONTENT_NAME_TOKENS
+        .iter()
+        .find(|token| lower.contains(*token))
+        .map(|token| format!("column name contains \"{token}\""))
+}
+
+/// Markers that identify a unified diff pasted into a text column.
+///
+/// Each is anchored so an ordinary sentence cannot match: a hunk header and the
+/// two file headers must start a line, and `diff --git` is distinctive on its
+/// own. `char(10)` is the newline SQLite has no escape for.
+const DIFF_MARKER_PREDICATES: &[&str] = &[
+    "LIKE '%diff --git %'",
+    "LIKE '%' || char(10) || '@@ %'",
+    "LIKE '@@ %'",
+    "LIKE '%' || char(10) || '--- a/%'",
+    "LIKE '%' || char(10) || '+++ b/%'",
+];
+
+/// Read one column's live counts and diff-marker hits.
+fn scan_column(
+    conn: &Connection,
+    table: &str,
+    column: &str,
+    class: TextClass,
+    rows: i64,
+) -> Result<ColumnContentScan> {
+    // Both identifiers came from `sqlite_master` / `PRAGMA table_info` on this
+    // same connection, never from caller input; quoting keeps an exotic
+    // identifier from changing the statement's shape all the same.
+    let t = table.replace('"', "\"\"");
+    let c = column.replace('"', "\"\"");
+
+    let (populated, max_len): (i64, i64) = conn
+        .query_row(
+            &format!(
+                "SELECT COUNT(\"{c}\"), COALESCE(MAX(LENGTH(\"{c}\")), 0) \
+                 FROM \"{t}\" WHERE \"{c}\" IS NOT NULL AND \"{c}\" <> ''"
+            ),
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .map_err(TgaError::from)?;
+
+    let predicate = DIFF_MARKER_PREDICATES
+        .iter()
+        .map(|p| format!("\"{c}\" {p}"))
+        .collect::<Vec<_>>()
+        .join(" OR ");
+    let diff_shaped_rows: i64 = conn
+        .query_row(
+            &format!("SELECT COUNT(*) FROM \"{t}\" WHERE {predicate}"),
+            [],
+            |row| row.get(0),
+        )
+        .map_err(TgaError::from)?;
+
+    Ok(ColumnContentScan {
+        table: table.to_string(),
+        column: column.to_string(),
+        class,
+        rows,
+        populated,
+        max_len,
+        diff_shaped_rows,
+    })
+}

--- a/crates/trusty-git-analytics/src/core/inspect/attest.rs
+++ b/crates/trusty-git-analytics/src/core/inspect/attest.rs
@@ -9,6 +9,13 @@
 //! DOC-67 §10 quotes. [`attest`] pairs them with a scan for content-bearing
 //! columns, a runtime read of every free-text column, and the pinned inventory
 //! of [`DIFF_TEXT_CONSUMERS`].
+//!
+//! What the diff probe reaches: plain text, and the common text transforms that
+//! carry a diff into a text column — today, JSON escaping of line breaks (see
+//! `unescaped_newlines`). It is a detector, not a decision procedure. A diff
+//! that arrives base64-encoded, compressed, or otherwise obfuscated reads as
+//! opaque text and is not counted, which is one of the reasons
+//! [`NOT_A_NO_CODE_CLAIM`] travels with the claim rather than being optional.
 //! Test: `core::inspect::tests`.
 
 use rusqlite::Connection;
@@ -238,7 +245,8 @@ fn content_reason(name: &str, declared_type: &str) -> Option<String> {
 ///
 /// Each is anchored so an ordinary sentence cannot match: a hunk header and the
 /// two file headers must start a line, and `diff --git` is distinctive on its
-/// own. `char(10)` is the newline SQLite has no escape for.
+/// own. `char(10)` is the newline SQLite has no escape for. Every one is
+/// matched against [`unescaped_newlines`], not against the raw column.
 const DIFF_MARKER_PREDICATES: &[&str] = &[
     "LIKE '%diff --git %'",
     "LIKE '%' || char(10) || '@@ %'",
@@ -246,6 +254,27 @@ const DIFF_MARKER_PREDICATES: &[&str] = &[
     "LIKE '%' || char(10) || '--- a/%'",
     "LIKE '%' || char(10) || '+++ b/%'",
 ];
+
+/// A SQL expression for `column` with JSON-escaped line breaks turned back into
+/// real newline bytes.
+///
+/// Why: #5218 — four of the five markers above anchor on a newline BYTE, and a
+/// diff serialized into a JSON column never has one. `work_items.raw_json` is
+/// the column the attestation most needs to read, and every marker except
+/// `diff --git ` silently missed it: a diff stored as `{"d":"--- a/x\n+++ b/x"}`
+/// carries the two-character escape, so the scan reported zero and the
+/// attestation said "consistent".
+/// What: rewrites `\r\n` then `\n` — as `char(92)`, the backslash, followed by
+/// `char(114)`/`char(110)` — into `char(10)`, so the anchored markers see line
+/// starts. The longer sequence is replaced first, or its trailing `\n` would be
+/// consumed and leave a stray `\r`.
+/// Test: `core::inspect::tests::attest_flags_a_diff_pasted_into_a_commit_message`,
+/// `core::inspect::tests::diff_probe_normalises_json_escaped_newlines`.
+fn unescaped_newlines(column: &str) -> String {
+    let crlf = "char(92) || char(114) || char(92) || char(110)";
+    let lf = "char(92) || char(110)";
+    format!("REPLACE(REPLACE(\"{column}\", {crlf}, char(10)), {lf}, char(10))")
+}
 
 /// Read one column's live counts and diff-marker hits.
 fn scan_column(
@@ -272,9 +301,12 @@ fn scan_column(
         )
         .map_err(TgaError::from)?;
 
+    // #5218: match the unescaped form, so a diff serialized into a JSON column
+    // is seen. Computed once and reused across the five markers.
+    let scanned = unescaped_newlines(&c);
     let predicate = DIFF_MARKER_PREDICATES
         .iter()
-        .map(|p| format!("\"{c}\" {p}"))
+        .map(|p| format!("{scanned} {p}"))
         .collect::<Vec<_>>()
         .join(" OR ");
     let diff_shaped_rows: i64 = conn

--- a/crates/trusty-git-analytics/src/core/inspect/mod.rs
+++ b/crates/trusty-git-analytics/src/core/inspect/mod.rs
@@ -1,0 +1,112 @@
+//! Database inspection and data-handling attestation (#5218).
+//!
+//! Why: a counterparty granting repository access asks what `tga` retained
+//! before they grant it. Answering from the migration files is not evidence —
+//! it describes the schema the binary would create, not the rows the operator's
+//! database actually holds. DOC-67 §10 defers to this module for the exact
+//! attestation language an AUDIT report may quote.
+//! What: [`schema`] reads the live schema through `sqlite_master` and
+//! `PRAGMA table_info`; [`attest`] turns that reading plus a runtime scan of
+//! the free-text columns into an [`attest::Attestation`]; [`render`] formats
+//! either one for a terminal. [`open_read_only`] is the entry point both use,
+//! and it never creates, migrates, or writes to the file it opens.
+//! Test: `core::inspect::tests`.
+
+pub mod attest;
+pub mod render;
+pub mod schema;
+pub mod text_columns;
+
+#[cfg(test)]
+mod tests;
+
+use std::path::{Path, PathBuf};
+
+use rusqlite::{Connection, OpenFlags};
+
+use crate::core::config::expand_path;
+use crate::core::errors::{Result, TgaError};
+
+/// Open `path` read-only, refusing anything that is not an existing SQLite
+/// database.
+///
+/// Why: #5218 — every other entry point in this crate goes through
+/// `Database::open`, which CREATES the file and runs all migrations when it is
+/// missing. An inspection command on that path would report a complete, empty,
+/// freshly-minted schema and exit 0, telling a reviewer that a database they
+/// cannot actually read holds nothing. Each arm below therefore names the
+/// cause and fails rather than manufacturing a subject to inspect.
+/// What: rejects a missing path, a directory, and a file whose first page is
+/// not the SQLite header, then opens with [`OpenFlags::SQLITE_OPEN_READ_ONLY`]
+/// so an inspection can never migrate or otherwise alter the operator's file.
+/// Test: `tests::open_read_only_names_a_missing_database`,
+/// `tests::open_read_only_names_a_directory`,
+/// `tests::open_read_only_names_a_non_sqlite_file`,
+/// `tests::open_read_only_does_not_migrate`.
+///
+/// # Errors
+///
+/// - [`TgaError::NotFound`] when `path` does not exist.
+/// - [`TgaError::ValidationError`] when `path` is a directory or is not a
+///   SQLite database file.
+/// - [`TgaError::IoError`] when the file exists but cannot be read.
+/// - [`TgaError::DbError`] when SQLite itself refuses the open.
+pub fn open_read_only(path: &Path) -> Result<Connection> {
+    let resolved: PathBuf = expand_path(path);
+
+    if !resolved.exists() {
+        return Err(TgaError::NotFound(format!(
+            "no database at {} — run `tga collect` first, or point --database at an existing tga.db",
+            resolved.display()
+        )));
+    }
+    if resolved.is_dir() {
+        return Err(TgaError::ValidationError(format!(
+            "{} is a directory, not a tga database file",
+            resolved.display()
+        )));
+    }
+
+    // Reading the header also surfaces a permission error as an I/O error
+    // naming the path, rather than SQLite's opaque "unable to open database
+    // file".
+    let header = read_header(&resolved)?;
+    if !header.starts_with(SQLITE_MAGIC) {
+        return Err(TgaError::ValidationError(format!(
+            "{} is not a SQLite database (expected the \"SQLite format 3\" header, \
+             found {} byte(s) of other content)",
+            resolved.display(),
+            header.len()
+        )));
+    }
+
+    Connection::open_with_flags(
+        &resolved,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_URI,
+    )
+    .map_err(TgaError::from)
+}
+
+/// The 16-byte magic string every SQLite database file begins with.
+const SQLITE_MAGIC: &[u8] = b"SQLite format 3\0";
+
+/// Read up to the first 16 bytes of `path`, propagating any I/O failure.
+fn read_header(path: &Path) -> Result<Vec<u8>> {
+    use std::io::Read;
+
+    let mut file = std::fs::File::open(path).map_err(|e| {
+        TgaError::IoError(std::io::Error::new(
+            e.kind(),
+            format!("cannot read {}: {e}", path.display()),
+        ))
+    })?;
+    let mut buf = vec![0_u8; SQLITE_MAGIC.len()];
+    let read = file.read(&mut buf).map_err(|e| {
+        TgaError::IoError(std::io::Error::new(
+            e.kind(),
+            format!("cannot read {}: {e}", path.display()),
+        ))
+    })?;
+    buf.truncate(read);
+    Ok(buf)
+}

--- a/crates/trusty-git-analytics/src/core/inspect/render.rs
+++ b/crates/trusty-git-analytics/src/core/inspect/render.rs
@@ -1,0 +1,201 @@
+//! Terminal rendering for the schema snapshot and the attestation.
+//!
+//! Why: #5218's first closure condition is that a reviewer can SEE every table
+//! and column, with the free-text ones called out. A JSON dump satisfies a
+//! downstream tool; a person reading it in a terminal needs the layout.
+//! What: [`schema_report`] and [`attestation_report`] each return one `String`
+//! the command prints. Neither writes to stdout itself, so both are directly
+//! assertable.
+//! Test: `core::inspect::tests::schema_report_marks_free_text_columns`,
+//! `core::inspect::tests::attestation_report_states_the_claim_and_the_caveat`.
+
+use std::fmt::Write as _;
+
+use super::attest::{Attestation, Verdict};
+use super::schema::{ObjectKind, SchemaSnapshot};
+use super::text_columns::TextClass;
+
+/// Short marker printed beside a `TEXT` column's name.
+fn class_marker(class: Option<TextClass>) -> &'static str {
+    match class {
+        Some(TextClass::FreeText) => "  ← FREE TEXT",
+        Some(TextClass::EmbeddedPayload) => "  ← EMBEDDED PAYLOAD",
+        Some(TextClass::Unclassified) => "  ← UNCLASSIFIED TEXT",
+        Some(TextClass::Constrained) | None => "",
+    }
+}
+
+/// Render the whole live schema: every table, every column, every row count.
+///
+/// Why: this is the artefact a reviewer reads; the free-text markers are what
+/// stop it being a wall of columns with the risky ones buried.
+/// What: tables first with their counts, then views, then a trailing summary of
+/// the free-text and embedded-payload columns so the reviewer does not have to
+/// scan back through the table listing to collect them.
+/// Test: `core::inspect::tests::schema_report_marks_free_text_columns`.
+pub fn schema_report(snapshot: &SchemaSnapshot) -> String {
+    let mut out = String::new();
+    let version = snapshot.schema_version.map_or_else(
+        || "unknown (no schema_migrations table)".to_string(),
+        |v| v.to_string(),
+    );
+    let _ = writeln!(out, "tga database schema — migration version {version}");
+    let _ = writeln!(out);
+
+    for object in &snapshot.objects {
+        match object.kind {
+            ObjectKind::Table => {
+                let rows = object.row_count.unwrap_or(0);
+                let _ = writeln!(
+                    out,
+                    "TABLE {} ({} column(s), {rows} row(s))",
+                    object.name,
+                    object.columns.len()
+                );
+            }
+            ObjectKind::View => {
+                let _ = writeln!(
+                    out,
+                    "VIEW  {} ({} column(s))",
+                    object.name,
+                    object.columns.len()
+                );
+            }
+        }
+        for column in &object.columns {
+            let declared = if column.declared_type.is_empty() {
+                "(untyped)"
+            } else {
+                &column.declared_type
+            };
+            let pk = if column.pk_position > 0 { " PK" } else { "" };
+            let not_null = if column.not_null { " NOT NULL" } else { "" };
+            let _ = writeln!(
+                out,
+                "    {:<28} {declared}{pk}{not_null}{}",
+                column.name,
+                class_marker(column.text_class)
+            );
+        }
+        let _ = writeln!(out);
+    }
+
+    let flagged: Vec<_> = snapshot
+        .text_columns()
+        .into_iter()
+        .filter(|(_, c)| c.text_class.is_some_and(TextClass::is_scanned))
+        .collect();
+    let _ = writeln!(out, "Free-text and payload columns ({}):", flagged.len());
+    for (table, column) in flagged {
+        let _ = writeln!(
+            out,
+            "    {}.{}{}",
+            table.name,
+            column.name,
+            class_marker(column.text_class)
+        );
+    }
+    out
+}
+
+/// Render the attestation, claim and caveat first.
+///
+/// Why: the claim is the sentence a report quotes, so it leads; the evidence
+/// under it is what makes quoting it defensible.
+/// What: claim, caveat, the content-column scan result, the per-column live
+/// reading, the pinned `diff_for_commit` consumers, then the verdict.
+/// Test: `core::inspect::tests::attestation_report_states_the_claim_and_the_caveat`.
+pub fn attestation_report(attestation: &Attestation) -> String {
+    let mut out = String::new();
+    let _ = writeln!(out, "{}", attestation.claim);
+    let _ = writeln!(out);
+    let _ = writeln!(out, "{}", attestation.caveat);
+    let _ = writeln!(out);
+
+    let version = attestation
+        .schema_version
+        .map_or_else(|| "unknown".to_string(), |v| v.to_string());
+    let _ = writeln!(
+        out,
+        "Scanned {} table(s) at migration version {version}.",
+        attestation.tables_scanned
+    );
+    let _ = writeln!(out);
+
+    let _ = writeln!(out, "Content-bearing columns");
+    if attestation.content_columns.is_empty() {
+        let _ = writeln!(
+            out,
+            "    none — no BLOB column, and no column named for a diff, patch, hunk, or file body."
+        );
+    } else {
+        for finding in &attestation.content_columns {
+            let _ = writeln!(
+                out,
+                "    {}.{} ({}) — {}",
+                finding.table, finding.column, finding.declared_type, finding.reason
+            );
+        }
+    }
+    let _ = writeln!(out);
+
+    let _ = writeln!(
+        out,
+        "Free-text columns, as they stand in this database\n    \
+         {:<44} {:>10} {:>10} {:>9}  CLASS",
+        "COLUMN", "POPULATED", "MAX BYTES", "DIFFS"
+    );
+    for scan in &attestation.scanned_columns {
+        let class = match scan.class {
+            TextClass::FreeText => "free text",
+            TextClass::EmbeddedPayload => "embedded payload",
+            TextClass::Unclassified => "UNCLASSIFIED",
+            TextClass::Constrained => "constrained",
+        };
+        let _ = writeln!(
+            out,
+            "    {:<44} {:>10} {:>10} {:>9}  {class}",
+            format!("{}.{}", scan.table, scan.column),
+            scan.populated,
+            scan.max_len,
+            scan.diff_shaped_rows
+        );
+    }
+    let _ = writeln!(
+        out,
+        "    DIFFS counts rows carrying a unified-diff marker. Any non-zero value \
+         contradicts the claim above."
+    );
+    let _ = writeln!(out);
+
+    let _ = writeln!(
+        out,
+        "Callers of collect::git::diff::diff_for_commit ({})",
+        attestation.diff_text_consumers.len()
+    );
+    for consumer in attestation.diff_text_consumers {
+        let _ = writeln!(
+            out,
+            "    {} — {}",
+            consumer.source_path, consumer.disposition
+        );
+    }
+    let _ = writeln!(
+        out,
+        "    This list is pinned in source and re-derived from the source tree by \
+         `cargo test -p tga`, so a new caller fails the build rather than passing unnoticed."
+    );
+    let _ = writeln!(out);
+
+    let _ = match attestation.verdict {
+        Verdict::Consistent => writeln!(
+            out,
+            "VERDICT: consistent — the claim holds for this database."
+        ),
+        Verdict::Findings => writeln!(
+            out,
+            "VERDICT: findings — review the rows above before quoting the claim."
+        ),
+    };
+    out
+}

--- a/crates/trusty-git-analytics/src/core/inspect/schema.rs
+++ b/crates/trusty-git-analytics/src/core/inspect/schema.rs
@@ -1,0 +1,218 @@
+//! Live schema reading — every table, view, and column the open database holds.
+//!
+//! Why: #5218 — a reviewer is owed the schema that is in front of them, not the
+//! one the migration files would produce. A database collected by an older
+//! `tga` is missing later tables, and a database someone hand-edited may carry
+//! extras; both are invisible to anyone reading `src/core/db/sql/`.
+//! What: [`snapshot`] reads `sqlite_master` for tables and views and
+//! `PRAGMA table_info` for each table's columns, then attaches the live row
+//! count and the pinned text classification from [`super::text_columns`].
+//! Test: `core::inspect::tests`.
+
+use rusqlite::Connection;
+use serde::Serialize;
+
+use crate::core::errors::{Result, TgaError};
+
+use super::text_columns::{classify, TextClass};
+
+/// One column of one table, as the open database declares it.
+#[derive(Debug, Clone, Serialize)]
+#[non_exhaustive]
+pub struct ColumnInfo {
+    /// Column name.
+    pub name: String,
+    /// Declared type (`TEXT`, `INTEGER`, …); empty when the DDL omitted one.
+    pub declared_type: String,
+    /// Whether the column carries `NOT NULL`.
+    pub not_null: bool,
+    /// 1-based position within the primary key, or 0 when not part of it.
+    pub pk_position: i64,
+    /// How this column's text is constrained — see [`TextClass`].
+    /// `None` for a column whose declared type is not `TEXT`.
+    pub text_class: Option<TextClass>,
+}
+
+/// Whether a `sqlite_master` entry is a table or a view.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ObjectKind {
+    /// A base table.
+    Table,
+    /// A `CREATE VIEW` projection over base tables.
+    View,
+}
+
+/// One table or view, with its columns and (for tables) its live row count.
+#[derive(Debug, Clone, Serialize)]
+#[non_exhaustive]
+pub struct TableInfo {
+    /// Object name.
+    pub name: String,
+    /// Table or view.
+    pub kind: ObjectKind,
+    /// Declared columns, in DDL order.
+    pub columns: Vec<ColumnInfo>,
+    /// `SELECT COUNT(*)` at snapshot time; `None` for a view.
+    pub row_count: Option<i64>,
+}
+
+/// Every table, view, and column the open database holds.
+#[derive(Debug, Clone, Serialize)]
+#[non_exhaustive]
+pub struct SchemaSnapshot {
+    /// Highest applied migration version, or `None` when the database has no
+    /// `schema_migrations` table (i.e. it was not created by `tga`).
+    pub schema_version: Option<i64>,
+    /// Tables first, then views; each group in name order.
+    pub objects: Vec<TableInfo>,
+}
+
+impl SchemaSnapshot {
+    /// Every declared-`TEXT` column, paired with its table name.
+    ///
+    /// Why: the attestation and the classification-coverage test both walk the
+    /// same set, and neither should re-derive the "declared TEXT" predicate.
+    /// What: `(table, column)` pairs in snapshot order.
+    /// Test: `tests::snapshot_reads_every_table_and_column`.
+    pub fn text_columns(&self) -> Vec<(&TableInfo, &ColumnInfo)> {
+        self.objects
+            .iter()
+            .filter(|o| o.kind == ObjectKind::Table)
+            .flat_map(|t| {
+                t.columns
+                    .iter()
+                    .filter(|c| c.declared_type.eq_ignore_ascii_case("TEXT"))
+                    .map(move |c| (t, c))
+            })
+            .collect()
+    }
+}
+
+/// Read the complete schema of an open connection.
+///
+/// Why: see the module docs — this is the evidence half of `tga inspect`.
+/// What: one `sqlite_master` query for the object list, then per table a
+/// `PRAGMA table_info` and a `SELECT COUNT(*)`. Views get columns but no count,
+/// because counting one re-runs its underlying aggregation for no reader
+/// benefit.
+/// Test: `tests::snapshot_reads_every_table_and_column`,
+/// `tests::snapshot_reports_row_counts`.
+///
+/// # Errors
+///
+/// Returns [`TgaError::DbError`] if any of those reads fails.
+pub fn snapshot(conn: &Connection) -> Result<SchemaSnapshot> {
+    let mut objects = Vec::new();
+    for (kind, name) in object_names(conn)? {
+        let columns = columns_of(conn, &name)?;
+        let row_count = match kind {
+            ObjectKind::Table => Some(count_rows(conn, &name)?),
+            ObjectKind::View => None,
+        };
+        objects.push(TableInfo {
+            name,
+            kind,
+            columns,
+            row_count,
+        });
+    }
+    Ok(SchemaSnapshot {
+        schema_version: schema_version(conn)?,
+        objects,
+    })
+}
+
+/// List user tables and views, tables first, each group in name order.
+fn object_names(conn: &Connection) -> Result<Vec<(ObjectKind, String)>> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT type, name FROM sqlite_master \
+             WHERE type IN ('table', 'view') AND name NOT LIKE 'sqlite_%' \
+             ORDER BY type = 'view', name",
+        )
+        .map_err(TgaError::from)?;
+    let rows = stmt
+        .query_map([], |row| {
+            let kind: String = row.get(0)?;
+            let name: String = row.get(1)?;
+            Ok((kind, name))
+        })
+        .map_err(TgaError::from)?;
+
+    let mut out = Vec::new();
+    for row in rows {
+        let (kind, name) = row.map_err(TgaError::from)?;
+        let kind = if kind == "view" {
+            ObjectKind::View
+        } else {
+            ObjectKind::Table
+        };
+        out.push((kind, name));
+    }
+    Ok(out)
+}
+
+/// Read one object's columns via `PRAGMA table_info`.
+///
+/// The table name is interpolated rather than bound because SQLite does not
+/// accept a parameter in a `PRAGMA` argument. Every name reaching here came
+/// from `sqlite_master` in this same connection, so it is not caller input; it
+/// is still quoted so an exotic identifier cannot change the statement's shape.
+fn columns_of(conn: &Connection, table: &str) -> Result<Vec<ColumnInfo>> {
+    let quoted = table.replace('"', "\"\"");
+    let mut stmt = conn
+        .prepare(&format!("PRAGMA table_info(\"{quoted}\")"))
+        .map_err(TgaError::from)?;
+    let rows = stmt
+        .query_map([], |row| {
+            Ok(ColumnInfo {
+                name: row.get::<_, String>(1)?,
+                declared_type: row.get::<_, String>(2)?,
+                not_null: row.get::<_, i64>(3)? != 0,
+                pk_position: row.get::<_, i64>(5)?,
+                text_class: None,
+            })
+        })
+        .map_err(TgaError::from)?;
+
+    let mut out = Vec::new();
+    for row in rows {
+        let mut col = row.map_err(TgaError::from)?;
+        if col.declared_type.eq_ignore_ascii_case("TEXT") {
+            col.text_class = Some(classify(table, &col.name));
+        }
+        out.push(col);
+    }
+    Ok(out)
+}
+
+/// Live row count for one table.
+fn count_rows(conn: &Connection, table: &str) -> Result<i64> {
+    let quoted = table.replace('"', "\"\"");
+    conn.query_row(&format!("SELECT COUNT(*) FROM \"{quoted}\""), [], |row| {
+        row.get(0)
+    })
+    .map_err(TgaError::from)
+}
+
+/// Highest applied migration version, or `None` when the database carries no
+/// `schema_migrations` table.
+fn schema_version(conn: &Connection) -> Result<Option<i64>> {
+    let present: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'schema_migrations'",
+            [],
+            |row| row.get(0),
+        )
+        .map_err(TgaError::from)?;
+    if present == 0 {
+        return Ok(None);
+    }
+    let version: Option<i64> = conn
+        .query_row("SELECT MAX(version) FROM schema_migrations", [], |row| {
+            row.get(0)
+        })
+        .map_err(TgaError::from)?;
+    Ok(version)
+}

--- a/crates/trusty-git-analytics/src/core/inspect/tests.rs
+++ b/crates/trusty-git-analytics/src/core/inspect/tests.rs
@@ -1,0 +1,555 @@
+//! Tests for `tga inspect` — schema reading, the attestation, the fail-open
+//! arms, and the enforced `diff_for_commit` caller check (#5218).
+
+use std::path::{Path, PathBuf};
+
+use crate::core::db::Database;
+use crate::core::errors::TgaError;
+
+use super::attest::{attest, DIFF_API_SITES, DIFF_TEXT_CONSUMERS, NO_CONTENT_CLAIM};
+use super::schema::{snapshot, ObjectKind};
+use super::text_columns::{classify, TextClass, CONSTRAINED, EMBEDDED_PAYLOAD, FREE_TEXT};
+use super::{open_read_only, render};
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+/// A temp directory removed on drop, so nothing this module writes survives it.
+struct TempDir {
+    path: PathBuf,
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+fn temp_dir(tag: &str) -> TempDir {
+    let mut path = std::env::temp_dir();
+    path.push(format!(
+        "tga-inspect-{tag}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0, |d| d.as_nanos())
+    ));
+    std::fs::create_dir_all(&path).expect("mkdir");
+    TempDir { path }
+}
+
+/// A fully-migrated on-disk database at `<dir>/tga.db`.
+fn migrated_db(dir: &TempDir) -> PathBuf {
+    let path = dir.path.join("tga.db");
+    Database::open(&path).expect("open and migrate");
+    path
+}
+
+// ─── Fail-open arms ───────────────────────────────────────────────────────────
+
+/// Why: `Database::open` CREATES a missing file and migrates it, so an
+/// inspection built on that path would print a complete empty schema and exit
+/// 0 — telling a reviewer their unreadable database holds nothing.
+/// What: asserts the missing-path arm errors and that the message names the
+/// path rather than reporting an empty success.
+/// Test: this test itself.
+#[test]
+fn open_read_only_names_a_missing_database() {
+    let dir = temp_dir("missing");
+    let missing = dir.path.join("absent.db");
+
+    let err = open_read_only(&missing).expect_err("a missing database must not open");
+    assert!(
+        matches!(err, TgaError::NotFound(_)),
+        "expected NotFound, got {err:?}"
+    );
+    assert!(
+        err.to_string().contains("absent.db"),
+        "the error must name the path it could not find: {err}"
+    );
+    assert!(
+        !missing.exists(),
+        "inspecting a missing database must not create one"
+    );
+}
+
+/// Why: `--database` pointed at a directory is the same fail-open hazard with a
+/// different cause, and SQLite's own message for it names no path.
+/// Test: this test itself.
+#[test]
+fn open_read_only_names_a_directory() {
+    let dir = temp_dir("isdir");
+
+    let err = open_read_only(&dir.path).expect_err("a directory must not open");
+    assert!(
+        matches!(err, TgaError::ValidationError(_)),
+        "expected ValidationError, got {err:?}"
+    );
+    assert!(
+        err.to_string().contains("is a directory"),
+        "the error must name the cause: {err}"
+    );
+}
+
+/// Why: a truncated or half-written file opens fine under SQLite's lazy header
+/// check and only fails on the first query, which is the wrong place to learn
+/// the file is not a database.
+/// Test: this test itself.
+#[test]
+fn open_read_only_names_a_non_sqlite_file() {
+    let dir = temp_dir("notdb");
+    let path = dir.path.join("notes.txt");
+    std::fs::write(&path, b"this is not a database").expect("write");
+
+    let err = open_read_only(&path).expect_err("a text file must not open as a database");
+    assert!(
+        matches!(err, TgaError::ValidationError(_)),
+        "expected ValidationError, got {err:?}"
+    );
+    assert!(
+        err.to_string().contains("not a SQLite database"),
+        "the error must name the cause: {err}"
+    );
+}
+
+/// Why: an inspection that migrated the operator's database would report the
+/// schema it just created rather than the one it was handed.
+/// What: opens a v0 database (an empty but valid SQLite file), snapshots it, and
+/// asserts no tga table appeared.
+/// Test: this test itself.
+#[test]
+fn open_read_only_does_not_migrate() {
+    let dir = temp_dir("nomigrate");
+    let path = dir.path.join("empty.db");
+    rusqlite::Connection::open(&path)
+        .expect("create")
+        .execute_batch("CREATE TABLE marker (x INTEGER);")
+        .expect("seed");
+
+    let conn = open_read_only(&path).expect("open the valid, un-migrated file");
+    let snap = snapshot(&conn).expect("snapshot");
+
+    assert_eq!(
+        snap.schema_version, None,
+        "no schema_migrations table exists"
+    );
+    let names: Vec<&str> = snap.objects.iter().map(|o| o.name.as_str()).collect();
+    assert_eq!(names, vec!["marker"], "inspection must not create tables");
+
+    // A write through the read-only handle must be refused.
+    let write = conn.execute_batch("CREATE TABLE sneaky (y INTEGER);");
+    assert!(write.is_err(), "the connection must be read-only");
+}
+
+// ─── Schema snapshot ──────────────────────────────────────────────────────────
+
+/// Why: the command's whole claim is that it shows what the database actually
+/// holds, so the reader must return every table and every column, not a
+/// hand-maintained subset.
+/// What: snapshots a fully-migrated database and checks a table from the first
+/// migration, one from the newest, a view, and a column added by an ALTER.
+/// Test: this test itself.
+#[test]
+fn snapshot_reads_every_table_and_column() {
+    let dir = temp_dir("snapshot");
+    let path = migrated_db(&dir);
+    let conn = open_read_only(&path).expect("open");
+    let snap = snapshot(&conn).expect("snapshot");
+
+    let names: Vec<&str> = snap.objects.iter().map(|o| o.name.as_str()).collect();
+    for expected in [
+        "commits",
+        "files",
+        "work_items",
+        "fact_pm_effort",
+        "schema_migrations",
+        "v_lead_time",
+    ] {
+        assert!(
+            names.contains(&expected),
+            "{expected} missing from {names:?}"
+        );
+    }
+
+    let commits = snap
+        .objects
+        .iter()
+        .find(|o| o.name == "commits")
+        .expect("commits table");
+    assert_eq!(commits.kind, ObjectKind::Table);
+    let cols: Vec<&str> = commits.columns.iter().map(|c| c.name.as_str()).collect();
+    assert!(cols.contains(&"message"), "column from 0001 missing");
+    assert!(cols.contains(&"agentic_mode"), "column from 0021 missing");
+
+    let view = snap
+        .objects
+        .iter()
+        .find(|o| o.name == "v_lead_time")
+        .expect("view");
+    assert_eq!(view.kind, ObjectKind::View);
+    assert_eq!(view.row_count, None, "views carry no row count");
+}
+
+/// Why: a reviewer reads the row counts to see which tables were actually
+/// populated, so a count that ignores rows is worse than none.
+/// Test: this test itself.
+#[test]
+fn snapshot_reports_row_counts() {
+    let dir = temp_dir("counts");
+    let path = migrated_db(&dir);
+    {
+        let db = Database::open(&path).expect("reopen");
+        db.connection()
+            .execute(
+                "INSERT INTO commits (sha, author_name, author_email, timestamp, message, repository) \
+                 VALUES ('abc123', 'Ada', 'ada@example.com', '2026-01-01T00:00:00Z', 'feat: x', 'r')",
+                [],
+            )
+            .expect("insert");
+    }
+
+    let conn = open_read_only(&path).expect("open");
+    let snap = snapshot(&conn).expect("snapshot");
+    let commits = snap
+        .objects
+        .iter()
+        .find(|o| o.name == "commits")
+        .expect("commits");
+    assert_eq!(commits.row_count, Some(1));
+}
+
+// ─── Text-column classification ───────────────────────────────────────────────
+
+/// Why: an inventory of free-text columns written once goes stale the next time
+/// a migration adds a `TEXT` column, and the attestation would keep printing a
+/// list that no longer covers the schema. This is the check that makes the
+/// inventory a standing guard rather than a one-time read.
+/// What: snapshots a fully-migrated database and asserts no `TEXT` column
+/// classifies as [`TextClass::Unclassified`].
+/// Test: this test itself.
+#[test]
+fn every_text_column_is_classified() {
+    let dir = temp_dir("classified");
+    let path = migrated_db(&dir);
+    let conn = open_read_only(&path).expect("open");
+    let snap = snapshot(&conn).expect("snapshot");
+
+    let unclassified: Vec<String> = snap
+        .text_columns()
+        .into_iter()
+        .filter(|(_, c)| c.text_class == Some(TextClass::Unclassified))
+        .map(|(t, c)| format!("{}.{}", t.name, c.name))
+        .collect();
+    assert!(
+        unclassified.is_empty(),
+        "these TEXT columns are in the schema but in none of FREE_TEXT / \
+         EMBEDDED_PAYLOAD / CONSTRAINED — classify them in \
+         core::inspect::text_columns: {unclassified:?}"
+    );
+
+    // The reverse direction: an inventory entry naming a column that no longer
+    // exists is equally misleading in the printed report.
+    let live: Vec<String> = snap
+        .text_columns()
+        .into_iter()
+        .map(|(t, c)| format!("{}.{}", t.name, c.name))
+        .collect();
+    let mut stale: Vec<&str> = Vec::new();
+    for key in FREE_TEXT.iter().chain(EMBEDDED_PAYLOAD).chain(CONSTRAINED) {
+        if !live.iter().any(|l| l == key) {
+            stale.push(key);
+        }
+    }
+    assert!(
+        stale.is_empty(),
+        "these inventory entries name columns the schema no longer has: {stale:?}"
+    );
+}
+
+/// Why: a column in two lists would classify by list order rather than by
+/// intent, and the one that lost would silently stop being scanned.
+/// Test: this test itself.
+#[test]
+fn text_class_lists_are_disjoint() {
+    for key in FREE_TEXT {
+        assert!(!EMBEDDED_PAYLOAD.contains(key), "{key} in two lists");
+        assert!(!CONSTRAINED.contains(key), "{key} in two lists");
+    }
+    for key in EMBEDDED_PAYLOAD {
+        assert!(!CONSTRAINED.contains(key), "{key} in two lists");
+    }
+    assert_eq!(
+        classify("commits", "message"),
+        TextClass::FreeText,
+        "the highest-exposure column must classify as free text"
+    );
+    assert_eq!(
+        classify("work_items", "raw_json"),
+        TextClass::EmbeddedPayload
+    );
+    assert_eq!(classify("commits", "sha"), TextClass::Constrained);
+    assert_eq!(classify("nope", "nope"), TextClass::Unclassified);
+}
+
+// ─── Attestation ──────────────────────────────────────────────────────────────
+
+/// Why: "no code" is the paraphrase #5218 exists to prevent, and a claim string
+/// is exactly the kind of text a later edit loosens without noticing.
+/// Test: this test itself.
+#[test]
+fn claim_never_says_no_code() {
+    assert!(
+        !NO_CONTENT_CLAIM.to_lowercase().contains("no code"),
+        "the claim must never assert the database contains no code: {NO_CONTENT_CLAIM}"
+    );
+    for term in ["file content", "diffs", "patches", "hunks", "blobs"] {
+        assert!(
+            NO_CONTENT_CLAIM.contains(term),
+            "the claim must name {term}: {NO_CONTENT_CLAIM}"
+        );
+    }
+}
+
+/// Why: the pass case has to be reachable, or the verdict carries no
+/// information.
+/// What: attests a freshly migrated, empty database and asserts no
+/// content-bearing column, a populated scan list, and a consistent verdict.
+/// Test: this test itself.
+#[test]
+fn attest_on_a_fresh_database_is_consistent() {
+    let dir = temp_dir("attest-clean");
+    let path = migrated_db(&dir);
+    let conn = open_read_only(&path).expect("open");
+    let snap = snapshot(&conn).expect("snapshot");
+    let report = attest(&conn, &snap).expect("attest");
+
+    assert!(
+        report.content_columns.is_empty(),
+        "tga's schema must hold no content-bearing column: {:?}",
+        report.content_columns
+    );
+    assert_eq!(report.verdict, super::attest::Verdict::Consistent);
+    assert!(
+        report
+            .scanned_columns
+            .iter()
+            .any(|s| s.table == "commits" && s.column == "message"),
+        "commits.message must be scanned"
+    );
+    assert!(
+        report
+            .scanned_columns
+            .iter()
+            .any(|s| s.table == "work_items" && s.column == "raw_json"),
+        "work_items.raw_json must be scanned at runtime, not read off the migration"
+    );
+    assert!(
+        report
+            .scanned_columns
+            .iter()
+            .all(|s| !matches!(s.class, TextClass::Constrained)),
+        "constrained columns must not be scanned"
+    );
+}
+
+/// Why: a scan that cannot find a diff proves nothing about the databases where
+/// one exists — the failing arm is what makes the passing arm evidence.
+/// What: pastes a unified diff into `commits.message` and a second one into
+/// `work_items.raw_json`, then asserts both are counted and the verdict flips.
+/// Test: this test itself.
+#[test]
+fn attest_flags_a_diff_pasted_into_a_commit_message() {
+    let dir = temp_dir("attest-dirty");
+    let path = migrated_db(&dir);
+    {
+        let db = Database::open(&path).expect("reopen");
+        db.connection()
+            .execute(
+                "INSERT INTO commits (sha, author_name, author_email, timestamp, message, repository) \
+                 VALUES ('deadbee', 'Ada', 'ada@example.com', '2026-01-01T00:00:00Z', ?1, 'r')",
+                ["fix: paste\n\ndiff --git a/src/lib.rs b/src/lib.rs\n@@ -1 +1 @@\n-old\n+new\n"],
+            )
+            .expect("insert commit");
+        db.connection()
+            .execute(
+                "INSERT INTO work_items (id, source, title, status, item_type, raw_json) \
+                 VALUES ('W-1', 'jira', 'T', 'Done', 'Bug', ?1)",
+                ["{\"desc\":\"--- a/x\\n+++ b/x\"}"],
+            )
+            .expect("insert work item");
+    }
+
+    let conn = open_read_only(&path).expect("open");
+    let snap = snapshot(&conn).expect("snapshot");
+    let report = attest(&conn, &snap).expect("attest");
+
+    let message = report
+        .scanned_columns
+        .iter()
+        .find(|s| s.table == "commits" && s.column == "message")
+        .expect("commits.message scan");
+    assert_eq!(
+        message.diff_shaped_rows, 1,
+        "a pasted unified diff must be counted"
+    );
+    assert_eq!(message.populated, 1);
+    assert!(message.max_len > 0);
+
+    assert_eq!(report.verdict, super::attest::Verdict::Findings);
+}
+
+// ─── The enforced diff_for_commit caller check ────────────────────────────────
+
+/// Why: #5218's standing guard. `diff_for_commit` computes a real unified diff,
+/// so a caller that persisted its result would break [`NO_CONTENT_CLAIM`]
+/// without changing one line of SQL. A schema read stays green through that; a
+/// list written once goes stale through it. This re-derives the caller set from
+/// the source tree on every run.
+/// What: walks `src/`, collects every non-comment, non-test line naming
+/// `diff_for_commit`, drops the defining and re-exporting files, and asserts the
+/// remaining files are exactly [`DIFF_TEXT_CONSUMERS`].
+/// Test: this test itself.
+#[test]
+fn diff_for_commit_callers_match_the_attestation() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut found: Vec<String> = Vec::new();
+    collect_callers(&root.join("src"), &root, &mut found);
+    found.sort();
+    found.dedup();
+
+    let mut attested: Vec<String> = DIFF_TEXT_CONSUMERS
+        .iter()
+        .map(|c| c.source_path.to_string())
+        .collect();
+    attested.sort();
+
+    assert_eq!(
+        found, attested,
+        "the non-test callers of diff_for_commit changed. Update DIFF_TEXT_CONSUMERS in \
+         core::inspect::attest, and confirm the new caller does not write diff text to the \
+         database — see #5218."
+    );
+}
+
+/// Walk `dir`, appending the crate-relative path of every file that calls
+/// `diff_for_commit` outside a comment and outside test code.
+fn collect_callers(dir: &Path, root: &Path, out: &mut Vec<String>) {
+    let entries = std::fs::read_dir(dir).expect("read src dir");
+    for entry in entries {
+        let entry = entry.expect("dir entry");
+        let path = entry.path();
+        if path.is_dir() {
+            collect_callers(&path, root, out);
+            continue;
+        }
+        if path.extension().is_none_or(|e| e != "rs") {
+            continue;
+        }
+        let rel = path
+            .strip_prefix(root)
+            .expect("path under crate root")
+            .to_string_lossy()
+            .replace('\\', "/");
+        if DIFF_API_SITES.contains(&rel.as_str()) || is_test_file(&rel) {
+            continue;
+        }
+        let body = std::fs::read_to_string(&path).expect("read source file");
+        if body.lines().any(is_caller_line) {
+            out.push(rel);
+        }
+    }
+}
+
+/// Whether a crate-relative path is test-only by this project's conventions.
+fn is_test_file(rel: &str) -> bool {
+    rel.contains("/tests/")
+        || rel.ends_with("/tests.rs")
+        || rel.ends_with("_test.rs")
+        || rel.ends_with("_tests.rs")
+}
+
+/// Whether one source line calls `diff_for_commit` rather than mentioning it.
+///
+/// A comment and a string literal both name the symbol without calling it —
+/// this module's own report text is one of each — so both are removed before
+/// the match. Everything that survives is code.
+fn is_caller_line(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    if trimmed.starts_with("//") {
+        return false;
+    }
+    strip_string_literals(line).contains("diff_for_commit")
+}
+
+/// Blank out every double-quoted span in `line`.
+///
+/// Deliberately naive: it does not track escapes or raw strings, because the
+/// only thing it must not do is hide real code, and a mishandled escape leaves
+/// MORE of the line visible, not less.
+fn strip_string_literals(line: &str) -> String {
+    let mut out = String::with_capacity(line.len());
+    let mut in_string = false;
+    for ch in line.chars() {
+        if ch == '"' {
+            in_string = !in_string;
+            continue;
+        }
+        if !in_string {
+            out.push(ch);
+        }
+    }
+    out
+}
+
+// ─── Rendering ────────────────────────────────────────────────────────────────
+
+/// Why: the closure condition is that a reviewer SEES the free-text columns
+/// called out, which the data structure alone does not deliver.
+/// Test: this test itself.
+#[test]
+fn schema_report_marks_free_text_columns() {
+    let dir = temp_dir("render-schema");
+    let path = migrated_db(&dir);
+    let conn = open_read_only(&path).expect("open");
+    let snap = snapshot(&conn).expect("snapshot");
+    let text = render::schema_report(&snap);
+
+    assert!(text.contains("TABLE commits"), "tables must be listed");
+    assert!(text.contains("VIEW  v_lead_time"), "views must be listed");
+    assert!(
+        text.contains("message") && text.contains("← FREE TEXT"),
+        "free-text columns must be marked"
+    );
+    assert!(
+        text.contains("← EMBEDDED PAYLOAD"),
+        "work_items.raw_json must be marked"
+    );
+    assert!(
+        text.contains("Free-text and payload columns"),
+        "the trailing summary must be present"
+    );
+}
+
+/// Why: DOC-67 §10 quotes this output, so the claim and its caveat must both
+/// survive into the rendered text — the claim alone is the overreach.
+/// Test: this test itself.
+#[test]
+fn attestation_report_states_the_claim_and_the_caveat() {
+    let dir = temp_dir("render-attest");
+    let path = migrated_db(&dir);
+    let conn = open_read_only(&path).expect("open");
+    let snap = snapshot(&conn).expect("snapshot");
+    let report = attest(&conn, &snap).expect("attest");
+    let text = render::attestation_report(&report);
+
+    assert!(text.contains(NO_CONTENT_CLAIM));
+    assert!(text.contains("not a claim that the database contains no code"));
+    assert!(
+        text.lines()
+            .next()
+            .is_some_and(|first| first == NO_CONTENT_CLAIM),
+        "the claim must lead the report, so a reader quoting the first line quotes it"
+    );
+    assert!(text.contains("commits.message"));
+    assert!(text.contains("src/profile/diff_sampler/sampler.rs"));
+    assert!(text.contains("VERDICT: consistent"));
+}

--- a/crates/trusty-git-analytics/src/core/inspect/tests.rs
+++ b/crates/trusty-git-analytics/src/core/inspect/tests.rs
@@ -353,13 +353,29 @@ fn attest_on_a_fresh_database_is_consistent() {
 
 /// Why: a scan that cannot find a diff proves nothing about the databases where
 /// one exists — the failing arm is what makes the passing arm evidence.
-/// What: pastes a unified diff into `commits.message` and a second one into
-/// `work_items.raw_json`, then asserts both are counted and the verdict flips.
+/// What: pastes a raw unified diff into `commits.message` and a
+/// `serde_json`-serialized one into `work_items.raw_json`, then asserts BOTH
+/// are counted and the verdict flips. The `raw_json` half is what the JSON
+/// escaping fix turns from 0 to 1 — the value reaching SQLite there carries the
+/// two-character escape `\n`, not a newline byte, so a newline-anchored
+/// predicate matches nothing.
 /// Test: this test itself.
 #[test]
 fn attest_flags_a_diff_pasted_into_a_commit_message() {
     let dir = temp_dir("attest-dirty");
     let path = migrated_db(&dir);
+    // Escaped by a real serializer, so the stored bytes are whatever the
+    // collector would actually have written — never a hand-built literal that
+    // could accidentally carry a real newline and pass for the wrong reason.
+    let payload = serde_json::to_string(&serde_json::json!({
+        "description": "--- a/x\n+++ b/x\n@@ -1 +1 @@\n-a\n+b\n",
+    }))
+    .expect("serialize");
+    assert!(
+        !payload.contains('\n'),
+        "the fixture must carry the JSON escape, not a newline byte: {payload}"
+    );
+
     {
         let db = Database::open(&path).expect("reopen");
         db.connection()
@@ -373,7 +389,7 @@ fn attest_flags_a_diff_pasted_into_a_commit_message() {
             .execute(
                 "INSERT INTO work_items (id, source, title, status, item_type, raw_json) \
                  VALUES ('W-1', 'jira', 'T', 'Done', 'Bug', ?1)",
-                ["{\"desc\":\"--- a/x\\n+++ b/x\"}"],
+                [&payload],
             )
             .expect("insert work item");
     }
@@ -394,7 +410,79 @@ fn attest_flags_a_diff_pasted_into_a_commit_message() {
     assert_eq!(message.populated, 1);
     assert!(message.max_len > 0);
 
+    let raw_json = report
+        .scanned_columns
+        .iter()
+        .find(|s| s.table == "work_items" && s.column == "raw_json")
+        .expect("work_items.raw_json scan");
+    assert_eq!(raw_json.populated, 1);
+    assert_eq!(
+        raw_json.diff_shaped_rows, 1,
+        "a diff serialized into JSON must be counted — its newlines are the \
+         two-character escape, so the scan has to normalise before matching"
+    );
+
     assert_eq!(report.verdict, super::attest::Verdict::Findings);
+}
+
+/// Why: the probe anchors four of its five markers on a newline BYTE, and the
+/// escaped forms that carry a diff into a text column have none. Each row below
+/// is a way a diff has actually reached a column, plus the prose that must NOT
+/// match — without the last one, normalising could be made to pass by widening
+/// the markers until everything matches.
+/// What: writes each fixture into `commits.message`, attests, and asserts the
+/// per-row verdict.
+/// Test: this test itself.
+#[test]
+fn diff_probe_normalises_json_escaped_newlines() {
+    let cases: &[(&str, &str, i64)] = &[
+        ("raw", "fix\n\ndiff --git a/x b/x\n@@ -1 +1 @@\n-a\n+b\n", 1),
+        // JSON escaping: the byte sequence backslash-n, not a newline.
+        (
+            "json_lf",
+            r#"{"description":"--- a/x\n+++ b/x\n@@ -1 +1 @@"}"#,
+            1,
+        ),
+        // A Windows-authored diff serialized the same way.
+        (
+            "json_crlf",
+            r#"{"description":"--- a/x\r\n+++ b/x\r\n@@ -1 +1 @@"}"#,
+            1,
+        ),
+        // Prose that name-drops the markers mid-line must stay uncounted.
+        (
+            "prose",
+            "Reviewed the @@ hunk headers and the --- a/ prefix in passing",
+            0,
+        ),
+    ];
+
+    for (label, message, expected) in cases {
+        let dir = temp_dir(&format!("probe-{label}"));
+        let path = migrated_db(&dir);
+        {
+            let db = Database::open(&path).expect("reopen");
+            db.connection()
+                .execute(
+                    "INSERT INTO commits (sha, author_name, author_email, timestamp, message, repository) \
+                     VALUES ('s1', 'Ada', 'ada@example.com', '2026-01-01T00:00:00Z', ?1, 'r')",
+                    [message],
+                )
+                .expect("insert");
+        }
+        let conn = open_read_only(&path).expect("open");
+        let snap = snapshot(&conn).expect("snapshot");
+        let report = attest(&conn, &snap).expect("attest");
+        let scan = report
+            .scanned_columns
+            .iter()
+            .find(|s| s.table == "commits" && s.column == "message")
+            .expect("commits.message scan");
+        assert_eq!(
+            scan.diff_shaped_rows, *expected,
+            "case {label}: expected {expected} diff-shaped row(s) for {message:?}"
+        );
+    }
 }
 
 // ─── The enforced diff_for_commit caller check ────────────────────────────────

--- a/crates/trusty-git-analytics/src/core/inspect/text_columns.rs
+++ b/crates/trusty-git-analytics/src/core/inspect/text_columns.rs
@@ -1,0 +1,233 @@
+//! The pinned classification of every declared-`TEXT` column in tga's schema.
+//!
+//! Why: #5218 — "no file content, diffs, patches, hunks, or blobs" is a claim
+//! about column TYPES, and it stays true while a free-text column quietly
+//! accumulates whatever a human pasted into a commit message or a ticket
+//! title. A reviewer needs those columns named, and the naming has to survive
+//! the next migration: an inventory written once goes stale silently, so
+//! `tests::every_text_column_is_classified` fails the build when a migration
+//! adds a `TEXT` column nobody put in one of these three lists.
+//! What: [`FREE_TEXT`], [`EMBEDDED_PAYLOAD`], and [`CONSTRAINED`] partition the
+//! schema's `TEXT` columns; [`classify`] resolves one `table.column` against
+//! them.
+//! Test: `core::inspect::tests::every_text_column_is_classified`,
+//! `core::inspect::tests::text_class_lists_are_disjoint`.
+
+use serde::Serialize;
+
+/// How constrained the text in a `TEXT` column is.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TextClass {
+    /// Unconstrained prose a human or an upstream system typed. Nothing in the
+    /// schema stops a pasted code snippet from landing here, so `tga inspect
+    /// attest` scans these columns at runtime rather than reasoning from the
+    /// migration files.
+    FreeText,
+    /// A serialized upstream payload. Today's writer puts a known, snippet-free
+    /// shape in it, but the column's declared type does not constrain a future
+    /// writer, so it is scanned at runtime alongside the free-text columns.
+    EmbeddedPayload,
+    /// An identifier, enumerated value, timestamp, or JSON array of
+    /// identifiers — a shape the writer controls end to end.
+    Constrained,
+    /// A `TEXT` column none of the three lists names. Reported rather than
+    /// assumed harmless; the coverage test fails on one in tga's own schema.
+    Unclassified,
+}
+
+impl TextClass {
+    /// Whether `tga inspect attest` scans this column's live contents.
+    ///
+    /// An unclassified column is scanned too — the safe reading of "nobody has
+    /// said what goes in here" is that anything might.
+    pub fn is_scanned(self) -> bool {
+        !matches!(self, TextClass::Constrained)
+    }
+}
+
+/// Free-text columns — the inventory a reviewer is owed by name.
+///
+/// `commits.message` is the highest-exposure entry: it holds the full commit
+/// subject and body, which is where a pasted stack trace or code fragment
+/// realistically ends up.
+pub const FREE_TEXT: &[&str] = &[
+    // Sprint/iteration display name, typed by whoever created the iteration.
+    "azdo_iterations.name",
+    // Justification a human typed when hand-labelling a commit.
+    "classification_overrides.notes",
+    // Full commit subject + body.
+    "commits.message",
+    "linear_issues.title",
+    "pull_requests.title",
+    // Comma-separated labels, typed upstream.
+    "work_items.tags",
+    "work_items.title",
+];
+
+/// Serialized upstream payloads.
+///
+/// `work_items.raw_json` is the whole list. Its only writer today serializes a
+/// struct with no description field, so it is clean in practice — but that is a
+/// property of the writer, not of the column, which is why the attestation
+/// reads the column instead of citing `0005_work_items.sql`.
+pub const EMBEDDED_PAYLOAD: &[&str] = &["work_items.raw_json"];
+
+/// Every remaining `TEXT` column: identifiers, enumerated values, timestamps,
+/// and JSON arrays of identifiers.
+pub const CONSTRAINED: &[&str] = &[
+    "authors.canonical_name",
+    "authors.canonical_email",
+    "authors.aliases",
+    "azdo_iterations.id",
+    "azdo_iterations.project",
+    "azdo_iterations.path",
+    "azdo_iterations.start_date",
+    "azdo_iterations.finish_date",
+    "azdo_iterations.time_frame",
+    "azdo_iterations.fetched_at",
+    "classification_overrides.commit_sha",
+    "classification_overrides.repo_path",
+    "classification_overrides.work_type",
+    "classification_overrides.change_type",
+    "classification_overrides.created_at",
+    "classifications.category",
+    "classifications.subcategory",
+    "classifications.ticket_id",
+    "classifications.method",
+    "classifications.top_level_category",
+    "collection_runs.repo_name",
+    "collection_runs.collected_at",
+    "commit_work_items.commit_sha",
+    "commit_work_items.work_item_id",
+    "commit_work_items.work_item_source",
+    "commits.sha",
+    "commits.author_name",
+    "commits.author_email",
+    "commits.timestamp",
+    "commits.repository",
+    "commits.ticket_id",
+    "commits.ai_tool",
+    "commits.agentic_mode",
+    "deployment_failures.deploy_id",
+    "deployment_failures.failure_commit_sha",
+    "deployment_failures.recovery_commit_sha",
+    "effort_percentile_thresholds.dataset",
+    "fact_commit_effort.sha",
+    "fact_commit_effort.repository",
+    "fact_commit_effort.size",
+    "fact_commit_effort.formula_version",
+    "fact_commit_reachability.commit_sha",
+    "fact_commit_reachability.reachable_from_tags",
+    "fact_commit_reachability.release_branches",
+    "fact_deployments.deploy_id",
+    "fact_deployments.repo",
+    "fact_deployments.environment",
+    "fact_deployments.status",
+    "fact_deployments.git_sha",
+    "fact_deployments.git_tag",
+    "fact_deployments.source",
+    "fact_incidents.incident_id",
+    "fact_incidents.source",
+    "fact_incidents.severity",
+    "fact_incidents.triggering_deploy",
+    "fact_incidents.repo",
+    "fact_incidents.jira_ticket",
+    "fact_jira_comment_detail.ticket_key",
+    "fact_jira_comment_detail.comment_id",
+    "fact_jira_comment_detail.project_key",
+    "fact_jira_comment_detail.author",
+    "fact_jira_comment_detail.created_at",
+    "fact_pm_effort.work_item_id",
+    "fact_pm_effort.work_item_source",
+    "fact_pm_effort.pm_name",
+    "fact_pm_effort.week_key",
+    "fact_pm_effort.effort_bucket",
+    "fact_pm_effort.score_status",
+    "fact_pm_effort.inputs_present",
+    "fact_pm_effort.formula_version",
+    "fact_pm_work.work_item_id",
+    "fact_pm_work.work_item_source",
+    "fact_pm_work.pm_name",
+    "fact_pm_work.week_key",
+    "fact_pm_work.exclusion_reason",
+    "fact_pm_work.formula_version",
+    "fact_ticket_transitions.ticket_key",
+    "fact_ticket_transitions.project_key",
+    "fact_ticket_transitions.from_status",
+    "fact_ticket_transitions.to_status",
+    "fact_ticket_transitions.transitioned_at",
+    "fact_ticket_transitions.author",
+    "fact_weekly_engineer.author_email",
+    "fact_weekly_engineer.repository",
+    "fact_weekly_engineer.formula_version",
+    "fact_weekly_quality.author_email",
+    "fact_weekly_quality.repository",
+    "fact_weekly_quality.formula_version",
+    "files.path",
+    "files.change_type",
+    "jira_sync_cursor.project_key",
+    "jira_sync_cursor.last_synced_at",
+    "jira_sync_cursor.last_run_at",
+    "linear_issues.identifier",
+    "linear_issues.state",
+    "linear_issues.team",
+    "linear_issues.team_key",
+    "linear_issues.assignee",
+    "linear_issues.url",
+    "linear_issues.fetched_at",
+    "pr_reviewers.provider",
+    "pr_reviewers.reviewer_id",
+    "pr_reviewers.display_name",
+    "pr_reviewers.review_state",
+    "pr_reviewers.submitted_at",
+    "pull_requests.author",
+    "pull_requests.state",
+    "pull_requests.created_at",
+    "pull_requests.merged_at",
+    "pull_requests.commit_shas",
+    "pull_requests.provider",
+    "pull_requests.repository",
+    "pull_requests.fetched_at",
+    "pull_requests.head_ref",
+    "pull_requests.body_ticket_id",
+    "repo_walk_state.repository",
+    "repo_walk_state.head_sha",
+    "repo_walk_state.head_ref",
+    "repo_walk_state.tips_digest",
+    "repo_walk_state.walk_scope",
+    "repo_walk_state.walked_at",
+    "repository_analysis_status.repo_name",
+    "repository_analysis_status.last_analyzed_at",
+    "schema_migrations.name",
+    "schema_migrations.applied_at",
+    "work_items.id",
+    "work_items.source",
+    "work_items.status",
+    "work_items.item_type",
+    "work_items.project",
+    "work_items.url",
+    "work_items.fetched_at",
+];
+
+/// Resolve one `table.column` against the three inventories.
+///
+/// Why: the schema reader and the attestation must agree on a column's class,
+/// and a second copy of the lookup is a second thing to keep in step.
+/// What: linear scan of [`FREE_TEXT`], then [`EMBEDDED_PAYLOAD`], then
+/// [`CONSTRAINED`]; anything else is [`TextClass::Unclassified`]. The lists
+/// hold ~140 entries and a caller runs this once per column, so a scan costs
+/// less than building a map.
+/// Test: `core::inspect::tests::every_text_column_is_classified`.
+pub fn classify(table: &str, column: &str) -> TextClass {
+    let key = format!("{table}.{column}");
+    if FREE_TEXT.contains(&key.as_str()) {
+        TextClass::FreeText
+    } else if EMBEDDED_PAYLOAD.contains(&key.as_str()) {
+        TextClass::EmbeddedPayload
+    } else if CONSTRAINED.contains(&key.as_str()) {
+        TextClass::Constrained
+    } else {
+        TextClass::Unclassified
+    }
+}

--- a/crates/trusty-git-analytics/src/core/mod.rs
+++ b/crates/trusty-git-analytics/src/core/mod.rs
@@ -10,6 +10,7 @@
 //!   the process environment (#6405)
 //! - [`db`] — SQLite database wrapper with WAL mode and versioned migrations
 //! - [`errors`] — crate-wide error enum and `Result` alias
+//! - [`inspect`] — live schema reading and the data-handling attestation (#5218)
 //! - [`models`] — domain structs for commits, authors, classifications, etc.
 //! - [`pm_effort`] — PM ticket complexity scoring (#3915)
 //! - [`pm_work`] — PM ticket meaningfulness classification (#3916)
@@ -23,6 +24,7 @@ pub mod db;
 pub mod effort;
 pub mod effort_percentile;
 pub mod errors;
+pub mod inspect;
 pub mod models;
 pub mod pm_effort;
 pub mod pm_work;

--- a/crates/trusty-git-analytics/src/main.rs
+++ b/crates/trusty-git-analytics/src/main.rs
@@ -30,6 +30,7 @@ use crate::commands::audit::AuditArgs;
 use crate::commands::author::AuthorArgs;
 use crate::commands::backfill::BackfillArgs;
 use crate::commands::dora::DoraArgs;
+use crate::commands::inspect::InspectArgs;
 use crate::commands::install::InstallArgs;
 use crate::commands::override_cmd::OverrideArgs;
 use crate::commands::pr_metrics::PrMetricsArgs;
@@ -150,6 +151,8 @@ enum Commands {
     Tui(TuiArgs),
     /// One-shot acquisition-diligence sweep over an org or configured repo set (#5235).
     Audit(AuditArgs),
+    /// Show the live database schema, or attest what it holds (#5218).
+    Inspect(InspectArgs),
 
     /// Manage inference provider configuration (API keys) — the universal
     /// `config keys set/list/test/unset` surface shared by every trusty-*
@@ -375,6 +378,15 @@ async fn run() -> anyhow::Result<()> {
         return commands::tui::run(config, &db_path, args, log_capture).await;
     }
 
+    // #5218: inspection reads the operator's database as it stands. The shared
+    // `Database::open` below CREATES and migrates a missing file, so an
+    // inspection routed through it would print a complete, empty, freshly-minted
+    // schema and exit 0 for a database the caller cannot read. It is dispatched
+    // here instead, through a read-only open that names the cause and fails.
+    if let Commands::Inspect(args) = cli.command {
+        return commands::inspect::run(&db_path, args);
+    }
+
     // #5465: `tga profile` opens the database through `ContributorSelector`,
     // which seeds the identity resolver from the same connection the rest of the
     // pipeline reads through — so it is dispatched before the shared open rather
@@ -417,6 +429,7 @@ async fn run() -> anyhow::Result<()> {
         // Handled above — match is exhaustive.
         Commands::Tui(_) => unreachable!("tui dispatched above"),
         Commands::Profile(_) => unreachable!("profile dispatched above"),
+        Commands::Inspect(_) => unreachable!("inspect dispatched above"),
         Commands::Install(_) => unreachable!("install dispatched above"),
         Commands::Config(_) => unreachable!("config dispatched above"),
     }

--- a/docs/trusty-git-analytics/requirements/database-schema.md
+++ b/docs/trusty-git-analytics/requirements/database-schema.md
@@ -14,6 +14,55 @@ PRAGMA foreign_keys = ON;
 The schema is managed by a versioned migration runner. Migrations are applied in order
 at startup and are idempotent (already-applied versions are skipped).
 
+**This page is a reference, not the source of truth.** The schema in front of you is
+whatever migrations that database has actually had applied, which is not necessarily the
+newest set. Read it directly:
+
+```bash
+tga inspect schema        # every table, view, and column, with free-text columns marked
+tga inspect attest        # the data-handling attestation, with the live evidence for it
+```
+
+Both open the file read-only and refuse to create one, so pointing them at a missing or
+unreadable path names the cause instead of reporting an empty database (issue #5218).
+
+---
+
+## Data-Handling Attestation
+
+The defensible claim about this schema is:
+
+> tga's database stores no file content, diffs, patches, hunks, or blobs.
+
+It is **never** "contains no code". No column exists to hold a file's contents, a diff, a
+patch, or a hunk, but the free-text columns below hold whatever a human or an upstream
+system typed — and a pasted snippet in a commit message is stored verbatim.
+
+| Free-text column | Source |
+|---|---|
+| `commits.message` | Full commit subject and body — the highest-exposure column |
+| `classification_overrides.notes` | Justification typed when hand-labelling a commit |
+| `pull_requests.title` | PR title from the provider |
+| `work_items.title` | Ticket title from the provider |
+| `work_items.tags` | Comma-separated labels from the provider |
+| `linear_issues.title` | Issue title from Linear |
+| `azdo_iterations.name` | Sprint name typed by whoever created the iteration |
+| `work_items.raw_json` | Serialized upstream payload — a shape the writer controls, not the schema |
+
+`tga inspect attest` reads those columns in the operator's own database rather than
+citing the migration that declared them, and counts any row carrying a unified-diff
+marker. The inventory itself is pinned in `src/core/inspect/text_columns.rs` and a
+migration that adds an unclassified `TEXT` column fails
+`core::inspect::tests::every_text_column_is_classified`.
+
+`collect::git::diff::diff_for_commit` does compute a real unified diff (200 KiB cap,
+issue #559). Its one non-test caller is the profile diff sampler
+(`src/profile/diff_sampler/sampler.rs`, #5465), which holds the text in memory for the
+period-review prompt and never binds it to a SQL statement. That caller list is pinned in
+`src/core/inspect/attest.rs` and re-derived from the source tree by
+`core::inspect::tests::diff_for_commit_callers_match_the_attestation`, so a new caller
+fails the build.
+
 ---
 
 ## Tables
@@ -21,6 +70,7 @@ at startup and are idempotent (already-applied versions are skipped).
 ### `authors`
 
 Canonical developer identities. One row per unique developer after alias resolution.
+Migration `0001_initial_schema.sql`.
 
 | Column | Type | Nullable | Notes |
 |---|---|---|---|
@@ -29,13 +79,14 @@ Canonical developer identities. One row per unique developer after alias resolut
 | `canonical_email` | TEXT | no | Primary email; UNIQUE constraint |
 | `aliases` | TEXT | no | JSON array of alternate emails/handles; default `'[]'` |
 
-**Indexes**: UNIQUE(`canonical_email`).
+**Indexes**: UNIQUE(`canonical_email`), INDEX(`canonical_email`).
 
 ---
 
 ### `commits`
 
-Raw git commit records. One row per commit SHA.
+Raw git commit records. One row per commit SHA. Migration `0001_initial_schema.sql`,
+extended by `0003`, `0007`, `0017`, and `0021`.
 
 | Column | Type | Nullable | Notes |
 |---|---|---|---|
@@ -45,7 +96,7 @@ Raw git commit records. One row per commit SHA.
 | `author_name` | TEXT | no | Raw name from git log |
 | `author_email` | TEXT | no | Raw email from git log |
 | `timestamp` | TEXT | no | ISO 8601 UTC timestamp |
-| `message` | TEXT | no | Full commit message |
+| `message` | TEXT | no | Full commit message — free text |
 | `repository` | TEXT | no | Repository name (from config `name` field) |
 | `files_changed` | INTEGER | no | Count of changed files; default 0 |
 | `insertions` | INTEGER | no | Lines added; default 0 |
@@ -53,18 +104,27 @@ Raw git commit records. One row per commit SHA.
 | `classification_id` | INTEGER | yes | FK → `classifications(id)` ON DELETE SET NULL |
 | `confidence` | REAL | yes | Classification confidence [0, 1] |
 | `is_merge` | INTEGER | no | Boolean (0/1); default 0 |
-| `ticketed` | INTEGER | no | Boolean — ticket reference detected; default 0 |
-| `ticket_id` | TEXT | yes | Detected ticket reference (e.g. `ENG-123`, `AB#456`) |
-| `is_revert` | INTEGER | no | Boolean — commit is a revert; default 0 |
-| `complexity` | INTEGER | yes | Complexity score 1–5 (populated by `--backfill-complexity`) |
+| `ticketed` | INTEGER | no | Boolean — ticket reference detected; default 0 (`0003`) |
+| `is_revert` | INTEGER | no | Boolean — commit is a revert; default 0 (`0007`) |
+| `ticket_id` | TEXT | yes | Detected ticket reference, e.g. `ENG-123`, `AB#456` (`0007`) |
+| `is_ai_assisted` | INTEGER | no | Boolean — AI co-authorship trailer detected; default 0 (`0017`) |
+| `ai_tool` | TEXT | yes | `claude`, `copilot`, `cursor`, … (`0017`) |
+| `agentic_mode` | TEXT | no | `none` / `ide_assisted` / `full_agentic`; default `'none'` (`0021`) |
 
-**Indexes**: UNIQUE(`sha`), INDEX(`author_id`), INDEX(`repository`), INDEX(`timestamp`).
+**Indexes**: UNIQUE(`sha`), INDEX(`author_id`), INDEX(`repository`), INDEX(`timestamp`),
+INDEX(`ticketed`), INDEX(`is_revert`), INDEX(`ticket_id`), INDEX(`is_ai_assisted`),
+INDEX(`agentic_mode`).
+
+There is no `complexity` column on `commits` — migration `0013` put it on
+`classifications`.
 
 ---
 
 ### `classifications`
 
-Classification results. One row per distinct verdict. Referenced by `commits.classification_id`.
+Classification results. One row per distinct verdict. Referenced by
+`commits.classification_id`. Migration `0001_initial_schema.sql`, extended by `0013` and
+`0017`.
 
 | Column | Type | Nullable | Notes |
 |---|---|---|---|
@@ -74,13 +134,19 @@ Classification results. One row per distinct verdict. Referenced by `commits.cla
 | `ticket_id` | TEXT | yes | Ticket reference extracted during classification |
 | `confidence` | REAL | no | Confidence score; default 0.0 |
 | `method` | TEXT | no | `exact_rule`, `regex_rule`, `fuzzy_match`, `llm_fallback`, or `manual` |
+| `complexity` | INTEGER | yes | Complexity score 1–5; NULL when not scored (`0013`) |
+| `top_level_category` | TEXT | yes | Category derived from the subcategory taxonomy (`0017`) |
+
+**Indexes**: INDEX(`category`), INDEX(`top_level_category`).
 
 ---
 
 ### `files`
 
 File-level change records. One row per (commit, file) pair. Present only when
-`output.include_files: true` in config.
+`output.include_files: true` in config. Migration `0001_initial_schema.sql`.
+
+Records a path and the two line counts, never the file's contents.
 
 | Column | Type | Nullable | Notes |
 |---|---|---|---|
@@ -91,85 +157,457 @@ File-level change records. One row per (commit, file) pair. Present only when
 | `insertions` | INTEGER | no | Lines added; default 0 |
 | `deletions` | INTEGER | no | Lines removed; default 0 |
 
-**Indexes**: INDEX(`commit_id`).
+**Indexes**: INDEX(`commit_id`), INDEX(`path`).
 
 ---
 
 ### `pull_requests`
 
-Pull request metadata fetched from GitHub, Bitbucket, or Azure DevOps.
+Pull request metadata fetched from GitHub, Bitbucket, or Azure DevOps. Migration
+`0001_initial_schema.sql`, extended by `0010`, `0012`, `0022`, and `0024`.
 
 | Column | Type | Nullable | Notes |
 |---|---|---|---|
 | `id` | INTEGER PK | no | Autoincrement |
-| `provider` | TEXT | no | `github`, `bitbucket`, or `azdo`; default `github` |
 | `pr_number` | INTEGER | no | PR number within the repository |
-| `title` | TEXT | no | PR title |
+| `title` | TEXT | no | PR title — free text |
 | `author` | TEXT | no | Author login or display name |
 | `state` | TEXT | no | `open`, `closed`, or `merged` |
 | `created_at` | TEXT | no | ISO 8601 timestamp |
 | `merged_at` | TEXT | yes | ISO 8601 timestamp; NULL if not merged |
 | `commit_shas` | TEXT | no | JSON array of commit SHAs in the PR; default `'[]'` |
-| `merge_commit_sha` | TEXT | yes | SHA of the merge commit (when available) |
+| `provider` | TEXT | no | `github`, `bitbucket`, or `azdo`; default `'github'` (`0010`) |
+| `repository` | TEXT | no | Repository name; default `'unknown'` (`0012`) |
+| `fetched_at` | TEXT | no | RFC3339 snapshot time, the stale-write guard; default `''` (`0022`) |
+| `head_ref` | TEXT | no | Source branch name; default `''` (`0024`) |
+| `body_ticket_id` | TEXT | yes | Ticket reference extracted from the PR body (`0024`) |
 
-**Indexes**: UNIQUE(`provider`, `pr_number`).
+**Indexes**: UNIQUE(`provider`, `repository`, `pr_number`), INDEX(`pr_number`),
+INDEX(`state`), INDEX(`provider`, `repository`).
+
+`0012` replaced `0010`'s UNIQUE(`provider`, `pr_number`) index, which collapsed
+cross-repository PR-number collisions (bug #88).
 
 ---
 
 ### `linear_issues`
 
-Linear ticket data fetched on reference detection.
+Linear ticket data fetched on reference detection. Migration `0002_linear_issues.sql`.
 
 | Column | Type | Nullable | Notes |
 |---|---|---|---|
 | `id` | INTEGER PK | no | Autoincrement |
-| `issue_id` | TEXT | no | Linear issue identifier (e.g. `ENG-123`) |
-| `title` | TEXT | yes | Issue title |
-| `state` | TEXT | yes | Issue state (e.g. `In Progress`, `Done`) |
-| `team_key` | TEXT | yes | Linear team key |
-| `url` | TEXT | yes | Issue URL |
+| `identifier` | TEXT | no | Linear issue identifier (e.g. `ENG-123`); UNIQUE constraint |
+| `title` | TEXT | no | Issue title — free text |
+| `state` | TEXT | no | Issue state (e.g. `In Progress`, `Done`) |
+| `team` | TEXT | no | Linear team name |
+| `team_key` | TEXT | no | Linear team key |
+| `assignee` | TEXT | yes | Assignee display name |
+| `priority` | INTEGER | no | Linear priority; default 0 |
+| `url` | TEXT | no | Issue URL; default `''` |
 | `fetched_at` | TEXT | no | ISO 8601 timestamp |
 
-**Indexes**: UNIQUE(`issue_id`).
+**Indexes**: UNIQUE(`identifier`), INDEX(`team_key`), INDEX(`state`), INDEX(`assignee`).
 
 ---
 
 ### `work_items`
 
-Unified ticket/work-item records from JIRA, Linear, and Azure DevOps.
+Unified ticket/work-item records from JIRA, GitHub, Linear, and Azure DevOps. Migration
+`0005_work_items.sql`.
 
 | Column | Type | Nullable | Notes |
 |---|---|---|---|
-| `id` | INTEGER PK | no | Autoincrement |
-| `provider` | TEXT | no | `jira`, `linear`, or `azdo` |
-| `external_id` | TEXT | no | Provider-specific ID (e.g. `ENG-123`, `AB#456`) |
-| `title` | TEXT | yes | |
-| `work_item_type` | TEXT | yes | Issue type (e.g. `Bug`, `Story`, `Task`) |
-| `state` | TEXT | yes | |
-| `fetched_at` | TEXT | no | ISO 8601 timestamp |
+| `id` | TEXT | no | PK part 1 — provider-specific ID (e.g. `ENG-123`, `42`) |
+| `source` | TEXT | no | PK part 2 — `azdo`, `jira`, `github`, or `linear` |
+| `title` | TEXT | no | Ticket title — free text |
+| `status` | TEXT | no | Provider status string |
+| `item_type` | TEXT | no | `Bug`, `User Story`, `Task`, `Epic`, … |
+| `tags` | TEXT | yes | Comma-separated labels — free text |
+| `project` | TEXT | yes | Project name or key |
+| `url` | TEXT | yes | Ticket URL |
+| `raw_json` | TEXT | yes | Full JSON payload as the collector serialized it |
+| `fetched_at` | TEXT | no | Default `datetime('now')` |
 
-**Indexes**: UNIQUE(`provider`, `external_id`).
+**PK**: (`id`, `source`) — an ADO `42` and a JIRA `42` are distinct rows.
+
+The composite `(id, source)` key replaced the `(provider, external_id)` shape earlier
+drafts of this page described; `provider`, `external_id`, `work_item_type`, and `state`
+have never existed in the shipped schema.
+
+`raw_json` is the one column whose contract does not constrain what a future writer puts
+in it — today's writer serializes a struct with no description field. `tga inspect attest`
+therefore reads the column rather than citing this table.
 
 ---
 
 ### `commit_work_items`
 
-Many-to-many join table linking commits to work items.
+Many-to-many join between commits and work items. Migration `0005_work_items.sql`.
 
 | Column | Type | Nullable | Notes |
 |---|---|---|---|
-| `commit_id` | INTEGER | no | FK → `commits(id)` ON DELETE CASCADE |
-| `work_item_id` | INTEGER | no | FK → `work_items(id)` ON DELETE CASCADE |
+| `commit_sha` | TEXT | no | Commit SHA (the natural key, not `commits.id`) |
+| `work_item_id` | TEXT | no | FK part 1 → `work_items(id)` |
+| `work_item_source` | TEXT | no | FK part 2 → `work_items(source)` |
 
-**PK**: (`commit_id`, `work_item_id`).
+**PK**: (`commit_sha`, `work_item_id`, `work_item_source`).
+**Indexes**: INDEX(`commit_sha`), INDEX(`work_item_id`, `work_item_source`).
+
+---
+
+### `classification_overrides`
+
+Manual Tier 0 overrides. Entries here take absolute priority over all rule-based and
+LLM classifications. Managed via `tga override add|list|remove`. Migration
+`0006_classification_overrides.sql`.
+
+| Column | Type | Nullable | Notes |
+|---|---|---|---|
+| `commit_sha` | TEXT | no | PK part 1 — commit SHA |
+| `repo_path` | TEXT | no | PK part 2 — repository scope, so a fork can differ |
+| `work_type` | TEXT | no | Subcategory (e.g. `feature`, `bugfix`) |
+| `change_type` | TEXT | no | Top-level category |
+| `notes` | TEXT | yes | Justification — free text |
+| `created_at` | TEXT | no | Default `datetime('now')` |
+
+**PK**: (`commit_sha`, `repo_path`). **Indexes**: INDEX(`commit_sha`).
+
+---
+
+### `repository_analysis_status`
+
+Per-repository classification-coverage bookkeeping. One row per repository name.
+Migration `0006_classification_overrides.sql`.
+
+| Column | Type | Nullable | Notes |
+|---|---|---|---|
+| `repo_name` | TEXT PK | no | Repository name |
+| `last_analyzed_at` | TEXT | no | Default `datetime('now')` |
+| `classification_coverage_pct` | REAL | yes | `classified / total * 100` |
+| `total_commits` | INTEGER | no | Total commits in the DB for this repo; default 0 |
+| `classified_commits` | INTEGER | no | Commits with a non-`uncategorized` verdict; default 0 |
+
+---
+
+### `collection_runs`
+
+Per-(repo, ISO year, ISO week) collection bookkeeping. Presence of a row signals that
+this tuple has already been collected; `--force` bypasses the check. Migrations
+`0004_collection_runs.sql` and `0009_collection_runs_repo_count.sql`.
+
+| Column | Type | Nullable | Notes |
+|---|---|---|---|
+| `id` | INTEGER PK | no | Autoincrement |
+| `repo_name` | TEXT | no | Repository name |
+| `iso_year` | INTEGER | no | ISO year (e.g. 2026) |
+| `iso_week` | INTEGER | no | ISO week number 1–53 |
+| `collected_at` | TEXT | no | ISO 8601 timestamp |
+| `commit_count` | INTEGER | no | Commits collected; default 0 |
+| `repo_count` | INTEGER | no | Size of `repositories[]` at write time; default 0 (`0009`) |
+
+**Indexes**: UNIQUE(`repo_name`, `iso_year`, `iso_week`),
+INDEX(`repo_name`, `iso_year`, `iso_week`).
+
+`repo_count` enables week-over-week baseline drift detection when repository lists change.
+
+---
+
+### `repo_walk_state`
+
+Per-repository full-history walk bookkeeping (issue #6073), so an incremental collection
+knows which tips it has already walked. Migration `0025_repo_walk_state.sql`.
+
+| Column | Type | Nullable | Notes |
+|---|---|---|---|
+| `repository` | TEXT PK | no | Repository name |
+| `head_sha` | TEXT | no | HEAD at the last walk |
+| `head_ref` | TEXT | no | HEAD's symbolic ref at the last walk |
+| `tips_digest` | TEXT | no | Digest over the tip set the walk covered |
+| `walk_scope` | TEXT | no | Scope label for that walk; default `''` |
+| `walk_complete` | INTEGER | no | Boolean — the walk finished; default 0 |
+| `walked_at` | TEXT | no | Timestamp of the walk |
+
+---
+
+### `azdo_iterations`
+
+Azure DevOps iteration/sprint data. Migration `0008_azdo_iterations.sql`.
+
+| Column | Type | Nullable | Notes |
+|---|---|---|---|
+| `id` | TEXT PK | no | ADO iteration GUID |
+| `project` | TEXT | no | ADO project name |
+| `name` | TEXT | no | Iteration display name — free text |
+| `path` | TEXT | yes | Iteration path |
+| `start_date` | TEXT | yes | ISO 8601 date |
+| `finish_date` | TEXT | yes | ISO 8601 date |
+| `time_frame` | TEXT | yes | `past`, `current`, or `future` |
+| `fetched_at` | TEXT | no | Default `datetime('now')` |
+
+**Indexes**: INDEX(`project`).
+
+---
+
+### `pr_reviewers`
+
+Per-PR reviewer records. Migrations `0011_pr_reviewers.sql` and
+`0020_pr_reviewers_review_state.sql`.
+
+| Column | Type | Nullable | Notes |
+|---|---|---|---|
+| `id` | INTEGER PK | no | Autoincrement |
+| `pr_id` | INTEGER | no | FK → `pull_requests(id)` ON DELETE CASCADE |
+| `provider` | TEXT | no | `azdo` or `github`; default `'azdo'` |
+| `reviewer_id` | TEXT | no | Upstream identity ID |
+| `display_name` | TEXT | yes | Human-readable name |
+| `vote` | INTEGER | no | ADO vote: 10 approved, 5 approved-with-suggestions, 0 no-vote, -5 waiting, -10 rejected; default 0 |
+| `is_required` | BOOLEAN | no | Whether reviewer approval is required; default 0 |
+| `is_container` | BOOLEAN | no | Whether the entry is a group/team; default 0 |
+| `review_state` | TEXT | yes | GitHub review state: `APPROVED`, `CHANGES_REQUESTED`, `COMMENTED`, `DISMISSED` (`0020`) |
+| `submitted_at` | TEXT | yes | GitHub review timestamp (`0020`) |
+
+**Indexes**: UNIQUE(`pr_id`, `provider`, `reviewer_id`), INDEX(`pr_id`).
+
+---
+
+### `fact_deployments`
+
+Canonical DORA deploy-event hub; every DORA query joins through it. Migration
+`0014_dora_tables.sql`.
+
+| Column | Type | Nullable | Notes |
+|---|---|---|---|
+| `deploy_id` | TEXT PK | no | Upstream primary key (Actions run id, release tag) |
+| `repo` | TEXT | no | Repository name |
+| `environment` | TEXT | no | Default `'production'` |
+| `triggered_at` | TIMESTAMP | yes | |
+| `completed_at` | TIMESTAMP | yes | |
+| `status` | TEXT | yes | e.g. `success` |
+| `git_sha` | TEXT | yes | Deployed commit |
+| `git_tag` | TEXT | yes | Deployed tag |
+| `triggered_by_pr` | INTEGER | yes | PR number that triggered the deploy |
+| `source` | TEXT | yes | Ingestion source |
+
+**Indexes**: INDEX(`repo`), INDEX(`triggered_at`), INDEX(`environment`, `status`),
+INDEX(`git_sha`).
+
+---
+
+### `fact_incidents`
+
+Production-incident observations. `mttr_hours` is denormalised on write so DORA
+aggregation stays cheap. Migration `0014_dora_tables.sql`.
+
+| Column | Type | Nullable | Notes |
+|---|---|---|---|
+| `incident_id` | TEXT PK | no | Upstream incident ID |
+| `source` | TEXT | yes | Datadog, PagerDuty, JIRA SRE, … |
+| `detected_at` | TIMESTAMP | yes | |
+| `resolved_at` | TIMESTAMP | yes | |
+| `mttr_hours` | REAL | yes | Denormalised recovery time |
+| `severity` | TEXT | yes | |
+| `triggering_deploy` | TEXT | yes | FK → `fact_deployments(deploy_id)` ON DELETE SET NULL |
+| `repo` | TEXT | yes | |
+| `jira_ticket` | TEXT | yes | |
+
+**Indexes**: INDEX(`repo`), INDEX(`detected_at`), INDEX(`source`).
+
+---
+
+### `deployment_failures`
+
+Derived join between a deployment and the commits that caused and fixed a failure.
+Populated by the `tga dora` analysis pass. Migration `0014_dora_tables.sql`.
+
+| Column | Type | Nullable | Notes |
+|---|---|---|---|
+| `id` | INTEGER PK | no | Autoincrement |
+| `deploy_id` | TEXT | yes | FK → `fact_deployments(deploy_id)` ON DELETE SET NULL |
+| `failure_commit_sha` | TEXT | yes | |
+| `recovery_commit_sha` | TEXT | yes | |
+| `detected_at` | TIMESTAMP | yes | |
+| `recovered_at` | TIMESTAMP | yes | |
+
+**Indexes**: INDEX(`deploy_id`), INDEX(`failure_commit_sha`).
+
+---
+
+### `fact_commit_reachability`
+
+Whether a commit is reachable from the default branch, any tag, or a release branch
+(issue #279). A separate fact table rather than columns on `commits`, so the reachability
+pass can re-run independently of collection. Migration
+`0015_tag_release_branch_reachability.sql`.
+
+| Column | Type | Nullable | Notes |
+|---|---|---|---|
+| `commit_sha` | TEXT PK | no | FK → `commits(sha)` ON DELETE CASCADE |
+| `on_default_branch` | INTEGER | no | Boolean; default 0 |
+| `on_any_tag` | INTEGER | no | Boolean; default 0 |
+| `reachable_from_tags` | TEXT | no | JSON array of tag names; default `'[]'` |
+| `on_release_branch` | INTEGER | no | Boolean; default 0 |
+| `release_branches` | TEXT | no | JSON array of branch names; default `'[]'` |
+
+**Indexes**: INDEX(`on_any_tag`), INDEX(`on_release_branch`), INDEX(`on_default_branch`).
+
+---
+
+### `fact_commit_effort`
+
+Per-commit empirical effort scores, written by `tga backfill effort`. Migrations
+`0016_fact_commit_effort.sql` and `0017_pushdown_445.sql`.
+
+| Column | Type | Nullable | Notes |
+|---|---|---|---|
+| `sha` | TEXT | no | PK part 1 |
+| `repository` | TEXT | no | PK part 2 — the same SHA can appear in a fork or mirror |
+| `size` | TEXT | no | `XS` / `S` / `M` / `L` / `XL`, from absolute score thresholds |
+| `score` | REAL | no | v1 formula: α·log₂(LoC+1) + β·log₂(files+1) + δ·tests_factor |
+| `loc` | INTEGER | no | Insertions + deletions |
+| `files` | INTEGER | no | |
+| `test_loc` | INTEGER | no | |
+| `tests_factor` | REAL | no | |
+| `formula_version` | TEXT | no | Default `'v1'` |
+| `computed_at` | INTEGER | no | Unix timestamp (seconds) |
+| `effort_tshirt` | INTEGER | yes | Corpus-percentile band 1–5 (`0017`) |
+
+**PK**: (`sha`, `repository`).
+**Indexes**: INDEX(`size`), INDEX(`repository`), INDEX(`score`), INDEX(`effort_tshirt`).
+
+`size` and `effort_tshirt` diverge on purpose: `size` bands the absolute score, while
+`effort_tshirt` ranks the commit against the corpus percentiles in
+`effort_percentile_thresholds`.
+
+---
+
+### `effort_percentile_thresholds`
+
+The p20/p40/p60/p80 breakpoints an incremental insert bins against, so single-commit
+ingestion does not re-scan the corpus. Migration `0019_effort_percentile_stats.sql`.
+
+| Column | Type | Nullable | Notes |
+|---|---|---|---|
+| `dataset` | TEXT PK | no | `'default'` for the main corpus |
+| `p20` | REAL | no | |
+| `p40` | REAL | no | |
+| `p60` | REAL | no | |
+| `p80` | REAL | no | |
+| `sample_count` | INTEGER | no | Corpus size the breakpoints were computed over |
+| `computed_at` | INTEGER | no | Unix timestamp (seconds) |
+
+---
+
+### `fact_weekly_quality`
+
+Per-engineer-per-week quality scores, UPSERTed by the report aggregator so downstream
+warehouses can join on them without re-running it. Migration
+`0018_fact_weekly_quality.sql`.
+
+| Column | Type | Nullable | Notes |
+|---|---|---|---|
+| `author_email` | TEXT | no | PK part 1 — canonical email |
+| `iso_year` | INTEGER | no | PK part 2 |
+| `iso_week` | INTEGER | no | PK part 3 (1–53) |
+| `repository` | TEXT | no | PK part 4 |
+| `quality_score` | REAL | no | [0.0, 1.0]; 0.35·(1−revert_rate) + 0.40·(1−bugfix_rate) + 0.25·ticket_rate |
+| `quality_tshirt` | INTEGER | no | Band 1–5 (5 = best) |
+| `revert_count` | INTEGER | no | Default 0 |
+| `bugfix_count` | INTEGER | no | Default 0 |
+| `ticketed_count` | INTEGER | no | Default 0 |
+| `commit_count` | INTEGER | no | Default 0 |
+| `formula_version` | TEXT | no | Default `'v1'` |
+| `computed_at` | INTEGER | no | Unix timestamp (seconds); default 0 |
+
+**PK**: (`author_email`, `iso_year`, `iso_week`, `repository`).
+**Indexes**: INDEX(`iso_year`, `iso_week`), INDEX(`author_email`), INDEX(`repository`).
+
+---
+
+### `fact_weekly_engineer`
+
+Per-engineer-per-week agentic-authorship roll-up (issue #1113). Created by migration 21.
+`0021_agentic_mode.sql` is a reference copy the runner does not execute — the live
+statements are in `src/core/db/migrations/v21.rs`, which guards `commits.agentic_mode`
+with a `PRAGMA table_info` check because SQLite has no `ADD COLUMN IF NOT EXISTS`.
+
+| Column | Type | Nullable | Notes |
+|---|---|---|---|
+| `author_email` | TEXT | no | PK part 1 |
+| `iso_year` | INTEGER | no | PK part 2 |
+| `iso_week` | INTEGER | no | PK part 3 |
+| `repository` | TEXT | no | PK part 4 |
+| `net_commits` | INTEGER | no | Default 0 |
+| `agentic_count` | INTEGER | no | Commits with `agentic_mode = 'full_agentic'`; default 0 |
+| `ide_assisted_count` | INTEGER | no | Commits with `agentic_mode = 'ide_assisted'`; default 0 |
+| `agentic_pct` | REAL | no | Default 0.0 |
+| `formula_version` | TEXT | no | Default `'v1'` |
+| `computed_at` | INTEGER | no | Unix timestamp (seconds); default 0 |
+
+**PK**: (`author_email`, `iso_year`, `iso_week`, `repository`).
+**Indexes**: INDEX(`iso_year`, `iso_week`), INDEX(`author_email`), INDEX(`repository`).
+
+---
+
+### `fact_ticket_transitions`
+
+One row per JIRA changelog status transition, written by `tga jira sync` (issue #3966).
+Migration `0023_jira_ingestion.sql`.
+
+| Column | Type | Nullable | Notes |
+|---|---|---|---|
+| `ticket_key` | TEXT | no | PK part 1 |
+| `project_key` | TEXT | no | |
+| `from_status` | TEXT | yes | NULL for a ticket's initial creation state |
+| `to_status` | TEXT | no | PK part 3 |
+| `transitioned_at` | TEXT | no | PK part 2 — RFC3339 |
+| `author` | TEXT | yes | NULL when JIRA reports no changelog author |
+| `synced_at` | INTEGER | no | Unix seconds when tga wrote the row |
+
+**PK**: (`ticket_key`, `transitioned_at`, `to_status`).
+**Indexes**: INDEX(`project_key`), INDEX(`synced_at`), INDEX(`ticket_key`).
+
+---
+
+### `fact_jira_comment_detail`
+
+One row per JIRA comment. Stores the comment's LENGTH, never its text. Migration
+`0023_jira_ingestion.sql`.
+
+| Column | Type | Nullable | Notes |
+|---|---|---|---|
+| `ticket_key` | TEXT | no | PK part 1 |
+| `comment_id` | TEXT | no | PK part 2 |
+| `project_key` | TEXT | no | |
+| `author` | TEXT | yes | NULL when JIRA reports no comment author |
+| `created_at` | TEXT | no | RFC3339 |
+| `body_len` | INTEGER | no | Length of the comment body; see `collect::jira::client` for the ADF-vs-plain-text caveat |
+| `synced_at` | INTEGER | no | Unix seconds when tga wrote the row |
+
+**PK**: (`ticket_key`, `comment_id`).
+**Indexes**: INDEX(`project_key`), INDEX(`synced_at`).
+
+---
+
+### `jira_sync_cursor`
+
+Per-project incremental-sync cursor for `tga jira sync`. Migration
+`0023_jira_ingestion.sql`.
+
+| Column | Type | Nullable | Notes |
+|---|---|---|---|
+| `project_key` | TEXT PK | no | |
+| `last_synced_at` | TEXT | no | RFC3339 — the JQL `updated >=` bound for the next run |
+| `last_run_at` | TEXT | no | RFC3339 — wall clock of the last successful sync |
+| `tickets_synced` | INTEGER | no | Default 0 |
 
 ---
 
 ### `fact_pm_work`
 
-PM ticket meaningfulness verdicts — the WORK tier of the Activity / Work / Effort
-model, filtering raw ticket activity down to the subset that represents real
-management labor (issue #3916). Populated by `tga backfill pm-work`.
+PM ticket meaningfulness verdicts — the WORK tier of the Activity / Work / Effort model,
+filtering raw ticket activity down to the subset that represents real management labor
+(issue #3916). Populated by `tga backfill pm-work`. Migration `0026_fact_pm_work.sql`.
 
 Rows here are counted in tickets; `fact_commit_effort` rows are counted in commit
 effort points. The two are incommensurable and must never share a visualization
@@ -192,103 +630,6 @@ axis (issue #3917).
 classifier replaces a verdict rather than accumulating one row per version.
 
 **Indexes**: INDEX(`is_meaningful`), INDEX(`exclusion_reason`), INDEX(`pm_name`, `week_key`).
-
----
-
-### `classification_overrides`
-
-Manual Tier 0 overrides. Entries here take absolute priority over all rule-based and
-LLM classifications. Managed via `tga override add|list|remove`.
-
-| Column | Type | Nullable | Notes |
-|---|---|---|---|
-| `id` | INTEGER PK | no | Autoincrement |
-| `commit_sha` | TEXT | no | Commit SHA |
-| `repo` | TEXT | yes | Repository name scope; NULL = applies to all repos |
-| `work_type` | TEXT | no | Override work type |
-| `change_type` | TEXT | no | Override change type |
-| `notes` | TEXT | yes | Justification/notes |
-| `created_at` | TEXT | no | ISO 8601 timestamp |
-
-**Indexes**: UNIQUE(`commit_sha`, `repo`).
-
----
-
-### `collection_runs`
-
-Per-(repo, ISO year, ISO week) collection bookkeeping. Presence of a row signals that
-this (repo, year, week) tuple has already been collected. The `--force` flag bypasses
-this check and allows re-collection.
-
-| Column | Type | Nullable | Notes |
-|---|---|---|---|
-| `id` | INTEGER PK | no | Autoincrement |
-| `repo_name` | TEXT | no | Repository name |
-| `iso_year` | INTEGER | no | ISO year (e.g. `2025`) |
-| `iso_week` | INTEGER | no | ISO week number 1–53 |
-| `collected_at` | TEXT | no | ISO 8601 timestamp |
-| `commit_count` | INTEGER | no | Number of commits collected; default 0 |
-| `repo_count` | INTEGER | no | Size of `repositories[]` at write time; default 0 |
-
-**Indexes**: UNIQUE(`repo_name`, `iso_year`, `iso_week`), INDEX(`repo_name`, `iso_year`, `iso_week`).
-
-`repo_count` (added in migration `0009`) enables week-over-week baseline drift detection
-when repository lists change.
-
----
-
-### `repository_analysis_status`
-
-Per-repository tracking of pipeline state. One row per repository name.
-
-| Column | Type | Nullable | Notes |
-|---|---|---|---|
-| `repo_name` | TEXT PK | no | Repository name |
-| `last_collected_at` | TEXT | yes | ISO 8601 timestamp |
-| `last_classified_at` | TEXT | yes | ISO 8601 timestamp |
-| `last_reported_at` | TEXT | yes | ISO 8601 timestamp |
-| `total_commits` | INTEGER | no | Total commits in DB for this repo |
-| `classified_commits` | INTEGER | no | Commits with a classification |
-| `classification_coverage_pct` | REAL | yes | `classified / total * 100` |
-| `config_hash` | TEXT | yes | BLAKE3 hash of config inputs; used to detect config drift |
-
----
-
-### `azdo_iterations`
-
-Azure DevOps iteration/sprint data.
-
-| Column | Type | Nullable | Notes |
-|---|---|---|---|
-| `id` | INTEGER PK | no | Autoincrement |
-| `iteration_id` | TEXT | no | ADO iteration ID |
-| `name` | TEXT | yes | Iteration display name |
-| `project` | TEXT | no | ADO project name |
-| `start_date` | TEXT | yes | ISO 8601 date |
-| `finish_date` | TEXT | yes | ISO 8601 date |
-| `fetched_at` | TEXT | no | ISO 8601 timestamp |
-
-**Indexes**: UNIQUE(`iteration_id`, `project`).
-
----
-
-### `pr_reviewers`
-
-Per-PR reviewer records. Supports ADO reviewer votes; the `provider` column allows
-future expansion to GitHub review requests.
-
-| Column | Type | Nullable | Notes |
-|---|---|---|---|
-| `id` | INTEGER PK | no | Autoincrement |
-| `pr_id` | INTEGER | no | FK → `pull_requests(id)` ON DELETE CASCADE |
-| `provider` | TEXT | no | `azdo`; future: `github`; default `azdo` |
-| `reviewer_id` | TEXT | no | Upstream identity ID |
-| `display_name` | TEXT | yes | Human-readable name |
-| `vote` | INTEGER | yes | ADO vote: 10=approved, 5=approved-with-suggestions, 0=no-vote, -5=waiting, -10=rejected |
-| `is_required` | INTEGER | yes | Boolean — whether reviewer approval is required |
-| `is_container` | INTEGER | yes | Boolean — whether entry represents a group/team |
-
-**Indexes**: UNIQUE(`pr_id`, `provider`, `reviewer_id`), INDEX(`pr_id`).
 
 ---
 
@@ -344,25 +685,73 @@ unit — the two must never share a visualization axis. See #3917.
 
 ---
 
+### `schema_migrations`
+
+Migration bookkeeping, created by the runner itself before the first migration
+(`src/core/db/migrations/mod.rs`, `ensure_migrations_table`).
+
+| Column | Type | Nullable | Notes |
+|---|---|---|---|
+| `version` | INTEGER PK | no | Migration version |
+| `name` | TEXT | no | Migration label |
+| `applied_at` | TEXT | no | RFC3339 |
+
+---
+
+## Views
+
+All four are thin wrappers over `fact_deployments` / `fact_incidents`, added by
+`0014_dora_tables.sql` so reports do not re-write the same aggregation three times.
+
+| View | What it returns |
+|---|---|
+| `v_deployment_frequency` | Weekly count of successful production deploys per repo |
+| `v_lead_time` | Hours between a commit's author date and the production deploy of that SHA |
+| `v_mttr` | Incident detection-to-resolution hours, from `fact_incidents.mttr_hours` |
+| `v_change_failure_rate` | Per-repo weekly failed/total deploy ratio |
+
+---
+
 ## Migration History
 
-Migrations are applied in order from `src/core/db/sql/`. Never modify an applied
-migration — always add a new one.
+Migrations live in `src/core/db/sql/` and are registered in
+`src/core/db/migrations/mod.rs`. Never modify an applied migration — always add a new one.
 
-| File | Description |
-|---|---|
-| `0001_initial_schema.sql` | Core tables: `authors`, `commits`, `classifications`, `files`, `pull_requests` |
-| `0002_linear_issues.sql` | `linear_issues` table |
-| `0003_commits_ticketed.sql` | `ticketed` and `ticket_id` columns on `commits` |
-| `0004_collection_runs.sql` | `collection_runs` table for per-week bookkeeping |
-| `0005_work_items.sql` | `work_items` and `commit_work_items` tables |
-| `0006_classification_overrides.sql` | `classification_overrides` table (Tier 0) |
-| `0007_pr_metrics_and_backfill.sql` | PR metrics columns; `is_revert` on `commits` |
-| `0008_azdo_iterations.sql` | `azdo_iterations` table |
-| `0009_collection_runs_repo_count.sql` | `repo_count` column on `collection_runs` |
-| `0010_pull_requests_provider.sql` | `provider` column and updated UNIQUE index on `pull_requests` |
-| `0011_pr_reviewers.sql` | `pr_reviewers` table |
-| `0012_repository_analysis_status.sql` | `repository_analysis_status` table |
-| `0013_commits_complexity.sql` | `complexity` column on `commits` (1–5 scale) |
+| Version | File | Description |
+|---|---|---|
+| 1 | `0001_initial_schema.sql` | `authors`, `commits`, `classifications`, `files`, `pull_requests` |
+| 2 | `0002_linear_issues.sql` | `linear_issues` table |
+| 3 | `0003_commits_ticketed.sql` | `ticketed` column on `commits` |
+| 4 | `0004_collection_runs.sql` | `collection_runs` table for per-week bookkeeping |
+| 5 | `0005_work_items.sql` | `work_items` and `commit_work_items` tables |
+| 6 | `0006_classification_overrides.sql` | `classification_overrides` and `repository_analysis_status` tables |
+| 7 | `0007_pr_metrics_and_backfill.sql` | `is_revert` and `ticket_id` columns on `commits` |
+| 8 | `0008_azdo_iterations.sql` | `azdo_iterations` table |
+| 9 | `0009_collection_runs_repo_count.sql` | `repo_count` column on `collection_runs` |
+| 10 | `0010_pull_requests_provider.sql` | `provider` column and UNIQUE(`provider`, `pr_number`) on `pull_requests` |
+| 11 | `0011_pr_reviewers.sql` | `pr_reviewers` table |
+| 12 | `0012_pull_requests_repository.sql` | `repository` column on `pull_requests`; UNIQUE index rebuilt as (`provider`, `repository`, `pr_number`) |
+| 13 | `0013_complexity.sql` | `complexity` column on `classifications` |
+| 14 | `0014_dora_tables.sql` | `fact_deployments`, `fact_incidents`, `deployment_failures`, and the four DORA views |
+| 15 | `0015_tag_release_branch_reachability.sql` | `fact_commit_reachability` table |
+| 16 | `0016_fact_commit_effort.sql` | `fact_commit_effort` table |
+| 17 | `0017_pushdown_445.sql` | `classifications.top_level_category`, `fact_commit_effort.effort_tshirt`, `commits.is_ai_assisted` / `commits.ai_tool`; applied through `migrations/v17.rs` for its column guard |
+| 18 | `0018_fact_weekly_quality.sql` | `fact_weekly_quality` table |
+| 19 | `0019_effort_percentile_stats.sql` | `effort_percentile_thresholds` table |
+| 20 | `0020_pr_reviewers_review_state.sql` | `review_state` and `submitted_at` columns on `pr_reviewers` |
+| 21 | `0021_agentic_mode.sql` | `commits.agentic_mode` and the `fact_weekly_engineer` table; applied through `migrations/v21.rs` for its column guard |
+| 22 | `0022_pull_requests_fetched_at.sql` | `fetched_at` column on `pull_requests` — the stale-write guard |
+| 23 | `0023_jira_ingestion.sql` | `fact_ticket_transitions`, `fact_jira_comment_detail`, `jira_sync_cursor` tables |
+| 24 | `0024_pull_requests_head_ref_and_body_ticket.sql` | `head_ref` and `body_ticket_id` columns on `pull_requests` |
+| 25 | `0025_repo_walk_state.sql` | `repo_walk_state` table |
+| 26 | `0026_fact_pm_work.sql` | `fact_pm_work` table |
+| 27 | `0027_fact_pm_effort.sql` | `fact_pm_effort` table |
 
-Future migrations continue from `0014_*.sql`.
+Migrations 17 and 21 carry a `PRAGMA table_info` pre-flight guard, because a pre-release
+build may already have added their columns and SQLite has no
+`ALTER TABLE … ADD COLUMN IF NOT EXISTS`. `migrations/mod.rs` routes both to a Rust
+module — `v17.rs` and `v21.rs` — so their `.sql` files are read as reference rather than
+executed. Migration 21's registry entry carries an empty `sql` string to make that
+explicit.
+
+Future migrations continue from `0028_*.sql`.


### PR DESCRIPTION
## Outcome

Add `tga inspect schema` and `tga inspect attest` commands to reveal database structure and no-content claims. Rebuild `docs/trusty-git-analytics/requirements/database-schema.md` from the migration SQL.

Refs #5218

## Changes

- `inspect schema`: read-only database open, lists every table, column, and live row count, calls out free-text and embedded-payload columns.
- `inspect attest`: scans every non-constrained TEXT column at runtime for populated count, max bytes, and diff-shaped rows (newlines normalised so JSON-escaped diffs are caught); returns exit 1 when findings are present.
- The `diff_for_commit` no-persistence property is an enforced test that pins the caller list.
- `docs/trusty-git-analytics/requirements/database-schema.md` rebuilt from migration SQL: history 1→27, eight sections corrected, thirteen tables and four views added.

## Risk

Rung 3 (read-only inspection, no migration added). Blast radius: tga module only. Schema documentation is regenerated, not hand-authored. tga stays 6.0.1 (above crates.io 6.0.0).

## Tests

```
cargo fmt --all --check && cargo clippy -p tga --all-targets -- -D warnings   # exit 0
cargo test -p tga --no-fail-fast            # lib 1539 passed, 0 failed, 7 ignored; 10 targets ok
cargo test -p trusty-analyze --no-fail-fast # direct dependent, 568 passed, 0 failed
bash scripts/check_changelog_fragment.sh && bash scripts/check_line_cap.sh && bash scripts/check_test_pointers.sh && bash scripts/check_sld.sh && bash scripts/check_rustdoc_links.sh   # OK
```

## Baseline

`check_semver.sh --crate tga` reports a pre-existing BREAK from PR #6729's `InstallArgs` fields, tracked in #6744; this branch does not touch install*.rs.

## Docs

Changelog fragment added. Schema documentation regenerated from SQL.

## Review

Code-critic BLOCK at the first commit (JSON-escaped diffs were not counted; the raw_json assertion was missing), fixed in the second commit with the assertion shown failing before and passing after; re-review APPROVE with the mutation reproduced by the critic.

Pre-push credential scan over `git diff origin/main...HEAD`: PASS, 14 + 3 files.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
