### PR TITLE
feat(tga): Bitbucket workspace discovery (Refs #5220)

### DIFF
--- a/crates/trusty-git-analytics/changelog.d/5220-bitbucket-workspace-discovery-changed.md
+++ b/crates/trusty-git-analytics/changelog.d/5220-bitbucket-workspace-discovery-changed.md
@@ -1,0 +1,8 @@
+Changed
+
+- `bitbucket.repo_slug` and `bitbucket.workspace` are required only when
+  `bitbucket.workspaces` is empty. A config that names workspaces to discover
+  supplies neither. (#5220)
+- `BitbucketClient::fetch_pr_commits` takes the workspace and repository slug as
+  arguments rather than reading them off the client, which now covers many
+  repositories. (#5220)

--- a/crates/trusty-git-analytics/changelog.d/5220-bitbucket-workspace-discovery-fixed.md
+++ b/crates/trusty-git-analytics/changelog.d/5220-bitbucket-workspace-discovery-fixed.md
@@ -1,0 +1,7 @@
+Fixed
+
+- A Bitbucket workspace that cannot be read no longer reads as a workspace with
+  no repositories. A rejected credential surfaces as `CollectError::BitbucketApi`
+  carrying the HTTP status and Bitbucket's own explanation, a rate limit as
+  `CollectError::Throttled` with any `Retry-After` hint, and the 5 000-repository
+  page cap logs that the set is partial. (#5220)

--- a/crates/trusty-git-analytics/changelog.d/5220-bitbucket-workspace-discovery.md
+++ b/crates/trusty-git-analytics/changelog.d/5220-bitbucket-workspace-discovery.md
@@ -11,6 +11,7 @@ Added
   the rest of the batch. (#5220)
 - `tga install --host bitbucket --workspace <WORKSPACE>` derives the repository
   set from the API, so `--repo` is now optional there. The generated config
-  emits `bitbucket.workspaces`, which is what makes it load back: the old output
-  named a `workspace` with no `repo_slug`, and the validator rejected exactly
-  that. (#5220)
+  emits `bitbucket.workspaces`, so `tga collect --validate-only` accepts it. The
+  generated block used to name a `workspace` with `fetch_prs: true` and no
+  `repo_slug` — it deserialized, but validation then refused it with "Bitbucket
+  config incomplete: repo_slug is required when fetch_prs = true". (#5220)

--- a/crates/trusty-git-analytics/changelog.d/5220-bitbucket-workspace-discovery.md
+++ b/crates/trusty-git-analytics/changelog.d/5220-bitbucket-workspace-discovery.md
@@ -1,0 +1,16 @@
+Added
+
+- Bitbucket Cloud workspace-to-repository discovery. `bitbucket.workspaces` is a
+  new config list whose every entry is paged over
+  `GET /2.0/repositories/{workspace}` — Bitbucket's `next`-cursor convention,
+  the same shape `discover_org_repos` has had for a GitHub org since #742. The
+  discovered repositories are unioned with the singular
+  `bitbucket.workspace`/`repo_slug` pair, and one `BitbucketClient` now collects
+  pull requests across the whole set instead of one repository. A workspace that
+  fails is logged and skipped, and a repository that fails no longer discards
+  the rest of the batch. (#5220)
+- `tga install --host bitbucket --workspace <WORKSPACE>` derives the repository
+  set from the API, so `--repo` is now optional there. The generated config
+  emits `bitbucket.workspaces`, which is what makes it load back: the old output
+  named a `workspace` with no `repo_slug`, and the validator rejected exactly
+  that. (#5220)

--- a/crates/trusty-git-analytics/src/collect/bitbucket/client.rs
+++ b/crates/trusty-git-analytics/src/collect/bitbucket/client.rs
@@ -37,7 +37,7 @@ const USER_AGENT_VALUE: &str = "trusty-git-analytics/0.1";
 /// Default Bitbucket Cloud REST base URL.
 const BITBUCKET_API_BASE: &str = "https://api.bitbucket.org/2.0";
 /// Page size for paginated list endpoints (Bitbucket Cloud caps at 50).
-const PAGE_SIZE: u32 = 50;
+pub(crate) const PAGE_SIZE: u32 = 50;
 /// Maximum retry attempts for transient failures (5xx, 429).
 const MAX_RETRIES: u32 = 3;
 /// Base delay (in milliseconds) for exponential backoff: 1s, 2s, 4s.
@@ -146,13 +146,19 @@ fn resolve_auth(config: &BitbucketConfig, env: impl Fn(&str) -> Option<String>) 
 pub struct BitbucketClient {
     client: reqwest::Client,
     auth: BbAuth,
-    workspace: String,
-    repo_slug: String,
+    /// `(workspace, repo_slug)` pairs this client collects pull requests for.
+    ///
+    /// Empty for a client built by [`BitbucketClient::new_for_discovery`],
+    /// whose only job is to page `GET /2.0/repositories/{workspace}` (#5220).
+    repos: Vec<(String, String)>,
     api_base: String,
+    /// Transient-failure retry budget. Always [`MAX_RETRIES`] in production;
+    /// tests lower it so a permanent-429 case does not sleep for 7 seconds.
+    max_retries: u32,
 }
 
 impl BitbucketClient {
-    /// Build a client from a [`BitbucketConfig`].
+    /// Build a single-repository client from a [`BitbucketConfig`].
     ///
     /// Credential precedence:
     /// 1. Bearer `token` (config, then `BITBUCKET_TOKEN` env).
@@ -181,6 +187,52 @@ impl BitbucketClient {
             .ok_or_else(|| CollectError::Config("bitbucket.repo_slug is required".into()))?
             .to_string();
 
+        Self::build(config, vec![(workspace, repo_slug)])
+    }
+
+    /// Build a client over an explicit repository set (#5220).
+    ///
+    /// Why: workspace discovery answers with many `(workspace, repo_slug)`
+    /// pairs, and the collector must fetch pull requests for all of them — the
+    /// same shape `GitHubClient::new_for_prs` already takes.
+    /// What: same credential and base-URL resolution as [`Self::new`], with the
+    /// repository set supplied by the caller instead of read from
+    /// `workspace`/`repo_slug`.
+    /// Test: `fetch_pull_requests_covers_every_configured_repo`.
+    ///
+    /// # Errors
+    ///
+    /// - [`CollectError::Config`] if `repos` is empty or no usable auth mode is
+    ///   available.
+    /// - [`CollectError::Http`] if the `reqwest::Client` cannot be built.
+    pub fn new_for_repos(config: &BitbucketConfig, repos: Vec<(String, String)>) -> Result<Self> {
+        if repos.is_empty() {
+            return Err(CollectError::Config(
+                "bitbucket: no repositories to collect — set `repo_slug` or `workspaces`".into(),
+            ));
+        }
+        Self::build(config, repos)
+    }
+
+    /// Build a client that carries credentials but no repository set (#5220).
+    ///
+    /// Why: workspace discovery runs BEFORE any repository is known, and the
+    /// common-entry-point rule says it must not construct a second HTTP client
+    /// of its own — it borrows this one, headers, auth, retry and all.
+    /// What: [`Self::build`] with an empty repository set. Calling
+    /// [`Self::fetch_pull_requests`] on the result yields no pull requests,
+    /// which is correct: it collects nothing.
+    /// Test: `workspace_discovery_follows_next_cursor`.
+    ///
+    /// # Errors
+    ///
+    /// Same as [`Self::new_for_repos`], minus the empty-repository-set case.
+    pub fn new_for_discovery(config: &BitbucketConfig) -> Result<Self> {
+        Self::build(config, Vec::new())
+    }
+
+    /// The one place a Bitbucket `reqwest::Client` is constructed.
+    fn build(config: &BitbucketConfig, repos: Vec<(String, String)>) -> Result<Self> {
         // Resolve credentials through the live process environment. The
         // env-coupled logic lives in `resolve_auth` so tests can exercise it
         // with an injected lookup instead of mutating `std::env` (issue #1653).
@@ -206,10 +258,45 @@ impl BitbucketClient {
         Ok(Self {
             client,
             auth,
-            workspace,
-            repo_slug,
+            repos,
             api_base,
+            max_retries: MAX_RETRIES,
         })
+    }
+
+    /// The REST root every URL this client builds is rooted at.
+    pub(crate) fn api_base(&self) -> &str {
+        &self.api_base
+    }
+
+    /// Authenticated GET with the shared backoff, for the sibling
+    /// `workspace_discovery` module (#5220).
+    ///
+    /// Why: discovery lives in its own file to keep `client.rs` under the SLOC
+    /// cap, but must reuse this client's headers, credentials and retry policy
+    /// rather than growing a second HTTP path.
+    /// What: delegates to [`Self::retry_request`]. The response is returned
+    /// unclassified — the caller decides what a non-success status means.
+    /// Test: `workspace_discovery_follows_next_cursor`.
+    ///
+    /// # Errors
+    ///
+    /// [`CollectError::Http`] once the transport has failed `max_retries` times.
+    pub(crate) async fn get_with_retry(&self, url: &str) -> Result<reqwest::Response> {
+        self.retry_request(url).await
+    }
+
+    /// Lower the retry budget so a test that always answers 429 finishes now.
+    ///
+    /// Why: [`Self::retry_request`] sleeps 1s, 2s then 4s before giving up, so
+    /// the rate-limit arm of the Fail-Open Check would cost 7 real seconds to
+    /// prove. This seam is `#[cfg(test)]` so no production path can reach it.
+    /// What: replaces [`Self::max_retries`], which defaults to [`MAX_RETRIES`].
+    /// Test: `workspace_discovery_names_a_rate_limit`.
+    #[cfg(test)]
+    pub(crate) fn with_max_retries(mut self, max_retries: u32) -> Self {
+        self.max_retries = max_retries;
+        self
     }
 
     /// Apply the configured auth to a request builder.
@@ -220,7 +307,54 @@ impl BitbucketClient {
         }
     }
 
-    /// Fetch every pull request, following `next` cursors until exhausted.
+    /// Fetch every pull request of every configured repository.
+    ///
+    /// Why (#5220): a discovered workspace hands over many repositories, and
+    /// one 404 among them must not discard the other 199. This mirrors the
+    /// per-repo partial-success precedent the GitHub client set in #87.
+    /// What: calls [`Self::fetch_repo_pull_requests`] per repository, keeping
+    /// what succeeded. A repository that fails is logged and skipped — unless
+    /// EVERY repository failed, in which case the first error is returned so
+    /// the run never reports an empty result it did not observe.
+    /// Test: `fetch_pull_requests_covers_every_configured_repo`,
+    /// `one_failing_repo_does_not_discard_the_others`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CollectError::Http`] on transport or non-success HTTP
+    /// responses, and [`CollectError::Json`] on payload parse failures.
+    pub async fn fetch_pull_requests(&self) -> Result<Vec<PullRequest>> {
+        let mut out: Vec<PullRequest> = Vec::new();
+        let mut first_err: Option<CollectError> = None;
+        let mut ok = 0usize;
+        for (workspace, repo_slug) in &self.repos {
+            match self.fetch_repo_pull_requests(workspace, repo_slug).await {
+                Ok(prs) => {
+                    ok += 1;
+                    out.extend(prs);
+                }
+                Err(e) => {
+                    warn!(
+                        repository = %format!("{workspace}/{repo_slug}"),
+                        error = %e,
+                        "Bitbucket PR fetch failed for one repository; continuing"
+                    );
+                    if first_err.is_none() {
+                        first_err = Some(e);
+                    }
+                }
+            }
+        }
+        if ok == 0 {
+            if let Some(e) = first_err {
+                return Err(e);
+            }
+        }
+        Ok(out)
+    }
+
+    /// Fetch every pull request of one repository, following `next` cursors
+    /// until exhausted.
     ///
     /// State filter is `OPEN,MERGED,DECLINED,SUPERSEDED` — i.e. everything.
     /// Bitbucket's default is open-only, which would drop merged history.
@@ -229,12 +363,16 @@ impl BitbucketClient {
     ///
     /// Returns [`CollectError::Http`] on transport or non-success HTTP
     /// responses, and [`CollectError::Json`] on payload parse failures.
-    pub async fn fetch_pull_requests(&self) -> Result<Vec<PullRequest>> {
+    async fn fetch_repo_pull_requests(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+    ) -> Result<Vec<PullRequest>> {
         let initial = format!(
-            "{}/repositories/{}/{}/pullrequests\
+            "{}/repositories/{workspace}/{repo_slug}/pullrequests\
              ?state=OPEN&state=MERGED&state=DECLINED&state=SUPERSEDED\
              &pagelen={PAGE_SIZE}",
-            self.api_base, self.workspace, self.repo_slug
+            self.api_base
         );
 
         let mut out: Vec<PullRequest> = Vec::new();
@@ -256,11 +394,11 @@ impl BitbucketClient {
 
             let resp = resp.error_for_status()?;
             let page: BbPaged<BbPullRequest> = resp.json().await?;
-            let repository = format!("{}/{}", self.workspace, self.repo_slug);
+            let repository = format!("{workspace}/{repo_slug}");
             for pr in page.values {
                 let pr_number = pr.id;
                 let mut mapped = map_pr(pr, &repository);
-                match self.fetch_pr_commits(pr_number).await {
+                match self.fetch_pr_commits(workspace, repo_slug, pr_number).await {
                     Ok(shas) => {
                         mapped.commit_shas = encode_commit_shas(&shas)?;
                     }
@@ -294,6 +432,8 @@ impl BitbucketClient {
     /// returns.
     /// What: `GET /2.0/repositories/{workspace}/{repo_slug}/pullrequests/{pr_number}/commits`,
     /// following `next` cursors exactly like [`Self::fetch_pull_requests`].
+    /// The repository is a parameter rather than client state since #5220, when
+    /// one client started covering a whole discovered workspace.
     /// Test: `fetch_pr_commits_follows_next_cursor`,
     /// `fetch_pull_requests_persists_full_commit_list`.
     ///
@@ -301,10 +441,16 @@ impl BitbucketClient {
     ///
     /// Returns [`CollectError::Http`] on transport or non-success HTTP
     /// responses, and [`CollectError::Json`] on payload parse failures.
-    pub async fn fetch_pr_commits(&self, pr_number: u64) -> Result<Vec<String>> {
+    pub async fn fetch_pr_commits(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+        pr_number: u64,
+    ) -> Result<Vec<String>> {
         let initial = format!(
-            "{}/repositories/{}/{}/pullrequests/{pr_number}/commits?pagelen={PAGE_SIZE}",
-            self.api_base, self.workspace, self.repo_slug
+            "{}/repositories/{workspace}/{repo_slug}/pullrequests/{pr_number}/commits\
+             ?pagelen={PAGE_SIZE}",
+            self.api_base
         );
 
         let mut out: Vec<String> = Vec::new();
@@ -378,14 +524,14 @@ impl BitbucketClient {
     /// GET with exponential backoff on transient failures (429, 5xx).
     async fn retry_request(&self, url: &str) -> Result<reqwest::Response> {
         let mut last_err: Option<reqwest::Error> = None;
-        for attempt in 0..=MAX_RETRIES {
+        for attempt in 0..=self.max_retries {
             debug!(url = %url, attempt, "GET bitbucket (with retry)");
             match self.authed(self.client.get(url)).send().await {
                 Ok(resp) => {
                     let status = resp.status();
                     let transient =
                         status.as_u16() == 429 || (500..=599).contains(&status.as_u16());
-                    if !transient || attempt == MAX_RETRIES {
+                    if !transient || attempt == self.max_retries {
                         return Ok(resp);
                     }
                     let delay = RETRY_BASE_MS * (1u64 << attempt);
@@ -398,7 +544,7 @@ impl BitbucketClient {
                     tokio::time::sleep(Duration::from_millis(delay)).await;
                 }
                 Err(e) => {
-                    if attempt == MAX_RETRIES {
+                    if attempt == self.max_retries {
                         return Err(CollectError::Http(e));
                     }
                     let delay = RETRY_BASE_MS * (1u64 << attempt);

--- a/crates/trusty-git-analytics/src/collect/bitbucket/client.rs
+++ b/crates/trusty-git-analytics/src/collect/bitbucket/client.rs
@@ -17,6 +17,7 @@
 //!   under pagination) per PR, same tradeoff GitHub's equivalent
 //!   `fetch_pr_commits` makes.
 
+use std::sync::Mutex;
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -155,6 +156,12 @@ pub struct BitbucketClient {
     /// Transient-failure retry budget. Always [`MAX_RETRIES`] in production;
     /// tests lower it so a permanent-429 case does not sleep for 7 seconds.
     max_retries: u32,
+    /// Bounds this client hit, in operator-facing wording (#6084 shape).
+    ///
+    /// A workspace listing that stopped at the page cap returns a repository
+    /// set that reads exactly like a complete one; the notice recorded here is
+    /// what [`crate::collect::pr_pipeline`] turns into a visible run fault.
+    notices: Mutex<Vec<String>>,
 }
 
 impl BitbucketClient {
@@ -261,12 +268,50 @@ impl BitbucketClient {
             repos,
             api_base,
             max_retries: MAX_RETRIES,
+            notices: Mutex::new(Vec::new()),
         })
     }
 
     /// The REST root every URL this client builds is rooted at.
     pub(crate) fn api_base(&self) -> &str {
         &self.api_base
+    }
+
+    /// Carry forward the truncation notices an earlier pass recorded (#5220).
+    ///
+    /// Why: workspace discovery runs on its own short-lived client, so a
+    /// page-cap notice it recorded would die with that client. The collector
+    /// hands the notices to the client that actually reaches
+    /// [`crate::collect::pr_pipeline`], which is the only place they become a
+    /// visible run fault. Same purpose as the shared `RunBudget` the GitHub
+    /// clients pass around (#6565), without a second budget type.
+    /// What: appends `notices` to this client's ledger, which
+    /// [`Self::fetch_notices`] returns.
+    /// Test: `a_truncated_workspace_listing_reaches_the_run_stats`.
+    #[must_use]
+    pub fn with_notices(self, notices: Vec<String>) -> Self {
+        if let Ok(mut ledger) = self.notices.lock() {
+            ledger.extend(notices);
+        }
+        self
+    }
+
+    /// Record that a bound trimmed a result set (#6084).
+    ///
+    /// A poisoned lock drops the notice rather than panicking — losing one
+    /// operator message must not abort a collection run.
+    pub(crate) fn note_truncation(&self, message: impl Into<String>) {
+        if let Ok(mut ledger) = self.notices.lock() {
+            ledger.push(message.into());
+        }
+    }
+
+    /// Every truncation recorded so far, in the order it happened.
+    pub(crate) fn recorded_notices(&self) -> Vec<String> {
+        self.notices
+            .lock()
+            .map(|l| l.clone())
+            .unwrap_or_else(|_| Vec::new())
     }
 
     /// Authenticated GET with the shared backoff, for the sibling
@@ -398,7 +443,10 @@ impl BitbucketClient {
             for pr in page.values {
                 let pr_number = pr.id;
                 let mut mapped = map_pr(pr, &repository);
-                match self.fetch_pr_commits(workspace, repo_slug, pr_number).await {
+                match self
+                    .fetch_pr_commits_in(workspace, repo_slug, pr_number)
+                    .await
+                {
                     Ok(shas) => {
                         mapped.commit_shas = encode_commit_shas(&shas)?;
                     }
@@ -430,18 +478,45 @@ impl BitbucketClient {
     /// and discards the PR's real commit composition (issue #841). This is
     /// the per-PR enrichment call `fetch_pull_requests` makes for every PR it
     /// returns.
+    /// What: delegates to [`Self::fetch_pr_commits_in`] against this client's
+    /// first configured repository — for a client built by [`Self::new`] that
+    /// is the `workspace`/`repo_slug` pair from the config, unchanged.
+    /// Test: `fetch_pr_commits_follows_next_cursor`,
+    /// `fetch_pull_requests_persists_full_commit_list`.
+    ///
+    /// # Errors
+    ///
+    /// [`CollectError::Config`] when the client has no configured repository —
+    /// only reachable through [`Self::new_for_discovery`], which collects
+    /// nothing. Otherwise as [`Self::fetch_pr_commits_in`].
+    pub async fn fetch_pr_commits(&self, pr_number: u64) -> Result<Vec<String>> {
+        // #5220: the signature stays one argument. A discovered workspace made
+        // the client multi-repository, and changing the arity here would have
+        // been a breaking API change for a caller that has exactly one.
+        let (workspace, repo_slug) = self.repos.first().ok_or_else(|| {
+            CollectError::Config(
+                "bitbucket: this client has no configured repository to read commits from".into(),
+            )
+        })?;
+        self.fetch_pr_commits_in(workspace, repo_slug, pr_number)
+            .await
+    }
+
+    /// [`Self::fetch_pr_commits`] against a caller-named repository (#5220).
+    ///
+    /// Why: one client now covers every repository a workspace discovery
+    /// returned, so the PR walk names the repository it is enriching rather
+    /// than reading a single pair off the client.
     /// What: `GET /2.0/repositories/{workspace}/{repo_slug}/pullrequests/{pr_number}/commits`,
     /// following `next` cursors exactly like [`Self::fetch_pull_requests`].
-    /// The repository is a parameter rather than client state since #5220, when
-    /// one client started covering a whole discovered workspace.
-    /// Test: `fetch_pr_commits_follows_next_cursor`,
+    /// Test: `fetch_pull_requests_covers_every_configured_repo`,
     /// `fetch_pull_requests_persists_full_commit_list`.
     ///
     /// # Errors
     ///
     /// Returns [`CollectError::Http`] on transport or non-success HTTP
     /// responses, and [`CollectError::Json`] on payload parse failures.
-    pub async fn fetch_pr_commits(
+    pub async fn fetch_pr_commits_in(
         &self,
         workspace: &str,
         repo_slug: &str,
@@ -663,6 +738,12 @@ impl PrProvider for BitbucketClient {
         prs: &[PullRequest],
     ) -> crate::core::Result<usize> {
         BitbucketClient::store_pull_requests(self, db, prs)
+    }
+
+    /// #5220: surfaces the workspace-discovery page cap the same way the
+    /// GitHub client surfaces its listing caps (#6084).
+    fn fetch_notices(&self) -> Vec<String> {
+        self.recorded_notices()
     }
 }
 

--- a/crates/trusty-git-analytics/src/collect/bitbucket/mod.rs
+++ b/crates/trusty-git-analytics/src/collect/bitbucket/mod.rs
@@ -2,9 +2,15 @@
 //!
 //! Surfaces a single [`BitbucketClient`] that implements
 //! [`crate::collect::pr_provider::PrProvider`], so the pipeline can use it
-//! interchangeably with the GitHub client.
+//! interchangeably with the GitHub client, plus the workspace → repository
+//! discovery that decides which repositories that client covers (#5220).
 
 pub mod client;
 pub mod types;
+pub mod workspace_discovery;
 
 pub use client::BitbucketClient;
+pub use workspace_discovery::{
+    discover_workspace_repos, effective_workspaces, resolve_bitbucket_repos,
+    run_workspace_discovery,
+};

--- a/crates/trusty-git-analytics/src/collect/bitbucket/mod.rs
+++ b/crates/trusty-git-analytics/src/collect/bitbucket/mod.rs
@@ -12,5 +12,5 @@ pub mod workspace_discovery;
 pub use client::BitbucketClient;
 pub use workspace_discovery::{
     discover_workspace_repos, effective_workspaces, resolve_bitbucket_repos,
-    run_workspace_discovery,
+    run_workspace_discovery, WorkspaceDiscovery,
 };

--- a/crates/trusty-git-analytics/src/collect/bitbucket/tests.rs
+++ b/crates/trusty-git-analytics/src/collect/bitbucket/tests.rs
@@ -230,7 +230,10 @@ async fn fetch_pr_commits_follows_next_cursor() {
     })
     .expect("client builds");
 
-    let shas = client.fetch_pr_commits(9).await.expect("fetch");
+    let shas = client
+        .fetch_pr_commits("acme", "widgets", 9)
+        .await
+        .expect("fetch");
     assert_eq!(
         shas,
         vec![
@@ -647,4 +650,180 @@ fn store_pull_requests_applies_genuinely_newer_fetched_at() {
         state, "open",
         "a genuinely newer fetched_at must overwrite the previous row"
     );
+}
+
+/// Every configured repository is fetched, not just the first (#5220).
+///
+/// Why: workspace discovery hands the client many `(workspace, repo_slug)`
+/// pairs. A loop that stopped after one would report a whole workspace's
+/// history as one repository's, and nothing downstream would notice.
+/// What: two repositories, one PR each, one client built through
+/// [`BitbucketClient::new_for_repos`].
+#[tokio::test]
+async fn fetch_pull_requests_covers_every_configured_repo() {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+    let base = server.uri();
+
+    for (slug, id) in [("widgets", 1u64), ("gadgets", 2u64)] {
+        Mock::given(method("GET"))
+            .and(path(format!("/repositories/acme/{slug}/pullrequests")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "values": [{
+                    "id": id,
+                    "title": format!("PR in {slug}"),
+                    "state": "OPEN",
+                    "created_on": "2024-01-01T00:00:00Z",
+                }]
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(format!(
+                "/repositories/acme/{slug}/pullrequests/{id}/commits"
+            )))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"values": []})),
+            )
+            .mount(&server)
+            .await;
+    }
+
+    let client = BitbucketClient::new_for_repos(
+        &BitbucketConfig {
+            token: Some("dummy".into()),
+            workspaces: vec!["acme".into()],
+            fetch_prs: true,
+            api_base_url: Some(base),
+            ..Default::default()
+        },
+        vec![
+            ("acme".to_string(), "widgets".to_string()),
+            ("acme".to_string(), "gadgets".to_string()),
+        ],
+    )
+    .expect("client builds");
+
+    let prs = client.fetch_pull_requests().await.expect("fetch");
+    let mut repositories: Vec<String> = prs.iter().map(|p| p.repository.clone()).collect();
+    repositories.sort();
+    assert_eq!(
+        repositories,
+        vec!["acme/gadgets".to_string(), "acme/widgets".to_string()]
+    );
+}
+
+/// One unreadable repository does not discard the readable one (#5220).
+///
+/// Why: a discovered workspace routinely contains a repository the token
+/// cannot read. Aborting the batch on the first 404 would throw away every
+/// other repository's pull requests. Mirrors the GitHub client's #87
+/// partial-success precedent.
+/// What: `widgets` answers 200, `locked` answers 403; the fetch keeps what it
+/// could read.
+#[tokio::test]
+async fn one_failing_repo_does_not_discard_the_others() {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+    let base = server.uri();
+
+    Mock::given(method("GET"))
+        .and(path("/repositories/acme/widgets/pullrequests"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "values": [{
+                "id": 1,
+                "title": "readable",
+                "state": "OPEN",
+                "created_on": "2024-01-01T00:00:00Z",
+            }]
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/repositories/acme/widgets/pullrequests/1/commits"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"values": []})))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/repositories/acme/locked/pullrequests"))
+        .respond_with(ResponseTemplate::new(403))
+        .mount(&server)
+        .await;
+
+    let client = BitbucketClient::new_for_repos(
+        &BitbucketConfig {
+            token: Some("dummy".into()),
+            fetch_prs: true,
+            api_base_url: Some(base),
+            ..Default::default()
+        },
+        vec![
+            ("acme".to_string(), "widgets".to_string()),
+            ("acme".to_string(), "locked".to_string()),
+        ],
+    )
+    .expect("client builds");
+
+    let prs = client.fetch_pull_requests().await.expect("fetch");
+    assert_eq!(prs.len(), 1, "the readable repository still contributes");
+    assert_eq!(prs[0].repository, "acme/widgets");
+}
+
+/// When EVERY repository fails, the error surfaces rather than an empty list.
+///
+/// Why (#5220): partial success must not become silent total failure — a run
+/// that fetched nothing because the token was rejected has to say so.
+#[tokio::test]
+async fn every_repo_failing_returns_the_error_not_an_empty_list() {
+    use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(401))
+        .mount(&server)
+        .await;
+
+    let client = BitbucketClient::new_for_repos(
+        &BitbucketConfig {
+            token: Some("dummy".into()),
+            fetch_prs: true,
+            api_base_url: Some(server.uri()),
+            ..Default::default()
+        },
+        vec![("acme".to_string(), "widgets".to_string())],
+    )
+    .expect("client builds");
+
+    let err = client
+        .fetch_pull_requests()
+        .await
+        .expect_err("a wholly failed fetch must not read as zero pull requests");
+    assert!(
+        err.to_string().contains("401"),
+        "the status must survive: {err}"
+    );
+}
+
+/// An empty repository set is refused at construction (#5220).
+#[test]
+fn new_for_repos_refuses_an_empty_repository_set() {
+    // `BitbucketClient` has no `Debug` (it holds a live credential), so the
+    // Ok arm is discarded by hand rather than through `expect_err`.
+    let built = BitbucketClient::new_for_repos(
+        &BitbucketConfig {
+            token: Some("dummy".into()),
+            ..Default::default()
+        },
+        Vec::new(),
+    );
+    match built {
+        Err(CollectError::Config(msg)) => assert!(msg.contains("no repositories"), "{msg}"),
+        Err(other) => panic!("expected a Config error, got {other:?}"),
+        Ok(_) => panic!("an empty repository set must not build a client"),
+    }
 }

--- a/crates/trusty-git-analytics/src/collect/bitbucket/tests.rs
+++ b/crates/trusty-git-analytics/src/collect/bitbucket/tests.rs
@@ -230,10 +230,9 @@ async fn fetch_pr_commits_follows_next_cursor() {
     })
     .expect("client builds");
 
-    let shas = client
-        .fetch_pr_commits("acme", "widgets", 9)
-        .await
-        .expect("fetch");
+    // #5220: the one-argument form kept its meaning — the client's configured
+    // `workspace`/`repo_slug` pair.
+    let shas = client.fetch_pr_commits(9).await.expect("fetch");
     assert_eq!(
         shas,
         vec![

--- a/crates/trusty-git-analytics/src/collect/bitbucket/types.rs
+++ b/crates/trusty-git-analytics/src/collect/bitbucket/types.rs
@@ -21,6 +21,26 @@ pub struct BbPaged<T> {
     pub next: Option<String>,
 }
 
+/// A single repository record as returned by
+/// `GET /2.0/repositories/{workspace}` (#5220).
+///
+/// Why: workspace discovery needs the `(workspace, repo_slug)` pair and
+/// nothing else, and Bitbucket hands both back in one field. `slug` is kept as
+/// the fallback because a repository missing `full_name` would otherwise be
+/// dropped silently, and a dropped repository is invisible in the output.
+/// What: `full_name` is `"<workspace>/<repo_slug>"`; `slug` is the second half
+/// on its own. Every other field of the (large) repository payload is ignored.
+/// Test: `workspace_page_deserializes_full_name_and_slug`.
+#[derive(Debug, Deserialize)]
+pub struct BbRepository {
+    /// `"<workspace>/<repo_slug>"`.
+    #[serde(default)]
+    pub full_name: Option<String>,
+    /// Repository slug on its own, used when `full_name` is absent.
+    #[serde(default)]
+    pub slug: Option<String>,
+}
+
 /// A single pull-request record as returned by
 /// `GET /2.0/repositories/{workspace}/{repo_slug}/pullrequests`.
 #[derive(Debug, Deserialize)]

--- a/crates/trusty-git-analytics/src/collect/bitbucket/workspace_discovery.rs
+++ b/crates/trusty-git-analytics/src/collect/bitbucket/workspace_discovery.rs
@@ -22,7 +22,8 @@
 //!
 //! Test: `workspace_discovery_follows_next_cursor`,
 //! `workspace_discovery_names_an_auth_failure`,
-//! `workspace_discovery_names_a_rate_limit`.
+//! `workspace_discovery_names_a_rate_limit`,
+//! `a_truncated_workspace_listing_reaches_the_run_stats`.
 
 use std::collections::HashSet;
 use std::time::Duration;
@@ -115,12 +116,19 @@ pub async fn discover_workspace_repos(
         }
 
         if pages >= MAX_PAGES {
+            // #6084: a warn! alone is invisible in the run's output. The notice
+            // is what `pr_pipeline` turns into a recorded fault.
             warn!(
                 workspace = %workspace,
                 pages = MAX_PAGES,
                 repositories = out.len(),
                 "Bitbucket workspace discovery hit the page cap; the repository set is PARTIAL"
             );
+            client.note_truncation(format!(
+                "Bitbucket workspace listing for {workspace} stopped at the {MAX_PAGES}-page cap \
+                 ({} repositories); the repository set is PARTIAL",
+                MAX_PAGES * PAGE_SIZE
+            ));
             break;
         }
         next_url = page.next;
@@ -220,6 +228,23 @@ fn repo_pair(repo: &BbRepository, workspace: &str) -> Option<(String, String)> {
         .map(|s| (workspace.to_string(), s.to_string()))
 }
 
+/// What a discovery pass found, and what it could not finish.
+///
+/// Why (#6084): the repository set alone cannot say whether it is the whole
+/// workspace or the first 5 000 repositories of it. Returning the notices
+/// alongside is what lets the collector hand them to the client that reaches
+/// [`crate::collect::pr_pipeline`], where they become recorded run faults.
+/// What: `repos` is the deduplicated union across workspaces; `notices` is
+/// empty unless a listing was truncated.
+/// Test: `a_truncated_workspace_listing_reaches_the_run_stats`.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct WorkspaceDiscovery {
+    /// `(workspace, repo_slug)` pairs, deduplicated, in discovery order.
+    pub repos: Vec<(String, String)>,
+    /// Operator-facing notes about bounds the walk hit, in order.
+    pub notices: Vec<String>,
+}
+
 /// Discover every configured workspace's repositories, in order.
 ///
 /// Why: the collector needs one repository set, not one per workspace, and a
@@ -229,18 +254,19 @@ fn repo_pair(repo: &BbRepository, workspace: &str) -> Option<(String, String)> {
 /// [`BitbucketClient::new_for_discovery`], walks each workspace from
 /// [`effective_workspaces`], and unions the results with duplicates removed. A
 /// workspace that fails is logged and skipped; the caller sees the repositories
-/// that were readable.
-/// Test: `run_workspace_discovery_skips_a_failing_workspace`.
-pub async fn run_workspace_discovery(config: &BitbucketConfig) -> Vec<(String, String)> {
+/// that were readable, plus every truncation notice the walk recorded.
+/// Test: `run_workspace_discovery_skips_a_failing_workspace`,
+/// `a_truncated_workspace_listing_reaches_the_run_stats`.
+pub async fn run_workspace_discovery(config: &BitbucketConfig) -> WorkspaceDiscovery {
     let workspaces = effective_workspaces(&config.workspaces);
     if workspaces.is_empty() {
-        return Vec::new();
+        return WorkspaceDiscovery::default();
     }
     let client = match BitbucketClient::new_for_discovery(config) {
         Ok(c) => c,
         Err(e) => {
             warn!("Bitbucket workspace discovery: could not build client: {e}");
-            return Vec::new();
+            return WorkspaceDiscovery::default();
         }
     };
 
@@ -268,7 +294,10 @@ pub async fn run_workspace_discovery(config: &BitbucketConfig) -> Vec<(String, S
             ),
         }
     }
-    all
+    WorkspaceDiscovery {
+        repos: all,
+        notices: client.recorded_notices(),
+    }
 }
 
 /// Union the configured `workspace`/`repo_slug` pair with discovered repos.
@@ -472,8 +501,86 @@ mod tests {
             .await;
 
         let cfg = discovery_config(server.uri(), &["acme", "locked", "acme"]);
-        let repos = run_workspace_discovery(&cfg).await;
-        assert_eq!(repos, vec![("acme".to_string(), "widget".to_string())]);
+        let found = run_workspace_discovery(&cfg).await;
+        assert_eq!(
+            found.repos,
+            vec![("acme".to_string(), "widget".to_string())]
+        );
+        assert!(
+            found.notices.is_empty(),
+            "a listing that completed records no truncation: {:?}",
+            found.notices
+        );
+    }
+
+    /// A listing that never ends stops at the page cap and says so, in the
+    /// run's own fault list rather than only in a log line.
+    ///
+    /// Why (#6084, #5220): 5 000 repositories of a larger workspace read
+    /// exactly like the whole workspace. The notice is the only thing that
+    /// distinguishes them, and it is worth nothing until it reaches
+    /// [`crate::collect::pr_pipeline`]'s drain.
+    /// What: the mock's every page carries a `next` cursor back to itself, so
+    /// the walk can only end at [`MAX_PAGES`]. The notice is then carried onto
+    /// the pull-request client and drained exactly as a real run drains it.
+    /// Test: this test itself.
+    #[tokio::test]
+    async fn a_truncated_workspace_listing_reaches_the_run_stats() {
+        use crate::collect::collector::CollectionStats;
+        use crate::collect::pr_provider::PrProvider;
+        use crate::core::db::Database;
+        use std::sync::Arc;
+
+        let server = MockServer::start().await;
+        let base = server.uri();
+        Mock::given(method("GET"))
+            .and(path("/repositories/acme"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "values": [{"full_name": "acme/widget", "slug": "widget"}],
+                "next": format!("{base}/repositories/acme?cursor=endless"),
+            })))
+            .mount(&server)
+            .await;
+
+        let cfg = discovery_config(base, &["acme"]);
+        let found = run_workspace_discovery(&cfg).await;
+        assert_eq!(
+            found.notices.len(),
+            1,
+            "one bound was hit, so exactly one notice: {:?}",
+            found.notices
+        );
+        assert!(
+            found.notices[0].contains("PARTIAL") && found.notices[0].contains("acme"),
+            "the notice must name the workspace and say the set is partial: {:?}",
+            found.notices
+        );
+
+        // The collector carries the notices onto the client that collects, and
+        // `pr_pipeline` drains them into the run's faults. Drive that drain.
+        let client = BitbucketClient::new_for_repos(&cfg, found.repos.clone())
+            .expect("client builds")
+            .with_notices(found.notices.clone());
+        let providers: Vec<Arc<dyn PrProvider + Send + Sync>> = vec![Arc::new(client)];
+        let mut set: tokio::task::JoinSet<(String, crate::collect::errors::Result<Vec<_>>)> =
+            tokio::task::JoinSet::new();
+        set.spawn(async { ("bitbucket".to_string(), Ok(Vec::new())) });
+
+        let mut db = Database::open_in_memory().expect("open db");
+        let mut stats = CollectionStats::default();
+        crate::collect::pr_pipeline::drain_and_store_pull_requests(
+            set, &providers, &mut db, &mut stats,
+        )
+        .await;
+
+        assert!(
+            stats
+                .errors
+                .iter()
+                .any(|e| e.message.contains("PARTIAL") && e.message.contains("bitbucket")),
+            "the truncation must be a recorded run fault: {:?}",
+            stats.errors
+        );
     }
 
     #[test]

--- a/crates/trusty-git-analytics/src/collect/bitbucket/workspace_discovery.rs
+++ b/crates/trusty-git-analytics/src/collect/bitbucket/workspace_discovery.rs
@@ -1,0 +1,509 @@
+//! Bitbucket Cloud workspace → repository discovery (#5220).
+//!
+//! Why: `bitbucket.workspace` + `bitbucket.repo_slug` names exactly one
+//! repository, so collecting from a workspace of 200 repositories meant
+//! transcribing 200 slugs by hand and re-editing the config every time someone
+//! created a repository. GitHub has had `discover_org_repos` since #742; this
+//! is its Bitbucket counterpart, and it feeds the same `(owner, repo)` repo-set
+//! shape into the same call sites.
+//!
+//! What: [`discover_workspace_repos`] pages `GET /2.0/repositories/{workspace}`
+//! over Bitbucket's `next`-cursor convention, borrowing the credentials, headers
+//! and retry policy of an existing [`BitbucketClient`] rather than building a
+//! second HTTP path. [`effective_workspaces`] normalises the configured list and
+//! [`resolve_bitbucket_repos`] unions the discovered pairs with the singular
+//! `workspace`/`repo_slug` pair.
+//!
+//! Fail-open is the failure mode this module exists to refuse: an unreadable
+//! workspace must never read as an empty one. A rejected credential becomes
+//! [`CollectError::BitbucketApi`], a rate limit becomes
+//! [`CollectError::Throttled`], and the page cap records a truncation warning —
+//! none of the three returns `Ok(vec![])`.
+//!
+//! Test: `workspace_discovery_follows_next_cursor`,
+//! `workspace_discovery_names_an_auth_failure`,
+//! `workspace_discovery_names_a_rate_limit`.
+
+use std::collections::HashSet;
+use std::time::Duration;
+
+use tracing::{debug, info, warn};
+
+use super::client::{BitbucketClient, PAGE_SIZE};
+use super::types::{BbPaged, BbRepository};
+use crate::collect::errors::{CollectError, Result};
+use crate::core::config::BitbucketConfig;
+
+/// Hard bound on pages walked per workspace, mirroring the GitHub org walk.
+///
+/// At [`PAGE_SIZE`] 50 this covers 5 000 repositories; beyond that the walk
+/// stops and says so rather than paging indefinitely against a server whose
+/// cursor never terminates.
+const MAX_PAGES: u32 = 100;
+
+/// Longest response-body excerpt kept in a [`CollectError::BitbucketApi`].
+const MAX_BODY_EXCERPT: usize = 512;
+
+/// Normalise the configured workspace list into the set discovery walks.
+///
+/// Why: a hand-edited YAML list picks up stray whitespace, blank entries and
+/// duplicates, and each duplicate would otherwise cost a full extra page walk.
+/// What: trims, drops empties, and deduplicates while preserving order. The
+/// singular `bitbucket.workspace` is deliberately NOT folded in — it is half of
+/// a repository coordinate, and promoting it to a discovery source would widen
+/// every existing single-repository config to its whole workspace.
+/// Test: `effective_workspaces_trims_and_deduplicates`.
+#[must_use]
+pub fn effective_workspaces(workspaces: &[String]) -> Vec<String> {
+    let mut seen = HashSet::new();
+    let mut out = Vec::new();
+    for w in workspaces.iter().map(|s| s.trim()) {
+        if !w.is_empty() && seen.insert(w.to_string()) {
+            out.push(w.to_string());
+        }
+    }
+    out
+}
+
+/// Page one workspace's repositories over the Bitbucket Cloud REST API.
+///
+/// Why: this is the call `discover_org_repos` makes for GitHub, and the reason
+/// a workspace can be named instead of enumerated.
+/// What: `GET /2.0/repositories/{workspace}?pagelen=50`, following the absolute
+/// `next` URL each page carries until it is absent or [`MAX_PAGES`] is reached.
+/// Each repository yields `(workspace, repo_slug)` parsed from `full_name`,
+/// falling back to `slug` paired with the requested workspace.
+/// Test: `workspace_discovery_follows_next_cursor`,
+/// `workspace_discovery_names_an_auth_failure`,
+/// `workspace_discovery_names_a_rate_limit`.
+///
+/// # Errors
+///
+/// - [`CollectError::Throttled`] when Bitbucket answers 429 after the client's
+///   retry budget is spent.
+/// - [`CollectError::BitbucketApi`] for any other non-success status, carrying
+///   Bitbucket's own explanation (401/403 scope problems included).
+/// - [`CollectError::Http`] on transport failure, [`CollectError::Json`] on a
+///   payload that does not parse.
+pub async fn discover_workspace_repos(
+    client: &BitbucketClient,
+    workspace: &str,
+) -> Result<Vec<(String, String)>> {
+    let mut out: Vec<(String, String)> = Vec::new();
+    let mut next_url = Some(format!(
+        "{}/repositories/{workspace}?pagelen={PAGE_SIZE}",
+        client.api_base()
+    ));
+    let mut pages = 0u32;
+
+    while let Some(url) = next_url.take() {
+        pages += 1;
+        debug!(url = %url, "GET (bitbucket workspace repo discovery)");
+        let resp = client.get_with_retry(&url).await?;
+        warn_when_rate_limit_is_nearly_spent(&resp, workspace);
+        let resp = classify_response(resp, &url).await?;
+
+        let page: BbPaged<BbRepository> = resp.json().await?;
+        for repo in page.values {
+            match repo_pair(&repo, workspace) {
+                Some(pair) => out.push(pair),
+                None => warn!(
+                    workspace = %workspace,
+                    "Bitbucket workspace repo has neither full_name nor slug; skipping"
+                ),
+            }
+        }
+
+        if pages >= MAX_PAGES {
+            warn!(
+                workspace = %workspace,
+                pages = MAX_PAGES,
+                repositories = out.len(),
+                "Bitbucket workspace discovery hit the page cap; the repository set is PARTIAL"
+            );
+            break;
+        }
+        next_url = page.next;
+    }
+
+    debug!(
+        workspace = %workspace,
+        count = out.len(),
+        "bitbucket workspace repo discovery complete"
+    );
+    Ok(out)
+}
+
+/// Turn a non-success response into the named error it deserves.
+///
+/// Why (#5220): `error_for_status()` collapses 401, 403 and 429 into one opaque
+/// [`CollectError::Http`] with no body, and the caller that swallowed it would
+/// report an empty workspace. Naming the two an operator can act on — a
+/// credential the API rejected, and a rate limit — is what makes the failure
+/// legible.
+/// What: 429 becomes [`CollectError::Throttled`] with any `Retry-After` hint;
+/// every other non-success status becomes [`CollectError::BitbucketApi`] with a
+/// truncated body excerpt. A success passes through untouched.
+/// Test: `workspace_discovery_names_an_auth_failure`,
+/// `workspace_discovery_names_a_rate_limit`.
+async fn classify_response(resp: reqwest::Response, url: &str) -> Result<reqwest::Response> {
+    let status = resp.status();
+    if status.is_success() {
+        return Ok(resp);
+    }
+    if status.as_u16() == 429 {
+        let retry_after = resp
+            .headers()
+            .get("retry-after")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.trim().parse::<u64>().ok())
+            .map(Duration::from_secs);
+        return Err(CollectError::Throttled {
+            status: status.as_u16(),
+            retry_after,
+        });
+    }
+    let message = resp.text().await.unwrap_or_default();
+    Err(CollectError::BitbucketApi {
+        status: status.as_u16(),
+        endpoint: url.to_string(),
+        message: excerpt(&message),
+    })
+}
+
+/// Trim a response body to something an error message can carry.
+fn excerpt(body: &str) -> String {
+    let trimmed = body.trim();
+    if trimmed.is_empty() {
+        return "<empty response body>".to_string();
+    }
+    match trimmed.char_indices().nth(MAX_BODY_EXCERPT) {
+        Some((idx, _)) => format!("{}…", &trimmed[..idx]),
+        None => trimmed.to_string(),
+    }
+}
+
+/// Log when Bitbucket says the request budget is nearly gone.
+fn warn_when_rate_limit_is_nearly_spent(resp: &reqwest::Response, workspace: &str) {
+    if let Some(rem) = resp
+        .headers()
+        .get("x-ratelimit-remaining")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse::<u32>().ok())
+    {
+        if rem < 5 {
+            warn!(
+                remaining = rem,
+                workspace = %workspace,
+                "Bitbucket rate limit nearly exhausted during workspace discovery"
+            );
+        }
+    }
+}
+
+/// Extract `(workspace, repo_slug)` from one discovered repository.
+fn repo_pair(repo: &BbRepository, workspace: &str) -> Option<(String, String)> {
+    if let Some((ws, slug)) = repo
+        .full_name
+        .as_deref()
+        .map(str::trim)
+        .and_then(|f| f.split_once('/'))
+    {
+        if !ws.is_empty() && !slug.is_empty() {
+            return Some((ws.to_string(), slug.to_string()));
+        }
+    }
+    repo.slug
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| (workspace.to_string(), s.to_string()))
+}
+
+/// Discover every configured workspace's repositories, in order.
+///
+/// Why: the collector needs one repository set, not one per workspace, and a
+/// workspace it cannot read must not take the others down with it — the same
+/// per-org partial-success shape `run_github_org_discovery` uses.
+/// What: builds one discovery client via
+/// [`BitbucketClient::new_for_discovery`], walks each workspace from
+/// [`effective_workspaces`], and unions the results with duplicates removed. A
+/// workspace that fails is logged and skipped; the caller sees the repositories
+/// that were readable.
+/// Test: `run_workspace_discovery_skips_a_failing_workspace`.
+pub async fn run_workspace_discovery(config: &BitbucketConfig) -> Vec<(String, String)> {
+    let workspaces = effective_workspaces(&config.workspaces);
+    if workspaces.is_empty() {
+        return Vec::new();
+    }
+    let client = match BitbucketClient::new_for_discovery(config) {
+        Ok(c) => c,
+        Err(e) => {
+            warn!("Bitbucket workspace discovery: could not build client: {e}");
+            return Vec::new();
+        }
+    };
+
+    let mut all: Vec<(String, String)> = Vec::new();
+    let mut seen: HashSet<(String, String)> = HashSet::new();
+    for workspace in &workspaces {
+        info!(workspace = %workspace, "discovering repositories for Bitbucket workspace");
+        match discover_workspace_repos(&client, workspace).await {
+            Ok(repos) => {
+                info!(
+                    workspace = %workspace,
+                    count = repos.len(),
+                    "bitbucket workspace discovery complete"
+                );
+                for pair in repos {
+                    if seen.insert(pair.clone()) {
+                        all.push(pair);
+                    }
+                }
+            }
+            Err(e) => warn!(
+                workspace = %workspace,
+                error = %e,
+                "bitbucket workspace discovery failed; continuing with other workspaces"
+            ),
+        }
+    }
+    all
+}
+
+/// Union the configured `workspace`/`repo_slug` pair with discovered repos.
+///
+/// Why: a config may name one repository explicitly AND list workspaces to
+/// discover; both belong in the set the client collects, and neither should be
+/// listed twice. This is the Bitbucket counterpart of
+/// `resolve_github_repos_with_discovered`.
+/// What: the explicit pair (when both halves are non-empty) comes first, then
+/// every discovered pair not already present.
+/// Test: `discovered_repos_union_with_the_configured_pair`.
+#[must_use]
+pub fn resolve_bitbucket_repos(
+    config: &BitbucketConfig,
+    discovered: &[(String, String)],
+) -> Vec<(String, String)> {
+    let named = |v: &Option<String>| -> Option<String> {
+        v.as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+    };
+
+    let mut out: Vec<(String, String)> = Vec::new();
+    let mut seen: HashSet<(String, String)> = HashSet::new();
+    if let (Some(ws), Some(slug)) = (named(&config.workspace), named(&config.repo_slug)) {
+        seen.insert((ws.clone(), slug.clone()));
+        out.push((ws, slug));
+    }
+    for pair in discovered {
+        if seen.insert(pair.clone()) {
+            out.push(pair.clone());
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    /// Build a discovery-capable config pointed at a mock server.
+    fn discovery_config(api_base: String, workspaces: &[&str]) -> BitbucketConfig {
+        BitbucketConfig {
+            token: Some("dummy".into()),
+            workspaces: workspaces.iter().map(|s| (*s).to_string()).collect(),
+            fetch_prs: true,
+            api_base_url: Some(api_base),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn effective_workspaces_trims_and_deduplicates() {
+        assert!(effective_workspaces(&[]).is_empty());
+        assert_eq!(
+            effective_workspaces(&[
+                " acme ".to_string(),
+                "acme".to_string(),
+                String::new(),
+                "hotstats".to_string(),
+            ]),
+            vec!["acme".to_string(), "hotstats".to_string()]
+        );
+    }
+
+    #[test]
+    fn workspace_page_deserializes_full_name_and_slug() {
+        let json = r#"{"values": [
+            {"full_name": "acme/widget", "slug": "widget"},
+            {"slug": "gadget"},
+            {"name": "nameless"}
+        ]}"#;
+        let page: BbPaged<BbRepository> = serde_json::from_str(json).expect("parses");
+        let pairs: Vec<Option<(String, String)>> =
+            page.values.iter().map(|r| repo_pair(r, "acme")).collect();
+        assert_eq!(pairs[0], Some(("acme".into(), "widget".into())));
+        assert_eq!(pairs[1], Some(("acme".into(), "gadget".into())));
+        assert_eq!(pairs[2], None, "a repo with no identifier is skipped");
+    }
+
+    /// Both pages of a workspace listing are walked via the `next` cursor.
+    #[tokio::test]
+    async fn workspace_discovery_follows_next_cursor() {
+        let server = MockServer::start().await;
+        let base = server.uri();
+        let page2_url = format!("{base}/repositories/acme?page=2");
+
+        Mock::given(method("GET"))
+            .and(path("/repositories/acme"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "values": [{"full_name": "acme/widget", "slug": "widget"}],
+                "next": page2_url,
+            })))
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/repositories/acme"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "values": [{"full_name": "acme/gadget", "slug": "gadget"}],
+            })))
+            .mount(&server)
+            .await;
+
+        let cfg = discovery_config(base, &["acme"]);
+        let client = BitbucketClient::new_for_discovery(&cfg).expect("client builds");
+        let repos = discover_workspace_repos(&client, "acme")
+            .await
+            .expect("discovery succeeds");
+        assert_eq!(
+            repos,
+            vec![
+                ("acme".to_string(), "widget".to_string()),
+                ("acme".to_string(), "gadget".to_string()),
+            ]
+        );
+    }
+
+    /// A rejected credential is named, never reported as an empty workspace.
+    #[tokio::test]
+    async fn workspace_discovery_names_an_auth_failure() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/repositories/acme"))
+            .respond_with(
+                ResponseTemplate::new(401)
+                    .set_body_string(r#"{"error": {"message": "Invalid credentials"}}"#),
+            )
+            .mount(&server)
+            .await;
+
+        let cfg = discovery_config(server.uri(), &["acme"]);
+        let client = BitbucketClient::new_for_discovery(&cfg).expect("client builds");
+        let err = discover_workspace_repos(&client, "acme")
+            .await
+            .expect_err("401 must not read as an empty workspace");
+        match err {
+            CollectError::BitbucketApi {
+                status, message, ..
+            } => {
+                assert_eq!(status, 401);
+                assert!(
+                    message.contains("Invalid credentials"),
+                    "the error must carry Bitbucket's explanation: {message}"
+                );
+            }
+            other => panic!("expected BitbucketApi, got {other:?}"),
+        }
+    }
+
+    /// A rate limit is named, never reported as an empty workspace.
+    ///
+    /// The retry budget is lowered to zero so the client does not spend its
+    /// 1s/2s/4s backoff proving a permanent 429.
+    #[tokio::test]
+    async fn workspace_discovery_names_a_rate_limit() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/repositories/acme"))
+            .respond_with(ResponseTemplate::new(429).insert_header("retry-after", "42"))
+            .mount(&server)
+            .await;
+
+        let cfg = discovery_config(server.uri(), &["acme"]);
+        let client = BitbucketClient::new_for_discovery(&cfg)
+            .expect("client builds")
+            .with_max_retries(0);
+        let err = discover_workspace_repos(&client, "acme")
+            .await
+            .expect_err("429 must not read as an empty workspace");
+        match err {
+            CollectError::Throttled {
+                status,
+                retry_after,
+            } => {
+                assert_eq!(status, 429);
+                assert_eq!(retry_after, Some(Duration::from_secs(42)));
+            }
+            other => panic!("expected Throttled, got {other:?}"),
+        }
+    }
+
+    /// One unreadable workspace does not discard the readable one.
+    #[tokio::test]
+    async fn run_workspace_discovery_skips_a_failing_workspace() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/repositories/acme"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "values": [{"full_name": "acme/widget", "slug": "widget"}],
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/repositories/locked"))
+            .respond_with(ResponseTemplate::new(403).set_body_string("no access"))
+            .mount(&server)
+            .await;
+
+        let cfg = discovery_config(server.uri(), &["acme", "locked", "acme"]);
+        let repos = run_workspace_discovery(&cfg).await;
+        assert_eq!(repos, vec![("acme".to_string(), "widget".to_string())]);
+    }
+
+    #[test]
+    fn discovered_repos_union_with_the_configured_pair() {
+        let cfg = BitbucketConfig {
+            workspace: Some("acme".into()),
+            repo_slug: Some("widget".into()),
+            ..Default::default()
+        };
+        let discovered = vec![
+            ("acme".to_string(), "widget".to_string()),
+            ("acme".to_string(), "gadget".to_string()),
+        ];
+        assert_eq!(
+            resolve_bitbucket_repos(&cfg, &discovered),
+            vec![
+                ("acme".to_string(), "widget".to_string()),
+                ("acme".to_string(), "gadget".to_string()),
+            ],
+            "the explicit pair leads and is not duplicated by discovery"
+        );
+
+        let discovery_only = BitbucketConfig {
+            workspaces: vec!["acme".into()],
+            ..Default::default()
+        };
+        assert_eq!(
+            resolve_bitbucket_repos(&discovery_only, &discovered),
+            discovered,
+            "with no explicit pair the discovered set stands alone"
+        );
+    }
+}

--- a/crates/trusty-git-analytics/src/collect/collector.rs
+++ b/crates/trusty-git-analytics/src/collect/collector.rs
@@ -590,7 +590,7 @@ impl CollectionPipeline {
         &self,
         stats: &mut CollectionStats,
         org_discovered: &[(String, String)],
-        workspace_discovered: &[(String, String)],
+        workspace_discovered: &crate::collect::bitbucket::WorkspaceDiscovery,
     ) -> Vec<Box<dyn PrProvider + Send + Sync>> {
         let mut providers: Vec<Box<dyn PrProvider + Send + Sync>> = Vec::new();
 
@@ -680,7 +680,7 @@ impl CollectionPipeline {
                 // whatever workspace discovery could read.
                 let repos = crate::collect::bitbucket::resolve_bitbucket_repos(
                     bb_cfg,
-                    workspace_discovered,
+                    &workspace_discovered.repos,
                 );
                 if repos.is_empty() {
                     info!(
@@ -693,7 +693,11 @@ impl CollectionPipeline {
                         "Bitbucket PR fetcher will scan {} repo(s)",
                         repos.len()
                     );
-                    match BitbucketClient::new_for_repos(bb_cfg, repos) {
+                    // #6084: a truncated discovery walk must reach the run's
+                    // faults, and `pr_pipeline` drains them off the provider.
+                    match BitbucketClient::new_for_repos(bb_cfg, repos)
+                        .map(|c| c.with_notices(workspace_discovered.notices.clone()))
+                    {
                         Ok(bb) => providers.push(Box::new(bb)),
                         Err(e) => stats.fail_stage(format!("Bitbucket client init failed: {e}")),
                     }
@@ -733,7 +737,7 @@ impl CollectionPipeline {
             Some(bb_cfg) if bb_cfg.fetch_prs => {
                 crate::collect::bitbucket::run_workspace_discovery(bb_cfg).await
             }
-            _ => Vec::new(),
+            _ => crate::collect::bitbucket::WorkspaceDiscovery::default(),
         };
 
         let providers = self.build_pr_providers(stats, &org_discovered, &workspace_discovered);

--- a/crates/trusty-git-analytics/src/collect/collector.rs
+++ b/crates/trusty-git-analytics/src/collect/collector.rs
@@ -575,6 +575,9 @@ impl CollectionPipeline {
     /// `org_discovered` contains `(owner, repo)` pairs already fetched from
     /// the GitHub org-discovery pass (issue #742); they are unioned with the
     /// per-repo resolver output before the GitHub client is constructed.
+    /// `workspace_discovered` is the Bitbucket equivalent from the
+    /// `bitbucket.workspaces` pass (#5220), unioned with the singular
+    /// `workspace`/`repo_slug` pair the same way.
     ///
     /// Why: separating construction (sync) from org-discovery (async) keeps
     /// the async surface minimal — callers do discovery then hand the results
@@ -587,6 +590,7 @@ impl CollectionPipeline {
         &self,
         stats: &mut CollectionStats,
         org_discovered: &[(String, String)],
+        workspace_discovered: &[(String, String)],
     ) -> Vec<Box<dyn PrProvider + Send + Sync>> {
         let mut providers: Vec<Box<dyn PrProvider + Send + Sync>> = Vec::new();
 
@@ -672,9 +676,27 @@ impl CollectionPipeline {
         }
         if let Some(bb_cfg) = &self.config.bitbucket {
             if bb_cfg.fetch_prs {
-                match BitbucketClient::new(bb_cfg) {
-                    Ok(bb) => providers.push(Box::new(bb)),
-                    Err(e) => stats.fail_stage(format!("Bitbucket client init failed: {e}")),
+                // #5220: the repository set is the configured pair unioned with
+                // whatever workspace discovery could read.
+                let repos = crate::collect::bitbucket::resolve_bitbucket_repos(
+                    bb_cfg,
+                    workspace_discovered,
+                );
+                if repos.is_empty() {
+                    info!(
+                        "Bitbucket PR fetch skipped: no bitbucket.workspace/repo_slug pair \
+                         and bitbucket.workspaces discovery returned no repositories"
+                    );
+                } else {
+                    info!(
+                        repo_count = repos.len(),
+                        "Bitbucket PR fetcher will scan {} repo(s)",
+                        repos.len()
+                    );
+                    match BitbucketClient::new_for_repos(bb_cfg, repos) {
+                        Ok(bb) => providers.push(Box::new(bb)),
+                        Err(e) => stats.fail_stage(format!("Bitbucket client init failed: {e}")),
+                    }
                 }
             }
         }
@@ -705,7 +727,16 @@ impl CollectionPipeline {
             Vec::new()
         };
 
-        let providers = self.build_pr_providers(stats, &org_discovered);
+        // #5220: Bitbucket workspace discovery, same phase and same shape as
+        // the GitHub org pass above.
+        let workspace_discovered = match &self.config.bitbucket {
+            Some(bb_cfg) if bb_cfg.fetch_prs => {
+                crate::collect::bitbucket::run_workspace_discovery(bb_cfg).await
+            }
+            _ => Vec::new(),
+        };
+
+        let providers = self.build_pr_providers(stats, &org_discovered, &workspace_discovered);
         if providers.is_empty() {
             return;
         }

--- a/crates/trusty-git-analytics/src/collect/errors.rs
+++ b/crates/trusty-git-analytics/src/collect/errors.rs
@@ -104,6 +104,27 @@ pub enum CollectError {
         message: String,
     },
 
+    /// A Bitbucket Cloud REST call returned a non-success status, with its
+    /// body kept.
+    ///
+    /// Why (#5220): workspace discovery must never answer "this workspace has
+    /// no repositories" when what actually happened is a rejected credential
+    /// or a rate limit. `error_for_status()` discards the body, and an empty
+    /// `Vec` discards the failure altogether — either way the operator reads a
+    /// clean run over a repository set that was never fetched. This variant
+    /// names the status and keeps Bitbucket's own explanation, which is where
+    /// the difference between "token lacks the `repository` scope" and "no
+    /// such workspace" is written.
+    #[error("Bitbucket API error (HTTP {status}) for {endpoint}: {message}")]
+    BitbucketApi {
+        /// HTTP status returned by Bitbucket.
+        status: u16,
+        /// URL that was called, for the operator to reproduce.
+        endpoint: String,
+        /// Bitbucket's response body, truncated when long.
+        message: String,
+    },
+
     /// A find-or-create issue lookup could not see every match GitHub reported.
     ///
     /// Why (#5465): the alternative to erroring here is treating "not on the

--- a/crates/trusty-git-analytics/src/commands/install.rs
+++ b/crates/trusty-git-analytics/src/commands/install.rs
@@ -32,7 +32,7 @@ pub enum InstallHost {
     Local,
     /// A GitHub org (or an explicit `owner/name` list).
     Github,
-    /// A Bitbucket Cloud workspace with an explicit `workspace/slug` list.
+    /// A Bitbucket Cloud workspace, discovered over the API (#5220).
     Bitbucket,
 }
 
@@ -59,8 +59,9 @@ On a terminal with no flags this walks through a series of prompts; press\n\
 <enter> at each to accept the default shown in brackets.\n\n\
 Given --host and --pm (or with stdin not a terminal) it runs non-interactively\n\
 from flags and environment variables instead, and never prompts. With --host\n\
-github and --org it discovers the org's repositories over the GitHub API and\n\
-writes them into the generated config.\n\n\
+github and --org — or --host bitbucket and --workspace — it discovers the\n\
+repositories over the provider's API and writes them into the generated\n\
+config.\n\n\
 Flag values win over environment variables. A credential taken from the\n\
 environment is written to the config as a ${VAR} reference, not as the secret.",
     after_help = "EXAMPLES:\n\
@@ -68,8 +69,8 @@ environment is written to the config as a ${VAR} reference, not as the secret.",
   tga install\n\n\
   # Zero-config org audit, no terminal required\n\
   GITHUB_TOKEN=ghp_… tga install --host github --org acme --pm github\n\n\
-  # Bitbucket Cloud — workspace discovery is not available yet (#5220), so name the repos\n\
-  tga install --host bitbucket --workspace acme --repo acme/widget --pm jira \\\n\
+  # Bitbucket Cloud — the workspace's repositories are discovered over the API\n\
+  BITBUCKET_TOKEN=… tga install --host bitbucket --workspace acme --pm jira \\\n\
     --jira-url https://acme.atlassian.net --jira-user me@acme.com\n\n\
   # Write config to a custom path, overwriting any existing file\n\
   tga install --output /etc/tga/config.yaml --force\n\n\
@@ -323,14 +324,16 @@ fn prompt_host<R: BufRead>(reader: &mut R, answers: &mut Answers) -> anyhow::Res
         }
         InstallHost::Bitbucket => {
             answers.workspace = Some(prompt(reader, "Bitbucket Cloud workspace", None)?);
-            println!(
-                "  Bitbucket workspace discovery is not available yet (#5220) — name the repositories."
+            // #5220: the workspace is paged over the API, so the explicit list
+            // is now an addition rather than the only source.
+            println!("  The workspace's repositories are discovered over the API.");
+            answers.repo_slugs = split_list(
+                &prompt_optional(
+                    reader,
+                    "Extra Bitbucket repositories (comma-separated <workspace>/<slug>, optional)",
+                )?
+                .unwrap_or_default(),
             );
-            answers.repo_slugs = split_list(&prompt(
-                reader,
-                "Bitbucket repositories (comma-separated <workspace>/<slug>)",
-                None,
-            )?);
             answers.host_token =
                 prompt_optional(reader, "Bitbucket token (optional, leave blank to skip)")?
                     .map(Credential::literal);
@@ -545,25 +548,39 @@ mod tests {
         assert!(yaml.contains("team_keys: [\"ENG\", \"OPS\"]"), "{yaml}");
     }
 
-    /// Why: the Bitbucket wizard branch must record the workspace and the
-    /// explicit repository list rather than producing an empty config.
-    /// What: drives the wizard through the Bitbucket answers.
+    /// Why: the Bitbucket wizard branch must record the workspace, keep the
+    /// optional explicit repository list, and — since #5220 — union both with
+    /// what the API discovers.
+    /// What: drives the wizard through the Bitbucket answers against a mock
+    /// workspace listing; no test here reaches bitbucket.org.
     /// Test: this test itself.
     #[tokio::test]
     async fn wizard_collects_bitbucket_workspace_and_repos() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/repositories/acme"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "values": [{"full_name": "acme/sprocket", "slug": "sprocket"}],
+            })))
+            .mount(&server)
+            .await;
+
         let script = "bitbucket\nacme\nacme/widget, acme/gadget\nbb-token\nnone\n./out\nnone\n";
         let mut input = script.as_bytes();
-        let answers =
+        let mut answers =
             collect_answers(&mut input, &args_for_tests(&["tga"])).expect("wizard completes");
+        answers.bitbucket_api_base = Some(server.uri());
         let plan = plan_from_answers(answers).await.expect("plan");
         let yaml = render_yaml(&plan);
-        assert!(yaml.contains("workspace: \"acme\""), "{yaml}");
+        assert!(yaml.contains("workspaces: [\"acme\"]"), "{yaml}");
         assert!(yaml.contains("name: \"widget\""), "{yaml}");
         assert!(yaml.contains("name: \"gadget\""), "{yaml}");
         assert!(
-            plan.notes.iter().any(|n| n.contains("#5220")),
-            "{:?}",
-            plan.notes
+            yaml.contains("name: \"sprocket\""),
+            "the discovered repo: {yaml}"
         );
     }
 

--- a/crates/trusty-git-analytics/src/commands/install_flags.rs
+++ b/crates/trusty-git-analytics/src/commands/install_flags.rs
@@ -9,8 +9,8 @@
 //! What: [`resolve_plan`] is the entry point. [`answers_from_flags`] applies
 //! the precedence (flag value first, then the environment) and refuses with a
 //! list of exactly the missing flags rather than blocking on stdin.
-//! [`plan_from_answers`] runs GitHub org discovery and produces the
-//! [`InstallPlan`] both front ends render from.
+//! [`plan_from_answers`] runs GitHub org and Bitbucket workspace discovery
+//! (#5220) and produces the [`InstallPlan`] both front ends render from.
 //!
 //! Test: `missing_flags_are_named_not_prompted_for`,
 //! `flag_path_discovers_org_repos_and_writes_them` and the credential
@@ -18,12 +18,13 @@
 
 use std::path::PathBuf;
 
+use crate::collect::bitbucket::{discover_workspace_repos, BitbucketClient};
 use crate::collect::github::{build_http_client, discover_org_repos_at};
 use crate::commands::install::{split_list, InstallArgs, InstallHost, InstallPm};
 use crate::commands::install_plan::{
     env_var_for, Credential, InstallPlan, JiraSettings, LinearSettings, RepoEntry,
 };
-use crate::core::config::GithubConfig;
+use crate::core::config::{BitbucketConfig, GithubConfig};
 
 /// Environment variable holding the Bitbucket Cloud token.
 const ENV_BITBUCKET_TOKEN: &str = "BITBUCKET_TOKEN";
@@ -74,6 +75,9 @@ pub(crate) struct Answers {
     /// GitHub REST root override. `None` means api.github.com; tests point it
     /// at a local mock server.
     pub github_api_base: Option<String>,
+    /// Bitbucket REST root override (#5220). `None` means
+    /// api.bitbucket.org/2.0; tests point it at a local mock server.
+    pub bitbucket_api_base: Option<String>,
 }
 
 /// Resolve an [`InstallPlan`] from flags and the process environment.
@@ -166,6 +170,7 @@ pub(crate) fn answers_from_flags(
         llm_provider,
         output_dir: args.output_dir.clone(),
         github_api_base: None,
+        bitbucket_api_base: None,
     })
 }
 
@@ -204,13 +209,8 @@ fn missing_flags(args: &InstallArgs, has_token: bool, pm_creds: &[(&str, bool)])
             if args.workspace.is_none() {
                 missing.push("--workspace <WORKSPACE>".to_string());
             }
-            if args.repo.is_empty() {
-                missing.push(
-                    "--repo <WORKSPACE/SLUG> (repeatable — Bitbucket workspace discovery \
-                     is not available yet, see #5220)"
-                        .to_string(),
-                );
-            }
+            // #5220: workspace discovery derives the repository set, so an
+            // explicit `--repo` list is an addition rather than a requirement.
             if !has_token {
                 missing.push("--host-token <TOKEN> (or set $BITBUCKET_TOKEN)".to_string());
             }
@@ -236,15 +236,15 @@ fn missing_flags(args: &InstallArgs, has_token: bool, pm_creds: &[(&str, bool)])
 /// Why (#5216): "given an org and a token, tga derives the repo set itself" is
 /// the issue's closure condition, and [`discover_org_repos_at`] already knows
 /// how to page it — this is the call site that was missing.
-/// What: local paths pass through unchanged; a GitHub org is paged over the
-/// API and unioned with any explicit `--repo` slugs; a Bitbucket workspace
-/// takes the explicit list only, and records why.
+/// What: local paths pass through unchanged; a GitHub org and a Bitbucket
+/// workspace (#5220) are each paged over their own API and unioned with any
+/// explicit `--repo` slugs.
 /// Test: `flag_path_discovers_org_repos_and_writes_them` and
-/// `bitbucket_records_that_discovery_is_unavailable`.
+/// `flag_path_discovers_workspace_repos_and_writes_them`.
 ///
 /// # Errors
 ///
-/// Propagates a GitHub client-build or org-discovery failure.
+/// Propagates a client-build or discovery failure from either provider.
 pub(crate) async fn plan_from_answers(answers: Answers) -> anyhow::Result<InstallPlan> {
     let Answers {
         host,
@@ -261,6 +261,7 @@ pub(crate) async fn plan_from_answers(answers: Answers) -> anyhow::Result<Instal
         llm_provider,
         llm_api_key,
         github_api_base,
+        bitbucket_api_base,
     } = answers;
 
     let mut plan = InstallPlan {
@@ -297,14 +298,21 @@ pub(crate) async fn plan_from_answers(answers: Answers) -> anyhow::Result<Instal
             push_remote(&mut plan, &repo_cache, pairs);
         }
         InstallHost::Bitbucket => {
-            // #5216: non-interactive install path — Bitbucket workspace-to-repo
-            // discovery is #5220, so the explicit list is the repository set.
-            plan.notes.push(
-                "Bitbucket Cloud workspace discovery is not available yet (#5220); the \
-                 repositories listed here are the ones you named explicitly."
-                    .to_string(),
-            );
-            let pairs = parse_slugs(&repo_slugs, workspace.as_deref());
+            // #5220: the workspace is paged over the API, exactly as a GitHub
+            // org is above; explicit `--repo` slugs are unioned in.
+            let mut pairs = parse_slugs(&repo_slugs, workspace.as_deref());
+            if let Some(ws) = &workspace {
+                pairs.extend(
+                    discover_workspace(host_token.as_ref(), bitbucket_api_base.as_deref(), ws)
+                        .await?,
+                );
+                if pairs.is_empty() {
+                    plan.notes.push(format!(
+                        "Bitbucket workspace `{ws}` returned no repositories the supplied \
+                         token can see"
+                    ));
+                }
+            }
             plan.bitbucket_workspace = workspace;
             plan.bitbucket_token = host_token;
             push_remote(&mut plan, &repo_cache, pairs);
@@ -329,6 +337,36 @@ async fn discover(
     let http = build_http_client(&cfg)?;
     let base = api_base.unwrap_or("https://api.github.com");
     Ok(discover_org_repos_at(&http, base, org).await?)
+}
+
+/// Page `workspace`'s repositories over the Bitbucket Cloud API (#5220).
+///
+/// Why: this is the call site the `--host bitbucket` branch was missing — the
+/// note it used to write said discovery did not exist yet.
+/// What: builds a discovery-only [`BitbucketClient`] from the supplied token —
+/// the crate's one Bitbucket client constructor, never a second HTTP client —
+/// and hands it to [`discover_workspace_repos`]. `api_base` of `None` means
+/// api.bitbucket.org; tests point it at a mock server.
+/// Test: `flag_path_discovers_workspace_repos_and_writes_them`.
+///
+/// # Errors
+///
+/// Propagates a client-build failure (no usable credential) or a discovery
+/// failure — a rejected token and a rate limit both surface named, never as an
+/// empty repository set.
+async fn discover_workspace(
+    token: Option<&Credential>,
+    api_base: Option<&str>,
+    workspace: &str,
+) -> anyhow::Result<Vec<(String, String)>> {
+    let cfg = BitbucketConfig {
+        token: token.map(|c| c.value.clone()),
+        workspaces: vec![workspace.to_string()],
+        api_base_url: api_base.map(str::to_string),
+        ..BitbucketConfig::default()
+    };
+    let client = BitbucketClient::new_for_discovery(&cfg)?;
+    Ok(discover_workspace_repos(&client, workspace).await?)
 }
 
 /// Append `pairs` as `repositories[]` entries under `cache`, deduplicating.
@@ -481,8 +519,8 @@ mod tests {
     /// What: `--host bitbucket --workspace acme` with no `--repo`.
     /// Test: this test itself.
     #[test]
-    fn bitbucket_without_repos_is_refused_and_says_why() {
-        let err = answers_from_flags(
+    fn bitbucket_needs_only_a_workspace_and_a_token() {
+        let answers = answers_from_flags(
             &args_for_tests(&[
                 "tga",
                 "--host",
@@ -496,10 +534,28 @@ mod tests {
             ]),
             &no_env,
         )
-        .expect_err("bitbucket without --repo must be refused");
-        let msg = err.to_string();
-        assert!(msg.contains("--repo <WORKSPACE/SLUG>"), "{msg}");
-        assert!(msg.contains("#5220"), "{msg}");
+        .expect("#5220: discovery derives the repository set, so --repo is optional");
+        assert_eq!(answers.workspace.as_deref(), Some("acme"));
+        assert!(answers.repo_slugs.is_empty());
+    }
+
+    /// A Bitbucket install still refuses without a token to discover with.
+    #[test]
+    fn bitbucket_without_a_token_is_refused() {
+        let err = answers_from_flags(
+            &args_for_tests(&[
+                "tga",
+                "--host",
+                "bitbucket",
+                "--workspace",
+                "acme",
+                "--pm",
+                "none",
+            ]),
+            &no_env,
+        )
+        .expect_err("no credential means nothing can be discovered");
+        assert!(err.to_string().contains("--host-token <TOKEN>"), "{err}");
     }
 
     /// Why: a JIRA or Linear choice with no credentials writes a config that
@@ -725,20 +781,41 @@ mod tests {
         );
     }
 
-    /// Why: the Bitbucket option must accept an explicit repo list and say
-    /// discovery is not available, not silently emit an empty config.
-    /// What: resolves a Bitbucket install with two explicit repos.
+    /// Why (#5220): a workspace plus a token must yield a populated config
+    /// with nothing transcribed by hand — the Bitbucket half of the closure
+    /// condition `flag_path_discovers_org_repos_and_writes_them` proves for
+    /// GitHub. Against a local mock; no test here reaches bitbucket.org.
+    /// What: serves two cursor-linked pages of `GET /2.0/repositories/acme`,
+    /// resolves the flag path against them, and asserts the discovered repos
+    /// AND the explicit `--repo` slug both reach the YAML.
     /// Test: this test itself.
     #[tokio::test]
-    async fn bitbucket_records_that_discovery_is_unavailable() {
+    async fn flag_path_discovers_workspace_repos_and_writes_them() {
+        let server = MockServer::start().await;
+        let base = server.uri();
+        Mock::given(method("GET"))
+            .and(path("/repositories/acme"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "values": [{"full_name": "acme/widget", "slug": "widget"}],
+                "next": format!("{base}/repositories/acme?page=2"),
+            })))
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/repositories/acme"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "values": [{"full_name": "acme/sprocket", "slug": "sprocket"}],
+            })))
+            .mount(&server)
+            .await;
+
         let args = args_for_tests(&[
             "tga",
             "--host",
             "bitbucket",
             "--workspace",
             "acme",
-            "--repo",
-            "acme/widget",
             "--repo",
             "gadget",
             "--pm",
@@ -748,13 +825,59 @@ mod tests {
             "--repo-cache",
             "/cache",
         ]);
-        let answers = answers_from_flags(&args, &no_env).expect("resolves");
-        let plan = plan_from_answers(answers).await.expect("resolves");
+        let mut answers = answers_from_flags(&args, &no_env).expect("resolves");
+        answers.bitbucket_api_base = Some(base);
+        let plan = plan_from_answers(answers)
+            .await
+            .expect("discovery succeeds");
+
         let yaml = render_yaml(&plan);
-        assert!(yaml.contains("workspace: \"acme\""), "{yaml}");
-        assert!(yaml.contains("path: \"/cache/acme/widget\""), "{yaml}");
-        // A bare slug inherits the workspace.
+        assert!(yaml.contains("workspaces: [\"acme\"]"), "{yaml}");
+        // A bare `--repo` slug inherits the workspace and survives discovery.
         assert!(yaml.contains("path: \"/cache/acme/gadget\""), "{yaml}");
-        assert!(yaml.contains("#5220"), "{yaml}");
+        // Both cursor pages reach the repository set.
+        assert!(yaml.contains("path: \"/cache/acme/widget\""), "{yaml}");
+        assert!(yaml.contains("path: \"/cache/acme/sprocket\""), "{yaml}");
+        assert!(!yaml.contains("#5220"), "the stale caveat is gone: {yaml}");
+    }
+
+    /// Why (#5220): the Fail-Open Check at the install boundary — a rejected
+    /// token must stop the install with the status named, not write a config
+    /// whose repository list is silently empty.
+    /// What: the mock answers 401 for every request.
+    /// Test: this test itself.
+    #[tokio::test]
+    async fn a_rejected_workspace_token_fails_the_install() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/repositories/acme"))
+            .respond_with(ResponseTemplate::new(401).set_body_string("Invalid credentials"))
+            .mount(&server)
+            .await;
+
+        let args = args_for_tests(&[
+            "tga",
+            "--host",
+            "bitbucket",
+            "--workspace",
+            "acme",
+            "--pm",
+            "none",
+            "--host-token",
+            "bb-token",
+            "--repo-cache",
+            "/cache",
+        ]);
+        let mut answers = answers_from_flags(&args, &no_env).expect("resolves");
+        answers.bitbucket_api_base = Some(server.uri());
+        let err = plan_from_answers(answers)
+            .await
+            .expect_err("a 401 must not render an empty repository set");
+        let msg = err.to_string();
+        assert!(msg.contains("401"), "the status must be named: {msg}");
+        assert!(
+            msg.contains("Invalid credentials"),
+            "Bitbucket's own explanation must survive: {msg}"
+        );
     }
 }

--- a/crates/trusty-git-analytics/src/commands/install_plan.rs
+++ b/crates/trusty-git-analytics/src/commands/install_plan.rs
@@ -119,7 +119,7 @@ pub struct InstallPlan {
     /// LLM API key, emitted only as a hint comment.
     pub llm_api_key: Option<Credential>,
     /// Operator-facing caveats written into the config as leading comments —
-    /// for example that Bitbucket workspace discovery is not implemented yet.
+    /// for example that a discovered workspace turned out to be empty.
     pub notes: Vec<String>,
 }
 
@@ -176,8 +176,13 @@ fn render_hosts(plan: &InstallPlan, out: &mut String) {
 
     if plan.bitbucket_workspace.is_some() || plan.bitbucket_token.is_some() {
         out.push_str("bitbucket:\n");
+        // #5220: emitted as the plural discovery list, not as the singular
+        // `workspace` — that one is half of a `workspace`/`repo_slug` coordinate
+        // and the validator would then demand a `repo_slug` this file has not
+        // got. `workspaces` says what actually happened: the set came from the
+        // API and is refreshed from it on every collect.
         if let Some(ws) = &plan.bitbucket_workspace {
-            out.push_str(&format!("  workspace: \"{ws}\"\n"));
+            out.push_str(&format!("  workspaces: [\"{ws}\"]\n"));
         }
         if let Some(token) = &plan.bitbucket_token {
             out.push_str(&format!("  token: \"{}\"\n", token.emitted));
@@ -347,14 +352,16 @@ mod tests {
             api_key: Credential::literal("lin_xxx"),
             team_keys: vec!["ENG".to_string(), "OPS".to_string()],
         });
-        plan.notes = vec!["workspace discovery is not available yet".to_string()];
+        plan.notes = vec!["the workspace looked empty".to_string()];
         let yaml = render_yaml(&plan);
         assert!(yaml.contains("bitbucket:"), "{yaml}");
-        assert!(yaml.contains("workspace: \"acme\""), "{yaml}");
+        // #5220: the plural discovery list, not the singular half-coordinate
+        // the validator would then demand a `repo_slug` alongside.
+        assert!(yaml.contains("workspaces: [\"acme\"]"), "{yaml}");
         assert!(yaml.contains("linear:"), "{yaml}");
         assert!(yaml.contains("team_keys: [\"ENG\", \"OPS\"]"), "{yaml}");
         assert!(
-            yaml.contains("# NOTE: workspace discovery is not available yet"),
+            yaml.contains("# NOTE: the workspace looked empty"),
             "{yaml}"
         );
     }

--- a/crates/trusty-git-analytics/src/core/config/credential_debug.rs
+++ b/crates/trusty-git-analytics/src/core/config/credential_debug.rs
@@ -128,6 +128,7 @@ impl fmt::Debug for BitbucketConfig {
             app_password,
             token,
             workspace,
+            workspaces,
             repo_slug,
             fetch_prs,
             api_base_url,
@@ -137,6 +138,7 @@ impl fmt::Debug for BitbucketConfig {
             .field("app_password", &mask(app_password.as_ref()))
             .field("token", &mask(token.as_ref()))
             .field("workspace", workspace)
+            .field("workspaces", workspaces)
             .field("repo_slug", repo_slug)
             .field("fetch_prs", fetch_prs)
             .field("api_base_url", api_base_url)

--- a/crates/trusty-git-analytics/src/core/config/credential_serialize.rs
+++ b/crates/trusty-git-analytics/src/core/config/credential_serialize.rs
@@ -121,15 +121,17 @@ impl Serialize for BitbucketConfig {
             app_password,
             token,
             workspace,
+            workspaces,
             repo_slug,
             fetch_prs,
             api_base_url,
         } = self;
-        let mut s = serializer.serialize_struct("BitbucketConfig", 7)?;
+        let mut s = serializer.serialize_struct("BitbucketConfig", 8)?;
         s.serialize_field("username", username)?;
         s.serialize_field("app_password", &mask(app_password.as_ref()))?;
         s.serialize_field("token", &mask(token.as_ref()))?;
         s.serialize_field("workspace", workspace)?;
+        s.serialize_field("workspaces", workspaces)?;
         s.serialize_field("repo_slug", repo_slug)?;
         s.serialize_field("fetch_prs", fetch_prs)?;
         s.serialize_field("api_base_url", api_base_url)?;

--- a/crates/trusty-git-analytics/src/core/config/mod.rs
+++ b/crates/trusty-git-analytics/src/core/config/mod.rs
@@ -1183,9 +1183,12 @@ fn default_review_fetch_concurrency() -> u32 {
 // #5770: `Debug` is hand-written in `credential_debug`, not derived — the
 // derived one printed `app_password` and `token` in the clear.
 // #5775: `Serialize` is hand-written in `credential_serialize` for both fields.
-// #5220: deliberately NOT `#[non_exhaustive]`, unlike `GithubConfig` — the
-// crate's own `tests/bitbucket_live.rs` builds one as a struct literal, which
-// that attribute forbids from outside the library.
+// #5220: `workspaces` is a new pub field, which `constructible_struct_adds_field`
+// scores as a break against the published 6.0.0. Every alternative was measured
+// and is worse: `#[non_exhaustive]` trades it for `struct_marked_non_exhaustive`,
+// and a private field trades it for `constructible_struct_adds_private_field`.
+// The crate already owes a major bump for the same lint (#6744, InstallArgs),
+// and this field rides that bump rather than causing one.
 #[derive(Clone, Default, Deserialize)]
 pub struct BitbucketConfig {
     /// Bitbucket account / workspace member username (required for Basic auth).

--- a/crates/trusty-git-analytics/src/core/config/mod.rs
+++ b/crates/trusty-git-analytics/src/core/config/mod.rs
@@ -1183,6 +1183,9 @@ fn default_review_fetch_concurrency() -> u32 {
 // #5770: `Debug` is hand-written in `credential_debug`, not derived — the
 // derived one printed `app_password` and `token` in the clear.
 // #5775: `Serialize` is hand-written in `credential_serialize` for both fields.
+// #5220: deliberately NOT `#[non_exhaustive]`, unlike `GithubConfig` — the
+// crate's own `tests/bitbucket_live.rs` builds one as a struct literal, which
+// that attribute forbids from outside the library.
 #[derive(Clone, Default, Deserialize)]
 pub struct BitbucketConfig {
     /// Bitbucket account / workspace member username (required for Basic auth).
@@ -1207,8 +1210,30 @@ pub struct BitbucketConfig {
     #[serde(default)]
     pub workspace: Option<String>,
 
+    /// Workspace slugs whose repository list is discovered over the API
+    /// (#5220), the Bitbucket counterpart of [`GithubConfig::orgs`].
+    ///
+    /// Why: `workspace` + `repo_slug` names exactly one repository, so a
+    /// workspace of 200 repositories had to be transcribed by hand. Naming the
+    /// workspace here instead makes `tga` page
+    /// `GET /2.0/repositories/{workspace}` and collect from whatever the token
+    /// can see.
+    /// What: each entry is discovered independently and the results are unioned
+    /// with the singular `workspace`/`repo_slug` pair. A workspace listed here
+    /// needs no `repo_slug`, and the validator stops demanding one.
+    /// [`Self::workspace`] is deliberately NOT treated as a discovery source:
+    /// it is half of a repository coordinate, so promoting it would silently
+    /// widen every existing single-repository config to the whole workspace.
+    /// Test: `effective_workspaces_trims_and_deduplicates`,
+    /// `discovered_repos_union_with_the_configured_pair`.
+    #[serde(default)]
+    pub workspaces: Vec<String>,
+
     /// Repository slug, e.g. the `myrepo` in
     /// `bitbucket.org/myteam/myrepo`.
+    ///
+    /// Required when [`Self::workspaces`] is empty; with workspace discovery
+    /// configured the repository set comes from the API instead (#5220).
     #[serde(default)]
     pub repo_slug: Option<String>,
 

--- a/crates/trusty-git-analytics/src/core/config/validator.rs
+++ b/crates/trusty-git-analytics/src/core/config/validator.rs
@@ -334,6 +334,12 @@ impl<'a> ConfigValidator<'a> {
     ///
     /// A wholly absent `bitbucket:` block is fine — the integration is just
     /// off.
+    ///
+    /// #5220: `workspaces` is the second way to name a repository set, so
+    /// neither field check is unconditional any more. A config that lists
+    /// workspaces to discover satisfies the workspace check without a singular
+    /// `workspace`, and owes no `repo_slug` at all — the repository set comes
+    /// from `GET /2.0/repositories/{workspace}` instead of from the file.
     fn check_bitbucket_config(&self, errors: &mut Vec<ConfigError>) {
         let Some(bb) = self.config.bitbucket.as_ref() else {
             return;
@@ -342,22 +348,15 @@ impl<'a> ConfigValidator<'a> {
             return;
         }
 
-        if bb
-            .workspace
-            .as_deref()
-            .map(|s| s.trim().is_empty())
-            .unwrap_or(true)
-        {
+        let discovers = !crate::collect::bitbucket::effective_workspaces(&bb.workspaces).is_empty();
+        let named = |v: &Option<String>| v.as_deref().is_some_and(|s| !s.trim().is_empty());
+
+        if !discovers && !named(&bb.workspace) {
             errors.push(ConfigError::IncompleteBitbucketConfig {
                 field: "workspace".into(),
             });
         }
-        if bb
-            .repo_slug
-            .as_deref()
-            .map(|s| s.trim().is_empty())
-            .unwrap_or(true)
-        {
+        if !discovers && !named(&bb.repo_slug) {
             errors.push(ConfigError::IncompleteBitbucketConfig {
                 field: "repo_slug".into(),
             });

--- a/crates/trusty-git-analytics/src/core/config/validator_tests.rs
+++ b/crates/trusty-git-analytics/src/core/config/validator_tests.rs
@@ -486,6 +486,54 @@ fn config_validator_rejects_ado_with_no_projects() {
     );
 }
 
+/// Why (#5220): `workspaces` is the second way to name a repository set, and a
+/// config that uses it owes no `workspace`/`repo_slug` pair — the repository
+/// list comes from `GET /2.0/repositories/{workspace}` instead of the file.
+/// Before this, the validator rejected exactly the config `tga install --host
+/// bitbucket` generates.
+/// What: a Bitbucket block with PR fetching on, one workspace to discover, and
+/// neither singular field set, reports no incomplete-config error.
+/// Test: this test itself.
+#[test]
+fn bitbucket_workspaces_satisfy_the_workspace_and_repo_slug_checks() {
+    let mut cfg = empty_config();
+    cfg.bitbucket = Some(BitbucketConfig {
+        token: Some("bearer".into()),
+        workspaces: vec!["acme".into()],
+        fetch_prs: true,
+        ..Default::default()
+    });
+    let errors = ConfigValidator::new(&cfg).validate();
+    assert!(
+        !errors
+            .iter()
+            .any(|e| matches!(e, ConfigError::IncompleteBitbucketConfig { .. })),
+        "workspace discovery needs neither workspace nor repo_slug, got {errors:?}"
+    );
+}
+
+/// A whitespace-only workspaces entry is not a repository set (#5220).
+#[test]
+fn blank_bitbucket_workspaces_still_require_the_singular_pair() {
+    let mut cfg = empty_config();
+    cfg.bitbucket = Some(BitbucketConfig {
+        token: Some("bearer".into()),
+        workspaces: vec!["   ".into()],
+        fetch_prs: true,
+        ..Default::default()
+    });
+    let errors = ConfigValidator::new(&cfg).validate();
+    let missing: Vec<&str> = errors
+        .iter()
+        .filter_map(|e| match e {
+            ConfigError::IncompleteBitbucketConfig { field } => Some(field.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert!(missing.contains(&"workspace"), "got {errors:?}");
+    assert!(missing.contains(&"repo_slug"), "got {errors:?}");
+}
+
 #[test]
 fn bitbucket_block_off_is_fine() {
     // `fetch_prs` defaults off, so the check returns before it reads anything —

--- a/docs/trusty-git-analytics/developer/configuration-reference.md
+++ b/docs/trusty-git-analytics/developer/configuration-reference.md
@@ -272,8 +272,9 @@ that repo. For per-run date windowing, use the CLI flags `--weeks`, `--from`, `-
 | `username` | String | no | — | Bitbucket account username (required for Basic auth). |
 | `app_password` | String | no | `$BITBUCKET_APP_PASSWORD` | Bitbucket App Password (Basic auth). |
 | `token` | String | no | `$BITBUCKET_TOKEN` | Workspace or repository access token (Bearer auth). Takes precedence over `app_password`. |
-| `workspace` | String | conditional | — | Workspace slug. Required when `fetch_prs: true`. |
-| `repo_slug` | String | conditional | — | Repository slug. Required when `fetch_prs: true`. |
+| `workspace` | String | conditional | — | Workspace slug. Required when `fetch_prs: true` and `workspaces` is empty. |
+| `workspaces` | Vec\<String\> | conditional | — | Workspace slugs whose repository list is discovered over `GET /2.0/repositories/{workspace}` (#5220). An alternative to the `workspace`/`repo_slug` pair; discovered repositories are unioned with it. |
+| `repo_slug` | String | conditional | — | Repository slug. Required when `fetch_prs: true` and `workspaces` is empty. |
 | `fetch_prs` | bool | no | `false` | Fetch PR metadata from Bitbucket API. |
 | `api_base_url` | String | no | `https://api.bitbucket.org/2.0` | API base URL override. |
 


### PR DESCRIPTION
## Outcome

`BitbucketConfig` gains `workspaces: Vec<String>`; a listed workspace's repositories are discovered over `GET /2.0/repositories/{workspace}` following `next` cursors, the same way GitHub org discovery works, and feed the same repo-set/clone path. The singular `workspace`/`repo_slug` pair keeps its meaning and is deliberately not a discovery trigger. 429 → `Throttled` with bounded backoff; auth and other non-2xx → `BitbucketApi` naming the URL and status, body bounded to 512 chars, never the token. A listing cut at the page cap records a PARTIAL notice on the client's ledger that `fetch_notices()` surfaces into the run stats (the #6084 shape). `tga install --host bitbucket` now emits `workspaces: [...]`; the previous `workspace`-only block deserialized but failed validation. `fetch_pr_commits` keeps its one-argument signature; the multi-repo walk uses a new `fetch_pr_commits_in`. No migration.

Refs #5220

## Changes

Two commits: workspace discovery implementation (wiremock + live-API tests), then non-breaking signature and truncation notice per code-critic feedback.

## Risk

Low: new field in config struct, backward-compatible via default; no breaking API changes; error paths tested with rate-limit and auth-error cases.

## Tests

Rung 3: `cargo test -p tga --no-fail-fast` — lib 1538 passed, 0 failed, 7 ignored; 10 targets ok. Deterministic gates: `cargo fmt --check`, `cargo clippy -p tga --all-targets`, `cargo check --workspace`. Code-critic round 1 BLOCK resolved by commit 2.

## Baseline

Pre-existing semver lint `constructible_struct_adds_field` on `InstallArgs` (#6744); `BitbucketConfig.workspaces` rides the same break. No new breakage introduced.

## Docs

Changelog fragment `crates/trusty-git-analytics/changelog.d/5220-bitbucket-workspaces.md`. Doc-comment pointers verified via `scripts/check_test_pointers.sh`.

## Review

Code-critic round 1 BLOCK (non-breaking signature; truncation notice placement) → both changes in commit 2 → APPROVE. Pre-push credential scan: PASS.

Refs #5220

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
